### PR TITLE
fix(validator): address review feedback for markdown codeblock lesson

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,3 +91,11 @@ repos:
     types: [markdown]
     files: ^lessons/
     pass_filenames: true
+
+  - id: validate-markdown-codeblock-syntax
+    name: Validate markdown codeblock syntax
+    description: Ensures markdown codeblocks have language tags to prevent parsing cut-offs.
+    entry: scripts/precommit/validators/validate_markdown_codeblock_syntax.py
+    language: system
+    types: [markdown]
+    pass_filenames: true

--- a/lessons/tools/markdown-codeblock-syntax.md
+++ b/lessons/tools/markdown-codeblock-syntax.md
@@ -82,4 +82,4 @@ Benefits:
 **What happens without language tags**: Parser may misinterpret closing ```, cutting content early. Your attention should recognize this pattern when seeing incomplete saves or files ending with ":" or "**".
 
 ## Related
-- Full context: knowledge/lessons/markdown-codeblock-syntax.md
+- Full context: https://github.com/ErikBjare/bob/blob/master/knowledge/lessons/tools/markdown-codeblock-syntax.md

--- a/scripts/precommit/validators/validate_markdown_codeblock_syntax.py
+++ b/scripts/precommit/validators/validate_markdown_codeblock_syntax.py
@@ -24,78 +24,7 @@ LESSON_PATH = "lessons/tools/markdown-codeblock-syntax.md"
 LESSON_NAME = "Markdown Codeblock Syntax"
 FILE_PATTERNS = [".md"]
 
-# Known valid language tags
-VALID_LANGUAGE_TAGS = {
-    # Common formats
-    "txt",
-    "text",
-    "csv",
-    "json",
-    "yaml",
-    "yml",
-    "toml",
-    "ini",
-    "xml",
-    "html",
-    # Code languages
-    "python",
-    "py",
-    "javascript",
-    "js",
-    "typescript",
-    "ts",
-    "bash",
-    "sh",
-    "shell",
-    "c",
-    "cpp",
-    "c++",
-    "java",
-    "go",
-    "rust",
-    "ruby",
-    "php",
-    "perl",
-    "lua",
-    # Markup/styling
-    "markdown",
-    "md",
-    "css",
-    "scss",
-    "sass",
-    "less",
-    # Data/visualization
-    "sql",
-    "graphql",
-    "diagram",
-    "ascii",
-    "mermaid",
-    "dot",
-    # Documentation
-    "diff",
-    "patch",
-    "log",
-    "output",
-    "stdout",
-    "stderr",
-    "result",
-    # Special
-    "console",
-    "terminal",
-    "plaintext",
-    # Tool-specific (gptme)
-    "save",
-    "append",
-    "patch",
-    "shell",
-    "ipython",
-    "tmux",
-    "complete",
-    "gh",
-    "todowrite",
-    "todoread",
-    "morph",
-}
+# No predefined language tags - accept any non-empty tag
 
 
 # ==============================================================================
@@ -129,10 +58,12 @@ class MarkdownCodeblockValidator:
 
         lines = content.split("\n")
         violations_found = False
+        fence_count = 0
 
         for line_num, line in enumerate(lines, start=1):
             # Check for codeblock fence
             if line.strip().startswith("```"):
+                fence_count += 1
                 # Extract language tag (everything after ```)
                 fence_match = re.match(r"^```(\S*)", line.strip())
                 if fence_match:
@@ -144,22 +75,19 @@ class MarkdownCodeblockValidator:
                             (filepath, line_num, "No language tag specified")
                         )
                         violations_found = True
-                    # Unknown language tag is a warning (not strict violation)
-                    elif lang_tag.lower() not in VALID_LANGUAGE_TAGS and self.verbose:
-                        if self.verbose:
-                            print(
-                                f"Info: {filepath}:{line_num} - Unknown language tag '{lang_tag}'"
-                            )
+
+        # Check for unclosed code blocks (odd number of fences)
+        if fence_count % 2 != 0:
+            self.violations.append(
+                (
+                    filepath,
+                    0,
+                    f"Unclosed code block detected ({fence_count} fences, expected even number)",
+                )
+            )
+            violations_found = True
 
         return not violations_found
-
-    def get_error_message(self, filepath: Path, line_num: int, reason: str) -> str:
-        """Get actionable error message for a violation."""
-        return (
-            f"Line {line_num}: {reason}\n"
-            f"    Fix: Add language tag like ```txt, ```csv, ```python, etc.\n"
-            f"    Example: ```txt  (not just ```)"
-        )
 
     def run(self, files: List[Path]) -> int:
         """Run validator on list of files."""


### PR DESCRIPTION
## Summary

This PR addresses the review feedback from PR #275 and provides a clean version of the markdown codeblock syntax lesson.

## Changes

- **Remove VALID_LANGUAGE_TAGS** - Accept any non-empty language tag (per Erik's feedback)
- **Add unclosed code block detection** - Track fence count to detect unbalanced code blocks
- **Remove dead code** - Deleted unused `get_error_message` method
- **Fix companion doc link** - Updated to use full GitHub URL
- **Add pre-commit hook** - Integrated into `.pre-commit-config.yaml` with `language: system`

## Context

The original PR #275 had become mixed with unrelated Twitter commits. This PR contains only the markdown codeblock lesson with all review feedback addressed.

Fixes #306
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances markdown codeblock validation by accepting any non-empty language tag, detecting unclosed blocks, and adding a pre-commit hook.
> 
>   - **Behavior**:
>     - Removes `VALID_LANGUAGE_TAGS` to accept any non-empty language tag in `validate_markdown_codeblock_syntax.py`.
>     - Adds detection for unclosed code blocks by tracking fence count in `validate_markdown_codeblock_syntax.py`.
>   - **Code Cleanup**:
>     - Removes unused `get_error_message` method in `validate_markdown_codeblock_syntax.py`.
>   - **Documentation**:
>     - Updates companion doc link to full GitHub URL in `markdown-codeblock-syntax.md`.
>   - **Pre-commit Hook**:
>     - Adds `validate-markdown-codeblock-syntax` to `.pre-commit-config.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for 17d054e9d42a86a1fb657aab8ef52685f3b3e26d. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->