### PR TITLE
fix(twitter): default TWITTER_HANDLE + annotate our thread messages

### DIFF
--- a/scripts/twitter/llm.py
+++ b/scripts/twitter/llm.py
@@ -388,7 +388,7 @@ def get_system_prompt() -> Message:
 
     # Create Twitter-specific system prompt
     agent_name = os.environ.get("AGENT_NAME", "Agent")
-    twitter_handle = os.environ.get("TWITTER_HANDLE", "agent")
+    twitter_handle = os.environ.get("TWITTER_HANDLE", "TimeToBuildBob")
     twitter_prompt = f"""You are {agent_name} (@{twitter_handle}), an AI agent who evaluates and responds to tweets.
 Your task is to evaluate tweets and generate appropriate responses while:
 1. Maintaining your established personality (direct, opinionated, occasionally witty)

--- a/scripts/twitter/llm.py
+++ b/scripts/twitter/llm.py
@@ -242,25 +242,45 @@ def load_config() -> Dict[Any, Any]:
 
 def create_tweet_eval_prompt(tweet: Dict, config: Dict) -> str:
     """Create prompt for tweet evaluation"""
-    # Include thread context if available
+    # Our handle — default matches twitter.py's TWITTER_EXPECTED_USERNAME default
+    # so the identity-context injection works out-of-the-box in production.
+    twitter_handle = os.environ.get("TWITTER_HANDLE", "TimeToBuildBob")
+    handle_lower = twitter_handle.lower()
+
+    # Include thread context if available. Annotate our own prior messages so
+    # the LLM doesn't read the thread as "two other parties" and conclude the
+    # conversation is already resolved.
     thread_context = ""
+    in_thread = False
     if tweet.get("thread_context"):
         thread_context = "\nConversation Thread:\n"
         for i, t in enumerate(tweet["thread_context"]):
-            thread_context += f"Tweet {i + 1} - @{t['author']}: {t['text']}\n"
+            author = t["author"]
+            is_us = author.lower() == handle_lower
+            if is_us:
+                in_thread = True
+            marker = " (US — our prior message)" if is_us else ""
+            thread_context += f"Tweet {i + 1} - @{author}{marker}: {t['text']}\n"
 
-    # Detect if tweet is a direct mention of our handle
-    twitter_handle = os.environ.get("TWITTER_HANDLE")
+    # Direct mention detection: handle appears in the tweet body itself.
     tweet_text = tweet.get("text", "")
-    is_direct_mention = bool(
-        twitter_handle and f"@{twitter_handle}".lower() in tweet_text.lower()
-    )
-    mention_note = (
-        f"\nIMPORTANT: This tweet directly mentions @{twitter_handle} — that IS our account."
-        f" This tweet is addressed TO us. Evaluate it as relevant to us personally."
-        if is_direct_mention
-        else ""
-    )
+    is_direct_mention = f"@{handle_lower}" in tweet_text.lower()
+
+    # Build identity context. Fire for direct mentions OR when we're in the
+    # thread — both cases need explicit identity to prevent confusion.
+    mention_note = ""
+    if is_direct_mention or in_thread:
+        mention_note = (
+            f"\nIMPORTANT: @{twitter_handle} IS our account — we are @{twitter_handle}."
+        )
+        if is_direct_mention:
+            mention_note += " This tweet is addressed TO us. Evaluate it as relevant to us personally."
+        if in_thread:
+            mention_note += (
+                f" Any prior @{twitter_handle} messages in the thread are OUR own replies;"
+                " their presence does NOT mean the conversation is resolved."
+                " Evaluate whether the most recent message from another party needs our response."
+            )
 
     return f"""Evaluate this tweet for response suitability.
 

--- a/tests/test_twitter_eval_prompt.py
+++ b/tests/test_twitter_eval_prompt.py
@@ -169,24 +169,104 @@ def test_case_insensitive_handle_match(
     assert "IS our account" in prompt
 
 
-def test_unset_handle_skips_detection(
+def test_unset_handle_uses_default_and_unrelated_mention_skipped(
     llm_module: types.ModuleType,
     eval_config: dict[str, Any],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """When TWITTER_HANDLE is unset, detection must be skipped entirely.
+    """When TWITTER_HANDLE is unset, the module default 'TimeToBuildBob' is used.
 
-    Regression guard for review feedback: the original code used a fallback
-    default 'agent', which would cause false non-matches on tweets mentioning
-    @agent. The fix removed that default — with no env var, no note is added.
+    A tweet mentioning an unrelated handle (@agent) still gets no identity note
+    because the default handle is 'TimeToBuildBob', not 'agent'. This guards
+    against false positives when the env var isn't explicitly configured
+    (the common production case — see ErikBjare/bob#602 follow-up).
     """
     monkeypatch.delenv("TWITTER_HANDLE", raising=False)
-    # Tweet that would have matched the old default handle 'agent'
+    # Tweet mentioning an unrelated handle
     tweet = _base_tweet("@agent can you help with this?")
 
     prompt = llm_module.create_tweet_eval_prompt(tweet, eval_config)
 
     assert "IS our account" not in prompt
+
+
+def test_unset_handle_default_fires_on_timetobuildbob_mention(
+    llm_module: types.ModuleType,
+    eval_config: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With TWITTER_HANDLE unset, the default 'TimeToBuildBob' still triggers detection.
+
+    Regression guard for ErikBjare/bob#602 follow-up: production was missing
+    TWITTER_HANDLE env var, so the fix from #663 never fired. The default
+    ensures identity injection works out-of-the-box even without env config.
+    """
+    monkeypatch.delenv("TWITTER_HANDLE", raising=False)
+    tweet = _base_tweet("@TimeToBuildBob is your timeline monitoring working?")
+
+    prompt = llm_module.create_tweet_eval_prompt(tweet, eval_config)
+
+    assert "IS our account" in prompt
+    assert "@TimeToBuildBob" in prompt
+
+
+def test_our_handle_in_thread_context_triggers_identity_note(
+    llm_module: types.ModuleType,
+    eval_config: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When our handle appears as a thread author, inject identity context.
+
+    Regression guard for ErikBjare/bob#602: the LLM saw a thread where
+    @TimeToBuildBob had already replied and concluded the conversation was
+    "a resolved technical issue between two other parties" — completely
+    missing that @TimeToBuildBob IS us. The eval prompt must mark our prior
+    messages and explain that their presence doesn't mean the thread is done.
+    """
+    monkeypatch.setenv("TWITTER_HANDLE", "TimeToBuildBob")
+    tweet = {
+        "text": "Doesn't seem to be working?",
+        "author": "ErikBjare",
+        "context": {},
+        "thread_context": [
+            {"author": "TimeToBuildBob", "text": "Here's my original tweet"},
+            {"author": "ErikBjare", "text": "404 link"},
+            {"author": "TimeToBuildBob", "text": "Corrected URL"},
+        ],
+    }
+
+    prompt = llm_module.create_tweet_eval_prompt(tweet, eval_config)
+
+    # Identity note fires because we're in the thread (even though the current
+    # tweet text doesn't contain @TimeToBuildBob)
+    assert "IS our account" in prompt
+    # Our prior messages are explicitly marked
+    assert "(US — our prior message)" in prompt
+    # Explain that prior replies don't mean the conversation is resolved
+    assert "does NOT mean the conversation is resolved" in prompt
+
+
+def test_thread_context_without_us_does_not_trigger(
+    llm_module: types.ModuleType,
+    eval_config: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Thread without our handle among authors should not trigger identity note."""
+    monkeypatch.setenv("TWITTER_HANDLE", "TimeToBuildBob")
+    tweet = {
+        "text": "Interesting thread",
+        "author": "SomeUser",
+        "context": {},
+        "thread_context": [
+            {"author": "OtherUserA", "text": "Original"},
+            {"author": "OtherUserB", "text": "Reply"},
+        ],
+    }
+
+    prompt = llm_module.create_tweet_eval_prompt(tweet, eval_config)
+
+    assert "IS our account" not in prompt
+    assert "(US — our prior message)" not in prompt
 
 
 def test_substring_handle_triggers_known_false_positive(


### PR DESCRIPTION
## Summary

The identity-context fix from #663 never fired in production because `TWITTER_HANDLE` was unset in the service env — so `is_direct_mention` was always `False`. Additionally, when our handle appeared in `thread_context` (e.g. an ongoing conversation with a trusted user), the LLM read the thread anonymously and concluded "resolved issue between two other parties", incorrectly ignoring replies that needed our response.

## Context

Erik replied to one of Bob's tweets about a 404'ing link on 2026-04-16. Bob never replied. Erik noticed and filed ErikBjare/bob#602: *"I replied to one of your tweets earlier (about a 404 link) but you never replied. Doesn't seem to be working?"*

Root cause (from eval cache `tweets/cache/2044716682023674094.json`):
> "This tweet is from @ErikBjare ... mentioning @TimeToBuildBob about broken links. The thread shows @TimeToBuildBob already responded and fixed the issue ... no additional response from us is needed. This is a resolved technical issue between two other parties."

The LLM saw @TimeToBuildBob as "another party" — because the eval prompt never told it that's our own account.

## Changes

Two changes to `scripts/twitter/llm.py`:

1. **Default `TWITTER_HANDLE` to `"TimeToBuildBob"`** — matches `twitter.py`'s `TWITTER_EXPECTED_USERNAME` fallback pattern. Identity injection works out-of-the-box without env config.

2. **Fire identity context when our handle appears as a thread author** — mark our prior messages with `(US — our prior message)` and explicitly tell the LLM: *"Any prior @{handle} messages in the thread are OUR own replies; their presence does NOT mean the conversation is resolved."*

## Tests

Added 3 new regression tests in `tests/test_twitter_eval_prompt.py`:
- `test_unset_handle_default_fires_on_timetobuildbob_mention` — verifies default works
- `test_our_handle_in_thread_context_triggers_identity_note` — verifies thread detection + US marker
- `test_thread_context_without_us_does_not_trigger` — negative test

Updated 1 existing test: `test_unset_handle_skips_detection` → `test_unset_handle_uses_default_and_unrelated_mention_skipped` (reflects new default behavior).

All 10 tests pass.

## Test plan

- [x] Run `tests/test_twitter_eval_prompt.py` locally
- [ ] CI green
- [ ] After merge: verify `bob-twitter-loop` next cycle picks up Erik's mention thread and queues a reply draft

Refs: ErikBjare/bob#602, #663
