### PR TITLE
feat(tasks): add fetch command to cache external issue states

### DIFF
--- a/state/issue-cache.json
+++ b/state/issue-cache.json
@@ -1,7 +1,0 @@
-{
-  "https://github.com/gptme/gptme-contrib/issues/129": {
-    "state": "OPEN",
-    "source": "github",
-    "last_fetched": "2026-01-10T15:17:56.581748"
-  }
-}


### PR DESCRIPTION
## Summary

Implements the state-cache approach per Erik's direction in #129.

## What this PR does

Adds a new `fetch` command that:
- Scans tasks for external URLs in `tracking`, `blocks`, and `related` fields
- Fetches state (open/closed) from GitHub API  
- Caches results in `state/issue-cache.json`
- Supports `--max-age` for cache expiry (default 1 hour)
- Supports `--json` output for machine consumption
- Can accept explicit URLs as arguments

## Usage Examples

```bash
# Fetch all external URLs from tasks
tasks.py fetch

# Refresh all (ignore cache age)
tasks.py fetch --all

# Fetch specific URL
tasks.py fetch https://github.com/o/r/issues/1

# JSON output
tasks.py fetch --json
```

## Architecture per #129

Erik clarified the architecture:
- **fetch** → get latest state, store to cache (this PR)
- **import** → import issues/PRs as tasks with `tracking` already set (PR #130)
- **sync** → runs fetch + compares with task state/tracking + shows drift + offers auto-update

This PR focuses only on the fetch/cache layer. The existing `sync` command can be enhanced to use this cache.

## Testing

```bash
$ python -m tasks fetch "https://github.com/gptme/gptme-contrib/issues/129" --json
{
  "fetched": 1,
  "cached": 0,
  "errors": 0,
  "total": 1,
  "cache_path": ".../state/issue-cache.json",
  "results": [
    {
      "url": "https://github.com/gptme/gptme-contrib/issues/129",
      "state": "OPEN",
      "source": "github",
      "status": "fetched"
    }
  ]
}
```

Refs: #129

@greptileai review
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `fetch` command to cache GitHub issue states, enhancing task readiness checks by integrating cache usage in `cli.py`.
> 
>   - **New Command**:
>     - Adds `fetch` command in `cli.py` to cache external issue states from GitHub.
>     - Caches results in `state/issue-cache.json`.
>     - Supports `--max-age` for cache expiry and `--json` for output.
>     - Accepts explicit URLs or scans tasks for URLs in `tracking`, `blocks`, and `related` fields.
>   - **Function Modifications**:
>     - Updates `is_task_ready()` to check URL-based blocks against cache.
>     - Modifies `ready`, `next_`, and `sync` commands to use cached states with `--use-cache` option.
>   - **Cache Management**:
>     - Implements `get_cache_path()`, `load_cache()`, and `save_cache()` for cache handling.
>     - Introduces `fetch_url_state()` to retrieve state from GitHub.
>   - **Testing**:
>     - Provides examples for using the `fetch` command with various options.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for 2495a90e2096207bcdb339d57b8a50499dc0992a. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->