### PR TITLE
feat(lessons): add session_categories to 10 LOO-positive lessons

### DIFF
--- a/lessons/autonomous/effective-autonomous-work-execution.md
+++ b/lessons/autonomous/effective-autonomous-work-execution.md
@@ -11,6 +11,7 @@ match:
   - "task selection"
   - "what to work on"
   - "work queue"
+  session_categories: [strategic, self-review]
 status: active
 ---
 

--- a/lessons/autonomous/lesson-quality-standards.md
+++ b/lessons/autonomous/lesson-quality-standards.md
@@ -14,6 +14,7 @@ match:
   - lesson creation
   - lesson quality
   - dated lesson variants
+  session_categories: [cleanup, self-review]
 ---
 
 # Lesson Quality Standards

--- a/lessons/autonomous/strategic-focus-during-autonomous-sessions.md
+++ b/lessons/autonomous/strategic-focus-during-autonomous-sessions.md
@@ -19,6 +19,7 @@ match:
   - "productivity theater"
   - "low-ROI work"
   - "idea backlog"
+  session_categories: [strategic, self-review]
 status: active
 ---
 

--- a/lessons/infrastructure/trajectory-persistence.md
+++ b/lessons/infrastructure/trajectory-persistence.md
@@ -8,6 +8,7 @@ match:
     - session data
     - cleanupPeriodDays
     - log cleanup
+  session_categories: [infrastructure, cleanup]
 target_grade: harm
 status: active
 ---

--- a/lessons/tools/greptile-pr-reviews.md
+++ b/lessons/tools/greptile-pr-reviews.md
@@ -14,6 +14,7 @@ match:
     - "retrigger greptile"
     - "pushed fixes after the earlier Greptile"
     - "after the earlier Greptile review"
+  session_categories: [cross-repo, code]
 status: active
 ---
 

--- a/lessons/tools/uv-sync-all-packages-after-changes.md
+++ b/lessons/tools/uv-sync-all-packages-after-changes.md
@@ -6,6 +6,7 @@ match:
     - "uv workspace package missing"
     - "cannot import workspace package after adding"
     - "uv sync all packages after changes"
+  session_categories: [code, infrastructure]
 status: active
 ---
 

--- a/lessons/workflow/pr-recovery-after-accidental-closure.md
+++ b/lessons/workflow/pr-recovery-after-accidental-closure.md
@@ -7,6 +7,7 @@ match:
     - reopen pr
     - force-push closed
     - replace pr
+  session_categories: [cross-repo, cleanup]
 status: active
 ---
 

--- a/lessons/workflow/pre-landing-self-review.md
+++ b/lessons/workflow/pre-landing-self-review.md
@@ -1,6 +1,7 @@
 ---
 match:
   keywords: ["self-review", "pre-landing", "review iteration", "code review", "substantial change"]
+  session_categories: [code, self-review]
 status: active
 ---
 

--- a/lessons/workflow/prefer-brain-over-local-memory.md
+++ b/lessons/workflow/prefer-brain-over-local-memory.md
@@ -6,6 +6,7 @@ match:
     - brain repo
     - claude memory
     - local memory
+  session_categories: [self-review, infrastructure]
 status: active
 ---
 

--- a/lessons/workflow/worktree-push-trap.md
+++ b/lessons/workflow/worktree-push-trap.md
@@ -5,6 +5,7 @@ match:
     - "git push -u origin"
     - "branch from master"
     - "push.default=upstream"
+  session_categories: [code, cross-repo]
 target_grade: [harm, productivity]
 status: active
 ---


### PR DESCRIPTION
## Summary

Phase 5 of KWBench, batch 4 — upstream the `session_categories` pattern from Bob's local lessons (commits `64857379e`, `4b487881d`, `35d1ad51f`) to gptme-contrib.

Adds explicit `session_categories` to 10 LOO-positive contrib lessons that were previously routed via session-classifier guesswork only.

## Why

`scripts/update-lesson-bandit.py` (KWBench Phase 2) consults a session category classifier when crediting `trigger_accuracy` to lessons. Explicit `session_categories` in lesson frontmatter replaces classifier guesswork with author intent, so:

- LOO sees more accurate "fired in the right context" signal
- The bandit reward for trigger quality is less noisy
- Future descriptor-matching work has a clean lane to add to

## Lessons updated

All chosen by reading each lesson's Context/Detection sections — not mechanical keyword overlap. Each lesson got 2 categories that match the failure modes / scenarios described in the lesson body.

| Lesson | Categories | LOO Δ |
|---|---|---|
| `prefer-brain-over-local-memory` | `[self-review, infrastructure]` | +0.0811 |
| `worktree-push-trap` | `[code, cross-repo]` | +0.0771 |
| `strategic-focus-during-autonomous-sessions` | `[strategic, self-review]` | +0.0766 |
| `uv-sync-all-packages-after-changes` | `[code, infrastructure]` | +0.0724 |
| `lesson-quality-standards` | `[cleanup, self-review]` | +0.0721 |
| `effective-autonomous-work-execution` | `[strategic, self-review]` | +0.0698 |
| `pre-landing-self-review` | `[code, self-review]` | +0.0540 |
| `trajectory-persistence` | `[infrastructure, cleanup]` | +0.0458 |
| `pr-recovery-after-accidental-closure` | `[cross-repo, cleanup]` | +0.0453 |
| `greptile-pr-reviews` | `[cross-repo, code]` | +0.0362 |

(LOO deltas from `scripts/lesson-loo-analysis.py --category-controlled --top 60` against Bob's session corpus — these are the upstream-shaped lessons most worth routing accurately.)

## Test plan

- [x] Validator clean on all 10 modified files (only pre-existing length/style warnings, unrelated to frontmatter additions)
- [x] No structural changes — pure additive YAML metadata inside existing `match:` block
- [x] Categories selected by reading lesson Context/Detection, not keyword overlap

## References

- Pattern source: ErikBjare/bob commits `64857379e` (batch 1), `4b487881d` (batch 2), `35d1ad51f` (batch 3) — local lesson edits with the same approach
- Validation: `python3 packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py`