### PR TITLE
fix(lessons): add session_categories to autonomous-session-structure

### DIFF
--- a/lessons/autonomous/autonomous-session-structure.md
+++ b/lessons/autonomous/autonomous-session-structure.md
@@ -6,6 +6,7 @@ match:
   - session phase planning
   - structured autonomous session
   - autonomous work phases
+  session_categories: [autonomous, self-review]
 status: active
 ---
 


### PR DESCRIPTION
## Problem

`autonomous-session-structure.md` has been **silent for 14+ days** — zero triggers despite being relevant to every autonomous session.

Root cause: all 5 keywords are meta-phrases that no one writes verbatim in a session transcript:
- `"autonomous session structure"` — never appears mid-conversation
- `"4-phase session"` — nobody types this
- `"session phase planning"`, `"structured autonomous session"`, `"autonomous work phases"` — same story

## Fix

Add `session_categories: [autonomous, self-review]` to the frontmatter so the lesson fires whenever an autonomous or self-review session is running — the two session types where structured work selection is most critical.

The existing keyword list is kept as a fallback for harnesses that don't implement session_categories filtering.

## Verification

Validated with `gptme-lessons-extras validate` — passes two-file format check.

Identified via `lesson-keyword-suggest.py --from-body` (body mining found commands from the lesson body like `gptodo ready` in 64/14d sessions, confirming the lesson content is relevant — it's just the trigger keywords that were broken).