### PR TITLE
feat(mcp): expose agent memory from lessons server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.10"
 
 [dependency-groups]
 dev = [
+    "mcp>=1.0.0",
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",
     "pytest-cov>=4.1.0",

--- a/scripts/gptme-lessons-mcp.py
+++ b/scripts/gptme-lessons-mcp.py
@@ -285,15 +285,21 @@ def _load_memory_backend(
     if not memory_dir.exists() or not retrieval_script.exists():
         return None
 
+    module_name = f"agent_memory_retrieval_{retrieval_script.resolve()}"
     spec = importlib.util.spec_from_file_location(
-        "agent_memory_retrieval",
+        module_name,
         retrieval_script,
     )
     if spec is None or spec.loader is None:
         return None
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
+    try:
+        spec.loader.exec_module(module)
+    except Exception as exc:
+        del sys.modules[spec.name]
+        print(f"Warning: failed to load memory module: {exc}", file=sys.stderr)
+        return None
     return MemoryBackend(
         memory_dir=memory_dir,
         state_file=memory_state_file,

--- a/scripts/gptme-lessons-mcp.py
+++ b/scripts/gptme-lessons-mcp.py
@@ -25,12 +25,15 @@ Dependencies:
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import re
 import sys
 from collections import Counter
 from dataclasses import dataclass, field
 from pathlib import Path
+from types import ModuleType
+from typing import Any, cast
 
 # ── Lesson loading ────────────────────────────────────────────────────────────
 
@@ -226,10 +229,122 @@ def search_lessons_by_query(
     return [lesson for _, lesson in scored[:10]]
 
 
+@dataclass
+class MemoryBackend:
+    memory_dir: Path
+    state_file: Path
+    module: ModuleType
+
+    def discover_entries(self) -> list[Any]:
+        return cast(list[Any], self.module.discover_memory_entries(self.memory_dir))
+
+    def search(self, query: str, limit: int = 5) -> list[dict[str, Any]]:
+        return cast(
+            list[dict[str, Any]],
+            self.module.select_relevant_memories(
+                query,
+                memory_dir=self.memory_dir,
+                state_file=self.state_file,
+                limit=limit,
+            ),
+        )
+
+
+def _discover_agent_root(search_from: list[Path]) -> Path | None:
+    seen: set[Path] = set()
+    for base in search_from:
+        for candidate in [base, *base.parents]:
+            if candidate in seen:
+                continue
+            seen.add(candidate)
+            if (candidate / "memory").is_dir() and (
+                candidate / "scripts" / "memory" / "memory_retrieval.py"
+            ).exists():
+                return candidate
+    return None
+
+
+def _load_memory_backend(
+    memory_dir: Path | None,
+    memory_state_file: Path | None,
+) -> MemoryBackend | None:
+    if memory_dir is None:
+        agent_root = _discover_agent_root([Path.cwd(), Path(__file__).resolve()])
+        if agent_root is None:
+            return None
+        memory_dir = agent_root / "memory"
+        memory_state_file = agent_root / "state" / "cc-memory" / "metadata.json"
+
+    memory_dir = memory_dir.expanduser().resolve()
+    if memory_state_file is None:
+        memory_state_file = memory_dir.parent / "state" / "cc-memory" / "metadata.json"
+    else:
+        memory_state_file = memory_state_file.expanduser().resolve()
+
+    retrieval_script = memory_dir.parent / "scripts" / "memory" / "memory_retrieval.py"
+    if not memory_dir.exists() or not retrieval_script.exists():
+        return None
+
+    spec = importlib.util.spec_from_file_location(
+        "agent_memory_retrieval",
+        retrieval_script,
+    )
+    if spec is None or spec.loader is None:
+        return None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return MemoryBackend(
+        memory_dir=memory_dir,
+        state_file=memory_state_file,
+        module=module,
+    )
+
+
+def _normalize_memory_name(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", value.lower()).strip()
+
+
+def _find_memory_entry(
+    backend: MemoryBackend, name: str
+) -> tuple[Any | None, list[str]]:
+    query = _normalize_memory_name(name)
+    if not query:
+        return None, []
+
+    exact: Any | None = None
+    partials: list[Any] = []
+
+    for entry in backend.discover_entries():
+        candidates = {
+            _normalize_memory_name(entry.key),
+            _normalize_memory_name(entry.path.stem),
+            _normalize_memory_name(entry.name),
+            *[_normalize_memory_name(alias) for alias in entry.aliases],
+        }
+        if query in candidates:
+            exact = entry
+            break
+        if any(query in candidate for candidate in candidates if candidate):
+            partials.append(entry)
+
+    if exact is not None:
+        return exact, []
+    if len(partials) == 1:
+        return partials[0], []
+    suggestions = [entry.path.name for entry in partials[:5]]
+    return None, suggestions
+
+
 # ── MCP server ────────────────────────────────────────────────────────────────
 
 
-def build_server(lessons: list[Lesson]):
+def build_server(
+    lessons: list[Lesson],
+    *,
+    memory_dir: Path | None = None,
+    memory_state_file: Path | None = None,
+):
     """Build the FastMCP server. Separated for testability."""
     try:
         from mcp.server.fastmcp import FastMCP
@@ -242,6 +357,7 @@ def build_server(lessons: list[Lesson]):
     mcp = FastMCP("gptme-lessons")
     active_lessons = [ls for ls in lessons if ls.status == "active"]
     lesson_by_id = {ls.id: ls for ls in active_lessons}
+    memory_backend = _load_memory_backend(memory_dir, memory_state_file)
 
     # ── Resources ────────────────────────────────────────────────────────────
 
@@ -274,9 +390,10 @@ def build_server(lessons: list[Lesson]):
             lines.append("\n---\n")
         return "\n".join(lines)
 
-    @mcp.resource("lessons://lesson/{lesson_id:path}")
-    def get_lesson(lesson_id: str) -> str:
+    @mcp.resource("lessons://lesson/{category}/{name}")
+    def get_lesson(category: str, name: str) -> str:
         """Full content of a specific lesson."""
+        lesson_id = f"{category}/{name}"
         lesson = lesson_by_id.get(lesson_id)
         if not lesson:
             return f"Lesson not found: {lesson_id}"
@@ -305,7 +422,7 @@ def build_server(lessons: list[Lesson]):
             kws = ", ".join(ls.keywords[:3]) if ls.keywords else "none"
             lines.append(f"**{ls.title}** (`{ls.id}`){eff}")
             lines.append(f"Keywords: {kws}")
-            lines.append(f"Resource: `lessons://lesson/{ls.id}`\n")
+            lines.append(f"Resource: `lessons://lesson/{ls.category}/{ls.path.stem}`\n")
         return "\n".join(lines)
 
     @mcp.tool()
@@ -360,6 +477,77 @@ def build_server(lessons: list[Lesson]):
             lines.append(f"- **{cat}** ({count} lessons)")
         return "\n".join(lines)
 
+    @mcp.tool()
+    def memory_search(query: str, limit: int = 5) -> str:
+        """Search durable memory entries using the agent's memory retrieval scorer.
+
+        Args:
+            query: Natural-language or alias query for memory/*.md entries
+            limit: Maximum number of matches to return (default: 5)
+        """
+        if memory_backend is None:
+            return (
+                "Memory support unavailable. Configure --memory-dir or run the server "
+                "inside an agent workspace with memory/*.md and scripts/memory/"
+                "memory_retrieval.py."
+            )
+
+        results = memory_backend.search(query, limit=max(1, min(limit, 10)))
+        if not results:
+            return f"No memory entries found matching: {query!r}"
+
+        lines = [
+            f"Found {len(results)} memory entr{'y' if len(results) == 1 else 'ies'} for {query!r}:\n"
+        ]
+        for entry in results:
+            lines.append(
+                f"**{entry['name']}** (`{entry['key']}`) "
+                f"[type={entry['type']}, score={entry['score']:.3f}]"
+            )
+            if entry["description"]:
+                lines.append(f"Description: {entry['description']}")
+            if entry["matched_terms"]:
+                lines.append(f"Match: {', '.join(entry['matched_terms'])}")
+            lines.append(
+                f"Confidence: {entry['confidence']:.2f} | Recency: {entry['recency']:.3f}"
+            )
+            if entry["excerpt"]:
+                lines.append(f"Excerpt: {entry['excerpt']}")
+            lines.append("")
+        return "\n".join(lines).rstrip()
+
+    @mcp.tool()
+    def memory_get(name: str) -> str:
+        """Return a specific durable memory entry by filename, stem, or alias.
+
+        Args:
+            name: Memory filename, stem, or alias (for example
+                'feedback_greptile_review_loop' or 'greptile review loop')
+        """
+        if memory_backend is None:
+            return (
+                "Memory support unavailable. Configure --memory-dir or run the server "
+                "inside an agent workspace with memory/*.md and scripts/memory/"
+                "memory_retrieval.py."
+            )
+
+        entry, suggestions = _find_memory_entry(memory_backend, name)
+        if entry is None:
+            hint = f" Did you mean: {', '.join(suggestions)}?" if suggestions else ""
+            return f"Memory entry not found: {name!r}.{hint}"
+
+        aliases = ", ".join(entry.aliases[:5]) if entry.aliases else "none"
+        lines = [
+            f"# {entry.name}",
+            f"File: {entry.path.name}",
+            f"Type: {entry.type}",
+            f"Description: {entry.description or 'none'}",
+            f"Aliases: {aliases}",
+            "",
+            entry.body,
+        ]
+        return "\n".join(lines).rstrip()
+
     return mcp
 
 
@@ -390,6 +578,24 @@ def main():
         ),
     )
     parser.add_argument(
+        "--memory-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Path to memory directory. Defaults to auto-detecting an enclosing "
+            "agent workspace with memory/*.md entries."
+        ),
+    )
+    parser.add_argument(
+        "--memory-state-file",
+        type=Path,
+        default=None,
+        help=(
+            "Path to memory metadata JSON. Defaults to "
+            "<memory-dir>/../state/cc-memory/metadata.json."
+        ),
+    )
+    parser.add_argument(
         "--list",
         action="store_true",
         help="List loaded lessons and exit (no server)",
@@ -399,6 +605,10 @@ def main():
     lessons_dir = args.lessons_dir.expanduser()
     effectiveness_file = (
         args.effectiveness_file.expanduser() if args.effectiveness_file else None
+    )
+    memory_dir = args.memory_dir.expanduser() if args.memory_dir else None
+    memory_state_file = (
+        args.memory_state_file.expanduser() if args.memory_state_file else None
     )
 
     if not lessons_dir.exists():
@@ -419,7 +629,11 @@ def main():
         return
 
     print(f"Loaded {len(lessons)} lessons from {lessons_dir}", file=sys.stderr)
-    mcp = build_server(lessons)
+    mcp = build_server(
+        lessons,
+        memory_dir=memory_dir,
+        memory_state_file=memory_state_file,
+    )
     mcp.run()
 
 

--- a/tests/test_gptme_lessons_mcp.py
+++ b/tests/test_gptme_lessons_mcp.py
@@ -1,0 +1,174 @@
+"""Tests for gptme-lessons MCP server memory tools."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import shutil
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "gptme-lessons-mcp.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("gptme_lessons_mcp", SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+MOD = _load_module()
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _content(response) -> str:
+    if isinstance(response, tuple):
+        content_list = response[0]
+    else:
+        content_list = response.content
+
+    parts = []
+    for item in content_list:
+        if hasattr(item, "text"):
+            parts.append(item.text)
+        elif isinstance(item, dict) and "text" in item:
+            parts.append(item["text"])
+    return "\n".join(parts)
+
+
+def _find_agent_root() -> Path:
+    for candidate in Path(__file__).resolve().parents:
+        if (candidate / "scripts" / "memory" / "memory_retrieval.py").exists():
+            return candidate
+    raise AssertionError(
+        "Could not locate agent root with scripts/memory/memory_retrieval.py"
+    )
+
+
+def _write_memory_fixture(tmp_path: Path) -> tuple[Path, Path]:
+    agent_root = tmp_path / "agent"
+    memory_dir = agent_root / "memory"
+    retrieval_dir = agent_root / "scripts" / "memory"
+    state_dir = agent_root / "state" / "cc-memory"
+    memory_dir.mkdir(parents=True)
+    retrieval_dir.mkdir(parents=True)
+    state_dir.mkdir(parents=True)
+
+    source_retrieval = _find_agent_root() / "scripts" / "memory" / "memory_retrieval.py"
+    shutil.copy2(source_retrieval, retrieval_dir / "memory_retrieval.py")
+
+    (memory_dir / "feedback_greptile_review_loop.md").write_text(
+        "---\n"
+        "name: greptile_review_loop\n"
+        "description: Must complete full Greptile review cycle before self-merging\n"
+        "type: feedback\n"
+        "aliases:\n"
+        "  - greptile review loop\n"
+        "---\n\n"
+        "Never self-merge until Greptile has reviewed the final diff.\n",
+        encoding="utf-8",
+    )
+    (memory_dir / "reference_release_checklist.md").write_text(
+        "---\n"
+        "name: release_checklist\n"
+        "description: Lightweight release checklist\n"
+        "type: reference\n"
+        "aliases:\n"
+        "  - release checklist\n"
+        "---\n\n"
+        "Run tests, check docs, then ship.\n",
+        encoding="utf-8",
+    )
+    state_file = state_dir / "metadata.json"
+    state_file.write_text(
+        json.dumps(
+            {
+                "feedback_greptile_review_loop.md": {
+                    "confidence": 0.96,
+                    "last_verified": "2026-05-11T00:00:00+00:00",
+                },
+                "reference_release_checklist.md": {
+                    "confidence": 0.65,
+                    "last_verified": "2026-04-01T00:00:00+00:00",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return memory_dir, state_file
+
+
+def test_tools_registered_with_memory_support(tmp_path):
+    memory_dir, state_file = _write_memory_fixture(tmp_path)
+    mcp = MOD.build_server([], memory_dir=memory_dir, memory_state_file=state_file)
+
+    async def _check():
+        tools = await mcp.list_tools()
+        return {tool.name for tool in tools}
+
+    names = _run(_check())
+    assert "memory_search" in names
+    assert "memory_get" in names
+
+
+def test_memory_search_returns_ranked_match(tmp_path):
+    memory_dir, state_file = _write_memory_fixture(tmp_path)
+    mcp = MOD.build_server([], memory_dir=memory_dir, memory_state_file=state_file)
+
+    async def _check():
+        response = await mcp.call_tool(
+            "memory_search",
+            {"query": "greptile review loop", "limit": 3},
+        )
+        return _content(response)
+
+    text = _run(_check())
+    assert "feedback_greptile_review_loop.md" in text
+    assert "score=" in text
+    assert (
+        "Match: greptile, loop, review" in text
+        or "Match: greptile, review, loop" in text
+    )
+    assert "Never self-merge until Greptile has reviewed the final diff." in text
+
+
+def test_memory_get_accepts_stem_and_returns_body(tmp_path):
+    memory_dir, state_file = _write_memory_fixture(tmp_path)
+    mcp = MOD.build_server([], memory_dir=memory_dir, memory_state_file=state_file)
+
+    async def _check():
+        response = await mcp.call_tool(
+            "memory_get",
+            {"name": "feedback_greptile_review_loop"},
+        )
+        return _content(response)
+
+    text = _run(_check())
+    assert text.startswith("# greptile_review_loop")
+    assert "File: feedback_greptile_review_loop.md" in text
+    assert "Never self-merge until Greptile has reviewed the final diff." in text
+    assert "name: greptile_review_loop" not in text
+
+
+def test_memory_get_accepts_alias_lookup(tmp_path):
+    memory_dir, state_file = _write_memory_fixture(tmp_path)
+    mcp = MOD.build_server([], memory_dir=memory_dir, memory_state_file=state_file)
+
+    async def _check():
+        response = await mcp.call_tool(
+            "memory_get",
+            {"name": "greptile review loop"},
+        )
+        return _content(response)
+
+    text = _run(_check())
+    assert "File: feedback_greptile_review_loop.md" in text
+    assert "Aliases: greptile review loop" in text

--- a/tests/test_gptme_lessons_mcp.py
+++ b/tests/test_gptme_lessons_mcp.py
@@ -9,6 +9,8 @@ import shutil
 import sys
 from pathlib import Path
 
+import pytest
+
 SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "gptme-lessons-mcp.py"
 
 
@@ -48,8 +50,9 @@ def _find_agent_root() -> Path:
     for candidate in Path(__file__).resolve().parents:
         if (candidate / "scripts" / "memory" / "memory_retrieval.py").exists():
             return candidate
-    raise AssertionError(
-        "Could not locate agent root with scripts/memory/memory_retrieval.py"
+    pytest.skip(
+        "memory_retrieval.py not found in any parent directory; "
+        "memory tests require the Bob agent workspace"
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1400,6 +1400,7 @@ source = { virtual = "." }
 
 [package.dev-dependencies]
 dev = [
+    { name = "mcp" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -1411,6 +1412,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "mcp", specifier = ">=1.0.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.0" },
     { name = "pytest-cov", specifier = ">=4.1.0" },


### PR DESCRIPTION
## Summary
- add `memory_search` and `memory_get` tools to `gptme-lessons-mcp.py`
- auto-discover an enclosing agent workspace memory store and reuse the existing memory retrieval scorer
- add focused MCP tests and declare `mcp` in workspace dev dependencies

## Verification
- `uv run pytest tests/test_gptme_lessons_mcp.py -q`
- `uv run ruff check scripts/gptme-lessons-mcp.py tests/test_gptme_lessons_mcp.py`
- live smoke against `/home/bob/bob/memory` via `memory_get` and `memory_search`

## Notes
- includes a small compatibility fix for the existing lesson resource URI template so the server boots under the current FastMCP package
- implements Bob idea backlog item #298 (Memory as MCP Resource)