### PR TITLE
fix(cc): drop --no-session-persistence for non-nested calls

### DIFF
--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -39,20 +39,25 @@ def call_claude_code(prompt: str, timeout: int = 120, max_retries: int = _MAX_RE
     import os
 
     env = os.environ.copy()
-    # Allow nesting: unset all CC env vars and use --no-session-persistence.
-    # Root cause: without --no-session-persistence, the subprocess tries to
-    # connect to the parent CC session's persistence layer, which causes it
-    # to silently return empty output (exit 0, no stdout). Clearing env vars
-    # alone is insufficient — the session persistence system is the actual
-    # nesting detection mechanism.
+    # Allow nesting: unset all CC env vars. Historically we also passed
+    # --no-session-persistence unconditionally, but for non-nested callers that
+    # prevents CC from writing a full trajectory to ~/.claude/projects/. Only
+    # pass the flag when actually nested (CLAUDECODE set in parent env) as a
+    # belt-and-suspenders safeguard against the empty-output bug
+    # (gptme/gptme-contrib#585). See: ErikBjare/bob#681.
+    nested = bool(env.get("CLAUDECODE"))
     env.pop("CLAUDECODE", None)
     env.pop("CLAUDE_CODE_ENTRYPOINT", None)
     env.pop("CC_SESSION_ID", None)
     env.pop("CC_MODEL", None)
 
+    cmd = ["claude", "-p", "-"]
+    if nested:
+        cmd.append("--no-session-persistence")
+
     for attempt in range(1, max_retries + 1):
         result = subprocess.run(
-            ["claude", "-p", "-", "--no-session-persistence"],
+            cmd,
             input=prompt,
             capture_output=True,
             text=True,

--- a/packages/gptme-activity-summary/tests/test_cc_backend.py
+++ b/packages/gptme-activity-summary/tests/test_cc_backend.py
@@ -202,15 +202,46 @@ def test_call_claude_code_unsets_all_cc_env_vars(mock_run):
 
 @patch("gptme_activity_summary.cc_backend.time.sleep")
 @patch("subprocess.run")
-def test_call_claude_code_uses_no_session_persistence(mock_run, mock_sleep):
-    """Verify --no-session-persistence flag prevents silent empty output when nested."""
+def test_call_claude_code_no_session_persistence_when_nested(mock_run, mock_sleep):
+    """--no-session-persistence is passed only when CLAUDECODE is set (nested)."""
+    import os
+
     mock_run.return_value = _make_completed_process(stdout="test output")
-    call_claude_code("test prompt")
-    cmd = mock_run.call_args[0][0]
-    assert "--no-session-persistence" in cmd, (
-        "Must pass --no-session-persistence to prevent CC session persistence "
-        "from hijacking output when running as a subprocess of another CC session"
-    )
+
+    # Nested case: CLAUDECODE set → flag present as belt-and-suspenders safeguard
+    os.environ["CLAUDECODE"] = "1"
+    try:
+        call_claude_code("test prompt")
+        cmd = mock_run.call_args[0][0]
+        assert "--no-session-persistence" in cmd, (
+            "Must pass --no-session-persistence when nested (CLAUDECODE set) "
+            "to prevent empty-output bug (gptme/gptme-contrib#585)"
+        )
+    finally:
+        os.environ.pop("CLAUDECODE", None)
+
+
+@patch("gptme_activity_summary.cc_backend.time.sleep")
+@patch("subprocess.run")
+def test_call_claude_code_no_flag_when_not_nested(mock_run, mock_sleep):
+    """--no-session-persistence is dropped for non-nested calls so CC writes a full trajectory."""
+    import os
+
+    mock_run.return_value = _make_completed_process(stdout="test output")
+
+    # Ensure CLAUDECODE is not set
+    prev = os.environ.pop("CLAUDECODE", None)
+    try:
+        call_claude_code("test prompt")
+        cmd = mock_run.call_args[0][0]
+        assert "--no-session-persistence" not in cmd, (
+            "Non-nested calls should NOT pass --no-session-persistence; "
+            "dropping the flag lets CC write a full trajectory to ~/.claude/projects/. "
+            "See ErikBjare/bob#681."
+        )
+    finally:
+        if prev is not None:
+            os.environ["CLAUDECODE"] = prev
 
 
 # --- Tests for _cc_failed flag propagation ---

--- a/scripts/autoresearch/merge-reject-loop.sh
+++ b/scripts/autoresearch/merge-reject-loop.sh
@@ -469,12 +469,19 @@ run_agent_with_fallback() {
                 gptme_cmd+=("${prompt}")
                 ;;
             claude-code|cc)
-                # Claude Code headless mode. Disable persistence for nested runs
-                # and clear inherited session env to prevent silent empty output.
-                # See: gptme/gptme-contrib#585 for the root cause.
+                # Claude Code headless mode. Clear inherited session env to prevent
+                # silent empty output from nested runs. Only pass
+                # --no-session-persistence when actually nested (CLAUDECODE set)
+                # so non-nested invocations write full trajectories to
+                # ~/.claude/projects/ instead of stubs.
+                # See: gptme/gptme-contrib#585 (original bug), ErikBjare/bob#681.
+                local _persist_flag=()
+                if [[ -n "${CLAUDECODE:-}" ]]; then
+                    _persist_flag=(--no-session-persistence)
+                fi
                 gptme_cmd=(
                     env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT -u CC_SESSION_ID -u CC_MODEL
-                    claude -p --no-session-persistence "${prompt}"
+                    claude -p "${_persist_flag[@]}" "${prompt}"
                     --cwd "${GPTME_DIR}"
                 )
                 if [[ -n "${candidate}" ]]; then
@@ -596,8 +603,13 @@ NEXT_FOCUS: <one concrete specific action the next iteration should take, differ
             gptme --non-interactive -m "${diag_model}" "${diag_prompt}" > "${diagnosis_log}" 2>&1
             ;;
         claude-code|cc)
+            # See nested-run notes above for the --no-session-persistence rationale.
+            local _diag_persist_flag=()
+            if [[ -n "${CLAUDECODE:-}" ]]; then
+                _diag_persist_flag=(--no-session-persistence)
+            fi
             env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT -u CC_SESSION_ID -u CC_MODEL \
-                claude -p --no-session-persistence "${diag_prompt}" --model "${diag_model}" > "${diagnosis_log}" 2>&1
+                claude -p "${_diag_persist_flag[@]}" "${diag_prompt}" --model "${diag_model}" > "${diagnosis_log}" 2>&1
             ;;
     esac
     set -e


### PR DESCRIPTION
## Summary
- Make `--no-session-persistence` conditional on `CLAUDECODE` in three CC callers
  (activity-summary `cc_backend.py`, autoresearch `merge-reject-loop.sh` main
  + diagnosis paths)
- Non-nested invocations (systemd, operator shell) now write full trajectories
  to `~/.claude/projects/` instead of stubs
- Tests updated to cover both nested (flag present) and non-nested (flag
  absent) cases

## Why
Erik's feedback on ErikBjare/bob#681 — we shouldn't use `--no-session-persistence`
anywhere it's not strictly needed. It was introduced as a belt-and-suspenders fix for
the nested-CC empty-output bug (#585), but for non-nested callers it suppresses
durable trajectory writing. Matches the conditional pattern already used in Bob's
`run.sh` and `tools/claude-code/queue.py`.

Companion change in Bob's main repo: `ErikBjare/bob@8e83d4a42` updates
`twitter-dispatch.sh` and the CC eval runner with the same pattern.

## Test plan
- [x] Unit tests updated (`test_call_claude_code_no_session_persistence_when_nested`
      and `test_call_claude_code_no_flag_when_not_nested`) — 20/20 pass
- [x] Bash syntax check on `merge-reject-loop.sh`
- [ ] Wait for Greptile review before merge