### PR TITLE
fix(gptme-voice): address HandoffHubWriter robustness issues

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/handoff.py
+++ b/packages/gptme-voice/src/gptme_voice/handoff.py
@@ -394,6 +394,7 @@ class HandoffHubWriter:
         ttl_seconds: int = _DEFAULT_TTL_SECONDS,
         extra: dict[str, Any] | None = None,
         now: datetime | None = None,
+        timeout: float = 10.0,
     ) -> PublishedHandoff:
         """Build a signed handoff and POST it to the hub.
 
@@ -401,7 +402,8 @@ class HandoffHubWriter:
         (the hub-assigned ID) and ``payload`` is the original signed payload.
 
         Raises ``urllib.error.HTTPError`` for 4xx/5xx hub responses, and
-        ``RuntimeError`` if the hub rejects the payload (422).
+        ``RuntimeError`` if the hub returns a 2xx response with
+        ``status=rejected`` or without a ``handoff_id`` field.
         """
         payload = build_handoff(
             from_agent=self.from_agent,
@@ -424,14 +426,18 @@ class HandoffHubWriter:
             },
             method="POST",
         )
-        with urllib.request.urlopen(req) as resp:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
             resp_body = json.loads(resp.read())
         if resp_body.get("status") == "rejected":
             raise RuntimeError(
                 f"Hub rejected handoff: {resp_body.get('reason', 'unknown')}"
             )
-        handoff_id = str(resp_body["handoff_id"])
-        return PublishedHandoff(path=Path(handoff_id), payload=payload)
+        raw_id = resp_body.get("handoff_id")
+        if raw_id is None:
+            raise RuntimeError(
+                f"Hub response missing 'handoff_id' field: {resp_body!r}"
+            )
+        return PublishedHandoff(path=Path(str(raw_id)), payload=payload)
 
 
 def archive_filename(


### PR DESCRIPTION
## Summary

Follow-up to #897, addressing three issues flagged in the Greptile review that landed after the PR was merged:

- **Missing `urlopen` timeout**: `urlopen(req)` had no timeout, meaning a slow or unreachable hub would block the calling voice-server thread indefinitely. Added `timeout` parameter (default 10s).
- **Bare `KeyError` on unexpected hub responses**: `resp_body["handoff_id"]` would raise an uninformative `KeyError` if the hub returned a 2xx without that field. Now uses `.get()` + an explicit `RuntimeError` with the full response body for context.
- **Incorrect docstring**: The docstring claimed a 422 raises `RuntimeError`, but 4xx/5xx hub responses surface as `urllib.error.HTTPError`. Corrected to describe when `RuntimeError` is actually raised (2xx with `status=rejected` or missing `handoff_id`).

## Test plan

- [ ] Existing `gptme-voice` tests still pass
- [ ] `HandoffHubWriter.initiate` with a mock that returns 2xx without `handoff_id` → `RuntimeError` with descriptive message
- [ ] `HandoffHubWriter.initiate` with a slow mock → times out at `timeout` seconds