### PR TITLE
feat(credential-slots): new package for safe OAuth slot rotation

### DIFF
--- a/packages/credential-slots/README.md
+++ b/packages/credential-slots/README.md
@@ -1,0 +1,118 @@
+# credential-slots
+
+Safe credential-slot rotation for gptme agents running Claude Max or other
+OAuth-backed subscriptions.
+
+A **slot** is a named credential file next to a live symlink, e.g.:
+
+```text
+~/.claude/.credentials.json             # symlink → one of the slots below
+~/.claude/.credentials.json.bob
+~/.claude/.credentials.json.alice
+~/.claude/.credentials.json.erik
+```
+
+This package handles the offline safety checks around flipping that symlink:
+
+- Reading a slot's stored `expiresAt`
+- Refusing to switch into an expired or unreadable slot
+- Detecting "drift" where the live file no longer matches any named slot
+  (typical after an operator runs `/login`)
+- Deferring automated switches while busy-signals are active
+
+Everything else — usage polling, switch logging, rebalance strategy — stays
+in the calling agent, with hooks (`on_switch`, `lock_guard`, `logger`) for
+injection.
+
+## Motivating incident — 2026-04-23
+
+Bob's live `~/.claude/.credentials.json` OAuth token became invalid
+server-side while still claiming a future `expiresAt`. Every autonomous
+Claude Code session hit 401. The per-backend crash counter tripped after
+three infra failures and opus was locked out for 1 h.
+
+When Erik refreshed the token via `claude /login`, the new credentials
+were written to the live file only — none of the named slots were
+updated. The next `manage-subscription.py --switch bob` would have
+silently put the stale token back.
+
+Bob's `manage-subscription.py` was hardened in commit `e9ea27097`
+(ErikBjare/bob) with three defensive checks. This package lifts those
+checks out of Bob's workspace so other agents inherit the same
+guarantees:
+
+1. **Target-slot expiry validation** in `switch_to` — refuses known-bad
+   tokens even under `force=True`.
+2. **`detect_live_slot_drift`** — warns when the live file hashes to
+   nothing the caller recognizes.
+3. **Lock-guard injection** — automated switches defer while the caller
+   reports active busy-signals; `force=True` overrides.
+
+## Install
+
+Dev-time (workspace mode, recommended for agents checking out
+gptme-contrib as a submodule):
+
+```bash
+uv pip install -e packages/credential-slots
+```
+
+## Usage
+
+```python
+from pathlib import Path
+from credential_slots import SlotManager
+
+mgr = SlotManager(
+    creds_dir=Path.home() / ".claude",
+    subscriptions=["bob", "alice", "erik"],
+    # Optional: defer automated switches while a busy-signal is present.
+    lock_guard=lambda: [p.stem for p in Path("/tmp").glob("agent-*.lock")],
+    # Optional: persist a switch log.
+    on_switch=lambda sub, reason: switch_log.write_text(
+        f"{datetime.utcnow()} switched to {sub} — {reason}\n"
+    ),
+    logger=print,  # defaults to silent
+)
+
+# Introspection
+mgr.get_active_subscription()       # "bob" | None
+mgr.get_available_subscriptions()   # ["bob", "alice"]
+
+# Safety checks
+ok, reason = mgr.slot_is_fresh("bob")
+drift = mgr.detect_live_slot_drift()
+if drift and drift["drift"]:
+    warn("live creds file matches no named slot — run /login then persist")
+
+# Switching
+result = mgr.switch_to("alice", reason="bob quota exhausted")
+if not result.ok:
+    print(f"could not switch: {result.reason}")
+    if result.deferred_locks:
+        print(f"deferred by: {result.deferred_locks}")
+```
+
+## Design
+
+- **Offline-only**: this package never makes network calls. Server-side
+  token invalidation (valid `expiresAt` but the API still returns 401)
+  must be detected by the agent's API response classifier.
+- **Dependency injection for paths**: nothing is hardcoded to
+  `~/.claude` or any single-agent layout. Tests instantiate the class
+  against `tmp_path`; agents pass whatever directory works for them.
+- **No workspace dependencies**: switch logs, rate-limit files,
+  usage-polling scripts, and rebalance state all stay in the caller.
+  This package provides the callbacks those callers plug into.
+
+## Tests
+
+```bash
+uv pip install -e packages/credential-slots
+uv run pytest packages/credential-slots/tests/ -v
+```
+
+## Status
+
+`v0.1.0` — ported from `manage-subscription.py` in ErikBjare/bob,
+commit `e9ea27097`. See `CHANGELOG` for future releases.

--- a/packages/credential-slots/pyproject.toml
+++ b/packages/credential-slots/pyproject.toml
@@ -1,0 +1,44 @@
+[project]
+name = "credential-slots"
+version = "0.1.0"
+description = "Safe credential-slot rotation for agents running Claude Max / OAuth-backed subscriptions"
+authors = [
+    {name = "gptme contributors", email = "gptme@superuserlabs.org"}
+]
+license = "MIT"
+readme = "README.md"
+requires-python = ">=3.10"
+keywords = ["credentials", "oauth", "claude", "gptme", "ai-agents", "subscription"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Security",
+    "Topic :: Utilities",
+]
+dependencies = []
+
+[project.urls]
+Homepage = "https://github.com/gptme/gptme-contrib"
+Repository = "https://github.com/gptme/gptme-contrib"
+Issues = "https://github.com/gptme/gptme-contrib/issues"
+
+[project.optional-dependencies]
+test = [
+    "pytest>=7.0",
+    "pytest-cov>=4.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/credential_slots"]
+
+[tool.mypy]
+strict = true

--- a/packages/credential-slots/src/credential_slots/__init__.py
+++ b/packages/credential-slots/src/credential_slots/__init__.py
@@ -23,7 +23,7 @@ Public API::
     mgr.get_active_subscription()       # -> "bob" | None
     mgr.slot_is_fresh("bob")            # -> (True, "valid until ...")
     mgr.detect_live_slot_drift()        # -> dict | None
-    mgr.switch_to("alice", "rebalance") # -> bool
+    mgr.switch_to("alice", "rebalance") # -> SwitchResult (result.ok, result.reason, result.deferred_locks)
 """
 
 from __future__ import annotations

--- a/packages/credential-slots/src/credential_slots/__init__.py
+++ b/packages/credential-slots/src/credential_slots/__init__.py
@@ -1,0 +1,53 @@
+"""Safe credential-slot rotation for agents running OAuth-backed subscriptions.
+
+This package extracts the reusable pieces of Bob's ``manage-subscription.py``
+so that other agents (alice, gordon, sven, ...) can inherit the same safety
+guarantees without forking the logic.
+
+Motivating incident (2026-04-23): Bob's live
+``~/.claude/.credentials.json`` OAuth token became invalid server-side while
+still claiming a future ``expiresAt``. Every autonomous session hit 401.
+After three infra failures the crash-loop cooldown engaged and opus was
+blocked for 1h. When an operator refreshed the token via ``/login`` it was
+written to the live file only — a future ``--switch bob`` could silently
+restore the stale credentials. See ``README.md`` for the full post-mortem.
+
+Public API::
+
+    from credential_slots import SlotManager
+
+    mgr = SlotManager(
+        creds_dir=Path.home() / ".claude",
+        subscriptions=["bob", "alice"],
+    )
+    mgr.get_active_subscription()       # -> "bob" | None
+    mgr.slot_is_fresh("bob")            # -> (True, "valid until ...")
+    mgr.detect_live_slot_drift()        # -> dict | None
+    mgr.switch_to("alice", "rebalance") # -> bool
+"""
+
+from __future__ import annotations
+
+from credential_slots.manager import (
+    DEFAULT_GRACE_SECONDS,
+    DEFAULT_LIVE_NAME,
+    DEFAULT_SLOT_TEMPLATE,
+    DriftInfo,
+    SlotManager,
+    SwitchResult,
+    read_slot_expiry,
+    slot_is_fresh,
+)
+
+__all__ = [
+    "DEFAULT_GRACE_SECONDS",
+    "DEFAULT_LIVE_NAME",
+    "DEFAULT_SLOT_TEMPLATE",
+    "DriftInfo",
+    "SlotManager",
+    "SwitchResult",
+    "read_slot_expiry",
+    "slot_is_fresh",
+]
+
+__version__ = "0.1.0"

--- a/packages/credential-slots/src/credential_slots/manager.py
+++ b/packages/credential-slots/src/credential_slots/manager.py
@@ -1,0 +1,361 @@
+"""Credential slot manager: offline safety checks for OAuth-backed slots.
+
+A "slot" is a named credential file next to the live one, e.g.:
+
+    ~/.claude/.credentials.json             # symlink → one of the slots below
+    ~/.claude/.credentials.json.bob         # slot "bob"
+    ~/.claude/.credentials.json.alice       # slot "alice"
+
+All checks here are **offline** — they inspect the file's stored
+``expiresAt`` and hash contents. Server-side token invalidation (valid
+``expiresAt`` but API returns 401) is out of scope; the agent's autonomous
+runner is expected to detect that via response classification.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Callable, TypedDict
+
+DEFAULT_LIVE_NAME = ".credentials.json"
+DEFAULT_SLOT_TEMPLATE = ".credentials.json.{sub}"
+DEFAULT_GRACE_SECONDS = 300
+
+
+class DriftInfo(TypedDict):
+    """Result of :meth:`SlotManager.detect_live_slot_drift`.
+
+    ``drift`` is True when the live file matches no known slot — typically
+    after an operator ran ``/login`` (which rewrites the live file but
+    leaves the named slots untouched). In that state, an automated
+    ``switch_to(matching_slot)`` would silently restore a stale token.
+    """
+
+    drift: bool
+    matching_slot: str | None
+    live_hash: str | None
+    slot_hashes: dict[str, str]
+
+
+@dataclass
+class SwitchResult:
+    """Outcome of a :meth:`SlotManager.switch_to` call.
+
+    ``ok`` is True when the symlink was updated. Otherwise ``reason`` gives
+    a short human-readable explanation ("deferred: autonomous sessions
+    active", "refusing: slot expired 7m ago", "slot missing: …"). Callers
+    choose whether to surface ``reason`` via print/log/telemetry.
+    """
+
+    ok: bool
+    reason: str
+    deferred_locks: list[str] = field(default_factory=list)
+
+
+def _parse_oauth_expiry(payload: object) -> datetime | None:
+    """Return the UTC ``expiresAt`` of a claudeAiOauth payload, or None.
+
+    The credential file format is::
+
+        {"claudeAiOauth": {"accessToken": ..., "expiresAt": <ms>, ...}}
+
+    ``expiresAt`` is a Unix epoch in milliseconds. Returns None for
+    missing/malformed payloads so callers can treat "unknown" distinctly
+    from "expired".
+    """
+    if not isinstance(payload, dict):
+        return None
+    oauth = payload.get("claudeAiOauth")
+    if not isinstance(oauth, dict):
+        return None
+    expires_ms = oauth.get("expiresAt")
+    if not isinstance(expires_ms, int | float):
+        return None
+    try:
+        return datetime.fromtimestamp(float(expires_ms) / 1000, tz=timezone.utc)
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+def read_slot_expiry(path: Path) -> datetime | None:
+    """Read ``expiresAt`` from an OAuth credential file.
+
+    Returns None for missing files, unreadable files, malformed JSON, or
+    payloads without a parseable ``claudeAiOauth.expiresAt`` field.
+    """
+    try:
+        raw = path.read_text()
+    except OSError:
+        return None
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    return _parse_oauth_expiry(payload)
+
+
+def slot_is_fresh(
+    path: Path,
+    *,
+    grace_seconds: int = DEFAULT_GRACE_SECONDS,
+    now: datetime | None = None,
+) -> tuple[bool, str]:
+    """Check whether a slot's stored OAuth token is safe to switch into.
+
+    Offline, cheap, no network: only validates ``expiresAt``. Catches the
+    common case where a slot's token lapsed since it was last persisted.
+    Does NOT catch server-side token invalidation with a still-future
+    ``expiresAt`` — detect that in the agent's API response classifier.
+
+    Returns ``(is_fresh, reason)``.
+    """
+    if not path.exists():
+        return False, f"slot missing: {path.name}"
+    expiry = read_slot_expiry(path)
+    if expiry is None:
+        return False, f"unreadable or no expiresAt in {path.name}"
+    current = now or datetime.now(timezone.utc)
+    if expiry <= current + timedelta(seconds=grace_seconds):
+        age = int((current - expiry).total_seconds())
+        if age >= 0:
+            return False, f"expired {age // 60}m ago (at {expiry.isoformat()})"
+        return False, f"expires within grace ({-age}s left, at {expiry.isoformat()})"
+    return True, f"valid until {expiry.isoformat()}"
+
+
+def _hash_file(path: Path) -> str | None:
+    """Return sha256 of a file's contents, or None if unreadable."""
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        return None
+
+
+@dataclass
+class SlotManager:
+    """Manages a family of named OAuth credential slots sharing one live file.
+
+    Workspace-specific behavior (switch logging, rate-limit files,
+    usage-based strategy, rebalance state, …) stays in the caller. This
+    class only cares about:
+
+    - Where the slots live (``creds_dir``, ``slot_template``, ``live_name``)
+    - Which slot is currently active (symlink target)
+    - Whether a target slot is safe to switch into (``expiresAt``)
+    - Whether the live file drifted away from every named slot
+    - Actually flipping the symlink, with optional defer-if-busy guard
+
+    Parameters
+    ----------
+    creds_dir:
+        Directory holding the live file + named slots.
+    subscriptions:
+        Names of the slots to consider (e.g. ``["bob", "alice", "erik"]``).
+    slot_template:
+        ``str.format``-style template with one ``{sub}`` placeholder,
+        joined to ``creds_dir``. Defaults to ``.credentials.json.{sub}``.
+    live_name:
+        Filename of the live symlink inside ``creds_dir``. Defaults to
+        ``.credentials.json``.
+    grace_seconds:
+        Reject slots whose expiry is within this many seconds of ``now``.
+    lock_guard:
+        Optional zero-arg callable returning the names of holds that
+        should defer automated switches. When non-empty and ``force`` is
+        False, :meth:`switch_to` returns ``SwitchResult(ok=False,
+        reason="deferred: ...", deferred_locks=...)`` without touching
+        the symlink. Workspaces can point this at lock files, running
+        sessions, or any custom busy-signal.
+    on_switch:
+        Optional ``(sub, reason) -> None`` callback invoked on successful
+        symlink flips. Use it to persist a switch log without baking log
+        paths into this package.
+    logger:
+        Optional ``(msg) -> None`` callback. Defaults to dropping the
+        message silently so importers don't get unexpected stderr noise.
+    """
+
+    creds_dir: Path
+    subscriptions: list[str]
+    slot_template: str = DEFAULT_SLOT_TEMPLATE
+    live_name: str = DEFAULT_LIVE_NAME
+    grace_seconds: int = DEFAULT_GRACE_SECONDS
+    lock_guard: Callable[[], list[str]] | None = None
+    on_switch: Callable[[str, str], None] | None = None
+    logger: Callable[[str], None] | None = None
+
+    def __post_init__(self) -> None:
+        if "{sub}" not in self.slot_template:
+            raise ValueError(
+                f"slot_template must contain '{{sub}}', got: {self.slot_template!r}"
+            )
+        if not self.subscriptions:
+            raise ValueError("subscriptions must be a non-empty list")
+
+    # ---- Path helpers ----
+
+    def slot_path(self, sub: str) -> Path:
+        """Absolute path to the named slot file."""
+        return self.creds_dir / self.slot_template.format(sub=sub)
+
+    @property
+    def live_path(self) -> Path:
+        """Absolute path to the live credential file/symlink."""
+        return self.creds_dir / self.live_name
+
+    # ---- Introspection ----
+
+    def get_active_subscription(self) -> str | None:
+        """Return the slot name the live symlink points at, or None.
+
+        Resolves the symlink and checks the target filename against the
+        configured slot_template. Returns None when the live file is a
+        regular file (i.e. drift — see :meth:`detect_live_slot_drift`) or
+        doesn't match any known slot.
+        """
+        live = self.live_path
+        if not live.is_symlink():
+            return None
+        target_name = live.resolve().name
+        for sub in self.subscriptions:
+            if target_name == self.slot_template.format(sub=sub):
+                return sub
+        return None
+
+    def get_available_subscriptions(self) -> list[str]:
+        """Return subscriptions whose slot file exists on disk.
+
+        Does NOT check freshness — use :meth:`slot_is_fresh` for that.
+        """
+        return [sub for sub in self.subscriptions if self.slot_path(sub).exists()]
+
+    # ---- Freshness ----
+
+    def read_slot_expiry(self, sub: str) -> datetime | None:
+        """Return ``expiresAt`` of a named slot, or None if unreadable."""
+        return read_slot_expiry(self.slot_path(sub))
+
+    def slot_is_fresh(
+        self,
+        sub: str,
+        *,
+        grace_seconds: int | None = None,
+        now: datetime | None = None,
+    ) -> tuple[bool, str]:
+        """Offline freshness check for a named slot.
+
+        See module-level :func:`slot_is_fresh` for semantics. Uses
+        ``self.grace_seconds`` by default.
+        """
+        return slot_is_fresh(
+            self.slot_path(sub),
+            grace_seconds=grace_seconds
+            if grace_seconds is not None
+            else self.grace_seconds,
+            now=now,
+        )
+
+    # ---- Drift detection ----
+
+    def detect_live_slot_drift(self) -> DriftInfo | None:
+        """Check whether the live file matches any known slot.
+
+        Returns None when the live file doesn't exist (nothing to
+        compare). Otherwise returns a :class:`DriftInfo` with
+        ``drift=True`` when no slot hashes match, indicating that the live
+        file was written by something other than :meth:`switch_to` — most
+        commonly an operator running ``/login``.
+        """
+        live = self.live_path
+        if not live.exists():
+            return None
+        live_hash = _hash_file(live)
+        if live_hash is None:
+            return None
+        slot_hashes: dict[str, str] = {}
+        matching: str | None = None
+        for sub in self.subscriptions:
+            slot = self.slot_path(sub)
+            if not slot.exists():
+                continue
+            h = _hash_file(slot)
+            if h is None:
+                continue
+            slot_hashes[sub] = h
+            if h == live_hash and matching is None:
+                matching = sub
+        return DriftInfo(
+            drift=matching is None,
+            matching_slot=matching,
+            live_hash=live_hash,
+            slot_hashes=slot_hashes,
+        )
+
+    # ---- Switching ----
+
+    def switch_to(
+        self,
+        sub: str,
+        reason: str,
+        *,
+        force: bool = False,
+    ) -> SwitchResult:
+        """Flip the live symlink to point at ``sub``'s slot file.
+
+        Safety guarantees:
+
+        - If ``force=False`` and ``lock_guard`` returns a non-empty list,
+          the switch is deferred and the symlink is not touched.
+        - If the target slot is expired or unreadable, the switch is
+          refused **regardless of** ``force`` — landing on a known-bad
+          credential just moves the 401 crash loop to the next run.
+        - On success, replaces the existing symlink atomically
+          (``unlink`` then ``symlink_to``) and calls ``on_switch``.
+
+        Returns a :class:`SwitchResult`. Callers decide whether to surface
+        ``reason`` via print / logging / telemetry.
+        """
+        if not force and self.lock_guard is not None:
+            active_locks = list(self.lock_guard())
+            if active_locks:
+                lock_desc = ", ".join(active_locks)
+                msg = (
+                    f"deferred: active lock(s) {lock_desc}; "
+                    f"would switch to {sub} ({reason})"
+                )
+                self._log(msg)
+                return SwitchResult(
+                    ok=False,
+                    reason=msg,
+                    deferred_locks=active_locks,
+                )
+
+        slot = self.slot_path(sub)
+        if not slot.exists():
+            msg = f"slot missing: {slot}"
+            self._log(msg)
+            return SwitchResult(ok=False, reason=msg)
+
+        fresh, fresh_reason = self.slot_is_fresh(sub)
+        if not fresh:
+            msg = f"refusing to switch to {sub}: {fresh_reason}"
+            self._log(msg)
+            return SwitchResult(ok=False, reason=msg)
+
+        live = self.live_path
+        live.unlink(missing_ok=True)
+        live.symlink_to(self.slot_template.format(sub=sub))
+
+        if self.on_switch is not None:
+            self.on_switch(sub, reason)
+        return SwitchResult(ok=True, reason=f"switched to {sub}")
+
+    # ---- Internals ----
+
+    def _log(self, msg: str) -> None:
+        if self.logger is not None:
+            self.logger(msg)

--- a/packages/credential-slots/src/credential_slots/manager.py
+++ b/packages/credential-slots/src/credential_slots/manager.py
@@ -349,6 +349,11 @@ class SlotManager:
         Returns a :class:`SwitchResult`. Callers decide whether to surface
         ``reason`` via print / logging / telemetry.
         """
+        if sub not in self.subscriptions:
+            msg = f"unknown subscription: {sub!r} (known: {self.subscriptions})"
+            self._log(msg)
+            return SwitchResult(ok=False, reason=msg)
+
         if not force and self.lock_guard is not None:
             active_locks = list(self.lock_guard())
             if active_locks:

--- a/packages/credential-slots/src/credential_slots/manager.py
+++ b/packages/credential-slots/src/credential_slots/manager.py
@@ -213,18 +213,26 @@ class SlotManager:
     def get_active_subscription(self) -> str | None:
         """Return the slot name the live symlink points at, or None.
 
-        Resolves the symlink and checks the target filename against the
-        configured slot_template. Returns None when the live file is a
-        regular file (i.e. drift — see :meth:`detect_live_slot_drift`) or
-        doesn't match any known slot.
+        Resolves the symlink and compares against each slot's resolved
+        path. Returns None when the live file is a regular file (i.e.
+        drift — see :meth:`detect_live_slot_drift`), the symlink is
+        broken, or it doesn't match any known slot.
         """
         live = self.live_path
         if not live.is_symlink():
             return None
-        target_name = live.resolve().name
+        try:
+            target = live.resolve(strict=True)
+        except (FileNotFoundError, OSError):
+            # Broken symlink — cannot resolve target
+            return None
         for sub in self.subscriptions:
-            if target_name == self.slot_template.format(sub=sub):
-                return sub
+            slot = self.slot_path(sub)
+            try:
+                if target == slot.resolve(strict=True):
+                    return sub
+            except (FileNotFoundError, OSError):
+                continue
         return None
 
     def get_available_subscriptions(self) -> list[str]:
@@ -265,20 +273,26 @@ class SlotManager:
     def detect_live_slot_drift(self) -> DriftInfo | None:
         """Check whether the live file matches any known slot.
 
-        Returns None when the live file doesn't exist (nothing to
-        compare). Otherwise returns a :class:`DriftInfo` with
-        ``drift=True`` when no slot hashes match, indicating that the live
-        file was written by something other than :meth:`switch_to` — most
-        commonly an operator running ``/login``.
+        Returns None when the live path doesn't exist at all (no file, no
+        symlink — nothing to compare). A broken live symlink (symlink
+        present, target missing) is reported as drift with
+        ``live_hash=None`` so callers can distinguish "no live file" from
+        "live symlink points at a deleted target" — the latter needs
+        repair, the former is a pristine state.
+
+        Otherwise returns a :class:`DriftInfo` with ``drift=True`` when no
+        slot hashes match, indicating that the live file was written by
+        something other than :meth:`switch_to` — most commonly an operator
+        running ``/login``.
         """
         live = self.live_path
+        broken_symlink = False
         if not live.exists():
-            return None
-        live_hash = _hash_file(live)
-        if live_hash is None:
-            return None
+            if live.is_symlink():
+                broken_symlink = True  # target missing — report as drift
+            else:
+                return None
         slot_hashes: dict[str, str] = {}
-        matching: str | None = None
         for sub in self.subscriptions:
             slot = self.slot_path(sub)
             if not slot.exists():
@@ -287,8 +301,21 @@ class SlotManager:
             if h is None:
                 continue
             slot_hashes[sub] = h
+        if broken_symlink:
+            return DriftInfo(
+                drift=True,
+                matching_slot=None,
+                live_hash=None,
+                slot_hashes=slot_hashes,
+            )
+        live_hash = _hash_file(live)
+        if live_hash is None:
+            return None
+        matching: str | None = None
+        for sub, h in slot_hashes.items():
             if h == live_hash and matching is None:
                 matching = sub
+                break
         return DriftInfo(
             drift=matching is None,
             matching_slot=matching,

--- a/packages/credential-slots/src/credential_slots/manager.py
+++ b/packages/credential-slots/src/credential_slots/manager.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -313,8 +314,10 @@ class SlotManager:
         - If the target slot is expired or unreadable, the switch is
           refused **regardless of** ``force`` — landing on a known-bad
           credential just moves the 401 crash loop to the next run.
-        - On success, replaces the existing symlink atomically
-          (``unlink`` then ``symlink_to``) and calls ``on_switch``.
+        - On success, replaces the existing symlink atomically via a
+          temp-symlink + ``os.replace`` (single rename syscall) so no
+          concurrent reader sees a missing ``live_path``, then calls
+          ``on_switch``.
 
         Returns a :class:`SwitchResult`. Callers decide whether to surface
         ``reason`` via print / logging / telemetry.
@@ -347,8 +350,13 @@ class SlotManager:
             return SwitchResult(ok=False, reason=msg)
 
         live = self.live_path
-        live.unlink(missing_ok=True)
-        live.symlink_to(self.slot_template.format(sub=sub))
+        tmp = self.creds_dir / (self.live_name + f".tmp{os.getpid()}")
+        try:
+            tmp.symlink_to(self.slot_template.format(sub=sub))
+            os.replace(tmp, live)  # atomic rename — no window where live_path is absent
+        except BaseException:
+            tmp.unlink(missing_ok=True)
+            raise
 
         if self.on_switch is not None:
             self.on_switch(sub, reason)

--- a/packages/credential-slots/tests/test_manager.py
+++ b/packages/credential-slots/tests/test_manager.py
@@ -185,6 +185,26 @@ class TestGetActiveSubscription:
         mgr.live_path.write_text("{}")
         assert mgr.get_active_subscription() is None
 
+    def test_path_separator_template_resolves(self, tmp_path: Path) -> None:
+        """Slot template containing a path separator resolves to the right sub.
+
+        Regression: a name-only comparison (``live.resolve().name`` against
+        ``slot_template.format(...)``) silently returned None when the
+        template included any directory component, because the template
+        output contained the separator while the resolved target name did
+        not. The fix compares resolved paths, not string names.
+        """
+        creds_dir = tmp_path / "creds"
+        (creds_dir / "slots").mkdir(parents=True)
+        m = SlotManager(
+            creds_dir=creds_dir,
+            subscriptions=["bob", "alice"],
+            slot_template="slots/{sub}.json",
+        )
+        _write_slot(m.slot_path("bob"), _ms_from_now(3600))
+        m.live_path.symlink_to("slots/bob.json")
+        assert m.get_active_subscription() == "bob"
+
 
 class TestGetAvailableSubscriptions:
     def test_empty_when_none_exist(self, mgr: SlotManager) -> None:
@@ -249,6 +269,31 @@ class TestDetectLiveSlotDrift:
         assert drift is not None
         expected_keys: set[str] = set(DriftInfo.__annotations__.keys())
         assert expected_keys.issubset(drift.keys())
+
+    def test_broken_symlink_reported_as_drift(self, mgr: SlotManager) -> None:
+        """Broken live symlink must not collapse into the 'no live file' branch.
+
+        Regression: ``Path.exists()`` returns False for broken symlinks, so
+        the prior ``if not live.exists(): return None`` silently masked a
+        broken symlink as "nothing to compare", which is indistinguishable
+        from "no live file at all". The fix: when the live path is a
+        broken symlink, report it as drift with ``live_hash=None`` so
+        callers can detect and repair the broken state.
+        """
+        # Create a broken symlink: target doesn't exist
+        mgr.live_path.symlink_to(".credentials.json.bob")
+        assert mgr.live_path.is_symlink()
+        assert not mgr.live_path.exists()  # broken — target missing
+
+        # Seed a slot so slot_hashes are populated
+        _write_slot(mgr.slot_path("alice"), _ms_from_now(3600))
+
+        drift = mgr.detect_live_slot_drift()
+        assert drift is not None, "broken symlink should not return None"
+        assert drift["drift"] is True
+        assert drift["matching_slot"] is None
+        assert drift["live_hash"] is None  # unreadable
+        assert "alice" in drift["slot_hashes"]
 
 
 class TestSwitchTo:

--- a/packages/credential-slots/tests/test_manager.py
+++ b/packages/credential-slots/tests/test_manager.py
@@ -394,6 +394,23 @@ class TestSwitchTo:
         mgr.switch_to("alice", "revert")
         assert mgr.get_active_subscription() == "alice"
 
+    def test_unknown_subscription_rejected(self, mgr: SlotManager) -> None:
+        """switch_to must refuse subs not in self.subscriptions.
+
+        Without this guard, a successful switch to an off-list name leaves
+        get_active_subscription() returning None — violating the invariant
+        that a successful switch is observable via the inverse call.
+        """
+        self._seed(mgr, bob_ms=_ms_from_now(3600), alice_ms=_ms_from_now(3600))
+        # Seed a slot file for an unregistered sub so the freshness check
+        # would otherwise pass — this isolates the guard as the rejection reason.
+        _write_slot(mgr.slot_path("gordon"), _ms_from_now(3600))
+        result = mgr.switch_to("gordon", "rebalance")
+        assert result.ok is False
+        assert "unknown" in result.reason.lower()
+        # Live symlink unchanged — still points at the initial alice slot.
+        assert mgr.get_active_subscription() == "alice"
+
 
 class TestSwitchResult:
     """Shape of :class:`SwitchResult`."""

--- a/packages/credential-slots/tests/test_manager.py
+++ b/packages/credential-slots/tests/test_manager.py
@@ -1,0 +1,363 @@
+"""Tests for credential_slots.manager.
+
+Ported from Bob's ``tests/test_manage_subscription.py`` (ErikBjare/bob,
+commit e9ea27097) with paths dependency-injected via the :class:`SlotManager`
+constructor instead of monkeypatching module globals.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from credential_slots import (
+    DriftInfo,
+    SlotManager,
+    SwitchResult,
+    read_slot_expiry,
+    slot_is_fresh,
+)
+
+
+def _ms_from_now(offset_seconds: float) -> int:
+    """Return a Unix epoch in milliseconds ``offset_seconds`` from now."""
+    return int((datetime.now(timezone.utc).timestamp() + offset_seconds) * 1000)
+
+
+def _write_slot(path: Path, expires_at_ms: int | None) -> None:
+    """Write a claudeAiOauth credential file with given ``expiresAt``.
+
+    ``expires_at_ms=None`` produces a payload with no ``expiresAt`` key,
+    exercising the unknown-expiry path.
+    """
+    oauth: dict[str, object] = {"accessToken": "fake-token"}
+    if expires_at_ms is not None:
+        oauth["expiresAt"] = expires_at_ms
+    path.write_text(json.dumps({"claudeAiOauth": oauth}))
+
+
+@pytest.fixture
+def mgr(tmp_path: Path) -> SlotManager:
+    """A SlotManager pointed at an isolated tmp creds_dir."""
+    creds_dir = tmp_path / "creds"
+    creds_dir.mkdir()
+    return SlotManager(creds_dir=creds_dir, subscriptions=["bob", "alice", "erik"])
+
+
+class TestConstructor:
+    def test_requires_sub_placeholder_in_template(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="\\{sub\\}"):
+            SlotManager(
+                creds_dir=tmp_path,
+                subscriptions=["bob"],
+                slot_template=".bad_template_no_placeholder",
+            )
+
+    def test_requires_non_empty_subscriptions(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            SlotManager(creds_dir=tmp_path, subscriptions=[])
+
+    def test_custom_live_name_and_template(self, tmp_path: Path) -> None:
+        creds_dir = tmp_path / "custom"
+        creds_dir.mkdir()
+        m = SlotManager(
+            creds_dir=creds_dir,
+            subscriptions=["a", "b"],
+            slot_template="creds-{sub}.json",
+            live_name="active.json",
+        )
+        assert m.slot_path("a") == creds_dir / "creds-a.json"
+        assert m.live_path == creds_dir / "active.json"
+
+
+class TestReadSlotExpiry:
+    """Reading ``expiresAt`` from a named credential slot."""
+
+    def test_missing_slot_returns_none(self, mgr: SlotManager) -> None:
+        assert mgr.read_slot_expiry("bob") is None
+
+    def test_valid_expiry_parses(self, mgr: SlotManager) -> None:
+        future_ms = _ms_from_now(3600)
+        _write_slot(mgr.slot_path("bob"), future_ms)
+        result = mgr.read_slot_expiry("bob")
+        assert result is not None
+        # Within 1 second of the written value
+        assert abs(result.timestamp() * 1000 - future_ms) < 1000
+
+    def test_missing_expiry_key_returns_none(self, mgr: SlotManager) -> None:
+        """Slot file exists but has no expiresAt — treat as unknown."""
+        _write_slot(mgr.slot_path("bob"), expires_at_ms=None)
+        assert mgr.read_slot_expiry("bob") is None
+
+    def test_malformed_json_returns_none(self, mgr: SlotManager) -> None:
+        mgr.slot_path("bob").write_text("{not json")
+        assert mgr.read_slot_expiry("bob") is None
+
+    def test_non_dict_payload_returns_none(self, mgr: SlotManager) -> None:
+        """JSON parses but root is a list — refuse rather than crash."""
+        mgr.slot_path("bob").write_text('["ok"]')
+        assert mgr.read_slot_expiry("bob") is None
+
+    def test_module_function_accepts_plain_path(self, tmp_path: Path) -> None:
+        """The module-level helper works without a SlotManager."""
+        p = tmp_path / "creds.json"
+        _write_slot(p, _ms_from_now(60))
+        assert read_slot_expiry(p) is not None
+
+
+class TestSlotIsFresh:
+    """Whether a named slot is safe to switch to."""
+
+    def test_future_expiry_is_fresh(self, mgr: SlotManager) -> None:
+        _write_slot(mgr.slot_path("bob"), _ms_from_now(3600))
+        ok, reason = mgr.slot_is_fresh("bob")
+        assert ok is True
+        assert "valid" in reason.lower()
+
+    def test_past_expiry_not_fresh(self, mgr: SlotManager) -> None:
+        _write_slot(mgr.slot_path("bob"), _ms_from_now(-3600))
+        ok, reason = mgr.slot_is_fresh("bob")
+        assert ok is False
+        assert "expired" in reason.lower()
+
+    def test_near_expiry_within_grace_not_fresh(self, mgr: SlotManager) -> None:
+        """Token within the 5-min grace window is rejected."""
+        _write_slot(mgr.slot_path("bob"), _ms_from_now(60))
+        ok, reason = mgr.slot_is_fresh("bob", grace_seconds=300)
+        assert ok is False
+        assert "expir" in reason.lower()
+
+    def test_grace_can_be_overridden_per_call(self, mgr: SlotManager) -> None:
+        """Per-call grace_seconds beats the manager default."""
+        _write_slot(mgr.slot_path("bob"), _ms_from_now(60))
+        # Default (300) rejects; a 10s grace accepts.
+        assert mgr.slot_is_fresh("bob")[0] is False
+        assert mgr.slot_is_fresh("bob", grace_seconds=10)[0] is True
+
+    def test_missing_slot_not_fresh(self, mgr: SlotManager) -> None:
+        ok, reason = mgr.slot_is_fresh("bob")
+        assert ok is False
+        assert (
+            "missing" in reason.lower()
+            or "not found" in reason.lower()
+            or "unreadable" in reason.lower()
+        )
+
+    def test_missing_expiry_treated_as_unknown(self, mgr: SlotManager) -> None:
+        """No expiresAt in a present file → refuse (surface unusual state)."""
+        _write_slot(mgr.slot_path("bob"), expires_at_ms=None)
+        ok, _ = mgr.slot_is_fresh("bob")
+        assert ok is False
+
+    def test_frozen_now_parameter(self, mgr: SlotManager) -> None:
+        """Passing a fixed ``now`` makes the check deterministic."""
+        _write_slot(mgr.slot_path("bob"), 2_000_000_000_000)  # far future
+        frozen = datetime.fromtimestamp(1_500_000_000, tz=timezone.utc)
+        ok, _ = mgr.slot_is_fresh("bob", now=frozen)
+        assert ok is True
+
+    def test_module_function_accepts_plain_path(self, tmp_path: Path) -> None:
+        p = tmp_path / "x.json"
+        _write_slot(p, _ms_from_now(3600))
+        ok, _ = slot_is_fresh(p)
+        assert ok is True
+
+
+class TestGetActiveSubscription:
+    def test_none_when_no_symlink(self, mgr: SlotManager) -> None:
+        assert mgr.get_active_subscription() is None
+
+    def test_reads_symlink_target(self, mgr: SlotManager) -> None:
+        _write_slot(mgr.slot_path("bob"), _ms_from_now(3600))
+        mgr.live_path.symlink_to(".credentials.json.bob")
+        assert mgr.get_active_subscription() == "bob"
+
+    def test_unknown_target_returns_none(self, mgr: SlotManager) -> None:
+        """Symlink points outside the known subscription list."""
+        (mgr.creds_dir / ".credentials.json.other").write_text("{}")
+        mgr.live_path.symlink_to(".credentials.json.other")
+        assert mgr.get_active_subscription() is None
+
+    def test_regular_file_returns_none(self, mgr: SlotManager) -> None:
+        """Live file is a regular file (drift state) — no active sub."""
+        mgr.live_path.write_text("{}")
+        assert mgr.get_active_subscription() is None
+
+
+class TestGetAvailableSubscriptions:
+    def test_empty_when_none_exist(self, mgr: SlotManager) -> None:
+        assert mgr.get_available_subscriptions() == []
+
+    def test_only_present_slots(self, mgr: SlotManager) -> None:
+        _write_slot(mgr.slot_path("bob"), _ms_from_now(3600))
+        _write_slot(mgr.slot_path("alice"), _ms_from_now(3600))
+        # erik missing
+        assert mgr.get_available_subscriptions() == ["bob", "alice"]
+
+    def test_does_not_check_freshness(self, mgr: SlotManager) -> None:
+        """``get_available_subscriptions`` only looks at existence."""
+        _write_slot(mgr.slot_path("bob"), _ms_from_now(-3600))  # expired
+        assert mgr.get_available_subscriptions() == ["bob"]
+
+
+class TestDetectLiveSlotDrift:
+    """Live credentials file should match exactly one named slot."""
+
+    def test_live_matches_one_slot(self, mgr: SlotManager) -> None:
+        blob = b'{"claudeAiOauth":{"accessToken":"x"}}'
+        mgr.live_path.write_bytes(blob)
+        mgr.slot_path("bob").write_bytes(blob)
+        mgr.slot_path("alice").write_bytes(b'{"other":true}')
+        drift = mgr.detect_live_slot_drift()
+        assert drift is not None
+        assert drift["drift"] is False
+        assert drift["matching_slot"] == "bob"
+
+    def test_live_matches_no_slot(self, mgr: SlotManager) -> None:
+        mgr.live_path.write_bytes(b'{"claudeAiOauth":{"accessToken":"fresh"}}')
+        mgr.slot_path("bob").write_bytes(
+            b'{"claudeAiOauth":{"accessToken":"stale-bob"}}'
+        )
+        mgr.slot_path("alice").write_bytes(
+            b'{"claudeAiOauth":{"accessToken":"stale-alice"}}'
+        )
+        drift = mgr.detect_live_slot_drift()
+        assert drift is not None
+        assert drift["drift"] is True
+        assert drift["matching_slot"] is None
+        # All slot hashes are reported
+        assert set(drift["slot_hashes"].keys()) == {"bob", "alice"}
+
+    def test_live_missing_returns_none(self, mgr: SlotManager) -> None:
+        assert mgr.detect_live_slot_drift() is None
+
+    def test_live_is_symlink_follows(self, mgr: SlotManager) -> None:
+        blob = b'{"claudeAiOauth":{"accessToken":"y"}}'
+        mgr.slot_path("bob").write_bytes(blob)
+        mgr.live_path.symlink_to(".credentials.json.bob")
+        drift = mgr.detect_live_slot_drift()
+        assert drift is not None
+        assert drift["drift"] is False
+        assert drift["matching_slot"] == "bob"
+
+    def test_drift_info_shape(self, mgr: SlotManager) -> None:
+        """Smoke-check that returned object matches the :class:`DriftInfo` keys."""
+        mgr.live_path.write_bytes(b"irrelevant")
+        drift = mgr.detect_live_slot_drift()
+        assert drift is not None
+        expected_keys: set[str] = set(DriftInfo.__annotations__.keys())
+        assert expected_keys.issubset(drift.keys())
+
+
+class TestSwitchTo:
+    """switch_to: atomic symlink flip with safety checks."""
+
+    def _seed(
+        self,
+        mgr: SlotManager,
+        *,
+        bob_ms: int,
+        alice_ms: int,
+        initial: str = "alice",
+    ) -> None:
+        _write_slot(mgr.slot_path("bob"), bob_ms)
+        _write_slot(mgr.slot_path("alice"), alice_ms)
+        mgr.live_path.symlink_to(f".credentials.json.{initial}")
+
+    def test_fresh_target_switches(self, mgr: SlotManager) -> None:
+        self._seed(mgr, bob_ms=_ms_from_now(3600), alice_ms=_ms_from_now(3600))
+        result = mgr.switch_to("bob", "probe")
+        assert result.ok is True
+        assert mgr.get_active_subscription() == "bob"
+
+    def test_expired_target_rejected(self, mgr: SlotManager) -> None:
+        self._seed(mgr, bob_ms=_ms_from_now(-3600), alice_ms=_ms_from_now(3600))
+        result = mgr.switch_to("bob", "probe")
+        assert result.ok is False
+        assert "expired" in result.reason.lower()
+        assert mgr.get_active_subscription() == "alice"
+
+    def test_expired_target_rejected_even_with_force(self, mgr: SlotManager) -> None:
+        """force bypasses the lock guard but NOT the expiry check."""
+        self._seed(mgr, bob_ms=_ms_from_now(-3600), alice_ms=_ms_from_now(3600))
+        result = mgr.switch_to("bob", "manual", force=True)
+        assert result.ok is False
+        assert mgr.get_active_subscription() == "alice"
+
+    def test_missing_slot_rejected(self, mgr: SlotManager) -> None:
+        mgr.live_path.symlink_to(".credentials.json.alice")
+        # No slot files at all
+        result = mgr.switch_to("bob", "probe")
+        assert result.ok is False
+        assert "missing" in result.reason.lower()
+
+    def test_lock_guard_defers_switch(self, mgr: SlotManager) -> None:
+        self._seed(mgr, bob_ms=_ms_from_now(3600), alice_ms=_ms_from_now(3600))
+        mgr.lock_guard = lambda: ["autonomous-infrastructure"]
+        result = mgr.switch_to("bob", "probe")
+        assert result.ok is False
+        assert result.deferred_locks == ["autonomous-infrastructure"]
+        assert "deferred" in result.reason.lower()
+        # Live symlink unchanged
+        assert mgr.get_active_subscription() == "alice"
+
+    def test_lock_guard_empty_list_allows_switch(self, mgr: SlotManager) -> None:
+        self._seed(mgr, bob_ms=_ms_from_now(3600), alice_ms=_ms_from_now(3600))
+        mgr.lock_guard = lambda: []  # no active locks
+        result = mgr.switch_to("bob", "probe")
+        assert result.ok is True
+
+    def test_force_bypasses_lock_guard(self, mgr: SlotManager) -> None:
+        self._seed(mgr, bob_ms=_ms_from_now(3600), alice_ms=_ms_from_now(3600))
+        mgr.lock_guard = lambda: ["busy-session"]
+        result = mgr.switch_to("bob", "manual", force=True)
+        assert result.ok is True
+        assert mgr.get_active_subscription() == "bob"
+
+    def test_on_switch_callback_fires_on_success(self, mgr: SlotManager) -> None:
+        self._seed(mgr, bob_ms=_ms_from_now(3600), alice_ms=_ms_from_now(3600))
+        events: list[tuple[str, str]] = []
+        mgr.on_switch = lambda sub, reason: events.append((sub, reason))
+        mgr.switch_to("bob", "probe")
+        assert events == [("bob", "probe")]
+
+    def test_on_switch_not_called_on_failure(self, mgr: SlotManager) -> None:
+        self._seed(mgr, bob_ms=_ms_from_now(-3600), alice_ms=_ms_from_now(3600))
+        events: list[tuple[str, str]] = []
+        mgr.on_switch = lambda sub, reason: events.append((sub, reason))
+        mgr.switch_to("bob", "probe")
+        assert events == []
+
+    def test_logger_receives_defer_message(self, mgr: SlotManager) -> None:
+        self._seed(mgr, bob_ms=_ms_from_now(3600), alice_ms=_ms_from_now(3600))
+        lines: list[str] = []
+        mgr.logger = lines.append
+        mgr.lock_guard = lambda: ["lock-a"]
+        mgr.switch_to("bob", "probe")
+        assert any("deferred" in line.lower() for line in lines)
+
+    def test_replaces_existing_symlink(self, mgr: SlotManager) -> None:
+        """Target slot change when symlink already exists (existing setup)."""
+        self._seed(mgr, bob_ms=_ms_from_now(3600), alice_ms=_ms_from_now(3600))
+        # initial points at alice
+        assert mgr.get_active_subscription() == "alice"
+        mgr.switch_to("bob", "rebalance")
+        assert mgr.get_active_subscription() == "bob"
+        # And back
+        mgr.switch_to("alice", "revert")
+        assert mgr.get_active_subscription() == "alice"
+
+
+class TestSwitchResult:
+    """Shape of :class:`SwitchResult`."""
+
+    def test_defaults(self) -> None:
+        r = SwitchResult(ok=True, reason="ok")
+        assert r.deferred_locks == []
+
+    def test_equality(self) -> None:
+        assert SwitchResult(ok=False, reason="x", deferred_locks=["a"]) == SwitchResult(
+            ok=False, reason="x", deferred_locks=["a"]
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,7 @@ resolution-markers = [
 
 [manifest]
 members = [
+    "credential-slots",
     "gptmail",
     "gptme-ace",
     "gptme-activity-summary",
@@ -718,6 +719,24 @@ wheels = [
 toml = [
     { name = "tomli", marker = "python_full_version <= '3.11'" },
 ]
+
+[[package]]
+name = "credential-slots"
+version = "0.1.0"
+source = { editable = "packages/credential-slots" }
+
+[package.optional-dependencies]
+test = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
+    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.0" },
+]
+provides-extras = ["test"]
 
 [[package]]
 name = "cryptography"


### PR DESCRIPTION
## Summary

New `packages/credential-slots/` package. Lifts the reusable pieces of Bob's `manage-subscription.py` into a standalone, dependency-injected class so alice, gordon, sven, and other agents inherit the same OAuth-rotation safety guarantees without forking the logic.

Ported from [ErikBjare/bob@e9ea27097](https://github.com/ErikBjare/bob/commit/e9ea27097).

## Motivating incident — 2026-04-23

Bob's live `~/.claude/.credentials.json` OAuth token became invalid server-side while still claiming a future `expiresAt`. Every autonomous Claude Code session hit 401. After three infra failures the per-backend crash counter tripped and opus was blocked for 1h. When the operator refreshed the token via `claude /login`, the new credentials were written to the live file only — a future `--switch bob` would have silently restored the stale token.

Bob's script was hardened with three defensive checks; this package lifts them out of Bob's workspace so the whole fleet benefits.

## Public API

```python
from credential_slots import SlotManager

mgr = SlotManager(
    creds_dir=Path.home() / ".claude",
    subscriptions=["bob", "alice", "erik"],
    lock_guard=lambda: [...],  # optional: defer switches while busy
    on_switch=lambda sub, reason: ...,  # optional: log switches
    logger=print,  # optional: default is silent
)

mgr.get_active_subscription()        # "bob" | None
mgr.slot_is_fresh("bob")             # (True, "valid until ...")
mgr.detect_live_slot_drift()         # {"drift": True, "matching_slot": None, ...}
result = mgr.switch_to("alice", "rebalance")
result.ok, result.reason, result.deferred_locks
```

## Design decisions (open for review discussion)

- **Class-based with injected paths** — the task brief asked about parameter vs module vs class; I went class-based so `creds_dir` / `slot_template` / `live_name` / `grace_seconds` / `lock_guard` / `on_switch` / `logger` all live on one object. Module-level `read_slot_expiry(path)` and `slot_is_fresh(path)` are also exposed for one-off use.
- **Offline-only** — the package never makes network calls. Server-side token invalidation with a still-future `expiresAt` (exactly the 2026-04-23 failure mode) is out of scope — detect it in the caller's API response classifier.
- **No workspace deps** — switch logs, rate-limit files, usage polling, rebalance state all stay in the caller. This package provides the callbacks those callers plug into (`on_switch`, `lock_guard`, `logger`).
- **`switch_to` refuses expired/unreadable slots under `force=True`** — landing on a known-bad credential just moves the 401 crash loop to the next run. An operator typing `--switch bob` doesn't want to land on an already-expired slot.
- **Scope** — Claude Code OAuth slots specifically, not any backend. gptme's config-toml credentials are a different shape and deliberately out of scope.

## Test plan

- [x] 42 unit tests pass (`uv run pytest packages/credential-slots/tests/ -v`)
- [x] `mypy --strict` clean
- [x] `ruff check` clean
- [x] Registered in `[tool.uv.workspace]` via `packages/*` glob; `uv sync --all-packages` succeeds
- [x] Pre-commit clean
- [ ] Greptile review requested & addressed (follow-up comment)
- [ ] Follow-up PR in ErikBjare/bob to refactor `scripts/manage-subscription.py` onto this package

Tracking issue: [ErikBjare/bob subscription-auth-recovery task](https://github.com/ErikBjare/bob/blob/master/tasks/subscription-auth-recovery.md).

Co-authored-by: Bob <bob@superuserlabs.org>