### PR TITLE
feat(gptme-sessions): add judge writeback helpers

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/judge.py
+++ b/packages/gptme-sessions/src/gptme_sessions/judge.py
@@ -93,6 +93,8 @@ The agent is a general-purpose autonomous AI assistant.
 2. Write high-quality code and documentation
 3. Self-improve through lessons and patterns
 4. Contribute to open-source projects"""
+NO_THINK_PREFILL = "<think></think>\n"
+NO_THINK_PREFILL_MODELS = frozenset({"lmstudio/qwen/qwen3.6-35b-a3b"})
 
 
 def _compute_judge_version() -> str:
@@ -264,24 +266,57 @@ def normalize_judge_verdict(payload: dict[str, Any]) -> JudgeVerdict:
     }
 
 
+def _strip_json_wrappers(text: str) -> str:
+    """Normalize common LLM wrappers around a JSON payload."""
+    cleaned = text.strip()
+    cleaned = re.sub(r"<think>.*?</think>", "", cleaned, flags=re.DOTALL).strip()
+
+    if "```" in cleaned:
+        match = re.search(r"```(?:json)?\s*(.*?)\s*```", cleaned, re.DOTALL)
+        if match:
+            cleaned = match.group(1).strip()
+
+    if cleaned.startswith("json"):
+        cleaned = cleaned[4:].strip()
+
+    return cleaned
+
+
 def _parse_judge_payload(text: str, model: str) -> dict | None:
     """Parse a judge JSON response, tolerating markdown code fences."""
     if not text:
         return None
-    payload = text.strip()
-    if "```" in payload:
-        m = re.search(r"```(?:json)?\s*(.*?)\s*```", payload, re.DOTALL)
-        if m:
-            payload = m.group(1).strip()
+    payload = _strip_json_wrappers(text)
     try:
         verdict = json.loads(payload)
-    except json.JSONDecodeError as exc:
-        logger.warning("LLM judge returned non-JSON response: %s", exc)
-        return None
+    except json.JSONDecodeError:
+        match = re.search(r"\{[\s\S]*\}", payload)
+        if not match:
+            logger.warning("LLM judge returned non-JSON response")
+            return None
+        verdict = json.loads(match.group(0))
     score = float(verdict.get("score", 0.5))
     reason = str(verdict.get("reason", ""))
     score = max(0.0, min(1.0, score))
     return {"score": score, "reason": reason, "model": model}
+
+
+def _prepare_messages_for_model(messages: list[Any], model: str) -> list[Any]:
+    """Apply known model-specific message tweaks before a gptme judge call."""
+    prepared = list(messages)
+    if model not in NO_THINK_PREFILL_MODELS:
+        return prepared
+    if (
+        prepared
+        and getattr(prepared[-1], "role", None) == "assistant"
+        and getattr(prepared[-1], "content", None) == NO_THINK_PREFILL
+    ):
+        return prepared
+
+    from gptme.message import Message
+
+    prepared.append(Message("assistant", NO_THINK_PREFILL))
+    return prepared
 
 
 def _judge_via_anthropic_direct(
@@ -341,10 +376,13 @@ def _judge_via_gptme(prompt: str, *, model: str) -> dict | None:
                 tool_format="markdown",
             )
             response = reply(
-                [
-                    Message("system", JUDGE_SYSTEM),
-                    Message("user", prompt),
-                ],
+                _prepare_messages_for_model(
+                    [
+                        Message("system", JUDGE_SYSTEM),
+                        Message("user", prompt),
+                    ],
+                    model,
+                ),
                 model,
                 stream=False,
             )

--- a/packages/gptme-sessions/src/gptme_sessions/judge.py
+++ b/packages/gptme-sessions/src/gptme_sessions/judge.py
@@ -150,7 +150,10 @@ def _load_config_env(config_paths: tuple[Path, ...] = CONFIG_PATHS) -> dict[str,
     try:
         import tomllib
     except ImportError:
-        return merged
+        try:
+            import tomli as tomllib  # type: ignore[no-redef]
+        except ImportError:
+            return merged
 
     for path in config_paths:
         if not path.exists():

--- a/packages/gptme-sessions/src/gptme_sessions/judge.py
+++ b/packages/gptme-sessions/src/gptme_sessions/judge.py
@@ -111,22 +111,13 @@ def _compute_judge_version() -> str:
 JUDGE_VERSION = _compute_judge_version()
 
 
-def _get_api_key() -> str:
+def _get_api_key(config_paths: tuple[Path, ...] = CONFIG_PATHS) -> str:
     """Resolve Anthropic API key from environment or gptme config."""
     key = os.environ.get("ANTHROPIC_API_KEY", "")
     if key:
         return key
-    # Try gptme config as fallback
-    try:
-        import tomllib
-
-        config_path = Path.home() / ".config" / "gptme" / "config.toml"
-        if config_path.exists():
-            config = tomllib.loads(config_path.read_text(encoding="utf-8"))
-            key = config.get("env", {}).get("ANTHROPIC_API_KEY", "")
-    except Exception:
-        pass
-    return key
+    # Try gptme config as fallback (reads both config.toml and config.local.toml)
+    return _load_config_env(config_paths).get("ANTHROPIC_API_KEY", "")
 
 
 def _normalize_context(context: str) -> str:

--- a/packages/gptme-sessions/src/gptme_sessions/judge.py
+++ b/packages/gptme-sessions/src/gptme_sessions/judge.py
@@ -20,15 +20,43 @@ Integration points:
 
 from __future__ import annotations
 
+import contextlib
+import hashlib
 import json
 import logging
 import os
 import re
+from collections.abc import Iterator
 from pathlib import Path
+from typing import Any, TypedDict
+
+from .store import SessionStore
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_JUDGE_MODEL = "claude-haiku-4-5-20251001"
+CONFIG_PATHS = (
+    Path.home() / ".config" / "gptme" / "config.toml",
+    Path.home() / ".config" / "gptme" / "config.local.toml",
+)
+CONTEXT_FALLBACKS = {
+    "JUDGE": ("JUDGE", "LLM_JUDGE", "EVAL"),
+    "LLM_JUDGE": ("LLM_JUDGE", "JUDGE", "EVAL"),
+    "EVAL": ("EVAL", "JUDGE", "LLM_JUDGE"),
+}
+
+
+class JudgeMetadata(TypedDict):
+    backend: str
+    judge_version: str
+
+
+class JudgeVerdict(TypedDict, total=False):
+    score: float
+    reason: str
+    model: str
+    meta: JudgeMetadata
+
 
 JUDGE_SYSTEM = """\
 You are evaluating an AI agent's work session for strategic value.
@@ -67,6 +95,20 @@ The agent is a general-purpose autonomous AI assistant.
 4. Contribute to open-source projects"""
 
 
+def _compute_judge_version() -> str:
+    payload = "\n---\n".join(
+        [
+            JUDGE_SYSTEM.strip(),
+            JUDGE_PROMPT_TEMPLATE.strip(),
+        ]
+    )
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:12]
+    return f"goal-alignment-v1-{digest}"
+
+
+JUDGE_VERSION = _compute_judge_version()
+
+
 def _get_api_key() -> str:
     """Resolve Anthropic API key from environment or gptme config."""
     key = os.environ.get("ANTHROPIC_API_KEY", "")
@@ -83,6 +125,92 @@ def _get_api_key() -> str:
     except Exception:
         pass
     return key
+
+
+def _normalize_context(context: str) -> str:
+    return re.sub(r"[^A-Z0-9]+", "_", context.strip().upper()).strip("_")
+
+
+def _candidate_openrouter_env_var_names(context: str) -> list[str]:
+    normalized = _normalize_context(context)
+    names: list[str] = []
+    for candidate in CONTEXT_FALLBACKS.get(normalized, ((normalized,) if normalized else ())):
+        env_var = f"OPENROUTER_API_KEY_{candidate}"
+        if env_var not in names:
+            names.append(env_var)
+    names.append("OPENROUTER_API_KEY")
+    return names
+
+
+def _load_config_env(config_paths: tuple[Path, ...] = CONFIG_PATHS) -> dict[str, str]:
+    """Load merged [env] values from gptme config, with local overrides last."""
+    merged: dict[str, str] = {}
+    try:
+        import tomllib
+    except ImportError:
+        return merged
+
+    for path in config_paths:
+        if not path.exists():
+            continue
+        try:
+            with path.open("rb") as fh:
+                data = tomllib.load(fh)
+        except Exception:
+            continue
+        env = data.get("env", {})
+        for key, value in env.items():
+            if isinstance(value, str):
+                merged[key] = value
+    return merged
+
+
+def _resolve_openrouter_api_key(
+    context: str,
+    *,
+    environ: dict[str, str] | None = None,
+    config_paths: tuple[Path, ...] = CONFIG_PATHS,
+) -> str | None:
+    """Resolve a scoped OpenRouter key, falling back to the shared default."""
+    env = os.environ if environ is None else environ
+    candidates = _candidate_openrouter_env_var_names(context)
+
+    for name in candidates:
+        value = env.get(name, "")
+        if value:
+            return value
+
+    config_env = _load_config_env(config_paths)
+    for name in candidates:
+        value = config_env.get(name, "")
+        if value:
+            return value
+
+    return None
+
+
+@contextlib.contextmanager
+def _judge_openrouter_env(model: str) -> Iterator[None]:
+    """Temporarily promote the judge-scoped OpenRouter key for judge calls."""
+    if not model.startswith("openrouter/"):
+        yield
+        return
+    judge_key = _resolve_openrouter_api_key("JUDGE")
+    if not judge_key:
+        yield
+        return
+    backup = os.environ.get("OPENROUTER_API_KEY")
+    if backup == judge_key:
+        yield
+        return
+    os.environ["OPENROUTER_API_KEY"] = judge_key
+    try:
+        yield
+    finally:
+        if backup is None:
+            os.environ.pop("OPENROUTER_API_KEY", None)
+        else:
+            os.environ["OPENROUTER_API_KEY"] = backup
 
 
 def _is_anthropic_direct_model(model: str) -> bool:
@@ -104,6 +232,36 @@ def _is_anthropic_direct_model(model: str) -> bool:
 
 def _strip_anthropic_prefix(model: str) -> str:
     return model.removeprefix("anthropic/") if model.startswith("anthropic/") else model
+
+
+def _judge_backend(model: str) -> str:
+    if _is_anthropic_direct_model(model):
+        return "anthropic-direct"
+    return "gptme-fallback"
+
+
+def _build_judge_meta(*, model: str) -> JudgeMetadata:
+    return {
+        "backend": _judge_backend(model),
+        "judge_version": JUDGE_VERSION,
+    }
+
+
+def normalize_judge_verdict(payload: dict[str, Any]) -> JudgeVerdict:
+    """Attach stable metadata to a raw judge verdict."""
+    model = str(payload.get("model", ""))
+    raw_meta = payload.get("meta")
+    meta = raw_meta if isinstance(raw_meta, dict) else {}
+    base_meta = _build_judge_meta(model=model)
+    return {
+        "score": max(0.0, min(1.0, float(payload.get("score", 0.5)))),
+        "reason": str(payload.get("reason", "")),
+        "model": model,
+        "meta": {
+            "backend": str(meta.get("backend", base_meta["backend"])),
+            "judge_version": str(meta.get("judge_version", base_meta["judge_version"])),
+        },
+    }
 
 
 def _parse_judge_payload(text: str, model: str) -> dict | None:
@@ -175,20 +333,21 @@ def _judge_via_gptme(prompt: str, *, model: str) -> dict | None:
         return None
 
     try:
-        init_gptme(
-            model=model,
-            interactive=False,
-            tool_allowlist=[],
-            tool_format="markdown",
-        )
-        response = reply(
-            [
-                Message("system", JUDGE_SYSTEM),
-                Message("user", prompt),
-            ],
-            model,
-            stream=False,
-        )
+        with _judge_openrouter_env(model):
+            init_gptme(
+                model=model,
+                interactive=False,
+                tool_allowlist=[],
+                tool_format="markdown",
+            )
+            response = reply(
+                [
+                    Message("system", JUDGE_SYSTEM),
+                    Message("user", prompt),
+                ],
+                model,
+                stream=False,
+            )
     except Exception as exc:
         logger.warning("LLM judge (gptme) failed: %s", exc)
         return None
@@ -290,3 +449,72 @@ def judge_from_signals(
         journal_text = "\n".join(parts) if parts else "(no signal data)"
 
     return judge_session(journal_text, category=category, **kwargs)
+
+
+def _store_judge_meta(record: Any, meta: JudgeMetadata | None) -> None:
+    """Persist judge metadata via the SessionRecord legacy-field bridge."""
+    if not meta:
+        return
+    normalized = {k: str(v) for k, v in meta.items() if v}
+    if not normalized:
+        return
+    legacy_fields = getattr(record, "_legacy_fields", None)
+    if isinstance(legacy_fields, dict):
+        legacy_fields["llm_judge_meta"] = normalized
+
+
+def write_alignment_grade(
+    *,
+    session_id: str,
+    verdict: JudgeVerdict,
+    sessions_dir: Path,
+) -> bool:
+    """Persist an alignment verdict onto an existing session record."""
+    store = SessionStore(sessions_dir=sessions_dir)
+    records = store.load_all()
+    normalized = normalize_judge_verdict(dict(verdict))
+    for record in records:
+        if record.session_id != session_id:
+            continue
+        record.set_alignment_grade(
+            normalized["score"],
+            reason=normalized["reason"],
+            model=normalized["model"],
+        )
+        _store_judge_meta(record, normalized.get("meta"))
+        store.rewrite(records)
+        return True
+    return False
+
+
+def judge_and_writeback(
+    *,
+    text: str,
+    category: str | None,
+    goals: str,
+    session_id: str,
+    sessions_dir: Path,
+    model: str = DEFAULT_JUDGE_MODEL,
+    api_key: str | None = None,
+) -> dict[str, Any]:
+    """Judge a session and persist the verdict via SessionStore."""
+    verdict = judge_session(
+        text,
+        category=category,
+        goals=goals,
+        model=model,
+        api_key=api_key,
+    )
+    if verdict is None:
+        return {"status": "failed"}
+
+    normalized = normalize_judge_verdict(verdict)
+    updated = write_alignment_grade(
+        session_id=session_id,
+        verdict=normalized,
+        sessions_dir=sessions_dir,
+    )
+    if not updated:
+        return {"status": "no_record", **normalized}
+
+    return {"status": "ok", **normalized}

--- a/packages/gptme-sessions/tests/test_judge.py
+++ b/packages/gptme-sessions/tests/test_judge.py
@@ -18,6 +18,7 @@ from gptme_sessions.judge import (
     JUDGE_PROMPT_TEMPLATE,
     JUDGE_SYSTEM,
     NO_THINK_PREFILL,
+    _get_api_key,
     _judge_openrouter_env,
     _parse_judge_payload,
     _prepare_messages_for_model,
@@ -334,6 +335,16 @@ class TestModelRouting:
             )
             == "judge-key"
         )
+
+    def test_get_api_key_reads_config_local(self, tmp_path: Path, monkeypatch) -> None:
+        """_get_api_key() falls back to config.local.toml, not just config.toml."""
+        config = tmp_path / "config.toml"
+        config.write_text("[env]\n", encoding="utf-8")
+        config_local = tmp_path / "config.local.toml"
+        config_local.write_text('[env]\nANTHROPIC_API_KEY = "local-key"\n', encoding="utf-8")
+
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        assert _get_api_key(config_paths=(config, config_local)) == "local-key"
 
     def test_judge_openrouter_env_promotes_scoped_key(self, monkeypatch) -> None:
         monkeypatch.setattr(

--- a/packages/gptme-sessions/tests/test_judge.py
+++ b/packages/gptme-sessions/tests/test_judge.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from gptme.message import Message
 
 from gptme_sessions.judge import (
     DEFAULT_GOALS,
@@ -16,7 +17,10 @@ from gptme_sessions.judge import (
     JUDGE_VERSION,
     JUDGE_PROMPT_TEMPLATE,
     JUDGE_SYSTEM,
+    NO_THINK_PREFILL,
     _judge_openrouter_env,
+    _parse_judge_payload,
+    _prepare_messages_for_model,
     _resolve_openrouter_api_key,
     _is_anthropic_direct_model,
     _strip_anthropic_prefix,
@@ -140,6 +144,42 @@ class TestJudgeSession:
         """Default goals should work for any agent, not just Bob."""
         assert "Bob" not in DEFAULT_GOALS
         assert "agent" in DEFAULT_GOALS.lower()
+
+    def test_parse_judge_payload_handles_think_tags_and_fences(self) -> None:
+        parsed = _parse_judge_payload(
+            """
+<think>internal</think>
+```json
+{"score": 1.4, "reason": "Shipped a real fix"}
+```
+""",
+            "openai-subscription/gpt-5.4",
+        )
+
+        assert parsed == {
+            "score": 1.0,
+            "reason": "Shipped a real fix",
+            "model": "openai-subscription/gpt-5.4",
+        }
+
+    def test_prepare_messages_for_qwen_adds_no_think_prefill(self) -> None:
+        prepared = _prepare_messages_for_model(
+            [Message("system", "judge"), Message("user", "score this")],
+            "lmstudio/qwen/qwen3.6-35b-a3b",
+        )
+
+        assert [msg.role for msg in prepared] == ["system", "user", "assistant"]
+        assert prepared[-1].content == NO_THINK_PREFILL
+
+    def test_prepare_messages_for_other_models_is_noop(self) -> None:
+        messages = [Message("system", "judge"), Message("user", "score this")]
+
+        prepared = _prepare_messages_for_model(
+            messages,
+            "openai-subscription/gpt-5.4",
+        )
+
+        assert prepared == messages
 
 
 class TestJudgeFromSignals:

--- a/packages/gptme-sessions/tests/test_judge.py
+++ b/packages/gptme-sessions/tests/test_judge.py
@@ -13,14 +13,20 @@ import pytest
 from gptme_sessions.judge import (
     DEFAULT_GOALS,
     DEFAULT_JUDGE_MODEL,
+    JUDGE_VERSION,
     JUDGE_PROMPT_TEMPLATE,
     JUDGE_SYSTEM,
+    _judge_openrouter_env,
+    _resolve_openrouter_api_key,
     _is_anthropic_direct_model,
     _strip_anthropic_prefix,
+    judge_and_writeback,
     judge_from_signals,
     judge_session,
+    normalize_judge_verdict,
 )
 from gptme_sessions.record import SessionRecord
+from gptme_sessions.store import SessionStore
 
 
 class TestJudgeSession:
@@ -263,6 +269,65 @@ class TestModelRouting:
             )
         assert result is None
 
+    def test_resolve_openrouter_api_key_prefers_scoped_env(self) -> None:
+        env = {
+            "OPENROUTER_API_KEY_JUDGE": "judge-key",
+            "OPENROUTER_API_KEY": "shared-key",
+        }
+
+        assert _resolve_openrouter_api_key("judge", environ=env) == "judge-key"
+
+    def test_resolve_openrouter_api_key_reads_config_local(self, tmp_path: Path) -> None:
+        config = tmp_path / "config.toml"
+        config.write_text('[env]\nOPENROUTER_API_KEY = "shared-key"\n', encoding="utf-8")
+        config_local = tmp_path / "config.local.toml"
+        config_local.write_text(
+            '[env]\nOPENROUTER_API_KEY_JUDGE = "judge-key"\n',
+            encoding="utf-8",
+        )
+
+        assert (
+            _resolve_openrouter_api_key(
+                "judge",
+                environ={},
+                config_paths=(config, config_local),
+            )
+            == "judge-key"
+        )
+
+    def test_judge_openrouter_env_promotes_scoped_key(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "gptme_sessions.judge._resolve_openrouter_api_key",
+            lambda *args, **kwargs: "judge-key",
+        )
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+        seen: list[str | None] = []
+        with _judge_openrouter_env("openrouter/qwen/qwen3-next-80b"):
+            seen.append(os.environ.get("OPENROUTER_API_KEY"))
+
+        assert seen == ["judge-key"]
+        assert "OPENROUTER_API_KEY" not in os.environ
+
+    def test_normalize_judge_verdict_attaches_meta(self) -> None:
+        normalized = normalize_judge_verdict(
+            {
+                "score": 0.74,
+                "reason": "Meaningful progress",
+                "model": "openai-subscription/gpt-5.4",
+            }
+        )
+
+        assert normalized == {
+            "score": 0.74,
+            "reason": "Meaningful progress",
+            "model": "openai-subscription/gpt-5.4",
+            "meta": {
+                "backend": "gptme-fallback",
+                "judge_version": JUDGE_VERSION,
+            },
+        }
+
 
 class TestSessionRecordJudgeFields:
     """Tests for LLM judge fields on SessionRecord."""
@@ -303,6 +368,68 @@ class TestSessionRecordJudgeFields:
         }
         record = SessionRecord.from_dict(old_data)
         assert record.llm_judge_score is None
+
+    def test_writeback_helpers_store_alignment_meta(self, tmp_path: Path) -> None:
+        store = SessionStore(sessions_dir=tmp_path)
+        store.append(SessionRecord(session_id="abc123", outcome="productive"))
+
+        with patch(
+            "gptme_sessions.judge.judge_session",
+            return_value={
+                "score": 0.74,
+                "reason": "Real work shipped",
+                "model": "openai-subscription/gpt-5.4",
+            },
+        ):
+            result = judge_and_writeback(
+                text="session text",
+                category="code",
+                goals="ship useful work",
+                session_id="abc123",
+                sessions_dir=tmp_path,
+                model="openai-subscription/gpt-5.4",
+            )
+
+        assert result["status"] == "ok"
+        updated = SessionStore(sessions_dir=tmp_path).load_all()[0]
+        assert updated.grades["alignment"] == 0.74
+        assert updated.grade_reasons["alignment"] == "Real work shipped"
+        assert updated.llm_judge_score == 0.74
+        assert updated.llm_judge_reason == "Real work shipped"
+        assert updated.llm_judge_model == "openai-subscription/gpt-5.4"
+        assert updated.to_dict()["llm_judge_meta"] == {
+            "backend": "gptme-fallback",
+            "judge_version": JUDGE_VERSION,
+        }
+
+    def test_judge_and_writeback_reports_missing_record(self, tmp_path: Path) -> None:
+        with patch(
+            "gptme_sessions.judge.judge_session",
+            return_value={
+                "score": 0.5,
+                "reason": "Did work",
+                "model": "openai-subscription/gpt-5.4",
+            },
+        ):
+            result = judge_and_writeback(
+                text="session text",
+                category="code",
+                goals="ship useful work",
+                session_id="missing",
+                sessions_dir=tmp_path,
+                model="openai-subscription/gpt-5.4",
+            )
+
+        assert result == {
+            "status": "no_record",
+            "score": 0.5,
+            "reason": "Did work",
+            "model": "openai-subscription/gpt-5.4",
+            "meta": {
+                "backend": "gptme-fallback",
+                "judge_version": JUDGE_VERSION,
+            },
+        }
 
 
 class TestJudgeCLI:


### PR DESCRIPTION
## Summary
- add shared judge writeback helpers and metadata persistence in `gptme-sessions`
- resolve judge-scoped OpenRouter keys from env or gptme config (`config.toml` + `config.local.toml`)
- add regression tests for scoped key resolution and writeback behavior

## Why
Bob was still carrying generic judge infrastructure locally: writeback into `SessionStore`, `llm_judge_meta` persistence, and judge-scoped OpenRouter key promotion. This moves the non-Bob-specific parts upstream so the local wrapper can shrink to fallback ordering + the qwen no-think prefill path.

## Testing
- `uv run pytest /home/bob/bob/gptme-contrib/packages/gptme-sessions/tests/test_judge.py -q`
- `uv run pytest /home/bob/bob/packages/metaproductivity/tests/test_session_alignment.py -q`