### PR TITLE
fix(git-hooks): allow gptme-superuser direct master commits

### DIFF
--- a/dotfiles/.config/git/allowed-repos.conf
+++ b/dotfiles/.config/git/allowed-repos.conf
@@ -16,4 +16,9 @@ ALLOWED_PATTERNS=(
     # "bob"
     # "alice"
     # "ErikBjare/my-agent"
+
+    # gptme-superuser: shared workspace for all agents
+    # Agents write standups, task updates, and cross-agent messages directly to master
+    # (Missing standup = automatic failure signal — requires direct master writes)
+    "gptme/gptme-superuser"
 )


### PR DESCRIPTION
## Summary

`gptme-superuser` is a shared workspace for all agents (Bob, Alice, Sven, Gordon). Agents write daily standup reports and coordination files directly to master — this is **by design**: a missing standup file is an automatic signal that an agent failed to run.

The git pre-commit hook was blocking this with "Cannot commit directly to master in external repos". This PR adds `gptme/gptme-superuser` to `ALLOWED_PATTERNS` so agents can write standups without bypassing hooks.

## Context

- ErikBjare/bob#384: Review Alice → discussion spawned standup system design
- ErikBjare/bob#385: Alice implementing the standup protocol
- First standup written: `gptme-superuser/standups/2026-03-05/bob.md` (commit 8e24f23)

## Why Direct Master Commits

The whole point of the standup system is that **missing file = agent is down**. If standups go through PRs, a missed standup could just mean "PR not merged yet" — the failure signal is lost. Direct master writes are the correct design here.

Co-authored-by: Bob <bob@superuserlabs.org>