### PR TITLE
feat(lessons): add confidence to allowed frontmatter fields

### DIFF
--- a/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
+++ b/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
@@ -172,6 +172,7 @@ class LessonValidator:
                 "deprecated_date",
                 "archived_reason",
                 "archived_date",
+                "confidence",
             }
             extra_fields = set(frontmatter.keys()) - allowed_fields
             if extra_fields:

--- a/packages/gptme-lessons-extras/tests/test_validate_confidence.py
+++ b/packages/gptme-lessons-extras/tests/test_validate_confidence.py
@@ -1,0 +1,98 @@
+"""Test that the confidence field is accepted in lesson frontmatter."""
+
+import tempfile
+from pathlib import Path
+
+from gptme_lessons_extras.validate import LessonValidator
+
+
+def _write_lesson(tmp: Path, content: str) -> Path:
+    """Write a lesson file and return its path."""
+    p = tmp / "test-lesson.md"
+    p.write_text(content)
+    return p
+
+
+def test_confidence_field_accepted():
+    """confidence block in frontmatter should not produce warnings."""
+    content = """\
+---
+match:
+  keywords:
+    - "test keyword phrase"
+status: active
+confidence:
+  score: 0.112
+  action: promote
+  evidence: 0.91
+  updated: 2026-03-24
+---
+
+# Test Lesson
+
+## Rule
+Test rule.
+
+## Context
+Test context.
+
+## Detection
+- Signal 1
+
+## Pattern
+```text
+example
+```
+
+## Outcome
+- Benefit 1
+"""
+    with tempfile.TemporaryDirectory() as tmp:
+        path = _write_lesson(Path(tmp), content)
+        validator = LessonValidator(path)
+        validator.validate()
+        # No warnings about confidence being an extra field
+        confidence_warnings = [
+            w for w in validator.warnings if "confidence" in w.lower()
+        ]
+        assert (
+            confidence_warnings == []
+        ), f"confidence field should be allowed, got warnings: {confidence_warnings}"
+
+
+def test_unknown_field_still_warned():
+    """Fields not in allowed_fields should still produce warnings."""
+    content = """\
+---
+match:
+  keywords:
+    - "test keyword phrase"
+status: active
+bogus_field: true
+---
+
+# Test Lesson
+
+## Rule
+Test rule.
+
+## Context
+Test context.
+
+## Detection
+- Signal 1
+
+## Pattern
+```text
+example
+```
+
+## Outcome
+- Benefit 1
+"""
+    with tempfile.TemporaryDirectory() as tmp:
+        path = _write_lesson(Path(tmp), content)
+        validator = LessonValidator(path)
+        validator.validate()
+        bogus_warnings = [w for w in validator.warnings if "bogus_field" in w]
+        assert len(bogus_warnings) > 0, "Unknown fields should still produce warnings"


### PR DESCRIPTION
## Summary
- Adds `confidence` to the lesson validator's `allowed_fields` set
- The lesson confidence scoring system (metaproductivity package) writes confidence metadata into lesson YAML frontmatter during automated LOO analysis
- Without this change, every scored lesson triggers a spurious "consider removing: confidence" warning

## Test plan
- [x] Added `test_confidence_field_accepted` — verifies no warnings for confidence field
- [x] Added `test_unknown_field_still_warned` — verifies unknown fields still produce warnings
- [x] Both tests pass locally