### PR TITLE
fix(lesson): narrow over-broad keywords in trajectory-persistence

### DIFF
--- a/lessons/infrastructure/trajectory-persistence.md
+++ b/lessons/infrastructure/trajectory-persistence.md
@@ -1,13 +1,14 @@
 ---
 match:
   keywords:
-    - trajectory
-    - cleanup
-    - delete
-    - retention
-    - session data
-    - cleanupPeriodDays
-    - log cleanup
+    - "delete trajectory"
+    - "delete session data"
+    - "session data retention"
+    - "trajectory files"
+    - "session records"
+    - "cleanupPeriodDays"
+    - "log cleanup"
+    - "retention policy"
   session_categories: [infrastructure, cleanup]
 target_grade: harm
 status: active


### PR DESCRIPTION
## Summary

Replaces single-word keywords (`trajectory`, `cleanup`, `delete`, `retention`) with specific multi-word phrases in the `trajectory-persistence` lesson.

LOO analysis (7d, n=613 sessions) showed the lesson firing in 22% of sessions with only 10% trigger accuracy and a borderline negative effect (Δ=-0.036, p=0.053). The broad keywords triggered in code/cross-repo sessions unrelated to session data deletion.

**Before** (over-broad, fires in 22% of sessions):
- `trajectory`, `cleanup`, `delete`, `retention`, `session data`

**After** (specific, fires only when lesson is relevant):
- `"delete trajectory"`, `"delete session data"`, `"session data retention"`, `"trajectory files"`, `"session records"`, `"retention policy"`

`session_categories: [infrastructure, cleanup]` retained for bundle delivery.

## Test plan
- [ ] Lesson validation passes
- [ ] Re-run LOO in ~7 days to confirm trigger rate drops to ~5-10%