### PR TITLE
feat(dashboard): client-side search fallback for static gh-pages deployments

### DIFF
--- a/packages/gptme-dashboard/src/gptme_dashboard/generate.py
+++ b/packages/gptme-dashboard/src/gptme_dashboard/generate.py
@@ -1692,13 +1692,16 @@ def generate_json(
         ],
         "plugins": [
             {k: v for k, v in plugin.items() if k not in _JSON_EXCLUDE}
+            | {"has_page": bool(plugin.get("body"))}
             for plugin in data["plugins"]
         ],
         "tasks": [
             {k: v for k, v in task.items() if k not in _JSON_EXCLUDE} for task in data["tasks"]
         ],
         "packages": [
-            {k: v for k, v in pkg.items() if k not in _JSON_EXCLUDE} for pkg in data["packages"]
+            {k: v for k, v in pkg.items() if k not in _JSON_EXCLUDE}
+            | {"has_page": bool(pkg.get("body"))}
+            for pkg in data["packages"]
         ],
         "summaries": [
             {k: v for k, v in s.items() if k not in _JSON_EXCLUDE} for s in data["summaries"]

--- a/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
+++ b/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
@@ -1805,9 +1805,11 @@ function _buildClientIndex(data) {
     addItem('summary', s.title || s.period, s.type, '', [], s.preview || '', pageUrl(s));
   }
   for (const p of (data.packages || [])) {
+    if (!p.has_page) continue;
     addItem('package', p.name, '', p.source, [], p.description, pageUrl(p));
   }
   for (const p of (data.plugins || [])) {
+    if (!p.has_page) continue;
     addItem('plugin', p.name, p.enabled == null ? '' : (p.enabled ? 'enabled' : 'disabled'), p.source, [], p.description,
       pageUrl(p));
   }

--- a/packages/gptme-dashboard/tests/test_generate.py
+++ b/packages/gptme-dashboard/tests/test_generate.py
@@ -4107,3 +4107,51 @@ def test_static_search_summary_preview_in_haystack(workspace: Path, tmp_path: Pa
         "_buildClientIndex must pass s.preview as excerpt for summaries "
         "so summary content is searchable"
     )
+
+
+def test_static_search_has_page_skips_bodyless_packages(workspace: Path, tmp_path: Path):
+    """_buildClientIndex must skip packages/plugins that have no generated detail page.
+
+    Packages and plugins without a README body get a page_url in data.json but no HTML
+    file is written. Without has_page filtering, static search results would link to 404s.
+    """
+    output = tmp_path / "site"
+    generate(workspace, output)
+    html = (output / "index.html").read_text()
+    # The guard must appear in _buildClientIndex before the addItem call for packages
+    build_idx = html.index("_buildClientIndex")
+    pkg_loop_idx = html.index("data.packages", build_idx)
+    assert "p.has_page" in html[pkg_loop_idx : pkg_loop_idx + 200], (
+        "_buildClientIndex must check p.has_page before indexing packages "
+        "to avoid search results pointing to non-existent detail pages"
+    )
+    # Same guard for plugins
+    plugin_loop_idx = html.index("data.plugins", build_idx)
+    assert (
+        "p.has_page" in html[plugin_loop_idx : plugin_loop_idx + 200]
+    ), "_buildClientIndex must check p.has_page before indexing plugins"
+
+
+def test_generate_json_has_page_field(workspace: Path):
+    """generate_json must emit has_page=true/false for packages and plugins.
+
+    has_page is true only when the item has a body (README), meaning a detail HTML page
+    was actually written. The client uses this to skip broken search result links.
+    """
+    import json as json_mod
+
+    data = collect_workspace_data(workspace)
+    json_str = generate_json(workspace, _data=data)
+    parsed = json_mod.loads(json_str)
+    for pkg in parsed.get("packages", []):
+        assert "has_page" in pkg, f"Package {pkg.get('name')} missing has_page field in data.json"
+        assert isinstance(
+            pkg["has_page"], bool
+        ), f"has_page must be a bool, got {type(pkg['has_page'])}"
+    for plugin in parsed.get("plugins", []):
+        assert (
+            "has_page" in plugin
+        ), f"Plugin {plugin.get('name')} missing has_page field in data.json"
+        assert isinstance(
+            plugin["has_page"], bool
+        ), f"has_page must be a bool, got {type(plugin['has_page'])}"


### PR DESCRIPTION
## Problem

On static gh-pages deployments (like gptme-contrib's public site), clicking the search button and typing returns **"Search error (404)"** — the search UI is always visible but `/api/search` only exists on live servers. This breaks search for the \"double as public site for gptme-contrib\" use case in gptme/gptme-contrib#382.

## Solution

Load `data.json` (already generated alongside `index.html`) for client-side search when the live API is unavailable.

**How it works:**
1. `initDynamic()` probes `/api/status` on page load — sets `_apiAvailable = true` on success, `false` on failure
2. On failure, `_loadStaticSearchIndex()` fetches `/data.json` and builds a flat in-memory index via `_buildClientIndex()`
3. `runSearch()` uses `_clientSearch()` (word-intersection scoring) when `_apiAvailable === false`, skipping the `/api/search` fetch entirely
4. `_renderResults()` is extracted as a shared helper used by both paths — no duplication

**Scoring**: same approach as the server — case-fold + strip punctuation, count word matches, rank by score. Good enough for a static index; the live API is still preferred when available.

**Zero extra dependencies**: `data.json` is always co-generated with `index.html` — no new build step needed.

## What changes

- `initDynamic()`: sets `_apiAvailable` flag and calls `_loadStaticSearchIndex()` on both `!resp.ok` and `catch` paths
- New functions: `_buildClientIndex`, `_clientSearch`, `_loadStaticSearchIndex`, `_renderResults`
- Live API path untouched — only activates when `_apiAvailable === false`

## Tests

3 new tests in `test_generate.py`:
- `test_static_search_js_present` — asserts all new functions/variables appear in generated HTML
- `test_static_search_initdynamic_sets_api_flag` — asserts failure path sets `_apiAvailable = false`
- `test_search_button_always_present` — asserts button is always rendered (static and live)

368 tests pass (3.10/3.11/3.12).

Addresses the static deployment use case in gptme/gptme-contrib#382.