### PR TITLE
feat(gptme-voice): add G.711 mu-law passthrough on OpenAI Twilio path

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
@@ -214,6 +214,18 @@ class SessionConfig:
     available_agents: list[str] = field(
         default_factory=lambda: ["alice", "gordon", "sven"]
     )
+    # When True, configure the OpenAI session to send/receive G.711 μ-law at
+    # 8kHz directly. The Twilio bridge uses this to skip an otherwise-required
+    # PCM16 ↔ μ-law and 8k ↔ 24k resampling round on the OpenAI branch.
+    # Has no effect on the xAI/Grok client (Grok requires PCM).
+    g711_passthrough: bool = False
+
+    def __post_init__(self) -> None:
+        if self.g711_passthrough:
+            self.input_format = "g711_ulaw"
+            self.output_format = "g711_ulaw"
+            self.input_sample_rate = 8000
+            self.output_sample_rate = 8000
 
 
 class OpenAIRealtimeClient:

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -439,6 +439,12 @@ class VoiceServer:
         self.voice = voice
         self.output_speed = output_speed
         self.enable_browser_transport = enable_browser_transport
+        # G.711 μ-law passthrough on the OpenAI Twilio path. Only takes effect
+        # for provider=openai; Grok is unaffected because its API requires PCM.
+        self.openai_g711_passthrough = (
+            (_get_config_env("GPTME_VOICE_OPENAI_G711_PASSTHROUGH") or "").lower()
+            in ("1", "true", "yes")
+        ) and provider == _PROVIDER_OPENAI
         if provider == _PROVIDER_GROK:
             self._api_key = _get_xai_api_key()
         else:
@@ -1387,6 +1393,7 @@ class VoiceServer:
         transcript: list[TranscriptTurn] = []
         metadata: dict[str, str] = {}
         handoff_id: str | None = None
+        g711_passthrough = self.openai_g711_passthrough
 
         try:
             async for message in websocket.iter_text():
@@ -1428,11 +1435,12 @@ class VoiceServer:
                     # is detected and awaited by _call_callback.
                     def _make_on_audio(_stream_sid: str):
                         async def _on_audio(audio: bytes) -> None:
-                            await self._send_to_twilio(
-                                websocket,
-                                _stream_sid,
-                                audio_converter.openai_to_twilio(audio),
+                            payload = (
+                                audio
+                                if g711_passthrough
+                                else audio_converter.openai_to_twilio(audio)
                             )
+                            await self._send_to_twilio(websocket, _stream_sid, payload)
 
                         return _on_audio
 
@@ -1518,10 +1526,15 @@ class VoiceServer:
                         media = data.get("media", {})
                         mulaw_b64 = media.get("payload", "")
                         if mulaw_b64:
-                            # Convert to PCM and send to realtime API
                             mulaw_data = base64.b64decode(mulaw_b64)
-                            pcm_data = audio_converter.twilio_to_openai(mulaw_data)
-                            await realtime_client.send_audio(pcm_data)
+                            if g711_passthrough:
+                                # OpenAI session is configured for g711_ulaw —
+                                # forward Twilio's μ-law payload as-is.
+                                await realtime_client.send_audio(mulaw_data)
+                            else:
+                                # Convert to PCM 24kHz and send to realtime API
+                                pcm_data = audio_converter.twilio_to_openai(mulaw_data)
+                                await realtime_client.send_audio(pcm_data)
 
                 elif event == "stop":
                     # Call ended
@@ -1581,6 +1594,8 @@ class VoiceServer:
             kwargs["voice"] = self.voice
         if self.output_speed is not None:
             kwargs["output_speed"] = self.output_speed
+        if self.openai_g711_passthrough:
+            kwargs["g711_passthrough"] = True
         return SessionConfig(**kwargs)
 
     def _make_client(

--- a/packages/gptme-voice/tests/test_openai_client.py
+++ b/packages/gptme-voice/tests/test_openai_client.py
@@ -717,3 +717,49 @@ def test_activate_session_before_session_ready_sends_greeting_on_ready() -> None
             await client.disconnect()
 
     asyncio.run(_exercise())
+
+
+def test_session_config_g711_passthrough_sets_format_and_rates() -> None:
+    cfg = SessionConfig(g711_passthrough=True)
+    assert cfg.input_format == "g711_ulaw"
+    assert cfg.output_format == "g711_ulaw"
+    assert cfg.input_sample_rate == 8000
+    assert cfg.output_sample_rate == 8000
+
+
+def test_session_config_g711_passthrough_default_off_keeps_pcm16() -> None:
+    cfg = SessionConfig()
+    assert cfg.g711_passthrough is False
+    assert cfg.input_format == "pcm16"
+    assert cfg.output_format == "pcm16"
+    assert cfg.input_sample_rate == 24000
+    assert cfg.output_sample_rate == 24000
+
+
+def test_connect_emits_g711_ulaw_audio_format_when_passthrough_enabled() -> None:
+    async def _exercise() -> None:
+        fake_ws = _FakeWebSocket()
+
+        async def _fake_connect(*_args, **_kwargs):
+            return fake_ws
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "gptme_voice.realtime.openai_client.websockets.connect", _fake_connect
+            )
+            client = OpenAIRealtimeClient(
+                api_key="test-key",
+                session_config=SessionConfig(
+                    instructions="You are Bob.",
+                    g711_passthrough=True,
+                ),
+            )
+            await client.connect()
+            await asyncio.sleep(0)
+            await client.disconnect()
+
+        session_update = fake_ws.sent[0]
+        assert session_update["type"] == "session.update"
+        session = session_update["session"]
+        assert session["input_audio_format"] == "g711_ulaw"
+        assert session["output_audio_format"] == "g711_ulaw"

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -1310,3 +1310,34 @@ class TestTranscriptPromotion:
 
         server._promote_transcript_to_gptme("+15551234567", transcript, metadata)
         assert len(calls) == 0
+
+
+def test_server_g711_passthrough_off_by_default() -> None:
+    server = VoiceServer()
+    assert server.openai_g711_passthrough is False
+
+
+def test_server_g711_passthrough_enabled_via_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GPTME_VOICE_OPENAI_G711_PASSTHROUGH", "1")
+    server = VoiceServer()
+    assert server.openai_g711_passthrough is True
+
+    session_config = server._build_session_config("You are Bob.")
+    assert session_config.g711_passthrough is True
+    assert session_config.input_format == "g711_ulaw"
+    assert session_config.output_format == "g711_ulaw"
+
+
+def test_server_g711_passthrough_ignored_for_grok_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GPTME_VOICE_OPENAI_G711_PASSTHROUGH", "1")
+    server = VoiceServer(provider="grok")
+    # Grok requires PCM; the env flag must not bleed into a Grok session.
+    assert server.openai_g711_passthrough is False
+
+    session_config = server._build_session_config("You are Bob.")
+    assert session_config.g711_passthrough is False
+    assert session_config.input_format == "pcm16"


### PR DESCRIPTION
## Summary

Adds a guarded path that lets the OpenAI Realtime session run with native
\`g711_ulaw\` audio formats and 8 kHz sample rates instead of PCM16/24 kHz.
When enabled, the Twilio bridge forwards μ-law bytes directly into
\`send_audio\` and emits provider audio bytes straight back to Twilio,
skipping both legs of the PCM round-trip:

\`\`\`
μ-law → [PCM 8k] → [PCM 24k] → IIR low-pass → [PCM 8k] → μ-law
\`\`\`

becomes

\`\`\`
μ-law → μ-law
\`\`\`

Default is **OFF**. Toggle with \`GPTME_VOICE_OPENAI_G711_PASSTHROUGH=1\`.
Has no effect on the xAI/Grok client (Grok requires PCM, and the env flag
only takes effect when \`provider=openai\`).

## Why

Bob's planned OpenAI Realtime trial keeps the existing PCM bridge so the
provider comparison vs Grok stays apples-to-apples. If the live OpenAI call
still sounds rough, the most defensible follow-up is to remove avoidable
transcoding before blaming the provider. This PR makes that follow-up a
single-flag flip rather than a code change.

## Scope

**In scope** (per \`tasks/openai-realtime-g711-ulaw-passthrough.md\`):
- Confirm \`g711_ulaw\` is reachable in Bob's OpenAI Realtime path: ✅ yes,
  no upstream shape blocks it.
- Narrow OpenAI-only Twilio branch, guarded behind an env flag.
- Tests covering both the SessionConfig surface and the server-level wiring.

**Out of scope (intentional)**:
- Subjective audio-quality / first-audio-token latency comparison — that
  needs a real call. Erik will run an A/B trial after a baseline OpenAI
  call without the flag.
- Changing the first OpenAI trial to use this path pre-emptively.
- Provider-side decisions about transcription quality at 8 kHz.

## Test plan

- [x] \`uv run pytest packages/gptme-voice/tests/test_openai_client.py\` — 23 passed
- [x] \`uv run pytest packages/gptme-voice/tests/test_server.py\` — green for the three new
      \`test_server_g711_passthrough_*\` cases plus all unrelated suites
- [x] Full voice package suite: 145 passed (one pre-existing post-call subprocess
      test failure unrelated to this change)
- [ ] Live trial: Erik runs a plain-OpenAI inbound call, then a second call with
      \`GPTME_VOICE_OPENAI_G711_PASSTHROUGH=1\`, captures subjective quality and
      latency in \`tasks/openai-realtime-g711-ulaw-passthrough.md\`

## Refs

- Bob task: \`tasks/openai-realtime-g711-ulaw-passthrough.md\` (now \`waiting\` on the live A/B)
- Bob readiness doc: \`knowledge/infrastructure/voice-openai-trial-readiness.md\` (Phase 2 prototype section)
- ErikBjare/bob#651