### PR TITLE
fix(ci): install all extras in packages coverage job

### DIFF
--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -131,9 +131,13 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get install -y portaudio19-dev libportaudio2
+
       - name: Install dependencies
         run: |
-          uv sync --all-packages
+          uv sync --all-packages --all-extras
 
       - name: Run coverage for all packages
         run: |
@@ -146,8 +150,6 @@ jobs:
             # Only packages with both tests/ and src/
             if [ -d "$pkg/tests" ] && [ -d "$pkg/src" ] && [ -f "$pkg/Makefile" ]; then
               echo "=== Coverage for $name ==="
-              # Install test extras (e.g. flask for gptme-dashboard[test] -> [serve])
-              uv pip install -e "$pkg[test]" --quiet 2>/dev/null || true
               uv run --with pytest --with pytest-cov --with pytest-timeout pytest "$pkg/tests" \
                 --cov="$pkg/src" \
                 --cov-append \


### PR DESCRIPTION
## Summary

- Fixes missing coverage for `gptme-dashboard` in the packages coverage CI job
- Adds `--all-extras` to `uv sync --all-packages` so optional dependencies (like `flask` in `gptme-dashboard[serve]`) are installed

## Root cause

`gptme-dashboard` tests import `flask` via `gptme_dashboard.server`. Flask is listed under `[serve]` optional extra and pulled in by the `[test]` extra. However, the coverage job used `uv sync --all-packages` (no extras), so flask was never installed — causing `ModuleNotFoundError: No module named 'flask'` and silently skipping dashboard coverage (due to `|| true`).

The separate `test` job works fine because its Makefile target uses `uv run --with flask pytest`, which temporarily adds flask. The coverage job bypassed the Makefile and ran pytest directly, missing that `--with flask`.

## Fix

```diff
- uv sync --all-packages
+ uv sync --all-packages --all-extras
```

This ensures all optional deps across all packages are installed before running coverage.

Closes #453