### PR TITLE
feat(repo-status): annotate stale CI runs when HEAD has advanced

### DIFF
--- a/scripts/github/repo-status.sh
+++ b/scripts/github/repo-status.sh
@@ -17,12 +17,19 @@ check_repo() {
     local repo=$1
     local label=${2:-$repo}
 
-    # Fetch last 5 runs so we can skip disabled-workflow runs and still have fallback.
-    # headSha is needed so we can detect when the most recent run lives on an older
-    # commit than the current default-branch HEAD — a common case when path filters
-    # skip CI on journal-only / docs-only commits.
+    # Scope all run queries to the default branch so feature-branch runs do not
+    # appear in the list and trigger false-positive stale annotations (a
+    # feature-branch headSha is always different from the default-branch HEAD).
+    local default_branch
+    default_branch=$(gh api "repos/$repo" --jq '.default_branch' 2>/dev/null || echo "master")
+
+    # Fetch last 5 runs on the default branch so we can skip disabled-workflow
+    # runs and still have a fallback.  headSha is needed so we can detect when
+    # the most recent run lives on an older commit than the current
+    # default-branch HEAD — a common case when path filters skip CI on
+    # journal-only / docs-only commits.
     local run_json
-    run_json=$(gh run list --repo "$repo" --limit 5 --json conclusion,status,url,name,headSha 2>/dev/null || echo "error")
+    run_json=$(gh run list --repo "$repo" --branch "$default_branch" --limit 5 --json conclusion,status,url,name,headSha 2>/dev/null || echo "error")
 
     if [ "$run_json" = "error" ]; then
         echo -e "${YELLOW}-${NC} $label: No Actions"

--- a/scripts/github/repo-status.sh
+++ b/scripts/github/repo-status.sh
@@ -17,9 +17,12 @@ check_repo() {
     local repo=$1
     local label=${2:-$repo}
 
-    # Fetch last 5 runs so we can skip disabled-workflow runs and still have fallback
+    # Fetch last 5 runs so we can skip disabled-workflow runs and still have fallback.
+    # headSha is needed so we can detect when the most recent run lives on an older
+    # commit than the current default-branch HEAD — a common case when path filters
+    # skip CI on journal-only / docs-only commits.
     local run_json
-    run_json=$(gh run list --repo "$repo" --limit 5 --json conclusion,status,url,name 2>/dev/null || echo "error")
+    run_json=$(gh run list --repo "$repo" --limit 5 --json conclusion,status,url,name,headSha 2>/dev/null || echo "error")
 
     if [ "$run_json" = "error" ]; then
         echo -e "${YELLOW}-${NC} $label: No Actions"
@@ -51,15 +54,35 @@ check_repo() {
     local suffix=""
     [ -n "$in_progress" ] && suffix=" (run in progress)"
 
+    # Determine index of the run we're reporting on (1 if latest is in-progress, else 0)
+    local idx=0
+    [ -n "$in_progress" ] && idx=1
+
+    # Stale-SHA detection: if the reported run was on a commit that is no longer HEAD
+    # (e.g. because path filters skipped CI on newer commits), annotate the output so
+    # we don't treat a stale red/green as authoritative for HEAD.
+    # Skipped entirely when latest run is in-progress — caller already signaled that
+    # fresh CI is running, so "stale" would be noise.
+    local stale_suffix=""
+    if [ -z "$in_progress" ]; then
+        local run_head_sha
+        run_head_sha=$(echo "$run_json" | jq -r ".[$idx].headSha // \"\"")
+        if [ -n "$run_head_sha" ]; then
+            local current_head_sha
+            current_head_sha=$(gh api "repos/$repo/commits" --jq '.[0].sha' 2>/dev/null || echo "")
+            if [ -n "$current_head_sha" ] && [ "$run_head_sha" != "$current_head_sha" ]; then
+                stale_suffix=" (stale; HEAD=${current_head_sha:0:7}, run=${run_head_sha:0:7})"
+            fi
+        fi
+    fi
+
     case "$conclusion" in
         "success")
-            echo -e "${GREEN}✓${NC} $label: Passing${suffix}"
+            echo -e "${GREEN}✓${NC} $label: Passing${suffix}${stale_suffix}"
             ;;
         "failure")
-            echo -e "${RED}✗${NC} $label: Failing${suffix}"
-            # Show URL for the failing run (index 1 if in-progress, else 0)
-            local idx=0
-            [ -n "$in_progress" ] && idx=1
+            echo -e "${RED}✗${NC} $label: Failing${suffix}${stale_suffix}"
+            # Show URL for the failing run
             local workflow_url
             workflow_url=$(echo "$run_json" | jq -r ".[$idx].url // \"\"")
             if [ -n "$workflow_url" ]; then
@@ -67,7 +90,7 @@ check_repo() {
             fi
             ;;
         "cancelled"|"skipped")
-            echo -e "${YELLOW}⚠${NC} $label: $conclusion${suffix}"
+            echo -e "${YELLOW}⚠${NC} $label: $conclusion${suffix}${stale_suffix}"
             ;;
         "")
             # No previous run to fall back on


### PR DESCRIPTION
## Summary

When GitHub Actions path filters skip CI on newer commits, `repo-status.sh` could report a stale `failure`/`success` conclusion as authoritative for HEAD even though HEAD hadn't been tested. This patch compares the reported run's `headSha` against the repo's current default-branch HEAD and annotates the output `(stale; HEAD=abc1234, run=def5678)` when they differ.

## Why

Concrete example from tonight on `ErikBjare/bob`:

1. Commit `d73db2176` (touched `scripts/` and `tasks/`) triggered a full pre-commit CI run, which failed because of a pre-existing bare-header journal file.
2. The fix commit `3b4396317` only touched `journal/`, so the workflow's `push.paths` filter skipped CI.
3. Subsequent journal-only commits also didn't retrigger CI.
4. `repo-status.sh` kept reporting `✗ bob: Failing` for several sessions, even though HEAD was clean — the most recent run was just on a stale SHA.

Autonomous sessions that use `repo-status.sh` as a quick health signal would treat master as broken and possibly pivot to phantom CI-fix work.

## Change

- Added `headSha` to the `gh run list` JSON fetch.
- Added a `stale_suffix` that compares `run_json[idx].headSha` to `gh api repos/$repo/commits[0].sha`.
- Appended the suffix to `success`, `failure`, and `cancelled/skipped` output lines when the SHAs differ.
- Skipped entirely when the latest run is in-progress (the existing `(run in progress)` suffix already signals fresh CI).

Adds one extra `gh api` call per repo. Repos already run in parallel (`&` + `wait`), so this is zero wall-clock impact beyond the single extra request per repo.

## Test plan

Manually verified from Bob's workspace against a small repo set:

```text
=== Repository CI Status ===
✗ bob: Failing (run in progress)
  https://github.com/ErikBjare/bob/actions/runs/24813432280
✓ gptme: Passing (stale; HEAD=c7f6833, run=462206f)
✓ gptme-contrib: Passing
```

- `bob`: latest completed run failed; fresh dispatched run is live → `Failing (run in progress)`, no stale tag (correct — new CI is coming).
- `gptme`: runs pass but HEAD has advanced past last tested commit → `(stale; ...)` tag appears.
- `gptme-contrib`: SHAs match → plain `Passing`, no tag (baseline case).

Additional validation:
- `shellcheck -S warning scripts/github/repo-status.sh` clean
- Parent wrapper `scripts/repo-status.sh` renders correctly across the full 9-repo set

## Scope

- [x] No behavior change when SHAs match
- [x] Backward-compatible output format (suffix-only addition)
- [x] No impact on in-progress reporting