### PR TITLE
feat(gptme-voice): add handoff protocol library module

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/handoff.py
+++ b/packages/gptme-voice/src/gptme_voice/handoff.py
@@ -1,0 +1,382 @@
+"""Cross-agent voice handoff protocol (v1).
+
+Library module for initiating and validating voice-call handoffs between agents
+(Bob, Alice, Gordon, Sven). The protocol is specified in
+knowledge/technical-designs/cross-agent-voice-handoff.md (in Bob's workspace).
+
+This module contains the load-bearing primitives:
+
+* ``compute_hmac`` / ``validate`` — HMAC-SHA256 over canonical JSON.
+* ``build_handoff`` — construct and sign a v1 payload.
+* ``atomic_write`` / ``atomic_move`` / ``make_state_dirs`` — filesystem
+  primitives used by the state machine (handoff/ -> claimed/ -> archive/).
+* ``HandoffWriter`` — convenience wrapper for the initiator side: signs a
+  payload and publishes it to a shared state directory via atomic rename.
+
+Phase 1 shipped a protocol spec, validator, and a dry-run harness living
+in Bob's workspace (``scripts/voice-handoff-*.py``). This module consolidates
+the primitives inside the ``gptme-voice`` package so downstream integrations
+(voice-server write-side, target-agent listener) can depend on a typed,
+unit-tested library instead of importing from a sibling script via
+``importlib``.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, NamedTuple
+
+PROTOCOL_VERSION = 1
+
+REQUIRED_FIELDS: tuple[str, ...] = (
+    "protocol_version",
+    "handoff_id",
+    "caller_hash",
+    "from_agent",
+    "to_agent",
+    "reason",
+    "initiated_at",
+    "expires_at",
+    "transcript",
+    "hmac",
+)
+
+VALID_AGENTS: frozenset[str] = frozenset({"bob", "alice", "gordon", "sven"})
+
+STATE_SUBDIRS: tuple[str, ...] = ("handoff", "claimed", "archive", "rejected")
+
+_DEFAULT_TTL_SECONDS = 60
+
+
+class ValidationResult(NamedTuple):
+    ok: bool
+    reason: str = ""
+
+    def __bool__(self) -> bool:
+        return self.ok
+
+
+def _parse_iso8601(value: Any) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        if value.endswith("Z"):
+            value = value[:-1] + "+00:00"
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _canonical_json(payload: dict[str, Any]) -> bytes:
+    """Canonical JSON bytes for HMAC (sorted keys, no whitespace, hmac stripped)."""
+    stripped = {k: v for k, v in payload.items() if k != "hmac"}
+    return json.dumps(stripped, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def compute_hmac(payload: dict[str, Any], secret: bytes) -> str:
+    """HMAC-SHA256 over canonical JSON, base64-encoded."""
+    mac = hmac.new(secret, _canonical_json(payload), hashlib.sha256).digest()
+    return base64.b64encode(mac).decode("ascii")
+
+
+def validate(
+    payload: dict[str, Any],
+    *,
+    secret: bytes | None = None,
+    now: datetime | None = None,
+) -> ValidationResult:
+    """Validate a handoff payload against protocol v1.
+
+    If ``secret`` is provided, HMAC is verified. If omitted, HMAC field presence is
+    checked but its value is not verified (useful for draft validation before signing).
+    """
+    if not isinstance(payload, dict):
+        return ValidationResult(False, "payload is not a JSON object")
+
+    if "protocol_version" not in payload:
+        return ValidationResult(False, "missing required field: protocol_version")
+    version = payload["protocol_version"]
+    if version != PROTOCOL_VERSION:
+        return ValidationResult(
+            False,
+            f"unsupported protocol_version: {version} (expected {PROTOCOL_VERSION})",
+        )
+
+    for field in REQUIRED_FIELDS:
+        if field not in payload:
+            return ValidationResult(False, f"missing required field: {field}")
+
+    for agent_field in ("from_agent", "to_agent"):
+        if payload[agent_field] not in VALID_AGENTS:
+            return ValidationResult(
+                False,
+                f"{agent_field}={payload[agent_field]!r} not in {sorted(VALID_AGENTS)}",
+            )
+    if payload["from_agent"] == payload["to_agent"]:
+        return ValidationResult(False, "from_agent and to_agent must differ")
+
+    payload_caller_hash = payload["caller_hash"]
+    if (
+        not isinstance(payload_caller_hash, str)
+        or len(payload_caller_hash) != 16
+        or not all(c in "0123456789abcdef" for c in payload_caller_hash)
+    ):
+        return ValidationResult(False, "caller_hash must be 16 lowercase hex chars")
+
+    initiated = _parse_iso8601(payload["initiated_at"])
+    expires = _parse_iso8601(payload["expires_at"])
+    if initiated is None:
+        return ValidationResult(False, "initiated_at is not valid ISO 8601")
+    if expires is None:
+        return ValidationResult(False, "expires_at is not valid ISO 8601")
+    if expires <= initiated:
+        return ValidationResult(False, "expires_at must be after initiated_at")
+
+    current = now or datetime.now(timezone.utc)
+    if current > expires:
+        return ValidationResult(
+            False,
+            f"handoff expired at {expires.isoformat()} (now={current.isoformat()})",
+        )
+
+    transcript = payload["transcript"]
+    if not isinstance(transcript, list):
+        return ValidationResult(False, "transcript must be a list")
+    for i, turn in enumerate(transcript):
+        if not isinstance(turn, dict):
+            return ValidationResult(False, f"transcript[{i}] is not an object")
+        if turn.get("role") not in ("user", "assistant", "system"):
+            return ValidationResult(
+                False, f"transcript[{i}].role must be user/assistant/system"
+            )
+        if not isinstance(turn.get("text"), str):
+            return ValidationResult(False, f"transcript[{i}].text must be a string")
+
+    if secret is not None:
+        expected = compute_hmac(payload, secret)
+        if not hmac.compare_digest(expected, str(payload["hmac"])):
+            return ValidationResult(
+                False, "HMAC mismatch (payload tampered or wrong secret)"
+            )
+
+    return ValidationResult(True)
+
+
+def caller_hash(caller_id: str) -> str:
+    """Return the 16-char hex digest used to identify a caller without leaking PII."""
+    return hashlib.sha256(caller_id.encode("utf-8")).hexdigest()[:16]
+
+
+def build_handoff(
+    *,
+    from_agent: str,
+    to_agent: str,
+    caller_id: str,
+    reason: str,
+    secret: bytes,
+    transcript: list[dict[str, Any]] | None = None,
+    ttl_seconds: int = _DEFAULT_TTL_SECONDS,
+    now: datetime | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Construct and sign a protocol-v1 handoff payload.
+
+    ``transcript`` is the conversation history to carry across the handoff.
+    Pass ``extra`` for optional fields (``context_summary``, ``pending_actions``,
+    ``resume_hint``, etc.) that aren't required by the validator but are useful
+    for the target agent.
+    """
+    if from_agent not in VALID_AGENTS:
+        raise ValueError(f"from_agent={from_agent!r} not in {sorted(VALID_AGENTS)}")
+    if to_agent not in VALID_AGENTS:
+        raise ValueError(f"to_agent={to_agent!r} not in {sorted(VALID_AGENTS)}")
+    if from_agent == to_agent:
+        raise ValueError("from_agent and to_agent must differ")
+
+    now = now or datetime.now(timezone.utc)
+    ts = now.isoformat().replace("+00:00", "Z")
+    expires = (now + timedelta(seconds=ttl_seconds)).isoformat().replace("+00:00", "Z")
+    handoff_id = f"{int(now.timestamp())}-{from_agent}-{to_agent}"
+
+    payload: dict[str, Any] = {
+        "protocol_version": PROTOCOL_VERSION,
+        "handoff_id": handoff_id,
+        "caller_hash": caller_hash(caller_id),
+        "caller_id_ref": f"plaintext:{caller_id}",
+        "from_agent": from_agent,
+        "to_agent": to_agent,
+        "reason": reason,
+        "initiated_at": ts,
+        "expires_at": expires,
+        "transcript": list(transcript or []),
+    }
+    if extra:
+        # Don't let extra fields overwrite required fields (the HMAC would still
+        # cover them, but the schema would become surprising to readers).
+        for key, value in extra.items():
+            if key in payload or key == "hmac":
+                raise ValueError(f"extra field {key!r} collides with protocol field")
+            payload[key] = value
+    payload["hmac"] = compute_hmac(payload, secret)
+    return payload
+
+
+def make_state_dirs(root: Path) -> dict[str, Path]:
+    """Ensure ``handoff/``, ``claimed/``, ``archive/``, ``rejected/`` exist under ``root``."""
+    dirs = {name: root / name for name in STATE_SUBDIRS}
+    for d in dirs.values():
+        d.mkdir(parents=True, exist_ok=True)
+    return dirs
+
+
+def atomic_write(path: Path, data: bytes) -> None:
+    """Write ``data`` to ``path`` via a sibling tempfile + ``os.replace``.
+
+    Readers polling the directory will never see a partially-written file.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f".{path.name}.tmp")
+    tmp.write_bytes(data)
+    os.replace(tmp, path)
+
+
+def atomic_move(src: Path, dst: Path) -> None:
+    """Same-filesystem atomic rename (``os.replace``), creating ``dst.parent`` if needed."""
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    os.replace(src, dst)
+
+
+def _next_sequence(handoff_dir: Path, caller_digest: str) -> int:
+    """Return the next monotonic sequence number for this caller in ``handoff_dir``.
+
+    Looks at both live handoff files and any shadowed ``.NAME.tmp`` in-flight
+    writes, so a racing second publish with the same timestamp doesn't reuse a
+    filename.
+    """
+    max_seq = -1
+    prefix = f"{caller_digest}-"
+    for entry in handoff_dir.iterdir() if handoff_dir.exists() else ():
+        name = entry.name.lstrip(".")
+        if not name.startswith(prefix) or not name.endswith(".json"):
+            continue
+        try:
+            seq_str = name[len(prefix) : -len(".json")]
+            # Strip the ".tmp" suffix if this was an in-flight write.
+            if seq_str.endswith(".tmp"):
+                seq_str = seq_str[: -len(".tmp")]
+            seq = int(seq_str)
+        except ValueError:
+            continue
+        max_seq = max(max_seq, seq)
+    return max_seq + 1
+
+
+@dataclass
+class PublishedHandoff:
+    """Return value from :meth:`HandoffWriter.initiate`."""
+
+    path: Path
+    payload: dict[str, Any]
+
+
+class HandoffWriter:
+    """Initiator-side helper: sign a payload and publish it to ``handoff/``.
+
+    The writer is stateless aside from the shared directory; a voice server can
+    keep a single instance per peer and call :meth:`initiate` whenever the LLM
+    decides to transfer the call.
+    """
+
+    def __init__(
+        self,
+        state_dir: Path,
+        *,
+        from_agent: str,
+        secret: bytes,
+    ) -> None:
+        if from_agent not in VALID_AGENTS:
+            raise ValueError(f"from_agent={from_agent!r} not in {sorted(VALID_AGENTS)}")
+        if not secret:
+            raise ValueError("secret must be non-empty bytes")
+        self.state_dir = state_dir
+        self.from_agent = from_agent
+        self.secret = secret
+        self._dirs = make_state_dirs(state_dir)
+
+    @property
+    def handoff_dir(self) -> Path:
+        return self._dirs["handoff"]
+
+    def initiate(
+        self,
+        *,
+        to_agent: str,
+        caller_id: str,
+        reason: str,
+        transcript: list[dict[str, Any]] | None = None,
+        ttl_seconds: int = _DEFAULT_TTL_SECONDS,
+        extra: dict[str, Any] | None = None,
+        now: datetime | None = None,
+    ) -> PublishedHandoff:
+        """Build a signed handoff and publish it atomically to ``handoff/``.
+
+        Raises ``ValueError`` for schema violations (unknown agent, self-handoff).
+        The returned ``PublishedHandoff`` carries both the final on-disk path and
+        the signed payload, so callers can log or surface the ``handoff_id``
+        without re-reading the file.
+        """
+        payload = build_handoff(
+            from_agent=self.from_agent,
+            to_agent=to_agent,
+            caller_id=caller_id,
+            reason=reason,
+            secret=self.secret,
+            transcript=transcript,
+            ttl_seconds=ttl_seconds,
+            now=now,
+            extra=extra,
+        )
+        digest = payload["caller_hash"]
+        seq = _next_sequence(self.handoff_dir, digest)
+        path = self.handoff_dir / f"{digest}-{seq}.json"
+        data = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+        atomic_write(path, data)
+        return PublishedHandoff(path=path, payload=payload)
+
+
+def archive_filename(
+    payload: dict[str, Any], *, completed_at: float | None = None
+) -> str:
+    """Return the canonical ``archive/`` filename for a completed handoff.
+
+    Filenames encode both agents plus the handoff id so lineage is preserved.
+    """
+    ts = int(completed_at if completed_at is not None else time.time())
+    return f"{ts}-{payload['from_agent']}-{payload['to_agent']}-{payload['handoff_id']}.json"
+
+
+__all__ = [
+    "PROTOCOL_VERSION",
+    "REQUIRED_FIELDS",
+    "STATE_SUBDIRS",
+    "VALID_AGENTS",
+    "HandoffWriter",
+    "PublishedHandoff",
+    "ValidationResult",
+    "archive_filename",
+    "atomic_move",
+    "atomic_write",
+    "build_handoff",
+    "caller_hash",
+    "compute_hmac",
+    "make_state_dirs",
+    "validate",
+]

--- a/packages/gptme-voice/src/gptme_voice/handoff.py
+++ b/packages/gptme-voice/src/gptme_voice/handoff.py
@@ -202,6 +202,8 @@ def build_handoff(
         raise ValueError("from_agent and to_agent must differ")
 
     now = now or datetime.now(timezone.utc)
+    if now.tzinfo is None:
+        raise ValueError("now must be timezone-aware (e.g. datetime.now(timezone.utc))")
     ts = now.isoformat().replace("+00:00", "Z")
     expires = (now + timedelta(seconds=ttl_seconds)).isoformat().replace("+00:00", "Z")
     ch = caller_hash(caller_id)

--- a/packages/gptme-voice/src/gptme_voice/handoff.py
+++ b/packages/gptme-voice/src/gptme_voice/handoff.py
@@ -204,13 +204,13 @@ def build_handoff(
     now = now or datetime.now(timezone.utc)
     ts = now.isoformat().replace("+00:00", "Z")
     expires = (now + timedelta(seconds=ttl_seconds)).isoformat().replace("+00:00", "Z")
-    handoff_id = f"{int(now.timestamp())}-{from_agent}-{to_agent}"
+    ch = caller_hash(caller_id)
+    handoff_id = f"{int(now.timestamp())}-{from_agent}-{to_agent}-{ch}"
 
     payload: dict[str, Any] = {
         "protocol_version": PROTOCOL_VERSION,
         "handoff_id": handoff_id,
-        "caller_hash": caller_hash(caller_id),
-        "caller_id_ref": f"plaintext:{caller_id}",
+        "caller_hash": ch,
         "from_agent": from_agent,
         "to_agent": to_agent,
         "reason": reason,
@@ -265,13 +265,17 @@ def _next_sequence(handoff_dir: Path, caller_digest: str) -> int:
     prefix = f"{caller_digest}-"
     for entry in handoff_dir.iterdir() if handoff_dir.exists() else ():
         name = entry.name.lstrip(".")
-        if not name.startswith(prefix) or not name.endswith(".json"):
+        if not name.startswith(prefix):
+            continue
+        # Accept both committed files ({hash}-{seq}.json) and in-flight atomics
+        # ({hash}-{seq}.json.tmp — written by atomic_write before os.replace).
+        if name.endswith(".json"):
+            seq_str = name[len(prefix) : -len(".json")]
+        elif name.endswith(".json.tmp"):
+            seq_str = name[len(prefix) : -len(".json.tmp")]
+        else:
             continue
         try:
-            seq_str = name[len(prefix) : -len(".json")]
-            # Strip the ".tmp" suffix if this was an in-flight write.
-            if seq_str.endswith(".tmp"):
-                seq_str = seq_str[: -len(".tmp")]
             seq = int(seq_str)
         except ValueError:
             continue

--- a/packages/gptme-voice/tests/test_handoff.py
+++ b/packages/gptme-voice/tests/test_handoff.py
@@ -1,0 +1,262 @@
+"""Tests for the cross-agent voice handoff library (protocol v1)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from gptme_voice.handoff import (
+    PROTOCOL_VERSION,
+    STATE_SUBDIRS,
+    HandoffWriter,
+    archive_filename,
+    atomic_move,
+    atomic_write,
+    build_handoff,
+    caller_hash,
+    compute_hmac,
+    make_state_dirs,
+    validate,
+)
+
+SECRET = b"bob-alice-handoff-test-secret-v1!"
+
+
+# ---------- compute_hmac / validate ----------
+
+
+def _sample_payload(
+    *,
+    now: datetime | None = None,
+    secret: bytes = SECRET,
+    **overrides,
+) -> dict:
+    now = now or datetime(2026, 4, 21, 10, 0, 0, tzinfo=timezone.utc)
+    return build_handoff(
+        from_agent="bob",
+        to_agent="alice",
+        caller_id="test-caller",
+        reason="scheduling_capability",
+        secret=secret,
+        transcript=[{"role": "user", "text": "hello", "ts": "2026-04-21T10:00:00Z"}],
+        now=now,
+        **overrides,
+    )
+
+
+def test_valid_payload_roundtrips():
+    payload = _sample_payload()
+    result = validate(
+        payload,
+        secret=SECRET,
+        now=datetime(2026, 4, 21, 10, 0, 30, tzinfo=timezone.utc),
+    )
+    assert result.ok, result.reason
+    # Re-computing the HMAC on an unchanged payload should match.
+    assert compute_hmac(payload, SECRET) == payload["hmac"]
+
+
+def test_unsupported_protocol_version_rejected():
+    payload = _sample_payload()
+    payload["protocol_version"] = 2
+    # Re-sign so the failure is version-based, not HMAC-based.
+    payload["hmac"] = compute_hmac(payload, SECRET)
+    result = validate(payload, secret=SECRET)
+    assert not result.ok
+    assert "protocol_version" in result.reason
+
+
+def test_missing_required_field_rejected():
+    payload = _sample_payload()
+    del payload["transcript"]
+    result = validate(payload, secret=SECRET)
+    assert not result.ok
+    assert "transcript" in result.reason
+
+
+def test_expired_payload_rejected():
+    now = datetime(2026, 4, 21, 10, 0, 0, tzinfo=timezone.utc)
+    payload = _sample_payload(now=now)
+    past = now + timedelta(seconds=120)  # 60s after expires_at
+    result = validate(payload, secret=SECRET, now=past)
+    assert not result.ok
+    assert "expired" in result.reason
+
+
+def test_tampered_transcript_rejected():
+    payload = _sample_payload()
+    payload["transcript"].append({"role": "user", "text": "injected"})
+    result = validate(payload, secret=SECRET)
+    assert not result.ok
+    assert "HMAC" in result.reason
+
+
+def test_self_handoff_rejected_at_build_time():
+    with pytest.raises(ValueError, match="differ"):
+        build_handoff(
+            from_agent="bob",
+            to_agent="bob",
+            caller_id="x",
+            reason="r",
+            secret=SECRET,
+        )
+
+
+def test_unknown_agent_rejected_at_build_time():
+    with pytest.raises(ValueError, match="not in"):
+        build_handoff(
+            from_agent="bob",
+            to_agent="mallory",
+            caller_id="x",
+            reason="r",
+            secret=SECRET,
+        )
+
+
+def test_hmac_without_secret_is_not_verified():
+    """Validation without a secret still requires the hmac field but doesn't verify it."""
+    payload = _sample_payload()
+    payload["hmac"] = "clearly-not-the-real-signature"
+    result = validate(payload, secret=None)
+    assert result.ok, result.reason
+
+
+def test_extra_fields_cannot_overwrite_protocol_fields():
+    with pytest.raises(ValueError, match="collides"):
+        build_handoff(
+            from_agent="bob",
+            to_agent="alice",
+            caller_id="x",
+            reason="r",
+            secret=SECRET,
+            extra={"transcript": "stolen"},
+        )
+
+
+def test_extra_fields_carried_and_signed():
+    payload = _sample_payload(
+        extra={"context_summary": "scheduling meeting with Patrik"}
+    )
+    assert payload["context_summary"] == "scheduling meeting with Patrik"
+    # Mutating the extra field should break the HMAC.
+    tampered = dict(payload)
+    tampered["context_summary"] = "mutated"
+    result = validate(tampered, secret=SECRET)
+    assert not result.ok
+    assert "HMAC" in result.reason
+
+
+# ---------- caller_hash ----------
+
+
+def test_caller_hash_is_stable_and_hex():
+    digest = caller_hash("+46765784797")
+    assert len(digest) == 16
+    assert all(c in "0123456789abcdef" for c in digest)
+    assert caller_hash("+46765784797") == digest  # deterministic
+
+
+# ---------- atomic_write / atomic_move ----------
+
+
+def test_atomic_write_creates_parent_and_no_partial(tmp_path: Path):
+    target = tmp_path / "subdir" / "payload.json"
+    atomic_write(target, b'{"ok": true}')
+    assert target.read_bytes() == b'{"ok": true}'
+    # No leftover tempfile.
+    assert not list(tmp_path.rglob(".*.tmp"))
+
+
+def test_atomic_move_across_subdirs(tmp_path: Path):
+    src = tmp_path / "handoff" / "a.json"
+    dst = tmp_path / "claimed" / "a.json"
+    atomic_write(src, b"{}")
+    atomic_move(src, dst)
+    assert dst.exists()
+    assert not src.exists()
+
+
+# ---------- HandoffWriter ----------
+
+
+def test_handoff_writer_initiate_writes_signed_payload(tmp_path: Path):
+    writer = HandoffWriter(tmp_path, from_agent="bob", secret=SECRET)
+    published = writer.initiate(
+        to_agent="alice",
+        caller_id="+46765784797",
+        reason="scheduling_capability",
+        transcript=[
+            {"role": "user", "text": "please get alice", "ts": "2026-04-21T10:00:00Z"}
+        ],
+    )
+    assert published.path.is_file()
+    on_disk = json.loads(published.path.read_text())
+    assert on_disk == published.payload
+    result = validate(on_disk, secret=SECRET)
+    assert result.ok, result.reason
+    assert on_disk["from_agent"] == "bob"
+    assert on_disk["to_agent"] == "alice"
+    assert on_disk["protocol_version"] == PROTOCOL_VERSION
+
+
+def test_handoff_writer_sequences_multiple_initiations_for_same_caller(
+    tmp_path: Path,
+):
+    writer = HandoffWriter(tmp_path, from_agent="bob", secret=SECRET)
+    now = datetime(2026, 4, 21, 10, 0, 0, tzinfo=timezone.utc)
+    first = writer.initiate(
+        to_agent="alice",
+        caller_id="+46765784797",
+        reason="r1",
+        now=now,
+    )
+    second = writer.initiate(
+        to_agent="alice",
+        caller_id="+46765784797",
+        reason="r2",
+        # Same instant — forces filenames to disambiguate via sequence, not timestamp.
+        now=now,
+    )
+    assert first.path != second.path
+    assert first.path.name.endswith("-0.json")
+    assert second.path.name.endswith("-1.json")
+
+
+def test_handoff_writer_creates_all_state_subdirs(tmp_path: Path):
+    HandoffWriter(tmp_path, from_agent="bob", secret=SECRET)
+    for subdir in STATE_SUBDIRS:
+        assert (tmp_path / subdir).is_dir()
+
+
+def test_handoff_writer_rejects_invalid_from_agent(tmp_path: Path):
+    with pytest.raises(ValueError, match="not in"):
+        HandoffWriter(tmp_path, from_agent="mallory", secret=SECRET)
+
+
+def test_handoff_writer_rejects_empty_secret(tmp_path: Path):
+    with pytest.raises(ValueError, match="secret"):
+        HandoffWriter(tmp_path, from_agent="bob", secret=b"")
+
+
+# ---------- make_state_dirs ----------
+
+
+def test_make_state_dirs_is_idempotent(tmp_path: Path):
+    dirs_a = make_state_dirs(tmp_path)
+    dirs_b = make_state_dirs(tmp_path)
+    assert dirs_a == dirs_b
+    for subdir in STATE_SUBDIRS:
+        assert dirs_a[subdir].is_dir()
+
+
+# ---------- archive_filename ----------
+
+
+def test_archive_filename_encodes_both_agents_and_id():
+    payload = _sample_payload()
+    name = archive_filename(payload, completed_at=1777000000)
+    assert name.startswith("1777000000-bob-alice-")
+    assert payload["handoff_id"] in name
+    assert name.endswith(".json")

--- a/packages/gptme-voice/tests/test_handoff.py
+++ b/packages/gptme-voice/tests/test_handoff.py
@@ -152,10 +152,10 @@ def test_extra_fields_carried_and_signed():
 
 
 def test_caller_hash_is_stable_and_hex():
-    digest = caller_hash("+46765784797")
+    digest = caller_hash("+15550001234")
     assert len(digest) == 16
     assert all(c in "0123456789abcdef" for c in digest)
-    assert caller_hash("+46765784797") == digest  # deterministic
+    assert caller_hash("+15550001234") == digest  # deterministic
 
 
 # ---------- atomic_write / atomic_move ----------
@@ -185,7 +185,7 @@ def test_handoff_writer_initiate_writes_signed_payload(tmp_path: Path):
     writer = HandoffWriter(tmp_path, from_agent="bob", secret=SECRET)
     published = writer.initiate(
         to_agent="alice",
-        caller_id="+46765784797",
+        caller_id="+15550001234",
         reason="scheduling_capability",
         transcript=[
             {"role": "user", "text": "please get alice", "ts": "2026-04-21T10:00:00Z"}
@@ -208,13 +208,13 @@ def test_handoff_writer_sequences_multiple_initiations_for_same_caller(
     now = datetime(2026, 4, 21, 10, 0, 0, tzinfo=timezone.utc)
     first = writer.initiate(
         to_agent="alice",
-        caller_id="+46765784797",
+        caller_id="+15550001234",
         reason="r1",
         now=now,
     )
     second = writer.initiate(
         to_agent="alice",
-        caller_id="+46765784797",
+        caller_id="+15550001234",
         reason="r2",
         # Same instant — forces filenames to disambiguate via sequence, not timestamp.
         now=now,

--- a/packages/gptme-voice/tests/test_handoff.py
+++ b/packages/gptme-voice/tests/test_handoff.py
@@ -115,6 +115,20 @@ def test_unknown_agent_rejected_at_build_time():
         )
 
 
+def test_naive_datetime_raises_value_error():
+    """Timezone-naive now must be rejected; otherwise validate() raises TypeError."""
+    naive_now = datetime(2026, 4, 21, 10, 0, 0)  # no tzinfo
+    with pytest.raises(ValueError, match="timezone-aware"):
+        build_handoff(
+            from_agent="bob",
+            to_agent="alice",
+            caller_id="test-caller",
+            reason="scheduling_capability",
+            secret=SECRET,
+            now=naive_now,
+        )
+
+
 def test_hmac_without_secret_is_not_verified():
     """Validation without a secret still requires the hmac field but doesn't verify it."""
     payload = _sample_payload()


### PR DESCRIPTION
## Summary

Packages the cross-agent voice handoff protocol v1 as an importable library module (`gptme_voice.handoff`) so voice servers can emit signed handoff payloads without the importlib+hyphenated-filename dance the bob-repo scripts currently use.

This is Phase 2 setup for idea #156 ([Cross-Agent Voice Handoff](https://github.com/ErikBjare/bob/blob/master/knowledge/technical-designs/cross-agent-voice-handoff.md)). Phase 1 (spec + validator + dry-run harness) already landed in bob's repo; this module is the shared surface that Phase 2b (voice-server write-side) and Phase 3 (cross-agent hub) will import from.

## What's in the module

- `build_handoff` / `validate` / `compute_hmac` — pure functions for constructing and verifying signed v1 payloads.
- `HandoffWriter` — stateless writer holding `(state_dir, from_agent, secret)`. Creates all state subdirs on init, writes atomically, sequences multiple handoffs for the same caller at the same timestamp so filenames stay unique.
- `atomic_write` / `atomic_move` / `make_state_dirs` — filesystem primitives exposed so the voice server's write side can reuse them.
- `caller_hash` / `archive_filename` — helpers.

## Design choices baked in

- `build_handoff` validates `from_agent`/`to_agent` against `VALID_AGENTS` and rejects self-handoff at build time, so bad payloads never hit disk.
- `extra` fields are covered by HMAC but cannot overwrite protocol fields — the helper raises `ValueError` if you try.
- `HandoffWriter` is stateless aside from its construction args so a voice server can keep one instance per peer without coordinating state.
- HMAC omits the `hmac` field itself and computes over canonical JSON (sorted keys, compact separators), matching the existing validator in bob's repo bit-for-bit.

## Test plan

- [x] `uv run --active pytest packages/gptme-voice/tests/test_handoff.py -q` — 20 new unit tests pass.
- [x] `uv run --active pytest packages/gptme-voice/tests -q` — full voice-package suite (89 tests) pass.
- [x] `uv run --active ruff check` + `ruff format --check` clean on new files.
- [x] Pre-commit hooks (prek) pass — ran via `git-safe-commit`.

Tests cover: HMAC roundtrip, protocol-version rejection, missing-field rejection, expired-payload rejection, transcript tamper detection, self-handoff rejection, unknown-agent rejection, extra-field signing, extra-field collision rejection, `caller_hash` stability, `atomic_write` atomicity, `atomic_move` across subdirs, `HandoffWriter.initiate` happy path, same-timestamp sequence disambiguation, state-subdir creation, invalid-agent/empty-secret rejection, `make_state_dirs` idempotency, and archive filename structure.

## What this unblocks

- Phase 2b: `_initiate_handoff(...)` in `VoiceServer` can now `from gptme_voice.handoff import HandoffWriter` and drop a signed payload into the shared state dir when a voice tool call requests a handoff.
- Phase 3: a cross-agent hub (or stub Alice listener on the same VM) can `from gptme_voice.handoff import validate, atomic_move` and drive the `handoff/ -> claimed/ -> archive/` state machine.

## Out of scope (follow-ups)

- Voice-server integration (`_initiate_handoff` tool call) — separate PR.
- Secret-management decision (per-pair `~/.secrets/voice-handoff-{peer}.key` bootstrap vs. folding into existing agent-key flow) — needs to land before a cross-VM Phase 3.
- Migrating bob's repo scripts (`scripts/voice-handoff-validate.py`, `scripts/voice-handoff-dry-run.py`) to import from this package — they'll keep working standalone until then.