### PR TITLE
feat(tasks): add --user flag to filter tasks by assigned_to

### DIFF
--- a/packages/tasks/src/tasks/generate_queue.py
+++ b/packages/tasks/src/tasks/generate_queue.py
@@ -225,8 +225,18 @@ class QueueGenerator:
         Source: GitHub issues in current repository
         Filter: label=priority:high/urgent AND state=open
         Boost: +1 score if assigned to configured username
+
+        Note: Skipped when --user filter is active, since GitHub uses
+        a different assignment model (GitHub usernames via assignees)
+        than local tasks (role-based assigned_to field).
         """
         tasks: List[Task] = []
+
+        # Skip GitHub issues when filtering by user
+        # GitHub issues use assignees (GitHub usernames) which don't map
+        # to the role-based assigned_to field used in local tasks
+        if self.user:
+            return tasks
 
         try:
             # Get current repository name


### PR DESCRIPTION
Allows generating user-specific work queues:

```bash
uv run python3 -m tasks.generate_queue --user human
```

When `--user` is specified:
- Filters tasks by `assigned_to` field (matches user or 'both')
- Includes all priorities (not just high/urgent)
- Outputs to `queue-generated-{user}.md`

**Use case**: Daily emails showing tasks assigned to a specific person (e.g., human tasks that unblock the agent).

Co-authored-by: Bob <bob@superuserlabs.org>
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `--user` flag to `generate_queue.py` to filter tasks by `assigned_to`, affecting task filtering and output file naming.
> 
>   - **Behavior**:
>     - Adds `--user` flag to `generate_queue.py` to filter tasks by `assigned_to` field.
>     - When `--user` is specified, includes all priorities and outputs to `queue-generated-{user}.md`.
>     - Skips GitHub issues when `--user` is active due to different assignment models.
>   - **Functions**:
>     - Updates `get_file_tasks()` to filter tasks by `assigned_to` when `--user` is specified.
>     - Updates `get_github_issues()` to skip issues when `--user` is specified.
>   - **Misc**:
>     - Updates `QueueGenerator.__init__()` to handle `user` parameter and adjust output file naming.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for 9d09db085e6a6f294814cbc477738e4839d165fe. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->