### PR TITLE
fix(gptme-voice): align subagent tool schema with voice rules

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
@@ -231,11 +231,11 @@ class OpenAIRealtimeClient:
                     "name": "subagent",
                     "description": (
                         "Dispatch a task to a gptme subagent running in the workspace. "
-                        "The subagent has full access to tools: shell, file read/write, "
-                        "python, and can reason about multi-step tasks. "
-                        "Use this for anything that requires interacting with the codebase, "
-                        "reading files, checking task status, running commands, searching code, etc. "
-                        "Describe what you want done in natural language."
+                        "Use it only for one small, focused workspace lookup or action: "
+                        "check one task, inspect one file, run one quick command, or verify "
+                        "one recent fact. Do not use it for broad investigations, full "
+                        "reviews, or post-call analysis. Describe one concrete request in "
+                        "natural language."
                     ),
                     "parameters": {
                         "type": "object",

--- a/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
@@ -248,10 +248,10 @@ class OpenAIRealtimeClient:
                                 "type": "string",
                                 "enum": ["smart", "fast"],
                                 "description": (
-                                    "Model quality tradeoff. 'smart' (default) uses the full model "
-                                    "for complex tasks like code analysis, multi-step reasoning, or "
-                                    "writing code. 'fast' uses a smaller model for quick lookups like "
-                                    "reading a file, checking git status, or simple searches."
+                                    "Response urgency. 'fast' uses a smaller model for speed — "
+                                    "prefer this for simple lookups. 'smart' (default) uses a "
+                                    "larger model when accuracy matters. Both are for small, "
+                                    "focused lookups only — never for broad investigations."
                                 ),
                             },
                         },

--- a/packages/gptme-voice/tests/test_openai_client.py
+++ b/packages/gptme-voice/tests/test_openai_client.py
@@ -1,0 +1,56 @@
+import asyncio
+import json
+
+import pytest
+from gptme_voice.realtime.openai_client import OpenAIRealtimeClient, SessionConfig
+
+
+class _FakeWebSocket:
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+        self.closed = False
+
+    async def send(self, message: str) -> None:
+        self.sent.append(json.loads(message))
+
+    def __aiter__(self) -> "_FakeWebSocket":
+        return self
+
+    async def __anext__(self) -> str:
+        raise StopAsyncIteration
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def test_connect_exposes_subagent_tool_as_focused_lookup_only() -> None:
+    async def _exercise() -> None:
+        fake_ws = _FakeWebSocket()
+
+        async def _fake_connect(*_args, **_kwargs):
+            return fake_ws
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "gptme_voice.realtime.openai_client.websockets.connect", _fake_connect
+            )
+            client = OpenAIRealtimeClient(
+                api_key="test-key",
+                session_config=SessionConfig(instructions="You are Bob."),
+            )
+            await client.connect()
+            await asyncio.sleep(0)
+            await client.disconnect()
+
+        session_update = fake_ws.sent[0]
+        tool = session_update["session"]["tools"][0]
+        description = tool["description"]
+
+        assert session_update["type"] == "session.update"
+        assert tool["name"] == "subagent"
+        assert "small, focused workspace lookup or action" in description
+        assert "broad investigations" in description
+        assert "post-call analysis" in description
+        assert fake_ws.closed is True
+
+    asyncio.run(_exercise())


### PR DESCRIPTION
Follow-up to #702.

Greptile was right about one remaining mismatch: the runtime prompt now restricts the `subagent` tool to small, focused lookups, but the tool schema still described it as a general-purpose codebase investigation tool.

This patch makes the schema match the new voice rules and adds a focused test that inspects the emitted `session.update` payload so the description can't silently drift again.

## Verification
- `uv run pytest packages/gptme-voice/tests/test_openai_client.py packages/gptme-voice/tests/test_xai_client.py -q`
- `uv run pytest packages/gptme-voice/tests/test_tool_bridge.py -q`
- `uv run ruff check packages/gptme-voice/src/gptme_voice/realtime/openai_client.py packages/gptme-voice/tests/test_openai_client.py`