### PR TITLE
feat(github): add pr-review-guide.py — configurable PR difficulty estimator

### DIFF
--- a/scripts/github/pr-review-guide.py
+++ b/scripts/github/pr-review-guide.py
@@ -92,8 +92,14 @@ def checks_green(status_checks: list[dict[str, Any]]) -> bool:
     for check in status_checks:
         conclusion = (check.get("conclusion") or "").upper()
         status = (check.get("status") or "").upper()
+        state = (check.get("state") or "").upper()  # StatusContext (legacy API)
+
+        # StatusContext path: no status/conclusion fields, use state directly
         if not status and not conclusion:
-            return False
+            if state not in ("SUCCESS", "NEUTRAL"):
+                return False
+            continue
+
         if status and status != "COMPLETED":
             return False
         if status == "COMPLETED" and not conclusion:

--- a/tests/test_pr_review_guide.py
+++ b/tests/test_pr_review_guide.py
@@ -278,6 +278,21 @@ def test_checks_green_rejects_completed_without_conclusion():
     assert not checks_green([{"status": "COMPLETED", "conclusion": None}])
 
 
+def test_checks_green_status_context_success():
+    """Legacy StatusContext with state=SUCCESS should be treated as green."""
+    assert checks_green([{"state": "SUCCESS"}])
+
+
+def test_checks_green_status_context_failure():
+    """Legacy StatusContext with state=FAILURE should not be green."""
+    assert not checks_green([{"state": "FAILURE"}])
+
+
+def test_checks_green_status_context_pending():
+    """Legacy StatusContext with state=PENDING should not be green."""
+    assert not checks_green([{"state": "PENDING"}])
+
+
 def test_estimate_review_marks_pending_ci_not_green():
     pr = _make_pr(loc=100)
     pr["statusCheckRollup"] = [{"status": "QUEUED", "conclusion": None}]


### PR DESCRIPTION
## Summary

- Upstream `pr-review-guide.py` from Bob's workspace — a PR review difficulty estimator that ranks open PRs by review effort to maximize merge throughput
- Scores PRs using: LOC (excluding lockfiles), file types (test/docs/config/logic), CI status, Greptile review coverage, description quality, merge conflicts, and PR age
- Configurable via `GPTME_TRACKED_REPOS` env var (comma-separated), defaults to `gptme/*` repos
- Three output modes: full human-readable display, `--json` for machine consumption, `--context` for compact context injection
- 38 tests covering all scoring dimensions, env var config, and formatting

## Context

Identified as a high-value upstream candidate in the [upstream-vs-local boundary audit](https://github.com/ErikBjare/bob/commit/fb26ac812). The scoring algorithm is entirely generic — no agent-specific logic. Companion to `pr-queue-health.py` (#578).

## Test plan

- [x] All 38 tests pass locally
- [x] ruff format + ruff check clean
- [x] mypy passes
- [x] prek (pre-commit) passes
- [ ] CI green on this PR