### PR TITLE
fix(gptme-sessions): ruff-format cli.py after Click migration

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -378,7 +378,9 @@ def signals(path: Path, as_json: bool, grade: bool, usage: bool) -> None:
                 primary = u["rate_limit_primary_pct"]
                 secondary = u.get("rate_limit_secondary_pct")
                 sec_str = f" secondary={secondary:.1f}%" if secondary is not None else ""
-                click.echo(f"Rate limits: primary={primary:.1f}%{sec_str} (no absolute token counts)")
+                click.echo(
+                    f"Rate limits: primary={primary:.1f}%{sec_str} (no absolute token counts)"
+                )
         return
 
     # Human-readable summary


### PR DESCRIPTION
## Summary

Fixes the master branch pre-commit CI failure introduced by #392 (Click migration).

The `ruff-format` hook (v0.6.9) reformats one long line in the `signals` command of `cli.py`:

```python
# Before (line too long)
click.echo(f"Rate limits: primary={primary:.1f}%{sec_str} (no absolute token counts)")

# After
click.echo(
    f"Rate limits: primary={primary:.1f}%{sec_str} (no absolute token counts)"
)
```

This is a pure formatting fix — no logic changes.