### PR TITLE
fix(twitter): prefer context-specific OpenRouter keys

### DIFF
--- a/scripts/twitter/llm.py
+++ b/scripts/twitter/llm.py
@@ -451,6 +451,19 @@ def parse_llm_response(content: str, response_type: Type[T], task: TaskType) -> 
         return response_type.default()
 
 
+def _resolve_openrouter_api_key() -> str:
+    """Prefer Twitter/social-specific OpenRouter keys over the shared default."""
+    for env_var in (
+        "OPENROUTER_API_KEY_TWITTER",
+        "OPENROUTER_API_KEY_SOCIAL",
+        "OPENROUTER_API_KEY",
+    ):
+        value = os.environ.get(env_var, "")
+        if value:
+            return value
+    return ""
+
+
 def _reply_with_max_tokens(messages: list[Message], model_name: str) -> Message:
     """Call LLM with explicit max_tokens to control OpenRouter budget reservation.
 
@@ -466,7 +479,7 @@ def _reply_with_max_tokens(messages: list[Message], model_name: str) -> Message:
     """
     import openai
 
-    api_key = os.environ.get("OPENROUTER_API_KEY", "")
+    api_key = _resolve_openrouter_api_key()
     if not api_key:
         # Not using OpenRouter — fall back to gptme's reply (no budget issue)
         return reply(messages, model_name, stream=False)

--- a/tests/test_twitter_eval_prompt.py
+++ b/tests/test_twitter_eval_prompt.py
@@ -188,6 +188,28 @@ def test_unset_handle_raises_value_error(
         llm_module.create_tweet_eval_prompt(tweet, eval_config)
 
 
+def test_openrouter_key_resolution_prefers_twitter_specific_key(
+    llm_module: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", "shared-key")
+    monkeypatch.setenv("OPENROUTER_API_KEY_SOCIAL", "social-key")
+    monkeypatch.setenv("OPENROUTER_API_KEY_TWITTER", "twitter-key")
+
+    assert llm_module._resolve_openrouter_api_key() == "twitter-key"
+
+
+def test_openrouter_key_resolution_falls_back_to_social_key(
+    llm_module: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY_TWITTER", raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY_SOCIAL", "social-key")
+
+    assert llm_module._resolve_openrouter_api_key() == "social-key"
+
+
 def test_our_handle_in_thread_context_triggers_identity_note(
     llm_module: types.ModuleType,
     eval_config: dict[str, Any],


### PR DESCRIPTION
## Summary

- Twitter LLM path now resolves the API key via `OPENROUTER_API_KEY_TWITTER` → `OPENROUTER_API_KEY_SOCIAL` → `OPENROUTER_API_KEY` (shared fallback)
- Delegates to the existing `openrouter_keys.py` helper in ErikBjare/bob
- Adds test coverage for the key-resolution path

## Motivation

Part of ErikBjare/bob#650 (separate OpenRouter keys per context for better budget control). The twitter context is now split-capable — add `OPENROUTER_API_KEY_TWITTER` or `OPENROUTER_API_KEY_SOCIAL` to `~/.config/gptme/config.local.toml` to enforce a separate daily limit; omit the key to keep existing shared-key behaviour unchanged.

## Test plan
- [ ] `uv run pytest tests/test_twitter_eval_prompt.py -q` passes