### PR TITLE
fix(gptme-voice): cancel previous audioEndTimer on consecutive audio_end events

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/static/index.html
+++ b/packages/gptme-voice/src/gptme_voice/static/index.html
@@ -109,6 +109,7 @@
     let outputQueue = [];
     let isPlaying = false;
     let playbackScheduledUntil = 0;
+    let audioEndTimer = null;
     let vuRafId = null;
 
     const connectBtn = document.getElementById('connectBtn');
@@ -229,9 +230,15 @@ registerProcessor('pcm16-capture', PCM16CaptureProcessor);
     }
 
     function onAudioEnd() {
-      // Give a small grace period for the last buffer to finish
+      // Cancel the previous timer so only the last audio_end controls isPlaying.
+      // Without this, consecutive audio responses (e.g. tool-call + reply) cause
+      // the first timer to fire while the second stream is still playing.
+      if (audioEndTimer !== null) {
+        clearTimeout(audioEndTimer);
+      }
       const remaining = (playbackScheduledUntil - (playCtx?.currentTime ?? 0)) * 1000;
-      setTimeout(() => {
+      audioEndTimer = setTimeout(() => {
+        audioEndTimer = null;
         isPlaying = false;
         playingIndicator.classList.add('hidden');
         // Commit any buffered audio after playback completes
@@ -293,6 +300,10 @@ registerProcessor('pcm16-capture', PCM16CaptureProcessor);
     function disconnect() {
       ws?.close();
       stopMic();
+      if (audioEndTimer !== null) {
+        clearTimeout(audioEndTimer);
+        audioEndTimer = null;
+      }
       isPlaying = false;
       playingIndicator.classList.add('hidden');
       playCtx?.close().catch(() => {});


### PR DESCRIPTION
## Summary

- Track pending timer in `audioEndTimer` variable; cancel it at the start of each `onAudioEnd` call so only the last timer controls `isPlaying` state
- Also clear the timer in `disconnect()` to prevent stale callbacks firing after the call ends

## Problem

Consecutive audio responses (e.g. tool-call followed by a spoken reply) emit multiple `audio_end` messages. The previous `onAudioEnd` scheduled a new `setTimeout` each time without cancelling the prior one. The first timer would fire while the second stream was still playing, prematurely flipping `isPlaying` to `false` and sending a spurious `commit` to the server — triggering an extra OpenAI inference round before the user had said anything.

Identified in the Greptile review of #874.

## Test plan

- [ ] Connect browser client and trigger a tool-call response (e.g. ask something that causes the assistant to use a tool then speak)
- [ ] Confirm mic does not activate while the second audio stream is still playing
- [ ] Confirm only one `commit` is sent after all audio finishes