### PR TITLE
fix(repo-status): skip 'skipped' workflow runs when finding CI status

### DIFF
--- a/scripts/github/repo-status.sh
+++ b/scripts/github/repo-status.sh
@@ -48,6 +48,16 @@ check_repo() {
         run_json=$(echo "$run_json" | jq --argjson disabled "$disabled_json" '[.[] | select(.name as $n | $disabled | index($n) | not)]')
     fi
 
+    # Filter out runs with "skipped" conclusion — conditional workflows that don't apply
+    # to the current event type (e.g. gptme-bot only runs on PR/issue events, gets
+    # "skipped" on master pushes and otherwise masks the passing build/test runs).
+    # Only filter if there are non-skipped runs to fall back to.
+    local non_skipped_json
+    non_skipped_json=$(echo "$run_json" | jq '[.[] | select(.conclusion != "skipped")]')
+    if [ "$(echo "$non_skipped_json" | jq 'length')" -gt 0 ]; then
+        run_json="$non_skipped_json"
+    fi
+
     local conclusion status in_progress=""
     conclusion=$(echo "$run_json" | jq -r '.[0].conclusion // ""')
     status=$(echo "$run_json" | jq -r '.[0].status // ""')


### PR DESCRIPTION
## Problem

`repo-status.sh` was reporting `gptme/gptme: skipped` as a warning in the CI status dashboard, even though all actual tests (Build, Docs, Lint, Benchmark) passed.

**Root cause**: The `gptme-bot` workflow is a conditional workflow that only runs on PR/issue events. On regular master pushes it completes with `conclusion=skipped`. Since it runs *after* the main CI suite, it becomes the most-recent run in `gh run list` output — masking the actual passing builds.

## Fix

After filtering disabled workflows, also filter out runs with `conclusion=skipped`. Only fall back to skipped-only if there are truly no other runs.

```bash
# Filter out runs with "skipped" conclusion — conditional workflows that don't apply
# to the current event type (e.g. gptme-bot only runs on PR/issue events, gets
# "skipped" on master pushes and otherwise masks the passing build/test runs).
local non_skipped_json
non_skipped_json=$(echo "$run_json" | jq '[.[] | select(.conclusion != "skipped")]')
if [ "$(echo "$non_skipped_json" | jq 'length')" -gt 0 ]; then
    run_json="$non_skipped_json"
fi
```

## Verified

Before: `⚠ gptme/gptme: skipped`  
After: `✓ gptme/gptme: Passing`