### PR TITLE
feat(tts): add KittenTTS backend — ultra-lightweight ONNX TTS (15M-80M params)

### DIFF
--- a/plugins/gptme-tts/tts_kittentts.py
+++ b/plugins/gptme-tts/tts_kittentts.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "kittentts>=0.8.0",
+#   "scipy>=1.11.0",
+#   "soundfile>=0.12.1",
+#   "numpy",
+# ]
+# ///
+"""
+KittenTTS backend implementation.
+
+Kitten TTS is an ultra-lightweight, CPU-friendly text-to-speech model
+with models ranging from 15M to 80M parameters (25-80 MB on disk).
+
+Model sizes:
+  - kitten-tts-mini  (80M,  80 MB) — best quality
+  - kitten-tts-micro (40M,  41 MB) — balanced
+  - kitten-tts-nano  (15M,  56 MB) — lightweight
+  - kitten-tts-nano-int8 (15M, 25 MB) — smallest
+
+Usage:
+    from tts_kittentts import KittenTTSBackend
+    backend = KittenTTSBackend(model="KittenML/kitten-tts-mini-0.8", voice="Jasper")
+    backend.initialize()
+    audio = backend.synthesize("Hello world", voice="Jasper")
+"""
+
+import io
+import logging
+
+import numpy as np
+import scipy.io.wavfile as wavfile
+
+log = logging.getLogger(__name__)
+
+
+# Cache mapping from model name to (model, voice_list) to avoid
+# re-downloading on every initialize() call.
+_model_cache: dict[str, tuple] = {}
+
+
+class KittenTTSBackend:
+    """KittenTTS backend implementation."""
+
+    def __init__(
+        self, model: str = "KittenML/kitten-tts-micro-0.8", voice: str = "Jasper"
+    ):
+        self.model_name = model
+        self.default_voice = voice
+        self._model = None
+        self._voices: list[str] = []
+
+    def list_voices(self, _lang_code: str | None = None) -> list[str]:
+        """List all available voices."""
+        return self._voices or [
+            "Bella",
+            "Jasper",
+            "Luna",
+            "Bruno",
+            "Rosie",
+            "Hugo",
+            "Kiki",
+            "Leo",
+        ]
+
+    def close(self) -> None:
+        """Close the model and release resources."""
+        self._model = None
+        log.info("KittenTTS model closed")
+
+    def initialize(self, voice: str | None = None) -> None:
+        """Initialize the KittenTTS model."""
+        try:
+            from kittentts import KittenTTS
+
+            voice_name = voice or self.default_voice
+
+            # Check cache first
+            if self.model_name in _model_cache:
+                self._model, _ = _model_cache[self.model_name]
+                log.info(f"Using cached KittenTTS model: {self.model_name}")
+            else:
+                log.info(f"Loading KittenTTS model: {self.model_name}...")
+                self._model = KittenTTS(self.model_name)
+                _model_cache[self.model_name] = (self._model, None)
+                log.info(f"KittenTTS model loaded: {self.model_name}")
+
+            # Cache available voices
+            self._voices = (
+                list(self._model.available_voices)
+                if hasattr(self._model, "available_voices")
+                else []
+            )
+            if not self._voices:
+                self._voices = [
+                    "Bella",
+                    "Jasper",
+                    "Luna",
+                    "Bruno",
+                    "Rosie",
+                    "Hugo",
+                    "Kiki",
+                    "Leo",
+                ]
+
+            if voice_name not in self._voices:
+                log.warning(
+                    f"Voice '{voice_name}' not found, using '{self._voices[0]}'. "
+                    f"Available: {self._voices}"
+                )
+
+            self.default_voice = (
+                voice_name if voice_name in self._voices else self._voices[0]
+            )
+            log.info(
+                f"KittenTTS initialized (model: {self.model_name}, voice: {self.default_voice})"
+            )
+
+        except ImportError as e:
+            raise ImportError(
+                f"Failed to import KittenTTS: {e}. "
+                "Install with: pip install https://github.com/KittenML/KittenTTS/releases/download/0.8.1/kittentts-0.8.1-py3-none-any.whl"
+            ) from e
+        except Exception as e:
+            raise RuntimeError(f"Failed to initialize KittenTTS: {e}") from e
+
+    def strip_silence(
+        self,
+        audio_data: np.ndarray,
+        threshold: float = 0.01,
+        min_silence_duration: int = 1000,
+    ) -> np.ndarray:
+        """Strip silence from the beginning and end of audio data."""
+        abs_audio = np.abs(audio_data)
+        mask = abs_audio > threshold
+
+        non_silent = np.where(mask)[0]
+        if len(non_silent) == 0:
+            return audio_data
+
+        start = max(0, non_silent[0] - min_silence_duration)
+        end = min(len(audio_data), non_silent[-1] + min_silence_duration)
+
+        return audio_data[start:end]
+
+    def synthesize(
+        self, text: str, voice: str | None = None, speed: float = 1.0
+    ) -> io.BytesIO:
+        """Convert text to speech and return audio buffer (WAV, 24kHz, 16-bit)."""
+        if self._model is None:
+            raise RuntimeError("Model not initialized. Call initialize() first.")
+
+        current_voice = voice or self.default_voice
+        if current_voice not in self._voices:
+            log.warning(
+                f"Voice '{current_voice}' not found, falling back to '{self._voices[0]}'"
+            )
+            current_voice = self._voices[0]
+
+        try:
+            log.info(
+                f"Generating audio with KittenTTS (voice: {current_voice}, speed: {speed}x)"
+            )
+
+            # KittenTTS generate() returns a numpy array at 24kHz
+            audio = self._model.generate(
+                text, voice=current_voice, speed=speed, clean_text=True
+            )
+
+            if audio is None or len(audio) == 0:
+                raise ValueError("No audio generated")
+
+            # Strip silence from audio
+            audio = self.strip_silence(audio)
+
+            # Normalize to [-1, 1] if needed
+            if np.max(np.abs(audio)) > 1.0:
+                audio = audio / np.max(np.abs(audio))
+
+            # Convert to 16-bit integer format (standard for WAV files)
+            audio_int16 = (audio * 32767).astype(np.int16)
+
+            # Convert to WAV format
+            buffer = io.BytesIO()
+            wavfile.write(buffer, 24000, audio_int16)
+            buffer.seek(0)
+
+            return buffer
+
+        except Exception as e:
+            log.error(f"Failed to generate speech with KittenTTS: {e}")
+            raise
+
+    def get_info(self) -> dict:
+        """Get backend information."""
+        try:
+            import kittentts
+
+            version = getattr(kittentts, "__version__", "0.8.1")
+        except Exception:
+            version = "unknown"
+
+        return {
+            "name": "kittentts",
+            "version": version,
+            "model": self.model_name,
+            "voice": {
+                "default": self.default_voice,
+                "available": self.list_voices(),
+            },
+        }

--- a/plugins/gptme-tts/tts_server.py
+++ b/plugins/gptme-tts/tts_server.py
@@ -7,6 +7,7 @@
 #   "click",
 #   "gradio-client",
 #   "kokoro>=0.9.0",
+#   "kittentts",
 #   "scipy",
 # ]
 # [tool.uv]
@@ -14,11 +15,10 @@
 # ///
 """
 Multi-backend TTS server supporting Kokoro and Chatterbox TTS.
-
 Usage:
     ./tts_server.py --backend kokoro
     ./tts_server.py --backend chatterbox
-
+    ./tts_server.py --backend kittentts
 API Endpoints:
     GET /tts?text=Hello&voice=af_heart&speed=1.0 - Convert text to speech
     GET /health - Check server health and backend info
@@ -51,7 +51,6 @@ log = logging.getLogger(__name__)
 async def lifespan(app: FastAPI):
     """Initialize backend on startup and teardown on shutdown."""
     global current_backend
-
     try:
         if backend_name == "kokoro":
             current_backend = TTSBackendLoader.load_kokoro_backend(
@@ -63,17 +62,18 @@ async def lifespan(app: FastAPI):
                 voice_sample_dir=os.getenv("TTS_VOICE_DIR"),
                 voice=os.getenv("TTS_VOICE"),
             )
+        elif backend_name == "kittentts":
+            current_backend = TTSBackendLoader.load_kittentts_backend(
+                model=os.getenv("TTS_MODEL", "KittenML/kitten-tts-micro-0.8"),
+                voice=os.getenv("TTS_VOICE", "Jasper"),
+            )
         else:
             raise ValueError(f"Unknown backend: {backend_name}")
-
         log.info(f"Successfully initialized {backend_name} backend")
-
     except Exception as e:
         log.error(f"Failed to initialize backend: {e}")
         raise
-
     yield
-
     # Cleanup backend on shutdown
     if current_backend is not None:
         try:
@@ -87,7 +87,6 @@ async def lifespan(app: FastAPI):
 
 # Initialize FastAPI app
 app = FastAPI(title="Multi-Backend TTS Server", lifespan=lifespan)
-
 # Global variables
 current_backend = None
 backend_name = "kokoro"  # Default backend
@@ -107,7 +106,6 @@ class TTSBackendLoader:
             backend = KokoroTTSBackend(lang_code=lang_code, voice=voice)
             backend.initialize(voice)
             return backend
-
         except ImportError as e:
             raise ImportError(
                 f"Failed to import Kokoro backend: {e}. Install dependencies with: pip install kokoro scipy soundfile numpy"
@@ -128,7 +126,6 @@ class TTSBackendLoader:
             backend = ChatterboxTTSBackend(voice_sample_dir=voice_sample_dir)
             backend.initialize(voice)
             return backend
-
         except ImportError as e:
             raise ImportError(
                 f"Failed to import Chatterbox backend: {e}. Install dependencies with: pip install gradio-client"
@@ -137,14 +134,37 @@ class TTSBackendLoader:
             raise RuntimeError(f"Failed to initialize Chatterbox backend: {e}") from e
 
     @staticmethod
+    def load_kittentts_backend(
+        model: str = "KittenML/kitten-tts-micro-0.8", voice: str = "Jasper"
+    ):
+        """Load and initialize KittenTTS backend."""
+        try:
+            sys.path.insert(0, str(Path(__file__).parent))
+            from tts_kittentts import KittenTTSBackend  # fmt: skip
+
+            backend = KittenTTSBackend(model_name=model, voice=voice)
+            backend.initialize()
+            return backend
+        except ImportError as e:
+            raise ImportError(
+                f"Failed to import KittenTTS backend: {e}. Install dependencies with: pip install soundfile numpy"
+            ) from e
+        except Exception as e:
+            raise RuntimeError(f"Failed to initialize KittenTTS backend: {e}") from e
+
+    @staticmethod
     def get_available_backends() -> list[str]:
         """Get list of available backends."""
         backends = []
-
         # Check if Kokoro is available
         if find_spec("kokoro"):
             backends.append("kokoro")
-
+        # Check if KittenTTS is available
+        if (
+            find_spec("kittentts")
+            or Path(__file__).parent.joinpath("tts_kittentts.py").exists()
+        ):
+            backends.append("kittentts")
         # Check if Chatterbox is available
         if os.getenv("GRADIO_SRC", "").count("/") > 1:
             # Not using HF_TOKEN for local dev versions
@@ -155,7 +175,6 @@ class TTSBackendLoader:
             if find_spec("gradio_client"):
                 log.info("Chatterbox backend is available")
                 backends.append("chatterbox")
-
         return backends
 
 
@@ -186,7 +205,6 @@ async def root():
 async def health():
     """Health check endpoint with backend information."""
     backend = get_backend()
-
     try:
         backend_info = backend.get_info()
         return {"status": "healthy", "backend": backend_name, **backend_info}
@@ -201,13 +219,11 @@ async def health():
 async def list_voices():
     """List available voices for the current backend."""
     backend = get_backend()
-
     try:
         if hasattr(backend, "list_voices"):
             voices = backend.list_voices()
         else:
             voices = []
-
         return {"backend": backend_name, "voices": voices, "count": len(voices)}
     except Exception as e:
         log.error(f"Failed to list voices: {e}")
@@ -227,6 +243,7 @@ async def list_backends():
             "descriptions": {
                 "kokoro": "Local neural TTS with multiple languages and voices",
                 "chatterbox": "Cloud-based TTS with voice cloning capabilities",
+                "kittentts": "Ultra-lightweight ONNX TTS under 25MB",
             },
         }
     except Exception as e:
@@ -249,10 +266,8 @@ async def text_to_speech(
 ) -> StreamingResponse:
     """Convert text to speech and return audio stream."""
     backend = get_backend()
-
     if not text.strip():
         raise HTTPException(status_code=400, detail="Text parameter cannot be empty")
-
     # Note: server accepts 0–3.0; the gptme plugin client enforces 0.5–2.0 for
     # typical voice quality. The wider server range allows direct API use with
     # experimental speeds outside the plugin's recommended range.
@@ -260,14 +275,16 @@ async def text_to_speech(
         raise HTTPException(
             status_code=400, detail="Speed must be greater than 0 and at most 3.0"
         )
-
     try:
         log.info(
             f"Generating audio: {shorten(text, 50, placeholder='...')} (backend: {backend_name})"
         )
-
         # Prepare synthesis parameters based on backend
         if backend_name == "kokoro":
+            audio_buffer = await asyncio.to_thread(
+                backend.synthesize, text=text, voice=voice, speed=speed
+            )
+        elif backend_name == "kittentts":
             audio_buffer = await asyncio.to_thread(
                 backend.synthesize, text=text, voice=voice, speed=speed
             )
@@ -286,32 +303,25 @@ async def text_to_speech(
             raise HTTPException(
                 status_code=500, detail=f"Unknown backend: {backend_name}"
             )
-
         # Save audio to outputs directory with timestamp
         timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d_%H%M%S_%f")[
             :-3
         ]  # Remove last 3 digits of microseconds
         outputs_dir = Path("outputs")
         outputs_dir.mkdir(exist_ok=True)
-
         output_path = outputs_dir / f"{timestamp}.wav"
-
         # Save audio buffer to file
         audio_data = audio_buffer.getvalue()
         with open(output_path, "wb") as f:
             f.write(audio_data)
-
         log.info(f"Saved audio to {output_path}")
-
         # Reset buffer position for streaming
         audio_buffer.seek(0)
-
         return StreamingResponse(
             audio_buffer,
             media_type="audio/wav",
             headers={"Content-Disposition": 'attachment; filename="speech.wav"'},
         )
-
     except ValueError as e:
         log.error(f"Invalid input: {e}")
         raise HTTPException(status_code=400, detail=str(e)) from e
@@ -327,7 +337,7 @@ async def text_to_speech(
 @click.option("--host", default="127.0.0.1", help="Host to run the server on")
 @click.option(
     "--backend",
-    type=click.Choice(["kokoro", "chatterbox"]),
+    type=click.Choice(["kokoro", "chatterbox", "kittentts"]),
     default="kokoro",
     help="TTS backend to use",
 )
@@ -344,7 +354,7 @@ async def text_to_speech(
 def main(
     port: int,
     host: str,
-    backend: Literal["kokoro", "chatterbox"],
+    backend: Literal["kokoro", "chatterbox", "kittentts"],
     voice: str | None,
     lang: str,
     voice_dir: str | None,
@@ -354,12 +364,9 @@ def main(
 ):
     """Run the multi-backend TTS server."""
     global backend_name, current_backend
-
     if verbose:
         logging.getLogger().setLevel(logging.DEBUG)
-
     backend_name = backend
-
     # Set environment variables for backend configuration
     if voice:
         os.environ["TTS_VOICE"] = voice
@@ -367,7 +374,6 @@ def main(
         os.environ["TTS_LANG"] = lang
     if voice_dir:
         os.environ["TTS_VOICE_DIR"] = voice_dir
-
     if list_backends:
         available = TTSBackendLoader.get_available_backends()
         click.echo("Available TTS backends:")
@@ -375,10 +381,9 @@ def main(
             click.echo(f"  - {b}")
         if not available:
             click.echo(
-                "  No backends available. Install dependencies for kokoro or chatterbox."
+                "  No backends available. Install dependencies for kokoro, chatterbox, or kittentts."
             )
         return
-
     if list_voices:
         try:
             # Initialize the specified backend temporarily
@@ -390,16 +395,18 @@ def main(
                 temp_backend = TTSBackendLoader.load_chatterbox_backend(
                     voice_dir, voice
                 )
+            elif backend == "kittentts":
+                temp_backend = TTSBackendLoader.load_kittentts_backend(
+                    voice=voice or "Jasper",
+                )
             else:
                 click.echo(f"Unknown backend: {backend}", err=True)
                 return
-
             voices = temp_backend.list_voices()
             click.echo(f"Available voices for {backend}:")
             for v in voices:
                 click.echo(f"  - {v}")
             return
-
         except Exception as e:
             click.echo(f"Error listing voices: {e}", err=True)
             return
@@ -410,7 +417,6 @@ def main(
                 pass
             except Exception:
                 pass
-
     # Check if the selected backend is available
     available_backends = TTSBackendLoader.get_available_backends()
     if backend not in available_backends:
@@ -426,17 +432,22 @@ def main(
                 "Install Chatterbox dependencies: pip install gradio-client", err=True
             )
             click.echo("Set HF_TOKEN environment variable", err=True)
+        elif backend == "kittentts":
+            click.echo(
+                "Install KittenTTS dependencies: pip install soundfile numpy scipy",
+                err=True,
+            )
         sys.exit(1)
-
     log.info(f"Starting TTS server on {host}:{port}")
     log.info(f"Using backend: {backend}")
     if voice:
         log.info(f"Default voice: {voice}")
     if backend == "kokoro":
         log.info(f"Language: {lang}")
+    if backend == "kittentts":
+        log.info(f"Model: {os.getenv('TTS_MODEL', 'KittenML/kitten-tts-micro-0.8')}")
     if voice_dir:
         log.info(f"Voice directory: {voice_dir}")
-
     uvicorn.run(app, host=host, port=port)
 
 

--- a/plugins/gptme-tts/tts_server.py
+++ b/plugins/gptme-tts/tts_server.py
@@ -142,7 +142,7 @@ class TTSBackendLoader:
             sys.path.insert(0, str(Path(__file__).parent))
             from tts_kittentts import KittenTTSBackend  # fmt: skip
 
-            backend = KittenTTSBackend(model_name=model, voice=voice)
+            backend = KittenTTSBackend(model=model, voice=voice)
             backend.initialize()
             return backend
         except ImportError as e:
@@ -159,11 +159,8 @@ class TTSBackendLoader:
         # Check if Kokoro is available
         if find_spec("kokoro"):
             backends.append("kokoro")
-        # Check if KittenTTS is available
-        if (
-            find_spec("kittentts")
-            or Path(__file__).parent.joinpath("tts_kittentts.py").exists()
-        ):
+        # Check if KittenTTS is available (pip package must be installed)
+        if find_spec("kittentts"):
             backends.append("kittentts")
         # Check if Chatterbox is available
         if os.getenv("GRADIO_SRC", "").count("/") > 1:


### PR DESCRIPTION
## Problem

The gptme TTS server currently supports Kokoro (local neural) and Chatterbox (cloud voice-cloning) backends. There is no lightweight CPU-first option for resource-constrained environments where Kokoro's models (~350MB+) are too heavy.

## Solution

Add KittenTTS as a third TTS backend. KittenTTS models range from 15M to 80M parameters (25-80 MB on disk), run on CPU via ONNX, and deliver real-time quality speech without a GPU.

**New file:** `plugins/gptme-tts/tts_kittentts.py` — `KittenTTSBackend` wrapping the `kittentts` ONNX inference API with:
- Model loading from Hugging Face Hub (configurable via `TTS_MODEL`)
- 8 built-in voices (Bella, Jasper, Luna, Bruno, Rosie, Hugo, Kiki, Leo)
- Configurable speech speed
- 24 kHz WAV output

**Modified:** `plugins/gptme-tts/tts_server.py`
- Lifecycle init for `kittentts` backend
- `/tts` handler for KittenTTS synthesis
- `/backends` endpoint includes KittenTTS
- CLI `--backend` option accepts `kittentts`
- `--list-voices` supports KittenTTS
- Availability detection via file existence (no pip package needed)
- Dependency hint on unavailable backend

## Usage

```bash
./tts_server.py --backend kittentts
# Optional: TTS_MODEL=KittenML/kitten-tts-nano-0.8 TTS_VOICE=Luna
```

## Acceptance Criteria
- [ ] Backend starts and health endpoint returns 200
- [ ] `/tts?text=Hello` returns valid WAV audio (24kHz)
- [ ] `/voices` lists KittenTTS voices
- [ ] `/backends` shows `kittentts` as available
- [ ] `--list-voices` works for KittenTTS
- [ ] Dep install hint shown when `kittentts` unavailable
- [ ] Existing kokoro/chatterbox backends unaffected

Partially addresses idea #34 from the idea backlog (KittenTTS for agent voice).