### PR TITLE
fix(gptme-voice): guard against in-call claims of post-call dispatch

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
@@ -114,6 +114,15 @@ def _load_project_instructions(workspace: str | None = None) -> str:
         "call ends. Just say goodbye naturally — the post-call job fires on its own.\n"
         "- When asked about recent activity, tasks, journal entries, or workspace facts, "
         "use the subagent tool to look up the specific thing asked. Never guess.\n\n"
+        "POST-CALL FOLLOW-UP:\n"
+        "- Post-call analysis and follow-up run automatically after the call ends. "
+        "They are triggered by the server on hangup, not by you.\n"
+        "- Do NOT claim, announce, or imply that you have dispatched, started, or queued "
+        "post-call work during the live call, even verbally without a tool call. "
+        "Saying 'post-call analysis dispatched' inside a call is wrong — it has not "
+        "happened yet and you are not the one who starts it.\n"
+        "- It is fine to acknowledge that follow-up will happen automatically after "
+        "hangup if the user asks. Just do not take credit for dispatching it.\n\n"
         "Below is your personality and context:\n\n"
     )
     result = preamble + "\n\n---\n\n".join(parts)

--- a/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
@@ -98,9 +98,8 @@ def _load_project_instructions(workspace: str | None = None) -> str:
         if total > _MAX_INSTRUCTIONS_LEN:
             break
 
-    if not parts:
-        return _DEFAULT_INSTRUCTIONS
-
+    # Build guards preamble — always applied regardless of personality files so
+    # behavioral constraints are never silently absent for a live-call session.
     preamble = (
         "You are in a real-time voice conversation. "
         "Keep responses concise and conversational.\n\n"
@@ -123,9 +122,16 @@ def _load_project_instructions(workspace: str | None = None) -> str:
         "happened yet and you are not the one who starts it.\n"
         "- It is fine to acknowledge that follow-up will happen automatically after "
         "hangup if the user asks. Just do not take credit for dispatching it.\n\n"
-        "Below is your personality and context:\n\n"
     )
-    result = preamble + "\n\n---\n\n".join(parts)
+
+    if not parts:
+        return preamble  # guards still apply even with no personality files
+
+    result = (
+        preamble
+        + "Below is your personality and context:\n\n"
+        + "\n\n---\n\n".join(parts)
+    )
 
     # Truncate if still too long
     if len(result) > _MAX_INSTRUCTIONS_LEN:

--- a/packages/gptme-voice/tests/test_openai_client.py
+++ b/packages/gptme-voice/tests/test_openai_client.py
@@ -1,8 +1,13 @@
 import asyncio
 import json
+from pathlib import Path
 
 import pytest
-from gptme_voice.realtime.openai_client import OpenAIRealtimeClient, SessionConfig
+from gptme_voice.realtime.openai_client import (
+    OpenAIRealtimeClient,
+    SessionConfig,
+    _load_project_instructions,
+)
 
 
 class _FakeWebSocket:
@@ -54,3 +59,29 @@ def test_connect_exposes_subagent_tool_as_focused_lookup_only() -> None:
         assert fake_ws.closed is True
 
     asyncio.run(_exercise())
+
+
+def test_load_project_instructions_includes_post_call_follow_up_guard(
+    tmp_path: Path,
+) -> None:
+    """Preamble must tell the live-call model not to claim post-call dispatch itself."""
+    (tmp_path / "gptme.toml").write_text(
+        '[prompt]\nfiles = ["ABOUT.md"]\n',
+    )
+    (tmp_path / "ABOUT.md").write_text("# ABOUT\nYou are Bob.\n")
+
+    instructions = _load_project_instructions(str(tmp_path))
+
+    # The preamble was applied (sanity — otherwise we'd get _DEFAULT_INSTRUCTIONS).
+    assert "real-time voice conversation" in instructions
+
+    # The new POST-CALL FOLLOW-UP section exists.
+    assert "POST-CALL FOLLOW-UP:" in instructions
+
+    # The core behavioral constraint from the 2026-04-20 call is present:
+    # do not verbally claim to have dispatched post-call work during the call.
+    assert "Do NOT claim, announce, or imply that you have dispatched" in instructions
+    assert "post-call analysis dispatched" in instructions
+
+    # Acknowledging automatic post-call follow-up is still allowed.
+    assert "happen automatically after" in instructions

--- a/packages/gptme-voice/tests/test_openai_client.py
+++ b/packages/gptme-voice/tests/test_openai_client.py
@@ -85,3 +85,23 @@ def test_load_project_instructions_includes_post_call_follow_up_guard(
 
     # Acknowledging automatic post-call follow-up is still allowed.
     assert "happen automatically after" in instructions
+
+
+def test_load_project_instructions_guards_present_without_personality_files(
+    tmp_path: Path,
+) -> None:
+    """Guards must apply even when a workspace has no matching personality files."""
+    # Config exists but references a file that doesn't exist — no parts loaded.
+    (tmp_path / "gptme.toml").write_text(
+        '[prompt]\nfiles = ["MISSING.md"]\n',
+    )
+
+    instructions = _load_project_instructions(str(tmp_path))
+
+    # Should NOT fall back to the bare _DEFAULT_INSTRUCTIONS.
+    assert "You are a helpful assistant" not in instructions
+
+    # Behavioral guards must still be present.
+    assert "real-time voice conversation" in instructions
+    assert "POST-CALL FOLLOW-UP:" in instructions
+    assert "Do NOT claim, announce, or imply that you have dispatched" in instructions


### PR DESCRIPTION
## Summary

The 2026-04-20 Twilio/Grok call transcript showed the model saying `Post-call analysis dispatched too` during the live call, even though the post-call job is only fired by the server after hangup. The prior subagent-tool rule (#702) prevented subagent-based dispatch, but not the verbal claim itself — the model never called a tool, it just announced that it had "dispatched" the work.

Evidence: `state/voice-calls/342ca8d9b8efb180.json` and the follow-up task `tasks/gptme-voice-in-call-post-call-dispatch-guard.md`.

## Changes

- `openai_client.py`: add a `POST-CALL FOLLOW-UP` section to the voice preamble that:
  - states post-call is triggered by the server on hangup, not by the model,
  - forbids claiming, announcing, or implying in-call dispatch (even without a tool call),
  - still allows acknowledging that automatic follow-up will happen after hangup.
- `tests/test_openai_client.py`: extend with a test that asserts the new section and the key `Do NOT claim, announce, or imply that you have dispatched` phrasing appear in the emitted instructions once a project config is loaded.

## Stacks on #703

This branch is based on `fix/gptme-voice-subagent-tool-schema` (PR #703), so it includes the schema-alignment change. Once #703 merges, this becomes a tiny diff on top of master.

## Test plan

- [x] `uv run pytest packages/gptme-voice/tests/test_openai_client.py -v` — 2 passed
- [x] `uv run pytest packages/gptme-voice/tests/ -q` — 36 passed
- [x] `uv run ruff check packages/gptme-voice/src/gptme_voice/realtime/openai_client.py packages/gptme-voice/tests/test_openai_client.py` — All checks passed
- [x] `prek` pre-commit hooks — pass (ruff-format reformatted multi-line assert, auto-staged)