### PR TITLE
fix(gptme-sessions): skip sentinel model values in extract_cc_model

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/discovery.py
+++ b/packages/gptme-sessions/src/gptme_sessions/discovery.py
@@ -21,6 +21,11 @@ DEFAULT_CC_PROJECTS_DIR = Path.home() / ".claude" / "projects"
 DEFAULT_CODEX_SESSIONS_DIR = Path.home() / ".codex" / "sessions"
 DEFAULT_COPILOT_STATE_DIR = Path.home() / ".copilot" / "session-state"
 
+# CC emits these as the assistant `model` field when no real model ran
+# (e.g. authentication failure 401 → message with model="<synthetic>"),
+# so they must not be returned as the session's model.
+_SENTINEL_MODELS = frozenset({"<synthetic>", "unknown"})
+
 
 def _get_gptme_logs_dir() -> Path:
     """Get gptme logs directory from env or default."""
@@ -158,7 +163,7 @@ def extract_cc_model(jsonl_path: Path) -> str | None:
                 msg = entry.get("message", {})
                 if isinstance(msg, dict) and msg.get("role") == "assistant":
                     model = msg.get("model")
-                    if model:
+                    if model and model not in _SENTINEL_MODELS:
                         return str(model)
     except (OSError, UnicodeDecodeError) as e:
         logger.debug("Failed to read %s for model extraction: %s", jsonl_path, e)
@@ -188,7 +193,7 @@ def _model_from_cc_stream_log(log_path: Path) -> str | None:
                 if not isinstance(obj, dict):
                     return None
                 model = obj.get("model")
-                if isinstance(model, str) and model:
+                if isinstance(model, str) and model and model not in _SENTINEL_MODELS:
                     return model
                 return None
     except (OSError, UnicodeDecodeError) as e:

--- a/packages/gptme-sessions/tests/test_discovery.py
+++ b/packages/gptme-sessions/tests/test_discovery.py
@@ -212,6 +212,43 @@ def test_extract_cc_model_non_dict_lines(tmp_path: Path) -> None:
     assert extract_cc_model(jsonl_file) == "claude-opus-4-6"
 
 
+def test_extract_cc_model_skips_synthetic_sentinel(tmp_path: Path) -> None:
+    """extract_cc_model treats `<synthetic>` (CC's auth-failure sentinel) as no model
+    and continues scanning for a real assistant model.
+    """
+    jsonl_file = tmp_path / "session.jsonl"
+    lines = [
+        # First assistant message is the synthetic 401 reply
+        json.dumps({"message": {"role": "assistant", "model": "<synthetic>", "content": []}}),
+        # Real model on the next assistant message
+        json.dumps({"message": {"role": "assistant", "model": "claude-opus-4-7", "content": []}}),
+    ]
+    jsonl_file.write_text("\n".join(lines) + "\n")
+    assert extract_cc_model(jsonl_file) == "claude-opus-4-7"
+
+
+def test_extract_cc_model_synthetic_only_returns_none(tmp_path: Path) -> None:
+    """All-synthetic trajectory (auth failed before any real call) returns None."""
+    jsonl_file = tmp_path / "session.jsonl"
+    lines = [
+        json.dumps({"message": {"role": "user", "content": "hi"}}),
+        json.dumps({"message": {"role": "assistant", "model": "<synthetic>", "content": []}}),
+    ]
+    jsonl_file.write_text("\n".join(lines) + "\n")
+    assert extract_cc_model(jsonl_file) is None
+
+
+def test_extract_cc_model_skips_unknown_sentinel(tmp_path: Path) -> None:
+    """`unknown` is also a sentinel — skip it like `<synthetic>`."""
+    jsonl_file = tmp_path / "session.jsonl"
+    lines = [
+        json.dumps({"message": {"role": "assistant", "model": "unknown", "content": []}}),
+        json.dumps({"message": {"role": "assistant", "model": "claude-sonnet-4-6", "content": []}}),
+    ]
+    jsonl_file.write_text("\n".join(lines) + "\n")
+    assert extract_cc_model(jsonl_file) == "claude-sonnet-4-6"
+
+
 # --- resolve_cc_session_model ---
 
 
@@ -229,6 +266,22 @@ def _write_stream_log(
     (tmp_dir / f"cc-session-log-ref-{session_id}.txt").write_text(
         str(log_path) + "\n", encoding="utf-8"
     )
+
+
+def test_resolve_cc_session_model_stream_log_synthetic_returns_none(tmp_path: Path) -> None:
+    """Stream log whose init line is `<synthetic>` (auth failed before any real
+    call) returns None — never pollutes the bandit with a sentinel arm."""
+    sid = "synthetic-stream"
+    tmp_dir = tmp_path / "tmp"
+    tmp_dir.mkdir()
+    log_path = tmp_dir / "cc-session-syn.log"
+    _write_stream_log(
+        tmp_dir,
+        sid,
+        log_path,
+        {"type": "system", "subtype": "init", "session_id": sid, "model": "<synthetic>"},
+    )
+    assert resolve_cc_session_model(sid, tmp_dir=tmp_dir) is None
 
 
 def test_resolve_cc_session_model_from_stream_log(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- CC emits `<synthetic>` as the `model` field when authentication fails (401) before any real model runs
- Previously this string polluted bandit arms and harness-model tracking with a fake arm name
- Now `<synthetic>` and `unknown` are filtered out as sentinels; the scanner continues to the next real assistant message

This mirrors the fix already applied to `scripts/track-model-version.py` and `scripts/update-harness-bandit.py` in the parent repo (committed in 743bd5509).

## Test plan

- [x] `test_extract_cc_model_skips_synthetic_sentinel` — synthetic first, real model second → returns real model
- [x] `test_extract_cc_model_synthetic_only_returns_none` — all-synthetic trajectory → returns None
- [x] `test_extract_cc_model_skips_unknown_sentinel` — `unknown` sentinel also skipped
- [x] `test_resolve_cc_session_model_stream_log_synthetic_returns_none` — stream log with synthetic → returns None