### PR TITLE
fix(sessions): preserve legacy/unknown fields through rewrite round-trip

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -7,6 +7,7 @@ import re
 import uuid
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
+from typing import Any
 
 # Normalize model names to short canonical forms
 MODEL_ALIASES: dict[str, str] = {
@@ -177,7 +178,7 @@ class SessionRecord:
     # Preserve fields written by older schema versions so load→mutate→rewrite
     # round-trips don't silently drop data (e.g. ``inferred_category``,
     # ``failure_reason``, ``recommended_confidence``, ``notes``).
-    _legacy_fields: dict = field(default_factory=dict, repr=False, compare=False)
+    _legacy_fields: dict[str, Any] = field(default_factory=dict, repr=False, compare=False)
 
     def __post_init__(self) -> None:
         if not self.session_id:

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -174,6 +174,11 @@ class SessionRecord:
     llm_judge_reason: str | None = None  # 1-sentence explanation
     llm_judge_model: str | None = None  # model used for judging (e.g. claude-haiku-4-5)
 
+    # Preserve fields written by older schema versions so load→mutate→rewrite
+    # round-trips don't silently drop data (e.g. ``inferred_category``,
+    # ``failure_reason``, ``recommended_confidence``, ``notes``).
+    _legacy_fields: dict = field(default_factory=dict, repr=False, compare=False)
+
     def __post_init__(self) -> None:
         if not self.session_id:
             self.session_id = str(uuid.uuid4())[:8]
@@ -200,12 +205,23 @@ class SessionRecord:
         return normalize_model(self.model)
 
     def to_dict(self) -> dict:
-        """Serialize to JSON-compatible dict."""
-        return asdict(self)
+        """Serialize to JSON-compatible dict.
+
+        Legacy/unknown fields captured in ``_legacy_fields`` during
+        ``from_dict`` are re-emitted alongside dataclass fields so that
+        load→rewrite cycles preserve them.
+        """
+        d = asdict(self)
+        legacy = d.pop("_legacy_fields", {}) or {}
+        for k, v in legacy.items():
+            # Known fields always win — we only add legacy keys that aren't
+            # already present as first-class fields.
+            d.setdefault(k, v)
+        return d
 
     @classmethod
     def from_dict(cls, data: dict) -> SessionRecord:
-        """Deserialize from dict, ignoring unknown fields.
+        """Deserialize from dict, preserving unknown fields for round-trip.
 
         Backward compat: old records stored the trajectory path (JSONL file or
         session directory) in ``journal_path`` before ``trajectory_path`` was
@@ -217,9 +233,14 @@ class SessionRecord:
         trajectory path stored by the old ``sync`` command and should be
         migrated — whether it's a ``.jsonl`` file or a bare session directory
         (the latter occurring for gptme sessions that lack ``conversation.jsonl``).
+
+        Any field not defined on the dataclass (e.g. legacy columns from older
+        schema versions) is captured into ``_legacy_fields`` so that subsequent
+        ``to_dict`` / ``rewrite`` calls preserve it.
         """
         known_fields = {f.name for f in cls.__dataclass_fields__.values()}
         filtered = {k: v for k, v in data.items() if k in known_fields}
+        legacy = {k: v for k, v in data.items() if k not in known_fields and not k.startswith("_")}
         # Migrate legacy records: journal_path that is not a .md file is
         # actually a trajectory path (JSONL or session directory) set by the
         # old sync command before trajectory_path was introduced.
@@ -229,6 +250,8 @@ class SessionRecord:
             and not filtered["journal_path"].endswith(".md")
         ):
             filtered["trajectory_path"] = filtered.pop("journal_path")
+        if legacy:
+            filtered["_legacy_fields"] = legacy
         return cls(**filtered)
 
     def to_json(self) -> str:

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -58,11 +58,49 @@ def test_session_record_serialization():
     assert r2.deliverables == ["abc123"]
 
 
-def test_session_record_from_dict_ignores_unknown():
-    """from_dict drops fields not in the dataclass."""
-    d = {"model": "sonnet", "unknown_field": "should_be_ignored"}
+def test_session_record_from_dict_preserves_unknown_fields():
+    """from_dict captures unknown fields into ``_legacy_fields`` so they
+    survive a subsequent ``to_dict``/rewrite.
+
+    Regression for silent data loss: older schemas wrote fields like
+    ``inferred_category``, ``failure_reason``, and ``recommended_confidence``
+    directly into the JSONL. Round-tripping such records through
+    ``load_all → mutate → rewrite`` previously dropped them.
+    """
+    d = {
+        "session_id": "abc",
+        "model": "sonnet",
+        "inferred_category": "infrastructure",
+        "failure_reason": "timeout",
+        "recommended_confidence": 0.42,
+    }
     r = SessionRecord.from_dict(d)
     assert r.model == "sonnet"
+    # Legacy fields survive round-trip via to_dict.
+    out = r.to_dict()
+    assert out["inferred_category"] == "infrastructure"
+    assert out["failure_reason"] == "timeout"
+    assert out["recommended_confidence"] == 0.42
+    # And via JSON round-trip.
+    reloaded = SessionRecord.from_dict(json.loads(r.to_json()))
+    reloaded_out = reloaded.to_dict()
+    assert reloaded_out["inferred_category"] == "infrastructure"
+    assert reloaded_out["failure_reason"] == "timeout"
+
+
+def test_session_record_to_dict_legacy_never_overrides_known_fields():
+    """A known-field value must win over an identically-keyed legacy entry.
+
+    ``_legacy_fields`` is only intended to cover fields *not* present on the
+    current dataclass — a forged/duplicate key in the legacy dict must not
+    shadow the authoritative dataclass value.
+    """
+    r = SessionRecord(session_id="x", model="sonnet", category="research")
+    # Simulate a legacy dict that (incorrectly) contains a known-field key.
+    r._legacy_fields = {"category": "DO_NOT_USE_ME", "inferred_category": "ok"}
+    out = r.to_dict()
+    assert out["category"] == "research"
+    assert out["inferred_category"] == "ok"
 
 
 def test_session_record_to_json():
@@ -227,6 +265,45 @@ def test_session_store_rewrite(tmp_path: Path):
     reloaded = store.load_all()
     assert len(reloaded) == 2
     assert reloaded[0].category == "code"
+
+
+def test_store_rewrite_preserves_legacy_fields(tmp_path: Path):
+    """rewrite() must not silently drop legacy fields written by older
+    schema versions (e.g. ``inferred_category``, ``failure_reason``).
+
+    This is the end-to-end regression for the silent data-loss path that
+    existed in ``sync --signals`` and ``sync --fix-timestamps``: both
+    mutate records in memory and then ``rewrite()`` them, which
+    previously stripped any field not defined on ``SessionRecord``.
+    """
+    store = SessionStore(sessions_dir=tmp_path)
+    # Hand-write a record containing legacy fields (simulating an older
+    # store written before the fields were removed from the dataclass).
+    legacy_line = json.dumps(
+        {
+            "session_id": "legacy1",
+            "timestamp": "2026-04-15T10:00:00+00:00",
+            "model": "opus",
+            "outcome": "noop",
+            "inferred_category": "infrastructure",
+            "failure_reason": "timeout",
+            "recommended_confidence": 0.73,
+        }
+    )
+    store.path.write_text(legacy_line + "\n")
+
+    # Load, mutate something unrelated, rewrite.
+    records = store.load_all()
+    assert len(records) == 1
+    records[0].outcome = "productive"  # any mutation
+    store.rewrite(records)
+
+    # Legacy fields must survive the round-trip.
+    raw = json.loads(store.path.read_text().splitlines()[0])
+    assert raw["outcome"] == "productive"
+    assert raw["inferred_category"] == "infrastructure"
+    assert raw["failure_reason"] == "timeout"
+    assert raw["recommended_confidence"] == 0.73
 
 
 def test_store_rewrite_preserves_appended_records(tmp_path: Path):


### PR DESCRIPTION
## Summary

`SessionRecord.from_dict` silently dropped fields not defined on the dataclass. Any code path that called `load_all` → mutate → `rewrite` (e.g. `sync --signals` backfill, `sync --fix-timestamps` from #668) then emitted records missing those fields.

## Real-world impact

Discovered while running `sync --fix-timestamps` (#668) against Alice's live session store. The noon-placeholder timestamps were repaired correctly, but **1,000 records lost their `inferred_category` field** in the process.

Full legacy-field exposure on the live store:

| Field | Records at risk |
|---|---|
| `inferred_category` | 1,000 |
| `failure_reason` | 78 |
| `recommended_confidence` | 67 |
| `notes` | 6 |

A single `sync --fix-timestamps` run against this store (187 records rewritten) would silently erase these fields from every rewritten record — and `sync --signals` has had the same behavior for any backfill path for some time.

## Fix

Capture unknown (non-underscore-prefixed) fields into a `_legacy_fields` dict in `from_dict` and re-emit them from `to_dict`, without overriding known dataclass fields. The dataclass schema stays unchanged.

## Tests

Three regression tests added in `test_sessions.py`:

- `test_session_record_from_dict_preserves_unknown_fields` — round-trip via `to_dict` and JSON
- `test_session_record_to_dict_legacy_never_overrides_known_fields` — safety guard: a forged/duplicate key in legacy dict must not shadow the real dataclass value
- `test_store_rewrite_preserves_legacy_fields` — end-to-end: `SessionStore.rewrite` preserves legacy fields on a real on-disk file

Replaces the now-outdated `test_session_record_from_dict_ignores_unknown` (the "ignore unknown" behavior was itself the bug).

## Test plan

- [x] New tests pass (`pytest tests/test_sessions.py -k "legacy or from_dict_preserves or never_overrides"`)
- [x] Full test suite passes (`pytest tests/` → 600 passed)
- [x] End-to-end verification against Alice's real 1,439-record session store: all 1,151 legacy-field instances preserved through `load_all` → `rewrite` (previously: 0 preserved)