### PR TITLE
feat(sessions): add cascade_intent field to SessionRecord

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -135,6 +135,7 @@ def post_session(
     trigger: str | None = None,
     category: str | None = None,
     recommended_category: str | None = None,
+    cascade_intent: dict | None = None,
     exit_code: int = 0,
     duration_seconds: int = 0,
     trajectory_path: Path | None = None,
@@ -383,6 +384,8 @@ def post_session(
         record_kwargs["category"] = actual_category
     if recommended_category is not None:
         record_kwargs["recommended_category"] = recommended_category
+    if cascade_intent is not None:
+        record_kwargs["cascade_intent"] = cascade_intent
     if trajectory_path is not None:
         record_kwargs["trajectory_path"] = str(trajectory_path)
     # Fallback: if caller didn't provide journal_path, use the first

--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -135,7 +135,7 @@ def post_session(
     trigger: str | None = None,
     category: str | None = None,
     recommended_category: str | None = None,
-    cascade_intent: dict | None = None,
+    cascade_intent: dict[str, Any] | None = None,
     exit_code: int = 0,
     duration_seconds: int = 0,
     trajectory_path: Path | None = None,
@@ -178,6 +178,10 @@ def post_session(
         Category recommended by the selector before the session ran
         (e.g. Thompson sampling, CASCADE). Stored alongside the actual
         category so drift between recommendation and reality is trackable.
+    cascade_intent:
+        Structured CASCADE selector metadata (for example ``{"reasons": [...],
+        "constraints": [...]}``) captured before the session ran. Stored
+        verbatim on the session record when provided.
     exit_code:
         Exit code from the agent process.  Non-zero (except 124 = timeout)
         marks the session as ``"failed"``.

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -194,7 +194,7 @@ class SessionRecord:
     category: str | None = None  # inferred from commits/files (what actually happened)
     recommended_category: str | None = None  # from Thompson sampling / CASCADE (what was intended)
     selector_mode: str | None = None  # e.g. scored, llm-context
-    cascade_intent: dict | None = None  # structured CASCADE reasons + constraints dict
+    cascade_intent: dict[str, Any] | None = None  # structured CASCADE reasons + constraints dict
 
     # Outcome
     outcome: str = "unknown"  # productive, noop, failed

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -194,6 +194,7 @@ class SessionRecord:
     category: str | None = None  # inferred from commits/files (what actually happened)
     recommended_category: str | None = None  # from Thompson sampling / CASCADE (what was intended)
     selector_mode: str | None = None  # e.g. scored, llm-context
+    cascade_intent: dict | None = None  # structured CASCADE reasons + constraints dict
 
     # Outcome
     outcome: str = "unknown"  # productive, noop, failed

--- a/packages/gptme-sessions/tests/test_post_session.py
+++ b/packages/gptme-sessions/tests/test_post_session.py
@@ -419,3 +419,26 @@ def test_post_session_explicit_category_overrides_inferred(tmp_path: Path):
 
     records = store.load_all()
     assert records[0].category == "code"
+
+
+def test_post_session_cascade_intent(tmp_path: Path):
+    """cascade_intent is stored in the SessionRecord when passed to post_session."""
+    store = SessionStore(sessions_dir=tmp_path)
+    cascade_intent = {
+        "reasons": ["recent CI failure", "priority score"],
+        "constraints": ["avoid social work"],
+    }
+
+    result = post_session(
+        store=store,
+        harness="claude-code",
+        model="opus",
+        cascade_intent=cascade_intent,
+        duration_seconds=120,
+    )
+    assert result.record.cascade_intent == cascade_intent
+
+    store2 = SessionStore(sessions_dir=tmp_path)
+    records = store2.load_all()
+    assert len(records) == 1
+    assert records[0].cascade_intent == cascade_intent

--- a/packages/gptme-sessions/tests/test_record.py
+++ b/packages/gptme-sessions/tests/test_record.py
@@ -107,6 +107,31 @@ def test_ab_group_tier_version_none_roundtrip():
     assert r2.tier_version is None
 
 
+def test_cascade_intent_roundtrip():
+    """cascade_intent survives to_dict/from_dict and JSON round-trip."""
+    cascade_intent = {
+        "reasons": ["high-priority task", "recent failure"],
+        "constraints": ["avoid project monitoring", "prefer code"],
+    }
+
+    r = SessionRecord(
+        harness="claude-code",
+        model="opus",
+        cascade_intent=cascade_intent,
+        outcome="productive",
+    )
+    d = r.to_dict()
+    assert d["cascade_intent"] == cascade_intent
+
+    r2 = SessionRecord.from_dict(d)
+    assert r2.cascade_intent == cascade_intent
+
+    parsed = json.loads(r.to_json())
+    assert parsed["cascade_intent"] == cascade_intent
+    r3 = SessionRecord.from_dict(parsed)
+    assert r3.cascade_intent == cascade_intent
+
+
 # -- project and session_name fields -----------------------------------------
 
 


### PR DESCRIPTION
Adds `cascade_intent` to `SessionRecord` for structured CASCADE metadata (reasons + constraints), and wires the field through `post_session()`.

No breaking changes: `cascade_intent` is optional (defaults to `None`), so existing records are unaffected.