### PR TITLE
fix(runloops): truncate lockfile on release to clear stale PIDs

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/utils/lock.py
+++ b/packages/gptme-runloops/src/gptme_runloops/utils/lock.py
@@ -1,9 +1,12 @@
 """File-based locking for run loops to prevent concurrent execution."""
 
 import fcntl
+import logging
 import os
 import time
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 class RunLoopLock:
@@ -140,8 +143,8 @@ class RunLoopLock:
             # prevents wiping a successor's PID. See ErikBjare/bob#755.
             try:
                 os.ftruncate(self.lock_fd, 0)
-            except OSError:
-                pass
+            except OSError as e:
+                logger.warning("Could not truncate lockfile %s: %s", self.lock_file, e)
 
             # Release lock and close file descriptor
             fcntl.flock(self.lock_fd, fcntl.LOCK_UN)

--- a/packages/gptme-runloops/src/gptme_runloops/utils/lock.py
+++ b/packages/gptme-runloops/src/gptme_runloops/utils/lock.py
@@ -134,6 +134,15 @@ class RunLoopLock:
             # Log to history before releasing
             self._log_history("RELEASED")
 
+            # Truncate lockfile contents BEFORE releasing flock — keeps the file
+            # honest for diagnostic readers ("cat lockfile" returns empty when no
+            # process holds the lock). Doing this while we still hold the lock
+            # prevents wiping a successor's PID. See ErikBjare/bob#755.
+            try:
+                os.ftruncate(self.lock_fd, 0)
+            except OSError:
+                pass
+
             # Release lock and close file descriptor
             fcntl.flock(self.lock_fd, fcntl.LOCK_UN)
             os.close(self.lock_fd)

--- a/packages/gptme-runloops/tests/test_lock.py
+++ b/packages/gptme-runloops/tests/test_lock.py
@@ -106,3 +106,25 @@ def test_lock_pid_written():
         assert str(os.getpid()) in content
 
         lock.release()
+
+
+def test_lock_file_truncated_on_release():
+    """Test that lockfile is truncated on release so stale PIDs don't persist.
+
+    Regression test for ErikBjare/bob#755: after a process exits cleanly, the
+    lockfile should not retain its PID — otherwise diagnostic readers see a
+    stale PID and can't tell whether the lock is actually held.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        lock = RunLoopLock(Path(tmpdir), "test")
+
+        lock.acquire()
+        assert str(os.getpid()) in lock.lock_file.read_text()
+
+        lock.release()
+
+        # After release, lockfile content should be empty (or absent).
+        # The kernel-level flock is what controls mutual exclusion; the file
+        # contents are purely informational, so empty == "lock not held".
+        if lock.lock_file.exists():
+            assert lock.lock_file.read_text().strip() == ""

--- a/packages/gptme-runloops/tests/test_lock.py
+++ b/packages/gptme-runloops/tests/test_lock.py
@@ -123,8 +123,8 @@ def test_lock_file_truncated_on_release():
 
         lock.release()
 
-        # After release, lockfile content should be empty (or absent).
-        # The kernel-level flock is what controls mutual exclusion; the file
-        # contents are purely informational, so empty == "lock not held".
-        if lock.lock_file.exists():
-            assert lock.lock_file.read_text().strip() == ""
+        # After release, lockfile should exist but be empty. The kernel-level
+        # flock is what controls mutual exclusion; the file contents are purely
+        # informational, so empty == "lock not held".
+        assert lock.lock_file.exists()
+        assert lock.lock_file.read_text().strip() == ""


### PR DESCRIPTION
## Summary

`RunLoopLock` (used by autonomous, project-monitoring, email runloops) keeps the holder's PID written to the lockfile after release. The kernel `fcntl.flock` correctly releases on process exit, but the PID stays in the file — making `cat /home/bob/bob/logs/gptme-project-monitoring.lock` lie to operators investigating concurrent run issues.

This was the cosmetic root cause behind ErikBjare/bob#755: a dead PID stayed in the lockfile for over an hour while no process actually held the lock, confusing diagnosis during the 2026-05-07 outage.

## Fix

Truncate the lockfile to 0 bytes before releasing the flock. Still holding the lock during the truncate prevents wiping a successor's PID. Empty contents now accurately mean "lock not held."

## Test plan
- [x] New regression test: `test_lock_file_truncated_on_release` (RED → GREEN)
- [x] All 188 existing gptme-runloops tests still pass
- [x] No behavioral change for actual mutual exclusion (kernel flock is still the mutex)

Refs ErikBjare/bob#755