### PR TITLE
docs(lessons): remove dead keywords flagged by 7-day keyword health

### DIFF
--- a/lessons/autonomous/rule-driven-session-gating.md
+++ b/lessons/autonomous/rule-driven-session-gating.md
@@ -9,13 +9,7 @@ tags:
 - orchestration
 match:
   keywords:
-  - inference cost
   - monitoring sessions
-  - session gating
-  - no-op sessions
-  - skip session
-  - session orchestration
-  - routine monitoring
   - cost optimization
 ---
 

--- a/lessons/patterns/data-loader-pr-quality.md
+++ b/lessons/patterns/data-loader-pr-quality.md
@@ -1,13 +1,8 @@
 ---
 match:
   keywords:
-  - data loader
-  - csv loader
   - file not found
   - assert path
-  - missing file test
-  - loader test
-  - timezone assertion
   session_categories: [code]
 status: active
 ---

--- a/lessons/workflow/fork-pr-secrets.md
+++ b/lessons/workflow/fork-pr-secrets.md
@@ -1,12 +1,7 @@
 ---
 match:
   keywords:
-    - "secret not accessible via fork"
-    - "push directly to repo"
     - "ANTHROPIC_API_KEY not set"
-    - "permission denied pushing to org repo"
-    - "fork PR failing CI"
-    - "CI secret not available"
   session_categories: [code, cross-repo]
 status: active
 ---

--- a/lessons/workflow/gptme-contrib-contribution-pattern.md
+++ b/lessons/workflow/gptme-contrib-contribution-pattern.md
@@ -1,6 +1,6 @@
 ---
 match:
-  keywords: ["contribute lesson", "contrib PR", "external contribution", "submit lesson", "upstream lesson", "upstream to gptme-contrib"]
+  keywords: ["contrib PR"]
 status: active
 ---
 

--- a/lessons/workflow/proactive-correction-in-agent-messages.md
+++ b/lessons/workflow/proactive-correction-in-agent-messages.md
@@ -11,11 +11,6 @@ match:
     - "correction to my earlier"
     - "correct my previous message"
     - "correct earlier advice"
-    - "ignore my last message"
-    - "wrong recommendation to"
-    - "follow-up correction"
-    - "before they act on it"
-    - "I gave the wrong advice"
 ---
 
 # Proactive Correction in Agent Messages


### PR DESCRIPTION
## Summary

Drop 25 lesson keywords across 5 active lessons that produced zero matches in
the trailing 7-day trajectory window. Output came from
`scripts/lesson-keyword-health.py --action-items` against the live Bob bandit
state on 2026-05-12.

| Lesson | Keep | Drop |
|--------|------|------|
| `autonomous/rule-driven-session-gating.md` | 2 | 6 |
| `workflow/fork-pr-secrets.md` | 1 | 5 |
| `workflow/proactive-correction-in-agent-messages.md` | 8 | 5 |
| `workflow/gptme-contrib-contribution-pattern.md` | 1 | 5 |
| `patterns/data-loader-pr-quality.md` | 2 | 5 |

Net: -22 lines, +1 line.

## Safety

- Only non-`target_grade: harm` lessons touched. Safety lessons with dead
  keywords are scenario-specific by design and were explicitly skipped by
  the keyword-health analyzer.
- Every modified lesson retains at least one live or scenario-specific
  keyword, so it can still fire when its actual trigger context appears.
- No behavioral change to lesson bodies. Only `match.keywords` lists were
  trimmed.

## Test plan

- [x] `gptme-lessons-extras` validator passes for all 5 changed files (no
  new errors; only pre-existing line-count / origin-section warnings).
- [x] Pre-commit (prek) passes locally.
- [x] Diff matches the keyword-health analyzer's "remove" recommendation
  exactly.
- [ ] Greptile review.