### PR TITLE
fix(twitter): support markdown draft discovery

### DIFF
--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -199,11 +199,11 @@ def _parse_markdown_frontmatter(text: str) -> tuple[dict[str, Any], str] | None:
         return None
 
     lines = text.splitlines()
-    if not lines or lines[0].strip() != "---":
+    if not lines or lines[0].rstrip() != "---":
         return None
 
     end_idx = next(
-        (i for i, line in enumerate(lines[1:], start=1) if line.strip() == "---"),
+        (i for i, line in enumerate(lines[1:], start=1) if line.rstrip() == "---"),
         None,
     )
     if end_idx is None:

--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -137,6 +137,7 @@ POSTED_DIR = TWEETS_DIR / "posted"
 REJECTED_DIR = TWEETS_DIR / "rejected"
 CACHE_DIR = TWEETS_DIR / "cache"
 MAX_POSTS_PER_CYCLE = 2  # Rate limit to prevent mass posting in auto mode
+DRAFT_FILE_SUFFIXES = (".yml", ".yaml", ".md")
 
 # Ensure directories exist
 for dir in [NEW_DIR, REVIEW_DIR, APPROVED_DIR, POSTED_DIR, REJECTED_DIR, CACHE_DIR]:
@@ -181,6 +182,39 @@ def load_from_cache(tweet_id: str) -> Tuple[dict | None, dict | None]:
         cache_data = json.load(f)
 
     return cache_data.get("evaluation"), cache_data.get("response")
+
+
+def _list_draft_files(directory: Path) -> List[Path]:
+    """Return draft files for all supported draft formats."""
+    files_by_name: dict[str, Path] = {}
+    for suffix in DRAFT_FILE_SUFFIXES:
+        for path in directory.glob(f"*{suffix}"):
+            files_by_name[path.name] = path
+    return [files_by_name[name] for name in sorted(files_by_name)]
+
+
+def _parse_markdown_frontmatter(text: str) -> tuple[dict[str, Any], str] | None:
+    """Split markdown frontmatter and body if present."""
+    if not text.startswith("---"):
+        return None
+
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return None
+
+    end_idx = next(
+        (i for i, line in enumerate(lines[1:], start=1) if line.strip() == "---"),
+        None,
+    )
+    if end_idx is None:
+        return None
+
+    metadata = yaml.safe_load("\n".join(lines[1:end_idx])) or {}
+    if not isinstance(metadata, dict):
+        raise ValueError("Markdown frontmatter must be a YAML dictionary")
+
+    body = "\n".join(lines[end_idx + 1 :]).strip()
+    return metadata, body
 
 
 class TweetDraft:
@@ -272,14 +306,38 @@ class TweetDraft:
 
     def save(self, path: Path) -> None:
         """Save draft to file"""
+        if path.suffix == ".md":
+            data = self.to_dict()
+            body = data.pop("text", "").strip()
+            with path.open("w") as f:
+                f.write("---\n")
+                yaml.safe_dump(data, f, sort_keys=False)
+                f.write("---\n")
+                if body:
+                    f.write("\n")
+                    f.write(body)
+                    f.write("\n")
+            return
+
         with path.open("w") as f:
-            yaml.dump(self.to_dict(), f)
+            yaml.safe_dump(self.to_dict(), f, sort_keys=False)
 
     @classmethod
     def load(cls, path: Path) -> "TweetDraft":
         """Load draft from file"""
-        with path.open("r") as f:
-            data = yaml.safe_load(f)
+        text = path.read_text()
+        frontmatter = (
+            _parse_markdown_frontmatter(text) if path.suffix == ".md" else None
+        )
+        if frontmatter is not None:
+            data, body = frontmatter
+            if body and not data.get("text") and not data.get("content"):
+                data["text"] = body
+        else:
+            data = yaml.safe_load(text)
+
+        if not isinstance(data, dict):
+            raise ValueError(f"Invalid draft payload in {path}")
         return cls.from_dict(data)
 
 
@@ -612,16 +670,28 @@ def find_draft(
     if "/" in draft_id:
         draft_path = Path(draft_id)
         if not draft_path.exists() and not draft_path.suffix:
-            draft_path = draft_path.with_suffix(".yml")
-        if draft_path.exists():
+            for suffix in DRAFT_FILE_SUFFIXES:
+                candidate = draft_path.with_suffix(suffix)
+                if candidate.exists():
+                    return candidate
+        elif draft_path.exists():
             return draft_path
     else:
         # Search in specified directories
         search_dirs = [status_dirs[status]] if status else status_dirs.values()
         for dir in search_dirs:
-            for path in [dir / draft_id, (dir / draft_id).with_suffix(".yml")] + list(
-                dir.glob(f"*{draft_id}*.yml")
-            ):
+            candidates = [dir / draft_id]
+            if not Path(draft_id).suffix:
+                candidates.extend(
+                    (dir / draft_id).with_suffix(suffix)
+                    for suffix in DRAFT_FILE_SUFFIXES
+                )
+            candidates.extend(
+                path
+                for path in _list_draft_files(dir)
+                if draft_id in path.stem or draft_id in path.name
+            )
+            for path in candidates:
                 if path.exists():
                     return path
 
@@ -629,7 +699,7 @@ def find_draft(
         status_msg = f" in {status} directory" if status else ""
         console.print(f"[red]No draft found{status_msg}: {draft_id}")
         console.print(
-            "[yellow]ID can be: simple ID, filename, or full path (e.g., tweet_20250419, reply_*.yml, tweets/new/*.yml)"
+            "[yellow]ID can be: simple ID, filename, or full path (e.g., tweet_20250419, reply_*.yml, manual-draft.md)"
         )
 
     return None
@@ -648,7 +718,7 @@ def list_drafts(status: str) -> List[Path]:
     if status not in status_dirs:
         raise ValueError(f"Invalid status: {status}")
 
-    return sorted(status_dirs[status].glob("*.yml"))
+    return _list_draft_files(status_dirs[status])
 
 
 @click.group()
@@ -734,7 +804,7 @@ def _check_for_duplicate_replies_internal(draft: TweetDraft) -> dict[str, list[P
             continue
 
         matching_drafts = []
-        for draft_path in status_dir.glob("*.yml"):
+        for draft_path in _list_draft_files(status_dir):
             try:
                 other_draft = TweetDraft.load(draft_path)
                 if other_draft.in_reply_to == tweet_id:
@@ -1193,7 +1263,7 @@ def process_timeline_tweets(
     tweets_skipped_prefilter = 0
 
     # Count existing drafts in new/ directory
-    existing_drafts = len(list(NEW_DIR.glob("*.yml")))
+    existing_drafts = len(_list_draft_files(NEW_DIR))
     total_drafts = existing_drafts + drafts_generated
 
     # Check if we're already at or over the limit
@@ -1216,7 +1286,7 @@ def process_timeline_tweets(
         status_dir = TWEETS_DIR / status_dir_name
         if not status_dir.exists():
             continue
-        for draft_path in status_dir.glob("*.yml"):
+        for draft_path in _list_draft_files(status_dir):
             try:
                 other_draft = TweetDraft.load(draft_path)
                 if other_draft.in_reply_to is not None:

--- a/tests/test_twitter_workflow_drafts.py
+++ b/tests/test_twitter_workflow_drafts.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import importlib.util
+import logging
+import sys
+import types
+from collections.abc import Generator
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW_PATH = REPO_ROOT / "scripts" / "twitter" / "workflow.py"
+
+
+def _make_pkg(name: str) -> types.ModuleType:
+    mod = types.ModuleType(name)
+    mod.__path__ = []
+    return mod
+
+
+def _load_workflow_module() -> Any:
+    class _Operation:
+        def complete(self, *args, **kwargs) -> None:
+            return None
+
+    class _MetricsCollector:
+        def start_operation(self, *args, **kwargs) -> _Operation:
+            return _Operation()
+
+    monitoring_stub: Any = types.ModuleType("gptmail.communication_utils.monitoring")
+    monitoring_stub.MetricsCollector = _MetricsCollector
+    monitoring_stub.get_logger = lambda *args, **kwargs: logging.getLogger(
+        "twitter-test"
+    )
+
+    gptmail_stub = _make_pkg("gptmail")
+    gptmail_comm_stub = _make_pkg("gptmail.communication_utils")
+
+    gptme_stub = _make_pkg("gptme")
+    gptme_init_stub: Any = types.ModuleType("gptme.init")
+    gptme_init_stub.init = lambda *args, **kwargs: None
+
+    dotenv_stub: Any = types.ModuleType("dotenv")
+    dotenv_stub.load_dotenv = lambda *args, **kwargs: None
+
+    click_stub: Any = types.ModuleType("click")
+
+    def _passthrough_decorator(*args, **kwargs):
+        def _decorator(func):
+            return func
+
+        return _decorator
+
+    def _group_decorator(*args, **kwargs):
+        def _decorator(func):
+            func.command = _passthrough_decorator
+            return func
+
+        return _decorator
+
+    click_stub.group = _group_decorator
+    click_stub.command = _passthrough_decorator
+    click_stub.option = _passthrough_decorator
+    click_stub.argument = _passthrough_decorator
+    click_stub.Choice = lambda choices: choices
+    click_stub.Path = lambda **kwargs: kwargs
+    click_stub.echo = lambda *args, **kwargs: None
+
+    rich_stub = _make_pkg("rich")
+    rich_console_stub: Any = types.ModuleType("rich.console")
+    rich_console_stub.Console = lambda *args, **kwargs: SimpleNamespace(
+        print=lambda *print_args, **print_kwargs: None
+    )
+    rich_prompt_stub: Any = types.ModuleType("rich.prompt")
+    rich_prompt_stub.Confirm = SimpleNamespace(ask=lambda *args, **kwargs: True)
+    rich_prompt_stub.Prompt = SimpleNamespace(ask=lambda *args, **kwargs: "")
+
+    trusted_users_stub: Any = types.ModuleType("trusted_users")
+    trusted_users_stub.is_trusted_user = lambda *args, **kwargs: False
+
+    twitter_pkg_stub = _make_pkg("twitter")
+    twitter_llm_stub: Any = types.ModuleType("twitter.llm")
+    twitter_llm_stub.EvaluationResponse = type("EvaluationResponse", (), {})
+    twitter_llm_stub.TweetResponse = type("TweetResponse", (), {})
+    twitter_llm_stub.process_tweet = lambda *args, **kwargs: None
+    twitter_llm_stub.verify_draft = lambda *args, **kwargs: (True, None)
+
+    twitter_api_stub: Any = types.ModuleType("twitter.twitter")
+    twitter_api_stub.cached_get_me = lambda *args, **kwargs: SimpleNamespace(
+        data=SimpleNamespace(id=0)
+    )
+    twitter_api_stub.load_twitter_client = lambda *args, **kwargs: None
+
+    stubbed_modules: dict[str, Any] = {
+        "gptmail": gptmail_stub,
+        "gptmail.communication_utils": gptmail_comm_stub,
+        "gptmail.communication_utils.monitoring": monitoring_stub,
+        "gptme": gptme_stub,
+        "gptme.init": gptme_init_stub,
+        "dotenv": dotenv_stub,
+        "click": click_stub,
+        "rich": rich_stub,
+        "rich.console": rich_console_stub,
+        "rich.prompt": rich_prompt_stub,
+        "trusted_users": trusted_users_stub,
+        "twitter": twitter_pkg_stub,
+        "twitter.llm": twitter_llm_stub,
+        "twitter.twitter": twitter_api_stub,
+    }
+
+    for name, stub in stubbed_modules.items():
+        sys.modules.setdefault(name, stub)
+
+    spec = importlib.util.spec_from_file_location(
+        "twitter_workflow_under_test", WORKFLOW_PATH
+    )
+    assert spec and spec.loader
+    module: Any = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def workflow_module() -> Generator[Any, None, None]:
+    stub_keys = (
+        "gptmail",
+        "gptmail.communication_utils",
+        "gptmail.communication_utils.monitoring",
+        "gptme",
+        "gptme.init",
+        "dotenv",
+        "click",
+        "rich",
+        "rich.console",
+        "rich.prompt",
+        "trusted_users",
+        "twitter",
+        "twitter.llm",
+        "twitter.twitter",
+        "twitter_workflow_under_test",
+    )
+    pre_existing = {key for key in stub_keys if key in sys.modules}
+    module = _load_workflow_module()
+    yield module
+    for key in stub_keys:
+        if key not in pre_existing:
+            sys.modules.pop(key, None)
+
+
+def _set_status_dirs(module: Any, tmp_path: Path) -> None:
+    tweets_dir = tmp_path / "tweets"
+    module.TWEETS_DIR = tweets_dir
+    module.NEW_DIR = tweets_dir / "new"
+    module.REVIEW_DIR = tweets_dir / "review"
+    module.APPROVED_DIR = tweets_dir / "approved"
+    module.POSTED_DIR = tweets_dir / "posted"
+    module.REJECTED_DIR = tweets_dir / "rejected"
+    module.CACHE_DIR = tweets_dir / "cache"
+    for directory in (
+        module.NEW_DIR,
+        module.REVIEW_DIR,
+        module.APPROVED_DIR,
+        module.POSTED_DIR,
+        module.REJECTED_DIR,
+        module.CACHE_DIR,
+    ):
+        directory.mkdir(parents=True, exist_ok=True)
+
+
+def _write_markdown_draft(
+    path: Path,
+    *,
+    body: str,
+    draft_type: str = "tweet",
+    in_reply_to: str | None = None,
+) -> None:
+    frontmatter = [
+        "---",
+        "status: draft",
+        "created: 2026-03-19",
+        f"type: {draft_type}",
+    ]
+    if in_reply_to is not None:
+        frontmatter.append(f'in_reply_to: "{in_reply_to}"')
+    frontmatter.extend(["---", "", body])
+    path.write_text("\n".join(frontmatter) + "\n")
+
+
+def test_tweet_draft_loads_markdown_frontmatter_body_as_text(
+    workflow_module: Any, tmp_path: Path
+) -> None:
+    draft_path = tmp_path / "manual-draft.md"
+    _write_markdown_draft(
+        draft_path,
+        body="Manual markdown draft body.",
+        draft_type="reply",
+        in_reply_to="12345",
+    )
+
+    draft = workflow_module.TweetDraft.load(draft_path)
+
+    assert draft.text == "Manual markdown draft body."
+    assert draft.type == "reply"
+    assert draft.in_reply_to == "12345"
+
+
+def test_list_and_find_drafts_include_markdown_files(
+    workflow_module: Any, tmp_path: Path
+) -> None:
+    _set_status_dirs(workflow_module, tmp_path)
+    md_path = workflow_module.NEW_DIR / "manual-draft.md"
+    yml_path = workflow_module.NEW_DIR / "tweet_20260319_120000.yml"
+
+    _write_markdown_draft(md_path, body="Manual markdown draft body.")
+    yml_path.write_text(
+        "text: YAML draft body.\ntype: tweet\ncreated_at: 2026-03-19T12:00:00\n"
+    )
+
+    drafts = workflow_module.list_drafts("new")
+
+    assert [path.name for path in drafts] == sorted([md_path.name, yml_path.name])
+    assert (
+        workflow_module.find_draft("manual-draft", "new", show_error=False) == md_path
+    )
+
+
+def test_move_draft_preserves_markdown_round_trip(
+    workflow_module: Any, tmp_path: Path
+) -> None:
+    _set_status_dirs(workflow_module, tmp_path)
+    draft_path = workflow_module.NEW_DIR / "manual-draft.md"
+    _write_markdown_draft(draft_path, body="Keep this markdown body intact.")
+
+    moved_path = workflow_module.move_draft(draft_path, "approved")
+    moved = workflow_module.TweetDraft.load(moved_path)
+
+    assert moved_path == workflow_module.APPROVED_DIR / "manual-draft.md"
+    assert moved.text == "Keep this markdown body intact."
+
+
+def test_duplicate_reply_detection_reads_markdown_drafts(
+    workflow_module: Any, tmp_path: Path
+) -> None:
+    _set_status_dirs(workflow_module, tmp_path)
+    existing_path = workflow_module.APPROVED_DIR / "reply_existing.md"
+    _write_markdown_draft(
+        existing_path,
+        body="Existing reply body.",
+        draft_type="reply",
+        in_reply_to="4242",
+    )
+
+    draft = workflow_module.TweetDraft(
+        text="New reply",
+        type="reply",
+        in_reply_to="4242",
+    )
+    duplicates = workflow_module._check_for_duplicate_replies_internal(draft)
+
+    assert duplicates == {"approved": [existing_path]}


### PR DESCRIPTION
## Summary
- teach the Twitter workflow to discover `.md` and `.yaml` drafts alongside `.yml`
- parse markdown frontmatter + body into `TweetDraft` so manual markdown drafts actually load
- add regression tests for listing, finding, moving, and duplicate-detecting markdown drafts

## Testing
- uv run pytest tests/test_twitter_workflow_drafts.py -q
- prek run mypy --files scripts/twitter/workflow.py tests/test_twitter_workflow_drafts.py
- uv run ruff check scripts/twitter/workflow.py tests/test_twitter_workflow_drafts.py