### PR TITLE
feat(pm-dispatch): add records-aggregate subcommand

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -910,6 +910,39 @@ def _append_ledger_main(argv: list[str]) -> int:
     return 0
 
 
+def _records_aggregate_main(argv: list[str]) -> int:
+    """CLI handler for the ``records-aggregate`` subcommand.
+
+    Reads all ``*.json`` files from a directory, parses each, and emits a
+    single JSON array on stdout. Files that fail to parse are skipped
+    silently, matching the inline bash-script heredoc behavior.
+    """
+    import argparse
+    import sys as _sys
+
+    parser = argparse.ArgumentParser(
+        prog="pm_dispatch records-aggregate",
+        description="Aggregate per-item monitoring records into a single JSON array.",
+    )
+    parser.add_argument(
+        "--records-dir",
+        required=True,
+        help="Directory containing per-item JSON record files",
+    )
+    args = parser.parse_args(argv)
+
+    records: list[Any] = []
+    records_dir = Path(args.records_dir)
+    if records_dir.is_dir():
+        for path in sorted(records_dir.glob("*.json")):
+            try:
+                records.append(json.loads(path.read_text()))
+            except Exception:
+                continue
+    print(json.dumps(records, ensure_ascii=False), file=_sys.stdout)
+    return 0
+
+
 def main() -> None:
     """CLI entry point.
 
@@ -920,6 +953,9 @@ def main() -> None:
 
       append-ledger --ledger-path P --phase X ...
         Append a dispatch telemetry entry to a JSONL ledger.
+
+      records-aggregate --records-dir DIR
+        Aggregate per-item JSON records into a single JSON array on stdout.
     """
     import sys as _sys
 
@@ -928,6 +964,8 @@ def main() -> None:
     # Subcommand dispatch
     if argv and argv[0] == "append-ledger":
         _sys.exit(_append_ledger_main(argv[1:]))
+    if argv and argv[0] == "records-aggregate":
+        _sys.exit(_records_aggregate_main(argv[1:]))
     if argv and argv[0] == "partition":
         argv = argv[1:]
 
@@ -935,7 +973,8 @@ def main() -> None:
         print(
             "Usage:\n"
             "  python3 -m gptme_runloops.pm_dispatch [partition] <fast_out> <slow_out>\n"
-            "  python3 -m gptme_runloops.pm_dispatch append-ledger --ledger-path P --phase X [...]",
+            "  python3 -m gptme_runloops.pm_dispatch append-ledger --ledger-path P --phase X [...]\n"
+            "  python3 -m gptme_runloops.pm_dispatch records-aggregate --records-dir DIR",
             file=_sys.stderr,
         )
         _sys.exit(1)

--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -914,8 +914,8 @@ def _records_aggregate_main(argv: list[str]) -> int:
     """CLI handler for the ``records-aggregate`` subcommand.
 
     Reads all ``*.json`` files from a directory, parses each, and emits a
-    single JSON array on stdout. Files that fail to parse are skipped
-    silently, matching the inline bash-script heredoc behavior.
+    single JSON array on stdout. Files with invalid JSON or encoding errors are
+    skipped silently; OS-level errors propagate.
     """
     import argparse
     import sys as _sys
@@ -937,7 +937,7 @@ def _records_aggregate_main(argv: list[str]) -> int:
         for path in sorted(records_dir.glob("*.json")):
             try:
                 records.append(json.loads(path.read_text()))
-            except Exception:
+            except (json.JSONDecodeError, UnicodeDecodeError):
                 continue
     print(json.dumps(records, ensure_ascii=False), file=_sys.stdout)
     return 0

--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -918,7 +918,6 @@ def _records_aggregate_main(argv: list[str]) -> int:
     skipped silently; OS-level errors propagate.
     """
     import argparse
-    import sys as _sys
 
     parser = argparse.ArgumentParser(
         prog="pm_dispatch records-aggregate",
@@ -939,7 +938,7 @@ def _records_aggregate_main(argv: list[str]) -> int:
                 records.append(json.loads(path.read_text()))
             except (json.JSONDecodeError, UnicodeDecodeError):
                 continue
-    print(json.dumps(records, ensure_ascii=False), file=_sys.stdout)
+    print(json.dumps(records, ensure_ascii=False))
     return 0
 
 

--- a/packages/gptme-runloops/tests/test_pm_dispatch.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch.py
@@ -1049,3 +1049,39 @@ class TestPartitionJsonlIO:
 
         slow_lines = [line for line in slow_path.read_text().splitlines() if line]
         assert len(slow_lines) == 1, "pr_update with string type should land in slow"
+
+
+class TestRecordsAggregateMain:
+    """Tests for the records-aggregate CLI subcommand."""
+
+    def test_aggregate_returns_array(self, tmp_path, capsys):
+        """All readable JSON files in the directory are merged into one array."""
+        from gptme_runloops.pm_dispatch import _records_aggregate_main
+
+        (tmp_path / "a.json").write_text(json.dumps({"k": 1}))
+        (tmp_path / "b.json").write_text(json.dumps({"k": 2}))
+
+        rc = _records_aggregate_main(["--records-dir", str(tmp_path)])
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert sorted(out, key=lambda r: r["k"]) == [{"k": 1}, {"k": 2}]
+
+    def test_aggregate_skips_unparseable(self, tmp_path, capsys):
+        """Files that fail to parse are silently skipped, matching prior bash behavior."""
+        from gptme_runloops.pm_dispatch import _records_aggregate_main
+
+        (tmp_path / "good.json").write_text(json.dumps({"ok": True}))
+        (tmp_path / "bad.json").write_text("not-json")
+
+        rc = _records_aggregate_main(["--records-dir", str(tmp_path)])
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out == [{"ok": True}]
+
+    def test_aggregate_missing_dir_returns_empty(self, tmp_path, capsys):
+        """A non-existent directory yields an empty array (mirrors bash heredoc)."""
+        from gptme_runloops.pm_dispatch import _records_aggregate_main
+
+        rc = _records_aggregate_main(["--records-dir", str(tmp_path / "nope")])
+        assert rc == 0
+        assert json.loads(capsys.readouterr().out) == []

--- a/packages/gptme-runloops/tests/test_pm_dispatch.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch.py
@@ -1067,7 +1067,7 @@ class TestRecordsAggregateMain:
         assert sorted(out, key=lambda r: r["k"]) == [{"k": 1}, {"k": 2}]
 
     def test_aggregate_skips_unparseable(self, tmp_path, capsys):
-        """Files that fail to parse are silently skipped, matching prior bash behavior."""
+        """Files with invalid JSON are silently skipped; OS errors propagate."""
         from gptme_runloops.pm_dispatch import _records_aggregate_main
 
         (tmp_path / "good.json").write_text(json.dumps({"ok": True}))


### PR DESCRIPTION
## Summary

Adds `records-aggregate` subcommand to `gptme_runloops.pm_dispatch` that reads all `*.json` files in a directory and emits a single JSON array on stdout. Skips unparseable files silently. Continues the Phase 2 extraction pattern alongside `partition` and `append-ledger`.

## Why

Replaces an inline 12-line Python heredoc in `scripts/runs/github/project-monitoring.sh` (in the parent ErikBjare/bob repo) that was untestable and awkward to edit. Moving it to a CLI subcommand gets it under unit-test coverage and continues incremental shrinkage of the bash script (Phase 2 of the project-monitoring overhaul, ErikBjare/bob#736).

## What Changed

- `pm_dispatch.py`: new `_records_aggregate_main()` handler + dispatch wiring + usage string.
- `tests/test_pm_dispatch.py`: new `TestRecordsAggregateMain` class with 3 tests:
  - happy path (multiple files → merged array)
  - unparseable file skipped
  - missing directory → empty array

## Test plan

- [x] `uv run pytest packages/gptme-runloops/tests/test_pm_dispatch.py` (87 passing, +3 new)
- [x] CLI smoke: `uv run python3 -m gptme_runloops.pm_dispatch records-aggregate --records-dir <dir>`
- [ ] Bash side switch over (separate PR in ErikBjare/bob: bumps submodule + replaces heredoc with CLI call) — atomic to avoid runtime regression.

## Refs

- ErikBjare/bob#736 (project-monitoring upstream and design/naming overhaul)