### PR TITLE
fix(sessions): filter CC stub sessions and gptme eval sessions from discovery

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/discovery.py
+++ b/packages/gptme-sessions/src/gptme_sessions/discovery.py
@@ -188,6 +188,9 @@ def discover_gptme_sessions(
     Scans ``~/.local/share/gptme/logs/`` (or ``GPTME_LOGS_DIR``) for
     directories whose name starts with an ISO date in ``[start, end]``.
 
+    Eval sessions (``gptme-evals-*``) are excluded — these are automated
+    benchmark runs that should not count as real agent work sessions.
+
     Returns sorted list of session directory paths.
     """
     if logs_dir is None:
@@ -201,6 +204,11 @@ def discover_gptme_sessions(
         for entry in sorted(logs_dir.iterdir()):
             if not entry.is_dir():
                 continue
+            # Skip eval benchmark sessions — they are not real work sessions
+            # and inflate NOOP counts when synced into session records.
+            name_after_date = entry.name[11:]  # strip YYYY-MM-DD- prefix
+            if name_after_date.startswith("gptme-evals-"):
+                continue
             if _session_in_range(entry.name, start, end):
                 sessions.append(entry)
     except PermissionError:
@@ -208,16 +216,28 @@ def discover_gptme_sessions(
     return sessions
 
 
+# Minimum file size for CC sessions to filter out stub sessions.
+# CC creates ~2.8KB metadata-only stubs for sessions that never got an
+# assistant response (e.g. cancelled before first reply, permission prompts
+# that were declined).  These contain only permission-mode, system prompts,
+# and user messages — no actual work.  Counting them inflates NOOP rates.
+CC_MIN_SESSION_SIZE = 4096  # bytes
+
+
 def discover_cc_sessions(
     start: date,
     end: date,
     cc_dir: Path | None = None,
+    min_size: int = CC_MIN_SESSION_SIZE,
 ) -> list[Path]:
     """Find Claude Code session JSONL files within a date range.
 
     Scans ``~/.claude/projects/`` (or ``CLAUDE_HOME/projects/``) for
     session ``.jsonl`` files. Uses quick first-line timestamp extraction
     for fast date filtering.
+
+    Files smaller than *min_size* bytes are skipped — these are typically
+    stub sessions that never received an assistant response.
 
     Returns sorted list of session JSONL file paths.
     """
@@ -233,6 +253,9 @@ def discover_cc_sessions(
             if not project_dir.is_dir():
                 continue
             for jsonl_file in sorted(project_dir.glob("*.jsonl")):
+                # Skip stub sessions (metadata-only, no assistant response)
+                if min_size > 0 and jsonl_file.stat().st_size < min_size:
+                    continue
                 session_date = _quick_date_from_jsonl(jsonl_file)
                 if session_date is None:
                     continue

--- a/packages/gptme-sessions/tests/test_discovery.py
+++ b/packages/gptme-sessions/tests/test_discovery.py
@@ -220,6 +220,21 @@ def test_discover_gptme_sessions_nonexistent(tmp_path: Path) -> None:
     assert result == []
 
 
+def test_discover_gptme_sessions_excludes_evals(tmp_path: Path) -> None:
+    """Eval benchmark sessions (gptme-evals-*) are excluded from discovery."""
+    # Real session
+    (tmp_path / "2026-03-05-dancing-blue-fish").mkdir()
+    # Eval sessions — should be excluded
+    (tmp_path / "2026-03-05-gptme-evals-anthropic--claude-sonnet-4-6-tool-abc123").mkdir()
+    (
+        tmp_path / "2026-03-05-gptme-evals-openrouter--anthropic--claude-haiku-4-5-tool-def456"
+    ).mkdir()
+
+    result = discover_gptme_sessions(date(2026, 3, 5), date(2026, 3, 5), logs_dir=tmp_path)
+    assert len(result) == 1
+    assert result[0].name == "2026-03-05-dancing-blue-fish"
+
+
 # --- discover_cc_sessions ---
 
 
@@ -242,7 +257,7 @@ def test_discover_cc_sessions(tmp_path: Path) -> None:
     _make_cc_session(project, "session3", "2026-03-05T14:00:00Z")
     _make_cc_session(project, "session4", "2026-03-06T09:00:00Z")
 
-    result = discover_cc_sessions(date(2026, 3, 5), date(2026, 3, 5), cc_dir=tmp_path)
+    result = discover_cc_sessions(date(2026, 3, 5), date(2026, 3, 5), cc_dir=tmp_path, min_size=0)
     assert len(result) == 2
     names = [p.stem for p in result]
     assert "session2" in names
@@ -260,7 +275,7 @@ def test_discover_cc_sessions_multi_project(tmp_path: Path) -> None:
     _make_cc_session(proj_b, "s2", "2026-03-05T11:00:00Z")
     _make_cc_session(proj_b, "s3", "2026-03-04T11:00:00Z")  # out of range
 
-    result = discover_cc_sessions(date(2026, 3, 5), date(2026, 3, 5), cc_dir=tmp_path)
+    result = discover_cc_sessions(date(2026, 3, 5), date(2026, 3, 5), cc_dir=tmp_path, min_size=0)
     assert len(result) == 2
 
 
@@ -269,6 +284,47 @@ def test_discover_cc_sessions_nonexistent(tmp_path: Path) -> None:
         date(2026, 3, 5), date(2026, 3, 5), cc_dir=tmp_path / "nonexistent"
     )
     assert result == []
+
+
+def test_discover_cc_sessions_filters_stubs(tmp_path: Path) -> None:
+    """Stub sessions (<4KB) are excluded by default; real sessions are kept."""
+    from gptme_sessions.discovery import CC_MIN_SESSION_SIZE
+
+    project = tmp_path / "-home-bob-bob"
+    project.mkdir()
+
+    # Create a stub session (small file, <4KB) — should be filtered
+    stub = _make_cc_session(project, "stub-session", "2026-03-05T10:00:00Z")
+    assert stub.stat().st_size < CC_MIN_SESSION_SIZE  # sanity check
+
+    # Create a real session (padded above threshold)
+    real = project / "real-session.jsonl"
+    line = json.dumps(
+        {"type": "user", "timestamp": "2026-03-05T12:00:00Z", "message": {"content": "hi"}}
+    )
+    # Pad with enough assistant lines to exceed 4KB
+    padding_line = json.dumps(
+        {
+            "message": {
+                "role": "assistant",
+                "model": "claude-opus-4-6",
+                "content": [{"type": "text", "text": "x" * 200}],
+            }
+        }
+    )
+    real.write_text((line + "\n") + (padding_line + "\n") * 20)
+    assert real.stat().st_size >= CC_MIN_SESSION_SIZE  # sanity check
+
+    # Default min_size: stub excluded, real included
+    result = discover_cc_sessions(date(2026, 3, 5), date(2026, 3, 5), cc_dir=tmp_path)
+    assert len(result) == 1
+    assert result[0].stem == "real-session"
+
+    # With min_size=0: both included
+    result_all = discover_cc_sessions(
+        date(2026, 3, 5), date(2026, 3, 5), cc_dir=tmp_path, min_size=0
+    )
+    assert len(result_all) == 2
 
 
 # --- discover_codex_sessions ---


### PR DESCRIPTION
## Summary
- `discover_cc_sessions()` now skips JSONL files smaller than 4KB (`CC_MIN_SESSION_SIZE`), filtering out CC metadata-only stub sessions that never received an assistant response (~2.8KB files created when sessions are cancelled or permission prompts declined)
- `discover_gptme_sessions()` now skips directories matching `gptme-evals-*`, filtering out automated eval benchmark runs that aren't real work sessions
- Both filters are tested; existing CC tests pass `min_size=0` to preserve their date-filtering coverage

Fixes a metrics pollution issue where ~125 sessions were classified as "unknown" with 100% NOOP rate, inflating friction analysis numbers.

## Test plan
- [x] All 50 discovery tests pass (`uv run pytest packages/gptme-sessions/tests/test_discovery.py -v`)
- [x] New test `test_discover_cc_sessions_filters_stubs` verifies stub exclusion and `min_size=0` bypass
- [x] New test `test_discover_gptme_sessions_excludes_evals` verifies eval session exclusion
- [x] Existing CC tests updated to use `min_size=0` (they test date filtering, not size filtering)