### PR TITLE
fix(lessons): add -b flag to worktree command to prevent detached HEAD

### DIFF
--- a/lessons/workflow/git-worktree-workflow.md
+++ b/lessons/workflow/git-worktree-workflow.md
@@ -43,7 +43,7 @@ This prevents accidentally including uncommitted/unmerged changes.
 PR=123 && \
 BRANCH=$(gh pr view $PR --json headRefName -q .headRefName) && \
 git fetch origin && \
-(git worktree list | grep -q "worktree/$BRANCH" || git worktree add "worktree/$BRANCH") && \
+(git worktree list | grep -q "worktree/$BRANCH" || git worktree add "worktree/$BRANCH" -b "$BRANCH") && \
 cd "worktree/$BRANCH" && \
 gh pr checkout $PR
 ```


### PR DESCRIPTION
Without `-b` flag, `git worktree add` creates a detached HEAD worktree.
Adding `-b "$BRANCH"` ensures a proper branch is created, which
`gh pr checkout` can then update to track the PR's remote branch.

This is a cherry-pick of commit 89dab1e which was pushed after PR #107 was merged (race condition).

Fixes #108

## Changes
- Add `-b "$BRANCH"` flag to the 'For existing PRs' worktree command in Quick Start section
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `-b "$BRANCH"` flag to `git worktree add` in `git-worktree-workflow.md` to prevent detached HEAD and ensure proper branch tracking.
> 
>   - **Behavior**:
>     - Adds `-b "$BRANCH"` flag to `git worktree add` command in `git-worktree-workflow.md` to prevent detached HEAD.
>     - Ensures `gh pr checkout` can update to track the PR's remote branch.
>   - **Context**:
>     - Cherry-pick of commit 89dab1e after PR #107 was merged.
>     - Fixes issue #108.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for 04db3abb09d3a585391830e7e7594b3bcd38f9d9. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->