### PR TITLE
feat(dashboard): add GitHub URLs for submodule items

### DIFF
--- a/packages/gptme-dashboard/src/gptme_dashboard/generate.py
+++ b/packages/gptme-dashboard/src/gptme_dashboard/generate.py
@@ -1211,21 +1211,38 @@ def collect_workspace_data(
         sub_name: str = sub["name"]
         submodule_names.append(sub_name)
 
+        sub_gh_url = detect_github_url(sub_path)
+
         if sub["has_lessons"]:
-            lessons.extend(scan_lessons(sub_path, source=sub_name))
+            sub_lessons = scan_lessons(sub_path, source=sub_name)
+            if sub_gh_url:
+                for lesson in sub_lessons:
+                    lesson["gh_url"] = github_blob_url(sub_gh_url, lesson["path"], prefix="lessons")
+            lessons.extend(sub_lessons)
         if sub["has_skills"]:
-            skills.extend(scan_skills(sub_path, source=sub_name))
+            sub_skills = scan_skills(sub_path, source=sub_name)
+            if sub_gh_url:
+                for skill in sub_skills:
+                    skill["gh_url"] = github_tree_url(sub_gh_url, skill["path"])
+            skills.extend(sub_skills)
         if sub["has_packages"]:
-            packages.extend(scan_packages(sub_path, source=sub_name))
+            sub_packages = scan_packages(sub_path, source=sub_name)
+            if sub_gh_url:
+                for pkg in sub_packages:
+                    pkg["gh_url"] = github_tree_url(sub_gh_url, pkg["path"])
+            packages.extend(sub_packages)
         if sub["has_plugins"]:
-            plugins.extend(scan_plugins(sub_path, source=sub_name))
+            sub_plugins = scan_plugins(sub_path, source=sub_name)
+            if sub_gh_url:
+                for plugin in sub_plugins:
+                    plugin["gh_url"] = github_tree_url(sub_gh_url, plugin["path"])
+            plugins.extend(sub_plugins)
 
     # Detect GitHub repo URL for source links
     gh_repo_url = detect_github_url(workspace)
 
     # Add GitHub source links to main-workspace items only.
-    # Submodule items (source != "") belong to a different repository and would
-    # get incorrect URLs if we applied the main workspace's gh_repo_url to them.
+    # Submodule items (source != "") already have gh_url set from their own repo above.
     if gh_repo_url:
         for lesson in lessons:
             if not lesson.get("source"):

--- a/packages/gptme-dashboard/tests/test_generate.py
+++ b/packages/gptme-dashboard/tests/test_generate.py
@@ -1103,7 +1103,7 @@ def test_generate_html_includes_github_links(tmp_path: Path):
 
 
 def test_collect_workspace_data_submodule_items_no_gh_url(tmp_path: Path):
-    """Submodule items should not get gh_url (they belong to a different repo)."""
+    """Submodule items without a git remote should not get gh_url."""
     import subprocess
 
     subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True)
@@ -1118,13 +1118,14 @@ def test_collect_workspace_data_submodule_items_no_gh_url(tmp_path: Path):
     lessons_dir.mkdir(parents=True)
     (lessons_dir / "main.md").write_text("---\nstatus: active\n---\n# Main\n\nBody.")
 
-    # Fake submodule with a lesson
+    # Fake submodule with a lesson but NO git remote
     sub_path = tmp_path / "gptme-contrib"
     sub_lessons = sub_path / "lessons" / "workflow"
     sub_lessons.mkdir(parents=True)
     (sub_lessons / "sub.md").write_text("---\nstatus: active\n---\n# Sub\n\nBody.")
     (sub_path / "gptme.toml").write_text('[agent]\nname = "contrib"\n')
     subprocess.run(["git", "init"], cwd=sub_path, capture_output=True)
+    # No git remote added — detect_github_url returns ""
 
     # Register as submodule via .gitmodules
     gitmodules = tmp_path / ".gitmodules"
@@ -1143,7 +1144,59 @@ def test_collect_workspace_data_submodule_items_no_gh_url(tmp_path: Path):
     assert "gh_url" in main_lessons[0]  # main workspace items get gh_url
 
     assert len(sub_lessons_data) == 1
-    assert "gh_url" not in sub_lessons_data[0]  # submodule items must NOT get gh_url
+    assert "gh_url" not in sub_lessons_data[0]  # no remote → no gh_url
+
+
+def test_collect_workspace_data_submodule_items_get_gh_url(tmp_path: Path):
+    """Submodule items get gh_url from the submodule's own git remote."""
+    import subprocess
+
+    subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", "git@github.com:test/main-repo.git"],
+        cwd=tmp_path,
+        capture_output=True,
+    )
+
+    # Main workspace lesson
+    lessons_dir = tmp_path / "lessons" / "workflow"
+    lessons_dir.mkdir(parents=True)
+    (lessons_dir / "main.md").write_text("---\nstatus: active\n---\n# Main\n\nBody.")
+
+    # Submodule with its OWN git remote
+    sub_path = tmp_path / "gptme-contrib"
+    sub_lessons = sub_path / "lessons" / "workflow"
+    sub_lessons.mkdir(parents=True)
+    (sub_lessons / "sub.md").write_text("---\nstatus: active\n---\n# Sub\n\nBody.")
+    (sub_path / "gptme.toml").write_text('[agent]\nname = "contrib"\n')
+    subprocess.run(["git", "init"], cwd=sub_path, capture_output=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", "git@github.com:gptme/gptme-contrib.git"],
+        cwd=sub_path,
+        capture_output=True,
+    )
+
+    # Register as submodule via .gitmodules
+    (tmp_path / ".gitmodules").write_text(
+        '[submodule "gptme-contrib"]\n'
+        "    path = gptme-contrib\n"
+        "    url = git@github.com:gptme/gptme-contrib.git\n"
+    )
+
+    data = collect_workspace_data(tmp_path)
+
+    main_lessons = [le for le in data["lessons"] if not le.get("source")]
+    sub_lessons_data = [le for le in data["lessons"] if le.get("source")]
+
+    assert len(main_lessons) == 1
+    assert "gh_url" in main_lessons[0]
+    assert "main-repo" in main_lessons[0]["gh_url"]
+
+    assert len(sub_lessons_data) == 1
+    # Submodule lesson gets gh_url pointing to the submodule's repo, not main repo
+    assert "gh_url" in sub_lessons_data[0]
+    assert "gptme-contrib" in sub_lessons_data[0]["gh_url"]
+    assert "main-repo" not in sub_lessons_data[0]["gh_url"]
 
 
 # ── agent.urls ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
When running the dashboard for an agent like Bob that has submodules (gptme-contrib, gptme-superuser), lessons and skills from those submodules appeared without any "src" GitHub link. This is because the main workspace's GitHub URL was (correctly) not applied to submodule items — but no URL was applied from the submodule's own repo either.

Closes part of #382 (nested submodule support).

## Changes

### `collect_workspace_data()` — detect submodule GitHub URLs

For each submodule scanned, call `detect_github_url(sub_path)` to get the submodule's own git remote URL. If present, apply `gh_url` values using that remote:

- Lessons: `github_blob_url(sub_gh_url, lesson["path"], prefix="lessons")`
- Skills/packages/plugins: `github_tree_url(sub_gh_url, item["path"])`

Submodules without a configured remote continue to produce items with no `gh_url` (same as before).

## Example

Running `gptme-dashboard generate` on Bob's workspace (which has gptme-contrib as a submodule):

**Before**: Lesson "shared-pattern" from gptme-contrib — no src link in guidance table

**After**: Lesson "shared-pattern" from gptme-contrib — links to `https://github.com/gptme/gptme-contrib/blob/HEAD/lessons/patterns/shared-pattern.md`

## Tests

11 total (was 9) for submodule scenarios:
- `test_collect_workspace_data_submodule_items_no_gh_url` — updated: submodule without remote still gets no gh_url
- `test_collect_workspace_data_submodule_items_get_gh_url` — **new**: submodule with remote gets gh_url from its own repo, not the main workspace's repo