### PR TITLE
feat(dotfiles): add MCP server configuration template for Notion

### DIFF
--- a/lessons/tools/notion-mcp-integration.md
+++ b/lessons/tools/notion-mcp-integration.md
@@ -12,7 +12,7 @@ category: tools
 # Notion MCP Integration
 
 ## Rule
-Use mcp-cli with the Notion MCP server for reading and writing Notion content. Create `~/.config/mcp/mcp_servers.json` and set `NOTION_TOKEN`.
+Use mcp-cli with the Notion MCP server for reading and writing Notion content. Add the Notion server config to `~/.config/mcp/mcp_servers.json` and set `NOTION_TOKEN`.
 
 ## Context
 When needing to search, read, or write content in Notion workspaces.
@@ -66,10 +66,9 @@ For each page/database you want to access:
 
 ## MCP Server Configuration
 
-Create `~/.config/mcp/mcp_servers.json`:
-```bash
-mkdir -p ~/.config/mcp
-cat > ~/.config/mcp/mcp_servers.json << 'EOF'
+Add the Notion server to your `~/.config/mcp/mcp_servers.json`:
+
+```json
 {
   "mcpServers": {
     "notion": {
@@ -81,8 +80,9 @@ cat > ~/.config/mcp/mcp_servers.json << 'EOF'
     }
   }
 }
-EOF
 ```
+
+**Note**: If you already have other MCP servers configured, add the `"notion": {...}` entry to your existing `mcpServers` object rather than replacing the entire file.
 
 The `${NOTION_TOKEN}` is expanded by mcp-cli from your environment.
 


### PR DESCRIPTION
## Summary

Adds Notion MCP integration lesson to help agents use Notion via mcp-cli.

## Changes

### Notion MCP Integration Lesson (`lessons/tools/notion-mcp-integration.md`)
- Setup guide (internal vs public integrations)
- Prerequisites (npx, mcp-cli, token)
- **Manual config creation** - agents create their own `~/.config/mcp/mcp_servers.json`
- Permission gotchas (new pages not auto-included)
- Database write limitations
- Usage examples

## Agent Setup (from lesson)

```bash
# 1. Create config
mkdir -p ~/.config/mcp
cat > ~/.config/mcp/mcp_servers.json <<'EOF'
{
  "mcpServers": {
    "notion": {
      "command": "npx",
      "args": ["-y", "@notionhq/notion-mcp-server"],
      "env": {
        "NOTION_TOKEN": "${NOTION_TOKEN}"
      }
    }
  }
}
EOF

# 2. Set token
export NOTION_TOKEN=ntn_xxx

# 3. Use mcp-cli
mcp-cli notion/API-post-search '{"query": "..."}'
```

## Relation to Coop's Lesson

- **mcp-cli lesson (PR #157)**: General mcp-cli usage patterns
- **This PR**: Notion-specific setup and usage