### PR TITLE
fix(gptme-voice): tune VAD for easier Grok interruption

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/xai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/xai_client.py
@@ -53,6 +53,18 @@ class XAIRealtimeClient(OpenAIRealtimeClient):
         if cfg.voice == _OPENAI_DEFAULT_VOICE:
             cfg = dataclasses.replace(cfg, voice=_DEFAULT_XAI_VOICE)
 
+        # VAD tuning for Grok interruption (from task #651 / Erik feedback)
+        # Lower threshold = more sensitive to speech, easier to interrupt
+        # Reduce silence duration so Bob stops faster
+        # Prefix padding reduced to minimize lag
+        if cfg.vad_threshold >= 0.65:  # only override default/high values
+            cfg = dataclasses.replace(
+                cfg,
+                vad_threshold=0.55,
+                vad_silence_duration_ms=250,
+                vad_prefix_padding_ms=150,
+            )
+
         super().__init__(api_key=resolved_key, session_config=cfg, **kwargs)
 
     def _get_ws_url(self) -> str:


### PR DESCRIPTION
## Summary

Lower VAD sensitivity for Grok realtime to match OpenAI realtime's interruption responsiveness.

- `vad_threshold`: 0.85 → **0.55** (more sensitive to incoming speech)
- `vad_silence_duration_ms`: 500 → **250** (Bob stops talking faster when Erik starts)
- `vad_prefix_padding_ms`: 300 → **150** (reduced lag before detection)

Per Erik's feedback in ErikBjare/bob#651: *"the VAD didn't work great for interruption with Grok (a bit frustrating to not be able to interrupt a misunderstanding), iirc it worked decent with OpenAI real-time"*

Context from task `gptme-voice-vad-tuning` in Bob's workspace.

## Test plan
- [ ] Test interruption latency on a live Twilio call with Grok backend
- [ ] Verify no regression in false-positive interruptions (background noise)
- [ ] Compare subjectively to OpenAI realtime's responsiveness