### PR TITLE
fix(skills/home-assistant): depersonalize SKILL.md — remove entity IDs and personal references

### DIFF
--- a/skills/home-assistant/SKILL.md
+++ b/skills/home-assistant/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: home-assistant
-description: Query Home Assistant for Erik's location, phone state, calendar, and cameras
+description: Query a Home Assistant instance for presence, sensor data, calendar events, and cameras
 tags: [home-assistant, iot, context, location, presence]
 license: MIT
-compatibility: "Requires HA_HOST and HA_API_KEY env vars; HA instance on Erik's local network"
+compatibility: "Requires HA_HOST and HA_API_KEY env vars"
 metadata:
   author: bob
   version: "1.0.0"
@@ -12,26 +12,28 @@ metadata:
   requires_skills: ""
 keywords:
   - "home assistant"
-  - "erik location"
-  - "is erik home"
+  - "is person home"
   - "ha.py status"
-  - "person.erik presence"
+  - "person presence"
+  - "home assistant sensor"
 ---
 
 # Home Assistant Skill
 
-Query Erik's Home Assistant instance for presence, sensor data, calendar events, and cameras.
+Query a Home Assistant instance for presence, sensor data, calendar events, and cameras.
 
 ## Setup
 
 Credentials in `.env` at your agent workspace root:
 ```
-HA_HOST=https://ha.hasselstugan.bjareholt.com
+HA_HOST=https://<your-ha-host>
 HA_API_KEY=<long-lived-access-token>
 ```
 
-**Connectivity**: `ha.hasselstugan.bjareholt.com` resolves publicly via Nabu Casa cloud relay
+**Cloud connectivity**: If your HA instance uses Nabu Casa, the host resolves publicly
 (CNAME → `*.ui.nabu.casa`). No `/etc/hosts` entry or VPN needed.
+
+**Generate a long-lived token**: HA UI → Profile → Long-Lived Access Tokens → Create.
 
 ## Quick Commands
 
@@ -41,15 +43,15 @@ HA=gptme-contrib/skills/home-assistant/scripts/ha.py
 # Test connectivity
 uv run python3 $HA status
 
-# Erik's current location / presence
+# Owner's current location / presence
 uv run python3 $HA location
 
-# Erik's full real-world context (location, weather, mower, next event, recent automations)
+# Full real-world context (location, weather, next event, recent automations)
 # — useful before voice calls, standups, or scheduling decisions
 uv run python3 $HA context
 uv run python3 $HA --json context
 
-# All person/device tracker states (Is Erik home? Same location as Tekla?)
+# All person/device tracker states
 uv run python3 $HA persons
 
 # Upcoming calendar events
@@ -59,7 +61,7 @@ uv run python3 $HA calendar
 uv run python3 $HA cameras
 
 # Get any entity state
-uv run python3 $HA state person.erik
+uv run python3 $HA state <entity_id>
 
 # List all entities (optionally filtered by domain)
 uv run python3 $HA states
@@ -70,56 +72,21 @@ uv run python3 $HA states --domain device_tracker
 uv run python3 $HA location --json
 ```
 
-## Verified Entity IDs (live as of 2026-05-02)
+## Common Entity ID Patterns
 
-| What | Entity ID | Notes |
-|------|-----------|-------|
-| Erik's location | `person.erik` | state: home/away/zone_name |
-| Tekla's location | `person.tekla` | state: home/away/zone_name |
-| Bob's presence | `person.bob` | state: unknown (not tracked yet) |
-| Erik's F8 phone (main) | `device_tracker.erb_f8` | primary GPS source for `person.erik` |
-| Erik's F3 phone | `device_tracker.erb_f3_2` | backup tracker |
-| Erik's F8 battery | `sensor.erb_f8_battery_level` | %, e.g. 23 |
-| Erik's F8 battery state | `sensor.erb_f8_battery_state` | charging/discharging |
-| Tekla's phone battery | `sensor.tekla_17t_battery_level` | % |
-| Main calendar | `calendar.main` | Erik's main Google Cal |
-| gptme internal | `calendar.gptme_internal` | |
-| Superuser Labs | `calendar.superuser_labs` | |
-| Active camera | `camera.p1435_le_0` | state: idle (accessible) |
-| Weather | `weather.forecast_hasselstugan` | e.g. sunny, 5.3°C |
-| Lawn mower | `lawn_mower.am310e_nera` | state: mowing/charging/docked |
-| Erik's home zone | `zone.home` | "Hasselstugan" |
-| `fleet.gptme.ai` outage automation | `automation.fleet_gptme_ai_down` | Erik's HA pings Bob's prod uptime — `last_triggered` = real outage |
+HA entity IDs follow predictable patterns — discover yours with `ha.py states`:
 
-## HA → Bob coordination signal
+| Domain | Example | Notes |
+|--------|---------|-------|
+| `person.<name>` | `person.alice` | state: home/away/zone_name |
+| `device_tracker.*` | `device_tracker.alice_phone` | GPS source for person entity |
+| `sensor.*_battery_level` | `sensor.alice_phone_battery_level` | % |
+| `calendar.main` | `calendar.main` | Primary Google calendar |
+| `weather.forecast_*` | `weather.forecast_home` | Current weather |
+| `camera.*` | `camera.front_door` | Camera snapshot |
+| `zone.home` | `zone.home` | Home geofence |
 
-Erik's HA contains an automation `automation.fleet_gptme_ai_down` that fires when
-`fleet.gptme.ai` is unreachable. Its `last_triggered` attribute is an
-**independent confirmation** of a real production outage — useful when you see
-ambiguous signals from PostHog/conformance and want a second opinion. Read it
-explicitly:
-
-```bash
-uv run python3 gptme-contrib/skills/home-assistant/scripts/ha.py state automation.fleet_gptme_ai_down
-```
-
-The `context` subcommand surfaces this automatically under "Automations triggered
-in last 24h" alongside other notable events (Tekla arriving home, sauna hot, etc.).
-
-## Other interesting domains discovered (2026-05-02)
-
-The HA instance has 807 entities total. Worth knowing about beyond presence/calendar:
-
-- **`todo.*`** (6 lists: `electricity`, `garden`, `shopping`, `home_automations`,
-  `plumbing`, `tekla_projects`) — Erik's HA-managed todos. `state` is item count.
-- **`zone.*`** (7 zones: `home`, `baravagen`, `ballet`, `hospital_bmc`,
-  `gronegatan`, `eslov_shopping`, `hasselstugan_1km`) — geofenced areas Erik/Tekla
-  pass through. `person.erik` resolves to a zone name when not at `home`.
-- **`scene.bedtime` / `scene.morning`** — Erik's daily routines.
-- **`ai_task.openai_ai_task` / `conversation.openai_conversation`** — HA's own
-  OpenAI integration; an alternate path for sending TTS/conversation if the
-  Twilio/Realtime path is degraded.
-- **`lawn_mower.am310e_nera`** — actively mowing on sunny days; a fun life signal.
+Use `ha.py states --domain sensor` to browse what's available on your instance.
 
 ## REST API Reference
 
@@ -133,16 +100,13 @@ Key endpoints:
 - `GET /api/calendars/<entity_id>?start=<iso-utc>&end=<iso-utc>` — calendar events (note: `Z` suffix required for UTC, not `+00:00`)
 - `GET /api/camera_proxy/<entity_id>` — camera snapshot (binary JPEG)
 
-## Google Calendar (Already Working)
+## Google Calendar (Alternative)
 
-The agent's Google account should be shared as a reader on the owner's main calendar.
-Use `gog` (gogcli) to query it without needing HA:
+If the agent's Google account is shared as a reader on the owner's main calendar,
+use `gog` (gogcli) directly without HA:
 
 ```bash
-# List all accessible calendars
-gog calendar calendars --results-only -j
-
-# Upcoming events (Erik's main calendar)
+# Upcoming events
 gog calendar events "<owner-google-account>" --results-only -j
 
 # Compact view
@@ -154,20 +118,10 @@ for e in json.load(sys.stdin):
 "
 ```
 
-Calendar ID: owner's Google account email (alias: "Main", timezone: Europe/Stockholm or as configured)
-
 ## Giving Another Agent the Same Capability
 
-### Google Calendar
-1. Ask the owner to share their main calendar with the agent's Google account (reader)
-2. The other agent can then use `gog calendar events "<owner-google-account>"` once the share is accepted
+1. SSH to the other agent's VM
+2. Add `HA_HOST` and `HA_API_KEY` to their `.env`
+3. Pull latest gptme-contrib — the script is at `gptme-contrib/skills/home-assistant/scripts/ha.py`
 
-### Home Assistant
-1. SSH to Alice's VM: `ssh alice@alice`
-2. Add `HA_HOST` and `HA_API_KEY` to `~/alice/.env`
-3. Pull latest gptme-contrib (skill is upstreamed there — `gptme-contrib/skills/home-assistant/`)
-
-## Related
-
-- Issue: https://github.com/ErikBjare/bob/issues/722
-- Script: `gptme-contrib/skills/home-assistant/scripts/ha.py`
+For Google Calendar: share the owner's calendar with the agent's Google account (reader access).


### PR DESCRIPTION
## Summary

Follows up on the review comment in ErikBjare/bob#722 (Erik's comment on PR #814):

> This contains a lot of my personal references. Those do not belong in a repo like gptme-contrib which is public and for general use (not just me).

The personalized version of the skill now lives in `gptme-superuser` (private, shared between Erik's agents). This PR replaces the public version with a generic one:

- Entity IDs replaced with placeholder patterns (`person.<name>`, `device_tracker.*`, etc.)
- Removed personal names, addresses, HA host URL, calendar entity names
- Removed instance-specific entity tables
- Kept `ha.py` as-is — it has no personal data
- Added guidance to discover entity IDs with `ha.py states`

The personal context (real entity IDs, `automation.fleet_gptme_ai_down` coordination signal, etc.) is preserved in the private `gptme-superuser` repo.

Closes the review concern from ErikBjare/bob#722.