### PR TITLE
fix(discord): persist conversation logs across restarts

### DIFF
--- a/scripts/discord/discord_bot.py
+++ b/scripts/discord/discord_bot.py
@@ -69,7 +69,7 @@ DISCORD_MSG_LIMIT = 2000
 ChannelID: TypeAlias = int
 CommandPrefix = str | Callable[..., str]  # Type for command prefix
 Settings: TypeAlias = Dict[ChannelID, "ChannelSettings"]
-Conversations: TypeAlias = Dict[ChannelID, Log]
+Conversations: TypeAlias = Dict[ChannelID, LogManager]
 
 # Global state with type hints
 conversations: Conversations = {}  # channel_id -> conversation log
@@ -382,13 +382,12 @@ def get_conversation(channel_id: ChannelID) -> Log:
         logpath = logsdir / str(channel_id)
         logpath.mkdir(parents=True, exist_ok=True)
         logger.info(f"Loading conversation log for channel {channel_id} ({logpath})")
-        # TODO: actually save conversations so there is something to load/resume, persisting tooluse responses across messages
         manager = LogManager.load(logpath, initial_msgs, create=True)
-        conversations[channel_id] = manager.log
+        conversations[channel_id] = manager
 
     # always keep system messages fresh
     # strip leading system messages, replace with initial_msgs
-    msgs = copy(conversations[channel_id].messages)
+    msgs = copy(conversations[channel_id].log.messages)
     while msgs and msgs[0].role == "system" and "<chat-history>" not in msgs[0].content:
         msgs.pop(0)
     for msg in reversed(initial_msgs):
@@ -753,7 +752,7 @@ async def status(ctx: commands.Context) -> None:
     """Show status of the current conversation."""
     channel_id = ctx.channel.id
     if channel_id in conversations:
-        log = conversations[channel_id]
+        log = conversations[channel_id].log
         msg_count = len(log)
         user_msgs = sum(1 for m in log if m.role == "user")
         assistant_msgs = sum(1 for m in log if m.role == "assistant")
@@ -896,7 +895,9 @@ async def process_conversation_step(
     had_error = False
     accumulated_content = ""
 
-    async for msg in async_step(conversations[channel_id], channel_id, message.channel):
+    async for msg in async_step(
+        conversations[channel_id].log, channel_id, message.channel
+    ):
         logger.info(f"Processing response msg: {msg}")
         (
             current_response,
@@ -906,11 +907,13 @@ async def process_conversation_step(
         ) = await process_message(
             msg,
             message.channel,
-            conversations[channel_id],
+            conversations[channel_id].log,
             current_response,
             accumulated_content,
         )
-        conversations[channel_id] = updated_log
+        # Sync the updated log back through the LogManager and write to disk
+        conversations[channel_id].log = updated_log
+        conversations[channel_id].write()
         had_error = had_error or msg_error
 
     return current_response, had_error
@@ -978,7 +981,7 @@ async def on_message(message: discord.Message) -> None:
             return  # Don't process the message further, let the welcome message be the only response
 
     # Add user message to conversation (only if we're not showing the welcome message)
-    conversations[channel_id] = log.append(Message("user", content))
+    conversations[channel_id].append(Message("user", content))
 
     try:
         # Setup message processing

--- a/scripts/discord/discord_bot.py
+++ b/scripts/discord/discord_bot.py
@@ -23,6 +23,7 @@ import contextvars
 import logging
 import os
 import re
+import shutil
 from copy import copy
 from pathlib import Path
 from typing import (
@@ -740,8 +741,16 @@ async def checkperms(ctx: commands.Context) -> None:
 async def clear(ctx: commands.Context) -> None:
     """Clear the conversation history in this channel."""
     channel_id = ctx.channel.id
-    if channel_id in conversations:
+    logpath = logsdir / str(channel_id)
+    had_memory = channel_id in conversations
+    had_persisted = logpath.exists()
+
+    if had_memory:
         del conversations[channel_id]
+    if had_persisted:
+        shutil.rmtree(logpath)
+
+    if had_memory or had_persisted:
         await ctx.send("Conversation history cleared! Starting fresh.")
     else:
         await ctx.send("No conversation history to clear.")

--- a/scripts/discord/test_discord_persistence.py
+++ b/scripts/discord/test_discord_persistence.py
@@ -14,21 +14,23 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from gptme.chat import Message
-from gptme.dirs import get_logs_dir
 from gptme.logmanager import LogManager
 
 
-def test_user_message_survives_reload(tmp_path: Path) -> None:
-    """User message appended through LogManager persists across reload.
+@pytest.fixture
+def logs_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Return a clean tmp_path wired into LogManager's log root."""
+    monkeypatch.setattr("gptme.dirs.get_logs_dir", lambda: tmp_path)
+    monkeypatch.setattr("gptme.logmanager.manager.get_logs_dir", lambda: tmp_path)
+    return tmp_path
 
-    Uses a logdir under get_logs_dir() so that LogManager.logfile resolves
-    to the same location LogManager.load() reads from.
-    """
-    # Simulate the channel path the Discord bot would use
-    logsdir = get_logs_dir()
-    channel_id = "test_persistence_channel_948b"
-    logdir = logsdir / channel_id
+
+def test_user_message_survives_reload(logs_dir: Path) -> None:
+    """User message appended through LogManager persists across reload."""
+    channel_id = "test_persistence_channel"
+    logdir = logs_dir / channel_id
 
     initial_msgs = [
         Message("system", "You are a helpful assistant."),
@@ -54,11 +56,10 @@ def test_user_message_survives_reload(tmp_path: Path) -> None:
     assert any(m.content == "Hello, bot!" for m in user_msgs2)
 
 
-def test_multiple_turns_survive_reload(tmp_path: Path) -> None:
+def test_multiple_turns_survive_reload(logs_dir: Path) -> None:
     """A full conversation turn (user + assistant + system) persists."""
-    logsdir = get_logs_dir()
-    channel_id = "test_multi_turn_948b"
-    logdir = logsdir / channel_id
+    channel_id = "test_multi_turn"
+    logdir = logs_dir / channel_id
 
     initial_msgs = [
         Message("system", "You are a helpful assistant."),
@@ -90,11 +91,10 @@ def test_multiple_turns_survive_reload(tmp_path: Path) -> None:
     assert "3+3 is 6." in contents
 
 
-def test_message_count_across_sessions(tmp_path: Path) -> None:
+def test_message_count_across_sessions(logs_dir: Path) -> None:
     """Message count is correct after multiple appends and a reload."""
-    logsdir = get_logs_dir()
-    channel_id = "test_count_948b"
-    logdir = logsdir / channel_id
+    channel_id = "test_count"
+    logdir = logs_dir / channel_id
 
     initial_msgs = [Message("system", "You are a helpful assistant.")]
 

--- a/scripts/discord/test_discord_persistence.py
+++ b/scripts/discord/test_discord_persistence.py
@@ -1,0 +1,111 @@
+"""Tests for Discord bot conversation log persistence.
+
+Verifies that conversation messages survive restarts when the bot stores
+LogManager objects and calls write() after each mutation.
+
+Key design constraint: LogManager.logfile for the 'main' branch resolves to
+get_logs_dir() / self.chat_id / "conversation.jsonl", NOT to self.logdir.
+The load path in LogManager.load() MUST match this write path for persistence
+to work. If the load logdir and the implicit write dir differ, writes land in
+the central directory while reload reads from a stale location.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from gptme.chat import Message
+from gptme.dirs import get_logs_dir
+from gptme.logmanager import LogManager
+
+
+def test_user_message_survives_reload(tmp_path: Path) -> None:
+    """User message appended through LogManager persists across reload.
+
+    Uses a logdir under get_logs_dir() so that LogManager.logfile resolves
+    to the same location LogManager.load() reads from.
+    """
+    # Simulate the channel path the Discord bot would use
+    logsdir = get_logs_dir()
+    channel_id = "test_persistence_channel_948b"
+    logdir = logsdir / channel_id
+
+    initial_msgs = [
+        Message("system", "You are a helpful assistant."),
+    ]
+
+    # Simulate get_conversation(): load or create
+    manager = LogManager.load(logdir, initial_msgs, create=True)
+
+    # Simulate on_message(): append a user message
+    manager.append(Message("user", "Hello, bot!"))
+
+    # Verify the message is in memory
+    user_msgs = [m for m in manager.log if m.role == "user"]
+    assert len(user_msgs) == 1
+    assert user_msgs[0].content == "Hello, bot!"
+
+    # Simulate a restart: load again with same path
+    manager2 = LogManager.load(logdir, initial_msgs, create=False)
+
+    # Messages should survive the reload
+    user_msgs2 = [m for m in manager2.log if m.role == "user"]
+    assert len(user_msgs2) >= 1
+    assert any(m.content == "Hello, bot!" for m in user_msgs2)
+
+
+def test_multiple_turns_survive_reload(tmp_path: Path) -> None:
+    """A full conversation turn (user + assistant + system) persists."""
+    logsdir = get_logs_dir()
+    channel_id = "test_multi_turn_948b"
+    logdir = logsdir / channel_id
+
+    initial_msgs = [
+        Message("system", "You are a helpful assistant."),
+    ]
+
+    manager = LogManager.load(logdir, initial_msgs, create=True)
+
+    # Turn 1
+    manager.append(Message("user", "What is 2+2?"))
+    manager.append(Message("assistant", "2+2 is 4."))
+
+    # Turn 2
+    manager.append(Message("user", "What about 3+3?"))
+    manager.append(Message("assistant", "3+3 is 6."))
+    manager.append(Message("system", "Ran command: echo done"))
+
+    # Reload
+    manager2 = LogManager.load(logdir, initial_msgs, create=False)
+
+    # All non-initial messages should survive
+    all_msgs = list(manager2.log.messages)
+    roles = [m.role for m in all_msgs]
+    contents = {m.content for m in all_msgs}
+
+    assert "user" in roles
+    assert "assistant" in roles
+    assert "What is 2+2?" in contents
+    assert "2+2 is 4." in contents
+    assert "3+3 is 6." in contents
+
+
+def test_message_count_across_sessions(tmp_path: Path) -> None:
+    """Message count is correct after multiple appends and a reload."""
+    logsdir = get_logs_dir()
+    channel_id = "test_count_948b"
+    logdir = logsdir / channel_id
+
+    initial_msgs = [Message("system", "You are a helpful assistant.")]
+
+    manager = LogManager.load(logdir, initial_msgs, create=True)
+
+    # Append 5 user messages
+    for i in range(5):
+        manager.append(Message("user", f"Message {i}"))
+
+    assert len(manager.log) == len(initial_msgs) + 5
+
+    # Reload — count should be the same
+    manager2 = LogManager.load(logdir, initial_msgs, create=False)
+    assert len(manager2.log) == len(initial_msgs) + 5


### PR DESCRIPTION
## Problem

The Discord bot loaded LogManager but only kept its .log in the per-channel conversations map. All message appends went to the in-memory Log and never touched the persistence surface, so restarts silently lost message history.

The live TODO captured this: 'actually save conversations so there is something to load/resume'.

## Fix

- Store LogManager (not plain Log) in conversations so all append paths flow through the persistence surface.
- Route user-message append through LogManager.append() in on_message().
- After each assistant/system step, sync the updated log back and call .write().
- Remove the stale TODO.

## Test

3 new regression tests in scripts/discord/test_discord_persistence.py covering reload survival and message count correctness.