### PR TITLE
feat(gptme-sessions): add judge_session_with_fallback + fallback_models to judge_and_writeback

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/judge.py
+++ b/packages/gptme-sessions/src/gptme_sessions/judge.py
@@ -433,6 +433,48 @@ def judge_session(
     return _judge_via_gptme(prompt, model=model)
 
 
+def judge_session_with_fallback(
+    journal_text: str,
+    category: str | None = None,
+    *,
+    goals: str = DEFAULT_GOALS,
+    default_model: str = DEFAULT_JUDGE_MODEL,
+    fallback_models: tuple[str, ...] = (),
+    api_key: str | None = None,
+) -> dict | None:
+    """Score a session, trying fallback models if the primary is unavailable.
+
+    Args:
+        journal_text: The session journal/summary text to evaluate.
+        category: Work category (e.g. "code", "triage", "content").
+        goals: Agent goals description (ordered by priority).
+        default_model: Primary judge model. Tried first.
+        fallback_models: Additional models to try in order when the primary fails.
+        api_key: Anthropic API key (Anthropic-direct path only).
+
+    Returns:
+        Dict with keys ``score``, ``reason``, ``model`` or ``None`` if all models fail.
+    """
+    models_to_try = (default_model, *fallback_models)
+    for i, model in enumerate(models_to_try):
+        if i > 0:
+            logger.info(
+                "Judge model %s unavailable; falling back to %s",
+                models_to_try[i - 1],
+                model,
+            )
+        result = judge_session(
+            journal_text,
+            category=category,
+            goals=goals,
+            model=model,
+            api_key=api_key,
+        )
+        if result is not None:
+            return result
+    return None
+
+
 def judge_from_signals(
     signals: dict,
     journal_text: str | None = None,
@@ -527,16 +569,30 @@ def judge_and_writeback(
     session_id: str,
     sessions_dir: Path,
     model: str = DEFAULT_JUDGE_MODEL,
+    fallback_models: tuple[str, ...] = (),
     api_key: str | None = None,
 ) -> dict[str, Any]:
-    """Judge a session and persist the verdict via SessionStore."""
-    verdict = judge_session(
-        text,
-        category=category,
-        goals=goals,
-        model=model,
-        api_key=api_key,
-    )
+    """Judge a session and persist the verdict via SessionStore.
+
+    If ``fallback_models`` is provided, tries them in order when ``model`` fails.
+    """
+    if fallback_models:
+        verdict = judge_session_with_fallback(
+            text,
+            category=category,
+            goals=goals,
+            default_model=model,
+            fallback_models=fallback_models,
+            api_key=api_key,
+        )
+    else:
+        verdict = judge_session(
+            text,
+            category=category,
+            goals=goals,
+            model=model,
+            api_key=api_key,
+        )
     if verdict is None:
         return {"status": "failed"}
 

--- a/packages/gptme-sessions/tests/test_judge.py
+++ b/packages/gptme-sessions/tests/test_judge.py
@@ -28,6 +28,7 @@ from gptme_sessions.judge import (
     judge_and_writeback,
     judge_from_signals,
     judge_session,
+    judge_session_with_fallback,
     normalize_judge_verdict,
 )
 from gptme_sessions.record import SessionRecord
@@ -181,6 +182,110 @@ class TestJudgeSession:
         )
 
         assert prepared == messages
+
+
+class TestJudgeSessionWithFallback:
+    """Tests for judge_session_with_fallback()."""
+
+    def test_returns_primary_on_success(self, monkeypatch) -> None:
+        """When the primary model succeeds, return its result without trying fallbacks."""
+        calls: list[str] = []
+
+        def _fake_judge_session(text, category=None, *, goals, model, **kw):
+            calls.append(model)
+            return {"score": 0.8, "reason": "Primary worked", "model": model}
+
+        monkeypatch.setattr("gptme_sessions.judge.judge_session", _fake_judge_session)
+
+        result = judge_session_with_fallback(
+            "session text",
+            goals="ship useful work",
+            fallback_models=("fallback/model-a",),
+        )
+
+        assert result is not None
+        assert result["score"] == 0.8
+        assert calls == [DEFAULT_JUDGE_MODEL]
+
+    def test_tries_fallback_after_primary_fails(self, monkeypatch) -> None:
+        """When the primary fails, the first fallback model is used."""
+        calls: list[str] = []
+
+        def _fake_judge_session(text, category=None, *, goals, model, **kw):
+            calls.append(model)
+            if model == DEFAULT_JUDGE_MODEL:
+                return None
+            return {"score": 0.7, "reason": "Fallback worked", "model": model}
+
+        monkeypatch.setattr("gptme_sessions.judge.judge_session", _fake_judge_session)
+
+        result = judge_session_with_fallback(
+            "session text",
+            goals="ship useful work",
+            fallback_models=("fallback/model-a", "fallback/model-b"),
+        )
+
+        assert result is not None
+        assert result["score"] == 0.7
+        assert calls == [DEFAULT_JUDGE_MODEL, "fallback/model-a"]
+
+    def test_returns_none_when_all_models_fail(self, monkeypatch) -> None:
+        """Returns None when every model in the chain fails."""
+        monkeypatch.setattr(
+            "gptme_sessions.judge.judge_session",
+            lambda *a, **kw: None,
+        )
+
+        result = judge_session_with_fallback(
+            "session text",
+            goals="ship useful work",
+            fallback_models=("fallback/model-a",),
+        )
+
+        assert result is None
+
+    def test_no_fallbacks_uses_default_model_only(self, monkeypatch) -> None:
+        """With no fallback_models, only the default model is tried."""
+        calls: list[str] = []
+
+        def _fake_judge_session(text, category=None, *, goals, model, **kw):
+            calls.append(model)
+            return None
+
+        monkeypatch.setattr("gptme_sessions.judge.judge_session", _fake_judge_session)
+
+        result = judge_session_with_fallback("session text", goals="ship work")
+        assert result is None
+        assert calls == [DEFAULT_JUDGE_MODEL]
+
+
+class TestJudgeAndWritebackFallback:
+    """Tests for judge_and_writeback() fallback_models parameter."""
+
+    def test_uses_fallback_when_provided(self, tmp_path: Path, monkeypatch) -> None:
+        """When fallback_models is given, judge_session_with_fallback is used."""
+        store = SessionStore(sessions_dir=tmp_path)
+        store.append(SessionRecord(session_id="sid1", outcome="productive"))
+
+        calls: list[str] = []
+
+        def _fake_fallback(text, category=None, *, goals, default_model, fallback_models, **kw):
+            calls.append(("fallback", default_model, fallback_models))
+            return {"score": 0.75, "reason": "Fallback judge", "model": "fallback/m"}
+
+        monkeypatch.setattr("gptme_sessions.judge.judge_session_with_fallback", _fake_fallback)
+
+        result = judge_and_writeback(
+            text="text",
+            category="code",
+            goals="ship work",
+            session_id="sid1",
+            sessions_dir=tmp_path,
+            fallback_models=("fallback/m",),
+        )
+
+        assert result["status"] == "ok"
+        assert calls == [("fallback", DEFAULT_JUDGE_MODEL, ("fallback/m",))]
 
 
 class TestJudgeFromSignals:


### PR DESCRIPTION
## Summary

- Adds `judge_session_with_fallback()` — tries a primary judge model then iterates through ordered fallback models before returning `None`
- Extends `judge_and_writeback()` with optional `fallback_models: tuple[str, ...]` parameter; callers that don't pass it see no behaviour change
- 5 new tests covering primary success, fallback iteration, all-fail, no-fallback, and the `judge_and_writeback` fallback path

## Motivation

Agent-specific judge wrappers (e.g. Bob's `metaproductivity.session_alignment`) carry their own fallback loops that are not agent-specific. By landing this in `gptme-sessions`, any agent can get multi-model fallback without duplicating the logic.

The OpenRouter context-key convention (`OPENROUTER_API_KEY_JUDGE`) is already upstream in `_judge_openrouter_env` (from PR #715), so no new convention decisions are needed.

## Test plan

- [x] All 41 existing `test_judge.py` tests still pass
- [x] 5 new tests in `TestJudgeSessionWithFallback` and `TestJudgeAndWritebackFallback` pass
- [ ] Greptile review