### PR TITLE
docs: update references from deprecated tasks.py to gptodo

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ See [scripts/github/README.md](scripts/github/README.md) for detailed documentat
 
 ### Other
 
-- **tasks.py** - Task management utilities
+- **gptodo** - Task management utilities
 - **wordcount.py** - Word counting utilities
 - **perplexity.py** - Perplexity API integration
 

--- a/lessons/autonomous/autonomous-session-structure.md
+++ b/lessons/autonomous/autonomous-session-structure.md
@@ -31,7 +31,7 @@ Observable signals that structured approach is needed:
 - Spending too much time on setup vs. actual progress
 - Treating "waiting for response" as "blocked" (they're different!)
 - Claiming "all blocked" when TERTIARY work exists
-- Not using `tasks.py ready` to find available work
+- Not using `gptodo ready` to find available work
 
 ## Pattern
 
@@ -86,10 +86,10 @@ gh api notifications --jq '.[] | {reason, subject: .subject.title}'
 **TERTIARY**: Check workspace tasks for ready work
 ```shell
 # Find tasks ready for work (no unmet dependencies)
-./scripts/tasks.py ready --json | jq '.ready_tasks[:3]'
+gptodo ready --json | jq '.ready_tasks[:3]'
 
 # Or use compact status view
-./scripts/tasks.py status --compact
+gptodo status --compact
 ```
 
 **CRITICAL - Waiting vs Blocked**:
@@ -131,7 +131,7 @@ cat state/queue-manual.md || echo "No work queue - continue to SECONDARY"
 ```
 
 **Format guidance**:
-- **Avoid state fields** like "OPEN/CLOSED" - they get outdated; use `tasks.py sync` to check external state
+- **Avoid state fields** like "OPEN/CLOSED" - they get outdated; use `gptodo sync` to check external state
 - **Rich in links** - issue URLs, PR links, documentation references
 - **Actionable next steps** - not "work on X" but "implement the foo function in bar.py"
 - **Evict completed items** - remove priorities after completion to keep queue focused
@@ -140,10 +140,10 @@ cat state/queue-manual.md || echo "No work queue - continue to SECONDARY"
 
 *Git policy*: **Commit the queue** - provides audit trail of agent planning and enables coordination across sessions/agents. Queue changes should be committed with journal entries to track planning evolution.
 
-*Useful tasks.py commands*:
-- `tasks.py sync --json` - Compare task/issue states, find out-of-sync items
-- `tasks.py stale --days 30` - Surface neglected tasks for review
-- `tasks.py plan <task>` - Show task impact analysis before starting work
+*Useful gptodo commands*:
+- `gptodo sync --json` - Compare task/issue states, find out-of-sync items
+- `gptodo stale --days 30` - Surface neglected tasks for review
+- `gptodo plan <task>` - Show task impact analysis before starting work
 
 **Selection Rule**: Check all three sources. First unblocked work found gets executed.
 
@@ -154,9 +154,9 @@ cat state/queue-manual.md || echo "No work queue - continue to SECONDARY"
 4. Response will surface later via notifications
 
 ```shell
-# When task is waiting (not blocked), update metadata using tasks.py:
-./scripts/tasks.py edit <task-name> --set waiting_for "Response on PR #123"
-./scripts/tasks.py edit <task-name> --set waiting_since 2025-01-10
+# When task is waiting (not blocked), update metadata using gptodo:
+gptodo edit <task-name> --set waiting_for "Response on PR #123"
+gptodo edit <task-name> --set waiting_since 2025-01-10
 # Then proceed to next ready work
 ```
 
@@ -249,8 +249,8 @@ git push origin master
 
 **Phase 2** (4 min):
 - `gh issue list --assignee @me` → found GitHub issue from collaborator (SECONDARY)
-- `./scripts/tasks.py ready --json` → 4 ready tasks, highest priority: agent-hosting-patterns
-- `./scripts/tasks.py next --json` → recommends agent-hosting-patterns with reasoning
+- `gptodo ready --json` → 4 ready tasks, highest priority: agent-hosting-patterns
+- `gptodo next --json` → recommends agent-hosting-patterns with reasoning
 - Decision: Work on GitHub issue (SECONDARY takes priority over TERTIARY)
 
 **Phase 3** (22 min):

--- a/lessons/autonomous/effective-autonomous-work-execution.md
+++ b/lessons/autonomous/effective-autonomous-work-execution.md
@@ -45,7 +45,7 @@ cat journal/most-recent-entry.md
 ### Phase 2: Task Selection (3-5 min)
 ```shell
 # Check task status and priorities
-./scripts/tasks.py status --compact
+gptodo status --compact
 
 # Check for GitHub notifications/issues
 gh issue list --assignee @me

--- a/lessons/tools/linear-api-integration.md
+++ b/lessons/tools/linear-api-integration.md
@@ -149,5 +149,5 @@ Following this pattern enables:
 - State filtering for issues
 
 ## Related
-- [gptme-contrib tasks.py import command](https://github.com/gptme/gptme-contrib) - Uses this pattern
+- [gptme-contrib gptodo import command](https://github.com/gptme/gptme-contrib) - Uses this pattern
 - [Linear GraphQL API docs](https://developers.linear.app/docs/graphql/working-with-the-graphql-api)

--- a/lessons/workflow/pre-issue-creation-checklist.md
+++ b/lessons/workflow/pre-issue-creation-checklist.md
@@ -43,7 +43,7 @@ ls -la journal/ | tail -5
 grep -r "issue\|create\|TODO" journal/ | tail -10
 
 # Check active tasks for overlap
-./scripts/tasks.py status --compact
+gptodo status --compact
 ```
 
 ### 4. Verify Necessity

--- a/lessons/workflow/session-startup-recent-actions-review.md
+++ b/lessons/workflow/session-startup-recent-actions-review.md
@@ -46,7 +46,7 @@ ls -1 journal/ | tail -3 | xargs -I {} sh -c 'echo "=== {} ==="; head -10 journa
 
 # 4. Active Task Context
 echo -e "\nActive tasks review:"
-./scripts/tasks.py status --compact
+gptodo status --compact
 
 echo "=== END RECENT ACTIONS REVIEW ==="
 ```


### PR DESCRIPTION
Updates documentation references from `scripts/tasks.py` (deprecated) to `gptodo` (the new standalone package).

## Changes

- Updated lesson files that referenced `tasks.py` to use `gptodo`
- Updated README.md package list
- Follows PR #171 which renamed the package to gptodo

## Files Changed

- README.md
- lessons/autonomous/autonomous-session-structure.md
- lessons/autonomous/effective-autonomous-work-execution.md
- lessons/tools/linear-api-integration.md
- lessons/workflow/pre-issue-creation-checklist.md
- lessons/workflow/session-startup-recent-actions-review.md

The `packages/gptodo/README.md` migration notes were intentionally left unchanged as they explain the migration path.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update documentation to replace references from deprecated `tasks.py` to `gptodo` in README and lesson files.
> 
>   - **Documentation Updates**:
>     - Replace `tasks.py` with `gptodo` in `README.md` and five lesson files.
>     - Affected lesson files: `autonomous-session-structure.md`, `effective-autonomous-work-execution.md`, and `linear-api-integration.md`.
>   - **Context**:
>     - Follows up on PR #171 which renamed the package to `gptodo`.
>     - `packages/gptodo/README.md` remains unchanged to preserve migration notes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for 8419c56c024bdaac0452d7fd99ed280197ed6dd0. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->