### PR TITLE
fix(git-safe-commit): show staged files and concrete command in error

### DIFF
--- a/scripts/git/git-safe-commit
+++ b/scripts/git/git-safe-commit
@@ -92,11 +92,35 @@ if [ "$PATHSPEC_COUNT" -eq 0 ] && [ "$ALLOW_ALL_STAGED" -ne 1 ] && [ "$ALLOW_EMP
     echo "   Use explicit file paths with git-safe-commit so concurrent sessions" >&2
     echo "   can't accidentally commit unrelated staged changes." >&2
     echo "" >&2
-    echo "   If you intentionally want the entire staged set, rerun with:" >&2
-    echo "     git-safe-commit --all-staged -m 'your message'" >&2
-    echo "" >&2
-    echo "   Safer default:" >&2
-    echo "     git-safe-commit <file1> <file2> -m 'your message'" >&2
+
+    # If the caller already staged specific files, show them and a ready-to-copy
+    # command. This turns the most common "git add X && git-safe-commit -m ..."
+    # antipattern into a one-step fix.
+    STAGED_FILES="$(git diff --cached --name-only 2>/dev/null)"
+    STAGED_COUNT=0
+    if [ -n "$STAGED_FILES" ]; then
+        STAGED_COUNT=$(printf '%s\n' "$STAGED_FILES" | grep -c '^' || echo 0)
+    fi
+    STAGED_SUGGEST_CAP=20
+
+    if [ "$STAGED_COUNT" -gt 0 ] && [ "$STAGED_COUNT" -le "$STAGED_SUGGEST_CAP" ]; then
+        echo "   You have $STAGED_COUNT file(s) already staged:" >&2
+        printf '%s\n' "$STAGED_FILES" | sed 's/^/     /' >&2
+        echo "" >&2
+        # Build the suggested command with the staged paths on one line.
+        STAGED_ONE_LINE="$(printf '%s\n' "$STAGED_FILES" | tr '\n' ' ' | sed 's/ $//')"
+        echo "   To commit exactly those files:" >&2
+        echo "     git-safe-commit $STAGED_ONE_LINE -m 'your message'" >&2
+        echo "" >&2
+        echo "   Or, to commit the entire staged set regardless:" >&2
+        echo "     git-safe-commit --all-staged -m 'your message'" >&2
+    else
+        echo "   If you intentionally want the entire staged set, rerun with:" >&2
+        echo "     git-safe-commit --all-staged -m 'your message'" >&2
+        echo "" >&2
+        echo "   Safer default:" >&2
+        echo "     git-safe-commit <file1> <file2> -m 'your message'" >&2
+    fi
     echo "" >&2
     exit 1
 fi

--- a/scripts/git/git-safe-commit
+++ b/scripts/git/git-safe-commit
@@ -108,7 +108,7 @@ if [ "$PATHSPEC_COUNT" -eq 0 ] && [ "$ALLOW_ALL_STAGED" -ne 1 ] && [ "$ALLOW_EMP
         printf '%s\n' "$STAGED_FILES" | sed 's/^/     /' >&2
         echo "" >&2
         # Build the suggested command with the staged paths on one line.
-        STAGED_ONE_LINE="$(printf '%s\n' "$STAGED_FILES" | tr '\n' ' ' | sed 's/ $//')"
+        STAGED_ONE_LINE="$(printf '%s\n' "$STAGED_FILES" | sed 's/.*/"\&"/' | tr '\n' ' ' | sed 's/ $//')"
         echo "   To commit exactly those files:" >&2
         echo "     git-safe-commit $STAGED_ONE_LINE -m 'your message'" >&2
         echo "" >&2

--- a/tests/test_git_safe_commit.py
+++ b/tests/test_git_safe_commit.py
@@ -162,6 +162,49 @@ def test_safe_commit_requires_explicit_paths_or_all_staged(git_repo: Path):
     assert "--all-staged" in result.stderr
 
 
+def test_safe_commit_error_shows_staged_files_as_concrete_hint(git_repo: Path):
+    """When refusing an implicit commit, show staged files + a ready-to-copy command."""
+    (git_repo / "test.txt").write_text("hello")
+    (git_repo / "other.txt").write_text("world")
+    subprocess.run(
+        ["git", "add", "test.txt", "other.txt"],
+        cwd=git_repo,
+        check=True,
+        capture_output=True,
+    )
+
+    result = subprocess.run(
+        [str(SAFE_COMMIT), "-m", "test: implicit all staged blocked"],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    # Lists the staged files so the user sees what they almost committed.
+    assert "test.txt" in result.stderr
+    assert "other.txt" in result.stderr
+    # Shows a concrete copy-paste-ready git-safe-commit invocation; git sorts
+    # the staged paths alphabetically.
+    assert "git-safe-commit other.txt test.txt" in result.stderr
+    # The existing --all-staged hint is still available as a fallback.
+    assert "--all-staged" in result.stderr
+
+
+def test_safe_commit_error_without_staged_files_keeps_generic_hint(git_repo: Path):
+    """With nothing staged, the error still shows the generic --all-staged fallback."""
+    result = subprocess.run(
+        [str(SAFE_COMMIT), "-m", "test: no paths, nothing staged"],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "implicit whole-index commit" in result.stderr.lower()
+    assert "--all-staged" in result.stderr
+
+
 def test_safe_commit_allows_explicit_all_staged_opt_in(git_repo: Path):
     """Intentional whole-index commits require the explicit --all-staged flag."""
     (git_repo / "test.txt").write_text("hello")


### PR DESCRIPTION
## Summary

- When `git-safe-commit` refuses an implicit whole-index commit, it now lists the currently staged files and prints a ready-to-copy `git-safe-commit <files> -m '...'` command with those paths.
- Falls back to the existing generic hint when nothing is staged, or when the staged set exceeds 20 files (pathological case).
- Existing behavior (refuse by default, honor `--all-staged`) is unchanged.

## Why

The `git add X && git-safe-commit -m '...'` antipattern is the most common way sessions hit this guard: 76 occurrences across 59 distinct CC sessions in the current workspace trajectory corpus. The previous generic hint told users to type the file list from scratch, so sessions often retried with `--all-staged` — the riskier path in shared repos with concurrent sessions.

Showing the already-staged paths turns the error into a one-step fix.

## Example (staged case)

```
🚫 Refusing implicit whole-index commit in shared repo

   Use explicit file paths with git-safe-commit so concurrent sessions
   can't accidentally commit unrelated staged changes.

   You have 2 file(s) already staged:
     other.txt
     test.txt

   To commit exactly those files:
     git-safe-commit other.txt test.txt -m 'your message'

   Or, to commit the entire staged set regardless:
     git-safe-commit --all-staged -m 'your message'
```

## Test plan

- [x] New: `test_safe_commit_error_shows_staged_files_as_concrete_hint` — verifies staged paths + concrete `git-safe-commit ...` suggestion appear in stderr.
- [x] New: `test_safe_commit_error_without_staged_files_keeps_generic_hint` — verifies the original generic fallback when nothing is staged.
- [x] Existing: all 18 prior `test_git_safe_commit.py` tests still pass (20/20 total).
- [x] `shellcheck scripts/git/git-safe-commit` — clean.