### PR TITLE
fix(coverage): pass CODECOV_TOKEN to fix uploads on protected branch

### DIFF
--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -162,6 +162,7 @@ jobs:
         if: hashFiles('coverage.xml') != ''
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
           flags: packages
           name: codecov-packages

--- a/.github/workflows/test-plugins.yml
+++ b/.github/workflows/test-plugins.yml
@@ -179,15 +179,18 @@ jobs:
           # Find all plugins with tests and run coverage
           for plugin in plugins/*/; do
             if [ -d "$plugin/tests" ]; then
-              pytest "$plugin/tests" -v -m "not slow" --cov="$plugin" --cov-append --cov-report=xml --cov-report=term --timeout=30 || true
+              pytest "$plugin/tests" -v -m "not slow" --cov="$plugin" --cov-append --cov-report=term-missing --timeout=30 || true
             fi
           done
+          # Generate combined XML report once after all plugins
+          coverage xml || true
 
       - name: Upload coverage to Codecov
         if: hashFiles('coverage.xml') != ''
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
-          flags: unittests
+          flags: plugins
           name: codecov-plugins
           fail_ci_if_error: false


### PR DESCRIPTION
## Summary

Fixes #453 (reopened after #454 merge).

**Root cause**: `codecov-action@v5` requires an explicit `token` input when uploading from protected branches. Without it, both the packages and plugins coverage jobs were silently failing with:

```
error - Upload failed: {"message":"Token required because branch is protected"}
```

This was masked by `fail_ci_if_error: false`, so CI stayed green but no coverage was actually reaching Codecov — explaining why Erik only saw old data for `plugins/imagen` and `plugins/consortium`.

## Changes

**`test-packages.yml`**:
- Add `token: ${{ secrets.CODECOV_TOKEN }}` to Codecov upload step

**`test-plugins.yml`**:
- Add `token: ${{ secrets.CODECOV_TOKEN }}` to Codecov upload step
- Fix coverage loop to generate XML once at end (matching packages job pattern, addressing Greptile's earlier feedback on #454)
- Rename flag from `unittests` → `plugins` for consistency with the packages flag

## Required repo setup

The `CODECOV_TOKEN` secret must be configured in the repo settings (Settings → Secrets → Actions). Once set, both coverage jobs should start uploading successfully.