### PR TITLE
feat(gptodo): add wait_until and recur fields for task scheduling

### DIFF
--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -1662,22 +1662,8 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask):
                     # Normalize deprecated states at write time (defense in depth)
                     if field == "state":
                         value = normalize_state(value, warn=False)
-                        # Recurring tasks: reset to active instead of marking done
-                        if value == "done" and post.metadata.get("recur"):
-                            from datetime import date
 
-                            from gptodo.utils import parse_recur_interval
-
-                            recur_str = str(post.metadata["recur"])
-                            if parse_recur_interval(recur_str) is not None:
-                                post.metadata["last_completed"] = date.today().isoformat()
-                                value = "active"
-                                console.print(
-                                    f"[cyan]↻ Recurring task reset (recur={recur_str},"
-                                    f" last_completed={post.metadata['last_completed']})[/]"
-                                )
                     post.metadata[field] = value
-
         # Save changes
         with open(task.path, "w") as f:
             f.write(frontmatter.dumps(post))
@@ -1693,6 +1679,11 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask):
                 # Handle recur: reset task to todo and advance wait: date
                 recur = post.metadata.get("recur")
                 if recur:
+                    from gptodo.utils import parse_recur_interval
+
+                    if parse_recur_interval(str(recur)) is None:
+                        completed_task_ids.append(task.id)
+                        continue
                     from gptodo.utils import advance_wait, parse_wait
 
                     current_wait = parse_wait(post.metadata.get("wait"))

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -1662,6 +1662,20 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask):
                     # Normalize deprecated states at write time (defense in depth)
                     if field == "state":
                         value = normalize_state(value, warn=False)
+                        # Recurring tasks: reset to active instead of marking done
+                        if value == "done" and post.metadata.get("recur"):
+                            from datetime import date
+
+                            from gptodo.utils import parse_recur_interval
+
+                            recur_str = str(post.metadata["recur"])
+                            if parse_recur_interval(recur_str) is not None:
+                                post.metadata["last_completed"] = date.today().isoformat()
+                                value = "active"
+                                console.print(
+                                    f"[cyan]↻ Recurring task reset (recur={recur_str},"
+                                    f" last_completed={post.metadata['last_completed']})[/]"
+                                )
                     post.metadata[field] = value
 
         # Save changes

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -349,7 +349,16 @@ def task_has_waiting_blocker(task: TaskInfo) -> bool:
     state = normalize_state(task.state or "", warn=False) if task.state else ""
     if state == "waiting":
         return True
-    return bool(task.metadata.get("waiting_for"))
+    if task.metadata.get("waiting_for"):
+        return True
+    # Simple wait_until: "YYYY-MM-DD" or ISO timestamp — blocks until that time passes
+    wait_until = task.metadata.get("wait_until")
+    if wait_until:
+        from gptodo.waiting import check_time
+
+        resolved, _ = check_time(str(wait_until))
+        return not resolved
+    return False
 
 
 def find_repo_root(start_path: Path) -> Path:
@@ -1166,6 +1175,9 @@ def get_blocking_reasons(
         return []
 
     if task_has_waiting_blocker(task):
+        wait_until = task.metadata.get("wait_until")
+        if wait_until:
+            return [f"Wait until: {wait_until}"]
         waiting_for = task.metadata.get("waiting_for")
         if waiting_for:
             return [f"Waiting on: {waiting_for}"]
@@ -1275,6 +1287,15 @@ class StateChecker:
             elif not task.state:
                 results["untracked"].append(task)
             else:
+                # Route wait_until tasks to "waiting" bucket (hides from --compact)
+                wait_until = task.metadata.get("wait_until")
+                if wait_until and "waiting" in results:
+                    from gptodo.waiting import check_time
+
+                    resolved, _ = check_time(str(wait_until))
+                    if not resolved:
+                        results["waiting"].append(task)
+                        continue
                 results[task.state].append(task)
 
         return results

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -344,7 +344,46 @@ class TaskInfo:
 # =============================================================================
 
 
-def task_has_waiting_blocker(task: TaskInfo) -> bool:
+def parse_recur_interval(recur: str) -> timedelta | None:
+    """Parse a recur duration string into a timedelta.
+
+    Formats:
+        Nd        → N days (e.g. "7d", "14d", "30d")
+        weekly    → 7 days
+        monthly   → 30 days
+
+    Returns None if the format is not recognised.
+    """
+    recur = recur.strip().lower()
+    _ALIASES: dict[str, timedelta] = {
+        "weekly": timedelta(days=7),
+        "monthly": timedelta(days=30),
+    }
+    if recur in _ALIASES:
+        return _ALIASES[recur]
+    m = re.match(r"^(\d+)d$", recur)
+    if m:
+        return timedelta(days=int(m.group(1)))
+    return None
+
+
+def task_is_recur_blocked(task: "TaskInfo") -> bool:
+    """Return True if a recurring task has been completed and is not yet due again."""
+    recur = task.metadata.get("recur")
+    last_completed = task.metadata.get("last_completed")
+    if not recur or not last_completed:
+        return False
+    interval = parse_recur_interval(str(recur))
+    if interval is None:
+        return False
+    try:
+        last_dt = datetime.fromisoformat(str(last_completed))
+        return datetime.now() < last_dt + interval
+    except ValueError:
+        return False
+
+
+def task_has_waiting_blocker(task: "TaskInfo") -> bool:
     """Return True when a task is explicitly waiting on an external condition."""
     state = normalize_state(task.state or "", warn=False) if task.state else ""
     if state == "waiting":
@@ -358,6 +397,9 @@ def task_has_waiting_blocker(task: TaskInfo) -> bool:
 
         resolved, _ = check_time(str(wait_until))
         return not resolved
+    # recur: block if last_completed + interval is in the future
+    if task_is_recur_blocked(task):
+        return True
     return False
 
 
@@ -1287,7 +1329,7 @@ class StateChecker:
             elif not task.state:
                 results["untracked"].append(task)
             else:
-                # Route wait_until tasks to "waiting" bucket (hides from --compact)
+                # Route wait_until / recur-blocked tasks to "waiting" bucket (hides from --compact)
                 wait_until = task.metadata.get("wait_until")
                 if wait_until and "waiting" in results:
                     from gptodo.waiting import check_time
@@ -1296,6 +1338,9 @@ class StateChecker:
                     if not resolved:
                         results["waiting"].append(task)
                         continue
+                if task_is_recur_blocked(task) and "waiting" in results:
+                    results["waiting"].append(task)
+                    continue
                 results[task.state].append(task)
 
         return results

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -344,29 +344,6 @@ class TaskInfo:
 # =============================================================================
 
 
-def parse_recur_interval(recur: str) -> timedelta | None:
-    """Parse a recur duration string into a timedelta.
-
-    Formats:
-        Nd        → N days (e.g. "7d", "14d", "30d")
-        weekly    → 7 days
-        monthly   → 30 days
-
-    Returns None if the format is not recognised.
-    """
-    recur = recur.strip().lower()
-    _ALIASES: dict[str, timedelta] = {
-        "weekly": timedelta(days=7),
-        "monthly": timedelta(days=30),
-    }
-    if recur in _ALIASES:
-        return _ALIASES[recur]
-    m = re.match(r"^(\d+)d$", recur)
-    if m:
-        return timedelta(days=int(m.group(1)))
-    return None
-
-
 def task_is_recur_blocked(task: "TaskInfo") -> bool:
     """Return True if a recurring task has been completed and is not yet due again."""
     recur = task.metadata.get("recur")
@@ -538,7 +515,7 @@ def parse_recur_interval(recur: str) -> timedelta | None:
     """
     if not recur:
         return None
-    recur = recur.strip()
+    recur = recur.strip().lower()
     if recur == "weekly":
         return timedelta(days=7)
     if recur == "monthly":

--- a/packages/gptodo/tests/test_recur.py
+++ b/packages/gptodo/tests/test_recur.py
@@ -1,0 +1,179 @@
+"""Tests for gptodo recur (recurring task) feature."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from click.testing import CliRunner
+
+from gptodo.cli import cli
+from gptodo.frontmatter_compat import frontmatter
+from gptodo.utils import parse_recur_interval, task_is_recur_blocked
+
+
+# =============================================================================
+# parse_recur_interval
+# =============================================================================
+
+
+class TestParseRecurInterval:
+    def test_days_format(self):
+        assert parse_recur_interval("7d") == timedelta(days=7)
+        assert parse_recur_interval("14d") == timedelta(days=14)
+        assert parse_recur_interval("30d") == timedelta(days=30)
+        assert parse_recur_interval("1d") == timedelta(days=1)
+
+    def test_named_weekly(self):
+        assert parse_recur_interval("weekly") == timedelta(days=7)
+
+    def test_named_monthly(self):
+        assert parse_recur_interval("monthly") == timedelta(days=30)
+
+    def test_case_insensitive(self):
+        assert parse_recur_interval("WEEKLY") == timedelta(days=7)
+        assert parse_recur_interval("Monthly") == timedelta(days=30)
+        assert parse_recur_interval("7D") == timedelta(days=7)
+
+    def test_whitespace_stripped(self):
+        assert parse_recur_interval("  7d  ") == timedelta(days=7)
+
+    def test_unknown_format_returns_none(self):
+        assert parse_recur_interval("") is None
+        assert parse_recur_interval("7w") is None
+        assert parse_recur_interval("every week") is None
+        assert parse_recur_interval("0 9 * * 1") is None
+
+
+# =============================================================================
+# task_is_recur_blocked — tested via duck-typed metadata holder
+# =============================================================================
+
+
+def _meta_task(recur: str | None = None, last_completed: str | None = None):
+    """Return a duck-typed object with only the .metadata attribute needed by task_is_recur_blocked."""
+    metadata: dict = {"state": "active"}
+    if recur is not None:
+        metadata["recur"] = recur
+    if last_completed is not None:
+        metadata["last_completed"] = last_completed
+    return SimpleNamespace(metadata=metadata)
+
+
+class TestTaskIsRecurBlocked:
+    def test_no_recur_not_blocked(self):
+        assert not task_is_recur_blocked(_meta_task())
+
+    def test_recur_without_last_completed_not_blocked(self):
+        assert not task_is_recur_blocked(_meta_task(recur="7d"))
+
+    def test_recently_completed_is_blocked(self):
+        yesterday = (datetime.now() - timedelta(days=1)).isoformat()
+        assert task_is_recur_blocked(_meta_task(recur="7d", last_completed=yesterday))
+
+    def test_overdue_is_not_blocked(self):
+        eight_days_ago = (datetime.now() - timedelta(days=8)).isoformat()
+        assert not task_is_recur_blocked(_meta_task(recur="7d", last_completed=eight_days_ago))
+
+    def test_exactly_at_boundary_not_blocked(self):
+        seven_days_plus_one_sec_ago = (datetime.now() - timedelta(days=7, seconds=1)).isoformat()
+        assert not task_is_recur_blocked(
+            _meta_task(recur="7d", last_completed=seven_days_plus_one_sec_ago)
+        )
+
+    def test_weekly_alias(self):
+        yesterday = (datetime.now() - timedelta(days=1)).isoformat()
+        assert task_is_recur_blocked(_meta_task(recur="weekly", last_completed=yesterday))
+
+    def test_monthly_alias(self):
+        ten_days_ago = (datetime.now() - timedelta(days=10)).isoformat()
+        assert task_is_recur_blocked(_meta_task(recur="monthly", last_completed=ten_days_ago))
+
+    def test_unknown_recur_format_not_blocked(self):
+        yesterday = (datetime.now() - timedelta(days=1)).isoformat()
+        assert not task_is_recur_blocked(_meta_task(recur="every-week", last_completed=yesterday))
+
+    def test_date_only_last_completed(self):
+        yesterday = (date.today() - timedelta(days=1)).isoformat()
+        assert task_is_recur_blocked(_meta_task(recur="7d", last_completed=yesterday))
+
+
+# =============================================================================
+# CLI integration: marking a recurring task done resets it
+# =============================================================================
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    (tmp_path / "tasks").mkdir()
+    (tmp_path / "gptme.toml").write_text('[agent]\nname = "gordon"\n')
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def write_task(workspace: Path, name: str, **metadata: object) -> Path:
+    """Write a task file with frontmatter (no repr quoting — plain YAML values)."""
+    lines = ["---"]
+    for key, value in metadata.items():
+        if isinstance(value, list):
+            lines.append(f"{key}:")
+            for item in value:
+                lines.append(f"  - {item}")
+        else:
+            lines.append(f"{key}: {value}")
+    lines.append("---")
+    lines.append(f"# {name}")
+    path = workspace / "tasks" / f"{name}.md"
+    path.write_text("\n".join(lines))
+    return path
+
+
+class TestRecurCliReset:
+    def test_done_resets_recurring_task_to_active(self, workspace: Path):
+        write_task(workspace, "weekly-review", state="active", recur="7d")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["edit", "weekly-review", "--set", "state", "done"])
+        assert result.exit_code == 0, result.output
+        assert "Recurring task reset" in result.output
+
+        post = frontmatter.load(workspace / "tasks" / "weekly-review.md")
+        assert post.metadata["state"] == "active"
+        assert post.metadata["last_completed"] == date.today().isoformat()
+
+    def test_done_sets_last_completed_to_today(self, workspace: Path):
+        write_task(workspace, "weekly-review", state="active", recur="weekly")
+        runner = CliRunner()
+        runner.invoke(cli, ["edit", "weekly-review", "--set", "state", "done"])
+
+        post = frontmatter.load(workspace / "tasks" / "weekly-review.md")
+        assert post.metadata["last_completed"] == date.today().isoformat()
+
+    def test_done_non_recurring_task_stays_done(self, workspace: Path):
+        write_task(workspace, "one-off-task", state="active")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["edit", "one-off-task", "--set", "state", "done"])
+        assert result.exit_code == 0, result.output
+
+        post = frontmatter.load(workspace / "tasks" / "one-off-task.md")
+        assert post.metadata["state"] == "done"
+        assert "last_completed" not in post.metadata
+
+    def test_recurring_task_blocked_after_reset(self, workspace: Path):
+        write_task(workspace, "weekly-review", state="active", recur="7d")
+        runner = CliRunner()
+        runner.invoke(cli, ["edit", "weekly-review", "--set", "state", "done"])
+
+        post = frontmatter.load(workspace / "tasks" / "weekly-review.md")
+        task_meta = SimpleNamespace(metadata=dict(post.metadata))
+        assert task_is_recur_blocked(task_meta)
+
+    def test_unknown_recur_format_marks_done_normally(self, workspace: Path):
+        write_task(workspace, "mystery-task", state="active", recur="every-week")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["edit", "mystery-task", "--set", "state", "done"])
+        assert result.exit_code == 0, result.output
+
+        post = frontmatter.load(workspace / "tasks" / "mystery-task.md")
+        assert post.metadata["state"] == "done"

--- a/packages/gptodo/tests/test_recur.py
+++ b/packages/gptodo/tests/test_recur.py
@@ -131,24 +131,28 @@ def write_task(workspace: Path, name: str, **metadata: object) -> Path:
 
 
 class TestRecurCliReset:
-    def test_done_resets_recurring_task_to_active(self, workspace: Path):
+    def test_done_resets_recurring_task_to_todo(self, workspace: Path):
         write_task(workspace, "weekly-review", state="active", recur="7d")
         runner = CliRunner()
         result = runner.invoke(cli, ["edit", "weekly-review", "--set", "state", "done"])
         assert result.exit_code == 0, result.output
-        assert "Recurring task reset" in result.output
+        assert "reset to todo" in result.output
 
         post = frontmatter.load(workspace / "tasks" / "weekly-review.md")
-        assert post.metadata["state"] == "active"
-        assert post.metadata["last_completed"] == date.today().isoformat()
+        assert post.metadata["state"] == "todo"
+        assert "last_completed" not in post.metadata
+        assert "wait" in post.metadata
 
-    def test_done_sets_last_completed_to_today(self, workspace: Path):
+    def test_done_sets_wait_to_future_for_recurring(self, workspace: Path):
         write_task(workspace, "weekly-review", state="active", recur="weekly")
         runner = CliRunner()
         runner.invoke(cli, ["edit", "weekly-review", "--set", "state", "done"])
 
         post = frontmatter.load(workspace / "tasks" / "weekly-review.md")
-        assert post.metadata["last_completed"] == date.today().isoformat()
+        assert post.metadata["state"] == "todo"
+        assert "wait" in post.metadata
+        tomorrow = date.today() + timedelta(days=1)
+        assert date.fromisoformat(str(post.metadata["wait"])) >= tomorrow
 
     def test_done_non_recurring_task_stays_done(self, workspace: Path):
         write_task(workspace, "one-off-task", state="active")
@@ -160,14 +164,16 @@ class TestRecurCliReset:
         assert post.metadata["state"] == "done"
         assert "last_completed" not in post.metadata
 
-    def test_recurring_task_blocked_after_reset(self, workspace: Path):
+    def test_recurring_task_gets_wait_after_done(self, workspace: Path):
         write_task(workspace, "weekly-review", state="active", recur="7d")
         runner = CliRunner()
         runner.invoke(cli, ["edit", "weekly-review", "--set", "state", "done"])
 
         post = frontmatter.load(workspace / "tasks" / "weekly-review.md")
-        task_meta = SimpleNamespace(metadata=dict(post.metadata))
-        assert task_is_recur_blocked(task_meta)
+        assert post.metadata["state"] == "todo"
+        assert "wait" in post.metadata
+        future = date.fromisoformat(str(post.metadata["wait"]))
+        assert future > date.today()
 
     def test_unknown_recur_format_marks_done_normally(self, workspace: Path):
         write_task(workspace, "mystery-task", state="active", recur="every-week")


### PR DESCRIPTION
## Summary

Adds two new task scheduling fields to gptodo, originally implemented by Gordon (`gordon@superuserlabs.org`):

### `wait_until`: time-gated deferral
```yaml
state: paused
wait_until: "2026-05-10"
```
Tasks hidden from active queue until the specified date passes. Already in production on Gordon's systemd-migration-phase2 workflow.

### `recur`: recurring task reset
```yaml
state: active
recur: 7d
```
On `gptodo edit --set state done`, the task resets to `todo` with an advanced `wait:` date. Supports `7d`, `14d`, `24h`, `weekly`, `monthly`. Already in production on Gordon's weekly-prediction-review workflow.

## Changes

- `wait_until` frontmatter field: checked by `task_has_waiting_blocker()` via existing `check_time()`
- `recur` frontmatter field: `edit --set state done` → reset to todo + advance wait
- `parse_recur_interval()`: parse `7d`, `24h`, `weekly`, `monthly`
- `advance_wait()`: compute next `wait:` date from recur interval
- StateChecker routes wait_until and recur-blocked tasks to `waiting` bucket
- Unknown recur formats (e.g. `every-week`) correctly mark tasks as done

## Fixes applied to Gordon's original patches

- Consolidated conflicting edit-time `active+last_completed` behavior into the completion hook's `todo+wait` approach
- Removed duplicate `parse_recur_interval` definition
- Added case-insensitive parsing (`WEEKLY` → `weekly`)
- Validates recur format in completion hook (unknown formats skip recurring behavior)

## Tests

```
197 passed in 0.99s
```
(20 new tests from Gordon + existing test suite — zero regressions)

Closes: No issue tracked — Gordon's feature request via inter-agent message.