### PR TITLE
docs(lessons): add gptme-contrib contribution pattern lesson

### DIFF
--- a/lessons/workflow/gptme-contrib-contribution-pattern.md
+++ b/lessons/workflow/gptme-contrib-contribution-pattern.md
@@ -29,8 +29,8 @@ Observable signals that you need this workflow:
 ls gptme-contrib/lessons/<category>/
 head -15 gptme-contrib/lessons/<category>/existing-lesson.md
 
-# Workflow files use: match.keywords (array) + status
-# Pattern files use: match.keywords (block) + status
+# All lesson files use: match.keywords + status
+# Keywords can be inline-array ["a","b"] or block-sequence style — both are valid
 # Do NOT add category/tags fields unless they appear in peer files
 ```
 
@@ -63,7 +63,7 @@ pre-commit run --all-files
 git checkout -b feat/descriptive-branch-name origin/master
 
 # Add and commit
-git add lessons/category/lesson-name.md
+git add lessons/<category>/<lesson-name>.md
 git commit -m "docs(lessons): add <topic> lesson"
 
 # Push and open PR
@@ -125,7 +125,7 @@ raise ValueError(f"Expected one of {VALID_UNITS}")  # output varies run to run
 
 **❌ Creating branch from local instead of origin/master:**
 Contaminating the PR with unrelated commits from other local work.
-See also: `clean-pr-creation.md`
+See also: `branch-from-master.md`, `clean-pr-creation.md`
 
 **❌ Slow review response:**
 Greptile leaves feedback. Leaving it unaddressed for days signals low engagement and
@@ -142,6 +142,7 @@ Following this workflow results in:
 ## Related
 
 - [Lesson Quality Standards](../autonomous/lesson-quality-standards.md) — Required lesson structure
+- [Branch From Master](./branch-from-master.md) — Always branch from origin/master
 - [Clean PR Creation](./clean-pr-creation.md) — Keeping PRs free of unrelated commits
 - [Pre-Landing Self-Review](./pre-landing-self-review.md) — Final review before submitting
 


### PR DESCRIPTION
## Summary

Adds `lessons/workflow/gptme-contrib-contribution-pattern.md` — a five-phase workflow for contributing lessons and code to gptme-contrib that ensures submissions reach the maintainer in merge-ready state.

## Content

**What it covers:**
- Phase 1: Pre-write content preparation — peer frontmatter schema check, numeric claim accuracy, deterministic set ordering, bash file-check anti-pattern
- Phase 2: Branch and PR creation (always from `origin/master`)
- Phase 3: Automated review response — Greptile feedback table with common issues and fixes
- Phase 4: Waiting for maintainer (no action needed)
- Phase 5: Post-merge hygiene

**What's genuinely new (not covered by existing lessons):**

The Greptile review pattern table captures four recurring failure modes found across recent PRs:

| Issue | Fix |
|-------|-----|
| Frontmatter fields not in peer files | Remove non-standard fields |
| Count mismatch ("five patterns" / six defined) | Recount and fix text |
| Non-deterministic set in error message | Use `sorted()` |
| `ls file 2>/dev/null` in bash examples | Use `[[ -f file ]]` |

These weren't documented anywhere in gptme-contrib before. `clean-pr-creation.md` covers PR hygiene (unrelated commits) — this covers the contribution lifecycle end-to-end.

## Validation
- [x] Pre-commit passes locally (all 15 checks)
- [x] Follows standard lesson format (Rule → Context → Detection → Pattern → Outcome)
- [x] Frontmatter matches peer workflow files (`match.keywords` array + `status`)
- [x] Linked lessons exist at correct paths

## Origin
Extracted from the contribution workflow across PRs #369–#371 (March 2026).