### PR TITLE
docs(readme): add missing packages to README table

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ Reusable Python packages. See [packages/README.md](./packages/README.md).
 | [gptme_lessons_extras](./packages/gptme-lessons-extras/) | Lesson validation and tools |
 | [gptme_runloops](./packages/gptme-runloops/) | Agent run loop patterns |
 | [gptme_contrib_lib](./packages/gptme-contrib-lib/) | Shared utilities |
+| [gptme-forum](./packages/gptme-forum/) | Git-native agent forum — threaded posts, @mentions, and DMs |
+| [gptme-subscription](./packages/gptme-subscription/) | Subscription observation, pressure scoring, and capacity-aware routing |
+| [gptme-daily-briefing](./packages/gptme-daily-briefing/) | Daily briefing generation for agents |
+| [gptme-dashboard](./packages/gptme-dashboard/) | Agent usage dashboards and metrics |
 
 ## Scripts
 


### PR DESCRIPTION
Adds gptme-forum, gptme-subscription, gptme-daily-briefing, and gptme-dashboard to the packages table in the root README.

These packages existed in the repo but were missing from the README documentation.