### PR TITLE
fix(lessons): tighten communication-loop keywords to reduce mismatched triggers

### DIFF
--- a/lessons/workflow/communication-loop-closure-patterns.md
+++ b/lessons/workflow/communication-loop-closure-patterns.md
@@ -1,11 +1,12 @@
 ---
 match:
   keywords:
-  - close the loop
   - update the issue
   - reply to the issue
   - comment on the issue
-  - follow up on the request
+  - close the communication loop
+  - respond in the original thread
+  - confirm the fix in the issue
   session_categories: [triage, cross-repo]
 status: active
 ---


### PR DESCRIPTION
## Problem

The `communication-loop-closure-patterns` lesson was the sole **genuinely-harmful** lesson in the 2026-05-08 LOO analysis (`Δ=-0.0193`, n=270, p<0.05, direction-consistency=57% across 7 categories). It matched 270 sessions but the reward delta was negative — sessions with this lesson performed worse than those without.

Root cause: two of its keywords — `close the loop` and `follow up on the request` — are over-broad and match sessions about unrelated loop-closure patterns (the general lesson pattern, not the communication-specific loop). The `close the loop` keyword particularly triggers on every journal entry with a "Close the loop" section.

## Changes

- **Removed** `close the loop` — matches journal template headings and unrelated loop-closure sessions
- **Removed** `follow up on the request` — too broad, fires in generic planning sessions
- **Added** `close the communication loop` — disambiguates from the generic lesson pattern
- **Added** `respond in the original thread` — matches the lesson's actual behavioral trigger
- **Added** `confirm the fix in the issue` — matches the lesson's core pattern

## Verification

- Pre-commit checks pass
- Two-file format validates (`communication-loop-closure-patterns.md`)
- Reasoning follows the lesson-system anti-confounding checklist (keyword narrowing is first-line fix before archival)