### PR TITLE
fix(lessons): archive 2 confirmed-harmful lessons (progress-despite-blockers, check-existing-prs)

### DIFF
--- a/lessons/workflow/check-existing-prs.md
+++ b/lessons/workflow/check-existing-prs.md
@@ -6,7 +6,7 @@ match:
   - gh pr list --search
   - gh api graphql
   session_categories: [cross-repo, code, triage]
-status: active
+status: archived
 ---
 
 # Check for Existing PRs Before Creating

--- a/lessons/workflow/progress-despite-blockers.md
+++ b/lessons/workflow/progress-despite-blockers.md
@@ -15,7 +15,7 @@ match:
   - "blocked on upstream"
   - "all tasks blocked on external"
   session_categories: [code, cross-repo, triage, cleanup, infrastructure]
-status: active
+status: archived
 ---
 
 # Making Progress Despite Blockers


### PR DESCRIPTION
## Summary

Archives two lessons identified as genuinely harmful by LOO analysis (unconfounded, p<0.05):

| Lesson | Δ | n | p |
|---|---|---|---|
| progress-despite-blockers | -0.1389 | 349 | <0.001 |
| check-existing-prs | -0.0429 | 267 | 0.022 |

Both had dead/broad keywords that caused high false-trigger rates, dragging down trajectory grades in sessions where they fired.

This follows the same pattern as PR #907 (gh-pr-review-extension archive), which was confirmed harmful at Δ=-0.1291.

Part of a systematic LOO-driven harmful-lesson archive pass.