### PR TITLE
chore: exclude stale packages/tasks from workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ venv/
 
 # Task lock files (runtime state)
 state/locks/
+
+# Stale directory from tasks->gptodo rename (PR #171)
+packages/tasks/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,4 +13,4 @@ dev = [
 
 [tool.uv.workspace]
 members = ["packages/*", "plugins/*"]
-exclude = ["packages/__pycache__", "plugins/__pycache__"]
+exclude = ["packages/__pycache__", "plugins/__pycache__", "packages/tasks"]


### PR DESCRIPTION
## Summary

After PR #171 renamed `tasks` → `gptodo`, some local checkouts retain the `packages/tasks/` directory with cache artifacts. This causes confusion and potential uv workspace errors.

## Changes

- Add `packages/tasks/` to `.gitignore` to prevent tracking
- Add `packages/tasks` to uv workspace exclude list in `pyproject.toml`

Fixes #175

---

*Automated by Bob*
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Exclude `packages/tasks` from tracking and uv workspace to prevent errors from stale directories.
> 
>   - **Configuration**:
>     - Add `packages/tasks/` to `.gitignore` to prevent tracking stale directories.
>     - Update `pyproject.toml` to exclude `packages/tasks` from the uv workspace.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for c49693eaad87de6c98335446a27b218f83e6d6d3. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->