### PR TITLE
feat(gptodo): add --github flag to status command

### DIFF
--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -36,6 +36,7 @@ from typing import (
 import click
 import frontmatter
 from rich.console import Console
+from rich.markup import escape as markup_escape
 from rich.table import Table
 from tabulate import tabulate
 
@@ -831,8 +832,8 @@ def _show_github_issues(
         for issue in untracked:
             labels_str = ""
             if issue.get("labels"):
-                labels_str = " [" + ", ".join(issue["labels"]) + "]"
-            console.print(f"  #{issue['number']}  {issue['title']}{labels_str}")
+                labels_str = markup_escape(" [" + ", ".join(issue["labels"]) + "]")
+            console.print(f"  #{issue['number']}  {markup_escape(issue['title'])}{labels_str}")
 
         if not compact:
             console.print(
@@ -916,6 +917,8 @@ def status(type, all, compact, summary, issues, github, github_repo):
     # Show GitHub issues not yet tracked as task files
     if github:
         _show_github_issues(console, repo_root, github_repo, compact)
+    elif github_repo:
+        console.print("[yellow]Warning: --repo has no effect without --github[/]")
 
 
 @cli.command()


### PR DESCRIPTION
## Summary
- Adds `--github` flag to `gptodo status` that shows open GitHub issues not yet tracked as task files
- Auto-detects repo via `gh repo view`, or accepts `--repo owner/name` override
- Filters out issues already linked via `tracking` frontmatter field
- Adds `tracking` to `VALID_FIELDS` so `gptodo edit --set tracking` works

## Usage
```
gptodo status --github              # auto-detect repo
gptodo status --github --repo org/repo  # explicit repo
gptodo status --github --compact    # compact output
```

## Example output
```
🐙 GitHub Issues — ErikBjare/bob (3 untracked, 14 already in tasks):
  #374  Session classifier: signal vocabulary gaps [bug]
  #375  Duplicate session numbering: race condition
  #376  Add OpenAI Codex support
```

## Test plan
- [x] Tested with ErikBjare/bob (17 issues, all tracked after import)
- [x] Tested with auto-detect and explicit `--repo`
- [x] Verified dedup against `tracking` field in task frontmatter
- [x] Verified `--compact` suppresses import hint
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `--github` flag to `gptodo status` to display untracked GitHub issues, with auto-detection and filtering based on task tracking.
> 
>   - **Feature**:
>     - Adds `--github` flag to `gptodo status` command in `cli.py` to show open GitHub issues not tracked as task files.
>     - Auto-detects GitHub repo using `gh repo view` or accepts `--repo owner/name` for manual specification.
>     - Filters out issues already linked via `tracking` field in task frontmatter.
>   - **Enhancements**:
>     - Adds `tracking` to `VALID_FIELDS` in `edit()` to allow setting tracking URLs.
>   - **Testing**:
>     - Verified with auto-detect and explicit `--repo` options.
>     - Confirmed deduplication against `tracking` field and `--compact` output option.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for fda0902fa640b0493c6862977b1702c7445dda84. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->