### PR TITLE
fix(lessons): tighten communication-loop keywords to failure-mode signals

### DIFF
--- a/lessons/workflow/communication-loop-closure-patterns.md
+++ b/lessons/workflow/communication-loop-closure-patterns.md
@@ -1,13 +1,17 @@
 ---
 match:
   keywords:
-  - update the issue
-  - reply to the issue
-  - comment on the issue
   - close the communication loop
   - respond in the original thread
   - confirm the fix in the issue
+  - completed the work but did not
+  - marked as done without commenting
+  - silent completion
+  - link back to the original issue
+  - end the session without responding
+  - finished but never replied
 status: active
+target_grade: alignment
 ---
 
 # Communication Loop Closure Patterns


### PR DESCRIPTION
## Summary

LOO analysis (`scripts/lesson-loo-analysis.py --category-controlled`,
n=271 sessions, p<0.05) flagged `communication-loop-closure-patterns` as the
**only genuinely-harmful (non-confounded) lesson** with Δ=-0.0207 vs baseline.

The previous keyword set still over-triggered:

```
- update the issue
- reply to the issue
- comment on the issue
- close the communication loop
- respond in the original thread
- confirm the fix in the issue
```

The first three fire on any GitHub-style work, making the lesson a weak proxy
for low-baseline session types rather than a closure-failure detector.

## Changes

- **Removed** generic GitHub triggers: "update the issue", "reply to the
  issue", "comment on the issue"
- **Kept** closure-specific triggers: "close the communication loop", "respond
  in the original thread", "confirm the fix in the issue"
- **Added** failure-mode signals that detect the *risk* of skipping closure:
  - "completed the work but did not"
  - "marked as done without commenting"
  - "silent completion"
  - "link back to the original issue"
  - "end the session without responding"
  - "finished but never replied"
- **Added** `target_grade: alignment` — closure is an alignment behavior, not
  productivity

## Iteration history

This continues a multi-round tightening line on this lesson:
9bf427f → 2fccf0d → 82772e9 → c9390c3 → d24042b → (this PR).

Each round narrowed keywords; LOO data still showed harm. The hypothesis
behind this iteration: previous keywords still match GitHub-work sessions in
general; the new keywords match the *specific moment of risk*, where the
agent has finished the work but is about to skip the closure step.

## Test plan

- [x] Lesson validator passes (two-file format)
- [ ] After merge, accumulate 30+ new sessions and re-run LOO analysis to
      confirm the delta direction reverses or attenuates, or the lesson
      drops out of the harmful list entirely