### PR TITLE
build(gptme-sessions): add Makefile so CI runs unit tests

### DIFF
--- a/packages/gptme-sessions/Makefile
+++ b/packages/gptme-sessions/Makefile
@@ -1,0 +1,7 @@
+.PHONY: test typecheck
+
+test:  ## Run tests for this package
+	uv run pytest tests/ -v
+
+typecheck:  ## Run mypy for this package
+	uv run --with mypy mypy src/ --ignore-missing-imports


### PR DESCRIPTION
## Summary

- `packages/gptme-sessions/` had no `Makefile`, so `ci-list-packages-json` excluded it from the test matrix
- All three open sessions PRs (#420, #426, #431) have had their `test` CI job silently skipped as a result — 237 unit tests were never running in CI

## Root cause

`Makefile` lists `PACKAGE_DIRS` filtered by `[ -f "$$pkg/Makefile" ]`. Every other package (gptme-activity-summary, gptodo, etc.) has one; `gptme-sessions` did not.

## Fix

Add a minimal `Makefile` with `test` and `typecheck` targets matching the pattern used by sibling packages:

```makefile
test:
	uv run pytest tests/ -v

typecheck:
	uv run --with mypy mypy src/ --ignore-missing-imports
```

## Verification

- `make ci-list-packages-json` now includes `gptme-sessions`
- All 237 tests pass locally
- `mypy src/` reports no issues

Closes part of #415.