### PR TITLE
fix(lessons): replace dead keywords in 7 lessons (batch 2)

### DIFF
--- a/lessons/autonomous/effective-autonomous-work-execution.md
+++ b/lessons/autonomous/effective-autonomous-work-execution.md
@@ -1,13 +1,11 @@
 ---
 match:
   keywords:
-  - autonomous work execution
-  - maximizing session value
-  - work execution patterns
-  - structured work approach
-  - blocked on dependencies
-  - autonomous session productivity
-  - task selection priorities
+  - start of autonomous session
+  - autonomous work workflow
+  - task selection in autonomous
+  - session startup workflow
+  - select what to work on
 status: active
 ---
 

--- a/lessons/autonomous/maintaining-readiness-during-blocked-periods.md
+++ b/lessons/autonomous/maintaining-readiness-during-blocked-periods.md
@@ -6,8 +6,8 @@ match:
     - blocked period activities
     - all tasks blocked
     - strategic pause framework
-    - value creation during blocked
-    - waiting for stakeholder input
+    - blocked waiting for response
+    - stakeholder hasn't replied
 status: active
 ---
 

--- a/lessons/autonomous/multi-issue-coordination-patterns.md
+++ b/lessons/autonomous/multi-issue-coordination-patterns.md
@@ -1,13 +1,11 @@
 ---
 match:
   keywords:
-  - multiple issues blocked
-  - parallel issue coordination
-  - github issue coordination
-  - multiple blocked tasks
-  - strategic issue prioritization
-  - issue coordination patterns
-  - managing blocked issues
+  - multiple tasks blocked
+  - all work waiting for review
+  - blocked across multiple issues
+  - parallel blocked tasks
+  - coordinate blocked work
 status: active
 ---
 

--- a/lessons/concepts/hierarchical-context-management.md
+++ b/lessons/concepts/hierarchical-context-management.md
@@ -1,13 +1,11 @@
 ---
 match:
   keywords:
-  - hierarchical context management
-  - Droid context architecture
-  - agent context layers
-  - Factory Droid context
-  - multi-layer context
-  - context layer architecture
-  - agentic context layers
+  - context window management
+  - organize context across steps
+  - prune older conversation context
+  - layered context approach
+  - context accumulating across steps
 status: active
 ---
 

--- a/lessons/patterns/progressive-disclosure.md
+++ b/lessons/patterns/progressive-disclosure.md
@@ -7,8 +7,8 @@ match:
     - "monolithic documentation needs restructuring"
     - "restructure large documentation"
     - "split monolithic docs"
-    - "auto-include too large"
-    - "context token budget"
+    - "auto-included file too large"
+    - "context window budget"
 status: active
 ---
 

--- a/lessons/workflow/bold-refactoring.md
+++ b/lessons/workflow/bold-refactoring.md
@@ -4,8 +4,8 @@ match:
     - "adding new code without refactoring"
     - "proposing refactoring without doing it"
     - "shared module created but not used"
-    - "duplicated code after adding abstraction"
-    - "be bold in refactoring"
+    - "PR adds code without removing old"
+    - "refactor when adding abstraction"
 status: active
 ---
 

--- a/lessons/workflow/communication-loop-closure-patterns.md
+++ b/lessons/workflow/communication-loop-closure-patterns.md
@@ -6,8 +6,8 @@ match:
   - memory failure
   - request completion
   - close the loop
-  - follow-through on communication
-  - respond to thread
+  - reply to issue comment
+  - update the requestor
 status: active
 ---
 


### PR DESCRIPTION
## Summary

Replaces dead keywords (zero trajectory matches in 357+ sessions over 7 days) with natural phrases that actually appear in agent conversations.

**7 lessons fixed:**
- `concepts/hierarchical-context-management`: Factory-specific terms (\"Droid context architecture\", \"Factory Droid context\") → generic context management phrases
- `autonomous/multi-issue-coordination-patterns`: abstract coordination terms → natural blocked-work phrases (\"multiple tasks blocked\", \"all work waiting for review\")
- `autonomous/effective-autonomous-work-execution`: abstract productivity terms → session startup phrases (\"start of autonomous session\", \"select what to work on\")
- `autonomous/maintaining-readiness-during-blocked-periods`: 2 dead keywords replaced with natural alternatives
- `patterns/progressive-disclosure`: 2 dead keywords replaced (\"auto-include too large\" → \"auto-included file too large\")
- `workflow/bold-refactoring`: 2 dead keywords replaced (\"be bold in refactoring\" → action phrases)
- `workflow/communication-loop-closure-patterns`: 2 dead keywords replaced

**Why these keywords were dead:**
- Too abstract/generic (matched nothing specific)
- Product-specific terminology (\"Droid\", \"Factory\") that doesn't appear in normal conversation
- Phrasing that sounds like lesson titles, not natural conversation

**Validation:** All format-valid lessons pass. Pre-existing format validation failures in legacy-format lessons (hierarchical-context, multi-issue-coordination, communication-loop-closure) are not introduced by this PR — they existed before on master.

Follows up on #340 (safe-operation-patterns), #341 (batch 1 — 6 high-frequency lessons).

## Test plan
- [ ] Lessons validate without new errors
- [ ] CI passes