### PR TITLE
docs(github): distinguish exit code 2 (usage error) from exit code 1 (no work) in integration pattern

### DIFF
--- a/scripts/github/README.md
+++ b/scripts/github/README.md
@@ -121,9 +121,9 @@ PENDING_STATE_DIR="${STATE_DIR}-pending"
 mkdir -p "$STATE_DIR" "$PENDING_STATE_DIR"
 rsync -a --delete "$STATE_DIR/" "$PENDING_STATE_DIR/"
 
+gate_exit=0
 work=$("$ACTIVITY_GATE" --author "$AUTHOR" --org "$ORG" \
-    --state-dir "$PENDING_STATE_DIR" --format jsonl)
-gate_exit=$?
+    --state-dir "$PENDING_STATE_DIR" --format jsonl) || gate_exit=$?
 if [ "$gate_exit" -eq 2 ]; then
     echo "Error: activity-gate.sh usage error (check AUTHOR/ORG/STATE_DIR are set)" >&2
     exit 2


### PR DESCRIPTION
## Summary

Follow-up to #532. Greptile identified a P1 issue in the integration pattern example after that PR was merged: the `||` handler silently swallows both exit code 1 (no work) and exit code 2 (usage error), masking misconfiguration when users copy the example with unset variables.

**Fix**: Capture the exit code explicitly and branch on its value:
- Exit code 2 → log to stderr and exit non-zero (surfaces usage errors)
- Other non-zero → silent skip (normal "no work" case)

## Changes

- `scripts/github/README.md`: Replace bare `||` handler with explicit exit-code check in the integration pattern example