### PR TITLE
docs(lessons): enhance mcp-cli lesson with official SKILL.md content

### DIFF
--- a/lessons/tools/mcp-cli-token-efficiency.md
+++ b/lessons/tools/mcp-cli-token-efficiency.md
@@ -43,12 +43,11 @@ Reactive signals (if you notice these, start using mcp-cli):
 
 ### Installation
 ```bash
-# Quick install
+# Download pre-built binary (no dependencies required)
 curl -fsSL https://raw.githubusercontent.com/philschmid/mcp-cli/main/install.sh | bash
-
-# Or via bun
-bun install -g https://github.com/philschmid/mcp-cli
 ```
+
+Installs to `~/.local/bin/mcp-cli`. Supports Linux (x64/arm64) and macOS (x64/arm64).
 
 ### Configuration
 Create `mcp_servers.json` in current directory or `~/.config/mcp/`:


### PR DESCRIPTION
## Summary

Enhances the mcp-cli lesson (#157) with content from the [official mcp-cli SKILL.md](https://github.com/philschmid/mcp-cli/blob/main/SKILL.md).

## Additions

### Quick Reference Table
Added at the top for fast lookup:
| Command | Output |
|---------|--------|
| `mcp-cli` | List all servers and tool names |
| `mcp-cli <server>` | Show tools with parameters |
| `mcp-cli <server>/<tool>` | Get tool JSON schema |
| `mcp-cli <server>/<tool> '<json>'` | Call tool with arguments |
| `mcp-cli grep "<glob>"` | Search tools by name |

### Stdin Input for Complex JSON
Documents the `-` pattern for JSON with quotes:
```bash
mcp-cli server/tool - <<EOF
{"content": "Text with 'quotes' inside"}
EOF
```

### Exit Codes
For script error handling:
- `0`: Success
- `1`: Client error
- `2`: Server error
- `3`: Network error

## What's Preserved

The original lesson's strengths:
- Token efficiency rationale (the "why")
- Installation instructions
- Configuration format
- Detection signals
- Anti-pattern comparison
- gptme-specific context
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances `mcp-cli` lesson with quick reference, stdin input for JSON, and exit codes, preserving original content strengths.
> 
>   - **Enhancements**:
>     - Adds a quick reference table for `mcp-cli` commands at the top of `mcp-cli-token-efficiency.md`.
>     - Documents stdin input for complex JSON using `-` pattern.
>     - Lists exit codes for script error handling: `0` for success, `1` for client error, `2` for server error, `3` for network error.
>   - **Preserved Content**:
>     - Retains original lesson's token efficiency rationale, installation instructions, configuration format, detection signals, anti-pattern comparison, and gptme-specific context.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for 6e47b372f670d8d2aa7e954d856140c3492ecb82. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->