### PR TITLE
fix(autoresearch): run uv sync in worktrees for pre-commit hooks

### DIFF
--- a/scripts/autoresearch/merge-reject-loop.sh
+++ b/scripts/autoresearch/merge-reject-loop.sh
@@ -213,6 +213,15 @@ prepare_worktree() {
         fi
     done
 
+    # Install Python packages so pre-commit hooks (mypy, tests) work.
+    # Without this, `make typecheck` fails with "Can't find package 'X'"
+    # because the worktree has no .venv.
+    if [[ -f "${WORKTREE_DIR}/pyproject.toml" ]]; then
+        echo "Installing packages in worktree..."
+        (cd "${WORKTREE_DIR}" && uv sync --all-packages --quiet 2>/dev/null) || \
+            echo "Warning: uv sync failed (non-fatal, pre-commit hooks may fail)"
+    fi
+
     GPTME_DIR="${WORKTREE_DIR}"
 }
 


### PR DESCRIPTION
## Summary
- Worktrees created by `prepare_worktree()` had no `.venv`, causing mypy to fail with `Can't find package 'coordination'` during `git commit`
- The pre-commit hook runs `make typecheck` which requires all workspace packages installed
- Adds `uv sync --all-packages` after submodule symlink setup in `prepare_worktree()`

**Root cause**: The `bob-workspace-tests` autoresearch experiment improved a score (0.972 → 0.974) but the commit was rejected because mypy couldn't find the `coordination` package — the worktree had no venv.

## Test plan
- [x] `bash -n` syntax validation passes
- [x] `shellcheck -S error` clean
- [ ] Verify next autoresearch run succeeds in committing improved scores