### PR TITLE
fix(activity-gate): re-emit notification follow-ups (don't dedupe by id alone)

### DIFF
--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -709,37 +709,54 @@ check_notifications() {
     # Only emitted notifications get state files — unemitted ones retry next run.
     local max_notif_per_run=5
 
+    # Notification state files store the most recently seen `updated_at`. GitHub
+    # re-uses the same notification ID across follow-up comments on the same
+    # thread (only `updated_at` advances), so a presence-only check would dedupe
+    # legitimate follow-up activity. Re-emit when `updated_at` is strictly newer
+    # than the stored timestamp.
     if [ "$FORMAT" = "jsonl" ]; then
         local _notif_emitted=0
         echo "$notifs" | jq -c '{
             id: .id,
+            updated_at: .updated_at,
             type: "notification",
             repo: .repository.full_name,
             number: (.subject.url // "" | split("/") | last | tonumber? // 0),
             title: .subject.title,
             detail: .reason
         }' 2>/dev/null | while IFS= read -r item; do
-            local notif_id state_file
+            local notif_id notif_updated state_file prior
             notif_id=$(echo "$item" | jq -r '.id')
+            notif_updated=$(echo "$item" | jq -r '.updated_at')
             state_file="$STATE_DIR/notif-${notif_id}.state"
-            if [ ! -f "$state_file" ]; then
+            prior=""
+            [ -f "$state_file" ] && prior=$(cat "$state_file" 2>/dev/null || true)
+            # Re-emit if no state file yet OR stored timestamp is older than current.
+            # String comparison works on ISO-8601 timestamps.
+            if [ -z "$prior" ] || [ "$prior" \< "$notif_updated" ]; then
                 _notif_emitted=$((_notif_emitted + 1))
                 if [ "$_notif_emitted" -le "$max_notif_per_run" ]; then
-                    touch "$state_file"
-                    # Strip the id field before emitting (consumer doesn't need it)
-                    echo "$item" | jq -c 'del(.id)'
+                    printf '%s' "$notif_updated" > "$state_file"
+                    # Strip id and updated_at before emitting (consumer doesn't need them)
+                    echo "$item" | jq -c 'del(.id, .updated_at)'
                 fi
             fi
         done
     else
         # Count new notifications and create state files (process substitution avoids subshell)
         local new_count=0
-        while IFS= read -r notif_id; do
-            if [ ! -f "$STATE_DIR/notif-${notif_id}.state" ]; then
-                touch "$STATE_DIR/notif-${notif_id}.state"
+        while IFS= read -r line; do
+            local notif_id notif_updated state_file prior
+            notif_id=${line%%$'\t'*}
+            notif_updated=${line#*$'\t'}
+            state_file="$STATE_DIR/notif-${notif_id}.state"
+            prior=""
+            [ -f "$state_file" ] && prior=$(cat "$state_file" 2>/dev/null || true)
+            if [ -z "$prior" ] || [ "$prior" \< "$notif_updated" ]; then
+                printf '%s' "$notif_updated" > "$state_file"
                 new_count=$((new_count + 1))
             fi
-        done < <(echo "$notifs" | jq -r '.id' 2>/dev/null)
+        done < <(echo "$notifs" | jq -r '"\(.id)\t\(.updated_at)"' 2>/dev/null)
         echo "$new_count"
     fi
 }

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -56,9 +56,12 @@
 #   open PR (issue comments endpoint). HEAD SHA comes from fetch_pr_data().
 #
 #   Notifications: Filters for actionable reasons (review_requested, mention,
-#   assign, author, comment). State-tracked by notification ID. State files
-#   accumulate in STATE_DIR/notif-*.state. GitHub notifications clear when
-#   marked as read upstream, so old state files become inert.
+#   assign, author, comment). State-tracked by notification ID + updated_at:
+#   follow-ups on the same thread reuse the same ID but advance updated_at, so
+#   the gate re-emits when updated_at advances. State files store the last-seen
+#   updated_at timestamp. State files accumulate in STATE_DIR/notif-*.state.
+#   GitHub notifications clear when marked as read upstream, so old state files
+#   become inert.
 #
 #   Item grouping: This gate emits one item per event (a PR can produce separate
 #   pr_update, ci_failure, and merge_conflict items). Callers that dispatch
@@ -736,9 +739,10 @@ check_notifications() {
             if [ -z "$prior" ] || [ "$prior" \< "$notif_updated" ]; then
                 _notif_emitted=$((_notif_emitted + 1))
                 if [ "$_notif_emitted" -le "$max_notif_per_run" ]; then
-                    printf '%s' "$notif_updated" > "$state_file"
-                    # Strip id and updated_at before emitting (consumer doesn't need them)
+                    # Emit first so a jq failure leaves the state file untouched and the
+                    # notification is retried on the next run (emit-before-persist semantics).
                     echo "$item" | jq -c 'del(.id, .updated_at)'
+                    printf '%s' "$notif_updated" > "$state_file"
                 fi
             fi
         done

--- a/tests/test_activity_gate_notif_followup.py
+++ b/tests/test_activity_gate_notif_followup.py
@@ -1,0 +1,223 @@
+"""Tests for notification follow-up re-emit in activity-gate.sh.
+
+GitHub re-uses the same notification ID across follow-up comments on the same
+thread (only ``updated_at`` advances). Earlier the gate stored a presence-only
+state file, which silently dropped every follow-up. The fix: state file stores
+the most recently seen ``updated_at`` and re-emits on advance.
+
+Regression for gptme-cloud#195 (Erik's follow-up went unnoticed for 12+ hours
+because the original outage-thread mention had already burned the state file).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "github" / "activity-gate.sh"
+
+NOTIF_ID = "23717308353"
+NOTIF_REPO = "gptme/gptme-cloud"
+NOTIF_NUMBER = 195
+
+# Fake gh stub: emits a single mention notification with a parametric updated_at.
+# All other gh calls return empty so the gate proceeds quickly to the
+# notifications check.
+FAKE_GH = r"""#!/usr/bin/env python3
+from __future__ import annotations
+import json, os, subprocess as sp, sys
+
+argv = sys.argv[1:]
+notif_updated = os.environ.get("TEST_NOTIF_UPDATED_AT", "2026-04-29T20:40:00Z")
+notif_id      = os.environ.get("TEST_NOTIF_ID", "23717308353")
+notif_repo    = os.environ.get("TEST_NOTIF_REPO", "gptme/gptme-cloud")
+notif_number  = int(os.environ.get("TEST_NOTIF_NUMBER", "195"))
+
+def apply_jq(data, jq_expr):
+    if not jq_expr:
+        return json.dumps(data)
+    r = sp.run(["jq", "-r", jq_expr],
+               input=json.dumps(data), capture_output=True, text=True)
+    return r.stdout.strip()
+
+def parse_endpoint_and_jq(args):
+    endpoint, jq_expr = "", ""
+    i = 1
+    while i < len(args):
+        if args[i] == "--jq" and i + 1 < len(args):
+            jq_expr = args[i + 1]; i += 2; continue
+        if args[i] in ("-f", "-F", "-H", "-q") and i + 1 < len(args):
+            i += 2; continue
+        if args[i] in ("--paginate", "--silent"):
+            i += 1; continue
+        if args[i].startswith("--"):
+            i += 1; continue
+        if args[i] != "api":
+            endpoint = args[i]
+        i += 1
+    return endpoint, jq_expr
+
+if not argv:
+    sys.exit(2)
+
+if argv[0] == "api":
+    endpoint, jq_expr = parse_endpoint_and_jq(argv)
+    if "notifications" in endpoint:
+        notifs = [{
+            "id": notif_id,
+            "reason": "mention",
+            "updated_at": notif_updated,
+            "subject": {
+                "title": "outage: fleet.gptme.ai",
+                "url": f"https://api.github.com/repos/{notif_repo}/issues/{notif_number}",
+                "type": "Issue",
+            },
+            "repository": {"full_name": notif_repo},
+        }]
+        print(apply_jq(notifs, jq_expr))
+        sys.exit(0)
+    print("[]")
+    sys.exit(0)
+
+# Everything else returns empty — gate has nothing else to find.
+sys.exit(0)
+"""
+
+
+def _run_gate(
+    tmp: Path,
+    state_dir: Path,
+    notif_updated: str,
+) -> subprocess.CompletedProcess[str]:
+    fake_gh = tmp / "gh"
+    fake_gh.write_text(FAKE_GH)
+    fake_gh.chmod(fake_gh.stat().st_mode | stat.S_IXUSR)
+
+    env = os.environ.copy()
+    env["TEST_NOTIF_UPDATED_AT"] = notif_updated
+    env["TEST_NOTIF_ID"] = NOTIF_ID
+    env["TEST_NOTIF_REPO"] = NOTIF_REPO
+    env["TEST_NOTIF_NUMBER"] = str(NOTIF_NUMBER)
+    env["PATH"] = f"{tmp}:{env['PATH']}"
+
+    return subprocess.run(
+        [
+            str(SCRIPT),
+            "--author",
+            "test-author",
+            "--org",
+            "gptme",
+            "--repo",
+            NOTIF_REPO,
+            "--state-dir",
+            str(state_dir),
+            "--format",
+            "jsonl",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _emitted_notifications(stdout: str) -> list[dict]:
+    items = []
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if obj.get("type") == "notification":
+            items.append(obj)
+    return items
+
+
+def test_first_emit_creates_state_with_timestamp() -> None:
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+
+        result = _run_gate(tmp, state_dir, "2026-04-29T20:40:00Z")
+        assert result.returncode in (0, 1), result.stderr
+
+        emitted = _emitted_notifications(result.stdout)
+        assert len(emitted) == 1
+        assert emitted[0]["repo"] == NOTIF_REPO
+        assert emitted[0]["number"] == NOTIF_NUMBER
+
+        state_file = state_dir / f"notif-{NOTIF_ID}.state"
+        assert state_file.exists()
+        # State now records the timestamp, not just presence.
+        assert state_file.read_text().strip() == "2026-04-29T20:40:00Z"
+
+
+def test_same_updated_at_does_not_reemit() -> None:
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+
+        # Prior run already saw this exact updated_at.
+        (state_dir / f"notif-{NOTIF_ID}.state").write_text("2026-04-29T20:40:00Z")
+
+        result = _run_gate(tmp, state_dir, "2026-04-29T20:40:00Z")
+        assert result.returncode in (0, 1), result.stderr
+
+        emitted = _emitted_notifications(result.stdout)
+        assert emitted == [], (
+            "Expected no re-emit when updated_at unchanged, got: " f"{emitted}"
+        )
+
+
+def test_advanced_updated_at_reemits_followup() -> None:
+    """Erik's #195 case: notification ID stable, updated_at advanced → re-emit."""
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+
+        # Original mention from yesterday already processed.
+        (state_dir / f"notif-{NOTIF_ID}.state").write_text("2026-04-29T20:40:00Z")
+
+        # Erik posts a follow-up comment 12h later — same notif ID, newer updated_at.
+        result = _run_gate(tmp, state_dir, "2026-04-30T10:01:28Z")
+        assert result.returncode in (0, 1), result.stderr
+
+        emitted = _emitted_notifications(result.stdout)
+        assert len(emitted) == 1, (
+            "Expected re-emit when updated_at advances, got: " f"{emitted}"
+        )
+        assert emitted[0]["number"] == NOTIF_NUMBER
+
+        # State file rolled forward to the newer timestamp.
+        assert (state_dir / f"notif-{NOTIF_ID}.state").read_text().strip() == (
+            "2026-04-30T10:01:28Z"
+        )
+
+
+def test_older_updated_at_does_not_reemit() -> None:
+    """Defensive: a stale fetch returning an older updated_at must not re-emit."""
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+
+        (state_dir / f"notif-{NOTIF_ID}.state").write_text("2026-04-30T10:01:28Z")
+
+        result = _run_gate(tmp, state_dir, "2026-04-29T20:40:00Z")
+        assert result.returncode in (0, 1), result.stderr
+
+        assert _emitted_notifications(result.stdout) == []
+        # State unchanged.
+        assert (state_dir / f"notif-{NOTIF_ID}.state").read_text().strip() == (
+            "2026-04-30T10:01:28Z"
+        )


### PR DESCRIPTION
## Summary
- Activity gate now stores `updated_at` per notification id and re-emits when it advances
- Fixes silent drop of follow-up comments on already-reacted-to notification threads
- Migration is automatic — existing empty presence-only state files trigger re-emit on first run

## Why
GitHub re-uses the same notification ID across follow-up comments on the same thread; only `updated_at` advances. The previous `notif-{id}.state` presence-only check silently dropped every follow-up after the first reaction.

Real-world failure (12+ hours): Erik posted an outage report on gptme-cloud#195 yesterday (mention notification ID `23717308353`). Bob reacted, state file created. Erik's follow-up `Hmm, I just attempted a cloud connect from android app but still getting 500 from nginx` 12h later was never seen by project monitoring because the state file already existed.

## Fix shape
- `check_notifications` now compares stored `updated_at` against current; re-emits when current is strictly newer (string comparison on ISO-8601 is correct)
- Markdown count path mirrored
- 4 new tests in `tests/test_activity_gate_notif_followup.py`: first emit, dedupe, follow-up re-emit, defensive older-timestamp guard

## Test plan
- [x] `uv run pytest gptme-contrib/tests/test_activity_gate_notif_followup.py` — 4 passed
- [x] `uv run pytest gptme-contrib/tests/test_activity_gate_cache.py` — existing tests still pass
- [x] `shellcheck -S warning scripts/github/activity-gate.sh` — clean
- [x] Project-monitoring next cycle should re-fire on the live #195 notification (state file currently empty, treated as no-prior → re-emit)

## Companion PR
ErikBjare/bob — extends `assigned_issue_pending_reply.py` to scan author-Bob issues, not just assigned. Belt-and-suspenders for the same failure class. Will link once submitted.