### PR TITLE
feat(gptme-sessions): add span_aggregates field + populate helper to SessionRecord (Phase 3)

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -208,6 +208,13 @@ class SessionRecord:
     llm_judge_reason: str | None = None  # 1-sentence explanation
     llm_judge_model: str | None = None  # model used for judging (e.g. claude-haiku-4-5)
 
+    # Per-tool-call span aggregates (Phase 2 of span-level tracing, idea #158).
+    # Dict shape mirrors SpanAggregates fields (total_spans, error_spans,
+    # error_rate, dominant_tool, avg_duration_ms, max_duration_ms,
+    # tool_counts, retry_depth) so downstream consumers can read it without
+    # importing gptme_sessions.spans. ``None`` means not yet populated.
+    span_aggregates: dict[str, Any] | None = None
+
     # Preserve fields written by older schema versions so load→mutate→rewrite
     # round-trips don't silently drop data (e.g. ``inferred_category``,
     # ``failure_reason``, ``recommended_confidence``, ``notes``).
@@ -294,6 +301,55 @@ class SessionRecord:
         if result is not None:
             self.trajectory_grade = result
         return result
+
+    def populate_span_aggregates(self, harness_hint: str | None = None) -> bool:
+        """Extract tool spans from ``trajectory_path`` and store aggregates.
+
+        Chooses the extractor based on ``harness_hint`` (or ``self.harness``
+        when not given): ``"claude-code"`` → CC JSONL, ``"gptme"`` → gptme
+        JSONL. Stores ``SpanAggregates.from_spans(...)`` serialized as a dict
+        on ``self.span_aggregates`` (including the computed ``error_rate``).
+
+        Returns ``True`` when aggregates were populated, ``False`` when the
+        trajectory path is missing, unreadable, or the harness is unknown.
+        Idempotent: safe to re-run when new trajectory data arrives.
+        """
+        from pathlib import Path
+
+        # Lazy import avoids a top-level cycle and keeps record.py independent
+        # of the spans module for users who never call this helper.
+        from gptme_sessions.spans import (
+            SpanAggregates,
+            extract_spans_from_cc_jsonl,
+            extract_spans_from_gptme_jsonl,
+        )
+
+        if not self.trajectory_path:
+            return False
+        traj = Path(self.trajectory_path)
+        if not traj.exists():
+            return False
+
+        harness = harness_hint or self.harness
+        if harness == "claude-code":
+            spans = extract_spans_from_cc_jsonl(traj, session_id=self.session_id)
+        elif harness == "gptme":
+            spans = extract_spans_from_gptme_jsonl(traj, session_id=self.session_id)
+        else:
+            return False
+
+        agg = SpanAggregates.from_spans(spans)
+        self.span_aggregates = {
+            "total_spans": agg.total_spans,
+            "error_spans": agg.error_spans,
+            "error_rate": agg.error_rate,
+            "dominant_tool": agg.dominant_tool,
+            "avg_duration_ms": agg.avg_duration_ms,
+            "max_duration_ms": agg.max_duration_ms,
+            "tool_counts": agg.tool_counts,
+            "retry_depth": agg.retry_depth,
+        }
+        return True
 
     @property
     def model_normalized(self) -> str | None:

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -7,6 +7,7 @@ import re
 import uuid
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
 # Normalize model names to short canonical forms
@@ -208,7 +209,7 @@ class SessionRecord:
     llm_judge_reason: str | None = None  # 1-sentence explanation
     llm_judge_model: str | None = None  # model used for judging (e.g. claude-haiku-4-5)
 
-    # Per-tool-call span aggregates (Phase 2 of span-level tracing, idea #158).
+    # Per-tool-call span aggregates (Phase 3 of span-level tracing, idea #158).
     # Dict shape mirrors SpanAggregates fields (total_spans, error_spans,
     # error_rate, dominant_tool, avg_duration_ms, max_duration_ms,
     # tool_counts, retry_depth) so downstream consumers can read it without
@@ -314,8 +315,6 @@ class SessionRecord:
         trajectory path is missing, unreadable, or the harness is unknown.
         Idempotent: safe to re-run when new trajectory data arrives.
         """
-        from pathlib import Path
-
         # Lazy import avoids a top-level cycle and keeps record.py independent
         # of the spans module for users who never call this helper.
         from gptme_sessions.spans import (

--- a/packages/gptme-sessions/src/gptme_sessions/spans.py
+++ b/packages/gptme-sessions/src/gptme_sessions/spans.py
@@ -38,12 +38,25 @@ _GPTME_NOISE_PREFIXES = (
     "Shellcheck found potential issues",
 )
 
+# Matches fractional seconds (e.g. ".1", ".123") before a timezone offset or end-of-string.
+# Python 3.10 fromisoformat() only accepts exactly 3 or 6 fractional digits; 3.11+ accepts any.
+_FRAC_RE = re.compile(r"\.(\d+)(?=[+\-Z]|$)")
+
+
+def _normalize_ts(ts_str: str) -> str:
+    """Pad fractional seconds to 6 digits for Python 3.10 fromisoformat() compat."""
+
+    def _pad(m: re.Match) -> str:  # type: ignore[type-arg]
+        return "." + m.group(1).ljust(6, "0")[:6]
+
+    return _FRAC_RE.sub(_pad, ts_str.replace("Z", "+00:00"))
+
 
 def _parse_ts(ts_str: str | None) -> datetime | None:
     if not ts_str:
         return None
     try:
-        return datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+        return datetime.fromisoformat(_normalize_ts(ts_str))
     except ValueError:
         return None
 

--- a/packages/gptme-sessions/src/gptme_sessions/spans.py
+++ b/packages/gptme-sessions/src/gptme_sessions/spans.py
@@ -46,7 +46,7 @@ _FRAC_RE = re.compile(r"\.(\d+)(?=[+\-Z]|$)")
 def _normalize_ts(ts_str: str) -> str:
     """Pad fractional seconds to 6 digits for Python 3.10 fromisoformat() compat."""
 
-    def _pad(m: re.Match) -> str:  # type: ignore[type-arg]
+    def _pad(m: re.Match[str]) -> str:
         return "." + m.group(1).ljust(6, "0")[:6]
 
     return _FRAC_RE.sub(_pad, ts_str.replace("Z", "+00:00"))

--- a/packages/gptme-sessions/tests/test_record.py
+++ b/packages/gptme-sessions/tests/test_record.py
@@ -1,5 +1,10 @@
 """Tests for SessionRecord dataclass."""
 
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
 import pytest
 
 from gptme_sessions.record import SessionRecord, normalize_model
@@ -310,3 +315,179 @@ def test_normalize_model_aliases(raw: str, expected: str) -> None:
 )
 def test_normalize_model_regex_fallback(raw: str | None, expected: str | None) -> None:
     assert normalize_model(raw) == expected
+
+
+# -- span_aggregates field + populate_span_aggregates helper ------------------
+
+
+def _write_cc_trajectory(tmp_path: Path) -> Path:
+    """Synthetic CC JSONL: one Bash dispatch + successful result."""
+    records = [
+        {
+            "type": "assistant",
+            "timestamp": "2026-04-21T10:00:00+00:00",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tid1",
+                        "name": "Bash",
+                        "input": {"command": "echo hi"},
+                    }
+                ]
+            },
+        },
+        {
+            "type": "user",
+            "timestamp": "2026-04-21T10:00:01+00:00",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "tid1",
+                        "content": "hi",
+                        "is_error": False,
+                    }
+                ]
+            },
+        },
+    ]
+    p = tmp_path / "session.jsonl"
+    p.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+    return p
+
+
+def _write_gptme_trajectory(tmp_path: Path, session_name: str = "sess-aa") -> Path:
+    """Synthetic gptme conversation.jsonl: one shell dispatch + success result."""
+    sess_dir = tmp_path / session_name
+    sess_dir.mkdir()
+    records = [
+        {
+            "role": "assistant",
+            "timestamp": "2026-04-21T10:00:00",
+            "content": '\n@shell(call-abc-0): {"command": "echo hi"}',
+        },
+        {
+            "role": "system",
+            "timestamp": "2026-04-21T10:00:01",
+            "content": "Ran allowlisted command: `echo hi`\n\n```stdout\nhi\n```",
+            "pinned": False,
+        },
+    ]
+    p = sess_dir / "conversation.jsonl"
+    p.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+    return p
+
+
+def test_span_aggregates_default_is_none():
+    """span_aggregates defaults to None."""
+    r = SessionRecord()
+    assert r.span_aggregates is None
+
+
+def test_span_aggregates_roundtrip():
+    """span_aggregates survives to_dict/from_dict and JSON round-trip."""
+    agg = {
+        "total_spans": 3,
+        "error_spans": 1,
+        "error_rate": 1 / 3,
+        "dominant_tool": "Bash",
+        "avg_duration_ms": 250.0,
+        "max_duration_ms": 500,
+        "tool_counts": {"Bash": 2, "Read": 1},
+        "retry_depth": 1,
+    }
+    r = SessionRecord(session_id="span-rt", span_aggregates=agg)
+    d = r.to_dict()
+    assert d["span_aggregates"] == agg
+
+    r2 = SessionRecord.from_dict(d)
+    assert r2.span_aggregates == agg
+
+    parsed = json.loads(r.to_json())
+    assert parsed["span_aggregates"] == agg
+    r3 = SessionRecord.from_dict(parsed)
+    assert r3.span_aggregates == agg
+
+
+def test_span_aggregates_none_roundtrip():
+    """span_aggregates=None round-trips correctly."""
+    r = SessionRecord()
+    d = r.to_dict()
+    assert d["span_aggregates"] is None
+
+    r2 = SessionRecord.from_dict(d)
+    assert r2.span_aggregates is None
+
+
+def test_populate_span_aggregates_no_trajectory_path():
+    """Returns False and leaves span_aggregates unchanged when trajectory_path is None."""
+    r = SessionRecord(harness="claude-code")
+    assert r.populate_span_aggregates() is False
+    assert r.span_aggregates is None
+
+
+def test_populate_span_aggregates_missing_file(tmp_path: Path):
+    """Returns False when trajectory file does not exist."""
+    r = SessionRecord(
+        harness="claude-code",
+        trajectory_path=str(tmp_path / "does-not-exist.jsonl"),
+    )
+    assert r.populate_span_aggregates() is False
+    assert r.span_aggregates is None
+
+
+def test_populate_span_aggregates_unknown_harness(tmp_path: Path):
+    """Returns False for harnesses without an extractor."""
+    p = _write_cc_trajectory(tmp_path)
+    r = SessionRecord(harness="copilot-cli", trajectory_path=str(p))
+    assert r.populate_span_aggregates() is False
+    assert r.span_aggregates is None
+
+
+def test_populate_span_aggregates_cc_trajectory(tmp_path: Path):
+    """Populates aggregates from a claude-code trajectory."""
+    p = _write_cc_trajectory(tmp_path)
+    r = SessionRecord(harness="claude-code", trajectory_path=str(p))
+    assert r.populate_span_aggregates() is True
+    assert r.span_aggregates is not None
+    assert r.span_aggregates["total_spans"] == 1
+    assert r.span_aggregates["error_spans"] == 0
+    assert r.span_aggregates["error_rate"] == 0.0
+    assert r.span_aggregates["dominant_tool"] == "Bash"
+    assert r.span_aggregates["max_duration_ms"] == 1000
+    assert r.span_aggregates["tool_counts"] == {"Bash": 1}
+    assert r.span_aggregates["retry_depth"] == 0
+
+
+def test_populate_span_aggregates_gptme_trajectory(tmp_path: Path):
+    """Populates aggregates from a gptme conversation.jsonl."""
+    p = _write_gptme_trajectory(tmp_path, session_name="sess-aa")
+    r = SessionRecord(harness="gptme", trajectory_path=str(p))
+    assert r.populate_span_aggregates() is True
+    assert r.span_aggregates is not None
+    assert r.span_aggregates["total_spans"] == 1
+    assert r.span_aggregates["dominant_tool"] == "shell"
+    assert r.span_aggregates["error_spans"] == 0
+    assert r.span_aggregates["tool_counts"] == {"shell": 1}
+
+
+def test_populate_span_aggregates_harness_hint_overrides(tmp_path: Path):
+    """harness_hint overrides self.harness for extractor selection."""
+    p = _write_cc_trajectory(tmp_path)
+    # harness is intentionally wrong; hint should still pick CC extractor.
+    r = SessionRecord(harness="gptme", trajectory_path=str(p))
+    assert r.populate_span_aggregates(harness_hint="claude-code") is True
+    assert r.span_aggregates is not None
+    assert r.span_aggregates["total_spans"] == 1
+    assert r.span_aggregates["dominant_tool"] == "Bash"
+
+
+def test_populate_span_aggregates_idempotent_rerun(tmp_path: Path):
+    """Re-running populate replaces previous aggregates (idempotent contract)."""
+    p = _write_cc_trajectory(tmp_path)
+    r = SessionRecord(harness="claude-code", trajectory_path=str(p))
+    assert r.populate_span_aggregates() is True
+    first = dict(r.span_aggregates or {})
+    assert r.populate_span_aggregates() is True
+    assert r.span_aggregates == first


### PR DESCRIPTION
## Summary

Phase 3 of span-level tracing ([idea #158](https://github.com/ErikBjare/bob/blob/master/knowledge/strategic/idea-backlog.md)). Wires per-tool-call span aggregates into `SessionRecord` so downstream consumers (LOO pipeline, vitals, judge features) can read them without importing `gptme_sessions.spans`.

Builds on:
- #729 — Phase 1: `ToolSpan` + `SpanAggregates.from_spans()`
- #731 — Phase 2: `extract_spans_from_gptme_jsonl` (gptme trajectories)

## Changes

- New optional field `span_aggregates: dict[str, Any] | None = None` on `SessionRecord`, mirroring `SpanAggregates` fields (`total_spans`, `error_spans`, `error_rate`, `dominant_tool`, `avg/max_duration_ms`, `tool_counts`, `retry_depth`) — serialized as a dict to decouple consumers from the spans module and allow schema evolution without dataclass changes.
- New method `populate_span_aggregates(harness_hint: str | None = None) -> bool` that:
  - Dispatches on `harness` (or `harness_hint` override): `claude-code` → `extract_spans_from_cc_jsonl`, `gptme` → `extract_spans_from_gptme_jsonl`
  - Uses lazy imports to avoid a top-level `record` ↔ `spans` cycle
  - Returns `False` (no mutation) when `trajectory_path` is missing, the file doesn't exist, or the harness has no registered extractor
  - Idempotent — safe to re-run as trajectories grow

## Tests

9 new tests covering:
- Default is `None`
- `to_dict` / `from_dict` / JSON round-trip with a populated dict
- Populate with missing `trajectory_path` → `False`
- Populate with nonexistent file → `False`
- Populate from a synthetic CC trajectory fixture → correct aggregates
- Populate from a synthetic gptme `conversation.jsonl` → correct aggregates
- Unknown harness → `False`
- `harness_hint` overrides `self.harness`
- Idempotent re-run produces same result

Full suite: `85 passed` (test_record.py + test_spans.py).

## Test plan

- [x] `uv run --active pytest tests/test_record.py tests/test_spans.py -q` passes (85/85)
- [x] Mypy clean on `record.py` / `spans.py` (other mypy errors in the package are pre-existing, unrelated)
- [x] Pre-commit (prek) hooks pass
- [ ] Greptile review
- [ ] CI green

## Next (separate PRs)

- Wire `populate_span_aggregates()` into the judge/writeback pipeline so new session records get aggregates auto-populated
- Surface aggregate signals (retry_depth, error_rate) as features for the LOO pipeline and bob-vitals