### PR TITLE
fix(twitter): silence tweepy SyntaxWarning spam

### DIFF
--- a/scripts/twitter/twitter.py
+++ b/scripts/twitter/twitter.py
@@ -53,12 +53,18 @@ For OAuth 2.0 setup:
 
 import os
 import sys
+import warnings
 from datetime import datetime, timedelta, timezone
 from functools import lru_cache
 from pathlib import Path
 
 import click
-import tweepy
+
+# Silence SyntaxWarning spam from tweepy's invalid escape sequences
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=SyntaxWarning, module="tweepy")
+    import tweepy  # noqa: E402
+
 from dotenv import load_dotenv
 from gptmail.communication_utils.auth import (  # type: ignore[import-not-found]
     run_oauth_callback,


### PR DESCRIPTION
## Summary
- Tweepy's pinned version has invalid escape sequences that produce `SyntaxWarning` noise on every import
- Wraps the `import tweepy` in `warnings.catch_warnings()` to filter `SyntaxWarning` before the import executes
- Uses a context manager so the filter is scoped and doesn't affect other warnings

## Test plan
- [ ] Run `./scripts/twitter/twitter.py --help` and verify no SyntaxWarning output
- [ ] Verify twitter commands still work (e.g. `./scripts/twitter/twitter.py me`)