### PR TITLE
feat(gptodo): add `claim` command + relax assigned_to validation

### DIFF
--- a/packages/gptodo/pyproject.toml
+++ b/packages/gptodo/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "click>=8.0.0",
     "rich>=13.0.0",
     "tabulate>=0.9.0",
+    "tomli>=2.0.1; python_version < '3.11'",
 ]
 
 [project.urls]

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -1393,7 +1393,9 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask):
         # Optional fields with validation
         "priority": {"type": "enum", "values": ["high", "medium", "low", "none"]},
         "task_type": {"type": "enum", "values": ["project", "action", "none"]},
-        "assigned_to": {"type": "enum", "values": ["agent", "human", "both", "none"]},
+        # Real workspaces use named assignees (bob, erik, alice, etc.).
+        # Keep "none" as the explicit clear value; otherwise accept any string.
+        "assigned_to": {"type": "string"},
         "waiting_since": {"type": "date"},
         # Optional fields with arbitrary string values
         "next_action": {"type": "string"},
@@ -1651,6 +1653,128 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask):
     # Show success message
     count = len(target_tasks)
     console.print(f"[green]✓ Updated {count} task{'s' if count > 1 else ''}[/]")
+
+
+# States that cannot be claimed (already terminal or deliberately deferred/blocked).
+_CLAIM_REFUSED_STATES = {"waiting", "ready_for_review", "someday", "done", "cancelled"}
+# States that get auto-promoted to active on claim.
+_CLAIM_PROMOTABLE_STATES = {"backlog", "todo"}
+
+
+def _resolve_agent_name(repo_root: Path, override: str | None) -> str:
+    """Resolve the agent name for a claim.
+
+    Order:
+        1. ``--agent NAME`` CLI override
+        2. ``GPTODO_AGENT_NAME`` env var
+        3. ``[agent].name`` from ``gptme.toml`` (lowercased)
+        4. fallback ``"agent"``
+    """
+    if override:
+        return override.strip()
+
+    env_name = os.environ.get("GPTODO_AGENT_NAME")
+    if env_name:
+        return env_name.strip()
+
+    gptme_toml = repo_root / "gptme.toml"
+    if gptme_toml.exists():
+        try:
+            try:
+                import tomllib  # type: ignore[import-not-found]
+            except ModuleNotFoundError:
+                import tomli as tomllib  # type: ignore[import-not-found,no-redef]
+            data = tomllib.loads(gptme_toml.read_text())
+            agent_section = data.get("agent")
+            if isinstance(agent_section, dict):
+                name = agent_section.get("name")
+                if isinstance(name, str) and name.strip():
+                    return name.strip().lower()
+        except Exception:
+            pass
+
+    return "agent"
+
+
+@cli.command("claim")
+@click.argument("task_id")
+@click.option("--agent", "agent_override", default=None, help="Agent name to record as owner.")
+def claim(task_id: str, agent_override: str | None):
+    """Claim a task for the current agent.
+
+    Sets ``state: active`` (for backlog/todo), records ``assigned_to`` and
+    ``assigned_at``, and refuses to claim waiting / ready_for_review /
+    someday / terminal tasks.
+
+    Agent name resolution: --agent flag, then GPTODO_AGENT_NAME env var,
+    then [agent].name from gptme.toml (lowercased), else "agent".
+
+    Examples:
+        gptodo claim my-task
+        gptodo claim my-task --agent bob
+    """
+    console = Console()
+    repo_root = find_repo_root(Path.cwd())
+    tasks_dir = repo_root / "tasks"
+
+    tasks = load_tasks(tasks_dir)
+    if not tasks:
+        console.print("[red]No tasks found[/]")
+        sys.exit(1)
+
+    try:
+        target_tasks = resolve_tasks([task_id], tasks, tasks_dir)
+    except ValueError as e:
+        console.print(f"[red]{e}[/]")
+        sys.exit(1)
+
+    if len(target_tasks) != 1:
+        console.print(f"[red]claim requires exactly one task, got {len(target_tasks)}[/]")
+        sys.exit(1)
+
+    task = target_tasks[0]
+    agent = _resolve_agent_name(repo_root, agent_override)
+
+    current_state = normalize_state(task.metadata.get("state", "backlog"), warn=False)
+    current_assignee = task.metadata.get("assigned_to")
+    current_assigned_at = task.metadata.get("assigned_at")
+
+    if current_state in _CLAIM_REFUSED_STATES:
+        console.print(
+            f"[red]Refusing to claim {task.id}: state is '{current_state}'. "
+            "Resolve the blocker (or revive from someday) before claiming.[/]"
+        )
+        sys.exit(1)
+
+    # Idempotent no-op: already active, same owner, has assigned_at.
+    if current_state == "active" and current_assignee == agent and current_assigned_at is not None:
+        console.print(
+            f"[yellow]Already claimed:[/] {task.id} (owner={agent}, since={current_assigned_at})"
+        )
+        return
+
+    post = frontmatter.load(task.path)
+
+    new_state = "active" if current_state in _CLAIM_PROMOTABLE_STATES else current_state
+    if current_state in _CLAIM_PROMOTABLE_STATES:
+        post.metadata["state"] = new_state
+
+    post.metadata["assigned_to"] = agent
+    now_utc = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    post.metadata["assigned_at"] = now_utc
+
+    with open(task.path, "w") as f:
+        f.write(frontmatter.dumps(post))
+
+    if current_state in _CLAIM_PROMOTABLE_STATES:
+        console.print(
+            f"[green]✓ Claimed[/] {task.id} (state: {current_state} → active, owner: {agent})"
+        )
+    elif current_assignee != agent:
+        prev = current_assignee or "unassigned"
+        console.print(f"[green]✓ Reassigned[/] {task.id} (owner: {prev} → {agent}, state: active)")
+    else:
+        console.print(f"[green]✓ Re-claimed[/] {task.id} (owner: {agent}, state: active)")
 
 
 @cli.command("tags")

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -6,6 +6,7 @@
 #     "rich>=13.0.0",
 #     "python-frontmatter>=1.1.0",
 #     "tabulate>=0.9.0",
+#     "tomli>=2.0.1; python_version < '3.11'",
 # ]
 # [tool.uv]
 # exclude-newer = "2024-04-01T00:00:00Z"
@@ -1670,12 +1671,14 @@ def _resolve_agent_name(repo_root: Path, override: str | None) -> str:
         3. ``[agent].name`` from ``gptme.toml`` (lowercased)
         4. fallback ``"agent"``
     """
-    if override:
-        return override.strip()
+    if override is not None:
+        stripped = override.strip()
+        if stripped:
+            return stripped
 
-    env_name = os.environ.get("GPTODO_AGENT_NAME")
+    env_name = os.environ.get("GPTODO_AGENT_NAME", "").strip()
     if env_name:
-        return env_name.strip()
+        return env_name
 
     gptme_toml = repo_root / "gptme.toml"
     if gptme_toml.exists():
@@ -1683,15 +1686,27 @@ def _resolve_agent_name(repo_root: Path, override: str | None) -> str:
             try:
                 import tomllib  # type: ignore[import-not-found]
             except ModuleNotFoundError:
-                import tomli as tomllib  # type: ignore[import-not-found,no-redef]
+                try:
+                    import tomli as tomllib  # type: ignore[import-not-found,no-redef]
+                except ModuleNotFoundError:
+                    console.print(
+                        "[yellow]Warning: tomli is required on Python <3.11 to read "
+                        "gptme.toml; falling back to 'agent'[/]"
+                    )
+                    return "agent"
+
             data = tomllib.loads(gptme_toml.read_text())
-            agent_section = data.get("agent")
-            if isinstance(agent_section, dict):
-                name = agent_section.get("name")
-                if isinstance(name, str) and name.strip():
-                    return name.strip().lower()
-        except Exception:
-            pass
+        except (OSError, tomllib.TOMLDecodeError) as exc:
+            console.print(
+                f"[yellow]Warning: Failed to load {gptme_toml}: {exc}. Falling back to 'agent'.[/]"
+            )
+            return "agent"
+
+        agent_section = data.get("agent")
+        if isinstance(agent_section, dict):
+            name = agent_section.get("name")
+            if isinstance(name, str) and name.strip():
+                return name.strip().lower()
 
     return "agent"
 

--- a/packages/gptodo/tests/test_claim.py
+++ b/packages/gptodo/tests/test_claim.py
@@ -158,6 +158,31 @@ def test_claim_resolves_agent_from_env(workspace: Path, monkeypatch: pytest.Monk
     assert meta["assigned_to"] == "alice"
 
 
+def test_claim_ignores_blank_agent_override(workspace: Path) -> None:
+    path = write_task(
+        workspace, "blank-override-task", state="backlog", created="2026-04-26T00:00:00+00:00"
+    )
+
+    result = CliRunner().invoke(cli, ["claim", "blank-override-task", "--agent", "   "])
+
+    assert result.exit_code == 0, result.output
+    meta = load_meta(path)
+    assert meta["assigned_to"] == "bob"
+
+
+def test_claim_ignores_blank_env(workspace: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GPTODO_AGENT_NAME", "   ")
+    path = write_task(
+        workspace, "blank-env-task", state="backlog", created="2026-04-26T00:00:00+00:00"
+    )
+
+    result = CliRunner().invoke(cli, ["claim", "blank-env-task"])
+
+    assert result.exit_code == 0, result.output
+    meta = load_meta(path)
+    assert meta["assigned_to"] == "bob"
+
+
 def test_claim_resolves_agent_from_gptme_toml(
     workspace: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -170,6 +195,23 @@ def test_claim_resolves_agent_from_gptme_toml(
     assert result.exit_code == 0
     meta = load_meta(path)
     assert meta["assigned_to"] == "bob"
+
+
+def test_claim_warns_on_invalid_gptme_toml(
+    workspace: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("GPTODO_AGENT_NAME", raising=False)
+    (workspace / "gptme.toml").write_text("[agent\nname = Bob\n")
+    path = write_task(
+        workspace, "invalid-toml-task", state="backlog", created="2026-04-26T00:00:00+00:00"
+    )
+
+    result = CliRunner().invoke(cli, ["claim", "invalid-toml-task"])
+
+    assert result.exit_code == 0, result.output
+    assert "Warning: Failed to load" in result.output
+    meta = load_meta(path)
+    assert meta["assigned_to"] == "agent"
 
 
 def test_edit_accepts_named_assigned_to(workspace: Path) -> None:

--- a/packages/gptodo/tests/test_claim.py
+++ b/packages/gptodo/tests/test_claim.py
@@ -1,0 +1,212 @@
+"""Tests for the ``gptodo claim`` command."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from gptodo.cli import cli
+from gptodo.frontmatter_compat import frontmatter
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Workspace with a tasks/ dir and a marker file ``find_repo_root`` will pick up."""
+    (tmp_path / "tasks").mkdir()
+    (tmp_path / "gptme.toml").write_text('[agent]\nname = "Bob"\n')
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("GPTODO_AGENT_NAME", raising=False)
+    return tmp_path
+
+
+def write_task(workspace: Path, name: str, **metadata: object) -> Path:
+    """Write a task file with frontmatter and return its path."""
+    lines = ["---"]
+    for key, value in metadata.items():
+        if isinstance(value, list):
+            lines.append(f"{key}:")
+            for item in value:
+                lines.append(f"  - {item}")
+        else:
+            lines.append(f"{key}: {value}")
+    lines.append("---")
+    lines.append(f"# {name}")
+    path = workspace / "tasks" / f"{name}.md"
+    path.write_text("\n".join(lines))
+    return path
+
+
+def load_meta(path: Path) -> dict:
+    return dict(frontmatter.load(path).metadata)
+
+
+def test_claim_backlog_task_promotes_to_active(workspace: Path) -> None:
+    path = write_task(
+        workspace, "backlog-task", state="backlog", created="2026-04-26T00:00:00+00:00"
+    )
+
+    result = CliRunner().invoke(cli, ["claim", "backlog-task", "--agent", "bob"])
+
+    assert result.exit_code == 0, result.output
+    meta = load_meta(path)
+    assert meta["state"] == "active"
+    assert meta["assigned_to"] == "bob"
+    assert isinstance(meta["assigned_at"], str)
+    assert meta["assigned_at"].endswith("+00:00") or "T" in meta["assigned_at"]
+
+
+def test_claim_todo_task_promotes_to_active(workspace: Path) -> None:
+    path = write_task(workspace, "todo-task", state="todo", created="2026-04-26T00:00:00+00:00")
+
+    result = CliRunner().invoke(cli, ["claim", "todo-task", "--agent", "bob"])
+
+    assert result.exit_code == 0
+    meta = load_meta(path)
+    assert meta["state"] == "active"
+    assert meta["assigned_to"] == "bob"
+    assert "assigned_at" in meta
+
+
+def test_claim_active_already_owned_is_noop(workspace: Path) -> None:
+    """Claiming an already-claimed active task by the same owner preserves assigned_at."""
+    original_assigned_at = "2026-04-25T12:00:00+00:00"
+    path = write_task(
+        workspace,
+        "active-task",
+        state="active",
+        created="2026-04-26T00:00:00+00:00",
+        assigned_to="bob",
+        assigned_at=original_assigned_at,
+    )
+
+    result = CliRunner().invoke(cli, ["claim", "active-task", "--agent", "bob"])
+
+    assert result.exit_code == 0
+    assert "Already claimed" in result.output
+    meta = load_meta(path)
+    assert meta["state"] == "active"
+    assert meta["assigned_to"] == "bob"
+    # First-claim timestamp preserved (YAML parses ISO datetimes; str uses " " separator).
+    preserved = str(meta["assigned_at"])
+    assert preserved.startswith("2026-04-25") and "12:00:00" in preserved
+
+
+def test_claim_active_reassigns_owner(workspace: Path) -> None:
+    """Reassignment updates owner and bumps assigned_at."""
+    path = write_task(
+        workspace,
+        "active-task",
+        state="active",
+        created="2026-04-26T00:00:00+00:00",
+        assigned_to="bob",
+        assigned_at="2026-04-25T12:00:00+00:00",
+    )
+
+    result = CliRunner().invoke(cli, ["claim", "active-task", "--agent", "erik"])
+
+    assert result.exit_code == 0
+    meta = load_meta(path)
+    assert meta["state"] == "active"
+    assert meta["assigned_to"] == "erik"
+    # Timestamp was bumped (no longer the original).
+    bumped = str(meta["assigned_at"])
+    assert not (bumped.startswith("2026-04-25") and "12:00:00" in bumped)
+
+
+def test_claim_waiting_task_refuses(workspace: Path) -> None:
+    path = write_task(
+        workspace,
+        "waiting-task",
+        state="waiting",
+        created="2026-04-26T00:00:00+00:00",
+        waiting_for="Erik review",
+    )
+
+    result = CliRunner().invoke(cli, ["claim", "waiting-task", "--agent", "bob"])
+
+    assert result.exit_code != 0
+    assert "Refusing to claim" in result.output
+    # Metadata unchanged.
+    meta = load_meta(path)
+    assert meta["state"] == "waiting"
+    assert "assigned_to" not in meta
+    assert "assigned_at" not in meta
+
+
+@pytest.mark.parametrize("state", ["done", "cancelled", "ready_for_review", "someday"])
+def test_claim_terminal_or_deferred_refuses(workspace: Path, state: str) -> None:
+    path = write_task(workspace, f"{state}-task", state=state, created="2026-04-26T00:00:00+00:00")
+
+    result = CliRunner().invoke(cli, ["claim", f"{state}-task"])
+
+    assert result.exit_code != 0
+    meta = load_meta(path)
+    assert meta["state"] == state
+
+
+def test_claim_resolves_agent_from_env(workspace: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GPTODO_AGENT_NAME", "alice")
+    path = write_task(workspace, "env-task", state="backlog", created="2026-04-26T00:00:00+00:00")
+
+    result = CliRunner().invoke(cli, ["claim", "env-task"])
+
+    assert result.exit_code == 0
+    meta = load_meta(path)
+    assert meta["assigned_to"] == "alice"
+
+
+def test_claim_resolves_agent_from_gptme_toml(
+    workspace: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """gptme.toml has [agent] name = "Bob"; expect lowercased "bob" when no override/env."""
+    monkeypatch.delenv("GPTODO_AGENT_NAME", raising=False)
+    path = write_task(workspace, "toml-task", state="backlog", created="2026-04-26T00:00:00+00:00")
+
+    result = CliRunner().invoke(cli, ["claim", "toml-task"])
+
+    assert result.exit_code == 0
+    meta = load_meta(path)
+    assert meta["assigned_to"] == "bob"
+
+
+def test_edit_accepts_named_assigned_to(workspace: Path) -> None:
+    """Regression: ``edit --set assigned_to bob`` must not be rejected as enum-invalid."""
+    path = write_task(workspace, "named-task", state="backlog", created="2026-04-26T00:00:00+00:00")
+
+    result = CliRunner().invoke(cli, ["edit", "named-task", "--set", "assigned_to", "bob"])
+
+    assert result.exit_code == 0, result.output
+    meta = load_meta(path)
+    assert meta["assigned_to"] == "bob"
+
+
+def test_edit_clears_assigned_to_with_none(workspace: Path) -> None:
+    path = write_task(
+        workspace,
+        "named-task",
+        state="backlog",
+        created="2026-04-26T00:00:00+00:00",
+        assigned_to="bob",
+    )
+
+    result = CliRunner().invoke(cli, ["edit", "named-task", "--set", "assigned_to", "none"])
+
+    assert result.exit_code == 0, result.output
+    meta = load_meta(path)
+    assert "assigned_to" not in meta
+
+
+def test_claim_unknown_task_fails(workspace: Path) -> None:
+    write_task(workspace, "real-task", state="backlog", created="2026-04-26T00:00:00+00:00")
+
+    result = CliRunner().invoke(cli, ["claim", "nonexistent-task"])
+
+    assert result.exit_code != 0
+
+
+# Sanity check: GPTODO_AGENT_NAME must not leak from the test runner's environment.
+def test_runner_env_does_not_leak(workspace: Path) -> None:
+    assert "GPTODO_AGENT_NAME" not in os.environ

--- a/uv.lock
+++ b/uv.lock
@@ -1914,6 +1914,7 @@ dependencies = [
     { name = "python-frontmatter" },
     { name = "rich" },
     { name = "tabulate" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 
 [package.optional-dependencies]
@@ -1938,6 +1939,7 @@ requires-dist = [
     { name = "python-frontmatter", specifier = ">=1.1.0" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "tabulate", specifier = ">=0.9.0" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.1" },
 ]
 provides-extras = ["dev", "test"]
 


### PR DESCRIPTION
## Summary

Implements `gptodo claim <task-id> [--agent NAME]` per the design in `knowledge/technical-designs/gptodo-claim-command.md` (Bob idea backlog #184; research note: `knowledge/research/2026-04-26-beads-vs-gptodo-task-graph-comparison.md`).

The motivation is that taking ownership of a task is currently expressed as two semantic actions through the generic `edit` field-mutator:

```
gptodo edit my-task --set state active --set assigned_to bob
```

That has a small but real race window for multi-agent / multi-worktree setups (one write flips state, another records ownership) and forces every caller to know that "claim" decomposes into two metadata fields.

`claim` collapses both into a single explicit verb with one file rewrite.

## Behavior

- `backlog` / `todo` → set `state: active`, set `assigned_to`, set `assigned_at`
- `active` (different owner) → reassignment, owner + timestamp updated
- `active` (same owner, has `assigned_at`) → idempotent no-op, **first-claim timestamp preserved**
- `waiting` / `ready_for_review` / `someday` / `done` / `cancelled` → refuses cleanly with non-zero exit, no metadata mutation

Refusing `waiting` is deliberate: silently flipping a blocked task to active would violate the workspace task-state contract.

### Agent-name resolution

In order:
1. `--agent NAME`
2. `GPTODO_AGENT_NAME` env
3. `[agent].name` from `gptme.toml` (lowercased)
4. fallback `"agent"`

## Also: relax `edit` `assigned_to` validation

The `edit` command was rejecting named assignees as enum-invalid:

```python
# before
"assigned_to": {"type": "enum", "values": ["agent", "human", "both", "none"]},
```

But real workspaces (and `generate_queue --user`) already use named values like `bob` / `erik`. Switched to a string field; `none` still clears via the existing logic.

## Tests

15 new tests in `packages/gptodo/tests/test_claim.py`:

- `claim backlog` / `claim todo` → promotes to active, sets owner + timestamp
- idempotent no-op on already-claimed-by-same-agent (preserves `assigned_at`)
- reassignment updates owner and bumps timestamp
- refusal for waiting / done / cancelled / ready_for_review / someday (parametrized)
- agent-name resolution from `--agent`, env, and `gptme.toml`
- regression: `edit --set assigned_to bob` is now accepted
- `edit --set assigned_to none` still clears the field
- unknown task fails

```
$ pytest packages/gptodo/tests/
135 passed in 0.92s   # 15 new + 120 existing
```

ruff format clean. The pre-existing mypy "duplicate source" error is unrelated to this PR (path-cache issue across workspace symlinks; not introduced here).

## Non-goals

- No new `claim:` frontmatter field — reuses existing `assigned_at`
- No batch claim, no release/handoff subcommand, no automatic wait-clearing
- No cross-task locking — that belongs in coordination/worktree machinery, not a CLI verb

## Test plan

- [x] new tests pass
- [x] full gptodo suite passes (135/135)
- [x] ruff lint + format clean
- [ ] CI green