### PR TITLE
fix(gptme-voice): remove stale Grok model guidance

### DIFF
--- a/packages/gptme-voice/README.md
+++ b/packages/gptme-voice/README.md
@@ -1,6 +1,6 @@
 # gptme-voice
 
-Voice interface for gptme agents using OpenAI Realtime API.
+Voice interface for gptme agents using OpenAI or xAI Grok Realtime APIs.
 
 ## Features
 
@@ -30,6 +30,9 @@ poetry install -E local
 ```bash
 # Auto-detects agent repo and loads personality
 gptme-voice-server
+
+# Use xAI Grok
+gptme-voice-server --provider grok
 
 # With debug logging
 gptme-voice-server --debug
@@ -81,14 +84,21 @@ gptme-voice-call +46701234567
 
 Use `--dry-run` to print the generated TwiML without dialing.
 
-### API key
+### API keys
 
-The OpenAI API key is loaded from gptme config (`~/.config/gptme/config.toml` or `config.local.toml`). No need to set `OPENAI_API_KEY` as an env var if it's already configured in gptme.
+Keys are loaded from gptme config (`~/.config/gptme/config.toml` or
+`config.local.toml`):
+
+- `OPENAI_API_KEY` for the default `openai` provider
+- `XAI_API_KEY` for `--provider grok`
+
+No need to export them as shell env vars if they're already configured in gptme.
 
 ## Architecture
 
 - **openai_client.py** - WebSocket client for OpenAI Realtime API with VAD, audio streaming, and event handling
-- **server.py** - Starlette WebSocket server bridging clients to OpenAI
+- **xai_client.py** - xAI Grok Voice Agent adapter (OpenAI-compatible WebSocket protocol)
+- **server.py** - Starlette WebSocket server bridging clients to OpenAI or xAI
 - **tool_bridge.py** - Async subagent dispatcher (runs `gptme --non-interactive` in background, injects results)
 - **audio.py** - Audio format conversion (PCM ↔ μ-law for Twilio)
 - **client.py** - Local client with mic/speaker I/O and feedback loop prevention

--- a/packages/gptme-voice/src/gptme_voice/__init__.py
+++ b/packages/gptme-voice/src/gptme_voice/__init__.py
@@ -2,7 +2,7 @@
 gptme-voice: Voice interface for gptme.
 
 Provides real-time voice conversations with gptme tool access
-via OpenAI Realtime API and Twilio Media Streams.
+via OpenAI or xAI Grok Realtime APIs and Twilio Media Streams.
 """
 
 __version__ = "0.1.0"

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -1,7 +1,7 @@
 """
 WebSocket server for Twilio Media Streams.
 
-Bridges Twilio phone calls to OpenAI Realtime API for real-time
+Bridges Twilio phone calls to a realtime API for real-time
 voice conversations with gptme tool access.
 """
 
@@ -72,7 +72,7 @@ class VoiceServer:
         self.workspace = workspace or _detect_agent_repo()
         self._instructions = _load_project_instructions(self.workspace)
 
-        # Active connections: call_sid -> (twilio_ws, openai_client)
+        # Active connections: call_sid -> (twilio_ws, realtime_client)
         self._connections: dict[str, tuple] = {}
 
         # Create Starlette app
@@ -321,7 +321,10 @@ class VoiceServer:
 @click.option(
     "--model",
     default=None,
-    help="Override the realtime model (e.g. gpt-4o-realtime-preview-2024-12-17 or grok-2-realtime).",
+    help=(
+        "Override the realtime model. Useful for OpenAI; for xAI Grok, omit this "
+        "unless you need a specific model alias from the xAI console."
+    ),
 )
 @click.option("--debug", is_flag=True, help="Enable debug logging")
 def main(


### PR DESCRIPTION
## Summary
- remove the dead \ example from the CLI help text
- update gptme-voice docs to reflect OpenAI and xAI provider support
- clarify that Grok usually should use the provider default unless a specific xAI model alias is needed

## Testing
- uv run pytest packages/gptme-voice/tests -q