### PR TITLE
fix(gptme-voice): drain late transcript events on disconnect

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
@@ -7,6 +7,7 @@ voice conversations.
 
 import asyncio
 import base64
+import contextlib
 import json
 import logging
 from dataclasses import dataclass
@@ -220,6 +221,7 @@ class OpenAIRealtimeClient:
         self._session_ready: asyncio.Event | None = None
         self._pending_audio: list[bytes] = []
         self._pending_audio_dropped = 0
+        self._event_notice: asyncio.Event | None = None
 
     def _get_ws_url(self) -> str:
         """WebSocket URL for this provider (override in subclasses)."""
@@ -243,6 +245,7 @@ class OpenAIRealtimeClient:
         self._session_ready = asyncio.Event()
         self._pending_audio = []
         self._pending_audio_dropped = 0
+        self._event_notice = asyncio.Event()
 
         url = self._get_ws_url()
         headers = self._get_ws_headers()
@@ -392,8 +395,36 @@ class OpenAIRealtimeClient:
         )
         await self._send_event("response.create", {})
 
-    async def disconnect(self) -> None:
+    async def disconnect(
+        self,
+        *,
+        drain_timeout_seconds: float = 0.0,
+        idle_timeout_seconds: float = 0.0,
+        commit_audio: bool = False,
+        stop_audio_output: bool = False,
+    ) -> None:
         """Disconnect from OpenAI Realtime API."""
+        if stop_audio_output:
+            # Once the call-side websocket is closing, late provider audio is
+            # more trouble than it's worth. Keep transcript callbacks alive so
+            # we can still persist the final text turns during the drain window.
+            self.on_audio = None
+            self.on_audio_end = None
+
+        if (
+            commit_audio
+            and self._session_ready is not None
+            and self._session_ready.is_set()
+        ):
+            with contextlib.suppress(Exception):
+                await self.commit_audio()
+
+        if drain_timeout_seconds > 0 and idle_timeout_seconds > 0:
+            await self._drain_incoming_events(
+                timeout_seconds=drain_timeout_seconds,
+                idle_timeout_seconds=idle_timeout_seconds,
+            )
+
         if self._receive_task:
             self._receive_task.cancel()
             try:
@@ -404,6 +435,41 @@ class OpenAIRealtimeClient:
         if self._ws:
             await self._ws.close()
             self._ws = None
+
+    async def _drain_incoming_events(
+        self, *, timeout_seconds: float, idle_timeout_seconds: float
+    ) -> None:
+        """Wait briefly for late provider events before disconnecting.
+
+        This is primarily for call teardown: a caller can hang up while the
+        realtime provider is still about to emit the final transcript turn.
+        Keeping the provider socket alive for a short idle-bounded window lets
+        those late text events land without keeping the connection open forever.
+        """
+
+        if timeout_seconds <= 0 or idle_timeout_seconds <= 0:
+            return
+
+        receive_task = self._receive_task
+        event_notice = self._event_notice
+        if receive_task is None or receive_task.done() or event_notice is None:
+            return
+
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout_seconds
+        while not receive_task.done():
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                return
+
+            event_notice.clear()
+            try:
+                await asyncio.wait_for(
+                    event_notice.wait(),
+                    timeout=min(idle_timeout_seconds, remaining),
+                )
+            except asyncio.TimeoutError:
+                return
 
     async def send_audio(self, pcm_data: bytes) -> None:
         """
@@ -493,6 +559,8 @@ class OpenAIRealtimeClient:
 
     async def _handle_event(self, event: dict) -> None:
         """Handle an event from OpenAI Realtime API."""
+        if self._event_notice is not None:
+            self._event_notice.set()
         event_type = event.get("type", "")
 
         # Audio output chunk (handle both old and new event names)

--- a/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
@@ -39,6 +39,17 @@ _MAX_INSTRUCTIONS_LEN = 4096
 # than enough for any realistic session-handshake delay while still capping
 # memory growth if the provider never confirms the session.
 _MAX_PENDING_AUDIO_CHUNKS = 500
+# Event types that carry transcript text — only these reset the drain idle timer.
+_TRANSCRIPT_EVENT_TYPES = frozenset(
+    {
+        "response.audio_transcript.delta",
+        "response.output_audio_transcript.delta",
+        "response.audio_transcript.done",
+        "response.output_audio_transcript.done",
+        "conversation.item.input_audio_transcription.delta",
+        "conversation.item.input_audio_transcription.completed",
+    }
+)
 
 
 def _detect_agent_repo() -> str | None:
@@ -420,10 +431,13 @@ class OpenAIRealtimeClient:
                 await self.commit_audio()
 
         if drain_timeout_seconds > 0 and idle_timeout_seconds > 0:
-            await self._drain_incoming_events(
-                timeout_seconds=drain_timeout_seconds,
-                idle_timeout_seconds=idle_timeout_seconds,
-            )
+            # CancelledError must not skip the cleanup below (receive_task cancel
+            # + ws.close). Suppress it here; caller's finally block still runs.
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._drain_incoming_events(
+                    timeout_seconds=drain_timeout_seconds,
+                    idle_timeout_seconds=idle_timeout_seconds,
+                )
 
         if self._receive_task:
             self._receive_task.cancel()
@@ -559,9 +573,11 @@ class OpenAIRealtimeClient:
 
     async def _handle_event(self, event: dict) -> None:
         """Handle an event from OpenAI Realtime API."""
-        if self._event_notice is not None:
-            self._event_notice.set()
         event_type = event.get("type", "")
+        # Only transcript-carrying events reset the drain idle timer; VAD and
+        # lifecycle events must not extend the teardown window unnecessarily.
+        if self._event_notice is not None and event_type in _TRANSCRIPT_EVENT_TYPES:
+            self._event_notice.set()
 
         # Audio output chunk (handle both old and new event names)
         if event_type in ("response.audio.delta", "response.output_audio.delta"):

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -50,6 +50,8 @@ _MAX_RESUME_TRANSCRIPT_CHARS = 2500
 # Delay before actually closing the WebSocket after the model requests hangup,
 # so the goodbye utterance has time to reach the caller.
 _HANGUP_FAREWELL_DELAY_SECONDS = 5.0
+_CALL_END_DRAIN_TIMEOUT_SECONDS = 1.5
+_CALL_END_IDLE_TIMEOUT_SECONDS = 0.25
 
 
 @dataclass
@@ -660,7 +662,7 @@ class VoiceServer:
             logger.exception("Error handling Twilio connection: %s", e)
         finally:
             if realtime_client:
-                await realtime_client.disconnect()
+                await self._disconnect_realtime_client(realtime_client)
             if call_sid and call_sid in self._connections:
                 del self._connections[call_sid]
             await self._on_call_end(caller_id, "twilio", transcript, metadata)
@@ -773,7 +775,7 @@ class VoiceServer:
             logger.exception("Error handling local connection: %s", e)
         finally:
             if realtime_client:
-                await realtime_client.disconnect()
+                await self._disconnect_realtime_client(realtime_client)
             await self._on_call_end(
                 caller_id,
                 "local",
@@ -812,6 +814,18 @@ class VoiceServer:
             await websocket.close()
         except Exception as exc:  # pragma: no cover - defensive
             logger.warning("Error closing WebSocket during hangup: %s", exc)
+
+    async def _disconnect_realtime_client(
+        self, realtime_client: OpenAIRealtimeClient
+    ) -> None:
+        """Drain late transcript events briefly before closing the provider socket."""
+
+        await realtime_client.disconnect(
+            drain_timeout_seconds=_CALL_END_DRAIN_TIMEOUT_SECONDS,
+            idle_timeout_seconds=_CALL_END_IDLE_TIMEOUT_SECONDS,
+            commit_audio=True,
+            stop_audio_output=True,
+        )
 
     async def _send_local_audio(self, websocket, audio_data: bytes):
         """Send audio to local client."""

--- a/packages/gptme-voice/tests/test_openai_client.py
+++ b/packages/gptme-voice/tests/test_openai_client.py
@@ -30,6 +30,29 @@ class _FakeWebSocket:
         self.closed = True
 
 
+class _QueuedWebSocket(_FakeWebSocket):
+    def __init__(self) -> None:
+        super().__init__()
+        self._incoming: asyncio.Queue[str | None] = asyncio.Queue()
+
+    async def feed(self, event: dict) -> None:
+        await self._incoming.put(json.dumps(event))
+
+    def __aiter__(self) -> "_QueuedWebSocket":
+        return self
+
+    async def __anext__(self) -> str:
+        message = await self._incoming.get()
+        if message is None:
+            raise StopAsyncIteration
+        return message
+
+    async def close(self) -> None:
+        if not self.closed:
+            self.closed = True
+            await self._incoming.put(None)
+
+
 def test_connect_exposes_subagent_tool_as_focused_lookup_only() -> None:
     async def _exercise() -> None:
         fake_ws = _FakeWebSocket()
@@ -196,3 +219,68 @@ def test_load_project_instructions_guards_present_without_personality_files(
     assert "real-time voice conversation" in instructions
     assert "POST-CALL FOLLOW-UP:" in instructions
     assert "Do NOT claim, announce, or imply that you have dispatched" in instructions
+
+
+def test_disconnect_drains_late_transcript_events_without_sending_late_audio() -> None:
+    """Call teardown should preserve late transcript events but suppress late audio.
+
+    Regression for Twilio calls that hang up while the provider is still about to
+    emit the final transcript turn. We want the text for persistence, but we must
+    not try to write late audio to a websocket that is already closing.
+    """
+
+    async def _exercise() -> None:
+        fake_ws = _QueuedWebSocket()
+        user_transcripts: list[str] = []
+        audio_chunks: list[bytes] = []
+
+        async def _fake_connect(*_args, **_kwargs):
+            return fake_ws
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "gptme_voice.realtime.openai_client.websockets.connect", _fake_connect
+            )
+            client = OpenAIRealtimeClient(
+                api_key="test-key",
+                on_user_transcript=user_transcripts.append,
+                on_audio=audio_chunks.append,
+            )
+            await client.connect()
+            await client._handle_event({"type": "session.created"})
+
+            async def _emit_late_events() -> None:
+                await asyncio.sleep(0.01)
+                await fake_ws.feed(
+                    {
+                        "type": "conversation.item.input_audio_transcription.completed",
+                        "transcript": "final words",
+                    }
+                )
+                await fake_ws.feed(
+                    {
+                        "type": "response.audio.delta",
+                        "delta": base64.b64encode(b"\x01\x02").decode("utf-8"),
+                    }
+                )
+
+            emit_task = asyncio.create_task(_emit_late_events())
+            await client.disconnect(
+                drain_timeout_seconds=0.2,
+                idle_timeout_seconds=0.05,
+                commit_audio=True,
+                stop_audio_output=True,
+            )
+            await emit_task
+
+        commit_events = [
+            event
+            for event in fake_ws.sent
+            if event.get("type") == "input_audio_buffer.commit"
+        ]
+        assert commit_events, "disconnect should commit pending audio before drain"
+        assert user_transcripts == ["final words"]
+        assert audio_chunks == []
+        assert fake_ws.closed is True
+
+    asyncio.run(_exercise())


### PR DESCRIPTION
## Summary
- commit pending audio before realtime disconnect on call teardown
- briefly drain late provider events so final transcript turns can land after hangup
- suppress late audio callbacks during teardown and add a regression test for the disconnect race

## Why
A real Twilio call on 2026-04-20 reached  and flushed audio, but the call-side websocket closed before any transcript event landed. The succeeding call from the same caller/provider persisted normally. The remaining plausible gap was eager teardown cutting the provider socket before the final transcript event arrived.

Relates to ErikBjare/bob#651 and the empty-transcript follow-up task in Bob's workspace.
