### PR TITLE
fix(validator): only flag opening fences for missing language tags

### DIFF
--- a/scripts/precommit/validators/validate_markdown_codeblock_syntax.py
+++ b/scripts/precommit/validators/validate_markdown_codeblock_syntax.py
@@ -69,8 +69,9 @@ class MarkdownCodeblockValidator:
                 if fence_match:
                     lang_tag = fence_match.group(1)
 
-                    # Empty language tag is a violation
-                    if not lang_tag:
+                    # Empty language tag on opening fence is a violation
+                    # (closing fences naturally have no tag — only odd count = opening)
+                    if not lang_tag and fence_count % 2 == 1:
                         self.violations.append(
                             (filepath, line_num, "No language tag specified")
                         )


### PR DESCRIPTION
## Summary
- Closing ```` ``` ```` fences were incorrectly flagged as missing language tags
- Added parity check (`fence_count % 2 == 1`) to only validate opening fences
- Reported by Gordon via agent message

## Test plan
- [x] Verified: file with tagged opening fences → clean pass
- [x] Verified: file with untagged opening fence → correctly flagged
- [x] Verified: closing fences no longer produce false warnings