### PR TITLE
fix(gptme-voice): buffer audio until session.created to prevent silent calls

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
@@ -33,6 +33,12 @@ _PERSONALITY_FILES = ["ABOUT.md", "README.md"]
 # Max chars for instructions (realtime API has limits)
 _MAX_INSTRUCTIONS_LEN = 4096
 
+# Max audio chunks to buffer before session.created arrives. Twilio sends
+# media frames every 20ms (50/sec), so 500 chunks ≈ 10s of audio — more
+# than enough for any realistic session-handshake delay while still capping
+# memory growth if the provider never confirms the session.
+_MAX_PENDING_AUDIO_CHUNKS = 500
+
 
 def _detect_agent_repo() -> str | None:
     """Auto-detect the agent repo root.
@@ -204,6 +210,14 @@ class OpenAIRealtimeClient:
         self._receive_task: asyncio.Task | None = None
         self._responding = False  # True while AI is generating a response
 
+        # Audio arriving before `session.created` would be forwarded to a session
+        # that does not exist yet, causing silent calls (observed on cold starts
+        # and cold reconnects). Buffer early audio and flush on session ready.
+        # Cap buffer size so a never-arriving session.created cannot leak memory.
+        self._session_ready: asyncio.Event | None = None
+        self._pending_audio: list[bytes] = []
+        self._pending_audio_dropped = 0
+
     def _get_ws_url(self) -> str:
         """WebSocket URL for this provider (override in subclasses)."""
         return f"{self.WS_URL}?model={self.session_config.model}"
@@ -221,6 +235,12 @@ class OpenAIRealtimeClient:
 
     async def connect(self) -> None:
         """Connect to OpenAI Realtime API."""
+        # Initialize session-ready gate inside the event loop that will drive
+        # this connection. Allows the client to be re-connected after disconnect.
+        self._session_ready = asyncio.Event()
+        self._pending_audio = []
+        self._pending_audio_dropped = 0
+
         url = self._get_ws_url()
         headers = self._get_ws_headers()
         self._ws = await websockets.connect(url, additional_headers=headers)
@@ -351,9 +371,50 @@ class OpenAIRealtimeClient:
         Audio is always forwarded so the server-side VAD can detect
         speech interruptions. Feedback loop prevention (speaker output
         being picked up by mic) is handled client-side.
+
+        Audio that arrives before the provider has confirmed the session
+        (``session.created``) is buffered and flushed once the session is
+        ready. This prevents silent calls on cold starts / fast reconnects
+        where Twilio's first media frames race ahead of the provider's
+        session handshake.
         """
+        if self._session_ready is None or not self._session_ready.is_set():
+            # Session not confirmed yet — buffer the chunk, bounded so a
+            # never-arriving session.created cannot leak memory.
+            if len(self._pending_audio) < _MAX_PENDING_AUDIO_CHUNKS:
+                self._pending_audio.append(pcm_data)
+            else:
+                self._pending_audio_dropped += 1
+                if self._pending_audio_dropped == 1:
+                    logger.warning(
+                        "Dropping pre-session audio (buffer full at %d chunks) — "
+                        "session.created may be delayed",
+                        _MAX_PENDING_AUDIO_CHUNKS,
+                    )
+            return
+
         audio_b64 = base64.b64encode(pcm_data).decode("utf-8")
         await self._send_event("input_audio_buffer.append", {"audio": audio_b64})
+
+    async def _flush_pending_audio(self) -> None:
+        """Send any audio that was buffered before ``session.created`` arrived."""
+        if not self._pending_audio:
+            return
+        chunks = self._pending_audio
+        self._pending_audio = []
+        logger.info(
+            "Flushing %d buffered audio chunk(s) after session.created",
+            len(chunks),
+        )
+        for pcm_data in chunks:
+            audio_b64 = base64.b64encode(pcm_data).decode("utf-8")
+            await self._send_event("input_audio_buffer.append", {"audio": audio_b64})
+        if self._pending_audio_dropped:
+            logger.warning(
+                "Dropped %d pre-session audio chunk(s) before flush",
+                self._pending_audio_dropped,
+            )
+            self._pending_audio_dropped = 0
 
     async def commit_audio(self) -> None:
         """Commit the audio buffer for processing."""
@@ -435,6 +496,11 @@ class OpenAIRealtimeClient:
         # Session events
         elif event_type == "session.created":
             logger.info("Session created")
+            # Provider has confirmed the session — safe to forward audio.
+            # Flush any audio buffered during the handshake race window.
+            if self._session_ready is not None:
+                self._session_ready.set()
+            await self._flush_pending_audio()
         elif event_type == "session.updated":
             logger.info("Session configured")
 

--- a/packages/gptme-voice/tests/test_openai_client.py
+++ b/packages/gptme-voice/tests/test_openai_client.py
@@ -1,9 +1,11 @@
 import asyncio
+import base64
 import json
 from pathlib import Path
 
 import pytest
 from gptme_voice.realtime.openai_client import (
+    _MAX_PENDING_AUDIO_CHUNKS,
     OpenAIRealtimeClient,
     SessionConfig,
     _load_project_instructions,
@@ -85,6 +87,95 @@ def test_load_project_instructions_includes_post_call_follow_up_guard(
 
     # Acknowledging automatic post-call follow-up is still allowed.
     assert "happen automatically after" in instructions
+
+
+def test_send_audio_buffers_until_session_created() -> None:
+    """Audio arriving before session.created must be buffered, not forwarded.
+
+    Regression for silent-call-on-startup: Twilio media frames can arrive
+    before the provider confirms the session with ``session.created``. Sending
+    audio before then is a no-op on the provider side — the caller hears
+    silence because Grok has not started listening.
+    """
+
+    async def _exercise() -> None:
+        fake_ws = _FakeWebSocket()
+
+        async def _fake_connect(*_args, **_kwargs):
+            return fake_ws
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "gptme_voice.realtime.openai_client.websockets.connect", _fake_connect
+            )
+            client = OpenAIRealtimeClient(api_key="test-key")
+            await client.connect()
+
+            # connect() sends session.update; everything after index 0 is
+            # what send_audio / flush produced.
+            assert fake_ws.sent[0]["type"] == "session.update"
+            baseline = len(fake_ws.sent)
+
+            # Audio before session.created must be buffered, not sent.
+            await client.send_audio(b"\x01\x02\x03")
+            await client.send_audio(b"\x04\x05\x06")
+            assert len(fake_ws.sent) == baseline
+            assert len(client._pending_audio) == 2
+
+            # Simulate provider confirming the session — the flush should
+            # replay buffered chunks in order.
+            await client._handle_event({"type": "session.created"})
+
+            assert client._session_ready is not None
+            assert client._session_ready.is_set()
+            assert client._pending_audio == []
+
+            appends = [
+                e for e in fake_ws.sent if e.get("type") == "input_audio_buffer.append"
+            ]
+            assert len(appends) == 2
+            assert base64.b64decode(appends[0]["audio"]) == b"\x01\x02\x03"
+            assert base64.b64decode(appends[1]["audio"]) == b"\x04\x05\x06"
+
+            # After ready, send_audio goes straight through.
+            await client.send_audio(b"\x07\x08")
+            appends = [
+                e for e in fake_ws.sent if e.get("type") == "input_audio_buffer.append"
+            ]
+            assert len(appends) == 3
+            assert base64.b64decode(appends[2]["audio"]) == b"\x07\x08"
+
+            await client.disconnect()
+
+    asyncio.run(_exercise())
+
+
+def test_send_audio_buffer_is_bounded() -> None:
+    """Buffer must be capped so a never-arriving session.created cannot leak memory."""
+
+    async def _exercise() -> None:
+        fake_ws = _FakeWebSocket()
+
+        async def _fake_connect(*_args, **_kwargs):
+            return fake_ws
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "gptme_voice.realtime.openai_client.websockets.connect", _fake_connect
+            )
+            client = OpenAIRealtimeClient(api_key="test-key")
+            await client.connect()
+
+            # Fill the buffer to capacity plus 3 overflow chunks.
+            for i in range(_MAX_PENDING_AUDIO_CHUNKS + 3):
+                await client.send_audio(bytes([i % 256]))
+
+            assert len(client._pending_audio) == _MAX_PENDING_AUDIO_CHUNKS
+            assert client._pending_audio_dropped == 3
+
+            await client.disconnect()
+
+    asyncio.run(_exercise())
 
 
 def test_load_project_instructions_guards_present_without_personality_files(


### PR DESCRIPTION
## Summary

- Buffer incoming audio in `OpenAIRealtimeClient.send_audio()` until the provider returns `session.created`, then flush the buffer in order. Fixes silent-call-on-startup where callers heard nothing on cold starts / cold reconnects.
- Cap the buffer at 500 chunks (~10s of 50Hz Twilio frames) so a never-arriving `session.created` cannot leak memory; overflow increments a drop counter and logs once.
- Re-init the gate + buffer in `connect()` so the client can be reconnected cleanly after `disconnect()`.

## Why

`session.update` is sent immediately on WebSocket connect, but `session.created` comes back asynchronously. Twilio media frames (~20ms apart) start streaming as soon as the call is answered, so audio was being forwarded to a session that didn't exist yet. Observed twice on 2026-04-20 (11:43 + 12:15 UTC) — callers connected, Bob received nothing, silence until the call was hung up.

The fix is a small `asyncio.Event` gate + bounded buffer around `send_audio()`:
- Pre-`session.created`: buffer the PCM chunk (up to cap).
- On `session.created`: flush buffered chunks, then direct-forward.

Because `XAIRealtimeClient` inherits from `OpenAIRealtimeClient`, Grok/Twilio callers get the fix automatically.

## Test plan

- [x] Added `test_send_audio_buffers_until_session_created` — verifies pre-ready buffering, ordered flush on `session.created`, and direct-forwarding after.
- [x] Added `test_send_audio_buffer_is_bounded` — verifies cap at `_MAX_PENDING_AUDIO_CHUNKS` with overflow tracked via `_pending_audio_dropped`.
- [x] `pytest packages/gptme-voice/tests/test_openai_client.py -v` — 5/5 pass.
- [ ] Manual: next inbound call over Twilio should no longer go silent on cold start (will validate on merge).

Refs: ErikBjare/bob#651, task `gptme-voice-silent-call-on-startup`