### PR TITLE
fix(twitter): log headless OAuth fallback when no token exists

### DIFF
--- a/scripts/twitter/twitter.py
+++ b/scripts/twitter/twitter.py
@@ -245,6 +245,10 @@ def load_twitter_client(
                     console.print(
                         "[yellow]Starting new OAuth 2.0 flow to get complete credentials..."
                     )
+            elif headless:
+                console.print(
+                    "[yellow]No saved OAuth 2.0 token in headless mode — skipping interactive OAuth 2.0, falling back to OAuth 1.0a"
+                )
 
             if not headless:
                 try:


### PR DESCRIPTION
## Summary
- log the headless OAuth 2.0 fallback when OAuth 2.0 credentials exist but no saved token is present
- keep behavior unchanged; this is just the missing observability path Greptile pointed out on #572

## Context
PR #572 merged before this follow-up log message landed on the branch, so this carries the leftover fix on top of current `master`.

## Test plan
- [x] `python3 -m py_compile scripts/twitter/twitter.py scripts/twitter/workflow.py`
- [x] `ruff format scripts/twitter/twitter.py`
- [x] `ruff check scripts/twitter/twitter.py`