### PR TITLE
fix(twitter): skip drafting replies for tweets with restricted reply_settings

### DIFF
--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -1338,6 +1338,27 @@ def should_evaluate_tweet(tweet_text: str, min_length: int = 50) -> Tuple[bool, 
     return True, ""
 
 
+def is_reply_restricted(tweet) -> bool:
+    """Return True if the tweet's author has restricted who can reply.
+
+    Twitter's reply_settings field can be one of:
+    - "everyone" (or None): anyone can reply
+    - "mentionedUsers": only mentioned users can reply
+    - "following": only accounts the author follows can reply
+    - "verified": only verified accounts can reply
+    - "subscribers": only paid subscribers can reply
+
+    Bob is rarely in any of the restricted categories for arbitrary timeline
+    accounts, so any non-"everyone" setting effectively blocks reply attempts
+    with a 403 from the API. Detect this upfront to avoid wasting LLM cycles
+    drafting replies that cannot be posted.
+    """
+    reply_settings = getattr(tweet, "reply_settings", None)
+    if reply_settings is None:
+        return False
+    return bool(reply_settings != "everyone")
+
+
 def process_timeline_tweets(
     tweets,
     users,
@@ -1422,6 +1443,21 @@ def process_timeline_tweets(
                     else str(tweet.author_id)
                 )
                 console.print(f"[dim]Skip: {skip_reason} - @{username_for_skip}[/dim]")
+                tweets_skipped_prefilter += 1
+                continue
+
+            # Skip tweets with restricted reply_settings — replying would 403
+            if is_reply_restricted(tweet):
+                author_for_skip = user_lookup.get(tweet.author_id)
+                username_for_skip = (
+                    author_for_skip.username
+                    if author_for_skip
+                    else str(tweet.author_id)
+                )
+                reply_setting = getattr(tweet, "reply_settings", "unknown")
+                console.print(
+                    f"[dim]Skip: reply_settings={reply_setting} - @{username_for_skip}[/dim]"
+                )
                 tweets_skipped_prefilter += 1
                 continue
 
@@ -1739,6 +1775,7 @@ def monitor(
                         "author_id",
                         "public_metrics",
                         "conversation_id",
+                        "reply_settings",
                     ],
                     expansions=["author_id"],
                     user_fields=["username", "public_metrics"],
@@ -1752,6 +1789,7 @@ def monitor(
                         "author_id",
                         "public_metrics",
                         "conversation_id",
+                        "reply_settings",
                     ],
                     expansions=["author_id"],
                     user_fields=["username", "public_metrics"],
@@ -1933,6 +1971,7 @@ def auto(
                         "author_id",
                         "public_metrics",
                         "conversation_id",
+                        "reply_settings",
                     ],
                     expansions=["author_id"],
                     user_fields=["username", "public_metrics"],
@@ -1946,6 +1985,7 @@ def auto(
                         "author_id",
                         "public_metrics",
                         "conversation_id",
+                        "reply_settings",
                     ],
                     expansions=["author_id"],
                     user_fields=["username", "public_metrics"],

--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -1923,6 +1923,7 @@ def auto(
                     "author_id",
                     "public_metrics",
                     "conversation_id",
+                    "reply_settings",
                 ],
                 expansions=["author_id", "referenced_tweets.id"],
                 user_fields=["username", "public_metrics"],

--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -1338,7 +1338,7 @@ def should_evaluate_tweet(tweet_text: str, min_length: int = 50) -> Tuple[bool, 
     return True, ""
 
 
-def is_reply_restricted(tweet) -> bool:
+def is_reply_restricted(tweet, from_mentions: bool = False) -> bool:
     """Return True if the tweet's author has restricted who can reply.
 
     Twitter's reply_settings field can be one of:
@@ -1352,9 +1352,15 @@ def is_reply_restricted(tweet) -> bool:
     accounts, so any non-"everyone" setting effectively blocks reply attempts
     with a 403 from the API. Detect this upfront to avoid wasting LLM cycles
     drafting replies that cannot be posted.
+
+    When from_mentions=True the tweet came from get_users_mentions, meaning Bob
+    was mentioned and is therefore in the allowed-replier set for "mentionedUsers"
+    tweets — those should NOT be skipped.
     """
     reply_settings = getattr(tweet, "reply_settings", None)
     if reply_settings is None:
+        return False
+    if from_mentions and reply_settings == "mentionedUsers":
         return False
     return bool(reply_settings != "everyone")
 
@@ -1368,6 +1374,7 @@ def process_timeline_tweets(
     dry_run: bool = False,
     max_drafts: int | None = None,
     max_auto_posts: int = 5,
+    from_mentions: bool = False,
 ) -> int:
     """Process tweets from timeline
 
@@ -1447,7 +1454,7 @@ def process_timeline_tweets(
                 continue
 
             # Skip tweets with restricted reply_settings — replying would 403
-            if is_reply_restricted(tweet):
+            if is_reply_restricted(tweet, from_mentions=from_mentions):
                 author_for_skip = user_lookup.get(tweet.author_id)
                 username_for_skip = (
                     author_for_skip.username
@@ -1943,6 +1950,7 @@ def auto(
                     times=max_drafts - total_drafts_generated,
                     dry_run=dry_run,
                     max_drafts=max_drafts - total_drafts_generated,
+                    from_mentions=True,
                 )
 
                 # Update counters

--- a/tests/test_twitter_workflow_drafts.py
+++ b/tests/test_twitter_workflow_drafts.py
@@ -292,3 +292,40 @@ def test_find_live_duplicate_reply_ids_returns_empty_without_identity(
     duplicate_ids = workflow_module._find_live_duplicate_reply_ids(object(), "4242")
 
     assert duplicate_ids == []
+
+
+def test_is_reply_restricted_everyone(workflow_module: Any) -> None:
+    tweet = SimpleNamespace(reply_settings="everyone")
+    assert workflow_module.is_reply_restricted(tweet) is False
+
+
+def test_is_reply_restricted_none_treated_as_open(workflow_module: Any) -> None:
+    tweet = SimpleNamespace(reply_settings=None)
+    assert workflow_module.is_reply_restricted(tweet) is False
+
+
+def test_is_reply_restricted_missing_attribute_treated_as_open(
+    workflow_module: Any,
+) -> None:
+    tweet = SimpleNamespace()
+    assert workflow_module.is_reply_restricted(tweet) is False
+
+
+def test_is_reply_restricted_following(workflow_module: Any) -> None:
+    tweet = SimpleNamespace(reply_settings="following")
+    assert workflow_module.is_reply_restricted(tweet) is True
+
+
+def test_is_reply_restricted_mentioned_users(workflow_module: Any) -> None:
+    tweet = SimpleNamespace(reply_settings="mentionedUsers")
+    assert workflow_module.is_reply_restricted(tweet) is True
+
+
+def test_is_reply_restricted_verified(workflow_module: Any) -> None:
+    tweet = SimpleNamespace(reply_settings="verified")
+    assert workflow_module.is_reply_restricted(tweet) is True
+
+
+def test_is_reply_restricted_subscribers(workflow_module: Any) -> None:
+    tweet = SimpleNamespace(reply_settings="subscribers")
+    assert workflow_module.is_reply_restricted(tweet) is True

--- a/tests/test_twitter_workflow_drafts.py
+++ b/tests/test_twitter_workflow_drafts.py
@@ -321,6 +321,14 @@ def test_is_reply_restricted_mentioned_users(workflow_module: Any) -> None:
     assert workflow_module.is_reply_restricted(tweet) is True
 
 
+def test_is_reply_restricted_mentioned_users_from_mentions(
+    workflow_module: Any,
+) -> None:
+    # When the tweet came from get_users_mentions, Bob was mentioned and can reply
+    tweet = SimpleNamespace(reply_settings="mentionedUsers")
+    assert workflow_module.is_reply_restricted(tweet, from_mentions=True) is False
+
+
 def test_is_reply_restricted_verified(workflow_module: Any) -> None:
     tweet = SimpleNamespace(reply_settings="verified")
     assert workflow_module.is_reply_restricted(tweet) is True


### PR DESCRIPTION
## Summary

When the monitor evaluates timeline tweets, it currently doesn't check `reply_settings`. If the author has restricted replies (`following` / `mentionedUsers` / `verified` / `subscribers`), the API returns 403 at post time:

```
Reply to this conversation is not allowed because you have not been
mentioned or otherwise engaged by the author of the post you are replying to.
```

So we burn LLM cycles drafting + reviewing + approving replies that can never be posted, and the new/approved queues fill up with undeliverable drafts. Bob hit this twice today on `@tom_doerr` tweets.

## Change

- Add `reply_settings` to `tweet_fields` in both `monitor()` and the `auto` cycle's timeline fetch (list and home).
- Add `is_reply_restricted(tweet)` — returns `True` only when `reply_settings` is set and not `"everyone"`. Missing/`None` values are treated as open (safe default).
- In `process_timeline_tweets()`, skip restricted tweets right after the existing `should_evaluate_tweet` pre-filter, with a clear `Skip: reply_settings=<value>` log line. Counts toward `tweets_skipped_prefilter`.
- 7 unit tests covering `everyone` / `None` / missing-attr / `following` / `mentionedUsers` / `verified` / `subscribers`.

## Test plan

- [x] `pytest tests/test_twitter_workflow_drafts.py` — 13/13 pass (6 existing + 7 new)
- [x] mypy / ruff / format pass via prek
- [ ] Confirmed in real run: next monitor cycle should skip restricted authors instead of generating 403'd drafts