### PR TITLE
fix(pre-commit): remove hard-coded Python 3.11 requirement

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,6 @@ repos:
   rev: v1.12.0
   hooks:
   - id: mypy
-    language_version: python3.11
     additional_dependencies: [
       "gptme @ git+https://github.com/gptme/gptme.git",
       rich,


### PR DESCRIPTION
## Summary

Removes the `language_version: python3.11` constraint from the mypy pre-commit hook.

## Problem

The mypy hook was configured with an explicit Python 3.11 requirement:
```yaml
- id: mypy
  language_version: python3.11
```

This prevented running pre-commit locally on systems that only have Python 3.12 (or other versions).

## Solution

Remove the explicit version constraint. Any recent Python (3.10, 3.11, 3.12) works fine with mypy, so pre-commit can use whatever Python version is available on the system.

## Testing

- Verified the change doesn't break anything by reviewing mypy requirements
- No specific Python 3.11 features are used in the type checking

Fixes #144
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes hard-coded Python 3.11 requirement from mypy pre-commit hook to allow broader Python version compatibility.
> 
>   - **Behavior**:
>     - Removes `language_version: python3.11` from the mypy hook in `.pre-commit-config.yaml`.
>     - Allows pre-commit to use any available Python version (3.10, 3.11, 3.12).
>   - **Testing**:
>     - Verified compatibility with mypy requirements.
>     - No Python 3.11 specific features used.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for b8c4a836b988aab541fb015f944a9e7b4b3f62d4. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->