### PR TITLE
fix(autonomous): loop continues on single-run failure

### DIFF
--- a/scripts/runs/autonomous/autonomous-loop.sh
+++ b/scripts/runs/autonomous/autonomous-loop.sh
@@ -141,22 +141,19 @@ while true; do
         echo "[$counter/$max_runs] Starting autonomous run at $(date '+%Y-%m-%d %H:%M:%S %Z')..."
     fi
 
-    systemctl --user start "$SERVICE_NAME"
-    exit_code=$?
-
-    if [ $exit_code -ne 0 ]; then
-        echo "❌ ERROR: Autonomous run $counter failed with exit code $exit_code"
-        echo "Aborting loop."
-        exit $exit_code
+    # Don't abort on a single run failure (e.g. transient lock contention,
+    # pre-start gate rejection). Log and continue so the loop stays resilient
+    # and systemd doesn't have to bounce the wrapper for every hiccup.
+    if systemctl --user start "$SERVICE_NAME"; then
+        # Wait for the service to complete
+        echo "[$counter] Waiting for service to complete..."
+        while systemctl --user is-active --quiet "$SERVICE_NAME"; do
+            sleep 5
+        done
+        echo "✅ Run $counter completed successfully at $(date '+%Y-%m-%d %H:%M:%S %Z')"
+    else
+        echo "⚠️  Run $counter failed to start — continuing loop after cooldown"
     fi
-
-    # Wait for the service to complete
-    echo "[$counter] Waiting for service to complete..."
-    while systemctl --user is-active --quiet "$SERVICE_NAME"; do
-        sleep 5
-    done
-
-    echo "✅ Run $counter completed successfully at $(date '+%Y-%m-%d %H:%M:%S %Z')"
     echo ""
 
     # Cooldown between runs

--- a/scripts/runs/autonomous/autonomous-loop.sh
+++ b/scripts/runs/autonomous/autonomous-loop.sh
@@ -42,6 +42,7 @@ get_service_name() {
 
 # Defaults
 counter=0
+failed_starts=0
 max_runs=-1  # -1 means infinite
 COOLDOWN=10  # seconds between runs
 SERVICE_NAME=""
@@ -130,7 +131,11 @@ while true; do
 
     # Check if we've reached the limit
     if [ "$max_runs" -ne -1 ] && [ "$counter" -gt "$max_runs" ]; then
-        echo "✅ Completed all $max_runs runs successfully"
+        if [ "$failed_starts" -gt 0 ]; then
+            echo "⚠️  Completed $max_runs runs ($failed_starts failed to start)"
+        else
+            echo "✅ Completed all $max_runs runs successfully"
+        fi
         exit 0
     fi
 
@@ -152,6 +157,7 @@ while true; do
         done
         echo "✅ Run $counter completed successfully at $(date '+%Y-%m-%d %H:%M:%S %Z')"
     else
+        failed_starts=$((failed_starts + 1))
         echo "⚠️  Run $counter failed to start — continuing loop after cooldown"
     fi
     echo ""


### PR DESCRIPTION
## Summary

`autonomous-loop.sh` currently aborts the entire loop whenever `systemctl --user start` returns non-zero — e.g. transient lock contention between a finishing run and the next start, or a pre-start gate rejection. systemd then restarts the wrapper for every hiccup.

On Alice the restart counter climbed past 10k, and 24h health summaries showed 0/6 successful loop starts even though individual runs were succeeding within each instance before the first failure. This looks broken in health dashboards and wastes startup cycles.

Change: treat a run start failure as a recoverable event — log and fall through to the cooldown. The loop still exits on `max_runs` completion or explicit signal.

## Test plan

- [x] `bash -n` syntax check passes
- [x] Logic preserved for the success path (same `is-active` poll + success log)
- [ ] Observe Alice's loop after deploy: fewer systemd restarts, same per-run behavior