### PR TITLE
feat(lessons): validate target_grade frontmatter

### DIFF
--- a/packages/gptme-lessons-extras/README.md
+++ b/packages/gptme-lessons-extras/README.md
@@ -68,6 +68,7 @@ Lessons use YAML frontmatter + Markdown:
 match:
   keywords: ["keyword1", "keyword2"]
 status: active
+target_grade: harm  # optional: trajectory_grade | productivity | alignment | harm
 ---
 
 # Lesson Title
@@ -116,6 +117,7 @@ make typecheck
 
 The validator checks:
 - Valid YAML frontmatter
+- Optional `target_grade` is a known dimension (`trajectory_grade`, `productivity`, `alignment`, `harm`)
 - Required sections present
 - Proper Markdown formatting
 - Keyword specificity

--- a/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
+++ b/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
@@ -28,6 +28,9 @@ import yaml
 # Configuration
 TARGET_LENGTH = 100  # lines (soft target for primary lessons)
 COMPANION_DIR = Path("knowledge/lessons")
+VALID_TARGET_GRADE_FIELDS = frozenset(
+    {"trajectory_grade", "productivity", "alignment", "harm"}
+)
 
 
 class LessonValidator:
@@ -150,6 +153,7 @@ class LessonValidator:
 
         Frontmatter philosophy — only stable, write-once metadata belongs here:
         - ``match`` / ``status``: Core lesson routing and lifecycle fields.
+        - ``target_grade``: Optional per-dim LOO target (single dim or list of dims).
         - ``version``: Optional integer or semver string tracking lesson revision history.
           Increment when making significant keyword or content changes so effectiveness
           data can be correlated to a specific lesson variant.
@@ -181,6 +185,7 @@ class LessonValidator:
             allowed_fields = {
                 "match",
                 "status",
+                "target_grade",
                 "version",
                 "automated_by",
                 "automated_date",
@@ -198,6 +203,8 @@ class LessonValidator:
             # Validate version field if present
             if "version" in frontmatter:
                 self._check_version_field(frontmatter["version"])
+            if "target_grade" in frontmatter:
+                self._check_target_grade_field(frontmatter["target_grade"])
 
         except (ValueError, yaml.YAMLError) as e:
             self.errors.append(f"Invalid YAML frontmatter: {e}")
@@ -228,6 +235,47 @@ class LessonValidator:
         else:
             self.errors.append(
                 f"version must be an integer or a string, got {type(value).__name__}"
+            )
+
+    def _check_target_grade_field(self, value: object) -> None:
+        """Validate the optional ``target_grade`` frontmatter field."""
+        targets: list[str] = []
+        if isinstance(value, str):
+            normalized = value.strip()
+            if not normalized:
+                self.errors.append("target_grade string must not be empty")
+                return
+            targets = [normalized]
+        elif isinstance(value, list):
+            if not value:
+                self.errors.append("target_grade list must not be empty")
+                return
+            for item in value:
+                if not isinstance(item, str):
+                    self.errors.append(
+                        "target_grade list items must all be non-empty strings"
+                    )
+                    return
+                normalized = item.strip()
+                if not normalized:
+                    self.errors.append(
+                        "target_grade list items must all be non-empty strings"
+                    )
+                    return
+                targets.append(normalized)
+        else:
+            self.errors.append(
+                "target_grade must be a string or a list of non-empty strings"
+            )
+            return
+
+        unknown = sorted(set(targets) - VALID_TARGET_GRADE_FIELDS)
+        if unknown:
+            allowed = ", ".join(sorted(VALID_TARGET_GRADE_FIELDS))
+            unknown_list = ", ".join(unknown)
+            self.errors.append(
+                f"target_grade contains unknown dimensions: {unknown_list} "
+                f"(allowed: {allowed})"
             )
 
     def _validate_two_file_format(self):

--- a/packages/gptme-lessons-extras/tests/test_validate.py
+++ b/packages/gptme-lessons-extras/tests/test_validate.py
@@ -191,3 +191,49 @@ def test_version_bool_rejected():
         validator.validate()
         version_errors = [e for e in validator.errors if "version" in e]
         assert version_errors, "version: true (bool) should produce an error"
+
+
+def test_target_grade_single_dim_accepted():
+    """target_grade as a single known dimension should be accepted."""
+    content = _VALID_LESSON.format(extra="target_grade: harm")
+    with tempfile.TemporaryDirectory() as tmp:
+        path = _write_lesson(Path(tmp), content)
+        validator = LessonValidator(path)
+        validator.validate()
+        assert not validator.errors, f"Unexpected errors: {validator.errors}"
+        target_warnings = [w for w in validator.warnings if "target_grade" in w]
+        assert (
+            not target_warnings
+        ), f"Unexpected target_grade warnings: {target_warnings}"
+
+
+def test_target_grade_list_accepted():
+    """target_grade as a list of known dimensions should be accepted."""
+    content = _VALID_LESSON.format(extra='target_grade: ["harm", "alignment"]')
+    with tempfile.TemporaryDirectory() as tmp:
+        path = _write_lesson(Path(tmp), content)
+        validator = LessonValidator(path)
+        validator.validate()
+        assert not validator.errors, f"Unexpected errors: {validator.errors}"
+
+
+def test_target_grade_unknown_dim_rejected():
+    """Unknown target_grade dimensions should produce an error."""
+    content = _VALID_LESSON.format(extra="target_grade: craftsmanship")
+    with tempfile.TemporaryDirectory() as tmp:
+        path = _write_lesson(Path(tmp), content)
+        validator = LessonValidator(path)
+        validator.validate()
+        target_errors = [e for e in validator.errors if "target_grade" in e]
+        assert target_errors, "Unknown target_grade dims should produce an error"
+
+
+def test_target_grade_non_string_list_item_rejected():
+    """List values must all be non-empty strings."""
+    content = _VALID_LESSON.format(extra='target_grade: ["harm", 3]')
+    with tempfile.TemporaryDirectory() as tmp:
+        path = _write_lesson(Path(tmp), content)
+        validator = LessonValidator(path)
+        validator.validate()
+        target_errors = [e for e in validator.errors if "target_grade" in e]
+        assert target_errors, "Non-string target_grade entries should produce an error"


### PR DESCRIPTION
## Summary
- allow `target_grade` in lesson frontmatter without warning as extra metadata
- reject unknown or malformed target-grade declarations in the lesson validator
- document the supported grading dimensions and add focused validator tests

## Testing
- python3 -m py_compile packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
- uv run pytest packages/gptme-lessons-extras/tests/test_validate.py -q