### PR TITLE
fix(monitoring): skip draft PRs in project monitoring

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/project_monitoring.py
+++ b/packages/gptme-runloops/src/gptme_runloops/project_monitoring.py
@@ -195,7 +195,7 @@ class ProjectMonitoringRun(BaseRunLoop):
                     "--state",
                     "open",
                     "--json",
-                    "number,title,updatedAt,url,headRefName",
+                    "number,title,updatedAt,url,headRefName,isDraft",
                 ],
                 capture_output=True,
                 text=True,
@@ -208,6 +208,9 @@ class ProjectMonitoringRun(BaseRunLoop):
             prs = json.loads(result.stdout)
 
             for pr in prs:
+                # Skip draft PRs — they're not on the merge path
+                if pr.get("isDraft"):
+                    continue
                 pr_number = pr["number"]
                 updated_at = pr["updatedAt"]
                 state_file = (
@@ -278,7 +281,7 @@ class ProjectMonitoringRun(BaseRunLoop):
                     "--state",
                     "open",
                     "--json",
-                    "number,title,statusCheckRollup,url",
+                    "number,title,statusCheckRollup,url,isDraft",
                 ],
                 capture_output=True,
                 text=True,
@@ -292,6 +295,9 @@ class ProjectMonitoringRun(BaseRunLoop):
             current_failures = []
 
             for pr in prs:
+                # Skip draft PRs — don't chase CI failures on deprioritized work
+                if pr.get("isDraft"):
+                    continue
                 pr_number = pr["number"]
                 checks = pr.get("statusCheckRollup") or []
 


### PR DESCRIPTION
## Summary
- Skip draft PRs in `check_pr_updates()` and `check_ci_failures()` in project monitoring
- Draft PRs signal deprioritized/not-ready work — agents shouldn't waste cycles on them
- `self-merge-check` already blocked drafts from merging, but the upstream discovery didn't filter them

Triggered by: gptme/gptme-cloud#171 is a draft PR that was still showing up as work items.

See also: ErikBjare/bob (skip-draft-prs branch) for the corresponding `spawn-sonnet-workers.sh` fix.

## Test plan
- [ ] Verify draft PRs no longer appear in project monitoring work items
- [ ] Verify non-draft PRs still get discovered normally