### PR TITLE
feat(judge): cascade_context routing-aware adjustment (Option C)

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/judge.py
+++ b/packages/gptme-sessions/src/gptme_sessions/judge.py
@@ -69,7 +69,7 @@ JUDGE_PROMPT_TEMPLATE = """\
 
 ## Session Category
 {category}
-
+{routing_context}
 ## Session Journal
 {journal}
 
@@ -101,6 +101,16 @@ Key principle: ONE impactful deliverable > FIVE small deliverables.
 Evaluate impact within the session's category, not the category's intrinsic
 priority.
 
+## Routing-Aware Adjustment
+If a `## Routing Context` block above states the session legitimately
+routed to lower-tier work because higher-tier work was unavailable
+(blocked / waiting / no actionable items), score primarily on execution
+quality within the chosen scope. Do not penalize for non-advancement of
+top-priority goals beyond −0.15 below the execution-quality score: the
+selector — not the agent — decided what was eligible.
+If no `## Routing Context` block is present, ignore this adjustment and
+apply the default rubric.
+
 Return JSON: {{"score": <float>, "reason": "<1 sentence>"}}"""
 
 DEFAULT_GOALS = """\
@@ -109,6 +119,48 @@ The agent is a general-purpose autonomous AI assistant.
 2. Write high-quality code and documentation
 3. Self-improve through lessons and patterns
 4. Contribute to open-source projects"""
+
+
+def format_routing_context(cascade_context: dict | None) -> str:
+    """Render a `## Routing Context` block from a CASCADE selector payload.
+
+    Returns an empty string when ``cascade_context`` is None or doesn't
+    describe a legitimate lower-tier route. The string is plugged into
+    JUDGE_PROMPT_TEMPLATE between Session Category and Session Journal.
+
+    Recognised keys (all optional):
+    - ``tier`` (int): CASCADE tier the selector landed on. 1/2 are
+      ignored (those *are* top-priority work). 3 enables the block.
+    - ``blocked_tier1_2_count`` (int): how many higher-tier tasks were
+      unactionable at selection time.
+    - ``selector_reason`` (str): human-readable selector rationale,
+      typically the top item from cascade_intent["reasons"].
+
+    The block intentionally only fires for Tier 3 + explicit blocked
+    context, so callers without that data degrade to "no adjustment".
+    """
+    if not cascade_context or not isinstance(cascade_context, dict):
+        return ""
+    tier = cascade_context.get("tier")
+    if tier != 3:
+        return ""
+    blocked = cascade_context.get("blocked_tier1_2_count")
+    reason = cascade_context.get("selector_reason") or ""
+    lines = [
+        "",
+        "## Routing Context",
+        "Session legitimately routed to Tier 3 (self-improvement / strategic /",
+        "cleanup / knowledge / research / content / novelty) because higher-tier",
+        "work was unavailable at selection time.",
+    ]
+    if isinstance(blocked, int) and blocked > 0:
+        lines.append(f"- Higher-tier tasks blocked / waiting at selection time: {blocked}")
+    if reason:
+        # Keep selector reasoning short; one line is enough signal for the judge.
+        lines.append(f"- Selector reason: {reason[:200]}")
+    return "\n".join(lines) + "\n"
+
+
 NO_THINK_PREFILL = "<think></think>\n"
 NO_THINK_PREFILL_MODELS = frozenset({"lmstudio/qwen/qwen3.6-35b-a3b"})
 
@@ -411,6 +463,7 @@ def judge_session(
     goals: str = DEFAULT_GOALS,
     model: str = DEFAULT_JUDGE_MODEL,
     api_key: str | None = None,
+    cascade_context: dict | None = None,
 ) -> dict | None:
     """Score a session's strategic value using an LLM judge.
 
@@ -426,6 +479,14 @@ def judge_session(
             installed.
         api_key: Anthropic API key (Anthropic-direct path only). Falls
             back to env/config if not provided.
+        cascade_context: Optional CASCADE selector payload describing
+            which tier the session legitimately routed to. When the
+            payload signals a Tier 3 fallback (higher-tier work was
+            blocked), the prompt instructs the judge to score primarily
+            on execution quality rather than penalize for not advancing
+            top-priority goals. See :func:`format_routing_context` for
+            the recognised keys. Pass ``None`` (default) to keep prompt
+            behaviour unchanged.
 
     Returns:
         Dict with keys ``score`` (float), ``reason`` (str), ``model`` (str),
@@ -441,6 +502,7 @@ def judge_session(
     prompt = JUDGE_PROMPT_TEMPLATE.format(
         goals=goals,
         category=category or "unknown",
+        routing_context=format_routing_context(cascade_context),
         journal=truncated,
     )
 
@@ -457,19 +519,11 @@ def judge_session_with_fallback(
     default_model: str = DEFAULT_JUDGE_MODEL,
     fallback_models: tuple[str, ...] = (),
     api_key: str | None = None,
+    cascade_context: dict | None = None,
 ) -> dict | None:
     """Score a session, trying fallback models if the primary is unavailable.
 
-    Args:
-        journal_text: The session journal/summary text to evaluate.
-        category: Work category (e.g. "code", "triage", "content").
-        goals: Agent goals description (ordered by priority).
-        default_model: Primary judge model. Tried first.
-        fallback_models: Additional models to try in order when the primary fails.
-        api_key: Anthropic API key (Anthropic-direct path only).
-
-    Returns:
-        Dict with keys ``score``, ``reason``, ``model`` or ``None`` if all models fail.
+    See :func:`judge_session` for ``cascade_context`` semantics.
     """
     models_to_try = (default_model, *fallback_models)
     for i, model in enumerate(models_to_try):
@@ -485,6 +539,7 @@ def judge_session_with_fallback(
             goals=goals,
             model=model,
             api_key=api_key,
+            cascade_context=cascade_context,
         )
         if result is not None:
             return result
@@ -605,10 +660,12 @@ def judge_and_writeback(
     model: str = DEFAULT_JUDGE_MODEL,
     fallback_models: tuple[str, ...] = (),
     api_key: str | None = None,
+    cascade_context: dict | None = None,
 ) -> dict[str, Any]:
     """Judge a session and persist the verdict via SessionStore.
 
     If ``fallback_models`` is provided, tries them in order when ``model`` fails.
+    See :func:`judge_session` for ``cascade_context`` semantics.
     """
     if fallback_models:
         verdict = judge_session_with_fallback(
@@ -618,6 +675,7 @@ def judge_and_writeback(
             default_model=model,
             fallback_models=fallback_models,
             api_key=api_key,
+            cascade_context=cascade_context,
         )
     else:
         verdict = judge_session(
@@ -626,6 +684,7 @@ def judge_and_writeback(
             goals=goals,
             model=model,
             api_key=api_key,
+            cascade_context=cascade_context,
         )
     if verdict is None:
         return {"status": "failed"}

--- a/packages/gptme-sessions/src/gptme_sessions/judge.py
+++ b/packages/gptme-sessions/src/gptme_sessions/judge.py
@@ -145,7 +145,8 @@ def format_routing_context(cascade_context: dict | None) -> str:
     if tier != 3:
         return ""
     blocked = cascade_context.get("blocked_tier1_2_count")
-    reason = cascade_context.get("selector_reason") or ""
+    _reason_raw = cascade_context.get("selector_reason")
+    reason = _reason_raw if isinstance(_reason_raw, str) else ""
     lines = [
         "",
         "## Routing Context",

--- a/packages/gptme-sessions/src/gptme_sessions/judge.py
+++ b/packages/gptme-sessions/src/gptme_sessions/judge.py
@@ -153,7 +153,7 @@ def format_routing_context(cascade_context: dict | None) -> str:
         "cleanup / knowledge / research / content / novelty) because higher-tier",
         "work was unavailable at selection time.",
     ]
-    if isinstance(blocked, int) and blocked > 0:
+    if isinstance(blocked, int) and not isinstance(blocked, bool) and blocked > 0:
         lines.append(f"- Higher-tier tasks blocked / waiting at selection time: {blocked}")
     if reason:
         # Keep selector reasoning short; one line is enough signal for the judge.
@@ -523,7 +523,17 @@ def judge_session_with_fallback(
 ) -> dict | None:
     """Score a session, trying fallback models if the primary is unavailable.
 
-    See :func:`judge_session` for ``cascade_context`` semantics.
+    Args:
+        journal_text: The session journal/summary text to evaluate.
+        category: Work category (e.g. "code", "triage", "content").
+        goals: Agent goals description (ordered by priority).
+        default_model: Primary judge model. Tried first.
+        fallback_models: Additional models to try in order when the primary fails.
+        api_key: Anthropic API key (Anthropic-direct path only).
+        cascade_context: Optional CASCADE selector payload. See :func:`judge_session`.
+
+    Returns:
+        Dict with keys ``score``, ``reason``, ``model`` or ``None`` if all models fail.
     """
     models_to_try = (default_model, *fallback_models)
     for i, model in enumerate(models_to_try):

--- a/packages/gptme-sessions/tests/test_judge.py
+++ b/packages/gptme-sessions/tests/test_judge.py
@@ -25,6 +25,7 @@ from gptme_sessions.judge import (
     _resolve_openrouter_api_key,
     _is_anthropic_direct_model,
     _strip_anthropic_prefix,
+    format_routing_context,
     judge_and_writeback,
     judge_from_signals,
     judge_session,
@@ -80,6 +81,7 @@ class TestJudgeSession:
         prompt = JUDGE_PROMPT_TEMPLATE.format(
             goals="Test goals",
             category="code",
+            routing_context="",
             journal="Did some work",
         )
         assert "Test goals" in prompt
@@ -100,6 +102,7 @@ class TestJudgeSession:
         prompt = JUDGE_PROMPT_TEMPLATE.format(
             goals="Test goals",
             category="infrastructure",
+            routing_context="",
             journal="Reduced future friction",
         )
         assert "Category Interpretation" in prompt
@@ -167,6 +170,97 @@ class TestJudgeSession:
         """Default goals should work for any agent, not just Bob."""
         assert "Bob" not in DEFAULT_GOALS
         assert "agent" in DEFAULT_GOALS.lower()
+
+    def test_format_routing_context_returns_empty_when_unset(self) -> None:
+        """No cascade_context => no Routing Context block (back-compat)."""
+        assert format_routing_context(None) == ""
+        assert format_routing_context({}) == ""
+
+    def test_format_routing_context_ignores_tier1_and_tier2(self) -> None:
+        """Tier 1/2 routing is itself top-priority work; no adjustment block."""
+        assert format_routing_context({"tier": 1, "blocked_tier1_2_count": 0}) == ""
+        assert format_routing_context({"tier": 2, "blocked_tier1_2_count": 0}) == ""
+        # Junk types should also degrade safely.
+        assert format_routing_context({"tier": "tier3"}) == ""
+
+    def test_format_routing_context_renders_for_tier3(self) -> None:
+        """Tier 3 with cascade evidence => routing block with summary lines."""
+        block = format_routing_context(
+            {
+                "tier": 3,
+                "blocked_tier1_2_count": 47,
+                "selector_reason": "Cleanup neglected boost suppressed",
+            }
+        )
+        assert "## Routing Context" in block
+        assert "Tier 3" in block
+        assert "47" in block
+        assert "Cleanup neglected boost suppressed" in block
+
+    def test_format_routing_context_truncates_long_reason(self) -> None:
+        """Selector reason is bounded so it can't dominate the prompt."""
+        block = format_routing_context({"tier": 3, "selector_reason": "x" * 500})
+        # Cap at 200 chars; the raw 500-char string must not appear verbatim.
+        assert "x" * 500 not in block
+        assert "x" * 200 in block
+
+    def test_judge_session_passes_routing_context_into_prompt(self) -> None:
+        """When cascade_context names Tier 3, the prompt carries the block."""
+        captured: dict[str, str] = {}
+
+        mock_anthropic = MagicMock()
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(text='{"score": 0.7, "reason": "OK"}')]
+
+        def _capture_create(**kwargs):
+            # The prompt is the first user message's content
+            captured["prompt"] = kwargs["messages"][0]["content"]
+            return mock_response
+
+        mock_anthropic.Anthropic.return_value.messages.create.side_effect = _capture_create
+
+        with (
+            patch.dict("sys.modules", {"anthropic": mock_anthropic}),
+            patch("gptme_sessions.judge._get_api_key", return_value="test-key"),
+        ):
+            result = judge_session(
+                "session text",
+                category="cleanup",
+                cascade_context={"tier": 3, "blocked_tier1_2_count": 30},
+            )
+
+        assert result is not None
+        assert "\n## Routing Context\n" in captured["prompt"]
+        assert "## Routing-Aware Adjustment" in captured["prompt"]
+        # The adjustment instructs the judge to cap the priority penalty.
+        assert "−0.15" in captured["prompt"] or "-0.15" in captured["prompt"]
+
+    def test_judge_session_omits_routing_block_when_no_context(self) -> None:
+        """No cascade_context => the prompt has no Routing Context block."""
+        captured: dict[str, str] = {}
+
+        mock_anthropic = MagicMock()
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(text='{"score": 0.5, "reason": "Mid"}')]
+
+        def _capture_create(**kwargs):
+            captured["prompt"] = kwargs["messages"][0]["content"]
+            return mock_response
+
+        mock_anthropic.Anthropic.return_value.messages.create.side_effect = _capture_create
+
+        with (
+            patch.dict("sys.modules", {"anthropic": mock_anthropic}),
+            patch("gptme_sessions.judge._get_api_key", return_value="test-key"),
+        ):
+            result = judge_session("session text", category="code")
+
+        assert result is not None
+        # The Routing-Aware adjustment text references the block name in
+        # backticks; the actual block header is bare. Look for the header form.
+        assert "\n## Routing Context\n" not in captured["prompt"]
+        # The adjustment paragraph is always rendered (it self-skips when the
+        # block is absent), so we don't assert its presence/absence here.
 
     def test_parse_judge_payload_handles_think_tags_and_fences(self) -> None:
         parsed = _parse_judge_payload(

--- a/packages/gptme-sessions/tests/test_judge.py
+++ b/packages/gptme-sessions/tests/test_judge.py
@@ -211,6 +211,19 @@ class TestJudgeSession:
         assert "True" not in block
         assert "1" not in block
 
+    def test_format_routing_context_rejects_non_string_selector_reason(self) -> None:
+        """Non-string selector_reason (e.g. int) must not raise TypeError."""
+        # int: would crash reason[:200] without the isinstance guard
+        block = format_routing_context({"tier": 3, "selector_reason": 42})
+        assert "42" not in block
+        assert "Selector reason" not in block
+        # list: another non-string truthy type
+        block = format_routing_context({"tier": 3, "selector_reason": ["a", "b"]})
+        assert "Selector reason" not in block
+        # None degrades gracefully (existing behaviour)
+        block = format_routing_context({"tier": 3, "selector_reason": None})
+        assert "Selector reason" not in block
+
     def test_judge_session_passes_routing_context_into_prompt(self) -> None:
         """When cascade_context names Tier 3, the prompt carries the block."""
         captured: dict[str, str] = {}

--- a/packages/gptme-sessions/tests/test_judge.py
+++ b/packages/gptme-sessions/tests/test_judge.py
@@ -204,6 +204,13 @@ class TestJudgeSession:
         assert "x" * 500 not in block
         assert "x" * 200 in block
 
+    def test_format_routing_context_rejects_bool_as_blocked_count(self) -> None:
+        """bool is a subclass of int; True should NOT render as blocked count."""
+        block = format_routing_context({"tier": 3, "blocked_tier1_2_count": True})
+        # The bool guard must stop 'True' from appearing in the prompt.
+        assert "True" not in block
+        assert "1" not in block
+
     def test_judge_session_passes_routing_context_into_prompt(self) -> None:
         """When cascade_context names Tier 3, the prompt carries the block."""
         captured: dict[str, str] = {}


### PR DESCRIPTION
## Summary

Adds an optional `cascade_context` parameter to the LLM judge so it can
distinguish "session legitimately routed to Tier 3 because Tier 1/2 was
blocked" from "session avoided top-priority work voluntarily." When the
payload signals a Tier 3 fallback, the prompt gains a `## Routing Context`
block plus a `## Routing-Aware Adjustment` rule that caps the
top-priority penalty at −0.15 below the execution-quality score.

## Why

The 2026-05-11 F7 partial-completion deep-dive
([Bob research note](https://github.com/ErikBjare/bob/blob/master/knowledge/research/2026-05-11-f7-partial-completion-judge-bias.md))
and the 14d cross-check found that **88% of F7 sessions were full-effort
Tier 3 work judged sub-priority** because they advanced self-improvement
instead of revenue goals. The agent did not choose Tier 3 — the selector
did, because Tier 1/2 had no actionable items at the time.

That mis-graded signal was then about to be used to argue for more
follow-through scaffolding ("idea #220 Phase 3") even though follow-through
was not the bottleneck.

## What

- `gptme_sessions.judge.format_routing_context(cascade_context)` —
  pure helper that returns either an empty string (default,
  back-compat) or a `## Routing Context` block.
- `judge_session(..., cascade_context=...)` — new optional kwarg,
  threaded through `judge_session_with_fallback` and
  `judge_and_writeback`. `judge_from_signals` already forwards via
  `**kwargs` so it inherits for free.
- Prompt template updates: new `{routing_context}` placeholder and a
  `## Routing-Aware Adjustment` paragraph that self-skips when no
  block is rendered.
- `JUDGE_VERSION` bumps via the existing template-hash function — no
  manual bookkeeping needed.

## Behavior

| `cascade_context` value           | Prompt change                              |
|-----------------------------------|--------------------------------------------|
| `None` / `{}` (existing callers)  | None — byte-identical apart from JUDGE_VERSION |
| `{"tier": 1}` or `{"tier": 2}`    | None — Tier 1/2 *is* top-priority work     |
| `{"tier": 3, ...}`                | Adds the routing block + applies the cap   |

The adjustment paragraph is always rendered but explicitly self-skips
when no block is present, so existing callers (and external consumers
of `gptme-sessions`) see no behavior change beyond the version bump.

## Pre-decided kill-switch

Per the cross-check note: if cap-eligible F7 share doesn't drop below
~35% in the 7 days after this lands in Bob's production grading path,
revert.

## Test plan

- [x] 50 judge tests pass locally (6 added: `format_routing_context`
      empty / Tier 1 / Tier 2 / Tier 3 / long-reason truncation; plus
      end-to-end prompt wiring with and without cascade_context)
- [x] 713 other gptme-sessions tests still pass
- [ ] CI green
- [ ] Wiring through `metaproductivity.session_alignment` and
      `scripts/runs/autonomous/autonomous-run.sh` ships in a follow-up
      Bob-side commit (smaller blast radius this way)