### PR TITLE
fix(ralph): improve plan extraction to filter gptme subprocess noise

### DIFF
--- a/plugins/gptme-ralph/src/gptme_ralph/tools/ralph_loop.py
+++ b/plugins/gptme-ralph/src/gptme_ralph/tools/ralph_loop.py
@@ -719,13 +719,11 @@ def create_project(
     plan_path = work_dir / "plan.md"
 
     if use_llm:
-        # Generate task-specific plan using LLM
+        # Generate task-specific plan using LLM with direct file save
         plan_content = _generate_plan_with_llm(
-            task_description, backend, model, work_dir
+            task_description, backend, model, work_dir, plan_path
         )
-        if plan_content:
-            plan_path.write_text(plan_content)
-        else:
+        if not plan_content:
             # Fall back to template if LLM generation fails
             create_plan(task_description, "plan.md", 5, workspace)
     else:
@@ -740,6 +738,7 @@ def _generate_plan_with_llm(
     backend: str,
     model: str | None,
     work_dir: Path,
+    output_file: Path | None = None,
 ) -> str | None:
     """
     Generate a task-specific implementation plan using an LLM.
@@ -749,6 +748,7 @@ def _generate_plan_with_llm(
         backend: 'gptme' or 'claude'
         model: Model to use (or None for default)
         work_dir: Working directory
+        output_file: If provided, save plan directly to this file (gptme backend)
 
     Returns:
         Plan content as markdown string, or None if generation fails
@@ -781,7 +781,7 @@ Output ONLY the plan content, nothing else."""
 
     try:
         if backend == "gptme":
-            return _generate_plan_gptme(prompt, model, work_dir)
+            return _generate_plan_gptme(prompt, model, work_dir, output_file)
         elif backend == "claude":
             return _generate_plan_claude(prompt, model, work_dir)
         else:
@@ -796,8 +796,21 @@ def _generate_plan_gptme(
     prompt: str,
     model: str | None,
     work_dir: Path,
+    output_file: Path | None = None,
 ) -> str | None:
-    """Generate plan using gptme backend."""
+    """Generate plan using gptme backend.
+
+    Uses --tools save to have gptme write directly to the output file,
+    avoiding the need to parse plan content from subprocess stdout.
+
+    Alternative approach (not implemented): A -p option similar to Claude Code
+    that only prints the last response, which would also simplify extraction.
+    """
+    # If output file provided, use direct save approach
+    if output_file is not None:
+        return _generate_plan_gptme_direct_save(prompt, model, work_dir, output_file)
+
+    # Fallback: parse from stdout (for backward compatibility)
     cmd = ["gptme", "-n", "-y"]
 
     if model:
@@ -827,6 +840,76 @@ def _generate_plan_gptme(
                 return plan
 
         logger.warning(f"gptme plan generation returned: {result.returncode}")
+        return None
+
+    except subprocess.TimeoutExpired:
+        logger.warning("gptme plan generation timed out")
+        return None
+    except Exception as e:
+        logger.warning(f"gptme plan generation failed: {e}")
+        return None
+
+
+def _generate_plan_gptme_direct_save(
+    prompt: str,
+    model: str | None,
+    work_dir: Path,
+    output_file: Path,
+) -> str | None:
+    """Generate plan using gptme with direct file save.
+
+    This approach uses --tools save to restrict gptme to only the save tool,
+    and prompts it to save the plan directly to the output file.
+    This eliminates the need to parse plan content from noisy subprocess output.
+    """
+    # Construct prompt that instructs gptme to save directly
+    save_prompt = f"""{prompt}
+
+IMPORTANT: Save your plan directly to the file: {output_file}
+Use the save tool to write the plan. Do not just output it - save it to the file."""
+
+    cmd = ["gptme", "-n", "-y", "--tools", "save"]
+
+    if model:
+        cmd.extend(["-m", model])
+
+    # Create temporary conversation for plan generation
+    temp_name = f"ralph-plan-gen-{uuid.uuid4().hex[:8]}"
+    cmd.extend(["--name", temp_name])
+
+    # Add the prompt
+    cmd.append(save_prompt)
+
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=work_dir,
+            capture_output=True,
+            text=True,
+            timeout=120,  # 2 minute timeout for plan generation
+        )
+
+        # Check if the file was created
+        if output_file.exists():
+            content = output_file.read_text().strip()
+            # Validate it looks like a plan (has checkboxes)
+            if "- [ ]" in content or "- [x]" in content:
+                logger.info(f"Plan saved directly to {output_file}")
+                return content
+            else:
+                logger.warning(
+                    f"File {output_file} created but doesn't look like a plan"
+                )
+                # Clean up invalid file
+                output_file.unlink()
+                return None
+
+        # File not created - log details for debugging
+        logger.warning(
+            f"gptme did not create plan file (returncode={result.returncode})"
+        )
+        if result.stderr:
+            logger.debug(f"gptme stderr: {result.stderr[:500]}")
         return None
 
     except subprocess.TimeoutExpired:


### PR DESCRIPTION
## Summary

The `_extract_plan_from_output` function was capturing gptme's subprocess noise (token counts, context loading messages, shell prompts) when extracting plans from LLM output. This caused plan.md files to contain raw gptme output instead of clean plan markdown.

## Bug Discovery

Discovered during Ralph Loop experiment (ErikBjare/bob#260) where `create_project()` produced plan files containing:
- Token usage info (`Tokens: input=2500 output=1200`)
- Context loading messages (`Loading context...`)  
- Shell prompt remnants
- System markers

## Fix

- Add `is_noise_line()` helper to filter gptme-specific patterns:
  - Token/cost output
  - Context loading messages  
  - System/tool markers
  - Shell prompt patterns
- Look for plan-specific headings (`# Implementation Plan`) first before generic markdown
- Better handling of code blocks and empty lines
- Stop on additional conversation markers (`User:`, `System:`)

## Testing

Verified with sample gptme-like output:
- ✅ Noise filtered out
- ✅ Checkboxes preserved
- ✅ Plan structure intact

Fixes: ErikBjare/bob#260
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes noise capture in `_extract_plan_from_output` by filtering gptme subprocess noise and improving plan extraction logic in `ralph_loop.py`.
> 
>   - **Behavior**:
>     - `_extract_plan_from_output` now filters gptme subprocess noise (e.g., token counts, context loading) using `is_noise_line()`.
>     - Prioritizes plan-specific headings like `# Implementation Plan` over generic markdown.
>     - Improved handling of code blocks and empty lines, stopping on conversation markers (`User:`, `System:`).
>   - **Functions**:
>     - Added `is_noise_line()` to identify and filter noise patterns in `_extract_plan_from_output`.
>     - Modified `_generate_plan_with_llm()` to support direct file save with gptme, avoiding stdout parsing.
>     - Introduced `_generate_plan_gptme_direct_save()` for direct file save approach.
>   - **Testing**:
>     - Verified noise filtering, checkbox preservation, and plan structure with sample gptme-like output.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for a5ffcae56c062574d1b77b8662e66737133b9540. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->