### PR TITLE
chore(lessons): remove 8 dead keywords from 4 active lessons

### DIFF
--- a/lessons/concepts/hierarchical-context-management.md
+++ b/lessons/concepts/hierarchical-context-management.md
@@ -4,8 +4,6 @@ match:
   - context window management
   - organize context across steps
   - prune older conversation context
-  - layered context approach
-  - context accumulating across steps
 status: active
 ---
 

--- a/lessons/patterns/avoid-excessive-setup-when-dir.md
+++ b/lessons/patterns/avoid-excessive-setup-when-dir.md
@@ -4,8 +4,6 @@ match:
     - "spending too much time on setup"
     - "5+ chains on prerequisites"
     - "need to understand full pipeline before testing"
-    - "excessive setup before testing component"
-    - "use mock data instead of full pipeline"
 status: active
 ---
 

--- a/lessons/tools/browser-verification.md
+++ b/lessons/tools/browser-verification.md
@@ -5,8 +5,6 @@ match:
   - "push without browser check"
   - "claiming fixed without testing"
   - "javascript fix without testing"
-  - "webui change without testing"
-  - "html fix without checking"
   session_categories: [code]
 status: active
 ---

--- a/lessons/workflow/cross-agent-workspace-review.md
+++ b/lessons/workflow/cross-agent-workspace-review.md
@@ -1,6 +1,6 @@
 ---
 match:
-  keywords: ["cross-agent review", "workspace review patterns", "reviewing other agent's work", "mutual workspace analysis", "cross-agent knowledge sharing"]
+  keywords: ["cross-agent review", "workspace review patterns", "reviewing other agent's work"]
 status: active
 ---
 


### PR DESCRIPTION
## Summary

Fourth-pass dead-keyword cleanup following #777 (8 lessons), #782 (11 lessons), and #788 (12 lessons).

4 active lessons trimmed of 8 keywords flagged by `lesson-keyword-health.py --action-items --days 14` as having **zero matches across 1,969 sessions**. All touched lessons retain working keywords (≥3); net -8 LOC.

## Methodology

Source: bob workspace `scripts/lesson-keyword-health.py`. Looked at the "Remove dead keywords from active lessons" section, then verified each:
- Confirmed lesson has ≥2 working keywords post-removal (no risk of silencing)
- Used 14-day window (matching #788) instead of 7-day, so dead keywords are stable, not edge cases
- Skipped scenario-specific lessons where dead ≠ wrong

## Removed Keywords

| Lesson | Removed |
|--------|---------|
| `cross-agent-workspace-review.md` | 'mutual workspace analysis', 'cross-agent knowledge sharing' |
| `hierarchical-context-management.md` | 'layered context approach', 'context accumulating across steps' |
| `avoid-excessive-setup-when-dir.md` | 'excessive setup before testing component', 'use mock data instead of full pipeline' |
| `browser-verification.md` | 'webui change without testing', 'html fix without checking' |

## Skipped

- `agent-orchestrator-patterns.md` — has 3 keywords total, removing 2 dead would leave only 1 (below the ≥2 floor used in prior passes)

## Test plan

- [x] Each lesson retains ≥3 working keywords post-edit
- [x] `lesson-keyword-health.py --action-items --days 14` confirms keywords had zero matches across 14-day window
- [x] Pre-commit hooks pass cleanly
- [x] No companion docs touched