### PR TITLE
feat(voice): use grok-voice-think-fast-1.0 as default xAI model

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/xai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/xai_client.py
@@ -18,8 +18,10 @@ from .openai_client import OpenAIRealtimeClient, SessionConfig
 logger = logging.getLogger(__name__)
 
 _OPENAI_DEFAULT_VOICE = "echo"
+_OPENAI_DEFAULT_MODEL = "gpt-4o-realtime-preview-2024-12-17"
 # "rex" = male, confident, clear — matches the Bob persona better than "eve" (female)
 _DEFAULT_XAI_VOICE = "rex"
+_DEFAULT_XAI_MODEL = "grok-voice-think-fast-1.0"
 
 
 def _get_xai_api_key() -> str | None:
@@ -55,6 +57,8 @@ class XAIRealtimeClient(OpenAIRealtimeClient):
         cfg = session_config or SessionConfig()
         if cfg.voice == _OPENAI_DEFAULT_VOICE:
             cfg = dataclasses.replace(cfg, voice=_DEFAULT_XAI_VOICE)
+        if cfg.model == _OPENAI_DEFAULT_MODEL:
+            cfg = dataclasses.replace(cfg, model=_DEFAULT_XAI_MODEL)
 
         # VAD tuning for Grok interruption (from task #651 / Erik feedback)
         # Lower threshold = more sensitive to speech, easier to interrupt
@@ -71,8 +75,8 @@ class XAIRealtimeClient(OpenAIRealtimeClient):
         super().__init__(api_key=resolved_key, session_config=cfg, **kwargs)
 
     def _get_ws_url(self) -> str:
-        """xAI uses the base URL only — no ?model= parameter."""
-        return self.WS_URL
+        """xAI supports ?model= in the WebSocket URL."""
+        return f"{self.WS_URL}?model={self.session_config.model}"
 
     def _get_ws_headers(self) -> dict[str, str]:
         """xAI auth — bearer token only, no OpenAI-Beta header."""

--- a/packages/gptme-voice/src/gptme_voice/realtime/xai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/xai_client.py
@@ -18,7 +18,12 @@ from .openai_client import OpenAIRealtimeClient, SessionConfig
 logger = logging.getLogger(__name__)
 
 _OPENAI_DEFAULT_VOICE = "echo"
-_OPENAI_DEFAULT_MODEL = "gpt-4o-realtime-preview-2024-12-17"
+# Derived from SessionConfig field default — stays in sync without duplication
+_OPENAI_DEFAULT_MODEL: str = next(
+    f.default  # type: ignore[assignment]
+    for f in dataclasses.fields(SessionConfig)
+    if f.name == "model"
+)
 # "rex" = male, confident, clear — matches the Bob persona better than "eve" (female)
 _DEFAULT_XAI_VOICE = "rex"
 _DEFAULT_XAI_MODEL = "grok-voice-think-fast-1.0"

--- a/packages/gptme-voice/tests/test_xai_client.py
+++ b/packages/gptme-voice/tests/test_xai_client.py
@@ -40,14 +40,13 @@ def test_xai_client_uses_xai_defaults() -> None:
 
 
 def test_xai_client_respects_explicit_model() -> None:
-    cfg = SessionConfig(model="grok-voice-think-fast-1.0")
+    # Use a model that is NOT the xAI default to verify passthrough is genuine
+    explicit_model = "grok-voice-think-1.0"
+    cfg = SessionConfig(model=explicit_model)
     client = XAIRealtimeClient(api_key="test-key", session_config=cfg)
 
-    assert client.session_config.model == "grok-voice-think-fast-1.0"
-    assert (
-        client._get_ws_url()
-        == "wss://api.x.ai/v1/realtime?model=grok-voice-think-fast-1.0"
-    )
+    assert client.session_config.model == explicit_model
+    assert client._get_ws_url() == f"wss://api.x.ai/v1/realtime?model={explicit_model}"
 
 
 def test_xai_client_treats_session_updated_as_ready_signal() -> None:

--- a/packages/gptme-voice/tests/test_xai_client.py
+++ b/packages/gptme-voice/tests/test_xai_client.py
@@ -29,10 +29,25 @@ def test_xai_client_uses_xai_defaults() -> None:
     client = XAIRealtimeClient(api_key="test-key", session_config=SessionConfig())
 
     assert client.session_config.voice == "rex"  # male voice for Bob persona
+    assert client.session_config.model == "grok-voice-think-fast-1.0"
     assert client.session_config.vad_threshold == 0.55
     assert client.session_config.vad_silence_duration_ms == 500
     assert client.session_config.vad_prefix_padding_ms == 150
-    assert client._get_ws_url() == "wss://api.x.ai/v1/realtime"
+    assert (
+        client._get_ws_url()
+        == "wss://api.x.ai/v1/realtime?model=grok-voice-think-fast-1.0"
+    )
+
+
+def test_xai_client_respects_explicit_model() -> None:
+    cfg = SessionConfig(model="grok-voice-think-fast-1.0")
+    client = XAIRealtimeClient(api_key="test-key", session_config=cfg)
+
+    assert client.session_config.model == "grok-voice-think-fast-1.0"
+    assert (
+        client._get_ws_url()
+        == "wss://api.x.ai/v1/realtime?model=grok-voice-think-fast-1.0"
+    )
 
 
 def test_xai_client_treats_session_updated_as_ready_signal() -> None:


### PR DESCRIPTION
## Summary

- Updates `XAIRealtimeClient` to explicitly request `grok-voice-think-fast-1.0` via `?model=` in the WebSocket URL (same pattern as OpenAI uses `?model=gpt-4o-realtime-preview-*`)
- Follows the existing voice/VAD override pattern: if `SessionConfig.model` is at the OpenAI default, replace it with the xAI-specific default; an explicit model passes through unchanged
- Updates the test to assert the new URL and adds a second test for explicit model passthrough

## Background

Previously `_get_ws_url()` returned the bare `wss://api.x.ai/v1/realtime` URL (no `?model=`), so xAI picked its API default. `grok-voice-think-fast-1.0` was released 2026-04-23 — we now explicitly request it.

Closes #756