### PR TITLE
feat(gptme-sessions): add --model flag to judge (anthropic-direct + gptme.llm routing)

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -943,10 +943,20 @@ def discover(
 @click.option("--grade", is_flag=True, help="Output grade only (float 0.0-1.0)")
 @click.option("--usage", is_flag=True, help="Output token usage breakdown")
 @click.option(
-    "--llm-judge", is_flag=True, help="Run LLM-as-judge scoring (requires anthropic package)"
+    "--llm-judge",
+    is_flag=True,
+    help="Run LLM-as-judge scoring (requires anthropic or gptme package)",
 )
 @click.option("--goals", default=None, help="Agent goals for LLM judge (default: generic)")
 @click.option("--category", "judge_category", default=None, help="Category hint for LLM judge")
+@click.option(
+    "--model",
+    "judge_model",
+    default=None,
+    help="Judge model ID. Anthropic IDs (claude-*, anthropic/*) use the anthropic SDK; "
+    "other provider-prefixed IDs (openrouter/..., openai-subscription/..., lmstudio/...) "
+    "route via gptme.llm.reply.",
+)
 def signals(
     path: Path,
     as_json: bool,
@@ -955,6 +965,7 @@ def signals(
     llm_judge: bool,
     goals: str | None,
     judge_category: str | None,
+    judge_model: str | None,
 ) -> None:
     """Extract productivity signals from a gptme or Claude Code trajectory (.jsonl)."""
     # Validate mutual exclusivity
@@ -983,6 +994,8 @@ def signals(
         judge_kwargs: dict = {}
         if goals:
             judge_kwargs["goals"] = goals
+        if judge_model:
+            judge_kwargs["model"] = judge_model
         verdict = judge_from_signals(
             result,
             category=judge_category,
@@ -991,7 +1004,10 @@ def signals(
         if verdict:
             result["llm_judge"] = verdict
         else:
-            click.echo("LLM judge: unavailable (missing API key or anthropic package)", err=True)
+            click.echo(
+                "LLM judge: unavailable (missing API key, SDK, or judge returned no result)",
+                err=True,
+            )
 
     if grade:
         click.echo(f"{result['grade']:.4f}")
@@ -1236,8 +1252,7 @@ def sync(
             if needs_fix:
                 if dry_run:
                     click.echo(
-                        f"  would fix: {rec.session_id}  "
-                        f"{rec.timestamp[:19]} → {correct_ts[:19]}"
+                        f"  would fix: {rec.session_id}  {rec.timestamp[:19]} → {correct_ts[:19]}"
                     )
                 else:
                     rec.timestamp = correct_ts
@@ -1589,6 +1604,14 @@ def post_session_cmd(
 @click.option("--last", type=int, default=20, help="Score last N sessions (default: 20)")
 @click.option("--goals", default=None, help="Agent goals for LLM judge (default: generic)")
 @click.option(
+    "--model",
+    "judge_model",
+    default=None,
+    help="Judge model ID. Anthropic IDs (claude-*, anthropic/*) use the anthropic SDK; "
+    "other provider-prefixed IDs (openrouter/..., openai-subscription/..., lmstudio/...) "
+    "route via gptme.llm.reply. Default: claude-haiku-4-5-20251001.",
+)
+@click.option(
     "--update-store",
     is_flag=True,
     help="Write scores back to session-records.jsonl (matching by session_id)",
@@ -1601,6 +1624,7 @@ def judge(
     journal_dir: Path | None,
     last: int,
     goals: str | None,
+    judge_model: str | None,
     update_store: bool,
     as_json: bool,
     dry_run: bool,
@@ -1613,10 +1637,12 @@ def judge(
     With --update-store, writes scores back to session-records.jsonl by matching
     session IDs from journal filenames to stored records.
     """
-    from .judge import DEFAULT_GOALS, judge_session
+    from .judge import DEFAULT_GOALS, DEFAULT_JUDGE_MODEL, judge_session
 
     if dry_run and update_store:
         raise click.UsageError("--dry-run and --update-store are mutually exclusive")
+
+    effective_model = judge_model or DEFAULT_JUDGE_MODEL
 
     if journal_dir is None:
         journal_dir = Path.cwd() / "journal"
@@ -1686,7 +1712,9 @@ def judge(
                     click.echo(f"  {sid:<12} {entry_date}  {cat:<14} {outcome}")
                 continue
 
-            verdict = judge_session(text, category=cat, goals=effective_goals)
+            verdict = judge_session(
+                text, category=cat, goals=effective_goals, model=effective_model
+            )
             score = verdict["score"] if verdict else None
             reason = verdict["reason"] if verdict else None
 

--- a/packages/gptme-sessions/src/gptme_sessions/judge.py
+++ b/packages/gptme-sessions/src/gptme_sessions/judge.py
@@ -1,12 +1,16 @@
 """LLM-as-judge for session goal-alignment scoring.
 
-Evaluates agent sessions for strategic value using a cheap LLM (Haiku).
+Evaluates agent sessions for strategic value using an LLM.
 Returns a score (0.0-1.0) and a 1-sentence reason.
 
 The judge is designed to be:
 - **Generic**: Works for any agent, not just Bob. Goals are passed as a parameter.
-- **Cheap**: Uses Haiku (~$0.001/eval) so it can run on every session.
-- **Optional**: Requires ``anthropic`` package. Returns None on failure.
+- **Cheap**: Uses Haiku by default (~$0.001/eval).
+- **Pluggable**: ``--model`` supports direct Anthropic IDs *and* any provider
+  gptme can route to (``openrouter/...``, ``openai-subscription/...``,
+  ``lmstudio/...``, ``anthropic/...``, etc.) when the ``gptme`` package is
+  installed.
+- **Optional**: Returns None on failure (missing API key, import error).
 
 Integration points:
 - ``gptme-sessions signals --llm-judge``: score a single trajectory
@@ -81,6 +85,118 @@ def _get_api_key() -> str:
     return key
 
 
+def _is_anthropic_direct_model(model: str) -> bool:
+    """True if the model ID should route via the direct Anthropic SDK.
+
+    Accepts bare Anthropic IDs (``claude-haiku-4-5-...``) and the
+    ``anthropic/<model>`` prefix. Anything else (``openrouter/...``,
+    ``openai-subscription/...``, ``lmstudio/...``, ``openai/...``, etc.)
+    routes through ``gptme.llm`` when available.
+    """
+    if model.startswith("anthropic/"):
+        return True
+    # Bare model IDs without a provider prefix: treat as Anthropic-direct iff
+    # they look like Anthropic IDs (keeps backcompat with the legacy default).
+    if "/" not in model and model.startswith("claude-"):
+        return True
+    return False
+
+
+def _strip_anthropic_prefix(model: str) -> str:
+    return model.removeprefix("anthropic/") if model.startswith("anthropic/") else model
+
+
+def _parse_judge_payload(text: str, model: str) -> dict | None:
+    """Parse a judge JSON response, tolerating markdown code fences."""
+    if not text:
+        return None
+    payload = text.strip()
+    if "```" in payload:
+        m = re.search(r"```(?:json)?\s*(.*?)\s*```", payload, re.DOTALL)
+        if m:
+            payload = m.group(1).strip()
+    try:
+        verdict = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        logger.warning("LLM judge returned non-JSON response: %s", exc)
+        return None
+    score = float(verdict.get("score", 0.5))
+    reason = str(verdict.get("reason", ""))
+    score = max(0.0, min(1.0, score))
+    return {"score": score, "reason": reason, "model": model}
+
+
+def _judge_via_anthropic_direct(
+    prompt: str,
+    *,
+    model: str,
+    api_key: str | None,
+) -> dict | None:
+    """Call the judge via the direct Anthropic SDK (legacy path)."""
+    try:
+        import anthropic
+    except ImportError:
+        logger.warning("anthropic package not installed; direct judge unavailable")
+        return None
+
+    key = api_key or _get_api_key()
+    if not key:
+        logger.warning("No Anthropic API key found; direct judge unavailable")
+        return None
+
+    try:
+        client = anthropic.Anthropic(api_key=key)
+        response = client.messages.create(
+            model=_strip_anthropic_prefix(model),
+            max_tokens=150,
+            system=JUDGE_SYSTEM,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        text = getattr(response.content[0], "text", "").strip()
+    except Exception as exc:
+        logger.warning("LLM judge (anthropic) failed: %s", exc)
+        return None
+
+    return _parse_judge_payload(text, model)
+
+
+def _judge_via_gptme(prompt: str, *, model: str) -> dict | None:
+    """Call the judge via ``gptme.llm.reply`` for non-Anthropic-direct models."""
+    try:
+        from gptme.init import init as init_gptme
+        from gptme.llm import reply
+        from gptme.message import Message
+    except ImportError:
+        logger.warning(
+            "gptme package not installed; model %r needs gptme.llm routing "
+            "(install gptme, or use an Anthropic-direct model ID)",
+            model,
+        )
+        return None
+
+    try:
+        init_gptme(
+            model=model,
+            interactive=False,
+            tool_allowlist=[],
+            tool_format="markdown",
+        )
+        response = reply(
+            [
+                Message("system", JUDGE_SYSTEM),
+                Message("user", prompt),
+            ],
+            model,
+            stream=False,
+        )
+    except Exception as exc:
+        logger.warning("LLM judge (gptme) failed: %s", exc)
+        return None
+
+    text = getattr(response, "content", "")
+    return _parse_judge_payload(text, model)
+
+
 def judge_session(
     journal_text: str,
     category: str | None = None,
@@ -95,24 +211,20 @@ def judge_session(
         journal_text: The session journal/summary text to evaluate.
         category: Work category (e.g. "code", "triage", "content").
         goals: Agent goals description (ordered by priority).
-        model: Anthropic model ID for the judge.
-        api_key: Anthropic API key. Falls back to env/config if not provided.
+        model: Model ID for the judge. Anthropic-direct IDs
+            (``claude-*``, ``anthropic/*``) use the ``anthropic`` SDK.
+            Other provider-prefixed IDs (``openrouter/...``,
+            ``openai-subscription/...``, ``lmstudio/...``, etc.) route
+            through ``gptme.llm.reply`` when the ``gptme`` package is
+            installed.
+        api_key: Anthropic API key (Anthropic-direct path only). Falls
+            back to env/config if not provided.
 
     Returns:
         Dict with keys ``score`` (float), ``reason`` (str), ``model`` (str),
-        or ``None`` if the evaluation fails (missing API key, import error, etc.).
+        or ``None`` if the evaluation fails (missing API key, import error,
+        non-JSON response, etc.).
     """
-    try:
-        import anthropic
-    except ImportError:
-        logger.warning("anthropic package not installed; LLM judge unavailable")
-        return None
-
-    key = api_key or _get_api_key()
-    if not key:
-        logger.warning("No Anthropic API key found; LLM judge unavailable")
-        return None
-
     # Truncate journal to ~4000 chars to keep costs low
     truncated = journal_text[:4000] if journal_text else "(empty session)"
 
@@ -125,35 +237,9 @@ def judge_session(
         journal=truncated,
     )
 
-    try:
-        client = anthropic.Anthropic(api_key=key)
-        response = client.messages.create(
-            model=model,
-            max_tokens=150,
-            system=JUDGE_SYSTEM,
-            messages=[{"role": "user", "content": prompt}],
-        )
-        text = getattr(response.content[0], "text", "").strip()
-
-        # Handle markdown code block wrapping — use regex to avoid splitting on
-        # backticks that appear inside the reason string
-        if "```" in text:
-            m = re.search(r"```(?:json)?\s*(.*?)\s*```", text, re.DOTALL)
-            if m:
-                text = m.group(1).strip()
-
-        verdict = json.loads(text)
-        score = float(verdict.get("score", 0.5))
-        reason = str(verdict.get("reason", ""))
-
-        # Clamp to valid range
-        score = max(0.0, min(1.0, score))
-
-        return {"score": score, "reason": reason, "model": model}
-
-    except Exception as e:
-        logger.warning("LLM judge failed: %s", e)
-        return None
+    if _is_anthropic_direct_model(model):
+        return _judge_via_anthropic_direct(prompt, model=model, api_key=api_key)
+    return _judge_via_gptme(prompt, model=model)
 
 
 def judge_from_signals(

--- a/packages/gptme-sessions/tests/test_judge.py
+++ b/packages/gptme-sessions/tests/test_judge.py
@@ -15,6 +15,8 @@ from gptme_sessions.judge import (
     DEFAULT_JUDGE_MODEL,
     JUDGE_PROMPT_TEMPLATE,
     JUDGE_SYSTEM,
+    _is_anthropic_direct_model,
+    _strip_anthropic_prefix,
     judge_from_signals,
     judge_session,
 )
@@ -192,6 +194,76 @@ class TestJudgeFromSignals:
             assert call_args[1]["model"] == "custom-model"
 
 
+class TestModelRouting:
+    """Tests for Anthropic-direct vs gptme.llm routing logic."""
+
+    def test_bare_claude_id_is_direct(self) -> None:
+        assert _is_anthropic_direct_model("claude-haiku-4-5-20251001") is True
+        assert _is_anthropic_direct_model("claude-sonnet-4-5") is True
+
+    def test_anthropic_prefix_is_direct(self) -> None:
+        assert _is_anthropic_direct_model("anthropic/claude-sonnet-4.6") is True
+        assert _is_anthropic_direct_model("anthropic/claude-haiku-4-5-20251001") is True
+
+    def test_provider_prefixed_is_not_direct(self) -> None:
+        assert _is_anthropic_direct_model("openrouter/anthropic/claude-sonnet-4.6") is False
+        assert _is_anthropic_direct_model("openai-subscription/gpt-5.4") is False
+        assert _is_anthropic_direct_model("lmstudio/qwen/qwen3.6-35b-a3b") is False
+        assert _is_anthropic_direct_model("openai/gpt-4o") is False
+
+    def test_strip_anthropic_prefix(self) -> None:
+        assert _strip_anthropic_prefix("anthropic/claude-sonnet-4.6") == "claude-sonnet-4.6"
+        assert _strip_anthropic_prefix("claude-haiku-4-5-20251001") == "claude-haiku-4-5-20251001"
+        # Non-anthropic prefixes are left alone
+        assert (
+            _strip_anthropic_prefix("openrouter/anthropic/claude-sonnet-4.6")
+            == "openrouter/anthropic/claude-sonnet-4.6"
+        )
+
+    def test_non_anthropic_model_routes_via_gptme(self) -> None:
+        """Non-Anthropic-direct models call _judge_via_gptme, not _judge_via_anthropic_direct."""
+        with (
+            patch(
+                "gptme_sessions.judge._judge_via_gptme",
+                return_value={"score": 0.6, "reason": "ok", "model": "openrouter/x"},
+            ) as mock_gptme,
+            patch("gptme_sessions.judge._judge_via_anthropic_direct") as mock_direct,
+        ):
+            result = judge_session(
+                "journal text", category="code", model="openrouter/anthropic/claude-sonnet-4.6"
+            )
+        assert result is not None
+        assert result["score"] == 0.6
+        mock_gptme.assert_called_once()
+        mock_direct.assert_not_called()
+
+    def test_anthropic_direct_model_routes_via_anthropic(self) -> None:
+        """Bare Anthropic IDs call _judge_via_anthropic_direct, not _judge_via_gptme."""
+        with (
+            patch(
+                "gptme_sessions.judge._judge_via_anthropic_direct",
+                return_value={"score": 0.7, "reason": "ok", "model": "claude-haiku-4-5-20251001"},
+            ) as mock_direct,
+            patch("gptme_sessions.judge._judge_via_gptme") as mock_gptme,
+        ):
+            result = judge_session("journal text", category="code")
+        assert result is not None
+        assert result["score"] == 0.7
+        mock_direct.assert_called_once()
+        mock_gptme.assert_not_called()
+
+    def test_gptme_path_returns_none_when_gptme_missing(self) -> None:
+        """When gptme is not installed, non-Anthropic models get None cleanly."""
+        with patch.dict(
+            "sys.modules",
+            {"gptme": None, "gptme.init": None, "gptme.llm": None, "gptme.message": None},
+        ):
+            result = judge_session(
+                "journal text", category="code", model="openrouter/anthropic/claude-sonnet-4.6"
+            )
+        assert result is None
+
+
 class TestSessionRecordJudgeFields:
     """Tests for LLM judge fields on SessionRecord."""
 
@@ -250,6 +322,16 @@ class TestJudgeCLI:
         param_names = [p.name for p in signals_cmd.params]
         assert "llm_judge" in param_names
         assert "goals" in param_names
+
+    def test_judge_and_signals_have_model_flag(self) -> None:
+        """Both 'judge' and 'signals' expose a --model flag for judge routing."""
+        from gptme_sessions.cli import cli
+
+        for cmd_name in ("judge", "signals"):
+            params = [p for p in cli.commands[cmd_name].params if p.name == "judge_model"]
+            assert params, f"{cmd_name!r} is missing --model flag"
+            flag = params[0]
+            assert "--model" in flag.opts
 
     @pytest.mark.skipif(
         getattr(os, "getuid", lambda: -1)() == 0,


### PR DESCRIPTION
## Summary

Makes the `gptme-sessions judge` LLM-as-judge pluggable across providers instead of hardcoded to Haiku via the direct Anthropic SDK.

Needed for environments that:
- Run without `ANTHROPIC_API_KEY` (e.g. subscription-mode agents that unset it)
- Route via OpenRouter for cost/quota segregation (`OPENROUTER_API_KEY_JUDGE`)
- Want a non-Haiku model (Sonnet/Opus/gpt-5.4/qwen3.6)

## Changes

- **`judge.py`**: split the call path into two helpers
  - `_judge_via_anthropic_direct` (legacy, bare `claude-*` / `anthropic/*` IDs)
  - `_judge_via_gptme` (everything else, via `gptme.llm.reply`)

  Routing is driven by a small `_is_anthropic_direct_model` predicate so default
  Haiku behavior is 100% unchanged.

- **`cli.py`**: add `--model MODEL` option to both `judge` and `signals` subcommands.
  Default stays `claude-haiku-4-5-20251001`. Help text documents the routing rule.

- **tests**: 7 new cases in `TestModelRouting` + `test_judge_and_signals_have_model_flag`
  covering: `_is_anthropic_direct_model` detection, prefix stripping, routing to the
  correct backend, graceful None when `gptme` is missing, and CLI flag registration.

## Acceptance

- `gptme-sessions judge --last 10 --update-store --model openrouter/anthropic/claude-sonnet-4.6`
  judges and persists, no env munging required
- `gptme-sessions judge --last 10 --update-store` (no `--model`) still uses Haiku via
  Anthropic-direct (backcompat preserved)
- All 26 tests in `test_judge.py` pass (19 existing + 7 new)

## Downstream

Unblocks removal of downstream workarounds that exist only because of this gap
(Bob's `scripts/eval/backfill-judge.py` and most of the `_judge_via_gptme`
fallback in `metaproductivity.session_alignment`).

## Test plan

- [x] `uv run --active pytest tests/test_judge.py -v` → 26 passed
- [x] `uv run --active ruff check src/ tests/` → clean
- [x] `uv run --active ruff format src/` → clean
- [x] mypy: no new errors (pre-existing import-not-found for optional deps unchanged)