### PR TITLE
fix(lessons): genericize agent name in rule-driven-session-gating example

### DIFF
--- a/.jscpd.json
+++ b/.jscpd.json
@@ -3,6 +3,8 @@
   "threshold": 1,
   "reporters": ["console"],
   "ignore": [
+    "worktree/**",
+    "worktrees/**",
     "**/__pycache__/**",
     "**/node_modules/**",
     "**/.venv/**",

--- a/lessons/autonomous/rule-driven-session-gating.md
+++ b/lessons/autonomous/rule-driven-session-gating.md
@@ -72,7 +72,8 @@ check_standup_ready() {
     local agent="$1" date="$2"
     [[ -f "gptme-superuser/standups/${date}/${agent}.md" ]] && echo 1 || echo 0
 }
-EVENTS=$(check_standup_ready gordon "$(date +%Y-%m-%d)")
+AGENT_NAME="your-agent"  # Replace with your agent's identifier
+EVENTS=$(check_standup_ready "$AGENT_NAME" "$(date +%Y-%m-%d)")
 ```
 
 **Price proximity check (external API + arithmetic):**


### PR DESCRIPTION
## What this fixes

Addresses post-merge feedback from @ErikBjare: the merged lesson still had a hardcoded `gordon` agent name in the signal check example.

**Before:**
```bash
EVENTS=$(check_standup_ready gordon "$(date +%Y-%m-%d)")
```

**After:**
```bash
AGENT_NAME="your-agent"  # Replace with your agent's identifier
EVENTS=$(check_standup_ready "$AGENT_NAME" "$(date +%Y-%m-%d)")
```

## Bonus: jscpd false positive fix

Also adds `worktree/**` and `worktrees/**` to `.jscpd.json` ignore list. The pre-commit jscpd check was scanning git worktrees inside the repo directory and generating hundreds of false-positive duplicate findings. These worktrees are checked-out branches for development — not actual duplicate code.

Fixes: ErikBjare/alice#25 (the agent-name comment)