### PR TITLE
docs(lessons): add target_grade: [harm, productivity] to worktree-push-trap

### DIFF
--- a/lessons/workflow/worktree-push-trap.md
+++ b/lessons/workflow/worktree-push-trap.md
@@ -5,6 +5,7 @@ match:
     - "git push -u origin"
     - "branch from master"
     - "push.default=upstream"
+target_grade: [harm, productivity]
 status: active
 ---
 


### PR DESCRIPTION
## Summary

Completes the multi-dimensional lesson re-grading identified by [idea #154](https://github.com/ErikBjare/bob/issues/154) (subliminal-transfer audit).

The `worktree-push-trap` lesson guards against a **dual failure mode**:
- **Destructive**: feature commits pushed to master under `push.default=upstream`
- **Productivity**: wasted time, forced recovery, embarrassing "I pushed to master" notes

Previously the lesson had no `target_grade`, so LOO analysis fell back to the default weighted scalar. Adding `target_grade: [harm, productivity]` makes LOO average both dimensions, so the safety signal isn't diluted by productivity-only framing.

This follows the same pattern as PR #720 (harm-only safety lessons), but uses a *list* target to cover the multi-dimensional nature of this lesson.

## Context

Sibling change in Bob-local repo handles `ci-notification-noise-from-deleted-branches.md`, which has the same multi-dimensional character (CI noise is both a harm signal — deleted branches producing phantom failures — and a productivity drain).

Erik flagged `worktree-push-trap` as a recurring issue (most recently commit `d69d07bbb` on 2026-04-17), and it now has a pre-push guard backstop. The harm grade strengthens LOO's causal signal so the lesson keeps getting reinforced.

## Test plan

- [x] `python3 packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py lessons/workflow/worktree-push-trap.md` — passes (two-file format)
- [x] Pre-commit checks pass (prek)
- [ ] CI green on PR
- [ ] LOO analysis picks up the new dimension on next weekly run

Advances: ErikBjare/bob#154