### PR TITLE
fix(tts): polish KittenTTS follow-up paths

### DIFF
--- a/plugins/gptme-tts/tests/test_tts.py
+++ b/plugins/gptme-tts/tests/test_tts.py
@@ -374,3 +374,72 @@ def test_lifespan_shutdown_calls_close():
         asyncio.run(exercise_lifespan())
 
     load_backend.assert_called_once_with(lang_code="a", voice="af_heart")
+
+
+def test_list_voices_kittentts_uses_tts_model_env_var():
+    """The temporary kittentts backend should honor TTS_MODEL for --list-voices."""
+    module = _import_tts_server()
+    temp_backend = MagicMock()
+    temp_backend.list_voices.return_value = ["Jasper"]
+
+    with (
+        patch.dict("os.environ", {"TTS_MODEL": "KittenML/kitten-tts-mini-0.8"}),
+        patch.object(
+            module.TTSBackendLoader,
+            "load_kittentts_backend",
+            return_value=temp_backend,
+        ) as load_backend,
+        patch("click.echo"),
+    ):
+        module.main.callback(
+            port=8765,
+            host="127.0.0.1",
+            backend="kittentts",
+            voice=None,
+            lang="a",
+            voice_dir=None,
+            list_voices=True,
+            list_backends=False,
+            verbose=False,
+        )
+
+    load_backend.assert_called_once_with(
+        model="KittenML/kitten-tts-mini-0.8",
+        voice="Jasper",
+    )
+    temp_backend.close.assert_called_once()
+
+
+def test_unavailable_kittentts_backend_prints_install_hint():
+    """Unavailable kittentts backend should tell users how to install it."""
+    module = _import_tts_server()
+
+    with (
+        patch.object(
+            module.TTSBackendLoader, "get_available_backends", return_value=[]
+        ),
+        patch("click.echo") as echo,
+        pytest.raises(SystemExit) as excinfo,
+    ):
+        module.main.callback(
+            port=8765,
+            host="127.0.0.1",
+            backend="kittentts",
+            voice=None,
+            lang="a",
+            voice_dir=None,
+            list_voices=False,
+            list_backends=False,
+            verbose=False,
+        )
+
+    assert excinfo.value.code == 1
+    echo.assert_any_call("Backend 'kittentts' is not available.", err=True)
+    echo.assert_any_call("Available backends: []", err=True)
+    echo.assert_any_call(
+        "Install KittenTTS: pip install "
+        "https://github.com/KittenML/KittenTTS/releases/download/0.8.1/"
+        "kittentts-0.8.1-py3-none-any.whl",
+        err=True,
+    )
+    echo.assert_any_call("Also install: pip install soundfile numpy scipy", err=True)

--- a/plugins/gptme-tts/tests/test_tts.py
+++ b/plugins/gptme-tts/tests/test_tts.py
@@ -415,9 +415,7 @@ def test_unavailable_kittentts_backend_prints_install_hint():
     module = _import_tts_server()
 
     with (
-        patch.object(
-            module.TTSBackendLoader, "get_available_backends", return_value=[]
-        ),
+        patch.object(module.TTSBackendLoader, "get_available_backends", return_value=[]),
         patch("click.echo") as echo,
         pytest.raises(SystemExit) as excinfo,
     ):

--- a/plugins/gptme-tts/tests/test_tts.py
+++ b/plugins/gptme-tts/tests/test_tts.py
@@ -415,7 +415,9 @@ def test_unavailable_kittentts_backend_prints_install_hint():
     module = _import_tts_server()
 
     with (
-        patch.object(module.TTSBackendLoader, "get_available_backends", return_value=[]),
+        patch.object(
+            module.TTSBackendLoader, "get_available_backends", return_value=[]
+        ),
         patch("click.echo") as echo,
         pytest.raises(SystemExit) as excinfo,
     ):

--- a/plugins/gptme-tts/tests/test_tts.py
+++ b/plugins/gptme-tts/tests/test_tts.py
@@ -437,9 +437,7 @@ def test_unavailable_kittentts_backend_prints_install_hint():
     echo.assert_any_call("Backend 'kittentts' is not available.", err=True)
     echo.assert_any_call("Available backends: []", err=True)
     echo.assert_any_call(
-        "Install KittenTTS: pip install "
-        "https://github.com/KittenML/KittenTTS/releases/download/0.8.1/"
-        "kittentts-0.8.1-py3-none-any.whl",
+        f"Install KittenTTS: pip install {module.KITTENTTS_WHEEL_URL}",
         err=True,
     )
     echo.assert_any_call("Also install: pip install soundfile numpy scipy", err=True)

--- a/plugins/gptme-tts/tts_server.py
+++ b/plugins/gptme-tts/tts_server.py
@@ -46,6 +46,11 @@ from fastapi.responses import StreamingResponse
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)
 
+KITTENTTS_WHEEL_URL = (
+    "https://github.com/KittenML/KittenTTS/releases/download/0.8.1/"
+    "kittentts-0.8.1-py3-none-any.whl"
+)
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -147,7 +152,9 @@ class TTSBackendLoader:
             return backend
         except ImportError as e:
             raise ImportError(
-                f"Failed to import KittenTTS backend: {e}. Install dependencies with: pip install soundfile numpy"
+                f"Failed to import KittenTTS backend: {e}. "
+                f"Install KittenTTS: pip install {KITTENTTS_WHEEL_URL}. "
+                "Also install: pip install soundfile numpy scipy"
             ) from e
         except Exception as e:
             raise RuntimeError(f"Failed to initialize KittenTTS backend: {e}") from e
@@ -240,7 +247,7 @@ async def list_backends():
             "descriptions": {
                 "kokoro": "Local neural TTS with multiple languages and voices",
                 "chatterbox": "Cloud-based TTS with voice cloning capabilities",
-                "kittentts": "Ultra-lightweight ONNX TTS under 25MB",
+                "kittentts": "Ultra-lightweight ONNX TTS with 25-80MB models",
             },
         }
     except Exception as e:
@@ -277,11 +284,7 @@ async def text_to_speech(
             f"Generating audio: {shorten(text, 50, placeholder='...')} (backend: {backend_name})"
         )
         # Prepare synthesis parameters based on backend
-        if backend_name == "kokoro":
-            audio_buffer = await asyncio.to_thread(
-                backend.synthesize, text=text, voice=voice, speed=speed
-            )
-        elif backend_name == "kittentts":
+        if backend_name in {"kokoro", "kittentts"}:
             audio_buffer = await asyncio.to_thread(
                 backend.synthesize, text=text, voice=voice, speed=speed
             )
@@ -394,6 +397,7 @@ def main(
                 )
             elif backend == "kittentts":
                 temp_backend = TTSBackendLoader.load_kittentts_backend(
+                    model=os.getenv("TTS_MODEL", "KittenML/kitten-tts-micro-0.8"),
                     voice=voice or "Jasper",
                 )
             else:
@@ -431,7 +435,11 @@ def main(
             click.echo("Set HF_TOKEN environment variable", err=True)
         elif backend == "kittentts":
             click.echo(
-                "Install KittenTTS dependencies: pip install soundfile numpy scipy",
+                f"Install KittenTTS: pip install {KITTENTTS_WHEEL_URL}",
+                err=True,
+            )
+            click.echo(
+                "Also install: pip install soundfile numpy scipy",
                 err=True,
             )
         sys.exit(1)


### PR DESCRIPTION
Follow-up to #930.

## Summary
- make `--list-voices --backend kittentts` respect `TTS_MODEL`
- print the actual KittenTTS wheel install hint when the backend is unavailable or import setup fails
- correct the `/backends` copy and collapse the duplicate Kokoro/KittenTTS synthesis branch

## Verification
- `PYTHONPATH=plugins/gptme-tts:plugins/gptme-tts/src uv run pytest plugins/gptme-tts/tests/test_tts.py -q -k "lifespan_shutdown_calls_close or list_voices_kittentts_uses_tts_model_env_var or unavailable_kittentts_backend_prints_install_hint"`
- `uv run ruff check plugins/gptme-tts/tts_server.py plugins/gptme-tts/tests/test_tts.py`