### PR TITLE
fix(github): use REST API in is_item_open to save GraphQL quota

### DIFF
--- a/scripts/github/check-notifications.sh
+++ b/scripts/github/check-notifications.sh
@@ -115,12 +115,14 @@ is_item_open() {
 
     case "$type" in
         PullRequest)
-            state=$(gh pr view "$number" --repo "$repo" --json state -q .state 2>/dev/null || echo "UNKNOWN")
-            [[ "$state" == "OPEN" ]]
+            # Use REST API to avoid consuming GraphQL quota (gh pr view uses GraphQL)
+            state=$(gh api "repos/$repo/pulls/$number" --jq '.state' 2>/dev/null || echo "unknown")
+            [[ "$state" == "open" ]]
             ;;
         Issue)
-            state=$(gh issue view "$number" --repo "$repo" --json state -q .state 2>/dev/null || echo "UNKNOWN")
-            [[ "$state" == "OPEN" ]]
+            # Use REST API to avoid consuming GraphQL quota (gh issue view uses GraphQL)
+            state=$(gh api "repos/$repo/issues/$number" --jq '.state' 2>/dev/null || echo "unknown")
+            [[ "$state" == "open" ]]
             ;;
         *)
             # For other types (discussions, releases), always show


### PR DESCRIPTION
## Problem

`is_item_open()` in `check-notifications.sh` uses `gh pr view --json state` and `gh issue view --json state`, which both hit the **GraphQL API** (5000 calls/hour limit). 

When `check-notifications.sh --only-open` is called, each notification triggers a GraphQL call to check open/closed status. With frequent session runs, this contributes to GraphQL quota exhaustion.

## Fix

Switch to `gh api repos/REPO/pulls/NUMBER` and `gh api repos/REPO/issues/NUMBER` which use the **REST/core API** (separate 5000/hour limit — much less contended).

Key difference: REST API returns lowercase `"open"` vs GraphQL `"OPEN"`, so comparisons updated accordingly.

## Impact

- Eliminates GraphQL calls for each notification filtered by `--only-open`
- REST quota is rarely exhausted (vs GraphQL hitting 0 daily)
- Same correctness — both APIs return the same semantic state

Co-authored-by: Bob <bob@superuserlabs.org>