### PR TITLE
fix(usage-check): reap stale tmux sessions from prior runs

### DIFF
--- a/scripts/check-claude-usage.sh
+++ b/scripts/check-claude-usage.sh
@@ -84,6 +84,23 @@ fi
 SESSION_NAME="claude-usage-check-$$"
 TIMEOUT=25
 
+# Reap stale sessions from prior runs (SIGKILLed, systemd-terminated, etc.).
+# Any claude-usage-check-* session older than 10 minutes is stale (the script
+# runs with TIMEOUT=25 and usually completes in under a minute).
+reap_stale_sessions() {
+    local now stale_cutoff
+    now=$(date +%s)
+    stale_cutoff=$((now - 600))  # 10 minutes ago
+    while IFS='|' read -r sess created; do
+        [ -z "$sess" ] && continue
+        if [ "$created" -lt "$stale_cutoff" ]; then
+            tmux kill-session -t "$sess" 2>/dev/null || true
+        fi
+    done < <(tmux list-sessions -F '#{session_name}|#{session_created}' 2>/dev/null \
+        | grep '^claude-usage-check-' || true)
+}
+reap_stale_sessions
+
 cleanup() {
     # Try graceful exit first
     tmux send-keys -t "$SESSION_NAME" Escape 2>/dev/null || true

--- a/scripts/check-claude-usage.sh
+++ b/scripts/check-claude-usage.sh
@@ -93,6 +93,7 @@ reap_stale_sessions() {
     stale_cutoff=$((now - 600))  # 10 minutes ago
     while IFS='|' read -r sess created; do
         [ -z "$sess" ] && continue
+        [ -z "$created" ] && continue
         if [ "$created" -lt "$stale_cutoff" ]; then
             tmux kill-session -t "$sess" 2>/dev/null || true
         fi


### PR DESCRIPTION
## Summary

If `check-claude-usage.sh` is SIGKILLed or systemd-terminated mid-run, its trap-based cleanup doesn't fire and the `claude-usage-check-$$` tmux session lingers forever.

Found **4 stale sessions** on Bob's VM from Mar 27, Apr 13, Apr 15, and Apr 19 — each preserving a dead `claude` TUI process. They never self-clean.

## Fix

At start of each run, reap any `claude-usage-check-*` session older than 10 minutes. The script normally finishes well under a minute (TIMEOUT=25s), so 10min is a safe staleness threshold.

Bounds stale-session accumulation at 15 min (next `bob-subscription-check.timer` fires).

## Test plan

- [x] `shellcheck scripts/check-claude-usage.sh` passes
- [x] `bash -n scripts/check-claude-usage.sh` passes
- [x] End-to-end run with `--no-cache` returns valid usage data
- [x] Pre-existing stale sessions on Bob's VM cleaned up manually