### PR TITLE
fix(lessons): add natural-phrasing keywords to read-full-github-context

### DIFF
--- a/lessons/workflow/read-full-github-context.md
+++ b/lessons/workflow/read-full-github-context.md
@@ -14,6 +14,11 @@ match:
     - "review pr comments"
     - "look at the pr discussion"
     - "check the github discussion"
+    - "reading the issue"
+    - "looking at the issue"
+    - "looking at the pr"
+    - "let me check the issue"
+    - "checking the issue"
 status: active
 ---
 


### PR DESCRIPTION
## Summary

The `read-full-github-context` lesson was effectively silent in production — LOO data showed it firing in only **1/2074 sessions** (~0.05%), despite being an important behavioral lesson about not truncating GitHub comment output.

Root cause: existing keywords were specific phrases (`review pr comments`, `look at the pr discussion`, `investigate the github issue`) that don't match how CC actually phrases GitHub engagement in autonomous trajectories.

## Trajectory evidence

Counted natural phrasings across recent CC autonomous transcripts (`~/.claude/projects/-home-bob-bob/*.jsonl`):

| Phrase | Occurrences |
|--------|------------:|
| `reading the issue` | 328 |
| `looking at the issue` | 139 |
| `looking at the pr` | 135 |
| `let me check the issue` | 47 |
| `checking the issue` | 44 |

None of these matched the prior keyword list.

## Change

Adds the five validated phrases above as additional keywords. Existing keywords stay intact.

## Risk / over-fire

These phrases are common but they only fire on sessions where the model is engaging with a GitHub issue/PR — exactly the moment when the truncation rule applies. Even in moderate-noise mode, the lesson's content is non-harmful (it's a "don't truncate" reminder).

## Test plan

- [x] Lesson validates: `python3 packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py lessons/workflow/read-full-github-context.md` → ✅
- [ ] CI passes
- [ ] Greptile review (will trigger via helper after CI)