### PR TITLE
feat(sessions): add byte-level context metrics to SessionRecord

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -100,6 +100,10 @@ class PostSessionResult:
         sys_prompt_tokens:     First-turn input context size, or ``None`` if not present.
         context_peak_tokens:   Largest per-turn input context size, or ``None`` if not present.
         context_window:        Model context window size, or ``None`` if not present.
+        sys_prompt_bytes:      System messages before first user message (UTF-8 bytes).
+        first_turn_bytes:      All messages before first assistant message (UTF-8 bytes).
+        context_peak_bytes:    Max per-turn context bytes before assistant.
+        session_total_bytes:   Total bytes of all message content.
     """
 
     record: SessionRecord
@@ -113,6 +117,10 @@ class PostSessionResult:
     sys_prompt_tokens: int | None = None
     context_peak_tokens: int | None = None
     context_window: int | None = None
+    sys_prompt_bytes: int | None = None
+    first_turn_bytes: int | None = None
+    context_peak_bytes: int | None = None
+    session_total_bytes: int | None = None
 
 
 def post_session(
@@ -233,6 +241,10 @@ def post_session(
     sys_prompt_tokens: int | None = None
     context_peak_tokens: int | None = None
     context_window: int | None = None
+    sys_prompt_bytes: int | None = None
+    first_turn_bytes: int | None = None
+    context_peak_bytes: int | None = None
+    session_total_bytes: int | None = None
     traj_productive: bool | None = None
 
     # --- Extract signals from trajectory ---
@@ -258,6 +270,15 @@ def post_session(
                 sys_prompt_tokens = int(_sys) if _sys is not None else None
                 context_peak_tokens = int(_peak) if _peak is not None else None
                 context_window = int(_window) if _window is not None else None
+                # Byte-level metrics (model-independent; ErikBjare/bob#738)
+                _sys_b = usage.get("sys_prompt_bytes")
+                _first_b = usage.get("first_turn_bytes")
+                _peak_b = usage.get("context_peak_bytes")
+                _total_b = usage.get("session_total_bytes")
+                sys_prompt_bytes = int(_sys_b) if _sys_b is not None else None
+                first_turn_bytes = int(_first_b) if _first_b is not None else None
+                context_peak_bytes = int(_peak_b) if _peak_b is not None else None
+                session_total_bytes = int(_total_b) if _total_b is not None else None
             if isinstance(usage, dict) and "total_tokens" in usage:
                 total = usage.get("total_tokens")
                 if total is not None:
@@ -392,6 +413,14 @@ def post_session(
         record_kwargs["context_peak_tokens"] = context_peak_tokens
     if context_window is not None:
         record_kwargs["context_window"] = context_window
+    if sys_prompt_bytes is not None:
+        record_kwargs["sys_prompt_bytes"] = sys_prompt_bytes
+    if first_turn_bytes is not None:
+        record_kwargs["first_turn_bytes"] = first_turn_bytes
+    if context_peak_bytes is not None:
+        record_kwargs["context_peak_bytes"] = context_peak_bytes
+    if session_total_bytes is not None:
+        record_kwargs["session_total_bytes"] = session_total_bytes
     record = SessionRecord(**record_kwargs)
     if grade is not None:
         record.set_productivity_grade(grade)
@@ -435,4 +464,8 @@ def post_session(
         sys_prompt_tokens=sys_prompt_tokens,
         context_peak_tokens=context_peak_tokens,
         context_window=context_window,
+        sys_prompt_bytes=sys_prompt_bytes,
+        first_turn_bytes=first_turn_bytes,
+        context_peak_bytes=context_peak_bytes,
+        session_total_bytes=session_total_bytes,
     )

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -208,6 +208,12 @@ class SessionRecord:
     context_peak_tokens: int | None = None
     context_window: int | None = None
 
+    # Byte-level context metrics (model-independent; #738)
+    sys_prompt_bytes: int | None = None  # system messages before first user msg
+    first_turn_bytes: int | None = None  # all messages before first assistant msg
+    context_peak_bytes: int | None = None  # max per-turn context bytes before assistant
+    session_total_bytes: int | None = None  # total bytes of all message content
+
     # Artifacts
     deliverables: list[str] = field(default_factory=list)  # commit SHAs, PR URLs
     trajectory_path: str | None = None  # path to trajectory JSONL file (for deduplication)

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -980,7 +980,7 @@ def extract_usage_gptme(msgs: list[dict]) -> dict:
         if not _first_user_seen:
             if role == "user":
                 _first_user_seen = True
-            else:
+            elif role == "system":
                 _sys_b += _cb
         if not _first_assistant_seen:
             if role == "assistant":

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -977,15 +977,16 @@ def extract_usage_gptme(msgs: list[dict]) -> dict:
         _cb = _message_content_bytes(msg)
         _total_b += _cb
         _cumulative_b += _cb
-        if not _first_user_seen and role != "system":
+        if not _first_user_seen:
             if role == "user":
                 _first_user_seen = True
             else:
                 _sys_b += _cb
         if not _first_assistant_seen:
-            _first_turn_b += _cb
             if role == "assistant":
                 _first_assistant_seen = True
+            else:
+                _first_turn_b += _cb
         if role == "assistant":
             context_before = _cumulative_b - _cb
             if context_before > _peak_b:
@@ -1034,7 +1035,11 @@ def extract_usage_gptme(msgs: list[dict]) -> dict:
         cost += metadata.get("cost", 0.0)
 
     total_tokens = input_tokens + output_tokens + cache_read_tokens + cache_creation_tokens
-    if total_tokens == 0 and cost == 0.0:
+    has_byte_metrics = any(
+        v is not None
+        for v in (sys_prompt_bytes, first_turn_bytes, context_peak_bytes, session_total_bytes)
+    )
+    if total_tokens == 0 and cost == 0.0 and not has_byte_metrics:
         return {}
     return {
         "model": model,

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -927,6 +927,16 @@ def extract_signals_cc(msgs: list[dict]) -> dict:
     }
 
 
+def _message_content_bytes(msg: dict) -> int:
+    """Count UTF-8 bytes of message content (model-independent)."""
+    content = msg.get("content", "")
+    if isinstance(content, list):
+        return sum(len(json.dumps(block, ensure_ascii=False).encode("utf-8")) for block in content)
+    if isinstance(content, str):
+        return len(content.encode("utf-8"))
+    return len(str(content).encode("utf-8"))
+
+
 def extract_usage_gptme(msgs: list[dict]) -> dict:
     """Extract cumulative token usage from a gptme conversation.jsonl trajectory.
 
@@ -946,6 +956,49 @@ def extract_usage_gptme(msgs: list[dict]) -> dict:
     model: str | None = None
     sys_prompt_tokens: int | None = None
     context_peak_tokens: int | None = None
+
+    # --- Byte-level metrics (model-independent; ErikBjare/bob#738) ---
+    sys_prompt_bytes: int | None = None
+    first_turn_bytes: int | None = None
+    context_peak_bytes: int | None = None
+    session_total_bytes: int | None = None
+
+    _sys_b = 0
+    _first_turn_b = 0
+    _peak_b = 0
+    _cumulative_b = 0
+    _total_b = 0
+    _first_assistant_seen = False
+    _first_user_seen = False
+    for msg in msgs:
+        role = msg.get("role")
+        if role is None:
+            continue
+        _cb = _message_content_bytes(msg)
+        _total_b += _cb
+        _cumulative_b += _cb
+        if not _first_user_seen and role != "system":
+            if role == "user":
+                _first_user_seen = True
+            else:
+                _sys_b += _cb
+        if not _first_assistant_seen:
+            _first_turn_b += _cb
+            if role == "assistant":
+                _first_assistant_seen = True
+        if role == "assistant":
+            context_before = _cumulative_b - _cb
+            if context_before > _peak_b:
+                _peak_b = context_before
+
+    if _sys_b > 0:
+        sys_prompt_bytes = _sys_b
+    if _first_turn_b > 0:
+        first_turn_bytes = _first_turn_b
+    if _peak_b > 0:
+        context_peak_bytes = _peak_b
+    if _total_b > 0:
+        session_total_bytes = _total_b
 
     for msg in msgs:
         if msg.get("role") != "assistant":
@@ -993,6 +1046,10 @@ def extract_usage_gptme(msgs: list[dict]) -> dict:
         "total_tokens": total_tokens,
         "sys_prompt_tokens": sys_prompt_tokens,
         "context_peak_tokens": context_peak_tokens,
+        "sys_prompt_bytes": sys_prompt_bytes,
+        "first_turn_bytes": first_turn_bytes,
+        "context_peak_bytes": context_peak_bytes,
+        "session_total_bytes": session_total_bytes,
     }
 
 

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -2430,7 +2430,7 @@ def test_extract_usage_gptme_empty():
 
 
 def test_extract_usage_gptme_no_metadata():
-    """Messages without metadata are skipped."""
+    """Messages without metadata still produce byte metrics; token fields are zero."""
     msgs = [
         {
             "role": "assistant",
@@ -2438,7 +2438,42 @@ def test_extract_usage_gptme_no_metadata():
             # no metadata field
         }
     ]
-    assert extract_usage_gptme(msgs) == {}
+    result = extract_usage_gptme(msgs)
+    # Byte metrics are computed even without token metadata
+    assert result["session_total_bytes"] == len("test")
+    # Token fields are absent/zero
+    assert result["total_tokens"] == 0
+    assert result["cost"] == 0.0
+
+
+def test_extract_usage_gptme_byte_metrics_without_token_data():
+    """Byte metrics are returned for token-less gptme sessions (the primary target use case).
+
+    Regression test for Greptile finding on PR #846: the early-return guard
+    `if total_tokens == 0 and cost == 0.0: return {}` must not discard byte
+    metrics for gptme sessions that have no token metadata.
+    """
+    sys_content = "You are a helpful assistant."
+    user_content = "Hello, world!"
+    asst_content = "Hi there!"
+    msgs = [
+        {"role": "system", "content": sys_content},
+        {"role": "user", "content": user_content},
+        {"role": "assistant", "content": asst_content},  # no metadata → no tokens
+    ]
+    result = extract_usage_gptme(msgs)
+    assert result, "Should return non-empty dict even with no token metadata"
+    # sys_prompt_bytes: bytes before first user turn (system message only)
+    assert result["sys_prompt_bytes"] == len(sys_content)
+    # first_turn_bytes: bytes before first assistant (system + user, not including assistant)
+    assert result["first_turn_bytes"] == len(sys_content) + len(user_content)
+    # session_total_bytes: all messages
+    assert result["session_total_bytes"] == len(sys_content) + len(user_content) + len(asst_content)
+    # context_peak_bytes: bytes before first (and only) assistant turn
+    assert result["context_peak_bytes"] == len(sys_content) + len(user_content)
+    # Token fields are zero since no metadata
+    assert result["total_tokens"] == 0
+    assert result["cost"] == 0.0
 
 
 def test_extract_usage_gptme_metadata_no_token_data():

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -2430,7 +2430,7 @@ def test_extract_usage_gptme_empty():
 
 
 def test_extract_usage_gptme_no_metadata():
-    """Messages without metadata still produce byte metrics; token fields are zero."""
+    """Messages without metadata still return byte metrics (token-less gptme sessions)."""
     msgs = [
         {
             "role": "assistant",
@@ -2439,11 +2439,15 @@ def test_extract_usage_gptme_no_metadata():
         }
     ]
     result = extract_usage_gptme(msgs)
-    # Byte metrics are computed even without token metadata
-    assert result["session_total_bytes"] == len("test")
-    # Token fields are absent/zero
+    # Byte metrics are returned even without token metadata (the primary gptme use case)
+    assert result["session_total_bytes"] == len("test".encode())
     assert result["total_tokens"] == 0
     assert result["cost"] == 0.0
+
+
+def test_extract_usage_gptme_truly_empty():
+    """Truly empty message list (no content, no tokens) returns {}."""
+    assert extract_usage_gptme([]) == {}
 
 
 def test_extract_usage_gptme_byte_metrics_without_token_data():
@@ -2464,16 +2468,74 @@ def test_extract_usage_gptme_byte_metrics_without_token_data():
     result = extract_usage_gptme(msgs)
     assert result, "Should return non-empty dict even with no token metadata"
     # sys_prompt_bytes: bytes before first user turn (system message only)
-    assert result["sys_prompt_bytes"] == len(sys_content)
+    assert result["sys_prompt_bytes"] == len(sys_content.encode())
     # first_turn_bytes: bytes before first assistant (system + user, not including assistant)
-    assert result["first_turn_bytes"] == len(sys_content) + len(user_content)
+    assert result["first_turn_bytes"] == len(sys_content.encode()) + len(user_content.encode())
     # session_total_bytes: all messages
-    assert result["session_total_bytes"] == len(sys_content) + len(user_content) + len(asst_content)
+    assert result["session_total_bytes"] == (
+        len(sys_content.encode()) + len(user_content.encode()) + len(asst_content.encode())
+    )
     # context_peak_bytes: bytes before first (and only) assistant turn
-    assert result["context_peak_bytes"] == len(sys_content) + len(user_content)
+    assert result["context_peak_bytes"] == len(sys_content.encode()) + len(user_content.encode())
     # Token fields are zero since no metadata
     assert result["total_tokens"] == 0
     assert result["cost"] == 0.0
+
+
+def test_extract_usage_gptme_sys_prompt_bytes_from_system_role():
+    """Regression: system-role messages must be counted in sys_prompt_bytes.
+
+    Bug: the original condition `role != 'system'` skipped actual system messages,
+    so sys_prompt_bytes was always 0 for the system prompt.
+    """
+    sys_text = "You are a helpful assistant."
+    msgs = [
+        {"role": "system", "content": sys_text},
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi"},
+    ]
+    result = extract_usage_gptme(msgs)
+    assert result["sys_prompt_bytes"] == len(sys_text.encode())
+
+
+def test_extract_usage_gptme_first_turn_bytes_excludes_assistant():
+    """Regression: first_turn_bytes must NOT include the first assistant message.
+
+    Bug: bytes were added before checking role=='assistant', so the first
+    assistant message was included in first_turn_bytes.
+    """
+    user_text = "Hello"
+    assistant_text = "Hi there, how can I help?"
+    msgs = [
+        {"role": "user", "content": user_text},
+        {"role": "assistant", "content": assistant_text},
+        {"role": "user", "content": "Another question"},
+    ]
+    result = extract_usage_gptme(msgs)
+    # first_turn_bytes = only the user message before first assistant reply
+    assert result["first_turn_bytes"] == len(user_text.encode())
+    assert result["session_total_bytes"] == len(
+        (user_text + assistant_text + "Another question").encode()
+    )
+
+
+def test_extract_usage_gptme_token_less_returns_bytes():
+    """Regression: token-less gptme sessions must not be silently dropped.
+
+    Bug: `if total_tokens == 0 and cost == 0.0: return {}` fired before
+    byte fields were included, discarding all byte data for gptme sessions
+    that have no token metadata — exactly the population this feature targets.
+    """
+    msgs = [
+        {"role": "system", "content": "System prompt here"},
+        {"role": "user", "content": "Query"},
+        {"role": "assistant", "content": "Response without token metadata"},
+    ]
+    result = extract_usage_gptme(msgs)
+    assert result != {}, "token-less gptme sessions must return byte metrics"
+    assert result["session_total_bytes"] is not None
+    assert result["sys_prompt_bytes"] == len("System prompt here".encode())
+    assert result["total_tokens"] == 0
 
 
 def test_extract_usage_gptme_metadata_no_token_data():


### PR DESCRIPTION
## Summary
Add model-independent byte-level context metrics to gptme-sessions, building on the canonical context peak fields added in #845.

## What changed
- **SessionRecord**: new fields `sys_prompt_bytes`, `first_turn_bytes`, `context_peak_bytes`, `session_total_bytes`
- **extract_usage_gptme** (signals.py): count UTF-8 bytes from message content alongside token counting — no tokenizer dependency
- **PostSessionResult.Usage**: expose byte fields for downstream consumers  
- **_collect_usage** and **_create_session_record** (post_session.py): wire byte fields through the full pipeline

## Why
Erik requested model-independent byte measurement on ErikBjare/bob#738 to support gptme sessions (which previously had 0% token coverage in the context-lengths report). The local report (`scripts/monitoring/context-lengths-report.py`) already computes byte metrics by re-parsing gptme JSONL trajectories — this moves that logic into the canonical session record so downstream tools get byte data without re-parsing.

Current gptme byte findings (1d window):
- sys_prompt_bytes p50: 82KB (strict system messages before first user)
- first_turn_bytes p50: 175KB (includes injected context from context.sh — 2.13× multiplier)
- context_peak_bytes p95: 435KB

## Verification
- `uv run pytest packages/gptme-sessions/tests/ -q` — 735 passed
- `uv run mypy packages/gptme-sessions/src/gptme_sessions/{record,signals,post_session}.py` — clean
- Context-lengths report continues to work with the updated logic

Related: ErikBjare/bob#738