### PR TITLE
feat(gptme-voice): persist subagent timings in call archives

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -14,7 +14,7 @@ import logging
 import os
 import shlex
 import time
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
 import click
@@ -67,6 +67,7 @@ class RecentCallRecord:
     ended_at: float
     transcript: list[TranscriptTurn]
     metadata: dict[str, str]
+    subagent_timings: list[dict[str, object]] = field(default_factory=list)
 
 
 def _build_caller_instructions(
@@ -280,13 +281,16 @@ class VoiceServer:
         )
 
     def _record_payload(self, record: RecentCallRecord) -> dict[str, object]:
-        return {
+        payload: dict[str, object] = {
             "caller_id": record.caller_id,
             "source": record.source,
             "ended_at": record.ended_at,
             "transcript": [asdict(turn) for turn in record.transcript],
             "metadata": record.metadata,
         }
+        if record.subagent_timings:
+            payload["subagent_timings"] = record.subagent_timings
+        return payload
 
     def _write_call_record(self, path: Path, record: RecentCallRecord) -> Path:
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -316,6 +320,10 @@ class VoiceServer:
                     for item in payload.get("transcript", [])
                     if item.get("role") and item.get("text")
                 ]
+                raw_timings = payload.get("subagent_timings") or []
+                subagent_timings = [
+                    dict(item) for item in raw_timings if isinstance(item, dict)
+                ]
                 return RecentCallRecord(
                     caller_id=payload["caller_id"],
                     source=payload.get("source", "unknown"),
@@ -326,6 +334,7 @@ class VoiceServer:
                         for key, value in payload.get("metadata", {}).items()
                         if value is not None
                     },
+                    subagent_timings=subagent_timings,
                 )
             except Exception as exc:
                 logger.warning(
@@ -447,9 +456,17 @@ class VoiceServer:
         source: str,
         transcript: list[TranscriptTurn],
         metadata: dict[str, str],
+        tool_bridge: GptmeToolBridge | None = None,
     ) -> None:
         if not caller_id:
             return
+
+        subagent_timings: list[dict[str, object]] = []
+        if tool_bridge is not None:
+            try:
+                subagent_timings = tool_bridge.get_timings()
+            except Exception as exc:  # defensive: never block archival on telemetry
+                logger.warning("Failed to collect subagent timings: %s", exc)
 
         record = RecentCallRecord(
             caller_id=caller_id,
@@ -457,6 +474,7 @@ class VoiceServer:
             ended_at=time.time(),
             transcript=transcript,
             metadata={k: v for k, v in metadata.items() if v},
+            subagent_timings=subagent_timings,
         )
         self._save_recent_call(record)
         record_path = self._save_call_record(record)
@@ -549,6 +567,7 @@ class VoiceServer:
         stream_sid: str | None = None
         caller_id: str | None = None
         realtime_client: OpenAIRealtimeClient | None = None
+        tool_bridge: GptmeToolBridge | None = None
         audio_converter = AudioConverter()
         transcript: list[TranscriptTurn] = []
         metadata: dict[str, str] = {}
@@ -665,7 +684,13 @@ class VoiceServer:
                 await self._disconnect_realtime_client(realtime_client)
             if call_sid and call_sid in self._connections:
                 del self._connections[call_sid]
-            await self._on_call_end(caller_id, "twilio", transcript, metadata)
+            await self._on_call_end(
+                caller_id,
+                "twilio",
+                transcript,
+                metadata,
+                tool_bridge=tool_bridge,
+            )
 
     async def _send_to_twilio(self, websocket, stream_sid: str, audio_data: bytes):
         """Send audio to Twilio Media Stream."""
@@ -707,6 +732,7 @@ class VoiceServer:
 
         caller_id = self._get_local_caller_id(websocket)
         realtime_client: OpenAIRealtimeClient | None = None
+        tool_bridge: GptmeToolBridge | None = None
         transcript: list[TranscriptTurn] = []
 
         try:
@@ -781,6 +807,7 @@ class VoiceServer:
                 "local",
                 transcript,
                 {"caller_id": caller_id, "provider": self.provider},
+                tool_bridge=tool_bridge,
             )
 
     async def _schedule_hangup(

--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -97,6 +97,7 @@ class GptmeToolBridge:
         self.model_smart = env_model_smart or legacy_env_model or self.MODEL_SMART
         self._pending_tasks: dict[str, PendingTask] = {}
         self._task_counter = 0
+        self._completed_timings: list[dict[str, object]] = []
 
     @staticmethod
     def _extract_error_text(stdout: str, stderr: str, output: str) -> str:
@@ -212,6 +213,44 @@ class GptmeToolBridge:
             entry.model or "default",
             ", ".join(parts),
         )
+
+        self._completed_timings.append(
+            self._build_timing_record(task_id, entry, timings)
+        )
+
+    def _build_timing_record(
+        self,
+        task_id: str,
+        entry: PendingTask,
+        timings: dict[str, float],
+    ) -> dict[str, object]:
+        description = entry.description or ""
+        if len(description) > _MAX_TASK_PREVIEW:
+            description = description[: _MAX_TASK_PREVIEW - 1] + "…"
+        record: dict[str, object] = {
+            "task_id": task_id,
+            "mode": entry.mode,
+            "model": entry.model,
+            "task_preview": description,
+            "returncode": entry.returncode,
+            "timings": dict(timings),
+        }
+        return record
+
+    def get_timings(self) -> list[dict[str, object]]:
+        """Return a copy of timing records for completed subagent runs.
+
+        Each entry is deep-copied one level so callers can mutate without
+        affecting the bridge's internal state.
+        """
+        copies: list[dict[str, object]] = []
+        for record in self._completed_timings:
+            copy = dict(record)
+            inner = record.get("timings")
+            if isinstance(inner, dict):
+                copy["timings"] = dict(inner)
+            copies.append(copy)
+        return copies
 
     async def _run_subagent(self, task_id: str, task: str, mode: str = "smart") -> None:
         """Run a subagent in the background and inject result when done."""

--- a/packages/gptme-voice/tests/test_tool_bridge.py
+++ b/packages/gptme-voice/tests/test_tool_bridge.py
@@ -666,6 +666,50 @@ def test_execute_kills_process_on_cancel() -> None:
     asyncio.run(_exercise())
 
 
+def test_get_timings_is_empty_before_any_dispatch() -> None:
+    bridge = GptmeToolBridge(workspace="/fake/workspace")
+    assert bridge.get_timings() == []
+
+
+def test_get_timings_records_completed_subagent_run() -> None:
+    async def _exercise() -> None:
+        async def _fake_create_subprocess_exec(*_args, **_kwargs):
+            return _FakeProcess(
+                returncode=0,
+                stdout="[INFO] quick lookup complete\n",
+            )
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+            bridge = GptmeToolBridge(workspace="/fake/workspace", timeout=10)
+
+            dispatch = await bridge.handle_function_call(
+                "subagent", {"task": "check active tasks", "mode": "fast"}
+            )
+            task_id = dispatch["task_id"]
+
+            # Let the background task run to completion.
+            for _ in range(20):
+                await asyncio.sleep(0)
+
+        timings = bridge.get_timings()
+        assert len(timings) == 1
+        record = timings[0]
+        assert record["task_id"] == task_id
+        assert record["mode"] == "fast"
+        assert record["model"] == bridge.model_fast
+        assert record["returncode"] == 0
+        assert "check active tasks" in record["task_preview"]
+        assert "timings" in record
+        assert record["timings"]["total_seconds"] >= 0
+
+        # Returned records must be copies, not shared state.
+        record["timings"]["total_seconds"] = 999.0
+        assert bridge.get_timings()[0]["timings"]["total_seconds"] != 999.0
+
+    asyncio.run(_exercise())
+
+
 def test_subagent_cancel_all_cancels_every_pending_task() -> None:
     async def _exercise() -> None:
         class _SlowProcess(_FakeProcess):


### PR DESCRIPTION
## Summary

- `GptmeToolBridge` now accumulates per-task timing records (dispatch→spawn, spawn→first_output, total) and exposes them via `get_timings()`
- `RecentCallRecord` gains an optional `subagent_timings` field; call archive JSON includes `subagent_timings` only when non-empty (backward compatible — existing archives and loaders are unaffected)
- Both Twilio and local call `_on_call_end` paths now thread the tool bridge through and persist timings into the archive
- New unit coverage for the accessor (empty-on-init, records after dispatch, deep copy isolation)

## Why

Voice call archives currently capture caller_id, source, transcript, and metadata, but subagent timing data was only emitted to journalctl via `_log_timing_summary` — never persisted. Retrospective latency analysis required log scraping, and logs rotate.

This supports the "where does subagent time actually go?" question raised on ErikBjare/bob#651. With timings in the per-call JSON, we can aggregate across days/weeks without relying on journald, and feed real dashboards instead of eyeballing `journalctl -u bob-voice-server`.

## Backward compatibility

- Old archives load cleanly: `subagent_timings` is `default_factory=list` on the dataclass, and `_load_recent_call` guards with `isinstance(item, dict)`
- New archives from calls without subagent dispatches emit no `subagent_timings` key, so existing on-disk files remain byte-identical on diff
- `_on_call_end` signature extension is a new optional param — no existing callsite breaks

## Test plan

- [x] `uv run pytest packages/gptme-voice/` — 67 passed
- [x] Unit tests cover: empty-on-init, accessor matches task_id/mode/model/returncode/task_preview, timings dict has total_seconds, copy isolation (caller-mutation doesn't leak into bridge state)

Ref: ErikBjare/bob#651