### PR TITLE
fix(codegraph): skip tests gracefully when tree-sitter extras not installed

### DIFF
--- a/packages/gptme-codegraph/tests/conftest.py
+++ b/packages/gptme-codegraph/tests/conftest.py
@@ -16,5 +16,5 @@ def pytest_collection_modifyitems(config, items):
             reason="tree-sitter not installed — run: uv sync --all-extras"
         )
         for item in items:
-            if "gptme_codegraph" in str(item.fspath) or "codegraph" in str(item.fspath):
+            if "codegraph" in str(item.path):
                 item.add_marker(skip_mark)


### PR DESCRIPTION
## Problem

Running `uv run pytest packages/` locally (without `--all-extras`) causes 59 false test failures in `gptme-codegraph`. The `tree-sitter` and `tree-sitter-python` packages are optional extras, so `parse_file` silently returns empty when they're absent — making all symbol-lookup assertions fail.

## Fix

Add a `conftest.py` to the codegraph tests that marks all codegraph tests as `skip` when `tree_sitter` is not importable, with a clear message directing the developer to run `uv sync --all-extras`.

CI already runs with `uv sync --all-packages --all-extras`, so tests continue to execute there.

## Testing

- With tree-sitter installed: 91 passed, 1 skipped (same as before)
- Without tree-sitter: all codegraph tests show as skipped (not failed)