### PR TITLE
feat(gptme-voice): consume handoff bootstrap at session start

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -15,6 +15,7 @@ import os
 import shlex
 import time
 from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 
 import click
@@ -257,8 +258,19 @@ class VoiceServer:
     def _recent_state_dir(self) -> Path:
         return self.state_dir / "recent"
 
+    def _handoff_state_dir(self) -> Path:
+        return self.state_dir / "handoffs"
+
     def _call_archive_dir(self) -> Path:
         return self.state_dir / "archive"
+
+    def _handoff_bootstrap_path(self, handoff_id: str) -> Path:
+        safe_handoff_id = "".join(
+            ch for ch in handoff_id if ch.isalnum() or ch in {"-", "_"}
+        )
+        if not safe_handoff_id:
+            safe_handoff_id = "handoff"
+        return self._handoff_state_dir() / f"{safe_handoff_id}.json"
 
     def _call_record_path(self, record: RecentCallRecord) -> Path:
         identifier = (
@@ -342,6 +354,99 @@ class VoiceServer:
                 )
 
         return None
+
+    def _parse_state_timestamp(self, value: object) -> float | None:
+        if not isinstance(value, str) or not value.strip():
+            return None
+        normalized = value.strip().replace("Z", "+00:00")
+        try:
+            parsed = datetime.fromisoformat(normalized)
+        except ValueError:
+            return None
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.timestamp()
+
+    def _consume_handoff_bootstrap(self, handoff_id: str | None) -> str | None:
+        if not handoff_id:
+            return None
+
+        path = self._handoff_bootstrap_path(handoff_id)
+        if not path.exists():
+            logger.warning("Handoff bootstrap %s not found at %s", handoff_id, path)
+            return None
+
+        try:
+            payload = json.loads(path.read_text())
+        except Exception as exc:
+            logger.warning("Failed to load handoff bootstrap %s: %s", path, exc)
+            return None
+
+        if payload.get("protocol_version") != 1:
+            logger.warning(
+                "Ignoring handoff bootstrap %s with unsupported protocol_version=%r",
+                handoff_id,
+                payload.get("protocol_version"),
+            )
+            return None
+        if payload.get("source") != "voice_handoff":
+            logger.warning(
+                "Ignoring handoff bootstrap %s with unexpected source=%r",
+                handoff_id,
+                payload.get("source"),
+            )
+            return None
+
+        accepted_at = self._parse_state_timestamp(payload.get("accepted_at"))
+        if accepted_at is not None:
+            age_seconds = time.time() - accepted_at
+            if age_seconds > self.resume_window_seconds:
+                logger.info(
+                    "Ignoring stale handoff bootstrap %s (%ds old)",
+                    handoff_id,
+                    int(age_seconds),
+                )
+                return None
+
+        resume_context = str(payload.get("resume_context") or "").strip()
+        if not resume_context:
+            logger.warning(
+                "Ignoring handoff bootstrap %s with empty resume_context", handoff_id
+            )
+            return None
+
+        try:
+            path.unlink()
+        except OSError as exc:
+            logger.warning(
+                "Failed to delete consumed handoff bootstrap %s: %s", path, exc
+            )
+
+        logger.info("Consumed handoff bootstrap %s from %s", handoff_id, path)
+        return resume_context
+
+    def _build_session_instructions(
+        self,
+        *,
+        caller_id: str | None,
+        from_number: str = "",
+        handoff_id: str | None = None,
+    ) -> str:
+        instructions = self._instructions
+        if from_number:
+            instructions = _build_caller_instructions(
+                instructions, from_number, self.workspace
+            )
+
+        handoff_resume_context = self._consume_handoff_bootstrap(handoff_id)
+        if handoff_resume_context:
+            return f"{handoff_resume_context}\n\n{instructions}"
+
+        return _build_resume_instructions(
+            instructions,
+            self._consume_recent_call(caller_id),
+            self.resume_window_seconds,
+        )
 
     def _consume_recent_call(self, caller_id: str | None) -> RecentCallRecord | None:
         if not caller_id:
@@ -486,6 +591,12 @@ class VoiceServer:
             return caller_id
         return "local"
 
+    def _get_local_handoff_id(self, websocket) -> str | None:
+        handoff_id = websocket.query_params.get("handoff_id")
+        if handoff_id:
+            return handoff_id
+        return None
+
     async def health_check(self, request: Request) -> PlainTextResponse:
         """Health check endpoint."""
         return PlainTextResponse("OK")
@@ -571,6 +682,7 @@ class VoiceServer:
         audio_converter = AudioConverter()
         transcript: list[TranscriptTurn] = []
         metadata: dict[str, str] = {}
+        handoff_id: str | None = None
 
         try:
             async for message in websocket.iter_text():
@@ -595,14 +707,12 @@ class VoiceServer:
                     # Inject caller context into instructions (phone + name lookup)
                     custom_params = start.get("customParameters", {})
                     from_number = custom_params.get("from_number", "")
+                    handoff_id = custom_params.get("handoff_id") or None
                     caller_id = from_number or call_sid or stream_sid
-                    instructions = _build_caller_instructions(
-                        self._instructions, from_number, self.workspace
-                    )
-                    instructions = _build_resume_instructions(
-                        instructions,
-                        self._consume_recent_call(caller_id),
-                        self.resume_window_seconds,
+                    instructions = self._build_session_instructions(
+                        caller_id=caller_id,
+                        from_number=from_number,
+                        handoff_id=handoff_id,
                     )
                     metadata = {
                         "from_number": from_number,
@@ -610,6 +720,8 @@ class VoiceServer:
                         "stream_sid": stream_sid,
                         "provider": self.provider,
                     }
+                    if handoff_id:
+                        metadata["handoff_id"] = handoff_id
 
                     if self.model:
                         session_cfg = SessionConfig(
@@ -731,15 +843,15 @@ class VoiceServer:
         await websocket.accept()
 
         caller_id = self._get_local_caller_id(websocket)
+        handoff_id = self._get_local_handoff_id(websocket)
         realtime_client: OpenAIRealtimeClient | None = None
         tool_bridge: GptmeToolBridge | None = None
         transcript: list[TranscriptTurn] = []
 
         try:
-            instructions = _build_resume_instructions(
-                self._instructions,
-                self._consume_recent_call(caller_id),
-                self.resume_window_seconds,
+            instructions = self._build_session_instructions(
+                caller_id=caller_id,
+                handoff_id=handoff_id,
             )
             if self.model:
                 session_cfg = SessionConfig(instructions=instructions, model=self.model)
@@ -806,7 +918,11 @@ class VoiceServer:
                 caller_id,
                 "local",
                 transcript,
-                {"caller_id": caller_id, "provider": self.provider},
+                {
+                    "caller_id": caller_id,
+                    "provider": self.provider,
+                    **({"handoff_id": handoff_id} if handoff_id else {}),
+                },
                 tool_bridge=tool_bridge,
             )
 

--- a/packages/gptme-voice/tests/test_handoff.py
+++ b/packages/gptme-voice/tests/test_handoff.py
@@ -22,6 +22,8 @@ from gptme_voice.handoff import (
 )
 
 SECRET = b"bob-alice-handoff-test-secret-v1!"
+SAMPLE_NOW = datetime(2026, 4, 21, 10, 0, 0, tzinfo=timezone.utc)
+SAMPLE_VALIDATION_NOW = SAMPLE_NOW + timedelta(seconds=30)
 
 
 # ---------- compute_hmac / validate ----------
@@ -33,7 +35,7 @@ def _sample_payload(
     secret: bytes = SECRET,
     **overrides,
 ) -> dict:
-    now = now or datetime(2026, 4, 21, 10, 0, 0, tzinfo=timezone.utc)
+    now = now or SAMPLE_NOW
     return build_handoff(
         from_agent="bob",
         to_agent="alice",
@@ -63,7 +65,7 @@ def test_unsupported_protocol_version_rejected():
     payload["protocol_version"] = 2
     # Re-sign so the failure is version-based, not HMAC-based.
     payload["hmac"] = compute_hmac(payload, SECRET)
-    result = validate(payload, secret=SECRET)
+    result = validate(payload, secret=SECRET, now=SAMPLE_VALIDATION_NOW)
     assert not result.ok
     assert "protocol_version" in result.reason
 
@@ -71,7 +73,7 @@ def test_unsupported_protocol_version_rejected():
 def test_missing_required_field_rejected():
     payload = _sample_payload()
     del payload["transcript"]
-    result = validate(payload, secret=SECRET)
+    result = validate(payload, secret=SECRET, now=SAMPLE_VALIDATION_NOW)
     assert not result.ok
     assert "transcript" in result.reason
 
@@ -88,7 +90,7 @@ def test_expired_payload_rejected():
 def test_tampered_transcript_rejected():
     payload = _sample_payload()
     payload["transcript"].append({"role": "user", "text": "injected"})
-    result = validate(payload, secret=SECRET)
+    result = validate(payload, secret=SECRET, now=SAMPLE_VALIDATION_NOW)
     assert not result.ok
     assert "HMAC" in result.reason
 
@@ -133,7 +135,7 @@ def test_hmac_without_secret_is_not_verified():
     """Validation without a secret still requires the hmac field but doesn't verify it."""
     payload = _sample_payload()
     payload["hmac"] = "clearly-not-the-real-signature"
-    result = validate(payload, secret=None)
+    result = validate(payload, secret=None, now=SAMPLE_VALIDATION_NOW)
     assert result.ok, result.reason
 
 
@@ -157,7 +159,7 @@ def test_extra_fields_carried_and_signed():
     # Mutating the extra field should break the HMAC.
     tampered = dict(payload)
     tampered["context_summary"] = "mutated"
-    result = validate(tampered, secret=SECRET)
+    result = validate(tampered, secret=SECRET, now=SAMPLE_VALIDATION_NOW)
     assert not result.ok
     assert "HMAC" in result.reason
 
@@ -208,7 +210,7 @@ def test_handoff_writer_initiate_writes_signed_payload(tmp_path: Path):
     assert published.path.is_file()
     on_disk = json.loads(published.path.read_text())
     assert on_disk == published.payload
-    result = validate(on_disk, secret=SECRET)
+    result = validate(on_disk, secret=SECRET, now=SAMPLE_VALIDATION_NOW)
     assert result.ok, result.reason
     assert on_disk["from_agent"] == "bob"
     assert on_disk["to_agent"] == "alice"

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -163,6 +163,79 @@ def test_recent_call_is_ignored_outside_resume_window() -> None:
         assert resumed is None
 
 
+def test_consume_handoff_bootstrap_returns_resume_context_and_deletes_file() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        server = VoiceServer()
+        server.state_dir = Path(tmpdir)
+        server.resume_window_seconds = 300
+        server._instructions = "You are Alice."
+        bootstrap_path = server._handoff_bootstrap_path("handoff-123")
+        bootstrap_path.parent.mkdir(parents=True, exist_ok=True)
+        bootstrap_path.write_text(
+            json.dumps(
+                {
+                    "protocol_version": 1,
+                    "source": "voice_handoff",
+                    "handoff_id": "handoff-123",
+                    "accepted_at": "1970-01-01T00:18:20Z",
+                    "resume_context": "bob transferred this caller to alice.",
+                }
+            )
+        )
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("gptme_voice.realtime.server.time.time", lambda: 1_200.0)
+            instructions = server._build_session_instructions(
+                caller_id="+46700000007",
+                handoff_id="handoff-123",
+            )
+
+        assert "bob transferred this caller to alice." in instructions
+        assert "You are Alice." in instructions
+        assert not bootstrap_path.exists()
+
+
+def test_stale_handoff_bootstrap_falls_back_to_recent_call_resume() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        server = VoiceServer()
+        server.state_dir = Path(tmpdir)
+        server.resume_window_seconds = 300
+        server._instructions = "You are Alice."
+        record = RecentCallRecord(
+            caller_id="+46700000008",
+            source="twilio",
+            ended_at=1_300.0,
+            transcript=[TranscriptTurn(role="user", text="Resume the old call")],
+            metadata={},
+        )
+        server._save_recent_call(record)
+
+        bootstrap_path = server._handoff_bootstrap_path("handoff-stale")
+        bootstrap_path.parent.mkdir(parents=True, exist_ok=True)
+        bootstrap_path.write_text(
+            json.dumps(
+                {
+                    "protocol_version": 1,
+                    "source": "voice_handoff",
+                    "handoff_id": "handoff-stale",
+                    "accepted_at": "1970-01-01T00:16:40Z",
+                    "resume_context": "stale handoff context",
+                }
+            )
+        )
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("gptme_voice.realtime.server.time.time", lambda: 1_600.0)
+            instructions = server._build_session_instructions(
+                caller_id=record.caller_id,
+                handoff_id="handoff-stale",
+            )
+
+        assert "Resume the old call" in instructions
+        assert "stale handoff context" not in instructions
+        assert bootstrap_path.exists()
+
+
 def test_schedule_post_call_runs_configured_command_hook() -> None:
     async def _exercise() -> None:
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- consume `GPTME_VOICE_STATE_DIR/handoffs/<handoff_id>.json` at session start when a local websocket query param or Twilio custom parameter provides `handoff_id`
- route startup through a shared instruction builder so explicit handoff bootstrap takes precedence over normal quick-reconnect resume, while stale/malformed bootstrap files safely fall back
- make `test_handoff.py` validate against its fixture clock instead of wall time so the package suite stays green after 2026-04-21

## Why
Protocol v1 intentionally writes target-side bootstrap state keyed by `handoff_id`, not raw caller identity. This makes the safe same-host step explicit: downstream startup can ask for a specific handoff bootstrap and consume it once, without pretending it is ordinary caller-bound resume state.

## Verification
- `uv run pytest tests/test_server.py -q`
- `uv run ruff check src/gptme_voice/realtime/server.py tests/test_server.py tests/test_handoff.py`
- `uv run pytest tests -q`
