### PR TITLE
fix(sessions): raise grade floor for monitoring sessions with minor errors

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -413,11 +413,13 @@ def grade_signals(signals: dict, *, category: str | None = None) -> float:
         # Distinguish dead sessions (zero tool calls) from active-but-unproductive ones
         if total_tools == 0:
             reward = 0.10
-        elif is_non_commit_category and errors == 0:
-            # Non-commit categories (monitoring, triage, etc.) that ran tools
-            # without errors but produced no writes/interactions are likely
-            # "correctly found no work" sessions, not failures. Give a neutral
-            # grade instead of the 0.25 floor.
+        elif is_non_commit_category:
+            # Non-commit categories (monitoring, triage, social, self-review, research)
+            # that ran tools but produced no writes/interactions are likely "correctly
+            # found no work" sessions, not failures. Give a neutral grade instead of
+            # the 0.25 floor — even when errors > 0. Errors in these categories often
+            # come from gh CLI commands returning non-zero for "no results found" or
+            # transient API issues, not actual session failures.
             reward = 0.35
         else:
             reward = 0.25

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -368,9 +368,14 @@ def grade_signals(signals: dict, *, category: str | None = None) -> float:
         signals: Raw signal dict from extract_signals* functions.
         category: Optional session category hint. When the category is one
             where commits are not the primary output (monitoring, research,
-            triage, social, self-review), the threshold for the 0.55 reward
-            tier is lowered from 3 effective writes to 1, preventing
-            productive review/triage sessions from being floor-graded.
+            triage, social, self-review), two adjustments apply:
+            1. The threshold for the 0.55 reward tier is lowered from 3
+               effective writes to 1, preventing productive review/triage
+               sessions from being floor-graded.
+            2. Tool-active sessions with no writes or interactions get a
+               neutral 0.35 floor instead of 0.25, treating "correctly found
+               no work" scans as non-failures even when errors > 0 (e.g. gh
+               CLI returning non-zero for "no results found").
     """
     commits = len(signals["git_commits"])
     # Use unique writes for tier placement — repeated edits to the same file

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -7212,7 +7212,12 @@ def test_grade_signals_category_aware_no_interaction():
 
 
 def test_grade_signals_category_aware_no_interaction_with_errors():
-    """Non-commit category with errors still gets the active-but-empty 0.25 floor."""
+    """Non-commit category at the error-rate boundary gets the raised 0.35 floor.
+
+    error_rate = 1/20 = 0.05, which is NOT > 0.05, so no error penalty applies.
+    The PR that removed the `errors == 0` gate means non-commit categories now
+    get 0.35 regardless of error count (penalty still applies for >5% error rate).
+    """
     sigs = {
         "git_commits": [],
         "file_writes": [],
@@ -7225,7 +7230,7 @@ def test_grade_signals_category_aware_no_interaction_with_errors():
         "prs_submitted": [],
         "issues_closed": 0,
     }
-    assert grade_signals(sigs, category="monitoring") == pytest.approx(0.25)
+    assert grade_signals(sigs, category="monitoring") == pytest.approx(0.35)
 
 
 def test_grade_signals_category_does_not_affect_commit_tiers():

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -1475,6 +1475,36 @@ def test_grade_signals_noop():
     assert grade_signals(sigs) == 0.25
 
 
+def test_grade_signals_monitoring_no_work_with_errors():
+    """Monitoring sessions that correctly find no work get neutral 0.35
+    even when they have minor errors (e.g. gh CLI returning non-zero
+    for 'no results'). Without this, low-error monitoring scans get
+    penalized at 0.25 or 0.15, suppressing the monitoring category in
+    Thompson sampling."""
+    sigs = {
+        "git_commits": [],
+        "file_writes": [],
+        "error_count": 2,
+        "retry_count": 0,
+        "tool_calls": {"Bash": 8},
+    }
+    # Without category hint: regular floor 0.25, minus error-rate penalty
+    # error_rate = 2/8 = 0.25 > 0.15 → -0.10 → 0.25 - 0.10 = 0.15
+    assert grade_signals(sigs) == pytest.approx(0.15)
+    # With monitoring category: neutral 0.35 floor, same error penalty
+    # 0.35 - 0.10 = 0.25 — improved from 0.15 without the fix
+    assert grade_signals(sigs, category="monitoring") == pytest.approx(0.25)
+    # For monitoring with very low errors (<5%): full neutral 0.35
+    sigs_low_err = {
+        "git_commits": [],
+        "file_writes": [],
+        "error_count": 0,
+        "retry_count": 0,
+        "tool_calls": {"Bash": 8},
+    }
+    assert grade_signals(sigs_low_err, category="monitoring") == pytest.approx(0.35)
+
+
 def test_grade_signals_productive():
     """Grade is higher when commits are present."""
     msgs = _make_cc_msgs(commits=2)


### PR DESCRIPTION
## Problem

Monitoring sessions that correctly find no actionable work were getting floor-graded at 0.25 (or 0.15 after error-rate penalty) even though they completed their scan correctly. The "errors" were typically gh CLI commands returning non-zero for "no results found" — not session failures.

From session-records.jsonl analysis (820 monitoring <60s):
- 62 sessions at 0.25 (tool-active but degraded by non-zero errors)
- 24 sessions at 0.15 (0.25 minus 0.10 error-rate penalty)
- 3 sessions at 0.10 (truly zero-tool)

## Fix

Remove the `errors == 0` gate on the 0.35 neutral-floor for non-commit categories (monitoring, triage, social, self-review, research). These categories produce non-code output by nature, so CLI stderr noise shouldn't drag their floor grade down to failure-equivalent levels.

The error-rate penalty still applies *on top of* the 0.35 floor, so a monitoring session with >15% error rate still gets docked — but from 0.35 instead of 0.25, making the net grade 0.25 instead of 0.15.

## Impact

After this fix:
- Clean monitoring scans (errors=0): 0.35 (was 0.35 — no change)
- Monitoring scans with minor errors (<5%): 0.35 (was 0.25 — improved)
- Monitoring scans with moderate errors (5-15%): 0.30 (was 0.20 — improved)
- Monitoring scans with high errors (>15%): 0.25 (was 0.15 — improved)

## Related

- Bob task: `tasks/monitoring-session-grading-bias.md`
- ErikBjare/bob discussion on monitoring category suppression in Thompson sampling