### PR TITLE
feat(activity-summary): rename CLI entrypoint to gptme-activity-summary

### DIFF
--- a/packages/gptme-activity-summary/README.md
+++ b/packages/gptme-activity-summary/README.md
@@ -24,16 +24,16 @@ pip install gptme-activity-summary
 
 ```bash
 # Daily summary
-summarize daily --date yesterday
+gptme-activity-summary daily --date yesterday
 
 # Weekly summary
-summarize weekly --week last
+gptme-activity-summary weekly --week last
 
 # Monthly summary
-summarize monthly --month last
+gptme-activity-summary monthly --month last
 
 # Smart mode (auto-triggers weekly/monthly when appropriate)
-summarize smart --date yesterday
+gptme-activity-summary smart --date yesterday
 ```
 
 ### GitHub User Mode (human activity)
@@ -42,16 +42,16 @@ Summarize any GitHub user's activity without requiring a journal or agent worksp
 
 ```bash
 # Weekly GitHub activity summary
-summarize github --user ErikBjare --period weekly
+gptme-activity-summary github --user ErikBjare --period weekly
 
 # Monthly summary
-summarize github --user ErikBjare --period monthly
+gptme-activity-summary github --user ErikBjare --period monthly
 
 # Raw data (no LLM summarization)
-summarize github --user ErikBjare --period weekly --raw
+gptme-activity-summary github --user ErikBjare --period weekly --raw
 
 # Custom date range reference
-summarize github --user ErikBjare --period weekly --date 2026-02-10
+gptme-activity-summary github --user ErikBjare --period weekly --date 2026-02-10
 ```
 
 ## Integration with gptme

--- a/packages/gptme-activity-summary/pyproject.toml
+++ b/packages/gptme-activity-summary/pyproject.toml
@@ -44,7 +44,8 @@ test = [
 ]
 
 [project.scripts]
-summarize = "gptme_activity_summary.cli:main"
+gptme-activity-summary = "gptme_activity_summary.cli:main"
+summarize = "gptme_activity_summary.cli:main"  # deprecated alias
 
 [build-system]
 requires = ["hatchling"]

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cli.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cli.py
@@ -4,17 +4,17 @@ CLI for activity summarization — journals, GitHub, sessions, tweets, email.
 Supports two modes:
 
 Agent mode (journal-based, default):
-    summarize daily [--date DATE]
-    summarize weekly [--week WEEK]
-    summarize monthly [--month MONTH]
-    summarize smart [--date DATE]  # Daily job that auto-runs weekly/monthly when due
-    summarize backfill [--from DATE] [--to DATE]
-    summarize stats
+    gptme-activity-summary daily [--date DATE]
+    gptme-activity-summary weekly [--week WEEK]
+    gptme-activity-summary monthly [--month MONTH]
+    gptme-activity-summary smart [--date DATE]  # Daily job that auto-runs weekly/monthly when due
+    gptme-activity-summary backfill [--from DATE] [--to DATE]
+    gptme-activity-summary stats
 
 Human mode (AW time tracking + optional GitHub):
-    summarize daily --mode human [--date DATE] [--github-user USER] [--raw]
-    summarize weekly --mode human [--week WEEK] [--github-user USER] [--raw]
-    summarize monthly --mode human [--month MONTH] [--github-user USER] [--raw]
+    gptme-activity-summary daily --mode human [--date DATE] [--github-user USER] [--raw]
+    gptme-activity-summary weekly --mode human [--week WEEK] [--github-user USER] [--raw]
+    gptme-activity-summary monthly --mode human [--month MONTH] [--github-user USER] [--raw]
 
 All summarization uses Claude Code backend for high-quality results.
 """


### PR DESCRIPTION
## Summary

- Rename the primary CLI entrypoint from `summarize` to `gptme-activity-summary` — the old name is too generic and doesn't identify what tool it belongs to
- Keep `summarize` as a deprecated alias in `pyproject.toml` for backwards compatibility
- Update README examples and CLI docstring to use the new command name

## Test plan

- [ ] Install package and verify `gptme-activity-summary --help` works
- [ ] Verify `summarize --help` still works as backwards-compatible alias
- [ ] Check that all subcommands (daily, weekly, monthly, smart, github) work under the new name