### PR TITLE
feat(discovery): resolve_cc_session_model covers claude -p stream logs

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/discovery.py
+++ b/packages/gptme-sessions/src/gptme_sessions/discovery.py
@@ -132,6 +132,14 @@ def extract_cc_model(jsonl_path: Path) -> str | None:
         {"message": {"role": "assistant", "model": "claude-opus-4-6", ...}, ...}
 
     Scans up to 50 lines to find an assistant message with a model field.
+
+    .. note::
+        This only reads the trajectory file. Claude Code sessions invoked
+        with ``claude -p --stream-json --session-id X`` (batch / autonomous
+        usage) write a stub trajectory with no assistant messages — the
+        actual model lives in the stream log. Use
+        :func:`resolve_cc_session_model` when you have a session id and
+        want to cover both pipelines.
     """
     try:
         with open(jsonl_path, encoding="utf-8") as f:
@@ -154,6 +162,99 @@ def extract_cc_model(jsonl_path: Path) -> str | None:
                         return str(model)
     except (OSError, UnicodeDecodeError) as e:
         logger.debug("Failed to read %s for model extraction: %s", jsonl_path, e)
+    return None
+
+
+def _model_from_cc_stream_log(log_path: Path) -> str | None:
+    """Extract model from a ``claude -p --stream-json`` log's init line.
+
+    Autonomous runs invoke ``claude -p --stream-json`` and tee the stream
+    to ``/tmp/cc-session-{hash}.log``. The first line is a
+    ``type=system, subtype=init`` JSON event with ``model`` at the top
+    level — that's the authoritative model for the entire run.
+
+    Returns ``None`` on any parse / IO failure.
+    """
+    try:
+        with open(log_path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    return None
+                if not isinstance(obj, dict):
+                    return None
+                model = obj.get("model")
+                if isinstance(model, str) and model:
+                    return model
+                return None
+    except (OSError, UnicodeDecodeError) as e:
+        logger.debug("Failed to read %s for model extraction: %s", log_path, e)
+    return None
+
+
+def resolve_cc_session_model(
+    session_id: str,
+    project_dir: Path | None = None,
+    tmp_dir: Path | None = None,
+) -> str | None:
+    """Resolve the model actually used by a Claude Code session.
+
+    Claude Code has two session pipelines with different storage layouts:
+
+    1. **Batch / autonomous** (``claude -p --stream-json --session-id X``)
+       writes only a stub trajectory at ``{project_dir}/{id}.jsonl``
+       (``aiTitle`` / ``sessionId`` metadata, no assistant messages). The
+       actual stream is teed to ``/tmp/cc-session-{hash}.log``, and a
+       pointer file at ``/tmp/cc-session-log-ref-{id}.txt`` contains the
+       log path. The first line of the log is a ``type=system,
+       subtype=init`` event with ``model`` at the top level.
+
+    2. **Interactive** CC sessions write a full trajectory to
+       ``{project_dir}/{id}.jsonl`` with ``message.model`` on each
+       assistant line.
+
+    Preference order: stream log first (covers the batch / autonomous
+    pipeline, which is the dominant usage for bandit updates), falling
+    back to the trajectory (interactive).
+
+    Returns ``None`` when neither source attributes — callers should
+    refuse to guess rather than silently pick another session's model
+    (see the post-mortem in ErikBjare/bob#615 for the contamination
+    vector this guarantees against).
+
+    :param session_id: the ``CC_SESSION_ID`` / ``--session-id`` uuid.
+    :param project_dir: Claude Code project directory (``~/.claude/projects/<slug>``).
+        If ``None``, only the stream log is consulted.
+    :param tmp_dir: directory containing the ``cc-session-log-ref-*.txt``
+        pointer files. Defaults to ``/tmp``.
+    """
+    if not session_id:
+        return None
+
+    if tmp_dir is None:
+        tmp_dir = Path("/tmp")
+
+    ref = tmp_dir / f"cc-session-log-ref-{session_id}.txt"
+    if ref.is_file():
+        try:
+            log_path = Path(ref.read_text(encoding="utf-8").strip())
+        except (OSError, UnicodeDecodeError) as e:
+            logger.debug("Failed to read pointer %s: %s", ref, e)
+            log_path = None
+        if log_path and log_path.is_file():
+            model = _model_from_cc_stream_log(log_path)
+            if model:
+                return model
+
+    if project_dir is not None:
+        trajectory = project_dir / f"{session_id}.jsonl"
+        if trajectory.is_file():
+            return extract_cc_model(trajectory)
+
     return None
 
 

--- a/packages/gptme-sessions/tests/test_discovery.py
+++ b/packages/gptme-sessions/tests/test_discovery.py
@@ -21,6 +21,7 @@ from gptme_sessions.discovery import (
     extract_project,
     extract_session_name,
     parse_gptme_config,
+    resolve_cc_session_model,
     session_datetime_from_path,
 )
 
@@ -209,6 +210,187 @@ def test_extract_cc_model_non_dict_lines(tmp_path: Path) -> None:
         + "\n"
     )
     assert extract_cc_model(jsonl_file) == "claude-opus-4-6"
+
+
+# --- resolve_cc_session_model ---
+
+
+def _write_stream_log(
+    tmp_dir: Path,
+    session_id: str,
+    log_path: Path,
+    first_line: dict | str,
+) -> None:
+    """Write a stream log and its pointer file for test setup."""
+    if isinstance(first_line, dict):
+        log_path.write_text(json.dumps(first_line) + "\n", encoding="utf-8")
+    else:
+        log_path.write_text(first_line, encoding="utf-8")
+    (tmp_dir / f"cc-session-log-ref-{session_id}.txt").write_text(
+        str(log_path) + "\n", encoding="utf-8"
+    )
+
+
+def test_resolve_cc_session_model_from_stream_log(tmp_path: Path) -> None:
+    """Resolve uses the stream log when the pointer file exists — covers
+    `claude -p --stream-json` autonomous sessions whose trajectory is a stub."""
+    sid = "abcd-1234"
+    tmp_dir = tmp_path / "tmp"
+    tmp_dir.mkdir()
+    log_path = tmp_dir / "cc-session-deadbeef.log"
+    _write_stream_log(
+        tmp_dir,
+        sid,
+        log_path,
+        {
+            "type": "system",
+            "subtype": "init",
+            "session_id": sid,
+            "model": "claude-sonnet-4-6",
+        },
+    )
+    assert resolve_cc_session_model(sid, tmp_dir=tmp_dir) == "claude-sonnet-4-6"
+
+
+def test_resolve_cc_session_model_stream_log_preferred_over_stub(tmp_path: Path) -> None:
+    """When both a stub trajectory (no assistant messages) and a stream log
+    exist, the stream log wins — the stub can't attribute."""
+    sid = "stub-and-log"
+    tmp_dir = tmp_path / "tmp"
+    tmp_dir.mkdir()
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+
+    log_path = tmp_dir / "cc-session-xyz.log"
+    _write_stream_log(
+        tmp_dir, sid, log_path, {"type": "system", "subtype": "init", "model": "claude-opus-4-6"}
+    )
+    # Stub trajectory — aiTitle only, no assistant message
+    (project_dir / f"{sid}.jsonl").write_text(
+        json.dumps({"aiTitle": "some title", "sessionId": sid, "type": "summary"}) + "\n",
+        encoding="utf-8",
+    )
+
+    assert (
+        resolve_cc_session_model(sid, project_dir=project_dir, tmp_dir=tmp_dir) == "claude-opus-4-6"
+    )
+
+
+def test_resolve_cc_session_model_falls_back_to_trajectory(tmp_path: Path) -> None:
+    """When no pointer/log exists (interactive session), fall back to the
+    trajectory file in the project dir."""
+    sid = "interactive-7890"
+    tmp_dir = tmp_path / "tmp"
+    tmp_dir.mkdir()
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+
+    (project_dir / f"{sid}.jsonl").write_text(
+        json.dumps({"message": {"role": "user", "content": "hi"}})
+        + "\n"
+        + json.dumps({"message": {"role": "assistant", "model": "claude-opus-4-7", "content": []}})
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert (
+        resolve_cc_session_model(sid, project_dir=project_dir, tmp_dir=tmp_dir) == "claude-opus-4-7"
+    )
+
+
+def test_resolve_cc_session_model_returns_none_when_nothing_resolves(tmp_path: Path) -> None:
+    """Neither a stream log nor a trajectory attributes — refuse to guess.
+    Guards the ErikBjare/bob#615 bandit-contamination invariant."""
+    tmp_dir = tmp_path / "tmp"
+    tmp_dir.mkdir()
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    assert resolve_cc_session_model("ghost-id", project_dir=project_dir, tmp_dir=tmp_dir) is None
+
+
+def test_resolve_cc_session_model_empty_session_id(tmp_path: Path) -> None:
+    """Empty session id short-circuits to None without touching the filesystem."""
+    tmp_dir = tmp_path / "tmp"
+    tmp_dir.mkdir()
+    assert resolve_cc_session_model("", tmp_dir=tmp_dir) is None
+
+
+def test_resolve_cc_session_model_dangling_pointer_falls_back(tmp_path: Path) -> None:
+    """Pointer file exists but references a non-existent log — fall back to
+    the trajectory rather than returning None."""
+    sid = "dangling-pointer"
+    tmp_dir = tmp_path / "tmp"
+    tmp_dir.mkdir()
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+
+    (tmp_dir / f"cc-session-log-ref-{sid}.txt").write_text(
+        "/tmp/does-not-exist.log\n", encoding="utf-8"
+    )
+    (project_dir / f"{sid}.jsonl").write_text(
+        json.dumps({"message": {"role": "assistant", "model": "claude-haiku-4-5", "content": []}})
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert (
+        resolve_cc_session_model(sid, project_dir=project_dir, tmp_dir=tmp_dir)
+        == "claude-haiku-4-5"
+    )
+
+
+def test_resolve_cc_session_model_stream_log_no_model_field(tmp_path: Path) -> None:
+    """Stream log's first line lacks a top-level model — fall back cleanly.
+    Covers the case where the log format drifts."""
+    sid = "no-model"
+    tmp_dir = tmp_path / "tmp"
+    tmp_dir.mkdir()
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+
+    log_path = tmp_dir / "cc-session-nomodel.log"
+    _write_stream_log(tmp_dir, sid, log_path, {"type": "system", "subtype": "init"})
+    (project_dir / f"{sid}.jsonl").write_text(
+        json.dumps({"message": {"role": "assistant", "model": "claude-sonnet-4-6", "content": []}})
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert (
+        resolve_cc_session_model(sid, project_dir=project_dir, tmp_dir=tmp_dir)
+        == "claude-sonnet-4-6"
+    )
+
+
+def test_resolve_cc_session_model_stream_log_garbage_first_line(tmp_path: Path) -> None:
+    """Stream log's first line is invalid JSON — return None from the log
+    probe and let the trajectory fallback kick in."""
+    sid = "garbage"
+    tmp_dir = tmp_path / "tmp"
+    tmp_dir.mkdir()
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+
+    log_path = tmp_dir / "cc-session-garbage.log"
+    _write_stream_log(tmp_dir, sid, log_path, "not-json-at-all\n")
+    (project_dir / f"{sid}.jsonl").write_text(
+        json.dumps({"message": {"role": "assistant", "model": "claude-opus-4-6", "content": []}})
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert (
+        resolve_cc_session_model(sid, project_dir=project_dir, tmp_dir=tmp_dir) == "claude-opus-4-6"
+    )
+
+
+def test_resolve_cc_session_model_without_project_dir(tmp_path: Path) -> None:
+    """When project_dir is None, only the stream log is consulted. A
+    missing pointer returns None instead of trying to read a trajectory."""
+    sid = "no-project-dir"
+    tmp_dir = tmp_path / "tmp"
+    tmp_dir.mkdir()
+    assert resolve_cc_session_model(sid, project_dir=None, tmp_dir=tmp_dir) is None
 
 
 # --- discover_gptme_sessions ---


### PR DESCRIPTION
## Summary

Adds `resolve_cc_session_model(session_id, project_dir, tmp_dir)` to `gptme_sessions.discovery`, which attributes a model to a specific CC session by checking both CC storage pipelines:

1. **Autonomous / `claude -p` sessions**: follow the pointer at `/tmp/cc-session-log-ref-{session_id}.txt` to the stream log at `/tmp/cc-session-{hash}.log` and read the top-level `model` field from the first `init` event.
2. **Interactive sessions**: fall back to `{project_dir}/{session_id}.jsonl` via the existing `extract_cc_model()`.

Returns `None` when neither source attributes — preserves the Thompson-sampling contamination guarantee from ErikBjare/bob#615 (never attribute a random newest-trajectory model to an unrelated session).

## Why

Bob's workspace already has this resolver at `scripts/track-model-version.py` and `scripts/update-harness-bandit.py`, but it needs to live upstream so **every** gptme-contrib consumer gets correct per-session model attribution. See gptme/gptme-contrib#674.

Before this PR, `extract_cc_model()` alone couldn't handle autonomous CC runs because `claude -p --stream-json` (with or without `--no-session-persistence`) writes conversation content to the stream log, not to the project-dir trajectory — so `.jsonl` either doesn't exist or is a stub.

## Test plan

- [x] 8 new tests in `test_discovery.py` covering: stream-log path, log-preferred-over-stub precedence, trajectory fallback, None-when-neither (contamination guarantee), empty `session_id` short-circuit, dangling pointer, stream log missing model field, garbage first line, no-project-dir usage.
- [x] `uv run pytest packages/gptme-sessions/tests/test_discovery.py -q` — 63 passed (55 pre-existing + 8 new).
- [x] `uv run ruff check` clean, `uv run ruff format` applied.
- [x] `uv run mypy packages/gptme-sessions/src/gptme_sessions/discovery.py` — no issues introduced.

Closes #674.

Refs ErikBjare/bob#615 (bandit contamination guarantee).