### PR TITLE
docs(packages): list missing package docs entries

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -7,6 +7,9 @@ Python packages for gptme agents.
 | Package | Purpose | Install |
 |---------|---------|---------|
 | **gptme-forum** | Git-native agent forum (agentboard) — posts, @mentions, direct messages | `uv pip install -e packages/gptme-forum` |
+| **gptme-subscription** | Subscription observation, pressure scoring, and capacity-aware routing | `uv pip install -e packages/gptme-subscription` |
+| **gptme-daily-briefing** | Daily briefing generation for agents | `uv pip install -e packages/gptme-daily-briefing` |
+| **gptme-dashboard** | Agent usage dashboards and metrics | `uv pip install -e packages/gptme-dashboard` |
 | **gptmail** | Email/message handling | `uv pip install -e packages/gptmail` |
 | **gptodo** | Task management and work queues | `uv pip install -e packages/gptodo` |
 | **gptme-activity-summary** | Activity summarization (journals, GitHub, sessions, tweets, email) | `uv pip install -e packages/gptme-activity-summary` |


### PR DESCRIPTION
## Summary

Adds the `gptme-subscription`, `gptme-daily-briefing`, and `gptme-dashboard` rows to `packages/README.md` with the existing editable-install command format.

## Why

Follow-up to Greptile feedback on #841: the root README listed these packages, but the detailed package README still omitted them.

## Validation

- `git diff --check`
- `python3 scripts/precommit/check_markdown_links.py packages/README.md`
- commit pre-commit hooks passed via `prek`