### PR TITLE
fix(email): increase sync-maildir timeout from 30s to 120s

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/email.py
+++ b/packages/gptme-runloops/src/gptme_runloops/email.py
@@ -61,7 +61,7 @@ class EmailRun(BaseRunLoop):
                 ["uv", "run", "python3", "-m", "gptmail", "sync-maildir"],
                 capture_output=True,
                 text=True,
-                timeout=30,
+                timeout=120,  # Increased from 30s - large mailboxes (11k+ emails) need more time
                 cwd=self.workspace,
             )
             if result.returncode == 0:


### PR DESCRIPTION
## Problem

The email-run service's `sync-maildir` command was timing out after 30 seconds, causing email sync to fail on large mailboxes (11k+ emails).

From the service logs:
```
ERROR: Error syncing workspace email: Command '['uv', 'run', 'python3', '-m', 'gptmail', 'sync-maildir']' timed out after 30 seconds
```

## Solution

Increased the timeout from 30 seconds to 120 seconds for the `sync-maildir` subprocess call.

## Testing

Manual testing shows the command completes successfully in ~60-90 seconds for a mailbox with 11,000+ emails:
```
Synced inbox: 10 succeeded, 0 failed, 11450 skipped (already exist)
Synced sent: 1 succeeded, 0 failed, 149 skipped (already exist)
```

## Related

- Discovered during investigation of Erik's report that email-runs service wasn't working (ErikBjare/bob#267)