### PR TITLE
Support nested metadata usage format from gptme

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -422,15 +422,12 @@ def extract_usage_gptme(msgs: list[dict]) -> dict:
             model = m
 
         # Support both nested format (usage sub-dict) and legacy flat format
-        usage = metadata.get("usage", {})
-        input_tokens += usage.get("input_tokens", 0) or metadata.get("input_tokens", 0)
-        output_tokens += usage.get("output_tokens", 0) or metadata.get("output_tokens", 0)
-        cache_read_tokens += usage.get("cache_read_tokens", 0) or metadata.get(
-            "cache_read_tokens", 0
-        )
-        cache_creation_tokens += usage.get("cache_creation_tokens", 0) or metadata.get(
-            "cache_creation_tokens", 0
-        )
+        # Select source dict once per message to avoid per-field falsy fallback issues
+        usage = metadata.get("usage") or metadata
+        input_tokens += usage.get("input_tokens", 0)
+        output_tokens += usage.get("output_tokens", 0)
+        cache_read_tokens += usage.get("cache_read_tokens", 0)
+        cache_creation_tokens += usage.get("cache_creation_tokens", 0)
         cost += metadata.get("cost", 0.0)
 
     total_tokens = input_tokens + output_tokens + cache_read_tokens + cache_creation_tokens

--- a/plugins/gptme-wrapped/src/gptme_wrapped/tools/__init__.py
+++ b/plugins/gptme-wrapped/src/gptme_wrapped/tools/__init__.py
@@ -67,19 +67,12 @@ def _analyze_conversation(conv_dir: Path) -> dict[str, Any]:
                 continue
 
             # Support both nested format (usage sub-dict) and legacy flat format
-            usage = metadata.get("usage", {})
-            stats["input_tokens"] += usage.get("input_tokens", 0) or metadata.get(
-                "input_tokens", 0
-            )
-            stats["output_tokens"] += usage.get("output_tokens", 0) or metadata.get(
-                "output_tokens", 0
-            )
-            stats["cache_read_tokens"] += usage.get(
-                "cache_read_tokens", 0
-            ) or metadata.get("cache_read_tokens", 0)
-            stats["cache_creation_tokens"] += usage.get(
-                "cache_creation_tokens", 0
-            ) or metadata.get("cache_creation_tokens", 0)
+            # Select source dict once per message to avoid per-field falsy fallback issues
+            usage = metadata.get("usage") or metadata
+            stats["input_tokens"] += usage.get("input_tokens", 0)
+            stats["output_tokens"] += usage.get("output_tokens", 0)
+            stats["cache_read_tokens"] += usage.get("cache_read_tokens", 0)
+            stats["cache_creation_tokens"] += usage.get("cache_creation_tokens", 0)
             stats["cost"] += metadata.get("cost", 0) or 0
 
             model = metadata.get("model", "unknown")


### PR DESCRIPTION
## Summary
- Updates `extract_usage_gptme()` in gptme-sessions and `_analyze_conversation()` in gptme-wrapped to support both the new nested `usage` sub-dict format and the legacy flat format
- Companion to ErikBjare/gptme#1638, which restructures `MessageMetadata` to nest token fields under `usage`

## Changes
- `packages/gptme-sessions/src/gptme_sessions/signals.py` — dual-format token extraction
- `plugins/gptme-wrapped/src/gptme_wrapped/tools/__init__.py` — dual-format token extraction

## Test plan
- [x] All 226 gptme-sessions tests pass locally
- [x] All 8 gptme-wrapped tests pass locally
- [ ] CI passes