### PR TITLE
feat(sessions): add fine-grained gh signals and extract pr_merges

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -68,6 +68,21 @@ _PR_CREATE_URL_RE = re.compile(r"https://github\.com/[^/\s]+/[^/\s]+/pull/(\d+)"
 # Tracks explicit issue closures as a forward-progress signal (blocker removal).
 _ISSUE_CLOSE_CMD_RE = re.compile(r"\bgh\s+issue\s+close\b")
 
+# Fine-grained gh interaction regexes — split gh_interactions into signal types.
+# These are detected on the command input side (same as _GH_INTERACTION_RE).
+# The aggregate gh_interactions count is kept for backward compatibility.
+
+# PR code reviews submitted (gh pr review — higher value than plain comments)
+_GH_PR_REVIEW_CMD_RE = re.compile(r"gh\s+pr\s+review\b")
+
+# Comments posted: PR comments, issue comments, and direct API comment endpoints
+_GH_COMMENT_CMD_RE = re.compile(
+    r"gh\s+(?:pr|issue)\s+comment\b" r"|gh\s+api\s+repos/[^\s]+/(?:pulls|issues)/\d+/comments\b"
+)
+
+# Issues created (gh issue create — creation event, analogous to prs_submitted)
+_GH_ISSUE_CREATE_CMD_RE = re.compile(r"\bgh\s+issue\s+create\b")
+
 
 def parse_trajectory(jsonl_path: Path) -> list[dict]:
     """Parse a JSONL trajectory file into a list of records."""
@@ -265,10 +280,10 @@ def grade_signals(signals: dict, *, category: str | None = None) -> float:
     - Error rate penalty
     - Retry penalty
 
-    Uses *effective_units* = commits + 1.2*prs_submitted + 0.4*issues_closed
+    Uses *effective_units* = commits + 1.5*pr_merges + 1.2*prs_submitted + 0.4*issues_closed
     so that sessions with no direct commits but high forward progress (e.g.
-    submitting two PRs in worktrees) are graded comparably to commit-producing
-    sessions.
+    submitting two PRs in worktrees, or merging reviewed PRs) are graded
+    comparably to commit-producing sessions.
 
     Args:
         signals: Raw signal dict from extract_signals* functions.
@@ -292,16 +307,18 @@ def grade_signals(signals: dict, *, category: str | None = None) -> float:
     # GitHub interactions (PR reviews, issue comments) count as productive work
     gh_interactions = signals.get("gh_interactions", 0)
 
-    # Forward-progress signals: PR submissions and issue closures.
+    # Forward-progress signals: PR merges, submissions, and issue closures.
     # These represent high-value work that may not produce direct commits
     # (e.g. PRs submitted from /tmp/worktrees without touching the main repo).
+    pr_merges = len(signals.get("pr_merges", []))
     prs_submitted = len(signals.get("prs_submitted", []))
     issues_closed = signals.get("issues_closed", 0)
 
     # Effective work units: weighted sum of all forward-progress signals.
-    # Weights reflect relative value: commit=1.0, PR submit=1.2, issue close=0.4.
-    # PR submission scored slightly above a commit because it bundles work + review loop.
-    effective_units = commits + 1.2 * prs_submitted + 0.4 * issues_closed
+    # Weights reflect relative value: merge=1.5, commit=1.0, PR submit=1.2, issue close=0.4.
+    # Merges scored above commits because they close a review loop (PR submit + reviewer feedback
+    # + address + merge). PR submission scored above a commit for similar compound-work reasons.
+    effective_units = commits + 1.5 * pr_merges + 1.2 * prs_submitted + 0.4 * issues_closed
 
     # Categories where gh_interactions and file_writes are the PRIMARY output,
     # not commits. For these, a single useful interaction is sufficient for the
@@ -354,6 +371,7 @@ def is_productive(signals: dict) -> bool:
         or len(set(signals["file_writes"])) >= 2
         or signals.get("gh_interactions", 0) >= 1
         or signals.get("prs_submitted")  # any PR submitted = productive
+        or signals.get("pr_merges")  # any PR merged = productive
         or signals.get("issues_closed", 0) >= 1  # confirmed issue close = productive
     )
 
@@ -387,9 +405,16 @@ def extract_signals_cc(msgs: list[dict]) -> dict:
     # Per-tool-call timing: map tool_use_id → (tool_name, dispatch_timestamp, batch_size)
     tool_dispatch: dict[str, tuple[str, datetime, int]] = {}
     tool_durations: dict[str, list[float]] = {}  # tool_name → list of durations (seconds)
-    # Forward-progress signals: PR submissions and issue closures.
+    # Forward-progress signals: PR submissions, merges, and issue closures.
     prs_submitted: list[str] = []  # PR numbers/URLs for PRs created this session
+    pr_merges: list[
+        str
+    ] = []  # PR numbers confirmed merged this session (higher weight than submit)
     issues_closed: int = 0  # count of confirmed successful gh issue close commands
+    # Fine-grained gh interaction signals (alongside aggregate gh_interactions).
+    reviews_submitted: int = 0  # count of gh pr review commands (code review)
+    comments_posted: int = 0  # count of gh pr/issue comment + api comment posts
+    issues_created: int = 0  # count of gh issue create commands
     _pr_create_pending: set[str] = set()  # tool_use_ids awaiting pr create result
     _issue_close_pending: set[str] = set()  # tool_use_ids awaiting issue close result
 
@@ -452,6 +477,15 @@ def extract_signals_cc(msgs: list[dict]) -> dict:
                     cmd = item.get("input", {}).get("command", "")
                     if _GH_INTERACTION_RE.search(cmd):
                         gh_interactions += 1
+
+                    # Fine-grained gh interaction signal tracking.
+                    # Populated alongside the aggregate gh_interactions count.
+                    if _GH_PR_REVIEW_CMD_RE.search(cmd):
+                        reviews_submitted += 1
+                    if _GH_COMMENT_CMD_RE.search(cmd):
+                        comments_posted += 1
+                    if _GH_ISSUE_CREATE_CMD_RE.search(cmd):
+                        issues_created += 1
 
                     # Track PR creation commands for output-side URL detection.
                     # gh pr create does not appear in _GH_INTERACTION_RE intentionally —
@@ -601,9 +635,12 @@ def extract_signals_cc(msgs: list[dict]) -> dict:
                     # gh pr merge detection: output format is
                     # "✓ Squashed and merged pull request #N (title)"
                     # which doesn't match _COMMIT_RE (no branch/hash format).
+                    # Tracked separately from git_commits so grade_signals can
+                    # weight merges at 1.5× (closing a review loop is higher-value
+                    # than a standalone commit).
                     for merge_match in _PR_MERGE_RE.finditer(result_str):
                         pr_num = merge_match.group(1)
-                        git_commits.append(f"merge PR #{pr_num}")
+                        pr_merges.append(f"PR #{pr_num}")
 
                     # gh pr create detection: successful output contains a PR URL.
                     # Only check when this tool_use_id was flagged as a pr create command.
@@ -625,7 +662,10 @@ def extract_signals_cc(msgs: list[dict]) -> dict:
     if len(timestamps) >= 2:
         duration_s = int((max(timestamps) - min(timestamps)).total_seconds())
 
-    deliverables = list(dict.fromkeys(git_commits + file_writes))
+    # pr_merges entries in deliverables: "merge PR #N" format for readability
+    deliverables = list(
+        dict.fromkeys(git_commits + [f"merge {m}" for m in pr_merges] + file_writes)
+    )
 
     # Summarize per-tool-call timing: total and max per tool name.
     # Enables detection of slow tests, long pre-commit hooks, and stalled tools.
@@ -651,7 +691,11 @@ def extract_signals_cc(msgs: list[dict]) -> dict:
         "retry_count": len(retry_candidates),
         "gh_interactions": gh_interactions,
         "prs_submitted": prs_submitted,
+        "pr_merges": pr_merges,
         "issues_closed": issues_closed,
+        "reviews_submitted": reviews_submitted,
+        "comments_posted": comments_posted,
+        "issues_created": issues_created,
         "deliverables": deliverables,
     }
 

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -851,7 +851,7 @@ def test_extract_signals_cc_background_bash_commits(tmp_path: Path):
 
 
 def test_extract_signals_cc_gh_pr_merge():
-    """CC trajectory: gh pr merge success output is detected as a commit signal."""
+    """CC trajectory: gh pr merge success output is detected as a pr_merges signal."""
     bash_id = "bash_merge_001"
     msgs = [
         {
@@ -886,8 +886,11 @@ def test_extract_signals_cc_gh_pr_merge():
         },
     ]
     sigs = extract_signals_cc(msgs)
-    assert len(sigs["git_commits"]) == 1
-    assert "merge PR #1725" in sigs["git_commits"][0]
+    # Merges are now in pr_merges (not git_commits) for distinct grade weighting
+    assert len(sigs["git_commits"]) == 0
+    assert sigs["pr_merges"] == ["PR #1725"]
+    # deliverables still includes the merge
+    assert any("merge PR #1725" in d for d in sigs["deliverables"])
 
 
 @pytest.mark.parametrize(
@@ -934,8 +937,117 @@ def test_extract_signals_cc_gh_pr_merge_variants(merge_output: str):
         },
     ]
     sigs = extract_signals_cc(msgs)
-    assert len(sigs["git_commits"]) == 1
-    assert "merge PR #42" in sigs["git_commits"][0]
+    # Merges are now in pr_merges (not git_commits) for distinct grade weighting
+    assert len(sigs["git_commits"]) == 0
+    assert sigs["pr_merges"] == ["PR #42"]
+    assert any("merge PR #42" in d for d in sigs["deliverables"])
+
+
+def _make_bash_exchange(cmd: str, result: str, bash_id: str = "bash_001") -> list[dict]:
+    """Helper: build a minimal CC assistant+user pair for a single Bash call."""
+    return [
+        {
+            "type": "assistant",
+            "timestamp": "2026-03-21T11:00:00.000Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": bash_id, "name": "Bash", "input": {"command": cmd}}
+                ],
+            },
+        },
+        {
+            "type": "user",
+            "timestamp": "2026-03-21T11:00:05.000Z",
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": bash_id,
+                        "is_error": False,
+                        "content": result,
+                    }
+                ],
+            },
+        },
+    ]
+
+
+def test_extract_signals_cc_reviews_submitted():
+    """gh pr review commands increment reviews_submitted (and gh_interactions)."""
+    sigs = extract_signals_cc(_make_bash_exchange("gh pr review 42 --approve", "Approved"))
+    assert sigs["reviews_submitted"] == 1
+    assert sigs["gh_interactions"] >= 1  # aggregate still counted
+
+
+def test_extract_signals_cc_comments_posted_pr():
+    """gh pr comment increments comments_posted."""
+    sigs = extract_signals_cc(
+        _make_bash_exchange("gh pr comment 42 --body 'LGTM'", "Added comment")
+    )
+    assert sigs["comments_posted"] == 1
+    assert sigs["gh_interactions"] >= 1
+
+
+def test_extract_signals_cc_comments_posted_issue():
+    """gh issue comment increments comments_posted."""
+    sigs = extract_signals_cc(
+        _make_bash_exchange("gh issue comment 99 --body 'Fixed'", "Added comment")
+    )
+    assert sigs["comments_posted"] == 1
+
+
+def test_extract_signals_cc_issues_created():
+    """gh issue create increments issues_created (and gh_interactions aggregate)."""
+    sigs = extract_signals_cc(
+        _make_bash_exchange(
+            "gh issue create --title 'Bug' --body 'desc'",
+            "https://github.com/org/repo/issues/123",
+        )
+    )
+    assert sigs["issues_created"] == 1
+    assert sigs["gh_interactions"] >= 1  # aggregate still counted
+
+
+def test_extract_signals_cc_pr_merge_grade():
+    """PR merges score at 1.5x in grade_signals (above PR submit at 1.2x)."""
+    # A session that merges one PR should grade higher than one that only submits one PR
+    sigs_merge = {
+        "git_commits": [],
+        "file_writes": [],
+        "error_count": 0,
+        "retry_count": 0,
+        "tool_calls": {"Bash": 1},
+        "pr_merges": ["PR #10"],
+        "prs_submitted": [],
+        "issues_closed": 0,
+        "gh_interactions": 1,
+    }
+    sigs_submit = {
+        "git_commits": [],
+        "file_writes": [],
+        "error_count": 0,
+        "retry_count": 0,
+        "tool_calls": {"Bash": 1},
+        "pr_merges": [],
+        "prs_submitted": ["PR #10"],
+        "issues_closed": 0,
+        "gh_interactions": 1,
+    }
+    assert grade_signals(sigs_merge) > grade_signals(sigs_submit)
+
+
+def test_extract_signals_cc_pr_merge_not_in_git_commits():
+    """PR merges are in pr_merges, NOT in git_commits (to avoid double-counting)."""
+    msgs = _make_bash_exchange(
+        "gh pr merge 99 --squash",
+        "✓ Squashed and merged pull request #99 (feat: new thing)",
+    )
+    sigs = extract_signals_cc(msgs)
+    assert sigs["pr_merges"] == ["PR #99"]
+    assert all("merge PR" not in c for c in sigs["git_commits"])
+    assert any("merge PR #99" in d for d in sigs["deliverables"])
 
 
 def test_grade_signals_dead_session():


### PR DESCRIPTION
## Summary

Phase 2 of ErikBjare/bob#499 — improve signal extraction fidelity for better Thompson sampling rewards.

**Fine-grained gh interaction signals** (split from `gh_interactions`):
- `reviews_submitted`: `gh pr review` commands (code review work, highest-value gh signal)
- `comments_posted`: `gh pr/issue comment` + API comment endpoints
- `issues_created`: `gh issue create` (creation events, parallel to `prs_submitted`)

The aggregate `gh_interactions` count is unchanged for backward compatibility.

**Extract `pr_merges` as a distinct signal:**
- Merges (`gh pr merge` → "✓ Squashed and merged…") are now tracked in `pr_merges` instead of `git_commits`
- `grade_signals` weights merges at **1.5×** (closing a review loop is higher-value than a standalone commit, vs 1.2× for PR submit, 1.0× for commit)
- `deliverables` still includes `"merge PR #N"` entries
- `is_productive()` checks `pr_merges` alongside `prs_submitted`

**Tests:** 8 new tests, 2 existing tests updated for the `git_commits` → `pr_merges` move. All 482 tests pass.

Phase 1 landed in #556 and #562. This is Phase 2.

## Test plan
- [x] `uv run pytest packages/gptme-sessions/tests/` — all 482 pass
- [x] `test_extract_signals_cc_reviews_submitted` — `gh pr review` → `reviews_submitted`
- [x] `test_extract_signals_cc_comments_posted_pr/issue` — comment signals
- [x] `test_extract_signals_cc_issues_created` — `gh issue create` signal
- [x] `test_extract_signals_cc_pr_merge_grade` — merges grade higher than submits
- [x] `test_extract_signals_cc_pr_merge_not_in_git_commits` — clean separation