### PR TITLE
perf(activity-gate): cache greptile score by HEAD SHA to skip redundant API calls

### DIFF
--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -437,7 +437,7 @@ check_merge_conflicts() {
 # code fixes, even if no other activity has occurred.
 #
 # API cost: 1 REST call per open PR (issue comments endpoint), ONLY when the
-# cached score is stale (> 30 min old) or a new HEAD SHA is detected. On quiet
+# cached score is stale (> 60 min old) or a new HEAD SHA is detected. On quiet
 # runs where no PRs have new commits, 0 API calls are made.
 # HEAD SHA comes from fetch_pr_data() (headRefOid) — no extra API call needed.
 #
@@ -446,8 +446,8 @@ check_merge_conflicts() {
 #   Re-emits when: (a) first time seeing a low score, or (b) new commits pushed
 #   since last emission (fix attempt may have changed things).
 #   Cooldown: 1 hour — won't re-emit the same PR within that window.
-#   Score cache TTL: 30 min — re-fetches after this window even if HEAD unchanged
-#   (covers manual @greptileai triggers via greptile-helper.sh).
+#   Score cache TTL: 60 min (= cooldown) — re-fetches after this window even if
+#   HEAD unchanged (covers manual @greptileai triggers via greptile-helper.sh).
 #
 # Emits:
 #   greptile_needs_fix       — score < 4 (significant findings to address)
@@ -459,7 +459,7 @@ check_greptile_scores() {
 
     local repo_safe="${repo//\//-}"
     local cooldown_seconds=3600  # 1 hour
-    local fetch_cache_ttl=1800   # 30 min — skip API call if score is cached for current HEAD SHA
+    local fetch_cache_ttl=3600   # 60 min (= cooldown) — skip API call if score is cached for current HEAD SHA
 
     echo "$prs" | jq -c '.[]' | while read -r pr_data; do
         local pr_number pr_title

--- a/tests/test_activity_gate_cache.py
+++ b/tests/test_activity_gate_cache.py
@@ -165,7 +165,11 @@ def test_fresh_cache_skips_api_call() -> None:
         ts = int(time.time()) - 300
         _state_file(state_dir).write_text(f"4:{ts}:{TEST_HEAD_SHA}")
 
-        _result, call_count = _run_gate(tmp, state_dir)
+        result, call_count = _run_gate(tmp, state_dir)
+        assert result.returncode in (
+            0,
+            1,
+        ), f"Script crashed (rc={result.returncode}): {result.stderr}"
         assert (
             call_count == 0
         ), f"Expected 0 API calls (cache hit, same SHA, fresh), got {call_count}"
@@ -182,24 +186,32 @@ def test_new_head_sha_calls_api() -> None:
         ts = int(time.time()) - 300
         _state_file(state_dir).write_text(f"4:{ts}:oldsha999")
 
-        _result, call_count = _run_gate(tmp, state_dir, head_sha=TEST_HEAD_SHA)
+        result, call_count = _run_gate(tmp, state_dir, head_sha=TEST_HEAD_SHA)
+        assert result.returncode in (
+            0,
+            1,
+        ), f"Script crashed (rc={result.returncode}): {result.stderr}"
         assert (
             call_count >= 1
         ), f"Expected API call (cache miss: SHA mismatch), got {call_count}"
 
 
 def test_stale_cache_calls_api() -> None:
-    """Cache miss: same head_sha but timestamp > 30 min → re-fetch from API."""
+    """Cache miss: same head_sha but timestamp > 60 min → re-fetch from API."""
     with tempfile.TemporaryDirectory() as tmp_str:
         tmp = Path(tmp_str)
         state_dir = tmp / "state"
         state_dir.mkdir()
 
-        # Pre-populate: same head_sha, but 35 minutes ago (> 30-min TTL)
-        ts = int(time.time()) - (35 * 60)
+        # Pre-populate: same head_sha, but 65 minutes ago (> 60-min TTL)
+        ts = int(time.time()) - (65 * 60)
         _state_file(state_dir).write_text(f"4:{ts}:{TEST_HEAD_SHA}")
 
-        _result, call_count = _run_gate(tmp, state_dir)
+        result, call_count = _run_gate(tmp, state_dir)
+        assert result.returncode in (
+            0,
+            1,
+        ), f"Script crashed (rc={result.returncode}): {result.stderr}"
         assert (
             call_count >= 1
         ), f"Expected API call (cache miss: stale TTL), got {call_count}"
@@ -213,7 +225,11 @@ def test_no_state_file_calls_api() -> None:
         state_dir.mkdir()
         # No state file — first-time encounter
 
-        _result, call_count = _run_gate(tmp, state_dir)
+        result, call_count = _run_gate(tmp, state_dir)
+        assert result.returncode in (
+            0,
+            1,
+        ), f"Script crashed (rc={result.returncode}): {result.stderr}"
         assert call_count >= 1, f"Expected API call (no state file), got {call_count}"
         # State file should be seeded now
         assert _state_file(


### PR DESCRIPTION
Caches the greptile score check by HEAD SHA (30-min TTL) to avoid calling gh api .../issues/.../comments for every PR every monitoring run. On quiet runs: 0 API calls instead of N. 4 new tests. Fixes: ErikBjare/bob#439