### PR TITLE
feat(voice): pre-warm provider connection to eliminate inbound call dead air

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
@@ -250,6 +250,10 @@ class OpenAIRealtimeClient:
         self._pending_audio_dropped = 0
         self._event_notice: asyncio.Event | None = None
         self._initial_response_sent = False
+        # When True, the initial response is held back even after session.created.
+        # Set this on pre-warmed sessions; call activate_session() once the
+        # call-side WebSocket is ready to receive audio.
+        self._hold_initial_response = False
 
     def _get_ws_url(self) -> str:
         """WebSocket URL for this provider (override in subclasses)."""
@@ -607,7 +611,11 @@ class OpenAIRealtimeClient:
     async def _send_initial_response_if_needed(self) -> None:
         """Trigger a one-shot startup response once the provider session is ready."""
         instructions = self.session_config.initial_response_instructions.strip()
-        if self._initial_response_sent or not instructions:
+        if (
+            self._initial_response_sent
+            or not instructions
+            or self._hold_initial_response
+        ):
             return
 
         self._initial_response_sent = True
@@ -620,6 +628,16 @@ class OpenAIRealtimeClient:
                 }
             },
         )
+
+    async def activate_session(self) -> None:
+        """Release the held initial response on a pre-warmed session.
+
+        Call this after attaching audio/transcript callbacks to a pre-warmed
+        client so the greeting fires once the call-side WebSocket is ready.
+        """
+        self._hold_initial_response = False
+        if self._session_ready is not None and self._session_ready.is_set():
+            await self._send_initial_response_if_needed()
 
     async def _flush_pending_audio(self) -> None:
         """Send any audio that was buffered before the session was ready."""

--- a/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
@@ -222,6 +222,7 @@ class OpenAIRealtimeClient:
         on_ai_transcript: Callable[[str], None] | None = None,
         on_user_transcript: Callable[[str], None] | None = None,
         on_function_call: Callable[[str, dict], Any] | None = None,
+        hold_initial_response: bool = False,
     ):
         self.api_key = api_key or _get_openai_api_key()
         if not self.api_key:
@@ -253,7 +254,7 @@ class OpenAIRealtimeClient:
         # When True, the initial response is held back even after session.created.
         # Set this on pre-warmed sessions; call activate_session() once the
         # call-side WebSocket is ready to receive audio.
-        self._hold_initial_response = False
+        self._hold_initial_response = hold_initial_response
 
     def _get_ws_url(self) -> str:
         """WebSocket URL for this provider (override in subclasses)."""

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -363,6 +363,11 @@ class VoiceServer:
         self._connections: dict[str, tuple] = {}
         self._pending_post_calls: dict[str, str] = {}
         self._pending_archive_records: dict[str, list[Path]] = {}
+        # Pre-warmed realtime connections: from_number -> (client, created_at)
+        # Keyed by from_number, claimed and discarded when the Twilio stream starts.
+        self._prewarm_sessions: dict[str, tuple[OpenAIRealtimeClient, float]] = {}
+        # Max seconds a pre-warm session is kept before being discarded
+        self._prewarm_ttl_seconds = 30
 
         routes = [
             Route("/", self.health_check, methods=["GET"]),
@@ -691,6 +696,65 @@ class VoiceServer:
                 self.workspace,
             ),
         )
+
+    async def _prewarm_for_inbound(self, from_number: str) -> None:
+        """Pre-connect to the realtime API while Twilio is setting up the media stream.
+
+        Called as a background task from handle_incoming_call so the provider
+        WebSocket and session handshake complete before the Twilio stream's
+        ``start`` event arrives.  The client is stored with
+        ``_hold_initial_response=True`` so no greeting is sent before the
+        call-side WebSocket is ready; activate_session() releases it.
+        """
+        try:
+            bootstrap = await self._build_session_bootstrap(
+                caller_id=from_number,
+                from_number=from_number,
+            )
+            if self.model:
+                session_cfg = SessionConfig(
+                    instructions=bootstrap.instructions,
+                    initial_response_instructions=(
+                        bootstrap.initial_response_instructions
+                        if bootstrap.should_greet_first
+                        else ""
+                    ),
+                    model=self.model,
+                    available_agents=self._available_agents,
+                )
+            else:
+                session_cfg = SessionConfig(
+                    instructions=bootstrap.instructions,
+                    initial_response_instructions=(
+                        bootstrap.initial_response_instructions
+                        if bootstrap.should_greet_first
+                        else ""
+                    ),
+                    available_agents=self._available_agents,
+                )
+            client = self._make_client(session_cfg)
+            client._hold_initial_response = True
+            await client.connect()
+            self._prewarm_sessions[from_number] = (client, time.monotonic())
+            logger.info("Pre-warm ready for %s", from_number)
+        except Exception as exc:
+            logger.warning("Pre-warm failed for %s: %s", from_number, exc)
+
+    def _claim_prewarm(self, from_number: str) -> OpenAIRealtimeClient | None:
+        """Claim and remove a pre-warmed session for from_number if still fresh."""
+        entry = self._prewarm_sessions.pop(from_number, None)
+        if entry is None:
+            return None
+        client, created_at = entry
+        age = time.monotonic() - created_at
+        if age > self._prewarm_ttl_seconds:
+            logger.info(
+                "Discarding stale pre-warm for %s (%.1fs old)", from_number, age
+            )
+            asyncio.create_task(self._disconnect_realtime_client(client))
+            return None
+        logger.info("Claimed pre-warm for %s (%.1fs old)", from_number, age)
+        return client
 
     async def _build_session_instructions(
         self,
@@ -1057,6 +1121,12 @@ class VoiceServer:
             host = request.headers.get("host", f"{self.host}:{self.port}")
             ws_url = build_stream_url(host)
 
+        # Fire-and-forget: pre-warm the provider connection so it is ready before
+        # Twilio's media-stream WebSocket sends its "start" event.  This eliminates
+        # most of the ~1-3s dead air between call answer and first greeting audio.
+        if from_number:
+            asyncio.create_task(self._prewarm_for_inbound(from_number))
+
         # Forward caller number to WebSocket handler via TwiML custom parameters.
         custom_params: dict[str, str] = {}
         if from_number:
@@ -1112,18 +1182,6 @@ class VoiceServer:
                     handoff_id = custom_params.get("handoff_id") or None
                     standup_brief = custom_params.get("standup_brief") or None
                     caller_id = from_number or call_sid or stream_sid
-                    bootstrap = await self._build_session_bootstrap(
-                        caller_id=caller_id,
-                        from_number=from_number,
-                        handoff_id=handoff_id,
-                        standup_brief=standup_brief,
-                    )
-                    instructions = bootstrap.instructions
-                    initial_response_instructions = (
-                        bootstrap.initial_response_instructions
-                        if bootstrap.should_greet_first
-                        else ""
-                    )
                     metadata = {
                         "from_number": from_number,
                         "call_sid": call_sid,
@@ -1133,33 +1191,76 @@ class VoiceServer:
                     if handoff_id:
                         metadata["handoff_id"] = handoff_id
 
-                    if self.model:
-                        session_cfg = SessionConfig(
-                            instructions=instructions,
-                            initial_response_instructions=initial_response_instructions,
-                            model=self.model,
-                            available_agents=self._available_agents,
-                        )
-                    else:
-                        session_cfg = SessionConfig(
-                            instructions=instructions,
-                            initial_response_instructions=initial_response_instructions,
-                            available_agents=self._available_agents,
-                        )
-                    realtime_client = self._make_client(
-                        session_cfg,
-                        on_audio=lambda audio: self._send_to_twilio(
-                            websocket,
-                            stream_sid,
-                            audio_converter.openai_to_twilio(audio),
-                        ),
-                        on_ai_transcript=lambda text: _append_transcript_turn(
-                            transcript, "assistant", text
-                        ),
-                        on_user_transcript=lambda text: _append_transcript_turn(
-                            transcript, "user", text
-                        ),
+                    # Callbacks — closures capture stream_sid and transcript from this scope.
+                    # Use a factory to bind stream_sid by value so the async coroutine
+                    # is detected and awaited by _call_callback.
+                    def _make_on_audio(_stream_sid: str):
+                        async def _on_audio(audio: bytes) -> None:
+                            await self._send_to_twilio(
+                                websocket,
+                                _stream_sid,
+                                audio_converter.openai_to_twilio(audio),
+                            )
+
+                        return _on_audio
+
+                    on_audio = _make_on_audio(stream_sid)
+
+                    def on_ai_transcript(text: str) -> None:
+                        _append_transcript_turn(transcript, "assistant", text)
+
+                    def on_user_transcript(text: str) -> None:
+                        _append_transcript_turn(transcript, "user", text)
+
+                    # Try to claim a pre-warmed session (no handoff/standup for inbound fresh calls)
+                    prewarm_eligible = (
+                        from_number and not handoff_id and not standup_brief
                     )
+                    prewarm_client = (
+                        self._claim_prewarm(from_number) if prewarm_eligible else None
+                    )
+
+                    if prewarm_client is not None:
+                        realtime_client = prewarm_client
+                        realtime_client.on_audio = on_audio
+                        realtime_client.on_ai_transcript = on_ai_transcript
+                        realtime_client.on_user_transcript = on_user_transcript
+                    else:
+                        # Cold path: build session from scratch
+                        bootstrap = await self._build_session_bootstrap(
+                            caller_id=caller_id,
+                            from_number=from_number,
+                            handoff_id=handoff_id,
+                            standup_brief=standup_brief,
+                        )
+                        instructions = bootstrap.instructions
+                        initial_response_instructions = (
+                            bootstrap.initial_response_instructions
+                            if bootstrap.should_greet_first
+                            else ""
+                        )
+                        if self.model:
+                            session_cfg = SessionConfig(
+                                instructions=instructions,
+                                initial_response_instructions=initial_response_instructions,
+                                model=self.model,
+                                available_agents=self._available_agents,
+                            )
+                        else:
+                            session_cfg = SessionConfig(
+                                instructions=instructions,
+                                initial_response_instructions=initial_response_instructions,
+                                available_agents=self._available_agents,
+                            )
+                        realtime_client = self._make_client(
+                            session_cfg,
+                            on_audio=on_audio,
+                            on_ai_transcript=on_ai_transcript,
+                            on_user_transcript=on_user_transcript,
+                        )
+
+                    # Wire tool bridge BEFORE connect/activate so on_function_call
+                    # is set when the initial greeting response fires.
                     hangup_ws = websocket
                     hangup_call_sid = call_sid
 
@@ -1180,7 +1281,11 @@ class VoiceServer:
                     )
                     realtime_client.on_function_call = tool_bridge.handle_function_call
 
-                    await realtime_client.connect()
+                    if prewarm_client is not None:
+                        await realtime_client.activate_session()
+                    else:
+                        await realtime_client.connect()
+
                     self._connections[call_sid] = (websocket, realtime_client)
 
                 elif event == "media":

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -652,6 +652,7 @@ class VoiceServer:
         from_number: str = "",
         handoff_id: str | None = None,
         standup_brief: str | None = None,
+        consume_recent: bool = True,
     ) -> SessionBootstrap:
         instructions = self._instructions
         if from_number:
@@ -677,7 +678,7 @@ class VoiceServer:
                 ),
             )
 
-        recent_call = await self._consume_recent_call(caller_id)
+        recent_call = await self._consume_recent_call(caller_id, consume=consume_recent)
         if recent_call:
             return SessionBootstrap(
                 instructions=_build_resume_instructions(
@@ -721,9 +722,14 @@ class VoiceServer:
         """
         self._evict_stale_prewarms()
         try:
+            # Peek at the resume record (consume_recent=False) so the on-disk
+            # state file is NOT deleted until connect() succeeds.  If connect()
+            # raises, the file stays intact and the cold-path _build_session_bootstrap
+            # can still resume the caller normally.
             bootstrap = await self._build_session_bootstrap(
                 caller_id=from_number,
                 from_number=from_number,
+                consume_recent=False,
             )
             session_cfg = self._build_session_config(
                 instructions=bootstrap.instructions,
@@ -735,6 +741,9 @@ class VoiceServer:
             )
             client = self._make_client(session_cfg, hold_initial_response=True)
             await client.connect()
+            # connect() succeeded — now safely consume the resume state so a
+            # cold-path fallback won't re-inject the same transcript.
+            await self._consume_recent_call(from_number)
             self._prewarm_sessions[from_number] = (client, time.monotonic())
             logger.info("Pre-warm ready for %s", from_number)
         except Exception as exc:
@@ -772,8 +781,16 @@ class VoiceServer:
         ).instructions
 
     async def _consume_recent_call(
-        self, caller_id: str | None
+        self, caller_id: str | None, *, consume: bool = True
     ) -> RecentCallRecord | None:
+        """Load the most recent call record for *caller_id*.
+
+        When *consume* is True (default) the on-disk state file is deleted,
+        any pending post-call schedule is cancelled, and archive record paths
+        are restored.  Pass ``consume=False`` to peek at the record without
+        side effects — useful when building bootstrap instructions before a
+        connect() that may fail, to avoid losing resume context.
+        """
         if not caller_id:
             return None
 
@@ -784,6 +801,9 @@ class VoiceServer:
         age_seconds = time.time() - recent_call.ended_at
         if age_seconds > self.resume_window_seconds:
             return None
+
+        if not consume:
+            return recent_call
 
         pending_unit = (
             self._pending_post_calls.pop(caller_id, None)

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -697,43 +697,43 @@ class VoiceServer:
             ),
         )
 
+    def _evict_stale_prewarms(self) -> None:
+        """Discard pre-warm entries that exceeded TTL without being claimed."""
+        now = time.monotonic()
+        stale = [
+            num
+            for num, (_, created_at) in self._prewarm_sessions.items()
+            if now - created_at > self._prewarm_ttl_seconds
+        ]
+        for num in stale:
+            client, _ = self._prewarm_sessions.pop(num)
+            logger.info("Evicting stale pre-warm for %s", num)
+            asyncio.create_task(self._disconnect_realtime_client(client))
+
     async def _prewarm_for_inbound(self, from_number: str) -> None:
         """Pre-connect to the realtime API while Twilio is setting up the media stream.
 
         Called as a background task from handle_incoming_call so the provider
         WebSocket and session handshake complete before the Twilio stream's
         ``start`` event arrives.  The client is stored with
-        ``_hold_initial_response=True`` so no greeting is sent before the
+        ``hold_initial_response=True`` so no greeting is sent before the
         call-side WebSocket is ready; activate_session() releases it.
         """
+        self._evict_stale_prewarms()
         try:
             bootstrap = await self._build_session_bootstrap(
                 caller_id=from_number,
                 from_number=from_number,
             )
-            if self.model:
-                session_cfg = SessionConfig(
-                    instructions=bootstrap.instructions,
-                    initial_response_instructions=(
-                        bootstrap.initial_response_instructions
-                        if bootstrap.should_greet_first
-                        else ""
-                    ),
-                    model=self.model,
-                    available_agents=self._available_agents,
-                )
-            else:
-                session_cfg = SessionConfig(
-                    instructions=bootstrap.instructions,
-                    initial_response_instructions=(
-                        bootstrap.initial_response_instructions
-                        if bootstrap.should_greet_first
-                        else ""
-                    ),
-                    available_agents=self._available_agents,
-                )
-            client = self._make_client(session_cfg)
-            client._hold_initial_response = True
+            session_cfg = self._build_session_config(
+                instructions=bootstrap.instructions,
+                initial_response_instructions=(
+                    bootstrap.initial_response_instructions
+                    if bootstrap.should_greet_first
+                    else ""
+                ),
+            )
+            client = self._make_client(session_cfg, hold_initial_response=True)
             await client.connect()
             self._prewarm_sessions[from_number] = (client, time.monotonic())
             logger.info("Pre-warm ready for %s", from_number)
@@ -1239,19 +1239,10 @@ class VoiceServer:
                             if bootstrap.should_greet_first
                             else ""
                         )
-                        if self.model:
-                            session_cfg = SessionConfig(
-                                instructions=instructions,
-                                initial_response_instructions=initial_response_instructions,
-                                model=self.model,
-                                available_agents=self._available_agents,
-                            )
-                        else:
-                            session_cfg = SessionConfig(
-                                instructions=instructions,
-                                initial_response_instructions=initial_response_instructions,
-                                available_agents=self._available_agents,
-                            )
+                        session_cfg = self._build_session_config(
+                            instructions=instructions,
+                            initial_response_instructions=initial_response_instructions,
+                        )
                         realtime_client = self._make_client(
                             session_cfg,
                             on_audio=on_audio,
@@ -1339,9 +1330,25 @@ class VoiceServer:
         }
         await websocket.send_text(json.dumps(message))
 
+    def _build_session_config(
+        self,
+        instructions: str,
+        initial_response_instructions: str = "",
+    ) -> SessionConfig:
+        """Build a SessionConfig with optional model override."""
+        kwargs: dict = dict(
+            instructions=instructions,
+            initial_response_instructions=initial_response_instructions,
+            available_agents=self._available_agents,
+        )
+        if self.model:
+            kwargs["model"] = self.model
+        return SessionConfig(**kwargs)
+
     def _make_client(
         self,
         session_config: SessionConfig,
+        hold_initial_response: bool = False,
         **kwargs,
     ) -> OpenAIRealtimeClient:
         """Instantiate the realtime client for the configured provider."""
@@ -1349,11 +1356,13 @@ class VoiceServer:
             return XAIRealtimeClient(
                 api_key=self._api_key,
                 session_config=session_config,
+                hold_initial_response=hold_initial_response,
                 **kwargs,
             )
         return OpenAIRealtimeClient(
             api_key=self._api_key,
             session_config=session_config,
+            hold_initial_response=hold_initial_response,
             **kwargs,
         )
 
@@ -1377,17 +1386,7 @@ class VoiceServer:
                 caller_id=caller_id,
                 handoff_id=handoff_id,
             )
-            if self.model:
-                session_cfg = SessionConfig(
-                    instructions=instructions,
-                    model=self.model,
-                    available_agents=self._available_agents,
-                )
-            else:
-                session_cfg = SessionConfig(
-                    instructions=instructions,
-                    available_agents=self._available_agents,
-                )
+            session_cfg = self._build_session_config(instructions=instructions)
             realtime_client = self._make_client(
                 session_cfg,
                 on_audio=lambda audio: self._send_local_audio(websocket, audio),
@@ -1480,17 +1479,7 @@ class VoiceServer:
                 caller_id=caller_id,
                 handoff_id=handoff_id,
             )
-            if self.model:
-                session_cfg = SessionConfig(
-                    instructions=instructions,
-                    model=self.model,
-                    available_agents=self._available_agents,
-                )
-            else:
-                session_cfg = SessionConfig(
-                    instructions=instructions,
-                    available_agents=self._available_agents,
-                )
+            session_cfg = self._build_session_config(instructions=instructions)
             realtime_client = self._make_client(
                 session_cfg,
                 on_audio=lambda audio: self._send_browser_audio(websocket, audio),

--- a/packages/gptme-voice/src/gptme_voice/realtime/xai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/xai_client.py
@@ -91,17 +91,6 @@ class XAIRealtimeClient(OpenAIRealtimeClient):
         """xAI does not support whisper-1; omit transcription config."""
         return None
 
-    async def _handle_event(self, event: dict) -> None:
-        """xAI does not emit session.created — treat session.updated as the ready signal."""
-        await super()._handle_event(event)
-        # xAI sends session.updated but not session.created. If _session_ready is
-        # still unset after session.updated arrives, mark it ready and flush buffered
-        # audio so Twilio audio doesn't sit in the pre-session buffer forever.
-        if (
-            event.get("type") == "session.updated"
-            and self._session_ready is not None
-            and not self._session_ready.is_set()
-        ):
-            logger.info("xAI session.updated received — marking session ready")
-            self._session_ready.set()
-            await self._flush_pending_audio()
+    # xAI does not emit session.created; it emits session.updated instead.
+    # The base class already handles session.updated via _mark_session_ready,
+    # so no override is needed here.

--- a/packages/gptme-voice/tests/test_openai_client.py
+++ b/packages/gptme-voice/tests/test_openai_client.py
@@ -463,3 +463,132 @@ def test_disconnect_drains_late_transcript_events_without_sending_late_audio() -
         assert fake_ws.closed is True
 
     asyncio.run(_exercise())
+
+
+def test_hold_initial_response_suppresses_greeting() -> None:
+    """_hold_initial_response=True must block the initial greeting even after session ready."""
+
+    async def _exercise() -> None:
+        fake_ws = _FakeWebSocket()
+
+        async def _fake_connect(*_args, **_kwargs):
+            return fake_ws
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "gptme_voice.realtime.openai_client.websockets.connect", _fake_connect
+            )
+            client = OpenAIRealtimeClient(
+                api_key="test-key",
+                session_config=SessionConfig(
+                    initial_response_instructions="Greet the caller.",
+                ),
+            )
+            client._hold_initial_response = True
+            await client.connect()
+
+            await client._handle_event({"type": "session.created"})
+            assert client._session_ready is not None
+            assert client._session_ready.is_set()
+
+            # No response.create must have been sent while held
+            response_creates = [
+                e for e in fake_ws.sent if e.get("type") == "response.create"
+            ]
+            assert response_creates == [], "greeting must be suppressed while held"
+
+            await client.disconnect()
+
+    asyncio.run(_exercise())
+
+
+def test_activate_session_releases_held_greeting() -> None:
+    """activate_session() must send the greeting on a held but session-ready client."""
+
+    async def _exercise() -> None:
+        fake_ws = _FakeWebSocket()
+
+        async def _fake_connect(*_args, **_kwargs):
+            return fake_ws
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "gptme_voice.realtime.openai_client.websockets.connect", _fake_connect
+            )
+            client = OpenAIRealtimeClient(
+                api_key="test-key",
+                session_config=SessionConfig(
+                    initial_response_instructions="Hey, what's up?",
+                ),
+            )
+            client._hold_initial_response = True
+            await client.connect()
+            await client._handle_event({"type": "session.created"})
+
+            # Session is ready but greeting is still held
+            assert client._session_ready is not None
+            assert client._session_ready.is_set()
+            assert client._initial_response_sent is False
+
+            # Activating releases the greeting
+            await client.activate_session()
+
+            response_creates = [
+                e for e in fake_ws.sent if e.get("type") == "response.create"
+            ]
+            assert len(response_creates) == 1
+            assert response_creates[0]["response"]["instructions"] == "Hey, what's up?"
+            assert client._initial_response_sent is True
+
+            await client.disconnect()
+
+    asyncio.run(_exercise())
+
+
+def test_activate_session_before_session_ready_sends_greeting_on_ready() -> None:
+    """activate_session() before session.created must still send greeting once ready.
+
+    Race: Twilio's "start" event can arrive before xAI confirms the session on
+    a cold connection.  The greeting must fire only after session.created/updated.
+    """
+
+    async def _exercise() -> None:
+        fake_ws = _FakeWebSocket()
+
+        async def _fake_connect(*_args, **_kwargs):
+            return fake_ws
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "gptme_voice.realtime.openai_client.websockets.connect", _fake_connect
+            )
+            client = OpenAIRealtimeClient(
+                api_key="test-key",
+                session_config=SessionConfig(
+                    initial_response_instructions="Hello there.",
+                ),
+            )
+            client._hold_initial_response = True
+            await client.connect()
+
+            # Activate before session.created arrives
+            await client.activate_session()
+
+            # Still no response.create — session not ready yet
+            response_creates = [
+                e for e in fake_ws.sent if e.get("type") == "response.create"
+            ]
+            assert response_creates == []
+
+            # Now session arrives
+            await client._handle_event({"type": "session.created"})
+
+            response_creates = [
+                e for e in fake_ws.sent if e.get("type") == "response.create"
+            ]
+            assert len(response_creates) == 1
+            assert response_creates[0]["response"]["instructions"] == "Hello there."
+
+            await client.disconnect()
+
+    asyncio.run(_exercise())

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -616,6 +616,56 @@ def test_consume_recent_call_deletes_state_file() -> None:
         assert not state_path.exists()
 
 
+def test_prewarm_connect_failure_preserves_resume_state() -> None:
+    """P1 fix: if _prewarm_for_inbound's connect() raises, the on-disk resume
+    state file must NOT be deleted so the cold-path _build_session_bootstrap
+    can still resume the caller normally."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        server = VoiceServer()
+        server.state_dir = Path(tmpdir)
+        server.resume_window_seconds = 300
+        record = RecentCallRecord(
+            caller_id="+46700000099",
+            source="twilio",
+            ended_at=1_000.0,
+            transcript=[TranscriptTurn(role="user", text="Keep this resume")],
+            metadata={},
+        )
+        server._save_recent_call(record)
+        state_path = server._recent_call_path("+46700000099")
+        assert state_path.exists()
+
+        # Simulate a connect() failure inside _prewarm_for_inbound
+        class _FailingClient:
+            async def connect(self):
+                raise ConnectionError("simulated provider failure")
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                server,
+                "_make_client",
+                lambda *args, **kwargs: _FailingClient(),  # type: ignore[assignment]
+            )
+            mp.setattr("gptme_voice.realtime.server.time.time", lambda: 1_100.0)
+            asyncio.run(server._prewarm_for_inbound("+46700000099"))
+
+        # Resume file must survive the failed prewarm
+        assert state_path.exists(), (
+            "Resume state file was deleted despite connect() failure — "
+            "caller would get a fresh greeting instead of resuming"
+        )
+
+        # And the cold path must still see the resume context
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("gptme_voice.realtime.server.time.time", lambda: 1_200.0)
+            bootstrap = asyncio.run(
+                server._build_session_bootstrap(caller_id="+46700000099")
+            )
+        assert (
+            not bootstrap.should_greet_first
+        ), "Cold-path bootstrap should resume (no greeting) after failed prewarm"
+
+
 def test_consume_recent_call_keeps_archived_record() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         server = VoiceServer()


### PR DESCRIPTION
## Problem

Inbound Twilio calls experience ~1-3s of dead air between the caller hearing the call connect and Bob's first greeting audio. The delay comes from:

1. WebSocket connection to xAI/OpenAI (~200-500ms)
2. Waiting for `session.updated`/`session.created` from provider (~300-700ms)
3. Grok generating the greeting audio (~500ms-2s)

Caller feedback (2026-04-28): Erik explicitly asked for Bob to answer only once the backend is ready, rather than picking up instantly then going silent.

## Solution

**Pre-warm the provider connection during the `/incoming` webhook** — which fires ~500ms before Twilio's media stream `start` event arrives. By the time Twilio sends `start`, the provider session is already warm and the greeting fires immediately.

### Changes

**`openai_client.py`**: Add `_hold_initial_response` flag + `activate_session()` method. Pre-warmed sessions hold the greeting back (no audio to send yet), then `activate_session()` releases it once Twilio callbacks are attached.

**`server.py`**: 
- `_prewarm_for_inbound(from_number)`: async task fired from `handle_incoming_call`, builds session config + connects to provider
- `_claim_prewarm(from_number)`: claims a pre-warm if still fresh (30s TTL)
- `handle_twilio_websocket` `start` handler: claims prewarm if eligible (inbound, no handoff/standup), reattaches callbacks, wires tool bridge, then calls `activate_session()`

**`xai_client.py`**: Remove dead `_handle_event` override. After `super()._handle_event()`, `_session_ready.is_set()` is always True, making the custom check always False. The override also missed calling `_send_initial_response_if_needed`. Left a clarifying comment instead.

### Prewarm eligibility

Only inbound fresh calls (no `handoff_id`, no `standup_brief`) benefit from prewarm. Handoffs and standup calls are already outbound or have special bootstrap logic that differs from the `/incoming` path.

### Tests

3 new tests in `test_openai_client.py`:
- `test_hold_initial_response_suppresses_greeting` — flag blocks greeting after session ready
- `test_activate_session_releases_held_greeting` — activate fires greeting on warm session
- `test_activate_session_before_session_ready_sends_greeting_on_ready` — race: activate before session.created, greeting fires on session.created

All 121 voice tests pass.