### PR TITLE
fix(gptme-voice): add caller allowlist and call context

### DIFF
--- a/packages/gptme-voice/README.md
+++ b/packages/gptme-voice/README.md
@@ -65,6 +65,17 @@ Speak into your microphone. The agent responds with its configured personality a
    `https://<your-ngrok-url>/incoming` (HTTP POST)
 3. Call the Twilio number — Twilio connects the call to the voice server.
 
+Optional hardening:
+
+```bash
+TWILIO_ALLOWED_CALLERS=+46765784797,+15551234567
+```
+
+When set, only those caller numbers can get past `/incoming`. The server also
+injects the caller number and Twilio caller name into the realtime instructions
+for that specific call, so the agent can acknowledge who is calling without
+guessing.
+
 ### Place outbound phone calls via Twilio
 
 Set these values in your environment or gptme config:

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -8,6 +8,7 @@ voice conversations with gptme tool access.
 import base64
 import json
 import logging
+from dataclasses import dataclass
 
 import click
 import uvicorn
@@ -18,6 +19,7 @@ from starlette.routing import Route, WebSocketRoute
 
 from .audio import AudioConverter
 from .openai_client import (
+    _MAX_INSTRUCTIONS_LEN,
     OpenAIRealtimeClient,
     SessionConfig,
     _detect_agent_repo,
@@ -28,6 +30,7 @@ from .tool_bridge import GptmeToolBridge
 from .twilio_integration import (
     _get_config_env,
     build_connect_stream_twiml,
+    build_reject_call_twiml,
     build_stream_url,
 )
 from .xai_client import XAIRealtimeClient, _get_xai_api_key
@@ -38,11 +41,121 @@ logger = logging.getLogger(__name__)
 _PROVIDER_OPENAI = "openai"
 _PROVIDER_GROK = "grok"
 _VALID_PROVIDERS = (_PROVIDER_OPENAI, _PROVIDER_GROK)
+_TRUNCATED_CALL_CONTEXT_SUFFIX = "\n\n[truncated for active call metadata]"
 
 
 def _get_twilio_field(payload: dict, camel_name: str, snake_name: str) -> str | None:
     """Read Twilio fields, preferring the documented camelCase form."""
     return payload.get(camel_name) or payload.get(snake_name)
+
+
+def _normalize_phone_number(value: str | None) -> str | None:
+    """Normalize phone numbers to a compact comparison-friendly form."""
+    if value is None:
+        return None
+
+    stripped = value.strip()
+    if not stripped:
+        return None
+    if stripped.lower().startswith("client:"):
+        return stripped
+
+    prefix = "+" if stripped.startswith("+") else ""
+    digits = "".join(ch for ch in stripped if ch.isdigit())
+    if digits:
+        return f"{prefix}{digits}"
+    return stripped
+
+
+def _parse_allowed_callers(raw: str | None) -> set[str]:
+    """Parse comma-separated allowlisted caller numbers."""
+    if not raw:
+        return set()
+
+    allowed = set()
+    for part in raw.split(","):
+        normalized = _normalize_phone_number(part)
+        if normalized:
+            allowed.add(normalized)
+    return allowed
+
+
+@dataclass(frozen=True)
+class CallContext:
+    """Metadata captured for the active Twilio call."""
+
+    call_sid: str
+    from_number: str | None = None
+    to_number: str | None = None
+    caller_name: str | None = None
+
+
+def _build_call_context(form_params: dict) -> CallContext | None:
+    """Extract caller metadata from the Twilio webhook payload."""
+    call_sid = str(form_params.get("CallSid", "")).strip()
+    if not call_sid:
+        return None
+
+    caller_name = str(form_params.get("CallerName", "")).strip() or None
+    return CallContext(
+        call_sid=call_sid,
+        from_number=_normalize_phone_number(str(form_params.get("From", ""))),
+        to_number=_normalize_phone_number(str(form_params.get("To", ""))),
+        caller_name=caller_name,
+    )
+
+
+def _is_allowed_caller(
+    allowed_callers: set[str], from_number: str | None, *, default: bool = True
+) -> bool:
+    """Check whether the caller is allowed to use the voice server."""
+    if not allowed_callers:
+        return True
+    if not from_number:
+        return default
+    return from_number in allowed_callers
+
+
+def _build_call_instructions(
+    base_instructions: str, call_context: CallContext | None
+) -> str:
+    """Inject caller metadata into the realtime instructions for this call."""
+    if call_context is None:
+        return base_instructions
+
+    details = []
+    if call_context.from_number:
+        details.append(f"- Caller phone number: {call_context.from_number}")
+    if call_context.caller_name:
+        details.append(f"- Caller name from Twilio: {call_context.caller_name}")
+    if call_context.to_number:
+        details.append(f"- Dialed number: {call_context.to_number}")
+
+    if not details:
+        return base_instructions
+
+    prefix = (
+        "Active call metadata from Twilio (treat this as ground truth for this call):\n"
+        + "\n".join(details)
+        + "\n"
+        + "Use this metadata during the conversation. If identity is still uncertain, "
+        + "mention the number and ask for confirmation instead of guessing. "
+        + "Do not claim that you cannot see the caller's number when it is present.\n\n"
+    )
+    budget = _MAX_INSTRUCTIONS_LEN - len(prefix)
+    if budget <= 0:
+        return prefix[:_MAX_INSTRUCTIONS_LEN]
+
+    instructions = base_instructions
+    if len(instructions) > budget:
+        truncated_budget = budget - len(_TRUNCATED_CALL_CONTEXT_SUFFIX)
+        if truncated_budget <= 0:
+            instructions = _TRUNCATED_CALL_CONTEXT_SUFFIX.strip()
+        else:
+            instructions = (
+                instructions[:truncated_budget] + _TRUNCATED_CALL_CONTEXT_SUFFIX
+            )
+    return prefix + instructions
 
 
 class VoiceServer:
@@ -71,9 +184,13 @@ class VoiceServer:
             self._api_key = openai_api_key or _get_openai_api_key()
         self.workspace = workspace or _detect_agent_repo()
         self._instructions = _load_project_instructions(self.workspace)
+        self._allowed_callers = _parse_allowed_callers(
+            _get_config_env("TWILIO_ALLOWED_CALLERS")
+        )
 
         # Active connections: call_sid -> (twilio_ws, realtime_client)
         self._connections: dict[str, tuple] = {}
+        self._call_contexts: dict[str, CallContext] = {}
 
         # Create Starlette app
         self.app = Starlette(
@@ -96,6 +213,8 @@ class VoiceServer:
         Configure your Twilio phone number's Voice webhook to POST to this endpoint.
         Twilio will then open a Media Stream WebSocket to /twilio.
         """
+        form_params = dict(await request.form())
+
         # Validate Twilio webhook signature when auth token is configured.
         # Skip in dev environments where TWILIO_AUTH_TOKEN is absent.
         auth_token = _get_config_env("TWILIO_AUTH_TOKEN")
@@ -105,12 +224,26 @@ class VoiceServer:
             signature = request.headers.get("X-Twilio-Signature", "")
             host = request.headers.get("host", f"{self.host}:{self.port}")
             validation_url = f"https://{host}/incoming"
-            form_params = dict(await request.form())
             if not RequestValidator(auth_token).validate(
                 validation_url, form_params, signature
             ):
                 logger.warning("Rejected request with invalid Twilio signature")
                 return PlainTextResponse("Forbidden", status_code=403)
+
+        call_context = _build_call_context(form_params)
+        if call_context and not _is_allowed_caller(
+            self._allowed_callers, call_context.from_number, default=False
+        ):
+            logger.warning(
+                "Rejected incoming call from non-allowlisted caller %s",
+                call_context.from_number,
+            )
+            return PlainTextResponse(
+                build_reject_call_twiml(),
+                media_type="text/xml",
+            )
+        if call_context:
+            self._call_contexts[call_context.call_sid] = call_context
 
         # Prefer the configured public URL; fall back to Host header.
         public_base_url = _get_config_env(
@@ -161,12 +294,16 @@ class VoiceServer:
                     if not call_sid:
                         call_sid = stream_sid
 
-                    if self.model:
-                        session_cfg = SessionConfig(
-                            instructions=self._instructions, model=self.model
+                    call_context = self._call_contexts.get(call_sid)
+                    if self._allowed_callers and call_context is None:
+                        logger.warning(
+                            "Rejected Twilio websocket for untracked callSid %s",
+                            call_sid,
                         )
-                    else:
-                        session_cfg = SessionConfig(instructions=self._instructions)
+                        await websocket.close(code=1008)
+                        break
+
+                    session_cfg = self._build_session_config(call_context)
                     realtime_client = self._make_client(
                         session_cfg,
                         on_audio=lambda audio: self._send_to_twilio(
@@ -202,6 +339,8 @@ class VoiceServer:
                         await realtime_client.disconnect()
                     if call_sid and call_sid in self._connections:
                         del self._connections[call_sid]
+                    if call_sid:
+                        self._call_contexts.pop(call_sid, None)
                     break
 
         except Exception as e:
@@ -211,6 +350,8 @@ class VoiceServer:
                 await realtime_client.disconnect()
             if call_sid and call_sid in self._connections:
                 del self._connections[call_sid]
+            if call_sid:
+                self._call_contexts.pop(call_sid, None)
 
     async def _send_to_twilio(self, websocket, stream_sid: str, audio_data: bytes):
         """Send audio to Twilio Media Stream."""
@@ -241,6 +382,15 @@ class VoiceServer:
             **kwargs,
         )
 
+    def _build_session_config(
+        self, call_context: CallContext | None = None
+    ) -> SessionConfig:
+        """Build session config, injecting caller metadata when available."""
+        instructions = _build_call_instructions(self._instructions, call_context)
+        if self.model:
+            return SessionConfig(instructions=instructions, model=self.model)
+        return SessionConfig(instructions=instructions)
+
     async def handle_local_websocket(self, websocket):
         """
         Handle WebSocket connection for local testing.
@@ -253,12 +403,7 @@ class VoiceServer:
         realtime_client: OpenAIRealtimeClient | None = None
 
         try:
-            if self.model:
-                session_cfg = SessionConfig(
-                    instructions=self._instructions, model=self.model
-                )
-            else:
-                session_cfg = SessionConfig(instructions=self._instructions)
+            session_cfg = self._build_session_config()
             realtime_client = self._make_client(
                 session_cfg,
                 on_audio=lambda audio: self._send_local_audio(websocket, audio),

--- a/packages/gptme-voice/src/gptme_voice/realtime/twilio_integration.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/twilio_integration.py
@@ -98,6 +98,14 @@ def build_connect_stream_twiml(stream_url: str) -> str:
 </Response>"""
 
 
+def build_reject_call_twiml() -> str:
+    """Build the TwiML used to reject an incoming call."""
+    return """<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+    <Reject />
+</Response>"""
+
+
 def resolve_outbound_call_settings(
     *, from_number: str | None = None, public_base_url: str | None = None
 ) -> OutboundCallSettings:

--- a/packages/gptme-voice/src/gptme_voice/realtime/xai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/xai_client.py
@@ -15,7 +15,7 @@ from gptme.config import get_config
 from .openai_client import OpenAIRealtimeClient, SessionConfig
 
 _OPENAI_DEFAULT_VOICE = "echo"
-_DEFAULT_XAI_VOICE = "eve"
+_DEFAULT_XAI_VOICE = "rex"
 
 
 def _get_xai_api_key() -> str | None:

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -2,7 +2,16 @@ import asyncio
 import base64
 import json
 
-from gptme_voice.realtime.server import VoiceServer, _get_twilio_field
+from gptme_voice.realtime.server import (
+    CallContext,
+    VoiceServer,
+    _build_call_instructions,
+    _get_twilio_field,
+    _is_allowed_caller,
+    _normalize_phone_number,
+    _parse_allowed_callers,
+)
+from starlette.testclient import TestClient
 
 
 class _DummyWebSocket:
@@ -11,6 +20,24 @@ class _DummyWebSocket:
 
     async def send_text(self, message: str) -> None:
         self.messages.append(message)
+
+
+class _StartOnlyWebSocket:
+    def __init__(self, message: dict) -> None:
+        self.message = json.dumps(message)
+        self.accepted = False
+        self.closed = False
+        self.close_code: int | None = None
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def close(self, code: int) -> None:
+        self.closed = True
+        self.close_code = code
+
+    async def iter_text(self):
+        yield self.message
 
 
 def test_get_twilio_field_prefers_camel_case() -> None:
@@ -38,3 +65,130 @@ def test_send_to_twilio_uses_stream_sid_field_name() -> None:
         "streamSid": "MZ123",
         "media": {"payload": base64.b64encode(b"\x00\x01").decode("utf-8")},
     }
+
+
+def test_normalize_phone_number_keeps_e164_format() -> None:
+    assert _normalize_phone_number(" +46 765-784 797 ") == "+46765784797"
+
+
+def test_parse_allowed_callers_normalizes_comma_separated_numbers() -> None:
+    assert _parse_allowed_callers("+46 765 784 797, +1 (555) 100-2000") == {
+        "+46765784797",
+        "+15551002000",
+    }
+
+
+def test_is_allowed_caller_denies_missing_number_when_allowlist_enabled() -> None:
+    assert not _is_allowed_caller({"+46765784797"}, None, default=False)
+
+
+def test_build_call_instructions_includes_caller_metadata() -> None:
+    context = CallContext(
+        call_sid="CA123",
+        from_number="+46765784797",
+        to_number="+15551234567",
+        caller_name="Erik",
+    )
+
+    instructions = _build_call_instructions("Base instructions", context)
+
+    assert "Caller phone number: +46765784797" in instructions
+    assert "Caller name from Twilio: Erik" in instructions
+    assert "Do not claim that you cannot see the caller's number" in instructions
+
+
+def test_build_session_config_injects_call_metadata(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "gptme_voice.realtime.server._get_config_env",
+        lambda name: None,
+    )
+    server = VoiceServer(workspace=None)
+    context = CallContext(call_sid="CA123", from_number="+46765784797")
+
+    session_cfg = server._build_session_config(context)
+
+    assert "Caller phone number: +46765784797" in session_cfg.instructions
+
+
+def test_incoming_call_rejects_non_allowlisted_caller(monkeypatch) -> None:
+    env = {
+        "TWILIO_ALLOWED_CALLERS": "+46765784797",
+        "GPTME_VOICE_PUBLIC_BASE_URL": "https://voice.example.com",
+    }
+    monkeypatch.setattr(
+        "gptme_voice.realtime.server._get_config_env",
+        lambda name: env.get(name),
+    )
+    server = VoiceServer(workspace=None)
+    client = TestClient(server.app)
+
+    response = client.post(
+        "/incoming",
+        data={"CallSid": "CA999", "From": "+15551234567", "To": "+46700000000"},
+    )
+
+    assert response.status_code == 200
+    assert "<Reject />" in response.text
+    assert "CA999" not in server._call_contexts
+
+
+def test_incoming_call_records_allowlisted_context(monkeypatch) -> None:
+    env = {
+        "TWILIO_ALLOWED_CALLERS": "+46765784797",
+        "GPTME_VOICE_PUBLIC_BASE_URL": "https://voice.example.com",
+    }
+    monkeypatch.setattr(
+        "gptme_voice.realtime.server._get_config_env",
+        lambda name: env.get(name),
+    )
+    server = VoiceServer(workspace=None)
+    client = TestClient(server.app)
+
+    response = client.post(
+        "/incoming",
+        data={
+            "CallSid": "CA123",
+            "From": "+46 765 784 797",
+            "To": "+46700000000",
+            "CallerName": "Erik",
+        },
+    )
+
+    assert response.status_code == 200
+    assert 'Stream url="wss://voice.example.com/twilio"' in response.text
+    assert server._call_contexts["CA123"] == CallContext(
+        call_sid="CA123",
+        from_number="+46765784797",
+        to_number="+46700000000",
+        caller_name="Erik",
+    )
+
+
+def test_twilio_websocket_rejects_untracked_call_when_allowlist_enabled(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "gptme_voice.realtime.server._get_config_env",
+        lambda name: None,
+    )
+    server = VoiceServer(workspace=None)
+    server._allowed_callers = {"+46765784797"}
+    websocket = _StartOnlyWebSocket(
+        {"event": "start", "start": {"streamSid": "MZ123", "callSid": "CA123"}}
+    )
+
+    called = False
+
+    def _unexpected_make_client(*args, **kwargs):  # pragma: no cover - sanity guard
+        nonlocal called
+        called = True
+        raise AssertionError("realtime client should not be created")
+
+    monkeypatch.setattr(server, "_make_client", _unexpected_make_client)
+
+    asyncio.run(server.handle_twilio_websocket(websocket))
+
+    assert websocket.accepted
+    assert websocket.closed
+    assert websocket.close_code == 1008
+    assert not called

--- a/packages/gptme-voice/tests/test_xai_client.py
+++ b/packages/gptme-voice/tests/test_xai_client.py
@@ -5,5 +5,5 @@ from gptme_voice.realtime.xai_client import XAIRealtimeClient
 def test_xai_client_uses_xai_defaults() -> None:
     client = XAIRealtimeClient(api_key="test-key", session_config=SessionConfig())
 
-    assert client.session_config.voice == "eve"
+    assert client.session_config.voice == "rex"
     assert client._get_ws_url() == "wss://api.x.ai/v1/realtime"


### PR DESCRIPTION
## Summary
- add `TWILIO_ALLOWED_CALLERS` support for `/incoming` and reject unknown callers with TwiML
- carry caller number/name into per-call realtime instructions and reject stray `/twilio` websockets when allowlisting is enabled
- switch the default xAI voice from `eve` to `rex` and document the new hardening knob

## Testing
- `PYTHONPATH=/tmp/worktrees/gptme-voice-caller-context/packages/gptme-voice/src /home/bob/bob/.venv/bin/pytest /tmp/worktrees/gptme-voice-caller-context/packages/gptme-voice/tests -q`

Refs ErikBjare/bob#651