### PR TITLE
feat: add jscpd config for duplicate code detection

### DIFF
--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json.schemastore.org/jscpd.json",
+  "threshold": 1,
+  "reporters": ["console"],
+  "ignore": [
+    "**/__pycache__/**",
+    "**/node_modules/**",
+    "**/.venv/**",
+    "**/uv.lock",
+    "**/*.lock",
+    "**/tests/**",
+    "dotfiles/**",
+    "packages/run_loops/**",
+    "packages/lessons/**",
+    "packages/gptme-runloops/**",
+    "packages/gptme-lessons-extras/**",
+    "packages/gptme-contrib-lib/**",
+    "packages/lib/src/lib/**",
+    "packages/gptodo/src/gptodo/**",
+    "scripts/communication_utils/**"
+  ],
+  "minTokens": 50,
+  "minLines": 5,
+  "format": ["python", "javascript", "bash", "yaml", "markdown"]
+}


### PR DESCRIPTION
## Summary
- Adds missing `.jscpd.json` config file for the jscpd pre-commit hook (hook already exists on master but had no config)
- 1% threshold (baseline: 0.87%) — catches ~55+ lines of new copy-paste
- Ignores legacy package rename paths (run_loops, lessons, gptme-contrib-lib, etc.) that create false duplicate positives

## Context
The jscpd hook and Node.js CI setup were added in a prior commit, but the `.jscpd.json` config was lost due to a submodule bare=true corruption. Without the config, jscpd runs with defaults (no ignore patterns, no threshold), which would fail on the legacy package rename duplicates.

## Test plan
- [x] `npx jscpd --config .jscpd.json .` — 28 clones, 0.87% (passes 1% threshold)
- [x] `pre-commit run jscpd --all-files` — Passed
- [ ] CI pre-commit workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `.jscpd.json` configuration for jscpd tool to set duplicate code detection threshold and ignore legacy paths.
> 
>   - **Configuration**:
>     - Adds `.jscpd.json` for jscpd tool configuration.
>     - Sets `threshold` to 1% for duplicate code detection.
>     - Specifies `ignore` paths for legacy packages to avoid false positives.
>   - **Behavior**:
>     - jscpd now detects ~55+ lines of new copy-paste with the 1% threshold.
>     - Pre-commit hook and CI workflow now use the correct configuration.
>   - **Misc**:
>     - Supports formats: `python`, `javascript`, `bash`, `yaml`, `markdown`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for 8ce9326d06b3f6e1bd7fb7821e9663b5894563a2. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->