### PR TITLE
feat(gptme-sessions): persist observed usage totals

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -99,6 +99,10 @@ class PostSessionResult:
     grade: float | None = None
     signals: dict[str, Any] | None = None
     token_count: int | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    cache_creation_tokens: int | None = None
+    cache_read_tokens: int | None = None
 
 
 def post_session(
@@ -212,6 +216,10 @@ def post_session(
     grade: float | None = None
     signals: dict[str, Any] | None = None
     token_count: int | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    cache_creation_tokens: int | None = None
+    cache_read_tokens: int | None = None
     traj_productive: bool | None = None
 
     # --- Extract signals from trajectory ---
@@ -222,6 +230,11 @@ def post_session(
             grade = result.get("grade")
             traj_productive = result.get("productive")
             usage = result.get("usage") or {}
+            if usage:
+                input_tokens = int(usage.get("input_tokens", 0))
+                output_tokens = int(usage.get("output_tokens", 0))
+                cache_creation_tokens = int(usage.get("cache_creation_tokens", 0))
+                cache_read_tokens = int(usage.get("cache_read_tokens", 0))
             total = usage.get("total_tokens", 0)
             if total:
                 token_count = int(total)
@@ -341,6 +354,14 @@ def post_session(
         record_kwargs["session_id"] = session_id
     if token_count is not None:
         record_kwargs["token_count"] = token_count
+    if input_tokens is not None:
+        record_kwargs["input_tokens"] = input_tokens
+    if output_tokens is not None:
+        record_kwargs["output_tokens"] = output_tokens
+    if cache_creation_tokens is not None:
+        record_kwargs["cache_creation_tokens"] = cache_creation_tokens
+    if cache_read_tokens is not None:
+        record_kwargs["cache_read_tokens"] = cache_read_tokens
     record = SessionRecord(**record_kwargs)
     if grade is not None:
         record.set_productivity_grade(grade)
@@ -377,4 +398,8 @@ def post_session(
         grade=grade,
         signals=signals,
         token_count=token_count,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_creation_tokens=cache_creation_tokens,
+        cache_read_tokens=cache_read_tokens,
     )

--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -86,13 +86,17 @@ class PostSessionResult:
     """Return value from :func:`post_session`.
 
     Attributes:
-        record:      The :class:`SessionRecord` that was appended to the store.
-        grade:       Graded reward (0.0–1.0) extracted from the trajectory, or
-                     ``None`` if no trajectory was available.
-        signals:     Raw signal dict from :func:`~gptme_sessions.signals.extract_from_path`,
-                     or ``None`` if no trajectory was available.
-        token_count: Total token count from the trajectory (CC format only),
-                     or ``None`` if not available.
+        record:                The :class:`SessionRecord` that was appended to the store.
+        grade:                 Graded reward (0.0–1.0) extracted from the trajectory, or
+                               ``None`` if no trajectory was available.
+        signals:               Raw signal dict from :func:`~gptme_sessions.signals.extract_from_path`,
+                               or ``None`` if no trajectory was available.
+        token_count:           Total token count from the trajectory (CC format only),
+                               or ``None`` if not available.
+        input_tokens:          Input tokens from usage breakdown, or ``None`` if not present.
+        output_tokens:         Output tokens from usage breakdown, or ``None`` if not present.
+        cache_creation_tokens: Cache-write tokens, or ``None`` if not present.
+        cache_read_tokens:     Cache-read tokens, or ``None`` if not present.
     """
 
     record: SessionRecord
@@ -231,10 +235,14 @@ def post_session(
             traj_productive = result.get("productive")
             usage = result.get("usage") or {}
             if usage:
-                input_tokens = int(usage.get("input_tokens", 0))
-                output_tokens = int(usage.get("output_tokens", 0))
-                cache_creation_tokens = int(usage.get("cache_creation_tokens", 0))
-                cache_read_tokens = int(usage.get("cache_read_tokens", 0))
+                _in = usage.get("input_tokens")
+                _out = usage.get("output_tokens")
+                _cc = usage.get("cache_creation_tokens")
+                _cr = usage.get("cache_read_tokens")
+                input_tokens = int(_in) if _in is not None else None
+                output_tokens = int(_out) if _out is not None else None
+                cache_creation_tokens = int(_cc) if _cc is not None else None
+                cache_read_tokens = int(_cr) if _cr is not None else None
             total = usage.get("total_tokens", 0)
             if total:
                 token_count = int(total)

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -186,6 +186,10 @@ class SessionRecord:
     exit_code: int | None = None  # process exit code (124 = timeout)
     duration_seconds: int = 0
     token_count: int | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    cache_creation_tokens: int | None = None
+    cache_read_tokens: int | None = None
 
     # Artifacts
     deliverables: list[str] = field(default_factory=list)  # commit SHAs, PR URLs

--- a/packages/gptme-sessions/tests/test_post_session.py
+++ b/packages/gptme-sessions/tests/test_post_session.py
@@ -208,3 +208,44 @@ def test_post_session_populates_productivity_grade(tmp_path: Path):
 
     records = store.load_all()
     assert records[0].grades == {"productivity": 0.68}
+
+
+def test_post_session_persists_usage_fields(tmp_path: Path):
+    """Trajectory usage totals should be written into the canonical session record."""
+    store = SessionStore(sessions_dir=tmp_path)
+    fake_traj = tmp_path / "trajectory.jsonl"
+    fake_traj.write_text("")
+
+    fake_signals = {
+        "session_duration_s": 60,
+        "productive": True,
+        "deliverables": [],
+        "usage": {
+            "model": "claude-sonnet-4-6",
+            "input_tokens": 120,
+            "output_tokens": 45,
+            "cache_creation_tokens": 30,
+            "cache_read_tokens": 600,
+            "total_tokens": 795,
+        },
+    }
+    with patch.object(_post_session_mod, "extract_from_path", return_value=fake_signals):
+        result = post_session(
+            store=store,
+            harness="claude-code",
+            model="unknown",
+            duration_seconds=0,
+            trajectory_path=fake_traj,
+        )
+
+    assert result.token_count == 795
+    assert result.record.input_tokens == 120
+    assert result.record.output_tokens == 45
+    assert result.record.cache_creation_tokens == 30
+    assert result.record.cache_read_tokens == 600
+
+    records = store.load_all()
+    assert records[0].input_tokens == 120
+    assert records[0].output_tokens == 45
+    assert records[0].cache_creation_tokens == 30
+    assert records[0].cache_read_tokens == 600

--- a/packages/gptme-sessions/tests/test_post_session.py
+++ b/packages/gptme-sessions/tests/test_post_session.py
@@ -249,3 +249,42 @@ def test_post_session_persists_usage_fields(tmp_path: Path):
     assert records[0].output_tokens == 45
     assert records[0].cache_creation_tokens == 30
     assert records[0].cache_read_tokens == 600
+
+
+def test_post_session_partial_usage_fields_stored_as_none(tmp_path: Path):
+    """Absent usage sub-fields must be None, not 0, to avoid corrupting analytics."""
+    store = SessionStore(sessions_dir=tmp_path)
+    fake_traj = tmp_path / "trajectory.jsonl"
+    fake_traj.write_text("")
+
+    # Older trajectory format: only total_tokens present, no breakdown keys
+    fake_signals = {
+        "session_duration_s": 60,
+        "productive": True,
+        "deliverables": [],
+        "usage": {
+            "model": "claude-sonnet-4-6",
+            "total_tokens": 500,
+        },
+    }
+    with patch.object(_post_session_mod, "extract_from_path", return_value=fake_signals):
+        result = post_session(
+            store=store,
+            harness="claude-code",
+            model="unknown",
+            duration_seconds=0,
+            trajectory_path=fake_traj,
+        )
+
+    assert result.token_count == 500
+    # Absent breakdown keys must be None, not 0
+    assert result.input_tokens is None
+    assert result.output_tokens is None
+    assert result.cache_creation_tokens is None
+    assert result.cache_read_tokens is None
+
+    records = store.load_all()
+    assert records[0].input_tokens is None
+    assert records[0].output_tokens is None
+    assert records[0].cache_creation_tokens is None
+    assert records[0].cache_read_tokens is None


### PR DESCRIPTION
## Summary
Persist per-session  token totals in  and  so downstream analytics can measure real token efficiency instead of only model-floor proxies.

## Testing
- uv run pytest /home/bob/bob/packages/gptme-sessions/tests/test_post_session.py -q
- uv run pytest /home/bob/bob/packages/gptme-sessions/tests/test_sessions.py -q -k session_record
