### PR TITLE
feat(gptme-sessions): store multivariate grades

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -46,6 +46,26 @@ logger = logging.getLogger(__name__)
 HARNESS_CHOICES = ["gptme", "claude-code", "codex", "copilot"]
 
 
+def _judge_fields(
+    score: float | None,
+    reason: str | None,
+    model: str | None,
+) -> dict[str, object]:
+    """Return legacy and multivariate-alignment fields for CLI results."""
+    if score is None:
+        return {}
+
+    fields: dict[str, object] = {
+        "llm_judge_score": score,
+        "llm_judge_reason": reason,
+        "llm_judge_model": model,
+        "grades": {"alignment": score},
+    }
+    if reason is not None:
+        fields["grade_reasons"] = {"alignment": reason}
+    return fields
+
+
 def _discover_all(
     since_days: int = 30,
     harness_filter: str | None = None,
@@ -1628,9 +1648,7 @@ def judge(
             score = verdict["score"] if verdict else None
             reason = verdict["reason"] if verdict else None
 
-            result_row["llm_judge_score"] = score
-            result_row["llm_judge_reason"] = reason
-            result_row["llm_judge_model"] = verdict["model"] if verdict else None
+            result_row.update(_judge_fields(score, reason, verdict["model"] if verdict else None))
             results.append(result_row)
 
             if not as_json and score is not None:
@@ -1655,9 +1673,11 @@ def judge(
         for rec in records:
             if rec.session_id in score_map:
                 s = score_map[rec.session_id]
-                rec.llm_judge_score = s["llm_judge_score"]
-                rec.llm_judge_reason = s["llm_judge_reason"]
-                rec.llm_judge_model = s["llm_judge_model"]
+                rec.set_alignment_grade(
+                    s["llm_judge_score"],
+                    reason=s.get("llm_judge_reason"),
+                    model=s.get("llm_judge_model"),
+                )
                 updated += 1
         if updated:
             store.rewrite(records)
@@ -1802,9 +1822,13 @@ def classify(
                 "journal_path": str(entry),
             }
             if judge_result:
-                row["llm_judge_score"] = judge_result["score"]
-                row["llm_judge_reason"] = judge_result["reason"]
-                row["llm_judge_model"] = judge_result["model"]
+                row.update(
+                    _judge_fields(
+                        judge_result["score"],
+                        judge_result["reason"],
+                        judge_result["model"],
+                    )
+                )
 
             results.append(row)
 
@@ -1830,9 +1854,11 @@ def classify(
                 r = cat_map[rec.session_id]
                 rec.category = r["category"]
                 if r.get("llm_judge_score") is not None:
-                    rec.llm_judge_score = r["llm_judge_score"]
-                    rec.llm_judge_reason = r["llm_judge_reason"]
-                    rec.llm_judge_model = r["llm_judge_model"]
+                    rec.set_alignment_grade(
+                        r["llm_judge_score"],
+                        reason=r.get("llm_judge_reason"),
+                        model=r.get("llm_judge_model"),
+                    )
                 updated += 1
         if updated:
             store.rewrite(records)

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -1420,6 +1420,48 @@ def sync(
         click.echo(", ".join(parts))
 
 
+@cli.command("repair-grades")
+@click.option("--dry-run", is_flag=True, help="Show what would change without rewriting the store")
+@click.pass_context
+def repair_grades(ctx: click.Context, dry_run: bool) -> None:
+    """Backfill multivariate grade fields from legacy scalar fields."""
+    store = SessionStore(sessions_dir=ctx.obj["sessions_dir"])
+    records = store.load_all()
+    if not records:
+        click.echo("No records in store.")
+        return
+
+    repaired = 0
+    productivity_added = 0
+    alignment_added = 0
+    reasons_added = 0
+
+    for rec in records:
+        had_productivity = "productivity" in rec.grades
+        had_alignment = "alignment" in rec.grades
+        had_alignment_reason = "alignment" in rec.grade_reasons
+
+        if rec.sync_grade_fields():
+            repaired += 1
+            if not had_productivity and "productivity" in rec.grades:
+                productivity_added += 1
+            if not had_alignment and "alignment" in rec.grades:
+                alignment_added += 1
+            if not had_alignment_reason and "alignment" in rec.grade_reasons:
+                reasons_added += 1
+
+    if repaired and not dry_run:
+        store.rewrite(records)
+
+    verb = "Would repair" if dry_run else "Repaired"
+    click.echo(
+        f"{verb} {repaired} record(s): "
+        f"productivity={productivity_added}, "
+        f"alignment={alignment_added}, "
+        f"alignment_reasons={reasons_added}."
+    )
+
+
 # -- post-session ------------------------------------------------------------
 
 
@@ -1668,7 +1710,7 @@ def judge(
     if update_store:
         store = SessionStore(sessions_dir=ctx.obj["sessions_dir"])
         records = store.load_all()
-        score_map = {r["session_id"]: r for r in results if r["llm_judge_score"] is not None}
+        score_map = {r["session_id"]: r for r in results if r.get("llm_judge_score") is not None}
         updated = 0
         for rec in records:
             if rec.session_id in score_map:
@@ -1694,7 +1736,7 @@ def judge(
         click.echo(json.dumps(results, indent=2))
     else:
         # Summary stats
-        scored = [r for r in results if r["llm_judge_score"] is not None]
+        scored = [r for r in results if r.get("llm_judge_score") is not None]
         if scored:
             scores = [r["llm_judge_score"] for r in scored]
             click.echo(

--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -301,10 +301,9 @@ def post_session(
         record_kwargs["session_id"] = session_id
     if token_count is not None:
         record_kwargs["token_count"] = token_count
-    if grade is not None:
-        record_kwargs["trajectory_grade"] = grade
-
     record = SessionRecord(**record_kwargs)
+    if grade is not None:
+        record.set_productivity_grade(grade)
     if journal_path is not None:
         try:
             existing_session_ids = [

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -167,6 +167,10 @@ class SessionRecord:
     trajectory_path: str | None = None  # path to trajectory JSONL file (for deduplication)
     journal_path: str | None = None  # path to human-written journal entry
 
+    # Per-dimension grades for the multivariate grading rollout.
+    grades: dict[str, float] = field(default_factory=dict)
+    grade_reasons: dict[str, str] = field(default_factory=dict)
+
     # Trajectory-based grade (from signal extraction, 0.0-1.0)
     trajectory_grade: float | None = None
 
@@ -196,9 +200,34 @@ class SessionRecord:
         # Guard against JSON null for integer field
         if self.duration_seconds is None:
             self.duration_seconds = 0
+        if self.grades is None:
+            self.grades = {}
+        if self.grade_reasons is None:
+            self.grade_reasons = {}
         # Model stored as-is (raw) — use model_normalized for display
         # Normalize run_type — reject numeric values (session numbers) and clean prefixes
         self.run_type = normalize_run_type(self.run_type)
+
+    def set_productivity_grade(self, score: float) -> None:
+        """Store the productivity dimension alongside the legacy scalar field."""
+        self.trajectory_grade = score
+        self.grades["productivity"] = score
+
+    def set_alignment_grade(
+        self,
+        score: float,
+        *,
+        reason: str | None = None,
+        model: str | None = None,
+    ) -> None:
+        """Store the alignment dimension alongside legacy judge fields."""
+        self.llm_judge_score = score
+        self.grades["alignment"] = score
+        if reason is not None:
+            self.llm_judge_reason = reason
+            self.grade_reasons["alignment"] = reason
+        if model is not None:
+            self.llm_judge_model = model
 
     @property
     def model_normalized(self) -> str | None:

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -223,11 +223,35 @@ class SessionRecord:
         """Store the alignment dimension alongside legacy judge fields."""
         self.llm_judge_score = score
         self.grades["alignment"] = score
+        self.llm_judge_reason = reason
         if reason is not None:
-            self.llm_judge_reason = reason
             self.grade_reasons["alignment"] = reason
+        else:
+            self.grade_reasons.pop("alignment", None)
         if model is not None:
             self.llm_judge_model = model
+
+    def sync_grade_fields(self) -> bool:
+        """Backfill multivariate grade fields from legacy scalar fields.
+
+        Returns ``True`` when any missing ``grades``/``grade_reasons`` entry
+        was added, otherwise ``False``.
+        """
+        changed = False
+        if self.trajectory_grade is not None and "productivity" not in self.grades:
+            self.grades["productivity"] = self.trajectory_grade
+            changed = True
+        if self.llm_judge_score is not None and "alignment" not in self.grades:
+            self.grades["alignment"] = self.llm_judge_score
+            changed = True
+        if (
+            self.llm_judge_reason is not None
+            and "alignment" in self.grades
+            and "alignment" not in self.grade_reasons
+        ):
+            self.grade_reasons["alignment"] = self.llm_judge_reason
+            changed = True
+        return changed
 
     @property
     def model_normalized(self) -> str | None:

--- a/packages/gptme-sessions/tests/test_cli.py
+++ b/packages/gptme-sessions/tests/test_cli.py
@@ -898,3 +898,47 @@ class TestProjectFilter:
         data = json.loads(out)
         assert len(data) == 1
         assert data[0]["project"] == "/Users/erb/myproject"
+
+
+class TestRepairGradesCommand:
+    def test_repair_grades_backfills_legacy_fields(self, tmp_path: Path):
+        """repair-grades persists multivariate grade fields for legacy records."""
+        store = SessionStore(sessions_dir=tmp_path)
+        legacy = SessionRecord(
+            session_id="legacy-sync",
+            harness="claude-code",
+            model="opus",
+            trajectory_grade=0.64,
+            llm_judge_score=0.82,
+            llm_judge_reason="Strong execution on the active task.",
+        )
+        store.append(legacy)
+
+        rc, out = _invoke(["repair-grades"], tmp_path)
+
+        assert rc == 0
+        assert "Repaired 1 record(s)" in out
+
+        repaired = SessionStore(sessions_dir=tmp_path).load_all()[0]
+        assert repaired.grades == {"productivity": 0.64, "alignment": 0.82}
+        assert repaired.grade_reasons == {"alignment": "Strong execution on the active task."}
+
+    def test_repair_grades_dry_run_does_not_rewrite_store(self, tmp_path: Path):
+        """repair-grades --dry-run reports changes without persisting them."""
+        store = SessionStore(sessions_dir=tmp_path)
+        store.append(
+            SessionRecord(
+                session_id="legacy-dry-run",
+                harness="claude-code",
+                model="opus",
+                trajectory_grade=0.58,
+            )
+        )
+
+        rc, out = _invoke(["repair-grades", "--dry-run"], tmp_path)
+
+        assert rc == 0
+        assert "Would repair 1 record(s)" in out
+
+        persisted = SessionStore(sessions_dir=tmp_path).load_all()[0]
+        assert persisted.grades == {}

--- a/packages/gptme-sessions/tests/test_judge.py
+++ b/packages/gptme-sessions/tests/test_judge.py
@@ -288,3 +288,104 @@ class TestJudgeCLI:
             assert "2026-03-07" in result.output or "abc123" in result.output
         finally:
             bad_entry.chmod(0o644)  # restore so tmp_path cleanup works
+
+    def test_judge_update_store_writes_alignment_grade(self, tmp_path: "Path") -> None:
+        """judge --update-store keeps legacy judge fields and grades.alignment in sync."""
+        from click.testing import CliRunner
+        from gptme_sessions.cli import cli
+        from gptme_sessions.store import SessionStore
+
+        journal_dir = tmp_path / "journal" / "2026-03-07"
+        journal_dir.mkdir(parents=True)
+        (journal_dir / "autonomous-session-abc123.md").write_text(
+            "## Session\nDid real work.\n",
+            encoding="utf-8",
+        )
+
+        sessions_dir = tmp_path / "sessions"
+        store = SessionStore(sessions_dir=sessions_dir)
+        store.append(SessionRecord(session_id="abc123", outcome="productive"))
+
+        runner = CliRunner()
+        with patch(
+            "gptme_sessions.judge.judge_session",
+            return_value={
+                "score": 0.81,
+                "reason": "Meaningful progress on the active task.",
+                "model": "claude-haiku-4-5",
+            },
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--sessions-dir",
+                    str(sessions_dir),
+                    "judge",
+                    "--journal-dir",
+                    str(tmp_path / "journal"),
+                    "--update-store",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        record = SessionStore(sessions_dir=sessions_dir).load_all()[0]
+        assert record.llm_judge_score == 0.81
+        assert record.llm_judge_reason == "Meaningful progress on the active task."
+        assert record.llm_judge_model == "claude-haiku-4-5"
+        assert record.grades == {"alignment": 0.81}
+        assert record.grade_reasons == {"alignment": "Meaningful progress on the active task."}
+
+    def test_classify_update_store_writes_alignment_grade(self, tmp_path: "Path") -> None:
+        """classify --judge --update-store mirrors judge output into grades.alignment."""
+        from click.testing import CliRunner
+        from gptme_sessions.classification import ClassificationResult
+        from gptme_sessions.cli import cli
+        from gptme_sessions.store import SessionStore
+
+        journal_dir = tmp_path / "journal" / "2026-03-07"
+        journal_dir.mkdir(parents=True)
+        (journal_dir / "autonomous-session-def456.md").write_text(
+            "## Session\nFixed a real bug.\n",
+            encoding="utf-8",
+        )
+
+        sessions_dir = tmp_path / "sessions"
+        store = SessionStore(sessions_dir=sessions_dir)
+        store.append(SessionRecord(session_id="def456", outcome="productive"))
+
+        runner = CliRunner()
+        with patch(
+            "gptme_sessions.classification.judge_and_classify",
+            return_value=(
+                ClassificationResult(
+                    category="code",
+                    confidence=0.93,
+                    productive=True,
+                    classifier="llm",
+                ),
+                {
+                    "score": 0.77,
+                    "reason": "Good progress on core implementation.",
+                    "model": "claude-haiku-4-5",
+                },
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--sessions-dir",
+                    str(sessions_dir),
+                    "classify",
+                    "--journal-dir",
+                    str(tmp_path / "journal"),
+                    "--judge",
+                    "--update-store",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        record = SessionStore(sessions_dir=sessions_dir).load_all()[0]
+        assert record.category == "code"
+        assert record.llm_judge_score == 0.77
+        assert record.grades == {"alignment": 0.77}
+        assert record.grade_reasons == {"alignment": "Good progress on core implementation."}

--- a/packages/gptme-sessions/tests/test_post_session.py
+++ b/packages/gptme-sessions/tests/test_post_session.py
@@ -180,3 +180,31 @@ def test_post_session_model_fallback_from_signals(tmp_path: Path):
             trajectory_path=fake_traj,
         )
     assert result.record.model == "claude-sonnet-4-6"
+
+
+def test_post_session_populates_productivity_grade(tmp_path: Path):
+    """post_session mirrors the scalar trajectory grade into grades.productivity."""
+    store = SessionStore(sessions_dir=tmp_path)
+    fake_traj = tmp_path / "trajectory.jsonl"
+    fake_traj.write_text("")
+
+    fake_signals = {
+        "session_duration_s": 60,
+        "productive": True,
+        "deliverables": ["feat: ship thing (abc1234)"],
+        "grade": 0.68,
+    }
+    with patch.object(_post_session_mod, "extract_from_path", return_value=fake_signals):
+        result = post_session(
+            store=store,
+            harness="claude-code",
+            model="sonnet",
+            duration_seconds=0,
+            trajectory_path=fake_traj,
+        )
+
+    assert result.record.trajectory_grade == 0.68
+    assert result.record.grades == {"productivity": 0.68}
+
+    records = store.load_all()
+    assert records[0].grades == {"productivity": 0.68}

--- a/packages/gptme-sessions/tests/test_record.py
+++ b/packages/gptme-sessions/tests/test_record.py
@@ -176,6 +176,24 @@ def test_grade_helpers_sync_multivariate_and_legacy_fields():
     assert r.grade_reasons == {"alignment": "Strong work on the active priority."}
 
 
+def test_sync_grade_fields_backfills_missing_multivariate_fields():
+    """Legacy scalar fields can backfill missing multivariate grade entries."""
+    r = SessionRecord(
+        session_id="legacy-grade-sync",
+        trajectory_grade=0.66,
+        llm_judge_score=0.81,
+        llm_judge_reason="Useful progress on the active task.",
+        llm_judge_model="claude-haiku-4-5",
+    )
+
+    changed = r.sync_grade_fields()
+
+    assert changed is True
+    assert r.grades == {"productivity": 0.66, "alignment": 0.81}
+    assert r.grade_reasons == {"alignment": "Useful progress on the active task."}
+    assert r.sync_grade_fields() is False
+
+
 # -- normalize_model: dot variants and regex fallback ------------------------
 
 

--- a/packages/gptme-sessions/tests/test_record.py
+++ b/packages/gptme-sessions/tests/test_record.py
@@ -9,6 +9,8 @@ def test_context_tier_default():
     """context_tier defaults to None."""
     r = SessionRecord()
     assert r.context_tier is None
+    assert r.grades == {}
+    assert r.grade_reasons == {}
 
 
 def test_context_tier_roundtrip():
@@ -153,6 +155,25 @@ def test_project_session_name_none_roundtrip():
     r2 = SessionRecord.from_dict(d)
     assert r2.project is None
     assert r2.session_name is None
+
+
+def test_grade_helpers_sync_multivariate_and_legacy_fields():
+    """Helper methods keep new grade dicts aligned with legacy scalar fields."""
+    r = SessionRecord(session_id="grades1")
+
+    r.set_productivity_grade(0.72)
+    r.set_alignment_grade(
+        0.84,
+        reason="Strong work on the active priority.",
+        model="claude-haiku-4-5",
+    )
+
+    assert r.trajectory_grade == 0.72
+    assert r.llm_judge_score == 0.84
+    assert r.llm_judge_reason == "Strong work on the active priority."
+    assert r.llm_judge_model == "claude-haiku-4-5"
+    assert r.grades == {"productivity": 0.72, "alignment": 0.84}
+    assert r.grade_reasons == {"alignment": "Strong work on the active priority."}
 
 
 # -- normalize_model: dot variants and regex fallback ------------------------


### PR DESCRIPTION
## Summary
- extend `SessionRecord` with `grades` and `grade_reasons`
- keep legacy scalar/judge fields in sync via helper methods during the migration
- write `grades["productivity"]` in post-session and `grades["alignment"]` in judge/classify flows

## Tests
- `uv run pytest /home/bob/bob/gptme-contrib/packages/gptme-sessions/tests/test_record.py /home/bob/bob/gptme-contrib/packages/gptme-sessions/tests/test_post_session.py /home/bob/bob/gptme-contrib/packages/gptme-sessions/tests/test_judge.py -q`
- `uv run pytest /home/bob/bob/gptme-contrib/packages/gptme-sessions/tests -q`