### PR TITLE
fix(gptme-voice): swallow RuntimeError from receive after server-initiated hangup

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -649,6 +649,13 @@ class VoiceServer:
 
         except WebSocketDisconnect:
             pass  # Normal path when _schedule_hangup closes the WebSocket
+        except RuntimeError as exc:
+            # Starlette raises RuntimeError from receive() when the socket is
+            # already closed (e.g. after _schedule_hangup closes server-side).
+            # Treat that as a normal disconnect instead of logging a traceback.
+            if "not connected" not in str(exc).lower():
+                raise
+            logger.debug("Twilio websocket already closed before iter_text: %s", exc)
         except Exception as e:
             logger.exception("Error handling Twilio connection: %s", e)
         finally:
@@ -755,6 +762,13 @@ class VoiceServer:
 
         except WebSocketDisconnect:
             pass  # Normal path when _schedule_hangup closes the WebSocket
+        except RuntimeError as exc:
+            # Starlette raises RuntimeError from receive() when the socket is
+            # already closed (e.g. after _schedule_hangup closes server-side).
+            # Treat that as a normal disconnect instead of logging a traceback.
+            if "not connected" not in str(exc).lower():
+                raise
+            logger.debug("Local websocket already closed before iter_text: %s", exc)
         except Exception as e:
             logger.exception("Error handling local connection: %s", e)
         finally:

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -407,3 +407,64 @@ def test_cancelled_post_call_command_terminates_subprocess() -> None:
                     await asyncio.sleep(0.05)
 
     asyncio.run(_exercise())
+
+
+class _ClosedIterTextWebSocket:
+    """WebSocket stub whose iter_text raises the starlette 'already closed' error.
+
+    Reproduces the condition observed after ``_schedule_hangup`` closes the socket
+    server-side: the next call into ``iter_text`` (which calls ``receive_text``)
+    sees ``application_state != CONNECTED`` and raises ``RuntimeError`` instead of
+    ``WebSocketDisconnect``.
+    """
+
+    def __init__(self, error: RuntimeError) -> None:
+        self._error = error
+        self.accepted = False
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    def iter_text(self):
+        async def _gen():
+            raise self._error
+            yield  # pragma: no cover - generator marker
+
+        return _gen()
+
+    @property
+    def query_params(self) -> dict[str, str]:
+        return {}
+
+
+def test_twilio_handler_swallows_runtimeerror_after_server_close(tmp_path) -> None:
+    """After _schedule_hangup closes the socket, iter_text raises RuntimeError.
+
+    The handler should treat a 'not connected' RuntimeError as a normal
+    disconnect (equivalent to WebSocketDisconnect) instead of logging a
+    traceback. Regression test for the noise observed in production logs:
+    'Error handling Twilio connection: WebSocket is not connected.'
+    """
+    server = VoiceServer()
+    server.state_dir = tmp_path
+    websocket = _ClosedIterTextWebSocket(
+        RuntimeError('WebSocket is not connected. Need to call "accept" first.')
+    )
+
+    # Should not raise — the RuntimeError must be swallowed like WebSocketDisconnect.
+    asyncio.run(server.handle_twilio_websocket(websocket))
+
+    assert websocket.accepted is True
+
+
+def test_twilio_handler_reraises_unrelated_runtimeerror(tmp_path) -> None:
+    """Only the starlette 'not connected' RuntimeError should be swallowed.
+
+    Unrelated RuntimeErrors must still surface so real bugs are not hidden.
+    """
+    server = VoiceServer()
+    server.state_dir = tmp_path
+    websocket = _ClosedIterTextWebSocket(RuntimeError("unexpected failure"))
+
+    with pytest.raises(RuntimeError, match="unexpected failure"):
+        asyncio.run(server.handle_twilio_websocket(websocket))


### PR DESCRIPTION
## Problem

After every successful call that ends via our hangup tool, voice server logs show:

```
ERROR: Error handling Twilio connection: WebSocket is not connected. Need to call "accept" first.
    raise RuntimeError('WebSocket is not connected. Need to call "accept" first.')
RuntimeError: WebSocket is not connected. Need to call "accept" first.
```

Reproduced on a real Twilio call today at 17:53:27 UTC.

## Root cause

`_schedule_hangup` closes the WebSocket server-side after the farewell delay. The `async for message in websocket.iter_text():` loop then calls starlette's `receive_text()`, which raises `RuntimeError('WebSocket is not connected. Need to call "accept" first.')` instead of `WebSocketDisconnect` — starlette checks `application_state != CONNECTED` before reading.

The existing handler catches `WebSocketDisconnect` silently but falls through to the broad `except Exception` clause for this `RuntimeError`, which logs a full traceback at ERROR severity. The hangup succeeded, the farewell played, and the `finally` block ran the normal `_on_call_end` teardown — this was just noise.

## Fix

Treat `RuntimeError` whose message contains `"not connected"` as a normal disconnect (log at debug) in both `handle_twilio_websocket` and `handle_local_websocket`. Any other `RuntimeError` is re-raised so real bugs still surface.

## Tests

Two regression tests in `test_server.py`:
- `test_twilio_handler_swallows_runtimeerror_after_server_close` — verifies the starlette "not connected" RuntimeError is silently handled
- `test_twilio_handler_reraises_unrelated_runtimeerror` — verifies unrelated RuntimeErrors still surface

All 58 gptme-voice tests pass.

## Test plan

- [x] Regression tests pass (`pytest packages/gptme-voice/tests/`)
- [x] Ruff clean
- [ ] Post-merge: confirm no more `Error handling Twilio connection: WebSocket is not connected` entries in voice server journal after a real Twilio call