### PR TITLE
chore(lessons): add target_grade to 3 remaining untagged lessons

### DIFF
--- a/lessons/autonomous/escalation-vs-autonomy.md
+++ b/lessons/autonomous/escalation-vs-autonomy.md
@@ -7,6 +7,7 @@ match:
   - "risky action requiring approval"
   - "irreversible change decision point"
 status: active
+target_grade: harm
 ---
 
 # Escalation vs Autonomy Decision Framework

--- a/lessons/patterns/simplify-before-optimize.md
+++ b/lessons/patterns/simplify-before-optimize.md
@@ -14,6 +14,7 @@ match:
   - "needs caching"
   - "optimize the code"
 status: active
+target_grade: alignment
 ---
 
 # Simplify Before Optimize

--- a/lessons/workflow/pr-recovery-after-accidental-closure.md
+++ b/lessons/workflow/pr-recovery-after-accidental-closure.md
@@ -6,6 +6,7 @@ match:
     - replace pr
   session_categories: [cross-repo, cleanup]
 status: active
+target_grade: productivity
 ---
 
 # PR Recovery After Accidental Closure


### PR DESCRIPTION
## Summary

Closes gap flagged in idea #154 (Subliminal behavioral transfer in distillation). The phase-4 acceptance checklist noted 3 gptme-contrib lessons with no `target_grade` frontmatter — this PR adds it:

- `lessons/workflow/pr-recovery-after-accidental-closure.md`: `target_grade: productivity`
- `lessons/patterns/simplify-before-optimize.md`: `target_grade: alignment`
- `lessons/autonomous/escalation-vs-autonomy.md`: `target_grade: harm`

All existing `target_grade` entries in gptme-contrib are now complete.

## Verification

- `target_grade` values match the lesson's behavioral purpose (productivity = speed of work, alignment = following best practices, harm = avoiding dangerous actions)
- No code impact — frontmatter-only change