### PR TITLE
fix(lessons): remove unused type: ignore comments

### DIFF
--- a/packages/lessons/src/lessons/analytics.py
+++ b/packages/lessons/src/lessons/analytics.py
@@ -45,7 +45,7 @@ from typing import Dict, List, Set, Tuple
 
 from rich.console import Console
 from rich.table import Table
-import frontmatter  # type: ignore[import-untyped]
+import frontmatter
 
 
 @dataclass

--- a/packages/lessons/src/lessons/sync.py
+++ b/packages/lessons/src/lessons/sync.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Optional
 
 try:
-    from lessons.export import export_all_lessons  # type: ignore[import-not-found]
+    from lessons.export import export_all_lessons
 
     # Use importlib for 'import' keyword conflict
     import_module = importlib.import_module("lessons.import")

--- a/packages/lessons/src/lessons/utils/variants.py
+++ b/packages/lessons/src/lessons/utils/variants.py
@@ -34,7 +34,7 @@ def generate_lesson_variants(
         List of lesson markdown strings
     """
     # Read template using helper from llm module
-    from lessons.utils.llm import _find_lesson_template  # type: ignore[import-not-found]
+    from lessons.utils.llm import _find_lesson_template
 
     template_path = _find_lesson_template()
 


### PR DESCRIPTION
These imports now type-check correctly after package installation.

Fixes mypy warnings in:
- sync.py
- analytics.py  
- utils/variants.py

The type ignores were added when imports weren't resolving, but now with proper package installation they're no longer needed.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes unnecessary `type: ignore` comments from import statements in `analytics.py`, `sync.py`, and `utils/variants.py` after successful package installation.
> 
>   - **Behavior**:
>     - Removes `type: ignore` comments from import statements in `analytics.py`, `sync.py`, and `utils/variants.py`.
>     - Imports now type-check correctly after package installation.
>   - **Misc**:
>     - Fixes mypy warnings related to unresolved imports in the mentioned files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for 61e9614f130c442161f7a7a9c0cfedfb1774c3a2. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->