### PR TITLE
fix(twitter): add URL validation in post() to prevent 404 tweets

### DIFF
--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -1289,6 +1289,19 @@ def post(
 
         if yes or Confirm.ask("Post this tweet?", default=True):
             try:
+                # URL validation: catch 404s before posting
+                if draft.text:
+                    bad_urls = _validate_urls_in_text(draft.text)
+                    if bad_urls:
+                        for url, status in bad_urls:
+                            console.print(f"[red]✗ URL returns {status}: {url}[/red]")
+                        console.print(
+                            "[red]Skipping draft — fix URLs or re-draft with "
+                            "--skip-url-check.[/red]"
+                        )
+                        move_draft(path, "rejected")
+                        continue
+
                 # Post the main tweet
                 response = client.create_tweet(
                     text=draft.text,

--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -1207,8 +1207,17 @@ def _git_commit_posted(path: Path) -> None:
     type=int,
     help=f"Max tweets to post in one run (default: {MAX_POSTS_PER_CYCLE} when --yes is used, unlimited otherwise)",
 )
+@click.option(
+    "--skip-url-check",
+    is_flag=True,
+    help="Skip HEAD-check of URLs in tweet text (use when URLs are intentionally pre-publish)",
+)
 def post(
-    dry_run: bool, yes: bool, draft_id: str | None = None, max_posts: int | None = None
+    dry_run: bool,
+    yes: bool,
+    draft_id: str | None = None,
+    max_posts: int | None = None,
+    skip_url_check: bool = False,
 ) -> None:
     """Post approved tweets"""
     # Apply rate limit: default to MAX_POSTS_PER_CYCLE when running non-interactively (--yes)
@@ -1287,21 +1296,20 @@ def post(
             console.print(f"[blue]Draft ID: {path.stem}[/blue]")
             continue
 
+        # URL validation: catch 404s before asking for confirmation
+        if not skip_url_check and draft.text:
+            bad_urls = _validate_urls_in_text(draft.text)
+            if bad_urls:
+                for url, status in bad_urls:
+                    console.print(f"[red]✗ URL returns {status}: {url}[/red]")
+                console.print(
+                    "[red]Skipping draft — fix URLs or pass --skip-url-check.[/red]"
+                )
+                move_draft(path, "rejected")
+                continue
+
         if yes or Confirm.ask("Post this tweet?", default=True):
             try:
-                # URL validation: catch 404s before posting
-                if draft.text:
-                    bad_urls = _validate_urls_in_text(draft.text)
-                    if bad_urls:
-                        for url, status in bad_urls:
-                            console.print(f"[red]✗ URL returns {status}: {url}[/red]")
-                        console.print(
-                            "[red]Skipping draft — fix URLs or re-draft with "
-                            "--skip-url-check.[/red]"
-                        )
-                        move_draft(path, "rejected")
-                        continue
-
                 # Post the main tweet
                 response = client.create_tweet(
                     text=draft.text,


### PR DESCRIPTION
## Problem

The `post` function in `workflow.py` had no URL validation before posting. URL validation only existed in the `draft` command (added in an earlier fix). Sessions that write directly to `tweets/new/` or `tweets/approved/` bypassed the draft-stage check entirely, allowing tweets with broken URLs (e.g., 404s from wrong `/blog/` prefix) to be posted.

ErikBjare/bob#728 — Erik replied "404 :(" to Bob tweets and nothing happened because the URL check only guarded draft-time input, not posting.

## Fix

Call `_validate_urls_in_text(draft.text)` before `client.create_tweet()` in the `post` function. If any URL returns 4xx/5xx, the draft is rejected (moved to `rejected/`) instead of posted.

The `rejected` folder path is used (not `retry/`) because URL validation failure is a content problem — re-posting a draft with a broken URL won't fix it. The author needs to fix the URL and re-draft.