### PR TITLE
feat(dashboard): add About section from workspace README.md

### DIFF
--- a/packages/gptme-dashboard/src/gptme_dashboard/generate.py
+++ b/packages/gptme-dashboard/src/gptme_dashboard/generate.py
@@ -774,6 +774,35 @@ def scan_skills(workspace: Path, source: str = "") -> list[dict]:
     return skills
 
 
+def scan_readme(workspace: Path) -> dict:
+    """Read the workspace README.md for display as an About section.
+
+    Returns a dict with ``body`` (raw markdown) and ``preview`` (first
+    non-heading paragraph, max 300 chars).  Returns an empty dict when
+    README.md is absent or empty.
+    """
+    readme_path = workspace / "README.md"
+    if not readme_path.exists():
+        return {}
+
+    _, body = parse_frontmatter(readme_path)
+    body = body.strip()
+    if not body:
+        return {}
+
+    # Extract first non-empty, non-heading paragraph as the preview.
+    preview = ""
+    for para in body.split("\n\n"):
+        para = para.strip()
+        if para and not para.startswith("#") and not para.startswith("!"):
+            preview = para[:300]
+            if len(para) > 300:
+                preview += "…"
+            break
+
+    return {"body": body, "preview": preview}
+
+
 def read_workspace_config(workspace: Path) -> dict:
     """Read gptme.toml for workspace metadata using inline TOML parsing."""
     try:
@@ -886,6 +915,7 @@ def collect_workspace_data(
     """
     config = read_workspace_config(workspace)
     agent_urls = read_agent_urls(workspace)
+    readme = scan_readme(workspace)
 
     lessons = scan_lessons(workspace)
     enabled_plugins = config.get("plugins_enabled")
@@ -1000,6 +1030,7 @@ def collect_workspace_data(
         "workspace_name": workspace_name,
         "gh_repo_url": gh_repo_url,
         "agent_urls": agent_urls,
+        "readme": readme,
         "lessons": lessons,
         "plugins": plugins,
         "packages": packages,
@@ -1040,7 +1071,8 @@ def generate(
     )
 
     template = env.get_template("index.html")
-    html = template.render(**data)
+    readme_html = render_markdown_to_html(data["readme"]["body"]) if data.get("readme") else ""
+    html = template.render(**data, readme_html=readme_html)
 
     output.mkdir(parents=True, exist_ok=True)
     (output / "index.html").write_text(html)

--- a/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
+++ b/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
@@ -162,6 +162,19 @@ tr:hover { background: var(--accent-dim); }
 .search-box::placeholder { color: var(--text-dim); }
 .search-box:focus { outline: none; border-color: var(--accent); }
 
+/* Rendered markdown content (About/README section) */
+.content { line-height: 1.6; }
+.content h1, .content h2 { font-size: 1.1rem; font-weight: 600; margin: 1rem 0 0.5rem; border-bottom: 1px solid var(--border); padding-bottom: 0.25rem; }
+.content h3 { font-size: 1rem; font-weight: 600; margin: 0.75rem 0 0.25rem; }
+.content p { margin: 0.5rem 0; }
+.content ul, .content ol { margin: 0.5rem 0; padding-left: 1.75rem; }
+.content li { margin: 0.2rem 0; }
+.content code { background: var(--code-bg); padding: 0.1em 0.3em; border-radius: 3px; font-size: 0.88em; font-family: monospace; }
+.content pre { background: var(--code-bg); border: 1px solid var(--border); border-radius: 6px; padding: 0.75rem; overflow-x: auto; margin: 0.5rem 0; }
+.content pre code { background: none; padding: 0; }
+.content a { color: var(--accent); }
+.content blockquote { border-left: 3px solid var(--accent); padding-left: 0.75rem; color: var(--text-dim); margin: 0.5rem 0; }
+
 /* GitHub source link */
 .gh-link {
   color: var(--text-dim);
@@ -251,6 +264,14 @@ tr:hover { background: var(--accent-dim); }
   </div>
   {% endif %}
 </div>
+
+{% if readme_html %}
+<!-- About (README) -->
+<section id="about">
+  <h2>About</h2>
+  <div class="content">{{ readme_html | safe }}</div>
+</section>
+{% endif %}
 
 <!-- Dynamic: Session Stats (shown when serve API is available) -->
 <section id="session-stats" class="dynamic-panel" style="display:none">

--- a/packages/gptme-dashboard/tests/test_generate.py
+++ b/packages/gptme-dashboard/tests/test_generate.py
@@ -29,6 +29,7 @@ from gptme_dashboard.generate import (
     scan_lessons,
     scan_packages,
     scan_plugins,
+    scan_readme,
     scan_recent_sessions,
     scan_skills,
     scan_tasks,
@@ -2204,3 +2205,97 @@ def test_scan_tasks_gptodo_path_includes_body(tmp_path: Path):
     assert "page_url" in tasks[0]
     assert tasks[0]["page_url"] == "tasks/my-task.html"
     assert "Do something" in tasks[0]["body"]
+
+
+# ---------------------------------------------------------------------------
+# scan_readme tests
+# ---------------------------------------------------------------------------
+
+
+def test_scan_readme_no_readme(tmp_path: Path):
+    """scan_readme returns empty dict when no README.md exists."""
+    result = scan_readme(tmp_path)
+    assert result == {}
+
+
+def test_scan_readme_basic(tmp_path: Path):
+    """scan_readme returns body and preview for a plain README."""
+    (tmp_path / "README.md").write_text(
+        "# My Project\n\nA handy library for doing things.\n\n## Install\n\n```\npip install it\n```\n"
+    )
+    result = scan_readme(tmp_path)
+    assert result["body"]
+    assert "My Project" in result["body"]
+    assert result["preview"] == "A handy library for doing things."
+
+
+def test_scan_readme_frontmatter_stripped(tmp_path: Path):
+    """scan_readme strips YAML frontmatter before returning body."""
+    (tmp_path / "README.md").write_text(
+        "---\ntitle: My Project\n---\n# My Project\n\nDescription here.\n"
+    )
+    result = scan_readme(tmp_path)
+    assert "title: My Project" not in result["body"]
+    assert "Description here." in result["body"]
+
+
+def test_scan_readme_preview_skips_headings(tmp_path: Path):
+    """scan_readme preview uses first non-heading paragraph."""
+    (tmp_path / "README.md").write_text(
+        "# Title\n\n## Subtitle\n\nThis is the first paragraph of real content.\n"
+    )
+    result = scan_readme(tmp_path)
+    assert result["preview"] == "This is the first paragraph of real content."
+
+
+def test_scan_readme_preview_truncated(tmp_path: Path):
+    """scan_readme truncates preview to 300 chars with ellipsis."""
+    long_text = "x" * 350
+    (tmp_path / "README.md").write_text(f"# Title\n\n{long_text}\n")
+    result = scan_readme(tmp_path)
+    assert len(result["preview"]) <= 301  # 300 chars + "…"
+    assert result["preview"].endswith("…")
+
+
+def test_scan_readme_empty_file(tmp_path: Path):
+    """scan_readme returns empty dict for an empty README."""
+    (tmp_path / "README.md").write_text("")
+    result = scan_readme(tmp_path)
+    assert result == {}
+
+
+def test_readme_in_workspace_data(tmp_path: Path):
+    """collect_workspace_data includes 'readme' key when README.md exists."""
+    (tmp_path / "README.md").write_text("# My Workspace\n\nA gptme workspace.\n")
+    data = collect_workspace_data(tmp_path)
+    assert "readme" in data
+    assert data["readme"]["preview"] == "A gptme workspace."
+
+
+def test_readme_absent_from_workspace_data(tmp_path: Path):
+    """collect_workspace_data returns empty readme dict when no README.md."""
+    data = collect_workspace_data(tmp_path)
+    assert data["readme"] == {}
+
+
+def test_generate_html_includes_about_section(workspace: Path, tmp_path: Path):
+    """Generated HTML includes About section when README.md exists."""
+    (workspace / "README.md").write_text(
+        "# Test Workspace\n\nThis is a great workspace for testing things.\n"
+    )
+    output = tmp_path / "site"
+    generate(workspace, output)
+    html = (output / "index.html").read_text()
+    assert 'id="about"' in html
+    assert "This is a great workspace for testing things." in html
+
+
+def test_generate_html_no_about_section_without_readme(workspace: Path, tmp_path: Path):
+    """Generated HTML omits About section when no README.md is present."""
+    readme = workspace / "README.md"
+    if readme.exists():
+        readme.unlink()
+    output = tmp_path / "site"
+    generate(workspace, output)
+    html = (output / "index.html").read_text()
+    assert 'id="about"' not in html


### PR DESCRIPTION
## Summary

When a workspace has a `README.md`, the generated dashboard now shows an **About** section below the stats overview, with the README rendered to HTML.

This directly addresses the "double as the public site" requirement from #382 — running `gptme-dashboard` on gptme-contrib now surfaces its project description without any extra configuration.

- New `scan_readme()` reads `README.md`, strips frontmatter, extracts a plain-text preview
- `collect_workspace_data()` returns `readme` key (raw body + preview, safe to JSON-serialize)
- `generate()` pre-renders README markdown to HTML and passes `readme_html` to the template
- `index.html`: About section shown only when `readme_html` is non-empty
- Added `.content` CSS for proper markdown rendering (code blocks, lists, headings, blockquotes)
- 10 new tests (138 total, all passing)

## Before / After

**Before**: Dashboard header shows only workspace name and GitHub link; no project description.

**After**: An "About" section appears below stats, showing the README rendered with syntax highlighting, lists, and headings — identical rendering to lesson/skill detail pages.

## Notes

- Skips image-only lines (`![]()`) when extracting the preview paragraph
- Returns empty dict (no About section) when README is absent or empty
- Works for any workspace: agents, gptme-contrib, gptme-agent-template, etc.

Closes part of #382.