### PR TITLE
fix(status): handle systemctl marker prefix in status-systemd.sh

### DIFF
--- a/scripts/status/util/status-systemd.sh
+++ b/scripts/status/util/status-systemd.sh
@@ -66,9 +66,10 @@ done < <(systemctl --user show "${AGENT_NAME}-*.service" --property=Id,ExecMainS
 while IFS= read -r line; do
     [[ -z "$line" ]] && continue
 
-    # Parse service name and state (column 3 is ACTIVE state)
-    service_name=$(echo "$line" | awk '{print $1}')
-    state=$(echo "$line" | awk '{print $3}')
+    # Parse service name and state
+    # Strip optional status marker prefix (●, *, ○) from systemctl output
+    service_name=$(echo "$line" | awk '{if ($1 ~ /^[*●○]/) print $2; else print $1}')
+    state=$(echo "$line" | awk '{if ($1 ~ /^[*●○]/) print $4; else print $3}')
 
     # Skip if not our agent's service
     [[ ! "$service_name" =~ ^${AGENT_NAME}- ]] && continue


### PR DESCRIPTION
## Summary
- Fix `status-systemd.sh` parsing of `systemctl --user list-units` output when services have a status marker prefix (`●`, `*`, `○`)
- `awk '{print $1}'` returned the marker character instead of the service name, causing incorrect display
- Same bug was already fixed in Bob's `schedule-status.py`, `status.sh`, `health-lib.sh`, and `self-heal.py` — this is the last remaining instance

## Test plan
- [x] Verified fix with marker prefix input: `● bob-gcal-sync.service` → correctly extracts `bob-gcal-sync.service`
- [x] Verified fix without marker: `  bob-autonomous.service` → still works correctly
- [x] State column (`$3` vs `$4`) also adjusted for marker offset