### PR TITLE
fix(lessons): improve keyword precision and clarity in concept lessons

### DIFF
--- a/lessons/concepts/ace-agentic-context-engineering.md
+++ b/lessons/concepts/ace-agentic-context-engineering.md
@@ -1,17 +1,13 @@
 ---
 match:
   keywords:
-  - context engineering
-  - ACE
-  - agentic context
-  - LLM context
-  - context management
-  - framework
-  - generator
-  - reflector
-  - curator
+  - agentic context engineering
+  - ACE context
+  - ACE framework
   - living playbooks
-  - context optimization
+  - context engineering LLM
+  - LLM context evolution
+  - dynamic context management
 ---
 
 # ACE (Agentic Context Engineering)
@@ -20,25 +16,29 @@ match:
 **ACE**: Agentic Context Engineering
 
 ## Definition
-Framework for dynamically managing and evolving LLM contexts as "living playbooks"
+Framework for dynamically managing and evolving LLM contexts as "living playbooks" that adapt over time.
 
 ## Components
-- **Generator**: Creates new context elements
-- **Reflector**: Evaluates context effectiveness
-- **Curator**: Selects and organizes context components
+- **Generator**: Creates new context elements based on task needs
+- **Reflector**: Evaluates context effectiveness and identifies gaps
+- **Curator**: Selects, organizes, and prunes context components
 
 ## Purpose
 - Addresses brevity bias in LLM context management
 - Prevents context collapse over long conversations
 - Enables dynamic context evolution based on task needs
 
+## Applicability
+
+Use ACE concepts when:
+- Managing long-running agent sessions
+- Building systems that need to evolve context over time
+- Addressing context staleness or collapse issues
+
 ## Source
 Stanford/SambaNova/UC Berkeley research paper (October 2025)
 
-## Context
-Advanced context management approach that treats context as an evolving, intelligent system rather than static information storage.
-
 ## Related
+- Hierarchical context management
 - Context compression strategies
-- Dynamic context management
 - LLM context optimization

--- a/lessons/concepts/hierarchical-context-management.md
+++ b/lessons/concepts/hierarchical-context-management.md
@@ -4,26 +4,25 @@ match:
   - hierarchical context management
   - Droid context architecture
   - agent context layers
-  - immediate context
-  - session context
-  - project context
-  - global context
-  - context cascading
-  - Factory Droid
+  - Factory Droid context
+  - multi-layer context
   - context layer architecture
+  - agentic context layers
 ---
 
 # Hierarchical Context Management (Droid Architecture)
 
+> **Not to be confused with**: The "CASCADE" workflow used in gptme autonomous sessions, which refers to task selection priority (PRIMARY → SECONDARY → TERTIARY). This lesson is about context management architecture, not task prioritization.
+
 ## Term
-**Hierarchical Context Management**: Context architecture used in Factory's Droid and similar advanced agent systems.
+**Hierarchical Context Management**: Context architecture pattern used in advanced agent systems like Factory's Droid.
 
 ## Definition
-Multi-layered context management approach that organizes information in cascading levels of importance and accessibility, assembling context per-step based on the current action.
+Multi-layered context management approach that organizes information in levels of importance and accessibility, assembling context per-step based on the current action.
 
 ## Architecture Layers
 
-Per Factory's Droid documentation:
+Common pattern in sophisticated agent systems:
 
 - **Global Context**: System policies, guardrails, organization conventions, role definitions
 - **Project/Repo Context**: Structural view of codebase, framework conventions, key entrypoints (retrieved on-demand via tools)
@@ -39,15 +38,17 @@ Per Factory's Droid documentation:
 3. **Role-aware prompts**: Each specialized agent has own context configuration
 4. **Guardrails by default**: Constraints in global and role layers enforced via prompt + tool policy
 
-## Disambiguation
+## Applicability
 
-**Note**: This is DIFFERENT from the "CASCADE" workflow used in gptme autonomous sessions, which refers to the task selection priority order: PRIMARY → SECONDARY → TERTIARY. That CASCADE is about task prioritization, not context management architecture.
+This pattern is valuable when:
+- Managing complex multi-step tasks with varying context needs
+- Building specialized agents with different context requirements
+- Implementing context-efficient systems that avoid token waste
 
 ## Source
-Factory AI's Droid product and public documentation on agentic context engineering.
+Pattern derived from Factory AI's Droid product and related agentic context engineering approaches. See also ACE (Agentic Context Engineering) for broader framework.
 
 ## Related
 - ACE (Agentic Context Engineering)
 - Context compression strategies
 - Memory hierarchy patterns
-- Multi-agent architectures


### PR DESCRIPTION
## Summary

Addresses #139 (Confusing lessons) by improving keyword precision and clarity in concept lessons.

## Changes

### hierarchical-context-management.md
- **Removed 'context cascading' keyword** - This could falsely trigger when discussing CASCADE workflow (task prioritization), causing confusion
- **Moved disambiguation note to top** - Now a visible callout rather than buried at bottom
- **Made keywords more specific** - Added 'Factory Droid context', 'multi-layer context', 'agentic context layers'
- **Softened claims** - Changed 'Per Factory's Droid documentation' to 'Common pattern in sophisticated agent systems' since we lack verified source links

### ace-agentic-context-engineering.md
- **Removed generic keywords** - 'framework', 'generator', 'reflector', 'curator' are too generic and would trigger falsely on common programming discussions
- **Made keywords more specific** - Now uses 'ACE context', 'ACE framework', 'agentic context engineering', 'living playbooks'
- **Added Applicability section** - Helps users understand when to apply these concepts

## Keyword Philosophy

I preserved the "FOUNDATIONAL KEYWORDS" pattern used in other lessons (e.g., python-invocation, browser-verification) where broad triggers are intentional for fundamental lessons. The concept lessons I fixed were different - they had keywords that would cause misleading cross-triggering between related but distinct concepts.

## Testing

- Keywords are now more specific and less likely to cause false positives
- Disambiguation is more prominent
- Claims are appropriately hedged given lack of primary sources
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves keyword precision and clarity in `hierarchical-context-management.md` and `ace-agentic-context-engineering.md` by refining keywords and reorganizing content.
> 
>   - **Keyword Changes**:
>     - `hierarchical-context-management.md`: Removed 'context cascading', added 'Factory Droid context', 'multi-layer context', 'agentic context layers'.
>     - `ace-agentic-context-engineering.md`: Removed 'framework', 'generator', 'reflector', 'curator', added 'ACE context', 'ACE framework', 'agentic context engineering', 'living playbooks'.
>   - **Content Reorganization**:
>     - `hierarchical-context-management.md`: Moved disambiguation note to top for visibility.
>     - `ace-agentic-context-engineering.md`: Added Applicability section to guide users on concept application.
>   - **Philosophy**:
>     - Maintained "FOUNDATIONAL KEYWORDS" pattern for fundamental lessons, adjusted concept lessons to prevent misleading cross-triggering.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for c9dae918d7c15fc70e3f1dff6a7f60d84448eb3c. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->