### PR TITLE
feat(subscription): add gptme-subscription package

### DIFF
--- a/packages/gptme-subscription/README.md
+++ b/packages/gptme-subscription/README.md
@@ -1,0 +1,31 @@
+# gptme-subscription
+
+Generic subscription observation, pressure scoring, and capacity-aware routing for agent credential slots.
+
+## Purpose
+
+This package provides the policy layer above [credential-slots](https://github.com/gptme/gptme-contrib/tree/main/packages/credential-slots):
+
+- **Observation state**: Track per-subscription quota reset timestamps
+- **Pressure scoring**: Compute compact pressure scores from usage snapshots
+- **Capacity-aware routing**: Sort fallbacks by pressure, find lower-pressure alternatives, forward-route to soonest-resetting subscriptions
+- **Rebalance state machine**: Persist and query rebalance decisions (rest durations, hold windows)
+
+## API
+
+```python
+from gptme_subscription import (
+    subscription_pressure_from_usage,
+    is_subscription_blocked,
+    format_duration,
+    capacity_aware_fallback_order,
+    best_lower_pressure_fallback,
+    compute_window_pacing,
+)
+```
+
+See `src/gptme_subscription/__init__.py` for the full public API.
+
+## Status
+
+Alpha — extracted from Bob's `manage-subscription.py`. See [gptme/gptme-contrib#831](https://github.com/gptme/gptme-contrib/issues/831).

--- a/packages/gptme-subscription/pyproject.toml
+++ b/packages/gptme-subscription/pyproject.toml
@@ -1,0 +1,44 @@
+[project]
+name = "gptme-subscription"
+version = "0.1.0"
+description = "Generic subscription observation, pressure scoring, and capacity-aware routing for agent credential slots"
+readme = "README.md"
+authors = [
+    {name = "gptme contributors", email = "gptme@superuserlabs.org"}
+]
+license = "MIT"
+
+requires-python = ">=3.10"
+keywords = ["subscription", "quota", "routing", "credentials", "gptme", "ai-agents"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Utilities",
+]
+dependencies = []
+
+[project.urls]
+Homepage = "https://github.com/gptme/gptme-contrib"
+Repository = "https://github.com/gptme/gptme-contrib"
+Issues = "https://github.com/gptme/gptme-contrib/issues"
+
+[project.optional-dependencies]
+test = [
+    "pytest>=7.0",
+    "pytest-cov>=4.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/gptme_subscription"]
+
+[tool.mypy]
+strict = true

--- a/packages/gptme-subscription/src/gptme_subscription/__init__.py
+++ b/packages/gptme-subscription/src/gptme_subscription/__init__.py
@@ -1,0 +1,50 @@
+"""gptme-subscription: subscription observation, pressure scoring, and capacity-aware routing.
+
+Extracted from Bob's manage-subscription.py to be reusable by any agent.
+See https://github.com/gptme/gptme-contrib/issues/831
+"""
+
+from gptme_subscription.observation import (
+    subscription_pressure_from_usage,
+    is_subscription_blocked,
+    format_duration,
+    record_sub_reset_time,
+    load_sub_observations,
+    remaining_until_observed_reset,
+    pressure_from_observation,
+    SubscriptionObservation,
+)
+
+from gptme_subscription.routing import (
+    compute_window_pacing,
+    compute_rebalance_hold_seconds,
+    capacity_aware_fallback_order,
+    best_lower_pressure_fallback,
+    soonest_resetting_fallback,
+    load_rebalance_state,
+    save_rebalance_state,
+    clear_rebalance_state,
+    RebalanceState,
+)
+
+__all__ = [
+    # Observation
+    "subscription_pressure_from_usage",
+    "is_subscription_blocked",
+    "format_duration",
+    "record_sub_reset_time",
+    "load_sub_observations",
+    "remaining_until_observed_reset",
+    "pressure_from_observation",
+    "SubscriptionObservation",
+    # Routing
+    "compute_window_pacing",
+    "compute_rebalance_hold_seconds",
+    "capacity_aware_fallback_order",
+    "best_lower_pressure_fallback",
+    "soonest_resetting_fallback",
+    "load_rebalance_state",
+    "save_rebalance_state",
+    "clear_rebalance_state",
+    "RebalanceState",
+]

--- a/packages/gptme-subscription/src/gptme_subscription/__init__.py
+++ b/packages/gptme-subscription/src/gptme_subscription/__init__.py
@@ -5,26 +5,25 @@ See https://github.com/gptme/gptme-contrib/issues/831
 """
 
 from gptme_subscription.observation import (
-    subscription_pressure_from_usage,
-    is_subscription_blocked,
-    format_duration,
-    record_sub_reset_time,
-    load_sub_observations,
-    remaining_until_observed_reset,
-    pressure_from_observation,
     SubscriptionObservation,
+    format_duration,
+    is_subscription_blocked,
+    load_sub_observations,
+    pressure_from_observation,
+    record_sub_reset_time,
+    remaining_until_observed_reset,
+    subscription_pressure_from_usage,
 )
-
 from gptme_subscription.routing import (
-    compute_window_pacing,
-    compute_rebalance_hold_seconds,
-    capacity_aware_fallback_order,
+    RebalanceState,
     best_lower_pressure_fallback,
-    soonest_resetting_fallback,
+    capacity_aware_fallback_order,
+    clear_rebalance_state,
+    compute_rebalance_hold_seconds,
+    compute_window_pacing,
     load_rebalance_state,
     save_rebalance_state,
-    clear_rebalance_state,
-    RebalanceState,
+    soonest_resetting_fallback,
 )
 
 __all__ = [

--- a/packages/gptme-subscription/src/gptme_subscription/observation.py
+++ b/packages/gptme-subscription/src/gptme_subscription/observation.py
@@ -92,9 +92,12 @@ def record_sub_reset_time(
     obs_file = obs_dir / f"{sub}.json"
     entry: dict[str, dict[str, str]] = {}
     if obs_file.exists():
-        raw = obs_file.read_text()
-        if raw.strip():
-            entry = json.loads(raw)
+        try:
+            raw = obs_file.read_text()
+            if raw.strip():
+                entry = json.loads(raw)
+        except (json.JSONDecodeError, OSError):
+            pass  # corrupt file — start fresh
     entry.setdefault("track_resets", {})[metric_key] = (
         timestamp or datetime.now(timezone.utc).isoformat()
     )
@@ -220,6 +223,7 @@ def subscription_pressure_from_usage(
     usage: dict,
     weekly_exhausted: float = DEFAULT_WEEKLY_EXHAUSTED,
     five_hour_threshold: float = DEFAULT_FIVE_HOUR_EXHAUSTED,
+    sonnet_weekly_exhausted: float = DEFAULT_SONNET_WEEKLY_EXHAUSTED,
     short_reset_window: int = 7200,
 ) -> float | None:
     """Return a compact pressure score for a subscription usage snapshot.
@@ -233,6 +237,9 @@ def subscription_pressure_from_usage(
         usage: Usage snapshot dict, typically from ``check-quota`` API.
         weekly_exhausted: Utilization level treated as exhausted (0-1).
         five_hour_threshold: 5h utilization level treated as exhausted (0-1).
+        sonnet_weekly_exhausted: Sonnet-weekly utilization level treated as
+            exhausted (0-1). Separate from ``weekly_exhausted`` because Sonnet
+            has a lower per-project cap (default 0.85 vs 0.95).
         short_reset_window: Min resets_in_seconds for 5h to count (avoids
             short spikes driving multi-day routing).
 
@@ -246,7 +253,9 @@ def subscription_pressure_from_usage(
 
     sonnet_weekly = usage.get("seven_day_sonnet", {}).get("utilization")
     if isinstance(sonnet_weekly, int | float):
-        components.append(_pressure_component(float(sonnet_weekly), weekly_exhausted))
+        components.append(
+            _pressure_component(float(sonnet_weekly), sonnet_weekly_exhausted)
+        )
 
     five_hour = usage.get("five_hour", {}).get("utilization")
     five_hour_resets = usage.get("five_hour", {}).get("resets_in_seconds", 0)

--- a/packages/gptme-subscription/src/gptme_subscription/observation.py
+++ b/packages/gptme-subscription/src/gptme_subscription/observation.py
@@ -126,6 +126,8 @@ def load_sub_observations(
             if not raw.strip():
                 continue
             data = json.loads(raw)
+            if not isinstance(data, dict):
+                continue
             sub = f.stem
             observations[sub] = SubscriptionObservation(
                 track_resets=data.get("track_resets", {}),

--- a/packages/gptme-subscription/src/gptme_subscription/observation.py
+++ b/packages/gptme-subscription/src/gptme_subscription/observation.py
@@ -207,10 +207,19 @@ def pressure_from_observation(
 # --- Pressure scoring ---
 
 
+def _pressure_component(utilization: float, exhausted_threshold: float) -> float:
+    """Return a 0-1 pressure component, treating threshold-crossing as exhausted."""
+    value = max(0.0, min(1.0, utilization))
+    threshold = max(0.0, min(1.0, exhausted_threshold))
+    if threshold <= 0 or value >= threshold:
+        return 1.0
+    return value
+
+
 def subscription_pressure_from_usage(
     usage: dict,
     weekly_exhausted: float = DEFAULT_WEEKLY_EXHAUSTED,
-    five_hour_threshold: float = 0.95,
+    five_hour_threshold: float = DEFAULT_FIVE_HOUR_EXHAUSTED,
     short_reset_window: int = 7200,
 ) -> float | None:
     """Return a compact pressure score for a subscription usage snapshot.
@@ -223,7 +232,7 @@ def subscription_pressure_from_usage(
     Args:
         usage: Usage snapshot dict, typically from ``check-quota`` API.
         weekly_exhausted: Utilization level treated as exhausted (0-1).
-        five_hour_threshold: Max utilization for 5h to count toward pressure.
+        five_hour_threshold: 5h utilization level treated as exhausted (0-1).
         short_reset_window: Min resets_in_seconds for 5h to count (avoids
             short spikes driving multi-day routing).
 
@@ -233,11 +242,11 @@ def subscription_pressure_from_usage(
     components: list[float] = []
     weekly = usage.get("seven_day", {}).get("utilization")
     if isinstance(weekly, int | float):
-        components.append(float(weekly))
+        components.append(_pressure_component(float(weekly), weekly_exhausted))
 
     sonnet_weekly = usage.get("seven_day_sonnet", {}).get("utilization")
     if isinstance(sonnet_weekly, int | float):
-        components.append(float(sonnet_weekly))
+        components.append(_pressure_component(float(sonnet_weekly), weekly_exhausted))
 
     five_hour = usage.get("five_hour", {}).get("utilization")
     five_hour_resets = usage.get("five_hour", {}).get("resets_in_seconds", 0)
@@ -246,7 +255,7 @@ def subscription_pressure_from_usage(
         and isinstance(five_hour_resets, int | float)
         and five_hour_resets > short_reset_window
     ):
-        components.append(float(five_hour))
+        components.append(_pressure_component(float(five_hour), five_hour_threshold))
 
     if not components:
         return None

--- a/packages/gptme-subscription/src/gptme_subscription/observation.py
+++ b/packages/gptme-subscription/src/gptme_subscription/observation.py
@@ -95,7 +95,9 @@ def record_sub_reset_time(
         try:
             raw = obs_file.read_text()
             if raw.strip():
-                entry = json.loads(raw)
+                parsed = json.loads(raw)
+                if isinstance(parsed, dict):
+                    entry = parsed
         except (json.JSONDecodeError, OSError):
             pass  # corrupt file — start fresh
     entry.setdefault("track_resets", {})[metric_key] = (

--- a/packages/gptme-subscription/src/gptme_subscription/observation.py
+++ b/packages/gptme-subscription/src/gptme_subscription/observation.py
@@ -1,0 +1,294 @@
+"""Subscription observation and pressure scoring.
+
+Generic helpers for tracking subscription quota usage, computing pressure
+scores, and determining whether a subscription is blocked.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass
+class SubscriptionObservation:
+    """Persistent observation state for a single subscription."""
+
+    track_resets: dict[str, str] = field(default_factory=dict)
+    """Mapping of metric keys (e.g. 'seven_day', 'seven_day_sonnet') to ISO-8601
+    timestamps of when they were last observed at a reset boundary."""
+
+    metadata: dict[str, object] = field(default_factory=dict)
+    """Arbitrary metadata (agent name, record version, etc.)."""
+
+
+# --- Thresholds (configurable) ---
+
+# Default exhaustion thresholds
+DEFAULT_WEEKLY_EXHAUSTED = 0.95
+DEFAULT_FIVE_HOUR_EXHAUSTED = 0.95
+DEFAULT_SONNET_WEEKLY_EXHAUSTED = 0.85
+
+# Default fallback routing constants
+DEFAULT_UNKNOWN_FALLBACK_PRESSURE = 0.5
+DEFAULT_SOON_TO_EXPIRE_THRESHOLD = 3600 * 4  # 4 hours
+DEFAULT_EXPIRING_CAPACITY_CREDIT = 0.15
+DEFAULT_CAPACITY_REBALANCE_MIN_PRESSURE = 0.3
+DEFAULT_CAPACITY_REBALANCE_MARGIN = 0.1
+DEFAULT_REBALANCE_MIN_HOLD = 600  # 10 minutes
+DEFAULT_REBALANCE_MAX_HOLD = 7200  # 2 hours
+DEFAULT_REBALANCE_TARGET_UTILIZATION = 0.85
+
+
+# --- Utility ---
+
+
+def format_duration(seconds: int) -> str:
+    """Format a compact human-readable duration.
+
+    >>> format_duration(0)
+    '0m'
+    >>> format_duration(3661)
+    '1h01m'
+    >>> format_duration(7200)
+    '2h'
+    >>> format_duration(1800)
+    '30m'
+    """
+    if seconds <= 0:
+        return "0m"
+    hours, remainder = divmod(seconds, 3600)
+    minutes = remainder // 60
+    if hours and minutes:
+        return f"{hours}h{minutes:02d}m"
+    if hours:
+        return f"{hours}h"
+    return f"{minutes}m"
+
+
+# --- Subscription observation state ---
+
+
+def record_sub_reset_time(
+    obs_dir: Path,
+    sub: str,
+    metric_key: str,
+    timestamp: str | None = None,
+) -> None:
+    """Record that a subscription's metric was just observed at a reset boundary.
+
+    The observation directory is consumer-managed; different agents may use
+    different paths (e.g. ``/home/bob/bob/state/backend-quota/``).
+
+    Args:
+        obs_dir: Directory where observation JSON files are stored.
+        sub: Subscription name (e.g. ``bob``, ``alice``, ``erik``).
+        metric_key: Which metric reset was observed (e.g. ``seven_day``).
+        timestamp: ISO-8601 timestamp. Defaults to current UTC time.
+    """
+    obs_dir.mkdir(parents=True, exist_ok=True)
+    obs_file = obs_dir / f"{sub}.json"
+    entry: dict[str, dict[str, str]] = {}
+    if obs_file.exists():
+        raw = obs_file.read_text()
+        if raw.strip():
+            entry = json.loads(raw)
+    entry.setdefault("track_resets", {})[metric_key] = (
+        timestamp or datetime.now(timezone.utc).isoformat()
+    )
+    obs_file.write_text(json.dumps(entry, indent=2) + "\n")
+
+
+def load_sub_observations(
+    obs_dir: Path,
+) -> dict[str, SubscriptionObservation]:
+    """Load all subscription observations from a directory.
+
+    Args:
+        obs_dir: Directory containing ``<sub>.json`` observation files.
+
+    Returns:
+        Dict mapping subscription name to its observation state.
+    """
+    observations: dict[str, SubscriptionObservation] = {}
+    if not obs_dir.exists():
+        return observations
+    for f in sorted(obs_dir.iterdir()):
+        if f.suffix != ".json":
+            continue
+        try:
+            raw = f.read_text()
+            if not raw.strip():
+                continue
+            data = json.loads(raw)
+            sub = f.stem
+            observations[sub] = SubscriptionObservation(
+                track_resets=data.get("track_resets", {}),
+                metadata=data.get("metadata", {}),
+            )
+        except (json.JSONDecodeError, OSError):
+            continue
+    return observations
+
+
+def remaining_until_observed_reset(
+    observation: SubscriptionObservation,
+    metric_key: str,
+    window_seconds: int,
+    now: datetime | None = None,
+) -> float | None:
+    """Compute seconds until the next reset, given the last observed reset time.
+
+    Args:
+        observation: Observation state for a subscription.
+        metric_key: Which metric's reset time to check.
+        window_seconds: Duration of the rolling window (e.g. 7*24*3600 for weekly).
+        now: Current time. Defaults to UTC now.
+
+    Returns:
+        Seconds until reset, or None if no observation exists.
+    """
+    current_time = now or datetime.now(timezone.utc)
+    reset_str = observation.track_resets.get(metric_key)
+    if not reset_str:
+        return None
+    try:
+        reset_time = datetime.fromisoformat(reset_str)
+    except (ValueError, TypeError):
+        return None
+    next_reset = reset_time + timedelta(seconds=window_seconds)
+    remaining = (next_reset - current_time).total_seconds()
+    return max(0.0, remaining)
+
+
+def pressure_from_observation(
+    observation: SubscriptionObservation,
+    metric_key: str,
+    window_seconds: int,
+    max_pressure_window: float = 0.85,
+    now: datetime | None = None,
+) -> float | None:
+    """Compute pressure from when a subscription was last observed at a reset.
+
+    Uses the fraction of the window that has elapsed since the last reset.
+    A subscription that was reset recently (e.g. 1h ago in a 7d window) has
+    low pressure because most of its quota remains. One observed long ago
+    has higher pressure (more quota consumed).
+
+    Args:
+        observation: Observation state for a subscription.
+        metric_key: Which metric to check.
+        window_seconds: Duration of the rolling window.
+        max_pressure_window: Cap the pressure-scoring window to this fraction
+            of the full window (prevents stale observations from saturating).
+        now: Current time.
+
+    Returns:
+        Pressure score 0-1, or None if no observation exists.
+    """
+    remaining = remaining_until_observed_reset(
+        observation, metric_key, window_seconds, now=now
+    )
+    if remaining is None:
+        return None
+    # Elapsed fraction of the window since observation
+    elapsed = max(0.0, window_seconds - remaining)
+    elapsed_frac = elapsed / window_seconds
+    # Cap so old observations don't saturate
+    return min(max_pressure_window, elapsed_frac)
+
+
+# --- Pressure scoring ---
+
+
+def subscription_pressure_from_usage(
+    usage: dict,
+    weekly_exhausted: float = DEFAULT_WEEKLY_EXHAUSTED,
+    five_hour_threshold: float = 0.95,
+    short_reset_window: int = 7200,
+) -> float | None:
+    """Return a compact pressure score for a subscription usage snapshot.
+
+    Weekly overall and Sonnet weekly limits are the durable pressure signals.
+    The 5h window only counts when it will remain tight for more than
+    ``short_reset_window`` seconds; a short-reset 5h spike should not drive
+    multi-day slot routing.
+
+    Args:
+        usage: Usage snapshot dict, typically from ``check-quota`` API.
+        weekly_exhausted: Utilization level treated as exhausted (0-1).
+        five_hour_threshold: Max utilization for 5h to count toward pressure.
+        short_reset_window: Min resets_in_seconds for 5h to count (avoids
+            short spikes driving multi-day routing).
+
+    Returns:
+        Pressure score 0-1, or None if no useful data.
+    """
+    components: list[float] = []
+    weekly = usage.get("seven_day", {}).get("utilization")
+    if isinstance(weekly, (int, float)):
+        components.append(float(weekly))
+
+    sonnet_weekly = usage.get("seven_day_sonnet", {}).get("utilization")
+    if isinstance(sonnet_weekly, (int, float)):
+        components.append(float(sonnet_weekly))
+
+    five_hour = usage.get("five_hour", {}).get("utilization")
+    five_hour_resets = usage.get("five_hour", {}).get("resets_in_seconds", 0)
+    if (
+        isinstance(five_hour, (int, float))
+        and isinstance(five_hour_resets, (int, float))
+        and five_hour_resets > short_reset_window
+    ):
+        components.append(float(five_hour))
+
+    if not components:
+        return None
+    return max(components)
+
+
+def is_subscription_blocked(
+    usage: dict,
+    weekly_exhausted: float = DEFAULT_WEEKLY_EXHAUSTED,
+    five_hour_exhausted: float = DEFAULT_FIVE_HOUR_EXHAUSTED,
+    sonnet_weekly_exhausted: float = DEFAULT_SONNET_WEEKLY_EXHAUSTED,
+) -> tuple[bool, str]:
+    """Check if a subscription's quota is too exhausted to use.
+
+    Three independent limits exist — any one being exhausted blocks the sub:
+    - Overall weekly + 5h both exhausted -> no Opus capacity left
+    - Sonnet weekly exhausted -> project-monitoring and Sonnet sessions break
+    - Sonnet data missing + high weekly -> assume Sonnet exhausted (conservative)
+
+    Args:
+        usage: Usage snapshot dict.
+        weekly_exhausted: Threshold for overall weekly (0-1).
+        five_hour_exhausted: Threshold for 5h window (0-1).
+        sonnet_weekly_exhausted: Threshold for Sonnet weekly (0-1).
+
+    Returns:
+        (blocked: bool, reason: str).
+    """
+    weekly = usage.get("seven_day", {}).get("utilization", 0)
+    five_hour = usage.get("five_hour", {}).get("utilization", 0)
+    sonnet_weekly = usage.get("seven_day_sonnet", {}).get("utilization", 0)
+    has_sonnet_data = "seven_day_sonnet" in usage
+
+    reasons: list[str] = []
+
+    # Opus blocked: both overall windows high
+    if weekly >= weekly_exhausted and five_hour >= five_hour_exhausted:
+        reasons.append(f"Opus exhausted ({weekly:.0%}w/{five_hour:.0%}5h)")
+
+    # Sonnet blocked: independent weekly limit (different reset schedule!)
+    if has_sonnet_data and sonnet_weekly >= sonnet_weekly_exhausted:
+        reasons.append(f"Sonnet exhausted ({sonnet_weekly:.0%})")
+    elif not has_sonnet_data and weekly >= weekly_exhausted:
+        # Can't confirm Sonnet is OK — be conservative when overall is already high
+        reasons.append("Sonnet data missing, weekly high — assuming Sonnet exhausted")
+
+    blocked = len(reasons) > 0
+    return blocked, "; ".join(reasons) if reasons else "all limits healthy"

--- a/packages/gptme-subscription/src/gptme_subscription/observation.py
+++ b/packages/gptme-subscription/src/gptme_subscription/observation.py
@@ -10,7 +10,6 @@ import json
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Optional
 
 
 @dataclass
@@ -157,6 +156,10 @@ def remaining_until_observed_reset(
         return None
     try:
         reset_time = datetime.fromisoformat(reset_str)
+        # Normalize naive timestamps to UTC to avoid TypeError when
+        # subtracting from timezone-aware current_time
+        if reset_time.tzinfo is None:
+            reset_time = reset_time.replace(tzinfo=timezone.utc)
     except (ValueError, TypeError):
         return None
     next_reset = reset_time + timedelta(seconds=window_seconds)
@@ -229,18 +232,18 @@ def subscription_pressure_from_usage(
     """
     components: list[float] = []
     weekly = usage.get("seven_day", {}).get("utilization")
-    if isinstance(weekly, (int, float)):
+    if isinstance(weekly, int | float):
         components.append(float(weekly))
 
     sonnet_weekly = usage.get("seven_day_sonnet", {}).get("utilization")
-    if isinstance(sonnet_weekly, (int, float)):
+    if isinstance(sonnet_weekly, int | float):
         components.append(float(sonnet_weekly))
 
     five_hour = usage.get("five_hour", {}).get("utilization")
     five_hour_resets = usage.get("five_hour", {}).get("resets_in_seconds", 0)
     if (
-        isinstance(five_hour, (int, float))
-        and isinstance(five_hour_resets, (int, float))
+        isinstance(five_hour, int | float)
+        and isinstance(five_hour_resets, int | float)
         and five_hour_resets > short_reset_window
     ):
         components.append(float(five_hour))

--- a/packages/gptme-subscription/src/gptme_subscription/routing.py
+++ b/packages/gptme-subscription/src/gptme_subscription/routing.py
@@ -1,0 +1,314 @@
+"""Capacity-aware fallback routing and rebalance state management.
+
+Generic helpers for deciding which subscription to use, when to rebalance,
+and how to manage persistent rebalance state.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from gptme_subscription.observation import (
+    DEFAULT_REBALANCE_MIN_HOLD,
+    DEFAULT_REBALANCE_MAX_HOLD,
+    DEFAULT_REBALANCE_TARGET_UTILIZATION,
+    DEFAULT_UNKNOWN_FALLBACK_PRESSURE,
+    DEFAULT_SOON_TO_EXPIRE_THRESHOLD,
+    DEFAULT_EXPIRING_CAPACITY_CREDIT,
+    DEFAULT_CAPACITY_REBALANCE_MIN_PRESSURE,
+    DEFAULT_CAPACITY_REBALANCE_MARGIN,
+    load_sub_observations,
+    pressure_from_observation,
+    remaining_until_observed_reset,
+    subscription_pressure_from_usage,
+)
+
+
+@dataclass
+class RebalanceState:
+    """Persistent rebalance decision state."""
+
+    switched_to: str = ""
+    """The subscription name we rebalanced to."""
+
+    switched_from: str = ""
+    """The subscription name we rebalanced from."""
+
+    switched_at: str = ""
+    """ISO-8601 timestamp when the rebalance switch was made."""
+
+    hold_until: str = ""
+    """ISO-8601 timestamp until which the rebalance decision is honored."""
+
+    reason: str = ""
+    """Human-readable reason for the rebalance."""
+
+    metadata: dict[str, object] = field(default_factory=dict)
+    """Extra metadata (pressure scores, cache info, etc.)."""
+
+
+# --- Window pacing ---
+
+
+def compute_window_pacing(
+    utilization: float,
+    resets_in_seconds: int,
+    window_seconds: int,
+) -> tuple[float, float, str] | None:
+    """Compute pacing (elapsed_frac, gap, status) for a quota window.
+
+    Uses the headroom model: if remaining budget is less than remaining time,
+    the gap is positive (overusing). Returns None for invalid inputs.
+
+    Args:
+        utilization: Current utilization fraction (0-1).
+        resets_in_seconds: Seconds until the window resets.
+        window_seconds: Total window duration in seconds.
+
+    Returns:
+        ``(elapsed_frac, gap, status)`` or None.
+        gap > 0 = overusing, gap < 0 = underusing, ≈ 0 = on track.
+        Status is ``"overusing"``, ``"underusing"``, or ``"on_track"``.
+    """
+    if window_seconds <= 0 or resets_in_seconds <= 0:
+        return None
+    remaining_time_frac = min(1.0, resets_in_seconds / window_seconds)
+    elapsed_frac = 1.0 - remaining_time_frac
+    gap = utilization - elapsed_frac
+    if gap > 0.05:
+        status = "overusing"
+    elif gap < -0.05:
+        status = "underusing"
+    else:
+        status = "on_track"
+    return elapsed_frac, gap, status
+
+
+def compute_rebalance_hold_seconds(
+    pace_overage: float,
+    min_hold: int = DEFAULT_REBALANCE_MIN_HOLD,
+    max_hold: int = DEFAULT_REBALANCE_MAX_HOLD,
+    target_utilization: float = DEFAULT_REBALANCE_TARGET_UTILIZATION,
+) -> int:
+    """Estimate how long to rest a subscription until pacing catches up.
+
+    Args:
+        pace_overage: Positive gap from ``compute_window_pacing``.
+        min_hold: Minimum hold time in seconds.
+        max_hold: Maximum hold time in seconds.
+        target_utilization: Target utilization fraction.
+
+    Returns:
+        Hold duration in seconds, clamped to ``[min_hold, max_hold]``.
+    """
+    if pace_overage <= 0:
+        return min_hold
+    weekly_window_seconds = 7 * 24 * 3600
+    catch_up_seconds = int(
+        pace_overage * weekly_window_seconds / target_utilization
+    )
+    return max(min_hold, min(max_hold, catch_up_seconds))
+
+
+# --- Rebalance state persistence ---
+
+
+def load_rebalance_state(
+    state_path: Path,
+) -> dict[str, object] | None:
+    """Load rebalance state from a JSON file.
+
+    Args:
+        state_path: Path to the state JSON file.
+
+    Returns:
+        Parsed dict, or None if file doesn't exist or is invalid.
+    """
+    if not state_path.exists():
+        return None
+    try:
+        raw = state_path.read_text()
+        if not raw.strip():
+            return None
+        return json.loads(raw)
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def save_rebalance_state(
+    state_path: Path,
+    decision: dict[str, object],
+) -> None:
+    """Persist a rebalance decision to a JSON file.
+
+    Args:
+        state_path: Path to write the state JSON file.
+        decision: Dict with rebalance decision fields.
+    """
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps(decision, indent=2) + "\n")
+
+
+def clear_rebalance_state(state_path: Path) -> None:
+    """Remove a persisted rebalance state file.
+
+    Args:
+        state_path: Path to the state JSON file to remove.
+    """
+    if state_path.exists():
+        state_path.unlink()
+
+
+# --- Fallback routing ---
+
+
+def capacity_aware_fallback_order(
+    fallback_order: list[str],
+    obs_dir: Path,
+    now: datetime | None = None,
+    unknown_pressure: float = DEFAULT_UNKNOWN_FALLBACK_PRESSURE,
+    soon_to_expire_threshold: float = DEFAULT_SOON_TO_EXPIRE_THRESHOLD,
+    expiring_capacity_credit: float = DEFAULT_EXPIRING_CAPACITY_CREDIT,
+) -> list[str]:
+    """Return ``fallback_order`` sorted by pressure, then expiring capacity.
+
+    Unknown usage gets ``unknown_pressure`` so stale/missing observations
+    don't look better than a known low-pressure slot. Soon-to-expire capacity
+    gets a bounded credit, enough to prefer moderately used expiring quota
+    but not enough to keep hammering an 80% slot when another sits around 20%.
+
+    Args:
+        fallback_order: Initial ordered list of subscription names.
+        obs_dir: Observation directory (passed to ``load_sub_observations``).
+        now: Current time. Defaults to UTC now.
+        unknown_pressure: Pressure score assigned when no observation exists.
+        soon_to_expire_threshold: Seconds remaining for expiry credit to apply.
+        expiring_capacity_credit: Max credit applied to expiring capacity.
+
+    Returns:
+        Reordered fallback list (ascending pressure, then expiring capacity).
+    """
+    current_time = now or datetime.now(timezone.utc)
+    observations = load_sub_observations(obs_dir)
+
+    def score(sub: str) -> tuple[float, float]:
+        entry = observations.get(sub)
+        if entry is None:
+            return unknown_pressure, float("inf")
+        pressure = pressure_from_observation(
+            entry, "seven_day", 7 * 24 * 3600, now=current_time
+        )
+        if pressure is None:
+            return unknown_pressure, float("inf")
+        remaining = remaining_until_observed_reset(
+            entry, "seven_day", 7 * 24 * 3600, now=current_time
+        )
+        if remaining is None:
+            return pressure, float("inf")
+        expiry_credit = 0.0
+        if remaining < soon_to_expire_threshold:
+            expiry_credit = expiring_capacity_credit * (
+                1.0 - (remaining / soon_to_expire_threshold)
+            )
+        rounded_remaining = round(remaining / 3600) * 3600
+        return pressure - expiry_credit, rounded_remaining
+
+    return sorted(fallback_order, key=score)
+
+
+def best_lower_pressure_fallback(
+    active: str,
+    active_usage: dict,
+    fallback_order: list[str],
+    obs_dir: Path,
+    now: datetime | None = None,
+    min_pressure: float = DEFAULT_CAPACITY_REBALANCE_MIN_PRESSURE,
+    margin: float = DEFAULT_CAPACITY_REBALANCE_MARGIN,
+) -> tuple[str, float, float] | None:
+    """Return a fallback with materially lower pressure than the active sub.
+
+    Args:
+        active: Current active subscription name.
+        active_usage: Usage snapshot for the active subscription.
+        fallback_order: Ordered list of fallback subscription names.
+        obs_dir: Observation directory for pressure lookups.
+        now: Current time.
+        min_pressure: Active must have pressure above this to consider swap.
+        margin: Minimum pressure difference required.
+
+    Returns:
+        ``(fallback_name, active_pressure, fallback_pressure)`` or None.
+    """
+    current_time = now or datetime.now(timezone.utc)
+    active_pressure = subscription_pressure_from_usage(active_usage)
+    if active_pressure is None or active_pressure < min_pressure:
+        return None
+
+    observations = load_sub_observations(obs_dir)
+    best: tuple[str, float] | None = None
+    for sub in capacity_aware_fallback_order(
+        fallback_order, obs_dir, now=current_time
+    ):
+        if sub == active:
+            continue
+        entry = observations.get(sub)
+        if entry is None:
+            continue
+        pressure = pressure_from_observation(
+            entry, "seven_day", 7 * 24 * 3600, now=current_time
+        )
+        if pressure is None:
+            continue
+        if active_pressure - pressure < margin:
+            continue
+        if best is None or pressure < best[1]:
+            best = (sub, pressure)
+
+    if best is None:
+        return None
+    return best[0], active_pressure, best[1]
+
+
+def soonest_resetting_fallback(
+    active: str,
+    fallback_order: list[str],
+    obs_dir: Path,
+    window_seconds: int = 7 * 24 * 3600,
+    now: datetime | None = None,
+) -> str | None:
+    """Find the fallback with the soonest scheduled reset.
+
+    Useful for forward routing: proactively spread quota across subscriptions
+    by picking the one that will reset first.
+
+    Args:
+        active: Skip this subscription (current active).
+        fallback_order: Ordered list to search.
+        obs_dir: Observation directory.
+        window_seconds: Window duration for reset calculation.
+        now: Current time.
+
+    Returns:
+        Subscription name with the soonest reset, or None if no data.
+    """
+    current_time = now or datetime.now(timezone.utc)
+    observations = load_sub_observations(obs_dir)
+    best: tuple[str, float] | None = None
+    for sub in fallback_order:
+        if sub == active:
+            continue
+        entry = observations.get(sub)
+        if entry is None:
+            continue
+        remaining = remaining_until_observed_reset(
+            entry, "seven_day", window_seconds, now=current_time
+        )
+        if remaining is None:
+            continue
+        if best is None or remaining < best[1]:
+            best = (sub, remaining)
+    return best[0] if best else None

--- a/packages/gptme-subscription/src/gptme_subscription/routing.py
+++ b/packages/gptme-subscription/src/gptme_subscription/routing.py
@@ -10,17 +10,16 @@ import json
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
 
 from gptme_subscription.observation import (
-    DEFAULT_REBALANCE_MIN_HOLD,
-    DEFAULT_REBALANCE_MAX_HOLD,
-    DEFAULT_REBALANCE_TARGET_UTILIZATION,
-    DEFAULT_UNKNOWN_FALLBACK_PRESSURE,
-    DEFAULT_SOON_TO_EXPIRE_THRESHOLD,
-    DEFAULT_EXPIRING_CAPACITY_CREDIT,
-    DEFAULT_CAPACITY_REBALANCE_MIN_PRESSURE,
     DEFAULT_CAPACITY_REBALANCE_MARGIN,
+    DEFAULT_CAPACITY_REBALANCE_MIN_PRESSURE,
+    DEFAULT_EXPIRING_CAPACITY_CREDIT,
+    DEFAULT_REBALANCE_MAX_HOLD,
+    DEFAULT_REBALANCE_MIN_HOLD,
+    DEFAULT_REBALANCE_TARGET_UTILIZATION,
+    DEFAULT_SOON_TO_EXPIRE_THRESHOLD,
+    DEFAULT_UNKNOWN_FALLBACK_PRESSURE,
     load_sub_observations,
     pressure_from_observation,
     remaining_until_observed_reset,
@@ -93,6 +92,7 @@ def compute_rebalance_hold_seconds(
     min_hold: int = DEFAULT_REBALANCE_MIN_HOLD,
     max_hold: int = DEFAULT_REBALANCE_MAX_HOLD,
     target_utilization: float = DEFAULT_REBALANCE_TARGET_UTILIZATION,
+    window_seconds: int = 7 * 24 * 3600,
 ) -> int:
     """Estimate how long to rest a subscription until pacing catches up.
 
@@ -101,16 +101,14 @@ def compute_rebalance_hold_seconds(
         min_hold: Minimum hold time in seconds.
         max_hold: Maximum hold time in seconds.
         target_utilization: Target utilization fraction.
+        window_seconds: Duration of the quota window (default 7 days).
 
     Returns:
         Hold duration in seconds, clamped to ``[min_hold, max_hold]``.
     """
     if pace_overage <= 0:
         return min_hold
-    weekly_window_seconds = 7 * 24 * 3600
-    catch_up_seconds = int(
-        pace_overage * weekly_window_seconds / target_utilization
-    )
+    catch_up_seconds = int(pace_overage * window_seconds / target_utilization)
     return max(min_hold, min(max_hold, catch_up_seconds))
 
 
@@ -173,6 +171,7 @@ def capacity_aware_fallback_order(
     unknown_pressure: float = DEFAULT_UNKNOWN_FALLBACK_PRESSURE,
     soon_to_expire_threshold: float = DEFAULT_SOON_TO_EXPIRE_THRESHOLD,
     expiring_capacity_credit: float = DEFAULT_EXPIRING_CAPACITY_CREDIT,
+    observations: dict[str, object] | None = None,
 ) -> list[str]:
     """Return ``fallback_order`` sorted by pressure, then expiring capacity.
 
@@ -188,12 +187,14 @@ def capacity_aware_fallback_order(
         unknown_pressure: Pressure score assigned when no observation exists.
         soon_to_expire_threshold: Seconds remaining for expiry credit to apply.
         expiring_capacity_credit: Max credit applied to expiring capacity.
+        observations: Pre-loaded observations dict. If None, loads from obs_dir.
 
     Returns:
         Reordered fallback list (ascending pressure, then expiring capacity).
     """
     current_time = now or datetime.now(timezone.utc)
-    observations = load_sub_observations(obs_dir)
+    if observations is None:
+        observations = load_sub_observations(obs_dir)
 
     def score(sub: str) -> tuple[float, float]:
         entry = observations.get(sub)
@@ -251,7 +252,7 @@ def best_lower_pressure_fallback(
     observations = load_sub_observations(obs_dir)
     best: tuple[str, float] | None = None
     for sub in capacity_aware_fallback_order(
-        fallback_order, obs_dir, now=current_time
+        fallback_order, obs_dir, now=current_time, observations=observations
     ):
         if sub == active:
             continue

--- a/packages/gptme-subscription/src/gptme_subscription/routing.py
+++ b/packages/gptme-subscription/src/gptme_subscription/routing.py
@@ -20,6 +20,7 @@ from gptme_subscription.observation import (
     DEFAULT_REBALANCE_TARGET_UTILIZATION,
     DEFAULT_SOON_TO_EXPIRE_THRESHOLD,
     DEFAULT_UNKNOWN_FALLBACK_PRESSURE,
+    SubscriptionObservation,
     load_sub_observations,
     pressure_from_observation,
     remaining_until_observed_reset,
@@ -132,7 +133,9 @@ def load_rebalance_state(
         raw = state_path.read_text()
         if not raw.strip():
             return None
-        return json.loads(raw)
+        result = json.loads(raw)
+        assert isinstance(result, dict)
+        return result
     except (json.JSONDecodeError, OSError):
         return None
 
@@ -171,7 +174,7 @@ def capacity_aware_fallback_order(
     unknown_pressure: float = DEFAULT_UNKNOWN_FALLBACK_PRESSURE,
     soon_to_expire_threshold: float = DEFAULT_SOON_TO_EXPIRE_THRESHOLD,
     expiring_capacity_credit: float = DEFAULT_EXPIRING_CAPACITY_CREDIT,
-    observations: dict[str, object] | None = None,
+    observations: dict[str, SubscriptionObservation] | None = None,
 ) -> list[str]:
     """Return ``fallback_order`` sorted by pressure, then expiring capacity.
 

--- a/packages/gptme-subscription/src/gptme_subscription/routing.py
+++ b/packages/gptme-subscription/src/gptme_subscription/routing.py
@@ -7,6 +7,7 @@ and how to manage persistent rebalance state.
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -133,22 +134,23 @@ def load_rebalance_state(
         raw = state_path.read_text()
         if not raw.strip():
             return None
-        result = json.loads(raw)
-        assert isinstance(result, dict)
-        return result
+        data = json.loads(raw)
+        if not isinstance(data, dict):
+            return None
+        return {str(key): value for key, value in data.items()}
     except (json.JSONDecodeError, OSError):
         return None
 
 
 def save_rebalance_state(
     state_path: Path,
-    decision: dict[str, object],
+    decision: Mapping[str, object],
 ) -> None:
     """Persist a rebalance decision to a JSON file.
 
     Args:
         state_path: Path to write the state JSON file.
-        decision: Dict with rebalance decision fields.
+        decision: Mapping with rebalance decision fields.
     """
     state_path.parent.mkdir(parents=True, exist_ok=True)
     state_path.write_text(json.dumps(decision, indent=2) + "\n")
@@ -174,7 +176,7 @@ def capacity_aware_fallback_order(
     unknown_pressure: float = DEFAULT_UNKNOWN_FALLBACK_PRESSURE,
     soon_to_expire_threshold: float = DEFAULT_SOON_TO_EXPIRE_THRESHOLD,
     expiring_capacity_credit: float = DEFAULT_EXPIRING_CAPACITY_CREDIT,
-    observations: dict[str, SubscriptionObservation] | None = None,
+    observations: Mapping[str, SubscriptionObservation] | None = None,
 ) -> list[str]:
     """Return ``fallback_order`` sorted by pressure, then expiring capacity.
 

--- a/packages/gptme-subscription/src/gptme_subscription/routing.py
+++ b/packages/gptme-subscription/src/gptme_subscription/routing.py
@@ -284,6 +284,7 @@ def soonest_resetting_fallback(
     fallback_order: list[str],
     obs_dir: Path,
     window_seconds: int = 7 * 24 * 3600,
+    metric_key: str = "seven_day",
     now: datetime | None = None,
 ) -> str | None:
     """Find the fallback with the soonest scheduled reset.
@@ -295,7 +296,11 @@ def soonest_resetting_fallback(
         active: Skip this subscription (current active).
         fallback_order: Ordered list to search.
         obs_dir: Observation directory.
-        window_seconds: Window duration for reset calculation.
+        window_seconds: Window duration for reset calculation. Must match the
+            window duration implied by ``metric_key`` (e.g. 7*24*3600 for
+            ``"seven_day"``).
+        metric_key: Which metric key to look up in observation state.
+            Must correspond to the same window as ``window_seconds``.
         now: Current time.
 
     Returns:
@@ -311,7 +316,7 @@ def soonest_resetting_fallback(
         if entry is None:
             continue
         remaining = remaining_until_observed_reset(
-            entry, "seven_day", window_seconds, now=current_time
+            entry, metric_key, window_seconds, now=current_time
         )
         if remaining is None:
             continue

--- a/packages/gptme-subscription/tests/test_observation.py
+++ b/packages/gptme-subscription/tests/test_observation.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from gptme_subscription.observation import (
     format_duration,
     is_subscription_blocked,
+    load_sub_observations,
     record_sub_reset_time,
     subscription_pressure_from_usage,
 )
@@ -164,6 +165,18 @@ class TestSubscriptionPressureFromUsage:
         usage = {"seven_day_sonnet": {"utilization": 0.75}}
         score = subscription_pressure_from_usage(usage, sonnet_weekly_exhausted=0.75)
         assert score == 1.0
+
+
+class TestLoadSubObservations:
+    def test_skips_non_dict_json(self, tmp_path: Path) -> None:
+        # A valid JSON array is not a dict — should be skipped, not crash
+        (tmp_path / "bob.json").write_text("[1, 2, 3]")
+        (tmp_path / "alice.json").write_text(
+            '{"track_resets": {"seven_day": "2026-01-01T00:00:00+00:00"}}'
+        )
+        result = load_sub_observations(tmp_path)
+        assert "bob" not in result  # skipped
+        assert "alice" in result  # valid dict still loaded
 
 
 class TestRecordSubResetTime:

--- a/packages/gptme-subscription/tests/test_observation.py
+++ b/packages/gptme-subscription/tests/test_observation.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-
 from gptme_subscription.observation import (
     format_duration,
     is_subscription_blocked,
@@ -19,8 +17,8 @@ class TestFormatDuration:
         assert format_duration(-100) == "0m"
 
     def test_minutes_only(self) -> None:
-        assert format_duration(1800) == "30m"   # 30 * 60
-        assert format_duration(3540) == "59m"   # 59 * 60
+        assert format_duration(1800) == "30m"  # 30 * 60
+        assert format_duration(3540) == "59m"  # 59 * 60
 
     def test_hours_only(self) -> None:
         assert format_duration(3600) == "1h"

--- a/packages/gptme-subscription/tests/test_observation.py
+++ b/packages/gptme-subscription/tests/test_observation.py
@@ -180,6 +180,17 @@ class TestLoadSubObservations:
 
 
 class TestRecordSubResetTime:
+    def test_non_dict_json_is_replaced(self, tmp_path: Path) -> None:
+        obs_file = tmp_path / "bob.json"
+        obs_file.write_text("[1, 2, 3]")  # valid JSON, not a dict
+        # Should not raise — non-dict content is treated as corrupt/reset
+        record_sub_reset_time(tmp_path, "bob", "seven_day")
+        import json
+
+        data = json.loads(obs_file.read_text())
+        assert isinstance(data, dict)
+        assert "seven_day" in data["track_resets"]
+
     def test_writes_observation(self, tmp_path: Path) -> None:
         record_sub_reset_time(tmp_path, "bob", "seven_day", "2026-01-01T00:00:00+00:00")
         data = (tmp_path / "bob.json").read_text()

--- a/packages/gptme-subscription/tests/test_observation.py
+++ b/packages/gptme-subscription/tests/test_observation.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from gptme_subscription.observation import (
     format_duration,
     is_subscription_blocked,
+    record_sub_reset_time,
     subscription_pressure_from_usage,
 )
 
@@ -149,3 +152,33 @@ class TestSubscriptionPressureFromUsage:
         usage: dict = {}
         score = subscription_pressure_from_usage(usage)
         assert score is None
+
+    def test_sonnet_weekly_uses_separate_threshold(self) -> None:
+        # Sonnet at 90% — above sonnet_weekly_exhausted (0.85) but below weekly_exhausted (0.95).
+        # Should report pressure=1.0, not 0.9 (regression: was using wrong threshold).
+        usage = {"seven_day_sonnet": {"utilization": 0.90}}
+        score = subscription_pressure_from_usage(usage)
+        assert score == 1.0
+
+    def test_sonnet_weekly_threshold_override(self) -> None:
+        usage = {"seven_day_sonnet": {"utilization": 0.75}}
+        score = subscription_pressure_from_usage(usage, sonnet_weekly_exhausted=0.75)
+        assert score == 1.0
+
+
+class TestRecordSubResetTime:
+    def test_writes_observation(self, tmp_path: Path) -> None:
+        record_sub_reset_time(tmp_path, "bob", "seven_day", "2026-01-01T00:00:00+00:00")
+        data = (tmp_path / "bob.json").read_text()
+        assert "seven_day" in data
+
+    def test_corrupt_file_does_not_raise(self, tmp_path: Path) -> None:
+        obs_file = tmp_path / "bob.json"
+        obs_file.write_text("CORRUPT {{{")
+        # Should not raise — corrupt file is silently reset
+        record_sub_reset_time(tmp_path, "bob", "seven_day")
+        import json
+
+        data = json.loads(obs_file.read_text())
+        assert "track_resets" in data
+        assert "seven_day" in data["track_resets"]

--- a/packages/gptme-subscription/tests/test_observation.py
+++ b/packages/gptme-subscription/tests/test_observation.py
@@ -132,6 +132,19 @@ class TestSubscriptionPressureFromUsage:
         assert score is not None
         assert score == 0.9  # max of 0.3 and 0.9
 
+    def test_weekly_threshold_override_treats_value_as_exhausted(self) -> None:
+        usage = {"seven_day": {"utilization": 0.8}}
+        score = subscription_pressure_from_usage(usage, weekly_exhausted=0.8)
+        assert score == 1.0
+
+    def test_5h_threshold_override_treats_value_as_exhausted(self) -> None:
+        usage = {
+            "seven_day": {"utilization": 0.1},
+            "five_hour": {"utilization": 0.7, "resets_in_seconds": 7201},
+        }
+        score = subscription_pressure_from_usage(usage, five_hour_threshold=0.7)
+        assert score == 1.0
+
     def test_no_usage_data_returns_none(self) -> None:
         usage: dict = {}
         score = subscription_pressure_from_usage(usage)

--- a/packages/gptme-subscription/tests/test_observation.py
+++ b/packages/gptme-subscription/tests/test_observation.py
@@ -1,0 +1,140 @@
+"""Tests for gptme_subscription.observation."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from gptme_subscription.observation import (
+    format_duration,
+    is_subscription_blocked,
+    subscription_pressure_from_usage,
+)
+
+
+class TestFormatDuration:
+    def test_zero(self) -> None:
+        assert format_duration(0) == "0m"
+
+    def test_negative(self) -> None:
+        assert format_duration(-100) == "0m"
+
+    def test_minutes_only(self) -> None:
+        assert format_duration(1800) == "30m"   # 30 * 60
+        assert format_duration(3540) == "59m"   # 59 * 60
+
+    def test_hours_only(self) -> None:
+        assert format_duration(3600) == "1h"
+        assert format_duration(7200) == "2h"
+
+    def test_hours_and_minutes(self) -> None:
+        assert format_duration(3661) == "1h01m"
+        assert format_duration(7260) == "2h01m"
+
+
+class TestIsSubscriptionBlocked:
+    def test_healthy_not_blocked(self) -> None:
+        usage = {
+            "seven_day": {"utilization": 0.3},
+            "five_hour": {"utilization": 0.1},
+            "seven_day_sonnet": {"utilization": 0.2},
+        }
+        blocked, reason = is_subscription_blocked(usage)
+        assert not blocked
+        assert "healthy" in reason
+
+    def test_opus_exhausted_blocked(self) -> None:
+        usage = {
+            "seven_day": {"utilization": 0.99},
+            "five_hour": {"utilization": 0.99},
+            "seven_day_sonnet": {"utilization": 0.2},
+        }
+        blocked, reason = is_subscription_blocked(usage)
+        assert blocked
+        assert "Opus" in reason
+
+    def test_weekly_high_5h_low_not_opus_blocked(self) -> None:
+        usage = {
+            "seven_day": {"utilization": 0.99},
+            "five_hour": {"utilization": 0.3},
+            "seven_day_sonnet": {"utilization": 0.2},
+        }
+        blocked, _reason = is_subscription_blocked(usage)
+        assert not blocked
+
+    def test_sonnet_exhausted_blocked(self) -> None:
+        usage = {
+            "seven_day": {"utilization": 0.3},
+            "five_hour": {"utilization": 0.1},
+            "seven_day_sonnet": {"utilization": 0.99},
+        }
+        blocked, reason = is_subscription_blocked(usage)
+        assert blocked
+        assert "Sonnet" in reason
+
+    def test_sonnet_missing_weekly_high_conservative_block(self) -> None:
+        usage = {
+            "seven_day": {"utilization": 0.99},
+            "five_hour": {"utilization": 0.99},
+        }
+        blocked, reason = is_subscription_blocked(usage)
+        assert blocked
+        assert "Sonnet data missing" in reason
+
+    def test_sonnet_missing_weekly_low_not_blocked(self) -> None:
+        usage = {
+            "seven_day": {"utilization": 0.3},
+            "five_hour": {"utilization": 0.1},
+        }
+        blocked, _reason = is_subscription_blocked(usage)
+        assert not blocked
+
+    def test_both_opus_and_sonnet_exhausted(self) -> None:
+        usage = {
+            "seven_day": {"utilization": 0.99},
+            "five_hour": {"utilization": 0.99},
+            "seven_day_sonnet": {"utilization": 0.99},
+        }
+        blocked, reason = is_subscription_blocked(usage)
+        assert blocked
+        assert "Opus" in reason
+        assert "Sonnet" in reason
+
+
+class TestSubscriptionPressureFromUsage:
+    def test_weekly_only(self) -> None:
+        usage = {"seven_day": {"utilization": 0.75}}
+        score = subscription_pressure_from_usage(usage)
+        assert score is not None
+        assert score == 0.75
+
+    def test_weekly_and_sonnet(self) -> None:
+        usage = {
+            "seven_day": {"utilization": 0.6},
+            "seven_day_sonnet": {"utilization": 0.8},
+        }
+        score = subscription_pressure_from_usage(usage)
+        assert score is not None
+        assert score == 0.8  # max of components
+
+    def test_5h_within_short_reset_window_excluded(self) -> None:
+        usage = {
+            "seven_day": {"utilization": 0.3},
+            "five_hour": {"utilization": 0.9, "resets_in_seconds": 600},
+        }
+        score = subscription_pressure_from_usage(usage)
+        assert score is not None
+        assert score == 0.3  # 5h excluded, only weekly counts
+
+    def test_5h_past_short_reset_window_included(self) -> None:
+        usage = {
+            "seven_day": {"utilization": 0.3},
+            "five_hour": {"utilization": 0.9, "resets_in_seconds": 7201},
+        }
+        score = subscription_pressure_from_usage(usage)
+        assert score is not None
+        assert score == 0.9  # max of 0.3 and 0.9
+
+    def test_no_usage_data_returns_none(self) -> None:
+        usage: dict = {}
+        score = subscription_pressure_from_usage(usage)
+        assert score is None

--- a/packages/gptme-subscription/tests/test_routing.py
+++ b/packages/gptme-subscription/tests/test_routing.py
@@ -1,0 +1,106 @@
+"""Tests for gptme_subscription.routing."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from gptme_subscription.routing import (
+    compute_window_pacing,
+    compute_rebalance_hold_seconds,
+    load_rebalance_state,
+    save_rebalance_state,
+    clear_rebalance_state,
+)
+
+
+WEEK = 7 * 24 * 3600
+
+
+class TestComputeWindowPacing:
+    def test_on_pace_mid_window(self) -> None:
+        """50% used at 50% time elapsed = on track."""
+        result = compute_window_pacing(0.5, int(WEEK * 0.5), WEEK)
+        assert result is not None
+        _, gap, status = result
+        assert abs(gap) <= 0.05
+        assert status == "on_track"
+
+    def test_on_pace_late_window(self) -> None:
+        """95% used with 5% time left = on pace (headroom ≈ 0)."""
+        result = compute_window_pacing(0.95, int(WEEK * 0.05), WEEK)
+        assert result is not None
+        _, gap, status = result
+        assert abs(gap) <= 0.05
+        assert status == "on_track"
+
+    def test_overusing_in_late_window(self) -> None:
+        """95% used with 20% time left = overusing."""
+        result = compute_window_pacing(0.95, int(WEEK * 0.2), WEEK)
+        assert result is not None
+        _, gap, status = result
+        assert gap > 0.05
+        assert status == "overusing"
+
+    def test_underusing_early_window(self) -> None:
+        """10% used at 50% time elapsed = underusing."""
+        result = compute_window_pacing(0.1, int(WEEK * 0.5), WEEK)
+        assert result is not None
+        _, gap, status = result
+        assert gap < -0.05
+        assert status == "underusing"
+
+    def test_returns_none_for_invalid_inputs(self) -> None:
+        assert compute_window_pacing(0.5, 0, WEEK) is None
+        assert compute_window_pacing(0.5, 3600, 0) is None
+
+
+class TestComputeRebalanceHoldSeconds:
+    def test_zero_overage_returns_min_hold(self) -> None:
+        hold = compute_rebalance_hold_seconds(0.0)
+        assert hold == 600  # REBALANCE_MIN_HOLD
+
+    def test_negative_overage_returns_min_hold(self) -> None:
+        hold = compute_rebalance_hold_seconds(-0.1)
+        assert hold == 600
+
+    def test_large_overage_clamped_to_max(self) -> None:
+        hold = compute_rebalance_hold_seconds(0.5)
+        assert hold == 7200  # REBALANCE_MAX_HOLD
+
+    def test_moderate_overage(self) -> None:
+        hold = compute_rebalance_hold_seconds(0.05)
+        assert 600 <= hold <= 7200
+
+
+class TestRebalanceStatePersistence:
+    def test_save_and_load_roundtrip(self, tmp_path: Path) -> None:
+        state_path = tmp_path / "rebalance.json"
+        decision = {
+            "switched_to": "alice",
+            "switched_from": "bob",
+            "reason": "weekly exhausted",
+            "switched_at": "2026-05-05T12:00:00+00:00",
+            "hold_until": "2026-05-05T14:00:00+00:00",
+        }
+        save_rebalance_state(state_path, decision)
+        assert state_path.exists()
+        loaded = load_rebalance_state(state_path)
+        assert loaded is not None
+        assert loaded["switched_to"] == "alice"
+        assert loaded["reason"] == "weekly exhausted"
+
+    def test_load_nonexistent_returns_none(self, tmp_path: Path) -> None:
+        result = load_rebalance_state(tmp_path / "nonexistent.json")
+        assert result is None
+
+    def test_clear_rebalance_state(self, tmp_path: Path) -> None:
+        state_path = tmp_path / "rebalance.json"
+        save_rebalance_state(state_path, {"switched_to": "alice"})
+        assert state_path.exists()
+        clear_rebalance_state(state_path)
+        assert not state_path.exists()
+
+    def test_clear_nonexistent_does_not_error(self, tmp_path: Path) -> None:
+        clear_rebalance_state(tmp_path / "nonexistent.json")

--- a/packages/gptme-subscription/tests/test_routing.py
+++ b/packages/gptme-subscription/tests/test_routing.py
@@ -2,18 +2,15 @@
 
 from __future__ import annotations
 
-import json
-from datetime import datetime, timezone
 from pathlib import Path
 
 from gptme_subscription.routing import (
-    compute_window_pacing,
+    clear_rebalance_state,
     compute_rebalance_hold_seconds,
+    compute_window_pacing,
     load_rebalance_state,
     save_rebalance_state,
-    clear_rebalance_state,
 )
-
 
 WEEK = 7 * 24 * 3600
 

--- a/packages/gptme-subscription/tests/test_routing.py
+++ b/packages/gptme-subscription/tests/test_routing.py
@@ -74,7 +74,7 @@ class TestComputeRebalanceHoldSeconds:
 class TestRebalanceStatePersistence:
     def test_save_and_load_roundtrip(self, tmp_path: Path) -> None:
         state_path = tmp_path / "rebalance.json"
-        decision = {
+        decision: dict[str, object] = {
             "switched_to": "alice",
             "switched_from": "bob",
             "reason": "weekly exhausted",

--- a/uv.lock
+++ b/uv.lock
@@ -42,8 +42,6 @@ members = [
     "gptme-wrapped",
     "gptme-youtube",
     "gptodo",
-    "subscription-management",
-    "subscription-manager",
 ]
 
 [[package]]
@@ -4669,42 +4667,6 @@ name = "strict-rfc3339"
 version = "0.7"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/56/e4/879ef1dbd6ddea1c77c0078cd59b503368b0456bcca7d063a870ca2119d3/strict-rfc3339-0.7.tar.gz", hash = "sha256:5cad17bedfc3af57b399db0fed32771f18fc54bbd917e85546088607ac5e1277", size = 17552, upload-time = "2016-04-24T04:24:04.403Z" }
-
-[[package]]
-name = "subscription-management"
-version = "0.1.0"
-source = { editable = "packages/subscription-management" }
-
-[package.optional-dependencies]
-test = [
-    { name = "pytest" },
-    { name = "pytest-cov" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
-    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.0" },
-]
-provides-extras = ["test"]
-
-[[package]]
-name = "subscription-manager"
-version = "0.1.0"
-source = { editable = "packages/subscription-manager" }
-
-[package.optional-dependencies]
-test = [
-    { name = "pytest" },
-    { name = "pytest-cov" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
-    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.0" },
-]
-provides-extras = ["test"]
 
 [[package]]
 name = "sympy"

--- a/uv.lock
+++ b/uv.lock
@@ -33,6 +33,7 @@ members = [
     "gptme-retrieval",
     "gptme-runloops",
     "gptme-sessions",
+    "gptme-subscription",
     "gptme-tts",
     "gptme-user-memories",
     "gptme-voice",
@@ -41,6 +42,8 @@ members = [
     "gptme-wrapped",
     "gptme-youtube",
     "gptodo",
+    "subscription-management",
+    "subscription-manager",
 ]
 
 [[package]]
@@ -1761,6 +1764,24 @@ requires-dist = [
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=1.0" },
 ]
 provides-extras = ["dev", "test"]
+
+[[package]]
+name = "gptme-subscription"
+version = "0.1.0"
+source = { editable = "packages/gptme-subscription" }
+
+[package.optional-dependencies]
+test = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
+    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.0" },
+]
+provides-extras = ["test"]
 
 [[package]]
 name = "gptme-tts"
@@ -4648,6 +4669,42 @@ name = "strict-rfc3339"
 version = "0.7"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/56/e4/879ef1dbd6ddea1c77c0078cd59b503368b0456bcca7d063a870ca2119d3/strict-rfc3339-0.7.tar.gz", hash = "sha256:5cad17bedfc3af57b399db0fed32771f18fc54bbd917e85546088607ac5e1277", size = 17552, upload-time = "2016-04-24T04:24:04.403Z" }
+
+[[package]]
+name = "subscription-management"
+version = "0.1.0"
+source = { editable = "packages/subscription-management" }
+
+[package.optional-dependencies]
+test = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
+    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.0" },
+]
+provides-extras = ["test"]
+
+[[package]]
+name = "subscription-manager"
+version = "0.1.0"
+source = { editable = "packages/subscription-manager" }
+
+[package.optional-dependencies]
+test = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
+    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.0" },
+]
+provides-extras = ["test"]
 
 [[package]]
 name = "sympy"


### PR DESCRIPTION
## Summary

New `gptme-subscription` package extracted from Bob's `manage-subscription.py` (~375 LOC of reusable logic, 1,016 LOC of Bob-specific wiring stays local).

Closes #831

### Package contents

**`gptme_subscription.observation`** — Generic subscription observation state and pressure scoring:
- `subscription_pressure_from_usage` — compact pressure score (0-1) combining weekly, Sonnet-weekly, and 5h signals
- `is_subscription_blocked` — independent limit checks (Opus weekly+5h, Sonnet weekly, conservative fallback)
- `record_sub_reset_time` / `load_sub_observations` / `pressure_from_observation` — persistent observation state
- `format_duration` — compact human-readable duration formatting

**`gptme_subscription.routing`** — Capacity-aware fallback routing and rebalance state machine:
- `capacity_aware_fallback_order` — sort fallbacks by pressure with expiring-capacity credit
- `best_lower_pressure_fallback` — find materially lower-pressure alternative slot
- `soonest_resetting_fallback` — forward-route to soonest-resetting subscription
- `compute_window_pacing` — headroom pacing model (elapsed_frac, gap, status)
- `compute_rebalance_hold_seconds` — estimate rest duration from pace overage
- `load_rebalance_state` / `save_rebalance_state` / `clear_rebalance_state` — persistent rebalance decisions

### Tests

30 tests passing (`pytest packages/gptme-subscription/tests/ -v\'), covering format_duration, is_subscription_blocked, subscription_pressure_from_usage, compute_window_pacing, compute_rebalance_hold_seconds, and rebalance state persistence round-trips.

### Next steps

Bob's `manage-subscription.py` will be refactored in a follow-up to import from `credential-slots` + `gptme-subscription`, making it a thin workspace wrapper.
