### PR TITLE
feat(activity-summary): add AW category breakdown to activity data

### DIFF
--- a/packages/gptme-activity-summary/src/gptme_activity_summary/aw_data.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/aw_data.py
@@ -393,14 +393,15 @@ def format_aw_activity_for_prompt(activity: AWActivity) -> str:
         # _fetch_app_usage() total which comes from a different HTTP round-trip.
         category_total = sum(c.duration for c in activity.categories)
         max_cats = 12
-        shown = activity.categories[:max_cats]
+        sorted_cats = sorted(activity.categories, key=lambda c: c.duration, reverse=True)
+        shown = sorted_cats[:max_cats]
         for cat in shown:
             pct = (cat.duration / category_total * 100) if category_total > 0 else 0
             h = cat.duration / 3600
             lines.append(f"- **{cat.name}**: {h:.1f}h ({pct:.0f}%)")
-        if len(activity.categories) > max_cats:
-            omitted = len(activity.categories) - max_cats
-            omitted_h = sum(c.duration for c in activity.categories[max_cats:]) / 3600
+        if len(sorted_cats) > max_cats:
+            omitted = len(sorted_cats) - max_cats
+            omitted_h = sum(c.duration for c in sorted_cats[max_cats:]) / 3600
             lines.append(f"- *...{omitted} more categories ({omitted_h:.1f}h not shown)*")
         lines.append("")
 

--- a/packages/gptme-activity-summary/tests/test_aw_data.py
+++ b/packages/gptme-activity-summary/tests/test_aw_data.py
@@ -283,6 +283,31 @@ def test_format_aw_activity_category_truncation():
     assert "Cat12" not in text
 
 
+def test_format_aw_activity_category_sort_order():
+    """Categories are displayed sorted by duration descending, regardless of input order.
+
+    Ensures the formatter sorts defensively rather than trusting callers to pre-sort.
+    """
+    cats = [
+        CategoryUsage(category=["Web"], duration=1800),  # 2nd in output
+        CategoryUsage(category=["Coding"], duration=5400),  # 1st in output
+        CategoryUsage(category=["Misc"], duration=900),  # 3rd in output
+    ]
+    activity = AWActivity(
+        start_date=date.today(),
+        end_date=date.today(),
+        available=True,
+        total_active_seconds=8100,
+        top_apps=[AppUsage(app="nvim", duration=8100)],
+        categories=cats,
+    )
+    text = format_aw_activity_for_prompt(activity)
+    coding_pos = text.index("Coding")
+    web_pos = text.index("Web")
+    misc_pos = text.index("Misc")
+    assert coding_pos < web_pos < misc_pos, "Categories should be sorted by duration descending"
+
+
 def test_fetch_category_usage_non_list_category():
     """Defensive branch: non-list $category values are cast to a single-element list."""
     from unittest.mock import MagicMock, patch


### PR DESCRIPTION
## Summary

Adds category-level time breakdown to `gptme-activity-summary`'s ActivityWatch integration. When the user has configured AW categorization rules, summaries now include a **Time by Category** section that shows time allocation at the category level — much more meaningful for LLM summaries than raw app names.

### Before

```markdown
### Top Applications
- **nvim**: 3.2h (45%)
- **kitty**: 1.8h (25%)
- **Firefox**: 1.8h (25%)
- **zoom**: 0.4h (5%)
```

### After

```markdown
### Time by Category
- **Coding**: 5.0h (70%)
- **Communication**: 0.4h (5%)
- **Web**: 1.8h (25%)

### Top Applications
- **nvim**: 3.2h (45%)
...
```

## Changes

- **`CategoryUsage` dataclass** — represents time in a category path (e.g. `["Coding", "Python"]`), with `name` (`"Coding > Python"`) and `top_level` properties
- **`_fetch_category_usage()`** — queries AW using `categorize(events, $categories)` + AFK filtering, same pattern as existing app usage query
- **`AWActivity.categories`** field populated in `fetch_aw_activity()`
- **`format_aw_activity_for_prompt()`** updated to show category section before apps (skipped when no categories configured)
- **8 new tests** (19 total, all passing)

## Behaviour

- Gracefully degrades when user has no categories configured (empty section, not shown)
- Uses the same AFK filtering as app usage for accurate active-only times
- Percentages are relative to total active time (not category total)
- Shows up to 12 categories, all categories (including Uncategorized)

Relates to: ActivityWatch/aw-webui#731 (Erik's request for richer AW data in summaries)

Co-authored-by: Bob <bob@superuserlabs.org>