### PR TITLE
fix(gptme-runloops): change monitoring CLI default backend to claude-code

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/cli.py
+++ b/packages/gptme-runloops/src/gptme_runloops/cli.py
@@ -19,14 +19,20 @@ def main():
     pass
 
 
-def _backend_option(f):
+def _backend_option(f=None, *, default: str = "gptme", note: str | None = None):
     """Shared --backend option for all commands."""
-    return click.option(
+    backends = list_backends()
+    help_text = f"Execution backend (available: {', '.join(backends)})"
+    if note:
+        help_text = f"{help_text}. {note}"
+
+    option = click.option(
         "--backend",
-        default="gptme",
-        type=click.Choice(list_backends()),
-        help=f"Execution backend (available: {', '.join(list_backends())})",
-    )(f)
+        default=default,
+        type=click.Choice(backends),
+        help=help_text,
+    )
+    return option(f) if f is not None else option
 
 
 @main.command()
@@ -175,15 +181,12 @@ def team(
     type=click.Choice(["markdown", "xml", "tool"]),
     help="Tool format override",
 )
-@click.option(
-    "--backend",
+@_backend_option(
     default="claude-code",
-    type=click.Choice(list_backends()),
-    help=(
-        "Execution backend. Monitoring defaults to claude-code because "
-        "gptme+slow-models is 100% NOOP on monitoring (82/82 sessions "
-        "over 3 days — produces analysis but zero concrete actions). "
-        f"Available: {', '.join(list_backends())}"
+    note=(
+        "Monitoring defaults to claude-code because gptme+slow-models is "
+        "100% NOOP on monitoring (82/82 sessions over 3 days — produces "
+        "analysis but zero concrete actions)"
     ),
 )
 def monitoring(

--- a/packages/gptme-runloops/src/gptme_runloops/cli.py
+++ b/packages/gptme-runloops/src/gptme_runloops/cli.py
@@ -175,7 +175,17 @@ def team(
     type=click.Choice(["markdown", "xml", "tool"]),
     help="Tool format override",
 )
-@_backend_option
+@click.option(
+    "--backend",
+    default="claude-code",
+    type=click.Choice(list_backends()),
+    help=(
+        "Execution backend. Monitoring defaults to claude-code because "
+        "gptme+slow-models is 100% NOOP on monitoring (82/82 sessions "
+        "over 3 days — produces analysis but zero concrete actions). "
+        f"Available: {', '.join(list_backends())}"
+    ),
+)
 def monitoring(
     workspace: Path,
     orgs: tuple[str, ...],
@@ -186,7 +196,14 @@ def monitoring(
     tool_format: str | None,
     backend: str,
 ):
-    """Run project monitoring loop."""
+    """Run project monitoring loop.
+
+    Monitoring defaults to claude-code (not gptme) because the gptme
+    harness with slower/larger models historically produced 100% NOOP
+    sessions — verbose analysis output with zero commits or tool actions.
+    gptme remains available as an explicit --backend gptme override for
+    testing or quota-diversion scenarios.
+    """
     executor = get_executor(backend)
     run = ProjectMonitoringRun(
         workspace,

--- a/packages/gptme-runloops/tests/test_integration.py
+++ b/packages/gptme-runloops/tests/test_integration.py
@@ -85,6 +85,30 @@ class TestCLIIntegration:
         assert result.returncode == 0
         assert "monitoring" in result.stdout.lower()
 
+    def test_cli_backend_defaults(self):
+        """Test command-specific backend defaults."""
+        from gptme_runloops.cli import autonomous, email, monitoring, team
+
+        commands = {
+            "autonomous": autonomous,
+            "email": email,
+            "team": team,
+            "monitoring": monitoring,
+        }
+        defaults = {
+            name: next(
+                param.default for param in command.params if param.name == "backend"
+            )
+            for name, command in commands.items()
+        }
+
+        assert defaults == {
+            "autonomous": "gptme",
+            "email": "gptme",
+            "team": "gptme",
+            "monitoring": "claude-code",
+        }
+
     def test_email_run_direct_instantiation(self, test_workspace: Path):
         """Test EmailRun class can be instantiated and configured."""
         from gptme_runloops.email import EmailRun


### PR DESCRIPTION
## Problem

gptme-runloops CLI `monitoring` command defaulted to `--backend gptme`, which wraps `gptme --non-interactive`. With slower/larger models like gpt-5.4, this produced **100% NOOP sessions** on monitoring (82/82 over 3 days) — verbose analysis output with zero commits, PR reviews, or tool actions.

## Fix

Changed the CLI default backend from `gptme` → `claude-code` for the monitoring command. Claude Code (sonnet) is cheaper, faster, and actually produces concrete work on monitoring sessions.

- `gptme` remains available via explicit `--backend gptme` for testing or quota-diversion scenarios
- Added inline documentation explaining the 100% NOOP history

## Verification

- `uv run python3 -m run_loops.cli monitoring --help` shows default `--backend claude-code`
- All 186 existing tests pass
- Companion bash fix in ErikBjare/bob updates `project-monitoring.sh` to explicitly pass `--backend claude-code`

## Related

- ErikBjare/bob#736
- ErikBjare/bob tasks/project-monitoring-phase3-gptme-runloops-noop.md