### PR TITLE
chore: migrate argparse to Click in gptme-voice, gptme-whatsapp, gptme-contrib-lib, gptmail

### DIFF
--- a/packages/gptmail/scripts/cleanup_duplicates.py
+++ b/packages/gptmail/scripts/cleanup_duplicates.py
@@ -13,6 +13,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Tuple
 
+import click
+
 
 def parse_headers(content: str) -> Dict[str, str]:
     """Parse email headers from markdown content."""
@@ -97,27 +99,22 @@ def find_duplicates(sent_dir: Path) -> List[Tuple[Path, Path, str]]:
     return duplicates
 
 
-def main():
-    """Main function to identify and optionally clean up duplicates."""
-    import argparse
-
-    parser = argparse.ArgumentParser(description="Find and clean up duplicate email files")
-    parser.add_argument("--dry-run", action="store_true", help="Only show duplicates, don't delete")
-    parser.add_argument(
-        "--sent-dir",
-        type=Path,
-        default=Path.home() / "workspace" / "email" / "sent",
-        help="Path to sent email directory",
-    )
-
-    args = parser.parse_args()
-
-    if not args.sent_dir.exists():
-        print(f"Error: Directory not found: {args.sent_dir}", file=sys.stderr)
+@click.command()
+@click.option("--dry-run", is_flag=True, help="Only show duplicates, don't delete")
+@click.option(
+    "--sent-dir",
+    type=click.Path(path_type=Path),
+    default=Path.home() / "workspace" / "email" / "sent",
+    help="Path to sent email directory",
+)
+def main(dry_run: bool, sent_dir: Path):
+    """Find and clean up duplicate email files."""
+    if not sent_dir.exists():
+        print(f"Error: Directory not found: {sent_dir}", file=sys.stderr)
         sys.exit(1)
 
-    print(f"Scanning for duplicates in: {args.sent_dir}")
-    duplicates = find_duplicates(args.sent_dir)
+    print(f"Scanning for duplicates in: {sent_dir}")
+    duplicates = find_duplicates(sent_dir)
 
     if not duplicates:
         print("✅ No duplicates found!")
@@ -131,14 +128,14 @@ def main():
         print(f"Reason: {reason}")
         print()
 
-        if not args.dry_run:
+        if not dry_run:
             try:
                 duplicate.unlink()
                 print(f"✅ Deleted: {duplicate.name}\n")
             except Exception as e:
                 print(f"❌ Error deleting {duplicate.name}: {e}\n", file=sys.stderr)
 
-    if args.dry_run:
+    if dry_run:
         print("\n⚠️  DRY RUN: No files were deleted.")
         print("   Run without --dry-run to actually delete duplicates.")
     else:

--- a/packages/gptme-contrib-lib/pyproject.toml
+++ b/packages/gptme-contrib-lib/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Shared library code for gptme agents"
 requires-python = ">=3.10"
 dependencies = [
+    "click>=8.0",
     "pydantic>=2.0",
     "pyyaml>=6.0",
     "tomli>=2.0.0; python_version<'3.11'",

--- a/packages/gptme-contrib-lib/src/gptme_contrib_lib/orchestrator.py
+++ b/packages/gptme-contrib-lib/src/gptme_contrib_lib/orchestrator.py
@@ -11,6 +11,8 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict, List
 
+import click
+
 from .config import InputSourcesConfig
 from .input_source_impl import (
     EmailInputSource,
@@ -255,50 +257,51 @@ class InputSourceOrchestrator:
         self.running = False
 
 
-async def main():
-    """Main entry point for orchestrator."""
-    import argparse
+@click.command()
+@click.option(
+    "--config",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Path to configuration file (YAML)",
+)
+@click.option(
+    "--once",
+    is_flag=True,
+    help="Run once and exit instead of continuous polling",
+)
+def main(config: Path | None, once: bool):
+    """Input sources orchestrator."""
 
-    parser = argparse.ArgumentParser(description="Input sources orchestrator")
-    parser.add_argument(
-        "--config",
-        type=Path,
-        help="Path to configuration file (YAML)",
-    )
-    parser.add_argument(
-        "--once",
-        action="store_true",
-        help="Run once and exit instead of continuous polling",
-    )
-    args = parser.parse_args()
-
-    # Load configuration
-    if args.config and args.config.exists():
-        config = InputSourcesConfig.from_yaml(args.config)
-    else:
-        # Use default configuration
-        config = InputSourcesConfig()
-
-    # Create orchestrator
-    orchestrator = InputSourceOrchestrator(config)
-
-    try:
-        if args.once:
-            # Run once and exit
-            results = await orchestrator.run_once()
-            total = sum(results.values())
-            print(f"Created {total} tasks")
-            if total > 0:
-                for source, count in results.items():
-                    if count > 0:
-                        print(f"  {source}: {count}")
+    async def _run():
+        # Load configuration
+        if config and config.exists():
+            cfg = InputSourcesConfig.from_yaml(config)
         else:
-            # Run continuously
-            await orchestrator.run_continuous()
-    except KeyboardInterrupt:
-        orchestrator.stop()
-        print("\nStopped")
+            # Use default configuration
+            cfg = InputSourcesConfig()
+
+        # Create orchestrator
+        orchestrator = InputSourceOrchestrator(cfg)
+
+        try:
+            if once:
+                # Run once and exit
+                results = await orchestrator.run_once()
+                total = sum(results.values())
+                print(f"Created {total} tasks")
+                if total > 0:
+                    for source, count in results.items():
+                        if count > 0:
+                            print(f"  {source}: {count}")
+            else:
+                # Run continuously
+                await orchestrator.run_continuous()
+        except KeyboardInterrupt:
+            orchestrator.stop()
+            print("\nStopped")
+
+    asyncio.run(_run())
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()

--- a/packages/gptme-voice/pyproject.toml
+++ b/packages/gptme-voice/pyproject.toml
@@ -5,6 +5,7 @@ description = "Voice interface for gptme with OpenAI Realtime API"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
+    "click>=8.0",
     "openai>=1.0.0",
     "websockets>=12.0",
     "starlette>=0.37.0",

--- a/packages/gptme-voice/src/gptme_voice/realtime/client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/client.py
@@ -24,6 +24,7 @@ except ImportError:
     PYAUDIO_AVAILABLE = False
     print("Warning: pyaudio not available. Install with: pip install pyaudio")
 
+import click
 import websockets  # type: ignore
 
 
@@ -168,30 +169,23 @@ class LocalVoiceTest:
             self.audio.terminate()
 
 
-async def _async_main():
-    """Async entry point."""
-    import argparse
+@click.command()
+@click.option(
+    "--server", default="ws://localhost:8080/local", help="Server WebSocket URL"
+)
+def main(server: str):
+    """Local voice interface test client."""
+    test = LocalVoiceTest(server_url=server)
 
-    parser = argparse.ArgumentParser(description="Local voice interface test")
-    parser.add_argument(
-        "--server", default="ws://localhost:8080/local", help="Server WebSocket URL"
-    )
+    async def _run():
+        try:
+            await test.run()
+        except KeyboardInterrupt:
+            print("\nExiting...")
+        finally:
+            test.cleanup()
 
-    args = parser.parse_args()
-
-    test = LocalVoiceTest(server_url=args.server)
-
-    try:
-        await test.run()
-    except KeyboardInterrupt:
-        print("\nExiting...")
-    finally:
-        test.cleanup()
-
-
-def main():
-    """Synchronous entry point for console_scripts."""
-    asyncio.run(_async_main())
+    asyncio.run(_run())
 
 
 if __name__ == "__main__":

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -9,6 +9,7 @@ import base64
 import json
 import logging
 
+import click
 import uvicorn
 from starlette.applications import Starlette
 from starlette.requests import Request
@@ -212,20 +213,15 @@ class VoiceServer:
         uvicorn.run(self.app, host=self.host, port=self.port)
 
 
-def main():
-    """Entry point for running the voice server."""
-    import argparse
-
-    parser = argparse.ArgumentParser(description="Voice Interface Server for gptme")
-    parser.add_argument("--host", default="0.0.0.0", help="Host to bind to")
-    parser.add_argument("--port", type=int, default=8080, help="Port to bind to")
-    parser.add_argument("--workspace", help="Working directory for gptme commands")
-    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
-
-    args = parser.parse_args()
-
+@click.command()
+@click.option("--host", default="0.0.0.0", help="Host to bind to")
+@click.option("--port", default=8080, type=int, help="Port to bind to")
+@click.option("--workspace", default=None, help="Working directory for gptme commands")
+@click.option("--debug", is_flag=True, help="Enable debug logging")
+def main(host: str, port: int, workspace: str | None, debug: bool):
+    """Voice Interface Server for gptme."""
     logging.basicConfig(
-        level=logging.DEBUG if args.debug else logging.INFO,
+        level=logging.DEBUG if debug else logging.INFO,
         format="%(asctime)s %(name)s %(levelname)s: %(message)s",
         datefmt="%H:%M:%S",
     )
@@ -233,13 +229,13 @@ def main():
     logging.getLogger("websockets").setLevel(logging.WARNING)
 
     server = VoiceServer(
-        host=args.host,
-        port=args.port,
-        workspace=args.workspace,
+        host=host,
+        port=port,
+        workspace=workspace,
     )
 
-    logger.info(f"Starting voice server on {args.host}:{args.port}")
-    logger.info(f"Local test endpoint: ws://{args.host}:{args.port}/local")
+    logger.info(f"Starting voice server on {host}:{port}")
+    logger.info(f"Local test endpoint: ws://{host}:{port}/local")
 
     server.run()
 

--- a/packages/gptme-whatsapp/pyproject.toml
+++ b/packages/gptme-whatsapp/pyproject.toml
@@ -4,7 +4,9 @@ version = "0.1.0"
 description = "WhatsApp integration for gptme agents via whatsapp-web.js"
 readme = "README.md"
 requires-python = ">=3.10"
-dependencies = []
+dependencies = [
+    "click>=8.0",
+]
 
 [project.optional-dependencies]
 test = ["pytest>=7.0"]

--- a/packages/gptme-whatsapp/src/gptme_whatsapp/setup.py
+++ b/packages/gptme-whatsapp/src/gptme_whatsapp/setup.py
@@ -9,6 +9,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import click
+
 NODE_DIR = Path(__file__).parent.parent.parent.parent / "node"
 
 
@@ -88,54 +90,50 @@ WantedBy=default.target
     return service
 
 
+@click.group()
 def main():
-    """CLI entry point for setup."""
-    import argparse
+    """gptme-whatsapp setup."""
 
-    parser = argparse.ArgumentParser(description="gptme-whatsapp setup")
-    subparsers = parser.add_subparsers(dest="command")
 
-    subparsers.add_parser("install", help="Install npm dependencies")
-
-    service_parser = subparsers.add_parser("service", help="Generate systemd service")
-    service_parser.add_argument("--agent", required=True, help="Agent name (e.g. sven)")
-    service_parser.add_argument(
-        "--workspace", required=True, help="Agent workspace path"
-    )
-    service_parser.add_argument("--contacts", nargs="+", help="Allowed phone numbers")
-    service_parser.add_argument(
-        "--node-path", default="/usr/local/bin", help="Node.js bin path"
-    )
-    service_parser.add_argument(
-        "--backend",
-        default="gptme",
-        choices=["gptme", "claude-code"],
-        help="Agent backend",
-    )
-    service_parser.add_argument(
-        "--claude-path", default="", help="Claude Code bin path"
-    )
-
-    args = parser.parse_args()
-
-    if args.command == "install":
-        if install_npm_deps():
-            print("npm dependencies installed successfully.")
-        else:
-            sys.exit(1)
-    elif args.command == "service":
-        contacts = args.contacts or []
-        service = generate_systemd_service(
-            args.agent,
-            args.workspace,
-            contacts,
-            args.node_path,
-            args.backend,
-            args.claude_path,
-        )
-        print(service)
+@main.command()
+def install():
+    """Install npm dependencies."""
+    if install_npm_deps():
+        print("npm dependencies installed successfully.")
     else:
-        parser.print_help()
+        sys.exit(1)
+
+
+@main.command()
+@click.option("--agent", required=True, help="Agent name (e.g. sven)")
+@click.option("--workspace", required=True, help="Agent workspace path")
+@click.option("--contacts", multiple=True, help="Allowed phone numbers")
+@click.option("--node-path", default="/usr/local/bin", help="Node.js bin path")
+@click.option(
+    "--backend",
+    default="gptme",
+    type=click.Choice(["gptme", "claude-code"]),
+    help="Agent backend",
+)
+@click.option("--claude-path", default="", help="Claude Code bin path")
+def service(
+    agent: str,
+    workspace: str,
+    contacts: tuple,
+    node_path: str,
+    backend: str,
+    claude_path: str,
+):
+    """Generate systemd service."""
+    service_text = generate_systemd_service(
+        agent,
+        workspace,
+        list(contacts),
+        node_path,
+        backend,
+        claude_path,
+    )
+    print(service_text)
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -994,6 +994,7 @@ name = "gptme-contrib-lib"
 version = "0.1.0"
 source = { editable = "packages/gptme-contrib-lib" }
 dependencies = [
+    { name = "click" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
@@ -1012,6 +1013,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "click", specifier = ">=8.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
@@ -1270,6 +1272,7 @@ version = "0.1.0"
 source = { editable = "packages/gptme-voice" }
 dependencies = [
     { name = "audioop-lts", marker = "python_full_version >= '3.13'" },
+    { name = "click" },
     { name = "openai" },
     { name = "starlette" },
     { name = "uvicorn" },
@@ -1287,6 +1290,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "audioop-lts", marker = "python_full_version >= '3.13'", specifier = ">=0.2" },
+    { name = "click", specifier = ">=8.0" },
     { name = "openai", specifier = ">=1.0.0" },
     { name = "pyaudio", marker = "extra == 'local'", specifier = ">=0.2.13" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
@@ -1326,6 +1330,9 @@ provides-extras = ["test"]
 name = "gptme-whatsapp"
 version = "0.1.0"
 source = { editable = "packages/gptme-whatsapp" }
+dependencies = [
+    { name = "click" },
+]
 
 [package.optional-dependencies]
 test = [
@@ -1333,7 +1340,10 @@ test = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" }]
+requires-dist = [
+    { name = "click", specifier = ">=8.0" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
+]
 provides-extras = ["test"]
 
 [[package]]


### PR DESCRIPTION
Part of #385.

Migrates 4 more packages from argparse to Click, following the pattern established in #383 (dashboard) and #387/#388 (gptme-sessions, gptodo).

## Packages migrated

- **gptme-voice**: `server.py` (`gptme-voice-server`) + `client.py` (`gptme-voice-client`)
- **gptme-whatsapp**: `setup.py` (`gptme-whatsapp-setup`) — uses `@click.group()` for `install`/`service` subcommands
- **gptme-contrib-lib**: `orchestrator.py` — wraps `async` body in `asyncio.run()` inside the click command
- **gptmail**: `scripts/cleanup_duplicates.py` — click was already a dep

Added `click>=8.0` to dependencies in gptme-voice, gptme-whatsapp, and gptme-contrib-lib pyproject.toml.

## Not included

- `gptme-sessions/thompson_sampling.py` (837 lines, 5 subcommands with complex args) — merits its own PR
- `gptme-lessons-extras/` (10+ files) — merits its own PR

## Test plan
- [x] All 5 modified files pass `ast.parse()` syntax check
- [x] `gptme-whatsapp` tests: 2 passed
- [x] `gptmail` tests: 7 passed
- [x] Manual click CliRunner smoke test: `--help`, subcommands, error paths all work