### PR TITLE
refactor(linear): remove LINEAR_API_KEY fallback

### DIFF
--- a/scripts/linear/linear-webhook-server.py
+++ b/scripts/linear/linear-webhook-server.py
@@ -166,7 +166,7 @@ def get_access_token() -> str | None:
         except (json.JSONDecodeError, IOError):
             pass
 
-    return os.environ.get("LINEAR_API_KEY")
+    return None
 
 
 def verify_signature(payload: bytes, signature: str) -> bool:


### PR DESCRIPTION
## Summary

Remove the `LINEAR_API_KEY` environment variable fallback from the Linear webhook server authentication.

## Rationale

The Linear integration should always use OAuth tokens for authentication. Having multiple authentication methods (OAuth tokens vs personal API key) confused agents when using the Linear scripts, as they would sometimes try to set up a personal API key instead of completing the OAuth flow.

## Changes

- Remove `LINEAR_API_KEY` fallback from `get_access_token()` in `linear-webhook-server.py`
- Function now returns `None` if no OAuth token is found (instead of falling back to API key)

## Authentication Methods (after this change)

1. `LINEAR_ACCESS_TOKEN` environment variable
2. `.tokens.json` OAuth tokens file (created by OAuth flow)

cc @patriklaurell
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `LINEAR_API_KEY` fallback in `get_access_token()` in `linear-webhook-server.py`, enforcing OAuth token usage.
> 
>   - **Behavior**:
>     - Remove `LINEAR_API_KEY` fallback from `get_access_token()` in `linear-webhook-server.py`.
>     - `get_access_token()` now returns `None` if no OAuth token is found.
>   - **Authentication Methods**:
>     - Uses `LINEAR_ACCESS_TOKEN` environment variable.
>     - Uses `.tokens.json` OAuth tokens file.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for 57a1eb5e41893ed0218395022199eeb85d4ad888. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->