### PR TITLE
fix(lessons): prune measured dead keywords

### DIFF
--- a/lessons/patterns/indexed-knowledge-base-for-llm-retrieval.md
+++ b/lessons/patterns/indexed-knowledge-base-for-llm-retrieval.md
@@ -2,9 +2,7 @@
 match:
   keywords:
     - knowledge base
-    - curated index
     - knowledge retrieval
-    - indexed knowledge
 status: active
 ---
 
@@ -17,6 +15,12 @@ Structure knowledge as a directory of markdown files with a curated index file. 
 LLMs need knowledge that grows over time — data inventories, design decisions, user preferences, domain facts. Dumping everything into a system prompt doesn't scale. But the LLM can't search files on its own without tooling.
 
 The solution is a two-tier structure: a **compact index** (always in context) that points to **detail files** (loaded on demand). Claude Code's auto-memory system uses exactly this pattern, but it's general-purpose and works for any knowledge base.
+
+## Detection
+- You need a growing knowledge store without loading every file into baseline context
+- A repo has many notes but no compact manifest telling the agent what exists
+- Retrieval is opaque because the only options are "load everything" or "search ad hoc"
+- Knowledge descriptions are too vague for selective loading
 
 ## Pattern
 

--- a/lessons/tools/check-cli---help-before-readin.md
+++ b/lessons/tools/check-cli---help-before-readin.md
@@ -4,11 +4,6 @@ match:
     - "doesn't have a flag for"
     - "wrap the command to add"
     - "before patching the wrapper"
-    - "no built-in option for"
-    - "let me read the source to figure out"
-    - "doesn't seem to support"
-    - "build a wrapper around"
-    - "monkey-patch the CLI"
 status: active
 ---
 

--- a/lessons/workflow/agent-orchestrator-patterns.md
+++ b/lessons/workflow/agent-orchestrator-patterns.md
@@ -2,7 +2,6 @@
 status: active
 match:
   keywords:
-    - "agent standup"
     - "orchestrator"
     - "multi-agent"
     - "agent health"

--- a/lessons/workflow/agent-workspace-maintenance.md
+++ b/lessons/workflow/agent-workspace-maintenance.md
@@ -1,10 +1,7 @@
 ---
 match:
   keywords:
-    - "update submodule to latest"
-    - "submodule is behind"
     - "update gptme-contrib"
-    - "bump the submodule"
   session_categories: [cleanup]
 status: active
 ---

--- a/lessons/workflow/check-existing-prs.md
+++ b/lessons/workflow/check-existing-prs.md
@@ -1,9 +1,6 @@
 ---
 match:
   keywords:
-  - gh pr create
-  - git checkout -b fix-
-  - gh pr list --search
   - gh api graphql
   session_categories: [cross-repo, code, triage]
 status: active

--- a/lessons/workflow/prefer-brain-over-local-memory.md
+++ b/lessons/workflow/prefer-brain-over-local-memory.md
@@ -1,11 +1,8 @@
 ---
 match:
   keywords:
-    - auto-memory
     - MEMORY.md
     - brain repo
-    - claude memory
-    - local memory
   session_categories: [self-review, infrastructure]
 status: active
 ---

--- a/lessons/workflow/read-full-github-context.md
+++ b/lessons/workflow/read-full-github-context.md
@@ -1,9 +1,7 @@
 ---
 match:
   keywords:
-    - "--comments | head"
     - "--comments | tail"
-    - "view --comments | grep"
     - "gh issue view --comments"
     - "gh pr view --comments"
   session_categories: [cross-repo, code]


### PR DESCRIPTION
## What

Prunes 19 dead keywords (zero trajectory matches in a 60-day window) across 7 lessons:

- **check-cli---help-before-readin**: 5 dead keywords removed
- **read-full-github-context**: 2 dead keywords removed
- **agent-orchestrator-patterns**: 1 dead keyword removed
- **agent-workspace-maintenance**: 3 dead keywords removed
- **check-existing-prs**: 3 dead keywords removed
- **prefer-brain-over-local-memory**: 3 dead keywords removed
- **indexed-knowledge-base-for-llm-retrieval**: 2 dead keywords removed

Also adds a `Detection` section to `indexed-knowledge-base-for-llm-retrieval` so the lesson follows the standard structure more closely and is easier to trigger intentionally.

## Verification

- `python3 scripts/lesson-keyword-health.py --days 60`
- `pre-commit` passed for this PR
