### PR TITLE
feat(gptme-sessions): add ToolSpan + SpanAggregates for per-tool-call tracing

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/__init__.py
+++ b/packages/gptme-sessions/src/gptme_sessions/__init__.py
@@ -48,6 +48,7 @@ from .classification import (
     judge_and_classify,
     normalize_category,
 )
+from .spans import SpanAggregates, ToolSpan, extract_spans_from_cc_jsonl
 from .store import SessionStore
 from .thompson_sampling import Bandit, BanditArm, BanditState, load_bandit_means
 from .transcript import (
@@ -99,4 +100,7 @@ __all__ = [
     "SessionTranscript",
     "TRANSCRIPT_SCHEMA_VERSION",
     "read_transcript",
+    "SpanAggregates",
+    "ToolSpan",
+    "extract_spans_from_cc_jsonl",
 ]

--- a/packages/gptme-sessions/src/gptme_sessions/spans.py
+++ b/packages/gptme-sessions/src/gptme_sessions/spans.py
@@ -247,9 +247,12 @@ def extract_spans_from_cc_jsonl(
 
                 dur_ms = -1
                 if dispatch_ts is not None and ts is not None:
-                    delta = (ts - dispatch_ts).total_seconds()
-                    if delta >= 0:
-                        dur_ms = int(delta * 1000)
+                    try:
+                        delta = (ts - dispatch_ts).total_seconds()
+                        if delta >= 0:
+                            dur_ms = int(delta * 1000)
+                    except TypeError:
+                        pass  # mixed tz-aware/naive timestamps – leave dur_ms as sentinel
 
                 exit_code = _exit_code(result_content) if tool_name == "Bash" else None
 

--- a/packages/gptme-sessions/src/gptme_sessions/spans.py
+++ b/packages/gptme-sessions/src/gptme_sessions/spans.py
@@ -41,7 +41,9 @@ def _output_size(content: object) -> int:
     if isinstance(content, str):
         return len(content)
     if isinstance(content, list):
-        return sum(len(c.get("text", "")) if isinstance(c, dict) else len(str(c)) for c in content)
+        return sum(
+            len(c.get("text", str(c))) if isinstance(c, dict) else len(str(c)) for c in content
+        )
     return 0
 
 
@@ -97,6 +99,12 @@ class SpanAggregates:
 
     These fields are suitable for inclusion in SessionRecord as optional
     fields (Phase 2 of the design doc).
+
+    Attributes:
+        retry_depth: Max consecutive redundant re-calls to the same tool
+            (first invocation excluded).  A value of 0 means no tool was
+            called twice in a row; 2 means the same tool was called 3 times
+            in succession (1 original + 2 retries).  Proxy for stuck loops.
     """
 
     total_spans: int
@@ -139,15 +147,16 @@ class SpanAggregates:
         avg_ms = sum(known_durations) / len(known_durations) if known_durations else -1.0
         max_ms = max(known_durations) if known_durations else -1
 
-        # Retry depth: max consecutive calls to the same tool
+        # Retry depth: max consecutive redundant re-calls to the same tool
+        # (first call is normal; streak counts re-invocations beyond it)
         retry_depth = 0
-        streak = 1
+        streak = 0
         for i in range(1, len(spans)):
             if spans[i].tool_name == spans[i - 1].tool_name:
                 streak += 1
                 retry_depth = max(retry_depth, streak)
             else:
-                streak = 1
+                streak = 0
 
         return cls(
             total_spans=len(spans),

--- a/packages/gptme-sessions/src/gptme_sessions/spans.py
+++ b/packages/gptme-sessions/src/gptme_sessions/spans.py
@@ -1,0 +1,262 @@
+"""Per-tool-call span extraction from agent trajectory files.
+
+A ToolSpan is a single tool invocation: one tool called once, with its
+timing, input/output sizes, and success recorded. Sessions produce
+sequences of spans that tell the per-turn story of what the agent did
+and how long each operation took.
+
+Supports Claude Code JSONL format. gptme format planned for a follow-up.
+
+Design doc: knowledge/technical-designs/span-level-tracing-design.md
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+
+_EXIT_CODE_RE = re.compile(r"(?:Exit code|exit code):\s*(\d+)")
+
+
+def _parse_ts(ts_str: str | None) -> datetime | None:
+    if not ts_str:
+        return None
+    try:
+        return datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _input_size(tool_input: object) -> int:
+    if isinstance(tool_input, dict):
+        return sum(len(str(v)) for v in tool_input.values())
+    return len(str(tool_input))
+
+
+def _output_size(content: object) -> int:
+    if isinstance(content, str):
+        return len(content)
+    if isinstance(content, list):
+        return sum(len(c.get("text", "")) if isinstance(c, dict) else len(str(c)) for c in content)
+    return 0
+
+
+def _output_text(content: object) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return " ".join(c.get("text", str(c)) if isinstance(c, dict) else str(c) for c in content)
+    return str(content)
+
+
+def _exit_code(content: object) -> int | None:
+    text = _output_text(content)
+    m = _EXIT_CODE_RE.search(text)
+    return int(m.group(1)) if m else None
+
+
+@dataclass
+class ToolSpan:
+    """A single tool invocation within an agent session.
+
+    Attributes:
+        span_id: Unique identifier for this span (UUID).
+        session_id: Parent session ID (trajectory filename stem by default).
+        tool_name: Tool that was invoked (e.g. "Bash", "Edit", "Read").
+        timestamp: ISO 8601 dispatch time (when the assistant sent the call).
+        duration_ms: Wall-clock milliseconds from dispatch to result arrival.
+            -1 when timestamps are unavailable or out-of-order.
+        success: False when the tool result carries ``is_error=True``.
+        input_size: Character count of the tool's input parameters.
+        output_size: Character count of the tool result content.
+        exit_code: For Bash spans, the subprocess exit code when annotated
+            in the result text ("Exit code: N"). None otherwise.
+        turn_index: 0-indexed assistant turn that dispatched this tool call.
+    """
+
+    span_id: str
+    session_id: str
+    tool_name: str
+    timestamp: str
+    duration_ms: int
+    success: bool
+    input_size: int
+    output_size: int
+    exit_code: int | None
+    turn_index: int
+    matched_lessons: list[str] = field(default_factory=list)
+
+
+@dataclass
+class SpanAggregates:
+    """Session-level aggregates derived from a list of ToolSpans.
+
+    These fields are suitable for inclusion in SessionRecord as optional
+    fields (Phase 2 of the design doc).
+    """
+
+    total_spans: int
+    error_spans: int
+    dominant_tool: str | None
+    avg_duration_ms: float
+    max_duration_ms: int
+    tool_counts: dict[str, int]
+    retry_depth: int
+
+    @property
+    def error_rate(self) -> float:
+        return self.error_spans / self.total_spans if self.total_spans else 0.0
+
+    @classmethod
+    def from_spans(cls, spans: list[ToolSpan]) -> SpanAggregates:
+        if not spans:
+            return cls(
+                total_spans=0,
+                error_spans=0,
+                dominant_tool=None,
+                avg_duration_ms=-1.0,
+                max_duration_ms=-1,
+                tool_counts={},
+                retry_depth=0,
+            )
+
+        tool_counts: dict[str, int] = {}
+        errors = 0
+        known_durations: list[int] = []
+
+        for span in spans:
+            tool_counts[span.tool_name] = tool_counts.get(span.tool_name, 0) + 1
+            if not span.success:
+                errors += 1
+            if span.duration_ms >= 0:
+                known_durations.append(span.duration_ms)
+
+        dominant = max(tool_counts, key=lambda k: tool_counts[k]) if tool_counts else None
+        avg_ms = sum(known_durations) / len(known_durations) if known_durations else -1.0
+        max_ms = max(known_durations) if known_durations else -1
+
+        # Retry depth: max consecutive calls to the same tool
+        retry_depth = 0
+        streak = 1
+        for i in range(1, len(spans)):
+            if spans[i].tool_name == spans[i - 1].tool_name:
+                streak += 1
+                retry_depth = max(retry_depth, streak)
+            else:
+                streak = 1
+
+        return cls(
+            total_spans=len(spans),
+            error_spans=errors,
+            dominant_tool=dominant,
+            avg_duration_ms=avg_ms,
+            max_duration_ms=max_ms,
+            tool_counts=tool_counts,
+            retry_depth=retry_depth,
+        )
+
+
+def extract_spans_from_cc_jsonl(
+    path: Path | str,
+    session_id: str | None = None,
+) -> list[ToolSpan]:
+    """Extract ToolSpan objects from a Claude Code JSONL trajectory file.
+
+    Parses assistant tool_use dispatches and user tool_result arrivals,
+    pairs them by tool_use_id, and computes per-span timing.
+
+    Args:
+        path: Path to the .jsonl trajectory file.
+        session_id: Session ID to assign to all spans. Defaults to the
+            filename stem (e.g. ``"abc123"`` for ``abc123.jsonl``).
+
+    Returns:
+        List of spans in chronological dispatch order.
+    """
+    path = Path(path)
+    if session_id is None:
+        session_id = path.stem
+
+    # pending maps tool_use_id → (tool_name, dispatch_ts, input_size, turn_index)
+    pending: dict[str, tuple[str, datetime | None, int, int]] = {}
+    spans: list[ToolSpan] = []
+    turn_index = 0
+
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        rec_type = record.get("type")
+        ts = _parse_ts(record.get("timestamp"))
+        ts_str = record.get("timestamp", "")
+
+        if rec_type == "assistant":
+            content = record.get("message", {}).get("content", [])
+            if not isinstance(content, list):
+                continue
+            dispatched_this_turn = False
+            for item in content:
+                if not isinstance(item, dict) or item.get("type") != "tool_use":
+                    continue
+                tool_id = item.get("id", "")
+                tool_name = item.get("name", "unknown")
+                isize = _input_size(item.get("input", {}))
+                if tool_id:
+                    pending[tool_id] = (tool_name, ts, isize, turn_index)
+                    dispatched_this_turn = True
+            if dispatched_this_turn:
+                turn_index += 1
+
+        elif rec_type == "user":
+            content = record.get("message", {}).get("content", [])
+            if not isinstance(content, list):
+                continue
+            for item in content:
+                if not isinstance(item, dict) or item.get("type") != "tool_result":
+                    continue
+                tool_use_id = item.get("tool_use_id", "")
+                if tool_use_id not in pending:
+                    continue
+                tool_name, dispatch_ts, isize, tidx = pending.pop(tool_use_id)
+                is_error = bool(item.get("is_error"))
+                result_content = item.get("content", "")
+                osize = _output_size(result_content)
+
+                dur_ms = -1
+                if dispatch_ts is not None and ts is not None:
+                    delta = (ts - dispatch_ts).total_seconds()
+                    if delta >= 0:
+                        dur_ms = int(delta * 1000)
+
+                exit_code = _exit_code(result_content) if tool_name == "Bash" else None
+
+                spans.append(
+                    ToolSpan(
+                        span_id=str(uuid.uuid4()),
+                        session_id=session_id,
+                        tool_name=tool_name,
+                        timestamp=ts_str,
+                        duration_ms=dur_ms,
+                        success=not is_error,
+                        input_size=isize,
+                        output_size=osize,
+                        exit_code=exit_code,
+                        turn_index=tidx,
+                    )
+                )
+
+    return spans

--- a/packages/gptme-sessions/src/gptme_sessions/spans.py
+++ b/packages/gptme-sessions/src/gptme_sessions/spans.py
@@ -181,8 +181,8 @@ def extract_spans_from_cc_jsonl(
     if session_id is None:
         session_id = path.stem
 
-    # pending maps tool_use_id → (tool_name, dispatch_ts, input_size, turn_index)
-    pending: dict[str, tuple[str, datetime | None, int, int]] = {}
+    # pending maps tool_use_id → (tool_name, dispatch_ts, dispatch_ts_str, input_size, turn_index)
+    pending: dict[str, tuple[str, datetime | None, str, int, int]] = {}
     spans: list[ToolSpan] = []
     turn_index = 0
 
@@ -216,7 +216,7 @@ def extract_spans_from_cc_jsonl(
                 tool_name = item.get("name", "unknown")
                 isize = _input_size(item.get("input", {}))
                 if tool_id:
-                    pending[tool_id] = (tool_name, ts, isize, turn_index)
+                    pending[tool_id] = (tool_name, ts, ts_str, isize, turn_index)
                     dispatched_this_turn = True
             if dispatched_this_turn:
                 turn_index += 1
@@ -231,7 +231,7 @@ def extract_spans_from_cc_jsonl(
                 tool_use_id = item.get("tool_use_id", "")
                 if tool_use_id not in pending:
                     continue
-                tool_name, dispatch_ts, isize, tidx = pending.pop(tool_use_id)
+                tool_name, dispatch_ts, dispatch_ts_str, isize, tidx = pending.pop(tool_use_id)
                 is_error = bool(item.get("is_error"))
                 result_content = item.get("content", "")
                 osize = _output_size(result_content)
@@ -249,7 +249,7 @@ def extract_spans_from_cc_jsonl(
                         span_id=str(uuid.uuid4()),
                         session_id=session_id,
                         tool_name=tool_name,
-                        timestamp=ts_str,
+                        timestamp=dispatch_ts_str,
                         duration_ms=dur_ms,
                         success=not is_error,
                         input_size=isize,

--- a/packages/gptme-sessions/tests/test_spans.py
+++ b/packages/gptme-sessions/tests/test_spans.py
@@ -285,6 +285,19 @@ def test_aggregates_unknown_duration_excluded() -> None:
     assert agg.max_duration_ms == 300
 
 
+def test_mixed_timezone_timestamps_no_crash(tmp_path: Path) -> None:
+    """Mixed tz-aware/naive timestamps should produce dur_ms=-1, not TypeError."""
+    records = [
+        _cc_assistant("Bash", "tid1", "cmd", "2026-04-21T10:00:00+00:00"),  # tz-aware
+        _cc_result("tid1", "done", "2026-04-21T10:00:01"),  # tz-naive
+    ]
+    p = _write_jsonl(tmp_path, records)
+    spans = extract_spans_from_cc_jsonl(p)
+
+    assert len(spans) == 1
+    assert spans[0].duration_ms == -1  # sentinel; subtraction failed gracefully
+
+
 def test_output_size_consistent_with_text_extraction(tmp_path: Path) -> None:
     """output_size should be non-zero when the result is a dict without 'text' key."""
     records = [

--- a/packages/gptme-sessions/tests/test_spans.py
+++ b/packages/gptme-sessions/tests/test_spans.py
@@ -285,11 +285,38 @@ def test_aggregates_unknown_duration_excluded() -> None:
     assert agg.max_duration_ms == 300
 
 
+def test_output_size_consistent_with_text_extraction(tmp_path: Path) -> None:
+    """output_size should be non-zero when the result is a dict without 'text' key."""
+    records = [
+        _cc_assistant("Bash", "tid1", "cmd", "2026-04-21T10:00:00+00:00"),
+        {
+            "type": "user",
+            "timestamp": "2026-04-21T10:00:01+00:00",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "tid1",
+                        "content": [{"type": "image", "source": "data:..."}],
+                    }
+                ]
+            },
+        },
+    ]
+    p = _write_jsonl(tmp_path, records)
+    spans = extract_spans_from_cc_jsonl(p)
+
+    assert len(spans) == 1
+    # With the fix, output_size reflects the actual str() representation;
+    # without it, output_size would be 0 (c.get("text", "") fallback).
+    assert spans[0].output_size > 0
+
+
 def test_aggregates_retry_depth() -> None:
-    # Bash × 3 consecutive = depth 3
+    # Bash × 3 consecutive → 2 retries beyond the first call
     spans = [_span("Bash"), _span("Bash"), _span("Bash"), _span("Edit")]
     agg = SpanAggregates.from_spans(spans)
-    assert agg.retry_depth == 3
+    assert agg.retry_depth == 2
 
 
 def test_aggregates_no_retry() -> None:

--- a/packages/gptme-sessions/tests/test_spans.py
+++ b/packages/gptme-sessions/tests/test_spans.py
@@ -1,0 +1,282 @@
+"""Tests for span-level tracing (gptme_sessions.spans)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gptme_sessions.spans import (
+    SpanAggregates,
+    ToolSpan,
+    extract_spans_from_cc_jsonl,
+)
+
+
+def _write_jsonl(tmp_path: Path, records: list[dict], name: str = "session.jsonl") -> Path:
+    p = tmp_path / name
+    p.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+    return p
+
+
+# ── CC JSONL fixtures ─────────────────────────────────────────────────────────
+
+
+def _cc_assistant(tool_name: str, tool_id: str, cmd: str, ts: str) -> dict:
+    return {
+        "type": "assistant",
+        "timestamp": ts,
+        "message": {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": tool_id,
+                    "name": tool_name,
+                    "input": {"command": cmd},
+                }
+            ]
+        },
+    }
+
+
+def _cc_result(tool_use_id: str, output: str, ts: str, is_error: bool = False) -> dict:
+    return {
+        "type": "user",
+        "timestamp": ts,
+        "message": {
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": tool_use_id,
+                    "content": output,
+                    "is_error": is_error,
+                }
+            ]
+        },
+    }
+
+
+# ── extract_spans_from_cc_jsonl ───────────────────────────────────────────────
+
+
+def test_single_bash_span(tmp_path: Path) -> None:
+    records = [
+        _cc_assistant("Bash", "tid1", "echo hello", "2026-04-21T10:00:00+00:00"),
+        _cc_result("tid1", "hello", "2026-04-21T10:00:01+00:00"),
+    ]
+    p = _write_jsonl(tmp_path, records)
+    spans = extract_spans_from_cc_jsonl(p)
+
+    assert len(spans) == 1
+    s = spans[0]
+    assert s.tool_name == "Bash"
+    assert s.session_id == "session"
+    assert s.duration_ms == 1000
+    assert s.success is True
+    assert s.exit_code is None  # no "Exit code:" annotation
+    assert s.output_size == len("hello")
+    assert s.turn_index == 0
+
+
+def test_error_span(tmp_path: Path) -> None:
+    records = [
+        _cc_assistant("Bash", "tid1", "false", "2026-04-21T10:00:00+00:00"),
+        _cc_result("tid1", "", "2026-04-21T10:00:00+00:00", is_error=True),
+    ]
+    p = _write_jsonl(tmp_path, records)
+    spans = extract_spans_from_cc_jsonl(p)
+
+    assert len(spans) == 1
+    assert spans[0].success is False
+    assert spans[0].duration_ms == 0
+
+
+def test_exit_code_extracted(tmp_path: Path) -> None:
+    output = "some output\nExit code: 2\n"
+    records = [
+        _cc_assistant("Bash", "tid1", "exit 2", "2026-04-21T10:00:00+00:00"),
+        _cc_result("tid1", output, "2026-04-21T10:00:00.5+00:00"),
+    ]
+    p = _write_jsonl(tmp_path, records)
+    spans = extract_spans_from_cc_jsonl(p)
+
+    assert spans[0].exit_code == 2
+
+
+def test_exit_code_not_set_for_non_bash(tmp_path: Path) -> None:
+    records = [
+        _cc_assistant("Read", "tid1", "/path/to/file", "2026-04-21T10:00:00+00:00"),
+        _cc_result("tid1", "Exit code: 0\ncontent", "2026-04-21T10:00:01+00:00"),
+    ]
+    p = _write_jsonl(tmp_path, records)
+    spans = extract_spans_from_cc_jsonl(p)
+
+    assert spans[0].exit_code is None  # exit code only extracted for Bash
+
+
+def test_multiple_spans_turn_index(tmp_path: Path) -> None:
+    records = [
+        _cc_assistant("Bash", "tid1", "git status", "2026-04-21T10:00:00+00:00"),
+        _cc_result("tid1", "clean", "2026-04-21T10:00:01+00:00"),
+        _cc_assistant("Edit", "tid2", "file.py", "2026-04-21T10:00:02+00:00"),
+        _cc_result("tid2", "ok", "2026-04-21T10:00:03+00:00"),
+    ]
+    p = _write_jsonl(tmp_path, records)
+    spans = extract_spans_from_cc_jsonl(p)
+
+    assert len(spans) == 2
+    assert spans[0].turn_index == 0
+    assert spans[1].turn_index == 1
+
+
+def test_batched_tool_calls(tmp_path: Path) -> None:
+    """Multiple tool_use items in a single assistant message share turn_index."""
+    records = [
+        {
+            "type": "assistant",
+            "timestamp": "2026-04-21T10:00:00+00:00",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tid1",
+                        "name": "Read",
+                        "input": {"file_path": "a.py"},
+                    },
+                    {
+                        "type": "tool_use",
+                        "id": "tid2",
+                        "name": "Read",
+                        "input": {"file_path": "b.py"},
+                    },
+                ]
+            },
+        },
+        _cc_result("tid1", "content a", "2026-04-21T10:00:01+00:00"),
+        _cc_result("tid2", "content b", "2026-04-21T10:00:02+00:00"),
+    ]
+    p = _write_jsonl(tmp_path, records)
+    spans = extract_spans_from_cc_jsonl(p)
+
+    assert len(spans) == 2
+    assert spans[0].turn_index == spans[1].turn_index == 0
+
+
+def test_session_id_from_filename(tmp_path: Path) -> None:
+    records = [
+        _cc_assistant("Bash", "tid1", "echo hi", "2026-04-21T10:00:00+00:00"),
+        _cc_result("tid1", "hi", "2026-04-21T10:00:01+00:00"),
+    ]
+    p = _write_jsonl(tmp_path, records, name="abc123def.jsonl")
+    spans = extract_spans_from_cc_jsonl(p)
+
+    assert spans[0].session_id == "abc123def"
+
+
+def test_session_id_override(tmp_path: Path) -> None:
+    records = [
+        _cc_assistant("Bash", "tid1", "echo hi", "2026-04-21T10:00:00+00:00"),
+        _cc_result("tid1", "hi", "2026-04-21T10:00:01+00:00"),
+    ]
+    p = _write_jsonl(tmp_path, records)
+    spans = extract_spans_from_cc_jsonl(p, session_id="custom-id")
+
+    assert spans[0].session_id == "custom-id"
+
+
+def test_empty_file(tmp_path: Path) -> None:
+    p = tmp_path / "empty.jsonl"
+    p.write_text("")
+    spans = extract_spans_from_cc_jsonl(p)
+    assert spans == []
+
+
+def test_missing_file() -> None:
+    spans = extract_spans_from_cc_jsonl(Path("/nonexistent/path/session.jsonl"))
+    assert spans == []
+
+
+def test_malformed_lines(tmp_path: Path) -> None:
+    p = tmp_path / "bad.jsonl"
+    p.write_text("not json\n{}\n")
+    spans = extract_spans_from_cc_jsonl(p)
+    assert spans == []
+
+
+def test_unknown_result_id_ignored(tmp_path: Path) -> None:
+    """Result with unmatched tool_use_id should not produce a span."""
+    records = [
+        _cc_result("unknown-id", "output", "2026-04-21T10:00:00+00:00"),
+    ]
+    p = _write_jsonl(tmp_path, records)
+    spans = extract_spans_from_cc_jsonl(p)
+    assert spans == []
+
+
+# ── SpanAggregates ────────────────────────────────────────────────────────────
+
+
+def _span(tool: str, dur_ms: int = 100, success: bool = True) -> ToolSpan:
+    return ToolSpan(
+        span_id="test",
+        session_id="s",
+        tool_name=tool,
+        timestamp="",
+        duration_ms=dur_ms,
+        success=success,
+        input_size=10,
+        output_size=20,
+        exit_code=None,
+        turn_index=0,
+    )
+
+
+def test_aggregates_empty() -> None:
+    agg = SpanAggregates.from_spans([])
+    assert agg.total_spans == 0
+    assert agg.error_rate == 0.0
+    assert agg.dominant_tool is None
+    assert agg.avg_duration_ms == -1.0
+    assert agg.max_duration_ms == -1
+    assert agg.retry_depth == 0
+
+
+def test_aggregates_basic() -> None:
+    spans = [_span("Bash"), _span("Edit"), _span("Bash", success=False)]
+    agg = SpanAggregates.from_spans(spans)
+
+    assert agg.total_spans == 3
+    assert agg.error_spans == 1
+    assert abs(agg.error_rate - 1 / 3) < 1e-9
+    assert agg.dominant_tool == "Bash"
+    assert agg.tool_counts == {"Bash": 2, "Edit": 1}
+
+
+def test_aggregates_duration() -> None:
+    spans = [_span("Bash", 200), _span("Bash", 400), _span("Read", 600)]
+    agg = SpanAggregates.from_spans(spans)
+
+    assert agg.avg_duration_ms == pytest.approx(400.0)
+    assert agg.max_duration_ms == 600
+
+
+def test_aggregates_unknown_duration_excluded() -> None:
+    spans = [_span("Bash", -1), _span("Edit", 300)]
+    agg = SpanAggregates.from_spans(spans)
+
+    assert agg.avg_duration_ms == pytest.approx(300.0)
+    assert agg.max_duration_ms == 300
+
+
+def test_aggregates_retry_depth() -> None:
+    # Bash × 3 consecutive = depth 3
+    spans = [_span("Bash"), _span("Bash"), _span("Bash"), _span("Edit")]
+    agg = SpanAggregates.from_spans(spans)
+    assert agg.retry_depth == 3
+
+
+def test_aggregates_no_retry() -> None:
+    spans = [_span("Bash"), _span("Edit"), _span("Read")]
+    agg = SpanAggregates.from_spans(spans)
+    assert agg.retry_depth == 0  # no consecutive same-tool calls

--- a/packages/gptme-sessions/tests/test_spans.py
+++ b/packages/gptme-sessions/tests/test_spans.py
@@ -163,6 +163,22 @@ def test_batched_tool_calls(tmp_path: Path) -> None:
     assert spans[0].turn_index == spans[1].turn_index == 0
 
 
+def test_timestamp_is_dispatch_time(tmp_path: Path) -> None:
+    """span.timestamp must reflect dispatch time, not result-arrival time."""
+    dispatch_ts = "2026-04-21T10:00:00+00:00"
+    arrival_ts = "2026-04-21T10:00:05+00:00"
+    records = [
+        _cc_assistant("Bash", "tid1", "sleep 5", dispatch_ts),
+        _cc_result("tid1", "done", arrival_ts),
+    ]
+    p = _write_jsonl(tmp_path, records)
+    spans = extract_spans_from_cc_jsonl(p)
+
+    assert len(spans) == 1
+    assert spans[0].timestamp == dispatch_ts
+    assert spans[0].duration_ms == 5000
+
+
 def test_session_id_from_filename(tmp_path: Path) -> None:
     records = [
         _cc_assistant("Bash", "tid1", "echo hi", "2026-04-21T10:00:00+00:00"),


### PR DESCRIPTION
## Summary

Adds span-level tracing to gptme-sessions: the ability to extract per-tool-call spans from Claude Code trajectory JSONL files, giving session analytics a fine-grained per-turn story beyond aggregate session grades.

- **`ToolSpan`** dataclass: tool name, dispatch timestamp, `duration_ms` (dispatch→result delta), `success`, `input_size`, `output_size`, `exit_code` (Bash only), `turn_index`, `matched_lessons`
- **`SpanAggregates`**: session-level aggregates computed from a list of spans — `error_rate`, `dominant_tool`, `avg/max_duration_ms`, `tool_counts`, `retry_depth` (max consecutive same-tool calls, a proxy for stuck loops)
- **`extract_spans_from_cc_jsonl`**: parse a CC `.jsonl` trajectory, pair `tool_use` dispatches with `tool_result` arrivals by ID, compute timing

## Motivation

- OpenAI Agents SDK ships tracing as a day-1 primitive; gptme has rich session-level analytics but no span-level story
- Session grades are noisy — spans isolate which turns produced value vs. which were retry loops
- `retry_depth` enables detecting stuck-loop sessions that inflate session duration without output
- Lays the groundwork for Phase 2: correlate matched lessons with per-span outcomes for finer-grained LOO signal

Design doc: https://github.com/TimeToBuildBob/bob/blob/master/knowledge/technical-designs/span-level-tracing-design.md  
Idea: #158 in Bob's workspace idea backlog

## Test plan

- [x] 18 tests covering: single span, error spans, exit-code extraction (Bash-only), batched tool calls (shared turn_index), session_id from filename/override, empty/missing/malformed files, orphan result IDs, all aggregate fields
- [x] `prek run --all-files` passes
- [x] ruff + ruff-format clean