### PR TITLE
fix(gptme-voice): greet first on fresh Twilio calls

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
@@ -183,6 +183,7 @@ class SessionConfig:
     model: str = "gpt-4o-realtime-preview-2024-12-17"
     voice: str = "echo"
     instructions: str = ""
+    initial_response_instructions: str = ""
     input_format: str = "pcm16"
     output_format: str = "pcm16"
     input_sample_rate: int = 24000
@@ -245,6 +246,7 @@ class OpenAIRealtimeClient:
         self._pending_audio: list[bytes] = []
         self._pending_audio_dropped = 0
         self._event_notice: asyncio.Event | None = None
+        self._initial_response_sent = False
 
     def _get_ws_url(self) -> str:
         """WebSocket URL for this provider (override in subclasses)."""
@@ -269,6 +271,7 @@ class OpenAIRealtimeClient:
         self._pending_audio = []
         self._pending_audio_dropped = 0
         self._event_notice = asyncio.Event()
+        self._initial_response_sent = False
 
         url = self._get_ws_url()
         headers = self._get_ws_headers()
@@ -578,6 +581,24 @@ class OpenAIRealtimeClient:
         logger.info("%s received — marking session ready", event_type)
         self._session_ready.set()
         await self._flush_pending_audio()
+        await self._send_initial_response_if_needed()
+
+    async def _send_initial_response_if_needed(self) -> None:
+        """Trigger a one-shot startup response once the provider session is ready."""
+        instructions = self.session_config.initial_response_instructions.strip()
+        if self._initial_response_sent or not instructions:
+            return
+
+        self._initial_response_sent = True
+        logger.info("Sending initial realtime response bootstrap")
+        await self._send_event(
+            "response.create",
+            {
+                "response": {
+                    "instructions": instructions,
+                }
+            },
+        )
 
     async def _flush_pending_audio(self) -> None:
         """Send any audio that was buffered before the session was ready."""

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -48,6 +48,11 @@ logger = logging.getLogger(__name__)
 _DEFAULT_RESUME_WINDOW_SECONDS = 300
 _DEFAULT_STATE_DIR = "/tmp/gptme-voice-call-state"
 _MAX_RESUME_TRANSCRIPT_CHARS = 2500
+_INITIAL_TWILIO_GREETING_INSTRUCTIONS = (
+    "A fresh inbound phone call has just connected. "
+    "Greet the caller briefly in one sentence, use their name if you know it, "
+    "then stop and wait for them to speak."
+)
 
 # Delay before actually closing the WebSocket after the model requests hangup,
 # so the goodbye utterance has time to reach the caller.
@@ -70,6 +75,12 @@ class RecentCallRecord:
     transcript: list[TranscriptTurn]
     metadata: dict[str, str]
     subagent_timings: list[dict[str, object]] = field(default_factory=list)
+
+
+@dataclass
+class SessionBootstrap:
+    instructions: str
+    should_greet_first: bool = False
 
 
 def _build_caller_instructions(
@@ -460,13 +471,13 @@ class VoiceServer:
         logger.info("Consumed handoff bootstrap %s from %s", handoff_id, path)
         return resume_context
 
-    def _build_session_instructions(
+    def _build_session_bootstrap(
         self,
         *,
         caller_id: str | None,
         from_number: str = "",
         handoff_id: str | None = None,
-    ) -> str:
+    ) -> SessionBootstrap:
         instructions = self._instructions
         if from_number:
             instructions = _build_caller_instructions(
@@ -475,13 +486,39 @@ class VoiceServer:
 
         handoff_resume_context = self._consume_handoff_bootstrap(handoff_id)
         if handoff_resume_context:
-            return f"{handoff_resume_context}\n\n{instructions}"
+            return SessionBootstrap(
+                instructions=f"{handoff_resume_context}\n\n{instructions}",
+                should_greet_first=False,
+            )
 
-        return _build_resume_instructions(
-            instructions,
-            self._consume_recent_call(caller_id),
-            self.resume_window_seconds,
+        recent_call = self._consume_recent_call(caller_id)
+        if recent_call:
+            return SessionBootstrap(
+                instructions=_build_resume_instructions(
+                    instructions,
+                    recent_call,
+                    self.resume_window_seconds,
+                ),
+                should_greet_first=False,
+            )
+
+        return SessionBootstrap(
+            instructions=instructions,
+            should_greet_first=True,
         )
+
+    def _build_session_instructions(
+        self,
+        *,
+        caller_id: str | None,
+        from_number: str = "",
+        handoff_id: str | None = None,
+    ) -> str:
+        return self._build_session_bootstrap(
+            caller_id=caller_id,
+            from_number=from_number,
+            handoff_id=handoff_id,
+        ).instructions
 
     def _consume_recent_call(self, caller_id: str | None) -> RecentCallRecord | None:
         if not caller_id:
@@ -808,10 +845,16 @@ class VoiceServer:
                     from_number = custom_params.get("from_number", "")
                     handoff_id = custom_params.get("handoff_id") or None
                     caller_id = from_number or call_sid or stream_sid
-                    instructions = self._build_session_instructions(
+                    bootstrap = self._build_session_bootstrap(
                         caller_id=caller_id,
                         from_number=from_number,
                         handoff_id=handoff_id,
+                    )
+                    instructions = bootstrap.instructions
+                    initial_response_instructions = (
+                        _INITIAL_TWILIO_GREETING_INSTRUCTIONS
+                        if bootstrap.should_greet_first
+                        else ""
                     )
                     metadata = {
                         "from_number": from_number,
@@ -825,12 +868,14 @@ class VoiceServer:
                     if self.model:
                         session_cfg = SessionConfig(
                             instructions=instructions,
+                            initial_response_instructions=initial_response_instructions,
                             model=self.model,
                             available_agents=self._available_agents,
                         )
                     else:
                         session_cfg = SessionConfig(
                             instructions=instructions,
+                            initial_response_instructions=initial_response_instructions,
                             available_agents=self._available_agents,
                         )
                     realtime_client = self._make_client(

--- a/packages/gptme-voice/tests/test_openai_client.py
+++ b/packages/gptme-voice/tests/test_openai_client.py
@@ -201,6 +201,45 @@ def test_send_audio_buffer_is_bounded() -> None:
     asyncio.run(_exercise())
 
 
+def test_initial_response_is_sent_once_after_session_ready() -> None:
+    async def _exercise() -> None:
+        fake_ws = _FakeWebSocket()
+
+        async def _fake_connect(*_args, **_kwargs):
+            return fake_ws
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "gptme_voice.realtime.openai_client.websockets.connect", _fake_connect
+            )
+            client = OpenAIRealtimeClient(
+                api_key="test-key",
+                session_config=SessionConfig(
+                    initial_response_instructions="Greet the caller briefly.",
+                ),
+            )
+            await client.connect()
+
+            await client._handle_event({"type": "session.created"})
+            await client._handle_event({"type": "session.updated"})
+
+            response_creates = [
+                event
+                for event in fake_ws.sent
+                if event.get("type") == "response.create"
+            ]
+            assert response_creates == [
+                {
+                    "type": "response.create",
+                    "response": {"instructions": "Greet the caller briefly."},
+                }
+            ]
+
+            await client.disconnect()
+
+    asyncio.run(_exercise())
+
+
 def test_load_project_instructions_guards_present_without_personality_files(
     tmp_path: Path,
 ) -> None:

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -100,6 +100,20 @@ def test_build_resume_instructions_includes_prior_transcript() -> None:
     assert "You are Bob." in result
 
 
+def test_build_session_bootstrap_greets_fresh_calls() -> None:
+    server = VoiceServer()
+    server._instructions = "You are Bob."
+
+    bootstrap = server._build_session_bootstrap(
+        caller_id="+46700000011",
+        from_number="+46700000011",
+    )
+
+    assert bootstrap.should_greet_first is True
+    assert "+46700000011" in bootstrap.instructions
+    assert "You are Bob." in bootstrap.instructions
+
+
 def test_truncate_resume_transcript_keeps_line_boundaries() -> None:
     # Lines must exceed max_chars so truncation is actually triggered
     transcript_text = "\n".join(
@@ -140,6 +154,30 @@ def test_recent_call_is_consumed_within_resume_window() -> None:
         assert resumed is not None
         assert resumed.caller_id == "+46700000001"
         assert resumed.transcript[0].text == "Hello again"
+
+
+def test_build_session_bootstrap_skips_greeting_for_recent_resume() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        server = VoiceServer()
+        server.state_dir = Path(tmpdir)
+        server.resume_window_seconds = 300
+        server._instructions = "You are Bob."
+        record = RecentCallRecord(
+            caller_id="+46700000012",
+            source="twilio",
+            ended_at=1_000.0,
+            transcript=[TranscriptTurn(role="user", text="Resume this call")],
+            metadata={"from_number": "+46700000012"},
+        )
+        server._save_recent_call(record)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("gptme_voice.realtime.server.time.time", lambda: 1_100.0)
+            bootstrap = server._build_session_bootstrap(caller_id=record.caller_id)
+
+        assert bootstrap.should_greet_first is False
+        assert "reconnected after a brief disconnect" in bootstrap.instructions
+        assert "Resume this call" in bootstrap.instructions
 
 
 def test_recent_call_is_ignored_outside_resume_window() -> None:

--- a/packages/gptme-voice/tests/test_xai_client.py
+++ b/packages/gptme-voice/tests/test_xai_client.py
@@ -45,7 +45,10 @@ def test_xai_client_treats_session_updated_as_ready_signal() -> None:
             )
             client = XAIRealtimeClient(
                 api_key="test-key",
-                session_config=SessionConfig(instructions="You are Bob."),
+                session_config=SessionConfig(
+                    instructions="You are Bob.",
+                    initial_response_instructions="Say hello first.",
+                ),
             )
             await client.connect()
 
@@ -63,6 +66,17 @@ def test_xai_client_treats_session_updated_as_ready_signal() -> None:
             ]
             assert len(appends) == 1
             assert base64.b64decode(appends[0]["audio"]) == b"\x01\x02\x03"
+            response_creates = [
+                event
+                for event in fake_ws.sent
+                if event.get("type") == "response.create"
+            ]
+            assert response_creates == [
+                {
+                    "type": "response.create",
+                    "response": {"instructions": "Say hello first."},
+                }
+            ]
 
             await client.disconnect()
             assert fake_ws.closed is True


### PR DESCRIPTION
## Summary
- add a one-shot realtime startup response hook for session-ready bootstrapping
- use it only for fresh inbound Twilio calls so callers hear Bob greet first on answer
- skip the greeting on reconnect/resume flows and cover OpenAI/xAI + server bootstrap behavior with tests

## Testing
- uv run pytest /home/bob/bob/gptme-contrib/packages/gptme-voice/tests/test_openai_client.py /home/bob/bob/gptme-contrib/packages/gptme-voice/tests/test_xai_client.py /home/bob/bob/gptme-contrib/packages/gptme-voice/tests/test_server.py -q
- uv run ruff check /home/bob/bob/gptme-contrib/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py /home/bob/bob/gptme-contrib/packages/gptme-voice/src/gptme_voice/realtime/server.py /home/bob/bob/gptme-contrib/packages/gptme-voice/tests/test_openai_client.py /home/bob/bob/gptme-contrib/packages/gptme-voice/tests/test_xai_client.py /home/bob/bob/gptme-contrib/packages/gptme-voice/tests/test_server.py

## Notes
- `uv run mypy packages/gptme-voice/...` still reports pre-existing package/stub issues unrelated to this diff (twilio/starlette/click stubs and older typing debt).