### PR TITLE
feat(pm-dispatch): bash-compatible ledger bridge

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -125,6 +125,123 @@ class LedgerEntry:
         return result
 
 
+# --- Bash-compatible full ledger entry ---
+#
+# The bash ``append_dispatch_ledger()`` function writes a richer schema than
+# ``LedgerEntry.to_dict()``: it preserves a ``unit`` field name, plus
+# ``item_count``, ``types`` (deduped sorted), and ``items`` (capped at 20)
+# derived from the dispatched work file. ``build_full_ledger_entry()`` is the
+# canonical Python reimplementation so the bash heredoc can be replaced with
+# a thin module call without changing the on-disk JSONL schema.
+
+
+def _maybe_int(value: str | int | None) -> int | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, int):
+        return value
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def build_full_ledger_entry(
+    *,
+    phase: str,
+    lane: str = "mixed",
+    dispatch_id: str | None = None,
+    unit_name: str | None = None,
+    work_file: str | Path | None = None,
+    running_units: str | int | None = None,
+    cap: str | int | None = None,
+    note: str | None = None,
+    successes: str | int | None = None,
+    failures: str | int | None = None,
+    duration_seconds: str | int | None = None,
+    timestamp: str | None = None,
+    max_items: int = 20,
+) -> dict[str, Any]:
+    """Build the full bash-compatible dispatch ledger entry.
+
+    Mirrors the on-disk schema produced by the bash
+    ``append_dispatch_ledger()`` function:
+    ``timestamp/phase/lane/dispatch_id/unit/item_count/item_refs/types/items``
+    plus optional ``running_units/cap/note/successes/failures/duration_seconds``.
+
+    The ``items`` list is capped at *max_items* entries (default 20). Items
+    are read from *work_file* (a JSONL of grouped items) when provided.
+    """
+    items: list[dict[str, Any]] = []
+    type_set: set[str] = set()
+    item_refs: list[str] = []
+
+    if work_file:
+        path = Path(work_file)
+        if path.is_file():
+            for raw in path.read_text(encoding="utf-8").splitlines():
+                if not raw.strip():
+                    continue
+                try:
+                    item = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(item, dict):
+                    continue
+                repo = str(item.get("repo", "") or "")
+                number = item.get("number")
+                item_types = item.get("types")
+                if not isinstance(item_types, list) or not item_types:
+                    single_type = item.get("type")
+                    item_types = [single_type] if isinstance(single_type, str) else []
+                normalized_types = [t for t in item_types if isinstance(t, str) and t]
+                type_set.update(normalized_types)
+                item_refs.append(f"{repo}#{number}")
+                items.append(
+                    {
+                        "repo": repo,
+                        "number": number,
+                        "types": normalized_types,
+                        "title": item.get("title"),
+                    }
+                )
+
+    return {
+        "timestamp": timestamp or datetime.now(timezone.utc).isoformat(),
+        "phase": phase,
+        "lane": lane,
+        "dispatch_id": dispatch_id or None,
+        "unit": unit_name or None,
+        "item_count": len(items),
+        "item_refs": list(dict.fromkeys(item_refs)),
+        "types": sorted(type_set),
+        "items": items[:max_items],
+        "running_units": _maybe_int(running_units),
+        "cap": _maybe_int(cap),
+        "note": note or None,
+        "successes": _maybe_int(successes),
+        "failures": _maybe_int(failures),
+        "duration_seconds": _maybe_int(duration_seconds),
+    }
+
+
+def append_full_ledger_entry(
+    ledger_path: str | Path,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Build a full ledger entry and append it to *ledger_path* (JSONL).
+
+    Returns the entry dict that was written. ``kwargs`` are forwarded to
+    :func:`build_full_ledger_entry`.
+    """
+    entry = build_full_ledger_entry(**kwargs)
+    path = Path(ledger_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    return entry
+
+
 # --- Slot key derivation ---
 
 
@@ -753,23 +870,77 @@ def dispatch_grouped_items(
     return result
 
 
-def main() -> None:
-    """CLI entry point: partition grouped JSONL items from stdin into fast/slow lane files.
+def _append_ledger_main(argv: list[str]) -> int:
+    """CLI handler for the ``append-ledger`` subcommand."""
+    import argparse
 
-    Usage:
-        cat grouped_items.jsonl | python3 -m gptme_runloops.pm_dispatch /tmp/fast.jsonl /tmp/slow.jsonl
+    parser = argparse.ArgumentParser(
+        prog="pm_dispatch append-ledger",
+        description="Append a dispatch telemetry entry to a JSONL ledger.",
+    )
+    parser.add_argument("--ledger-path", required=True)
+    parser.add_argument("--phase", required=True)
+    parser.add_argument("--lane", default="mixed")
+    parser.add_argument("--dispatch-id", default="")
+    parser.add_argument("--unit", default="")
+    parser.add_argument("--work-file", default="")
+    parser.add_argument("--running-units", default="")
+    parser.add_argument("--cap", default="")
+    parser.add_argument("--note", default="")
+    parser.add_argument("--successes", default="")
+    parser.add_argument("--failures", default="")
+    parser.add_argument("--duration-seconds", default="")
+    args = parser.parse_args(argv)
+
+    append_full_ledger_entry(
+        args.ledger_path,
+        phase=args.phase,
+        lane=args.lane,
+        dispatch_id=args.dispatch_id or None,
+        unit_name=args.unit or None,
+        work_file=args.work_file or None,
+        running_units=args.running_units,
+        cap=args.cap,
+        note=args.note or None,
+        successes=args.successes,
+        failures=args.failures,
+        duration_seconds=args.duration_seconds,
+    )
+    return 0
+
+
+def main() -> None:
+    """CLI entry point.
+
+    Subcommands:
+
+      partition <fast_out> <slow_out>      (legacy default — also no subcmd)
+        Read grouped JSONL items from stdin, write fast/slow lane files.
+
+      append-ledger --ledger-path P --phase X ...
+        Append a dispatch telemetry entry to a JSONL ledger.
     """
     import sys as _sys
 
-    if len(_sys.argv) < 3:
+    argv = _sys.argv[1:]
+
+    # Subcommand dispatch
+    if argv and argv[0] == "append-ledger":
+        _sys.exit(_append_ledger_main(argv[1:]))
+    if argv and argv[0] == "partition":
+        argv = argv[1:]
+
+    if len(argv) < 2:
         print(
-            "Usage: python3 -m gptme_runloops.pm_dispatch <fast_out> <slow_out>",
+            "Usage:\n"
+            "  python3 -m gptme_runloops.pm_dispatch [partition] <fast_out> <slow_out>\n"
+            "  python3 -m gptme_runloops.pm_dispatch append-ledger --ledger-path P --phase X [...]",
             file=_sys.stderr,
         )
         _sys.exit(1)
 
-    fast_path = Path(_sys.argv[1])
-    slow_path = Path(_sys.argv[2])
+    fast_path = Path(argv[0])
+    slow_path = Path(argv[1])
     _partition_jsonl_io(fast_path, slow_path)
     fast_count = (
         len(fast_path.read_text().splitlines()) if fast_path.stat().st_size else 0

--- a/packages/gptme-runloops/tests/test_pm_dispatch.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch.py
@@ -17,6 +17,8 @@ from gptme_runloops.pm_dispatch import (
     SlotItem,
     SlotManager,
     _partition_jsonl_io,
+    append_full_ledger_entry,
+    build_full_ledger_entry,
     classify_lane,
     derive_slot_key,
     dispatch_grouped_items,
@@ -248,6 +250,186 @@ class TestDispatchLedger:
         assert [entry.dispatch_id for entry in DispatchLedger(ledger_path).read()] == [
             "ok"
         ]
+
+
+# --- Bash-compatible full ledger entry ---
+
+
+class TestBuildFullLedgerEntry:
+    """Schema-parity tests for the bash-compatible ledger builder."""
+
+    EXPECTED_KEYS = {
+        "timestamp",
+        "phase",
+        "lane",
+        "dispatch_id",
+        "unit",
+        "item_count",
+        "item_refs",
+        "types",
+        "items",
+        "running_units",
+        "cap",
+        "note",
+        "successes",
+        "failures",
+        "duration_seconds",
+    }
+
+    def test_schema_keys_match_bash(self):
+        entry = build_full_ledger_entry(phase="planned")
+        assert set(entry.keys()) == self.EXPECTED_KEYS
+
+    def test_minimal_entry(self):
+        entry = build_full_ledger_entry(phase="planned", lane="fast")
+        assert entry["phase"] == "planned"
+        assert entry["lane"] == "fast"
+        assert entry["dispatch_id"] is None
+        assert entry["unit"] is None
+        assert entry["item_count"] == 0
+        assert entry["item_refs"] == []
+        assert entry["types"] == []
+        assert entry["items"] == []
+        assert entry["timestamp"]  # auto-populated
+
+    def test_uses_unit_field_not_unit_name(self):
+        """Bash schema names the field 'unit', not 'unit_name'."""
+        entry = build_full_ledger_entry(phase="planned", unit_name="bob-pm-foo")
+        assert entry["unit"] == "bob-pm-foo"
+        assert "unit_name" not in entry
+
+    def test_derives_items_from_work_file(self, tmp_path):
+        work = tmp_path / "work.jsonl"
+        work.write_text(
+            "\n".join(
+                [
+                    json.dumps(
+                        {
+                            "repo": "x/y",
+                            "number": 1,
+                            "types": ["assigned_issue"],
+                            "title": "first",
+                        }
+                    ),
+                    json.dumps(
+                        {
+                            "repo": "x/y",
+                            "number": 2,
+                            "type": "pr_update",
+                            "title": "two",
+                        }
+                    ),
+                    "",  # blank line
+                    "not-json",  # silently skipped
+                ]
+            )
+            + "\n"
+        )
+        entry = build_full_ledger_entry(phase="dispatched", work_file=work)
+        assert entry["item_count"] == 2
+        assert entry["item_refs"] == ["x/y#1", "x/y#2"]
+        assert entry["types"] == ["assigned_issue", "pr_update"]
+        assert entry["items"][0]["title"] == "first"
+        assert entry["items"][1]["types"] == ["pr_update"]
+
+    def test_caps_items_at_max(self, tmp_path):
+        work = tmp_path / "work.jsonl"
+        lines = [
+            json.dumps({"repo": "a/b", "number": i, "types": ["assigned_issue"]})
+            for i in range(50)
+        ]
+        work.write_text("\n".join(lines) + "\n")
+        entry = build_full_ledger_entry(phase="x", work_file=work)
+        assert entry["item_count"] == 50  # full count preserved
+        assert len(entry["items"]) == 20  # but list capped at 20
+        assert len(entry["item_refs"]) == 50
+
+    def test_dedupes_item_refs_preserving_order(self, tmp_path):
+        work = tmp_path / "work.jsonl"
+        work.write_text(
+            "\n".join(
+                [
+                    json.dumps({"repo": "a/b", "number": 1, "types": ["t1"]}),
+                    json.dumps({"repo": "a/b", "number": 1, "types": ["t1"]}),
+                    json.dumps({"repo": "a/b", "number": 2, "types": ["t1"]}),
+                ]
+            )
+            + "\n"
+        )
+        entry = build_full_ledger_entry(phase="x", work_file=work)
+        assert entry["item_refs"] == ["a/b#1", "a/b#2"]
+        assert entry["item_count"] == 3  # raw count, before dedup
+
+    def test_coerces_int_strings(self):
+        entry = build_full_ledger_entry(
+            phase="x",
+            running_units="2",
+            cap="3",
+            successes="0",
+            failures="1",
+            duration_seconds="42",
+        )
+        assert entry["running_units"] == 2
+        assert entry["cap"] == 3
+        assert entry["successes"] == 0
+        assert entry["failures"] == 1
+        assert entry["duration_seconds"] == 42
+
+    def test_invalid_int_strings_become_none(self):
+        entry = build_full_ledger_entry(phase="x", running_units="not-a-number")
+        assert entry["running_units"] is None
+
+    def test_empty_strings_become_none(self):
+        entry = build_full_ledger_entry(
+            phase="x", dispatch_id="", note="", running_units=""
+        )
+        assert entry["dispatch_id"] is None
+        assert entry["note"] is None
+        assert entry["running_units"] is None
+
+    def test_explicit_timestamp_preserved(self):
+        ts = "2026-05-08T18:00:00+00:00"
+        entry = build_full_ledger_entry(phase="x", timestamp=ts)
+        assert entry["timestamp"] == ts
+
+    def test_missing_work_file_silently_ignored(self, tmp_path):
+        entry = build_full_ledger_entry(
+            phase="x", work_file=tmp_path / "does-not-exist.jsonl"
+        )
+        assert entry["item_count"] == 0
+        assert entry["items"] == []
+
+
+class TestAppendFullLedgerEntry:
+    def test_appends_jsonl_line(self, tmp_path):
+        ledger = tmp_path / "ledger.jsonl"
+        entry = append_full_ledger_entry(
+            ledger,
+            phase="planned",
+            lane="fast",
+            dispatch_id="d1",
+            unit_name="bob-pm-d1",
+        )
+        lines = ledger.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 1
+        loaded = json.loads(lines[0])
+        assert loaded["dispatch_id"] == "d1"
+        assert loaded["unit"] == "bob-pm-d1"
+        assert loaded == entry
+
+    def test_creates_parent_dir(self, tmp_path):
+        ledger = tmp_path / "nested" / "deeper" / "ledger.jsonl"
+        append_full_ledger_entry(ledger, phase="planned")
+        assert ledger.exists()
+
+    def test_appends_multiple_entries(self, tmp_path):
+        ledger = tmp_path / "ledger.jsonl"
+        for i in range(3):
+            append_full_ledger_entry(ledger, phase="planned", dispatch_id=f"d{i}")
+        lines = ledger.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 3
+        ids = [json.loads(line)["dispatch_id"] for line in lines]
+        assert ids == ["d0", "d1", "d2"]
 
 
 # --- SlotManager ---


### PR DESCRIPTION
Phase 2 remainder of the project-monitoring upstream overhaul (ErikBjare/bob#736).

## What

- New `build_full_ledger_entry()` and `append_full_ledger_entry()` produce the exact on-disk JSONL schema written today by the bash `append_dispatch_ledger()` heredoc:

  `timestamp / phase / lane / dispatch_id / unit / item_count / item_refs / types / items / running_units / cap / note / successes / failures / duration_seconds`

- Adds an `append-ledger` subcommand to the `pm_dispatch` CLI so the bash wrapper can drop its inline `python3 - <<PY` heredoc in favor of a thin module call. The existing positional-args partition behavior is preserved (legacy callers unchanged); an explicit `partition` subcommand is also accepted.

## Why

The ledger heredoc was the last piece of dispatch logic still inlined in shell. Moving it behind a public Python helper:

- Removes ~60 lines of embedded Python from `scripts/github/project-monitoring-lib.sh`.
- Makes the schema testable (14 new unit tests covering schema parity, item capping, dedup, int coercion, missing-file handling, parent-dir creation).
- Sets up the next slice — flipping the bash dispatcher to delegate ledger writes via the CLI without changing the on-disk format.

The companion bash change is drafted in ErikBjare/bob and will land once this PR merges and the submodule pointer is bumped (the bash call-site references the new `append-ledger` subcommand which only exists on this branch).

## Test

\`\`\`
uv run pytest packages/gptme-runloops/tests/test_pm_dispatch.py -q
# 83 passed (was 69; +14 new schema-parity tests)
uv run mypy packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
# Success: no issues found in 1 source file
\`\`\`

Live smoke test: bash `append_dispatch_ledger` shim invoked through `uv run python3 -m gptme_runloops.pm_dispatch append-ledger ...` produces JSONL with all 15 expected fields and identical structure to the previous heredoc output.