### PR TITLE
chore(lessons): prune 11 dead keywords from greptile-pr-reviews

### DIFF
--- a/lessons/tools/greptile-pr-reviews.md
+++ b/lessons/tools/greptile-pr-reviews.md
@@ -10,19 +10,8 @@ match:
     - "greptile found issues in PR"
     - "greptile score"
     - "trigger greptile"
-    - "retrigger a re-review"
-    - "retrigger greptile"
     - "pushed fixes after the earlier Greptile"
     - "after the earlier Greptile review"
-    - "retrigger automated review"
-    - "bot re-review after fixes"
-    - "new commits after bot review"
-    - "request another bot review"
-    - "make the bot take another look"
-    - "bot take another look"
-    - "addressed the automated reviewer"
-    - "automated reviewer's feedback"
-    - "how do I retrigger greptile"
   session_categories: [cross-repo, code]
 status: active
 ---


### PR DESCRIPTION
## Summary

Pruned 11 dead keyword variants from `lessons/tools/greptile-pr-reviews.md`
that never fired in trajectories over the last 7 days (1182 sessions),
per `scripts/lesson-keyword-health.py`.

The lesson is otherwise healthy:
- Continues to fire (TS=0.554, 6/1182 sessions) on its 11 remaining active keywords
- Status: active, two-file format (companion at `knowledge/lessons/tools/greptile-pr-reviews.md`)

## Why prune

Bloated keyword lists make over-broad future matches more likely and inflate the lesson context tax. The pruned phrases are all variants of "retrigger ..." / "bot ... review" / "automated reviewer ..." that real session transcripts don't actually use — sessions trigger the lesson via the surviving phrasings (e.g. "trigger greptile", "@greptileai review comment", "request greptile re-review", "pushed fixes after the earlier Greptile").

## Validation

- `gptme-lessons-extras/validate.py lessons/tools/greptile-pr-reviews.md` ✅
- prek pre-commit checks ✅
- 11 active keywords retained — no behavior change expected for sessions that legitimately need the lesson

## Test plan

- [x] Validate lesson format passes
- [x] prek hooks pass on commit
- [ ] Greptile auto-review (will run on this PR)