### PR TITLE
fix(gptme-voice): expose OpenAI realtime reasoning effort

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
@@ -12,7 +12,7 @@ import json
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Literal
 
 import websockets  # type: ignore
 from gptme.config import get_config, get_project_config
@@ -198,6 +198,7 @@ class SessionConfig:
     """Configuration for OpenAI Realtime API session."""
 
     model: str = "gpt-realtime-2"
+    reasoning_effort: Literal["minimal", "low", "medium", "high", "xhigh"] | None = None
     voice: str = "echo"
     output_speed: float | None = None
     instructions: str = ""
@@ -277,14 +278,18 @@ class OpenAIRealtimeClient:
 
     def _get_ws_headers(self) -> dict[str, str]:
         """Auth headers for this provider (override in subclasses)."""
-        return {
-            "Authorization": f"Bearer {self.api_key}",
-            "OpenAI-Beta": "realtime=v1",
-        }
+        return {"Authorization": f"Bearer {self.api_key}"}
 
     def _get_transcription_config(self) -> dict | None:
         """Transcription config for session.update (override to None to omit)."""
         return {"model": "whisper-1"}
+
+    def _get_reasoning_config(self) -> dict[str, str] | None:
+        """Reasoning config for session.update (override to omit or customize)."""
+        effort = self.session_config.reasoning_effort
+        if effort is None:
+            return None
+        return {"effort": effort}
 
     async def connect(self) -> None:
         """Connect to OpenAI Realtime API."""
@@ -464,6 +469,9 @@ class OpenAIRealtimeClient:
         }
         if self.session_config.output_speed is not None:
             session_params["output"] = {"speed": self.session_config.output_speed}
+        reasoning = self._get_reasoning_config()
+        if reasoning is not None:
+            session_params["reasoning"] = reasoning
         transcription = self._get_transcription_config()
         if transcription is not None:
             session_params["input_audio_transcription"] = transcription

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -403,6 +403,7 @@ def _build_resume_instructions(
 _PROVIDER_OPENAI = "openai"
 _PROVIDER_GROK = "grok"
 _VALID_PROVIDERS = (_PROVIDER_OPENAI, _PROVIDER_GROK)
+_VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh")
 
 
 def _get_twilio_field(payload: dict, camel_name: str, snake_name: str) -> str | None:
@@ -425,6 +426,7 @@ class VoiceServer:
         workspace: str | None = None,
         provider: str = _PROVIDER_OPENAI,
         model: str | None = None,
+        reasoning_effort: str | None = "low",
         voice: str | None = None,
         output_speed: float | None = None,
         enable_browser_transport: bool = False,
@@ -433,6 +435,7 @@ class VoiceServer:
         self.port = port
         self.provider = provider
         self.model = model
+        self.reasoning_effort = reasoning_effort
         self.voice = voice
         self.output_speed = output_speed
         self.enable_browser_transport = enable_browser_transport
@@ -1566,6 +1569,8 @@ class VoiceServer:
         )
         if self.model:
             kwargs["model"] = self.model
+        if self.reasoning_effort is not None:
+            kwargs["reasoning_effort"] = self.reasoning_effort
         if self.voice:
             kwargs["voice"] = self.voice
         if self.output_speed is not None:
@@ -1887,6 +1892,16 @@ class VoiceServer:
     ),
 )
 @click.option(
+    "--reasoning-effort",
+    default="low",
+    type=click.Choice(_VALID_REASONING_EFFORTS),
+    show_default=True,
+    help=(
+        "OpenAI Realtime reasoning effort. Ignored for xAI. OpenAI recommends "
+        "starting gpt-realtime-2 at low for production voice agents."
+    ),
+)
+@click.option(
     "--voice",
     default=None,
     help=(
@@ -1915,6 +1930,7 @@ def main(
     workspace: str | None,
     provider: str,
     model: str | None,
+    reasoning_effort: str,
     voice: str | None,
     output_speed: float | None,
     enable_browser_transport: bool,
@@ -1935,12 +1951,20 @@ def main(
         workspace=workspace,
         provider=provider,
         model=model,
+        reasoning_effort=reasoning_effort,
         voice=voice,
         output_speed=output_speed,
         enable_browser_transport=enable_browser_transport,
     )
 
-    logger.info(f"Starting voice server on {host}:{port} (provider={provider})")
+    logger.info(
+        "Starting voice server on %s:%s (provider=%s, model=%s, reasoning_effort=%s)",
+        host,
+        port,
+        provider,
+        model or "<default>",
+        reasoning_effort if provider == _PROVIDER_OPENAI else "<ignored>",
+    )
     logger.info(f"Local test endpoint: ws://{host}:{port}/local")
     if enable_browser_transport:
         logger.info(f"Browser test endpoint: ws://{host}:{port}/voice")

--- a/packages/gptme-voice/src/gptme_voice/realtime/xai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/xai_client.py
@@ -91,6 +91,10 @@ class XAIRealtimeClient(OpenAIRealtimeClient):
         """xAI does not support whisper-1; omit transcription config."""
         return None
 
+    def _get_reasoning_config(self) -> dict[str, str] | None:
+        """xAI's voice agent API does not expose OpenAI-style reasoning controls."""
+        return None
+
     # xAI does not emit session.created; it emits session.updated instead.
     # The base class already handles session.updated via _mark_session_ready,
     # so no override is needed here.

--- a/packages/gptme-voice/tests/test_openai_client.py
+++ b/packages/gptme-voice/tests/test_openai_client.py
@@ -109,6 +109,39 @@ def test_connect_omits_output_key_when_speed_not_configured() -> None:
         session_update = fake_ws.sent[0]
         assert session_update["type"] == "session.update"
         assert "output" not in session_update["session"]
+        assert "reasoning" not in session_update["session"]
+
+    asyncio.run(_exercise())
+
+
+def test_connect_uses_current_openai_headers_and_reasoning_effort() -> None:
+    async def _exercise() -> None:
+        fake_ws = _FakeWebSocket()
+        captured_headers: dict[str, str] = {}
+
+        async def _fake_connect(*_args, **_kwargs):
+            captured_headers.update(_kwargs["additional_headers"])
+            return fake_ws
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "gptme_voice.realtime.openai_client.websockets.connect", _fake_connect
+            )
+            client = OpenAIRealtimeClient(
+                api_key="test-key",
+                session_config=SessionConfig(
+                    instructions="You are Bob.",
+                    reasoning_effort="low",
+                ),
+            )
+            await client.connect()
+            await asyncio.sleep(0)
+            await client.disconnect()
+
+        session_update = fake_ws.sent[0]
+        assert captured_headers == {"Authorization": "Bearer test-key"}
+        assert "OpenAI-Beta" not in captured_headers
+        assert session_update["session"]["reasoning"] == {"effort": "low"}
 
     asyncio.run(_exercise())
 

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -163,6 +163,14 @@ def test_send_to_twilio_uses_stream_sid_field_name() -> None:
     }
 
 
+def test_build_session_config_passes_reasoning_effort_override() -> None:
+    server = VoiceServer(reasoning_effort="minimal")
+
+    session_config = server._build_session_config("You are Bob.")
+
+    assert session_config.reasoning_effort == "minimal"
+
+
 def test_voice_route_disabled_by_default() -> None:
     server = VoiceServer()
 

--- a/packages/gptme-voice/tests/test_xai_client.py
+++ b/packages/gptme-voice/tests/test_xai_client.py
@@ -99,3 +99,31 @@ def test_xai_client_treats_session_updated_as_ready_signal() -> None:
             assert fake_ws.closed is True
 
     asyncio.run(_exercise())
+
+
+def test_xai_client_ignores_openai_reasoning_config() -> None:
+    async def _exercise() -> None:
+        fake_ws = _FakeWebSocket()
+
+        async def _fake_connect(*_args, **_kwargs):
+            return fake_ws
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "gptme_voice.realtime.openai_client.websockets.connect", _fake_connect
+            )
+            client = XAIRealtimeClient(
+                api_key="test-key",
+                session_config=SessionConfig(
+                    instructions="You are Bob.",
+                    reasoning_effort="low",
+                ),
+            )
+            await client.connect()
+            await asyncio.sleep(0)
+            await client.disconnect()
+
+        session_update = fake_ws.sent[0]
+        assert "reasoning" not in session_update["session"]
+
+    asyncio.run(_exercise())


### PR DESCRIPTION
## Summary
- add `reasoning_effort` to `SessionConfig` and thread it through `gptme-voice-server`
- expose `--reasoning-effort` on the CLI with `low` as the OpenAI default
- stop sending the legacy `OpenAI-Beta: realtime=v1` header
- keep xAI on its current path by explicitly omitting OpenAI-only reasoning config
- add focused tests for headers, reasoning payloads, and server config plumbing

## Why
OpenAI's current Realtime guidance says `gpt-realtime-2` is the reasoning voice model and recommends starting with `reasoning.effort=low` for production voice agents. Our client already defaulted to `gpt-realtime-2`, but it had no way to set reasoning effort and still sent the old beta header.

This keeps the change narrow: no schema churn, no prompt rewrite, just enough to make Bob's upcoming OpenAI realtime trial use the current control surface.

Refs:
- https://developers.openai.com/api/docs/guides/realtime-models-prompting
- https://developers.openai.com/api/docs/models/gpt-realtime-2
- https://developers.openai.com/api/reference/resources/realtime

## Verification
- `uv run --python 3.12 pytest packages/gptme-voice/tests -q`
- `uv run ruff check packages/gptme-voice/src/gptme_voice/realtime/openai_client.py packages/gptme-voice/src/gptme_voice/realtime/xai_client.py packages/gptme-voice/src/gptme_voice/realtime/server.py packages/gptme-voice/tests/test_openai_client.py packages/gptme-voice/tests/test_xai_client.py packages/gptme-voice/tests/test_server.py`
