### PR TITLE
feat(gptme-sessions): populate span_aggregates in judge writeback (Phase 4)

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/judge.py
+++ b/packages/gptme-sessions/src/gptme_sessions/judge.py
@@ -543,7 +543,14 @@ def write_alignment_grade(
     verdict: JudgeVerdict,
     sessions_dir: Path,
 ) -> bool:
-    """Persist an alignment verdict onto an existing session record."""
+    """Persist an alignment verdict onto an existing session record.
+
+    Also opportunistically populates ``span_aggregates`` from the session's
+    trajectory when one is available. This is the natural integration point:
+    the record is already being loaded and rewritten, so the extra work is
+    amortized and keeps per-tool-call span data flowing into the LOO /
+    analytics pipelines that key off ``SessionRecord``.
+    """
     store = SessionStore(sessions_dir=sessions_dir)
     records = store.load_all()
     normalized = normalize_judge_verdict(dict(verdict))
@@ -556,6 +563,17 @@ def write_alignment_grade(
             model=normalized["model"],
         )
         _store_judge_meta(record, normalized.get("meta"))
+        # Safe to run unconditionally: returns False when trajectory_path is
+        # missing / unreadable or harness is unknown, and is idempotent when
+        # re-run after new trajectory data arrives.
+        try:
+            record.populate_span_aggregates()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "populate_span_aggregates failed for %s: %s",
+                session_id,
+                exc,
+            )
         store.rewrite(records)
         return True
     return False

--- a/packages/gptme-sessions/tests/test_judge.py
+++ b/packages/gptme-sessions/tests/test_judge.py
@@ -558,6 +558,69 @@ class TestSessionRecordJudgeFields:
             "judge_version": JUDGE_VERSION,
         }
 
+    def test_writeback_populates_span_aggregates(self, tmp_path: Path) -> None:
+        """write_alignment_grade opportunistically calls populate_span_aggregates."""
+        store = SessionStore(sessions_dir=tmp_path)
+        store.append(SessionRecord(session_id="abc123", outcome="productive"))
+
+        with (
+            patch(
+                "gptme_sessions.judge.judge_session",
+                return_value={
+                    "score": 0.74,
+                    "reason": "Real work shipped",
+                    "model": "openai-subscription/gpt-5.4",
+                },
+            ),
+            patch.object(
+                SessionRecord, "populate_span_aggregates", return_value=True
+            ) as mock_populate,
+        ):
+            result = judge_and_writeback(
+                text="session text",
+                category="code",
+                goals="ship useful work",
+                session_id="abc123",
+                sessions_dir=tmp_path,
+                model="openai-subscription/gpt-5.4",
+            )
+
+        assert result["status"] == "ok"
+        mock_populate.assert_called_once()
+
+    def test_writeback_tolerates_span_aggregates_failure(self, tmp_path: Path) -> None:
+        """Writeback still succeeds if span aggregation raises unexpectedly."""
+        store = SessionStore(sessions_dir=tmp_path)
+        store.append(SessionRecord(session_id="abc123", outcome="productive"))
+
+        with (
+            patch(
+                "gptme_sessions.judge.judge_session",
+                return_value={
+                    "score": 0.5,
+                    "reason": "Did work",
+                    "model": "openai-subscription/gpt-5.4",
+                },
+            ),
+            patch.object(
+                SessionRecord,
+                "populate_span_aggregates",
+                side_effect=RuntimeError("boom"),
+            ),
+        ):
+            result = judge_and_writeback(
+                text="session text",
+                category="code",
+                goals="ship useful work",
+                session_id="abc123",
+                sessions_dir=tmp_path,
+                model="openai-subscription/gpt-5.4",
+            )
+
+        assert result["status"] == "ok"
+        updated = SessionStore(sessions_dir=tmp_path).load_all()[0]
+        assert updated.grades["alignment"] == 0.5
+
     def test_judge_and_writeback_reports_missing_record(self, tmp_path: Path) -> None:
         with patch(
             "gptme_sessions.judge.judge_session",


### PR DESCRIPTION
## Summary
- Wire `SessionRecord.populate_span_aggregates()` into `write_alignment_grade()` so judge verdict writes naturally keep per-tool-call span data fresh.
- The writeback path already loads + rewrites the record, so this is the lowest-overhead integration point for Phase 3's `span_aggregates` field.
- Best-effort + idempotent: wrapped in `try/except` so trajectory parse failures never regress verdict writeback; `populate_span_aggregates()` short-circuits on missing trajectory or already-current data.

## Context
Phase 4 of [ErikBjare/bob idea #158](https://github.com/ErikBjare/bob/blob/master/knowledge/strategic/idea-backlog.md) (span-level tracing rollout). Direct continuation of:

- #729 (Phase 1) — `ToolSpan` + `SpanAggregates`
- #731 (Phase 2) — `extract_spans_from_gptme_jsonl`
- #732 (Phase 3) — `SessionRecord.span_aggregates` field + `populate_span_aggregates()` helper

Phase 3 added the field and the helper; Phase 4 is where that helper starts actually running in the judge/writeback hot-path, so records land with span data ready for LOO / vitals consumers.

## Test plan
- [x] `pytest packages/gptme-sessions/tests/test_judge.py -q` → 43 passed
- [x] Full `pytest packages/gptme-sessions/tests -q` → 713 passed
- [x] New test `test_writeback_populates_span_aggregates` — asserts `populate_span_aggregates` is called once during writeback
- [x] New test `test_writeback_tolerates_span_aggregates_failure` — asserts writeback still persists the alignment grade if span extraction raises
- [x] No new mypy errors (pre-existing `tomli` import-not-found unrelated)