### PR TITLE
feat(gptodo): add --changes-only flag to sync for stale queue detection

### DIFF
--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -2162,7 +2162,9 @@ def sync(update, output_json, use_cache, light, full, changes_only):
         return
 
     # Rich table output
-    table = Table(title=f"[bold]Task-Issue Sync Status[/] ({len(results)} tracked)")
+    table = Table(
+        title=f"[bold]Task-Issue Sync Status[/] ({len(results)} {'changed' if changes_only else 'tracked'})"
+    )
     table.add_column("Task", style="cyan")
     table.add_column("Issue", style="blue")
     table.add_column("Task State", style="yellow")


### PR DESCRIPTION
## Summary

Adds `--changes-only` flag to `gptodo sync` command to help agents detect stale queue entries efficiently.

## Problem

Work queues accumulate stale state - e.g., showing 'PRs Awaiting Review' when those PRs have already been merged. Constant re-checking is costly, but not checking means stale data.

## Solution

`gptodo sync --changes-only` filters sync output to show only items where:
- State has changed (out of sync with tracked issue/PR)
- New activity detected since `waiting_since`

When no changes are detected, outputs a clear '✓ No state changes detected' message.

### Usage

```bash
# Check for any state changes
gptodo sync --changes-only

# JSON output for scripts
gptodo sync --changes-only --json

# With light sync to refresh from notifications first
gptodo sync --light --changes-only
```

## Example Output

When changes exist:
```
┌─────────────────────────────────────────────────────────────┐
│            Task-Issue Sync Status (2 changed)                │
├────────────┬──────────────┬────────────┬────────────┬───────┤
│ Task       │ Issue        │ Task State │ Issue State│ Status│
├────────────┼──────────────┼────────────┼────────────┼───────┤
│ my-task    │ owner/repo#5 │ active     │ closed     │ ⚠ Out │
└────────────────────────────────────────────────────────────┘
```

When no changes:
```
✓ No state changes detected - all tracked items in sync
```

Ref: ErikBjare/bob#262
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `--changes-only` flag to `gptodo sync` to filter output for state changes or new activity, aiding in stale queue detection.
> 
>   - **Behavior**:
>     - Adds `--changes-only` flag to `sync` command in `cli.py` to filter output for state changes or new activity since `waiting_since`.
>     - Outputs '✓ No state changes detected' if no changes are found.
>   - **Functionality**:
>     - Modifies `sync()` function to handle `changes_only` option, filtering results based on state changes or new activity.
>     - Updates output logic to display filtered results or a no-change message.
>   - **Output**:
>     - Supports JSON output with `--json` flag, showing no changes message in JSON format.
>     - Updates table title to reflect number of changed items when `--changes-only` is used.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for 04b8ee610104b6a5d30c2173ebe90ef71da71013. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->