### PR TITLE
feat(gptme-voice): wire handoff_to_agent tool to voice server (Phase 2b)

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
@@ -10,7 +10,7 @@ import base64
 import contextlib
 import json
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable
 
@@ -191,6 +191,9 @@ class SessionConfig:
     vad_threshold: float = 0.7
     vad_silence_duration_ms: int = 500
     vad_prefix_padding_ms: int = 300
+    available_agents: list[str] = field(
+        default_factory=lambda: ["alice", "gordon", "sven"]
+    )
 
 
 class OpenAIRealtimeClient:
@@ -386,7 +389,11 @@ class OpenAIRealtimeClient:
                     "type": "function",
                     "name": "handoff_to_agent",
                     "description": (
-                        "Transfer the caller to another AI agent (Alice, Gordon, or Sven). "
+                        "Transfer the caller to another AI agent ("
+                        + ", ".join(
+                            a.capitalize() for a in self.session_config.available_agents
+                        )
+                        + "). "
                         "Use this when the caller explicitly asks to speak with a different "
                         "agent, or when the topic is clearly outside your expertise and "
                         "another agent is better suited. Say a brief handoff notice first "
@@ -398,7 +405,7 @@ class OpenAIRealtimeClient:
                         "properties": {
                             "to_agent": {
                                 "type": "string",
-                                "enum": ["alice", "gordon", "sven"],
+                                "enum": self.session_config.available_agents,
                                 "description": "The agent to transfer the caller to.",
                             },
                             "reason": {

--- a/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
@@ -146,6 +146,15 @@ def _load_project_instructions(workspace: str | None = None) -> str:
         "happened yet and you are not the one who starts it.\n"
         "- It is fine to acknowledge that follow-up will happen automatically after "
         "hangup if the user asks. Just do not take credit for dispatching it.\n\n"
+        "HANDOFF TO ANOTHER AGENT:\n"
+        "- Use handoff_to_agent ONLY when the caller explicitly asks to speak with "
+        "Alice, Gordon, or Sven, or when the topic is clearly outside your expertise "
+        "and another specific agent is better suited.\n"
+        "- Always say a brief handoff notice before calling the tool "
+        "(e.g. 'I'll transfer you to Alice now — one moment.').\n"
+        "- The full transcript is forwarded automatically. You don't need to summarise "
+        "the conversation unless there's important context not obvious from the transcript.\n"
+        "- Do not use handoff as a way to avoid answering a question.\n\n"
     )
 
     if not parts:
@@ -371,6 +380,44 @@ class OpenAIRealtimeClient:
                                 ),
                             },
                         },
+                    },
+                },
+                {
+                    "type": "function",
+                    "name": "handoff_to_agent",
+                    "description": (
+                        "Transfer the caller to another AI agent (Alice, Gordon, or Sven). "
+                        "Use this when the caller explicitly asks to speak with a different "
+                        "agent, or when the topic is clearly outside your expertise and "
+                        "another agent is better suited. Say a brief handoff notice first "
+                        "(e.g. 'I'll transfer you to Alice now'). The transfer includes the "
+                        "full conversation transcript so the receiving agent has context."
+                    ),
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "to_agent": {
+                                "type": "string",
+                                "enum": ["alice", "gordon", "sven"],
+                                "description": "The agent to transfer the caller to.",
+                            },
+                            "reason": {
+                                "type": "string",
+                                "description": (
+                                    "Short reason for the transfer "
+                                    "(e.g. 'caller asked to speak with Alice'). Required."
+                                ),
+                            },
+                            "context_summary": {
+                                "type": "string",
+                                "description": (
+                                    "Optional brief summary of the conversation for the "
+                                    "receiving agent (max 500 chars). Use this to highlight "
+                                    "key context not obvious from the transcript."
+                                ),
+                            },
+                        },
+                        "required": ["to_agent", "reason"],
                     },
                 },
             ],

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -25,6 +25,7 @@ from starlette.responses import PlainTextResponse
 from starlette.routing import Route, WebSocketRoute
 from starlette.websockets import WebSocketDisconnect
 
+from ..handoff import HandoffWriter
 from .audio import AudioConverter
 from .openai_client import (
     OpenAIRealtimeClient,
@@ -231,6 +232,23 @@ class VoiceServer:
             _get_config_env("GPTME_VOICE_STATE_DIR") or _DEFAULT_STATE_DIR
         )
         self.state_dir.mkdir(parents=True, exist_ok=True)
+
+        # Cross-agent handoff writer (optional — only active when GPTME_VOICE_HANDOFF_DIR set)
+        handoff_dir_env = _get_config_env("GPTME_VOICE_HANDOFF_DIR")
+        agent_name = _get_config_env("GPTME_VOICE_AGENT_NAME") or "bob"
+        handoff_secret_env = _get_config_env("GPTME_VOICE_HANDOFF_SECRET")
+        if handoff_dir_env:
+            handoff_secret = (handoff_secret_env or "dev-only-secret").encode("utf-8")
+            self._handoff_writer: HandoffWriter | None = HandoffWriter(
+                Path(handoff_dir_env),
+                from_agent=agent_name,
+                secret=handoff_secret,
+            )
+            logger.info(
+                "Handoff enabled: from_agent=%s, dir=%s", agent_name, handoff_dir_env
+            )
+        else:
+            self._handoff_writer = None
 
         # Active connections: call_sid -> (twilio_ws, realtime_client)
         self._connections: dict[str, tuple] = {}
@@ -450,6 +468,70 @@ class VoiceServer:
 
         self._pending_post_calls[caller_id] = asyncio.create_task(_runner())
 
+    def _make_handoff_callback(
+        self,
+        caller_id_ref: list[str | None],
+        transcript_ref: list[TranscriptTurn],
+    ):
+        """Return an async callback for tool_bridge.on_handoff that captures call context.
+
+        ``caller_id_ref[0]`` and ``transcript_ref`` are mutable containers so the
+        callback always sees the current transcript at the moment of the handoff, not
+        the snapshot from when the callback was created.
+        """
+
+        async def _on_handoff(
+            to_agent: str, reason: str, context_summary: str | None
+        ) -> dict:
+            if self._handoff_writer is None:
+                return {
+                    "status": "not_supported",
+                    "message": (
+                        "Handoff is not configured. "
+                        "Set GPTME_VOICE_HANDOFF_DIR to enable cross-agent transfers."
+                    ),
+                }
+            caller_id = caller_id_ref[0]
+            if not caller_id:
+                return {
+                    "status": "error",
+                    "message": "Cannot initiate handoff: caller identity not yet established.",
+                }
+            transcript_dicts = [
+                {"role": t.role, "text": t.text} for t in transcript_ref
+            ]
+            extra: dict = {}
+            if context_summary:
+                extra["context_summary"] = context_summary
+            try:
+                published = self._handoff_writer.initiate(
+                    to_agent=to_agent,
+                    caller_id=caller_id,
+                    reason=reason,
+                    transcript=transcript_dicts,
+                    extra=extra or None,
+                )
+                logger.info(
+                    "Handoff published: id=%s to=%s path=%s",
+                    published.payload["handoff_id"],
+                    to_agent,
+                    published.path,
+                )
+                return {
+                    "status": "handoff_initiated",
+                    "handoff_id": published.payload["handoff_id"],
+                    "to_agent": to_agent,
+                    "message": (
+                        f"Transfer to {to_agent} initiated. "
+                        "The caller will be connected shortly."
+                    ),
+                }
+            except ValueError as exc:
+                logger.warning("Handoff rejected: %s", exc)
+                return {"status": "error", "message": str(exc)}
+
+        return _on_handoff
+
     async def _on_call_end(
         self,
         caller_id: str | None,
@@ -646,6 +728,7 @@ class VoiceServer:
                         workspace=self.workspace,
                         on_result=realtime_client.inject_message,
                         on_hangup=_twilio_hangup,
+                        on_handoff=self._make_handoff_callback([caller_id], transcript),
                     )
                     realtime_client.on_function_call = tool_bridge.handle_function_call
 
@@ -770,6 +853,7 @@ class VoiceServer:
                 workspace=self.workspace,
                 on_result=realtime_client.inject_message,
                 on_hangup=_local_hangup,
+                on_handoff=self._make_handoff_callback([caller_id], transcript),
             )
             realtime_client.on_function_call = tool_bridge.handle_function_call
 

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -237,7 +237,24 @@ class VoiceServer:
         handoff_dir_env = _get_config_env("GPTME_VOICE_HANDOFF_DIR")
         agent_name = _get_config_env("GPTME_VOICE_AGENT_NAME") or "bob"
         handoff_secret_env = _get_config_env("GPTME_VOICE_HANDOFF_SECRET")
+        handoff_agents_env = _get_config_env("GPTME_VOICE_HANDOFF_AGENTS")
+        # Comma-separated list of agents the running server can hand off to.
+        # Defaults to the known agents minus the current one.
+        _default_agents = [
+            a for a in ["alice", "gordon", "sven", "bob"] if a != agent_name
+        ]
+        self._available_agents: list[str] = (
+            [a.strip() for a in handoff_agents_env.split(",") if a.strip()]
+            if handoff_agents_env
+            else _default_agents
+        )
         if handoff_dir_env:
+            if not handoff_secret_env:
+                logger.warning(
+                    "GPTME_VOICE_HANDOFF_SECRET not set while GPTME_VOICE_HANDOFF_DIR is "
+                    "configured — using insecure fallback. Set GPTME_VOICE_HANDOFF_SECRET "
+                    "to a strong random value in production."
+                )
             handoff_secret = (handoff_secret_env or "dev-only-secret").encode("utf-8")
             self._handoff_writer: HandoffWriter | None = HandoffWriter(
                 Path(handoff_dir_env),
@@ -526,8 +543,8 @@ class VoiceServer:
                         "The caller will be connected shortly."
                     ),
                 }
-            except ValueError as exc:
-                logger.warning("Handoff rejected: %s", exc)
+            except (ValueError, OSError) as exc:
+                logger.warning("Handoff failed: %s", exc)
                 return {"status": "error", "message": str(exc)}
 
         return _on_handoff
@@ -695,10 +712,15 @@ class VoiceServer:
 
                     if self.model:
                         session_cfg = SessionConfig(
-                            instructions=instructions, model=self.model
+                            instructions=instructions,
+                            model=self.model,
+                            available_agents=self._available_agents,
                         )
                     else:
-                        session_cfg = SessionConfig(instructions=instructions)
+                        session_cfg = SessionConfig(
+                            instructions=instructions,
+                            available_agents=self._available_agents,
+                        )
                     realtime_client = self._make_client(
                         session_cfg,
                         on_audio=lambda audio: self._send_to_twilio(
@@ -825,9 +847,16 @@ class VoiceServer:
                 self.resume_window_seconds,
             )
             if self.model:
-                session_cfg = SessionConfig(instructions=instructions, model=self.model)
+                session_cfg = SessionConfig(
+                    instructions=instructions,
+                    model=self.model,
+                    available_agents=self._available_agents,
+                )
             else:
-                session_cfg = SessionConfig(instructions=instructions)
+                session_cfg = SessionConfig(
+                    instructions=instructions,
+                    available_agents=self._available_agents,
+                )
             realtime_client = self._make_client(
                 session_cfg,
                 on_audio=lambda audio: self._send_local_audio(websocket, audio),

--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -84,12 +84,14 @@ class GptmeToolBridge:
         workspace: str | None = None,
         on_result: Callable[[str], Awaitable[None]] | None = None,
         on_hangup: Callable[[str | None], Awaitable[None]] | None = None,
+        on_handoff: Callable[[str, str, str | None], Awaitable[dict]] | None = None,
     ):
         self.gptme_path = os.environ.get("GPTME_VOICE_SUBAGENT_PATH") or gptme_path
         self.timeout = timeout
         self.workspace = workspace
         self.on_result = on_result
         self.on_hangup = on_hangup
+        self.on_handoff = on_handoff
         legacy_env_model = os.environ.get("GPTME_VOICE_SUBAGENT_MODEL")
         env_model_fast = os.environ.get("GPTME_VOICE_SUBAGENT_MODEL_FAST")
         env_model_smart = os.environ.get("GPTME_VOICE_SUBAGENT_MODEL_SMART")
@@ -579,5 +581,25 @@ class GptmeToolBridge:
                 "status": "hanging_up",
                 "message": "Ending the call shortly.",
             }
+
+        if name == "handoff_to_agent":
+            to_agent = arguments.get("to_agent", "")
+            reason = arguments.get("reason", "")
+            context_summary = arguments.get("context_summary") or None
+            logger.info(
+                "Handoff requested (to_agent=%s, reason=%s)",
+                to_agent,
+                reason or "<none>",
+            )
+            if self.on_handoff is None:
+                return {
+                    "status": "not_supported",
+                    "message": (
+                        "Handoff is not configured on this server. "
+                        "Set GPTME_VOICE_HANDOFF_DIR to enable cross-agent transfers."
+                    ),
+                }
+            result = await self.on_handoff(to_agent, reason, context_summary)
+            return result
 
         return {"error": f"Unknown function: {name}"}

--- a/packages/gptme-voice/tests/test_tool_bridge.py
+++ b/packages/gptme-voice/tests/test_tool_bridge.py
@@ -786,3 +786,85 @@ def test_subagent_cancel_all_cancels_every_pending_task() -> None:
             assert status["pending_count"] == 0
 
     asyncio.run(_exercise())
+
+
+# --- handoff_to_agent tests ---
+
+
+def test_handoff_not_supported_when_callback_is_none() -> None:
+    """Without on_handoff wired, handoff_to_agent returns not_supported."""
+
+    async def _exercise() -> None:
+        bridge = GptmeToolBridge(workspace="/fake/workspace")
+        result = await bridge.handle_function_call(
+            "handoff_to_agent", {"to_agent": "alice", "reason": "caller asked"}
+        )
+        assert result["status"] == "not_supported"
+        assert "GPTME_VOICE_HANDOFF_DIR" in result["message"]
+
+    asyncio.run(_exercise())
+
+
+def test_handoff_invokes_callback_with_correct_args() -> None:
+    """When on_handoff is wired, the callback receives to_agent, reason, context_summary."""
+
+    async def _exercise() -> None:
+        captured: dict = {}
+
+        async def _fake_handoff(
+            to_agent: str, reason: str, context_summary: str | None
+        ) -> dict:
+            captured["to_agent"] = to_agent
+            captured["reason"] = reason
+            captured["context_summary"] = context_summary
+            return {
+                "status": "handoff_initiated",
+                "handoff_id": "test-id",
+                "to_agent": to_agent,
+                "message": "ok",
+            }
+
+        bridge = GptmeToolBridge(
+            workspace="/fake/workspace",
+            on_handoff=_fake_handoff,
+        )
+        result = await bridge.handle_function_call(
+            "handoff_to_agent",
+            {
+                "to_agent": "alice",
+                "reason": "caller asked for Alice",
+                "context_summary": "discussing gptme issues",
+            },
+        )
+        assert result["status"] == "handoff_initiated"
+        assert result["to_agent"] == "alice"
+        assert captured["to_agent"] == "alice"
+        assert captured["reason"] == "caller asked for Alice"
+        assert captured["context_summary"] == "discussing gptme issues"
+
+    asyncio.run(_exercise())
+
+
+def test_handoff_passes_none_context_summary_when_absent() -> None:
+    """context_summary is optional; when absent the callback gets None."""
+
+    async def _exercise() -> None:
+        captured: dict = {}
+
+        async def _fake_handoff(
+            to_agent: str, reason: str, context_summary: str | None
+        ) -> dict:
+            captured["context_summary"] = context_summary
+            return {
+                "status": "handoff_initiated",
+                "to_agent": to_agent,
+                "message": "ok",
+            }
+
+        bridge = GptmeToolBridge(workspace="/fake/workspace", on_handoff=_fake_handoff)
+        await bridge.handle_function_call(
+            "handoff_to_agent", {"to_agent": "gordon", "reason": "financial question"}
+        )
+        assert captured["context_summary"] is None
+
+    asyncio.run(_exercise())


### PR DESCRIPTION
## Summary

Phase 2b of cross-agent voice handoff (idea #156 in Bob's workspace). Builds on the `gptme_voice.handoff` library module shipped in #725.

- **`tool_bridge.py`**: adds `on_handoff` callback param to `GptmeToolBridge`; handles `handoff_to_agent` function calls; degrades gracefully when not wired (`not_supported` with actionable message pointing to `GPTME_VOICE_HANDOFF_DIR`)
- **`openai_client.py`**: adds `handoff_to_agent` tool schema (alice/gordon/sven targets, `reason` required, `context_summary` optional) and system-prompt guidance about when to use it
- **`server.py`**: imports `HandoffWriter`; reads `GPTME_VOICE_HANDOFF_DIR` / `GPTME_VOICE_AGENT_NAME` / `GPTME_VOICE_HANDOFF_SECRET` env vars; adds `_make_handoff_callback()` method that builds a closure over the live `caller_id` and `transcript`; wires `on_handoff` into both Twilio and local WebSocket handlers
- **`tests/test_tool_bridge.py`**: 3 new tests — not-supported path, callback invocation with full args, absent `context_summary` → `None`

## Configuration

To enable handoffs, set on the voice server:

```bash
GPTME_VOICE_HANDOFF_DIR=/path/to/shared/handoff/state   # shared across agents
GPTME_VOICE_AGENT_NAME=bob                               # default
GPTME_VOICE_HANDOFF_SECRET=<real-secret>                 # dev fallback if unset
```

The target agent (Phase 3) listens on `handoff/` in that shared dir, validates HMAC, and claims the file. For now the write-side is complete; the listener stub and hub service are Phase 3.

## Test plan

- [x] 93 tests pass in `packages/gptme-voice/tests/` (3 new + 90 existing)
- [x] Compiles cleanly, ruff/mypy pass
- [x] Handoff not configured → `not_supported` response (no crash)
- [x] Callback invoked with correct `to_agent`, `reason`, `context_summary`
- [x] Absent `context_summary` → `None` passed to callback