### PR TITLE
docs: fix README inaccuracies and add missing entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # gptme-contrib
 
-Community-contributed plugins, packages, scripts, and lessons for [gptme](https://github.com/ErikBjare/gptme).
+Community-contributed plugins, packages, scripts, and lessons for [gptme](https://github.com/gptme/gptme).
 
 ## Overview
 
 This repository contains:
-- **[`plugins/`](./plugins/)** - Extend gptme with custom functionality ([gptme docs](https://gptme.org/docs/custom_tool.html))
+- **[`plugins/`](./plugins/)** - Extend gptme with custom functionality ([gptme docs](https://gptme.org/docs/plugins.html))
 - **[`packages/`](./packages/)** - Reusable Python packages
 - **[`scripts/`](./scripts/)** - Standalone scripts for automation
 - **[`lessons/`](./lessons/)** - Shared lessons for prompts and workflows
@@ -20,12 +20,15 @@ Plugins extend gptme's capabilities with custom tools and hooks. See [plugins/RE
 | [gptme-attention-tracker](./plugins/gptme-attention-tracker/) | Attention routing + history tracking for context management |
 | [gptme-claude-code](./plugins/gptme-claude-code/) | Claude Code subagent integration |
 | [gptme-consortium](./plugins/gptme-consortium/) | Multi-model consensus decision-making |
+| [gptme-gptodo](./plugins/gptme-gptodo/) | gptodo delegation plugin for coordinator-only agent mode |
 | [gptme-gupp](./plugins/gptme-gupp/) | Work persistence for session continuity |
 | [gptme-hooks-examples](./plugins/gptme-hooks-examples/) | Example hook implementations |
 | [gptme-imagen](./plugins/gptme-imagen/) | Multi-provider image generation |
 | [gptme-lsp](./plugins/gptme-lsp/) | Language Server Protocol integration |
+| [gptme-ralph](./plugins/gptme-ralph/) | Ralph Loop pattern — iterative execution with context reset |
+| [gptme-retrieval](./plugins/gptme-retrieval/) | Automatic context retrieval via semantic/keyword search |
 | [gptme-warpgrep](./plugins/gptme-warpgrep/) | Enhanced search with Warp-style filtering |
-| [gptme-wrapped](./plugins/gptme-wrapped/) | Wrapped tool definitions for sandboxing |
+| [gptme-wrapped](./plugins/gptme-wrapped/) | Year-end analytics for your gptme usage (Spotify Wrapped-style) |
 
 ### Plugin Usage
 
@@ -45,6 +48,10 @@ Reusable Python packages. See [packages/README.md](./packages/README.md).
 |---------|-------------|
 | [gptmail](./packages/gptmail/) | Universal email system for AI agents |
 | [gptodo](./packages/gptodo/) | Task management CLI and utilities |
+| [gptme-activity-summary](./packages/gptme-activity-summary/) | Activity summarization for agents — journals, GitHub, sessions, tweets, email |
+| [gptme-sessions](./packages/gptme-sessions/) | Session tracking, analytics, and trajectory extraction |
+| [gptme-voice](./packages/gptme-voice/) | Voice interface using OpenAI Realtime API |
+| [gptme-whatsapp](./packages/gptme-whatsapp/) | WhatsApp integration for agents via whatsapp-web.js |
 | [gptme_lessons_extras](./packages/gptme-lessons-extras/) | Lesson validation and tools |
 | [gptme_runloops](./packages/gptme-runloops/) | Agent run loop patterns |
 | [gptme_contrib_lib](./packages/gptme-contrib-lib/) | Shared utilities |
@@ -55,10 +62,15 @@ Standalone scripts for automation. See each directory's README for details.
 
 | Directory | Description |
 |-----------|-------------|
-| [github/](./scripts/github/) | GitHub context generation, repo status |
-| [twitter/](./scripts/twitter/) | Twitter automation and monitoring |
+| [context/](./scripts/context/) | Context generation for agent system prompts |
 | [discord/](./scripts/discord/) | Discord bot integration |
+| [github/](./scripts/github/) | GitHub context generation, repo status |
+| [linear/](./scripts/linear/) | Linear issue tracking integration |
+| [telegram/](./scripts/telegram/) | Telegram bot integration |
+| [twitter/](./scripts/twitter/) | Twitter automation and monitoring |
 | [bluesky/](./scripts/bluesky/) | Bluesky integration |
+| [status/](./scripts/status/) | Agent infrastructure status monitoring |
+| [workspace_validator/](./scripts/workspace_validator/) | Agent workspace structure validation |
 
 ## Lessons
 

--- a/packages/README.md
+++ b/packages/README.md
@@ -8,6 +8,10 @@ Python packages for gptme agents.
 |---------|---------|---------|
 | **gptmail** | Email/message handling | `uv pip install -e packages/gptmail` |
 | **gptodo** | Task management and work queues | `uv pip install -e packages/gptodo` |
+| **gptme-activity-summary** | Activity summarization (journals, GitHub, sessions, tweets, email) | `uv pip install -e packages/gptme-activity-summary` |
+| **gptme-sessions** | Session tracking, analytics, and trajectory extraction | `uv pip install -e packages/gptme-sessions` |
+| **gptme-voice** | Voice interface using OpenAI Realtime API | `uv pip install -e packages/gptme-voice` |
+| **gptme-whatsapp** | WhatsApp integration for agents | `uv pip install -e packages/gptme-whatsapp` |
 | **gptme_lessons_extras** | Lesson format validation and analysis | `uv pip install -e packages/gptme-lessons-extras` |
 | **gptme_contrib_lib** | Shared utilities across packages | `uv pip install -e packages/gptme-contrib-lib` |
 | **gptme_runloops** | Autonomous run loop infrastructure | `uv pip install -e packages/gptme-runloops` |


### PR DESCRIPTION
## Summary
- Fix gptme-wrapped description: was "Wrapped tool definitions for sandboxing", actually "Year-end analytics for gptme usage (Spotify Wrapped-style)"
- Add 3 missing plugins: gptme-gptodo, gptme-ralph, gptme-retrieval
- Add 4 missing packages: gptme-activity-summary, gptme-sessions, gptme-voice, gptme-whatsapp
- Add 5 missing script directories: context, linear, telegram, status, workspace_validator
- Fix docs link: `custom_tool.html` -> `plugins.html`
- Update `packages/README.md` with same missing packages

Fixes #358