### PR TITLE
fix(gptodo): surface unloadable task files in check (no more silent drop)

### DIFF
--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -943,9 +943,13 @@ def check(fix: bool, task_files: list[str]):
     repo_root = find_repo_root(Path.cwd())
     tasks_dir = repo_root / "tasks"
 
-    # ALWAYS load all tasks to build complete task_ids set for dependency checking
-    all_tasks = load_tasks(tasks_dir)
-    if not all_tasks:
+    # ALWAYS load all tasks to build complete task_ids set for dependency checking.
+    # Capture per-file load errors so we can surface invisible tasks (files that
+    # fail to parse, e.g. broken YAML frontmatter, are otherwise silently dropped
+    # by load_tasks and the user sees a misleading "All N tasks verified" report).
+    load_errors: list[tuple[Path, str]] = []
+    all_tasks = load_tasks(tasks_dir, errors_out=load_errors)
+    if not all_tasks and not load_errors:
         console.print("[yellow]No tasks found in tasks directory![/]")
         return
 
@@ -1036,6 +1040,15 @@ def check(fix: bool, task_files: list[str]):
 
     # Report results by category
     has_issues = False
+
+    if load_errors:
+        has_issues = True
+        console.print(
+            f"\n[bold red]Unloadable Task Files ({len(load_errors)}) — "
+            "these were silently dropped from selection:[/]"
+        )
+        for unloadable_path, err in load_errors:
+            console.print(f"  • {unloadable_path.relative_to(repo_root)}: {err}")
 
     if validation_issues:
         has_issues = True

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -973,14 +973,18 @@ def check(fix: bool, task_files: list[str]):
                 # Just filename, resolve from tasks_dir
                 path = tasks_dir / path
             try:
-                file_tasks = load_tasks(path.parent, single_file=path)
+                file_errors: list[tuple[Path, str]] = []
+                file_tasks = load_tasks(path.parent, single_file=path, errors_out=file_errors)
+                if file_errors:
+                    existing_paths = {e[0] for e in load_errors}
+                    load_errors.extend(e for e in file_errors if e[0] not in existing_paths)
                 if file_tasks:
                     tasks_to_validate.extend(file_tasks)
                 else:
                     console.print(f"[yellow]Warning: No valid task found in {file}[/]")
             except Exception as e:
                 console.print(f"[red]Error reading {file}: {e}[/]")
-        if not tasks_to_validate:
+        if not tasks_to_validate and not load_errors:
             console.print("[yellow]No valid tasks to validate![/]")
             return
     else:

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -627,7 +627,10 @@ def load_task(file: Path) -> Tuple[fmPost, SubtaskCount]:
 
 
 def load_tasks(
-    tasks_dir: Path, recursive: bool = False, single_file: Path | None = None
+    tasks_dir: Path,
+    recursive: bool = False,
+    single_file: Path | None = None,
+    errors_out: list[Tuple[Path, str]] | None = None,
 ) -> List[TaskInfo]:
     """Load tasks from directory or single file with metadata.
 
@@ -635,6 +638,10 @@ def load_tasks(
         tasks_dir: Directory containing task files
         recursive: Whether to search subdirectories
         single_file: Optional specific file to load
+        errors_out: Optional list to append (file, error_message) tuples for files
+            that failed to load. When None (default), errors are only logged via
+            ``logging.error`` — preserving the legacy behaviour. Pass a list to
+            surface dropped files to the caller (e.g. for ``gptodo check``).
 
     Returns:
         List of TaskInfo objects
@@ -793,6 +800,8 @@ def load_tasks(
 
         except Exception as e:
             logging.error(f"Error reading {file}: {e}")
+            if errors_out is not None:
+                errors_out.append((file, str(e)))
 
     return tasks
 

--- a/packages/gptodo/tests/test_load_tasks_errors.py
+++ b/packages/gptodo/tests/test_load_tasks_errors.py
@@ -1,0 +1,90 @@
+"""Regression tests for load_tasks error surfacing.
+
+A task file with broken YAML frontmatter (e.g. an unquoted ``next_action: foo
+\\`:1\\` bar`` that PyYAML mis-parses as a mapping) was previously dropped
+silently — the file disappeared from the loaded list, the loader logged to
+stderr, and ``gptodo check`` reported "All N tasks verified" with the wrong
+N. The ``errors_out`` parameter lets callers detect this case.
+"""
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from gptodo.cli import cli
+from gptodo.utils import load_tasks
+
+
+VALID_TASK = """\
+---
+state: backlog
+created: 2026-04-27T00:00:00+00:00
+---
+# Valid Task
+"""
+
+# Real reproducer from session 21b1 (2026-04-27): an unquoted next_action that
+# embeds a backtick-colon-digit-backtick (`\`:1\``) makes PyYAML attempt a
+# mapping parse inside the continuation and the entire frontmatter block fails.
+BROKEN_TASK = """\
+---
+state: backlog
+created: 2026-04-27T00:00:00+00:00
+next_action: Run user-testing loop on `v0.31.1.dev202604277` (or later) on
+  display `:1` — verify settings polish from #2247/#2248 in packaged build,
+  then complete one real in-app message/tool roundtrip
+---
+# Broken Task
+"""
+
+
+def test_load_tasks_appends_to_errors_out_when_yaml_invalid(tmp_path: Path) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "valid.md").write_text(VALID_TASK)
+    (tasks_dir / "broken.md").write_text(BROKEN_TASK)
+
+    errors: list[tuple[Path, str]] = []
+    tasks = load_tasks(tasks_dir, errors_out=errors)
+
+    assert len(tasks) == 1, "broken file should not appear in the loaded list"
+    assert tasks[0].name == "valid"
+    assert len(errors) == 1, f"broken file should be reported in errors_out, got: {errors}"
+    file, msg = errors[0]
+    assert file.name == "broken.md"
+    assert msg, "error message must not be empty"
+
+
+def test_load_tasks_default_behavior_unchanged(tmp_path: Path) -> None:
+    """Without errors_out, behavior matches the legacy contract: silent drop."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "valid.md").write_text(VALID_TASK)
+    (tasks_dir / "broken.md").write_text(BROKEN_TASK)
+
+    tasks = load_tasks(tasks_dir)
+
+    assert len(tasks) == 1
+    assert tasks[0].name == "valid"
+
+
+def test_check_command_surfaces_unloadable_files(tmp_path: Path, monkeypatch) -> None:
+    """`gptodo check` must fail loud — not report success — when a task file
+    is unloadable. Previously the success line read 'All N tasks verified'
+    with N silently low."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "valid.md").write_text(VALID_TASK)
+    (tasks_dir / "broken.md").write_text(BROKEN_TASK)
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(cli, ["check"])
+
+    assert result.exit_code == 1, (
+        f"check must exit non-zero when a file is unloadable, "
+        f"got {result.exit_code}\noutput: {result.output}"
+    )
+    assert "Unloadable Task Files" in result.output
+    assert "broken.md" in result.output
+    # Must NOT claim success
+    assert "tasks verified successfully" not in result.output

--- a/packages/gptodo/tests/test_load_tasks_errors.py
+++ b/packages/gptodo/tests/test_load_tasks_errors.py
@@ -88,3 +88,22 @@ def test_check_command_surfaces_unloadable_files(tmp_path: Path, monkeypatch) ->
     assert "broken.md" in result.output
     # Must NOT claim success
     assert "tasks verified successfully" not in result.output
+
+
+def test_check_targeted_file_surfaces_unloadable(tmp_path: Path, monkeypatch) -> None:
+    """`gptodo check tasks/broken.md` must also fail loud — the early-return
+    path in the task_files branch must not suppress load_errors (P1 gap)."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "valid.md").write_text(VALID_TASK)
+    (tasks_dir / "broken.md").write_text(BROKEN_TASK)
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(cli, ["check", "tasks/broken.md"])
+
+    assert result.exit_code == 1, (
+        f"check tasks/broken.md must exit non-zero when the file is unloadable, "
+        f"got {result.exit_code}\noutput: {result.output}"
+    )
+    assert "Unloadable Task Files" in result.output
+    assert "broken.md" in result.output


### PR DESCRIPTION
## Summary

A task file with broken YAML frontmatter is silently dropped by `load_tasks()` — the loader logs via `logging.error` and returns the surviving tasks, but the caller has no way to know a file was dropped. As a result, `gptodo check` reports "✓ All N tasks verified" with N silently low.

**Real-world impact**: Bob session 21b1 (2026-04-27) discovered a `gptme-tauri-recurring-user-testing` task that had been silently dropped from CASCADE selection for **2 days**. Root cause was an unquoted `next_action` containing `` `:1` `` (backtick-colon-digit-backtick), which made PyYAML attempt a mapping parse and fail.

## Changes

Two minimal, backwards-compatible changes:

1. **`load_tasks(..., errors_out: list[tuple[Path, str]] | None = None)`** — opt-in list parameter that gets `(file, error_message)` tuples for unloadable files. Default behavior (`errors_out=None`) is unchanged: log only, return loaded tasks. No existing caller needs updating.

2. **`gptodo check` opts in**. Unloadable files are surfaced under a new "Unloadable Task Files" section and force exit code 1. The "tasks verified successfully" line no longer appears alongside silently dropped files.

## Before / After

**Before** (silent drop):
```
✓ All 38 tasks verified successfully! (2 with subtasks)
```
…with no indication that 39 task files actually existed.

**After** (loud failure):
```
Unloadable Task Files (1) — these were silently dropped from selection:
  • tasks/broken.md: while parsing a block mapping
  in "<unicode string>", line 6, column 3
```
…and exit code 1.

## Test plan

- [x] New test file `test_load_tasks_errors.py` (3 tests, uses real session 21b1 reproducer)
- [x] `errors_out=None` default behavior unchanged (existing 145 tests still pass)
- [x] `gptodo check` exits 1 and prints unloadable file under new heading
- [x] mypy clean