### PR TITLE
fix(gptme-voice): drop ?model= from xAI WebSocket URL

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/xai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/xai_client.py
@@ -55,6 +55,10 @@ class XAIRealtimeClient(OpenAIRealtimeClient):
 
         super().__init__(api_key=resolved_key, session_config=cfg, **kwargs)
 
+    def _get_ws_url(self) -> str:
+        """xAI uses the base URL only — no ?model= parameter."""
+        return self.WS_URL
+
     def _get_ws_headers(self) -> dict[str, str]:
         """xAI auth — bearer token only, no OpenAI-Beta header."""
         return {"Authorization": f"Bearer {self.api_key}"}


### PR DESCRIPTION
## Summary

- Overrides `_get_ws_url()` in `XAIRealtimeClient` to return `self.WS_URL` directly, without appending `?model=<name>`

## Why

The xAI Voice Agent API docs show the connection URL as `wss://api.x.ai/v1/realtime` with no `?model=` parameter. OpenAI requires `?model=` in the URL for routing, but xAI does not — model is either implicit (single realtime endpoint) or handled differently.

The inherited `OpenAIRealtimeClient._get_ws_url()` was appending `?model=grok-2-realtime`, which likely caused a failed WebSocket handshake against the xAI endpoint. This manifested as Twilio error 31951 ("Stream - Protocol - Invalid message") — the WebSocket connection to `/twilio` closed unexpectedly when the xAI connect failed, which Twilio reports as a protocol violation.

## Test plan
- `gptme-voice-server --provider grok` starts and connects to `wss://api.x.ai/v1/realtime` (no `?model=` in URL)
- Inbound call via Twilio routes audio to Grok and gets a voice response back

Fixes: ErikBjare/bob#651