### PR TITLE
fix(gptme-voice): clarify subagent rules in voice system prompt

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
@@ -103,12 +103,17 @@ def _load_project_instructions(workspace: str | None = None) -> str:
 
     preamble = (
         "You are in a real-time voice conversation. "
-        "Keep responses concise and conversational. "
-        "IMPORTANT: When asked about your recent activity, tasks, journal entries, "
-        "code changes, or anything factual about your workspace — ALWAYS use the "
-        "subagent tool to look it up. Never guess or hallucinate facts about what "
-        "you've been doing. Only speak from the personality context below for "
-        "identity questions (who you are, your values, etc).\n\n"
+        "Keep responses concise and conversational.\n\n"
+        "SUBAGENT TOOL RULES:\n"
+        "- Use the subagent tool ONLY for small, specific lookups: a single task status, "
+        "a recent journal entry, a quick file check. One focused question per call.\n"
+        "- Do NOT dispatch broad investigation tasks (e.g. 'investigate the whole system', "
+        "'run a full review') — these always time out and leave the call hanging.\n"
+        "- NEVER use the subagent tool to run post-call analysis, summarise the session, "
+        "or queue follow-up work. That is handled automatically by the server after the "
+        "call ends. Just say goodbye naturally — the post-call job fires on its own.\n"
+        "- When asked about recent activity, tasks, journal entries, or workspace facts, "
+        "use the subagent tool to look up the specific thing asked. Never guess.\n\n"
         "Below is your personality and context:\n\n"
     )
     result = preamble + "\n\n---\n\n".join(parts)


### PR DESCRIPTION
## Summary

Two bugs observed in live calls with Erik (2026-04-20):

1. **Post-call confusion**: The voice model dispatched a `subagent` tool call to "run post-call analysis" right after the caller said goodbye. The caller was then confused when the model announced it. Post-call runs automatically after hangup via the server's `GPTME_VOICE_POST_CALL_COMMAND` — the model should never trigger it manually.

2. **Subagent timeout**: The model kept dispatching broad tasks like "investigate the whole voice system thoroughly" which consistently hit the 300s timeout, leaving the conversation in a stuck state while waiting.

**Fix**: Add explicit `SUBAGENT TOOL RULES` section to the voice preamble:
- Only small, specific lookups (one thing at a time)  
- Never broad investigation tasks that will time out
- Never post-call analysis — server fires that automatically on hangup

## Test plan

- [ ] 26 existing tests pass (`uv run --directory packages/gptme-voice pytest tests/ -q`)
- [ ] Next live call: model should not attempt to dispatch post-call subagent after goodbye
- [ ] Next live call: subagent tasks should stay small and not time out