### PR TITLE
docs(lessons): add Quick Start single-command workflow for worktrees

### DIFF
--- a/lessons/workflow/git-worktree-workflow.md
+++ b/lessons/workflow/git-worktree-workflow.md
@@ -35,6 +35,35 @@ last_used: '2025-11-04T18:24:16.449224Z'
 When creating new work, always `git fetch origin master` first, then create branch from `origin/master`.
 This prevents accidentally including uncommitted/unmerged changes.
 
+## Quick Start: Single-Command Workflow
+
+**For existing PRs** (checkout and resume work):
+```shell
+# Run from repo root (e.g., ~/gptme)
+PR=123 && \
+BRANCH=$(gh pr view $PR --json headRefName -q .headRefName) && \
+git fetch origin && \
+(git worktree list | grep -q "worktree/$BRANCH" || git worktree add "worktree/$BRANCH") && \
+cd "worktree/$BRANCH" && \
+gh pr checkout $PR
+```
+
+**For new work** (create branch and worktree):
+```shell
+# Run from repo root
+BRANCH="feature-name" && \
+git fetch origin && \
+(git worktree list | grep -q "worktree/$BRANCH" || git worktree add "worktree/$BRANCH" -b "$BRANCH" origin/master) && \
+cd "worktree/$BRANCH" && \
+git branch --unset-upstream && \
+git push -u origin "$BRANCH"
+```
+
+**Key points**:
+- `gh pr checkout` handles branch tracking automatically for existing PRs
+- The `grep -q` check reuses existing worktrees instead of failing
+- For new branches, `--unset-upstream` prevents accidental push to master
+
 ## Context
 When making changes to repositories you don't own (gptme, gptme-contrib, etc.) where you need to create PRs.
 


### PR DESCRIPTION
## Summary
Addresses Erik's feedback on issue #228 regarding efficient worktree setup.

## Changes
Added a "Quick Start: Single-Command Workflow" section with:
- **For existing PRs**: Single command using `gh pr checkout` (handles tracking automatically)
- **For new work**: Single command with proper `--unset-upstream` to prevent accidental push to master
- **Worktree reuse**: `grep -q` check reuses existing worktrees instead of failing

## Key Points Documented
- `gh pr checkout` reliably handles branch tracking for existing PRs
- `grep -q` pattern allows reusing existing worktrees
- `--unset-upstream` is needed for new branches to prevent tracking master

Closes #228 request for efficient single-command workflow documentation.

Related: #106 (original worktree lesson PR)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a "Quick Start: Single-Command Workflow" section to `git-worktree-workflow.md` for efficient worktree setup with commands for existing PRs and new work.
> 
>   - **Documentation**:
>     - Adds "Quick Start: Single-Command Workflow" section in `git-worktree-workflow.md`.
>     - Provides commands for existing PRs using `gh pr checkout` and new work with `--unset-upstream`.
>     - Includes `grep -q` check for reusing existing worktrees.
>   - **Key Points**:
>     - `gh pr checkout` manages branch tracking for existing PRs.
>     - `--unset-upstream` prevents new branches from tracking master.
>     - `grep -q` ensures worktree reuse instead of failure.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for 5499ca5fedc8cd6b700000f4a39771ff1cb33e98. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->