### PR TITLE
fix(gptme-voice): use Twilio streamSid field names

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -40,6 +40,11 @@ _PROVIDER_GROK = "grok"
 _VALID_PROVIDERS = (_PROVIDER_OPENAI, _PROVIDER_GROK)
 
 
+def _get_twilio_field(payload: dict, camel_name: str, snake_name: str) -> str | None:
+    """Read Twilio fields, preferring the documented camelCase form."""
+    return payload.get(camel_name) or payload.get(snake_name)
+
+
 class VoiceServer:
     """
     WebSocket server that bridges Twilio Media Streams to a Realtime API.
@@ -147,8 +152,14 @@ class VoiceServer:
 
                 elif event == "start":
                     # Call started
-                    call_sid = data.get("start", {}).get("call_sid")
-                    stream_sid = data.get("start", {}).get("stream_sid")
+                    start = data.get("start", {})
+                    stream_sid = _get_twilio_field(start, "streamSid", "stream_sid")
+                    call_sid = _get_twilio_field(start, "callSid", "call_sid")
+                    if not stream_sid:
+                        logger.warning("Twilio start event missing streamSid: %s", data)
+                        continue
+                    if not call_sid:
+                        call_sid = stream_sid
 
                     if self.model:
                         session_cfg = SessionConfig(
@@ -207,7 +218,7 @@ class VoiceServer:
         audio_b64 = base64.b64encode(audio_data).decode("utf-8")
         message = {
             "event": "media",
-            "stream_sid": stream_sid,
+            "streamSid": stream_sid,
             "media": {"payload": audio_b64},
         }
         await websocket.send_text(json.dumps(message))

--- a/packages/gptme-voice/src/gptme_voice/realtime/xai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/xai_client.py
@@ -3,18 +3,19 @@ xAI (Grok) Realtime API WebSocket client.
 
 Drop-in replacement for OpenAIRealtimeClient using xAI's voice agent API.
 The protocol is largely OpenAI-compatible; the differences are the endpoint
-URL, authentication header, and default model name.
+URL, authentication header, and xAI-specific defaults.
 
 See: https://docs.x.ai/developers/model-capabilities/audio/voice-agent
 """
+
+import dataclasses
 
 from gptme.config import get_config
 
 from .openai_client import OpenAIRealtimeClient, SessionConfig
 
-# Default OpenAI model sentinel — detected so we can swap in the Grok default
-_OPENAI_DEFAULT_MODEL = "gpt-4o-realtime-preview-2024-12-17"
-_DEFAULT_XAI_MODEL = "grok-2-realtime"
+_OPENAI_DEFAULT_VOICE = "echo"
+_DEFAULT_XAI_VOICE = "eve"
 
 
 def _get_xai_api_key() -> str | None:
@@ -30,7 +31,7 @@ class XAIRealtimeClient(OpenAIRealtimeClient):
     - Connects to api.x.ai instead of api.openai.com
     - Uses XAI_API_KEY for authentication
     - No OpenAI-Beta header
-    - Defaults to the Grok realtime model
+    - Defaults to an xAI-supported voice
     """
 
     WS_URL = "wss://api.x.ai/v1/realtime"
@@ -48,10 +49,8 @@ class XAIRealtimeClient(OpenAIRealtimeClient):
             )
 
         cfg = session_config or SessionConfig()
-        if cfg.model == _OPENAI_DEFAULT_MODEL:
-            import dataclasses
-
-            cfg = dataclasses.replace(cfg, model=_DEFAULT_XAI_MODEL)
+        if cfg.voice == _OPENAI_DEFAULT_VOICE:
+            cfg = dataclasses.replace(cfg, voice=_DEFAULT_XAI_VOICE)
 
         super().__init__(api_key=resolved_key, session_config=cfg, **kwargs)
 

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -1,0 +1,40 @@
+import asyncio
+import base64
+import json
+
+from gptme_voice.realtime.server import VoiceServer, _get_twilio_field
+
+
+class _DummyWebSocket:
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    async def send_text(self, message: str) -> None:
+        self.messages.append(message)
+
+
+def test_get_twilio_field_prefers_camel_case() -> None:
+    payload = {"streamSid": "MZ123", "stream_sid": "legacy"}
+
+    assert _get_twilio_field(payload, "streamSid", "stream_sid") == "MZ123"
+
+
+def test_get_twilio_field_falls_back_to_snake_case() -> None:
+    payload = {"stream_sid": "legacy"}
+
+    assert _get_twilio_field(payload, "streamSid", "stream_sid") == "legacy"
+
+
+def test_send_to_twilio_uses_stream_sid_field_name() -> None:
+    server = VoiceServer()
+    websocket = _DummyWebSocket()
+
+    asyncio.run(server._send_to_twilio(websocket, "MZ123", b"\x00\x01"))
+
+    assert len(websocket.messages) == 1
+    message = json.loads(websocket.messages[0])
+    assert message == {
+        "event": "media",
+        "streamSid": "MZ123",
+        "media": {"payload": base64.b64encode(b"\x00\x01").decode("utf-8")},
+    }

--- a/packages/gptme-voice/tests/test_xai_client.py
+++ b/packages/gptme-voice/tests/test_xai_client.py
@@ -1,0 +1,9 @@
+from gptme_voice.realtime.openai_client import SessionConfig
+from gptme_voice.realtime.xai_client import XAIRealtimeClient
+
+
+def test_xai_client_uses_xai_defaults() -> None:
+    client = XAIRealtimeClient(api_key="test-key", session_config=SessionConfig())
+
+    assert client.session_config.voice == "eve"
+    assert client._get_ws_url() == "wss://api.x.ai/v1/realtime"


### PR DESCRIPTION
## Summary
- read and send Twilio Media Streams IDs using the documented `streamSid`/`callSid` casing
- keep a snake_case fallback for tolerance when parsing start events
- default the xAI adapter to an xAI-supported voice and cover both fixes with tests

## Verification
- `uv run pytest /home/bob/bob/gptme-contrib/packages/gptme-voice/tests -q`
- direct xAI realtime sanity check at 2026-04-19 22:15 UTC returned transcript: `Hello, how are you?`

Refs: ErikBjare/bob#651