### PR TITLE
feat(sessions): sort discover output chronologically across harnesses

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/__init__.py
+++ b/packages/gptme-sessions/src/gptme_sessions/__init__.py
@@ -19,6 +19,7 @@ from .discovery import (
     discover_copilot_sessions,
     discover_gptme_sessions,
     parse_gptme_config,
+    session_date_from_path,
 )
 from .post_session import PostSessionResult, post_session
 from .record import MODEL_ALIASES, SessionRecord, normalize_model
@@ -60,6 +61,7 @@ __all__ = [
     "discover_copilot_sessions",
     "parse_gptme_config",
     "decode_cc_project_path",
+    "session_date_from_path",
     "Bandit",
     "BanditArm",
     "BanditState",

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -26,6 +26,7 @@ from .discovery import (
     discover_gptme_sessions,
     extract_cc_model,
     parse_gptme_config,
+    session_date_from_path,
 )
 from .post_session import post_session
 from .record import SessionRecord, normalize_run_type
@@ -46,12 +47,15 @@ def _discover_all(
     since_days: int = 30,
     harness_filter: str | None = None,
 ) -> list[dict]:
-    """Collect discovered sessions across all harnesses.
+    """Collect discovered sessions across all harnesses, sorted chronologically.
 
-    Returns a list of dicts with keys ``harness`` and ``path``.
+    Returns a list of dicts with keys ``harness``, ``path``, and
+    ``session_date`` (a :class:`datetime.date` or ``None``).
     Dicts for ``gptme`` and ``claude-code`` harnesses also include ``model``
     (may be ``None`` if extraction fails); ``codex`` and ``copilot`` entries
     do not include ``model``.  Callers should use ``.get("model")`` accordingly.
+    Results are sorted oldest-first across all harnesses so callers get a
+    unified chronological view rather than harness-grouped output.
     Used for fallback display and the ``sync`` command.
     """
     today = date.today()
@@ -63,18 +67,46 @@ def _discover_all(
             jsonl = p / "conversation.jsonl"
             resolved = jsonl if jsonl.exists() else p
             model = parse_gptme_config(p).get("model") or None
-            discovered.append({"harness": "gptme", "path": resolved, "model": model})
+            discovered.append(
+                {
+                    "harness": "gptme",
+                    "path": resolved,
+                    "model": model,
+                    "session_date": session_date_from_path("gptme", resolved),
+                }
+            )
     if harness_filter in (None, "claude-code"):
         for p in discover_cc_sessions(start, today):
             model = extract_cc_model(p)
-            discovered.append({"harness": "claude-code", "path": p, "model": model})
+            discovered.append(
+                {
+                    "harness": "claude-code",
+                    "path": p,
+                    "model": model,
+                    "session_date": session_date_from_path("claude-code", p),
+                }
+            )
     if harness_filter in (None, "codex"):
         for p in discover_codex_sessions(start, today):
-            discovered.append({"harness": "codex", "path": p})
+            discovered.append(
+                {
+                    "harness": "codex",
+                    "path": p,
+                    "session_date": session_date_from_path("codex", p),
+                }
+            )
     if harness_filter in (None, "copilot"):
         for p in discover_copilot_sessions(start, today):
-            discovered.append({"harness": "copilot", "path": p})
+            discovered.append(
+                {
+                    "harness": "copilot",
+                    "path": p,
+                    "session_date": session_date_from_path("copilot", p),
+                }
+            )
 
+    # Sort chronologically across harnesses; entries without a date sort last.
+    discovered.sort(key=lambda e: e.get("session_date") or date.max)
     return discovered
 
 
@@ -597,19 +629,46 @@ def discover(
         for p in discover_gptme_sessions(start, today):
             jsonl = p / "conversation.jsonl"
             resolved = jsonl if jsonl.exists() else p
-            discovered.append({"harness": "gptme", "path": str(resolved)})
+            discovered.append(
+                {
+                    "harness": "gptme",
+                    "path": str(resolved),
+                    "session_date": session_date_from_path("gptme", resolved),
+                }
+            )
 
     if harness in (None, "claude-code"):
         for p in discover_cc_sessions(start, today):
-            discovered.append({"harness": "claude-code", "path": str(p)})
+            discovered.append(
+                {
+                    "harness": "claude-code",
+                    "path": str(p),
+                    "session_date": session_date_from_path("claude-code", p),
+                }
+            )
 
     if harness in (None, "codex"):
         for p in discover_codex_sessions(start, today):
-            discovered.append({"harness": "codex", "path": str(p)})
+            discovered.append(
+                {
+                    "harness": "codex",
+                    "path": str(p),
+                    "session_date": session_date_from_path("codex", p),
+                }
+            )
 
     if harness in (None, "copilot"):
         for p in discover_copilot_sessions(start, today):
-            discovered.append({"harness": "copilot", "path": str(p)})
+            discovered.append(
+                {
+                    "harness": "copilot",
+                    "path": str(p),
+                    "session_date": session_date_from_path("copilot", p),
+                }
+            )
+
+    # Sort chronologically across all harnesses; entries without a date sort last.
+    discovered.sort(key=lambda e: e.get("session_date") or date.max)
 
     # Mark each entry as synced or not by cross-referencing the store.
     # Normalize paths so symlinks/relative paths don't cause false mismatches.
@@ -646,7 +705,11 @@ def discover(
         # window" (total_discovered=0, sessions=[]) from "all already synced"
         # (total_discovered>0, sessions=[]) when --unsynced is active.
         click.echo(
-            json.dumps({"sessions": discovered, "total_discovered": total_discovered}, indent=2)
+            json.dumps(
+                {"sessions": discovered, "total_discovered": total_discovered},
+                indent=2,
+                default=str,
+            )
         )
     else:
         if not discovered:
@@ -662,6 +725,7 @@ def discover(
             path_str = entry["path"]
             harness_str = entry["harness"].ljust(harness_width)
             sync_flag = "S" if entry["synced"] else " "
+            date_str = str(entry["session_date"]) if entry.get("session_date") else "????"
             if signals and "grade" in entry:
                 grade = entry["grade"]
                 prod = "+" if entry["productive"] else "-"
@@ -669,16 +733,17 @@ def discover(
                 commits = entry["git_commits"]
                 errors = entry["error_count"]
                 click.echo(
-                    f"[{sync_flag}][{prod}] {harness_str}  grade={grade:.2f}"
+                    f"[{sync_flag}][{prod}] {date_str}  {harness_str}  grade={grade:.2f}"
                     f"  tools={tools} commits={commits} errors={errors}"
                     f"  {path_str}"
                 )
             elif "signals_error" in entry:
                 click.echo(
-                    f"[{sync_flag}][?] {harness_str}  (signals error: {entry['signals_error']})  {path_str}"
+                    f"[{sync_flag}][?] {date_str}  {harness_str}"
+                    f"  (signals error: {entry['signals_error']})  {path_str}"
                 )
             else:
-                click.echo(f"[{sync_flag}]   {harness_str}  {path_str}")
+                click.echo(f"[{sync_flag}]   {date_str}  {harness_str}  {path_str}")
         if unsynced:
             synced_skipped = total_discovered - len(discovered)
             footer = (

--- a/packages/gptme-sessions/src/gptme_sessions/discovery.py
+++ b/packages/gptme-sessions/src/gptme_sessions/discovery.py
@@ -289,6 +289,36 @@ def discover_codex_sessions(
     return [path for _, path in sorted(dated_sessions)]
 
 
+def session_date_from_path(harness: str, path: Path) -> date | None:
+    """Extract session date from a discovered session path.
+
+    Uses fast, no-I/O extraction where possible:
+
+    - **gptme**: parse from session directory name (``YYYY-MM-DD-…``)
+    - **codex**: parse from directory structure (``…/YYYY/MM/DD/file.jsonl``)
+    - **claude-code**, **copilot**: read first timestamp from the JSONL file
+
+    Returns ``None`` if the date cannot be determined.
+    """
+    if harness == "gptme":
+        # path is either the session dir or a .jsonl inside it
+        dir_name = path.parent.name if path.suffix == ".jsonl" else path.name
+        try:
+            return date.fromisoformat(dir_name[:10])
+        except (ValueError, AttributeError):
+            return None
+    elif harness == "codex":
+        # path is at …/YYYY/MM/DD/file.jsonl
+        try:
+            parts = path.parts
+            return date(int(parts[-4]), int(parts[-3]), int(parts[-2]))
+        except (ValueError, IndexError):
+            return None
+    else:
+        # claude-code, copilot: date is embedded in the JSONL file
+        return _quick_date_from_jsonl(path)
+
+
 def discover_copilot_sessions(
     start: date,
     end: date,

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -3369,6 +3369,169 @@ def test_cli_discover_invalid_since(tmp_path: Path, capsys, monkeypatch):
     assert rc != 0
 
 
+# ---------------------------------------------------------------------------
+# session_date_from_path tests
+# ---------------------------------------------------------------------------
+
+
+def test_session_date_from_path_gptme(tmp_path: Path):
+    """gptme sessions: date extracted from session directory name."""
+    from datetime import date
+
+    from gptme_sessions.discovery import session_date_from_path
+
+    # Path is the conversation.jsonl inside a date-prefixed session dir
+    session_dir = tmp_path / "2026-03-07-my-session"
+    session_dir.mkdir()
+    jsonl = session_dir / "conversation.jsonl"
+    jsonl.touch()
+
+    result = session_date_from_path("gptme", jsonl)
+    assert result == date(2026, 3, 7)
+
+
+def test_session_date_from_path_gptme_dir(tmp_path: Path):
+    """gptme sessions: date extracted when path is the session directory itself."""
+    from datetime import date
+
+    from gptme_sessions.discovery import session_date_from_path
+
+    session_dir = tmp_path / "2026-03-08-another-session"
+    session_dir.mkdir()
+
+    result = session_date_from_path("gptme", session_dir)
+    assert result == date(2026, 3, 8)
+
+
+def test_session_date_from_path_codex(tmp_path: Path):
+    """codex sessions: date extracted from directory structure YYYY/MM/DD."""
+    from datetime import date
+
+    from gptme_sessions.discovery import session_date_from_path
+
+    codex_file = tmp_path / "2026" / "03" / "05" / "session.jsonl"
+    codex_file.parent.mkdir(parents=True)
+    codex_file.touch()
+
+    result = session_date_from_path("codex", codex_file)
+    assert result == date(2026, 3, 5)
+
+
+def test_session_date_from_path_cc(tmp_path: Path):
+    """claude-code sessions: date extracted from JSONL first line."""
+    from datetime import date
+
+    from gptme_sessions.discovery import session_date_from_path
+
+    jsonl = tmp_path / "session.jsonl"
+    jsonl.write_text(
+        json.dumps({"role": "user", "content": "hi", "timestamp": "2026-03-06T10:00:00+00:00"})
+        + "\n"
+    )
+
+    result = session_date_from_path("claude-code", jsonl)
+    assert result == date(2026, 3, 6)
+
+
+def test_session_date_from_path_unknown_returns_none(tmp_path: Path):
+    """session_date_from_path returns None for unreadable paths."""
+    from gptme_sessions.discovery import session_date_from_path
+
+    missing = tmp_path / "nonexistent.jsonl"
+    # Should return None, not raise
+    result = session_date_from_path("claude-code", missing)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Cross-harness chronological ordering tests
+# ---------------------------------------------------------------------------
+
+
+def test_discover_chronological_ordering(tmp_path: Path, capsys, monkeypatch):
+    """discover output is sorted chronologically across harnesses."""
+    import sys
+
+    from gptme_sessions.cli import main
+
+    # Simulate a gptme session from 2026-03-09 and a codex session from 2026-03-05.
+    # After chronological sort the codex session (earlier) must appear first.
+
+    gptme_dir = tmp_path / "2026-03-09-test-session"
+    gptme_dir.mkdir()
+    gptme_jsonl = gptme_dir / "conversation.jsonl"
+    gptme_jsonl.touch()
+
+    codex_file = tmp_path / "2026" / "03" / "05" / "session.jsonl"
+    codex_file.parent.mkdir(parents=True)
+    codex_file.touch()
+
+    monkeypatch.setattr("gptme_sessions.cli.discover_gptme_sessions", lambda *a, **kw: [gptme_dir])
+    monkeypatch.setattr("gptme_sessions.cli.discover_cc_sessions", lambda *a, **kw: [])
+    monkeypatch.setattr("gptme_sessions.cli.discover_codex_sessions", lambda *a, **kw: [codex_file])
+    monkeypatch.setattr("gptme_sessions.cli.discover_copilot_sessions", lambda *a, **kw: [])
+
+    monkeypatch.setattr(sys, "argv", ["gptme-sessions", "discover", "--since", "30d"])
+    rc = main()
+    assert rc == 0
+    captured = capsys.readouterr()
+
+    gptme_pos = captured.out.index(str(gptme_jsonl))
+    codex_pos = captured.out.index(str(codex_file))
+    # codex session (2026-03-05) must appear before gptme session (2026-03-09)
+    assert codex_pos < gptme_pos, "Sessions should be sorted oldest-first across harnesses"
+
+
+def test_discover_json_includes_session_date(tmp_path: Path, capsys, monkeypatch):
+    """discover --json includes session_date field for each entry."""
+    import json as _json
+    import sys
+
+    from gptme_sessions.cli import main
+
+    gptme_dir = tmp_path / "2026-03-07-test"
+    gptme_dir.mkdir()
+    (gptme_dir / "conversation.jsonl").touch()
+
+    monkeypatch.setattr("gptme_sessions.cli.discover_gptme_sessions", lambda *a, **kw: [gptme_dir])
+    monkeypatch.setattr("gptme_sessions.cli.discover_cc_sessions", lambda *a, **kw: [])
+    monkeypatch.setattr("gptme_sessions.cli.discover_codex_sessions", lambda *a, **kw: [])
+    monkeypatch.setattr("gptme_sessions.cli.discover_copilot_sessions", lambda *a, **kw: [])
+
+    monkeypatch.setattr(sys, "argv", ["gptme-sessions", "discover", "--harness", "gptme", "--json"])
+    rc = main()
+    assert rc == 0
+    captured = capsys.readouterr()
+    data = _json.loads(captured.out)
+    assert data["total_discovered"] == 1
+    assert len(data["sessions"]) == 1
+    assert data["sessions"][0]["session_date"] == "2026-03-07"
+
+
+def test_discover_date_shown_in_output(tmp_path: Path, capsys, monkeypatch):
+    """discover human output includes the date for each session."""
+    import sys
+
+    from gptme_sessions.cli import main
+
+    gptme_dir = tmp_path / "2026-03-07-test"
+    gptme_dir.mkdir()
+    (gptme_dir / "conversation.jsonl").touch()
+
+    monkeypatch.setattr("gptme_sessions.cli.discover_gptme_sessions", lambda *a, **kw: [gptme_dir])
+    monkeypatch.setattr("gptme_sessions.cli.discover_cc_sessions", lambda *a, **kw: [])
+    monkeypatch.setattr("gptme_sessions.cli.discover_codex_sessions", lambda *a, **kw: [])
+    monkeypatch.setattr("gptme_sessions.cli.discover_copilot_sessions", lambda *a, **kw: [])
+
+    monkeypatch.setattr(
+        sys, "argv", ["gptme-sessions", "discover", "--harness", "gptme", "--since", "30d"]
+    )
+    rc = main()
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "2026-03-07" in captured.out
+
+
 @pytest.mark.parametrize(
     "signals,expected",
     [


### PR DESCRIPTION
## Summary

Addresses the core request in #415:

> *"the script should fallback or default to something like `gptme-sessions discover` (sorted chronologically) to make sure no sessions are missed"*

Previously `discover` listed all gptme sessions, then all claude-code sessions, then codex, etc. — grouped by harness. When you have sessions from multiple harnesses, you couldn't see a unified timeline. This PR fixes that.

**Before:**
```
    gptme        ~/.local/share/gptme/logs/2026-03-09-.../conversation.jsonl
    gptme        ~/.local/share/gptme/logs/2026-03-07-.../conversation.jsonl
    claude-code  ~/.claude/projects/…/session1.jsonl   ← from 2026-03-08, but listed after all gptme
```

**After:**
```
    2026-03-07  gptme        ~/.local/share/gptme/logs/2026-03-07-.../conversation.jsonl
    2026-03-08  claude-code  ~/.claude/projects/…/session1.jsonl
    2026-03-09  gptme        ~/.local/share/gptme/logs/2026-03-09-.../conversation.jsonl
```

## Changes

- **`discovery.py`**: Add `session_date_from_path(harness, path) -> date | None` — extracts the session date with zero extra I/O for gptme (from directory name like `2026-03-07-...`) and codex (from `YYYY/MM/DD/` directory structure); reads only the first JSONL line for claude-code and copilot.
- **`cli.py`** (`_discover_all`): populate `session_date` on every entry and sort oldest-first before returning — so the fallback display and `sync` also use a chronological order.
- **`cli.py`** (`discover` command): same sort + date column in human-readable output. `--json` includes `session_date` as ISO string.
- **`__init__.py`**: export `session_date_from_path` from the top-level package.
- **8 new tests**: unit tests for each harness extraction path, cross-harness chronological ordering, JSON field presence, and date shown in human output.

## Test plan

- [x] `test_session_date_from_path_gptme` — date from `2026-03-07-session/conversation.jsonl`
- [x] `test_session_date_from_path_gptme_dir` — date from session directory itself
- [x] `test_session_date_from_path_codex` — date from `YYYY/MM/DD/` structure
- [x] `test_session_date_from_path_cc` — date from JSONL first line
- [x] `test_session_date_from_path_unknown_returns_none` — graceful None for missing file
- [x] `test_discover_chronological_ordering` — codex 2026-03-05 appears before gptme 2026-03-09
- [x] `test_discover_json_includes_session_date` — `session_date` field in JSON output
- [x] `test_discover_date_shown_in_output` — date visible in human-readable output

Closes #415 (together with #420, #426, #431, #433, #437)