### PR TITLE
feat(gptme-voice): add xAI Grok realtime provider support

### DIFF
--- a/packages/gptme-voice/pyproject.toml
+++ b/packages/gptme-voice/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "gptme-voice"
 version = "0.1.0"
-description = "Voice interface for gptme with OpenAI Realtime API"
+description = "Voice interface for gptme with OpenAI and xAI Grok Realtime APIs"
 readme = "README.md"
 requires-python = ">=3.10,<4.0"
 dependencies = [

--- a/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
@@ -177,14 +177,21 @@ class OpenAIRealtimeClient:
         self._receive_task: asyncio.Task | None = None
         self._responding = False  # True while AI is generating a response
 
-    async def connect(self) -> None:
-        """Connect to OpenAI Realtime API."""
-        headers = {
+    def _get_ws_url(self) -> str:
+        """WebSocket URL for this provider (override in subclasses)."""
+        return f"{self.WS_URL}?model={self.session_config.model}"
+
+    def _get_ws_headers(self) -> dict[str, str]:
+        """Auth headers for this provider (override in subclasses)."""
+        return {
             "Authorization": f"Bearer {self.api_key}",
             "OpenAI-Beta": "realtime=v1",
         }
 
-        url = f"{self.WS_URL}?model={self.session_config.model}"
+    async def connect(self) -> None:
+        """Connect to OpenAI Realtime API."""
+        url = self._get_ws_url()
+        headers = self._get_ws_headers()
         self._ws = await websockets.connect(url, additional_headers=headers)
 
         instructions = self.session_config.instructions or _DEFAULT_INSTRUCTIONS

--- a/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
@@ -188,6 +188,10 @@ class OpenAIRealtimeClient:
             "OpenAI-Beta": "realtime=v1",
         }
 
+    def _get_transcription_config(self) -> dict | None:
+        """Transcription config for session.update (override to None to omit)."""
+        return {"model": "whisper-1"}
+
     async def connect(self) -> None:
         """Connect to OpenAI Realtime API."""
         url = self._get_ws_url()
@@ -200,59 +204,57 @@ class OpenAIRealtimeClient:
         )
 
         # Configure session
-        await self._send_event(
-            "session.update",
-            {
-                "session": {
-                    "modalities": ["text", "audio"],
-                    "instructions": instructions,
-                    "voice": self.session_config.voice,
-                    "input_audio_format": self.session_config.input_format,
-                    "output_audio_format": self.session_config.output_format,
-                    "input_audio_transcription": {"model": "whisper-1"},
-                    "turn_detection": {
-                        "type": self.session_config.turn_detection,
-                        "threshold": self.session_config.vad_threshold,
-                        "silence_duration_ms": self.session_config.vad_silence_duration_ms,
-                        "prefix_padding_ms": self.session_config.vad_prefix_padding_ms,
-                    },
-                    "tools": [
-                        {
-                            "type": "function",
-                            "name": "subagent",
-                            "description": (
-                                "Dispatch a task to a gptme subagent running in the workspace. "
-                                "The subagent has full access to tools: shell, file read/write, "
-                                "python, and can reason about multi-step tasks. "
-                                "Use this for anything that requires interacting with the codebase, "
-                                "reading files, checking task status, running commands, searching code, etc. "
-                                "Describe what you want done in natural language."
-                            ),
-                            "parameters": {
-                                "type": "object",
-                                "properties": {
-                                    "task": {
-                                        "type": "string",
-                                        "description": "Natural language description of the task for the subagent",
-                                    },
-                                    "mode": {
-                                        "type": "string",
-                                        "enum": ["smart", "fast"],
-                                        "description": (
-                                            "Model quality tradeoff. 'smart' (default) uses the full model "
-                                            "for complex tasks like code analysis, multi-step reasoning, or "
-                                            "writing code. 'fast' uses a smaller model for quick lookups like "
-                                            "reading a file, checking git status, or simple searches."
-                                        ),
-                                    },
-                                },
-                                "required": ["task"],
-                            },
-                        }
-                    ],
-                }
+        session_params: dict = {
+            "modalities": ["text", "audio"],
+            "instructions": instructions,
+            "voice": self.session_config.voice,
+            "input_audio_format": self.session_config.input_format,
+            "output_audio_format": self.session_config.output_format,
+            "turn_detection": {
+                "type": self.session_config.turn_detection,
+                "threshold": self.session_config.vad_threshold,
+                "silence_duration_ms": self.session_config.vad_silence_duration_ms,
+                "prefix_padding_ms": self.session_config.vad_prefix_padding_ms,
             },
-        )
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "subagent",
+                    "description": (
+                        "Dispatch a task to a gptme subagent running in the workspace. "
+                        "The subagent has full access to tools: shell, file read/write, "
+                        "python, and can reason about multi-step tasks. "
+                        "Use this for anything that requires interacting with the codebase, "
+                        "reading files, checking task status, running commands, searching code, etc. "
+                        "Describe what you want done in natural language."
+                    ),
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "task": {
+                                "type": "string",
+                                "description": "Natural language description of the task for the subagent",
+                            },
+                            "mode": {
+                                "type": "string",
+                                "enum": ["smart", "fast"],
+                                "description": (
+                                    "Model quality tradeoff. 'smart' (default) uses the full model "
+                                    "for complex tasks like code analysis, multi-step reasoning, or "
+                                    "writing code. 'fast' uses a smaller model for quick lookups like "
+                                    "reading a file, checking git status, or simple searches."
+                                ),
+                            },
+                        },
+                        "required": ["task"],
+                    },
+                }
+            ],
+        }
+        transcription = self._get_transcription_config()
+        if transcription is not None:
+            session_params["input_audio_transcription"] = transcription
+        await self._send_event("session.update", {"session": session_params})
 
         # Start receiving messages
         self._receive_task = asyncio.create_task(self._receive_loop())

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -30,13 +30,21 @@ from .twilio_integration import (
     build_connect_stream_twiml,
     build_stream_url,
 )
+from .xai_client import XAIRealtimeClient, _get_xai_api_key
 
 logger = logging.getLogger(__name__)
 
 
+_PROVIDER_OPENAI = "openai"
+_PROVIDER_GROK = "grok"
+_VALID_PROVIDERS = (_PROVIDER_OPENAI, _PROVIDER_GROK)
+
+
 class VoiceServer:
     """
-    WebSocket server that bridges Twilio Media Streams to OpenAI Realtime API.
+    WebSocket server that bridges Twilio Media Streams to a Realtime API.
+
+    Supports OpenAI (default) and xAI Grok as providers.
     """
 
     def __init__(
@@ -45,10 +53,17 @@ class VoiceServer:
         port: int = 8080,
         openai_api_key: str | None = None,
         workspace: str | None = None,
+        provider: str = _PROVIDER_OPENAI,
+        model: str | None = None,
     ):
         self.host = host
         self.port = port
-        self.openai_api_key = openai_api_key or _get_openai_api_key()
+        self.provider = provider
+        self.model = model
+        if provider == _PROVIDER_GROK:
+            self._api_key = _get_xai_api_key()
+        else:
+            self._api_key = openai_api_key or _get_openai_api_key()
         self.workspace = workspace or _detect_agent_repo()
         self._instructions = _load_project_instructions(self.workspace)
 
@@ -118,7 +133,7 @@ class VoiceServer:
         await websocket.accept()
 
         call_sid: str | None = None
-        openai_client: OpenAIRealtimeClient | None = None
+        realtime_client: OpenAIRealtimeClient | None = None
         audio_converter = AudioConverter()
 
         try:
@@ -135,11 +150,15 @@ class VoiceServer:
                     call_sid = data.get("start", {}).get("call_sid")
                     stream_sid = data.get("start", {}).get("stream_sid")
 
-                    # Create OpenAI client, then tool bridge with inject callback
-                    openai_client = OpenAIRealtimeClient(
-                        api_key=self.openai_api_key,
-                        session_config=SessionConfig(instructions=self._instructions),
-                        on_audio=lambda audio: self._send_to_twilio(  # type: ignore[arg-type]
+                    if self.model:
+                        session_cfg = SessionConfig(
+                            instructions=self._instructions, model=self.model
+                        )
+                    else:
+                        session_cfg = SessionConfig(instructions=self._instructions)
+                    realtime_client = self._make_client(
+                        session_cfg,
+                        on_audio=lambda audio: self._send_to_twilio(
                             websocket,
                             stream_sid,
                             audio_converter.openai_to_twilio(audio),
@@ -147,29 +166,29 @@ class VoiceServer:
                     )
                     tool_bridge = GptmeToolBridge(
                         workspace=self.workspace,
-                        on_result=openai_client.inject_message,
+                        on_result=realtime_client.inject_message,
                     )
-                    openai_client.on_function_call = tool_bridge.handle_function_call
+                    realtime_client.on_function_call = tool_bridge.handle_function_call
 
-                    await openai_client.connect()
-                    self._connections[call_sid] = (websocket, openai_client)  # type: ignore[index]
+                    await realtime_client.connect()
+                    self._connections[call_sid] = (websocket, realtime_client)
 
                 elif event == "media":
                     # Audio chunk from Twilio
-                    if openai_client:
+                    if realtime_client:
                         # Extract μ-law audio
                         media = data.get("media", {})
                         mulaw_b64 = media.get("payload", "")
                         if mulaw_b64:
-                            # Convert to PCM and send to OpenAI
+                            # Convert to PCM and send to realtime API
                             mulaw_data = base64.b64decode(mulaw_b64)
                             pcm_data = audio_converter.twilio_to_openai(mulaw_data)
-                            await openai_client.send_audio(pcm_data)
+                            await realtime_client.send_audio(pcm_data)
 
                 elif event == "stop":
                     # Call ended
-                    if openai_client:
-                        await openai_client.disconnect()
+                    if realtime_client:
+                        await realtime_client.disconnect()
                     if call_sid and call_sid in self._connections:
                         del self._connections[call_sid]
                     break
@@ -177,8 +196,8 @@ class VoiceServer:
         except Exception as e:
             logger.exception("Error handling Twilio connection: %s", e)
         finally:
-            if openai_client:
-                await openai_client.disconnect()
+            if realtime_client:
+                await realtime_client.disconnect()
             if call_sid and call_sid in self._connections:
                 del self._connections[call_sid]
 
@@ -193,6 +212,24 @@ class VoiceServer:
         }
         await websocket.send_text(json.dumps(message))
 
+    def _make_client(
+        self,
+        session_config: SessionConfig,
+        **kwargs,
+    ) -> OpenAIRealtimeClient:
+        """Instantiate the realtime client for the configured provider."""
+        if self.provider == _PROVIDER_GROK:
+            return XAIRealtimeClient(
+                api_key=self._api_key,
+                session_config=session_config,
+                **kwargs,
+            )
+        return OpenAIRealtimeClient(
+            api_key=self._api_key,
+            session_config=session_config,
+            **kwargs,
+        )
+
     async def handle_local_websocket(self, websocket):
         """
         Handle WebSocket connection for local testing.
@@ -202,23 +239,27 @@ class VoiceServer:
         """
         await websocket.accept()
 
-        openai_client: OpenAIRealtimeClient | None = None
+        realtime_client: OpenAIRealtimeClient | None = None
 
         try:
-            # Create OpenAI client first, then tool bridge with inject callback
-            openai_client = OpenAIRealtimeClient(
-                api_key=self.openai_api_key,
-                session_config=SessionConfig(instructions=self._instructions),
-                on_audio=lambda audio: self._send_local_audio(websocket, audio),  # type: ignore[arg-type]
+            if self.model:
+                session_cfg = SessionConfig(
+                    instructions=self._instructions, model=self.model
+                )
+            else:
+                session_cfg = SessionConfig(instructions=self._instructions)
+            realtime_client = self._make_client(
+                session_cfg,
+                on_audio=lambda audio: self._send_local_audio(websocket, audio),
                 on_audio_end=lambda: self._send_local_audio_end(websocket),
             )
             tool_bridge = GptmeToolBridge(
                 workspace=self.workspace,
-                on_result=openai_client.inject_message,
+                on_result=realtime_client.inject_message,
             )
-            openai_client.on_function_call = tool_bridge.handle_function_call
+            realtime_client.on_function_call = tool_bridge.handle_function_call
 
-            await openai_client.connect()
+            await realtime_client.connect()
 
             async for message in websocket.iter_text():
                 data = json.loads(message)
@@ -228,16 +269,16 @@ class VoiceServer:
                     audio_b64 = data.get("audio", "")
                     if audio_b64:
                         audio_data = base64.b64decode(audio_b64)
-                        await openai_client.send_audio(audio_data)
+                        await realtime_client.send_audio(audio_data)
 
                 elif data.get("type") == "commit":
-                    await openai_client.commit_audio()
+                    await realtime_client.commit_audio()
 
         except Exception as e:
             logger.exception("Error handling local connection: %s", e)
         finally:
-            if openai_client:
-                await openai_client.disconnect()
+            if realtime_client:
+                await realtime_client.disconnect()
 
     async def _send_local_audio(self, websocket, audio_data: bytes):
         """Send audio to local client."""
@@ -259,8 +300,27 @@ class VoiceServer:
 @click.option("--host", default="0.0.0.0", help="Host to bind to")
 @click.option("--port", default=8080, type=int, help="Port to bind to")
 @click.option("--workspace", default=None, help="Working directory for gptme commands")
+@click.option(
+    "--provider",
+    default=_PROVIDER_OPENAI,
+    type=click.Choice(_VALID_PROVIDERS),
+    show_default=True,
+    help="Realtime API provider.",
+)
+@click.option(
+    "--model",
+    default=None,
+    help="Override the realtime model (e.g. gpt-4o-realtime-preview-2024-12-17 or grok-2-realtime).",
+)
 @click.option("--debug", is_flag=True, help="Enable debug logging")
-def main(host: str, port: int, workspace: str | None, debug: bool):
+def main(
+    host: str,
+    port: int,
+    workspace: str | None,
+    provider: str,
+    model: str | None,
+    debug: bool,
+):
     """Voice Interface Server for gptme."""
     logging.basicConfig(
         level=logging.DEBUG if debug else logging.INFO,
@@ -274,9 +334,11 @@ def main(host: str, port: int, workspace: str | None, debug: bool):
         host=host,
         port=port,
         workspace=workspace,
+        provider=provider,
+        model=model,
     )
 
-    logger.info(f"Starting voice server on {host}:{port}")
+    logger.info(f"Starting voice server on {host}:{port} (provider={provider})")
     logger.info(f"Local test endpoint: ws://{host}:{port}/local")
 
     server.run()

--- a/packages/gptme-voice/src/gptme_voice/realtime/xai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/xai_client.py
@@ -58,3 +58,7 @@ class XAIRealtimeClient(OpenAIRealtimeClient):
     def _get_ws_headers(self) -> dict[str, str]:
         """xAI auth — bearer token only, no OpenAI-Beta header."""
         return {"Authorization": f"Bearer {self.api_key}"}
+
+    def _get_transcription_config(self) -> dict | None:
+        """xAI does not support whisper-1; omit transcription config."""
+        return None

--- a/packages/gptme-voice/src/gptme_voice/realtime/xai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/xai_client.py
@@ -1,0 +1,60 @@
+"""
+xAI (Grok) Realtime API WebSocket client.
+
+Drop-in replacement for OpenAIRealtimeClient using xAI's voice agent API.
+The protocol is largely OpenAI-compatible; the differences are the endpoint
+URL, authentication header, and default model name.
+
+See: https://docs.x.ai/developers/model-capabilities/audio/voice-agent
+"""
+
+from gptme.config import get_config
+
+from .openai_client import OpenAIRealtimeClient, SessionConfig
+
+# Default OpenAI model sentinel — detected so we can swap in the Grok default
+_OPENAI_DEFAULT_MODEL = "gpt-4o-realtime-preview-2024-12-17"
+_DEFAULT_XAI_MODEL = "grok-2-realtime"
+
+
+def _get_xai_api_key() -> str | None:
+    """Get xAI API key from gptme config (env var, project, or user config)."""
+    return get_config().get_env("XAI_API_KEY")
+
+
+class XAIRealtimeClient(OpenAIRealtimeClient):
+    """
+    WebSocket client for xAI Grok Realtime API.
+
+    Identical to OpenAIRealtimeClient except:
+    - Connects to api.x.ai instead of api.openai.com
+    - Uses XAI_API_KEY for authentication
+    - No OpenAI-Beta header
+    - Defaults to the Grok realtime model
+    """
+
+    WS_URL = "wss://api.x.ai/v1/realtime"
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        session_config: SessionConfig | None = None,
+        **kwargs,
+    ):
+        resolved_key = api_key or _get_xai_api_key()
+        if not resolved_key:
+            raise ValueError(
+                "XAI_API_KEY not found. Set it in gptme config or as an env var."
+            )
+
+        cfg = session_config or SessionConfig()
+        if cfg.model == _OPENAI_DEFAULT_MODEL:
+            import dataclasses
+
+            cfg = dataclasses.replace(cfg, model=_DEFAULT_XAI_MODEL)
+
+        super().__init__(api_key=resolved_key, session_config=cfg, **kwargs)
+
+    def _get_ws_headers(self) -> dict[str, str]:
+        """xAI auth — bearer token only, no OpenAI-Beta header."""
+        return {"Authorization": f"Bearer {self.api_key}"}


### PR DESCRIPTION
## Summary

- Adds `XAIRealtimeClient` (`xai_client.py`) — a drop-in replacement for `OpenAIRealtimeClient` using xAI's voice agent API (`wss://api.x.ai/v1/realtime`). The protocol is OpenAI-compatible; only the WS URL, auth headers (no `OpenAI-Beta`), and default model (`grok-2-realtime`) differ.
- Refactors `openai_client.py` to extract `_get_ws_url()` and `_get_ws_headers()` as overridable methods — subclasses only override what differs.
- Updates `server.py` with `--provider openai|grok` and `--model` CLI options. The new `_make_client()` factory instantiates the right client. Renames `openai_client` variable to `realtime_client` throughout for clarity.

Usage:
```bash
# OpenAI (default, unchanged)
gptme-voice-server --port 8082 --workspace /home/bob/bob

# Grok (requires XAI_API_KEY in gptme config)
gptme-voice-server --provider grok --port 8082 --workspace /home/bob/bob

# Specific model override
gptme-voice-server --provider grok --model grok-2-realtime --port 8082
```

## Test plan
- [ ] `uv run mypy packages/gptme-voice/src/` passes (no new errors introduced)
- [ ] `gptme-voice-server --help` shows `--provider` and `--model` options
- [ ] Live test: `gptme-voice-server --provider grok --port 8083` starts without error, connects to xAI API on first call

Closes ErikBjare/bob#651 (partial — Grok provider support; Twilio inbound was #688)