### PR TITLE
fix(activity-summary): fix Model Usage table inaccuracies, add steps column

### DIFF
--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_session_data.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_session_data.py
@@ -20,11 +20,12 @@ logger = logging.getLogger(__name__)
 def _extract_cc_metadata(msgs: list[dict]) -> dict:
     """Extract CC-specific metadata not covered by gptme-sessions.
 
-    Returns workspace, interactive flag, message count, and duration.
+    Returns workspace, interactive flag, message count, steps, and duration.
     """
     workspace = ""
     is_bypass = False
     message_count = 0
+    assistant_turns = 0
     first_ts: datetime | None = None
     last_ts: datetime | None = None
 
@@ -51,8 +52,11 @@ def _extract_cc_metadata(msgs: list[dict]) -> dict:
             is_bypass = True
 
         # Count user + assistant messages
-        if entry.get("type") in ("assistant", "user"):
+        entry_type = entry.get("type")
+        if entry_type in ("assistant", "user"):
             message_count += 1
+        if entry_type == "assistant":
+            assistant_turns += 1
 
     duration = 0.0
     if first_ts and last_ts:
@@ -62,6 +66,7 @@ def _extract_cc_metadata(msgs: list[dict]) -> dict:
         "workspace": workspace,
         "interactive": not is_bypass,
         "message_count": message_count,
+        "steps": assistant_turns,
         "duration_seconds": duration,
     }
 
@@ -87,13 +92,25 @@ def fetch_cc_session_stats_range(
         # CC-specific metadata
         meta = _extract_cc_metadata(msgs)
 
+        # Skip empty sessions (no assistant response — just initialization artifacts)
+        if meta["steps"] == 0:
+            continue
+
+        # Include cache tokens on input side for accurate totals
+        input_tokens = (
+            usage.get("input_tokens", 0)
+            + usage.get("cache_read_tokens", 0)
+            + usage.get("cache_creation_tokens", 0)
+        )
+
         info = SessionInfo(
             name=jsonl_file.stem,
             harness="claude-code",
             model=usage.get("model") or "",
             workspace=meta["workspace"],
             message_count=meta["message_count"],
-            input_tokens=usage.get("input_tokens", 0),
+            steps=meta["steps"],
+            input_tokens=input_tokens,
             output_tokens=usage.get("output_tokens", 0),
             cost=0.0,  # Subscription model, no per-token cost
             duration_seconds=meta["duration_seconds"],

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cli.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cli.py
@@ -82,6 +82,7 @@ def _build_model_breakdown(session_stats):  # type: ignore[no-untyped-def]
             model=mb.model,
             harness=mb.harness,
             sessions=mb.sessions,
+            steps=mb.steps,
             tokens=mb.total_tokens,
             cost=mb.cost,
         )

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/schemas.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/schemas.py
@@ -64,6 +64,7 @@ class ModelUsage:
     model: str
     harness: str = ""  # "gptme", "claude-code", etc.
     sessions: int = 0
+    steps: int = 0  # agent turns (each = one LLM invocation, 0+ tool calls)
     tokens: int = 0
     cost: float = 0.0
 
@@ -140,43 +141,57 @@ def _format_model_table(metrics: "Metrics") -> list[str]:
     # Check if we have multiple harnesses (show harness column if so)
     harnesses = {m.harness for m in metrics.model_breakdown if m.harness}
     show_harness = len(harnesses) > 1
+    # Only show steps column if any model has steps data
+    has_steps = any(m.steps > 0 for m in metrics.model_breakdown)
 
+    # Build header
+    cols = []
     if show_harness:
-        lines = [
-            "## Model Usage",
-            "",
-            "| Harness | Model | Sessions | Tokens | Cost |",
-            "|---------|-------|----------|--------|------|",
-        ]
-        for m in metrics.model_breakdown:
-            cost_str = f"${m.cost:.2f}" if m.cost > 0 else "-"
-            tokens_str = _fmt_tokens(m.tokens) if m.tokens > 0 else "-"
-            harness_str = m.harness or "-"
-            lines.append(
-                f"| {harness_str} | {m.model} | {m.sessions} | {tokens_str} | {cost_str} |"
-            )
-    else:
-        lines = [
-            "## Model Usage",
-            "",
-            "| Model | Sessions | Tokens | Cost |",
-            "|-------|----------|--------|------|",
-        ]
-        for m in metrics.model_breakdown:
-            cost_str = f"${m.cost:.2f}" if m.cost > 0 else "-"
-            tokens_str = _fmt_tokens(m.tokens) if m.tokens > 0 else "-"
-            lines.append(f"| {m.model} | {m.sessions} | {tokens_str} | {cost_str} |")
+        cols.append("Harness")
+    cols.append("Model")
+    cols.append("Sessions")
+    if has_steps:
+        cols.append("Steps")
+    cols.append("Tokens")
+    cols.append("Cost")
+
+    header = "| " + " | ".join(cols) + " |"
+    sep = "|" + "|".join("-" * (len(c) + 2) for c in cols) + "|"
+    lines = ["## Model Usage", "", header, sep]
+
+    for m in metrics.model_breakdown:
+        cost_str = f"${m.cost:.2f}" if m.cost > 0 else "-"
+        tokens_str = _fmt_tokens(m.tokens) if m.tokens > 0 else "-"
+        steps_str = f"{m.steps:,}" if m.steps > 0 else "-"
+        row = []
+        if show_harness:
+            row.append(m.harness or "-")
+        row.append(m.model)
+        row.append(str(m.sessions))
+        if has_steps:
+            row.append(steps_str)
+        row.append(tokens_str)
+        row.append(cost_str)
+        lines.append("| " + " | ".join(row) + " |")
 
     # Total row
     total_sessions = sum(m.sessions for m in metrics.model_breakdown)
+    total_steps = sum(m.steps for m in metrics.model_breakdown)
     total_tokens = sum(m.tokens for m in metrics.model_breakdown)
     total_cost = sum(m.cost for m in metrics.model_breakdown)
-    cost_str = f"${total_cost:.2f}" if total_cost > 0 else "-"
-    tokens_str = _fmt_tokens(total_tokens) if total_tokens > 0 else "-"
+    cost_str = f"**${total_cost:.2f}**" if total_cost > 0 else "-"
+    tokens_str = f"**{_fmt_tokens(total_tokens)}**" if total_tokens > 0 else "-"
+    steps_str = f"**{total_steps:,}**" if total_steps > 0 else "-"
+    row = []
     if show_harness:
-        lines.append(f"| | **Total** | **{total_sessions}** | **{tokens_str}** | **{cost_str}** |")
-    else:
-        lines.append(f"| **Total** | **{total_sessions}** | **{tokens_str}** | **{cost_str}** |")
+        row.append("")
+    row.append("**Total**")
+    row.append(f"**{total_sessions}**")
+    if has_steps:
+        row.append(steps_str)
+    row.append(tokens_str)
+    row.append(cost_str)
+    lines.append("| " + " | ".join(row) + " |")
     lines.append("")
     return lines
 

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/session_data.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/session_data.py
@@ -6,6 +6,7 @@ keeping only aggregation types and formatting here.
 """
 
 import logging
+import re
 from dataclasses import dataclass, field
 from datetime import date, datetime
 from pathlib import Path
@@ -25,6 +26,7 @@ class SessionInfo:
     harness: str = ""  # "gptme", "claude-code", "codex", etc.
     workspace: str = ""
     message_count: int = 0
+    steps: int = 0  # assistant turns (each = one LLM invocation, 0+ tool calls)
     input_tokens: int = 0
     output_tokens: int = 0
     cost: float = 0.0
@@ -39,6 +41,7 @@ class ModelBreakdown:
     model: str
     harness: str = ""
     sessions: int = 0
+    steps: int = 0
     input_tokens: int = 0
     output_tokens: int = 0
     cost: float = 0.0
@@ -107,6 +110,7 @@ def _aggregate_session(stats: SessionStats, info: SessionInfo) -> None:
             stats._model_data[key] = ModelBreakdown(model=info.model, harness=info.harness)
         mb = stats._model_data[key]
         mb.sessions += 1
+        mb.steps += info.steps
         mb.input_tokens += info.input_tokens
         mb.output_tokens += info.output_tokens
         mb.cost += info.cost
@@ -115,6 +119,38 @@ def _aggregate_session(stats: SessionStats, info: SessionInfo) -> None:
     stats.total_output_tokens += info.output_tokens
     stats.total_cost += info.cost
     stats.total_duration_seconds += info.duration_seconds
+
+
+def _extract_model_from_eval_dirname(dirname: str) -> str:
+    """Extract model string from gptme eval session dirname.
+
+    E.g. '2026-03-17-gptme-evals-anthropic--claude-haiku-4-5-markdown-1a97c271'
+    → 'anthropic/claude-haiku-4-5'
+
+    The dirname pattern is: DATE-gptme-evals-PROVIDER--MODEL-FORMAT-HASH
+    where '--' separates provider/model segments and FORMAT is one of
+    markdown/tool/xml.
+    """
+    # Strip date prefix
+    name = re.sub(r"^\d{4}-\d{2}-\d{2}-", "", dirname)
+    if not name.startswith("gptme-evals-"):
+        return ""
+    name = name[len("gptme-evals-") :]
+
+    # Strip trailing hash (8 hex chars)
+    name = re.sub(r"-[a-f0-9]{8}$", "", name)
+
+    # Strip format suffix (known formats)
+    for fmt in ("markdown", "tool", "xml"):
+        if name.endswith(f"-{fmt}"):
+            name = name[: -len(fmt) - 1]
+            break
+
+    # Split on '--' to get provider/model segments, rejoin with '/'
+    parts = name.split("--")
+    if len(parts) >= 2:
+        return "/".join(parts)
+    return name
 
 
 def fetch_session_stats(
@@ -153,6 +189,9 @@ def fetch_session_stats_range(
             info.message_count = len(msgs)
             info.duration_seconds = _extract_duration(msgs)
 
+            # Count assistant turns as steps (each = one LLM invocation)
+            info.steps = sum(1 for m in msgs if m.get("role") == "assistant")
+
             # Token usage via gptme-sessions
             usage = extract_usage_gptme(msgs)
             if usage:
@@ -160,6 +199,10 @@ def fetch_session_stats_range(
                 info.input_tokens = usage["input_tokens"]
                 info.output_tokens = usage["output_tokens"]
                 info.cost = usage["cost"]
+
+        # Fallback: extract model from eval dirname
+        if not info.model and "evals" in session_dir.name:
+            info.model = _extract_model_from_eval_dirname(session_dir.name)
 
         _aggregate_session(stats, info)
 
@@ -196,6 +239,7 @@ def merge_session_stats(a: SessionStats, b: SessionStats) -> SessionStats:
                 merged._model_data[key] = ModelBreakdown(model=mb.model, harness=mb.harness)
             dest = merged._model_data[key]
             dest.sessions += mb.sessions
+            dest.steps += mb.steps
             dest.input_tokens += mb.input_tokens
             dest.output_tokens += mb.output_tokens
             dest.cost += mb.cost

--- a/packages/gptme-activity-summary/tests/test_cc_session_data.py
+++ b/packages/gptme-activity-summary/tests/test_cc_session_data.py
@@ -72,6 +72,7 @@ def test_extract_cc_metadata_basic():
     assert meta["workspace"] == "/home/bob/bob"
     assert meta["interactive"] is False  # bypassPermissions
     assert meta["message_count"] == 4  # 2 user + 2 assistant
+    assert meta["steps"] == 2  # 2 assistant turns = 2 steps
     assert meta["duration_seconds"] == 180.0  # 3 minutes
 
 
@@ -83,6 +84,26 @@ def test_extract_cc_metadata_interactive():
     ]
     meta = _extract_cc_metadata(msgs)
     assert meta["interactive"] is True
+    assert meta["steps"] == 1
+
+
+def test_empty_session_filtered(tmp_path):
+    """Test that sessions with no assistant turns are filtered out."""
+    empty_msgs = [
+        {"type": "system", "content": "init", "cwd": "/home/bob"},
+        {"type": "system", "content": "config"},
+        _make_user_msg("2026-02-17T10:00:00Z"),
+    ]
+    real_msgs = [
+        _make_user_msg("2026-02-17T10:00:00Z"),
+        _make_assistant_msg("2026-02-17T10:05:00Z", input_tokens=100, output_tokens=50),
+    ]
+    _make_session_jsonl(tmp_path, "-home-bob-bob", "empty-sess", empty_msgs)
+    _make_session_jsonl(tmp_path, "-home-bob-bob", "real-sess", real_msgs)
+
+    stats = fetch_cc_session_stats_range(date(2026, 2, 17), date(2026, 2, 17), cc_dir=tmp_path)
+    assert stats.session_count == 1  # only the real session
+    assert stats.total_input_tokens == 100
 
 
 def test_fetch_cc_session_stats_range(tmp_path):

--- a/packages/gptme-activity-summary/tests/test_session_data.py
+++ b/packages/gptme-activity-summary/tests/test_session_data.py
@@ -9,6 +9,7 @@ from gptme_activity_summary.session_data import (
     SessionInfo,
     SessionStats,
     _extract_duration,
+    _extract_model_from_eval_dirname,
     fetch_session_stats,
     fetch_session_stats_range,
     format_sessions_for_prompt,
@@ -181,6 +182,53 @@ def test_merge_session_stats():
     assert breakdown["opus"].sessions == 3
     assert breakdown["opus"].input_tokens == 1300
     assert breakdown["sonnet"].sessions == 1
+
+
+def test_extract_model_from_eval_dirname():
+    """Test model extraction from gptme eval session dirnames."""
+    assert (
+        _extract_model_from_eval_dirname(
+            "2026-03-17-gptme-evals-anthropic--claude-haiku-4-5-markdown-1a97c271"
+        )
+        == "anthropic/claude-haiku-4-5"
+    )
+    assert (
+        _extract_model_from_eval_dirname(
+            "2026-03-17-gptme-evals-openrouter--google--gemini-2.0-flash-001-tool-abcd1234"
+        )
+        == "openrouter/google/gemini-2.0-flash-001"
+    )
+    assert (
+        _extract_model_from_eval_dirname(
+            "2026-03-17-gptme-evals-openai-subscription--gpt-5.4-xml-deadbeef"
+        )
+        == "openai-subscription/gpt-5.4"
+    )
+    # Non-eval dirnames should return empty
+    assert _extract_model_from_eval_dirname("2026-03-17-climbing-crazy-jellyfish") == ""
+
+
+def test_merge_session_stats_steps():
+    """Test that merge_session_stats merges steps correctly."""
+    a = SessionStats(
+        start_date=date(2025, 1, 1),
+        end_date=date(2025, 1, 1),
+        session_count=1,
+        sessions=[SessionInfo(name="s1", model="opus", steps=10)],
+    )
+    a._model_data["opus"] = ModelBreakdown(model="opus", sessions=1, steps=10)
+
+    b = SessionStats(
+        start_date=date(2025, 1, 2),
+        end_date=date(2025, 1, 2),
+        session_count=1,
+        sessions=[SessionInfo(name="s2", model="opus", steps=5)],
+    )
+    b._model_data["opus"] = ModelBreakdown(model="opus", sessions=1, steps=5)
+
+    merged = merge_session_stats(a, b)
+    breakdown = {mb.model: mb for mb in merged.model_breakdown}
+    assert breakdown["opus"].steps == 15
 
 
 def test_format_sessions_header():


### PR DESCRIPTION
## Summary

- **Session count mismatch fixed**: 91 empty CC sessions (init artifacts with 0 assistant turns) now filtered out; 138 gptme eval sessions now attributed via dirname model extraction (e.g. `gptme-evals-anthropic--claude-haiku-4-5-markdown-*` → `anthropic/claude-haiku-4-5`). Gap between header count and table total: 229 → 0.
- **Token counts fixed**: CC sessions were only counting `input_tokens + output_tokens` (2.9M), missing `cache_read_tokens` (1.17B) and `cache_creation_tokens` (88M). Now includes all token types for accurate totals (1.26B).
- **Steps column added**: Shows agent turns (LLM invocations) per model in the table. Auto-hides when no data.

Before: `954 sessions, 725 in table (229 gap), 4.9M tokens, no steps`
After: `863 sessions, 863 in table (0 gap), 1.26B tokens, 14,938 steps`

## Test plan
- [x] All 66 existing + new tests pass
- [x] Verified against real 2026-03-17 data
- [x] Table renders correctly for single-harness and multi-harness cases
- [x] Steps column auto-hides when no steps data