### PR TITLE
fix(tests): add overloads to _run_helper for precise mypy return types

### DIFF
--- a/tests/test_greptile_helper.py
+++ b/tests/test_greptile_helper.py
@@ -14,6 +14,7 @@ import subprocess
 import tempfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import Literal, overload
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SCRIPT = REPO_ROOT / "scripts" / "github" / "greptile-helper.sh"
@@ -118,6 +119,24 @@ def _make_commit(date: str) -> dict:
             "message": "test commit",
         },
     }
+
+
+@overload
+def _run_helper(
+    command: str,
+    fixture: dict[str, object],
+    *,
+    capture_gh_log: Literal[True],
+) -> tuple[subprocess.CompletedProcess[str], str]: ...
+
+
+@overload
+def _run_helper(
+    command: str,
+    fixture: dict[str, object],
+    *,
+    capture_gh_log: Literal[False] = ...,
+) -> subprocess.CompletedProcess[str]: ...
 
 
 def _run_helper(


### PR DESCRIPTION
## Summary

- Adds `@overload` declarations to `_run_helper` in `tests/test_greptile_helper.py` so mypy can narrow the return type based on the `capture_gh_log` literal parameter
- When `capture_gh_log=True`: returns `tuple[CompletedProcess[str], str]`
- When `capture_gh_log=False` (default): returns `CompletedProcess[str]`
- Fixes 22 mypy `union-attr` errors that were breaking the `Pre-commit Checks` CI job on master

## Test plan
- [ ] CI pre-commit / mypy passes