### PR TITLE
feat(dashboard): Phase 3 — schedule/timer monitor

### DIFF
--- a/packages/gptme-dashboard/src/gptme_dashboard/server.py
+++ b/packages/gptme-dashboard/src/gptme_dashboard/server.py
@@ -346,12 +346,12 @@ def create_app(workspace: Path, site_dir: Path | None = None) -> Any:
 
     @app.route("/api/schedule")
     def api_schedule() -> Any:
-        """Return systemd/launchd timer schedule for gptme-related timers.
+        """Return systemd timer schedule for gptme-related timers.
 
         Complements ``/api/services`` by showing *when* services run, not just
         whether they are running.  On Linux, parses ``systemctl --user
-        list-timers``; on macOS, inspects ``launchctl`` plists.  Returns an
-        empty list when detection is unavailable or no relevant timers exist.
+        list-timers``.  Returns an empty list on macOS (not yet supported),
+        when detection is unavailable, or when no relevant timers exist.
         """
         import json as _json
         import platform
@@ -423,6 +423,7 @@ def create_app(workspace: Path, site_dir: Path | None = None) -> Any:
                     subprocess.TimeoutExpired,
                     _json.JSONDecodeError,
                     ValueError,
+                    OverflowError,
                 ):
                     pass
 

--- a/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
+++ b/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
@@ -924,8 +924,10 @@ async function loadSchedule() {
       else if (absDiff < 3600000) rel = Math.round(absDiff / 60000) + 'min';
       else if (absDiff < 86400000) rel = Math.round(absDiff / 3600000) + 'h';
       else rel = Math.round(absDiff / 86400000) + 'd';
-      if (diffMs > 0) rel = 'in ' + rel;
-      else if (rel !== 'just now') rel = rel + ' ago';
+      if (rel !== 'just now') {
+        if (diffMs > 0) rel = 'in ' + rel;
+        else rel = rel + ' ago';
+      }
       return '<span title="' + esc(d.toLocaleString()) + '">' + esc(rel) + '</span>';
     }
 

--- a/packages/gptme-dashboard/tests/test_server.py
+++ b/packages/gptme-dashboard/tests/test_server.py
@@ -811,6 +811,36 @@ def test_api_schedule_timeout_handled(client):
     assert data["timers"] == []
 
 
+def test_api_schedule_overflow_timestamps(client):
+    """Test /api/schedule handles very large sentinel timestamps (UINT64_MAX)."""
+    systemctl_output = json.dumps(
+        [
+            {
+                "next": 18446744073709551615,  # UINT64_MAX sentinel
+                "left": 18446744073709551615,
+                "last": 1773150000046572,
+                "passed": 1830362162103,
+                "unit": "gptme-overflow.timer",
+                "activates": "gptme-overflow.service",
+            },
+        ]
+    )
+    mock_result = unittest.mock.MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = systemctl_output
+
+    with (
+        unittest.mock.patch("platform.system", return_value="Linux"),
+        unittest.mock.patch("subprocess.run", return_value=mock_result),
+    ):
+        resp = client.get("/api/schedule")
+
+    # Should not 500 — graceful fallback
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data["timers"], list)
+
+
 def test_api_schedule_darwin_empty(client):
     """Test /api/schedule returns empty timers on macOS (not yet supported)."""
     with unittest.mock.patch("platform.system", return_value="Darwin"):


### PR DESCRIPTION
## Summary

Adds real-time visibility into systemd/launchd timer scheduling — Phase 3 of the multi-agent dashboard (#13 in idea backlog).

Complements the existing `/api/services` endpoint (which shows *whether* services are running) by showing *when* they're scheduled to run.

## Changes

### Backend (`server.py`)
- New `GET /api/schedule` endpoint
- Parses `systemctl --user list-timers --all --output=json` on Linux
- Converts microsecond timestamps to ISO format (null for zero/never-triggered)
- Same agent-name + "gptme" relevance filter as `/api/services`
- Graceful fallback: empty list on macOS, subprocess errors, or timeouts

### Frontend (`index.html`)
- New "Schedule" dynamic panel below Services
- Table: Timer / Activates / Last Trigger / Next Run
- Relative time display ("in 5min", "23min ago") with full timestamp on hover
- Sorted by next run time (soonest first)
- Auto-hidden when no timers detected

### Tests
- **7 new tests** (41 total, all passing):
  - `test_api_schedule_structure` — response shape
  - `test_api_schedule_linux_detection` — agent/gptme name filtering
  - `test_api_schedule_timestamp_conversion` — μs → ISO
  - `test_api_schedule_zero_timestamps` — null for never-triggered
  - `test_api_schedule_systemctl_failure` — graceful empty on error
  - `test_api_schedule_timeout_handled` — subprocess timeout
  - `test_api_schedule_darwin_empty` — macOS returns empty (not yet supported)

## Context

Dashboard phases:
- Phase 1 (merged): Foundation — session stats, service detection, multi-agent visibility
- Phase 2 (just merged, gptme/gptme-contrib#446): Session filtering + pagination
- **Phase 3 (this PR)**: Schedule/timer monitor
- Phase 4 (planned): Service health checks, resource usage

Essential for autonomous agent operations where knowing *when* the next autonomous run, email check, or monitoring sweep happens is critical for operational awareness.