### PR TITLE
fix(precommit): skip template directories in markdown link checker

### DIFF
--- a/scripts/precommit/check_markdown_links.py
+++ b/scripts/precommit/check_markdown_links.py
@@ -26,7 +26,7 @@ LINK_PATTERN = re.compile(r"\[([^\]]*)\]\(([^)]+)\)")
 SKIP_PROTOCOLS = ("http://", "https://", "ftp://", "mailto:", "#")
 
 # Directories to skip
-SKIP_DIRS = {"worktree", ".git", "node_modules", "__pycache__", ".venv"}
+SKIP_DIRS = {"worktree", ".git", "node_modules", "__pycache__", ".venv", "templates"}
 
 
 def get_repo_root() -> Path:


### PR DESCRIPTION
Template files (e.g., `journal/templates/daily.md`) contain placeholder links like `../tasks/task-name.md` that are intentionally not valid. These should not be checked for broken links.

## Problem
CI in gptme-agent-template#43 is failing because when forking an agent, the `pre-commit` checks fail on template placeholder links that don't resolve to actual files.

Example error:
```
journal/templates/daily.md: Broken link '../tasks/task-name.md' -> .../test-agent/journal/tasks/task-name.md
```

## Solution
Add `templates` to `SKIP_DIRS` so files in template directories are excluded from markdown link validation.

## Testing
- Files in any `templates/` directory will now be skipped
- This is consistent with how other placeholder content directories are handled

Fixes CI failures in gptme/gptme-agent-template#43
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `templates` to `SKIP_DIRS` in `check_markdown_links.py` to skip markdown link validation in template directories, preventing CI failures from placeholder links.
> 
>   - **Behavior**:
>     - Add `templates` to `SKIP_DIRS` in `check_markdown_links.py` to skip markdown link validation in template directories.
>     - Prevents CI failures due to placeholder links in template files.
>   - **Testing**:
>     - Ensures files in `templates/` directories are excluded from link checks, consistent with other placeholder directories.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for aa11a8bfbd832183e6f2df621c4fc07a7bc1ecbb. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->