### PR TITLE
fix(email): add consecutive-failure backoff to prevent over-triggering

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/email.py
+++ b/packages/gptme-runloops/src/gptme_runloops/email.py
@@ -1,11 +1,27 @@
-"""Email processing run loop implementation."""
+"""Email processing run loop implementation.
 
+Includes consecutive-failure backoff: if the same set of unreplied emails
+keeps appearing after execution (indicating the LLM couldn't process them,
+e.g. due to auth errors), we progressively skip runs to avoid burning tokens.
+"""
+
+import hashlib
+import json
 import subprocess
 from pathlib import Path
+from typing import Any
 
 from gptme_runloops.base import BaseRunLoop
 from gptme_runloops.utils.execution import ExecutionResult
 from gptme_runloops.utils.prompt import generate_base_prompt, get_agent_name
+
+# Backoff schedule: after N consecutive failures, skip runs
+# Maps threshold -> (skip_probability, description)
+_BACKOFF_SCHEDULE = [
+    (8, 7, 8, "skip 7/8 runs (~40 min between attempts)"),
+    (5, 3, 4, "skip 3/4 runs (~20 min between attempts)"),
+    (3, 1, 2, "skip 1/2 runs (~10 min between attempts)"),
+]
 
 
 class EmailRun(BaseRunLoop):
@@ -15,6 +31,10 @@ class EmailRun(BaseRunLoop):
     - Sync emails via mbsync (in has_work, before lock)
     - Check for unreplied emails (in has_work, before lock)
     - Process with gptme if emails found (after lock acquired)
+
+    Includes failure backoff: tracks consecutive runs where the same
+    unreplied emails persist after execution, and progressively skips
+    runs to avoid wasting tokens on unresolvable emails.
     """
 
     def __init__(
@@ -38,6 +58,53 @@ class EmailRun(BaseRunLoop):
             model=model,
             tool_format=tool_format,
         )
+        self._state_file = workspace / "state" / "email-backoff.json"
+        self._current_email_hash: str | None = None
+
+    def _load_backoff_state(self) -> dict[str, Any]:
+        """Load backoff state from disk."""
+        if self._state_file.exists():
+            try:
+                data: dict[str, Any] = json.loads(self._state_file.read_text())
+                return data
+            except (json.JSONDecodeError, OSError):
+                return {}
+        return {}
+
+    def _save_backoff_state(self, state: dict[str, Any]) -> None:
+        """Save backoff state to disk."""
+        self._state_file.parent.mkdir(parents=True, exist_ok=True)
+        self._state_file.write_text(json.dumps(state))
+
+    def _hash_email_set(self, description: str) -> str:
+        """Create a hash of the unreplied email set for change detection."""
+        return hashlib.sha256(description.encode()).hexdigest()[:16]
+
+    def _should_skip_backoff(self) -> bool:
+        """Check if we should skip this run due to consecutive failures.
+
+        Returns:
+            True if this run should be skipped
+        """
+        import random
+
+        state = self._load_backoff_state()
+        failures = state.get("consecutive_failures", 0)
+
+        for threshold, skip_n, out_of, desc in _BACKOFF_SCHEDULE:
+            if failures >= threshold:
+                if random.randint(1, out_of) <= skip_n:
+                    self.logger.info(
+                        f"Email backoff: skipping ({failures} consecutive failures, {desc})"
+                    )
+                    return True
+                else:
+                    self.logger.info(
+                        f"Email backoff: running despite {failures} failures (lucky draw)"
+                    )
+                    return False
+
+        return False
 
     def _sync_emails(self) -> None:
         """Sync emails from server via mbsync."""
@@ -86,6 +153,9 @@ class EmailRun(BaseRunLoop):
         This syncs emails and checks for unreplied ones without taking
         a lock, so runs with no emails don't create calendar entries.
 
+        Also checks backoff state: if the same emails have been seen
+        repeatedly without being resolved, progressively skips runs.
+
         Returns:
             True if there are unreplied emails to process
         """
@@ -107,6 +177,13 @@ class EmailRun(BaseRunLoop):
             # Exit codes: 0=no emails, 1=has emails, 2=error
             if result.returncode == 0:
                 self.logger.info("No unreplied emails found")
+                # Reset backoff on success (emails were resolved)
+                state = self._load_backoff_state()
+                if state.get("consecutive_failures", 0) > 0:
+                    self.logger.info("Email backoff: reset (no unreplied emails)")
+                    self._save_backoff_state(
+                        {"consecutive_failures": 0, "last_hash": ""}
+                    )
                 return False
             elif result.returncode == 1:
                 # Parse output to get email count and first email info
@@ -124,6 +201,25 @@ class EmailRun(BaseRunLoop):
                     desc = f"{count_line} - {sender}: {subject}..."
                 else:
                     desc = count_line
+
+                # Check if this is the same email set we've been failing on
+                self._current_email_hash = self._hash_email_set(output)
+                state = self._load_backoff_state()
+                if state.get("last_hash") == self._current_email_hash:
+                    # Same emails as last time — check backoff
+                    if self._should_skip_backoff():
+                        return False
+                else:
+                    # New email set — reset backoff
+                    if state.get("consecutive_failures", 0) > 0:
+                        self.logger.info("Email backoff: reset (new emails detected)")
+                    self._save_backoff_state(
+                        {
+                            "consecutive_failures": 0,
+                            "last_hash": self._current_email_hash,
+                        }
+                    )
+
                 self._work_description = desc
                 self.logger.info(f"Found {desc}")
                 return True
@@ -205,3 +301,46 @@ Complete when all emails are addressed.
         # has_work() already confirmed there are unreplied emails
         self.logger.info("Processing emails with gptme...")
         return super().execute(prompt)
+
+    def post_run(self, result: ExecutionResult) -> None:
+        """Track whether emails were actually resolved.
+
+        If the same emails are still unreplied after execution,
+        increment the failure counter to trigger backoff.
+        """
+        # Quick re-check: are the same emails still unreplied?
+        try:
+            check = subprocess.run(
+                ["uv", "run", "python3", "-m", "gptmail", "check-unreplied"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                cwd=self.workspace,
+            )
+
+            state = self._load_backoff_state()
+
+            if check.returncode == 0:
+                # All emails resolved — reset backoff
+                self.logger.info("Post-run: all emails resolved, resetting backoff")
+                self._save_backoff_state({"consecutive_failures": 0, "last_hash": ""})
+            elif check.returncode == 1:
+                # Emails still unreplied — increment failure counter
+                post_hash = self._hash_email_set(check.stdout.strip())
+                if post_hash == self._current_email_hash:
+                    failures = state.get("consecutive_failures", 0) + 1
+                    self.logger.warning(
+                        f"Post-run: same emails still unreplied "
+                        f"(consecutive failures: {failures})"
+                    )
+                    self._save_backoff_state(
+                        {"consecutive_failures": failures, "last_hash": post_hash}
+                    )
+                else:
+                    # Different set (some resolved, new ones appeared)
+                    self.logger.info("Post-run: email set changed, resetting backoff")
+                    self._save_backoff_state(
+                        {"consecutive_failures": 0, "last_hash": post_hash}
+                    )
+        except Exception as e:
+            self.logger.error(f"Post-run email check failed: {e}")


### PR DESCRIPTION
## Summary

- Add backoff mechanism to email processing to skip runs after consecutive failures on the same email set
- Prevents situations where auth errors cause the same emails to trigger a new gptme session every 5 minutes indefinitely (burned 113+ sessions in 24h)

## Details

When unreplied emails persist after LLM execution (e.g. due to auth errors), the same emails were triggering new sessions without any progress. This adds:

- Hash the unreplied email set to detect "same emails, no progress"
- After 3 consecutive failures: skip 50% of runs (~10 min interval)
- After 5 failures: skip 75% (~20 min interval)
- After 8 failures: skip 87.5% (~40 min interval)
- Reset when email set changes or all emails are resolved
- State persisted in `workspace/state/email-backoff.json`

## Test plan
- [x] Manual inspection of backoff logic (state file, skip conditions, reset conditions)
- [ ] Verify CI passes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a backoff mechanism in `EmailRun` to manage consecutive email processing failures, reducing unnecessary session triggers.
> 
>   - **Behavior**:
>     - Adds backoff mechanism in `EmailRun` to skip runs after consecutive failures on the same email set.
>     - Hashes unreplied email set to detect unchanged emails.
>     - Implements backoff schedule: skip 50% of runs after 3 failures, 75% after 5, and 87.5% after 8.
>     - Resets backoff when email set changes or all emails are resolved.
>     - State persisted in `email-backoff.json`.
>   - **Functions**:
>     - Adds `_load_backoff_state()`, `_save_backoff_state()`, `_hash_email_set()`, and `_should_skip_backoff()` in `EmailRun`.
>     - Modifies `has_work()` and `post_run()` to integrate backoff logic.
>   - **Misc**:
>     - Updates docstring in `email.py` to reflect new backoff functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for 8a5138ec794c031d1e02e11cd587dec66adda071. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->