### PR TITLE
fix(gptme-voice): harden subagent bridge for noninteractive calls

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -18,10 +18,15 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Awaitable, Callable
 
+from .twilio_integration import _get_config_env
+
 logger = logging.getLogger(__name__)
 
 # Max output to return (avoid overwhelming the realtime API)
 _MAX_OUTPUT_LEN = 2000
+_IGNORABLE_ERROR_LINES = {
+    "Warning: Input is not a terminal (fd=0).",
+}
 
 # Appended to each task so the subagent writes a clean response file
 _RESPONSE_SUFFIX = (
@@ -59,12 +64,47 @@ class GptmeToolBridge:
         workspace: str | None = None,
         on_result: Callable[[str], Awaitable[None]] | None = None,
     ):
-        self.gptme_path = gptme_path
+        self.gptme_path = _get_config_env("GPTME_VOICE_SUBAGENT_PATH") or gptme_path
         self.timeout = timeout
         self.workspace = workspace
         self.on_result = on_result
+        shared_model = _get_config_env("GPTME_VOICE_SUBAGENT_MODEL")
+        self.model_fast = (
+            _get_config_env("GPTME_VOICE_SUBAGENT_MODEL_FAST")
+            or shared_model
+            or self.MODEL_FAST
+        )
+        self.model_smart = (
+            _get_config_env("GPTME_VOICE_SUBAGENT_MODEL_SMART")
+            or shared_model
+            or self.MODEL_SMART
+        )
         self._pending_tasks: dict[str, asyncio.Task] = {}
         self._task_counter = 0
+
+    @staticmethod
+    def _extract_error_text(stdout: str, stderr: str, output: str) -> str:
+        stderr_lines = [
+            line.strip()
+            for line in stderr.splitlines()
+            if line.strip() and line.strip() not in _IGNORABLE_ERROR_LINES
+        ]
+        if stderr_lines:
+            return "\n".join(stderr_lines)
+
+        stdout_lines = [line.strip() for line in stdout.splitlines() if line.strip()]
+        for needle in ("Error code:", "API error:", "invalid_request_error", "ERROR"):
+            for line in reversed(stdout_lines):
+                if needle.lower() in line.lower():
+                    return line
+        if output:
+            return output
+        if stdout_lines:
+            return stdout_lines[-1]
+        fallback_stderr = stderr.strip()
+        if fallback_stderr:
+            return fallback_stderr
+        return ""
 
     async def _run_subagent(self, task_id: str, task: str, mode: str = "smart") -> None:
         """Run a subagent in the background and inject result when done."""
@@ -92,7 +132,7 @@ class GptmeToolBridge:
             response_file = Path(tf.name)
         augmented_task = task + _RESPONSE_SUFFIX.format(response_file=response_file)
 
-        model = self.MODEL_FAST if mode == "fast" else self.MODEL_SMART
+        model = self.model_fast if mode == "fast" else self.model_smart
         logger.info(f"Dispatching subagent ({mode}): {task}")
         logger.debug(f"Response file: {response_file}")
 
@@ -126,18 +166,27 @@ class GptmeToolBridge:
                     error=f"Subagent timed out after {self.timeout}s",
                 )
 
+            stdout_text = stdout.decode("utf-8", errors="replace").strip()
+            stderr_text = stderr.decode("utf-8", errors="replace").strip()
+
             # Read the response file if it exists
             if response_file.exists():
                 output = response_file.read_text().strip()
-                logger.info(
-                    f"Subagent response ({len(output)} chars): {output[:200]}..."
-                )
+                if output:
+                    logger.info(
+                        f"Subagent response ({len(output)} chars): {output[:200]}..."
+                    )
+                else:
+                    output = stdout_text
+                    logger.warning(
+                        "Subagent wrote an empty response file, using stdout"
+                    )
             else:
                 # Fall back to stdout if no response file was written
-                output = stdout.decode("utf-8", errors="replace").strip()
+                output = stdout_text
                 logger.warning("Subagent did not write response file, using stdout")
 
-            error = stderr.decode("utf-8", errors="replace").strip()
+            error = self._extract_error_text(stdout_text, stderr_text, output)
 
             # Truncate long output
             if len(output) > _MAX_OUTPUT_LEN:

--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -13,12 +13,11 @@ conversation when ready.
 
 import asyncio
 import logging
+import os
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Awaitable, Callable
-
-from .twilio_integration import _get_config_env
 
 logger = logging.getLogger(__name__)
 
@@ -64,21 +63,13 @@ class GptmeToolBridge:
         workspace: str | None = None,
         on_result: Callable[[str], Awaitable[None]] | None = None,
     ):
-        self.gptme_path = _get_config_env("GPTME_VOICE_SUBAGENT_PATH") or gptme_path
+        self.gptme_path = os.environ.get("GPTME_VOICE_SUBAGENT_PATH") or gptme_path
         self.timeout = timeout
         self.workspace = workspace
         self.on_result = on_result
-        shared_model = _get_config_env("GPTME_VOICE_SUBAGENT_MODEL")
-        self.model_fast = (
-            _get_config_env("GPTME_VOICE_SUBAGENT_MODEL_FAST")
-            or shared_model
-            or self.MODEL_FAST
-        )
-        self.model_smart = (
-            _get_config_env("GPTME_VOICE_SUBAGENT_MODEL_SMART")
-            or shared_model
-            or self.MODEL_SMART
-        )
+        env_model = os.environ.get("GPTME_VOICE_SUBAGENT_MODEL")
+        self.model_fast = env_model or self.MODEL_FAST
+        self.model_smart = env_model or self.MODEL_SMART
         self._pending_tasks: dict[str, asyncio.Task] = {}
         self._task_counter = 0
 

--- a/packages/gptme-voice/tests/test_tool_bridge.py
+++ b/packages/gptme-voice/tests/test_tool_bridge.py
@@ -1,0 +1,99 @@
+import asyncio
+
+import pytest
+from gptme_voice.realtime.tool_bridge import GptmeToolBridge
+
+
+class _FakeProcess:
+    def __init__(
+        self,
+        *,
+        returncode: int,
+        stdout: str = "",
+        stderr: str = "",
+    ) -> None:
+        self.returncode = returncode
+        self._stdout = stdout.encode("utf-8")
+        self._stderr = stderr.encode("utf-8")
+        self.killed = False
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        return self._stdout, self._stderr
+
+    def kill(self) -> None:
+        self.killed = True
+
+
+def test_execute_prefers_meaningful_stdout_error_over_tty_warning() -> None:
+    async def _exercise() -> None:
+        bridge = GptmeToolBridge(workspace="/home/bob/bob")
+        stdout = """
+[11:13:00] ERROR    Fatal error occurred
+[11:13:00] ERROR    Error code: 400 - {'type': 'error', 'error': {'type': 'invalid_request_error', 'message': 'You have reached your specified API usage limits. You will regain access on 2026-05-01 at 00:00 UTC.'}}
+""".strip()
+        stderr = "Warning: Input is not a terminal (fd=0)."
+
+        async def _fake_create_subprocess_exec(*_args, **_kwargs):
+            return _FakeProcess(returncode=1, stdout=stdout, stderr=stderr)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+            result = await bridge._execute("Investigate the voice system", mode="smart")
+
+        assert result.success is False
+        assert result.error is not None
+        assert "API usage limits" in result.error
+        assert "Input is not a terminal" not in result.error
+
+    asyncio.run(_exercise())
+
+
+def test_execute_uses_env_override_for_smart_model() -> None:
+    async def _exercise() -> None:
+        captured: dict[str, object] = {}
+
+        async def _fake_create_subprocess_exec(*args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return _FakeProcess(returncode=0)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("GPTME_VOICE_SUBAGENT_MODEL_SMART", "openai-subscription/gpt-5.4")
+            mp.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+            bridge = GptmeToolBridge(workspace="/home/bob/bob")
+            result = await bridge._execute("Inspect recent voice changes", mode="smart")
+
+        assert result.success is True
+        assert tuple(captured["args"])[:7] == (
+            "gptme",
+            "--non-interactive",
+            "--context",
+            "files",
+            "--model",
+            "openai-subscription/gpt-5.4",
+            "--tool-format",
+        )
+        assert tuple(captured["args"])[7] == "tool"
+
+    asyncio.run(_exercise())
+
+
+def test_execute_uses_env_override_for_gptme_path() -> None:
+    async def _exercise() -> None:
+        captured: dict[str, object] = {}
+
+        async def _fake_create_subprocess_exec(*args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return _FakeProcess(returncode=0)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("GPTME_VOICE_SUBAGENT_PATH", "/home/bob/.local/bin/gptme")
+            mp.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+            bridge = GptmeToolBridge(workspace="/home/bob/bob")
+            result = await bridge._execute("Inspect recent voice changes", mode="smart")
+
+        assert result.success is True
+        assert tuple(captured["args"])[0] == "/home/bob/.local/bin/gptme"
+
+    asyncio.run(_exercise())

--- a/packages/gptme-voice/tests/test_tool_bridge.py
+++ b/packages/gptme-voice/tests/test_tool_bridge.py
@@ -26,7 +26,7 @@ class _FakeProcess:
 
 def test_execute_prefers_meaningful_stdout_error_over_tty_warning() -> None:
     async def _exercise() -> None:
-        bridge = GptmeToolBridge(workspace="/home/bob/bob")
+        bridge = GptmeToolBridge(workspace="/fake/workspace")
         stdout = """
 [11:13:00] ERROR    Fatal error occurred
 [11:13:00] ERROR    Error code: 400 - {'type': 'error', 'error': {'type': 'invalid_request_error', 'message': 'You have reached your specified API usage limits. You will regain access on 2026-05-01 at 00:00 UTC.'}}
@@ -58,9 +58,9 @@ def test_execute_uses_env_override_for_smart_model() -> None:
             return _FakeProcess(returncode=0)
 
         with pytest.MonkeyPatch.context() as mp:
-            mp.setenv("GPTME_VOICE_SUBAGENT_MODEL_SMART", "openai-subscription/gpt-5.4")
+            mp.setenv("GPTME_VOICE_SUBAGENT_MODEL", "openai-subscription/gpt-5.4")
             mp.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
-            bridge = GptmeToolBridge(workspace="/home/bob/bob")
+            bridge = GptmeToolBridge(workspace="/fake/workspace")
             result = await bridge._execute("Inspect recent voice changes", mode="smart")
 
         assert result.success is True
@@ -88,12 +88,12 @@ def test_execute_uses_env_override_for_gptme_path() -> None:
             return _FakeProcess(returncode=0)
 
         with pytest.MonkeyPatch.context() as mp:
-            mp.setenv("GPTME_VOICE_SUBAGENT_PATH", "/home/bob/.local/bin/gptme")
+            mp.setenv("GPTME_VOICE_SUBAGENT_PATH", "/fake/bin/gptme")
             mp.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
-            bridge = GptmeToolBridge(workspace="/home/bob/bob")
+            bridge = GptmeToolBridge(workspace="/fake/workspace")
             result = await bridge._execute("Inspect recent voice changes", mode="smart")
 
         assert result.success is True
-        assert tuple(captured["args"])[0] == "/home/bob/.local/bin/gptme"
+        assert tuple(captured["args"])[0] == "/fake/bin/gptme"
 
     asyncio.run(_exercise())


### PR DESCRIPTION
## Summary
Fixes the in-call `gptme-voice` subagent path that was failing during Twilio/Grok calls under Bob's systemd service.

## What changed
- add `GPTME_VOICE_SUBAGENT_PATH` override so the voice server can call a known-good `gptme` binary instead of whatever `uv run` put first on `PATH`
- add `GPTME_VOICE_SUBAGENT_MODEL[_SMART|_FAST]` support so deployments can pin a noninteractive subagent model explicitly
- treat an empty response file as failure-to-write and fall back to stdout
- ignore the harmless `Warning: Input is not a terminal (fd=0).` line when picking the real error message
- add regression tests for error selection, model override, and binary-path override

## Why
Bob's live voice server runs under `uv run gptme-voice-server`, which meant `gptme` resolved to the project venv binary. That build did not support the configured `openai-subscription/gpt-5.4` subagent model, so the bridge failed and then misreported the harmless TTY warning as the root cause.

## Verification
- `uv run pytest packages/gptme-voice/tests -q`
- `uv run ruff check packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py packages/gptme-voice/tests/test_tool_bridge.py`
- live noninteractive repro from inside `uv run python3` succeeds when `GPTME_VOICE_SUBAGENT_PATH=/home/bob/.local/bin/gptme` and `GPTME_VOICE_SUBAGENT_MODEL_SMART=openai-subscription/gpt-5.4`
