### PR TITLE
fix(twitter): load .env in workflow.py CLI so direct invocations work

### DIFF
--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -52,6 +52,7 @@ from typing import (
 
 import click
 import yaml
+from dotenv import load_dotenv
 
 # Import monitoring utilities
 from gptmail.communication_utils.monitoring import (  # type: ignore[import-not-found]
@@ -658,6 +659,14 @@ def list_drafts(status: str) -> List[Path]:
 )
 def cli(model: str | None = None) -> None:
     """Twitter Workflow Manager"""
+    # Sibling scripts (twitter.py, check_replies.py) call load_dotenv() at
+    # import time. workflow.py historically relied on twitter-loop.sh exporting
+    # envs like TWITTER_HANDLE, so direct CLI invocations crashed inside the
+    # LLM grader with `ValueError: TWITTER_HANDLE env var must be set`. Load
+    # .env at CLI entry so `workflow.py` works regardless of how it is invoked.
+    # override=False so values already in the environment (e.g. set by the
+    # systemd loop) still win.
+    load_dotenv(override=False)
     init_gptme(
         model=model, interactive=False, tool_allowlist=[], tool_format="markdown"
     )

--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -654,7 +654,7 @@ def list_drafts(status: str) -> List[Path]:
 @click.group()
 @click.option(
     "--model",
-    default=os.getenv("MODEL", "anthropic/claude-sonnet-4-5"),
+    default=None,
     help="Model to use for LLM operations",
 )
 def cli(model: str | None = None) -> None:
@@ -667,6 +667,9 @@ def cli(model: str | None = None) -> None:
     # override=False so values already in the environment (e.g. set by the
     # systemd loop) still win.
     load_dotenv(override=False)
+    # Defer MODEL resolution until after load_dotenv() so .env takes effect.
+    if model is None:
+        model = os.getenv("MODEL", "anthropic/claude-sonnet-4-5")
     init_gptme(
         model=model, interactive=False, tool_allowlist=[], tool_format="markdown"
     )


### PR DESCRIPTION
## Problem

`workflow.py review` (and other workflow.py subcommands that call the LLM grader) crash with:

```
ValueError: TWITTER_HANDLE env var must be set (e.g. export TWITTER_HANDLE=MyBotHandle)
```

when run directly from the shell, even though `.env` defines `TWITTER_HANDLE`.

## Why

The sibling Twitter scripts (`twitter.py`, `check_replies.py`) already call `load_dotenv()` at import time, so they pick up `.env` automatically. `workflow.py` did not. The systemd loop (`scripts/runs/twitter/twitter-loop.sh`) papers over this by exporting `TWITTER_HANDLE` itself, so the loop kept working — but humans (and any other non-loop caller, e.g. ad-hoc agent sessions) hit the crash.

## Fix

Call `load_dotenv(override=False)` at the top of `cli()` so the CLI works regardless of how it's invoked. `override=False` is intentional: values already in the environment (e.g. exported by the systemd loop) still win.

## Verification

End-to-end test: with `TWITTER_HANDLE` and `AGENT_NAME` unset in the parent shell, `workflow.py review` now reaches the Anthropic API instead of crashing inside `get_system_prompt()`. Pre-commit (`prek run --files scripts/twitter/workflow.py`) all green.

## Origin

Surfaced from a Bob autonomous session on 2026-04-26 trying to use `workflow.py review` interactively for a quality grade before posting a tweet — the crash blocked the auto-grade path.