### PR TITLE
feat(gptodo): add ready_for_review and actionable to ready --state

### DIFF
--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -1901,9 +1901,14 @@ def tags(state: str | None, show_tasks: bool, filter_tags: tuple[str, ...]):
 @cli.command("ready")
 @click.option(
     "--state",
-    type=click.Choice(["backlog", "active", "someday", "both"]),
+    type=click.Choice(["backlog", "active", "ready_for_review", "someday", "both", "actionable"]),
     default="both",
-    help="Filter by task state. 'both' = backlog+active. 'someday' = explicitly query deferred tasks.",
+    help=(
+        "Filter by task state. 'both' = backlog+active (default, current behavior). "
+        "'actionable' = backlog+active+ready_for_review (everything locally workable). "
+        "'ready_for_review' = only tasks awaiting local review/verification. "
+        "'someday' = explicitly query deferred tasks."
+    ),
 )
 @click.option(
     "--json",
@@ -1966,8 +1971,14 @@ def ready(state, output_json, output_jsonl, use_cache):
         filtered_tasks = [task for task in all_tasks if task.state == "backlog"]
     elif state == "active":
         filtered_tasks = [task for task in all_tasks if task.state == "active"]
+    elif state == "ready_for_review":
+        filtered_tasks = [task for task in all_tasks if task.state == "ready_for_review"]
     elif state == "someday":
         filtered_tasks = [task for task in all_tasks if task.state == "someday"]
+    elif state == "actionable":
+        filtered_tasks = [
+            task for task in all_tasks if task.state in ["backlog", "active", "ready_for_review"]
+        ]
     else:  # both
         filtered_tasks = [task for task in all_tasks if task.state in ["backlog", "active"]]
 

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -123,6 +123,7 @@ from gptodo.utils import (
     get_cache_path,
     has_new_activity,
     is_task_ready,
+    task_has_waiting_blocker,
     load_cache,
     load_tasks,
     normalize_state,
@@ -1982,8 +1983,24 @@ def ready(state, output_json, output_jsonl, use_cache):
     else:  # both
         filtered_tasks = [task for task in all_tasks if task.state in ["backlog", "active"]]
 
-    # Filter for ready (unblocked) tasks
-    ready_tasks = [task for task in filtered_tasks if is_task_ready(task, tasks_dict, issue_cache)]
+    # Filter for ready (unblocked) tasks.
+    # ready_for_review tasks: work is done; skip dependency checks, only check waiting_for.
+    if state == "ready_for_review":
+        ready_tasks = [task for task in filtered_tasks if not task_has_waiting_blocker(task)]
+    elif state == "actionable":
+        # backlog/active go through full is_task_ready; ready_for_review only needs waiting check
+        ready_tasks = [
+            task
+            for task in filtered_tasks
+            if (task.state == "ready_for_review" and not task_has_waiting_blocker(task))
+            or (
+                task.state in ["backlog", "active"] and is_task_ready(task, tasks_dict, issue_cache)
+            )
+        ]
+    else:
+        ready_tasks = [
+            task for task in filtered_tasks if is_task_ready(task, tasks_dict, issue_cache)
+        ]
 
     if not ready_tasks:
         if output_json:

--- a/packages/gptodo/tests/test_ready_selection.py
+++ b/packages/gptodo/tests/test_ready_selection.py
@@ -293,3 +293,37 @@ def test_ready_actionable_includes_all_local_workable(tmp_path: Path, monkeypatc
     ids = sorted(t["id"] for t in payload["ready_tasks"])
     assert ids == ["active-task", "backlog-task", "review-task"]
     assert "deferred-task" not in ids
+
+
+def test_ready_for_review_not_silenced_by_stale_requires(tmp_path: Path, monkeypatch) -> None:
+    """ready_for_review tasks with unresolved `requires` must NOT be silently excluded.
+
+    The work is done; dependency metadata may be stale. We should surface the task
+    so the reviewer/CASCADE can act on it, not hide it.
+    """
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    # A task whose work is complete but the requires pointer was never closed
+    write_task(
+        tasks_dir,
+        "review-task",
+        state="ready_for_review",
+        created="2026-04-26T00:00:00",
+        requires=["still-open-task"],
+    )
+    write_task(
+        tasks_dir,
+        "still-open-task",
+        state="active",  # not done/cancelled — simulates stale metadata
+        created="2026-04-26T01:00:00",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["ready", "--state", "ready_for_review", "--json"])
+
+    assert result.exit_code == 0
+    payload_text = result.output.split("\nNo ready tasks found", 1)[0]
+    payload = json.loads(payload_text)
+    ids = [t["id"] for t in payload["ready_tasks"]]
+    assert "review-task" in ids, "ready_for_review task must not be hidden by stale requires"

--- a/packages/gptodo/tests/test_ready_selection.py
+++ b/packages/gptodo/tests/test_ready_selection.py
@@ -191,3 +191,105 @@ def test_ready_someday_explicit_query_returns_them(tmp_path: Path, monkeypatch) 
     payload = json.loads(payload_text)
     ids = [t["id"] for t in payload["ready_tasks"]]
     assert "deferred-task" in ids
+
+
+def test_ready_for_review_excluded_from_both_default(tmp_path: Path, monkeypatch) -> None:
+    """`gptodo ready --state both` must NOT surface ready_for_review tasks.
+
+    Preserves backwards-compatible default: 'both' = backlog+active only.
+    """
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(
+        tasks_dir,
+        "review-task",
+        state="ready_for_review",
+        created="2026-04-26T00:00:00",
+    )
+    write_task(
+        tasks_dir,
+        "active-task",
+        state="active",
+        created="2026-04-26T01:00:00",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["ready", "--state", "both", "--json"])
+
+    assert result.exit_code == 0
+    payload_text = result.output.split("\nNo ready tasks found", 1)[0]
+    payload = json.loads(payload_text)
+    ids = [t["id"] for t in payload["ready_tasks"]]
+    assert "review-task" not in ids
+    assert "active-task" in ids
+
+
+def test_ready_for_review_explicit_query_returns_them(tmp_path: Path, monkeypatch) -> None:
+    """`gptodo ready --state ready_for_review` lists tasks awaiting local review."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(
+        tasks_dir,
+        "review-task",
+        state="ready_for_review",
+        created="2026-04-26T00:00:00",
+    )
+    write_task(
+        tasks_dir,
+        "active-task",
+        state="active",
+        created="2026-04-26T01:00:00",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["ready", "--state", "ready_for_review", "--json"])
+
+    assert result.exit_code == 0
+    payload_text = result.output.split("\nNo ready tasks found", 1)[0]
+    payload = json.loads(payload_text)
+    ids = [t["id"] for t in payload["ready_tasks"]]
+    assert "review-task" in ids
+    assert "active-task" not in ids
+
+
+def test_ready_actionable_includes_all_local_workable(tmp_path: Path, monkeypatch) -> None:
+    """`gptodo ready --state actionable` returns backlog + active + ready_for_review."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(
+        tasks_dir,
+        "backlog-task",
+        state="backlog",
+        created="2026-04-26T00:00:00",
+    )
+    write_task(
+        tasks_dir,
+        "active-task",
+        state="active",
+        created="2026-04-26T01:00:00",
+    )
+    write_task(
+        tasks_dir,
+        "review-task",
+        state="ready_for_review",
+        created="2026-04-26T02:00:00",
+    )
+    write_task(
+        tasks_dir,
+        "deferred-task",
+        state="someday",
+        created="2026-04-26T03:00:00",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["ready", "--state", "actionable", "--json"])
+
+    assert result.exit_code == 0
+    payload_text = result.output.split("\nNo ready tasks found", 1)[0]
+    payload = json.loads(payload_text)
+    ids = sorted(t["id"] for t in payload["ready_tasks"])
+    assert ids == ["active-task", "backlog-task", "review-task"]
+    assert "deferred-task" not in ids


### PR DESCRIPTION
## Summary

`gptodo ready` previously couldn't surface tasks in `ready_for_review` state, forcing autonomous workflows (CASCADE in particular) to inspect task files directly. Bob's `CLAUDE.md` explicitly calls this out as a known gap. This PR closes it without changing the default behavior.

Two new `--state` filters:

- `--state ready_for_review` — only tasks awaiting local review/verification
- `--state actionable` — backlog + active + ready_for_review (the natural superset for autonomous selection of locally-workable tasks)

`--state both` (the default) keeps its current semantics (= backlog+active) so existing CASCADE/`gptodo next` callers that intentionally separate the review lane don't get a behavioral surprise.

## Test plan

- [x] `uv run --extra test pytest packages/gptodo/tests/test_ready_selection.py -v` → 10/10 pass
- [x] 3 new tests cover: review state excluded from `--state both` default, `--state ready_for_review` returns only review tasks, `--state actionable` returns the union (and still excludes `someday`)
- [x] No changes to `is_task_ready` logic — only the state filter is widened