### PR TITLE
fix(gptmail): RFC 2047 encode Subject and From headers for non-ASCII chars

### DIFF
--- a/packages/gptmail/src/gptmail/lib.py
+++ b/packages/gptmail/src/gptmail/lib.py
@@ -572,13 +572,9 @@ class AgentEmail:
             msg = MIMEMultipart("alternative")
 
             # Set headers from extracted metadata
-            # RFC 2047 encode From if it contains non-ASCII display name
+            # RFC 2047 encode From and Subject for proper non-ASCII handling
             from_header = headers.get("From") or sender
-            msg["From"] = (
-                Header(from_header, "utf-8").encode()
-                if any(ord(c) > 127 for c in from_header)
-                else from_header
-            )
+            msg["From"] = Header(from_header, "utf-8").encode()
             msg["To"] = recipient
             # RFC 2047 encode Subject to handle non-ASCII characters (åäö etc)
             subject = headers.get("Subject", "")


### PR DESCRIPTION
## Problem

Email headers with special characters like åäö were being sent as raw UTF-8 bytes, which some email clients/servers display incorrectly.

## Solution

Use `email.header.Header` to RFC 2047 encode:
1. **Subject header** - always encoded to handle any non-ASCII characters
2. **From header** - encoded only when it contains non-ASCII characters (for display names)

## Testing

```python
from email.header import Header
subject = 'Test med svenska tecken: åäö och ÅÄÖ'
encoded = Header(subject, 'utf-8')
# Result: =?utf-8?b?VGVzdCBtZWQgc3ZlbnNrYSB0ZWNrZW46IMOlw6TDtiBvY2ggw4XDhMOW?=
```

This properly RFC 2047 encodes the header which email clients then decode correctly.

## Related

- Addresses ErikBjare/bob#221
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> RFC 2047 encoding added to `send()` in `lib.py` for `From` and `Subject` headers to handle non-ASCII characters.
> 
>   - **Behavior**:
>     - RFC 2047 encoding added to `send()` in `lib.py` for `From` and `Subject` headers to handle non-ASCII characters.
>     - `From` header encoded only if it contains non-ASCII characters.
>   - **Imports**:
>     - Added `Header` from `email.header` in `lib.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for 55d2f649830710491a1bdd9e3f1815b5e3eec03b. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->