### PR TITLE
fix(team): include ipython in coordinator tools

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/team.py
+++ b/packages/gptme-runloops/src/gptme_runloops/team.py
@@ -81,7 +81,8 @@ class TeamRun(BaseRunLoop):
     """
 
     # Tools available to the coordinator
-    COORDINATOR_TOOLS = "gptodo,save,append,read,todoread,todowrite,complete"
+    # Note: ipython is required because gptodo functions are registered there
+    COORDINATOR_TOOLS = "gptodo,ipython,save,append,read,todoread,todowrite,complete"
 
     def __init__(self, workspace: Path, tools: str | None = None):
         """Initialize team run.


### PR DESCRIPTION
## Summary

The gptodo plugin registers functions (`delegate()`, `list_tasks()`, `task_status()`, etc.) in the **ipython** tool. Without `ipython` in `COORDINATOR_TOOLS`, these functions cannot be called, causing the team run to fail.

## Problem

When running team mode:
```bash
gptme --tools gptodo,save,read,complete --non-interactive --no-confirm "Test delegation"
```

The ipython code blocks are not detected because ipython isn't in the tools list.

## Fix

Add `ipython` to `COORDINATOR_TOOLS`:
```python
COORDINATOR_TOOLS = "gptodo,ipython,save,append,read,todoread,todowrite,complete"
```

## Testing

After this fix, the team run should be able to call gptodo functions like:
```python
result = task_status()
print(result)
```

## Related

- Issue ErikBjare/bob#300 - Learn from Claude Code Agent Teams
- PR #252 - Original gptodo plugin implementation
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `ipython` to `COORDINATOR_TOOLS` in `TeamRun` to enable gptodo functions during team runs.
> 
>   - **Behavior**:
>     - Add `ipython` to `COORDINATOR_TOOLS` in `TeamRun` class in `team.py` to enable gptodo functions.
>   - **Problem**:
>     - Without `ipython`, gptodo functions like `delegate()` and `task_status()` cannot be called, causing team runs to fail.
>   - **Testing**:
>     - After fix, team runs can successfully call gptodo functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for c02021722161b3a01b9b4128c25c8f6c7737f49b. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->