### PR TITLE
fix(gptme-codegraph): preserve decorated python defs

### DIFF
--- a/packages/gptme-codegraph/src/gptme_codegraph/core.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/core.py
@@ -834,6 +834,80 @@ def _extract_imports_javascript(root) -> list[ImportInfo]:
 
 
 # ---------------------------------------------------------------------------
+# Python extraction
+# ---------------------------------------------------------------------------
+
+
+def _unwrap_python_definition(node):
+    """Return the underlying Python definition for decorated nodes."""
+    if node.type != "decorated_definition":
+        return node
+
+    for child in node.named_children:
+        if child.type in ("function_definition", "class_definition"):
+            return child
+    return None
+
+
+def _extract_symbols_python(root, filepath: str) -> list[Symbol]:
+    """Extract functions, classes, and methods from a Python parse tree."""
+    symbols: list[Symbol] = []
+
+    def walk(node, parent_class: str | None = None):
+        node = _unwrap_python_definition(node)
+        if node is None:
+            return
+
+        if node.type == "function_definition":
+            name_node = node.child_by_field_name("name")
+            body_node = node.child_by_field_name("body")
+            if name_node:
+                name = _text(name_node)
+                calls = _extract_calls(body_node) if body_node else []
+                docstring = _extract_docstring(body_node) if body_node else None
+                kind = "method" if parent_class else "function"
+                symbols.append(
+                    Symbol(
+                        name=name,
+                        kind=kind,
+                        file=filepath,
+                        start_line=node.start_point[0] + 1,
+                        end_line=node.end_point[0] + 1,
+                        parent_class=parent_class,
+                        docstring=docstring,
+                        calls=list(set(calls)),
+                    )
+                )
+            return
+
+        if node.type == "class_definition":
+            name_node = node.child_by_field_name("name")
+            body_node = node.child_by_field_name("body")
+            if name_node:
+                name = _text(name_node)
+                docstring = _extract_docstring(body_node) if body_node else None
+                symbols.append(
+                    Symbol(
+                        name=name,
+                        kind="class",
+                        file=filepath,
+                        start_line=node.start_point[0] + 1,
+                        end_line=node.end_point[0] + 1,
+                        docstring=docstring,
+                    )
+                )
+                if body_node:
+                    for child in body_node.named_children:
+                        walk(child, parent_class=name)
+            return
+
+    for child in root.named_children:
+        walk(child)
+
+    return symbols
+
+
+# ---------------------------------------------------------------------------
 # TypeScript / JavaScript extraction
 # ---------------------------------------------------------------------------
 
@@ -1060,51 +1134,7 @@ def parse_file(filepath: Path) -> FileParseResult:
     symbols: list[Symbol] = []
 
     if lang_name == "python":
-        # --- Python extraction (existing logic) ---
-
-        def walk(node, parent_class: str | None = None):
-            if node.type == "function_definition":
-                name_node = node.child_by_field_name("name")
-                body_node = node.child_by_field_name("body")
-                if name_node:
-                    name = _text(name_node)
-                    calls = _extract_calls(body_node) if body_node else []
-                    docstring = _extract_docstring(body_node) if body_node else None
-                    kind = "method" if parent_class else "function"
-                    symbols.append(
-                        Symbol(
-                            name=name,
-                            kind=kind,
-                            file=filename,
-                            start_line=node.start_point[0] + 1,
-                            end_line=node.end_point[0] + 1,
-                            parent_class=parent_class,
-                            docstring=docstring,
-                            calls=list(set(calls)),
-                        )
-                    )
-            elif node.type == "class_definition":
-                name_node = node.child_by_field_name("name")
-                body_node = node.child_by_field_name("body")
-                if name_node:
-                    name = _text(name_node)
-                    docstring = _extract_docstring(body_node) if body_node else None
-                    symbols.append(
-                        Symbol(
-                            name=name,
-                            kind="class",
-                            file=filename,
-                            start_line=node.start_point[0] + 1,
-                            end_line=node.end_point[0] + 1,
-                            docstring=docstring,
-                        )
-                    )
-                    if body_node:
-                        for child in body_node.named_children:
-                            walk(child, parent_class=name)
-
-        for child in root.named_children:
-            walk(child)
+        symbols = _extract_symbols_python(root, filename)
 
     elif lang_name in ("typescript", "javascript", "tsx"):
         symbols = _extract_symbols_typescript(root, filename)

--- a/packages/gptme-codegraph/src/gptme_codegraph/core.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/core.py
@@ -854,13 +854,18 @@ def _extract_symbols_python(root, filepath: str) -> list[Symbol]:
     symbols: list[Symbol] = []
 
     def walk(node, parent_class: str | None = None):
-        node = _unwrap_python_definition(node)
-        if node is None:
+        unwrapped = _unwrap_python_definition(node)
+        if unwrapped is None:
             return
 
-        if node.type == "function_definition":
-            name_node = node.child_by_field_name("name")
-            body_node = node.child_by_field_name("body")
+        # Use the outer (decorated_definition) node for start_line so
+        # decorated symbols report their full extent (first decorator),
+        # not just the def/class keyword line.
+        start_node = node if node.type == "decorated_definition" else unwrapped
+
+        if unwrapped.type == "function_definition":
+            name_node = unwrapped.child_by_field_name("name")
+            body_node = unwrapped.child_by_field_name("body")
             if name_node:
                 name = _text(name_node)
                 calls = _extract_calls(body_node) if body_node else []
@@ -871,8 +876,8 @@ def _extract_symbols_python(root, filepath: str) -> list[Symbol]:
                         name=name,
                         kind=kind,
                         file=filepath,
-                        start_line=node.start_point[0] + 1,
-                        end_line=node.end_point[0] + 1,
+                        start_line=start_node.start_point[0] + 1,
+                        end_line=unwrapped.end_point[0] + 1,
                         parent_class=parent_class,
                         docstring=docstring,
                         calls=list(set(calls)),
@@ -880,9 +885,9 @@ def _extract_symbols_python(root, filepath: str) -> list[Symbol]:
                 )
             return
 
-        if node.type == "class_definition":
-            name_node = node.child_by_field_name("name")
-            body_node = node.child_by_field_name("body")
+        if unwrapped.type == "class_definition":
+            name_node = unwrapped.child_by_field_name("name")
+            body_node = unwrapped.child_by_field_name("body")
             if name_node:
                 name = _text(name_node)
                 docstring = _extract_docstring(body_node) if body_node else None
@@ -891,8 +896,8 @@ def _extract_symbols_python(root, filepath: str) -> list[Symbol]:
                         name=name,
                         kind="class",
                         file=filepath,
-                        start_line=node.start_point[0] + 1,
-                        end_line=node.end_point[0] + 1,
+                        start_line=start_node.start_point[0] + 1,
+                        end_line=unwrapped.end_point[0] + 1,
                         docstring=docstring,
                     )
                 )

--- a/packages/gptme-codegraph/tests/test_codegraph.py
+++ b/packages/gptme-codegraph/tests/test_codegraph.py
@@ -968,11 +968,13 @@ class Tool:
         symbol for symbol in result.symbols if symbol.name == "cmd_plugin"
     )
     assert "helper" in cmd_plugin.calls
+    assert cmd_plugin.start_line == 12  # decorator line, not def keyword (13)
 
     cmd_run = next(symbol for symbol in result.symbols if symbol.name == "cmd_run")
     assert cmd_run.kind == "method"
     assert cmd_run.parent_class == "Tool"
     assert "helper" in cmd_run.calls
+    assert cmd_run.start_line == 18  # decorator line, not def keyword (19)
 
 
 # ---------------------------------------------------------------------------
@@ -1089,6 +1091,7 @@ def cmd_plugin():
 
     assert len(entries) == 1
     assert entries[0].kind == "function"
+    assert entries[0].start_line == 12  # decorator line (not def keyword at 13)
 
     callees, callers = build_cross_file_call_graph(index, tmp_path)
 

--- a/packages/gptme-codegraph/tests/test_codegraph.py
+++ b/packages/gptme-codegraph/tests/test_codegraph.py
@@ -932,6 +932,49 @@ def test_parse_file_returns_imports(tmp_path: Path):
     assert result.imports[0].name == "json"
 
 
+def test_parse_file_includes_decorated_python_definitions(tmp_path: Path):
+    """parse_file preserves decorated Python functions and methods."""
+    f = tmp_path / "decorated.py"
+    f.write_text(
+        """
+def command(name):
+    def decorator(func):
+        return func
+    return decorator
+
+
+def helper():
+    return "ok"
+
+
+@command("plugin")
+def cmd_plugin():
+    return helper()
+
+
+class Tool:
+    @command("run")
+    def cmd_run(self):
+        return helper()
+"""
+    )
+
+    result = parse_file(f)
+    names = {symbol.name for symbol in result.symbols}
+
+    assert {"command", "helper", "cmd_plugin", "Tool", "cmd_run"} <= names
+
+    cmd_plugin = next(
+        symbol for symbol in result.symbols if symbol.name == "cmd_plugin"
+    )
+    assert "helper" in cmd_plugin.calls
+
+    cmd_run = next(symbol for symbol in result.symbols if symbol.name == "cmd_run")
+    assert cmd_run.kind == "method"
+    assert cmd_run.parent_class == "Tool"
+    assert "helper" in cmd_run.calls
+
+
 # ---------------------------------------------------------------------------
 # Cross-file call graph
 # ---------------------------------------------------------------------------
@@ -1019,3 +1062,35 @@ def test_build_index_collects_imports(tmp_path: Path):
     names = {imp.name for imp in imports}
     assert "os" in names
     assert "path" in names
+
+
+def test_build_index_and_call_graph_include_decorated_functions(tmp_path: Path):
+    """Decorated Python functions stay visible to the index and call graph."""
+    (tmp_path / "main.py").write_text(
+        """
+def command(name):
+    def decorator(func):
+        return func
+    return decorator
+
+
+def helper():
+    return "ok"
+
+
+@command("plugin")
+def cmd_plugin():
+    return helper()
+"""
+    )
+
+    index = build_index(tmp_path)
+    entries = index.lookup("cmd_plugin")
+
+    assert len(entries) == 1
+    assert entries[0].kind == "function"
+
+    callees, callers = build_cross_file_call_graph(index, tmp_path)
+
+    assert "main::helper" in callees.get("main::cmd_plugin", set())
+    assert "main::cmd_plugin" in callers.get("main::helper", set())


### PR DESCRIPTION
## Summary
- teach the Python extractor to unwrap `decorated_definition` nodes before symbol extraction
- add regression coverage proving decorated functions and methods survive `parse_file()`, indexing, and call-graph construction
- restore real `gptme` command entrypoints like `cmd_plugin` to `parse`, `def`, and `callees` output

## Root Cause
The Python path in `parse_file()` only visited raw `function_definition` and `class_definition` nodes. Tree-sitter wraps decorated defs in `decorated_definition`, so decorated commands in `gptme/commands/meta.py` were skipped entirely.

## Validation
- `PYTHONPATH=/tmp/worktrees/gptme-contrib/codegraph-decorated-python-entrypoints/packages/gptme-codegraph/src uv run pytest /tmp/worktrees/gptme-contrib/codegraph-decorated-python-entrypoints/packages/gptme-codegraph/tests -q`
- `PYTHONPATH=/tmp/worktrees/gptme-contrib/codegraph-decorated-python-entrypoints/packages/gptme-codegraph/src uv run gptme-codegraph /home/bob/projects/gptme/gptme/commands/meta.py parse --json`
- `PYTHONPATH=/tmp/worktrees/gptme-contrib/codegraph-decorated-python-entrypoints/packages/gptme-codegraph/src uv run gptme-codegraph /home/bob/projects/gptme/gptme/commands/meta.py --directory /home/bob/projects/gptme def cmd_plugin --json`
- `PYTHONPATH=/tmp/worktrees/gptme-contrib/codegraph-decorated-python-entrypoints/packages/gptme-codegraph/src uv run gptme-codegraph /home/bob/projects/gptme/gptme/commands/meta.py --directory /home/bob/projects/gptme callees cmd_plugin --json`
