### PR TITLE
feat(gptodo): add wait: and recur: for time-based and recurring tasks

### DIFF
--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -1425,9 +1425,11 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask):
         # Keep "none" as the explicit clear value; otherwise accept any string.
         "assigned_to": {"type": "string"},
         "waiting_since": {"type": "date"},
+        "wait": {"type": "date"},  # Hide from queue until this date
         # Optional fields with arbitrary string values
         "next_action": {"type": "string"},
         "waiting_for": {"type": "string"},
+        "recur": {"type": "string"},  # Recurrence interval (7d, 24h, weekly, monthly)
         "parent": {"type": "string"},  # Parent task ID (for subtasks)
         # List fields handled separately via --add/--remove
         "tags": {"type": "list"},
@@ -1478,16 +1480,27 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask):
                 console.print(f"[red]Invalid {field}: {value}. Valid values: {valid}[/]")
                 return
         elif field_spec["type"] == "date":
-            try:
-                # Parse and validate the date format
-                created_dt = datetime.fromisoformat(value)
-                # Convert to string format for storage
-                value = created_dt.isoformat()
-            except ValueError:
-                console.print(
-                    f"[red]Invalid {field} date format. Use ISO format (YYYY-MM-DD[THH:MM:SS+HH:MM])[/]"
-                )
-                return
+            from datetime import date as _date
+
+            # wait: stores as date-only (YYYY-MM-DD); other date fields store full ISO datetime
+            if field == "wait":
+                try:
+                    _date.fromisoformat(value[:10])
+                    value = value[:10]  # normalise to YYYY-MM-DD
+                except ValueError:
+                    console.print(f"[red]Invalid {field} date format. Use YYYY-MM-DD[/]")
+                    return
+            else:
+                try:
+                    # Parse and validate the date format
+                    created_dt = datetime.fromisoformat(value)
+                    # Convert to string format for storage
+                    value = created_dt.isoformat()
+                except ValueError:
+                    console.print(
+                        f"[red]Invalid {field} date format. Use ISO format (YYYY-MM-DD[THH:MM:SS+HH:MM])[/]"
+                    )
+                    return
         elif field_spec["type"] == "string":
             # Arbitrary string value - no validation needed
             pass
@@ -1653,6 +1666,22 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask):
             # Re-load task to get updated metadata
             post = frontmatter.load(task.path)
             if post.metadata.get("state") == "done":
+                # Handle recur: reset task to todo and advance wait: date
+                recur = post.metadata.get("recur")
+                if recur:
+                    from gptodo.utils import advance_wait, parse_wait_date
+
+                    current_wait = parse_wait_date(post.metadata.get("wait"))
+                    next_wait = advance_wait(current_wait, recur)
+                    post.metadata["state"] = "todo"
+                    post.metadata["wait"] = next_wait.isoformat()
+                    with open(task.path, "w") as f:
+                        f.write(frontmatter.dumps(post))
+                    console.print(
+                        f"[cyan]↩ {task.name} recurring — reset to todo, next wait: {next_wait}[/]"
+                    )
+                    continue  # skip done-completion logic for recurring tasks
+
                 completed_task_ids.append(task.id)
 
                 # Run task completion hook if configured via env var

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -1480,21 +1480,23 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask):
                 console.print(f"[red]Invalid {field}: {value}. Valid values: {valid}[/]")
                 return
         elif field_spec["type"] == "date":
-            from datetime import date as _date
-
-            # wait: stores as date-only (YYYY-MM-DD); other date fields store full ISO datetime
+            # wait: accepts YYYY-MM-DD or YYYY-MM-DDTHH:MM; other date fields store full ISO datetime
             if field == "wait":
-                try:
-                    _date.fromisoformat(value[:10])
-                    value = value[:10]  # normalise to YYYY-MM-DD
-                except ValueError:
-                    console.print(f"[red]Invalid {field} date format. Use YYYY-MM-DD[/]")
+                from gptodo.utils import parse_wait
+
+                parsed = parse_wait(value)
+                if parsed is None:
+                    console.print(
+                        f"[red]Invalid {field} format. Use YYYY-MM-DD or YYYY-MM-DDTHH:MM[/]"
+                    )
                     return
+                if isinstance(parsed, datetime):
+                    value = parsed.isoformat()
+                else:
+                    value = parsed.isoformat()
             else:
                 try:
-                    # Parse and validate the date format
                     created_dt = datetime.fromisoformat(value)
-                    # Convert to string format for storage
                     value = created_dt.isoformat()
                 except ValueError:
                     console.print(
@@ -1669,9 +1671,9 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask):
                 # Handle recur: reset task to todo and advance wait: date
                 recur = post.metadata.get("recur")
                 if recur:
-                    from gptodo.utils import advance_wait, parse_wait_date
+                    from gptodo.utils import advance_wait, parse_wait
 
-                    current_wait = parse_wait_date(post.metadata.get("wait"))
+                    current_wait = parse_wait(post.metadata.get("wait"))
                     next_wait = advance_wait(current_wait, recur)
                     post.metadata["state"] = "todo"
                     post.metadata["wait"] = next_wait.isoformat()

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -1504,8 +1504,16 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask):
                     )
                     return
         elif field_spec["type"] == "string":
+            if field == "recur":
+                from gptodo.utils import is_valid_recur_value
+
+                if not is_valid_recur_value(value):
+                    console.print(
+                        "[red]Invalid recur format. Use 7d, 24h, weekly, monthly, "
+                        "or a cron expression like '0 9 * * 1'[/]"
+                    )
+                    return
             # Arbitrary string value - no validation needed
-            pass
 
         changes.append(("set", field, value))
 

--- a/packages/gptodo/src/gptodo/generate_queue.py
+++ b/packages/gptodo/src/gptodo/generate_queue.py
@@ -23,7 +23,7 @@ import json
 import os
 import subprocess
 import sys
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import List
 
@@ -195,8 +195,18 @@ class QueueGenerator:
 
                 # Filter by state (new or active only)
                 state = post.metadata.get("state", "new")
-                if state not in ("new", "active"):
+                if state not in ("new", "active", "todo", "backlog"):
                     continue
+
+                # Skip tasks whose wait: date hasn't arrived yet
+                wait_val = post.metadata.get("wait")
+                if wait_val:
+                    try:
+                        wait_date = date.fromisoformat(str(wait_val)[:10])
+                        if wait_date > date.today():
+                            continue
+                    except ValueError:
+                        pass
 
                 # Filter by assigned_to if --user is specified
                 if self.user:
@@ -405,6 +415,15 @@ class QueueGenerator:
                     post = frontmatter.load(task_file)
                     if post.metadata.get("state") == "waiting" or post.metadata.get("waiting_for"):
                         continue
+                    # Skip tasks whose wait: date hasn't arrived yet
+                    wait_val = post.metadata.get("wait")
+                    if wait_val:
+                        try:
+                            wait_date = date.fromisoformat(str(wait_val)[:10])
+                            if wait_date > date.today():
+                                continue
+                        except ValueError:
+                            pass
                 except Exception:
                     pass
 

--- a/packages/gptodo/src/gptodo/generate_queue.py
+++ b/packages/gptodo/src/gptodo/generate_queue.py
@@ -206,7 +206,7 @@ class QueueGenerator:
                     parsed = parse_wait(wait_val)
                     if parsed is not None:
                         if isinstance(parsed, datetime):
-                            if parsed > datetime.now():
+                            if parsed > datetime.now(tz=parsed.tzinfo):
                                 continue
                         elif parsed > date.today():
                             continue

--- a/packages/gptodo/src/gptodo/generate_queue.py
+++ b/packages/gptodo/src/gptodo/generate_queue.py
@@ -24,6 +24,8 @@ import os
 import subprocess
 import sys
 from datetime import date, datetime, timezone
+
+from gptodo.utils import parse_wait
 from pathlib import Path
 from typing import List
 
@@ -195,18 +197,19 @@ class QueueGenerator:
 
                 # Filter by state (new or active only)
                 state = post.metadata.get("state", "new")
-                if state not in ("new", "active", "todo", "backlog"):
+                if state not in ("new", "active", "todo"):
                     continue
 
-                # Skip tasks whose wait: date hasn't arrived yet
+                # Skip tasks whose wait: date/time hasn't arrived yet
                 wait_val = post.metadata.get("wait")
                 if wait_val:
-                    try:
-                        wait_date = date.fromisoformat(str(wait_val)[:10])
-                        if wait_date > date.today():
+                    parsed = parse_wait(wait_val)
+                    if parsed is not None:
+                        if isinstance(parsed, datetime):
+                            if parsed > datetime.now():
+                                continue
+                        elif parsed > date.today():
                             continue
-                    except ValueError:
-                        pass
 
                 # Filter by assigned_to if --user is specified
                 if self.user:
@@ -415,15 +418,16 @@ class QueueGenerator:
                     post = frontmatter.load(task_file)
                     if post.metadata.get("state") == "waiting" or post.metadata.get("waiting_for"):
                         continue
-                    # Skip tasks whose wait: date hasn't arrived yet
+                    # Skip tasks whose wait: date/time hasn't arrived yet
                     wait_val = post.metadata.get("wait")
                     if wait_val:
-                        try:
-                            wait_date = date.fromisoformat(str(wait_val)[:10])
-                            if wait_date > date.today():
+                        parsed = parse_wait(wait_val)
+                        if parsed is not None:
+                            if isinstance(parsed, datetime):
+                                if parsed > datetime.now():
+                                    continue
+                            elif parsed > date.today():
                                 continue
-                        except ValueError:
-                            pass
                 except Exception:
                     pass
 

--- a/packages/gptodo/src/gptodo/generate_queue.py
+++ b/packages/gptodo/src/gptodo/generate_queue.py
@@ -424,7 +424,7 @@ class QueueGenerator:
                         parsed = parse_wait(wait_val)
                         if parsed is not None:
                             if isinstance(parsed, datetime):
-                                if parsed > datetime.now():
+                                if parsed > datetime.now(tz=parsed.tzinfo):
                                     continue
                             elif parsed > date.today():
                                 continue

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -491,7 +491,11 @@ def advance_wait(current_wait: date | None, recur: str) -> date:
     if interval is None:
         # Fallback for unrecognised intervals: schedule 7 days from today
         return date.today() + timedelta(days=7)
-    return base + interval
+    # Python's date arithmetic silently drops sub-day components
+    # (date + timedelta(hours=12) == date + timedelta(days=0) == same day).
+    # Round up to at least 1 day so "12h" doesn't schedule the task immediately.
+    days = interval.days if interval.days > 0 else 1
+    return base + timedelta(days=days)
 
 
 def task_is_waiting_for_date(task: "TaskInfo") -> bool:

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -24,6 +24,7 @@ from typing import (
     Dict,
     List,
     NamedTuple,
+    Optional,
     Tuple,
 )
 
@@ -276,6 +277,11 @@ class TaskInfo:
     subtasks: SubtaskCount
     issues: List[str]
     metadata: Dict
+    # Scheduling fields
+    wait: Optional[date] = (
+        None  # Hide from queue until this date (inclusive: task appears on this date)
+    )
+    recur: Optional[str] = None  # Recurrence interval: 7d, 24h, weekly, monthly, or cron expression
     # Multi-agent coordination fields (Phase 2)
     parallelizable: bool = False  # Can run concurrently with other work
     isolation: str | None = None  # none, worktree, container
@@ -427,6 +433,72 @@ def format_time_ago(dt: datetime) -> str:
         return f"{days}d ago"
     else:
         return dt.strftime("%Y-%m-%d")
+
+
+def parse_wait_date(value: Any) -> date | None:
+    """Parse a wait: field value into a date.
+
+    Accepts: date objects, datetime objects, YYYY-MM-DD strings, ISO datetime strings.
+    Returns None if value is missing or unparseable.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        try:
+            return date.fromisoformat(value[:10])
+        except ValueError:
+            return None
+    return None
+
+
+def parse_recur_interval(recur: str) -> timedelta | None:
+    """Parse a recur: field value into a timedelta (or None for unsupported formats).
+
+    Supported formats:
+    - "Nd"  / "Nh" — N days / N hours
+    - "weekly" — 7 days
+    - "monthly" — 30 days (calendar-approximate)
+    - cron expressions are accepted as a string but return None (not yet computed here)
+    """
+    if not recur:
+        return None
+    recur = recur.strip()
+    if recur == "weekly":
+        return timedelta(days=7)
+    if recur == "monthly":
+        return timedelta(days=30)
+    m = re.fullmatch(r"(\d+)d", recur)
+    if m:
+        return timedelta(days=int(m.group(1)))
+    m = re.fullmatch(r"(\d+)h", recur)
+    if m:
+        return timedelta(hours=int(m.group(1)))
+    return None  # cron or unrecognised — caller decides
+
+
+def advance_wait(current_wait: date | None, recur: str) -> date:
+    """Compute the next wait: date after completing a recurring task.
+
+    If current_wait is in the past (or None), uses today as the base so that
+    a lapsed recurring task re-schedules from now, not from the stale date.
+    """
+    interval = parse_recur_interval(recur)
+    base = max(current_wait or date.today(), date.today())
+    if interval is None:
+        # Fallback for unrecognised intervals: schedule 7 days from today
+        return date.today() + timedelta(days=7)
+    return base + interval
+
+
+def task_is_waiting_for_date(task: "TaskInfo") -> bool:
+    """Return True when a task has a wait: date that hasn't arrived yet."""
+    if task.wait is None:
+        return False
+    return task.wait > date.today()
 
 
 def has_new_activity(updated_at: str | None, waiting_since: str | date | None) -> bool:
@@ -615,6 +687,12 @@ def validate_task_file(file: Path, post: fmPost) -> List[str]:
     if "discovered-from" in metadata and not isinstance(metadata["discovered-from"], list):
         issues.append("Discovered-from must be a list")
 
+    # Validate wait: field (must be a parseable date)
+    if "wait" in metadata:
+        wait_val = metadata["wait"]
+        if parse_wait_date(wait_val) is None and not isinstance(wait_val, (date, datetime)):
+            issues.append("wait must be a date (YYYY-MM-DD) or datetime")
+
     return issues
 
 
@@ -785,6 +863,9 @@ def load_tasks(
                 subtasks=subtasks,
                 issues=issues,
                 metadata=metadata,
+                # Scheduling fields
+                wait=parse_wait_date(metadata.get("wait")),
+                recur=metadata.get("recur"),
                 # Multi-agent coordination fields (Phase 2)
                 parallelizable=bool(metadata.get("parallelizable", False)),
                 isolation=metadata.get("isolation"),
@@ -846,6 +927,9 @@ def task_to_dict(task: TaskInfo) -> Dict[str, Any]:
             "total": task.subtasks.total,
         },
         "has_issues": task.has_issues,
+        # Scheduling fields
+        "wait": task.wait.isoformat() if task.wait else None,
+        "recur": task.recur,
         # Multi-agent coordination fields
         "parallelizable": task.parallelizable,
         "isolation": task.isolation,
@@ -883,6 +967,10 @@ def is_task_ready(
         True if task is ready, False if blocked
     """
     if task_has_waiting_blocker(task):
+        return False
+
+    # Skip tasks whose wait: date hasn't arrived yet
+    if task_is_waiting_for_date(task):
         return False
 
     # Use requires (canonical field, includes deprecated depends/blocks)

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -694,7 +694,7 @@ def validate_task_file(file: Path, post: fmPost) -> List[str]:
     # Validate wait: field (must be a parseable date)
     if "wait" in metadata:
         wait_val = metadata["wait"]
-        if parse_wait_date(wait_val) is None and not isinstance(wait_val, (date, datetime)):
+        if parse_wait_date(wait_val) is None:
             issues.append("wait must be a date (YYYY-MM-DD) or datetime")
 
     return issues

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -278,7 +278,7 @@ class TaskInfo:
     issues: List[str]
     metadata: Dict
     # Scheduling fields
-    wait: Optional[date] = (
+    wait: Optional[date | datetime] = (
         None  # Hide from queue until this date (inclusive: task appears on this date)
     )
     recur: Optional[str] = None  # Recurrence interval: 7d, 24h, weekly, monthly, or cron expression
@@ -435,24 +435,45 @@ def format_time_ago(dt: datetime) -> str:
         return dt.strftime("%Y-%m-%d")
 
 
-def parse_wait_date(value: Any) -> date | None:
-    """Parse a wait: field value into a date.
+def parse_wait(value: Any) -> date | datetime | None:
+    """Parse a wait: field value into a date or datetime.
 
     Accepts: date objects, datetime objects, YYYY-MM-DD strings, ISO datetime strings.
+    - YYYY-MM-DD (date-only) → date
+    - YYYY-MM-DDTHH:MM or YYYY-MM-DD HH:MM (with time) → datetime
+    - datetime objects preserved as-is
+    - date objects preserved as-is (date-only = available any time on/after this date)
     Returns None if value is missing or unparseable.
     """
     if value is None:
         return None
     if isinstance(value, datetime):
-        return value.date()
+        return value
     if isinstance(value, date):
         return value
     if isinstance(value, str):
         try:
+            # Try full ISO datetime first (has T or time component)
+            if "T" in value or " " in value:
+                cleaned = value.replace(" ", "T")
+                return datetime.fromisoformat(cleaned)
+            # Fall back to date-only
             return date.fromisoformat(value[:10])
-        except ValueError:
+        except (ValueError, TypeError):
             return None
     return None
+
+
+def parse_wait_date(value: Any) -> date | None:
+    """Legacy wrapper — parse a wait: field value into a date.
+
+    For backward compatibility: strips time info, returns only the date.
+    New code should use parse_wait() instead.
+    """
+    result = parse_wait(value)
+    if isinstance(result, datetime):
+        return result.date()
+    return result
 
 
 def parse_recur_interval(recur: str) -> timedelta | None:
@@ -480,28 +501,45 @@ def parse_recur_interval(recur: str) -> timedelta | None:
     return None  # cron or unrecognised — caller decides
 
 
-def advance_wait(current_wait: date | None, recur: str) -> date:
-    """Compute the next wait: date after completing a recurring task.
+def advance_wait(current_wait: date | datetime | None, recur: str) -> date | datetime:
+    """Compute the next wait: value after completing a recurring task.
 
-    If current_wait is in the past (or None), uses today as the base so that
-    a lapsed recurring task re-schedules from now, not from the stale date.
+    Behaviour depends on the wait type and recur interval:
+    - Sub-day intervals (e.g. "12h", "6h"): always return a datetime with exact
+      precision, regardless of current_wait type. date-only can't represent sub-day.
+    - Day+ intervals with a datetime current_wait: return datetime, preserving precision.
+    - Day+ intervals with a date or None current_wait: return date (simpler, no TZ issues).
+    - Lapsed tasks (current_wait in the past) re-schedule from now, not the stale date.
     """
     interval = parse_recur_interval(recur)
-    base = max(current_wait or date.today(), date.today())
+    now = datetime.now()
+
+    if isinstance(current_wait, datetime):
+        # DateTime precision: use the current datetime as base if lapsed
+        base = now if current_wait < now else current_wait
+        return (now + timedelta(days=7)) if interval is None else (base + interval)
+
+    # Date-only or None path
+    today = date.today()
     if interval is None:
-        # Fallback for unrecognised intervals: schedule 7 days from today
-        return date.today() + timedelta(days=7)
-    # Python's date arithmetic silently drops sub-day components
-    # (date + timedelta(hours=12) == date + timedelta(days=0) == same day).
-    # Round up to at least 1 day so "12h" doesn't schedule the task immediately.
-    days = interval.days if interval.days > 0 else 1
-    return base + timedelta(days=days)
+        return today + timedelta(days=7)
+    # Sub-day interval: date arithmetic silently drops hours; return datetime instead
+    if interval.days == 0:
+        return now + interval
+    date_base = max(current_wait or today, today)
+    return date_base + timedelta(days=interval.days)
 
 
 def task_is_waiting_for_date(task: "TaskInfo") -> bool:
-    """Return True when a task has a wait: date that hasn't arrived yet."""
+    """Return True when a task has a wait: value that hasn't arrived yet.
+
+    Compares datetime waits against the current datetime (sub-day precision),
+    date-only waits against today's date.
+    """
     if task.wait is None:
         return False
+    if isinstance(task.wait, datetime):
+        return task.wait > datetime.now()
     return task.wait > date.today()
 
 
@@ -691,11 +729,11 @@ def validate_task_file(file: Path, post: fmPost) -> List[str]:
     if "discovered-from" in metadata and not isinstance(metadata["discovered-from"], list):
         issues.append("Discovered-from must be a list")
 
-    # Validate wait: field (must be a parseable date)
+    # Validate wait: field (must be a parseable date or datetime)
     if "wait" in metadata:
         wait_val = metadata["wait"]
-        if parse_wait_date(wait_val) is None:
-            issues.append("wait must be a date (YYYY-MM-DD) or datetime")
+        if parse_wait(wait_val) is None:
+            issues.append("wait must be a date (YYYY-MM-DD) or datetime (YYYY-MM-DDTHH:MM)")
 
     return issues
 
@@ -868,7 +906,7 @@ def load_tasks(
                 issues=issues,
                 metadata=metadata,
                 # Scheduling fields
-                wait=parse_wait_date(metadata.get("wait")),
+                wait=parse_wait(metadata.get("wait")),
                 recur=metadata.get("recur"),
                 # Multi-agent coordination fields (Phase 2)
                 parallelizable=bool(metadata.get("parallelizable", False)),

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -512,14 +512,15 @@ def advance_wait(current_wait: date | datetime | None, recur: str) -> date | dat
     - Lapsed tasks (current_wait in the past) re-schedule from now, not the stale date.
     """
     interval = parse_recur_interval(recur)
-    now = datetime.now()
 
     if isinstance(current_wait, datetime):
-        # DateTime precision: use the current datetime as base if lapsed
+        # Match tz-awareness to avoid TypeError when current_wait is tz-aware
+        now = datetime.now(tz=current_wait.tzinfo)
         base = now if current_wait < now else current_wait
         return (now + timedelta(days=7)) if interval is None else (base + interval)
 
     # Date-only or None path
+    now = datetime.now()
     today = date.today()
     if interval is None:
         return today + timedelta(days=7)
@@ -539,7 +540,7 @@ def task_is_waiting_for_date(task: "TaskInfo") -> bool:
     if task.wait is None:
         return False
     if isinstance(task.wait, datetime):
-        return task.wait > datetime.now()
+        return task.wait > datetime.now(tz=task.wait.tzinfo)
     return task.wait > date.today()
 
 

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -736,6 +736,14 @@ def validate_task_file(file: Path, post: fmPost) -> List[str]:
         if parse_wait(wait_val) is None:
             issues.append("wait must be a date (YYYY-MM-DD) or datetime (YYYY-MM-DDTHH:MM)")
 
+    # Validate recur: field (must be a parseable interval if set)
+    if "recur" in metadata:
+        recur_val = metadata.get("recur")
+        if recur_val and parse_recur_interval(str(recur_val)) is None:
+            issues.append(
+                f"recur must be a valid interval (e.g. 7d, 24h, weekly, monthly), got: {recur_val!r}"
+            )
+
     return issues
 
 

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -501,6 +501,25 @@ def parse_recur_interval(recur: str) -> timedelta | None:
     return None  # cron or unrecognised — caller decides
 
 
+def is_cron_recur_expression(recur: str) -> bool:
+    """Return True for cron-like recur: strings we accept but do not yet compute.
+
+    We intentionally keep this permissive: any 5- or 6-field whitespace-separated
+    spec counts as cron-like so validation matches the documented contract.
+    """
+    if not recur:
+        return False
+    parts = recur.strip().split()
+    return len(parts) in (5, 6) and all(parts)
+
+
+def is_valid_recur_value(recur: str) -> bool:
+    """Return True when recur: is either directly supported or cron-like."""
+    if not recur:
+        return False
+    return parse_recur_interval(recur) is not None or is_cron_recur_expression(recur)
+
+
 def advance_wait(current_wait: date | datetime | None, recur: str) -> date | datetime:
     """Compute the next wait: value after completing a recurring task.
 
@@ -739,9 +758,10 @@ def validate_task_file(file: Path, post: fmPost) -> List[str]:
     # Validate recur: field (must be a parseable interval if set)
     if "recur" in metadata:
         recur_val = metadata.get("recur")
-        if recur_val and parse_recur_interval(str(recur_val)) is None:
+        if recur_val and not is_valid_recur_value(str(recur_val)):
             issues.append(
-                f"recur must be a valid interval (e.g. 7d, 24h, weekly, monthly), got: {recur_val!r}"
+                "recur must be a valid interval (e.g. 7d, 24h, weekly, monthly) "
+                f"or a cron expression, got: {recur_val!r}"
             )
 
     return issues

--- a/packages/gptodo/tests/test_wait_recur.py
+++ b/packages/gptodo/tests/test_wait_recur.py
@@ -105,6 +105,17 @@ def test_advance_wait_from_none() -> None:
     assert result == date.today() + timedelta(days=7)
 
 
+def test_advance_wait_sub_24h_not_today() -> None:
+    # Sub-24h hour intervals must produce a future date, not today.
+    # Python date + timedelta(hours=12) silently drops sub-day components and
+    # returns today — advance_wait must guard against this.
+    result = advance_wait(None, "12h")
+    assert result > date.today(), "12h recurrence must schedule at least 1 day out"
+
+    result6 = advance_wait(None, "6h")
+    assert result6 > date.today(), "6h recurrence must schedule at least 1 day out"
+
+
 # ---------------------------------------------------------------------------
 # task_is_waiting_for_date
 # ---------------------------------------------------------------------------

--- a/packages/gptodo/tests/test_wait_recur.py
+++ b/packages/gptodo/tests/test_wait_recur.py
@@ -1,6 +1,6 @@
 """Tests for wait: and recur: scheduling fields."""
 
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -105,15 +105,18 @@ def test_advance_wait_from_none() -> None:
     assert result == date.today() + timedelta(days=7)
 
 
-def test_advance_wait_sub_24h_not_today() -> None:
-    # Sub-24h hour intervals must produce a future date, not today.
-    # Python date + timedelta(hours=12) silently drops sub-day components and
-    # returns today — advance_wait must guard against this.
+def test_advance_wait_sub_24h_returns_datetime() -> None:
+    # Sub-24h intervals must return a *datetime* with exact precision so the task
+    # is hidden for the right number of hours, not just "tomorrow".
     result = advance_wait(None, "12h")
-    assert result > date.today(), "12h recurrence must schedule at least 1 day out"
+    assert isinstance(result, datetime), "12h recurrence must return datetime"
+    assert result > datetime.now(), "12h recurrence must be in the future"
+    assert result < datetime.now() + timedelta(hours=13), "12h recurrence must not overshoot"
 
     result6 = advance_wait(None, "6h")
-    assert result6 > date.today(), "6h recurrence must schedule at least 1 day out"
+    assert isinstance(result6, datetime), "6h recurrence must return datetime"
+    assert result6 > datetime.now(), "6h recurrence must be in the future"
+    assert result6 < datetime.now() + timedelta(hours=7), "6h recurrence must not overshoot"
 
 
 # ---------------------------------------------------------------------------
@@ -242,6 +245,42 @@ def test_edit_done_with_recur_resets_to_todo(
     assert post.metadata["state"] == "todo"
     next_wait = date.fromisoformat(str(post.metadata["wait"]))
     assert next_wait > date.today()
+
+
+def test_edit_done_with_subday_recur_stores_datetime(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Completing a task with recur: 12h stores a datetime wait (not a date)."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+
+    today = date.today().isoformat()
+    write_task(
+        tasks_dir,
+        "frequent-check",
+        state="todo",
+        created="2026-01-01",
+        wait=today,
+        recur="12h",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["edit", "frequent-check", "--set", "state", "done"])
+
+    assert result.exit_code == 0, result.output
+
+    import frontmatter as fm
+
+    post = fm.load(tasks_dir / "frequent-check.md")
+    assert post.metadata["state"] == "todo"
+    wait_val = str(post.metadata["wait"])
+    assert (
+        "T" in wait_val or " " in wait_val
+    ), f"sub-24h recur should store a datetime string with time component, got: {wait_val!r}"
+    # Verify it's actually in the future
+    next_dt = datetime.fromisoformat(wait_val.replace(" ", "T"))
+    assert next_dt > datetime.now(), "next wait must be in the future"
 
 
 def test_edit_done_without_recur_stays_done(

--- a/packages/gptodo/tests/test_wait_recur.py
+++ b/packages/gptodo/tests/test_wait_recur.py
@@ -1,0 +1,253 @@
+"""Tests for wait: and recur: scheduling fields."""
+
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from gptodo.cli import cli
+from gptodo.utils import (
+    advance_wait,
+    is_task_ready,
+    load_tasks,
+    parse_recur_interval,
+    parse_wait_date,
+    task_is_waiting_for_date,
+)
+
+
+def write_task(tasks_dir: Path, name: str, **metadata: object) -> None:
+    lines = ["---"]
+    for key, value in metadata.items():
+        if isinstance(value, list):
+            lines.append(f"{key}:")
+            for item in value:
+                lines.append(f"  - {item}")
+        else:
+            lines.append(f"{key}: {value}")
+    lines.extend(["---", f"# {name}"])
+    (tasks_dir / f"{name}.md").write_text("\n".join(lines))
+
+
+# ---------------------------------------------------------------------------
+# parse_wait_date
+# ---------------------------------------------------------------------------
+
+
+def test_parse_wait_date_string() -> None:
+    assert parse_wait_date("2026-05-10") == date(2026, 5, 10)
+
+
+def test_parse_wait_date_datetime_string() -> None:
+    assert parse_wait_date("2026-05-10T09:00:00") == date(2026, 5, 10)
+
+
+def test_parse_wait_date_date_object() -> None:
+    d = date(2026, 5, 10)
+    assert parse_wait_date(d) == d
+
+
+def test_parse_wait_date_none() -> None:
+    assert parse_wait_date(None) is None
+
+
+def test_parse_wait_date_invalid() -> None:
+    assert parse_wait_date("not-a-date") is None
+
+
+# ---------------------------------------------------------------------------
+# parse_recur_interval
+# ---------------------------------------------------------------------------
+
+
+def test_parse_recur_days() -> None:
+    assert parse_recur_interval("7d") == timedelta(days=7)
+
+
+def test_parse_recur_hours() -> None:
+    assert parse_recur_interval("24h") == timedelta(hours=24)
+
+
+def test_parse_recur_weekly() -> None:
+    assert parse_recur_interval("weekly") == timedelta(days=7)
+
+
+def test_parse_recur_monthly() -> None:
+    assert parse_recur_interval("monthly") == timedelta(days=30)
+
+
+def test_parse_recur_cron_returns_none() -> None:
+    # cron expressions are accepted but not yet computed to a timedelta
+    assert parse_recur_interval("0 9 * * 1") is None
+
+
+# ---------------------------------------------------------------------------
+# advance_wait
+# ---------------------------------------------------------------------------
+
+
+def test_advance_wait_from_future_date() -> None:
+    future = date.today() + timedelta(days=3)
+    result = advance_wait(future, "7d")
+    assert result == future + timedelta(days=7)
+
+
+def test_advance_wait_from_past_date() -> None:
+    # Lapsed task: base should be today, not the stale past date
+    past = date.today() - timedelta(days=10)
+    result = advance_wait(past, "7d")
+    assert result == date.today() + timedelta(days=7)
+
+
+def test_advance_wait_from_none() -> None:
+    result = advance_wait(None, "7d")
+    assert result == date.today() + timedelta(days=7)
+
+
+# ---------------------------------------------------------------------------
+# task_is_waiting_for_date
+# ---------------------------------------------------------------------------
+
+
+def test_task_is_waiting_future(tmp_path: Path) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    future = (date.today() + timedelta(days=5)).isoformat()
+    write_task(tasks_dir, "future-task", state="backlog", created="2026-01-01", wait=future)
+
+    tasks = load_tasks(tasks_dir)
+    task = next(t for t in tasks if t.name == "future-task")
+    assert task_is_waiting_for_date(task) is True
+
+
+def test_task_is_not_waiting_past(tmp_path: Path) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    past = (date.today() - timedelta(days=1)).isoformat()
+    write_task(tasks_dir, "past-task", state="backlog", created="2026-01-01", wait=past)
+
+    tasks = load_tasks(tasks_dir)
+    task = next(t for t in tasks if t.name == "past-task")
+    assert task_is_waiting_for_date(task) is False
+
+
+def test_task_is_not_waiting_today(tmp_path: Path) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    today = date.today().isoformat()
+    write_task(tasks_dir, "today-task", state="backlog", created="2026-01-01", wait=today)
+
+    tasks = load_tasks(tasks_dir)
+    task = next(t for t in tasks if t.name == "today-task")
+    # wait == today means task becomes available today (not waiting)
+    assert task_is_waiting_for_date(task) is False
+
+
+# ---------------------------------------------------------------------------
+# is_task_ready with wait:
+# ---------------------------------------------------------------------------
+
+
+def test_is_task_ready_blocked_by_future_wait(tmp_path: Path) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    future = (date.today() + timedelta(days=5)).isoformat()
+    write_task(tasks_dir, "sched-task", state="backlog", created="2026-01-01", wait=future)
+
+    tasks = load_tasks(tasks_dir)
+    task_lookup = {t.name: t for t in tasks}
+    assert is_task_ready(task_lookup["sched-task"], task_lookup) is False
+
+
+def test_is_task_ready_unblocked_when_wait_passed(tmp_path: Path) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    past = (date.today() - timedelta(days=1)).isoformat()
+    write_task(tasks_dir, "past-task", state="backlog", created="2026-01-01", wait=past)
+
+    tasks = load_tasks(tasks_dir)
+    task_lookup = {t.name: t for t in tasks}
+    assert is_task_ready(task_lookup["past-task"], task_lookup) is True
+
+
+# ---------------------------------------------------------------------------
+# gptodo next skips future-wait tasks
+# ---------------------------------------------------------------------------
+
+
+def test_next_skips_future_wait_task(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+
+    future = (date.today() + timedelta(days=7)).isoformat()
+    write_task(tasks_dir, "future-task", state="backlog", created="2026-01-01", wait=future)
+    write_task(tasks_dir, "ready-task", state="backlog", created="2026-01-01")
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["next", "--json"])
+
+    assert result.exit_code == 0
+    import json
+
+    data = json.loads(result.output)
+    assert data["next_task"] is not None
+    assert data["next_task"]["id"] == "ready-task"
+
+
+# ---------------------------------------------------------------------------
+# gptodo edit --set state done on recurring task resets to todo
+# ---------------------------------------------------------------------------
+
+
+def test_edit_done_with_recur_resets_to_todo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+
+    today = date.today().isoformat()
+    write_task(
+        tasks_dir,
+        "weekly-review",
+        state="todo",
+        created="2026-01-01",
+        wait=today,
+        recur="7d",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["edit", "weekly-review", "--set", "state", "done"])
+
+    assert result.exit_code == 0, result.output
+    assert "recurring" in result.output.lower() or "reset" in result.output.lower()
+
+    # Task should now be todo with a future wait date
+    import frontmatter as fm
+
+    post = fm.load(tasks_dir / "weekly-review.md")
+    assert post.metadata["state"] == "todo"
+    next_wait = date.fromisoformat(str(post.metadata["wait"]))
+    assert next_wait > date.today()
+
+
+def test_edit_done_without_recur_stays_done(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+
+    write_task(tasks_dir, "one-off", state="todo", created="2026-01-01")
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["edit", "one-off", "--set", "state", "done"])
+
+    assert result.exit_code == 0, result.output
+
+    import frontmatter as fm
+
+    post = fm.load(tasks_dir / "one-off.md")
+    assert post.metadata["state"] == "done"

--- a/packages/gptodo/tests/test_wait_recur.py
+++ b/packages/gptodo/tests/test_wait_recur.py
@@ -301,3 +301,35 @@ def test_edit_done_without_recur_stays_done(
 
     post = fm.load(tasks_dir / "one-off.md")
     assert post.metadata["state"] == "done"
+
+
+def test_task_is_waiting_timezone_aware(tmp_path: Path) -> None:
+    """PyYAML parses 'wait: 2099-01-01T00:00:00+00:00' as a tz-aware datetime.
+    Comparing against naive datetime.now() raises TypeError; use now(tz=...) instead."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+
+    # PyYAML auto-parses this as a tz-aware datetime object
+    write_task(
+        tasks_dir, "tz-future", state="todo", created="2026-01-01", wait="2099-01-01T00:00:00+00:00"
+    )
+    write_task(
+        tasks_dir, "tz-past", state="todo", created="2026-01-01", wait="2000-01-01T00:00:00+00:00"
+    )
+
+    tasks = {t.name: t for t in load_tasks(tasks_dir)}
+    # Must not raise TypeError on comparison
+    assert task_is_waiting_for_date(tasks["tz-future"]) is True
+    assert task_is_waiting_for_date(tasks["tz-past"]) is False
+
+
+def test_advance_wait_timezone_aware() -> None:
+    """advance_wait must not raise TypeError when current_wait is tz-aware."""
+    from datetime import timezone
+
+    aware = datetime(2000, 1, 1, tzinfo=timezone.utc)
+    result = advance_wait(aware, "7d")
+    # Result should be tz-aware and in the future
+    assert isinstance(result, datetime)
+    assert result.tzinfo is not None
+    assert result > datetime.now(tz=timezone.utc)

--- a/packages/gptodo/tests/test_wait_recur.py
+++ b/packages/gptodo/tests/test_wait_recur.py
@@ -10,6 +10,7 @@ from gptodo.cli import cli
 from gptodo.utils import (
     advance_wait,
     is_task_ready,
+    is_valid_recur_value,
     load_tasks,
     parse_recur_interval,
     parse_wait_date,
@@ -80,6 +81,14 @@ def test_parse_recur_monthly() -> None:
 def test_parse_recur_cron_returns_none() -> None:
     # cron expressions are accepted but not yet computed to a timedelta
     assert parse_recur_interval("0 9 * * 1") is None
+
+
+def test_is_valid_recur_value_accepts_cron() -> None:
+    assert is_valid_recur_value("0 9 * * 1") is True
+
+
+def test_is_valid_recur_value_rejects_garbage() -> None:
+    assert is_valid_recur_value("weakly") is False
 
 
 # ---------------------------------------------------------------------------
@@ -301,6 +310,75 @@ def test_edit_done_without_recur_stays_done(
 
     post = fm.load(tasks_dir / "one-off.md")
     assert post.metadata["state"] == "done"
+
+
+def test_load_tasks_allows_cron_recur_without_validation_issue(tmp_path: Path) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(
+        tasks_dir,
+        "cron-review",
+        state="todo",
+        created="2026-01-01",
+        recur="0 9 * * 1",
+    )
+
+    task = next(t for t in load_tasks(tasks_dir) if t.name == "cron-review")
+    assert not any("recur must be a valid interval" in issue for issue in task.issues)
+
+
+def test_load_tasks_rejects_invalid_recur_with_issue(tmp_path: Path) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(
+        tasks_dir,
+        "bad-recur",
+        state="todo",
+        created="2026-01-01",
+        recur="weakly",
+    )
+
+    task = next(t for t in load_tasks(tasks_dir) if t.name == "bad-recur")
+    assert any("recur must be a valid interval" in issue for issue in task.issues)
+
+
+def test_edit_set_recur_accepts_cron_expression(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(tasks_dir, "cron-task", state="todo", created="2026-01-01")
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["edit", "cron-task", "--set", "recur", "0 9 * * 1"])
+
+    assert result.exit_code == 0, result.output
+
+    import frontmatter as fm
+
+    post = fm.load(tasks_dir / "cron-task.md")
+    assert post.metadata["recur"] == "0 9 * * 1"
+
+
+def test_edit_set_recur_rejects_invalid_value(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(tasks_dir, "bad-task", state="todo", created="2026-01-01")
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["edit", "bad-task", "--set", "recur", "weakly"])
+
+    assert result.exit_code == 0
+    assert "Invalid recur format" in result.output
+
+    import frontmatter as fm
+
+    post = fm.load(tasks_dir / "bad-task.md")
+    assert "recur" not in post.metadata
 
 
 def test_task_is_waiting_timezone_aware(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Implements `wait:` and `recur:` scheduling fields in gptodo task frontmatter, as requested in #826.

### `wait: YYYY-MM-DD`
Hides a task from `gptodo next` / `gptodo ready` / `generate-queue` until the date arrives. The task appears on the specified date (inclusive: `wait: today` = available today).

```yaml
---
state: todo
wait: 2026-05-11
recur: weekly
---
# Weekly review
```

### `recur: <interval>`
When a task with `recur:` is marked `done`, it resets to `todo` and advances `wait:` by the interval — instead of completing permanently.

Supported formats (matches taskwarrior conventions):
- `7d`, `30d` — N days
- `24h` — N hours
- `weekly` — 7 days
- `monthly` — 30 days (calendar-approximate)
- cron expressions accepted in the field but not yet computed (fallback: 7d)

Field name follows Erik's suggestion: `wait:` not `wait_until:`. Recurrence model is mutate-in-place (not parent/child spawning), simpler for now and extensible later.

### Lapsed task behaviour
If a recurring task's `wait:` is in the past when marked done, the next `wait:` advances from *today*, not from the stale date. This prevents a 3-week-stale weekly review from scheduling 7 days into the past.

## Changes

- **`utils.py`**: `TaskInfo.wait` + `.recur` fields; `parse_wait_date()`, `parse_recur_interval()`, `advance_wait()`, `task_is_waiting_for_date()`; `is_task_ready()` blocks on future `wait:`; `validate_task_file()` validates `wait:`; `task_to_dict()` serialises both fields
- **`cli.py`**: `VALID_FIELDS` gains `wait:` (date) and `recur:` (string); `edit` resets recurring tasks on done
- **`generate_queue.py`**: `get_file_tasks()` and `filter_blocked_tasks()` skip future-wait tasks

## Test plan

- [x] 21 new tests in `test_wait_recur.py` — all pass
- [x] Full 167-test gptodo suite passes
- [x] `parse_wait_date` / `parse_recur_interval` / `advance_wait` unit tests
- [x] `is_task_ready` blocks on future `wait:`, unblocks when past
- [x] `gptodo next` skips future-wait task, returns ready task
- [x] `gptodo edit --set state done` on recurring task resets to todo + advances wait
- [x] Non-recurring tasks still complete normally

Closes #826