### PR TITLE
fix(twitter): require TWITTER_HANDLE to be explicitly set, no default

### DIFF
--- a/scripts/twitter/llm.py
+++ b/scripts/twitter/llm.py
@@ -242,9 +242,11 @@ def load_config() -> Dict[Any, Any]:
 
 def create_tweet_eval_prompt(tweet: Dict, config: Dict) -> str:
     """Create prompt for tweet evaluation"""
-    # Our handle — default matches twitter.py's TWITTER_EXPECTED_USERNAME default
-    # so the identity-context injection works out-of-the-box in production.
-    twitter_handle = os.environ.get("TWITTER_HANDLE", "TimeToBuildBob")
+    twitter_handle = os.environ.get("TWITTER_HANDLE")
+    if not twitter_handle:
+        raise ValueError(
+            "TWITTER_HANDLE env var must be set (e.g. export TWITTER_HANDLE=MyBotHandle)"
+        )
     handle_lower = twitter_handle.lower()
 
     # Include thread context if available. Annotate our own prior messages so
@@ -388,7 +390,11 @@ def get_system_prompt() -> Message:
 
     # Create Twitter-specific system prompt
     agent_name = os.environ.get("AGENT_NAME", "Agent")
-    twitter_handle = os.environ.get("TWITTER_HANDLE", "TimeToBuildBob")
+    twitter_handle = os.environ.get("TWITTER_HANDLE")
+    if not twitter_handle:
+        raise ValueError(
+            "TWITTER_HANDLE env var must be set (e.g. export TWITTER_HANDLE=MyBotHandle)"
+        )
     twitter_prompt = f"""You are {agent_name} (@{twitter_handle}), an AI agent who evaluates and responds to tweets.
 Your task is to evaluate tweets and generate appropriate responses while:
 1. Maintaining your established personality (direct, opinionated, occasionally witty)

--- a/tests/test_twitter_eval_prompt.py
+++ b/tests/test_twitter_eval_prompt.py
@@ -169,45 +169,23 @@ def test_case_insensitive_handle_match(
     assert "IS our account" in prompt
 
 
-def test_unset_handle_uses_default_and_unrelated_mention_skipped(
+def test_unset_handle_raises_value_error(
     llm_module: types.ModuleType,
     eval_config: dict[str, Any],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """When TWITTER_HANDLE is unset, the module default 'TimeToBuildBob' is used.
+    """TWITTER_HANDLE must be explicitly set — no silent default.
 
-    A tweet mentioning an unrelated handle (@agent) still gets no identity note
-    because the default handle is 'TimeToBuildBob', not 'agent'. This guards
-    against false positives when the env var isn't explicitly configured
-    (the common production case — see ErikBjare/bob#602 follow-up).
+    ErikBjare/bob#602: defaulting to 'TimeToBuildBob' makes the script
+    unusable for other agents without an obvious error. Fail loudly instead.
     """
     monkeypatch.delenv("TWITTER_HANDLE", raising=False)
-    # Tweet mentioning an unrelated handle
     tweet = _base_tweet("@agent can you help with this?")
 
-    prompt = llm_module.create_tweet_eval_prompt(tweet, eval_config)
+    import pytest as _pytest
 
-    assert "IS our account" not in prompt
-
-
-def test_unset_handle_default_fires_on_timetobuildbob_mention(
-    llm_module: types.ModuleType,
-    eval_config: dict[str, Any],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """With TWITTER_HANDLE unset, the default 'TimeToBuildBob' still triggers detection.
-
-    Regression guard for ErikBjare/bob#602 follow-up: production was missing
-    TWITTER_HANDLE env var, so the fix from #663 never fired. The default
-    ensures identity injection works out-of-the-box even without env config.
-    """
-    monkeypatch.delenv("TWITTER_HANDLE", raising=False)
-    tweet = _base_tweet("@TimeToBuildBob is your timeline monitoring working?")
-
-    prompt = llm_module.create_tweet_eval_prompt(tweet, eval_config)
-
-    assert "IS our account" in prompt
-    assert "@TimeToBuildBob" in prompt
+    with _pytest.raises(ValueError, match="TWITTER_HANDLE"):
+        llm_module.create_tweet_eval_prompt(tweet, eval_config)
 
 
 def test_our_handle_in_thread_context_triggers_identity_note(
@@ -300,7 +278,7 @@ def test_prompt_contains_tweet_text_and_author(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Sanity check: the prompt should echo back the tweet text and author."""
-    monkeypatch.delenv("TWITTER_HANDLE", raising=False)
+    monkeypatch.setenv("TWITTER_HANDLE", "TestBot")
     tweet = _base_tweet("a very specific string 17d2g")
     tweet["author"] = "UniqueAuthor17d2g"
 


### PR DESCRIPTION
## Summary

- Remove the hardcoded `'TimeToBuildBob'` default from `llm.py` (`create_tweet_eval_prompt` and `generate_tweet_response`)
- Raise `ValueError` with a clear message when `TWITTER_HANDLE` is unset
- Update tests: replace the two tests that relied on the default with a single test asserting the `ValueError`

## Why

The default caused other agents using this library to silently evaluate tweets as if they were Bob — wrong identity, wrong responses, no error. Erik flagged this in ErikBjare/bob#602.

Bob's own `scripts/runs/twitter/twitter-loop.sh` now exports `TWITTER_HANDLE=TimeToBuildBob` explicitly, so the service keeps working.

## Test plan
- [x] `uv run pytest gptme-contrib/tests/test_twitter_eval_prompt.py` — 9 passed