### PR TITLE
fix(lessons): improve CLI --help lesson keywords; replace stale ace example

### DIFF
--- a/lessons/tools/check-cli---help-before-readin.md
+++ b/lessons/tools/check-cli---help-before-readin.md
@@ -1,14 +1,14 @@
 ---
 match:
   keywords:
-    - "examine source code to understand CLI"
-    - "planning complex workaround"
-    - "making assumptions about CLI options"
-    - "read the source to find the flag"
     - "doesn't have a flag for"
     - "wrap the command to add"
-    - "reading source to figure out"
     - "before patching the wrapper"
+    - "no built-in option for"
+    - "let me read the source to figure out"
+    - "doesn't seem to support"
+    - "build a wrapper around"
+    - "monkey-patch the CLI"
 status: active
 ---
 
@@ -32,7 +32,7 @@ When encountering a new command-line tool or unfamiliar command, developers ofte
 3. Look specifically for utility flags like --dry-run, --status, --format, --verbose
 4. Only dive into source code after understanding the documented interface
 
-Example: Running `uv run python3 -m ace.curator generate --help` revealed --dry-run option, enabling safe testing without API calls instead of building a complex validation workaround.
+Example: Running `uv run gptodo --help` and `uv run gptodo edit --help` reveals subcommands and flags (`--set`, `--add`, `--state`) that obviate building a wrapper or sed-editing YAML frontmatter directly.
 
 ## Outcome
 - **Time savings**: Discover built-in features vs building workarounds


### PR DESCRIPTION
## Summary

The CLI `--help` lesson (`lessons/tools/check-cli---help-before-readin.md`) was the **only true-corpus-silent active lesson** in the workspace per a 14-day trajectory cross-reference (`scripts/lesson-keyword-journal-crossref.py`). Its keywords were narrative-style strings like `"examine source code to understand CLI"` and `"making assumptions about CLI options"` that don't appear in real session text.

This PR:

- Replaces the overly-prose keywords with natural failure-mode phrases agents actually emit when they're about to skip `--help` (e.g. `"no built-in option for"`, `"doesn't seem to support"`, `"build a wrapper around"`, `"monkey-patch the CLI"`).
- Keeps the previously-effective concrete keywords (`"doesn't have a flag for"`, `"wrap the command to add"`, `"before patching the wrapper"`).
- Updates the inline example from a removed package (`ace.curator`, deprecated 2026-04) to a currently-installed CLI (`gptodo`), so the example doesn't reference dead code.

## Why

Silent lessons add zero value to the bandit / LOO loop. Fixing keyword routing is a cheap, high-signal improvement to the lesson system as a whole.

## Test plan

- [x] `validate.py lessons/tools/check-cli---help-before-readin.md` → `✅ ... is valid (two-file format)`
- [x] prek pre-commit hooks pass