### PR TITLE
fix(git): clarify pre-commit rerun status message

### DIFF
--- a/scripts/git/pre-commit-auto-stage
+++ b/scripts/git/pre-commit-auto-stage
@@ -175,11 +175,11 @@ else
   set -e
 
   if [ $PRECOMMIT_EXIT -eq 0 ]; then
-    echo -e "${GREEN}✓ All checks passed after auto-staging${NC}"
+    echo -e "${GREEN}✓ All checks passed after verification re-run${NC}"
     exit 0
   else
     echo "$PRECOMMIT_OUTPUT"
-    echo -e "${RED}✗ Pre-commit still failing after auto-staging${NC}"
+    echo -e "${RED}✗ Pre-commit still failing after verification re-run${NC}"
     exit 1
   fi
 fi


### PR DESCRIPTION
## What

Clarifies the final rerun status messages in `scripts/git/pre-commit-auto-stage`.

- replace `after auto-staging` with `after verification re-run`
- update the matching failure message to the same neutral wording

## Why

Follow-up to #903. That PR taught the helper to handle two remediation paths:

- worktree formatter edits that need auto-staging
- index-only hook updates that are already staged

The old final banner said `after auto-staging` in both cases, which is inaccurate on the index-only path and makes debugging noisier than it needs to be.

## Impact

Users now get status text that matches what actually happened during the rerun path.

## Validation

- `shellcheck scripts/git/pre-commit-auto-stage`
- `git diff --check -- scripts/git/pre-commit-auto-stage`
- `prek run --files scripts/git/pre-commit-auto-stage`
