### PR TITLE
docs(lessons): clarify scope of rule-driven-session-gating

### DIFF
--- a/lessons/autonomous/rule-driven-session-gating.md
+++ b/lessons/autonomous/rule-driven-session-gating.md
@@ -37,7 +37,7 @@ This lesson addresses one question: **when to skip a session entirely** because 
 
 It does *not* address what to do with remaining inference budget when the agent has capacity left after covering event-driven work. When an agent has leftover cycles within its budget, it should still do productive autonomous work — exploring new opportunities, self-review, refining systems, running CASCADE sessions. Reducing an agent to a "position monitor" wastes available capacity.
 
-The complementary pattern is **budget-based productive-work scheduling**: use CASCADE + Thompson sampling to pick the highest-value work category when the agent has inference budget and no immediate events to respond to ([tracking issue #349](https://github.com/gptme/gptme-contrib/issues/349)). Session gating and productive-work scheduling are two separate mechanisms that should both be in place.
+The complementary pattern is **budget-based productive-work scheduling**: use CASCADE to pick the highest-value work category when the agent has inference budget and no immediate events to respond to ([tracking issue #349](https://github.com/gptme/gptme-contrib/issues/349)). Session gating and productive-work scheduling are two separate mechanisms that should both be in place.
 
 ## Detection
 Observable signals that session gating would reduce waste:


### PR DESCRIPTION
## Summary

Adds a **Scope** section to `rule-driven-session-gating.md` clarifying that the lesson only covers event-based gating (when to skip sessions entirely), and explicitly calls out that it does *not* address productive-work scheduling for remaining inference budget.

Follow-up to [ErikBjare/alice#25](https://github.com/ErikBjare/alice/issues/25) where Erik pointed out that reducing a monitoring agent to a "position monitor" wastes available capacity. When an agent has leftover budget, it should run productive work (CASCADE-guided) — not just sit idle because the event-gating check returned false.

The two mechanisms are complementary:
- **Event-gating** (this lesson): skip sessions when there's nothing to decide
- **Budget-driven productive work** (CASCADE + Thompson sampling, per [#349](https://github.com/gptme/gptme-contrib/issues/349)): use remaining capacity for self-review, research, system refinement

No functional changes — documentation only.