### PR TITLE
ci: gate test runs to affected packages/plugins on PRs

### DIFF
--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -12,20 +12,54 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       packages: ${{ steps.discover.outputs.packages }}
+      has_changes: ${{ steps.discover.outputs.has_changes }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Needed for git diff with base branch on PRs
 
       - name: Discover packages
         id: discover
         run: |
-          # Use Makefile for package discovery (single source of truth)
-          packages=$(make ci-list-packages-json)
+          # Get all packages from Makefile (single source of truth)
+          make ci-list-packages-json > /tmp/all_packages.json
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            # Get files changed in this PR
+            changed=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+
+            # If shared config changed, run all packages
+            if echo "$changed" | grep -qE '^(\.github/workflows/test-packages\.yml|Makefile|pyproject\.toml|uv\.lock)'; then
+              echo "Shared config changed, running all packages"
+              packages=$(cat /tmp/all_packages.json)
+              echo "has_changes=true" >> $GITHUB_OUTPUT
+            else
+              # Extract affected package names from changed paths
+              affected=$(echo "$changed" | sed -n 's|^packages/\([^/]*\)/.*|\1|p' | sort -u)
+
+              if [ -z "$affected" ]; then
+                echo "No package files changed, skipping tests"
+                packages="[]"
+                echo "has_changes=false" >> $GITHUB_OUTPUT
+              else
+                # Filter all packages to only affected ones
+                packages=$(echo "$affected" | python3 -c "import json,sys; all_pkgs=json.load(open('/tmp/all_packages.json')); affected=set(sys.stdin.read().strip().split('\n')); print(json.dumps([p for p in all_pkgs if p in affected]))")
+                echo "has_changes=true" >> $GITHUB_OUTPUT
+              fi
+            fi
+          else
+            # On push to master, run all packages
+            packages=$(cat /tmp/all_packages.json)
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
           echo "packages=$packages" >> $GITHUB_OUTPUT
           echo "Discovered packages: $packages"
 
   # Test each package in parallel
   test:
     needs: discover
+    if: needs.discover.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -54,6 +88,8 @@ jobs:
 
   # Typecheck all packages (single job, not parallelized per-package)
   typecheck:
+    needs: discover
+    if: needs.discover.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-plugins.yml
+++ b/.github/workflows/test-plugins.yml
@@ -12,20 +12,54 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       plugins: ${{ steps.discover.outputs.plugins }}
+      has_changes: ${{ steps.discover.outputs.has_changes }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Needed for git diff with base branch on PRs
 
       - name: Discover plugins with tests
         id: discover
         run: |
-          # Use Makefile for plugin discovery (single source of truth)
-          plugins=$(make ci-list-plugins-json)
+          # Get all plugins from Makefile (single source of truth)
+          make ci-list-plugins-json > /tmp/all_plugins.json
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            # Get files changed in this PR
+            changed=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+
+            # If shared config changed, run all plugins
+            if echo "$changed" | grep -qE '^(\.github/workflows/test-plugins\.yml|Makefile)'; then
+              echo "Shared config changed, running all plugins"
+              plugins=$(cat /tmp/all_plugins.json)
+              echo "has_changes=true" >> $GITHUB_OUTPUT
+            else
+              # Extract affected plugin names from changed paths
+              affected=$(echo "$changed" | sed -n 's|^plugins/\([^/]*\)/.*|\1|p' | sort -u)
+
+              if [ -z "$affected" ]; then
+                echo "No plugin files changed, skipping tests"
+                plugins="[]"
+                echo "has_changes=false" >> $GITHUB_OUTPUT
+              else
+                # Filter all plugins to only affected ones
+                plugins=$(echo "$affected" | python3 -c "import json,sys; all_plugins=json.load(open('/tmp/all_plugins.json')); affected=set(sys.stdin.read().strip().split('\n')); print(json.dumps([p for p in all_plugins if p in affected]))")
+                echo "has_changes=true" >> $GITHUB_OUTPUT
+              fi
+            fi
+          else
+            # On push to master, run all plugins
+            plugins=$(cat /tmp/all_plugins.json)
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
           echo "plugins=$plugins" >> $GITHUB_OUTPUT
           echo "Discovered plugins: $plugins"
 
   # Test each plugin in parallel
   test:
     needs: discover
+    if: needs.discover.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -90,6 +124,7 @@ jobs:
   # Coverage report (combined for all plugins)
   coverage:
     needs: discover
+    if: needs.discover.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Reduces CI runs on PRs from 63 (all packages × all Python versions) to only the packages/plugins that actually changed.

**Behavior:**
- **PRs**: Only test packages/plugins with file changes in the PR
- **Shared config changes** (Makefile, pyproject.toml, uv.lock, workflow file): Run all, as a safety net
- **No changes to packages/plugins**: Skip all tests (`has_changes=false`)
- **Push to master**: Unchanged — runs everything

The `typecheck` (packages) and `coverage` (plugins) jobs are also gated via `needs.discover.outputs.has_changes`.

## Implementation

In the `discover` job:
1. `fetch-depth: 0` added to checkout (needed for `git diff` against base branch)
2. On PRs: parse `git diff --name-only origin/$base...HEAD`, extract affected package/plugin names, filter the full list from Makefile
3. Emit `has_changes` output alongside the existing matrix output

Downstream jobs use `if: needs.discover.outputs.has_changes == 'true'` to skip when nothing changed.

## Test plan

- [ ] PR touching only `packages/gptodo/` → only `gptodo` tests run
- [ ] PR touching only `lessons/` → all package/plugin tests skip
- [ ] PR touching `Makefile` → all packages/plugins run (shared config fallback)
- [ ] Push to master → all packages/plugins run (unchanged)

Closes #393