### PR TITLE
fix(lessons): add session_categories to two false-negative lessons

### DIFF
--- a/lessons/workflow/progress-despite-blockers.md
+++ b/lessons/workflow/progress-despite-blockers.md
@@ -14,6 +14,7 @@ match:
   - "tasks blocked on external dependencies"
   - "blocked on external dependencies"
   - "all tasks blocked on external"
+  session_categories: [code, cross-repo, triage, cleanup, infrastructure]
 status: active
 ---
 

--- a/lessons/workflow/project-monitoring-session-patterns.md
+++ b/lessons/workflow/project-monitoring-session-patterns.md
@@ -13,6 +13,7 @@ match:
     - "triage notifications across repos"
     - "monitoring run derailing"
     - "act vs defer"
+  session_categories: [monitoring, triage]
 status: active
 ---
 


### PR DESCRIPTION
## Summary

Two lessons in this repo were flagged as **false negatives** by Bob's lesson keyword crossref report: their existing keywords matched ≥2 distinct sessions over a 14-day window, but the lesson never actually injected. Adding `session_categories` routes them via skill-bundle delivery as a backstop when keyword injection misses.

## Changes

- `lessons/workflow/progress-despite-blockers.md` — `session_categories: [code, cross-repo, triage, cleanup, infrastructure]`
  - These are the categories where blocked-on-external work tends to surface
- `lessons/workflow/project-monitoring-session-patterns.md` — `session_categories: [monitoring, triage]`
  - Sessions where ACT vs DEF triage classification is the actual workflow

## Why

The crossref tool distinguishes:
- **True silent**: keywords don't match real session text → fix is to add keywords
- **False negative**: keywords DO match but lesson doesn't deliver → fix is bundle routing

Both of these are the second case — keyword authoring is fine, the delivery pipeline (PreToolUse hook tail vs full corpus, MAX_PRETOOL_LESSONS cap, dedup) is dropping them. `session_categories` provides bundle-level delivery so they get injected when a session's category matches, regardless of keyword tail visibility.

This is the same pattern already used by ~20 other lessons in this repo (e.g. `worktree-push-trap.md`, `pre-landing-self-review.md`, `pr-recovery-after-accidental-closure.md`).

## Test plan

- [x] Both files validate via `gptme_lessons_extras.validate` (two-file format)
- [x] Pre-commit hooks pass
- [ ] Verify in next session that one of these lessons fires via skill-bundle when a `triage` or `monitoring` session runs (will show up in `state/lesson-trajectories/`)