### PR TITLE
fix(gptodo): remove wait_until duplicate and dead recur routing code

### DIFF
--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -344,40 +344,12 @@ class TaskInfo:
 # =============================================================================
 
 
-def task_is_recur_blocked(task: "TaskInfo") -> bool:
-    """Return True if a recurring task has been completed and is not yet due again."""
-    recur = task.metadata.get("recur")
-    last_completed = task.metadata.get("last_completed")
-    if not recur or not last_completed:
-        return False
-    interval = parse_recur_interval(str(recur))
-    if interval is None:
-        return False
-    try:
-        last_dt = datetime.fromisoformat(str(last_completed))
-        return datetime.now() < last_dt + interval
-    except ValueError:
-        return False
-
-
 def task_has_waiting_blocker(task: "TaskInfo") -> bool:
     """Return True when a task is explicitly waiting on an external condition."""
     state = normalize_state(task.state or "", warn=False) if task.state else ""
     if state == "waiting":
         return True
-    if task.metadata.get("waiting_for"):
-        return True
-    # Simple wait_until: "YYYY-MM-DD" or ISO timestamp — blocks until that time passes
-    wait_until = task.metadata.get("wait_until")
-    if wait_until:
-        from gptodo.waiting import check_time
-
-        resolved, _ = check_time(str(wait_until))
-        return not resolved
-    # recur: block if last_completed + interval is in the future
-    if task_is_recur_blocked(task):
-        return True
-    return False
+    return bool(task.metadata.get("waiting_for"))
 
 
 def find_repo_root(start_path: Path) -> Path:
@@ -1194,9 +1166,6 @@ def get_blocking_reasons(
         return []
 
     if task_has_waiting_blocker(task):
-        wait_until = task.metadata.get("wait_until")
-        if wait_until:
-            return [f"Wait until: {wait_until}"]
         waiting_for = task.metadata.get("waiting_for")
         if waiting_for:
             return [f"Waiting on: {waiting_for}"]
@@ -1306,18 +1275,6 @@ class StateChecker:
             elif not task.state:
                 results["untracked"].append(task)
             else:
-                # Route wait_until / recur-blocked tasks to "waiting" bucket (hides from --compact)
-                wait_until = task.metadata.get("wait_until")
-                if wait_until and "waiting" in results:
-                    from gptodo.waiting import check_time
-
-                    resolved, _ = check_time(str(wait_until))
-                    if not resolved:
-                        results["waiting"].append(task)
-                        continue
-                if task_is_recur_blocked(task) and "waiting" in results:
-                    results["waiting"].append(task)
-                    continue
                 results[task.state].append(task)
 
         return results

--- a/packages/gptodo/tests/test_recur.py
+++ b/packages/gptodo/tests/test_recur.py
@@ -2,16 +2,15 @@
 
 from __future__ import annotations
 
-from datetime import date, datetime, timedelta
+from datetime import date, timedelta
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
 from click.testing import CliRunner
 
 from gptodo.cli import cli
 from gptodo.frontmatter_compat import frontmatter
-from gptodo.utils import parse_recur_interval, task_is_recur_blocked
+from gptodo.utils import parse_recur_interval
 
 
 # =============================================================================
@@ -45,59 +44,6 @@ class TestParseRecurInterval:
         assert parse_recur_interval("7w") is None
         assert parse_recur_interval("every week") is None
         assert parse_recur_interval("0 9 * * 1") is None
-
-
-# =============================================================================
-# task_is_recur_blocked — tested via duck-typed metadata holder
-# =============================================================================
-
-
-def _meta_task(recur: str | None = None, last_completed: str | None = None):
-    """Return a duck-typed object with only the .metadata attribute needed by task_is_recur_blocked."""
-    metadata: dict = {"state": "active"}
-    if recur is not None:
-        metadata["recur"] = recur
-    if last_completed is not None:
-        metadata["last_completed"] = last_completed
-    return SimpleNamespace(metadata=metadata)
-
-
-class TestTaskIsRecurBlocked:
-    def test_no_recur_not_blocked(self):
-        assert not task_is_recur_blocked(_meta_task())
-
-    def test_recur_without_last_completed_not_blocked(self):
-        assert not task_is_recur_blocked(_meta_task(recur="7d"))
-
-    def test_recently_completed_is_blocked(self):
-        yesterday = (datetime.now() - timedelta(days=1)).isoformat()
-        assert task_is_recur_blocked(_meta_task(recur="7d", last_completed=yesterday))
-
-    def test_overdue_is_not_blocked(self):
-        eight_days_ago = (datetime.now() - timedelta(days=8)).isoformat()
-        assert not task_is_recur_blocked(_meta_task(recur="7d", last_completed=eight_days_ago))
-
-    def test_exactly_at_boundary_not_blocked(self):
-        seven_days_plus_one_sec_ago = (datetime.now() - timedelta(days=7, seconds=1)).isoformat()
-        assert not task_is_recur_blocked(
-            _meta_task(recur="7d", last_completed=seven_days_plus_one_sec_ago)
-        )
-
-    def test_weekly_alias(self):
-        yesterday = (datetime.now() - timedelta(days=1)).isoformat()
-        assert task_is_recur_blocked(_meta_task(recur="weekly", last_completed=yesterday))
-
-    def test_monthly_alias(self):
-        ten_days_ago = (datetime.now() - timedelta(days=10)).isoformat()
-        assert task_is_recur_blocked(_meta_task(recur="monthly", last_completed=ten_days_ago))
-
-    def test_unknown_recur_format_not_blocked(self):
-        yesterday = (datetime.now() - timedelta(days=1)).isoformat()
-        assert not task_is_recur_blocked(_meta_task(recur="every-week", last_completed=yesterday))
-
-    def test_date_only_last_completed(self):
-        yesterday = (date.today() - timedelta(days=1)).isoformat()
-        assert task_is_recur_blocked(_meta_task(recur="7d", last_completed=yesterday))
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

PR #847 added a `wait_until` field that duplicates the `wait:` field from PR #827. It also added `task_is_recur_blocked` which requires `last_completed` — but the CLI completion hook never writes `last_completed`, making the routing code unreachable (as Greptile noted in the original review).

This PR removes both while preserving the genuinely useful additions:
- **Case-insensitive `parse_recur_interval`** (accepts `WEEKLY`, `Monthly`, etc.)
- **Invalid recur format validation** in the edit command
- **Invalid recur format guard** in the completion hook

## Changes
- `utils.py`: Removed `task_is_recur_blocked()`, `wait_until` from `task_has_waiting_blocker()`, `wait_until`/`recur` routing from `StateChecker`, and `wait_until` from `get_blocking_reasons()`
- `test_recur.py`: Removed `TestTaskIsRecurBlocked` class and dependent imports

## Tests
```
188 passed in 1.04s
```

Closes: The original feature overlap concern from PR #847