### PR TITLE
fix(gptme-voice): treat session.updated as ready signal for xAI provider

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/xai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/xai_client.py
@@ -9,10 +9,13 @@ See: https://docs.x.ai/developers/model-capabilities/audio/voice-agent
 """
 
 import dataclasses
+import logging
 
 from gptme.config import get_config
 
 from .openai_client import OpenAIRealtimeClient, SessionConfig
+
+logger = logging.getLogger(__name__)
 
 _OPENAI_DEFAULT_VOICE = "echo"
 # "rex" = male, confident, clear — matches the Bob persona better than "eve" (female)
@@ -78,3 +81,18 @@ class XAIRealtimeClient(OpenAIRealtimeClient):
     def _get_transcription_config(self) -> dict | None:
         """xAI does not support whisper-1; omit transcription config."""
         return None
+
+    async def _handle_event(self, event: dict) -> None:
+        """xAI does not emit session.created — treat session.updated as the ready signal."""
+        await super()._handle_event(event)
+        # xAI sends session.updated but not session.created. If _session_ready is
+        # still unset after session.updated arrives, mark it ready and flush buffered
+        # audio so Twilio audio doesn't sit in the pre-session buffer forever.
+        if (
+            event.get("type") == "session.updated"
+            and self._session_ready is not None
+            and not self._session_ready.is_set()
+        ):
+            logger.info("xAI session.updated received — marking session ready")
+            self._session_ready.set()
+            await self._flush_pending_audio()


### PR DESCRIPTION
## Root cause

xAI's Grok Realtime API does **not** emit `session.created` on connection open, unlike OpenAI which sends it immediately. The #707 audio-buffering fix correctly buffers Twilio audio until `session.created` arrives — but for xAI that event never comes, so `_session_ready` stays unset and all audio sits in the 500-chunk pre-session buffer until it fills, after which incoming audio is silently dropped. The call sounds silent to the caller.

Evidence from service logs:
```
15:26:31 openai_client INFO: Session configured       # session.updated received ✓
# "Session created" never logged                      # session.created not emitted by xAI ✗
15:26:40 openai_client WARNING: Dropping pre-session audio (buffer full at 500 chunks)
15:26:49 INFO: connection closed
```

## Fix

Override `_handle_event` in `XAIRealtimeClient` to also set `_session_ready` and flush buffered audio when `session.updated` arrives, if `session.created` hasn't fired first. This is safe for both cases:
- If xAI does later send `session.created`, the event is already set — the base handler skips the flush (no-op)
- If xAI never sends `session.created` (current behaviour), this correctly unblocks buffered audio

## Test plan

- [x] All 48 existing tests pass
- [ ] Next call from Erik should produce audio response (no silent call)