### PR TITLE
fix(twitter): ensure tokens are reloaded after refresh

### DIFF
--- a/scripts/twitter/check_replies.py
+++ b/scripts/twitter/check_replies.py
@@ -11,8 +11,8 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from dotenv import load_dotenv
 from .trusted_users import is_trusted_user
 
-# Load environment variables
-load_dotenv()
+# Load environment variables (override=True to get latest tokens after refresh)
+load_dotenv(override=True)
 
 
 def get_twitter_client():


### PR DESCRIPTION
## Summary
- Use `load_dotenv(override=True)` to always get latest tokens from .env file
- Explicitly update `os.environ` after saving new tokens for same-process reliability
- Add documentation explaining the single-use nature of OAuth 2.0 refresh tokens

## Root Cause
Twitter OAuth 2.0 refresh tokens are single-use (RFC 6749 Section 6). After a successful refresh:
1. Twitter invalidates the old refresh token
2. The code saves the new tokens to `.env` file
3. BUT the running Python process still has the OLD tokens in `os.environ`
4. On the next refresh attempt, it uses the stale (already-used) refresh token
5. Twitter returns 400 Bad Request because that token was already consumed

## The Fix
1. **`load_dotenv(override=True)`**: Forces reloading of `.env` values on every client initialization, ensuring fresh tokens
2. **Direct `os.environ` update**: After saving tokens to file, also update `os.environ` immediately for same-process calls

This is a belt-and-suspenders approach that addresses both:
- Cross-process scenarios (new Python invocations get fresh tokens from `.env`)
- Same-process scenarios (subsequent calls in the same process use updated `os.environ`)

## Test plan
- [ ] Verify syntax is correct (Python compilation succeeds)
- [ ] Monitor Twitter service for 1-2 token refresh cycles (each ~2 hours)
- [ ] Check logs for "Token refreshed successfully" messages without subsequent 400 errors

Related: ErikBjare/bob#307

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure Twitter OAuth 2.0 tokens are reloaded from `.env` and update `os.environ` after refresh to handle single-use tokens.
> 
>   - **Behavior**:
>     - Use `load_dotenv(override=True)` in `check_replies.py` and `twitter.py` to ensure latest tokens are loaded from `.env`.
>     - Update `os.environ` directly in `load_twitter_client()` in `twitter.py` after saving new tokens for same-process reliability.
>   - **Documentation**:
>     - Add comments in `twitter.py` explaining the single-use nature of OAuth 2.0 refresh tokens and the importance of reloading tokens.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for 3d8391a3013e275446b8d70e36cfbf8028db9ffb. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->