### PR TITLE
fix(lessons): replace overly broad keywords in safe-operation-patterns

### DIFF
--- a/lessons/autonomous/safe-operation-patterns.md
+++ b/lessons/autonomous/safe-operation-patterns.md
@@ -5,10 +5,8 @@ match:
   - "GREEN YELLOW RED classification"
   - "safe to execute autonomously"
   - "requires human approval"
-  - classification
-  - GREEN
-  - YELLOW
-  - RED
+  - "operation safety classification"
+  - "risky operation"
 status: active
 ---
 


### PR DESCRIPTION
## Summary

- Remove 4 single-word keywords (`classification`, `GREEN`, `YELLOW`, `RED`) from `lessons/autonomous/safe-operation-patterns.md` that caused excessive false-positive lesson matches
- Replace with 2 specific multi-word phrases: `"operation safety classification"` and `"risky operation"`

## Problem

Single-word keywords like `RED`, `GREEN`, `YELLOW`, and `classification` match inside common words: `RED` matches in `required`, `stored`, `considered`, `referenced`, etc. Trajectory analysis showed 9 false triggers from `RED` alone across 10 sessions.

## Fix

Before:
```yaml
match:
  keywords:
  - "classify operation before executing"
  - "GREEN YELLOW RED classification"
  - "safe to execute autonomously"
  - "requires human approval"
  - classification
  - GREEN
  - YELLOW
  - RED
```

After:
```yaml
match:
  keywords:
  - "classify operation before executing"
  - "GREEN YELLOW RED classification"
  - "safe to execute autonomously"
  - "requires human approval"
  - "operation safety classification"
  - "risky operation"
```

The existing multi-word phrase `"GREEN YELLOW RED classification"` already handles the primary use case. The two new phrases cover scenarios where someone explicitly discusses operation safety classification or risky operations without using the full phrase.

## Test plan
- [ ] Verify lesson still matches correctly on `"classify operation before executing"`
- [ ] Verify lesson still matches on `"safe to execute autonomously"`
- [ ] Verify `RED` no longer triggers false matches in unrelated text containing `required`, `stored`, etc.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace overly broad single-word keywords with specific multi-word phrases in `safe-operation-patterns.md` to reduce false-positive matches.
> 
>   - **Keywords Update**:
>     - Remove single-word keywords: `classification`, `GREEN`, `YELLOW`, `RED` from `safe-operation-patterns.md`.
>     - Add multi-word phrases: `"operation safety classification"`, `"risky operation"`.
>   - **Problem**:
>     - Single-word keywords caused false-positive matches, e.g., `RED` matched in `required`, `stored`, etc.
>   - **Test Plan**:
>     - Verify lesson matches on specific phrases and no false matches occur with removed keywords.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for 2b35912db4b0f399b85f7ff6ad4acea410dd763a. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->