### PR TITLE
feat(gptme-voice): add hangup tool for clean call termination

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
@@ -257,7 +257,29 @@ class OpenAIRealtimeClient:
                         },
                         "required": ["task"],
                     },
-                }
+                },
+                {
+                    "type": "function",
+                    "name": "hangup",
+                    "description": (
+                        "End the current voice call cleanly. Use this only when the caller "
+                        "has clearly said goodbye or explicitly asked to hang up. Do not use "
+                        "this to interrupt ongoing work or avoid a question. "
+                        "Say a brief farewell first; the call will terminate shortly after."
+                    ),
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "reason": {
+                                "type": "string",
+                                "description": (
+                                    "Short free-form reason for hanging up "
+                                    "(e.g. 'caller said goodbye'). Optional."
+                                ),
+                            },
+                        },
+                    },
+                },
             ],
         }
         transcription = self._get_transcription_config()

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -46,6 +46,10 @@ _DEFAULT_RESUME_WINDOW_SECONDS = 300
 _DEFAULT_STATE_DIR = "/tmp/gptme-voice-call-state"
 _MAX_RESUME_TRANSCRIPT_CHARS = 2500
 
+# Delay before actually closing the WebSocket after the model requests hangup,
+# so the goodbye utterance has time to reach the caller.
+_HANGUP_FAREWELL_DELAY_SECONDS = 5.0
+
 
 @dataclass
 class TranscriptTurn:
@@ -555,9 +559,21 @@ class VoiceServer:
                             transcript, "user", text
                         ),
                     )
+                    hangup_ws = websocket
+                    hangup_call_sid = call_sid
+
+                    async def _twilio_hangup(reason: str | None) -> None:
+                        await self._schedule_hangup(
+                            hangup_ws,
+                            source="twilio",
+                            reason=reason,
+                            call_sid=hangup_call_sid,
+                        )
+
                     tool_bridge = GptmeToolBridge(
                         workspace=self.workspace,
                         on_result=realtime_client.inject_message,
+                        on_hangup=_twilio_hangup,
                     )
                     realtime_client.on_function_call = tool_bridge.handle_function_call
 
@@ -652,9 +668,20 @@ class VoiceServer:
                     transcript, "user", text
                 ),
             )
+            local_ws = websocket
+
+            async def _local_hangup(reason: str | None) -> None:
+                await self._schedule_hangup(
+                    local_ws,
+                    source="local",
+                    reason=reason,
+                    call_sid=None,
+                )
+
             tool_bridge = GptmeToolBridge(
                 workspace=self.workspace,
                 on_result=realtime_client.inject_message,
+                on_hangup=_local_hangup,
             )
             realtime_client.on_function_call = tool_bridge.handle_function_call
 
@@ -684,6 +711,38 @@ class VoiceServer:
                 transcript,
                 {"caller_id": caller_id, "provider": self.provider},
             )
+
+    async def _schedule_hangup(
+        self,
+        websocket,
+        *,
+        source: str,
+        reason: str | None,
+        call_sid: str | None,
+    ) -> None:
+        """Close the call-side WebSocket after a short delay.
+
+        Runs from a background task spawned by the tool bridge. The delay lets
+        the model finish its farewell utterance before the socket drops. When
+        the socket closes, the ``handle_*_websocket`` loop exits its
+        ``async for`` and falls through to the ``finally`` block, which runs
+        the normal ``_on_call_end`` teardown (post-call hook, transcript
+        persistence, resume record).
+        """
+        logger.info(
+            "Hangup scheduled: source=%s call_sid=%s reason=%s",
+            source,
+            call_sid,
+            reason or "<none>",
+        )
+        try:
+            await asyncio.sleep(_HANGUP_FAREWELL_DELAY_SECONDS)
+        except asyncio.CancelledError:
+            raise
+        try:
+            await websocket.close()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("Error closing WebSocket during hangup: %s", exc)
 
     async def _send_local_audio(self, websocket, audio_data: bytes):
         """Send audio to local client."""

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -23,6 +23,7 @@ from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
 from starlette.routing import Route, WebSocketRoute
+from starlette.websockets import WebSocketDisconnect
 
 from .audio import AudioConverter
 from .openai_client import (
@@ -596,6 +597,8 @@ class VoiceServer:
                     # Call ended
                     break
 
+        except WebSocketDisconnect:
+            pass  # Normal path when _schedule_hangup closes the WebSocket
         except Exception as e:
             logger.exception("Error handling Twilio connection: %s", e)
         finally:
@@ -700,6 +703,8 @@ class VoiceServer:
                 elif data.get("type") == "commit":
                     await realtime_client.commit_audio()
 
+        except WebSocketDisconnect:
+            pass  # Normal path when _schedule_hangup closes the WebSocket
         except Exception as e:
             logger.exception("Error handling local connection: %s", e)
         finally:

--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -62,11 +62,13 @@ class GptmeToolBridge:
         timeout: int = 300,
         workspace: str | None = None,
         on_result: Callable[[str], Awaitable[None]] | None = None,
+        on_hangup: Callable[[str | None], Awaitable[None]] | None = None,
     ):
         self.gptme_path = os.environ.get("GPTME_VOICE_SUBAGENT_PATH") or gptme_path
         self.timeout = timeout
         self.workspace = workspace
         self.on_result = on_result
+        self.on_hangup = on_hangup
         env_model = os.environ.get("GPTME_VOICE_SUBAGENT_MODEL")
         self.model_fast = env_model or self.MODEL_FAST
         self.model_smart = env_model or self.MODEL_SMART
@@ -233,6 +235,25 @@ class GptmeToolBridge:
                 "status": "dispatched",
                 "task_id": task_id,
                 "message": f"Working on it: {task}",
+            }
+
+        if name == "hangup":
+            reason = arguments.get("reason") or None
+            logger.info("Hangup requested (reason=%s)", reason or "<none>")
+            if self.on_hangup is None:
+                return {
+                    "status": "not_supported",
+                    "message": (
+                        "Hang-up is not wired up on this server; "
+                        "the call will end when the caller hangs up."
+                    ),
+                }
+            # Fire the teardown in the background so the model still gets a
+            # synchronous function-call response and can finish speaking.
+            asyncio.create_task(self.on_hangup(reason))
+            return {
+                "status": "hanging_up",
+                "message": "Ending the call shortly.",
             }
 
         return {"error": f"Unknown function: {name}"}

--- a/packages/gptme-voice/tests/test_tool_bridge.py
+++ b/packages/gptme-voice/tests/test_tool_bridge.py
@@ -203,3 +203,104 @@ def test_execute_reports_timeout() -> None:
         assert "timed out" in result.error.lower()
 
     asyncio.run(_exercise())
+
+
+def test_handle_function_call_hangup_fires_callback_when_wired() -> None:
+    """hangup triggers on_hangup callback with optional reason."""
+
+    async def _exercise() -> None:
+        captured: dict[str, object] = {"calls": []}
+
+        async def _on_hangup(reason: str | None) -> None:
+            captured["calls"].append(reason)  # type: ignore[attr-defined]
+
+        bridge = GptmeToolBridge(workspace="/fake/workspace", on_hangup=_on_hangup)
+        result = await bridge.handle_function_call(
+            "hangup", {"reason": "caller said goodbye"}
+        )
+
+        assert result["status"] == "hanging_up"
+        # Give the background task a tick to run
+        await asyncio.sleep(0)
+        assert captured["calls"] == ["caller said goodbye"]
+
+    asyncio.run(_exercise())
+
+
+def test_handle_function_call_hangup_without_reason() -> None:
+    """hangup works when arguments is empty (reason is optional)."""
+
+    async def _exercise() -> None:
+        captured: dict[str, object] = {"calls": []}
+
+        async def _on_hangup(reason: str | None) -> None:
+            captured["calls"].append(reason)  # type: ignore[attr-defined]
+
+        bridge = GptmeToolBridge(workspace="/fake/workspace", on_hangup=_on_hangup)
+        result = await bridge.handle_function_call("hangup", {})
+
+        assert result["status"] == "hanging_up"
+        await asyncio.sleep(0)
+        assert captured["calls"] == [None]
+
+    asyncio.run(_exercise())
+
+
+def test_handle_function_call_hangup_returns_not_supported_without_callback() -> None:
+    """hangup returns not_supported when server has no on_hangup wired."""
+
+    async def _exercise() -> None:
+        bridge = GptmeToolBridge(workspace="/fake/workspace")  # no on_hangup
+        result = await bridge.handle_function_call("hangup", {})
+        assert result["status"] == "not_supported"
+        assert "message" in result
+
+    asyncio.run(_exercise())
+
+
+def test_handle_function_call_subagent_still_works_alongside_hangup() -> None:
+    """Adding hangup support does not regress subagent dispatch."""
+
+    async def _exercise() -> None:
+        async def _on_hangup(reason: str | None) -> None:  # pragma: no cover
+            return None
+
+        bridge = GptmeToolBridge(workspace="/fake/workspace", on_hangup=_on_hangup)
+
+        async def _fake_create_subprocess_exec(*_args, **_kwargs):
+            return _FakeProcess(returncode=0, stdout="ok")
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+            result = await bridge.handle_function_call(
+                "subagent", {"task": "check something"}
+            )
+
+        assert result["status"] == "dispatched"
+        assert "task_id" in result
+
+    asyncio.run(_exercise())
+
+
+def test_handle_function_call_unknown_name_returns_error() -> None:
+    async def _exercise() -> None:
+        bridge = GptmeToolBridge(workspace="/fake/workspace")
+        result = await bridge.handle_function_call("not_a_tool", {})
+        assert "error" in result
+
+    asyncio.run(_exercise())
+
+
+def test_hangup_tool_advertised_in_openai_session_config() -> None:
+    """Ensure the hangup tool is present in the OpenAI session tools list
+    so the model can actually discover and call it.
+    """
+    import inspect
+
+    from gptme_voice.realtime import openai_client
+
+    source = inspect.getsource(openai_client.OpenAIRealtimeClient.connect)
+    assert (
+        '"name": "hangup"' in source
+    ), "hangup tool must be declared in OpenAIRealtimeClient.connect() tools list"
+    assert '"name": "subagent"' in source, "subagent tool must also still be declared"


### PR DESCRIPTION
## Summary

Adds a real `hangup` tool to gptme-voice so the model can end a call explicitly after farewell instead of only *saying* it will.

Evidence: call record `342ca8d9` where Erik said "I don't think you actually have a hang up tool." The model could say goodbye but had no way to actually terminate the connection.

## How it works

- **openai_client.py** — declares `hangup` in the session `tools` list with an optional `reason: string` parameter.
- **tool_bridge.py** — routes the call via a new optional `on_hangup: Callable[[str | None], Awaitable[None]] | None` callback. Returns `{"status": "not_supported", ...}` when unwired instead of silently failing.
- **server.py** — wires closures for both Twilio and local WebSocket handlers. `_schedule_hangup` sleeps 5s (so the goodbye utterance reaches the caller) then closes the WebSocket. The existing `finally` block in `handle_*_websocket` already runs `_on_call_end`, so no new teardown logic is needed — closing the socket is enough.

## Test plan

- [x] `uv run pytest packages/gptme-voice/tests/test_tool_bridge.py` — 17/17 pass (11 existing + 6 new)
- [x] `uv run pytest packages/gptme-voice/tests/` — 40/40 pass
- [x] pre-commit/prek green (typecheck, ruff, ruff-format)
- [ ] Live call regression test: model says goodbye, then actually hangs up after ~5s
- [ ] Verify `_on_call_end` fires from hangup-triggered close (post-call cleanup still runs)

New tests:
- `test_handle_function_call_hangup_fires_callback_when_wired` — callback receives reason
- `test_handle_function_call_hangup_without_reason` — missing reason → `None`
- `test_handle_function_call_hangup_returns_not_supported_without_callback` — graceful fallback
- `test_handle_function_call_subagent_still_works_alongside_hangup` — no regression
- `test_handle_function_call_unknown_name_returns_error`
- `test_hangup_tool_advertised_in_openai_session_config` — inspects `OpenAIRealtimeClient.connect` source to verify the tool is declared

Closes task: `gptme-voice-call-hangup-tool`
Related: ErikBjare/bob#651