### PR TITLE
feat(gptme-sessions): extract Codex project from session payload.cwd

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/discovery.py
+++ b/packages/gptme-sessions/src/gptme_sessions/discovery.py
@@ -524,6 +524,7 @@ def extract_project(harness: str, path: Path) -> str | None:
     - **claude-code**: decode the project directory name via
       :func:`decode_cc_project_path` (e.g. ``-Users-erb-myproj`` → ``/Users/erb/myproj``)
     - **gptme**: read ``workspace`` from the session's ``config.toml``
+    - **codex**: read ``payload.cwd`` from the first event in the JSONL file
 
     Returns ``None`` for harnesses where project cannot be determined.
     """
@@ -537,7 +538,25 @@ def extract_project(harness: str, path: Path) -> str | None:
         config = parse_gptme_config(session_dir)
         workspace = config.get("workspace", "")
         return workspace if workspace else None
+    elif harness == "codex":
+        # Read the first event's payload.cwd from the JSONL file
+        return _first_event_cwd(path)
     return None
+
+
+def _first_event_cwd(jsonl_path: Path) -> str | None:
+    """Extract ``payload.cwd`` from the first event in a Codex JSONL file."""
+    try:
+        with jsonl_path.open(encoding="utf-8") as f:
+            first_line = f.readline().strip()
+        if not first_line:
+            return None
+        event = json.loads(first_line)
+        payload: dict[str, object] = event.get("payload", {})
+        cwd: object = payload.get("cwd")
+        return str(cwd) if isinstance(cwd, str) else None
+    except (OSError, json.JSONDecodeError, AttributeError):
+        return None
 
 
 def discover_copilot_sessions(

--- a/packages/gptme-sessions/tests/test_discovery.py
+++ b/packages/gptme-sessions/tests/test_discovery.py
@@ -835,6 +835,12 @@ class TestExtractProject:
         jsonl.write_text(json.dumps(event) + "\n")
         assert extract_project("codex", jsonl) is None
 
+    def test_codex_invalid_json_returns_none(self, tmp_path: Path) -> None:
+        """codex: returns None when the first line is not valid JSON."""
+        jsonl = tmp_path / "session.jsonl"
+        jsonl.write_text("not valid json{{{[[[")
+        assert extract_project("codex", jsonl) is None
+
     def test_copilot_returns_none(self, tmp_path: Path) -> None:
         """copilot: returns None (no project info available)."""
         events = tmp_path / "events.jsonl"

--- a/packages/gptme-sessions/tests/test_discovery.py
+++ b/packages/gptme-sessions/tests/test_discovery.py
@@ -803,11 +803,23 @@ class TestExtractProject:
         config.write_text("[chat]\nmodel = 'opus'\n")
         assert extract_project("gptme", session_dir) is None
 
-    def test_codex_returns_none(self, tmp_path: Path) -> None:
-        """codex: returns None (no project info available)."""
+    def test_codex_empty_file(self, tmp_path: Path) -> None:
+        """codex: returns None when JSONL is empty."""
         jsonl = tmp_path / "session.jsonl"
         jsonl.touch()
         assert extract_project("codex", jsonl) is None
+
+    def test_codex_extracts_cwd(self, tmp_path: Path) -> None:
+        """codex: extracts cwd from the first event's payload."""
+        import json
+
+        jsonl = tmp_path / "session.jsonl"
+        event = {
+            "type": "session_meta",
+            "payload": {"cwd": "/home/bob/bob"},
+        }
+        jsonl.write_text(json.dumps(event) + "\n")
+        assert extract_project("codex", jsonl) == "/home/bob/bob"
 
     def test_copilot_returns_none(self, tmp_path: Path) -> None:
         """copilot: returns None (no project info available)."""

--- a/packages/gptme-sessions/tests/test_discovery.py
+++ b/packages/gptme-sessions/tests/test_discovery.py
@@ -811,8 +811,6 @@ class TestExtractProject:
 
     def test_codex_extracts_cwd(self, tmp_path: Path) -> None:
         """codex: extracts cwd from the first event's payload."""
-        import json
-
         jsonl = tmp_path / "session.jsonl"
         event = {
             "type": "session_meta",
@@ -820,6 +818,22 @@ class TestExtractProject:
         }
         jsonl.write_text(json.dumps(event) + "\n")
         assert extract_project("codex", jsonl) == "/home/bob/bob"
+
+    def test_codex_non_dict_first_event_returns_none(self, tmp_path: Path) -> None:
+        """codex: returns None when the first JSONL value is not an object."""
+        jsonl = tmp_path / "session.jsonl"
+        jsonl.write_text('["not", "an", "object"]\n')
+        assert extract_project("codex", jsonl) is None
+
+    def test_codex_non_string_cwd_returns_none(self, tmp_path: Path) -> None:
+        """codex: returns None when payload.cwd is not a string."""
+        jsonl = tmp_path / "session.jsonl"
+        event = {
+            "type": "session_meta",
+            "payload": {"cwd": 123},
+        }
+        jsonl.write_text(json.dumps(event) + "\n")
+        assert extract_project("codex", jsonl) is None
 
     def test_copilot_returns_none(self, tmp_path: Path) -> None:
         """copilot: returns None (no project info available)."""


### PR DESCRIPTION
## Problem

Session record field coverage (self-review check 14) flagged `project` as a zero-coverage field. Codex sessions always had `project: null` because `extract_project("codex", ...)` unconditionally returned `None`.

## Fix

Codex JSONL sessions record the working directory in `payload.cwd` of the first event (a `session_meta` event). This PR adds extraction for the `codex` harness by reading the first line of the JSONL and extracting `payload.cwd`, matching the pattern already used by claude-code (project dir decoding) and gptme (config.toml reading).

## Changes

- `discovery.py`: Add `_first_event_cwd()` helper and wire it into `extract_project("codex", ...)`
- `test_discovery.py`: Replace the old `test_codex_returns_none` with two tests:
  - `test_codex_empty_file` — empty JSONL returns None
  - `test_codex_extracts_cwd` — valid JSONL extracts project from `payload.cwd`

## Verification

- `uv run pytest packages/gptme-sessions/tests/test_discovery.py -k TestExtractProject -v` — 8 passed
- `uv run pytest packages/gptme-sessions/tests/test_discovery.py` — 68 passed
- `uv run --with mypy mypy src/ --ignore-missing-imports` — clean (from package dir)