### PR TITLE
fix(voice): make post-call follow-up survive restarts

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -581,7 +581,7 @@ class VoiceServer:
         logger.info("Consumed handoff bootstrap %s from %s", handoff_id, path)
         return resume_context
 
-    def _build_session_bootstrap(
+    async def _build_session_bootstrap(
         self,
         *,
         caller_id: str | None,
@@ -601,7 +601,7 @@ class VoiceServer:
                 should_greet_first=False,
             )
 
-        recent_call = self._consume_recent_call(caller_id)
+        recent_call = await self._consume_recent_call(caller_id)
         if recent_call:
             return SessionBootstrap(
                 instructions=_build_resume_instructions(
@@ -621,20 +621,24 @@ class VoiceServer:
             ),
         )
 
-    def _build_session_instructions(
+    async def _build_session_instructions(
         self,
         *,
         caller_id: str | None,
         from_number: str = "",
         handoff_id: str | None = None,
     ) -> str:
-        return self._build_session_bootstrap(
-            caller_id=caller_id,
-            from_number=from_number,
-            handoff_id=handoff_id,
+        return (
+            await self._build_session_bootstrap(
+                caller_id=caller_id,
+                from_number=from_number,
+                handoff_id=handoff_id,
+            )
         ).instructions
 
-    def _consume_recent_call(self, caller_id: str | None) -> RecentCallRecord | None:
+    async def _consume_recent_call(
+        self, caller_id: str | None
+    ) -> RecentCallRecord | None:
         if not caller_id:
             return None
 
@@ -651,7 +655,10 @@ class VoiceServer:
             or recent_call.pending_post_call_unit
         )
         if pending_unit:
-            self._cancel_post_call_schedule(pending_unit)
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(
+                None, self._cancel_post_call_schedule, pending_unit
+            )
             logger.info(
                 "Deferred pending post-call follow-up for resumed caller %s", caller_id
             )
@@ -756,7 +763,10 @@ class VoiceServer:
     ) -> None:
         existing_unit = self._pending_post_calls.pop(caller_id, None)
         if existing_unit:
-            self._cancel_post_call_schedule(existing_unit)
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(
+                None, self._cancel_post_call_schedule, existing_unit
+            )
 
         deduped_record_paths = self._dedupe_record_paths(record_paths)
         if not deduped_record_paths:
@@ -1030,7 +1040,7 @@ class VoiceServer:
                     from_number = custom_params.get("from_number", "")
                     handoff_id = custom_params.get("handoff_id") or None
                     caller_id = from_number or call_sid or stream_sid
-                    bootstrap = self._build_session_bootstrap(
+                    bootstrap = await self._build_session_bootstrap(
                         caller_id=caller_id,
                         from_number=from_number,
                         handoff_id=handoff_id,
@@ -1185,7 +1195,7 @@ class VoiceServer:
         transcript: list[TranscriptTurn] = []
 
         try:
-            instructions = self._build_session_instructions(
+            instructions = await self._build_session_instructions(
                 caller_id=caller_id,
                 handoff_id=handoff_id,
             )

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -777,12 +777,33 @@ class VoiceServer:
         if unit_name:
             self._pending_post_calls[caller_id] = unit_name
 
-        await self._run_post_call_command(
-            caller_id,
-            deduped_record_paths,
-            delay_seconds=self.post_call_delay_seconds,
-            unit_name=unit_name,
-        )
+        if self.post_call_delay_seconds > 0:
+            logger.info(
+                "Post-call delay of %ds for %s is delegated to the external command "
+                "via GPTME_VOICE_POST_CALL_DELAY_SECONDS; the server no longer enforces it directly",
+                self.post_call_delay_seconds,
+                caller_id,
+            )
+
+        # Cap the dispatch command at 30s so a hung systemd-run can't stall _on_call_end
+        # indefinitely. The dispatch command (e.g. post-call-dispatch.sh) is expected to exit
+        # in <1s after scheduling a systemd timer, not after the full post-call delay.
+        try:
+            await asyncio.wait_for(
+                self._run_post_call_command(
+                    caller_id,
+                    deduped_record_paths,
+                    delay_seconds=self.post_call_delay_seconds,
+                    unit_name=unit_name,
+                ),
+                timeout=30.0,
+            )
+        except asyncio.TimeoutError:
+            logger.error(
+                "Post-call dispatch command timed out after 30s for %s — "
+                "follow-up may not have been scheduled",
+                caller_id,
+            )
 
     def _make_handoff_callback(
         self,

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 import shlex
+import subprocess
 import time
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
@@ -70,6 +71,8 @@ class RecentCallRecord:
     transcript: list[TranscriptTurn]
     metadata: dict[str, str]
     subagent_timings: list[dict[str, object]] = field(default_factory=list)
+    archive_record_paths: list[str] = field(default_factory=list)
+    pending_post_call_unit: str | None = None
 
 
 @dataclass
@@ -300,7 +303,7 @@ class VoiceServer:
 
         # Active connections: call_sid -> (twilio_ws, realtime_client)
         self._connections: dict[str, tuple] = {}
-        self._pending_post_calls: dict[str, asyncio.Task[None]] = {}
+        self._pending_post_calls: dict[str, str] = {}
         self._pending_archive_records: dict[str, list[Path]] = {}
 
         # Create Starlette app
@@ -358,7 +361,9 @@ class VoiceServer:
             / f"{ended_at}-{milliseconds:03d}-{record.source}-{safe_identifier}.json"
         )
 
-    def _record_payload(self, record: RecentCallRecord) -> dict[str, object]:
+    def _record_payload(
+        self, record: RecentCallRecord, *, include_pending_state: bool = False
+    ) -> dict[str, object]:
         payload: dict[str, object] = {
             "caller_id": record.caller_id,
             "source": record.source,
@@ -368,17 +373,37 @@ class VoiceServer:
         }
         if record.subagent_timings:
             payload["subagent_timings"] = record.subagent_timings
+        if include_pending_state and record.archive_record_paths:
+            payload["archive_record_paths"] = record.archive_record_paths
+        if include_pending_state and record.pending_post_call_unit:
+            payload["pending_post_call_unit"] = record.pending_post_call_unit
         return payload
 
-    def _write_call_record(self, path: Path, record: RecentCallRecord) -> Path:
+    def _write_call_record(
+        self,
+        path: Path,
+        record: RecentCallRecord,
+        *,
+        include_pending_state: bool = False,
+    ) -> Path:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(
-            json.dumps(self._record_payload(record), indent=2, sort_keys=True)
+            json.dumps(
+                self._record_payload(
+                    record, include_pending_state=include_pending_state
+                ),
+                indent=2,
+                sort_keys=True,
+            )
         )
         return path
 
     def _save_recent_call(self, record: RecentCallRecord) -> Path:
-        return self._write_call_record(self._recent_call_path(record.caller_id), record)
+        return self._write_call_record(
+            self._recent_call_path(record.caller_id),
+            record,
+            include_pending_state=True,
+        )
 
     def _save_call_record(self, record: RecentCallRecord) -> Path:
         return self._write_call_record(self._call_record_path(record), record)
@@ -402,6 +427,7 @@ class VoiceServer:
                 subagent_timings = [
                     dict(item) for item in raw_timings if isinstance(item, dict)
                 ]
+                raw_archive_paths = payload.get("archive_record_paths") or []
                 return RecentCallRecord(
                     caller_id=payload["caller_id"],
                     source=payload.get("source", "unknown"),
@@ -413,6 +439,17 @@ class VoiceServer:
                         if value is not None
                     },
                     subagent_timings=subagent_timings,
+                    archive_record_paths=[
+                        str(path)
+                        for path in raw_archive_paths
+                        if isinstance(path, str) and path.strip()
+                    ],
+                    pending_post_call_unit=(
+                        payload.get("pending_post_call_unit")
+                        if isinstance(payload.get("pending_post_call_unit"), str)
+                        and payload.get("pending_post_call_unit")
+                        else None
+                    ),
                 )
             except Exception as exc:
                 logger.warning(
@@ -420,6 +457,59 @@ class VoiceServer:
                 )
 
         return None
+
+    def _dedupe_record_paths(self, record_paths: list[Path]) -> list[Path]:
+        return list(dict.fromkeys(record_paths))
+
+    def _restore_archive_record_paths(self, raw_paths: list[str]) -> list[Path]:
+        restored_paths: list[Path] = []
+        for raw_path in raw_paths:
+            path = Path(raw_path)
+            if path.exists():
+                restored_paths.append(path)
+        return self._dedupe_record_paths(restored_paths)
+
+    def _build_post_call_unit_name(
+        self, caller_id: str, record_paths: list[Path]
+    ) -> str | None:
+        deduped_record_paths = self._dedupe_record_paths(record_paths)
+        if not deduped_record_paths:
+            return None
+
+        digest = hashlib.sha256()
+        digest.update(caller_id.encode("utf-8"))
+        for record_path in deduped_record_paths:
+            digest.update(b"\0")
+            digest.update(str(record_path).encode("utf-8"))
+        return f"gptme-voice-post-call-{digest.hexdigest()[:12]}"
+
+    def _cancel_post_call_schedule(self, unit_name: str | None) -> None:
+        if not unit_name:
+            return
+
+        units = (f"{unit_name}.timer", f"{unit_name}.service")
+        for action in ("stop", "reset-failed"):
+            for unit in units:
+                result = subprocess.run(
+                    ["systemctl", "--user", action, unit],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                if result.returncode == 0:
+                    continue
+
+                stderr = (result.stderr or "").strip().lower()
+                if "not loaded" in stderr or "not found" in stderr:
+                    continue
+
+                logger.warning(
+                    "Failed to %s pending post-call unit %s: exit=%s stderr=%s",
+                    action,
+                    unit,
+                    result.returncode,
+                    (result.stderr or "").strip(),
+                )
 
     def _parse_state_timestamp(self, value: object) -> float | None:
         if not isinstance(value, str) or not value.strip():
@@ -556,12 +646,23 @@ class VoiceServer:
         if age_seconds > self.resume_window_seconds:
             return None
 
-        pending_task = self._pending_post_calls.pop(caller_id, None)
-        if pending_task:
-            pending_task.cancel()
+        pending_unit = (
+            self._pending_post_calls.pop(caller_id, None)
+            or recent_call.pending_post_call_unit
+        )
+        if pending_unit:
+            self._cancel_post_call_schedule(pending_unit)
             logger.info(
                 "Deferred pending post-call follow-up for resumed caller %s", caller_id
             )
+
+        restored_archive_paths = self._restore_archive_record_paths(
+            recent_call.archive_record_paths
+        )
+        if restored_archive_paths:
+            self._pending_archive_records[caller_id] = restored_archive_paths
+        else:
+            self._pending_archive_records.pop(caller_id, None)
 
         # Delete the resume-state file(s) so a crash-resume can't re-inject the old
         # transcript, but keep archived per-call records for post-call analysis.
@@ -583,7 +684,12 @@ class VoiceServer:
         return recent_call
 
     async def _run_post_call_command(
-        self, caller_id: str, record_paths: list[Path]
+        self,
+        caller_id: str,
+        record_paths: list[Path],
+        *,
+        delay_seconds: int = 0,
+        unit_name: str | None = None,
     ) -> None:
         if not self.post_call_command:
             return
@@ -604,6 +710,10 @@ class VoiceServer:
             [str(path) for path in record_paths]
         )
         env["GPTME_VOICE_CALLER_ID"] = caller_id
+        if delay_seconds > 0:
+            env["GPTME_VOICE_POST_CALL_DELAY_SECONDS"] = str(delay_seconds)
+        if unit_name:
+            env["GPTME_VOICE_POST_CALL_UNIT_NAME"] = unit_name
         process = await asyncio.create_subprocess_exec(
             *argv,
             *(str(path) for path in record_paths),
@@ -644,11 +754,11 @@ class VoiceServer:
     async def _schedule_post_call(
         self, caller_id: str, record_paths: list[Path]
     ) -> None:
-        existing_task = self._pending_post_calls.pop(caller_id, None)
-        if existing_task:
-            existing_task.cancel()
+        existing_unit = self._pending_post_calls.pop(caller_id, None)
+        if existing_unit:
+            self._cancel_post_call_schedule(existing_unit)
 
-        deduped_record_paths = list(dict.fromkeys(record_paths))
+        deduped_record_paths = self._dedupe_record_paths(record_paths)
         if not deduped_record_paths:
             self._pending_archive_records.pop(caller_id, None)
             logger.warning(
@@ -659,23 +769,20 @@ class VoiceServer:
         self._pending_archive_records[caller_id] = deduped_record_paths
 
         if not self.post_call_command:
+            self._pending_post_calls.pop(caller_id, None)
             self._pending_archive_records.pop(caller_id, None)
             return
 
-        async def _runner() -> None:
-            task = asyncio.current_task()
-            try:
-                await asyncio.sleep(self.post_call_delay_seconds)
-                await self._run_post_call_command(caller_id, deduped_record_paths)
-            except asyncio.CancelledError:
-                raise
-            finally:
-                # Only remove our own entry — a newer task may have replaced us
-                if self._pending_post_calls.get(caller_id) is task:
-                    self._pending_post_calls.pop(caller_id)
-                    self._pending_archive_records.pop(caller_id, None)
+        unit_name = self._build_post_call_unit_name(caller_id, deduped_record_paths)
+        if unit_name:
+            self._pending_post_calls[caller_id] = unit_name
 
-        self._pending_post_calls[caller_id] = asyncio.create_task(_runner())
+        await self._run_post_call_command(
+            caller_id,
+            deduped_record_paths,
+            delay_seconds=self.post_call_delay_seconds,
+            unit_name=unit_name,
+        )
 
     def _make_handoff_callback(
         self,
@@ -767,11 +874,16 @@ class VoiceServer:
             metadata={k: v for k, v in metadata.items() if v},
             subagent_timings=subagent_timings,
         )
-        self._save_recent_call(record)
         record_path = self._save_call_record(record)
         pending_record_paths = list(self._pending_archive_records.get(caller_id, []))
         pending_record_paths.append(record_path)
-        await self._schedule_post_call(caller_id, pending_record_paths)
+        deduped_record_paths = self._dedupe_record_paths(pending_record_paths)
+        record.archive_record_paths = [str(path) for path in deduped_record_paths]
+        record.pending_post_call_unit = self._build_post_call_unit_name(
+            caller_id, deduped_record_paths
+        )
+        self._save_recent_call(record)
+        await self._schedule_post_call(caller_id, deduped_record_paths)
 
     def _get_local_caller_id(self, websocket) -> str:
         caller_id = websocket.query_params.get("caller_id")

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -5,6 +5,8 @@ import os
 import shlex
 import sys
 import tempfile
+import textwrap
+import time
 from pathlib import Path
 
 import pytest
@@ -326,19 +328,27 @@ def test_schedule_post_call_runs_configured_command_hook() -> None:
             record_path = server._save_call_record(record)
             observed: dict[str, object] = {}
 
-            async def _fake_run_post_call(caller_id: str, paths: list[Path]) -> None:
+            async def _fake_run_post_call(
+                caller_id: str,
+                paths: list[Path],
+                *,
+                delay_seconds: int = 0,
+                unit_name: str | None = None,
+            ) -> None:
                 observed["caller_id"] = caller_id
                 observed["paths"] = [str(path) for path in paths]
+                observed["delay_seconds"] = delay_seconds
+                observed["unit_name"] = unit_name
 
             server._run_post_call_command = _fake_run_post_call  # type: ignore[method-assign]
 
             await server._schedule_post_call(record.caller_id, [record_path])
-            task = server._pending_post_calls[record.caller_id]
-            await task
 
             assert observed == {
                 "caller_id": "+46700000001",
                 "paths": [str(record_path)],
+                "delay_seconds": 0,
+                "unit_name": server._pending_post_calls[record.caller_id],
             }
 
     asyncio.run(_exercise())
@@ -431,6 +441,19 @@ def test_resume_carries_prior_archive_into_next_post_call() -> None:
             server.resume_window_seconds = 300
             server.post_call_command = "run-post-call"
             server.post_call_delay_seconds = 1_000
+            cancelled_units: list[str] = []
+
+            async def _fake_run_post_call(
+                caller_id: str,
+                paths: list[Path],
+                *,
+                delay_seconds: int = 0,
+                unit_name: str | None = None,
+            ) -> None:
+                return None
+
+            server._run_post_call_command = _fake_run_post_call  # type: ignore[method-assign]
+            server._cancel_post_call_schedule = cancelled_units.append  # type: ignore[method-assign]
 
             first = RecentCallRecord(
                 caller_id="+46700000010",
@@ -440,17 +463,18 @@ def test_resume_carries_prior_archive_into_next_post_call() -> None:
                 metadata={"call_sid": "CAfirst"},
             )
             first_path = server._save_call_record(first)
-            server._save_recent_call(first)
             await server._schedule_post_call(first.caller_id, [first_path])
-            first_task = server._pending_post_calls[first.caller_id]
+            first_unit = server._pending_post_calls[first.caller_id]
+            first.archive_record_paths = [str(first_path)]
+            first.pending_post_call_unit = first_unit
+            server._save_recent_call(first)
 
             with pytest.MonkeyPatch.context() as mp:
                 mp.setattr("gptme_voice.realtime.server.time.time", lambda: 1_100.0)
                 resumed = server._consume_recent_call(first.caller_id)
-            await asyncio.sleep(0)
 
             assert resumed is not None
-            assert first_task.cancelled()
+            assert cancelled_units == [first_unit]
             assert server._pending_archive_records[first.caller_id] == [first_path]
 
             second = RecentCallRecord(
@@ -467,8 +491,7 @@ def test_resume_carries_prior_archive_into_next_post_call() -> None:
                 first_path,
                 second_path,
             ]
-
-            server._pending_post_calls[first.caller_id].cancel()
+            assert server._pending_post_calls[first.caller_id] != first_unit
 
     asyncio.run(_exercise())
 
@@ -508,16 +531,30 @@ def test_save_call_record_uses_unique_archive_path_per_call() -> None:
         )
 
 
-def test_schedule_post_call_runner_finally_does_not_evict_newer_task() -> None:
-    """P1 fix: cancelling an old _runner task must not pop the newer task
-    that replaced it in _pending_post_calls."""
+def test_schedule_post_call_replaces_existing_timer_unit() -> None:
+    """Rescheduling a caller should cancel the old transient timer and keep the new one."""
 
     async def _exercise() -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             server = VoiceServer()
             server.state_dir = Path(tmpdir)
             server.post_call_command = "run-post-call"
-            server.post_call_delay_seconds = 1_000  # effectively never fires
+            server.post_call_delay_seconds = 1_000
+            cancelled_units: list[str] = []
+            scheduled_units: list[str] = []
+
+            async def _fake_run_post_call(
+                caller_id: str,
+                paths: list[Path],
+                *,
+                delay_seconds: int = 0,
+                unit_name: str | None = None,
+            ) -> None:
+                if unit_name is not None:
+                    scheduled_units.append(unit_name)
+
+            server._run_post_call_command = _fake_run_post_call  # type: ignore[method-assign]
+            server._cancel_post_call_schedule = cancelled_units.append  # type: ignore[method-assign]
 
             record = RecentCallRecord(
                 caller_id="+46700000003",
@@ -526,27 +563,206 @@ def test_schedule_post_call_runner_finally_does_not_evict_newer_task() -> None:
                 transcript=[],
                 metadata={},
             )
-            record_path = server._save_recent_call(record)
+            record_path = server._save_call_record(record)
+            second_path = server._save_call_record(
+                RecentCallRecord(
+                    caller_id=record.caller_id,
+                    source="twilio",
+                    ended_at=1_001.0,
+                    transcript=[],
+                    metadata={},
+                )
+            )
 
-            # Schedule first task (long sleep — won't complete naturally)
             await server._schedule_post_call(record.caller_id, [record_path])
-            first_task = server._pending_post_calls[record.caller_id]
+            first_unit = server._pending_post_calls[record.caller_id]
 
-            # Schedule second task — cancels first and registers itself
-            await server._schedule_post_call(record.caller_id, [record_path])
-            second_task = server._pending_post_calls[record.caller_id]
+            await server._schedule_post_call(
+                record.caller_id, [record_path, second_path]
+            )
+            second_unit = server._pending_post_calls[record.caller_id]
 
-            # Wait for the first task's finally-block to run
-            await asyncio.sleep(0)
-            await asyncio.sleep(0)
-
-            # The second task must still be registered
-            assert server._pending_post_calls.get(record.caller_id) is second_task
-            assert first_task.cancelled()
-
-            second_task.cancel()
+            assert cancelled_units == [first_unit]
+            assert second_unit != first_unit
+            assert scheduled_units == [first_unit, second_unit]
+            assert server._pending_post_calls.get(record.caller_id) == second_unit
 
     asyncio.run(_exercise())
+
+
+def test_consume_recent_call_restores_pending_schedule_after_restart() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        first_server = VoiceServer()
+        first_server.state_dir = Path(tmpdir)
+        record = RecentCallRecord(
+            caller_id="+46700000012",
+            source="twilio",
+            ended_at=1_000.0,
+            transcript=[TranscriptTurn(role="user", text="Restart-safe resume")],
+            metadata={"call_sid": "CArestart"},
+        )
+        record_path = first_server._save_call_record(record)
+        record.archive_record_paths = [str(record_path)]
+        record.pending_post_call_unit = "gptme-voice-post-call-restart"
+        first_server._save_recent_call(record)
+
+        second_server = VoiceServer()
+        second_server.state_dir = Path(tmpdir)
+        cancelled_units: list[str] = []
+        second_server._cancel_post_call_schedule = cancelled_units.append  # type: ignore[method-assign]
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("gptme_voice.realtime.server.time.time", lambda: 1_100.0)
+            resumed = second_server._consume_recent_call(record.caller_id)
+
+        assert resumed is not None
+        assert cancelled_units == ["gptme-voice-post-call-restart"]
+        assert second_server._pending_archive_records[record.caller_id] == [record_path]
+
+
+def test_on_call_end_persists_pending_post_call_state() -> None:
+    async def _exercise() -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            server = VoiceServer()
+            server.state_dir = Path(tmpdir)
+            server.post_call_command = "run-post-call"
+            server.post_call_delay_seconds = 300
+
+            async def _fake_run_post_call(
+                caller_id: str,
+                paths: list[Path],
+                *,
+                delay_seconds: int = 0,
+                unit_name: str | None = None,
+            ) -> None:
+                return None
+
+            server._run_post_call_command = _fake_run_post_call  # type: ignore[method-assign]
+
+            await server._on_call_end(
+                caller_id="+46700000013",
+                source="twilio",
+                transcript=[TranscriptTurn(role="user", text="Persist the chain")],
+                metadata={"call_sid": "CApersist"},
+            )
+
+            recent = server._load_recent_call("+46700000013")
+            assert recent is not None
+            assert len(recent.archive_record_paths) == 1
+            assert (
+                recent.pending_post_call_unit
+                == server._pending_post_calls["+46700000013"]
+            )
+            assert Path(recent.archive_record_paths[0]).exists()
+
+    asyncio.run(_exercise())
+
+
+def test_post_call_schedule_survives_scheduler_process_exit(tmp_path: Path) -> None:
+    marker_file = tmp_path / "post-call-fired.txt"
+    launcher_done_file = tmp_path / "launcher-done.txt"
+    wrapper_path = tmp_path / "fake_post_call_wrapper.py"
+    launcher_path = tmp_path / "schedule_call.py"
+
+    wrapper_path.write_text(
+        textwrap.dedent(
+            """\
+import os
+import subprocess
+import sys
+
+delay_seconds = float(os.environ.get("GPTME_VOICE_POST_CALL_DELAY_SECONDS", "0"))
+marker_path = os.environ["MARKER_FILE"]
+launcher_done_path = os.environ["LAUNCHER_DONE_FILE"]
+record_path = sys.argv[1]
+payload = os.environ.get("GPTME_VOICE_POST_CALL_UNIT_NAME", record_path)
+child_code = '''
+import pathlib
+import sys
+import time
+
+done_path = pathlib.Path(sys.argv[1])
+while not done_path.exists():
+    time.sleep(0.05)
+time.sleep(float(sys.argv[2]))
+pathlib.Path(sys.argv[3]).write_text(sys.argv[4])
+'''
+subprocess.Popen(
+    [
+        sys.executable,
+        "-c",
+        child_code,
+        launcher_done_path,
+        str(delay_seconds),
+        marker_path,
+        payload,
+    ],
+    close_fds=True,
+    stdin=subprocess.DEVNULL,
+    stdout=subprocess.DEVNULL,
+    stderr=subprocess.DEVNULL,
+    start_new_session=True,
+)
+"""
+        )
+    )
+
+    launcher_path.write_text(
+        textwrap.dedent(
+            """\
+import asyncio
+import shlex
+import sys
+from pathlib import Path
+
+from gptme_voice.realtime.server import TranscriptTurn, VoiceServer
+
+async def main() -> None:
+    server = VoiceServer()
+    server.state_dir = Path(sys.argv[1])
+    server.post_call_command = (
+        f"{sys.executable} {shlex.quote(str(Path(sys.argv[2])))}"
+    )
+    server.post_call_delay_seconds = 3
+    await server._on_call_end(
+        caller_id="+46700000014",
+        source="twilio",
+        transcript=[TranscriptTurn(role="user", text="Stay durable")],
+        metadata={"call_sid": "CAsubprocess"},
+    )
+    Path(sys.argv[3]).write_text("done")
+
+asyncio.run(main())
+"""
+        )
+    )
+
+    env = os.environ.copy()
+    env["MARKER_FILE"] = str(marker_file)
+    env["LAUNCHER_DONE_FILE"] = str(launcher_done_file)
+    result = os.spawnve(
+        os.P_WAIT,
+        sys.executable,
+        [
+            sys.executable,
+            str(launcher_path),
+            str(tmp_path),
+            str(wrapper_path),
+            str(launcher_done_file),
+        ],
+        env,
+    )
+
+    assert result == 0
+    assert launcher_done_file.exists()
+    assert not marker_file.exists()
+
+    deadline = time.time() + 8
+    while time.time() < deadline and not marker_file.exists():
+        time.sleep(0.05)
+
+    assert marker_file.exists()
+    assert marker_file.read_text().startswith("gptme-voice-post-call-")
 
 
 def test_cancelled_post_call_command_terminates_subprocess() -> None:

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -723,7 +723,7 @@ async def main() -> None:
     server.post_call_command = (
         f"{sys.executable} {shlex.quote(str(Path(sys.argv[2])))}"
     )
-    server.post_call_delay_seconds = 3
+    server.post_call_delay_seconds = 1
     await server._on_call_end(
         caller_id="+46700000014",
         source="twilio",
@@ -757,7 +757,7 @@ asyncio.run(main())
     assert launcher_done_file.exists()
     assert not marker_file.exists()
 
-    deadline = time.time() + 8
+    deadline = time.time() + 15
     while time.time() < deadline and not marker_file.exists():
         time.sleep(0.05)
 

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -106,9 +106,11 @@ def test_build_session_bootstrap_greets_fresh_calls() -> None:
     server = VoiceServer()
     server._instructions = "You are Bob."
 
-    bootstrap = server._build_session_bootstrap(
-        caller_id="+46700000011",
-        from_number="+46700000011",
+    bootstrap = asyncio.run(
+        server._build_session_bootstrap(
+            caller_id="+46700000011",
+            from_number="+46700000011",
+        )
     )
 
     assert bootstrap.should_greet_first is True
@@ -126,9 +128,11 @@ def test_build_session_bootstrap_personalizes_known_caller_greeting() -> None:
         server = VoiceServer(workspace=tmpdir)
         server._instructions = "You are Bob."
 
-        bootstrap = server._build_session_bootstrap(
-            caller_id="+46700000001",
-            from_number="+46700000001",
+        bootstrap = asyncio.run(
+            server._build_session_bootstrap(
+                caller_id="+46700000001",
+                from_number="+46700000001",
+            )
         )
 
     assert bootstrap.should_greet_first is True
@@ -140,9 +144,11 @@ def test_build_session_bootstrap_asks_unknown_caller_to_identify() -> None:
     server = VoiceServer()
     server._instructions = "You are Bob."
 
-    bootstrap = server._build_session_bootstrap(
-        caller_id="+15551234567",
-        from_number="+15551234567",
+    bootstrap = asyncio.run(
+        server._build_session_bootstrap(
+            caller_id="+15551234567",
+            from_number="+15551234567",
+        )
     )
 
     assert bootstrap.should_greet_first is True
@@ -186,7 +192,7 @@ def test_recent_call_is_consumed_within_resume_window() -> None:
 
         with pytest.MonkeyPatch.context() as mp:
             mp.setattr("gptme_voice.realtime.server.time.time", lambda: 1_100.0)
-            resumed = server._consume_recent_call("+46700000001")
+            resumed = asyncio.run(server._consume_recent_call("+46700000001"))
 
         assert resumed is not None
         assert resumed.caller_id == "+46700000001"
@@ -210,7 +216,9 @@ def test_build_session_bootstrap_skips_greeting_for_recent_resume() -> None:
 
         with pytest.MonkeyPatch.context() as mp:
             mp.setattr("gptme_voice.realtime.server.time.time", lambda: 1_100.0)
-            bootstrap = server._build_session_bootstrap(caller_id=record.caller_id)
+            bootstrap = asyncio.run(
+                server._build_session_bootstrap(caller_id=record.caller_id)
+            )
 
         assert bootstrap.should_greet_first is False
         assert "reconnected after a brief disconnect" in bootstrap.instructions
@@ -233,7 +241,7 @@ def test_recent_call_is_ignored_outside_resume_window() -> None:
 
         with pytest.MonkeyPatch.context() as mp:
             mp.setattr("gptme_voice.realtime.server.time.time", lambda: 1_400.1)
-            resumed = server._consume_recent_call("+46700000001")
+            resumed = asyncio.run(server._consume_recent_call("+46700000001"))
 
         assert resumed is None
 
@@ -260,9 +268,11 @@ def test_consume_handoff_bootstrap_returns_resume_context_and_deletes_file() -> 
 
         with pytest.MonkeyPatch.context() as mp:
             mp.setattr("gptme_voice.realtime.server.time.time", lambda: 1_200.0)
-            instructions = server._build_session_instructions(
-                caller_id="+46700000007",
-                handoff_id="handoff-123",
+            instructions = asyncio.run(
+                server._build_session_instructions(
+                    caller_id="+46700000007",
+                    handoff_id="handoff-123",
+                )
             )
 
         assert "bob transferred this caller to alice." in instructions
@@ -301,9 +311,11 @@ def test_stale_handoff_bootstrap_falls_back_to_recent_call_resume() -> None:
 
         with pytest.MonkeyPatch.context() as mp:
             mp.setattr("gptme_voice.realtime.server.time.time", lambda: 1_600.0)
-            instructions = server._build_session_instructions(
-                caller_id=record.caller_id,
-                handoff_id="handoff-stale",
+            instructions = asyncio.run(
+                server._build_session_instructions(
+                    caller_id=record.caller_id,
+                    handoff_id="handoff-stale",
+                )
             )
 
         assert "Resume the old call" in instructions
@@ -404,7 +416,7 @@ def test_consume_recent_call_deletes_state_file() -> None:
 
         with pytest.MonkeyPatch.context() as mp:
             mp.setattr("gptme_voice.realtime.server.time.time", lambda: 1_100.0)
-            server._consume_recent_call("+46700000002")
+            asyncio.run(server._consume_recent_call("+46700000002"))
 
         assert not state_path.exists()
 
@@ -426,7 +438,7 @@ def test_consume_recent_call_keeps_archived_record() -> None:
 
         with pytest.MonkeyPatch.context() as mp:
             mp.setattr("gptme_voice.realtime.server.time.time", lambda: 1_100.0)
-            server._consume_recent_call(record.caller_id)
+            asyncio.run(server._consume_recent_call(record.caller_id))
 
         assert archived_path.exists()
         payload = json.loads(archived_path.read_text())
@@ -471,7 +483,7 @@ def test_resume_carries_prior_archive_into_next_post_call() -> None:
 
             with pytest.MonkeyPatch.context() as mp:
                 mp.setattr("gptme_voice.realtime.server.time.time", lambda: 1_100.0)
-                resumed = server._consume_recent_call(first.caller_id)
+                resumed = await server._consume_recent_call(first.caller_id)
 
             assert resumed is not None
             assert cancelled_units == [first_unit]
@@ -613,7 +625,7 @@ def test_consume_recent_call_restores_pending_schedule_after_restart() -> None:
 
         with pytest.MonkeyPatch.context() as mp:
             mp.setattr("gptme_voice.realtime.server.time.time", lambda: 1_100.0)
-            resumed = second_server._consume_recent_call(record.caller_id)
+            resumed = asyncio.run(second_server._consume_recent_call(record.caller_id))
 
         assert resumed is not None
         assert cancelled_units == ["gptme-voice-post-call-restart"]


### PR DESCRIPTION
## Summary
- replace the in-process post-call sleep with immediate scheduling of a transient timer/service pair
- persist archive-chain + transient unit metadata in recent-call state so quick resumes still cancel the right follow-up after a restart
- add restart/resume regressions, including a subprocess test that proves the delayed follow-up survives the scheduler process exiting

## Testing
- uv run --project /home/bob/bob/gptme-contrib/packages/gptme-voice pytest /home/bob/bob/gptme-contrib/packages/gptme-voice/tests -q
