### PR TITLE
docs(lessons): prefer brain repo over local machine memory

### DIFF
--- a/lessons/workflow/prefer-brain-over-local-memory.md
+++ b/lessons/workflow/prefer-brain-over-local-memory.md
@@ -1,0 +1,58 @@
+---
+match:
+  keywords:
+    - memory
+    - remember
+    - save
+    - persist
+    - knowledge
+    - brain
+    - MEMORY.md
+    - auto-memory
+---
+
+# Prefer Brain Repo Over Local Machine Memory
+
+## Rule
+When an agent has a brain repo (git workspace), persist knowledge there — not in runtime-local memory systems like Claude Code's `~/.claude/projects/*/memory/`.
+
+## Context
+Claude Code has a local auto-memory system (`MEMORY.md` + memory files) that persists across conversations on the same machine+project. Agents like Alice and Bob have their own git-based brain repos with `knowledge/`, `journal/`, and task systems. These serve different purposes.
+
+## Detection
+Observable signals you're about to make this mistake:
+- Writing to `~/.claude/projects/*/memory/` when the project IS an agent's brain repo
+- Saving knowledge about data sources, architecture, or findings to local memory instead of `knowledge/`
+- Information that other runtimes (gptme, other machines) would also benefit from
+
+## Pattern
+
+**Wrong**: Save to Claude Code's local memory
+```
+~/.claude/projects/-Users-erb-Programming-alice/memory/qs-data.md
+```
+This only exists on one machine, in one runtime. If Alice runs via gptme on alice-vm, this knowledge is invisible.
+
+**Correct**: Save to the brain repo
+```
+~/Programming/alice/knowledge/quantified-self/qs-data-landscape.md
+```
+This is versioned in git, available on all machines, included in all runtimes.
+
+**When to use local memory**: User preferences, feedback on Claude Code behavior, interaction style notes — things specific to the Claude Code runtime on this machine. These are the exception.
+
+**When to use brain repo**: Everything about the project, domain knowledge, data inventories, architecture decisions, process documentation. This is the default.
+
+## Outcome
+Following this pattern ensures:
+- Knowledge persists across all runtimes (gptme, Claude Code, Codex)
+- Knowledge is versioned and reviewable via git
+- Other agents or sessions on different machines can access it
+- The agent's brain is the single source of truth, not scattered across runtime-local stores
+
+## Related
+- Agent workspace architecture (ARCHITECTURE.md in each brain repo)
+- Task and journal systems are also brain-repo-local, not runtime-local
+
+## Origin
+2026-04-13: Alice saved QS data landscape to Claude Code local memory instead of brain repo's `knowledge/` directory. Erik corrected: "store stuff in alice's brain, not this local machine's memory."

--- a/lessons/workflow/prefer-brain-over-local-memory.md
+++ b/lessons/workflow/prefer-brain-over-local-memory.md
@@ -1,14 +1,12 @@
 ---
 match:
   keywords:
-    - memory
-    - remember
-    - save
-    - persist
-    - knowledge
-    - brain
-    - MEMORY.md
     - auto-memory
+    - MEMORY.md
+    - brain repo
+    - claude memory
+    - local memory
+status: active
 ---
 
 # Prefer Brain Repo Over Local Machine Memory

--- a/lessons/workflow/prefer-brain-over-local-memory.md
+++ b/lessons/workflow/prefer-brain-over-local-memory.md
@@ -17,7 +17,7 @@ match:
 When an agent has a brain repo (git workspace), persist knowledge there — not in runtime-local memory systems like Claude Code's `~/.claude/projects/*/memory/`.
 
 ## Context
-Claude Code has a local auto-memory system (`MEMORY.md` + memory files) that persists across conversations on the same machine+project. Agents like Alice and Bob have their own git-based brain repos with `knowledge/`, `journal/`, and task systems. These serve different purposes.
+Claude Code has a local auto-memory system (`MEMORY.md` + memory files) that persists across conversations on the same machine+project. Agents like Alice and Bob have their own git-based brain repos with `knowledge/`, `journal/`, and task systems. The local memory is strictly inferior — it's not versioned, not portable across machines, and invisible to other runtimes.
 
 ## Detection
 Observable signals you're about to make this mistake:
@@ -39,19 +39,17 @@ This only exists on one machine, in one runtime. If Alice runs via gptme on alic
 ```
 This is versioned in git, available on all machines, included in all runtimes.
 
-**When to use local memory**: User preferences, feedback on Claude Code behavior, interaction style notes — things specific to the Claude Code runtime on this machine. These are the exception.
+**Everything goes in the brain repo** — domain knowledge, user preferences, interaction style, feedback. There's no good reason for any of it to be local-only. Even "runtime-specific" preferences (like "user wants terse responses") are valuable across runtimes.
 
-**When to use brain repo**: Everything about the project, domain knowledge, data inventories, architecture decisions, process documentation. This is the default.
-
-**Best of both worlds — symlink approach**:
+**Symlink approach** (recommended — no trade-off):
 ```bash
-# Move Claude memory into brain repo
+# Move Claude memory into brain repo, symlink back
 mkdir -p knowledge/claude-memory
 cp ~/.claude/projects/-Users-.../memory/* knowledge/claude-memory/
 rm -rf ~/.claude/projects/-Users-.../memory
 ln -s /path/to/brain/knowledge/claude-memory ~/.claude/projects/-Users-.../memory
 ```
-This way Claude Code's auto-retrieval (MEMORY.md index + description-based relevance matching) still works, but the files live in git. You get Claude's retrieval mechanism AND git durability/portability.
+Claude Code's auto-retrieval (MEMORY.md index + description-based relevance matching) still works, but the files live in git. You get Claude's retrieval mechanism AND git durability/portability.
 
 ## Outcome
 Following this pattern ensures:

--- a/lessons/workflow/prefer-brain-over-local-memory.md
+++ b/lessons/workflow/prefer-brain-over-local-memory.md
@@ -15,7 +15,7 @@ status: active
 When an agent has a brain repo (git workspace), persist knowledge there — not in runtime-local memory systems like Claude Code's `~/.claude/projects/*/memory/`.
 
 ## Context
-Claude Code has a local auto-memory system (`MEMORY.md` + memory files) that persists across conversations on the same machine+project. Agents like Alice and Bob have their own git-based brain repos with `knowledge/`, `journal/`, and task systems. The local memory is strictly inferior — it's not versioned, not portable across machines, and invisible to other runtimes.
+Claude Code has a local auto-memory system (`MEMORY.md` + memory files) that persists across conversations on the same machine+project. It has useful retrieval features: an auto-loaded index, description-based relevance matching, and structured frontmatter. But it's not versioned, not portable across machines, and invisible to other runtimes. Agents with git-based brain repos (`knowledge/`, `journal/`, task systems) should use those instead — and the symlink approach below preserves Claude's retrieval while adding git durability.
 
 ## Detection
 Observable signals you're about to make this mistake:

--- a/lessons/workflow/prefer-brain-over-local-memory.md
+++ b/lessons/workflow/prefer-brain-over-local-memory.md
@@ -43,6 +43,16 @@ This is versioned in git, available on all machines, included in all runtimes.
 
 **When to use brain repo**: Everything about the project, domain knowledge, data inventories, architecture decisions, process documentation. This is the default.
 
+**Best of both worlds — symlink approach**:
+```bash
+# Move Claude memory into brain repo
+mkdir -p knowledge/claude-memory
+cp ~/.claude/projects/-Users-.../memory/* knowledge/claude-memory/
+rm -rf ~/.claude/projects/-Users-.../memory
+ln -s /path/to/brain/knowledge/claude-memory ~/.claude/projects/-Users-.../memory
+```
+This way Claude Code's auto-retrieval (MEMORY.md index + description-based relevance matching) still works, but the files live in git. You get Claude's retrieval mechanism AND git durability/portability.
+
 ## Outcome
 Following this pattern ensures:
 - Knowledge persists across all runtimes (gptme, Claude Code, Codex)


### PR DESCRIPTION
## Summary
- Adds lesson about persisting ALL agent knowledge in the brain repo (git) rather than runtime-local memory systems (e.g. Claude Code's `~/.claude/projects/*/memory/`)
- Everything belongs in the brain — domain knowledge, preferences, feedback. No carve-outs for "runtime-specific" data.
- Includes symlink solution: point Claude's memory dir at `knowledge/claude-memory/` in the brain repo. Claude's retrieval still works, files live in git. No trade-off.

## Origin
Alice saved QS data findings to Claude Code's local auto-memory instead of her brain repo. Erik corrected the pattern and pointed out even preferences should be in the brain, not just domain knowledge.

## Test plan
- [ ] Lesson keywords match expected triggers (memory, remember, save, persist, knowledge, brain)
- [ ] Lesson frontmatter is valid YAML
- [ ] Symlink approach tested (Alice's repo now uses this)