### PR TITLE
fix(signals): detect commits from background bash tasks and gh pr merge

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -35,7 +35,8 @@ _WARNING_PHRASE_RE = re.compile(r"error:|\bfailed\b|\bfailures?\b|\btraceback\b|
 # When CC runs a Bash command in background mode, the tool result contains:
 # "Command running in background with ID: TASKID. Output is being written to: PATH"
 # The actual git commit output (which matches _COMMIT_RE) is in that file, not the result.
-_BG_TASK_RE = re.compile(r"Output is being written to: ([^\s]+\.output)")
+# Note: paths are matched greedily up to the end of line to handle spaces in paths.
+_BG_TASK_RE = re.compile(r"Output is being written to: (.+\.output)")
 
 # Regex for gh pr merge success output.
 # Format: "✓ Squashed and merged pull request #N (title)"
@@ -490,7 +491,7 @@ def extract_signals_cc(msgs: list[dict]) -> dict:
                                 commit_hash = commit_match.group(1)
                                 commit_msg = commit_match.group(2).strip()
                                 git_commits.append(f"{commit_msg} ({commit_hash})")
-                        except (OSError, IOError):
+                        except OSError:
                             pass  # File may not exist if session ran on a different host
 
                     # gh pr merge detection: output format is

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -890,6 +890,54 @@ def test_extract_signals_cc_gh_pr_merge():
     assert "merge PR #1725" in sigs["git_commits"][0]
 
 
+@pytest.mark.parametrize(
+    "merge_output",
+    [
+        "✓ Squashed and merged pull request #42 (feat: squash test)",
+        "✓ Rebased and merged pull request #42 (feat: rebase test)",
+        "✓ Merged pull request #42 (feat: merge test)",
+    ],
+)
+def test_extract_signals_cc_gh_pr_merge_variants(merge_output: str):
+    """CC trajectory: all gh pr merge variants (squash/rebase/plain) are detected."""
+    bash_id = "bash_merge_variants"
+    msgs = [
+        {
+            "type": "assistant",
+            "timestamp": "2026-03-21T11:00:00.000Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": bash_id,
+                        "name": "Bash",
+                        "input": {"command": "gh pr merge 42"},
+                    }
+                ],
+            },
+        },
+        {
+            "type": "user",
+            "timestamp": "2026-03-21T11:00:10.000Z",
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": bash_id,
+                        "is_error": False,
+                        "content": merge_output,
+                    }
+                ],
+            },
+        },
+    ]
+    sigs = extract_signals_cc(msgs)
+    assert len(sigs["git_commits"]) == 1
+    assert "merge PR #42" in sigs["git_commits"][0]
+
+
 def test_grade_signals_dead_session():
     """Grade is very low (0.10) for dead sessions with zero tool calls."""
     sigs = extract_signals_cc([])


### PR DESCRIPTION
## Problem

Cross-repo CC sessions were scoring `trajectory_grade=0.15` despite merging real PRs. This caused the harness bandit to receive unfairly low rewards for productive cross-repo work.

Two root causes:
1. **Background bash tasks**: When CC runs Bash in background mode, the tool result only contains a pointer: `"Output is being written to: /tmp/claude-NNN/.../tasks/TASKID.output"`. The actual git commit output (matching `_COMMIT_RE`) is in that file, not the result string. Signal extractor never read those files.
2. **gh pr merge**: `gh pr merge --squash` outputs `✓ Squashed and merged pull request #N (title)` which doesn't match `_COMMIT_RE` (no `[branch hash]` format).

## Fix

Adds two new detection paths in `extract_signals_cc()`:
- **`_BG_TASK_RE`**: detects `"Output is being written to: PATH"` in Bash results, reads that file, and scans it for `_COMMIT_RE` patterns.
- **`_PR_MERGE_RE`**: detects `"Squashed/Rebased/Merged pull request #N"` directly in Bash tool results.

## Tests

Two new tests:
- `test_extract_signals_cc_background_bash_commits` — verifies commits in background task output files are detected
- `test_extract_signals_cc_gh_pr_merge` — verifies `gh pr merge` success is detected as a commit signal

All 448 tests pass.