### PR TITLE
fix(scripts): fix output ordering and use GH_USER in repo-status.sh

### DIFF
--- a/scripts/github/repo-status.sh
+++ b/scripts/github/repo-status.sh
@@ -99,9 +99,9 @@ if [ $# -gt 0 ]; then
     done
     wait  # Wait for all parallel checks to complete
 
-    # Print results in order
-    for f in "$TMPDIR"/*.txt; do
-        cat "$f"
+    # Print results in order (iterate by index to handle 10+ repos correctly)
+    for j in $(seq 0 $((i - 1))); do
+        [ -f "$TMPDIR/$j.txt" ] && cat "$TMPDIR/$j.txt"
     done
 else
     # Dynamically build repo list: gptme org (non-archived) + recently updated personal repos
@@ -111,7 +111,7 @@ else
 
     # Fetch repo lists in parallel
     gh repo list gptme --no-archived --json nameWithOwner --jq '.[].nameWithOwner' --limit 30 > "$TMPDIR/org_repos.txt" 2>/dev/null &
-    gh repo list ErikBjare --no-archived --source --json nameWithOwner,pushedAt --limit 10 > "$TMPDIR/personal_repos.json" 2>/dev/null &
+    gh repo list "${GH_USER:-ErikBjare}" --no-archived --source --json nameWithOwner,pushedAt --limit 10 > "$TMPDIR/personal_repos.json" 2>/dev/null &
     wait
 
     # Get 5 most recently pushed personal repos
@@ -142,8 +142,8 @@ except Exception:
     done <<< "$all_repos"
     wait
 
-    # Print results in order
-    for f in "$TMPDIR"/[0-9]*.txt; do
-        [ -f "$f" ] && cat "$f"
+    # Print results in order (iterate by index to handle 10+ repos correctly)
+    for j in $(seq 0 $((i - 1))); do
+        [ -f "$TMPDIR/$j.txt" ] && cat "$TMPDIR/$j.txt"
     done
 fi


### PR DESCRIPTION
## Summary
- Fix lexicographic glob ordering issue with 10+ repos — `10.txt` sorted before `2.txt` with `*.txt` glob. Replaced with index-based iteration using `seq`.
- Use `$GH_USER` variable (with `ErikBjare` fallback) instead of hardcoded username for personal repo listing, making the script portable to other users.

## Context
These pre-existing bugs were identified by Greptile review on PR #303.

## Test plan
- [ ] Run `repo-status.sh` with >10 repo arguments and verify ordering
- [ ] Run with `GH_USER` unset (should default to ErikBjare)
- [ ] Run with custom `GH_USER` set
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes output ordering for 10+ repos and uses `GH_USER` in `repo-status.sh` for improved portability.
> 
>   - **Behavior**:
>     - Fixes output ordering for 10+ repos in `repo-status.sh` by iterating with `seq` instead of using a glob pattern.
>     - Uses `$GH_USER` variable with fallback to `ErikBjare` for personal repo listing, enhancing script portability.
>   - **Misc**:
>     - Identified issues were found during Greptile review on PR #303.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for ea1d74f3c8ffec5ac355c38285e7509a0b83823b. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->