### PR TITLE
fix(gptodo): add -- separator to fix claude spawn prompt parsing

### DIFF
--- a/packages/gptodo/src/gptodo/subagent.py
+++ b/packages/gptodo/src/gptodo/subagent.py
@@ -152,7 +152,7 @@ def spawn_agent(
             shell_cmd = f'gptme -n {model_arg} {safe_prompt} > {safe_output} 2>&1; echo "EXIT_CODE=$?" >> {safe_output}'
         else:
             # Claude backend doesn't support model selection
-            shell_cmd = f'claude -p --dangerously-skip-permissions --tools default {safe_prompt} > {safe_output} 2>&1; echo "EXIT_CODE=$?" >> {safe_output}'
+            shell_cmd = f'claude -p --dangerously-skip-permissions --tools default -- {safe_prompt} > {safe_output} 2>&1; echo "EXIT_CODE=$?" >> {safe_output}'
 
         # Build environment exports for critical API keys
         # These may not be inherited by tmux detached sessions
@@ -230,7 +230,7 @@ def spawn_agent(
         cmd.append(prompt)
     else:
         # Claude backend doesn't support model selection
-        cmd = ["claude", "-p", "--dangerously-skip-permissions", "--tools", "default", prompt]
+        cmd = ["claude", "-p", "--dangerously-skip-permissions", "--tools", "default", "--", prompt]
 
     # Build environment for subprocess
     # If clear_keys is enabled, create modified environment without API keys


### PR DESCRIPTION
## Summary

Fixes the "spawn-producing-no-work" issue reported in #228.

## Root Cause

The claude CLI's `--tools` option accepts variadic arguments (`<tools...>`), which was consuming the prompt as an additional tool name instead of passing it as the positional prompt argument.

**Before:**
```
claude -p --tools default 'prompt'
  -> tools=['default', 'prompt'], prompt=None
  -> Error: Input must be provided either through stdin or as a prompt argument
```

**After:**
```
claude -p --tools default -- 'prompt'  
  -> tools=['default'], prompt='prompt'
  -> Works correctly
```

## Testing

Verified fix works:
```bash
# Without -- (fails)
timeout 5 claude -p --tools default 'respond with HELLO' 2>&1
# Error: Input must be provided...

# With -- (works)  
timeout 10 claude -p --tools default -- 'respond with HELLO' 2>&1
# HELLO
```

## Changes

- Added `--` separator before prompt in both background (tmux) and foreground execution paths

Fixes: #228
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes prompt parsing in `spawn_agent()` by adding `--` separator for Claude CLI in `subagent.py`.
> 
>   - **Behavior**:
>     - Fixes prompt parsing issue in `spawn_agent()` in `subagent.py` by adding `--` separator for Claude CLI.
>     - Ensures prompt is correctly passed as positional argument, not as a tool name.
>   - **Testing**:
>     - Verified fix with and without `--` separator, confirming correct behavior with `--`.
>   - **Misc**:
>     - Addresses issue #228.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for a08ce8bd0ccd30d94602a2737fa583d5ea1d430e. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->