### PR TITLE
feat(runs): add launchd support for macOS agents

### DIFF
--- a/scripts/runs/launchd/autonomous-run.sh
+++ b/scripts/runs/launchd/autonomous-run.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Autonomous run script for launchd
+#
+# This script runs a single autonomous session using the run_loops CLI.
+# Customize WORKSPACE to point to your agent workspace.
+#
+# Usage: ./autonomous-run.sh [--workspace PATH]
+
+set -e
+
+# Load user environment (for PATH, API keys, etc.)
+# shellcheck source=/dev/null
+[ -f ~/.profile ] && source ~/.profile
+# shellcheck source=/dev/null
+[ -f ~/.bash_profile ] && source ~/.bash_profile
+# shellcheck source=/dev/null
+[ -f ~/.zshrc ] && source ~/.zshrc 2>/dev/null
+
+# Configuration - UPDATE THIS for your setup
+WORKSPACE="${WORKSPACE:-$HOME/gptme-agent}"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --workspace)
+            WORKSPACE="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# Validate workspace
+if [ ! -d "$WORKSPACE" ]; then
+    echo "Error: Workspace not found: $WORKSPACE"
+    echo "Set WORKSPACE environment variable or use --workspace PATH"
+    exit 1
+fi
+
+cd "$WORKSPACE"
+
+# Run autonomous session
+# Option 1: If run_loops is installed via uv (recommended)
+if command -v uv &>/dev/null; then
+    exec uv run python3 -m run_loops.cli autonomous --workspace "$WORKSPACE"
+# Option 2: If run_loops is installed in system Python
+elif python3 -c "import run_loops" &>/dev/null; then
+    exec python3 -m run_loops.cli autonomous --workspace "$WORKSPACE"
+else
+    echo "Error: run_loops package not found"
+    echo "Install with: uv add gptme-runloops"
+    exit 1
+fi

--- a/scripts/runs/launchd/com.gptme.agent-autonomous.plist
+++ b/scripts/runs/launchd/com.gptme.agent-autonomous.plist
@@ -9,20 +9,17 @@
     <array>
         <string>/bin/bash</string>
         <string>-c</string>
-        <!-- Update this path to your agent workspace -->
-        <string>cd $HOME/gptme-agent && ./scripts/runs/autonomous/autonomous-run.sh</string>
+        <!-- The setup script will replace AGENT_WORKSPACE with actual path -->
+        <string>cd AGENT_WORKSPACE && ./scripts/runs/launchd/autonomous-run.sh --workspace AGENT_WORKSPACE 2>&1 | head -10000</string>
     </array>
 
-    <!-- Working directory (update to your workspace) -->
+    <!-- Working directory (setup script replaces AGENT_WORKSPACE) -->
     <key>WorkingDirectory</key>
-    <string>/Users/YOUR_USERNAME/gptme-agent</string>
+    <string>AGENT_WORKSPACE</string>
 
-    <!-- Schedule: Weekdays hourly 6am-8pm, weekends every 2 hours -->
-    <!-- Note: launchd doesn't support day-of-week filtering, so we run hourly -->
-    <!-- The autonomous script should handle scheduling logic if needed -->
+    <!-- Schedule: Every hour at minute 0 during typical working hours (6am-8pm) -->
     <key>StartCalendarInterval</key>
     <array>
-        <!-- Every hour at minute 0 during typical working hours -->
         <dict><key>Hour</key><integer>6</integer><key>Minute</key><integer>0</integer></dict>
         <dict><key>Hour</key><integer>7</integer><key>Minute</key><integer>0</integer></dict>
         <dict><key>Hour</key><integer>8</integer><key>Minute</key><integer>0</integer></dict>
@@ -40,56 +37,36 @@
         <dict><key>Hour</key><integer>20</integer><key>Minute</key><integer>0</integer></dict>
     </array>
 
-    <!-- Timeout: 1 hour (matches systemd TimeoutSec=3600) -->
+    <!-- Timeout: 1 hour -->
     <key>TimeoutSeconds</key>
     <integer>3600</integer>
 
-    <!-- Logging configuration -->
+    <!-- Logging configuration (setup script replaces USER_HOME) -->
     <key>StandardOutPath</key>
-    <string>/Users/YOUR_USERNAME/Library/Logs/gptme-agent/autonomous.log</string>
+    <string>USER_HOME/Library/Logs/gptme-agent/autonomous.log</string>
     <key>StandardErrorPath</key>
-    <string>/Users/YOUR_USERNAME/Library/Logs/gptme-agent/autonomous.error.log</string>
+    <string>USER_HOME/Library/Logs/gptme-agent/autonomous.error.log</string>
 
-    <!-- Environment variables (customize as needed) -->
+    <!-- Environment variables -->
     <key>EnvironmentVariables</key>
     <dict>
         <!-- Ensure PATH includes common tool locations -->
         <key>PATH</key>
         <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
-        <!-- Uncomment and set your API keys, or source from .env file in script -->
-        <!--
-        <key>ANTHROPIC_API_KEY</key>
-        <string>sk-ant-...</string>
-        <key>OPENAI_API_KEY</key>
-        <string>sk-...</string>
-        -->
+        <!-- API keys can be set here or in shell profile -->
+        <!-- The script sources ~/.profile, ~/.bash_profile, ~/.zshrc -->
     </dict>
 
-    <!-- Run at load (useful for immediate testing) -->
+    <!-- Don't run at load -->
     <key>RunAtLoad</key>
     <false/>
 
-    <!-- Keep alive settings -->
-    <!-- Set to false for scheduled oneshot jobs -->
+    <!-- Oneshot job, don't keep alive -->
     <key>KeepAlive</key>
     <false/>
 
-    <!-- Nice value (lower priority) -->
+    <!-- Lower priority -->
     <key>Nice</key>
     <integer>10</integer>
-
-    <!-- Resource limits (optional, uncomment if needed) -->
-    <!--
-    <key>SoftResourceLimits</key>
-    <dict>
-        <key>NumberOfFiles</key>
-        <integer>1024</integer>
-    </dict>
-    <key>HardResourceLimits</key>
-    <dict>
-        <key>NumberOfFiles</key>
-        <integer>2048</integer>
-    </dict>
-    -->
 </dict>
 </plist>

--- a/scripts/runs/launchd/com.gptme.agent-project-monitoring.plist
+++ b/scripts/runs/launchd/com.gptme.agent-project-monitoring.plist
@@ -9,38 +9,34 @@
     <array>
         <string>/bin/bash</string>
         <string>-c</string>
-        <!-- Update this path to your agent workspace -->
-        <string>cd $HOME/gptme-agent && ./scripts/runs/autonomous/project-monitoring.sh 2>&1 | head -1000</string>
+        <!-- The setup script will replace AGENT_WORKSPACE with actual path -->
+        <string>cd AGENT_WORKSPACE && ./scripts/runs/launchd/project-monitoring.sh --workspace AGENT_WORKSPACE 2>&1 | head -5000</string>
     </array>
 
-    <!-- Working directory (update to your workspace) -->
+    <!-- Working directory (setup script replaces AGENT_WORKSPACE) -->
     <key>WorkingDirectory</key>
-    <string>/Users/YOUR_USERNAME/gptme-agent</string>
+    <string>AGENT_WORKSPACE</string>
 
     <!-- Schedule: Every 5 minutes -->
     <key>StartInterval</key>
     <integer>300</integer>
 
-    <!-- Timeout: 30 minutes for project monitoring -->
+    <!-- Timeout: 30 minutes -->
     <key>TimeoutSeconds</key>
     <integer>1800</integer>
 
-    <!-- Logging configuration -->
+    <!-- Logging configuration (setup script replaces USER_HOME) -->
     <key>StandardOutPath</key>
-    <string>/Users/YOUR_USERNAME/Library/Logs/gptme-agent/project-monitoring.log</string>
+    <string>USER_HOME/Library/Logs/gptme-agent/project-monitoring.log</string>
     <key>StandardErrorPath</key>
-    <string>/Users/YOUR_USERNAME/Library/Logs/gptme-agent/project-monitoring.error.log</string>
+    <string>USER_HOME/Library/Logs/gptme-agent/project-monitoring.error.log</string>
 
     <!-- Environment variables -->
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
         <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
-        <!-- GitHub CLI needs auth token -->
-        <!--
-        <key>GITHUB_TOKEN</key>
-        <string>ghp_...</string>
-        -->
+        <!-- GitHub CLI needs auth - can set GITHUB_TOKEN here or use gh auth -->
     </dict>
 
     <!-- Don't run at load -->

--- a/scripts/runs/launchd/project-monitoring.sh
+++ b/scripts/runs/launchd/project-monitoring.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Project monitoring script for launchd
+#
+# This script runs project monitoring (GitHub notifications, PR updates, etc.)
+# using the run_loops CLI. Customize WORKSPACE to point to your agent workspace.
+#
+# Usage: ./project-monitoring.sh [--workspace PATH]
+
+set -e
+
+# Load user environment (for PATH, API keys, etc.)
+# shellcheck source=/dev/null
+[ -f ~/.profile ] && source ~/.profile
+# shellcheck source=/dev/null
+[ -f ~/.bash_profile ] && source ~/.bash_profile
+# shellcheck source=/dev/null
+[ -f ~/.zshrc ] && source ~/.zshrc 2>/dev/null
+
+# Configuration - UPDATE THIS for your setup
+WORKSPACE="${WORKSPACE:-$HOME/gptme-agent}"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --workspace)
+            WORKSPACE="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# Validate workspace
+if [ ! -d "$WORKSPACE" ]; then
+    echo "Error: Workspace not found: $WORKSPACE"
+    echo "Set WORKSPACE environment variable or use --workspace PATH"
+    exit 1
+fi
+
+cd "$WORKSPACE"
+
+# Run project monitoring
+# Option 1: If run_loops is installed via uv (recommended)
+if command -v uv &>/dev/null; then
+    exec uv run python3 -m run_loops.cli monitoring --workspace "$WORKSPACE"
+# Option 2: If run_loops is installed in system Python
+elif python3 -c "import run_loops" &>/dev/null; then
+    exec python3 -m run_loops.cli monitoring --workspace "$WORKSPACE"
+else
+    echo "Error: run_loops package not found"
+    echo "Install with: uv add gptme-runloops"
+    exit 1
+fi

--- a/scripts/runs/launchd/setup-launchd.sh
+++ b/scripts/runs/launchd/setup-launchd.sh
@@ -36,12 +36,37 @@ if [[ ! -d "$AGENT_WORKSPACE" ]]; then
     exit 1
 fi
 
+# Check for run_loops availability
+if command -v uv &>/dev/null; then
+    echo -e "${YELLOW}Checking run_loops package...${NC}"
+    if ! (cd "$AGENT_WORKSPACE" && uv run python3 -c "import run_loops" 2>/dev/null); then
+        echo -e "${YELLOW}Warning: run_loops package not found in workspace.${NC}"
+        echo "  Install with: cd $AGENT_WORKSPACE && uv add gptme-runloops"
+        echo ""
+    else
+        echo -e "  ${GREEN}✓ run_loops package found${NC}"
+    fi
+fi
+
 # Create directories
 echo -e "${YELLOW}Creating directories...${NC}"
 mkdir -p "$LAUNCHD_DIR"
 mkdir -p "$LOG_DIR"
 echo "  Created: $LAUNCHD_DIR"
 echo "  Created: $LOG_DIR"
+
+# Copy scripts to workspace if not already there
+echo -e "${YELLOW}Copying run scripts to workspace...${NC}"
+SCRIPTS_DEST="$AGENT_WORKSPACE/scripts/runs/launchd"
+mkdir -p "$SCRIPTS_DEST"
+
+for script in autonomous-run.sh project-monitoring.sh; do
+    if [[ -f "$SCRIPT_DIR/$script" ]]; then
+        cp "$SCRIPT_DIR/$script" "$SCRIPTS_DEST/"
+        chmod +x "$SCRIPTS_DEST/$script"
+        echo "  Copied: $script"
+    fi
+done
 
 # Function to install plist
 install_plist() {
@@ -51,9 +76,10 @@ install_plist() {
 
     echo -e "${YELLOW}Installing: $(basename "$template")${NC}"
 
-    # Copy and customize plist
-    sed -e "s|/Users/YOUR_USERNAME|$HOME|g" \
-        -e "s|\$HOME/gptme-agent|$AGENT_WORKSPACE|g" \
+    # Copy and customize plist with all placeholders
+    sed -e "s|AGENT_WORKSPACE|$AGENT_WORKSPACE|g" \
+        -e "s|USER_HOME|$HOME|g" \
+        -e "s|/Users/YOUR_USERNAME|$HOME|g" \
         "$template" > "$target"
 
     echo "  Installed: $target"
@@ -71,8 +97,9 @@ echo -e "${GREEN}Installation complete!${NC}"
 echo ""
 echo "Next steps:"
 echo ""
-echo "1. Edit API keys in the plist files (or ensure they're in your .env file):"
-echo "   open $LAUNCHD_DIR"
+echo "1. Ensure API keys are available (in shell profile or plist):"
+echo "   export ANTHROPIC_API_KEY='sk-ant-...'"
+echo "   export OPENAI_API_KEY='sk-...'"
 echo ""
 echo "2. Load the agents:"
 echo "   launchctl load ~/Library/LaunchAgents/com.gptme.agent-autonomous.plist"


### PR DESCRIPTION
## Summary

Add launchd plist templates as alternative to systemd for macOS systems.

## Changes

- **README.md**: Documentation with systemd-to-launchd conversion guide
- **com.gptme.agent-autonomous.plist**: Main autonomous run template (hourly 6am-8pm)
- **com.gptme.agent-project-monitoring.plist**: Project monitoring template (every 5 min)
- **setup-launchd.sh**: Automated setup script for easy installation

## Quick Start

```bash
# Install launchd jobs
./scripts/runs/launchd/setup-launchd.sh ~/my-agent

# Load agents
launchctl load ~/Library/LaunchAgents/com.gptme.agent-autonomous.plist
launchctl load ~/Library/LaunchAgents/com.gptme.agent-project-monitoring.plist

# Check status
launchctl list | grep gptme
```

## systemd vs launchd

| systemd | launchd |
|---------|---------|
| `.service` + `.timer` | Single `.plist` |
| `systemctl --user start X` | `launchctl load ~/Library/LaunchAgents/X.plist` |
| `journalctl --user -u X` | `cat ~/Library/Logs/gptme-agent/*.log` |

Closes ErikBjare/bob#265