### PR TITLE
fix(voice): preserve resumed call archives for post-call

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -282,6 +282,7 @@ class VoiceServer:
         # Active connections: call_sid -> (twilio_ws, realtime_client)
         self._connections: dict[str, tuple] = {}
         self._pending_post_calls: dict[str, asyncio.Task[None]] = {}
+        self._pending_archive_records: dict[str, list[Path]] = {}
 
         # Create Starlette app
         self.app = Starlette(
@@ -535,7 +536,9 @@ class VoiceServer:
         pending_task = self._pending_post_calls.pop(caller_id, None)
         if pending_task:
             pending_task.cancel()
-            logger.info("Cancelled pending post-call follow-up for %s", caller_id)
+            logger.info(
+                "Deferred pending post-call follow-up for resumed caller %s", caller_id
+            )
 
         # Delete the resume-state file(s) so a crash-resume can't re-inject the old
         # transcript, but keep archived per-call records for post-call analysis.
@@ -556,8 +559,15 @@ class VoiceServer:
         )
         return recent_call
 
-    async def _run_post_call_command(self, caller_id: str, record_path: Path) -> None:
+    async def _run_post_call_command(
+        self, caller_id: str, record_paths: list[Path]
+    ) -> None:
         if not self.post_call_command:
+            return
+        if not record_paths:
+            logger.warning(
+                "Ignoring post-call command for %s with no records", caller_id
+            )
             return
 
         argv = shlex.split(self.post_call_command)
@@ -566,11 +576,14 @@ class VoiceServer:
             return
 
         env = os.environ.copy()
-        env["GPTME_VOICE_POST_CALL_JSON"] = str(record_path)
+        env["GPTME_VOICE_POST_CALL_JSON"] = str(record_paths[0])
+        env["GPTME_VOICE_POST_CALL_JSONS"] = json.dumps(
+            [str(path) for path in record_paths]
+        )
         env["GPTME_VOICE_CALLER_ID"] = caller_id
         process = await asyncio.create_subprocess_exec(
             *argv,
-            str(record_path),
+            *(str(path) for path in record_paths),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             env=env,
@@ -605,25 +618,39 @@ class VoiceServer:
                 stdout.decode("utf-8", errors="replace").strip(),
             )
 
-    async def _schedule_post_call(self, caller_id: str, record_path: Path) -> None:
+    async def _schedule_post_call(
+        self, caller_id: str, record_paths: list[Path]
+    ) -> None:
         existing_task = self._pending_post_calls.pop(caller_id, None)
         if existing_task:
             existing_task.cancel()
 
+        deduped_record_paths = list(dict.fromkeys(record_paths))
+        if not deduped_record_paths:
+            self._pending_archive_records.pop(caller_id, None)
+            logger.warning(
+                "Ignoring post-call schedule for %s with no records", caller_id
+            )
+            return
+
+        self._pending_archive_records[caller_id] = deduped_record_paths
+
         if not self.post_call_command:
+            self._pending_archive_records.pop(caller_id, None)
             return
 
         async def _runner() -> None:
             task = asyncio.current_task()
             try:
                 await asyncio.sleep(self.post_call_delay_seconds)
-                await self._run_post_call_command(caller_id, record_path)
+                await self._run_post_call_command(caller_id, deduped_record_paths)
             except asyncio.CancelledError:
                 raise
             finally:
                 # Only remove our own entry — a newer task may have replaced us
                 if self._pending_post_calls.get(caller_id) is task:
                     self._pending_post_calls.pop(caller_id)
+                    self._pending_archive_records.pop(caller_id, None)
 
         self._pending_post_calls[caller_id] = asyncio.create_task(_runner())
 
@@ -719,7 +746,9 @@ class VoiceServer:
         )
         self._save_recent_call(record)
         record_path = self._save_call_record(record)
-        await self._schedule_post_call(caller_id, record_path)
+        pending_record_paths = list(self._pending_archive_records.get(caller_id, []))
+        pending_record_paths.append(record_path)
+        await self._schedule_post_call(caller_id, pending_record_paths)
 
     def _get_local_caller_id(self, websocket) -> str:
         caller_id = websocket.query_params.get("caller_id")

--- a/packages/gptme-voice/src/gptme_voice/realtime/xai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/xai_client.py
@@ -58,13 +58,13 @@ class XAIRealtimeClient(OpenAIRealtimeClient):
 
         # VAD tuning for Grok interruption (from task #651 / Erik feedback)
         # Lower threshold = more sensitive to speech, easier to interrupt
-        # Reduce silence duration so Bob stops faster
+        # Keep end-of-turn silence conservative so noisy lines do not chop up speech
         # Prefix padding reduced to minimize lag
         if cfg.vad_threshold >= 0.65:  # only override default/high values
             cfg = dataclasses.replace(
                 cfg,
                 vad_threshold=0.55,
-                vad_silence_duration_ms=250,
+                vad_silence_duration_ms=500,
                 vad_prefix_padding_ms=150,
             )
 

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -289,21 +289,21 @@ def test_schedule_post_call_runs_configured_command_hook() -> None:
                 metadata={},
             )
             record_path = server._save_call_record(record)
-            observed: dict[str, str] = {}
+            observed: dict[str, object] = {}
 
-            async def _fake_run_post_call(caller_id: str, path: Path) -> None:
+            async def _fake_run_post_call(caller_id: str, paths: list[Path]) -> None:
                 observed["caller_id"] = caller_id
-                observed["path"] = str(path)
+                observed["paths"] = [str(path) for path in paths]
 
             server._run_post_call_command = _fake_run_post_call  # type: ignore[method-assign]
 
-            await server._schedule_post_call(record.caller_id, record_path)
+            await server._schedule_post_call(record.caller_id, [record_path])
             task = server._pending_post_calls[record.caller_id]
             await task
 
             assert observed == {
                 "caller_id": "+46700000001",
-                "path": str(record_path),
+                "paths": [str(record_path)],
             }
 
     asyncio.run(_exercise())
@@ -388,6 +388,56 @@ def test_consume_recent_call_keeps_archived_record() -> None:
         assert payload["transcript"][0]["text"] == "Archive me"
 
 
+def test_resume_carries_prior_archive_into_next_post_call() -> None:
+    async def _exercise() -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            server = VoiceServer()
+            server.state_dir = Path(tmpdir)
+            server.resume_window_seconds = 300
+            server.post_call_command = "run-post-call"
+            server.post_call_delay_seconds = 1_000
+
+            first = RecentCallRecord(
+                caller_id="+46700000010",
+                source="twilio",
+                ended_at=1_000.0,
+                transcript=[TranscriptTurn(role="user", text="first leg")],
+                metadata={"call_sid": "CAfirst"},
+            )
+            first_path = server._save_call_record(first)
+            server._save_recent_call(first)
+            await server._schedule_post_call(first.caller_id, [first_path])
+            first_task = server._pending_post_calls[first.caller_id]
+
+            with pytest.MonkeyPatch.context() as mp:
+                mp.setattr("gptme_voice.realtime.server.time.time", lambda: 1_100.0)
+                resumed = server._consume_recent_call(first.caller_id)
+            await asyncio.sleep(0)
+
+            assert resumed is not None
+            assert first_task.cancelled()
+            assert server._pending_archive_records[first.caller_id] == [first_path]
+
+            second = RecentCallRecord(
+                caller_id=first.caller_id,
+                source="twilio",
+                ended_at=1_200.0,
+                transcript=[TranscriptTurn(role="user", text="second leg")],
+                metadata={"call_sid": "CAsecond"},
+            )
+            second_path = server._save_call_record(second)
+            await server._schedule_post_call(first.caller_id, [first_path, second_path])
+
+            assert server._pending_archive_records[first.caller_id] == [
+                first_path,
+                second_path,
+            ]
+
+            server._pending_post_calls[first.caller_id].cancel()
+
+    asyncio.run(_exercise())
+
+
 def test_save_call_record_uses_unique_archive_path_per_call() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         server = VoiceServer()
@@ -444,11 +494,11 @@ def test_schedule_post_call_runner_finally_does_not_evict_newer_task() -> None:
             record_path = server._save_recent_call(record)
 
             # Schedule first task (long sleep — won't complete naturally)
-            await server._schedule_post_call(record.caller_id, record_path)
+            await server._schedule_post_call(record.caller_id, [record_path])
             first_task = server._pending_post_calls[record.caller_id]
 
             # Schedule second task — cancels first and registers itself
-            await server._schedule_post_call(record.caller_id, record_path)
+            await server._schedule_post_call(record.caller_id, [record_path])
             second_task = server._pending_post_calls[record.caller_id]
 
             # Wait for the first task's finally-block to run
@@ -493,7 +543,7 @@ def test_cancelled_post_call_command_terminates_subprocess() -> None:
             with pytest.MonkeyPatch.context() as mp:
                 mp.setenv("PID_FILE", str(pid_file))
                 task = asyncio.create_task(
-                    server._run_post_call_command("+46700000004", record_path)
+                    server._run_post_call_command("+46700000004", [record_path])
                 )
 
                 deadline = asyncio.get_running_loop().time() + 5

--- a/packages/gptme-voice/tests/test_xai_client.py
+++ b/packages/gptme-voice/tests/test_xai_client.py
@@ -29,6 +29,9 @@ def test_xai_client_uses_xai_defaults() -> None:
     client = XAIRealtimeClient(api_key="test-key", session_config=SessionConfig())
 
     assert client.session_config.voice == "rex"  # male voice for Bob persona
+    assert client.session_config.vad_threshold == 0.55
+    assert client.session_config.vad_silence_duration_ms == 500
+    assert client.session_config.vad_prefix_padding_ms == 150
     assert client._get_ws_url() == "wss://api.x.ai/v1/realtime"
 
 


### PR DESCRIPTION
## Summary
- carry pending archive records across quick call resumes instead of dropping the cancelled post-call task's record
- pass every archive path to the post-call command so one follow-up can link all legs of a resumed conversation
- raise xAI/Grok VAD silence duration back to 500ms while keeping lower threshold/prefix tuning for interruption responsiveness

## Tests
- uv run --project /home/bob/bob/gptme-contrib/packages/gptme-voice pytest /home/bob/bob/gptme-contrib/packages/gptme-voice/tests -q
- uv run --project /home/bob/bob/gptme-contrib/packages/gptme-voice ruff check /home/bob/bob/gptme-contrib/packages/gptme-voice/src/gptme_voice/realtime/server.py /home/bob/bob/gptme-contrib/packages/gptme-voice/src/gptme_voice/realtime/xai_client.py /home/bob/bob/gptme-contrib/packages/gptme-voice/tests/test_server.py /home/bob/bob/gptme-contrib/packages/gptme-voice/tests/test_xai_client.py
- uv run --project /home/bob/bob/gptme-contrib/packages/gptme-voice ruff format --check /home/bob/bob/gptme-contrib/packages/gptme-voice/src/gptme_voice/realtime/server.py /home/bob/bob/gptme-contrib/packages/gptme-voice/src/gptme_voice/realtime/xai_client.py /home/bob/bob/gptme-contrib/packages/gptme-voice/tests/test_server.py /home/bob/bob/gptme-contrib/packages/gptme-voice/tests/test_xai_client.py