### PR TITLE
fix(signals): capture merge-commit SHA for squash-merged PRs

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -19,6 +19,7 @@ import glob as _glob
 import json
 import os
 import re
+import subprocess
 from datetime import datetime
 from pathlib import Path
 
@@ -72,6 +73,20 @@ _ISSUE_CLOSE_CMD_RE = re.compile(r"\bgh\s+issue\s+close\b")
 # Must be command-gated (not just output-gated) because _PR_MERGE_RE patterns
 # can appear in test files, file-read results, and other non-merge contexts.
 _GH_PR_MERGE_CMD_RE = re.compile(r"\bgh\s+pr\s+merge\b")
+
+# Regex to extract `--repo OWNER/REPO` from a `gh` command string.
+# Used to learn the target repo for `gh pr merge`/`gh pr view` so we can
+# resolve the server-side merge-commit SHA after a squash merge.
+_GH_REPO_FLAG_RE = re.compile(r"--repo[=\s]+([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)")
+
+# Regex to extract the PR number from a `gh pr merge <N>` style command.
+# Lets us attach `pr create` repo context to a later `pr merge` for the same PR
+# when only one side carries `--repo`.
+_GH_PR_MERGE_NUM_RE = re.compile(r"\bgh\s+pr\s+merge\s+(?:--?\S+\s+)*(\d+)")
+
+# Regex to extract owner/repo from a PR URL produced by `gh pr create`.
+# Example: "https://github.com/owner/repo/pull/42" -> ("owner/repo", "42")
+_PR_CREATE_URL_REPO_RE = re.compile(r"https://github\.com/([^/\s]+/[^/\s]+)/pull/(\d+)")
 
 # Fine-grained gh interaction regexes — split gh_interactions into signal types.
 # These are detected on the command input side (same as _GH_INTERACTION_RE).
@@ -173,6 +188,58 @@ def _extract_path_from_args(args_str: str) -> str | None:
     """Extract the 'path' field from a tool call's JSON args string."""
     m = re.search(r'"path"\s*:\s*"([^"]+)"', args_str)
     return m.group(1) if m else None
+
+
+def _resolve_merge_shas(pr_merges: list[str], pr_context: dict[int, str]) -> list[str]:
+    """For each 'PR #N' in pr_merges, look up merge commit SHA via gh CLI.
+
+    When a session runs ``gh pr merge --squash``, GitHub creates a new merge
+    commit *server-side*; the session trajectory never observes that SHA. This
+    helper calls ``gh pr view <N> --repo <owner/repo> --json mergeCommit`` after
+    the fact so the SHA can be added to deliverables and thus be reverse-indexed
+    for revert-attribution.
+
+    Returns a list of merge-commit SHAs (full 40-char hex). Silently skips:
+    - PR numbers with no known repo context (no --repo flag, no captured URL)
+    - gh CLI failures (missing binary, network, auth, non-zero exit)
+    - Timeouts
+    - Malformed SHA output (not 40 hex chars)
+    """
+    shas: list[str] = []
+    for pr_merge in pr_merges:
+        m = re.match(r"PR #(\d+)", pr_merge)
+        if not m:
+            continue
+        pr_num = int(m.group(1))
+        repo = pr_context.get(pr_num)
+        if not repo:
+            continue
+        try:
+            result = subprocess.run(
+                [
+                    "gh",
+                    "pr",
+                    "view",
+                    str(pr_num),
+                    "--repo",
+                    repo,
+                    "--json",
+                    "mergeCommit",
+                    "-q",
+                    ".mergeCommit.oid",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except (subprocess.TimeoutExpired, OSError):
+            continue
+        if result.returncode != 0:
+            continue
+        sha = result.stdout.strip()
+        if len(sha) == 40 and all(c in "0123456789abcdef" for c in sha):
+            shas.append(sha)
+    return shas
 
 
 def extract_signals(msgs: list[dict]) -> dict:
@@ -442,6 +509,17 @@ def extract_signals_cc(msgs: list[dict]) -> dict:
     _ci_failure_found: bool = False  # True when a --log-failed check returned non-empty output
     _pr_merge_pending: set[str] = set()  # tool_use_ids awaiting pr merge result
     _all_direct_commit_hashes: set[str] = set()  # session-wide dedup for git commits
+    # Map PR number → "owner/repo" for post-session gh pr view lookups.
+    # Populated from (a) gh pr create URL output and (b) `--repo` flags on gh pr merge
+    # commands. Used by _resolve_merge_shas to fetch server-side merge-commit SHAs
+    # for squash-merged PRs (which the session never observes directly).
+    pr_context: dict[int, str] = {}
+    # Stash the repo flag extracted from a `gh pr merge` command at dispatch time,
+    # so it can be attributed to the actual PR number when the result is parsed.
+    _pr_merge_repo_by_tool_id: dict[str, str] = {}
+    # PR number extracted from `gh pr merge <N>` command (may be absent if the
+    # command used `gh pr merge` without an explicit number). Keyed by tool_use_id.
+    _pr_merge_num_by_tool_id: dict[str, int] = {}
 
     for record in msgs:
         rec_type = record.get("type", "")
@@ -537,6 +615,15 @@ def extract_signals_cc(msgs: list[dict]) -> dict:
                     if _GH_PR_MERGE_CMD_RE.search(cmd):
                         if tool_id:
                             _pr_merge_pending.add(tool_id)
+                            # Stash repo flag and PR number so the result parser
+                            # can build pr_context (PR# -> owner/repo) for the
+                            # later gh pr view mergeCommit lookup.
+                            repo_m = _GH_REPO_FLAG_RE.search(cmd)
+                            if repo_m:
+                                _pr_merge_repo_by_tool_id[tool_id] = repo_m.group(1)
+                            num_m = _GH_PR_MERGE_NUM_RE.search(cmd)
+                            if num_m:
+                                _pr_merge_num_by_tool_id[tool_id] = int(num_m.group(1))
 
                     # Parse Bash commands for journal writes via cat heredoc redirects.
                     # Many CC sessions write journals via heredoc (cat > path << EOF)
@@ -686,17 +773,39 @@ def extract_signals_cc(msgs: list[dict]) -> dict:
                     # strings. Only credit a merge when the command was `gh pr merge`.
                     if tool_use_id in _pr_merge_pending:
                         _pr_merge_pending.discard(tool_use_id)
+                        repo_for_merge = _pr_merge_repo_by_tool_id.pop(tool_use_id, None)
+                        stashed_num = _pr_merge_num_by_tool_id.pop(tool_use_id, None)
                         for merge_match in _PR_MERGE_RE.finditer(result_str):
                             pr_num = merge_match.group(1)
                             pr_merges.append(f"PR #{pr_num}")
+                            # Prefer repo extracted from the command itself;
+                            # do NOT overwrite context captured earlier from
+                            # the gh pr create URL output.
+                            if repo_for_merge and int(pr_num) not in pr_context:
+                                pr_context[int(pr_num)] = repo_for_merge
+                        # If the command specified a PR number explicitly but the
+                        # output didn't match (rare — silent success format change),
+                        # still record the repo so future sessions can pick it up.
+                        if (
+                            stashed_num is not None
+                            and repo_for_merge
+                            and stashed_num not in pr_context
+                        ):
+                            pr_context[stashed_num] = repo_for_merge
 
                     # gh pr create detection: successful output contains a PR URL.
                     # Only check when this tool_use_id was flagged as a pr create command.
                     if tool_use_id in _pr_create_pending:
                         _pr_create_pending.discard(tool_use_id)
-                        url_match = _PR_CREATE_URL_RE.search(result_str)
-                        if url_match:
-                            prs_submitted.append(f"PR #{url_match.group(1)}")
+                        # Extract PR number AND owner/repo from the URL; the
+                        # owner/repo mapping is used later to look up the server-
+                        # side merge-commit SHA after `gh pr merge`.
+                        repo_match = _PR_CREATE_URL_REPO_RE.search(result_str)
+                        if repo_match:
+                            owner_repo = repo_match.group(1)
+                            pr_num_str = repo_match.group(2)
+                            prs_submitted.append(f"PR #{pr_num_str}")
+                            pr_context[int(pr_num_str)] = owner_repo
 
                     # gh issue close confirmation: count only when result is not an error.
                     # is_error=True is already handled above (continue), so reaching here
@@ -735,7 +844,24 @@ def extract_signals_cc(msgs: list[dict]) -> dict:
     # Session-level signal (not per-cycle) since most sessions address one CI issue.
     ci_fixed = _ci_failure_found and bool(git_commits)
 
-    # pr_merges entries in deliverables: "merge PR #N" format for readability
+    # Resolve server-side merge-commit SHAs for squash-merged PRs. When a session
+    # runs `gh pr merge --squash`, GitHub creates the merge commit *server-side*
+    # and the session never observes that SHA — so it would be missing from
+    # deliverables and not reverse-indexed for revert attribution. Look it up
+    # via `gh pr view <N> --json mergeCommit` for every detected merge where we
+    # have repo context. Graceful on failure (no gh, network down, auth missing).
+    merge_shas = _resolve_merge_shas(pr_merges, pr_context)
+    for sha in merge_shas:
+        # Label commit message so grep / human-readable audits can tell these
+        # apart from locally-observed commits. The SHA is the load-bearing bit —
+        # that's what the harm-signal reverse index keys on.
+        commit_entry = f"merge-commit ({sha})"
+        if commit_entry not in git_commits:
+            git_commits.append(commit_entry)
+
+    # pr_merges entries in deliverables: "merge PR #N" format for readability.
+    # git_commits now includes any resolved merge SHAs from the loop above, so
+    # they flow into deliverables here without extra bookkeeping.
     deliverables = list(
         dict.fromkeys(git_commits + [f"merge {m}" for m in pr_merges] + file_writes)
     )

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -82,7 +82,10 @@ _GH_REPO_FLAG_RE = re.compile(r"--repo[=\s]+([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)")
 # Regex to extract the PR number from a `gh pr merge <N>` style command.
 # Lets us attach `pr create` repo context to a later `pr merge` for the same PR
 # when only one side carries `--repo`.
-_GH_PR_MERGE_NUM_RE = re.compile(r"\bgh\s+pr\s+merge\s+(?:--?\S+\s+)*(\d+)")
+# The inner group accepts a flag plus an optional space-separated value whose
+# first character is neither `-` (next flag) nor a digit (the PR number), so
+# patterns like `gh pr merge --repo owner/repo 99 --squash` parse correctly.
+_GH_PR_MERGE_NUM_RE = re.compile(r"\bgh\s+pr\s+merge\s+(?:--?\S+(?:\s+[^-\d]\S*)?\s+)*(\d+)")
 
 # Regex to extract owner/repo from a PR URL produced by `gh pr create`.
 # Example: "https://github.com/owner/repo/pull/42" -> ("owner/repo", "42")

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -61,10 +61,6 @@ _GH_INTERACTION_RE = re.compile(
 # work that should boost the session grade comparable to a real commit.
 _PR_CREATE_CMD_RE = re.compile(r"\bgh\s+pr\s+create\b")
 
-# Regex for detecting the PR URL in gh pr create output.
-# Format: "https://github.com/owner/repo/pull/N"
-_PR_CREATE_URL_RE = re.compile(r"https://github\.com/[^/\s]+/[^/\s]+/pull/(\d+)")
-
 # Regex for gh issue close command detection (from Bash input).
 # Tracks explicit issue closures as a forward-progress signal (blocker removal).
 _ISSUE_CLOSE_CMD_RE = re.compile(r"\bgh\s+issue\s+close\b")

--- a/packages/gptme-sessions/tests/test_signals_merge_sha.py
+++ b/packages/gptme-sessions/tests/test_signals_merge_sha.py
@@ -19,6 +19,7 @@ import subprocess
 from unittest.mock import patch
 
 from gptme_sessions.signals import (
+    _GH_PR_MERGE_NUM_RE,
     _resolve_merge_shas,
     extract_signals_cc,
 )
@@ -40,6 +41,28 @@ def _make_mock_run(stdout: str = "", returncode: int = 0):
         )
 
     return _run
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _GH_PR_MERGE_NUM_RE: captures PR number across flag orderings
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_gh_pr_merge_num_re_captures_across_flag_orderings():
+    """Regression for the --repo-before-N ordering flagged by greptile on #677."""
+    cases = [
+        ("gh pr merge 99 --squash", "99"),
+        ("gh pr merge --squash 99", "99"),
+        ("gh pr merge --repo owner/repo 99 --squash", "99"),
+        ("gh pr merge --repo=owner/repo 99 --squash", "99"),
+        ("gh pr merge --squash --repo owner/repo 99", "99"),
+        ("gh pr merge --auto --squash 123", "123"),
+        ("gh pr merge -R owner/repo 45", "45"),
+    ]
+    for cmd, expected in cases:
+        m = _GH_PR_MERGE_NUM_RE.search(cmd)
+        assert m is not None, f"regex did not match: {cmd!r}"
+        assert m.group(1) == expected, f"{cmd!r} → {m.group(1)}, expected {expected}"
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/packages/gptme-sessions/tests/test_signals_merge_sha.py
+++ b/packages/gptme-sessions/tests/test_signals_merge_sha.py
@@ -1,0 +1,380 @@
+"""Tests for server-side merge-commit SHA resolution in signals.py.
+
+Bug: sessions that shipped via `gh pr merge --squash` never observed the
+server-side merge-commit SHA, so those commits went missing from
+`deliverables` and could not be reverse-indexed for revert attribution.
+
+Fix: after extraction, `extract_signals_cc` calls `_resolve_merge_shas`,
+which invokes `gh pr view <N> --repo <owner/repo> --json mergeCommit` for
+each detected merge and adds the returned SHA to `git_commits` and
+`deliverables`.
+
+These tests mock `subprocess.run` at the `gptme_sessions.signals` module
+scope so no real `gh` binary is ever invoked.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+from gptme_sessions.signals import (
+    _resolve_merge_shas,
+    extract_signals_cc,
+)
+
+# 40-char hex — mimics a real git SHA.
+FAKE_SHA = "a" * 40
+FAKE_SHA_2 = "b" * 40
+
+
+def _make_mock_run(stdout: str = "", returncode: int = 0):
+    """Build a lambda usable as a subprocess.run side_effect."""
+
+    def _run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=args[0] if args else [],
+            returncode=returncode,
+            stdout=stdout,
+            stderr="",
+        )
+
+    return _run
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _resolve_merge_shas: direct unit tests
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_resolve_merge_shas_success():
+    """gh returns a valid 40-char SHA; it's appended to the result list."""
+    with patch(
+        "gptme_sessions.signals.subprocess.run",
+        side_effect=_make_mock_run(stdout=FAKE_SHA + "\n"),
+    ) as mock_run:
+        shas = _resolve_merge_shas(pr_merges=["PR #42"], pr_context={42: "owner/repo"})
+    assert shas == [FAKE_SHA]
+    mock_run.assert_called_once()
+    # Verify the gh invocation form.
+    call_args = mock_run.call_args.args[0]
+    assert call_args[:3] == ["gh", "pr", "view"]
+    assert "42" in call_args
+    assert "owner/repo" in call_args
+    assert "mergeCommit" in call_args
+
+
+def test_resolve_merge_shas_missing_context():
+    """PR with no known repo → no subprocess call, no SHA returned."""
+    with patch("gptme_sessions.signals.subprocess.run") as mock_run:
+        shas = _resolve_merge_shas(pr_merges=["PR #42"], pr_context={})
+    assert shas == []
+    mock_run.assert_not_called()
+
+
+def test_resolve_merge_shas_gh_failure_nonzero_exit():
+    """gh exits non-zero (auth error, PR not found, etc.) → graceful skip."""
+    with patch(
+        "gptme_sessions.signals.subprocess.run",
+        side_effect=_make_mock_run(stdout="", returncode=1),
+    ):
+        shas = _resolve_merge_shas(pr_merges=["PR #42"], pr_context={42: "owner/repo"})
+    assert shas == []
+
+
+def test_resolve_merge_shas_gh_timeout():
+    """gh call times out → graceful skip, no exception raised."""
+
+    def _timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=10)
+
+    with patch("gptme_sessions.signals.subprocess.run", side_effect=_timeout):
+        shas = _resolve_merge_shas(pr_merges=["PR #42"], pr_context={42: "owner/repo"})
+    assert shas == []
+
+
+def test_resolve_merge_shas_gh_oserror():
+    """gh binary missing (OSError/FileNotFoundError) → graceful skip."""
+
+    def _oserror(*args, **kwargs):
+        raise FileNotFoundError("gh: command not found")
+
+    with patch("gptme_sessions.signals.subprocess.run", side_effect=_oserror):
+        shas = _resolve_merge_shas(pr_merges=["PR #42"], pr_context={42: "owner/repo"})
+    assert shas == []
+
+
+def test_resolve_merge_shas_malformed_output():
+    """gh returns garbage / short hash → not counted as a valid SHA."""
+    with patch(
+        "gptme_sessions.signals.subprocess.run",
+        side_effect=_make_mock_run(stdout="not-a-sha\n"),
+    ):
+        shas = _resolve_merge_shas(pr_merges=["PR #42"], pr_context={42: "owner/repo"})
+    assert shas == []
+
+
+def test_resolve_merge_shas_empty_list():
+    """No PRs merged → no subprocess calls, empty result."""
+    with patch("gptme_sessions.signals.subprocess.run") as mock_run:
+        shas = _resolve_merge_shas(pr_merges=[], pr_context={})
+    assert shas == []
+    mock_run.assert_not_called()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Integration: extract_signals_cc end-to-end with merge-SHA resolution
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _pr_create_then_merge_msgs(
+    pr_num: int = 42,
+    owner_repo: str = "owner/repo",
+) -> list[dict]:
+    """Build a CC trajectory: gh pr create succeeds, then gh pr merge --squash."""
+    create_id = "bash_create_001"
+    merge_id = "bash_merge_001"
+    pr_url = f"https://github.com/{owner_repo}/pull/{pr_num}"
+    return [
+        {
+            "type": "assistant",
+            "timestamp": "2026-04-17T10:00:00.000Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": create_id,
+                        "name": "Bash",
+                        "input": {"command": "gh pr create --title 'fix: thing' --body 'body'"},
+                    }
+                ],
+            },
+        },
+        {
+            "type": "user",
+            "timestamp": "2026-04-17T10:00:05.000Z",
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": create_id,
+                        "is_error": False,
+                        "content": f"Creating pull request\n{pr_url}",
+                    }
+                ],
+            },
+        },
+        {
+            "type": "assistant",
+            "timestamp": "2026-04-17T10:01:00.000Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": merge_id,
+                        "name": "Bash",
+                        "input": {"command": f"gh pr merge {pr_num} --squash"},
+                    }
+                ],
+            },
+        },
+        {
+            "type": "user",
+            "timestamp": "2026-04-17T10:01:10.000Z",
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": merge_id,
+                        "is_error": False,
+                        "content": (
+                            f"\u2713 Squashed and merged pull request #{pr_num} (fix: thing)"
+                        ),
+                    }
+                ],
+            },
+        },
+    ]
+
+
+def test_extract_signals_cc_includes_resolved_merge_sha():
+    """End-to-end: pr create URL → pr_context → gh pr view mock → merge SHA in deliverables."""
+    msgs = _pr_create_then_merge_msgs(pr_num=42, owner_repo="ErikBjare/bob")
+    with patch(
+        "gptme_sessions.signals.subprocess.run",
+        side_effect=_make_mock_run(stdout=FAKE_SHA + "\n"),
+    ) as mock_run:
+        sigs = extract_signals_cc(msgs)
+
+    # pr_merges still captured as usual.
+    assert sigs["pr_merges"] == ["PR #42"]
+    assert sigs["prs_submitted"] == ["PR #42"]
+
+    # Fake merge SHA now appears in git_commits AND deliverables.
+    assert any(
+        FAKE_SHA in c for c in sigs["git_commits"]
+    ), f"expected {FAKE_SHA} in git_commits, got {sigs['git_commits']}"
+    assert any(
+        FAKE_SHA in d for d in sigs["deliverables"]
+    ), f"expected {FAKE_SHA} in deliverables, got {sigs['deliverables']}"
+
+    # Exactly one gh-view call — for PR #42.
+    mock_run.assert_called_once()
+    args = mock_run.call_args.args[0]
+    assert args[:3] == ["gh", "pr", "view"]
+    assert "ErikBjare/bob" in args
+    assert "42" in args
+
+
+def test_extract_signals_cc_uses_repo_flag_from_merge_cmd():
+    """No pr create URL but `gh pr merge --repo X/Y 99` provides repo context."""
+    merge_id = "bash_merge_with_repo_flag"
+    msgs = [
+        {
+            "type": "assistant",
+            "timestamp": "2026-04-17T10:00:00.000Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": merge_id,
+                        "name": "Bash",
+                        "input": {"command": "gh pr merge --repo gptme/gptme-contrib 99 --squash"},
+                    }
+                ],
+            },
+        },
+        {
+            "type": "user",
+            "timestamp": "2026-04-17T10:00:10.000Z",
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": merge_id,
+                        "is_error": False,
+                        "content": "\u2713 Squashed and merged pull request #99 (fix: y)",
+                    }
+                ],
+            },
+        },
+    ]
+    with patch(
+        "gptme_sessions.signals.subprocess.run",
+        side_effect=_make_mock_run(stdout=FAKE_SHA_2 + "\n"),
+    ) as mock_run:
+        sigs = extract_signals_cc(msgs)
+    assert sigs["pr_merges"] == ["PR #99"]
+    assert any(FAKE_SHA_2 in d for d in sigs["deliverables"])
+    assert any(FAKE_SHA_2 in c for c in sigs["git_commits"])
+    # Verify the repo from `--repo` was used for the lookup.
+    args = mock_run.call_args.args[0]
+    assert "gptme/gptme-contrib" in args
+
+
+def test_extract_signals_cc_gh_failure_does_not_break_extraction():
+    """When gh pr view fails, extraction still succeeds and pr_merges is intact."""
+    msgs = _pr_create_then_merge_msgs(pr_num=42, owner_repo="owner/repo")
+    with patch(
+        "gptme_sessions.signals.subprocess.run",
+        side_effect=_make_mock_run(stdout="", returncode=1),
+    ):
+        sigs = extract_signals_cc(msgs)
+    # Still records the merge — just no resolved SHA.
+    assert sigs["pr_merges"] == ["PR #42"]
+    # No fake sha added.
+    assert not any(FAKE_SHA in c for c in sigs["git_commits"])
+    # deliverables still contains the human-readable "merge PR #42" entry.
+    assert any("merge PR #42" in d for d in sigs["deliverables"])
+
+
+def test_extract_signals_cc_no_pr_merges_no_gh_calls():
+    """Regression: sessions with no pr merges do NOT invoke gh pr view."""
+    # Minimal trajectory: just an assistant write, no gh pr merge.
+    msgs = [
+        {
+            "type": "assistant",
+            "timestamp": "2026-04-17T10:00:00.000Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "w1",
+                        "name": "Write",
+                        "input": {"file_path": "/tmp/x.py", "content": "x = 1"},
+                    }
+                ],
+            },
+        },
+        {
+            "type": "user",
+            "timestamp": "2026-04-17T10:00:05.000Z",
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "w1",
+                        "is_error": False,
+                        "content": "wrote 1 line",
+                    }
+                ],
+            },
+        },
+    ]
+    with patch("gptme_sessions.signals.subprocess.run") as mock_run:
+        sigs = extract_signals_cc(msgs)
+    mock_run.assert_not_called()
+    assert sigs["pr_merges"] == []
+    # No fake SHA leaked in.
+    assert not any(FAKE_SHA in c for c in sigs["git_commits"])
+
+
+def test_extract_signals_cc_merge_no_repo_context_skips_lookup():
+    """`gh pr merge` without --repo and without a prior pr create → no lookup."""
+    merge_id = "bash_merge_no_context"
+    msgs = [
+        {
+            "type": "assistant",
+            "timestamp": "2026-04-17T10:00:00.000Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": merge_id,
+                        "name": "Bash",
+                        "input": {"command": "gh pr merge 55 --squash"},
+                    }
+                ],
+            },
+        },
+        {
+            "type": "user",
+            "timestamp": "2026-04-17T10:00:10.000Z",
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": merge_id,
+                        "is_error": False,
+                        "content": "\u2713 Squashed and merged pull request #55 (fix: z)",
+                    }
+                ],
+            },
+        },
+    ]
+    with patch("gptme_sessions.signals.subprocess.run") as mock_run:
+        sigs = extract_signals_cc(msgs)
+    # Merge still recorded.
+    assert sigs["pr_merges"] == ["PR #55"]
+    # But no gh lookup — we have no repo for this PR.
+    mock_run.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes a silent gap in `extract_signals_cc`: sessions that ship via `gh pr merge --squash` never captured the server-side merge-commit SHA, so those commits were missing from `deliverables` and could not be reverse-indexed for revert attribution.

## Root cause

`signals.py` extracts \"deliverables\" (commit SHAs) by parsing `git commit` shell output. When a session runs `gh pr merge --squash`, GitHub creates a **new** merge-commit SHA server-side — the session never observes it, only the `✓ Squashed and merged pull request #N` success message. Result: squash-merged commits went unattributed when later reverted on master.

**Evidence** (from ErikBjare/bob harm-signal analysis): of 7 reverts detected in the last 365 days, only 1 was attributable (the one direct commit). The other 6 reverts all targeted squash-merged PRs with SHAs that never appeared in any trajectory file.

## The fix

After `pr_merges` is populated, call a new helper `_resolve_merge_shas` that runs:

```
gh pr view <N> --repo <owner/repo> --json mergeCommit -q .mergeCommit.oid
```

for each detected merge, and appends the returned 40-char hex SHA to `git_commits` (and thus to `deliverables`).

Repo context (`pr_context: dict[int, str]` mapping PR# → owner/repo) is collected from two sources:

1. `gh pr create` output — owner/repo parsed from the PR URL.
2. `gh pr merge --repo OWNER/REPO <N>` commands — owner/repo parsed from the `--repo` flag at dispatch.

**Backward compatible**: `pr_merges` remains `list[str]` (no schema change). A parallel `pr_context` dict is added instead of refactoring.

**Graceful degrade**: `gh` missing, network/auth failure, timeout, malformed output → no SHA added, no exception raised.

## Test coverage

Adds `tests/test_signals_merge_sha.py` with **12 tests**, all mocking `subprocess.run` at module scope so no real `gh` binary is invoked:

**Unit tests for `_resolve_merge_shas`** (7):
- Valid SHA returned from gh → appended
- No repo context → no subprocess call, empty result
- gh non-zero exit → graceful skip
- gh timeout → graceful skip
- gh OSError (binary missing) → graceful skip
- Malformed output (non-40-hex) → not counted
- Empty pr_merges list → no subprocess calls

**Integration tests for `extract_signals_cc`** (5):
- End-to-end `gh pr create` → `gh pr merge` flow puts mocked SHA in deliverables
- `--repo` flag on merge command provides repo context
- gh failure does not break extraction (pr_merges still recorded)
- No merges → no gh calls (regression guard)
- Merge with no repo context → no lookup attempted

All 626 tests in `packages/gptme-sessions` pass. `mypy` clean. `ruff` clean.

## Scope discipline

- No refactor of `pr_merges` schema
- No other signals/judges/post_session touched
- Single function + wiring + tests
- 130 LOC in signals.py, 380 LOC in tests (includes helpers/fixtures)

## Impact

Unblocks the `>=5 attributed sessions` DoD item for ErikBjare/bob#632 (multivariate session grading, Phase 2.5). Every future squash-merge becomes reverse-indexable by `scripts/compute-harm-signal.py` in the bob repo, so reverted PRs correctly penalize their originating session's grade.

Refs: ErikBjare/bob#632

## Test plan

- [x] `make test` passes (626 tests)
- [x] `make typecheck` passes (mypy clean)
- [x] `ruff check`/`ruff format` clean
- [x] New `test_signals_merge_sha.py` 12/12 passing
- [x] Manual review of signals.py diff for scope creep