### PR TITLE
fix(lessons): archive gh-pr-review-extension (confirmed harmful, Δ=-0.1291)

### DIFF
--- a/lessons/tools/gh-pr-review-extension.md
+++ b/lessons/tools/gh-pr-review-extension.md
@@ -7,7 +7,7 @@ match:
     - "gh-pr-review"
     - "close conversation thread"
     - "mark thread resolved"
-status: active
+status: archived
 ---
 
 # gh-pr-review Extension for Review Thread Management


### PR DESCRIPTION
## Problem

The `gh-pr-review-extension` lesson has been flagged as **genuinely harmful** by LOO analysis: Δ=-0.1291 (n=512), p<0.01, unconfounded.

This is one of the 3 genuinely harmful lessons identified in today's full LOO run (along with `progress-despite-blockers` at Δ=-0.1389 and `check-existing-prs` at Δ=-0.0429).

## Changes

- Set `status: archived` on `lessons/tools/gh-pr-review-extension.md`

Note: `progress-despite-blockers` and `check-existing-prs` had their harmful signal confirmed at the same time, but their keyword fixes were already committed in #909 (new behavioral keywords added). This PR handles the straightforward archive of the remaining confirmed-harmful lesson where keyword-only fixes weren't sufficient.