### PR TITLE
fix(dashboard): simplify nav to scroll-spy, fix heatmap responsive, fix /blob/HEAD/

### DIFF
--- a/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
+++ b/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
@@ -105,28 +105,12 @@ header p { color: var(--text-dim); margin-top: 0.25rem; }
   font-size: 0.8rem;
 }
 
-/* Multi-view navigation */
+/* Active nav link (scroll-spy highlight) */
 .dashboard-nav-links a.nav-active {
   background: var(--accent-dim);
   color: var(--accent);
   font-weight: 500;
 }
-.section-hidden {
-  display: none !important;
-}
-.nav-home-link {
-  display: flex;
-  align-items: center;
-  gap: 0.35rem;
-  text-decoration: none;
-  color: var(--text-dim);
-  border-radius: 6px;
-  padding: 0.35rem 0.5rem;
-  font-size: 0.9rem;
-  margin-bottom: 0.25rem;
-}
-.nav-home-link:hover { background: var(--accent-dim); color: var(--text); }
-.nav-home-link.nav-active { background: var(--accent-dim); color: var(--accent); font-weight: 500; }
 
 /* Sections */
 section {
@@ -470,17 +454,23 @@ tr:hover { background: var(--accent-dim); }
 }
 
 /* Activity heatmap */
-.heatmap-wrap { overflow-x: auto; }
+.heatmap-wrap { overflow-x: auto; -webkit-overflow-scrolling: touch; }
 .heatmap-month-labels {
   display: flex;
-  gap: 3px;
-  margin-bottom: 3px;
+  gap: var(--hm-gap, 3px);
+  margin-bottom: var(--hm-gap, 3px);
   font-size: 0.7rem;
   color: var(--text-dim);
 }
-.heatmap-month-label { width: 12px; flex-shrink: 0; white-space: nowrap; overflow: visible; }
-.heatmap-grid { display: flex; gap: 3px; }
-.heatmap-col { display: flex; flex-direction: column; gap: 3px; }
+.heatmap-month-label { width: var(--hm-size, 12px); flex-shrink: 0; white-space: nowrap; overflow: visible; }
+.heatmap-grid { display: flex; gap: var(--hm-gap, 3px); }
+.heatmap-col { display: flex; flex-direction: column; gap: var(--hm-gap, 3px); }
+@media (max-width: 900px) {
+  .heatmap-wrap { --hm-size: 8px; --hm-gap: 2px; }
+}
+@media (max-width: 600px) {
+  .heatmap-wrap { --hm-size: 6px; --hm-gap: 1px; }
+}
 .heatmap-cell {
   width: 12px;
   height: 12px;
@@ -588,7 +578,6 @@ tr:hover { background: var(--accent-dim); }
 <div class="dashboard-layout">
   <aside class="dashboard-nav" aria-label="Dashboard navigation">
     <h2>Quick navigation</h2>
-    <a href="#" id="nav-home" class="nav-home-link" aria-label="Show all sections">⊞ All sections</a>
 
     {% if readme_html or tasks or sessions or journals or summaries %}
     <div class="dashboard-nav-group">
@@ -982,7 +971,7 @@ tr:hover { background: var(--accent-dim); }
     {% for f in core_files %}
       <tr>
         <td><code>{{ f }}</code></td>
-        {% if gh_repo_url %}<td><a href="{{ gh_repo_url }}/blob/master/{{ f }}" class="gh-link">src</a></td>{% endif %}
+        {% if gh_repo_url %}<td><a href="{{ gh_repo_url }}/blob/HEAD/{{ f }}" class="gh-link">src</a></td>{% endif %}
       </tr>
     {% endfor %}
     </tbody>
@@ -1835,103 +1824,64 @@ document.addEventListener('keydown', function(e) {
 </script>
 
 <script>
-/* === Multi-view section navigation ===
- * Clicking a static-section nav link shows only that section (focused view).
- * The "All sections" home link restores the full overview.
- * Dynamic panels (live API) are left untouched — they appear/hide based on API
- * availability and are not affected by the focused-view toggle.
+/* === Section navigation ===
+ * Nav links smooth-scroll to the target section and highlight the active link.
+ * Scroll-spy updates the highlight as the user scrolls.
  */
 (function () {
   'use strict';
 
-  // IDs of sections controlled by the live API (style.display managed by initDynamic)
-  var DYNAMIC = new Set([
-    'session-stats', 'activity-heatmap', 'recent-sessions',
-    'agent-services', 'agent-schedule', 'service-health',
-    'service-logs', 'dynamic-journals'
-  ]);
+  var navLinks = document.querySelectorAll('.dashboard-nav-links a[href^="#"]');
 
-  // Sections that must always be shown together (e.g. two-col layout siblings)
-  var COUPLED = { 'packages': 'plugins', 'plugins': 'packages' };
+  // Highlight the nav link matching the given section id
+  function setActive(id) {
+    navLinks.forEach(function (a) {
+      a.classList.toggle('nav-active', a.getAttribute('href') === '#' + id);
+    });
+  }
 
-  function showSection(id) {
-    var homeLink = document.getElementById('nav-home');
-    var navLinks = document.querySelectorAll('.dashboard-nav-links a');
-    var sections = document.querySelectorAll('.dashboard-main section');
-
-    navLinks.forEach(function (a) { a.classList.remove('nav-active'); });
-    if (homeLink) homeLink.classList.remove('nav-active');
-
-    if (!id) {
-      // Overview: show all static sections
-      if (homeLink) homeLink.classList.add('nav-active');
-      sections.forEach(function (s) { s.classList.remove('section-hidden'); });
-    } else if (DYNAMIC.has(id)) {
-      // Dynamic panel: restore full overview so any hidden static sections are
-      // revealed, then scroll to the panel if it's currently visible.
-      if (homeLink) homeLink.classList.add('nav-active');
-      sections.forEach(function (s) { s.classList.remove('section-hidden'); });
+  // Click → smooth scroll + highlight
+  navLinks.forEach(function (a) {
+    a.addEventListener('click', function (e) {
+      var id = a.getAttribute('href').slice(1);
       var el = document.getElementById(id);
-      if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-      return;
-    } else if (!document.getElementById(id)) {
-      // Unknown hash: fall back to full overview instead of blank content area
-      if (homeLink) homeLink.classList.add('nav-active');
-      sections.forEach(function (s) { s.classList.remove('section-hidden'); });
-    } else {
-      // Focused view: show only the target static section (+ any coupled siblings)
-      var coupled = COUPLED[id] || null;
-      sections.forEach(function (s) {
-        if (s.id === id || s.id === coupled) {
-          s.classList.remove('section-hidden');
-        } else if (!DYNAMIC.has(s.id)) {
-          s.classList.add('section-hidden');
-        }
-        // Dynamic sections are left as-is (API manages their visibility)
+      if (!el) return;  // let browser handle missing targets
+      e.preventDefault();
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      history.replaceState(null, '', '#' + id);
+      setActive(id);
+    });
+  });
+
+  // Scroll-spy: update active link as user scrolls.
+  // Skip elements with zero height — hidden sections (display:none) always
+  // return top=0 and would otherwise permanently overwrite the best match.
+  var ticking = false;
+  window.addEventListener('scroll', function () {
+    if (ticking) return;
+    ticking = true;
+    requestAnimationFrame(function () {
+      ticking = false;
+      var best = '';
+      navLinks.forEach(function (a) {
+        var id = a.getAttribute('href').slice(1);
+        var el = document.getElementById(id);
+        if (!el) return;
+        var rect = el.getBoundingClientRect();
+        if (rect.height > 0 && rect.top <= 120) best = id;
       });
-      var escaped = typeof CSS !== 'undefined' && CSS.escape ? CSS.escape(id) : id.replace(/[^\w-]/g, '\\$&');
-      var activeLink = document.querySelector('.dashboard-nav-links a[href="#' + escaped + '"]');
-      if (activeLink) activeLink.classList.add('nav-active');
-      window.scrollTo(0, 0);
+      if (best) setActive(best);
+    });
+  });
+
+  // On load: scroll to hash target if present
+  if (location.hash) {
+    var el = document.getElementById(location.hash.slice(1));
+    if (el) {
+      el.scrollIntoView({ block: 'start' });
+      setActive(location.hash.slice(1));
     }
   }
-
-  // Intercept nav link clicks — static sections get focused view; dynamic panels
-  // get showSection() too so the stale nav-active indicator is cleared.
-  document.querySelectorAll('.dashboard-nav-links a').forEach(function (a) {
-    var href = a.getAttribute('href') || '';
-    if (!href.startsWith('#')) return;
-    var id = href.slice(1);
-    a.addEventListener('click', function (e) {
-      e.preventDefault();
-      history.pushState({ section: id }, '', '#' + id);
-      showSection(id);
-    });
-  });
-
-  // Home link restores full overview
-  var homeLink = document.getElementById('nav-home');
-  if (homeLink) {
-    homeLink.addEventListener('click', function (e) {
-      e.preventDefault();
-      history.pushState({ section: null }, '', location.pathname + location.search);
-      showSection(null);
-    });
-  }
-
-  // Restore view from URL hash on page load
-  var initial = location.hash ? location.hash.slice(1) : null;
-  showSection(initial || null);
-
-  // Handle browser back / forward
-  // Distinguish e.state === null (no state pushed yet, use hash)
-  // from e.state = { section: null } (home button, which explicitly clears section)
-  window.addEventListener('popstate', function (e) {
-    var id = (e.state !== null && e.state !== undefined)
-      ? e.state.section
-      : (location.hash ? location.hash.slice(1) : null);
-    showSection(id || null);
-  });
 }());
 </script>
 {% endblock %}

--- a/packages/gptme-dashboard/tests/test_generate.py
+++ b/packages/gptme-dashboard/tests/test_generate.py
@@ -3093,105 +3093,52 @@ def test_generate_dashboard_navigation_sidebar_dom_order(workspace: Path, tmp_pa
     assert aside_pos < main_pos, "aside.dashboard-nav must precede div.dashboard-main in DOM"
 
 
-def test_generate_dashboard_multiview_home_button(workspace: Path, tmp_path: Path):
-    """Dashboard includes a multi-view home button in the sidebar nav."""
+def test_generate_dashboard_nav_no_home_button(workspace: Path, tmp_path: Path):
+    """Dashboard uses scroll-spy nav — no 'All sections' home button or section-hiding."""
     output = tmp_path / "out"
     template_dir = Path(__file__).parent.parent / "src" / "gptme_dashboard" / "templates"
     generate(workspace, output, template_dir)
 
     html = (output / "index.html").read_text()
 
-    assert 'id="nav-home"' in html, "nav-home home link missing"
-    assert 'class="nav-home-link"' in html, "nav-home-link class missing"
-    assert "All sections" in html, "All sections label missing"
+    # Old multi-view artefacts must not be present
+    assert 'id="nav-home"' not in html, "nav-home home link should be removed (scroll-spy nav)"
+    assert "section-hidden" not in html, "section-hidden should be removed (scroll-spy nav)"
+    assert "showSection" not in html, "showSection should be removed (scroll-spy nav)"
+    assert "COUPLED" not in html, "COUPLED map should be removed (scroll-spy nav)"
 
 
-def test_generate_dashboard_multiview_js(workspace: Path, tmp_path: Path):
-    """Dashboard includes multi-view section navigation JS."""
+def test_generate_dashboard_nav_scroll_spy_js(workspace: Path, tmp_path: Path):
+    """Dashboard includes scroll-spy navigation JS with hidden-element guard."""
     output = tmp_path / "out"
     template_dir = Path(__file__).parent.parent / "src" / "gptme_dashboard" / "templates"
     generate(workspace, output, template_dir)
 
     html = (output / "index.html").read_text()
 
-    assert "section-hidden" in html, "section-hidden CSS class missing"
-    assert "showSection" in html, "showSection JS function missing"
-    assert "DYNAMIC" in html, "DYNAMIC set missing from multi-view JS"
+    # Scroll-spy essentials
     assert "nav-active" in html, "nav-active CSS class missing"
-
-
-def test_generate_dashboard_multiview_home_precedes_nav_groups(workspace: Path, tmp_path: Path):
-    """Home link appears before the first nav group in the sidebar."""
-    output = tmp_path / "out"
-    template_dir = Path(__file__).parent.parent / "src" / "gptme_dashboard" / "templates"
-    generate(workspace, output, template_dir)
-
-    html = (output / "index.html").read_text()
-
-    assert 'id="nav-home"' in html, "nav-home home link missing"
-    assert 'class="dashboard-nav-group"' in html, "dashboard-nav-group missing"
-    home_pos = html.index('id="nav-home"')
-    group_pos = html.index('class="dashboard-nav-group"')
-    assert home_pos < group_pos, "nav-home must appear before the first nav group"
-
-
-def test_generate_dashboard_multiview_js_dynamic_clears_section_hidden(
-    workspace: Path, tmp_path: Path
-):
-    """DYNAMIC branch in showSection restores full overview (no section-hidden left behind)."""
-    output = tmp_path / "out"
-    template_dir = Path(__file__).parent.parent / "src" / "gptme_dashboard" / "templates"
-    generate(workspace, output, template_dir)
-
-    html = (output / "index.html").read_text()
-
-    # The DYNAMIC branch must call classList.remove('section-hidden') on all sections
-    # (not just scroll) so that a prior focused view is cleared.
-    assert "DYNAMIC.has(id)" in html, "DYNAMIC.has(id) check missing"
-    assert "classList.remove('section-hidden')" in html, "section-hidden removal missing from JS"
-    # Verify the DYNAMIC branch itself contains the section-hidden removal.
-    # Search for the removal *after* the DYNAMIC.has(id) check so we find the
-    # occurrence inside that branch, not the earlier overview-branch occurrence.
-    dynamic_idx = html.index("DYNAMIC.has(id)")
-    remove_after_dynamic_idx = html.index("classList.remove('section-hidden')", dynamic_idx)
-    assert (
-        remove_after_dynamic_idx < dynamic_idx + 300
-    ), "section-hidden removal should appear inside the DYNAMIC branch (within 300 chars of DYNAMIC.has(id))"
-
-
-def test_generate_dashboard_multiview_js_coupled_sections(workspace: Path, tmp_path: Path):
-    """COUPLED map keeps packages/plugins shown together in focused view."""
-    output = tmp_path / "out"
-    template_dir = Path(__file__).parent.parent / "src" / "gptme_dashboard" / "templates"
-    generate(workspace, output, template_dir)
-
-    html = (output / "index.html").read_text()
-
-    assert "COUPLED" in html, "COUPLED map missing from multi-view JS"
-    assert "'packages': 'plugins'" in html, "packages->plugins coupling missing"
-    assert "'plugins': 'packages'" in html, "plugins->packages coupling missing"
-    assert "coupled = COUPLED[id]" in html, "coupled variable assignment missing"
-
-
-def test_generate_dashboard_multiview_dynamic_links_call_show_section(
-    workspace: Path, tmp_path: Path
-):
-    """DYNAMIC nav links get a click handler that calls showSection to clear stale nav-active."""
-    output = tmp_path / "out"
-    template_dir = Path(__file__).parent.parent / "src" / "gptme_dashboard" / "templates"
-    generate(workspace, output, template_dir)
-
-    html = (output / "index.html").read_text()
-
-    # The click handler setup loop must NOT bail out early for DYNAMIC links.
-    # If "DYNAMIC.has(id)) return" is present, dynamic links skip showSection
-    # and leave a stale nav-active indicator on the previously-active static link.
-    assert "DYNAMIC.has(id)) return" not in html, (
-        "DYNAMIC links must not skip the click handler — they need showSection() "
-        "to clear the stale nav-active indicator from previously-active static links"
+    assert "scrollIntoView" in html, "scrollIntoView missing from nav JS"
+    assert "getBoundingClientRect" in html, "scroll-spy getBoundingClientRect missing"
+    assert "setActive" in html, "setActive function missing from scroll-spy JS"
+    # Hidden-element guard: visible elements only (rect.height > 0 prevents display:none
+    # sections from always satisfying the top <= threshold condition)
+    assert "rect.height > 0" in html, (
+        "scroll-spy must skip hidden elements (rect.height > 0 guard missing) — "
+        "display:none sections have height=0 and top=0 which always satisfies top<=120"
     )
-    # All nav links (static and dynamic) should go through the same addEventListener path.
+
+
+def test_generate_dashboard_nav_smooth_scroll_click(workspace: Path, tmp_path: Path):
+    """Clicking a nav link smooth-scrolls to the target section."""
+    output = tmp_path / "out"
+    template_dir = Path(__file__).parent.parent / "src" / "gptme_dashboard" / "templates"
+    generate(workspace, output, template_dir)
+
+    html = (output / "index.html").read_text()
+
     assert "a.addEventListener('click'" in html, "click handler missing from nav link setup"
+    assert "behavior: 'smooth'" in html, "smooth scroll behavior missing"
 
 
 def test_generate_dashboard_live_nav_group_hidden_in_static_mode(workspace: Path, tmp_path: Path):
@@ -3210,6 +3157,37 @@ def test_generate_dashboard_live_nav_group_hidden_in_static_mode(workspace: Path
     assert 'style="display:none"' in snippet, f"live-nav-group not hidden by default: {snippet!r}"
     # initDynamic must reference the group by JS variable name
     assert "liveGroup" in html, "liveGroup JS variable missing from initDynamic"
+
+
+def test_generate_dashboard_core_files_use_blob_head(tmp_path: Path):
+    """Core Files GitHub links use /blob/HEAD/ (not /blob/master/) for branch portability."""
+    import subprocess
+
+    ws = tmp_path / "workspace"
+    ws.mkdir()
+    subprocess.run(["git", "init"], cwd=ws, capture_output=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", "git@github.com:test/myagent.git"],
+        cwd=ws,
+        capture_output=True,
+    )
+    # Minimal workspace with gptme.toml that lists prompt files
+    (ws / "ABOUT.md").write_text("# About\n")
+    (ws / "GOALS.md").write_text("# Goals\n")
+    (ws / "gptme.toml").write_text('[prompt]\nfiles = ["ABOUT.md", "GOALS.md"]\n')
+    lessons_dir = ws / "lessons" / "workflow"
+    lessons_dir.mkdir(parents=True)
+    (lessons_dir / "test.md").write_text("---\nstatus: active\n---\n# Test\n\nBody.")
+
+    output = tmp_path / "out"
+    template_dir = Path(__file__).parent.parent / "src" / "gptme_dashboard" / "templates"
+    generate(ws, output, template_dir)
+
+    html = (output / "index.html").read_text()
+
+    assert "ABOUT.md" in html, "Core Files section missing ABOUT.md"
+    assert "/blob/HEAD/ABOUT.md" in html, "Core Files GitHub links must use /blob/HEAD/"
+    assert "/blob/master/" not in html, "Core Files must not hardcode /blob/master/"
 
 
 def test_generate_dashboard_readme_section_label(workspace: Path, tmp_path: Path):


### PR DESCRIPTION
## Summary

Follow-up to #471 / alternative to #473. Addresses the UX feedback from the #469 merge (\"clicking links does nothing\", \"weird and unintuitive\") and fixes two correctness issues:

- **Remove complex multi-view nav**: Strips the `section-hidden` hide-all-but-one approach (DYNAMIC set, COUPLED map, `showSection` function, \"⊞ All sections\" home button) — ~70 lines of JS removed
- **Scroll-spy nav**: Clicking a nav link now smooth-scrolls to the target section; active link is highlighted as you scroll
- **Hidden-element guard**: `rect.height > 0` check in scroll-spy prevents `display:none` sections (dynamic panels) from always overwriting `best` — their `getBoundingClientRect().top === 0` would otherwise make the active highlight never work in static mode
- **Fix `/blob/master/`**: Core Files GitHub links now use `/blob/HEAD/` (consistent with `github_blob_url()` utility and correct for `main`-default repos)
- **Heatmap responsive**: CSS custom properties `--hm-size`/`--hm-gap` scale cells down at 900px and 600px breakpoints

## Tests

5 old multi-view tests (section-hidden, DYNAMIC, COUPLED, home button) replaced with 4 scroll-spy tests + 1 `/blob/HEAD/` correctness test. 213 passing (3.10/3.11/3.12).

## Relation to #473

PR #473 (by @ErikBjare) has the same intent but is conflicting with master and has two Greptile-identified bugs (scroll-spy broken by hidden elements, hardcoded `/blob/master/`). This PR starts from current master with both issues fixed.

Closes part of #382.