### PR TITLE
feat(codegraph): add gptme-codegraph as experimental package

### DIFF
--- a/.jscpd.json
+++ b/.jscpd.json
@@ -19,7 +19,8 @@
     "packages/gptme-contrib-lib/**",
     "packages/lib/src/lib/**",
     "packages/gptodo/src/gptodo/**",
-    "scripts/communication_utils/**"
+    "scripts/communication_utils/**",
+    "packages/gptme-codegraph/**"
   ],
   "minTokens": 50,
   "minLines": 5,

--- a/packages/gptme-codegraph/README.md
+++ b/packages/gptme-codegraph/README.md
@@ -1,0 +1,72 @@
+# gptme-codegraph
+
+Structural code retrieval for gptme via [tree-sitter](https://tree-sitter.github.io/tree-sitter/) — complementary to gptme-rag (text chunks), this retrieves code *structure*: function/class definitions, call graphs, blast radius, and impact analysis.
+
+## Features
+
+- **5 MCP tools**: `codegraph_callers`, `codegraph_callees`, `codegraph_impact`, `codegraph_blast`, `codegraph_def`
+- **Cross-file import resolution** (including `import X as Y`, `from X import Y as Z`, wildcard imports)
+- **Qualified symbol IDs** (`module::Class.method`) for unambiguous cross-file references
+- **SQLite index cache** — optional persistent cache for large codebases
+- **Blast/impact semantics split**: `blast` = dependency closure (what X needs), `impact` = what breaks if you change X
+
+## Install
+
+```bash
+pip install gptme-codegraph[treesitter,mcp]
+```
+
+Or with uv:
+
+```bash
+uv add gptme-codegraph[treesitter,mcp]
+```
+
+## Usage
+
+### CLI
+
+```bash
+# Extract symbols from a file
+gptme-codegraph path/to/file.py parse
+
+# Who calls a function?
+gptme-codegraph path/to/file.py callers my_function
+
+# What does a function call?
+gptme-codegraph path/to/file.py callees my_function
+
+# What breaks if you change a function?
+gptme-codegraph path/to/file.py impact my_function
+
+# Where is a symbol defined?
+gptme-codegraph path/to/file.py def my_function
+```
+
+### MCP Server
+
+```bash
+# Start the MCP server (stdio transport)
+gptme-codegraph-mcp
+```
+
+Configure in Claude Code:
+
+```bash
+claude mcp add codegraph -- gptme-codegraph-mcp
+```
+
+### Python API
+
+```python
+from gptme_codegraph import build_index, impact_radius
+
+index = build_index(Path("src/"))
+callers, callees = impact_radius("my_module::MyClass.my_method", index)
+```
+
+## Status
+
+Experimental package — Python only (v0). Multi-language support planned for v1.1.
+
+> Namespace packages (`import google.cloud.storage` without `__init__.py`) are a known v1.1 gap.

--- a/packages/gptme-codegraph/pyproject.toml
+++ b/packages/gptme-codegraph/pyproject.toml
@@ -1,0 +1,34 @@
+[project]
+name = "gptme-codegraph"
+version = "0.1.0"
+description = "Structural code retrieval for gptme via tree-sitter (callers, callees, blast radius)"
+readme = "README.md"
+authors = [
+    { name = "Erik Bjäreholt", email = "erik@bjareho.lt" }
+]
+requires-python = ">=3.10"
+dependencies = []
+
+[project.optional-dependencies]
+treesitter = [
+    "tree-sitter>=0.21.0",
+    "tree-sitter-python>=0.21.0",
+]
+mcp = [
+    "mcp>=1.0.0",
+]
+dev = [
+    "mypy>=1.0.0",
+    "pytest>=7.0.0",
+]
+
+[project.scripts]
+gptme-codegraph = "gptme_codegraph.core:main"
+gptme-codegraph-mcp = "gptme_codegraph.mcp_server:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/gptme_codegraph"]

--- a/packages/gptme-codegraph/src/gptme_codegraph/__init__.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/__init__.py
@@ -1,0 +1,31 @@
+"""gptme-codegraph: structural code retrieval via tree-sitter."""
+
+from gptme_codegraph.core import (
+    IndexEntry,
+    SqliteIndexCache,
+    Symbol,
+    SymbolIndex,
+    blast_radius,
+    build_call_graph,
+    build_cross_file_call_graph,
+    build_index,
+    dependency_closure,
+    extract_symbols,
+    impact_radius,
+    parse_file,
+)
+
+__all__ = [
+    "IndexEntry",
+    "SqliteIndexCache",
+    "Symbol",
+    "SymbolIndex",
+    "blast_radius",
+    "build_call_graph",
+    "build_cross_file_call_graph",
+    "build_index",
+    "dependency_closure",
+    "extract_symbols",
+    "impact_radius",
+    "parse_file",
+]

--- a/packages/gptme-codegraph/src/gptme_codegraph/core.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/core.py
@@ -471,11 +471,6 @@ def _tree_sitter_parse(code: bytes, lang_name: str = "python"):
         return None, None
 
 
-def _get_parser(lang_name: str):
-    """Return a tree-sitter Parser instance for the given language."""
-    _tree_sitter_parse(b"", lang_name)
-
-
 def _text(node) -> str:
     """Get the text of a tree-sitter node."""
     try:

--- a/packages/gptme-codegraph/src/gptme_codegraph/core.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/core.py
@@ -1,0 +1,1356 @@
+"""gptme-codegraph — structural code retrieval via tree-sitter.
+
+Complementary to gptme-rag (text chunks), this retrieves code *structure*:
+function/class definitions, call graphs, and blast radius.
+
+v0: In-memory, single-file Python only. Tree-sitter grammars are the
+bottleneck (one per language). This prototype proves the concept before
+committing to SQLite + multi-language + persistent indexing.
+
+Usage:
+    gptme-codegraph <file.py> parse           # Extract symbols
+    gptme-codegraph <file.py> callers <name>  # Who calls X?
+    gptme-codegraph <file.py> callees <name>  # What does X call?
+    python3 scripts/codegraph.py <file.py> deps <name>     # Dependency closure (what X needs)
+    python3 scripts/codegraph.py <file.py> impact <name>   # Impact radius (what needs X)
+    python3 scripts/codegraph.py <file.py> blast <name>    # [deprecated] alias for deps
+    python3 scripts/codegraph.py <file.py> def <name>      # Where is X defined?
+    python3 scripts/codegraph.py <file.py> refs <name>     # Where is X referenced?
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sqlite3
+import sys
+from collections import defaultdict
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def _module_path(filepath: str, directory: str | None = None) -> str:
+    """Convert a file path to a dotted module path (e.g. 'scripts/codegraph').
+
+    Strips ``__init__`` from package-roots so ``pkg/__init__.py`` maps to
+    ``pkg`` rather than ``pkg.__init__``, matching Python runtime semantics.
+    """
+    p = Path(filepath)
+    if directory:
+        try:
+            rel = p.relative_to(directory)
+        except ValueError:
+            # Fallback: use filepath as-is
+            rel = p
+    else:
+        # No directory context: use the path as given, strip .py
+        rel = p
+    # Remove .py suffix and replace / with dot
+    parts = str(rel.with_suffix("")).replace("\\", "/").split("/")
+    # Strip trailing ``__init__`` so packages get the correct module path
+    if parts and parts[-1] == "__init__":
+        parts.pop()
+    module = ".".join(parts)
+    return module
+
+
+@dataclass
+class IndexEntry:
+    """A lightweight cross-file symbol registry entry."""
+
+    name: str
+    kind: str  # function, method, class
+    file: str
+    start_line: int
+    end_line: int
+    parent_class: str | None = None
+    module_path: str = ""  # dotted module path, set by build_index
+
+    def qualified_id(self) -> str:
+        """Return a stable qualified ID for this symbol.
+
+        Format: ``module_path::Class.method`` for methods,
+        ``module_path::name`` for top-level symbols.
+        """
+        if self.parent_class:
+            return f"{self.module_path}::{self.parent_class}.{self.name}"
+        return f"{self.module_path}::{self.name}"
+
+
+@dataclass
+class ImportInfo:
+    """A single import in a Python file.
+
+    Naming conventions:
+    - ``name`` is the *original imported name* as written in the source.
+      For ``import os`` it is ``"os"``; for ``from os import path`` it is
+      ``"path"``; for ``from os import path as p`` it is still ``"path"``.
+    - ``alias`` is the local binding when the source uses ``as``. For
+      ``import calc as c`` it is ``"c"``; for ``from utils import add`` it is
+      ``None``.
+    - The local binding visible in the importing file is
+      ``alias or name``; use :func:`local_binding` to compute it.
+    """
+
+    file: str
+    name: str
+    module: str | None = None  # source module (e.g. 'os.path')
+    is_from: bool = False
+    alias: str | None = None
+
+
+def local_binding(imp: ImportInfo) -> str:
+    """Return the local name an import binds in its file.
+
+    Equal to ``alias`` when present, otherwise ``name``. For
+    ``from os import path as p`` returns ``"p"``; for ``import calc`` returns
+    ``"calc"``.
+    """
+    return imp.alias or imp.name
+
+
+@dataclass
+class SymbolIndex:
+    """Cross-file symbol registry.
+
+    Maps symbol names to their definitions across a directory tree.
+    Also tracks imports per file for cross-file call resolution.
+    """
+
+    entries: dict[str, list[IndexEntry]] = field(default_factory=dict)
+    imports: dict[str, list[ImportInfo]] = field(default_factory=dict)
+
+    def lookup(self, name: str) -> list[IndexEntry]:
+        """Return all definitions of ``name`` across the index."""
+        return self.entries.get(name, [])
+
+    def has(self, name: str) -> bool:
+        """Return True if ``name`` exists anywhere in the index."""
+        return name in self.entries and bool(self.entries[name])
+
+    def all_names(self) -> list[str]:
+        """Return all indexed symbol names."""
+        return sorted(self.entries.keys())
+
+    def file_imports(self, filepath: str) -> list[ImportInfo]:
+        """Return all imports in the given file."""
+        return self.imports.get(filepath, [])
+
+
+# ---------------------------------------------------------------------------
+# SQLite-backed index cache (persists across server restarts)
+# ---------------------------------------------------------------------------
+
+_CODEGRAPH_STATE_DIR = Path.home() / ".local" / "state" / "codegraph"
+
+
+def _ensure_state_dir() -> Path:
+    """Create and return the state directory for codegraph caches."""
+    _CODEGRAPH_STATE_DIR.mkdir(parents=True, exist_ok=True)
+    return _CODEGRAPH_STATE_DIR
+
+
+def _db_path(directory: str) -> str:
+    """Return the SQLite database path for a directory (sanitized).
+
+    Uses a hash of the absolute path to avoid filesystem-unsafe characters
+    in the filename, and appends the directory basename for readability.
+    """
+    raw = str(Path(directory).resolve())
+    h = hashlib.sha256(raw.encode()).hexdigest()[:16]
+    name = Path(raw).name or "root"
+    return str(_ensure_state_dir() / f"index_{name}_{h}.db")
+
+
+def _file_mtime(path: Path) -> float:
+    """Return file mtime, or 0 if file doesn't exist."""
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return 0.0
+
+
+class SqliteIndexCache:
+    """Persistent SQLite-backed cache for SymbolIndex data.
+
+    Stores:
+    - IndexEntry rows (name, kind, file, start_line, end_line, parent_class, module_path)
+    - File mtimes so stale directories are detected on rebuild
+    - A metadata row for cache version tracking
+
+    This is an optional enhancement over the in-memory cache. When available,
+    the MCP server loads from SQLite instead of re-parsing on every startup.
+    """
+
+    SCHEMA_VERSION = 4
+
+    def __init__(self, directory: str):
+        self.db_path = _db_path(directory)
+        self._directory = str(Path(directory).resolve())
+        self._conn: sqlite3.Connection | None = None
+
+    def _connect(self) -> sqlite3.Connection:
+        if self._conn is None:
+            self._conn = sqlite3.connect(self.db_path)
+            self._conn.execute("PRAGMA journal_mode=WAL")
+            self._conn.execute("PRAGMA synchronous=NORMAL")
+        return self._conn
+
+    def _init_schema(self) -> None:
+        conn = self._connect()
+        # Ensure the metadata table exists before reading schema_version. We
+        # drop stale data tables when the persisted schema is older than the
+        # current code expects, which prevents silent corruption on upgrade.
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL)"
+        )
+        row = conn.execute(
+            "SELECT value FROM metadata WHERE key = 'schema_version'"
+        ).fetchone()
+        existing_version = int(row[0]) if row else None
+        if existing_version is not None and existing_version != self.SCHEMA_VERSION:
+            for tbl in ("entries", "file_mtimes", "imports"):
+                conn.execute(f"DROP TABLE IF EXISTS {tbl}")
+            conn.commit()
+        conn.executescript("""
+            CREATE TABLE IF NOT EXISTS metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS entries (
+                name TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                file TEXT NOT NULL,
+                start_line INTEGER NOT NULL,
+                end_line INTEGER NOT NULL,
+                parent_class TEXT,
+                module_path TEXT NOT NULL DEFAULT '',
+                directory TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_entries_name ON entries(name);
+            CREATE INDEX IF NOT EXISTS idx_entries_dir ON entries(directory);
+            CREATE INDEX IF NOT EXISTS idx_entries_file ON entries(file);
+            CREATE TABLE IF NOT EXISTS file_mtimes (
+                filepath TEXT PRIMARY KEY,
+                mtime REAL NOT NULL,
+                directory TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS imports (
+                file TEXT NOT NULL,
+                name TEXT NOT NULL,
+                module TEXT,
+                is_from INTEGER NOT NULL DEFAULT 0,
+                alias TEXT,
+                directory TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_imports_file ON imports(file);
+            CREATE INDEX IF NOT EXISTS idx_imports_dir ON imports(directory);
+        """)
+        conn.execute(
+            "INSERT OR REPLACE INTO metadata (key, value) VALUES (?, ?)",
+            ("schema_version", str(self.SCHEMA_VERSION)),
+        )
+        conn.commit()
+
+    def is_fresh(self) -> bool:
+        """Check if the cached index is up-to-date with the filesystem.
+
+        Returns True if:
+        - The database has entries for this directory
+        - All indexed files still exist and have the same mtime
+        - No new Python files exist in the directory
+        """
+        conn = self._connect()
+        self._init_schema()
+
+        count = conn.execute(
+            "SELECT COUNT(*) FROM entries WHERE directory = ?",
+            (self._directory,),
+        ).fetchone()[0]
+        if count == 0:
+            return False
+
+        dir_path = Path(self._directory)
+        if not dir_path.is_dir():
+            return False
+
+        rows = conn.execute(
+            "SELECT filepath, mtime FROM file_mtimes WHERE directory = ?",
+            (self._directory,),
+        ).fetchall()
+        tracked = {row[0]: row[1] for row in rows}
+
+        for filepath, cached_mtime in tracked.items():
+            fp = Path(filepath)
+            if not fp.exists():
+                return False
+            if _file_mtime(fp) != cached_mtime:
+                return False
+
+        # Check that no new Python files appeared
+        for fp in dir_path.rglob("*.py"):
+            if str(fp.resolve()) not in tracked:
+                return False
+
+        return True
+
+    def save(self, index: SymbolIndex) -> None:
+        """Persist a SymbolIndex to SQLite."""
+        conn = self._connect()
+        self._init_schema()
+
+        conn.execute("DELETE FROM entries WHERE directory = ?", (self._directory,))
+        conn.execute("DELETE FROM imports WHERE directory = ?", (self._directory,))
+        conn.execute("DELETE FROM file_mtimes WHERE directory = ?", (self._directory,))
+
+        seen_files: set[str] = set()
+        for name, entries in index.entries.items():
+            for entry in entries:
+                conn.execute(
+                    """INSERT INTO entries (name, kind, file, start_line, end_line, parent_class, module_path, directory)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (
+                        entry.name,
+                        entry.kind,
+                        entry.file,
+                        entry.start_line,
+                        entry.end_line,
+                        entry.parent_class,
+                        entry.module_path,
+                        self._directory,
+                    ),
+                )
+                seen_files.add(entry.file)
+
+        for file_path, imp_list in index.imports.items():
+            for imp in imp_list:
+                conn.execute(
+                    """INSERT INTO imports (file, name, module, is_from, alias, directory)
+                       VALUES (?, ?, ?, ?, ?, ?)""",
+                    (
+                        imp.file,
+                        imp.name,
+                        imp.module,
+                        1 if imp.is_from else 0,
+                        imp.alias,
+                        self._directory,
+                    ),
+                )
+                seen_files.add(imp.file)
+
+        for fp_str in seen_files:
+            fp = Path(fp_str)
+            conn.execute(
+                "INSERT OR REPLACE INTO file_mtimes (filepath, mtime, directory) VALUES (?, ?, ?)",
+                (fp_str, _file_mtime(fp), self._directory),
+            )
+
+        # Also track all Python files to detect new files on freshness check
+        dir_path = Path(self._directory)
+        for fp in dir_path.rglob("*.py"):
+            fp_str = str(fp.resolve())
+            if fp_str not in seen_files:
+                conn.execute(
+                    "INSERT OR IGNORE INTO file_mtimes (filepath, mtime, directory) VALUES (?, ?, ?)",
+                    (fp_str, _file_mtime(fp), self._directory),
+                )
+
+        conn.execute(
+            "INSERT OR REPLACE INTO metadata (key, value) VALUES (?, ?)",
+            ("last_updated", datetime.now(timezone.utc).isoformat()),
+        )
+        conn.commit()
+
+    def load(self) -> SymbolIndex | None:
+        """Load a persisted SymbolIndex from SQLite, or None if empty or stale."""
+        if not self.is_fresh():
+            return None
+
+        conn = self._connect()
+        self._init_schema()
+
+        rows = conn.execute(
+            "SELECT name, kind, file, start_line, end_line, parent_class, module_path "
+            "FROM entries WHERE directory = ? ORDER BY name",
+            (self._directory,),
+        ).fetchall()
+        if not rows:
+            return None
+
+        entries: dict[str, list[IndexEntry]] = {}
+        for name, kind, file, start_line, end_line, parent_class, module_path in rows:
+            entry = IndexEntry(
+                name=str(name),
+                kind=str(kind),
+                file=str(file),
+                start_line=int(start_line),
+                end_line=int(end_line),
+                parent_class=str(parent_class) if parent_class else None,
+                module_path=str(module_path) if module_path else "",
+            )
+            entries.setdefault(str(name), []).append(entry)
+
+        imports: dict[str, list[ImportInfo]] = {}
+        imp_rows = conn.execute(
+            "SELECT file, name, module, is_from, alias "
+            "FROM imports WHERE directory = ?",
+            (self._directory,),
+        ).fetchall()
+        for file, name, module, is_from, alias in imp_rows:
+            imp = ImportInfo(
+                file=str(file),
+                name=str(name),
+                module=str(module) if module else None,
+                is_from=bool(is_from),
+                alias=str(alias) if alias else None,
+            )
+            imports.setdefault(str(file), []).append(imp)
+
+        return SymbolIndex(entries=entries, imports=imports)
+
+    def close(self) -> None:
+        """Close the SQLite connection."""
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
+
+
+@dataclass
+class Symbol:
+    """A parsed symbol with its definition and location."""
+
+    name: str
+    kind: str  # function, class, method
+    file: str
+    start_line: int
+    end_line: int
+    parent_class: str | None = None
+    docstring: str | None = None
+    calls: list[str] = field(default_factory=list)  # symbols called by this one
+    module_path: str = ""  # dotted module path, set by build_index
+
+    def qualified_id(self) -> str:
+        """Return a stable qualified ID for this symbol.
+
+        Format: ``module_path::Class.method`` for methods,
+        ``module_path::name`` for top-level symbols.
+        """
+        if self.parent_class:
+            return f"{self.module_path}::{self.parent_class}.{self.name}"
+        return f"{self.module_path}::{self.name}"
+
+
+@dataclass
+class FileParseResult:
+    """Result of parsing a single Python file."""
+
+    symbols: list[Symbol] = field(default_factory=list)
+    imports: list[ImportInfo] = field(default_factory=list)
+
+
+def _tree_sitter_parse(code: bytes, lang_name: str = "python"):
+    """Parse source code with tree-sitter and return the root node.
+
+    Falls back gracefully if tree-sitter is not installed or the grammar
+    is unavailable. Returns (root_node, parser) on success.
+    """
+    try:
+        import tree_sitter_python as tspython  # type: ignore[import-not-found]
+        from tree_sitter import Language, Parser  # type: ignore[import-untyped]
+
+        parser = Parser()
+        language = Language(tspython.language())
+        parser.language = language
+        tree = parser.parse(code)
+        if tree is None:
+            return None, None
+        return tree.root_node, parser
+    except ImportError:
+        return None, None
+
+
+def _get_parser(lang_name: str):
+    """Return a tree-sitter Parser instance for the given language."""
+    _tree_sitter_parse(b"", lang_name)
+
+
+def _text(node) -> str:
+    """Get the text of a tree-sitter node."""
+    try:
+        return str(node.text.decode("utf-8"))
+    except Exception:
+        return ""
+
+
+def _extract_docstring(body_node) -> str | None:
+    """Extract docstring from a function/class body node."""
+    try:
+        for child in body_node.named_children:
+            if child.type == "expression_statement":
+                expr = child.child(0)
+                if expr and expr.type == "string":
+                    raw = _text(expr)
+                    if raw.startswith(('"""', "'''")):
+                        return raw[3:-3].strip()
+                    elif raw.startswith(('"', "'")):
+                        return raw[1:-1].strip()
+        return None
+    except Exception:
+        return None
+
+
+def _extract_calls(node) -> list[str]:
+    """Extract all called function names from a tree-sitter node subtree."""
+    calls = []
+    try:
+        cursor = node.walk()
+        reached_root = False
+        while not reached_root:
+            if cursor.node.type == "call":
+                func_node = cursor.node.child_by_field_name("function")
+                if func_node:
+                    calls.append(_text(func_node))
+            if cursor.goto_first_child():
+                continue
+            if cursor.goto_next_sibling():
+                continue
+            cursor.goto_parent()
+            if cursor.goto_next_sibling():
+                continue
+            while not cursor.goto_next_sibling():
+                if not cursor.goto_parent():
+                    reached_root = True
+                    break
+    except Exception:
+        pass
+    return calls
+
+
+def _extract_imports(root) -> list[ImportInfo]:
+    """Extract all import statements from a parsed Python file.
+
+    Handles:
+    - import os
+    - import os.path
+    - from os import path
+    - from os import path as p
+    - from os import *
+    """
+    imports: list[ImportInfo] = []
+    try:
+        for node in root.named_children:
+            if node.type == "import_statement":
+                # import foo, foo.bar
+                # import numpy as np
+                for child in node.children:
+                    if child.type == "dotted_name":
+                        module = _text(child)
+                        imports.append(
+                            ImportInfo(
+                                file="",
+                                name=module.split(".")[0],
+                                module=module,
+                                is_from=False,
+                            )
+                        )
+                    elif child.type == "aliased_import":
+                        name_node = child.child_by_field_name("name")
+                        alias_node = child.child_by_field_name("alias")
+                        name = _text(name_node) if name_node else ""
+                        alias = _text(alias_node) if alias_node else None
+                        # ``import calc as c`` -> name="calc", alias="c".
+                        # ``module`` mirrors the original dotted name so
+                        # consumers can still recover the source path.
+                        imports.append(
+                            ImportInfo(
+                                file="",
+                                name=name,
+                                module=name,
+                                is_from=False,
+                                alias=alias,
+                            )
+                        )
+            elif node.type == "import_from_statement":
+                # from module import name [as alias], ...
+                module_node = node.child_by_field_name("module_name")
+                from_module: str | None = _text(module_node) if module_node else None
+                # Find all imported names (skip keywords like 'from', 'import')
+                for child in node.children:
+                    if child.type == "dotted_name":
+                        # This could be the module name or an imported name
+                        if child == module_node:
+                            continue
+                        name = _text(child)
+                        imports.append(
+                            ImportInfo(
+                                file="",
+                                name=name,
+                                module=from_module,
+                                is_from=True,
+                            )
+                        )
+                    elif child.type == "aliased_import":
+                        name_node = child.child_by_field_name("name")
+                        alias_node = child.child_by_field_name("alias")
+                        name = _text(name_node) if name_node else ""
+                        alias = _text(alias_node) if alias_node else None
+                        # ``from os import path as p`` -> name="path", alias="p".
+                        # The original imported symbol is preserved in ``name``
+                        # so cross-file resolution can find it.
+                        imports.append(
+                            ImportInfo(
+                                file="",
+                                name=name,
+                                module=from_module,
+                                is_from=True,
+                                alias=alias,
+                            )
+                        )
+                    elif child.type == "wildcard_import":
+                        # ``from os import *`` — record module only, can't
+                        # enumerate actual names without runtime import.
+                        imports.append(
+                            ImportInfo(
+                                file="",
+                                name="*",
+                                module=from_module,
+                                is_from=True,
+                            )
+                        )
+    except Exception:
+        pass
+    return imports
+
+
+def parse_file(filepath: Path) -> FileParseResult:
+    """Extract all symbols and imports from a Python file."""
+    code = filepath.read_bytes()
+    root, _parser = _tree_sitter_parse(code)
+    if root is None:
+        return FileParseResult()
+
+    filename = str(filepath)
+    symbols: list[Symbol] = []
+
+    def walk(node, parent_class: str | None = None):
+        if node.type == "function_definition":
+            name_node = node.child_by_field_name("name")
+            body_node = node.child_by_field_name("body")
+            if name_node:
+                name = _text(name_node)
+                calls = _extract_calls(body_node) if body_node else []
+                docstring = _extract_docstring(body_node) if body_node else None
+                kind = "method" if parent_class else "function"
+                symbols.append(
+                    Symbol(
+                        name=name,
+                        kind=kind,
+                        file=filename,
+                        start_line=node.start_point[0] + 1,
+                        end_line=node.end_point[0] + 1,
+                        parent_class=parent_class,
+                        docstring=docstring,
+                        calls=list(set(calls)),
+                    )
+                )
+        elif node.type == "class_definition":
+            name_node = node.child_by_field_name("name")
+            body_node = node.child_by_field_name("body")
+            if name_node:
+                name = _text(name_node)
+                docstring = _extract_docstring(body_node) if body_node else None
+                symbols.append(
+                    Symbol(
+                        name=name,
+                        kind="class",
+                        file=filename,
+                        start_line=node.start_point[0] + 1,
+                        end_line=node.end_point[0] + 1,
+                        docstring=docstring,
+                    )
+                )
+                if body_node:
+                    for child in body_node.named_children:
+                        walk(child, parent_class=name)
+
+    for child in root.named_children:
+        walk(child)
+
+    imports = _extract_imports(root)
+    for imp in imports:
+        imp.file = filename
+
+    return FileParseResult(symbols=symbols, imports=imports)
+
+
+def extract_symbols(filepath: Path) -> list[Symbol]:
+    """Extract all symbols (functions, classes) from a Python file.
+
+    Returns a list of Symbol objects with names, locations, docstrings,
+    and call graphs. (Convenience wrapper around parse_file.)
+    """
+    return parse_file(filepath).symbols
+
+
+def build_index(directory: Path) -> SymbolIndex:
+    """Build a cross-file symbol index for all Python files in a directory.
+
+    Scans all ``.py`` files recursively, extracts symbols and imports, and
+    creates an ``IndexEntry`` for each symbol and ``ImportInfo`` for each import.
+    """
+    index = SymbolIndex()
+    dir_str = str(directory)
+    for fp in sorted(directory.rglob("*.py")):
+        # Skip common non-source directories
+        parts = fp.relative_to(directory).parts
+        if any(
+            p.startswith(".") or p in ("__pycache__", "node_modules", ".git")
+            for p in parts
+        ):
+            continue
+        result = parse_file(fp)
+        mp = _module_path(str(fp), dir_str)
+        for sym in result.symbols:
+            entry = IndexEntry(
+                name=sym.name,
+                kind=sym.kind,
+                file=sym.file,
+                start_line=sym.start_line,
+                end_line=sym.end_line,
+                parent_class=sym.parent_class,
+                module_path=mp,
+            )
+            index.entries.setdefault(sym.name, []).append(entry)
+        if result.imports:
+            index.imports[result.imports[0].file] = result.imports
+    return index
+
+
+def build_call_graph(
+    symbols: list[Symbol],
+) -> tuple[dict[str, set[str]], dict[str, set[str]]]:
+    """Build bidirectional call graph from extracted symbols.
+
+    Returns (callees, callers) where:
+    - callees[X] = set of symbol qualified IDs that symbol X calls
+    - callers[Y] = set of symbol qualified IDs that call symbol Y
+
+    Graph keys are stable qualified IDs (``module_path::Class.method``)
+    rather than bare names, preventing collisions across files.
+    """
+    known_names = {s.name for s in symbols}
+    # Map bare names → qualified IDs for the single-file case.
+    # Within one file, name collisions don't occur, so this is 1:1.
+    name_to_qid: dict[str, str] = {}
+    for s in symbols:
+        qid = s.qualified_id()
+        name_to_qid[s.name] = qid
+
+    callees: dict[str, set[str]] = {}
+    callers: dict[str, set[str]] = defaultdict(set)
+
+    for sym in symbols:
+        if sym.kind == "class":
+            continue
+        qid = name_to_qid.get(sym.name, sym.qualified_id())
+        # Filter to known symbols only: excludes external builtins and dotted
+        # attribute calls like 'calc.add' that can't be resolved locally.
+        filtered_calls = {name_to_qid[c] for c in sym.calls if c in known_names}
+        callees[qid] = filtered_calls
+        for called_qid in filtered_calls:
+            callers[called_qid].add(qid)
+
+    return callees, callers
+
+
+def _resolve_imported_symbol(
+    call: str, file_imports: list[ImportInfo], directory: Path
+) -> str | None:
+    """Try to resolve a dotted call like 'module.func' to a symbol name.
+
+    Uses import map to find which file defines the called symbol.
+    Returns the resolved symbol name if found, None otherwise.
+
+    Honors aliases on both forms:
+    - ``import calc as c`` then ``c.add()`` -> ``"add"``
+    - ``from utils import add as a`` then ``a()`` -> ``"add"``
+    """
+    if not call:
+        return None
+
+    parts = call.split(".")
+    if not parts:
+        return None
+
+    # Check direct from-import: ``from module import func`` -> ``func()``.
+    # Also handles aliased from-imports: ``from m import f as g; g()``.
+    for imp in file_imports:
+        if imp.is_from and len(parts) == 1 and local_binding(imp) == parts[0]:
+            # Return the original symbol name, not the alias, so the call links
+            # to the actual definition rather than a non-existent alias entry.
+            return imp.name
+
+    # Check module import: ``import module; module.func()`` and aliased forms
+    # like ``import module.sub as ms; ms.func()``.
+    for imp in file_imports:
+        if not imp.is_from and imp.module and len(parts) > 1:
+            local = local_binding(imp)
+            mod_first = imp.module.split(".")[0]
+            # Match either the local binding (alias-aware) or the raw module
+            # head. The latter keeps backward compatibility with imports that
+            # don't actually have an alias.
+            if parts[0] == local or parts[0] == mod_first:
+                return parts[-1]
+
+    # Check from-import where the imported name is itself a module:
+    # ``from pkg import sub`` then ``sub.func()`` -> ``func``.
+    for imp in file_imports:
+        if (
+            imp.is_from
+            and imp.module
+            and len(parts) > 1
+            and parts[0] == local_binding(imp)
+        ):
+            return parts[-1]
+
+    return None
+
+
+def build_cross_file_call_graph(
+    index: SymbolIndex,
+    directory: Path,
+) -> tuple[dict[str, set[str]], dict[str, set[str]]]:
+    """Build a unified call graph across all files in the index.
+
+    Resolves calls through imports to link symbols across files.
+    Graph keys are stable qualified IDs (``module_path::Class.method``)
+    rather than bare names, preventing collisions across files.
+    Returns (callees, callers) dictionaries.
+    """
+    # Re-parse all indexed files to get symbols with their calls
+    # (IndexEntry does not store calls, so we need the full Symbol)
+    all_symbols: list[Symbol] = []
+    file_symbols: dict[str, list[Symbol]] = {}
+    seen_files: set[str] = set()
+    for entries in index.entries.values():
+        for entry in entries:
+            seen_files.add(entry.file)
+
+    for file_path in seen_files:
+        fp = Path(file_path)
+        if fp.exists():
+            result = parse_file(fp)
+            # Set module_path from the file path and indexed directory
+            mp = _module_path(str(fp), str(directory))
+            for sym in result.symbols:
+                sym.module_path = mp
+                all_symbols.append(sym)
+                file_symbols.setdefault(file_path, []).append(sym)
+
+    known_names = {s.name for s in all_symbols}
+    # Build name → qualified ID map for cross-file resolution.
+    # When multiple files define the same bare name, the first entry is
+    # the default (one-to-many names are rare and the index handles them
+    # separately via ``index.lookup()``).
+    name_to_qid: dict[str, str] = {}
+    for sym in all_symbols:
+        qid = sym.qualified_id()
+        if sym.name not in name_to_qid:
+            name_to_qid[sym.name] = qid
+
+    callees: dict[str, set[str]] = {}
+    callers: dict[str, set[str]] = defaultdict(set)
+
+    for file_path, symbols in file_symbols.items():
+        imports = index.file_imports(file_path)
+        for sym in symbols:
+            if sym.kind == "class":
+                continue
+            resolved_calls: set[str] = set()
+            for call in sym.calls:
+                if call in known_names:
+                    # Local or same-file call
+                    resolved_calls.add(call)
+                else:
+                    # Try import resolution for both dotted (``mod.func``)
+                    # and plain (``alias_local``) calls. Plain calls matter for
+                    # ``from m import f as g; g()`` — the local binding is not
+                    # in ``known_names`` but resolution maps it back to ``f``.
+                    resolved = _resolve_imported_symbol(call, imports, directory)
+                    if resolved and resolved in known_names:
+                        resolved_calls.add(resolved)
+                    # else: external builtin/library — ignore
+            qid = name_to_qid.get(sym.name, sym.qualified_id())
+            qid_calls = {name_to_qid.get(c, c) for c in resolved_calls}
+            callees[qid] = qid_calls
+            for called in qid_calls:
+                callers[called].add(qid)
+
+    return callees, callers
+
+
+def _resolve_graph_key(name: str, graph: dict[str, set[str]]) -> str | None:
+    """Resolve a user-provided bare name to a qualified graph key.
+
+    Tries exact match first, then ``::name`` (common for symbols from
+    temp/single files with empty module_path), then scans all keys
+    for a ``::name`` suffix.
+    Returns the resolved key or None.
+    """
+    if name in graph:
+        return name
+    flat = "::" + name
+    if flat in graph:
+        return flat
+    # Scan for ::name suffix (handles module_path::name qualified IDs)
+    for key in graph:
+        if key.endswith("::" + name):
+            return key
+    return None
+
+
+def dependency_closure(
+    name: str,
+    callees: dict[str, set[str]],
+    max_depth: int = 10,
+) -> dict[str, set[str]]:
+    """Compute the dependency closure of a symbol.
+
+    Walks callees (downstream): what does this symbol depend on?
+    Returns dict mapping depth level to set of symbols.
+    ``name`` can be a bare name or a qualified ID.
+    """
+    resolved = _resolve_graph_key(name, callees)
+    if resolved is None:
+        return {"depth_0": {name}}
+
+    visited: set[str] = set()
+    radius: dict[str, set[str]] = {}
+    queue: list[tuple[str, int]] = [(resolved, 0)]
+
+    while queue:
+        current, depth = queue.pop(0)
+        if current in visited or depth > max_depth:
+            continue
+        visited.add(current)
+        radius.setdefault(f"depth_{depth}", set()).add(current)
+        for callee in callees.get(current, set()):
+            if callee not in visited:
+                queue.append((callee, depth + 1))
+
+    return radius
+
+
+def impact_radius(
+    name: str,
+    callers: dict[str, set[str]],
+    max_depth: int = 10,
+) -> dict[str, set[str]]:
+    """Compute the impact radius of a symbol.
+
+    Walks callers (upstream): what breaks if I change this symbol?
+    Returns dict mapping depth level to set of affected symbols.
+    ``name`` can be a bare name or a qualified ID.
+    """
+    resolved = _resolve_graph_key(name, callers)
+    if resolved is None:
+        return {"depth_0": {name}}
+
+    visited: set[str] = set()
+    radius: dict[str, set[str]] = {}
+    queue: list[tuple[str, int]] = [(resolved, 0)]
+
+    while queue:
+        current, depth = queue.pop(0)
+        if current in visited or depth > max_depth:
+            continue
+        visited.add(current)
+        radius.setdefault(f"depth_{depth}", set()).add(current)
+        for caller in callers.get(current, set()):
+            if caller not in visited:
+                queue.append((caller, depth + 1))
+
+    return radius
+
+
+# Keep backward-compatible alias
+blast_radius = dependency_closure
+
+
+def format_json(data) -> str:
+    """Format data as pretty-printed JSON."""
+    return json.dumps(data, indent=2, default=str)
+
+
+def format_symbols(symbols: list[Symbol]) -> str:
+    """Format extracted symbols as human-readable text."""
+    funcs = [s for s in symbols if s.kind == "function"]
+    classes = [s for s in symbols if s.kind == "class"]
+    methods = [s for s in symbols if s.kind == "method"]
+    total = len(symbols)
+
+    lines = [
+        f"Functions: {len(funcs)}  Classes: {len(classes)}  Methods: {len(methods)}",
+        f"Total: {total}",
+    ]
+    if not symbols:
+        return "\n".join(lines)
+
+    lines.append("")
+    for s in symbols:
+        qual = f" (class {s.parent_class})" if s.parent_class else ""
+        lines.append(f"{s.kind} {s.name}{qual}: L{s.start_line}-{s.end_line}")
+        if s.docstring:
+            lines.append(f"  {s.docstring[:200]}")
+        if s.calls:
+            lines.append(f"  calls: {', '.join(sorted(s.calls))}")
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Structural code retrieval via tree-sitter"
+    )
+    parser.add_argument("file", help="Python file to analyze")
+    parser.add_argument(
+        "--directory",
+        help="Cross-file index directory (enables cross-file lookups)",
+    )
+    parser.add_argument(
+        "--use-sqlite",
+        action="store_true",
+        help="Use SQLite cache for cross-file index (persists across runs)",
+    )
+    sub = parser.add_subparsers(dest="command", required=True, help="Subcommand")
+
+    p_parse = sub.add_parser("parse", help="Extract symbols")
+    p_parse.add_argument("--json", action="store_true", help="Output as JSON")
+
+    p_callers = sub.add_parser("callers", help="Find callers of a symbol")
+    p_callers.add_argument("name", help="Symbol name to find callers for")
+    p_callers.add_argument("--json", action="store_true", help="Output as JSON")
+
+    p_callees = sub.add_parser("callees", help="Find symbols called by a symbol")
+    p_callees.add_argument("name", help="Symbol name")
+    p_callees.add_argument("--json", action="store_true", help="Output as JSON")
+
+    p_blast = sub.add_parser("blast", help="[deprecated] Use 'impact' or 'deps'")
+    p_blast.add_argument("name", help="Symbol name")
+    p_blast.add_argument(
+        "--max-depth", type=int, default=10, help="Maximum depth (default: 10)"
+    )
+    p_blast.add_argument("--json", action="store_true", help="Output as JSON")
+
+    p_deps = sub.add_parser(
+        "deps", help="Compute dependency closure (what this symbol depends on)"
+    )
+    p_deps.add_argument("name", help="Symbol name")
+    p_deps.add_argument(
+        "--max-depth", type=int, default=10, help="Maximum depth (default: 10)"
+    )
+    p_deps.add_argument("--json", action="store_true", help="Output as JSON")
+
+    p_impact = sub.add_parser(
+        "impact", help="Compute impact radius (what depends on this symbol)"
+    )
+    p_impact.add_argument("name", help="Symbol name")
+    p_impact.add_argument(
+        "--max-depth", type=int, default=10, help="Maximum depth (default: 10)"
+    )
+    p_impact.add_argument("--json", action="store_true", help="Output as JSON")
+
+    p_def = sub.add_parser("def", help="Find where a symbol is defined")
+    p_def.add_argument("name", help="Symbol name")
+    p_def.add_argument("--json", action="store_true", help="Output as JSON")
+
+    p_refs = sub.add_parser("refs", help="Find references to a symbol")
+    p_refs.add_argument("name", help="Symbol name")
+    p_refs.add_argument("--json", action="store_true", help="Output as JSON")
+
+    args = parser.parse_args()
+    filepath = Path(args.file)
+
+    if not filepath.exists():
+        sys.exit(f"File not found: {filepath}")
+
+    symbols = extract_symbols(filepath)
+    if not symbols:
+        print("No symbols found.")
+        return
+
+    name_map = {s.name: s for s in symbols}
+
+    # Cross-file index: build if --directory is given
+    index: SymbolIndex | None = None
+    if args.directory is not None:
+        index_dir = Path(args.directory)
+        if not index_dir.exists():
+            sys.exit(f"Directory not found: {index_dir}")
+        if args.use_sqlite:
+            cache = SqliteIndexCache(str(index_dir))
+            cached = cache.load()
+            if cached is not None:
+                index = cached
+            else:
+                index = build_index(index_dir)
+                cache.save(index)
+            cache.close()
+        else:
+            index = build_index(index_dir)
+
+    # Build call graph: cross-file when directory is given, local-only otherwise
+    if index is not None:
+        callees_graph, callers_graph = build_cross_file_call_graph(
+            index, Path(args.directory)
+        )
+    else:
+        callees_graph, callers_graph = build_call_graph(symbols)
+
+    # Helper: resolve a symbol locally or from the cross-file index
+    def resolve(name: str) -> Symbol | None:
+        found = name_map.get(name)
+        if found is not None:
+            return found
+        if index is not None and index.has(name):
+            entry = index.lookup(name)[0]
+            return Symbol(
+                name=entry.name,
+                kind=entry.kind,
+                file=entry.file,
+                start_line=entry.start_line,
+                end_line=entry.end_line,
+                parent_class=entry.parent_class,
+            )
+        return None
+
+    if args.command == "parse":
+        if args.json:
+            print(format_json([asdict(s) for s in symbols]))
+        else:
+            print(format_symbols(symbols))
+
+    elif args.command == "callers":
+        found = resolve(args.name)
+        if not found:
+            sys.exit(f"Symbol not found: {args.name}")
+        if index is not None and index.has(args.name):
+            entries = index.lookup(args.name)
+            cross_file_info = f"\n  Defined in {len(entries)} file(s):" + "".join(
+                f"\n    {e.file}:L{e.start_line}" for e in entries[:10]
+            )
+        else:
+            cross_file_info = ""
+        resolved_key = _resolve_graph_key(args.name, callers_graph)
+        callers = sorted(callers_graph.get(resolved_key, set())) if resolved_key else []
+        if args.json:
+            output: dict = {"symbol": args.name, "callers": callers}
+            if index and index.has(args.name):
+                output["definitions"] = [
+                    {"file": e.file, "line": e.start_line}
+                    for e in index.lookup(args.name)
+                ]
+            print(format_json(output))
+        else:
+            print(f"Callers of {args.name}():{cross_file_info}")
+            if callers:
+                for c in callers:
+                    s = resolve(c)
+                    if s:
+                        print(
+                            f"  {c}()  L{s.start_line} ({s.file})"
+                            if index
+                            else f"  {c}()  L{s.start_line}-{s.end_line}"
+                        )
+                    else:
+                        print(f"  {c}()")
+            else:
+                print("  (none found)")
+
+    elif args.command == "callees":
+        found = resolve(args.name)
+        if not found:
+            sys.exit(f"Symbol not found: {args.name}")
+        resolved_key = _resolve_graph_key(args.name, callees_graph)
+        callees = sorted(callees_graph.get(resolved_key, set())) if resolved_key else []
+        if args.json:
+            output = {"symbol": args.name, "callees": callees}
+            if index and index.has(args.name):
+                output["definitions"] = [
+                    {"file": e.file, "line": e.start_line}
+                    for e in index.lookup(args.name)
+                ]
+            print(format_json(output))
+        else:
+            print(f"{args.name}() calls:")
+            if callees:
+                for c in callees:
+                    s = resolve(c)
+                    if s:
+                        print(
+                            f"  {c}()  L{s.start_line} ({s.file})"
+                            if index
+                            else f"  {c}()  L{s.start_line}-{s.end_line}"
+                        )
+                    else:
+                        print(f"  {c}()  (external)")
+            else:
+                print("  (none)")
+
+    elif args.command == "blast":
+        found = resolve(args.name)
+        if not found:
+            sys.exit(f"Symbol not found: {args.name}")
+        # backward compat: walk callees
+        radius = dependency_closure(args.name, callees_graph, max_depth=args.max_depth)
+        if args.json:
+            print(
+                format_json(
+                    {
+                        "symbol": args.name,
+                        "blast_radius": {k: sorted(v) for k, v in radius.items()},
+                    }
+                )
+            )
+        else:
+            print(f"Blast radius of {args.name}() (dependency closure):")
+            total = 0
+            for depth_key in sorted(radius.keys()):
+                deps = sorted(radius[depth_key])
+                if deps:
+                    print(f"  {depth_key}: {', '.join(deps[:10])}")
+                    if len(deps) > 10:
+                        print(f"    ... and {len(deps) - 10} more")
+                    total += len(deps)
+            print(f"  Total downstream: {total} symbols reachable")
+
+    elif args.command == "deps":
+        found = resolve(args.name)
+        if not found:
+            sys.exit(f"Symbol not found: {args.name}")
+        radius = dependency_closure(args.name, callees_graph, max_depth=args.max_depth)
+        if args.json:
+            print(
+                format_json(
+                    {
+                        "symbol": args.name,
+                        "deps": {k: sorted(v) for k, v in radius.items()},
+                    }
+                )
+            )
+        else:
+            print(f"Dependency closure of {args.name}():")
+            total = 0
+            for depth_key in sorted(radius.keys()):
+                deps = sorted(radius[depth_key])
+                if deps:
+                    print(f"  {depth_key}: {', '.join(deps[:10])}")
+                    if len(deps) > 10:
+                        print(f"    ... and {len(deps) - 10} more")
+                    total += len(deps)
+            print(f"  Total dependencies: {total} symbols reachable")
+
+    elif args.command == "impact":
+        found = resolve(args.name)
+        if not found:
+            sys.exit(f"Symbol not found: {args.name}")
+        radius = impact_radius(args.name, callers_graph, max_depth=args.max_depth)
+        if args.json:
+            print(
+                format_json(
+                    {
+                        "symbol": args.name,
+                        "impact_radius": {k: sorted(v) for k, v in radius.items()},
+                    }
+                )
+            )
+        else:
+            print(f"Impact radius of {args.name}():")
+            total = 0
+            for depth_key in sorted(radius.keys()):
+                affected = sorted(radius[depth_key])
+                if affected:
+                    print(f"  {depth_key}: {', '.join(affected[:10])}")
+                    if len(affected) > 10:
+                        print(f"    ... and {len(affected) - 10} more")
+                    total += len(affected)
+            print(f"  Total affected: {total} symbols that could break")
+
+    elif args.command == "def":
+        found = resolve(args.name)
+        if not found:
+            sys.exit(f"Symbol not found: {args.name}")
+        if args.json:
+            if (
+                index
+                and index.has(args.name)
+                and (not found or found.file != str(filepath))
+            ):
+                all_defs = [
+                    {
+                        "name": args.name,
+                        "kind": e.kind,
+                        "file": e.file,
+                        "start_line": e.start_line,
+                        "end_line": e.end_line,
+                        "parent_class": e.parent_class,
+                    }
+                    for e in index.lookup(args.name)
+                ]
+                print(format_json(all_defs if len(all_defs) > 1 else all_defs[0]))
+            else:
+                print(format_json(asdict(found)))
+        else:
+            qual = f" (in class {found.parent_class})" if found.parent_class else ""
+            print(
+                f"{found.kind} {found.name}{qual}: "
+                f"lines {found.start_line}-{found.end_line}"
+            )
+            if found.docstring:
+                print(f"  {found.docstring[:200]}")
+            if index and index.has(args.name):
+                entries = [e for e in index.lookup(args.name) if e.file != found.file]
+                if entries:
+                    print(f"\n  Also defined in {len(entries)} other file(s):")
+                    for e in entries[:10]:
+                        print(f"    {e.file}:L{e.start_line}")
+
+    elif args.command == "refs":
+        found = resolve(args.name)
+        if not found:
+            sys.exit(f"Symbol not found: {args.name}")
+        if index is not None and index.has(args.name):
+            entries = index.lookup(args.name)
+            cross_file_info = f"\n  Defined in {len(entries)} file(s):" + "".join(
+                f"\n    {e.file}:L{e.start_line}" for e in entries[:10]
+            )
+        else:
+            cross_file_info = ""
+        resolved_key = _resolve_graph_key(args.name, callers_graph)
+        callers = sorted(callers_graph.get(resolved_key, set())) if resolved_key else []
+        if args.json:
+            output = {
+                "symbol": args.name,
+                "references": callers,
+            }
+            if index and index.has(args.name):
+                output["definitions"] = [
+                    {"file": e.file, "line": e.start_line}
+                    for e in index.lookup(args.name)
+                ]
+            print(format_json(output))
+        else:
+            print(f"References to {args.name}():{cross_file_info}")
+            if callers:
+                print(f"  {len(callers)} call site(s):")
+                for c in callers:
+                    s = resolve(c)
+                    if s:
+                        print(f"    {c}()  line {s.start_line}")
+            else:
+                print("  No callers found")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/gptme-codegraph/src/gptme_codegraph/mcp_server.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/mcp_server.py
@@ -54,11 +54,25 @@ _index_cache: dict[str, tuple[SymbolIndex, SqliteIndexCache | None]] = {}
 
 
 def _get_or_build_index(directory: str) -> SymbolIndex:
-    """Get a cached index (SQLite-backed, falling through to in-memory)."""
+    """Get a cached index (SQLite-backed, falling through to in-memory).
+
+    When SQLite is available, freshness is re-checked on every call so file
+    edits between calls are detected automatically.  Without SQLite backing
+    (i.e. the ``[treesitter]`` extra is not installed) the in-memory snapshot
+    is returned unconditionally — restart the server to pick up changes.
+    """
     dir_path = str(Path(directory).resolve())
 
     if dir_path in _index_cache:
-        return _index_cache[dir_path][0]
+        cached_index, cached_sqlite = _index_cache[dir_path]
+        if cached_sqlite is None:
+            # No freshness oracle available — return the snapshot as-is.
+            return cached_index
+        # Re-check SQLite freshness; returns None when any indexed file changed.
+        if cached_sqlite.load() is not None:
+            return cached_index
+        # Stale — drop and fall through to rebuild.
+        del _index_cache[dir_path]
 
     # Try SQLite first
     sqlite_cache: SqliteIndexCache | None = None
@@ -154,16 +168,16 @@ def codegraph_index(directory: str) -> str:
     index = _get_or_build_index(directory)
     all_names = index.all_names()
 
-    # Summarize: top N most-referenced symbols and file count
+    # Summarize: first N symbols (alphabetical) and file count
     file_count = len({e.file for entries in index.entries.values() for e in entries})
-    top_names = all_names[:20] if len(all_names) > 20 else all_names
+    sample_names = all_names[:20] if len(all_names) > 20 else all_names
 
     return json.dumps(
         {
             "directory": str(dir_path.resolve()),
             "files_indexed": file_count,
             "unique_symbols": len(all_names),
-            "top_symbols": top_names,
+            "symbols_sample": sample_names,
         },
         indent=2,
     )
@@ -362,55 +376,6 @@ def codegraph_callers(
             ]
 
     return json.dumps(result, indent=2)
-
-
-def _cross_file_callers(name: str, directory: str) -> str:
-    """Cross-file caller search — scan all files in the index for callers."""
-    import ast
-
-    dir_path = Path(directory)
-    callers: list[dict] = []
-
-    def _name_matches(node: ast.AST, target: str) -> bool:
-        if isinstance(node, ast.Name) and node.id == target:
-            return True
-        if isinstance(node, ast.Attribute) and node.attr == target:
-            return True
-        return False
-
-    for fp in sorted(dir_path.rglob("*.py")):
-        try:
-            tree = ast.parse(fp.read_bytes())
-            for node in ast.walk(tree):
-                if isinstance(node, ast.Call):
-                    func = node.func
-                    if isinstance(func, ast.Name) and func.id == name:
-                        callers.append(
-                            {
-                                "file": str(fp),
-                                "line": node.lineno,
-                                "caller": "module-level",
-                            }
-                        )
-                    elif isinstance(func, ast.Attribute) and func.attr == name:
-                        callers.append(
-                            {
-                                "file": str(fp),
-                                "line": node.lineno,
-                                "caller": "module-level",
-                            }
-                        )
-        except SyntaxError:
-            continue
-
-    return json.dumps(
-        {
-            "symbol": name,
-            "cross_file_callers": callers,
-            "total": len(callers),
-        },
-        indent=2,
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/packages/gptme-codegraph/src/gptme_codegraph/mcp_server.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/mcp_server.py
@@ -1,0 +1,712 @@
+"""MCP server wrapping gptme-codegraph — structural code retrieval via tree-sitter.
+
+Exposes codegraph tools as MCP resources so any MCP-compatible agent
+(Claude Code, Cursor, Codex, gptme) can query code structure without
+a separate CLI invocation.
+
+Usage:
+    # As an MCP server (stdio transport)
+    gptme-codegraph-mcp
+
+    # Configure in Claude Code:
+    #   claude mcp add codegraph -- gptme-codegraph-mcp
+
+Tools exposed:
+    codegraph_parse                — Extract symbols from a single file
+    codegraph_index                — Build cross-file symbol index for a directory
+    codegraph_def                  — Find where a symbol is defined
+    codegraph_callers              — Find callers of a symbol
+    codegraph_callees              — Find callees of a symbol
+    codegraph_refs                 — Find references to a symbol
+    codegraph_blast                — Compute dependency closure (walks callees)
+    codegraph_impact               — Compute impact radius (walks callers — what breaks if you change this)
+
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# FastMCP server
+# ---------------------------------------------------------------------------
+from mcp.server.fastmcp import FastMCP
+
+from gptme_codegraph.core import (
+    SqliteIndexCache,
+    SymbolIndex,
+    _resolve_graph_key,
+    blast_radius,
+    build_call_graph,
+    build_cross_file_call_graph,
+    build_index,
+    extract_symbols,
+    impact_radius,
+)
+
+mcp = FastMCP("codegraph", log_level="WARNING")
+
+# ---------------------------------------------------------------------------
+# In-memory + SQLite index cache
+# ---------------------------------------------------------------------------
+
+_index_cache: dict[str, tuple[SymbolIndex, SqliteIndexCache | None]] = {}
+
+
+def _get_or_build_index(directory: str) -> SymbolIndex:
+    """Get a cached index (SQLite-backed, falling through to in-memory)."""
+    dir_path = str(Path(directory).resolve())
+
+    if dir_path in _index_cache:
+        return _index_cache[dir_path][0]
+
+    # Try SQLite first
+    sqlite_cache: SqliteIndexCache | None = None
+    try:
+        sqlite_cache = SqliteIndexCache(dir_path)
+        cached = sqlite_cache.load()
+        if cached is not None:
+            _index_cache[dir_path] = (cached, sqlite_cache)
+            return cached
+    except Exception:
+        pass
+
+    # Build fresh and save to SQLite
+    index = build_index(Path(dir_path))
+    if sqlite_cache is not None:
+        try:
+            sqlite_cache.save(index)
+        except Exception:
+            pass
+    _index_cache[dir_path] = (index, sqlite_cache)
+    return index
+
+
+def _invalidate_cache(directory: str) -> None:
+    """Force rebuild on next access for a directory."""
+    dir_path = str(Path(directory).resolve())
+    _index_cache.pop(dir_path, None)
+
+
+# ---------------------------------------------------------------------------
+# Tool: codegraph_parse
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def codegraph_parse(filepath: str) -> str:
+    """Extract symbols (functions, classes) from a Python file.
+
+    Args:
+        filepath: Absolute path to the Python file to analyze.
+
+    Returns:
+        JSON with symbol count, file, and list of symbols with their
+        locations, docstrings, and call graphs.
+    """
+    fp = Path(filepath)
+    if not fp.exists():
+        return json.dumps({"error": f"File not found: {filepath}"})
+    if not fp.is_file():
+        return json.dumps({"error": f"Not a file: {filepath}"})
+
+    symbols = extract_symbols(fp)
+    return json.dumps(
+        {
+            "file": filepath,
+            "symbol_count": len(symbols),
+            "symbols": [
+                {
+                    "name": s.name,
+                    "kind": s.kind,
+                    "start_line": s.start_line,
+                    "end_line": s.end_line,
+                    "parent_class": s.parent_class,
+                    "docstring": s.docstring[:200] if s.docstring else None,
+                    "calls": sorted(s.calls),
+                }
+                for s in symbols
+            ],
+        },
+        indent=2,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool: codegraph_index
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def codegraph_index(directory: str) -> str:
+    """Build (or load from SQLite cache) a cross-file symbol index for a directory.
+
+    Args:
+        directory: Directory to scan recursively for Python files.
+
+    Returns:
+        JSON with file count, symbol count, and top symbols.
+    """
+    dir_path = Path(directory)
+    if not dir_path.is_dir():
+        return json.dumps({"error": f"Directory not found: {directory}"})
+
+    index = _get_or_build_index(directory)
+    all_names = index.all_names()
+
+    # Summarize: top N most-referenced symbols and file count
+    file_count = len({e.file for entries in index.entries.values() for e in entries})
+    top_names = all_names[:20] if len(all_names) > 20 else all_names
+
+    return json.dumps(
+        {
+            "directory": str(dir_path.resolve()),
+            "files_indexed": file_count,
+            "unique_symbols": len(all_names),
+            "top_symbols": top_names,
+        },
+        indent=2,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool: codegraph_def
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def codegraph_def(
+    name: str,
+    filepath: str | None = None,
+    directory: str | None = None,
+) -> str:
+    """Find the definition of a symbol.
+
+    Args:
+        name: Symbol name to find (function, class, method).
+        filepath: Single-file mode: path to the file to search.
+        directory: Cross-file mode: directory to search (requires --directory).
+
+    Returns:
+        JSON with found, match details, and optional cross-file definitions.
+    """
+    if filepath:
+        fp = Path(filepath)
+        if not fp.exists():
+            return json.dumps({"error": f"File not found: {filepath}"})
+        symbols = extract_symbols(fp)
+        for s in symbols:
+            if s.name == name:
+                result = {
+                    "found": True,
+                    "matches": [
+                        {
+                            "name": s.name,
+                            "kind": s.kind,
+                            "file": fp.name,
+                            "start_line": s.start_line,
+                            "end_line": s.end_line,
+                            "parent_class": s.parent_class,
+                            "docstring": s.docstring[:200] if s.docstring else None,
+                        }
+                    ],
+                }
+                # Cross-file fallback
+                if directory:
+                    index = _get_or_build_index(directory)
+                    if index.has(name):
+                        entries = index.lookup(name)
+                        result["definitions"] = len(entries)
+                        result["cross_file"] = [
+                            {"file": e.file, "line": e.start_line, "kind": e.kind}
+                            for e in entries[:10]
+                        ]
+                return json.dumps(result, indent=2)
+
+        # Not found locally; try cross-file if directory given
+        if directory:
+            return str(codegraph_def(name, directory=directory))
+        return json.dumps({"found": False, "matches": []})
+
+    if directory:
+        index = _get_or_build_index(directory)
+        if index.has(name):
+            entries = index.lookup(name)
+            return json.dumps(
+                {
+                    "found": True,
+                    "definitions": len(entries),
+                    "matches": [
+                        {
+                            "name": e.name,
+                            "kind": e.kind,
+                            "file": e.file,
+                            "start_line": e.start_line,
+                            "end_line": e.end_line,
+                            "parent_class": e.parent_class,
+                        }
+                        for e in entries[:20]
+                    ],
+                },
+                indent=2,
+            )
+
+    return json.dumps({"found": False, "matches": []})
+
+
+# ---------------------------------------------------------------------------
+# Tool: codegraph_callers
+# ---------------------------------------------------------------------------
+
+
+def _cross_file_callers_mcp(name: str, directory: str) -> str:
+    """Cross-file caller lookup using the index-based call graph."""
+    index = _get_or_build_index(directory)
+    if not index.has(name):
+        return json.dumps({"error": f"Symbol '{name}' not found in index"})
+
+    dir_path = Path(directory)
+    callees_graph, callers_graph = build_cross_file_call_graph(index, dir_path)
+
+    resolved = _resolve_graph_key(name, callers_graph)
+    direct_callers = sorted(callers_graph.get(resolved, set())) if resolved else []
+    files = {e.file for e in index.lookup(name)}
+
+    return json.dumps(
+        {
+            "symbol": name,
+            "callers": direct_callers,
+            "caller_count": len(direct_callers),
+            "defined_in": sorted(files),
+            "search_directory": str(dir_path),
+        },
+        indent=2,
+    )
+
+
+def _cross_file_callees_mcp(name: str, directory: str) -> str:
+    """Cross-file callee lookup using the index-based call graph."""
+    index = _get_or_build_index(directory)
+    if not index.has(name):
+        return json.dumps({"error": f"Symbol '{name}' not found in index"})
+
+    dir_path = Path(directory)
+    callees_graph, _callers_graph = build_cross_file_call_graph(index, dir_path)
+
+    resolved = _resolve_graph_key(name, callees_graph)
+    direct_callees = sorted(callees_graph.get(resolved, set())) if resolved else []
+
+    return json.dumps(
+        {
+            "symbol": name,
+            "callees": direct_callees,
+            "callee_count": len(direct_callees),
+            "search_directory": str(dir_path),
+        },
+        indent=2,
+    )
+
+
+@mcp.tool()
+def codegraph_callers(
+    name: str,
+    filepath: str | None = None,
+    directory: str | None = None,
+) -> str:
+    """Find all callers of a symbol — within a file, or across an indexed directory.
+
+    Args:
+        name: Symbol name to find callers for.
+        filepath: Optional path to the Python file containing the symbol.
+            If omitted, ``directory`` must be set for index-based lookup.
+        directory: Optional directory for cross-file index lookup.
+
+    Returns:
+        JSON with symbol, callers list, and cross-file info.
+    """
+    # Cross-file mode: no filepath, use index
+    if filepath is None:
+        if not directory:
+            return json.dumps({"error": "Either filepath or directory is required"})
+        return _cross_file_callers_mcp(name, directory)
+
+    # Single-file mode
+    fp = Path(filepath)
+    if not fp.exists():
+        return json.dumps({"error": f"File not found: {filepath}"})
+
+    symbols = extract_symbols(fp)
+    name_map = {s.name: s for s in symbols}
+    _callees_graph, callers_graph = build_call_graph(symbols)
+
+    if name not in name_map:
+        # Try cross-file as fallback
+        if directory:
+            return _cross_file_callers_mcp(name, directory)
+        return json.dumps({"error": f"Symbol '{name}' not found in {filepath}"})
+
+    resolved = _resolve_graph_key(name, callers_graph)
+    callers = sorted(callers_graph.get(resolved, set())) if resolved else []
+    result: dict[str, Any] = {
+        "symbol": name,
+        "callers": callers,
+    }
+
+    if directory:
+        index = _get_or_build_index(directory)
+        if index.has(name):
+            entries = index.lookup(name)
+            result["definitions"] = len(entries)
+            result["cross_file_defs"] = [
+                {"file": e.file, "line": e.start_line} for e in entries[:10]
+            ]
+
+    return json.dumps(result, indent=2)
+
+
+def _cross_file_callers(name: str, directory: str) -> str:
+    """Cross-file caller search — scan all files in the index for callers."""
+    import ast
+
+    dir_path = Path(directory)
+    callers: list[dict] = []
+
+    def _name_matches(node: ast.AST, target: str) -> bool:
+        if isinstance(node, ast.Name) and node.id == target:
+            return True
+        if isinstance(node, ast.Attribute) and node.attr == target:
+            return True
+        return False
+
+    for fp in sorted(dir_path.rglob("*.py")):
+        try:
+            tree = ast.parse(fp.read_bytes())
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Call):
+                    func = node.func
+                    if isinstance(func, ast.Name) and func.id == name:
+                        callers.append(
+                            {
+                                "file": str(fp),
+                                "line": node.lineno,
+                                "caller": "module-level",
+                            }
+                        )
+                    elif isinstance(func, ast.Attribute) and func.attr == name:
+                        callers.append(
+                            {
+                                "file": str(fp),
+                                "line": node.lineno,
+                                "caller": "module-level",
+                            }
+                        )
+        except SyntaxError:
+            continue
+
+    return json.dumps(
+        {
+            "symbol": name,
+            "cross_file_callers": callers,
+            "total": len(callers),
+        },
+        indent=2,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool: codegraph_callees
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def codegraph_callees(
+    name: str,
+    filepath: str | None = None,
+    directory: str | None = None,
+) -> str:
+    """Find all symbols called by a given function/method.
+
+    Args:
+        name: Symbol name to find callees for.
+        filepath: Optional path to the Python file containing the symbol.
+            If omitted, ``directory`` must be set for index-based lookup.
+        directory: Optional directory for cross-file lookup.
+
+    Returns:
+        JSON with symbol, callees list, and optional cross-file info.
+    """
+    # Cross-file mode: no filepath, use index
+    if filepath is None:
+        if not directory:
+            return json.dumps({"error": "Either filepath or directory is required"})
+        return _cross_file_callees_mcp(name, directory)
+
+    # Single-file mode
+    fp = Path(filepath)
+    if not fp.exists():
+        return json.dumps({"error": f"File not found: {filepath}"})
+
+    symbols = extract_symbols(fp)
+    name_map = {s.name: s for s in symbols}
+    callees_graph, _callers_graph = build_call_graph(symbols)
+
+    if name not in name_map:
+        if directory:
+            index = _get_or_build_index(directory)
+            if index.has(name):
+                return json.dumps(
+                    {
+                        "symbol": name,
+                        "note": "Symbol found in cross-file index but callee"
+                        " analysis is single-file only.",
+                        "definitions": len(index.lookup(name)),
+                    },
+                    indent=2,
+                )
+        return json.dumps({"error": f"Symbol '{name}' not found in {filepath}"})
+
+    resolved = _resolve_graph_key(name, callees_graph)
+    callees = sorted(callees_graph.get(resolved, set())) if resolved else []
+    result: dict[str, Any] = {
+        "symbol": name,
+        "callees": callees,
+    }
+
+    if directory:
+        index = _get_or_build_index(directory)
+        if index.has(name):
+            result["definitions"] = len(index.lookup(name))
+
+    return json.dumps(result, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Tool: codegraph_refs
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def codegraph_refs(
+    name: str,
+    filepath: str,
+    directory: str | None = None,
+) -> str:
+    """Find all references to a symbol (delegates to callers for now).
+
+    Args:
+        name: Symbol name to find references for.
+        filepath: Path to the Python file.
+        directory: Optional directory for cross-file lookup.
+
+    Returns:
+        JSON with symbol and references list.
+    """
+    return str(codegraph_callers(name, filepath, directory))
+
+
+# ---------------------------------------------------------------------------
+# Tool: codegraph_blast
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def codegraph_blast(
+    name: str,
+    filepath: str | None = None,
+    max_depth: int = 5,
+    directory: str | None = None,
+) -> str:
+    """Compute the dependency closure of a symbol — what it transitively depends on.
+
+    Walks the callee graph (downstream): if you read this symbol's body, what
+    other symbols does it ultimately invoke? Use ``codegraph_impact`` instead
+    when you want the upstream view ("what breaks if I change this").
+
+    Args:
+        name: Symbol name to compute dependency closure for.
+        filepath: Optional path to the Python file containing the symbol.
+            If omitted, ``directory`` must be set for index-based cross-file mode.
+        max_depth: Maximum depth for transitive call graph (default: 5).
+        directory: Optional directory for cross-file lookup.
+
+    Returns:
+        JSON with symbol, total affected, and breakdown by depth.
+    """
+    # Cross-file mode: no filepath, use index-based cross-file blast
+    if filepath is None:
+        if not directory:
+            return json.dumps({"error": "Either filepath or directory is required"})
+        index = _get_or_build_index(directory)
+        if not index.has(name):
+            return json.dumps({"error": f"Symbol '{name}' not found in index"})
+        dir_path = Path(directory)
+        callees_graph, _callers_graph = build_cross_file_call_graph(index, dir_path)
+        if name not in callees_graph:
+            files = {e.file for e in index.lookup(name)}
+            return json.dumps(
+                {
+                    "symbol": name,
+                    "total_affected": 1,
+                    "depth_breakdown": {"depth_0": [name]},
+                    "defined_in": sorted(files),
+                    "note": "No cross-file calls found for this symbol",
+                },
+                indent=2,
+            )
+        radius = blast_radius(name, callees_graph, max_depth=max_depth)
+        total = sum(len(names) for names in radius.values())
+        files = {e.file for e in index.lookup(name)}
+        return json.dumps(
+            {
+                "symbol": name,
+                "total_affected": total,
+                "depth_breakdown": {k: sorted(v) for k, v in sorted(radius.items())},
+                "defined_in": sorted(files),
+            },
+            indent=2,
+        )
+
+    # Single-file mode
+    fp = Path(filepath)
+    if not fp.exists():
+        return json.dumps({"error": f"File not found: {filepath}"})
+
+    symbols = extract_symbols(fp)
+    name_map = {s.name: s for s in symbols}
+    callees_graph, _callers_graph = build_call_graph(symbols)
+
+    if name not in name_map:
+        if directory:
+            index = _get_or_build_index(directory)
+            if index.has(name):
+                return json.dumps(
+                    {
+                        "symbol": name,
+                        "note": "Symbol in index but blast radius requires"
+                        " single-file call graph.",
+                        "definitions": len(index.lookup(name)),
+                    }
+                )
+        return json.dumps({"error": f"Symbol '{name}' not found in {filepath}"})
+
+    radius = blast_radius(name, callees_graph, max_depth=max_depth)
+    total = sum(len(names) for names in radius.values())
+
+    result = {
+        "symbol": name,
+        "total_affected": total,
+        "depth_breakdown": {k: sorted(v) for k, v in sorted(radius.items())},
+    }
+
+    if directory:
+        index = _get_or_build_index(directory)
+        if index.has(name):
+            result["definitions"] = len(index.lookup(name))
+
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+def codegraph_impact(
+    name: str,
+    filepath: str | None = None,
+    max_depth: int = 5,
+    directory: str | None = None,
+) -> str:
+    """Compute the impact radius of a symbol — what breaks if you change it.
+
+    Walks the caller graph (upstream): which symbols transitively depend on
+    this one? Use ``codegraph_blast`` for the downstream view (what this
+    symbol depends on).
+
+    Args:
+        name: Symbol name to compute impact radius for.
+        filepath: Optional path to the Python file containing the symbol.
+            If omitted, ``directory`` must be set for index-based cross-file mode.
+        max_depth: Maximum depth for transitive call graph (default: 5).
+        directory: Optional directory for cross-file lookup.
+
+    Returns:
+        JSON with symbol, total affected callers, and breakdown by depth.
+    """
+    # Cross-file mode: no filepath, use index-based cross-file impact
+    if filepath is None:
+        if not directory:
+            return json.dumps({"error": "Either filepath or directory is required"})
+        index = _get_or_build_index(directory)
+        if not index.has(name):
+            return json.dumps({"error": f"Symbol '{name}' not found in index"})
+        dir_path = Path(directory)
+        _callees_graph, callers_graph = build_cross_file_call_graph(index, dir_path)
+        if name not in callers_graph:
+            files = {e.file for e in index.lookup(name)}
+            return json.dumps(
+                {
+                    "symbol": name,
+                    "total_affected": 1,
+                    "depth_breakdown": {"depth_0": [name]},
+                    "defined_in": sorted(files),
+                    "note": "No cross-file callers found for this symbol",
+                },
+                indent=2,
+            )
+        radius = impact_radius(name, callers_graph, max_depth=max_depth)
+        total = sum(len(names) for names in radius.values())
+        files = {e.file for e in index.lookup(name)}
+        return json.dumps(
+            {
+                "symbol": name,
+                "total_affected": total,
+                "depth_breakdown": {k: sorted(v) for k, v in sorted(radius.items())},
+                "defined_in": sorted(files),
+            },
+            indent=2,
+        )
+
+    # Single-file mode
+    fp = Path(filepath)
+    if not fp.exists():
+        return json.dumps({"error": f"File not found: {filepath}"})
+
+    symbols = extract_symbols(fp)
+    name_map = {s.name: s for s in symbols}
+    _callees_graph, callers_graph = build_call_graph(symbols)
+
+    if name not in name_map:
+        if directory:
+            index = _get_or_build_index(directory)
+            if index.has(name):
+                return json.dumps(
+                    {
+                        "symbol": name,
+                        "note": "Symbol in index but impact radius requires"
+                        " single-file call graph.",
+                        "definitions": len(index.lookup(name)),
+                    }
+                )
+        return json.dumps({"error": f"Symbol '{name}' not found in {filepath}"})
+
+    radius = impact_radius(name, callers_graph, max_depth=max_depth)
+    total = sum(len(names) for names in radius.values())
+
+    result: dict[str, Any] = {
+        "symbol": name,
+        "total_affected": total,
+        "depth_breakdown": {k: sorted(v) for k, v in sorted(radius.items())},
+    }
+
+    if directory:
+        index = _get_or_build_index(directory)
+        if index.has(name):
+            result["definitions"] = len(index.lookup(name))
+
+    return json.dumps(result, indent=2)
+
+
+def main() -> None:
+    """Run the codegraph MCP server."""
+    mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/gptme-codegraph/tests/test_codegraph.py
+++ b/packages/gptme-codegraph/tests/test_codegraph.py
@@ -1,0 +1,793 @@
+"""Tests for scripts/codegraph.py — structural code retrieval via tree-sitter."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+from gptme_codegraph.core import (
+    IndexEntry,
+    Symbol,
+    SymbolIndex,
+    _extract_imports,
+    _module_path,
+    _tree_sitter_parse,
+    blast_radius,
+    build_call_graph,
+    build_cross_file_call_graph,
+    build_index,
+    dependency_closure,
+    extract_symbols,
+    format_json,
+    format_symbols,
+    impact_radius,
+    parse_file,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def simple_module() -> Generator[Path, None, None]:
+    """A small Python module with functions, classes, and cross-references."""
+    code = """
+def greet(name: str) -> str:
+    \"\"\"Say hello.\"\"\"
+    return f"Hello {name}"
+
+
+def farewell(name: str) -> str:
+    \"\"\"Say goodbye.\"\"\"
+    msg = greet(name)
+    return f"{msg}, and goodbye"
+
+
+class Calculator:
+    \"\"\"A simple calculator.\"\"\"
+
+    def add(self, a: int, b: int) -> int:
+        \"\"\"Add two numbers.\"\"\"
+        return greet(f"result={a + b}")
+
+    def multiply(self, a: int, b: int) -> int:
+        return a * b
+
+
+def run():
+    calc = Calculator()
+    result = calc.add(1, 2)
+    return result
+
+
+def unused_helper():
+    pass
+"""
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".py", delete=False, prefix="test_simple_"
+    ) as f:
+        f.write(code)
+        path = Path(f.name)
+    yield path
+    path.unlink(missing_ok=True)
+
+
+@pytest.fixture
+def empty_module() -> Generator[Path, None, None]:
+    """A Python file with no symbols (only comments and whitespace)."""
+    code = """# This file has no functions, classes, or methods.
+# Just comments.
+# And whitespace.
+
+"""
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".py", delete=False, prefix="test_empty_"
+    ) as f:
+        f.write(code)
+        path = Path(f.name)
+    yield path
+    path.unlink(missing_ok=True)
+
+
+@pytest.fixture
+def class_only_module() -> Generator[Path, None, None]:
+    """A module with only a class and methods, no top-level functions."""
+    code = """
+class DataProcessor:
+    \"\"\"Process data.\"\"\"
+
+    def transform(self, data: list) -> list:
+        return [x * 2 for x in data]
+
+    def validate(self, data: list) -> bool:
+        return len(data) > 0
+"""
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".py", delete=False, prefix="test_class_"
+    ) as f:
+        f.write(code)
+        path = Path(f.name)
+    yield path
+    path.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Symbol extraction
+# ---------------------------------------------------------------------------
+
+
+def test_extract_symbols_finds_functions(simple_module: Path):
+    symbols = extract_symbols(simple_module)
+    names = {s.name for s in symbols}
+    assert "greet" in names
+    assert "farewell" in names
+    assert "run" in names
+    assert "unused_helper" in names
+
+
+def test_extract_symbols_finds_classes(simple_module: Path):
+    symbols = extract_symbols(simple_module)
+    names = {s.name for s in symbols}
+    assert "Calculator" in names
+
+
+def test_extract_symbols_finds_class_methods(simple_module: Path):
+    symbols = extract_symbols(simple_module)
+    methods = [s for s in symbols if s.kind == "method"]
+    method_names = {m.name for m in methods}
+    assert "add" in method_names
+    assert "multiply" in method_names
+    for m in methods:
+        if m.name == "add":
+            assert m.parent_class == "Calculator"
+        if m.name == "multiply":
+            assert m.parent_class == "Calculator"
+
+
+def test_extract_symbols_docstrings(simple_module: Path):
+    symbols = extract_symbols(simple_module)
+    greet = next(s for s in symbols if s.name == "greet")
+    assert greet.docstring == "Say hello."
+    calc = next(s for s in symbols if s.name == "Calculator")
+    assert calc.docstring == "A simple calculator."
+    add = next(s for s in symbols if s.name == "add")
+    assert add.docstring == "Add two numbers."
+
+
+def test_extract_symbols_line_numbers(simple_module: Path):
+    symbols = extract_symbols(simple_module)
+    greet = next(s for s in symbols if s.name == "greet")
+    assert greet.start_line >= 0  # 0-indexed or 1-indexed
+    assert greet.end_line > greet.start_line
+
+
+def test_extract_symbols_calls(simple_module: Path):
+    symbols = extract_symbols(simple_module)
+    farewell = next(s for s in symbols if s.name == "farewell")
+    assert "greet" in farewell.calls
+    add = next(s for s in symbols if s.name == "add")
+    assert "greet" in add.calls
+
+
+def test_extract_symbols_empty_module(empty_module: Path):
+    symbols = extract_symbols(empty_module)
+    assert len(symbols) == 0
+
+
+def test_extract_symbols_class_only(class_only_module: Path):
+    symbols = extract_symbols(class_only_module)
+    names = {s.name for s in symbols}
+    assert "DataProcessor" in names
+    assert "transform" in names
+    assert "validate" in names
+    # No top-level functions in class-only module
+    funcs = [s for s in symbols if s.kind == "function"]
+    assert len(funcs) == 0
+    methods = [s for s in symbols if s.kind == "method"]
+    assert len(methods) == 2
+
+
+def test_extract_symbols_kind_distribution(simple_module: Path):
+    symbols = extract_symbols(simple_module)
+    kinds = {s.kind for s in symbols}
+    assert "function" in kinds
+    assert "class" in kinds
+    assert "method" in kinds
+
+
+# ---------------------------------------------------------------------------
+# Call graph
+# ---------------------------------------------------------------------------
+
+
+def test_build_call_graph_callees(simple_module: Path):
+    symbols = extract_symbols(simple_module)
+    callees, _callers = build_call_graph(symbols)
+    # Qualified IDs: symbols in temp files have module_path=""
+    greet = "::greet"
+    farewell = "::farewell"
+    add = "::Calculator.add"
+    run_sym = "::run"
+    calc = "::Calculator"
+    unused = "::unused_helper"
+    assert greet in callees.get(farewell, set())
+    assert greet in callees.get(add, set())
+    assert calc in callees.get(run_sym, set())
+    # unused_helper calls nothing
+    assert unused not in callees or not callees[unused]
+
+
+def test_build_call_graph_callers(simple_module: Path):
+    symbols = extract_symbols(simple_module)
+    _callees, callers = build_call_graph(symbols)
+    greet = "::greet"
+    farewell = "::farewell"
+    add = "::Calculator.add"
+    assert farewell in callers.get(greet, set())
+    assert add in callers.get(greet, set())
+    # Calculator also extracts calls from its body scope, so greet may be found there too
+    greet_callers = callers.get(greet, set())
+    assert len(greet_callers) >= 2  # farewell + Calculator.add
+
+
+def test_build_call_graph_no_external_calls(simple_module: Path):
+    """External calls (like 'len', 'print', 'f"..."') should not appear."""
+    symbols = extract_symbols(simple_module)
+    callees, _callers = build_call_graph(symbols)
+    # All callees should be known symbols — now qualified IDs
+    known_qids = {s.qualified_id() for s in symbols}
+    all_callee_ids = set()
+    for targets in callees.values():
+        all_callee_ids.update(targets)
+    for qid in all_callee_ids:
+        assert qid in known_qids, f"Unknown callee {qid} in call graph"
+
+
+def test_build_call_graph_empty():
+    """Empty symbol list produces empty graphs."""
+    callees, callers = build_call_graph([])
+    assert callees == {}
+    assert callers == {}
+
+
+def test_build_call_graph_no_crossrefs(simple_module: Path):
+    """Symbols that neither call nor are called have empty graph entries."""
+    symbols = extract_symbols(simple_module)
+    callees, callers = build_call_graph(symbols)
+    # unused_helper calls nothing
+    unused = callees.get("unused_helper", set())
+    assert len(unused) == 0
+    # greet is called but calls nothing internal
+    greet_callees = callees.get("greet", set())
+    assert len(greet_callees) == 0
+
+
+# ---------------------------------------------------------------------------
+# Blast radius
+# ---------------------------------------------------------------------------
+
+
+def test_module_path():
+    """_module_path converts file paths to dotted module paths.
+
+    ``__init__.py`` files are stripped to their package root so that
+    ``pkg/__init__.py`` maps to ``pkg`` rather than ``pkg.__init__``,
+    matching Python runtime semantics.
+    """
+    assert (
+        _module_path("/home/bob/bob/scripts/codegraph.py", "/home/bob/bob")
+        == "scripts.codegraph"
+    )
+    assert _module_path("scripts/codegraph.py") == "scripts.codegraph"
+    # __init__.py strips to the package root
+    assert (
+        _module_path("packages/context/src/context/__init__.py")
+        == "packages.context.src.context"
+    )
+    # Root __init__.py → empty path (not useful but should not crash)
+    assert _module_path("__init__.py") == ""
+
+
+def test_dependency_closure_basic(simple_module: Path):
+    """dependency_closure walks callees (same as old blast_radius)."""
+    symbols = extract_symbols(simple_module)
+    callees, _callers = build_call_graph(symbols)
+    radius = dependency_closure("greet", callees)
+    assert "depth_0" in radius
+    assert radius["depth_0"] == {"::greet"}
+
+
+def test_impact_radius_basic(simple_module: Path):
+    """impact_radius walks callers."""
+    symbols = extract_symbols(simple_module)
+    _callees, callers = build_call_graph(symbols)
+    radius = impact_radius("greet", callers)
+    assert "depth_0" in radius
+    assert "::greet" in radius["depth_0"]
+    # farewell calls greet, so farewell should be depth_1
+    depths = sorted(radius.keys())
+    if len(depths) > 1:
+        assert "::farewell" in radius[depths[1]]
+
+
+def test_dependency_closure_and_impact_complement(simple_module: Path):
+    """deps and impact should produce symmetric results for callers/callees."""
+    symbols = extract_symbols(simple_module)
+    callees, callers = build_call_graph(symbols)
+    # farewell calls greet
+    deps_farewell = dependency_closure("farewell", callees)
+    impact_greet = impact_radius("greet", callers)
+    depths_deps = sorted(deps_farewell.keys())
+    depths_impact = sorted(impact_greet.keys())
+    # farewell's deps should include greet
+    if len(depths_deps) > 1:
+        assert "::greet" in deps_farewell[depths_deps[1]]
+    # greet's impact should include farewell
+    if len(depths_impact) > 1:
+        assert "::farewell" in impact_greet[depths_impact[1]]
+
+
+# ---------------------------------------------------------------------------
+
+
+def test_blast_radius_basic(simple_module: Path):
+    symbols = extract_symbols(simple_module)
+    callees, _callers = build_call_graph(symbols)
+    radius = blast_radius("greet", callees)
+    assert "depth_0" in radius
+    assert radius["depth_0"] == {"::greet"}
+    # greet calls nothing internal, so depth_1 should be empty
+    assert "depth_1" not in radius or not radius["depth_1"]
+
+
+def test_blast_radius_downstream(simple_module: Path):
+    """farewell calls greet, so greet should appear in farewell's blast radius."""
+    symbols = extract_symbols(simple_module)
+    callees, _callers = build_call_graph(symbols)
+    radius = blast_radius("farewell", callees)
+    assert "depth_0" in radius
+    assert "::farewell" in radius["depth_0"]
+    # farewell calls greet
+    assert "depth_1" in radius or any("::greet" in s for s in radius.values())
+    # The first depth past depth_0 should contain greet
+    depths = sorted(radius.keys())
+    if len(depths) > 1:
+        assert "::greet" in radius[depths[1]]
+
+
+def test_blast_radius_max_depth(simple_module: Path):
+    symbols = extract_symbols(simple_module)
+    callees, _callers = build_call_graph(symbols)
+    radius = blast_radius("greet", callees, max_depth=0)
+    assert "depth_0" in radius
+    assert "depth_1" not in radius
+
+
+def test_blast_radius_unknown_symbol():
+    """Unknown symbol produces no blast."""
+    callees = {"a": {"b"}, "b": {"c"}}
+    radius = blast_radius("unknown", callees)
+    assert "depth_0" in radius
+    assert "unknown" in radius["depth_0"]
+    assert "depth_1" not in radius
+
+
+# ---------------------------------------------------------------------------
+# Formatting
+# ---------------------------------------------------------------------------
+
+
+def test_format_symbols_basic(simple_module: Path):
+    symbols = extract_symbols(simple_module)
+    output = format_symbols(symbols)
+    assert "Functions:" in output
+    assert "greet" in output
+    assert "Calculator" in output
+    assert "Say hello." in output or "say hello" in output.lower()
+
+
+def test_format_symbols_empty():
+    """Empty symbol list prints zero."""
+    output = format_symbols([])
+    assert "Functions: 0" in output
+    assert "Total: 0" in output
+
+
+def test_format_json_basic():
+    """JSON formatter produces valid JSON."""
+    data = {"key": "value", "number": 42}
+    result = format_json(data)
+    parsed = json.loads(result)
+    assert parsed == data
+
+
+# ---------------------------------------------------------------------------
+# CLI edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_cli_parse_json(simple_module: Path):
+    """The parse subcommand with --json produces valid JSON symbol output."""
+    from gptme_codegraph.core import extract_symbols
+
+    symbols = extract_symbols(simple_module)
+    data = [s.__dict__ if hasattr(s, "__dict__") else vars(s) for s in symbols]
+
+    # Verify each symbol has the expected fields
+    for entry in data:
+        assert "name" in entry
+        assert "kind" in entry
+        assert "start_line" in entry
+        assert "end_line" in entry
+
+
+def test_cli_def_output(simple_module: Path):
+    """Validate the 'def' lookup finds a symbol."""
+    symbols = extract_symbols(simple_module)
+    name_map = {s.name: s for s in symbols}
+
+    greet = name_map.get("greet")
+    assert greet is not None
+    assert greet.kind == "function"
+    assert "Say hello" in (greet.docstring or "")
+
+    calc = name_map.get("Calculator")
+    assert calc is not None
+    assert calc.kind == "class"
+    assert "simple calculator" in (calc.docstring or "").lower()
+
+
+def test_cli_refs_output(simple_module: Path):
+    """Validate the 'refs' lookup finds callers."""
+    symbols = extract_symbols(simple_module)
+    _callees, callers = build_call_graph(symbols)
+
+    # greet is called by farewell and Calculator.add
+    # (qualified IDs: ::farewell, ::Calculator.add)
+    greet_callers = callers.get("::greet", set())
+    assert "::farewell" in greet_callers
+    assert "::Calculator.add" in greet_callers
+    assert len(greet_callers) >= 2  # farewell + Calculator.add
+
+
+def test_coverage_of_self(simple_module: Path):
+    """The codegraph script can analyze itself (meta-test)."""
+    codegraph_path = Path(__file__).resolve().parent.parent / "scripts" / "codegraph.py"
+    if not codegraph_path.exists():
+        pytest.skip("codegraph.py not found for meta-test")
+    symbols = extract_symbols(codegraph_path)
+    assert len(symbols) > 5
+    names = {s.name for s in symbols}
+    assert "main" in names
+    assert "extract_symbols" in names
+    assert "blast_radius" in names or "dependency_closure" in names
+    assert "build_call_graph" in names
+
+
+# ---------------------------------------------------------------------------
+# Cross-file index
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def multi_file_project(tmp_path: Path) -> Path:
+    """Create a small multi-file project for cross-file resolution tests."""
+    root = tmp_path / "project"
+    root.mkdir()
+
+    # utils.py — utility functions
+    (root / "utils.py").write_text("""
+def format_name(name: str) -> str:
+    \"\"\"Format a name.\"\"\"
+    return name.strip().title()
+
+
+def parse_count(raw: str) -> int:
+    \"\"\"Parse a count string.\"\"\"
+    return int(raw.strip())
+""")
+
+    # models.py — data classes
+    (root / "models.py").write_text("""
+class User:
+    \"\"\"A user model.\"\"\"
+    def __init__(self, name: str):
+        self.name = name
+
+    def greet(self) -> str:
+        from utils import format_name
+        return f"Hello, {format_name(self.name)}"
+""")
+
+    # main.py — entry point that calls across modules
+    (root / "main.py").write_text("""
+from utils import format_name, parse_count
+from models import User
+
+
+def run_app(names: list[str]) -> list[str]:
+    \"\"\"Run the app.\"\"\"
+    results = []
+    for name in names:
+        user = User(name)
+        results.append(user.greet())
+    return results
+
+
+def count_items(raw: str) -> int:
+    \"\"\"Count comma-separated items.\"\"\"
+    count = parse_count(raw)
+    return count
+""")
+
+    return root
+
+
+def test_index_entry():
+    """IndexEntry stores symbol metadata."""
+    entry = IndexEntry(
+        name="greet",
+        kind="function",
+        file="utils.py",
+        start_line=1,
+        end_line=5,
+    )
+    assert entry.name == "greet"
+    assert entry.kind == "function"
+    assert entry.parent_class is None
+
+
+def test_symbol_index_empty():
+    """Empty index returns nothing."""
+    index = SymbolIndex()
+    assert not index.has("greet")
+    assert index.lookup("greet") == []
+    assert index.all_names() == []
+
+
+def test_symbol_index_lookup():
+    """Index can store and retrieve entries."""
+    index = SymbolIndex()
+    index.entries["greet"] = [
+        IndexEntry(
+            name="greet",
+            kind="function",
+            file="a.py",
+            start_line=1,
+            end_line=5,
+        ),
+    ]
+    assert index.has("greet")
+    results = index.lookup("greet")
+    assert len(results) == 1
+    assert results[0].file == "a.py"
+
+
+def test_symbol_index_multi_file():
+    """Index can track same symbol across files."""
+    index = SymbolIndex()
+    index.entries["Config"] = [
+        IndexEntry(name="Config", kind="class", file="a.py", start_line=1, end_line=10),
+        IndexEntry(name="Config", kind="class", file="b.py", start_line=1, end_line=8),
+    ]
+    assert len(index.lookup("Config")) == 2
+    assert index.has("Config")
+
+
+def test_build_index_empty_directory(tmp_path: Path):
+    """build_index on empty dir returns empty index."""
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+    index = build_index(empty_dir)
+    assert index.all_names() == []
+
+
+def test_build_index_skips_noise(tmp_path: Path):
+    """build_index skips .venv, __pycache__, etc."""
+    root = tmp_path / "project"
+    root.mkdir()
+    (root / "real.py").write_text("def foo(): pass")
+    (root / ".venv").mkdir()
+    (root / ".venv" / "lib.py").write_text("def injected(): pass")
+    (root / "__pycache__").mkdir()
+    (root / "__pycache__" / "cached.py").write_text("def cached(): pass")
+
+    index = build_index(root)
+    assert index.has("foo")
+    assert not index.has("injected")
+    assert not index.has("cached")
+
+
+def test_build_index_multi_file(multi_file_project: Path):
+    """build_index captures symbols across multiple files."""
+    index = build_index(multi_file_project)
+    assert index.has("format_name")
+    assert index.has("parse_count")
+    assert index.has("User")
+    assert index.has("run_app")
+    assert index.has("count_items")
+
+
+def test_build_index_symbol_locations(multi_file_project: Path):
+    """Index entries have correct file paths."""
+    index = build_index(multi_file_project)
+    format_name_entries = index.lookup("format_name")
+    assert len(format_name_entries) == 1
+    assert "utils.py" in format_name_entries[0].file
+
+    user_entries = index.lookup("User")
+    assert len(user_entries) == 1
+    assert "models.py" in user_entries[0].file
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_symbol_dataclass_defaults():
+    """Symbol dataclass has correct defaults."""
+    sym = Symbol(name="test", kind="function", file="test.py", start_line=1, end_line=5)
+    assert sym.parent_class is None
+    assert sym.calls == []
+    assert sym.docstring is None
+
+
+def test_symbol_dataclass_with_all_fields():
+    """Symbol dataclass with all fields set."""
+    sym = Symbol(
+        name="test",
+        kind="method",
+        file="test.py",
+        start_line=1,
+        end_line=5,
+        parent_class="Foo",
+        calls=["helper"],
+        docstring="Does something.",
+    )
+    assert sym.parent_class == "Foo"
+    assert sym.calls == ["helper"]
+    assert sym.docstring == "Does something."
+
+
+def test_nonexistent_file():
+    """Non-existent file raises FileNotFoundError."""
+    path = Path("/nonexistent/test_codegraph_nonexistent.py")
+    with pytest.raises((FileNotFoundError, OSError)):
+        extract_symbols(path)
+
+
+# ---------------------------------------------------------------------------
+# Import extraction
+# ---------------------------------------------------------------------------
+
+
+def test_extract_imports_basic():
+    """_extract_imports finds simple imports."""
+    code = b"import os\nfrom sys import path\n"
+    root, _ = _tree_sitter_parse(code)
+    assert root is not None
+    imports = _extract_imports(root)
+    names = {imp.name for imp in imports}
+    assert "os" in names
+    assert "path" in names
+
+
+def test_extract_imports_alias():
+    """_extract_imports handles aliased imports.
+
+    ``name`` carries the original imported symbol; ``alias`` is the local
+    binding visible inside the file.
+    """
+    code = b"from os import path as p\n"
+    root, _ = _tree_sitter_parse(code)
+    assert root is not None
+    imports = _extract_imports(root)
+    assert len(imports) == 1
+    assert imports[0].name == "path"
+    assert imports[0].alias == "p"
+    assert imports[0].module == "os"
+
+
+def test_parse_file_returns_imports(tmp_path: Path):
+    """parse_file returns both symbols and imports."""
+    f = tmp_path / "test.py"
+    f.write_text("import json\ndef helper(): pass\n")
+    result = parse_file(f)
+    assert len(result.symbols) == 1
+    assert result.symbols[0].name == "helper"
+    assert len(result.imports) == 1
+    assert result.imports[0].name == "json"
+
+
+# ---------------------------------------------------------------------------
+# Cross-file call graph
+# ---------------------------------------------------------------------------
+
+
+def test_cross_file_call_graph_resolves_imports(tmp_path: Path):
+    """build_cross_file_call_graph resolves calls through imports."""
+    # module_a.py: defines greet()
+    (tmp_path / "module_a.py").write_text("def greet(): pass\n")
+    # module_b.py: imports and calls greet()
+    (tmp_path / "module_b.py").write_text(
+        "from module_a import greet\ndef main(): greet()\n"
+    )
+
+    index = build_index(tmp_path)
+    callees, callers = build_cross_file_call_graph(index, tmp_path)
+
+    # Graph keys are qualified IDs (module_a::greet, module_b::main)
+    # main() calls greet()
+    assert "module_a::greet" in callees.get("module_b::main", set())
+    # greet() is called by main()
+    assert "module_b::main" in callers.get("module_a::greet", set())
+
+
+def test_cross_file_call_graph_module_prefix(tmp_path: Path):
+    """build_cross_file_call_graph resolves module-prefixed calls."""
+    (tmp_path / "calc.py").write_text("def add(a, b): return a + b\n")
+    (tmp_path / "main.py").write_text("import calc\ndef run(): calc.add(1, 2)\n")
+
+    index = build_index(tmp_path)
+    callees, callers = build_cross_file_call_graph(index, tmp_path)
+
+    assert "calc::add" in callees.get("main::run", set())
+    assert "main::run" in callers.get("calc::add", set())
+
+
+def test_cross_file_call_graph_import_as_alias(tmp_path: Path):
+    """build_cross_file_call_graph resolves calls through aliased imports.
+
+    ``import calc as c`` then ``c.add()`` should resolve to ``calc::add``.
+    """
+    (tmp_path / "calc.py").write_text("def add(a, b): return a + b\n")
+    (tmp_path / "main.py").write_text("import calc as c\ndef run(): c.add(1, 2)\n")
+
+    index = build_index(tmp_path)
+    callees, callers = build_cross_file_call_graph(index, tmp_path)
+
+    assert "calc::add" in callees.get("main::run", set())
+    assert "main::run" in callers.get("calc::add", set())
+
+
+def test_cross_file_call_graph_from_import_as_alias(tmp_path: Path):
+    """build_cross_file_call_graph resolves from-import-as calls.
+
+    ``from calc import add as a`` then ``a()`` should resolve to ``calc::add``.
+    """
+    (tmp_path / "calc.py").write_text("def add(a, b): return a + b\n")
+    (tmp_path / "main.py").write_text("from calc import add as a\ndef run(): a(1, 2)\n")
+
+    index = build_index(tmp_path)
+    callees, callers = build_cross_file_call_graph(index, tmp_path)
+
+    assert "calc::add" in callees.get("main::run", set())
+    assert "main::run" in callers.get("calc::add", set())
+
+
+def test_cross_file_call_graph_ignores_unresolved(tmp_path: Path):
+    """build_cross_file_call_graph ignores calls that can't be resolved."""
+    (tmp_path / "main.py").write_text("def run(): print('hello')\n")
+
+    index = build_index(tmp_path)
+    callees, callers = build_cross_file_call_graph(index, tmp_path)
+
+    # print is not in the index, so it shouldn't appear in callees
+    assert "main::run" in callees
+    assert "print" not in str(callees)  # no unresolved calls
+
+
+def test_build_index_collects_imports(tmp_path: Path):
+    """build_index stores imports in the SymbolIndex."""
+    (tmp_path / "main.py").write_text("import os\nfrom sys import path\n")
+
+    index = build_index(tmp_path)
+    imports = index.file_imports(str(tmp_path / "main.py"))
+    names = {imp.name for imp in imports}
+    assert "os" in names
+    assert "path" in names

--- a/packages/gptme-codegraph/tests/test_codegraph_imports.py
+++ b/packages/gptme-codegraph/tests/test_codegraph_imports.py
@@ -1,0 +1,237 @@
+"""Tests for codegraph import alias and relative-import resolution.
+
+These tests probe the documented sharp edges from
+knowledge/research/2026-05-03-codegraph-productization-roadmap.md item #4.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from gptme_codegraph.core import (
+    _extract_imports,
+    _tree_sitter_parse,
+    build_cross_file_call_graph,
+    build_index,
+)
+
+# ---------------------------------------------------------------------------
+# Alias scenarios
+# ---------------------------------------------------------------------------
+
+
+def test_module_alias_resolves_dotted_call(tmp_path: Path):
+    """`import calc as c; c.add()` should link `add` to its caller.
+
+    Demonstrates whether `_resolve_imported_symbol` honors module aliases for
+    dotted calls. Today this is a documented sharp edge.
+    """
+    (tmp_path / "calc.py").write_text("def add(a, b): return a + b\n")
+    (tmp_path / "main.py").write_text("import calc as c\ndef run(): c.add(1, 2)\n")
+
+    index = build_index(tmp_path)
+    callees, callers = build_cross_file_call_graph(index, tmp_path)
+
+    # Graph keys are qualified IDs (calc::add, main::run)
+    assert (
+        "calc::add" in callees.get("main::run", set())
+    ), f"Expected `run` to call `add` via aliased module import; got {callees.get('main::run')}"
+    assert "main::run" in callers.get("calc::add", set())
+
+
+def test_from_import_alias_resolves_call(tmp_path: Path):
+    """`from utils import add as a; a()` should link `add` to its caller."""
+    (tmp_path / "utils.py").write_text("def add(): return 1\n")
+    (tmp_path / "main.py").write_text("from utils import add as a\ndef run(): a()\n")
+
+    index = build_index(tmp_path)
+    callees, callers = build_cross_file_call_graph(index, tmp_path)
+
+    assert (
+        "utils::add" in callees.get("main::run", set())
+    ), f"Expected `run` to call `add` via from-import alias; got {callees.get('main::run')}"
+    assert "main::run" in callers.get("utils::add", set())
+
+
+def test_dotted_module_alias(tmp_path: Path):
+    """`import os.path as op` records the original module name + alias.
+
+    Under the new ``ImportInfo`` semantics, ``name`` carries the original
+    imported identifier (``os.path``) and ``alias`` carries the local binding
+    (``op``).
+    """
+    code = b"import os.path as op\n"
+    root, _ = _tree_sitter_parse(code)
+    assert root is not None
+    imports = _extract_imports(root)
+    assert any(i.name == "os.path" and i.alias == "op" for i in imports), (
+        f"Expected aliased dotted import; got "
+        f"{[(i.name, i.module, i.alias) for i in imports]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Relative imports
+# ---------------------------------------------------------------------------
+
+
+def test_relative_import_extracted(tmp_path: Path):
+    """`from .utils import add` should be extracted, not silently dropped."""
+    code = b"from .utils import add\n"
+    root, _ = _tree_sitter_parse(code)
+    assert root is not None
+    imports = _extract_imports(root)
+    # We don't yet require absolute resolution — just that the import is captured.
+    names = [imp.name for imp in imports]
+    assert (
+        "add" in names
+    ), f"Expected `add` to be extracted from relative import; got {names}"
+
+
+def test_relative_import_resolves_within_package(tmp_path: Path):
+    """`from .utils import add` should link calls when both files are indexed.
+
+    Even without a __init__.py, the package directory is the indexed root, so
+    sibling files are discoverable. This is the common monorepo case.
+    """
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "utils.py").write_text("def add(): return 1\n")
+    (pkg / "main.py").write_text("from .utils import add\ndef run(): add()\n")
+
+    index = build_index(pkg)
+    callees, callers = build_cross_file_call_graph(index, pkg)
+
+    # Graph keys are qualified IDs (main::run, utils::add) — module_path is
+    # relative to the indexed directory (pkg/), so files at the root get
+    # bare module paths: main.py → main, utils.py → utils.
+    assert (
+        "utils::add" in callees.get("main::run", set())
+    ), f"Expected `run` to call `add` via relative import; got {callees.get('main::run')}"
+
+
+# ---------------------------------------------------------------------------
+# Wildcard / star imports
+# ---------------------------------------------------------------------------
+
+
+def test_wildcard_import_extracted():
+    """`from math import *` should be captured, not silently dropped."""
+    code = b"from math import *\n"
+    root, _ = _tree_sitter_parse(code)
+    assert root is not None
+    imports = _extract_imports(root)
+    names = [(imp.name, imp.module) for imp in imports]
+    assert (
+        "*",
+        "math",
+    ) in names, f"Expected ('*', 'math') from wildcard import; got {names}"
+
+
+# ---------------------------------------------------------------------------
+# Namespace-package / __init__.py scenarios
+# ---------------------------------------------------------------------------
+
+
+def test_init_py_module_path_strips_init(tmp_path: Path):
+    """Symbols in ``__init__.py`` get the package module path, not a ``.__init__`` suffix.
+
+    When indexed from the parent directory, ``pkg/__init__.py`` → ``pkg``.
+    When indexed from the package dir itself, it's the root (``""``).
+    """
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("def api_func(): pass\n")
+
+    # Index from parent: module_path includes the package name
+    index = build_index(tmp_path)
+    assert index.has("api_func")
+    entries = index.lookup("api_func")
+    assert len(entries) == 1
+    assert entries[0].module_path == "pkg", (
+        f"Expected module_path 'pkg' for symbol in pkg/__init__.py "
+        f"indexed from parent; got {entries[0].module_path!r}"
+    )
+
+    # Index from package dir itself: module_path is the root
+    index2 = build_index(pkg)
+    entries2 = index2.lookup("api_func")
+    assert entries2[0].module_path == "", (
+        f"Expected empty module_path for package-root __init__.py; "
+        f"got {entries2[0].module_path!r}"
+    )
+
+
+def test_namespace_package_cross_file_resolution(tmp_path: Path):
+    """Cross-file resolution works through __init__.py re-exports.
+
+    Simulates::
+
+        pkg/
+          __init__.py   # from .utils import add
+          utils.py       # def add(): ...
+          main.py        # import pkg; pkg.add()
+
+    ``main::run`` calls ``add`` through the pkg namespace. The call graph
+    should resolve ``add`` to ``pkg::add`` (from __init__.py), which in
+    turn calls nothing because it's a re-export.
+    """
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("from .utils import add\n")
+    (pkg / "utils.py").write_text("def add(): return 1\n")
+    (pkg / "main.py").write_text("import pkg\ndef run(): pkg.add()\n")
+
+    index = build_index(pkg)
+    callees, callers = build_cross_file_call_graph(index, pkg)
+
+    # ``pkg::add`` should be resolvable (via __init__.py import)
+    assert "pkg::add" in callees or "main::run" in callees, (
+        f"Expected callee graph to include symbols from __init__.py; "
+        f"got callees keys: {sorted(callees.keys())}"
+    )
+
+
+def test_subpackage_init_py_module_path(tmp_path: Path):
+    """Deeply nested __init__.py gets correct module path: a.b.c not a.b.c.__init__."""
+    a = tmp_path / "a"
+    a.mkdir()
+    b = a / "b"
+    b.mkdir()
+    c = b / "c"
+    c.mkdir()
+    (c / "__init__.py").write_text("def deep_func(): pass\n")
+
+    index = build_index(tmp_path)
+
+    # Verify the module path for a function in __init__.py
+    entries = index.lookup("deep_func")
+    assert len(entries) == 1
+    assert (
+        entries[0].module_path == "a.b.c"
+    ), f"Expected 'a.b.c' for nested __init__.py; got {entries[0].module_path!r}"
+
+
+def test_namespace_package_without_top_init(tmp_path: Path):
+    """Index works when directory has no __init__.py at any level (PEP 420)."""
+    ns = tmp_path / "ns"
+    ns.mkdir()
+    pkg = ns / "pkg"
+    pkg.mkdir()
+    sub = pkg / "sub"
+    sub.mkdir()
+    # No __init__.py files — pure PEP 420 namespace packages
+    (sub / "mod.py").write_text("def func(): return 42\n")
+    (ns / "main.py").write_text("from pkg.sub.mod import func\ndef run(): func()\n")
+
+    index = build_index(ns)
+    callees, callers = build_cross_file_call_graph(index, ns)
+
+    assert (
+        "main::run" in callees
+    ), f"Expected 'main::run' in callees; got {sorted(callees.keys())}"
+    assert "pkg.sub.mod::func" in callees.get("main::run", set()), (
+        f"Expected run→func via cross-file resolution in namespace package; "
+        f"got {callees.get('main::run', set())}"
+    )

--- a/packages/gptme-codegraph/tests/test_codegraph_mcp_server.py
+++ b/packages/gptme-codegraph/tests/test_codegraph_mcp_server.py
@@ -1,0 +1,470 @@
+"""Tests for codegraph MCP server.
+
+Tests use a shared module fixture that builds a temporary directory with
+Python source files to test both single-file and cross-file tools.
+"""
+
+import json
+import tempfile
+from collections.abc import Generator
+from pathlib import Path
+
+import gptme_codegraph.mcp_server as _MOD
+import pytest
+
+
+def _content(response) -> str:
+    """Extract text content from MCP tool response.
+    Handles both CallToolResult (with .content) and tuple (content, metadata) formats.
+    """
+    # MCP returns tuple (list_of_content_items, metadata_dict) in some versions
+    if isinstance(response, tuple):
+        content_list = response[0]
+    else:
+        content_list = response.content
+
+    parts = []
+    for content_item in content_list:
+        if hasattr(content_item, "text"):
+            parts.append(content_item.text)
+        elif isinstance(content_item, dict) and "text" in content_item:
+            parts.append(content_item["text"])
+    return "\n".join(parts)
+
+
+def _run(coro):
+    """Run an async coroutine synchronously."""
+    import asyncio
+
+    return asyncio.run(coro)
+
+
+# -------------------------------------------------------------------------
+# Fixtures
+# -------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def sample_dir() -> Generator[str, None, None]:
+    """Create a temporary directory with a small Python module for testing."""
+    with tempfile.TemporaryDirectory(prefix="codegraph_test_") as tmp:
+        # Module a: defines add and helper
+        (Path(tmp) / "a.py").write_text(
+            "def add(x, y):\n"
+            "    return x + y\n"
+            "\n"
+            "def helper(msg):\n"
+            "    return f'help: {msg}'\n"
+        )
+        # Module b: defines compute that calls add from a
+        (Path(tmp) / "b.py").write_text(
+            "from a import add\n"
+            "\n"
+            "def compute(items):\n"
+            "    return [add(i, 1) for i in items]\n"
+        )
+        # Module c: defines run that calls compute from b
+        (Path(tmp) / "c.py").write_text(
+            "from b import compute\n\ndef run():\n    return compute([1, 2, 3])\n"
+        )
+        yield tmp
+
+
+@pytest.fixture(scope="session")
+def sample_file(sample_dir) -> str:
+    """Return path to a.py in the sample directory."""
+    return str(Path(sample_dir) / "a.py")
+
+
+# -------------------------------------------------------------------------
+# Tool registration
+# -------------------------------------------------------------------------
+
+
+def test_tools_registered():
+    """Verify the 8 expected MCP tools are registered.
+    Cross-file tools collapsed into optional filepath parameter."""
+
+    async def _check():
+        tools = await _MOD.mcp.list_tools()
+        return {t.name for t in tools}
+
+    names = _run(_check())
+    expected = {
+        "codegraph_parse",
+        "codegraph_index",
+        "codegraph_def",
+        "codegraph_callers",
+        "codegraph_callees",
+        "codegraph_refs",
+        "codegraph_blast",
+        "codegraph_impact",
+    }
+    assert names == expected
+
+
+# -------------------------------------------------------------------------
+# Single-file tools
+# -------------------------------------------------------------------------
+
+
+def test_parse(sample_file):
+    """Test codegraph_parse extracts symbols."""
+
+    async def _check():
+        r = await _MOD.mcp.call_tool("codegraph_parse", {"filepath": sample_file})
+        return json.loads(_content(r))
+
+    d = _run(_check())
+    assert "error" not in d
+    assert d["file"] == sample_file
+    assert len(d["symbols"]) >= 2  # add, helper
+
+
+def test_index(sample_dir):
+    """Test codegraph_index builds index for a directory."""
+
+    async def _check():
+        r = await _MOD.mcp.call_tool("codegraph_index", {"directory": sample_dir})
+        return json.loads(_content(r))
+
+    d = _run(_check())
+    assert "error" not in d
+    assert d.get("files_indexed", 0) >= 3
+    assert d.get("unique_symbols", 0) >= 4
+
+
+def test_def(sample_file):
+    """Test codegraph_def finds symbol definition."""
+
+    async def _check():
+        r = await _MOD.mcp.call_tool(
+            "codegraph_def", {"name": "add", "filepath": sample_file}
+        )
+        return json.loads(_content(r))
+
+    d = _run(_check())
+    assert d["found"]
+
+
+def test_def_missing(sample_file):
+    """Test codegraph_def returns not-found for nonexistent symbol."""
+
+    async def _check():
+        r = await _MOD.mcp.call_tool(
+            "codegraph_def",
+            {"name": "nonexistent", "filepath": sample_file},
+        )
+        return json.loads(_content(r))
+
+    d = _run(_check())
+    assert not d["found"]
+
+
+def test_def_cross_file(sample_dir):
+    """Test codegraph_def resolves symbol across files via directory."""
+
+    async def _check():
+        r = await _MOD.mcp.call_tool(
+            "codegraph_def",
+            {"name": "add", "filepath": None, "directory": sample_dir},
+        )
+        return json.loads(_content(r))
+
+    d = _run(_check())
+    assert d["found"]
+    # codegraph_def returns definitions_count (int) when using cross-file index
+    defs = d.get("definitions") or d.get("definitions_count", 0)
+    if isinstance(defs, list | tuple):
+        assert len(defs) >= 1
+    else:
+        assert defs >= 1
+
+
+def test_callers(sample_file):
+    """Test codegraph_callers finds callers of a symbol."""
+
+    async def _check():
+        r = await _MOD.mcp.call_tool(
+            "codegraph_callers", {"name": "helper", "filepath": sample_file}
+        )
+        return json.loads(_content(r))
+
+    d = _run(_check())
+    assert "error" not in d
+    assert "callers" in d
+
+
+def test_callees(sample_file):
+    """Test codegraph_callees finds callees of a symbol."""
+
+    async def _check():
+        r = await _MOD.mcp.call_tool(
+            "codegraph_callees", {"name": "add", "filepath": sample_file}
+        )
+        return json.loads(_content(r))
+
+    d = _run(_check())
+    assert "error" not in d
+    assert "callees" in d
+
+
+def test_blast(sample_file):
+    """Test codegraph_blast computes blast radius."""
+
+    async def _check():
+        r = await _MOD.mcp.call_tool(
+            "codegraph_blast", {"name": "add", "filepath": sample_file}
+        )
+        return json.loads(_content(r))
+
+    d = _run(_check())
+    assert "error" not in d
+    assert "total_affected" in d
+
+
+def test_blast_missing_symbol(sample_file):
+    """Test codegraph_blast returns error for missing symbol."""
+
+    async def _check():
+        r = await _MOD.mcp.call_tool(
+            "codegraph_blast",
+            {"name": "nonexistent", "filepath": sample_file},
+        )
+        return json.loads(_content(r))
+
+    d = _run(_check())
+    assert "error" in d
+
+
+def test_impact(sample_file):
+    """codegraph_impact should report symbols that call the target.
+
+    In a.py: add() is called by nothing within a.py (it's only called from
+    b.py). helper() is the function that's called externally. So impact
+    of helper should show callers within a.py (if any).
+    """
+
+    async def _check():
+        r = await _MOD.mcp.call_tool(
+            "codegraph_impact", {"name": "helper", "filepath": sample_file}
+        )
+        return json.loads(_content(r))
+
+    d = _run(_check())
+    assert "error" not in d
+    assert "total_affected" in d
+
+
+def test_impact_differs_from_blast(sample_file):
+    """codegraph_impact (callers) and codegraph_blast (callees) must differ.
+
+    In a.py, helper() has no internal callees but may have internal callers.
+    For helper, both impact and blast report depth_0=self, so total_affected
+    may be 1 for both. Check they differ OR that helper is not a no-op.
+    """
+
+    async def _check():
+        r1 = await _MOD.mcp.call_tool(
+            "codegraph_impact", {"name": "helper", "filepath": sample_file}
+        )
+        r2 = await _MOD.mcp.call_tool(
+            "codegraph_blast", {"name": "helper", "filepath": sample_file}
+        )
+        return json.loads(_content(r1)), json.loads(_content(r2))
+
+    impact_d, blast_d = _run(_check())
+    # helper is a leaf function: no callees, no internal callers
+    # Both report depth_0=[helper] with total_affected=1
+    assert blast_d["total_affected"] >= 1
+    # Verify callees is empty (no depth_1+) for a leaf function
+    assert all(k.startswith("depth_") for k in blast_d["depth_breakdown"])
+
+
+def test_impact_missing_symbol(sample_file):
+    """codegraph_impact returns error for unknown symbol."""
+
+    async def _check():
+        r = await _MOD.mcp.call_tool(
+            "codegraph_impact",
+            {"name": "nonexistent", "filepath": sample_file},
+        )
+        return json.loads(_content(r))
+
+    d = _run(_check())
+    assert "error" in d
+
+
+# -------------------------------------------------------------------------
+# Cross-file tools (via optional filepath parameter)
+# -------------------------------------------------------------------------
+
+
+def test_cross_file_impact(sample_dir):
+    """codegraph_impact with filepath=None, directory=... resolves cross-file.
+
+    The fixture exposes `add` (defined in module `a`, called from `compute`
+    in module `b`). The cross-file impact of `add` must include `compute`.
+    """
+
+    async def _check():
+        r = await _MOD.mcp.call_tool(
+            "codegraph_impact",
+            {"name": "add", "filepath": None, "directory": sample_dir, "max_depth": 3},
+        )
+        return json.loads(_content(r))
+
+    d = _run(_check())
+    assert "error" not in d
+    assert d["symbol"] == "add"
+    assert d["total_affected"] >= 1
+    assert "depth_0" in d["depth_breakdown"]
+    assert "add" in d["depth_breakdown"]["depth_0"]
+
+
+def test_cross_file_impact_missing_symbol(sample_dir):
+    """codegraph_impact (cross-file mode) returns error for unknown symbol."""
+
+    async def _check():
+        r = await _MOD.mcp.call_tool(
+            "codegraph_impact",
+            {"name": "nonexistent_func", "filepath": None, "directory": sample_dir},
+        )
+        return json.loads(_content(r))
+
+    d = _run(_check())
+    assert "error" in d
+
+
+def test_refs_equals_callers(sample_file):
+    """Test codegraph_refs returns same result as codegraph_callers."""
+
+    async def _check():
+        r1 = await _MOD.mcp.call_tool(
+            "codegraph_refs", {"name": "helper", "filepath": sample_file}
+        )
+        r2 = await _MOD.mcp.call_tool(
+            "codegraph_callers", {"name": "helper", "filepath": sample_file}
+        )
+        return _content(r1), _content(r2)
+
+    r1, r2 = _run(_check())
+    assert json.loads(r1) == json.loads(r2)
+
+
+def test_nonexistent_file(sample_file):
+    """All tools return error for nonexistent file path."""
+
+    async def _check():
+        r = await _MOD.mcp.call_tool(
+            "codegraph_parse", {"filepath": "/nonexistent/file.py"}
+        )
+        return json.loads(_content(r))
+
+    d = _run(_check())
+    assert "error" in d
+
+
+def test_nonexistent_directory():
+    """Tools with directory return error for nonexistent directory."""
+
+    async def _check():
+        r = await _MOD.mcp.call_tool(
+            "codegraph_index", {"directory": "/nonexistent/dir"}
+        )
+        return json.loads(_content(r))
+
+    d = _run(_check())
+    assert "error" in d
+
+
+def test_error_on_no_filepath(sample_dir):
+    """Tools that require filepath or directory error when both are missing."""
+
+    async def _check():
+        r = await _MOD.mcp.call_tool("codegraph_callers", {"name": "add"})
+        return json.loads(_content(r))
+
+    d = _run(_check())
+    assert "error" in d
+
+
+def test_cross_file_callers(sample_dir):
+    """codegraph_callers with filepath=None resolves cross-file callers."""
+
+    async def _check():
+        r = await _MOD.mcp.call_tool(
+            "codegraph_callers",
+            {"name": "add", "filepath": None, "directory": sample_dir},
+        )
+        return json.loads(_content(r))
+
+    d = _run(_check())
+    assert "error" not in d
+    assert d["symbol"] == "add"
+    assert d["caller_count"] >= 1
+
+
+def test_cross_file_callers_missing_symbol(sample_dir):
+    """codegraph_callers (cross-file mode) returns error for unknown symbol."""
+
+    async def _check():
+        r = await _MOD.mcp.call_tool(
+            "codegraph_callers",
+            {"name": "nonexistent_func", "filepath": None, "directory": sample_dir},
+        )
+        return json.loads(_content(r))
+
+    d = _run(_check())
+    assert "error" in d
+
+
+def test_cross_file_callees(sample_dir):
+    """codegraph_callees with filepath=None resolves cross-file callees."""
+
+    async def _check():
+        r = await _MOD.mcp.call_tool(
+            "codegraph_callees",
+            {"name": "run", "filepath": None, "directory": sample_dir},
+        )
+        return json.loads(_content(r))
+
+    d = _run(_check())
+    assert "error" not in d
+    assert d["symbol"] == "run"
+    assert d["callee_count"] >= 1
+
+
+def test_cross_file_blast(sample_dir):
+    """codegraph_blast with filepath=None resolves cross-file blast radius."""
+
+    async def _check():
+        r = await _MOD.mcp.call_tool(
+            "codegraph_blast",
+            {
+                "name": "compute",
+                "filepath": None,
+                "directory": sample_dir,
+                "max_depth": 3,
+            },
+        )
+        return json.loads(_content(r))
+
+    d = _run(_check())
+    assert "error" not in d
+    assert d["symbol"] == "compute"
+    assert d["total_affected"] >= 1
+
+
+def test_cross_file_blast_missing_symbol(sample_dir):
+    """codegraph_blast (cross-file mode) returns error for unknown symbol."""
+
+    async def _check():
+        r = await _MOD.mcp.call_tool(
+            "codegraph_blast",
+            {"name": "nonexistent_func", "filepath": None, "directory": sample_dir},
+        )
+        return json.loads(_content(r))
+
+    d = _run(_check())
+    assert "error" in d

--- a/packages/gptme-codegraph/tests/test_codegraph_sqlite_cache.py
+++ b/packages/gptme-codegraph/tests/test_codegraph_sqlite_cache.py
@@ -1,0 +1,201 @@
+"""Tests for the SQLite-backed index cache in codegraph.
+
+Verifies that SqliteIndexCache saves, loads, detects staleness,
+and falls through to rebuild when files change.
+"""
+
+from pathlib import Path
+
+import pytest
+from gptme_codegraph.core import SqliteIndexCache, build_index
+
+
+@pytest.fixture
+def sample_dir(tmp_path):
+    """Create a minimal multi-file project."""
+    (tmp_path / "utils.py").write_text("""\
+def add(a, b):
+    return a + b
+
+def multiply(a, b):
+    return a * b
+""")
+    (tmp_path / "main.py").write_text("""\
+from utils import add, multiply
+
+def compute(x):
+    return multiply(add(x, 1), 2)
+""")
+    return str(tmp_path)
+
+
+def test_sqlite_save_load_roundtrip(sample_dir):
+    """Test that index saved to SQLite can be loaded back identically."""
+    cache = SqliteIndexCache(sample_dir)
+
+    index = build_index(Path(sample_dir))
+    assert index.has("add")
+    assert index.has("compute")
+    cache.save(index)
+
+    loaded = cache.load()
+    assert loaded is not None
+    assert loaded.has("add")
+    assert loaded.has("compute")
+    assert loaded.has("multiply")
+
+    add_entries = loaded.lookup("add")
+    assert len(add_entries) >= 1
+    assert add_entries[0].kind == "function"
+    assert "utils.py" in add_entries[0].file
+    assert add_entries[0].module_path == "utils"
+    assert add_entries[0].qualified_id() == "utils::add"
+
+    cache.close()
+
+
+def test_sqlite_freshness_detects_mtime_change(sample_dir):
+    """Test that is_fresh returns False after a file is modified."""
+    cache = SqliteIndexCache(sample_dir)
+
+    index = build_index(Path(sample_dir))
+    cache.save(index)
+    assert cache.is_fresh()
+
+    # Modify a file
+    (Path(sample_dir) / "utils.py").write_text("""\
+def add(a, b):
+    return a + b + 1  # modified
+""")
+
+    assert not cache.is_fresh()
+    cache.close()
+
+
+def test_sqlite_freshness_detects_new_file(sample_dir):
+    """Test that is_fresh returns False after a new file is added."""
+    cache = SqliteIndexCache(sample_dir)
+
+    index = build_index(Path(sample_dir))
+    cache.save(index)
+    assert cache.is_fresh()
+
+    (Path(sample_dir) / "new.py").write_text("def new_func(): pass")
+    assert not cache.is_fresh()
+
+    cache.close()
+
+
+def test_sqlite_freshness_detects_deleted_file(sample_dir):
+    """Test that is_fresh returns False after a file is removed."""
+    cache = SqliteIndexCache(sample_dir)
+
+    index = build_index(Path(sample_dir))
+    cache.save(index)
+    assert cache.is_fresh()
+
+    (Path(sample_dir) / "utils.py").unlink()
+    assert not cache.is_fresh()
+
+    cache.close()
+
+
+def test_sqlite_empty_cache_returns_none(tmp_path):
+    """Test that loading from an empty/new cache returns None."""
+    cache = SqliteIndexCache(str(tmp_path))
+    loaded = cache.load()
+    assert loaded is None
+    cache.close()
+
+
+def test_sqlite_autorebuild_on_stale(sample_dir):
+    """Test that load() returns None when stale, forcing rebuild."""
+    cache = SqliteIndexCache(sample_dir)
+
+    index = build_index(Path(sample_dir))
+    cache.save(index)
+    assert cache.is_fresh()
+
+    (Path(sample_dir) / "utils.py").write_text("""\
+def add(a, b):
+    return a + b + 1
+""")
+
+    loaded = cache.load()
+    assert loaded is None
+
+    rebuilt = build_index(Path(sample_dir))
+    cache.save(rebuilt)
+    assert cache.is_fresh()
+
+    cache.close()
+
+
+def test_sqlite_multiple_directories(tmp_path):
+    """Test that indices for different directories don't conflict."""
+    dir_a = tmp_path / "project_a"
+    dir_b = tmp_path / "project_b"
+    dir_a.mkdir()
+    dir_b.mkdir()
+
+    (dir_a / "mod.py").write_text("def alpha(): pass")
+    (dir_b / "mod.py").write_text("def beta(): pass")
+
+    cache_a = SqliteIndexCache(str(dir_a))
+    cache_b = SqliteIndexCache(str(dir_b))
+
+    index_a = build_index(dir_a)
+    index_b = build_index(dir_b)
+
+    cache_a.save(index_a)
+    cache_b.save(index_b)
+
+    loaded_a = cache_a.load()
+    loaded_b = cache_b.load()
+
+    assert loaded_a is not None
+    assert loaded_b is not None
+    assert loaded_a.lookup("alpha")[0].module_path == "mod"
+    assert loaded_a.has("alpha")
+    assert not loaded_a.has("beta")
+    assert loaded_b.has("beta")
+    assert not loaded_b.has("alpha")
+
+    cache_a.close()
+    cache_b.close()
+
+
+def test_sqlite_db_path_unique(tmp_path):
+    """Test that different directories get different db paths."""
+    from gptme_codegraph.core import _db_path
+
+    path_a = _db_path(str(tmp_path / "proj_a"))
+    path_b = _db_path(str(tmp_path / "proj_b"))
+    assert path_a != path_b
+
+
+def test_sqlite_invalidates_on_schema_bump(sample_dir, monkeypatch):
+    """Cache rebuilds when SCHEMA_VERSION moves forward.
+
+    Simulates an upgrade where the data schema changes between codegraph
+    versions. The cache must drop the old entries rather than silently serve
+    stale rows that no longer match the current parser semantics.
+    """
+    cache = SqliteIndexCache(sample_dir)
+    index = build_index(Path(sample_dir))
+    cache.save(index)
+    # Sanity check: data is there.
+    loaded = cache.load()
+    assert loaded is not None and loaded.has("add")
+    cache.close()
+
+    # Simulate a code upgrade that bumped the schema and reopen the cache.
+    bumped = SqliteIndexCache(sample_dir)
+    monkeypatch.setattr(bumped, "SCHEMA_VERSION", SqliteIndexCache.SCHEMA_VERSION + 1)
+    # First call after the bump must observe an empty data store.
+    bumped._init_schema()
+    reloaded = bumped.load()
+    assert reloaded is None or not reloaded.has(
+        "add"
+    ), "Expected cache to be invalidated after SCHEMA_VERSION bump"
+    bumped.close()

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,7 @@ members = [
     "gptme-activity-summary",
     "gptme-attention-tracker",
     "gptme-claude-code",
+    "gptme-codegraph",
     "gptme-consortium",
     "gptme-contrib-lib",
     "gptme-contrib-workspace",
@@ -1304,6 +1305,34 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [{ name = "gptme", git = "https://github.com/gptme/gptme.git?branch=master" }]
+
+[[package]]
+name = "gptme-codegraph"
+version = "0.1.0"
+source = { editable = "packages/gptme-codegraph" }
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+]
+mcp = [
+    { name = "mcp" },
+]
+treesitter = [
+    { name = "tree-sitter" },
+    { name = "tree-sitter-python" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0.0" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
+    { name = "tree-sitter", marker = "extra == 'treesitter'", specifier = ">=0.21.0" },
+    { name = "tree-sitter-python", marker = "extra == 'treesitter'", specifier = ">=0.21.0" },
+]
+provides-extras = ["treesitter", "mcp", "dev"]
 
 [[package]]
 name = "gptme-consortium"
@@ -4937,6 +4966,65 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c4/35/67252acc1b929dc88b6602e8c4a982e64f31e733b804c14bc24b47da35e6/transformers-4.57.6.tar.gz", hash = "sha256:55e44126ece9dc0a291521b7e5492b572e6ef2766338a610b9ab5afbb70689d3", size = 10134912, upload-time = "2026-01-16T10:38:39.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/b8/e484ef633af3887baeeb4b6ad12743363af7cce68ae51e938e00aaa0529d/transformers-4.57.6-py3-none-any.whl", hash = "sha256:4c9e9de11333ddfe5114bc872c9f370509198acf0b87a832a0ab9458e2bd0550", size = 11993498, upload-time = "2026-01-16T10:38:31.289Z" },
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.25.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/7c/0350cfc47faadc0d3cf7d8237a4e34032b3014ddf4a12ded9933e1648b55/tree-sitter-0.25.2.tar.gz", hash = "sha256:fe43c158555da46723b28b52e058ad444195afd1db3ca7720c59a254544e9c20", size = 177961, upload-time = "2025-09-25T17:37:59.751Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/d4/f7ffb855cb039b7568aba4911fbe42e4c39c0e4398387c8e0d8251489992/tree_sitter-0.25.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:72a510931c3c25f134aac2daf4eb4feca99ffe37a35896d7150e50ac3eee06c7", size = 146749, upload-time = "2025-09-25T17:37:16.475Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/58/f8a107f9f89700c0ab2930f1315e63bdedccbb5fd1b10fcbc5ebadd54ac8/tree_sitter-0.25.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:44488e0e78146f87baaa009736886516779253d6d6bac3ef636ede72bc6a8234", size = 137766, upload-time = "2025-09-25T17:37:18.138Z" },
+    { url = "https://files.pythonhosted.org/packages/19/fb/357158d39f01699faea466e8fd5a849f5a30252c68414bddc20357a9ac79/tree_sitter-0.25.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c2f8e7d6b2f8489d4a9885e3adcaef4bc5ff0a275acd990f120e29c4ab3395c5", size = 599809, upload-time = "2025-09-25T17:37:19.169Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a4/68ae301626f2393a62119481cb660eb93504a524fc741a6f1528a4568cf6/tree_sitter-0.25.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:20b570690f87f1da424cd690e51cc56728d21d63f4abd4b326d382a30353acc7", size = 627676, upload-time = "2025-09-25T17:37:20.715Z" },
+    { url = "https://files.pythonhosted.org/packages/69/fe/4c1bef37db5ca8b17ca0b3070f2dff509468a50b3af18f17665adcab42b9/tree_sitter-0.25.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a0ec41b895da717bc218a42a3a7a0bfcfe9a213d7afaa4255353901e0e21f696", size = 624281, upload-time = "2025-09-25T17:37:21.823Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/30/3283cb7fa251cae2a0bf8661658021a789810db3ab1b0569482d4a3671fd/tree_sitter-0.25.2-cp310-cp310-win_amd64.whl", hash = "sha256:7712335855b2307a21ae86efe949c76be36c6068d76df34faa27ce9ee40ff444", size = 127295, upload-time = "2025-09-25T17:37:22.977Z" },
+    { url = "https://files.pythonhosted.org/packages/88/90/ceb05e6de281aebe82b68662890619580d4ffe09283ebd2ceabcf5df7b4a/tree_sitter-0.25.2-cp310-cp310-win_arm64.whl", hash = "sha256:a925364eb7fbb9cdce55a9868f7525a1905af512a559303bd54ef468fd88cb37", size = 113991, upload-time = "2025-09-25T17:37:23.854Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/22/88a1e00b906d26fa8a075dd19c6c3116997cb884bf1b3c023deb065a344d/tree_sitter-0.25.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b8ca72d841215b6573ed0655b3a5cd1133f9b69a6fa561aecad40dca9029d75b", size = 146752, upload-time = "2025-09-25T17:37:24.775Z" },
+    { url = "https://files.pythonhosted.org/packages/57/1c/22cc14f3910017b7a76d7358df5cd315a84fe0c7f6f7b443b49db2e2790d/tree_sitter-0.25.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cc0351cfe5022cec5a77645f647f92a936b38850346ed3f6d6babfbeeeca4d26", size = 137765, upload-time = "2025-09-25T17:37:26.103Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/0c/d0de46ded7d5b34631e0f630d9866dab22d3183195bf0f3b81de406d6622/tree_sitter-0.25.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1799609636c0193e16c38f366bda5af15b1ce476df79ddaae7dd274df9e44266", size = 604643, upload-time = "2025-09-25T17:37:27.398Z" },
+    { url = "https://files.pythonhosted.org/packages/34/38/b735a58c1c2f60a168a678ca27b4c1a9df725d0bf2d1a8a1c571c033111e/tree_sitter-0.25.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3e65ae456ad0d210ee71a89ee112ac7e72e6c2e5aac1b95846ecc7afa68a194c", size = 632229, upload-time = "2025-09-25T17:37:28.463Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f6/cda1e1e6cbff5e28d8433578e2556d7ba0b0209d95a796128155b97e7693/tree_sitter-0.25.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:49ee3c348caa459244ec437ccc7ff3831f35977d143f65311572b8ba0a5f265f", size = 629861, upload-time = "2025-09-25T17:37:29.593Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/19/427e5943b276a0dd74c2a1f1d7a7393443f13d1ee47dedb3f8127903c080/tree_sitter-0.25.2-cp311-cp311-win_amd64.whl", hash = "sha256:56ac6602c7d09c2c507c55e58dc7026b8988e0475bd0002f8a386cce5e8e8adc", size = 127304, upload-time = "2025-09-25T17:37:30.549Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d9/eef856dc15f784d85d1397a17f3ee0f82df7778efce9e1961203abfe376a/tree_sitter-0.25.2-cp311-cp311-win_arm64.whl", hash = "sha256:b3d11a3a3ac89bb8a2543d75597f905a9926f9c806f40fcca8242922d1cc6ad5", size = 113990, upload-time = "2025-09-25T17:37:31.852Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/9e/20c2a00a862f1c2897a436b17edb774e831b22218083b459d0d081c9db33/tree_sitter-0.25.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ddabfff809ffc983fc9963455ba1cecc90295803e06e140a4c83e94c1fa3d960", size = 146941, upload-time = "2025-09-25T17:37:34.813Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/04/8512e2062e652a1016e840ce36ba1cc33258b0dcc4e500d8089b4054afec/tree_sitter-0.25.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c0c0ab5f94938a23fe81928a21cc0fac44143133ccc4eb7eeb1b92f84748331c", size = 137699, upload-time = "2025-09-25T17:37:36.349Z" },
+    { url = "https://files.pythonhosted.org/packages/47/8a/d48c0414db19307b0fb3bb10d76a3a0cbe275bb293f145ee7fba2abd668e/tree_sitter-0.25.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd12d80d91d4114ca097626eb82714618dcdfacd6a5e0955216c6485c350ef99", size = 607125, upload-time = "2025-09-25T17:37:37.725Z" },
+    { url = "https://files.pythonhosted.org/packages/39/d1/b95f545e9fc5001b8a78636ef942a4e4e536580caa6a99e73dd0a02e87aa/tree_sitter-0.25.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b43a9e4c89d4d0839de27cd4d6902d33396de700e9ff4c5ab7631f277a85ead9", size = 635418, upload-time = "2025-09-25T17:37:38.922Z" },
+    { url = "https://files.pythonhosted.org/packages/de/4d/b734bde3fb6f3513a010fa91f1f2875442cdc0382d6a949005cd84563d8f/tree_sitter-0.25.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fbb1706407c0e451c4f8cc016fec27d72d4b211fdd3173320b1ada7a6c74c3ac", size = 631250, upload-time = "2025-09-25T17:37:40.039Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f2/5f654994f36d10c64d50a192239599fcae46677491c8dd53e7579c35a3e3/tree_sitter-0.25.2-cp312-cp312-win_amd64.whl", hash = "sha256:6d0302550bbe4620a5dc7649517c4409d74ef18558276ce758419cf09e578897", size = 127156, upload-time = "2025-09-25T17:37:41.132Z" },
+    { url = "https://files.pythonhosted.org/packages/67/23/148c468d410efcf0a9535272d81c258d840c27b34781d625f1f627e2e27d/tree_sitter-0.25.2-cp312-cp312-win_arm64.whl", hash = "sha256:0c8b6682cac77e37cfe5cf7ec388844957f48b7bd8d6321d0ca2d852994e10d5", size = 113984, upload-time = "2025-09-25T17:37:42.074Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/67/67492014ce32729b63d7ef318a19f9cfedd855d677de5773476caf771e96/tree_sitter-0.25.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0628671f0de69bb279558ef6b640bcfc97864fe0026d840f872728a86cd6b6cd", size = 146926, upload-time = "2025-09-25T17:37:43.041Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/9c/a278b15e6b263e86c5e301c82a60923fa7c59d44f78d7a110a89a413e640/tree_sitter-0.25.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f5ddcd3e291a749b62521f71fc953f66f5fd9743973fd6dd962b092773569601", size = 137712, upload-time = "2025-09-25T17:37:44.039Z" },
+    { url = "https://files.pythonhosted.org/packages/54/9a/423bba15d2bf6473ba67846ba5244b988cd97a4b1ea2b146822162256794/tree_sitter-0.25.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd88fbb0f6c3a0f28f0a68d72df88e9755cf5215bae146f5a1bdc8362b772053", size = 607873, upload-time = "2025-09-25T17:37:45.477Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/4c/b430d2cb43f8badfb3a3fa9d6cd7c8247698187b5674008c9d67b2a90c8e/tree_sitter-0.25.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b878e296e63661c8e124177cc3084b041ba3f5936b43076d57c487822426f614", size = 636313, upload-time = "2025-09-25T17:37:46.68Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/27/5f97098dbba807331d666a0997662e82d066e84b17d92efab575d283822f/tree_sitter-0.25.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d77605e0d353ba3fe5627e5490f0fbfe44141bafa4478d88ef7954a61a848dae", size = 631370, upload-time = "2025-09-25T17:37:47.993Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/3c/87caaed663fabc35e18dc704cd0e9800a0ee2f22bd18b9cbe7c10799895d/tree_sitter-0.25.2-cp313-cp313-win_amd64.whl", hash = "sha256:463c032bd02052d934daa5f45d183e0521ceb783c2548501cf034b0beba92c9b", size = 127157, upload-time = "2025-09-25T17:37:48.967Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/23/f8467b408b7988aff4ea40946a4bd1a2c1a73d17156a9d039bbaff1e2ceb/tree_sitter-0.25.2-cp313-cp313-win_arm64.whl", hash = "sha256:b3f63a1796886249bd22c559a5944d64d05d43f2be72961624278eff0dcc5cb8", size = 113975, upload-time = "2025-09-25T17:37:49.922Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e3/d9526ba71dfbbe4eba5e51d89432b4b333a49a1e70712aa5590cd22fc74f/tree_sitter-0.25.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:65d3c931013ea798b502782acab986bbf47ba2c452610ab0776cf4a8ef150fc0", size = 146776, upload-time = "2025-09-25T17:37:50.898Z" },
+    { url = "https://files.pythonhosted.org/packages/42/97/4bd4ad97f85a23011dd8a535534bb1035c4e0bac1234d58f438e15cff51f/tree_sitter-0.25.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bda059af9d621918efb813b22fb06b3fe00c3e94079c6143fcb2c565eb44cb87", size = 137732, upload-time = "2025-09-25T17:37:51.877Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/19/1e968aa0b1b567988ed522f836498a6a9529a74aab15f09dd9ac1e41f505/tree_sitter-0.25.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eac4e8e4c7060c75f395feec46421eb61212cb73998dbe004b7384724f3682ab", size = 609456, upload-time = "2025-09-25T17:37:52.925Z" },
+    { url = "https://files.pythonhosted.org/packages/48/b6/cf08f4f20f4c9094006ef8828555484e842fc468827ad6e56011ab668dbd/tree_sitter-0.25.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:260586381b23be33b6191a07cea3d44ecbd6c01aa4c6b027a0439145fcbc3358", size = 636772, upload-time = "2025-09-25T17:37:54.647Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e2/d42d55bf56360987c32bc7b16adb06744e425670b823fb8a5786a1cea991/tree_sitter-0.25.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7d2ee1acbacebe50ba0f85fff1bc05e65d877958f00880f49f9b2af38dce1af0", size = 631522, upload-time = "2025-09-25T17:37:55.833Z" },
+    { url = "https://files.pythonhosted.org/packages/03/87/af9604ebe275a9345d88c3ace0cf2a1341aa3f8ef49dd9fc11662132df8a/tree_sitter-0.25.2-cp314-cp314-win_amd64.whl", hash = "sha256:4973b718fcadfb04e59e746abfbb0288694159c6aeecd2add59320c03368c721", size = 130864, upload-time = "2025-09-25T17:37:57.453Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/6e/e64621037357acb83d912276ffd30a859ef117f9c680f2e3cb955f47c680/tree_sitter-0.25.2-cp314-cp314-win_arm64.whl", hash = "sha256:b8d4429954a3beb3e844e2872610d2a4800ba4eb42bb1990c6a4b1949b18459f", size = 117470, upload-time = "2025-09-25T17:37:58.431Z" },
+]
+
+[[package]]
+name = "tree-sitter-python"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/8b/c992ff0e768cb6768d5c96234579bf8842b3a633db641455d86dd30d5dac/tree_sitter_python-0.25.0.tar.gz", hash = "sha256:b13e090f725f5b9c86aa455a268553c65cadf325471ad5b65cd29cac8a1a68ac", size = 159845, upload-time = "2025-09-11T06:47:58.159Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/64/a4e503c78a4eb3ac46d8e72a29c1b1237fa85238d8e972b063e0751f5a94/tree_sitter_python-0.25.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:14a79a47ddef72f987d5a2c122d148a812169d7484ff5c75a3db9609d419f361", size = 73790, upload-time = "2025-09-11T06:47:47.652Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/1d/60d8c2a0cc63d6ec4ba4e99ce61b802d2e39ef9db799bdf2a8f932a6cd4b/tree_sitter_python-0.25.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:480c21dbd995b7fe44813e741d71fed10ba695e7caab627fb034e3828469d762", size = 76691, upload-time = "2025-09-11T06:47:49.038Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/cb/d9b0b67d037922d60cbe0359e0c86457c2da721bc714381a63e2c8e35eba/tree_sitter_python-0.25.0-cp310-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:86f118e5eecad616ecdb81d171a36dde9bef5a0b21ed71ea9c3e390813c3baf5", size = 108133, upload-time = "2025-09-11T06:47:50.499Z" },
+    { url = "https://files.pythonhosted.org/packages/40/bd/bf4787f57e6b2860f3f1c8c62f045b39fb32d6bac4b53d7a9e66de968440/tree_sitter_python-0.25.0-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be71650ca2b93b6e9649e5d65c6811aad87a7614c8c1003246b303f6b150f61b", size = 110603, upload-time = "2025-09-11T06:47:51.985Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/25/feff09f5c2f32484fbce15db8b49455c7572346ce61a699a41972dea7318/tree_sitter_python-0.25.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e6d5b5799628cc0f24691ab2a172a8e676f668fe90dc60468bee14084a35c16d", size = 108998, upload-time = "2025-09-11T06:47:53.046Z" },
+    { url = "https://files.pythonhosted.org/packages/75/69/4946da3d6c0df316ccb938316ce007fb565d08f89d02d854f2d308f0309f/tree_sitter_python-0.25.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:71959832fc5d9642e52c11f2f7d79ae520b461e63334927e93ca46cd61cd9683", size = 107268, upload-time = "2025-09-11T06:47:54.388Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a2/996fc2dfa1076dc460d3e2f3c75974ea4b8f02f6bc925383aaae519920e8/tree_sitter_python-0.25.0-cp310-abi3-win_amd64.whl", hash = "sha256:9bcde33f18792de54ee579b00e1b4fe186b7926825444766f849bf7181793a76", size = 76073, upload-time = "2025-09-11T06:47:55.773Z" },
+    { url = "https://files.pythonhosted.org/packages/07/19/4b5569d9b1ebebb5907d11554a96ef3fa09364a30fcfabeff587495b512f/tree_sitter_python-0.25.0-cp310-abi3-win_arm64.whl", hash = "sha256:0fbf6a3774ad7e89ee891851204c2e2c47e12b63a5edbe2e9156997731c128bb", size = 74169, upload-time = "2025-09-11T06:47:56.747Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Packages Bob's `codegraph` prototype as an experimental `gptme-codegraph` package in gptme-contrib.

Approved by Erik on the tracking issue: gptme/gptme-contrib#828 ("Yes! Go")

**What is gptme-codegraph?** Structural code retrieval via tree-sitter — complementary to gptme-rag (text chunks), this retrieves code *structure*: function/class definitions, call graphs, blast radius, and impact analysis.

- **5 MCP tools**: `codegraph_callers`, `codegraph_callees`, `codegraph_impact`, `codegraph_blast`, `codegraph_def`
- **Cross-file import resolution** (alias, wildcard, relative)
- **Qualified symbol IDs** (`module::Class.method`)
- **SQLite-backed persistent index cache** (optional)
- **91 tests** ported from Bob's workspace and passing

### Package layout

```
packages/gptme-codegraph/
├── pyproject.toml
├── README.md
├── src/gptme_codegraph/
│   ├── __init__.py     # re-exports public API
│   ├── core.py         # tree-sitter analysis engine (1,347 LOC)
│   └── mcp_server.py   # FastMCP stdio server (726 LOC)
└── tests/              # 91 tests
```

### CLI entry points

- `gptme-codegraph` — CLI for single/cross-file analysis
- `gptme-codegraph-mcp` — MCP stdio server (`claude mcp add codegraph -- gptme-codegraph-mcp`)

### Notes

- `tree-sitter` and `mcp` are optional extras (`[treesitter]` and `[mcp]`); core module degrades gracefully without tree-sitter
- Added `packages/gptme-codegraph/**` to `.jscpd.json` ignore — MCP tool handlers inherently share boilerplate; factoring is a follow-up concern
- Namespace packages (`import google.cloud.storage`) are a known v1.1 gap

Closes #828