### PR TITLE
feat(gptodo): auto-detect workspace tasks directory

### DIFF
--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -138,10 +138,21 @@ console = Console()
 
 @click.group()
 @click.option("-v", "--verbose", is_flag=True)
-def cli(verbose):
+@click.option(
+    "--tasks-dir",
+    type=click.Path(exists=False, file_okay=False, resolve_path=True),
+    envvar="GPTODO_TASKS_DIR",
+    help="Path to tasks directory (overrides auto-detection). Can also be set via GPTODO_TASKS_DIR env var.",
+)
+def cli(verbose, tasks_dir):
     """Task verification and status CLI."""
     log_level = logging.DEBUG if verbose else logging.INFO
     logging.basicConfig(level=log_level)
+
+    # Set GPTODO_TASKS_DIR if provided via CLI
+    # This allows find_repo_root to pick it up
+    if tasks_dir:
+        os.environ["GPTODO_TASKS_DIR"] = tasks_dir
 
 
 @cli.command("show")

--- a/packages/gptodo/tests/test_find_repo_root.py
+++ b/packages/gptodo/tests/test_find_repo_root.py
@@ -1,0 +1,99 @@
+"""Tests for workspace detection in find_repo_root."""
+
+from pathlib import Path
+
+
+from gptodo.utils import find_repo_root
+
+
+class TestFindRepoRoot:
+    """Test cases for find_repo_root workspace detection."""
+
+    def test_gptme_toml_takes_priority(self, tmp_path):
+        """gptme.toml should be found before plain .git directories."""
+        # Create nested structure: root/sub1/sub2
+        root = tmp_path / "root"
+        sub1 = root / "sub1"
+        sub2 = sub1 / "sub2"
+        sub2.mkdir(parents=True)
+
+        # Put gptme.toml at root and .git at sub1
+        (root / "gptme.toml").touch()
+        (sub1 / ".git").mkdir()
+
+        # From sub2, should find root (gptme.toml), not sub1 (.git)
+        assert find_repo_root(sub2) == root
+
+    def test_git_with_tasks_beats_git_alone(self, tmp_path):
+        """A .git directory with tasks/ sibling should win over plain .git."""
+        # Create nested structure
+        outer = tmp_path / "outer"
+        inner = outer / "inner"
+        deep = inner / "deep"
+        deep.mkdir(parents=True)
+
+        # outer has .git with tasks/
+        (outer / ".git").mkdir()
+        (outer / "tasks").mkdir()
+
+        # inner has only .git
+        (inner / ".git").mkdir()
+
+        # From deep, should find outer (has tasks), not inner
+        assert find_repo_root(deep) == outer
+
+    def test_falls_back_to_plain_git(self, tmp_path):
+        """Without gptme.toml or tasks/, should fall back to .git."""
+        repo = tmp_path / "repo"
+        subdir = repo / "src" / "module"
+        subdir.mkdir(parents=True)
+
+        # Only .git, no gptme.toml or tasks/
+        (repo / ".git").mkdir()
+
+        assert find_repo_root(subdir) == repo
+
+    def test_gptodo_tasks_dir_env_override(self, tmp_path, monkeypatch):
+        """GPTODO_TASKS_DIR should take highest priority."""
+        custom_tasks = tmp_path / "custom" / "tasks"
+        custom_tasks.mkdir(parents=True)
+
+        # Create a repo that would normally be found
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        (repo / "tasks").mkdir()
+
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(custom_tasks))
+
+        # Should return parent of custom_tasks, not the repo
+        result = find_repo_root(repo)
+        assert result == custom_tasks.parent
+
+    def test_tasks_repo_root_env_legacy(self, tmp_path, monkeypatch):
+        """TASKS_REPO_ROOT (legacy) should work as fallback."""
+        # Clear any GPTODO_TASKS_DIR
+        monkeypatch.delenv("GPTODO_TASKS_DIR", raising=False)
+
+        custom_root = tmp_path / "custom_root"
+        custom_root.mkdir()
+        (custom_root / ".git").mkdir()
+
+        monkeypatch.setenv("TASKS_REPO_ROOT", str(custom_root))
+
+        # Should use custom_root as starting point
+        result = find_repo_root(Path("/nonexistent"))
+        assert result == custom_root
+
+    def test_fallback_to_start_path(self, tmp_path, monkeypatch):
+        """Without any markers, should return start_path."""
+        # Clear environment variables
+        monkeypatch.delenv("GPTODO_TASKS_DIR", raising=False)
+        monkeypatch.delenv("TASKS_REPO_ROOT", raising=False)
+
+        # Create a directory with no markers
+        empty = tmp_path / "empty"
+        empty.mkdir()
+
+        result = find_repo_root(empty)
+        assert result == empty


### PR DESCRIPTION
## Summary

Implements #227 - gptodo now auto-detects the correct tasks directory instead of always using `./tasks/` relative to cwd.

## Changes

### Priority order for finding workspace root:
1. `--tasks-dir` CLI option (highest priority)
2. `GPTODO_TASKS_DIR` environment variable
3. Auto-detect by looking for workspace markers:
   - `gptme.toml` (gptme workspace config - strongest signal)
   - `.git` with `tasks/` sibling (task workspace)
   - `.git` alone (any git repo - fallback)
4. `./tasks/` relative to cwd (ultimate fallback)

### Files changed:
- `packages/gptodo/src/gptodo/utils.py`: Enhanced `find_repo_root()` to look for workspace markers
- `packages/gptodo/src/gptodo/cli.py`: Added `--tasks-dir` global option (also reads `GPTODO_TASKS_DIR`)
- Added 6 new tests for workspace detection

## Problem Solved

Before this change, running `gptodo` from `gptme-contrib` would create tasks in `gptme-contrib/tasks/` instead of the target workspace (e.g., `gptme-bob/tasks/`).

## Testing

All 18 tests pass:
```
tests/test_find_repo_root.py - 6 new tests for workspace detection
tests/test_unblock.py - 12 existing tests still pass
```

Closes #227
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances `gptodo` to auto-detect the tasks directory using a priority order of CLI options, environment variables, and workspace markers.
> 
>   - **Behavior**:
>     - `find_repo_root()` in `utils.py` now auto-detects the workspace root using a priority order: `--tasks-dir` CLI option, `GPTODO_TASKS_DIR` env var, `gptme.toml`, `.git` with `tasks/`, `.git`, and `./tasks/`.
>     - `cli.py` adds `--tasks-dir` option to override auto-detection, also reads `GPTODO_TASKS_DIR`.
>   - **Testing**:
>     - Adds 6 tests in `test_find_repo_root.py` for workspace detection, covering all priority cases.
>   - **Problem Solved**:
>     - Fixes issue where `gptodo` would incorrectly create tasks in the current directory's `tasks/` instead of the intended workspace.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for 917394a5c71883be4f3da61645428b5c886b9988. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->