### PR TITLE
fix(lessons): add duplicate comment prevention to github-issue-engagement

### DIFF
--- a/lessons/social/github-issue-engagement.md
+++ b/lessons/social/github-issue-engagement.md
@@ -13,13 +13,16 @@ match:
   - "gh issue"
   - "check own previous comments"
   - "agent created duplicate issues"
+  - "duplicate comment prevention"
+  - "triple posted"
+  - "comment spam"
 status: active
 ---
 
 # GitHub Issue and PR Engagement
 
 ## Rule
-Always search for existing issues/PRs before creating new ones, read full context before engaging, and update issues/PRs after completing work.
+Always search for existing issues/PRs before creating new ones, read full context before engaging, check your own previous comments before posting, and update issues/PRs after completing work.
 
 ## Context
 When planning to work on a feature, fix, or improvement in any GitHub repository, and after completing work in response to comments.
@@ -46,8 +49,14 @@ Check, read full context, coordinate, work, then update:
 
 ```shell
 # 0. Pre-flight: Check own previous actions (CRITICAL for agents)
-gh issue view <number> --comments | grep -A5 "$(gh api user --jq .login)"
+MY_LOGIN=$(gh api user --jq .login)
+gh issue view <number> --comments | grep -A5 "$MY_LOGIN"
 # If you already commented/acted → DON'T duplicate. Update existing if needed.
+
+# 0b. For cross-repo issues, check with API for precise matching
+gh api repos/<owner>/<repo>/issues/<number>/comments \
+  --jq "[.[] | select(.user.login == \"$MY_LOGIN\")] | length"
+# If count > 0 → you already commented. Do NOT post again.
 
 # 1. Search for existing work
 gh issue list --repo owner/repo --search "topic keywords"
@@ -78,6 +87,25 @@ Details:
 - [Any remaining work]"
 ```
 
+## Anti-Pattern: Duplicate Comments
+
+**Real failure (2026-02-22)**: Bob triple-posted the same "Submitted a fix" comment on ActivityWatch/aw-webui#590. Three autonomous sessions each independently discovered the issue, worked on it, and posted a comment — none checked whether a previous session had already commented.
+
+**Root cause**: Multiple autonomous sessions run independently. Each "discovers" the same issue and comments without checking existing comments first. Without dedup, N sessions = N identical comments = spam.
+
+**Prevention**: Before posting ANY comment on an issue or PR, check your own existing comments:
+
+```shell
+# Check if you already commented on this issue
+MY_LOGIN=$(gh api user --jq .login)
+EXISTING=$(gh api repos/<owner>/<repo>/issues/<number>/comments \
+  --jq "[.[] | select(.user.login == \"$MY_LOGIN\")] | length")
+if [ "$EXISTING" -gt 0 ]; then
+  echo "Already commented — skipping to avoid duplicate"
+  # If you need to update, edit the existing comment instead
+fi
+```
+
 ## Outcome
 Following this pattern results in:
 - No duplicate work (saves hours of wasted effort)
@@ -88,6 +116,7 @@ Following this pattern results in:
 - **Clear status tracking** (maintainers know what's done)
 - **No confusion in future runs** (autonomous agents see completed work)
 - **Professional workflow** (closes communication loop)
+- **No comment spam** (each autonomous session checks before posting)
 
 ## Related
 - [Read Full GitHub Context](../workflow/read-full-github-context.md) - Why both views matter


### PR DESCRIPTION
Adds explicit anti-pattern documentation and prevention steps for the duplicate comment issue (Bob triple-posted on ActivityWatch/aw-webui#590).

Changes:
- Added keywords for lesson matching: "duplicate comment prevention", "triple posted", "comment spam"
- Added API-based dedup check in step 0b of the Pattern section
- Added Anti-Pattern section with real failure example and concrete `gh api` prevention commands
- Updated Rule to mention checking previous comments before posting
- Added "No comment spam" outcome bullet

Triggered by Erik flagging the triple-comment spam.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds duplicate comment prevention steps and documentation to `github-issue-engagement.md`, including API checks and anti-pattern examples.
> 
>   - **Behavior**:
>     - Adds API-based deduplication check in step 0b of the Pattern section in `github-issue-engagement.md`.
>     - Updates Rule to include checking previous comments before posting.
>     - Adds "No comment spam" to Outcome section.
>   - **Documentation**:
>     - Adds Anti-Pattern section with real failure example and `gh api` prevention commands.
>     - Adds keywords for lesson matching: "duplicate comment prevention", "triple posted", "comment spam".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for a227fd15476c3b765b7c030ad2c88720ea9ef9ba. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->