### PR TITLE
feat(activity-gate): add Greptile score sweep for stale low-scored PRs

### DIFF
--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -457,13 +457,16 @@ check_greptile_scores() {
         # Uses --paginate to handle PRs with >30 comments (default page size).
         # Greptile's bot username contains "greptile" (case-insensitive).
         # Look for "Score: N/5" pattern, anchored to avoid matching prose/flowcharts.
-        # The jq `capture` returns null when no match — we filter that explicitly.
+        #
+        # Note: --paginate with --jq applies the filter per-page, so if multiple
+        # pages each contain Greptile comments, we'd get multiple lines of output.
+        # We take only the last line (tail -1) to get the most recent score.
         local greptile_score
         greptile_score=$(gh api "repos/${repo}/issues/${pr_number}/comments" \
             --paginate --jq '
                 [.[] | select(.user.login | test("greptile"; "i"))] | last |
                 .body // "" | capture("Score: (?<n>[0-9])/5") | .n // empty
-            ' 2>/dev/null || true)
+            ' 2>/dev/null | tail -1 || true)
 
         # No Greptile review or no score found — skip
         # Guard against both empty string and literal "null" from jq


### PR DESCRIPTION
## Summary

- Adds `check_greptile_scores()` to `activity-gate.sh` that sweeps open PRs for low Greptile review scores
- Greptile updates review comments in-place (doesn't bump `updatedAt`), so PRs with low scores sit indefinitely — this sweep catches them
- Emits `greptile_needs_fix` (score < 4) or `greptile_needs_improvement` (score = 4) work items

## How it works

1. For each open PR (using data already fetched by `fetch_pr_data()`), fetches issue comments via REST API
2. Finds the last Greptile comment and extracts the score from "Score: N/5" pattern
3. State-tracks per PR (`score:timestamp:head_sha`) to avoid spam:
   - Only emits on first sighting or when new commits are pushed (fix attempt)
   - 4-hour cooldown prevents redundant emissions
   - Score 5 or no review = skip

## API cost

- 1 REST call per open PR (issue comments endpoint)
- HEAD SHA reuses `headRefOid` from `fetch_pr_data()` — no extra call needed
- Added `headRefOid` to the shared `fetch_pr_data()` fields

## Test plan

- [ ] `bash -n` and `shellcheck` pass (verified locally)
- [ ] Run against repos with Greptile reviews to verify score parsing
- [ ] Verify state files are created/updated correctly
- [ ] Verify cooldown prevents re-emission within 4 hours
- [ ] Verify new commits (changed HEAD SHA) trigger re-emission