### PR TITLE
feat(git): add git-safe-commit and pre-commit-auto-stage scripts

### DIFF
--- a/scripts/git/git-safe-commit
+++ b/scripts/git/git-safe-commit
@@ -66,10 +66,17 @@ for arg in "$@"; do
         --)
             PARSE_AFTER_DASHDASH=1
             ;;
-        -m|--message|-F|--file|-c|--reedit-message|-C|--reuse-message|--fixup|--squash|--author|--date|--trailer|--pathspec-from-file)
+        -m|--message|-F|--file|-c|--reedit-message|-C|--reuse-message|--fixup|--squash|--author|--date|--trailer)
             SKIP_NEXT_ARG=1
             ;;
-        --message=*|--file=*|--author=*|--date=*|--fixup=*|--squash=*|--trailer=*|--pathspec-from-file=*)
+        --pathspec-from-file)
+            SKIP_NEXT_ARG=1
+            PATHSPEC_COUNT=$((PATHSPEC_COUNT + 1))
+            ;;
+        --message=*|--file=*|--author=*|--date=*|--fixup=*|--squash=*|--trailer=*)
+            ;;
+        --pathspec-from-file=*)
+            PATHSPEC_COUNT=$((PATHSPEC_COUNT + 1))
             ;;
         -*)
             ;;

--- a/scripts/git/git-safe-commit
+++ b/scripts/git/git-safe-commit
@@ -1,0 +1,231 @@
+#!/bin/bash
+# git-safe-commit: Serialize git commits to prevent concurrent staging conflicts
+#
+# Problem: When multiple sessions (autonomous, operator, meta-operator) run
+# concurrently on the same repo, they share .git/index. prek's stash/restore
+# cycle during pre-commit hooks can race with concurrent commits, causing:
+#   - Wrong files in commits (staged by another session)
+#   - prek stash-restore conflicts that silently revert edits
+#   - Wasted tokens re-doing work that was lost
+#
+# Solution: flock serializes the entire commit (including pre-commit hooks)
+# so prek's stash/restore is atomic from other sessions' perspective.
+#
+# Usage: git-safe-commit file1.py file2.py -m "feat: description"
+#        git-safe-commit --all-staged -m "chore: commit intentional staged set"
+#        (same arguments as `git commit`, plus optional --all-staged guard)
+#
+# See: https://github.com/ErikBjare/bob/issues/465
+
+set -uo pipefail
+
+GIT_DIR="$(git rev-parse --git-dir 2>/dev/null)" || true
+if [ -z "$GIT_DIR" ]; then
+    echo "error: not in a git repository" >&2
+    exit 1
+fi
+
+LOCKFILE="$GIT_DIR/commit.lock"
+
+NO_VERIFY=0
+ALLOW_ALL_STAGED=0
+ALLOW_EMPTY=0
+PATHSPEC_COUNT=0
+PARSE_AFTER_DASHDASH=0
+SKIP_NEXT_ARG=0
+FORWARD_ARGS=()
+
+for arg in "$@"; do
+    if [ "$SKIP_NEXT_ARG" -eq 1 ]; then
+        SKIP_NEXT_ARG=0
+        FORWARD_ARGS+=("$arg")
+        continue
+    fi
+
+    if [ "$arg" = "--all-staged" ]; then
+        ALLOW_ALL_STAGED=1
+        continue
+    fi
+
+    if [ "$arg" = "--no-verify" ] || [ "$arg" = "-n" ]; then
+        NO_VERIFY=1
+    fi
+
+    if [ "$arg" = "--allow-empty" ]; then
+        ALLOW_EMPTY=1
+    fi
+
+    FORWARD_ARGS+=("$arg")
+
+    if [ "$PARSE_AFTER_DASHDASH" -eq 1 ]; then
+        PATHSPEC_COUNT=$((PATHSPEC_COUNT + 1))
+        continue
+    fi
+
+    case "$arg" in
+        --)
+            PARSE_AFTER_DASHDASH=1
+            ;;
+        -m|--message|-F|--file|-c|--reedit-message|-C|--reuse-message|--fixup|--squash|--author|--date|--trailer|--pathspec-from-file)
+            SKIP_NEXT_ARG=1
+            ;;
+        --message=*|--file=*|--author=*|--date=*|--fixup=*|--squash=*|--trailer=*|--pathspec-from-file=*)
+            ;;
+        -*)
+            ;;
+        *)
+            PATHSPEC_COUNT=$((PATHSPEC_COUNT + 1))
+            ;;
+    esac
+done
+
+if [ "$PATHSPEC_COUNT" -eq 0 ] && [ "$ALLOW_ALL_STAGED" -ne 1 ] && [ "$ALLOW_EMPTY" -ne 1 ]; then
+    echo "🚫 Refusing implicit whole-index commit in shared repo" >&2
+    echo "" >&2
+    echo "   Use explicit file paths with git-safe-commit so concurrent sessions" >&2
+    echo "   can't accidentally commit unrelated staged changes." >&2
+    echo "" >&2
+    echo "   If you intentionally want the entire staged set, rerun with:" >&2
+    echo "     git-safe-commit --all-staged -m 'your message'" >&2
+    echo "" >&2
+    echo "   Safer default:" >&2
+    echo "     git-safe-commit <file1> <file2> -m 'your message'" >&2
+    echo "" >&2
+    exit 1
+fi
+
+check_index_corruption() {
+    # Run this under the commit lock so we see the latest index state after any
+    # waiting, not a stale snapshot from before lock acquisition.
+    local head_count tracked_count phantom_missing_count phantom_missing_sample
+    local phantom_sample_limit phantom_sample_count new_count
+    local phantom_missing_threshold
+
+    head_count=$(git ls-tree -r --name-only HEAD 2>/dev/null | wc -l)
+    tracked_count=$(git ls-files 2>/dev/null | wc -l)
+    phantom_missing_count=0
+    phantom_missing_sample=""
+    phantom_sample_limit=5
+    phantom_sample_count=0
+
+    if [ "$head_count" -gt 1000 ]; then
+        while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            if [ -e "$f" ] || [ -L "$f" ]; then
+                phantom_missing_count=$((phantom_missing_count + 1))
+                if [ "$phantom_sample_count" -lt "$phantom_sample_limit" ]; then
+                    phantom_missing_sample="${phantom_missing_sample}${f}
+"
+                    phantom_sample_count=$((phantom_sample_count + 1))
+                fi
+            fi
+        done < <(
+            comm -23 \
+                <(git ls-tree -r --name-only HEAD 2>/dev/null | sort) \
+                <(git ls-files 2>/dev/null | sort)
+        )
+    fi
+
+    phantom_missing_threshold=100
+    if [ "$head_count" -gt 1000 ] && [ "$phantom_missing_count" -gt "$phantom_missing_threshold" ]; then
+        echo "🚨 Git index corruption detected ($phantom_missing_count HEAD-tracked files missing from index but still on disk)" >&2
+        echo "" >&2
+        echo "   HEAD has $head_count paths; index currently tracks $tracked_count." >&2
+        echo "   Sample phantom paths:" >&2
+        printf '%s' "$phantom_missing_sample" | sed 's/^/     /' >&2
+        echo "" >&2
+        echo "   Attempting auto-recovery: git read-tree HEAD" >&2
+        git read-tree HEAD
+        new_count=$(git ls-files 2>/dev/null | wc -l)
+        echo "   ✅ Index rebuilt: $new_count tracked files" >&2
+        echo "" >&2
+        echo "   Please re-stage your files and retry:" >&2
+        echo "     git add <your-files>" >&2
+        echo "     git-safe-commit <your-files> -m 'your message'" >&2
+        echo "" >&2
+        exit 1
+    fi
+}
+
+check_clean_worktree_for_hooks() {
+    local unstaged_files untracked_files dirty_count
+
+    unstaged_files="$(git diff --name-only --ignore-submodules -- 2>/dev/null)" || true
+    untracked_files="$(git ls-files --others --exclude-standard 2>/dev/null)" || true
+    dirty_count=0
+
+    if [ -n "$unstaged_files" ]; then
+        dirty_count=$((dirty_count + $(printf '%s\n' "$unstaged_files" | grep -c . || true)))
+    fi
+    if [ -n "$untracked_files" ]; then
+        dirty_count=$((dirty_count + $(printf '%s\n' "$untracked_files" | grep -c . || true)))
+    fi
+
+    if [ "$dirty_count" -gt 0 ]; then
+        echo "🚫 Refusing to run pre-commit in a dirty worktree ($dirty_count unstaged/untracked paths)" >&2
+        echo "" >&2
+        echo "   In this shared repo, prek/pre-commit may stash+restore unrelated files" >&2
+        echo "   and corrupt the index (issue #642)." >&2
+        echo "" >&2
+        echo "   Clean the worktree first, or after manual verification rerun with:" >&2
+        echo "     git-safe-commit ... --no-verify" >&2
+        echo "" >&2
+        echo "   Sample dirty paths:" >&2
+        {
+            printf '%s\n' "$unstaged_files"
+            printf '%s\n' "$untracked_files"
+        } | grep -v '^$' | head -10 | sed 's/^/     /' >&2
+        if [ "$dirty_count" -gt 10 ]; then
+            echo "     ... and $((dirty_count - 10)) more" >&2
+        fi
+        echo "" >&2
+        exit 1
+    fi
+}
+
+LOCK_TIMEOUT=60
+exec 9>"$LOCKFILE"
+if ! flock --timeout "$LOCK_TIMEOUT" 9; then
+    echo "error: timed out waiting for commit lock" >&2
+    exit 1
+fi
+
+check_index_corruption
+
+if [ "$NO_VERIFY" -ne 1 ]; then
+    check_clean_worktree_for_hooks
+    env GIT_SAFE_COMMIT_LOCK_HELD=1 GIT_SAFE_COMMIT_EXPECT_CLEAN=1 git commit "${FORWARD_ARGS[@]}"
+else
+    env GIT_SAFE_COMMIT_LOCK_HELD=1 git commit "${FORWARD_ARGS[@]}"
+fi
+COMMIT_EXIT=$?
+
+if [ "$COMMIT_EXIT" -ne 0 ]; then
+    exit "$COMMIT_EXIT"
+fi
+
+# Post-commit safety net: detect catastrophic index corruption (issue #642).
+# Even if pre-commit hooks pass (phantom filter suppresses warnings), verify
+# the committed diff doesn't contain mass file deletions. If it does,
+# auto-revert before the damage can be pushed.
+DELETED_IN_COMMIT=$(git diff-tree --no-commit-id -r --diff-filter=D HEAD 2>/dev/null | wc -l)
+DELETION_THRESHOLD=100
+
+if [ "$DELETED_IN_COMMIT" -gt "$DELETION_THRESHOLD" ]; then
+    COMMIT_SHA=$(git rev-parse --short HEAD)
+    echo ""
+    echo "🚨 CATASTROPHIC COMMIT DETECTED (issue #642 safeguard)"
+    echo "   Commit $COMMIT_SHA deleted $DELETED_IN_COMMIT files"
+    echo ""
+    echo "   Auto-reverting with: git reset --soft HEAD~1"
+    git reset --soft HEAD~1
+    echo "   ✅ Commit reverted. Your changes are still staged."
+    echo ""
+    echo "   To commit safely:"
+    echo "     1. Run: git diff --cached --stat  (verify only intended files staged)"
+    echo "     2. Run: git commit --no-verify -m 'your message'"
+    echo ""
+    exit 1
+fi
+
+exit 0

--- a/scripts/git/pre-commit-auto-stage
+++ b/scripts/git/pre-commit-auto-stage
@@ -20,6 +20,7 @@ NC='\033[0m' # No Color
 # --- Mass-deletion guard (runs unconditionally, ~1ms) ---
 # This MUST run before the prek/pre-commit availability check below,
 # because when prek is missing, the hook exits 0 and all guards are skipped.
+# The guard script is optional — only present in repos that ship it (e.g. ErikBjare/bob).
 # See: ErikBjare/bob#536 (catastrophic deletion incident)
 _REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 if [ -n "$_REPO_ROOT" ] && [ -f "$_REPO_ROOT/scripts/git/guard-mass-delete.sh" ]; then
@@ -90,7 +91,11 @@ echo -e "${GREEN}Running pre-commit checks (via $PRECOMMIT_CMD)...${NC}"
 
 # Capture the staged set before formatters run so auto-staging cannot pick up
 # files another session changed in the meantime.
-mapfile -t ORIGINALLY_STAGED_FILES < <(git diff --cached --name-only --diff-filter=ACM)
+ORIGINALLY_STAGED_FILES=()
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  ORIGINALLY_STAGED_FILES+=("$line")
+done < <(git diff --cached --name-only --diff-filter=ACM)
 
 run_precommit() {
   if [ ${#ORIGINALLY_STAGED_FILES[@]} -eq 0 ]; then

--- a/scripts/git/pre-commit-auto-stage
+++ b/scripts/git/pre-commit-auto-stage
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Pre-commit hook with auto-staging and commit serialization.
+# Prevents concurrent pre-commit runs from overlapping on the same working tree.
+#
+# Installation:
+#   ln -sf $(pwd)/scripts/git/pre-commit-auto-stage .git/hooks/pre-commit
+#
+# Or copy:
+#   cp scripts/git/pre-commit-auto-stage .git/hooks/pre-commit
+#   chmod +x .git/hooks/pre-commit
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# --- Mass-deletion guard (runs unconditionally, ~1ms) ---
+# This MUST run before the prek/pre-commit availability check below,
+# because when prek is missing, the hook exits 0 and all guards are skipped.
+# See: ErikBjare/bob#536 (catastrophic deletion incident)
+_REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -n "$_REPO_ROOT" ] && [ -f "$_REPO_ROOT/scripts/git/guard-mass-delete.sh" ]; then
+  # shellcheck disable=SC1091
+  source "$_REPO_ROOT/scripts/git/guard-mass-delete.sh"
+  guard_mass_delete_staged
+fi
+
+if [ ! -f ".pre-commit-config.yaml" ]; then
+  exit 0
+fi
+
+if command -v prek >/dev/null 2>&1; then
+  PRECOMMIT_CMD="prek"
+elif command -v pre-commit >/dev/null 2>&1; then
+  PRECOMMIT_CMD="pre-commit"
+else
+  echo -e "${YELLOW}⚠️  Neither prek nor pre-commit found, skipping checks${NC}"
+  exit 0
+fi
+
+GIT_DIR="$(git rev-parse --git-dir 2>/dev/null)"
+LOCKFILE="$GIT_DIR/commit.lock"
+LOCK_TIMEOUT="${PRECOMMIT_LOCK_TIMEOUT:-60}"
+
+if [ "${GIT_SAFE_COMMIT_LOCK_HELD:-0}" != "1" ]; then
+  exec 9>"$LOCKFILE"
+  if ! flock --timeout "$LOCK_TIMEOUT" 9; then
+    echo -e "${RED}✗ Another commit or pre-commit run is already in progress${NC}" >&2
+    echo -e "${RED}Retry shortly, or use git safe-commit for full commit serialization${NC}" >&2
+    exit 1
+  fi
+fi
+
+if [ "${GIT_SAFE_COMMIT_EXPECT_CLEAN:-0}" = "1" ]; then
+  UNSTAGED_FILES="$(git diff --name-only --ignore-submodules -- 2>/dev/null)" || true
+  UNTRACKED_FILES="$(git ls-files --others --exclude-standard 2>/dev/null)" || true
+  DIRTY_COUNT=0
+
+  if [ -n "$UNSTAGED_FILES" ]; then
+    DIRTY_COUNT=$((DIRTY_COUNT + $(printf '%s\n' "$UNSTAGED_FILES" | grep -c . || true)))
+  fi
+  if [ -n "$UNTRACKED_FILES" ]; then
+    DIRTY_COUNT=$((DIRTY_COUNT + $(printf '%s\n' "$UNTRACKED_FILES" | grep -c . || true)))
+  fi
+
+  if [ "$DIRTY_COUNT" -gt 0 ]; then
+    echo -e "${RED}✗ Refusing to run pre-commit after git-safe-commit detected new dirty paths${NC}" >&2
+    echo -e "${RED}  Another session likely dirtied the worktree after the wrapper checked it.${NC}" >&2
+    echo -e "${RED}  Running prek now would trigger stash/restore on unrelated files (issue #642).${NC}" >&2
+    echo "" >&2
+    echo -e "${YELLOW}Sample dirty paths:${NC}" >&2
+    {
+      printf '%s\n' "$UNSTAGED_FILES"
+      printf '%s\n' "$UNTRACKED_FILES"
+    } | grep -v '^$' | head -10 | sed 's/^/  /' >&2
+    if [ "$DIRTY_COUNT" -gt 10 ]; then
+      echo "  ... and $((DIRTY_COUNT - 10)) more" >&2
+    fi
+    echo "" >&2
+    echo "Clean the worktree and retry, or after manual verification use:" >&2
+    echo "  git-safe-commit ... --no-verify" >&2
+    exit 1
+  fi
+fi
+
+echo -e "${GREEN}Running pre-commit checks (via $PRECOMMIT_CMD)...${NC}"
+
+# Capture the staged set before formatters run so auto-staging cannot pick up
+# files another session changed in the meantime.
+mapfile -t ORIGINALLY_STAGED_FILES < <(git diff --cached --name-only --diff-filter=ACM)
+
+run_precommit() {
+  if [ ${#ORIGINALLY_STAGED_FILES[@]} -eq 0 ]; then
+    "$PRECOMMIT_CMD" run
+  else
+    "$PRECOMMIT_CMD" run --files "${ORIGINALLY_STAGED_FILES[@]}"
+  fi
+}
+
+set +e
+PRECOMMIT_OUTPUT="$(run_precommit 2>&1)"
+PRECOMMIT_EXIT=$?
+set -e
+
+if [ $PRECOMMIT_EXIT -eq 0 ]; then
+  echo -e "${GREEN}✓ All pre-commit checks passed${NC}"
+  exit 0
+else
+  echo "$PRECOMMIT_OUTPUT"
+  echo -e "${YELLOW}Pre-commit modified files, checking for auto-staging...${NC}"
+
+  # Check if any files were actually modified
+  if git diff --quiet; then
+    echo -e "${RED}✗ Pre-commit failed but no files were modified${NC}"
+    echo -e "${RED}This indicates a real failure, not auto-fixing${NC}"
+    exit 1
+  fi
+
+  while IFS= read -r file; do
+    for staged_file in "${ORIGINALLY_STAGED_FILES[@]}"; do
+      if [ "$file" = "$staged_file" ]; then
+        git add "$file"
+        break
+      fi
+    done
+  done < <(git diff --name-only --diff-filter=M)
+
+  echo -e "${GREEN}✓ Auto-staged formatter fixes for originally staged files${NC}"
+
+  # Re-run pre-commit to verify all checks pass
+  echo -e "${GREEN}Re-running pre-commit checks (via $PRECOMMIT_CMD)...${NC}"
+
+  set +e
+  PRECOMMIT_OUTPUT="$(run_precommit 2>&1)"
+  PRECOMMIT_EXIT=$?
+  set -e
+
+  if [ $PRECOMMIT_EXIT -eq 0 ]; then
+    echo -e "${GREEN}✓ All checks passed after auto-staging${NC}"
+    exit 0
+  else
+    echo "$PRECOMMIT_OUTPUT"
+    echo -e "${RED}✗ Pre-commit still failing after auto-staging${NC}"
+    exit 1
+  fi
+fi

--- a/tests/test_git_safe_commit.py
+++ b/tests/test_git_safe_commit.py
@@ -337,7 +337,8 @@ def test_safe_commit_serialization(git_repo: Path):
 
     # At least one should succeed; the other might succeed or fail
     # depending on timing, but neither should produce a corrupted commit
-    assert proc_a.returncode == 0 or proc_b.returncode == 0
+    assert proc_a.returncode == 0, f"Session A failed: {err_a.decode()}"
+    assert proc_b.returncode == 0, f"Session B failed: {err_b.decode()}"
 
     # Verify we have the right number of commits (init + 1 or 2)
     log = subprocess.run(

--- a/tests/test_git_safe_commit.py
+++ b/tests/test_git_safe_commit.py
@@ -1,0 +1,799 @@
+"""Tests for scripts/git/git-safe-commit — flock-based commit serialization."""
+
+import fcntl
+import os
+import subprocess
+import tempfile
+import textwrap
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SAFE_COMMIT = REPO_ROOT / "scripts" / "git" / "git-safe-commit"
+PRE_COMMIT_HOOK = REPO_ROOT / "scripts" / "git" / "pre-commit-auto-stage"
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path) -> Path:
+    """Create a temporary git repo for testing."""
+    subprocess.run(
+        ["git", "init", "-b", "test-branch", str(tmp_path)],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    # Disable global hooks that block commits to master
+    subprocess.run(
+        ["git", "config", "core.hooksPath", "/dev/null"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    # Initial commit so HEAD exists
+    (tmp_path / "README.md").write_text("init")
+    subprocess.run(
+        ["git", "add", "README.md"], cwd=tmp_path, check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "init"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    return tmp_path
+
+
+def test_safe_commit_script_exists():
+    """The safe-commit script exists and is executable."""
+    assert SAFE_COMMIT.exists()
+    assert os.access(SAFE_COMMIT, os.X_OK)
+
+
+def test_safe_commit_basic(git_repo: Path):
+    """Safe commit works for a basic commit with explicit files."""
+    test_file = git_repo / "test.txt"
+    test_file.write_text("hello")
+    subprocess.run(
+        ["git", "add", "test.txt"], cwd=git_repo, check=True, capture_output=True
+    )
+
+    result = subprocess.run(
+        [str(SAFE_COMMIT), "test.txt", "-m", "test: basic commit"],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+
+    # Verify commit was created
+    log = subprocess.run(
+        ["git", "log", "--oneline", "-1"],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+    )
+    assert "test: basic commit" in log.stdout
+
+
+def test_safe_commit_creates_lockfile(git_repo: Path):
+    """Safe commit creates a lockfile in .git/ during execution."""
+    test_file = git_repo / "test.txt"
+    test_file.write_text("hello")
+    subprocess.run(
+        ["git", "add", "test.txt"], cwd=git_repo, check=True, capture_output=True
+    )
+
+    # Run commit
+    subprocess.run(
+        [str(SAFE_COMMIT), "test.txt", "-m", "test: lockfile"],
+        cwd=git_repo,
+        capture_output=True,
+    )
+
+    # The lockfile should exist (created by flock, persists as empty file)
+    lockfile = git_repo / ".git" / "commit.lock"
+    assert lockfile.exists()
+
+
+def test_safe_commit_not_in_git_repo(tmp_path: Path):
+    """Safe commit fails gracefully outside a git repo."""
+    result = subprocess.run(
+        [str(SAFE_COMMIT), "-m", "test"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert (
+        "not in a git repository" in result.stderr
+        or "not a git repository" in result.stderr
+    )
+
+
+def test_safe_commit_passes_all_args(git_repo: Path):
+    """All git commit arguments are passed through correctly."""
+    # Test --allow-empty
+    result = subprocess.run(
+        [str(SAFE_COMMIT), "--allow-empty", "-m", "test: empty commit"],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+
+    log = subprocess.run(
+        ["git", "log", "--oneline", "-1"],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+    )
+    assert "test: empty commit" in log.stdout
+
+
+def test_safe_commit_requires_explicit_paths_or_all_staged(git_repo: Path):
+    """Bare staged commits must use an explicit opt-in in shared repos."""
+    (git_repo / "test.txt").write_text("hello")
+    subprocess.run(
+        ["git", "add", "test.txt"], cwd=git_repo, check=True, capture_output=True
+    )
+
+    result = subprocess.run(
+        [str(SAFE_COMMIT), "-m", "test: implicit all staged blocked"],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "implicit whole-index commit" in result.stderr.lower()
+    assert "--all-staged" in result.stderr
+
+
+def test_safe_commit_allows_explicit_all_staged_opt_in(git_repo: Path):
+    """Intentional whole-index commits require the explicit --all-staged flag."""
+    (git_repo / "test.txt").write_text("hello")
+    subprocess.run(
+        ["git", "add", "test.txt"], cwd=git_repo, check=True, capture_output=True
+    )
+
+    result = subprocess.run(
+        [str(SAFE_COMMIT), "--all-staged", "-m", "test: explicit all staged"],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    log = subprocess.run(
+        ["git", "log", "--oneline", "-1"],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "test: explicit all staged" in log.stdout
+
+
+def test_safe_commit_refuses_dirty_worktree_without_no_verify(git_repo: Path):
+    """Dirty worktrees are blocked before prek can stash unrelated files."""
+    (git_repo / "dirty.txt").write_text("dirty\n")
+    (git_repo / "commit.txt").write_text("commit me\n")
+    subprocess.run(
+        ["git", "add", "commit.txt"], cwd=git_repo, check=True, capture_output=True
+    )
+
+    sha_before = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=git_repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    result = subprocess.run(
+        [str(SAFE_COMMIT), "commit.txt", "-m", "test: dirty worktree blocked"],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "dirty worktree" in result.stderr.lower()
+    assert "--no-verify" in result.stderr
+
+    sha_after = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=git_repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert sha_before == sha_after
+
+
+def test_safe_commit_allows_dirty_worktree_with_no_verify(git_repo: Path):
+    """The explicit --no-verify escape hatch still works after manual checks."""
+    (git_repo / "dirty.txt").write_text("dirty\n")
+    (git_repo / "commit.txt").write_text("commit me\n")
+    subprocess.run(
+        ["git", "add", "commit.txt"], cwd=git_repo, check=True, capture_output=True
+    )
+
+    result = subprocess.run(
+        [
+            str(SAFE_COMMIT),
+            "commit.txt",
+            "--no-verify",
+            "-m",
+            "test: dirty worktree allowed",
+        ],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    log = subprocess.run(
+        ["git", "log", "--oneline", "-1"],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "test: dirty worktree allowed" in log.stdout
+
+
+def test_safe_commit_rechecks_dirty_worktree_after_waiting_for_lock(git_repo: Path):
+    """The dirty-worktree check must happen after lock acquisition, not before."""
+    (git_repo / "commit.txt").write_text("commit me\n")
+    subprocess.run(
+        ["git", "add", "commit.txt"], cwd=git_repo, check=True, capture_output=True
+    )
+
+    sha_before = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=git_repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    # Hold the lock in-process via fcntl.flock so there is no subprocess-startup
+    # race (bash -lc login shells can take >200ms on CI to reach the flock call).
+    lockfile_path = git_repo / ".git" / "commit.lock"
+    lock_fd = open(lockfile_path, "w")
+    fcntl.flock(lock_fd, fcntl.LOCK_EX)
+    try:
+        commit_proc = subprocess.Popen(
+            [str(SAFE_COMMIT), "commit.txt", "-m", "test: recheck after lock"],
+            cwd=git_repo,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        # Give git-safe-commit time to start and block on flock.
+        time.sleep(0.3)
+        (git_repo / "dirty.txt").write_text("dirty\n")
+        # Release the lock so git-safe-commit can proceed and recheck.
+        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+    finally:
+        lock_fd.close()
+
+    stdout, stderr = commit_proc.communicate(timeout=15)
+    assert commit_proc.returncode == 1, stdout + stderr
+    assert "dirty worktree" in stderr.lower()
+
+    sha_after = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=git_repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert sha_before == sha_after
+
+
+def test_safe_commit_serialization(git_repo: Path):
+    """Two concurrent safe-commits don't interfere with each other."""
+    # Create and stage two files
+    (git_repo / "a.txt").write_text("file a")
+    (git_repo / "b.txt").write_text("file b")
+    subprocess.run(
+        ["git", "add", "a.txt", "b.txt"], cwd=git_repo, check=True, capture_output=True
+    )
+
+    # Start both commits concurrently
+    proc_a = subprocess.Popen(
+        [str(SAFE_COMMIT), "a.txt", "-m", "test: commit a"],
+        cwd=git_repo,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    proc_b = subprocess.Popen(
+        [str(SAFE_COMMIT), "b.txt", "-m", "test: commit b"],
+        cwd=git_repo,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    # Both should succeed (one waits for the other)
+    out_a, err_a = proc_a.communicate(timeout=30)
+    out_b, err_b = proc_b.communicate(timeout=30)
+
+    # At least one should succeed; the other might succeed or fail
+    # depending on timing, but neither should produce a corrupted commit
+    assert proc_a.returncode == 0 or proc_b.returncode == 0
+
+    # Verify we have the right number of commits (init + 1 or 2)
+    log = subprocess.run(
+        ["git", "log", "--oneline"],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+    )
+    commits = log.stdout.strip().split("\n")
+    # Should have at least 2 commits (init + at least one successful)
+    assert len(commits) >= 2
+
+
+def test_safe_commit_works_with_serialized_pre_commit_hook(tmp_path: Path):
+    """safe-commit should not deadlock when the hook also uses commit.lock."""
+    subprocess.run(
+        ["git", "init", "-b", "test-branch", str(tmp_path)],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+
+    hooks_dir = tmp_path / ".git" / "hooks"
+    hooks_dir.mkdir(exist_ok=True)
+    subprocess.run(
+        ["git", "config", "core.hooksPath", str(hooks_dir)],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    (hooks_dir / "pre-commit").unlink(missing_ok=True)
+    (hooks_dir / "pre-commit").symlink_to(PRE_COMMIT_HOOK)
+
+    fake_bin = Path(tempfile.mkdtemp(prefix="fake-prek-"))
+    fake_prek = fake_bin / "prek"
+    fake_prek.write_text(
+        textwrap.dedent(
+            """\
+            #!/bin/sh
+            if [ "$1" = "run" ]; then
+                exit 0
+            fi
+            echo "unexpected args: $*" >&2
+            exit 2
+            """
+        )
+    )
+    fake_prek.chmod(0o755)
+
+    (tmp_path / ".pre-commit-config.yaml").write_text("repos: []\n")
+    (tmp_path / "README.md").write_text("init\n")
+    subprocess.run(
+        ["git", "add", "README.md", ".pre-commit-config.yaml"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    init_commit = subprocess.run(
+        [str(SAFE_COMMIT), "README.md", ".pre-commit-config.yaml", "-m", "init"],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    assert init_commit.returncode == 0, init_commit.stderr
+
+    (tmp_path / "test.txt").write_text("hello\n")
+    subprocess.run(
+        ["git", "add", "test.txt"], cwd=tmp_path, check=True, capture_output=True
+    )
+    result = subprocess.run(
+        [str(SAFE_COMMIT), "test.txt", "-m", "test: hook-safe commit"],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_safe_commit_hook_blocks_dirty_worktree_created_after_precheck(tmp_path: Path):
+    """The hook should abort if the worktree gets dirtied after wrapper pre-check."""
+    subprocess.run(
+        ["git", "init", "-b", "test-branch", str(tmp_path)],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "core.hooksPath", "/dev/null"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+
+    (tmp_path / "README.md").write_text("init\n")
+    subprocess.run(
+        ["git", "add", "README.md"], cwd=tmp_path, check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "init"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+
+    hooks_dir = tmp_path / ".git" / "hooks"
+    hooks_dir.mkdir(exist_ok=True)
+    subprocess.run(
+        ["git", "config", "core.hooksPath", str(hooks_dir)],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    pre_commit_hook = hooks_dir / "pre-commit"
+    pre_commit_hook.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/bin/sh
+            printf 'dirty\\n' > dirty.txt
+            exec "{PRE_COMMIT_HOOK}" "$@"
+            """
+        )
+    )
+    pre_commit_hook.chmod(0o755)
+
+    fake_bin = Path(tempfile.mkdtemp(prefix="fake-prek-"))
+    fake_prek = fake_bin / "prek"
+    fake_prek.write_text(
+        textwrap.dedent(
+            """\
+            #!/bin/sh
+            if [ "$1" = "run" ]; then
+                exit 0
+            fi
+            echo "unexpected args: $*" >&2
+            exit 2
+            """
+        )
+    )
+    fake_prek.chmod(0o755)
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+
+    (tmp_path / ".pre-commit-config.yaml").write_text("repos: []\n")
+    subprocess.run(
+        ["git", "add", ".pre-commit-config.yaml"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "commit", "--no-verify", "-m", "add config"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+
+    (tmp_path / "commit.txt").write_text("hello\n")
+    subprocess.run(
+        ["git", "add", "commit.txt"], cwd=tmp_path, check=True, capture_output=True
+    )
+
+    sha_before = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    result = subprocess.run(
+        [str(SAFE_COMMIT), "commit.txt", "-m", "test: hook catches late dirty state"],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "dirty" in result.stderr.lower()
+    assert "issue #642" in result.stderr.lower()
+
+    sha_after = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert sha_before == sha_after
+
+
+def _init_large_repo(tmp_path: Path, file_count: int) -> Path:
+    subprocess.run(
+        ["git", "init", "-b", "test-branch", str(tmp_path)],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "core.hooksPath", "/dev/null"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    files_dir = tmp_path / "files"
+    files_dir.mkdir()
+    for i in range(file_count):
+        (files_dir / f"file_{i:04d}.txt").write_text(f"content {i}\n")
+    subprocess.run(
+        ["git", "add", "files/"], cwd=tmp_path, check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "commit", "-m", f"init: {file_count} files"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    return tmp_path
+
+
+@pytest.fixture
+def large_git_repo(tmp_path: Path) -> Path:
+    """Git repo with 1100 tracked files — triggers #642 pre-check threshold."""
+    return _init_large_repo(tmp_path, 1100)
+
+
+@pytest.fixture
+def huge_git_repo(tmp_path: Path) -> Path:
+    """Git repo with 1300 tracked files — allows deletion of 200 files while
+    keeping TRACKED_COUNT above the pre-check threshold, so Layer 2 fires."""
+    return _init_large_repo(tmp_path, 1300)
+
+
+def test_safe_commit_detects_index_corruption(large_git_repo: Path):
+    """Pre-commit check aborts when index is corrupted (issue #642 Layer 1).
+
+    Simulates the #642 scenario where prek's stash/restore wiped out tracked
+    files from the index. git-safe-commit should detect TRACKED << HEAD and
+    refuse to commit (auto-rebuild + request retry).
+    """
+    # Simulate index corruption: remove all tracked files from the index
+    # except one file that user is trying to commit.
+    subprocess.run(
+        ["git", "rm", "--cached", "-r", "files/"],
+        cwd=large_git_repo,
+        check=True,
+        capture_output=True,
+    )
+    # Stage a single "new" file the user wanted to commit
+    (large_git_repo / "test.txt").write_text("hello\n")
+    subprocess.run(
+        ["git", "add", "test.txt"],
+        cwd=large_git_repo,
+        check=True,
+        capture_output=True,
+    )
+
+    result = subprocess.run(
+        [str(SAFE_COMMIT), "test.txt", "-m", "test: should be blocked"],
+        cwd=large_git_repo,
+        capture_output=True,
+        text=True,
+    )
+
+    # Should abort (exit 1) with corruption warning
+    assert (
+        result.returncode == 1
+    ), f"Expected corruption detection, got:\n{result.stdout}\n{result.stderr}"
+    assert "corruption" in result.stderr.lower()
+    # Index should be auto-rebuilt
+    tracked_after = subprocess.run(
+        ["git", "ls-files"],
+        cwd=large_git_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    tracked_count = len(tracked_after.stdout.strip().splitlines())
+    assert (
+        tracked_count >= 1100
+    ), f"Expected index rebuild to restore ~1100 files, got {tracked_count}"
+
+
+def test_safe_commit_detects_partial_index_corruption_above_old_threshold(
+    huge_git_repo: Path,
+):
+    """Pre-check catches partial index loss even when >1000 files remain tracked.
+
+    This is the blind spot the old TRACKED_COUNT < 1000 heuristic missed:
+    a large repo can lose hundreds of index entries, still track >1000 files,
+    and be catastrophically wrong.
+    """
+    # Remove 200 tracked files from the index, but leave them on disk.
+    # TRACKED_COUNT remains 1100, so the old heuristic would not fire.
+    files_to_drop = [f"files/file_{i:04d}.txt" for i in range(200)]
+    subprocess.run(
+        ["git", "rm", "--cached", *files_to_drop],
+        cwd=huge_git_repo,
+        check=True,
+        capture_output=True,
+    )
+
+    # Stage a legitimate file the user was trying to commit.
+    (huge_git_repo / "test.txt").write_text("hello\n")
+    subprocess.run(
+        ["git", "add", "test.txt"],
+        cwd=huge_git_repo,
+        check=True,
+        capture_output=True,
+    )
+
+    result = subprocess.run(
+        [str(SAFE_COMMIT), "test.txt", "-m", "test: partial corruption blocked"],
+        cwd=huge_git_repo,
+        capture_output=True,
+        text=True,
+    )
+
+    assert (
+        result.returncode == 1
+    ), f"Expected partial corruption detection, got:\n{result.stdout}\n{result.stderr}"
+    assert "corruption" in result.stderr.lower()
+    assert "missing from index but still on disk" in result.stderr
+
+    tracked_after = subprocess.run(
+        ["git", "ls-files"],
+        cwd=huge_git_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    tracked_count = len(tracked_after.stdout.strip().splitlines())
+    assert (
+        tracked_count >= 1300
+    ), f"Expected index rebuild to restore ~1300 files, got {tracked_count}"
+
+
+def test_safe_commit_reverts_catastrophic_deletion(huge_git_repo: Path):
+    """Post-commit check auto-reverts if the commit deleted >100 files (issue #642 Layer 2).
+
+    Uses a 1300-file repo so that deleting 200 leaves TRACKED=1100 (above
+    pre-check threshold) — ensures Layer 1 doesn't fire first and we actually
+    exercise the post-commit safety net.
+    """
+    # Stage deletion of 200 files (exceeds 100-file threshold, TRACKED stays > 1000)
+    for i in range(200):
+        (huge_git_repo / "files" / f"file_{i:04d}.txt").unlink()
+    subprocess.run(
+        ["git", "add", "-A"],
+        cwd=huge_git_repo,
+        check=True,
+        capture_output=True,
+    )
+
+    sha_before = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=huge_git_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+    result = subprocess.run(
+        [str(SAFE_COMMIT), "--all-staged", "-m", "test: mass deletion"],
+        cwd=huge_git_repo,
+        capture_output=True,
+        text=True,
+    )
+
+    # Should exit non-zero after auto-revert
+    assert (
+        result.returncode != 0
+    ), f"Expected auto-revert, got:\n{result.stdout}\n{result.stderr}"
+    assert (
+        "CATASTROPHIC" in result.stdout or "reverted" in result.stdout.lower()
+    ), f"Expected post-commit revert message, got stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+
+    # HEAD should be unchanged (soft revert)
+    sha_after = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=huge_git_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert (
+        sha_before == sha_after
+    ), f"Expected HEAD unchanged after revert, was {sha_before[:8]}, now {sha_after[:8]}"
+
+    # Changes should remain staged (soft reset)
+    staged = subprocess.run(
+        ["git", "diff", "--cached", "--name-only"],
+        cwd=huge_git_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    staged_count = len(staged.stdout.strip().splitlines())
+    assert (
+        staged_count >= 200
+    ), f"Expected ~200 staged deletions after soft reset, got {staged_count}"
+
+
+def test_safe_commit_allows_normal_small_repo_commit(git_repo: Path):
+    """Safeguards do not trigger on small repos (HEAD_COUNT < 1000 threshold)."""
+    # git_repo has only 1 file (README.md); TRACKED=1, HEAD=1 — below threshold
+    (git_repo / "test.txt").write_text("hello")
+    subprocess.run(
+        ["git", "add", "test.txt"], cwd=git_repo, check=True, capture_output=True
+    )
+
+    result = subprocess.run(
+        [str(SAFE_COMMIT), "test.txt", "-m", "test: small repo commit"],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

Upstreams two git scripts from [ErikBjare/bob](https://github.com/ErikBjare/bob) so all agents can use them. Requested in ErikBjare/bob#646.

- **`scripts/git/git-safe-commit`**: flock-based commit serialization for shared repos where multiple agent sessions commit concurrently. Prevents staging races, index corruption, and catastrophic deletion commits.
- **`scripts/git/pre-commit-auto-stage`**: pre-commit hook that auto-stages files modified by formatters and serializes concurrent hook runs via the same lock.

### git-safe-commit features

- Serializes commits via `.git/commit.lock` so `prek`'s stash/restore is atomic from other sessions' perspective
- Refuses implicit whole-index commits — requires explicit file paths or `--all-staged` opt-in
- Detects git index corruption before committing (Layer 1: pre-check, auto-rebuild)
- Refuses to commit in dirty worktrees when pre-commit hooks would run (prevents stash/restore corruption)
- Auto-reverts catastrophic deletion commits post-commit (Layer 2: >100 files deleted)

### Usage

```bash
# Explicit file paths (recommended)
git-safe-commit file1.py file2.py -m "feat: description"

# Intentional whole-index commit
git-safe-commit --all-staged -m "chore: commit full staged set"

# Dirty worktree escape hatch (after manual verification)
git-safe-commit file.py --no-verify -m "fix: description"
```

### Installation (pre-commit hook)

```bash
ln -sf $(pwd)/scripts/git/pre-commit-auto-stage .git/hooks/pre-commit
```

## Test plan

- [x] 17 tests covering all features pass in gptme-contrib (`uv run --active pytest tests/test_git_safe_commit.py -v`)
- [x] Tests also pass in the source repo (ErikBjare/bob) where the script was developed
- [x] Pre-commit hooks (prek) pass on commit