### PR TITLE
fix(lessons): improve browser-verification keyword precision

### DIFF
--- a/lessons/tools/browser-verification.md
+++ b/lessons/tools/browser-verification.md
@@ -4,11 +4,12 @@ match:
   - "verify web changes in browser"
   - "check browser console errors"
   - "deployment verification"
-  - "web changes not working"
-  - "page not loading correctly"
+  - "commit web changes without testing"
+  - "push without browser check"
   - "claiming fixed without testing"
   - "check in browser"
-  - "browser tool"
+  - "forgot to test in browser"
+  - "web change deployed without verification"
 status: active
 ---
 
@@ -63,3 +64,7 @@ Following this pattern results in:
 Example (from real incident):
 - Without verification: "Fixed!" → still broken → second fix needed
 - With verification: Caught missing elements → fixed first time
+
+## Related
+- [Pre-Landing Self-Review](../workflow/pre-landing-self-review.md) - Verification before merging
+- [Git Workflow](../workflow/git-workflow.md) - General commit hygiene


### PR DESCRIPTION
## Summary

Improves the keyword matching for the `browser-verification` lesson to reduce false positives.

**Problem**: The lesson had two categories of overly broad keywords:

1. **`"browser tool"`** — fired in *every* session that mentions the browser tool, including sessions where the browser tool is being used correctly. This created confounding in LOO effectiveness analysis (LOO Δ=-0.097, p=0.076): sessions with this lesson appeared to have lower rewards, but only because they were inherently harder browser-debugging sessions.

2. **`"web changes not working"` / `"page not loading correctly"`** — fired when a problem already exists (post-hoc), not when verification is being skipped (preventive). This is a classic error-signal confound: the lesson fires because the session is already struggling, not because the lesson causes struggle.

**Fix**: Replace with action-specific keywords that fire only when verification is being *skipped* before it's needed:
- `"commit web changes without testing"`
- `"push without browser check"`  
- `"forgot to test in browser"`
- `"web change deployed without verification"`

Also adds the missing `Related` section required by lesson validation.

## Why this matters

LOO effectiveness analysis on Bob's sessions (n=557, last 7d) showed this lesson at the margin of significance for being harmful. Narrowing the keywords should:
- Reduce false-positive matches in browser sessions that don't need verification reminders
- Make the LOO signal cleaner (fewer confounded sessions)
- Keep the lesson firing when it's actually needed (someone about to push web changes without checking)

Co-authored-by: Bob <bob@superuserlabs.org>