### PR TITLE
fix(scripts): use $((i + 1)) instead of ((i++)) in repo-status.sh

### DIFF
--- a/scripts/github/repo-status.sh
+++ b/scripts/github/repo-status.sh
@@ -95,7 +95,7 @@ if [ $# -gt 0 ]; then
         else
             check_repo "$arg" > "$TMPDIR/$i.txt" 2>&1 &
         fi
-        ((i++))
+        i=$((i + 1))
     done
     wait  # Wait for all parallel checks to complete
 
@@ -138,7 +138,7 @@ except Exception:
     i=0
     while read -r repo; do
         [ -n "$repo" ] && check_repo "$repo" > "$TMPDIR/$i.txt" 2>&1 &
-        ((i++))
+        i=$((i + 1))
     done <<< "$all_repos"
     wait
 


### PR DESCRIPTION
## Summary
- Fix `repo-status.sh` silently failing due to `set -e` + `((i++))` interaction
- When `i=0`, `((i++))` evaluates `((0))` which is false (exit code 1), causing immediate script exit
- Replace with `i=$((i + 1))` which is an assignment and always succeeds

## Test plan
- [x] Verified `repo-status.sh` now produces output (was previously silent exit 1)
- [x] All 16 repos checked successfully with correct status display
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes premature exit in `repo-status.sh` by replacing `((i++))` with `i=$((i + 1))`, ensuring proper iteration over repositories.
> 
>   - **Behavior**:
>     - Fixes premature script exit in `repo-status.sh` by replacing `((i++))` with `i=$((i + 1))`.
>     - Ensures script continues execution when iterating over repositories.
>   - **Testing**:
>     - Verified script now produces output and checks all 16 repositories successfully.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for 7bd6c5ee3f38781f8d3db17cb4a4de52487c0130. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->