### PR TITLE
fix(ralph): enable tool execution in Claude backend

### DIFF
--- a/plugins/gptme-ralph/src/gptme_ralph/tools/ralph_loop.py
+++ b/plugins/gptme-ralph/src/gptme_ralph/tools/ralph_loop.py
@@ -461,7 +461,8 @@ for i in $(seq 1 $MAX_ITER); do
 
     # Run the agent with spec + plan as context
     if [ "$BACKEND" = "claude" ]; then
-        timeout $TIMEOUT claude -p "$(cat $SPEC_FILE)\\n\\n$(cat $PLAN_FILE)\\n\\nComplete the next unchecked step, then mark it done in the plan file."
+        # Use --dangerously-skip-permissions and --tools default for non-interactive execution
+        timeout $TIMEOUT claude -p --dangerously-skip-permissions --tools default "$(cat $SPEC_FILE)\\n\\n$(cat $PLAN_FILE)\\n\\nComplete the next unchecked step, then mark it done in the plan file."
     else
         timeout $TIMEOUT gptme -n "$(cat $SPEC_FILE)\\n\\n$(cat $PLAN_FILE)\\n\\nComplete the next unchecked step, then mark it done in the plan file."
     fi


### PR DESCRIPTION
## Problem

The Claude backend was using `-p` (print mode) without enabling tools, causing it to only output text descriptions instead of actually executing code and creating files.

When running:
```python
run_loop('spec.md', 'plan.md', backend='claude')
```

The output would be text like 'I've created calculator.py...' but no files were actually created.

## Solution

Add the necessary flags for tool execution in print mode:
- `--tools default`: Enable all built-in tools in print mode
- `--dangerously-skip-permissions`: Allow non-interactive execution without permission prompts

## Testing

Verified that `claude --help` shows:
- `--tools` only works with `--print` mode
- `--dangerously-skip-permissions` bypasses permission checks for sandboxed execution

## Related

Fixes #187
Related to: ErikBjare/bob#254 (Ralph Loop plugin)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enable tool execution in Claude backend by adding necessary flags for non-interactive operation in `ralph_loop.py`.
> 
>   - **Behavior**:
>     - Adds `--tools default` and `--dangerously-skip-permissions` flags to Claude command in `_run_iteration()` and `_run_background_loop()` to enable tool execution in print mode.
>     - Ensures non-interactive execution by bypassing permission prompts.
>   - **Prompt Instructions**:
>     - Updates instructions in `_build_prompt()` to emphasize updating plan file checkboxes for step completion.
>   - **Misc**:
>     - Fixes #187 related to tool execution in Claude backend.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for 09a7eb2e012f40994cd2163e3f4b265737969659. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->