### PR TITLE
feat(scripts): upstream find-dupes.py from Bob's workspace

### DIFF
--- a/scripts/find-dupes.py
+++ b/scripts/find-dupes.py
@@ -43,9 +43,6 @@ DEFAULT_SCAN_DIRS = [
     "plugins",
 ]
 
-# Cross-repo directories (absolute paths) — empty by default; use --cross-repo-dir to add
-CROSS_REPO_DIRS: list[Path] = []
-
 # Patterns to exclude
 EXCLUDE_PATTERNS = {
     "__pycache__",
@@ -193,7 +190,11 @@ def find_near_duplicates(
                 with open(report_path) as f:
                     data: dict[str, object] = json.load(f)
                     return data
-        except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+        except (
+            subprocess.TimeoutExpired,
+            FileNotFoundError,
+            json.JSONDecodeError,
+        ) as e:
             print(f"jscpd error: {e}", file=sys.stderr)
 
     return None
@@ -282,10 +283,10 @@ def main():
         # Print exact duplicates
         if exact_groups:
             print(f"\n## Exact Duplicates ({len(exact_groups)} groups)\n")
-            for i, group in enumerate(
-                sorted(exact_groups, key=lambda g: -count_lines(g[0])), 1
-            ):
-                lines = count_lines(group[0])
+            sorted_groups = sorted(
+                [(count_lines(g[0]), g) for g in exact_groups], key=lambda t: -t[0]
+            )
+            for i, (lines, group) in enumerate(sorted_groups, 1):
                 size = group[0].stat().st_size
                 print(f"### Group {i} ({lines} lines, {size} bytes)")
                 for f in group:


### PR DESCRIPTION
## Summary

- Adds `scripts/find-dupes.py` — hash-based exact duplicate finder with symlink-aware filtering and optional jscpd near-duplicate detection
- Useful for any agent to audit their workspace for duplicates and identify upstreaming candidates
- Already used in cross-repo analysis that identified `scripts/communication_utils/` duplication (gptme-contrib#538) and the `agent-msg.py` upstreaming opportunity (gptme-contrib#539)

## Usage

```bash
# Exact duplicates
python3 scripts/find-dupes.py

# Near-duplicates via jscpd
python3 scripts/find-dupes.py --near-dupes

# Filter by extension, min lines
python3 scripts/find-dupes.py --ext .py .sh --min-lines 10
```

Closes #540. Upstreamed from ErikBjare/bob#482.