### PR TITLE
fix(lessons): deprecate llmlingua-compression glossary entry; fix over-broad keywords in stated-intention-follow-through

### DIFF
--- a/lessons/concepts/llmlingua-compression.md
+++ b/lessons/concepts/llmlingua-compression.md
@@ -4,7 +4,7 @@ match:
     - llmlingua
     - "llmlingua compression"
     - "prompt compression technique"
-status: active
+status: deprecated
 ---
 # LLMLingua (Compression Technique)
 

--- a/lessons/concepts/llmlingua-compression.md
+++ b/lessons/concepts/llmlingua-compression.md
@@ -2,7 +2,8 @@
 match:
   keywords:
     - llmlingua
-    - compression
+    - "llmlingua compression"
+    - "prompt compression technique"
 status: active
 ---
 # LLMLingua (Compression Technique)

--- a/lessons/workflow/stated-intention-follow-through.md
+++ b/lessons/workflow/stated-intention-follow-through.md
@@ -2,7 +2,6 @@
 status: active
 match:
   keywords:
-  - "I'll follow up"
   - "I'll submit a PR"
   - "comment promising"
   - "I'll fix this"

--- a/lessons/workflow/stated-intention-follow-through.md
+++ b/lessons/workflow/stated-intention-follow-through.md
@@ -2,13 +2,12 @@
 status: active
 match:
   keywords:
-  - i'll do
-  - i will
-  - follow through
-  - accountability
-  - intention
-  - promise
-  - stated intention
+  - "I'll follow up"
+  - "I'll submit a PR"
+  - "comment promising"
+  - "I'll fix this"
+  - "promised to"
+  - "stated intention"
 ---
 
 # Stated Intention Follow-Through


### PR DESCRIPTION
## What this fixes

Two LOO-surfaced lesson quality issues:

1. **llmlingua-compression** (Δ=-0.0854, trajectory_grade, conf=1.0): This is a glossary entry, not a behavioral lesson. It triggers on the generic "compression" keyword and has no rule/pattern/outcome structure. Negative signal is noise from over-broad matching. Deprecated rather than deleted so the concept definition remains findable but isn't injected as behavioral guidance.

2. **stated-intention-follow-through** (Δ=-0.0710, alignment, conf=1.0): The keywords "I'll follow up", "I'll create a", and "close the loop" are matching internal planning language (agents talking to themselves about what they're about to do), not external commitments. Replaced with higher-precision intent phrases: "I'll submit a PR", "I'll fix this", "promised to", "stated intention".

## Verification

- [ ] CI passes