### PR TITLE
perf(activity-gate): parallelize per-repo checks (~27s → ~7s)

### DIFF
--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -738,9 +738,11 @@ done
 wait
 
 # Collect results from all repos
+shopt -s nullglob
 for f in "$PARALLEL_TMPDIR"/*; do
-    [ -f "$f" ] && all_items+="$(cat "$f")"$'\n'
+    all_items+="$(cat "$f")"$'\n'
 done
+shopt -u nullglob
 
 if [ "$FORMAT" = "jsonl" ]; then
     notif_items=$(check_notifications)

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -76,6 +76,11 @@
 #   This reduces gh pr list calls from 3N to N (where N = number of repos).
 #   The repo list from discover_repos() is cached for 1 hour.
 #
+#   Parallelism: Per-repo work runs concurrently (up to 8 repos at once).
+#   State files are repo-prefixed, so there's no cross-repo contention.
+#   Results are collected via temp files. On a 13-repo org, this reduces
+#   wall-clock time from ~27s to ~7s.
+#
 #   Subshell note: Several checks pipe into `while read` loops, which run in
 #   subshells. Variable modifications inside these loops don't propagate to the
 #   parent. This is fine because output is captured via stdout, not variables.
@@ -680,30 +685,56 @@ check_notifications() {
 all_repos=$(discover_repos | sort -u)
 all_items=""
 
+# Process repos in parallel — each repo's checks are independent (state files
+# are repo-prefixed, no cross-repo contention). Collect output via temp files.
+# Cap concurrency at 8 to avoid GitHub API rate limits.
+PARALLEL_TMPDIR=$(mktemp -d)
+trap 'rm -rf "$PARALLEL_TMPDIR"' EXIT
+MAX_PARALLEL=8
+running=0
+
 for repo in $all_repos; do
-    # Fetch all PR data once per repo (replaces 3 separate gh pr list calls)
-    pr_data=$(fetch_pr_data "$repo")
+    repo_safe="${repo//\//-}"
+    (
+        # Fetch all PR data once per repo (replaces 3 separate gh pr list calls)
+        pr_data=$(fetch_pr_data "$repo")
+        repo_items=""
 
-    items=$(check_pr_updates "$repo" "$pr_data" 2>/dev/null || true)
-    [ -n "$items" ] && all_items+="$items"$'\n'
+        items=$(check_pr_updates "$repo" "$pr_data" 2>/dev/null || true)
+        [ -n "$items" ] && repo_items+="$items"$'\n'
 
-    items=$(check_ci_failures "$repo" "$pr_data" 2>/dev/null || true)
-    [ -n "$items" ] && all_items+="$items"$'\n'
+        items=$(check_ci_failures "$repo" "$pr_data" 2>/dev/null || true)
+        [ -n "$items" ] && repo_items+="$items"$'\n'
 
-    items=$(check_assigned_issues "$repo" 2>/dev/null || true)
-    [ -n "$items" ] && all_items+="$items"$'\n'
+        items=$(check_assigned_issues "$repo" 2>/dev/null || true)
+        [ -n "$items" ] && repo_items+="$items"$'\n'
 
-    items=$(check_master_ci "$repo" 2>/dev/null || true)
-    [ -n "$items" ] && all_items+="$items"$'\n'
+        items=$(check_master_ci "$repo" 2>/dev/null || true)
+        [ -n "$items" ] && repo_items+="$items"$'\n'
 
-    items=$(check_merge_conflicts "$repo" "$pr_data" 2>/dev/null || true)
-    [ -n "$items" ] && all_items+="$items"$'\n'
+        items=$(check_merge_conflicts "$repo" "$pr_data" 2>/dev/null || true)
+        [ -n "$items" ] && repo_items+="$items"$'\n'
 
-    items=$(check_greptile_scores "$repo" "$pr_data" 2>/dev/null || true)
-    [ -n "$items" ] && all_items+="$items"$'\n'
+        items=$(check_greptile_scores "$repo" "$pr_data" 2>/dev/null || true)
+        [ -n "$items" ] && repo_items+="$items"$'\n'
 
-    items=$(check_merge_ready "$repo" "$pr_data" 2>/dev/null || true)
-    [ -n "$items" ] && all_items+="$items"$'\n'
+        items=$(check_merge_ready "$repo" "$pr_data" 2>/dev/null || true)
+        [ -n "$items" ] && repo_items+="$items"$'\n'
+
+        [ -n "$repo_items" ] && printf '%s' "$repo_items" > "$PARALLEL_TMPDIR/$repo_safe"
+    ) &
+    running=$((running + 1))
+    if [ "$running" -ge "$MAX_PARALLEL" ]; then
+        # wait -n (bash 4.3+) waits for any single child; fall back to wait-all
+        wait -n 2>/dev/null || wait
+        running=0
+    fi
+done
+wait
+
+# Collect results from all repos
+for f in "$PARALLEL_TMPDIR"/*; do
+    [ -f "$f" ] && all_items+="$(cat "$f")"$'\n'
 done
 
 if [ "$FORMAT" = "jsonl" ]; then

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -726,8 +726,13 @@ for repo in $all_repos; do
     running=$((running + 1))
     if [ "$running" -ge "$MAX_PARALLEL" ]; then
         # wait -n (bash 4.3+) waits for any single child; fall back to wait-all
-        wait -n 2>/dev/null || wait
-        running=0
+        if wait -n 2>/dev/null; then
+            running=$((running - 1))
+        else
+            # wait -n not available (bash <4.3): wait for all, reset counter
+            wait
+            running=0
+        fi
     fi
 done
 wait


### PR DESCRIPTION
## Summary

- Parallelize per-repo work in the activity gate using background processes
- Each repo's checks are independent (state files are repo-prefixed, no cross-repo contention)
- Results collected via temp files, capped at 8 concurrent jobs to avoid GitHub API rate limits
- Measured on a 13-repo org: **27.5s → 7.3s (73% reduction)**

## Motivation

The activity gate runs at session start for agents that use `context.sh`. At 13 repos × ~2s per repo (sequential), it takes ~27s — the dominant cost of context loading. Since each repo's API calls and state tracking are fully independent, parallelizing is safe and straightforward.

## Implementation

- Each repo's work (fetch_pr_data + 7 check functions) runs in a subshell background process
- Output collected via temp files in a `mktemp -d` directory (cleaned up on EXIT trap)
- `wait -n` (bash 4.3+) for throttling, with fallback to `wait` for older bash
- No changes to check function logic or state file format

## Test plan

- [x] Verified on 13-repo org: consistent results across multiple runs
- [x] Tested both `markdown` and `jsonl` output formats
- [x] No state file corruption on repeated runs
- [ ] Should work on macOS (uses portable constructs, `wait -n` has fallback)