### PR TITLE
fix(types): clear prompt helper mypy regressions

### DIFF
--- a/packages/gptme-daily-briefing/src/gptme_daily_briefing/collectors.py
+++ b/packages/gptme-daily-briefing/src/gptme_daily_briefing/collectors.py
@@ -150,7 +150,7 @@ def collect_session_stats(sessions_dir: Path, days: int = 1) -> dict[str, Any]:
     ``count: 0`` and an ``error`` field instead of raising.
     """
     try:
-        from gptme_sessions.store import SessionStore  # type: ignore[import-not-found]
+        from gptme_sessions.store import SessionStore
 
         store = SessionStore(sessions_dir=sessions_dir)
         records = store.load_all()

--- a/packages/gptme-runloops/src/gptme_runloops/utils/prompt.py
+++ b/packages/gptme-runloops/src/gptme_runloops/utils/prompt.py
@@ -30,7 +30,11 @@ def get_agent_name(workspace: Path) -> str:
     if config_file.exists():
         try:
             config = tomllib.loads(config_file.read_text())
-            return config.get("agent", {}).get("name", "Agent")
+            agent_config = config.get("agent", {})
+            if isinstance(agent_config, dict):
+                name = agent_config.get("name")
+                if isinstance(name, str):
+                    return name
         except (tomllib.TOMLDecodeError, OSError):
             pass
     return "Agent"


### PR DESCRIPTION
## Summary
- tighten `get_agent_name()` typing in `gptme-runloops`
- remove the stale `gptme_sessions` import ignore in `gptme-daily-briefing`
- restore the green baseline for bob's root pre-commit run

## Verification
- `uv run mypy /home/bob/bob/gptme-contrib/packages/gptme-runloops/src/gptme_runloops/utils/prompt.py /home/bob/bob/gptme-contrib/packages/gptme-daily-briefing/src/gptme_daily_briefing/collectors.py`
- `UV_PROJECT_ENVIRONMENT=/home/bob/bob/.venv /home/bob/bob/gptme-contrib/scripts/git/git-safe-commit ...`
