### PR TITLE
fix(github): suppress permission-blocked merge_ready PRs (ErikBjare/bob#680)

### DIFF
--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -556,6 +556,48 @@ check_greptile_scores() {
     done
 }
 
+# Check if the bot account has already posted a maintainer-facing status comment
+# on this PR indicating that the ball is in the maintainer's court.
+#
+# Signals the bot acknowledged it lacks merge permission on the target repo, so
+# re-emitting merge_ready produces fake-ready churn (the same PR reappears every
+# cooldown window despite nothing being actionable).
+#
+# We check the full comment history (not just the last comment) because later
+# "CI is now green" status updates often overwrite the canonical waiting phrase,
+# but the acknowledgment is still valid — subsequent re-emits would still
+# produce the same "nothing changed" churn.
+#
+# Bot username is resolved from $BOT_USERNAME (default: TimeToBuildBob) to keep
+# the helper reusable across forks.
+#
+# Returns 0 when the maintainer-waiting signal is present (i.e. SUPPRESS),
+# 1 otherwise (emit as normal).
+has_maintainer_waiting_comment() {
+    local repo=$1
+    local number=$2
+    local bot="${BOT_USERNAME:-TimeToBuildBob}"
+
+    local bot_comments
+    bot_comments=$(gh api "repos/$repo/issues/$number/comments?per_page=100" \
+        --jq "[.[] | select(.user.login == \"$bot\") | .body] | join(\"\n\")" 2>/dev/null) || return 1
+
+    [ -n "$bot_comments" ] || return 1
+
+    # Match any of the canonical or real-world phrasings that signal "waiting
+    # only on a maintainer click." Matching is case-insensitive on the anchor
+    # word so minor capitalisation drift doesn't defeat the guard.
+    local lower
+    lower=$(printf '%s' "$bot_comments" | tr '[:upper:]' '[:lower:]')
+    case "$lower" in
+        *"waiting only on a maintainer click"*) return 0 ;;
+        *"waiting only on a maintainer merge click"*) return 0 ;;
+        *"ready to merge when convenient"*) return 0 ;;
+        *"blocked by missing mergepullrequest permission"*) return 0 ;;
+    esac
+    return 1
+}
+
 # Find PRs that are ready to merge: CI green, no conflicts, and Greptile score
 # is acceptable (>= 5/5, or no Greptile review at all for simple PRs).
 #
@@ -566,8 +608,14 @@ check_greptile_scores() {
 #   Cooldown: 12 hours — merge decisions shouldn't be nagged frequently.
 #   Re-emits when HEAD SHA changes (new commits may change merge readiness).
 #
-# API cost: Zero additional API calls. Reads Greptile score from the state file
-# written by check_greptile_scores() instead of re-fetching issue comments.
+# Suppression: If the bot already left a "waiting only on a maintainer click"
+# status comment (see has_maintainer_waiting_comment), we skip emitting for
+# that HEAD even after the cooldown expires. The state file is still bumped so
+# subsequent runs follow the normal cooldown path once a new HEAD arrives.
+#
+# API cost: +1 comments fetch per CLEAN/MERGEABLE candidate that passes the
+# Greptile and cooldown gates. Typical workload is a handful of PRs per cycle,
+# so the added cost is negligible compared to the existing PR search calls.
 check_merge_ready() {
     local repo=$1
     local prs=$2
@@ -618,6 +666,16 @@ check_merge_ready() {
             # HEAD changed or cooldown expired — re-emit
         fi
         # First-time discovery OR state change — emit immediately (no seed-only behavior)
+
+        # Suppress re-emits when the bot already signalled it is waiting only on
+        # a maintainer merge click. The state file is still updated so we stay
+        # on the normal cooldown schedule once the situation changes (new HEAD,
+        # new review, CI change that forces the "waiting" comment to be
+        # refreshed into a different status).
+        if has_maintainer_waiting_comment "$repo" "$pr_number"; then
+            echo "${head_sha}:${now}" > "$state_file"
+            continue
+        fi
 
         echo "${head_sha}:${now}" > "$state_file"
 

--- a/scripts/github/check-notifications.sh
+++ b/scripts/github/check-notifications.sh
@@ -154,13 +154,24 @@ is_permission_blocked_merge_ready_pr() {
     [[ "$is_draft" == "false" ]] || return 1
     [[ "$non_success_count" == "0" ]] || return 1
 
-    local last_bob_comment
-    last_bob_comment=$(gh api "repos/$repo/issues/$number/comments" \
-        --jq '[.[] | select(.user.login == "TimeToBuildBob")][-1].body // ""' 2>/dev/null) || return 1
+    # Check Bob's full comment history, not just the last comment — later
+    # routine "CI is now green" status updates often bury the canonical
+    # waiting phrase without invalidating the acknowledgment. Matches the
+    # signal set used by activity-gate.sh so the two suppression paths stay
+    # aligned (see ErikBjare/bob#680).
+    local bot_comments
+    bot_comments=$(gh api "repos/$repo/issues/$number/comments?per_page=100" \
+        --jq '[.[] | select(.user.login == "TimeToBuildBob") | .body] | join("\n")' 2>/dev/null) || return 1
 
-    [[ -n "$last_bob_comment" ]] || return 1
-    case "$last_bob_comment" in
-        *"waiting only on a maintainer click"*|*"waiting only on a maintainer merge click"*) ;;
+    [[ -n "$bot_comments" ]] || return 1
+
+    local lower
+    lower=$(printf '%s' "$bot_comments" | tr '[:upper:]' '[:lower:]')
+    case "$lower" in
+        *"waiting only on a maintainer click"*) ;;
+        *"waiting only on a maintainer merge click"*) ;;
+        *"ready to merge when convenient"*) ;;
+        *"blocked by missing mergepullrequest permission"*) ;;
         *) return 1 ;;
     esac
 


### PR DESCRIPTION
## Summary

`project-monitoring` was dispatching fake-ready sessions every 12-hour
cooldown for external PRs that are merge-ready but stuck behind
missing maintainer merge permission. The first status comment is
useful; the N-th "still merge-ready" session is pure churn.

This PR closes the loop in the two scripts that drive dispatch:
`activity-gate.sh` (project-monitoring source) and
`check-notifications.sh` (bob's interactive notification feed).

## What changed

- `activity-gate.sh::check_merge_ready` now calls a new
  `has_maintainer_waiting_comment` helper before emitting. If the bot
  already posted a maintainer-facing "ready to merge" signal, the
  state file is still updated (so cooldown semantics stay consistent)
  but no work item is emitted.
- `check-notifications.sh::is_permission_blocked_merge_ready_pr`
  realigned with the same signal set. It previously matched only the
  canonical phrase against the *last* bot comment, so any later "CI
  is now green" update defeated the guard in practice
  (verified against `ActivityWatch/aw-server-rust#589`).
- Both predicates now search the bot's full comment history
  (one page / 100 entries) with a shared, case-insensitive signal set:
  - `waiting only on a maintainer click` / `… merge click`
  - `ready to merge when convenient`
  - `blocked by missing MergePullRequest permission`

## Live verification

Tested against real PRs before opening this:

| PR | Expected | Observed |
|----|----------|----------|
| `ActivityWatch/aw-server-rust#589` (example from ErikBjare/bob#680) | SUPPRESS | SUPPRESS ✓ |
| `ActivityWatch/aw-server-rust#584` (still under review, no ready comment) | EMIT | EMIT ✓ |
| `ErikBjare/bob#680` (meta issue, no merge-ready comments) | EMIT | EMIT ✓ |

## Why this is safe

- `check_merge_ready` still gates on `mergeStateStatus == "CLEAN" and
  mergeable == "MERGEABLE"` upstream, so blocking reviews / CI
  failures naturally re-open the channel.
- Cooldown / HEAD-SHA state tracking is unchanged: new commits
  re-emit immediately, and the state file is always refreshed so
  timing semantics never diverge.
- API cost: one extra `gh api …/comments` call per CLEAN+MERGEABLE
  candidate that passes the Greptile and cooldown gates. That's on
  the order of a handful per cycle.

## Test plan

- [x] `bash -n` and `shellcheck` clean on both files
- [x] Live-tested predicate against three real PRs (see table)
- [ ] (follow-up) Watch `bob-project-monitoring.service` logs for the
  first cycle after merge to confirm `ActivityWatch/aw-server-rust#589`
  is no longer dispatched.

Refs: ErikBjare/bob#680