### PR TITLE
feat(lessons): rule-driven session gating for monitoring agents

### DIFF
--- a/lessons/autonomous/rule-driven-session-gating.md
+++ b/lessons/autonomous/rule-driven-session-gating.md
@@ -62,6 +62,43 @@ else
 fi
 ```
 
+### Implementing Signal Checks
+
+The `check-*` commands above are abstractions — implement them as simple scripts with no LLM cost:
+
+**File-based signal (standup or event file appeared):**
+```bash
+check_standup_ready() {
+    local agent="$1" date="$2"
+    [[ -f "gptme-superuser/standups/${date}/${agent}.md" ]] && echo 1 || echo 0
+}
+EVENTS=$(check_standup_ready gordon "$(date +%Y-%m-%d)")
+```
+
+**Price proximity check (external API + arithmetic):**
+```bash
+check_price_near_strike() {
+    # Returns 1 if current price is within threshold% of strike
+    local current="$1" strike="$2" threshold="${3:-0.05}"
+    python3 -c "
+c=$current; s=$strike; t=$threshold
+print(1 if abs(c - s) / s <= t else 0)"
+}
+BTC_PRICE=$(curl -sf 'https://api.example.com/price/btc' | jq -r '.usd')
+SIGNALS=$(check_price_near_strike "$BTC_PRICE" 72000 0.01)
+```
+
+**New message check (file modification time):**
+```bash
+check_new_messages() {
+    find gptme-superuser/messages/ -newer .last-check -name "to-*.md" 2>/dev/null | wc -l
+}
+MESSAGES=$(check_new_messages)
+touch .last-check  # update watermark after checking
+```
+
+These run in milliseconds with zero inference cost.
+
 ### Session Cadence Optimization
 
 Pair session gating with adaptive cadence:


### PR DESCRIPTION
## What this adds

A new lesson on reducing inference waste for monitoring agents by gating sessions externally before spawning gptme.

**File**: `lessons/autonomous/rule-driven-session-gating.md`

## Core pattern

Use a lightweight external check (shell script, API call) to determine if a session is warranted. Skip entirely when there's nothing to decide:

```bash
SIGNALS=
EVENTS=

if [[ "$SIGNALS" -gt 0 || "$EVENTS" -gt 0 ]]; then
    gptme --model sonnet "Agent run: signals=$SIGNALS events=$EVENTS"
else
    echo "$(date -u): No signals, skipping session" >> session-gate.log
fi
```

## Why this over model-tier switching

Initial draft proposed using Haiku for routine sessions. Revised after review:
- Haiku is unreliable at tool use — can't be trusted for agent tasks
- Skipping entirely is cheaper and more reliable than running cheaply
- This pattern is already how gptme's autonomous/project monitoring runs work (timers + conditions)

## Motivation

Observed Gordon running 16 sessions/day with ~12-14 producing zero signals. 75% of sessions were pure no-ops. Rule-driven gating would cut to 4 sessions/day on the same schedule, ~75% cost reduction.

## Changes from initial draft

- Renamed: `tiered-model-strategy-by-session-type.md` → `rule-driven-session-gating.md`
- Removed model-tier switching pattern (wrong implementation)
- Removed Haiku recommendation (unreliable for tool use)
- Implementation now shows external orchestrator spawning gptme conditionally
- Added explicit "Why Not a Lighter Model?" section