### PR TITLE
docs(validate): document frontmatter philosophy — no auto-computed scores

### DIFF
--- a/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
+++ b/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
@@ -147,6 +147,18 @@ class LessonValidator:
         """Check for required YAML frontmatter and validate structure.
 
         Ensures frontmatter exists, is valid YAML, and contains only allowed fields.
+
+        Frontmatter philosophy — only stable, human-authored metadata belongs here:
+        - ``match`` / ``status``: Core lesson routing and lifecycle fields.
+        - ``automated_by`` / ``automated_date``: Set once when a lesson is automated.
+        - ``deprecated_by`` / ``deprecated_date``: Set once on deprecation.
+        - ``archived_reason`` / ``archived_date``: Set once on archival.
+
+        Do NOT add auto-computed or frequently-updated scores here (e.g. ``confidence``,
+        ``effectiveness``, ``score``).  Such values are recalculated on every analysis
+        run, which would produce a noisy stream of lesson-file diffs and make git history
+        hard to read.  Store them in dedicated state files instead
+        (e.g. ``state/lesson-confidence/``).
         """
         if not self.content.startswith("---"):
             self.errors.append("Missing YAML frontmatter")
@@ -162,7 +174,7 @@ class LessonValidator:
                 self.errors.append("Empty frontmatter")
                 return
 
-            # Check for minimal frontmatter (should primarily be 'match' with keywords)
+            # Only stable, human-authored fields are allowed — see docstring above.
             allowed_fields = {
                 "match",
                 "status",


### PR DESCRIPTION
## Summary

Follow-up to #536 (revert of #535), addressing Erik's review comment:
> You gave a good summary, but need to incorporate the reasoning into code/docs/docstrings/comments so that it doesn't recur and we don't end up with noisy/counter/score metadata.

- Adds a detailed docstring to `_check_frontmatter` explaining *why* auto-computed fields like `confidence` must not go in lesson frontmatter
- Updates the inline comment on `allowed_fields` to reference the docstring
- No behavior change — purely documentation

The key principle documented: frontmatter must hold only stable, human-authored metadata. Auto-computed scores (confidence, effectiveness, etc.) are recalculated on every analysis run, producing noisy lesson-file diffs. They belong in state files (`state/lesson-confidence/`) not frontmatter.

## Test plan
- [x] No behavior change — existing tests still pass
- [x] Pre-commit hooks pass