### PR TITLE
fix(activity-summary): unset CLAUDECODE for nested claude -p, render themes as list

### DIFF
--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -27,11 +27,19 @@ def call_claude_code(prompt: str, timeout: int = 120) -> str:
         subprocess.TimeoutExpired: If the command times out
         subprocess.CalledProcessError: If the command fails
     """
+    # Allow nesting: unset CLAUDECODE to avoid the nested-session guard
+    # when called from within a Claude Code session (e.g. systemd timer).
+    import os
+
+    env = os.environ.copy()
+    env.pop("CLAUDECODE", None)
+
     result = subprocess.run(
         ["claude", "-p", prompt],
         capture_output=True,
         text=True,
         timeout=timeout,
+        env=env,
     )
     if result.returncode != 0:
         raise subprocess.CalledProcessError(

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/schemas.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/schemas.py
@@ -327,7 +327,7 @@ class DailySummary:
             lines.extend(
                 [
                     "## Themes",
-                    f"*{', '.join(self.themes)}*",
+                    *[f"- {t}" for t in self.themes],
                     "",
                 ]
             )
@@ -420,7 +420,7 @@ class WeeklySummary:
             lines.extend(
                 [
                     "## Recurring Themes",
-                    f"*{', '.join(self.recurring_themes)}*",
+                    *[f"- {t}" for t in self.recurring_themes],
                     "",
                 ]
             )


### PR DESCRIPTION
## Summary
- Unset `CLAUDECODE` env var before `subprocess.run` in `cc_backend.py` to allow nested `claude -p` calls from within a Claude Code session (e.g. systemd timers)
- Render themes/recurring_themes as bullet lists instead of inline italicized comma-separated text for better readability

## Test plan
- [ ] Verify `summarize daily` works from within a Claude Code session
- [ ] Check themes render as bullet list in generated markdown
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Unset `CLAUDECODE` for nested `claude -p` calls and render themes as bullet lists for better readability.
> 
>   - **Behavior**:
>     - Unset `CLAUDECODE` environment variable in `call_claude_code()` in `cc_backend.py` to allow nested `claude -p` calls.
>     - Render `themes` and `recurring_themes` as bullet lists in `to_markdown()` in `schemas.py` for better readability.
>   - **Test Plan**:
>     - Verify `summarize daily` works within a Claude Code session.
>     - Check themes render as bullet lists in generated markdown.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for 2a620961d83d6e4438025590ba35c97f2741b4ca. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->