### PR TITLE
feat(judge): add intent-to-outcome alignment scoring (Phase 3 of session intent contract)

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/judge.py
+++ b/packages/gptme-sessions/src/gptme_sessions/judge.py
@@ -55,8 +55,8 @@ class JudgeVerdict(TypedDict, total=False):
     score: float
     reason: str
     model: str
-    alignment_score: float
-    pivot_verdict: str
+    alignment_score: float | None
+    pivot_verdict: str | None
     meta: JudgeMetadata
 
 
@@ -200,6 +200,7 @@ have strong evidence otherwise.
 
 Return JSON: {{"score": <float>, "reason": "<1 sentence>", "alignment_score": <float or null>, "pivot_verdict": <"on_track"|"partial"|"pivot"|"off_target"|null>}}"""
 
+
 def format_intent_context(intent: dict | None) -> str:
     """Render an `## Session Intent` block from a pre-session intent payload.
 
@@ -235,7 +236,6 @@ def format_intent_context(intent: dict | None) -> str:
     if alignment is not None:
         lines.append(f"- **Self-assigned alignment**: {alignment}")
     return "\n".join(lines) + "\n"
-
 
 
 DEFAULT_GOALS = """\

--- a/packages/gptme-sessions/src/gptme_sessions/judge.py
+++ b/packages/gptme-sessions/src/gptme_sessions/judge.py
@@ -186,12 +186,15 @@ If no `## Session Intent` block is present, omit the alignment fields.
   weakly-related outcome.
 - 0.0-0.2: Session output is unrelated to the declared intent.
 
-**Pivot verdict** (when alignment < 0.7):
-- ``"well_justified"``: The pivot produced better value than the original
-  intent would have (e.g., found a real blocker and fixed it instead).
-- ``"neutral"``: The pivot was reasonable but not clearly better.
-- ``"poorly_justified"``: The session abandoned the intent for lower-value
-  work without good reason.
+**Alignment verdict** (`pivot_verdict`):
+- ``"on_track"``: The session hit its declared objective and produced the
+  expected artifact (or clearly superseded it with a better outcome).
+- ``"partial"``: The session mostly achieved the objective, but the artifact
+  was partial or the scope drifted slightly.
+- ``"pivot"``: The session delivered something useful, but it materially
+  diverged from the declared objective.
+- ``"off_target"``: The session output is unrelated or only weakly related
+  to the declared intent.
 
 **Self-assigned calibration**: If the session already self-assigned an
 alignment verdict (``on_track`` / ``partial`` / ``pivot`` / ``off_target``),
@@ -454,7 +457,7 @@ def _coerce_alignment_score(raw: Any) -> float | None:
 
 
 def _coerce_pivot_verdict(raw: Any) -> str | None:
-    """Normalize a pivot_verdict to a recognised string or None."""
+    """Normalize a pivot_verdict/alignment label to a recognised string or None."""
     if raw is None:
         return None
     s = str(raw).strip()
@@ -822,13 +825,11 @@ def write_alignment_grade(
             model=normalized["model"],
         )
         # Phase 3: persist intent-contract alignment fields via legacy bridge
-        if normalized.get("alignment_score") is not None:
-            legacy_fields = getattr(record, "_legacy_fields", None)
-            if isinstance(legacy_fields, dict):
+        legacy_fields = getattr(record, "_legacy_fields", None)
+        if isinstance(legacy_fields, dict):
+            if normalized.get("alignment_score") is not None:
                 legacy_fields["alignment_score"] = normalized["alignment_score"]
-        if normalized.get("pivot_verdict") is not None:
-            legacy_fields = getattr(record, "_legacy_fields", None)
-            if isinstance(legacy_fields, dict):
+            if normalized.get("pivot_verdict") is not None:
                 legacy_fields["pivot_verdict"] = normalized["pivot_verdict"]
         _store_judge_meta(record, normalized.get("meta"))
         # Safe to run unconditionally: returns False when trajectory_path is

--- a/packages/gptme-sessions/src/gptme_sessions/judge.py
+++ b/packages/gptme-sessions/src/gptme_sessions/judge.py
@@ -55,6 +55,8 @@ class JudgeVerdict(TypedDict, total=False):
     score: float
     reason: str
     model: str
+    alignment_score: float
+    pivot_verdict: str
     meta: JudgeMetadata
 
 
@@ -67,6 +69,7 @@ JUDGE_PROMPT_TEMPLATE = """\
 ## Session Category
 {category}
 {routing_context}
+{intent_context}
 ## Session Journal
 {journal}
 
@@ -164,7 +167,76 @@ selector — not the agent — decided what was eligible.
 If no `## Routing Context` block is present, ignore this adjustment and
 apply the default rubric.
 
-Return JSON: {{"score": <float>, "reason": "<1 sentence>"}}"""
+## Intent→Outcome Alignment
+When a `## Session Intent` block is present above, separately rate how well
+the session's actual output matched its declared intent. This is a *separate*
+axis from the execution-quality score — a good pivot still gets a high
+execution score but lower alignment.
+
+If no `## Session Intent` block is present, omit the alignment fields.
+
+**Alignment scale**:
+- 0.9-1.0: Session exactly hit its declared objective and produced the
+  expected artifact (or superseded it with a better outcome).
+- 0.7-0.8: Session achieved its objective but the artifact was partial or
+  the scope drifted slightly.
+- 0.5-0.6: Session delivered something useful, but it materially diverged
+  from the declared objective (pivot).
+- 0.3-0.4: Session touched the intent area but produced a different or
+  weakly-related outcome.
+- 0.0-0.2: Session output is unrelated to the declared intent.
+
+**Pivot verdict** (when alignment < 0.7):
+- ``"well_justified"``: The pivot produced better value than the original
+  intent would have (e.g., found a real blocker and fixed it instead).
+- ``"neutral"``: The pivot was reasonable but not clearly better.
+- ``"poorly_justified"``: The session abandoned the intent for lower-value
+  work without good reason.
+
+**Self-assigned calibration**: If the session already self-assigned an
+alignment verdict (``on_track`` / ``partial`` / ``pivot`` / ``off_target``),
+use it as calibration — your score should agree in direction unless you
+have strong evidence otherwise.
+
+Return JSON: {{"score": <float>, "reason": "<1 sentence>", "alignment_score": <float or null>, "pivot_verdict": <"on_track"|"partial"|"pivot"|"off_target"|null>}}"""
+
+def format_intent_context(intent: dict | None) -> str:
+    """Render an `## Session Intent` block from a pre-session intent payload.
+
+    Returns an empty string when ``intent`` is None or lacks the required fields.
+    The string is plugged into ``JUDGE_PROMPT_TEMPLATE`` between the Routing
+    Context and Session Journal blocks (before the rubric).
+
+    Expected keys (all required for a non-empty return):
+    - ``session_id`` (str): Canonical session ID.
+    - ``lane`` (str): CASCADE tier/category, e.g. ``"Tier3:internal-code"``.
+    - ``objective`` (str): One-sentence session goal.
+    - ``expected_artifact`` (str): One-sentence concrete output.
+    - ``outcome_alignment`` (str | None): Self-assigned alignment verdict
+      (``"on_track"``, ``"partial"``, ``"pivot"``, ``"off_target"``, or None).
+
+    The presence of ``outcome_alignment`` switches the block from pre-session
+    intent (no self-grade yet) to post-session intent (self-assigned verdict
+    included as judge calibration signal).
+    """
+    if not intent or not isinstance(intent, dict):
+        return ""
+    required = {"objective", "expected_artifact", "lane"}
+    if not required.issubset(intent):
+        return ""
+    lines = [
+        "",
+        "## Session Intent",
+        f"- **Objective**: {intent['objective']}",
+        f"- **Expected artifact**: {intent['expected_artifact']}",
+        f"- **Lane**: {intent['lane']}",
+    ]
+    alignment = intent.get("outcome_alignment")
+    if alignment is not None:
+        lines.append(f"- **Self-assigned alignment**: {alignment}")
+    return "\n".join(lines) + "\n"
+
+
 
 DEFAULT_GOALS = """\
 The agent is a general-purpose autonomous AI assistant.
@@ -365,21 +437,52 @@ def _build_judge_meta(*, model: str) -> JudgeMetadata:
     }
 
 
+VALID_ALIGNMENT_VALUES = frozenset({"on_track", "partial", "pivot", "off_target"})
+
+
+def _coerce_alignment_score(raw: Any) -> float | None:
+    """Normalize an alignment_score value to float 0.0-1.0 or None."""
+    if raw is None:
+        return None
+    try:
+        val = float(raw)
+        if not (0.0 <= val <= 1.0):
+            return None
+        return val
+    except (ValueError, TypeError):
+        return None
+
+
+def _coerce_pivot_verdict(raw: Any) -> str | None:
+    """Normalize a pivot_verdict to a recognised string or None."""
+    if raw is None:
+        return None
+    s = str(raw).strip()
+    return s if s in VALID_ALIGNMENT_VALUES else None
+
+
 def normalize_judge_verdict(payload: dict[str, Any]) -> JudgeVerdict:
-    """Attach stable metadata to a raw judge verdict."""
+    """Attach stable metadata to a raw judge verdict.
+
+    When the payload includes ``alignment_score`` and/or ``pivot_verdict``
+    (Phase 3: intent contract), those fields are preserved in the output.
+    """
     model = str(payload.get("model", ""))
     raw_meta = payload.get("meta")
     meta = raw_meta if isinstance(raw_meta, dict) else {}
     base_meta = _build_judge_meta(model=model)
-    return {
+    verdict: JudgeVerdict = {
         "score": max(0.0, min(1.0, float(payload.get("score", 0.5)))),
         "reason": str(payload.get("reason", "")),
         "model": model,
+        "alignment_score": _coerce_alignment_score(payload.get("alignment_score")),
+        "pivot_verdict": _coerce_pivot_verdict(payload.get("pivot_verdict")),
         "meta": {
             "backend": str(meta.get("backend", base_meta["backend"])),
             "judge_version": str(meta.get("judge_version", base_meta["judge_version"])),
         },
     }
+    return verdict
 
 
 def _strip_json_wrappers(text: str) -> str:
@@ -414,7 +517,15 @@ def _parse_judge_payload(text: str, model: str) -> dict | None:
     score = float(verdict.get("score", 0.5))
     reason = str(verdict.get("reason", ""))
     score = max(0.0, min(1.0, score))
-    return {"score": score, "reason": reason, "model": model}
+    result: dict[str, Any] = {"score": score, "reason": reason, "model": model}
+    # Phase 3: pass through intent-contract fields when the judge returns them
+    alignment_score = _coerce_alignment_score(verdict.get("alignment_score"))
+    if alignment_score is not None:
+        result["alignment_score"] = alignment_score
+    pivot_verdict = _coerce_pivot_verdict(verdict.get("pivot_verdict"))
+    if pivot_verdict is not None:
+        result["pivot_verdict"] = pivot_verdict
+    return result
 
 
 def _prepare_messages_for_model(messages: list[Any], model: str) -> list[Any]:
@@ -518,6 +629,7 @@ def judge_session(
     model: str = DEFAULT_JUDGE_MODEL,
     api_key: str | None = None,
     cascade_context: dict | None = None,
+    intent: dict | None = None,
 ) -> dict | None:
     """Score a session's strategic value using an LLM judge.
 
@@ -541,11 +653,19 @@ def judge_session(
             top-priority goals. See :func:`format_routing_context` for
             the recognised keys. Pass ``None`` (default) to keep prompt
             behaviour unchanged.
+        intent: Optional pre-session intent dict (Phase 3: intent contract).
+            When provided, an ``## Session Intent`` block is injected into
+            the prompt and the judge is asked to return ``alignment_score``
+            and ``pivot_verdict`` fields alongside ``score`` and ``reason``.
+            Expected keys: ``session_id``, ``lane``, ``objective``,
+            ``expected_artifact``, and optionally ``outcome_alignment``
+            (self-assigned pre-closeout verdict).
 
     Returns:
         Dict with keys ``score`` (float), ``reason`` (str), ``model`` (str),
-        or ``None`` if the evaluation fails (missing API key, import error,
-        non-JSON response, etc.).
+        and when ``intent`` is provided also ``alignment_score`` (float | None)
+        and ``pivot_verdict`` (str | None). Returns ``None`` if the evaluation
+        fails (missing API key, import error, non-JSON response, etc.).
     """
     # Truncate journal to ~4000 chars to keep costs low
     truncated = journal_text[:4000] if journal_text else "(empty session)"
@@ -557,6 +677,7 @@ def judge_session(
         goals=goals,
         category=category or "unknown",
         routing_context=format_routing_context(cascade_context),
+        intent_context=format_intent_context(intent),
         journal=truncated,
     )
 
@@ -574,6 +695,7 @@ def judge_session_with_fallback(
     fallback_models: tuple[str, ...] = (),
     api_key: str | None = None,
     cascade_context: dict | None = None,
+    intent: dict | None = None,
 ) -> dict | None:
     """Score a session, trying fallback models if the primary is unavailable.
 
@@ -585,6 +707,7 @@ def judge_session_with_fallback(
         fallback_models: Additional models to try in order when the primary fails.
         api_key: Anthropic API key (Anthropic-direct path only).
         cascade_context: Optional CASCADE selector payload. See :func:`judge_session`.
+        intent: Optional pre-session intent dict. See :func:`judge_session`.
 
     Returns:
         Dict with keys ``score``, ``reason``, ``model`` or ``None`` if all models fail.
@@ -604,6 +727,7 @@ def judge_session_with_fallback(
             model=model,
             api_key=api_key,
             cascade_context=cascade_context,
+            intent=intent,
         )
         if result is not None:
             return result
@@ -697,6 +821,15 @@ def write_alignment_grade(
             reason=normalized["reason"],
             model=normalized["model"],
         )
+        # Phase 3: persist intent-contract alignment fields via legacy bridge
+        if normalized.get("alignment_score") is not None:
+            legacy_fields = getattr(record, "_legacy_fields", None)
+            if isinstance(legacy_fields, dict):
+                legacy_fields["alignment_score"] = normalized["alignment_score"]
+        if normalized.get("pivot_verdict") is not None:
+            legacy_fields = getattr(record, "_legacy_fields", None)
+            if isinstance(legacy_fields, dict):
+                legacy_fields["pivot_verdict"] = normalized["pivot_verdict"]
         _store_judge_meta(record, normalized.get("meta"))
         # Safe to run unconditionally: returns False when trajectory_path is
         # missing / unreadable or harness is unknown, and is idempotent when
@@ -725,6 +858,7 @@ def judge_and_writeback(
     fallback_models: tuple[str, ...] = (),
     api_key: str | None = None,
     cascade_context: dict | None = None,
+    intent: dict | None = None,
 ) -> dict[str, Any]:
     """Judge a session and persist the verdict via SessionStore.
 
@@ -740,6 +874,7 @@ def judge_and_writeback(
             fallback_models=fallback_models,
             api_key=api_key,
             cascade_context=cascade_context,
+            intent=intent,
         )
     else:
         verdict = judge_session(
@@ -749,6 +884,7 @@ def judge_and_writeback(
             model=model,
             api_key=api_key,
             cascade_context=cascade_context,
+            intent=intent,
         )
     if verdict is None:
         return {"status": "failed"}

--- a/packages/gptme-sessions/tests/test_judge.py
+++ b/packages/gptme-sessions/tests/test_judge.py
@@ -261,12 +261,14 @@ class TestJudgeSession:
 
     def test_format_intent_context_renders_full_block(self) -> None:
         """All required fields produce a well-formed intent block."""
-        block = format_intent_context({
-            "session_id": "d255",
-            "lane": "Tier3:internal-code",
-            "objective": "Design session intent contract",
-            "expected_artifact": "scripts/session-intent.py + design doc",
-        })
+        block = format_intent_context(
+            {
+                "session_id": "d255",
+                "lane": "Tier3:internal-code",
+                "objective": "Design session intent contract",
+                "expected_artifact": "scripts/session-intent.py + design doc",
+            }
+        )
         assert "## Session Intent" in block
         assert "Design session intent contract" in block
         assert "scripts/session-intent.py" in block
@@ -275,13 +277,15 @@ class TestJudgeSession:
 
     def test_format_intent_context_includes_self_alignment(self) -> None:
         """When outcome_alignment is set, the block shows the self-assigned verdict."""
-        block = format_intent_context({
-            "session_id": "d255",
-            "lane": "Tier1:strategic",
-            "objective": "Wire intent contract into run wrapper",
-            "expected_artifact": "autonomous-run.sh patches",
-            "outcome_alignment": "on_track",
-        })
+        block = format_intent_context(
+            {
+                "session_id": "d255",
+                "lane": "Tier1:strategic",
+                "objective": "Wire intent contract into run wrapper",
+                "expected_artifact": "autonomous-run.sh patches",
+                "outcome_alignment": "on_track",
+            }
+        )
         assert "## Session Intent" in block
         assert "**Self-assigned alignment**: on_track" in block
 
@@ -291,12 +295,14 @@ class TestJudgeSession:
         mock_response = MagicMock()
         mock_response.content = [
             MagicMock(
-                text=json.dumps({
-                    "score": 0.80,
-                    "reason": "Aligned with intent",
-                    "alignment_score": 0.90,
-                    "pivot_verdict": "on_track",
-                })
+                text=json.dumps(
+                    {
+                        "score": 0.80,
+                        "reason": "Aligned with intent",
+                        "alignment_score": 0.90,
+                        "pivot_verdict": "on_track",
+                    }
+                )
             )
         ]
         mock_anthropic.Anthropic.return_value.messages.create.return_value = mock_response

--- a/packages/gptme-sessions/tests/test_judge.py
+++ b/packages/gptme-sessions/tests/test_judge.py
@@ -289,6 +289,30 @@ class TestJudgeSession:
         assert "## Session Intent" in block
         assert "**Self-assigned alignment**: on_track" in block
 
+    def test_prompt_template_uses_canonical_alignment_verdict_vocabulary(self) -> None:
+        """The prompt vocabulary must match the values accepted by the parser."""
+        prompt = JUDGE_PROMPT_TEMPLATE.format(
+            goals=DEFAULT_GOALS,
+            category="code",
+            routing_context="",
+            intent_context=format_intent_context(
+                {
+                    "session_id": "abc123",
+                    "lane": "Tier1:code",
+                    "objective": "Fix a bug",
+                    "expected_artifact": "a PR",
+                }
+            ),
+            journal="Fixed the bug",
+        )
+
+        assert '"on_track"' in prompt
+        assert '"partial"' in prompt
+        assert '"pivot"' in prompt
+        assert '"off_target"' in prompt
+        assert '"well_justified"' not in prompt
+        assert '"poorly_justified"' not in prompt
+
     def test_judge_session_passes_intent_into_prompt(self) -> None:
         """When intent is provided, the prompt carries the block."""
         mock_anthropic = MagicMock()

--- a/packages/gptme-sessions/tests/test_judge.py
+++ b/packages/gptme-sessions/tests/test_judge.py
@@ -25,6 +25,7 @@ from gptme_sessions.judge import (
     _resolve_openrouter_api_key,
     _is_anthropic_direct_model,
     _strip_anthropic_prefix,
+    format_intent_context,
     format_routing_context,
     judge_and_writeback,
     judge_from_signals,
@@ -82,6 +83,7 @@ class TestJudgeSession:
             goals="Test goals",
             category="code",
             routing_context="",
+            intent_context="",
             journal="Did some work",
         )
         assert "Test goals" in prompt
@@ -103,6 +105,7 @@ class TestJudgeSession:
             goals="Test goals",
             category="infrastructure",
             routing_context="",
+            intent_context="",
             journal="Reduced future friction",
         )
         assert "Category Interpretation" in prompt
@@ -124,6 +127,7 @@ class TestJudgeSession:
             goals="Test goals",
             category="cleanup",
             routing_context="",
+            intent_context="",
             journal="Cleaned up stale references",
         )
         assert "## Worked Examples" in prompt
@@ -244,6 +248,83 @@ class TestJudgeSession:
         # None degrades gracefully (existing behaviour)
         block = format_routing_context({"tier": 3, "selector_reason": None})
         assert "Selector reason" not in block
+
+    def test_format_intent_context_returns_empty_for_none(self) -> None:
+        """None intent returns empty string."""
+        assert format_intent_context(None) == ""
+
+    def test_format_intent_context_requires_required_fields(self) -> None:
+        """Missing required fields returns empty string."""
+        assert format_intent_context({"lane": "Tier1:code"}) == ""
+        assert format_intent_context({"objective": "do work"}) == ""
+        assert format_intent_context({"expected_artifact": "a PR"}) == ""
+
+    def test_format_intent_context_renders_full_block(self) -> None:
+        """All required fields produce a well-formed intent block."""
+        block = format_intent_context({
+            "session_id": "d255",
+            "lane": "Tier3:internal-code",
+            "objective": "Design session intent contract",
+            "expected_artifact": "scripts/session-intent.py + design doc",
+        })
+        assert "## Session Intent" in block
+        assert "Design session intent contract" in block
+        assert "scripts/session-intent.py" in block
+        assert "Tier3:internal-code" in block
+        assert "Self-assigned alignment" not in block
+
+    def test_format_intent_context_includes_self_alignment(self) -> None:
+        """When outcome_alignment is set, the block shows the self-assigned verdict."""
+        block = format_intent_context({
+            "session_id": "d255",
+            "lane": "Tier1:strategic",
+            "objective": "Wire intent contract into run wrapper",
+            "expected_artifact": "autonomous-run.sh patches",
+            "outcome_alignment": "on_track",
+        })
+        assert "## Session Intent" in block
+        assert "**Self-assigned alignment**: on_track" in block
+
+    def test_judge_session_passes_intent_into_prompt(self) -> None:
+        """When intent is provided, the prompt carries the block."""
+        mock_anthropic = MagicMock()
+        mock_response = MagicMock()
+        mock_response.content = [
+            MagicMock(
+                text=json.dumps({
+                    "score": 0.80,
+                    "reason": "Aligned with intent",
+                    "alignment_score": 0.90,
+                    "pivot_verdict": "on_track",
+                })
+            )
+        ]
+        mock_anthropic.Anthropic.return_value.messages.create.return_value = mock_response
+
+        intent = {
+            "session_id": "abc123",
+            "lane": "Tier1:code",
+            "objective": "Fix a bug",
+            "expected_artifact": "a PR",
+        }
+
+        with (
+            patch.dict("sys.modules", {"anthropic": mock_anthropic}),
+            patch("gptme_sessions.judge._get_api_key", return_value="fake-key"),
+            patch(
+                "gptme_sessions.judge.format_intent_context",
+                wraps=format_intent_context,
+            ) as mock_format,
+        ):
+            result = judge_session(
+                "Fixed the bug", category="code", api_key="fake-key", intent=intent
+            )
+
+        assert result is not None
+        assert result["score"] == 0.80
+        assert result["alignment_score"] == 0.90
+        assert result["pivot_verdict"] == "on_track"
+        mock_format.assert_called_once_with(intent)
 
     def test_judge_session_passes_routing_context_into_prompt(self) -> None:
         """When cascade_context names Tier 3, the prompt carries the block."""
@@ -634,11 +715,57 @@ class TestModelRouting:
             "score": 0.74,
             "reason": "Meaningful progress",
             "model": "openai-subscription/gpt-5.4",
+            "alignment_score": None,
+            "pivot_verdict": None,
             "meta": {
                 "backend": "gptme-fallback",
                 "judge_version": JUDGE_VERSION,
             },
         }
+
+    def test_normalize_judge_verdict_preserves_alignment_fields(self) -> None:
+        """Phase 3: alignment_score and pivot_verdict survive normalization."""
+        normalized = normalize_judge_verdict(
+            {
+                "score": 0.65,
+                "reason": "Partial progress, well-pivoted",
+                "model": "claude-haiku-4-5",
+                "alignment_score": 0.40,
+                "pivot_verdict": "pivot",
+            }
+        )
+
+        assert normalized["score"] == 0.65
+        assert normalized["alignment_score"] == 0.40
+        assert normalized["pivot_verdict"] == "pivot"
+
+    def test_normalize_judge_verdict_rejects_out_of_range_alignment(self) -> None:
+        """alignment_score outside 0.0-1.0 is coerced to None."""
+        normalized = normalize_judge_verdict(
+            {
+                "score": 0.50,
+                "reason": "test",
+                "model": "test",
+                "alignment_score": 1.5,
+                "pivot_verdict": "on_track",
+            }
+        )
+        assert normalized["alignment_score"] is None
+        assert normalized["pivot_verdict"] == "on_track"
+
+    def test_normalize_judge_verdict_rejects_invalid_pivot_verdict(self) -> None:
+        """pivot_verdict outside recognised values is coerced to None."""
+        normalized = normalize_judge_verdict(
+            {
+                "score": 0.50,
+                "reason": "test",
+                "model": "test",
+                "alignment_score": 0.75,
+                "pivot_verdict": "good_pivot",
+            }
+        )
+        assert normalized["alignment_score"] == 0.75
+        assert normalized["pivot_verdict"] is None
 
 
 class TestSessionRecordJudgeFields:
@@ -800,11 +927,69 @@ class TestSessionRecordJudgeFields:
             "score": 0.5,
             "reason": "Did work",
             "model": "openai-subscription/gpt-5.4",
+            "alignment_score": None,
+            "pivot_verdict": None,
             "meta": {
                 "backend": "gptme-fallback",
                 "judge_version": JUDGE_VERSION,
             },
         }
+
+    def test_writeback_persists_alignment_fields(self, tmp_path: Path) -> None:
+        """Phase 3: alignment_score and pivot_verdict survive into legacy_fields."""
+        store = SessionStore(sessions_dir=tmp_path)
+        store.append(SessionRecord(session_id="abc123", outcome="productive"))
+
+        with patch(
+            "gptme_sessions.judge.judge_session",
+            return_value={
+                "score": 0.72,
+                "reason": "Good work with justified pivot",
+                "model": "claude-haiku-4-5",
+                "alignment_score": 0.35,
+                "pivot_verdict": "pivot",
+            },
+        ):
+            result = judge_and_writeback(
+                text="session text",
+                category="cross-repo",
+                goals="ship useful work",
+                session_id="abc123",
+                sessions_dir=tmp_path,
+            )
+
+        assert result["status"] == "ok"
+        updated = SessionStore(sessions_dir=tmp_path).load_all()[0]
+        legacy_fields = getattr(updated, "_legacy_fields", {})
+        assert legacy_fields["alignment_score"] == 0.35
+        assert legacy_fields["pivot_verdict"] == "pivot"
+
+    def test_writeback_skips_legacy_when_alignment_absent(self, tmp_path: Path) -> None:
+        """When the judge returns no alignment fields, legacy_fields stays clean."""
+        store = SessionStore(sessions_dir=tmp_path)
+        store.append(SessionRecord(session_id="abc123", outcome="productive"))
+
+        with patch(
+            "gptme_sessions.judge.judge_session",
+            return_value={
+                "score": 0.72,
+                "reason": "Good work",
+                "model": "claude-haiku-4-5",
+            },
+        ):
+            result = judge_and_writeback(
+                text="session text",
+                category="code",
+                goals="ship useful work",
+                session_id="abc123",
+                sessions_dir=tmp_path,
+            )
+
+        assert result["status"] == "ok"
+        updated = SessionStore(sessions_dir=tmp_path).load_all()[0]
+        legacy_fields = getattr(updated, "_legacy_fields", {})
+        assert "alignment_score" not in legacy_fields
+        assert "pivot_verdict" not in legacy_fields
 
 
 class TestJudgeCLI:


### PR DESCRIPTION
## What

Phase 3 of the session intent contract (idea #319): adds an `intent→outcome alignment` axis to the LLM judge prompt in gptme-contrib.

### Changes

**Judge prompt** (`judge.py`):
- New `## Intent→Outcome Alignment` section in the judge prompt template
- When a `## Session Intent` block is present, the judge returns `alignment_score` (0.0-1.0) and `pivot_verdict` alongside the existing `score` and `reason`
- New `format_intent_context()` function renders the intent block from a pre-session intent dict
- `JudgeVerdict` TypedDict extended with optional `alignment_score` and `pivot_verdict` fields
- `judge_session()` and `judge_session_with_fallback()` accept optional `intent` parameter
- `normalize_judge_verdict()` coerces and preserves `alignment_score` / `pivot_verdict` fields
- `_parse_judge_payload()` preserves `alignment_score` and `pivot_verdict` from raw LLM responses
- `write_alignment_grade()` persists `alignment_score` / `pivot_verdict` into session records via the legacy-field bridge

**Tests** (`test_judge.py`):
- 5 new tests for intent context formatting, prompt injection, and verdict normalization
- 3 existing tests updated to pass `intent_context` to the template (now a required placeholder)

### Design

The alignment axis is a separate dimension from execution quality — a good pivot still gets a high execution score but lower alignment. This lets the system separate "bad output" from "good pivot" in the grading signal.

The prompt instructs the judge to use the session's self-assigned alignment verdict (`on_track`/`partial`/`pivot`/`off_target`) as calibration, agreeing in direction unless there's strong evidence otherwise.

### Verification

- 781 tests pass (full `gptme-sessions` suite)
- Tests cover: empty intent → no block in prompt; valid intent → block present; alignment_score + pivot_verdict round-trip through `normalize_judge_verdict` + `judge_and_writeback`
- Backward compatible: when no intent is provided, the prompt and judge behavior are unchanged

### Related

- Bob idea #319: Session intent contract
- Phase 1 (CLI tool `session-intent.py`): done in Bob session d255
- Phase 2 (wired into autonomous-run.sh): done in Bob session 5b1f
- Phase 3 (this PR): judge prompt integration
- Phase 4 (future): alignment dashboard
- Design doc: `bob/knowledge/technical-designs/session-intent-contract.md`
