### PR TITLE
feat(voice): add gated browser websocket transport

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/audio.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/audio.py
@@ -21,7 +21,9 @@ class AudioConverter:
     OPENAI_RATE = 24000
 
     def __init__(self):
-        self._resample_state: tuple | None = None
+        # Keyed by input_rate so Twilio (8kHz) and Browser (16kHz) paths
+        # don't corrupt each other's resampler state when called on the same instance.
+        self._resample_states: dict[int, tuple | None] = {}
 
     def pcm_to_openai(self, pcm_data: bytes, input_rate: int) -> bytes:
         """
@@ -37,14 +39,15 @@ class AudioConverter:
         if input_rate == self.OPENAI_RATE:
             return pcm_data
 
-        pcm_24k, self._resample_state = audioop.ratecv(
+        pcm_24k, new_state = audioop.ratecv(
             pcm_data,
             2,  # 2 bytes per sample (16-bit)
             1,  # mono
             input_rate,
             self.OPENAI_RATE,
-            self._resample_state,
+            self._resample_states.get(input_rate),
         )
+        self._resample_states[input_rate] = new_state
         return pcm_24k
 
     def twilio_to_openai(self, mulaw_data: bytes) -> bytes:

--- a/packages/gptme-voice/src/gptme_voice/realtime/audio.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/audio.py
@@ -15,11 +15,37 @@ class AudioConverter:
 
     # Twilio uses 8kHz μ-law
     TWILIO_RATE = 8000
+    # Browser AudioWorklet path uses PCM 16kHz
+    BROWSER_RATE = 16000
     # OpenAI Realtime uses 24kHz PCM
     OPENAI_RATE = 24000
 
     def __init__(self):
         self._resample_state: tuple | None = None
+
+    def pcm_to_openai(self, pcm_data: bytes, input_rate: int) -> bytes:
+        """
+        Convert linear PCM audio to OpenAI PCM 24kHz.
+
+        Args:
+            pcm_data: PCM audio at ``input_rate`` (16-bit signed little-endian)
+            input_rate: Sample rate of ``pcm_data``
+
+        Returns:
+            PCM audio at 24kHz (16-bit signed little-endian)
+        """
+        if input_rate == self.OPENAI_RATE:
+            return pcm_data
+
+        pcm_24k, self._resample_state = audioop.ratecv(
+            pcm_data,
+            2,  # 2 bytes per sample (16-bit)
+            1,  # mono
+            input_rate,
+            self.OPENAI_RATE,
+            self._resample_state,
+        )
+        return pcm_24k
 
     def twilio_to_openai(self, mulaw_data: bytes) -> bytes:
         """
@@ -33,18 +59,19 @@ class AudioConverter:
         """
         # Convert μ-law to linear PCM (16-bit)
         pcm_data = audioop.ulaw2lin(mulaw_data, 2)
+        return self.pcm_to_openai(pcm_data, self.TWILIO_RATE)
 
-        # Resample from 8kHz to 24kHz (3x upsample)
-        pcm_24k, self._resample_state = audioop.ratecv(
-            pcm_data,
-            2,  # 2 bytes per sample (16-bit)
-            1,  # mono
-            self.TWILIO_RATE,
-            self.OPENAI_RATE,
-            self._resample_state,
-        )
+    def browser_to_openai(self, pcm_data: bytes) -> bytes:
+        """
+        Convert browser PCM 16kHz audio to OpenAI PCM 24kHz.
 
-        return pcm_24k
+        Args:
+            pcm_data: PCM audio at 16kHz (16-bit signed little-endian)
+
+        Returns:
+            PCM audio at 24kHz (16-bit signed little-endian)
+        """
+        return self.pcm_to_openai(pcm_data, self.BROWSER_RATE)
 
     def openai_to_twilio(self, pcm_data: bytes) -> bytes:
         """

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -1444,7 +1444,13 @@ class VoiceServer:
                 if not isinstance(text, str):
                     continue
 
-                data = json.loads(text)
+                try:
+                    data = json.loads(text)
+                except json.JSONDecodeError:
+                    logger.warning(
+                        "Browser websocket: ignoring malformed JSON text frame"
+                    )
+                    continue
                 if data.get("type") == "commit":
                     await realtime_client.commit_audio()
 

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -298,11 +298,13 @@ class VoiceServer:
         workspace: str | None = None,
         provider: str = _PROVIDER_OPENAI,
         model: str | None = None,
+        enable_browser_transport: bool = False,
     ):
         self.host = host
         self.port = port
         self.provider = provider
         self.model = model
+        self.enable_browser_transport = enable_browser_transport
         if provider == _PROVIDER_GROK:
             self._api_key = _get_xai_api_key()
         else:
@@ -362,15 +364,16 @@ class VoiceServer:
         self._pending_post_calls: dict[str, str] = {}
         self._pending_archive_records: dict[str, list[Path]] = {}
 
-        # Create Starlette app
-        self.app = Starlette(
-            routes=[
-                Route("/", self.health_check, methods=["GET"]),
-                Route("/incoming", self.handle_incoming_call, methods=["POST"]),
-                WebSocketRoute("/twilio", self.handle_twilio_websocket),
-                WebSocketRoute("/local", self.handle_local_websocket),
-            ]
-        )
+        routes = [
+            Route("/", self.health_check, methods=["GET"]),
+            Route("/incoming", self.handle_incoming_call, methods=["POST"]),
+            WebSocketRoute("/twilio", self.handle_twilio_websocket),
+            WebSocketRoute("/local", self.handle_local_websocket),
+        ]
+        if self.enable_browser_transport:
+            routes.append(WebSocketRoute("/voice", self.handle_browser_websocket))
+
+        self.app = Starlette(routes=routes)
 
     def _recent_call_path(self, caller_id: str) -> Path:
         digest = hashlib.sha256(caller_id.encode("utf-8")).hexdigest()[:16]
@@ -1351,6 +1354,123 @@ class VoiceServer:
                 tool_bridge=tool_bridge,
             )
 
+    async def handle_browser_websocket(self, websocket):
+        """
+        Handle WebSocket connection for browser voice transport.
+
+        Accepts raw binary PCM16 audio frames at 16kHz from the browser side.
+        Control messages remain JSON text frames.
+        """
+        await websocket.accept()
+
+        caller_id = self._get_local_caller_id(websocket)
+        handoff_id = self._get_local_handoff_id(websocket)
+        realtime_client: OpenAIRealtimeClient | None = None
+        tool_bridge: GptmeToolBridge | None = None
+        transcript: list[TranscriptTurn] = []
+        audio_converter = AudioConverter()
+
+        try:
+            instructions = await self._build_session_instructions(
+                caller_id=caller_id,
+                handoff_id=handoff_id,
+            )
+            if self.model:
+                session_cfg = SessionConfig(
+                    instructions=instructions,
+                    model=self.model,
+                    available_agents=self._available_agents,
+                )
+            else:
+                session_cfg = SessionConfig(
+                    instructions=instructions,
+                    available_agents=self._available_agents,
+                )
+            realtime_client = self._make_client(
+                session_cfg,
+                on_audio=lambda audio: self._send_browser_audio(websocket, audio),
+                on_audio_end=lambda: self._send_browser_audio_end(websocket),
+                on_ai_transcript=lambda text: _append_transcript_turn(
+                    transcript, "assistant", text
+                ),
+                on_user_transcript=lambda text: _append_transcript_turn(
+                    transcript, "user", text
+                ),
+            )
+            browser_ws = websocket
+
+            async def _browser_hangup(reason: str | None) -> None:
+                await self._schedule_hangup(
+                    browser_ws,
+                    source="browser",
+                    reason=reason,
+                    call_sid=None,
+                )
+
+            tool_bridge = GptmeToolBridge(
+                workspace=self.workspace,
+                on_result=realtime_client.inject_message,
+                on_hangup=_browser_hangup,
+                on_handoff=self._make_handoff_callback([caller_id], transcript),
+                transcript_provider=lambda: transcript,
+            )
+            realtime_client.on_function_call = tool_bridge.handle_function_call
+
+            await realtime_client.connect()
+            await websocket.send_text(
+                json.dumps(
+                    {
+                        "type": "ready",
+                        "input_sample_rate": AudioConverter.BROWSER_RATE,
+                        "output_sample_rate": AudioConverter.OPENAI_RATE,
+                    }
+                )
+            )
+
+            while True:
+                message = await websocket.receive()
+                message_type = message.get("type")
+                if message_type == "websocket.disconnect":
+                    break
+
+                audio_data = message.get("bytes")
+                if isinstance(audio_data, bytes):
+                    await realtime_client.send_audio(
+                        audio_converter.browser_to_openai(audio_data)
+                    )
+                    continue
+
+                text = message.get("text")
+                if not isinstance(text, str):
+                    continue
+
+                data = json.loads(text)
+                if data.get("type") == "commit":
+                    await realtime_client.commit_audio()
+
+        except WebSocketDisconnect:
+            pass
+        except RuntimeError as exc:
+            if "not connected" not in str(exc).lower():
+                raise
+            logger.debug("Browser websocket already closed before receive: %s", exc)
+        except Exception as e:
+            logger.exception("Error handling browser connection: %s", e)
+        finally:
+            if realtime_client:
+                await self._disconnect_realtime_client(realtime_client)
+            await self._on_call_end(
+                caller_id,
+                "browser",
+                transcript,
+                {
+                    "caller_id": caller_id,
+                    "provider": self.provider,
+                    **({"handoff_id": handoff_id} if handoff_id else {}),
+                },
+                tool_bridge=tool_bridge,
+            )
+
     async def _schedule_hangup(
         self,
         websocket,
@@ -1406,6 +1526,15 @@ class VoiceServer:
         message = {"type": "audio_end"}
         await websocket.send_text(json.dumps(message))
 
+    async def _send_browser_audio(self, websocket, audio_data: bytes):
+        """Send raw PCM audio frames to the browser transport."""
+        await websocket.send_bytes(audio_data)
+
+    async def _send_browser_audio_end(self, websocket):
+        """Signal to the browser transport that playback is complete."""
+        message = {"type": "audio_end"}
+        await websocket.send_text(json.dumps(message))
+
     def run(self):
         """Run the server."""
         uvicorn.run(self.app, host=self.host, port=self.port)
@@ -1430,6 +1559,11 @@ class VoiceServer:
         "unless you need a specific model alias from the xAI console."
     ),
 )
+@click.option(
+    "--enable-browser-transport",
+    is_flag=True,
+    help="Expose /voice WebSocket for browser PCM transport.",
+)
 @click.option("--debug", is_flag=True, help="Enable debug logging")
 def main(
     host: str,
@@ -1437,6 +1571,7 @@ def main(
     workspace: str | None,
     provider: str,
     model: str | None,
+    enable_browser_transport: bool,
     debug: bool,
 ):
     """Voice Interface Server for gptme."""
@@ -1454,10 +1589,13 @@ def main(
         workspace=workspace,
         provider=provider,
         model=model,
+        enable_browser_transport=enable_browser_transport,
     )
 
     logger.info(f"Starting voice server on {host}:{port} (provider={provider})")
     logger.info(f"Local test endpoint: ws://{host}:{port}/local")
+    if enable_browser_transport:
+        logger.info(f"Browser test endpoint: ws://{host}:{port}/voice")
 
     server.run()
 

--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -18,7 +18,7 @@ import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Awaitable, Callable
+from typing import Awaitable, Callable, Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -94,7 +94,7 @@ class GptmeToolBridge:
         on_result: Callable[[str], Awaitable[None]] | None = None,
         on_hangup: Callable[[str | None], Awaitable[None]] | None = None,
         on_handoff: Callable[[str, str, str | None], Awaitable[dict]] | None = None,
-        transcript_provider: Callable[[], list[object]] | None = None,
+        transcript_provider: Callable[[], Sequence[object]] | None = None,
     ):
         self.gptme_path = os.environ.get("GPTME_VOICE_SUBAGENT_PATH") or gptme_path
         self.timeout = timeout

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -10,6 +10,7 @@ import time
 from pathlib import Path
 
 import pytest
+from gptme_voice.realtime.audio import AudioConverter
 from gptme_voice.realtime.server import (
     RecentCallRecord,
     TranscriptTurn,
@@ -25,9 +26,73 @@ from gptme_voice.realtime.server import (
 class _DummyWebSocket:
     def __init__(self) -> None:
         self.messages: list[str] = []
+        self.binary_messages: list[bytes] = []
 
     async def send_text(self, message: str) -> None:
         self.messages.append(message)
+
+    async def send_bytes(self, message: bytes) -> None:
+        self.binary_messages.append(message)
+
+
+class _DummyBrowserWebSocket:
+    def __init__(self, incoming: list[dict[str, object]]) -> None:
+        self.query_params: dict[str, str] = {}
+        self._incoming = incoming
+        self.accepted = False
+        self.text_messages: list[str] = []
+        self.binary_messages: list[bytes] = []
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def receive(self) -> dict[str, object]:
+        if self._incoming:
+            return self._incoming.pop(0)
+        return {"type": "websocket.disconnect"}
+
+    async def send_text(self, message: str) -> None:
+        self.text_messages.append(message)
+
+    async def send_bytes(self, message: bytes) -> None:
+        self.binary_messages.append(message)
+
+
+class _FakeRealtimeClient:
+    def __init__(self) -> None:
+        self.sent_audio: list[bytes] = []
+        self.commit_count = 0
+        self.disconnect_kwargs: dict[str, object] | None = None
+        self.on_function_call = None
+
+    async def connect(self) -> None:
+        return None
+
+    async def send_audio(self, audio_data: bytes) -> None:
+        self.sent_audio.append(audio_data)
+
+    async def commit_audio(self) -> None:
+        self.commit_count += 1
+
+    async def disconnect(self, **kwargs: object) -> None:
+        self.disconnect_kwargs = kwargs
+
+    async def inject_message(self, _text: str) -> None:
+        return None
+
+
+class _DummyToolBridge:
+    def __init__(self, *args, **kwargs) -> None:
+        return None
+
+    async def handle_function_call(self, _name: str, _args: dict) -> None:
+        return None
+
+    def pending_task_ids(self) -> list[str]:
+        return []
+
+    def get_timings(self) -> list[dict[str, object]]:
+        return []
 
 
 def test_build_caller_instructions_no_number() -> None:
@@ -96,6 +161,92 @@ def test_send_to_twilio_uses_stream_sid_field_name() -> None:
         "streamSid": "MZ123",
         "media": {"payload": base64.b64encode(b"\x00\x01").decode("utf-8")},
     }
+
+
+def test_voice_route_disabled_by_default() -> None:
+    server = VoiceServer()
+
+    websocket_paths = {
+        route.path for route in server.app.routes if hasattr(route, "path")
+    }
+
+    assert "/voice" not in websocket_paths
+
+
+def test_voice_route_enabled_when_requested() -> None:
+    server = VoiceServer(enable_browser_transport=True)
+
+    websocket_paths = {
+        route.path for route in server.app.routes if hasattr(route, "path")
+    }
+
+    assert "/voice" in websocket_paths
+
+
+def test_send_browser_audio_uses_binary_frames() -> None:
+    server = VoiceServer(enable_browser_transport=True)
+    websocket = _DummyWebSocket()
+
+    asyncio.run(server._send_browser_audio(websocket, b"\x00\x01"))
+
+    assert websocket.binary_messages == [b"\x00\x01"]
+
+
+def test_send_browser_audio_end_uses_text_control_message() -> None:
+    server = VoiceServer(enable_browser_transport=True)
+    websocket = _DummyWebSocket()
+
+    asyncio.run(server._send_browser_audio_end(websocket))
+
+    assert [json.loads(message) for message in websocket.messages] == [
+        {"type": "audio_end"}
+    ]
+
+
+def test_handle_browser_websocket_resamples_binary_pcm_and_commits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server = VoiceServer(enable_browser_transport=True)
+    websocket = _DummyBrowserWebSocket(
+        [
+            {"type": "websocket.receive", "bytes": b"\x00\x00\x01\x00"},
+            {"type": "websocket.receive", "text": json.dumps({"type": "commit"})},
+            {"type": "websocket.disconnect"},
+        ]
+    )
+    fake_client = _FakeRealtimeClient()
+
+    async def _fake_build_session_instructions(
+        *, caller_id: str, handoff_id: str | None
+    ) -> str:
+        return "You are Bob."
+
+    def _fake_make_client(_session_cfg, **_kwargs):
+        return fake_client
+
+    async def _fake_on_call_end(*args, **kwargs) -> None:
+        return None
+
+    monkeypatch.setattr(
+        server, "_build_session_instructions", _fake_build_session_instructions
+    )
+    monkeypatch.setattr(server, "_make_client", _fake_make_client)
+    monkeypatch.setattr(server, "_on_call_end", _fake_on_call_end)
+    monkeypatch.setattr("gptme_voice.realtime.server.GptmeToolBridge", _DummyToolBridge)
+
+    asyncio.run(server.handle_browser_websocket(websocket))
+
+    expected_audio = AudioConverter().browser_to_openai(b"\x00\x00\x01\x00")
+    assert websocket.accepted is True
+    assert json.loads(websocket.text_messages[0]) == {
+        "type": "ready",
+        "input_sample_rate": AudioConverter.BROWSER_RATE,
+        "output_sample_rate": AudioConverter.OPENAI_RATE,
+    }
+    assert fake_client.sent_audio == [expected_audio]
+    assert fake_client.commit_count == 1
+    assert fake_client.disconnect_kwargs is not None
+    assert fake_client.disconnect_kwargs["commit_audio"] is True
 
 
 def test_build_resume_instructions_includes_prior_transcript() -> None:

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -1087,3 +1087,68 @@ def test_twilio_handler_reraises_unrelated_runtimeerror(tmp_path) -> None:
 
     with pytest.raises(RuntimeError, match="unexpected failure"):
         asyncio.run(server.handle_twilio_websocket(websocket))
+
+
+def test_browser_websocket_ignores_malformed_json_text_frame(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A malformed JSON text frame must not kill the browser voice session (P1 fix)."""
+    server = VoiceServer(enable_browser_transport=True)
+    websocket = _DummyBrowserWebSocket(
+        [
+            {"type": "websocket.receive", "text": "not-valid-json"},
+            {"type": "websocket.receive", "text": json.dumps({"type": "commit"})},
+            {"type": "websocket.disconnect"},
+        ]
+    )
+    fake_client = _FakeRealtimeClient()
+
+    async def _fake_build_session_instructions(
+        *, caller_id: str, handoff_id: str | None
+    ) -> str:
+        return "You are Bob."
+
+    def _fake_make_client(_session_cfg, **_kwargs):
+        return fake_client
+
+    async def _fake_on_call_end(*args, **kwargs) -> None:
+        return None
+
+    monkeypatch.setattr(
+        server, "_build_session_instructions", _fake_build_session_instructions
+    )
+    monkeypatch.setattr(server, "_make_client", _fake_make_client)
+    monkeypatch.setattr(server, "_on_call_end", _fake_on_call_end)
+    monkeypatch.setattr("gptme_voice.realtime.server.GptmeToolBridge", _DummyToolBridge)
+
+    # Should not raise — malformed frame is skipped, commit still fires
+    asyncio.run(server.handle_browser_websocket(websocket))
+
+    assert fake_client.commit_count == 1
+
+
+def test_audio_converter_independent_resample_states() -> None:
+    """Twilio (8kHz) and Browser (16kHz) upsampling must not share resampler state (P2 fix).
+
+    After priming the Twilio (8kHz→24kHz) path, Browser (16kHz→24kHz) output must
+    be identical to a fresh converter that has never seen Twilio audio. If the two
+    paths shared one _resample_state the state from the 8kHz path would corrupt
+    the 16kHz conversion.
+    """
+    twilio_pcm = b"\x00\x00" * 160  # 160 samples @ 8kHz = 20ms
+    browser_pcm = (
+        b"\x01\x00" * 320
+    )  # 320 samples @ 16kHz = 20ms (non-zero to detect corruption)
+
+    # Converter that sees both paths interleaved
+    combined = AudioConverter()
+    combined.twilio_to_openai(twilio_pcm)  # prime 8kHz state
+    combined_browser_out = combined.browser_to_openai(browser_pcm)
+
+    # Fresh converter that has only ever seen browser audio
+    fresh = AudioConverter()
+    fresh_browser_out = fresh.browser_to_openai(browser_pcm)
+
+    # With per-rate state slots the browser path starts fresh regardless of prior
+    # Twilio calls — outputs must be identical.
+    assert combined_browser_out == fresh_browser_out


### PR DESCRIPTION
## Summary
- add a gated `/voice` websocket route for browser PCM transport
- resample 16kHz browser PCM input to the realtime client's 24kHz format
- send raw PCM audio frames back to browser clients plus a small `ready`/`audio_end` control protocol
- cover the new route, binary transport, and commit flow with server tests
- make `transcript_provider` accept a `Sequence` so server transports don't trip list invariance

## Testing
- `uv run --python /usr/bin/python3.12 pytest packages/gptme-voice/tests -q`
- `uv run --python /usr/bin/python3.12 ruff check packages/gptme-voice/src/gptme_voice/realtime/audio.py packages/gptme-voice/src/gptme_voice/realtime/server.py packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py packages/gptme-voice/tests/test_server.py`

## Notes
- Browser transport is gated behind `--enable-browser-transport`.
- Protocol is intentionally minimal for phase 1: binary audio frames in, binary audio frames out, JSON text frames for control messages.
