### PR TITLE
feat(linear): add interactive setup script

### DIFF
--- a/scripts/linear/setup.sh
+++ b/scripts/linear/setup.sh
@@ -66,7 +66,8 @@ check_prerequisites() {
 
     # Check ngrok
     if command -v ngrok &> /dev/null; then
-        success "ngrok found"
+        NGROK_PATH=$(command -v ngrok)
+        success "ngrok found at $NGROK_PATH"
     else
         missing+=("ngrok (install: snap install ngrok or see https://ngrok.com/download)")
     fi
@@ -334,7 +335,7 @@ WantedBy=default.target
 EOF
     success "Created webhook service: ${AGENT_NAME}-linear-webhook.service"
 
-    # ngrok service
+    # ngrok service - use full path since systemd has minimal PATH
     cat > ~/.config/systemd/user/${AGENT_NAME}-ngrok.service << EOF
 [Unit]
 Description=Ngrok tunnel for ${AGENT_NAME^} Linear webhook
@@ -342,7 +343,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/env ngrok http $PORT --log=stdout
+ExecStart=$NGROK_PATH http $PORT --log=stdout
 Restart=always
 RestartSec=5
 


### PR DESCRIPTION
## Summary

Add an interactive setup script (`setup.sh`) that automates the Linear integration setup process, replacing error-prone manual configuration.

## Problem

Having agents set up the Linear integration themselves was unreliable and led to misconfigurations. The setup guide has many steps and it's easy to miss something or misconfigure values.

## Solution

A comprehensive bash script that:

### Prerequisites Check
- ✅ Verifies Linux with systemd (exits with clear error on other OSes)
- ✅ Checks for Python 3.10+, uv, ngrok, gptme, git

### Interactive Configuration
- Prompts for agent name (used for @mentions and service names)
- Prompts for workspace path with validation
- Prompts for ngrok URL and calculates webhook/callback URLs
- **Displays exact values to enter in Linear OAuth app setup**
- Securely prompts for credentials (no echo for secrets)

### Automated Setup
- Creates all necessary directories
- Copies scripts to workspace if needed
- Creates `.env` file with proper permissions (600)
- Adds secrets to `.gitignore`
- Creates and enables systemd services
- Offers to run OAuth flow
- Offers to start services

### Output
- Clear summary of configuration
- Service management commands
- Reminder about `loginctl enable-linger`
- Instructions for testing

## Usage

```bash
cd /path/to/gptme-contrib/scripts/linear
./setup.sh
```

Then follow the interactive prompts.

## Non-Linux Support

The script explicitly checks for Linux and exits with a clear error message on other operating systems, as the integration requires systemd for service management.

cc @patriklaurell
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `setup.sh` to automate Linear integration setup with interactive prompts and systemd service configuration on Linux.
> 
>   - **Behavior**:
>     - Adds `setup.sh` to automate Linear integration setup, replacing manual configuration.
>     - Checks for Linux with systemd, Python 3.10+, `uv`, `ngrok`, `gptme`, and `git`.
>     - Prompts for agent name, workspace path, ngrok URL, and credentials.
>     - Creates necessary directories and `.env` file with permissions.
>     - Sets up systemd services for webhook and ngrok.
>     - Offers to run OAuth flow and start services.
>   - **Output**:
>     - Provides configuration summary and service management commands.
>     - Reminds about `loginctl enable-linger` and ngrok URL updates.
>   - **Usage**:
>     - Run `./setup.sh` in `scripts/linear` and follow prompts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for 36aa43136edc97f22a19f5256987587515c7fde7. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->