### PR TITLE
feat(sessions): persist context peak metrics

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -97,6 +97,9 @@ class PostSessionResult:
         output_tokens:         Output tokens from usage breakdown, or ``None`` if not present.
         cache_creation_tokens: Cache-write tokens, or ``None`` if not present.
         cache_read_tokens:     Cache-read tokens, or ``None`` if not present.
+        sys_prompt_tokens:     First-turn input context size, or ``None`` if not present.
+        context_peak_tokens:   Largest per-turn input context size, or ``None`` if not present.
+        context_window:        Model context window size, or ``None`` if not present.
     """
 
     record: SessionRecord
@@ -107,6 +110,9 @@ class PostSessionResult:
     output_tokens: int | None = None
     cache_creation_tokens: int | None = None
     cache_read_tokens: int | None = None
+    sys_prompt_tokens: int | None = None
+    context_peak_tokens: int | None = None
+    context_window: int | None = None
 
 
 def post_session(
@@ -224,6 +230,9 @@ def post_session(
     output_tokens: int | None = None
     cache_creation_tokens: int | None = None
     cache_read_tokens: int | None = None
+    sys_prompt_tokens: int | None = None
+    context_peak_tokens: int | None = None
+    context_window: int | None = None
     traj_productive: bool | None = None
 
     # --- Extract signals from trajectory ---
@@ -239,10 +248,16 @@ def post_session(
                 _out = usage.get("output_tokens")
                 _cc = usage.get("cache_creation_tokens")
                 _cr = usage.get("cache_read_tokens")
+                _sys = usage.get("sys_prompt_tokens")
+                _peak = usage.get("context_peak_tokens")
+                _window = usage.get("context_window")
                 input_tokens = int(_in) if _in is not None else None
                 output_tokens = int(_out) if _out is not None else None
                 cache_creation_tokens = int(_cc) if _cc is not None else None
                 cache_read_tokens = int(_cr) if _cr is not None else None
+                sys_prompt_tokens = int(_sys) if _sys is not None else None
+                context_peak_tokens = int(_peak) if _peak is not None else None
+                context_window = int(_window) if _window is not None else None
             if isinstance(usage, dict) and "total_tokens" in usage:
                 total = usage.get("total_tokens")
                 if total is not None:
@@ -371,6 +386,12 @@ def post_session(
         record_kwargs["cache_creation_tokens"] = cache_creation_tokens
     if cache_read_tokens is not None:
         record_kwargs["cache_read_tokens"] = cache_read_tokens
+    if sys_prompt_tokens is not None:
+        record_kwargs["sys_prompt_tokens"] = sys_prompt_tokens
+    if context_peak_tokens is not None:
+        record_kwargs["context_peak_tokens"] = context_peak_tokens
+    if context_window is not None:
+        record_kwargs["context_window"] = context_window
     record = SessionRecord(**record_kwargs)
     if grade is not None:
         record.set_productivity_grade(grade)
@@ -411,4 +432,7 @@ def post_session(
         output_tokens=output_tokens,
         cache_creation_tokens=cache_creation_tokens,
         cache_read_tokens=cache_read_tokens,
+        sys_prompt_tokens=sys_prompt_tokens,
+        context_peak_tokens=context_peak_tokens,
+        context_window=context_window,
     )

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -204,6 +204,9 @@ class SessionRecord:
     output_tokens: int | None = None
     cache_creation_tokens: int | None = None
     cache_read_tokens: int | None = None
+    sys_prompt_tokens: int | None = None
+    context_peak_tokens: int | None = None
+    context_window: int | None = None
 
     # Artifacts
     deliverables: list[str] = field(default_factory=list)  # commit SHAs, PR URLs

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -973,7 +973,7 @@ def extract_usage_gptme(msgs: list[dict]) -> dict:
         output_tokens += turn_output
         cache_read_tokens += turn_cache_read
         cache_creation_tokens += turn_cache_create
-        if sys_prompt_tokens is None:
+        if sys_prompt_tokens is None and turn_context > 0:
             sys_prompt_tokens = turn_context
         context_peak_tokens = (
             turn_context if context_peak_tokens is None else max(context_peak_tokens, turn_context)

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -1417,7 +1417,7 @@ def extract_usage_codex(msgs: list[dict]) -> dict:
         if output_tokens is not None:
             result["output_tokens"] = output_tokens
         if cached_input_tokens is not None:
-            result["cached_input_tokens"] = cached_input_tokens
+            result["cache_read_tokens"] = cached_input_tokens
         if total_tokens is not None:
             result["total_tokens"] = total_tokens
     if sys_prompt_tokens is not None:

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -1344,6 +1344,8 @@ def extract_usage_codex(msgs: list[dict]) -> dict:
     """Extract model, token, and rate-limit info from Codex CLI trajectories.
 
     Returns an empty dict if no model/usage data is found.
+    Omits the ``model`` key when usage data exists but the model was never
+    surfaced in a ``turn_context`` record.
     """
     model: str | None = None
     rate_limit_primary: float | None = None
@@ -1398,7 +1400,9 @@ def extract_usage_codex(msgs: list[dict]) -> dict:
         and context_peak_tokens is None
     ):
         return {}
-    result: dict = {"model": model}
+    result: dict = {}
+    if model is not None:
+        result["model"] = model
     if rate_limit_primary is not None:
         result["rate_limit_primary_pct"] = rate_limit_primary
     if rate_limit_secondary is not None:

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -70,6 +70,18 @@ _ISSUE_CLOSE_CMD_RE = re.compile(r"\bgh\s+issue\s+close\b")
 # can appear in test files, file-read results, and other non-merge contexts.
 _GH_PR_MERGE_CMD_RE = re.compile(r"\bgh\s+pr\s+merge\b")
 
+
+def _as_int(value: object) -> int | None:
+    """Return integer token counters without accepting bools or lossy floats."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return None
+
+
 # Regex to extract `--repo OWNER/REPO` from a `gh` command string.
 # Used to learn the target repo for `gh pr merge`/`gh pr view` so we can
 # resolve the server-side merge-commit SHA after a squash merge.
@@ -932,6 +944,8 @@ def extract_usage_gptme(msgs: list[dict]) -> dict:
     cache_creation_tokens = 0
     cost = 0.0
     model: str | None = None
+    sys_prompt_tokens: int | None = None
+    context_peak_tokens: int | None = None
 
     for msg in msgs:
         if msg.get("role") != "assistant":
@@ -949,10 +963,21 @@ def extract_usage_gptme(msgs: list[dict]) -> dict:
         # Support both nested format (usage sub-dict) and legacy flat format
         # Select source dict once per message to avoid per-field falsy fallback issues
         usage = metadata.get("usage") or metadata
-        input_tokens += usage.get("input_tokens", 0)
-        output_tokens += usage.get("output_tokens", 0)
-        cache_read_tokens += usage.get("cache_read_tokens", 0)
-        cache_creation_tokens += usage.get("cache_creation_tokens", 0)
+        turn_input = _as_int(usage.get("input_tokens")) or 0
+        turn_output = _as_int(usage.get("output_tokens")) or 0
+        turn_cache_read = _as_int(usage.get("cache_read_tokens")) or 0
+        turn_cache_create = _as_int(usage.get("cache_creation_tokens")) or 0
+        turn_context = turn_input + turn_cache_read + turn_cache_create
+
+        input_tokens += turn_input
+        output_tokens += turn_output
+        cache_read_tokens += turn_cache_read
+        cache_creation_tokens += turn_cache_create
+        if sys_prompt_tokens is None:
+            sys_prompt_tokens = turn_context
+        context_peak_tokens = (
+            turn_context if context_peak_tokens is None else max(context_peak_tokens, turn_context)
+        )
         cost += metadata.get("cost", 0.0)
 
     total_tokens = input_tokens + output_tokens + cache_read_tokens + cache_creation_tokens
@@ -966,6 +991,8 @@ def extract_usage_gptme(msgs: list[dict]) -> dict:
         "cache_creation_tokens": cache_creation_tokens,
         "cost": cost,
         "total_tokens": total_tokens,
+        "sys_prompt_tokens": sys_prompt_tokens,
+        "context_peak_tokens": context_peak_tokens,
     }
 
 
@@ -991,16 +1018,32 @@ def extract_usage_cc(msgs: list[dict]) -> dict:
     cache_creation_tokens = 0
     cache_read_tokens = 0
     model: str | None = None
+    sys_prompt_tokens: int | None = None
+    context_peak_tokens: int | None = None
 
     for record in msgs:
         if record.get("type") != "assistant":
             continue
         msg = record.get("message", {})
         usage = msg.get("usage") or {}
-        input_tokens += usage.get("input_tokens", 0)
-        output_tokens += usage.get("output_tokens", 0)
-        cache_creation_tokens += usage.get("cache_creation_input_tokens", 0)
-        cache_read_tokens += usage.get("cache_read_input_tokens", 0)
+        turn_input = _as_int(usage.get("input_tokens")) or 0
+        turn_output = _as_int(usage.get("output_tokens")) or 0
+        turn_cache_create = _as_int(usage.get("cache_creation_input_tokens")) or 0
+        turn_cache_read = _as_int(usage.get("cache_read_input_tokens")) or 0
+        turn_context = turn_input + turn_cache_create + turn_cache_read
+
+        input_tokens += turn_input
+        output_tokens += turn_output
+        cache_creation_tokens += turn_cache_create
+        cache_read_tokens += turn_cache_read
+        if usage and sys_prompt_tokens is None:
+            sys_prompt_tokens = turn_context
+        if usage:
+            context_peak_tokens = (
+                turn_context
+                if context_peak_tokens is None
+                else max(context_peak_tokens, turn_context)
+            )
         if msg.get("model"):
             model = msg["model"]
 
@@ -1015,6 +1058,8 @@ def extract_usage_cc(msgs: list[dict]) -> dict:
         "cache_creation_tokens": cache_creation_tokens,
         "cache_read_tokens": cache_read_tokens,
         "total_tokens": total_tokens,
+        "sys_prompt_tokens": sys_prompt_tokens,
+        "context_peak_tokens": context_peak_tokens,
     }
 
 
@@ -1296,16 +1341,17 @@ def extract_signals_copilot(msgs: list[dict]) -> dict:
 
 
 def extract_usage_codex(msgs: list[dict]) -> dict:
-    """Extract model and rate-limit info from Codex CLI trajectories.
-
-    Codex only provides rate-limit percentages (not absolute token counts).
-    We extract the model name and last-seen rate limit usage for reference.
+    """Extract model, token, and rate-limit info from Codex CLI trajectories.
 
     Returns an empty dict if no model/usage data is found.
     """
     model: str | None = None
     rate_limit_primary: float | None = None
     rate_limit_secondary: float | None = None
+    sys_prompt_tokens: int | None = None
+    context_peak_tokens: int | None = None
+    context_window: int | None = None
+    final_total: dict | None = None
 
     for record in msgs:
         rec_type = record.get("type", "")
@@ -1318,6 +1364,24 @@ def extract_usage_codex(msgs: list[dict]) -> dict:
         elif rec_type == "event_msg":
             payload = record.get("payload") or {}
             if payload.get("type") == "token_count":
+                info = payload.get("info") or {}
+                if isinstance(info, dict):
+                    last = info.get("last_token_usage")
+                    if isinstance(last, dict):
+                        turn_input = _as_int(last.get("input_tokens"))
+                        if turn_input is not None:
+                            if sys_prompt_tokens is None:
+                                sys_prompt_tokens = turn_input
+                            context_peak_tokens = (
+                                turn_input
+                                if context_peak_tokens is None
+                                else max(context_peak_tokens, turn_input)
+                            )
+                    total = info.get("total_token_usage")
+                    if isinstance(total, dict):
+                        final_total = total
+                    context_window = _as_int(info.get("model_context_window")) or context_window
+
                 rl = payload.get("rate_limits") or {}
                 primary = rl.get("primary") or {}
                 secondary = rl.get("secondary") or {}
@@ -1326,13 +1390,38 @@ def extract_usage_codex(msgs: list[dict]) -> dict:
                 if secondary.get("used_percent") is not None:
                     rate_limit_secondary = secondary["used_percent"]
 
-    if model is None:
+    if (
+        model is None
+        and rate_limit_primary is None
+        and rate_limit_secondary is None
+        and final_total is None
+        and context_peak_tokens is None
+    ):
         return {}
     result: dict = {"model": model}
     if rate_limit_primary is not None:
         result["rate_limit_primary_pct"] = rate_limit_primary
     if rate_limit_secondary is not None:
         result["rate_limit_secondary_pct"] = rate_limit_secondary
+    if final_total is not None:
+        input_tokens = _as_int(final_total.get("input_tokens"))
+        output_tokens = _as_int(final_total.get("output_tokens"))
+        cached_input_tokens = _as_int(final_total.get("cached_input_tokens"))
+        total_tokens = _as_int(final_total.get("total_tokens"))
+        if input_tokens is not None:
+            result["input_tokens"] = input_tokens
+        if output_tokens is not None:
+            result["output_tokens"] = output_tokens
+        if cached_input_tokens is not None:
+            result["cached_input_tokens"] = cached_input_tokens
+        if total_tokens is not None:
+            result["total_tokens"] = total_tokens
+    if sys_prompt_tokens is not None:
+        result["sys_prompt_tokens"] = sys_prompt_tokens
+    if context_peak_tokens is not None:
+        result["context_peak_tokens"] = context_peak_tokens
+    if context_window is not None:
+        result["context_window"] = context_window
     return result
 
 

--- a/packages/gptme-sessions/tests/test_post_session.py
+++ b/packages/gptme-sessions/tests/test_post_session.py
@@ -227,6 +227,9 @@ def test_post_session_persists_usage_fields(tmp_path: Path):
             "cache_creation_tokens": 30,
             "cache_read_tokens": 600,
             "total_tokens": 795,
+            "sys_prompt_tokens": 150,
+            "context_peak_tokens": 750,
+            "context_window": 200000,
         },
     }
     with patch.object(_post_session_mod, "extract_from_path", return_value=fake_signals):
@@ -243,12 +246,18 @@ def test_post_session_persists_usage_fields(tmp_path: Path):
     assert result.record.output_tokens == 45
     assert result.record.cache_creation_tokens == 30
     assert result.record.cache_read_tokens == 600
+    assert result.record.sys_prompt_tokens == 150
+    assert result.record.context_peak_tokens == 750
+    assert result.record.context_window == 200000
 
     records = store.load_all()
     assert records[0].input_tokens == 120
     assert records[0].output_tokens == 45
     assert records[0].cache_creation_tokens == 30
     assert records[0].cache_read_tokens == 600
+    assert records[0].sys_prompt_tokens == 150
+    assert records[0].context_peak_tokens == 750
+    assert records[0].context_window == 200000
 
 
 def test_post_session_partial_usage_fields_stored_as_none(tmp_path: Path):

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -3765,7 +3765,7 @@ def test_extract_usage_codex():
     assert usage["context_peak_tokens"] == 12000
     assert usage["context_window"] == 200000
     assert usage["input_tokens"] == 12000
-    assert usage["cached_input_tokens"] == 9000
+    assert usage["cache_read_tokens"] == 9000
     assert usage["output_tokens"] == 100
     assert usage["total_tokens"] == 12100
 

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -3776,6 +3776,38 @@ def test_extract_usage_codex_empty():
     assert extract_usage_codex([{"type": "session_meta", "payload": {}}]) == {}
 
 
+def test_extract_usage_codex_without_model_omits_model_key():
+    """Usage-only Codex records should not emit a ``model: None`` placeholder."""
+    msgs = [
+        {
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "last_token_usage": {
+                        "input_tokens": 4000,
+                        "output_tokens": 50,
+                    },
+                    "total_token_usage": {
+                        "input_tokens": 4000,
+                        "output_tokens": 50,
+                        "total_tokens": 4050,
+                    },
+                },
+            },
+        }
+    ]
+
+    usage = extract_usage_codex(msgs)
+
+    assert "model" not in usage
+    assert usage["sys_prompt_tokens"] == 4000
+    assert usage["context_peak_tokens"] == 4000
+    assert usage["input_tokens"] == 4000
+    assert usage["output_tokens"] == 50
+    assert usage["total_tokens"] == 4050
+
+
 # ============================================================
 # Copilot CLI format tests
 # ============================================================

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -2441,6 +2441,51 @@ def test_extract_usage_gptme_no_metadata():
     assert extract_usage_gptme(msgs) == {}
 
 
+def test_extract_usage_gptme_metadata_no_token_data():
+    """Metadata present but without token data should not lock sys_prompt_tokens at 0.
+
+    Regression test for Greptile finding on PR #845: the gptme extractor must not
+    set sys_prompt_tokens unconditionally on the first metadata-bearing turn when
+    no real token data is present. A later turn with actual data should still be
+    captured as sys_prompt.
+    """
+    msgs = [
+        {
+            "role": "user",
+            "content": "Hello",
+        },
+        {
+            "role": "assistant",
+            "content": "First response",
+            "metadata": {"model": "test-model"},
+            # metadata without any token fields
+        },
+        {
+            "role": "user",
+            "content": "Do something",
+        },
+        {
+            "role": "assistant",
+            "content": "Second response",
+            "metadata": {
+                "model": "test-model",
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cost": 0.002,
+            },
+        },
+    ]
+    usage = extract_usage_gptme(msgs)
+    assert usage, "Should return non-empty dict when token data exists"
+    assert usage["sys_prompt_tokens"] == 100, (
+        "sys_prompt_tokens should be the first turn WITH real token data, "
+        "not the first metadata-bearing turn"
+    )
+    assert usage["context_peak_tokens"] == 100
+    assert usage["input_tokens"] == 100
+    assert usage["output_tokens"] == 50
+
+
 def test_extract_usage_gptme_non_assistant_ignored():
     """Token data on user/system messages must not be accumulated."""
     msgs = [

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -1659,6 +1659,8 @@ def test_extract_usage_cc_basic():
     assert usage["cache_read_tokens"] == 500
     assert usage["total_tokens"] == 880
     assert usage["model"] == "claude-sonnet-4-6"
+    assert usage["sys_prompt_tokens"] == 300
+    assert usage["context_peak_tokens"] == 510
 
 
 def test_extract_usage_cc_empty():
@@ -1699,6 +1701,8 @@ def test_extract_usage_cc_no_usage_field():
     assert usage["input_tokens"] == 5
     assert usage["output_tokens"] == 3
     assert usage["total_tokens"] == 8
+    assert usage["sys_prompt_tokens"] == 5
+    assert usage["context_peak_tokens"] == 5
 
 
 def test_detect_format_cc_with_preamble():
@@ -2416,6 +2420,8 @@ def test_extract_usage_gptme_metadata():
     assert usage["total_tokens"] == 380
     assert abs(usage["cost"] - 0.008) < 1e-9
     assert usage["model"] == "anthropic/claude-sonnet-4-6"
+    assert usage["sys_prompt_tokens"] == 100
+    assert usage["context_peak_tokens"] == 200
 
 
 def test_extract_usage_gptme_empty():
@@ -2527,6 +2533,8 @@ def test_extract_from_path_gptme_includes_usage(tmp_path: Path):
     assert result["usage"]["input_tokens"] == 500
     assert result["usage"]["output_tokens"] == 100
     assert result["usage"]["model"] == "anthropic/claude-sonnet-4-6"
+    assert result["usage"]["sys_prompt_tokens"] == 500
+    assert result["usage"]["context_peak_tokens"] == 500
 
 
 def test_extract_usage_gptme_cache_tokens():
@@ -2842,6 +2850,8 @@ def test_post_session_token_count_from_trajectory(tmp_path: Path):
     )
     assert result.token_count == 1800  # 1000+500+200+100
     assert result.record.token_count == 1800
+    assert result.record.sys_prompt_tokens == 1300
+    assert result.record.context_peak_tokens == 1300
 
 
 def test_post_session_missing_trajectory(tmp_path: Path):
@@ -3671,7 +3681,7 @@ def test_extract_signals_codex_commit_in_long_output():
 
 
 def test_extract_usage_codex():
-    """Extract model and rate-limit info from Codex trajectory."""
+    """Extract model, token, and rate-limit info from Codex trajectory."""
     msgs = [
         {
             "type": "turn_context",
@@ -3681,6 +3691,19 @@ def test_extract_usage_codex():
             "type": "event_msg",
             "payload": {
                 "type": "token_count",
+                "info": {
+                    "last_token_usage": {
+                        "input_tokens": 12000,
+                        "output_tokens": 100,
+                    },
+                    "total_token_usage": {
+                        "input_tokens": 12000,
+                        "cached_input_tokens": 9000,
+                        "output_tokens": 100,
+                        "total_tokens": 12100,
+                    },
+                    "model_context_window": 200000,
+                },
                 "rate_limits": {
                     "limit_id": "codex",
                     "primary": {"used_percent": 8.0, "window_minutes": 300},
@@ -3693,6 +3716,13 @@ def test_extract_usage_codex():
     assert usage["model"] == "gpt-5.3-codex"
     assert usage["rate_limit_primary_pct"] == 8.0
     assert usage["rate_limit_secondary_pct"] == 2.0
+    assert usage["sys_prompt_tokens"] == 12000
+    assert usage["context_peak_tokens"] == 12000
+    assert usage["context_window"] == 200000
+    assert usage["input_tokens"] == 12000
+    assert usage["cached_input_tokens"] == 9000
+    assert usage["output_tokens"] == 100
+    assert usage["total_tokens"] == 12100
 
 
 def test_extract_usage_codex_empty():


### PR DESCRIPTION
## Summary
- add canonical `sys_prompt_tokens`, `context_peak_tokens`, and `context_window` fields to `SessionRecord`
- populate those fields from gptme, Claude Code, and Codex trajectory usage extraction when available
- keep cumulative token totals unchanged while exposing first-turn and peak input-context metrics for downstream monitoring

## Verification
- `uv run pytest /home/bob/bob/packages/gptme-sessions/tests/test_sessions.py /home/bob/bob/packages/gptme-sessions/tests/test_post_session.py /home/bob/bob/tests/test_context_lengths_report.py -q`
- `uv run mypy /home/bob/bob/scripts/monitoring/context-lengths-report.py /home/bob/bob/gptme-contrib/packages/gptme-sessions/src/gptme_sessions/record.py /home/bob/bob/gptme-contrib/packages/gptme-sessions/src/gptme_sessions/signals.py /home/bob/bob/gptme-contrib/packages/gptme-sessions/src/gptme_sessions/post_session.py`

Related: ErikBjare/bob#738
