### PR TITLE
fix(sessions): deduplicate commits from background task output files

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -552,21 +552,31 @@ def extract_signals_cc(msgs: list[dict]) -> dict:
                 # Other tools (Read, Glob, Write) can return content containing
                 # commit-like patterns from files, which would be false positives.
                 if tool_id_to_name.get(tool_use_id) == "Bash":
+                    # Track hashes found in result_str to deduplicate against bg file.
+                    # CC background tasks stream the full output into result_str when
+                    # the command finishes, so the commit line appears in BOTH the
+                    # direct result and the background output file. Without dedup,
+                    # the same commit gets appended twice.
+                    _direct_hashes: set[str] = set()
                     for commit_match in _COMMIT_RE.finditer(result_str):
                         commit_hash = commit_match.group(1)
                         commit_msg = commit_match.group(2).strip()
                         git_commits.append(f"{commit_msg} ({commit_hash})")
+                        _direct_hashes.add(commit_hash)
 
                     # Background bash tasks: when CC runs a command in background mode,
                     # the tool result only contains a pointer to an output file like:
                     # "Command running in background with ID: X. Output is being written to: PATH"
                     # The actual git commit output (matching _COMMIT_RE) is in that file.
+                    # Skip hashes already found in result_str to avoid double-counting.
                     for bg_match in _BG_TASK_RE.finditer(result_str):
                         bg_path = bg_match.group(1)
                         try:
                             bg_content = Path(bg_path).read_text(errors="replace")
                             for commit_match in _COMMIT_RE.finditer(bg_content):
                                 commit_hash = commit_match.group(1)
+                                if commit_hash in _direct_hashes:
+                                    continue  # already captured from result_str
                                 commit_msg = commit_match.group(2).strip()
                                 git_commits.append(f"{commit_msg} ({commit_hash})")
                         except OSError:

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -6511,3 +6511,67 @@ def test_is_productive_issue_closed_zero():
         "issues_closed": 0,
     }
     assert not is_productive(sigs)
+
+
+def test_extract_signals_cc_background_commit_no_duplicate(tmp_path: Path):
+    """Background bash commit must not be double-counted when result_str also has the output.
+
+    CC streams the full background task output into result_str when the command
+    finishes. So the commit line appears in BOTH result_str (direct scan) AND the
+    background output file (bg file scan). Without deduplication the commit is
+    appended twice.
+
+    The fix: track hashes found in result_str and skip them in the bg file scan.
+    """
+    commit_line = (
+        "[feat/my-feature a1b2c3d] feat(test): add background dedup test\n 2 files changed\n"
+    )
+    bg_output = tmp_path / "abc123.output"
+    bg_output.write_text("Some prek output\n✓ All pre-commit checks passed\n" + commit_line)
+
+    bash_id = "bash_bg_dedup_001"
+    # result_str contains BOTH the bg file pointer AND the full output (CC streaming)
+    result_content = (
+        f"Command running in background with ID: abc123. "
+        f"Output is being written to: {bg_output}\n"
+        f"Some prek output\n✓ All pre-commit checks passed\n" + commit_line
+    )
+    msgs = [
+        {
+            "type": "assistant",
+            "timestamp": "2026-03-24T10:00:00.000Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": bash_id,
+                        "name": "Bash",
+                        "input": {"command": "git safe-commit signals.py -m 'feat: add test'"},
+                    }
+                ],
+            },
+        },
+        {
+            "type": "user",
+            "timestamp": "2026-03-24T10:00:10.000Z",
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": bash_id,
+                        "is_error": False,
+                        "content": result_content,
+                    }
+                ],
+            },
+        },
+    ]
+    sigs = extract_signals_cc(msgs)
+    # Must be exactly 1, not 2
+    assert (
+        len(sigs["git_commits"]) == 1
+    ), f"Expected 1 commit, got {len(sigs['git_commits'])}: {sigs['git_commits']}"
+    assert "feat(test): add background dedup test" in sigs["git_commits"][0]
+    assert "a1b2c3d" in sigs["git_commits"][0]


### PR DESCRIPTION
## Problem

When Claude Code runs `git commit` (or `git safe-commit`) as a **background** Bash task, the commit output appears in **two places**:
1. `result_str` — CC streams the full task output when the command finishes
2. The background output file at the path in `"Output is being written to: ..."`

Without deduplication, `extract_signals_cc()` appended the same commit twice — once from the direct scan of `result_str`, and once from scanning the background output file. This inflated `effective_units` and pushed the session grade up by ~0.10.

**Observed in the wild**: session `45f591c8` (feat/fps-forward-progress-signals worktree) showed commit `653ac61` counted twice.

## Fix

Track commit hashes found in `result_str` (direct scan) and skip them when scanning the background output file:

```python
_direct_hashes: set[str] = set()
for commit_match in _COMMIT_RE.finditer(result_str):
    ...
    _direct_hashes.add(commit_hash)

# bg file scan — skip already-found hashes
for commit_match in _COMMIT_RE.finditer(bg_content):
    if commit_hash in _direct_hashes:
        continue
    ...
```

## Test

Added `test_extract_signals_cc_background_commit_no_duplicate`: constructs a tool result that contains both the bg file pointer and the full commit output (simulating CC streaming), and asserts exactly 1 commit is detected.

264 tests passing ✅

## Related

Addresses the follow-up Erik requested in gptme/gptme-contrib#556 — "better commit detection from tool outputs". The detection itself was already working; this fixes the double-counting edge case.