### PR TITLE
fix(gptodo): preserve ISO 8601 'T' separator on datetime round-trip

### DIFF
--- a/packages/gptodo/src/gptodo/frontmatter_compat.py
+++ b/packages/gptodo/src/gptodo/frontmatter_compat.py
@@ -1,10 +1,39 @@
 from __future__ import annotations
 
 import re
+from datetime import date, datetime
 from pathlib import Path
 from typing import Any, TextIO
 
 import yaml  # type: ignore[import-untyped]
+
+
+def _datetime_representer(dumper: yaml.SafeDumper, data: datetime) -> yaml.ScalarNode:
+    """Serialize datetime with ISO 8601 'T' separator instead of PyYAML's default space.
+
+    PyYAML's default timestamp serialization uses a space between the date and time,
+    producing values like '2026-05-01 09:31:00+00:00' that the workspace task validator
+    rejects. This representer preserves the strict ISO 8601 form.
+    """
+    return dumper.represent_scalar("tag:yaml.org,2002:timestamp", data.isoformat())
+
+
+def _date_representer(dumper: yaml.SafeDumper, data: date) -> yaml.ScalarNode:
+    """Serialize date as plain ISO 8601 (YYYY-MM-DD)."""
+    return dumper.represent_scalar("tag:yaml.org,2002:timestamp", data.isoformat())
+
+
+# Register on every SafeDumper variant we might encounter:
+#   - yaml.SafeDumper (pure-Python, used by the compat shim)
+#   - yaml.CSafeDumper (C-accelerated, used by python-frontmatter when libyaml
+#     is available — different class, separate representer table)
+_DUMPERS: list[Any] = [yaml.SafeDumper]
+_csafe = getattr(yaml, "CSafeDumper", None)
+if _csafe is not None:
+    _DUMPERS.append(_csafe)
+for _dumper in _DUMPERS:
+    _dumper.add_representer(datetime, _datetime_representer)
+    _dumper.add_representer(date, _date_representer)
 
 
 class Post(dict[str, Any]):

--- a/packages/gptodo/tests/test_frontmatter_compat.py
+++ b/packages/gptodo/tests/test_frontmatter_compat.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from datetime import date, datetime, timezone
 from pathlib import Path
 
-from gptodo.frontmatter_compat import Post, dumps, load, loads
+import yaml
+
+from gptodo.frontmatter_compat import Post, dumps, frontmatter, load, loads
 
 
 def test_loads_frontmatter_file(tmp_path: Path) -> None:
@@ -29,3 +32,39 @@ def test_dumps_roundtrips_post_metadata() -> None:
 
     assert reparsed.metadata == {"state": "done", "created": "2026-04-06"}
     assert reparsed.content == "# Task\n"
+
+
+def test_datetime_round_trip_preserves_iso_t_separator() -> None:
+    """A YAML datetime value must round-trip with the 'T' separator intact.
+
+    PyYAML's default timestamp serialization uses a space, which the workspace
+    task validator rejects. This test guards against the regression where a
+    `frontmatter.load -> frontmatter.dumps` cycle silently rewrites
+    `2026-05-01T09:31:00+00:00` as `2026-05-01 09:31:00+00:00`.
+    """
+    text = (
+        "---\n"
+        "created: 2026-05-01T09:31:00+00:00\n"
+        "state: waiting\n"
+        "waiting_since: 2026-05-02\n"
+        "---\n"
+        "body\n"
+    )
+    post = frontmatter.loads(text)
+    out = frontmatter.dumps(post)
+
+    assert "2026-05-01T09:31:00" in out, f"datetime T separator lost: {out!r}"
+    assert "2026-05-02" in out
+
+
+def test_safe_dump_datetime_uses_t_separator() -> None:
+    """yaml.safe_dump must also use the T separator after the representer is registered."""
+    rendered = yaml.safe_dump({"created": datetime(2026, 5, 1, 9, 31, 0, tzinfo=timezone.utc)})
+    assert "2026-05-01T09:31:00" in rendered, rendered
+
+
+def test_date_round_trip_stays_iso() -> None:
+    """A bare date must serialize as YYYY-MM-DD (no spurious time component)."""
+    post = Post(content="body", waiting_since=date(2026, 5, 2))
+    rendered = dumps(post)
+    assert "waiting_since: 2026-05-02" in rendered


### PR DESCRIPTION
## Summary

PyYAML's default timestamp serialization uses a space between the date and time, producing values like `2026-05-01 09:31:00+00:00`. The workspace task validator requires the strict ISO 8601 form with `T`.

Every gptodo write goes through `frontmatter.dumps -> yaml dumper`, so a `frontmatter.load -> mutate -> frontmatter.dumps` cycle silently rewrites all datetime fields and breaks pre-commit on tasks that were previously valid. Bob's repo has had to run a normalization sweep multiple times to recover (e.g. ErikBjare/bob commit 161f99f79 normalized 53 task files in one go on May 6, and 2 days later 2 tasks regressed via the same path).

## Fix

Register a representer for `datetime`/`date` on `yaml.SafeDumper` and `yaml.CSafeDumper` (the C-accelerated variant python-frontmatter uses when libyaml is available). The representer emits `.isoformat()`, so the `T` separator survives the round-trip.

Both dumpers need it because they have separate representer tables — registering on `yaml.SafeDumper` alone doesn't catch python-frontmatter's writes.

## Test plan

- [x] Added regression test: `frontmatter.load -> frontmatter.dumps` preserves `T` separator
- [x] Added regression test: bare `yaml.safe_dump` of a datetime uses `T`
- [x] Added regression test: bare `date` round-trips as `YYYY-MM-DD`
- [x] All 191 gptodo tests pass
- [x] `make typecheck` clean