### PR TITLE
docs(lessons): add Thompson sampling work category bandit pattern

### DIFF
--- a/lessons/autonomous/thompson-sampling-work-categories.md
+++ b/lessons/autonomous/thompson-sampling-work-categories.md
@@ -5,7 +5,6 @@ tags:
 - thompson-sampling
 - work-category
 - session-optimization
-- cascade
 - bandit
 match:
   keywords:
@@ -57,6 +56,9 @@ If you have a base scoring system (like CASCADE), add an additive boost:
 ```python
 from gptme_sessions import load_bandit_means
 
+# Call load_bandit_means() fresh at the start of each scheduling cycle.
+# In a long-running process that loops, stale means won't reflect bandit
+# updates from earlier cycles — so reload rather than reusing a closure.
 means = load_bandit_means("state/category-bandit", arm_ids=CATEGORIES)
 
 def apply_ts_boost(base_score: float, category: str, weight: float = 1.5) -> float:


### PR DESCRIPTION
## Summary

Adds a lesson documenting how to use gptme-sessions' Thompson sampling API for work category optimization in autonomous agents.

This is the Tier 2 "category bandit pattern" called for in #349: a generic, reusable guide that any agent can use to optimize which *kind* of work to pursue — not just Bob's CASCADE-specific implementation.

## What the lesson covers

- Why to optimize **categories** (code, triage, infrastructure, content), not **session modes** (autonomous, monitoring)
- Setting up a `Bandit` for work categories
- `load_bandit_means()` integration for existing scoring systems (additive boost pattern)
- The `post_session()` → grade → bandit update loop
- The anti-pattern: Thompson sampling over session pipelines (modes have obvious success rates, not useful signal)

## Connection to #349

The `rule-driven-session-gating.md` lesson (already in contrib) references "budget-based productive-work scheduling" as a complementary pattern and links to issue #349. Now that #349's infrastructure is merged (PRs #351, #354, #359), this lesson documents the actual usage pattern for other agents to follow.

## Test plan
- [x] `validate-lesson-metadata` passes
- [x] All pre-commit checks pass
- [x] Required sections present: Rule, Context, Detection, Pattern, Anti-Pattern, Outcome, Related
- [x] Code blocks have language tags
- [x] Relative link to `rule-driven-session-gating.md` resolves correctly