### PR TITLE
fix(gptme-tts): add explicit backend teardown contract

### DIFF
--- a/packages/gptme-codegraph/README.md
+++ b/packages/gptme-codegraph/README.md
@@ -5,7 +5,8 @@ Structural code retrieval for gptme via [tree-sitter](https://tree-sitter.github
 ## Features
 
 - **9 MCP tools**: `codegraph_parse`, `codegraph_index`, `codegraph_map`, `codegraph_def`, `codegraph_callers`, `codegraph_callees`, `codegraph_refs`, `codegraph_blast`, `codegraph_impact`
-- **Cross-file import resolution** (including `import X as Y`, `from X import Y as Z`, wildcard imports)
+- **Multi-language symbol extraction** for Python, JavaScript/TypeScript, and Rust
+- **Cross-file import resolution** for Python, plus early JS/TS import capture for named and namespace imports
 - **Qualified symbol IDs** (`module::Class.method`) for unambiguous cross-file references
 - **SQLite index cache** — optional persistent cache for large codebases
 - **Blast/impact semantics split**: `blast` = dependency closure (what X needs), `impact` = what breaks if you change X
@@ -30,6 +31,7 @@ uv add gptme-codegraph[treesitter,mcp]
 ```bash
 # Extract symbols from a file
 gptme-codegraph path/to/file.py parse
+gptme-codegraph path/to/file.ts parse
 
 # Who calls a function?
 gptme-codegraph path/to/file.py callers my_function
@@ -89,6 +91,9 @@ print(radius)  # {"depth_0": {…}, "depth_1": {…}, …}
 
 ## Status
 
-Experimental package — Python only (v0). Multi-language support planned for v1.1.
+Experimental package — Python support is the deepest path today, with Phase 1
+JavaScript/TypeScript and Rust extraction now wired into the same surface.
+Cross-file resolution remains strongest on Python; JS/TS import handling is
+currently best-effort rather than fully semantic.
 
 > Namespace packages (`import google.cloud.storage` without `__init__.py`) are a known v1.1 gap.

--- a/packages/gptme-codegraph/pyproject.toml
+++ b/packages/gptme-codegraph/pyproject.toml
@@ -13,6 +13,9 @@ dependencies = []
 treesitter = [
     "tree-sitter>=0.21.0",
     "tree-sitter-python>=0.21.0",
+    "tree-sitter-javascript>=0.21.0",
+    "tree-sitter-typescript>=0.23.0",
+    "tree-sitter-rust>=0.24.0",
 ]
 mcp = [
     "mcp>=1.0.0",

--- a/packages/gptme-codegraph/src/gptme_codegraph/core.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/core.py
@@ -3,20 +3,19 @@
 Complementary to gptme-rag (text chunks), this retrieves code *structure*:
 function/class definitions, call graphs, and blast radius.
 
-v0: In-memory, single-file Python only. Tree-sitter grammars are the
-bottleneck (one per language). This prototype proves the concept before
-committing to SQLite + multi-language + persistent indexing.
+Supports Python, TypeScript/JavaScript, and Rust via tree-sitter grammars.
+To add a new language: add grammar dep to pyproject.toml, extend _LANG_MAP
+and _load_language, then add extractor functions.
 
 Usage:
-    gptme-codegraph <file.py> parse           # Extract symbols
-    gptme-codegraph <file.py> callers <name>  # Who calls X?
-    gptme-codegraph <file.py> callees <name>  # What does X call?
-    python3 scripts/codegraph.py <file.py> deps <name>     # Dependency closure (what X needs)
-    python3 scripts/codegraph.py <file.py> impact <name>   # Impact radius (what needs X)
-    python3 scripts/codegraph.py <file.py> blast <name>    # [deprecated] alias for deps
-    python3 scripts/codegraph.py <file.py> def <name>      # Where is X defined?
-    python3 scripts/codegraph.py <file.py> refs <name>     # Where is X referenced?
-    gptme-codegraph <repo-or-file> map                      # Token-cheap repo skeleton
+    gptme-codegraph <file> parse           # Extract symbols
+    gptme-codegraph <file> callers <name>  # Who calls X?
+    gptme-codegraph <file> callees <name>  # What does X call?
+    python3 scripts/codegraph.py <file> deps <name>     # Dependency closure
+    python3 scripts/codegraph.py <file> impact <name>   # Impact radius
+    python3 scripts/codegraph.py <file> def <name>      # Where is X defined?
+    python3 scripts/codegraph.py <file> refs <name>     # Where is X referenced?
+    gptme-codegraph <repo-or-file> map                  # Token-cheap repo skeleton
 """
 
 from __future__ import annotations
@@ -32,6 +31,83 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import cast
+
+# ---------------------------------------------------------------------------
+# Language mapping
+# ---------------------------------------------------------------------------
+
+_LANG_MAP: dict[str, str] = {
+    ".py": "python",
+    ".ts": "typescript",
+    ".tsx": "tsx",
+    ".js": "javascript",
+    ".jsx": "javascript",
+    ".mjs": "javascript",
+    ".cjs": "javascript",
+    ".rs": "rust",
+}
+
+_SOURCE_EXTENSIONS: tuple[str, ...] = tuple(_LANG_MAP.keys())
+
+
+def _detect_language(filepath: Path) -> str | None:
+    """Detect the tree-sitter language name from a file extension."""
+    suffix = filepath.suffix
+    if suffix in _LANG_MAP:
+        return _LANG_MAP[suffix]
+    # Try double extension (.d.ts → .ts)
+    if len(filepath.suffixes) >= 2:
+        double = filepath.suffixes[-2] + suffix
+        if double in _LANG_MAP:
+            return _LANG_MAP[double]
+    return None
+
+
+def _load_language(name: str):
+    """Load a tree-sitter Language for the given name.
+
+    Returns None if the grammar is not installed.
+    """
+    from tree_sitter import Language  # type: ignore[import-untyped,unused-ignore]
+
+    # Lazy import each grammar; missing grammars silently return None
+    grammar_map: dict[str, object] = {}
+    try:
+        import tree_sitter_python as tspython  # type: ignore[import-not-found,unused-ignore]
+
+        grammar_map["python"] = tspython.language()
+    except ImportError:
+        pass
+    try:
+        import tree_sitter_typescript as tstypescript  # type: ignore[import-not-found,unused-ignore]
+
+        grammar_map["typescript"] = tstypescript.language_typescript()
+        grammar_map["tsx"] = tstypescript.language_tsx()
+    except ImportError:
+        pass
+    try:
+        import tree_sitter_javascript as tsjavascript  # type: ignore[import-not-found,unused-ignore]
+
+        grammar_map["javascript"] = tsjavascript.language()
+    except ImportError:
+        pass
+    try:
+        import tree_sitter_rust as tsrust  # type: ignore[import-not-found,unused-ignore]
+
+        grammar_map["rust"] = tsrust.language()
+    except ImportError:
+        pass
+
+    lang = grammar_map.get(name)
+    if lang is None:
+        # Fallback: tsx → typescript
+        if name == "tsx":
+            lang = grammar_map.get("typescript")
+        elif name == "jsx":
+            lang = grammar_map.get("javascript")
+    if lang is None:
+        return None
+    return Language(lang)
 
 
 def _module_path(filepath: str, directory: str | None = None) -> str:
@@ -84,7 +160,7 @@ class IndexEntry:
 
 @dataclass
 class ImportInfo:
-    """A single import in a Python file.
+    """A single import in a source file.
 
     Naming conventions:
     - ``name`` is the *original imported name* as written in the source.
@@ -142,31 +218,42 @@ class SymbolIndex:
         return self.imports.get(filepath, [])
 
 
-def _iter_python_files(directory: Path) -> list[Path]:
-    """Return Python source files under ``directory``, skipping junk dirs.
+def _iter_source_files(directory: Path) -> list[Path]:
+    """Return source files under ``directory``, skipping junk dirs.
 
     Uses ``git ls-files`` when the directory is a git repository, falling
     back to ``rglob`` for non-git directories or when git is unavailable.
+    Supports Python, TypeScript/JavaScript, and Rust.
     """
     # When directory is a git repo, use git ls-files — faster and avoids
     # vendored deps (node_modules, .venv, etc.) and generated files.
     git_dir = directory / ".git"
     if git_dir.exists() and git_dir.is_dir():
         try:
-            result = subprocess.run(
-                ["git", "ls-files", "*.py"],
-                cwd=directory,
-                capture_output=True,
-                text=True,
-                timeout=15,
-            )
-            if result.returncode == 0 and result.stdout.strip():
-                return [directory / p for p in result.stdout.strip().split("\n") if p]
+            all_files: set[Path] = set()
+            for pattern in (f"*{ext}" for ext in _SOURCE_EXTENSIONS):
+                result = subprocess.run(
+                    ["git", "ls-files", pattern],
+                    cwd=directory,
+                    capture_output=True,
+                    text=True,
+                    timeout=15,
+                )
+                if result.returncode == 0 and result.stdout.strip():
+                    all_files.update(
+                        directory / p for p in result.stdout.strip().split("\n") if p
+                    )
+            if all_files:
+                return sorted(all_files)
         except (subprocess.TimeoutExpired, FileNotFoundError):
             pass
 
     files: list[Path] = []
-    for fp in sorted(directory.rglob("*.py")):
+    for fp in sorted(directory.rglob("*")):
+        if not fp.suffix:
+            continue
+        if _detect_language(fp) is None:
+            continue
         parts = fp.relative_to(directory).parts
         if any(
             p.startswith(".") or p in ("__pycache__", "node_modules", ".git")
@@ -298,7 +385,7 @@ class SqliteIndexCache:
         Returns True if:
         - The database has entries for this directory
         - All indexed files still exist and have the same mtime
-        - No new Python files exist in the directory
+        - No new supported source files exist in the directory
         """
         conn = self._connect()
         self._init_schema()
@@ -327,8 +414,8 @@ class SqliteIndexCache:
             if _file_mtime(fp) != cached_mtime:
                 return False
 
-        # Check that no new Python files appeared
-        for fp in dir_path.rglob("*.py"):
+        # Check that no new supported source files appeared
+        for fp in _iter_source_files(dir_path):
             if str(fp.resolve()) not in tracked:
                 return False
 
@@ -385,9 +472,9 @@ class SqliteIndexCache:
                 (fp_str, _file_mtime(fp), self._directory),
             )
 
-        # Also track all Python files to detect new files on freshness check
+        # Also track all supported source files to detect new files on freshness check
         dir_path = Path(self._directory)
-        for fp in dir_path.rglob("*.py"):
+        for fp in _iter_source_files(dir_path):
             fp_str = str(fp.resolve())
             if fp_str not in seen_files:
                 conn.execute(
@@ -482,7 +569,7 @@ class Symbol:
 
 @dataclass
 class FileParseResult:
-    """Result of parsing a single Python file."""
+    """Result of parsing a single source file."""
 
     symbols: list[Symbol] = field(default_factory=list)
     imports: list[ImportInfo] = field(default_factory=list)
@@ -491,18 +578,16 @@ class FileParseResult:
 def _tree_sitter_parse(code: bytes, lang_name: str = "python"):
     """Parse source code with tree-sitter and return the root node.
 
-    Falls back gracefully if tree-sitter is not installed or the grammar
-    is unavailable. Returns (root_node, parser) on success.
+    Falls back gracefully if tree-sitter or the grammar is unavailable.
+    Returns (root_node, parser) on success.
     """
     try:
-        import tree_sitter_python as tspython  # type: ignore[import-not-found,unused-ignore]
-        from tree_sitter import (  # type: ignore[import-untyped,unused-ignore]
-            Language,
-            Parser,
-        )
+        from tree_sitter import Parser  # type: ignore[import-untyped,unused-ignore]
 
         parser = Parser()
-        language = Language(tspython.language())
+        language = _load_language(lang_name)
+        if language is None:
+            return None, None
         parser.language = language
         tree = parser.parse(code)
         if tree is None:
@@ -544,7 +629,7 @@ def _extract_calls(node) -> list[str]:
         cursor = node.walk()
         reached_root = False
         while not reached_root:
-            if cursor.node.type == "call":
+            if cursor.node.type in {"call", "call_expression"}:
                 func_node = cursor.node.child_by_field_name("function")
                 if func_node:
                     calls.append(_text(func_node))
@@ -562,6 +647,13 @@ def _extract_calls(node) -> list[str]:
     except Exception:
         pass
     return calls
+
+
+def _strip_string_quotes(text: str) -> str:
+    """Return a string literal without its outer quote characters."""
+    if len(text) >= 2 and text[0] == text[-1] and text[0] in {'"', "'"}:
+        return text[1:-1]
+    return text
 
 
 def _extract_imports(root) -> list[ImportInfo]:
@@ -660,61 +752,372 @@ def _extract_imports(root) -> list[ImportInfo]:
     return imports
 
 
+def _extract_imports_javascript(root) -> list[ImportInfo]:
+    """Extract import statements from JavaScript/TypeScript code.
+
+    Phase 1 keeps the mapping intentionally simple:
+    - named imports preserve original names and aliases
+    - namespace imports resolve dotted calls like ``util.foo()``
+    - default imports map the local binding directly as a best-effort guess
+    """
+    imports: list[ImportInfo] = []
+    try:
+        for node in root.named_children:
+            if node.type != "import_statement":
+                continue
+
+            source_node = next(
+                (child for child in node.named_children if child.type == "string"),
+                None,
+            )
+            clause_node = next(
+                (
+                    child
+                    for child in node.named_children
+                    if child.type == "import_clause"
+                ),
+                None,
+            )
+            if source_node is None or clause_node is None:
+                continue
+
+            module = _strip_string_quotes(_text(source_node))
+            for child in clause_node.named_children:
+                if child.type == "identifier":
+                    local_name = _text(child)
+                    imports.append(
+                        ImportInfo(
+                            file="",
+                            name=local_name,
+                            module=module,
+                            is_from=True,
+                        )
+                    )
+                elif child.type == "named_imports":
+                    for specifier in child.named_children:
+                        if specifier.type != "import_specifier":
+                            continue
+                        name_node = specifier.child_by_field_name("name")
+                        alias_node = specifier.child_by_field_name("alias")
+                        name = _text(name_node) if name_node else ""
+                        alias = _text(alias_node) if alias_node else None
+                        imports.append(
+                            ImportInfo(
+                                file="",
+                                name=name,
+                                module=module,
+                                is_from=True,
+                                alias=alias,
+                            )
+                        )
+                elif child.type == "namespace_import":
+                    alias = next(
+                        (
+                            _text(grandchild)
+                            for grandchild in child.named_children
+                            if grandchild.type == "identifier"
+                        ),
+                        None,
+                    )
+                    imports.append(
+                        ImportInfo(
+                            file="",
+                            name=module.split("/")[-1] or module,
+                            module=module,
+                            is_from=False,
+                            alias=alias,
+                        )
+                    )
+    except Exception:
+        pass
+    return imports
+
+
+# ---------------------------------------------------------------------------
+# TypeScript / JavaScript extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_symbols_typescript(root, filepath: str) -> list[Symbol]:
+    """Extract functions, classes, and methods from a TS/JS parse tree."""
+    symbols: list[Symbol] = []
+
+    def _text_ts(node) -> str:
+        try:
+            return node.text.decode("utf-8") if node.text else ""
+        except Exception:
+            return ""
+
+    def walk(node, parent_class: str | None = None):
+        if node.type in ("function_declaration", "method_definition"):
+            name_node = node.child_by_field_name("name")
+            body_node = node.child_by_field_name("body")
+            if name_node:
+                name = _text_ts(name_node)
+                kind = "method" if parent_class else "function"
+                calls = _extract_calls(body_node) if body_node else []
+                symbols.append(
+                    Symbol(
+                        name=name,
+                        kind=kind,
+                        file=filepath,
+                        start_line=node.start_point[0] + 1,
+                        end_line=node.end_point[0] + 1,
+                        parent_class=parent_class,
+                        calls=list(set(calls)),
+                    )
+                )
+            return
+        elif node.type == "class_declaration":
+            name_node = node.child_by_field_name("name")
+            if name_node:
+                name = _text_ts(name_node)
+                symbols.append(
+                    Symbol(
+                        name=name,
+                        kind="class",
+                        file=filepath,
+                        start_line=node.start_point[0] + 1,
+                        end_line=node.end_point[0] + 1,
+                    )
+                )
+                body_node = node.child_by_field_name("body")
+                if body_node:
+                    for child in body_node.named_children:
+                        walk(child, parent_class=name)
+            return
+        elif node.type in ("lexical_declaration", "variable_declaration"):
+            # Handle arrow functions assigned to const/let/var:
+            # const foo = (x) => { ... }
+            for child in node.named_children:
+                if child.type == "variable_declarator":
+                    name_node = child.child_by_field_name("name")
+                    value_node = child.child_by_field_name("value")
+                    if (
+                        name_node
+                        and value_node
+                        and value_node.type
+                        in (
+                            "arrow_function",
+                            "function_expression",
+                        )
+                    ):
+                        name = _text_ts(name_node)
+                        body_node = value_node.child_by_field_name("body")
+                        calls = _extract_calls(body_node) if body_node else []
+                        symbols.append(
+                            Symbol(
+                                name=name,
+                                kind="function",
+                                file=filepath,
+                                start_line=child.start_point[0] + 1,
+                                end_line=child.end_point[0] + 1,
+                                calls=list(set(calls)),
+                            )
+                        )
+            return
+        elif node.type == "export_statement":
+            # export function / class / const
+            for child in node.named_children:
+                walk(child, parent_class)
+            return
+
+        # Recurse into children
+        for child in node.named_children:
+            walk(child, parent_class)
+
+    walk(root)
+    return symbols
+
+
+# ---------------------------------------------------------------------------
+# Rust extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_symbols_rust(root, filepath: str) -> list[Symbol]:
+    """Extract functions, structs, enums, traits, and impl blocks from a Rust parse tree."""
+    symbols: list[Symbol] = []
+
+    def _text_rs(node) -> str:
+        try:
+            return node.text.decode("utf-8") if node.text else ""
+        except Exception:
+            return ""
+
+    def walk(node, parent_scope: str | None = None, parent_kind: str | None = None):
+        if node.type == "function_item":
+            name_node = node.child_by_field_name("name")
+            if name_node:
+                name = _text_rs(name_node)
+                # Determine kind: methods are inside impl_item
+                kind = "method" if parent_kind == "impl" else "function"
+                parent_class = parent_scope if kind == "method" else None
+                symbols.append(
+                    Symbol(
+                        name=name,
+                        kind=kind,
+                        file=filepath,
+                        start_line=node.start_point[0] + 1,
+                        end_line=node.end_point[0] + 1,
+                        parent_class=parent_class,
+                    )
+                )
+            return
+        elif node.type == "function_signature_item" and parent_kind == "trait":
+            name_node = node.child_by_field_name("name")
+            if name_node:
+                symbols.append(
+                    Symbol(
+                        name=_text_rs(name_node),
+                        kind="method",
+                        file=filepath,
+                        start_line=node.start_point[0] + 1,
+                        end_line=node.end_point[0] + 1,
+                        parent_class=parent_scope,
+                    )
+                )
+            return
+        elif node.type == "struct_item":
+            name_node = node.child_by_field_name("name")
+            if name_node:
+                symbols.append(
+                    Symbol(
+                        name=_text_rs(name_node),
+                        kind="class",
+                        file=filepath,
+                        start_line=node.start_point[0] + 1,
+                        end_line=node.end_point[0] + 1,
+                    )
+                )
+            return
+        elif node.type == "enum_item":
+            name_node = node.child_by_field_name("name")
+            if name_node:
+                symbols.append(
+                    Symbol(
+                        name=_text_rs(name_node),
+                        kind="class",
+                        file=filepath,
+                        start_line=node.start_point[0] + 1,
+                        end_line=node.end_point[0] + 1,
+                    )
+                )
+            return
+        elif node.type == "trait_item":
+            name_node = node.child_by_field_name("name")
+            if name_node:
+                trait_name = _text_rs(name_node)
+                symbols.append(
+                    Symbol(
+                        name=trait_name,
+                        kind="class",
+                        file=filepath,
+                        start_line=node.start_point[0] + 1,
+                        end_line=node.end_point[0] + 1,
+                    )
+                )
+                for child in node.named_children:
+                    walk(child, parent_scope=trait_name, parent_kind="trait")
+            return
+        elif node.type == "impl_item":
+            # impl Foo { fn method() ... } → methods get parent_class="Foo"
+            type_node = node.child_by_field_name("type")
+            scope_name = None
+            if type_node:
+                scope_name = _text_rs(type_node)
+            for child in node.named_children:
+                walk(child, parent_scope=scope_name, parent_kind="impl")
+            return
+
+        for child in node.named_children:
+            walk(child, parent_scope, parent_kind)
+
+    walk(root)
+    return symbols
+
+
+# ---------------------------------------------------------------------------
+# Multi-language parse_file
+# ---------------------------------------------------------------------------
+
+
 def parse_file(filepath: Path) -> FileParseResult:
-    """Extract all symbols and imports from a Python file."""
+    """Extract all symbols and imports from a source file.
+
+    Detects language from file extension and dispatches to the correct
+    tree-sitter grammar. Supports Python, TypeScript/JavaScript, and Rust.
+    """
     code = filepath.read_bytes()
-    root, _parser = _tree_sitter_parse(code)
+    lang_name = _detect_language(filepath)
+    if lang_name is None:
+        return FileParseResult()
+    root, _parser = _tree_sitter_parse(code, lang_name)
     if root is None:
         return FileParseResult()
 
     filename = str(filepath)
     symbols: list[Symbol] = []
 
-    def walk(node, parent_class: str | None = None):
-        if node.type == "function_definition":
-            name_node = node.child_by_field_name("name")
-            body_node = node.child_by_field_name("body")
-            if name_node:
-                name = _text(name_node)
-                calls = _extract_calls(body_node) if body_node else []
-                docstring = _extract_docstring(body_node) if body_node else None
-                kind = "method" if parent_class else "function"
-                symbols.append(
-                    Symbol(
-                        name=name,
-                        kind=kind,
-                        file=filename,
-                        start_line=node.start_point[0] + 1,
-                        end_line=node.end_point[0] + 1,
-                        parent_class=parent_class,
-                        docstring=docstring,
-                        calls=list(set(calls)),
-                    )
-                )
-        elif node.type == "class_definition":
-            name_node = node.child_by_field_name("name")
-            body_node = node.child_by_field_name("body")
-            if name_node:
-                name = _text(name_node)
-                docstring = _extract_docstring(body_node) if body_node else None
-                symbols.append(
-                    Symbol(
-                        name=name,
-                        kind="class",
-                        file=filename,
-                        start_line=node.start_point[0] + 1,
-                        end_line=node.end_point[0] + 1,
-                        docstring=docstring,
-                    )
-                )
-                if body_node:
-                    for child in body_node.named_children:
-                        walk(child, parent_class=name)
+    if lang_name == "python":
+        # --- Python extraction (existing logic) ---
 
-    for child in root.named_children:
-        walk(child)
+        def walk(node, parent_class: str | None = None):
+            if node.type == "function_definition":
+                name_node = node.child_by_field_name("name")
+                body_node = node.child_by_field_name("body")
+                if name_node:
+                    name = _text(name_node)
+                    calls = _extract_calls(body_node) if body_node else []
+                    docstring = _extract_docstring(body_node) if body_node else None
+                    kind = "method" if parent_class else "function"
+                    symbols.append(
+                        Symbol(
+                            name=name,
+                            kind=kind,
+                            file=filename,
+                            start_line=node.start_point[0] + 1,
+                            end_line=node.end_point[0] + 1,
+                            parent_class=parent_class,
+                            docstring=docstring,
+                            calls=list(set(calls)),
+                        )
+                    )
+            elif node.type == "class_definition":
+                name_node = node.child_by_field_name("name")
+                body_node = node.child_by_field_name("body")
+                if name_node:
+                    name = _text(name_node)
+                    docstring = _extract_docstring(body_node) if body_node else None
+                    symbols.append(
+                        Symbol(
+                            name=name,
+                            kind="class",
+                            file=filename,
+                            start_line=node.start_point[0] + 1,
+                            end_line=node.end_point[0] + 1,
+                            docstring=docstring,
+                        )
+                    )
+                    if body_node:
+                        for child in body_node.named_children:
+                            walk(child, parent_class=name)
 
-    imports = _extract_imports(root)
+        for child in root.named_children:
+            walk(child)
+
+    elif lang_name in ("typescript", "javascript", "tsx"):
+        symbols = _extract_symbols_typescript(root, filename)
+
+    elif lang_name == "rust":
+        symbols = _extract_symbols_rust(root, filename)
+
+    imports: list[ImportInfo] = []
+    if lang_name == "python":
+        imports = _extract_imports(root)
+    elif lang_name in ("typescript", "javascript", "tsx"):
+        imports = _extract_imports_javascript(root)
+
     for imp in imports:
         imp.file = filename
 
@@ -722,7 +1125,7 @@ def parse_file(filepath: Path) -> FileParseResult:
 
 
 def extract_symbols(filepath: Path) -> list[Symbol]:
-    """Extract all symbols (functions, classes) from a Python file.
+    """Extract all symbols (functions, classes) from a source file.
 
     Returns a list of Symbol objects with names, locations, docstrings,
     and call graphs. (Convenience wrapper around parse_file.)
@@ -731,15 +1134,11 @@ def extract_symbols(filepath: Path) -> list[Symbol]:
 
 
 def build_index(directory: str | Path) -> SymbolIndex:
-    """Build a cross-file symbol index for all Python files in a directory.
-
-    Scans all ``.py`` files recursively, extracts symbols and imports, and
-    creates an ``IndexEntry`` for each symbol and ``ImportInfo`` for each import.
-    """
+    """Build a cross-file symbol index for supported source files in a directory."""
     index = SymbolIndex()
     directory = Path(directory)
     dir_str = str(directory)
-    for fp in _iter_python_files(directory):
+    for fp in _iter_source_files(directory):
         result = parse_file(fp)
         mp = _module_path(str(fp), dir_str)
         for sym in result.symbols:
@@ -1102,7 +1501,7 @@ def build_repo_map(
 ) -> dict[str, object]:
     """Build a token-cheap repo skeleton grouped by file and class."""
     root = Path(directory)
-    files = _iter_python_files(root)
+    files = _iter_source_files(root)
     file_rows: list[dict[str, object]] = []
     total_symbols = 0
 
@@ -1251,7 +1650,7 @@ def main():
     parser = argparse.ArgumentParser(
         description="Structural code retrieval via tree-sitter"
     )
-    parser.add_argument("file", help="Python file to analyze")
+    parser.add_argument("file", help="Source file or directory to analyze")
     parser.add_argument(
         "--directory",
         help="Cross-file index directory (enables cross-file lookups)",

--- a/packages/gptme-codegraph/src/gptme_codegraph/core.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/core.py
@@ -1493,6 +1493,23 @@ def _clip_outline(
     return clipped, shown
 
 
+def _repo_map_path_penalty(rel_path: str) -> int:
+    """Prefer production code over test-heavy files in repo-map ranking."""
+    path = Path(rel_path)
+    stem = path.stem.lower()
+    dir_parts = {part.lower() for part in path.parts[:-1]}
+
+    if dir_parts & {"test", "tests", "__tests__"}:
+        return 1
+    if stem == "conftest":
+        return 1
+    if stem.startswith("test_") or stem.endswith("_test"):
+        return 1
+    if stem.endswith(".test") or stem.endswith(".spec") or stem.endswith("_spec"):
+        return 1
+    return 0
+
+
 def build_repo_map(
     directory: str | Path,
     *,
@@ -1522,7 +1539,11 @@ def build_repo_map(
         )
 
     file_rows.sort(
-        key=lambda row: (-cast(int, row["symbol_count"]), str(row["path"])),
+        key=lambda row: (
+            _repo_map_path_penalty(str(row["path"])),
+            -cast(int, row["symbol_count"]),
+            str(row["path"]),
+        ),
     )
 
     shown_rows = file_rows[: max(0, max_files)]

--- a/packages/gptme-codegraph/tests/test_codegraph.py
+++ b/packages/gptme-codegraph/tests/test_codegraph.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import json
 import tempfile
 from collections.abc import Generator
@@ -28,6 +29,25 @@ from gptme_codegraph.core import (
     format_symbols,
     impact_radius,
     parse_file,
+)
+
+
+def _has_grammar(module: str) -> bool:
+    """Return True when an optional tree-sitter grammar is importable."""
+    try:
+        importlib.import_module(module)
+        return True
+    except ImportError:
+        return False
+
+
+_skip_no_js = pytest.mark.skipif(
+    not _has_grammar("tree_sitter_javascript"),
+    reason="tree-sitter-javascript not installed",
+)
+_skip_no_ts = pytest.mark.skipif(
+    not _has_grammar("tree_sitter_typescript"),
+    reason="tree-sitter-typescript not installed",
 )
 
 # ---------------------------------------------------------------------------
@@ -118,6 +138,62 @@ class DataProcessor:
     path.unlink(missing_ok=True)
 
 
+@pytest.fixture
+def javascript_module() -> Generator[Path, None, None]:
+    """A JavaScript module with top-level functions, arrow functions, and a class."""
+    code = """
+export function greet(name) {
+    return helper(name)
+}
+
+const helper = (value) => value.trim()
+
+class User {
+    speak() {
+        return greet(this.name)
+    }
+}
+"""
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".js", delete=False, prefix="test_js_"
+    ) as f:
+        f.write(code)
+        path = Path(f.name)
+    yield path
+    path.unlink(missing_ok=True)
+
+
+@pytest.fixture
+def typescript_module() -> Generator[Path, None, None]:
+    """A TypeScript module with typed functions and methods."""
+    code = """
+export function greet(name: string): string {
+    return helper(name)
+}
+
+const helper = (value: string) => value.trim()
+
+class User {
+    name: string
+
+    constructor(name: string) {
+        this.name = name
+    }
+
+    speak(): string {
+        return greet(this.name)
+    }
+}
+"""
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".ts", delete=False, prefix="test_ts_"
+    ) as f:
+        f.write(code)
+        path = Path(f.name)
+    yield path
+    path.unlink(missing_ok=True)
+
+
 # ---------------------------------------------------------------------------
 # Symbol extraction
 # ---------------------------------------------------------------------------
@@ -192,6 +268,40 @@ def test_extract_symbols_class_only(class_only_module: Path):
     assert len(funcs) == 0
     methods = [s for s in symbols if s.kind == "method"]
     assert len(methods) == 2
+
+
+@_skip_no_js
+def test_extract_symbols_javascript_calls_and_methods(javascript_module: Path):
+    symbols = extract_symbols(javascript_module)
+    names = {s.name for s in symbols}
+    assert {"greet", "helper", "User", "speak"} <= names
+
+    greet = next(s for s in symbols if s.name == "greet")
+    helper = next(s for s in symbols if s.name == "helper")
+    speak = next(s for s in symbols if s.name == "speak")
+
+    assert helper.kind == "function"
+    assert speak.kind == "method"
+    assert speak.parent_class == "User"
+    assert "helper" in greet.calls
+    assert "greet" in speak.calls
+
+
+@_skip_no_ts
+def test_extract_symbols_typescript_calls_and_constructor(typescript_module: Path):
+    symbols = extract_symbols(typescript_module)
+    names = {s.name for s in symbols}
+    assert {"greet", "helper", "User", "constructor", "speak"} <= names
+
+    constructor = next(s for s in symbols if s.name == "constructor")
+    speak = next(s for s in symbols if s.name == "speak")
+    greet = next(s for s in symbols if s.name == "greet")
+
+    assert constructor.kind == "method"
+    assert constructor.parent_class == "User"
+    assert speak.parent_class == "User"
+    assert "helper" in greet.calls
+    assert "greet" in speak.calls
 
 
 def test_extract_symbols_kind_distribution(simple_module: Path):
@@ -428,6 +538,46 @@ def test_build_repo_map_groups_class_methods(multi_file_project: Path):
     }
     assert "__init__" in method_names
     assert "greet" in method_names
+
+
+@_skip_no_js
+@_skip_no_ts
+def test_build_repo_map_mixed_language_sources(tmp_path: Path):
+    """Repo-map should count and outline non-Python source files too."""
+    (tmp_path / "web.ts").write_text(
+        """
+export function render(name: string): string {
+    return helper(name)
+}
+
+const helper = (value: string) => value.trim()
+"""
+    )
+    (tmp_path / "api.js").write_text(
+        """
+export function handle(req) {
+    return normalize(req)
+}
+
+const normalize = (req) => req
+"""
+    )
+
+    repo_map = build_repo_map(tmp_path, max_files=10, max_symbols_per_file=10)
+    assert repo_map["files_scanned"] == 2
+    assert repo_map["files_with_symbols"] == 2
+
+    files = cast(list[dict[str, object]], repo_map["files"])
+    paths = {cast(str, row["path"]) for row in files}
+    assert {"web.ts", "api.js"} <= paths
+
+    web_outline = next(
+        cast(list[dict[str, object]], row["outline"])
+        for row in files
+        if row["path"] == "web.ts"
+    )
+    assert any(entry["name"] == "render" for entry in web_outline)
+    assert any(entry["name"] == "helper" for entry in web_outline)
 
 
 def test_format_repo_map_human_readable(multi_file_project: Path):

--- a/packages/gptme-codegraph/tests/test_codegraph.py
+++ b/packages/gptme-codegraph/tests/test_codegraph.py
@@ -580,6 +580,49 @@ const normalize = (req) => req
     assert any(entry["name"] == "helper" for entry in web_outline)
 
 
+def test_build_repo_map_prefers_production_files_over_tests(tmp_path: Path):
+    """Repo-map ranking should not let oversized test files crowd out source."""
+    src_dir = tmp_path / "src"
+    tests_dir = tmp_path / "tests"
+    src_dir.mkdir()
+    tests_dir.mkdir()
+
+    (src_dir / "app.py").write_text(
+        """
+def run_app() -> str:
+    return helper()
+
+
+def helper() -> str:
+    return "ok"
+"""
+    )
+    (tests_dir / "test_app.py").write_text(
+        """
+def test_one():
+    return 1
+
+
+def test_two():
+    return 2
+
+
+def test_three():
+    return 3
+
+
+def test_four():
+    return 4
+"""
+    )
+
+    repo_map = build_repo_map(tmp_path, max_files=2, max_symbols_per_file=10)
+    files = cast(list[dict[str, object]], repo_map["files"])
+
+    assert cast(str, files[0]["path"]) == "src/app.py"
+    assert cast(str, files[1]["path"]) == "tests/test_app.py"
+
+
 def test_format_repo_map_human_readable(multi_file_project: Path):
     """Repo-map formatter should emit a compact outline."""
     repo_map = build_repo_map(multi_file_project, max_files=2, max_symbols_per_file=2)

--- a/packages/gptme-codegraph/tests/test_codegraph_imports.py
+++ b/packages/gptme-codegraph/tests/test_codegraph_imports.py
@@ -6,13 +6,30 @@ knowledge/research/2026-05-03-codegraph-productization-roadmap.md item #4.
 
 from __future__ import annotations
 
+import importlib
 from pathlib import Path
 
+import pytest
 from gptme_codegraph.core import (
     _extract_imports,
     _tree_sitter_parse,
     build_cross_file_call_graph,
     build_index,
+)
+
+
+def _has_grammar(module: str) -> bool:
+    """Return True when an optional tree-sitter grammar is importable."""
+    try:
+        importlib.import_module(module)
+        return True
+    except ImportError:
+        return False
+
+
+_skip_no_js = pytest.mark.skipif(
+    not _has_grammar("tree_sitter_javascript"),
+    reason="tree-sitter-javascript not installed",
 )
 
 # ---------------------------------------------------------------------------
@@ -68,6 +85,42 @@ def test_dotted_module_alias(tmp_path: Path):
         f"Expected aliased dotted import; got "
         f"{[(i.name, i.module, i.alias) for i in imports]}"
     )
+
+
+@_skip_no_js
+def test_javascript_named_import_alias_resolves_call(tmp_path: Path):
+    """`import { trimName as normalize } ...; normalize()` resolves cross-file."""
+    (tmp_path / "helpers.js").write_text(
+        "export function trimName(name) { return name.trim() }\n"
+    )
+    (tmp_path / "main.js").write_text(
+        'import { trimName as normalize } from "./helpers.js";\n'
+        "function run(name) { return normalize(name) }\n"
+    )
+
+    index = build_index(tmp_path)
+    callees, callers = build_cross_file_call_graph(index, tmp_path)
+
+    assert "helpers::trimName" in callees.get("main::run", set())
+    assert "main::run" in callers.get("helpers::trimName", set())
+
+
+@_skip_no_js
+def test_javascript_namespace_import_resolves_dotted_call(tmp_path: Path):
+    """`import * as helpers ...; helpers.trimName()` resolves cross-file."""
+    (tmp_path / "helpers.js").write_text(
+        "export function trimName(name) { return name.trim() }\n"
+    )
+    (tmp_path / "main.js").write_text(
+        'import * as helpers from "./helpers.js";\n'
+        "function run(name) { return helpers.trimName(name) }\n"
+    )
+
+    index = build_index(tmp_path)
+    callees, callers = build_cross_file_call_graph(index, tmp_path)
+
+    assert "helpers::trimName" in callees.get("main::run", set())
+    assert "main::run" in callers.get("helpers::trimName", set())
 
 
 # ---------------------------------------------------------------------------

--- a/packages/gptme-codegraph/tests/test_codegraph_sqlite_cache.py
+++ b/packages/gptme-codegraph/tests/test_codegraph_sqlite_cache.py
@@ -86,6 +86,22 @@ def test_sqlite_freshness_detects_new_file(sample_dir):
     cache.close()
 
 
+def test_sqlite_freshness_detects_new_typescript_file(sample_dir):
+    """New non-Python source files should also invalidate the cache."""
+    cache = SqliteIndexCache(sample_dir)
+
+    index = build_index(Path(sample_dir))
+    cache.save(index)
+    assert cache.is_fresh()
+
+    (Path(sample_dir) / "new.ts").write_text(
+        "export function newFunc(name: string) { return name.trim() }\n"
+    )
+    assert not cache.is_fresh()
+
+    cache.close()
+
+
 def test_sqlite_freshness_detects_deleted_file(sample_dir):
     """Test that is_fresh returns False after a file is removed."""
     cache = SqliteIndexCache(sample_dir)

--- a/packages/gptme-codegraph/tests/test_multilang.py
+++ b/packages/gptme-codegraph/tests/test_multilang.py
@@ -1,0 +1,589 @@
+"""Tests for multi-language support in gptme-codegraph (JS/TS, Rust).
+
+Verifies that parse_file, extract_symbols, and build_index work correctly
+for JavaScript, TypeScript, and Rust source files.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+from gptme_codegraph.core import (
+    _tree_sitter_parse,
+    build_index,
+    extract_symbols,
+    parse_file,
+)
+
+
+def _has_grammar(lang: str) -> bool:
+    """Check if a tree-sitter grammar is available."""
+    import importlib
+
+    try:
+        importlib.import_module(f"tree_sitter_{lang}")
+        return True
+    except ImportError:
+        return False
+
+
+_skip_no_js = pytest.mark.skipif(
+    not _has_grammar("javascript"),
+    reason="tree-sitter-javascript not installed",
+)
+_skip_no_ts = pytest.mark.skipif(
+    not _has_grammar("typescript"),
+    reason="tree-sitter-typescript not installed",
+)
+_skip_no_rust = pytest.mark.skipif(
+    not _has_grammar("rust"),
+    reason="tree-sitter-rust not installed",
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def js_module() -> Generator[Path, None, None]:
+    """A JavaScript module with functions, classes, and methods."""
+    code = """\
+// utils.js — shared helpers
+
+export function greet(name) {
+    return `Hello ${name}`;
+}
+
+export function formatDate(date) {
+    const ts = date.getTime();
+    return date.toISOString().split('T')[0];
+}
+
+export class Calculator {
+    constructor(initialValue = 0) {
+        this.value = initialValue;
+    }
+
+    add(n) {
+        this.value += n;
+        return this;
+    }
+
+    multiply(n) {
+        this.value *= n;
+        return this;
+    }
+
+    result() {
+        return this.value;
+    }
+}
+
+const PI = 3.14159;
+export { PI };
+"""
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".js", delete=False, prefix="test_js_"
+    ) as f:
+        f.write(code)
+        path = Path(f.name)
+    yield path
+    path.unlink(missing_ok=True)
+
+
+@pytest.fixture
+def ts_module() -> Generator[Path, None, None]:
+    """A TypeScript module with functions, classes, and methods."""
+    code = """\
+// models.ts — typed data models
+
+export interface User {
+    id: number;
+    name: string;
+    email: string;
+}
+
+export class UserRepository {
+    private users: User[] = [];
+
+    addUser(user: User): void {
+        this.users.push(user);
+    }
+
+    findById(id: number): User | undefined {
+        return this.users.find(u => u.id === id);
+    }
+
+    findAll(): User[] {
+        return [...this.users];
+    }
+}
+
+export function validateEmail(email: string): boolean {
+    const re = /^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$/;
+    return re.test(email);
+}
+
+export const APP_VERSION = "1.0.0";
+"""
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".ts", delete=False, prefix="test_ts_"
+    ) as f:
+        f.write(code)
+        path = Path(f.name)
+    yield path
+    path.unlink(missing_ok=True)
+
+
+@pytest.fixture
+def tsx_module() -> Generator[Path, None, None]:
+    """A TSX module with React components."""
+    code = """\
+// Button.tsx — reusable button component
+import React from 'react';
+
+interface ButtonProps {
+    label: string;
+    onClick: () => void;
+    disabled?: boolean;
+}
+
+export function Button({ label, onClick, disabled = false }: ButtonProps): JSX.Element {
+    return (
+        <button onClick={onClick} disabled={disabled} className="btn">
+            {label}
+        </button>
+    );
+}
+
+export function IconButton({ icon, ...props }: ButtonProps & { icon: string }): JSX.Element {
+    return (
+        <button {...props} className="btn-icon">
+            <span className="icon">{icon}</span>
+            <span>{props.label}</span>
+        </button>
+    );
+}
+"""
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".tsx", delete=False, prefix="test_tsx_"
+    ) as f:
+        f.write(code)
+        path = Path(f.name)
+    yield path
+    path.unlink(missing_ok=True)
+
+
+@pytest.fixture
+def rust_module() -> Generator[Path, None, None]:
+    """A Rust module with functions, struct, impl, enum, and trait."""
+    code = """\
+// calculator.rs — a simple calculator module
+
+/// Adds two numbers together.
+pub fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+/// Multiplies two numbers.
+pub fn multiply(a: i32, b: i32) -> i32 {
+    let result = a * b;
+    multiply_internal(result)
+}
+
+fn multiply_internal(value: i32) -> i32 {
+    value
+}
+
+pub struct Config {
+    pub precision: u8,
+    pub max_value: i32,
+}
+
+impl Config {
+    pub fn new(precision: u8) -> Self {
+        Self {
+            precision,
+            max_value: 100,
+        }
+    }
+
+    pub fn with_max(mut self, max: i32) -> Self {
+        self.max_value = max;
+        self
+    }
+}
+
+pub enum Operation {
+    Add,
+    Subtract,
+    Multiply,
+    Divide,
+}
+
+pub trait Calculator {
+    fn calculate(&self, op: Operation, a: i32, b: i32) -> i32;
+}
+
+use std::fmt;
+use std::io::{self, Write};
+"""
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".rs", delete=False, prefix="test_rust_"
+    ) as f:
+        f.write(code)
+        path = Path(f.name)
+    yield path
+    path.unlink(missing_ok=True)
+
+
+@pytest.fixture
+def rust_simple() -> Generator[Path, None, None]:
+    """A minimal Rust file for quick parse tests."""
+    code = """\
+fn main() {
+    println!("Hello");
+}
+"""
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".rs", delete=False, prefix="test_rust_simple_"
+    ) as f:
+        f.write(code)
+        path = Path(f.name)
+    yield path
+    path.unlink(missing_ok=True)
+
+
+@pytest.fixture
+def multilang_project(tmp_path: Path) -> Generator[Path, None, None]:
+    """A project directory with JS, TS, and Rust source files."""
+    proj = tmp_path / "multilang"
+    proj.mkdir()
+
+    js_dir = proj / "src" / "js"
+    js_dir.mkdir(parents=True)
+    (js_dir / "main.js").write_text(
+        "export function run() { return 42; }\n"
+        "export class App { start() { run(); } }\n"
+    )
+
+    ts_dir = proj / "src" / "ts"
+    ts_dir.mkdir(parents=True)
+    (ts_dir / "types.ts").write_text(
+        "export interface Config { debug: boolean; }\n"
+        "export function loadConfig(): Config { return { debug: true }; }\n"
+    )
+
+    rust_dir = proj / "src" / "rust"
+    rust_dir.mkdir(parents=True)
+    (rust_dir / "lib.rs").write_text(
+        "pub fn init() -> bool { true }\n" "pub struct State { pub ready: bool }\n"
+    )
+
+    yield proj
+
+
+# ---------------------------------------------------------------------------
+# Language detection
+# ---------------------------------------------------------------------------
+
+
+def test_language_detection_python():
+    """Default language is python."""
+    code = b"def foo(): pass\n"
+    root, parser = _tree_sitter_parse(code)
+    assert root is not None
+    assert root.type == "module"
+
+
+@_skip_no_js
+def test_language_detection_js():
+    """_tree_sitter_parse detects .js files."""
+    code = b"function foo() { return 1; }\n"
+    root, parser = _tree_sitter_parse(code, lang_name="javascript")
+    assert root is not None
+    assert root.type == "program"
+
+
+@_skip_no_ts
+def test_language_detection_ts():
+    """_tree_sitter_parse detects .ts files."""
+    code = b"function foo(): number { return 1; }\n"
+    root, parser = _tree_sitter_parse(code, lang_name="typescript")
+    assert root is not None
+    assert root.type == "program"
+
+
+@_skip_no_ts
+def test_language_detection_tsx():
+    """_tree_sitter_parse detects .tsx files."""
+    code = b"const el = <div>hello</div>;\n"
+    root, parser = _tree_sitter_parse(code, lang_name="tsx")
+    assert root is not None
+    assert root.type == "program"
+
+
+@_skip_no_rust
+def test_language_detection_rust():
+    """_tree_sitter_parse detects .rs files."""
+    code = b"fn main() {}\n"
+    root, parser = _tree_sitter_parse(code, lang_name="rust")
+    assert root is not None
+    assert root.type == "source_file"
+
+
+# ---------------------------------------------------------------------------
+# JavaScript parsing
+# ---------------------------------------------------------------------------
+
+
+@_skip_no_js
+def test_parse_js_functions(js_module: Path):
+    """JavaScript: parse_file extracts functions."""
+    result = parse_file(js_module)
+    func_names = {s.name for s in result.symbols if s.kind == "function"}
+    assert "greet" in func_names
+    assert "formatDate" in func_names
+
+
+@_skip_no_js
+def test_parse_js_classes(js_module: Path):
+    """JavaScript: parse_file extracts classes and methods."""
+    result = parse_file(js_module)
+    class_names = {s.name for s in result.symbols if s.kind == "class"}
+    assert "Calculator" in class_names
+
+    methods = [s for s in result.symbols if s.kind == "method"]
+    method_names = {s.name for s in methods}
+    assert "add" in method_names
+    assert "multiply" in method_names
+    assert "result" in method_names
+    # Verify parent class linkage
+    for m in methods:
+        assert m.parent_class == "Calculator"
+
+
+@_skip_no_js
+def test_parse_js_method_locations(js_module: Path):
+    """JavaScript: method locations are correct."""
+    result = parse_file(js_module)
+    constructor = [s for s in result.symbols if s.name == "constructor"]
+    assert len(constructor) == 1
+    ctor = constructor[0]
+    assert ctor.kind == "method"
+    assert ctor.parent_class == "Calculator"
+    assert ctor.start_line >= 1
+    assert ctor.end_line >= ctor.start_line
+
+
+@_skip_no_js
+def test_extract_symbols_js(js_module: Path):
+    """extract_symbols works on JS files."""
+    symbols = extract_symbols(js_module)
+    assert len(symbols) >= 5  # 2 functions + 1 class + 3 methods + 1 variable
+    assert any(s.name == "greet" and s.kind == "function" for s in symbols)
+
+
+# ---------------------------------------------------------------------------
+# TypeScript parsing
+# ---------------------------------------------------------------------------
+
+
+@_skip_no_ts
+def test_parse_ts_functions(ts_module: Path):
+    """TypeScript: parse_file extracts functions."""
+    result = parse_file(ts_module)
+    func_names = {s.name for s in result.symbols if s.kind == "function"}
+    assert "validateEmail" in func_names
+
+
+@_skip_no_ts
+def test_parse_ts_classes(ts_module: Path):
+    """TypeScript: parse_file extracts classes and methods."""
+    result = parse_file(ts_module)
+    class_names = {s.name for s in result.symbols if s.kind == "class"}
+    assert "UserRepository" in class_names
+
+    methods = [s for s in result.symbols if s.kind == "method"]
+    method_names = {s.name for s in methods}
+    assert "addUser" in method_names
+    assert "findById" in method_names
+    assert "findAll" in method_names
+
+
+@_skip_no_ts
+def test_parse_ts_interface_not_symbol(ts_module: Path):
+    """TypeScript: interfaces are not extracted as symbols."""
+    result = parse_file(ts_module)
+    # Interfaces are not classes/functions/methods, so they shouldn't appear
+    interface_symbols = [s for s in result.symbols if s.name == "User"]
+    assert len(interface_symbols) == 0
+
+
+@_skip_no_ts
+def test_parse_tsx_react_components(tsx_module: Path):
+    """TSX: React function components are extracted."""
+    result = parse_file(tsx_module)
+    func_names = {s.name for s in result.symbols if s.kind == "function"}
+    assert "Button" in func_names
+    assert "IconButton" in func_names
+
+
+# ---------------------------------------------------------------------------
+# Rust parsing
+# ---------------------------------------------------------------------------
+
+
+@_skip_no_rust
+def test_parse_rust_functions(rust_module: Path):
+    """Rust: parse_file extracts functions."""
+    result = parse_file(rust_module)
+    func_names = {s.name for s in result.symbols if s.kind == "function"}
+    assert "add" in func_names
+    assert "multiply" in func_names
+    assert "multiply_internal" in func_names
+
+
+@_skip_no_rust
+def test_parse_rust_struct(rust_module: Path):
+    """Rust: parse_file extracts struct."""
+    result = parse_file(rust_module)
+    structs = [s for s in result.symbols if s.kind == "class"]
+    struct_names = {s.name for s in structs}
+    assert "Config" in struct_names
+
+
+@_skip_no_rust
+def test_parse_rust_impl_methods(rust_module: Path):
+    """Rust: impl methods are extracted as methods of the struct."""
+    result = parse_file(rust_module)
+    methods = [
+        s for s in result.symbols if s.kind == "method" and s.parent_class == "Config"
+    ]
+    method_names = {s.name for s in methods}
+    assert "new" in method_names
+    assert "with_max" in method_names
+    # Verify parent class linkage
+    for m in methods:
+        assert m.parent_class == "Config"
+
+
+@_skip_no_rust
+def test_parse_rust_enum(rust_module: Path):
+    """Rust: enum is extracted as a class."""
+    result = parse_file(rust_module)
+    enums = [s for s in result.symbols if s.name == "Operation"]
+    assert len(enums) == 1
+    assert enums[0].kind == "class"
+
+
+@_skip_no_rust
+def test_parse_rust_trait(rust_module: Path):
+    """Rust: trait with method signature is extracted."""
+    result = parse_file(rust_module)
+    trait = [s for s in result.symbols if s.name == "Calculator"]
+    assert len(trait) == 1
+    # trait items are symbols in our model
+    trait_methods = [
+        s
+        for s in result.symbols
+        if s.kind == "method" and s.parent_class == "Calculator"
+    ]
+    assert len(trait_methods) == 1
+    assert trait_methods[0].name == "calculate"
+
+
+@_skip_no_rust
+def test_parse_rust_simple(rust_simple: Path):
+    """Rust: minimal file parses correctly."""
+    result = parse_file(rust_simple)
+    funcs = [s for s in result.symbols if s.kind == "function"]
+    assert len(funcs) == 1
+    assert funcs[0].name == "main"
+
+
+# ---------------------------------------------------------------------------
+# build_index with multi-language
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not (
+        _has_grammar("javascript")
+        and _has_grammar("typescript")
+        and _has_grammar("rust")
+    ),
+    reason="Need all three tree-sitter grammars",
+)
+def test_build_index_multilang(multilang_project: Path):
+    """build_index handles JS, TS, and Rust files in the same directory."""
+    index = build_index(multilang_project)
+    names = set(index.all_names())
+    # JS
+    assert "run" in names
+    assert "App" in names
+    # TS
+    assert "loadConfig" in names
+    # Rust
+    assert "init" in names
+    assert "State" in names
+
+
+# ---------------------------------------------------------------------------
+# Graceful fallback
+# ---------------------------------------------------------------------------
+
+
+def test_parse_file_unknown_extension_fallback(tmp_path: Path):
+    """Unknown extensions fall back to Python parser gracefully."""
+    f = tmp_path / "script.c"
+    f.write_text("int main() { return 0; }")
+    result = parse_file(f)
+    # Should not crash — falls back to Python parser which can't parse C
+    assert isinstance(result.symbols, list)
+
+
+def test_parse_file_empty(tmp_path: Path):
+    """Empty file returns empty result."""
+    f = tmp_path / "empty.py"
+    f.write_text("")
+    result = parse_file(f)
+    assert result.symbols == []
+
+
+def test_tree_sitter_parse_unknown_lang():
+    """Unknown language falls back gracefully."""
+    code = b"some code"
+    root, parser = _tree_sitter_parse(code, lang_name="fortran")
+    # Should fall back to Python or return None
+    # Either is acceptable — main thing is no crash
+    assert root is None or root.type in ("program", "module", "source_file", "ERROR")
+
+
+# ---------------------------------------------------------------------------
+# Symbol quality checks
+# ---------------------------------------------------------------------------
+
+
+@_skip_no_js
+def test_js_symbol_locations(js_module: Path):
+    """JavaScript: symbol locations are non-zero."""
+    result = parse_file(js_module)
+    for s in result.symbols:
+        assert s.start_line >= 1
+        assert s.end_line >= s.start_line
+        assert s.file == str(js_module)
+
+
+@_skip_no_rust
+def test_rust_symbol_locations(rust_module: Path):
+    """Rust: symbol locations are non-zero."""
+    result = parse_file(rust_module)
+    for s in result.symbols:
+        assert s.start_line >= 1
+        assert s.end_line >= s.start_line
+        assert s.file == str(rust_module)

--- a/packages/gptme-contrib-lib/src/gptme_contrib_lib/config.py
+++ b/packages/gptme-contrib-lib/src/gptme_contrib_lib/config.py
@@ -319,9 +319,9 @@ class InputSourcesConfig(BaseModel):
             Validated InputSourcesConfig instance
         """
         try:
-            import tomllib
+            import tomllib  # type: ignore[import-not-found]  # Python 3.11+ stdlib; only exists on 3.10 via tomli shim
         except ImportError:
-            import tomli as tomllib  # type: ignore[no-redef]
+            import tomli as tomllib  # type: ignore[no-redef,import-not-found]
 
         with open(config_path, "rb") as f:
             config_dict = tomllib.load(f)

--- a/plugins/gptme-tts/tests/conftest.py
+++ b/plugins/gptme-tts/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Test configuration for gptme-tts plugin."""
+
+import sys
+from pathlib import Path
+
+
+def pytest_configure():
+    """Add plugin root to sys.path for importing flat backend modules."""
+    plugin_root = Path(__file__).resolve().parent.parent  # plugins/gptme-tts/
+    if str(plugin_root) not in sys.path:
+        sys.path.insert(0, str(plugin_root))

--- a/plugins/gptme-tts/tests/test_tts.py
+++ b/plugins/gptme-tts/tests/test_tts.py
@@ -221,3 +221,74 @@ def test_wait_on_session_end_disabled():
 
         mock_queue.join.assert_not_called()
         assert len(result) == 0
+
+
+# --- Backend teardown contract tests ---
+
+
+def _has_backend_kokoro():
+    try:
+        from tts_kokoro import KokoroTTSBackend  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def _has_backend_chatterbox():
+    try:
+        from tts_chatterbox import ChatterboxTTSBackend  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def test_kokoro_backend_close_contract():
+    """KokoroTTSBackend.close() exists, is idempotent, and does not raise."""
+    from tts_kokoro import KokoroTTSBackend
+
+    backend = KokoroTTSBackend(lang_code="a", voice="af_heart")
+    # close() with uninitialized pipeline should be a no-op
+    backend.close()
+    # second call should also be safe (idempotent)
+    backend.close()
+    # If the backend has an `initialize` method, close after init should also be safe
+    # (we skip actual init here since it requires espeak; the no-op path is the contract)
+
+
+def test_chatterbox_backend_close_contract():
+    """ChatterboxTTSBackend.close() exists, is idempotent, and does not raise."""
+    from tts_chatterbox import ChatterboxTTSBackend
+
+    # Initialize without HF token; close should still be safe
+    with patch.dict("os.environ", {"HF_TOKEN": "test-token"}):
+        backend = ChatterboxTTSBackend(voice_sample_dir="/tmp")
+        # close() with uninitialized client should be a no-op
+        backend.close()
+    # second call should also be safe
+    backend.close()
+
+
+def test_lifespan_shutdown_calls_close():
+    """FastAPI lifespan shutdown path calls close() on the backend."""
+    from tts_kokoro import KokoroTTSBackend
+
+    backend = KokoroTTSBackend(lang_code="a", voice="af_heart")
+    backend.initialize = MagicMock()
+    backend.close = MagicMock()
+
+    # This tests the post-yield path: close() is called after shutdown
+    # We can't easily run the full lifespan context manager in a synthetic test,
+    # so we verify the pattern directly.
+    close_mock = MagicMock()
+    backend.close = close_mock
+
+    # Simulate the shutdown path: close() + clear
+    backend.close()
+    assert close_mock.call_count == 1
+
+    # close() again (idempotent)
+    backend.close()
+    assert close_mock.call_count == 2
+    # No exception on second call

--- a/plugins/gptme-tts/tests/test_tts.py
+++ b/plugins/gptme-tts/tests/test_tts.py
@@ -1,3 +1,7 @@
+import asyncio
+import importlib
+import sys
+import types
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -226,69 +230,147 @@ def test_wait_on_session_end_disabled():
 # --- Backend teardown contract tests ---
 
 
-def _has_backend_kokoro():
+def _import_tts_kokoro():
+    kokoro_stub = types.ModuleType("kokoro")
+    kokoro_stub.KPipeline = type("DummyPipeline", (), {})
+    kokoro_stub.__version__ = "test"
+
+    previous = sys.modules.get("kokoro")
+    sys.modules.pop("tts_kokoro", None)
+    sys.modules["kokoro"] = kokoro_stub
     try:
-        from tts_kokoro import KokoroTTSBackend  # noqa: F401
+        return importlib.import_module("tts_kokoro")
+    finally:
+        if previous is None:
+            sys.modules.pop("kokoro", None)
+        else:
+            sys.modules["kokoro"] = previous
 
-        return True
-    except ImportError:
-        return False
 
+def _import_tts_chatterbox():
+    gradio_client_stub = types.ModuleType("gradio_client")
 
-def _has_backend_chatterbox():
+    class DummyClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def close(self):
+            pass
+
+    gradio_client_stub.Client = DummyClient
+    gradio_client_stub.handle_file = lambda path: path
+
+    previous = sys.modules.get("gradio_client")
+    sys.modules.pop("tts_chatterbox", None)
+    sys.modules["gradio_client"] = gradio_client_stub
     try:
-        from tts_chatterbox import ChatterboxTTSBackend  # noqa: F401
+        return importlib.import_module("tts_chatterbox")
+    finally:
+        if previous is None:
+            sys.modules.pop("gradio_client", None)
+        else:
+            sys.modules["gradio_client"] = previous
 
-        return True
-    except ImportError:
-        return False
+
+def _import_tts_server():
+    fastapi_stub = types.ModuleType("fastapi")
+    fastapi_responses_stub = types.ModuleType("fastapi.responses")
+
+    class DummyFastAPI:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def get(self, *args, **kwargs):
+            def decorator(func):
+                return func
+
+            return decorator
+
+    class DummyHTTPException(Exception):
+        def __init__(self, status_code: int, detail: str):
+            super().__init__(detail)
+            self.status_code = status_code
+            self.detail = detail
+
+    class DummyStreamingResponse:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    fastapi_stub.FastAPI = DummyFastAPI
+    fastapi_stub.HTTPException = DummyHTTPException
+    fastapi_responses_stub.StreamingResponse = DummyStreamingResponse
+
+    previous_fastapi = sys.modules.get("fastapi")
+    previous_fastapi_responses = sys.modules.get("fastapi.responses")
+    sys.modules.pop("tts_server", None)
+    sys.modules["fastapi"] = fastapi_stub
+    sys.modules["fastapi.responses"] = fastapi_responses_stub
+    try:
+        return importlib.import_module("tts_server")
+    finally:
+        if previous_fastapi is None:
+            sys.modules.pop("fastapi", None)
+        else:
+            sys.modules["fastapi"] = previous_fastapi
+        if previous_fastapi_responses is None:
+            sys.modules.pop("fastapi.responses", None)
+        else:
+            sys.modules["fastapi.responses"] = previous_fastapi_responses
 
 
 def test_kokoro_backend_close_contract():
     """KokoroTTSBackend.close() exists, is idempotent, and does not raise."""
-    from tts_kokoro import KokoroTTSBackend
+    module = _import_tts_kokoro()
 
-    backend = KokoroTTSBackend(lang_code="a", voice="af_heart")
-    # close() with uninitialized pipeline should be a no-op
+    with patch.object(module.KokoroTTSBackend, "_check_espeak", return_value=None):
+        backend = module.KokoroTTSBackend(lang_code="a", voice="af_heart")
+
+    backend.pipeline = object()
     backend.close()
-    # second call should also be safe (idempotent)
+    assert backend.pipeline is None
+
     backend.close()
-    # If the backend has an `initialize` method, close after init should also be safe
-    # (we skip actual init here since it requires espeak; the no-op path is the contract)
+    assert backend.pipeline is None
 
 
 def test_chatterbox_backend_close_contract():
     """ChatterboxTTSBackend.close() exists, is idempotent, and does not raise."""
-    from tts_chatterbox import ChatterboxTTSBackend
+    module = _import_tts_chatterbox()
 
-    # Initialize without HF token; close should still be safe
     with patch.dict("os.environ", {"HF_TOKEN": "test-token"}):
-        backend = ChatterboxTTSBackend(voice_sample_dir="/tmp")
-        # close() with uninitialized client should be a no-op
+        backend = module.ChatterboxTTSBackend(voice_sample_dir="/tmp")
         backend.close()
-    # second call should also be safe
+
+    client = MagicMock()
+    backend.client = client
     backend.close()
+    client.close.assert_called_once()
+    assert backend.client is None
+
+    backend.close()
+    client.close.assert_called_once()
 
 
 def test_lifespan_shutdown_calls_close():
     """FastAPI lifespan shutdown path calls close() on the backend."""
-    from tts_kokoro import KokoroTTSBackend
+    module = _import_tts_server()
 
-    backend = KokoroTTSBackend(lang_code="a", voice="af_heart")
-    backend.initialize = MagicMock()
-    backend.close = MagicMock()
+    backend = MagicMock()
 
-    # This tests the post-yield path: close() is called after shutdown
-    # We can't easily run the full lifespan context manager in a synthetic test,
-    # so we verify the pattern directly.
-    close_mock = MagicMock()
-    backend.close = close_mock
+    async def exercise_lifespan():
+        module.current_backend = None
+        module.backend_name = "kokoro"
+        async with module.lifespan(module.app):
+            assert module.current_backend is backend
 
-    # Simulate the shutdown path: close() + clear
-    backend.close()
-    assert close_mock.call_count == 1
+        backend.close.assert_called_once()
+        assert module.current_backend is None
 
-    # close() again (idempotent)
-    backend.close()
-    assert close_mock.call_count == 2
-    # No exception on second call
+    with patch.object(
+        module.TTSBackendLoader,
+        "load_kokoro_backend",
+        return_value=backend,
+    ) as load_backend:
+        asyncio.run(exercise_lifespan())
+
+    load_backend.assert_called_once_with(lang_code="a", voice="af_heart")

--- a/plugins/gptme-tts/tts_chatterbox.py
+++ b/plugins/gptme-tts/tts_chatterbox.py
@@ -70,6 +70,16 @@ class ChatterboxTTSBackend:
         voices = _list_voices(self.voice_sample_dir)
         self.default_voice: str | None = voices[0] if voices else None
 
+    def close(self) -> None:
+        """Close the Chatterbox TTS client and release resources."""
+        if self.client:
+            try:
+                self.client.close()
+            except Exception:
+                log.warning("Error closing Chatterbox client", exc_info=True)
+        self.client = None
+        log.info("Chatterbox TTS client closed")
+
     def initialize(self, voice: str | None = None) -> None:
         """Initialize the Chatterbox TTS client."""
         try:

--- a/plugins/gptme-tts/tts_kokoro.py
+++ b/plugins/gptme-tts/tts_kokoro.py
@@ -126,6 +126,11 @@ class KokoroTTSBackend:
 
         return ["af_heart"]  # Default fallback
 
+    def close(self) -> None:
+        """Close the Kokoro TTS pipeline and release resources."""
+        self.pipeline = None
+        log.info("Kokoro pipeline closed")
+
     def initialize(self, voice: str | None = None) -> None:
         """Initialize the Kokoro TTS pipeline."""
         try:

--- a/plugins/gptme-tts/tts_server.py
+++ b/plugins/gptme-tts/tts_server.py
@@ -49,7 +49,7 @@ log = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    """Initialize backend on startup."""
+    """Initialize backend on startup and teardown on shutdown."""
     global current_backend
 
     try:
@@ -74,7 +74,15 @@ async def lifespan(app: FastAPI):
 
     yield
 
-    # TODO: cleanup
+    # Cleanup backend on shutdown
+    if current_backend is not None:
+        try:
+            current_backend.close()
+            log.info(f"Cleaned up {backend_name} backend")
+        except Exception as e:
+            log.error(f"Error during backend cleanup: {e}")
+        finally:
+            current_backend = None
 
 
 # Initialize FastAPI app
@@ -395,6 +403,11 @@ def main(
         except Exception as e:
             click.echo(f"Error listing voices: {e}", err=True)
             return
+        finally:
+            try:
+                temp_backend.close()
+            except Exception:
+                pass
 
     # Check if the selected backend is available
     available_backends = TTSBackendLoader.get_available_backends()

--- a/plugins/gptme-tts/tts_server.py
+++ b/plugins/gptme-tts/tts_server.py
@@ -406,6 +406,8 @@ def main(
         finally:
             try:
                 temp_backend.close()
+            except NameError:
+                pass
             except Exception:
                 pass
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,15 +12,12 @@ dev = [
     "pytest-cov>=4.1.0",
     "pytest-mock>=3.12.0",
     "pyyaml>=6.0",
+    "types-PyYAML>=6.0",
 ]
 
 [tool.uv.workspace]
 members = ["packages/*", "plugins/*"]
-# Exclude old package paths (now symlinks to new names for backward compatibility)
-# packages/lessons -> gptme-lessons-extras
-# packages/lib -> gptme-contrib-lib
-# packages/run_loops -> gptme-runloops
-exclude = ["packages/__pycache__", "plugins/__pycache__", "packages/tasks", "packages/lessons", "packages/lib", "packages/run_loops"]
+exclude = ["packages/__pycache__", "plugins/__pycache__", "packages/tasks"]
 
 [tool.uv.sources]
 gptme = { git = "https://github.com/gptme/gptme.git", branch = "master" }
@@ -47,10 +44,9 @@ ignore = [
 
 [tool.mypy]
 check_untyped_defs = true
-# Exclude packages with hyphenated names from mypy
-# These cause "not a valid Python package name" errors due to mypy config parsing
-# TODO: investigate mypy hyphen handling (gptme-runloops fixed and type-checked)
-exclude = [
-    "^packages/gptme-contrib-lib",
-    "^packages/gptme-lessons-extras",
+
+[[tool.mypy.overrides]]
+module = [
+    "frontmatter",        # third-party; no stubs or py.typed marker
 ]
+ignore_missing_imports = true

--- a/uv.lock
+++ b/uv.lock
@@ -1322,7 +1322,10 @@ mcp = [
 ]
 treesitter = [
     { name = "tree-sitter" },
+    { name = "tree-sitter-javascript" },
     { name = "tree-sitter-python" },
+    { name = "tree-sitter-rust" },
+    { name = "tree-sitter-typescript" },
 ]
 
 [package.metadata]
@@ -1331,7 +1334,10 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "tree-sitter", marker = "extra == 'treesitter'", specifier = ">=0.21.0" },
+    { name = "tree-sitter-javascript", marker = "extra == 'treesitter'", specifier = ">=0.21.0" },
     { name = "tree-sitter-python", marker = "extra == 'treesitter'", specifier = ">=0.21.0" },
+    { name = "tree-sitter-rust", marker = "extra == 'treesitter'", specifier = ">=0.24.0" },
+    { name = "tree-sitter-typescript", marker = "extra == 'treesitter'", specifier = ">=0.23.0" },
 ]
 provides-extras = ["treesitter", "mcp", "dev"]
 
@@ -5033,6 +5039,22 @@ wheels = [
 ]
 
 [[package]]
+name = "tree-sitter-javascript"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/e0/e63103c72a9d3dfd89a31e02e660263ad84b7438e5f44ee82e443e65bbde/tree_sitter_javascript-0.25.0.tar.gz", hash = "sha256:329b5414874f0588a98f1c291f1b28138286617aa907746ffe55adfdcf963f38", size = 132338, upload-time = "2025-09-01T07:13:44.792Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/df/5106ac250cd03661ebc3cc75da6b3d9f6800a3606393a0122eca58038104/tree_sitter_javascript-0.25.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b70f887fb269d6e58c349d683f59fa647140c410cfe2bee44a883b20ec92e3dc", size = 64052, upload-time = "2025-09-01T07:13:36.865Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/8f/6b4b2bc90d8ab3955856ce852cc9d1e82c81d7ab9646385f0e75ffd5b5d3/tree_sitter_javascript-0.25.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:8264a996b8845cfce06965152a013b5d9cbb7d199bc3503e12b5682e62bb1de1", size = 66440, upload-time = "2025-09-01T07:13:37.962Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c4/7da74ecdcd8a398f88bd003a87c65403b5fe0e958cdd43fbd5fd4a398fcf/tree_sitter_javascript-0.25.0-cp310-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9dc04ba91fc8583344e57c1f1ed5b2c97ecaaf47480011b92fbeab8dda96db75", size = 99728, upload-time = "2025-09-01T07:13:38.755Z" },
+    { url = "https://files.pythonhosted.org/packages/96/c8/97da3af4796495e46421e9344738addb3602fa6426ea695be3fcbadbee37/tree_sitter_javascript-0.25.0-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:199d09985190852e0912da2b8d26c932159be314bc04952cf917ed0e4c633e6b", size = 106072, upload-time = "2025-09-01T07:13:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/13/be/c964e8130be08cc9bd6627d845f0e4460945b158429d39510953bbcb8fcc/tree_sitter_javascript-0.25.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:dfcf789064c58dc13c0a4edb550acacfc6f0f280577f1e7a00de3e89fc7f8ddc", size = 104388, upload-time = "2025-09-01T07:13:40.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/89/9b773dee0f8961d1bb8d7baf0a204ab587618df19897c1ef260916f318ec/tree_sitter_javascript-0.25.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1b852d3aee8a36186dbcc32c798b11b4869f9b5041743b63b65c2ef793db7a54", size = 98377, upload-time = "2025-09-01T07:13:41.838Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/dc/d90cb1790f8cec9b4878d278ad9faf7c8f893189ce0f855304fd704fc274/tree_sitter_javascript-0.25.0-cp310-abi3-win_amd64.whl", hash = "sha256:e5ed840f5bd4a3f0272e441d19429b26eedc257abe5574c8546da6b556865e3c", size = 62975, upload-time = "2025-09-01T07:13:42.828Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1f/f9eba1038b7d4394410f3c0a6ec2122b590cd7acb03f196e52fa57ebbe72/tree_sitter_javascript-0.25.0-cp310-abi3-win_arm64.whl", hash = "sha256:622a69d677aa7f6ee2931d8c77c981a33f0ebb6d275aa9d43d3397c879a9bb0b", size = 61668, upload-time = "2025-09-01T07:13:43.803Z" },
+]
+
+[[package]]
 name = "tree-sitter-python"
 version = "0.25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5046,6 +5068,37 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/75/69/4946da3d6c0df316ccb938316ce007fb565d08f89d02d854f2d308f0309f/tree_sitter_python-0.25.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:71959832fc5d9642e52c11f2f7d79ae520b461e63334927e93ca46cd61cd9683", size = 107268, upload-time = "2025-09-11T06:47:54.388Z" },
     { url = "https://files.pythonhosted.org/packages/ed/a2/996fc2dfa1076dc460d3e2f3c75974ea4b8f02f6bc925383aaae519920e8/tree_sitter_python-0.25.0-cp310-abi3-win_amd64.whl", hash = "sha256:9bcde33f18792de54ee579b00e1b4fe186b7926825444766f849bf7181793a76", size = 76073, upload-time = "2025-09-11T06:47:55.773Z" },
     { url = "https://files.pythonhosted.org/packages/07/19/4b5569d9b1ebebb5907d11554a96ef3fa09364a30fcfabeff587495b512f/tree_sitter_python-0.25.0-cp310-abi3-win_arm64.whl", hash = "sha256:0fbf6a3774ad7e89ee891851204c2e2c47e12b63a5edbe2e9156997731c128bb", size = 74169, upload-time = "2025-09-11T06:47:56.747Z" },
+]
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.24.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/87/75cbd22b927267d310f76cca1ab3c1d9d41035dfa3eb9cc95f96ee199440/tree_sitter_rust-0.24.2.tar.gz", hash = "sha256:54fb02a5911e345308b405174465112479f56dc39e3f1e7744d7568595f00db9", size = 339341, upload-time = "2026-03-27T21:08:55.629Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/24/2b2d33af5e27c84a4fde4e8cd2594bb4ab1e1cf48756a9f40dadc84956cc/tree_sitter_rust-0.24.2-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:3620cfd12340efa43082d45df76349ff511893a9c361da2f8d6d51e307020a59", size = 129507, upload-time = "2026-03-27T21:08:47.585Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2a/cf39f881a545360b5a86bb1accba1f4acc713daab01fb9edd35b6e84f473/tree_sitter_rust-0.24.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:01a46622735498493f29f3e628a90de95c96a07bfbeb88996243eb986b1cee36", size = 136812, upload-time = "2026-03-27T21:08:48.761Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/45/a051bbd3045a61182dde25b93ae9a33d2677c935b16952283e12eaf46051/tree_sitter_rust-0.24.2-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:e033c5a93b57c88e0a835880de39fc802909ff69f57aaff6000211c196ea5190", size = 164706, upload-time = "2026-03-27T21:08:49.605Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/f6/a5a146df5c0a5daea3ffcd5d7245775fe7f084357770d5a313dd6245ae78/tree_sitter_rust-0.24.2-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9d76d1208c3638b871236090759dfc13d478921320653a6c9da5336e7c58f65a", size = 170310, upload-time = "2026-03-27T21:08:50.424Z" },
+    { url = "https://files.pythonhosted.org/packages/95/a8/f85b1ca75e01361ca5f92d226593ca4857cea49551b9f6c8fa6fc08ea917/tree_sitter_rust-0.24.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:87930163a462408c49ab62c667e74029bc26b4cc7123dd1bdc7352215786c64a", size = 168668, upload-time = "2026-03-27T21:08:51.404Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/e1/3519f866a4679ca36acd9f5a06a779ecb8a92b18887c5546458d521df557/tree_sitter_rust-0.24.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:da2b86099028fd42c6cd32878b7b16b01f8aac0f7b0e98742b7fa6bc3cf09b89", size = 162403, upload-time = "2026-03-27T21:08:52.588Z" },
+    { url = "https://files.pythonhosted.org/packages/34/71/7ef609894dbfe5699eb16f7471f9b8af1d958d8ba3e29c238d7607e8cb47/tree_sitter_rust-0.24.2-cp39-abi3-win_amd64.whl", hash = "sha256:4529c125d928882ddfb879fdc6bc0704913261ecc078b6fa7902559e0daf200d", size = 129422, upload-time = "2026-03-27T21:08:54.031Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d8/050a781172745bc345f98abb7c56e72022ea0790f8e793de981c83c2ef15/tree_sitter_rust-0.24.2-cp39-abi3-win_arm64.whl", hash = "sha256:66ba90f61bd54f4c4f5d30434957daf64507c16b0313df76becb37d63f70a227", size = 128245, upload-time = "2026-03-27T21:08:54.803Z" },
+]
+
+[[package]]
+name = "tree-sitter-typescript"
+version = "0.23.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/fc/bb52958f7e399250aee093751e9373a6311cadbe76b6e0d109b853757f35/tree_sitter_typescript-0.23.2.tar.gz", hash = "sha256:7b167b5827c882261cb7a50dfa0fb567975f9b315e87ed87ad0a0a3aedb3834d", size = 773053, upload-time = "2024-11-11T02:36:11.396Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/95/4c00680866280e008e81dd621fd4d3f54aa3dad1b76b857a19da1b2cc426/tree_sitter_typescript-0.23.2-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:3cd752d70d8e5371fdac6a9a4df9d8924b63b6998d268586f7d374c9fba2a478", size = 286677, upload-time = "2024-11-11T02:35:58.839Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/2f/1f36fda564518d84593f2740d5905ac127d590baf5c5753cef2a88a89c15/tree_sitter_typescript-0.23.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:c7cc1b0ff5d91bac863b0e38b1578d5505e718156c9db577c8baea2557f66de8", size = 302008, upload-time = "2024-11-11T02:36:00.733Z" },
+    { url = "https://files.pythonhosted.org/packages/96/2d/975c2dad292aa9994f982eb0b69cc6fda0223e4b6c4ea714550477d8ec3a/tree_sitter_typescript-0.23.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4b1eed5b0b3a8134e86126b00b743d667ec27c63fc9de1b7bb23168803879e31", size = 351987, upload-time = "2024-11-11T02:36:02.669Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d1/a71c36da6e2b8a4ed5e2970819b86ef13ba77ac40d9e333cb17df6a2c5db/tree_sitter_typescript-0.23.2-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e96d36b85bcacdeb8ff5c2618d75593ef12ebaf1b4eace3477e2bdb2abb1752c", size = 344960, upload-time = "2024-11-11T02:36:04.443Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/cb/f57b149d7beed1a85b8266d0c60ebe4c46e79c9ba56bc17b898e17daf88e/tree_sitter_typescript-0.23.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8d4f0f9bcb61ad7b7509d49a1565ff2cc363863644a234e1e0fe10960e55aea0", size = 340245, upload-time = "2024-11-11T02:36:06.473Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ab/dd84f0e2337296a5f09749f7b5483215d75c8fa9e33738522e5ed81f7254/tree_sitter_typescript-0.23.2-cp39-abi3-win_amd64.whl", hash = "sha256:3f730b66396bc3e11811e4465c41ee45d9e9edd6de355a58bbbc49fa770da8f9", size = 278015, upload-time = "2024-11-11T02:36:07.631Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/e4/81f9a935789233cf412a0ed5fe04c883841d2c8fb0b7e075958a35c65032/tree_sitter_typescript-0.23.2-cp39-abi3-win_arm64.whl", hash = "sha256:05db58f70b95ef0ea126db5560f3775692f609589ed6f8dd0af84b7f19f1cbb7", size = 274052, upload-time = "2024-11-11T02:36:09.514Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1412,6 +1412,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pyyaml" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
@@ -1424,6 +1425,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "pytest-mock", specifier = ">=3.12.0" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "types-pyyaml", specifier = ">=6.0" },
 ]
 
 [[package]]
@@ -5128,6 +5130,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b5/97/c439bc2c058f8a24edd732f5cc82adedd8794bcc2da0836c2eff1e2dbe91/twilio-9.10.5.tar.gz", hash = "sha256:d9f93b9280349ee7b52e7f17a0600fd7bfd0f7ff88eb00c40270164bc058743f", size = 1641690, upload-time = "2026-04-14T09:52:09.392Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/97/4fdde5e54fcbb789aa1a70c371f2f33d7eb1e58e8a6131fdbd8a98490976/twilio-9.10.5-py2.py3-none-any.whl", hash = "sha256:7972db54496fbf501b238f34d1f717f80ff22720313dc706632787aad5934997", size = 2284944, upload-time = "2026-04-14T09:52:07.333Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260510"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/85/0d9fafce21be112e977a89677f1ce9d1aef921d745b17c758c93e861c11f/types_pyyaml-6.0.12.20260510.tar.gz", hash = "sha256:09c1f1cb65a6eebea1e2e51ccf4918b8288e152909609a35cdb0d805efd125ad", size = 17831, upload-time = "2026-05-10T05:26:28.136Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/ad/fd618a218925daada7b8a5e7326e662599fa5fdff4a4c44ab2795bd2d9ca/types_pyyaml-6.0.12.20260510-py3-none-any.whl", hash = "sha256:3492eb9ba4d9d833473214c4d5736cccf5f37d93f5854059721e1c84f785309d", size = 20304, upload-time = "2026-05-10T05:26:26.981Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a proper teardown contract to the gptme-tts plugin backends. This closes the literal `# TODO: cleanup` placeholder that has been in `tts_server.py:77` since the lifespan handler was introduced.

## Changes

- **tts_kokoro.py**: Add `KokoroTTSBackend.close()` — sets pipeline to `None` (idempotent)
- **tts_chatterbox.py**: Add `ChatterboxTTSBackend.close()` — closes HTTP client if initialized, sets to `None` (idempotent)
- **tts_server.py**: Wire `backend.close()` into FastAPI lifespan shutdown path; also apply the same contract to the `--list-voices` temporary backend
- **tests/test_tts.py**: Add 3 new tests verifying:
  - Kokoro backend close is idempotent and does not raise
  - Chatterbox backend close is idempotent with/without initialized client
  - Lifespan shutdown path calls close() on the backend
- **tests/conftest.py**: Add pytest config for flat-module imports (needed because these are legacy-style flat modules)

## Verification

- All existing tests pass
- New tests pass
- Pre-commit checks passed (ruff, mypy)
- Backends no longer carry uninitialized resources after close

Closes the long-standing teardown TODO.
