### PR TITLE
feat(autoresearch): support CONFIG_DIR env var override in outer loop

### DIFF
--- a/scripts/autoresearch/autoresearch-loop.sh
+++ b/scripts/autoresearch/autoresearch-loop.sh
@@ -60,7 +60,7 @@ ENABLED="$(get_config enabled true)"
 
 # General autoresearch fields — support any artifact, eval, harness, and program spec.
 # These replace gptme-specific hardcoded defaults and allow running arbitrary experiments.
-ARTIFACT_DIR="$(get_config artifact_dir "$(pwd)")"
+ARTIFACT_DIR="${ARTIFACT_DIR:-$(get_config artifact_dir "$(pwd)")}"
 AGENT_HARNESS="$(get_config agent_harness gptme)"
 EVAL_CMD="$(get_config eval_cmd "")"           # Optional: custom eval command (stdout → float)
 PROGRAM_SPEC="$(get_config program_spec "")"   # Optional: path to agent program spec


### PR DESCRIPTION
## Summary

- Add `CONFIG_DIR` env var override to `autoresearch-loop.sh` — defaults to `${SCRIPT_DIR}/experiments` (no behavior change)
- Document `CONFIG_DIR` and `ARTIFACT_DIR` overrides in the usage header
- Enables thin wrapper deployments where experiment configs live outside gptme-contrib (e.g. Bob's workspace)

## Motivation

Bob's `scripts/autoresearch/autoresearch-loop.sh` is a near-copy of this upstream script with one difference: it sets `CONFIG_DIR` to Bob's local experiments directory. With this change, Bob's local script can become a thin wrapper (~10 lines) that sets env vars and delegates to this upstream script:

```bash
#!/usr/bin/env bash
# Thin wrapper — delegates to upstream autoresearch-loop.sh
export CONFIG_DIR="${REPO_ROOT}/scripts/autoresearch/experiments"
export ARTIFACT_DIR="${ARTIFACT_DIR:-/home/bob/gptme}"
export GITHUB_REPO="${GITHUB_REPO:-gptme/gptme}"
exec "${REPO_ROOT}/gptme-contrib/scripts/autoresearch/autoresearch-loop.sh" "$@"
```

Closes ErikBjare/bob#506 (outer loop wrapper step).

## Test plan
- [ ] Verify default behavior unchanged: `autoresearch-loop.sh gptme-eval` still finds configs in `./experiments/`
- [ ] Verify override works: `CONFIG_DIR=/tmp/myconfigs autoresearch-loop.sh myexp` finds config there