### PR TITLE
fix(lessons): remove over-triggering keyword from safe-operation-patterns

### DIFF
--- a/lessons/autonomous/safe-operation-patterns.md
+++ b/lessons/autonomous/safe-operation-patterns.md
@@ -2,7 +2,6 @@
 match:
   keywords:
   - "classify operation before executing"
-  - "GREEN YELLOW RED classification"
   - "safe to execute autonomously"
   - "requires human approval"
   - "operation safety classification"


### PR DESCRIPTION
## Problem

The keyword `"GREEN YELLOW RED classification"` in `lessons/autonomous/safe-operation-patterns.md` matches the GLOSSARY.md entry `### GREEN/YELLOW/RED Classification` which is auto-included in every gptme session.

This causes the lesson to fire on ~100% of sessions regardless of whether the agent is actually planning a potentially risky operation — confirmed by trajectory analysis showing 281 triggers across 264 sessions (nearly every session) with the lesson classified as "likely_noise".

## Fix

Remove the over-triggering keyword. The remaining 5 keywords are task-specific and sufficient:
- `"classify operation before executing"`
- `"safe to execute autonomously"`
- `"requires human approval"`
- `"operation safety classification"`
- `"risky operation"`

These only fire when the agent is genuinely discussing operation safety, not due to GLOSSARY.md auto-inclusion.

## Evidence

From `lesson-effectiveness-report.py --days 4` (2082 trajectory records, 378 sessions):
- "Safe Operation Patterns" triggers: 281 across 264 sessions
- Classification: `likely_noise` (lesson fires but content not referenced in subsequent behavior)
- The over-trigger was confirmed live: lesson injected in a session where the only Bash command was `git status` in a submodule