### PR TITLE
feat(gptme-sessions): add steps/yields signal to trajectory extraction

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -116,9 +116,12 @@ def main() -> int:
             return 0
         # Human-readable summary
         tc = result["tool_calls"]
+        total_tools = sum(tc.values())
+        steps = result.get("steps", 0)
         print(f"Format: {result.get('format', 'gptme')}")
+        tools_per_step = f" ({total_tools / steps:.1f} tools/step)" if steps else ""
         print(
-            f"Tool calls: {sum(tc.values())} "
+            f"Tool calls: {total_tools} in {steps} step(s){tools_per_step} "
             f"({', '.join(f'{t}:{n}' for t, n in sorted(tc.items(), key=lambda x: -x[1])[:5])})"
         )
         print(f"Git commits: {len(result['git_commits'])}")

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -94,6 +94,7 @@ def extract_signals(msgs: list[dict]) -> dict:
     file_writes: list[str] = []
     retry_candidates: list[str] = []
     timestamps: list[datetime] = []
+    steps = 0  # number of assistant turns that yielded to await tool results
 
     # Track recent (tool, path) pairs for retry detection
     recent_sigs: list[str] = []
@@ -112,12 +113,14 @@ def extract_signals(msgs: list[dict]) -> dict:
         if role == "assistant":
             # Find all @tool_name(call_id): JSON_ARGS blocks.
             blocks = re.split(r"(?=\n@\w+\()", "\n" + content)
+            step_has_tool = False
             for block in blocks:
                 m = re.match(r"\n@(\w+)\(([^)]+)\):\s*(.*)", block, re.DOTALL)
                 if not m:
                     continue
                 tool, _call_id, args_str = m.group(1), m.group(2), m.group(3)
                 tool_calls[tool] = tool_calls.get(tool, 0) + 1
+                step_has_tool = True
 
                 if tool in ("save", "write", "patch", "edit"):
                     path = _extract_path_from_args(args_str)
@@ -134,6 +137,8 @@ def extract_signals(msgs: list[dict]) -> dict:
                     # file writes. Placeholder strings like "<save>" would inflate the
                     # unique-write count used in grade_signals and push unproductive
                     # sessions into higher reward tiers.
+            if step_has_tool:
+                steps += 1
 
         elif role == "system" and ts_str:
             content_stripped = content.strip()
@@ -165,6 +170,7 @@ def extract_signals(msgs: list[dict]) -> dict:
 
     return {
         "tool_calls": tool_calls,
+        "steps": steps,
         "error_count": error_count,
         "git_commits": git_commits,
         "file_writes": file_writes,
@@ -252,6 +258,7 @@ def extract_signals_cc(msgs: list[dict]) -> dict:
     file_writes: list[str] = []
     retry_candidates: list[str] = []
     timestamps: list[datetime] = []
+    steps = 0  # number of assistant turns that yielded to await tool results
     recent_sigs: list[str] = []
     # Map tool_use id → tool name for filtering commit detection to Bash only
     tool_id_to_name: dict[str, str] = {}
@@ -268,6 +275,7 @@ def extract_signals_cc(msgs: list[dict]) -> dict:
             content = record.get("message", {}).get("content", [])
             if not isinstance(content, list):
                 continue
+            step_has_tool = False
             for item in content:
                 if not isinstance(item, dict) or item.get("type") != "tool_use":
                     continue
@@ -275,6 +283,7 @@ def extract_signals_cc(msgs: list[dict]) -> dict:
                 if not tool:
                     continue
                 tool_calls[tool] = tool_calls.get(tool, 0) + 1
+                step_has_tool = True
 
                 # Track id → name for commit detection filtering
                 tool_id = item.get("id", "")
@@ -300,6 +309,8 @@ def extract_signals_cc(msgs: list[dict]) -> dict:
                                 recent_sigs.pop(0)
                     # No else: tool calls without extractable paths are not counted as
                     # file writes — same rationale as the gptme path above.
+            if step_has_tool:
+                steps += 1
 
         elif rec_type == "user":
             content = record.get("message", {}).get("content", [])
@@ -340,6 +351,7 @@ def extract_signals_cc(msgs: list[dict]) -> dict:
     deliverables = list(dict.fromkeys(git_commits + file_writes))
     return {
         "tool_calls": tool_calls,
+        "steps": steps,
         "error_count": error_count,
         "git_commits": git_commits,
         "file_writes": file_writes,

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -1249,3 +1249,125 @@ def test_extract_signals_cc_no_placeholder_inflation():
     ]
     sigs = extract_signals_cc(msgs)
     assert len(sigs["file_writes"]) == 0
+
+
+def test_extract_signals_gptme_steps_basic():
+    """gptme trajectory: each assistant turn with tool calls counts as one step."""
+    msgs = [
+        # Turn 1: one tool call
+        {
+            "role": "assistant",
+            "content": '@shell(c0): {"command": "ls"}',
+            "timestamp": "2026-03-01T10:00:00+00:00",
+        },
+        {"role": "system", "content": "file.py", "timestamp": "2026-03-01T10:00:01+00:00"},
+        # Turn 2: two tool calls (parallel) — still one step
+        {
+            "role": "assistant",
+            "content": '@shell(c1): {"command": "git status"}\n@save(c2): {"path": "/tmp/out.py"}',
+            "timestamp": "2026-03-01T10:00:02+00:00",
+        },
+        {"role": "system", "content": "ok", "timestamp": "2026-03-01T10:00:03+00:00"},
+        # Turn 3: pure text, no tool calls — NOT a step
+        {
+            "role": "assistant",
+            "content": "Here is my analysis.",
+            "timestamp": "2026-03-01T10:00:04+00:00",
+        },
+    ]
+    sigs = extract_signals(msgs)
+    assert sigs["steps"] == 2
+
+
+def test_extract_signals_gptme_steps_parallel_tools():
+    """gptme trajectory: multiple parallel tool calls in one turn = one step."""
+    msgs = [
+        {
+            "role": "assistant",
+            "content": ("@shell(c0): {}\n" "@shell(c1): {}\n" "@shell(c2): {}\n"),
+            "timestamp": "2026-03-01T10:00:00+00:00",
+        }
+    ]
+    sigs = extract_signals(msgs)
+    assert sigs["steps"] == 1
+    assert sum(sigs["tool_calls"].values()) == 3
+
+
+def test_extract_signals_gptme_steps_zero():
+    """gptme trajectory: no tool calls → steps is 0."""
+    msgs = [
+        {"role": "assistant", "content": "Hello world", "timestamp": "2026-03-01T10:00:00+00:00"},
+        {"role": "user", "content": "Thanks", "timestamp": "2026-03-01T10:00:01+00:00"},
+    ]
+    sigs = extract_signals(msgs)
+    assert sigs["steps"] == 0
+
+
+def test_extract_signals_cc_steps_basic():
+    """CC trajectory: each assistant record with tool_use items counts as one step."""
+    msgs = [
+        # Step 1: single Bash tool call
+        {
+            "type": "assistant",
+            "timestamp": "2026-03-01T10:00:00.000Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "t1", "name": "Bash", "input": {"command": "ls"}}
+                ],
+            },
+        },
+        # Step 2: two tool calls in parallel — still one step
+        {
+            "type": "assistant",
+            "timestamp": "2026-03-01T10:00:02.000Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "t2", "name": "Bash", "input": {"command": "pwd"}},
+                    {
+                        "type": "tool_use",
+                        "id": "t3",
+                        "name": "Read",
+                        "input": {"file_path": "/tmp/x"},
+                    },
+                ],
+            },
+        },
+        # Pure text turn — NOT a step
+        {
+            "type": "assistant",
+            "timestamp": "2026-03-01T10:00:04.000Z",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Done."}],
+            },
+        },
+    ]
+    sigs = extract_signals_cc(msgs)
+    assert sigs["steps"] == 2
+
+
+def test_extract_signals_cc_steps_parallel_tools():
+    """CC trajectory: multiple parallel tool_use items in one record = one step."""
+    msgs = [
+        {
+            "type": "assistant",
+            "timestamp": "2026-03-01T10:00:00.000Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": f"t{i}",
+                        "name": "Bash",
+                        "input": {"command": f"cmd{i}"},
+                    }
+                    for i in range(4)
+                ],
+            },
+        }
+    ]
+    sigs = extract_signals_cc(msgs)
+    assert sigs["steps"] == 1
+    assert sigs["tool_calls"]["Bash"] == 4


### PR DESCRIPTION
## Summary

Follow-up to #346, implementing Erik's request from that PR:

> we should also add "steps"/"yields" (as opposed to just "tool calls") as a signal as it highlights the actual number of times the assistant "yields" generation to await tool results (the expensive part, parallelization is good). Cost could be a good proxy for this already, but steps would transfer across models of varying cost.

**`steps`** = number of assistant turns that executed at least one tool call (i.e., yielded to await results). Different from total tool call count:

- 1 step with 4 parallel Bash calls → `steps=1, tool_calls=4`
- 4 sequential Bash calls → `steps=4, tool_calls=4`

The ratio `total_tool_calls / steps` is a direct parallelism measure — higher is better. Unlike cost (Erik's suggested proxy), `steps` is model-agnostic.

## Changes

- `signals.py`: added `steps` counter to both `extract_signals()` (gptme) and `extract_signals_cc()` (CC)
- `cli.py`: updated human-readable output to show `"Tool calls: N in M step(s) (K tools/step)"`
- 5 new tests covering: basic step counting, parallel tools in one step, zero steps, CC format

```
$ gptme-sessions signals path/to/conversation.jsonl
Format: claude_code
Tool calls: 106 in 34 steps (3.1 tools/step)
Git commits: 2
...
```

76 tests pass.

Co-authored-by: Bob <bob@superuserlabs.org>