### PR TITLE
fix(activity-gate): filter out draft PRs from work discovery

### DIFF
--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -203,8 +203,10 @@ discover_repos() {
 # This replaces 3 separate `gh pr list` calls with a single one.
 fetch_pr_data() {
     local repo=$1
+    # Filter out draft PRs — they're intentionally deprioritized/not on merge path
     gh pr list --repo "$repo" --author "$AUTHOR" --state open \
-        --json number,title,updatedAt,comments,latestReviews,statusCheckRollup,mergeable,mergeStateStatus,headRefOid \
+        --json number,title,updatedAt,comments,latestReviews,statusCheckRollup,mergeable,mergeStateStatus,headRefOid,isDraft \
+        --jq '[.[] | select(.isDraft | not)]' \
         2>/dev/null || echo "[]"
 }
 


### PR DESCRIPTION
## Summary
- Filter draft PRs in `fetch_pr_data()` — the single data source for all PR check functions in `activity-gate.sh`
- This is the **production path** (runs every 10min via systemd) that the previous PR (#523) missed
- #523 fixed the Python `ProjectMonitoringRun` class (gptme backend), but the shell-based activity gate is what actually runs

One-line fix: add `isDraft` to JSON fields + `--jq '[.[] | select(.isDraft | not)]'`

Covers all downstream checks: `check_pr_updates`, `check_ci_failures`, `check_merge_conflicts`, `check_greptile_scores`, `check_merge_ready`.

## Test plan
- [ ] Verify `fetch_pr_data` excludes draft PRs (test with gptme/gptme-cloud#171 which is a draft)
- [ ] Verify non-draft PRs still appear in monitoring