### PR TITLE
perf(activity-gate): deduplicate gh pr list calls (3N to N)

### DIFF
--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -159,11 +159,18 @@ discover_repos() {
 
     if [ -f "$cache_file" ]; then
         local cache_age
-        cache_age=$(( $(date +%s) - $(stat -c %Y "$cache_file" 2>/dev/null || stat -f %m "$cache_file" 2>/dev/null || echo 0) ))
-        if [ "$cache_age" -lt "$cache_max_age" ]; then
-            cat "$cache_file"
-            for r in "${EXTRA_REPOS[@]}"; do echo "$r"; done
-            return
+        local mtime
+        mtime=$(stat -c %Y "$cache_file" 2>/dev/null || stat -f %m "$cache_file" 2>/dev/null || echo "")
+        if [ -z "$mtime" ]; then
+            echo "WARN: stat failed on cache file, skipping cache" >&2
+            rm -f "$cache_file"
+        else
+            cache_age=$(( $(date +%s) - mtime ))
+            if [ "$cache_age" -lt "$cache_max_age" ]; then
+                cat "$cache_file"
+                for r in "${EXTRA_REPOS[@]}"; do echo "$r"; done
+                return
+            fi
         fi
     fi
 
@@ -451,7 +458,8 @@ check_notifications() {
 
 # --- Main ---
 
-all_repos=$(discover_repos)
+# Deduplicate repos (EXTRA_REPOS may overlap with org repos)
+all_repos=$(discover_repos | sort -u)
 all_items=""
 
 for repo in $all_repos; do


### PR DESCRIPTION
## Summary

- Merge 3 separate `gh pr list` calls per repo into a single `fetch_pr_data()` call that fetches all needed JSON fields, then passes the data to `check_pr_updates`, `check_ci_failures`, and `check_merge_conflicts`
- Cache `discover_repos()` output for 1 hour via mtime-checked temp file (org membership rarely changes)
- With 17 repos at 10-minute intervals, this saves ~204 API calls/hour (~34 calls/run reduced to ~17)

## Details

Previously each check function called `gh pr list` independently with its own subset of `--json` fields:

| Function | Fields |
|----------|--------|
| `check_pr_updates` | `number,title,updatedAt,comments,latestReviews` |
| `check_ci_failures` | `number,title,statusCheckRollup` |
| `check_merge_conflicts` | `number,title,mergeable,mergeStateStatus` |

Now `fetch_pr_data()` requests the union of all fields once, and each function receives the pre-fetched JSON as its second argument. No behavioral changes -- same filtering, same state tracking, same output.

Other API calls (`gh issue list`, `gh run list`, `gh api notifications`) are unrelated endpoints and remain unchanged.

## Test plan

- [ ] `bash -n scripts/github/activity-gate.sh` passes (verified)
- [ ] `shellcheck` clean (verified)
- [ ] Manual run with `--format jsonl` produces same output shape
- [ ] Manual run with `--format markdown` produces same output shape
- [ ] State files still created/updated correctly in STATE_DIR
- [ ] Repo list cache file created in STATE_DIR, reused on subsequent runs within 1 hour