### PR TITLE
fix(twitter): atomic token save + timezone-aware expiry + fallback expires_at

### DIFF
--- a/lessons/workflow/gptme-contrib-contribution-pattern.md
+++ b/lessons/workflow/gptme-contrib-contribution-pattern.md
@@ -1,6 +1,6 @@
 ---
 match:
-  keywords: ["gptme-contrib", "contribute lesson", "contrib PR", "external contribution", "submit lesson", "upstream lesson"]
+  keywords: ["contribute lesson", "contrib PR", "external contribution", "submit lesson", "upstream lesson", "upstream to gptme-contrib"]
 status: active
 ---
 

--- a/packages/gptmail/src/gptmail/communication_utils/auth/__init__.py
+++ b/packages/gptmail/src/gptmail/communication_utils/auth/__init__.py
@@ -6,7 +6,7 @@ for email, Twitter, Discord, and other platforms.
 """
 
 from .oauth import OAuthManager
-from .token_storage import save_token_to_env
+from .token_storage import save_token_to_env, save_tokens_to_env
 from .tokens import TokenInfo, TokenManager
 
 # Flask-dependent OAuth callback server (requires gptmail[oauth])
@@ -20,6 +20,13 @@ try:
         "TokenManager",
         "run_oauth_callback",
         "save_token_to_env",
+        "save_tokens_to_env",
     ]
 except ImportError:
-    __all__ = ["OAuthManager", "TokenInfo", "TokenManager", "save_token_to_env"]
+    __all__ = [
+        "OAuthManager",
+        "TokenInfo",
+        "TokenManager",
+        "save_token_to_env",
+        "save_tokens_to_env",
+    ]

--- a/packages/gptmail/src/gptmail/communication_utils/auth/oauth.py
+++ b/packages/gptmail/src/gptmail/communication_utils/auth/oauth.py
@@ -162,7 +162,7 @@ class OAuthManager:
         Returns:
             TokenInfo with token details
         """
-        from datetime import datetime, timedelta
+        from datetime import datetime, timedelta, timezone
 
         access_token = response_data["access_token"]
         token_type = response_data.get("token_type", "Bearer")
@@ -171,7 +171,7 @@ class OAuthManager:
 
         expires_at = None
         if expires_in:
-            expires_at = datetime.now() + timedelta(seconds=int(expires_in))
+            expires_at = datetime.now(timezone.utc) + timedelta(seconds=int(expires_in))
 
         return TokenInfo(
             token=access_token,

--- a/packages/gptmail/src/gptmail/communication_utils/auth/token_storage.py
+++ b/packages/gptmail/src/gptmail/communication_utils/auth/token_storage.py
@@ -98,3 +98,51 @@ def save_token_to_env(
 
     # Write atomically
     return _write_env_atomically(env_path, env_lines)
+
+
+def save_tokens_to_env(
+    tokens: dict[str, str],
+    env_path: Path | None = None,
+    comment: str | None = None,
+) -> bool:
+    """Save multiple tokens to .env file in a single atomic write.
+
+    This avoids race conditions where partial writes leave the .env file
+    in an inconsistent state (e.g., new access_token but stale expires_at).
+
+    Args:
+        tokens: Dict of {env_var_name: value} to save
+        env_path: Path to .env file (defaults to find_dotenv())
+        comment: Optional comment for newly appended tokens
+
+    Returns:
+        True if successful, False otherwise
+    """
+    if env_path is None:
+        try:
+            from dotenv import find_dotenv
+        except ImportError:
+            raise ImportError(
+                "python-dotenv is required when env_path is not provided. "
+                "Install it with: pip install gptmail[oauth]"
+            ) from None
+        env_path_str = find_dotenv()
+        if not env_path_str:
+            return False
+        env_path = Path(env_path_str)
+
+    env_lines = _read_env_lines(env_path)
+
+    for token_name, token_value in tokens.items():
+        token_line_idx = _find_token_line_index(env_lines, token_name)
+        new_token_line = f"{token_name}={token_value}\n"
+
+        if token_line_idx is not None:
+            env_lines[token_line_idx] = new_token_line
+        else:
+            if comment:
+                env_lines.extend(["\n", f"# {comment}\n", new_token_line])
+            else:
+                env_lines.append(new_token_line)
+
+    return _write_env_atomically(env_path, env_lines)

--- a/packages/gptmail/src/gptmail/communication_utils/auth/tokens.py
+++ b/packages/gptmail/src/gptmail/communication_utils/auth/tokens.py
@@ -7,7 +7,7 @@ from environment variables with secure defaults.
 
 import os
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 
 @dataclass
@@ -30,7 +30,12 @@ class TokenInfo:
             return False  # No expiry info means we assume valid
 
         buffer = timedelta(seconds=buffer_seconds)
-        return datetime.now() >= (self.expires_at - buffer)
+        now = datetime.now(timezone.utc)
+        # Handle naive datetimes (assume UTC) for backwards compatibility
+        expires = self.expires_at
+        if expires.tzinfo is None:
+            expires = expires.replace(tzinfo=timezone.utc)
+        return now >= (expires - buffer)
 
     def is_valid(self) -> bool:
         """Check if token is valid (exists and not expired)."""

--- a/packages/gptmail/tests/test_token_expiry.py
+++ b/packages/gptmail/tests/test_token_expiry.py
@@ -1,0 +1,67 @@
+"""Tests for TokenInfo.is_expired with timezone-aware datetimes."""
+
+from datetime import datetime, timedelta, timezone
+
+from gptmail.communication_utils.auth.tokens import TokenInfo
+
+
+def test_is_expired_with_utc_aware() -> None:
+    """Timezone-aware expired token is detected."""
+    expired = datetime.now(timezone.utc) - timedelta(hours=1)
+    info = TokenInfo(token="t", expires_at=expired)
+    assert info.is_expired() is True
+
+
+def test_is_not_expired_with_utc_aware() -> None:
+    """Timezone-aware future token is not expired."""
+    future = datetime.now(timezone.utc) + timedelta(hours=2)
+    info = TokenInfo(token="t", expires_at=future)
+    assert info.is_expired() is False
+
+
+def test_is_expired_with_naive_datetime() -> None:
+    """Naive datetime (legacy) still works — treated as UTC."""
+    expired = datetime.utcnow() - timedelta(hours=1)
+    info = TokenInfo(token="t", expires_at=expired)
+    assert info.is_expired() is True
+
+
+def test_is_not_expired_with_naive_datetime() -> None:
+    """Naive datetime (legacy) future token works."""
+    future = datetime.utcnow() + timedelta(hours=2)
+    info = TokenInfo(token="t", expires_at=future)
+    assert info.is_expired() is False
+
+
+def test_is_expired_none_means_valid() -> None:
+    """No expiry info means token is assumed valid."""
+    info = TokenInfo(token="t", expires_at=None)
+    assert info.is_expired() is False
+
+
+def test_is_expired_within_buffer() -> None:
+    """Token expiring within buffer period is considered expired."""
+    # Expires in 60 seconds, but buffer is 300 seconds
+    almost = datetime.now(timezone.utc) + timedelta(seconds=60)
+    info = TokenInfo(token="t", expires_at=almost)
+    assert info.is_expired(buffer_seconds=300) is True
+
+
+def test_is_expired_outside_buffer() -> None:
+    """Token expiring well after buffer period is not expired."""
+    future = datetime.now(timezone.utc) + timedelta(seconds=600)
+    info = TokenInfo(token="t", expires_at=future)
+    assert info.is_expired(buffer_seconds=300) is False
+
+
+def test_is_valid_with_expired_token() -> None:
+    """is_valid returns False for expired tokens."""
+    expired = datetime.now(timezone.utc) - timedelta(hours=1)
+    info = TokenInfo(token="t", expires_at=expired)
+    assert info.is_valid() is False
+
+
+def test_is_valid_with_empty_token() -> None:
+    """is_valid returns False for empty token string."""
+    info = TokenInfo(token="", expires_at=None)
+    assert info.is_valid() is False

--- a/packages/gptmail/tests/test_token_storage.py
+++ b/packages/gptmail/tests/test_token_storage.py
@@ -1,0 +1,97 @@
+"""Tests for token_storage module — atomic batch saves."""
+
+from pathlib import Path
+
+from gptmail.communication_utils.auth.token_storage import (
+    save_token_to_env,
+    save_tokens_to_env,
+)
+
+
+def test_save_tokens_to_env_creates_file(tmp_path: Path) -> None:
+    """save_tokens_to_env creates .env with all tokens in one write."""
+    env_path = tmp_path / ".env"
+    result = save_tokens_to_env(
+        {"TOKEN_A": "val_a", "TOKEN_B": "val_b"},
+        env_path=env_path,
+        comment="test tokens",
+    )
+    assert result is True
+    content = env_path.read_text()
+    assert "TOKEN_A=val_a" in content
+    assert "TOKEN_B=val_b" in content
+
+
+def test_save_tokens_to_env_updates_existing(tmp_path: Path) -> None:
+    """save_tokens_to_env updates existing keys in-place."""
+    env_path = tmp_path / ".env"
+    env_path.write_text("TOKEN_A=old_a\nTOKEN_B=old_b\n")
+    result = save_tokens_to_env(
+        {"TOKEN_A": "new_a", "TOKEN_B": "new_b"},
+        env_path=env_path,
+    )
+    assert result is True
+    content = env_path.read_text()
+    assert "TOKEN_A=new_a" in content
+    assert "TOKEN_B=new_b" in content
+    assert "old_a" not in content
+    assert "old_b" not in content
+
+
+def test_save_tokens_to_env_preserves_other_lines(tmp_path: Path) -> None:
+    """save_tokens_to_env doesn't clobber unrelated env vars."""
+    env_path = tmp_path / ".env"
+    env_path.write_text("UNRELATED=keep_me\nTOKEN_A=old\n")
+    save_tokens_to_env({"TOKEN_A": "new"}, env_path=env_path)
+    content = env_path.read_text()
+    assert "UNRELATED=keep_me" in content
+    assert "TOKEN_A=new" in content
+
+
+def test_save_tokens_to_env_mixed_update_and_append(tmp_path: Path) -> None:
+    """Some tokens exist (updated), some are new (appended)."""
+    env_path = tmp_path / ".env"
+    env_path.write_text("TOKEN_A=old_a\n")
+    save_tokens_to_env(
+        {"TOKEN_A": "new_a", "TOKEN_B": "new_b"},
+        env_path=env_path,
+    )
+    content = env_path.read_text()
+    assert "TOKEN_A=new_a" in content
+    assert "TOKEN_B=new_b" in content
+
+
+def test_save_tokens_to_env_atomic_vs_separate(tmp_path: Path) -> None:
+    """Atomic batch save produces same result as separate saves."""
+    # Batch save
+    env_batch = tmp_path / "batch.env"
+    env_batch.write_text("X=1\n")
+    save_tokens_to_env({"A": "1", "B": "2", "C": "3"}, env_path=env_batch)
+
+    # Separate saves
+    env_sep = tmp_path / "separate.env"
+    env_sep.write_text("X=1\n")
+    save_token_to_env("A", "1", env_path=env_sep)
+    save_token_to_env("B", "2", env_path=env_sep)
+    save_token_to_env("C", "3", env_path=env_sep)
+
+    # Both should have the same keys (order may differ)
+    batch_keys = {
+        line.split("=")[0]
+        for line in env_batch.read_text().splitlines()
+        if "=" in line and not line.startswith("#")
+    }
+    sep_keys = {
+        line.split("=")[0]
+        for line in env_sep.read_text().splitlines()
+        if "=" in line and not line.startswith("#")
+    }
+    assert batch_keys == sep_keys
+
+
+def test_save_tokens_empty_dict(tmp_path: Path) -> None:
+    """Empty dict is a no-op (file unchanged)."""
+    env_path = tmp_path / ".env"
+    env_path.write_text("KEEP=me\n")
+    save_tokens_to_env({}, env_path=env_path)
+    assert env_path.read_text() == "KEEP=me\n"

--- a/scripts/twitter/twitter.py
+++ b/scripts/twitter/twitter.py
@@ -53,7 +53,7 @@ For OAuth 2.0 setup:
 
 import os
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from functools import lru_cache
 
 import click
@@ -61,7 +61,7 @@ import tweepy
 from dotenv import load_dotenv
 from gptmail.communication_utils.auth import (  # type: ignore[import-not-found]
     run_oauth_callback,
-    save_token_to_env,
+    save_tokens_to_env,
 )
 from gptmail.communication_utils.auth.oauth import (  # type: ignore[import-not-found]
     OAuthManager,
@@ -203,38 +203,39 @@ def load_twitter_client(
                         if error or not new_token_info:
                             raise Exception(f"Token refresh failed: {error}")
 
-                        # Save new tokens to .env file
-                        save_token_to_env(
-                            "TWITTER_OAUTH2_ACCESS_TOKEN",
-                            new_token_info.token,
-                            comment="OAuth 2.0 User Context access token (auto-refreshed)",
-                        )
-                        if new_token_info.refresh_token:
-                            save_token_to_env(
-                                "TWITTER_OAUTH2_REFRESH_TOKEN",
-                                new_token_info.refresh_token,
-                                comment="OAuth 2.0 refresh token",
+                        # Fallback: if no expires_at from response, default to 2h
+                        if not new_token_info.expires_at:
+                            new_token_info = TokenInfo(
+                                token=new_token_info.token,
+                                expires_at=datetime.now(timezone.utc)
+                                + timedelta(hours=2),
+                                refresh_token=new_token_info.refresh_token,
+                                token_type=new_token_info.token_type,
                             )
-                        if new_token_info.expires_at:
-                            save_token_to_env(
-                                "TWITTER_OAUTH2_EXPIRES_AT",
-                                new_token_info.expires_at.isoformat(),
-                                comment="OAuth 2.0 token expiration time",
+                            console.print(
+                                "[yellow]No expires_in in response, defaulting to 2h expiry"
                             )
 
-                        # CRITICAL: Also update os.environ with new tokens
-                        # This ensures subsequent calls in the same process use new tokens
-                        # Twitter refresh tokens are single-use, so the old refresh token
-                        # is now invalid and must not be reused
-                        os.environ["TWITTER_OAUTH2_ACCESS_TOKEN"] = new_token_info.token
+                        # Save all tokens atomically to .env file
+                        tokens_to_save: dict[str, str] = {
+                            "TWITTER_OAUTH2_ACCESS_TOKEN": new_token_info.token,
+                        }
                         if new_token_info.refresh_token:
-                            os.environ["TWITTER_OAUTH2_REFRESH_TOKEN"] = (
+                            tokens_to_save["TWITTER_OAUTH2_REFRESH_TOKEN"] = (
                                 new_token_info.refresh_token
                             )
                         if new_token_info.expires_at:
-                            os.environ["TWITTER_OAUTH2_EXPIRES_AT"] = (
+                            tokens_to_save["TWITTER_OAUTH2_EXPIRES_AT"] = (
                                 new_token_info.expires_at.isoformat()
                             )
+                        save_tokens_to_env(
+                            tokens_to_save, comment="OAuth 2.0 tokens (auto-refreshed)"
+                        )
+
+                        # Also update os.environ so subsequent calls in the same
+                        # process use the new tokens (refresh tokens are single-use)
+                        for key, value in tokens_to_save.items():
+                            os.environ[key] = value
 
                         saved_token = new_token_info.token
                         console.print("[green]Token refreshed successfully")
@@ -323,34 +324,45 @@ def load_twitter_client(
                     access_token = oauth2_user_handler.fetch_token(
                         authorization_response=full_url
                     )
-                    print(f"{access_token=}")
+                    # Log the raw response for debugging token persistence issues
+                    console.print(
+                        f"[dim]fetch_token response keys: {list(access_token.keys())}"
+                    )
+                    console.print(
+                        f"[dim]  expires_in={access_token.get('expires_in', 'MISSING')}"
+                    )
+                    console.print(
+                        f"[dim]  refresh_token={'present' if 'refresh_token' in access_token else 'MISSING'}"
+                    )
 
-                    # Save all tokens to .env using shared utility
+                    # Save all tokens atomically to .env
                     try:
-                        save_token_to_env(
-                            "TWITTER_OAUTH2_ACCESS_TOKEN",
-                            access_token["access_token"],
-                            comment="OAuth 2.0 User Context access token",
-                        )
+                        new_tokens: dict[str, str] = {
+                            "TWITTER_OAUTH2_ACCESS_TOKEN": access_token["access_token"],
+                        }
 
-                        # Save refresh token if present
                         if "refresh_token" in access_token:
-                            save_token_to_env(
-                                "TWITTER_OAUTH2_REFRESH_TOKEN",
-                                access_token["refresh_token"],
-                                comment="OAuth 2.0 refresh token",
-                            )
+                            new_tokens["TWITTER_OAUTH2_REFRESH_TOKEN"] = access_token[
+                                "refresh_token"
+                            ]
 
-                        # Calculate and save expiration time
+                        # Calculate expiration time (fallback to 2h if expires_in absent)
                         if "expires_in" in access_token:
-                            expires_at = datetime.now() + timedelta(
+                            expires_at = datetime.now(timezone.utc) + timedelta(
                                 seconds=access_token["expires_in"]
                             )
-                            save_token_to_env(
-                                "TWITTER_OAUTH2_EXPIRES_AT",
-                                expires_at.isoformat(),
-                                comment="OAuth 2.0 token expiration time",
+                        else:
+                            expires_at = datetime.now(timezone.utc) + timedelta(hours=2)
+                            console.print(
+                                "[yellow]No expires_in in response, defaulting to 2h expiry"
                             )
+                        new_tokens["TWITTER_OAUTH2_EXPIRES_AT"] = expires_at.isoformat()
+
+                        save_tokens_to_env(new_tokens, comment="OAuth 2.0 tokens")
+
+                        # Update os.environ so subsequent calls in same process use new tokens
+                        for key, value in new_tokens.items():
+                            os.environ[key] = value
 
                         if "refresh_token" in access_token:
                             console.print(


### PR DESCRIPTION
## Summary

Fixes the recurring "token expired immediately after OAuth flow" bug that required Erik to repeatedly re-authenticate.

**Root causes found and fixed:**
- `save_token_to_env` was called 3 times separately (access_token, refresh_token, expires_at) — if `expires_in` was absent from Twitter's response, `expires_at` stayed stale in .env
- After full OAuth browser flow, `os.environ` was NOT updated (unlike the refresh path which did update it), so subsequent calls in the same process used stale tokens
- All datetime comparisons used naive `datetime.now()` — could break when comparing with timezone-aware stored timestamps

**Fixes:**
1. New `save_tokens_to_env()` batch helper — single atomic .env read-modify-write for all token fields
2. Both refresh and full OAuth paths now use atomic batch save
3. Both paths update `os.environ` after saving (was missing for full flow)
4. Fallback to 2h expiry when `expires_in` absent from Twitter response
5. Debug logging of `fetch_token` response keys for future diagnosis
6. `TokenInfo.is_expired()` handles both naive and aware datetimes (backwards-compatible)
7. All `datetime.now()` calls use `timezone.utc` consistently

**Tests:** 15 new tests (6 for batch save, 9 for timezone-aware expiry)

## Test plan

- [x] All 29 gptmail tests pass (15 new + 14 existing)
- [x] mypy clean
- [ ] CI green
- [ ] Erik re-auths Twitter, runs `twitter.py me` twice — second run should NOT trigger new OAuth flow

Closes: ErikBjare/bob#521
Ref: ErikBjare/bob#516, ErikBjare/bob#479