### PR TITLE
feat(scripts): add agent-check.sh for multi-agent health overview

### DIFF
--- a/scripts/agent-check.sh
+++ b/scripts/agent-check.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Agent health check — quick overview of all agent VMs
+#
+# Usage:
+#   ./agent-check.sh                  # check all configured agents
+#   ./agent-check.sh bob alice        # check specific agents
+#   AGENT_HOSTS="bob alice" ./agent-check.sh
+#
+# Configuration:
+#   Set AGENT_HOSTS env var, or edit the defaults below.
+#   Each agent host is an SSH alias (matching ~/.ssh/config).
+#
+# Per-agent commands:
+#   - Claude usage (if check-claude-usage.sh exists)
+#   - Session stats via gptme-sessions (auto-discovers CC + gptme sessions)
+#   - Recent git activity
+#
+# Prerequisites:
+#   - SSH access to agent VMs (configured in ~/.ssh/config)
+#   - gptme-sessions installed on each VM (uv tool install)
+
+set -euo pipefail
+
+# Default agent hosts — override with AGENT_HOSTS env var or positional args
+DEFAULT_HOSTS="bob alice gordon"
+HOSTS="${AGENT_HOSTS:-$DEFAULT_HOSTS}"
+if [[ $# -gt 0 ]]; then
+    HOSTS="$*"
+fi
+
+STATS_PERIOD="${STATS_PERIOD:-1d}"
+
+for host in $HOSTS; do
+    echo "============================================"
+    echo "  $host"
+    echo "============================================"
+
+    # Detect workspace directory (agent name = host by default)
+    workspace="$host"
+
+    # Claude usage (optional — only if script exists)
+    ssh "$host" "cd ~/$workspace 2>/dev/null && test -f ./scripts/check-claude-usage.sh && ./scripts/check-claude-usage.sh 2>/dev/null || test -f ./gptme-contrib/scripts/check-claude-usage.sh && ./gptme-contrib/scripts/check-claude-usage.sh 2>/dev/null || echo '  (no claude usage script found)'" 2>/dev/null || echo "  (ssh failed)"
+
+    echo ""
+
+    # Session stats via gptme-sessions
+    # First try sync to pick up any new sessions, then show stats
+    ssh "$host" "cd ~/$workspace 2>/dev/null && \$HOME/.local/bin/uv tool run gptme-sessions sync --since $STATS_PERIOD --signals 2>/dev/null | tail -1; \$HOME/.local/bin/uv tool run gptme-sessions stats --since $STATS_PERIOD 2>/dev/null || echo '  (gptme-sessions not available)'" 2>/dev/null || echo "  (ssh failed)"
+
+    echo ""
+
+    # Recent git activity
+    ssh "$host" "cd ~/$workspace 2>/dev/null && echo 'Recent commits:' && git log --oneline --since '$STATS_PERIOD' 2>/dev/null | head -5 || echo '  (no git repo)'" 2>/dev/null || echo "  (ssh failed)"
+
+    echo ""
+done

--- a/scripts/agent-check.sh
+++ b/scripts/agent-check.sh
@@ -8,7 +8,8 @@
 #
 # Configuration:
 #   Set AGENT_HOSTS env var, or edit the defaults below.
-#   Each agent host is an SSH alias (matching ~/.ssh/config).
+#   Each entry is "name" or "name=user@host" when the SSH target
+#   differs from the agent name (e.g. alice=alice@alice).
 #
 # Per-agent commands:
 #   - Claude usage (if check-claude-usage.sh exists)
@@ -22,7 +23,8 @@
 set -euo pipefail
 
 # Default agent hosts — override with AGENT_HOSTS env var or positional args
-DEFAULT_HOSTS="bob alice gordon"
+# Use "name=user@host" when SSH target differs from agent name
+DEFAULT_HOSTS="bob alice=alice@alice gordon"
 HOSTS="${AGENT_HOSTS:-$DEFAULT_HOSTS}"
 if [[ $# -gt 0 ]]; then
     HOSTS="$*"
@@ -30,27 +32,36 @@ fi
 
 STATS_PERIOD="${STATS_PERIOD:-1d}"
 
-for host in $HOSTS; do
+for entry in $HOSTS; do
+    # Parse "name=ssh_target" or just "name"
+    if [[ "$entry" == *=* ]]; then
+        host="${entry%%=*}"
+        ssh_target="${entry#*=}"
+    else
+        host="$entry"
+        ssh_target="$entry"
+    fi
+
     echo "============================================"
     echo "  $host"
     echo "============================================"
 
-    # Detect workspace directory (agent name = host by default)
+    # Workspace directory matches agent name
     workspace="$host"
 
     # Claude usage (optional — only if script exists)
-    ssh "$host" "cd ~/$workspace 2>/dev/null && test -f ./scripts/check-claude-usage.sh && ./scripts/check-claude-usage.sh 2>/dev/null || test -f ./gptme-contrib/scripts/check-claude-usage.sh && ./gptme-contrib/scripts/check-claude-usage.sh 2>/dev/null || echo '  (no claude usage script found)'" 2>/dev/null || echo "  (ssh failed)"
+    ssh "$ssh_target" "cd ~/$workspace 2>/dev/null && test -f ./scripts/check-claude-usage.sh && ./scripts/check-claude-usage.sh 2>/dev/null || test -f ./gptme-contrib/scripts/check-claude-usage.sh && ./gptme-contrib/scripts/check-claude-usage.sh 2>/dev/null || echo '  (no claude usage script found)'" 2>/dev/null || echo "  (ssh failed)"
 
     echo ""
 
     # Session stats via gptme-sessions
     # First try sync to pick up any new sessions, then show stats
-    ssh "$host" "cd ~/$workspace 2>/dev/null && \$HOME/.local/bin/uv tool run gptme-sessions sync --since $STATS_PERIOD --signals 2>/dev/null | tail -1; \$HOME/.local/bin/uv tool run gptme-sessions stats --since $STATS_PERIOD 2>/dev/null || echo '  (gptme-sessions not available)'" 2>/dev/null || echo "  (ssh failed)"
+    ssh "$ssh_target" "cd ~/$workspace 2>/dev/null && \$HOME/.local/bin/uv tool run gptme-sessions sync --since $STATS_PERIOD --signals 2>/dev/null | tail -1; \$HOME/.local/bin/uv tool run gptme-sessions stats --since $STATS_PERIOD 2>/dev/null || echo '  (gptme-sessions not available)'" 2>/dev/null || echo "  (ssh failed)"
 
     echo ""
 
     # Recent git activity
-    ssh "$host" "cd ~/$workspace 2>/dev/null && echo 'Recent commits:' && git log --oneline --since '$STATS_PERIOD' 2>/dev/null | head -5 || echo '  (no git repo)'" 2>/dev/null || echo "  (ssh failed)"
+    ssh "$ssh_target" "cd ~/$workspace 2>/dev/null && echo 'Recent commits:' && git log --oneline --since '$STATS_PERIOD' 2>/dev/null | head -5 || echo '  (no git repo)'" 2>/dev/null || echo "  (ssh failed)"
 
     echo ""
 done

--- a/scripts/agent-check.sh
+++ b/scripts/agent-check.sh
@@ -50,18 +50,19 @@ for entry in $HOSTS; do
     workspace="$host"
 
     # Claude usage (optional — only if script exists)
-    ssh "$ssh_target" "cd ~/$workspace 2>/dev/null && test -f ./scripts/check-claude-usage.sh && ./scripts/check-claude-usage.sh 2>/dev/null || test -f ./gptme-contrib/scripts/check-claude-usage.sh && ./gptme-contrib/scripts/check-claude-usage.sh 2>/dev/null || echo '  (no claude usage script found)'" 2>/dev/null || echo "  (ssh failed)"
+    # Use if/elif to avoid double-execution if the first script is found but exits non-zero
+    ssh -o ConnectTimeout=5 -o BatchMode=yes "$ssh_target" "cd ~/$workspace 2>/dev/null; if test -f ./scripts/check-claude-usage.sh; then ./scripts/check-claude-usage.sh 2>/dev/null; elif test -f ./gptme-contrib/scripts/check-claude-usage.sh; then ./gptme-contrib/scripts/check-claude-usage.sh 2>/dev/null; else echo '  (no claude usage script found)'; fi" 2>/dev/null || echo "  (ssh failed)"
 
     echo ""
 
     # Session stats via gptme-sessions
     # First try sync to pick up any new sessions, then show stats
-    ssh "$ssh_target" "cd ~/$workspace 2>/dev/null && \$HOME/.local/bin/uv tool run gptme-sessions sync --since $STATS_PERIOD --signals 2>/dev/null | tail -1; \$HOME/.local/bin/uv tool run gptme-sessions stats --since $STATS_PERIOD 2>/dev/null || echo '  (gptme-sessions not available)'" 2>/dev/null || echo "  (ssh failed)"
+    ssh -o ConnectTimeout=5 -o BatchMode=yes "$ssh_target" "cd ~/$workspace 2>/dev/null && \$HOME/.local/bin/uv tool run gptme-sessions sync --since '$STATS_PERIOD' --signals 2>/dev/null | tail -1; \$HOME/.local/bin/uv tool run gptme-sessions stats --since '$STATS_PERIOD' 2>/dev/null || echo '  (gptme-sessions not available)'" 2>/dev/null || echo "  (ssh failed)"
 
     echo ""
 
     # Recent git activity
-    ssh "$ssh_target" "cd ~/$workspace 2>/dev/null && echo 'Recent commits:' && git log --oneline --since '$STATS_PERIOD' 2>/dev/null | head -5 || echo '  (no git repo)'" 2>/dev/null || echo "  (ssh failed)"
+    ssh -o ConnectTimeout=5 -o BatchMode=yes "$ssh_target" "cd ~/$workspace 2>/dev/null && echo 'Recent commits:' && git log --oneline --since '$STATS_PERIOD' 2>/dev/null | head -5 || echo '  (no git repo)'" 2>/dev/null || echo "  (ssh failed)"
 
     echo ""
 done

--- a/scripts/agent-check.sh
+++ b/scripts/agent-check.sh
@@ -32,6 +32,14 @@ fi
 
 STATS_PERIOD="${STATS_PERIOD:-1d}"
 
+# Git's approxidate parser does not understand compact "1d" shorthands.
+# Translate "Xd" → "X days ago" so --since filters correctly scope commits.
+if [[ "$STATS_PERIOD" =~ ^([0-9]+)d$ ]]; then
+    GIT_SINCE="${BASH_REMATCH[1]} days ago"
+else
+    GIT_SINCE="$STATS_PERIOD"
+fi
+
 for entry in $HOSTS; do
     # Parse "name=ssh_target" or just "name"
     if [[ "$entry" == *=* ]]; then
@@ -62,7 +70,8 @@ for entry in $HOSTS; do
     echo ""
 
     # Recent git activity
-    ssh -o ConnectTimeout=5 -o BatchMode=yes "$ssh_target" "cd ~/$workspace 2>/dev/null && echo 'Recent commits:' && git log --oneline --since '$STATS_PERIOD' 2>/dev/null | head -5 || echo '  (no git repo)'" 2>/dev/null || echo "  (ssh failed)"
+    # Use GIT_SINCE (git approxidate format) rather than STATS_PERIOD (e.g. "1d" is not understood by git)
+    ssh -o ConnectTimeout=5 -o BatchMode=yes "$ssh_target" "cd ~/$workspace 2>/dev/null && echo 'Recent commits:' && git log --oneline --since '${GIT_SINCE}' 2>/dev/null | head -5 || echo '  (no git repo)'" 2>/dev/null || echo "  (ssh failed)"
 
     echo ""
 done


### PR DESCRIPTION
## Summary

- Adds `scripts/agent-check.sh` — a configurable multi-agent health checker
- SSHs into agent VMs and reports: Claude subscription usage, session stats (via `gptme-sessions`), recent git activity
- Auto-syncs discovered sessions before showing stats (works without post-session hooks)
- Configurable via `AGENT_HOSTS` env var, positional args, or `STATS_PERIOD`

## Usage

```bash
# Check all agents (default: bob alice gordon)
./scripts/agent-check.sh

# Check specific agents
./scripts/agent-check.sh bob alice

# Custom period
STATS_PERIOD=7d ./scripts/agent-check.sh
```

## Context

Erik had a manual `agent-check.sh` that called hardcoded SSH commands per agent. This version:
- Uses `gptme-sessions sync --signals` before stats (auto-imports CC trajectories)
- Works without post-session hooks (trajectory-based productivity detection)
- Is configurable rather than hardcoded

Related: gptme/gptme-contrib#655 (gptme-sessions should auto-discover in stats)

## Test plan

- [ ] Run on a machine with SSH access to agent VMs
- [ ] Verify it handles missing agents gracefully (SSH failure)
- [ ] Verify `gptme-sessions sync` picks up CC sessions without post-session hooks