### PR TITLE
feat(tasks): add --jsonl option for LLM-friendly compact output

### DIFF
--- a/packages/tasks/src/tasks/cli.py
+++ b/packages/tasks/src/tasks/cli.py
@@ -232,9 +232,17 @@ def list_(sort, active_only, context, output_json, output_jsonl):
     if active_only:
         tasks = [task for task in all_tasks if task.state in ["new", "active"]]
         if not tasks:
+            if output_json:
+                print("No new or active tasks found", file=sys.stderr)
+                print(json.dumps({"tasks": [], "count": 0}, indent=2))
+                return
+            if output_jsonl:
+                print("No new or active tasks found", file=sys.stderr)
+                return
             console.print("[yellow]No new or active tasks found[/]")
             return
-        console.print("[blue]Showing only new and active tasks[/]\n")
+        if not output_json and not output_jsonl:
+            console.print("[blue]Showing only new and active tasks[/]\n")
 
     # Filter by context if specified
     if context:
@@ -242,9 +250,21 @@ def list_(sort, active_only, context, output_json, output_jsonl):
         context_tag = context if context.startswith("@") else f"@{context}"
         tasks = [task for task in tasks if context_tag in (task.tags or [])]
         if not tasks:
+            if output_json:
+                print(
+                    f"No tasks found with context tag '{context_tag}'", file=sys.stderr
+                )
+                print(json.dumps({"tasks": [], "count": 0}, indent=2))
+                return
+            if output_jsonl:
+                print(
+                    f"No tasks found with context tag '{context_tag}'", file=sys.stderr
+                )
+                return
             console.print(f"[yellow]No tasks found with context tag '{context_tag}'[/]")
             return
-        console.print(f"[blue]Showing tasks with context tag '{context_tag}'[/]\n")
+        if not output_json and not output_jsonl:
+            console.print(f"[blue]Showing tasks with context tag '{context_tag}'[/]\n")
 
     # Sort tasks for display based on option
     if sort == "state":
@@ -1257,9 +1277,11 @@ def ready(state, output_json, output_jsonl, use_cache):
 
     if not ready_tasks:
         if output_json:
+            print("No ready tasks found", file=sys.stderr)
             print(json.dumps({"ready_tasks": [], "count": 0}, indent=2))
             return
         if output_jsonl:
+            print("No ready tasks found", file=sys.stderr)
             return  # Empty output for JSONL
         console.print("[yellow]No ready tasks found![/]")
         console.print(
@@ -1355,6 +1377,15 @@ def next_(output_json, use_cache):
     # Load all tasks
     all_tasks = load_tasks(tasks_dir)
     if not all_tasks:
+        if output_json:
+            print("No tasks found", file=sys.stderr)
+            print(
+                json.dumps(
+                    {"next_task": None, "alternatives": [], "error": "No tasks found"},
+                    indent=2,
+                )
+            )
+            return
         console.print("[yellow]No tasks found![/]")
         return
 
@@ -1370,6 +1401,19 @@ def next_(output_json, use_cache):
     # Filter for new or active tasks
     workable_tasks = [task for task in all_tasks if task.state in ["new", "active"]]
     if not workable_tasks:
+        if output_json:
+            print("No new or active tasks found", file=sys.stderr)
+            print(
+                json.dumps(
+                    {
+                        "next_task": None,
+                        "alternatives": [],
+                        "error": "No new or active tasks found",
+                    },
+                    indent=2,
+                )
+            )
+            return
         console.print("[yellow]No new or active tasks found![/]")
         return
 
@@ -1380,6 +1424,7 @@ def next_(output_json, use_cache):
 
     if not ready_tasks:
         if output_json:
+            print("No ready tasks found", file=sys.stderr)
             print(
                 json.dumps(
                     {
@@ -1508,12 +1553,20 @@ def stale(days: int, state: str, output_json: bool, output_jsonl: bool):
     if not stale_tasks:
         if output_json:
             print(
+                f"No stale tasks found (threshold: {days} days, state: {state})",
+                file=sys.stderr,
+            )
+            print(
                 json.dumps(
                     {"stale_tasks": [], "count": 0, "days_threshold": days}, indent=2
                 )
             )
             return
         if output_jsonl:
+            print(
+                f"No stale tasks found (threshold: {days} days, state: {state})",
+                file=sys.stderr,
+            )
             return  # Empty output for JSONL when no tasks
         console.print(
             f"[green]No stale tasks found![/] (threshold: {days} days, state: {state})"


### PR DESCRIPTION
Adds `--jsonl` flag to `list`, `ready`, and `stale` commands that outputs one task per line (JSON Lines format).

This is much more compact when LLMs use `head -n40` as a safeguard:

| Format | Tasks visible in 40 lines |
|--------|--------------------------|
| JSON (pretty-printed) | ~2 tasks |
| **JSONL (one per line)** | **40 tasks** |

Each line is a complete, valid JSON object that can be parsed independently.

```shell
# Example usage
tasks list --jsonl | head -40     # 40 complete tasks
tasks ready --jsonl | head -20    # 20 ready tasks  
tasks stale --jsonl | head -10    # 10 stale tasks
```
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `--jsonl` option to `list_`, `ready`, and `stale` commands for JSON Lines output in `cli.py`.
> 
>   - **Feature**:
>     - Adds `--jsonl` option to `list_`, `ready`, and `stale` commands in `cli.py` for JSON Lines output.
>     - Outputs one task per line, suitable for LLM consumption.
>   - **Behavior**:
>     - Handles cases with no tasks by printing an error message and returning empty output for JSONL.
>     - Adjusts output format based on `--json` and `--jsonl` flags.
>   - **Misc**:
>     - Updates help messages for commands to include `--jsonl` option.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for 2f628345f92f2097fef82392c4a523453ad596aa. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->