### PR TITLE
fix(codegraph): update cross-file impact test assertion for qualified IDs

### DIFF
--- a/packages/gptme-codegraph/tests/test_codegraph_mcp_server.py
+++ b/packages/gptme-codegraph/tests/test_codegraph_mcp_server.py
@@ -319,7 +319,7 @@ def test_cross_file_impact(sample_dir):
     assert d["symbol"] == "add"
     assert d["total_affected"] >= 1
     assert "depth_0" in d["depth_breakdown"]
-    assert "add" in d["depth_breakdown"]["depth_0"]
+    assert "a::add" in d["depth_breakdown"]["depth_0"]
 
 
 def test_cross_file_impact_missing_symbol(sample_dir):


### PR DESCRIPTION
The cross-file impact test was checking for bare symbol names like `add` in the depth breakdown, but the qualified-ID migration (PR #829) prefixed cross-file symbols with module paths like `a::add`. Updated the assertion to match the actual output format.

Test: `uv run pytest packages/gptme-codegraph/tests/test_codegraph_mcp_server.py -x -q` — 24 passed