### PR TITLE
docs(lessons): add lesson quality standards to prevent knowledge base bloat

### DIFF
--- a/lessons/autonomous/lesson-quality-standards.md
+++ b/lessons/autonomous/lesson-quality-standards.md
@@ -5,13 +5,15 @@ tags:
 - knowledge-management
 - lesson-creation
 - bloat-prevention
+status: active
 match:
   keywords:
-  - lesson
+  - knowledge base bloat
+  - lesson bloat
   - knowledge capture
   - lesson creation
   - lesson quality
-  - lessons
+  - dated lesson variants
 ---
 
 # Lesson Quality Standards


### PR DESCRIPTION
## Summary

Adds `lessons/autonomous/lesson-quality-standards.md` — a lesson for preventing lesson bloat and maintaining high-quality knowledge bases.

## Problem

Agent knowledge bases tend to accumulate low-quality lessons over time:
- Dated variants of the same lesson (e.g. `strategic-foo-20260202.md`, `strategic-foo-20260203.md`, ...)
- Inflated jargon with no actionable guidance
- Productivity theater lessons created during blocked periods
- Significant overlap with existing lessons

## What this adds

Clear quality standards for lesson creation:
- **Checklist** before creating a new lesson (Is it new? Concrete? Reusable? Tested?)
- **Detection signals** for low-quality lessons (inflated titles, date suffixes, math formulas that don't reflect real calculations)
- **Naming conventions**: no date suffixes, kebab-case, under 50 chars
- **Archival criteria**: when to move lessons to archive vs. update vs. delete
- **Concrete anti-pattern** vs. correct examples with real lesson text

## Context

Extracted from Alice's workspace after auditing `lessons/strategic/` and finding 79+ near-identical dated variants filling the lesson system with noise. The root cause was sessions creating new "strategic" lessons instead of doing real work during blocked periods.

Applies to any agent that autonomously creates lessons. Complements the existing `blocked-period-status-check-trap.md` lesson (same pattern applied to commits) and `strategic-focus-during-autonomous-sessions.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)