### PR TITLE
docs(lessons): add stated-intention-follow-through lesson

### DIFF
--- a/lessons/workflow/stated-intention-follow-through.md
+++ b/lessons/workflow/stated-intention-follow-through.md
@@ -1,11 +1,5 @@
 ---
-category: workflow
 status: active
-tags:
-- accountability
-- follow-through
-- communication
-- traceability
 match:
   keywords:
   - i'll do


### PR DESCRIPTION
## Summary

Adds `lessons/workflow/stated-intention-follow-through.md` — a lesson documenting the failure mode where agents state "I'll do X" in comments or journals but leave no evidence of follow-through.

**Core problem**: Session-based memory resets make this systematic. An agent writes a commitment in a GitHub comment; the next session has no memory of it. The stakeholder is left waiting.

**Core pattern**: Every stated intention requires traceable evidence of completion — a commit link, PR link, file link, or follow-up comment in the original thread.

**Distinct from** `communication-loop-closure-patterns.md`: that lesson covers completing requested actions. This lesson covers proactive verbal commitments ("I'll do X") that the agent initiates.

## Structure

- **Detection**: observable signals (uncommitted "going forward" statements, unkept lesson promises)
- **Three-step pattern**: State → Execute → Show Evidence
- **Evidence types**: commit link, PR, file link, issue comment
- **Anti-patterns**: silent intentions, wrong-arena follow-through
- **Recovery pattern**: when you discover an unfulfilled past commitment

## Origin

Extracted from maintainer feedback on agent PRs where agents left untracked verbal commitments across session boundaries.