### PR TITLE
ci: add gptme-ralph to plugin test workflow

### DIFF
--- a/.github/workflows/test-plugins.yml
+++ b/.github/workflows/test-plugins.yml
@@ -30,11 +30,13 @@ jobs:
           pip install -e plugins/gptme-imagen
           pip install -e plugins/gptme-consortium
           pip install -e plugins/gptme-attention-tracker
+          pip install -e plugins/gptme-ralph
 
       - name: Run unit tests
         run: |
           pytest plugins/gptme-consortium/tests/test_consortium.py -v -m "not slow" --timeout=30
           pytest plugins/gptme-imagen/tests/test_image_gen_phase1.py -v -m "not slow" --timeout=30
+          pytest plugins/gptme-ralph/tests/ -v -m "not slow" --timeout=30
 
       - name: Run integration tests (with API keys)
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
@@ -50,6 +52,7 @@ jobs:
         run: |
           pytest plugins/gptme-consortium/tests/test_consortium.py -v -m "not slow" --cov=plugins/gptme-consortium --cov-report=xml --cov-report=term
           pytest plugins/gptme-imagen/tests/test_image_gen_phase1.py -v -m "not slow" --cov=plugins/gptme-imagen --cov-append --cov-report=xml --cov-report=term
+          pytest plugins/gptme-ralph/tests/ -v -m "not slow" --cov=plugins/gptme-ralph --cov-append --cov-report=xml --cov-report=term
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4


### PR DESCRIPTION
## Summary

Add gptme-ralph plugin tests to CI to catch test failures before merge.

## Problem

During PR #195 review, Erik identified that Ralph Loop tests weren't running in CI. The workflow only tested a hardcoded subset of plugins:
- gptme-consortium
- gptme-imagen  
- gptme-attention-tracker

This meant we could merge PRs with broken tests because CI never ran them.

## Solution

Add gptme-ralph to the CI workflow:
- Install the plugin dependencies
- Run unit tests with the same configuration as other plugins
- Include in coverage reporting

## Testing

The existing Ralph Loop tests at `plugins/gptme-ralph/tests/` will now run as part of the CI pipeline.

## Related

- Fixes #196
- PR #195 discussion: https://github.com/gptme/gptme-contrib/pull/195#issuecomment-3797984953

cc @ErikBjare