### PR TITLE
fix(gptme-sessions): category-aware rubric in LLM judge prompt

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/judge.py
+++ b/packages/gptme-sessions/src/gptme_sessions/judge.py
@@ -82,8 +82,24 @@ Rate the strategic value of this session's output on 0.0-1.0:
 - 0.1-0.2: Minimal output (mostly blocked, NOOP-adjacent)
 - 0.0: No output / pure NOOP
 
+## Category Interpretation
+Sessions are routed across categories. Some categories (code, content,
+cross-repo) directly target top-priority product/revenue goals. Others
+(infrastructure, monitoring, cleanup, knowledge, research, self-review,
+triage, news, social, novelty, strategic) are support work that compounds
+future capability. Score on **within-category value**, not on whether the
+category itself targets goal #1:
+- A clean infrastructure / instrumentation / measurement session that
+  meaningfully reduces future friction or persists durable learning is
+  goal-aligned — score 0.7-0.9, do not cap it for "not revenue work".
+- Penalize all categories equally for thrashing, no-shipped-artifact,
+  over-engineering, or work the agent invented to fill the session.
+- Reserve 0.9-1.0 for sessions where the deliverable plausibly moves a
+  top-priority goal *or* is a category-best example of compounding work.
+
 Key principle: ONE impactful deliverable > FIVE small deliverables.
-Evaluate impact and goal-alignment, not quantity.
+Evaluate impact within the session's category, not the category's intrinsic
+priority.
 
 Return JSON: {{"score": <float>, "reason": "<1 sentence>"}}"""
 

--- a/packages/gptme-sessions/src/gptme_sessions/judge.py
+++ b/packages/gptme-sessions/src/gptme_sessions/judge.py
@@ -77,7 +77,7 @@ JUDGE_PROMPT_TEMPLATE = """\
 Rate the strategic value of this session's output on 0.0-1.0:
 - 0.9-1.0: Major progress on a top-priority goal (shipped key feature, unblocked critical path)
 - 0.7-0.8: Meaningful progress on a priority goal (solid PR, design doc, real bug fix)
-- 0.5-0.6: Useful but not top-priority work (minor improvements, maintenance)
+- 0.5-0.6: Low-impact output in any category (weak improvements, thrashing-lite)
 - 0.3-0.4: Low-value work (tiny PRs, busywork, over-engineering)
 - 0.1-0.2: Minimal output (mostly blocked, NOOP-adjacent)
 - 0.0: No output / pure NOOP

--- a/packages/gptme-sessions/src/gptme_sessions/judge.py
+++ b/packages/gptme-sessions/src/gptme_sessions/judge.py
@@ -76,7 +76,7 @@ JUDGE_PROMPT_TEMPLATE = """\
 ## Scoring Rubric
 Rate the strategic value of this session's output on 0.0-1.0:
 - 0.9-1.0: Major progress on a top-priority goal (shipped key feature, unblocked critical path)
-- 0.7-0.8: Meaningful progress on a priority goal (solid PR, design doc, real bug fix)
+- 0.7-0.8: Meaningful progress on any goal — priority or compounding support (solid PR, durable infra win, real bug fix)
 - 0.5-0.6: Low-impact output in any category (weak improvements, thrashing-lite)
 - 0.3-0.4: Low-value work (tiny PRs, busywork, over-engineering)
 - 0.1-0.2: Minimal output (mostly blocked, NOOP-adjacent)

--- a/packages/gptme-sessions/tests/test_judge.py
+++ b/packages/gptme-sessions/tests/test_judge.py
@@ -88,6 +88,27 @@ class TestJudgeSession:
         assert "0.0-1.0" in prompt
         assert "JSON" in JUDGE_SYSTEM
 
+    def test_prompt_template_includes_category_interpretation(self) -> None:
+        """The prompt must instruct the judge to score within-category, not penalize support categories.
+
+        Regression guard: when the judge does not see a category-interpretation block,
+        it applies revenue/goal-#1 alignment as a fixed ceiling on
+        infrastructure/monitoring/knowledge work, producing systematic harness
+        bias documented in
+        knowledge/strategic/2026-05-10-gptme-harness-verification-gap.md.
+        """
+        prompt = JUDGE_PROMPT_TEMPLATE.format(
+            goals="Test goals",
+            category="infrastructure",
+            journal="Reduced future friction",
+        )
+        assert "Category Interpretation" in prompt
+        assert "within-category value" in prompt
+        # The block must explicitly name representative support categories so
+        # the judge does not collapse them into "non-revenue, low-score".
+        for support_cat in ("infrastructure", "monitoring", "knowledge", "research"):
+            assert support_cat in prompt
+
     def test_score_clamping(self) -> None:
         """Out-of-range scores from the LLM are clamped to [0.0, 1.0]."""
         mock_anthropic = MagicMock()


### PR DESCRIPTION
## Summary

Adds a "Category Interpretation" block to the LLM judge prompt that instructs
the model to score sessions on **within-category value**, not on whether the
category itself targets a top-priority goal.

## Why

Bob's harness verification gap investigation found that the judge applies
"revenue alignment critique" as a fixed ceiling on infrastructure / monitoring
/ knowledge work. 75% of low-grade gptme sessions are downgraded for "not
targeting goal #1" regardless of execution quality. This makes
`verified_artifact_rate` (and the harness bandit it feeds) measure category
routing rather than execution quality.

Decomposition of the 40 pp Round-5 gap between claude-code and gptme:

| Source | Contribution |
|---|---|
| Short-duration sessions (already filtered) | 16 pp |
| **Category routing (judge bias — this PR)** | **14 pp** |
| deepseek-flash quality regression | 6 pp |
| Residual real-quality gap | ~4 pp |

Full analysis: `knowledge/strategic/2026-05-10-gptme-harness-verification-gap.md` in [ErikBjare/bob](https://github.com/ErikBjare/bob).

## What changes

- New `## Category Interpretation` block in `JUDGE_PROMPT_TEMPLATE` that
  explicitly names support categories (infrastructure, monitoring, cleanup,
  knowledge, research, self-review, triage, news, social, novelty, strategic)
  and tells the judge:
  - Compounding work earns 0.7-0.9, do not cap it for "not revenue work"
  - Penalize all categories equally for thrashing / no-shipped-artifact /
    over-engineering
  - Reserve 0.9-1.0 for top-priority goal movement OR category-best
    compounding work
- 0.0-1.0 scale and "ONE impactful deliverable" principle preserved
- `JUDGE_VERSION` hash changes (sha256 of the prompt) — expected signal that
  a prompt revision is in flight; older records keep their old version tag

## Test plan

- [x] `test_prompt_template_includes_category_interpretation` added as a
  regression guard (would have failed before this commit)
- [x] All 44 `gptme-sessions` judge tests pass locally
- [ ] Greptile review
- [ ] CI green

## Out of scope

- Re-grading historical sessions with the new prompt (not free, requires
  `judge` CLI batch run; can be a follow-up if useful)
- Bandit formula changes — evidence-first approach, this PR fixes the
  measurement before adjusting the controller