### PR TITLE
feat(gptme-sessions): add extract_usage_copilot() for model extraction

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -974,12 +974,42 @@ def infer_category(signals: dict) -> str | None:
     return best
 
 
+def extract_usage_copilot(msgs: list[dict]) -> dict:
+    """Extract model info from Copilot CLI events.jsonl trajectories.
+
+    Copilot events do not include per-turn token counts or cost data.
+    We extract the model name from ``session.model_change`` events (or
+    from ``session.start`` context if available) so callers always get a
+    consistent ``{"model": ...}`` dict across all harnesses.
+
+    Returns an empty dict if no model information is found.
+    """
+    model: str | None = None
+
+    for record in msgs:
+        rec_type = record.get("type", "")
+        if rec_type == "session.model_change":
+            m = (record.get("data") or {}).get("newModel")
+            if m:
+                model = m
+        elif rec_type == "session.start" and model is None:
+            # Some versions may include model in start context
+            data = record.get("data") or {}
+            m = data.get("selectedModel")
+            if m:
+                model = m
+
+    if model is None:
+        return {}
+    return {"model": model}
+
+
 def extract_from_path(jsonl_path: Path) -> dict:
     """Parse trajectory and return signals + grade in one call.
 
     Auto-detects format: gptme, Claude Code, Codex, or Copilot.
     Token usage is extracted when available (CC has full counts, Codex has
-    rate-limit percentages only, Copilot has no token data).
+    rate-limit percentages only, Copilot has model info only).
     """
     msgs = parse_trajectory(jsonl_path)
     fmt = detect_format(msgs)
@@ -991,7 +1021,7 @@ def extract_from_path(jsonl_path: Path) -> dict:
         usage = extract_usage_codex(msgs)
     elif fmt == "copilot":
         signals = extract_signals_copilot(msgs)
-        usage = {}  # Copilot has no token data in events
+        usage = extract_usage_copilot(msgs)
     else:
         signals = extract_signals(msgs)
         usage = extract_usage_gptme(msgs)

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -2714,8 +2714,128 @@ def test_extract_from_path_copilot(tmp_path: Path):
     result = extract_from_path(trajectory_file)
     assert result["format"] == "copilot"
     assert result["tool_calls"]["bash"] == 1
-    # Copilot has no token data
-    assert "usage" not in result
+    # Model extracted from session.start.selectedModel
+    assert result["usage"] == {"model": "claude-opus-4.6"}
+
+
+def test_extract_usage_copilot_model_change():
+    """extract_usage_copilot extracts model from session.model_change events."""
+    from gptme_sessions.signals import extract_usage_copilot
+
+    msgs = [
+        {
+            "type": "session.start",
+            "data": {"sessionId": "test", "producer": "copilot-agent"},
+            "timestamp": "2026-03-04T10:50:00Z",
+        },
+        {
+            "type": "session.model_change",
+            "data": {"newModel": "claude-sonnet-4.6"},
+            "timestamp": "2026-03-04T10:51:00Z",
+        },
+        {
+            "type": "assistant.message",
+            "data": {"toolRequests": [{"toolCallId": "tc_1", "name": "bash"}]},
+            "timestamp": "2026-03-04T10:51:05Z",
+        },
+    ]
+    usage = extract_usage_copilot(msgs)
+    assert usage == {"model": "claude-sonnet-4.6"}
+
+
+def test_extract_usage_copilot_session_start_selected_model():
+    """extract_usage_copilot falls back to selectedModel from session.start."""
+    from gptme_sessions.signals import extract_usage_copilot
+
+    msgs = [
+        {
+            "type": "session.start",
+            "data": {
+                "sessionId": "test",
+                "producer": "copilot-agent",
+                "selectedModel": "claude-opus-4.6",
+            },
+        },
+        {
+            "type": "assistant.message",
+            "data": {"toolRequests": []},
+        },
+    ]
+    usage = extract_usage_copilot(msgs)
+    assert usage == {"model": "claude-opus-4.6"}
+
+
+def test_extract_usage_copilot_no_model():
+    """extract_usage_copilot returns empty dict when no model info available."""
+    from gptme_sessions.signals import extract_usage_copilot
+
+    msgs = [
+        {
+            "type": "session.start",
+            "data": {"sessionId": "test", "producer": "copilot-agent"},
+        },
+        {
+            "type": "assistant.message",
+            "data": {"toolRequests": []},
+        },
+    ]
+    usage = extract_usage_copilot(msgs)
+    assert usage == {}
+
+
+def test_extract_usage_copilot_multiple_model_changes():
+    """extract_usage_copilot uses the last model change (matches CC/gptme behavior)."""
+    from gptme_sessions.signals import extract_usage_copilot
+
+    msgs = [
+        {
+            "type": "session.model_change",
+            "data": {"newModel": "claude-sonnet-4.6"},
+        },
+        {
+            "type": "session.model_change",
+            "data": {"newModel": "gpt-5.4"},
+        },
+    ]
+    usage = extract_usage_copilot(msgs)
+    assert usage == {"model": "gpt-5.4"}
+
+
+def test_extract_from_path_copilot_with_model(tmp_path: Path):
+    """extract_from_path includes usage with model when model_change is present."""
+    trajectory_file = tmp_path / "events.jsonl"
+    msgs = [
+        {
+            "type": "session.start",
+            "data": {"sessionId": "test", "producer": "copilot-agent"},
+            "timestamp": "2026-03-04T10:50:00Z",
+        },
+        {
+            "type": "session.model_change",
+            "data": {"newModel": "claude-sonnet-4.6"},
+            "timestamp": "2026-03-04T10:51:00Z",
+        },
+        {
+            "type": "assistant.message",
+            "data": {"toolRequests": [{"toolCallId": "tc_1", "name": "bash"}]},
+            "timestamp": "2026-03-04T10:51:05Z",
+        },
+        {
+            "type": "tool.execution_complete",
+            "data": {"toolCallId": "tc_1", "success": True, "result": {"content": "ok"}},
+            "timestamp": "2026-03-04T10:51:10Z",
+        },
+    ]
+    with open(trajectory_file, "w") as f:
+        for msg in msgs:
+            f.write(json.dumps(msg) + "\n")
+
+    from gptme_sessions.signals import extract_from_path
+
+    result = extract_from_path(trajectory_file)
+    assert result["format"] == "copilot"
+    assert "usage" in result
+    assert result["usage"]["model"] == "claude-sonnet-4.6"
 
 
 # --- Null-guard regression tests ---


### PR DESCRIPTION
## Summary

- Add `extract_usage_copilot()` that extracts model info from Copilot CLI `session.model_change` events
- Wire into `extract_from_path()` so Copilot sessions return a `usage` dict with model info, consistent with all other harnesses
- Previously Copilot was the only harness where `extract_from_path()` returned no `usage` key at all

## Context

Copilot CLI `events.jsonl` includes model information in `session.model_change` events (e.g., `{"newModel": "claude-sonnet-4.6"}`) but no per-turn token counts. This made it the only harness without model info in the usage dict, causing inconsistency in cross-harness analytics.

Confirmed by testing on real Copilot sessions on Bob's VM (3 sessions found, 2 with events.jsonl — signal extraction works correctly: 1 commit, grade 0.60 on best session).

## Test plan

- [x] `test_extract_usage_copilot_model_change` — extracts model from model_change event
- [x] `test_extract_usage_copilot_no_model` — returns empty dict when no model info
- [x] `test_extract_usage_copilot_multiple_model_changes` — last model wins (consistent with CC/gptme)
- [x] `test_extract_from_path_copilot_with_model` — end-to-end: usage included in result
- [x] All 220 existing tests still pass