### PR TITLE
feat(daily-briefing): new package — generic bundle schema + collectors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
     args: [--config-file=mypy.ini, --explicit-package-bases]
     types: [python]
     pass_filenames: true
-    exclude: ^(packages/(gptme-lessons-extras|gptme-runloops|gptme-contrib-lib|gptodo|gptmail|gptme-activity-summary|gptme-voice|gptme-dashboard|gptme-sessions)/|plugins/)
+    exclude: ^(packages/(gptme-lessons-extras|gptme-runloops|gptme-contrib-lib|gptodo|gptmail|gptme-activity-summary|gptme-voice|gptme-dashboard|gptme-sessions|gptme-daily-briefing)/|plugins/)
 - repo: local
   hooks:
   - id: check-markdown-links

--- a/packages/gptme-daily-briefing/Makefile
+++ b/packages/gptme-daily-briefing/Makefile
@@ -1,0 +1,7 @@
+.PHONY: test typecheck
+
+test:
+	uv run pytest tests/ -v
+
+typecheck:
+	uv run --with mypy --with types-PyYAML mypy -p gptme_daily_briefing --ignore-missing-imports

--- a/packages/gptme-daily-briefing/README.md
+++ b/packages/gptme-daily-briefing/README.md
@@ -1,0 +1,54 @@
+# gptme-daily-briefing
+
+Generic daily-briefing bundle schema and collectors for gptme agents.
+
+This is the upstream extraction of Bob's `collect-daily-briefing.py` morning
+pipeline — see [the design doc](https://github.com/ErikBjare/bob/blob/master/knowledge/technical-designs/daily-briefing-pipeline.md)
+and the [tracking issue](https://github.com/ErikBjare/bob/issues/676).
+
+## What it provides
+
+- **`schema`** — TypedDicts describing the bundle JSON contract that email
+  and voice renderers consume (`BriefingBundle`, `Bullets`, `Analytics`,
+  `Workstream`, etc.). Any agent can produce or consume this format.
+- **`collectors`** — generic, agent-agnostic data gatherers:
+  - `collect_blockers(repo, label)` — open issues by label
+  - `collect_active_tasks(workspace_root)` — `gptodo` active/todo tasks
+  - `collect_waiting_tasks(workspace_root)` — task frontmatter `waiting_for`
+  - `collect_recent_highlights(workspace_root)` — recent commit subjects
+  - `collect_session_stats(sessions_dir)` — gptme-sessions count + categories
+  - `collect_open_prs(repos, username)` — open PRs by user across repos
+  - `collect_graphql_rate_limit()` — GitHub GraphQL budget probe
+
+Agent-specific bits (KPI shape, bandit state, agent persona) stay in each
+agent's local wrapper.
+
+## Use
+
+```python
+from pathlib import Path
+from gptme_daily_briefing.collectors import (
+    collect_blockers,
+    collect_active_tasks,
+    collect_recent_highlights,
+)
+
+workspace = Path("/home/agent/agent")
+bundle = {
+    "bullets": {
+        "blockers": collect_blockers("OWNER/REPO", "request-for-erik"),
+        "active_tasks": collect_active_tasks(workspace),
+        "recent_highlights": collect_recent_highlights(workspace),
+    },
+}
+```
+
+The agent's own wrapper composes the bundle and writes it to
+`state/daily-briefing/YYYY-MM-DD.json` (or wherever).
+
+## Bob's reference wrapper
+
+[`scripts/monitoring/collect-daily-briefing.py`](https://github.com/ErikBjare/bob/blob/master/scripts/monitoring/collect-daily-briefing.py)
+in Bob's workspace is the reference consumer. It composes the generic
+collectors here with Bob-local additions (Thompson sampling bandit tops,
+`weekly-goals.py` KPI snapshot, `pr-review-guide.py` rich PR list).

--- a/packages/gptme-daily-briefing/pyproject.toml
+++ b/packages/gptme-daily-briefing/pyproject.toml
@@ -1,0 +1,43 @@
+[project]
+name = "gptme-daily-briefing"
+version = "0.1.0"
+description = "Generic daily-briefing bundle schema and collectors for gptme agents"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.10"
+keywords = ["briefing", "standup", "gptme", "ai-agents"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+dependencies = [
+    "pyyaml>=6.0.0",
+]
+
+[project.optional-dependencies]
+sessions = ["gptme-sessions"]
+test = ["pytest>=7.0"]
+dev = ["pytest>=7.0", "mypy>=1.0.0"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/gptme_daily_briefing"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.mypy]
+python_version = "3.10"
+check_untyped_defs = true
+warn_return_any = true
+warn_unused_configs = true
+ignore_missing_imports = true

--- a/packages/gptme-daily-briefing/src/gptme_daily_briefing/__init__.py
+++ b/packages/gptme-daily-briefing/src/gptme_daily_briefing/__init__.py
@@ -1,0 +1,21 @@
+"""Generic daily-briefing bundle schema and collectors for gptme agents."""
+
+from gptme_daily_briefing.schema import (
+    Analytics,
+    BriefingBundle,
+    Bullets,
+    OpenPR,
+    SessionStats,
+    WaitingTask,
+    Workstream,
+)
+
+__all__ = [
+    "Analytics",
+    "BriefingBundle",
+    "Bullets",
+    "OpenPR",
+    "SessionStats",
+    "WaitingTask",
+    "Workstream",
+]

--- a/packages/gptme-daily-briefing/src/gptme_daily_briefing/collectors.py
+++ b/packages/gptme-daily-briefing/src/gptme_daily_briefing/collectors.py
@@ -1,0 +1,196 @@
+"""Generic collectors for daily-briefing bundles.
+
+Each collector is a small, side-effect-free function that returns a piece
+of the bundle. Agents compose them in their own wrapper script.
+
+Design constraint: nothing here may import agent-local packages
+(metaproductivity, Bob-specific scripts, agent-specific KPIs). Such
+collectors stay in each agent's local wrapper.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _run(cmd: list[str], cwd: Path | None = None, timeout: int = 30) -> str:
+    """Run a command, return stripped stdout or empty string on failure."""
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            cwd=str(cwd) if cwd else None,
+            timeout=timeout,
+        )
+        return result.stdout.strip()
+    except Exception as e:
+        print(f"[warn] {cmd[0]}: {e}", file=sys.stderr)
+        return ""
+
+
+def collect_graphql_rate_limit() -> dict[str, Any] | None:
+    """Return GitHub GraphQL rate-limit info via REST, or None on failure."""
+    out = _run(["gh", "api", "rate_limit"], timeout=10)
+    if not out:
+        return None
+    try:
+        resources = json.loads(out).get("resources", {})
+    except json.JSONDecodeError:
+        return None
+    graphql = resources.get("graphql")
+    return graphql if isinstance(graphql, dict) else None
+
+
+def collect_blockers(repo: str, label: str, limit: int = 6) -> list[str]:
+    """Open issues with `label` in `repo` (excludes PRs).
+
+    Returns formatted strings like ``"#570: Title"``.
+    """
+    out = _run(
+        [
+            "gh",
+            "api",
+            f"repos/{repo}/issues?labels={label}&state=open&per_page={limit}",
+        ]
+    )
+    if not out:
+        return []
+    try:
+        blockers = [
+            f"#{item['number']}: {item['title']}"
+            for item in json.loads(out)
+            if "pull_request" not in item
+        ]
+        return blockers[:limit]
+    except (json.JSONDecodeError, KeyError):
+        return []
+
+
+def collect_active_tasks(workspace_root: Path, limit: int = 6) -> list[str]:
+    """Active and todo task ids via `gptodo list --json` (run inside workspace_root)."""
+    out = _run(["uv", "run", "gptodo", "list", "--json"], cwd=workspace_root)
+    if not out:
+        return []
+    try:
+        tasks = json.loads(out).get("tasks", [])
+        return [t["id"] for t in tasks if t.get("state") in ("active", "todo") and t.get("id")][
+            :limit
+        ]
+    except (json.JSONDecodeError, KeyError):
+        return []
+
+
+def collect_waiting_tasks(workspace_root: Path, limit: int = 8) -> list[dict[str, str]]:
+    """Waiting tasks with `waiting_for`, parsed from ``<workspace>/tasks/*.md`` frontmatter.
+
+    `gptodo list --json` doesn't currently surface ``waiting_for``, so we read
+    the YAML frontmatter directly.
+    """
+    tasks_dir = workspace_root / "tasks"
+    if not tasks_dir.is_dir():
+        return []
+    result: list[dict[str, str]] = []
+    for task_file in sorted(tasks_dir.glob("*.md")):
+        try:
+            text = task_file.read_text()
+        except OSError:
+            continue
+        m = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+        if not m:
+            continue
+        try:
+            import yaml
+
+            fm = yaml.safe_load(m.group(1)) or {}
+        except Exception:
+            continue
+        if fm.get("state") != "waiting":
+            continue
+        wf = fm.get("waiting_for")
+        if wf:
+            result.append({"task": task_file.stem, "waiting_for": str(wf)[:200]})
+    return result[:limit]
+
+
+def collect_recent_highlights(workspace_root: Path, limit: int = 6) -> list[str]:
+    """Recent commit subjects from ``origin/master``, fall back to local master."""
+    fetch_n = max(limit * 2, 10)
+    out = _run(
+        ["git", "log", "--pretty=format:%s", f"-{fetch_n}", "origin/master"],
+        cwd=workspace_root,
+    )
+    if not out:
+        out = _run(
+            ["git", "log", "--pretty=format:%s", f"-{fetch_n}"],
+            cwd=workspace_root,
+        )
+    return [line.strip() for line in out.splitlines() if line.strip()][:limit]
+
+
+def collect_session_stats(sessions_dir: Path, days: int = 1) -> dict[str, Any]:
+    """Session count and category distribution over the last ``days`` days.
+
+    Requires the ``gptme-sessions`` package — install via the ``[sessions]`` extra.
+    On any failure (missing package, bad records), returns a stats dict with
+    ``count: 0`` and an ``error`` field instead of raising.
+    """
+    try:
+        from gptme_sessions.store import SessionStore  # type: ignore[import-not-found]
+
+        store = SessionStore(sessions_dir=sessions_dir)
+        records = store.load_all()
+        cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+
+        recent = []
+        for r in records:
+            try:
+                ts = datetime.fromisoformat(r.timestamp.replace("Z", "+00:00"))
+                if ts >= cutoff:
+                    recent.append(r)
+            except Exception:
+                continue
+
+        cats: dict[str, int] = {}
+        for r in recent:
+            cat = getattr(r, "category", None) or "unknown"
+            cats[cat] = cats.get(cat, 0) + 1
+
+        return {"count": len(recent), "categories": cats}
+    except Exception as e:
+        return {"count": 0, "error": str(e)}
+
+
+def collect_open_prs(
+    repos: list[str], username: str, limit_per_repo: int = 5
+) -> list[dict[str, Any]]:
+    """Open PRs by ``username`` across the given repositories."""
+    prs: list[dict[str, Any]] = []
+    for repo in repos:
+        out = _run(["gh", "api", f"repos/{repo}/pulls?state=open&per_page=100"])
+        if not out:
+            continue
+        try:
+            repo_prs = []
+            for pr in json.loads(out):
+                if pr.get("user", {}).get("login") != username:
+                    continue
+                repo_prs.append(
+                    {
+                        "repo": repo,
+                        "number": pr["number"],
+                        "title": pr["title"],
+                        "draft": pr.get("draft", False),
+                        "url": f"https://github.com/{repo}/pull/{pr['number']}",
+                    }
+                )
+            prs.extend(repo_prs[:limit_per_repo])
+        except (json.JSONDecodeError, KeyError):
+            continue
+    return prs

--- a/packages/gptme-daily-briefing/src/gptme_daily_briefing/collectors.py
+++ b/packages/gptme-daily-briefing/src/gptme_daily_briefing/collectors.py
@@ -17,6 +17,9 @@ import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
+
+import yaml
 
 
 def _run(cmd: list[str], cwd: Path | None = None, timeout: int = 30) -> str:
@@ -51,13 +54,16 @@ def collect_graphql_rate_limit() -> dict[str, Any] | None:
 def collect_blockers(repo: str, label: str, limit: int = 6) -> list[str]:
     """Open issues with `label` in `repo` (excludes PRs).
 
-    Returns formatted strings like ``"#570: Title"``.
+    Returns formatted strings like ``"#570: Title"``. The label is
+    URL-encoded so values containing spaces (``"help wanted"``) or
+    ampersands work correctly.
     """
+    encoded_label = quote(label, safe="")
     out = _run(
         [
             "gh",
             "api",
-            f"repos/{repo}/issues?labels={label}&state=open&per_page={limit}",
+            f"repos/{repo}/issues?labels={encoded_label}&state=open&per_page={limit}",
         ]
     )
     if not out:
@@ -106,8 +112,6 @@ def collect_waiting_tasks(workspace_root: Path, limit: int = 8) -> list[dict[str
         if not m:
             continue
         try:
-            import yaml
-
             fm = yaml.safe_load(m.group(1)) or {}
         except Exception:
             continue
@@ -120,18 +124,22 @@ def collect_waiting_tasks(workspace_root: Path, limit: int = 8) -> list[dict[str
 
 
 def collect_recent_highlights(workspace_root: Path, limit: int = 6) -> list[str]:
-    """Recent commit subjects from ``origin/master``, fall back to local master."""
+    """Recent commit subjects from the agent's main integration branch.
+
+    Tries refs in order: ``origin/master`` → ``origin/main`` → ``master`` →
+    ``main``. Explicitly avoids logging the bare current ``HEAD`` because on
+    a feature branch that would silently surface off-topic commits instead
+    of landed integration work.
+    """
     fetch_n = max(limit * 2, 10)
-    out = _run(
-        ["git", "log", "--pretty=format:%s", f"-{fetch_n}", "origin/master"],
-        cwd=workspace_root,
-    )
-    if not out:
+    for ref in ("origin/master", "origin/main", "master", "main"):
         out = _run(
-            ["git", "log", "--pretty=format:%s", f"-{fetch_n}"],
+            ["git", "log", "--pretty=format:%s", f"-{fetch_n}", ref],
             cwd=workspace_root,
         )
-    return [line.strip() for line in out.splitlines() if line.strip()][:limit]
+        if out:
+            return [line.strip() for line in out.splitlines() if line.strip()][:limit]
+    return []
 
 
 def collect_session_stats(sessions_dir: Path, days: int = 1) -> dict[str, Any]:

--- a/packages/gptme-daily-briefing/src/gptme_daily_briefing/schema.py
+++ b/packages/gptme-daily-briefing/src/gptme_daily_briefing/schema.py
@@ -1,0 +1,73 @@
+"""Bundle schema — the durable JSON contract between collectors and renderers.
+
+The bundle is written by a `collect-daily-briefing` step and read by
+both email and voice renderers, so neither re-queries upstream data.
+
+Agent-specific extensions (e.g. Bob's bandit tops, KPI snapshots) live under
+the open-shape `analytics` and `workstream` namespaces — those values are
+typed `dict[str, Any]` so each agent can attach its own structures without
+changing this schema.
+"""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+
+class WaitingTask(TypedDict):
+    """A task in `state: waiting` with its `waiting_for` blocker."""
+
+    task: str
+    waiting_for: str
+
+
+class Bullets(TypedDict, total=False):
+    """The `bullets` namespace — short lists for the morning summary."""
+
+    blockers: list[str]
+    active_tasks: list[str]
+    waiting_tasks: list[WaitingTask]
+    recent_highlights: list[str]
+
+
+class SessionStats(TypedDict, total=False):
+    """Session count + per-category breakdown over a recent window."""
+
+    count: int
+    categories: dict[str, int]
+    error: str
+
+
+class Analytics(TypedDict, total=False):
+    """Analytics snapshot: sessions, agent-specific bandits/KPI."""
+
+    sessions_24h: SessionStats
+    bandits: dict[str, Any]
+    kpi: dict[str, Any]
+
+
+class OpenPR(TypedDict):
+    """A single open PR by the agent."""
+
+    repo: str
+    number: int
+    title: str
+    draft: bool
+    url: str
+
+
+class Workstream(TypedDict, total=False):
+    """In-flight work: open PRs, optional rich review-guide payload."""
+
+    open_prs: list[OpenPR]
+    open_prs_guide: dict[str, Any] | None
+
+
+class BriefingBundle(TypedDict, total=False):
+    """Top-level bundle — the durable artifact at `state/daily-briefing/<date>.json`."""
+
+    generated_at: str
+    date: str
+    bullets: Bullets
+    analytics: Analytics
+    workstream: Workstream

--- a/packages/gptme-daily-briefing/tests/test_collectors.py
+++ b/packages/gptme-daily-briefing/tests/test_collectors.py
@@ -19,12 +19,14 @@ def _git(*args: str, cwd: Path) -> None:
 
 @pytest.fixture
 def git_workspace(tmp_path: Path) -> Path:
-    """A fresh git repo with a couple of commits, so highlights have data.
+    """A fresh git repo with a couple of commits on a `master` branch.
 
-    Uses a non-master default branch to dodge any global hook that blocks
-    direct commits to master in unfamiliar repos.
+    `collect_recent_highlights` only logs from `origin/master`, `origin/main`,
+    `master`, or `main` (it explicitly avoids bare HEAD). The fixture also
+    sets `commit.gpgsign=false` and uses `--no-verify` so any global commit
+    hooks don't interfere.
     """
-    _git("init", "-q", "-b", "test-default", cwd=tmp_path)
+    _git("init", "-q", "-b", "master", cwd=tmp_path)
     _git("config", "user.email", "test@example.com", cwd=tmp_path)
     _git("config", "user.name", "Test", cwd=tmp_path)
     _git("config", "commit.gpgsign", "false", cwd=tmp_path)
@@ -38,10 +40,34 @@ def git_workspace(tmp_path: Path) -> Path:
     return tmp_path
 
 
+@pytest.fixture
+def feature_branch_workspace(git_workspace: Path) -> Path:
+    """Same as git_workspace but checked out on an unrelated feature branch.
+
+    The fallback should still surface the *master* commits, NOT whatever the
+    feature branch added — that's the whole point of the explicit branch list.
+    """
+    _git("checkout", "-q", "-b", "feature", cwd=git_workspace)
+    (git_workspace / "feature.md").write_text("feature wip\n")
+    _git("add", "feature.md", cwd=git_workspace)
+    _git("commit", "-q", "--no-verify", "-m", "WIP do not surface this", cwd=git_workspace)
+    return git_workspace
+
+
 def test_collect_recent_highlights_returns_subjects_in_order(git_workspace: Path) -> None:
-    # `origin/master` doesn't exist in the fixture repo; the function falls back to local log
+    # `origin/master` doesn't exist in the fixture repo; the fallback chain
+    # finds local `master` and surfaces those commits in newest-first order.
     out = collect_recent_highlights(git_workspace, limit=3)
     assert out == ["fix: trailing body", "docs: add section", "feat: first commit"]
+
+
+def test_collect_recent_highlights_uses_master_not_head_on_feature_branch(
+    feature_branch_workspace: Path,
+) -> None:
+    """Even on a feature branch with extra commits, only master is surfaced."""
+    out = collect_recent_highlights(feature_branch_workspace, limit=4)
+    assert "WIP do not surface this" not in out
+    assert out[0] == "fix: trailing body"
 
 
 def test_collect_recent_highlights_respects_limit(git_workspace: Path) -> None:
@@ -53,6 +79,40 @@ def test_collect_recent_highlights_empty_repo(tmp_path: Path) -> None:
     # No git repo at all — should return [] without raising
     out = collect_recent_highlights(tmp_path, limit=5)
     assert out == []
+
+
+def test_collect_blockers_url_encodes_label(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A label containing a space must be percent-encoded so the gh URL is valid."""
+    captured: list[list[str]] = []
+
+    def fake_run(cmd: list[str], cwd: Path | None = None, timeout: int = 30) -> str:
+        captured.append(cmd)
+        return "[]"
+
+    from gptme_daily_briefing import collectors as col
+
+    monkeypatch.setattr(col, "_run", fake_run)
+    col.collect_blockers("owner/repo", "help wanted")
+    assert captured, "no command captured"
+    url = captured[0][-1]
+    assert "labels=help%20wanted" in url, f"label not encoded: {url}"
+    assert "labels=help wanted" not in url
+
+
+def test_collect_blockers_url_encodes_special_chars(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A label containing '&' must not leak into the query as a separator."""
+    captured: list[list[str]] = []
+
+    def fake_run(cmd: list[str], cwd: Path | None = None, timeout: int = 30) -> str:
+        captured.append(cmd)
+        return "[]"
+
+    from gptme_daily_briefing import collectors as col
+
+    monkeypatch.setattr(col, "_run", fake_run)
+    col.collect_blockers("owner/repo", "p1&urgent")
+    url = captured[0][-1]
+    assert "labels=p1%26urgent" in url, f"& not encoded: {url}"
 
 
 def test_collect_waiting_tasks_parses_frontmatter(tmp_path: Path) -> None:

--- a/packages/gptme-daily-briefing/tests/test_collectors.py
+++ b/packages/gptme-daily-briefing/tests/test_collectors.py
@@ -1,0 +1,118 @@
+"""Tests for generic collectors (no network — only filesystem/git operations)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from gptme_daily_briefing.collectors import (
+    collect_recent_highlights,
+    collect_waiting_tasks,
+)
+
+
+def _git(*args: str, cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+
+@pytest.fixture
+def git_workspace(tmp_path: Path) -> Path:
+    """A fresh git repo with a couple of commits, so highlights have data.
+
+    Uses a non-master default branch to dodge any global hook that blocks
+    direct commits to master in unfamiliar repos.
+    """
+    _git("init", "-q", "-b", "test-default", cwd=tmp_path)
+    _git("config", "user.email", "test@example.com", cwd=tmp_path)
+    _git("config", "user.name", "Test", cwd=tmp_path)
+    _git("config", "commit.gpgsign", "false", cwd=tmp_path)
+    (tmp_path / "README.md").write_text("# Test\n")
+    _git("add", "README.md", cwd=tmp_path)
+    _git("commit", "-q", "--no-verify", "-m", "feat: first commit", cwd=tmp_path)
+    (tmp_path / "README.md").write_text("# Test\n\n## Section\n")
+    _git("commit", "-aq", "--no-verify", "-m", "docs: add section", cwd=tmp_path)
+    (tmp_path / "README.md").write_text("# Test\n\n## Section\n\nBody\n")
+    _git("commit", "-aq", "--no-verify", "-m", "fix: trailing body", cwd=tmp_path)
+    return tmp_path
+
+
+def test_collect_recent_highlights_returns_subjects_in_order(git_workspace: Path) -> None:
+    # `origin/master` doesn't exist in the fixture repo; the function falls back to local log
+    out = collect_recent_highlights(git_workspace, limit=3)
+    assert out == ["fix: trailing body", "docs: add section", "feat: first commit"]
+
+
+def test_collect_recent_highlights_respects_limit(git_workspace: Path) -> None:
+    out = collect_recent_highlights(git_workspace, limit=1)
+    assert out == ["fix: trailing body"]
+
+
+def test_collect_recent_highlights_empty_repo(tmp_path: Path) -> None:
+    # No git repo at all — should return [] without raising
+    out = collect_recent_highlights(tmp_path, limit=5)
+    assert out == []
+
+
+def test_collect_waiting_tasks_parses_frontmatter(tmp_path: Path) -> None:
+    tasks = tmp_path / "tasks"
+    tasks.mkdir()
+    # Quote the value because '#' would otherwise start a YAML comment
+    (tasks / "blocked-on-erik.md").write_text(
+        "---\n"
+        "state: waiting\n"
+        'waiting_for: "Erik to merge PR #123"\n'
+        "created: 2026-04-29T00:00:00+00:00\n"
+        "---\n"
+        "# A task\n"
+    )
+    (tasks / "active.md").write_text(
+        "---\n" "state: active\n" "created: 2026-04-29T00:00:00+00:00\n" "---\n" "# Another task\n"
+    )
+    (tasks / "waiting-no-blocker.md").write_text(
+        "---\nstate: waiting\ncreated: 2026-04-29T00:00:00+00:00\n---\n"
+    )
+    (tasks / "no-frontmatter.md").write_text("Just a body.\n")
+
+    out = collect_waiting_tasks(tmp_path)
+
+    assert out == [{"task": "blocked-on-erik", "waiting_for": "Erik to merge PR #123"}]
+
+
+def test_collect_waiting_tasks_truncates_long_blocker(tmp_path: Path) -> None:
+    tasks = tmp_path / "tasks"
+    tasks.mkdir()
+    big = "x" * 500
+    (tasks / "long.md").write_text(
+        "---\n"
+        "state: waiting\n"
+        f"waiting_for: {big}\n"
+        "created: 2026-04-29T00:00:00+00:00\n"
+        "---\n"
+    )
+    out = collect_waiting_tasks(tmp_path)
+    assert len(out) == 1
+    assert len(out[0]["waiting_for"]) == 200
+
+
+def test_collect_waiting_tasks_no_tasks_dir(tmp_path: Path) -> None:
+    # Workspace exists but no tasks/ subdir
+    assert collect_waiting_tasks(tmp_path) == []
+
+
+def test_collect_waiting_tasks_respects_limit(tmp_path: Path) -> None:
+    tasks = tmp_path / "tasks"
+    tasks.mkdir()
+    for i in range(12):
+        (tasks / f"w{i:02d}.md").write_text(
+            "---\n"
+            "state: waiting\n"
+            f"waiting_for: blocker {i}\n"
+            "created: 2026-04-29T00:00:00+00:00\n"
+            "---\n"
+        )
+    out = collect_waiting_tasks(tmp_path, limit=4)
+    assert len(out) == 4
+    # Sorted alphabetically by stem
+    assert [t["task"] for t in out] == ["w00", "w01", "w02", "w03"]

--- a/uv.lock
+++ b/uv.lock
@@ -19,6 +19,7 @@ members = [
     "gptme-consortium",
     "gptme-contrib-lib",
     "gptme-contrib-workspace",
+    "gptme-daily-briefing",
     "gptme-dashboard",
     "gptme-forum",
     "gptme-gptodo",
@@ -847,18 +848,6 @@ wheels = [
 ]
 
 [[package]]
-name = "deprecated"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "wrapt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
-]
-
-[[package]]
 name = "deprecation"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1166,20 +1155,19 @@ provides-extras = ["oauth", "test"]
 [[package]]
 name = "gptme"
 version = "0.31.0"
-source = { git = "https://github.com/gptme/gptme.git?branch=master#a81083c054e1cda04d7cc31dcd02e47ee2db3e49" }
+source = { git = "https://github.com/gptme/gptme.git?branch=master#771528ed806cb3bfcfeb263fa1230e042c27191c" }
 dependencies = [
     { name = "anthropic" },
     { name = "bashlex" },
     { name = "click" },
     { name = "click-default-group" },
-    { name = "deprecated" },
     { name = "ipython" },
     { name = "json-repair" },
     { name = "lxml" },
     { name = "mcp" },
     { name = "multiprocessing-logging" },
     { name = "openai" },
-    { name = "pick" },
+    { name = "pick", marker = "sys_platform != 'win32'" },
     { name = "pillow" },
     { name = "platformdirs" },
     { name = "pypdf" },
@@ -1399,6 +1387,36 @@ dev = [
     { name = "pytest-mock", specifier = ">=3.12.0" },
     { name = "pyyaml", specifier = ">=6.0" },
 ]
+
+[[package]]
+name = "gptme-daily-briefing"
+version = "0.1.0"
+source = { editable = "packages/gptme-daily-briefing" }
+dependencies = [
+    { name = "pyyaml" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+]
+sessions = [
+    { name = "gptme-sessions" },
+]
+test = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "gptme-sessions", marker = "extra == 'sessions'", editable = "packages/gptme-sessions" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
+    { name = "pyyaml", specifier = ">=6.0.0" },
+]
+provides-extras = ["sessions", "test", "dev"]
 
 [[package]]
 name = "gptme-dashboard"
@@ -3209,9 +3227,6 @@ wheels = [
 name = "pick"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "windows-curses", marker = "sys_platform == 'win32'" },
-]
 sdist = { url = "https://files.pythonhosted.org/packages/df/f5/980b90af3fd82d18adaa3a1249037d3b1f95e201d640e17a7c5ce6188f45/pick-2.4.0.tar.gz", hash = "sha256:71f1b1b5d83652f87652fea5f51a3ba0b3388a71718cdcf8c6bc1326f85ae0b9", size = 5085, upload-time = "2024-09-15T14:04:29.445Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/95/c1ed539b784246182fd04a3fdee6ba473518e658c84d776caa714904d0f9/pick-2.4.0-py3-none-any.whl", hash = "sha256:2b07be18d16d655c7f491e1ecca7a29de3be85e1e000c8d46193672f14faa203", size = 5515, upload-time = "2024-09-15T14:04:28.245Z" },
@@ -3704,14 +3719,14 @@ crypto = [
 
 [[package]]
 name = "pypdf"
-version = "5.9.0"
+version = "6.10.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/89/3a/584b97a228950ed85aec97c811c68473d9b8d149e6a8c155668287cf1a28/pypdf-5.9.0.tar.gz", hash = "sha256:30f67a614d558e495e1fbb157ba58c1de91ffc1718f5e0dfeb82a029233890a1", size = 5035118, upload-time = "2025-07-27T14:04:52.364Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/3f/9f2167401c2e94833ca3b69535bad89e533b5de75fefe4197a2c224baec2/pypdf-6.10.2.tar.gz", hash = "sha256:7d09ce108eff6bf67465d461b6ef352dcb8d84f7a91befc02f904455c6eea11d", size = 5315679, upload-time = "2026-04-15T16:37:36.978Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/d9/6cff57c80a6963e7dd183bf09e9f21604a77716644b1e580e97b259f7612/pypdf-5.9.0-py3-none-any.whl", hash = "sha256:be10a4c54202f46d9daceaa8788be07aa8cd5ea8c25c529c50dd509206382c35", size = 313193, upload-time = "2025-07-27T14:04:50.53Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/d6/1d5c60cc17bbdf37c1552d9c03862fc6d32c5836732a0415b2d637edc2d0/pypdf-6.10.2-py3-none-any.whl", hash = "sha256:aa53be9826655b51c96741e5d7983ca224d898ac0a77896e64636810517624aa", size = 336308, upload-time = "2026-04-15T16:37:34.851Z" },
 ]
 
 [[package]]
@@ -5075,114 +5090,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/61/f1/ee81806690a87dab5f5653c1f146c92bc066d7f4cebc603ef88eb9e13957/werkzeug-3.1.6.tar.gz", hash = "sha256:210c6bede5a420a913956b4791a7f4d6843a43b6fcee4dfa08a65e93007d0d25", size = 864736, upload-time = "2026-02-19T15:17:18.884Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/ec/d58832f89ede95652fd01f4f24236af7d32b70cab2196dfcc2d2fd13c5c2/werkzeug-3.1.6-py3-none-any.whl", hash = "sha256:7ddf3357bb9564e407607f988f683d72038551200c704012bb9a4c523d42f131", size = 225166, upload-time = "2026-02-19T15:17:17.475Z" },
-]
-
-[[package]]
-name = "windows-curses"
-version = "2.4.1"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/34/e70815e7ae6f157c00121180a607dbcdc82acfd949c70bba28c45d206dec/windows_curses-2.4.1-cp310-cp310-win32.whl", hash = "sha256:53d711e07194d0d3ff7ceff29e0955b35479bc01465d46c3041de67b8141db2f", size = 71136, upload-time = "2025-01-11T00:26:15.273Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/1d/1bb512c445af24fb0a3dccf9537c8727bba5920e69539227b87f5351f608/windows_curses-2.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:325439cd4f37897a1de8a9c068a5b4c432f9244bf9c855ee2fbeb3fa721a770c", size = 81418, upload-time = "2025-01-11T00:26:16.963Z" },
-    { url = "https://files.pythonhosted.org/packages/74/b3/46a2508fff83b5affb5a311797c584c494b4b0c4c8796a1afa2c1b1e03ac/windows_curses-2.4.1-cp311-cp311-win32.whl", hash = "sha256:4fa1a176bfcf098d0c9bb7bc03dce6e83a4257fc0c66ad721f5745ebf0c00746", size = 71129, upload-time = "2025-01-11T00:26:19.137Z" },
-    { url = "https://files.pythonhosted.org/packages/50/29/fd7c0c80177d8df55f841504a5f332b95b0002c80f82055913b6caac94e6/windows_curses-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:fd7d7a9cf6c1758f46ed76b8c67f608bc5fcd5f0ca91f1580fd2d84cf41c7f4f", size = 81431, upload-time = "2025-01-11T00:26:20.359Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/99/60f34e51514c82631aa5c6d21eab88ce1701562de9844608411e39462a46/windows_curses-2.4.1-cp312-cp312-win32.whl", hash = "sha256:bdbe7d58747408aef8a9128b2654acf6fbd11c821b91224b9a046faba8c6b6ca", size = 71489, upload-time = "2025-01-11T00:26:22.726Z" },
-    { url = "https://files.pythonhosted.org/packages/62/8f/d908bcab1954375b156a9300fa86ceccb110f39457cd6fd59c72777626ab/windows_curses-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:5c9c2635faf171a229caca80e1dd760ab00db078e2a285ba2f667bbfcc31777c", size = 81777, upload-time = "2025-01-11T00:26:25.273Z" },
-    { url = "https://files.pythonhosted.org/packages/25/a0/e8d074f013117633f6b502ca123ecfc377fe0bd36818fe65e8935c91ca9c/windows_curses-2.4.1-cp313-cp313-win32.whl", hash = "sha256:05d1ca01e5199a435ccb6c8c2978df4a169cdff1ec99ab15f11ded9de8e5be26", size = 71390, upload-time = "2025-01-11T00:26:27.66Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/4b/2838a829b074a68c570d54ae0ae8539979657d3e619a4dc5a4b03eb69745/windows_curses-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8cf653f8928af19c103ae11cfed38124f418dcdd92643c4cd17239c0cec2f9da", size = 81636, upload-time = "2025-01-11T00:26:29.595Z" },
-]
-
-[[package]]
-name = "wrapt"
-version = "2.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/49/2a/6de8a50cb435b7f42c46126cf1a54b2aab81784e74c8595c8e025e8f36d3/wrapt-2.0.1.tar.gz", hash = "sha256:9c9c635e78497cacb81e84f8b11b23e0aacac7a136e73b8e5b2109a1d9fc468f", size = 82040, upload-time = "2025-11-07T00:45:33.312Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/0d/12d8c803ed2ce4e5e7d5b9f5f602721f9dfef82c95959f3ce97fa584bb5c/wrapt-2.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:64b103acdaa53b7caf409e8d45d39a8442fe6dcfec6ba3f3d141e0cc2b5b4dbd", size = 77481, upload-time = "2025-11-07T00:43:11.103Z" },
-    { url = "https://files.pythonhosted.org/packages/05/3e/4364ebe221ebf2a44d9fc8695a19324692f7dd2795e64bd59090856ebf12/wrapt-2.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:91bcc576260a274b169c3098e9a3519fb01f2989f6d3d386ef9cbf8653de1374", size = 60692, upload-time = "2025-11-07T00:43:13.697Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/ff/ae2a210022b521f86a8ddcdd6058d137c051003812b0388a5e9a03d3fe10/wrapt-2.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ab594f346517010050126fcd822697b25a7031d815bb4fbc238ccbe568216489", size = 61574, upload-time = "2025-11-07T00:43:14.967Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/93/5cf92edd99617095592af919cb81d4bff61c5dbbb70d3c92099425a8ec34/wrapt-2.0.1-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:36982b26f190f4d737f04a492a68accbfc6fa042c3f42326fdfbb6c5b7a20a31", size = 113688, upload-time = "2025-11-07T00:43:18.275Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/0a/e38fc0cee1f146c9fb266d8ef96ca39fb14a9eef165383004019aa53f88a/wrapt-2.0.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:23097ed8bc4c93b7bf36fa2113c6c733c976316ce0ee2c816f64ca06102034ef", size = 115698, upload-time = "2025-11-07T00:43:19.407Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/85/bef44ea018b3925fb0bcbe9112715f665e4d5309bd945191da814c314fd1/wrapt-2.0.1-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8bacfe6e001749a3b64db47bcf0341da757c95959f592823a93931a422395013", size = 112096, upload-time = "2025-11-07T00:43:16.5Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/0b/733a2376e413117e497aa1a5b1b78e8f3a28c0e9537d26569f67d724c7c5/wrapt-2.0.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:8ec3303e8a81932171f455f792f8df500fc1a09f20069e5c16bd7049ab4e8e38", size = 114878, upload-time = "2025-11-07T00:43:20.81Z" },
-    { url = "https://files.pythonhosted.org/packages/da/03/d81dcb21bbf678fcda656495792b059f9d56677d119ca022169a12542bd0/wrapt-2.0.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:3f373a4ab5dbc528a94334f9fe444395b23c2f5332adab9ff4ea82f5a9e33bc1", size = 111298, upload-time = "2025-11-07T00:43:22.229Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/d5/5e623040e8056e1108b787020d56b9be93dbbf083bf2324d42cde80f3a19/wrapt-2.0.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f49027b0b9503bf6c8cdc297ca55006b80c2f5dd36cecc72c6835ab6e10e8a25", size = 113361, upload-time = "2025-11-07T00:43:24.301Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/f3/de535ccecede6960e28c7b722e5744846258111d6c9f071aa7578ea37ad3/wrapt-2.0.1-cp310-cp310-win32.whl", hash = "sha256:8330b42d769965e96e01fa14034b28a2a7600fbf7e8f0cc90ebb36d492c993e4", size = 58035, upload-time = "2025-11-07T00:43:28.96Z" },
-    { url = "https://files.pythonhosted.org/packages/21/15/39d3ca5428a70032c2ec8b1f1c9d24c32e497e7ed81aed887a4998905fcc/wrapt-2.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:1218573502a8235bb8a7ecaed12736213b22dcde9feab115fa2989d42b5ded45", size = 60383, upload-time = "2025-11-07T00:43:25.804Z" },
-    { url = "https://files.pythonhosted.org/packages/43/c2/dfd23754b7f7a4dce07e08f4309c4e10a40046a83e9ae1800f2e6b18d7c1/wrapt-2.0.1-cp310-cp310-win_arm64.whl", hash = "sha256:eda8e4ecd662d48c28bb86be9e837c13e45c58b8300e43ba3c9b4fa9900302f7", size = 58894, upload-time = "2025-11-07T00:43:27.074Z" },
-    { url = "https://files.pythonhosted.org/packages/98/60/553997acf3939079dab022e37b67b1904b5b0cc235503226898ba573b10c/wrapt-2.0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0e17283f533a0d24d6e5429a7d11f250a58d28b4ae5186f8f47853e3e70d2590", size = 77480, upload-time = "2025-11-07T00:43:30.573Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/50/e5b3d30895d77c52105c6d5cbf94d5b38e2a3dd4a53d22d246670da98f7c/wrapt-2.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:85df8d92158cb8f3965aecc27cf821461bb5f40b450b03facc5d9f0d4d6ddec6", size = 60690, upload-time = "2025-11-07T00:43:31.594Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/40/660b2898703e5cbbb43db10cdefcc294274458c3ca4c68637c2b99371507/wrapt-2.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c1be685ac7700c966b8610ccc63c3187a72e33cab53526a27b2a285a662cd4f7", size = 61578, upload-time = "2025-11-07T00:43:32.918Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/36/825b44c8a10556957bc0c1d84c7b29a40e05fcf1873b6c40aa9dbe0bd972/wrapt-2.0.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:df0b6d3b95932809c5b3fecc18fda0f1e07452d05e2662a0b35548985f256e28", size = 114115, upload-time = "2025-11-07T00:43:35.605Z" },
-    { url = "https://files.pythonhosted.org/packages/83/73/0a5d14bb1599677304d3c613a55457d34c344e9b60eda8a737c2ead7619e/wrapt-2.0.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4da7384b0e5d4cae05c97cd6f94faaf78cc8b0f791fc63af43436d98c4ab37bb", size = 116157, upload-time = "2025-11-07T00:43:37.058Z" },
-    { url = "https://files.pythonhosted.org/packages/01/22/1c158fe763dbf0a119f985d945711d288994fe5514c0646ebe0eb18b016d/wrapt-2.0.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ec65a78fbd9d6f083a15d7613b2800d5663dbb6bb96003899c834beaa68b242c", size = 112535, upload-time = "2025-11-07T00:43:34.138Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/28/4f16861af67d6de4eae9927799b559c20ebdd4fe432e89ea7fe6fcd9d709/wrapt-2.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7de3cc939be0e1174969f943f3b44e0d79b6f9a82198133a5b7fc6cc92882f16", size = 115404, upload-time = "2025-11-07T00:43:39.214Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/8b/7960122e625fad908f189b59c4aae2d50916eb4098b0fb2819c5a177414f/wrapt-2.0.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:fb1a5b72cbd751813adc02ef01ada0b0d05d3dcbc32976ce189a1279d80ad4a2", size = 111802, upload-time = "2025-11-07T00:43:40.476Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/73/7881eee5ac31132a713ab19a22c9e5f1f7365c8b1df50abba5d45b781312/wrapt-2.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3fa272ca34332581e00bf7773e993d4f632594eb2d1b0b162a9038df0fd971dd", size = 113837, upload-time = "2025-11-07T00:43:42.921Z" },
-    { url = "https://files.pythonhosted.org/packages/45/00/9499a3d14e636d1f7089339f96c4409bbc7544d0889f12264efa25502ae8/wrapt-2.0.1-cp311-cp311-win32.whl", hash = "sha256:fc007fdf480c77301ab1afdbb6ab22a5deee8885f3b1ed7afcb7e5e84a0e27be", size = 58028, upload-time = "2025-11-07T00:43:47.369Z" },
-    { url = "https://files.pythonhosted.org/packages/70/5d/8f3d7eea52f22638748f74b102e38fdf88cb57d08ddeb7827c476a20b01b/wrapt-2.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:47434236c396d04875180171ee1f3815ca1eada05e24a1ee99546320d54d1d1b", size = 60385, upload-time = "2025-11-07T00:43:44.34Z" },
-    { url = "https://files.pythonhosted.org/packages/14/e2/32195e57a8209003587bbbad44d5922f13e0ced2a493bb46ca882c5b123d/wrapt-2.0.1-cp311-cp311-win_arm64.whl", hash = "sha256:837e31620e06b16030b1d126ed78e9383815cbac914693f54926d816d35d8edf", size = 58893, upload-time = "2025-11-07T00:43:46.161Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/73/8cb252858dc8254baa0ce58ce382858e3a1cf616acebc497cb13374c95c6/wrapt-2.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1fdbb34da15450f2b1d735a0e969c24bdb8d8924892380126e2a293d9902078c", size = 78129, upload-time = "2025-11-07T00:43:48.852Z" },
-    { url = "https://files.pythonhosted.org/packages/19/42/44a0db2108526ee6e17a5ab72478061158f34b08b793df251d9fbb9a7eb4/wrapt-2.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3d32794fe940b7000f0519904e247f902f0149edbe6316c710a8562fb6738841", size = 61205, upload-time = "2025-11-07T00:43:50.402Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/8a/5b4b1e44b791c22046e90d9b175f9a7581a8cc7a0debbb930f81e6ae8e25/wrapt-2.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:386fb54d9cd903ee0012c09291336469eb7b244f7183d40dc3e86a16a4bace62", size = 61692, upload-time = "2025-11-07T00:43:51.678Z" },
-    { url = "https://files.pythonhosted.org/packages/11/53/3e794346c39f462bcf1f58ac0487ff9bdad02f9b6d5ee2dc84c72e0243b2/wrapt-2.0.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7b219cb2182f230676308cdcacd428fa837987b89e4b7c5c9025088b8a6c9faf", size = 121492, upload-time = "2025-11-07T00:43:55.017Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/7e/10b7b0e8841e684c8ca76b462a9091c45d62e8f2de9c4b1390b690eadf16/wrapt-2.0.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:641e94e789b5f6b4822bb8d8ebbdfc10f4e4eae7756d648b717d980f657a9eb9", size = 123064, upload-time = "2025-11-07T00:43:56.323Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/d1/3c1e4321fc2f5ee7fd866b2d822aa89b84495f28676fd976c47327c5b6aa/wrapt-2.0.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fe21b118b9f58859b5ebaa4b130dee18669df4bd111daad082b7beb8799ad16b", size = 117403, upload-time = "2025-11-07T00:43:53.258Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/b0/d2f0a413cf201c8c2466de08414a15420a25aa83f53e647b7255cc2fab5d/wrapt-2.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:17fb85fa4abc26a5184d93b3efd2dcc14deb4b09edcdb3535a536ad34f0b4dba", size = 121500, upload-time = "2025-11-07T00:43:57.468Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/45/bddb11d28ca39970a41ed48a26d210505120f925918592283369219f83cc/wrapt-2.0.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:b89ef9223d665ab255ae42cc282d27d69704d94be0deffc8b9d919179a609684", size = 116299, upload-time = "2025-11-07T00:43:58.877Z" },
-    { url = "https://files.pythonhosted.org/packages/81/af/34ba6dd570ef7a534e7eec0c25e2615c355602c52aba59413411c025a0cb/wrapt-2.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a453257f19c31b31ba593c30d997d6e5be39e3b5ad9148c2af5a7314061c63eb", size = 120622, upload-time = "2025-11-07T00:43:59.962Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/3e/693a13b4146646fb03254636f8bafd20c621955d27d65b15de07ab886187/wrapt-2.0.1-cp312-cp312-win32.whl", hash = "sha256:3e271346f01e9c8b1130a6a3b0e11908049fe5be2d365a5f402778049147e7e9", size = 58246, upload-time = "2025-11-07T00:44:03.169Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/36/715ec5076f925a6be95f37917b66ebbeaa1372d1862c2ccd7a751574b068/wrapt-2.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:2da620b31a90cdefa9cd0c2b661882329e2e19d1d7b9b920189956b76c564d75", size = 60492, upload-time = "2025-11-07T00:44:01.027Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/3e/62451cd7d80f65cc125f2b426b25fbb6c514bf6f7011a0c3904fc8c8df90/wrapt-2.0.1-cp312-cp312-win_arm64.whl", hash = "sha256:aea9c7224c302bc8bfc892b908537f56c430802560e827b75ecbde81b604598b", size = 58987, upload-time = "2025-11-07T00:44:02.095Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/fe/41af4c46b5e498c90fc87981ab2972fbd9f0bccda597adb99d3d3441b94b/wrapt-2.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:47b0f8bafe90f7736151f61482c583c86b0693d80f075a58701dd1549b0010a9", size = 78132, upload-time = "2025-11-07T00:44:04.628Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/92/d68895a984a5ebbbfb175512b0c0aad872354a4a2484fbd5552e9f275316/wrapt-2.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:cbeb0971e13b4bd81d34169ed57a6dda017328d1a22b62fda45e1d21dd06148f", size = 61211, upload-time = "2025-11-07T00:44:05.626Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/26/ba83dc5ae7cf5aa2b02364a3d9cf74374b86169906a1f3ade9a2d03cf21c/wrapt-2.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb7cffe572ad0a141a7886a1d2efa5bef0bf7fe021deeea76b3ab334d2c38218", size = 61689, upload-time = "2025-11-07T00:44:06.719Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/67/d7a7c276d874e5d26738c22444d466a3a64ed541f6ef35f740dbd865bab4/wrapt-2.0.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c8d60527d1ecfc131426b10d93ab5d53e08a09c5fa0175f6b21b3252080c70a9", size = 121502, upload-time = "2025-11-07T00:44:09.557Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/6b/806dbf6dd9579556aab22fc92908a876636e250f063f71548a8660382184/wrapt-2.0.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c654eafb01afac55246053d67a4b9a984a3567c3808bb7df2f8de1c1caba2e1c", size = 123110, upload-time = "2025-11-07T00:44:10.64Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/08/cdbb965fbe4c02c5233d185d070cabed2ecc1f1e47662854f95d77613f57/wrapt-2.0.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:98d873ed6c8b4ee2418f7afce666751854d6d03e3c0ec2a399bb039cd2ae89db", size = 117434, upload-time = "2025-11-07T00:44:08.138Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/d1/6aae2ce39db4cb5216302fa2e9577ad74424dfbe315bd6669725569e048c/wrapt-2.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c9e850f5b7fc67af856ff054c71690d54fa940c3ef74209ad9f935b4f66a0233", size = 121533, upload-time = "2025-11-07T00:44:12.142Z" },
-    { url = "https://files.pythonhosted.org/packages/79/35/565abf57559fbe0a9155c29879ff43ce8bd28d2ca61033a3a3dd67b70794/wrapt-2.0.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:e505629359cb5f751e16e30cf3f91a1d3ddb4552480c205947da415d597f7ac2", size = 116324, upload-time = "2025-11-07T00:44:13.28Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/e0/53ff5e76587822ee33e560ad55876d858e384158272cd9947abdd4ad42ca/wrapt-2.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2879af909312d0baf35f08edeea918ee3af7ab57c37fe47cb6a373c9f2749c7b", size = 120627, upload-time = "2025-11-07T00:44:14.431Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/7b/38df30fd629fbd7612c407643c63e80e1c60bcc982e30ceeae163a9800e7/wrapt-2.0.1-cp313-cp313-win32.whl", hash = "sha256:d67956c676be5a24102c7407a71f4126d30de2a569a1c7871c9f3cabc94225d7", size = 58252, upload-time = "2025-11-07T00:44:17.814Z" },
-    { url = "https://files.pythonhosted.org/packages/85/64/d3954e836ea67c4d3ad5285e5c8fd9d362fd0a189a2db622df457b0f4f6a/wrapt-2.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:9ca66b38dd642bf90c59b6738af8070747b610115a39af2498535f62b5cdc1c3", size = 60500, upload-time = "2025-11-07T00:44:15.561Z" },
-    { url = "https://files.pythonhosted.org/packages/89/4e/3c8b99ac93527cfab7f116089db120fef16aac96e5f6cdb724ddf286086d/wrapt-2.0.1-cp313-cp313-win_arm64.whl", hash = "sha256:5a4939eae35db6b6cec8e7aa0e833dcca0acad8231672c26c2a9ab7a0f8ac9c8", size = 58993, upload-time = "2025-11-07T00:44:16.65Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/f4/eff2b7d711cae20d220780b9300faa05558660afb93f2ff5db61fe725b9a/wrapt-2.0.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:a52f93d95c8d38fed0669da2ebdb0b0376e895d84596a976c15a9eb45e3eccb3", size = 82028, upload-time = "2025-11-07T00:44:18.944Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/67/cb945563f66fd0f61a999339460d950f4735c69f18f0a87ca586319b1778/wrapt-2.0.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:4e54bbf554ee29fcceee24fa41c4d091398b911da6e7f5d7bffda963c9aed2e1", size = 62949, upload-time = "2025-11-07T00:44:20.074Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/ca/f63e177f0bbe1e5cf5e8d9b74a286537cd709724384ff20860f8f6065904/wrapt-2.0.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:908f8c6c71557f4deaa280f55d0728c3bca0960e8c3dd5ceeeafb3c19942719d", size = 63681, upload-time = "2025-11-07T00:44:21.345Z" },
-    { url = "https://files.pythonhosted.org/packages/39/a1/1b88fcd21fd835dca48b556daef750952e917a2794fa20c025489e2e1f0f/wrapt-2.0.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:e2f84e9af2060e3904a32cea9bb6db23ce3f91cfd90c6b426757cf7cc01c45c7", size = 152696, upload-time = "2025-11-07T00:44:24.318Z" },
-    { url = "https://files.pythonhosted.org/packages/62/1c/d9185500c1960d9f5f77b9c0b890b7fc62282b53af7ad1b6bd779157f714/wrapt-2.0.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e3612dc06b436968dfb9142c62e5dfa9eb5924f91120b3c8ff501ad878f90eb3", size = 158859, upload-time = "2025-11-07T00:44:25.494Z" },
-    { url = "https://files.pythonhosted.org/packages/91/60/5d796ed0f481ec003220c7878a1d6894652efe089853a208ea0838c13086/wrapt-2.0.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6d2d947d266d99a1477cd005b23cbd09465276e302515e122df56bb9511aca1b", size = 146068, upload-time = "2025-11-07T00:44:22.81Z" },
-    { url = "https://files.pythonhosted.org/packages/04/f8/75282dd72f102ddbfba137e1e15ecba47b40acff32c08ae97edbf53f469e/wrapt-2.0.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:7d539241e87b650cbc4c3ac9f32c8d1ac8a54e510f6dca3f6ab60dcfd48c9b10", size = 155724, upload-time = "2025-11-07T00:44:26.634Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/27/fe39c51d1b344caebb4a6a9372157bdb8d25b194b3561b52c8ffc40ac7d1/wrapt-2.0.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:4811e15d88ee62dbf5c77f2c3ff3932b1e3ac92323ba3912f51fc4016ce81ecf", size = 144413, upload-time = "2025-11-07T00:44:27.939Z" },
-    { url = "https://files.pythonhosted.org/packages/83/2b/9f6b643fe39d4505c7bf926d7c2595b7cb4b607c8c6b500e56c6b36ac238/wrapt-2.0.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c1c91405fcf1d501fa5d55df21e58ea49e6b879ae829f1039faaf7e5e509b41e", size = 150325, upload-time = "2025-11-07T00:44:29.29Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/b6/20ffcf2558596a7f58a2e69c89597128781f0b88e124bf5a4cadc05b8139/wrapt-2.0.1-cp313-cp313t-win32.whl", hash = "sha256:e76e3f91f864e89db8b8d2a8311d57df93f01ad6bb1e9b9976d1f2e83e18315c", size = 59943, upload-time = "2025-11-07T00:44:33.211Z" },
-    { url = "https://files.pythonhosted.org/packages/87/6a/0e56111cbb3320151eed5d3821ee1373be13e05b376ea0870711f18810c3/wrapt-2.0.1-cp313-cp313t-win_amd64.whl", hash = "sha256:83ce30937f0ba0d28818807b303a412440c4b63e39d3d8fc036a94764b728c92", size = 63240, upload-time = "2025-11-07T00:44:30.935Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/54/5ab4c53ea1f7f7e5c3e7c1095db92932cc32fd62359d285486d00c2884c3/wrapt-2.0.1-cp313-cp313t-win_arm64.whl", hash = "sha256:4b55cacc57e1dc2d0991dbe74c6419ffd415fb66474a02335cb10efd1aa3f84f", size = 60416, upload-time = "2025-11-07T00:44:32.002Z" },
-    { url = "https://files.pythonhosted.org/packages/73/81/d08d83c102709258e7730d3cd25befd114c60e43ef3891d7e6877971c514/wrapt-2.0.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:5e53b428f65ece6d9dad23cb87e64506392b720a0b45076c05354d27a13351a1", size = 78290, upload-time = "2025-11-07T00:44:34.691Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/14/393afba2abb65677f313aa680ff0981e829626fed39b6a7e3ec807487790/wrapt-2.0.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:ad3ee9d0f254851c71780966eb417ef8e72117155cff04821ab9b60549694a55", size = 61255, upload-time = "2025-11-07T00:44:35.762Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/10/a4a1f2fba205a9462e36e708ba37e5ac95f4987a0f1f8fd23f0bf1fc3b0f/wrapt-2.0.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7b822c61ed04ee6ad64bc90d13368ad6eb094db54883b5dde2182f67a7f22c0", size = 61797, upload-time = "2025-11-07T00:44:37.22Z" },
-    { url = "https://files.pythonhosted.org/packages/12/db/99ba5c37cf1c4fad35349174f1e38bd8d992340afc1ff27f526729b98986/wrapt-2.0.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7164a55f5e83a9a0b031d3ffab4d4e36bbec42e7025db560f225489fa929e509", size = 120470, upload-time = "2025-11-07T00:44:39.425Z" },
-    { url = "https://files.pythonhosted.org/packages/30/3f/a1c8d2411eb826d695fc3395a431757331582907a0ec59afce8fe8712473/wrapt-2.0.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e60690ba71a57424c8d9ff28f8d006b7ad7772c22a4af432188572cd7fa004a1", size = 122851, upload-time = "2025-11-07T00:44:40.582Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/8d/72c74a63f201768d6a04a8845c7976f86be6f5ff4d74996c272cefc8dafc/wrapt-2.0.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3cd1a4bd9a7a619922a8557e1318232e7269b5fb69d4ba97b04d20450a6bf970", size = 117433, upload-time = "2025-11-07T00:44:38.313Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/5a/df37cf4042cb13b08256f8e27023e2f9b3d471d553376616591bb99bcb31/wrapt-2.0.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b4c2e3d777e38e913b8ce3a6257af72fb608f86a1df471cb1d4339755d0a807c", size = 121280, upload-time = "2025-11-07T00:44:41.69Z" },
-    { url = "https://files.pythonhosted.org/packages/54/34/40d6bc89349f9931e1186ceb3e5fbd61d307fef814f09fbbac98ada6a0c8/wrapt-2.0.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:3d366aa598d69416b5afedf1faa539fac40c1d80a42f6b236c88c73a3c8f2d41", size = 116343, upload-time = "2025-11-07T00:44:43.013Z" },
-    { url = "https://files.pythonhosted.org/packages/70/66/81c3461adece09d20781dee17c2366fdf0cb8754738b521d221ca056d596/wrapt-2.0.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c235095d6d090aa903f1db61f892fffb779c1eaeb2a50e566b52001f7a0f66ed", size = 119650, upload-time = "2025-11-07T00:44:44.523Z" },
-    { url = "https://files.pythonhosted.org/packages/46/3a/d0146db8be8761a9e388cc9cc1c312b36d583950ec91696f19bbbb44af5a/wrapt-2.0.1-cp314-cp314-win32.whl", hash = "sha256:bfb5539005259f8127ea9c885bdc231978c06b7a980e63a8a61c8c4c979719d0", size = 58701, upload-time = "2025-11-07T00:44:48.277Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/38/5359da9af7d64554be63e9046164bd4d8ff289a2dd365677d25ba3342c08/wrapt-2.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:4ae879acc449caa9ed43fc36ba08392b9412ee67941748d31d94e3cedb36628c", size = 60947, upload-time = "2025-11-07T00:44:46.086Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/3f/96db0619276a833842bf36343685fa04f987dd6e3037f314531a1e00492b/wrapt-2.0.1-cp314-cp314-win_arm64.whl", hash = "sha256:8639b843c9efd84675f1e100ed9e99538ebea7297b62c4b45a7042edb84db03e", size = 59359, upload-time = "2025-11-07T00:44:47.164Z" },
-    { url = "https://files.pythonhosted.org/packages/71/49/5f5d1e867bf2064bf3933bc6cf36ade23505f3902390e175e392173d36a2/wrapt-2.0.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:9219a1d946a9b32bb23ccae66bdb61e35c62773ce7ca6509ceea70f344656b7b", size = 82031, upload-time = "2025-11-07T00:44:49.4Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/89/0009a218d88db66ceb83921e5685e820e2c61b59bbbb1324ba65342668bc/wrapt-2.0.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:fa4184e74197af3adad3c889a1af95b53bb0466bced92ea99a0c014e48323eec", size = 62952, upload-time = "2025-11-07T00:44:50.74Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/18/9b968e920dd05d6e44bcc918a046d02afea0fb31b2f1c80ee4020f377cbe/wrapt-2.0.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c5ef2f2b8a53b7caee2f797ef166a390fef73979b15778a4a153e4b5fedce8fa", size = 63688, upload-time = "2025-11-07T00:44:52.248Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/7d/78bdcb75826725885d9ea26c49a03071b10c4c92da93edda612910f150e4/wrapt-2.0.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:e042d653a4745be832d5aa190ff80ee4f02c34b21f4b785745eceacd0907b815", size = 152706, upload-time = "2025-11-07T00:44:54.613Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/77/cac1d46f47d32084a703df0d2d29d47e7eb2a7d19fa5cbca0e529ef57659/wrapt-2.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2afa23318136709c4b23d87d543b425c399887b4057936cd20386d5b1422b6fa", size = 158866, upload-time = "2025-11-07T00:44:55.79Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/11/b521406daa2421508903bf8d5e8b929216ec2af04839db31c0a2c525eee0/wrapt-2.0.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6c72328f668cf4c503ffcf9434c2b71fdd624345ced7941bc6693e61bbe36bef", size = 146148, upload-time = "2025-11-07T00:44:53.388Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/c0/340b272bed297baa7c9ce0c98ef7017d9c035a17a6a71dce3184b8382da2/wrapt-2.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3793ac154afb0e5b45d1233cb94d354ef7a983708cc3bb12563853b1d8d53747", size = 155737, upload-time = "2025-11-07T00:44:56.971Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/93/bfcb1fb2bdf186e9c2883a4d1ab45ab099c79cbf8f4e70ea453811fa3ea7/wrapt-2.0.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:fec0d993ecba3991645b4857837277469c8cc4c554a7e24d064d1ca291cfb81f", size = 144451, upload-time = "2025-11-07T00:44:58.515Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/6b/dca504fb18d971139d232652656180e3bd57120e1193d9a5899c3c0b7cdd/wrapt-2.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:949520bccc1fa227274da7d03bf238be15389cd94e32e4297b92337df9b7a349", size = 150353, upload-time = "2025-11-07T00:44:59.753Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/f6/a1de4bd3653afdf91d250ca5c721ee51195df2b61a4603d4b373aa804d1d/wrapt-2.0.1-cp314-cp314t-win32.whl", hash = "sha256:be9e84e91d6497ba62594158d3d31ec0486c60055c49179edc51ee43d095f79c", size = 60609, upload-time = "2025-11-07T00:45:03.315Z" },
-    { url = "https://files.pythonhosted.org/packages/01/3a/07cd60a9d26fe73efead61c7830af975dfdba8537632d410462672e4432b/wrapt-2.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:61c4956171c7434634401db448371277d07032a81cc21c599c22953374781395", size = 64038, upload-time = "2025-11-07T00:45:00.948Z" },
-    { url = "https://files.pythonhosted.org/packages/41/99/8a06b8e17dddbf321325ae4eb12465804120f699cd1b8a355718300c62da/wrapt-2.0.1-cp314-cp314t-win_arm64.whl", hash = "sha256:35cdbd478607036fee40273be8ed54a451f5f23121bd9d4be515158f9498f7ad", size = 60634, upload-time = "2025-11-07T00:45:02.087Z" },
-    { url = "https://files.pythonhosted.org/packages/15/d1/b51471c11592ff9c012bd3e2f7334a6ff2f42a7aed2caffcf0bdddc9cb89/wrapt-2.0.1-py3-none-any.whl", hash = "sha256:4d2ce1bf1a48c5277d7969259232b57645aae5686dba1eaeade39442277afbca", size = 44046, upload-time = "2025-11-07T00:45:32.116Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a new `gptme-daily-briefing` package — the upstream extraction of Bob's
`collect-daily-briefing.py` morning pipeline. This is **Phase 5** of the
daily-briefing-pipeline convergence (see [Bob's design doc](https://github.com/ErikBjare/bob/blob/master/knowledge/technical-designs/daily-briefing-pipeline.md)
and [tracking issue ErikBjare/bob#676](https://github.com/ErikBjare/bob/issues/676)).

The goal: let other agents (Alice, Gordon, future template agents) build their own
morning-briefing pipelines without copying the 366 lines of glue Bob currently has
locally.

## What's in the package

- **`schema`** — TypedDicts for the bundle JSON contract (`BriefingBundle`,
  `Bullets`, `Analytics`, `Workstream`, `OpenPR`, `WaitingTask`, `SessionStats`).
  Uses `total=False` and an open `dict[str, Any]` for agent-specific extensions
  (bandits, KPI shape) so each agent can attach its own structures without
  changing the schema.
- **`collectors`** — pure data gatherers, no agent imports:
  - `collect_blockers(repo, label)` — open issues by label
  - `collect_active_tasks(workspace_root)` — `gptodo` active/todo
  - `collect_waiting_tasks(workspace_root)` — task frontmatter `waiting_for`
  - `collect_recent_highlights(workspace_root)` — recent commit subjects
  - `collect_session_stats(sessions_dir)` — gptme-sessions count + categories (extra)
  - `collect_open_prs(repos, username)` — open PRs by user across repos
  - `collect_graphql_rate_limit()` — GitHub GraphQL budget probe

## What stays in each agent's local wrapper

Per Bob's design doc, agent-specific bits stay local:

- Thompson sampling bandit tops (depends on `metaproductivity`)
- Weekly goals + KPI snapshot (each agent's KPI shape differs)
- Rich PR review guide (depends on workspace-local `pr-review-guide.py`)
- Brief-agent persona / prompt
- Erik-specific routing and call target

## Tests

7 tests, all green — covers highlights ordering, limits, missing repo,
waiting-task frontmatter parsing, truncation, missing tasks/ dir, and limit
enforcement.

```text
$ cd packages/gptme-daily-briefing && uv run pytest tests/ -v
test_collectors.py::test_collect_recent_highlights_returns_subjects_in_order PASSED
test_collectors.py::test_collect_recent_highlights_respects_limit            PASSED
test_collectors.py::test_collect_recent_highlights_empty_repo                PASSED
test_collectors.py::test_collect_waiting_tasks_parses_frontmatter            PASSED
test_collectors.py::test_collect_waiting_tasks_truncates_long_blocker        PASSED
test_collectors.py::test_collect_waiting_tasks_no_tasks_dir                  PASSED
test_collectors.py::test_collect_waiting_tasks_respects_limit                PASSED
========================= 7 passed in 0.27s =========================
```

Smoke-tested against Bob's real workspace — blockers, active/waiting tasks,
highlights, and 218 sessions/24h with the same category breakdown the existing
script produces.

## Lockfile

`uv.lock` was stale — pinned a `gptme` master commit (`a81083c0…`) that's no
longer reachable on origin, which broke `make typecheck` for any new commit
on this branch. Refreshed via `uv lock --upgrade-package gptme`; net effect
is bumping `gptme` to the current master and dropping unused transitive deps
(`deprecated`, `wrapt`, `windows-curses`). 36 insertions / 129 deletions in
`uv.lock`.

## Follow-up

A separate PR in [Bob's repo](https://github.com/ErikBjare/bob) will refactor
`scripts/monitoring/collect-daily-briefing.py` to import these collectors and
keep only the bandit/KPI/pr-review-guide composition local. Doing the upstream
package first so the dependency direction stays clean.

## Test plan

- [x] All 7 unit tests pass locally
- [x] Smoke-tested against Bob's workspace produces the same data as the
      existing script
- [x] `make typecheck-packages` green
- [ ] CI green