### PR TITLE
feat(gptme-sessions): wire selector_mode + recommended-category through post-session

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -1600,6 +1600,16 @@ def repair_grades(ctx: click.Context, dry_run: bool) -> None:
 @click.option("--trigger", default=None, help="Session trigger: timer, dispatch, manual, spawn")
 @click.option("--category", default=None, help="Work category (code, triage, ...)")
 @click.option(
+    "--recommended-category",
+    default=None,
+    help="Category recommended by the selector before the session ran",
+)
+@click.option(
+    "--selector-mode",
+    default=None,
+    help="Selector strategy used (e.g. scored, llm-context)",
+)
+@click.option(
     "--exit-code",
     type=int,
     default=0,
@@ -1644,6 +1654,8 @@ def post_session_cmd(
     run_type: str,
     trigger: str | None,
     category: str | None,
+    recommended_category: str | None,
+    selector_mode: str | None,
     exit_code: int,
     duration: int,
     trajectory: Path | None,
@@ -1667,6 +1679,8 @@ def post_session_cmd(
         run_type=run_type,
         trigger=trigger,
         category=category,
+        recommended_category=recommended_category,
+        selector_mode=selector_mode,
         exit_code=exit_code,
         duration_seconds=duration,
         trajectory_path=trajectory,

--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -135,6 +135,7 @@ def post_session(
     trigger: str | None = None,
     category: str | None = None,
     recommended_category: str | None = None,
+    selector_mode: str | None = None,
     cascade_intent: dict[str, Any] | None = None,
     exit_code: int = 0,
     duration_seconds: int = 0,
@@ -178,6 +179,11 @@ def post_session(
         Category recommended by the selector before the session ran
         (e.g. Thompson sampling, CASCADE). Stored alongside the actual
         category so drift between recommendation and reality is trackable.
+    selector_mode:
+        Which selector strategy was used to pick this session's work
+        (e.g. ``"scored"``, ``"llm-context"``). Set by the CASCADE
+        selector and forwarded by the runner so post-hoc analyses can
+        compare outcomes across selector strategies.
     cascade_intent:
         Structured CASCADE selector metadata (for example ``{"reasons": [...],
         "constraints": [...]}``) captured before the session ran. Stored
@@ -388,6 +394,8 @@ def post_session(
         record_kwargs["category"] = actual_category
     if recommended_category is not None:
         record_kwargs["recommended_category"] = recommended_category
+    if selector_mode is not None:
+        record_kwargs["selector_mode"] = selector_mode
     if cascade_intent is not None:
         record_kwargs["cascade_intent"] = cascade_intent
     if trajectory_path is not None:

--- a/packages/gptme-sessions/tests/test_post_session.py
+++ b/packages/gptme-sessions/tests/test_post_session.py
@@ -97,6 +97,39 @@ def test_post_session_ab_group_tier_version_none(tmp_path: Path):
     assert result.record.tier_version is None
 
 
+def test_post_session_selector_mode(tmp_path: Path):
+    """selector_mode is stored in the SessionRecord when passed to post_session."""
+    store = SessionStore(sessions_dir=tmp_path)
+    result = post_session(
+        store=store,
+        harness="claude-code",
+        model="opus",
+        selector_mode="llm-context",
+        recommended_category="cleanup",
+        duration_seconds=60,
+    )
+    assert result.record.selector_mode == "llm-context"
+    assert result.record.recommended_category == "cleanup"
+
+    store2 = SessionStore(sessions_dir=tmp_path)
+    records = store2.load_all()
+    assert len(records) == 1
+    assert records[0].selector_mode == "llm-context"
+    assert records[0].recommended_category == "cleanup"
+
+
+def test_post_session_selector_mode_none(tmp_path: Path):
+    """selector_mode defaults to None when not provided."""
+    store = SessionStore(sessions_dir=tmp_path)
+    result = post_session(
+        store=store,
+        harness="gptme",
+        model="sonnet",
+        duration_seconds=30,
+    )
+    assert result.record.selector_mode is None
+
+
 def test_post_session_ab_group_invalid(tmp_path: Path):
     """post_session raises ValueError for invalid ab_group values."""
     store = SessionStore(sessions_dir=tmp_path)


### PR DESCRIPTION
## Summary

Closes a quiet field-coverage gap: \`SessionRecord.selector_mode\` was defined in
the schema and read by downstream tools (session-db, harm analysis,
loop-intelligence-report) but **never populated**. The Stop-hook entry point
\`post_session()\` accepted \`recommended_category\`, \`category\`, \`trigger\`, etc.
but **not** \`selector_mode\`. Same gap on the \`post-session\` CLI: callers
couldn't pass \`--selector-mode\` or \`--recommended-category\`, so Bob's
\`autonomous-run.sh\` builds the kwargs in inline Python instead of calling the
CLI.

Empirical impact: 0/354 session records over the last 24h had \`selector_mode\`
set, even though the CASCADE selector (in Bob's repo) decides between the
\`scored\` and \`llm-context\` strategies via Thompson sampling and could trivially
forward that choice.

## Changes

- \`post_session.py\`: add \`selector_mode: str | None = None\` parameter; forward to
  \`record_kwargs\` so it lands on the SessionRecord.
- \`cli.py\`: expose \`--selector-mode\` and \`--recommended-category\` on the
  \`gptme-sessions post-session\` command (the \`recommended-category\` plumbing was
  half-finished — function accepted it, CLI didn't pass it).
- \`tests/test_post_session.py\`: round-trip test (set + reload) and a
  default-None test.

## Test plan

- [x] \`pytest tests/test_post_session.py\` — 21 passed
- [x] \`pytest tests/test_cli.py -k 'post_session or annotate or selector'\` — 4 passed
- [x] \`mypy src/gptme_sessions/post_session.py src/gptme_sessions/cli.py\` — clean
- [x] \`gptme-sessions post-session --help\` shows both new options
- [ ] CI green