### PR TITLE
feat(self-merge-check): allow WORKSPACE_REPO allowlist for trusted cross-repo PRs

### DIFF
--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -14,7 +14,12 @@ Policy summary:
 
 The workspace repo (the repo where the agent's brain lives) is detected automatically.
 Cross-repo PRs (agent pushing to external repos) are disqualified by default.
-To allow cross-repo merges, clear WORKSPACE_REPO (set it to empty string).
+To allow cross-repo merges, either:
+- Set WORKSPACE_REPO to a comma- or whitespace-separated allowlist of owner/name
+  entries (e.g. "ErikBjare/bob,gptme/gptme,gptme/gptme-contrib") — all other
+  category/CI/Greptile checks still apply.
+- Or clear WORKSPACE_REPO entirely (set it to empty string) to disable the
+  cross-repo restriction (not recommended; widens the merge surface).
 
 Usage:
     python3 scripts/github/self-merge-check.py <pr-url>
@@ -22,10 +27,10 @@ Usage:
     python3 scripts/github/self-merge-check.py --json <pr-url>
 
 Environment:
-    WORKSPACE_REPO  Override auto-detected workspace repo (owner/name format).
-                    Set to empty string to disable cross-repo restriction.
-                    Defaults to the repo inferred from `git remote get-url origin`
-                    in the script's directory tree.
+    WORKSPACE_REPO  Allowlist of workspace repos (owner/name), comma- or
+                    whitespace-separated. Auto-detected single repo used when
+                    unset. Set to empty string to disable the cross-repo
+                    restriction entirely.
 """
 
 from __future__ import annotations
@@ -179,6 +184,28 @@ def detect_workspace_repo() -> str:
                 break
             candidate = parent
     return ""
+
+
+def _parse_workspace_repos(value: str | None) -> list[str] | None:
+    """Parse a WORKSPACE_REPO value into an allowlist.
+
+    Returns:
+        None       — caller passed None (detection failed / unset)
+        []         — explicit empty-string opt-out of the cross-repo restriction
+        list[str]  — one or more owner/repo entries, comma- or whitespace-separated
+
+    Whitespace around entries is trimmed. Empty entries between separators
+    (e.g. ``"a/b,, c/d"``) are silently dropped.
+    """
+    if value is None:
+        return None
+    stripped = value.strip()
+    if not stripped:
+        return []
+    # Support both comma- and whitespace-separated input. Replace commas with
+    # spaces then split on whitespace to normalize across ``"a/b,c/d"``,
+    # ``"a/b c/d"``, and ``"a/b, c/d"``.
+    return [r for r in stripped.replace(",", " ").split() if r]
 
 
 def _parse_remote_url(url: str) -> str:
@@ -690,7 +717,53 @@ def classify_category(paths: list[str]) -> tuple[str | None, list[str]]:
     ]
 
 
-def evaluate_pr(repo: str, number: int, *, workspace_repo: str | None) -> CheckResult:
+def _check_workspace_repo(
+    repo: str, workspace_repos: list[str] | None
+) -> tuple[list[str], list[str]]:
+    """Evaluate the cross-repo policy against a PR's repo.
+
+    Returns a ``(reasons, warnings)`` pair. ``reasons`` disqualify the PR from
+    self-merge; ``warnings`` are informational only.
+
+    Semantics:
+    - ``workspace_repos is None``  → detection failed, disqualify (we cannot
+      tell whether the PR is cross-repo)
+    - ``workspace_repos == []``    → explicit opt-out, emit a warning but do
+      not disqualify on cross-repo grounds
+    - ``repo in workspace_repos``  → allowlisted, no reasons or warnings
+    - otherwise                    → cross-repo, disqualify
+    """
+    if workspace_repos is None:
+        return (
+            [
+                "Workspace repo could not be auto-detected; cross-repo restriction cannot be "
+                "enforced. Pass --workspace-repo or set WORKSPACE_REPO (use '' to opt out)."
+            ],
+            [],
+        )
+    if not workspace_repos:
+        return (
+            [],
+            [
+                "Workspace repo check disabled via WORKSPACE_REPO='' or --workspace-repo ''; "
+                "cross-repo restriction is not enforced."
+            ],
+        )
+    if repo not in workspace_repos:
+        allowed = ", ".join(workspace_repos)
+        return (
+            [
+                f"Cross-repo PR ({repo}) is not in allowed workspace repos: {allowed}. "
+                "Clear WORKSPACE_REPO or add this repo to the allowlist."
+            ],
+            [],
+        )
+    return [], []
+
+
+def evaluate_pr(
+    repo: str, number: int, *, workspace_repos: list[str] | None
+) -> CheckResult:
     pr = fetch_pr(repo, number)
     author = pr.get("author", {}).get("login", "")
     title = pr.get("title", "")
@@ -715,21 +788,11 @@ def evaluate_pr(repo: str, number: int, *, workspace_repo: str | None) -> CheckR
     elif author != current_user:
         result.reasons.append(f"PR author is {author}, expected {current_user}")
 
-    if workspace_repo is None:
-        result.reasons.append(
-            "Workspace repo could not be auto-detected; cross-repo restriction cannot be "
-            "enforced. Pass --workspace-repo or set WORKSPACE_REPO (use '' to opt out)."
-        )
-    elif not workspace_repo:
-        result.warnings.append(
-            "Workspace repo check disabled via WORKSPACE_REPO='' or --workspace-repo ''; "
-            "cross-repo restriction is not enforced."
-        )
-    elif repo != workspace_repo:
-        result.reasons.append(
-            f"Cross-repo PR ({repo}) is not eligible for workspace {workspace_repo}. "
-            "Clear WORKSPACE_REPO to disable cross-repo restriction."
-        )
+    cross_repo_reasons, cross_repo_warnings = _check_workspace_repo(
+        repo, workspace_repos
+    )
+    result.reasons.extend(cross_repo_reasons)
+    result.warnings.extend(cross_repo_warnings)
 
     if pr.get("isDraft"):
         result.reasons.append("PR is still a draft")
@@ -800,20 +863,25 @@ def format_human(result: CheckResult) -> str:
     return "\n".join(lines)
 
 
-def _resolve_workspace_repo(args: argparse.Namespace) -> str | None:
-    """Resolve workspace repo from CLI args, env, or auto-detection.
+def _resolve_workspace_repos(args: argparse.Namespace) -> list[str] | None:
+    """Resolve the workspace-repo allowlist from CLI args, env, or auto-detection.
+
+    ``--workspace-repo`` / ``WORKSPACE_REPO`` accept a comma- or whitespace-
+    separated list of ``owner/repo`` entries.
 
     Returns:
-        str  — explicit value (including "" to opt out of cross-repo restriction)
-        None — detection was attempted but failed; cross-repo restriction will disqualify
+        list[str]  — one or more allowed workspace repos
+        []         — explicit opt-out via empty string (cross-repo restriction disabled)
+        None       — detection was attempted but failed; cross-repo restriction
+                     will disqualify because we cannot tell whether the PR is cross-repo
     """
     cli_value: str | None = getattr(args, "workspace_repo", None)
     if cli_value is not None:
-        return cli_value  # explicit "" = opt out
+        return _parse_workspace_repos(cli_value)
     if "WORKSPACE_REPO" in os.environ:
-        return os.environ["WORKSPACE_REPO"]  # "" still means opt out
+        return _parse_workspace_repos(os.environ["WORKSPACE_REPO"])
     detected = detect_workspace_repo()
-    return detected if detected else None  # None = unknown, not opt-out
+    return [detected] if detected else None
 
 
 def main() -> int:
@@ -829,19 +897,20 @@ def main() -> int:
     parser.add_argument(
         "--workspace-repo",
         help=(
-            "Workspace repo (owner/name) for cross-repo policy. "
-            "Auto-detected from git remote if not provided."
+            "Workspace-repo allowlist (owner/name, comma- or whitespace-separated) "
+            "for cross-repo policy. Auto-detected single repo from git remote if "
+            "not provided. Pass '' to disable the cross-repo restriction entirely."
         ),
     )
     args = parser.parse_args()
-    workspace_repo = _resolve_workspace_repo(args)
+    workspace_repos = _resolve_workspace_repos(args)
 
     try:
         repo, number = parse_pr_target(args.pr, args.repo, args.number)
         result = evaluate_pr(
             repo,
             number,
-            workspace_repo=workspace_repo,
+            workspace_repos=workspace_repos,
         )
     except Exception as exc:
         if args.json:
@@ -853,8 +922,8 @@ def main() -> int:
     if args.json:
         print(json.dumps(asdict(result), indent=2))
     else:
-        if workspace_repo:
-            print(f"Workspace repo: {workspace_repo}")
+        if workspace_repos:
+            print(f"Workspace repos: {', '.join(workspace_repos)}")
         print(format_human(result))
 
     return 0 if result.eligible else 1

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -99,7 +99,7 @@ def test_evaluate_pr_blocks_changes_requested() -> None:
         result = self_merge_check.evaluate_pr(
             "gptme/gptme-contrib",
             999,
-            workspace_repo="gptme/gptme-contrib",
+            workspace_repos=["gptme/gptme-contrib"],
         )
 
     assert not result.eligible
@@ -366,8 +366,8 @@ def test_is_sensitive_path_handles_deploy_word_forms(path: str, expected: bool) 
     assert self_merge_check.is_sensitive_path(path) is expected
 
 
-def test_evaluate_pr_warns_when_workspace_repo_empty() -> None:
-    """Explicit opt-out (workspace_repo='') emits a warning but does not disqualify."""
+def test_evaluate_pr_warns_when_workspace_repos_empty() -> None:
+    """Explicit opt-out (workspace_repos=[]) emits a warning but does not disqualify."""
     pr_data = {
         "author": {"login": "TimeToBuildBob"},
         "title": "Test PR",
@@ -391,7 +391,7 @@ def test_evaluate_pr_warns_when_workspace_repo_empty() -> None:
         result = self_merge_check.evaluate_pr(
             "gptme/gptme-contrib",
             999,
-            workspace_repo="",  # explicit opt-out via WORKSPACE_REPO=''
+            workspace_repos=[],  # explicit opt-out via WORKSPACE_REPO=''
         )
 
     # Explicit opt-out → warning, but PR is still eligible
@@ -401,8 +401,8 @@ def test_evaluate_pr_warns_when_workspace_repo_empty() -> None:
     ), f"Explicit opt-out should not disqualify; reasons: {result.reasons}"
 
 
-def test_evaluate_pr_disqualified_when_workspace_repo_unknown() -> None:
-    """Detection failure (workspace_repo=None) must disqualify the PR."""
+def test_evaluate_pr_disqualified_when_workspace_repos_unknown() -> None:
+    """Detection failure (workspace_repos=None) must disqualify the PR."""
     pr_data = {
         "author": {"login": "TimeToBuildBob"},
         "title": "Test PR",
@@ -426,7 +426,7 @@ def test_evaluate_pr_disqualified_when_workspace_repo_unknown() -> None:
         result = self_merge_check.evaluate_pr(
             "gptme/gptme-contrib",
             999,
-            workspace_repo=None,  # detection failed — unknown workspace
+            workspace_repos=None,  # detection failed — unknown workspace
         )
 
     # Detection failure → disqualified (not just a warning)
@@ -494,14 +494,14 @@ def test_evaluate_pr_ineligible_on_auth_failure() -> None:
         result = self_merge_check.evaluate_pr(
             "gptme/gptme-contrib",
             999,
-            workspace_repo="gptme/gptme-contrib",
+            workspace_repos=["gptme/gptme-contrib"],
         )
 
     assert any("author-identity check failed" in r for r in result.reasons)
     assert not result.eligible
 
 
-def test_resolve_workspace_repo_honors_empty_env_opt_out() -> None:
+def test_resolve_workspace_repos_honors_empty_env_opt_out() -> None:
     """WORKSPACE_REPO='' should disable the cross-repo restriction (opt-out)."""
     import argparse
     import os
@@ -509,9 +509,86 @@ def test_resolve_workspace_repo_honors_empty_env_opt_out() -> None:
     args = argparse.Namespace(workspace_repo=None)
 
     with patch.dict(os.environ, {"WORKSPACE_REPO": ""}, clear=False):
-        workspace_repo = self_merge_check._resolve_workspace_repo(args)
+        workspace_repos = self_merge_check._resolve_workspace_repos(args)
 
-    assert workspace_repo == "", (
-        f"WORKSPACE_REPO='' should yield empty workspace_repo so cross-repo "
-        f"restriction is disabled; got: {workspace_repo!r}"
+    assert workspace_repos == [], (
+        f"WORKSPACE_REPO='' should yield [] so cross-repo restriction is "
+        f"disabled; got: {workspace_repos!r}"
     )
+
+
+# --- WORKSPACE_REPO allowlist parsing + cross-repo check --------------------
+
+
+def test_parse_workspace_repos_none() -> None:
+    assert self_merge_check._parse_workspace_repos(None) is None
+
+
+def test_parse_workspace_repos_empty_is_opt_out() -> None:
+    # Explicit empty string opts out of the cross-repo restriction entirely.
+    assert self_merge_check._parse_workspace_repos("") == []
+    assert self_merge_check._parse_workspace_repos("   ") == []
+
+
+def test_parse_workspace_repos_comma_separated() -> None:
+    assert self_merge_check._parse_workspace_repos("a/b,c/d") == ["a/b", "c/d"]
+
+
+def test_parse_workspace_repos_whitespace_separated() -> None:
+    assert self_merge_check._parse_workspace_repos("a/b c/d") == ["a/b", "c/d"]
+
+
+def test_parse_workspace_repos_mixed_and_trimmed() -> None:
+    # Trailing spaces, spaces around commas, multiple whitespace — all normalized.
+    assert self_merge_check._parse_workspace_repos("  a/b, c/d , e/f  ") == [
+        "a/b",
+        "c/d",
+        "e/f",
+    ]
+
+
+def test_parse_workspace_repos_skips_empty_entries() -> None:
+    assert self_merge_check._parse_workspace_repos("a/b,,c/d") == ["a/b", "c/d"]
+
+
+def test_check_workspace_repo_detection_failed_disqualifies() -> None:
+    reasons, warnings = self_merge_check._check_workspace_repo("gptme/gptme", None)
+    assert reasons and "could not be auto-detected" in reasons[0]
+    assert warnings == []
+
+
+def test_check_workspace_repo_opt_out_warns_but_allows() -> None:
+    reasons, warnings = self_merge_check._check_workspace_repo("gptme/gptme", [])
+    assert reasons == []
+    assert warnings and "cross-repo restriction is not enforced" in warnings[0]
+
+
+def test_check_workspace_repo_allowed_single() -> None:
+    reasons, warnings = self_merge_check._check_workspace_repo(
+        "ErikBjare/bob", ["ErikBjare/bob"]
+    )
+    assert reasons == []
+    assert warnings == []
+
+
+def test_check_workspace_repo_allowed_in_multi() -> None:
+    reasons, warnings = self_merge_check._check_workspace_repo(
+        "gptme/gptme",
+        ["ErikBjare/bob", "gptme/gptme", "gptme/gptme-contrib"],
+    )
+    assert reasons == []
+    assert warnings == []
+
+
+def test_check_workspace_repo_not_in_allowlist_disqualifies() -> None:
+    reasons, warnings = self_merge_check._check_workspace_repo(
+        "some-other/repo",
+        ["ErikBjare/bob", "gptme/gptme"],
+    )
+    assert warnings == []
+    assert reasons
+    # Error must surface both the PR repo and the allowed list so the user
+    # can see at a glance why the PR was rejected and what to add.
+    assert "some-other/repo" in reasons[0]
+    assert "ErikBjare/bob" in reasons[0]
+    assert "gptme/gptme" in reasons[0]


### PR DESCRIPTION
## Summary

- `WORKSPACE_REPO` now accepts a comma- or whitespace-separated list of `owner/repo` entries so an agent maintaining multiple trusted repos can opt them in individually without disabling the cross-repo restriction entirely.
- All other checks (CI green, Greptile clean, category eligible, author match, sensitive-path rules) still apply to allowlisted repos — this is only the cross-repo gate becoming list-aware.
- Refactor: `evaluate_pr` now takes `workspace_repos: list[str] | None` (was `workspace_repo: str | None`), and a new `_check_workspace_repo` pure helper encapsulates the policy so it is unit-testable without mocking the GitHub API.

## Why

Today the cross-repo policy is binary: auto-detect a single workspace repo, or opt out entirely via `WORKSPACE_REPO=''`. That forces agents like Bob — who are legitimate maintainers of \`gptme/gptme\`, \`gptme/gptme-contrib\`, and \`ErikBjare/bob\` — to either reject all non-workspace PRs or disable the cross-repo safety net entirely (widening the merge surface well beyond what is actually trusted).

This shows up in real \`pr-address-wait-and-merge.sh\` telemetry: the single captured event disqualified gptme/gptme#2214 in part on \"Cross-repo PR (gptme/gptme) is not eligible for workspace ErikBjare/bob\" even though Bob maintains both repos. With this change, an operator can set \`WORKSPACE_REPO=\"ErikBjare/bob,gptme/gptme,gptme/gptme-contrib\"\` and let allowlisted repos flow through the remaining checks instead of bouncing on cross-repo grounds.

### Safety posture

- **No behavior change by default** — auto-detection still yields a single-entry list
- **Opt-out semantics preserved** — empty string still means \"warn, do not disqualify\"
- **Production activation is inert until opt-in** — \`project-monitoring.sh\` only invokes the wait-and-merge wrapper on Bob-local PRs today; the allowlist does nothing until an operator (a) sets the env var AND (b) updates prompt logic to invoke the wrapper on allowlisted cross-repo PRs too.

## Test plan

- [x] 12 new unit tests covering parsing + policy (empty, single, comma, whitespace, mixed, skipped empties, detection-failed, opt-out, allowed-single, allowed-in-multi, miss, error-message content)
- [x] Existing tests updated for renamed parameter (\`workspace_repo\` → \`workspace_repos\`)
- [x] All 39 tests pass locally (\`uv run pytest tests/test_self_merge_check.py\`)
- [x] \`mypy scripts/github/self-merge-check.py\` clean
- [x] Manual smoke test: default auto-detect still rejects cross-repo with the new message; \`WORKSPACE_REPO=\"ErikBjare/bob,gptme/gptme,gptme/gptme-contrib\"\` correctly lets gptme-contrib#751 pass the workspace check

## Follow-up

If Erik wants to activate the allowlist in production for Bob's \`pr-address-wait-and-merge\` loop, that's a two-step follow-up:
1. Set \`WORKSPACE_REPO=\"ErikBjare/bob,gptme/gptme,gptme/gptme-contrib\"\` in the monitoring service environment
2. Update \`scripts/runs/github/project-monitoring.sh\` prompt to invoke \`pr-address-wait-and-merge.sh\` on allowlisted cross-repo PRs too

Both are explicitly opt-in; this PR only makes them possible.