### PR TITLE
docs(lessons): extend measure-before-optimize for PR/comment claims

### DIFF
--- a/lessons/workflow/measure-before-optimize.md
+++ b/lessons/workflow/measure-before-optimize.md
@@ -7,6 +7,11 @@ match:
   - this looks complex so it must be slow
   - pytest --profile
   - premature optimization
+  - claiming latency win without measurement
+  - PR description promises speedup
+  - expected speedup not verified
+  - context size is the bottleneck
+  - skipping context will speed this up
 status: active
 ---
 
@@ -24,6 +29,8 @@ Observable signals indicating need for measurement:
 - Assuming slowness based on complexity without measurement
 - Building caching solutions before confirming problems exist
 - Unable to articulate specific performance metrics that need improvement
+- Writing "should drop to Xs" in a PR description or issue comment without a baseline number
+- Pointing at one component (prompt size, import time, N+1) as "the" bottleneck without having compared it to other candidates
 
 ## Pattern
 Measure first, then decide based on data:
@@ -47,6 +54,21 @@ pytest tests/test_lessons*.py --profile --durations=10
 # "This looks complex, so it must be slow"
 # Implements caching for lesson parsing
 # No profiling data to support the need
+```
+
+**Anti-pattern**: Latency-win claims in PR descriptions / issue comments
+```text
+# smell: PR body says "simple lookups should drop to ~5-10s"
+# but no before/after timing is shown, and the target number
+# is anchored on one component (prompt size) rather than on
+# the actual cost model (turns × tok/s + startup + tool-use).
+
+# Correct shape:
+# - show baseline (e.g. "currently p50 = 42s over N calls")
+# - explain cost model and which component dominates
+# - project delta from the dominant component, not from the
+#   smallest one
+# - after landing, post measured delta — not re-projected one
 ```
 
 ## Outcome


### PR DESCRIPTION
## Summary

Adds keywords and an anti-pattern section to `measure-before-optimize` covering the failure mode of writing latency-win claims (e.g. *"should drop to ~5-10s"*) in PR descriptions or issue comments without a baseline number or cost-model comparison.

The existing lesson covered code-level premature optimization (caching, profiling `pytest`), but did not trigger on the more common agent failure: anchoring a projected speedup on one component (prompt size) instead of the dominant cost (turns × tok/s + startup + tool-use).

## Motivation

ErikBjare/bob#651 — in gptme/gptme-contrib#713 I wrote *"mode=fast now skips --context files entirely → simple lookups should drop to ~5-10s"* without showing that prompt-eval was actually the dominant latency source. Erik pushed back: *"20k tokens is not a dominating latency source, the total number of steps/turns in the workflow and the tok/s of the model is probably the main driver."* He was right.

The measurement-first response was gptme/gptme-contrib#718, which added per-stage timing (`dispatch->spawn`, `spawn->first_output`, `first_output->done`, `quiet_tail`) to the voice subagent bridge. Claims about where time goes can now be evidence-based.

## Changes

- **Keywords** (for lesson matching): `claiming latency win without measurement`, `PR description promises speedup`, `expected speedup not verified`, `context size is the bottleneck`, `skipping context will speed this up`.
- **Detection**: two bullets for the PR/comment failure mode and the single-component anchoring trap.
- **Anti-pattern**: new text example showing the shape of a bad latency claim and the correct shape (baseline → cost model → dominant-component projection → post-merge measured delta).

## Test plan

- [x] `python3 gptme-contrib/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py lessons/workflow/measure-before-optimize.md` passes
- [x] Lesson stays under length limit (adds ~22 lines, total well under cap)
- [x] No changes to `Rule`, `Context`, `Outcome`, or `Related` sections — additive only