### PR TITLE
feat(voice): promote call transcripts to gptme conversation log

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -15,6 +15,8 @@ import os
 import shlex
 import subprocess
 import time
+import urllib.error
+import urllib.request
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -56,6 +58,46 @@ class CallerIdentity:
 _DEFAULT_RESUME_WINDOW_SECONDS = 300
 _DEFAULT_STATE_DIR = "/tmp/gptme-voice-call-state"
 _MAX_RESUME_TRANSCRIPT_CHARS = 2500
+
+
+def _http_post_sync(url: str, payload: bytes, api_key: str) -> None:
+    """Fire-and-forget HTTP POST to the gptme server transcript endpoint.
+
+    Runs in a thread-pool executor so it never blocks the event loop.
+    Failures are logged but never raised — transcript promotion is
+    best-effort.
+    """
+    try:
+        req = urllib.request.Request(
+            url,
+            data=payload,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            body = resp.read().decode("utf-8", errors="replace")
+            if resp.status == 200:
+                logger.info(
+                    "Promoted transcript to gptme server (%d bytes)", len(payload)
+                )
+            else:
+                logger.warning(
+                    "Unexpected %d from transcript endpoint: %s",
+                    resp.status,
+                    body[:200],
+                )
+    except urllib.error.HTTPError as exc:
+        logger.warning(
+            "Transcript promotion HTTP %d: %s",
+            exc.code,
+            exc.read().decode("utf-8", errors="replace")[:200],
+        )
+    except (urllib.error.URLError, OSError) as exc:
+        logger.warning("Transcript promotion failed (network): %s", exc)
+
 
 # Delay before actually closing the WebSocket after the model requests hangup,
 # so the goodbye utterance has time to reach the caller.
@@ -339,6 +381,8 @@ class VoiceServer:
             or self.resume_window_seconds
         )
         self.post_call_command = _get_config_env("GPTME_VOICE_POST_CALL_COMMAND")
+        self.gptme_server_url = _get_config_env("GPTME_VOICE_GPTME_SERVER_URL") or ""
+        self.gptme_server_key = _get_config_env("GPTME_VOICE_GPTME_SERVER_KEY") or ""
         self.state_dir = Path(
             _get_config_env("GPTME_VOICE_STATE_DIR") or _DEFAULT_STATE_DIR
         )
@@ -1053,6 +1097,65 @@ class VoiceServer:
 
         return _on_handoff
 
+    def _promote_transcript_to_gptme(
+        self,
+        caller_id: str,
+        transcript: list[TranscriptTurn],
+        metadata: dict[str, str],
+    ) -> None:
+        """POST the call transcript to the gptme server conversation endpoint.
+
+        Called as a fire-and-forget background task after the archive record
+        is written.  Idempotent: the gptme server deduplicates by *call_sid*,
+        so retries are safe.
+
+        Requires ``GPTME_VOICE_GPTME_SERVER_URL`` and
+        ``GPTME_VOICE_GPTME_SERVER_KEY`` env vars.  Silently skips when
+        either is empty or missing.
+        """
+        if not self.gptme_server_url or not self.gptme_server_key:
+            return
+
+        call_sid = metadata.get("call_sid")
+        if not call_sid:
+            logger.warning(
+                "Skipping transcript promotion for %s: no call_sid in metadata",
+                caller_id,
+            )
+            return
+
+        turns = [
+            {"role": turn.role, "text": turn.text}
+            for turn in transcript
+            if turn.text.strip()
+        ]
+        if not turns:
+            logger.info(
+                "Skipping transcript promotion for %s: empty transcript", caller_id
+            )
+            return
+
+        url = f"{self.gptme_server_url.rstrip('/')}/api/v2/conversations/{caller_id}/transcript"
+        payload = json.dumps(
+            {
+                "turns": turns,
+                "call_metadata": {"call_sid": call_sid},
+            }
+        ).encode("utf-8")
+
+        try:
+            loop = asyncio.get_running_loop()
+            loop.run_in_executor(
+                None,
+                _http_post_sync,
+                url,
+                payload,
+                self.gptme_server_key,
+            )
+        except RuntimeError:
+            # No running loop (tests / sync context) — post synchronously
+            _http_post_sync(url, payload, self.gptme_server_key)
+
     async def _on_call_end(
         self,
         caller_id: str | None,
@@ -1089,6 +1192,10 @@ class VoiceServer:
         )
         self._save_recent_call(record)
         await self._schedule_post_call(caller_id, deduped_record_paths)
+
+        # Promote transcript to gptme server for persistence in conversation log.
+        # Fire-and-forget — never blocks the call-end teardown.
+        self._promote_transcript_to_gptme(caller_id, transcript, metadata)
 
     def _get_local_caller_id(self, websocket) -> str:
         caller_id = websocket.query_params.get("caller_id")

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -1146,13 +1146,14 @@ class VoiceServer:
 
         try:
             loop = asyncio.get_running_loop()
-            loop.run_in_executor(
+            fut = loop.run_in_executor(
                 None,
                 _http_post_sync,
                 url,
                 payload,
                 self.gptme_server_key,
             )
+            fut.add_done_callback(lambda _: None)
         except RuntimeError:
             # No running loop (tests / sync context) — post synchronously
             _http_post_sync(url, payload, self.gptme_server_key)

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -16,6 +16,7 @@ import shlex
 import subprocess
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
@@ -79,7 +80,7 @@ def _http_post_sync(url: str, payload: bytes, api_key: str) -> None:
         )
         with urllib.request.urlopen(req, timeout=30) as resp:
             body = resp.read().decode("utf-8", errors="replace")
-            if resp.status == 200:
+            if 200 <= resp.status < 300:
                 logger.info(
                     "Promoted transcript to gptme server (%d bytes)", len(payload)
                 )
@@ -1135,7 +1136,7 @@ class VoiceServer:
             )
             return
 
-        url = f"{self.gptme_server_url.rstrip('/')}/api/v2/conversations/{caller_id}/transcript"
+        url = f"{self.gptme_server_url.rstrip('/')}/api/v2/conversations/{urllib.parse.quote(caller_id, safe='')}/transcript"
         payload = json.dumps(
             {
                 "turns": turns,

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -1239,7 +1239,7 @@ class TestTranscriptPromotion:
 
         assert len(calls) == 1
         url, payload, key = calls[0]
-        assert url == "https://gptme.ai/api/v2/conversations/+15551234567/transcript"
+        assert url == "https://gptme.ai/api/v2/conversations/%2B15551234567/transcript"
         assert key == "test-key"
 
         body = json.loads(payload)

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -1202,3 +1202,103 @@ def test_audio_converter_independent_resample_states() -> None:
     # With per-rate state slots the browser path starts fresh regardless of prior
     # Twilio calls — outputs must be identical.
     assert combined_browser_out == fresh_browser_out
+
+
+# ── transcript promotion (Phase 3 Step 2) ──────────────────────────────────
+
+
+class TestTranscriptPromotion:
+    """Voice Phase 3: transcript → gptme conversation log."""
+
+    def test_promote_transcript_posts_to_server(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A transcript with turns is POSTed to the gptme server."""
+        calls: list[tuple[str, bytes, str]] = []
+
+        def _fake_post_sync(url: str, payload: bytes, api_key: str) -> None:
+            calls.append((url, payload, api_key))
+
+        monkeypatch.setattr(
+            "gptme_voice.realtime.server._http_post_sync", _fake_post_sync
+        )
+        monkeypatch.setenv("GPTME_VOICE_GPTME_SERVER_URL", "https://gptme.ai")
+        monkeypatch.setenv("GPTME_VOICE_GPTME_SERVER_KEY", "test-key")
+
+        server = VoiceServer()
+        transcript = [
+            TranscriptTurn(role="user", text="Hello"),
+            TranscriptTurn(role="assistant", text="Hi there"),
+        ]
+        metadata = {
+            "call_sid": "CAabc123",
+            "from": "+15551234567",
+        }
+
+        server._promote_transcript_to_gptme("+15551234567", transcript, metadata)
+
+        assert len(calls) == 1
+        url, payload, key = calls[0]
+        assert url == "https://gptme.ai/api/v2/conversations/+15551234567/transcript"
+        assert key == "test-key"
+
+        body = json.loads(payload)
+        assert body["call_metadata"]["call_sid"] == "CAabc123"
+        assert len(body["turns"]) == 2
+        assert body["turns"][0] == {"role": "user", "text": "Hello"}
+        assert body["turns"][1] == {"role": "assistant", "text": "Hi there"}
+
+    def test_promote_skips_when_unconfigured(self) -> None:
+        """When GPTME_VOICE_GPTME_SERVER_URL is empty, promotion is a no-op."""
+        server = VoiceServer()
+        assert server.gptme_server_url == ""
+
+        transcript = [TranscriptTurn(role="user", text="Hello")]
+        metadata = {"call_sid": "CAabc123"}
+
+        # Should not raise — just return silently.
+        server._promote_transcript_to_gptme("+15551234567", transcript, metadata)
+
+    def test_promote_skips_empty_transcript(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A transcript with no non-whitespace turns is skipped."""
+        calls: list[tuple[str, bytes, str]] = []
+
+        def _fake_post_sync(url: str, payload: bytes, api_key: str) -> None:
+            calls.append((url, payload, api_key))
+
+        monkeypatch.setattr(
+            "gptme_voice.realtime.server._http_post_sync", _fake_post_sync
+        )
+        monkeypatch.setenv("GPTME_VOICE_GPTME_SERVER_URL", "https://gptme.ai")
+        monkeypatch.setenv("GPTME_VOICE_GPTME_SERVER_KEY", "test-key")
+
+        server = VoiceServer()
+        transcript = [TranscriptTurn(role="user", text="   ")]
+        metadata = {"call_sid": "CAabc123"}
+
+        server._promote_transcript_to_gptme("+15551234567", transcript, metadata)
+        assert len(calls) == 0
+
+    def test_promote_skips_missing_call_sid(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without a call_sid in metadata, promotion is skipped."""
+        calls: list[tuple[str, bytes, str]] = []
+
+        def _fake_post_sync(url: str, payload: bytes, api_key: str) -> None:
+            calls.append((url, payload, api_key))
+
+        monkeypatch.setattr(
+            "gptme_voice.realtime.server._http_post_sync", _fake_post_sync
+        )
+        monkeypatch.setenv("GPTME_VOICE_GPTME_SERVER_URL", "https://gptme.ai")
+        monkeypatch.setenv("GPTME_VOICE_GPTME_SERVER_KEY", "test-key")
+
+        server = VoiceServer()
+        transcript = [TranscriptTurn(role="user", text="Hello")]
+        metadata: dict[str, str] = {}  # no call_sid
+
+        server._promote_transcript_to_gptme("+15551234567", transcript, metadata)
+        assert len(calls) == 0


### PR DESCRIPTION
## Summary

**Voice Phase 3 Step 2** — wires the voice server to POST call transcripts to the gptme server endpoint after every call ends.

## How it works

1. After `_on_call_end` archives the call record and schedules post-call hooks, it calls `_promote_transcript_to_gptme()` as a fire-and-forget side-effect
2. The method POSTs `{turns, call_metadata}` to `{GPTME_VOICE_GPTME_SERVER_URL}/api/v2/conversations/{caller_id}/transcript`
3. The gptme server deduplicates by `call_sid` (idempotent)
4. When `GPTME_VOICE_GPTME_SERVER_URL` is empty, the feature is silently disabled

## Configuration

```bash
export GPTME_VOICE_GPTME_SERVER_URL="https://gptme.ai"
export GPTME_VOICE_GPTME_SERVER_KEY="your-server-key"
```

## Changes

- `server.py`: `_http_post_sync` helper, `_promote_transcript_to_gptme()` method, env var loading
- `test_server.py`: 4 tests (happy-path POST, unconfigured skip, empty-transcript skip, no-call_sid skip)

Full voice suite: 134/134 tests pass.

Related: gptme/gptme#2315