### PR TITLE
fix(hooks): show pre-commit failure output when checks fail

### DIFF
--- a/dotfiles/.config/git/hooks/pre-commit
+++ b/dotfiles/.config/git/hooks/pre-commit
@@ -114,8 +114,11 @@ echo -e "${GREEN}Running pre-commit checks...${NC}"
 
 # Run pre-commit checks on staged files only
 # Capture output to avoid spamming context with passed/skipped hooks
+# NOTE: Temporarily disable set -e so we can capture exit code even on failure
+set +e
 PRECOMMIT_OUTPUT=$(pre-commit run 2>&1)
 PRECOMMIT_EXIT=$?
+set -e
 
 if [ $PRECOMMIT_EXIT -eq 0 ]; then
     echo -e "${GREEN}✓ All pre-commit checks passed${NC}"
@@ -138,8 +141,11 @@ else
     echo -e "${GREEN}Auto-staged modified files. Re-running pre-commit...${NC}"
 
     # Re-run pre-commit on staged files
+    # NOTE: Temporarily disable set -e so we can capture exit code even on failure
+    set +e
     PRECOMMIT_OUTPUT=$(pre-commit run 2>&1)
     PRECOMMIT_EXIT=$?
+    set -e
 
     if [ $PRECOMMIT_EXIT -eq 0 ]; then
         echo -e "${GREEN}✓ All pre-commit checks passed after auto-staging${NC}"

--- a/uv.lock
+++ b/uv.lock
@@ -732,6 +732,8 @@ version = "0.1.0"
 source = { editable = "plugins/gptme-ace" }
 dependencies = [
     { name = "gptme" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
@@ -764,6 +766,7 @@ requires-dist = [
     { name = "faiss-cpu", marker = "extra == 'embeddings'", specifier = ">=1.7.0" },
     { name = "gptme" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
+    { name = "numpy", specifier = ">=1.24.0" },
     { name = "numpy", marker = "extra == 'embeddings'", specifier = ">=1.24.0" },
     { name = "plotext", marker = "extra == 'full'", specifier = ">=5.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },


### PR DESCRIPTION
## Problem

When pre-commit checks failed, the failure output was not displayed. Users only saw:

```
Running pre-commit checks...
Return code: 1
```

Instead of seeing the actual errors (mypy errors, linting issues, etc.).

## Root Cause

The global pre-commit hook uses `set -e` at the top, which causes the script to exit immediately when any command returns non-zero.

The command substitution `PRECOMMIT_OUTPUT=$(pre-commit run 2>&1)` runs pre-commit and captures its output. With `set -e`, when pre-commit returns non-zero, the script exits immediately before it can:
1. Capture the exit code in `PRECOMMIT_EXIT`
2. Echo the failure output

## Fix

Temporarily disable `set -e` around the pre-commit invocation:

```bash
set +e
PRECOMMIT_OUTPUT=$(pre-commit run 2>&1)
PRECOMMIT_EXIT=$?
set -e
```

This allows the script to capture both the output and exit code, then re-enables strict error handling.

## Testing

Before fix:
```
Running pre-commit checks...
---EXIT CODE: 1---
```

After fix:
```
Running pre-commit checks...
[full pre-commit output with mypy errors, etc.]
---EXIT CODE: 1---
```