### PR TITLE
ci: gate test runs on affected paths to reduce CI load

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -7,7 +7,33 @@ on:
     branches: [ main, master ]
 
 jobs:
+  # Detect which paths changed to skip expensive jobs on unrelated PRs
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        filters: |
+          code:
+            - 'packages/**'
+            - 'plugins/**'
+            - 'scripts/**'
+            - 'pyproject.toml'
+            - 'uv.lock'
+            - 'Makefile'
+            - '.github/workflows/test-integration.yml'
+
   integration-tests:
+    needs: changes
+    # Always run on push to master; on PRs, only when code changed
+    if: github.event_name == 'push' || needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -7,8 +7,32 @@ on:
     branches: [ main, master ]
 
 jobs:
+  # Detect which paths changed to skip expensive jobs on unrelated PRs
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      packages: ${{ steps.filter.outputs.packages }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        filters: |
+          packages:
+            - 'packages/**'
+            - 'pyproject.toml'
+            - 'uv.lock'
+            - 'Makefile'
+            - '.github/workflows/test-packages.yml'
+
   # Discovery job - outputs package matrix dynamically using Makefile (single source of truth)
   discover:
+    needs: changes
+    # Always run on push to master; on PRs, only when package code changed
+    if: github.event_name == 'push' || needs.changes.outputs.packages == 'true'
     runs-on: ubuntu-latest
     outputs:
       packages: ${{ steps.discover.outputs.packages }}
@@ -54,6 +78,9 @@ jobs:
 
   # Typecheck all packages (single job, not parallelized per-package)
   typecheck:
+    needs: changes
+    # Always run on push to master; on PRs, only when package code changed
+    if: github.event_name == 'push' || needs.changes.outputs.packages == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-plugins.yml
+++ b/.github/workflows/test-plugins.yml
@@ -7,8 +7,29 @@ on:
     branches: [ main, master ]
 
 jobs:
+  # Detect which paths changed to skip expensive jobs on unrelated PRs
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      plugins: ${{ steps.filter.outputs.plugins }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        filters: |
+          plugins:
+            - 'plugins/**'
+            - '.github/workflows/test-plugins.yml'
+
   # Discovery job - outputs plugin matrix dynamically using Makefile (single source of truth)
   discover:
+    needs: changes
+    # Always run on push to master; on PRs, only when plugin code changed
+    if: github.event_name == 'push' || needs.changes.outputs.plugins == 'true'
     runs-on: ubuntu-latest
     outputs:
       plugins: ${{ steps.discover.outputs.plugins }}
@@ -89,7 +110,9 @@ jobs:
 
   # Coverage report (combined for all plugins)
   coverage:
-    needs: discover
+    needs: changes
+    # Always run on push to master; on PRs, only when plugin code changed
+    if: github.event_name == 'push' || needs.changes.outputs.plugins == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Add `dorny/paths-filter@v3` to all three test workflows (`test-packages.yml`, `test-plugins.yml`, `test-integration.yml`)
- PRs that don't touch relevant paths skip the corresponding test jobs entirely
- All jobs still run unconditionally on push to master

## Impact

Currently every PR commit triggers ~50 CI jobs across all packages and plugins. A docs-only or lessons-only PR (which is common) runs zero relevant tests but still spawns all jobs.

With this change:
- **Lessons/docs PRs**: Skip all test workflows (saves ~50 jobs)
- **Package-only PRs**: Skip plugin tests (saves ~28 jobs)
- **Plugin-only PRs**: Skip package tests (saves ~20 jobs)

### Path filter rules

| Workflow | Triggers on changes to |
|----------|----------------------|
| test-packages | `packages/**`, `pyproject.toml`, `uv.lock`, `Makefile`, workflow file |
| test-plugins | `plugins/**`, workflow file |
| test-integration | `packages/**`, `plugins/**`, `scripts/**`, `pyproject.toml`, `uv.lock`, `Makefile`, workflow file |

### Pattern

Uses the same `dorny/paths-filter` + `if: github.event_name == 'push' || needs.changes.outputs.X == 'true'` pattern already proven in gptme core's `test.yml`.

Closes #393