### PR TITLE
fix(lessons): remove dead keywords + fix silent agent-orchestrator-patterns

### DIFF
--- a/lessons/patterns/avoid-deep-nesting.md
+++ b/lessons/patterns/avoid-deep-nesting.md
@@ -1,19 +1,8 @@
 ---
 match:
   keywords:
-  - deep nesting 4+ levels
-  - nested if statement pyramid
-  - guard clause pattern
-  - early return for simplicity
-  - function extraction for nesting
-  - arrow code smell
-  - too many indentation levels
   - "deeply nested"
-  - "flatten the code"
-  - "nesting level"
-  - "guard clauses"
   - "early return"
-  - "refactor nesting"
 status: active
 ---
 

--- a/lessons/workflow/agent-orchestrator-patterns.md
+++ b/lessons/workflow/agent-orchestrator-patterns.md
@@ -3,11 +3,13 @@ status: active
 match:
   keywords:
     - "orchestrating multiple agents"
-    - "agent team health check"
-    - "daily agent standup"
-    - "inference utilization across agents"
-    - "monitor agent work queue"
-    - "coordinate parallel agent sessions"
+    - "agent team health"
+    - "daily standup"
+    - "inference utilization"
+    - "agent work queue"
+    - "coordinate agents"
+    - "agent orchestrator"
+    - "multi-agent health"
 ---
 
 # Agent Orchestrator Patterns


### PR DESCRIPTION
## Summary

- **avoid-deep-nesting**: removed 11 dead keywords, kept only `deeply nested` and `early return` (the 2 that actually fire)
- **agent-orchestrator-patterns**: shortened 6 over-specific keywords to fix silent-lesson classification (e.g. `agent team health check` → `agent team health`, `daily agent standup` → `daily standup`); added `agent orchestrator` and `multi-agent health` as aliases

## Data source

`lesson-keyword-health.py --action-items` (7-day window, 1134 sessions):
- `avoid-deep-nesting` had 11/13 keywords with 0 matches in 7-day window
- `agent-orchestrator-patterns` flagged as **silent** (too-specific cause) — all 6 original keywords too long to appear in natural session text

## What was NOT changed

The 2 noise lessons (`ci-failure-resolution-precommit-maintenance`, `sibling-tool-call-errored`) fire only 2 times each in 1134 sessions — sample too small for reliable TS estimate; skipped to avoid false positives.