### PR TITLE
ci: gate test matrix on affected packages/plugins for PRs

### DIFF
--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -14,18 +14,46 @@ jobs:
       packages: ${{ steps.discover.outputs.packages }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Discover packages
         id: discover
         run: |
           # Use Makefile for package discovery (single source of truth)
-          packages=$(make ci-list-packages-json)
+          all_packages=$(make ci-list-packages-json)
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # On PRs, only test packages with changed files
+            git fetch origin "${{ github.base_ref }}" --depth=1 2>/dev/null || true
+
+            # If shared/CI files changed, run all packages
+            shared_changed=$(git diff --name-only "origin/${{ github.base_ref }}"...HEAD \
+              | grep -cE '^(Makefile|pyproject\.toml|uv\.lock|\.github/)' || echo 0)
+
+            if [ "$shared_changed" -gt 0 ]; then
+              packages="$all_packages"
+              echo "Shared files changed → running all packages"
+            else
+              # Filter to only packages with changed files
+              changed_pkgs=$(git diff --name-only "origin/${{ github.base_ref }}"...HEAD \
+                | grep '^packages/' | cut -d/ -f2 | sort -u \
+                | jq -R . | jq -sc .)
+              packages=$(echo "$all_packages" \
+                | jq --argjson changed "$changed_pkgs" \
+                  '[.[] | select(. as $p | $changed | any(. == $p))]')
+            fi
+          else
+            packages="$all_packages"
+          fi
+
           echo "packages=$packages" >> $GITHUB_OUTPUT
-          echo "Discovered packages: $packages"
+          echo "Running tests for packages: $packages"
 
   # Test each package in parallel
   test:
     needs: discover
+    if: needs.discover.outputs.packages != '[]'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/test-plugins.yml
+++ b/.github/workflows/test-plugins.yml
@@ -14,18 +14,46 @@ jobs:
       plugins: ${{ steps.discover.outputs.plugins }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Discover plugins with tests
         id: discover
         run: |
           # Use Makefile for plugin discovery (single source of truth)
-          plugins=$(make ci-list-plugins-json)
+          all_plugins=$(make ci-list-plugins-json)
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # On PRs, only test plugins with changed files
+            git fetch origin "${{ github.base_ref }}" --depth=1 2>/dev/null || true
+
+            # If shared/CI files changed, run all plugins
+            shared_changed=$(git diff --name-only "origin/${{ github.base_ref }}"...HEAD \
+              | grep -cE '^(Makefile|pyproject\.toml|uv\.lock|\.github/)' || echo 0)
+
+            if [ "$shared_changed" -gt 0 ]; then
+              plugins="$all_plugins"
+              echo "Shared files changed → running all plugins"
+            else
+              # Filter to only plugins with changed files
+              changed_plugins=$(git diff --name-only "origin/${{ github.base_ref }}"...HEAD \
+                | grep '^plugins/' | cut -d/ -f2 | sort -u \
+                | jq -R . | jq -sc .)
+              plugins=$(echo "$all_plugins" \
+                | jq --argjson changed "$changed_plugins" \
+                  '[.[] | select(. as $p | $changed | any(. == $p))]')
+            fi
+          else
+            plugins="$all_plugins"
+          fi
+
           echo "plugins=$plugins" >> $GITHUB_OUTPUT
-          echo "Discovered plugins: $plugins"
+          echo "Running tests for plugins: $plugins"
 
   # Test each plugin in parallel
   test:
     needs: discover
+    if: needs.discover.outputs.plugins != '[]'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -54,7 +82,7 @@ jobs:
   # Integration tests (only on master push, with API keys)
   integration-tests:
     needs: discover
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master' && needs.discover.outputs.plugins != '[]'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -90,6 +118,7 @@ jobs:
   # Coverage report (combined for all plugins)
   coverage:
     needs: discover
+    if: needs.discover.outputs.plugins != '[]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Fixes #393

## Summary

On pull requests, the test matrix now filters to only packages/plugins that have changed files. Previously every PR triggered ~63 matrix runs regardless of what changed.

**How it works:**

- In the `discover` job, on PR events: compare changed files against the base branch using `git diff`
- Filter the matrix to only packages/plugins under their respective directory (`packages/<name>/`, `plugins/<name>/`)
- **Fallback to all**: if shared files change (`Makefile`, `pyproject.toml`, `uv.lock`, `.github/`) — run the full matrix to keep CI honest
- If nothing in the matrix changed, skip test/integration/coverage jobs entirely via `if: ... != '[]'`
- On master push: always run everything (no filtering)

## Example

PR touching only `packages/gptodo/` → runs 3 matrix jobs (one per Python version) instead of 27. PR touching a plugin → runs 2 jobs instead of 30+.

## Test plan
- [ ] PR touching a single package only runs tests for that package
- [ ] PR touching a single plugin only runs tests for that plugin
- [ ] PR touching `Makefile` or `.github/` runs all packages and plugins
- [ ] PR with no package/plugin changes skips test jobs entirely
- [ ] Master push runs all packages and plugins as before