### PR TITLE
feat(gptme-voice): add subagent_status and subagent_cancel tools

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
@@ -117,11 +117,14 @@ def _load_project_instructions(workspace: str | None = None) -> str:
         "- NEVER use the subagent tool to run post-call analysis, summarise the session, "
         "or queue follow-up work. That is handled automatically by the server after the "
         "call ends. Just say goodbye naturally — the post-call job fires on its own.\n"
-        "- NEVER use the subagent tool to cancel or check the status of another subagent. "
-        "You cannot cancel running subagents. If asked to cancel a task in progress, "
-        "say so honestly: 'I can't cancel it — it will complete on its own'.\n"
         "- When asked about recent activity, tasks, journal entries, or workspace facts, "
         "use the subagent tool to look up the specific thing asked. Never guess.\n\n"
+        "SUBAGENT STATUS AND CANCEL:\n"
+        "- If the caller asks what the subagent is doing, call the subagent_status tool "
+        "to list pending tasks — do not use a fresh subagent dispatch for this.\n"
+        "- If the caller asks to cancel the subagent, call the subagent_cancel tool. "
+        "Pass task_id for a specific task, or omit task_id to cancel all pending tasks.\n"
+        "- Do not promise to 'try to stop it' verbally without calling subagent_cancel.\n\n"
         "POST-CALL FOLLOW-UP:\n"
         "- Post-call analysis and follow-up run automatically after the call ends. "
         "They are triggered by the server on hangup, not by you.\n"
@@ -294,6 +297,44 @@ class OpenAIRealtimeClient:
                             },
                         },
                         "required": ["task"],
+                    },
+                },
+                {
+                    "type": "function",
+                    "name": "subagent_status",
+                    "description": (
+                        "Check which subagent tasks are still running. Use this when "
+                        "the caller asks what the subagent is doing, or before deciding "
+                        "to cancel. Returns each pending task's id, a short preview of "
+                        "the task, the mode, and elapsed seconds."
+                    ),
+                    "parameters": {
+                        "type": "object",
+                        "properties": {},
+                    },
+                },
+                {
+                    "type": "function",
+                    "name": "subagent_cancel",
+                    "description": (
+                        "Cancel a running subagent task. Use this when the caller "
+                        "explicitly asks to stop or cancel the subagent, or when the "
+                        "dispatched task no longer matches what the caller wants. "
+                        "Pass task_id to cancel a specific task, or omit task_id to "
+                        "cancel every pending subagent task."
+                    ),
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "task_id": {
+                                "type": "string",
+                                "description": (
+                                    "Task id to cancel (as returned by subagent or "
+                                    "subagent_status). Omit task_id to cancel every "
+                                    "pending subagent task."
+                                ),
+                            },
+                        },
                     },
                 },
                 {

--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -181,6 +181,9 @@ class GptmeToolBridge:
                     output="",
                     error=f"Subagent timed out after {self.timeout}s",
                 )
+            except asyncio.CancelledError:
+                process.kill()
+                raise
 
             stdout_text = stdout.decode("utf-8", errors="replace").strip()
             stderr_text = stderr.decode("utf-8", errors="replace").strip()

--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -15,11 +15,15 @@ import asyncio
 import logging
 import os
 import tempfile
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Awaitable, Callable
 
 logger = logging.getLogger(__name__)
+
+# Max task-description length to echo back when reporting status
+_MAX_TASK_PREVIEW = 120
 
 # Max output to return (avoid overwhelming the realtime API)
 _MAX_OUTPUT_LEN = 2000
@@ -41,6 +45,16 @@ class ToolResult:
     success: bool
     output: str
     error: str | None = None
+
+
+@dataclass
+class PendingTask:
+    """Metadata for an in-flight subagent dispatch."""
+
+    task: asyncio.Task
+    description: str
+    mode: str
+    started_at: float
 
 
 class GptmeToolBridge:
@@ -72,7 +86,7 @@ class GptmeToolBridge:
         env_model = os.environ.get("GPTME_VOICE_SUBAGENT_MODEL")
         self.model_fast = env_model or self.MODEL_FAST
         self.model_smart = env_model or self.MODEL_SMART
-        self._pending_tasks: dict[str, asyncio.Task] = {}
+        self._pending_tasks: dict[str, PendingTask] = {}
         self._task_counter = 0
 
     @staticmethod
@@ -101,7 +115,16 @@ class GptmeToolBridge:
 
     async def _run_subagent(self, task_id: str, task: str, mode: str = "smart") -> None:
         """Run a subagent in the background and inject result when done."""
-        result = await self._execute(task, mode=mode)
+        try:
+            result = await self._execute(task, mode=mode)
+        except asyncio.CancelledError:
+            logger.info(f"Task {task_id} cancelled")
+            if self.on_result:
+                await self.on_result(
+                    f"Subagent task {task_id} was cancelled before it finished."
+                )
+            self._pending_tasks.pop(task_id, None)
+            raise
 
         if result.success:
             response_text = result.output
@@ -210,6 +233,29 @@ class GptmeToolBridge:
         finally:
             response_file.unlink(missing_ok=True)
 
+    def _describe_pending(self, task_id: str, entry: PendingTask) -> dict:
+        description = entry.description
+        if len(description) > _MAX_TASK_PREVIEW:
+            description = description[:_MAX_TASK_PREVIEW].rstrip() + "..."
+        elapsed = max(0.0, time.monotonic() - entry.started_at)
+        return {
+            "task_id": task_id,
+            "task": description,
+            "mode": entry.mode,
+            "elapsed_seconds": round(elapsed, 1),
+        }
+
+    async def _cancel_task(self, task_id: str, entry: PendingTask) -> dict:
+        entry.task.cancel()
+        try:
+            await entry.task
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:  # noqa: BLE001 - report anything else back
+            logger.warning(f"Task {task_id} raised during cancel: {e}")
+        self._pending_tasks.pop(task_id, None)
+        return {"task_id": task_id, "cancelled": True}
+
     async def handle_function_call(self, name: str, arguments: dict) -> dict:
         """Handle an OpenAI function call.
 
@@ -229,12 +275,66 @@ class GptmeToolBridge:
             task_id = f"task-{self._task_counter}"
 
             bg_task = asyncio.create_task(self._run_subagent(task_id, task, mode=mode))
-            self._pending_tasks[task_id] = bg_task
+            self._pending_tasks[task_id] = PendingTask(
+                task=bg_task,
+                description=task,
+                mode=mode,
+                started_at=time.monotonic(),
+            )
 
             return {
                 "status": "dispatched",
                 "task_id": task_id,
                 "message": f"Working on it: {task}",
+            }
+
+        if name == "subagent_status":
+            pending = [
+                self._describe_pending(tid, entry)
+                for tid, entry in self._pending_tasks.items()
+                if not entry.task.done()
+            ]
+            return {
+                "status": "ok",
+                "pending_count": len(pending),
+                "pending": pending,
+            }
+
+        if name == "subagent_cancel":
+            task_id_arg: str | None = arguments.get("task_id")
+            if task_id_arg:
+                entry = self._pending_tasks.get(task_id_arg)
+                if entry is None or entry.task.done():
+                    return {
+                        "status": "not_found",
+                        "task_id": task_id_arg,
+                        "message": (
+                            f"No pending subagent task with id {task_id_arg}. "
+                            "Use subagent_status to list pending tasks."
+                        ),
+                    }
+                result = await self._cancel_task(task_id_arg, entry)
+                return {"status": "cancelled", **result}
+
+            # No task_id — cancel all pending
+            targets = [
+                (tid, entry)
+                for tid, entry in list(self._pending_tasks.items())
+                if not entry.task.done()
+            ]
+            if not targets:
+                return {
+                    "status": "no_pending",
+                    "message": "No subagent tasks are currently running.",
+                }
+            cancelled = []
+            for tid, entry in targets:
+                result = await self._cancel_task(tid, entry)
+                cancelled.append(result)
+            return {
+                "status": "cancelled_all",
+                "cancelled_count": len(cancelled),
+                "cancelled": cancelled,
             }
 
         if name == "hangup":

--- a/packages/gptme-voice/tests/test_tool_bridge.py
+++ b/packages/gptme-voice/tests/test_tool_bridge.py
@@ -426,6 +426,38 @@ def test_subagent_cancel_specific_task_injects_cancel_notice() -> None:
     asyncio.run(_exercise())
 
 
+def test_execute_kills_process_on_cancel() -> None:
+    """Cancelling a running _execute call must kill the underlying OS process."""
+
+    async def _exercise() -> None:
+        killed: list[bool] = []
+
+        class _SlowProcess(_FakeProcess):
+            async def communicate(self) -> tuple[bytes, bytes]:  # type: ignore[override]
+                await asyncio.sleep(10)
+                return b"", b""
+
+            def kill(self) -> None:
+                killed.append(True)
+
+        async def _fake_create_subprocess_exec(*_args, **_kwargs):
+            return _SlowProcess(returncode=0)
+
+        bridge = GptmeToolBridge(workspace="/fake/workspace", timeout=30)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+            task = asyncio.create_task(bridge._execute("long task", mode="fast"))
+            await asyncio.sleep(0)  # let the task start
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        assert killed, "process.kill() must be called when _execute is cancelled"
+
+    asyncio.run(_exercise())
+
+
 def test_subagent_cancel_all_cancels_every_pending_task() -> None:
     async def _exercise() -> None:
         class _SlowProcess(_FakeProcess):

--- a/packages/gptme-voice/tests/test_tool_bridge.py
+++ b/packages/gptme-voice/tests/test_tool_bridge.py
@@ -304,3 +304,151 @@ def test_hangup_tool_advertised_in_openai_session_config() -> None:
         '"name": "hangup"' in source
     ), "hangup tool must be declared in OpenAIRealtimeClient.connect() tools list"
     assert '"name": "subagent"' in source, "subagent tool must also still be declared"
+    assert (
+        '"name": "subagent_status"' in source
+    ), "subagent_status tool must be declared so the model can check pending tasks"
+    assert (
+        '"name": "subagent_cancel"' in source
+    ), "subagent_cancel tool must be declared so the model can cancel pending tasks"
+
+
+def test_subagent_status_empty_when_no_tasks() -> None:
+    async def _exercise() -> None:
+        bridge = GptmeToolBridge(workspace="/fake/workspace")
+        result = await bridge.handle_function_call("subagent_status", {})
+        assert result["status"] == "ok"
+        assert result["pending_count"] == 0
+        assert result["pending"] == []
+
+    asyncio.run(_exercise())
+
+
+def test_subagent_status_lists_pending_dispatch() -> None:
+    """After dispatching, status should show the task with metadata."""
+
+    async def _exercise() -> None:
+        class _SlowProcess(_FakeProcess):
+            async def communicate(self) -> tuple[bytes, bytes]:  # type: ignore[override]
+                await asyncio.sleep(5)
+                return b"", b""
+
+        async def _fake_create_subprocess_exec(*_args, **_kwargs):
+            return _SlowProcess(returncode=0)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+            bridge = GptmeToolBridge(workspace="/fake/workspace", timeout=10)
+
+            dispatch = await bridge.handle_function_call(
+                "subagent", {"task": "check one thing", "mode": "fast"}
+            )
+            assert dispatch["status"] == "dispatched"
+            task_id = dispatch["task_id"]
+
+            await asyncio.sleep(0)
+
+            status = await bridge.handle_function_call("subagent_status", {})
+            assert status["status"] == "ok"
+            assert status["pending_count"] == 1
+            entry = status["pending"][0]
+            assert entry["task_id"] == task_id
+            assert entry["task"] == "check one thing"
+            assert entry["mode"] == "fast"
+            assert entry["elapsed_seconds"] >= 0
+
+            # Clean up the background task
+            await bridge.handle_function_call("subagent_cancel", {"task_id": task_id})
+
+    asyncio.run(_exercise())
+
+
+def test_subagent_cancel_unknown_task_id_returns_not_found() -> None:
+    async def _exercise() -> None:
+        bridge = GptmeToolBridge(workspace="/fake/workspace")
+        result = await bridge.handle_function_call(
+            "subagent_cancel", {"task_id": "task-999"}
+        )
+        assert result["status"] == "not_found"
+        assert "task-999" in result["message"]
+
+    asyncio.run(_exercise())
+
+
+def test_subagent_cancel_with_no_pending_returns_no_pending() -> None:
+    async def _exercise() -> None:
+        bridge = GptmeToolBridge(workspace="/fake/workspace")
+        result = await bridge.handle_function_call("subagent_cancel", {})
+        assert result["status"] == "no_pending"
+
+    asyncio.run(_exercise())
+
+
+def test_subagent_cancel_specific_task_injects_cancel_notice() -> None:
+    async def _exercise() -> None:
+        class _SlowProcess(_FakeProcess):
+            async def communicate(self) -> tuple[bytes, bytes]:  # type: ignore[override]
+                await asyncio.sleep(5)
+                return b"", b""
+
+        async def _fake_create_subprocess_exec(*_args, **_kwargs):
+            return _SlowProcess(returncode=0)
+
+        injected: list[str] = []
+
+        async def _on_result(text: str) -> None:
+            injected.append(text)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+            bridge = GptmeToolBridge(
+                workspace="/fake/workspace", timeout=10, on_result=_on_result
+            )
+
+            dispatch = await bridge.handle_function_call(
+                "subagent", {"task": "do a thing"}
+            )
+            task_id = dispatch["task_id"]
+            await asyncio.sleep(0)
+
+            result = await bridge.handle_function_call(
+                "subagent_cancel", {"task_id": task_id}
+            )
+            assert result["status"] == "cancelled"
+            assert result["task_id"] == task_id
+            assert result["cancelled"] is True
+
+            status = await bridge.handle_function_call("subagent_status", {})
+            assert status["pending_count"] == 0
+
+            assert injected, "expected on_result to be called with cancel notice"
+            assert "cancelled" in injected[0].lower()
+
+    asyncio.run(_exercise())
+
+
+def test_subagent_cancel_all_cancels_every_pending_task() -> None:
+    async def _exercise() -> None:
+        class _SlowProcess(_FakeProcess):
+            async def communicate(self) -> tuple[bytes, bytes]:  # type: ignore[override]
+                await asyncio.sleep(5)
+                return b"", b""
+
+        async def _fake_create_subprocess_exec(*_args, **_kwargs):
+            return _SlowProcess(returncode=0)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+            bridge = GptmeToolBridge(workspace="/fake/workspace", timeout=10)
+
+            await bridge.handle_function_call("subagent", {"task": "a"})
+            await bridge.handle_function_call("subagent", {"task": "b"})
+            await asyncio.sleep(0)
+
+            result = await bridge.handle_function_call("subagent_cancel", {})
+            assert result["status"] == "cancelled_all"
+            assert result["cancelled_count"] == 2
+
+            status = await bridge.handle_function_call("subagent_status", {})
+            assert status["pending_count"] == 0
+
+    asyncio.run(_exercise())


### PR DESCRIPTION
## Summary

The voice model currently has no way to tell the caller what a running subagent is doing, and no way to stop one. Recent call transcripts show callers asking *"can you cancel the subagent?"* and the model answering *"I can't — it will complete on its own"* even though the dispatch is just an `asyncio.Task` we already hold in `_pending_tasks`.

This PR exposes two new function-call tools to the realtime model:

- **`subagent_status()`** — returns each pending dispatch with `task_id`, a preview of the task description, the mode (`fast`/`smart`), and `elapsed_seconds`.
- **`subagent_cancel(task_id=None)`** — cancels a specific task by id, or (with `task_id` omitted) cancels every pending subagent task. Cancellation injects a short user-facing notice back into the conversation via `on_result` so the caller actually hears that the work stopped.

## Implementation

- `_pending_tasks` now tracks `PendingTask(task, description, mode, started_at)` dataclasses instead of bare `asyncio.Task`s so status responses can report meaningful metadata.
- `_run_subagent` catches `CancelledError`, sends a cancellation notice via `on_result`, cleans up `_pending_tasks`, and re-raises so the awaiter sees cancellation.
- Voice system prompt (`openai_client.py`) drops the now-wrong *"You cannot cancel running subagents"* line and gains a `SUBAGENT STATUS AND CANCEL` section telling the model to call these tools instead of refusing.

## Tests

`packages/gptme-voice/tests/test_tool_bridge.py`:
- `subagent_status` empty / lists pending dispatch with metadata
- `subagent_cancel` with unknown id → `not_found`
- `subagent_cancel` with no pending → `no_pending`
- `subagent_cancel` for specific task → cancels, injects notice, status cleared
- `subagent_cancel` with no args → cancels all pending
- Tool advertisement assertion extended to require `subagent_status` and `subagent_cancel` in `OpenAIRealtimeClient.connect()`

`uv run pytest packages/gptme-voice/tests -q` → **55 passed** (was 47). No new mypy errors over master.

## Test plan

- [x] Unit tests cover status + cancel happy paths and error paths
- [x] Full `gptme-voice` suite green
- [x] Pre-commit (prek) passes
- [ ] After merge: restart `bob-voice-server.service` and verify on next call that asking "what is the subagent doing?" triggers a tool call, and "cancel the subagent" actually cancels