### PR TITLE
refactor(sessions): rename 'monitoring' category to 'pm-react'

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/classification.py
+++ b/packages/gptme-sessions/src/gptme_sessions/classification.py
@@ -345,9 +345,10 @@ DEFAULT_CATEGORIES: list[Category] = [
         ],
     ),
     Category(
-        name="monitoring",
-        description="PR monitoring, notification handling, CI checks",
+        name="pm-react",
+        description="Project-monitoring / notification reaction (was 'monitoring')",
         title_keywords=[
+            "pm-react",
             "monitoring",
             "notification",
             "pr review",
@@ -359,12 +360,14 @@ DEFAULT_CATEGORIES: list[Category] = [
             "prs reviewed",
             "ci checked",
             "monitoring complete",
+            "pm-react",
         ],
         execution_keywords=[
             "checked notifications",
             "reviewed pr",
             "ci status",
             "monitoring run",
+            "pm-react",
         ],
         deliverable_keywords=[
             "review comment",

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -2102,10 +2102,10 @@ def classify_stats(
         if len(recent_cats) >= 3 and len(set(recent_cats[-3:])) == 1:
             alerts.append(f"3+ consecutive '{recent_cats[-1]}' sessions — consider diversifying")
 
-        non_code = sum(1 for c in recent_cats if c in ("triage", "monitoring"))
+        non_code = sum(1 for c in recent_cats if c in ("triage", "pm-react"))
         if non_code >= 3:
             alerts.append(
-                f"{non_code}/{diversity_window} sessions were triage/monitoring — pivot to code or ideas"
+                f"{non_code}/{diversity_window} sessions were triage/pm-react — pivot to code or ideas"
             )
 
         code_sessions = sum(1 for c in recent_cats if c == "code")

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -411,7 +411,7 @@ def grade_signals(signals: dict, *, category: str | None = None) -> float:
     # Categories where gh_interactions and file_writes are the PRIMARY output,
     # not commits. For these, a single useful interaction is sufficient for the
     # 0.55 "active" tier — don't floor-grade productive review/triage sessions.
-    _NON_COMMIT_CATS = {"monitoring", "research", "triage", "social", "self-review"}
+    _NON_COMMIT_CATS = {"pm-react", "research", "triage", "social", "self-review"}
     is_non_commit_category = category in _NON_COMMIT_CATS
 
     if effective_units == 0 and writes == 0 and gh_interactions == 0:
@@ -1542,7 +1542,7 @@ def infer_category(signals: dict) -> str | None:
     # that post one incidental comment while doing something else.
     # Checked before vote count so commit-free review sessions aren't left uncategorised.
     if signals.get("gh_interactions", 0) >= 2 and not commits and not file_writes:
-        return "monitoring"
+        return "pm-react"
 
     if not votes:
         return None

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -1493,7 +1493,7 @@ def test_grade_signals_monitoring_no_work_with_errors():
     assert grade_signals(sigs) == pytest.approx(0.15)
     # With monitoring category: neutral 0.35 floor, same error penalty
     # 0.35 - 0.10 = 0.25 — improved from 0.15 without the fix
-    assert grade_signals(sigs, category="monitoring") == pytest.approx(0.25)
+    assert grade_signals(sigs, category="pm-react") == pytest.approx(0.25)
     # For monitoring with very low errors (<5%): full neutral 0.35
     sigs_low_err = {
         "git_commits": [],
@@ -1502,7 +1502,7 @@ def test_grade_signals_monitoring_no_work_with_errors():
         "retry_count": 0,
         "tool_calls": {"Bash": 8},
     }
-    assert grade_signals(sigs_low_err, category="monitoring") == pytest.approx(0.35)
+    assert grade_signals(sigs_low_err, category="pm-react") == pytest.approx(0.35)
 
 
 def test_grade_signals_productive():
@@ -7174,7 +7174,7 @@ def test_grade_signals_category_aware_monitoring():
     # Without category: effective_writes=2 < 3 → floor at 0.40
     assert grade_signals(sigs) == pytest.approx(0.40)
     # With monitoring category: any interaction clears 0.55 tier
-    assert grade_signals(sigs, category="monitoring") == pytest.approx(0.55)
+    assert grade_signals(sigs, category="pm-react") == pytest.approx(0.55)
 
 
 def test_grade_signals_category_aware_triage():
@@ -7208,7 +7208,7 @@ def test_grade_signals_category_aware_no_interaction():
     # Monitoring sessions that ran tools without errors but found no work are
     # "correctly empty" rather than failed. They get a neutral 0.35 instead
     # of the 0.25 floor to avoid systematic bias in bandit updates.
-    assert grade_signals(sigs, category="monitoring") == pytest.approx(0.35)
+    assert grade_signals(sigs, category="pm-react") == pytest.approx(0.35)
 
 
 def test_grade_signals_category_aware_no_interaction_with_errors():
@@ -7230,7 +7230,7 @@ def test_grade_signals_category_aware_no_interaction_with_errors():
         "prs_submitted": [],
         "issues_closed": 0,
     }
-    assert grade_signals(sigs, category="monitoring") == pytest.approx(0.35)
+    assert grade_signals(sigs, category="pm-react") == pytest.approx(0.35)
 
 
 def test_grade_signals_category_does_not_affect_commit_tiers():
@@ -7247,7 +7247,7 @@ def test_grade_signals_category_does_not_affect_commit_tiers():
     }
     # effective_units=1 < 1.5 → 0.60 regardless of category
     assert grade_signals(sigs) == pytest.approx(0.60)
-    assert grade_signals(sigs, category="monitoring") == pytest.approx(0.60)
+    assert grade_signals(sigs, category="pm-react") == pytest.approx(0.60)
 
 
 def test_grade_signals_backward_compat():
@@ -7273,7 +7273,7 @@ def test_infer_category_monitoring_fallback():
         "file_writes": [],
         "gh_interactions": 3,
     }
-    assert infer_category(sigs) == "monitoring"
+    assert infer_category(sigs) == "pm-react"
 
 
 def test_infer_category_monitoring_not_triggered_with_commits():
@@ -7312,9 +7312,9 @@ def test_grade_signals_monitoring_via_infer_category():
     }
     # Without wiring: category=None → effective_writes=2 < 3 → 0.40
     assert grade_signals(sigs, category=None) == pytest.approx(0.40)
-    # With infer_category providing "monitoring" → relaxed threshold → 0.55
+    # With infer_category providing "pm-react" → relaxed threshold → 0.55
     category = infer_category(sigs)
-    assert category == "monitoring"
+    assert category == "pm-react"
     assert grade_signals(sigs, category=category) == pytest.approx(0.55)
 
 


### PR DESCRIPTION
## Summary

Renames the session category from `"monitoring"` to `"pm-react"` (project-monitoring / notification reaction) for clarity. The old `"monitoring"` name conflated the project-monitoring service outcome with a CASCADE arm name, making session analytics harder to read.

## Changes

- **classification.py**: Renamed the `Category` entry, updated description, kept `"monitoring"` as a backward-compat keyword
- **signals.py**: Updated `_NON_COMMIT_CATS` set and `infer_category()` return value
- **cli.py**: Updated diversity checker to reference `pm-react`
- **tests**: Updated all category-related assertions to use `pm-react`

## Verification

- All 729 tests pass (`uv run pytest packages/gptme-sessions/tests/ -q`)
- 14 monitoring/pm-react-specific tests pass
- Import clean: `from gptme_sessions.classification import DEFAULT_CATEGORIES`

## Related

- Bob workspace: #736 (upstream overhaul)