### PR TITLE
fix(lessons): add session_categories to 2 high-value lessons

### DIFF
--- a/lessons/autonomous/blocked-period-status-check-trap.md
+++ b/lessons/autonomous/blocked-period-status-check-trap.md
@@ -10,7 +10,7 @@ match:
     - waiting for input
     - strategic pause
     - productive while blocked
-  session_categories: [strategic, autonomous, cleanup]
+  session_categories: [strategic, self-review, cleanup]
 status: active
 ---
 

--- a/lessons/autonomous/blocked-period-status-check-trap.md
+++ b/lessons/autonomous/blocked-period-status-check-trap.md
@@ -10,6 +10,7 @@ match:
     - waiting for input
     - strategic pause
     - productive while blocked
+  session_categories: [strategic, autonomous, cleanup]
 status: active
 ---
 

--- a/lessons/workflow/branch-from-master.md
+++ b/lessons/workflow/branch-from-master.md
@@ -1,6 +1,7 @@
 ---
 match:
   keywords: ["create branch", "git checkout -b", "new feature branch", "PR contains unrelated commits"]
+  session_categories: [code, cross-repo, workflow]
 status: active
 ---
 

--- a/lessons/workflow/branch-from-master.md
+++ b/lessons/workflow/branch-from-master.md
@@ -1,7 +1,7 @@
 ---
 match:
   keywords: ["create branch", "git checkout -b", "new feature branch", "PR contains unrelated commits"]
-  session_categories: [code, cross-repo, workflow]
+  session_categories: [code, cross-repo, infrastructure]
 status: active
 ---
 


### PR DESCRIPTION
Adds explicit session_categories metadata for improved LOO trigger accuracy (replaces classifier guesswork):

- blocked-period-status-check-trap: [strategic, self-review, cleanup]
- branch-from-master: [code, cross-repo, infrastructure]

These lessons have positive LOO deltas (0.056 and 0.053 respectively) but were missing explicit session_categories, causing the classifier to guess instead of using declared categories for trigger_accuracy scoring.

Note: an earlier draft of this PR used `autonomous` and `workflow` as category values; a follow-up commit on the same branch replaced these with the correct established values (`self-review` and `infrastructure` respectively).

Refs: ErikBjare/bob#153 (Phase 5 follow-up)