### PR TITLE
fix(gptmail): treat malformed dates as oldest

### DIFF
--- a/packages/gptmail/src/gptmail/lib.py
+++ b/packages/gptmail/src/gptmail/lib.py
@@ -380,11 +380,7 @@ class AgentEmail:
                     if already_replied:
                         continue
 
-                    sort_date = (
-                        self._parse_email_date(date_match.group(1))
-                        if date_match
-                        else datetime.min.replace(tzinfo=timezone.utc)
-                    )
+                    sort_date = self._parse_email_date(date_match.group(1) if date_match else "")
                     unreplied_with_dates.append(
                         (sort_date, email_file.name, (message_id, subject, sender))
                     )
@@ -1051,8 +1047,8 @@ class AgentEmail:
 
             return parsedate_to_datetime(date_str)
         except Exception:
-            # Fallback to current time if parsing fails
-            return datetime.now(timezone.utc)
+            # Unknown dates should sort with the oldest messages.
+            return datetime.min.replace(tzinfo=timezone.utc)
 
     def _format_thread_display(self, message_id: str) -> str:
         """Format a complete thread for display."""

--- a/packages/gptmail/src/gptmail/lib.py
+++ b/packages/gptmail/src/gptmail/lib.py
@@ -380,7 +380,10 @@ class AgentEmail:
                     if already_replied:
                         continue
 
-                    sort_date = self._parse_email_date(date_match.group(1) if date_match else "")
+                    sort_date = self._parse_email_date(
+                        date_match.group(1) if date_match else "",
+                        invalid_default=datetime.min.replace(tzinfo=timezone.utc),
+                    )
                     unreplied_with_dates.append(
                         (sort_date, email_file.name, (message_id, subject, sender))
                     )
@@ -1037,18 +1040,22 @@ class AgentEmail:
 
         return "unknown"
 
-    def _parse_email_date(self, date_str: str) -> datetime:
+    def _parse_email_date(
+        self, date_str: str, *, invalid_default: datetime | None = None
+    ) -> datetime:
         """Parse email date string to datetime object."""
         if not date_str:
             return datetime.min.replace(tzinfo=timezone.utc)
+
+        if invalid_default is None:
+            invalid_default = datetime.now(timezone.utc)
 
         try:
             # Try parsing RFC 2822 format
 
             return parsedate_to_datetime(date_str)
         except Exception:
-            # Unknown dates should sort with the oldest messages.
-            return datetime.min.replace(tzinfo=timezone.utc)
+            return invalid_default
 
     def _format_thread_display(self, message_id: str) -> str:
         """Format a complete thread for display."""

--- a/packages/gptmail/tests/test_unreplied_emails.py
+++ b/packages/gptmail/tests/test_unreplied_emails.py
@@ -42,6 +42,32 @@ def _write_email(
     )
 
 
+def _write_email_with_raw_date(
+    path: Path,
+    *,
+    message_id: str,
+    subject: str,
+    sender: str,
+    recipient: str,
+    date_header: str | None,
+) -> None:
+    lines = [
+        f"Message-ID: {message_id}",
+        f"From: Friend <{sender}>",
+        f"To: {recipient}",
+    ]
+    if date_header is not None:
+        lines.append(f"Date: {date_header}")
+    lines.extend(
+        [
+            f"Subject: {subject}",
+            "",
+            "Body",
+        ]
+    )
+    path.write_text("\n".join(lines))
+
+
 def test_get_unreplied_emails_sorts_oldest_first(
     agent: AgentEmail,
     monkeypatch: pytest.MonkeyPatch,
@@ -81,4 +107,43 @@ def test_get_unreplied_emails_sorts_oldest_first(
     assert [message_id for message_id, _, _ in unreplied] == [
         "<older@example.com>",
         "<newer@example.com>",
+    ]
+
+
+def test_get_unreplied_emails_treats_missing_and_malformed_dates_as_oldest(
+    agent: AgentEmail,
+) -> None:
+    inbox = agent.email_dir / "inbox"
+
+    _write_email_with_raw_date(
+        inbox / "b-missing-date.md",
+        message_id="<missing@example.com>",
+        subject="Missing date",
+        sender="friend@example.com",
+        recipient="test@example.com",
+        date_header=None,
+    )
+    _write_email_with_raw_date(
+        inbox / "a-malformed-date.md",
+        message_id="<malformed@example.com>",
+        subject="Malformed date",
+        sender="friend@example.com",
+        recipient="test@example.com",
+        date_header="definitely not a real date",
+    )
+    _write_email(
+        inbox / "c-valid-date.md",
+        message_id="<valid@example.com>",
+        subject="Valid date",
+        sender="friend@example.com",
+        recipient="test@example.com",
+        date=datetime(2026, 5, 16, 10, 0, tzinfo=timezone.utc),
+    )
+
+    unreplied = agent.get_unreplied_emails()
+
+    assert [message_id for message_id, _, _ in unreplied] == [
+        "<malformed@example.com>",
+        "<missing@example.com>",
+        "<valid@example.com>",
     ]

--- a/packages/gptmail/tests/test_unreplied_emails.py
+++ b/packages/gptmail/tests/test_unreplied_emails.py
@@ -50,6 +50,7 @@ def _write_email_with_raw_date(
     sender: str,
     recipient: str,
     date_header: str | None,
+    in_reply_to: str | None = None,
 ) -> None:
     lines = [
         f"Message-ID: {message_id}",
@@ -58,6 +59,8 @@ def _write_email_with_raw_date(
     ]
     if date_header is not None:
         lines.append(f"Date: {date_header}")
+    if in_reply_to is not None:
+        lines.append(f"In-Reply-To: {in_reply_to}")
     lines.extend(
         [
             f"Subject: {subject}",
@@ -147,3 +150,61 @@ def test_get_unreplied_emails_treats_missing_and_malformed_dates_as_oldest(
         "<missing@example.com>",
         "<valid@example.com>",
     ]
+
+
+def test_list_messages_keeps_malformed_dates_last(agent: AgentEmail) -> None:
+    inbox = agent.email_dir / "inbox"
+
+    _write_email(
+        inbox / "valid-date.md",
+        message_id="<valid@example.com>",
+        subject="Valid date",
+        sender="friend@example.com",
+        recipient="test@example.com",
+        date=datetime(2000, 1, 1, 10, 0, tzinfo=timezone.utc),
+    )
+    _write_email_with_raw_date(
+        inbox / "malformed-date.md",
+        message_id="<malformed@example.com>",
+        subject="Malformed date",
+        sender="friend@example.com",
+        recipient="test@example.com",
+        date_header="definitely not a real date",
+    )
+
+    messages = agent.list_messages("inbox")
+
+    assert [message_id for message_id, _, _ in messages] == [
+        "<valid@example.com>",
+        "<malformed@example.com>",
+    ]
+
+
+def test_get_thread_messages_keeps_malformed_dates_last(agent: AgentEmail) -> None:
+    inbox = agent.email_dir / "inbox"
+    sent = agent.email_dir / "sent"
+
+    root_id = "<root@example.com>"
+    reply_id = "<reply@example.com>"
+
+    _write_email(
+        inbox / agent._format_filename(root_id),
+        message_id=root_id,
+        subject="Root message",
+        sender="friend@example.com",
+        recipient="test@example.com",
+        date=datetime(2000, 1, 1, 10, 0, tzinfo=timezone.utc),
+    )
+    _write_email_with_raw_date(
+        sent / agent._format_filename(reply_id),
+        message_id=reply_id,
+        subject="Reply message",
+        sender="test@example.com",
+        recipient="friend@example.com",
+        date_header="definitely not a real date",
+        in_reply_to=root_id,
+    )
+
+    thread_messages = agent.get_thread_messages(root_id)
+
+    assert [message["id"] for message in thread_messages] == [root_id, reply_id]


### PR DESCRIPTION
## Summary
- treat malformed email `Date` headers the same as missing ones by sorting both into the oldest bucket
- route `get_unreplied_emails()` through `_parse_email_date()` for both present and missing headers
- add a regression test covering malformed and missing dates together

## Context
Follow-up to #920 after an unresolved Greptile review comment flagged inconsistent fallback ordering for unknown dates.

## Testing
- `uv run pytest tests -q`
- `uv run ruff check packages/gptmail/src/gptmail/lib.py packages/gptmail/tests/test_unreplied_emails.py`
