### PR TITLE
feat(gptme-sessions): add discover CLI subcommand for all harnesses

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -283,7 +283,11 @@ def main() -> int:
 
         if harness_filter in (None, "gptme"):
             for p in discover_gptme_sessions(start, today):
-                discovered.append({"harness": "gptme", "path": str(p)})
+                # discover_gptme_sessions returns session directories; resolve to the
+                # actual conversation file so extract_from_path can open it.
+                jsonl = p / "conversation.jsonl"
+                resolved = jsonl if jsonl.exists() else p
+                discovered.append({"harness": "gptme", "path": str(resolved)})
 
         if harness_filter in (None, "claude-code"):
             for p in discover_cc_sessions(start, today):

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -3067,6 +3067,45 @@ def test_cli_discover_with_signals(tmp_path: Path, capsys, monkeypatch):
     assert "grade=" in captured.out
 
 
+def test_cli_discover_gptme_sessions_with_signals(tmp_path: Path, capsys, monkeypatch):
+    """discover --signals resolves gptme session directories to conversation.jsonl.
+
+    discover_gptme_sessions returns *directory* paths, not .jsonl files.
+    The discover handler must resolve them before calling extract_from_path,
+    otherwise --signals fails with IsADirectoryError.
+    """
+    import sys
+
+    from gptme_sessions.cli import main
+
+    # Create a gptme-style session directory with conversation.jsonl inside
+    session_dir = tmp_path / "2026-03-06-test-session"
+    session_dir.mkdir()
+    conversation_file = session_dir / "conversation.jsonl"
+    msgs = _make_gptme_msgs(commits=1)
+    with open(conversation_file, "w") as f:
+        for msg in msgs:
+            f.write(json.dumps(msg) + "\n")
+
+    # discover_gptme_sessions returns the directory, not the file
+    monkeypatch.setattr(
+        "gptme_sessions.cli.discover_gptme_sessions", lambda *a, **kw: [session_dir]
+    )
+    monkeypatch.setattr("gptme_sessions.cli.discover_cc_sessions", lambda *a, **kw: [])
+    monkeypatch.setattr("gptme_sessions.cli.discover_codex_sessions", lambda *a, **kw: [])
+    monkeypatch.setattr("gptme_sessions.cli.discover_copilot_sessions", lambda *a, **kw: [])
+
+    monkeypatch.setattr(
+        sys, "argv", ["gptme-sessions", "discover", "--harness", "gptme", "--signals"]
+    )
+    rc = main()
+    assert rc == 0
+    captured = capsys.readouterr()
+    # --signals must produce grade output, not "signals error: Is a directory"
+    assert "grade=" in captured.out
+    assert "Is a directory" not in captured.out
+
+
 def test_cli_discover_invalid_since(tmp_path: Path, capsys, monkeypatch):
     """discover returns non-zero on invalid --since value."""
     import sys


### PR DESCRIPTION
## Summary

Adds `gptme-sessions discover` — a CLI subcommand to list trajectory files from all supported harnesses (gptme, Claude Code, Codex, Copilot) in a single command.

This is the natural follow-up to #368 (Codex/Copilot trajectory support): the extraction functions landed in #368, now there's a CLI entry point to actually use them for batch discovery and analysis.

## Usage

```bash
# Discover all sessions from last 7 days (default)
gptme-sessions discover

# Filter to a specific harness
gptme-sessions discover --harness codex --since 30d

# Extract signals inline (grade, productivity, tool_calls, commits, errors)
gptme-sessions discover --harness codex --since 3d --signals

# Machine-readable output
gptme-sessions discover --json | jq '.[].path'
```

## Example output

```
    codex  /home/bob/.codex/sessions/2026/03/06/rollout-....jsonl
    codex  /home/bob/.codex/sessions/2026/03/05/rollout-....jsonl

2 session(s) found (2026-02-27 to 2026-03-06)
```

With `--signals`:
```
[-] codex  grade=0.25  tools=28 commits=0 errors=1  /home/bob/.codex/...
[+] codex  grade=0.75  tools=52 commits=3 errors=0  /home/bob/.codex/...
```

## Changes

- **`cli.py`**: new `discover` subparser + handler using the existing `discover_*` functions from `discovery.py`
- **`test_sessions.py`**: 6 new tests (no-sessions, path listing, harness filter, JSON output, signal extraction, invalid `--since`)

## Test plan
- [x] 214 tests passing, 0 regressions
- [x] mypy clean
- [x] Validated against real Codex sessions on Bob's VM

Closes #357