### PR TITLE
docs(lessons): add progress-despite-blockers and stage-files-before-commit

### DIFF
--- a/lessons/tools/stage-files-before-commit.md
+++ b/lessons/tools/stage-files-before-commit.md
@@ -15,7 +15,7 @@ status: active
 Always `git add <files>` before committing or running prek. New files must be staged first; prek validates the staged version, not your working directory.
 
 ## Context
-Git distinguishes tracked vs untracked files. `git commit FILE` only works for tracked files. prek stashes unstaged changes, so fixes aren't validated unless staged.
+When you're about to commit or run prek after editing files. If you skip staging, Git may reject new files and prek may validate stale content instead of the fixes you just made.
 
 ## Detection
 - Error: 'pathspec... did not match any file(s) known to git'

--- a/lessons/workflow/progress-despite-blockers.md
+++ b/lessons/workflow/progress-despite-blockers.md
@@ -36,7 +36,7 @@ Observable signals indicating opportunity for alternative progress:
 5. **Continuation Work**: Enhance existing stable systems
 6. **Preparation Work**: Write follow-up drafts, research alternatives, gather data
 
-**Automated discovery**: Set up a project monitoring service that finds actionable work across repos.
+**Automated discovery**: Use a project monitoring service to surface actionable work across repos. See [Project Monitoring Session Patterns](./project-monitoring-session-patterns.md).
 
 ## Real Blocker Criteria
 
@@ -56,5 +56,8 @@ Following these patterns results in:
 - **Faster unblocking**: Prepared when blockers lift
 
 ## Related
+- [Maintaining Readiness During Blocked Periods](../autonomous/maintaining-readiness-during-blocked-periods.md) - Stay useful while waiting on others
+- [Strategic Completion Leverage When Blocked](../autonomous/strategic-completion-leverage-when-blocked.md) - Finish the highest-leverage adjacent work
 - [Autonomous Session Structure](../autonomous/autonomous-session-structure.md) - Overall session workflow
+- [Project Monitoring Session Patterns](./project-monitoring-session-patterns.md) - Automated discovery of actionable work
 - [Close the Loop](../patterns/close-the-loop.md) - Automation approach


### PR DESCRIPTION
Two workflow lessons upstreamed from Bob's workspace with high LOO-positive session reward impact (Δ=+0.18 and Δ=+0.14, p<0.001 over 30d/800+ sessions):

- **progress-despite-blockers**: Six strategies for making progress when tasks are blocked on external dependencies. Prevents sessions from declaring a 'Real Blocker' without exhausting all alternatives.

- **stage-files-before-commit**: Reminds agents to `git add` before committing or running prek. Prevents 'pathspec did not match' errors and prek validating stale staged content.