### PR TITLE
fix(gptme-voice): harden resume truncation and post-call cancel

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -7,6 +7,7 @@ voice conversations with gptme tool access.
 
 import asyncio
 import base64
+import contextlib
 import hashlib
 import json
 import logging
@@ -123,6 +124,31 @@ def _format_transcript(transcript: list[TranscriptTurn]) -> str:
     return "\n".join(f"{turn.role.title()}: {turn.text}" for turn in transcript)
 
 
+def _truncate_resume_transcript(transcript_text: str, max_chars: int) -> str:
+    """Keep the newest transcript lines without starting mid-line."""
+    if len(transcript_text) <= max_chars:
+        return transcript_text
+
+    lines = transcript_text.splitlines()
+    kept_lines: list[str] = []
+    total_chars = 0
+
+    for line in reversed(lines):
+        line_chars = len(line) + (1 if kept_lines else 0)
+        if kept_lines and total_chars + line_chars > max_chars:
+            break
+        if not kept_lines and len(line) > max_chars:
+            return line[-max_chars:]
+
+        kept_lines.append(line)
+        total_chars += line_chars
+
+    if kept_lines:
+        return "\n".join(reversed(kept_lines))
+
+    return transcript_text[-max_chars:]
+
+
 def _build_resume_instructions(
     base_instructions: str,
     recent_call: RecentCallRecord | None,
@@ -133,8 +159,9 @@ def _build_resume_instructions(
         return base_instructions
 
     transcript_text = _format_transcript(recent_call.transcript)
-    if len(transcript_text) > _MAX_RESUME_TRANSCRIPT_CHARS:
-        transcript_text = transcript_text[-_MAX_RESUME_TRANSCRIPT_CHARS:]
+    transcript_text = _truncate_resume_transcript(
+        transcript_text, _MAX_RESUME_TRANSCRIPT_CHARS
+    )
 
     age_seconds = max(int(time.time() - recent_call.ended_at), 0)
     resume_ctx = (
@@ -306,7 +333,20 @@ class VoiceServer:
             stderr=asyncio.subprocess.PIPE,
             env=env,
         )
-        stdout, stderr = await process.communicate()
+        try:
+            stdout, stderr = await process.communicate()
+        except asyncio.CancelledError:
+            if process.returncode is None:
+                logger.info("Cancelling post-call command for %s", caller_id)
+                with contextlib.suppress(ProcessLookupError):
+                    process.terminate()
+                try:
+                    await asyncio.wait_for(process.wait(), timeout=2)
+                except asyncio.TimeoutError:
+                    with contextlib.suppress(ProcessLookupError):
+                        process.kill()
+                    await process.wait()
+            raise
         if process.returncode != 0:
             logger.error(
                 "Post-call command failed for %s (exit=%s): %s",

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -1,6 +1,9 @@
 import asyncio
 import base64
 import json
+import os
+import shlex
+import sys
 import tempfile
 from pathlib import Path
 
@@ -12,6 +15,7 @@ from gptme_voice.realtime.server import (
     _build_caller_instructions,
     _build_resume_instructions,
     _get_twilio_field,
+    _truncate_resume_transcript,
 )
 
 
@@ -94,6 +98,23 @@ def test_build_resume_instructions_includes_prior_transcript() -> None:
     assert "User: Hello Bob" in result
     assert "Assistant: Hi Erik" in result
     assert "You are Bob." in result
+
+
+def test_truncate_resume_transcript_keeps_line_boundaries() -> None:
+    transcript_text = "\n".join(
+        [
+            f"User: {'a' * 1200}",
+            f"Assistant: {'b' * 1200}",
+            "User: tail",
+        ]
+    )
+
+    truncated = _truncate_resume_transcript(transcript_text, 2_500)
+    formatted_lines = transcript_text.splitlines()
+
+    assert truncated.splitlines()[0] in formatted_lines
+    assert truncated.endswith("User: tail")
+    assert len(truncated) <= 2_500
 
 
 def test_recent_call_is_consumed_within_resume_window() -> None:
@@ -237,5 +258,61 @@ def test_schedule_post_call_runner_finally_does_not_evict_newer_task() -> None:
             assert first_task.cancelled()
 
             second_task.cancel()
+
+    asyncio.run(_exercise())
+
+
+def test_cancelled_post_call_command_terminates_subprocess() -> None:
+    def _pid_exists(pid: int) -> bool:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+        return True
+
+    async def _exercise() -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            server = VoiceServer()
+            server.state_dir = Path(tmpdir)
+            pid_file = Path(tmpdir) / "post-call.pid"
+            record_path = Path(tmpdir) / "recent-call.json"
+            record_path.write_text("{}")
+            script = (
+                "import os, pathlib, time; "
+                "pathlib.Path(os.environ['PID_FILE']).write_text(str(os.getpid())); "
+                "time.sleep(60)"
+            )
+            server.post_call_command = (
+                f"{shlex.quote(sys.executable)} -c {shlex.quote(script)}"
+            )
+
+            with pytest.MonkeyPatch.context() as mp:
+                mp.setenv("PID_FILE", str(pid_file))
+                task = asyncio.create_task(
+                    server._run_post_call_command("+46700000004", record_path)
+                )
+
+                deadline = asyncio.get_running_loop().time() + 5
+                while not pid_file.exists():
+                    if asyncio.get_running_loop().time() > deadline:
+                        raise RuntimeError("post-call command did not start")
+                    await asyncio.sleep(0.05)
+
+                pid = int(pid_file.read_text())
+                assert _pid_exists(pid)
+
+                task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await task
+
+                deadline = asyncio.get_running_loop().time() + 5
+                while _pid_exists(pid):
+                    if asyncio.get_running_loop().time() > deadline:
+                        raise AssertionError(
+                            "cancelled post-call command subprocess still running"
+                        )
+                    await asyncio.sleep(0.05)
 
     asyncio.run(_exercise())

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -101,10 +101,11 @@ def test_build_resume_instructions_includes_prior_transcript() -> None:
 
 
 def test_truncate_resume_transcript_keeps_line_boundaries() -> None:
+    # Lines must exceed max_chars so truncation is actually triggered
     transcript_text = "\n".join(
         [
-            f"User: {'a' * 1200}",
-            f"Assistant: {'b' * 1200}",
+            f"User: {'a' * 1500}",
+            f"Assistant: {'b' * 1500}",
             "User: tail",
         ]
     )
@@ -112,6 +113,7 @@ def test_truncate_resume_transcript_keeps_line_boundaries() -> None:
     truncated = _truncate_resume_transcript(transcript_text, 2_500)
     formatted_lines = transcript_text.splitlines()
 
+    assert len(transcript_text) > 2_500, "input must exceed budget to test truncation"
     assert truncated.splitlines()[0] in formatted_lines
     assert truncated.endswith("User: tail")
     assert len(truncated) <= 2_500


### PR DESCRIPTION
## Summary
- terminate delayed post-call subprocesses when the scheduling task is cancelled
- truncate resumed transcripts on whole-line boundaries when possible instead of starting mid-line
- add regression coverage for both cases

## Verification
- uv run --directory /tmp/worktrees/gptme-contrib-pr-698/packages/gptme-voice pytest tests/test_server.py -q
- uv run --directory /tmp/worktrees/gptme-contrib-pr-698/packages/gptme-voice ruff check src/gptme_voice/realtime/server.py tests/test_server.py