### PR TITLE
fix(self-merge): add greptileai to _BOT_EXACT_NAMES

### DIFF
--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -474,7 +474,7 @@ def fetch_greptile_status(
 # Known bot logins (exact match, case-insensitive) to exclude when counting
 # human review threads.  GitHub Apps append "[bot]" to their login, so any
 # login ending with that suffix is also excluded.
-_BOT_EXACT_NAMES = frozenset(("greptile", "codecov", "greptile-apps"))
+_BOT_EXACT_NAMES = frozenset(("greptile", "codecov", "greptile-apps", "greptileai"))
 
 
 def _is_bot_author(author: str) -> bool:


### PR DESCRIPTION
## Summary

`fetch_unresolved_human_threads` was not filtering `greptileai` as a bot author, causing `test_human_threads_counts_unresolved` to fail in ErikBjare/bob after the `fetch_unresolved_human_threads` function was enabled by the gptme-contrib#547 submodule bump.

## Root Cause

`_BOT_EXACT_NAMES` had `"greptile"` and `"greptile-apps"` but not `"greptileai"`. The test helper `_greptile_thread` creates threads with author `"greptileai"` (the Greptile organization login), which `_is_bot_author` did not match — so it was counted as a human unresolved thread.

**Failing assertion** (`assert 2 == 1`):
- 1 unresolved human thread (ErikBjare) → counted ✓
- 1 greptile thread (`greptileai`, unresolved) → should be skipped, was counted ✗

## Fix

Add `"greptileai"` to `_BOT_EXACT_NAMES` alongside the existing `"greptile"` and `"greptile-apps"` entries.

## Test

The existing test `test_human_threads_counts_unresolved` in `ErikBjare/bob` covers this — it will pass once this fix is included in the submodule.