### PR TITLE
fix(validate): replace 'human-authored' with 'write-once' in frontmatter docstring

### DIFF
--- a/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
+++ b/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
@@ -148,7 +148,7 @@ class LessonValidator:
 
         Ensures frontmatter exists, is valid YAML, and contains only allowed fields.
 
-        Frontmatter philosophy — only stable, human-authored metadata belongs here:
+        Frontmatter philosophy — only stable, write-once metadata belongs here:
         - ``match`` / ``status``: Core lesson routing and lifecycle fields.
         - ``automated_by`` / ``automated_date``: Set once when a lesson is automated.
         - ``deprecated_by`` / ``deprecated_date``: Set once on deprecation.
@@ -174,7 +174,7 @@ class LessonValidator:
                 self.errors.append("Empty frontmatter")
                 return
 
-            # Only stable, human-authored fields are allowed — see docstring above.
+            # Only stable, write-once fields are allowed — see docstring above.
             allowed_fields = {
                 "match",
                 "status",


### PR DESCRIPTION
Follow-up to #537, addressing Erik's inline review comments.

## Problem

The phrase `human-authored` was inaccurate: `automated_by` and `automated_date` are set by tooling, not humans. Erik flagged this in two inline comments on #537.

## Fix

Replace `human-authored` with `write-once` in both occurrences:
- Docstring: `only stable, write-once metadata belongs here`
- Inline comment: `Only stable, write-once fields are allowed`

The real principle is that frontmatter fields must be **stable and write-once** — set once and not recalculated on every analysis run. This correctly describes all allowed fields including the automation-related ones.