### PR TITLE
fix(monitoring): add review/comment to notification reasons

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/project_monitoring.py
+++ b/packages/gptme-runloops/src/gptme_runloops/project_monitoring.py
@@ -701,7 +701,15 @@ class ProjectMonitoringRun(BaseRunLoop):
             notifications = json.loads(result.stdout)
 
             # Filter for relevant notification reasons
-            relevant_reasons = {"mention", "assign", "review_requested", "team_mention"}
+            # Includes review/comment to catch review feedback on PRs
+            relevant_reasons = {
+                "mention",
+                "assign",
+                "review_requested",
+                "team_mention",
+                "review",  # Review submitted on your PR
+                "comment",  # Comment on issue/PR you're subscribed to
+            }
             relevant_notifications = [
                 n
                 for n in notifications


### PR DESCRIPTION
Project monitoring wasn't triggering on review comments because the notification filter only included: mention, assign, review_requested, team_mention.

Added 'review' and 'comment' reasons to catch review feedback on PRs.

Fixes issue where review comments required a separate normal comment to trigger monitoring.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds 'review' and 'comment' to notification reasons in `check_notifications()` to ensure review comments trigger monitoring.
> 
>   - **Behavior**:
>     - Adds 'review' and 'comment' to `relevant_reasons` in `check_notifications()` in `project_monitoring.py` to ensure review comments trigger monitoring.
>     - Fixes issue where review comments required a separate normal comment to trigger monitoring.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for fd50b7468b08efd2d5b2cdd896ebd56e2fc38c1e. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->