### PR TITLE
fix: fixed exit code on failed test/typecheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ test-packages:  ## Run tests for all packages
 			echo "\n=== Testing $$(basename $$pkg) ==="; \
 			$(MAKE) -C "$$pkg" test || failed=1; \
 		fi \
-	done
-	@if [ -n "$$failed" ]; then exit 1; fi
+	done; \
+	if [ -n "$$failed" ]; then exit 1; fi
 
 typecheck-packages:  ## Run mypy for all packages
 	@echo "Running typecheck for all packages..."
@@ -21,8 +21,8 @@ typecheck-packages:  ## Run mypy for all packages
 			echo "\n=== Typechecking $$(basename $$pkg) ==="; \
 			$(MAKE) -C "$$pkg" typecheck || failed=1; \
 		fi \
-	done
-	@if [ -n "$$failed" ]; then exit 1; fi
+	done; \
+	if [ -n "$$failed" ]; then exit 1; fi
 
 check-names:
 	@# If we are in gptme-contrib, we should have no agent/instance/user-specific names, and vice versa


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes exit code handling in `Makefile` to ensure non-zero exit on failed tests or typechecks.
> 
>   - **Behavior**:
>     - Fixes exit code handling in `Makefile` for `test-packages` and `typecheck-packages` targets.
>     - Ensures non-zero exit code if any package test or typecheck fails.
>   - **Implementation**:
>     - Modifies `test-packages` to set `failed=1` on test failure and exits with code 1 if any test fails.
>     - Modifies `typecheck-packages` to set `failed=1` on typecheck failure and exits with code 1 if any typecheck fails.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for e0af4db27a69e0b57778a95a55c404636b4cb858. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->