### PR TITLE
fix(greptile): add max-retries guard to prevent infinite re-review loops

### DIFF
--- a/scripts/github/greptile-helper.sh
+++ b/scripts/github/greptile-helper.sh
@@ -172,7 +172,7 @@ _our_trigger_status() {
     local created_at
     created_at=$(echo "$comment_info" | _json_field "created_at") || created_at=""
     local count_since_review
-    count_since_review=$(echo "$comment_info" | _json_field "count_since_review") || count_since_review=0
+    count_since_review=$(echo "$comment_info" | _json_field "count_since_review")
 
     if [ -z "$comment_id" ]; then
         echo "none"

--- a/tests/test_greptile_helper.py
+++ b/tests/test_greptile_helper.py
@@ -400,3 +400,30 @@ def test_max_retries_guard_blocks_after_repeated_triggers():
     result, gh_log = _run_helper("trigger", fixture, capture_gh_log=True)
     assert result.returncode == 0, f"stderr: {result.stderr}"
     assert not gh_log, f"Should NOT have posted trigger comment, got: {gh_log}"
+
+
+def test_max_retries_guard_allows_below_threshold():
+    """2 triggers since last review (< MAX_RE_TRIGGERS=3) → NOT blocked, should re-trigger.
+
+    Lower-bound boundary check: the guard only fires at >= threshold, not below.
+    """
+    reviewed_at = _iso_ago(minutes=120)
+    fixture = {
+        "pr_number": 1651,
+        "raw_comments": [
+            _make_greptile_comment(4, reviewed_at=reviewed_at),
+            # Two re-review triggers posted after the review (below the threshold of 3)
+            _make_trigger_comment("test-user", _iso_ago(minutes=60)),
+            _make_trigger_comment("test-user", _iso_ago(minutes=30)),
+        ],
+        "raw_commits": [
+            _make_commit(_iso_ago(minutes=10)),  # New commits since review
+        ],
+        "raw_pr": {"created_at": _iso_ago(minutes=180)},
+        "bot_reaction_count": 0,  # Last trigger not yet acked — age guard doesn't apply
+    }
+    # status: should NOT be in-progress (guard not fired yet)
+    status = _run_helper("status", fixture)
+    assert (
+        status.stdout.strip() != "in-progress"
+    ), f"Should NOT block at count=2 (< MAX_RE_TRIGGERS=3), got: {status.stdout.strip()}"


### PR DESCRIPTION
## Problem

When Greptile acks a re-review trigger (via `+1` reaction) but never posts a review comment, the `ACK_GRACE_SECONDS` expiry (20min) caused the helper to mark the trigger as `stale` and re-trigger indefinitely.

**Incident**: gptme#1651 accumulated 7 `@greptileai review` comments in a single day (2026-03-18) because every session saw the previous trigger as "acked but stale" and re-triggered.

## Fix

Add a `MAX_RE_TRIGGERS` guard (default: 3) in `_our_trigger_status()`:
- The jq query now also computes `count_since_review` — how many of our `@greptileai review` comments exist since the last Greptile review
- If `count_since_review >= MAX_RE_TRIGGERS`, return `in-progress` regardless of ACK state, blocking further triggers

Also fix: `status` command now calls `_our_trigger_status` for `needs-re-review` PRs, so it accurately reflects `in-progress` when the max-retries guard fires.

## Test

Added `test_max_retries_guard_blocks_after_repeated_triggers` — 3 triggers since last review, Greptile acked each but never reviewed → check blocks, status shows `in-progress`, trigger skips.

10/10 tests pass.