### PR TITLE
feat(lessons): allow nested automation field in lesson frontmatter

### DIFF
--- a/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
+++ b/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
@@ -158,6 +158,10 @@ class LessonValidator:
           Increment when making significant keyword or content changes so effectiveness
           data can be correlated to a specific lesson variant.
         - ``automated_by`` / ``automated_date``: Set once when a lesson is automated.
+        - ``automation``: Structured automation metadata (alternative to the flat
+          ``automated_by``/``automated_date`` fields). Nested mapping that may carry
+          ``status`` (``automated``), ``validator`` (relative path to enforcer),
+          ``enforcement`` (``warning`` | ``error``), and ``automated_date``.
         - ``deprecated_by`` / ``deprecated_date``: Set once on deprecation.
         - ``archived_reason`` / ``archived_date``: Set once on archival.
 
@@ -189,6 +193,7 @@ class LessonValidator:
                 "version",
                 "automated_by",
                 "automated_date",
+                "automation",
                 "deprecated_by",
                 "deprecated_date",
                 "archived_reason",
@@ -205,6 +210,8 @@ class LessonValidator:
                 self._check_version_field(frontmatter["version"])
             if "target_grade" in frontmatter:
                 self._check_target_grade_field(frontmatter["target_grade"])
+            if "automation" in frontmatter:
+                self._check_automation_field(frontmatter["automation"])
 
         except (ValueError, yaml.YAMLError) as e:
             self.errors.append(f"Invalid YAML frontmatter: {e}")
@@ -276,6 +283,34 @@ class LessonValidator:
             self.errors.append(
                 f"target_grade contains unknown dimensions: {unknown_list} "
                 f"(allowed: {allowed})"
+            )
+
+    def _check_automation_field(self, value: object) -> None:
+        """Validate the optional ``automation`` frontmatter field.
+
+        Allowed sub-fields:
+        - ``status``: Lifecycle marker (typically ``automated``).
+        - ``validator``: Relative path to the enforcing script.
+        - ``enforcement``: ``warning`` or ``error``.
+        - ``automated_date``: ISO date the lesson was automated.
+        - ``notes``: Free-form description of partial automation or caveats.
+        """
+        if not isinstance(value, dict):
+            self.errors.append(
+                f"automation must be a mapping, got {type(value).__name__}"
+            )
+            return
+        allowed_sub = {"status", "validator", "enforcement", "automated_date", "notes"}
+        unknown = sorted(set(value.keys()) - allowed_sub)
+        if unknown:
+            self.warnings.append(
+                f"automation contains unknown sub-fields: {', '.join(unknown)} "
+                f"(allowed: {', '.join(sorted(allowed_sub))})"
+            )
+        enforcement = value.get("enforcement")
+        if enforcement is not None and enforcement not in ("warning", "error"):
+            self.errors.append(
+                f"automation.enforcement must be 'warning' or 'error', got {enforcement!r}"
             )
 
     def _validate_two_file_format(self):

--- a/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
+++ b/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
@@ -161,7 +161,8 @@ class LessonValidator:
         - ``automation``: Structured automation metadata (alternative to the flat
           ``automated_by``/``automated_date`` fields). Nested mapping that may carry
           ``status`` (``automated``), ``validator`` (relative path to enforcer),
-          ``enforcement`` (``warning`` | ``error``), and ``automated_date``.
+          ``enforcement`` (``warning`` | ``error``), ``automated_date``, and
+          ``notes`` (free-form description of partial automation or caveats).
         - ``deprecated_by`` / ``deprecated_date``: Set once on deprecation.
         - ``archived_reason`` / ``archived_date``: Set once on archival.
 
@@ -212,6 +213,15 @@ class LessonValidator:
                 self._check_target_grade_field(frontmatter["target_grade"])
             if "automation" in frontmatter:
                 self._check_automation_field(frontmatter["automation"])
+                flat_automation_fields = {"automated_by", "automated_date"} & set(
+                    frontmatter.keys()
+                )
+                if flat_automation_fields:
+                    self.warnings.append(
+                        f"Both 'automation' block and flat field(s) "
+                        f"{', '.join(sorted(flat_automation_fields))} are present; "
+                        "remove the flat fields in favour of the 'automation' block"
+                    )
 
         except (ValueError, yaml.YAMLError) as e:
             self.errors.append(f"Invalid YAML frontmatter: {e}")

--- a/packages/gptme-lessons-extras/tests/test_validate.py
+++ b/packages/gptme-lessons-extras/tests/test_validate.py
@@ -237,3 +237,86 @@ def test_target_grade_non_string_list_item_rejected():
         validator.validate()
         target_errors = [e for e in validator.errors if "target_grade" in e]
         assert target_errors, "Non-string target_grade entries should produce an error"
+
+
+# ---------------------------------------------------------------------------
+# automation field tests
+# ---------------------------------------------------------------------------
+
+
+_AUTOMATION_BLOCK = """\
+automation:
+  status: automated
+  validator: scripts/precommit/validators/validate_example.py
+  enforcement: {enforcement}
+  automated_date: 2026-04-19"""
+
+
+def test_automation_field_accepted():
+    """A well-formed automation mapping should be accepted silently."""
+    content = _VALID_LESSON.format(
+        extra=_AUTOMATION_BLOCK.format(enforcement="warning")
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        path = _write_lesson(Path(tmp), content)
+        validator = LessonValidator(path)
+        validator.validate()
+        assert not validator.errors, f"Unexpected errors: {validator.errors}"
+        automation_warnings = [w for w in validator.warnings if "automation" in w]
+        assert (
+            not automation_warnings
+        ), f"Unexpected automation warnings: {automation_warnings}"
+
+
+def test_automation_enforcement_error_accepted():
+    """enforcement: error should also be valid."""
+    content = _VALID_LESSON.format(extra=_AUTOMATION_BLOCK.format(enforcement="error"))
+    with tempfile.TemporaryDirectory() as tmp:
+        path = _write_lesson(Path(tmp), content)
+        validator = LessonValidator(path)
+        validator.validate()
+        assert not validator.errors, f"Unexpected errors: {validator.errors}"
+
+
+def test_automation_invalid_enforcement_rejected():
+    """enforcement must be 'warning' or 'error'."""
+    content = _VALID_LESSON.format(
+        extra=_AUTOMATION_BLOCK.format(enforcement="critical")
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        path = _write_lesson(Path(tmp), content)
+        validator = LessonValidator(path)
+        validator.validate()
+        automation_errors = [e for e in validator.errors if "automation" in e]
+        assert (
+            automation_errors
+        ), "Invalid automation.enforcement should produce an error"
+
+
+def test_automation_unknown_subfield_warns():
+    """Unknown sub-fields under automation should produce a warning (not error)."""
+    content = _VALID_LESSON.format(
+        extra="automation:\n  status: automated\n  weirdfield: nope"
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        path = _write_lesson(Path(tmp), content)
+        validator = LessonValidator(path)
+        validator.validate()
+        assert not [
+            e for e in validator.errors if "automation" in e
+        ], f"Unknown sub-fields should warn, not error: {validator.errors}"
+        warnings = [
+            w for w in validator.warnings if "automation" in w and "weirdfield" in w
+        ]
+        assert warnings, "Unknown automation sub-fields should produce a warning"
+
+
+def test_automation_must_be_mapping():
+    """automation as a non-mapping (e.g. a string) should be an error."""
+    content = _VALID_LESSON.format(extra='automation: "just a string"')
+    with tempfile.TemporaryDirectory() as tmp:
+        path = _write_lesson(Path(tmp), content)
+        validator = LessonValidator(path)
+        validator.validate()
+        automation_errors = [e for e in validator.errors if "automation" in e]
+        assert automation_errors, "Non-mapping automation value should produce an error"

--- a/packages/gptme-lessons-extras/tests/test_validate.py
+++ b/packages/gptme-lessons-extras/tests/test_validate.py
@@ -320,3 +320,20 @@ def test_automation_must_be_mapping():
         validator.validate()
         automation_errors = [e for e in validator.errors if "automation" in e]
         assert automation_errors, "Non-mapping automation value should produce an error"
+
+
+def test_automation_coexists_with_flat_fields_warns():
+    """Having both 'automation' block and flat automated_by/automated_date should warn."""
+    content = _VALID_LESSON.format(
+        extra="automation:\n  status: automated\nautomated_by: some-validator\nautomated_date: 2025-01-01"
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        path = _write_lesson(Path(tmp), content)
+        validator = LessonValidator(path)
+        validator.validate()
+        coexist_warnings = [
+            w for w in validator.warnings if "automation" in w and "automated_by" in w
+        ]
+        assert (
+            coexist_warnings
+        ), "Coexisting 'automation' block and flat automated_by field should warn"


### PR DESCRIPTION
## Summary

- Add `automation` to the allowed frontmatter fields in `LessonValidator`, plus structured sub-field validation.
- Before this change, every lesson using the dominant nested-automation convention was emitting a "Frontmatter should be minimal" warning despite using exactly the kind of stable, write-once metadata the validator's docstring endorses.

## Why

The validator restricted automation metadata to flat `automated_by` / `automated_date` fields, but both Bob's workspace (14 lessons) and gptme-contrib itself (`lessons/tools/markdown-codeblock-syntax.md`) use a nested mapping that carries `status`, `validator` (path), `enforcement` (warning/error), `automated_date`, and `notes` together:

```yaml
automation:
  status: automated
  validator: scripts/precommit/validators/validate_markdown_codeblock_syntax.py
  enforcement: warning
  automated_date: 2025-11-26
```

The nested form preserves the validator path and enforcement level — information the flat fields cannot express — and groups the whole automation story together next to the lesson. It is stable, write-once metadata, which is exactly what the frontmatter philosophy endorses.

## Changes

- Add `automation` to `allowed_fields` set in `_check_frontmatter`.
- Add `_check_automation_field` with structured sub-field validation:
  - Allowed sub-fields: `status`, `validator`, `enforcement`, `automated_date`, `notes`
  - Unknown sub-fields → **warning**, not error
  - `enforcement` must be `"warning"` or `"error"` if present → **error**
  - Non-mapping `automation` value → **error**
- Update the frontmatter-philosophy docstring to document the field.
- Add 5 new unit tests covering accept/reject cases.

## Impact

Running the updated validator against Bob's 204 local lessons:

- **Before**: 15 "Frontmatter should be minimal" warnings for `automation`.
- **After**: 1 remaining warning (unrelated — a missing companion-doc link).

## Test plan

- [x] `pytest packages/gptme-lessons-extras/tests/test_validate.py` — all 19 tests pass (14 existing + 5 new)
- [x] Re-ran validator across Bob's 204 lessons — no false-positive warnings on legitimate `automation:` usage
- [x] Verified gptme-contrib's own `lessons/tools/markdown-codeblock-syntax.md` is now clean
- [x] `enforcement: critical` still errors
- [x] `automation: "a string"` still errors
- [x] Unknown sub-fields still warn (so typos still get flagged, just not as policy violations)