### PR TITLE
fix(twitter): increment drafts_generated for main draft

### DIFF
--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -967,6 +967,7 @@ def process_timeline_tweets(
                     # Save draft
                     path = save_draft(draft, "new")
                     console.print(f"[green]Created draft response: {path}")
+                    drafts_generated += 1
                 else:
                     console.print("[yellow]Would create draft response:")
                     console.print(f"[white]{draft.text}")


### PR DESCRIPTION
Fixes #19

## Problem
The `drafts_generated` counter was only incremented for thread drafts (line 999) but not for the main draft response. This caused under-reporting in summary statistics.

## Solution
Added `drafts_generated += 1` after saving the main draft (line 970), ensuring both main drafts and thread drafts correctly increment the counter.

## Testing
- Pre-commit hooks: ✅ All passing (ruff, mypy, etc.)
- Logic verified: Counter now increments for both draft types

## Files Changed
- `scripts/twitter/workflow.py`: Added missing counter increment (1 line)

Co-authored-by: Bob <bob@superuserlabs.org>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `drafts_generated` counter in `workflow.py` to increment for main drafts, ensuring accurate statistics.
> 
>   - **Behavior**:
>     - Fixes `drafts_generated` counter in `process_timeline_tweets()` in `workflow.py` to increment for main drafts.
>     - Ensures accurate draft generation statistics by incrementing after saving main drafts.
>   - **Testing**:
>     - Verified logic: Counter increments for both main and thread drafts.
>     - All pre-commit hooks passing.
>   - **Misc**:
>     - Co-authored by Bob <bob@superuserlabs.org>.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for 40dbcbc6f23a126e5dfb64ca32cc515ccce07e07. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->