### PR TITLE
docs(lessons): add API-based PR check to existing-PRs lesson

### DIFF
--- a/lessons/workflow/check-existing-prs.md
+++ b/lessons/workflow/check-existing-prs.md
@@ -30,6 +30,9 @@ Check before creating:
 gh pr list --state open --search "605 in:body"
 gh pr list --state open --search "mcp config"
 
+# Also check via API for issue-linked PRs (more reliable than text search)
+gh api "repos/OWNER/REPO/issues/605" --jq '.pull_request'
+
 # If found: Review and coordinate
 # If not found: Proceed with new PR
 git checkout -b fix-issue-605


### PR DESCRIPTION
Adds a small improvement to the `check-existing-prs` lesson: an alternative method using the GitHub API to check if an issue is already linked to a PR (via `gh api` with the `pull_request` field).

This pattern is more reliable than text search when an issue reference number (e.g., `#605`) may appear in PR descriptions for unrelated reasons.