### PR TITLE
fix(voice): add IIR anti-aliasing pre-filter before 24kHz→8kHz downsample

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/audio.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/audio.py
@@ -24,6 +24,9 @@ class AudioConverter:
         # Keyed by input_rate so Twilio (8kHz) and Browser (16kHz) paths
         # don't corrupt each other's resampler state when called on the same instance.
         self._resample_states: dict[int, tuple | None] = {}
+        # Pre-filter state persisted across calls to avoid step-response transients
+        # at chunk boundaries during continuous streaming.
+        self._prefilter_state: tuple | None = None
 
     def pcm_to_openai(self, pcm_data: bytes, input_rate: int) -> bytes:
         """
@@ -91,13 +94,13 @@ class AudioConverter:
         # This attenuates 5–12kHz spectral energy by 3–6dB, reducing fold-back
         # artifacts when downsampling 3x to 8kHz. Voice content (0–3.4kHz) loses
         # at most ~2dB. Uses no extra dependencies (audioop is stdlib).
-        pcm_filtered, _ = audioop.ratecv(
+        pcm_filtered, self._prefilter_state = audioop.ratecv(
             pcm_data,
             2,  # 2 bytes per sample (16-bit)
             1,  # mono
             self.OPENAI_RATE,
             self.OPENAI_RATE,
-            None,
+            self._prefilter_state,
             2,  # weightA
             1,  # weightB
         )

--- a/packages/gptme-voice/src/gptme_voice/realtime/audio.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/audio.py
@@ -86,9 +86,25 @@ class AudioConverter:
         Returns:
             μ-law encoded audio at 8kHz
         """
+        # Anti-aliasing pre-filter: gentle IIR low-pass at 24kHz before downsampling.
+        # weightA=2, weightB=1 gives fc≈4.7kHz (-3dB) at 24kHz sample rate.
+        # This attenuates 5–12kHz spectral energy by 3–6dB, reducing fold-back
+        # artifacts when downsampling 3x to 8kHz. Voice content (0–3.4kHz) loses
+        # at most ~2dB. Uses no extra dependencies (audioop is stdlib).
+        pcm_filtered, _ = audioop.ratecv(
+            pcm_data,
+            2,  # 2 bytes per sample (16-bit)
+            1,  # mono
+            self.OPENAI_RATE,
+            self.OPENAI_RATE,
+            None,
+            2,  # weightA
+            1,  # weightB
+        )
+
         # Resample from 24kHz to 8kHz (3x downsample)
         pcm_8k, _ = audioop.ratecv(
-            pcm_data,
+            pcm_filtered,
             2,  # 2 bytes per sample (16-bit)
             1,  # mono
             self.OPENAI_RATE,
@@ -97,9 +113,7 @@ class AudioConverter:
         )
 
         # Convert linear PCM to μ-law
-        mulaw_data = audioop.lin2ulaw(pcm_8k, 2)
-
-        return mulaw_data
+        return audioop.lin2ulaw(pcm_8k, 2)
 
     @staticmethod
     def pcm_to_base64(pcm_data: bytes) -> str:

--- a/packages/gptme-voice/tests/test_audio.py
+++ b/packages/gptme-voice/tests/test_audio.py
@@ -36,16 +36,15 @@ class TestOpenaiToTwilio:
         assert len(result) == 80
 
     def test_silence_stays_silence(self):
-        """Silent input produces silent μ-law output (all bytes = 0xFF or 0x7F)."""
+        """Silent input produces silent μ-law output (all bytes = 0xFF)."""
         converter = AudioConverter()
         pcm = bytes(480)  # 480 zero bytes = silence
         result = converter.openai_to_twilio(pcm)
-        # μ-law silence is 0xFF (positive zero) or 0x7F (negative zero)
+        # All-zero PCM encodes as μ-law positive silence (0xFF only)
         unique = set(result)
-        assert unique <= {
-            0xFF,
-            0x7F,
-        }, f"Non-silent bytes in output: {unique - {0xFF, 0x7F}}"
+        assert unique == {
+            0xFF
+        }, f"Expected only μ-law positive silence (0xFF), got: {unique}"
 
     def test_valid_mulaw_output(self):
         """Output can be decoded back to PCM without error."""

--- a/packages/gptme-voice/tests/test_audio.py
+++ b/packages/gptme-voice/tests/test_audio.py
@@ -1,0 +1,119 @@
+"""Tests for AudioConverter format conversion."""
+
+import audioop
+import math
+import struct
+
+from gptme_voice.realtime.audio import AudioConverter
+
+
+def sine_wave_pcm(freq_hz: float, duration_s: float, sample_rate: int) -> bytes:
+    """Generate a mono 16-bit PCM sine wave."""
+    n = int(sample_rate * duration_s)
+    samples = [
+        int(32767 * math.sin(2 * math.pi * freq_hz * i / sample_rate)) for i in range(n)
+    ]
+    return struct.pack(f"<{n}h", *samples)
+
+
+def rms_energy(pcm_bytes: bytes) -> float:
+    """Return RMS energy of a 16-bit PCM buffer."""
+    n = len(pcm_bytes) // 2
+    if n == 0:
+        return 0.0
+    samples = struct.unpack(f"<{n}h", pcm_bytes)
+    return math.sqrt(sum(s * s for s in samples) / n)
+
+
+class TestOpenaiToTwilio:
+    def test_output_length(self):
+        """openai_to_twilio produces 3x fewer bytes (24kHz PCM → 8kHz μ-law)."""
+        converter = AudioConverter()
+        # 10ms at 24kHz = 240 samples = 480 bytes PCM
+        pcm = bytes(480)
+        result = converter.openai_to_twilio(pcm)
+        # 10ms at 8kHz = 80 samples = 80 bytes μ-law
+        assert len(result) == 80
+
+    def test_silence_stays_silence(self):
+        """Silent input produces silent μ-law output (all bytes = 0xFF or 0x7F)."""
+        converter = AudioConverter()
+        pcm = bytes(480)  # 480 zero bytes = silence
+        result = converter.openai_to_twilio(pcm)
+        # μ-law silence is 0xFF (positive zero) or 0x7F (negative zero)
+        unique = set(result)
+        assert unique <= {
+            0xFF,
+            0x7F,
+        }, f"Non-silent bytes in output: {unique - {0xFF, 0x7F}}"
+
+    def test_valid_mulaw_output(self):
+        """Output can be decoded back to PCM without error."""
+        converter = AudioConverter()
+        pcm = sine_wave_pcm(1000, 0.02, AudioConverter.OPENAI_RATE)
+        mulaw = converter.openai_to_twilio(pcm)
+        # Should not raise
+        pcm_back = audioop.ulaw2lin(mulaw, 2)
+        assert len(pcm_back) == len(mulaw) * 2
+
+    def test_antialiasing_attenuates_high_frequencies(self):
+        """A tone above the 8kHz Nyquist has lower energy after anti-aliasing filter."""
+        converter_new = AudioConverter()
+        # 9kHz tone — above Nyquist for 8kHz output, will alias without pre-filter
+        high_freq_pcm = sine_wave_pcm(9000, 0.05, AudioConverter.OPENAI_RATE)
+        mulaw_filtered = converter_new.openai_to_twilio(high_freq_pcm)
+        pcm_filtered = audioop.ulaw2lin(mulaw_filtered, 2)
+        energy_filtered = rms_energy(pcm_filtered)
+
+        # Without pre-filter: simulate raw downsample (direct ratecv + ulaw)
+        pcm_8k_raw, _ = audioop.ratecv(high_freq_pcm, 2, 1, 24000, 8000, None)
+        mulaw_raw = audioop.lin2ulaw(pcm_8k_raw, 2)
+        pcm_raw = audioop.ulaw2lin(mulaw_raw, 2)
+        energy_raw = rms_energy(pcm_raw)
+
+        # Pre-filter should reduce or not increase high-frequency fold-back
+        # (energy_filtered <= energy_raw * 1.05 allows tiny float rounding)
+        assert energy_filtered <= energy_raw * 1.05, (
+            f"Anti-aliasing filter increased high-freq energy: "
+            f"filtered={energy_filtered:.1f} raw={energy_raw:.1f}"
+        )
+
+    def test_voice_frequency_preserved(self):
+        """A 1kHz voice-range tone passes through with reasonable fidelity (< 3dB loss)."""
+        converter = AudioConverter()
+        voice_pcm = sine_wave_pcm(1000, 0.05, AudioConverter.OPENAI_RATE)
+        mulaw = converter.openai_to_twilio(voice_pcm)
+        pcm_back = audioop.ulaw2lin(mulaw, 2)
+        energy_out = rms_energy(pcm_back)
+
+        # Reference: raw downsample without filter
+        pcm_8k_raw, _ = audioop.ratecv(voice_pcm, 2, 1, 24000, 8000, None)
+        mulaw_raw = audioop.lin2ulaw(pcm_8k_raw, 2)
+        pcm_raw_back = audioop.ulaw2lin(mulaw_raw, 2)
+        energy_ref = rms_energy(pcm_raw_back)
+
+        # With pre-filter, voice energy should not drop more than ~3dB (factor 0.7)
+        assert energy_out >= energy_ref * 0.7, (
+            f"Too much voice-range energy loss: "
+            f"filtered={energy_out:.1f} ref={energy_ref:.1f}"
+        )
+
+
+class TestTwilioToOpenai:
+    def test_output_rate(self):
+        """twilio_to_openai upsamples 8kHz μ-law to 24kHz PCM (~3x more bytes)."""
+        converter = AudioConverter()
+        # 10ms at 8kHz = 80 samples μ-law = 80 bytes
+        mulaw = audioop.lin2ulaw(bytes(160), 2)  # 80 samples of silence
+        result = converter.twilio_to_openai(mulaw)
+        # 10ms at 24kHz ≈ 240 samples = 480 bytes PCM; ratecv may produce ±4 bytes
+        assert abs(len(result) - 480) <= 8, f"Expected ~480 bytes, got {len(result)}"
+
+    def test_roundtrip_length(self):
+        """PCM → μ-law → PCM yields correct lengths at each step."""
+        converter = AudioConverter()
+        pcm_original = sine_wave_pcm(500, 0.01, AudioConverter.OPENAI_RATE)
+        mulaw = converter.openai_to_twilio(pcm_original)
+        pcm_back = converter.twilio_to_openai(mulaw)
+        # Length should be ~same as original (minor rounding in ratecv is OK)
+        assert abs(len(pcm_back) - len(pcm_original)) <= 8


### PR DESCRIPTION
## Problem

`audioop.ratecv` performs no anti-aliasing when downsampling 24kHz PCM to 8kHz
(Twilio μ-law). Any spectral energy above 4kHz folds back into the 0–4kHz voice
band and adds audible raspiness — confirmed by Erik on 2026-04-28 Grok-only calls.

## Fix

Add a stateless IIR pre-filter pass at 24kHz before the 3x downsample using
`audioop.ratecv` with `weightA=2, weightB=1` (same in/out rate):

| Frequency | Pre-filter loss | Notes |
|-----------|----------------|-------|
| 1 kHz     | −0.2 dB        | Core voice — negligible loss |
| 3.4 kHz   | −1.9 dB        | Telephony ceiling — acceptable |
| **4.7 kHz** | **−3 dB** | **Design cutoff** |
| 9 kHz     | −4.5 dB        | Alias source zone — attenuated |
| 12 kHz    | −6 dB          | Nyquist — significant attenuation |

**No new dependencies.** `audioop` is stdlib (or `audioop-lts` on Python 3.13+, already listed).

## Tests added (`test_audio.py`)

- `test_output_length` — 480-byte 24kHz input → 80-byte 8kHz μ-law output
- `test_silence_stays_silence` — silence in, silence out
- `test_valid_mulaw_output` — output decodes without error
- `test_antialiasing_attenuates_high_frequencies` — 9kHz tone energy ≤ raw downsample
- `test_voice_frequency_preserved` — 1kHz voice energy loss < 3dB vs raw
- `test_output_rate` / `test_roundtrip_length` — TwilioToOpenai path

## Context

Research comparing Gemini Live API vs Grok for telephony confirmed there's no
provider-level fix: the μ-law 8kHz ceiling is universal. The anti-aliasing
pre-filter is the only tunable in the current code path.

Related: ErikBjare/bob issue `voice-telephony-audio-quality-and-speed` task.