### PR TITLE
fix(gptme-sessions): add __main__.py for python -m invocation

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/__main__.py
+++ b/packages/gptme-sessions/src/gptme_sessions/__main__.py
@@ -1,0 +1,5 @@
+"""Allow ``python -m gptme_sessions`` to invoke the CLI."""
+
+from .cli import main
+
+raise SystemExit(main())


### PR DESCRIPTION
## Summary

Add `__main__.py` to `gptme_sessions` so the package can be invoked via `python -m gptme_sessions`.

Without this, any code using `runpy.run_module("gptme_sessions")` fails with:
```
ImportError: No module named gptme_sessions.__main__; 'gptme_sessions' is a package and cannot be directly executed
```

This was causing Bob's `session-records.py` wrapper to fail on every autonomous run (56 failures in 48 hours) — it tried `runpy.run_module("gptme_sessions")` which requires `__main__.py`.

## Test plan

- [x] `python -m gptme_sessions --help` works after change
- [x] `runpy.run_module("gptme_sessions")` no longer raises ImportError