### PR TITLE
feat(grading): Phase 3 weighted trajectory_grade combine

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -21,6 +21,7 @@ What this function does **not** do (kept in caller scripts):
 
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import dataclass
 from pathlib import Path
@@ -31,6 +32,46 @@ from .signals import extract_from_path
 from .store import SessionStore
 
 logger = logging.getLogger(__name__)
+
+#: Default path for grading weights config (Phase 3 multivariate grading).
+_GRADING_WEIGHTS_PATH = (
+    Path(__file__).resolve().parent.parent.parent.parent.parent.parent
+    / "state"
+    / "grading-weights.json"
+)
+
+#: Fallback weights when config file is not found.
+_DEFAULT_WEIGHTS: dict[str, float] = {
+    "productivity": 0.40,
+    "alignment": 0.35,
+    "harm": 0.25,
+}
+
+
+def load_grading_weights() -> dict[str, float]:
+    """Load grading weights from state/grading-weights.json, with fallback."""
+    # Try to find grading-weights.json by walking up from this file
+    path = _GRADING_WEIGHTS_PATH
+    if path.exists():
+        try:
+            data: dict[str, float] = json.loads(path.read_text())
+            return data
+        except Exception as e:
+            logger.warning("Failed to load grading weights from %s: %s", path, e)
+    # Try environment variable for agent workspace
+    import os
+
+    agent_path = os.environ.get("AGENT_PATH") or os.environ.get("GPTME_AGENT_PATH")
+    if agent_path:
+        alt = Path(agent_path) / "state" / "grading-weights.json"
+        if alt.exists():
+            try:
+                alt_data: dict[str, float] = json.loads(alt.read_text())
+                return alt_data
+            except Exception as e:
+                logger.warning("Failed to load grading weights from %s: %s", alt, e)
+    return _DEFAULT_WEIGHTS
+
 
 #: Valid values for the ``context_tier`` parameter.  Exported so ``cli.py``
 #: can use a single source of truth for ``click.Choice``.
@@ -304,6 +345,17 @@ def post_session(
     record = SessionRecord(**record_kwargs)
     if grade is not None:
         record.set_productivity_grade(grade)
+        # Phase 3: recompute trajectory_grade as weighted combine when multiple
+        # grade dimensions are populated (e.g. alignment from a prior judge run).
+        if len(record.grades) > 1:
+            weights = load_grading_weights()
+            combined = record.apply_weighted_grade(weights)
+            if combined is not None:
+                logger.info(
+                    "Post-session: weighted trajectory_grade=%.3f from dims=%s",
+                    combined,
+                    list(record.grades.keys()),
+                )
     if journal_path is not None:
         try:
             existing_session_ids = [

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -122,6 +122,31 @@ def normalize_run_type(raw: str | None) -> str | None:
     return raw
 
 
+def compute_trajectory_grade(
+    grades: dict[str, float],
+    weights: dict[str, float],
+) -> float | None:
+    """Compute a weighted-average trajectory grade from a grades vector.
+
+    Only dimensions present in *both* ``grades`` and ``weights`` contribute.
+    Missing dimensions are excluded from the denominator so their absence
+    doesn't artificially depress the score.
+
+    Returns ``None`` when there are no overlapping dimensions (can't grade).
+
+    Example::
+
+        >>> compute_trajectory_grade({"productivity": 0.8, "alignment": 0.7},
+        ...                          {"productivity": 0.4, "alignment": 0.35, "harm": 0.25})
+        0.7538461538461538
+    """
+    numerator = sum(grades[k] * weights[k] for k in grades if k in weights)
+    denominator = sum(weights[k] for k in grades if k in weights)
+    if denominator == 0.0:
+        return None
+    return numerator / denominator
+
+
 @dataclass
 class SessionRecord:
     """Canonical per-session metadata record.
@@ -210,8 +235,8 @@ class SessionRecord:
 
     def set_productivity_grade(self, score: float) -> None:
         """Store the productivity dimension alongside the legacy scalar field."""
-        self.trajectory_grade = score
         self.grades["productivity"] = score
+        self.trajectory_grade = score
 
     def set_alignment_grade(
         self,
@@ -252,6 +277,19 @@ class SessionRecord:
             self.grade_reasons["alignment"] = self.llm_judge_reason
             changed = True
         return changed
+
+    def apply_weighted_grade(self, weights: dict[str, float]) -> float | None:
+        """Recompute trajectory_grade as a weighted average of populated grade dims.
+
+        Only dims present in both ``self.grades`` and ``weights`` contribute.
+        Missing dims are excluded from the denominator (no penalty for absent signals).
+        Updates ``self.trajectory_grade`` in place and returns the new value.
+        Returns ``None`` when no overlapping dims are found.
+        """
+        result = compute_trajectory_grade(self.grades, weights)
+        if result is not None:
+            self.trajectory_grade = result
+        return result
 
     @property
     def model_normalized(self) -> str | None:

--- a/packages/gptme-sessions/tests/test_record.py
+++ b/packages/gptme-sessions/tests/test_record.py
@@ -194,6 +194,73 @@ def test_sync_grade_fields_backfills_missing_multivariate_fields():
     assert r.sync_grade_fields() is False
 
 
+# -- compute_trajectory_grade and apply_weighted_grade -----------------------
+
+
+def test_compute_trajectory_grade_basic():
+    """Weighted average uses only dims present in both grades and weights."""
+    from gptme_sessions.record import compute_trajectory_grade
+
+    grades = {"productivity": 0.8, "alignment": 0.6}
+    weights = {"productivity": 0.4, "alignment": 0.35, "harm": 0.25}
+    # harm missing from grades — only productivity + alignment contribute
+    expected = (0.8 * 0.4 + 0.6 * 0.35) / (0.4 + 0.35)
+    assert abs(compute_trajectory_grade(grades, weights) - expected) < 1e-9
+
+
+def test_compute_trajectory_grade_all_dims():
+    """All three dims present — full weighted average."""
+    from gptme_sessions.record import compute_trajectory_grade
+
+    grades = {"productivity": 0.8, "alignment": 0.7, "harm": 1.0}
+    weights = {"productivity": 0.4, "alignment": 0.35, "harm": 0.25}
+    expected = (0.8 * 0.4 + 0.7 * 0.35 + 1.0 * 0.25) / 1.0
+    assert abs(compute_trajectory_grade(grades, weights) - expected) < 1e-9
+
+
+def test_compute_trajectory_grade_no_overlap():
+    """No overlapping dims → returns None."""
+    from gptme_sessions.record import compute_trajectory_grade
+
+    grades = {"novelty": 0.9}
+    weights = {"productivity": 0.5, "harm": 0.5}
+    assert compute_trajectory_grade(grades, weights) is None
+
+
+def test_compute_trajectory_grade_empty_grades():
+    """Empty grades dict → returns None."""
+    from gptme_sessions.record import compute_trajectory_grade
+
+    assert compute_trajectory_grade({}, {"productivity": 1.0}) is None
+
+
+def test_apply_weighted_grade_updates_trajectory_grade():
+    """apply_weighted_grade() updates trajectory_grade and returns the value."""
+    r = SessionRecord(session_id="weighted-test")
+    r.set_productivity_grade(0.8)
+    r.grades["alignment"] = 0.6
+    weights = {"productivity": 0.4, "alignment": 0.35, "harm": 0.25}
+
+    result = r.apply_weighted_grade(weights)
+
+    expected = (0.8 * 0.4 + 0.6 * 0.35) / (0.4 + 0.35)
+    assert result is not None
+    assert abs(result - expected) < 1e-9
+    assert abs(r.trajectory_grade - expected) < 1e-9
+
+
+def test_apply_weighted_grade_no_grades_returns_none():
+    """apply_weighted_grade() with no matching dims returns None without mutating."""
+    r = SessionRecord(session_id="no-weights")
+    r.grades["novelty"] = 0.9
+    weights = {"productivity": 1.0}
+
+    result = r.apply_weighted_grade(weights)
+
+    assert result is None
+    assert r.trajectory_grade is None
+
+
 # -- normalize_model: dot variants and regex fallback ------------------------
 
 


### PR DESCRIPTION
## Summary

Phase 3 of ErikBjare/bob#632 (multivariate session grading).

Closes the key gap: harm scores were being computed and stored in `grade-revisions.jsonl` but had **zero effect** on `trajectory_grade` (the scalar the bandits read). This PR wires them together.

## Changes

### `record.py`
- `compute_trajectory_grade(grades, weights) -> float | None`: module-level weighted average. Dims missing from `grades` are excluded from the denominator — no penalty for absent signals. Returns `None` when no overlap.
- `apply_weighted_grade(weights)`: SessionRecord method that calls `compute_trajectory_grade` and updates `self.trajectory_grade` in-place.

### `post_session.py`
- `load_grading_weights()`: reads `state/grading-weights.json`, falls back to hardcoded defaults.
- After `set_productivity_grade()`, if >1 grade dim is populated (e.g. alignment from a prior judge run), applies weighted combine so `trajectory_grade` is always a multi-dim composite when possible.

### Tests (`test_record.py`)
6 new tests covering:
- Basic weighted average (missing harm dim excluded)
- All three dims present
- No overlapping dims → `None`
- Empty grades → `None`
- `apply_weighted_grade` updates `trajectory_grade`
- `apply_weighted_grade` with no matching dims returns `None` without mutating

## How it works

```
grades = {"productivity": 0.8, "alignment": 0.7, "harm": 1.0}
weights = {"productivity": 0.40, "alignment": 0.35, "harm": 0.25}
# trajectory_grade = (0.8×0.40 + 0.7×0.35 + 1.0×0.25) / 1.0 = 0.795
```

If harm is missing (not yet computed):
```
grades = {"productivity": 0.8, "alignment": 0.7}
# trajectory_grade = (0.8×0.40 + 0.7×0.35) / 0.75 = 0.753...
```