### PR TITLE
feat(gptme-voice): caller context, phone allowlist, and male voice for Bob

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -8,6 +8,7 @@ voice conversations with gptme tool access.
 import base64
 import json
 import logging
+from pathlib import Path
 
 import click
 import uvicorn
@@ -49,8 +50,6 @@ def _build_caller_instructions(
 
     caller_name: str | None = None
     if workspace:
-        from pathlib import Path
-
         people_dir = Path(workspace) / "people"
         if people_dir.is_dir():
             for md_file in people_dir.glob("*.md"):
@@ -170,11 +169,17 @@ class VoiceServer:
         allowlist_raw = _get_config_env("TWILIO_CALLER_ALLOWLIST")
         if allowlist_raw:
             allowlist = {n.strip() for n in allowlist_raw.split(",") if n.strip()}
+            if not auth_token:
+                logger.warning(
+                    "TWILIO_CALLER_ALLOWLIST is set but TWILIO_AUTH_TOKEN is absent — "
+                    "the From field is unauthenticated and can be spoofed; "
+                    "set TWILIO_AUTH_TOKEN to enforce the allowlist securely."
+                )
             if from_number not in allowlist:
                 logger.warning(
-                    "Rejected call from unlisted number: %s (allowlist: %s)",
+                    "Rejected call from unlisted number: %s (%d number(s) in allowlist)",
                     from_number,
-                    allowlist,
+                    len(allowlist),
                 )
                 return PlainTextResponse("Forbidden", status_code=403)
 

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -35,6 +35,57 @@ from .xai_client import XAIRealtimeClient, _get_xai_api_key
 logger = logging.getLogger(__name__)
 
 
+def _build_caller_instructions(
+    base_instructions: str, from_number: str, workspace: str | None
+) -> str:
+    """Prepend caller-identity context to session instructions.
+
+    Looks up the caller's phone number in the workspace people/ directory to
+    find a name.  Falls back to the raw phone number so the agent at least
+    knows who is calling instead of being blind.
+    """
+    if not from_number:
+        return base_instructions
+
+    caller_name: str | None = None
+    if workspace:
+        from pathlib import Path
+
+        people_dir = Path(workspace) / "people"
+        if people_dir.is_dir():
+            for md_file in people_dir.glob("*.md"):
+                try:
+                    text = md_file.read_text()
+                    if from_number in text:
+                        # Use the stem as a hint; the file header is the canonical name
+                        first_h1 = next(
+                            (
+                                line.lstrip("# ").strip()
+                                for line in text.splitlines()
+                                if line.startswith("# ")
+                            ),
+                            None,
+                        )
+                        caller_name = first_h1 or md_file.stem.replace("-", " ").title()
+                        break
+                except Exception:
+                    pass
+
+    if caller_name:
+        caller_ctx = (
+            f"The current caller's phone number is {from_number} "
+            f"({caller_name}). "
+            f"You know this person — refer to them by name."
+        )
+    else:
+        caller_ctx = (
+            f"The current caller's phone number is {from_number}. "
+            f"You do not recognise this number; treat the caller as an unknown guest."
+        )
+
+    return f"{caller_ctx}\n\n{base_instructions}"
+
+
 _PROVIDER_OPENAI = "openai"
 _PROVIDER_GROK = "grok"
 _VALID_PROVIDERS = (_PROVIDER_OPENAI, _PROVIDER_GROK)
@@ -96,6 +147,9 @@ class VoiceServer:
         Configure your Twilio phone number's Voice webhook to POST to this endpoint.
         Twilio will then open a Media Stream WebSocket to /twilio.
         """
+        form_params = dict(await request.form())
+        from_number = form_params.get("From", "")
+
         # Validate Twilio webhook signature when auth token is configured.
         # Skip in dev environments where TWILIO_AUTH_TOKEN is absent.
         auth_token = _get_config_env("TWILIO_AUTH_TOKEN")
@@ -105,11 +159,23 @@ class VoiceServer:
             signature = request.headers.get("X-Twilio-Signature", "")
             host = request.headers.get("host", f"{self.host}:{self.port}")
             validation_url = f"https://{host}/incoming"
-            form_params = dict(await request.form())
             if not RequestValidator(auth_token).validate(
                 validation_url, form_params, signature
             ):
                 logger.warning("Rejected request with invalid Twilio signature")
+                return PlainTextResponse("Forbidden", status_code=403)
+
+        # Allowlist: only accept calls from known numbers.
+        # Set TWILIO_CALLER_ALLOWLIST to a comma-separated list of E.164 numbers.
+        allowlist_raw = _get_config_env("TWILIO_CALLER_ALLOWLIST")
+        if allowlist_raw:
+            allowlist = {n.strip() for n in allowlist_raw.split(",") if n.strip()}
+            if from_number not in allowlist:
+                logger.warning(
+                    "Rejected call from unlisted number: %s (allowlist: %s)",
+                    from_number,
+                    allowlist,
+                )
                 return PlainTextResponse("Forbidden", status_code=403)
 
         # Prefer the configured public URL; fall back to Host header.
@@ -122,7 +188,11 @@ class VoiceServer:
             host = request.headers.get("host", f"{self.host}:{self.port}")
             ws_url = build_stream_url(host)
 
-        twiml = build_connect_stream_twiml(ws_url)
+        # Forward caller number to WebSocket handler via TwiML custom parameters.
+        custom_params: dict[str, str] = {}
+        if from_number:
+            custom_params["from_number"] = from_number
+        twiml = build_connect_stream_twiml(ws_url, custom_params or None)
         return PlainTextResponse(twiml, media_type="text/xml")
 
     async def handle_twilio_websocket(self, websocket):
@@ -161,12 +231,19 @@ class VoiceServer:
                     if not call_sid:
                         call_sid = stream_sid
 
+                    # Inject caller context into instructions (phone + name lookup)
+                    custom_params = start.get("customParameters", {})
+                    from_number = custom_params.get("from_number", "")
+                    instructions = _build_caller_instructions(
+                        self._instructions, from_number, self.workspace
+                    )
+
                     if self.model:
                         session_cfg = SessionConfig(
-                            instructions=self._instructions, model=self.model
+                            instructions=instructions, model=self.model
                         )
                     else:
-                        session_cfg = SessionConfig(instructions=self._instructions)
+                        session_cfg = SessionConfig(instructions=instructions)
                     realtime_client = self._make_client(
                         session_cfg,
                         on_audio=lambda audio: self._send_to_twilio(

--- a/packages/gptme-voice/src/gptme_voice/realtime/twilio_integration.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/twilio_integration.py
@@ -87,13 +87,28 @@ def build_stream_url(
     return urlunsplit((scheme, parsed.netloc, path, "", ""))
 
 
-def build_connect_stream_twiml(stream_url: str) -> str:
-    """Build the TwiML needed to attach a call to a Media Stream."""
+def build_connect_stream_twiml(
+    stream_url: str, custom_params: dict[str, str] | None = None
+) -> str:
+    """Build the TwiML needed to attach a call to a Media Stream.
+
+    custom_params are forwarded to the WebSocket handler via Twilio's
+    <Parameter> elements, arriving in the "start.customParameters" payload.
+    """
     safe_url = _html_escape(stream_url, quote=True)
+    param_lines = ""
+    if custom_params:
+        for key, value in custom_params.items():
+            safe_key = _html_escape(key, quote=True)
+            safe_value = _html_escape(value, quote=True)
+            param_lines += (
+                f'\n            <Parameter name="{safe_key}" value="{safe_value}" />'
+            )
     return f"""<?xml version="1.0" encoding="UTF-8"?>
 <Response>
     <Connect>
-        <Stream url="{safe_url}" />
+        <Stream url="{safe_url}">{param_lines}
+        </Stream>
     </Connect>
 </Response>"""
 

--- a/packages/gptme-voice/src/gptme_voice/realtime/xai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/xai_client.py
@@ -15,7 +15,8 @@ from gptme.config import get_config
 from .openai_client import OpenAIRealtimeClient, SessionConfig
 
 _OPENAI_DEFAULT_VOICE = "echo"
-_DEFAULT_XAI_VOICE = "eve"
+# "rex" = male, confident, clear — matches the Bob persona better than "eve" (female)
+_DEFAULT_XAI_VOICE = "rex"
 
 
 def _get_xai_api_key() -> str | None:

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -1,8 +1,14 @@
 import asyncio
 import base64
 import json
+import tempfile
+from pathlib import Path
 
-from gptme_voice.realtime.server import VoiceServer, _get_twilio_field
+from gptme_voice.realtime.server import (
+    VoiceServer,
+    _build_caller_instructions,
+    _get_twilio_field,
+)
 
 
 class _DummyWebSocket:
@@ -11,6 +17,32 @@ class _DummyWebSocket:
 
     async def send_text(self, message: str) -> None:
         self.messages.append(message)
+
+
+def test_build_caller_instructions_no_number() -> None:
+    base = "You are Bob."
+    result = _build_caller_instructions(base, "", None)
+    assert result == base
+
+
+def test_build_caller_instructions_unknown_number() -> None:
+    result = _build_caller_instructions("You are Bob.", "+15551234567", None)
+    assert "+15551234567" in result
+    assert "unknown" in result.lower()
+    assert "You are Bob." in result
+
+
+def test_build_caller_instructions_known_number_from_people_dir() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        people_dir = Path(tmpdir) / "people"
+        people_dir.mkdir()
+        (people_dir / "erik-bjareholt.md").write_text(
+            "# Erik Bjäreholt\n\nPhone: +46765784797\n"
+        )
+        result = _build_caller_instructions("You are Bob.", "+46765784797", tmpdir)
+    assert "Erik Bjäreholt" in result
+    assert "+46765784797" in result
+    assert "You are Bob." in result
 
 
 def test_get_twilio_field_prefers_camel_case() -> None:

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -37,11 +37,11 @@ def test_build_caller_instructions_known_number_from_people_dir() -> None:
         people_dir = Path(tmpdir) / "people"
         people_dir.mkdir()
         (people_dir / "erik-bjareholt.md").write_text(
-            "# Erik Bjäreholt\n\nPhone: +46765784797\n"
+            "# Erik Bjäreholt\n\nPhone: +46700000001\n"
         )
-        result = _build_caller_instructions("You are Bob.", "+46765784797", tmpdir)
+        result = _build_caller_instructions("You are Bob.", "+46700000001", tmpdir)
     assert "Erik Bjäreholt" in result
-    assert "+46765784797" in result
+    assert "+46700000001" in result
     assert "You are Bob." in result
 
 

--- a/packages/gptme-voice/tests/test_twilio_integration.py
+++ b/packages/gptme-voice/tests/test_twilio_integration.py
@@ -30,10 +30,10 @@ def test_build_connect_stream_twiml_embeds_stream_url():
 def test_build_connect_stream_twiml_with_custom_params():
     twiml = build_connect_stream_twiml(
         "wss://voice.example/twilio",
-        custom_params={"from_number": "+46765784797", "name": "Erik"},
+        custom_params={"from_number": "+46700000001", "name": "Erik"},
     )
 
-    assert 'name="from_number" value="+46765784797"' in twiml
+    assert 'name="from_number" value="+46700000001"' in twiml
     assert 'name="name" value="Erik"' in twiml
     assert "<Parameter" in twiml
 

--- a/packages/gptme-voice/tests/test_twilio_integration.py
+++ b/packages/gptme-voice/tests/test_twilio_integration.py
@@ -23,8 +23,19 @@ def test_build_stream_url_accepts_bare_host_with_path():
 def test_build_connect_stream_twiml_embeds_stream_url():
     twiml = build_connect_stream_twiml("wss://voice.example/twilio")
 
-    assert '<Stream url="wss://voice.example/twilio" />' in twiml
+    assert 'url="wss://voice.example/twilio"' in twiml
     assert twiml.startswith('<?xml version="1.0" encoding="UTF-8"?>')
+
+
+def test_build_connect_stream_twiml_with_custom_params():
+    twiml = build_connect_stream_twiml(
+        "wss://voice.example/twilio",
+        custom_params={"from_number": "+46765784797", "name": "Erik"},
+    )
+
+    assert 'name="from_number" value="+46765784797"' in twiml
+    assert 'name="name" value="Erik"' in twiml
+    assert "<Parameter" in twiml
 
 
 def test_build_connect_stream_twiml_escapes_url():
@@ -112,4 +123,4 @@ def test_call_cli_dry_run_prints_twiml(monkeypatch):
     )
 
     assert result.exit_code == 0
-    assert '<Stream url="wss://voice.example/twilio" />' in result.output
+    assert 'url="wss://voice.example/twilio"' in result.output

--- a/packages/gptme-voice/tests/test_xai_client.py
+++ b/packages/gptme-voice/tests/test_xai_client.py
@@ -5,5 +5,5 @@ from gptme_voice.realtime.xai_client import XAIRealtimeClient
 def test_xai_client_uses_xai_defaults() -> None:
     client = XAIRealtimeClient(api_key="test-key", session_config=SessionConfig())
 
-    assert client.session_config.voice == "eve"
+    assert client.session_config.voice == "rex"  # male voice for Bob persona
     assert client._get_ws_url() == "wss://api.x.ai/v1/realtime"


### PR DESCRIPTION
Addresses feedback from ErikBjare/bob#651 (Erik's first successful call).

## Changes

### Male voice (`rex` instead of `eve`)
Grok's default voice `eve` is female — not right for the Bob persona. This switches the xAI default to `rex` (male, confident, clear). `eve` was only used when no voice was specified; the override is still possible via `--model` / `SessionConfig`.

### Phone number allowlist
`TWILIO_CALLER_ALLOWLIST` — comma-separated E.164 numbers (e.g. `+4676578479799`). `/incoming` returns 403 for any caller not in the list. Prevents prompt injection from unknown callers.

Set in gptme config or environment:
```
TWILIO_CALLER_ALLOWLIST=+4676578479799
```

### Caller context injection
The caller's phone number is now forwarded from the HTTP `/incoming` webhook to the WebSocket handler via a TwiML `<Parameter>` element. The handler looks up the number in `people/*.md` and prepends identity context to the session instructions:

- **Known caller**: "The current caller's phone number is +4676578479799 (Erik Bjäreholt). You know this person — refer to them by name."
- **Unknown caller**: "The current caller's phone number is +15551234567. You do not recognise this number; treat the caller as an unknown guest."

This means Bob no longer needs to be told who's on the line — he already knows.

## Test plan
- [x] 15 tests pass (`uv run pytest packages/gptme-voice/tests`)
- [x] `test_build_caller_instructions_known_number_from_people_dir` — number lookup in people/
- [x] `test_build_caller_instructions_unknown_number` — fallback for strangers
- [x] `test_build_connect_stream_twiml_with_custom_params` — custom params in TwiML output
- [x] `test_xai_client_uses_xai_defaults` updated to expect `rex`

## Follow-up (not in this PR)
- Post-call session queuing: save transcript on `stop` event, queue a follow-up agent run to process and write journal/tasks