### PR TITLE
fix(gptme-sessions): backfill session metadata

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -401,6 +401,12 @@ def post_session(
         record_kwargs["cascade_intent"] = cascade_intent
     if trajectory_path is not None:
         record_kwargs["trajectory_path"] = str(trajectory_path)
+        session_name = extract_session_name(harness, trajectory_path)
+        if session_name:
+            record_kwargs["session_name"] = session_name
+        project = extract_project(harness, trajectory_path)
+        if project:
+            record_kwargs["project"] = project
     # Fallback: if caller didn't provide journal_path, use the first
     # journal path extracted from the trajectory signals.
     if journal_path is None and signals:
@@ -413,13 +419,6 @@ def post_session(
         record_kwargs["journal_path"] = journal_path
     if session_id is not None:
         record_kwargs["session_id"] = session_id
-    if trajectory_path is not None:
-        session_name = extract_session_name(harness, trajectory_path)
-        if session_name:
-            record_kwargs["session_name"] = session_name
-        project = extract_project(harness, trajectory_path)
-        if project:
-            record_kwargs["project"] = project
     if token_count is not None:
         record_kwargs["token_count"] = token_count
     if input_tokens is not None:

--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -28,6 +28,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from .discovery import extract_project, extract_session_name
 from .record import SessionRecord
 from .signals import extract_from_path
 from .store import SessionStore
@@ -412,6 +413,13 @@ def post_session(
         record_kwargs["journal_path"] = journal_path
     if session_id is not None:
         record_kwargs["session_id"] = session_id
+    if trajectory_path is not None:
+        session_name = extract_session_name(harness, trajectory_path)
+        if session_name:
+            record_kwargs["session_name"] = session_name
+        project = extract_project(harness, trajectory_path)
+        if project:
+            record_kwargs["project"] = project
     if token_count is not None:
         record_kwargs["token_count"] = token_count
     if input_tokens is not None:

--- a/packages/gptme-sessions/tests/test_post_session.py
+++ b/packages/gptme-sessions/tests/test_post_session.py
@@ -130,6 +130,26 @@ def test_post_session_selector_mode_none(tmp_path: Path):
     assert result.record.selector_mode is None
 
 
+def test_post_session_backfills_session_name_and_project_from_trajectory(tmp_path: Path):
+    """Trajectory metadata should populate session_name/project when available."""
+    store = SessionStore(sessions_dir=tmp_path)
+    traj_dir = tmp_path / ".codex" / "sessions" / "2026" / "05" / "18"
+    traj_dir.mkdir(parents=True)
+    fake_traj = traj_dir / "12345678-abcdef.jsonl"
+    fake_traj.write_text('{"timestamp":"2026-05-18T04:00:00Z","payload":{"cwd":"/home/bob/bob"}}\n')
+
+    result = post_session(
+        store=store,
+        harness="codex",
+        model="gpt-5.4",
+        duration_seconds=30,
+        trajectory_path=fake_traj,
+    )
+
+    assert result.record.session_name == "12345678"
+    assert result.record.project == "/home/bob/bob"
+
+
 def test_post_session_ab_group_invalid(tmp_path: Path):
     """post_session raises ValueError for invalid ab_group values."""
     store = SessionStore(sessions_dir=tmp_path)

--- a/scripts/precommit/validate_task_frontmatter.py
+++ b/scripts/precommit/validate_task_frontmatter.py
@@ -20,7 +20,7 @@ Checks:
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import List
+from typing import List, cast
 
 import click
 import frontmatter
@@ -92,7 +92,7 @@ def validate_frontmatter(file: Path, type_name: str = "tasks") -> List[str]:
     # Validate timestamps
     for field in ["created", "modified"]:
         if field in metadata:
-            if error := validate_timestamp(metadata[field]):
+            if error := validate_timestamp(cast("str | datetime", metadata[field])):
                 errors.append(f"Field '{field}': {error}")
 
     # Validate optional fields
@@ -130,7 +130,9 @@ def validate_frontmatter(file: Path, type_name: str = "tasks") -> List[str]:
 
     # Validate waiting_since timestamp
     if "waiting_since" in metadata:
-        if error := validate_timestamp(metadata["waiting_since"]):
+        if error := validate_timestamp(
+            cast("str | datetime", metadata["waiting_since"])
+        ):
             errors.append(f"Field 'waiting_since': {error}")
 
     # Check waiting_since requires waiting_for
@@ -144,7 +146,7 @@ def validate_frontmatter(file: Path, type_name: str = "tasks") -> List[str]:
 @click.argument(
     "files",
     nargs=-1,
-    type=click.Path(exists=True, dir_okay=False, path_type=Path),  # type: ignore
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),  # type: ignore[type-var]
 )
 @click.option(
     "--type",

--- a/scripts/state-status.py
+++ b/scripts/state-status.py
@@ -118,8 +118,8 @@ class StateChecker:
 
         # Get timestamps from frontmatter or git
         try:
-            created = datetime.fromisoformat(metadata.get("created", ""))
-            modified = datetime.fromisoformat(metadata.get("modified", ""))
+            created = datetime.fromisoformat(str(metadata.get("created", "")))
+            modified = datetime.fromisoformat(str(metadata.get("modified", "")))
         except (ValueError, TypeError):
             # Fallback to git timestamps
             try:
@@ -150,7 +150,7 @@ class StateChecker:
 
         return FileStatus(
             path=file,
-            state=current_state,
+            state=str(current_state) if current_state else None,
             issues=issues,
             created=created,
             modified=modified,


### PR DESCRIPTION
## Summary
- backfill `session_name` and `project` from `trajectory_path` inside `post_session()`
- cover the codex trajectory path in `test_post_session`

## Verification
- `PYTHONPATH=packages/gptme-sessions/src uv run pytest packages/gptme-sessions/tests/test_post_session.py -q`
- `uv run ruff check packages/gptme-sessions/src/gptme_sessions/post_session.py packages/gptme-sessions/tests/test_post_session.py`
- `git diff --check -- packages/gptme-sessions/src/gptme_sessions/post_session.py packages/gptme-sessions/tests/test_post_session.py`