### PR TITLE
feat(gptodo): dependency-aware queue generation with unblocking power

### DIFF
--- a/packages/gptodo/tests/test_generate_queue.py
+++ b/packages/gptodo/tests/test_generate_queue.py
@@ -1,0 +1,219 @@
+"""Tests for generate_queue dependency filtering and unblocking power."""
+
+from pathlib import Path
+
+import pytest
+
+from gptodo.generate_queue import QueueGenerator, Task
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    """Create a workspace with task files for testing."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    journal_dir = tmp_path / "journal"
+    journal_dir.mkdir()
+    return tmp_path
+
+
+def write_task(tasks_dir: Path, name: str, **metadata: object) -> None:
+    """Write a task file with frontmatter."""
+    lines = ["---"]
+    for key, value in metadata.items():
+        if isinstance(value, list):
+            lines.append(f"{key}:")
+            for item in value:
+                lines.append(f"  - {item}")
+        else:
+            lines.append(f"{key}: {value}")
+    lines.append("---")
+    lines.append(f"# {name}")
+    (tasks_dir / f"{name}.md").write_text("\n".join(lines))
+
+
+class TestFilterBlockedTasks:
+    def test_no_requires(self, workspace: Path) -> None:
+        """Tasks without requires should pass through."""
+        write_task(workspace / "tasks", "task-a", state="active", priority="high")
+
+        gen = QueueGenerator(workspace)
+        tasks = [Task(id="task-a", title="A", priority="high", state="active", source="tasks")]
+        result = gen.filter_blocked_tasks(tasks)
+        assert len(result) == 1
+
+    def test_resolved_requires(self, workspace: Path) -> None:
+        """Tasks whose requires are done should pass through."""
+        write_task(workspace / "tasks", "dep-task", state="done", priority="medium")
+        write_task(
+            workspace / "tasks", "task-a", state="active", priority="high", requires=["dep-task"]
+        )
+
+        gen = QueueGenerator(workspace)
+        tasks = [
+            Task(
+                id="task-a",
+                title="A",
+                priority="high",
+                state="active",
+                source="tasks",
+                requires=["dep-task"],
+            )
+        ]
+        result = gen.filter_blocked_tasks(tasks)
+        assert len(result) == 1
+
+    def test_unresolved_requires(self, workspace: Path) -> None:
+        """Tasks whose requires are not done should be filtered out."""
+        write_task(workspace / "tasks", "dep-task", state="active", priority="medium")
+        write_task(
+            workspace / "tasks", "task-a", state="active", priority="high", requires=["dep-task"]
+        )
+
+        gen = QueueGenerator(workspace)
+        tasks = [
+            Task(
+                id="task-a",
+                title="A",
+                priority="high",
+                state="active",
+                source="tasks",
+                requires=["dep-task"],
+            )
+        ]
+        result = gen.filter_blocked_tasks(tasks)
+        assert len(result) == 0
+
+    def test_cancelled_dep_counts_as_resolved(self, workspace: Path) -> None:
+        """Cancelled dependencies should count as resolved."""
+        write_task(workspace / "tasks", "dep-task", state="cancelled", priority="medium")
+
+        gen = QueueGenerator(workspace)
+        tasks = [
+            Task(
+                id="task-a",
+                title="A",
+                priority="high",
+                state="active",
+                source="tasks",
+                requires=["dep-task"],
+            )
+        ]
+        result = gen.filter_blocked_tasks(tasks)
+        assert len(result) == 1
+
+    def test_archived_dep_resolved(self, workspace: Path) -> None:
+        """Dependencies in archive/ should be checked."""
+        archive_dir = workspace / "tasks" / "archive"
+        archive_dir.mkdir()
+        write_task(archive_dir, "dep-task", state="done", priority="medium")
+
+        gen = QueueGenerator(workspace)
+        tasks = [
+            Task(
+                id="task-a",
+                title="A",
+                priority="high",
+                state="active",
+                source="tasks",
+                requires=["dep-task"],
+            )
+        ]
+        result = gen.filter_blocked_tasks(tasks)
+        assert len(result) == 1
+
+    def test_url_requires_skipped(self, workspace: Path) -> None:
+        """URL-based requires should be skipped (no cache)."""
+        gen = QueueGenerator(workspace)
+        tasks = [
+            Task(
+                id="task-a",
+                title="A",
+                priority="high",
+                state="active",
+                source="tasks",
+                requires=["https://github.com/org/repo/issues/1"],
+            )
+        ]
+        result = gen.filter_blocked_tasks(tasks)
+        assert len(result) == 1
+
+
+class TestComputeUnblockingPower:
+    def test_no_dependents(self, workspace: Path) -> None:
+        """Tasks that nothing depends on should have 0 unblocking power."""
+        write_task(workspace / "tasks", "task-a", state="active", priority="high")
+
+        gen = QueueGenerator(workspace)
+        tasks = [Task(id="task-a", title="A", priority="high", state="active", source="tasks")]
+        gen.compute_unblocking_power(tasks)
+        assert tasks[0].unblocking_power == 0
+
+    def test_direct_dependent(self, workspace: Path) -> None:
+        """Tasks with one direct dependent should have unblocking power 1."""
+        write_task(workspace / "tasks", "task-a", state="active", priority="high")
+        write_task(
+            workspace / "tasks", "task-b", state="new", priority="medium", requires=["task-a"]
+        )
+
+        gen = QueueGenerator(workspace)
+        tasks = [Task(id="task-a", title="A", priority="high", state="active", source="tasks")]
+        gen.compute_unblocking_power(tasks)
+        assert tasks[0].unblocking_power == 1
+
+    def test_transitive_dependents(self, workspace: Path) -> None:
+        """Transitive dependents should be counted."""
+        write_task(workspace / "tasks", "task-a", state="active", priority="high")
+        write_task(
+            workspace / "tasks", "task-b", state="new", priority="medium", requires=["task-a"]
+        )
+        write_task(
+            workspace / "tasks", "task-c", state="new", priority="medium", requires=["task-b"]
+        )
+
+        gen = QueueGenerator(workspace)
+        tasks = [Task(id="task-a", title="A", priority="high", state="active", source="tasks")]
+        gen.compute_unblocking_power(tasks)
+        assert tasks[0].unblocking_power == 2
+
+    def test_done_tasks_not_counted(self, workspace: Path) -> None:
+        """Done tasks should not count as dependents."""
+        write_task(workspace / "tasks", "task-a", state="active", priority="high")
+        write_task(
+            workspace / "tasks", "task-b", state="done", priority="medium", requires=["task-a"]
+        )
+
+        gen = QueueGenerator(workspace)
+        tasks = [Task(id="task-a", title="A", priority="high", state="active", source="tasks")]
+        gen.compute_unblocking_power(tasks)
+        assert tasks[0].unblocking_power == 0
+
+    def test_github_tasks_skipped(self, workspace: Path) -> None:
+        """GitHub-sourced tasks should not have unblocking power computed."""
+        gen = QueueGenerator(workspace)
+        tasks = [Task(id="issue-1", title="GH", priority="high", state="active", source="github")]
+        gen.compute_unblocking_power(tasks)
+        assert tasks[0].unblocking_power == 0
+
+
+class TestPriorityScoreWithUnblocking:
+    def test_unblocking_boosts_priority(self) -> None:
+        """Tasks with higher unblocking power should score higher."""
+        task_a = Task(id="a", title="A", priority="medium", state="active", source="tasks")
+        task_b = Task(id="b", title="B", priority="medium", state="active", source="tasks")
+        task_a.unblocking_power = 3
+        task_b.unblocking_power = 0
+
+        assert task_a.priority_score() > task_b.priority_score()
+
+    def test_unblocking_can_outrank_priority(self) -> None:
+        """A medium-priority task unblocking 3 should outrank a high-priority task unblocking 0."""
+        task_medium = Task(id="m", title="M", priority="medium", state="active", source="tasks")
+        task_high = Task(id="h", title="H", priority="high", state="active", source="tasks")
+        task_medium.unblocking_power = 3
+        task_high.unblocking_power = 0
+
+        # medium (2) + 3 = 5 > high (3) + 0 = 3
+        assert task_medium.priority_score() > task_high.priority_score()


### PR DESCRIPTION
## Summary
- `generate-queue` now filters out blocked tasks (those with unresolved `requires`/`depends`)
- Computes "unblocking power" — how many tasks each task transitively unblocks — and uses it as a priority score boost
- A medium-priority task that unblocks 3 downstream tasks now ranks higher than a high-priority task that unblocks nothing
- Checks both `tasks/` and `tasks/archive/` for dependency resolution
- Shows unblocking power in queue entry output

## Context
Previously `generate_queue.py` completely ignored the `requires`/`depends` fields in task frontmatter. This meant blocked tasks could appear in the queue, and the queue didn't prioritize tasks based on their "critical path" importance.

The existing dependency infrastructure in gptodo (ready checks, cycle detection, dep-tree) was already mature — this PR closes the gap in queue generation.

Related to: `tasks/task-dependency-dag.md` (Phase 2: Smart Queue Generation)

## Test plan
- [x] 13 new tests covering filter_blocked_tasks, compute_unblocking_power, and priority scoring
- [x] Type checking passes
- [x] Manual test with real task set (`generate-queue --workspace /home/bob/bob`)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances `generate-queue` to filter blocked tasks and compute unblocking power for priority scoring, with tests added.
> 
>   - **Behavior**:
>     - `generate-queue` filters out tasks with unresolved dependencies (`requires`/`depends`).
>     - Computes unblocking power for tasks, boosting priority scores for tasks that unblock more downstream tasks.
>     - Tasks in `tasks/` and `tasks/archive/` are checked for dependency resolution.
>     - Displays unblocking power in queue entry output.
>   - **Functions**:
>     - `filter_blocked_tasks()` in `generate_queue.py` filters tasks with unmet dependencies.
>     - `compute_unblocking_power()` in `generate_queue.py` calculates unblocking power for tasks.
>     - `priority_score()` in `Task` class now includes unblocking power in score calculation.
>   - **Tests**:
>     - 13 new tests in `test_generate_queue.py` for `filter_blocked_tasks`, `compute_unblocking_power`, and priority scoring.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for d776230ef4d1c4970791ec71da69ae6cff8c80f5. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->