### PR TITLE
fix(gptme-sessions): extract Anthropic cache tokens in extract_usage_gptme

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -390,6 +390,11 @@ def extract_usage_gptme(msgs: list[dict]) -> dict:
       - msg.metadata.usage (future/nested format)
     Also handles OpenAI-style naming (prompt_tokens, completion_tokens).
 
+    For Anthropic models, also extracts prompt-cache token fields:
+      - cache_creation_input_tokens: tokens written to the prompt cache
+      - cache_read_input_tokens: context served from the prompt cache
+    These are included in total_tokens for accurate billing representation.
+
     Only accumulates tokens from assistant turns (consistent with extract_usage_cc).
     Records the last-seen model (consistent with extract_usage_cc).
 
@@ -397,6 +402,8 @@ def extract_usage_gptme(msgs: list[dict]) -> dict:
     """
     input_tokens = 0.0
     output_tokens = 0.0
+    cache_creation_tokens = 0.0
+    cache_read_tokens = 0.0
     cost = 0.0
     model: str | None = None
 
@@ -431,14 +438,27 @@ def extract_usage_gptme(msgs: list[dict]) -> dict:
             meta_usage.get("cost"),
             metadata.get("cost"),
         )
+        # Anthropic prompt-cache fields — present when using Claude models via gptme
+        cache_creation_tokens += _first_not_none(
+            usage.get("cache_creation_input_tokens"),
+            meta_usage.get("cache_creation_input_tokens"),
+            metadata.get("cache_creation_input_tokens"),
+        )
+        cache_read_tokens += _first_not_none(
+            usage.get("cache_read_input_tokens"),
+            meta_usage.get("cache_read_input_tokens"),
+            metadata.get("cache_read_input_tokens"),
+        )
 
-    total_tokens = input_tokens + output_tokens
+    total_tokens = input_tokens + output_tokens + cache_creation_tokens + cache_read_tokens
     if total_tokens == 0 and model is None:
         return {}
     return {
         "model": model,
         "input_tokens": int(input_tokens),
         "output_tokens": int(output_tokens),
+        "cache_creation_tokens": int(cache_creation_tokens),
+        "cache_read_tokens": int(cache_read_tokens),
         "cost": cost,
         "total_tokens": int(total_tokens),
     }

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -1645,6 +1645,83 @@ def test_extract_usage_gptme_last_model_wins():
     assert usage["output_tokens"] == 60
 
 
+def test_extract_usage_gptme_cache_tokens():
+    """Anthropic cache tokens are extracted and included in total_tokens."""
+    msgs = [
+        {
+            "role": "assistant",
+            "content": "turn 1",
+            "metadata": {
+                "model": "anthropic/claude-sonnet-4-6",
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cache_creation_input_tokens": 400,
+                "cache_read_input_tokens": 0,
+                "cost": 0.005,
+            },
+        },
+        {
+            "role": "assistant",
+            "content": "turn 2",
+            "metadata": {
+                "model": "anthropic/claude-sonnet-4-6",
+                "input_tokens": 10,
+                "output_tokens": 30,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 400,
+                "cost": 0.001,
+            },
+        },
+    ]
+    usage = extract_usage_gptme(msgs)
+    assert usage["input_tokens"] == 110
+    assert usage["output_tokens"] == 80
+    assert usage["cache_creation_tokens"] == 400
+    assert usage["cache_read_tokens"] == 400
+    # total_tokens includes all four fields
+    assert usage["total_tokens"] == 110 + 80 + 400 + 400
+
+
+def test_extract_usage_gptme_cache_tokens_meta_usage():
+    """Cache tokens are extracted from msg.metadata.usage (nested format)."""
+    msgs = [
+        {
+            "role": "assistant",
+            "content": "test",
+            "metadata": {
+                "model": "anthropic/claude-opus-4-6",
+                "usage": {
+                    "input_tokens": 50,
+                    "output_tokens": 20,
+                    "cache_creation_input_tokens": 300,
+                    "cache_read_input_tokens": 150,
+                    "cost": 0.002,
+                },
+            },
+        }
+    ]
+    usage = extract_usage_gptme(msgs)
+    assert usage["cache_creation_tokens"] == 300
+    assert usage["cache_read_tokens"] == 150
+    assert usage["total_tokens"] == 50 + 20 + 300 + 150
+
+
+def test_extract_usage_gptme_no_cache_tokens_zero():
+    """Cache token keys are always present, defaulting to 0 for non-Anthropic models."""
+    msgs = [
+        {
+            "role": "assistant",
+            "content": "test",
+            "usage": {"prompt_tokens": 100, "completion_tokens": 40},
+            "metadata": {"model": "openai/gpt-4o"},
+        }
+    ]
+    usage = extract_usage_gptme(msgs)
+    assert usage["cache_creation_tokens"] == 0
+    assert usage["cache_read_tokens"] == 0
+    assert usage["total_tokens"] == 140
+
+
 def test_extract_from_path_gptme_includes_usage(tmp_path: Path):
     """extract_from_path includes usage data for gptme format trajectories."""
     from gptme_sessions.signals import extract_from_path


### PR DESCRIPTION
## Summary

Follow-up to #365 — addresses Erik's review comment about cache token accuracy.

`extract_usage_gptme()` was not extracting Anthropic prompt-cache fields, causing `total_tokens` to be understated for gptme sessions using Claude models with caching enabled.

**Changes:**
- Extract `cache_creation_input_tokens` and `cache_read_input_tokens` from all three storage locations (`msg.usage`, `msg.metadata`, `msg.metadata.usage`)
- Include both in `total_tokens` (fresh input + output + cache_creation + cache_read)
- Return `cache_creation_tokens` and `cache_read_tokens` in result dict — consistent with `extract_usage_cc()`
- Add 3 new tests: flat metadata, nested `metadata.usage`, and non-Anthropic (zero) case

## Test plan
- [x] `uv run pytest packages/gptme-sessions/tests/ -v` — 157/157 pass
- [x] 3 new tests covering cache token extraction paths