### PR TITLE
fix(tests): add @overload signatures to _run_helper for mypy type narrowing

### DIFF
--- a/packages/gptme-dashboard/src/gptme_dashboard/generate.py
+++ b/packages/gptme-dashboard/src/gptme_dashboard/generate.py
@@ -624,7 +624,7 @@ def scan_tasks(workspace: Path) -> list[dict]:
 
     _gptodo_load_tasks = None
     try:
-        from gptodo.utils import load_tasks as _gptodo_load_tasks  # type: ignore[assignment]
+        from gptodo.utils import load_tasks as _gptodo_load_tasks  # type: ignore[assignment,no-redef]
     except ImportError:
         pass
 

--- a/tests/test_greptile_helper.py
+++ b/tests/test_greptile_helper.py
@@ -14,6 +14,7 @@ import subprocess
 import tempfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import Literal, overload
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SCRIPT = REPO_ROOT / "scripts" / "github" / "greptile-helper.sh"
@@ -118,6 +119,24 @@ def _make_commit(date: str) -> dict:
             "message": "test commit",
         },
     }
+
+
+@overload
+def _run_helper(
+    command: str,
+    fixture: dict[str, object],
+    *,
+    capture_gh_log: Literal[True],
+) -> tuple[subprocess.CompletedProcess[str], str]: ...
+
+
+@overload
+def _run_helper(
+    command: str,
+    fixture: dict[str, object],
+    *,
+    capture_gh_log: Literal[False] = ...,
+) -> subprocess.CompletedProcess[str]: ...
 
 
 def _run_helper(


### PR DESCRIPTION
## Summary

Fixes the master CI failure (mypy errors in `tests/test_greptile_helper.py`).

The `_run_helper` function returns different types depending on `capture_gh_log`:
- `capture_gh_log=False` → `CompletedProcess[str]`
- `capture_gh_log=True` → `tuple[CompletedProcess[str], str]`

Without `@overload`, mypy sees the return type as a union and can't narrow it at call sites, producing 22 `union-attr` errors when callers access `.returncode`, `.stderr`, `.stdout`.

**Fix**: Add `@overload` signatures using `Literal[True]`/`Literal[False]` so mypy knows the exact return type at each call site.

Also fixes a `no-redef` error in `gptme-dashboard/generate.py` surfaced by mypy 13.0 (updates `type: ignore[assignment]` → `type: ignore[assignment,no-redef]`).

## Changes

- `tests/test_greptile_helper.py`: Add `@overload` stubs with `Literal[True/False]` for `_run_helper`
- `packages/gptme-dashboard/src/gptme_dashboard/generate.py`: Extend `type: ignore` to cover `no-redef`

## Validation

- `uvx mypy tests/test_greptile_helper.py --ignore-missing-imports` → `Success: no issues found`
- Local pre-commit (all hooks) passes cleanly