### PR TITLE
docs(lessons): add absolute-paths and git-commit-format workflow lessons

### DIFF
--- a/lessons/workflow/absolute-paths-for-workspace-files.md
+++ b/lessons/workflow/absolute-paths-for-workspace-files.md
@@ -28,18 +28,19 @@ When working across multiple repositories. If you `cd` into an external repo (e.
 ## Pattern
 ```bash
 # ❌ Wrong: relative path, depends on cwd
-echo "..." >> journal/2025-10-14/session.md  # creates in current repo!
+echo "..." >> journal/2025-10-14/session.md  # silently writes to current repo!
 
 # ❌ Wrong: git rev-parse resolves to *current* git root, not workspace
-WORKSPACE=$(git rev-parse --show-toplevel)
-echo "..." >> "$WORKSPACE/journal/..."  # fails when cwd is external repo
+REPO_ROOT=$(git rev-parse --show-toplevel)
+echo "..." >> "$REPO_ROOT/journal/..."  # silently writes to external repo — no error, data goes to wrong location
 
 # ✅ Correct: hardcoded absolute path always works
 echo "..." >> /home/agent/workspace/journal/2025-10-14/session.md
 
 # ✅ Correct: use WORKSPACE env var set at session start
+# Guard against unset: if WORKSPACE is empty, paths expand to /journal/... (wrong!)
+: "${WORKSPACE:?WORKSPACE is not set — export it at session start: export WORKSPACE=/home/agent/workspace}"
 echo "..." >> "$WORKSPACE/journal/2025-10-14/session.md"
-# where WORKSPACE is set once at startup: WORKSPACE=/home/agent/workspace
 ```
 
 For write/save tools, always provide the full absolute path:

--- a/lessons/workflow/git-commit-format.md
+++ b/lessons/workflow/git-commit-format.md
@@ -44,6 +44,13 @@ test(tasks): add integration tests for task state machine
 chore: update dependency lockfile
 ```
 
+**Breaking changes** (use `!` suffix and/or `BREAKING CHANGE:` footer):
+```text
+feat(api)!: rename /v1/query to /v1/ask
+
+BREAKING CHANGE: /v1/query endpoint removed; use /v1/ask instead.
+```
+
 **With body** (when context helps):
 ```text
 fix(api): handle rate limit errors gracefully


### PR DESCRIPTION
Two workflow lessons upstreamed from Bob's workspace, identified as high-impact via LOO effectiveness analysis.

## Lessons

### `absolute-paths-for-workspace-files`
Agents must use hardcoded absolute paths for workspace files. Using relative paths or `git rev-parse --show-toplevel` **both fail** when cwd is an external repo (e.g., a PR worktree) — `git rev-parse` resolves to the current git root, not the agent workspace.

This fixes a logical error in the original gptme-agent-template#74 draft where the "correct" example still used `git rev-parse`.

### `git-commit-format`
Conventional Commits format for all commit messages. Generalized from Bob's workspace (agent-specific co-authorship note removed).

## Origin
Closes out follow-up from gptme/gptme-agent-template#74, which Erik redirected here.