### PR TITLE
fix(lessons): replace dead keywords in measure-before-optimize

### DIFF
--- a/lessons/workflow/measure-before-optimize.md
+++ b/lessons/workflow/measure-before-optimize.md
@@ -1,15 +1,20 @@
 ---
 match:
   keywords:
-  - implementing optimization without profiling
-  - assuming slowness based on complexity
-  - building caching before confirming problems
-  - this looks complex so it must be slow
-  - pytest --profile
-  - premature optimization
-  - optimize without profiling
-  session_categories: [code]
+  - "should drop to"
+  - "should be faster"
+  - "needs caching"
+  - "add caching"
+  - "without a baseline"
+  - "no baseline number"
+  - "before/after timing"
+  - "p50 = "
+  - "is the bottleneck"
+  - "premature optimization"
+  - "pytest --profile"
+  session_categories: [code, infrastructure]
 status: active
+target_grade: alignment
 ---
 
 # Measure Before Optimize


### PR DESCRIPTION
## Summary

Sibling fix to #888 — applies the same dead-keyword replacement pattern to the
`measure-before-optimize` lesson.

## Why

`scripts/lesson-keyword-health.py --action-items` (run today, 7-day window of
1301 sessions) flagged all 7 keywords of `lessons/workflow/measure-before-optimize.md`
as **dead** (zero trajectory matches), despite the lesson scoring **TS=0.587**
when it does fire — well above the "good lesson" threshold of 0.45. The lesson
is helpful when surfaced; the keywords just don't surface it.

The sibling lesson `simplify-before-optimize` had the exact same problem and
was fixed in #888 yesterday.

## Before / After

**Before** — meta-phrases that describe the situation rather than match real session text:
- `implementing optimization without profiling`
- `assuming slowness based on complexity`
- `building caching before confirming problems`
- `this looks complex so it must be slow`
- `pytest --profile`
- `premature optimization`
- `optimize without profiling`

**After** — natural multi-word phrases that actually appear in session text when this anti-pattern fires:
- `should drop to`
- `should be faster`
- `needs caching`
- `add caching`
- `without a baseline`
- `no baseline number`
- `before/after timing`
- `p50 = `
- `is the bottleneck`
- `premature optimization` (kept — natural phrase)
- `pytest --profile` (kept — literal tool reference)

Also added:
- `session_categories: [code, infrastructure]` for bundle delivery in those session types
- `target_grade: alignment` to match the sibling lesson's grading dimension

## Test plan

- [x] `prek run --files lessons/workflow/measure-before-optimize.md` — all hooks pass
- [x] Lesson validator: `✅ measure-before-optimize.md is valid (two-file format)`
- [ ] Post-merge: re-run `lesson-keyword-health.py --action-items` in 7 days; lesson should drop out of dead-keyword bucket