### PR TITLE
feat(sessions): add forward-progress signals — prs_submitted and issues_closed

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -338,6 +338,7 @@ def is_productive(signals: dict) -> bool:
         or len(set(signals["file_writes"])) >= 2
         or signals.get("gh_interactions", 0) >= 1
         or signals.get("prs_submitted")  # any PR submitted = productive
+        or signals.get("issues_closed", 0) >= 1  # confirmed issue close = productive
     )
 
 
@@ -372,8 +373,9 @@ def extract_signals_cc(msgs: list[dict]) -> dict:
     tool_durations: dict[str, list[float]] = {}  # tool_name → list of durations (seconds)
     # Forward-progress signals: PR submissions and issue closures.
     prs_submitted: list[str] = []  # PR numbers/URLs for PRs created this session
-    issues_closed: int = 0  # count of explicit gh issue close commands
+    issues_closed: int = 0  # count of confirmed successful gh issue close commands
     _pr_create_pending: set[str] = set()  # tool_use_ids awaiting pr create result
+    _issue_close_pending: set[str] = set()  # tool_use_ids awaiting issue close result
 
     for record in msgs:
         rec_type = record.get("type", "")
@@ -439,11 +441,14 @@ def extract_signals_cc(msgs: list[dict]) -> dict:
                     # gh pr create does not appear in _GH_INTERACTION_RE intentionally —
                     # it's a higher-value signal tracked separately as prs_submitted.
                     if _PR_CREATE_CMD_RE.search(cmd):
-                        _pr_create_pending.add(tool_id)
+                        if tool_id:  # guard against empty tool_id
+                            _pr_create_pending.add(tool_id)
 
-                    # Track explicit issue close commands as blocker-removal signals.
+                    # Track issue close commands for output-side confirmation.
+                    # Only count confirmed closes (not failed/permission-denied).
                     if _ISSUE_CLOSE_CMD_RE.search(cmd):
-                        issues_closed += 1
+                        if tool_id:
+                            _issue_close_pending.add(tool_id)
 
                     # Parse Bash commands for journal writes via cat heredoc redirects.
                     # Many CC sessions write journals via heredoc (cat > path << EOF)
@@ -581,6 +586,14 @@ def extract_signals_cc(msgs: list[dict]) -> dict:
                         url_match = _PR_CREATE_URL_RE.search(result_str)
                         if url_match:
                             prs_submitted.append(f"PR #{url_match.group(1)}")
+
+                    # gh issue close confirmation: count only when result is not an error.
+                    # is_error=True is already handled above (continue), so reaching here
+                    # means the command succeeded — unlike command-side counting, this
+                    # avoids crediting failed closes (permission errors, non-existent issues).
+                    if tool_use_id in _issue_close_pending:
+                        _issue_close_pending.discard(tool_use_id)
+                        issues_closed += 1
 
     duration_s = 0
     if len(timestamps) >= 2:

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -6286,7 +6286,7 @@ def test_extract_signals_cc_issue_close():
 
 
 def test_extract_signals_cc_issue_close_multiple():
-    """Multiple gh issue close commands accumulate in issues_closed."""
+    """Multiple confirmed gh issue close commands accumulate in issues_closed."""
     tool_id1, tool_id2 = "bash_close_001", "bash_close_002"
     msgs = [
         {
@@ -6310,9 +6310,109 @@ def test_extract_signals_cc_issue_close_multiple():
                 ],
             },
         },
+        # Both closes succeed
+        {
+            "type": "user",
+            "timestamp": "2026-03-24T10:00:03.000Z",
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": tool_id1,
+                        "is_error": False,
+                        "content": "✓ Closed issue #10",
+                    },
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": tool_id2,
+                        "is_error": False,
+                        "content": "✓ Closed issue #11",
+                    },
+                ],
+            },
+        },
     ]
     sigs = extract_signals_cc(msgs)
     assert sigs["issues_closed"] == 2
+
+
+def test_extract_signals_cc_issue_close_error_not_counted():
+    """Failed gh issue close (is_error=True) does NOT increment issues_closed."""
+    tool_id = "bash_close_fail"
+    msgs = [
+        {
+            "type": "assistant",
+            "timestamp": "2026-03-24T10:00:00.000Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": tool_id,
+                        "name": "Bash",
+                        "input": {"command": "gh issue close 999"},
+                    }
+                ],
+            },
+        },
+        {
+            "type": "user",
+            "timestamp": "2026-03-24T10:00:02.000Z",
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": tool_id,
+                        "is_error": True,  # permission denied or issue not found
+                        "content": "Error: issue not found or you lack permission",
+                    }
+                ],
+            },
+        },
+    ]
+    sigs = extract_signals_cc(msgs)
+    assert sigs["issues_closed"] == 0
+
+
+def test_extract_signals_cc_pr_create_empty_tool_id():
+    """gh pr create with empty tool_id does not cause a spurious PR to be attributed."""
+    msgs = [
+        {
+            "type": "assistant",
+            "timestamp": "2026-03-24T10:00:00.000Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "",  # empty tool_id edge case
+                        "name": "Bash",
+                        "input": {"command": "gh pr create --title 'test' --body 'body'"},
+                    }
+                ],
+            },
+        },
+        {
+            "type": "user",
+            "timestamp": "2026-03-24T10:00:05.000Z",
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "",  # empty id in result
+                        "is_error": False,
+                        "content": "https://github.com/owner/repo/pull/77\n",
+                    }
+                ],
+            },
+        },
+    ]
+    sigs = extract_signals_cc(msgs)
+    # Empty tool_id means we cannot safely attribute the URL to the right command
+    assert sigs["prs_submitted"] == []
 
 
 def test_grade_signals_pr_submitted_alone():
@@ -6387,3 +6487,27 @@ def test_is_productive_pr_submitted():
         "prs_submitted": ["PR #99"],
     }
     assert is_productive(sigs)
+
+
+def test_is_productive_issue_closed():
+    """is_productive returns True when an issue was successfully closed."""
+    sigs = {
+        "git_commits": [],
+        "file_writes": [],
+        "gh_interactions": 0,
+        "prs_submitted": [],
+        "issues_closed": 1,
+    }
+    assert is_productive(sigs)
+
+
+def test_is_productive_issue_closed_zero():
+    """is_productive returns False when issues_closed is 0 and nothing else."""
+    sigs = {
+        "git_commits": [],
+        "file_writes": [],
+        "gh_interactions": 0,
+        "prs_submitted": [],
+        "issues_closed": 0,
+    }
+    assert not is_productive(sigs)


### PR DESCRIPTION
## Summary

Adds two new trajectory signals to `extract_signals_cc()` to capture high-value work that doesn't produce direct commits:

- **`prs_submitted`** (`list[str]`): PRs created via `gh pr create` whose output contains a GitHub PR URL. Captures sessions that submit PRs from worktrees without making commits in the main repo.
- **`issues_closed`** (`int`): count of `gh issue close` commands — explicit blocker removal.

**Updated `grade_signals()`**: now uses `effective_units = commits + 1.2×prs_submitted + 0.4×issues_closed` for tier placement. Sessions that submit 2 PRs with no direct commits now grade at 0.70 (comparable to 2 commits), instead of being floor-graded at 0.25.

**Updated `is_productive()`**: returns `True` when any PR was submitted (even with no commits/writes).

**Backward compatible**: old signal dicts without the new keys grade identically (keys default to `[]` / `0`).

## Why this matters

Bob frequently submits PRs from `/tmp/worktrees/` — those sessions have `git_commits=[]` against the main brain repo. Without this fix, they were being graded at 0.25 (NOOP territory), suppressing their bandit reward signal and causing the TS model/harness selector to underestimate their productivity.

## Test plan

- [x] 10 new unit tests covering PR create detection, issue close detection, grade tiers, is_productive, and backward compat
- [x] All 259 tests pass (was 249 before)
- [x] `make typecheck` passes