### PR TITLE
fix(linear): validate OAuth state round-trip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,10 @@ __pycache__
 # Secrets - never commit
 scripts/discord/logs/*
 scripts/*/.env
+scripts/*/.oauth-state
 scripts/*/.tokens.json
 scripts/.env
+*.oauth-state
 *.tokens.json
 
 .venv/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.10"
 
 [dependency-groups]
 dev = [
+    "flask>=3.0.0",
     "mcp>=1.0.0",
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",

--- a/scripts/linear/.gitignore
+++ b/scripts/linear/.gitignore
@@ -1,5 +1,6 @@
 # Secrets - NEVER commit these
 .env
+.oauth-state
 .tokens.json
 
 # Logs

--- a/scripts/linear/README.md
+++ b/scripts/linear/README.md
@@ -191,24 +191,25 @@ uv run linear-activity.py auth
 
 This will:
 1. Generate the Linear authorization URL
-2. Open it in your browser (or print if no display)
-3. After you authorize, Linear redirects to your callback URL
-4. Extract the code from the redirect and exchange for tokens
+2. Include a one-time OAuth `state` value in that URL
+3. Open it in your browser (or print if no display)
+4. After you authorize, Linear redirects to your callback URL
+5. Validate the returned `state`, then exchange the code for tokens
 
 ### Option B: Manual Token Creation
 
 If the CLI auth flow doesn't work, manually create tokens:
 
-1. Build the authorization URL:
-   ```
-   https://linear.app/oauth/authorize?client_id=<CLIENT_ID>&redirect_uri=<CALLBACK_URL>&scope=read,write,app:mentionable,app:assignable&response_type=code&state=auth
-   ```
+1. Run `uv run linear-activity.py auth` and copy the full authorization URL it prints.
+   Do not replace the `state` parameter with a hardcoded value; the command
+   generates a one-time state token for each auth attempt.
 
-2. Visit the URL in browser and authorize
+2. Visit that exact URL in your browser and authorize.
 
-3. After redirect, extract the `code` parameter from the URL
+3. After redirect, extract both the `code` and `state` parameters from the URL.
 
-4. Exchange code for tokens:
+4. Verify the returned `state` matches the URL from step 1, then exchange the
+   `code` for tokens:
    ```bash
    curl -X POST https://api.linear.app/oauth/token \
      -H "Content-Type: application/x-www-form-urlencoded" \

--- a/scripts/linear/linear-activity.py
+++ b/scripts/linear/linear-activity.py
@@ -41,7 +41,6 @@ API Commands:
 
 import json
 import os
-import secrets
 import sys
 import time
 from enum import Enum
@@ -50,6 +49,7 @@ from typing import Any
 from urllib.parse import parse_qs, urlencode, urlparse
 
 import httpx
+import linear_oauth_state  # type: ignore[import-not-found]
 from dotenv import load_dotenv
 
 # ============================================================================
@@ -127,7 +127,6 @@ class ActivityType(Enum):
 # Load environment from .env file in script directory
 ENV_FILE = Path(__file__).parent / ".env"
 TOKENS_FILE = Path(__file__).parent / ".tokens.json"
-OAUTH_STATE_FILE = Path(__file__).parent / ".oauth-state"
 load_dotenv(ENV_FILE)
 
 # Linear endpoints
@@ -195,45 +194,6 @@ def load_oauth_credentials() -> tuple[str, str]:
         )
 
     return client_id, client_secret
-
-
-def save_pending_oauth_state(state: str) -> None:
-    """Persist the pending OAuth state for the next callback."""
-    OAUTH_STATE_FILE.write_text(state)
-
-
-def load_pending_oauth_state() -> str | None:
-    """Load the pending OAuth state if it exists."""
-    if not OAUTH_STATE_FILE.exists():
-        return None
-
-    value = OAUTH_STATE_FILE.read_text().strip()
-    return value or None
-
-
-def clear_pending_oauth_state() -> None:
-    """Remove the pending OAuth state after a successful auth flow."""
-    OAUTH_STATE_FILE.unlink(missing_ok=True)
-
-
-def generate_and_save_oauth_state() -> str:
-    """Generate a per-attempt OAuth state and persist it."""
-    state = secrets.token_urlsafe(32)
-    save_pending_oauth_state(state)
-    return state
-
-
-def get_oauth_state_error(
-    received_state: str | None, *, expected_state: str | None
-) -> str | None:
-    """Return an error message when the OAuth state is missing or invalid."""
-    if not expected_state:
-        return "No pending OAuth state found. Start a new authorization attempt."
-    if not received_state:
-        return "No OAuth state found in callback URL."
-    if received_state != expected_state:
-        return "OAuth state mismatch. Start a new authorization attempt."
-    return None
 
 
 def build_authorization_url(
@@ -369,7 +329,7 @@ def do_auth() -> None:
 
     # Build authorization URL
     scopes = "read,write,app:mentionable,app:assignable,initiative:read,initiative:write,issues:create,comments:create"
-    expected_state = generate_and_save_oauth_state()
+    expected_state = linear_oauth_state.generate_and_save_oauth_state()
     auth_url = build_authorization_url(
         client_id=client_id,
         callback_url=callback_url,
@@ -387,20 +347,24 @@ def do_auth() -> None:
     try:
         redirect_url = input("Redirect URL: ").strip()
     except (EOFError, KeyboardInterrupt):
+        linear_oauth_state.clear_pending_oauth_state()
         raise AuthenticationError("Authorization aborted")
 
-    code, returned_state = parse_redirect_callback(redirect_url)
-    if not code:
-        raise AuthenticationError("No authorization code found in URL")
-
-    state_error = get_oauth_state_error(returned_state, expected_state=expected_state)
-    if state_error:
-        raise AuthenticationError(state_error)
-
-    print("\nExchanging code for tokens...")
-
-    # Exchange code for tokens
     try:
+        code, returned_state = parse_redirect_callback(redirect_url)
+        if not code:
+            raise AuthenticationError("No authorization code found in URL")
+
+        state_error = linear_oauth_state.get_oauth_state_error(
+            returned_state,
+            expected_state=expected_state,
+        )
+        if state_error:
+            raise AuthenticationError(state_error)
+
+        print("\nExchanging code for tokens...")
+
+        # Exchange code for tokens
         response = httpx.post(
             LINEAR_OAUTH_TOKEN_URL,
             data={
@@ -432,12 +396,16 @@ def do_auth() -> None:
         }
 
         TOKENS_FILE.write_text(json.dumps(tokens, indent=2))
-        clear_pending_oauth_state()
+        linear_oauth_state.clear_pending_oauth_state()
         print(f"✓ Tokens saved to {TOKENS_FILE}")
         print(f"  Expires in {data.get('expires_in', 0) // 3600}h")
 
     except httpx.HTTPError as e:
+        linear_oauth_state.clear_pending_oauth_state()
         raise AuthenticationError(f"HTTP error during token exchange: {e}")
+    except Exception:
+        linear_oauth_state.clear_pending_oauth_state()
+        raise
 
 
 def token_status() -> None:

--- a/scripts/linear/linear-activity.py
+++ b/scripts/linear/linear-activity.py
@@ -41,11 +41,13 @@ API Commands:
 
 import json
 import os
+import secrets
 import sys
 import time
 from enum import Enum
 from pathlib import Path
 from typing import Any
+from urllib.parse import parse_qs, urlencode, urlparse
 
 import httpx
 from dotenv import load_dotenv
@@ -125,6 +127,7 @@ class ActivityType(Enum):
 # Load environment from .env file in script directory
 ENV_FILE = Path(__file__).parent / ".env"
 TOKENS_FILE = Path(__file__).parent / ".tokens.json"
+OAUTH_STATE_FILE = Path(__file__).parent / ".oauth-state"
 load_dotenv(ENV_FILE)
 
 # Linear endpoints
@@ -192,6 +195,76 @@ def load_oauth_credentials() -> tuple[str, str]:
         )
 
     return client_id, client_secret
+
+
+def save_pending_oauth_state(state: str) -> None:
+    """Persist the pending OAuth state for the next callback."""
+    OAUTH_STATE_FILE.write_text(state)
+
+
+def load_pending_oauth_state() -> str | None:
+    """Load the pending OAuth state if it exists."""
+    if not OAUTH_STATE_FILE.exists():
+        return None
+
+    value = OAUTH_STATE_FILE.read_text().strip()
+    return value or None
+
+
+def clear_pending_oauth_state() -> None:
+    """Remove the pending OAuth state after a successful auth flow."""
+    OAUTH_STATE_FILE.unlink(missing_ok=True)
+
+
+def generate_and_save_oauth_state() -> str:
+    """Generate a per-attempt OAuth state and persist it."""
+    state = secrets.token_urlsafe(32)
+    save_pending_oauth_state(state)
+    return state
+
+
+def get_oauth_state_error(
+    received_state: str | None, *, expected_state: str | None
+) -> str | None:
+    """Return an error message when the OAuth state is missing or invalid."""
+    if not expected_state:
+        return "No pending OAuth state found. Start a new authorization attempt."
+    if not received_state:
+        return "No OAuth state found in callback URL."
+    if received_state != expected_state:
+        return "OAuth state mismatch. Start a new authorization attempt."
+    return None
+
+
+def build_authorization_url(
+    *,
+    client_id: str,
+    callback_url: str,
+    scopes: str,
+    state: str,
+) -> str:
+    """Build the Linear authorization URL with a per-attempt state."""
+    query = urlencode(
+        {
+            "client_id": client_id,
+            "redirect_uri": callback_url,
+            "scope": scopes,
+            "response_type": "code",
+            "actor": "app",
+            "state": state,
+        }
+    )
+    return f"{LINEAR_OAUTH_AUTHORIZE_URL}?{query}"
+
+
+def parse_redirect_callback(redirect_url: str) -> tuple[str | None, str | None]:
+    """Extract the OAuth code and state from a callback URL."""
+    query = parse_qs(urlparse(redirect_url).query)
+    code_values: list[str] | None = query.get("code")
+    state_values: list[str] | None = query.get("state")
+    code = code_values[0] if code_values else None
+    state = state_values[0] if state_values else None
+    return code, state
 
 
 def is_token_expired() -> bool:
@@ -296,14 +369,12 @@ def do_auth() -> None:
 
     # Build authorization URL
     scopes = "read,write,app:mentionable,app:assignable,initiative:read,initiative:write,issues:create,comments:create"
-    auth_url = (
-        f"{LINEAR_OAUTH_AUTHORIZE_URL}?"
-        f"client_id={client_id}&"
-        f"redirect_uri={callback_url}&"
-        f"scope={scopes}&"
-        f"response_type=code&"
-        f"actor=app&"
-        f"state=auth"
+    expected_state = generate_and_save_oauth_state()
+    auth_url = build_authorization_url(
+        client_id=client_id,
+        callback_url=callback_url,
+        scopes=scopes,
+        state=expected_state,
     )
 
     print("=== Linear OAuth Authorization ===\n")
@@ -318,11 +389,14 @@ def do_auth() -> None:
     except (EOFError, KeyboardInterrupt):
         raise AuthenticationError("Authorization aborted")
 
-    # Extract code from URL
-    if "code=" not in redirect_url:
+    code, returned_state = parse_redirect_callback(redirect_url)
+    if not code:
         raise AuthenticationError("No authorization code found in URL")
 
-    code = redirect_url.split("code=")[1].split("&")[0]
+    state_error = get_oauth_state_error(returned_state, expected_state=expected_state)
+    if state_error:
+        raise AuthenticationError(state_error)
+
     print("\nExchanging code for tokens...")
 
     # Exchange code for tokens
@@ -358,6 +432,7 @@ def do_auth() -> None:
         }
 
         TOKENS_FILE.write_text(json.dumps(tokens, indent=2))
+        clear_pending_oauth_state()
         print(f"✓ Tokens saved to {TOKENS_FILE}")
         print(f"  Expires in {data.get('expires_in', 0) // 3600}h")
 

--- a/scripts/linear/linear-webhook-server.py
+++ b/scripts/linear/linear-webhook-server.py
@@ -110,6 +110,7 @@ GPTME_TIMEOUT = 30 * 60  # 30 minutes
 LINEAR_API = "https://api.linear.app/graphql"
 LINEAR_OAUTH_TOKEN_URL = "https://api.linear.app/oauth/token"
 TOKENS_FILE = Path(__file__).parent / ".tokens.json"
+OAUTH_STATE_FILE = Path(__file__).parent / ".oauth-state"
 
 # Session tracking for deduplication
 processed_sessions: set[str] = set()
@@ -142,6 +143,38 @@ log.addHandler(_file_handler)
 
 # Path to the linear-activity.py CLI
 LINEAR_ACTIVITY_CLI = Path(__file__).parent / "linear-activity.py"
+
+
+def save_pending_oauth_state(state: str) -> None:
+    """Persist the pending OAuth state for the next callback."""
+    OAUTH_STATE_FILE.write_text(state)
+
+
+def load_pending_oauth_state() -> str | None:
+    """Load the pending OAuth state if it exists."""
+    if not OAUTH_STATE_FILE.exists():
+        return None
+
+    value = OAUTH_STATE_FILE.read_text().strip()
+    return value or None
+
+
+def clear_pending_oauth_state() -> None:
+    """Remove the pending OAuth state after a successful auth flow."""
+    OAUTH_STATE_FILE.unlink(missing_ok=True)
+
+
+def get_oauth_state_error(
+    received_state: str | None, *, expected_state: str | None
+) -> str | None:
+    """Return an error message when the OAuth state is missing or invalid."""
+    if not expected_state:
+        return "No pending OAuth state found. Start a new authorization attempt."
+    if not received_state:
+        return "No OAuth state found in callback URL."
+    if received_state != expected_state:
+        return "OAuth state mismatch. Start a new authorization attempt."
+    return None
 
 
 def ensure_valid_token() -> bool:
@@ -839,7 +872,7 @@ def oauth_callback():
     """
     # Get the authorization code from the query string
     code = request.args.get("code")
-    _state = request.args.get("state")  # TODO: Implement CSRF validation with state
+    state = request.args.get("state")
     error = request.args.get("error")
 
     if error:
@@ -867,6 +900,24 @@ def oauth_callback():
         <body style="font-family: sans-serif; padding: 40px; text-align: center;">
             <h1 style="color: #dc3545;">❌ Missing Authorization Code</h1>
             <p>No authorization code was provided in the callback.</p>
+            <p><a href="/">Back to home</a></p>
+        </body>
+        </html>
+        """,
+            400,
+        )
+
+    state_error = get_oauth_state_error(
+        state, expected_state=load_pending_oauth_state()
+    )
+    if state_error:
+        return (
+            f"""
+        <html>
+        <head><title>Invalid OAuth State</title></head>
+        <body style="font-family: sans-serif; padding: 40px; text-align: center;">
+            <h1 style="color: #dc3545;">❌ Invalid OAuth State</h1>
+            <p>{html.escape(state_error)}</p>
             <p><a href="/">Back to home</a></p>
         </body>
         </html>
@@ -968,6 +1019,7 @@ def oauth_callback():
         }
 
         TOKENS_FILE.write_text(json.dumps(tokens, indent=2))
+        clear_pending_oauth_state()
         print(f"✓ OAuth tokens saved to {TOKENS_FILE}", file=sys.stderr)
 
         return """

--- a/scripts/linear/linear-webhook-server.py
+++ b/scripts/linear/linear-webhook-server.py
@@ -26,6 +26,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import httpx
+import linear_oauth_state  # type: ignore[import-not-found]
 from dotenv import load_dotenv
 from flask import Flask, jsonify, request
 
@@ -110,7 +111,6 @@ GPTME_TIMEOUT = 30 * 60  # 30 minutes
 LINEAR_API = "https://api.linear.app/graphql"
 LINEAR_OAUTH_TOKEN_URL = "https://api.linear.app/oauth/token"
 TOKENS_FILE = Path(__file__).parent / ".tokens.json"
-OAUTH_STATE_FILE = Path(__file__).parent / ".oauth-state"
 
 # Session tracking for deduplication
 processed_sessions: set[str] = set()
@@ -143,38 +143,6 @@ log.addHandler(_file_handler)
 
 # Path to the linear-activity.py CLI
 LINEAR_ACTIVITY_CLI = Path(__file__).parent / "linear-activity.py"
-
-
-def save_pending_oauth_state(state: str) -> None:
-    """Persist the pending OAuth state for the next callback."""
-    OAUTH_STATE_FILE.write_text(state)
-
-
-def load_pending_oauth_state() -> str | None:
-    """Load the pending OAuth state if it exists."""
-    if not OAUTH_STATE_FILE.exists():
-        return None
-
-    value = OAUTH_STATE_FILE.read_text().strip()
-    return value or None
-
-
-def clear_pending_oauth_state() -> None:
-    """Remove the pending OAuth state after a successful auth flow."""
-    OAUTH_STATE_FILE.unlink(missing_ok=True)
-
-
-def get_oauth_state_error(
-    received_state: str | None, *, expected_state: str | None
-) -> str | None:
-    """Return an error message when the OAuth state is missing or invalid."""
-    if not expected_state:
-        return "No pending OAuth state found. Start a new authorization attempt."
-    if not received_state:
-        return "No OAuth state found in callback URL."
-    if received_state != expected_state:
-        return "OAuth state mismatch. Start a new authorization attempt."
-    return None
 
 
 def ensure_valid_token() -> bool:
@@ -907,8 +875,9 @@ def oauth_callback():
             400,
         )
 
-    state_error = get_oauth_state_error(
-        state, expected_state=load_pending_oauth_state()
+    state_error = linear_oauth_state.get_oauth_state_error(
+        state,
+        expected_state=linear_oauth_state.load_pending_oauth_state(),
     )
     if state_error:
         return (
@@ -1019,7 +988,7 @@ def oauth_callback():
         }
 
         TOKENS_FILE.write_text(json.dumps(tokens, indent=2))
-        clear_pending_oauth_state()
+        linear_oauth_state.clear_pending_oauth_state()
         print(f"✓ OAuth tokens saved to {TOKENS_FILE}", file=sys.stderr)
 
         return """

--- a/scripts/linear/linear_oauth_state.py
+++ b/scripts/linear/linear_oauth_state.py
@@ -1,0 +1,47 @@
+"""Shared helpers for Linear OAuth state persistence and validation."""
+
+from __future__ import annotations
+
+import secrets
+from pathlib import Path
+
+OAUTH_STATE_FILE = Path(__file__).parent / ".oauth-state"
+
+
+def save_pending_oauth_state(state: str) -> None:
+    """Persist the pending OAuth state for the next callback."""
+    OAUTH_STATE_FILE.write_text(state)
+
+
+def load_pending_oauth_state() -> str | None:
+    """Load the pending OAuth state if it exists."""
+    if not OAUTH_STATE_FILE.exists():
+        return None
+
+    value = OAUTH_STATE_FILE.read_text().strip()
+    return value or None
+
+
+def clear_pending_oauth_state() -> None:
+    """Remove the pending OAuth state after a successful auth flow."""
+    OAUTH_STATE_FILE.unlink(missing_ok=True)
+
+
+def generate_and_save_oauth_state() -> str:
+    """Generate a per-attempt OAuth state and persist it."""
+    state = secrets.token_urlsafe(32)
+    save_pending_oauth_state(state)
+    return state
+
+
+def get_oauth_state_error(
+    received_state: str | None, *, expected_state: str | None
+) -> str | None:
+    """Return an error message when the OAuth state is missing or invalid."""
+    if not expected_state:
+        return "No pending OAuth state found. Start a new authorization attempt."
+    if not received_state:
+        return "No OAuth state found in callback URL."
+    if received_state != expected_state:
+        return "OAuth state mismatch. Start a new authorization attempt."
+    return None

--- a/tests/test_linear_oauth_state.py
+++ b/tests/test_linear_oauth_state.py
@@ -1,0 +1,157 @@
+"""Regression tests for Linear OAuth state validation."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+SCRIPT_DIR = Path(__file__).parent.parent / "scripts" / "linear"
+sys.path.insert(0, str(SCRIPT_DIR))
+
+LINEAR_ACTIVITY_PATH = SCRIPT_DIR / "linear-activity.py"
+LINEAR_WEBHOOK_PATH = SCRIPT_DIR / "linear-webhook-server.py"
+
+
+class DummyResponse:
+    """Minimal httpx-style response object for auth tests."""
+
+    def __init__(
+        self,
+        *,
+        status_code: int = 200,
+        payload: dict[str, object] | None = None,
+        text: str = "ok",
+    ) -> None:
+        self.status_code = status_code
+        self._payload = payload or {"access_token": "test-token", "expires_in": 3600}
+        self.text = text
+
+    def json(self) -> dict[str, object]:
+        return self._payload
+
+
+def load_script_module(name: str, path: Path):
+    """Import a script module directly from its filesystem path."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def configure_state_file(
+    monkeypatch: pytest.MonkeyPatch,
+    module: object,
+    state_file: Path,
+    *,
+    expected_state: str | None = None,
+) -> None:
+    """Route OAuth state storage to a temp file for the test."""
+    monkeypatch.setattr(module, "OAUTH_STATE_FILE", state_file, raising=False)
+
+    oauth_state = sys.modules.get("oauth_state")
+    if oauth_state is not None:
+        monkeypatch.setattr(oauth_state, "OAUTH_STATE_FILE", state_file)
+        if expected_state is not None:
+            oauth_state.save_pending_oauth_state(expected_state)
+        return
+
+    if expected_state is not None:
+        state_file.write_text(expected_state)
+
+
+@pytest.fixture
+def linear_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Set the required Linear webhook/CLI environment."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    monkeypatch.setenv("AGENT_NAME", "bob")
+    monkeypatch.setenv("AGENT_WORKSPACE", str(workspace))
+    monkeypatch.setenv("DEFAULT_BRANCH", "master")
+    monkeypatch.setenv("LINEAR_CLIENT_ID", "client-id")
+    monkeypatch.setenv("LINEAR_CLIENT_SECRET", "client-secret")
+    monkeypatch.setenv("LINEAR_CALLBACK_URL", "https://example.com/oauth/callback")
+    return tmp_path
+
+
+def test_do_auth_rejects_mismatched_state_before_token_exchange(
+    linear_env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """CLI auth must reject a callback URL whose state does not match."""
+    activity = load_script_module("linear_activity_under_test", LINEAR_ACTIVITY_PATH)
+    token_file = linear_env / "tokens.json"
+    state_file = linear_env / "oauth-state.json"
+    configure_state_file(monkeypatch, activity, state_file)
+    monkeypatch.setattr(activity, "TOKENS_FILE", token_file)
+
+    printed: list[str] = []
+    token_exchange_called = False
+
+    def fake_print(*args: object, **kwargs: object) -> None:
+        printed.append(" ".join(str(arg) for arg in args))
+
+    def fake_input(_prompt: str) -> str:
+        auth_url = next(
+            line.strip()
+            for line in printed
+            if "https://linear.app/oauth/authorize" in line
+        )
+        expected_state = parse_qs(urlparse(auth_url).query)["state"][0]
+        return (
+            "https://example.com/oauth/callback?"
+            f"code=test-code&state={expected_state}-wrong"
+        )
+
+    def fake_post(*args: object, **kwargs: object) -> DummyResponse:
+        nonlocal token_exchange_called
+        token_exchange_called = True
+        return DummyResponse()
+
+    monkeypatch.setattr("builtins.print", fake_print)
+    monkeypatch.setattr("builtins.input", fake_input)
+    monkeypatch.setattr(activity.httpx, "post", fake_post)
+
+    with pytest.raises(activity.AuthenticationError, match="state"):
+        activity.do_auth()
+
+    assert not token_exchange_called
+    assert not token_file.exists()
+
+
+def test_oauth_callback_rejects_mismatched_state_before_token_exchange(
+    linear_env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Webhook callback must reject a mismatched OAuth state."""
+    webhook = load_script_module("linear_webhook_under_test", LINEAR_WEBHOOK_PATH)
+    token_file = linear_env / "tokens.json"
+    state_file = linear_env / "oauth-state.json"
+    configure_state_file(
+        monkeypatch,
+        webhook,
+        state_file,
+        expected_state="expected-state",
+    )
+    monkeypatch.setattr(webhook, "TOKENS_FILE", token_file)
+
+    token_exchange_called = False
+
+    def fake_post(*args: object, **kwargs: object) -> DummyResponse:
+        nonlocal token_exchange_called
+        token_exchange_called = True
+        return DummyResponse()
+
+    monkeypatch.setattr(webhook.httpx, "post", fake_post)
+
+    response = webhook.app.test_client().get(
+        "/oauth/callback?code=test-code&state=wrong-state"
+    )
+
+    assert response.status_code == 400
+    assert "state" in response.get_data(as_text=True).lower()
+    assert not token_exchange_called
+    assert not token_file.exists()

--- a/tests/test_linear_oauth_state.py
+++ b/tests/test_linear_oauth_state.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import sys
 from pathlib import Path
+from typing import Any
 from urllib.parse import parse_qs, urlparse
 
 import pytest
@@ -45,23 +46,16 @@ def load_script_module(name: str, path: Path):
 
 def configure_state_file(
     monkeypatch: pytest.MonkeyPatch,
-    module: object,
+    module: Any,
     state_file: Path,
     *,
     expected_state: str | None = None,
 ) -> None:
     """Route OAuth state storage to a temp file for the test."""
-    monkeypatch.setattr(module, "OAUTH_STATE_FILE", state_file, raising=False)
-
-    oauth_state = sys.modules.get("oauth_state")
-    if oauth_state is not None:
-        monkeypatch.setattr(oauth_state, "OAUTH_STATE_FILE", state_file)
-        if expected_state is not None:
-            oauth_state.save_pending_oauth_state(expected_state)
-        return
+    monkeypatch.setattr(module.linear_oauth_state, "OAUTH_STATE_FILE", state_file)
 
     if expected_state is not None:
-        state_file.write_text(expected_state)
+        module.linear_oauth_state.save_pending_oauth_state(expected_state)
 
 
 @pytest.fixture
@@ -120,6 +114,7 @@ def test_do_auth_rejects_mismatched_state_before_token_exchange(
         activity.do_auth()
 
     assert not token_exchange_called
+    assert not state_file.exists()
     assert not token_file.exists()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1406,6 +1406,7 @@ source = { virtual = "." }
 
 [package.dev-dependencies]
 dev = [
+    { name = "flask" },
     { name = "mcp" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1419,6 +1420,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "flask", specifier = ">=3.0.0" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.0" },


### PR DESCRIPTION
## Summary
- generate a per-attempt OAuth state in the Linear CLI auth flow and validate it before token exchange
- reject missing or mismatched state in the webhook callback and ignore the runtime state file in git
- add focused regression coverage and the Flask test dependency needed to import the webhook server in tests

## Testing
- uv run pytest tests/test_linear_oauth_state.py -q
- uv run ruff check scripts/linear/linear-activity.py scripts/linear/linear-webhook-server.py tests/test_linear_oauth_state.py
- uv run --with mypy --with flask mypy scripts/linear/linear-activity.py scripts/linear/linear-webhook-server.py tests/test_linear_oauth_state.py
- python3 -m py_compile scripts/linear/linear-activity.py scripts/linear/linear-webhook-server.py tests/test_linear_oauth_state.py