### PR TITLE
fix(codegraph): accept str paths in build_index by converting to Path

### DIFF
--- a/packages/gptme-codegraph/src/gptme_codegraph/core.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/core.py
@@ -689,7 +689,7 @@ def extract_symbols(filepath: Path) -> list[Symbol]:
     return parse_file(filepath).symbols
 
 
-def build_index(directory: Path) -> SymbolIndex:
+def build_index(directory: str | Path) -> SymbolIndex:
     """Build a cross-file symbol index for all Python files in a directory.
 
     Scans all ``.py`` files recursively, extracts symbols and imports, and

--- a/packages/gptme-codegraph/src/gptme_codegraph/core.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/core.py
@@ -696,6 +696,7 @@ def build_index(directory: Path) -> SymbolIndex:
     creates an ``IndexEntry`` for each symbol and ``ImportInfo`` for each import.
     """
     index = SymbolIndex()
+    directory = Path(directory)
     dir_str = str(directory)
     for fp in sorted(directory.rglob("*.py")):
         # Skip common non-source directories


### PR DESCRIPTION
The type annotation said `Path` but the function body uses `.rglob()` which requires a Path object. Multiple callers pass strings (including the MCP server), so convert at the entry point rather than updating all callers.

- Fixes: `AttributeError: 'str' object has no attribute 'rglob'` when calling `build_index()` with a string path
- Tests: 91 passed, 1 skipped (no regression)