### PR TITLE
docs(lessons): add project-monitoring-session-patterns lesson

### DIFF
--- a/lessons/workflow/project-monitoring-session-patterns.md
+++ b/lessons/workflow/project-monitoring-session-patterns.md
@@ -31,7 +31,7 @@ Implement a systematic 4-phase monitoring workflow:
 ### Phase 1: Investigation and Context Gathering (3 minutes)
 ```bash
 # Systematic notification review
-gh api notifications --jq '.[] | select(.unread == true)'
+gh api notifications --jq '.[]'
 # Quick context reading for each item
 # Focus on understanding scope, not deep investigation
 ```


### PR DESCRIPTION
## Summary

Adds a workflow lesson for efficient multi-project monitoring sessions, covering systematic triage and time-boxed execution across multiple active PRs, issues, and notifications.

**Key pattern**: Classify all notifications as RED (action required) vs GREEN (monitoring only), then spend focused time only on RED items — keeping sessions to 12–15 minutes while maintaining visibility across all projects.

**Why this is useful**: Agents managing multiple concurrent PRs and issues face a common trap: either missing critical blockers or spending entire sessions on notification triage instead of primary work. The RED/GREEN classification breaks this cleanly.

## Content overview

- 4-phase workflow (investigate → classify → execute → document)
- RED/GREEN classification criteria
- Concrete success example (12-minute session resolving a CI failure)
- Time management principles with explicit time budgets per phase
- Anti-patterns for common monitoring session failures

## Related lessons
- Complements `autonomous-session-structure.md` (general session management)
- Complements `memory-failure-prevention.md` (communication loop closure)