### PR TITLE
fix(lessons): replace dead keywords on avoid-long-try-blocks

### DIFF
--- a/lessons/patterns/avoid-long-try-blocks.md
+++ b/lessons/patterns/avoid-long-try-blocks.md
@@ -1,17 +1,13 @@
 ---
 match:
   keywords:
-  - try block too long
-  - exception handling > 10 lines
-  - split error handling into focused blocks
-  - multiple operations in one try block
-  - generic error messages
+  - "except Exception:"
+  - "except Exception as e"
   - "bare except"
+  - "broad except"
   - "broad exception"
-  - "except Exception"
   - "try/except"
-  - "split the try block"
-  - "large try block"
+  - "wrap in try"
   session_categories: [code]
 status: active
 ---


### PR DESCRIPTION
## Summary

Replace 9 descriptive natural-language keywords that never fire in trajectories with 7 verified failure-mode keywords from real session data.

The dead keywords described the lesson's own subject (\"try block too long\", \"split the try block\", \"large try block\") rather than signals that appear in actual prompts.

## Trajectory verification (last 500 sessions)

| keyword | hits |
|---|---|
| \`except Exception:\` | 17 |
| \`except Exception as e\` | 21 |
| \`try/except\` | 17 |
| \`broad except\` | 4 |
| \`broad exception\` | 4 |
| \`bare except\` | 2 |
| \`wrap in try\` | 1 |

## Why

\`lesson-keyword-health.py --action-items\` flagged this lesson with 9 dead keywords (TS=0.514, fires in 6/1235 sessions). The same methodology used in #883 — drop self-referential descriptive keywords, add concrete code patterns and failure-mode signals that actually appear in prompts.

## Test plan

- [x] Lesson validator passes (\`gptme_lessons_extras/validate.py\`)
- [ ] 7-day trajectory window after merge to confirm new keywords actually fire