### PR TITLE
chore(lessons): recover 7 live keywords across 3 lessons

### DIFF
--- a/lessons/workflow/agent-orchestrator-patterns.md
+++ b/lessons/workflow/agent-orchestrator-patterns.md
@@ -7,6 +7,9 @@ match:
     - "standup missing"
     - "agent coordination"
     - "inference utilization"
+    - "orchestrating multiple agents"
+    - "standup report"
+    - "inference spend"
   session_categories: [monitoring, cross-repo]
 ---
 

--- a/lessons/workflow/agent-workspace-maintenance.md
+++ b/lessons/workflow/agent-workspace-maintenance.md
@@ -2,6 +2,8 @@
 match:
   keywords:
     - "update gptme-contrib"
+    - "update submodule to latest"
+    - "submodule is behind"
   session_categories: [cleanup]
 status: active
 ---

--- a/lessons/workflow/communication-loop-closure-patterns.md
+++ b/lessons/workflow/communication-loop-closure-patterns.md
@@ -10,6 +10,8 @@ match:
   - link back to the original issue
   - end the session without responding
   - finished but never replied
+  - reply to the issue
+  - update the issue
 status: active
 target_grade: alignment
 ---


### PR DESCRIPTION
## Summary

Restores 7 keywords that were removed in the April 2026 dead-keyword cleanup but are now actively firing in recent sessions. Verified live in the last 7-day trajectory window via `lesson-keyword-health.py`.

## Changes

- **agent-orchestrator-patterns**: +3 ("orchestrating multiple agents", "standup report", "inference spend")
- **agent-workspace-maintenance**: +2 ("update submodule to latest", "submodule is behind")  
- **communication-loop-closure-patterns**: +2 ("reply to the issue", "update the issue")

## Why

Keywords that were dead in April can become live again as usage patterns shift (new session types, model migrations, tool changes). This recovery pass reconnects lessons to their actual firing keywords.

Each keyword was confirmed live in the last 7 days of trajectory data. No speculative additions — only evidence-backed recovery.