### PR TITLE
feat(monitoring): add branch names to work items to prevent wrong-branch pushes

### DIFF
--- a/packages/run_loops/src/run_loops/project_monitoring.py
+++ b/packages/run_loops/src/run_loops/project_monitoring.py
@@ -172,7 +172,7 @@ class ProjectMonitoringRun(BaseRunLoop):
                     "--state",
                     "open",
                     "--json",
-                    "number,title,updatedAt,url",
+                    "number,title,updatedAt,url,headRefName",
                 ],
                 capture_output=True,
                 text=True,
@@ -206,6 +206,7 @@ class ProjectMonitoringRun(BaseRunLoop):
                         # Update state file
                         state_file.write_text(updated_at)
 
+                        branch_name = pr.get("headRefName", "unknown")
                         work_items.append(
                             WorkItem(
                                 repo=repo,
@@ -213,7 +214,7 @@ class ProjectMonitoringRun(BaseRunLoop):
                                 number=pr_number,
                                 title=pr["title"],
                                 url=pr["url"],
-                                details=f"PR #{pr_number} updated: {updated_at}",
+                                details=f"PR #{pr_number} updated: {updated_at}\n  - **Branch**: `{branch_name}` (push to this branch!)",
                             )
                         )
 
@@ -687,6 +688,11 @@ Classify each work item:
 - MUST use worktrees for PRs
 - MUST update PR after fixing (don't just commit)
 - Never commit directly to master/main
+
+**Branch Verification (CRITICAL)**:
+- Work item shows branch name: push to THAT branch
+- Before pushing: `git branch -vv` → verify correct upstream
+- If tracking wrong branch: `git branch --unset-upstream && git push -u origin <branch>`
 
 **For Workspace Repo**:
 - Can commit directly to master


### PR DESCRIPTION
## Summary

Adds branch name (headRefName) to PR work items in project monitoring, helping agents push to the correct branches.

## Changes

1. **Include headRefName in PR discovery** - Added to the `gh pr list` JSON query
2. **Display branch prominently in work item details** - Shows `**Branch**: `branch-name` (push to this branch!)`
3. **Add branch verification guidance in prompt** - New section explaining how to verify tracking before pushing

## Problem Addressed

From ErikBjare/bob#188:
> Pushing to the wrong pr/branch
> Maybe fix this by giving better project monitoring prompt description that includes branch name?

## Example Output

Work items will now show:
```
PR #123 updated: 2025-12-08T06:00:00Z
  - **Branch**: `feat/my-feature` (push to this branch!)
```

And the prompt includes:
```
**Branch Verification (CRITICAL)**:
- Work item shows branch name: push to THAT branch
- Before pushing: `git branch -vv` → verify correct upstream
- If tracking wrong branch: `git branch --unset-upstream && git push -u origin <branch>`
```

## Testing

- Syntax validated with py_compile
- All pre-commit checks pass

## Related

- Addresses: ErikBjare/bob#188
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds branch names to PR work items in `project_monitoring.py` to prevent wrong-branch pushes and updates prompt with branch verification guidance.
> 
>   - **Behavior**:
>     - Adds `headRefName` to `gh pr list` query in `check_pr_updates()` in `project_monitoring.py` to include branch names in work items.
>     - Updates work item details to display branch name prominently.
>     - Enhances prompt with branch verification guidance, including steps to verify and correct branch tracking.
>   - **Testing**:
>     - Syntax validated with `py_compile`.
>     - All pre-commit checks pass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for 211d6abe40954be5e024dfd9c1ae9530b23ae623. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->