### PR TITLE
chore: add .venv/ and venv/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ __pycache__
 scripts/discord/logs/*
 scripts/*/.env
 scripts/.env
+
+.venv/
+venv/


### PR DESCRIPTION
Simple cleanup to ignore Python virtual environment directories that were showing as untracked in git status.

Co-authored-by: Bob <bob@superuserlabs.org>