### PR TITLE
fix(git-hooks): allow branch-deletion pushes when current branch lacks upstream

### DIFF
--- a/dotfiles/.config/git/hooks/validate-worktree-tracking.sh
+++ b/dotfiles/.config/git/hooks/validate-worktree-tracking.sh
@@ -22,10 +22,23 @@ fi
 
 # Read push refspecs from stdin early (stdin can only be read once).
 # Pre-push hook receives: local_ref local_sha remote_ref remote_sha
+ZERO="0000000000000000000000000000000000000000"
 push_remote_refs=()
-while read -r _local_ref _local_sha remote_ref _remote_sha; do
+all_deletions=true
+any_pushed=false
+while read -r _local_ref local_sha remote_ref _remote_sha; do
     push_remote_refs+=("$remote_ref")
+    any_pushed=true
+    if [ "$local_sha" != "$ZERO" ]; then
+        all_deletions=false
+    fi
 done
+
+# Skip if push contains only branch deletions (e.g. `git push origin --delete BRANCH`).
+# The current branch's upstream is irrelevant when we're not pushing it.
+if [ "$any_pushed" = true ] && [ "$all_deletions" = true ]; then
+    exit 0
+fi
 
 # Get upstream tracking branch
 upstream=$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || echo "")


### PR DESCRIPTION
## Summary

The `validate-worktree-tracking` pre-push hook checks the current branch's upstream regardless of what's being pushed. This makes `git push origin --delete BRANCH` fail with "Branch X has no upstream" whenever the local checkout happens to be on a branch without an upstream — even though the push doesn't touch that branch at all.

## Reproduction

`scripts/github/cleanup-stale-branches.sh` runs `git push origin --delete BRANCH` from each repo's local checkout. On 2026-05-01 the gptme checkout sat on `docs/readme-positioning-post-warp` (no upstream), and deletion of two completely unrelated stale branches (`docs/readme-warp-positioning-var-a`, `fix/openrouter-double-prefix-models`) failed with:

```
❌ Error: Branch 'docs/readme-positioning-post-warp' has no upstream tracking branch
   Fix with: git branch --set-upstream-to=origin/docs/readme-positioning-post-warp
```

The error referenced the *currently checked-out* branch, not the branch being deleted.

## Fix

Detect when all pushed refs are deletions (`local_sha == ZERO`) and skip the upstream check — the current branch's tracking config is irrelevant for deletion-only pushes.

The existing master/main push protection further up the hook chain still applies for non-deletion pushes.

## Test plan
- [x] `git push origin --delete <nonexistent-branch>` from a checkout on a branch with no upstream — passes (was previously blocked)
- [x] prek validates new shellcheck lines
- [ ] Real cleanup-stale-branches.sh run against gptme repo successfully deletes branches without "no upstream" errors