### PR TITLE
fix(gptodo): use precise URL scheme check to avoid false matches on task IDs

### DIFF
--- a/packages/gptodo/src/gptodo/checker.py
+++ b/packages/gptodo/src/gptodo/checker.py
@@ -141,7 +141,7 @@ def check_dependency_resolution(task: TaskInfo, all_tasks: dict[str, TaskInfo]) 
     resolved: list[str] = []
 
     for dep in task.requires:
-        if dep.startswith("http"):
+        if dep.startswith(("http://", "https://")):
             # URL dependency - can't check without cache
             continue
         dep_task = all_tasks.get(dep)
@@ -153,7 +153,7 @@ def check_dependency_resolution(task: TaskInfo, all_tasks: dict[str, TaskInfo]) 
             resolved.append(dep)
 
     # Exclude URL deps from total since they're skipped
-    url_deps = sum(1 for dep in task.requires if dep.startswith("http"))
+    url_deps = sum(1 for dep in task.requires if dep.startswith(("http://", "https://")))
     details["resolved"] = resolved
     details["unresolved"] = unresolved
     details["total"] = len(task.requires) - url_deps

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -319,7 +319,7 @@ def effective(task_id: str):
     if task.requires:
         console.print("\n[bold]Requirements:[/]")
         for req in task.requires:
-            if isinstance(req, str) and req.startswith("http"):
+            if isinstance(req, str) and req.startswith(("http://", "https://")):
                 # URL requirement
                 cached = issue_cache.get(req) if issue_cache else None
                 if cached:

--- a/packages/gptodo/src/gptodo/deptree.py
+++ b/packages/gptodo/src/gptodo/deptree.py
@@ -49,7 +49,7 @@ def build_dependency_graph(
 
         # Process requires (what this task depends on)
         for req in task.requires:
-            if req.startswith("http"):
+            if req.startswith(("http://", "https://")):
                 # URL dependency - create a placeholder node
                 short_name = req[:50] + "..." if len(req) > 50 else req
                 if req not in nodes:

--- a/packages/gptodo/src/gptodo/unblock.py
+++ b/packages/gptodo/src/gptodo/unblock.py
@@ -157,7 +157,7 @@ def auto_unblock_tasks(
             all_deps_done = True
             for dep_name in task_requires:
                 # Skip URL-based dependencies
-                if isinstance(dep_name, str) and dep_name.startswith("http"):
+                if isinstance(dep_name, str) and dep_name.startswith(("http://", "https://")):
                     continue
                 dep_task = all_tasks_dict.get(dep_name)
                 if dep_task and dep_task.state not in ["done", "cancelled"]:

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -827,7 +827,7 @@ def is_task_ready(
     url_requires = []
     task_requires = []
     for req in requires:
-        if isinstance(req, str) and req.startswith("http"):
+        if isinstance(req, str) and req.startswith(("http://", "https://")):
             url_requires.append(req)
         else:
             task_requires.append(req)
@@ -891,7 +891,7 @@ def compute_effective_state(
 
     # Check each dependency
     for req in requires:
-        if isinstance(req, str) and req.startswith("http"):
+        if isinstance(req, str) and req.startswith(("http://", "https://")):
             # URL-based dependency - check cache
             if issue_cache:
                 cached = issue_cache.get(req)
@@ -942,7 +942,7 @@ def get_blocking_reasons(
 
     reasons = []
     for req in requires:
-        if isinstance(req, str) and req.startswith("http"):
+        if isinstance(req, str) and req.startswith(("http://", "https://")):
             # URL-based dependency
             if issue_cache:
                 cached = issue_cache.get(req)
@@ -1273,9 +1273,9 @@ def extract_external_urls(task: TaskInfo) -> List[str]:
     if tracking:
         if isinstance(tracking, list):
             for item in tracking:
-                if isinstance(item, str) and item.startswith("http"):
+                if isinstance(item, str) and item.startswith(("http://", "https://")):
                     urls.append(item)
-        elif isinstance(tracking, str) and tracking.startswith("http"):
+        elif isinstance(tracking, str) and tracking.startswith(("http://", "https://")):
             urls.append(tracking)
 
     # Check blocks field
@@ -1283,9 +1283,9 @@ def extract_external_urls(task: TaskInfo) -> List[str]:
     if blocks:
         if isinstance(blocks, list):
             for item in blocks:
-                if isinstance(item, str) and item.startswith("http"):
+                if isinstance(item, str) and item.startswith(("http://", "https://")):
                     urls.append(item)
-        elif isinstance(blocks, str) and blocks.startswith("http"):
+        elif isinstance(blocks, str) and blocks.startswith(("http://", "https://")):
             urls.append(blocks)
 
     # Check related field
@@ -1293,9 +1293,9 @@ def extract_external_urls(task: TaskInfo) -> List[str]:
     if related:
         if isinstance(related, list):
             for item in related:
-                if isinstance(item, str) and item.startswith("http"):
+                if isinstance(item, str) and item.startswith(("http://", "https://")):
                     urls.append(item)
-        elif isinstance(related, str) and related.startswith("http"):
+        elif isinstance(related, str) and related.startswith(("http://", "https://")):
             urls.append(related)
 
     return urls


### PR DESCRIPTION
## Summary
- Fixes `startswith("http")` incorrectly matching task IDs like `http-client-setup` as URLs
- Updated all 14 remaining occurrences across 5 files to use `startswith(("http://", "https://"))`
- Follows the same fix pattern already applied in `generate_queue.py` (commit 3ccd5e4)

**Files changed:** `checker.py`, `cli.py`, `deptree.py`, `unblock.py`, `utils.py`

## Test plan
- [x] All 71 gptodo tests pass
- [x] Verified zero remaining `startswith("http")` occurrences
- [x] The correct 2-tuple pattern now used consistently in all 16 URL checks
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes incorrect URL matching for task IDs by updating URL scheme checks across multiple files.
> 
>   - **Behavior**:
>     - Fixes `startswith("http")` incorrectly matching task IDs like `http-client-setup` as URLs.
>     - Updates all 14 occurrences across 5 files to use `startswith(("http://", "https://"))`.
>     - Follows the same fix pattern already applied in `generate_queue.py`.
>   - **Files Changed**:
>     - `checker.py`: Updates URL scheme check in `check_dependency_resolution()`.
>     - `cli.py`: Updates URL scheme check in `effective()`.
>     - `deptree.py`: Updates URL scheme check in `build_dependency_graph()`.
>   - **Testing**:
>     - All 71 gptodo tests pass.
>     - Verified zero remaining `startswith("http")` occurrences.
>     - Consistent use of 2-tuple pattern in all 16 URL checks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for f63aa01878f493df2ac26404fabe223447e839eb. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->