### PR TITLE
feat(gptme-sessions): add --token-count to append command

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -174,6 +174,9 @@ def main() -> int:
     store = SessionStore(sessions_dir=args.sessions_dir)
 
     if args.command == "append":
+        if args.token_count is not None and args.token_count < 0:
+            print("error: --token-count must be non-negative", file=sys.stderr)
+            return 1
         record = SessionRecord(
             harness=args.harness,
             model=args.model,


### PR DESCRIPTION
## Summary

Adds `--token-count` flag to `gptme-sessions append`, completing the token tracking pipeline started in #354.

**Before**: `token_count` field in session records was always `null` — no way to pass it via CLI.  
**After**: `--token-count INT` sets the `token_count` field in the session record.

## Motivation

PR #354 added `--usage` to `signals`, enabling token extraction from CC trajectories. This PR closes the loop so agents can persist that data in session records:

```bash
# Full pipeline (e.g. in a post-session hook):
TOKENS=$(gptme-sessions signals "$TRANSCRIPT" --json | jq '.usage.total_tokens')
gptme-sessions append --token-count "$TOKENS" --outcome productive ...
```

## Changes

- `cli.py`: Added `--token-count` argument to `append` subparser; passes it to `SessionRecord(token_count=...)`

## Testing

- `SessionRecord` already has `token_count: int | None = None` — no schema changes needed
- Existing tests unaffected (field is optional)
- Verified end-to-end with Alice's post-session hook extracting ~1.5M tokens from today's sessions