### PR TITLE
fix(lesson): add session_categories to session-ending-protocol

### DIFF
--- a/lessons/workflow/session-ending-protocol.md
+++ b/lessons/workflow/session-ending-protocol.md
@@ -1,6 +1,7 @@
 ---
 match:
   keywords: ["session complete"]
+  session_categories: [code, cross-repo, infrastructure, cleanup]
 status: active
 ---
 


### PR DESCRIPTION
## Summary
Adds `session_categories: [code, cross-repo, infrastructure, cleanup]` to `session-ending-protocol.md` so the lesson gets bundle-delivered when matching session categories run.

## Why
The `session complete` keyword matched 6 distinct sessions across the 14-day Bob CC+gptme corpus, but the lesson was never injected. This is a **false-negative pipeline issue** — the keyword matching pipeline (PreToolUse tail-window) and the session classifier disagree about whether to inject. The fix per the standard recipe is `session_categories` for category-bundle delivery.

Verified via `scripts/lesson-keyword-journal-crossref.py --suggest --days 14` in the Bob workspace. Companion fixes for two Bob-local lessons in the same false-negative bucket landed in `ErikBjare/bob@dea332257`.

## Categories chosen
- `code`, `cross-repo`, `infrastructure`, `cleanup` — work types where session-end git/PR/state hygiene matters most.
- Excluded `social`, `news`, `monitoring`, etc., where the protocol is less relevant. Keeping the bundle scope narrow avoids context noise.

## Test plan
- [x] Lesson validation passes (`gptme-lessons-extras/validate.py`)
- [x] prek pre-commit checks pass
- [ ] After merge: re-run `lesson-keyword-journal-crossref.py --suggest 7d` in Bob workspace — `session-ending-protocol` should drop out of the False Negatives bucket