### PR TITLE
docs(trajectory-persistence): add confound_note metadata for cleanup-selection-bias

### DIFF
--- a/lessons/infrastructure/trajectory-persistence.md
+++ b/lessons/infrastructure/trajectory-persistence.md
@@ -125,9 +125,10 @@ delta.
 - Corrective (fires during risk): **negative bias** — fires in higher-harm contexts
 - After-the-fact (fires post-incident): negative — selection on outcome
 
-The `confound_note: cleanup-selection-bias` frontmatter field instructs
-downstream tooling (lesson-confidence, auto-lifecycle) to skip automated
-archival based on this signal.
+The `confound_note: cleanup-selection-bias` frontmatter field is read by
+`lesson_confidence.py` (`load_lesson_confound_note`) to treat this lesson as
+confounded, returning action `"confounded"` instead of `"archive"` even before
+the LOO state file has been populated with a `confounded=true` entry.
 
 ## Related
 - [Pre-Mortem for Risky Actions](../autonomous/pre-mortem-for-risky-actions.md) — run before any deletion logic

--- a/lessons/infrastructure/trajectory-persistence.md
+++ b/lessons/infrastructure/trajectory-persistence.md
@@ -107,6 +107,28 @@ Following this rule prevents:
 - **Broken debugging**: Post-hoc analysis becomes impossible without the original trace
 - **Trust violations**: User safety settings (`cleanupPeriodDays: 1000000`) must never be overridden by scripts
 
+## LOO Analysis Note
+
+Leave-one-out (LOO) analysis shows Δ=−0.0841 (p=0.009) against the harm
+target. This is a **selection-bias artifact, not a causal effect**:
+
+This lesson is *corrective*: it fires when the agent is already contemplating
+trajectory deletion — an inherently higher-harm context. The LOO delta
+measures `baseline_harm + lesson_mitigation` vs the uncontaminated baseline
+(sessions where deletion was never discussed). Even if the lesson successfully
+reduces harm within those sessions, the residual harm score after mitigation
+is still higher than the no-deletion-discussion baseline, producing a negative
+delta.
+
+**Lesson type → LOO bias**:
+- Preventive (fires before risk): LOO signal can be positive
+- Corrective (fires during risk): **negative bias** — fires in higher-harm contexts
+- After-the-fact (fires post-incident): negative — selection on outcome
+
+The `confound_note: cleanup-selection-bias` frontmatter field instructs
+downstream tooling (lesson-confidence, auto-lifecycle) to skip automated
+archival based on this signal.
+
 ## Related
 - [Pre-Mortem for Risky Actions](../autonomous/pre-mortem-for-risky-actions.md) — run before any deletion logic
 - [Autonomous Operation Safety](../autonomous/autonomous-operation-safety.md) — boundaries for autonomous actions

--- a/lessons/infrastructure/trajectory-persistence.md
+++ b/lessons/infrastructure/trajectory-persistence.md
@@ -125,10 +125,12 @@ delta.
 - Corrective (fires during risk): **negative bias** — fires in higher-harm contexts
 - After-the-fact (fires post-incident): negative — selection on outcome
 
-The `confound_note: cleanup-selection-bias` frontmatter field is read by
-`lesson_confidence.py` (`load_lesson_confound_note`) to treat this lesson as
-confounded, returning action `"confounded"` instead of `"archive"` even before
-the LOO state file has been populated with a `confounded=true` entry.
+The `confound_note` frontmatter field is consumed by agent-workspace tooling
+(e.g. `lesson_confidence.py` → `load_lesson_confound_note` in the agent's
+`metaproductivity` package) to treat this lesson as confounded and skip
+automated archival.  The field is not implemented in gptme-contrib itself —
+it is listed in `validate.py`'s `allowed_fields` so the validator accepts it,
+and the consuming implementation lives in the agent's own workspace.
 
 ## Related
 - [Pre-Mortem for Risky Actions](../autonomous/pre-mortem-for-risky-actions.md) — run before any deletion logic

--- a/lessons/infrastructure/trajectory-persistence.md
+++ b/lessons/infrastructure/trajectory-persistence.md
@@ -12,6 +12,7 @@ match:
   session_categories: [infrastructure, cleanup]
 target_grade: harm
 status: active
+confound_note: "cleanup-selection-bias — LOO-negative because it fires in inherently higher-harm cleanup contexts, not because it causes harm"
 ---
 
 # Trajectory Persistence

--- a/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
+++ b/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
@@ -228,6 +228,8 @@ class LessonValidator:
                         f"{', '.join(sorted(flat_automation_fields))} are present; "
                         "remove the flat fields in favour of the 'automation' block"
                     )
+            if "confound_note" in frontmatter:
+                self._check_confound_note_field(frontmatter["confound_note"])
 
         except (ValueError, yaml.YAMLError) as e:
             self.errors.append(f"Invalid YAML frontmatter: {e}")
@@ -328,6 +330,23 @@ class LessonValidator:
             self.errors.append(
                 f"automation.enforcement must be 'warning' or 'error', got {enforcement!r}"
             )
+
+    def _check_confound_note_field(self, value: object) -> None:
+        """Validate the optional ``confound_note`` frontmatter field.
+
+        Must be a non-empty string describing the confound.  Boolean values are
+        rejected (YAML ``true``/``false`` are a common accidental substitution).
+        """
+        if isinstance(value, bool):
+            self.errors.append(
+                "confound_note must be a non-empty string, not a boolean"
+            )
+        elif not isinstance(value, str):
+            self.errors.append(
+                f"confound_note must be a non-empty string, got {type(value).__name__}"
+            )
+        elif not value.strip():
+            self.errors.append("confound_note must not be an empty string")
 
     def _validate_two_file_format(self):
         """Validate two-file format (concise primary + companion)."""

--- a/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
+++ b/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
@@ -199,6 +199,7 @@ class LessonValidator:
                 "deprecated_date",
                 "archived_reason",
                 "archived_date",
+                "confound_note",
             }
             extra_fields = set(frontmatter.keys()) - allowed_fields
             if extra_fields:

--- a/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
+++ b/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
@@ -165,6 +165,11 @@ class LessonValidator:
           ``notes`` (free-form description of partial automation or caveats).
         - ``deprecated_by`` / ``deprecated_date``: Set once on deprecation.
         - ``archived_reason`` / ``archived_date``: Set once on archival.
+        - ``confound_note``: Optional string documenting a known confound that causes
+          LOO analysis to misattribute harm (e.g. corrective lessons that fire in
+          inherently higher-risk contexts).  Consumed by agent-workspace tooling
+          (e.g. ``lesson_confidence.py``) to skip automated archival.  Set once
+          and left stable; not recalculated.
 
         Do NOT add auto-computed or frequently-updated scores here (e.g. ``confidence``,
         ``effectiveness``, ``score``).  Such values are recalculated on every analysis

--- a/packages/gptme-lessons-extras/tests/test_validate.py
+++ b/packages/gptme-lessons-extras/tests/test_validate.py
@@ -337,3 +337,54 @@ def test_automation_coexists_with_flat_fields_warns():
         assert (
             coexist_warnings
         ), "Coexisting 'automation' block and flat automated_by field should warn"
+
+
+# confound_note field tests
+
+
+def test_confound_note_string_accepted():
+    """A non-empty confound_note string should be accepted without errors."""
+    content = _VALID_LESSON.format(
+        extra='confound_note: "corrective lesson — fires in higher-harm contexts"'
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        path = _write_lesson(Path(tmp), content)
+        validator = LessonValidator(path)
+        validator.validate()
+        confound_errors = [e for e in validator.errors if "confound_note" in e]
+        assert (
+            not confound_errors
+        ), f"Valid confound_note should not produce errors: {confound_errors}"
+
+
+def test_confound_note_empty_string_rejected():
+    """An empty confound_note string should produce an error."""
+    content = _VALID_LESSON.format(extra='confound_note: ""')
+    with tempfile.TemporaryDirectory() as tmp:
+        path = _write_lesson(Path(tmp), content)
+        validator = LessonValidator(path)
+        validator.validate()
+        confound_errors = [e for e in validator.errors if "confound_note" in e]
+        assert confound_errors, "Empty confound_note should produce an error"
+
+
+def test_confound_note_bool_rejected():
+    """A boolean confound_note should produce an error."""
+    content = _VALID_LESSON.format(extra="confound_note: true")
+    with tempfile.TemporaryDirectory() as tmp:
+        path = _write_lesson(Path(tmp), content)
+        validator = LessonValidator(path)
+        validator.validate()
+        confound_errors = [e for e in validator.errors if "confound_note" in e]
+        assert confound_errors, "Boolean confound_note should produce an error"
+
+
+def test_confound_note_wrong_type_rejected():
+    """A non-string confound_note (e.g. integer) should produce an error."""
+    content = _VALID_LESSON.format(extra="confound_note: 42")
+    with tempfile.TemporaryDirectory() as tmp:
+        path = _write_lesson(Path(tmp), content)
+        validator = LessonValidator(path)
+        validator.validate()
+        confound_errors = [e for e in validator.errors if "confound_note" in e]
+        assert confound_errors, "Non-string confound_note should produce an error"


### PR DESCRIPTION
LOO analysis shows Δ=−0.0841 (p=0.009) against harm target on this lesson, but it passes all automated confound checks. The signal is a latent selection bias: the lesson fires in cleanup/infrastructure contexts that are inherently higher-harm-risk. The negative delta reflects residual harm after correction, not causation.

Analysis note: `knowledge/analysis/trajectory-persistence-selection-bias-2026-05-03.md` (in Bob's workspace — not in this repo)