### PR TITLE
fix(lessons): broaden keywords on two silent workflow lessons

### DIFF
--- a/lessons/workflow/proactive-correction-in-agent-messages.md
+++ b/lessons/workflow/proactive-correction-in-agent-messages.md
@@ -7,6 +7,15 @@ match:
     - "sent wrong advice to agent"
     - "need to correct prior message"
     - "earlier message was wrong"
+    - "send a correction"
+    - "correction to my earlier"
+    - "correct my previous message"
+    - "correct earlier advice"
+    - "ignore my last message"
+    - "wrong recommendation to"
+    - "follow-up correction"
+    - "before they act on it"
+    - "I gave the wrong advice"
 ---
 
 # Proactive Correction in Agent Messages

--- a/lessons/workflow/project-monitoring-session-patterns.md
+++ b/lessons/workflow/project-monitoring-session-patterns.md
@@ -5,6 +5,14 @@ match:
     - "ACT vs DEF notification classification"
     - "monitoring session derailing into investigation"
     - "multi-project notification triage"
+    - "project monitoring session"
+    - "monitoring session structure"
+    - "time-box monitoring"
+    - "classify each notification"
+    - "github notifications triage"
+    - "triage notifications across repos"
+    - "monitoring run derailing"
+    - "act vs defer"
 status: active
 ---
 


### PR DESCRIPTION
## Summary

Two workflow lessons have been silent (zero corpus matches) for ~14 days due to overly-narrow keyword phrasing:

- `proactive-correction-in-agent-messages` — keywords like `"retract incorrect recommendation"` are jargon-y phrasings that don't appear in real session text.
- `project-monitoring-session-patterns` — keywords like `"ACT vs DEF notification classification"` use the lesson's own internal taxonomy that agents don't reach for.

Added natural-language alternates pulled directly from each lesson's own example body (`"send a correction"`, `"correction to my earlier"`, `"ignore my last message"`, `"project monitoring session"`, `"time-box monitoring"`, `"classify each notification"`, etc.).

## Verification

- `lesson-keyword-journal-crossref.py --suggest --days 14` reported both lessons in `true_silent` (0 corpus hits across 14d of CC + gptme sessions, 13.6 days since last activation).
- Pre-existing `validate.py` warnings unchanged by these edits.
- Originals retained — only additive expansion.

## Test plan

- [x] `validate.py` clean for both lessons (warnings pre-existing)
- [x] No format breakage (frontmatter still parses)
- [ ] After merge, watch next `lesson-keyword-journal-crossref` run — both lessons should drop out of `true_silent`