### PR TITLE
fix(linear): emphasize primary-directive-thread in prompt

### DIFF
--- a/scripts/linear/linear-webhook-server.py
+++ b/scripts/linear/linear-webhook-server.py
@@ -477,9 +477,18 @@ def build_gptme_prompt(session_data: dict) -> str:
 
     return f"""# Linear Agent Session: {session_id}
 
+## 🎯 YOUR IMMEDIATE TASK
+
 You have been {action} in Linear issue {issue.get("identifier", "unknown")}: {issue.get("title", "Unknown")}
 
+**IMPORTANT**: Look for the `<primary-directive-thread>` below - this contains the comment/request you should respond to.
+- The `<primary-directive-thread>` is what the user is asking RIGHT NOW
+- The `<issue>` description is background context only
+- Do NOT try to complete the entire issue unless the triggering comment specifically asks for that
+- Respond to what the USER ASKED in the `<primary-directive-thread>`
+
 ## Context from Linear
+
 {prompt_context}
 
 ## Your Tools


### PR DESCRIPTION
## Problem

Agents were solving the entire issue instead of responding to the triggering comment. For example, when asked for 'a summary of research', the agent would implement the full issue task instead.

## Solution

Added clear instructions at the top of the prompt to:
- Focus on `<primary-directive-thread>` as the immediate task
- Treat `<issue>` description as background context only
- Respond to what the user actually asked in the triggering comment

## Testing

This should be tested with the next Linear session to verify agents properly respond to the triggering comment rather than defaulting to 'solve the issue' mode.