### PR TITLE
fix(git-safe-commit): relax dirty-guard to allow untracked files by default

### DIFF
--- a/scripts/git/git-safe-commit
+++ b/scripts/git/git-safe-commit
@@ -186,10 +186,35 @@ check_index_corruption() {
     fi
 }
 
+hook_allows_untracked_dirty_guard_relaxation() {
+    local hook_path
+
+    hook_path="${1:-}"
+
+    # No pre-commit hook means no stash/restore cycle to worry about.
+    if [ -z "$hook_path" ]; then
+        return 0
+    fi
+
+    # The bundled auto-stage hook captures the staged set and always runs
+    # prek/pre-commit with `--files <staged>`, which avoids pre-commit's
+    # repo-wide stash/restore path. Symlinked and copied installs both work
+    # because grep reads the target file contents.
+    if grep -Fq "Pre-commit hook with auto-staging and commit serialization." "$hook_path" 2>/dev/null && \
+       grep -Fq 'run --files "${ORIGINALLY_STAGED_FILES[@]}"' "$hook_path" 2>/dev/null; then
+        return 0
+    fi
+
+    return 1
+}
+
 check_clean_worktree_for_hooks() {
     local unstaged_files untracked_files unstaged_count untracked_count
-    local sample_count mode block block_reason
+    local sample_count mode block block_reason pre_commit_hook
     local unstaged_reason untracked_reason
+    local allow_untracked allow_untracked_reason
+
+    pre_commit_hook="${1:-}"
 
     unstaged_files="$(git diff --name-only --ignore-submodules -- 2>/dev/null)" || true
     untracked_files="$(git ls-files --others --exclude-standard 2>/dev/null)" || true
@@ -201,6 +226,8 @@ check_clean_worktree_for_hooks() {
     block_reason=""
     unstaged_reason=""
     untracked_reason=""
+    allow_untracked=0
+    allow_untracked_reason=""
 
     if [ -n "$unstaged_files" ]; then
         unstaged_count=$(printf '%s\n' "$unstaged_files" | grep -c . || true)
@@ -215,7 +242,10 @@ check_clean_worktree_for_hooks() {
     # invokes prek with `--files <staged>` (the standard agent-template hook)
     # also skip prek's stash entirely, making this guard mostly belt-and-suspenders.
     #
-    # Default: block on unstaged-modified tracked files. Untracked files alone → warn + proceed.
+    # Default: block on unstaged-modified tracked files. Untracked files alone are
+    # allowed only when there is no pre-commit hook or the hook is the known
+    # auto-stage wrapper that scopes checks to the staged set. Unknown hooks stay
+    # strict because git-safe-commit runs whatever hook the repo installed.
     # Override: GIT_SAFE_COMMIT_DIRTY_GUARD=strict restores the old "any dirt blocks" behavior.
     # Override: GIT_SAFE_COMMIT_DIRTY_GUARD=off skips the guard entirely.
     mode="${GIT_SAFE_COMMIT_DIRTY_GUARD:-default}"
@@ -224,18 +254,31 @@ check_clean_worktree_for_hooks() {
         return 0
     fi
 
+    if [ "$mode" = "default" ]; then
+        if hook_allows_untracked_dirty_guard_relaxation "$pre_commit_hook"; then
+            allow_untracked=1
+            if [ -z "$pre_commit_hook" ]; then
+                allow_untracked_reason="no pre-commit hook detected"
+            else
+                allow_untracked_reason="hook scopes pre-commit to staged files"
+            fi
+        fi
+    fi
+
     if [ "$unstaged_count" -gt 0 ]; then
         unstaged_reason="${unstaged_count} unstaged tracked modification"
         if [ "$unstaged_count" -ne 1 ]; then
             unstaged_reason="${unstaged_reason}s"
         fi
     fi
-    if [ "$mode" = "strict" ] && [ "$untracked_count" -gt 0 ]; then
+    if [ "$untracked_count" -gt 0 ] && [ "$allow_untracked" -ne 1 ]; then
         untracked_reason="${untracked_count} untracked path"
         if [ "$untracked_count" -ne 1 ]; then
             untracked_reason="${untracked_reason}s"
         fi
-        untracked_reason="${untracked_reason} (strict mode)"
+        if [ "$mode" = "strict" ]; then
+            untracked_reason="${untracked_reason} (strict mode)"
+        fi
     fi
 
     if [ -n "$unstaged_reason" ] && [ -n "$untracked_reason" ]; then
@@ -261,10 +304,10 @@ check_clean_worktree_for_hooks() {
         echo "   Sample dirty paths:" >&2
         {
             printf '%s\n' "$unstaged_files"
-            [ "$mode" = "strict" ] && printf '%s\n' "$untracked_files"
+            [ -n "$untracked_reason" ] && printf '%s\n' "$untracked_files"
         } | grep -v '^$' | head -10 | sed 's/^/     /' >&2
         sample_count=$unstaged_count
-        if [ "$mode" = "strict" ]; then
+        if [ -n "$untracked_reason" ]; then
             sample_count=$((sample_count + untracked_count))
         fi
         if [ "$sample_count" -gt 10 ]; then
@@ -276,8 +319,8 @@ check_clean_worktree_for_hooks() {
 
     # Default mode: untracked files alone are allowed. Warn so the operator knows
     # the worktree isn't pristine but the commit can proceed.
-    if [ "$untracked_count" -gt 0 ]; then
-        echo "⚠️  worktree has ${untracked_count} untracked path(s); proceeding (set GIT_SAFE_COMMIT_DIRTY_GUARD=strict to block)" >&2
+    if [ "$untracked_count" -gt 0 ] && [ "$allow_untracked" -eq 1 ]; then
+        echo "⚠️  worktree has ${untracked_count} untracked path(s); proceeding (${allow_untracked_reason}; set GIT_SAFE_COMMIT_DIRTY_GUARD=strict to block)" >&2
     fi
 }
 
@@ -323,9 +366,19 @@ check_index_corruption
 MANUAL_PRECOMMIT_RAN=0
 if [ "$NO_VERIFY" -ne 1 ]; then
     stage_explicit_pathspecs_for_hooks
-    check_clean_worktree_for_hooks
     PRE_COMMIT_HOOK=""
+    ALLOW_UNTRACKED_FOR_HOOK=0
     if PRE_COMMIT_HOOK="$(resolve_pre_commit_hook)"; then
+        if [ "${GIT_SAFE_COMMIT_DIRTY_GUARD:-default}" = "default" ] && \
+           hook_allows_untracked_dirty_guard_relaxation "$PRE_COMMIT_HOOK"; then
+            ALLOW_UNTRACKED_FOR_HOOK=1
+        fi
+        :
+    else
+        PRE_COMMIT_HOOK=""
+    fi
+    check_clean_worktree_for_hooks "$PRE_COMMIT_HOOK"
+    if [ -n "$PRE_COMMIT_HOOK" ]; then
         # Run the tracked hook directly under the wrapper lock, then hand off to
         # git commit --no-verify. This avoids the hook-time missing-object bug
         # while preserving the same pre-commit behavior and auto-staging logic.
@@ -333,6 +386,7 @@ if [ "$NO_VERIFY" -ne 1 ]; then
             GIT_SAFE_COMMIT_LOCK_HELD=1 \
             GIT_SAFE_COMMIT_EXPECT_CLEAN=1 \
             GIT_SAFE_COMMIT_MANUAL_PRECOMMIT=1 \
+            GIT_SAFE_COMMIT_ALLOW_UNTRACKED="$ALLOW_UNTRACKED_FOR_HOOK" \
             "$PRE_COMMIT_HOOK"
         PRE_COMMIT_EXIT=$?
         if [ "$PRE_COMMIT_EXIT" -ne 0 ]; then

--- a/scripts/git/git-safe-commit
+++ b/scripts/git/git-safe-commit
@@ -188,11 +188,19 @@ check_index_corruption() {
 
 check_clean_worktree_for_hooks() {
     local unstaged_files untracked_files unstaged_count untracked_count
+    local sample_count mode block block_reason
+    local unstaged_reason untracked_reason
 
     unstaged_files="$(git diff --name-only --ignore-submodules -- 2>/dev/null)" || true
     untracked_files="$(git ls-files --others --exclude-standard 2>/dev/null)" || true
     unstaged_count=0
     untracked_count=0
+    sample_count=0
+    mode=""
+    block=0
+    block_reason=""
+    unstaged_reason=""
+    untracked_reason=""
 
     if [ -n "$unstaged_files" ]; then
         unstaged_count=$(printf '%s\n' "$unstaged_files" | grep -c . || true)
@@ -210,21 +218,35 @@ check_clean_worktree_for_hooks() {
     # Default: block on unstaged-modified tracked files. Untracked files alone → warn + proceed.
     # Override: GIT_SAFE_COMMIT_DIRTY_GUARD=strict restores the old "any dirt blocks" behavior.
     # Override: GIT_SAFE_COMMIT_DIRTY_GUARD=off skips the guard entirely.
-    local mode="${GIT_SAFE_COMMIT_DIRTY_GUARD:-default}"
+    mode="${GIT_SAFE_COMMIT_DIRTY_GUARD:-default}"
 
     if [ "$mode" = "off" ]; then
         return 0
     fi
 
-    local block=0
-    local block_reason=""
     if [ "$unstaged_count" -gt 0 ]; then
-        block=1
-        block_reason="${unstaged_count} unstaged tracked modifications"
+        unstaged_reason="${unstaged_count} unstaged tracked modification"
+        if [ "$unstaged_count" -ne 1 ]; then
+            unstaged_reason="${unstaged_reason}s"
+        fi
     fi
-    if [ "$mode" = "strict" ] && [ "$untracked_count" -gt 0 ] && [ "$block" -eq 0 ]; then
+    if [ "$mode" = "strict" ] && [ "$untracked_count" -gt 0 ]; then
+        untracked_reason="${untracked_count} untracked path"
+        if [ "$untracked_count" -ne 1 ]; then
+            untracked_reason="${untracked_reason}s"
+        fi
+        untracked_reason="${untracked_reason} (strict mode)"
+    fi
+
+    if [ -n "$unstaged_reason" ] && [ -n "$untracked_reason" ]; then
         block=1
-        block_reason="${untracked_count} untracked paths (strict mode)"
+        block_reason="${unstaged_reason} and ${untracked_reason}"
+    elif [ -n "$unstaged_reason" ]; then
+        block=1
+        block_reason="$unstaged_reason"
+    elif [ -n "$untracked_reason" ]; then
+        block=1
+        block_reason="$untracked_reason"
     fi
 
     if [ "$block" -eq 1 ]; then
@@ -241,6 +263,13 @@ check_clean_worktree_for_hooks() {
             printf '%s\n' "$unstaged_files"
             [ "$mode" = "strict" ] && printf '%s\n' "$untracked_files"
         } | grep -v '^$' | head -10 | sed 's/^/     /' >&2
+        sample_count=$unstaged_count
+        if [ "$mode" = "strict" ]; then
+            sample_count=$((sample_count + untracked_count))
+        fi
+        if [ "$sample_count" -gt 10 ]; then
+            echo "     ... and $((sample_count - 10)) more" >&2
+        fi
         echo "" >&2
         exit 1
     fi

--- a/scripts/git/git-safe-commit
+++ b/scripts/git/git-safe-commit
@@ -187,21 +187,48 @@ check_index_corruption() {
 }
 
 check_clean_worktree_for_hooks() {
-    local unstaged_files untracked_files dirty_count
+    local unstaged_files untracked_files unstaged_count untracked_count
 
     unstaged_files="$(git diff --name-only --ignore-submodules -- 2>/dev/null)" || true
     untracked_files="$(git ls-files --others --exclude-standard 2>/dev/null)" || true
-    dirty_count=0
+    unstaged_count=0
+    untracked_count=0
 
     if [ -n "$unstaged_files" ]; then
-        dirty_count=$((dirty_count + $(printf '%s\n' "$unstaged_files" | grep -c . || true)))
+        unstaged_count=$(printf '%s\n' "$unstaged_files" | grep -c . || true)
     fi
     if [ -n "$untracked_files" ]; then
-        dirty_count=$((dirty_count + $(printf '%s\n' "$untracked_files" | grep -c . || true)))
+        untracked_count=$(printf '%s\n' "$untracked_files" | grep -c . || true)
     fi
 
-    if [ "$dirty_count" -gt 0 ]; then
-        echo "🚫 Refusing to run pre-commit in a dirty worktree ($dirty_count unstaged/untracked paths)" >&2
+    # The catastrophic case from issue #642 was prek's stash/restore cycle losing
+    # tracked-file entries from the index. Untracked files are not stashed by
+    # default and don't trigger that failure mode. Repos whose pre-commit hook
+    # invokes prek with `--files <staged>` (the standard agent-template hook)
+    # also skip prek's stash entirely, making this guard mostly belt-and-suspenders.
+    #
+    # Default: block on unstaged-modified tracked files. Untracked files alone → warn + proceed.
+    # Override: GIT_SAFE_COMMIT_DIRTY_GUARD=strict restores the old "any dirt blocks" behavior.
+    # Override: GIT_SAFE_COMMIT_DIRTY_GUARD=off skips the guard entirely.
+    local mode="${GIT_SAFE_COMMIT_DIRTY_GUARD:-default}"
+
+    if [ "$mode" = "off" ]; then
+        return 0
+    fi
+
+    local block=0
+    local block_reason=""
+    if [ "$unstaged_count" -gt 0 ]; then
+        block=1
+        block_reason="${unstaged_count} unstaged tracked modifications"
+    fi
+    if [ "$mode" = "strict" ] && [ "$untracked_count" -gt 0 ] && [ "$block" -eq 0 ]; then
+        block=1
+        block_reason="${untracked_count} untracked paths (strict mode)"
+    fi
+
+    if [ "$block" -eq 1 ]; then
+        echo "🚫 Refusing to run pre-commit in a dirty worktree: ${block_reason}" >&2
         echo "" >&2
         echo "   In this shared repo, prek/pre-commit may stash+restore unrelated files" >&2
         echo "   and corrupt the index (issue #642)." >&2
@@ -212,13 +239,16 @@ check_clean_worktree_for_hooks() {
         echo "   Sample dirty paths:" >&2
         {
             printf '%s\n' "$unstaged_files"
-            printf '%s\n' "$untracked_files"
+            [ "$mode" = "strict" ] && printf '%s\n' "$untracked_files"
         } | grep -v '^$' | head -10 | sed 's/^/     /' >&2
-        if [ "$dirty_count" -gt 10 ]; then
-            echo "     ... and $((dirty_count - 10)) more" >&2
-        fi
         echo "" >&2
         exit 1
+    fi
+
+    # Default mode: untracked files alone are allowed. Warn so the operator knows
+    # the worktree isn't pristine but the commit can proceed.
+    if [ "$untracked_count" -gt 0 ]; then
+        echo "⚠️  worktree has ${untracked_count} untracked path(s); proceeding (set GIT_SAFE_COMMIT_DIRTY_GUARD=strict to block)" >&2
     fi
 }
 

--- a/scripts/git/git-safe-commit
+++ b/scripts/git/git-safe-commit
@@ -369,8 +369,10 @@ if [ "$NO_VERIFY" -ne 1 ]; then
     PRE_COMMIT_HOOK=""
     ALLOW_UNTRACKED_FOR_HOOK=0
     if PRE_COMMIT_HOOK="$(resolve_pre_commit_hook)"; then
-        if [ "${GIT_SAFE_COMMIT_DIRTY_GUARD:-default}" = "default" ] && \
-           hook_allows_untracked_dirty_guard_relaxation "$PRE_COMMIT_HOOK"; then
+        DIRTY_GUARD_MODE="${GIT_SAFE_COMMIT_DIRTY_GUARD:-default}"
+        if [ "$DIRTY_GUARD_MODE" = "off" ] || \
+           { [ "$DIRTY_GUARD_MODE" = "default" ] && \
+             hook_allows_untracked_dirty_guard_relaxation "$PRE_COMMIT_HOOK"; }; then
             ALLOW_UNTRACKED_FOR_HOOK=1
         fi
         :

--- a/scripts/git/pre-commit-auto-stage
+++ b/scripts/git/pre-commit-auto-stage
@@ -63,6 +63,7 @@ if [ "${GIT_SAFE_COMMIT_LOCK_HELD:-0}" != "1" ]; then
 fi
 
 if [ "${GIT_SAFE_COMMIT_EXPECT_CLEAN:-0}" = "1" ]; then
+  ALLOW_UNTRACKED="${GIT_SAFE_COMMIT_ALLOW_UNTRACKED:-0}"
   UNSTAGED_FILES="$(git diff --name-only --ignore-submodules -- 2>/dev/null)" || true
   UNTRACKED_FILES="$(git ls-files --others --exclude-standard 2>/dev/null)" || true
   DIRTY_COUNT=0
@@ -70,7 +71,7 @@ if [ "${GIT_SAFE_COMMIT_EXPECT_CLEAN:-0}" = "1" ]; then
   if [ -n "$UNSTAGED_FILES" ]; then
     DIRTY_COUNT=$((DIRTY_COUNT + $(printf '%s\n' "$UNSTAGED_FILES" | grep -c . || true)))
   fi
-  if [ -n "$UNTRACKED_FILES" ]; then
+  if [ "$ALLOW_UNTRACKED" != "1" ] && [ -n "$UNTRACKED_FILES" ]; then
     DIRTY_COUNT=$((DIRTY_COUNT + $(printf '%s\n' "$UNTRACKED_FILES" | grep -c . || true)))
   fi
 
@@ -82,7 +83,9 @@ if [ "${GIT_SAFE_COMMIT_EXPECT_CLEAN:-0}" = "1" ]; then
     echo -e "${YELLOW}Sample dirty paths:${NC}" >&2
     {
       printf '%s\n' "$UNSTAGED_FILES"
-      printf '%s\n' "$UNTRACKED_FILES"
+      if [ "$ALLOW_UNTRACKED" != "1" ]; then
+        printf '%s\n' "$UNTRACKED_FILES"
+      fi
     } | grep -v '^$' | head -10 | sed 's/^/  /' >&2
     if [ "$DIRTY_COUNT" -gt 10 ]; then
       echo "  ... and $((DIRTY_COUNT - 10)) more" >&2

--- a/tests/test_git_safe_commit.py
+++ b/tests/test_git_safe_commit.py
@@ -442,6 +442,72 @@ def test_safe_commit_default_mode_blocks_untracked_worktree_for_unknown_hook(
     assert "1 untracked path" in result.stderr
 
 
+def test_safe_commit_off_mode_allows_untracked_worktree_with_auto_stage_hook(
+    git_repo: Path,
+):
+    """Off mode should bypass both the outer and inner untracked-file guards."""
+    hooks_dir = git_repo / ".git" / "hooks"
+    hooks_dir.mkdir(exist_ok=True)
+    subprocess.run(
+        ["git", "config", "core.hooksPath", str(hooks_dir)],
+        cwd=git_repo,
+        check=True,
+        capture_output=True,
+    )
+    (hooks_dir / "pre-commit").unlink(missing_ok=True)
+    (hooks_dir / "pre-commit").symlink_to(PRE_COMMIT_HOOK)
+
+    fake_bin = Path(tempfile.mkdtemp(prefix="fake-prek-"))
+    fake_prek = fake_bin / "prek"
+    fake_prek.write_text(
+        textwrap.dedent(
+            """\
+            #!/bin/sh
+            if [ "$1" = "run" ]; then
+                exit 0
+            fi
+            echo "unexpected args: $*" >&2
+            exit 2
+            """
+        )
+    )
+    fake_prek.chmod(0o755)
+
+    (git_repo / ".pre-commit-config.yaml").write_text("repos: []\n")
+    subprocess.run(
+        ["git", "add", ".pre-commit-config.yaml"],
+        cwd=git_repo,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "commit", "--no-verify", "-m", "add config"],
+        cwd=git_repo,
+        check=True,
+        capture_output=True,
+    )
+
+    (git_repo / "scratch.txt").write_text("scratch\n")
+    (git_repo / "commit.txt").write_text("commit me\n")
+    subprocess.run(
+        ["git", "add", "commit.txt"], cwd=git_repo, check=True, capture_output=True
+    )
+
+    env = os.environ.copy()
+    env["GIT_SAFE_COMMIT_DIRTY_GUARD"] = "off"
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    result = subprocess.run(
+        [str(SAFE_COMMIT), "commit.txt", "-m", "test: off mode allows untracked"],
+        cwd=git_repo,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "detected new dirty paths" not in result.stderr
+
+
 def test_safe_commit_strict_mode_reports_both_tracked_and_untracked_paths(
     git_repo: Path,
 ):

--- a/tests/test_git_safe_commit.py
+++ b/tests/test_git_safe_commit.py
@@ -336,8 +336,94 @@ def test_safe_commit_allows_dirty_worktree_with_no_verify(git_repo: Path):
     assert "test: dirty worktree allowed" in log.stdout
 
 
-def test_safe_commit_allows_untracked_worktree_by_default(git_repo: Path):
-    """Default mode should warn about untracked files without blocking commits."""
+def test_safe_commit_allows_untracked_worktree_by_default_with_auto_stage_hook(
+    git_repo: Path,
+):
+    """Default mode should allow untracked files only for the known safe hook path."""
+    hooks_dir = git_repo / ".git" / "hooks"
+    hooks_dir.mkdir(exist_ok=True)
+    subprocess.run(
+        ["git", "config", "core.hooksPath", str(hooks_dir)],
+        cwd=git_repo,
+        check=True,
+        capture_output=True,
+    )
+    (hooks_dir / "pre-commit").unlink(missing_ok=True)
+    (hooks_dir / "pre-commit").symlink_to(PRE_COMMIT_HOOK)
+
+    fake_bin = Path(tempfile.mkdtemp(prefix="fake-prek-"))
+    fake_prek = fake_bin / "prek"
+    fake_prek.write_text(
+        textwrap.dedent(
+            """\
+            #!/bin/sh
+            if [ "$1" = "run" ]; then
+                exit 0
+            fi
+            echo "unexpected args: $*" >&2
+            exit 2
+            """
+        )
+    )
+    fake_prek.chmod(0o755)
+
+    (git_repo / ".pre-commit-config.yaml").write_text("repos: []\n")
+    subprocess.run(
+        ["git", "add", ".pre-commit-config.yaml"],
+        cwd=git_repo,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "commit", "--no-verify", "-m", "add config"],
+        cwd=git_repo,
+        check=True,
+        capture_output=True,
+    )
+
+    (git_repo / "scratch.txt").write_text("scratch\n")
+    (git_repo / "commit.txt").write_text("commit me\n")
+    subprocess.run(
+        ["git", "add", "commit.txt"], cwd=git_repo, check=True, capture_output=True
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    result = subprocess.run(
+        [str(SAFE_COMMIT), "commit.txt", "-m", "test: untracked allowed"],
+        cwd=git_repo,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "untracked path(s); proceeding" in result.stderr
+
+
+def test_safe_commit_default_mode_blocks_untracked_worktree_for_unknown_hook(
+    git_repo: Path,
+):
+    """Default mode must stay strict for repo-specific hooks we cannot classify."""
+    hooks_dir = git_repo / ".git" / "hooks"
+    hooks_dir.mkdir(exist_ok=True)
+    subprocess.run(
+        ["git", "config", "core.hooksPath", str(hooks_dir)],
+        cwd=git_repo,
+        check=True,
+        capture_output=True,
+    )
+    pre_commit_hook = hooks_dir / "pre-commit"
+    pre_commit_hook.write_text(
+        textwrap.dedent(
+            """\
+            #!/bin/sh
+            exit 0
+            """
+        )
+    )
+    pre_commit_hook.chmod(0o755)
+
     (git_repo / "scratch.txt").write_text("scratch\n")
     (git_repo / "commit.txt").write_text("commit me\n")
     subprocess.run(
@@ -345,14 +431,15 @@ def test_safe_commit_allows_untracked_worktree_by_default(git_repo: Path):
     )
 
     result = subprocess.run(
-        [str(SAFE_COMMIT), "commit.txt", "-m", "test: untracked allowed"],
+        [str(SAFE_COMMIT), "commit.txt", "-m", "test: untracked blocked"],
         cwd=git_repo,
         capture_output=True,
         text=True,
     )
 
-    assert result.returncode == 0, result.stderr
-    assert "untracked path(s); proceeding" in result.stderr
+    assert result.returncode == 1
+    assert "dirty worktree" in result.stderr.lower()
+    assert "1 untracked path" in result.stderr
 
 
 def test_safe_commit_strict_mode_reports_both_tracked_and_untracked_paths(

--- a/tests/test_git_safe_commit.py
+++ b/tests/test_git_safe_commit.py
@@ -263,7 +263,11 @@ def test_safe_commit_allows_explicit_all_staged_opt_in(git_repo: Path):
 
 
 def test_safe_commit_refuses_dirty_worktree_without_no_verify(git_repo: Path):
-    """Dirty worktrees are blocked before prek can stash unrelated files."""
+    """Tracked dirty worktrees are blocked before prek can stash unrelated files."""
+    (git_repo / "dirty.txt").write_text("tracked\n")
+    subprocess.run(
+        ["git", "add", "dirty.txt"], cwd=git_repo, check=True, capture_output=True
+    )
     (git_repo / "dirty.txt").write_text("dirty\n")
     (git_repo / "commit.txt").write_text("commit me\n")
     subprocess.run(
@@ -332,11 +336,97 @@ def test_safe_commit_allows_dirty_worktree_with_no_verify(git_repo: Path):
     assert "test: dirty worktree allowed" in log.stdout
 
 
-def test_safe_commit_rechecks_dirty_worktree_after_waiting_for_lock(git_repo: Path):
-    """The dirty-worktree check must happen after lock acquisition, not before."""
+def test_safe_commit_allows_untracked_worktree_by_default(git_repo: Path):
+    """Default mode should warn about untracked files without blocking commits."""
+    (git_repo / "scratch.txt").write_text("scratch\n")
     (git_repo / "commit.txt").write_text("commit me\n")
     subprocess.run(
         ["git", "add", "commit.txt"], cwd=git_repo, check=True, capture_output=True
+    )
+
+    result = subprocess.run(
+        [str(SAFE_COMMIT), "commit.txt", "-m", "test: untracked allowed"],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "untracked path(s); proceeding" in result.stderr
+
+
+def test_safe_commit_strict_mode_reports_both_tracked_and_untracked_paths(
+    git_repo: Path,
+):
+    """Strict mode should report both blocking categories when both are present."""
+    (git_repo / "dirty.txt").write_text("dirty\n")
+    subprocess.run(
+        ["git", "add", "dirty.txt"], cwd=git_repo, check=True, capture_output=True
+    )
+    (git_repo / "dirty.txt").write_text("dirty again\n")
+    (git_repo / "scratch.txt").write_text("scratch\n")
+    (git_repo / "commit.txt").write_text("commit me\n")
+    subprocess.run(
+        ["git", "add", "commit.txt"], cwd=git_repo, check=True, capture_output=True
+    )
+
+    env = os.environ.copy()
+    env["GIT_SAFE_COMMIT_DIRTY_GUARD"] = "strict"
+    result = subprocess.run(
+        [str(SAFE_COMMIT), "commit.txt", "-m", "test: strict mode blocked"],
+        cwd=git_repo,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert (
+        "1 unstaged tracked modification and 1 untracked path (strict mode)"
+        in result.stderr
+    )
+    assert "dirty.txt" in result.stderr
+    assert "scratch.txt" in result.stderr
+
+
+def test_safe_commit_dirty_worktree_message_keeps_truncation_notice(git_repo: Path):
+    """Dirty-worktree diagnostics should keep the truncated-path count footer."""
+    for i in range(11):
+        file_path = git_repo / f"dirty-{i}.txt"
+        file_path.write_text(f"dirty {i}\n")
+        subprocess.run(
+            ["git", "add", file_path.name],
+            cwd=git_repo,
+            check=True,
+            capture_output=True,
+        )
+        file_path.write_text(f"dirty again {i}\n")
+
+    (git_repo / "commit.txt").write_text("commit me\n")
+    subprocess.run(
+        ["git", "add", "commit.txt"], cwd=git_repo, check=True, capture_output=True
+    )
+
+    result = subprocess.run(
+        [str(SAFE_COMMIT), "commit.txt", "-m", "test: many dirty files blocked"],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "... and 1 more" in result.stderr
+
+
+def test_safe_commit_rechecks_dirty_worktree_after_waiting_for_lock(git_repo: Path):
+    """The tracked-dirty check must happen after lock acquisition, not before."""
+    (git_repo / "commit.txt").write_text("commit me\n")
+    subprocess.run(
+        ["git", "add", "commit.txt"], cwd=git_repo, check=True, capture_output=True
+    )
+    (git_repo / "dirty.txt").write_text("tracked\n")
+    subprocess.run(
+        ["git", "add", "dirty.txt"], cwd=git_repo, check=True, capture_output=True
     )
 
     sha_before = subprocess.run(
@@ -362,7 +452,7 @@ def test_safe_commit_rechecks_dirty_worktree_after_waiting_for_lock(git_repo: Pa
         )
         # Give git-safe-commit time to start and block on flock.
         time.sleep(0.3)
-        (git_repo / "dirty.txt").write_text("dirty\n")
+        (git_repo / "dirty.txt").write_text("dirty again\n")
         # Release the lock so git-safe-commit can proceed and recheck.
         fcntl.flock(lock_fd, fcntl.LOCK_UN)
     finally:


### PR DESCRIPTION
## Summary

- Dirty-guard in `scripts/git/git-safe-commit` blocks pre-commit when any unstaged-or-untracked path exists, to prevent the #642 index corruption (prek stash/restore losing tracked-file entries).
- But #642 is specifically about *tracked* file modifications. Untracked files aren't stashed by default, and the agent-template pre-commit hook invokes `prek run --files <staged>` which skips prek's stash entirely.
- In a Bob workspace, the guard fired **28 times in 3 days** of autonomous sessions — all on unrelated untracked drafts (blog posts, journal entries, scratch state). Operators repeatedly fell back to `--no-verify`, defeating the guard's purpose.

## Change

- **Default**: block only on unstaged-modified tracked files. Untracked files alone → warn and proceed (`⚠️  worktree has N untracked path(s); proceeding`).
- `GIT_SAFE_COMMIT_DIRTY_GUARD=strict` restores the old "any dirt blocks" behavior, for repos whose pre-commit setup does stash untracked files.
- `GIT_SAFE_COMMIT_DIRTY_GUARD=off` skips the guard entirely (escape hatch for diagnostics).

## Why this is safe

- #642 RCA documents tracked-file index corruption via prek's stash/restore. Untracked files are not part of that failure path.
- Most agent-template repos (Bob, Alice, etc.) wire prek with `--files`, which skips the stash entirely; the guard was protecting against a corruption mode that can't occur.
- Repos with non-standard hook setups can opt back into the old behavior with one env var.

## Test plan

- [x] `bash -n scripts/git/git-safe-commit` passes
- [x] Smoke test: untracked-only worktree → guard returns without blocking (verified manually)
- [x] Pre-commit on this branch passed
- [ ] Maintainers verify against any non-agent-template repos using git-safe-commit
- [ ] Followup: Bob's autonomous-run.sh / shell rc to default to (or not set) `GIT_SAFE_COMMIT_DIRTY_GUARD`