### PR TITLE
fix(lessons): remove session_categories from communication-loop-closure-patterns

### DIFF
--- a/lessons/workflow/communication-loop-closure-patterns.md
+++ b/lessons/workflow/communication-loop-closure-patterns.md
@@ -7,7 +7,6 @@ match:
   - close the communication loop
   - respond in the original thread
   - confirm the fix in the issue
-  session_categories: [triage, cross-repo]
 status: active
 ---
 


### PR DESCRIPTION
## Summary

- Removes `session_categories: [triage, cross-repo]` from `communication-loop-closure-patterns` lesson frontmatter
- Lesson becomes keyword-only instead of firing in all triage and cross-repo sessions

## Motivation

LOO (Leave-One-Out) analysis over 3466 sessions identified this as the **only genuinely harmful lesson** (not confounded):

```
communication-loop-closure-patterns: Δ=-0.0199 (n=270)
  with=0.488 (n=270) vs without=0.508 (n=3196)  p<0.1
```

Root cause: `session_categories: [triage, cross-repo]` caused the lesson to inject into **all** triage and cross-repo sessions (~68% of its 270 triggers), even when no communication loop was actually in scope. This added overhead noise — the lesson was nudging agents to post GitHub comments in sessions focused on code or review work.

With session_categories removed, the lesson fires only when keywords like "reply to the issue", "update the issue", or "close the communication loop" appear — i.e., when loop closure is actually relevant.

**Expected impact**: ~68% fewer triggers, better signal-to-noise ratio, neutral-to-positive effect on session quality.

## Test plan

- [x] Lesson validates: `validate.py communication-loop-closure-patterns.md` → ✅ valid
- [x] Pre-commit passes
- [ ] LOO re-run after 1 week to confirm improvement