### PR TITLE
feat(sessions): extract outputTokens from copilot-cli assistant messages

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -1772,13 +1772,14 @@ def infer_category(signals: dict) -> str | None:
 
 
 def extract_usage_copilot(msgs: list[dict]) -> dict:
-    """Extract model info and byte-level context metrics from Copilot trajectories.
+    """Extract model info, byte-level context metrics, and output tokens from Copilot trajectories.
 
-    Copilot events do not include per-turn token counts or cost data.
-    We extract the model name from ``session.model_change`` events (or
-    from ``session.start`` context if available) so callers always get a
-    consistent usage dict across all harnesses.
+    Copilot events expose ``outputTokens`` per assistant turn but not input tokens,
+    so ``sys_prompt_tokens`` / ``context_peak_tokens`` remain unavailable; callers
+    should fall back to byte-level estimates for those.  We sum ``outputTokens``
+    across all assistant messages to populate ``output_tokens``.
 
+    Model is extracted from ``session.model_change`` events (or ``session.start``).
     Tool requests live on assistant messages and tool outputs live on
     ``tool.execution_complete`` events, so both are counted in the byte-level
     message flow to avoid underestimating context growth.
@@ -1787,6 +1788,7 @@ def extract_usage_copilot(msgs: list[dict]) -> dict:
     """
     model: str | None = None
     messages: list[dict[str, object]] = []
+    total_output_tokens = 0
 
     for record in msgs:
         rec_type = record.get("type", "")
@@ -1820,6 +1822,9 @@ def extract_usage_copilot(msgs: list[dict]) -> dict:
                     "bytes": _content_bytes(content) + _content_bytes(data.get("toolRequests")),
                 }
             )
+            tok = data.get("outputTokens")
+            if isinstance(tok, int) and tok > 0:
+                total_output_tokens += tok
         elif rec_type == "tool.execution_complete":
             payload = data.get("result")
             if payload is None:
@@ -1835,6 +1840,7 @@ def extract_usage_copilot(msgs: list[dict]) -> dict:
         and first_turn_bytes is None
         and context_peak_bytes is None
         and session_total_bytes is None
+        and total_output_tokens == 0
     ):
         return {}
 
@@ -1849,6 +1855,8 @@ def extract_usage_copilot(msgs: list[dict]) -> dict:
         usage["context_peak_bytes"] = context_peak_bytes
     if session_total_bytes is not None:
         usage["session_total_bytes"] = session_total_bytes
+    if total_output_tokens > 0:
+        usage["output_tokens"] = total_output_tokens
     return usage
 
 

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -4336,6 +4336,50 @@ def test_extract_usage_copilot_includes_byte_metrics():
     assert usage["session_total_bytes"] > usage["first_turn_bytes"]
 
 
+def test_extract_usage_copilot_output_tokens():
+    """extract_usage_copilot sums outputTokens from assistant.message events."""
+    from gptme_sessions.signals import extract_usage_copilot
+
+    msgs = [
+        {
+            "type": "session.start",
+            "data": {"sessionId": "test", "producer": "copilot-agent", "selectedModel": "gpt-5.4"},
+        },
+        {"type": "system.message", "data": {"content": "SYS"}},
+        {"type": "user.message", "data": {"content": "hi"}},
+        {
+            "type": "assistant.message",
+            "data": {"content": "hello", "outputTokens": 300},
+        },
+        {"type": "user.message", "data": {"content": "continue"}},
+        {
+            "type": "assistant.message",
+            "data": {"content": "world", "outputTokens": 150},
+        },
+    ]
+
+    usage = extract_usage_copilot(msgs)
+
+    assert usage["output_tokens"] == 450
+    assert usage["model"] == "gpt-5.4"
+
+
+def test_extract_usage_copilot_no_output_tokens():
+    """extract_usage_copilot omits output_tokens when no outputTokens present."""
+    from gptme_sessions.signals import extract_usage_copilot
+
+    msgs = [
+        {
+            "type": "session.start",
+            "data": {"sessionId": "test", "producer": "copilot-agent", "selectedModel": "gpt-5.4"},
+        },
+        {"type": "assistant.message", "data": {"content": "hello"}},
+    ]
+
+    usage = extract_usage_copilot(msgs)
+    assert "output_tokens" not in usage
+
+
 def test_extract_from_path_copilot_with_model(tmp_path: Path):
     """extract_from_path includes usage with model when model_change is present."""
     trajectory_file = tmp_path / "events.jsonl"


### PR DESCRIPTION
## Problem

Copilot-cli session records show `output_tokens: None` even though copilot
`assistant.message` events emit `outputTokens` per turn. This meant
cost/volume tracking was completely blind for copilot sessions.

## Solution

Sum `outputTokens` across all `assistant.message` events in
`extract_usage_copilot()` and expose it as `output_tokens` in the returned
usage dict.

**What copilot exposes vs what it doesn't:**
- ✅ `outputTokens` per turn → now extracted as `output_tokens`
- ❌ Input tokens per turn (not available in events format) — byte-level fallback handles context-lengths tracking

## Testing

Added 2 new tests:
- `test_extract_usage_copilot_output_tokens` — verifies accumulation across turns (300+150=450)
- `test_extract_usage_copilot_no_output_tokens` — verifies field is omitted when missing

All 7 `extract_usage_copilot` tests pass.

## Related

- Closes ErikBjare/bob#760
- Part of context-lengths tracking work in ErikBjare/bob#738