### PR TITLE
fix(tests): silence pytest collection and unknown-mark warnings

### DIFF
--- a/packages/gptme-runloops/tests/test_base.py
+++ b/packages/gptme-runloops/tests/test_base.py
@@ -12,6 +12,8 @@ from gptme_runloops.utils.execution import ExecutionResult
 class TestRunLoop(BaseRunLoop):
     """Concrete test implementation of BaseRunLoop."""
 
+    __test__ = False  # Tell pytest this is a helper class, not a test class
+
     def generate_prompt(self) -> str:
         return "Test prompt"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ gptmail = { workspace = true }
 # Without this, multiple packages with tests/__init__.py cause namespace collisions
 addopts = "--import-mode=importlib"
 asyncio_mode = "auto"
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP"]


### PR DESCRIPTION
## Summary

Silence the two pre-existing warnings that show up on every `pytest packages/` run.

## Changes

1. **`PytestCollectionWarning: cannot collect test class 'TestRunLoop'`**
   - `TestRunLoop` in `packages/gptme-runloops/tests/test_base.py` is a concrete subclass of `BaseRunLoop` used as a test helper, not a test class.
   - Added `__test__ = False` so pytest skips collection.

2. **`PytestUnknownMarkWarning: Unknown pytest.mark.slow`**
   - `@pytest.mark.slow` was used in `packages/gptme-runloops/tests/test_integration.py` but never registered.
   - Added the standard `slow` marker definition to `[tool.pytest.ini_options]`.

Both fixes are pure noise reduction.

## Verification

```
$ uv run --active pytest packages/ -q --ignore=packages/gptme-voice
1583 passed, 1 skipped, 2 warnings in 77.32s
```

The 2 remaining warnings are pre-existing `datetime.utcnow()` deprecations in `gptmail` tests — unrelated to this PR.

Before this PR, the same command would produce **4** warnings (the 2 fixed here + the 2 datetime ones).

## Test plan

- [x] `uv run --active pytest packages/gptme-runloops/tests/ -q` — clean, no warnings
- [x] `uv run --active pytest packages/ -q --ignore=packages/gptme-voice` — full suite still passes
- [x] Pre-commit / prek green