### PR TITLE
fix(voice): filter gptme plugin-load warnings from subagent error text

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -139,9 +139,7 @@ class GptmeToolBridge:
             stripped = line.strip()
             if stripped in _IGNORABLE_ERROR_LINES:
                 return True
-            return any(
-                stripped.endswith(p) or p in stripped for p in _IGNORABLE_ERROR_PREFIXES
-            )
+            return any(stripped.startswith(p) for p in _IGNORABLE_ERROR_PREFIXES)
 
         stderr_lines = [
             line.strip()

--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -30,6 +30,13 @@ _MAX_OUTPUT_LEN = 2000
 _IGNORABLE_ERROR_LINES = {
     "Warning: Input is not a terminal (fd=0).",
 }
+# Prefix patterns for stderr lines that should never be treated as the
+# subagent error text.  These are gptme startup/runtime diagnostics that
+# appear regardless of whether the task succeeded or failed.
+_IGNORABLE_ERROR_PREFIXES = (
+    "WARNING  Failed to load plugin ",  # gptme plugin discovery noise
+    "WARNING  OpenTelemetry dependencies not available",
+)
 _DEFAULT_TRANSCRIPT_TAIL_TURNS = 8
 _DEFAULT_TRANSCRIPT_TAIL_CHARS = 1_600
 
@@ -128,10 +135,18 @@ class GptmeToolBridge:
 
     @staticmethod
     def _extract_error_text(stdout: str, stderr: str, output: str) -> str:
+        def _is_ignorable(line: str) -> bool:
+            stripped = line.strip()
+            if stripped in _IGNORABLE_ERROR_LINES:
+                return True
+            return any(
+                stripped.endswith(p) or p in stripped for p in _IGNORABLE_ERROR_PREFIXES
+            )
+
         stderr_lines = [
             line.strip()
             for line in stderr.splitlines()
-            if line.strip() and line.strip() not in _IGNORABLE_ERROR_LINES
+            if line.strip() and not _is_ignorable(line)
         ]
         if stderr_lines:
             return "\n".join(stderr_lines)


### PR DESCRIPTION
## Summary

When a gptme plugin fails to load at startup (e.g. `gptme_ace`), the WARNING appears in the subagent's stderr. If the subagent then times out (exit 124), `_extract_error_text` treats that WARNING as the reported error instead of the actual timeout signal — making it look like a plugin bug caused the failure rather than a timeout.

**Investigation**: Traced the `gptme_ace` warning to gptme's entry-point plugin discovery running in the gptme-contrib venv context. The warning is a diagnostic from gptme startup, not a task outcome.

**Fix**: Add `_IGNORABLE_ERROR_PREFIXES` to filter out gptme startup diagnostics from stderr before using it as error text:
- `"WARNING  Failed to load plugin ..."` — plugin discovery noise
- `"WARNING  OpenTelemetry dependencies not available"` — OTel noise

Real errors (rate limits, API failures, etc.) still pass through as before.

## Test plan
- [ ] Verify plugin load warning is filtered when timeout occurs
- [ ] Verify real API errors still surface correctly
- [ ] Voice subagent call with a plugin warning doesn't report "plugin error" to caller

Closes: ErikBjare/bob `tasks/investigate-gptme-ace-plugin-warning-in-voice-subagents.md` (Erik's voice call request 2026-04-27)