### PR TITLE
fix(pm-dispatch): skip item_refs entry when number is None

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -196,7 +196,8 @@ def build_full_ledger_entry(
                     item_types = [single_type] if isinstance(single_type, str) else []
                 normalized_types = [t for t in item_types if isinstance(t, str) and t]
                 type_set.update(normalized_types)
-                item_refs.append(f"{repo}#{number}")
+                if number is not None:
+                    item_refs.append(f"{repo}#{number}")
                 items.append(
                     {
                         "repo": repo,

--- a/packages/gptme-runloops/tests/test_pm_dispatch.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch.py
@@ -399,6 +399,26 @@ class TestBuildFullLedgerEntry:
         assert entry["item_count"] == 0
         assert entry["items"] == []
 
+    def test_item_without_number_omitted_from_refs(self, tmp_path):
+        """Items missing a 'number' field must not produce 'repo#None' refs."""
+        work = tmp_path / "work.jsonl"
+        work.write_text(
+            "\n".join(
+                [
+                    json.dumps({"repo": "a/b", "number": 1, "types": ["t1"]}),
+                    json.dumps({"repo": "a/b", "types": ["t2"]}),  # no number key
+                    json.dumps(
+                        {"repo": "a/b", "number": None, "types": ["t3"]}
+                    ),  # explicit None
+                ]
+            )
+            + "\n"
+        )
+        entry = build_full_ledger_entry(phase="x", work_file=work)
+        assert entry["item_count"] == 3
+        assert entry["item_refs"] == ["a/b#1"]
+        assert all("#None" not in ref for ref in entry["item_refs"])
+
 
 class TestAppendFullLedgerEntry:
     def test_appends_jsonl_line(self, tmp_path):


### PR DESCRIPTION
Items missing a `number` field produced `repo#None` refs — a schema divergence from bash which would never write that string. Guard the f-string append with a None check and add a regression test covering both the missing-key and explicit-None cases.

## Changes
- `pm_dispatch.py`: skip item_refs append when item number is None
- `test_pm_dispatch.py`: add 2 regression tests for missing-key and explicit-None cases

Fixes a schema parity bug introduced in #861.