### PR TITLE
fix(lessons): add session_categories routing to agent-orchestrator-patterns

### DIFF
--- a/lessons/workflow/agent-orchestrator-patterns.md
+++ b/lessons/workflow/agent-orchestrator-patterns.md
@@ -2,7 +2,15 @@
 status: active
 match:
   keywords:
-    - "standup report"
+    - "agent standup"
+    - "orchestrator"
+    - "multi-agent"
+    - "agent health"
+    - "peripheral agent"
+    - "standup missing"
+    - "agent coordination"
+    - "inference utilization"
+  session_categories: [monitoring, cross-repo]
 ---
 
 # Agent Orchestrator Patterns


### PR DESCRIPTION
The agent-orchestrator-patterns lesson uses session_categories for routing but lacked the required frontmatter key. This adds it so the lesson is properly delivered via category routing.

Fixes the true-silent finding from lesson-keyword-journal-crossref.