### PR TITLE
fix(greptile-helper): use try/catch for jq capture to handle no-score comments

### DIFF
--- a/scripts/github/greptile-helper.sh
+++ b/scripts/github/greptile-helper.sh
@@ -112,7 +112,7 @@ _greptile_review_info() {
               else {
                 "has_review": true,
                 "reviewed_at": .updated_at,
-                "score": (.body | capture("Score[*:]*\\s*(?<n>[0-9])/5") | .n | tonumber? // null)
+                "score": (.body | [capture("Score[*:]*\\s*(?<n>[0-9])/5")] | if length == 0 then null else .[0].n | tonumber end)
               }
               end' > "$_REVIEW_CACHE_FILE" 2>/dev/null || echo '{"has_review": false, "score": null, "reviewed_at": null}' > "$_REVIEW_CACHE_FILE"
     cat "$_REVIEW_CACHE_FILE"


### PR DESCRIPTION
## Summary
- Fixes `_greptile_review_info()` incorrectly returning `has_review: false` when the latest Greptile comment has no `Score: X/5` pattern (e.g., a follow-up "LGTM" comment)

## Root cause
When Greptile posts a follow-up comment (no score line), jq `capture()` produces **empty output** — not null, not an error. Since empty output propagates silently through object construction, the entire `{...}` expression produces no output and the `|| fallback` fires, writing `{"has_review": false}`.

`tonumber? // null` doesn't help (no value to apply `//` to). `try...catch` also doesn't help (capture's "no match" is not an exception).

## Fix
Wrap `capture()` in `[...]` so a no-match produces an empty array, then check `length`:
```diff
- "score": (.body | capture("Score[*:]*\\s*(?<n>[0-9])/5") | .n | tonumber? // null)
+ "score": (.body | [capture("Score[*:]*\\s*(?<n>[0-9])/5")] | if length == 0 then null else .[0].n | tonumber end)
```

## Test plan
- [x] `greptile-helper.sh status gptme/gptme-contrib 668` returns `already-reviewed` (previously `awaiting-initial-review`)
- [x] Pre-commit passes
- [x] Score is correctly extracted when present: `"Score: 5/5"` → `5`