### PR TITLE
fix(greptile): retrigger after reviewed PR updates

### DIFF
--- a/lessons/tools/greptile-pr-reviews.md
+++ b/lessons/tools/greptile-pr-reviews.md
@@ -19,15 +19,16 @@ Use `greptile-helper.sh` for all Greptile triggers so re-reviews stay safe, idem
 
 ## Context
 When working on PRs that:
-- Previously received low code quality scores from Greptile
-- Have been improved with bug fixes or additional tests
-- Need validation that quality improvements were effective
-- Are ready for re-review after addressing feedback
+- Already have a Greptile review
+- Have changed since that review (for example bug fixes, new tests, or follow-up commits)
+- Need validation that the latest head still looks good before human review
+- Are ready for re-review after addressing feedback or otherwise changing the PR
 
 ## Detection
 Observable signals that indicate you need a Greptile re-review:
-- PR has an existing Greptile review with a low score (for example 3/5)
+- PR has an existing Greptile review, but the head changed afterward
 - You made improvements (fixed bugs, added tests, improved coverage)
+- You pushed follow-up commits after a prior 5/5 review and want a fresh snapshot
 - You want to verify the improvements before requesting human review
 - Coverage or test results improved, but there is no new Greptile review yet
 
@@ -59,7 +60,7 @@ The helper centralizes the anti-spam guards:
 - recent-trigger cooldown
 - bot-ack detection and grace period
 - fail-safe handling for API/rate-limit errors
-- re-review logic only when new commits exist after a low-scoring review
+- re-review logic only when new commits exist after the latest Greptile review
 
 Greptile should auto-review new PRs. Use the helper only for re-review after improvements, or when the helper explicitly indicates `needs-re-review`. `status` is safe for inspection; `trigger` is the only mutation path.
 

--- a/scripts/github/README.md
+++ b/scripts/github/README.md
@@ -212,8 +212,9 @@ These scripts are designed to be integrated into gptme agent workflows:
 Batch-trigger safe Greptile re-review requests for open PRs.
 
 Scans open PRs authored by the authenticated user, identifies which ones need a
-re-review (new commits since the last Greptile review), and routes triggers through
-`greptile-helper.sh`. Never triggers initial reviews — Greptile auto-reviews new PRs.
+re-review because new commits landed since the last Greptile review, and routes
+triggers through `greptile-helper.sh`. Never triggers initial reviews — Greptile
+auto-reviews new PRs.
 
 **Features:**
 - Safe re-review triggering (no spam — uses greptile-helper.sh guards)

--- a/scripts/github/greptile-helper.sh
+++ b/scripts/github/greptile-helper.sh
@@ -8,17 +8,18 @@
 #     already-reviewed | needs-re-review | in-progress | awaiting-initial-review | stale | error
 #
 # Exit codes for 'check':
-#   0 = safe to trigger (re-review needed: score < 5/5 + new commits)
+#   0 = safe to trigger (re-review needed: new commits since the last Greptile review)
 #   1 = skip: no review yet (awaiting Greptile auto-review), or re-review trigger in-flight
-#   2 = skip: reviewed by greptile-apps[bot], score=5/5 or no new commits since review
+#   2 = skip: reviewed by greptile-apps[bot], and no new commits since review
 #   3 = api error (fail-safe = skip)
 #
 # Erik's requests (ErikBjare/bob#434):
 #   1. Reduce 30min age guard → 15min (reviews complete in 5-15min)
-#   2. Re-request after addressing feedback: if score < 5/5 AND new commits → trigger
+#   2. Re-request after addressing feedback once new commits land after a Greptile review
 #
 # Initial review policy: Greptile automatically reviews all new PRs. We NEVER manually
-# trigger initial reviews. Only re-reviews (score < 5/5 + new commits) are triggered.
+# trigger initial reviews. Only re-reviews (new commits after the latest Greptile
+# review) are triggered.
 # Status 'awaiting-initial-review' is returned for ALL unreviewed PRs regardless of age.
 #
 # Root cause of spam incidents:
@@ -124,20 +125,14 @@ _has_greptile_review() {
     echo "$info" | python3 -c "import sys,json; d=json.load(sys.stdin); exit(0 if d.get('has_review') else 1)" 2>/dev/null
 }
 
-# --- Helper: check if re-review is needed (not 5/5 + new commits since review) ---
+# --- Helper: check if re-review is needed (new commits since latest review) ---
 # Returns 0 = re-review needed, 1 = no re-review needed
 _needs_re_review() {
-    local info score reviewed_at new_commits
+    local info reviewed_at new_commits
     info=$(_greptile_review_info) || return 1
-    score=$(echo "$info" | python3 -c "import sys,json; d=json.load(sys.stdin); s=d.get('score'); print(s) if s is not None else print('none')" 2>/dev/null) || score="none"
     reviewed_at=$(echo "$info" | _json_field "reviewed_at") || reviewed_at=""
 
-    # Score 5 or unknown → no re-review
-    if [ "$score" = "5" ] || [ "$score" = "none" ]; then
-        return 1
-    fi
-
-    # Score < 5 → check for new commits since review
+    # No review timestamp → can't determine whether review is stale.
     if [ -z "$reviewed_at" ]; then
         return 1
     fi
@@ -172,7 +167,9 @@ _our_trigger_status() {
             # which always have a non-empty cutoff, so this invariant holds.
             local _ts_in_cycle=0  # 1 = TS is from current review cycle; 0 = skip fast-path
             if [ -n "$review_cutoff" ]; then
-                _timestamp_gt "$_local_ts" "$review_cutoff" 2>/dev/null && _ts_in_cycle=1 || true
+                if _timestamp_gt "$_local_ts" "$review_cutoff" 2>/dev/null; then
+                    _ts_in_cycle=1
+                fi
             fi
             if [ "$_ts_in_cycle" -eq 1 ]; then
                 local _local_age
@@ -269,7 +266,7 @@ case "${1:-}" in
 check)
     # Check if safe to trigger
     if _has_greptile_review; then
-        # Already reviewed — check if re-review is needed (score < 5/5 + new commits)
+        # Already reviewed — check if re-review is needed (new commits since review)
         if _needs_re_review; then
             reviewed_at=$( _greptile_review_info | _json_field "reviewed_at") || reviewed_at=""
             # Eligible for re-review — but check trigger isn't in-flight
@@ -279,7 +276,7 @@ check)
             fi
             exit 0  # Re-review needed
         fi
-        exit 2  # Reviewed and 5/5 (or no new commits)
+        exit 2  # Reviewed and no new commits since latest review
     fi
     # No review yet — Greptile auto-reviews new PRs. Never manually trigger initial review.
     exit 1
@@ -309,7 +306,7 @@ trigger)
                 echo "  [greptile] Re-review trigger in-flight on $REPO#$PR_NUMBER. Skipping."
                 exit 0
             fi
-            echo "  [greptile] Re-triggering @greptileai review on $REPO#$PR_NUMBER (score < 5/5 + new commits)..."
+            echo "  [greptile] Re-triggering @greptileai review on $REPO#$PR_NUMBER (new commits landed after the last review)..."
             # Use REST API instead of `gh pr comment` (GraphQL) — REST has a
             # separate 5000/hour quota that's rarely exhausted.
             if gh api "repos/$REPO/issues/$PR_NUMBER/comments" -f body="@greptileai review" --silent 2>/dev/null; then
@@ -324,7 +321,7 @@ trigger)
                 echo "  [greptile] Trigger failed (non-fatal)."
             fi
         else
-            echo "  [greptile] Already reviewed on $REPO#$PR_NUMBER (5/5 or no new commits). Skipping."
+            echo "  [greptile] Already reviewed on $REPO#$PR_NUMBER (no new commits since latest review). Skipping."
         fi
         exit 0
     fi

--- a/tests/test_greptile_helper.py
+++ b/tests/test_greptile_helper.py
@@ -368,6 +368,29 @@ def test_score_5_is_already_reviewed():
     assert status.stdout.strip() == "already-reviewed"
 
 
+def test_score_5_with_new_commits_needs_rereview():
+    """Score 5/5 is not terminal once new commits land after the review."""
+    reviewed_at = _iso_ago(minutes=30)
+    fixture = {
+        "pr_number": 124,
+        "raw_comments": [
+            _make_greptile_comment(
+                5, reviewed_at=_iso_ago(minutes=60), updated_at=reviewed_at
+            ),
+        ],
+        "raw_commits": [
+            _make_commit(_iso_ago(minutes=10)),
+        ],
+        "raw_pr": {"created_at": _iso_ago(minutes=120)},
+        "bot_reaction_count": 0,
+    }
+    result = _run_helper("check", fixture)
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+
+    status = _run_helper("status", fixture)
+    assert status.stdout.strip() == "needs-re-review"
+
+
 def test_trigger_skips_unreviewed_pr_initial_review():
     """Trigger on old PR with no review → skips (awaiting Greptile auto-review)."""
     fixture = {
@@ -421,6 +444,29 @@ def test_trigger_re_reviews_on_low_score_with_new_commits():
     assert (
         gh_log
     ), "comment was never posted (neither gh pr comment nor gh api REST call)"
+    assert "@greptileai review" in gh_log
+
+
+def test_trigger_re_reviews_after_score_5_when_new_commits_land():
+    """A 5/5 review still needs a fresh pass if the PR head changed afterward."""
+    reviewed_at = _iso_ago(minutes=30)
+    fixture = {
+        "pr_number": 778,
+        "raw_comments": [
+            _make_greptile_comment(
+                5, reviewed_at=_iso_ago(minutes=60), updated_at=reviewed_at
+            ),
+        ],
+        "raw_commits": [
+            _make_commit(_iso_ago(minutes=10)),
+        ],
+        "raw_pr": {"created_at": _iso_ago(minutes=120)},
+        "bot_reaction_count": 0,
+    }
+    result, gh_log = _run_helper("trigger", fixture, capture_gh_log=True)
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert "Re-triggered successfully" in result.stdout
+    assert gh_log, "comment was never posted"
     assert "@greptileai review" in gh_log
 
 


### PR DESCRIPTION
## Summary
- allow Greptile re-reviews whenever new commits land after the latest Greptile review, even if the prior review scored 5/5
- add regression coverage for 5/5-followed-by-new-commit status and trigger flows
- update helper docs and lesson text to match the new rule

## Testing
- uv run pytest tests/test_greptile_helper.py tests/test_pr_greptile_trigger.py -q
- python3 packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py lessons/tools/greptile-pr-reviews.md
- shellcheck scripts/github/greptile-helper.sh