### PR TITLE
feat(gptodo): promote `someday` to canonical first-class state

### DIFF
--- a/packages/gptodo/README.md
+++ b/packages/gptodo/README.md
@@ -119,7 +119,7 @@ Task files should use frontmatter metadata:
 
 ```yaml
 ---
-state: active      # new, active, paused, done, cancelled, someday
+state: active      # backlog, todo, active, ready_for_review, waiting, someday, done, cancelled
 priority: high     # low, medium, high
 task_type: project # project (multi-step) or action (single-step)
 assigned_to: bob   # agent name

--- a/packages/gptodo/src/gptodo/checker.py
+++ b/packages/gptodo/src/gptodo/checker.py
@@ -82,11 +82,12 @@ class CheckerConfig:
 
 # Valid state transitions
 VALID_TRANSITIONS: dict[str, list[str]] = {
-    "backlog": ["todo", "cancelled"],
-    "todo": ["active", "backlog", "cancelled"],
-    "active": ["ready_for_review", "waiting", "done", "cancelled"],
+    "backlog": ["todo", "someday", "cancelled"],
+    "todo": ["active", "backlog", "someday", "cancelled"],
+    "active": ["ready_for_review", "waiting", "someday", "done", "cancelled"],
     "ready_for_review": ["active", "done", "cancelled"],  # Can go back to active if review fails
-    "waiting": ["active", "cancelled"],
+    "waiting": ["active", "someday", "cancelled"],
+    "someday": ["backlog", "todo", "cancelled"],  # Can be revived back to actionable lanes
     "done": [],  # Terminal state
     "cancelled": [],  # Terminal state
 }

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -1753,9 +1753,9 @@ def tags(state: str | None, show_tasks: bool, filter_tags: tuple[str, ...]):
 @cli.command("ready")
 @click.option(
     "--state",
-    type=click.Choice(["backlog", "active", "both"]),
+    type=click.Choice(["backlog", "active", "someday", "both"]),
     default="both",
-    help="Filter by task state (backlog, active, or both)",
+    help="Filter by task state. 'both' = backlog+active. 'someday' = explicitly query deferred tasks.",
 )
 @click.option(
     "--json",
@@ -1818,6 +1818,8 @@ def ready(state, output_json, output_jsonl, use_cache):
         filtered_tasks = [task for task in all_tasks if task.state == "backlog"]
     elif state == "active":
         filtered_tasks = [task for task in all_tasks if task.state == "active"]
+    elif state == "someday":
+        filtered_tasks = [task for task in all_tasks if task.state == "someday"]
     else:  # both
         filtered_tasks = [task for task in all_tasks if task.state in ["backlog", "active"]]
 
@@ -3473,8 +3475,22 @@ def list_all_locks(cleanup: bool, output_json: bool):
 )
 @click.option(
     "--state",
-    type=click.Choice(["new", "active", "paused", "done", "cancelled", "someday"]),
-    default="new",
+    type=click.Choice(
+        [
+            "backlog",
+            "todo",
+            "active",
+            "ready_for_review",
+            "waiting",
+            "someday",
+            "done",
+            "cancelled",
+            # Deprecated aliases (backward compatibility)
+            "new",
+            "paused",
+        ]
+    ),
+    default="backlog",
     help="Initial task state",
 )
 @click.option(
@@ -4794,6 +4810,7 @@ def transitions_cmd(output_json: bool):
                 console.print(f"  {state} [dim](terminal state)[/]")
         console.print("\n[dim]State flow: backlog → todo → active → ready_for_review → done[/]")
         console.print("[dim]Alternate: active → waiting → active → done[/]")
+        console.print("[dim]Deferred:  any → someday → backlog/todo (revive when ready)[/]")
 
 
 # =============================================================================

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -678,7 +678,7 @@ def load_tasks(
                 issues.append("No state in frontmatter")
                 state = "backlog"  # Default state (canonical)
             else:
-                # Normalize deprecated states (new/someday/paused → backlog)
+                # Normalize deprecated states (new/paused → backlog)
                 # Note: warnings suppressed during load, validated separately
                 state = normalize_state(state, warn=False)
 
@@ -1276,7 +1276,7 @@ def fetch_linear_issue_state(identifier: str) -> str | None:
 def update_task_state(task_path: Path, new_state: str) -> bool:
     """Update task frontmatter state field.
 
-    If new_state is a deprecated alias (new, someday, paused),
+    If new_state is a deprecated alias (new, paused),
     it will be normalized to the canonical state (backlog) with a warning.
     """
     frontmatter = _get_frontmatter()

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -61,9 +61,13 @@ class DirectoryConfig:
 
 # Deprecated state aliases - these map to their canonical state
 # Used by normalize_state() to provide backward compatibility
+#
+# Note: `someday` is intentionally NOT in this list. It is a canonical state
+# that means "deferred indefinitely, not currently actionable" and is excluded
+# from `gptodo next` / `gptodo ready` selection. This preserves the GTD
+# someday/maybe distinction so plateau-pivot decisions stick.
 DEPRECATED_STATE_ALIASES: dict[str, str] = {
     "new": "backlog",  # new → backlog (untriaged work)
-    "someday": "backlog",  # someday → backlog (deferred work)
     "paused": "backlog",  # paused → backlog (intentionally deferred)
 }
 
@@ -99,32 +103,42 @@ def normalize_state(state: str, warn: bool = True) -> str:
 
 def get_canonical_states() -> list[str]:
     """Get list of canonical (non-deprecated) task states."""
-    return ["backlog", "todo", "active", "ready_for_review", "waiting", "done", "cancelled"]
+    return [
+        "backlog",
+        "todo",
+        "active",
+        "ready_for_review",
+        "waiting",
+        "someday",
+        "done",
+        "cancelled",
+    ]
 
 
 CONFIGS = {
     "tasks": DirectoryConfig(
         type_name="tasks",
         # State model (Issue #240 design + ready_for_review from Issue #255):
-        # - backlog: not triaged or intentionally deferred (consolidates new/someday/paused)
+        # - backlog: untriaged or generally available work, eligible for `next`/`ready`
         # - todo: triaged and ready to pick up
         # - active: being actively worked on
         # - ready_for_review: work done, awaiting review/verification (Issue #255)
         # - waiting: blocked on external response
+        # - someday: deferred indefinitely, NOT eligible for `next`/`ready` (GTD someday/maybe)
         # - done: completed
         # - cancelled: won't do
-        # Also accepts deprecated aliases: new, someday, paused (with warnings)
+        # Also accepts deprecated aliases: new, paused (with warnings)
         states=[
             "backlog",
             "todo",
             "active",
             "ready_for_review",  # Issue #255: review state before done
             "waiting",
+            "someday",
             "done",
             "cancelled",
             # Deprecated aliases accepted for backward compatibility
             "new",
-            "someday",
             "paused",
         ],
         special_files=["README.md", "templates", "video-scripts"],
@@ -160,6 +174,7 @@ STATE_STYLES = {
     "active": ("blue", "active"),
     "ready_for_review": ("bright_yellow", "review"),  # Issue #255
     "waiting": ("magenta", "waiting"),
+    "someday": ("dim", "someday"),  # canonical: GTD someday/maybe (excluded from next/ready)
     "done": ("green", "done"),
     "cancelled": ("red", "cancelled"),
     # Virtual states (computed, not stored in frontmatter)
@@ -167,7 +182,6 @@ STATE_STYLES = {
     # Deprecated task states (still accepted, mapped to canonical)
     "new": ("yellow", "new"),  # deprecated → backlog
     "paused": ("cyan", "paused"),  # deprecated → backlog
-    "someday": ("yellow", "someday"),  # deprecated → backlog
     # Tweets
     "queued": ("yellow", "queued"),
     "approved": ("blue", "approved"),
@@ -190,12 +204,12 @@ STATE_EMOJIS = {
     "active": "🏃",
     "ready_for_review": "👀",  # Issue #255: review state
     "waiting": "⏳",
+    "someday": "💭",  # canonical: GTD someday/maybe
     "done": "✅",
     "cancelled": "❌",
     # Deprecated task states (still accepted)
     "new": "🆕",  # deprecated → backlog
     "paused": "⚪",  # deprecated → backlog
-    "someday": "💭",  # deprecated → backlog
     "issues": "⚠️",
     "untracked": "❓",
     # priorities

--- a/packages/gptodo/tests/test_ready_selection.py
+++ b/packages/gptodo/tests/test_ready_selection.py
@@ -93,3 +93,101 @@ def test_next_command_ignores_waiting_task_even_if_higher_priority(
     assert result.exit_code == 0
     payload = json.loads(result.output)
     assert payload["next_task"]["id"] == "ready-task"
+
+
+def test_someday_state_preserved_not_normalized(tmp_path: Path) -> None:
+    """`someday` is canonical now — must NOT be silently rewritten to backlog."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(
+        tasks_dir,
+        "deferred-task",
+        state="someday",
+        created="2026-04-22T00:00:00",
+    )
+
+    tasks = load_tasks(tasks_dir)
+    task_lookup = {task.name: task for task in tasks}
+
+    assert task_lookup["deferred-task"].state == "someday"
+
+
+def test_ready_excludes_someday_tasks(tmp_path: Path, monkeypatch) -> None:
+    """`gptodo ready --state both` must skip someday tasks (GTD someday/maybe)."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(
+        tasks_dir,
+        "deferred-task",
+        state="someday",
+        created="2026-04-22T00:00:00",
+        priority="high",
+    )
+    write_task(
+        tasks_dir,
+        "real-task",
+        state="backlog",
+        created="2026-04-22T01:00:00",
+        priority="low",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["ready", "--state", "both", "--json"])
+
+    assert result.exit_code == 0
+    payload_text = result.output.split("\nNo ready tasks found", 1)[0]
+    payload = json.loads(payload_text)
+    ids = [t["id"] for t in payload["ready_tasks"]]
+    assert "deferred-task" not in ids
+    assert "real-task" in ids
+
+
+def test_next_skips_someday_even_when_higher_priority(tmp_path: Path, monkeypatch) -> None:
+    """`gptodo next` must not surface someday tasks even if priority is higher."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(
+        tasks_dir,
+        "deferred-task",
+        state="someday",
+        created="2026-04-22T00:00:00",
+        priority="high",
+    )
+    write_task(
+        tasks_dir,
+        "real-task",
+        state="backlog",
+        created="2026-04-22T01:00:00",
+        priority="low",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["next", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["next_task"]["id"] == "real-task"
+
+
+def test_ready_someday_explicit_query_returns_them(tmp_path: Path, monkeypatch) -> None:
+    """`gptodo ready --state someday` returns the deferred queue for explicit review."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(
+        tasks_dir,
+        "deferred-task",
+        state="someday",
+        created="2026-04-22T00:00:00",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["ready", "--state", "someday", "--json"])
+
+    assert result.exit_code == 0
+    payload_text = result.output.split("\nNo ready tasks found", 1)[0]
+    payload = json.loads(payload_text)
+    ids = [t["id"] for t in payload["ready_tasks"]]
+    assert "deferred-task" in ids


### PR DESCRIPTION
## Summary

`someday` was a deprecated alias that silently normalized to `backlog`, which meant tasks intentionally deferred via `someday` were still surfaced by `gptodo next` and `gptodo ready`. That defeated the GTD someday/maybe distinction and caused autonomous sessions to keep re-picking work that a previous session had explicitly parked.

Concrete failure observed in Bob's workspace today: an earlier autonomous session moved two tasks (`judge-thompson-sampling`, `share-vitals-dashboard-data-layer`) to `state: someday` to deprioritize them. The next session ran `gptodo next --json` and got `judge-thompson-sampling` back as the recommended next task — because under the hood it had been silently rewritten as `backlog`.

## Changes

- Removed `someday` from `DEPRECATED_STATE_ALIASES` (no more silent normalization)
- Added to canonical states list, `STATE_STYLES`, `STATE_EMOJIS`
- Excluded from `gptodo next` / `gptodo ready` defaults (which only consider backlog/active)
- Queryable explicitly via `gptodo ready --state someday`
- Allowed transition into and out of `someday` from non-terminal states
- `gptodo add --state` now exposes the full canonical set with `backlog` as default (was `new`)

`new` and `paused` remain deprecated aliases for `backlog`.

## Test plan

- [x] All 120 existing gptodo tests pass
- [x] 4 new tests in `test_ready_selection.py` cover: state preserved on load, ready/next exclusion, explicit `--state someday` query path
- [x] Smoke test against Bob's real workspace: `gptodo next` no longer returns the two `someday`-marked tasks; `gptodo status --compact` correctly shows them as 💭 (someday) instead of mixed into backlog