### PR TITLE
docs(dashboard): Phase 7b design — gptme-webui fleet integration

### DIFF
--- a/packages/gptme-dashboard/DESIGN.md
+++ b/packages/gptme-dashboard/DESIGN.md
@@ -265,21 +265,23 @@ Each agent renders as a card in gptme-webui's "Org" tab:
 │  Last active: 2 hours ago                     │
 │  Active tasks: 3  •  Services: 4/4 healthy    │
 │  Working on: gptme-contrib#382 dashboard      │
-│  Recent session: productive (2h) — PR opened  │
+│  Recent session: productive                   │
 └──────────────────────────────────────────────┘
 ```
 
 Fields:
 | Field | API source |
 |-------|-----------|
-| Status (active/idle) | `/api/tasks?state=active` — active tasks = agent is working |
+| Status (active/idle) | `/api/tasks?state=active` — active tasks = agent is working _(shared call — see note below)_ |
 | Last active | `/api/sessions` — most recent session timestamp |
-| Active task count | `/api/tasks?state=active` |
+| Active task count | `/api/tasks?state=active` _(shared call)_ |
 | Service health | `/api/services/health` |
-| Current task title | `/api/tasks?state=active` first result |
-| Latest session summary | `/api/sessions` first result `.outcome` |
+| Current task title | `/api/tasks?state=active` first result _(shared call)_ |
+| Latest session summary | `/api/sessions` first result `.outcome` (e.g. `"productive"`) |
 | `[Open]` button | links to `agent.urls.dashboard`; hidden if not set |
 | `[↗]` button | opens the agent's chat interface in gptme-webui in a new tab; URL is relative to the current gptme-webui instance's origin, e.g. `/?server=http%3A%2F%2Fbob-vm%3A8140`; exact deep-link format is TBD by gptme-webui implementation |
+
+> **Note**: Status, active task count, and current task title all derive from a single `/api/tasks?state=active` call per poll cycle — implementations should fetch once and reuse the response for all three fields.
 
 ### Agent Command Center Vision
 
@@ -314,6 +316,7 @@ The status/task/session fields are achievable with the existing `/api/*` endpoin
 - If `dashboard-api` is **absent**:
   - If `agent.urls.dashboard` is set: show minimal card with server name/URL + `[Open]` button (links to static site); omit live-data fields; add "live API not available" note
   - If neither key is set: show minimal card with server name/URL and a "dashboard not configured" indicator; no API calls made
+- **Polling cadence**: poll each agent's live-data endpoints (tasks, services, sessions) every 30 seconds; a shorter interval (e.g. 10 s) can be used for the active card when drill-down is open. SSE support is not planned for Phase 7b — if gptme-server gains SSE endpoints in the future, the Org tab can subscribe instead of polling.
 
 **Step 4** (optional, later): Auth for dashboard-proxy route
 - gptme-server's existing auth mechanism covers the proxy route — no new config file needed


### PR DESCRIPTION
## Summary

Expands the fleet/org design section in `DESIGN.md` with a concrete Phase 7b plan, based on [Erik's feedback in #382](https://github.com/gptme/gptme-contrib/issues/382) (2026-03-11):

> "Maybe we should add gptme-dashboard API support as an extra in gptme-webui... Start iterating on a design document."

**Key additions:**

- **Discovery-based architecture**: gptme-webui reads `agent.urls.dashboard-api` from each server's `/api/config` response — no separate org.toml needed. Each gptme-server Erik already has configured in gptme-webui can expose its gptme-dashboard API automatically.

- **Agent card spec**: concrete field-by-field breakdown of what the fleet view shows and which `/api/*` endpoint feeds each field.

- **Agent command center vision**: grid layout, status-at-a-glance, drill-down, quick actions, idle detection — matches the "IDE for teams of agents" direction.

- **Implementation plan**: 4 steps across gptme-contrib (no change needed) and gptme/gptme (expose `agent.urls` in `/api/config`, add Org tab to webui).

- **Roadmap table update**: mark phases 6b/6c/6d as merged, add 7a (PR #467) and 7b (this design, planned).

## Changes

- `DESIGN.md`: expand fleet section (~117 lines added)

## Test plan
- [ ] `uv run pytest packages/gptme-dashboard/tests/ -q` — 325 tests pass (doc-only change)
- [ ] Read DESIGN.md fleet section end-to-end for coherence with current implementation