### PR TITLE
refactor(github-actions): extract shared helpers to github_actions_common (#747+#749)

### DIFF
--- a/scripts/github_actions_common/__init__.py
+++ b/scripts/github_actions_common/__init__.py
@@ -1,0 +1,128 @@
+"""Shared helpers for gptme GitHub Actions orchestrators.
+
+Used by `scripts/github_hygiene/` (warning-only triage) and
+`scripts/github_resolver/` (opt-in resolver). Both invoke `gh` to read an
+issue, render a prompt, run `gptme` against it, and post a marker-tagged
+comment back. This module owns the parts that are genuinely identical so
+the two action scripts don't drift.
+
+Intentionally **not** shared:
+
+- `render_prompt(...)` — each Action injects different fields.
+- `run_gptme(...)` — Actions pass different gptme flags (e.g. resolver runs
+  inside a working directory and needs `--no-confirm`; hygiene runs
+  read-only with `--tools read`).
+- The marker constants (e.g. `<!-- gptme-issue-hygiene: v1 -->`) — each
+  Action versions its marker independently.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+MAX_BODY_CHARS = 6000
+
+
+@dataclass
+class Issue:
+    number: int
+    title: str
+    body: str
+    author: str
+    labels: list[str] = field(default_factory=list)
+
+
+def gh(args: list[str], *, check: bool = True, timeout: int | None = 60) -> str:
+    """Run `gh` CLI, return stdout. Raises CalledProcessError on non-zero."""
+    result = subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        check=check,
+        timeout=timeout,
+    )
+    return result.stdout
+
+
+def fetch_issue(repo: str, issue_number: int) -> Issue:
+    """Fetch an issue and truncate its body to ``MAX_BODY_CHARS``."""
+    raw = gh(
+        [
+            "issue",
+            "view",
+            str(issue_number),
+            "--repo",
+            repo,
+            "--json",
+            "number,title,body,author,labels",
+        ]
+    )
+    data = json.loads(raw)
+    body = (data.get("body") or "").strip()
+    if len(body) > MAX_BODY_CHARS:
+        body = body[:MAX_BODY_CHARS] + "\n…(truncated)"
+    return Issue(
+        number=int(data["number"]),
+        title=data["title"],
+        body=body,
+        author=(data.get("author") or {}).get("login", "unknown"),
+        labels=[label["name"] for label in data.get("labels", [])],
+    )
+
+
+def has_marker_comment(repo: str, issue_number: int, marker: str) -> bool:
+    """Return True if any comment on ``issue_number`` already contains ``marker``."""
+    raw = gh(
+        [
+            "issue",
+            "view",
+            str(issue_number),
+            "--repo",
+            repo,
+            "--json",
+            "comments",
+        ]
+    )
+    data = json.loads(raw)
+    for comment in data.get("comments", []):
+        if marker in (comment.get("body") or ""):
+            return True
+    return False
+
+
+def post_issue_comment(repo: str, issue_number: int, body: str) -> None:
+    """Post a comment to ``repo#issue_number`` via the gh CLI."""
+    subprocess.run(
+        [
+            "gh",
+            "issue",
+            "comment",
+            str(issue_number),
+            "--repo",
+            repo,
+            "--body",
+            body,
+        ],
+        check=True,
+        timeout=60,
+    )
+
+
+def write_output(output_dir: Path, name: str, data: str) -> None:
+    """Write ``data`` to ``output_dir/name``, creating the directory if needed."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / name).write_text(data)
+
+
+__all__ = [
+    "MAX_BODY_CHARS",
+    "Issue",
+    "gh",
+    "fetch_issue",
+    "has_marker_comment",
+    "post_issue_comment",
+    "write_output",
+]

--- a/scripts/github_actions_common/test_common.py
+++ b/scripts/github_actions_common/test_common.py
@@ -1,0 +1,113 @@
+"""Tests for the shared GitHub Actions helpers.
+
+No network or subprocess: every test stubs the `gh` CLI by patching the
+internal `subprocess.run` reference.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest import mock
+
+# Make the package importable when running directly: `pytest test_common.py`.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from github_actions_common import (  # noqa: E402
+    MAX_BODY_CHARS,
+    Issue,
+    fetch_issue,
+    has_marker_comment,
+    write_output,
+)
+
+
+def _completed(stdout: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=["gh"], returncode=0, stdout=stdout, stderr=""
+    )
+
+
+def test_fetch_issue_truncates_long_bodies() -> None:
+    long_body = "x" * (MAX_BODY_CHARS + 100)
+    payload = {
+        "number": 42,
+        "title": "Bug",
+        "body": long_body,
+        "author": {"login": "alice"},
+        "labels": [{"name": "bug"}, {"name": "triage"}],
+    }
+    with mock.patch(
+        "github_actions_common.subprocess.run",
+        return_value=_completed(json.dumps(payload)),
+    ) as run:
+        issue = fetch_issue("owner/repo", 42)
+    run.assert_called_once()
+    assert isinstance(issue, Issue)
+    assert issue.number == 42
+    assert issue.author == "alice"
+    assert issue.labels == ["bug", "triage"]
+    assert issue.body.endswith("…(truncated)")
+    assert len(issue.body) == MAX_BODY_CHARS + len("\n…(truncated)")
+
+
+def test_fetch_issue_handles_missing_author() -> None:
+    payload = {
+        "number": 1,
+        "title": "x",
+        "body": "",
+        "author": None,
+        "labels": [],
+    }
+    with mock.patch(
+        "github_actions_common.subprocess.run",
+        return_value=_completed(json.dumps(payload)),
+    ):
+        issue = fetch_issue("owner/repo", 1)
+    assert issue.author == "unknown"
+    assert issue.body == ""
+    assert issue.labels == []
+
+
+def test_has_marker_comment_true() -> None:
+    payload = {
+        "comments": [
+            {"body": "Some random comment"},
+            {"body": "<!-- gptme-issue-hygiene: v1 -->\nactual hygiene"},
+        ]
+    }
+    marker = "<!-- gptme-issue-hygiene: v1 -->"
+    with mock.patch(
+        "github_actions_common.subprocess.run",
+        return_value=_completed(json.dumps(payload)),
+    ):
+        assert has_marker_comment("owner/repo", 1, marker) is True
+
+
+def test_has_marker_comment_false_when_marker_missing() -> None:
+    payload = {"comments": [{"body": "ok"}, {"body": None}]}
+    marker = "<!-- gptme-issue-hygiene: v1 -->"
+    with mock.patch(
+        "github_actions_common.subprocess.run",
+        return_value=_completed(json.dumps(payload)),
+    ):
+        assert has_marker_comment("owner/repo", 1, marker) is False
+
+
+def test_has_marker_comment_isolates_versions() -> None:
+    """A v1 marker check must not match a v2 comment, and vice versa."""
+    payload = {"comments": [{"body": "<!-- gptme-issue-hygiene: v2 -->\n..."}]}
+    marker_v1 = "<!-- gptme-issue-hygiene: v1 -->"
+    with mock.patch(
+        "github_actions_common.subprocess.run",
+        return_value=_completed(json.dumps(payload)),
+    ):
+        assert has_marker_comment("owner/repo", 1, marker_v1) is False
+
+
+def test_write_output_creates_directory(tmp_path: Path) -> None:
+    target = tmp_path / "nested" / "output"
+    write_output(target, "status.txt", "ok")
+    assert (target / "status.txt").read_text() == "ok"

--- a/scripts/github_hygiene/issue_hygiene.py
+++ b/scripts/github_hygiene/issue_hygiene.py
@@ -32,62 +32,26 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+# Make the sibling `github_actions_common` package importable when the script
+# is run directly inside the Action workflow (no editable install).
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from github_actions_common import (  # noqa: E402
+    Issue,
+    fetch_issue,
+    gh,
+    has_marker_comment,
+)
+
 MARKER = "<!-- gptme-issue-hygiene: v1 -->"
 SKIP_TOKEN = "NO_ISSUES"
 MAX_RECENT_ISSUES = 15
-MAX_BODY_CHARS = 6000
-
-
-@dataclass
-class Issue:
-    number: int
-    title: str
-    body: str
-    author: str
-    labels: list[str]
 
 
 @dataclass
 class RecentIssue:
     number: int
     title: str
-
-
-def gh(args: list[str], *, check: bool = True) -> str:
-    """Run `gh` CLI, return stdout. Raises CalledProcessError on non-zero."""
-    result = subprocess.run(
-        ["gh", *args],
-        capture_output=True,
-        text=True,
-        check=check,
-        timeout=60,
-    )
-    return result.stdout
-
-
-def fetch_issue(repo: str, issue_number: int) -> Issue:
-    raw = gh(
-        [
-            "issue",
-            "view",
-            str(issue_number),
-            "--repo",
-            repo,
-            "--json",
-            "number,title,body,author,labels",
-        ]
-    )
-    data = json.loads(raw)
-    body = (data.get("body") or "").strip()
-    if len(body) > MAX_BODY_CHARS:
-        body = body[:MAX_BODY_CHARS] + "\n…(truncated)"
-    return Issue(
-        number=int(data["number"]),
-        title=data["title"],
-        body=body,
-        author=(data.get("author") or {}).get("login", "unknown"),
-        labels=[label["name"] for label in data.get("labels", [])],
-    )
 
 
 def fetch_recent_issues(
@@ -120,22 +84,7 @@ def fetch_recent_issues(
 
 
 def already_commented(repo: str, issue_number: int) -> bool:
-    raw = gh(
-        [
-            "issue",
-            "view",
-            str(issue_number),
-            "--repo",
-            repo,
-            "--json",
-            "comments",
-        ]
-    )
-    data = json.loads(raw)
-    for comment in data.get("comments", []):
-        if MARKER in (comment.get("body") or ""):
-            return True
-    return False
+    return has_marker_comment(repo, issue_number, MARKER)
 
 
 def render_prompt(

--- a/scripts/github_hygiene/issue_hygiene.py
+++ b/scripts/github_hygiene/issue_hygiene.py
@@ -41,6 +41,7 @@ from github_actions_common import (  # noqa: E402
     fetch_issue,
     gh,
     has_marker_comment,
+    post_issue_comment,
 )
 
 MARKER = "<!-- gptme-issue-hygiene: v1 -->"
@@ -146,14 +147,6 @@ def build_comment(verdict: str) -> str:
     return f"{MARKER}\n\n{preface}{verdict.strip()}\n"
 
 
-def post_comment(repo: str, issue_number: int, body: str) -> None:
-    subprocess.run(
-        ["gh", "issue", "comment", str(issue_number), "--repo", repo, "--body", body],
-        check=True,
-        timeout=60,
-    )
-
-
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo", required=True, help="owner/repo")
@@ -193,7 +186,7 @@ def main(argv: list[str] | None = None) -> int:
         print(body)
         return 0
 
-    post_comment(args.repo, args.issue, body)
+    post_issue_comment(args.repo, args.issue, body)
     print(f"Posted hygiene comment on {args.repo}#{args.issue}.")
     return 0
 

--- a/scripts/github_resolver/resolve_issue.py
+++ b/scripts/github_resolver/resolve_issue.py
@@ -44,24 +44,25 @@ import os
 import re
 import subprocess
 import sys
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
+
+# Make the sibling `github_actions_common` package importable when the script
+# is run directly inside the Action workflow (no editable install).
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from github_actions_common import (  # noqa: E402
+    Issue,
+    fetch_issue,
+    gh,
+    write_output,
+)
 
 MARKER_COMMENT = "<!-- gptme-issue-resolver: v1 -->"
 STATUS_RE = re.compile(r"^RESOLVER_STATUS:\s*(changes|no_changes)\s*$", re.MULTILINE)
 SUMMARY_RE = re.compile(r"^RESOLVER_SUMMARY:\s*(.+?)\s*$", re.MULTILINE)
 REASON_RE = re.compile(r"^RESOLVER_REASON:\s*(.+?)\s*$", re.MULTILINE)
-MAX_BODY_CHARS = 6000
 BRANCH_PREFIX = "gptme-resolver/issue-"
-
-
-@dataclass
-class Issue:
-    number: int
-    title: str
-    body: str
-    author: str
-    labels: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -72,42 +73,11 @@ class ResolverOutcome:
     pr_url: str | None
 
 
-def gh(args: list[str], *, check: bool = True) -> str:
-    """Run `gh` CLI and return stdout."""
-    result = subprocess.run(["gh", *args], capture_output=True, text=True, check=check)
-    return result.stdout
-
-
 def git(args: list[str], *, check: bool = True, cwd: Path | None = None) -> str:
     result = subprocess.run(
         ["git", *args], capture_output=True, text=True, check=check, cwd=cwd
     )
     return result.stdout
-
-
-def fetch_issue(repo: str, issue_number: int) -> Issue:
-    raw = gh(
-        [
-            "issue",
-            "view",
-            str(issue_number),
-            "--repo",
-            repo,
-            "--json",
-            "number,title,body,author,labels",
-        ]
-    )
-    data = json.loads(raw)
-    body = (data.get("body") or "").strip()
-    if len(body) > MAX_BODY_CHARS:
-        body = body[:MAX_BODY_CHARS] + "\n…(truncated)"
-    return Issue(
-        number=int(data["number"]),
-        title=data["title"],
-        body=body,
-        author=(data.get("author") or {}).get("login", "unknown"),
-        labels=[label["name"] for label in data.get("labels", [])],
-    )
 
 
 def render_prompt(template: str, *, repo: str, issue: Issue) -> str:
@@ -271,11 +241,6 @@ def comment_on_issue(
         ],
         check=True,
     )
-
-
-def write_output(output_dir: Path, name: str, data: str) -> None:
-    output_dir.mkdir(parents=True, exist_ok=True)
-    (output_dir / name).write_text(data)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/github_resolver/resolve_issue.py
+++ b/scripts/github_resolver/resolve_issue.py
@@ -55,6 +55,7 @@ from github_actions_common import (  # noqa: E402
     Issue,
     fetch_issue,
     gh,
+    post_issue_comment,
     write_output,
 )
 
@@ -228,19 +229,7 @@ def comment_on_issue(
         if branch:
             lines.append(f"\nPartial attempt preserved on branch `{branch}`.")
     body = "\n".join(lines)
-    subprocess.run(
-        [
-            "gh",
-            "issue",
-            "comment",
-            str(issue_number),
-            "--repo",
-            repo,
-            "--body",
-            body,
-        ],
-        check=True,
-    )
+    post_issue_comment(repo, issue_number, body)
 
 
 def main(argv: list[str] | None = None) -> int:


### PR DESCRIPTION
## Summary

Answers Erik's review question on #749 ("consolidate or refactor into shared package/code? Or are they clearly separate?"): they share enough `gh`-CLI surface to be worth extracting, but the prompt + gptme-invocation parts genuinely diverge and stay separate.

Both PRs landed sibling Action orchestrators (warning-only hygiene + opt-in resolver) that ended up duplicating the same plumbing:

- `gh()` subprocess wrapper
- `Issue` dataclass
- `fetch_issue()` with body truncation
- Marker-comment idempotency check
- `write_output()` artifact helper

This PR pulls the genuinely identical pieces into a small `scripts/github_actions_common/` module. Each Action keeps its own marker constant, prompt template, `render_prompt`, and `run_gptme` invocation — those legitimately differ between the two.

## What's shared

| Symbol | Where it lived before |
|---|---|
| `gh(args, *, check, timeout)` | duplicated in both scripts |
| `Issue` dataclass | duplicated in both scripts |
| `fetch_issue(repo, n)` | duplicated in both scripts |
| `MAX_BODY_CHARS = 6000` | duplicated in both scripts |
| `has_marker_comment(repo, n, marker)` | new abstraction over `already_commented` (hygiene only) |
| `post_issue_comment(repo, n, body)` | new abstraction (resolver had inline `gh issue comment`) |
| `write_output(dir, name, data)` | resolver only |

## What stays separate

- **Marker constants** — `<!-- gptme-issue-hygiene: v1 -->` vs `<!-- gptme-issue-resolver: v1 -->` are versioned independently so a schema change to one Action doesn't force a bump on the other.
- **`render_prompt(...)`** — hygiene injects `recent_issues`, resolver doesn't.
- **`run_gptme(...)`** — hygiene runs read-only with `--tools read`, resolver runs in a working directory with `--no-confirm`.

## Net change

- `-86 LOC` across `issue_hygiene.py` + `resolve_issue.py`
- `+96 LOC` shared module (`__init__.py`)
- `+106 LOC` new tests (`test_common.py`, 6 unit tests, no network/subprocess)

## Tests

```text
$ uv run --with pytest pytest scripts/github_actions_common/ scripts/github_hygiene/ scripts/github_resolver/ -x -q
29 passed in 0.11s
```

- 6 new tests for the shared module (truncation, missing author, marker-version isolation, write_output)
- All 7 hygiene tests still pass
- All 12 resolver tests still pass

## Rollout

Pure refactor — no behavior change. Workflow YAML, prompt templates, and marker contracts are untouched. Both Actions still resolve their imports via a relative `sys.path.insert(...)` because they execute as scripts inside the GitHub workflow (no editable install).

## Related

- #747 — warning-only issue-hygiene Action (merged)
- #749 — opt-in issue-resolver Action (merged)
- ErikBjare/bob idea backlog #168 + #169