### PR TITLE
fix(lessons): replace person-specific blocker keyword

### DIFF
--- a/lessons/workflow/progress-despite-blockers.md
+++ b/lessons/workflow/progress-despite-blockers.md
@@ -2,7 +2,7 @@
 match:
   keywords:
   - "completely blocked"
-  - "waiting on Erik"
+  - "need human review"
   - "waiting for input"
   - "cannot proceed"
   - "stuck on this"


### PR DESCRIPTION
Follow-up to #905.

Greptile was right that `"waiting on Erik"` is overfit to one person and has near-zero recall outside this team. This swaps it for `"need human review"`, which is generic to the situation the lesson is trying to catch and has live matches in Bob's trajectory data.

Validation:
- `python3 /home/bob/bob/scripts/lesson-keyword-health.py --days 60 --validate "need human review" --json` -> healthy (10 matched sessions)
- `git diff --check -- lessons/workflow/progress-despite-blockers.md`
- `prek run --files lessons/workflow/progress-despite-blockers.md` (file-scoped hooks passed before the shared-worktree typecheck cache issue)
