### PR TITLE
fix(twitter): handle string context in create_review_prompt

### DIFF
--- a/scripts/twitter/llm.py
+++ b/scripts/twitter/llm.py
@@ -366,13 +366,18 @@ def create_review_prompt(draft: Dict, config: Dict) -> str:
         if isinstance(original_tweet, dict):
             thread = original_tweet.get("thread_context")
             if isinstance(thread, list):
-                thread_context = "\nThread Context:\n"
-                for i, tweet in enumerate(thread):
+                # Build entries first; only emit the header when at least one
+                # well-formed tweet survives so an empty or all-malformed
+                # thread doesn't leave an orphaned "Thread Context:" header.
+                entries: list[str] = []
+                for tweet in thread:
                     if not isinstance(tweet, dict):
                         continue
                     author = tweet.get("author", "?")
                     text = tweet.get("text", "")
-                    thread_context += f"Tweet {i + 1} - @{author}: {text}\n"
+                    entries.append(f"Tweet {len(entries) + 1} - @{author}: {text}")
+                if entries:
+                    thread_context = "\nThread Context:\n" + "\n".join(entries) + "\n"
 
     return f"""Review this draft tweet.
 

--- a/scripts/twitter/llm.py
+++ b/scripts/twitter/llm.py
@@ -354,12 +354,25 @@ def create_review_prompt(draft: Dict, config: Dict) -> str:
                     for status, text in example.items():
                         detailed_criteria += f"  • {status.upper()}: {text}\n"
 
-    # Include thread context if available
+    # Include thread context if available.
+    # `context` may be a free-text string for original tweets (no thread); only
+    # reply drafts have the structured `{original_tweet: {thread_context: [...]}}`
+    # shape. Defend against both at every level so a malformed/string context
+    # does not crash review.
     thread_context = ""
-    if draft.get("context", {}).get("original_tweet", {}).get("thread_context"):
-        thread_context = "\nThread Context:\n"
-        for i, tweet in enumerate(draft["context"]["original_tweet"]["thread_context"]):
-            thread_context += f"Tweet {i + 1} - @{tweet['author']}: {tweet['text']}\n"
+    ctx = draft.get("context")
+    if isinstance(ctx, dict):
+        original_tweet = ctx.get("original_tweet")
+        if isinstance(original_tweet, dict):
+            thread = original_tweet.get("thread_context")
+            if isinstance(thread, list):
+                thread_context = "\nThread Context:\n"
+                for i, tweet in enumerate(thread):
+                    if not isinstance(tweet, dict):
+                        continue
+                    author = tweet.get("author", "?")
+                    text = tweet.get("text", "")
+                    thread_context += f"Tweet {i + 1} - @{author}: {text}\n"
 
     return f"""Review this draft tweet.
 


### PR DESCRIPTION
## Summary

The Twitter auto loop has been crash-looping every 30 minutes (cycles 400-402+ failed) with:

```
File "/home/bob/bob/gptme-contrib/scripts/twitter/llm.py", line 359, in create_review_prompt
    if draft.get("context", {}).get("original_tweet", {}).get("thread_context"):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'get'
```

## Root cause

Original (non-reply) tweet drafts use a YAML string for `context` to describe the angle/source:

```yaml
# tweets/new/2303-agent-transparency.yaml
context: >
  Andrew Kelley (Zig creator) quote via Simon Willison 2026-04-30...
```

Reply drafts use a structured dict (`context.original_tweet.thread_context`).

`create_review_prompt` chained `.get()` calls assuming `context` was always a dict, which crashed on string-context drafts and blocked the entire review pipeline — including approved replies that were ready to post.

## Fix

Defensive `isinstance` check at every level of the chain. String contexts now produce empty thread context (correct: there's no thread on an original tweet). Reply drafts continue to render thread context unchanged.

## Verification

Manually verified with the actual broken draft (`tweets/new/2303-agent-transparency.yaml`) and the actual reply draft (`tweets/approved/reply_*.yml`), plus three edge cases (malformed `original_tweet`, non-dict thread items, missing context).

```
PASS: string context handled (no crash, empty thread)
PASS: reply thread context preserved
PASS: malformed original_tweet handled
PASS: non-dict thread items skipped
PASS: missing context handled
```

## Test plan

- [ ] CI green
- [ ] After merge: bob-twitter-loop next cycle completes without `AttributeError`
- [ ] Approved reply gets posted by the loop (it's been queued since 06:37 UTC)