### PR TITLE
fix(daily-briefing): paginate collect_open_prs to handle >100 open PRs per repo

### DIFF
--- a/packages/gptme-daily-briefing/src/gptme_daily_briefing/collectors.py
+++ b/packages/gptme-daily-briefing/src/gptme_daily_briefing/collectors.py
@@ -218,7 +218,5 @@ def collect_open_prs(
                 break
             if len(batch) < 100:
                 break
-            if len(repo_prs) >= limit_per_repo:
-                break
         prs.extend(repo_prs[:limit_per_repo])
     return prs

--- a/packages/gptme-daily-briefing/src/gptme_daily_briefing/collectors.py
+++ b/packages/gptme-daily-briefing/src/gptme_daily_briefing/collectors.py
@@ -218,5 +218,7 @@ def collect_open_prs(
                 break
             if len(batch) < 100:
                 break
+            if len(repo_prs) >= limit_per_repo:
+                break
         prs.extend(repo_prs[:limit_per_repo])
     return prs

--- a/packages/gptme-daily-briefing/src/gptme_daily_briefing/collectors.py
+++ b/packages/gptme-daily-briefing/src/gptme_daily_briefing/collectors.py
@@ -176,29 +176,47 @@ def collect_session_stats(sessions_dir: Path, days: int = 1) -> dict[str, Any]:
 
 
 def collect_open_prs(
-    repos: list[str], username: str, limit_per_repo: int = 5
+    repos: list[str],
+    username: str,
+    limit_per_repo: int = 5,
+    max_pages: int = 5,
 ) -> list[dict[str, Any]]:
-    """Open PRs by ``username`` across the given repositories."""
+    """Open PRs by ``username`` across the given repositories.
+
+    Paginates through ``state=open&per_page=100`` results so users with PRs
+    beyond the first 100 in a repo aren't silently dropped. Stops at the
+    first empty page or when ``max_pages`` is reached (default 5 → up to
+    500 PRs scanned per repo).
+    """
     prs: list[dict[str, Any]] = []
     for repo in repos:
-        out = _run(["gh", "api", f"repos/{repo}/pulls?state=open&per_page=100"])
-        if not out:
-            continue
-        try:
-            repo_prs = []
-            for pr in json.loads(out):
-                if pr.get("user", {}).get("login") != username:
-                    continue
-                repo_prs.append(
-                    {
-                        "repo": repo,
-                        "number": pr["number"],
-                        "title": pr["title"],
-                        "draft": pr.get("draft", False),
-                        "url": f"https://github.com/{repo}/pull/{pr['number']}",
-                    }
-                )
-            prs.extend(repo_prs[:limit_per_repo])
-        except (json.JSONDecodeError, KeyError):
-            continue
+        repo_prs: list[dict[str, Any]] = []
+        for page in range(1, max_pages + 1):
+            out = _run(["gh", "api", f"repos/{repo}/pulls?state=open&per_page=100&page={page}"])
+            if not out:
+                break
+            try:
+                batch = json.loads(out)
+            except json.JSONDecodeError:
+                break
+            if not batch:
+                break
+            try:
+                for pr in batch:
+                    if pr.get("user", {}).get("login") != username:
+                        continue
+                    repo_prs.append(
+                        {
+                            "repo": repo,
+                            "number": pr["number"],
+                            "title": pr["title"],
+                            "draft": pr.get("draft", False),
+                            "url": f"https://github.com/{repo}/pull/{pr['number']}",
+                        }
+                    )
+            except KeyError:
+                break
+            if len(batch) < 100:
+                break
+        prs.extend(repo_prs[:limit_per_repo])
     return prs

--- a/packages/gptme-daily-briefing/src/gptme_daily_briefing/collectors.py
+++ b/packages/gptme-daily-briefing/src/gptme_daily_briefing/collectors.py
@@ -199,7 +199,7 @@ def collect_open_prs(
                 batch = json.loads(out)
             except json.JSONDecodeError:
                 break
-            if not batch:
+            if not isinstance(batch, list) or not batch:
                 break
             try:
                 for pr in batch:

--- a/packages/gptme-daily-briefing/tests/test_collectors.py
+++ b/packages/gptme-daily-briefing/tests/test_collectors.py
@@ -176,3 +176,89 @@ def test_collect_waiting_tasks_respects_limit(tmp_path: Path) -> None:
     assert len(out) == 4
     # Sorted alphabetically by stem
     assert [t["task"] for t in out] == ["w00", "w01", "w02", "w03"]
+
+
+def _pr_payload(number: int, login: str, title: str = "x") -> dict:
+    return {
+        "number": number,
+        "title": title,
+        "draft": False,
+        "user": {"login": login},
+    }
+
+
+def test_collect_open_prs_paginates_when_first_page_full(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A full first page (100 items) must trigger a second-page fetch."""
+    import json as _json
+
+    from gptme_daily_briefing import collectors as col
+
+    captured: list[str] = []
+    page1 = [_pr_payload(i, "alice" if i % 10 == 0 else "other") for i in range(100)]
+    page2 = [_pr_payload(1000, "alice", "from-page-2")]
+    pages = {1: page1, 2: page2, 3: []}
+
+    def fake_run(cmd: list[str], cwd: Path | None = None, timeout: int = 30) -> str:
+        url = cmd[-1]
+        captured.append(url)
+        page = int(url.split("page=")[-1])
+        return _json.dumps(pages.get(page, []))
+
+    monkeypatch.setattr(col, "_run", fake_run)
+
+    out = col.collect_open_prs(["owner/repo"], "alice", limit_per_repo=20)
+
+    # Walked at least pages 1 and 2 (3 may or may not be hit depending on impl,
+    # but the contract is "stops at first empty page")
+    assert any("page=1" in u for u in captured), captured
+    assert any("page=2" in u for u in captured), captured
+    # Page-2-only PR must be present (the original bug: silent miss)
+    assert any(p["number"] == 1000 and p["title"] == "from-page-2" for p in out), out
+
+
+def test_collect_open_prs_stops_on_short_page(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A page returning <100 items signals the last page — don't fetch more."""
+    import json as _json
+
+    from gptme_daily_briefing import collectors as col
+
+    captured: list[str] = []
+    page1 = [_pr_payload(i, "alice") for i in range(5)]
+
+    def fake_run(cmd: list[str], cwd: Path | None = None, timeout: int = 30) -> str:
+        url = cmd[-1]
+        captured.append(url)
+        page = int(url.split("page=")[-1])
+        return _json.dumps(page1 if page == 1 else [])
+
+    monkeypatch.setattr(col, "_run", fake_run)
+    col.collect_open_prs(["owner/repo"], "alice")
+
+    # Only one HTTP call: short first page is the last page
+    assert len(captured) == 1, captured
+
+
+def test_collect_open_prs_respects_max_pages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cap at max_pages even if every page returns 100 results."""
+    import json as _json
+
+    from gptme_daily_briefing import collectors as col
+
+    captured: list[str] = []
+    full_page = [_pr_payload(i, "alice") for i in range(100)]
+
+    def fake_run(cmd: list[str], cwd: Path | None = None, timeout: int = 30) -> str:
+        captured.append(cmd[-1])
+        return _json.dumps(full_page)
+
+    monkeypatch.setattr(col, "_run", fake_run)
+    col.collect_open_prs(["owner/repo"], "alice", max_pages=2)
+
+    # Exactly 2 pages walked, no more
+    assert len(captured) == 2, captured


### PR DESCRIPTION
## Summary

`collect_open_prs` (in `packages/gptme-daily-briefing`) called the GitHub API with
`per_page=100` and a single page, silently dropping any of the user's PRs beyond
that window. Closes #798 (Greptile P2 follow-up from #797).

## What changed

- Added `max_pages` parameter (default 5 → up to 500 PRs scanned per repo).
- Loop pages 1..max_pages, stopping early on:
  - empty page (definitive end)
  - short page (< 100 items, no more pages possible)
  - JSON decode error or malformed payload (defensive)
- Three new tests covering: pagination on full first page, single-call
  short-page path, and `max_pages` cap behavior.

## Test plan

- [x] `uv run pytest packages/gptme-daily-briefing/tests/test_collectors.py` — 13/13 pass
- [x] All pre-commit hooks pass (ruff format auto-applied to long URL line)
- [ ] Greptile review

## Notes

In practice every repo Bob currently tracks has fewer than 100 open PRs, so this
isn't a live data bug — but it removes a silent-miss class of error that would
only manifest once a tracked repo crossed the threshold.