### PR TITLE
feat(classification): add novelty/news categories, normalize_category, and stats CLI

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/__init__.py
+++ b/packages/gptme-sessions/src/gptme_sessions/__init__.py
@@ -44,6 +44,7 @@ from .classification import (
     classify_by_llm,
     classify_session,
     judge_and_classify,
+    normalize_category,
 )
 from .store import SessionStore
 from .thompson_sampling import Bandit, BanditArm, BanditState, load_bandit_means
@@ -56,6 +57,7 @@ __all__ = [
     "classify_by_llm",
     "classify_session",
     "judge_and_classify",
+    "normalize_category",
     "SessionRecord",
     "SessionStore",
     "MODEL_ALIASES",

--- a/packages/gptme-sessions/src/gptme_sessions/classification.py
+++ b/packages/gptme-sessions/src/gptme_sessions/classification.py
@@ -433,6 +433,83 @@ DEFAULT_CATEGORIES: list[Category] = [
         ],
     ),
     Category(
+        name="novelty",
+        description="Novel exploration — new tools, experiments, unconventional approaches",
+        title_keywords=[
+            "novel",
+            "experiment",
+            "new approach",
+            "unconventional",
+            "first time",
+            "prototype",
+            "proof of concept",
+            "spike",
+            "exploration —",
+        ],
+        outcome_keywords=[
+            "novel approach",
+            "experimented",
+            "prototype",
+            "proof of concept",
+            "first attempt",
+            "new technique",
+            "unconventional",
+        ],
+        execution_keywords=[
+            "experimented with",
+            "tried new",
+            "prototype built",
+            "proof of concept",
+            "spike completed",
+            "novel technique",
+            "unconventional approach",
+        ],
+        deliverable_keywords=[
+            "prototype",
+            "proof of concept",
+            "experiment",
+            "spike",
+            "novel",
+        ],
+    ),
+    Category(
+        name="news",
+        description="News consumption — reading RSS, HN, timelines, summarizing finds",
+        title_keywords=[
+            "rss",
+            "hacker news",
+            "news feed",
+            "timeline",
+            "reading list",
+            "news —",
+            "news scan",
+        ],
+        outcome_keywords=[
+            "read rss",
+            "read hacker news",
+            "summarized articles",
+            "news digest",
+            "news summary",
+        ],
+        execution_keywords=[
+            "read feeds",
+            "news summary",
+            "hacker news",
+            "rss digest",
+            "reading session",
+            "github trending",
+        ],
+        deliverable_keywords=[
+            "rss",
+            "hacker news",
+            "hn",
+            "timeline",
+            "news feed",
+            "reading list",
+            "summarized articles",
+        ],
+    ),
+    Category(
         name="noop-hard",
         description="Nothing happened — error, timeout, empty session",
         title_keywords=[],
@@ -475,6 +552,94 @@ class ClassificationResult:
         if self.secondary_category:
             d["secondary_category"] = self.secondary_category
         return d
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Category normalization (noisy labels → canonical names)
+# ──────────────────────────────────────────────────────────────────────
+
+# Common aliases for category labels found in journals, session records, etc.
+_CATEGORY_ALIASES: dict[str, str] = {
+    "cross-repo-contribution": "cross-repo",
+    "documentation": "content",
+    "docs": "content",
+    "blog": "content",
+    "feature": "code",
+    "coding": "code",
+    "development": "code",
+    "bug-fix": "code",
+    "bugfix": "code",
+    "pr-followup": "code",
+    "hygiene": "infrastructure",
+    "task-hygiene": "infrastructure",
+    "maintenance": "infrastructure",
+    "infra-maintenance": "infrastructure",
+    "self-improvement": "strategic",
+    "lesson-quality": "strategic",
+    "product": "strategic",
+    "planning": "strategic",
+    "coordination": "strategic",
+    "metaproductivity": "strategic",
+}
+
+_FRAGMENT_SPLIT_RE = re.compile(r"[,+|/]")
+
+
+def _resolve_category(category: str, valid: set[str]) -> str | None:
+    """Try to resolve a single normalized label to a valid category."""
+    if category in valid:
+        return category
+
+    direct = _CATEGORY_ALIASES.get(category)
+    if direct:
+        return direct
+
+    # Handle parenthesized sub-labels like "code(bugfix)"
+    if "(" in category and ")" in category:
+        inner = category.split("(", 1)[1].rsplit(")", 1)[0].strip().lower().replace("_", "-")
+        resolved = _resolve_category(inner, valid)
+        if resolved:
+            return resolved
+
+    # Handle composite labels like "code, infrastructure" or "code/infra"
+    for fragment in _FRAGMENT_SPLIT_RE.split(category):
+        fragment = fragment.strip().lower().replace("_", "-")
+        if not fragment or fragment == category:
+            continue
+        resolved = _resolve_category(fragment, valid)
+        if resolved:
+            return resolved
+
+    return None
+
+
+def normalize_category(
+    category: str,
+    categories: list[Category] | None = None,
+) -> str:
+    """Map noisy category labels onto canonical category names.
+
+    Handles common aliases, composite labels (comma/slash-separated),
+    and parenthesized sub-labels. Returns the input unchanged if no
+    mapping is found.
+
+    Args:
+        category: A raw category label (e.g. "bug-fix", "code/infra").
+        categories: Valid category definitions. Defaults to DEFAULT_CATEGORIES.
+
+    Returns:
+        The canonical category name, or the original input if unresolvable.
+    """
+    if categories is None:
+        categories = DEFAULT_CATEGORIES
+    valid = {c.name for c in categories}
+
+    normalized = category.strip().lower().replace("_", "-")
+    if not normalized:
+        return ""
+
+    resolved = _resolve_category(normalized, valid)
+    return resolved or normalized
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -1605,6 +1605,173 @@ def classify(
             click.echo(f"  {cat:<16} {count}")
 
 
+def _discover_journal_entries(
+    journal_dir: Path,
+    last: int,
+) -> list[Path]:
+    """Discover autonomous session journal entries, sorted chronologically."""
+    entries: list[Path] = []
+    for day_dir in sorted(journal_dir.iterdir()):
+        if day_dir.is_dir() and re.fullmatch(r"\d{4}-\d{2}-\d{2}", day_dir.name):
+            entries.extend(sorted(day_dir.glob("*autonomous-session-*.md")))
+    return entries[-last:] if last > 0 else entries
+
+
+@cli.command("classify-stats")
+@click.option(
+    "--journal-dir",
+    type=click.Path(path_type=Path, exists=True),  # type: ignore[type-var]
+    default=None,
+    help="Path to journal directory (default: ./journal)",
+)
+@click.option("--last", type=int, default=20, help="Number of sessions to analyze (default: 20)")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+@click.option(
+    "--diversity-window", type=int, default=5, help="Window for diversity check (default: 5)"
+)
+def classify_stats(
+    journal_dir: Path | None,
+    last: int,
+    as_json: bool,
+    diversity_window: int,
+) -> None:
+    """Show classification stats and session diversity alerts.
+
+    Classifies recent sessions using the fast keyword classifier and shows
+    category breakdown, productivity rate, trends, and diversity warnings.
+    """
+    from collections import Counter
+
+    from .classification import classify_by_keywords
+
+    if journal_dir is None:
+        journal_dir = Path.cwd() / "journal"
+    if not journal_dir.is_dir():
+        raise click.BadParameter(f"{journal_dir} is not a directory", param_hint="'--journal-dir'")
+
+    entries = _discover_journal_entries(journal_dir, last)
+    if not entries:
+        click.echo("No autonomous session journal entries found.", err=True)
+        return
+
+    # Classify all entries (keyword-only for speed)
+    results: list[dict] = []
+    for entry in entries:
+        try:
+            text = entry.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        result = classify_by_keywords(text)
+        row = {
+            "date": entry.parent.name,
+            **result.to_dict(),
+        }
+        results.append(row)
+
+    if not results:
+        click.echo("No sessions could be classified.", err=True)
+        return
+
+    if as_json:
+        click.echo(json.dumps(results, indent=2))
+        return
+
+    total = len(results)
+    productive = sum(1 for r in results if r.get("productive"))
+    cats = Counter(r["category"] for r in results)
+
+    # Multi-label counts (primary + secondary)
+    cats_multi: Counter[str] = Counter()
+    for r in results:
+        cats_multi[r["category"]] += 1
+        sec = r.get("secondary_category")
+        if sec:
+            cats_multi[sec] += 1
+
+    click.echo(f"Session Classification Stats (last {total} sessions)")
+    click.echo("=" * 50)
+    click.echo(f"Productive: {productive}/{total} ({productive * 100 // total}%)")
+    click.echo(f"NOOP:       {total - productive}/{total} ({(total - productive) * 100 // total}%)")
+    click.echo()
+    click.echo("Category Breakdown (primary):")
+    for cat, count in cats.most_common():
+        pct = count * 100 // total
+        bar = "#" * (pct // 2)
+        click.echo(f"  {cat:15s} {count:3d} ({pct:2d}%) {bar}")
+
+    # Multi-label view
+    has_secondary = any(r.get("secondary_category") for r in results)
+    if has_secondary:
+        click.echo()
+        click.echo("Category Presence (primary + secondary):")
+        for cat, count in cats_multi.most_common():
+            pct = count * 100 // total
+            bar = "#" * (pct // 2)
+            primary_count = cats.get(cat, 0)
+            secondary_count = count - primary_count
+            detail = f"{primary_count}p"
+            if secondary_count > 0:
+                detail += f"+{secondary_count}s"
+            click.echo(f"  {cat:15s} {count:3d} ({pct:2d}%) {bar}  [{detail}]")
+
+    # Missing categories
+    productive_cats = {
+        "code",
+        "infrastructure",
+        "triage",
+        "strategic",
+        "content",
+        "cross-repo",
+        "research",
+    }
+    present_cats = set(cats_multi.keys())
+    missing = productive_cats - present_cats
+    if missing:
+        click.echo(f"\n  Missing categories: {', '.join(sorted(missing))}")
+
+    # Trend (last 5 vs previous 5)
+    if total >= 10:
+        recent = results[-5:]
+        earlier = results[-10:-5]
+        recent_prod = sum(1 for c in recent if c.get("productive"))
+        earlier_prod = sum(1 for c in earlier if c.get("productive"))
+        if recent_prod > earlier_prod:
+            trend = "improving"
+        elif recent_prod < earlier_prod:
+            trend = "declining"
+        else:
+            trend = "stable"
+        click.echo(f"\nTrend: {trend} (recent 5: {recent_prod}/5, previous 5: {earlier_prod}/5)")
+
+    # Diversity check
+    if len(results) >= diversity_window:
+        click.echo()
+        click.echo(f"Session Diversity (last {diversity_window}):")
+        recent_cats = [r["category"] for r in results[-diversity_window:]]
+        alerts: list[str] = []
+
+        if len(set(recent_cats[:3])) == 1:
+            alerts.append(f"3+ consecutive '{recent_cats[0]}' sessions — consider diversifying")
+
+        non_code = sum(1 for c in recent_cats if c in ("triage", "monitoring"))
+        if non_code >= 3:
+            alerts.append(
+                f"{non_code}/{diversity_window} sessions were triage/monitoring — pivot to code or ideas"
+            )
+
+        code_sessions = sum(1 for c in recent_cats if c == "code")
+        if code_sessions == 0 and diversity_window >= 5:
+            alerts.append("No code sessions in last 5 — consider picking up a coding task")
+
+        if alerts:
+            for alert in alerts:
+                click.echo(f"  ⚠️  {alert}")
+        else:
+            unique = len(set(recent_cats))
+            cats_str = ", ".join(f"{c}({recent_cats.count(c)})" for c in dict.fromkeys(recent_cats))
+            click.echo(f"  ✅ Good diversity: {unique}/{diversity_window} categories — {cats_str}")
+
+
 def main() -> int:
     """Entry point for console_scripts (backward-compatible wrapper).
 

--- a/packages/gptme-sessions/tests/test_classification.py
+++ b/packages/gptme-sessions/tests/test_classification.py
@@ -19,6 +19,7 @@ from gptme_sessions.classification import (
     classify_by_llm,
     classify_session,
     judge_and_classify,
+    normalize_category,
 )
 
 
@@ -99,6 +100,35 @@ SAMPLE_STRATEGIC_JOURNAL = """\
 ### Deliverables
 - Design doc: knowledge/technical-designs/new-feature-design.md
 - Roadmap updated
+"""
+
+SAMPLE_NOVELTY_JOURNAL = """\
+## Session e4f2 — Novel experiment with WebAssembly agents
+
+### Work
+
+- Experimented with WASM-based agent sandboxing
+- Built proof of concept for isolated tool execution
+- Tried new approach to context compression via WASM modules
+
+### Deliverables
+- Prototype: packages/wasm-sandbox/
+- Experiment results documented
+"""
+
+SAMPLE_NEWS_JOURNAL = """\
+## Session f7a1 — News scan: GitHub trending + HN highlights
+
+### Work
+
+- Scanned GitHub trending for relevant projects
+- Read Hacker News top stories
+- Summarized articles on agent architectures
+- RSS digest of AI research feeds
+
+### Deliverables
+- News summary in journal
+- 2 ideas added to backlog from reading list
 """
 
 
@@ -661,3 +691,73 @@ class TestDataclasses:
         )
         d = result.to_dict()
         assert "secondary_category" not in d
+
+    def test_default_categories_include_novelty_and_news(self) -> None:
+        names = {c.name for c in DEFAULT_CATEGORIES}
+        assert "novelty" in names
+        assert "news" in names
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Tests: new categories (novelty, news)
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestNewCategories:
+    def test_novelty_session(self) -> None:
+        result = classify_by_keywords(SAMPLE_NOVELTY_JOURNAL)
+        assert result.category == "novelty"
+        assert result.productive is True
+
+    def test_news_session(self) -> None:
+        result = classify_by_keywords(SAMPLE_NEWS_JOURNAL)
+        assert result.category == "news"
+        assert result.productive is True
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Tests: normalize_category
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestNormalizeCategory:
+    def test_canonical_unchanged(self) -> None:
+        assert normalize_category("code") == "code"
+        assert normalize_category("infrastructure") == "infrastructure"
+
+    def test_alias_resolution(self) -> None:
+        assert normalize_category("bug-fix") == "code"
+        assert normalize_category("bugfix") == "code"
+        assert normalize_category("docs") == "content"
+        assert normalize_category("documentation") == "content"
+        assert normalize_category("planning") == "strategic"
+
+    def test_case_insensitive(self) -> None:
+        assert normalize_category("Code") == "code"
+        assert normalize_category("BUG-FIX") == "code"
+
+    def test_underscore_to_dash(self) -> None:
+        assert normalize_category("bug_fix") == "code"
+        assert normalize_category("task_hygiene") == "infrastructure"
+
+    def test_composite_label(self) -> None:
+        assert normalize_category("code, infrastructure") == "code"
+        assert normalize_category("code/infra") == "code"
+
+    def test_parenthesized_label(self) -> None:
+        assert normalize_category("code(bugfix)") == "code"
+
+    def test_unknown_passthrough(self) -> None:
+        assert normalize_category("totally-unknown") == "totally-unknown"
+
+    def test_empty_string(self) -> None:
+        assert normalize_category("") == ""
+
+    def test_whitespace_stripped(self) -> None:
+        assert normalize_category("  code  ") == "code"
+
+    def test_custom_categories(self) -> None:
+        custom = [Category(name="trading", description="Financial trading")]
+        # With custom categories, "code" is unknown since it's not in the custom list
+        result = normalize_category("trading", categories=custom)
+        assert result == "trading"


### PR DESCRIPTION
## Summary

Enriches the `gptme-sessions` classification module with features ported from Bob's local `session-classifier.py`:

- **Two new categories**: `novelty` (experiments, prototypes, spikes) and `news` (RSS, HN, trending, feeds) — useful for any autonomous agent doing exploration or news consumption
- **`normalize_category()` function**: Alias resolution for noisy category labels — handles composite labels like `"monitoring, code"`, parenthesized sub-labels like `"code (tool improvements)"`, underscore normalization, and 20+ aliases mapping to canonical names
- **`classify-stats` CLI command**: Category breakdown with bar charts, multi-label view, missing categories detection, productivity trends, and session diversity alerts (consecutive same-category, triage starvation, no-code alerts)

## Details

- Added `novelty` and `news` `Category` entries with keyword lists to `DEFAULT_CATEGORIES`
- Added `_CATEGORY_ALIASES` dict with 20+ aliases → canonical name mappings
- Added `_resolve_category()` internal helper for fragment splitting and alias lookup
- Added `normalize_category()` public API (exported from `__init__.py`)
- Added `_discover_journal_entries()` helper for finding autonomous session journals
- Added `classify-stats` command to CLI with rich category/diversity output
- 13 new tests covering both new categories and normalize_category edge cases

## Test plan

- [x] All 504 existing package tests pass
- [x] 13 new tests for novelty/news classification and normalize_category
- [x] `prek run --all-files` passes (ruff, mypy, etc.)
- [ ] CI green