### PR TITLE
feat(gptodo): add unblocking_power scoring and gptodo dep dag command

### DIFF
--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -4602,7 +4602,7 @@ def dep_check(output_json: bool):
     "show_power",
     is_flag=True,
     default=True,
-    help="Show unblocking power scores [Nup] (default: on)",
+    help="Show unblocking power scores [N↑] (default: on)",
 )
 @click.option(
     "--no-power",
@@ -4660,7 +4660,7 @@ def dep_dag(state: tuple[str, ...], show_power: bool):
     console.print(dag)
 
     if show_power:
-        console.print("\n[dim][Nup] = unblocking power (# tasks transitively unblocked)[/]")
+        console.print("\n[dim][N↑] = unblocking power (# tasks transitively unblocked)[/]")
 
 
 # ============================================================================

--- a/packages/gptodo/src/gptodo/deptree.py
+++ b/packages/gptodo/src/gptodo/deptree.py
@@ -185,7 +185,7 @@ def render_full_dag_ascii(
 
     # Collect non-external nodes
     task_nodes = {n: node for n, node in nodes.items() if not node.is_external}
-    if filter_states:
+    if filter_states is not None:
         task_nodes = {n: node for n, node in task_nodes.items() if node.state in filter_states}
 
     def has_visible_edges(node: DependencyNode) -> bool:

--- a/packages/gptodo/tests/test_deptree.py
+++ b/packages/gptodo/tests/test_deptree.py
@@ -240,6 +240,15 @@ class TestRenderFullDagAscii:
         assert "active-task" in result
         assert "done-task" not in result
 
+    def test_empty_filter_states_hides_all_tasks(self):
+        """An empty filter set should hide everything, not disable filtering."""
+        tasks = [make_task("done-task", state="done")]
+        nodes = build_dependency_graph(tasks)
+
+        result = render_full_dag_ascii(nodes, filter_states=set())
+
+        assert result == ""
+
     def test_filter_states_hidden_edges_become_isolated(self):
         """Tasks connected only to filtered-out nodes should render as isolated."""
         tasks = [


### PR DESCRIPTION
## Summary

- **`compute_unblocking_power()`** in `deptree.py`: for each task, counts the unique set of tasks that transitively depend on it (deduplicates diamond patterns correctly). Used as a tiebreaker in `gptodo next` sorting.
- **`gptodo next` upgraded**: now sorts by `priority → unblocking_power → age`. Tasks that unlock more downstream work are preferred when priorities are equal — improves throughput on dependency chains.
- **`render_full_dag_ascii()`**: renders the full workspace dependency graph as ASCII, with optional `[Nup]` unblocking power annotations.
- **`gptodo dep dag`**: new subcommand showing the full workspace DAG with dependency edges, state filtering (`--state`), and unblocking power scores.
- **16 new tests** in `test_deptree.py` covering: chains, fan-out, fan-in, diamonds, circular deps, state exclusion (done/cancelled), custom exclude sets, missing deps.

## Test plan

- [ ] `uv run pytest packages/gptodo/tests/test_deptree.py -v` — all 16 tests pass
- [ ] `uv run pytest packages/gptodo/tests/ -q` — full gptodo suite passes (108 tests)
- [ ] `gptodo dep dag` shows workspace DAG with `[Nup]` scores
- [ ] `gptodo next --json` returns task with highest unblocking power as tiebreaker