### PR TITLE
refactor(run-loops): generalize backoff into BaseRunLoop

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/base.py
+++ b/packages/gptme-runloops/src/gptme_runloops/base.py
@@ -1,8 +1,11 @@
 """Base class for all run loop types."""
 
+import json
+import random
 import time
 from abc import ABC, abstractmethod
 from pathlib import Path
+from typing import Any
 
 from gptme_runloops.utils.execution import ExecutionResult, execute_gptme
 from gptme_runloops.utils.git import git_pull_with_retry
@@ -12,6 +15,16 @@ from gptme_runloops.utils.logging import (
     log_execution_end,
     log_execution_start,
 )
+
+# Backoff schedule for consecutive-failure detection.
+# Each entry: (failure_threshold, skip_n, out_of, description)
+# "skip_n out_of out_of" means skip the run with probability skip_n/out_of.
+# Entries are checked from most severe to least severe.
+BACKOFF_SCHEDULE = [
+    (8, 7, 8, "skip 7/8 runs (~40 min between attempts)"),
+    (5, 3, 4, "skip 3/4 runs (~20 min between attempts)"),
+    (3, 1, 2, "skip 1/2 runs (~10 min between attempts)"),
+]
 
 
 class BaseRunLoop(ABC):
@@ -23,11 +36,17 @@ class BaseRunLoop(ABC):
     - Git operations with retry
     - gptme execution with timeout
     - Cleanup and error handling
+    - Consecutive-failure backoff (opt-in via work_hash in subclasses)
 
     Subclasses override:
     - generate_prompt(): Create run-specific prompt
     - pre_run(): Run-specific preparation
     - post_run(): Run-specific cleanup
+
+    To enable backoff, subclasses call:
+    - _check_backoff(work_hash) in has_work() — returns True if run should be skipped
+    - _record_backoff_success() in post_run() when work was resolved
+    - _record_backoff_failure(work_hash) in post_run() when same work persists
     """
 
     def __init__(
@@ -64,6 +83,99 @@ class BaseRunLoop(ABC):
         self._start_time: float | None = None
         self._work_description: str | None = None  # Description of work found
 
+    # --- Backoff infrastructure ---
+
+    @property
+    def _backoff_state_file(self) -> Path:
+        """Path to the backoff state file for this run type."""
+        return self.workspace / "state" / f"{self.run_type}-backoff.json"
+
+    def _load_backoff_state(self) -> dict[str, Any]:
+        """Load backoff state from disk."""
+        if self._backoff_state_file.exists():
+            try:
+                data: dict[str, Any] = json.loads(self._backoff_state_file.read_text())
+                return data
+            except (json.JSONDecodeError, OSError):
+                return {}
+        return {}
+
+    def _save_backoff_state(self, state: dict[str, Any]) -> None:
+        """Save backoff state to disk."""
+        self._backoff_state_file.parent.mkdir(parents=True, exist_ok=True)
+        self._backoff_state_file.write_text(json.dumps(state))
+
+    def _check_backoff(self, work_hash: str) -> bool:
+        """Check if this run should be skipped due to consecutive failures.
+
+        Call this in has_work() after computing a hash of the current work.
+        If the same work hash has been seen repeatedly without resolution,
+        progressively skips runs to avoid wasting tokens.
+
+        Also resets the backoff counter when a new/different work set is
+        detected (new hash means the situation changed, so retry eagerly).
+
+        Args:
+            work_hash: Hash identifying the current work set. Should change
+                       when the underlying work is resolved or changes.
+
+        Returns:
+            True if this run should be skipped (backed off)
+        """
+        state = self._load_backoff_state()
+        failures = state.get("consecutive_failures", 0)
+
+        if state.get("last_hash") != work_hash:
+            # New/different work — reset backoff and proceed
+            if failures > 0:
+                self.logger.info(
+                    f"Backoff: reset (new work detected, was {failures} failures)"
+                )
+            self._save_backoff_state(
+                {"consecutive_failures": 0, "last_hash": work_hash}
+            )
+            return False
+
+        # Same work as last time — apply schedule
+        for threshold, skip_n, out_of, desc in BACKOFF_SCHEDULE:
+            if failures >= threshold:
+                if random.randint(1, out_of) <= skip_n:
+                    self.logger.info(
+                        f"Backoff: skipping ({failures} consecutive failures, {desc})"
+                    )
+                    return True
+                else:
+                    self.logger.info(
+                        f"Backoff: running despite {failures} failures (lucky draw)"
+                    )
+                    return False
+
+        return False
+
+    def _record_backoff_success(self) -> None:
+        """Record that work was successfully resolved — reset backoff counter."""
+        state = self._load_backoff_state()
+        if state.get("consecutive_failures", 0) > 0:
+            self.logger.info("Backoff: reset (work resolved)")
+        self._save_backoff_state({"consecutive_failures": 0, "last_hash": ""})
+
+    def _record_backoff_failure(self, work_hash: str) -> None:
+        """Record that the same work persists after execution — increment counter.
+
+        Args:
+            work_hash: Hash of the work set that is still unresolved.
+        """
+        state = self._load_backoff_state()
+        failures = state.get("consecutive_failures", 0) + 1
+        self.logger.warning(
+            f"Backoff: same work still unresolved (consecutive failures: {failures})"
+        )
+        self._save_backoff_state(
+            {"consecutive_failures": failures, "last_hash": work_hash}
+        )
+
+    # --- Run loop lifecycle ---
+
     def setup(self) -> bool:
         """Acquire lock and perform initial setup.
 
@@ -95,6 +207,9 @@ class BaseRunLoop(ABC):
         entries for runs that don't actually do anything.
 
         If work is found, set self._work_description to describe what was found.
+
+        To opt into backoff, call self._check_backoff(work_hash) and return
+        False if it returns True.
 
         Returns:
             True if there is work to do (default), False to skip this run

--- a/packages/gptme-runloops/src/gptme_runloops/email.py
+++ b/packages/gptme-runloops/src/gptme_runloops/email.py
@@ -3,25 +3,18 @@
 Includes consecutive-failure backoff: if the same set of unreplied emails
 keeps appearing after execution (indicating the LLM couldn't process them,
 e.g. due to auth errors), we progressively skip runs to avoid burning tokens.
+
+Backoff is implemented via the base class infrastructure (_check_backoff,
+_record_backoff_success, _record_backoff_failure).
 """
 
 import hashlib
-import json
 import subprocess
 from pathlib import Path
-from typing import Any
 
 from gptme_runloops.base import BaseRunLoop
 from gptme_runloops.utils.execution import ExecutionResult
 from gptme_runloops.utils.prompt import generate_base_prompt, get_agent_name
-
-# Backoff schedule: after N consecutive failures, skip runs
-# Maps threshold -> (skip_probability, description)
-_BACKOFF_SCHEDULE = [
-    (8, 7, 8, "skip 7/8 runs (~40 min between attempts)"),
-    (5, 3, 4, "skip 3/4 runs (~20 min between attempts)"),
-    (3, 1, 2, "skip 1/2 runs (~10 min between attempts)"),
-]
 
 
 class EmailRun(BaseRunLoop):
@@ -32,9 +25,9 @@ class EmailRun(BaseRunLoop):
     - Check for unreplied emails (in has_work, before lock)
     - Process with gptme if emails found (after lock acquired)
 
-    Includes failure backoff: tracks consecutive runs where the same
-    unreplied emails persist after execution, and progressively skips
-    runs to avoid wasting tokens on unresolvable emails.
+    Uses the base class backoff infrastructure to track consecutive runs
+    where the same unreplied emails persist after execution, progressively
+    skipping runs to avoid wasting tokens on unresolvable emails.
     """
 
     def __init__(
@@ -58,53 +51,11 @@ class EmailRun(BaseRunLoop):
             model=model,
             tool_format=tool_format,
         )
-        self._state_file = workspace / "state" / "email-backoff.json"
         self._current_email_hash: str | None = None
-
-    def _load_backoff_state(self) -> dict[str, Any]:
-        """Load backoff state from disk."""
-        if self._state_file.exists():
-            try:
-                data: dict[str, Any] = json.loads(self._state_file.read_text())
-                return data
-            except (json.JSONDecodeError, OSError):
-                return {}
-        return {}
-
-    def _save_backoff_state(self, state: dict[str, Any]) -> None:
-        """Save backoff state to disk."""
-        self._state_file.parent.mkdir(parents=True, exist_ok=True)
-        self._state_file.write_text(json.dumps(state))
 
     def _hash_email_set(self, description: str) -> str:
         """Create a hash of the unreplied email set for change detection."""
         return hashlib.sha256(description.encode()).hexdigest()[:16]
-
-    def _should_skip_backoff(self) -> bool:
-        """Check if we should skip this run due to consecutive failures.
-
-        Returns:
-            True if this run should be skipped
-        """
-        import random
-
-        state = self._load_backoff_state()
-        failures = state.get("consecutive_failures", 0)
-
-        for threshold, skip_n, out_of, desc in _BACKOFF_SCHEDULE:
-            if failures >= threshold:
-                if random.randint(1, out_of) <= skip_n:
-                    self.logger.info(
-                        f"Email backoff: skipping ({failures} consecutive failures, {desc})"
-                    )
-                    return True
-                else:
-                    self.logger.info(
-                        f"Email backoff: running despite {failures} failures (lucky draw)"
-                    )
-                    return False
-
-        return False
 
     def _sync_emails(self) -> None:
         """Sync emails from server via mbsync."""
@@ -153,7 +104,7 @@ class EmailRun(BaseRunLoop):
         This syncs emails and checks for unreplied ones without taking
         a lock, so runs with no emails don't create calendar entries.
 
-        Also checks backoff state: if the same emails have been seen
+        Uses backoff via base class: if the same emails have been seen
         repeatedly without being resolved, progressively skips runs.
 
         Returns:
@@ -177,13 +128,7 @@ class EmailRun(BaseRunLoop):
             # Exit codes: 0=no emails, 1=has emails, 2=error
             if result.returncode == 0:
                 self.logger.info("No unreplied emails found")
-                # Reset backoff on success (emails were resolved)
-                state = self._load_backoff_state()
-                if state.get("consecutive_failures", 0) > 0:
-                    self.logger.info("Email backoff: reset (no unreplied emails)")
-                    self._save_backoff_state(
-                        {"consecutive_failures": 0, "last_hash": ""}
-                    )
+                self._record_backoff_success()
                 return False
             elif result.returncode == 1:
                 # Parse output to get email count and first email info
@@ -204,21 +149,8 @@ class EmailRun(BaseRunLoop):
 
                 # Check if this is the same email set we've been failing on
                 self._current_email_hash = self._hash_email_set(output)
-                state = self._load_backoff_state()
-                if state.get("last_hash") == self._current_email_hash:
-                    # Same emails as last time — check backoff
-                    if self._should_skip_backoff():
-                        return False
-                else:
-                    # New email set — reset backoff
-                    if state.get("consecutive_failures", 0) > 0:
-                        self.logger.info("Email backoff: reset (new emails detected)")
-                    self._save_backoff_state(
-                        {
-                            "consecutive_failures": 0,
-                            "last_hash": self._current_email_hash,
-                        }
-                    )
+                if self._check_backoff(self._current_email_hash):
+                    return False
 
                 self._work_description = desc
                 self.logger.info(f"Found {desc}")
@@ -318,29 +250,18 @@ Complete when all emails are addressed.
                 cwd=self.workspace,
             )
 
-            state = self._load_backoff_state()
-
             if check.returncode == 0:
                 # All emails resolved — reset backoff
                 self.logger.info("Post-run: all emails resolved, resetting backoff")
-                self._save_backoff_state({"consecutive_failures": 0, "last_hash": ""})
+                self._record_backoff_success()
             elif check.returncode == 1:
-                # Emails still unreplied — increment failure counter
+                # Emails still unreplied — check if same set
                 post_hash = self._hash_email_set(check.stdout.strip())
                 if post_hash == self._current_email_hash:
-                    failures = state.get("consecutive_failures", 0) + 1
-                    self.logger.warning(
-                        f"Post-run: same emails still unreplied "
-                        f"(consecutive failures: {failures})"
-                    )
-                    self._save_backoff_state(
-                        {"consecutive_failures": failures, "last_hash": post_hash}
-                    )
+                    self._record_backoff_failure(post_hash)
                 else:
                     # Different set (some resolved, new ones appeared)
                     self.logger.info("Post-run: email set changed, resetting backoff")
-                    self._save_backoff_state(
-                        {"consecutive_failures": 0, "last_hash": post_hash}
-                    )
+                    self._record_backoff_success()
         except Exception as e:
             self.logger.error(f"Post-run email check failed: {e}")

--- a/packages/gptme-runloops/tests/test_base.py
+++ b/packages/gptme-runloops/tests/test_base.py
@@ -4,7 +4,8 @@ import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
-from gptme_runloops.base import BaseRunLoop
+import pytest
+from gptme_runloops.base import BACKOFF_SCHEDULE, BaseRunLoop
 from gptme_runloops.utils.execution import ExecutionResult
 
 
@@ -122,3 +123,120 @@ def test_base_run_exception_handling():
             assert exit_code == 1
             # Lock should be released in cleanup
             assert run.lock.lock_fd is None
+
+
+# --- Backoff tests ---
+
+
+def test_backoff_state_file_path():
+    """Test that backoff state file uses run_type in path."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        workspace = Path(tmpdir)
+        (workspace / "logs").mkdir()
+
+        run = TestRunLoop(workspace, "mytype")
+        assert run._backoff_state_file == workspace / "state" / "mytype-backoff.json"
+
+
+def test_backoff_initial_state_no_skip():
+    """Test that with no prior state, backoff does not skip."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        workspace = Path(tmpdir)
+        (workspace / "logs").mkdir()
+
+        run = TestRunLoop(workspace, "test")
+        # No state file exists — should not skip
+        assert not run._check_backoff("hash1")
+
+
+def test_backoff_resets_on_new_hash():
+    """Test that a new work hash resets the backoff counter."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        workspace = Path(tmpdir)
+        (workspace / "logs").mkdir()
+
+        run = TestRunLoop(workspace, "test")
+
+        # Simulate many failures with hash1
+        run._save_backoff_state({"consecutive_failures": 10, "last_hash": "hash1"})
+
+        # New hash — should reset and not skip
+        assert not run._check_backoff("hash2")
+
+        # Verify state was reset
+        state = run._load_backoff_state()
+        assert state["consecutive_failures"] == 0
+        assert state["last_hash"] == "hash2"
+
+
+def test_backoff_record_success_resets():
+    """Test that recording success resets failure counter."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        workspace = Path(tmpdir)
+        (workspace / "logs").mkdir()
+
+        run = TestRunLoop(workspace, "test")
+        run._save_backoff_state({"consecutive_failures": 5, "last_hash": "hash1"})
+
+        run._record_backoff_success()
+
+        state = run._load_backoff_state()
+        assert state["consecutive_failures"] == 0
+        assert state["last_hash"] == ""
+
+
+def test_backoff_record_failure_increments():
+    """Test that recording failure increments counter."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        workspace = Path(tmpdir)
+        (workspace / "logs").mkdir()
+
+        run = TestRunLoop(workspace, "test")
+        run._save_backoff_state({"consecutive_failures": 2, "last_hash": "hash1"})
+
+        run._record_backoff_failure("hash1")
+
+        state = run._load_backoff_state()
+        assert state["consecutive_failures"] == 3
+        assert state["last_hash"] == "hash1"
+
+
+@pytest.mark.parametrize("threshold,skip_n,out_of,_desc", BACKOFF_SCHEDULE)
+def test_backoff_schedule_skips_at_threshold(threshold, skip_n, out_of, _desc):
+    """Test that backoff skips runs at the specified threshold."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        workspace = Path(tmpdir)
+        (workspace / "logs").mkdir()
+
+        run = TestRunLoop(workspace, "test")
+        run._save_backoff_state(
+            {"consecutive_failures": threshold, "last_hash": "hash1"}
+        )
+
+        # Run many trials — with high skip probability, at least some should skip
+        results = [run._check_backoff("hash1") for _ in range(100)]
+        skip_count = sum(results)
+
+        expected_fraction = skip_n / out_of
+        # Allow ±20% variance from expected fraction
+        assert skip_count >= (expected_fraction - 0.20) * 100
+        assert skip_count <= (expected_fraction + 0.20) * 100
+
+
+def test_backoff_corrupted_state_file():
+    """Test that corrupted state file is handled gracefully."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        workspace = Path(tmpdir)
+        (workspace / "logs").mkdir()
+        (workspace / "state").mkdir()
+
+        run = TestRunLoop(workspace, "test")
+        # Write corrupted JSON
+        run._backoff_state_file.write_text("not valid json{{")
+
+        # Should not raise, should return empty state
+        state = run._load_backoff_state()
+        assert state == {}
+
+        # And check_backoff should work fine (no skip with empty state)
+        assert not run._check_backoff("hash1")


### PR DESCRIPTION
## Summary

Closes #337.

Extracts the consecutive-failure backoff mechanism from `EmailRun` into `BaseRunLoop` so all run loop types can opt into it.

### What changed

**`BaseRunLoop`** — three new methods:
- `_check_backoff(work_hash)` — call in `has_work()`. Returns `True` if the run should be skipped. Automatically resets the counter when a new work hash is seen.
- `_record_backoff_success()` — call in `post_run()` when work was resolved.
- `_record_backoff_failure(work_hash)` — call in `post_run()` when the same work persists after execution.

State file: `workspace/state/{run_type}-backoff.json` (namespaced by run type so different loops don't interfere).

The backoff schedule (`BACKOFF_SCHEDULE`) is now a public constant importable for testing.

**`EmailRun`** — simplified to use base class methods. Removed `_load_backoff_state`, `_save_backoff_state`, `_should_skip_backoff` (replaced by `_check_backoff`). Only email-specific code (`_hash_email_set`, mbsync logic) remains.

**Tests** — 9 new tests in `test_base.py` covering all backoff methods, schedule thresholds, new-hash resets, and corrupted state file recovery.

## Test plan

- [x] All 22 tests pass (`test_base.py` + `test_email.py`)
- [x] No new mypy errors introduced
- [x] Email behavior unchanged (same schedule, same logic, just using shared infrastructure)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactors backoff mechanism from `EmailRun` to `BaseRunLoop`, adding new methods and tests for generalized functionality.
> 
>   - **Behavior**:
>     - Generalizes backoff mechanism from `EmailRun` to `BaseRunLoop`.
>     - Adds `_check_backoff(work_hash)`, `_record_backoff_success()`, and `_record_backoff_failure(work_hash)` to `BaseRunLoop`.
>     - Uses `workspace/state/{run_type}-backoff.json` for state management.
>     - `BACKOFF_SCHEDULE` is now a public constant.
>   - **EmailRun**:
>     - Simplified to use `BaseRunLoop` methods for backoff.
>     - Removed `_load_backoff_state`, `_save_backoff_state`, `_should_skip_backoff`.
>   - **Tests**:
>     - Adds 9 tests in `test_base.py` for backoff methods, schedule thresholds, new-hash resets, and corrupted state file recovery.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for 9507d5c4c069b03f9b2c45b5476e053f03ff8bb6. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->