### PR TITLE
feat(credential-slots): add SlotManager.heal_drift_to(sub) for OAuth-refresh recovery

### DIFF
--- a/packages/credential-slots/README.md
+++ b/packages/credential-slots/README.md
@@ -91,6 +91,16 @@ if not result.ok:
     print(f"could not switch: {result.reason}")
     if result.deferred_locks:
         print(f"deferred by: {result.deferred_locks}")
+
+# Healing drift after CC OAuth refresh (live file replaced by a regular file
+# with a fresh token; named slots stranded at the old token).
+# Caller decides which sub was active before the refresh — typically by
+# inspecting their own switch log.
+last_active = read_my_switch_log()  # caller-owned
+if last_active:
+    result = mgr.heal_drift_to(last_active)
+    if result.ok:
+        print(result.reason)  # "healed: synced live → .credentials.json.bob, ..."
 ```
 
 ## Design
@@ -114,5 +124,11 @@ uv run pytest packages/credential-slots/tests/ -v
 
 ## Status
 
-`v0.1.0` — ported from `manage-subscription.py` in ErikBjare/bob,
-commit `e9ea27097`. See `CHANGELOG` for future releases.
+- **`v0.2.0`** — added `SlotManager.heal_drift_to(sub, *, force=False)`
+  for OAuth-refresh recovery. Ported from Bob's `manage-subscription.py`
+  auto-heal logic (commit `b59d54d72`, ErikBjare/bob#685). Handles the
+  recurring case where CC writes a fresh OAuth token to the live file
+  (turning the symlink into a regular file) and every named slot is
+  stranded at the old token.
+- `v0.1.0` — initial release, ported from `manage-subscription.py` in
+  ErikBjare/bob, commit `e9ea27097`.

--- a/packages/credential-slots/pyproject.toml
+++ b/packages/credential-slots/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "credential-slots"
-version = "0.1.0"
+version = "0.2.0"
 description = "Safe credential-slot rotation for agents running Claude Max / OAuth-backed subscriptions"
 authors = [
     {name = "gptme contributors", email = "gptme@superuserlabs.org"}

--- a/packages/credential-slots/src/credential_slots/__init__.py
+++ b/packages/credential-slots/src/credential_slots/__init__.py
@@ -24,6 +24,7 @@ Public API::
     mgr.slot_is_fresh("bob")            # -> (True, "valid until ...")
     mgr.detect_live_slot_drift()        # -> dict | None
     mgr.switch_to("alice", "rebalance") # -> SwitchResult (result.ok, result.reason, result.deferred_locks)
+    mgr.heal_drift_to("bob")            # -> SwitchResult (resync live → slot, restore symlink)
 """
 
 from __future__ import annotations
@@ -50,4 +51,4 @@ __all__ = [
     "slot_is_fresh",
 ]
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/packages/credential-slots/src/credential_slots/manager.py
+++ b/packages/credential-slots/src/credential_slots/manager.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import shutil
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -393,6 +394,127 @@ class SlotManager:
         if self.on_switch is not None:
             self.on_switch(sub, reason)
         return SwitchResult(ok=True, reason=f"switched to {sub}")
+
+    # ---- Healing ----
+
+    def heal_drift_to(
+        self,
+        sub: str,
+        *,
+        force: bool = False,
+    ) -> SwitchResult:
+        """Sync the drifted live file into ``sub``'s slot, then re-symlink.
+
+        When CC's OAuth refresh writes a fresh token to the live file, the
+        symlink is replaced by a regular file and the named slot snapshots
+        are stranded at the old token. :meth:`detect_live_slot_drift`
+        reports drift, and :meth:`switch_to` refuses to act because every
+        slot looks expired.
+
+        ``heal_drift_to`` resolves this by treating the live file as the
+        source of truth: copy live → ``sub``'s slot atomically, then replace
+        the live path with a symlink to the slot. The caller decides which
+        ``sub`` was active before the refresh (typically by inspecting a
+        switch log they own).
+
+        Refuses (returns ``ok=False`` with diagnostic ``reason``) when:
+
+        - ``sub`` is not in :attr:`subscriptions`
+        - No drift is detected
+        - Live is a symlink (drift implies a slot rewrite, not OAuth
+          refresh — ambiguous which slot to heal into)
+        - Live file is missing, unreadable, or has no ``claudeAiOauth``
+          payload
+        - Live token is expired or within ``grace_seconds`` of expiry
+        - ``force=False`` and :attr:`lock_guard` reports active locks
+
+        On success, :attr:`on_switch` is called with reason
+        ``"auto-heal drift (live cred resynced to slot)"`` so caller-owned
+        switch logs see the action.
+        """
+        if sub not in self.subscriptions:
+            msg = f"unknown subscription: {sub!r} (known: {self.subscriptions})"
+            self._log(msg)
+            return SwitchResult(ok=False, reason=msg)
+
+        drift = self.detect_live_slot_drift()
+        if drift is None or not drift["drift"]:
+            return SwitchResult(ok=False, reason="no drift")
+
+        live = self.live_path
+        if live.is_symlink():
+            return SwitchResult(
+                ok=False,
+                reason="live is a symlink — drift implies slot rewrite, not OAuth refresh",
+            )
+        if not live.exists():
+            return SwitchResult(ok=False, reason="live file missing")
+
+        try:
+            payload = json.loads(live.read_text())
+        except (OSError, json.JSONDecodeError) as e:
+            return SwitchResult(
+                ok=False,
+                reason=f"live file unreadable or malformed JSON: {e}",
+            )
+        oauth = payload.get("claudeAiOauth") if isinstance(payload, dict) else None
+        if not isinstance(oauth, dict):
+            return SwitchResult(
+                ok=False,
+                reason="live file missing claudeAiOauth payload",
+            )
+        expires_ms = oauth.get("expiresAt")
+        if not isinstance(expires_ms, int | float):
+            return SwitchResult(
+                ok=False,
+                reason="live file missing expiresAt",
+            )
+        try:
+            expiry = datetime.fromtimestamp(float(expires_ms) / 1000, tz=timezone.utc)
+        except (OverflowError, OSError, ValueError) as e:
+            return SwitchResult(
+                ok=False,
+                reason=f"live file expiresAt unparseable: {e}",
+            )
+        now = datetime.now(timezone.utc)
+        if expiry <= now + timedelta(seconds=self.grace_seconds):
+            return SwitchResult(
+                ok=False,
+                reason=f"live token expired or in grace ({expiry.isoformat()})",
+            )
+
+        if not force and self.lock_guard is not None:
+            active_locks = list(self.lock_guard())
+            if active_locks:
+                lock_desc = ", ".join(active_locks)
+                msg = f"deferred: active lock(s) {lock_desc}; would heal to {sub}"
+                self._log(msg)
+                return SwitchResult(
+                    ok=False,
+                    reason=msg,
+                    deferred_locks=active_locks,
+                )
+
+        target_slot = self.slot_path(sub)
+        slot_tmp = target_slot.with_suffix(target_slot.suffix + f".tmp{os.getpid()}")
+        link_tmp = self.creds_dir / (self.live_name + f".tmp{os.getpid()}")
+        try:
+            shutil.copy2(live, slot_tmp)
+            os.chmod(slot_tmp, 0o600)
+            os.replace(slot_tmp, target_slot)
+            link_tmp.symlink_to(self.slot_template.format(sub=sub))
+            os.replace(link_tmp, live)
+        except BaseException:
+            slot_tmp.unlink(missing_ok=True)
+            link_tmp.unlink(missing_ok=True)
+            raise
+
+        if self.on_switch is not None:
+            self.on_switch(sub, "auto-heal drift (live cred resynced to slot)")
+        return SwitchResult(
+            ok=True,
+            reason=f"healed: synced live → {target_slot.name}, symlink restored",
+        )
 
     # ---- Internals ----
 

--- a/packages/credential-slots/tests/test_manager.py
+++ b/packages/credential-slots/tests/test_manager.py
@@ -8,6 +8,7 @@ constructor instead of monkeypatching module globals.
 from __future__ import annotations
 
 import json
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -423,3 +424,213 @@ class TestSwitchResult:
         assert SwitchResult(ok=False, reason="x", deferred_locks=["a"]) == SwitchResult(
             ok=False, reason="x", deferred_locks=["a"]
         )
+
+
+class TestHealDriftTo:
+    """heal_drift_to() syncs the live cred to ``sub``'s slot after CC OAuth refresh.
+
+    Recurring incident: ErikBjare/bob#685 — every CC OAuth token refresh
+    rewrites the live credential file, breaking the symlink and stranding
+    every named slot at a stale token. Without heal, the auto-switcher
+    refuses to act because every slot looks expired.
+
+    Workspace caller (e.g. ``manage-subscription.py``) owns *which* sub to
+    heal into (typically inferred from a switch log they own); this method
+    just performs the file ops safely.
+    """
+
+    def _seed_drifted(
+        self,
+        mgr: SlotManager,
+        *,
+        live_oauth_expires_ms: int | None,
+        live_is_symlink: bool = False,
+        live_present: bool = True,
+        slots_expires_ms: int | None = None,
+    ) -> Path:
+        """Set up a drifted state and return the live path.
+
+        Default: all named slots have a 1h-stale token; live is a regular
+        file with caller-supplied expiry. Override flags exercise the
+        symlink-drift and missing-live paths.
+        """
+        stale_ms = (
+            slots_expires_ms if slots_expires_ms is not None else _ms_from_now(-3600)
+        )
+        for sub in mgr.subscriptions:
+            _write_slot(mgr.slot_path(sub), stale_ms)
+        live = mgr.live_path
+        if live_present:
+            if live_is_symlink:
+                # Broken symlink — detect_live_slot_drift reports drift with
+                # live_hash=None, distinct from the regular-file OAuth-refresh
+                # case. heal_drift_to must refuse this since it cannot
+                # determine which slot the operator meant to heal.
+                live.symlink_to(".credentials.json.deleted-target")
+            else:
+                payload: dict[str, object] = {
+                    "claudeAiOauth": {"accessToken": "fresh-token-from-cc-refresh"}
+                }
+                if live_oauth_expires_ms is not None:
+                    payload["claudeAiOauth"]["expiresAt"] = live_oauth_expires_ms  # type: ignore[index]
+                live.write_text(json.dumps(payload))
+        return live
+
+    def test_no_drift_returns_false(self, mgr: SlotManager) -> None:
+        """Heal is a no-op when drift detector reports no drift."""
+        bob_slot = mgr.slot_path("bob")
+        bob_slot.write_bytes(b'{"claudeAiOauth":{"accessToken":"x"}}')
+        mgr.live_path.symlink_to(".credentials.json.bob")
+        result = mgr.heal_drift_to("bob")
+        assert result.ok is False
+        assert "no drift" in result.reason
+
+    def test_drift_executes_heal(self, mgr: SlotManager) -> None:
+        """Drift + fresh live token: copy live → slot, replace with symlink."""
+        live = self._seed_drifted(mgr, live_oauth_expires_ms=_ms_from_now(3600))
+        original_live_content = live.read_text()
+        bob_slot = mgr.slot_path("bob")
+
+        result = mgr.heal_drift_to("bob")
+        assert result.ok is True
+        assert "healed" in result.reason
+        # Live is now a symlink pointing at bob's slot
+        assert live.is_symlink()
+        assert os.readlink(str(live)) == ".credentials.json.bob"
+        # Bob's slot now contains the freshest token (was overwritten)
+        assert bob_slot.read_text() == original_live_content
+        # No drift now
+        drift = mgr.detect_live_slot_drift()
+        assert drift is not None
+        assert drift["drift"] is False
+
+    def test_symlink_live_refused(self, mgr: SlotManager) -> None:
+        """Drift via symlink-with-missing-target is ambiguous; refuse."""
+        live = self._seed_drifted(mgr, live_oauth_expires_ms=None, live_is_symlink=True)
+        result = mgr.heal_drift_to("bob")
+        assert result.ok is False
+        assert "symlink" in result.reason
+        # Untouched
+        assert live.is_symlink()
+
+    def test_expired_live_token_not_healed(self, mgr: SlotManager) -> None:
+        """Refuse to heal when the live token itself is expired."""
+        live = self._seed_drifted(mgr, live_oauth_expires_ms=_ms_from_now(-3600))
+        result = mgr.heal_drift_to("bob")
+        assert result.ok is False
+        assert "expired or in grace" in result.reason
+        assert not live.is_symlink()
+
+    def test_missing_oauth_payload_not_healed(self, mgr: SlotManager) -> None:
+        """Refuse to heal when live file lacks the claudeAiOauth payload."""
+        for sub in mgr.subscriptions:
+            _write_slot(mgr.slot_path(sub), _ms_from_now(-3600))
+        live = mgr.live_path
+        live.write_text(json.dumps({"some_other_format": True}))
+        result = mgr.heal_drift_to("bob")
+        assert result.ok is False
+        assert "claudeAiOauth" in result.reason
+
+    def test_missing_expires_at_not_healed(self, mgr: SlotManager) -> None:
+        """Refuse when payload exists but has no parseable expiresAt."""
+        live = self._seed_drifted(mgr, live_oauth_expires_ms=None)
+        result = mgr.heal_drift_to("bob")
+        assert result.ok is False
+        assert "expiresAt" in result.reason
+        assert not live.is_symlink()
+
+    def test_unknown_subscription_rejected(self, mgr: SlotManager) -> None:
+        """Refuse to heal into a sub not in self.subscriptions."""
+        self._seed_drifted(mgr, live_oauth_expires_ms=_ms_from_now(3600))
+        result = mgr.heal_drift_to("gordon")
+        assert result.ok is False
+        assert "unknown" in result.reason.lower()
+
+    def test_malformed_json_not_healed(self, mgr: SlotManager) -> None:
+        """Refuse cleanly when live file is not valid JSON."""
+        for sub in mgr.subscriptions:
+            _write_slot(mgr.slot_path(sub), _ms_from_now(-3600))
+        live = mgr.live_path
+        live.write_text("not json{")
+        result = mgr.heal_drift_to("bob")
+        assert result.ok is False
+        assert "unreadable or malformed JSON" in result.reason
+
+    def test_invokes_on_switch_callback(self, tmp_path: Path) -> None:
+        """Successful heal calls on_switch with the auto-heal reason."""
+        creds_dir = tmp_path / "creds"
+        creds_dir.mkdir()
+        events: list[tuple[str, str]] = []
+        mgr = SlotManager(
+            creds_dir=creds_dir,
+            subscriptions=["bob", "alice"],
+            on_switch=lambda sub, reason: events.append((sub, reason)),
+        )
+        self._seed_drifted(mgr, live_oauth_expires_ms=_ms_from_now(3600))
+        result = mgr.heal_drift_to("alice")
+        assert result.ok is True
+        assert events == [("alice", "auto-heal drift (live cred resynced to slot)")]
+
+    def test_lock_guard_defers_unless_forced(self, tmp_path: Path) -> None:
+        """When lock_guard returns active locks, heal defers; force bypasses."""
+        creds_dir = tmp_path / "creds"
+        creds_dir.mkdir()
+        mgr = SlotManager(
+            creds_dir=creds_dir,
+            subscriptions=["bob", "alice"],
+            lock_guard=lambda: ["session-abc"],
+        )
+        live = self._seed_drifted(mgr, live_oauth_expires_ms=_ms_from_now(3600))
+
+        # Default: defers
+        result = mgr.heal_drift_to("bob")
+        assert result.ok is False
+        assert "deferred" in result.reason
+        assert result.deferred_locks == ["session-abc"]
+        assert not live.is_symlink()  # untouched
+
+        # force=True: heals through the lock
+        result = mgr.heal_drift_to("bob", force=True)
+        assert result.ok is True
+        assert live.is_symlink()
+
+    def test_slot_file_chmod_to_user_only(self, mgr: SlotManager) -> None:
+        """Healed slot file has 0600 perms (no group/other read)."""
+        self._seed_drifted(mgr, live_oauth_expires_ms=_ms_from_now(3600))
+        bob_slot = mgr.slot_path("bob")
+        result = mgr.heal_drift_to("bob")
+        assert result.ok is True
+        mode = bob_slot.stat().st_mode & 0o777
+        assert mode == 0o600, f"expected 0o600, got {oct(mode)}"
+
+    def test_atomicity_preserves_state_on_failure(
+        self, mgr: SlotManager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If os.replace fails mid-heal, no partial state is left behind.
+
+        Simulate failure of the second os.replace (the symlink swap). The
+        slot has already been replaced with fresh content (acceptable —
+        slot now matches live) but the live file remains a regular file.
+        Verify that no .tmp* artifacts remain.
+        """
+        live = self._seed_drifted(mgr, live_oauth_expires_ms=_ms_from_now(3600))
+
+        original_replace = os.replace
+        call_count = {"n": 0}
+
+        def flaky_replace(src: object, dst: object) -> None:
+            call_count["n"] += 1
+            if call_count["n"] == 2:
+                raise OSError("simulated EACCES")
+            original_replace(src, dst)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(os, "replace", flaky_replace)
+        with pytest.raises(OSError, match="simulated EACCES"):
+            mgr.heal_drift_to("bob")
+
+        # Live file remains as a regular file (heal aborted before symlink swap)
+        assert live.exists()
+        assert not live.is_symlink()
+        # No leftover .tmp* artifacts in creds_dir
+        leftovers = sorted(p.name for p in mgr.creds_dir.iterdir() if ".tmp" in p.name)
+        assert leftovers == [], f"unexpected tmp files: {leftovers}"

--- a/uv.lock
+++ b/uv.lock
@@ -722,7 +722,7 @@ toml = [
 
 [[package]]
 name = "credential-slots"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "packages/credential-slots" }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Closes #758.

## Summary

Lifts the auto-heal logic from Bob's `manage-subscription.py`
([ErikBjare/bob@b59d54d72](https://github.com/ErikBjare/bob/commit/b59d54d72))
into the `credential-slots` package so Alice/Sven/Gordon get the same
self-healing.

## Why

When CC's OAuth refresh writes a fresh token to the live
`~/.claude/.credentials.json`, the symlink is replaced by a regular
file and the named slot snapshots are stranded at the old token.
`detect_live_slot_drift` reports drift, and `switch_to` refuses to act
because every slot looks expired. Without heal, autonomous sessions
either keep using stale slots (401) or fall back to non-Claude
backends. Bob saw this fire today (ErikBjare/bob#685) and the
workspace-side fix has been verified end-to-end.

## API

\`\`\`python
def heal_drift_to(self, sub: str, *, force: bool = False) -> SwitchResult:
\`\`\`

Treats the live file as the source of truth: copies live → \`sub\`'s slot
atomically, then replaces the live path with a symlink to the slot. The
caller decides which \`sub\` was active before the refresh (typically by
inspecting their own switch log).

Refuses cleanly with diagnostic \`reason\` for: unknown sub, no drift,
symlink live (drift implies slot rewrite — ambiguous), missing/
unreadable live, missing \`claudeAiOauth\` payload or \`expiresAt\`,
expired/grace-window live token. Respects \`lock_guard\` like
\`switch_to\`; \`force=True\` bypasses.

On success, calls \`on_switch(sub, "auto-heal drift (live cred resynced
to slot)")\` so caller-owned switch logs see the action.

## Tests

12 new tests in \`TestHealDriftTo\` covering:
- Happy path (drift + fresh live → heal succeeds, symlink restored, slot updated)
- Every refusal mode (no drift, symlink live, expired token, missing payload, missing expiresAt, malformed JSON, unknown sub)
- \`on_switch\` callback fires with the auto-heal reason
- \`lock_guard\` semantics (defers without \`force\`, bypasses with \`force=True\`)
- Slot file gets 0600 perms (no group/other read)
- Atomicity preservation when \`os.replace\` fails mid-heal (no leftover \`.tmp*\`)

All 57 tests pass (12 new + 45 existing). \`mypy --strict\` clean.

## Workspace migration

Bob's \`scripts/manage-subscription.py\` will switch to using
\`SlotManager.heal_drift_to(infer_active_slot_from_log())\` in a separate
PR (ErikBjare/bob) once this lands. Alice/Sven/Gordon get the same
benefit by upgrading their pinned \`credential-slots\` version.

## Test plan

- [x] \`uv run pytest packages/credential-slots/tests/ -v\` — 57 passed
- [x] \`uv run mypy --strict packages/credential-slots/src/\` — clean
- [x] \`prek run --all-files\` on commit — all hooks pass
- [x] Verified workspace heal_drift end-to-end on real drift event today (ErikBjare/bob#685)