### PR TITLE
feat(voice): standup-call support via custom_params + standup_brief

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -154,6 +154,14 @@ def _build_fresh_call_greeting_instructions(
     )
 
 
+def _build_standup_call_instructions(brief_text: str) -> str:
+    """Build initial response instructions for a standup call with a pre-generated brief."""
+    return (
+        f"Deliver this standup brief to Erik verbatim, then wait for his response:\n\n"
+        f"{brief_text}"
+    )
+
+
 def _append_transcript_turn(
     transcript: list[TranscriptTurn], role: str, text: str
 ) -> None:
@@ -587,6 +595,7 @@ class VoiceServer:
         caller_id: str | None,
         from_number: str = "",
         handoff_id: str | None = None,
+        standup_brief: str | None = None,
     ) -> SessionBootstrap:
         instructions = self._instructions
         if from_number:
@@ -610,6 +619,15 @@ class VoiceServer:
                     self.resume_window_seconds,
                 ),
                 should_greet_first=False,
+            )
+
+        if standup_brief:
+            return SessionBootstrap(
+                instructions=f"{standup_brief}\n\n{instructions}",
+                should_greet_first=True,
+                initial_response_instructions=_build_standup_call_instructions(
+                    standup_brief
+                ),
             )
 
         return SessionBootstrap(
@@ -1039,11 +1057,13 @@ class VoiceServer:
                     custom_params = start.get("customParameters", {})
                     from_number = custom_params.get("from_number", "")
                     handoff_id = custom_params.get("handoff_id") or None
+                    standup_brief = custom_params.get("standup_brief") or None
                     caller_id = from_number or call_sid or stream_sid
                     bootstrap = await self._build_session_bootstrap(
                         caller_id=caller_id,
                         from_number=from_number,
                         handoff_id=handoff_id,
+                        standup_brief=standup_brief,
                     )
                     instructions = bootstrap.instructions
                     initial_response_instructions = (

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -610,6 +610,17 @@ class VoiceServer:
                 should_greet_first=False,
             )
 
+        # standup_brief takes priority over recent-call resume: an explicit outbound
+        # standup should always deliver the brief, not silently resume a prior session.
+        if standup_brief:
+            return SessionBootstrap(
+                instructions=f"{standup_brief}\n\n{instructions}",
+                should_greet_first=True,
+                initial_response_instructions=_build_standup_call_instructions(
+                    standup_brief
+                ),
+            )
+
         recent_call = await self._consume_recent_call(caller_id)
         if recent_call:
             return SessionBootstrap(
@@ -619,15 +630,6 @@ class VoiceServer:
                     self.resume_window_seconds,
                 ),
                 should_greet_first=False,
-            )
-
-        if standup_brief:
-            return SessionBootstrap(
-                instructions=f"{standup_brief}\n\n{instructions}",
-                should_greet_first=True,
-                initial_response_instructions=_build_standup_call_instructions(
-                    standup_brief
-                ),
             )
 
         return SessionBootstrap(

--- a/packages/gptme-voice/src/gptme_voice/realtime/twilio_integration.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/twilio_integration.py
@@ -2,7 +2,7 @@
 Twilio helpers for gptme-voice.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from html import escape as _html_escape
 from urllib.parse import urlsplit, urlunsplit
 
@@ -27,7 +27,7 @@ class OutboundCallSettings:
     auth_token: str
     from_number: str
     stream_url: str
-    custom_params: dict[str, str] | None = None
+    custom_params: dict[str, str] | None = field(default=None, hash=False)
 
 
 def _get_config_env(name: str) -> str | None:

--- a/packages/gptme-voice/src/gptme_voice/realtime/twilio_integration.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/twilio_integration.py
@@ -27,6 +27,7 @@ class OutboundCallSettings:
     auth_token: str
     from_number: str
     stream_url: str
+    custom_params: dict[str, str] | None = None
 
 
 def _get_config_env(name: str) -> str | None:
@@ -114,7 +115,10 @@ def build_connect_stream_twiml(
 
 
 def resolve_outbound_call_settings(
-    *, from_number: str | None = None, public_base_url: str | None = None
+    *,
+    from_number: str | None = None,
+    public_base_url: str | None = None,
+    custom_params: dict[str, str] | None = None,
 ) -> OutboundCallSettings:
     """Resolve Twilio credentials and stream target for outbound calls."""
     resolved_from_number = from_number or _require_config_value("TWILIO_PHONE_NUMBER")
@@ -125,6 +129,7 @@ def resolve_outbound_call_settings(
         auth_token=_require_config_value("TWILIO_AUTH_TOKEN"),
         from_number=resolved_from_number,
         stream_url=build_stream_url(resolved_public_base_url),
+        custom_params=custom_params,
     )
 
 
@@ -147,6 +152,6 @@ def create_outbound_call(
     call = client.calls.create(
         to=to_number,
         from_=settings.from_number,
-        twiml=build_connect_stream_twiml(settings.stream_url),
+        twiml=build_connect_stream_twiml(settings.stream_url, settings.custom_params),
     )
     return call.sid


### PR DESCRIPTION
## Summary

- Adds `custom_params: dict[str, str] | None = None` field to `OutboundCallSettings` (frozen dataclass); wired through `resolve_outbound_call_settings` and `create_outbound_call` so callers can attach arbitrary key/value pairs to the Twilio Media Stream as `<Parameter>` elements
- `_build_session_bootstrap` gains a `standup_brief` parameter: when provided, it prepends the brief text to the session instructions and sets `should_greet_first=True` with `initial_response_instructions` that tell the agent to deliver the brief verbatim before waiting for Erik's response
- New module-level helper `_build_standup_call_instructions(brief_text)` encapsulates the standup delivery prompt
- WebSocket handler extracts `standup_brief` from Twilio `customParameters` and passes it to `_build_session_bootstrap`

The intended flow: Bob runs `daily-brief-generator.py` before placing the call, then passes `standup_brief=<text>` in `custom_params` when calling `create_outbound_call`. The voice server picks it up from the Twilio `start` event and delivers it as the opening statement.

## Test plan

- [x] All 106 existing tests pass (`uv run pytest packages/gptme-voice/tests/ -q`)
- [x] `test_build_connect_stream_twiml_with_custom_params` — custom params rendered as `<Parameter>` elements
- [x] `test_create_outbound_call_uses_twilio_client` — twiml generation still correct
- [x] `test_build_session_bootstrap_*` tests — existing bootstrap paths unaffected
- [ ] Manual end-to-end test: place outbound call with `standup_brief` in custom_params and verify brief is read aloud