### PR TITLE
fix(hooks): preserve stdin for worktree tracking validation

### DIFF
--- a/dotfiles/.config/git/hooks/pre-push
+++ b/dotfiles/.config/git/hooks/pre-push
@@ -6,6 +6,11 @@
 
 SCRIPT_DIR="$(dirname "$0")"
 
+# Store stdin for reuse (git provides: local_ref local_sha remote_ref remote_sha)
+# This is needed because we may read stdin in the master/main check
+# and need it again for worktree tracking validation
+STDIN_CONTENT=$(cat)
+
 # --- Master/Main Push Protection ---
 # Source allowed repos from config file (shared with pre-commit hook)
 # Falls back to empty array if config doesn't exist (backwards compatible)
@@ -48,8 +53,9 @@ if [ "$is_allowed" = false ]; then
             echo "  git push -u origin feature-branch"
             exit 1
         fi
-    done
+    done <<< "$STDIN_CONTENT"
 fi
 
 # --- Worktree Tracking Validation ---
-exec "$SCRIPT_DIR/validate-worktree-tracking.sh" "$@"
+# Pass stored stdin to validation script
+echo "$STDIN_CONTENT" | "$SCRIPT_DIR/validate-worktree-tracking.sh" "$@"


### PR DESCRIPTION
## Problem

The pre-push hook was consuming stdin in the master/main check loop, leaving nothing for `validate-worktree-tracking.sh` to read. This caused worktree tracking validation to silently fail for repositories not in the allowed list.

## Solution

Store stdin in a variable at the start and reuse it for both validations:
1. Store stdin: `STDIN_CONTENT=$(cat)`
2. Use `<<< "$STDIN_CONTENT"` for the master/main while loop
3. Pipe stored stdin to validate-worktree-tracking.sh

## Root Cause

When a repository is NOT in the allowed patterns list, the pre-push hook's while loop would consume all stdin looking for master/main pushes. When it then called `validate-worktree-tracking.sh`, that script would receive empty stdin and fail to validate properly.

This fixes Issue #229 in ErikBjare/bob regarding hook reliability in worktrees.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes stdin consumption in `pre-push` hook by storing and reusing stdin for master/main check and worktree tracking validation.
> 
>   - **Behavior**:
>     - Fixes stdin consumption issue in `pre-push` hook by storing stdin in `STDIN_CONTENT`.
>     - Reuses `STDIN_CONTENT` for master/main check and worktree tracking validation.
>   - **Scripts**:
>     - Updates `pre-push` to use `<<< "$STDIN_CONTENT"` for master/main loop.
>     - Pipes `STDIN_CONTENT` to `validate-worktree-tracking.sh`.
>   - **Issue Fix**:
>     - Resolves Issue #229 in ErikBjare/bob regarding hook reliability in worktrees.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for 1bdf6bb588ccdcc6859569257a0536c1c228e23e. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->