### PR TITLE
feat(forum): add digest command for cross-project activity summary

### DIFF
--- a/packages/gptme-forum/src/gptme_forum/cli.py
+++ b/packages/gptme-forum/src/gptme_forum/cli.py
@@ -303,6 +303,137 @@ def mentions(
 
 
 # ---------------------------------------------------------------------------
+# Digest command
+# ---------------------------------------------------------------------------
+
+
+@cli.command()
+@click.option(
+    "--agent",
+    "-a",
+    default=None,
+    help="Agent name to check mentions for (default: detected).",
+)
+@click.option(
+    "--since",
+    "-s",
+    default=None,
+    help="ISO datetime to check from (e.g. 2026-04-15T10:00:00Z).",
+)
+@click.option(
+    "--unread", "-u", is_flag=True, help="Only show since last check (uses state file)."
+)
+@click.option("--state-file", default=None, help="State file for unread tracking.")
+@click.option(
+    "--context",
+    "context_mode",
+    is_flag=True,
+    help="Compact one-liner for context injection.",
+)
+@click.pass_context
+def digest(
+    ctx: click.Context,
+    agent: str | None,
+    since: str | None,
+    unread: bool,
+    state_file: str | None,
+    context_mode: bool,
+) -> None:
+    """Show a digest of recent forum activity (posts, comments, mentions).
+
+    Example:\n
+        agentboard digest --unread --agent bob\n
+        agentboard digest --context --unread --agent bob
+    """
+    forum = _find_forum(ctx.obj)
+    agent_name = agent or get_agent_name()
+
+    if unread:
+        sf: Path | None = Path(state_file) if state_file else None
+        if sf is None:
+            try:
+                result = subprocess.run(
+                    ["git", "rev-parse", "--show-toplevel"],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                )
+                repo_root = Path(result.stdout.strip())
+                sf = repo_root / f"state/forum-digest-{agent_name}.txt"
+            except Exception:
+                sf = Path(f"/tmp/agentboard-digest-{agent_name}.txt")
+        data = forum.unread_digest(agent=agent_name, state_file=sf)
+    else:
+        since_dt = None
+        if since:
+            since_dt = datetime.fromisoformat(since.replace("Z", "+00:00"))
+        data = forum.digest(agent=agent_name, since=since_dt)
+
+    new_posts = data["new_posts"]
+    new_comments = data["new_comments"]
+    mentions = data["mentions"]
+    since_dt = data["since"]
+
+    if context_mode:
+        # Compact one-liner for context injection
+        parts = []
+        if new_posts:
+            latest = max(new_posts, key=lambda p: p.date)
+            parts.append(
+                f"{len(new_posts)} new post(s), latest: {latest.title!r} by {latest.author}"
+            )
+        if new_comments:
+            parts.append(f"{len(new_comments)} new comment(s)")
+        if mentions:
+            parts.append(f"{len(mentions)} mention(s) for @{agent_name}")
+        if not parts:
+            click.echo("Forum: no new activity.")
+        else:
+            click.echo(f"Forum: {'; '.join(parts)}.")
+        return
+
+    # Full output
+    since_label = since_dt.strftime("%Y-%m-%d %H:%M UTC") if since_dt else "all time"
+    total = len(new_posts) + len(new_comments)
+    click.echo(f"## Forum Digest (since {since_label})\n")
+    if not total and not mentions:
+        click.echo("No new activity.")
+        return
+
+    if new_posts:
+        click.echo(f"### New Posts ({len(new_posts)})")
+        for p in sorted(new_posts, key=lambda x: x.date, reverse=True):
+            tags_str = f" [{', '.join(p.tags)}]" if p.tags else ""
+            mention_str = (
+                f" (mentions: {', '.join('@' + m for m in p.mentions)})"
+                if p.mentions
+                else ""
+            )
+            click.echo(
+                f"  {p.date.strftime('%Y-%m-%d %H:%M')}  {p.ref:<40}  {p.author:<12}{tags_str}{mention_str}"
+            )
+            click.echo(f"    {p.title}")
+
+    if new_comments:
+        click.echo(f"\n### New Comments ({len(new_comments)})")
+        for c, post in sorted(new_comments, key=lambda x: x[0].date, reverse=True):
+            click.echo(
+                f"  {c.date.strftime('%Y-%m-%d %H:%M')}  {post.ref:<40}  by {c.author:<12}"
+            )
+            click.echo(f"    {c.body[:80].splitlines()[0]}")
+
+    if mentions:
+        click.echo(f"\n### Mentions for @{agent_name} ({len(mentions)})")
+        for item, kind in mentions:
+            if kind == "post":
+                assert isinstance(item, Post)
+                click.echo(f"  [post]    {item.ref}  by {item.author}")
+            else:
+                assert isinstance(item, Comment)
+                click.echo(f"  [comment] {item.path.name}  by {item.author}")
+
+
+# ---------------------------------------------------------------------------
 # Direct message commands (compatible with gptme-superuser/messages/ format)
 # ---------------------------------------------------------------------------
 

--- a/packages/gptme-forum/src/gptme_forum/forum.py
+++ b/packages/gptme-forum/src/gptme_forum/forum.py
@@ -344,3 +344,55 @@ class Forum:
             state_file.parent.mkdir(parents=True, exist_ok=True)
             state_file.write_text(now.isoformat())
         return results
+
+    def digest(self, agent: str | None = None, since: datetime | None = None) -> dict:
+        """Return a digest of forum activity.
+
+        Returns a dict with:
+          - new_posts: list of Post
+          - new_comments: list of (Comment, Post) pairs
+          - mentions: list of (Post|Comment, kind) pairs where agent is mentioned
+          - since: the datetime used as cutoff (or None)
+        """
+        new_posts: list[Post] = []
+        new_comments: list[tuple[Comment, Post]] = []
+        mentions: list[tuple[Post | Comment, str]] = []
+
+        for post in self.iter_posts():
+            is_new_post = since is None or post.date > since
+            if is_new_post:
+                new_posts.append(post)
+            if agent and agent in post.mentions and is_new_post:
+                mentions.append((post, "post"))
+            for comment in post.comments():
+                is_new_comment = since is None or comment.date > since
+                if is_new_comment:
+                    new_comments.append((comment, post))
+                if agent and agent in comment.mentions and is_new_comment:
+                    mentions.append((comment, "comment"))
+
+        return {
+            "new_posts": new_posts,
+            "new_comments": new_comments,
+            "mentions": mentions,
+            "since": since,
+        }
+
+    def unread_digest(
+        self, agent: str | None = None, state_file: Path | None = None
+    ) -> dict:
+        """Return digest of activity since last check, updating state_file."""
+        since: datetime | None = None
+        if state_file and state_file.exists():
+            raw = state_file.read_text().strip()
+            if raw:
+                try:
+                    since = datetime.fromisoformat(raw)
+                except ValueError:
+                    pass
+        result = self.digest(agent=agent, since=since)
+        if state_file:
+            now = datetime.now(tz=timezone.utc)
+            state_file.parent.mkdir(parents=True, exist_ok=True)
+            state_file.write_text(now.isoformat())
+        return result

--- a/packages/gptme-forum/tests/test_forum.py
+++ b/packages/gptme-forum/tests/test_forum.py
@@ -1,5 +1,6 @@
 """Tests for gptme-forum core library."""
 
+from datetime import datetime, timezone
 from pathlib import Path
 
 from gptme_forum.forum import Comment, Forum, Post, find_mentions
@@ -137,3 +138,67 @@ def test_forum_list_projects(tmp_path: Path):
     Post.create(forum.project_dir("beta"), "beta", "alice", "T2", "body")
     projs = forum.list_projects()
     assert projs == ["alpha", "beta"]
+
+
+def test_forum_digest_all_time(tmp_path: Path):
+    forum = Forum(tmp_path / "forum")
+    forum.ensure_exists()
+    p1 = Post.create(forum.project_dir("gptme"), "gptme", "alice", "Post 1", "hey @bob")
+    Post.create(forum.project_dir("gptme"), "gptme", "gordon", "Post 2", "nothing")
+    Comment.create(p1.comment_dir, "bob", "Thanks @alice!", index=1)
+
+    data = forum.digest(agent="bob")
+    assert len(data["new_posts"]) == 2
+    assert len(data["new_comments"]) == 1
+    # bob is mentioned in post 1 body
+    assert len(data["mentions"]) == 1
+    item, kind = data["mentions"][0]
+    assert kind == "post"
+    assert isinstance(item, Post)
+
+
+def test_forum_digest_with_since(tmp_path: Path):
+    from datetime import timedelta
+
+    forum = Forum(tmp_path / "forum")
+    forum.ensure_exists()
+    Post.create(forum.project_dir("gptme"), "gptme", "alice", "Old Post", "hey @bob")
+
+    # 'since' set to now — no new posts
+    since = datetime.now(tz=timezone.utc)
+    data = forum.digest(agent="bob", since=since)
+    assert data["new_posts"] == []
+    assert data["new_comments"] == []
+    assert data["mentions"] == []
+
+    # 'since' set to an hour ago — old post is visible
+    data2 = forum.digest(agent="bob", since=since - timedelta(hours=1))
+    assert len(data2["new_posts"]) == 1
+
+
+def test_forum_unread_digest_state_tracking(tmp_path: Path):
+    forum = Forum(tmp_path / "forum")
+    forum.ensure_exists()
+    state_file = tmp_path / "digest-state.txt"
+
+    Post.create(forum.project_dir("gptme"), "gptme", "alice", "Post 1", "hey @bob")
+
+    # First call: sees 1 post
+    data = forum.unread_digest(agent="bob", state_file=state_file)
+    assert len(data["new_posts"]) == 1
+    assert state_file.exists()
+
+    # Second call: state advanced — no new posts
+    data2 = forum.unread_digest(agent="bob", state_file=state_file)
+    assert data2["new_posts"] == []
+
+
+def test_forum_digest_no_agent(tmp_path: Path):
+    forum = Forum(tmp_path / "forum")
+    forum.ensure_exists()
+    Post.create(forum.project_dir("gptme"), "gptme", "alice", "Post 1", "hey @bob")
+
+    # Without agent — posts and comments listed, no mention filtering
+    data = forum.digest()
+    assert len(data["new_posts"]) == 1
+    assert data["mentions"] == []


### PR DESCRIPTION
## Summary

- Adds `Forum.digest()` and `Forum.unread_digest()` methods that return new posts, new comments, and agent mentions since a given cutoff
- Adds `agentboard digest` CLI command with `--unread` (stateful), `--since`, `--context` (compact one-liner), and `--agent` flags
- 4 new tests covering full digest, since-filter, unread state tracking, and no-agent mode
- Updates `context.sh` section 10 to use `digest --unread` instead of `mentions --unread`, giving richer session-start awareness (posts + comments + mentions in one pass)

## Why

The `mentions --unread` check in context.sh only surfaced @mentions. `digest` gives a fuller picture: what new posts/comments exist even if the agent wasn't mentioned. Useful for standups that @mention others, cross-project discussions, etc.

The `--context` flag produces a one-liner like `Forum: 2 new post(s), latest: 'Bob standup 2026-04-17' by bob.` for compact context injection.

## Test plan
- All 16 existing + new tests pass (`uv run pytest packages/gptme-forum/tests/`)
- Manual smoke test: `agentboard --forum-dir gptme-superuser/forum digest --unread --agent bob` shows new posts; second run shows "No new activity"