### PR TITLE
feat(sessions): show hint when stats finds unsynced sessions

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -443,6 +443,7 @@ def stats(
         project=project,
     )
     s = store.stats(records)
+    showed_fallback = False
     if as_json:
         click.echo(json.dumps(s, indent=2))
     elif s.get("total", 0) == 0:
@@ -456,13 +457,15 @@ def stats(
             )
         else:
             _show_discovery_fallback(since_days=30)
+            showed_fallback = True
     else:
         if not since:
             click.echo(f"Last {since_days} days (use --since all for all-time):\n")
         format_stats(s)
-    if not as_json:
+    if not as_json and not showed_fallback:
         # Check for unsynced sessions regardless of whether stats matched anything —
         # hint is useful even when results exist (import may add more context).
+        # Skip when _show_discovery_fallback already printed a sync recommendation.
         hint_window = since_days if since_days else 30
         unsynced = _count_unsynced(store, since_days=hint_window)
         if unsynced > 0:

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -449,14 +449,6 @@ def stats(
         has_filters = any([model, run_type, category, harness, outcome, project, since])
         if has_filters:
             click.echo("No records match your filters.")
-            # Check if there are discoverable sessions that haven't been synced yet
-            hint_window = since_days if since_days else 30
-            unsynced = _count_unsynced(store, records=records, since_days=hint_window)
-            if unsynced > 0:
-                click.echo(
-                    f"Hint: {unsynced} session(s) discovered but not synced. "
-                    "Run 'gptme-sessions sync' to import."
-                )
         elif store.load_all():
             # Records exist but all fall outside the implicit 30-day window
             click.echo(
@@ -468,6 +460,16 @@ def stats(
         if not since:
             click.echo(f"Last {since_days} days (use --since all for all-time):\n")
         format_stats(s)
+    if not as_json:
+        # Check for unsynced sessions regardless of whether stats matched anything —
+        # hint is useful even when results exist (import may add more context).
+        hint_window = since_days if since_days else 30
+        unsynced = _count_unsynced(store, since_days=hint_window)
+        if unsynced > 0:
+            click.echo(
+                f"\nHint: {unsynced} session(s) discovered but not synced. "
+                "Run 'gptme-sessions sync' to import."
+            )
 
 
 # -- runs --------------------------------------------------------------------

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -140,7 +140,9 @@ def _count_unsynced(
         return 0
     if records is None:
         records = store.load_all()
-    existing_paths = {r.journal_path for r in records if r.journal_path}
+    existing_paths = {r.journal_path for r in records if r.journal_path} | {
+        r.trajectory_path for r in records if r.trajectory_path
+    }
     return sum(1 for e in discovered if str(e["path"]) not in existing_paths)
 
 

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -447,6 +447,14 @@ def stats(
         has_filters = any([model, run_type, category, harness, outcome, project, since])
         if has_filters:
             click.echo("No records match your filters.")
+            # Check if there are discoverable sessions that haven't been synced yet
+            hint_window = since_days if since_days else 30
+            unsynced = _count_unsynced(store, since_days=hint_window)
+            if unsynced > 0:
+                click.echo(
+                    f"Hint: {unsynced} session(s) discovered but not synced. "
+                    "Run 'gptme-sessions sync --signals' to import."
+                )
         elif store.load_all():
             # Records exist but all fall outside the implicit 30-day window
             click.echo(

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -451,11 +451,11 @@ def stats(
             click.echo("No records match your filters.")
             # Check if there are discoverable sessions that haven't been synced yet
             hint_window = since_days if since_days else 30
-            unsynced = _count_unsynced(store, since_days=hint_window)
+            unsynced = _count_unsynced(store, records=records, since_days=hint_window)
             if unsynced > 0:
                 click.echo(
                     f"Hint: {unsynced} session(s) discovered but not synced. "
-                    "Run 'gptme-sessions sync --signals' to import."
+                    "Run 'gptme-sessions sync' to import."
                 )
         elif store.load_all():
             # Records exist but all fall outside the implicit 30-day window

--- a/packages/gptme-sessions/tests/test_cli.py
+++ b/packages/gptme-sessions/tests/test_cli.py
@@ -281,7 +281,7 @@ class TestStatsCommand:
         assert "no records" in out.lower()
         assert "hint" in out.lower()
         assert "2 session(s) discovered but not synced" in out
-        assert "sync --signals" in out
+        assert "sync" in out
 
     def test_stats_no_matches_no_hint_when_all_synced(self, tmp_path: Path):
         """stats with filter that matches nothing shows no hint when all sessions are synced."""
@@ -323,6 +323,20 @@ class TestStatsCommand:
         assert rc == 0
         assert "no records" in out.lower()
         assert "hint" not in out.lower(), f"False-positive hint shown:\n{out}"
+
+    def test_stats_with_results_shows_unsynced_hint(self, tmp_path: Path):
+        """stats with matching results still shows hint when unsynced sessions exist."""
+        from unittest.mock import patch
+
+        _seed_store(tmp_path)
+        fake_discovered = [
+            {"harness": "claude-code", "path": Path("/fake/new-session.jsonl")},
+        ]
+        with patch("gptme_sessions.cli._discover_all", return_value=fake_discovered):
+            rc, out = _invoke(["stats"], tmp_path)
+        assert rc == 0
+        assert "hint" in out.lower()
+        assert "1 session(s) discovered but not synced" in out
 
     def test_stats_shows_model_breakdown(self, tmp_path: Path):
         """stats --json includes per-model breakdown."""
@@ -671,6 +685,8 @@ class TestStatsDefaults:
 
     def test_stats_old_records_no_misleading_fallback(self, tmp_path: Path):
         """stats on store with only old records shows a helpful message, not 'run sync'."""
+        from unittest.mock import patch
+
         store = SessionStore(sessions_dir=tmp_path)
         # Insert a record with a timestamp far in the past (outside the implicit 30d window)
         old_record = SessionRecord(
@@ -679,7 +695,8 @@ class TestStatsDefaults:
             timestamp="2020-01-01T00:00:00+00:00",
         )
         store.append(old_record)
-        rc, out = _invoke(["stats"], tmp_path)
+        with patch("gptme_sessions.cli._discover_all", return_value=[]):
+            rc, out = _invoke(["stats"], tmp_path)
         assert rc == 0
         # Should NOT tell the user to run sync (misleading — data is already synced)
         assert "sync" not in out.lower()

--- a/packages/gptme-sessions/tests/test_cli.py
+++ b/packages/gptme-sessions/tests/test_cli.py
@@ -295,6 +295,35 @@ class TestStatsCommand:
         assert "no records" in out.lower()
         assert "hint" not in out.lower()
 
+    def test_stats_no_matches_no_hint_when_synced_via_trajectory_path(self, tmp_path: Path):
+        """stats shows no hint when discovered sessions are already synced via trajectory_path.
+
+        This is the primary sync workflow: sync writes trajectory_path (not journal_path)
+        on imported records, so _count_unsynced must check both fields.
+        """
+        from unittest.mock import patch
+
+        store = SessionStore(sessions_dir=tmp_path)
+        fake_paths = ["/fake/logs/session1.jsonl", "/fake/logs/session2.jsonl"]
+        for path in fake_paths:
+            r = SessionRecord(
+                harness="claude-code",
+                model="sonnet",
+                run_type="autonomous",
+                category="code",
+                outcome="productive",
+                duration_seconds=600,
+                trajectory_path=path,
+            )
+            store.append(r)
+
+        fake_discovered = [{"harness": "claude-code", "path": Path(p)} for p in fake_paths]
+        with patch("gptme_sessions.cli._discover_all", return_value=fake_discovered):
+            rc, out = _invoke(["stats", "--model", "nonexistent"], tmp_path)
+        assert rc == 0
+        assert "no records" in out.lower()
+        assert "hint" not in out.lower(), f"False-positive hint shown:\n{out}"
+
     def test_stats_shows_model_breakdown(self, tmp_path: Path):
         """stats --json includes per-model breakdown."""
         _seed_store(tmp_path)

--- a/packages/gptme-sessions/tests/test_cli.py
+++ b/packages/gptme-sessions/tests/test_cli.py
@@ -265,6 +265,36 @@ class TestStatsCommand:
         assert rc == 0
         assert "no records" in out.lower()
 
+    def test_stats_no_matches_shows_unsynced_hint(self, tmp_path: Path):
+        """stats with filter that matches nothing shows hint when unsynced sessions exist."""
+        from unittest.mock import patch
+
+        _seed_store(tmp_path)
+        # Mock _discover_all to return fake unsynced sessions
+        fake_discovered = [
+            {"harness": "claude-code", "path": Path("/fake/session1.jsonl")},
+            {"harness": "gptme", "path": Path("/fake/session2.jsonl")},
+        ]
+        with patch("gptme_sessions.cli._discover_all", return_value=fake_discovered):
+            rc, out = _invoke(["stats", "--model", "nonexistent"], tmp_path)
+        assert rc == 0
+        assert "no records" in out.lower()
+        assert "hint" in out.lower()
+        assert "2 session(s) discovered but not synced" in out
+        assert "sync --signals" in out
+
+    def test_stats_no_matches_no_hint_when_all_synced(self, tmp_path: Path):
+        """stats with filter that matches nothing shows no hint when all sessions are synced."""
+        from unittest.mock import patch
+
+        _seed_store(tmp_path)
+        # Mock _discover_all to return empty (nothing to sync)
+        with patch("gptme_sessions.cli._discover_all", return_value=[]):
+            rc, out = _invoke(["stats", "--model", "nonexistent"], tmp_path)
+        assert rc == 0
+        assert "no records" in out.lower()
+        assert "hint" not in out.lower()
+
     def test_stats_shows_model_breakdown(self, tmp_path: Path):
         """stats --json includes per-model breakdown."""
         _seed_store(tmp_path)

--- a/packages/gptme-sessions/tests/test_cli.py
+++ b/packages/gptme-sessions/tests/test_cli.py
@@ -258,6 +258,27 @@ class TestStatsCommand:
         assert rc == 0
         assert "discover" in out.lower() or "sync" in out.lower() or "session" in out.lower()
 
+    def test_stats_empty_store_no_duplicate_hint(self, tmp_path: Path):
+        """stats on empty store with discovered sessions shows sync hint exactly once.
+
+        _show_discovery_fallback already prints a sync recommendation; the new
+        _count_unsynced hint must be suppressed in this code path to avoid
+        printing two nearly identical sync suggestions.
+        """
+        from unittest.mock import patch
+
+        SessionStore(sessions_dir=tmp_path)
+        fake_discovered = [
+            {"harness": "claude-code", "path": Path("/fake/session1.jsonl")},
+        ]
+        with patch("gptme_sessions.cli._discover_all", return_value=fake_discovered):
+            rc, out = _invoke(["stats"], tmp_path)
+        assert rc == 0
+        # Exactly one sync recommendation — not two
+        assert (
+            out.count("gptme-sessions sync") == 1
+        ), f"Expected exactly one sync recommendation, got:\n{out}"
+
     def test_stats_no_matches_with_filter(self, tmp_path: Path):
         """stats with filter that matches nothing shows appropriate message."""
         _seed_store(tmp_path)


### PR DESCRIPTION
## Summary

- When `gptme-sessions stats` (with filters like `--model`, `--since`) returns zero matching records, checks for discoverable sessions not yet imported into the store
- If unsynced sessions exist, prints a hint: `Hint: N session(s) discovered but not synced. Run 'gptme-sessions sync --signals' to import.`
- Does NOT auto-sync (that could be slow/surprising) — just informs the user
- Adds 2 tests: one verifying the hint appears, one verifying it doesn't appear when nothing is unsynced

## Test plan

- [x] All 52 existing + new CLI tests pass
- [x] `stats --model nonexistent` on a seeded store with mock unsynced sessions shows the hint
- [x] `stats --model nonexistent` on a seeded store with no unsynced sessions shows no hint
- [x] Existing `test_stats_no_matches_with_filter` still passes (no regression)

Closes #655