### PR TITLE
fix(lessons): replace dead strategic-focus keywords

### DIFF
--- a/lessons/autonomous/strategic-focus-during-autonomous-sessions.md
+++ b/lessons/autonomous/strategic-focus-during-autonomous-sessions.md
@@ -36,6 +36,8 @@ Observable signals that strategic focus discipline is needed:
 - Completed major deliverables but unclear on next strategic priorities
 - Available time could be spent on optimization vs. strategic advancement
 - Risk of "productivity theater" - appearing busy without strategic progress
+- `anti-monotony guard` suggests the current session is repeating a familiar lane instead of advancing the highest-leverage work
+- `category_monotony` from the work-category bandit indicates repeated work-category selection and should trigger a strategic reset
 
 ## Pattern
 Apply strategic focus discipline throughout autonomous session:

--- a/lessons/autonomous/strategic-focus-during-autonomous-sessions.md
+++ b/lessons/autonomous/strategic-focus-during-autonomous-sessions.md
@@ -8,16 +8,14 @@ tags:
 match:
   keywords:
   - strategic focus discipline
-  - productivity trap avoidance
   - darwinian trap avoidance
-  - autonomous session planning
-  - strategic work selection
   - "strategic focus"
   - "productivity trap"
   - "darwinian trap"
   - "busy work"
   - "productivity theater"
-  - "low-ROI work"
+  - "anti-monotony guard"
+  - "category_monotony"
   - "idea backlog"
   session_categories: [strategic, self-review]
 status: active


### PR DESCRIPTION
Summary:
- remove four dead keywords from Strategic Focus During Autonomous Sessions
- replace them with trajectory-backed phrases that actually fire: anti-monotony guard and category_monotony
- keep the lesson scope unchanged outside keyword routing

Verification:
- python3 /home/bob/bob/scripts/lesson-keyword-health.py --lesson /home/bob/bob/gptme-contrib/lessons/autonomous/strategic-focus-during-autonomous-sessions.md
- validate.py on the changed lesson file
- git -C /home/bob/bob/gptme-contrib diff --check
