### PR TITLE
fix(linear): add OAuth callback endpoint to webhook server

### DIFF
--- a/scripts/linear/linear-webhook-server.py
+++ b/scripts/linear/linear-webhook-server.py
@@ -14,6 +14,7 @@ Usage:
 
 import hashlib
 import hmac
+import html
 import json
 import os
 import subprocess
@@ -729,8 +730,8 @@ def oauth_callback():
         <head><title>Authorization Failed</title></head>
         <body style="font-family: sans-serif; padding: 40px; text-align: center;">
             <h1 style="color: #dc3545;">❌ Authorization Failed</h1>
-            <p>Error: {error}</p>
-            <p>{error_desc}</p>
+            <p>Error: {html.escape(error)}</p>
+            <p>{html.escape(error_desc)}</p>
             <p><a href="/">Back to home</a></p>
         </body>
         </html>
@@ -812,7 +813,7 @@ def oauth_callback():
             <body style="font-family: sans-serif; padding: 40px; text-align: center;">
                 <h1 style="color: #dc3545;">❌ Token Exchange Failed</h1>
                 <p>Status: {response.status_code}</p>
-                <p>Error: {response.text}</p>
+                <p>Error: {html.escape(response.text)}</p>
                 <p><a href="/">Back to home</a></p>
             </body>
             </html>
@@ -829,7 +830,7 @@ def oauth_callback():
             <head><title>Invalid Response</title></head>
             <body style="font-family: sans-serif; padding: 40px; text-align: center;">
                 <h1 style="color: #dc3545;">❌ Invalid Token Response</h1>
-                <p>Response: {data}</p>
+                <p>Response: {html.escape(str(data))}</p>
                 <p><a href="/">Back to home</a></p>
             </body>
             </html>
@@ -883,7 +884,7 @@ def oauth_callback():
         <head><title>Error</title></head>
         <body style="font-family: sans-serif; padding: 40px; text-align: center;">
             <h1 style="color: #dc3545;">❌ Error</h1>
-            <p>{type(e).__name__}: {e}</p>
+            <p>{html.escape(f"{type(e).__name__}: {e}")}</p>
             <p><a href="/">Back to home</a></p>
         </body>
         </html>


### PR DESCRIPTION
## Summary

Adds `/oauth/callback` route to `linear-webhook-server.py` that:
- Receives authorization code from Linear redirect
- Exchanges code for access/refresh tokens
- Saves tokens to `.tokens.json`
- Shows success/error HTML pages

This eliminates the manual URL copy-paste step during OAuth setup.

**Partially addresses #162** (OAuth callback endpoint - item 1 of 3)

## Changes

1. Added `LINEAR_OAUTH_TOKEN_URL` constant
2. Added `/oauth/callback` endpoint with:
   - Code extraction from query parameters
   - Token exchange with Linear OAuth API
   - Token persistence to `.tokens.json`
   - User-friendly success/error HTML pages
3. Updated index endpoint to list new route
4. Bumped version to 2.1.0

## Remaining items from #162

- [ ] Better error messages for missing environment variables (item 2)
- [ ] Documentation about ngrok URL changes (item 3)