### PR TITLE
fix(gptme-sessions): preserve zero-token session counts

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -233,7 +233,7 @@ def post_session(
             signals = result
             grade = result.get("grade")
             traj_productive = result.get("productive")
-            usage = result.get("usage") or {}
+            usage = result.get("usage")
             if usage:
                 _in = usage.get("input_tokens")
                 _out = usage.get("output_tokens")
@@ -243,9 +243,10 @@ def post_session(
                 output_tokens = int(_out) if _out is not None else None
                 cache_creation_tokens = int(_cc) if _cc is not None else None
                 cache_read_tokens = int(_cr) if _cr is not None else None
-            total = usage.get("total_tokens", 0)
-            if total:
-                token_count = int(total)
+            if isinstance(usage, dict) and "total_tokens" in usage:
+                total = usage.get("total_tokens")
+                if total is not None:
+                    token_count = int(total)
         except Exception as e:
             # Signal extraction is non-fatal; proceed without signals
             logger.warning("Signal extraction from %s failed: %s", trajectory_path, e)

--- a/packages/gptme-sessions/tests/test_post_session.py
+++ b/packages/gptme-sessions/tests/test_post_session.py
@@ -288,3 +288,39 @@ def test_post_session_partial_usage_fields_stored_as_none(tmp_path: Path):
     assert records[0].output_tokens is None
     assert records[0].cache_creation_tokens is None
     assert records[0].cache_read_tokens is None
+
+
+def test_post_session_preserves_zero_token_usage(tmp_path: Path):
+    """Zero-token trajectories are stored as token_count=0, not dropped as missing."""
+    store = SessionStore(sessions_dir=tmp_path)
+    fake_traj = tmp_path / "trajectory.jsonl"
+    fake_traj.write_text("")
+
+    fake_signals = {
+        "session_duration_s": 60,
+        "productive": False,
+        "deliverables": [],
+        "usage": {
+            "model": "claude-sonnet-4-6",
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_creation_tokens": 0,
+            "cache_read_tokens": 0,
+            "total_tokens": 0,
+        },
+    }
+    with patch.object(_post_session_mod, "extract_from_path", return_value=fake_signals):
+        result = post_session(
+            store=store,
+            harness="claude-code",
+            model="sonnet",
+            duration_seconds=0,
+            trajectory_path=fake_traj,
+            exit_code=1,
+        )
+
+    assert result.token_count == 0
+    assert result.record.token_count == 0
+
+    records = store.load_all()
+    assert records[0].token_count == 0


### PR DESCRIPTION
## Summary
- keep `token_count=0` when trajectory usage exists but totals are zero
- add a regression test for zero-token failed sessions

## Why
Bob's operator gate needs a durable way to distinguish upstream/API outage failures from normal failed services. Dropping zero-token usage as `None` erased that signal.