### PR TITLE
fix(voice): correct GPT-Realtime-2 model to generic name gpt-realtime-2

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
@@ -197,7 +197,7 @@ def _load_project_instructions(workspace: str | None = None) -> str:
 class SessionConfig:
     """Configuration for OpenAI Realtime API session."""
 
-    model: str = "gpt-realtime-2025-08-28"
+    model: str = "gpt-realtime-2"
     voice: str = "echo"
     instructions: str = ""
     initial_response_instructions: str = ""


### PR DESCRIPTION
## Problem

PR #856 set the OpenAI Realtime model to `gpt-realtime-2025-08-28`, which is the **v1 pinned** model — not the v2 model Erik was asking for.

## Evidence

OpenAI models API shows:
- `gpt-realtime-2025-08-28` — created 2025-08-27 (v1 pinned)
- `gpt-realtime-2` — created 2026-05-05 (v2, "released yesterday" per Erik on 2026-05-07)

## Change

This changes the default model from `gpt-realtime-2025-08-28` to `gpt-realtime-2` (generic name, resolves to latest v2).

## Verification

- [x] 134 voice tests pass
- [x] OpenAI models API confirms `gpt-realtime-2` is available
- [x] Manual call test still needed post-merge (same as PR #856)

## Follow-up

Also fix the model string in `scripts/voice-provider-switch.sh` on the bob workspace — it references `gpt-realtime-2` by name already, which is correct, so no change needed there.