### PR TITLE
fix(lessons): narrow over-broad keywords in github-issue-engagement lesson

### DIFF
--- a/lessons/social/github-issue-engagement.md
+++ b/lessons/social/github-issue-engagement.md
@@ -1,21 +1,18 @@
 ---
 match:
   keywords:
-  - "github issue"
-  - "open issue"
-  - "create issue"
-  - "close issue"
   - "about to create new issue"
   - "duplicate issue prevention"
   - "search existing issues first"
   - "check for similar issues"
   - "update issue after work"
-  - "gh issue"
   - "check own previous comments"
   - "agent created duplicate issues"
   - "duplicate comment prevention"
   - "triple posted"
   - "comment spam"
+  - "check if already commented"
+  - "before posting any comment"
 status: active
 ---
 


### PR DESCRIPTION
## Problem

The `github-issue-engagement` lesson was firing in ~41% of sessions (1116/2718) due to 5 over-broad keywords:
- `"github issue"`
- `"open issue"`
- `"create issue"`
- `"close issue"`
- `"gh issue"`

These match almost any GitHub-related session, making the lesson context noise rather than targeted guidance.

## Solution

Removed the 5 over-broad keywords. Added 2 more specific keywords that better capture the failure modes this lesson targets:
- `"check if already commented"`
- `"before posting any comment"`

The remaining keywords focus on the actual anti-patterns: duplicate issue prevention, checking own previous comments, and comment spam detection.

## Verification

- Lesson validator: will pass (no schema changes)
- Expected trigger rate: should drop significantly from 41% to <5% (scenario-specific triggers only)
- TS score (0.454) suggests the lesson IS helpful when it fires — we just want it to fire for the right sessions