### PR TITLE
feat(dashboard): add per-package detail pages with markdown rendering

### DIFF
--- a/packages/gptme-dashboard/src/gptme_dashboard/generate.py
+++ b/packages/gptme-dashboard/src/gptme_dashboard/generate.py
@@ -95,6 +95,14 @@ def task_page_path(task_id: str) -> str:
     return f"tasks/{task_id}.html"
 
 
+def package_page_path(package_path: str) -> str:
+    """Convert a package's directory path to its detail page URL path.
+
+    E.g. 'packages/gptme-dashboard' -> 'packages/gptme-dashboard/index.html'
+    """
+    return (Path(package_path) / "index.html").as_posix()
+
+
 def journal_page_path(date: str, name: str) -> str:
     """Convert a journal entry's date + name to its detail page URL path.
 
@@ -723,11 +731,21 @@ def scan_packages(workspace: Path, source: str = "") -> list[dict]:
                     if description and version:
                         break
 
+        readme = d / "README.md"
+        body = readme.read_text(errors="replace") if readme.exists() else ""
+
+        rel_path = str(d.relative_to(workspace))
+        page_url = package_page_path(rel_path)
+        if source:
+            page_url = f"{source}/{page_url}"
+
         entry: dict = {
             "name": d.name,
             "description": description,
             "version": version,
-            "path": str(d.relative_to(workspace)),
+            "path": rel_path,
+            "body": body,
+            "page_url": page_url,
         }
         if source:
             entry["source"] = source
@@ -1160,16 +1178,34 @@ def generate(
         page_path.parent.mkdir(parents=True, exist_ok=True)
         page_path.write_text(plugin_html)
 
+    # Generate per-package detail pages (only for packages with a README)
+    package_template = env.get_template("package.html")
+    packages_with_pages = [p for p in data["packages"] if p.get("body")]
+    for pkg in packages_with_pages:
+        # page_url is e.g. "packages/gptme-dashboard/index.html" (depth=2) → root_prefix="../../"
+        depth = len(Path(pkg["page_url"]).parts) - 1
+        root_prefix = "../" * depth
+        pkg_html = package_template.render(
+            workspace_name=data["workspace_name"],
+            package=pkg,
+            body_html=render_markdown_to_html(pkg["body"]),
+            root_prefix=root_prefix,
+        )
+        page_path = output / pkg["page_url"]
+        page_path.parent.mkdir(parents=True, exist_ok=True)
+        page_path.write_text(pkg_html)
+
     stats = data["stats"]
     journal_count = len(data["journals"])
     plugin_page_count = len(plugins_with_pages)
     task_count = len(data["tasks"])
+    package_page_count = len(packages_with_pages)
     session_msg = f", {stats['total_sessions']} sessions" if include_sessions else ""
     print(f"Generated dashboard at {output / 'index.html'}")
     print(
         f"  {stats['total_lessons']} lessons ({stats['total_lessons']} detail pages), "
         f"{stats['total_plugins']} plugins ({plugin_page_count} detail pages), "
-        f"{stats['total_packages']} packages, "
+        f"{stats['total_packages']} packages ({package_page_count} detail pages), "
         f"{stats['total_skills']} skills ({stats['total_skills']} detail pages), "
         f"{journal_count} journals ({journal_count} detail pages), "
         f"{task_count} tasks ({task_count} detail pages)"
@@ -1225,6 +1261,9 @@ def generate_json(
         ],
         "tasks": [
             {k: v for k, v in task.items() if k not in _JSON_EXCLUDE} for task in data["tasks"]
+        ],
+        "packages": [
+            {k: v for k, v in pkg.items() if k not in _JSON_EXCLUDE} for pkg in data["packages"]
         ],
     }
     json_str = json.dumps(export_data, indent=2)

--- a/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
+++ b/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
@@ -400,7 +400,7 @@ tr:hover { background: var(--accent-dim); }
       <tbody>
       {% for pkg in packages %}
         <tr>
-          <td><strong>{{ pkg.name }}</strong></td>
+          <td><strong>{% if pkg.body %}<a href="{{ pkg.page_url }}">{{ pkg.name }}</a>{% else %}{{ pkg.name }}{% endif %}</strong></td>
           <td>{{ pkg.version }}</td>
           <td>{{ pkg.description }}</td>
           {% if gh_repo_url %}<td>{% if pkg.gh_url %}<a href="{{ pkg.gh_url }}" title="View on GitHub" class="gh-link">src</a>{% endif %}</td>{% endif %}

--- a/packages/gptme-dashboard/src/gptme_dashboard/templates/package.html
+++ b/packages/gptme-dashboard/src/gptme_dashboard/templates/package.html
@@ -1,0 +1,116 @@
+{% extends "base.html" %}
+
+{% block title %}{{ package.name }} - {{ workspace_name }}{% endblock %}
+
+{% block extra_style %}
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+}
+
+.breadcrumb {
+  font-size: 0.85rem;
+  color: var(--text-dim);
+  margin-bottom: 1.5rem;
+}
+.breadcrumb a { color: var(--accent); }
+
+header h1 {
+  font-size: 1.75rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.meta {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+/* Markdown content */
+.content {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 2rem;
+}
+.content h1 { font-size: 1.5rem; margin: 1.5rem 0 0.75rem; border-bottom: 1px solid var(--border); padding-bottom: 0.5rem; }
+.content h2 { font-size: 1.25rem; margin: 1.5rem 0 0.75rem; border-bottom: 1px solid var(--border); padding-bottom: 0.5rem; }
+.content h3 { font-size: 1.1rem; margin: 1.25rem 0 0.5rem; }
+.content p { margin: 0.75rem 0; }
+.content ul, .content ol { margin: 0.75rem 0; padding-left: 2rem; }
+.content li { margin: 0.25rem 0; }
+.content code {
+  background: var(--code-bg);
+  padding: 0.15em 0.35em;
+  border-radius: 4px;
+  font-size: 0.9em;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+}
+.content pre {
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 1rem;
+  overflow-x: auto;
+  margin: 0.75rem 0;
+}
+.content pre code {
+  background: none;
+  padding: 0;
+  border-radius: 0;
+}
+.content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0.75rem 0;
+}
+.content th, .content td {
+  text-align: left;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--border);
+}
+.content th {
+  background: var(--code-bg);
+  font-weight: 600;
+}
+.content strong { color: var(--text); }
+.content blockquote {
+  border-left: 3px solid var(--accent);
+  padding-left: 1rem;
+  color: var(--text-dim);
+  margin: 0.75rem 0;
+}
+
+@media (max-width: 600px) {
+  .content { padding: 1rem; }
+}
+{% endblock %}
+
+{% block content %}
+<nav class="breadcrumb">
+  <a href="{{ root_prefix }}index.html">{{ workspace_name }}</a>
+  &rsaquo; <a href="{{ root_prefix }}index.html#packages">Packages</a>
+  &rsaquo; {{ package.name }}
+</nav>
+
+<header>
+  <h1>{{ package.name }}</h1>
+  <div class="meta">
+    {% if package.version %}
+    <span class="tag">v{{ package.version }}</span>
+    {% endif %}
+    {% if package.description %}
+    <span style="color: var(--text-dim); font-size: 0.9rem;">{{ package.description }}</span>
+    {% endif %}
+    <span style="color: var(--text-dim); font-size: 0.85rem;">{{ package.path }}</span>
+    {% if package.gh_url %}<a href="{{ package.gh_url }}" style="color: var(--text-dim); font-size: 0.85rem;">View on GitHub</a>{% endif %}
+  </div>
+</header>
+
+<div class="content">
+  {{ body_html | safe }}
+</div>
+{% endblock %}

--- a/packages/gptme-dashboard/tests/test_generate.py
+++ b/packages/gptme-dashboard/tests/test_generate.py
@@ -21,6 +21,7 @@ from gptme_dashboard.generate import (
     journal_page_path,
     lesson_page_path,
     parse_frontmatter,
+    package_page_path,
     plugin_page_path,
     read_agent_urls,
     read_workspace_config,
@@ -113,6 +114,7 @@ def workspace(tmp_path: Path) -> Path:
         description = "A test package"
         """)
     )
+    (pkg_dir / "README.md").write_text("# test-pkg\n\nA package for testing purposes.\n")
 
     # Skills
     skill_dir = tmp_path / "skills" / "test-skill"
@@ -2299,3 +2301,113 @@ def test_generate_html_no_about_section_without_readme(workspace: Path, tmp_path
     generate(workspace, output)
     html = (output / "index.html").read_text()
     assert 'id="about"' not in html
+
+
+# ── Per-package detail pages ────────────────────────────────────────────────
+
+
+def test_package_page_path():
+    """Test package directory to URL conversion."""
+    assert package_page_path("packages/gptme-dashboard") == "packages/gptme-dashboard/index.html"
+    assert package_page_path("packages/gptodo") == "packages/gptodo/index.html"
+
+
+def test_scan_packages_includes_body_and_page_url(workspace: Path):
+    """Test that scan_packages includes body and page_url fields."""
+    packages = scan_packages(workspace)
+    assert len(packages) == 1
+    pkg = packages[0]
+    assert "body" in pkg
+    assert "page_url" in pkg
+    assert "A package for testing purposes" in pkg["body"]
+    assert pkg["page_url"] == "packages/test-pkg/index.html"
+
+
+def test_scan_packages_empty_body_when_no_readme(tmp_path: Path):
+    """Test that packages without README have empty body and still get page_url."""
+    pkg_dir = tmp_path / "packages" / "no-readme-pkg"
+    pkg_dir.mkdir(parents=True)
+    (pkg_dir / "pyproject.toml").write_text(
+        '[project]\nname = "no-readme-pkg"\nversion = "0.1.0"\ndescription = ""\n'
+    )
+    # No README.md
+
+    packages = scan_packages(tmp_path)
+    assert len(packages) == 1
+    assert packages[0]["body"] == ""
+    assert packages[0]["page_url"] == "packages/no-readme-pkg/index.html"
+
+
+def test_generate_package_detail_pages(workspace: Path, tmp_path: Path):
+    """Test that per-package detail pages are generated for packages with README."""
+    output = tmp_path / "output"
+    template_dir = Path(__file__).parent.parent / "src" / "gptme_dashboard" / "templates"
+    generate(workspace, output, template_dir)
+
+    pkg_page = output / "packages" / "test-pkg" / "index.html"
+    assert pkg_page.exists(), f"Expected {pkg_page} to exist"
+
+    html = pkg_page.read_text()
+    assert "test-pkg" in html
+    assert "A package for testing purposes" in html
+
+
+def test_generate_index_links_to_packages(workspace: Path, tmp_path: Path):
+    """Test that index.html package names link to detail pages when README exists."""
+    output = tmp_path / "output"
+    template_dir = Path(__file__).parent.parent / "src" / "gptme_dashboard" / "templates"
+    generate(workspace, output, template_dir)
+
+    html = (output / "index.html").read_text()
+    assert 'href="packages/test-pkg/index.html"' in html
+
+
+def test_package_detail_breadcrumb(workspace: Path, tmp_path: Path):
+    """Test that package detail page breadcrumb uses correct relative root prefix."""
+    output = tmp_path / "output"
+    template_dir = Path(__file__).parent.parent / "src" / "gptme_dashboard" / "templates"
+    generate(workspace, output, template_dir)
+
+    # packages/test-pkg/index.html is two levels deep → needs ../../
+    html = (output / "packages" / "test-pkg" / "index.html").read_text()
+    assert 'href="../../index.html"' in html
+
+
+def test_package_detail_renders_markdown(workspace: Path, tmp_path: Path):
+    """Test that package README markdown is rendered as HTML."""
+    output = tmp_path / "output"
+    template_dir = Path(__file__).parent.parent / "src" / "gptme_dashboard" / "templates"
+    generate(workspace, output, template_dir)
+
+    html = (output / "packages" / "test-pkg" / "index.html").read_text()
+    assert "<h1>" in html or "<h2>" in html, "Headings should be rendered as HTML"
+    assert "&lt;h" not in html, "HTML tags must not be escaped"
+
+
+def test_generate_no_package_page_when_no_readme(tmp_path: Path):
+    """Test that packages without README do not get a detail page."""
+    (tmp_path / "gptme.toml").write_text('[agent]\nname = "Test"\n')
+    pkg_dir = tmp_path / "packages" / "bare-pkg"
+    pkg_dir.mkdir(parents=True)
+    (pkg_dir / "pyproject.toml").write_text(
+        '[project]\nname = "bare-pkg"\nversion = "0.1.0"\ndescription = ""\n'
+    )
+    # No README.md — package has no body
+
+    output = tmp_path / "output"
+    template_dir = Path(__file__).parent.parent / "src" / "gptme_dashboard" / "templates"
+    generate(tmp_path, output, template_dir)
+
+    pkg_page = output / "packages" / "bare-pkg" / "index.html"
+    assert not pkg_page.exists(), "No detail page should be generated for packages without README"
+
+
+def test_generate_json_excludes_package_body(workspace: Path):
+    """Test that generate_json excludes body from packages to keep data.json lean."""
+    data = collect_workspace_data(workspace)
+    json_str = generate_json(workspace, _data=data)
+    parsed = json.loads(json_str)
+
+    assert len(parsed["packages"]) == 1
+    assert "body" not in parsed["packages"][0]
+    assert "page_url" in parsed["packages"][0]


### PR DESCRIPTION
## Summary

- Each package with a README.md now links to a dedicated `packages/<name>/index.html` detail page
- Package name in the index table becomes a clickable link when a README exists
- Full README rendered to HTML with version badge, description, path, and GitHub source link
- Packages without a README remain in the index but without a link (graceful degradation)

Follows the exact same pattern as per-plugin detail pages (#435):
- `package_page_path()` helper in `generate.py`
- `scan_packages()` now includes `body` + `page_url` fields
- `generate()` writes per-package pages via new `package.html` template
- `generate_json()` excludes `body` (same as lessons/skills/plugins/journals)
- 9 new tests (152 → 161 total), all CI ✅

## Test plan
- [x] `test_package_page_path` — URL path conversion
- [x] `test_scan_packages_includes_body_and_page_url` — body + page_url present
- [x] `test_scan_packages_empty_body_when_no_readme` — graceful degradation
- [x] `test_generate_package_detail_pages` — pages generated for packages with README
- [x] `test_generate_index_links_to_packages` — index links to detail pages
- [x] `test_package_detail_breadcrumb` — correct relative root prefix
- [x] `test_package_detail_renders_markdown` — markdown rendered as HTML
- [x] `test_generate_no_package_page_when_no_readme` — no page without README
- [x] `test_generate_json_excludes_package_body` — body excluded from data.json

Closes part of #382.