### PR TITLE
fix(twitter): clarify identity in eval prompt for direct mentions

### DIFF
--- a/scripts/twitter/llm.py
+++ b/scripts/twitter/llm.py
@@ -249,12 +249,23 @@ def create_tweet_eval_prompt(tweet: Dict, config: Dict) -> str:
         for i, t in enumerate(tweet["thread_context"]):
             thread_context += f"Tweet {i + 1} - @{t['author']}: {t['text']}\n"
 
+    # Detect if tweet is a direct mention of our handle
+    twitter_handle = os.environ.get("TWITTER_HANDLE", "agent")
+    tweet_text = tweet.get("text", "")
+    is_direct_mention = f"@{twitter_handle}" in tweet_text
+    mention_note = (
+        f"\nIMPORTANT: This tweet directly mentions @{twitter_handle} — that IS our account."
+        f" This tweet is addressed TO us. Evaluate it as a message requiring our response."
+        if is_direct_mention
+        else ""
+    )
+
     return f"""Evaluate this tweet for response suitability.
 
-Tweet: "{tweet["text"]}"
+Tweet: "{tweet_text}"
 Author: @{tweet["author"]}
 Context: {json.dumps(tweet.get("context", {}), indent=2)}
-{thread_context}
+{thread_context}{mention_note}
 
 Evaluation criteria:
 1. Relevance to our topics: {", ".join(config["evaluation"]["topics"])}

--- a/scripts/twitter/llm.py
+++ b/scripts/twitter/llm.py
@@ -250,12 +250,14 @@ def create_tweet_eval_prompt(tweet: Dict, config: Dict) -> str:
             thread_context += f"Tweet {i + 1} - @{t['author']}: {t['text']}\n"
 
     # Detect if tweet is a direct mention of our handle
-    twitter_handle = os.environ.get("TWITTER_HANDLE", "agent")
+    twitter_handle = os.environ.get("TWITTER_HANDLE")
     tweet_text = tweet.get("text", "")
-    is_direct_mention = f"@{twitter_handle}" in tweet_text
+    is_direct_mention = bool(
+        twitter_handle and f"@{twitter_handle}".lower() in tweet_text.lower()
+    )
     mention_note = (
         f"\nIMPORTANT: This tweet directly mentions @{twitter_handle} — that IS our account."
-        f" This tweet is addressed TO us. Evaluate it as a message requiring our response."
+        f" This tweet is addressed TO us. Evaluate it as relevant to us personally."
         if is_direct_mention
         else ""
     )


### PR DESCRIPTION
## Problem

When @ErikBjare replied to a tweet with `@TimeToBuildBob More 404'ing links :(`, the LLM evaluation cached it as IGNORE with reasoning:

> "The mention is directed at @TimeToBuildBob, not at our agent account. We are not directly involved in this conversation and responding would be inserting ourselves unnecessarily into someone else's bug report."

This is wrong — we ARE @TimeToBuildBob. The system prompt says so, but the LLM forgot when evaluating the specific tweet.

## Fix

When the tweet text contains `@{TWITTER_HANDLE}` (our own handle), add an explicit sentence to the evaluation prompt:

```
IMPORTANT: This tweet directly mentions @TimeToBuildBob — that IS our account. This tweet is addressed TO us. Evaluate it as a message requiring our response.
```

This is a minimal prompt addition, no API changes required. The `TWITTER_HANDLE` env var is already set in the deployment environment.

## Why this works

The LLM was reasoning correctly but from a confused premise. Making the identity explicit in the per-tweet prompt — not just in the system prompt — prevents the "we're not part of this conversation" reasoning error.

## Related

- ErikBjare/bob#602 — the incident that revealed this bug