### PR TITLE
fix(link-checker): skip links inside fenced code blocks

### DIFF
--- a/scripts/precommit/check_markdown_links.py
+++ b/scripts/precommit/check_markdown_links.py
@@ -38,9 +38,14 @@ def get_repo_root() -> Path:
     return cwd
 
 
+def strip_code_blocks(content: str) -> str:
+    """Remove fenced code blocks to avoid checking example links inside them."""
+    return re.sub(r"```.*?```", "", content, flags=re.DOTALL)
+
+
 def extract_links(content: str) -> list[tuple[str, str]]:
-    """Extract all markdown links from content."""
-    return LINK_PATTERN.findall(content)
+    """Extract all markdown links from content, skipping code blocks."""
+    return LINK_PATTERN.findall(strip_code_blocks(content))
 
 
 def resolve_link(link: str, file_path: Path, repo_root: Path) -> Path | None:


### PR DESCRIPTION
## Problem

Master CI is failing on pre-commit checks because the markdown link checker was flagging example links inside fenced code blocks as broken.

Broken links reported:
- `lessons/patterns/indexed-knowledge-base-for-llm-retrieval.md`: `qs-data-landscape.md`, `predictive-framework.md`, `feedback-journal-format.md`

These are all **example links inside a ` ```markdown ` code block** — they're not meant to be real files.

## Fix

Strip fenced code blocks from content before extracting links to check. Added `strip_code_blocks()` helper that uses `re.sub(r"```.*?```", "", content, flags=re.DOTALL)`.

## Test plan

- [x] Verified `check_markdown_links.py lessons/patterns/indexed-knowledge-base-for-llm-retrieval.md` returns 0 (no errors)
- [x] Verified real links in other lesson files still get checked correctly
- [x] Pre-commit hooks pass locally