### PR TITLE
feat(scripts): upstream HN and GitHub trending news fetchers from Bob's workspace

### DIFF
--- a/scripts/fetch-github-trending.py
+++ b/scripts/fetch-github-trending.py
@@ -88,8 +88,12 @@ def parse_trending(html: str) -> list[dict]:
         if stars_match:
             stars = int(stars_match.group(1).replace(",", ""))
 
-        # Today's stars
-        today_match = re.search(r"([\d,]+)\s+stars?\s+today", article, re.DOTALL)
+        # Stars in selected period (GitHub renders "today", "this week", or "this month")
+        today_match = re.search(
+            r"([\d,]+)\s+stars?\s+(?:today|this\s+week|this\s+month)",
+            article,
+            re.DOTALL,
+        )
         today_stars = 0
         if today_match:
             today_stars = int(today_match.group(1).replace(",", ""))

--- a/scripts/fetch-hn-top.py
+++ b/scripts/fetch-hn-top.py
@@ -118,6 +118,8 @@ def main() -> None:
     keywords = [k.strip() for k in args.filter.split(",")] if args.filter else None
 
     stories = fetch_top_stories(args.limit)
+    if not stories:
+        sys.exit(1)
 
     if args.json:
         filtered = stories


### PR DESCRIPTION
## Summary

Upstreams two standalone news-fetching scripts from Bob's workspace to gptme-contrib, making them available for any gptme agent workspace.

- `scripts/fetch-hn-top.py` — Fetch Hacker News top stories via the official HN Firebase API (no auth). Supports limit, JSON output, keyword filtering. Pure stdlib.
- `scripts/fetch-github-trending.py` — Fetch GitHub trending repos by scraping github.com/trending (no auth). Supports language filter, daily/weekly/monthly time range, keyword filtering. Pure stdlib.

Both scripts are designed for agent news consumption sessions and produce compact, LLM-friendly output.

Changes from Bob's workspace versions:
- User-Agent updated from `gptme-bob/1.0` / `Mozilla/5.0 (compatible; gptme-bob/1.0)` to `gptme/1.0` / `Mozilla/5.0 (compatible; gptme/1.0)` for generic reuse

Closes #542

## Usage

```bash
# HN top stories
./scripts/fetch-hn-top.py --limit 15
./scripts/fetch-hn-top.py --filter "agent,llm,cli"
./scripts/fetch-hn-top.py --json

# GitHub trending
./scripts/fetch-github-trending.py --lang python
./scripts/fetch-github-trending.py --lang rust --since weekly
./scripts/fetch-github-trending.py --filter "agent,llm"
```

## Test plan

- [ ] `python3 scripts/fetch-hn-top.py --limit 5` returns formatted stories
- [ ] `python3 scripts/fetch-hn-top.py --json --limit 3` returns valid JSON
- [ ] `python3 scripts/fetch-github-trending.py --lang python` returns repos
- [ ] `python3 scripts/fetch-github-trending.py --filter "agent"` filters correctly