### PR TITLE
feat(scripts): add gptme-lessons-mcp MCP server for lesson discovery

### DIFF
--- a/scripts/gptme-lessons-mcp.py
+++ b/scripts/gptme-lessons-mcp.py
@@ -165,11 +165,10 @@ def load_lessons(lessons_dir: Path, state_file: Path | None = None) -> list[Less
     if state_file and state_file.exists():
         try:
             data = json.loads(state_file.read_text())
-            # Expected format: {"lesson_name.md": score, ...}
+            # Expected format: {"category/stem": score, ...} (e.g. "workflow/autonomous-run")
             effectiveness = {
                 k: v for k, v in data.items() if isinstance(v, int | float)
             }
-            # Expected format: {"category/stem": score, ...} (e.g. "workflow/autonomous-run")
         except (json.JSONDecodeError, OSError):
             pass
 


### PR DESCRIPTION
## Summary

- Adds `scripts/gptme-lessons-mcp.py`: a FastMCP server that exposes gptme lessons as queryable MCP resources
- Any MCP-capable agent (Claude Code, Cursor, Cq, etc.) can search and retrieve lessons regardless of framework
- Addresses the cross-agent lesson sharing gap: lessons are currently per-agent, not accessible to other frameworks

## Features

**Resources:**
- `lessons://index` — full index of all lessons with metadata
- `lessons://category/{name}` — all lessons in a category
- `lessons://lesson/{id}` — full content of a specific lesson

**Tools:**
- `search_lessons(query, category?)` — keyword/title search
- `get_effective_lessons(min_effectiveness?)` — filter by LOO effectiveness score
- `get_lesson_context(situation)` — get relevant lessons for a described situation
- `list_categories()` — list all categories with counts

## Usage

```bash
# List loaded lessons
python3 scripts/gptme-lessons-mcp.py --list --lessons-dir /path/to/lessons

# Run MCP server
python3 scripts/gptme-lessons-mcp.py --lessons-dir /path/to/lessons
```

Configure in Claude Code `settings.json`:
```json
{
  "mcpServers": {
    "gptme-lessons": {
      "command": "python3",
      "args": ["path/to/gptme-lessons-mcp.py", "--lessons-dir", "~/bob/lessons"]
    }
  }
}
```

## Design

Design doc: `knowledge/technical-designs/gptme-lessons-mcp.md` (in Bob's workspace)

Motivated by [Cq](https://github.com/mozilla-ai/cq) (Mozilla AI) — an MCP-based knowledge sharing system. gptme lessons are essentially Knowledge Units that could be queryable by any agent.

## Test plan

- [x] `--list` runs without errors (loads 146 lessons from workspace)
- [x] `search_lessons_by_query("autonomous session")` returns correct results
- [x] `search_lessons_by_query("pre-commit hook")` returns correct result
- [x] Keyword extraction handles nested `match.keywords` YAML frontmatter
- [x] Ruff/mypy/pre-commit all pass