### PR TITLE
fix(gptodo): exclude waiting tasks from ready selection

### DIFF
--- a/packages/gptodo/src/gptodo/generate_queue.py
+++ b/packages/gptodo/src/gptodo/generate_queue.py
@@ -399,6 +399,15 @@ class QueueGenerator:
 
         ready_tasks = []
         for task in tasks:
+            task_file = self.tasks_dir / f"{task.id}.md"
+            if task_file.exists():
+                try:
+                    post = frontmatter.load(task_file)
+                    if post.metadata.get("state") == "waiting" or post.metadata.get("waiting_for"):
+                        continue
+                except Exception:
+                    pass
+
             if not task.requires:
                 ready_tasks.append(task)
                 continue

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -326,6 +326,14 @@ class TaskInfo:
 # =============================================================================
 
 
+def task_has_waiting_blocker(task: TaskInfo) -> bool:
+    """Return True when a task is explicitly waiting on an external condition."""
+    state = normalize_state(task.state or "", warn=False) if task.state else ""
+    if state == "waiting":
+        return True
+    return bool(task.metadata.get("waiting_for"))
+
+
 def find_repo_root(start_path: Path) -> Path:
     """Find the workspace root by looking for workspace markers.
 
@@ -853,6 +861,9 @@ def is_task_ready(
     Returns:
         True if task is ready, False if blocked
     """
+    if task_has_waiting_blocker(task):
+        return False
+
     # Use requires (canonical field, includes deprecated depends/blocks)
     requires = task.requires
     if not requires:
@@ -918,6 +929,9 @@ def compute_effective_state(
     if task.state in ("done", "cancelled"):
         return task.state or "unknown"
 
+    if task_has_waiting_blocker(task):
+        return "waiting"
+
     # Check if task is blocked by dependencies
     requires = task.requires
     if not requires:
@@ -970,6 +984,12 @@ def get_blocking_reasons(
     # Terminal states are never blocked
     if task.state in ("done", "cancelled"):
         return []
+
+    if task_has_waiting_blocker(task):
+        waiting_for = task.metadata.get("waiting_for")
+        if waiting_for:
+            return [f"Waiting on: {waiting_for}"]
+        return ["Waiting on external dependency"]
 
     requires = task.requires
     if not requires:

--- a/packages/gptodo/tests/test_generate_queue.py
+++ b/packages/gptodo/tests/test_generate_queue.py
@@ -177,6 +177,21 @@ class TestFilterBlockedTasks:
         result = gen.filter_blocked_tasks(tasks)
         assert len(result) == 0
 
+    def test_waiting_for_filters_task_without_requires(self, workspace: Path) -> None:
+        """Tasks with waiting_for are blocked even without explicit requires."""
+        write_task(
+            workspace / "tasks",
+            "task-a",
+            state="active",
+            priority="high",
+            waiting_for="Erik review",
+        )
+
+        gen = QueueGenerator(workspace)
+        tasks = [Task(id="task-a", title="A", priority="high", state="active", source="tasks")]
+        result = gen.filter_blocked_tasks(tasks)
+        assert len(result) == 0
+
 
 class TestComputeUnblockingPower:
     def test_no_dependents(self, workspace: Path) -> None:

--- a/packages/gptodo/tests/test_ready_selection.py
+++ b/packages/gptodo/tests/test_ready_selection.py
@@ -1,0 +1,95 @@
+"""Regression tests for ready/next task selection."""
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from gptodo.cli import cli
+from gptodo.utils import is_task_ready, load_tasks
+
+
+def write_task(tasks_dir: Path, name: str, **metadata: object) -> None:
+    """Write a minimal task file with YAML frontmatter."""
+    lines = ["---"]
+    for key, value in metadata.items():
+        if isinstance(value, list):
+            lines.append(f"{key}:")
+            for item in value:
+                lines.append(f"  - {item}")
+        else:
+            lines.append(f"{key}: {value}")
+    lines.extend(["---", f"# {name}"])
+    (tasks_dir / f"{name}.md").write_text("\n".join(lines))
+
+
+def test_is_task_ready_false_when_waiting_for_set(tmp_path: Path) -> None:
+    """Tasks with waiting_for must not count as ready work."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(
+        tasks_dir,
+        "waiting-task",
+        state="backlog",
+        created="2026-03-28T00:00:00",
+        waiting_for="Erik review",
+    )
+
+    tasks = load_tasks(tasks_dir)
+    task_lookup = {task.name: task for task in tasks}
+
+    assert is_task_ready(task_lookup["waiting-task"], task_lookup) is False
+
+
+def test_ready_command_skips_waiting_for_tasks(tmp_path: Path, monkeypatch) -> None:
+    """`gptodo ready` should not surface waiting tasks as actionable."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(
+        tasks_dir,
+        "waiting-task",
+        state="backlog",
+        created="2026-03-28T00:00:00",
+        waiting_for="Erik review",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["ready", "--state", "backlog", "--json"])
+
+    assert result.exit_code == 0
+    payload_text = result.output.split("\nNo ready tasks found", 1)[0]
+    payload = json.loads(payload_text)
+    assert payload["count"] == 0
+    assert payload["ready_tasks"] == []
+
+
+def test_next_command_ignores_waiting_task_even_if_higher_priority(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """`gptodo next` should pick the real ready task, not the waiting one."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(
+        tasks_dir,
+        "waiting-task",
+        state="backlog",
+        created="2026-03-28T00:00:00",
+        priority="high",
+        waiting_for="Erik review",
+    )
+    write_task(
+        tasks_dir,
+        "ready-task",
+        state="active",
+        created="2026-03-28T01:00:00",
+        priority="medium",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["next", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["next_task"]["id"] == "ready-task"


### PR DESCRIPTION
## Summary
- treat tasks with `waiting_for` or `state: waiting` as not ready
- keep `gptodo next` and `ready` from surfacing externally blocked work
- add regression coverage for both CLI selection and queue generation

## Testing
- PYTHONPATH=packages/gptodo/src uv run --with click --with python-frontmatter --with rich --with tabulate --with pytest pytest packages/gptodo/tests -q
- uv run --with ruff ruff check packages/gptodo/src/gptodo/utils.py packages/gptodo/src/gptodo/generate_queue.py packages/gptodo/tests/test_generate_queue.py packages/gptodo/tests/test_ready_selection.py