### PR TITLE
fix(git): surface real hook failure when no auto-fixable changes

### DIFF
--- a/scripts/git/pre-commit-auto-stage
+++ b/scripts/git/pre-commit-auto-stage
@@ -122,14 +122,19 @@ if [ $PRECOMMIT_EXIT -eq 0 ]; then
   exit 0
 else
   echo "$PRECOMMIT_OUTPUT"
-  echo -e "${YELLOW}Pre-commit modified files, checking for auto-staging...${NC}"
 
-  # Check if any files were actually modified
+  # Check if any files were actually modified by formatters before announcing
+  # auto-staging. If nothing was modified, this is a real hook failure and the
+  # output above is the remediation surface — don't bury it under a misleading
+  # "checking for auto-staging" header.
   if git diff --quiet; then
-    echo -e "${RED}✗ Pre-commit failed but no files were modified${NC}"
-    echo -e "${RED}This indicates a real failure, not auto-fixing${NC}"
+    echo -e "${RED}✗ Pre-commit hook failed (no auto-fixable changes)${NC}" >&2
+    echo -e "${RED}  See the hook output above for the specific failure and fix.${NC}" >&2
+    echo -e "${RED}  To re-run a single hook directly: prek run --files <path>${NC}" >&2
     exit 1
   fi
+
+  echo -e "${YELLOW}Pre-commit modified files, auto-staging formatter fixes...${NC}"
 
   while IFS= read -r file; do
     for staged_file in "${ORIGINALLY_STAGED_FILES[@]}"; do

--- a/scripts/git/pre-commit-auto-stage
+++ b/scripts/git/pre-commit-auto-stage
@@ -130,7 +130,7 @@ else
   if git diff --quiet; then
     echo -e "${RED}✗ Pre-commit hook failed (no auto-fixable changes)${NC}" >&2
     echo -e "${RED}  See the hook output above for the specific failure and fix.${NC}" >&2
-    echo -e "${RED}  To re-run a single hook directly: prek run --files <path>${NC}" >&2
+    echo -e "${RED}  To re-run a single hook directly: ${PRECOMMIT_CMD} run --files <path>${NC}" >&2
     exit 1
   fi
 

--- a/tests/test_git_safe_commit.py
+++ b/tests/test_git_safe_commit.py
@@ -946,3 +946,92 @@ def test_safe_commit_runs_pre_commit_manually_before_no_verify_commit(git_repo: 
     assert "test: manual pre-commit bridge" in commit_message.stdout
     # prepare-commit-msg still runs under --no-verify; commit-msg is intentionally skipped
     assert "Manual-Hook: yes" in commit_message.stdout
+
+
+def test_safe_commit_real_hook_failure_message_is_actionable(tmp_path: Path):
+    """When prek fails without modifying files, surface the hook output as the
+    primary signal — don't bury it under a misleading 'checking for auto-staging'
+    header that suggests fixes are happening."""
+    subprocess.run(
+        ["git", "init", "-b", "test-branch", str(tmp_path)],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+
+    hooks_dir = tmp_path / ".git" / "hooks"
+    hooks_dir.mkdir(exist_ok=True)
+    subprocess.run(
+        ["git", "config", "core.hooksPath", str(hooks_dir)],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    (hooks_dir / "pre-commit").unlink(missing_ok=True)
+    (hooks_dir / "pre-commit").symlink_to(PRE_COMMIT_HOOK)
+
+    # Fake prek that fails on `run` without modifying any files (simulates a
+    # validator hook like validate-blog-urls catching a real issue).
+    fake_bin = Path(tempfile.mkdtemp(prefix="fake-prek-fail-"))
+    fake_prek = fake_bin / "prek"
+    fake_prek.write_text(
+        textwrap.dedent(
+            """\
+            #!/bin/sh
+            if [ "$1" = "run" ]; then
+                echo "validate-blog-urls.................Failed"
+                echo "- hook id: validate-blog-urls"
+                echo "- exit code: 1"
+                echo ""
+                echo "Private repo link detected: https://github.com/ErikBjare/bob/..."
+                exit 1
+            fi
+            exit 2
+            """
+        )
+    )
+    fake_prek.chmod(0o755)
+
+    (tmp_path / ".pre-commit-config.yaml").write_text("repos: []\n")
+    (tmp_path / "README.md").write_text("init\n")
+    subprocess.run(
+        ["git", "add", "README.md", ".pre-commit-config.yaml"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    init_result = subprocess.run(
+        [str(SAFE_COMMIT), "README.md", ".pre-commit-config.yaml", "-m", "init"],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+
+    assert init_result.returncode != 0, "Expected commit to fail when hook rejects"
+    combined = init_result.stdout + init_result.stderr
+
+    # Real hook output must be visible
+    assert "validate-blog-urls" in combined
+    assert "Private repo link detected" in combined
+
+    # New, accurate failure message must appear
+    assert "no auto-fixable changes" in combined
+    assert "prek run --files" in combined
+
+    # Old misleading header must NOT appear when no files were modified
+    assert "checking for auto-staging" not in combined


### PR DESCRIPTION
## What

`scripts/git/pre-commit-auto-stage` printed "Pre-commit modified files, checking for auto-staging..." **before** checking whether files were actually modified. When a validator hook (e.g. `validate-blog-urls`) failed without producing fixes, that misleading header preceded "no files were modified, real failure" — burying the real error and suggesting fixes were happening when they weren't.

## Why

In session 34fb (Bob, 2026-05-02), three commit attempts failed to surface that the actual blocker was a private-repo link the `validate-blog-urls` hook flags. The wrapper output sequence:

```
Pre-commit modified files, checking for auto-staging...
✗ Pre-commit failed but no files were modified
This indicates a real failure, not auto-fixing
```

…hides the hook output above it under a header that announces fixes are happening. Running `prek run --files <path>` directly surfaced the failure + remediation in one line, but only after the user knew to bypass the wrapper.

## Change

- Reorder so the no-auto-fixable path runs **first** with a clearer message: `Pre-commit hook failed (no auto-fixable changes)` followed by `See the hook output above for the specific failure and fix.` and a remediation hint pointing at `prek run --files <path>`.
- The "Pre-commit modified files, auto-staging..." header now only fires when files were actually modified.
- Errors emit to stderr (they were stdout before).

## Test

Adds `test_safe_commit_real_hook_failure_message_is_actionable` covering:

- Real hook output stays visible (`validate-blog-urls`, error body)
- New message appears (`no auto-fixable changes`, `prek run --files`)
- Old misleading header is **absent** when files weren't modified

22/22 tests pass locally (`uv run pytest tests/test_git_safe_commit.py`).

## Origin

[Bob session 34fb journal](https://github.com/ErikBjare/bob/tree/master/journal/2026-05-02) — three commit attempts wasted before user manually invoked `prek run --files <path>` to find the real blocker. This wrapper-message clarity fix was identified there as out-of-scope-but-real; this PR scopes it down and ships it.