### PR TITLE
fix(lessons): add pre-flight comment check to prevent agent duplicate actions

### DIFF
--- a/lessons/social/github-issue-engagement.md
+++ b/lessons/social/github-issue-engagement.md
@@ -46,7 +46,7 @@ Check, read full context, coordinate, work, then update:
 
 ```shell
 # 0. Pre-flight: Check own previous actions (CRITICAL for agents)
-gh issue view <number> --comments | grep -A5 "<your-handle>"
+gh issue view <number> --comments | grep -A5 "$(gh api user --jq .login)"
 # If you already commented/acted → DON'T duplicate. Update existing if needed.
 
 # 1. Search for existing work


### PR DESCRIPTION
## Summary

- Add step 0 "check own previous comments" to the GitHub issue engagement lesson
- Prevents agents from creating duplicate issues/PRs/comments when returning to threads across sessions
- Add keywords for duplicate prevention triggering

## Context

From the alice#4 incident where Alice created ~6 duplicate issues because she never checked her own previous comments when returning to a thread. Filed as ErikBjare/bob#319.

The root cause: agents don't reliably recall recent actions taken in the same thread across sessions. The fix is a pre-flight check before engaging with any issue/PR.

## Test plan

- [ ] Verify lesson validates (`validate.py`)
- [ ] Verify keywords trigger appropriately in gptme sessions
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds pre-flight comment check to `github-issue-engagement.md` to prevent duplicate actions by agents.
> 
>   - **Behavior**:
>     - Adds step 0 "check own previous comments" to `github-issue-engagement.md` to prevent duplicate issues/PRs/comments by agents.
>     - Introduces keywords "check own previous comments" and "agent created duplicate issues" for duplicate prevention.
>   - **Context**:
>     - Addresses issue from incident alice#4 where duplicate issues were created due to lack of comment checks.
>     - Root cause: agents not recalling recent actions across sessions.
>   - **Test Plan**:
>     - Verify lesson validates with `validate.py`.
>     - Ensure keywords trigger in gptme sessions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for 74605d9c130b8a425b4e790e12b2dd010ea85e66. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->