### PR TITLE
fix(plugins): fix test failures in attention-tracker and example-hooks

### DIFF
--- a/plugins/gptme-hooks-examples/src/gptme_example_hooks/hooks/example_hooks.py
+++ b/plugins/gptme-hooks-examples/src/gptme_example_hooks/hooks/example_hooks.py
@@ -51,7 +51,7 @@ def tool_pre_execute_hook(
     """Hook that runs before any tool executes.
 
     Demonstrates:
-    - TOOL_EXECUTE_PRE hook type
+    - TOOL_PRE_EXECUTE hook type
     - Accessing tool information
     - Validating or logging tool usage
 
@@ -74,10 +74,10 @@ def tool_pre_execute_hook(
 def message_post_process_hook(
     manager: "LogManager",
 ) -> Generator[Message, None, None]:
-    """Hook that runs after a complete turn (all steps done).
+    """Hook that runs after processing a message.
 
     Demonstrates:
-    - TURN_POST hook type
+    - MESSAGE_POST_PROCESS hook type
     - Accessing conversation state via LogManager
     - Reacting to processed messages
 
@@ -126,15 +126,15 @@ def register() -> None:
     # Register tool pre-execute hook (default priority 0)
     register_hook(
         name="example_hooks.tool_pre_execute",
-        hook_type=HookType.TOOL_EXECUTE_PRE,
+        hook_type=HookType.TOOL_PRE_EXECUTE,
         func=tool_pre_execute_hook,
         priority=0,
     )
 
-    # Register turn post hook (priority -100 - runs late)
+    # Register message post-process hook (priority -100 - runs late)
     register_hook(
-        name="example_hooks.turn_post",
-        hook_type=HookType.TURN_POST,
+        name="example_hooks.message_post_process",
+        hook_type=HookType.MESSAGE_POST_PROCESS,
         func=message_post_process_hook,
         priority=-100,
     )


### PR DESCRIPTION
## Summary
- **attention-tracker**: Fix `test_batch_threshold_auto_flush` by falling back to internal `pending_turns` counter when `get_turns_since_invalidation()` returns 0 (happens in tests or when no conversation is actively running)
- **example-hooks**: Fix `test_register` by using correct `HookType` enum values (`TOOL_EXECUTE_PRE` instead of `TOOL_PRE_EXECUTE`, `TURN_POST` instead of `MESSAGE_POST_PROCESS`)

## Test plan
- [x] All 26 attention-tracker tests pass
- [x] All 6 example-hooks tests pass
- [x] Pre-commit checks pass
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix test failures in `attention-tracker` by adjusting turn counting logic and in `example-hooks` by correcting `HookType` enum values.
> 
>   - **attention-tracker**:
>     - Fix `test_batch_threshold_auto_flush` in `attention_router.py` by using `pending_turns` when `get_turns_since_invalidation()` returns 0.
>   - **example-hooks**:
>     - Fix `test_register` in `example_hooks.py` by correcting `HookType` enum values: `TOOL_EXECUTE_PRE` instead of `TOOL_PRE_EXECUTE`, `TURN_POST` instead of `MESSAGE_POST_PROCESS`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for 4818ab7af4069c1b1f4b017756e4638e69e4b5b3. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->