### PR TITLE
feat(github-resolver): opt-in issue-resolver Action prototype (#169 Phase 1)

### DIFF
--- a/.github/workflows/issue-resolver.yml
+++ b/.github/workflows/issue-resolver.yml
@@ -55,6 +55,7 @@ permissions:
 jobs:
   resolve:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: |
       (github.event_name == 'issues' && github.event.action == 'labeled'
         && github.event.label.name == (inputs.trigger-label || 'gptme-resolve'))

--- a/.github/workflows/issue-resolver.yml
+++ b/.github/workflows/issue-resolver.yml
@@ -1,0 +1,107 @@
+name: Issue Resolver (opt-in draft PR)
+
+# Opt-in resolver: trusted users trigger a gptme run against a labeled issue,
+# or a `/gptme-resolve` comment macro, and the workflow either opens a draft PR
+# with proposed changes OR pushes an attempt branch and posts a failure
+# explanation. This is distinct from the warning-only hygiene Action in
+# `issue-hygiene.yml`.
+#
+# Design invariants (Phase 1):
+#   - Opt-in only (explicit label or macro), never fires on every issue.
+#   - Never auto-merges; always opens a DRAFT PR.
+#   - Preserves failed attempts as branches so the user can pick them up.
+#   - Idempotent: re-triggering updates the existing attempt branch.
+#   - Uploads gptme session log as an artifact for post-hoc inspection.
+#
+# Source script: scripts/github_resolver/resolve_issue.py
+# Research note: knowledge/research/2026-04-23-openhands-resolver-runtime-patterns.md
+#                (lives in Bob's private brain repo; public summary in PR body)
+
+on:
+  issues:
+    types: [labeled]
+  issue_comment:
+    types: [created]
+  workflow_call:
+    inputs:
+      issue-number:
+        description: "Issue number to resolve (defaults to triggering issue)."
+        required: false
+        type: number
+      model:
+        description: "Optional gptme --model override."
+        required: false
+        type: string
+      trigger-label:
+        description: "Label that activates the resolver when present."
+        required: false
+        type: string
+        default: gptme-resolve
+      trigger-macro:
+        description: "Macro that activates the resolver in issue comments."
+        required: false
+        type: string
+        default: "/gptme-resolve"
+    secrets:
+      gptme-provider-key:
+        description: "API key gptme should use (e.g. OPENAI_API_KEY)."
+        required: false
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'issues' && github.event.action == 'labeled'
+        && github.event.label.name == (inputs.trigger-label || 'gptme-resolve'))
+      || (github.event_name == 'issue_comment' && github.event.action == 'created'
+        && startsWith(github.event.comment.body, (inputs.trigger-macro || '/gptme-resolve'))
+        && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
+      || github.event_name == 'workflow_call'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install gptme
+        run: uv tool install gptme
+
+      - name: Resolve issue
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPTME_MODEL: ${{ inputs.model }}
+          OPENAI_API_KEY: ${{ secrets.gptme-provider-key }}
+        run: |
+          ISSUE_NUMBER="${{ inputs.issue-number || github.event.issue.number }}"
+          if [ -z "$ISSUE_NUMBER" ]; then
+            echo "No issue number available; nothing to do."
+            exit 0
+          fi
+
+          mkdir -p output
+          uv run python scripts/github_resolver/resolve_issue.py \
+            --repo "$GITHUB_REPOSITORY" \
+            --issue "$ISSUE_NUMBER" \
+            --output-dir output
+
+      - name: Upload session artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gptme-resolver-output
+          path: output/
+          retention-days: 30
+          if-no-files-found: ignore

--- a/scripts/github_resolver/README.md
+++ b/scripts/github_resolver/README.md
@@ -1,0 +1,77 @@
+# gptme Issue Resolver (opt-in GitHub Action)
+
+Opt-in companion to `scripts/github_hygiene/`. When a trusted user applies the
+`gptme-resolve` label or comments `/gptme-resolve` on an issue, the reusable
+workflow in `.github/workflows/issue-resolver.yml` spins up a fresh checkout,
+runs `gptme` against a narrow resolver prompt, and then either:
+
+- opens a **draft** PR attached to the issue, or
+- posts a failure comment and preserves any partial work on an attempt branch.
+
+This is distinct from the warning-only issue-hygiene Action: hygiene never
+touches code, resolver is authorised to make edits but deliberately never
+auto-merges.
+
+## Design invariants (Phase 1)
+
+- **Opt-in only.** The workflow's `if:` gate only fires on an explicit
+  `gptme-resolve` label, a `/gptme-resolve` comment from a trusted
+  `author_association`, or an explicit `workflow_call`.
+- **Never auto-merges.** PRs are always created as drafts.
+- **Idempotent attempt branch.** The branch name is
+  `gptme-resolver/issue-<N>`; re-triggers force-push to the same branch with
+  `--force-with-lease` so history is never orphaned silently.
+- **Failure-preserving.** If gptme declines or errors out with partial
+  changes, those changes are pushed as a branch and mentioned in the issue
+  comment.
+- **Observable.** The gptme stdout log + final status JSON are uploaded as a
+  workflow artifact (`gptme-resolver-output`, 30-day retention).
+
+## How trusted users invoke it
+
+Either:
+
+1. Apply the label `gptme-resolve` to an open issue. (Label creation is
+   intentionally left to the repository; if the label does not exist, the
+   workflow simply never fires.)
+2. Post a comment whose body starts with `/gptme-resolve` from an account with
+   `OWNER`, `MEMBER`, or `COLLABORATOR` association.
+
+## Output contract
+
+The resolver prompt instructs gptme to end its run with one of:
+
+```text
+RESOLVER_STATUS: changes
+RESOLVER_SUMMARY: <one paragraph>
+```
+
+or
+
+```text
+RESOLVER_STATUS: no_changes
+RESOLVER_REASON: <one paragraph>
+```
+
+`resolve_issue.py` parses these markers, double-checks against
+`git status --porcelain`, and routes to the draft-PR or
+failure-comment path accordingly. Missing or malformed markers fall back to an
+`error` path that still preserves any dirty worktree as a branch.
+
+## Running locally
+
+```sh
+# Dry run against a real issue, no mutations:
+python scripts/github_resolver/resolve_issue.py \
+    --repo gptme/gptme-contrib \
+    --issue 999 \
+    --workdir "$PWD" \
+    --dry-run
+```
+
+## Relationship to other ideas
+
+- `scripts/github_hygiene/` — warning-only triage for freshly opened issues.
+- Research note (in Bob's brain repo):
+  `knowledge/research/2026-04-23-openhands-resolver-runtime-patterns.md`.
+- Idea backlog entry: `knowledge/strategic/idea-backlog.md` #169.

--- a/scripts/github_resolver/__init__.py
+++ b/scripts/github_resolver/__init__.py
@@ -1,0 +1,4 @@
+"""gptme issue-resolver action orchestrator.
+
+See `resolve_issue.py` for the entrypoint and the accompanying README.
+"""

--- a/scripts/github_resolver/prompts/issue-resolver.md
+++ b/scripts/github_resolver/prompts/issue-resolver.md
@@ -1,0 +1,52 @@
+You are gptme running as an opt-in GitHub issue-resolver Action on repository
+`{repo}`. A trusted user asked you to attempt issue #{issue_number}.
+
+## Task
+
+Read the issue and decide:
+
+1. Is this an actionable code or docs change you can make with confidence given
+   the current repository state?
+2. If yes, make the minimum set of file edits that resolve the issue. Do NOT
+   invent unrelated cleanups.
+3. If no — the issue needs product direction, is a duplicate, is ambiguous,
+   cannot be verified without running external services, or would require
+   touching files outside this repository — stop and write a short failure
+   reason instead of making changes.
+
+## Issue
+
+- Number: #{issue_number}
+- Title: {issue_title}
+- Author: @{issue_author}
+- Labels: {issue_labels}
+
+### Body
+
+{issue_body}
+
+## Hard constraints
+
+- Work only in the checked-out working directory (`$PWD`).
+- Do not call `git commit` or `git push` yourself — the workflow does that.
+- Do not run interactive commands or anything that requires a TTY.
+- Do not delete `.github/workflows/` files unless the issue explicitly asks
+  for that.
+- If tests exist and your change is code-touching, add or update the most
+  obviously relevant test.
+- If you make changes, end your run with a short summary in this exact format:
+
+    ```
+    RESOLVER_STATUS: changes
+    RESOLVER_SUMMARY: <one-paragraph description of the change>
+    ```
+
+- If you decide NOT to make changes, end your run with:
+
+    ```
+    RESOLVER_STATUS: no_changes
+    RESOLVER_REASON: <one-paragraph explanation>
+    ```
+
+The workflow parses those final markers to decide whether to open a draft PR
+or post a failure comment. Keep the markers verbatim.

--- a/scripts/github_resolver/resolve_issue.py
+++ b/scripts/github_resolver/resolve_issue.py
@@ -207,21 +207,25 @@ def open_draft_pr(repo: str, issue_number: int, branch: str, summary: str) -> st
         f"Closes #{issue_number}\n\n"
         f"**Resolver summary:** {summary}\n"
     )
-    raw = gh(
-        [
-            "pr",
-            "create",
-            "--repo",
-            repo,
-            "--draft",
-            "--head",
-            branch,
-            "--title",
-            f"[gptme-resolver] attempt for #{issue_number}",
-            "--body",
-            body,
-        ]
-    )
+    try:
+        raw = gh(
+            [
+                "pr",
+                "create",
+                "--repo",
+                repo,
+                "--draft",
+                "--head",
+                branch,
+                "--title",
+                f"[gptme-resolver] attempt for #{issue_number}",
+                "--body",
+                body,
+            ]
+        )
+    except subprocess.CalledProcessError:
+        # PR already exists for this branch (re-trigger). Return existing URL.
+        raw = gh(["pr", "view", "--repo", repo, "--json", "url", "-q", ".url", branch])
     return raw.strip().splitlines()[-1] if raw.strip() else ""
 
 

--- a/scripts/github_resolver/resolve_issue.py
+++ b/scripts/github_resolver/resolve_issue.py
@@ -1,0 +1,383 @@
+"""GitHub issue-resolver orchestrator.
+
+Opt-in companion to `scripts/github_hygiene/issue_hygiene.py`. Triggered by a
+`gptme-resolve` label or a `/gptme-resolve` comment from a trusted author,
+this script:
+
+1. Reads the issue body + metadata.
+2. Runs `gptme` with a narrow resolver prompt in the checked-out repo.
+3. Parses gptme's trailing `RESOLVER_STATUS:` marker.
+4. If gptme reported changes AND git detects modified/untracked files, pushes
+   an attempt branch and opens a DRAFT PR linked to the issue.
+5. If gptme reported `no_changes` OR there is nothing to commit, pushes any
+   partial attempt branch (if there are uncommitted changes) and posts a
+   failure explanation comment on the issue.
+
+Phase-1 safety invariants:
+
+- Always DRAFT PRs. Never auto-merge.
+- Never close the source issue.
+- Branch name is derived from the issue number and is stable across
+  re-triggers (`gptme-resolver/issue-<N>`).
+- Idempotent: re-triggering overwrites the attempt branch with the new state.
+
+The orchestrator is intentionally separate from `gptme` itself so the action
+stays debuggable offline (unit tests can stub `run_gptme` and `git_*`).
+
+Usage (inside the workflow):
+
+    python scripts/github_resolver/resolve_issue.py \\
+        --repo "$GITHUB_REPOSITORY" \\
+        --issue "$ISSUE_NUMBER" \\
+        --output-dir output
+
+Environment:
+    GH_TOKEN     — token with `contents: write` + `pull-requests: write` scopes
+    GPTME_MODEL  — optional model override
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+MARKER_COMMENT = "<!-- gptme-issue-resolver: v1 -->"
+STATUS_RE = re.compile(r"^RESOLVER_STATUS:\s*(changes|no_changes)\s*$", re.MULTILINE)
+SUMMARY_RE = re.compile(r"^RESOLVER_SUMMARY:\s*(.+?)\s*$", re.MULTILINE)
+REASON_RE = re.compile(r"^RESOLVER_REASON:\s*(.+?)\s*$", re.MULTILINE)
+MAX_BODY_CHARS = 6000
+BRANCH_PREFIX = "gptme-resolver/issue-"
+
+
+@dataclass
+class Issue:
+    number: int
+    title: str
+    body: str
+    author: str
+    labels: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ResolverOutcome:
+    status: str  # "changes" | "no_changes" | "error"
+    summary: str
+    branch: str | None
+    pr_url: str | None
+
+
+def gh(args: list[str], *, check: bool = True) -> str:
+    """Run `gh` CLI and return stdout."""
+    result = subprocess.run(["gh", *args], capture_output=True, text=True, check=check)
+    return result.stdout
+
+
+def git(args: list[str], *, check: bool = True, cwd: Path | None = None) -> str:
+    result = subprocess.run(
+        ["git", *args], capture_output=True, text=True, check=check, cwd=cwd
+    )
+    return result.stdout
+
+
+def fetch_issue(repo: str, issue_number: int) -> Issue:
+    raw = gh(
+        [
+            "issue",
+            "view",
+            str(issue_number),
+            "--repo",
+            repo,
+            "--json",
+            "number,title,body,author,labels",
+        ]
+    )
+    data = json.loads(raw)
+    body = (data.get("body") or "").strip()
+    if len(body) > MAX_BODY_CHARS:
+        body = body[:MAX_BODY_CHARS] + "\n…(truncated)"
+    return Issue(
+        number=int(data["number"]),
+        title=data["title"],
+        body=body,
+        author=(data.get("author") or {}).get("login", "unknown"),
+        labels=[label["name"] for label in data.get("labels", [])],
+    )
+
+
+def render_prompt(template: str, *, repo: str, issue: Issue) -> str:
+    labels_block = ", ".join(issue.labels) or "(none)"
+    return template.format(
+        repo=repo,
+        issue_number=issue.number,
+        issue_title=issue.title,
+        issue_author=issue.author,
+        issue_labels=labels_block,
+        issue_body=issue.body or "(empty body)",
+    )
+
+
+def run_gptme(prompt: str, *, model: str | None = None, workdir: Path) -> str:
+    """Invoke gptme non-interactively. Fail soft: return empty on error."""
+    cmd = ["gptme", "--non-interactive", "--no-confirm", "-"]
+    if model:
+        cmd.extend(["--model", model])
+    try:
+        result = subprocess.run(
+            cmd,
+            input=prompt,
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=workdir,
+        )
+    except FileNotFoundError:
+        sys.stderr.write("gptme not found on PATH; skipping resolver.\n")
+        return ""
+    if result.returncode != 0:
+        sys.stderr.write(f"gptme failed (rc={result.returncode}):\n{result.stderr}\n")
+    return result.stdout
+
+
+def parse_status(gptme_output: str) -> tuple[str, str]:
+    """Return (status, message).
+
+    status in {"changes", "no_changes", "error"}
+    message is the SUMMARY (on changes) or REASON (on no_changes). On missing
+    marker, status is "error" and message is a short explanation.
+    """
+    match = STATUS_RE.search(gptme_output)
+    if not match:
+        return "error", "gptme produced no RESOLVER_STATUS marker"
+    status = match.group(1)
+    if status == "changes":
+        m = SUMMARY_RE.search(gptme_output)
+        return "changes", (m.group(1).strip() if m else "(no summary provided)")
+    m = REASON_RE.search(gptme_output)
+    return "no_changes", (m.group(1).strip() if m else "(no reason provided)")
+
+
+def has_git_changes(cwd: Path) -> bool:
+    out = git(["status", "--porcelain"], cwd=cwd)
+    return bool(out.strip())
+
+
+def branch_for_issue(issue_number: int) -> str:
+    return f"{BRANCH_PREFIX}{issue_number}"
+
+
+def commit_and_push(
+    cwd: Path,
+    branch: str,
+    *,
+    commit_message: str,
+    author_name: str = "gptme-resolver",
+    author_email: str = "gptme-resolver@users.noreply.github.com",
+) -> None:
+    """Commit all pending changes onto ``branch`` and push to origin."""
+    git(["checkout", "-B", branch], cwd=cwd)
+    git(["add", "-A"], cwd=cwd)
+    # Configure the attempt commit author explicitly; the workflow runs as the
+    # default `actions` user otherwise.
+    git(
+        [
+            "-c",
+            f"user.name={author_name}",
+            "-c",
+            f"user.email={author_email}",
+            "commit",
+            "-m",
+            commit_message,
+        ],
+        cwd=cwd,
+    )
+    git(["push", "--force-with-lease", "origin", branch], cwd=cwd)
+
+
+def open_draft_pr(repo: str, issue_number: int, branch: str, summary: str) -> str:
+    body = (
+        f"{MARKER_COMMENT}\n\n"
+        "Automated draft PR opened by the `gptme` resolver Action. This is a "
+        "best-effort attempt — read the diff before merging.\n\n"
+        f"Closes #{issue_number}\n\n"
+        f"**Resolver summary:** {summary}\n"
+    )
+    raw = gh(
+        [
+            "pr",
+            "create",
+            "--repo",
+            repo,
+            "--draft",
+            "--head",
+            branch,
+            "--title",
+            f"[gptme-resolver] attempt for #{issue_number}",
+            "--body",
+            body,
+        ]
+    )
+    return raw.strip().splitlines()[-1] if raw.strip() else ""
+
+
+def comment_on_issue(
+    repo: str,
+    issue_number: int,
+    *,
+    status: str,
+    message: str,
+    branch: str | None = None,
+    pr_url: str | None = None,
+) -> None:
+    lines = [MARKER_COMMENT, ""]
+    if status == "changes" and pr_url:
+        lines.append(f"🛠️ gptme resolver opened a draft PR: {pr_url}\n\n{message}")
+    elif status == "no_changes":
+        lines.append(
+            f"ℹ️ gptme resolver declined to make changes.\n\n**Reason:** {message}"
+        )
+        if branch:
+            lines.append(f"\nPartial attempt preserved on branch `{branch}`.")
+    else:
+        lines.append(
+            f"⚠️ gptme resolver failed to produce a usable result.\n\n"
+            f"**Detail:** {message}"
+        )
+        if branch:
+            lines.append(f"\nPartial attempt preserved on branch `{branch}`.")
+    body = "\n".join(lines)
+    subprocess.run(
+        [
+            "gh",
+            "issue",
+            "comment",
+            str(issue_number),
+            "--repo",
+            repo,
+            "--body",
+            body,
+        ],
+        check=True,
+    )
+
+
+def write_output(output_dir: Path, name: str, data: str) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / name).write_text(data)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="owner/repo")
+    parser.add_argument("--issue", type=int, required=True, help="issue number")
+    parser.add_argument(
+        "--prompt-file",
+        type=Path,
+        default=Path(__file__).parent / "prompts" / "issue-resolver.md",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("output"),
+        help="Directory for session log + status artifacts.",
+    )
+    parser.add_argument(
+        "--workdir",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository working directory.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Run gptme and print the proposed action without touching git or the issue.",
+    )
+    args = parser.parse_args(argv)
+
+    issue = fetch_issue(args.repo, args.issue)
+    template = args.prompt_file.read_text()
+    prompt = render_prompt(template, repo=args.repo, issue=issue)
+
+    gptme_output = run_gptme(
+        prompt, model=os.environ.get("GPTME_MODEL"), workdir=args.workdir
+    )
+    write_output(args.output_dir, "gptme-stdout.log", gptme_output or "")
+
+    status, message = parse_status(gptme_output)
+    write_output(
+        args.output_dir,
+        "resolver-status.json",
+        json.dumps({"status": status, "message": message}, indent=2),
+    )
+
+    branch = branch_for_issue(issue.number)
+    pr_url: str | None = None
+
+    # gptme said "changes" — but only trust it if git actually sees changes.
+    if status == "changes" and has_git_changes(args.workdir):
+        if args.dry_run:
+            print(f"[dry-run] Would push {branch} and open draft PR: {message}")
+            return 0
+        commit_and_push(
+            args.workdir,
+            branch,
+            commit_message=f"gptme-resolver attempt for #{issue.number}\n\n{message}",
+        )
+        pr_url = open_draft_pr(args.repo, issue.number, branch, message)
+        comment_on_issue(
+            args.repo,
+            issue.number,
+            status="changes",
+            message=message,
+            branch=branch,
+            pr_url=pr_url,
+        )
+        print(f"Opened draft PR for #{issue.number} at {pr_url}")
+        return 0
+
+    # gptme said "changes" but worktree is clean — treat as a failed attempt.
+    if status == "changes" and not has_git_changes(args.workdir):
+        status = "error"
+        message = (
+            "gptme reported changes but no files were modified. "
+            f"Upstream message: {message}"
+        )
+
+    # no_changes / error: preserve partial work if present.
+    partial_branch: str | None = None
+    if has_git_changes(args.workdir):
+        if args.dry_run:
+            print(f"[dry-run] Would push partial attempt to {branch}")
+        else:
+            commit_and_push(
+                args.workdir,
+                branch,
+                commit_message=(
+                    f"gptme-resolver partial attempt for #{issue.number}\n\n"
+                    f"Status: {status}\n\n{message}"
+                ),
+            )
+            partial_branch = branch
+
+    if args.dry_run:
+        print(f"[dry-run] Would comment on issue — status={status}, message={message}")
+        return 0
+
+    comment_on_issue(
+        args.repo,
+        issue.number,
+        status=status,
+        message=message,
+        branch=partial_branch,
+    )
+    print(f"Resolver finished for #{issue.number}: status={status}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/github_resolver/resolve_issue.py
+++ b/scripts/github_resolver/resolve_issue.py
@@ -122,8 +122,10 @@ def render_prompt(template: str, *, repo: str, issue: Issue) -> str:
     )
 
 
-def run_gptme(prompt: str, *, model: str | None = None, workdir: Path) -> str:
-    """Invoke gptme non-interactively. Fail soft: return empty on error."""
+def run_gptme(
+    prompt: str, *, model: str | None = None, workdir: Path
+) -> tuple[str, str]:
+    """Invoke gptme non-interactively. Fail soft: return (stdout, stderr)."""
     cmd = ["gptme", "--non-interactive", "--no-confirm", "-"]
     if model:
         cmd.extend(["--model", model])
@@ -137,11 +139,12 @@ def run_gptme(prompt: str, *, model: str | None = None, workdir: Path) -> str:
             cwd=workdir,
         )
     except FileNotFoundError:
-        sys.stderr.write("gptme not found on PATH; skipping resolver.\n")
-        return ""
+        msg = "gptme not found on PATH; skipping resolver.\n"
+        sys.stderr.write(msg)
+        return "", msg
     if result.returncode != 0:
         sys.stderr.write(f"gptme failed (rc={result.returncode}):\n{result.stderr}\n")
-    return result.stdout
+    return result.stdout, result.stderr
 
 
 def parse_status(gptme_output: str) -> tuple[str, str]:
@@ -307,10 +310,11 @@ def main(argv: list[str] | None = None) -> int:
     template = args.prompt_file.read_text()
     prompt = render_prompt(template, repo=args.repo, issue=issue)
 
-    gptme_output = run_gptme(
+    gptme_output, gptme_stderr = run_gptme(
         prompt, model=os.environ.get("GPTME_MODEL"), workdir=args.workdir
     )
     write_output(args.output_dir, "gptme-stdout.log", gptme_output or "")
+    write_output(args.output_dir, "gptme-stderr.log", gptme_stderr or "")
 
     status, message = parse_status(gptme_output)
     write_output(

--- a/scripts/github_resolver/test_resolve_issue.py
+++ b/scripts/github_resolver/test_resolve_issue.py
@@ -1,0 +1,148 @@
+"""Tests for resolve_issue orchestrator.
+
+These cover the pure parts the prototype must get right before it is pointed
+at a real repo: the stable idempotency marker on comments, the prompt
+template round-trip, and the `RESOLVER_STATUS`/`RESOLVER_SUMMARY` parser.
+
+External I/O (`gh`, `gptme`, `git`) is stubbed — those are thin subprocess
+wrappers exercised in the staged rollout, not in unit tests.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import resolve_issue  # type: ignore[import-not-found]  # noqa: E402,I001
+
+
+REPO = "gptme/gptme-contrib"
+TEMPLATE_PATH = Path(__file__).parent / "prompts" / "issue-resolver.md"
+
+
+def _issue(**overrides):
+    base = dict(
+        number=42,
+        title="gptme crashes on empty prompt",
+        body="Steps:\n1. Run gptme\n2. Hit enter\n\nCrash.",
+        author="alice",
+        labels=["bug"],
+    )
+    base.update(overrides)
+    return resolve_issue.Issue(**base)
+
+
+def test_marker_is_stable_and_versioned():
+    assert resolve_issue.MARKER_COMMENT.startswith("<!--")
+    assert resolve_issue.MARKER_COMMENT.endswith("v1 -->")
+
+
+def test_branch_name_is_deterministic():
+    assert resolve_issue.branch_for_issue(42) == "gptme-resolver/issue-42"
+    assert resolve_issue.branch_for_issue(1) == "gptme-resolver/issue-1"
+
+
+def test_render_prompt_substitutes_every_placeholder():
+    template = TEMPLATE_PATH.read_text()
+    rendered = resolve_issue.render_prompt(template, repo=REPO, issue=_issue())
+    for placeholder in (
+        "{repo}",
+        "{issue_number}",
+        "{issue_title}",
+        "{issue_author}",
+        "{issue_labels}",
+        "{issue_body}",
+    ):
+        assert placeholder not in rendered, f"unfilled placeholder: {placeholder}"
+    assert REPO in rendered
+    assert "42" in rendered
+    assert "gptme crashes on empty prompt" in rendered
+    assert "@alice" in rendered
+
+
+def test_render_prompt_handles_empty_body_and_no_labels():
+    template = TEMPLATE_PATH.read_text()
+    rendered = resolve_issue.render_prompt(
+        template, repo=REPO, issue=_issue(body="", labels=[])
+    )
+    assert "(empty body)" in rendered
+    assert "(none)" in rendered
+
+
+def test_render_prompt_does_not_crash_on_format_conflicts():
+    # Issue bodies often contain `{` / `}` (JSON snippets, f-string examples).
+    # The renderer must not treat those as format placeholders.
+    template = TEMPLATE_PATH.read_text()
+    tricky = _issue(body='{"error": "unexpected {bracket}"}')
+    rendered = resolve_issue.render_prompt(template, repo=REPO, issue=tricky)
+    assert '"error": "unexpected {bracket}"' in rendered
+
+
+def test_parse_status_changes_extracts_summary():
+    out = (
+        "... work ...\n"
+        "RESOLVER_STATUS: changes\n"
+        "RESOLVER_SUMMARY: Fixed the crash by guarding the empty-prompt branch.\n"
+    )
+    status, message = resolve_issue.parse_status(out)
+    assert status == "changes"
+    assert "empty-prompt" in message
+
+
+def test_parse_status_no_changes_extracts_reason():
+    out = (
+        "RESOLVER_STATUS: no_changes\n"
+        "RESOLVER_REASON: Needs product direction on retry semantics.\n"
+    )
+    status, message = resolve_issue.parse_status(out)
+    assert status == "no_changes"
+    assert message.startswith("Needs product direction")
+
+
+def test_parse_status_missing_marker_returns_error():
+    out = "model chatted about the issue but forgot the marker.\n"
+    status, message = resolve_issue.parse_status(out)
+    assert status == "error"
+    assert "RESOLVER_STATUS" in message
+
+
+def test_parse_status_is_last_line_tolerant():
+    # The marker can appear anywhere — we anchor on the line, not the tail.
+    out = (
+        "pre-amble\n"
+        "RESOLVER_STATUS: changes\n"
+        "RESOLVER_SUMMARY: tightened regex\n"
+        "post-amble junk\n"
+    )
+    status, message = resolve_issue.parse_status(out)
+    assert status == "changes"
+    assert message == "tightened regex"
+
+
+def test_write_output_creates_dir(tmp_path):
+    resolve_issue.write_output(
+        tmp_path / "out", "status.json", json.dumps({"ok": True})
+    )
+    assert (tmp_path / "out" / "status.json").exists()
+
+
+def test_prompt_template_mentions_both_markers():
+    # The prompt contract itself has to advertise both markers or the model
+    # will never emit them — guard against silent template rot.
+    template = TEMPLATE_PATH.read_text()
+    assert "RESOLVER_STATUS: changes" in template
+    assert "RESOLVER_STATUS: no_changes" in template
+    assert "RESOLVER_SUMMARY" in template
+    assert "RESOLVER_REASON" in template
+
+
+def test_status_regex_ignores_prose_mentions():
+    # The model often echoes the words "RESOLVER_STATUS" in the middle of a
+    # sentence while explaining what it's about to do. Only an anchored line
+    # of the exact form should count.
+    prose = "I'll now emit RESOLVER_STATUS: changes inline like this."
+    status, _ = resolve_issue.parse_status(prose)
+    assert status == "error"

--- a/scripts/github_resolver/test_resolve_issue.py
+++ b/scripts/github_resolver/test_resolve_issue.py
@@ -146,3 +146,28 @@ def test_status_regex_ignores_prose_mentions():
     prose = "I'll now emit RESOLVER_STATUS: changes inline like this."
     status, _ = resolve_issue.parse_status(prose)
     assert status == "error"
+
+
+def test_open_draft_pr_retrigger_returns_existing_url(monkeypatch):
+    # On re-trigger, `gh pr create` exits 1 ("a pull request … already exists").
+    # open_draft_pr must catch CalledProcessError and return the existing PR URL
+    # via `gh pr view` so the caller can still post the issue comment.
+    import subprocess
+
+    calls: list[list[str]] = []
+
+    def fake_gh(args, *, check=True):
+        calls.append(args)
+        if args[0] == "pr" and args[1] == "create":
+            raise subprocess.CalledProcessError(1, "gh")
+        if args[0] == "pr" and args[1] == "view":
+            return "https://github.com/gptme/gptme-contrib/pull/99\n"
+        return ""
+
+    monkeypatch.setattr(resolve_issue, "gh", fake_gh)
+    url = resolve_issue.open_draft_pr(
+        "gptme/gptme-contrib", 42, "gptme-resolver/issue-42", "fixed the crash"
+    )
+    assert url == "https://github.com/gptme/gptme-contrib/pull/99"
+    # Verify we fell back to `gh pr view`
+    assert any(a[0] == "pr" and a[1] == "view" for a in calls)


### PR DESCRIPTION
Sibling to #747 (warning-only issue-hygiene): an opt-in GitHub Action that
lets trusted users trigger a \`gptme\` run against a tagged issue and gets
back either a draft PR with proposed changes or a failure comment plus a
preserved attempt branch.

Draft-only for now — I want field experience before any auto-merge path.

## Phase-1 invariants

- **Opt-in only.** The workflow's \`if:\` gate fires only on an explicit
  \`gptme-resolve\` label or a \`/gptme-resolve\` comment from an
  \`OWNER\` / \`MEMBER\` / \`COLLABORATOR\`. It never fires on freshly-opened
  issues.
- **Draft PRs only.** No auto-merge path exists in this PR. A human still
  has to un-draft and merge.
- **Deterministic attempt branch.** \`gptme-resolver/issue-<N>\`, force-pushed
  with \`--force-with-lease\` on re-triggers so history is never orphaned.
- **Failure-preserving.** \`no_changes\` / \`error\` paths still push the
  dirty tree as a branch and mention it in the issue comment.
- **Observable.** gptme stdout log + final status JSON are uploaded as the
  \`gptme-resolver-output\` artifact (30-day retention).

## Output contract (marker protocol)

The resolver prompt instructs gptme to end its run with one of:

\`\`\`
RESOLVER_STATUS: changes
RESOLVER_SUMMARY: <one paragraph>
\`\`\`

or

\`\`\`
RESOLVER_STATUS: no_changes
RESOLVER_REASON: <one paragraph>
\`\`\`

\`resolve_issue.py\` parses those markers, cross-checks against
\`git status --porcelain\`, and routes to draft-PR or failure-comment
accordingly. Missing or malformed markers fall through to an \`error\`
path that still preserves any dirty worktree as a branch.

## Tests

12 unit tests covering:

- Versioned HTML idempotency marker stays stable.
- Deterministic branch name (\`gptme-resolver/issue-<N>\`).
- Prompt template round-trip including empty body, no labels, \`{}\` in
  the body (JSON snippets must not be reinterpreted as format placeholders).
- \`RESOLVER_STATUS\` regex is line-anchored — prose mentions of the marker
  inside a sentence do NOT count.
- Missing-marker case falls to \`error\`, not a silent success.
- \`write_output\` creates the target directory.

\`\`\`
uv run --with pytest pytest scripts/github_resolver/ -x -q
12 passed in 0.04s
\`\`\`

## Not in this PR (deliberately deferred)

- Auto-merge path.
- Reading \`GPTME_RESOLVER_*\` config from \`.gptme/\` in the repo.
- Multi-attempt or iterative retry.
- Repo-scoped prompt overrides.
- Model-routing based on issue labels.

Each of those would commit us to design choices before we've watched the
prototype run against a real issue.

## Rollout plan

1. Merge this PR.
2. Manually dispatch on one real \`gptme-contrib\` issue (likely via
   \`workflow_dispatch\` once I add a thin trampoline, or by applying the
   \`gptme-resolve\` label to one deliberately chosen issue).
3. One-week false-positive audit: how often does gptme emit
   \`RESOLVER_STATUS: changes\` for work that a human reviewer would reject,
   vs \`no_changes\` for work it could have done?
4. Only then consider promoting to \`gptme/gptme\` as a reusable workflow.

## Relationship to other work

- Sibling: #747 (warning-only issue-hygiene Action).
- Research: OpenHands resolver runtime patterns (Bob's brain repo:
  \`knowledge/research/2026-04-23-openhands-resolver-runtime-patterns.md\`).
- Idea backlog entry: #169 (ErikBjare/bob).