### PR TITLE
feat(tasks): add sync command to compare task/issue states

### DIFF
--- a/packages/tasks/src/tasks/cli.py
+++ b/packages/tasks/src/tasks/cli.py
@@ -2007,7 +2007,6 @@ def stale(days: int, state: str, output_json: bool):
     console.print("[dim]Run [bold]tasks.py show <id>[/] to inspect a task's details[/]")
 
 
-
 @cli.command("sync")
 @click.option(
     "--update",
@@ -2103,7 +2102,7 @@ def sync(update, output_json):
             continue
 
         # Determine expected task state based on issue state
-        expected_state = "done" if issue_state == "CLOSED" else task.state
+        expected_state = "done" if issue_state == "CLOSED" else (task.state or "active")
         if issue_state == "OPEN" and task.state == "done":
             expected_state = "active"  # Reopened issue
 
@@ -2258,6 +2257,7 @@ def update_task_state(task_path: Path, new_state: str) -> bool:
         return True
     except Exception:
         return False
+
 
 if __name__ == "__main__":
     cli()


### PR DESCRIPTION
## Summary

Adds `tasks.py sync` command that synchronizes task states with linked GitHub issues.

## Features

- Finds tasks with `tracking_issue` field in frontmatter
- Fetches GitHub issue/PR state via `gh` CLI
- Reports sync status (in sync / out of sync)
- `--update` flag to auto-update task states to match issue states
- `--json` for machine-readable output

## Frontmatter Format

```yaml
tracking_issue: 'owner/repo#123'
# or
tracking_issue: 'https://github.com/owner/repo/issues/123'
```

## GitHub State Mapping

| Issue State | Expected Task State |
|-------------|---------------------|
| OPEN | active/new/paused |
| CLOSED | done |

## Usage

```bash
# Check sync status
tasks.py sync

# Check with JSON output
tasks.py sync --json

# Auto-update task states to match issues
tasks.py sync --update
```

## Part of
- Closes: Part of ErikBjare/bob#235 (tasks system parity with beads)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `sync` command to `tasks/cli.py` for synchronizing task states with GitHub issues, supporting auto-update and JSON output.
> 
>   - **Behavior**:
>     - Adds `sync` command in `tasks/cli.py` to synchronize task states with GitHub issues.
>     - Supports `--update` flag to auto-update task states and `--json` for machine-readable output.
>     - Maps GitHub issue states to task states: `OPEN` to `active/new/paused`, `CLOSED` to `done`.
>   - **Functions**:
>     - `parse_tracking_ref()` to extract repo and issue number from tracking references.
>     - `fetch_github_issue_state()` to get issue state using `gh` CLI.
>     - `update_task_state()` to update task state in frontmatter.
>   - **Misc**:
>     - Handles tasks with `tracking_issue` in frontmatter, reports sync status, and logs errors if issues occur.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for 0d6c7fc65934c530c5ae2e50469b1973e3ea71c9. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->