### PR TITLE
fix(codegraph): resolve bare names in cross-file blast/impact + fix README API example

### DIFF
--- a/packages/gptme-codegraph/README.md
+++ b/packages/gptme-codegraph/README.md
@@ -59,10 +59,28 @@ claude mcp add codegraph -- gptme-codegraph-mcp
 ### Python API
 
 ```python
-from gptme_codegraph import build_index, impact_radius
+from gptme_codegraph import (
+    build_call_graph,
+    build_cross_file_call_graph,
+    build_index,
+    extract_symbols,
+    impact_radius,
+)
+from pathlib import Path
 
+# Single-file: extract symbols and build call graph
+symbols = extract_symbols(Path("src/my_module.py"))
+_callees_graph, callers_graph = build_call_graph(symbols)
+
+# Compute impact radius: what breaks if you change this symbol?
+radius = impact_radius("my_function", callers_graph, max_depth=5)
+print(radius)  # {"depth_0": {…}, "depth_1": {…}, …}
+
+# Cross-file: build an index over a whole directory
 index = build_index(Path("src/"))
-callers, callees = impact_radius("my_module::MyClass.my_method", index)
+_callees_graph, callers_graph = build_cross_file_call_graph(index, Path("src/"))
+radius = impact_radius("my_module::MyClass.my_method", callers_graph, max_depth=5)
+print(radius)  # {"depth_0": {…}, "depth_1": {…}, …}
 ```
 
 ## Status

--- a/packages/gptme-codegraph/src/gptme_codegraph/mcp_server.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/mcp_server.py
@@ -502,11 +502,12 @@ def codegraph_blast(
         if not directory:
             return json.dumps({"error": "Either filepath or directory is required"})
         index = _get_or_build_index(directory)
-        if not index.has(name):
-            return json.dumps({"error": f"Symbol '{name}' not found in index"})
         dir_path = Path(directory)
         callees_graph, _callers_graph = build_cross_file_call_graph(index, dir_path)
-        if name not in callees_graph:
+        resolved = _resolve_graph_key(name, callees_graph)
+        if resolved is None:
+            if not index.has(name):
+                return json.dumps({"error": f"Symbol '{name}' not found in index"})
             files = {e.file for e in index.lookup(name)}
             return json.dumps(
                 {
@@ -518,7 +519,7 @@ def codegraph_blast(
                 },
                 indent=2,
             )
-        radius = blast_radius(name, callees_graph, max_depth=max_depth)
+        radius = blast_radius(resolved, callees_graph, max_depth=max_depth)
         total = sum(len(names) for names in radius.values())
         files = {e.file for e in index.lookup(name)}
         return json.dumps(
@@ -599,11 +600,12 @@ def codegraph_impact(
         if not directory:
             return json.dumps({"error": "Either filepath or directory is required"})
         index = _get_or_build_index(directory)
-        if not index.has(name):
-            return json.dumps({"error": f"Symbol '{name}' not found in index"})
         dir_path = Path(directory)
         _callees_graph, callers_graph = build_cross_file_call_graph(index, dir_path)
-        if name not in callers_graph:
+        resolved = _resolve_graph_key(name, callers_graph)
+        if resolved is None:
+            if not index.has(name):
+                return json.dumps({"error": f"Symbol '{name}' not found in index"})
             files = {e.file for e in index.lookup(name)}
             return json.dumps(
                 {
@@ -615,7 +617,7 @@ def codegraph_impact(
                 },
                 indent=2,
             )
-        radius = impact_radius(name, callers_graph, max_depth=max_depth)
+        radius = impact_radius(resolved, callers_graph, max_depth=max_depth)
         total = sum(len(names) for names in radius.values())
         files = {e.file for e in index.lookup(name)}
         return json.dumps(


### PR DESCRIPTION
## What

Fixes two Greptile-reported bugs from #829 that remained after merge (Erik flagged as "premature merge - 3/5 confidence"):

### Bug 1: `codegraph_blast` / `codegraph_impact` always short-circuit for bare names in cross-file mode

`build_cross_file_call_graph` stores keys as qualified IDs (`module::Name`), but the early-exit guard checked bare names directly — so `if name not in callees_graph` was always True for bare inputs, returning the "No cross-file calls found" stub without computing an actual radius.

**Fix**: Use `_resolve_graph_key()` (same helper already used correctly in `_cross_file_callers_mcp`) before the graph membership check, and pass the resolved qualified key to `blast_radius`/`impact_radius`.

### Bug 2: README Python API example wrong

The example called `impact_radius(symbol, index)` passing a `SymbolIndex` where the function expects `dict[str, set[str]]`, and destructured the return value as a tuple when it returns a single dict.

**Fix**: Rewrite the example to show correct single-file and cross-file usage.

## Testing

- Core tests pass (32/92 passing; 60 failures are pre-existing tree-sitter grammar availability issues)
- Logic verified: `_resolve_graph_key` is the same pattern used by `_cross_file_callers_mcp` (line 285 in original)
- `blast_radius` (`= dependency_closure`) internally uses `_resolve_graph_key`, so passing the already-resolved key is correct and avoids double work

Closes #829 (remaining issues)