### PR TITLE
fix(twitter): check live self-replies before posting

### DIFF
--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -818,6 +818,37 @@ def _check_for_duplicate_replies_internal(draft: TweetDraft) -> dict[str, list[P
     return duplicates
 
 
+def _find_live_duplicate_reply_ids(client, tweet_id: str) -> list[str]:
+    """Return recent live reply tweet IDs we already posted to ``tweet_id``.
+
+    This closes the gap where file-based draft history is missing (for example after
+    a branch checkout) but the reply already exists on Twitter.
+    """
+    try:
+        me = cached_get_me(client, user_auth=False)
+        username = getattr(getattr(me, "data", None), "username", None)
+        if not username:
+            return []
+
+        thread_context = get_conversation_thread(client, tweet_id)
+        tweet_id = str(tweet_id)
+        username = username.lower()
+
+        duplicate_ids = {
+            str(tweet["id"])
+            for tweet in thread_context
+            if str(tweet.get("replied_to_id")) == tweet_id
+            and str(tweet.get("author", "")).lower() == username
+        }
+        return sorted(duplicate_ids)
+    except Exception as e:
+        logger.warning(
+            "Live duplicate reply lookup failed",
+            extra={"tweet_id": str(tweet_id), "error": str(e)},
+        )
+        return []
+
+
 @cli.command()
 @click.argument("draft_path", type=click.Path(exists=True))
 def check_for_duplicate_replies(draft_path: str):
@@ -1169,16 +1200,28 @@ def post(
 
             # Check for already posted duplicates
             duplicates = _check_for_duplicate_replies_internal(draft)
-            if "posted" in duplicates:
-                console.print(
-                    f"\n[red]⚠ WARNING: Already posted {len(duplicates['posted'])} reply(ies) to this tweet![/red]"
+            live_duplicate_ids = []
+            if "posted" not in duplicates:
+                live_duplicate_ids = _find_live_duplicate_reply_ids(
+                    client, str(draft.in_reply_to)
                 )
-                for dup_path in duplicates["posted"]:
-                    dup_draft = TweetDraft.load(dup_path)
-                    console.print(f"[red]  - Posted: {dup_draft.text[:80]}...[/red]")
+
+            if "posted" in duplicates or live_duplicate_ids:
                 console.print(
-                    "[red]This would be a duplicate reply. Consider rejecting instead.[/red]\n"
+                    "\n[red]⚠ WARNING: Already posted reply to this tweet![/red]"
                 )
+                if "posted" in duplicates:
+                    for dup_path in duplicates["posted"]:
+                        dup_draft = TweetDraft.load(dup_path)
+                        console.print(
+                            f"[red]  - Posted draft: {dup_draft.text[:80]}...[/red]"
+                        )
+                for live_tweet_id in live_duplicate_ids:
+                    console.print(
+                        f"[red]  - Live tweet on Twitter: {live_tweet_id}[/red]"
+                    )
+                console.print("[red]Skipping duplicate reply.[/red]\n")
+                continue
 
         console.print(f"[white]{draft.text}")
 
@@ -1978,10 +2021,20 @@ def auto(
 
                     # Check for already posted duplicates
                     duplicates = _check_for_duplicate_replies_internal(draft)
-                    if "posted" in duplicates:
+                    live_duplicate_ids = []
+                    if "posted" not in duplicates:
+                        live_duplicate_ids = _find_live_duplicate_reply_ids(
+                            client, str(draft.in_reply_to)
+                        )
+
+                    if "posted" in duplicates or live_duplicate_ids:
                         console.print(
                             f"[red]⚠ Skipping duplicate reply to {draft.in_reply_to}[/red]"
                         )
+                        for live_tweet_id in live_duplicate_ids:
+                            console.print(
+                                f"[red]  - Live tweet on Twitter: {live_tweet_id}[/red]"
+                            )
                         move_draft(path, "rejected")
                         continue
 

--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -1221,6 +1221,7 @@ def post(
                         f"[red]  - Live tweet on Twitter: {live_tweet_id}[/red]"
                     )
                 console.print("[red]Skipping duplicate reply.[/red]\n")
+                move_draft(path, "rejected")
                 continue
 
         console.print(f"[white]{draft.text}")

--- a/tests/test_twitter_eval_prompt.py
+++ b/tests/test_twitter_eval_prompt.py
@@ -47,6 +47,11 @@ def _load_llm_module() -> types.ModuleType:
     gptme_message_stub.Message = type("Message", (), {})  # type: ignore[attr-defined]
     gptme_prompts_stub = types.ModuleType("gptme.prompts")
     gptme_prompts_stub.prompt_workspace = lambda *args, **kwargs: iter([])  # type: ignore[attr-defined]
+    rich_stub: Any = _make_pkg("rich")
+    rich_console_stub: Any = types.ModuleType("rich.console")
+    rich_console_stub.Console = lambda *args, **kwargs: types.SimpleNamespace(
+        print=lambda *print_args, **print_kwargs: None
+    )
 
     sys.modules.setdefault("gptme", gptme_stub)
     sys.modules.setdefault("gptme.llm", gptme_llm_stub)
@@ -54,6 +59,8 @@ def _load_llm_module() -> types.ModuleType:
     sys.modules.setdefault("gptme.dirs", gptme_dirs_stub)
     sys.modules.setdefault("gptme.message", gptme_message_stub)
     sys.modules.setdefault("gptme.prompts", gptme_prompts_stub)
+    sys.modules.setdefault("rich", rich_stub)
+    sys.modules.setdefault("rich.console", rich_console_stub)
 
     spec = importlib.util.spec_from_file_location("twitter_llm_under_test", LLM_PATH)
     assert spec and spec.loader
@@ -72,6 +79,8 @@ def llm_module() -> Generator[types.ModuleType, None, None]:
         "gptme.dirs",
         "gptme.message",
         "gptme.prompts",
+        "rich",
+        "rich.console",
     )
     pre_existing = {k for k in _STUB_KEYS if k in sys.modules}
     module = _load_llm_module()

--- a/tests/test_twitter_workflow_drafts.py
+++ b/tests/test_twitter_workflow_drafts.py
@@ -262,3 +262,33 @@ def test_duplicate_reply_detection_reads_markdown_drafts(
     duplicates = workflow_module._check_for_duplicate_replies_internal(draft)
 
     assert duplicates == {"approved": [existing_path]}
+
+
+def test_find_live_duplicate_reply_ids_matches_own_replies(
+    workflow_module: Any,
+) -> None:
+    workflow_module.cached_get_me = lambda *args, **kwargs: SimpleNamespace(
+        data=SimpleNamespace(username="TimeToBuildBob")
+    )
+    workflow_module.get_conversation_thread = lambda *args, **kwargs: [
+        {"id": "9001", "author": "TimeToBuildBob", "replied_to_id": "4242"},
+        {"id": "9002", "author": "someoneelse", "replied_to_id": "4242"},
+        {"id": "9003", "author": "TimeToBuildBob", "replied_to_id": "1111"},
+    ]
+
+    duplicate_ids = workflow_module._find_live_duplicate_reply_ids(object(), "4242")
+
+    assert duplicate_ids == ["9001"]
+
+
+def test_find_live_duplicate_reply_ids_returns_empty_without_identity(
+    workflow_module: Any,
+) -> None:
+    workflow_module.cached_get_me = lambda *args, **kwargs: SimpleNamespace(data=None)
+    workflow_module.get_conversation_thread = lambda *args, **kwargs: [
+        {"id": "9001", "author": "TimeToBuildBob", "replied_to_id": "4242"},
+    ]
+
+    duplicate_ids = workflow_module._find_live_duplicate_reply_ids(object(), "4242")
+
+    assert duplicate_ids == []

--- a/tests/test_twitter_workflow_drafts.py
+++ b/tests/test_twitter_workflow_drafts.py
@@ -268,12 +268,12 @@ def test_find_live_duplicate_reply_ids_matches_own_replies(
     workflow_module: Any,
 ) -> None:
     workflow_module.cached_get_me = lambda *args, **kwargs: SimpleNamespace(
-        data=SimpleNamespace(username="TimeToBuildBob")
+        data=SimpleNamespace(username="TestBotUser")
     )
     workflow_module.get_conversation_thread = lambda *args, **kwargs: [
-        {"id": "9001", "author": "TimeToBuildBob", "replied_to_id": "4242"},
+        {"id": "9001", "author": "TestBotUser", "replied_to_id": "4242"},
         {"id": "9002", "author": "someoneelse", "replied_to_id": "4242"},
-        {"id": "9003", "author": "TimeToBuildBob", "replied_to_id": "1111"},
+        {"id": "9003", "author": "TestBotUser", "replied_to_id": "1111"},
     ]
 
     duplicate_ids = workflow_module._find_live_duplicate_reply_ids(object(), "4242")
@@ -286,7 +286,7 @@ def test_find_live_duplicate_reply_ids_returns_empty_without_identity(
 ) -> None:
     workflow_module.cached_get_me = lambda *args, **kwargs: SimpleNamespace(data=None)
     workflow_module.get_conversation_thread = lambda *args, **kwargs: [
-        {"id": "9001", "author": "TimeToBuildBob", "replied_to_id": "4242"},
+        {"id": "9001", "author": "TestBotUser", "replied_to_id": "4242"},
     ]
 
     duplicate_ids = workflow_module._find_live_duplicate_reply_ids(object(), "4242")


### PR DESCRIPTION
## Summary
- check the live Twitter conversation for recent self-replies before posting approved drafts
- skip duplicate replies even when the local `tweets/posted` history is missing after branch/worktree churn
- add regression coverage for the live duplicate lookup and fix the nearby Twitter eval test stub so the focused Twitter test slice runs again

## Testing
- `uv run pytest tests/test_twitter_workflow_drafts.py tests/test_twitter_eval_prompt.py -q`
- `uv run ruff check scripts/twitter/workflow.py tests/test_twitter_workflow_drafts.py tests/test_twitter_eval_prompt.py`
