### PR TITLE
feat(voice): add OpenAI trial voice and speed overrides

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
@@ -199,6 +199,7 @@ class SessionConfig:
 
     model: str = "gpt-realtime-2"
     voice: str = "echo"
+    output_speed: float | None = None
     instructions: str = ""
     initial_response_instructions: str = ""
     input_format: str = "pcm16"
@@ -461,6 +462,8 @@ class OpenAIRealtimeClient:
                 },
             ],
         }
+        if self.session_config.output_speed is not None:
+            session_params["output"] = {"speed": self.session_config.output_speed}
         transcription = self._get_transcription_config()
         if transcription is not None:
             session_params["input_audio_transcription"] = transcription

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -425,12 +425,16 @@ class VoiceServer:
         workspace: str | None = None,
         provider: str = _PROVIDER_OPENAI,
         model: str | None = None,
+        voice: str | None = None,
+        output_speed: float | None = None,
         enable_browser_transport: bool = False,
     ):
         self.host = host
         self.port = port
         self.provider = provider
         self.model = model
+        self.voice = voice
+        self.output_speed = output_speed
         self.enable_browser_transport = enable_browser_transport
         if provider == _PROVIDER_GROK:
             self._api_key = _get_xai_api_key()
@@ -1554,7 +1558,7 @@ class VoiceServer:
         instructions: str,
         initial_response_instructions: str = "",
     ) -> SessionConfig:
-        """Build a SessionConfig with optional model override."""
+        """Build a SessionConfig with optional runtime overrides."""
         kwargs: dict = dict(
             instructions=instructions,
             initial_response_instructions=initial_response_instructions,
@@ -1562,6 +1566,10 @@ class VoiceServer:
         )
         if self.model:
             kwargs["model"] = self.model
+        if self.voice:
+            kwargs["voice"] = self.voice
+        if self.output_speed is not None:
+            kwargs["output_speed"] = self.output_speed
         return SessionConfig(**kwargs)
 
     def _make_client(
@@ -1879,6 +1887,23 @@ class VoiceServer:
     ),
 )
 @click.option(
+    "--voice",
+    default=None,
+    help=(
+        "Override the provider voice. For OpenAI Realtime, current voices include "
+        "echo, alloy, ash, ballad, coral, sage, shimmer, verse, marin, and cedar."
+    ),
+)
+@click.option(
+    "--output-speed",
+    default=None,
+    type=click.FloatRange(0.25, 1.5),
+    help=(
+        "Override spoken output speed. Currently passed through only for OpenAI "
+        "Realtime, which supports 0.25 to 1.5."
+    ),
+)
+@click.option(
     "--enable-browser-transport",
     is_flag=True,
     help="Expose /voice WebSocket for browser PCM transport.",
@@ -1890,6 +1915,8 @@ def main(
     workspace: str | None,
     provider: str,
     model: str | None,
+    voice: str | None,
+    output_speed: float | None,
     enable_browser_transport: bool,
     debug: bool,
 ):
@@ -1908,6 +1935,8 @@ def main(
         workspace=workspace,
         provider=provider,
         model=model,
+        voice=voice,
+        output_speed=output_speed,
         enable_browser_transport=enable_browser_transport,
     )
 

--- a/packages/gptme-voice/tests/test_openai_client.py
+++ b/packages/gptme-voice/tests/test_openai_client.py
@@ -87,6 +87,32 @@ def test_connect_exposes_subagent_tool_as_focused_lookup_only() -> None:
     asyncio.run(_exercise())
 
 
+def test_connect_omits_output_key_when_speed_not_configured() -> None:
+    async def _exercise() -> None:
+        fake_ws = _FakeWebSocket()
+
+        async def _fake_connect(*_args, **_kwargs):
+            return fake_ws
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "gptme_voice.realtime.openai_client.websockets.connect", _fake_connect
+            )
+            client = OpenAIRealtimeClient(
+                api_key="test-key",
+                session_config=SessionConfig(instructions="You are Bob."),
+            )
+            await client.connect()
+            await asyncio.sleep(0)
+            await client.disconnect()
+
+        session_update = fake_ws.sent[0]
+        assert session_update["type"] == "session.update"
+        assert "output" not in session_update["session"]
+
+    asyncio.run(_exercise())
+
+
 def test_connect_includes_output_speed_when_configured() -> None:
     async def _exercise() -> None:
         fake_ws = _FakeWebSocket()

--- a/packages/gptme-voice/tests/test_openai_client.py
+++ b/packages/gptme-voice/tests/test_openai_client.py
@@ -87,6 +87,36 @@ def test_connect_exposes_subagent_tool_as_focused_lookup_only() -> None:
     asyncio.run(_exercise())
 
 
+def test_connect_includes_output_speed_when_configured() -> None:
+    async def _exercise() -> None:
+        fake_ws = _FakeWebSocket()
+
+        async def _fake_connect(*_args, **_kwargs):
+            return fake_ws
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "gptme_voice.realtime.openai_client.websockets.connect", _fake_connect
+            )
+            client = OpenAIRealtimeClient(
+                api_key="test-key",
+                session_config=SessionConfig(
+                    instructions="You are Bob.",
+                    output_speed=1.15,
+                ),
+            )
+            await client.connect()
+            await asyncio.sleep(0)
+            await client.disconnect()
+
+        session_update = fake_ws.sent[0]
+        assert session_update["type"] == "session.update"
+        assert session_update["session"]["output"] == {"speed": 1.15}
+        assert fake_ws.closed is True
+
+    asyncio.run(_exercise())
+
+
 def test_load_project_instructions_includes_post_call_follow_up_guard(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- add `--voice` and `--output-speed` flags to `gptme-voice-server`
- thread those overrides into `SessionConfig`
- emit OpenAI Realtime `output.speed` only when explicitly configured

## Why
Bob's OpenAI Realtime trial path can currently switch provider and model, but it can't use docs-backed trial settings like `marin`/`cedar` or the Realtime output speed control. That leaves the upcoming OpenAI trial stuck on the old `echo` default and forces a false "speech rate is not tunable" conclusion in Bob's task notes.

This keeps the default behavior unchanged while exposing the runtime controls needed for the trial.

## Verification
- `uv run pytest packages/gptme-voice/tests -q`