### PR TITLE
chore(lessons): prune 6 dead keywords across 5 lessons

### DIFF
--- a/lessons/autonomous/agent-event-watch-workflow.md
+++ b/lessons/autonomous/agent-event-watch-workflow.md
@@ -2,9 +2,7 @@
 status: active
 match:
   keywords:
-    - event watch
     - watch task
-    - settlement watch
     - upcoming event
 ---
 

--- a/lessons/concepts/llmlingua-compression.md
+++ b/lessons/concepts/llmlingua-compression.md
@@ -2,7 +2,6 @@
 match:
   keywords:
     - llmlingua
-    - text compression
     - compression
 status: active
 ---

--- a/lessons/tools/gh-pr-checks-exit-code-8.md
+++ b/lessons/tools/gh-pr-checks-exit-code-8.md
@@ -2,7 +2,6 @@
 match:
   keywords:
     - "exit code 8"
-    - "checks still pending"
 status: active
 generated_from:
   sessions: 538

--- a/lessons/workflow/agent-orchestrator-patterns.md
+++ b/lessons/workflow/agent-orchestrator-patterns.md
@@ -2,9 +2,7 @@
 status: active
 match:
   keywords:
-    - "orchestrating multiple agents"
     - "standup report"
-    - "inference spend"
 ---
 
 # Agent Orchestrator Patterns

--- a/lessons/workflow/branch-from-master.md
+++ b/lessons/workflow/branch-from-master.md
@@ -1,6 +1,6 @@
 ---
 match:
-  keywords: ["create branch", "git checkout -b", "new feature branch"]
+  keywords: ["create branch", "git checkout -b"]
   session_categories: [code, cross-repo, infrastructure]
 status: active
 ---


### PR DESCRIPTION
## Summary

Removes 6 dead keywords across 5 lessons — keywords that never fired in 7+ days of trajectory data. Follows the same pattern as #854.

## Changes

| File | Dead keyword(s) removed | Remaining |
|------|------------------------|-----------|
| `lessons/workflow/agent-orchestrator-patterns.md` | "orchestrating multiple agents", "inference spend" | "standup report" |
| `lessons/autonomous/agent-event-watch-workflow.md` | "event watch", "settlement watch" | "watch task", "upcoming event" |
| `lessons/workflow/branch-from-master.md` | "new feature branch" | "create branch", "git checkout -b" |
| `lessons/concepts/llmlingua-compression.md` | "text compression" | "llmlingua", "compression" |
| `lessons/tools/gh-pr-checks-exit-code-8.md` | "checks still pending" | "exit code 8" |

Each lesson retains at least one live-firing keyword.

## Identified via

`uv run python3 scripts/lesson-keyword-health.py --dead-only` (in Bob's brain repo)

## Skipped

`lessons/patterns/avoid-deep-nesting.md` — both "deeply nested" and "early return" are dead, so pruning would orphan the lesson. Needs new keywords instead, not a prune.

## Test plan

- [x] Lesson validator passes for all 5 edited files
- [x] Pre-commit hooks green
- [x] Each lesson retains ≥1 live keyword (no orphaning)