### PR TITLE
feat(skills): add home-assistant skill with HA CLI script

### DIFF
--- a/skills/home-assistant/SKILL.md
+++ b/skills/home-assistant/SKILL.md
@@ -130,12 +130,12 @@ Key endpoints:
 - `GET /api/states` — all entity states
 - `GET /api/states/<entity_id>` — single entity
 - `GET /api/config` — HA config (location, timezone)
-- `GET /api/calendar/events?entity_id=<id>&start=<iso>&end=<iso>` — calendar events
+- `GET /api/calendars/<entity_id>?start=<iso-utc>&end=<iso-utc>` — calendar events (note: `Z` suffix required for UTC, not `+00:00`)
 - `GET /api/camera_proxy/<entity_id>` — camera snapshot (binary JPEG)
 
 ## Google Calendar (Already Working)
 
-Erik's main calendar is already shared with `timetobuildbob@gmail.com` (reader access).
+The agent's Google account should be shared as a reader on the owner's main calendar.
 Use `gog` (gogcli) to query it without needing HA:
 
 ```bash
@@ -143,10 +143,10 @@ Use `gog` (gogcli) to query it without needing HA:
 gog calendar calendars --results-only -j
 
 # Upcoming events (Erik's main calendar)
-gog calendar events "erik.bjareholt@gmail.com" --results-only -j
+gog calendar events "<owner-google-account>" --results-only -j
 
 # Compact view
-gog calendar events "erik.bjareholt@gmail.com" --results-only -j | python3 -c "
+gog calendar events "<owner-google-account>" --results-only -j | python3 -c "
 import json, sys
 for e in json.load(sys.stdin):
     start = e.get('start', {}).get('dateTime', e.get('start', {}).get('date', '?'))[:16]
@@ -154,13 +154,13 @@ for e in json.load(sys.stdin):
 "
 ```
 
-Calendar ID: `erik.bjareholt@gmail.com` (alias: "Main", timezone: Europe/Stockholm)
+Calendar ID: owner's Google account email (alias: "Main", timezone: Europe/Stockholm or as configured)
 
-## Giving Alice the Same Capability
+## Giving Another Agent the Same Capability
 
 ### Google Calendar
-1. Ask Erik to share his main calendar with Alice's Google account too
-2. Alice can then use `gog calendar events "erik.bjareholt@gmail.com"` once the share is accepted
+1. Ask the owner to share their main calendar with the agent's Google account (reader)
+2. The other agent can then use `gog calendar events "<owner-google-account>"` once the share is accepted
 
 ### Home Assistant
 1. SSH to Alice's VM: `ssh alice@alice`

--- a/skills/home-assistant/SKILL.md
+++ b/skills/home-assistant/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: home-assistant
+description: Query Home Assistant for Erik's location, phone state, calendar, and cameras
+tags: [home-assistant, iot, context, location, presence]
+license: MIT
+compatibility: "Requires HA_HOST and HA_API_KEY env vars; HA instance on Erik's local network"
+metadata:
+  author: bob
+  version: "1.0.0"
+  tags: "home-assistant,iot,context,location,presence"
+  requires_tools: ""
+  requires_skills: ""
+keywords:
+  - "home assistant"
+  - "erik location"
+  - "is erik home"
+  - "ha.py status"
+  - "person.erik presence"
+---
+
+# Home Assistant Skill
+
+Query Erik's Home Assistant instance for presence, sensor data, calendar events, and cameras.
+
+## Setup
+
+Credentials in `.env` at your agent workspace root:
+```
+HA_HOST=https://ha.hasselstugan.bjareholt.com
+HA_API_KEY=<long-lived-access-token>
+```
+
+**Connectivity**: `ha.hasselstugan.bjareholt.com` resolves publicly via Nabu Casa cloud relay
+(CNAME → `*.ui.nabu.casa`). No `/etc/hosts` entry or VPN needed.
+
+## Quick Commands
+
+```bash
+HA=gptme-contrib/skills/home-assistant/scripts/ha.py
+
+# Test connectivity
+uv run python3 $HA status
+
+# Erik's current location / presence
+uv run python3 $HA location
+
+# Erik's full real-world context (location, weather, mower, next event, recent automations)
+# — useful before voice calls, standups, or scheduling decisions
+uv run python3 $HA context
+uv run python3 $HA --json context
+
+# All person/device tracker states (Is Erik home? Same location as Tekla?)
+uv run python3 $HA persons
+
+# Upcoming calendar events
+uv run python3 $HA calendar
+
+# List all cameras
+uv run python3 $HA cameras
+
+# Get any entity state
+uv run python3 $HA state person.erik
+
+# List all entities (optionally filtered by domain)
+uv run python3 $HA states
+uv run python3 $HA states --domain sensor
+uv run python3 $HA states --domain device_tracker
+
+# JSON output for scripting
+uv run python3 $HA location --json
+```
+
+## Verified Entity IDs (live as of 2026-05-02)
+
+| What | Entity ID | Notes |
+|------|-----------|-------|
+| Erik's location | `person.erik` | state: home/away/zone_name |
+| Tekla's location | `person.tekla` | state: home/away/zone_name |
+| Bob's presence | `person.bob` | state: unknown (not tracked yet) |
+| Erik's F8 phone (main) | `device_tracker.erb_f8` | primary GPS source for `person.erik` |
+| Erik's F3 phone | `device_tracker.erb_f3_2` | backup tracker |
+| Erik's F8 battery | `sensor.erb_f8_battery_level` | %, e.g. 23 |
+| Erik's F8 battery state | `sensor.erb_f8_battery_state` | charging/discharging |
+| Tekla's phone battery | `sensor.tekla_17t_battery_level` | % |
+| Main calendar | `calendar.main` | Erik's main Google Cal |
+| gptme internal | `calendar.gptme_internal` | |
+| Superuser Labs | `calendar.superuser_labs` | |
+| Active camera | `camera.p1435_le_0` | state: idle (accessible) |
+| Weather | `weather.forecast_hasselstugan` | e.g. sunny, 5.3°C |
+| Lawn mower | `lawn_mower.am310e_nera` | state: mowing/charging/docked |
+| Erik's home zone | `zone.home` | "Hasselstugan" |
+| `fleet.gptme.ai` outage automation | `automation.fleet_gptme_ai_down` | Erik's HA pings Bob's prod uptime — `last_triggered` = real outage |
+
+## HA → Bob coordination signal
+
+Erik's HA contains an automation `automation.fleet_gptme_ai_down` that fires when
+`fleet.gptme.ai` is unreachable. Its `last_triggered` attribute is an
+**independent confirmation** of a real production outage — useful when you see
+ambiguous signals from PostHog/conformance and want a second opinion. Read it
+explicitly:
+
+```bash
+uv run python3 gptme-contrib/skills/home-assistant/scripts/ha.py state automation.fleet_gptme_ai_down
+```
+
+The `context` subcommand surfaces this automatically under "Automations triggered
+in last 24h" alongside other notable events (Tekla arriving home, sauna hot, etc.).
+
+## Other interesting domains discovered (2026-05-02)
+
+The HA instance has 807 entities total. Worth knowing about beyond presence/calendar:
+
+- **`todo.*`** (6 lists: `electricity`, `garden`, `shopping`, `home_automations`,
+  `plumbing`, `tekla_projects`) — Erik's HA-managed todos. `state` is item count.
+- **`zone.*`** (7 zones: `home`, `baravagen`, `ballet`, `hospital_bmc`,
+  `gronegatan`, `eslov_shopping`, `hasselstugan_1km`) — geofenced areas Erik/Tekla
+  pass through. `person.erik` resolves to a zone name when not at `home`.
+- **`scene.bedtime` / `scene.morning`** — Erik's daily routines.
+- **`ai_task.openai_ai_task` / `conversation.openai_conversation`** — HA's own
+  OpenAI integration; an alternate path for sending TTS/conversation if the
+  Twilio/Realtime path is degraded.
+- **`lawn_mower.am310e_nera`** — actively mowing on sunny days; a fun life signal.
+
+## REST API Reference
+
+Base URL: `$HA_HOST/api/`
+Auth header: `Authorization: Bearer $HA_API_KEY`
+
+Key endpoints:
+- `GET /api/states` — all entity states
+- `GET /api/states/<entity_id>` — single entity
+- `GET /api/config` — HA config (location, timezone)
+- `GET /api/calendar/events?entity_id=<id>&start=<iso>&end=<iso>` — calendar events
+- `GET /api/camera_proxy/<entity_id>` — camera snapshot (binary JPEG)
+
+## Google Calendar (Already Working)
+
+Erik's main calendar is already shared with `timetobuildbob@gmail.com` (reader access).
+Use `gog` (gogcli) to query it without needing HA:
+
+```bash
+# List all accessible calendars
+gog calendar calendars --results-only -j
+
+# Upcoming events (Erik's main calendar)
+gog calendar events "erik.bjareholt@gmail.com" --results-only -j
+
+# Compact view
+gog calendar events "erik.bjareholt@gmail.com" --results-only -j | python3 -c "
+import json, sys
+for e in json.load(sys.stdin):
+    start = e.get('start', {}).get('dateTime', e.get('start', {}).get('date', '?'))[:16]
+    print(f'{start}  {e.get(\"summary\", \"(no title)\")}')
+"
+```
+
+Calendar ID: `erik.bjareholt@gmail.com` (alias: "Main", timezone: Europe/Stockholm)
+
+## Giving Alice the Same Capability
+
+### Google Calendar
+1. Ask Erik to share his main calendar with Alice's Google account too
+2. Alice can then use `gog calendar events "erik.bjareholt@gmail.com"` once the share is accepted
+
+### Home Assistant
+1. SSH to Alice's VM: `ssh alice@alice`
+2. Add `HA_HOST` and `HA_API_KEY` to `~/alice/.env`
+3. Pull latest gptme-contrib (skill is upstreamed there — `gptme-contrib/skills/home-assistant/`)
+
+## Related
+
+- Issue: https://github.com/ErikBjare/bob/issues/722
+- Script: `gptme-contrib/skills/home-assistant/scripts/ha.py`

--- a/skills/home-assistant/scripts/ha.py
+++ b/skills/home-assistant/scripts/ha.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""Home Assistant CLI — query Erik's HA instance for presence, sensors, calendar, cameras.
+
+Usage:
+    uv run python3 skills/home-assistant/scripts/ha.py status              # Test connectivity
+    uv run python3 skills/home-assistant/scripts/ha.py location            # Erik + Tekla location
+    uv run python3 skills/home-assistant/scripts/ha.py persons             # All person/device_tracker states
+    uv run python3 skills/home-assistant/scripts/ha.py calendar            # Upcoming calendar events
+    uv run python3 skills/home-assistant/scripts/ha.py cameras             # List cameras (+ save snapshots)
+    uv run python3 skills/home-assistant/scripts/ha.py states              # All entity states
+    uv run python3 skills/home-assistant/scripts/ha.py states --domain sensor   # Filter by domain
+    uv run python3 skills/home-assistant/scripts/ha.py state <entity_id>   # Single entity state
+    uv run python3 skills/home-assistant/scripts/ha.py context             # Erik's full real-world context
+    uv run python3 skills/home-assistant/scripts/ha.py --json <subcommand> # JSON output
+
+Credentials: HA_HOST and HA_API_KEY in a .env file anywhere in the CWD→root walk.
+URL: ha.hasselstugan.bjareholt.com (Nabu Casa cloud relay — publicly resolvable).
+"""
+
+import argparse
+import json
+import os
+import socket
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+
+def _find_env_file() -> Path | None:
+    """Walk up from CWD looking for a .env file."""
+    p = Path.cwd()
+    while True:
+        candidate = p / ".env"
+        if candidate.exists():
+            return candidate
+        parent = p.parent
+        if parent == p:
+            return None
+        p = parent
+
+
+_env_path = _find_env_file()
+if _env_path:
+    for _line in _env_path.read_text().splitlines():
+        _line = _line.strip()
+        if _line and not _line.startswith("#") and "=" in _line:
+            _k, _, _v = _line.partition("=")
+            os.environ.setdefault(_k.strip(), _v.strip())
+
+HA_HOST = os.environ.get("HA_HOST", "").rstrip("/")
+HA_API_KEY = os.environ.get("HA_API_KEY", "")
+TIMEOUT = 10
+
+
+def _extract_hostname(url: str) -> str | None:
+    """Extract hostname from a URL like https://ha.example.com."""
+    if not url:
+        return None
+    no_proto = url.split("://")[-1] if "://" in url else url
+    return no_proto.split(":")[0].split("/")[0]
+
+
+def _resolve_hostname(hostname: str) -> str | None:
+    """Resolve a hostname, returning IP or None."""
+    try:
+        return socket.gethostbyname(hostname)
+    except socket.gaierror:
+        return None
+
+
+def _diagnose_dns(hostname: str) -> None:
+    """Print DNS diagnostics."""
+    ip = _resolve_hostname(hostname)
+    if ip:
+        return  # DNS works
+    print(f"  ✗ {hostname} does not resolve via system DNS", file=sys.stderr)
+    try:
+        hosts = Path("/etc/hosts").read_text()
+        if hostname in hosts:
+            line = next(ln for ln in hosts.splitlines() if hostname in ln)
+            print(f"  ✓ Found in /etc/hosts: {line.strip()}", file=sys.stderr)
+            return
+    except OSError:
+        pass
+    print("  ✗ Not found in /etc/hosts either", file=sys.stderr)
+    print("\n  Ask Erik for the HA server IP, then run:", file=sys.stderr)
+    print(f"    echo '<IP> {hostname}' | sudo tee -a /etc/hosts", file=sys.stderr)
+
+
+def ha_request(path: str, method: str = "GET", body: dict | None = None) -> Any:
+    if not HA_HOST or not HA_API_KEY:
+        print("ERROR: HA_HOST and HA_API_KEY must be set in .env", file=sys.stderr)
+        sys.exit(1)
+    url = f"{HA_HOST}/api/{path.lstrip('/')}"
+    data = json.dumps(body).encode() if body else None
+    req = Request(
+        url,
+        data=data,
+        headers={
+            "Authorization": f"Bearer {HA_API_KEY}",
+            "Content-Type": "application/json",
+        },
+        method=method,
+    )
+    try:
+        with urlopen(req, timeout=TIMEOUT) as resp:
+            raw = resp.read()
+            return json.loads(raw) if raw else {}
+    except URLError as e:
+        hostname = _extract_hostname(HA_HOST)
+        if hostname:
+            _diagnose_dns(hostname)
+        print(f"\nERROR connecting to {url}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def cmd_status(args: argparse.Namespace) -> None:
+    data = ha_request("")
+    if args.json:
+        print(json.dumps(data, indent=2))
+    else:
+        print(f"✓ Home Assistant {data.get('version', '?')} at {HA_HOST}")
+        print(f"  Message: {data.get('message', '')}")
+
+
+def cmd_states(args: argparse.Namespace) -> None:
+    states: list[dict] = ha_request("states")
+    if args.domain:
+        states = [s for s in states if s["entity_id"].startswith(f"{args.domain}.")]
+    if args.json:
+        print(json.dumps(states, indent=2))
+        return
+    print(f"{'Entity':50} {'State':20} {'Last changed'}")
+    print("-" * 90)
+    for s in sorted(states, key=lambda x: x["entity_id"]):
+        changed = s.get("last_changed", "")[:19]
+        print(f"{s['entity_id']:50} {s['state']:20} {changed}")
+
+
+def cmd_state(args: argparse.Namespace) -> None:
+    s = ha_request(f"states/{args.entity_id}")
+    if args.json:
+        print(json.dumps(s, indent=2))
+        return
+    print(f"Entity:       {s['entity_id']}")
+    print(f"State:        {s['state']}")
+    print(f"Last changed: {s.get('last_changed', '')}")
+    attrs = s.get("attributes", {})
+    if attrs:
+        print("Attributes:")
+        for k, v in attrs.items():
+            print(f"  {k}: {v}")
+
+
+def cmd_location(args: argparse.Namespace) -> None:
+    """Show Erik's and Tekla's location / presence."""
+    all_states: list[dict] = ha_request("states")
+    persons = [s for s in all_states if s["entity_id"].startswith("person.")]
+    trackers = [s for s in all_states if s["entity_id"].startswith("device_tracker.")]
+
+    if args.json:
+        print(json.dumps({"persons": persons, "device_trackers": trackers}, indent=2))
+        return
+
+    if persons:
+        print("## Persons")
+        for p in persons:
+            name = p.get("attributes", {}).get("friendly_name", p["entity_id"])
+            state = p["state"]
+            lat = p.get("attributes", {}).get("latitude", "?")
+            lon = p.get("attributes", {}).get("longitude", "?")
+            gps = f" ({lat}, {lon})" if lat != "?" else ""
+            print(f"  {name}: {state}{gps}")
+
+    if trackers:
+        print("\n## Device trackers")
+        for t in trackers:
+            name = t.get("attributes", {}).get("friendly_name", t["entity_id"])
+            print(f"  {name}: {t['state']}")
+
+    if not persons and not trackers:
+        print("No person or device_tracker entities found.")
+
+
+def cmd_persons(args: argparse.Namespace) -> None:
+    args.domain = "person"
+    cmd_states(args)
+
+
+def cmd_calendar(args: argparse.Namespace) -> None:
+    """Show upcoming calendar events (next 7 days)."""
+    all_states: list[dict] = ha_request("states")
+    cal_entities = [
+        s["entity_id"] for s in all_states if s["entity_id"].startswith("calendar.")
+    ]
+
+    if not cal_entities:
+        print("No calendar entities found.")
+        return
+
+    now = datetime.now(timezone.utc)
+    end = now + timedelta(days=7)
+    # HA REST API requires Z suffix for UTC, not +00:00 offset format
+    start_str = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+    end_str = end.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    all_events: list[dict] = []
+    for cal_id in cal_entities:
+        try:
+            events = ha_request(f"calendars/{cal_id}?start={start_str}&end={end_str}")
+            for e in events:
+                e["_calendar"] = cal_id
+            all_events.extend(events)
+        except SystemExit:
+            pass
+
+    all_events.sort(
+        key=lambda e: e.get("start", {}).get(
+            "dateTime", e.get("start", {}).get("date", "")
+        )
+    )
+
+    if args.json:
+        print(json.dumps(all_events, indent=2))
+        return
+
+    if not all_events:
+        print(f"No events in the next 7 days across: {', '.join(cal_entities)}")
+        return
+
+    print(f"## Upcoming events (next 7 days) from {len(cal_entities)} calendar(s)\n")
+    for e in all_events:
+        start = e.get("start", {})
+        dt = start.get("dateTime", start.get("date", "?"))[:16]
+        summary = e.get("summary", "(no title)")
+        cal = e.get("_calendar", "")
+        print(f"  {dt}  {summary}  [{cal}]")
+
+
+def cmd_context(args: argparse.Namespace) -> None:
+    """Snapshot of Erik's current real-world context — for voice/standup awareness."""
+    states: list[dict] = ha_request("states")
+    by_id = {s["entity_id"]: s for s in states}
+
+    def get(eid: str, default: str = "?") -> str:
+        s = by_id.get(eid)
+        return s["state"] if s else default
+
+    def attr(eid: str, key: str, default: str = "") -> str:
+        s = by_id.get(eid)
+        if not s:
+            return default
+        return str(s.get("attributes", {}).get(key, default))
+
+    erik_loc = get("person.erik")
+    tekla_loc = get("person.tekla")
+    co_located = erik_loc == tekla_loc and erik_loc not in ("?", "unknown") and erik_loc
+
+    weather_state = get("weather.forecast_hasselstugan")
+    weather_temp = attr("weather.forecast_hasselstugan", "temperature")
+
+    erik_battery = get("sensor.erb_f8_battery_level")
+    erik_battery_state = get("sensor.erb_f8_battery_state")
+    lawn_mower = get("lawn_mower.am310e_nera")
+
+    # Next calendar event (next 4h, main calendar only — fast)
+    next_event = None
+    try:
+        now = datetime.now(timezone.utc)
+        end = now + timedelta(hours=4)
+        events = ha_request(
+            "calendars/calendar.main"
+            f"?start={now.strftime('%Y-%m-%dT%H:%M:%SZ')}"
+            f"&end={end.strftime('%Y-%m-%dT%H:%M:%SZ')}"
+        )
+        if events:
+            e = events[0]
+            start = e.get("start", {})
+            dt = start.get("dateTime", start.get("date", "?"))[:16]
+            next_event = f"{dt} {e.get('summary', '')}"
+    except SystemExit:
+        pass
+
+    # Recently triggered automations of interest (last 24h)
+    notable_automations = []
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=24)
+    for s in states:
+        if not s["entity_id"].startswith("automation."):
+            continue
+        last = s.get("attributes", {}).get("last_triggered")
+        if not last:
+            continue
+        try:
+            last_dt = datetime.fromisoformat(last.replace("Z", "+00:00"))
+        except (ValueError, AttributeError):
+            continue
+        if last_dt > cutoff:
+            notable_automations.append(
+                {
+                    "name": s.get("attributes", {}).get(
+                        "friendly_name", s["entity_id"]
+                    ),
+                    "last_triggered": last,
+                }
+            )
+    notable_automations.sort(key=lambda x: x["last_triggered"], reverse=True)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "erik": {"location": erik_loc, "phone_battery": erik_battery},
+                    "tekla": {"location": tekla_loc},
+                    "co_located": bool(co_located),
+                    "weather": {"state": weather_state, "temp_c": weather_temp},
+                    "lawn_mower": lawn_mower,
+                    "next_event_4h": next_event,
+                    "automations_24h": notable_automations[:10],
+                },
+                indent=2,
+            )
+        )
+        return
+
+    print(f"## Erik's context @ {datetime.now(timezone.utc).strftime('%H:%MZ')}")
+    print(f"- Erik:    {erik_loc}  (phone {erik_battery}% {erik_battery_state})")
+    print(f"- Tekla:   {tekla_loc}{'  (with Erik)' if co_located else ''}")
+    print(f"- Weather: {weather_state}, {weather_temp}°C")
+    if lawn_mower not in ("?", "unknown"):
+        print(f"- Mower:   {lawn_mower}")
+    print(f"- Next 4h: {next_event or '(nothing scheduled)'}")
+    if notable_automations:
+        print(f"\n## Automations triggered in last 24h ({len(notable_automations)})")
+        for a in notable_automations[:5]:
+            print(f"  {a['last_triggered'][:19]}  {a['name']}")
+
+
+def cmd_cameras(args: argparse.Namespace) -> None:
+    all_states: list[dict] = ha_request("states")
+    cameras = [s for s in all_states if s["entity_id"].startswith("camera.")]
+
+    if args.json:
+        print(json.dumps(cameras, indent=2))
+        return
+
+    if not cameras:
+        print("No camera entities found.")
+        return
+
+    print(f"Found {len(cameras)} camera(s):")
+    for c in cameras:
+        name = c.get("attributes", {}).get("friendly_name", c["entity_id"])
+        print(f"  {c['entity_id']}: {name} (state: {c['state']})")
+
+    if args.snapshot:
+        outdir = Path(args.snapshot)
+        outdir.mkdir(parents=True, exist_ok=True)
+        print(f"\nSaving snapshots to {outdir}/")
+        for c in cameras:
+            eid = c["entity_id"]
+            url = f"{HA_HOST}/api/camera_proxy/{eid}"
+            req = Request(url, headers={"Authorization": f"Bearer {HA_API_KEY}"})
+            try:
+                with urlopen(req, timeout=TIMEOUT) as resp:
+                    img_data = resp.read()
+                out = outdir / f"{eid.replace('.', '_')}.jpg"
+                out.write_bytes(img_data)
+                print(f"  Saved {out} ({len(img_data) // 1024}KB)")
+            except Exception as e:
+                print(f"  Failed {eid}: {e}", file=sys.stderr)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--json", action="store_true", help="JSON output")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("status", help="Test HA connectivity")
+    p_states = sub.add_parser("states", help="List entity states")
+    p_states.add_argument(
+        "--domain", help="Filter by domain (e.g. sensor, device_tracker)"
+    )
+    p_state = sub.add_parser("state", help="Get single entity state")
+    p_state.add_argument("entity_id", help="Entity ID (e.g. person.erik)")
+    sub.add_parser("location", help="Show person/device_tracker states")
+    sub.add_parser("persons", help="Show all person entity states")
+    sub.add_parser("calendar", help="Show upcoming calendar events (7 days)")
+    sub.add_parser(
+        "context",
+        help="Erik's current context snapshot (location, weather, next event, recent automations)",
+    )
+    p_cameras = sub.add_parser(
+        "cameras", help="List cameras and optionally save snapshots"
+    )
+    p_cameras.add_argument(
+        "--snapshot", metavar="DIR", help="Save JPEG snapshots to DIR"
+    )
+
+    args = parser.parse_args()
+    cmds = {
+        "status": cmd_status,
+        "states": cmd_states,
+        "state": cmd_state,
+        "location": cmd_location,
+        "persons": cmd_persons,
+        "calendar": cmd_calendar,
+        "context": cmd_context,
+        "cameras": cmd_cameras,
+    }
+    cmds[args.cmd](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/home-assistant/scripts/ha.py
+++ b/skills/home-assistant/scripts/ha.py
@@ -48,7 +48,8 @@ if _env_path:
         _line = _line.strip()
         if _line and not _line.startswith("#") and "=" in _line:
             _k, _, _v = _line.partition("=")
-            os.environ.setdefault(_k.strip(), _v.strip())
+            _v = _v.strip().strip('"').strip("'")
+            os.environ.setdefault(_k.strip(), _v)
 
 HA_HOST = os.environ.get("HA_HOST", "").rstrip("/")
 HA_API_KEY = os.environ.get("HA_API_KEY", "")

--- a/skills/home-assistant/scripts/ha.py
+++ b/skills/home-assistant/scripts/ha.py
@@ -29,6 +29,10 @@ from urllib.error import URLError
 from urllib.request import Request, urlopen
 
 
+class HAError(Exception):
+    pass
+
+
 def _find_env_file() -> Path | None:
     """Walk up from CWD looking for a .env file."""
     p = Path.cwd()
@@ -114,8 +118,7 @@ def ha_request(path: str, method: str = "GET", body: dict | None = None) -> Any:
         hostname = _extract_hostname(HA_HOST)
         if hostname:
             _diagnose_dns(hostname)
-        print(f"\nERROR connecting to {url}: {e}", file=sys.stderr)
-        sys.exit(1)
+        raise HAError(f"ERROR connecting to {url}: {e}") from e
 
 
 def cmd_status(args: argparse.Namespace) -> None:
@@ -215,7 +218,7 @@ def cmd_calendar(args: argparse.Namespace) -> None:
             for e in events:
                 e["_calendar"] = cal_id
             all_events.extend(events)
-        except SystemExit:
+        except HAError:
             pass
 
     all_events.sort(
@@ -282,7 +285,7 @@ def cmd_context(args: argparse.Namespace) -> None:
             start = e.get("start", {})
             dt = start.get("dateTime", start.get("date", "?"))[:16]
             next_event = f"{dt} {e.get('summary', '')}"
-    except SystemExit:
+    except HAError:
         pass
 
     # Recently triggered automations of interest (last 24h)
@@ -413,7 +416,11 @@ def main() -> None:
         "context": cmd_context,
         "cameras": cmd_cameras,
     }
-    cmds[args.cmd](args)
+    try:
+        cmds[args.cmd](args)
+    except HAError as e:
+        print(e, file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds `skills/home-assistant/SKILL.md` — skill for querying Erik's HA instance (presence, calendar, cameras, context snapshot)
- Adds `skills/home-assistant/scripts/ha.py` — stdlib-only HA REST API CLI (no dependencies)
- Script finds `.env` by walking up from CWD, so it works correctly from any agent workspace root
- Documented entity IDs, HA domains, and the `automation.fleet_gptme_ai_down` cross-system signal

Upstreamed from `ErikBjare/bob` per request in ErikBjare/bob#722. Both Bob and Alice use/will use this skill.

## Key design decisions

- **No external deps**: uses only stdlib (`urllib`, `json`, `socket`) — no `requests`, no `httpx`
- **CWD-walking .env loader**: replaces the previous `Path(__file__).parent.parent` path, which broke when the script lived in a submodule
- **Credentials via env vars**: `HA_HOST` + `HA_API_KEY` — agent-agnostic, no hardcoded paths

## Test plan

- [ ] Run `uv run python3 gptme-contrib/skills/home-assistant/scripts/ha.py status` from an agent workspace with HA creds in `.env`
- [ ] Confirm `location`, `persons`, `calendar`, `context` subcommands return valid output
- [ ] Confirm script works when invoked from a subdirectory (CWD-walk .env discovery)