### PR TITLE
fix(github): suppress 'ready (to|for) merge @<maintainer>' phrasing (ErikBjare/bob#682)

### DIFF
--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -595,6 +595,13 @@ has_maintainer_waiting_comment() {
         *"ready to merge when convenient"*) return 0 ;;
         *"blocked by missing mergepullrequest permission"*) return 0 ;;
     esac
+    # "ready (to|for) merge @<maintainer>" — the @-mention indicates the ball
+    # is explicitly in the maintainer's court. Bare "ready to merge" is too
+    # broad (Bob says it about his own PRs in unrelated contexts), so we
+    # require the @-mention as the maintainer-handoff signal.
+    if printf '%s' "$lower" | grep -qE 'ready (to|for) merge @[a-z0-9_-]+'; then
+        return 0
+    fi
     return 1
 }
 

--- a/scripts/github/check-notifications.sh
+++ b/scripts/github/check-notifications.sh
@@ -168,14 +168,18 @@ is_permission_blocked_merge_ready_pr() {
     local lower
     lower=$(printf '%s' "$bot_comments" | tr '[:upper:]' '[:lower:]')
     case "$lower" in
-        *"waiting only on a maintainer click"*) ;;
-        *"waiting only on a maintainer merge click"*) ;;
-        *"ready to merge when convenient"*) ;;
-        *"blocked by missing mergepullrequest permission"*) ;;
-        *) return 1 ;;
+        *"waiting only on a maintainer click"*) return 0 ;;
+        *"waiting only on a maintainer merge click"*) return 0 ;;
+        *"ready to merge when convenient"*) return 0 ;;
+        *"blocked by missing mergepullrequest permission"*) return 0 ;;
     esac
-
-    return 0
+    # "ready (to|for) merge @<maintainer>" — the @-mention indicates the ball
+    # is explicitly in the maintainer's court. Bare "ready to merge" is too
+    # broad, so we require the @-mention as the maintainer-handoff signal.
+    if printf '%s' "$lower" | grep -qE 'ready (to|for) merge @[a-z0-9_-]+'; then
+        return 0
+    fi
+    return 1
 }
 
 # Helper function to format compactly with smart timestamps (limit 10 per category)


### PR DESCRIPTION
## Summary

Closes incomplete suppression heuristic from #750 — adds the most common
real-world phrasing Bob uses on his own PRs.

## Problem

The permission-blocked merge-ready suppression added in #750 only matched four
canonical phrases:

- `waiting only on a maintainer click`
- `waiting only on a maintainer merge click`
- `ready to merge when convenient`
- `blocked by missing mergepullrequest permission`

But Bob's real-world ready comment on `ActivityWatch/aw-server-rust#584` was:

> Ready for merge @ErikBjare — just needs your LGTM.

That phrasing fell through the case statement, so project-monitoring kept
re-dispatching focused sessions for a PR that was already explicitly handed
off to a maintainer with no merge permission for Bob — exactly the churn that
ErikBjare/bob#682 documented.

## Fix

Add a regex check after the literal phrases:

```bash
ready (to|for) merge @[a-z0-9_-]+
```

The `@<maintainer>` mention is the explicit handoff signal. Bare *"ready to
merge once CI passes"* still does **not** match (verified), so this stays
narrow.

Both project-monitoring paths get the same pattern:

- `has_maintainer_waiting_comment` in `scripts/github/activity-gate.sh`
- `is_permission_blocked_merge_ready_pr` in `scripts/github/check-notifications.sh`

so the two suppression surfaces stay aligned (per #750's design note).

## Verification

End-to-end against the live PR:

```text
$ source scripts/github/check-notifications.sh
$ is_permission_blocked_merge_ready_pr ActivityWatch/aw-server-rust 584
RESULT: SUPPRESSED (correct)
```

Pattern unit checks:

- `ready for merge @ErikBjare …` → match ✅
- `this is ready to merge once CI passes` → no match ✅

`shellcheck` clean on both files.

## Test plan

- [x] Pattern matches Bob's real comment on aw-server-rust#584
- [x] Pattern does NOT match generic "ready to merge once CI passes"
- [x] Shellcheck clean
- [x] End-to-end function call returns 0 (suppress) for #584

Closes ErikBjare/bob#682