### PR TITLE
feat(twitter): HEAD-check URLs in workflow.py draft command

### DIFF
--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -745,6 +745,34 @@ def cli(model: str | None = None) -> None:
     )
 
 
+def _validate_urls_in_text(text: str) -> list[tuple[str, int]]:
+    """HEAD-check any http(s) URLs in tweet text. Return [(url, status)] for unreachable ones (4xx/5xx).
+
+    Network errors are treated as non-fatal (returns nothing for those URLs) — the goal is to
+    catch deterministic 404s like the recurring `/YYYY/MM/DD/title/` vs `/blog/title/` permalink
+    bug, not to require connectivity. Mirrors the check in scripts/twitter/post-blog-tweet.py.
+    """
+    import re
+    import urllib.error
+    import urllib.request
+
+    url_pattern = re.compile(r"https?://[^\s\"'<>)]+")
+    bad: list[tuple[str, int]] = []
+    for url in url_pattern.findall(text):
+        url = url.rstrip(".,;:!?")
+        try:
+            req = urllib.request.Request(url, method="HEAD")
+            req.add_header("User-Agent", "Mozilla/5.0 (URL checker)")
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                if resp.status >= 400:
+                    bad.append((url, resp.status))
+        except urllib.error.HTTPError as e:
+            bad.append((url, e.code))
+        except Exception:
+            pass
+    return bad
+
+
 @cli.command()
 @click.argument("text")
 @click.option(
@@ -752,11 +780,35 @@ def cli(model: str | None = None) -> None:
 )
 @click.option("--reply-to", help="Tweet ID to reply to")
 @click.option("--schedule", help="Schedule time (ISO format)")
-def draft(text: str, type: str, reply_to: str | None, schedule: str | None) -> None:
+@click.option(
+    "--skip-url-check",
+    is_flag=True,
+    help="Skip HEAD-check of URLs in tweet text (use for pre-publish drafts)",
+)
+def draft(
+    text: str,
+    type: str,
+    reply_to: str | None,
+    schedule: str | None,
+    skip_url_check: bool,
+) -> None:
     """Create a new tweet draft"""
     op = metrics.start_operation("draft_creation", "twitter")
 
     try:
+        if not skip_url_check:
+            bad_urls = _validate_urls_in_text(text)
+            if bad_urls:
+                for url, status in bad_urls:
+                    console.print(
+                        f"[red]✗ URL returns {status}: {url}[/red]",
+                    )
+                console.print(
+                    "[red]Aborting draft — fix URLs or pass --skip-url-check.[/red]"
+                )
+                op.complete(success=False, error="bad_url")
+                sys.exit(1)
+
         scheduled_time = datetime.fromisoformat(schedule) if schedule else None
 
         draft = TweetDraft(

--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -763,9 +763,8 @@ def _validate_urls_in_text(text: str) -> list[tuple[str, int]]:
         try:
             req = urllib.request.Request(url, method="HEAD")
             req.add_header("User-Agent", "Mozilla/5.0 (URL checker)")
-            with urllib.request.urlopen(req, timeout=5) as resp:
-                if resp.status >= 400:
-                    bad.append((url, resp.status))
+            with urllib.request.urlopen(req, timeout=5):
+                pass  # 4xx/5xx raise HTTPError before reaching here
         except urllib.error.HTTPError as e:
             bad.append((url, e.code))
         except Exception:


### PR DESCRIPTION
## Summary

Mirror the URL validation already present in `scripts/twitter/post-blog-tweet.py` so any draft-creation path catches dead links at **draft time**, not after posting.

The trigger: a tweet drafted via `workflow.py draft` used the wrong permalink pattern (`/YYYY/MM/DD/title/` instead of `/blog/title/`) and would have posted as a 404 link. This is a recurring 404 pattern Erik has flagged at least 4 times since Apr 24 in the bob workspace.

After this change, both draft paths share the same HEAD-check semantics:
- abort on 4xx/5xx
- ignore network errors so offline drafting still works
- `--skip-url-check` opt-out for cases where the URL legitimately doesn't exist yet

## Changes

- New helper `_validate_urls_in_text(text)` — regex-extracts http(s) URLs and HEAD-checks each (5s timeout, treats network errors as non-fatal). Strips trailing punctuation so "url." doesn't fail.
- `draft` command runs the check by default; `--skip-url-check` opts out.

## Related

There's an unmerged sibling branch [`fix/tweet-url-validation`](https://github.com/gptme/gptme-contrib/tree/fix/tweet-url-validation) (Apr 13) that adds URL validation at **post time** with private-repo detection but only warns. The two checks are complementary — this PR catches problems earlier; the older branch's post-time check could be combined later in a follow-up PR.

## Test plan

- [ ] `workflow.py draft "see https://example.com"` succeeds (200)
- [ ] `workflow.py draft "see https://timetobuildbob.github.io/2026/04/30/zig-contributor-poker-ai-ban/"` aborts with 404 message
- [ ] `workflow.py draft --skip-url-check "see https://example.com/missing"` succeeds without checking
- [ ] Network failure (DNS error, connection refused) does not block draft creation