### PR TITLE
feat(skills): add rewrite-soul skill for agent persona tightening

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -87,6 +87,23 @@ Skills extend gptme's lesson system by providing executable components alongside
 - `find_duplicate_code()` - Duplicate detection
 - `check_test_coverage()` - Test file analysis
 
+### 4. rewrite-soul
+
+**Purpose**: Tighten or create an agent's `SOUL.md` into a compact runtime persona (voice, taste, stance) without pulling in operational rules, tool lists, or dated initiatives.
+
+**Use cases**:
+- Creating `SOUL.md` for a new agent from broader identity docs
+- Tightening a drifted `SOUL.md` that has grown into a README or tool index
+- Splitting runtime voice out of `ABOUT.md` after it has grown too long
+
+**Features**:
+- 5-step workflow with boundary-file reading, content triage, compression, surgical rewrite, and verification
+- Reusable rewrite prompt that enforces persona-only content
+- Content/ownership table showing what belongs in `SOUL.md` vs `ABOUT.md` / `AGENTS.md` / `GOALS.md`
+- Anti-pattern checklist for the most common ways persona files drift
+
+**Keywords**: `SOUL.md`, `persona`, `agent voice`, `rewrite soul`, `agent identity`
+
 ## Using Skills
 
 ### Loading a Skill

--- a/skills/rewrite-soul/SKILL.md
+++ b/skills/rewrite-soul/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: rewrite-soul
+description: "Use when creating or revising an agent's SOUL.md, splitting runtime voice out of broader identity docs, or tightening a vague persona file into a short, opinionated, voice-only artifact without changing the agent's core identity."
+license: MIT
+compatibility: "Requires gptme"
+metadata:
+  author: bob
+  version: "1.0.0"
+  tags: [agent, soul, persona, identity, voice]
+  requires_tools: []
+  requires_skills: []
+---
+
+# Rewrite Soul
+
+## Overview
+
+Tighten an agent's `SOUL.md` into a compact runtime persona.
+Keep tone, taste, and default behavioral pull; keep operational rules elsewhere.
+
+`SOUL.md` is a first-class persona file in the
+[`gptme-agent-template`](https://github.com/gptme/gptme-agent-template)
+bootstrap: it sits alongside `ABOUT.md`, `GOALS.md`, and `AGENTS.md`/`CLAUDE.md`
+and is auto-included so the agent's voice loads every session. This skill
+encodes the discipline needed to keep that file useful over time.
+
+## When to Use This Skill
+
+Apply this skill when:
+
+- Creating `SOUL.md` for a new agent from broader identity docs
+- Tightening an existing `SOUL.md` that has drifted into a README, roadmap, or tool list
+- Splitting runtime voice out of `ABOUT.md` after the file has grown too long
+- Aligning a fork's persona with its source agent without copying operational baggage
+
+## Workflow
+
+### 1. Read the boundary files first
+
+Read these before rewriting:
+
+- `SOUL.md` if it already exists
+- broader identity docs such as `ABOUT.md`, `GOALS.md`, or `README.md`
+- operating docs such as `AGENTS.md` or `CLAUDE.md`
+
+Use the broader docs as source material, not as the output shape. `SOUL.md` is
+runtime voice, not a dump of everything true about the agent.
+
+If no `SOUL.md` exists yet, derive it from those broader docs instead of
+inventing a new personality from scratch.
+
+### 2. Keep only persona material
+
+Keep:
+
+- voice and tone
+- taste and preferences
+- default behavioral pull under ambiguity
+- social texture or stance
+- a few durable values if they clearly affect decisions
+
+Move out or leave out:
+
+- tool lists
+- directory layouts
+- git workflow rules
+- task schemas
+- temporary initiatives, metrics, or blockers
+- long biography or justification paragraphs
+
+### 3. Compress hard
+
+Aim for:
+
+- 20-60 lines
+- 3-5 short sections
+- quotable bullets instead of explanatory paragraphs
+- direct language with no corporate filler
+
+Recommended sections:
+
+- `Voice`
+- `Taste`
+- `Behavioral Pull`
+- `Social Texture`
+
+### 4. Rewrite surgically
+
+Preserve the agent's identity; do not invent a different one just to sound
+stronger. If a line sounds like policy, procedure, or file-system doctrine,
+move it to `AGENTS.md`, `ABOUT.md`, `TASKS.md`, or another operational file
+instead of keeping it in `SOUL.md`.
+
+When content is duplicated, prefer a clear split:
+
+- `SOUL.md` = voice, taste, stance
+- `ABOUT.md` = background, doctrine, longer-form values
+- `AGENTS.md` / `CLAUDE.md` = operating constraints
+- `GOALS.md` = explicit goal hierarchy
+
+### 5. Verify the result
+
+A good `SOUL.md` should answer:
+
+- How does this agent sound?
+- What does it find tasteful or distasteful?
+- What does it default toward when the prompt is vague?
+- What kind of social energy does it bring?
+
+A bad `SOUL.md` reads like a README, policy manual, roadmap, or tool index.
+
+## Rewrite Prompt
+
+```txt
+Read SOUL.md, ABOUT.md, GOALS.md, and AGENTS.md/CLAUDE.md if present.
+Rewrite SOUL.md into a sharper runtime persona.
+
+Constraints:
+- Preserve the agent's identity; do not invent a new one.
+- Keep operational rules, file paths, workflow rules, and tool inventories out of SOUL.md.
+- Prefer short, opinionated lines over explanatory paragraphs.
+- Keep it to 20-60 lines.
+- Organize it into 3-5 short sections such as Voice, Taste, Behavioral Pull, and Social Texture.
+
+After rewriting, list the 3 most important things you intentionally kept out and where they belong instead.
+```
+
+## Anti-Patterns
+
+- Turning `SOUL.md` into `ABOUT.md` but shorter
+- Stuffing in operational constraints because they feel important
+- Making it bland to sound "professional"
+- Hard-coding current initiatives or dated facts
+- Adding values that never change decisions
+
+## Example: what belongs where
+
+| Content | Belongs in |
+|---------|------------|
+| "Direct, opinionated, no corporate fluff" | `SOUL.md` (Voice) |
+| "Prefers Unix philosophy, local-first tools" | `SOUL.md` (Taste) |
+| "Always use absolute paths when saving files" | `AGENTS.md` / `CLAUDE.md` |
+| "Uses gptodo for task management" | `ARCHITECTURE.md` or `TASKS.md` |
+| "Final goal: play the longest possible game" | `GOALS.md` |
+| "Was created by X on date Y" | `ABOUT.md` |
+
+## Related
+
+- [gptme-agent-template](https://github.com/gptme/gptme-agent-template) — template that ships a `SOUL.md` skeleton by default
+- `ABOUT.md` / `AGENTS.md` / `CLAUDE.md` / `GOALS.md` in the agent workspace — the
+  files `SOUL.md` deliberately defers to

--- a/skills/rewrite-soul/agents/openai.yaml
+++ b/skills/rewrite-soul/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Rewrite SOUL"
+  short_description: "Rewrite or tighten a SOUL.md persona file"
+  default_prompt: "Rewrite this agent's SOUL.md to be sharper and more opinionated without changing its core identity."


### PR DESCRIPTION
## Summary

Adds a packaged, user-facing **`rewrite-soul`** skill to `gptme-contrib/skills/`, upstreaming what was previously a Bob-local workflow. The skill is generic — it applies to any agent following the `gptme-agent-template` layout (`SOUL.md` + `ABOUT.md` + `AGENTS.md` / `CLAUDE.md` + `GOALS.md`).

Now that [`gptme/gptme-agent-template#77`](https://github.com/gptme/gptme-agent-template/pull/77) makes `SOUL.md` a first-class persona file in the bootstrap, new agents ship with a `SOUL.md` skeleton by default. This skill gives them a reusable discipline for *keeping `SOUL.md` useful over time*: runtime voice only, not a tool index or roadmap.

## What the skill does

Encodes a 5-step workflow:

1. **Read boundary files first** — `SOUL.md`, `ABOUT.md`, `GOALS.md`, `AGENTS.md` / `CLAUDE.md`
2. **Keep only persona material** — voice, taste, behavioral pull, social texture
3. **Compress hard** — 20–60 lines, 3–5 short sections
4. **Rewrite surgically** — preserve identity; move operational lines elsewhere
5. **Verify** — four voice-oriented questions the final file must answer

Includes:

- A ready-to-use **Rewrite Prompt** that enforces the constraints
- An **ownership table** showing what belongs in `SOUL.md` vs `ABOUT.md` / `AGENTS.md` / `GOALS.md`
- An **anti-pattern checklist** (e.g. *"Turning `SOUL.md` into `ABOUT.md` but shorter"*)
- An `agents/openai.yaml` interface descriptor so it registers cleanly as a named skill

## Files changed

- `skills/rewrite-soul/SKILL.md` — main workflow (new)
- `skills/rewrite-soul/agents/openai.yaml` — interface config (new)
- `skills/README.md` — lists the new skill under **Available Skills**

## Background

Bob-local `skills/rewrite-soul/` has been exercised by Bob's own `SOUL.md` rewrites and has proven useful enough to generalize. This PR is the *"packaged user-facing skill upstream"* item tracked on Bob's idea backlog under the SOUL.md thread.

## Test plan

- [x] `SKILL.md` frontmatter parses (`name`, `description`, `license`, `compatibility`, `metadata`)
- [x] `agents/openai.yaml` carries the `interface:` block used by other skills
- [x] Pre-commit (prek) passes locally
- [x] Skill is listed in `skills/README.md` under **Available Skills**
- [ ] Reviewer applies the Rewrite Prompt to a sample `SOUL.md` and confirms the output fits the workflow's constraints (20–60 lines, voice-only, no operational leakage)