### PR TITLE
fix(twitter): prevent duplicate replies for trusted users

### DIFF
--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -1253,6 +1253,14 @@ def process_timeline_tweets(
                         and eval_result
                         and eval_result.action == "respond"
                     ):
+                        # Check for duplicate replies before auto-posting
+                        duplicates = _check_for_duplicate_replies_internal(draft)
+                        if "posted" in duplicates:
+                            console.print(
+                                f"[yellow]⚠ Skipping auto-post: already posted {len(duplicates['posted'])} reply(ies) to tweet {draft.in_reply_to}"
+                            )
+                            continue
+
                         # Auto-post for trusted users
                         console.print(
                             f"[green]Auto-posting reply to trusted user @{author_username}"


### PR DESCRIPTION
## Problem

When auto-posting replies for trusted users, the workflow did not check if a reply to the same tweet already existed. This caused duplicate replies to be posted to the same tweet.

## Solution

Added duplicate check before auto-posting for trusted users:
- Uses existing `_check_for_duplicate_replies_internal()` function
- Skips posting if a reply already exists in the `posted/` directory
- Logs a warning message when skipping

## Testing

- Verified the duplicate check logic works correctly
- Tested with existing tweet replies in the posted directory

## Related

- Issue: ErikBjare/bob#307 (Twitter integration)
- Reported by: @ErikBjare
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a duplicate check in `process_timeline_tweets()` to prevent auto-posting duplicate replies for trusted users in `workflow.py`.
> 
>   - **Behavior**:
>     - Adds duplicate check in `process_timeline_tweets()` in `workflow.py` before auto-posting replies for trusted users.
>     - Uses `_check_for_duplicate_replies_internal()` to check for existing replies in `posted/` directory.
>     - Skips posting and logs a warning if a duplicate is found.
>   - **Testing**:
>     - Verified duplicate check logic.
>     - Tested with existing tweet replies in the `posted` directory.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for 0cbc447f7ec18aec7862e792ee80359b0a29146a. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->