### PR TITLE
docs(lessons): polish Greptile helper guidance

### DIFF
--- a/lessons/tools/greptile-pr-reviews.md
+++ b/lessons/tools/greptile-pr-reviews.md
@@ -39,6 +39,7 @@ bash scripts/github/greptile-helper.sh trigger OWNER/REPO PR_NUMBER
 
 # Or inspect state first
 bash scripts/github/greptile-helper.sh status OWNER/REPO PR_NUMBER
+# Read-only: inspect state before deciding whether to trigger
 # Returns: already-reviewed | needs-re-review | in-progress | awaiting-initial-review
 ```
 
@@ -60,7 +61,7 @@ The helper centralizes the anti-spam guards:
 - fail-safe handling for API/rate-limit errors
 - re-review logic only when new commits exist after a low-scoring review
 
-Greptile should auto-review new PRs. Use the helper only for re-review after improvements, or when the helper explicitly indicates `needs-re-review`.
+Greptile should auto-review new PRs. Use the helper only for re-review after improvements, or when the helper explicitly indicates `needs-re-review`. `status` is safe for inspection; `trigger` is the only mutation path.
 
 ## Outcome
 Following this pattern results in:


### PR DESCRIPTION
## Summary
- carry over the two post-merge review-fix commits that were pushed after #570 was squash-merged
- make the rule benefit-first instead of prohibition-first
- document the real `status` outputs and clarify that `status` is read-only while `trigger` is the only mutation path

## Context
#570 merged at commit `52072e2`, but the follow-up review-fix commits (`9045f9f`, `cdf6242`) were left only on the branch tip and never reached `master`. This PR applies those fixes on top of current `master`.

## Validation
- `prek run --files lessons/tools/greptile-pr-reviews.md`
- `python3 packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py lessons/tools/greptile-pr-reviews.md`
