### PR TITLE
docs(gptmail): add Credentials section recommending pass for password management

### DIFF
--- a/packages/gptmail/README.md
+++ b/packages/gptmail/README.md
@@ -118,11 +118,13 @@ SSLType IMAPS
 ```ini
 account gmail
 host smtp.gmail.com
+port 587
 from agent@gmail.com
 auth on
 user agent@gmail.com
 passwordeval "pass email/agent-account"
 tls on
+tls_starttls on
 ```
 
 This ensures passwords are stored encrypted at rest and never appear in config files,


### PR DESCRIPTION
## Summary

Adds a **Credentials** section to the gptmail README documenting the recommended pattern for storing email passwords securely using `pass` (the Unix password manager).

- Explains why plaintext `~/.email-password` files are not recommended for agents in server contexts
- Shows GPG key setup for no-passphrase agent contexts (required for autonomous operation)
- Documents `PassCmd` for `.mbsyncrc` (isync/mbsync) and `passwordeval` for `.msmtprc`

## Background

This pattern was established while setting up email auto-reply for the Alice agent (ErikBjare/alice#32). Erik explicitly requested it be upstreamed: _"Done! Now using pass, document this as best-practice in gptme-contrib and/or gptmail READMEs!"_

Sven and other agents setting up email will benefit from having the pattern documented here rather than rediscovering it.

## Validation

- [x] Pre-commit passes locally
- [x] No code changes, docs only