### PR TITLE
fix(types): fix test imports and type annotations across packages

### DIFF
--- a/packages/gptmail/src/gptmail/lib.py
+++ b/packages/gptmail/src/gptmail/lib.py
@@ -47,7 +47,7 @@ from email.mime.text import MIMEText
 from email.policy import default
 from email.utils import format_datetime, parseaddr, parsedate_to_datetime
 from pathlib import Path
-from typing import Dict, Tuple
+from typing import Any, Dict, Tuple
 
 import markdown
 
@@ -148,7 +148,7 @@ class AgentEmail:
         """
         # Clear message index cache at start of sync
         # This ensures we rebuild the index with current state
-        self._message_index_cache = {}
+        self._message_index_cache: dict[str, Any] = {}
 
         self.workspace = Path(workspace_dir)
         self.email_dir = self.workspace / "email"
@@ -1247,7 +1247,7 @@ class AgentEmail:
         logger.debug(f"Built message index for {folder}: {len(index)} entries")
         return index
 
-    def _get_message_key(self, email_msg: EmailMessage, folder: str) -> Tuple[str, str]:
+    def _get_message_key(self, email_msg: EmailMessage, folder: str) -> Tuple[str, str | None]:
         """Get indexing keys for a message.
 
         Args:

--- a/packages/gptme-dashboard/tests/test_server.py
+++ b/packages/gptme-dashboard/tests/test_server.py
@@ -8,7 +8,9 @@ from pathlib import Path
 
 import pytest
 
-from gptme_dashboard.server import create_app, load_org_config
+flask = pytest.importorskip("flask", reason="Flask required for dashboard server tests")
+
+from gptme_dashboard.server import create_app, load_org_config  # noqa: E402
 
 
 @pytest.fixture

--- a/packages/gptodo/tests/test_unblock.py
+++ b/packages/gptodo/tests/test_unblock.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 import frontmatter
 
@@ -23,9 +23,9 @@ def create_task_info(
     name: str,
     path: Path,
     state: str = "active",
-    requires: List[str] = None,
-    depends: List[str] = None,
-    metadata: dict = None,
+    requires: Optional[List[str]] = None,
+    depends: Optional[List[str]] = None,
+    metadata: Optional[dict] = None,
 ) -> TaskInfo:
     """Create a TaskInfo object for testing."""
     metadata = metadata or {}


### PR DESCRIPTION
## Summary
- **gptme-dashboard**: Add `pytest.importorskip("flask")` so server tests skip gracefully when Flask isn't installed (instead of `ImportError` crash)
- **gptodo**: Fix implicit `Optional` parameters in `test_unblock.py` (`requires`, `depends`, `metadata` defaulting to `None` without `Optional` annotation)
- **gptmail**: Fix `_get_message_key` return type from `Tuple[str, str]` to `Tuple[str, str | None]` (alt_key can be None), add type annotation to `_message_index_cache`

## Test plan
- [x] `pytest packages/gptodo/tests/test_unblock.py` — all 12 tests pass
- [x] Dashboard tests should now skip instead of fail when Flask is not installed