### PR TITLE
fix(twitter): make TweetDraft.from_dict resilient to alternate field names

### DIFF
--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -238,7 +238,7 @@ class TweetDraft:
         """
         draft = cls(
             text=data.get("text", data.get("content", "")),
-            type=data["type"],
+            type=data.get("type", "tweet"),
             in_reply_to=data.get("in_reply_to"),
             scheduled_time=(
                 data["scheduled_time"]


### PR DESCRIPTION
## Summary

- Accept `content` as fallback for `text` field in tweet draft YAML files
- Accept `created` as fallback for `created_at` field
- Make `context` field optional (defaults to empty dict)
- Handle `date` objects in addition to `datetime` and strings for `created_at`

This fixes `KeyError: 'text'` crashes when loading manually-created draft files that use slightly different field names than what the code generates programmatically.

## Test plan

- [x] Verified alternate field names (`content`, `created`, no `context`) parse correctly
- [x] Verified standard field names (`text`, `created_at`, `context`) still work
- [x] Verified missing `created_at` defaults to `datetime.now()`
- [x] Verified `datetime` and `date` objects both work for `created_at`/`created`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `TweetDraft.from_dict` now supports alternate field names and `date` objects for `created_at`, improving resilience to manually-created drafts.
> 
>   - **Behavior**:
>     - `TweetDraft.from_dict` now accepts `content` as a fallback for `text` and `created` for `created_at`.
>     - `context` field is optional and defaults to an empty dict.
>     - Handles `date` objects for `created_at`, converting them to `datetime`.
>     - Defaults `created_at` to `datetime.now()` if missing.
>   - **Misc**:
>     - Import `date` from `datetime` in `workflow.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for 8a0ae5fccb2be609476cccb3728997fd5d1a40d9. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->