### PR TITLE
feat(self-merge): allow trusted repo-path overrides

### DIFF
--- a/lessons/autonomous/effective-autonomous-work-execution.md
+++ b/lessons/autonomous/effective-autonomous-work-execution.md
@@ -2,8 +2,6 @@
 match:
   keywords:
   - "autonomous session"
-  - "task selection"
-  - "work queue"
   session_categories: [strategic, self-review]
 status: active
 ---

--- a/lessons/autonomous/rule-driven-session-gating.md
+++ b/lessons/autonomous/rule-driven-session-gating.md
@@ -9,7 +9,6 @@ tags:
 - orchestration
 match:
   keywords:
-  - monitoring sessions
   - cost optimization
 ---
 

--- a/lessons/autonomous/scope-discipline-in-autonomous-work.md
+++ b/lessons/autonomous/scope-discipline-in-autonomous-work.md
@@ -5,6 +5,16 @@ match:
   - "discovered tangential improvement opportunity"
   - "also fixed some nearby code while at it"
   - "scope creep during autonomous session"
+  - "scope creep"
+  - "while I'm here"
+  - "bonus improvement"
+  - "bonus commit"
+  - "bonus cleanup"
+  - "bonus fix"
+  - "nice to have"
+  - "convenient fix"
+  - "discovered a related fix"
+  - "out-of-scope improvement"
   - "staying focused on stated objective"
 status: active
 ---

--- a/lessons/tools/greptile-pr-reviews.md
+++ b/lessons/tools/greptile-pr-reviews.md
@@ -3,12 +3,6 @@ match:
   keywords:
     - "greptile score"
     - "trigger greptile"
-    - "run greptile re-review"
-    - "greptile feedback"
-    - "check greptile results"
-    - "greptile found issues in PR"
-    - "greptile quality review"
-    - "improvements since greptile"
   session_categories: [cross-repo, code]
 status: active
 ---

--- a/lessons/workflow/agent-orchestrator-patterns.md
+++ b/lessons/workflow/agent-orchestrator-patterns.md
@@ -4,8 +4,6 @@ match:
   keywords:
     - "orchestrator"
     - "multi-agent"
-    - "agent health"
-    - "peripheral agent"
     - "standup missing"
     - "agent coordination"
     - "inference utilization"

--- a/lessons/workflow/gptme-contrib-contribution-pattern.md
+++ b/lessons/workflow/gptme-contrib-contribution-pattern.md
@@ -1,6 +1,6 @@
 ---
 match:
-  keywords: ["contrib PR", "gptme-contrib PR", "contributing lesson to gptme"]
+  keywords: ["contrib PR"]
   session_categories: [cross-repo, code]
 status: active
 ---

--- a/scripts/check-claude-usage.sh
+++ b/scripts/check-claude-usage.sh
@@ -146,7 +146,7 @@ tmux send-keys -t "$SESSION_NAME" Enter
 # Wait for usage data to render
 for _ in $(seq 1 "$TIMEOUT"); do
     content=$(tmux capture-pane -t "$SESSION_NAME" -p -S -80 2>/dev/null || true)
-    if echo "$content" | grep -qiE '(%\s*used|not enabled|Extra usage|Resets)'; then
+    if echo "$content" | grep -qiE '(Current week \(all models\)|Current week \(Sonnet only\)|not enabled)'; then
         break
     fi
     sleep 1
@@ -159,6 +159,13 @@ OUTPUT=$(tmux capture-pane -t "$SESSION_NAME" -p -S -80 2>/dev/null || true)
 if [ "$MODE" = "raw" ]; then
     echo "$OUTPUT"
     exit 0
+fi
+
+if echo "$OUTPUT" | grep -qi 'Loading usage data' \
+    && ! echo "$OUTPUT" | grep -qiE '(Current week \(all models\)|Current week \(Sonnet only\)|not enabled)'; then
+    echo "Error: Claude /usage never finished loading quota data." >&2
+    echo "Run with --raw to see raw output." >&2
+    exit 3
 fi
 
 # Parse the TUI output

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -35,8 +35,8 @@ Environment:
                     Per-repo path-glob allowlist for files that don't match
                     the generic self-merge categories. Format:
                     "owner/repo:path-glob[,owner/repo:path-glob...]".
-                    Uses PurePosixPath.match() semantics (* does NOT cross
-                    directory boundaries; use ** for recursive matching).
+                    Uses repo-relative segment globs (* stays within one
+                    directory segment; ** matches zero or more directories).
 """
 
 from __future__ import annotations
@@ -49,7 +49,9 @@ import subprocess
 import sys
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
-from pathlib import Path, PurePosixPath
+from fnmatch import fnmatchcase
+from functools import cache
+from pathlib import Path
 from typing import Any, cast
 
 MAX_GRAPHQL_PAGE_SIZE = 100
@@ -654,6 +656,38 @@ def _get_repo_path_allowlist() -> dict[str, list[str]]:
     return _parse_repo_path_allowlist(os.environ.get(SELF_MERGE_ALLOWED_PATHS_ENV))
 
 
+def _path_glob_match(path: str, pattern: str) -> bool:
+    """Match repo-relative paths with shell-style globs.
+
+    `*` stays within one path segment. A standalone `**` segment matches zero or
+    more full directory segments, which keeps the allowlist semantics stable
+    across Python versions and matches normal globstar expectations.
+    """
+    path_parts = tuple(part for part in path.replace("\\", "/").split("/") if part)
+    pattern_parts = tuple(
+        part for part in pattern.replace("\\", "/").split("/") if part
+    )
+
+    @cache
+    def _match(path_index: int, pattern_index: int) -> bool:
+        if pattern_index == len(pattern_parts):
+            return path_index == len(path_parts)
+
+        pattern_part = pattern_parts[pattern_index]
+        if pattern_part == "**":
+            return _match(path_index, pattern_index + 1) or (
+                path_index < len(path_parts) and _match(path_index + 1, pattern_index)
+            )
+
+        if path_index >= len(path_parts):
+            return False
+        if not fnmatchcase(path_parts[path_index], pattern_part):
+            return False
+        return _match(path_index + 1, pattern_index + 1)
+
+    return _match(0, 0)
+
+
 def is_repo_allowlisted_path(
     path: str,
     repo: str | None,
@@ -670,7 +704,7 @@ def is_repo_allowlisted_path(
         return False
     normalized = path.replace("\\", "/")
     return any(
-        PurePosixPath(normalized).match(pattern) for pattern in allowlist.get(repo, [])
+        _path_glob_match(normalized, pattern) for pattern in allowlist.get(repo, [])
     )
 
 

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -43,6 +43,7 @@ import subprocess
 import sys
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
+from fnmatch import fnmatchcase
 from pathlib import Path
 from typing import Any, cast
 
@@ -108,6 +109,7 @@ BOT_CONFIG_FILES = {
     "Makefile",
 }
 BOT_CONFIG_PREFIXES = (".github/",)
+SELF_MERGE_ALLOWED_PATHS_ENV = "SELF_MERGE_ALLOWED_PATHS"
 
 
 @dataclass
@@ -620,6 +622,51 @@ def is_bot_config(path: str) -> bool:
     return path in BOT_CONFIG_FILES or path.startswith(BOT_CONFIG_PREFIXES)
 
 
+def _parse_repo_path_allowlist(value: str | None) -> dict[str, list[str]]:
+    """Parse SELF_MERGE_ALLOWED_PATHS into a repo -> glob patterns mapping.
+
+    Format:
+        owner/repo:path-glob[,owner/repo:path-glob...]
+
+    Both commas and whitespace may separate entries. Invalid entries are ignored.
+    """
+    if value is None:
+        return {}
+    stripped = value.strip()
+    if not stripped:
+        return {}
+
+    mapping: dict[str, list[str]] = {}
+    for entry in stripped.replace(",", " ").split():
+        repo, sep, pattern = entry.partition(":")
+        if not sep or not repo or not pattern:
+            continue
+        mapping.setdefault(repo, []).append(pattern.replace("\\", "/"))
+    return mapping
+
+
+def _get_repo_path_allowlist() -> dict[str, list[str]]:
+    return _parse_repo_path_allowlist(os.environ.get(SELF_MERGE_ALLOWED_PATHS_ENV))
+
+
+def is_repo_allowlisted_path(
+    path: str,
+    repo: str | None,
+    repo_path_allowlist: dict[str, list[str]] | None = None,
+) -> bool:
+    if not repo:
+        return False
+    allowlist = (
+        repo_path_allowlist
+        if repo_path_allowlist is not None
+        else _get_repo_path_allowlist()
+    )
+    if not allowlist:
+        return False
+    normalized = path.replace("\\", "/")
+    return any(fnmatchcase(normalized, pattern) for pattern in allowlist.get(repo, []))
+
+
 def is_sensitive_path(path: str) -> bool:
     normalized = path.lower().replace("\\", "/")
     if normalized.startswith(tuple(p.lower() for p in SENSITIVE_PATH_PREFIXES)):
@@ -642,7 +689,11 @@ def is_sensitive_path(path: str) -> bool:
     return False
 
 
-def is_allowed_file(path: str) -> bool:
+def is_allowed_file(
+    path: str,
+    repo: str | None = None,
+    repo_path_allowlist: dict[str, list[str]] | None = None,
+) -> bool:
     """Check if a file falls into any allowed self-merge category."""
     if is_sensitive_path(path):
         return False
@@ -656,10 +707,13 @@ def is_allowed_file(path: str) -> bool:
         or is_task_metadata(path)
         or is_internal_tooling(path)
         or is_doc_file(path)
+        or is_repo_allowlisted_path(path, repo, repo_path_allowlist)
     )
 
 
-def classify_category(paths: list[str]) -> tuple[str | None, list[str]]:
+def classify_category(
+    paths: list[str], repo: str | None = None
+) -> tuple[str | None, list[str]]:
     """Return the allowed category, or None with disqualifying reasons.
 
     The policy says all changed files must fall into *one of* the allowed
@@ -684,6 +738,8 @@ def classify_category(paths: list[str]) -> tuple[str | None, list[str]]:
         reasons.append("Touches spec-like documentation requiring human review")
         return None, reasons
 
+    repo_path_allowlist = _get_repo_path_allowlist()
+
     # Single-category fast paths
     if all(is_test_file(path) for path in paths):
         return "test-only", reasons
@@ -695,9 +751,13 @@ def classify_category(paths: list[str]) -> tuple[str | None, list[str]]:
         return "internal-tooling", reasons
     if all(is_doc_file(path) for path in paths):
         return "docs-only", reasons
+    if repo and all(
+        is_repo_allowlisted_path(path, repo, repo_path_allowlist) for path in paths
+    ):
+        return f"repo-allowlisted({repo})", reasons
 
     # Mixed-category: eligible if ALL files are in some allowed category
-    if all(is_allowed_file(path) for path in paths):
+    if all(is_allowed_file(path, repo, repo_path_allowlist) for path in paths):
         categories: list[str] = []
         if any(is_test_file(path) for path in paths):
             categories.append("tests")
@@ -709,9 +769,15 @@ def classify_category(paths: list[str]) -> tuple[str | None, list[str]]:
             categories.append("internal-tooling")
         if any(is_doc_file(path) for path in paths):
             categories.append("docs")
+        if repo and any(
+            is_repo_allowlisted_path(path, repo, repo_path_allowlist) for path in paths
+        ):
+            categories.append("repo-paths")
         return f"mixed-allowed({'+'.join(categories)})", reasons
 
-    disqualifying = [p for p in paths if not is_allowed_file(p)]
+    disqualifying = [
+        p for p in paths if not is_allowed_file(p, repo, repo_path_allowlist)
+    ]
     return None, [
         f"Files not in any allowed self-merge category: {', '.join(disqualifying)}"
     ]
@@ -829,7 +895,7 @@ def evaluate_pr(
             f"from: {authors}"
         )
 
-    category, category_reasons = classify_category(files)
+    category, category_reasons = classify_category(files, repo=repo)
     result.category = category
     result.reasons.extend(category_reasons)
 

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -31,6 +31,12 @@ Environment:
                     whitespace-separated. Auto-detected single repo used when
                     unset. Set to empty string to disable the cross-repo
                     restriction entirely.
+    SELF_MERGE_ALLOWED_PATHS
+                    Per-repo path-glob allowlist for files that don't match
+                    the generic self-merge categories. Format:
+                    "owner/repo:path-glob[,owner/repo:path-glob...]".
+                    Uses PurePosixPath.match() semantics (* does NOT cross
+                    directory boundaries; use ** for recursive matching).
 """
 
 from __future__ import annotations
@@ -43,8 +49,7 @@ import subprocess
 import sys
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
-from fnmatch import fnmatchcase
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, cast
 
 MAX_GRAPHQL_PAGE_SIZE = 100
@@ -664,7 +669,9 @@ def is_repo_allowlisted_path(
     if not allowlist:
         return False
     normalized = path.replace("\\", "/")
-    return any(fnmatchcase(normalized, pattern) for pattern in allowlist.get(repo, []))
+    return any(
+        PurePosixPath(normalized).match(pattern) for pattern in allowlist.get(repo, [])
+    )
 
 
 def is_sensitive_path(path: str) -> bool:

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -599,8 +599,7 @@ def test_check_workspace_repo_not_in_allowlist_disqualifies() -> None:
 
 def test_parse_repo_path_allowlist_space_separated() -> None:
     result = self_merge_check._parse_repo_path_allowlist(
-        "TimeToBuildBob/whatdidyougetdone:whatdidyougetdone.py "
-        "OtherOrg/repo:src/*.py"
+        "TimeToBuildBob/whatdidyougetdone:whatdidyougetdone.py OtherOrg/repo:src/*.py"
     )
     assert "TimeToBuildBob/whatdidyougetdone" in result
     assert result["TimeToBuildBob/whatdidyougetdone"] == ["whatdidyougetdone.py"]
@@ -610,8 +609,7 @@ def test_parse_repo_path_allowlist_space_separated() -> None:
 
 def test_parse_repo_path_allowlist_comma_separated() -> None:
     result = self_merge_check._parse_repo_path_allowlist(
-        "TimeToBuildBob/whatdidyougetdone:whatdidyougetdone.py,"
-        "OtherOrg/repo:src/*.py"
+        "TimeToBuildBob/whatdidyougetdone:whatdidyougetdone.py,OtherOrg/repo:src/*.py"
     )
     assert result["TimeToBuildBob/whatdidyougetdone"] == ["whatdidyougetdone.py"]
     assert result["OtherOrg/repo"] == ["src/*.py"]

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -592,3 +592,101 @@ def test_check_workspace_repo_not_in_allowlist_disqualifies() -> None:
     assert "some-other/repo" in reasons[0]
     assert "ErikBjare/bob" in reasons[0]
     assert "gptme/gptme" in reasons[0]
+
+
+# --- repo-path allowlist tests ---
+
+
+def test_parse_repo_path_allowlist_space_separated() -> None:
+    result = self_merge_check._parse_repo_path_allowlist(
+        "TimeToBuildBob/whatdidyougetdone:whatdidyougetdone.py "
+        "OtherOrg/repo:src/*.py"
+    )
+    assert "TimeToBuildBob/whatdidyougetdone" in result
+    assert result["TimeToBuildBob/whatdidyougetdone"] == ["whatdidyougetdone.py"]
+    assert "OtherOrg/repo" in result
+    assert result["OtherOrg/repo"] == ["src/*.py"]
+
+
+def test_parse_repo_path_allowlist_comma_separated() -> None:
+    result = self_merge_check._parse_repo_path_allowlist(
+        "TimeToBuildBob/whatdidyougetdone:whatdidyougetdone.py,"
+        "OtherOrg/repo:src/*.py"
+    )
+    assert result["TimeToBuildBob/whatdidyougetdone"] == ["whatdidyougetdone.py"]
+    assert result["OtherOrg/repo"] == ["src/*.py"]
+
+
+def test_parse_repo_path_allowlist_empty() -> None:
+    assert self_merge_check._parse_repo_path_allowlist("") == {}
+    assert self_merge_check._parse_repo_path_allowlist(None) == {}
+
+
+def test_parse_repo_path_allowlist_invalid_entries_ignored() -> None:
+    # Entries without a colon or with empty sides are skipped
+    result = self_merge_check._parse_repo_path_allowlist(
+        "just-plain-text :orphan_pattern orphan_repo:"
+    )
+    assert result == {}
+
+
+def test_is_repo_allowlisted_path_basic_match() -> None:
+    allowlist = {"TimeToBuildBob/whatdidyougetdone": ["whatdidyougetdone.py"]}
+    assert self_merge_check.is_repo_allowlisted_path(
+        "whatdidyougetdone.py", "TimeToBuildBob/whatdidyougetdone", allowlist
+    )
+    assert not self_merge_check.is_repo_allowlisted_path(
+        "other.py", "TimeToBuildBob/whatdidyougetdone", allowlist
+    )
+
+
+def test_is_repo_allowlisted_path_empty_repo_or_allowlist() -> None:
+    assert not self_merge_check.is_repo_allowlisted_path("f.py", None)
+    assert not self_merge_check.is_repo_allowlisted_path("f.py", "repo", {})
+
+
+def test_is_repo_allowlisted_path_star_does_not_cross_dirs() -> None:
+    """PurePosixPath.match prevents * from crossing directory boundaries."""
+    allowlist = {"repo": ["src/*.py"]}
+    # Should match a file directly in src/
+    assert self_merge_check.is_repo_allowlisted_path("src/main.py", "repo", allowlist)
+    # Should NOT match a file in a subdirectory
+    assert not self_merge_check.is_repo_allowlisted_path(
+        "src/subdir/secret.py", "repo", allowlist
+    )
+
+
+def test_is_repo_allowlisted_path_double_star_crosses_dirs() -> None:
+    """** pattern should match across directory boundaries."""
+    allowlist = {"repo": ["src/**/*.py"]}
+    assert self_merge_check.is_repo_allowlisted_path(
+        "src/subdir/secret.py", "repo", allowlist
+    )
+
+
+def test_classify_repo_allowlisted_path_allowed() -> None:
+    with patch.dict(
+        "os.environ",
+        {
+            "SELF_MERGE_ALLOWED_PATHS": "TimeToBuildBob/whatdidyougetdone:whatdidyougetdone.py"
+        },
+    ):
+        category, reasons = self_merge_check.classify_category(
+            ["whatdidyougetdone.py"], repo="TimeToBuildBob/whatdidyougetdone"
+        )
+        assert category == "repo-allowlisted(TimeToBuildBob/whatdidyougetdone)"
+        assert reasons == []
+
+
+def test_classify_repo_allowlisted_path_is_repo_scoped() -> None:
+    with patch.dict(
+        "os.environ",
+        {
+            "SELF_MERGE_ALLOWED_PATHS": "TimeToBuildBob/whatdidyougetdone:whatdidyougetdone.py"
+        },
+    ):
+        category, reasons = self_merge_check.classify_category(
+            ["whatdidyougetdone.py"], repo="TimeToBuildBob/other-repo"
+        )
+        assert category is None
+        assert any("allowed self-merge category" in reason for reason in reasons)

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -646,7 +646,7 @@ def test_is_repo_allowlisted_path_empty_repo_or_allowlist() -> None:
 
 
 def test_is_repo_allowlisted_path_star_does_not_cross_dirs() -> None:
-    """PurePosixPath.match prevents * from crossing directory boundaries."""
+    """Single-star globs stay within one directory level."""
     allowlist = {"repo": ["src/*.py"]}
     # Should match a file directly in src/
     assert self_merge_check.is_repo_allowlisted_path("src/main.py", "repo", allowlist)
@@ -657,10 +657,14 @@ def test_is_repo_allowlisted_path_star_does_not_cross_dirs() -> None:
 
 
 def test_is_repo_allowlisted_path_double_star_crosses_dirs() -> None:
-    """** pattern should match across directory boundaries."""
+    """Globstar should match zero or more directory segments."""
     allowlist = {"repo": ["src/**/*.py"]}
+    assert self_merge_check.is_repo_allowlisted_path("src/main.py", "repo", allowlist)
     assert self_merge_check.is_repo_allowlisted_path(
         "src/subdir/secret.py", "repo", allowlist
+    )
+    assert self_merge_check.is_repo_allowlisted_path(
+        "src/subdir/deep/nested/main.py", "repo", allowlist
     )
 
 


### PR DESCRIPTION
## Overview
Add `SELF_MERGE_ALLOWED_PATHS` env var support for repo-level path glob allowlists.

## Why
When a self-owned repo has files that don't match the generic docs/tests/internal-tooling self-merge categories (e.g., a main application script like `whatdidyougetdone.py`), there's no way to allow self-merging without either broadening the generic categories or adding a trusted exception. This adds an explicit escape hatch for trusted self-owned repos.

## What
- Add `_parse_repo_path_allowlist()` — parses `owner/repo:path-glob` entries
- Add `is_repo_allowlisted_path()` — fnmatch-based per-repo path matching
- Thread `repo` and allowlist through `classify_category()` and `is_allowed_file()`
- Supported format: `owner/repo:path-glob,owner/repo:path-glob...` (comma or space separated)

## Example usage
```
SELF_MERGE_ALLOWED_PATHS=TimeToBuildBob/whatdidyougetdone:whatdidyougetdone.py,Team/repo:src/*.py
```

## Verification
- [x] Live-tested on PR #5 in TimeToBuildBob/whatdidyougetdone (repo-path allowlist correctly classified the PR as self-merge eligible)
- [x] Pre-commit clean