### PR TITLE
feat(credential-slots): identity drift detection via refresh-token fingerprint

### DIFF
--- a/packages/credential-slots/README.md
+++ b/packages/credential-slots/README.md
@@ -85,6 +85,17 @@ drift = mgr.detect_live_slot_drift()
 if drift and drift["drift"]:
     warn("live creds file matches no named slot — run /login then persist")
 
+# Identity drift — catches the case where an operator (or stray
+# `claude /login`) writes a new OAuth credential *through* the live
+# symlink, silently replacing the slot's tokens. Hash-based
+# detect_live_slot_drift() can't see this because live and slot still match.
+# See ErikBjare/bob#769.
+ident = mgr.detect_slot_identity_drift("bob")
+if ident["drift"]:
+    warn(f"slot identity changed: {ident['reason']}")
+# After a fresh login that establishes a new identity for a slot, capture it:
+# mgr.capture_slot_fingerprint("bob")  # switch_to/heal_drift_to do this automatically
+
 # Switching
 result = mgr.switch_to("alice", reason="bob quota exhausted")
 if not result.ok:

--- a/packages/credential-slots/pyproject.toml
+++ b/packages/credential-slots/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "credential-slots"
-version = "0.2.0"
+version = "0.3.0"
 description = "Safe credential-slot rotation for agents running Claude Max / OAuth-backed subscriptions"
 authors = [
     {name = "gptme contributors", email = "gptme@superuserlabs.org"}

--- a/packages/credential-slots/src/credential_slots/__init__.py
+++ b/packages/credential-slots/src/credential_slots/__init__.py
@@ -30,25 +30,31 @@ Public API::
 from __future__ import annotations
 
 from credential_slots.manager import (
+    DEFAULT_FINGERPRINT_TEMPLATE,
     DEFAULT_GRACE_SECONDS,
     DEFAULT_LIVE_NAME,
     DEFAULT_SLOT_TEMPLATE,
     DriftInfo,
+    IdentityDriftInfo,
     SlotManager,
     SwitchResult,
+    compute_slot_fingerprint,
     read_slot_expiry,
     slot_is_fresh,
 )
 
 __all__ = [
+    "DEFAULT_FINGERPRINT_TEMPLATE",
     "DEFAULT_GRACE_SECONDS",
     "DEFAULT_LIVE_NAME",
     "DEFAULT_SLOT_TEMPLATE",
     "DriftInfo",
+    "IdentityDriftInfo",
     "SlotManager",
     "SwitchResult",
+    "compute_slot_fingerprint",
     "read_slot_expiry",
     "slot_is_fresh",
 ]
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/packages/credential-slots/src/credential_slots/manager.py
+++ b/packages/credential-slots/src/credential_slots/manager.py
@@ -489,12 +489,8 @@ class SlotManager:
         ============================== =====
         """
         if sub not in self.subscriptions:
-            return IdentityDriftInfo(
-                drift=False,
-                sub=sub,
-                stored_fingerprint=None,
-                current_fingerprint=None,
-                reason=f"unknown subscription: {sub!r}",
+            raise ValueError(
+                f"unknown subscription: {sub!r} (known: {self.subscriptions})"
             )
         stored = self.read_stored_fingerprint(sub)
         current = compute_slot_fingerprint(self.slot_path(sub))
@@ -605,7 +601,10 @@ class SlotManager:
             tmp.unlink(missing_ok=True)
             raise
 
-        self.capture_slot_fingerprint(sub)
+        try:
+            self.capture_slot_fingerprint(sub)
+        except Exception as exc:
+            self._log(f"fingerprint capture failed for {sub}: {exc}")
         if self.on_switch is not None:
             self.on_switch(sub, reason)
         return SwitchResult(ok=True, reason=f"switched to {sub}")
@@ -724,7 +723,10 @@ class SlotManager:
             link_tmp.unlink(missing_ok=True)
             raise
 
-        self.capture_slot_fingerprint(sub)
+        try:
+            self.capture_slot_fingerprint(sub)
+        except Exception as exc:
+            self._log(f"fingerprint capture failed for {sub}: {exc}")
         if self.on_switch is not None:
             self.on_switch(sub, "auto-heal drift (live cred resynced to slot)")
         return SwitchResult(

--- a/packages/credential-slots/src/credential_slots/manager.py
+++ b/packages/credential-slots/src/credential_slots/manager.py
@@ -25,6 +25,7 @@ from typing import Callable, TypedDict
 
 DEFAULT_LIVE_NAME = ".credentials.json"
 DEFAULT_SLOT_TEMPLATE = ".credentials.json.{sub}"
+DEFAULT_FINGERPRINT_TEMPLATE = ".credentials.json.{sub}.fingerprint.json"
 DEFAULT_GRACE_SECONDS = 300
 
 
@@ -41,6 +42,38 @@ class DriftInfo(TypedDict):
     matching_slot: str | None
     live_hash: str | None
     slot_hashes: dict[str, str]
+
+
+class IdentityDriftInfo(TypedDict):
+    """Result of :meth:`SlotManager.detect_slot_identity_drift`.
+
+    Identity drift means the slot's *current* refresh-token fingerprint
+    does not match the fingerprint captured at last :meth:`switch_to` /
+    :meth:`heal_drift_to`. This catches the scenario in ErikBjare/bob#769
+    where an operator (or stray ``claude /login``) writes a new OAuth
+    credential **through** the live symlink, silently replacing the slot's
+    identity while the hash-based drift check still sees a "matching"
+    live → slot pair.
+
+    Fields:
+
+    - ``drift``: True when stored fingerprint exists and disagrees with the
+      slot's current refresh token; False when they match or when no
+      fingerprint has been captured yet (caller should call
+      :meth:`capture_slot_fingerprint` on a fresh login).
+    - ``sub``: subscription name the check was run for.
+    - ``stored_fingerprint``: hash captured at last switch/heal, or None
+      when no fingerprint file exists yet.
+    - ``current_fingerprint``: hash of the slot's current refresh token,
+      or None when the slot file is missing or unreadable.
+    - ``reason``: short human-readable explanation suitable for logs.
+    """
+
+    drift: bool
+    sub: str
+    stored_fingerprint: str | None
+    current_fingerprint: str | None
+    reason: str
 
 
 @dataclass
@@ -137,6 +170,50 @@ def _hash_file(path: Path) -> str | None:
         return None
 
 
+def _read_refresh_token(path: Path) -> str | None:
+    """Return ``claudeAiOauth.refreshToken`` from a slot file, or None.
+
+    Returns None for missing files, unreadable files, malformed JSON,
+    payloads without ``claudeAiOauth.refreshToken``, or non-string
+    refresh-token values.
+    """
+    try:
+        raw = path.read_text()
+    except OSError:
+        return None
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    oauth = payload.get("claudeAiOauth")
+    if not isinstance(oauth, dict):
+        return None
+    rt = oauth.get("refreshToken")
+    if not isinstance(rt, str) or not rt:
+        return None
+    return rt
+
+
+def compute_slot_fingerprint(path: Path) -> str | None:
+    """Return sha256 of the slot's refresh token, or None if unavailable.
+
+    Used as the per-slot identity fingerprint: the refresh token rotates
+    only when the OAuth flow actively exchanges it, so a sudden change
+    between two snapshots is a strong signal that the slot's identity was
+    silently replaced (see ErikBjare/bob#769).
+
+    Hashing the refresh token (rather than storing it verbatim) keeps the
+    fingerprint files free of additional credential material — they're
+    only useful for equality comparison, not for replay.
+    """
+    rt = _read_refresh_token(path)
+    if rt is None:
+        return None
+    return hashlib.sha256(rt.encode("utf-8")).hexdigest()
+
+
 @dataclass
 class SlotManager:
     """Manages a family of named OAuth credential slots sharing one live file.
@@ -185,6 +262,7 @@ class SlotManager:
     subscriptions: list[str]
     slot_template: str = DEFAULT_SLOT_TEMPLATE
     live_name: str = DEFAULT_LIVE_NAME
+    fingerprint_template: str = DEFAULT_FINGERPRINT_TEMPLATE
     grace_seconds: int = DEFAULT_GRACE_SECONDS
     lock_guard: Callable[[], list[str]] | None = None
     on_switch: Callable[[str, str], None] | None = None
@@ -195,6 +273,10 @@ class SlotManager:
             raise ValueError(
                 f"slot_template must contain '{{sub}}', got: {self.slot_template!r}"
             )
+        if "{sub}" not in self.fingerprint_template:
+            raise ValueError(
+                f"fingerprint_template must contain '{{sub}}', got: {self.fingerprint_template!r}"
+            )
         if not self.subscriptions:
             raise ValueError("subscriptions must be a non-empty list")
 
@@ -203,6 +285,10 @@ class SlotManager:
     def slot_path(self, sub: str) -> Path:
         """Absolute path to the named slot file."""
         return self.creds_dir / self.slot_template.format(sub=sub)
+
+    def fingerprint_path(self, sub: str) -> Path:
+        """Absolute path to the per-slot fingerprint sidecar file."""
+        return self.creds_dir / self.fingerprint_template.format(sub=sub)
 
     @property
     def live_path(self) -> Path:
@@ -324,6 +410,134 @@ class SlotManager:
             slot_hashes=slot_hashes,
         )
 
+    # ---- Identity fingerprints ----
+
+    def read_stored_fingerprint(self, sub: str) -> str | None:
+        """Return the fingerprint captured at last switch/heal, or None."""
+        fp_path = self.fingerprint_path(sub)
+        try:
+            raw = fp_path.read_text()
+        except OSError:
+            return None
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(payload, dict):
+            return None
+        fp = payload.get("refresh_token_sha256")
+        if not isinstance(fp, str) or not fp:
+            return None
+        return fp
+
+    def capture_slot_fingerprint(self, sub: str) -> str | None:
+        """Capture the slot's current refresh-token fingerprint to disk.
+
+        Atomically writes ``fingerprint_path(sub)`` with the slot's current
+        refresh-token sha256 plus a captured-at timestamp. Returns the
+        fingerprint, or None when the slot file is missing / unreadable /
+        lacks a refresh token.
+
+        Callers should invoke this after performing a fresh OAuth login
+        for a slot, so :meth:`detect_slot_identity_drift` has a baseline
+        to compare against on later checks. :meth:`switch_to` and
+        :meth:`heal_drift_to` invoke it automatically on success.
+        """
+        fp = compute_slot_fingerprint(self.slot_path(sub))
+        if fp is None:
+            return None
+        payload = {
+            "refresh_token_sha256": fp,
+            "captured_at": datetime.now(timezone.utc).isoformat(),
+            "slot": sub,
+        }
+        fp_path = self.fingerprint_path(sub)
+        tmp = fp_path.with_suffix(fp_path.suffix + f".tmp{os.getpid()}")
+        try:
+            tmp.write_text(json.dumps(payload, sort_keys=True))
+            os.chmod(tmp, 0o600)
+            os.replace(tmp, fp_path)
+        except BaseException:
+            tmp.unlink(missing_ok=True)
+            raise
+        return fp
+
+    def detect_slot_identity_drift(self, sub: str) -> IdentityDriftInfo:
+        """Check whether ``sub``'s slot still holds the captured identity.
+
+        Compares the slot file's current refresh-token sha256 against the
+        fingerprint stored by the most recent :meth:`switch_to` /
+        :meth:`heal_drift_to` / :meth:`capture_slot_fingerprint` call.
+
+        Catches the failure mode in ErikBjare/bob#769: an operator (or
+        stray ``claude /login``) writes a new OAuth credential through the
+        live symlink, silently replacing the slot's identity. The classic
+        hash-based :meth:`detect_live_slot_drift` reports "no drift" in
+        that scenario because live and slot still hash-match — but they
+        now hold someone else's tokens.
+
+        Behavior matrix:
+
+        ============================== =====
+        Stored / Current               drift
+        ============================== =====
+        match                          False
+        mismatch (real identity drift) True
+        stored present, current None   True   (slot vanished or unreadable)
+        stored None, current any       False  (no baseline yet; ``reason`` says so)
+        both None                      False  (no slot file, no fingerprint)
+        ============================== =====
+        """
+        if sub not in self.subscriptions:
+            return IdentityDriftInfo(
+                drift=False,
+                sub=sub,
+                stored_fingerprint=None,
+                current_fingerprint=None,
+                reason=f"unknown subscription: {sub!r}",
+            )
+        stored = self.read_stored_fingerprint(sub)
+        current = compute_slot_fingerprint(self.slot_path(sub))
+        if stored is None and current is None:
+            return IdentityDriftInfo(
+                drift=False,
+                sub=sub,
+                stored_fingerprint=None,
+                current_fingerprint=None,
+                reason="no fingerprint stored and slot missing/unreadable",
+            )
+        if stored is None:
+            return IdentityDriftInfo(
+                drift=False,
+                sub=sub,
+                stored_fingerprint=None,
+                current_fingerprint=current,
+                reason="no fingerprint stored yet — call capture_slot_fingerprint after a fresh login",
+            )
+        if current is None:
+            return IdentityDriftInfo(
+                drift=True,
+                sub=sub,
+                stored_fingerprint=stored,
+                current_fingerprint=None,
+                reason="slot is missing or has no refresh token; cannot verify identity",
+            )
+        if stored != current:
+            return IdentityDriftInfo(
+                drift=True,
+                sub=sub,
+                stored_fingerprint=stored,
+                current_fingerprint=current,
+                reason="refresh token changed since last capture — slot identity may have been replaced",
+            )
+        return IdentityDriftInfo(
+            drift=False,
+            sub=sub,
+            stored_fingerprint=stored,
+            current_fingerprint=current,
+            reason="fingerprint matches",
+        )
+
     # ---- Switching ----
 
     def switch_to(
@@ -391,6 +605,7 @@ class SlotManager:
             tmp.unlink(missing_ok=True)
             raise
 
+        self.capture_slot_fingerprint(sub)
         if self.on_switch is not None:
             self.on_switch(sub, reason)
         return SwitchResult(ok=True, reason=f"switched to {sub}")
@@ -509,6 +724,7 @@ class SlotManager:
             link_tmp.unlink(missing_ok=True)
             raise
 
+        self.capture_slot_fingerprint(sub)
         if self.on_switch is not None:
             self.on_switch(sub, "auto-heal drift (live cred resynced to slot)")
         return SwitchResult(

--- a/packages/credential-slots/src/credential_slots/manager.py
+++ b/packages/credential-slots/src/credential_slots/manager.py
@@ -454,8 +454,10 @@ class SlotManager:
         fp_path = self.fingerprint_path(sub)
         tmp = fp_path.with_suffix(fp_path.suffix + f".tmp{os.getpid()}")
         try:
-            tmp.write_text(json.dumps(payload, sort_keys=True))
-            os.chmod(tmp, 0o600)
+            # Create at 0o600 from the start — no world-readable window before chmod
+            fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            with os.fdopen(fd, "w") as f:
+                f.write(json.dumps(payload, sort_keys=True))
             os.replace(tmp, fp_path)
         except BaseException:
             tmp.unlink(missing_ok=True)

--- a/packages/credential-slots/tests/test_manager.py
+++ b/packages/credential-slots/tests/test_manager.py
@@ -15,8 +15,10 @@ from pathlib import Path
 import pytest
 from credential_slots import (
     DriftInfo,
+    IdentityDriftInfo,
     SlotManager,
     SwitchResult,
+    compute_slot_fingerprint,
     read_slot_expiry,
     slot_is_fresh,
 )
@@ -27,15 +29,23 @@ def _ms_from_now(offset_seconds: float) -> int:
     return int((datetime.now(timezone.utc).timestamp() + offset_seconds) * 1000)
 
 
-def _write_slot(path: Path, expires_at_ms: int | None) -> None:
+def _write_slot(
+    path: Path,
+    expires_at_ms: int | None,
+    *,
+    refresh_token: str | None = "fake-refresh-token",
+) -> None:
     """Write a claudeAiOauth credential file with given ``expiresAt``.
 
     ``expires_at_ms=None`` produces a payload with no ``expiresAt`` key,
-    exercising the unknown-expiry path.
+    exercising the unknown-expiry path. ``refresh_token=None`` omits the
+    ``refreshToken`` field (used to exercise no-fingerprint paths).
     """
     oauth: dict[str, object] = {"accessToken": "fake-token"}
     if expires_at_ms is not None:
         oauth["expiresAt"] = expires_at_ms
+    if refresh_token is not None:
+        oauth["refreshToken"] = refresh_token
     path.write_text(json.dumps({"claudeAiOauth": oauth}))
 
 
@@ -634,3 +644,226 @@ class TestHealDriftTo:
         # No leftover .tmp* artifacts in creds_dir
         leftovers = sorted(p.name for p in mgr.creds_dir.iterdir() if ".tmp" in p.name)
         assert leftovers == [], f"unexpected tmp files: {leftovers}"
+
+
+class TestSlotFingerprint:
+    """Identity fingerprint capture and computation."""
+
+    def test_compute_returns_sha256_of_refresh_token(self, tmp_path: Path) -> None:
+        p = tmp_path / "slot.json"
+        _write_slot(p, _ms_from_now(3600), refresh_token="rt-bob")
+        fp = compute_slot_fingerprint(p)
+        assert fp is not None
+        assert len(fp) == 64  # sha256 hex
+        # Same content → same fingerprint
+        _write_slot(tmp_path / "slot2.json", _ms_from_now(60), refresh_token="rt-bob")
+        assert compute_slot_fingerprint(tmp_path / "slot2.json") == fp
+
+    def test_compute_distinguishes_tokens(self, tmp_path: Path) -> None:
+        a = tmp_path / "a.json"
+        b = tmp_path / "b.json"
+        _write_slot(a, _ms_from_now(3600), refresh_token="rt-bob")
+        _write_slot(b, _ms_from_now(3600), refresh_token="rt-alice")
+        assert compute_slot_fingerprint(a) != compute_slot_fingerprint(b)
+
+    def test_compute_returns_none_when_no_refresh_token(self, tmp_path: Path) -> None:
+        p = tmp_path / "no-rt.json"
+        _write_slot(p, _ms_from_now(3600), refresh_token=None)
+        assert compute_slot_fingerprint(p) is None
+
+    def test_compute_returns_none_for_missing_file(self, tmp_path: Path) -> None:
+        assert compute_slot_fingerprint(tmp_path / "nope.json") is None
+
+    def test_capture_writes_fingerprint_file(self, mgr: SlotManager) -> None:
+        _write_slot(mgr.slot_path("bob"), _ms_from_now(3600), refresh_token="rt-bob")
+        fp = mgr.capture_slot_fingerprint("bob")
+        assert fp is not None
+        fp_path = mgr.fingerprint_path("bob")
+        assert fp_path.exists()
+        payload = json.loads(fp_path.read_text())
+        assert payload["refresh_token_sha256"] == fp
+        assert payload["slot"] == "bob"
+        assert "captured_at" in payload
+
+    def test_capture_returns_none_when_slot_missing(self, mgr: SlotManager) -> None:
+        assert mgr.capture_slot_fingerprint("bob") is None
+        assert not mgr.fingerprint_path("bob").exists()
+
+    def test_capture_overwrites_atomically(self, mgr: SlotManager) -> None:
+        _write_slot(mgr.slot_path("bob"), _ms_from_now(3600), refresh_token="rt-old")
+        first = mgr.capture_slot_fingerprint("bob")
+        _write_slot(mgr.slot_path("bob"), _ms_from_now(3600), refresh_token="rt-new")
+        second = mgr.capture_slot_fingerprint("bob")
+        assert first is not None and second is not None
+        assert first != second
+        # No leftover .tmp* artifacts
+        leftovers = sorted(p.name for p in mgr.creds_dir.iterdir() if ".tmp" in p.name)
+        assert leftovers == [], f"unexpected tmp files: {leftovers}"
+
+    def test_capture_uses_secure_permissions(self, mgr: SlotManager) -> None:
+        _write_slot(mgr.slot_path("bob"), _ms_from_now(3600), refresh_token="rt-bob")
+        mgr.capture_slot_fingerprint("bob")
+        mode = mgr.fingerprint_path("bob").stat().st_mode & 0o777
+        assert mode == 0o600
+
+    def test_read_stored_handles_malformed(self, mgr: SlotManager) -> None:
+        mgr.fingerprint_path("bob").write_text("{not json")
+        assert mgr.read_stored_fingerprint("bob") is None
+
+    def test_constructor_validates_fingerprint_template(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="fingerprint_template"):
+            SlotManager(
+                creds_dir=tmp_path,
+                subscriptions=["bob"],
+                fingerprint_template=".bad_template_no_placeholder",
+            )
+
+
+class TestDetectSlotIdentityDrift:
+    """Identity drift detection via stored fingerprints.
+
+    Regression coverage for ErikBjare/bob#769: detects when a slot's
+    refresh token has been silently replaced (e.g. operator wrote a new
+    OAuth credential through the live symlink, landing in the slot file
+    while the live↔slot hashes still match).
+    """
+
+    def test_returns_no_drift_when_fingerprint_matches(self, mgr: SlotManager) -> None:
+        _write_slot(mgr.slot_path("bob"), _ms_from_now(3600), refresh_token="rt-bob")
+        mgr.capture_slot_fingerprint("bob")
+        info = mgr.detect_slot_identity_drift("bob")
+        assert info["drift"] is False
+        assert info["sub"] == "bob"
+        assert info["stored_fingerprint"] == info["current_fingerprint"]
+        assert "match" in info["reason"].lower()
+
+    def test_detects_identity_drift_in_769_scenario(self, mgr: SlotManager) -> None:
+        """ErikBjare/bob#769 reproduction.
+
+        Bob slot is established with refresh token rt-bob, fingerprint
+        captured. Live symlink points at bob slot. An operator writes
+        Alice's credentials *through* the symlink — the bob slot now
+        contains rt-alice, but the hash-based drift check sees live and
+        slot still match. Identity drift catches it.
+        """
+        # Initial state: bob slot established, symlink + fingerprint captured
+        bob_slot = mgr.slot_path("bob")
+        _write_slot(bob_slot, _ms_from_now(3600), refresh_token="rt-bob")
+        mgr.live_path.symlink_to(".credentials.json.bob")
+        mgr.capture_slot_fingerprint("bob")
+
+        # Hash drift sees no drift (live == slot, by symlink)
+        legacy = mgr.detect_live_slot_drift()
+        assert legacy is not None and legacy["drift"] is False
+
+        # Operator writes Alice's creds through the live symlink — lands in bob slot
+        mgr.live_path.write_text(
+            json.dumps(
+                {
+                    "claudeAiOauth": {
+                        "accessToken": "alice-token",
+                        "refreshToken": "rt-alice",
+                        "expiresAt": _ms_from_now(3600),
+                    }
+                }
+            )
+        )
+
+        # Hash check still misses it (live === slot)
+        legacy2 = mgr.detect_live_slot_drift()
+        assert legacy2 is not None and legacy2["drift"] is False
+
+        # Identity check catches it
+        info = mgr.detect_slot_identity_drift("bob")
+        assert info["drift"] is True
+        assert info["sub"] == "bob"
+        assert info["stored_fingerprint"] != info["current_fingerprint"]
+        assert "refresh token changed" in info["reason"]
+
+    def test_no_drift_when_fingerprint_not_yet_captured(self, mgr: SlotManager) -> None:
+        """Backward-compatible: pre-existing slots without a captured
+        fingerprint must not be reported as drifting (would create
+        false-positives on first deploy)."""
+        _write_slot(mgr.slot_path("bob"), _ms_from_now(3600), refresh_token="rt-bob")
+        info = mgr.detect_slot_identity_drift("bob")
+        assert info["drift"] is False
+        assert info["stored_fingerprint"] is None
+        assert info["current_fingerprint"] is not None
+        assert "no fingerprint stored" in info["reason"].lower()
+
+    def test_drift_when_slot_vanishes_after_capture(self, mgr: SlotManager) -> None:
+        """Fingerprint was captured but the slot is now missing/unreadable —
+        treat as identity drift since we cannot verify the slot still holds
+        the expected token."""
+        _write_slot(mgr.slot_path("bob"), _ms_from_now(3600), refresh_token="rt-bob")
+        mgr.capture_slot_fingerprint("bob")
+        mgr.slot_path("bob").unlink()
+        info = mgr.detect_slot_identity_drift("bob")
+        assert info["drift"] is True
+        assert info["stored_fingerprint"] is not None
+        assert info["current_fingerprint"] is None
+        assert (
+            "missing" in info["reason"].lower()
+            or "cannot verify" in info["reason"].lower()
+        )
+
+    def test_no_drift_when_slot_missing_and_no_fingerprint(
+        self, mgr: SlotManager
+    ) -> None:
+        info = mgr.detect_slot_identity_drift("bob")
+        assert info["drift"] is False
+        assert info["stored_fingerprint"] is None
+        assert info["current_fingerprint"] is None
+
+    def test_unknown_subscription_returns_no_drift(self, mgr: SlotManager) -> None:
+        info = mgr.detect_slot_identity_drift("not-a-real-sub")
+        assert info["drift"] is False
+        assert "unknown subscription" in info["reason"]
+
+    def test_switch_to_auto_captures_fingerprint(self, mgr: SlotManager) -> None:
+        _write_slot(mgr.slot_path("bob"), _ms_from_now(3600), refresh_token="rt-bob")
+        assert not mgr.fingerprint_path("bob").exists()
+        result = mgr.switch_to("bob", "initial")
+        assert result.ok is True
+        assert mgr.fingerprint_path("bob").exists()
+        # Subsequent identity check sees no drift
+        info = mgr.detect_slot_identity_drift("bob")
+        assert info["drift"] is False
+
+    def test_heal_drift_to_auto_captures_fingerprint(self, mgr: SlotManager) -> None:
+        # Set up drift state: live file is a regular file (no symlink),
+        # slot file is older with different refresh token
+        live = mgr.live_path
+        live.write_text(
+            json.dumps(
+                {
+                    "claudeAiOauth": {
+                        "accessToken": "fresh",
+                        "refreshToken": "rt-new",
+                        "expiresAt": _ms_from_now(3600),
+                    }
+                }
+            )
+        )
+        _write_slot(mgr.slot_path("bob"), _ms_from_now(60), refresh_token="rt-old")
+
+        result = mgr.heal_drift_to("bob")
+        assert result.ok is True, result.reason
+        assert mgr.fingerprint_path("bob").exists()
+        # Fingerprint reflects the *new* token now in the slot
+        info = mgr.detect_slot_identity_drift("bob")
+        assert info["drift"] is False
+        assert info["current_fingerprint"] == compute_slot_fingerprint(
+            mgr.slot_path("bob")
+        )
+
+    def test_typed_dict_shape(self, mgr: SlotManager) -> None:
+        """IdentityDriftInfo has the documented fields."""
+        info: IdentityDriftInfo = mgr.detect_slot_identity_drift("bob")
+        assert set(info.keys()) == {
+            "drift",
+            "sub",
+            "stored_fingerprint",
+            "current_fingerprint",
+            "reason",
+        }

--- a/packages/credential-slots/tests/test_manager.py
+++ b/packages/credential-slots/tests/test_manager.py
@@ -422,6 +422,28 @@ class TestSwitchTo:
         # Live symlink unchanged — still points at the initial alice slot.
         assert mgr.get_active_subscription() == "alice"
 
+    def test_fingerprint_write_failure_does_not_abort_successful_switch(
+        self, mgr: SlotManager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A disk-full or permission error during fingerprint capture must not
+        turn a successfully-flipped symlink into an unhandled exception.
+        on_switch must still fire and SwitchResult(ok=True) must be returned.
+        """
+        self._seed(mgr, bob_ms=_ms_from_now(3600), alice_ms=_ms_from_now(3600))
+        events: list[tuple[str, str]] = []
+        mgr.on_switch = lambda sub, reason: events.append((sub, reason))
+
+        def _raise(*args: object, **kwargs: object) -> None:
+            raise OSError("disk full")
+
+        monkeypatch.setattr(mgr, "capture_slot_fingerprint", _raise)
+        result = mgr.switch_to("bob", "test")
+        assert result.ok is True
+        # symlink was placed
+        assert mgr.get_active_subscription() == "bob"
+        # on_switch still fired
+        assert events == [("bob", "test")]
+
 
 class TestSwitchResult:
     """Shape of :class:`SwitchResult`."""
@@ -645,6 +667,29 @@ class TestHealDriftTo:
         leftovers = sorted(p.name for p in mgr.creds_dir.iterdir() if ".tmp" in p.name)
         assert leftovers == [], f"unexpected tmp files: {leftovers}"
 
+    def test_fingerprint_write_failure_does_not_abort_successful_heal(
+        self, mgr: SlotManager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A fingerprint capture failure after a successful symlink heal must not
+        propagate as an unhandled exception. on_switch must still fire and
+        SwitchResult(ok=True) must be returned.
+        """
+        self._seed_drifted(mgr, live_oauth_expires_ms=_ms_from_now(3600))
+        events: list[tuple[str, str]] = []
+        mgr.on_switch = lambda sub, reason: events.append((sub, reason))
+
+        def _raise(*args: object, **kwargs: object) -> None:
+            raise OSError("disk full")
+
+        monkeypatch.setattr(mgr, "capture_slot_fingerprint", _raise)
+        result = mgr.heal_drift_to("bob")
+        assert result.ok is True
+        # Live is now a symlink to bob's slot
+        assert mgr.live_path.is_symlink()
+        # on_switch still fired
+        assert len(events) == 1
+        assert "auto-heal" in events[0][1]
+
 
 class TestSlotFingerprint:
     """Identity fingerprint capture and computation."""
@@ -815,10 +860,9 @@ class TestDetectSlotIdentityDrift:
         assert info["stored_fingerprint"] is None
         assert info["current_fingerprint"] is None
 
-    def test_unknown_subscription_returns_no_drift(self, mgr: SlotManager) -> None:
-        info = mgr.detect_slot_identity_drift("not-a-real-sub")
-        assert info["drift"] is False
-        assert "unknown subscription" in info["reason"]
+    def test_unknown_subscription_raises(self, mgr: SlotManager) -> None:
+        with pytest.raises(ValueError, match="unknown subscription"):
+            mgr.detect_slot_identity_drift("not-a-real-sub")
 
     def test_switch_to_auto_captures_fingerprint(self, mgr: SlotManager) -> None:
         _write_slot(mgr.slot_path("bob"), _ms_from_now(3600), refresh_token="rt-bob")

--- a/uv.lock
+++ b/uv.lock
@@ -725,7 +725,7 @@ toml = [
 
 [[package]]
 name = "credential-slots"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "packages/credential-slots" }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Adds per-slot identity fingerprints (sha256 of the refresh token) to the
`credential-slots` package so callers can detect when a slot's identity
has been silently replaced — even when the hash-based
`detect_live_slot_drift()` reports no drift.

Fixes the failure mode in [ErikBjare/bob#769](https://github.com/ErikBjare/bob/issues/769):
an operator (or stray `claude /login`) writes a new OAuth credential
**through** the live symlink, so the write lands inside the named slot
file. The live and slot hashes still match — yet the slot now holds
someone else's tokens. In the original incident, Bob's autonomous loop
silently consumed Alice's weekly Sonnet quota.

## What the new check sees that the old one doesn't

Scenario: symlink `.credentials.json -> .credentials.json.bob`. Someone
writes Alice's OAuth payload through the live symlink. Result:

| Check | Before | After |
|-------|--------|-------|
| `detect_live_slot_drift()` | drift=False (live and slot still hash-match) | drift=False (unchanged) |
| `detect_slot_identity_drift('bob')` | n/a | **drift=True**: refresh token changed since last capture |

The fingerprint sidecar file (`.credentials.json.<sub>.fingerprint.json`)
stores only the sha256 of the refresh token — no additional credential
material is duplicated to disk.

## API additions

- `SlotManager.capture_slot_fingerprint(sub)` — atomic write of the
  per-slot fingerprint sidecar with sha256 + captured-at timestamp
- `SlotManager.detect_slot_identity_drift(sub) -> IdentityDriftInfo` —
  the new check
- `SlotManager.fingerprint_path(sub)` / `read_stored_fingerprint(sub)`
- `compute_slot_fingerprint(path)` module-level helper
- `IdentityDriftInfo` TypedDict

`switch_to()` and `heal_drift_to()` auto-capture the fingerprint on
success — every legitimate slot change writes the new baseline.

## Backward compatibility

- Pre-existing slots without a captured fingerprint return
  `drift=False` with `reason="no fingerprint stored yet — call
  capture_slot_fingerprint after a fresh login"`. No false positives
  on first deploy.
- Sidecar files are written with `0o600`, like the slot files.
- New ``fingerprint_template`` constructor arg defaults to
  ``.credentials.json.{sub}.fingerprint.json``; same `{sub}` validation
  as `slot_template`.

## Test plan

- [x] Unit tests reproduce the 769 scenario:
      `TestDetectSlotIdentityDrift::test_detects_identity_drift_in_769_scenario`
      verifies the legacy hash check misses it while the new identity
      check catches it.
- [x] Auto-capture wired into both `switch_to` and `heal_drift_to`.
- [x] No false positives for pre-existing slots without a captured
      baseline.
- [x] Missing/unreadable slot after capture is treated as drift.
- [x] Fingerprint files written atomically with secure permissions.
- [x] All 76 tests pass locally (54 pre-existing + 22 new).

```
$ uv run --active pytest packages/credential-slots/tests/test_manager.py -q
76 passed in 0.34s
```

Refs ErikBjare/bob#769.