### PR TITLE
fix(activity-summary): load AW category rules from settings

### DIFF
--- a/packages/gptme-activity-summary/src/gptme_activity_summary/aw_data.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/aw_data.py
@@ -6,11 +6,13 @@ from a local ActivityWatch server.
 Default AW server: http://localhost:5600 (configurable via AW_SERVER env var)
 """
 
+import json
 import logging
 import os
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta, timezone
 from typing import Any, cast
+from urllib.request import urlopen
 
 logger = logging.getLogger(__name__)
 
@@ -152,6 +154,45 @@ def _run_aw_query(
     return None
 
 
+def _fetch_category_rules() -> list[list[Any]]:
+    """Fetch category rules from the ActivityWatch settings API.
+
+    AW webui persists categorization rules under the ``classes`` setting and
+    injects them directly into queries. The Python aw-client does not expose a
+    settings helper, so we read the REST endpoint directly and convert the saved
+    categories into the ``[category_path, rule]`` shape expected by
+    ``categorize(...)``.
+
+    Returns an empty list when no classes are saved or the settings endpoint is
+    unavailable. That fallback still produces a valid ``categorize(events, [])``
+    query, which yields ``["Uncategorized"]`` instead of a server-side parse
+    error.
+    """
+    settings_url = f"{AW_SERVER.rstrip('/')}/api/0/settings/classes"
+    try:
+        with urlopen(settings_url, timeout=AW_TIMEOUT) as response:
+            payload = json.load(response)
+    except Exception as e:
+        logger.debug("AW category settings fetch failed: %s", e)
+        return []
+
+    if not isinstance(payload, list):
+        return []
+
+    rules: list[list[Any]] = []
+    for category in payload:
+        if not isinstance(category, dict):
+            continue
+        name = category.get("name")
+        rule = category.get("rule")
+        if not isinstance(name, list) or not isinstance(rule, dict):
+            continue
+        if rule.get("type") is None:
+            continue
+        rules.append([name, rule])
+    return rules
+
+
 def _fetch_app_usage(
     client: Any, window_bucket: str, afk_bucket: str | None, timeperiod: tuple[datetime, datetime]
 ) -> tuple[list[AppUsage], float]:
@@ -248,10 +289,10 @@ def _fetch_browser_domains(
 def _fetch_category_usage(
     client: Any, window_bucket: str, afk_bucket: str | None, timeperiod: tuple[datetime, datetime]
 ) -> list[CategoryUsage]:
-    """Fetch time per category using AW's user-configured categorization rules.
+    """Fetch time per category using AW's saved categorization rules.
 
-    Uses AW's built-in categorize() function with the user's saved $categories rules.
-    Returns an empty list only if the query fails.
+    Uses AW's built-in ``categorize()`` function with rules loaded from the
+    ActivityWatch settings API. Returns an empty list only if the query fails.
 
     When no categories are configured, AW assigns all events to ["Uncategorized"],
     so this returns [CategoryUsage(["Uncategorized"], total_duration)] rather than [].
@@ -259,13 +300,14 @@ def _fetch_category_usage(
 
     The $category field in results is a list like ["Coding", "Python"] or ["Uncategorized"].
     """
+    category_rules = json.dumps(_fetch_category_rules())
     if afk_bucket:
         query = [
             f'afk_events = query_bucket("{afk_bucket}");',
             'afk_events = filter_keyvals(afk_events, "status", ["not-afk"]);',
             f'window_events = query_bucket("{window_bucket}");',
             "events = filter_period_intersect(window_events, afk_events);",
-            "events = categorize(events, $categories);",
+            f"events = categorize(events, {category_rules});",
             'events = merge_events_by_keys(events, ["$category"]);',
             "events = sort_by_duration(events);",
             "RETURN = events;",
@@ -273,7 +315,7 @@ def _fetch_category_usage(
     else:
         query = [
             f'window_events = query_bucket("{window_bucket}");',
-            "events = categorize(window_events, $categories);",
+            f"events = categorize(window_events, {category_rules});",
             'events = merge_events_by_keys(events, ["$category"]);',
             "events = sort_by_duration(events);",
             "RETURN = events;",

--- a/packages/gptme-activity-summary/tests/test_aw_data.py
+++ b/packages/gptme-activity-summary/tests/test_aw_data.py
@@ -1,6 +1,9 @@
 """Tests for aw_data.py — ActivityWatch integration."""
 
+import json
+from contextlib import nullcontext
 from datetime import date, datetime, timezone
+from io import BytesIO
 
 import pytest
 
@@ -13,6 +16,7 @@ from gptme_activity_summary.aw_data import (
     format_aw_activity_for_prompt,
     _build_timeperiod,
     _fetch_category_usage,
+    _fetch_category_rules,
     _get_client,
 )
 
@@ -326,6 +330,100 @@ def test_fetch_category_usage_non_list_category():
     assert len(result) == 1
     assert result[0].category == ["FlatString"]
     assert result[0].duration == 3600
+
+
+def test_fetch_category_rules_reads_aw_settings_classes():
+    """Saved AW classes are converted into categorize() query rules."""
+    from unittest.mock import patch
+
+    payload = [
+        {"name": ["Coding"], "rule": {"type": "regex", "regex": "nvim"}},
+        {"name": ["IgnoreMe"], "rule": {"type": None}},
+        {"name": "bad-shape", "rule": {"type": "regex", "regex": "bad"}},
+    ]
+
+    with patch(
+        "gptme_activity_summary.aw_data.urlopen",
+        return_value=nullcontext(BytesIO(json.dumps(payload).encode())),
+    ):
+        result = _fetch_category_rules()
+
+    assert result == [[["Coding"], {"type": "regex", "regex": "nvim"}]]
+
+
+def test_fetch_category_rules_returns_empty_when_setting_missing():
+    """Null or missing classes settings should degrade to an empty rule list."""
+    from unittest.mock import patch
+
+    with patch(
+        "gptme_activity_summary.aw_data.urlopen",
+        return_value=nullcontext(BytesIO(b"null")),
+    ):
+        result = _fetch_category_rules()
+
+    assert result == []
+
+
+def test_fetch_category_usage_inlines_saved_category_rules():
+    """Category queries inline server-backed rules instead of the dead $categories token."""
+    from unittest.mock import MagicMock, patch
+
+    timeperiod = (
+        datetime(2026, 3, 1, tzinfo=timezone.utc),
+        datetime(2026, 3, 2, tzinfo=timezone.utc),
+    )
+    captured: dict[str, list[str]] = {}
+
+    def fake_run(_client, query, _timeperiod):
+        captured["query"] = query
+        return []
+
+    with (
+        patch(
+            "gptme_activity_summary.aw_data._fetch_category_rules",
+            return_value=[[["Coding"], {"type": "regex", "regex": "nvim"}]],
+        ),
+        patch("gptme_activity_summary.aw_data._run_aw_query", side_effect=fake_run),
+    ):
+        mock_client = MagicMock()
+        _fetch_category_usage(mock_client, "aw-watcher-window_host", None, timeperiod)
+
+    query_text = "\n".join(captured["query"])
+    assert "$categories" not in query_text
+    assert (
+        'categorize(window_events, [[["Coding"], {"type": "regex", "regex": "nvim"}]])'
+        in query_text
+    )
+
+
+def test_fetch_category_usage_uses_empty_rules_fallback():
+    """When no classes are saved, categorize(events, []) should still produce a valid query."""
+    from unittest.mock import MagicMock, patch
+
+    timeperiod = (
+        datetime(2026, 3, 1, tzinfo=timezone.utc),
+        datetime(2026, 3, 2, tzinfo=timezone.utc),
+    )
+    captured: dict[str, list[str]] = {}
+
+    def fake_run(_client, query, _timeperiod):
+        captured["query"] = query
+        return []
+
+    with (
+        patch(
+            "gptme_activity_summary.aw_data._fetch_category_rules",
+            return_value=[],
+        ),
+        patch("gptme_activity_summary.aw_data._run_aw_query", side_effect=fake_run),
+    ):
+        mock_client = MagicMock()
+        _fetch_category_usage(
+            mock_client, "aw-watcher-window_host", "aw-watcher-afk_host", timeperiod
+        )
+
+    query_text = "\n".join(captured["query"])
+    assert "events = categorize(events, []);" in query_text
 
 
 @pytest.mark.skipif(_get_client() is None, reason="aw-client not installed")


### PR DESCRIPTION
## Summary
- replace the dead `categorize(..., $categories)` query token in `gptme-activity-summary`
- load saved ActivityWatch category rules from `/api/0/settings/classes` and inline them into the query, matching current AW webui behavior
- fall back to `categorize(events, [])` when no classes are saved so the package returns `Uncategorized` instead of tripping AW's parser
- add focused tests for settings parsing, inlined rule queries, and the empty-rules fallback

## Why
Bob's local ActivityWatch service was logging:

```txt
aw_query.exceptions.QueryParseException: Syntax error: $categories
```

The Python `aw_client` doesn't expose a settings helper, and the old `$categories` token no longer works with the current query engine. This made category summaries fail noisily whenever `gptme-activity-summary` queried AW.

## Verification
- `uv run pytest /home/bob/bob/gptme-contrib/packages/gptme-activity-summary/tests/test_aw_data.py -q`
- `uv run ruff check /home/bob/bob/gptme-contrib/packages/gptme-activity-summary/src/gptme_activity_summary/aw_data.py /home/bob/bob/gptme-contrib/packages/gptme-activity-summary/tests/test_aw_data.py`
- live smoke check:
  - `uv run python3 - <<'PY' ... fetch_aw_activity(date(2026,4,25), date(2026,4,25)) ... PY`
  - returned `available True`, populated app usage, and `categories ['Uncategorized']`
  - `journalctl --user -u bob-activitywatch.service --since '2 minutes ago' -o cat` showed no fresh `Syntax error: $categories`
