### PR TITLE
feat(gptodo): add clear_keys option for credential isolation

### DIFF
--- a/packages/gptodo/src/gptodo/subagent.py
+++ b/packages/gptodo/src/gptodo/subagent.py
@@ -32,7 +32,7 @@ class AgentSession:
     session_id: str
     task_id: str
     agent_type: Literal["general", "explore", "plan", "execute"]
-    backend: Literal["gptme", "claude"]
+    backend: Literal["gptme", "claude", "codex"]
     started: str
     status: Literal["running", "completed", "failed", "killed"]
     tmux_session: Optional[str] = None
@@ -96,7 +96,7 @@ def spawn_agent(
     task_id: str,
     prompt: str,
     agent_type: Literal["general", "explore", "plan", "execute"] = "general",
-    backend: Literal["gptme", "claude"] = "gptme",
+    backend: Literal["gptme", "claude", "codex"] = "gptme",
     background: bool = False,
     workspace: Optional[Path] = None,
     timeout: int = 600,


### PR DESCRIPTION
## Summary

Adds a `clear_keys` option to `spawn_agent()` that explicitly unsets API keys for backends that have their own authentication (Claude Code, Codex). This addresses Erik's suggestion in #228.

## Changes

- Add `clear_keys: Optional[bool]` parameter to `spawn_agent()`
  - `None` (default): auto-detect based on backend
  - `True`: explicitly unset API keys
  - `False`: export all API keys
- For tmux sessions: adds `unset VAR1 VAR2 ...` before exports
- For foreground: passes modified env dict to `subprocess.run()`
- Supports `claude` and `codex` backends (with their OAuth subscriptions)

## Motivation

When Claude Code runs in an environment where `ANTHROPIC_API_KEY` is set, it uses the API key instead of its OAuth subscription. This hits rate limits and bypasses the flat-fee subscription.

The fix ensures we explicitly unset these vars, making the intent clear and the behavior predictable.

## Related

- Closes #228 (API key vs OAuth issue - the specific item addressed)

Co-authored-by: Bob <bob@superuserlabs.org>
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `clear_keys` option to `spawn_agent()` for credential isolation, affecting API key handling for `claude` and `codex` backends.
> 
>   - **Behavior**:
>     - Adds `clear_keys` option to `spawn_agent()` in `subagent.py` to manage API key usage.
>     - `None` (default): auto-detect based on backend.
>     - `True`: unset API keys for `claude` and `codex`.
>     - `False`: export all API keys.
>   - **Environment Handling**:
>     - For tmux sessions, adds `unset VAR1 VAR2 ...` before exports.
>     - For foreground sessions, passes modified env dict to `subprocess.run()`.
>   - **Backends**:
>     - Supports `claude` and `codex` backends with OAuth subscriptions.
>   - **Misc**:
>     - Updates `AgentSession` to include `codex` in `backend` options.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for 413e81548c30ad819de0069abd8a938bf94209fd. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->