### PR TITLE
fix(lessons): broaden keywords for two trajectory-silent lessons

### DIFF
--- a/lessons/patterns/persist-before-noting.md
+++ b/lessons/patterns/persist-before-noting.md
@@ -4,6 +4,11 @@ match:
     - "noted for future reference"
     - "I'll remember this"
     - "will keep this in mind"
+    - "good to know"
+    - "thanks for the clarification"
+    - "won't forget"
+    - "for next time"
+    - "should write this down"
 status: active
 ---
 

--- a/lessons/tools/check-cli---help-before-readin.md
+++ b/lessons/tools/check-cli---help-before-readin.md
@@ -4,6 +4,11 @@ match:
     - "examine source code to understand CLI"
     - "planning complex workaround"
     - "making assumptions about CLI options"
+    - "read the source to find the flag"
+    - "doesn't have a flag for"
+    - "wrap the command to add"
+    - "reading source to figure out"
+    - "before patching the wrapper"
 status: active
 ---
 


### PR DESCRIPTION
## Summary

Two lessons in this repo hadn't fired in 30+ days of recent agent session trajectories because their keywords were either too narrow or didn't match natural session text:

- **`lessons/patterns/persist-before-noting.md`** — added common English acknowledgments (\"good to know\", \"thanks for the clarification\", \"won't forget\", \"for next time\", \"should write this down\") that signal an insight is about to be lost without persistence.

- **`lessons/tools/check-cli---help-before-readin.md`** — added natural phrasings of the anti-pattern (\"read the source to find the flag\", \"doesn't have a flag for\", \"wrap the command to add\", \"reading source to figure out\", \"before patching the wrapper\").

## Why

Both lessons appeared on the trajectory-silent list from `scripts/lesson-keyword-journal-crossref.py --days 14`. Originally the keywords described the **failure mode in the lesson author's voice** rather than what an agent would actually type when in the failure mode. Broadening to common phrasings should let them fire in real situations.

## Out of scope

- `lessons/workflow/pre-issue-creation-checklist.md` is also trajectory-silent but its structural format is missing required sections (pre-existing issue, unrelated to keywords). Keeping that fix separate.

## Test plan

- [ ] Pre-commit hooks pass locally (✅ ran via `prek`)
- [ ] Re-run `lesson-keyword-journal-crossref.py` after merge to confirm the two lessons drop from the silent list