### PR TITLE
docs(lessons): add session_categories to 5 high-impact lessons

### DIFF
--- a/lessons/autonomous/pre-mortem-for-risky-actions.md
+++ b/lessons/autonomous/pre-mortem-for-risky-actions.md
@@ -14,6 +14,7 @@ match:
   - "DROP TABLE"
   - "production change"
   - "risky operation"
+  session_categories: [code, infrastructure, cleanup]
 target_grade: harm
 status: active
 ---

--- a/lessons/autonomous/thompson-sampling-work-categories.md
+++ b/lessons/autonomous/thompson-sampling-work-categories.md
@@ -12,6 +12,7 @@ match:
   - optimizing session mode bandit
   - category selection explore exploit
   - work category bandit setup
+  session_categories: [monitoring, self-review]
 ---
 
 # Thompson Sampling for Work Category Optimization

--- a/lessons/patterns/avoid-long-try-blocks.md
+++ b/lessons/patterns/avoid-long-try-blocks.md
@@ -12,6 +12,7 @@ match:
   - "try/except"
   - "split the try block"
   - "large try block"
+  session_categories: [code]
 status: active
 ---
 

--- a/lessons/patterns/data-loader-pr-quality.md
+++ b/lessons/patterns/data-loader-pr-quality.md
@@ -9,6 +9,7 @@ match:
   - loader test
   - timezone assertion
   - unit validation
+  session_categories: [code]
 status: active
 ---
 

--- a/lessons/tools/linear-api-integration.md
+++ b/lessons/tools/linear-api-integration.md
@@ -6,6 +6,7 @@ match:
     - "LINEAR_API_KEY not set"
     - "Linear GraphQL mutation"
     - "create Linear ticket"
+  session_categories: [triage, infrastructure]
 category: tools
 status: active
 ---


### PR DESCRIPTION
## Summary

Adds explicit `session_categories` metadata to 5 gptme-contrib lessons that have high LOO effectiveness scores but very low `trigger_accuracy` (0.00–0.09). This is part of the KWBench-style lesson trigger quality initiative (idea #153 in Bob's workspace).

With `session_categories` set, the session classifier uses `source=explicit, confidence=1.0` instead of the heuristic salience proxy, enabling more accurate measurement of whether lessons fire in the right session contexts.

**Lessons updated:**
- `avoid-long-try-blocks`: `[code]` (ta=0.05, Δ=+0.06)
- `data-loader-pr-quality`: `[code]` (ta=0.01, Δ=+0.04)
- `linear-api-integration`: `[triage, infrastructure]` (ta=0.06, Δ=+0.12)
- `pre-mortem-for-risky-actions`: `[code, infrastructure, cleanup]` (ta=0.06, Δ=+0.07)
- `thompson-sampling-work-categories`: `[monitoring, self-review]` (ta=0.06, Δ=+0.06)

## How it works

The `session_categories` field (under `match:` in frontmatter) is read by `session-classifier.py` via `_explicit_lesson_session_categories()`. When present, it bypasses the heuristic keyword-signal classifier and returns `source=explicit, confidence=1.0`.

The `update-lesson-bandit.py` then uses this to compute `trigger_accuracy` — the fraction of sessions where the lesson fired AND the session category matched the lesson's intended category.

## Test plan
- [x] `prek run --all-files` passes (verified locally)
- [x] Lesson format validated
- [x] Each updated lesson returns `source=explicit` from `infer_lesson_situation_categories()`