### PR TITLE
chore(lessons): deprecate 5 silent lessons shadowed by Bob-local equivalents

### DIFF
--- a/lessons/autonomous/maintaining-readiness-during-blocked-periods.md
+++ b/lessons/autonomous/maintaining-readiness-during-blocked-periods.md
@@ -8,10 +8,17 @@ match:
     - strategic pause framework
     - blocked waiting for response
     - stakeholder hasn't replied
-status: active
+status: deprecated
 ---
 
 # Maintaining Readiness During Blocked Periods
+
+> **Deprecated 2026-04-26**: shadowed by Bob-local
+> `strategic/pivot-to-secondary-tasks-when-.md` (TS=0.450, n=49) and
+> `workflow/autonomous-run.md` (TS=0.439, n=1896), which cover the same
+> actionable kernel without 274 lines of Alice-specific framework material.
+> Rationale: `knowledge/analysis/silent-lessons-shadowing-2026-04-26.md` in
+> ErikBjare/bob.
 
 ## Rule
 Maintain strategic readiness and productive capacity when all primary work is blocked by external dependencies.

--- a/lessons/autonomous/multi-issue-coordination-patterns.md
+++ b/lessons/autonomous/multi-issue-coordination-patterns.md
@@ -6,10 +6,17 @@ match:
   - blocked across multiple issues
   - parallel blocked tasks
   - coordinate blocked work
-status: active
+status: deprecated
 ---
 
 # Multi-Issue Coordination Patterns
+
+> **Deprecated 2026-04-26**: shadowed by Bob-local
+> `strategic/pivot-to-secondary-tasks-when-.md` (TS=0.450, n=49) and
+> `workflow/autonomous-run.md` (TS=0.439, n=1896), which cover the same
+> actionable kernel without 274 lines of Alice-specific framework material.
+> Rationale: `knowledge/analysis/silent-lessons-shadowing-2026-04-26.md` in
+> ErikBjare/bob.
 
 Strategies for effectively managing multiple parallel GitHub issues when primary work is blocked on external dependencies.
 

--- a/lessons/autonomous/thompson-sampling-work-categories.md
+++ b/lessons/autonomous/thompson-sampling-work-categories.md
@@ -1,5 +1,5 @@
 ---
-status: active
+status: deprecated
 category: autonomous
 tags:
 - thompson-sampling
@@ -16,6 +16,13 @@ match:
 ---
 
 # Thompson Sampling for Work Category Optimization
+
+> **Deprecated 2026-04-26**: shadowed by Bob-local
+> `workflow/category-conditional-bandit-routing.md` and
+> `patterns/friction-analysis.md` (TS=0.525, n=763), which carry the runtime
+> decision in production. Justification content for category-level TS belongs
+> in `knowledge/`, not as runtime lesson guidance. Rationale:
+> `knowledge/analysis/silent-lessons-shadowing-2026-04-26.md` in ErikBjare/bob.
 
 ## Rule
 Use Thompson sampling over *work categories* (code, triage, infrastructure, content), not *session modes* (autonomous, monitoring, email). Categories are the explore/exploit decision; modes are a scheduling choice.

--- a/lessons/communication/github-issue-follow-through.md
+++ b/lessons/communication/github-issue-follow-through.md
@@ -8,10 +8,16 @@ match:
     - confirm completion in thread
     - missing follow-up response
     - broken communication loop
-status: active
+status: deprecated
 ---
 
 # GitHub Issue Follow-Through Pattern
+
+> **Deprecated 2026-04-26**: shadowed by Bob-local
+> `social/github-issue-engagement.md` (TS=0.416, n=1200), which fires reliably
+> on the same surface (close the loop on the original issue when work
+> completes). Rationale:
+> `knowledge/analysis/silent-lessons-shadowing-2026-04-26.md` in ErikBjare/bob.
 
 ## Rule
 ALWAYS respond in the original issue thread when completing any action requested in that thread.

--- a/lessons/tools/shell-output-filtering.md
+++ b/lessons/tools/shell-output-filtering.md
@@ -5,10 +5,16 @@ match:
   - command dumped 10k+ tokens
   - large output 1000+ lines
   - token efficiency shell
-status: active
+status: deprecated
 ---
 
 # Shell Output Filtering for Token Efficiency
+
+> **Deprecated 2026-04-26**: shadowed by Bob-local
+> `tools/grep-recursive-safety.md` (TS=0.510, n=445) and
+> `tools/extract-code-sections-with-sed.md` (TS=0.520, n=198), which carry the
+> same principle with concrete tool guidance and active matching. Rationale:
+> `knowledge/analysis/silent-lessons-shadowing-2026-04-26.md` in ErikBjare/bob.
 
 ## Rule
 Always filter shell output with grep/head/tail when expecting large results (>1000 lines).


### PR DESCRIPTION
## Summary

Five lessons in `gptme-contrib/lessons/` had zero firings in the last 7-day window per Bob's Thompson sampling trajectory data, and each is shadowed by a high-firing Bob-local lesson covering the same actionable surface. Flipping them to `status: deprecated` keeps the rule content and git history intact while removing them from runtime context budget for agents that don't override.

## Shadowing analysis (snapshot 2026-04-26 18:55 UTC)

TS = α/(α+β) Beta posterior mean from `state/lesson-thompson/bandit-state.json`. n = total selections.

| Deprecated lesson | Local shadow(s) (TS / n) | Why deprecate |
|---|---|---|
| `autonomous/multi-issue-coordination-patterns.md` | `strategic/pivot-to-secondary-tasks-when-.md` (0.450 / 49), `workflow/autonomous-run.md` (0.439 / 1896) | Bob's two lessons cover the same actionable kernel — pivot to secondary work when primary is blocked, return when unblocked — without the 274 lines of Alice-specific framework material. |
| `autonomous/maintaining-readiness-during-blocked-periods.md` | (same as above) | Same shadow, same reasoning. Both lessons were extracted from Alice's coordinated-blocking experience over Jan-Feb 2026. |
| `autonomous/thompson-sampling-work-categories.md` | `workflow/category-conditional-bandit-routing.md`, `patterns/friction-analysis.md` (0.525 / 763) | Reference content (justification for category-level TS) belongs in `knowledge/`, not as runtime guidance — the live decision is encoded in friction-analysis. |
| `communication/github-issue-follow-through.md` | `social/github-issue-engagement.md` (0.416 / 1200) | Same surface (close the loop on the original issue when work completes); the Bob-local copy fires 1200 times. |
| `tools/shell-output-filtering.md` | `tools/grep-recursive-safety.md` (0.510 / 445), `tools/extract-code-sections-with-sed.md` (0.520 / 198) | Bob already has two strong local lessons covering the same principle with concrete tool guidance. |

Net: 5 deprecations across 3 categories.

## Two silent lessons NOT in this PR

- `tools/ast-grep-refactoring.md` — no shadow, tool-specific. Needs keyword re-keying from body content (real `sg run --pattern` invocations).
- `workflow/agent-event-watch-workflow.md` — no shadow, genuinely useful watch-task pattern. Needs body-extraction re-keying.

These are blocked on Phase 2 of ErikBjare/bob#694 (`--from-body` mode for `lesson-keyword-suggest.py`).

## Why deprecation, not deletion

- Removes the lesson from runtime context but signals intent
- Preserves git history and the rule content for archaeological reference
- Allows other gptme-based agents (Alice, Sven, Gordon) to override status if they have a different operational profile (e.g. Alice's blocked-period lessons may genuinely fit her)
- Keeps the path open to undeprecate if the operational context changes

Each deprecated file has a one-line note pointing to its Bob-local shadow.

## Rationale source

Full per-lesson reasoning in `knowledge/analysis/silent-lessons-shadowing-2026-04-26.md` (ErikBjare/bob workspace, commit 211965efd).

## Test plan

- [x] All 5 files pass `scripts/precommit/validate_lesson_metadata.py`
- [x] Pre-commit hooks passed locally (prek)
- [ ] CI on this PR