### PR TITLE
fix(voice): forward transcript tail to subagents

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -908,6 +908,7 @@ class VoiceServer:
                         on_result=realtime_client.inject_message,
                         on_hangup=_twilio_hangup,
                         on_handoff=self._make_handoff_callback([caller_id], transcript),
+                        transcript_provider=lambda: transcript,
                     )
                     realtime_client.on_function_call = tool_bridge.handle_function_call
 
@@ -1040,6 +1041,7 @@ class VoiceServer:
                 on_result=realtime_client.inject_message,
                 on_hangup=_local_hangup,
                 on_handoff=self._make_handoff_callback([caller_id], transcript),
+                transcript_provider=lambda: transcript,
             )
             realtime_client.on_function_call = tool_bridge.handle_function_call
 

--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -18,7 +18,7 @@ import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Awaitable, Callable
+from typing import Awaitable, Callable
 
 logger = logging.getLogger(__name__)
 
@@ -200,7 +200,9 @@ class GptmeToolBridge:
         try:
             raw_turns = list(self.transcript_provider() or [])
         except Exception as exc:
-            logger.warning("Failed to fetch transcript tail for voice subagent: %s", exc)
+            logger.warning(
+                "Failed to fetch transcript tail for voice subagent: %s", exc
+            )
             return None
 
         formatted_lines: list[str] = []
@@ -216,7 +218,10 @@ class GptmeToolBridge:
                 role, text, self.transcript_tail_chars
             )
             line_chars = len(line) + (1 if formatted_lines else 0)
-            if formatted_lines and total_chars + line_chars > self.transcript_tail_chars:
+            if (
+                formatted_lines
+                and total_chars + line_chars > self.transcript_tail_chars
+            ):
                 break
             formatted_lines.append(line)
             total_chars += line_chars

--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -18,7 +18,7 @@ import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Awaitable, Callable
+from typing import Any, Awaitable, Callable
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +30,8 @@ _MAX_OUTPUT_LEN = 2000
 _IGNORABLE_ERROR_LINES = {
     "Warning: Input is not a terminal (fd=0).",
 }
+_DEFAULT_TRANSCRIPT_TAIL_TURNS = 8
+_DEFAULT_TRANSCRIPT_TAIL_CHARS = 1_600
 
 # Appended to each task so the subagent writes a clean response file
 _RESPONSE_SUFFIX = (
@@ -85,6 +87,7 @@ class GptmeToolBridge:
         on_result: Callable[[str], Awaitable[None]] | None = None,
         on_hangup: Callable[[str | None], Awaitable[None]] | None = None,
         on_handoff: Callable[[str, str, str | None], Awaitable[dict]] | None = None,
+        transcript_provider: Callable[[], list[object]] | None = None,
     ):
         self.gptme_path = os.environ.get("GPTME_VOICE_SUBAGENT_PATH") or gptme_path
         self.timeout = timeout
@@ -92,14 +95,36 @@ class GptmeToolBridge:
         self.on_result = on_result
         self.on_hangup = on_hangup
         self.on_handoff = on_handoff
+        self.transcript_provider = transcript_provider
         legacy_env_model = os.environ.get("GPTME_VOICE_SUBAGENT_MODEL")
         env_model_fast = os.environ.get("GPTME_VOICE_SUBAGENT_MODEL_FAST")
         env_model_smart = os.environ.get("GPTME_VOICE_SUBAGENT_MODEL_SMART")
         self.model_fast = env_model_fast or legacy_env_model or self.MODEL_FAST
         self.model_smart = env_model_smart or legacy_env_model or self.MODEL_SMART
+        self.transcript_tail_turns = self._parse_env_int(
+            "GPTME_VOICE_SUBAGENT_TRANSCRIPT_TAIL_TURNS",
+            default=_DEFAULT_TRANSCRIPT_TAIL_TURNS,
+            minimum=0,
+        )
+        self.transcript_tail_chars = self._parse_env_int(
+            "GPTME_VOICE_SUBAGENT_TRANSCRIPT_TAIL_CHARS",
+            default=_DEFAULT_TRANSCRIPT_TAIL_CHARS,
+            minimum=0,
+        )
         self._pending_tasks: dict[str, PendingTask] = {}
         self._task_counter = 0
         self._completed_timings: list[dict[str, object]] = []
+
+    @staticmethod
+    def _parse_env_int(name: str, *, default: int, minimum: int = 0) -> int:
+        value = os.environ.get(name)
+        if value is None:
+            return default
+        try:
+            return max(minimum, int(value))
+        except ValueError:
+            logger.warning("%s=%r is not an integer; using %s", name, value, default)
+            return default
 
     @staticmethod
     def _extract_error_text(stdout: str, stderr: str, output: str) -> str:
@@ -132,6 +157,75 @@ class GptmeToolBridge:
         if value is None:
             return None
         return round(max(0.0, value), 1)
+
+    @staticmethod
+    def _extract_transcript_turn(turn: object) -> tuple[str, str] | None:
+        if isinstance(turn, dict):
+            role = turn.get("role")
+            text = turn.get("text")
+        else:
+            role = getattr(turn, "role", None)
+            text = getattr(turn, "text", None)
+
+        if not isinstance(role, str) or not isinstance(text, str):
+            return None
+
+        cleaned = text.strip()
+        if not cleaned:
+            return None
+
+        return role.strip(), cleaned
+
+    @staticmethod
+    def _truncate_transcript_line(role: str, text: str, max_chars: int) -> str:
+        prefix = f"{role.title()}: "
+        if len(prefix) + len(text) <= max_chars:
+            return prefix + text
+
+        remaining = max_chars - len(prefix)
+        if remaining <= 0:
+            return (prefix + text)[-max_chars:]
+        if remaining <= 3:
+            return prefix + text[-remaining:]
+        return prefix + "..." + text[-(remaining - 3) :]
+
+    def _build_transcript_tail(self) -> tuple[str, int] | None:
+        if (
+            self.transcript_provider is None
+            or self.transcript_tail_turns <= 0
+            or self.transcript_tail_chars <= 0
+        ):
+            return None
+
+        try:
+            raw_turns = list(self.transcript_provider() or [])
+        except Exception as exc:
+            logger.warning("Failed to fetch transcript tail for voice subagent: %s", exc)
+            return None
+
+        formatted_lines: list[str] = []
+        total_chars = 0
+        included_turns = 0
+
+        for raw_turn in reversed(raw_turns[-self.transcript_tail_turns :]):
+            turn = self._extract_transcript_turn(raw_turn)
+            if turn is None:
+                continue
+            role, text = turn
+            line = self._truncate_transcript_line(
+                role, text, self.transcript_tail_chars
+            )
+            line_chars = len(line) + (1 if formatted_lines else 0)
+            if formatted_lines and total_chars + line_chars > self.transcript_tail_chars:
+                break
+            formatted_lines.append(line)
+            total_chars += line_chars
+            included_turns += 1
+
+        if not formatted_lines:
+            return None
+
+        return "\n".join(reversed(formatted_lines)), included_turns
 
     def _timing_breakdown(
         self,
@@ -328,6 +422,7 @@ class GptmeToolBridge:
             prefix="gptme-voice-", suffix=".md", delete=False
         ) as tf:
             response_file = Path(tf.name)
+        transcript_tail_file: Path | None = None
         augmented_task = task + _RESPONSE_SUFFIX.format(response_file=response_file)
 
         model = self.model_fast if mode == "fast" else self.model_smart
@@ -346,6 +441,20 @@ class GptmeToolBridge:
         # scripts/context.sh while still giving the subagent its runtime rules.
         if model:
             cmd += ["--model", model, "--tool-format", "tool"]
+        transcript_tail = self._build_transcript_tail()
+        if transcript_tail is not None:
+            transcript_tail_text, transcript_tail_turns = transcript_tail
+            with tempfile.NamedTemporaryFile(
+                prefix="gptme-voice-transcript-", suffix=".txt", delete=False
+            ) as tf:
+                transcript_tail_file = Path(tf.name)
+                tf.write(transcript_tail_text.encode("utf-8"))
+            cmd += [
+                "--transcript-tail-turns",
+                str(transcript_tail_turns),
+                "--transcript-tail-file",
+                str(transcript_tail_file),
+            ]
         cmd.append(augmented_task)
 
         try:
@@ -447,6 +556,8 @@ class GptmeToolBridge:
             return ToolResult(success=False, output="", error=str(e))
         finally:
             response_file.unlink(missing_ok=True)
+            if transcript_tail_file is not None:
+                transcript_tail_file.unlink(missing_ok=True)
 
     def _describe_pending(self, task_id: str, entry: PendingTask) -> dict:
         description = entry.description

--- a/packages/gptme-voice/tests/test_tool_bridge.py
+++ b/packages/gptme-voice/tests/test_tool_bridge.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from pathlib import Path
 
 import pytest
 from gptme_voice.realtime.tool_bridge import GptmeToolBridge
@@ -268,6 +269,76 @@ def test_execute_smart_mode_keeps_context_loading() -> None:
         args = tuple(captured["args"])
         assert "--context" in args
         assert "files" in args
+
+    asyncio.run(_exercise())
+
+
+def test_execute_passes_bounded_transcript_tail_to_wrapper() -> None:
+    async def _exercise() -> None:
+        captured: dict[str, object] = {}
+
+        transcript = [
+            {"role": "user", "text": "first question"},
+            {"role": "assistant", "text": "first answer"},
+            {"role": "user", "text": "second question"},
+            {"role": "assistant", "text": "second answer"},
+        ]
+
+        async def _fake_create_subprocess_exec(*args, **kwargs):
+            captured["args"] = args
+            tail_file_index = args.index("--transcript-tail-file") + 1
+            captured["tail_text"] = Path(args[tail_file_index]).read_text()
+            turns_index = args.index("--transcript-tail-turns") + 1
+            captured["tail_turns"] = args[turns_index]
+            captured["kwargs"] = kwargs
+            return _FakeProcess(returncode=0)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+            bridge = GptmeToolBridge(
+                workspace="/fake/workspace",
+                transcript_provider=lambda: transcript,
+            )
+            bridge.transcript_tail_turns = 3
+            bridge.transcript_tail_chars = 512
+            result = await bridge._execute("detailed analysis", mode="smart")
+
+        assert result.success is True
+        args = tuple(captured["args"])
+        assert "--transcript-tail-file" in args
+        assert "--transcript-tail-turns" in args
+        assert captured["tail_turns"] == "3"
+        assert captured["tail_text"] == (
+            "Assistant: first answer\n"
+            "User: second question\n"
+            "Assistant: second answer"
+        )
+
+    asyncio.run(_exercise())
+
+
+def test_execute_skips_transcript_tail_when_disabled() -> None:
+    async def _exercise() -> None:
+        captured: dict[str, object] = {}
+
+        async def _fake_create_subprocess_exec(*args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return _FakeProcess(returncode=0)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+            bridge = GptmeToolBridge(
+                workspace="/fake/workspace",
+                transcript_provider=lambda: [{"role": "user", "text": "hello"}],
+            )
+            bridge.transcript_tail_turns = 0
+            result = await bridge._execute("detailed analysis", mode="smart")
+
+        assert result.success is True
+        args = tuple(captured["args"])
+        assert "--transcript-tail-file" not in args
+        assert "--transcript-tail-turns" not in args
 
     asyncio.run(_exercise())
 


### PR DESCRIPTION
## Summary
- forward a bounded tail of the live call transcript into voice subagent dispatches
- pass the tail through the voice wrapper so the subagent contract includes caller context
- add regression tests for the bridge and wrapper plumbing

## Testing
- uv run pytest tests/test_tool_bridge.py tests/test_server.py -q
- uv run pytest tests/test_voice_subagent_wrapper_script.py -q
- shellcheck /home/bob/bob/scripts/runs/voice/voice-subagent.sh
