### PR TITLE
feat(gptodo): add success_criterion field to task frontmatter

### DIFF
--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -239,6 +239,8 @@ def show(task_id):
         table.add_row("Subtasks", f"{task.subtasks.completed}/{task.subtasks.total} completed")
     if task.issues:
         table.add_row("Issues", ", ".join(task.issues))
+    if task.success_criterion:
+        table.add_row("Success Criterion", task.success_criterion)
 
     # Print metadata table
     console.print("\n[bold]Task Metadata:[/]")
@@ -1431,6 +1433,7 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask):
         "waiting_for": {"type": "string"},
         "recur": {"type": "string"},  # Recurrence interval (7d, 24h, weekly, monthly)
         "parent": {"type": "string"},  # Parent task ID (for subtasks)
+        "success_criterion": {"type": "string"},  # Verifiable "done" gate
         # List fields handled separately via --add/--remove
         "tags": {"type": "list"},
         "depends": {"type": "list"},  # Deprecated, use requires instead

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -292,6 +292,7 @@ class TaskInfo:
     spawned_from: str | None = None  # Parent task that spawned this
     spawned_tasks: List[str] = field(default_factory=list)  # Child tasks
     coordination_mode: str | None = None  # sequential, parallel, fan-out-fan-in
+    success_criterion: str | None = None  # Verifiable "done" gate (Outcomes-style)
 
     @property
     def id(self) -> str:
@@ -947,6 +948,7 @@ def load_tasks(
                 spawned_from=metadata.get("spawned_from"),
                 spawned_tasks=metadata.get("spawned_tasks", []),
                 coordination_mode=metadata.get("coordination_mode"),
+                success_criterion=metadata.get("success_criterion"),
             )
             tasks.append(task)
 

--- a/packages/gptodo/tests/test_success_criterion.py
+++ b/packages/gptodo/tests/test_success_criterion.py
@@ -1,0 +1,126 @@
+"""Tests for the success_criterion field in task frontmatter.
+
+success_criterion is an optional string that expresses a verifiable "done" gate
+so agents can self-check before marking a task complete (Outcomes-style).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from gptodo.cli import cli
+from gptodo.utils import load_tasks
+
+
+TASK_WITH_CRITERION = """\
+---
+state: active
+created: 2026-05-09T00:00:00+00:00
+success_criterion: "All 191 gptodo tests pass and gptodo check shows no issues"
+---
+# Task With Success Criterion
+"""
+
+TASK_WITHOUT_CRITERION = """\
+---
+state: backlog
+created: 2026-05-09T00:00:00+00:00
+---
+# Simple Task
+"""
+
+
+def test_load_task_with_success_criterion(tmp_path: Path) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "with-criterion.md").write_text(TASK_WITH_CRITERION)
+
+    tasks = load_tasks(tasks_dir)
+
+    assert len(tasks) == 1
+    assert (
+        tasks[0].success_criterion == "All 191 gptodo tests pass and gptodo check shows no issues"
+    )
+
+
+def test_load_task_without_success_criterion_defaults_to_none(tmp_path: Path) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "without-criterion.md").write_text(TASK_WITHOUT_CRITERION)
+
+    tasks = load_tasks(tasks_dir)
+
+    assert len(tasks) == 1
+    assert tasks[0].success_criterion is None
+
+
+def test_show_displays_success_criterion(tmp_path: Path, monkeypatch) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "with-criterion.md").write_text(TASK_WITH_CRITERION)
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(cli, ["show", "with-criterion"])
+
+    assert result.exit_code == 0, f"show failed: {result.output}"
+    assert "Success Criterion" in result.output
+    assert "All 191 gptodo tests pass" in result.output
+
+
+def test_show_omits_success_criterion_when_unset(tmp_path: Path, monkeypatch) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "without-criterion.md").write_text(TASK_WITHOUT_CRITERION)
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(cli, ["show", "without-criterion"])
+
+    assert result.exit_code == 0, f"show failed: {result.output}"
+    assert "Success Criterion" not in result.output
+
+
+def test_edit_set_success_criterion(tmp_path: Path, monkeypatch) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    task_file = tasks_dir / "without-criterion.md"
+    task_file.write_text(TASK_WITHOUT_CRITERION)
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(
+        cli,
+        [
+            "edit",
+            "without-criterion",
+            "--set",
+            "success_criterion",
+            "CI green and review addressed",
+        ],
+    )
+
+    assert result.exit_code == 0, f"edit failed: {result.output}"
+
+    # Verify it persisted
+    tasks = load_tasks(tasks_dir)
+    assert len(tasks) == 1
+    assert tasks[0].success_criterion == "CI green and review addressed"
+
+
+def test_edit_clear_success_criterion(tmp_path: Path, monkeypatch) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    task_file = tasks_dir / "with-criterion.md"
+    task_file.write_text(TASK_WITH_CRITERION)
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(
+        cli,
+        ["edit", "with-criterion", "--set", "success_criterion", "none"],
+    )
+
+    assert result.exit_code == 0, f"edit failed: {result.output}"
+
+    tasks = load_tasks(tasks_dir)
+    assert len(tasks) == 1
+    assert tasks[0].success_criterion is None


### PR DESCRIPTION
Adds an optional `success_criterion` string field to gptodo task frontmatter so tasks can carry a verifiable "done" gate — inspired by Anthropic's Outcomes feature.

## Changes

- **`utils.py`**: Add `success_criterion: str | None = None` field to `TaskInfo` dataclass; parse from frontmatter in `load_tasks`
- **`cli.py`**: Show `Success Criterion` in `gptodo show` output (only when set); add to `VALID_FIELDS` so `gptodo edit --set success_criterion <text>` works
- **`tests/test_success_criterion.py`**: 6 tests covering load, show display/omit, and edit set/clear

## Usage

```yaml
---
state: active
created: 2026-05-09T00:00:00+00:00
success_criterion: "All 191 gptodo tests pass and gptodo check shows no issues"
---
```

```
$ gptodo show my-task
Task Metadata:
 File              tasks/my-task.md
 State             active
 ...
 Success Criterion All 191 gptodo tests pass and gptodo check shows no issues
```

```bash
gptodo edit my-task --set success_criterion "CI green and review addressed"
gptodo edit my-task --set success_criterion none  # clear it
```

## Backward Compatibility

Fully backward-compatible: the field defaults to `None` and is never required. Existing tasks load unchanged.

## Test Results

197 tests pass (191 original + 6 new).