### PR TITLE
fix(greptile): never trigger initial reviews, only re-reviews

### DIFF
--- a/scripts/github/greptile-helper.sh
+++ b/scripts/github/greptile-helper.sh
@@ -5,17 +5,21 @@
 #   greptile-helper.sh check <repo> <pr_number>   # Check status, exit 0=ok-to-trigger 1=skip
 #   greptile-helper.sh trigger <repo> <pr_number> # Trigger once if safe, else skip
 #   greptile-helper.sh status <repo> <pr_number>  # Print status string:
-#     already-reviewed | needs-re-review | in-progress | none | stale | awaiting-initial-review | error
+#     already-reviewed | needs-re-review | in-progress | awaiting-initial-review | stale | error
 #
 # Exit codes for 'check':
-#   0 = safe to trigger (no review yet, or re-review needed: not 5/5 + new commits)
-#   1 = skip: trigger in-flight (our comment has Greptile bot ack, or comment < 15min old)
+#   0 = safe to trigger (re-review needed: score < 5/5 + new commits)
+#   1 = skip: no review yet (awaiting Greptile auto-review), or re-review trigger in-flight
 #   2 = skip: reviewed by greptile-apps[bot], score=5/5 or no new commits since review
 #   3 = api error (fail-safe = skip)
 #
 # Erik's requests (ErikBjare/bob#434):
 #   1. Reduce 30min age guard → 15min (reviews complete in 5-15min)
 #   2. Re-request after addressing feedback: if score < 5/5 AND new commits → trigger
+#
+# Initial review policy: Greptile automatically reviews all new PRs. We NEVER manually
+# trigger initial reviews. Only re-reviews (score < 5/5 + new commits) are triggered.
+# Status 'awaiting-initial-review' is returned for ALL unreviewed PRs regardless of age.
 #
 # Root cause of spam incidents:
 #   Multiple concurrent sessions each check "any trigger comments?" → all see 0
@@ -216,35 +220,8 @@ check)
         fi
         exit 2  # Reviewed and 5/5 (or no new commits)
     fi
-
-    # Fresh PR grace period: Greptile auto-reviews new PRs within ~5-20 min.
-    # Don't trigger manually until the auto-review window has passed.
-    INITIAL_REVIEW_GRACE="${INITIAL_REVIEW_GRACE:-1200}"  # 20 min default
-    trigger_status=$(_our_trigger_status || echo "in-progress")
-    case "$trigger_status" in
-    "none")
-        # No trigger comment exists. Check if the PR is new enough that
-        # Greptile's auto-review might still arrive.
-        pr_created_at=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.created_at' 2>/dev/null) || pr_created_at=""
-        if [ -n "$pr_created_at" ]; then
-            pr_age=$(_age_seconds "$pr_created_at" 2>/dev/null) || pr_age=99999
-            if [ "$pr_age" -lt "$INITIAL_REVIEW_GRACE" ]; then
-                exit 1  # Fresh PR — wait for auto-review
-            fi
-        fi
-        exit 0  # Old enough, no auto-review came — safe to trigger
-        ;;
-    "stale")
-        exit 0  # Had a trigger but it's stale — safe to re-trigger
-        ;;
-    "in-progress")
-        exit 1
-        ;;
-    *)
-        echo "Error: unexpected trigger_status='$trigger_status'" >&2
-        exit 1
-        ;;
-    esac
+    # No review yet — Greptile auto-reviews new PRs. Never manually trigger initial review.
+    exit 1
     ;;
 
 trigger)
@@ -282,38 +259,9 @@ trigger)
         exit 0
     fi
 
-    trigger_status=$(_our_trigger_status || echo "in-progress")
-    case "$trigger_status" in
-    "in-progress")
-        echo "  [greptile] Trigger in-flight on $REPO#$PR_NUMBER (recent or bot-acked). Skipping."
-        exit 0
-        ;;
-    "none")
-        # Fresh PR grace: wait for Greptile auto-review before manually triggering
-        pr_created_at=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.created_at' 2>/dev/null) || pr_created_at=""
-        if [ -n "$pr_created_at" ]; then
-            pr_age=$(_age_seconds "$pr_created_at" 2>/dev/null) || pr_age=99999
-            if [ "$pr_age" -lt "${INITIAL_REVIEW_GRACE:-1200}" ]; then
-                echo "  [greptile] Fresh PR $REPO#$PR_NUMBER (${pr_age}s old). Waiting for auto-review."
-                exit 0
-            fi
-        fi
-        echo "  [greptile] Triggering @greptileai review on $REPO#$PR_NUMBER..."
-        gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@greptileai review" 2>/dev/null \
-            && echo "  [greptile] Triggered successfully." \
-            || echo "  [greptile] Trigger failed (non-fatal)."
-        ;;
-    "stale")
-        echo "  [greptile] Triggering @greptileai review on $REPO#$PR_NUMBER (stale trigger)..."
-        gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@greptileai review" 2>/dev/null \
-            && echo "  [greptile] Triggered successfully." \
-            || echo "  [greptile] Trigger failed (non-fatal)."
-        ;;
-    *)
-        echo "  [greptile] Error: unexpected trigger_status='$trigger_status'" >&2
-        exit 1
-        ;;
-    esac
+    # No review yet — let Greptile auto-review. Don't manually trigger initial review.
+    echo "  [greptile] No review yet on $REPO#$PR_NUMBER. Awaiting Greptile auto-review."
+    exit 0
     ;;
 
 status)
@@ -324,19 +272,13 @@ status)
             echo "already-reviewed"
         fi
     else
+        # No review yet — check if there's a trigger in-flight (edge case: manual trigger)
         _ts=$(_our_trigger_status || echo 'error')
-        if [ "$_ts" = "none" ]; then
-            # Check if PR is fresh enough for auto-review
-            pr_created_at=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.created_at' 2>/dev/null) || pr_created_at=""
-            if [ -n "$pr_created_at" ]; then
-                pr_age=$(_age_seconds "$pr_created_at" 2>/dev/null) || pr_age=99999
-                if [ "$pr_age" -lt "${INITIAL_REVIEW_GRACE:-1200}" ]; then
-                    echo "awaiting-initial-review"
-                    exit 0
-                fi
-            fi
+        if [ "$_ts" = "in-progress" ]; then
+            echo "in-progress"
+        else
+            echo "awaiting-initial-review"
         fi
-        echo "$_ts"
     fi
     ;;
 

--- a/tests/test_greptile_helper.py
+++ b/tests/test_greptile_helper.py
@@ -198,7 +198,7 @@ def test_check_blocks_recently_acknowledged_trigger():
 
 
 def test_check_retries_acknowledged_trigger_after_timeout():
-    """Trigger > 20min with bot ack → stale."""
+    """Stale trigger (> 20min, bot ack, no review) → still awaiting-initial-review; check skips."""
     fixture = {
         "pr_number": 123,
         "raw_comments": [
@@ -209,10 +209,12 @@ def test_check_retries_acknowledged_trigger_after_timeout():
         "bot_reaction_count": 1,
     }
     result = _run_helper("check", fixture)
-    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert (
+        result.returncode == 1
+    ), f"Should skip (no review yet, never trigger initial). stderr: {result.stderr}"
 
     status = _run_helper("status", fixture)
-    assert status.stdout.strip() == "stale"
+    assert status.stdout.strip() == "awaiting-initial-review"
 
 
 def test_rereview_ignores_old_trigger_from_previous_review_cycle():
@@ -255,8 +257,8 @@ def test_fresh_pr_awaits_initial_review():
     assert result.returncode == 1, f"Should skip fresh PR. stderr: {result.stderr}"
 
 
-def test_old_pr_without_review_is_actionable():
-    """Old PR (> 20 min, no review, no trigger) → none (safe to trigger)."""
+def test_old_pr_without_review_awaits_initial_review():
+    """Old PR (> 20 min, no review, no trigger) → awaiting-initial-review (never trigger initial)."""
     fixture = {
         "pr_number": 789,
         "raw_comments": [],
@@ -265,10 +267,12 @@ def test_old_pr_without_review_is_actionable():
         "bot_reaction_count": 0,
     }
     status = _run_helper("status", fixture)
-    assert status.stdout.strip() == "none"
+    assert status.stdout.strip() == "awaiting-initial-review"
 
     result = _run_helper("check", fixture)
-    assert result.returncode == 0, f"Should be actionable. stderr: {result.stderr}"
+    assert (
+        result.returncode == 1
+    ), f"Should skip (never trigger initial review). stderr: {result.stderr}"
 
 
 def test_score_5_is_already_reviewed():
@@ -289,8 +293,8 @@ def test_score_5_is_already_reviewed():
     assert status.stdout.strip() == "already-reviewed"
 
 
-def test_trigger_posts_comment_on_old_unreviewed_pr():
-    """Trigger on old PR with no review → posts @greptileai review comment."""
+def test_trigger_skips_unreviewed_pr_initial_review():
+    """Trigger on old PR with no review → skips (awaiting Greptile auto-review)."""
     fixture = {
         "pr_number": 999,
         "raw_comments": [],
@@ -300,9 +304,8 @@ def test_trigger_posts_comment_on_old_unreviewed_pr():
     }
     result, gh_log = _run_helper("trigger", fixture, capture_gh_log=True)
     assert result.returncode == 0, f"stderr: {result.stderr}"
-    assert "Triggered successfully" in result.stdout
-    assert gh_log, "gh pr comment was never called"
-    assert "@greptileai review" in gh_log
+    assert "Awaiting" in result.stdout
+    assert not gh_log, "gh pr comment should NOT have been called"
 
 
 def test_trigger_skips_fresh_pr():
@@ -316,7 +319,7 @@ def test_trigger_skips_fresh_pr():
     }
     result = _run_helper("trigger", fixture)
     assert result.returncode == 0, f"stderr: {result.stderr}"
-    assert "Waiting for auto-review" in result.stdout
+    assert "Awaiting" in result.stdout
 
 
 def test_trigger_re_reviews_on_low_score_with_new_commits():


### PR DESCRIPTION
## Summary

- Removes manual triggering of initial Greptile reviews entirely
- Greptile auto-reviews all new PRs — no need for `@greptileai review` on first open
- Only re-reviews are triggered: when `score < 5/5` AND new commits since last review
- Simplifies `check`/`trigger`/`status` by removing the 20-min `INITIAL_REVIEW_GRACE` window

## Motivation

Erik's feedback in ErikBjare/bob#434:
> "trigger comments aren't needed for the initial review. Greptile should self-review new PRs. Could help reduce spam further."

The previous approach still triggered for PRs older than 20 minutes with no review, which was an unnecessary spam vector. Now we never trigger initial reviews regardless of PR age.

## Behavior change

| State | Before | After |
|-------|--------|-------|
| New PR (< 20 min) | `awaiting-initial-review`, skip | `awaiting-initial-review`, skip |
| Old PR (> 20 min), no review | `none`, **trigger** | `awaiting-initial-review`, **skip** |
| Re-review needed (score < 5/5 + new commits) | trigger | trigger (unchanged) |
| Already reviewed 5/5 | skip | skip (unchanged) |

## Test plan

- [x] `uv run pytest tests/test_greptile_helper.py -v` → 9 passed
- [x] Existing re-review test passes (`test_trigger_re_reviews_on_low_score_with_new_commits`)
- [x] New test `test_old_pr_without_review_awaits_initial_review` verifies old PRs no longer trigger
- [x] `test_trigger_skips_unreviewed_pr_initial_review` verifies trigger command skips