### PR TITLE
fix(twitter): restore parent sys.path for twitter package imports

### DIFF
--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -31,9 +31,10 @@ import email.message  # noqa: F401
 import sys
 from pathlib import Path as _Path
 
-# Add current directory to path FIRST so local twitter/ is found
-# This prevents conflict with any installed 'twitter' package
+# Add current directory to path FIRST so local imports (trusted_users etc.) are found
 sys.path.insert(0, str(_Path(__file__).parent))
+# Add parent directory so `from twitter.llm import ...` resolves to scripts/twitter/
+sys.path.insert(0, str(_Path(__file__).parent.parent))
 
 import json
 import logging


### PR DESCRIPTION
## Summary

Fixes a regression introduced in #559 (migration of `communication_utils` to gptmail).

**Root cause**: commit ce005cd removed the `sys.path.insert(parent.parent)` line when it was no longer needed for `communication_utils`. But `parent.parent` (`scripts/`) was also required for `from twitter.llm import ...` and `from twitter.twitter import ...` to work — these imports expect to find the `scripts/twitter/` directory as a Python package named `twitter`.

Without `parent.parent` in `sys.path`, Python finds `twitter.py` (a file/module) in `scripts/twitter/` instead of the `twitter/` directory (a package), causing:
```
ModuleNotFoundError: No module named 'twitter.llm'; 'twitter' is not a package
```

This broke the twitter loop starting 2026-03-24, stopping all tweet monitoring and posting.

**Fix**: Restore the second `sys.path.insert` with updated comment to clarify its purpose.

## Test plan
- [ ] Verify `workflow.py auto` runs without the ModuleNotFoundError
- [ ] Twitter loop resumes posting after deploy