### PR TITLE
fix(activity-summary): pass min_size=0 in tests to bypass CC stub filter

### DIFF
--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_session_data.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_session_data.py
@@ -9,7 +9,11 @@ import logging
 from datetime import datetime
 from pathlib import Path
 
-from gptme_sessions.discovery import decode_cc_project_path, discover_cc_sessions
+from gptme_sessions.discovery import (
+    CC_MIN_SESSION_SIZE,
+    decode_cc_project_path,
+    discover_cc_sessions,
+)
 from gptme_sessions.signals import extract_usage_cc, parse_trajectory
 
 from .session_data import SessionInfo, SessionStats, _aggregate_session
@@ -75,15 +79,20 @@ def fetch_cc_session_stats_range(
     start,
     end,
     cc_dir: Path | None = None,
+    min_size: int = CC_MIN_SESSION_SIZE,
 ) -> SessionStats:
     """Fetch aggregated CC session stats for a date range.
 
     Uses gptme-sessions for directory discovery and token extraction.
     Handles CC-specific metadata (workspace, interactive, timestamps) locally.
+
+    *min_size* is passed to :func:`~gptme_sessions.discovery.discover_cc_sessions`
+    to skip stub session files.  Pass ``min_size=0`` in tests to bypass the
+    size filter when working with small synthetic JSONL files.
     """
     stats = SessionStats(start_date=start, end_date=end)
 
-    for jsonl_file in discover_cc_sessions(start, end, cc_dir):
+    for jsonl_file in discover_cc_sessions(start, end, cc_dir, min_size=min_size):
         msgs = parse_trajectory(jsonl_file)
 
         # Token usage via gptme-sessions

--- a/packages/gptme-activity-summary/tests/test_cc_session_data.py
+++ b/packages/gptme-activity-summary/tests/test_cc_session_data.py
@@ -101,7 +101,9 @@ def test_empty_session_filtered(tmp_path):
     _make_session_jsonl(tmp_path, "-home-bob-bob", "empty-sess", empty_msgs)
     _make_session_jsonl(tmp_path, "-home-bob-bob", "real-sess", real_msgs)
 
-    stats = fetch_cc_session_stats_range(date(2026, 2, 17), date(2026, 2, 17), cc_dir=tmp_path)
+    stats = fetch_cc_session_stats_range(
+        date(2026, 2, 17), date(2026, 2, 17), cc_dir=tmp_path, min_size=0
+    )
     assert stats.session_count == 1  # only the real session
     assert stats.total_input_tokens == 100
 
@@ -129,14 +131,18 @@ def test_fetch_cc_session_stats_range(tmp_path):
     _make_session_jsonl(tmp_path, "-home-bob-bob", "sess-b", messages_16)
 
     # Query just Feb 17
-    stats = fetch_cc_session_stats_range(date(2026, 2, 17), date(2026, 2, 17), cc_dir=tmp_path)
+    stats = fetch_cc_session_stats_range(
+        date(2026, 2, 17), date(2026, 2, 17), cc_dir=tmp_path, min_size=0
+    )
     assert stats.session_count == 1
     assert stats.total_input_tokens == 1000
     assert stats.total_output_tokens == 500
     assert "claude-opus-4-6" in stats.models_used
 
     # Query full range
-    stats_all = fetch_cc_session_stats_range(date(2026, 2, 16), date(2026, 2, 17), cc_dir=tmp_path)
+    stats_all = fetch_cc_session_stats_range(
+        date(2026, 2, 16), date(2026, 2, 17), cc_dir=tmp_path, min_size=0
+    )
     assert stats_all.session_count == 2
     assert stats_all.total_input_tokens == 1200
     assert "claude-opus-4-6" in stats_all.models_used
@@ -172,7 +178,9 @@ def test_multiple_projects(tmp_path):
     _make_session_jsonl(tmp_path, "-home-bob-bob", "sess-1", messages_a)
     _make_session_jsonl(tmp_path, "-home-bob-other", "sess-2", messages_b)
 
-    stats = fetch_cc_session_stats_range(date(2026, 2, 17), date(2026, 2, 17), cc_dir=tmp_path)
+    stats = fetch_cc_session_stats_range(
+        date(2026, 2, 17), date(2026, 2, 17), cc_dir=tmp_path, min_size=0
+    )
     assert stats.session_count == 2
     assert stats.total_input_tokens == 300
     assert stats.total_output_tokens == 150


### PR DESCRIPTION
## Summary

- PR #662 added a 4KB minimum size filter to `discover_cc_sessions()` to skip stub sessions (metadata-only files with no assistant response)
- This broke 3 tests in `gptme-activity-summary` that create small synthetic JSONL files (~100 bytes), which get filtered out before the `steps == 0` guard can run
- Fix: expose `min_size` param in `fetch_cc_session_stats_range()` and pass `min_size=0` in the 3 affected tests

The `steps == 0` check in `cc_session_data.py` already handles empty sessions at the application level; the size filter is a production performance optimization that tests should opt out of.

## Test plan

- [ ] `test_empty_session_filtered` — verifies session without assistant turns is filtered (application-level check)
- [ ] `test_fetch_cc_session_stats_range` — verifies date-range filtering and token aggregation
- [ ] `test_multiple_projects` — verifies cross-project aggregation