### PR TITLE
feat(scripts): upstream check-claude-usage.sh and quota-gate.sh from Bob

### DIFF
--- a/scripts/check-claude-usage.sh
+++ b/scripts/check-claude-usage.sh
@@ -45,7 +45,8 @@ CACHE_TTL="${CLAUDE_USAGE_CACHE_TTL:-600}"  # 10 minutes default
 
 # --- Cache check (JSON and human-readable modes only, not --raw) ---
 if [ "$MODE" != "raw" ] && [ "$NO_CACHE" = false ] && [ -f "$CACHE_FILE" ]; then
-    CACHE_AGE=$(( $(date +%s) - $(stat -c %Y "$CACHE_FILE" 2>/dev/null || echo 0) ))
+    # stat mtime: -c %Y on Linux, -f %m on macOS/BSD
+    CACHE_AGE=$(( $(date +%s) - $(stat -c %Y "$CACHE_FILE" 2>/dev/null || stat -f %m "$CACHE_FILE" 2>/dev/null || echo 0) ))
     if [ "$CACHE_AGE" -lt "$CACHE_TTL" ]; then
         if [ "$MODE" = "json" ]; then
             cat "$CACHE_FILE"
@@ -256,13 +257,23 @@ for key in result:
         result[key]['resets_in_seconds'] = max(0, int(delta.total_seconds()))
         result[key]['time_left'] = format_time_left(reset_dt)
 
-# --- Off-peak detection (March 2026 promotion: Mar 13-27) ---
+# --- Off-peak detection ---
 # Peak: 8 AM-2 PM ET (12:00-18:00 UTC) weekdays. Off-peak: everything else.
-# Off-peak: 5h usage doubled, doesn't count against weekly.
+# Anthropic may run promotions where off-peak usage is discounted or doesn't count
+# against weekly limits. Set CLAUDE_USAGE_PROMO_START / CLAUDE_USAGE_PROMO_END
+# (ISO 8601 UTC strings) to enable off-peak tracking for a custom promo window.
+import os as _os
 now_utc = datetime.now(timezone.utc)
 is_weekday = now_utc.weekday() < 5
 is_peak_hour = is_weekday and 12 <= now_utc.hour < 18
-promo_active = datetime(2026, 3, 13, tzinfo=timezone.utc) <= now_utc <= datetime(2026, 3, 28, tzinfo=timezone.utc)
+promo_start_env = _os.environ.get('CLAUDE_USAGE_PROMO_START', '')
+promo_end_env = _os.environ.get('CLAUDE_USAGE_PROMO_END', '')
+if promo_start_env and promo_end_env:
+    promo_start = datetime.fromisoformat(promo_start_env)
+    promo_end = datetime.fromisoformat(promo_end_env)
+    promo_active = promo_start <= now_utc <= promo_end
+else:
+    promo_active = False
 off_peak = promo_active and not is_peak_hour
 result['_off_peak'] = {
     'active': off_peak,

--- a/scripts/quota-gate.sh
+++ b/scripts/quota-gate.sh
@@ -21,7 +21,16 @@ QUOTA_GATE_SESSION_THRESHOLD="${QUOTA_GATE_SESSION_THRESHOLD:-0.90}"   # 5h sess
 QUOTA_GATE_WEEKLY_THRESHOLD="${QUOTA_GATE_WEEKLY_THRESHOLD:-0.90}"     # 7d weekly window
 
 quota_gate_check() {
-    local model="${1:-}"  # optional: "sonnet" checks sonnet-specific weekly limit
+    # Parse args: supports both positional (quota_gate_check sonnet)
+    # and flag form (quota_gate_check --model sonnet)
+    local model=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --model) model="${2:-}"; shift 2 ;;
+            --model=*) model="${1#--model=}"; shift ;;
+            *) model="$1"; shift ;;
+        esac
+    done
     local log_prefix="${QUOTA_GATE_LOG_PREFIX:-[quota-gate]}"
 
     if [ ! -f "$QUOTA_CHECK_SCRIPT" ]; then


### PR DESCRIPTION
## Summary

Upstreams Bob's Claude Code subscription quota monitoring scripts to gptme-contrib so other agents (Alice, etc.) can adopt them without duplicating logic.

- **`scripts/check-claude-usage.sh`**: Reads CC's `/usage` TUI via headless tmux session. Returns 5h session, 7d weekly, and 7d-sonnet utilization as JSON. Includes off-peak detection and weekly pacing analysis. Cached (10 min TTL). Requires CC OAuth login and `ANTHROPIC_API_KEY` NOT in env.

- **`scripts/quota-gate.sh`**: Lightweight gate for autonomous run scripts. Source it and call `quota_gate_check` before starting a session — exits 1 (skip session) if quota is exhausted, 0 (proceed) if available. Logs pacing status. Thresholds configurable via env vars.

## Usage

```bash
# In autonomous-run-cc.sh
source "$WORKSPACE/gptme-contrib/scripts/quota-gate.sh"
quota_gate_check --model sonnet || { echo "Quota exhausted, skipping session"; exit 0; }
```

## Test plan
- [ ] Run `check-claude-usage.sh --json` on a logged-in CC instance
- [ ] Run `check-claude-usage.sh --raw` to debug TUI output
- [ ] Test `quota-gate.sh` sourcing: `source scripts/quota-gate.sh && quota_gate_check`
- [ ] Verify skip behavior when quota > 90%

Ref: ErikBjare/bob#476