### PR TITLE
fix(gptme-voice): don't re-surface filtered TTY warning on empty subagent output

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -118,9 +118,11 @@ class GptmeToolBridge:
             return output
         if stdout_lines:
             return stdout_lines[-1]
-        fallback_stderr = stderr.strip()
-        if fallback_stderr:
-            return fallback_stderr
+        # Don't fall back to raw stderr here: if we got this far, the primary
+        # stderr filter already excluded ignorable lines (e.g. the non-TTY
+        # warning from prompt_toolkit). Returning raw stderr would re-surface
+        # exactly those filtered lines as the "error" reported to the user.
+        # Returning "" lets the caller fall back to the exit-code message.
         return ""
 
     @staticmethod
@@ -347,6 +349,7 @@ class GptmeToolBridge:
         try:
             process = await asyncio.create_subprocess_exec(
                 *cmd,
+                stdin=asyncio.subprocess.DEVNULL,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 cwd=self.workspace,

--- a/packages/gptme-voice/tests/test_tool_bridge.py
+++ b/packages/gptme-voice/tests/test_tool_bridge.py
@@ -69,6 +69,56 @@ def test_execute_prefers_meaningful_stdout_error_over_tty_warning() -> None:
     asyncio.run(_exercise())
 
 
+def test_execute_does_not_report_tty_warning_when_stdout_is_empty() -> None:
+    """Regression: subagent that exits 1 with empty stdout and an
+    only-ignorable stderr (e.g. the prompt_toolkit non-TTY warning) used to
+    surface that warning as the user-visible error. The fallback should
+    return an actionable exit-code message instead."""
+
+    async def _exercise() -> None:
+        bridge = GptmeToolBridge(workspace="/fake/workspace")
+
+        async def _fake_create_subprocess_exec(*_args, **_kwargs):
+            return _FakeProcess(
+                returncode=1,
+                stdout="",
+                stderr="Warning: Input is not a terminal (fd=0).\n",
+            )
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+            result = await bridge._execute("Investigate the voice system", mode="smart")
+
+        assert result.success is False
+        assert result.error is not None
+        assert "Input is not a terminal" not in result.error
+        assert "Exit code 1" in result.error
+
+    asyncio.run(_exercise())
+
+
+def test_execute_passes_devnull_stdin_to_subprocess() -> None:
+    """Defensive: the subagent should never inherit the parent's stdin.
+    Explicit DEVNULL prevents prompt_toolkit's non-TTY warning and also
+    guarantees the subagent can't block waiting on parent input."""
+
+    async def _exercise() -> None:
+        captured: dict[str, object] = {}
+
+        async def _fake_create_subprocess_exec(*args, **kwargs):
+            captured["kwargs"] = kwargs
+            return _FakeProcess(returncode=0)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+            bridge = GptmeToolBridge(workspace="/fake/workspace")
+            await bridge._execute("Inspect recent voice changes", mode="smart")
+
+        assert captured["kwargs"]["stdin"] == asyncio.subprocess.DEVNULL
+
+    asyncio.run(_exercise())
+
+
 def test_execute_uses_legacy_env_override_for_smart_model() -> None:
     async def _exercise() -> None:
         captured: dict[str, object] = {}


### PR DESCRIPTION
## Summary

Follow-on to #700 (which fixed the root-cause binary-path bug) and #718
(which exposed timings so we could see the failure mode).

The `_extract_error_text` fallback in `tool_bridge.py` returned raw
`stderr.strip()` when all other fields were empty. But raw stderr includes
lines the primary filter just explicitly excluded — in particular
prompt_toolkit's `Warning: Input is not a terminal (fd=0).` — so the
very warning we tried to suppress came back as the user-visible error
message whenever the subagent exited non-zero with no stdout.

If we reach that fallback, `stderr_lines` was already empty after
filtering, so stderr is by construction either empty or only-ignorable
content. Drop the buggy fallback and let the caller's existing
`f"Exit code {returncode}"` message surface instead.

Also pass `stdin=DEVNULL` to the subagent process. The subagent inherits
the voice server's stdin otherwise; under systemd (`StandardInput=null`)
that's fd 0 pointing at /dev/null, which is what triggers prompt_toolkit
to emit the non-TTY warning in the first place. Explicit DEVNULL makes
the intent obvious and prevents accidental inheritance if the server is
ever run under a different stdin setup.

## Test plan

- [x] `uv run --active pytest packages/gptme-voice/tests -q` → 69 passed
- [x] New `test_execute_does_not_report_tty_warning_when_stdout_is_empty`
  covers the empty-stdout + only-ignorable-stderr fallback path
- [x] New `test_execute_passes_devnull_stdin_to_subprocess` covers the
  defensive stdin change
- [ ] Verified in production on Bob's voice server (next live call that
  hits a subagent startup failure should report `Exit code N` instead
  of the TTY warning)

## Refs

- Follow-on to gptme/gptme-contrib#700 and gptme/gptme-contrib#718
- Context: ErikBjare/bob#651 (Grok realtime voice)