### PR TITLE
docs(lessons): add absolute-paths and git-commit-format workflow lessons

### DIFF
--- a/lessons/workflow/absolute-paths-for-workspace-files.md
+++ b/lessons/workflow/absolute-paths-for-workspace-files.md
@@ -4,7 +4,7 @@ match:
   - "save file to"
   - "write journal entry"
   - "mkdir -p journal"
-  - "file path"
+  - "file written to wrong"
   - "wrong directory"
 status: active
 ---
@@ -25,14 +25,17 @@ When working across multiple repositories or when current directory might change
 
 ## Pattern
 ```bash
-# ❌ Wrong: relative path, depends on cwd
-cd ~/projects/gptme
-echo "..." >> journal/2025-10-14-topic.md  # creates in wrong repo
+# ❌ Wrong: relative path, CWD may have drifted to a different repo
+# (e.g., after cd-ing into ~/gptme to apply a fix)
+echo "..." >> journal/2025-10-14-topic.md  # creates in ~/gptme/journal/, not bob's!
 
-# ✅ Correct: absolute path works from any directory
-REPO_ROOT=$(git rev-parse --show-toplevel)
+# ✅ Correct: capture REPO_ROOT early, before CWD can change
+REPO_ROOT=$(git rev-parse --show-toplevel)  # run this while CWD is in the correct repo
 echo "..." >> "$REPO_ROOT/journal/2025-10-14-topic.md"
 ```
+
+**Note**: `$(git rev-parse --show-toplevel)` returns the root of whichever repo contains the
+current directory. Capture it at session start while CWD is known to be correct.
 
 ## Outcome
 - **Reliability**: Works regardless of current directory

--- a/lessons/workflow/git-commit-format.md
+++ b/lessons/workflow/git-commit-format.md
@@ -20,7 +20,6 @@ When creating git commits in any workspace or repository.
 Observable signals indicating incorrect commit format:
 - Commit message missing type prefix (feat, fix, docs, etc.)
 - Vague descriptions ("update code", "fix stuff")
-- Multiple unrelated changes in single commit
 - Missing scope when relevant (e.g., "fix: bug" instead of "fix(api): bug")
 
 ## Pattern
@@ -49,6 +48,7 @@ Following this pattern ensures:
 
 ## Related
 - [Conventional Commits Specification](https://www.conventionalcommits.org/)
+- [git-workflow.md](./git-workflow.md) - Broader commit hygiene and branch practices
 
 ## Origin
 Extracted from LOO effectiveness analysis in Bob's workspace (Δ=+0.162 session reward, p<0.001).


### PR DESCRIPTION
## Summary

Adds two workflow lessons extracted from Bob's workspace LOO (leave-one-out) effectiveness analysis. These were originally submitted to gptme-agent-template#74, but Erik correctly pointed out they belong in gptme-contrib so all agents benefit.

- **`absolute-paths-for-workspace-files`** (Δ=+0.198 session reward, p<0.001): Always use absolute paths when writing workspace files. Prevents journal entries from being created in the wrong directory when working across multiple repos.

- **`git-commit-format`** (Δ=+0.162 session reward, p<0.001): Conventional Commits format for all commit messages.

Both lessons are generalized from Bob-specific versions:
- Absolute-paths: replaced `/home/bob/bob/` hardcoded path with `$(git rev-parse --show-toplevel)`
- Commit-format: removed Bob co-authorship rule, kept only the generic conventional commits guidance

## Test plan

- [x] Pre-commit hooks pass (lessons validated)
- [x] Keywords are specific multi-word phrases
- [x] Origin section explains data provenance