### PR TITLE
docs(gptodo): document 'none' value for clearing optional fields in edit

### DIFF
--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -1324,7 +1324,7 @@ def watch(interval: int, fix: bool, once: bool, verbose: bool):
     "set_fields",
     type=(str, str),
     multiple=True,
-    help="Set a field value (state, priority, created)",
+    help="Set a field value (state, priority, created). Pass 'none' to clear an optional field (e.g. --set waiting_since none).",
 )
 @click.option(
     "--add",
@@ -1358,6 +1358,15 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask):
         tasks edit task-123 --remove tag wip
         tasks edit task-123 --set state active --add tag feature --add depends other-task
         tasks edit task-123 --set-subtask "Handle simple responses" done
+
+    Clearing optional fields:
+        Pass 'none' as the value to clear (unset) an optional field.
+        Useful when transitioning a task to a terminal state (done/cancelled)
+        and removing now-stale waiting metadata:
+
+        tasks edit task-123 --set waiting_for none --set waiting_since none
+        tasks edit task-123 --set priority none
+        tasks edit task-123 --set next_action none
 
     Date formats:
         The created field accepts ISO format dates:


### PR DESCRIPTION
## Summary

The `gptodo edit` command already supports clearing optional fields by passing `'none'` as the value (see `cli.py:1424-1427`), but this was undocumented. As a result, users (and agents) trying to clean up terminal-state tasks with stale `waiting_for` / `waiting_since` metadata hit dead ends:

- `--set waiting_since ""` fails on date validation
- `--remove waiting_since` is rejected (only valid for list fields)
- The hand-edit YAML fallback bypasses the validator

The actual working syntax — `--set waiting_since none` — was hiding in the source.

## Changes

- Mention the `'none'` clearing pattern in the `--set` `--help` text
- Add a dedicated **Clearing optional fields** section in the docstring with the most common use case (terminal-state cleanup)

Behavior is unchanged. This is a discoverability fix.

## Test plan

- [x] `uv run ruff check packages/gptodo/src/gptodo/cli.py` passes
- [x] Manually verified `--set waiting_since none` clears the field on a fixture task (existing behavior)
- [x] Pre-commit hooks pass

## Why now

Hit during cleanup of a terminal-state task in https://github.com/ErikBjare/bob — see [autonomous-session-4c93.md](https://github.com/ErikBjare/bob/blob/master/journal/2026-04-26/autonomous-session-4c93.md) "Bonus: task hygiene" section.