### PR TITLE
ci: filter test matrix to affected packages/plugins on PRs

### DIFF
--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -44,28 +44,36 @@ jobs:
 
       - name: Discover packages
         id: discover
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
           # Get all packages from Makefile (single source of truth)
           make ci-list-packages-json > /tmp/all_packages.json
 
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            # Get files changed in this PR
-            changed=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+            # Get files changed in this PR (use env var to avoid shell injection)
+            changed=$(git diff --name-only "origin/${BASE_REF}...HEAD")
 
             # If shared config changed, run all packages (can't tell which are affected)
             if echo "$changed" | grep -qE '^(Makefile|pyproject\.toml|uv\.lock|\.github/workflows/test-packages\.yml)'; then
               echo "Shared config changed, running all packages"
               packages=$(cat /tmp/all_packages.json)
             else
-              # Extract affected package names from changed paths (packages/<name>/...)
-              affected=$(echo "$changed" | sed -n 's|^packages/\([^/]*\)/.*|\1|p' | sort -u)
-
-              if [ -z "$affected" ]; then
-                echo "No package files changed, skipping tests"
-                packages="[]"
+              # Files directly under packages/ (not in a subdirectory) also trigger full run
+              if echo "$changed" | grep -qE '^packages/[^/]+$'; then
+                echo "Root-level packages/ file changed, running all packages"
+                packages=$(cat /tmp/all_packages.json)
               else
-                # Filter all packages to only affected ones
-                packages=$(echo "$affected" | python3 -c "import json,sys; all_pkgs=json.load(open('/tmp/all_packages.json')); affected=set(sys.stdin.read().strip().split('\n')); print(json.dumps([p for p in all_pkgs if p in affected]))")
+                # Extract affected package names from changed paths (packages/<name>/...)
+                affected=$(echo "$changed" | sed -n 's|^packages/\([^/]*\)/.*|\1|p' | sort -u)
+
+                if [ -z "$affected" ]; then
+                  echo "No package files changed, skipping tests"
+                  packages="[]"
+                else
+                  # Filter all packages to only affected ones
+                  packages=$(echo "$affected" | python3 -c "import json,sys; all_pkgs=json.load(open('/tmp/all_packages.json')); affected=set(sys.stdin.read().strip().split('\n')); print(json.dumps([p for p in all_pkgs if p in affected]))")
+                fi
               fi
             fi
           else

--- a/.github/workflows/test-plugins.yml
+++ b/.github/workflows/test-plugins.yml
@@ -44,28 +44,36 @@ jobs:
 
       - name: Discover plugins with tests
         id: discover
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
           # Get all plugins from Makefile (single source of truth)
           make ci-list-plugins-json > /tmp/all_plugins.json
 
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            # Get files changed in this PR
-            changed=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+            # Get files changed in this PR (use env var to avoid shell injection)
+            changed=$(git diff --name-only "origin/${BASE_REF}...HEAD")
 
             # If shared config changed, run all plugins (can't tell which are affected)
             if echo "$changed" | grep -qE '^(Makefile|pyproject\.toml|uv\.lock|\.github/workflows/test-plugins\.yml)'; then
               echo "Shared config changed, running all plugins"
               plugins=$(cat /tmp/all_plugins.json)
             else
-              # Extract affected plugin names from changed paths (plugins/<name>/...)
-              affected=$(echo "$changed" | sed -n 's|^plugins/\([^/]*\)/.*|\1|p' | sort -u)
-
-              if [ -z "$affected" ]; then
-                echo "No plugin files changed, skipping tests"
-                plugins="[]"
+              # Files directly under plugins/ (not in a subdirectory) also trigger full run
+              if echo "$changed" | grep -qE '^plugins/[^/]+$'; then
+                echo "Root-level plugins/ file changed, running all plugins"
+                plugins=$(cat /tmp/all_plugins.json)
               else
-                # Filter all plugins to only affected ones
-                plugins=$(echo "$affected" | python3 -c "import json,sys; all_plugins=json.load(open('/tmp/all_plugins.json')); affected=set(sys.stdin.read().strip().split('\n')); print(json.dumps([p for p in all_plugins if p in affected]))")
+                # Extract affected plugin names from changed paths (plugins/<name>/...)
+                affected=$(echo "$changed" | sed -n 's|^plugins/\([^/]*\)/.*|\1|p' | sort -u)
+
+                if [ -z "$affected" ]; then
+                  echo "No plugin files changed, skipping tests"
+                  plugins="[]"
+                else
+                  # Filter all plugins to only affected ones
+                  plugins=$(echo "$affected" | python3 -c "import json,sys; all_plugins=json.load(open('/tmp/all_plugins.json')); affected=set(sys.stdin.read().strip().split('\n')); print(json.dumps([p for p in all_plugins if p in affected]))")
+                fi
               fi
             fi
           else


### PR DESCRIPTION
Follow-up to #394 as requested by @ErikBjare.

## What this adds

The `discover` job now uses `git diff` to determine *which* packages/plugins actually changed on a PR, and narrows the test matrix to only those. The `changes` job from #394 still provides the coarse gate (skip entirely if nothing in `packages/**` changed); this PR adds fine-grained filtering *within* that gate.

**Before** (after #394): PR touching only `gptodo` → `changes` says yes → all 9 packages × 3 Python versions = **27 jobs**

**After** (this PR): PR touching only `gptodo` → `changes` says yes → `discover` filters to `["gptodo"]` → **3 jobs**

## Logic

- **PR, only package/plugin files changed**: matrix = affected packages/plugins only
- **PR, shared config changed** (Makefile, pyproject.toml, uv.lock, workflow file): matrix = all (can't determine scope)
- **Push to master**: matrix = all (unchanged)

## Files changed

- `.github/workflows/test-packages.yml` — `discover` job: `fetch-depth: 0` + git diff filtering; `test` job: skip if matrix is empty (`[]`)
- `.github/workflows/test-plugins.yml` — same pattern

The `typecheck` and `coverage` jobs are unchanged (they don't have per-package granularity anyway).