### PR TITLE
fix(twitter): include rejected/review dirs in reply-dedup to stop re-evaluation loop

### DIFF
--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -1459,7 +1459,7 @@ def process_timeline_tweets(
             if tweet.author_id == cached_get_me(client, user_auth=False).data.id:
                 continue
 
-            # Check if tweet already has a reply in any directory (posted, approved, new)
+            # Check if tweet already has a reply in any directory (posted, approved, new, review, rejected)
             tweet_id_str = str(tweet.id)
             if tweet_id_str in _replied_tweet_ids:
                 console.print(

--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -840,7 +840,11 @@ def draft(
 def _check_for_duplicate_replies_internal(draft: TweetDraft) -> dict[str, list[Path]]:
     """Internal utility to check if we already have replies to the same tweet.
 
-    Returns dict with keys: 'posted', 'approved', 'new' containing paths to duplicates.
+    Returns dict with keys 'posted', 'approved', 'new', 'review', 'rejected'
+    containing paths to duplicates. ``rejected`` and ``review`` are included so
+    repeated dispatch cycles don't keep re-evaluating tweets we already drafted
+    a reply to — even if that draft was rejected (e.g. by the live-duplicate
+    guard when our prior reply is already on Twitter).
     """
     if not draft.in_reply_to:
         return {}
@@ -849,7 +853,7 @@ def _check_for_duplicate_replies_internal(draft: TweetDraft) -> dict[str, list[P
     tweet_id = draft.in_reply_to
 
     # Check each directory
-    for status in ["posted", "approved", "new"]:
+    for status in ["posted", "approved", "new", "review", "rejected"]:
         status_dir = TWEETS_DIR / status
         if not status_dir.exists():
             continue
@@ -1425,8 +1429,11 @@ def process_timeline_tweets(
     # Build a set of tweet IDs we already have replies for (across all directories)
     # This is more robust than filename substring matching
     # Use strings for consistent comparison (in_reply_to can be int or str)
+    # ``review`` and ``rejected`` are included so a rejected draft (e.g. moved
+    # there because our prior reply is already live on Twitter) suppresses
+    # re-drafting on subsequent dispatch cycles.
     _replied_tweet_ids: set[str] = set()
-    for status_dir_name in ["posted", "approved", "new"]:
+    for status_dir_name in ["posted", "approved", "new", "review", "rejected"]:
         status_dir = TWEETS_DIR / status_dir_name
         if not status_dir.exists():
             continue

--- a/tests/test_twitter_workflow_drafts.py
+++ b/tests/test_twitter_workflow_drafts.py
@@ -264,6 +264,44 @@ def test_duplicate_reply_detection_reads_markdown_drafts(
     assert duplicates == {"approved": [existing_path]}
 
 
+def test_duplicate_reply_detection_includes_rejected_and_review(
+    workflow_module: Any, tmp_path: Path
+) -> None:
+    """A previously rejected draft must surface as a duplicate.
+
+    Otherwise the dispatch loop keeps regenerating drafts for the same tweet
+    every cycle, burning LLM calls and piling up rejected/ files. Same for
+    drafts pending review.
+    """
+    _set_status_dirs(workflow_module, tmp_path)
+    rejected_path = workflow_module.REJECTED_DIR / "reply_rejected.md"
+    review_path = workflow_module.REVIEW_DIR / "reply_review.md"
+    _write_markdown_draft(
+        rejected_path,
+        body="Earlier rejected reply.",
+        draft_type="reply",
+        in_reply_to="4242",
+    )
+    _write_markdown_draft(
+        review_path,
+        body="Draft pending review.",
+        draft_type="reply",
+        in_reply_to="4242",
+    )
+
+    draft = workflow_module.TweetDraft(
+        text="New reply attempt",
+        type="reply",
+        in_reply_to="4242",
+    )
+    duplicates = workflow_module._check_for_duplicate_replies_internal(draft)
+
+    assert duplicates == {
+        "review": [review_path],
+        "rejected": [rejected_path],
+    }
+
+
 def test_find_live_duplicate_reply_ids_matches_own_replies(
     workflow_module: Any,
 ) -> None:


### PR DESCRIPTION
## Summary

The Twitter dispatch loop re-evaluates the same already-replied tweet every cycle because the dedup set built at `workflow.py:1429` only scans `posted/`, `approved/`, and `new/` — not `rejected/` or `review/`.

The failure mode reproduces cleanly:
1. Live-duplicate guard (`_find_live_duplicate_reply_ids`) detects our prior reply is on Twitter when posting → moves draft to `rejected/`.
2. Next cycle (30 min later): the dedup set doesn't include `rejected/`, so the tweet is re-evaluated by the LLM, drafted again, then rejected again.
3. Repeat indefinitely.

Observed locally (TimeToBuildBob): 5 rejected drafts for the same `in_reply_to=2053824325405311055` accumulated in ~3 hours against a thread that the other party had already concluded with "Thanks, I'll reach out if we're stuck." Each cycle burned an LLM call for an outcome that was deterministically going to be rejected.

## Fix

- Add `review` and `rejected` to the directory scans in both:
  - `_check_for_duplicate_replies_internal` (used by the post path)
  - The dispatch loop's `_replied_tweet_ids` build (used by the draft path)
- Existing callers of `_check_for_duplicate_replies_internal` only key off specific buckets (`"posted"`, `"approved"`), so widening the returned dict is non-breaking.
- New regression test `test_duplicate_reply_detection_includes_rejected_and_review` covers the bug directly.

## Test plan

- [x] `uv run pytest tests/test_twitter_workflow_drafts.py -v` — 15/15 pass, including the new test
- [x] No callers of `_check_for_duplicate_replies_internal` rely on the dict NOT containing `rejected`/`review` keys (verified by reading every call site)