### PR TITLE
fix(greptile-helper): address remaining review findings

### DIFF
--- a/scripts/github/greptile-helper.sh
+++ b/scripts/github/greptile-helper.sh
@@ -41,6 +41,9 @@ if [ -z "$GITHUB_AUTHOR" ]; then
 fi
 
 _json_field() {
+    # Reset EXIT trap — this runs in a subshell (right side of pipe) that
+    # inherits the parent's trap, which would delete the cache file.
+    trap - EXIT
     local field="$1"
     python3 -c "import json, sys; data = json.load(sys.stdin); v = data.get('$field'); print(v if v is not None else '')" 2>/dev/null
 }
@@ -222,7 +225,7 @@ check)
     "none")
         # No trigger comment exists. Check if the PR is new enough that
         # Greptile's auto-review might still arrive.
-        pr_created_at=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.created_at' | tr -d '"' 2>/dev/null) || pr_created_at=""
+        pr_created_at=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.created_at' 2>/dev/null) || pr_created_at=""
         if [ -n "$pr_created_at" ]; then
             pr_age=$(_age_seconds "$pr_created_at" 2>/dev/null) || pr_age=99999
             if [ "$pr_age" -lt "$INITIAL_REVIEW_GRACE" ]; then
@@ -235,6 +238,10 @@ check)
         exit 0  # Had a trigger but it's stale — safe to re-trigger
         ;;
     "in-progress")
+        exit 1
+        ;;
+    *)
+        echo "Error: unexpected trigger_status='$trigger_status'" >&2
         exit 1
         ;;
     esac
@@ -283,7 +290,7 @@ trigger)
         ;;
     "none")
         # Fresh PR grace: wait for Greptile auto-review before manually triggering
-        pr_created_at=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.created_at' | tr -d '"' 2>/dev/null) || pr_created_at=""
+        pr_created_at=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.created_at' 2>/dev/null) || pr_created_at=""
         if [ -n "$pr_created_at" ]; then
             pr_age=$(_age_seconds "$pr_created_at" 2>/dev/null) || pr_age=99999
             if [ "$pr_age" -lt "${INITIAL_REVIEW_GRACE:-1200}" ]; then
@@ -302,6 +309,10 @@ trigger)
             && echo "  [greptile] Triggered successfully." \
             || echo "  [greptile] Trigger failed (non-fatal)."
         ;;
+    *)
+        echo "  [greptile] Error: unexpected trigger_status='$trigger_status'" >&2
+        exit 1
+        ;;
     esac
     ;;
 
@@ -316,7 +327,7 @@ status)
         _ts=$(_our_trigger_status || echo 'error')
         if [ "$_ts" = "none" ]; then
             # Check if PR is fresh enough for auto-review
-            pr_created_at=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.created_at' | tr -d '"' 2>/dev/null) || pr_created_at=""
+            pr_created_at=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.created_at' 2>/dev/null) || pr_created_at=""
             if [ -n "$pr_created_at" ]; then
                 pr_age=$(_age_seconds "$pr_created_at" 2>/dev/null) || pr_age=99999
                 if [ "$pr_age" -lt "${INITIAL_REVIEW_GRACE:-1200}" ]; then

--- a/tests/test_greptile_helper.py
+++ b/tests/test_greptile_helper.py
@@ -77,7 +77,8 @@ else:
 
 raw = json.dumps(data)
 if jq_expr:
-    r = sp.run(["jq", jq_expr], input=raw, capture_output=True, text=True)
+    # Use jq -r to match gh --jq behavior (outputs raw strings, not quoted)
+    r = sp.run(["jq", "-r", jq_expr], input=raw, capture_output=True, text=True)
     print(r.stdout.strip())
 else:
     print(raw)
@@ -126,8 +127,8 @@ def _run_helper(
     command: str,
     fixture: dict[str, object],
     *,
-    capture_gh_log: Literal[True],
-) -> tuple[subprocess.CompletedProcess[str], str]: ...
+    capture_gh_log: Literal[False] = ...,
+) -> subprocess.CompletedProcess[str]: ...
 
 
 @overload
@@ -135,8 +136,8 @@ def _run_helper(
     command: str,
     fixture: dict[str, object],
     *,
-    capture_gh_log: Literal[False] = ...,
-) -> subprocess.CompletedProcess[str]: ...
+    capture_gh_log: Literal[True],
+) -> tuple[subprocess.CompletedProcess[str], str]: ...
 
 
 def _run_helper(
@@ -316,3 +317,28 @@ def test_trigger_skips_fresh_pr():
     result = _run_helper("trigger", fixture)
     assert result.returncode == 0, f"stderr: {result.stderr}"
     assert "Waiting for auto-review" in result.stdout
+
+
+def test_trigger_re_reviews_on_low_score_with_new_commits():
+    """Trigger on PR with score 4/5 + new commits → posts re-review comment."""
+    reviewed_at = _iso_ago(minutes=30)
+    fixture = {
+        "pr_number": 777,
+        "raw_comments": [
+            _make_greptile_comment(
+                4, reviewed_at=_iso_ago(minutes=60), updated_at=reviewed_at
+            ),
+            # Old trigger from previous cycle (before review)
+            _make_trigger_comment("test-user", _iso_ago(minutes=45)),
+        ],
+        "raw_commits": [
+            _make_commit(_iso_ago(minutes=10)),  # New commit after review
+        ],
+        "raw_pr": {"created_at": _iso_ago(minutes=120)},
+        "bot_reaction_count": 1,
+    }
+    result, gh_log = _run_helper("trigger", fixture, capture_gh_log=True)
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert "Re-triggered successfully" in result.stdout
+    assert gh_log, "gh pr comment was never called"
+    assert "@greptileai review" in gh_log


### PR DESCRIPTION
## Summary

Follow-up to PR #489 (now merged), addressing remaining Greptile review findings on `scripts/github/greptile-helper.sh`:

- **Remove dead code**: 3 occurrences of `| tr -d '"'` after `gh api --jq` were no-ops since `--jq` already outputs unquoted strings
- **Add fail-safe defaults**: Inner `case "$trigger_status"` blocks in `check` and `trigger` commands now have `*) exit 1 ;;` default arms, preventing silent fall-through on unexpected values
- **Fix pipe trap inheritance**: `_json_field()` now resets the EXIT trap to prevent pipe subshells from deleting the review cache file
- **Fix test stub fidelity**: Fake `gh` stub now uses `jq -r` to match real `gh --jq` raw string output behavior
- **Add re-review trigger test**: Verifies that `trigger` on a PR with score 4/5 + new commits posts a `@greptileai review` comment
- **Fix mypy**: Add `@overload` signatures for `_run_helper` to resolve union-attr errors

## Test plan

- [x] `bash -n` syntax check passes
- [x] All 9 tests pass (`uv run pytest tests/test_greptile_helper.py -v`)
- [x] mypy clean
- [x] ruff format clean
- [x] Pre-commit hooks pass