### PR TITLE
fix(autoresearch): keep uv sync failure diagnostics

### DIFF
--- a/scripts/autoresearch/merge-reject-loop.sh
+++ b/scripts/autoresearch/merge-reject-loop.sh
@@ -217,9 +217,14 @@ prepare_worktree() {
     # Without this, `make typecheck` fails with "Can't find package 'X'"
     # because the worktree has no .venv.
     if [[ -f "${WORKTREE_DIR}/pyproject.toml" ]]; then
+        local sync_err=""
         echo "Installing packages in worktree..."
-        (cd "${WORKTREE_DIR}" && uv sync --all-packages --quiet 2>/dev/null) || \
-            echo "Warning: uv sync failed (non-fatal, pre-commit hooks may fail)"
+        sync_err=$(cd "${WORKTREE_DIR}" && uv sync --all-packages --quiet 2>&1) || {
+            echo "Warning: uv sync failed (non-fatal, pre-commit hooks may fail)" >&2
+            if [[ -n "${sync_err}" ]]; then
+                printf '%s\n' "${sync_err}" >&2
+            fi
+        }
     fi
 
     GPTME_DIR="${WORKTREE_DIR}"


### PR DESCRIPTION
## Summary
- preserve `uv sync` stderr when worktree dependency setup fails
- keep the install non-fatal so autoresearch still relies on pre-commit as the final gate
- print the captured diagnostics so unattended failures are debuggable

## Test plan
- [x] `bash -n scripts/autoresearch/merge-reject-loop.sh`
- [x] `shellcheck -S error scripts/autoresearch/merge-reject-loop.sh`
