### PR TITLE
feat(github-hygiene): warning-only issue-hygiene Action prototype

### DIFF
--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -1,0 +1,68 @@
+name: Issue Hygiene (warning-only)
+
+# Warning-only prototype: on every newly-opened issue, run gptme against a
+# narrow prompt and post AT MOST ONE marker-tagged comment with duplicate /
+# missing-info / routing hints.
+#
+# This workflow NEVER closes issues, NEVER edits labels, and NEVER edits the
+# issue body. It is intentionally reusable (workflow_call) so downstream repos
+# can adopt it with a one-liner once we're happy with false-positive rates.
+#
+# Source: scripts/github_hygiene/issue_hygiene.py
+# Research: knowledge/research/2026-04-23-opencode-github-hygiene-agents.md
+#           (in Bob's private brain repo; public summary in PR)
+
+on:
+  issues:
+    types: [opened]
+  workflow_call:
+    inputs:
+      issue-number:
+        description: "Issue number to check (defaults to triggering issue)."
+        required: false
+        type: number
+      model:
+        description: "Optional gptme --model override."
+        required: false
+        type: string
+    secrets:
+      gptme-provider-key:
+        description: "API key gptme should use (e.g. OPENAI_API_KEY)."
+        required: false
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  hygiene:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install gptme
+        run: |
+          uv tool install gptme
+
+      - name: Run hygiene check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPTME_MODEL: ${{ inputs.model }}
+          OPENAI_API_KEY: ${{ secrets.gptme-provider-key }}
+        run: |
+          ISSUE_NUMBER="${{ inputs.issue-number || github.event.issue.number }}"
+          if [ -z "$ISSUE_NUMBER" ]; then
+            echo "No issue number available; nothing to do."
+            exit 0
+          fi
+          uv run python scripts/github_hygiene/issue_hygiene.py \
+            --repo "$GITHUB_REPOSITORY" \
+            --issue "$ISSUE_NUMBER"

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Install gptme
         run: |
-          uv tool install gptme
+          uv tool install "gptme>=0.21,<1"
 
       - name: Run hygiene check
         env:

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -11,10 +11,27 @@ name: Issue Hygiene (warning-only)
 # Source: scripts/github_hygiene/issue_hygiene.py
 # Research: knowledge/research/2026-04-23-opencode-github-hygiene-agents.md
 #           (in Bob's private brain repo; public summary in PR)
+#
+# Staged rollout: manual dispatch only on gptme-contrib first. Promote to
+# `issues: opened` auto-trigger only after a one-week false-positive audit.
+# See README.md for full rollout plan.
 
 on:
-  issues:
-    types: [opened]
+  workflow_dispatch:
+    inputs:
+      issue-number:
+        description: "Issue number to run hygiene check on."
+        required: true
+        type: number
+      model:
+        description: "Optional gptme --model override."
+        required: false
+        type: string
+      provider-key-env:
+        description: "Env var name for the provider API key (e.g. ANTHROPIC_API_KEY)."
+        required: false
+        default: "OPENAI_API_KEY"
+        type: string
   workflow_call:
     inputs:
       issue-number:
@@ -25,9 +42,13 @@ on:
         description: "Optional gptme --model override."
         required: false
         type: string
+      provider-key-env:
+        description: "Env var name for the provider API key (e.g. ANTHROPIC_API_KEY)."
+        required: false
+        type: string
     secrets:
       gptme-provider-key:
-        description: "API key gptme should use (e.g. OPENAI_API_KEY)."
+        description: "API key gptme should use."
         required: false
 
 permissions:
@@ -56,8 +77,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPTME_MODEL: ${{ inputs.model }}
-          OPENAI_API_KEY: ${{ secrets.gptme-provider-key }}
+          GPTME_PROVIDER_KEY: ${{ secrets.gptme-provider-key }}
+          GPTME_PROVIDER_KEY_ENV: ${{ inputs.provider-key-env || 'OPENAI_API_KEY' }}
         run: |
+          # Export the provider key under the caller-specified env var name.
+          if [ -n "$GPTME_PROVIDER_KEY" ]; then
+            export "${GPTME_PROVIDER_KEY_ENV}=${GPTME_PROVIDER_KEY}"
+          fi
           ISSUE_NUMBER="${{ inputs.issue-number || github.event.issue.number }}"
           if [ -z "$ISSUE_NUMBER" ]; then
             echo "No issue number available; nothing to do."

--- a/scripts/github_hygiene/README.md
+++ b/scripts/github_hygiene/README.md
@@ -1,0 +1,99 @@
+# GitHub Hygiene Action (warning-only)
+
+Prototype of a gptme-powered GitHub Action that posts at most **one
+warning-only comment** on newly-opened issues covering:
+
+- **Likely duplicates** — scanned against recent open issues
+- **Missing info** — version, OS, repro steps, expected vs actual
+- **Routing suggestion** — a single label hint
+
+It never closes issues, never edits labels, never edits the issue body. If the
+model finds nothing to say it emits the sentinel `NO_ISSUES` and the
+orchestrator skips commenting.
+
+Inspired by OpenCode's `duplicate-issues.yml`/`triage.yml` pattern, with the
+aggressive 2-hour auto-close policy deliberately left out. See the Bob research
+note linked from the PR for the full peer analysis.
+
+## Layout
+
+```
+scripts/github_hygiene/
+├── issue_hygiene.py          # Orchestrator (idempotency + prompt render)
+├── prompts/
+│   └── issue-hygiene.md      # Prompt template (uses str.format placeholders)
+├── test_issue_hygiene.py     # Marker + prompt-render tests (no I/O)
+└── README.md                 # This file
+```
+
+## Idempotency
+
+Every comment posted by this orchestrator leads with an HTML marker:
+
+```
+<!-- gptme-issue-hygiene: v1 -->
+```
+
+Before calling gptme, the orchestrator fetches the issue's comments and skips
+if any comment already carries the marker. The marker is versioned on purpose:
+a schema-breaking change (new sections, different output contract) must bump
+`v1` to `v2` so already-processed issues can be re-evaluated.
+
+## Local dry-run
+
+```shell
+# Requires gh authenticated against the target repo and gptme in PATH
+uv run python scripts/github_hygiene/issue_hygiene.py \
+  --repo gptme/gptme-contrib \
+  --issue 123 \
+  --dry-run
+```
+
+`--dry-run` renders the prompt, calls gptme, and prints the comment that
+would be posted without touching GitHub. Useful for calibrating the prompt
+against real recent issues.
+
+## Tests
+
+```shell
+uv run pytest scripts/github_hygiene/test_issue_hygiene.py -v
+```
+
+Tests cover:
+
+- Marker is versioned, present exactly once, and hidden as an HTML comment.
+- Every `{…}` placeholder in the prompt template is substituted.
+- Empty issue bodies and empty label lists render sensibly.
+- Issue bodies containing `{` / `}` (e.g. JSON snippets) do not trip `format`.
+- `NO_ISSUES` skip token matches the literal string in the prompt template.
+
+No network or subprocess calls are exercised — the orchestrator's `gh` and
+`gptme` wrappers are thin and will be exercised in the staged rollout.
+
+## Using the reusable workflow
+
+In a downstream repo's `.github/workflows/issue-hygiene.yml`:
+
+```yaml
+name: Issue Hygiene
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  hygiene:
+    uses: gptme/gptme-contrib/.github/workflows/issue-hygiene.yml@master
+    secrets:
+      gptme-provider-key: ${{ secrets.OPENAI_API_KEY }}
+```
+
+## Staged rollout
+
+1. **Land the prototype behind manual dispatch** on `gptme-contrib` only.
+2. **One week warning-only** on `gptme-contrib`; audit comments for
+   false-positive rate.
+3. If FP rate is low, promote to `gptme/gptme`.
+4. Only then consider expanding beyond hygiene (e.g. label application).
+
+Do not copy OpenCode's 2-hour auto-close window until the false-positive rate
+is demonstrated low on a small repo first.

--- a/scripts/github_hygiene/issue_hygiene.py
+++ b/scripts/github_hygiene/issue_hygiene.py
@@ -60,6 +60,7 @@ def gh(args: list[str], *, check: bool = True) -> str:
         capture_output=True,
         text=True,
         check=check,
+        timeout=60,
     )
     return result.stdout
 
@@ -200,6 +201,7 @@ def post_comment(repo: str, issue_number: int, body: str) -> None:
     subprocess.run(
         ["gh", "issue", "comment", str(issue_number), "--repo", repo, "--body", body],
         check=True,
+        timeout=60,
     )
 
 

--- a/scripts/github_hygiene/issue_hygiene.py
+++ b/scripts/github_hygiene/issue_hygiene.py
@@ -167,13 +167,18 @@ def run_gptme(prompt: str, *, model: str | None = None) -> str:
     cmd = ["gptme", "--non-interactive", "-"]
     if model:
         cmd.extend(["--model", model])
-    result = subprocess.run(
-        cmd,
-        input=prompt,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            cmd,
+            input=prompt,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=300,
+        )
+    except subprocess.TimeoutExpired:
+        sys.stderr.write("gptme timed out after 300s; skipping comment.\n")
+        return ""
     if result.returncode != 0:
         # Fail soft: print stderr but return empty to suppress commenting.
         sys.stderr.write(f"gptme failed (rc={result.returncode}):\n{result.stderr}\n")

--- a/scripts/github_hygiene/issue_hygiene.py
+++ b/scripts/github_hygiene/issue_hygiene.py
@@ -164,9 +164,10 @@ def run_gptme(prompt: str, *, model: str | None = None) -> str:
     We pipe the prompt via stdin and use `--non-interactive` so the action
     does not block waiting on stdin TTY.
     """
-    cmd = ["gptme", "--non-interactive", "-"]
+    cmd = ["gptme", "--non-interactive"]
     if model:
         cmd.extend(["--model", model])
+    cmd.append("-")
     try:
         result = subprocess.run(
             cmd,
@@ -231,7 +232,7 @@ def main(argv: list[str] | None = None) -> int:
     if not verdict:
         print("gptme returned empty output; skipping.")
         return 0
-    if verdict.strip() == SKIP_TOKEN:
+    if SKIP_TOKEN in verdict:
         print("gptme reported NO_ISSUES; skipping.")
         return 0
 

--- a/scripts/github_hygiene/issue_hygiene.py
+++ b/scripts/github_hygiene/issue_hygiene.py
@@ -164,7 +164,7 @@ def run_gptme(prompt: str, *, model: str | None = None) -> str:
     We pipe the prompt via stdin and use `--non-interactive` so the action
     does not block waiting on stdin TTY.
     """
-    cmd = ["gptme", "--non-interactive"]
+    cmd = ["gptme", "--non-interactive", "--tools", "read"]
     if model:
         cmd.extend(["--model", model])
     cmd.append("-")

--- a/scripts/github_hygiene/issue_hygiene.py
+++ b/scripts/github_hygiene/issue_hygiene.py
@@ -1,0 +1,245 @@
+"""GitHub issue hygiene orchestrator.
+
+Reads a newly-opened issue, runs `gptme` against a narrow prompt, and posts at
+most one warning-only comment marked with an HTML idempotency marker.
+
+Warning-only by design: no close policy, no label mutations, no edits.
+See: knowledge/research/2026-04-23-opencode-github-hygiene-agents.md (Bob's repo)
+
+Usage (inside a GitHub Action):
+
+    python -m issue_hygiene \
+        --repo "$GITHUB_REPOSITORY" \
+        --issue "$ISSUE_NUMBER" \
+        --prompt-file prompts/issue-hygiene.md
+
+Environment:
+    GH_TOKEN     — token with `issues: write` scope
+    GPTME_MODEL  — optional model override (defaults to env default)
+
+The script is idempotent: if a comment containing MARKER is already present on
+the issue, it exits 0 without calling gptme or posting anything. This matches
+OpenCode's `duplicate-issues.yml` pattern (HTML marker for replayable runs).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+MARKER = "<!-- gptme-issue-hygiene: v1 -->"
+SKIP_TOKEN = "NO_ISSUES"
+MAX_RECENT_ISSUES = 15
+MAX_BODY_CHARS = 6000
+
+
+@dataclass
+class Issue:
+    number: int
+    title: str
+    body: str
+    author: str
+    labels: list[str]
+
+
+@dataclass
+class RecentIssue:
+    number: int
+    title: str
+
+
+def gh(args: list[str], *, check: bool = True) -> str:
+    """Run `gh` CLI, return stdout. Raises CalledProcessError on non-zero."""
+    result = subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+    return result.stdout
+
+
+def fetch_issue(repo: str, issue_number: int) -> Issue:
+    raw = gh(
+        [
+            "issue",
+            "view",
+            str(issue_number),
+            "--repo",
+            repo,
+            "--json",
+            "number,title,body,author,labels",
+        ]
+    )
+    data = json.loads(raw)
+    body = (data.get("body") or "").strip()
+    if len(body) > MAX_BODY_CHARS:
+        body = body[:MAX_BODY_CHARS] + "\n…(truncated)"
+    return Issue(
+        number=int(data["number"]),
+        title=data["title"],
+        body=body,
+        author=(data.get("author") or {}).get("login", "unknown"),
+        labels=[label["name"] for label in data.get("labels", [])],
+    )
+
+
+def fetch_recent_issues(
+    repo: str, *, limit: int = MAX_RECENT_ISSUES, exclude: int | None = None
+) -> list[RecentIssue]:
+    raw = gh(
+        [
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--limit",
+            str(limit + 1),
+            "--json",
+            "number,title",
+        ]
+    )
+    rows = json.loads(raw)
+    out: list[RecentIssue] = []
+    for row in rows:
+        num = int(row["number"])
+        if exclude is not None and num == exclude:
+            continue
+        out.append(RecentIssue(number=num, title=row["title"]))
+        if len(out) >= limit:
+            break
+    return out
+
+
+def already_commented(repo: str, issue_number: int) -> bool:
+    raw = gh(
+        [
+            "issue",
+            "view",
+            str(issue_number),
+            "--repo",
+            repo,
+            "--json",
+            "comments",
+        ]
+    )
+    data = json.loads(raw)
+    for comment in data.get("comments", []):
+        if MARKER in (comment.get("body") or ""):
+            return True
+    return False
+
+
+def render_prompt(
+    template: str,
+    *,
+    repo: str,
+    issue: Issue,
+    recent: list[RecentIssue],
+) -> str:
+    recent_block = "\n".join(f"- #{r.number}: {r.title}" for r in recent) or "(none)"
+    labels_block = ", ".join(issue.labels) or "(none)"
+    body = issue.body or "(empty body)"
+    return template.format(
+        repo=repo,
+        issue_number=issue.number,
+        issue_title=issue.title,
+        issue_author=issue.author,
+        issue_labels=labels_block,
+        issue_body=body,
+        recent_issues=recent_block,
+    )
+
+
+def run_gptme(prompt: str, *, model: str | None = None) -> str:
+    """Invoke `gptme` in non-interactive mode with the rendered prompt.
+
+    We pipe the prompt via stdin and use `--non-interactive` so the action
+    does not block waiting on stdin TTY.
+    """
+    cmd = ["gptme", "--non-interactive", "-"]
+    if model:
+        cmd.extend(["--model", model])
+    result = subprocess.run(
+        cmd,
+        input=prompt,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        # Fail soft: print stderr but return empty to suppress commenting.
+        sys.stderr.write(f"gptme failed (rc={result.returncode}):\n{result.stderr}\n")
+        return ""
+    return result.stdout.strip()
+
+
+def build_comment(verdict: str) -> str:
+    preface = (
+        "**Automated issue hygiene check** — warning-only, posted by "
+        "[gptme](https://github.com/gptme/gptme). "
+        "If anything below is wrong, just reply and a human will sort it out.\n\n"
+    )
+    return f"{MARKER}\n\n{preface}{verdict.strip()}\n"
+
+
+def post_comment(repo: str, issue_number: int, body: str) -> None:
+    subprocess.run(
+        ["gh", "issue", "comment", str(issue_number), "--repo", repo, "--body", body],
+        check=True,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="owner/repo")
+    parser.add_argument("--issue", type=int, required=True, help="issue number")
+    parser.add_argument(
+        "--prompt-file",
+        type=Path,
+        default=Path(__file__).parent / "prompts" / "issue-hygiene.md",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Render prompt and print gptme output without posting a comment.",
+    )
+    args = parser.parse_args(argv)
+
+    if already_commented(args.repo, args.issue):
+        print(f"Already commented on {args.repo}#{args.issue}; skipping.")
+        return 0
+
+    issue = fetch_issue(args.repo, args.issue)
+    recent = fetch_recent_issues(args.repo, exclude=issue.number)
+    template = args.prompt_file.read_text()
+    prompt = render_prompt(template, repo=args.repo, issue=issue, recent=recent)
+
+    verdict = run_gptme(prompt, model=os.environ.get("GPTME_MODEL"))
+    if not verdict:
+        print("gptme returned empty output; skipping.")
+        return 0
+    if verdict.strip() == SKIP_TOKEN:
+        print("gptme reported NO_ISSUES; skipping.")
+        return 0
+
+    body = build_comment(verdict)
+    if args.dry_run:
+        print("--- dry run, would post: ---")
+        print(body)
+        return 0
+
+    post_comment(args.repo, args.issue, body)
+    print(f"Posted hygiene comment on {args.repo}#{args.issue}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/github_hygiene/prompts/issue-hygiene.md
+++ b/scripts/github_hygiene/prompts/issue-hygiene.md
@@ -1,0 +1,52 @@
+# Issue Hygiene Check
+
+You are reviewing a newly-opened GitHub issue for hygiene problems only.
+Your output is **warning-only** — do not close issues, do not remove content,
+do not accuse the author. Be concise and helpful.
+
+## Repo Context
+
+- **Repository**: `{repo}`
+- **Issue number**: `{issue_number}`
+- **Title**: `{issue_title}`
+- **Author**: `@{issue_author}`
+- **Labels**: `{issue_labels}`
+
+## Issue Body
+
+```
+{issue_body}
+```
+
+## Recent Open Issues (for duplicate scan)
+
+```
+{recent_issues}
+```
+
+## Task
+
+Produce a short markdown comment (≤ 250 words) covering at most these sections,
+and ONLY if each applies:
+
+1. **Likely duplicate?** — If you see one or more recent issues that look like
+   the same bug or request, list them as `- #N: <title>` with a one-line reason
+   each. Skip this section entirely if nothing matches.
+
+2. **Missing info?** — If the issue body lacks crucial reproduction info
+   (version, OS, steps, expected vs actual), list the missing items as bullets.
+   Be specific: "No gptme version" beats "needs more info".
+
+3. **Routing suggestion?** — If the issue clearly belongs to a specific area
+   (e.g. `area: tools`, `area: webui`, `area: server`), suggest one label.
+
+## Rules
+
+- If none of the three sections apply, output exactly the token `NO_ISSUES`.
+  The orchestrator will skip commenting on `NO_ISSUES`.
+- Never suggest closing the issue.
+- Never reformulate the issue body or paraphrase the author.
+- Never speculate about user intent or tone.
+- Do not include any preamble, sign-off, or meta commentary.
+
+Output the markdown body now, or `NO_ISSUES`.

--- a/scripts/github_hygiene/test_issue_hygiene.py
+++ b/scripts/github_hygiene/test_issue_hygiene.py
@@ -129,6 +129,26 @@ def test_skip_token_matches_with_role_prefix():
     assert issue_hygiene.SKIP_TOKEN in prefixed
 
 
+def test_run_gptme_restricts_tools():
+    # Prevent prompt injection from untrusted issue bodies executing shell/gh/python.
+    # --tools must restrict to a safe read-only allowlist so CI runners can't be
+    # exfiltrated via crafted issue content.
+    import inspect
+
+    src = inspect.getsource(issue_hygiene.run_gptme)
+    assert "--tools" in src, (
+        "run_gptme must pass --tools to gptme to restrict tool access and prevent "
+        "prompt injection from untrusted issue bodies executing arbitrary commands"
+    )
+    # Ensure dangerous tools are not in the allowlist
+    tools_line_pos = src.find('"--tools"')
+    assert tools_line_pos != -1
+    # The value after --tools should not include shell or ipython
+    after_tools = src[tools_line_pos:]
+    assert "shell" not in after_tools[:100], "shell tool must not be in allowlist"
+    assert "ipython" not in after_tools[:100], "ipython tool must not be in allowlist"
+
+
 def test_model_arg_comes_before_stdin_dash():
     # --model must precede the positional `-` arg; appending it after `-` breaks
     # most CLI parsers since positional args terminate option parsing.

--- a/scripts/github_hygiene/test_issue_hygiene.py
+++ b/scripts/github_hygiene/test_issue_hygiene.py
@@ -122,5 +122,26 @@ def test_skip_token_matches_template_contract():
     )
 
 
+def test_skip_token_matches_with_role_prefix():
+    # gptme may emit role-prefix framing like "assistant: NO_ISSUES"; the check
+    # must not require exact equality so those cases are silently skipped too.
+    prefixed = f"assistant: {issue_hygiene.SKIP_TOKEN}"
+    assert issue_hygiene.SKIP_TOKEN in prefixed
+
+
+def test_model_arg_comes_before_stdin_dash():
+    # --model must precede the positional `-` arg; appending it after `-` breaks
+    # most CLI parsers since positional args terminate option parsing.
+    import inspect
+
+    src = inspect.getsource(issue_hygiene.run_gptme)
+    # Verify `-` is appended last (after any --model extension)
+    append_dash_pos = src.rfind('append("-")')
+    extend_model_pos = src.rfind('cmd.extend(["--model"')
+    assert (
+        append_dash_pos > extend_model_pos
+    ), "--model must be added to cmd before the positional '-' is appended"
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))

--- a/scripts/github_hygiene/test_issue_hygiene.py
+++ b/scripts/github_hygiene/test_issue_hygiene.py
@@ -1,0 +1,126 @@
+"""Tests for issue_hygiene orchestrator.
+
+These tests cover the two things the prototype has to get right before it
+touches a real repo:
+
+1. The idempotency marker matches exactly what `build_comment` emits.
+2. The prompt template renders every expected field, including truncation and
+   empty-body handling, without raising KeyError.
+
+External I/O (`gh`, `gptme`) is never exercised here — those are thin
+subprocess wrappers and will be exercised in the staged rollout.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import issue_hygiene  # type: ignore[import-not-found]  # noqa: E402,I001
+
+
+REPO = "gptme/gptme-contrib"
+TEMPLATE_PATH = Path(__file__).parent / "prompts" / "issue-hygiene.md"
+
+
+def _issue(**overrides):
+    base = dict(
+        number=42,
+        title="gptme crashes on empty prompt",
+        body="Steps:\n1. Run gptme\n2. Hit enter\n\nCrash.",
+        author="alice",
+        labels=["bug"],
+    )
+    base.update(overrides)
+    return issue_hygiene.Issue(**base)
+
+
+def _recent(n: int = 3):
+    return [
+        issue_hygiene.RecentIssue(number=10 + i, title=f"example issue {i}")
+        for i in range(n)
+    ]
+
+
+def test_marker_is_stable_and_hidden_in_comment():
+    body = issue_hygiene.build_comment("- Missing gptme version")
+    assert issue_hygiene.MARKER in body
+    # Marker must be an HTML comment so GitHub does not render it.
+    assert body.strip().startswith("<!--")
+    # No duplicate markers (idempotency depends on this).
+    assert body.count(issue_hygiene.MARKER) == 1
+
+
+def test_marker_is_versioned():
+    # If we break the schema we should bump the version; leaving it at v1
+    # without intent would silently re-trigger on already-processed issues.
+    assert issue_hygiene.MARKER.endswith("v1 -->")
+
+
+def test_render_prompt_substitutes_every_placeholder():
+    template = TEMPLATE_PATH.read_text()
+    rendered = issue_hygiene.render_prompt(
+        template,
+        repo=REPO,
+        issue=_issue(),
+        recent=_recent(),
+    )
+    for placeholder in (
+        "{repo}",
+        "{issue_number}",
+        "{issue_title}",
+        "{issue_author}",
+        "{issue_labels}",
+        "{issue_body}",
+        "{recent_issues}",
+    ):
+        assert placeholder not in rendered, f"unfilled placeholder: {placeholder}"
+
+    assert REPO in rendered
+    assert "42" in rendered
+    assert "gptme crashes on empty prompt" in rendered
+    assert "@alice" in rendered
+    assert "- #10: example issue 0" in rendered
+
+
+def test_render_prompt_handles_empty_body_and_no_labels():
+    template = TEMPLATE_PATH.read_text()
+    rendered = issue_hygiene.render_prompt(
+        template,
+        repo=REPO,
+        issue=_issue(body="", labels=[]),
+        recent=[],
+    )
+    assert "(empty body)" in rendered
+    assert "(none)" in rendered  # labels and recent both fall back to (none)
+
+
+def test_render_prompt_does_not_crash_on_format_conflicts():
+    # Issue bodies often contain `{` and `}` (e.g. JSON snippets). The renderer
+    # must not interpret those as format placeholders.
+    template = TEMPLATE_PATH.read_text()
+    tricky = _issue(body='{"error": "unexpected {bracket}"}')
+    rendered = issue_hygiene.render_prompt(template, repo=REPO, issue=tricky, recent=[])
+    assert '"error": "unexpected {bracket}"' in rendered
+
+
+def test_build_comment_contains_warning_framing():
+    body = issue_hygiene.build_comment("- Possible duplicate of #1")
+    assert "warning-only" in body.lower()
+    assert "- Possible duplicate of #1" in body
+
+
+def test_skip_token_matches_template_contract():
+    template = TEMPLATE_PATH.read_text()
+    assert issue_hygiene.SKIP_TOKEN in template, (
+        "SKIP_TOKEN must match the exact string the prompt tells the model "
+        "to emit when nothing is wrong."
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Prototype of a gptme-powered **warning-only** GitHub Actions workflow that runs against newly-opened issues and posts at most ONE marker-tagged comment covering:

- **Likely duplicates** — scanned against recent open issues
- **Missing info** — version, OS, repro steps, expected vs actual
- **Routing suggestion** — one label hint

The action never closes issues, never edits labels, never edits the issue body. If the model finds nothing to say it emits the sentinel `NO_ISSUES` and the orchestrator skips commenting entirely.

Inspired by OpenCode's `duplicate-issues.yml` / `triage.yml` pattern, with the aggressive 2-hour auto-close window deliberately **left out** until false-positive rate is demonstrated low on `gptme-contrib` first.

This is idea #168 from Bob's strategic backlog; research note in Bob's brain repo: `knowledge/research/2026-04-23-opencode-github-hygiene-agents.md`.

## Layout

| Path | Purpose |
|---|---|
| `.github/workflows/issue-hygiene.yml` | Reusable (`workflow_call`) workflow |
| `scripts/github_hygiene/issue_hygiene.py` | Orchestrator (idempotency + prompt render) |
| `scripts/github_hygiene/prompts/issue-hygiene.md` | Prompt template |
| `scripts/github_hygiene/test_issue_hygiene.py` | Marker + render tests (no I/O) |
| `scripts/github_hygiene/README.md` | Layout, dry-run, staged rollout |

## Idempotency

Every posted comment leads with:

    <!-- gptme-issue-hygiene: v1 -->

Before calling `gptme`, the orchestrator checks whether any existing comment carries the marker; if so, it exits 0 without calling the model. The marker is **versioned on purpose** so a schema-breaking change (new sections / different output contract) can bump to `v2` and re-evaluate already-processed issues.

## Tests (7/7 pass, no network / subprocess)

- Marker is versioned, present exactly once, and hidden as an HTML comment
- Every ``{…}`` placeholder in the prompt template is substituted
- Empty body / empty label list render sensibly
- Bodies with literal `{` / `}` (JSON snippets etc.) don't trip `str.format`
- `NO_ISSUES` skip token matches the prompt template literal
- Comment body contains the "warning-only" framing

## Staged rollout (not in this PR)

1. Land prototype behind **manual dispatch only** on `gptme-contrib`
2. One week warning-only, **audit comments for false-positive rate**
3. If FP rate is low → promote to `gptme/gptme`
4. Only then consider expanding beyond hygiene (label application, etc.)

Do **not** copy OpenCode's 2-hour auto-close window until the false-positive rate is demonstrated low on a small repo first.

## Test plan

- [x] Unit tests pass locally (`uv run pytest scripts/github_hygiene/test_issue_hygiene.py -v` → 7/7)
- [x] Lint clean (`uv run ruff check scripts/github_hygiene/`)
- [x] Workflow YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Manual dispatch on one real `gptme-contrib` issue (post-merge, warning-only)
- [ ] One-week false-positive audit on `gptme-contrib`
- [ ] Promote to `gptme/gptme` only if FP rate is low

Keeping as **draft** while the prompt gets calibrated against real recent issues.