### PR TITLE
fix(twitter): skip interactive OAuth 2.0 flow in headless/auto mode

### DIFF
--- a/scripts/twitter/twitter.py
+++ b/scripts/twitter/twitter.py
@@ -103,8 +103,17 @@ def cached_get_me(client, user_auth: bool = False):
     return client.get_me(user_auth=user_auth)
 
 
-def load_twitter_client(require_auth: bool = False) -> tweepy.Client:
+def load_twitter_client(
+    require_auth: bool = False, headless: bool = False
+) -> tweepy.Client:
     """Initialize Twitter client with credentials from .env
+
+    Args:
+        require_auth: If True, authenticate with user context (needed for posting).
+        headless: If True, skip interactive OAuth 2.0 flow (browser-based) and
+            fall back directly to OAuth 1.0a when the saved token/refresh fails.
+            Use this in automated/headless environments where no user can interact
+            with a browser.
 
     Note: We use override=True with load_dotenv() to ensure we always get
     the latest tokens from .env. This is critical because after token refresh,
@@ -218,122 +227,135 @@ def load_twitter_client(require_auth: bool = False) -> tweepy.Client:
                         return client
                 except Exception as e:
                     console.print(f"[yellow]Saved token/refresh failed: {e}")
-                    console.print("[yellow]Starting new OAuth 2.0 flow...")
+                    if headless:
+                        console.print(
+                            "[yellow]Headless mode — skipping interactive OAuth 2.0, falling back to OAuth 1.0a"
+                        )
+                    else:
+                        console.print("[yellow]Starting new OAuth 2.0 flow...")
             elif saved_token:
                 console.print(
                     "[yellow]Saved token exists but missing refresh token or expiry"
                 )
-                console.print(
-                    "[yellow]Starting new OAuth 2.0 flow to get complete credentials..."
-                )
-
-            try:
-                # Initialize OAuth 2.0 handler
-                oauth2_user_handler = tweepy.OAuth2UserHandler(
-                    client_id=client_id,
-                    client_secret=client_secret,
-                    redirect_uri="http://localhost:9876/callback",
-                    scope=[
-                        "tweet.read",
-                        "tweet.write",
-                        "users.read",
-                        "follows.write",
-                        "offline.access",
-                    ],
-                )
-
-                # Get authorization URL and provide it to the user
-                auth_url = oauth2_user_handler.get_authorization_url()
-                console.print(
-                    "[yellow]Please open this URL in your browser to authorize the application:"
-                )
-                console.print(f"[blue]{auth_url}")
-
-                # Wait for OAuth callback using shared utility
-                console.print(
-                    "[yellow]Waiting for authorization (timeout: 5 minutes)..."
-                )
-                try:
-                    response_code, full_url = run_oauth_callback(port=9876, timeout=300)
-                    console.print("[green]Authorization received!")
-                except TimeoutError as e:
-                    console.print("[red]Error: Authorization timeout")
-                    console.print(f"[red]Details: {str(e)}")
-                    raise
-                except Exception as e:
-                    console.print("[red]Error: Authorization failed")
-                    console.print(f"[red]Details: {str(e)}")
-                    raise
-
-                # Get access token using the full callback URL
-                access_token = oauth2_user_handler.fetch_token(
-                    authorization_response=full_url
-                )
-                print(f"{access_token=}")
-
-                # Save all tokens to .env using shared utility
-                try:
-                    save_token_to_env(
-                        "TWITTER_OAUTH2_ACCESS_TOKEN",
-                        access_token["access_token"],
-                        comment="OAuth 2.0 User Context access token",
-                    )
-
-                    # Save refresh token if present
-                    if "refresh_token" in access_token:
-                        save_token_to_env(
-                            "TWITTER_OAUTH2_REFRESH_TOKEN",
-                            access_token["refresh_token"],
-                            comment="OAuth 2.0 refresh token",
-                        )
-
-                    # Calculate and save expiration time
-                    if "expires_in" in access_token:
-                        expires_at = datetime.now() + timedelta(
-                            seconds=access_token["expires_in"]
-                        )
-                        save_token_to_env(
-                            "TWITTER_OAUTH2_EXPIRES_AT",
-                            expires_at.isoformat(),
-                            comment="OAuth 2.0 token expiration time",
-                        )
-
-                    if "refresh_token" in access_token:
-                        console.print(
-                            "[yellow]Saved OAuth 2.0 tokens with refresh capability"
-                        )
-                    else:
-                        console.print(
-                            "[yellow]Warning: No refresh token received (add 'offline.access' scope)"
-                        )
-                except Exception as e:
-                    console.print(f"[red]Error saving token: {str(e)}")
-                    sys.exit(1)
-
-                # Create client with OAuth 2.0 User Context authentication
-                client = tweepy.Client(
-                    access_token[
-                        "access_token"
-                    ],  # Pass access token directly as first argument
-                    wait_on_rate_limit=True,
-                )
-
-                # Test the credentials with OAuth 2.0
-                test = cached_get_me(client, user_auth=False)
-                if test.data:
+                if headless:
                     console.print(
-                        f"[green]Successfully authenticated as @{test.data.username}"
+                        "[yellow]Headless mode — skipping interactive OAuth 2.0, falling back to OAuth 1.0a"
                     )
-                    return client
                 else:
                     console.print(
-                        "[red]Could not get user info after OAuth 2.0 authentication"
+                        "[yellow]Starting new OAuth 2.0 flow to get complete credentials..."
                     )
-                    sys.exit(1)
 
-            except tweepy.TweepyException as e:
-                console.print(f"[red]OAuth 2.0 authentication failed: {str(e)}")
-                console.print("[yellow]Falling back to OAuth 1.0a...")
+            if not headless:
+                try:
+                    # Initialize OAuth 2.0 handler
+                    oauth2_user_handler = tweepy.OAuth2UserHandler(
+                        client_id=client_id,
+                        client_secret=client_secret,
+                        redirect_uri="http://localhost:9876/callback",
+                        scope=[
+                            "tweet.read",
+                            "tweet.write",
+                            "users.read",
+                            "follows.write",
+                            "offline.access",
+                        ],
+                    )
+
+                    # Get authorization URL and provide it to the user
+                    auth_url = oauth2_user_handler.get_authorization_url()
+                    console.print(
+                        "[yellow]Please open this URL in your browser to authorize the application:"
+                    )
+                    console.print(f"[blue]{auth_url}")
+
+                    # Wait for OAuth callback using shared utility
+                    console.print(
+                        "[yellow]Waiting for authorization (timeout: 5 minutes)..."
+                    )
+                    try:
+                        response_code, full_url = run_oauth_callback(
+                            port=9876, timeout=300
+                        )
+                        console.print("[green]Authorization received!")
+                    except TimeoutError as e:
+                        console.print("[red]Error: Authorization timeout")
+                        console.print(f"[red]Details: {str(e)}")
+                        raise
+                    except Exception as e:
+                        console.print("[red]Error: Authorization failed")
+                        console.print(f"[red]Details: {str(e)}")
+                        raise
+
+                    # Get access token using the full callback URL
+                    access_token = oauth2_user_handler.fetch_token(
+                        authorization_response=full_url
+                    )
+                    print(f"{access_token=}")
+
+                    # Save all tokens to .env using shared utility
+                    try:
+                        save_token_to_env(
+                            "TWITTER_OAUTH2_ACCESS_TOKEN",
+                            access_token["access_token"],
+                            comment="OAuth 2.0 User Context access token",
+                        )
+
+                        # Save refresh token if present
+                        if "refresh_token" in access_token:
+                            save_token_to_env(
+                                "TWITTER_OAUTH2_REFRESH_TOKEN",
+                                access_token["refresh_token"],
+                                comment="OAuth 2.0 refresh token",
+                            )
+
+                        # Calculate and save expiration time
+                        if "expires_in" in access_token:
+                            expires_at = datetime.now() + timedelta(
+                                seconds=access_token["expires_in"]
+                            )
+                            save_token_to_env(
+                                "TWITTER_OAUTH2_EXPIRES_AT",
+                                expires_at.isoformat(),
+                                comment="OAuth 2.0 token expiration time",
+                            )
+
+                        if "refresh_token" in access_token:
+                            console.print(
+                                "[yellow]Saved OAuth 2.0 tokens with refresh capability"
+                            )
+                        else:
+                            console.print(
+                                "[yellow]Warning: No refresh token received (add 'offline.access' scope)"
+                            )
+                    except Exception as e:
+                        console.print(f"[red]Error saving token: {str(e)}")
+                        sys.exit(1)
+
+                    # Create client with OAuth 2.0 User Context authentication
+                    client = tweepy.Client(
+                        access_token[
+                            "access_token"
+                        ],  # Pass access token directly as first argument
+                        wait_on_rate_limit=True,
+                    )
+
+                    # Test the credentials with OAuth 2.0
+                    test = cached_get_me(client, user_auth=False)
+                    if test.data:
+                        console.print(
+                            f"[green]Successfully authenticated as @{test.data.username}"
+                        )
+                        return client
+                    else:
+                        console.print(
+                            "[red]Could not get user info after OAuth 2.0 authentication"
+                        )
+                        sys.exit(1)
+
+                except tweepy.TweepyException as e:
+                    console.print(f"[red]OAuth 2.0 authentication failed: {str(e)}")
+                    console.print("[yellow]Falling back to OAuth 1.0a...")
 
         # Fall back to OAuth 1.0a if OAuth 2.0 fails or isn't configured
         console.print("[yellow]Debug: Using OAuth 1.0a authentication")

--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -1377,7 +1377,9 @@ def process_timeline_tweets(
                             f"[green]Auto-posting reply to trusted user @{author_username}"
                         )
                         try:
-                            client_for_post = load_twitter_client(require_auth=True)
+                            client_for_post = load_twitter_client(
+                                require_auth=True, headless=True
+                            )
                             post_response = client_for_post.create_tweet(
                                 text=draft.text,
                                 in_reply_to_tweet_id=draft.in_reply_to,
@@ -1522,7 +1524,7 @@ def monitor(
     console.print(f"[blue]Draft limit: {max_drafts}")
 
     # Initialize Twitter client
-    client = load_twitter_client(require_auth=True)
+    client = load_twitter_client(require_auth=True, headless=True)
 
     def check_timeline():
         """Check timeline and generate drafts"""
@@ -1667,7 +1669,7 @@ def auto(
 
     # Step 1: Monitor sources and generate drafts
     console.print("\n[bold]Step 1: Monitoring for new content[/bold]")
-    client = load_twitter_client(require_auth=True)
+    client = load_twitter_client(require_auth=True, headless=True)
 
     # Get our user ID for mentions
     me = cached_get_me(client, user_auth=False)


### PR DESCRIPTION
## Summary
- Add `headless` parameter to `load_twitter_client()` in `scripts/twitter/twitter.py`
- When `headless=True` and saved OAuth 2.0 token/refresh fails, skip the interactive browser-based OAuth 2.0 flow (which opens a browser and waits 5 minutes for a callback on port 9876) and fall back directly to OAuth 1.0a
- Pass `headless=True` from all automated call sites in `workflow.py` (`auto`, `monitor`, auto-post for trusted users)
- Interactive CLI commands (`post`) retain the default `headless=False` so the browser flow still works when a user is present

## Problem
In automated/headless mode (e.g. `workflow.py auto`), when the saved OAuth 2.0 token refresh fails, the code attempts an interactive OAuth 2.0 flow that opens a browser and waits for a callback on localhost:9876 with a 300-second timeout. This always fails in headless environments, wasting 5 minutes before eventually falling back to OAuth 1.0a anyway.

## Test plan
- [ ] Verify `workflow.py auto` skips interactive OAuth 2.0 when token refresh fails and falls back to OAuth 1.0a immediately
- [ ] Verify `workflow.py post` still attempts interactive OAuth 2.0 flow when token refresh fails (headless defaults to False)
- [ ] Verify normal OAuth 2.0 token refresh (non-expired saved tokens) still works in both modes