### PR TITLE
fix(tests): isolate git config writes from host repo in test_git_hooks

### DIFF
--- a/tests/integration/test_git_hooks.py
+++ b/tests/integration/test_git_hooks.py
@@ -31,16 +31,21 @@ HOOKS_DIR = (
 
 
 def _clean_git_env() -> dict:
-    """Return a copy of the environment with GIT_DIR and GIT_WORK_TREE stripped.
+    """Return a copy of the environment with all GIT_* variables stripped.
 
     When tests run inside an autonomous session, GIT_DIR may point at the host
     repo's .git directory.  Any ``git config`` call that inherits that env will
     write into the *host* repo instead of the freshly-initialised test repo,
     silently leaking test identity into production git config.
+
+    We strip *all* GIT_* variables (GIT_DIR, GIT_WORK_TREE, GIT_INDEX_FILE,
+    GIT_OBJECT_DIRECTORY, GIT_ALTERNATE_OBJECT_DIRECTORIES, …) for maximum
+    isolation — any inherited git-env var can cause subtle misdirection.
     """
     env = os.environ.copy()
-    env.pop("GIT_DIR", None)
-    env.pop("GIT_WORK_TREE", None)
+    for key in list(env):
+        if key.startswith("GIT_"):
+            del env[key]
     return env
 
 


### PR DESCRIPTION
## Summary

Fixes a security vulnerability in the `temp_repo` test fixture where `git config` calls could silently contaminate the host repository's git config when `GIT_DIR` is inherited from an autonomous session (same class of bug as ErikBjare/bob#414).

- Add `--local` flag to all `git config` calls in `temp_repo` fixture so writes are scoped to the temp repo even if `GIT_DIR` leaks from the outer environment
- Strip `GIT_DIR` and `GIT_WORK_TREE` from subprocess env via a new `_clean_git_env()` helper, applied to both `temp_repo` and `run_pre_push_hook`
- Set `core.hooksPath = /dev/null` in test repos to prevent host machine's global hooks from interfering with test commit operations
- Rename test identity to `Test Automation` / `test-automation@example.com` so any accidental leaks are immediately visible in `git log` output

## Test plan

- [x] All 9 existing tests pass (`uv run pytest tests/integration/test_git_hooks.py -v`)
- [x] No new tests needed — the fix is purely defensive hardening of the existing fixture