### PR TITLE
fix(lessons): add session_categories to 3 high-LOO lessons

### DIFF
--- a/lessons/workflow/check-existing-prs.md
+++ b/lessons/workflow/check-existing-prs.md
@@ -7,6 +7,7 @@ match:
   - gh pr list --search
   - issue has been open for a while
   - duplicate PR risk
+  session_categories: [cross-repo, code, triage]
 status: active
 ---
 

--- a/lessons/workflow/git-worktree-workflow.md
+++ b/lessons/workflow/git-worktree-workflow.md
@@ -11,6 +11,7 @@ match:
   - "external repository PR"
   - "multiple branches simultaneously"
   - "work on PR in separate directory"
+  session_categories: [cross-repo, code]
 status: active
 ---
 

--- a/lessons/workflow/verifiable-tasks-principle.md
+++ b/lessons/workflow/verifiable-tasks-principle.md
@@ -5,6 +5,7 @@ match:
   - "no way to verify"
   - "unclear completion criteria"
   - "task success is unclear"
+  session_categories: [strategic, code]
 status: active
 ---
 


### PR DESCRIPTION
## Summary

Adds explicit `session_categories` metadata to 3 lessons that show positive
LOO deltas in 14d category-controlled analysis but were missing the metadata,
forcing `session-classifier.py` to guess based on heuristics.

| Lesson | LOO delta | Significance | Categories added |
|--------|-----------|--------------|------------------|
| `workflow/check-existing-prs.md` | +0.0976 | *** | cross-repo, code, triage |
| `workflow/git-worktree-workflow.md` | +0.0595 | (n=15) | cross-repo, code |
| `workflow/verifiable-tasks-principle.md` | (medium tier) | — | strategic, code |

## Why

Continuation of the KWBench-for-lessons initiative (Phase 5+). When
`session_categories` is set, `update-lesson-bandit.py` logs `trigger_accuracy`
from the explicit metadata rather than the classifier's category inference. For
lessons with strong LOO signals but no explicit metadata, the classifier was
the limiting factor on attribution accuracy.

Phase 5 of this initiative landed 12 high-value Bob-local lessons with explicit
categories on 2026-04-24. This PR extends the same pattern to gptme-contrib
lessons with positive deltas. The Bob-local companion edit (4 more lessons)
landed in `ErikBjare/bob` master at `08f45b924`.

Categories chosen by reading each lesson's body and matching to the canonical
list already in use in lesson frontmatter:
`autonomous, cleanup, code, content, cross-repo, infra-maintenance, infrastructure, knowledge, monitoring, news, novelty, research, self-review, social, strategic, triage`.

## Test plan
- [x] `validate.py` passes for all 3 lessons (pre-existing length warnings unrelated)
- [x] YAML parses with `session_categories` under `match:` at the same level as `keywords:`
- [x] No keyword changes — purely additive metadata