### PR TITLE
fix(twitter): use authorization_response parameter in fetch_token

### DIFF
--- a/scripts/twitter/twitter.py
+++ b/scripts/twitter/twitter.py
@@ -187,7 +187,9 @@ def load_twitter_client(require_auth: bool = False) -> tweepy.Client:
                     raise
 
                 # Get access token using the full callback URL
-                access_token = oauth2_user_handler.fetch_token(full_url)
+                access_token = oauth2_user_handler.fetch_token(
+                    authorization_response=full_url
+                )
                 print(f"{access_token=}")
 
                 # Save access token to .env using shared utility


### PR DESCRIPTION
OAuth2UserHandler.fetch_token() requires named parameter
authorization_response= instead of positional argument.

This fixes the 'Please supply either code or authorization_response
parameters' error that was preventing OAuth flow from completing.

Fixes ErikBjare/bob#152

Co-authored-by: Bob <bob@superuserlabs.org>

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes OAuth2 authentication flow in `load_twitter_client()` by using `authorization_response` parameter in `fetch_token()` to resolve an error.
> 
>   - **Behavior**:
>     - Fixes OAuth2 authentication flow in `load_twitter_client()` in `twitter.py` by using `authorization_response` named parameter in `fetch_token()`.
>     - Resolves 'Please supply either code or authorization_response parameters' error.
>   - **Misc**:
>     - Fixes ErikBjare/bob#152.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for 9dc84a6bc6947e79e6ed230dd45f578014e4942c. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->