### PR TITLE
feat(gptodo): add concurrency limit for spawn command

### DIFF
--- a/packages/gptodo/tests/test_subagent.py
+++ b/packages/gptodo/tests/test_subagent.py
@@ -1,0 +1,81 @@
+"""Tests for subagent session management."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from gptodo.subagent import (
+    AgentSession,
+    save_session,
+    load_session,
+    list_sessions,
+)
+
+
+@pytest.fixture
+def sessions_dir(tmp_path):
+    """Create a temporary sessions directory."""
+    sd = tmp_path / "state" / "sessions"
+    sd.mkdir(parents=True)
+    return tmp_path
+
+
+def _make_session(
+    session_id: str = "test-abc123",
+    task_id: str = "my-task",
+    status: str = "running",
+    **kwargs,
+) -> AgentSession:
+    return AgentSession(
+        session_id=session_id,
+        task_id=task_id,
+        agent_type=kwargs.get("agent_type", "general"),
+        backend=kwargs.get("backend", "gptme"),
+        started=kwargs.get("started", datetime.now(timezone.utc).isoformat()),
+        status=status,
+        tmux_session=kwargs.get("tmux_session"),
+        output_file=kwargs.get("output_file"),
+    )
+
+
+def test_save_and_load_session(sessions_dir):
+    session = _make_session()
+    save_session(session, sessions_dir)
+    loaded = load_session("test-abc123", sessions_dir)
+    assert loaded is not None
+    assert loaded.session_id == "test-abc123"
+    assert loaded.task_id == "my-task"
+    assert loaded.status == "running"
+
+
+def test_list_sessions_all(sessions_dir):
+    save_session(_make_session("s1", status="running"), sessions_dir)
+    save_session(_make_session("s2", status="completed"), sessions_dir)
+    save_session(_make_session("s3", status="running"), sessions_dir)
+
+    all_sessions = list_sessions(sessions_dir)
+    assert len(all_sessions) == 3
+
+
+def test_list_sessions_by_status(sessions_dir):
+    save_session(_make_session("s1", status="running"), sessions_dir)
+    save_session(_make_session("s2", status="completed"), sessions_dir)
+    save_session(_make_session("s3", status="running"), sessions_dir)
+
+    running = list_sessions(sessions_dir, status="running")
+    assert len(running) == 2
+
+    completed = list_sessions(sessions_dir, status="completed")
+    assert len(completed) == 1
+
+
+def test_load_nonexistent_session(sessions_dir):
+    loaded = load_session("nonexistent", sessions_dir)
+    assert loaded is None
+
+
+def test_load_corrupted_session(sessions_dir):
+    sd = sessions_dir / "state" / "sessions"
+    (sd / "corrupt.json").write_text("not valid json")
+    loaded = load_session("corrupt", sessions_dir)
+    assert loaded is None


### PR DESCRIPTION
## Summary
- Adds `--max-concurrent` option to `gptodo spawn` (default 4) to prevent overwhelming the system with unlimited background agents
- Before spawning, reconciles session state with actual tmux sessions to get accurate running count
- Adds `test_subagent.py` with tests for session save/load/list operations

## Test plan
- [x] All 55 gptodo tests pass
- [x] Typecheck passes for gptodo package
- [ ] Manual: spawn 4 agents, verify 5th is blocked with helpful message
- [ ] Manual: kill an agent, verify spawn succeeds again
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds concurrency limit to `gptodo spawn` command and tests for session management.
> 
>   - **Behavior**:
>     - Adds `--max-concurrent` option to `gptodo spawn` command in `cli.py`, defaulting to 4, to limit concurrent background agents.
>     - Reconciles session state with actual tmux sessions to ensure accurate running count before spawning.
>   - **Tests**:
>     - Adds `test_subagent.py` with tests for session save/load and list operations, including edge cases like nonexistent and corrupted sessions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for 5d329700b4169d4c6f4e14499ca4d9821fad557f. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->