### PR TITLE
fix(self-merge): add greptileai to bot detection set

### DIFF
--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -474,7 +474,7 @@ def fetch_greptile_status(
 # Known bot logins (exact match, case-insensitive) to exclude when counting
 # human review threads.  GitHub Apps append "[bot]" to their login, so any
 # login ending with that suffix is also excluded.
-_BOT_EXACT_NAMES = frozenset(("greptile", "codecov", "greptile-apps"))
+_BOT_EXACT_NAMES = frozenset(("greptile", "codecov", "greptile-apps", "greptileai"))
 
 
 def _is_bot_author(author: str) -> bool:


### PR DESCRIPTION
## Problem

`_BOT_EXACT_NAMES` was missing `"greptileai"` — the Greptile reviewer account login.
This caused `fetch_unresolved_human_threads` to count Greptile's review threads as
human threads, returning `unresolved=2` instead of `1` in test fixtures.

The `[bot]` suffix check catches `greptile-apps[bot]` (the GitHub App), but
`greptileai` is a plain login without that suffix.

## Fix

Add `"greptileai"` to the `_BOT_EXACT_NAMES` frozenset (one character change).

## Impact

Fixes `test_self_merge_check::test_human_threads_counts_unresolved` on ErikBjare/bob master CI.