### PR TITLE
fix(cc-backend): add --no-session-persistence to fix nested CC empty output

### DIFF
--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -39,13 +39,20 @@ def call_claude_code(prompt: str, timeout: int = 120, max_retries: int = _MAX_RE
     import os
 
     env = os.environ.copy()
-    # Allow nesting: unset env vars that trigger CC's nested-session guard
+    # Allow nesting: unset all CC env vars and use --no-session-persistence.
+    # Root cause: without --no-session-persistence, the subprocess tries to
+    # connect to the parent CC session's persistence layer, which causes it
+    # to silently return empty output (exit 0, no stdout). Clearing env vars
+    # alone is insufficient — the session persistence system is the actual
+    # nesting detection mechanism.
     env.pop("CLAUDECODE", None)
     env.pop("CLAUDE_CODE_ENTRYPOINT", None)
+    env.pop("CC_SESSION_ID", None)
+    env.pop("CC_MODEL", None)
 
     for attempt in range(1, max_retries + 1):
         result = subprocess.run(
-            ["claude", "-p", "-"],
+            ["claude", "-p", "-", "--no-session-persistence"],
             input=prompt,
             capture_output=True,
             text=True,

--- a/packages/gptme-activity-summary/tests/test_cc_backend.py
+++ b/packages/gptme-activity-summary/tests/test_cc_backend.py
@@ -176,22 +176,41 @@ def test_call_claude_code_linear_backoff(mock_run, mock_sleep):
 
 
 @patch("subprocess.run")
-def test_call_claude_code_unsets_env_vars(mock_run):
-    """Test that CLAUDECODE and CLAUDE_CODE_ENTRYPOINT are unset."""
+def test_call_claude_code_unsets_all_cc_env_vars(mock_run):
+    """Test that all CC-related env vars are stripped from subprocess."""
     mock_run.return_value = _make_completed_process(stdout="ok")
 
     import os
 
-    os.environ["CLAUDECODE"] = "1"
-    os.environ["CLAUDE_CODE_ENTRYPOINT"] = "/usr/bin/claude"
+    cc_vars = {
+        "CLAUDECODE": "1",
+        "CLAUDE_CODE_ENTRYPOINT": "/usr/bin/claude",
+        "CC_SESSION_ID": "test-session-id",
+        "CC_MODEL": "opus",
+    }
+    for k, v in cc_vars.items():
+        os.environ[k] = v
     try:
         call_claude_code("test")
         env_used = mock_run.call_args.kwargs["env"]
-        assert "CLAUDECODE" not in env_used
-        assert "CLAUDE_CODE_ENTRYPOINT" not in env_used
+        for var in cc_vars:
+            assert var not in env_used, f"CC env var {var} should be stripped"
     finally:
-        os.environ.pop("CLAUDECODE", None)
-        os.environ.pop("CLAUDE_CODE_ENTRYPOINT", None)
+        for k in cc_vars:
+            os.environ.pop(k, None)
+
+
+@patch("gptme_activity_summary.cc_backend.time.sleep")
+@patch("subprocess.run")
+def test_call_claude_code_uses_no_session_persistence(mock_run, mock_sleep):
+    """Verify --no-session-persistence flag prevents silent empty output when nested."""
+    mock_run.return_value = _make_completed_process(stdout="test output")
+    call_claude_code("test prompt")
+    cmd = mock_run.call_args[0][0]
+    assert "--no-session-persistence" in cmd, (
+        "Must pass --no-session-persistence to prevent CC session persistence "
+        "from hijacking output when running as a subprocess of another CC session"
+    )
 
 
 # --- Tests for _cc_failed flag propagation ---


### PR DESCRIPTION
## Summary

- Adds `--no-session-persistence` flag to `claude -p` subprocess calls, fixing the root cause of silent empty output when `cc_backend.py` runs inside a Claude Code session
- Also clears `CC_SESSION_ID` and `CC_MODEL` env vars (belt-and-suspenders)
- Adds 2 new tests: flag verification and full env var stripping

## Root Cause Analysis

When `claude -p` runs as a subprocess of an active CC session, it tries to connect to the parent session's persistence layer. This causes the subprocess to silently return empty output (exit 0, no stdout) instead of producing independent results.

**Key findings from investigation:**
- Clearing `CLAUDECODE` + `CLAUDE_CODE_ENTRYPOINT` alone is insufficient (the fix in #584)
- CC also sets `CC_SESSION_ID` and `CC_MODEL` env vars, but clearing those alone also doesn't help
- strace showed the subprocess loading `libproc2` (process library) suggesting process-tree detection
- The subprocess creates a session log that piggybacks on the parent session
- `--no-session-persistence` is the actual fix — forces fully independent operation

**Empirical verification:** 4/4 tests succeed with the flag, 0/4 without it.

The retry logic from #584 is retained as a safety net for transient failures.

## Test plan

- [x] 19 unit tests pass (including 2 new ones)
- [x] Verified empirically: `claude -p "..." --no-session-persistence` returns correct output inside active CC session
- [ ] End-to-end: next daily summary run at 04:00 UTC should produce narrative content