### PR TITLE
docs(lessons): add fork-pr-secrets lesson for CI secret access

### DIFF
--- a/lessons/workflow/fork-pr-secrets.md
+++ b/lessons/workflow/fork-pr-secrets.md
@@ -1,0 +1,62 @@
+---
+match:
+  keywords:
+    - "CI secret not available"
+    - "fork PR failing CI"
+    - "secret not accessible via fork"
+    - "push directly to repo"
+    - "ANTHROPIC_API_KEY not set"
+    - "permission denied pushing to org repo"
+---
+
+# Fork PR Secrets Access
+
+## Rule
+Secrets are not available to PRs from forks; push directly to the repo if you have member access.
+
+## Context
+When CI fails on a PR due to missing secrets, and you're a member of the organization.
+
+## Detection
+Observable signals:
+- CI fails with "secret is empty" or "API key not found" errors
+- You created PR from a fork (your-username/repo → org/repo)
+- CI succeeds on master but fails on your PR with same code
+- Error messages like "No API key found, couldn't auto-detect provider"
+- You have org membership but PR still can't access secrets
+
+## Pattern
+Check access and push directly:
+```shell
+# Check your permissions on the repo
+gh api repos/ORG/REPO --jq '.permissions'
+# If push: true → you can push directly
+
+# Option 1: Push directly to the org repo
+git remote add upstream git@github.com:ORG/REPO.git
+git push upstream your-branch:your-branch
+
+# Option 2: For existing fork-based PR with no push access
+# Have maintainer cherry-pick your commits to a direct branch
+# Or request push access
+```
+
+**Why this happens**:
+- GitHub prevents fork PRs from accessing repository secrets (security)
+- This protects secrets from malicious PRs that could exfiltrate them
+- Org members with push access should push directly instead
+
+**If you don't have push access**:
+- Request access from maintainers
+- Have maintainer cherry-pick your commits to a direct branch
+- CI tests requiring secrets may need to be skipped for fork PRs
+
+## Outcome
+Following this pattern results in:
+- CI can access secrets (ANTHROPIC_API_KEY, etc.)
+- Full CI test suite passes
+- No security exposure (direct branches are from trusted contributors)
+
+## Related
+- [Git Workflow](./git-workflow.md) - Branch management
+- [Git Worktree Workflow](./git-worktree-workflow.md) - Working with external repos


### PR DESCRIPTION
## Summary

Adds a lesson documenting the common issue where CI fails on fork-based PRs due to inaccessible secrets.

## Motivation

When contributing to org repos via forks, CI often fails because GitHub doesn't expose repository secrets to fork PRs (for security). This lesson documents:

- Why this happens (security protection)
- How to detect it (secret-related CI errors)
- What to do (push directly if you have access, or request access)

## Origin

Discovered while working on gptme-webui PR #108, where CI couldn't access `ANTHROPIC_API_KEY`. Erik suggested creating this lesson.

## Related

- gptme/gptme-webui#108 - Original issue that prompted this lesson
- GitHub docs on [fork PR secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds documentation on handling CI failures for fork-based PRs due to inaccessible secrets in `lessons/workflow/fork-pr-secrets.md`.
> 
>   - **Documentation**:
>     - Adds `fork-pr-secrets.md` to `lessons/workflow/` documenting CI failures on fork-based PRs due to inaccessible secrets.
>     - Explains why secrets are not available to fork PRs (security reasons) and how to detect related CI errors.
>     - Provides solutions: push directly if you have access, or request access/cherry-pick commits if not.
>   - **Context**:
>     - Originated from issue in gptme-webui PR #108 where `ANTHROPIC_API_KEY` was inaccessible.
>     - Related to GitHub's security measures for fork PRs.
>   - **Related Links**:
>     - References GitHub documentation on fork PR secrets and related internal documentation on git workflows.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for b86178839c2fa0929021671c1b1c0eeea99a7ef5. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->