### PR TITLE
docs(lessons): add agent-event-watch-workflow lesson

### DIFF
--- a/lessons/autonomous/agent-event-watch-workflow.md
+++ b/lessons/autonomous/agent-event-watch-workflow.md
@@ -1,4 +1,12 @@
 ---
+status: active
+category: autonomous
+tags:
+- event-watch
+- orchestration
+- monitoring
+- settlement
+- trigger-check
 match:
   keywords:
     - event watch
@@ -10,7 +18,6 @@ match:
     - event trigger
     - monitor for result
     - waiting for outcome
-status: active
 ---
 
 # Agent Event Watch Workflow
@@ -31,6 +38,19 @@ conference result arriving. These events:
 
 Without a structured watch task, results get processed late or with insufficient context —
 the analysis happens days after the event when memory is stale and context must be re-researched.
+
+## Detection
+
+Observable signals that a watch task is warranted:
+- An upcoming event will produce data that triggers a decision (scale / hold / reduce / rollback)
+- The result will appear in a predictable location (standup, GitHub PR, log file) at a known future time
+- Missing or delaying the analysis would mean acting on stale information
+- The event is one-off or infrequent — not routine daily output that's already monitored
+
+Do NOT create watch tasks for:
+- Routine monitoring that's already handled by scheduled sessions
+- Events with no decision attached (informational only)
+- Events where timing of analysis doesn't matter
 
 ## Workflow
 
@@ -95,7 +115,7 @@ Then check if the trigger condition is met:
 
 ```bash
 # For standup-based triggers:
-ls gptme-superuser/standups/$(date +%Y-%m-%d)/gordon.md 2>/dev/null || echo "Not yet"
+[[ -f "gptme-superuser/standups/$(date +%Y-%m-%d)/gordon.md" ]] && echo "TRIGGERED" || echo "Not yet"
 
 # For file-based triggers:
 [[ -f "path/to/result/file" ]] && echo "TRIGGERED" || echo "Not yet"


### PR DESCRIPTION
## Summary

Adds a generalized lesson for the "event watch" pattern: when a significant upcoming event could change strategy, create a structured watch task that documents exactly what to look for and what to do when the result appears.

**Core ideas:**
- Pre-capture baseline context before the event fires (so analysis session is self-contained)
- Define trigger criteria and outcome thresholds upfront (not after seeing the result)
- Check for trigger in Phase 1 of every session during the watch period
- Act in the same session when triggered — don't defer

**Trigger types covered:** standup file appearances, PR state changes, deployment health checks, log file success markers.

**Decision framework:** Three-outcome template (scale up / hold / reduce) with pre-defined thresholds to avoid post-hoc threshold bias.

## Origin

Extracted from orchestrating a trading agent's settlement batch monitoring. The pattern generalizes to any agent orchestrator tracking a time-bounded high-stakes event.

## Related
- Connects to: `autonomous-session-structure.md` (Phase 1 check), `rule-driven-session-gating.md` (trigger check pattern)