### PR TITLE
fix(pm-dispatch): skip item_refs entry when number is None

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -196,7 +196,8 @@ def build_full_ledger_entry(
                     item_types = [single_type] if isinstance(single_type, str) else []
                 normalized_types = [t for t in item_types if isinstance(t, str) and t]
                 type_set.update(normalized_types)
-                item_refs.append(f"{repo}#{number}")
+                if number is not None:
+                    item_refs.append(f"{repo}#{number}")
                 items.append(
                     {
                         "repo": repo,

--- a/packages/gptme-runloops/tests/test_pm_dispatch.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch.py
@@ -399,6 +399,26 @@ class TestBuildFullLedgerEntry:
         assert entry["item_count"] == 0
         assert entry["items"] == []
 
+    def test_item_without_number_omitted_from_refs(self, tmp_path):
+        """Items missing a 'number' field must not produce 'repo#None' refs."""
+        work = tmp_path / "work.jsonl"
+        work.write_text(
+            "\n".join(
+                [
+                    json.dumps({"repo": "a/b", "number": 1, "types": ["t1"]}),
+                    json.dumps({"repo": "a/b", "types": ["t2"]}),  # no number key
+                    json.dumps(
+                        {"repo": "a/b", "number": None, "types": ["t3"]}
+                    ),  # explicit None
+                ]
+            )
+            + "\n"
+        )
+        entry = build_full_ledger_entry(phase="x", work_file=work)
+        assert entry["item_count"] == 3
+        assert entry["item_refs"] == ["a/b#1"]
+        assert all("#None" not in ref for ref in entry["item_refs"])
+
 
 class TestAppendFullLedgerEntry:
     def test_appends_jsonl_line(self, tmp_path):


### PR DESCRIPTION
## Summary

- `build_full_ledger_entry()` produced `"repo#None"` in `item_refs` when a work-file item had no `number` field (or `number: null`), diverging from the bash schema which would never write that string
- Fix: guard the `item_refs.append(f"{repo}#{number}")` with `if number is not None`
- Adds a regression test covering both the missing-key case and the explicit-`None` case

Flagged by Greptile review on #861 after merge.

## Test plan
- [ ] `uv run pytest packages/gptme-runloops/tests/test_pm_dispatch.py::TestBuildFullLedgerEntry -v` — all 12 pass