### PR TITLE
fix(cc-backend): tag subprocess invocations to prevent bandit pollution

### DIFF
--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -50,6 +50,14 @@ def call_claude_code(prompt: str, timeout: int = 120, max_retries: int = _MAX_RE
     env.pop("CLAUDE_CODE_ENTRYPOINT", None)
     env.pop("CC_SESSION_ID", None)
     env.pop("CC_MODEL", None)
+    # Tag the subprocess so agent Stop hooks can distinguish it from a real
+    # autonomous run. Each `claude -p` call still writes an ai-title entry to
+    # ~/.claude/projects/, which fires Stop hooks and would otherwise be tagged
+    # as run_type=autonomous (default), polluting session-records.jsonl with
+    # 0-duration noops. Alice's post-session.py reads ALICE_SESSION_TYPE; the
+    # generic GPTME_SUBPROCESS=1 is for future cross-agent hook adoption.
+    env["ALICE_SESSION_TYPE"] = "subprocess"
+    env["GPTME_SUBPROCESS"] = "1"
 
     cmd = ["claude", "-p", "-"]
     if nested:

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -54,9 +54,8 @@ def call_claude_code(prompt: str, timeout: int = 120, max_retries: int = _MAX_RE
     # autonomous run. Each `claude -p` call still writes an ai-title entry to
     # ~/.claude/projects/, which fires Stop hooks and would otherwise be tagged
     # as run_type=autonomous (default), polluting session-records.jsonl with
-    # 0-duration noops. Alice's post-session.py reads ALICE_SESSION_TYPE; the
-    # generic GPTME_SUBPROCESS=1 is for future cross-agent hook adoption.
-    env["ALICE_SESSION_TYPE"] = "subprocess"
+    # 0-duration noops. Agent hooks should check GPTME_SUBPROCESS=1 to detect
+    # subprocess sessions (the generic cross-agent signal).
     env["GPTME_SUBPROCESS"] = "1"
 
     cmd = ["claude", "-p", "-"]


### PR DESCRIPTION
## Summary

Each `claude -p` call from `cc_backend.call_claude_code()` creates a CC session that fires the calling agent's Stop hook. Without a session-type marker, those records get tagged as `run_type=autonomous` (the post-session.py default), polluting `session-records.jsonl` with 0-duration noop sessions that bias the agent's bandit analytics toward `_exhausted` states.

This sets `ALICE_SESSION_TYPE=subprocess` (read by Alice's existing `post-session.py` hook) and the generic `GPTME_SUBPROCESS=1` for future cross-agent hook adoption. Existing analytics (`session-bandit.py`, `inference-review.py`) already filter by `run_type='autonomous'`, so subprocess-tagged records are automatically excluded.

## Empirical Evidence

11 polluted records found in Alice's `session-records.jsonl` over `2026-04-14` through `2026-04-26`, all clustered at the daily-email cron time (~10:00 UTC) — exactly when `gptme-activity-summary daily` runs. Each had:
- `run_type: autonomous` (incorrect)
- `duration_seconds: 0`
- `model: unknown`
- `token_count: null`
- `trajectory_path` pointing to `~/.claude/projects/{uuid}.jsonl`

Inspecting those trajectory files showed each contained a single line — just the auto-generated `ai-title` entry, no user/assistant turns. Backfill of historical records to `run_type=subprocess` was done locally in alice's repo.

## Test plan

- [ ] After this lands and submodule is bumped, monitor next ~10:00 UTC daily-email cycle (2026-04-29) and verify the resulting Stop-hook record has `run_type: subprocess`, not `autonomous`
- [ ] `bandit-effectiveness.py` output should no longer show daily 10:00 UTC noops feeding into the `_exhausted` decisions