### PR TITLE
feat(dashboard): show context_tier in sessions panel

### DIFF
--- a/packages/gptme-dashboard/src/gptme_dashboard/server.py
+++ b/packages/gptme-dashboard/src/gptme_dashboard/server.py
@@ -600,6 +600,7 @@ def create_app(
                         "timestamp": s.get("date", ""),
                         "harness": s.get("harness", ""),
                         "model": s.get("model", ""),
+                        "context_tier": s.get("context_tier"),
                         "category": s.get("category", ""),
                         "outcome": s.get("outcome")
                         or ("productive" if _is_productive(s) else "noop"),

--- a/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
+++ b/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
@@ -662,7 +662,7 @@ tr:hover { background: var(--accent-dim); }
   </div>
   <table id="dynamic-sessions-table">
     <thead>
-      <tr><th>Time</th><th>Harness</th><th>Model</th><th>Category</th><th>Outcome</th><th>Duration</th></tr>
+      <tr><th>Time</th><th>Harness</th><th>Model</th><th>Context</th><th>Category</th><th>Outcome</th><th>Duration</th></tr>
     </thead>
     <tbody></tbody>
   </table>
@@ -1297,6 +1297,7 @@ async function loadRecentSessions(offset) {
         + '<td>' + esc(time) + '</td>'
         + '<td>' + esc(s.harness || '') + '</td>'
         + '<td>' + esc(s.model || '') + '</td>'
+        + '<td>' + (s.context_tier ? '<span class="tag">' + esc(s.context_tier) + '</span>' : '') + '</td>'
         + '<td>' + esc(s.category || '') + '</td>'
         + '<td><span class="tag ' + cls + '">' + esc(s.outcome || '') + '</span></td>'
         + '<td>' + esc(dur) + '</td>'

--- a/packages/gptme-dashboard/tests/test_server.py
+++ b/packages/gptme-dashboard/tests/test_server.py
@@ -59,6 +59,7 @@ def workspace(tmp_path: Path) -> Path:
             "model": "claude-opus-4-6",
             "run_type": "autonomous",
             "category": "infrastructure",
+            "context_tier": "massive",
             "outcome": "productive",
             "duration_seconds": 900,
             "deliverables": ["commit:abc123"],
@@ -194,6 +195,18 @@ def test_api_sessions_list(client):
     # Most recent first
     assert data["sessions"][0]["session_id"] == "abc3"
     assert data["sessions"][0]["outcome"] == "productive"
+
+
+def test_api_sessions_includes_context_tier(client):
+    """Test /api/sessions includes context_tier field when present in session record."""
+    resp = client.get("/api/sessions")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    sessions_by_id = {s["session_id"]: s for s in data["sessions"]}
+    # abc3 has context_tier="massive" in fixture
+    assert sessions_by_id["abc3"].get("context_tier") == "massive"
+    # abc1 has no context_tier — field should be absent or None
+    assert sessions_by_id["abc1"].get("context_tier") is None
 
 
 def test_api_sessions_limit(client):


### PR DESCRIPTION
## Summary

`context_tier` (`standard` / `extended` / `large` / `massive`) is already stored in `SessionRecord` and returned by `SessionRecord.to_dict()`, but the sessions panel in the live dashboard didn't display it.

**Changes:**
- Adds a **Context** column to the dynamic sessions table — renders the tier as a compact tag badge when set, blank when absent
- Propagates `context_tier` through the fallback scan-path dict so the field is consistently present in both the `SessionStore` and `_get_scanned_sessions` paths
- New test `test_api_sessions_includes_context_tier` verifies the field passes through the API and is `None` when not set in the record

**Why it's useful:** context tier is a direct proxy for cost / context pressure per session. Surfacing it in the sessions table makes it easy to spot sessions that consumed large/massive context and correlate with grade/outcome.

## Test plan
- [x] `uv run pytest packages/gptme-dashboard/tests/ -q` → 366 passed
- [x] Pre-commit hooks pass

Contributes to #382