### PR TITLE
fix(monitoring): surface Bob-authored draft PRs in pr_update flow

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/project_monitoring.py
+++ b/packages/gptme-runloops/src/gptme_runloops/project_monitoring.py
@@ -247,11 +247,9 @@ class ProjectMonitoringRun(BaseRunLoop):
             prs = json.loads(result.stdout)
 
             for pr in prs:
-                # Skip draft PRs — they're not on the merge path
-                if pr.get("isDraft"):
-                    continue
                 pr_number = pr["number"]
                 updated_at = pr["updatedAt"]
+                is_draft = bool(pr.get("isDraft"))
                 state_file = (
                     self.state_dir / f"{repo.replace('/', '-')}-pr-{pr_number}.state"
                 )
@@ -278,14 +276,19 @@ class ProjectMonitoringRun(BaseRunLoop):
                         state_file.write_text(updated_at)
 
                         branch_name = pr.get("headRefName", "unknown")
+                        draft_note = (
+                            "\n  - **Draft**: yes — promote to ready or address the gap blocking promotion"
+                            if is_draft
+                            else ""
+                        )
                         work_items.append(
                             WorkItem(
                                 repo=repo,
                                 item_type="pr_update",
                                 number=pr_number,
-                                title=pr["title"],
+                                title=("[DRAFT] " if is_draft else "") + pr["title"],
                                 url=pr["url"],
-                                details=f"PR #{pr_number} updated: {updated_at}\n  - **Branch**: `{branch_name}` (push to this branch!)",
+                                details=f"PR #{pr_number} updated: {updated_at}\n  - **Branch**: `{branch_name}` (push to this branch!){draft_note}",
                             )
                         )
 

--- a/packages/gptme-runloops/tests/test_project_monitoring.py
+++ b/packages/gptme-runloops/tests/test_project_monitoring.py
@@ -419,6 +419,10 @@ def test_check_pr_updates_surfaces_draft(mock_run, workspace):
     assert item.title.startswith("[DRAFT] ")
     assert "Draft" in item.details
 
+    # Second call with same timestamp: state written, no duplicate surfaced
+    work_items = run.check_pr_updates("gptme/gptme")
+    assert len(work_items) == 0
+
 
 @patch("gptme_runloops.project_monitoring.subprocess.run")
 def test_check_ci_failures_still_skips_drafts(mock_run, workspace):

--- a/packages/gptme-runloops/tests/test_project_monitoring.py
+++ b/packages/gptme-runloops/tests/test_project_monitoring.py
@@ -388,6 +388,66 @@ def test_check_pr_updates_no_change(mock_run, workspace):
 
 
 @patch("gptme_runloops.project_monitoring.subprocess.run")
+def test_check_pr_updates_surfaces_draft(mock_run, workspace):
+    """Draft PRs authored by self should still surface as pr_update items.
+
+    Regression: prior behavior skipped drafts entirely, so a Bob-authored draft
+    PR was invisible to monitoring until manually promoted. Erik flagged this
+    on gptme/gptme#2390.
+    """
+    pr_data = json.dumps(
+        [
+            {
+                "number": 999,
+                "title": "WIP: thing",
+                "updatedAt": "2026-05-12T20:17:24Z",
+                "url": "https://github.com/gptme/gptme/pull/999",
+                "headRefName": "wip-thing",
+                "isDraft": True,
+            }
+        ]
+    )
+    mock_run.return_value = MagicMock(returncode=0, stdout=pr_data, stderr="")
+
+    run = ProjectMonitoringRun(workspace)
+    work_items = run.check_pr_updates("gptme/gptme")
+
+    assert len(work_items) == 1
+    item = work_items[0]
+    assert item.item_type == "pr_update"
+    assert item.number == 999
+    assert item.title.startswith("[DRAFT] ")
+    assert "Draft" in item.details
+
+
+@patch("gptme_runloops.project_monitoring.subprocess.run")
+def test_check_ci_failures_still_skips_drafts(mock_run, workspace):
+    """CI-failure path should keep skipping drafts.
+
+    Drafts often have intentionally-broken CI during early development;
+    chasing CI fixes on parked work is the failure mode that the original
+    skip (commit 91a8ca5) addressed. Only the pr_update path changed.
+    """
+    pr_data = json.dumps(
+        [
+            {
+                "number": 999,
+                "title": "WIP: thing",
+                "url": "https://github.com/gptme/gptme/pull/999",
+                "statusCheckRollup": [{"conclusion": "FAILURE"}],
+                "isDraft": True,
+            }
+        ]
+    )
+    mock_run.return_value = MagicMock(returncode=0, stdout=pr_data, stderr="")
+
+    run = ProjectMonitoringRun(workspace)
+    work_items = run.check_ci_failures("gptme/gptme")
+
+    assert work_items == []
+
+
+@patch("gptme_runloops.project_monitoring.subprocess.run")
 def test_check_ci_failures(mock_run, workspace):
     """Test detecting CI failures."""
     # Mock gh pr list response with failing checks


### PR DESCRIPTION
## Summary

- Stop completely skipping draft PRs in `check_pr_updates`. Tag the work item title with `[DRAFT]` and append a hint so the dispatched agent knows the next action.
- Keep the draft skip in `check_ci_failures` — drafts often have intentionally-broken CI; only the pr_update path changes.

## Context

The original draft skip (commit `91a8ca5`, #523, 2026-03-21) assumed drafts signal "deprioritized/not-ready work." In practice Bob almost never uses drafts as intentional parking — they show up as a transient state during PR creation, or as an accidental result of `gh pr create --draft` defaults.

Empirical case that triggered this fix: `gptme/gptme#2390` spent 23 minutes as a draft after Bob created it (20:17Z → 20:40Z), fully invisible to monitoring, then got promoted to ready and merged. Erik flagged the gap on the PR: *"I don't think your project-monitoring handles it well (seems to ignore draft PRs)."*

## Why split pr_update vs ci_failures

| Path | Before | After | Reasoning |
|---|---|---|---|
| `check_pr_updates` | Skipped drafts | Surfaces drafts with `[DRAFT]` tag | Drafts Bob authored are work Bob should advance — promote, address review, etc. |
| `check_ci_failures` | Skipped drafts | Still skips drafts | Drafts often have intentionally-broken CI during early development; chasing CI on parked work is the failure mode the original skip addressed. |

## Test plan

- [x] `test_check_pr_updates_surfaces_draft` — new test confirming drafts produce work items with `[DRAFT]` tag
- [x] `test_check_ci_failures_still_skips_drafts` — new test confirming the CI-failure path is unchanged
- [x] Full `test_project_monitoring.py` suite (26 tests) still passes

Refs gptme/gptme#2390