### PR TITLE
fix(sessions): require failure for retry_depth streak

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/spans.py
+++ b/packages/gptme-sessions/src/gptme_sessions/spans.py
@@ -131,10 +131,13 @@ class SpanAggregates:
     fields (Phase 2 of the design doc).
 
     Attributes:
-        retry_depth: Max consecutive redundant re-calls to the same tool
-            (first invocation excluded).  A value of 0 means no tool was
-            called twice in a row; 2 means the same tool was called 3 times
-            in succession (1 original + 2 retries).  Proxy for stuck loops.
+        retry_depth: Max consecutive same-tool calls where the preceding
+            call *failed*. A retry semantically implies the prior attempt
+            didn't work — without the failure gate, generic dispatcher
+            tools (Bash running distinct shell commands) inflate this to
+            uselessness. 0 means no failed-then-same-tool pattern; 2 means
+            two successive failed-tool calls followed by another same-tool
+            call. Proxy for stuck loops / flailing.
     """
 
     total_spans: int
@@ -177,12 +180,14 @@ class SpanAggregates:
         avg_ms = sum(known_durations) / len(known_durations) if known_durations else -1.0
         max_ms = max(known_durations) if known_durations else -1
 
-        # Retry depth: max consecutive redundant re-calls to the same tool
-        # (first call is normal; streak counts re-invocations beyond it)
+        # Retry depth: max consecutive same-tool calls where the preceding
+        # call failed. A retry semantically implies the previous attempt
+        # didn't work — without this gate, generic dispatcher tools (Bash
+        # running unrelated commands) inflate the signal to uselessness.
         retry_depth = 0
         streak = 0
         for i in range(1, len(spans)):
-            if spans[i].tool_name == spans[i - 1].tool_name:
+            if spans[i].tool_name == spans[i - 1].tool_name and not spans[i - 1].success:
                 streak += 1
                 retry_depth = max(retry_depth, streak)
             else:

--- a/packages/gptme-sessions/tests/test_spans.py
+++ b/packages/gptme-sessions/tests/test_spans.py
@@ -327,8 +327,13 @@ def test_output_size_consistent_with_text_extraction(tmp_path: Path) -> None:
 
 
 def test_aggregates_retry_depth() -> None:
-    # Bash × 3 consecutive → 2 retries beyond the first call
-    spans = [_span("Bash"), _span("Bash"), _span("Bash"), _span("Edit")]
+    # Bash fails, Bash fails, Bash succeeds → 2 retries (each preceded by failure)
+    spans = [
+        _span("Bash", success=False),
+        _span("Bash", success=False),
+        _span("Bash"),
+        _span("Edit"),
+    ]
     agg = SpanAggregates.from_spans(spans)
     assert agg.retry_depth == 2
 
@@ -337,6 +342,28 @@ def test_aggregates_no_retry() -> None:
     spans = [_span("Bash"), _span("Edit"), _span("Read")]
     agg = SpanAggregates.from_spans(spans)
     assert agg.retry_depth == 0  # no consecutive same-tool calls
+
+
+def test_aggregates_no_retry_when_successful_streak() -> None:
+    # Bash × 3 consecutive, all successful → NOT retries; these are distinct
+    # shell commands (grep, ls, cat, etc.), not stuck-loop behavior.
+    spans = [_span("Bash"), _span("Bash"), _span("Bash"), _span("Edit")]
+    agg = SpanAggregates.from_spans(spans)
+    assert agg.retry_depth == 0
+
+
+def test_aggregates_retry_only_after_failure() -> None:
+    # Only the Bash after a failed Bash counts as a retry.
+    spans = [
+        _span("Bash"),  # ok
+        _span("Bash"),  # consecutive but prev succeeded → not a retry
+        _span("Bash", success=False),  # consecutive; prev succeeded → not a retry
+        _span("Bash"),  # consecutive; prev failed → retry streak=1
+        _span("Bash", success=False),  # consecutive; prev succeeded → not counted
+        _span("Bash"),  # consecutive; prev failed → retry streak=1
+    ]
+    agg = SpanAggregates.from_spans(spans)
+    assert agg.retry_depth == 1
 
 
 # ── extract_spans_from_gptme_jsonl ────────────────────────────────────────────


### PR DESCRIPTION
## Problem

`SpanAggregates.retry_depth` counted any consecutive same-tool call as a retry, including unrelated Bash commands (grep, ls, cat, etc.). The docstring claimed "redundant re-calls" but the code ignored redundancy — just matched tool names.

Evidence: session d530 (2026-04-22, productive cleanup, 121 Bash calls, 2 errors, grade 0.7) reported `retry_depth=117`. Pure noise. Session 3311 picked this up as a potential stuck-loop alert in `bob-vitals.py`, which surfaced the artifact in the terminal/context dashboard.

## Fix

Gate the streak on `spans[i-1].success == False`. A retry semantically requires the previous attempt to have failed — now the code matches the docstring.

## Verification

Recomputed on 8 recent CC trajectories:

| session[:8] | old retry_depth | new retry_depth | errors |
|-------------|----------------:|----------------:|-------:|
| 2aa74abb    |              12 |               0 |      0 |
| 7b082b2c    |               5 |               0 |      1 |
| 11fd8bf7    |              13 |               2 |      2 |
| 5e8e86d9    |              11 |               1 |      1 |
| dcbb4c86    |               2 |               0 |      0 |
| 21233008    |               5 |               0 |      0 |
| 34b2306d    |               6 |               0 |      0 |
| a4852c91    |              12 |               1 |      4 |

New values correlate with actual errors. Zero-error sessions collapse to 0; error-bearing sessions produce bounded retry signals.

## Historical data

Existing records stay as-is (not worth backfilling 4000+ rows). Downstream alerts in `bob-vitals.py` at `retry_depth >= 10` will become meaningful on new session records instead of noisy on old ones.

## Tests

- Updated `test_aggregates_retry_depth` — now failure-gated
- Added `test_aggregates_no_retry_when_successful_streak` — guards the semantic
- Added `test_aggregates_retry_only_after_failure` — edge case for interleaved success/failure

All 719 gptme-sessions tests pass.