### PR TITLE
fix(sessions): show sync hint when store has partial entries

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -122,6 +122,7 @@ def cli(ctx: click.Context, sessions_dir: Path | None) -> None:
             _show_discovery_fallback()
         else:
             format_stats(s)
+            click.echo("Tip: Run 'gptme-sessions sync' to keep the store up to date.")
 
 
 # -- Shared filter options for query/stats -----------------------------------


### PR DESCRIPTION
## Summary

- When `gptme-sessions` is invoked with no subcommand and the store has entries, now shows: `Tip: Run 'gptme-sessions sync' to keep the store up to date.`
- The empty-store fallback already showed a sync hint; this fills the gap for partial stores

## Motivation

Erik reported in #415 that after running `gptme-sessions` with a single manual `append` record, he saw only raw stats with no indication that more sessions existed on disk. This hint closes that discoverability gap.

The change is a single `click.echo()` line after `format_stats(s)` in the main CLI group's no-subcommand path. It does not affect subcommands (`stats`, `runs`, `query`) or JSON output paths.

Closes #415 (together with #418, #420, #422).