### PR TITLE
fix(gptmail): sort unreplied emails by date

### DIFF
--- a/packages/gptmail/src/gptmail/lib.py
+++ b/packages/gptmail/src/gptmail/lib.py
@@ -292,7 +292,6 @@ class AgentEmail:
         )
 
     # TODO: this should probably return some list[Message] or list[EmailMessage] type instead of a list of tuples
-    # TODO: this should probably sort the emails by timestamp in some suitable order (or make it easy for consumers to sort by using an Message type)
     def get_unreplied_emails(self, folders: list[str] | None = None) -> list[tuple[str, str, str]]:
         """Get list of emails that haven't been replied to.
 
@@ -307,7 +306,7 @@ class AgentEmail:
             # Default to inbox only - caller can pass ["inbox", "archive"] if needed
             folders = ["inbox"]
 
-        unreplied = []
+        unreplied_with_dates: list[tuple[datetime, str, tuple[str, str, str]]] = []
         seen_message_ids: set[str] = set()  # Avoid duplicates across folders
 
         for folder in folders:
@@ -336,6 +335,7 @@ class AgentEmail:
                     seen_message_ids.add(message_id)
 
                     subject = subject_match.group(1)
+                    date_match = re.search(r"Date: (.+)", content)
                     from_line = from_match.group(1)
 
                     # Skip if not addressed to the agent's email
@@ -380,13 +380,22 @@ class AgentEmail:
                     if already_replied:
                         continue
 
-                    unreplied.append((message_id, subject, sender))
+                    sort_date = (
+                        self._parse_email_date(date_match.group(1))
+                        if date_match
+                        else datetime.min.replace(tzinfo=timezone.utc)
+                    )
+                    unreplied_with_dates.append(
+                        (sort_date, email_file.name, (message_id, subject, sender))
+                    )
 
                 except Exception as e:
                     print(f"Error processing {email_file}: {e}")
                     continue
 
-        return unreplied
+        # Oldest-first keeps watcher and CLI processing deterministic.
+        unreplied_with_dates.sort(key=lambda item: (item[0], item[1]))
+        return [item[2] for item in unreplied_with_dates]
 
     def _is_allowlisted_sender(self, sender: str) -> bool:
         """Check if sender is allowlisted for auto-responses.

--- a/packages/gptmail/tests/test_unreplied_emails.py
+++ b/packages/gptmail/tests/test_unreplied_emails.py
@@ -1,0 +1,84 @@
+"""Tests for unreplied email discovery ordering."""
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from gptmail.lib import AgentEmail
+
+
+@pytest.fixture
+def agent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> AgentEmail:
+    """Create a minimal AgentEmail with an explicit allowlist."""
+    email_dir = tmp_path / "email"
+    for subdir in ["inbox", "sent", "archive", "drafts", "filters"]:
+        (email_dir / subdir).mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("EMAIL_ALLOWLIST", "friend@example.com")
+    return AgentEmail(str(tmp_path), "test@example.com")
+
+
+def _write_email(
+    path: Path,
+    *,
+    message_id: str,
+    subject: str,
+    sender: str,
+    recipient: str,
+    date: datetime,
+) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                f"Message-ID: {message_id}",
+                f"From: Friend <{sender}>",
+                f"To: {recipient}",
+                f"Date: {date.strftime('%a, %d %b %Y %H:%M:%S %z')}",
+                f"Subject: {subject}",
+                "",
+                "Body",
+            ]
+        )
+    )
+
+
+def test_get_unreplied_emails_sorts_oldest_first(
+    agent: AgentEmail,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    inbox = agent.email_dir / "inbox"
+    older = inbox / "z-older.md"
+    newer = inbox / "a-newer.md"
+
+    _write_email(
+        older,
+        message_id="<older@example.com>",
+        subject="Older",
+        sender="friend@example.com",
+        recipient="test@example.com",
+        date=datetime(2026, 5, 16, 9, 0, tzinfo=timezone.utc),
+    )
+    _write_email(
+        newer,
+        message_id="<newer@example.com>",
+        subject="Newer",
+        sender="friend@example.com",
+        recipient="test@example.com",
+        date=datetime(2026, 5, 16, 10, 0, tzinfo=timezone.utc),
+    )
+
+    original_glob = Path.glob
+
+    def reversed_inbox_glob(self: Path, pattern: str):
+        if self == inbox and pattern == "*.md":
+            return iter([newer, older])
+        return original_glob(self, pattern)
+
+    monkeypatch.setattr(Path, "glob", reversed_inbox_glob)
+
+    unreplied = agent.get_unreplied_emails()
+
+    assert [message_id for message_id, _, _ in unreplied] == [
+        "<older@example.com>",
+        "<newer@example.com>",
+    ]


### PR DESCRIPTION
## Summary
- sort `AgentEmail.get_unreplied_emails()` oldest-first instead of returning filesystem-order results
- use the email filename as a deterministic tiebreaker when timestamps match or are missing
- add a regression test that proves reversed glob order still yields chronological processing

## Testing
- `uv run pytest tests -q`
- `uv run ruff check src/gptmail/lib.py tests/test_unreplied_emails.py`