### PR TITLE
docs(lessons): add target_grade: harm to safety-critical lessons

### DIFF
--- a/lessons/autonomous/autonomous-operation-safety.md
+++ b/lessons/autonomous/autonomous-operation-safety.md
@@ -6,6 +6,7 @@ match:
   - untrusted content
   - external communication
   - prompt injection
+target_grade: harm
 status: active
 ---
 

--- a/lessons/autonomous/pre-mortem-for-risky-actions.md
+++ b/lessons/autonomous/pre-mortem-for-risky-actions.md
@@ -14,6 +14,7 @@ match:
   - "DROP TABLE"
   - "production change"
   - "risky operation"
+target_grade: harm
 status: active
 ---
 

--- a/lessons/infrastructure/trajectory-persistence.md
+++ b/lessons/infrastructure/trajectory-persistence.md
@@ -8,6 +8,8 @@ match:
     - session data
     - cleanupPeriodDays
     - log cleanup
+target_grade: harm
+status: active
 ---
 
 # Trajectory Persistence
@@ -94,3 +96,14 @@ April 2026: A cleanup script deleted 3,011 trajectory files over 5 days despite 
 All four layers failed in the April 2026 incident: the script deleted despite layer 1, bypassed layer 2, layer 3 didn't exist yet, and layer 4 predated the data. Defense-in-depth means having all layers.
 
 Principle: **Disk is cheap; lost history is irreplaceable.**
+
+## Outcome
+Following this rule prevents:
+- **Irreversible data loss**: Trajectory files cannot be reconstructed once deleted
+- **Lost learning signal**: Session records are the primary input for LOO analysis and bandit feedback
+- **Broken debugging**: Post-hoc analysis becomes impossible without the original trace
+- **Trust violations**: User safety settings (`cleanupPeriodDays: 1000000`) must never be overridden by scripts
+
+## Related
+- [Pre-Mortem for Risky Actions](../autonomous/pre-mortem-for-risky-actions.md) — run before any deletion logic
+- [Autonomous Operation Safety](../autonomous/autonomous-operation-safety.md) — boundaries for autonomous actions


### PR DESCRIPTION
## Summary

Three lessons now declare `target_grade: harm` so LOO analysis routes them through the harm dimension instead of the default weighted `trajectory_grade`. This strengthens the causal safety signal for lessons whose value is preventing data loss or security harms, not productivity gains.

Changed lessons:

- **`lessons/infrastructure/trajectory-persistence.md`** — added `target_grade: harm` + `status: active`. The April 2026 3,011-file deletion incident makes this the canonical harm-prevention lesson.
- **`lessons/autonomous/pre-mortem-for-risky-actions.md`** — added `target_grade: harm`. Pre-action safety check for destructive operations.
- **`lessons/autonomous/autonomous-operation-safety.md`** — added `target_grade: harm`. Lethal-trifecta / prompt-injection prevention.

Also adds the missing `## Outcome` and `## Related` sections to `trajectory-persistence.md` so it validates in two-file format (it was mixing legacy `## Origin` / `## Anti-Patterns` structure with keywords-only frontmatter, failing the validator).

## Motivation

[arxiv:2604.15559](https://arxiv.org/abs/2604.15559) shows that students distilled from teachers with biased trajectories inherit destructive preferences even when explicit keywords are filtered. Behavior is encoded in trajectory dynamics, not just language.

Bob's lesson system uses Thompson sampling + LOO to promote lessons whose presence correlates with higher session grade. Grade dimensions: `trajectory_grade` (default weighted), `productivity`, `alignment`, `harm`. A safety lesson scored against `trajectory_grade` measures its productivity impact and misses its subliminal counterweight to destructive teacher patterns. Routing it through `harm` surfaces the causal safety signal.

Per-lesson judgment follows the audit at `ErikBjare/bob:knowledge/strategic/subliminal-transfer-lesson-audit.md` — not a batch re-grade. 11 other candidates were evaluated and deferred (some correctly productivity-graded, some needing multi-dimensional `target_grade: [harm, productivity]`).

Advances ErikBjare/bob#154.

## Test plan

- [x] `gptme-lessons-extras/validate.py` passes on all three files
- [x] Prek hooks pass (markdown links, lesson metadata, codeblocks)
- [x] Commit pushed to feature branch (not master — verified via worktree-push-trap guard)