### PR TITLE
feat(ralph): change default backend from claude to gptme

### DIFF
--- a/plugins/gptme-ralph/README.md
+++ b/plugins/gptme-ralph/README.md
@@ -92,7 +92,7 @@ Run a Ralph Loop with the given spec and plan.
 - `spec_file`: Path to the specification/PRD file
 - `plan_file`: Path to the implementation plan (markdown with checkboxes)
 - `workspace`: Working directory (default: current)
-- `backend`: "claude" or "gptme" (default: "claude")
+- `backend`: "claude" or "gptme" (default: "gptme")
 - `max_iterations`: Maximum loop iterations (default: 50)
 - `step_timeout`: Timeout per step in seconds (default: 600)
 - `background`: Run in tmux session (default: False)

--- a/plugins/gptme-ralph/src/gptme_ralph/tools/ralph_loop.py
+++ b/plugins/gptme-ralph/src/gptme_ralph/tools/ralph_loop.py
@@ -259,7 +259,7 @@ def run_loop(
     spec_file: str,
     plan_file: str,
     workspace: str | None = None,
-    backend: str = "claude",
+    backend: str = "gptme",
     max_iterations: int = 50,
     step_timeout: int = 600,
     background: bool = False,


### PR DESCRIPTION
## Summary

Changes the default backend for Ralph Loop from `claude` to `gptme`.

## Motivation

Based on testing in ErikBjare/bob#260, both backends now work well:
- **gptme backend**: 10/10 steps, 167.6s ✅
- **claude backend**: 10/10 steps, 411.2s ✅

The gptme backend:
- Works out of the box for gptme-contrib users
- No external dependency on Claude Code CLI
- Faster execution (2.5x in tests)
- Aligns with Erik's direction in #254

## Changes

- `ralph_loop.py`: Change default `backend='claude'` → `backend='gptme'`
- `README.md`: Update documentation to reflect new default

## Related

- Closes #190
- Related: ErikBjare/bob#260 (experiment results)
- Related: ErikBjare/bob#254 (original direction)