### PR TITLE
fix(sessions): detect codex apply_patch + write_stdin commits

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -1008,12 +1008,14 @@ def extract_signals_codex(msgs: list[dict]) -> dict:
     Codex format uses typed entries:
     - session_meta: session start metadata
     - turn_context: per-turn context (model, cwd)
-    - response_item: messages and tool calls (function_call / function_call_output)
+    - response_item: messages and tool calls (function_call / function_call_output /
+      custom_tool_call for apply_patch)
     - event_msg: events (token_count, task lifecycle)
 
-    Codex uses exec_command for all tool calls (shell-based). File writes are
-    detected from shell redirect patterns rather than individual tool names
-    since all operations go through the shell.
+    File writes are detected from two sources:
+    - apply_patch (custom_tool_call): "Add File" / "Update File" directives in patch input
+    - exec_command (function_call): shell redirect patterns in the command string
+    Git commits are detected from exec_command and write_stdin outputs.
     """
     tool_calls: dict[str, int] = {}
     error_count = 0
@@ -1050,14 +1052,15 @@ def extract_signals_codex(msgs: list[dict]) -> dict:
             payload_type = payload.get("type", "")
 
             # Codex uses custom_tool_call (not function_call) for apply_patch.
-            # Parse "*** Add File: PATH" and "*** Update File: PATH" directives.
+            # Only "Add File" and "Update File" directives count as writes;
+            # "Delete File" removes files rather than writing them.
             if payload_type == "custom_tool_call" and payload.get("name") == "apply_patch":
                 tool_calls["apply_patch"] = tool_calls.get("apply_patch", 0) + 1
                 current_turn_has_tool = True
                 patch_input = payload.get("input", "") or ""
                 if isinstance(patch_input, str):
                     for patch_match in re.finditer(
-                        r"^\*\*\*\s+(?:Add|Update|Delete)\s+File:\s+(.+?)\s*$",
+                        r"^\*\*\*\s+(?:Add|Update)\s+File:\s+(.+?)\s*$",
                         patch_input,
                         re.MULTILINE,
                     ):

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -1049,7 +1049,31 @@ def extract_signals_codex(msgs: list[dict]) -> dict:
             payload = record.get("payload") or {}
             payload_type = payload.get("type", "")
 
-            if payload_type == "function_call":
+            # Codex uses custom_tool_call (not function_call) for apply_patch.
+            # Parse "*** Add File: PATH" and "*** Update File: PATH" directives.
+            if payload_type == "custom_tool_call" and payload.get("name") == "apply_patch":
+                tool_calls["apply_patch"] = tool_calls.get("apply_patch", 0) + 1
+                current_turn_has_tool = True
+                patch_input = payload.get("input", "") or ""
+                if isinstance(patch_input, str):
+                    for patch_match in re.finditer(
+                        r"^\*\*\*\s+(?:Add|Update|Delete)\s+File:\s+(.+?)\s*$",
+                        patch_input,
+                        re.MULTILINE,
+                    ):
+                        path = patch_match.group(1).strip()
+                        if "/journal/" in path or path.startswith("journal/"):
+                            journal_paths.append(path)
+                        else:
+                            file_writes.append(path)
+                            sig = f"apply_patch:{path}"
+                            if sig in recent_sigs:
+                                retry_candidates.append("apply_patch")
+                            recent_sigs.append(sig)
+                            if len(recent_sigs) > 20:
+                                recent_sigs.pop(0)
+
+            elif payload_type == "function_call":
                 tool = payload.get("name", "")
                 if tool:
                     tool_calls[tool] = tool_calls.get(tool, 0) + 1
@@ -1099,9 +1123,15 @@ def extract_signals_codex(msgs: list[dict]) -> dict:
                     if code_match and code_match.group(1) != "0":
                         error_count += 1
 
-                # Git commit detection from exec_command output
-                if tool_name == "exec_command":
-                    for commit_match in _COMMIT_RE.finditer(output[:500]):
+                # Git commit detection from shell output. Codex uses a persistent
+                # shell session: an initial exec_command spawns the shell, and
+                # subsequent commands (including `git commit`) are piped through
+                # write_stdin — so the commit hash often appears in output
+                # attached to a write_stdin call. Codex outputs are also verbose
+                # (full file dumps), so scan a wider window than the legacy
+                # 500-char head.
+                if tool_name in ("exec_command", "write_stdin"):
+                    for commit_match in _COMMIT_RE.finditer(output[:8000]):
                         commit_hash = commit_match.group(1)
                         commit_msg = commit_match.group(2).strip()
                         git_commits.append(f"{commit_msg} ({commit_hash})")

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -3513,6 +3513,133 @@ def test_extract_signals_codex_tee_flags():
     assert "/tmp/output.log" in signals["file_writes"]
 
 
+def test_extract_signals_codex_apply_patch_file_writes():
+    """Codex uses custom_tool_call name=apply_patch for file edits.
+
+    Regression test for codex misclassification: real productive codex
+    sessions were grading 0.25 because apply_patch was invisible to the
+    extractor (it only checked function_call payloads, not custom_tool_call).
+    """
+    patch_input = (
+        "*** Begin Patch\n"
+        "*** Add File: knowledge/strategic/decision.md\n"
+        "+# Decision\n"
+        "+content\n"
+        "*** Update File: tasks/example.md\n"
+        "@@\n"
+        "-old line\n"
+        "+new line\n"
+        "*** Add File: journal/2026-04-25/autonomous-session-1994.md\n"
+        "+# Session\n"
+        "*** End Patch\n"
+    )
+    msgs = [
+        {
+            "timestamp": "2026-04-25T06:39:09Z",
+            "type": "session_meta",
+            "payload": {"originator": "codex_exec"},
+        },
+        {
+            "timestamp": "2026-04-25T06:40:00Z",
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call",
+                "name": "apply_patch",
+                "call_id": "call_p1",
+                "input": patch_input,
+            },
+        },
+    ]
+    signals = extract_signals_codex(msgs)
+    assert signals["tool_calls"].get("apply_patch") == 1
+    assert "knowledge/strategic/decision.md" in signals["file_writes"]
+    assert "tasks/example.md" in signals["file_writes"]
+    # Journal paths route to journal_paths, not file_writes
+    assert "journal/2026-04-25/autonomous-session-1994.md" in signals["journal_paths"]
+    assert "journal/2026-04-25/autonomous-session-1994.md" not in signals["file_writes"]
+
+
+def test_extract_signals_codex_commit_in_write_stdin_output():
+    """Commit hash output gets attached to write_stdin call_id, not exec_command.
+
+    Codex uses a persistent shell: exec_command spawns it, write_stdin sends
+    subsequent commands. The commit hash often lands in a write_stdin output.
+    """
+    msgs = [
+        {
+            "timestamp": "2026-04-25T06:39:09Z",
+            "type": "session_meta",
+            "payload": {"originator": "codex_exec"},
+        },
+        {
+            "timestamp": "2026-04-25T06:40:00Z",
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "write_stdin",
+                "call_id": "call_w1",
+                "arguments": json.dumps({"session_id": 1, "chars": "git commit ...\n"}),
+            },
+        },
+        {
+            "timestamp": "2026-04-25T06:40:01Z",
+            "type": "response_item",
+            "payload": {
+                "type": "function_call_output",
+                "call_id": "call_w1",
+                "output": (
+                    "Output:\n"
+                    "✓ All pre-commit checks passed\n"
+                    "[master b16170f38] docs(strategic): codify tauri BYOK as Q2 primary surface\n"
+                    " 6 files changed, 265 insertions(+), 1 deletion(-)\n"
+                ),
+            },
+        },
+    ]
+    signals = extract_signals_codex(msgs)
+    assert len(signals["git_commits"]) == 1
+    assert "b16170f38" in signals["git_commits"][0]
+    assert "tauri BYOK" in signals["git_commits"][0]
+
+
+def test_extract_signals_codex_commit_in_long_output():
+    """Commit hash buried after >500 chars of output should still be detected.
+
+    Codex outputs are verbose (full file dumps from sed/cat reads), so the
+    legacy 500-char cap missed real commits.
+    """
+    long_prefix = "x" * 1500 + "\n"
+    msgs = [
+        {
+            "timestamp": "2026-04-25T06:39:09Z",
+            "type": "session_meta",
+            "payload": {"originator": "codex_exec"},
+        },
+        {
+            "timestamp": "2026-04-25T06:40:00Z",
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "exec_command",
+                "call_id": "call_1",
+                "arguments": json.dumps({"cmd": "git commit ..."}),
+            },
+        },
+        {
+            "timestamp": "2026-04-25T06:40:01Z",
+            "type": "response_item",
+            "payload": {
+                "type": "function_call_output",
+                "call_id": "call_1",
+                "output": long_prefix + "[master abc1234] feat: new feature\n",
+            },
+        },
+    ]
+    signals = extract_signals_codex(msgs)
+    assert len(signals["git_commits"]) == 1
+    assert "abc1234" in signals["git_commits"][0]
+
+
 def test_extract_usage_codex():
     """Extract model and rate-limit info from Codex trajectory."""
     msgs = [


### PR DESCRIPTION
## Summary

Codex sessions were graded as noop-soft (0.25) despite real productive work. Two bugs in `extract_signals_codex` caused this:

### Bug 1: `apply_patch` invisible to extractor

Codex uses `custom_tool_call` (not `function_call`) with `name=apply_patch` for **all** file edits. The patch body lives in `payload.input` with `*** Add/Update/Delete File: PATH` directives. The extractor only iterated `payload_type == "function_call"`, so every apply_patch operation produced zero `file_writes`.

**Sampling 30 recent codex sessions: 29/30 used `apply_patch`** — almost every codex session was silently misclassified.

### Bug 2: Commit hash routed to `write_stdin`, not `exec_command`

Codex runs a persistent shell — `exec_command` spawns it, `write_stdin` sends subsequent commands. Commit hashes (`[master abc1234] msg`) end up in `function_call_output` of the `write_stdin` call_id, not `exec_command`. The detector only checked `tool_name == "exec_command"`.

Adjacent fix: widened the output scan window from 500 to 8000 chars (codex outputs are verbose with full file dumps).

## Real impact on session 1994 (codex/gpt-5.4, strategic)

| Field | Before | After |
|-------|--------|-------|
| `tool_calls.apply_patch` | 0 | 2 |
| `file_writes` | 0 | 5 |
| `journal_paths` | 0 | 1 |
| `git_commits` | 0 | 1 |
| `trajectory_grade` | **0.25** (noop floor) | **0.60** |

Now sits in the same band as `llm_judge_score=0.76` instead of the 0.51-gap noop floor.

## Wider sample (30 sequential codex sessions, 2026-04-25)

- 29/30 (97%) had `apply_patch > 0` and were silently misclassified
- 16/30 (53%) now grade ≥ 0.55 (active & productive)
- Only 2 still graded ≤ 0.25 (genuine noop sessions)

## Test plan

- [x] 3 new regression tests in `test_sessions.py`:
  - `test_extract_signals_codex_apply_patch_file_writes` — Add/Update/Delete File directives
  - `test_extract_signals_codex_commit_in_write_stdin_output` — commit on write_stdin call_id
  - `test_extract_signals_codex_commit_in_long_output` — commit hash buried >500 chars
- [x] All 22 codex tests pass
- [x] Full `gptme-sessions` suite: **722 passed, 0 failures**
- [x] Validated against real session trajectory (1994)

## Notes

- Forward-only correction: not retroactively re-grading existing sessions in the DB. The codex bandit posterior was depressed by misclassification (alpha=10.6, beta=16.1); new sessions starting now will accumulate corrected grades and the posterior will rebalance naturally.