### PR TITLE
fix(dashboard): correct README deps, add /api/journals docs and tests

### DIFF
--- a/packages/gptme-dashboard/README.md
+++ b/packages/gptme-dashboard/README.md
@@ -80,6 +80,7 @@ Static gh-pages deployments are unaffected — the dynamic panels only appear wh
 | `GET /api/sessions/stats` | Aggregated session statistics by model/category |
 | `GET /api/sessions[?days=N]` | Recent sessions (last 30 days by default) |
 | `GET /api/services` | Systemd/launchd services matching the agent name |
+| `GET /api/journals[?limit=N]` | Recent journal entries (last 30 by default) |
 
 Requires `pip install "gptme-dashboard[serve]"`.
 
@@ -126,9 +127,8 @@ gptme-dashboard generate --workspace ~/bob
 - `click` (CLI)
 - `jinja2` (templating)
 - `pyyaml` (frontmatter parsing)
-- `markdown` (lesson/skill detail pages)
+- `markdown-it-py` (lesson/skill detail pages, CommonMark compliant)
 - `pygments` (syntax highlighting in detail pages)
-- `gptme` (workspace data model)
 
 Optional:
 - `flask` + `gptme-sessions` — required for `gptme-dashboard serve` (`[serve]` extra)

--- a/packages/gptme-dashboard/tests/test_server.py
+++ b/packages/gptme-dashboard/tests/test_server.py
@@ -339,3 +339,63 @@ def test_workspace_no_sessions(tmp_path: Path):
         resp = c.get("/api/sessions")
         assert resp.status_code == 200
         assert resp.get_json() == []
+
+
+def test_api_journals_empty(client):
+    """Test /api/journals returns empty list when no journal directory exists."""
+    resp = client.get("/api/journals")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data, list)
+    assert len(data) == 0
+
+
+def test_api_journals_with_entries(tmp_path: Path):
+    """Test /api/journals returns journal entries when journal directory exists."""
+    (tmp_path / "gptme.toml").write_text('[agent]\nname = "TestBot"\n')
+    (tmp_path / "lessons").mkdir()
+
+    # Create journal entries in subdirectory format
+    day_dir = tmp_path / "journal" / "2026-03-07"
+    day_dir.mkdir(parents=True)
+    (day_dir / "session.md").write_text("## Morning session\n\nWorked on the dashboard.\n")
+    (day_dir / "notes.md").write_text("## Notes\n\nSome notes here.\n")
+
+    site_dir = tmp_path / "site"
+    app = create_app(tmp_path, site_dir=site_dir)
+    app.config["TESTING"] = True
+
+    with app.test_client() as c:
+        resp = c.get("/api/journals")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert isinstance(data, list)
+        assert len(data) == 2
+        # Entries should have date, name, preview
+        entry = data[0]
+        assert entry["date"] == "2026-03-07"
+        assert "name" in entry
+        assert "preview" in entry
+
+
+def test_api_journals_limit(tmp_path: Path):
+    """Test /api/journals respects the limit parameter."""
+    (tmp_path / "gptme.toml").write_text('[agent]\nname = "TestBot"\n')
+    (tmp_path / "lessons").mkdir()
+
+    # Create 5 journal days
+    for i in range(1, 6):
+        day_dir = tmp_path / "journal" / f"2026-03-{i:02d}"
+        day_dir.mkdir(parents=True)
+        (day_dir / "session.md").write_text(f"## Day {i}\n\nContent for day {i}.\n")
+
+    site_dir = tmp_path / "site"
+    app = create_app(tmp_path, site_dir=site_dir)
+    app.config["TESTING"] = True
+
+    with app.test_client() as c:
+        resp = c.get("/api/journals?limit=3")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert isinstance(data, list)
+        assert len(data) == 3


### PR DESCRIPTION
## Summary

Small polish fixes for the dashboard package, addressing remaining gaps after the main PRs (up through #414) were merged.

- **Fix README dependency**: `markdown` → `markdown-it-py` (the actual dep since #414 switched from the `markdown` library)
- **Add `/api/journals` to API table in README**: The endpoint was implemented in #411 but never documented in the live API endpoints table
- **Add 3 tests for `/api/journals`**: The endpoint existed but had zero test coverage in `test_server.py`

## Test plan

- [x] All 114 tests pass locally (`uv run --with flask pytest tests/ -q`)
- [x] New tests cover: empty workspace, subdirectory journal format, and `?limit=N` parameter

Closes #382 (if everything else is in order after this).