### PR TITLE
fix(sessions): backfill copilot context metrics in sync

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -43,7 +43,24 @@ from .store import (
 
 logger = logging.getLogger(__name__)
 
-HARNESS_CHOICES = ["gptme", "claude-code", "codex", "copilot"]
+HARNESS_CHOICES = ["gptme", "claude-code", "codex", "copilot-cli"]
+
+# Maps usage dict keys (from extract_from_path) to SessionRecord field names.
+_USAGE_FIELD_MAP: dict[str, str] = {
+    "model": "model",
+    "total_tokens": "token_count",
+    "input_tokens": "input_tokens",
+    "output_tokens": "output_tokens",
+    "cache_creation_tokens": "cache_creation_tokens",
+    "cache_read_tokens": "cache_read_tokens",
+    "sys_prompt_tokens": "sys_prompt_tokens",
+    "context_peak_tokens": "context_peak_tokens",
+    "context_window": "context_window",
+    "sys_prompt_bytes": "sys_prompt_bytes",
+    "first_turn_bytes": "first_turn_bytes",
+    "context_peak_bytes": "context_peak_bytes",
+    "session_total_bytes": "session_total_bytes",
+}
 
 
 def _assign_if_missing(record: SessionRecord, field: str, value: object) -> bool:
@@ -59,6 +76,8 @@ def _assign_if_missing(record: SessionRecord, field: str, value: object) -> bool
             return True
         return False
     if current not in (None, "", 0, "unknown"):
+        return False
+    if current == value:
         return False
     setattr(record, field, value)
     return True
@@ -79,22 +98,7 @@ def _apply_extract_result_to_record(record: SessionRecord, result: dict) -> bool
 
     usage = result.get("usage")
     if isinstance(usage, dict):
-        field_map = {
-            "model": "model",
-            "total_tokens": "token_count",
-            "input_tokens": "input_tokens",
-            "output_tokens": "output_tokens",
-            "cache_creation_tokens": "cache_creation_tokens",
-            "cache_read_tokens": "cache_read_tokens",
-            "sys_prompt_tokens": "sys_prompt_tokens",
-            "context_peak_tokens": "context_peak_tokens",
-            "context_window": "context_window",
-            "sys_prompt_bytes": "sys_prompt_bytes",
-            "first_turn_bytes": "first_turn_bytes",
-            "context_peak_bytes": "context_peak_bytes",
-            "session_total_bytes": "session_total_bytes",
-        }
-        for usage_key, record_key in field_map.items():
+        for usage_key, record_key in _USAGE_FIELD_MAP.items():
             changed |= _assign_if_missing(record, record_key, usage.get(usage_key))
 
     return changed
@@ -112,22 +116,7 @@ def _apply_extract_result_to_kwargs(record_kwargs: dict, result: dict) -> None:
     if not isinstance(usage, dict):
         return
 
-    field_map = {
-        "model": "model",
-        "total_tokens": "token_count",
-        "input_tokens": "input_tokens",
-        "output_tokens": "output_tokens",
-        "cache_creation_tokens": "cache_creation_tokens",
-        "cache_read_tokens": "cache_read_tokens",
-        "sys_prompt_tokens": "sys_prompt_tokens",
-        "context_peak_tokens": "context_peak_tokens",
-        "context_window": "context_window",
-        "sys_prompt_bytes": "sys_prompt_bytes",
-        "first_turn_bytes": "first_turn_bytes",
-        "context_peak_bytes": "context_peak_bytes",
-        "session_total_bytes": "session_total_bytes",
-    }
-    for usage_key, record_key in field_map.items():
+    for usage_key, record_key in _USAGE_FIELD_MAP.items():
         value = usage.get(usage_key)
         if value is not None:
             record_kwargs[record_key] = value

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -1395,9 +1395,19 @@ def sync(
                 existing.project = entry["project"]
                 needs_update = True
 
-            usage_backfill_needed = any(
-                getattr(existing, field) is None
-                for field in (
+            # Copilot trajectories never contain token-count fields — only byte
+            # metrics and model name are extractable. Checking token fields for
+            # copilot-cli sessions would keep usage_backfill_needed=True forever.
+            if existing.harness == "copilot-cli":
+                _backfill_fields: tuple[str, ...] = (
+                    "model",
+                    "sys_prompt_bytes",
+                    "first_turn_bytes",
+                    "context_peak_bytes",
+                    "session_total_bytes",
+                )
+            else:
+                _backfill_fields = (
                     "token_count",
                     "input_tokens",
                     "output_tokens",
@@ -1411,6 +1421,8 @@ def sync(
                     "context_peak_bytes",
                     "session_total_bytes",
                 )
+            usage_backfill_needed = any(
+                getattr(existing, field) is None for field in _backfill_fields
             )
 
             if (

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -46,6 +46,93 @@ logger = logging.getLogger(__name__)
 HARNESS_CHOICES = ["gptme", "claude-code", "codex", "copilot"]
 
 
+def _assign_if_missing(record: SessionRecord, field: str, value: object) -> bool:
+    """Set ``record.field`` when it is empty/unknown and ``value`` is usable."""
+    if value is None:
+        return False
+    current = getattr(record, field)
+    if isinstance(current, list):
+        if current:
+            return False
+        if isinstance(value, list):
+            setattr(record, field, value)
+            return True
+        return False
+    if current not in (None, "", 0, "unknown"):
+        return False
+    setattr(record, field, value)
+    return True
+
+
+def _apply_extract_result_to_record(record: SessionRecord, result: dict) -> bool:
+    """Backfill missing fields on an existing record from ``extract_from_path`` output."""
+    changed = False
+
+    if record.outcome == "unknown":
+        record.outcome = "productive" if result.get("productive") else "noop"
+        changed = True
+    changed |= _assign_if_missing(
+        record, "duration_seconds", int(result.get("session_duration_s") or 0)
+    )
+    changed |= _assign_if_missing(record, "deliverables", result.get("deliverables", []))
+    changed |= _assign_if_missing(record, "category", result.get("inferred_category"))
+
+    usage = result.get("usage")
+    if isinstance(usage, dict):
+        field_map = {
+            "model": "model",
+            "total_tokens": "token_count",
+            "input_tokens": "input_tokens",
+            "output_tokens": "output_tokens",
+            "cache_creation_tokens": "cache_creation_tokens",
+            "cache_read_tokens": "cache_read_tokens",
+            "sys_prompt_tokens": "sys_prompt_tokens",
+            "context_peak_tokens": "context_peak_tokens",
+            "context_window": "context_window",
+            "sys_prompt_bytes": "sys_prompt_bytes",
+            "first_turn_bytes": "first_turn_bytes",
+            "context_peak_bytes": "context_peak_bytes",
+            "session_total_bytes": "session_total_bytes",
+        }
+        for usage_key, record_key in field_map.items():
+            changed |= _assign_if_missing(record, record_key, usage.get(usage_key))
+
+    return changed
+
+
+def _apply_extract_result_to_kwargs(record_kwargs: dict, result: dict) -> None:
+    """Populate new-record kwargs from ``extract_from_path`` output."""
+    record_kwargs["outcome"] = "productive" if result.get("productive") else "noop"
+    record_kwargs["duration_seconds"] = int(result.get("session_duration_s") or 0)
+    record_kwargs["deliverables"] = result.get("deliverables", [])
+    if result.get("inferred_category"):
+        record_kwargs["category"] = result["inferred_category"]
+
+    usage = result.get("usage")
+    if not isinstance(usage, dict):
+        return
+
+    field_map = {
+        "model": "model",
+        "total_tokens": "token_count",
+        "input_tokens": "input_tokens",
+        "output_tokens": "output_tokens",
+        "cache_creation_tokens": "cache_creation_tokens",
+        "cache_read_tokens": "cache_read_tokens",
+        "sys_prompt_tokens": "sys_prompt_tokens",
+        "context_peak_tokens": "context_peak_tokens",
+        "context_window": "context_window",
+        "sys_prompt_bytes": "sys_prompt_bytes",
+        "first_turn_bytes": "first_turn_bytes",
+        "context_peak_bytes": "context_peak_bytes",
+        "session_total_bytes": "session_total_bytes",
+    }
+    for usage_key, record_key in field_map.items():
+        value = usage.get(usage_key)
+        if value is not None:
+            record_kwargs[record_key] = value
+
+
 def _judge_fields(
     score: float | None,
     reason: str | None,
@@ -128,7 +215,7 @@ def _discover_all(
         for p in discover_copilot_sessions(start, today):
             discovered.append(
                 {
-                    "harness": "copilot",
+                    "harness": "copilot-cli",
                     "path": p,
                     "session_date": session_date_from_path("copilot", p),
                     "session_name": extract_session_name("copilot", p),
@@ -835,7 +922,7 @@ def discover(
         for p in discover_copilot_sessions(start, today):
             discovered.append(
                 {
-                    "harness": "copilot",
+                    "harness": "copilot-cli",
                     "path": str(p),
                     "session_date": session_date_from_path("copilot", p),
                 }
@@ -1319,18 +1406,33 @@ def sync(
                 existing.project = entry["project"]
                 needs_update = True
 
-            # With --signals, backfill records that have no outcome yet.
-            if with_signals and existing.outcome == "unknown" and traj_path.is_file():
+            usage_backfill_needed = any(
+                getattr(existing, field) is None
+                for field in (
+                    "token_count",
+                    "input_tokens",
+                    "output_tokens",
+                    "cache_creation_tokens",
+                    "cache_read_tokens",
+                    "sys_prompt_tokens",
+                    "context_peak_tokens",
+                    "context_window",
+                    "sys_prompt_bytes",
+                    "first_turn_bytes",
+                    "context_peak_bytes",
+                    "session_total_bytes",
+                )
+            )
+
+            if (
+                with_signals
+                and traj_path.is_file()
+                and (existing.outcome == "unknown" or usage_backfill_needed)
+            ):
                 if not dry_run:
                     try:
                         result = extract_from_path(traj_path)
-                        existing.outcome = "productive" if result.get("productive") else "noop"
-                        existing.duration_seconds = int(result.get("session_duration_s") or 0)
-                        if not existing.deliverables:
-                            existing.deliverables = result.get("deliverables", [])
-                        if result.get("inferred_category") and not existing.category:
-                            existing.category = result["inferred_category"]
-                        needs_update = True
+                        needs_update |= _apply_extract_result_to_record(existing, result)
                     except Exception as exc:
                         click.echo(
                             f"  warning: signals extraction failed for {path_str}: {exc}",
@@ -1340,7 +1442,11 @@ def sync(
                             skipped += 1
                 else:
                     needs_update = True  # mark for dry-run reporting
-            elif with_signals and existing.outcome == "unknown" and not traj_path.is_file():
+            elif (
+                with_signals
+                and not traj_path.is_file()
+                and (existing.outcome == "unknown" or usage_backfill_needed)
+            ):
                 click.echo(
                     f"  warning: trajectory not found, cannot backfill signals for {path_str}",
                     err=True,
@@ -1396,11 +1502,7 @@ def sync(
         if with_signals and traj_path.is_file() and not dry_run:
             try:
                 result = extract_from_path(traj_path)
-                record_kwargs["outcome"] = "productive" if result.get("productive") else "noop"
-                record_kwargs["duration_seconds"] = int(result.get("session_duration_s") or 0)
-                record_kwargs["deliverables"] = result.get("deliverables", [])
-                if result.get("inferred_category"):
-                    record_kwargs["category"] = result["inferred_category"]
+                _apply_extract_result_to_kwargs(record_kwargs, result)
             except Exception as exc:
                 click.echo(
                     f"  warning: signals extraction failed for {path_str}: {exc}",

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -200,7 +200,7 @@ def _discover_all(
                     "project": extract_project("codex", p),
                 }
             )
-    if harness_filter in (None, "copilot"):
+    if harness_filter in (None, "copilot-cli"):
         for p in discover_copilot_sessions(start, today):
             discovered.append(
                 {
@@ -907,7 +907,7 @@ def discover(
                 }
             )
 
-    if harness in (None, "copilot"):
+    if harness in (None, "copilot-cli"):
         for p in discover_copilot_sessions(start, today):
             discovered.append(
                 {

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -1791,6 +1791,8 @@ def extract_usage_copilot(msgs: list[dict]) -> dict:
     for record in msgs:
         rec_type = record.get("type", "")
         data = record.get("data") or {}
+        if not isinstance(data, dict):
+            continue
         if rec_type == "session.model_change":
             m = data.get("newModel")
             if m:
@@ -1800,8 +1802,6 @@ def extract_usage_copilot(msgs: list[dict]) -> dict:
             m = data.get("selectedModel")
             if m:
                 model = m
-        elif not isinstance(data, dict):
-            continue
 
         if rec_type == "system.message":
             messages.append({"role": "system", "bytes": _content_bytes(data.get("content"))})

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -937,6 +937,68 @@ def _message_content_bytes(msg: dict) -> int:
     return len(str(content).encode("utf-8"))
 
 
+def _content_bytes(value: object) -> int:
+    """Count UTF-8 bytes for arbitrary event payload content."""
+    if value is None:
+        return 0
+    if isinstance(value, str):
+        return len(value.encode("utf-8"))
+    if isinstance(value, list):
+        return sum(_content_bytes(item) for item in value)
+    return len(json.dumps(value, ensure_ascii=False).encode("utf-8"))
+
+
+def _summarize_message_bytes(
+    messages: list[dict[str, object]],
+) -> tuple[int | None, int | None, int | None, int | None]:
+    """Summarize byte-level context growth from normalized message entries."""
+    if not messages:
+        return None, None, None, None
+
+    sys_prompt_bytes = 0
+    for msg in messages:
+        role = msg.get("role")
+        msg_bytes = msg.get("bytes")
+        if not isinstance(msg_bytes, int):
+            continue
+        if role == "user":
+            break
+        if role == "system":
+            sys_prompt_bytes += msg_bytes
+
+    first_turn_bytes = 0
+    for msg in messages:
+        msg_bytes = msg.get("bytes")
+        if not isinstance(msg_bytes, int):
+            continue
+        if msg.get("role") == "assistant":
+            break
+        first_turn_bytes += msg_bytes
+
+    context_peak_bytes = 0
+    cumulative = 0
+    for msg in messages:
+        msg_bytes = msg.get("bytes")
+        if not isinstance(msg_bytes, int):
+            continue
+        cumulative += msg_bytes
+        if msg.get("role") == "assistant":
+            context_before = cumulative - msg_bytes
+            if context_before > context_peak_bytes:
+                context_peak_bytes = context_before
+
+    session_total_bytes = sum(
+        msg_bytes for msg in messages if isinstance((msg_bytes := msg.get("bytes")), int)
+    )
+
+    return (
+        sys_prompt_bytes if sys_prompt_bytes > 0 else None,
+        first_turn_bytes if first_turn_bytes > 0 else None,
+        context_peak_bytes if context_peak_bytes > 0 else None,
+        session_total_bytes if session_total_bytes > 0 else None,
+    )
+
+
 def extract_usage_gptme(msgs: list[dict]) -> dict:
     """Extract cumulative token usage from a gptme conversation.jsonl trajectory.
 
@@ -1710,33 +1772,84 @@ def infer_category(signals: dict) -> str | None:
 
 
 def extract_usage_copilot(msgs: list[dict]) -> dict:
-    """Extract model info from Copilot CLI events.jsonl trajectories.
+    """Extract model info and byte-level context metrics from Copilot trajectories.
 
     Copilot events do not include per-turn token counts or cost data.
     We extract the model name from ``session.model_change`` events (or
     from ``session.start`` context if available) so callers always get a
-    consistent ``{"model": ...}`` dict across all harnesses.
+    consistent usage dict across all harnesses.
 
-    Returns an empty dict if no model information is found.
+    Tool requests live on assistant messages and tool outputs live on
+    ``tool.execution_complete`` events, so both are counted in the byte-level
+    message flow to avoid underestimating context growth.
+
+    Returns an empty dict only when neither model info nor byte metrics are found.
     """
     model: str | None = None
+    messages: list[dict[str, object]] = []
 
     for record in msgs:
         rec_type = record.get("type", "")
+        data = record.get("data") or {}
         if rec_type == "session.model_change":
-            m = (record.get("data") or {}).get("newModel")
+            m = data.get("newModel")
             if m:
                 model = m
         elif rec_type == "session.start" and model is None:
             # Some versions may include model in start context
-            data = record.get("data") or {}
             m = data.get("selectedModel")
             if m:
                 model = m
+        elif not isinstance(data, dict):
+            continue
 
-    if model is None:
+        if rec_type == "system.message":
+            messages.append({"role": "system", "bytes": _content_bytes(data.get("content"))})
+        elif rec_type == "user.message":
+            content = data.get("content")
+            if content is None:
+                content = data.get("text")
+            messages.append({"role": "user", "bytes": _content_bytes(content)})
+        elif rec_type == "assistant.message":
+            content = data.get("content")
+            if content is None:
+                content = data.get("text")
+            messages.append(
+                {
+                    "role": "assistant",
+                    "bytes": _content_bytes(content) + _content_bytes(data.get("toolRequests")),
+                }
+            )
+        elif rec_type == "tool.execution_complete":
+            payload = data.get("result")
+            if payload is None:
+                payload = data.get("error")
+            messages.append({"role": "tool", "bytes": _content_bytes(payload)})
+
+    sys_prompt_bytes, first_turn_bytes, context_peak_bytes, session_total_bytes = (
+        _summarize_message_bytes(messages)
+    )
+    if (
+        model is None
+        and sys_prompt_bytes is None
+        and first_turn_bytes is None
+        and context_peak_bytes is None
+        and session_total_bytes is None
+    ):
         return {}
-    return {"model": model}
+
+    usage: dict[str, object] = {}
+    if model is not None:
+        usage["model"] = model
+    if sys_prompt_bytes is not None:
+        usage["sys_prompt_bytes"] = sys_prompt_bytes
+    if first_turn_bytes is not None:
+        usage["first_turn_bytes"] = first_turn_bytes
+    if context_peak_bytes is not None:
+        usage["context_peak_bytes"] = context_peak_bytes
+    if session_total_bytes is not None:
+        usage["session_total_bytes"] = session_total_bytes
+    return usage
 
 
 def extract_from_path(jsonl_path: Path) -> dict:

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -4203,7 +4203,9 @@ def test_extract_from_path_copilot(tmp_path: Path):
     assert result["format"] == "copilot"
     assert result["tool_calls"]["bash"] == 1
     # Model extracted from session.start.selectedModel
-    assert result["usage"] == {"model": "claude-opus-4.6"}
+    assert result["usage"]["model"] == "claude-opus-4.6"
+    assert "sys_prompt_bytes" not in result["usage"]
+    assert "first_turn_bytes" not in result["usage"]
 
 
 def test_extract_usage_copilot_model_change():
@@ -4228,7 +4230,7 @@ def test_extract_usage_copilot_model_change():
         },
     ]
     usage = extract_usage_copilot(msgs)
-    assert usage == {"model": "claude-sonnet-4.6"}
+    assert usage["model"] == "claude-sonnet-4.6"
 
 
 def test_extract_usage_copilot_session_start_selected_model():
@@ -4250,11 +4252,11 @@ def test_extract_usage_copilot_session_start_selected_model():
         },
     ]
     usage = extract_usage_copilot(msgs)
-    assert usage == {"model": "claude-opus-4.6"}
+    assert usage["model"] == "claude-opus-4.6"
 
 
 def test_extract_usage_copilot_no_model():
-    """extract_usage_copilot returns empty dict when no model info available."""
+    """extract_usage_copilot can still return byte metrics when model info is absent."""
     from gptme_sessions.signals import extract_usage_copilot
 
     msgs = [
@@ -4263,12 +4265,19 @@ def test_extract_usage_copilot_no_model():
             "data": {"sessionId": "test", "producer": "copilot-agent"},
         },
         {
+            "type": "user.message",
+            "data": {"content": "hello"},
+        },
+        {
             "type": "assistant.message",
-            "data": {"toolRequests": []},
+            "data": {"content": "hi", "toolRequests": []},
         },
     ]
     usage = extract_usage_copilot(msgs)
-    assert usage == {}
+    assert "model" not in usage
+    assert usage["first_turn_bytes"] == len("hello".encode())
+    assert usage["context_peak_bytes"] == len("hello".encode())
+    assert usage["session_total_bytes"] == len("hellohi".encode())
 
 
 def test_extract_usage_copilot_multiple_model_changes():
@@ -4286,7 +4295,45 @@ def test_extract_usage_copilot_multiple_model_changes():
         },
     ]
     usage = extract_usage_copilot(msgs)
-    assert usage == {"model": "gpt-5.4"}
+    assert usage["model"] == "gpt-5.4"
+
+
+def test_extract_usage_copilot_includes_byte_metrics():
+    """extract_usage_copilot includes byte-level context metrics for Copilot sessions."""
+    from gptme_sessions.signals import extract_usage_copilot
+
+    system_text = "SYS"
+    user_text = "USER"
+    assistant_text = "ASSIST"
+    tool_requests = [{"name": "bash", "arguments": {"command": "echo hi"}}]
+    tool_result = {"content": "OUT"}
+
+    msgs = [
+        {
+            "type": "session.start",
+            "data": {
+                "sessionId": "test",
+                "producer": "copilot-agent",
+                "selectedModel": "gpt-5.4",
+            },
+        },
+        {"type": "system.message", "data": {"content": system_text}},
+        {"type": "user.message", "data": {"content": user_text}},
+        {
+            "type": "assistant.message",
+            "data": {"content": assistant_text, "toolRequests": tool_requests},
+        },
+        {"type": "tool.execution_complete", "data": {"result": tool_result, "success": True}},
+    ]
+
+    usage = extract_usage_copilot(msgs)
+
+    assert usage["model"] == "gpt-5.4"
+    assert usage["sys_prompt_bytes"] == len(system_text.encode())
+    assert usage["first_turn_bytes"] == len(system_text.encode()) + len(user_text.encode())
+    assert usage["context_peak_bytes"] == len(system_text.encode()) + len(user_text.encode())
+    assert usage["session_total_bytes"] > usage["context_peak_bytes"]
+    assert usage["session_total_bytes"] > usage["first_turn_bytes"]
 
 
 def test_extract_from_path_copilot_with_model(tmp_path: Path):
@@ -5949,6 +5996,128 @@ def test_sync_signals_backfills_existing_records(tmp_path: Path, capsys, monkeyp
     assert records[0].outcome == "productive"
     assert records[0].duration_seconds == 300
     assert records[0].category == "code"
+
+
+def test_sync_signals_import_persists_usage_fields(tmp_path: Path, capsys, monkeypatch):
+    """sync --signals persists extracted usage/context fields on new records."""
+    import sys
+
+    from gptme_sessions import SessionStore
+    from gptme_sessions.cli import main
+
+    fake_file = tmp_path / "session.jsonl"
+    fake_file.touch()
+
+    monkeypatch.setattr("gptme_sessions.cli.discover_gptme_sessions", lambda *a, **kw: [])
+    monkeypatch.setattr("gptme_sessions.cli.discover_cc_sessions", lambda *a, **kw: [])
+    monkeypatch.setattr("gptme_sessions.cli.discover_codex_sessions", lambda *a, **kw: [])
+    monkeypatch.setattr(
+        "gptme_sessions.cli.discover_copilot_sessions", lambda *a, **kw: [fake_file]
+    )
+    monkeypatch.setattr(
+        "gptme_sessions.cli.extract_from_path",
+        lambda p: {
+            "productive": True,
+            "session_duration_s": 45,
+            "deliverables": [],
+            "inferred_category": "monitoring",
+            "usage": {
+                "model": "gpt-5.4",
+                "sys_prompt_bytes": 100,
+                "first_turn_bytes": 200,
+                "context_peak_bytes": 200,
+                "session_total_bytes": 350,
+            },
+        },
+    )
+
+    sessions_dir = tmp_path / "sessions"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["gptme-sessions", "--sessions-dir", str(sessions_dir), "sync", "--signals"],
+    )
+    rc = main()
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "Imported 1" in captured.out
+
+    store = SessionStore(sessions_dir=sessions_dir)
+    records = store.load_all()
+    assert len(records) == 1
+    assert records[0].harness == "copilot-cli"
+    assert records[0].model == "gpt-5.4"
+    assert records[0].sys_prompt_bytes == 100
+    assert records[0].first_turn_bytes == 200
+    assert records[0].context_peak_bytes == 200
+    assert records[0].session_total_bytes == 350
+
+
+def test_sync_signals_backfills_usage_for_existing_known_record(
+    tmp_path: Path, capsys, monkeypatch
+):
+    """sync --signals backfills missing usage/context fields even when outcome is known."""
+    import sys
+
+    from gptme_sessions import SessionRecord, SessionStore
+    from gptme_sessions.cli import main
+
+    fake_file = tmp_path / "session.jsonl"
+    fake_file.touch()
+
+    monkeypatch.setattr("gptme_sessions.cli.discover_gptme_sessions", lambda *a, **kw: [])
+    monkeypatch.setattr("gptme_sessions.cli.discover_cc_sessions", lambda *a, **kw: [])
+    monkeypatch.setattr("gptme_sessions.cli.discover_codex_sessions", lambda *a, **kw: [])
+    monkeypatch.setattr(
+        "gptme_sessions.cli.discover_copilot_sessions", lambda *a, **kw: [fake_file]
+    )
+    monkeypatch.setattr(
+        "gptme_sessions.cli.extract_from_path",
+        lambda p: {
+            "productive": True,
+            "session_duration_s": 90,
+            "deliverables": [],
+            "inferred_category": "monitoring",
+            "usage": {
+                "model": "gpt-5.4",
+                "sys_prompt_bytes": 120,
+                "first_turn_bytes": 260,
+                "context_peak_bytes": 260,
+                "session_total_bytes": 400,
+            },
+        },
+    )
+
+    sessions_dir = tmp_path / "sessions"
+    store = SessionStore(sessions_dir=sessions_dir)
+    store.append(
+        SessionRecord(
+            harness="copilot-cli",
+            trajectory_path=str(fake_file),
+            outcome="productive",
+            duration_seconds=12,
+        )
+    )
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["gptme-sessions", "--sessions-dir", str(sessions_dir), "sync", "--signals"],
+    )
+    rc = main()
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "updated 1" in captured.out
+
+    records = store.load_all()
+    assert len(records) == 1
+    assert records[0].outcome == "productive"
+    assert records[0].duration_seconds == 12
+    assert records[0].model == "gpt-5.4"
+    assert records[0].sys_prompt_bytes == 120
+    assert records[0].first_turn_bytes == 260
+    assert records[0].context_peak_bytes == 260
+    assert records[0].session_total_bytes == 400
 
 
 def test_sync_signals_does_not_overwrite_existing_deliverables(tmp_path: Path, capsys, monkeypatch):

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -5941,6 +5941,23 @@ def test_sync_captures_gptme_model_from_config(tmp_path: Path, capsys, monkeypat
     assert records[0].model_normalized == "sonnet"
 
 
+def test_assign_if_missing_no_false_positive_on_zero():
+    """_assign_if_missing must not return True when current == value == 0."""
+    from gptme_sessions import SessionRecord
+    from gptme_sessions.cli import _assign_if_missing
+
+    record = SessionRecord(harness="copilot-cli", trajectory_path="/tmp/x.jsonl")
+    record.duration_seconds = 0
+    changed = _assign_if_missing(record, "duration_seconds", 0)
+    assert not changed, "zero == zero should not be treated as a change"
+    assert record.duration_seconds == 0
+
+    # Sanity-check: a real new value must still trigger a change.
+    changed = _assign_if_missing(record, "duration_seconds", 42)
+    assert changed
+    assert record.duration_seconds == 42
+
+
 def test_sync_signals_backfills_existing_records(tmp_path: Path, capsys, monkeypatch):
     """sync --signals updates existing records that have outcome=unknown."""
     import sys


### PR DESCRIPTION
## Summary
- persist extracted usage/context fields during `gptme-sessions sync --signals` for new imports
- backfill missing usage/context fields on existing records even when outcome is already known
- add byte-level copilot usage extraction and align synced harness naming with `copilot-cli`

## Testing
- `uv run pytest packages/gptme-sessions/tests/test_sessions.py -q -k 'copilot or sync_signals'`
- `uv run pytest packages/gptme-sessions/tests -q`
- `make typecheck`
