### PR TITLE
fix(gptme-voice): add HANGUP TOOL RULES so model actually calls the tool

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
@@ -149,6 +149,20 @@ def _load_project_instructions(workspace: str | None = None) -> str:
         "happened yet and you are not the one who starts it.\n"
         "- It is fine to acknowledge that follow-up will happen automatically after "
         "hangup if the user asks. Just do not take credit for dispatching it.\n\n"
+        "HANGUP TOOL RULES:\n"
+        "- The call only ends when you call the hangup tool. A spoken goodbye does NOT "
+        "end the call by itself — verbal-only goodbyes leave the line open and frustrate "
+        "the caller.\n"
+        "- Once the caller has clearly said goodbye OR asked you to end the call, call "
+        "the hangup tool immediately. Do not ask for confirmation ('Would you like me "
+        "to end the call?') — their goodbye is the confirmation.\n"
+        "- Do not say 'I'll end the call now', 'one moment while I end the call', or "
+        "similar without calling the hangup tool in the same turn. Saying it without "
+        "calling the tool is the failure mode.\n"
+        "- Say a brief farewell first if you want; then call the tool. The 5-second "
+        "farewell delay gives your goodbye time to play before the line drops.\n"
+        "- If you have already said goodbye verbally and the caller is still on the "
+        "line, that means you forgot to call the tool. Call it now.\n\n"
         "HANDOFF TO ANOTHER AGENT:\n"
         "- Use handoff_to_agent ONLY when the caller explicitly asks to speak with "
         "Alice, Gordon, or Sven, or when the topic is clearly outside your expertise "
@@ -380,10 +394,15 @@ class OpenAIRealtimeClient:
                     "type": "function",
                     "name": "hangup",
                     "description": (
-                        "End the current voice call cleanly. Use this only when the caller "
-                        "has clearly said goodbye or explicitly asked to hang up. Do not use "
-                        "this to interrupt ongoing work or avoid a question. "
-                        "Say a brief farewell first; the call will terminate shortly after."
+                        "End the current voice call. This is the ONLY way the call ends — "
+                        "saying goodbye verbally does not hang up. Call this tool whenever "
+                        "the caller has said goodbye or explicitly asked to end the call. "
+                        "Do not ask for confirmation; the caller's goodbye is the "
+                        "confirmation. Do not announce 'I'll end the call now' without "
+                        "calling the tool in the same turn. Say a brief farewell first if "
+                        "you like — the call drops a few seconds after the tool fires so "
+                        "your goodbye still reaches the caller. Do not use this tool to "
+                        "interrupt ongoing work or avoid a question."
                     ),
                     "parameters": {
                         "type": "object",

--- a/packages/gptme-voice/tests/test_openai_client.py
+++ b/packages/gptme-voice/tests/test_openai_client.py
@@ -263,6 +263,42 @@ def test_load_project_instructions_guards_present_without_personality_files(
     assert "wait for the actual subagent result" in instructions
 
 
+def test_load_project_instructions_includes_hangup_tool_rules(
+    tmp_path: Path,
+) -> None:
+    """Preamble must instruct the model to actually CALL the hangup tool.
+
+    Regression for the 2026-04-29 pre-event call where the model said goodbye
+    five-plus times verbally without ever calling the hangup tool. Once Erik
+    explicitly asked, the model still verbalized "I'll end the call now" three
+    more turns before finally invoking the tool. The fix is a prompt-level
+    instruction that verbal-only goodbyes are the failure mode and the tool
+    must be called whenever the call should end.
+    """
+    (tmp_path / "gptme.toml").write_text(
+        '[prompt]\nfiles = ["ABOUT.md"]\n',
+    )
+    (tmp_path / "ABOUT.md").write_text("# ABOUT\nYou are Bob.\n")
+
+    instructions = _load_project_instructions(str(tmp_path))
+
+    # The dedicated section exists.
+    assert "HANGUP TOOL RULES:" in instructions
+
+    # The core constraint: only the tool ends the call.
+    assert "only ends when you call the hangup tool" in instructions
+
+    # Anti-pattern guidance: don't ask permission, don't verbalize without calling.
+    assert "Do not ask for confirmation" in instructions
+    assert (
+        "without calling the hangup tool in the same turn" in instructions
+        or "without calling the hangup tool" in instructions
+    )
+
+    # Self-recovery hint when the model notices it forgot.
+    assert "you forgot to call the tool" in instructions
+
+
 def test_function_call_subagent_dispatch_does_not_auto_create_response() -> None:
     async def _exercise() -> None:
         fake_ws = _FakeWebSocket()


### PR DESCRIPTION
## Summary

Erik's 2026-04-29 pre-event call exposed a behavioral failure in the live hangup path: the model said goodbye **five times** verbally without ever calling the `hangup` tool. After Erik explicitly asked ("notice you're not using your hang up tool or whatever"), the model still verbalized "I'll end the call now" three more turns before finally invoking the tool. Erik was stuck on the line for ~2 minutes after the first goodbye.

## Root cause

Server logs confirm the tool itself works correctly — once called at `14:22:54`, the WebSocket closed immediately:

```
14:22:54 ... AI: One moment Erik, I'll use the hangup tool right now.
14:22:54 ... Function call: hangup({'reason': 'caller explicitly asked to end the call after multiple goodbyes'})
14:22:54 ... Hangup scheduled: source=twilio call_sid=CA0aec1897... 
INFO:     connection closed
```

Earlier "I'll end the call now" turns at `14:22:09`, `14:22:20`, and `14:22:43` were verbal-only — no `function_call` event was emitted by the model. The issue is purely **prompt-level**: the model treats verbal goodbye as sufficient and asks permission instead of invoking the tool.

The existing tool description (`"Say a brief farewell first; the call will terminate shortly after."`) is misleading — it implies saying farewell is enough. There's also no preamble guidance about the hangup tool, while subagent, post-call follow-up, and handoff each have dedicated `*_RULES` sections.

## Fix

- **Add a HANGUP TOOL RULES section** to the live-call preamble in `_load_project_instructions`, mirroring the existing SUBAGENT/POST-CALL/HANDOFF guard sections. Key constraints:
  - The call only ends when you call the tool — verbal goodbyes don't.
  - Don't ask for confirmation; the caller's goodbye is the confirmation.
  - Don't say "I'll end the call now" without invoking the tool in the same turn.
  - Self-recovery: if you've said goodbye and the line is still open, you forgot to call the tool.

- **Sharpen the `hangup` tool description** to be imperative: only the tool ends the call, no confirmation needed, don't announce intent without calling.

- **Add regression test** `test_load_project_instructions_includes_hangup_tool_rules` covering the new section's load-bearing phrases. Existing 122 tests still pass.

## Verification

- `pytest tests/test_openai_client.py -v -k "hangup or guard or follow_up"` → 3 passed
- `pytest tests/` → 123 passed (full suite)

## Refs

- Task: [`tasks/voice-hangup-tool-reliability.md`](https://github.com/ErikBjare/bob/blob/master/tasks/voice-hangup-tool-reliability.md)
- Tracking issue: ErikBjare/bob#676
- Call archive: `state/voice-calls/archive/20260429T142300Z-107-twilio-CA0aec1897248c0afebf3443d8b6e1fc9d.json`
- Related prior work: gptme/gptme-contrib#704 (initial hangup tool), #712 (RuntimeError swallow)

## Test plan

- [x] New unit test passes (`test_load_project_instructions_includes_hangup_tool_rules`)
- [x] Existing voice tests pass (123/123)
- [ ] Live-call validation on next answered Twilio call (Erik to verify behavior change)