### PR TITLE
feat(user-memories): move storage to ~/.config/gptme/user-memories/

### DIFF
--- a/plugins/gptme-user-memories/README.md
+++ b/plugins/gptme-user-memories/README.md
@@ -7,7 +7,7 @@ A gptme plugin that automatically extracts user facts from past conversations an
 1. A `SESSION_END` hook runs after each conversation
 2. It checks if the session was a personal (non-autonomous) conversation
 3. Uses Claude Haiku to extract key user facts from the conversation
-4. Stores them in `~/.local/share/gptme/user-memories.md`
+4. Stores them in `~/.config/gptme/user-memories/facts.md`
 5. You include that file in your gptme.toml or context script
 
 ## Installation
@@ -36,16 +36,16 @@ Add to your `gptme.toml`:
 [prompt]
 files = [
     # ... other files ...
-    "~/.local/share/gptme/user-memories.md",
+    "~/.config/gptme/user-memories/facts.md",
 ]
 ```
 
 Or in your context script (`context.sh`):
 
 ```bash
-if [[ -f ~/.local/share/gptme/user-memories.md ]]; then
+if [[ -f ~/.config/gptme/user-memories/facts.md ]]; then
     echo "# User Memories"
-    cat ~/.local/share/gptme/user-memories.md
+    cat ~/.config/gptme/user-memories/facts.md
 fi
 ```
 
@@ -87,7 +87,7 @@ All processing is local. The only external call is to Anthropic's API to extract
 
 ## Storage
 
-Memories are stored in `~/.local/share/gptme/user-memories.md` as a simple markdown list:
+Memories are stored in `~/.config/gptme/user-memories/facts.md` as a simple markdown list:
 
 ```markdown
 # User Memories
@@ -133,7 +133,7 @@ from gptme_user_memories.extractor import load_existing_memories, merge_facts, s
 from pathlib import Path
 
 # Process a specific session
-new_facts = process_logdir(Path("~/.local/share/gptme/logs/my-session").expanduser())
+new_facts = process_logdir(Path("~/.local/share/gptme/logs/my-session").expanduser())  # gptme logs path (unchanged)
 
 # Merge and save (process_logdir returns None if session was filtered)
 if new_facts is not None:

--- a/plugins/gptme-user-memories/src/gptme_user_memories/extractor.py
+++ b/plugins/gptme-user-memories/src/gptme_user_memories/extractor.py
@@ -541,7 +541,7 @@ def main() -> None:
     import argparse
 
     parser = argparse.ArgumentParser(
-        description="Extract user facts from past gptme/Claude Code sessions and store them in user-memories.md.",
+        description="Extract user facts from past gptme/Claude Code sessions and store them in ~/.config/gptme/user-memories/facts.md.",
     )
     parser.add_argument(
         "--days",

--- a/plugins/gptme-user-memories/src/gptme_user_memories/hooks/session_end.py
+++ b/plugins/gptme-user-memories/src/gptme_user_memories/hooks/session_end.py
@@ -36,7 +36,7 @@ def session_end_user_memories_hook(
     """Run user memory extraction at session end.
 
     Extracts facts about the user from the just-completed conversation and
-    merges them into ~/.local/share/gptme/user-memories.md.
+    merges them into ~/.config/gptme/user-memories/facts.md.
 
     Args:
         manager: Active LogManager for this conversation


### PR DESCRIPTION
## Summary

- Move `USER_MEMORIES_FILE` from `~/.local/share/gptme/user-memories.md` to `~/.config/gptme/user-memories/facts.md`
- Add `USER_MEMORIES_DIR` constant pointing to the parent directory

## Rationale

As part of the memory architecture design ([ErikBjare/bob#259](https://github.com/ErikBjare/bob/issues/259)):

- **XDG convention**: `~/.config/` is the correct location for user preferences/facts (not `~/.local/share/` which is for app data)
- **Cross-agent sharing**: The directory `~/.config/gptme/user-memories/` is readable by all gptme agents on the same machine, enabling cross-agent user profile sharing
- **Future extensibility**: Directory structure allows expanding to category files (`preferences.md`, `projects.md`, `personal.md`) without breaking existing integrations
- **Separation from app data**: Logs and sentinels stay in `~/.local/share/gptme/` (app data); user profile facts belong in `~/.config/gptme/` (user config)

## Migration

Existing users with `~/.local/share/gptme/user-memories.md` will need to move it manually:
```bash
mkdir -p ~/.config/gptme/user-memories/
mv ~/.local/share/gptme/user-memories.md ~/.config/gptme/user-memories/facts.md
```

## Test plan

- [x] All 79 existing tests pass (tests use mock patches, not the actual path)
- [ ] Manual test: run extraction, verify file created at new path
- [ ] Update gptme.toml docs to reference new path