### PR TITLE
fix(hooks): skip branch-base warning for branches tracking origin

### DIFF
--- a/dotfiles/.config/git/hooks/validate-branch-base.sh
+++ b/dotfiles/.config/git/hooks/validate-branch-base.sh
@@ -15,6 +15,15 @@ if [ "$current_branch" = "master" ] || [ "$current_branch" = "main" ]; then
     exit 0
 fi
 
+# Skip check if branch already tracks a remote on origin (it's a PR branch)
+# These branches are intentionally not rebased until merge time
+upstream=$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || echo "")
+if [[ "$upstream" =~ ^origin/ ]]; then
+    # Branch is tracking origin - it's already pushed/in a PR
+    # Don't warn about being behind master; rebasing PRs during review is usually undesirable
+    exit 0
+fi
+
 # Get merge base with origin/master (try both master and main)
 merge_base=""
 for remote_branch in origin/master origin/main; do

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,8 @@ resolution-markers = [
 [manifest]
 members = [
     "gptmail",
+    "gptme-attention-history",
+    "gptme-attention-router",
     "gptme-cc-analyze",
     "gptme-consortium",
     "gptme-contrib-workspace",
@@ -648,6 +650,50 @@ sdist = { url = "https://files.pythonhosted.org/packages/cf/48/95c9aa7ab0c6144de
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cd/14/8da70aa8ed9b937d4a01dfa875450b7b857a691c58b75ebe3ebba42482e8/gptme-0.30.0-py3-none-any.whl", hash = "sha256:bd414e431a6de6a31159ae7bbc2f7ac3ecb07091bdc64e572666b3d3c874236a", size = 407955, upload-time = "2025-11-18T11:26:28.414Z" },
 ]
+
+[[package]]
+name = "gptme-attention-history"
+version = "0.1.0"
+source = { editable = "plugins/attention-history" }
+dependencies = [
+    { name = "gptme" },
+]
+
+[package.optional-dependencies]
+test = [
+    { name = "pytest" },
+    { name = "pytest-mock" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "gptme", specifier = ">=0.27.0" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
+    { name = "pytest-mock", marker = "extra == 'test'", specifier = ">=3.12.0" },
+]
+provides-extras = ["test"]
+
+[[package]]
+name = "gptme-attention-router"
+version = "0.1.0"
+source = { editable = "plugins/attention-router" }
+dependencies = [
+    { name = "gptme" },
+]
+
+[package.optional-dependencies]
+test = [
+    { name = "pytest" },
+    { name = "pytest-mock" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "gptme", specifier = ">=0.27.0" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
+    { name = "pytest-mock", marker = "extra == 'test'", specifier = ">=3.12.0" },
+]
+provides-extras = ["test"]
 
 [[package]]
 name = "gptme-cc-analyze"


### PR DESCRIPTION
## Summary

Branches that already track `origin/*` are PR branches - they're intentionally not rebased until merge time. The 'not based on latest master' warning is not actionable for these branches and creates noise in the workflow.

## Changes

- Skip the branch-base validation warning for branches that track remote branches on origin
- Also includes uv.lock sync with new attention plugins

## What this fixes

The warning still fires for:
- Local branches not yet pushed (useful to catch stale bases before first push)
- Branches tracking non-origin remotes

The warning is now skipped for:
- Branches tracking `origin/feature-branch` (existing PRs)  
- Worktrees checking out PR branches

## Context

Addresses Issue ErikBjare/bob#229 about noisy warnings for long-running PRs that are waiting for review.

Co-authored-by: Bob <bob@superuserlabs.org>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Skip branch-base validation warning for branches tracking `origin/*` and sync `uv.lock` with new plugins.
> 
>   - **Behavior**:
>     - Skip branch-base validation warning for branches tracking `origin/*` in `validate-branch-base.sh`.
>     - Warning still applies to local branches not pushed and branches tracking non-origin remotes.
>   - **Misc**:
>     - Sync `uv.lock` with new plugins `gptme-attention-history` and `gptme-attention-router`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for c7ac2f2e96e8a019e5f6e97ded2617aaef6b85f3. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->