### PR TITLE
fix(skills/home-assistant): depersonalize ha.py — auto-discover entities instead of hardcoding

### DIFF
--- a/skills/home-assistant/scripts/ha.py
+++ b/skills/home-assistant/scripts/ha.py
@@ -1,20 +1,19 @@
 #!/usr/bin/env python3
-"""Home Assistant CLI — query Erik's HA instance for presence, sensors, calendar, cameras.
+"""Home Assistant CLI — query a Home Assistant instance for presence, sensors, calendar, cameras.
 
 Usage:
     uv run python3 skills/home-assistant/scripts/ha.py status              # Test connectivity
-    uv run python3 skills/home-assistant/scripts/ha.py location            # Erik + Tekla location
+    uv run python3 skills/home-assistant/scripts/ha.py location            # Person/device_tracker locations
     uv run python3 skills/home-assistant/scripts/ha.py persons             # All person/device_tracker states
     uv run python3 skills/home-assistant/scripts/ha.py calendar            # Upcoming calendar events
     uv run python3 skills/home-assistant/scripts/ha.py cameras             # List cameras (+ save snapshots)
     uv run python3 skills/home-assistant/scripts/ha.py states              # All entity states
     uv run python3 skills/home-assistant/scripts/ha.py states --domain sensor   # Filter by domain
     uv run python3 skills/home-assistant/scripts/ha.py state <entity_id>   # Single entity state
-    uv run python3 skills/home-assistant/scripts/ha.py context             # Erik's full real-world context
+    uv run python3 skills/home-assistant/scripts/ha.py context             # Real-world context snapshot
     uv run python3 skills/home-assistant/scripts/ha.py --json <subcommand> # JSON output
 
 Credentials: HA_HOST and HA_API_KEY in a .env file anywhere in the CWD→root walk.
-URL: ha.hasselstugan.bjareholt.com (Nabu Casa cloud relay — publicly resolvable).
 """
 
 import argparse
@@ -91,7 +90,7 @@ def _diagnose_dns(hostname: str) -> None:
     except OSError:
         pass
     print("  ✗ Not found in /etc/hosts either", file=sys.stderr)
-    print("\n  Ask Erik for the HA server IP, then run:", file=sys.stderr)
+    print("\n  Get the HA server IP from your HA admin, then run:", file=sys.stderr)
     print(f"    echo '<IP> {hostname}' | sudo tee -a /etc/hosts", file=sys.stderr)
 
 
@@ -160,7 +159,7 @@ def cmd_state(args: argparse.Namespace) -> None:
 
 
 def cmd_location(args: argparse.Namespace) -> None:
-    """Show Erik's and Tekla's location / presence."""
+    """Show person/device_tracker locations."""
     all_states: list[dict] = ha_request("states")
     persons = [s for s in all_states if s["entity_id"].startswith("person.")]
     trackers = [s for s in all_states if s["entity_id"].startswith("device_tracker.")]
@@ -245,38 +244,36 @@ def cmd_calendar(args: argparse.Namespace) -> None:
 
 
 def cmd_context(args: argparse.Namespace) -> None:
-    """Snapshot of Erik's current real-world context — for voice/standup awareness."""
+    """Snapshot of real-world context — persons, weather, upcoming events, recent automations."""
     states: list[dict] = ha_request("states")
-    by_id = {s["entity_id"]: s for s in states}
 
-    def get(eid: str, default: str = "?") -> str:
-        s = by_id.get(eid)
-        return s["state"] if s else default
-
-    def attr(eid: str, key: str, default: str = "") -> str:
-        s = by_id.get(eid)
-        if not s:
-            return default
+    def attr(s: dict, key: str, default: str = "") -> str:
         return str(s.get("attributes", {}).get(key, default))
 
-    erik_loc = get("person.erik")
-    tekla_loc = get("person.tekla")
-    co_located = erik_loc == tekla_loc and erik_loc not in ("?", "unknown") and erik_loc
+    # Auto-discover person entities
+    person_states = [s for s in states if s["entity_id"].startswith("person.")]
+    person_locations = {s["entity_id"]: s["state"] for s in person_states}
 
-    weather_state = get("weather.forecast_hasselstugan")
-    weather_temp = attr("weather.forecast_hasselstugan", "temperature")
+    # First weather.forecast_* entity
+    weather_entities = [
+        s for s in states if s["entity_id"].startswith("weather.forecast_")
+    ]
+    weather_eid = weather_entities[0] if weather_entities else None
+    weather_state = weather_eid["state"] if weather_eid else "?"
+    weather_temp = attr(weather_eid, "temperature") if weather_eid else ""
 
-    erik_battery = get("sensor.erb_f8_battery_level")
-    erik_battery_state = get("sensor.erb_f8_battery_state")
-    lawn_mower = get("lawn_mower.am310e_nera")
+    # First lawn_mower entity (skip if none)
+    mowers = [s for s in states if s["entity_id"].startswith("lawn_mower.")]
+    lawn_mower_state = mowers[0]["state"] if mowers else None
 
-    # Next calendar event (next 4h, main calendar only — fast)
+    # Next calendar event (next 4h, configurable via HA_CONTEXT_CALENDAR env var)
+    calendar_eid = os.environ.get("HA_CONTEXT_CALENDAR", "calendar.main")
     next_event = None
     try:
         now = datetime.now(timezone.utc)
         end = now + timedelta(hours=4)
         events = ha_request(
-            "calendars/calendar.main"
+            f"calendars/{calendar_eid}"
             f"?start={now.strftime('%Y-%m-%dT%H:%M:%SZ')}"
             f"&end={end.strftime('%Y-%m-%dT%H:%M:%SZ')}"
         )
@@ -288,7 +285,7 @@ def cmd_context(args: argparse.Namespace) -> None:
     except HAError:
         pass
 
-    # Recently triggered automations of interest (last 24h)
+    # Recently triggered automations (last 24h)
     notable_automations = []
     cutoff = datetime.now(timezone.utc) - timedelta(hours=24)
     for s in states:
@@ -316,11 +313,9 @@ def cmd_context(args: argparse.Namespace) -> None:
         print(
             json.dumps(
                 {
-                    "erik": {"location": erik_loc, "phone_battery": erik_battery},
-                    "tekla": {"location": tekla_loc},
-                    "co_located": bool(co_located),
+                    "persons": person_locations,
                     "weather": {"state": weather_state, "temp_c": weather_temp},
-                    "lawn_mower": lawn_mower,
+                    "lawn_mower": lawn_mower_state,
                     "next_event_4h": next_event,
                     "automations_24h": notable_automations[:10],
                 },
@@ -329,12 +324,13 @@ def cmd_context(args: argparse.Namespace) -> None:
         )
         return
 
-    print(f"## Erik's context @ {datetime.now(timezone.utc).strftime('%H:%MZ')}")
-    print(f"- Erik:    {erik_loc}  (phone {erik_battery}% {erik_battery_state})")
-    print(f"- Tekla:   {tekla_loc}{'  (with Erik)' if co_located else ''}")
+    print(f"## HA context @ {datetime.now(timezone.utc).strftime('%H:%MZ')}")
+    for eid, loc in person_locations.items():
+        name = eid.replace("person.", "").replace("_", " ").title()
+        print(f"- {name}: {loc}")
     print(f"- Weather: {weather_state}, {weather_temp}°C")
-    if lawn_mower not in ("?", "unknown"):
-        print(f"- Mower:   {lawn_mower}")
+    if lawn_mower_state is not None and lawn_mower_state not in ("?", "unknown"):
+        print(f"- Mower:   {lawn_mower_state}")
     print(f"- Next 4h: {next_event or '(nothing scheduled)'}")
     if notable_automations:
         print(f"\n## Automations triggered in last 24h ({len(notable_automations)})")
@@ -390,13 +386,13 @@ def main() -> None:
         "--domain", help="Filter by domain (e.g. sensor, device_tracker)"
     )
     p_state = sub.add_parser("state", help="Get single entity state")
-    p_state.add_argument("entity_id", help="Entity ID (e.g. person.erik)")
+    p_state.add_argument("entity_id", help="Entity ID (e.g. person.someone)")
     sub.add_parser("location", help="Show person/device_tracker states")
     sub.add_parser("persons", help="Show all person entity states")
     sub.add_parser("calendar", help="Show upcoming calendar events (7 days)")
     sub.add_parser(
         "context",
-        help="Erik's current context snapshot (location, weather, next event, recent automations)",
+        help="Context snapshot (persons, weather, next event, recent automations)",
     )
     p_cameras = sub.add_parser(
         "cameras", help="List cameras and optionally save snapshots"

--- a/skills/home-assistant/scripts/ha.py
+++ b/skills/home-assistant/scripts/ha.py
@@ -258,9 +258,9 @@ def cmd_context(args: argparse.Namespace) -> None:
     weather_entities = [
         s for s in states if s["entity_id"].startswith("weather.forecast_")
     ]
-    weather_eid = weather_entities[0] if weather_entities else None
-    weather_state = weather_eid["state"] if weather_eid else "?"
-    weather_temp = attr(weather_eid, "temperature") if weather_eid else ""
+    weather_entity = weather_entities[0] if weather_entities else None
+    weather_state = weather_entity["state"] if weather_entity else "?"
+    weather_temp = attr(weather_entity, "temperature") if weather_entity else ""
 
     # First lawn_mower entity (skip if none)
     mowers = [s for s in states if s["entity_id"].startswith("lawn_mower.")]


### PR DESCRIPTION
## Summary

Follow-up to #817 (which depersonalized `SKILL.md`) and closes #816 (superseded).

`ha.py` still contained personal identifiers that Greptile flagged as P1 in the #816 review:
- Module docstring named "Erik's HA instance" and included the personal HA hostname
- `cmd_context` hardcoded `person.erik`, `person.tekla`, `weather.forecast_hasselstugan`, `sensor.erb_f8_battery_level/state`, `lawn_mower.am310e_nera`
- `cmd_location` docstring named "Erik's and Tekla's"
- DNS diagnostic said "Ask Erik for the HA server IP"
- `--help` text named "Erik's current context snapshot"

**Changes:**
- Module docstring: generic description, removed personal HA hostname
- `cmd_location`: generic docstring
- `cmd_context`: replaced hardcoded entity IDs with auto-discovery
  - `person.*` entities: enumerate dynamically from HA states
  - `weather.forecast_*`: use first found entity
  - `lawn_mower.*`: use first found entity
  - calendar: configurable via `HA_CONTEXT_CALENDAR` env var (default: `calendar.main`)
  - JSON output now uses `"persons": {entity_id: state}` dict instead of per-name keys
- DNS diagnostic: removed "Ask Erik" instruction
- `state` subcommand `--help` example: `person.erik` → `person.someone`
- `context` subcommand `--help`: generic description

The personal instance config (real entity IDs, HA host) lives in `gptme-superuser/skills/home-assistant/` (private).

## Test plan
- [ ] `ha.py context` auto-discovers persons instead of returning `?` for hardcoded IDs
- [ ] `ha.py context --json` returns `"persons"` dict keyed by entity ID
- [ ] `ha.py --help` shows no personal names
- [ ] No personal names remain in source