### PR TITLE
fix: remove symlinks that caused duplicate workspace members

### DIFF
--- a/packages/lessons
+++ b/packages/lessons
@@ -1,1 +1,0 @@
-gptme-lessons-extras

--- a/packages/lib
+++ b/packages/lib
@@ -1,1 +1,0 @@
-gptme-contrib-lib

--- a/packages/run_loops
+++ b/packages/run_loops
@@ -1,1 +1,0 @@
-gptme-runloops


### PR DESCRIPTION
## Summary
Removes symlinks that were added in 9912d56, which caused CI failures.

## Problem
The symlinks from old package locations to new ones created duplicate workspace members:
- `packages/lessons` → `packages/gptme-lessons-extras` 
- `packages/lib` → `packages/gptme-contrib-lib`
- `packages/run_loops` → `packages/gptme-runloops`

Both the symlink and the target directory have `pyproject.toml` files with the same package name, causing uv to detect duplicates:
```
error: Two workspace members are both named `gptme-lessons-extras`
```

## Solution
Remove the symlinks. Backward compatibility can be handled differently if needed (e.g., documenting migration path or updating import paths in dependent projects).

## CI Status
This fixes the currently broken CI on master.