### PR TITLE
fix(voice): wait for subagent results before speaking

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
@@ -124,6 +124,9 @@ def _load_project_instructions(workspace: str | None = None) -> str:
         "SUBAGENT TOOL RULES:\n"
         "- Use the subagent tool ONLY for small, specific lookups: a single task status, "
         "a recent journal entry, a quick file check. One focused question per call.\n"
+        "- If you need a live lookup, you may say one short acknowledgement before "
+        "calling subagent (for example: 'One moment, checking that.'). After dispatch, "
+        "wait for the actual subagent result instead of narrating progress or guessing.\n"
         "- Do NOT dispatch broad investigation tasks (e.g. 'investigate the whole system', "
         "'run a full review') — these always time out and leave the call hanging.\n"
         "- NEVER use the subagent tool to run post-call analysis, summarise the session, "
@@ -304,8 +307,10 @@ class OpenAIRealtimeClient:
                         "Use it only for one small, focused workspace lookup or action: "
                         "check one task, inspect one file, run one quick command, or verify "
                         "one recent fact. Do not use it for broad investigations, full "
-                        "reviews, or post-call analysis. Describe one concrete request in "
-                        "natural language."
+                        "reviews, or post-call analysis. Say at most one brief "
+                        "acknowledgement before calling it, then wait for the real "
+                        "subagent result instead of answering early. Describe one "
+                        "concrete request in natural language."
                     ),
                     "parameters": {
                         "type": "object",
@@ -462,6 +467,22 @@ class OpenAIRealtimeClient:
             },
         )
         await self._send_event("response.create", {})
+
+    @staticmethod
+    def _should_auto_respond_after_function_output(name: str, result: Any) -> bool:
+        """Decide whether a function-call result should trigger immediate speech.
+
+        Async subagent dispatch only returns a receipt. Auto-responding to that
+        receipt makes the model talk as if it already has the answer. The real
+        spoken answer should wait for the injected subagent result instead.
+        """
+        if (
+            name == "subagent"
+            and isinstance(result, dict)
+            and result.get("status") == "dispatched"
+        ):
+            return False
+        return True
 
     async def disconnect(
         self,
@@ -742,8 +763,10 @@ class OpenAIRealtimeClient:
                         }
                     },
                 )
-                # Trigger a new response after function output
-                await self._send_event("response.create", {})
+                if self._should_auto_respond_after_function_output(name, result):
+                    # Trigger a new response after function output when the
+                    # tool returned an answer the caller should hear now.
+                    await self._send_event("response.create", {})
 
         # Errors
         elif event_type == "error":

--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -627,7 +627,10 @@ class GptmeToolBridge:
             return {
                 "status": "dispatched",
                 "task_id": task_id,
-                "message": f"Working on it: {task}",
+                "message": (
+                    "Async lookup dispatched. Wait for the subagent result "
+                    "before giving the substantive answer."
+                ),
             }
 
         if name == "subagent_status":

--- a/packages/gptme-voice/tests/test_openai_client.py
+++ b/packages/gptme-voice/tests/test_openai_client.py
@@ -81,6 +81,7 @@ def test_connect_exposes_subagent_tool_as_focused_lookup_only() -> None:
         assert "small, focused workspace lookup or action" in description
         assert "broad investigations" in description
         assert "post-call analysis" in description
+        assert "wait for the real subagent result" in description
         assert fake_ws.closed is True
 
     asyncio.run(_exercise())
@@ -99,6 +100,7 @@ def test_load_project_instructions_includes_post_call_follow_up_guard(
 
     # The preamble was applied (sanity — otherwise we'd get _DEFAULT_INSTRUCTIONS).
     assert "real-time voice conversation" in instructions
+    assert "wait for the actual subagent result" in instructions
 
     # The new POST-CALL FOLLOW-UP section exists.
     assert "POST-CALL FOLLOW-UP:" in instructions
@@ -258,6 +260,144 @@ def test_load_project_instructions_guards_present_without_personality_files(
     assert "real-time voice conversation" in instructions
     assert "POST-CALL FOLLOW-UP:" in instructions
     assert "Do NOT claim, announce, or imply that you have dispatched" in instructions
+    assert "wait for the actual subagent result" in instructions
+
+
+def test_function_call_subagent_dispatch_does_not_auto_create_response() -> None:
+    async def _exercise() -> None:
+        fake_ws = _FakeWebSocket()
+
+        async def _fake_connect(*_args, **_kwargs):
+            return fake_ws
+
+        async def _on_function_call(name: str, arguments: dict) -> dict:
+            assert name == "subagent"
+            assert arguments == {"task": "check latest standup"}
+            return {
+                "status": "dispatched",
+                "task_id": "task-1",
+                "message": "Async lookup dispatched. Wait for the subagent result before giving the substantive answer.",
+            }
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "gptme_voice.realtime.openai_client.websockets.connect", _fake_connect
+            )
+            client = OpenAIRealtimeClient(
+                api_key="test-key",
+                on_function_call=_on_function_call,
+            )
+            await client.connect()
+            await client._handle_event({"type": "session.created"})
+
+            baseline = len(fake_ws.sent)
+            await client._handle_event(
+                {
+                    "type": "response.function_call_arguments.done",
+                    "call_id": "call-1",
+                    "name": "subagent",
+                    "arguments": json.dumps({"task": "check latest standup"}),
+                }
+            )
+
+            new_events = fake_ws.sent[baseline:]
+            assert new_events == [
+                {
+                    "type": "conversation.item.create",
+                    "item": {
+                        "type": "function_call_output",
+                        "call_id": "call-1",
+                        "output": json.dumps(
+                            {
+                                "status": "dispatched",
+                                "task_id": "task-1",
+                                "message": "Async lookup dispatched. Wait for the subagent result before giving the substantive answer.",
+                            }
+                        ),
+                    },
+                }
+            ]
+
+            await client.disconnect()
+
+    asyncio.run(_exercise())
+
+
+def test_function_call_subagent_status_still_auto_creates_response() -> None:
+    async def _exercise() -> None:
+        fake_ws = _FakeWebSocket()
+
+        async def _fake_connect(*_args, **_kwargs):
+            return fake_ws
+
+        async def _on_function_call(name: str, arguments: dict) -> dict:
+            assert name == "subagent_status"
+            assert arguments == {}
+            return {
+                "status": "ok",
+                "pending_count": 1,
+                "pending": [
+                    {
+                        "task_id": "task-1",
+                        "task": "check latest standup",
+                        "mode": "fast",
+                        "elapsed_seconds": 2.3,
+                        "stage": "running",
+                    }
+                ],
+            }
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "gptme_voice.realtime.openai_client.websockets.connect", _fake_connect
+            )
+            client = OpenAIRealtimeClient(
+                api_key="test-key",
+                on_function_call=_on_function_call,
+            )
+            await client.connect()
+            await client._handle_event({"type": "session.created"})
+
+            baseline = len(fake_ws.sent)
+            await client._handle_event(
+                {
+                    "type": "response.function_call_arguments.done",
+                    "call_id": "call-2",
+                    "name": "subagent_status",
+                    "arguments": json.dumps({}),
+                }
+            )
+
+            new_events = fake_ws.sent[baseline:]
+            assert new_events == [
+                {
+                    "type": "conversation.item.create",
+                    "item": {
+                        "type": "function_call_output",
+                        "call_id": "call-2",
+                        "output": json.dumps(
+                            {
+                                "status": "ok",
+                                "pending_count": 1,
+                                "pending": [
+                                    {
+                                        "task_id": "task-1",
+                                        "task": "check latest standup",
+                                        "mode": "fast",
+                                        "elapsed_seconds": 2.3,
+                                        "stage": "running",
+                                    }
+                                ],
+                            }
+                        ),
+                    },
+                },
+                {"type": "response.create"},
+            ]
+
+            await client.disconnect()
+
+    asyncio.run(_exercise())
 
 
 def test_disconnect_drains_late_transcript_events_without_sending_late_audio() -> None:


### PR DESCRIPTION
## Summary
- treat async `subagent` dispatch as a receipt, not a cue to generate another spoken reply
- tighten the voice instructions/tool description so the model gives at most one brief acknowledgement, then waits for the real result
- add regressions covering both suppressed auto-response for `subagent` and retained auto-response for `subagent_status`

## Why
Erik reported on the 2026-04-27 Twilio call that Bob answered twice before the subagent result had landed. The realtime client was auto-triggering `response.create` after every function output, including the async `subagent` dispatch receipt.

## Testing
- `PYTHONPATH=/home/bob/bob/gptme-contrib/packages/gptme-voice/src uv run pytest /home/bob/bob/gptme-contrib/packages/gptme-voice/tests/test_openai_client.py /home/bob/bob/gptme-contrib/packages/gptme-voice/tests/test_tool_bridge.py -q`
- `PYTHONPATH=/home/bob/bob/gptme-contrib/packages/gptme-voice/src uv run pytest /home/bob/bob/gptme-contrib/packages/gptme-voice/tests/test_xai_client.py -q`
- `uv run python3 -m py_compile /home/bob/bob/gptme-contrib/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py /home/bob/bob/gptme-contrib/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py`