### PR TITLE
fix(gptme-voice): separate fast and smart subagent models

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -84,9 +84,11 @@ class GptmeToolBridge:
         self.workspace = workspace
         self.on_result = on_result
         self.on_hangup = on_hangup
-        env_model = os.environ.get("GPTME_VOICE_SUBAGENT_MODEL")
-        self.model_fast = env_model or self.MODEL_FAST
-        self.model_smart = env_model or self.MODEL_SMART
+        legacy_env_model = os.environ.get("GPTME_VOICE_SUBAGENT_MODEL")
+        env_model_fast = os.environ.get("GPTME_VOICE_SUBAGENT_MODEL_FAST")
+        env_model_smart = os.environ.get("GPTME_VOICE_SUBAGENT_MODEL_SMART")
+        self.model_fast = env_model_fast or legacy_env_model or self.MODEL_FAST
+        self.model_smart = env_model_smart or legacy_env_model or self.MODEL_SMART
         self._pending_tasks: dict[str, PendingTask] = {}
         self._task_counter = 0
 
@@ -161,14 +163,19 @@ class GptmeToolBridge:
         augmented_task = task + _RESPONSE_SUFFIX.format(response_file=response_file)
 
         model = self.model_fast if mode == "fast" else self.model_smart
-        logger.info(f"Dispatching subagent ({mode}): {task}")
+        logger.info(
+            f"Dispatching subagent ({mode}, model={model or 'default'}): {task}"
+        )
         logger.debug(f"Response file: {response_file}")
 
-        cmd = [self.gptme_path, "--non-interactive"]
-        # Fast mode skips workspace context loading — avoids 20k+ token overhead
-        # that would otherwise add 30-60s latency for simple lookups.
-        if mode != "fast":
-            cmd += ["--context", "files"]
+        cmd = [
+            self.gptme_path,
+            "--non-interactive",
+            "--context",
+            "files",
+        ]
+        # Keep project prompt files but skip context_cmd. This avoids pulling in
+        # scripts/context.sh while still giving the subagent its runtime rules.
         if model:
             cmd += ["--model", model, "--tool-format", "tool"]
         cmd.append(augmented_task)

--- a/packages/gptme-voice/tests/test_tool_bridge.py
+++ b/packages/gptme-voice/tests/test_tool_bridge.py
@@ -68,7 +68,7 @@ def test_execute_prefers_meaningful_stdout_error_over_tty_warning() -> None:
     asyncio.run(_exercise())
 
 
-def test_execute_uses_env_override_for_smart_model() -> None:
+def test_execute_uses_legacy_env_override_for_smart_model() -> None:
     async def _exercise() -> None:
         captured: dict[str, object] = {}
 
@@ -79,6 +79,61 @@ def test_execute_uses_env_override_for_smart_model() -> None:
 
         with pytest.MonkeyPatch.context() as mp:
             mp.setenv("GPTME_VOICE_SUBAGENT_MODEL", "openai-subscription/gpt-5.4")
+            mp.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+            bridge = GptmeToolBridge(workspace="/fake/workspace")
+            result = await bridge._execute("Inspect recent voice changes", mode="smart")
+
+        assert result.success is True
+        assert tuple(captured["args"])[:7] == (
+            "gptme",
+            "--non-interactive",
+            "--context",
+            "files",
+            "--model",
+            "openai-subscription/gpt-5.4",
+            "--tool-format",
+        )
+        assert tuple(captured["args"])[7] == "tool"
+
+    asyncio.run(_exercise())
+
+
+def test_execute_uses_fast_model_override_without_touching_smart() -> None:
+    async def _exercise() -> None:
+        captured: dict[str, object] = {}
+
+        async def _fake_create_subprocess_exec(*args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return _FakeProcess(returncode=0)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("GPTME_VOICE_SUBAGENT_MODEL_FAST", "openai/gpt-5-mini")
+            mp.setenv("GPTME_VOICE_SUBAGENT_MODEL_SMART", "openai-subscription/gpt-5.4")
+            mp.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+            bridge = GptmeToolBridge(workspace="/fake/workspace")
+            result = await bridge._execute("Inspect recent voice changes", mode="fast")
+
+        assert result.success is True
+        assert "--model" in tuple(captured["args"])
+        model_index = tuple(captured["args"]).index("--model") + 1
+        assert tuple(captured["args"])[model_index] == "openai/gpt-5-mini"
+
+    asyncio.run(_exercise())
+
+
+def test_execute_uses_smart_model_override_without_touching_fast() -> None:
+    async def _exercise() -> None:
+        captured: dict[str, object] = {}
+
+        async def _fake_create_subprocess_exec(*args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return _FakeProcess(returncode=0)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("GPTME_VOICE_SUBAGENT_MODEL_FAST", "openai/gpt-5-mini")
+            mp.setenv("GPTME_VOICE_SUBAGENT_MODEL_SMART", "openai-subscription/gpt-5.4")
             mp.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
             bridge = GptmeToolBridge(workspace="/fake/workspace")
             result = await bridge._execute("Inspect recent voice changes", mode="smart")
@@ -119,8 +174,8 @@ def test_execute_uses_env_override_for_gptme_path() -> None:
     asyncio.run(_exercise())
 
 
-def test_execute_fast_mode_skips_context_loading() -> None:
-    """fast mode must NOT pass --context files — that's the main latency source."""
+def test_execute_fast_mode_keeps_context_files() -> None:
+    """fast mode should skip context_cmd without dropping project prompt files."""
 
     async def _exercise() -> None:
         captured: dict[str, object] = {}
@@ -136,8 +191,8 @@ def test_execute_fast_mode_skips_context_loading() -> None:
             await bridge._execute("quick lookup", mode="fast")
 
         args = tuple(captured["args"])
-        assert "--context" not in args, "fast mode must not load workspace context"
-        assert "files" not in args, "fast mode must not load workspace context"
+        assert "--context" in args
+        assert "files" in args
         assert "--non-interactive" in args
 
     asyncio.run(_exercise())

--- a/packages/gptme-voice/tests/test_tool_bridge.py
+++ b/packages/gptme-voice/tests/test_tool_bridge.py
@@ -249,17 +249,18 @@ def test_subagent_status_shows_last_output() -> None:
             )
             task_id = dispatch["task_id"]
 
-            # Allow the stdout reader to consume lines
-            await asyncio.sleep(0)
-            await asyncio.sleep(0)
+            # Allow the stdout reader to consume all lines (needs multiple event loop turns)
+            await output_written.wait()
+            for _ in range(10):
+                await asyncio.sleep(0)
 
             status = await bridge.handle_function_call("subagent_status", {})
             entry = next(
                 (e for e in status["pending"] if e["task_id"] == task_id), None
             )
             assert entry is not None
-            if entry.get("last_output"):
-                assert "Found 3 active tasks" in entry["last_output"]
+            assert entry.get("last_output") is not None
+            assert "Found 3 active tasks" in entry["last_output"]
 
             await bridge.handle_function_call("subagent_cancel", {"task_id": task_id})
 


### PR DESCRIPTION
## Summary

- keep `--context files` for both subagent modes so gptme skips `context_cmd` but still keeps project prompt files
- add `GPTME_VOICE_SUBAGENT_MODEL_FAST` and `GPTME_VOICE_SUBAGENT_MODEL_SMART` overrides so deployments can keep fast lookups on a lighter model without changing smart lookups
- keep the stdout streaming work from #713 so `subagent_status` can expose `last_output` while a task is still running

## Why this follow-up exists

The earlier latency explanation in #713 was wrong.

Measured locally:

- default context (`gptme --non-interactive ...`) in `/home/bob/bob` took about `40.67s`, with `scripts/context.sh` alone taking about `24.67s`
- `--context files` in `/home/bob/bob` took about `16.48s`
- `--context files` in `/tmp` took about `14.24s`

So:

- removing `--context files` would regress latency by re-enabling `context_cmd`
- project prompt files are some overhead, but only a small part of the total in this simple benchmark
- the live deployment problem was that one env var (`GPTME_VOICE_SUBAGENT_MODEL=openai-subscription/gpt-5.4`) forced both `fast` and `smart` onto the smart model

## Test plan

- [x] `uv run pytest packages/gptme-voice/tests/test_tool_bridge.py -q`