### PR TITLE
fix(twitter): cap max_tokens=4096 to prevent OpenRouter budget exhaustion

### DIFF
--- a/scripts/twitter/llm.py
+++ b/scripts/twitter/llm.py
@@ -451,6 +451,9 @@ def _reply_with_max_tokens(messages: list[Message], model_name: str) -> Message:
         model=api_model,
         messages=messages_dicts,  # type: ignore[arg-type]
         max_tokens=TWITTER_MAX_TOKENS,
+        # temperature=0.5: intentional — provides balanced creativity for tweet generation.
+        # 0.0 (deterministic) would produce robotic outputs; the fallback gptme reply() uses
+        # whatever the model's default is (varies by model). Explicit 0.5 is more predictable.
         temperature=0.5,
     )
 


### PR DESCRIPTION
## Problem

OpenRouter reserves the model's full `max_output` against the daily key budget per request, not actual tokens used.

For `claude-sonnet-4-5` (`max_output=64000`, `~$15/M`):
- Each request reserves: 64,000 × $15/M = **$0.96**
- Twitter loop: 48 cycles/day × ~2 LLM calls = ~96 reservations/day
- Cost at reservation: **$92/day** (vs ~$1/day actual usage)
- Result: 402 errors after ~10 requests on a $10/day key

## Fix

Add `_reply_with_max_tokens()` that calls OpenRouter directly with `max_tokens=4096`:
- Tweet evaluations/responses need ~200-500 tokens; 4096 is generous
- Reserved per request: 4,096 × $15/M = **$0.06** (16× reduction)
- Daily budget covers **160+ requests** on $10/day key
- Falls back to gptme's `reply()` if `OPENROUTER_API_KEY` is not set

## Future

Once [gptme/gptme#1828](https://github.com/gptme/gptme/pull/1828) (add `max_tokens` to `reply()`) is merged and installed, this can be simplified to:
```python
reply(messages, model.full, stream=False, max_tokens=TWITTER_MAX_TOKENS)
```

## Related

- ErikBjare/bob#479 — Twitter OAuth tracking issue where this bug was discovered
- gptme/gptme#1828 — upstream fix to add max_tokens to reply()