### PR TITLE
fix(sessions): preserve real start time on sync instead of noon placeholder

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/__init__.py
+++ b/packages/gptme-sessions/src/gptme_sessions/__init__.py
@@ -21,6 +21,7 @@ from .discovery import (
     discover_gptme_sessions,
     parse_gptme_config,
     session_date_from_path,
+    session_datetime_from_path,
 )
 from .post_session import PostSessionResult, post_session
 from .record import MODEL_ALIASES, SessionRecord, normalize_model
@@ -87,6 +88,7 @@ __all__ = [
     "parse_gptme_config",
     "decode_cc_project_path",
     "session_date_from_path",
+    "session_datetime_from_path",
     "Bandit",
     "BanditArm",
     "BanditState",

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -1203,13 +1203,14 @@ def sync(
                 correct_ts = f"{sd.isoformat()}T00:00:00+00:00"
                 new_prefix = sd.isoformat()
 
-            # Detect noon-UTC placeholder (all-zero duration + 12:00 timestamp):
-            # these are bulk-imported records whose real time is recoverable
-            # from the trajectory.
+            # Detect noon-UTC placeholder: synthetic 12:00:00 timestamps
+            # produced by the old sync path. We include records whose duration
+            # was later backfilled by --with-signals — those still have the
+            # wrong time even though duration_seconds is now non-zero.
             is_noon_placeholder = (
                 real_dt is not None
                 and rec.timestamp[11:19] == "12:00:00"
-                and (rec.duration_seconds or 0) == 0
+                and real_dt.isoformat()[11:19] != "12:00:00"
             )
             needs_fix = not rec.timestamp.startswith(new_prefix) or is_noon_placeholder
             if needs_fix:

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -29,6 +29,7 @@ from .discovery import (
     extract_session_name,
     parse_gptme_config,
     session_date_from_path,
+    session_datetime_from_path,
 )
 from .post_session import VALID_AB_GROUPS, VALID_CONTEXT_TIERS, post_session
 from .record import SessionRecord, normalize_run_type
@@ -1188,16 +1189,34 @@ def sync(
             if not rec.trajectory_path:
                 continue
             h = rec.harness or "unknown"
-            sd = session_date_from_path(h, Path(rec.trajectory_path))
-            if sd is None:
-                continue
-            correct_ts = f"{sd.isoformat()}T00:00:00+00:00"
-            # Only fix if the existing timestamp doesn't match the session date
-            if not rec.timestamp.startswith(sd.isoformat()):
+            traj = Path(rec.trajectory_path)
+            # Prefer the real start time from the trajectory; fall back to
+            # session_date at midnight when the trajectory can't be read.
+            real_dt = session_datetime_from_path(h, traj) if traj.is_file() else None
+            if real_dt:
+                correct_ts = real_dt.isoformat()
+                new_prefix = real_dt.date().isoformat()
+            else:
+                sd = session_date_from_path(h, traj)
+                if sd is None:
+                    continue
+                correct_ts = f"{sd.isoformat()}T00:00:00+00:00"
+                new_prefix = sd.isoformat()
+
+            # Detect noon-UTC placeholder (all-zero duration + 12:00 timestamp):
+            # these are bulk-imported records whose real time is recoverable
+            # from the trajectory.
+            is_noon_placeholder = (
+                real_dt is not None
+                and rec.timestamp[11:19] == "12:00:00"
+                and (rec.duration_seconds or 0) == 0
+            )
+            needs_fix = not rec.timestamp.startswith(new_prefix) or is_noon_placeholder
+            if needs_fix:
                 if dry_run:
                     click.echo(
                         f"  would fix: {rec.session_id}  "
-                        f"{rec.timestamp[:10]} → {sd.isoformat()}"
+                        f"{rec.timestamp[:19]} → {correct_ts[:19]}"
                     )
                 else:
                     rec.timestamp = correct_ts
@@ -1299,15 +1318,24 @@ def sync(
                     updated += 1
             continue
 
-        # Build the record with correct timestamp from session_date (not now()).
-        # Without this, all bulk-synced records get today's timestamp and
-        # skew daily stats (e.g. 7102 records appearing as "today").
+        # Build the record with correct timestamp from the trajectory's first
+        # event (not now()).  Without this, all bulk-synced records either get
+        # today's timestamp (skewing daily stats) or a noon-UTC placeholder
+        # (which collapses many sessions to a single hour and breaks hourly
+        # analytics).  Read the real first-event datetime when possible;
+        # fall back to noon-UTC on the session_date only if the trajectory
+        # has no readable timestamp.
+        session_dt: datetime | None = (
+            session_datetime_from_path(entry["harness"], traj_path) if traj_path.is_file() else None
+        )
         session_date: date | None = entry.get("session_date")
         record_kwargs: dict = {
             "harness": entry["harness"],
             "trajectory_path": path_str,  # used for deduplication on re-sync
         }
-        if session_date:
+        if session_dt:
+            record_kwargs["timestamp"] = session_dt.isoformat()
+        elif session_date:
             record_kwargs["timestamp"] = datetime(
                 session_date.year,
                 session_date.month,

--- a/packages/gptme-sessions/src/gptme_sessions/discovery.py
+++ b/packages/gptme-sessions/src/gptme_sessions/discovery.py
@@ -66,8 +66,8 @@ def _session_in_range(session_name: str, start: date, end: date) -> bool:
         return False
 
 
-def _quick_date_from_jsonl(jsonl_path: Path) -> date | None:
-    """Extract session date from the first timestamped line of a JSONL file.
+def _quick_datetime_from_jsonl(jsonl_path: Path) -> datetime | None:
+    """Extract session start datetime from the first timestamped line of a JSONL file.
 
     Reads only until the first valid timestamp is found (fast).
     """
@@ -86,13 +86,21 @@ def _quick_date_from_jsonl(jsonl_path: Path) -> date | None:
                 ts_str = entry.get("timestamp")
                 if ts_str:
                     try:
-                        ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
-                        return ts.date()
+                        return datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
                     except (ValueError, TypeError):
                         continue
     except (OSError, UnicodeDecodeError) as e:
         logger.debug("Failed to read %s: %s", jsonl_path, e)
     return None
+
+
+def _quick_date_from_jsonl(jsonl_path: Path) -> date | None:
+    """Extract session date from the first timestamped line of a JSONL file.
+
+    Reads only until the first valid timestamp is found (fast).
+    """
+    dt = _quick_datetime_from_jsonl(jsonl_path)
+    return dt.date() if dt else None
 
 
 def decode_cc_project_path(encoded: str) -> str:
@@ -340,6 +348,36 @@ def session_date_from_path(harness: str, path: Path) -> date | None:
     else:
         # claude-code, copilot: date is embedded in the JSONL file
         return _quick_date_from_jsonl(path)
+
+
+def session_datetime_from_path(harness: str, path: Path) -> datetime | None:
+    """Extract session start datetime from a discovered session path.
+
+    For **claude-code** and **copilot**, reads the first event timestamp from
+    the JSONL file, yielding a real datetime (not a placeholder).
+    For **gptme** and **codex**, the path structure only encodes a date, so this
+    returns ``None`` unless the session's JSONL can be located and read.
+
+    Callers that need a real start time (e.g. to avoid noon-UTC placeholder
+    timestamps when syncing into the store) should prefer this function over
+    ``session_date_from_path``.
+
+    Returns ``None`` if the datetime cannot be determined.
+    """
+    if harness == "gptme":
+        # path is either the session dir or a .jsonl inside it; try conversation.jsonl
+        jsonl = path if path.suffix == ".jsonl" else path / "conversation.jsonl"
+        if jsonl.is_file():
+            return _quick_datetime_from_jsonl(jsonl)
+        return None
+    elif harness == "codex":
+        # path is at …/YYYY/MM/DD/file.jsonl — read first timestamp if available
+        if path.is_file():
+            return _quick_datetime_from_jsonl(path)
+        return None
+    else:
+        # claude-code, copilot: start time is embedded in the JSONL file
+        return _quick_datetime_from_jsonl(path)
 
 
 def extract_session_name(harness: str, path: Path) -> str | None:

--- a/packages/gptme-sessions/tests/test_cli.py
+++ b/packages/gptme-sessions/tests/test_cli.py
@@ -770,6 +770,46 @@ class TestSyncFixTimestamps:
         rec = store.load_all()[0]
         assert rec.timestamp.startswith("2026-04-15T22:42:48")
 
+    def test_fix_timestamps_restores_noon_placeholder_with_backfilled_duration(
+        self, tmp_path: Path
+    ):
+        """--fix-timestamps also repairs noon-placeholders whose duration was backfilled.
+
+        Regression for Greptile P1 on PR #668: records synced before the fix had
+        duration_seconds=0 and noon timestamps. Later sync --with-signals runs
+        populated duration_seconds to a non-zero value. The original detector
+        required duration_seconds == 0, so these already-backfilled records were
+        silently skipped. Detection should key on the synthetic noon timestamp
+        itself, not on duration_seconds.
+        """
+        traj_dir = tmp_path / "projects" / "-home-user-proj"
+        traj_dir.mkdir(parents=True)
+        traj = traj_dir / "def67890-0000-0000-0000-000000000000.jsonl"
+        traj.write_text(json.dumps({"type": "system", "timestamp": "2026-04-15T09:15:22Z"}) + "\n")
+
+        store = SessionStore(sessions_dir=tmp_path / "store")
+        store.append(
+            SessionRecord(
+                harness="claude-code",
+                timestamp="2026-04-15T12:00:00+00:00",  # noon placeholder
+                duration_seconds=1847,  # backfilled by --with-signals
+                trajectory_path=str(traj),
+            )
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["--sessions-dir", str(tmp_path / "store"), "sync", "--fix-timestamps"],
+        )
+        assert result.exit_code == 0
+        assert "Fixed 1 timestamp" in result.output
+
+        rec = store.load_all()[0]
+        assert rec.timestamp.startswith("2026-04-15T09:15:22")
+        # Duration preserved — we only fix the timestamp, not the duration.
+        assert rec.duration_seconds == 1847
+
 
 # -- stats defaults ----------------------------------------------------------
 

--- a/packages/gptme-sessions/tests/test_cli.py
+++ b/packages/gptme-sessions/tests/test_cli.py
@@ -658,6 +658,56 @@ class TestSyncTimestamp:
             # The timestamp should start with the session date, not today
             assert gptme_records[0].timestamp.startswith("2026-03-10")
 
+    def test_sync_imports_real_start_time_from_trajectory(self, tmp_path: Path):
+        """sync should record the real start time, not a noon-UTC placeholder.
+
+        Regression test: previously, every synced Claude Code session landed at
+        YYYY-MM-DDT12:00:00 because sync only had a date, not a datetime.  This
+        collapsed 100+ sessions into a single hour and produced bogus noop
+        spikes in downstream analytics (bandit, inference-review).
+        """
+        # CLAUDE_HOME points at a directory containing a `projects/` subdir
+        claude_home = tmp_path / "cc"
+        proj = claude_home / "projects" / "-home-user-proj"
+        proj.mkdir(parents=True)
+        traj = proj / "abc12345-aaaa-bbbb-cccc-ddddeeeeffff.jsonl"
+        # File must exceed CC_MIN_SESSION_SIZE (4096 bytes) so it isn't filtered
+        # out as a stub session by discover_cc_sessions.
+        lines = [
+            json.dumps({"type": "system", "timestamp": "2026-04-15T22:42:48Z"}),
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": "2026-04-15T22:43:00Z",
+                    "message": {"role": "assistant", "content": "x" * 5000},
+                }
+            ),
+        ]
+        traj.write_text("\n".join(lines) + "\n")
+
+        store_dir = tmp_path / "store"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "--sessions-dir",
+                str(store_dir),
+                "sync",
+                "--harness",
+                "claude-code",
+                "--since",
+                "all",
+            ],
+            env={"CLAUDE_HOME": str(claude_home)},
+        )
+        assert result.exit_code == 0
+
+        store = SessionStore(sessions_dir=store_dir)
+        cc_records = [r for r in store.load_all() if r.harness == "claude-code"]
+        assert len(cc_records) == 1
+        # Must preserve the real hour/minute/second — not the noon placeholder
+        assert cc_records[0].timestamp.startswith("2026-04-15T22:42:48")
+
 
 class TestSyncFixTimestamps:
     def test_fix_timestamps_corrects_records(self, tmp_path: Path):
@@ -682,6 +732,43 @@ class TestSyncFixTimestamps:
         # Verify the timestamp was corrected
         records = store.load_all()
         assert records[0].timestamp.startswith("2026-03-10")
+
+    def test_fix_timestamps_restores_real_time_from_trajectory(self, tmp_path: Path):
+        """--fix-timestamps restores the real start time (not noon placeholder).
+
+        Regression test for the noon-UTC placeholder bug: when sync imports a
+        trajectory without extracting its first-event timestamp, every record
+        lands at YYYY-MM-DDT12:00:00 with duration_seconds=0, collapsing the
+        hourly distribution.  --fix-timestamps must detect these placeholders
+        and recover the real start time from the trajectory file.
+        """
+        # Create a real Claude Code trajectory with a non-noon start time
+        traj_dir = tmp_path / "projects" / "-home-user-proj"
+        traj_dir.mkdir(parents=True)
+        traj = traj_dir / "abc12345-0000-0000-0000-000000000000.jsonl"
+        traj.write_text(json.dumps({"type": "system", "timestamp": "2026-04-15T22:42:48Z"}) + "\n")
+
+        # Seed a placeholder record pointing at that trajectory
+        store = SessionStore(sessions_dir=tmp_path / "store")
+        store.append(
+            SessionRecord(
+                harness="claude-code",
+                timestamp="2026-04-15T12:00:00+00:00",  # noon placeholder
+                duration_seconds=0,
+                trajectory_path=str(traj),
+            )
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["--sessions-dir", str(tmp_path / "store"), "sync", "--fix-timestamps"],
+        )
+        assert result.exit_code == 0
+        assert "Fixed 1 timestamp" in result.output
+
+        rec = store.load_all()[0]
+        assert rec.timestamp.startswith("2026-04-15T22:42:48")
 
 
 # -- stats defaults ----------------------------------------------------------

--- a/packages/gptme-sessions/tests/test_discovery.py
+++ b/packages/gptme-sessions/tests/test_discovery.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import json
-from datetime import date
+from datetime import date, datetime, timezone
 from pathlib import Path
 
 import pytest
 
 from gptme_sessions.discovery import (
     _quick_date_from_jsonl,
+    _quick_datetime_from_jsonl,
     _session_in_range,
     decode_cc_project_path,
     discover_cc_sessions,
@@ -20,6 +21,7 @@ from gptme_sessions.discovery import (
     extract_project,
     extract_session_name,
     parse_gptme_config,
+    session_datetime_from_path,
 )
 
 
@@ -94,6 +96,42 @@ def test_quick_date_from_jsonl_non_dict_lines(tmp_path: Path) -> None:
         + "\n"
     )
     assert _quick_date_from_jsonl(jsonl) == date(2026, 3, 5)
+
+
+# --- _quick_datetime_from_jsonl ---
+
+
+def test_quick_datetime_from_jsonl_returns_full_datetime(tmp_path: Path) -> None:
+    """Real start time is preserved — not collapsed to a date."""
+    jsonl = tmp_path / "session.jsonl"
+    jsonl.write_text(json.dumps({"type": "user", "timestamp": "2026-03-05T22:42:48Z"}) + "\n")
+    assert _quick_datetime_from_jsonl(jsonl) == datetime(
+        2026, 3, 5, 22, 42, 48, tzinfo=timezone.utc
+    )
+
+
+def test_quick_datetime_from_jsonl_missing(tmp_path: Path) -> None:
+    jsonl = tmp_path / "empty.jsonl"
+    jsonl.write_text("")
+    assert _quick_datetime_from_jsonl(jsonl) is None
+
+
+# --- session_datetime_from_path ---
+
+
+def test_session_datetime_from_path_claude_code(tmp_path: Path) -> None:
+    """Avoids the noon-UTC placeholder bug by returning the trajectory's real start time."""
+    jsonl = tmp_path / "abc12345-ffff.jsonl"
+    jsonl.write_text(json.dumps({"type": "system", "timestamp": "2026-04-15T22:42:48.123Z"}) + "\n")
+    dt = session_datetime_from_path("claude-code", jsonl)
+    assert dt is not None
+    assert dt.date() == date(2026, 4, 15)
+    assert (dt.hour, dt.minute, dt.second) == (22, 42, 48)
+
+
+def test_session_datetime_from_path_missing_file_returns_none(tmp_path: Path) -> None:
+    jsonl = tmp_path / "does-not-exist.jsonl"
+    assert session_datetime_from_path("claude-code", jsonl) is None
 
 
 # --- parse_gptme_config ---


### PR DESCRIPTION
## Summary

`gptme-sessions sync` was importing every trajectory at `YYYY-MM-DDT12:00:00+00:00` because it had only the session_date, not a datetime. For Claude Code sessions this collapsed many records into a single synthetic hour and produced bogus noop spikes in downstream analytics (bandit, inference-review).

In my local store this manifested as **183 placeholder-noon records** with `duration_seconds=0` over two days (131 on 2026-04-15, 52 on 2026-04-16) — enough to inflate the daily session count of one agent from ~20 to ~150 and push the apparent noop rate from ~20% to 93%. Most of these were CC stub sessions that PR #662 now filters from discovery, but any real session synced before the fix has the same corrupted timestamp.

## Changes

- Add `_quick_datetime_from_jsonl` and `session_datetime_from_path` returning the real start `datetime` from a trajectory's first event.
- `_quick_date_from_jsonl` now delegates to the datetime variant (same behavior).
- `sync` reads the real start time when the trajectory exists, falling back to noon-UTC on `session_date` only when the trajectory is unreadable.
- `sync --fix-timestamps` now detects existing noon placeholders (12:00 + 0 duration) and restores the real start time from the trajectory file, so existing stores can be repaired.

## Test plan

- [x] New unit tests for `_quick_datetime_from_jsonl` and `session_datetime_from_path`
- [x] New regression test: `sync` imports the real start time for a Claude Code trajectory (not noon)
- [x] New regression test: `sync --fix-timestamps` restores real time for existing noon+0-duration records
- [x] Full test suite passes (604 tests)
- [x] No changes to public API for existing callers (`session_date_from_path` keeps the same contract)

## Rollout

After merging, existing stores can be repaired with:
```
gptme-sessions sync --fix-timestamps --dry-run
gptme-sessions sync --fix-timestamps
```