### PR TITLE
fix(sessions): support hours in --since flag

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -174,7 +174,10 @@ def _show_discovery_fallback(since_days: int = 30) -> None:
 
 
 def _parse_since(since: str | None) -> int | None:
-    """Parse a --since value like '7d', '30', or 'all' into days (None = no filter)."""
+    """Parse a --since value like '7d', '1h', '30', or 'all' into days (None = no filter).
+
+    Hours are converted to days (minimum 1 day for store queries).
+    """
     if not since:
         return None
     if since.lower() == "all":
@@ -182,10 +185,14 @@ def _parse_since(since: str | None) -> int | None:
     try:
         if since.endswith("d"):
             return int(since[:-1])
+        if since.endswith("h"):
+            import math
+
+            return max(1, math.ceil(int(since[:-1]) / 24))
         return int(since)
     except ValueError:
         raise click.BadParameter(
-            f"invalid value {since!r} (expected e.g. 7d, 30d, or 'all')",
+            f"invalid value {since!r} (expected e.g. 1h, 7d, 30d, or 'all')",
             param_hint="'--since'",
         )
 


### PR DESCRIPTION
## Summary
- Adds `h` suffix support to `--since` (e.g. `--since 1h`, `--since 6h`)
- Hours are ceil'd to days (minimum 1) since the store queries use day granularity
- Updates help text and error messages to mention the new format

## Context
`gptme-sessions stats --since 1h` was failing with "Invalid value". Hours are useful for quick checks during active development/monitoring.