### PR TITLE
fix(voice): prefer caller call name in greetings

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -46,6 +46,13 @@ from .xai_client import XAIRealtimeClient, _get_xai_api_key
 
 logger = logging.getLogger(__name__)
 
+
+@dataclass
+class CallerIdentity:
+    canonical_name: str
+    preferred_spoken_name: str
+
+
 _DEFAULT_RESUME_WINDOW_SECONDS = 300
 _DEFAULT_STATE_DIR = "/tmp/gptme-voice-call-state"
 _MAX_RESUME_TRANSCRIPT_CHARS = 2500
@@ -82,7 +89,19 @@ class SessionBootstrap:
     initial_response_instructions: str = ""
 
 
-def _lookup_caller_name(from_number: str, workspace: str | None) -> str | None:
+def _extract_preferred_spoken_name(text: str, canonical_name: str) -> str:
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.lower().startswith("- call name:"):
+            value = stripped.split(":", 1)[1].strip()
+            if value:
+                return value
+    return canonical_name.split()[0] if canonical_name.split() else canonical_name
+
+
+def _lookup_caller_identity(
+    from_number: str, workspace: str | None
+) -> CallerIdentity | None:
     if workspace:
         people_dir = Path(workspace) / "people"
         if people_dir.is_dir():
@@ -90,7 +109,6 @@ def _lookup_caller_name(from_number: str, workspace: str | None) -> str | None:
                 try:
                     text = md_file.read_text()
                     if from_number in text:
-                        # Use the stem as a hint; the file header is the canonical name
                         first_h1 = next(
                             (
                                 line.lstrip("# ").strip()
@@ -99,7 +117,16 @@ def _lookup_caller_name(from_number: str, workspace: str | None) -> str | None:
                             ),
                             None,
                         )
-                        return first_h1 or md_file.stem.replace("-", " ").title()
+                        canonical_name = (
+                            first_h1 or md_file.stem.replace("-", " ").title()
+                        )
+                        preferred_spoken_name = _extract_preferred_spoken_name(
+                            text, canonical_name
+                        )
+                        return CallerIdentity(
+                            canonical_name=canonical_name,
+                            preferred_spoken_name=preferred_spoken_name,
+                        )
                 except Exception:
                     pass
     return None
@@ -117,13 +144,14 @@ def _build_caller_instructions(
     if not from_number:
         return base_instructions
 
-    caller_name = _lookup_caller_name(from_number, workspace)
+    caller_identity = _lookup_caller_identity(from_number, workspace)
 
-    if caller_name:
+    if caller_identity:
         caller_ctx = (
             f"The current caller's phone number is {from_number} "
-            f"({caller_name}). "
-            f"You know this person — refer to them by name."
+            f"({caller_identity.canonical_name}). "
+            f"You know this person — refer to them by name. "
+            f"On voice calls, prefer '{caller_identity.preferred_spoken_name}' over their full name."
         )
     else:
         caller_ctx = (
@@ -137,11 +165,16 @@ def _build_caller_instructions(
 def _build_fresh_call_greeting_instructions(
     from_number: str, workspace: str | None
 ) -> str:
-    caller_name = _lookup_caller_name(from_number, workspace) if from_number else None
-    if caller_name:
+    caller_identity = (
+        _lookup_caller_identity(from_number, workspace) if from_number else None
+    )
+    if caller_identity:
+        spoken_name = caller_identity.preferred_spoken_name
+        canonical_name = caller_identity.canonical_name
         return (
-            f"The caller is {caller_name}. Greet them by name in one short sentence, "
-            f"for example 'Hi {caller_name}' or 'Hey {caller_name}, what's up?'. "
+            f"The caller is {canonical_name}. On voice calls, greet them using '{spoken_name}', "
+            f"not their full name, in one short sentence, for example 'Hi {spoken_name}' "
+            f"or 'Hey {spoken_name}, what's up?'. "
             "Do NOT say 'thanks for calling' or use other stock phone greetings. "
             "Then stop and wait for them to speak."
         )

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -148,11 +148,16 @@ def _build_caller_instructions(
     caller_identity = _lookup_caller_identity(from_number, workspace)
 
     if caller_identity:
+        name_hint = (
+            f" On voice calls, prefer '{caller_identity.preferred_spoken_name}' over their full name."
+            if caller_identity.preferred_spoken_name != caller_identity.canonical_name
+            else ""
+        )
         caller_ctx = (
             f"The current caller's phone number is {from_number} "
             f"({caller_identity.canonical_name}). "
-            f"You know this person — refer to them by name. "
-            f"On voice calls, prefer '{caller_identity.preferred_spoken_name}' over their full name."
+            f"You know this person — refer to them by name."
+            f"{name_hint}"
         )
     else:
         caller_ctx = (

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -96,7 +96,8 @@ def _extract_preferred_spoken_name(text: str, canonical_name: str) -> str:
             value = stripped.split(":", 1)[1].strip()
             if value:
                 return value
-    return canonical_name.split()[0] if canonical_name.split() else canonical_name
+    parts = canonical_name.split()
+    return parts[0] if parts else canonical_name
 
 
 def _lookup_caller_identity(
@@ -171,11 +172,20 @@ def _build_fresh_call_greeting_instructions(
     if caller_identity:
         spoken_name = caller_identity.preferred_spoken_name
         canonical_name = caller_identity.canonical_name
+        if spoken_name == canonical_name:
+            greeting_target = (
+                f"The caller is {canonical_name}. Greet them by name in one short sentence, "
+                f"for example 'Hi {spoken_name}' or 'Hey {spoken_name}, what's up?'. "
+            )
+        else:
+            greeting_target = (
+                f"The caller is {canonical_name}. On voice calls, greet them using '{spoken_name}', "
+                f"not their full name, in one short sentence, for example 'Hi {spoken_name}' "
+                f"or 'Hey {spoken_name}, what's up?'. "
+            )
         return (
-            f"The caller is {canonical_name}. On voice calls, greet them using '{spoken_name}', "
-            f"not their full name, in one short sentence, for example 'Hi {spoken_name}' "
-            f"or 'Hey {spoken_name}, what's up?'. "
-            "Do NOT say 'thanks for calling' or use other stock phone greetings. "
+            greeting_target
+            + "Do NOT say 'thanks for calling' or use other stock phone greetings. "
             "Then stop and wait for them to speak."
         )
 

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -159,6 +159,31 @@ def test_build_session_bootstrap_personalizes_known_caller_greeting() -> None:
     assert "Do NOT say 'thanks for calling'" in bootstrap.initial_response_instructions
 
 
+def test_build_session_bootstrap_avoids_full_name_warning_for_single_token_name() -> (
+    None
+):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        people_dir = Path(tmpdir) / "people"
+        people_dir.mkdir()
+        (people_dir / "erik.md").write_text("# Erik\n\nPhone: +46700000002\n")
+        server = VoiceServer(workspace=tmpdir)
+        server._instructions = "You are Bob."
+
+        bootstrap = asyncio.run(
+            server._build_session_bootstrap(
+                caller_id="+46700000002",
+                from_number="+46700000002",
+            )
+        )
+
+    assert bootstrap.should_greet_first is True
+    assert (
+        "The caller is Erik. Greet them by name"
+        in bootstrap.initial_response_instructions
+    )
+    assert "not their full name" not in bootstrap.initial_response_instructions
+
+
 def test_build_session_bootstrap_asks_unknown_caller_to_identify() -> None:
     server = VoiceServer()
     server._instructions = "You are Bob."

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -17,6 +17,7 @@ from gptme_voice.realtime.server import (
     _build_caller_instructions,
     _build_resume_instructions,
     _get_twilio_field,
+    _lookup_caller_identity,
     _truncate_resume_transcript,
 )
 
@@ -53,6 +54,21 @@ def test_build_caller_instructions_known_number_from_people_dir() -> None:
     assert "Erik Bjäreholt" in result
     assert "+46700000001" in result
     assert "You are Bob." in result
+
+
+def test_lookup_caller_identity_uses_call_name_when_present() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        people_dir = Path(tmpdir) / "people"
+        people_dir.mkdir()
+        (people_dir / "erik-bjareholt.md").write_text(
+            "# Erik Bjäreholt\n\n- Call name: Erik\nPhone: +46700000001\n"
+        )
+
+        identity = _lookup_caller_identity("+46700000001", tmpdir)
+
+    assert identity is not None
+    assert identity.canonical_name == "Erik Bjäreholt"
+    assert identity.preferred_spoken_name == "Erik"
 
 
 def test_get_twilio_field_prefers_camel_case() -> None:
@@ -137,6 +153,9 @@ def test_build_session_bootstrap_personalizes_known_caller_greeting() -> None:
 
     assert bootstrap.should_greet_first is True
     assert "Erik Bjäreholt" in bootstrap.initial_response_instructions
+    assert (
+        "using 'Erik', not their full name" in bootstrap.initial_response_instructions
+    )
     assert "Do NOT say 'thanks for calling'" in bootstrap.initial_response_instructions
 
 


### PR DESCRIPTION
## Summary
Known callers can already store richer metadata in their people files, but realtime voice greetings still default to the full canonical name. This makes first-contact voice greetings sound awkward for cases like Erik, who prefers first-name-only greetings.

This PR teaches the voice server to:
- parse a `- Call name:` field from matched people files
- carry both canonical and preferred spoken names through caller lookup
- tell the greeting builder to use the preferred spoken name on voice calls
- fall back to the first token of the canonical name when no explicit call name is present

## Tests
- `uv run python3 -m py_compile packages/gptme-voice/src/gptme_voice/realtime/server.py packages/gptme-voice/tests/test_server.py`
- `uv run pytest packages/gptme-voice/tests/test_server.py -q`
