### PR TITLE
fix(grading): remove dead weighted-combine guard in post_session

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -59,8 +60,6 @@ def load_grading_weights() -> dict[str, float]:
         except Exception as e:
             logger.warning("Failed to load grading weights from %s: %s", path, e)
     # Try environment variable for agent workspace
-    import os
-
     agent_path = os.environ.get("AGENT_PATH") or os.environ.get("GPTME_AGENT_PATH")
     if agent_path:
         alt = Path(agent_path) / "state" / "grading-weights.json"
@@ -345,17 +344,10 @@ def post_session(
     record = SessionRecord(**record_kwargs)
     if grade is not None:
         record.set_productivity_grade(grade)
-        # Phase 3: recompute trajectory_grade as weighted combine when multiple
-        # grade dimensions are populated (e.g. alignment from a prior judge run).
-        if len(record.grades) > 1:
-            weights = load_grading_weights()
-            combined = record.apply_weighted_grade(weights)
-            if combined is not None:
-                logger.info(
-                    "Post-session: weighted trajectory_grade=%.3f from dims=%s",
-                    combined,
-                    list(record.grades.keys()),
-                )
+        # NOTE: Weighted multi-dim combine (productivity × alignment × harm)
+        # is handled by compute-harm-signal.py after harm grades are computed.
+        # At post_session time only productivity is available, so there is
+        # nothing to combine yet.
     if journal_path is not None:
         try:
             existing_session_ids = [


### PR DESCRIPTION
## Fix

Addresses the P1 finding from Greptile on #678: the `len(record.grades) > 1` guard was always `False` because `set_productivity_grade()` inserts exactly one key (`"productivity"`), making the `apply_weighted_grade()` call unreachable.

### What changed

- **Removed dead code block** — the weighted combine in `post_session()` could never fire since only productivity is available at recording time.
- **Added clarifying comment** — the weighted multi-dim combine (productivity × alignment × harm) is correctly handled by `compute-harm-signal.py` which runs after harm grades are computed and has access to all dimensions.
- **Moved `import os` to module level** (Greptile P2 finding).

### Why the original code was unreachable

```python
record = SessionRecord(**record_kwargs)  # grades = {}
record.set_productivity_grade(grade)     # grades = {'productivity': 0.8}
if len(record.grades) > 1:              # 1 > 1 → always False
    ...                                  # never reached
```

The actual weighted combine works correctly in `scripts/compute-harm-signal.py::apply_harm_grades_to_records()`, which loads existing records, adds the harm dimension, and recomputes `trajectory_grade` as a weighted average.