### PR TITLE
fix(gptme-voice): honor session.updated as a ready signal

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
@@ -373,14 +373,13 @@ class OpenAIRealtimeClient:
         being picked up by mic) is handled client-side.
 
         Audio that arrives before the provider has confirmed the session
-        (``session.created``) is buffered and flushed once the session is
-        ready. This prevents silent calls on cold starts / fast reconnects
-        where Twilio's first media frames race ahead of the provider's
-        session handshake.
+        is buffered and flushed once the session is ready. This prevents
+        silent calls on cold starts / fast reconnects where Twilio's first
+        media frames race ahead of the provider's session handshake.
         """
         if self._session_ready is None or not self._session_ready.is_set():
             # Session not confirmed yet — buffer the chunk, bounded so a
-            # never-arriving session.created cannot leak memory.
+            # never-arriving ready signal cannot leak memory.
             if len(self._pending_audio) < _MAX_PENDING_AUDIO_CHUNKS:
                 self._pending_audio.append(pcm_data)
             else:
@@ -388,7 +387,7 @@ class OpenAIRealtimeClient:
                 if self._pending_audio_dropped == 1:
                     logger.warning(
                         "Dropping pre-session audio (buffer full at %d chunks) — "
-                        "session.created may be delayed",
+                        "provider ready signal may be delayed",
                         _MAX_PENDING_AUDIO_CHUNKS,
                     )
             return
@@ -396,14 +395,23 @@ class OpenAIRealtimeClient:
         audio_b64 = base64.b64encode(pcm_data).decode("utf-8")
         await self._send_event("input_audio_buffer.append", {"audio": audio_b64})
 
+    async def _mark_session_ready(self, event_type: str) -> None:
+        """Mark the provider session ready and flush any buffered audio once."""
+        if self._session_ready is None or self._session_ready.is_set():
+            return
+
+        logger.info("%s received — marking session ready", event_type)
+        self._session_ready.set()
+        await self._flush_pending_audio()
+
     async def _flush_pending_audio(self) -> None:
-        """Send any audio that was buffered before ``session.created`` arrived."""
+        """Send any audio that was buffered before the session was ready."""
         if not self._pending_audio:
             return
         chunks = self._pending_audio
         self._pending_audio = []
         logger.info(
-            "Flushing %d buffered audio chunk(s) after session.created",
+            "Flushing %d buffered audio chunk(s) after session ready",
             len(chunks),
         )
         for pcm_data in chunks:
@@ -496,13 +504,10 @@ class OpenAIRealtimeClient:
         # Session events
         elif event_type == "session.created":
             logger.info("Session created")
-            # Provider has confirmed the session — safe to forward audio.
-            # Flush any audio buffered during the handshake race window.
-            if self._session_ready is not None:
-                self._session_ready.set()
-            await self._flush_pending_audio()
+            await self._mark_session_ready(event_type)
         elif event_type == "session.updated":
             logger.info("Session configured")
+            await self._mark_session_ready(event_type)
 
         # Response lifecycle — mute mic while responding
         elif event_type == "response.created":

--- a/packages/gptme-voice/src/gptme_voice/realtime/xai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/xai_client.py
@@ -9,10 +9,13 @@ See: https://docs.x.ai/developers/model-capabilities/audio/voice-agent
 """
 
 import dataclasses
+import logging
 
 from gptme.config import get_config
 
 from .openai_client import OpenAIRealtimeClient, SessionConfig
+
+logger = logging.getLogger(__name__)
 
 _OPENAI_DEFAULT_VOICE = "echo"
 # "rex" = male, confident, clear — matches the Bob persona better than "eve" (female)
@@ -78,3 +81,18 @@ class XAIRealtimeClient(OpenAIRealtimeClient):
     def _get_transcription_config(self) -> dict | None:
         """xAI does not support whisper-1; omit transcription config."""
         return None
+
+    async def _handle_event(self, event: dict) -> None:
+        """xAI does not emit session.created — treat session.updated as the ready signal."""
+        await super()._handle_event(event)
+        # xAI sends session.updated but not session.created. If _session_ready is
+        # still unset after session.updated arrives, mark it ready and flush buffered
+        # audio so Twilio audio doesn't sit in the pre-session buffer forever.
+        if (
+            event.get("type") == "session.updated"
+            and self._session_ready is not None
+            and not self._session_ready.is_set()
+        ):
+            logger.info("xAI session.updated received — marking session ready")
+            self._session_ready.set()
+            await self._flush_pending_audio()

--- a/packages/gptme-voice/src/gptme_voice/realtime/xai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/xai_client.py
@@ -9,13 +9,10 @@ See: https://docs.x.ai/developers/model-capabilities/audio/voice-agent
 """
 
 import dataclasses
-import logging
 
 from gptme.config import get_config
 
 from .openai_client import OpenAIRealtimeClient, SessionConfig
-
-logger = logging.getLogger(__name__)
 
 _OPENAI_DEFAULT_VOICE = "echo"
 # "rex" = male, confident, clear — matches the Bob persona better than "eve" (female)
@@ -81,18 +78,3 @@ class XAIRealtimeClient(OpenAIRealtimeClient):
     def _get_transcription_config(self) -> dict | None:
         """xAI does not support whisper-1; omit transcription config."""
         return None
-
-    async def _handle_event(self, event: dict) -> None:
-        """xAI does not emit session.created — treat session.updated as the ready signal."""
-        await super()._handle_event(event)
-        # xAI sends session.updated but not session.created. If _session_ready is
-        # still unset after session.updated arrives, mark it ready and flush buffered
-        # audio so Twilio audio doesn't sit in the pre-session buffer forever.
-        if (
-            event.get("type") == "session.updated"
-            and self._session_ready is not None
-            and not self._session_ready.is_set()
-        ):
-            logger.info("xAI session.updated received — marking session ready")
-            self._session_ready.set()
-            await self._flush_pending_audio()

--- a/packages/gptme-voice/tests/test_xai_client.py
+++ b/packages/gptme-voice/tests/test_xai_client.py
@@ -1,5 +1,28 @@
+import asyncio
+import base64
+import json
+
+import pytest
 from gptme_voice.realtime.openai_client import SessionConfig
 from gptme_voice.realtime.xai_client import XAIRealtimeClient
+
+
+class _FakeWebSocket:
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+        self.closed = False
+
+    async def send(self, message: str) -> None:
+        self.sent.append(json.loads(message))
+
+    def __aiter__(self) -> "_FakeWebSocket":
+        return self
+
+    async def __anext__(self) -> str:
+        raise StopAsyncIteration
+
+    async def close(self) -> None:
+        self.closed = True
 
 
 def test_xai_client_uses_xai_defaults() -> None:
@@ -7,3 +30,41 @@ def test_xai_client_uses_xai_defaults() -> None:
 
     assert client.session_config.voice == "rex"  # male voice for Bob persona
     assert client._get_ws_url() == "wss://api.x.ai/v1/realtime"
+
+
+def test_xai_client_treats_session_updated_as_ready_signal() -> None:
+    async def _exercise() -> None:
+        fake_ws = _FakeWebSocket()
+
+        async def _fake_connect(*_args, **_kwargs):
+            return fake_ws
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "gptme_voice.realtime.openai_client.websockets.connect", _fake_connect
+            )
+            client = XAIRealtimeClient(
+                api_key="test-key",
+                session_config=SessionConfig(instructions="You are Bob."),
+            )
+            await client.connect()
+
+            await client.send_audio(b"\x01\x02\x03")
+            assert client._session_ready is not None
+            assert not client._session_ready.is_set()
+
+            await client._handle_event({"type": "session.updated"})
+
+            assert client._session_ready.is_set()
+            appends = [
+                event
+                for event in fake_ws.sent
+                if event.get("type") == "input_audio_buffer.append"
+            ]
+            assert len(appends) == 1
+            assert base64.b64decode(appends[0]["audio"]) == b"\x01\x02\x03"
+
+            await client.disconnect()
+            assert fake_ws.closed is True
+
+    asyncio.run(_exercise())


### PR DESCRIPTION
## Summary
- treat `session.updated` as a ready signal in the shared realtime client
- remove the xAI-only override now that the base client handles both ready events
- add regression coverage for the xAI path buffering/flush behavior

## Testing
- `uv run pytest /home/bob/bob/gptme-contrib/packages/gptme-voice/tests -q`

## Context
Live Grok/Twilio logs showed `Session configured` followed by `Dropping pre-session audio`, which meant early audio stayed buffered even after the provider acknowledged the session. This patch makes `session.updated` open the audio gate everywhere.