### PR TITLE
fix(activity-gate): cache per-repo gh fetches to reduce GraphQL load

### DIFF
--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -258,10 +258,16 @@ gh_cache_get_or_fetch() {
             fi
         fi
     fi
-    local out
+    local out tmp_file
     if out=$(eval "$producer"); then
         if [ -n "$out" ]; then
-            printf '%s' "$out" > "$cache_file"
+            tmp_file=$(mktemp "$GH_CACHE_DIR/${safe_key}.json.tmp.XXXXXX" 2>/dev/null || printf '')
+            if [ -n "$tmp_file" ]; then
+                # Write via temp file + rename so readers never observe partial JSON.
+                if ! printf '%s' "$out" > "$tmp_file" || ! mv "$tmp_file" "$cache_file"; then
+                    rm -f "$tmp_file"
+                fi
+            fi
         fi
         printf '%s' "$out"
         return 0

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -207,15 +207,69 @@ discover_repos() {
     for r in "${EXTRA_REPOS[@]}"; do echo "$r"; done
 }
 
+# Per-repo GraphQL response cache. Default cadence is every 2 minutes across 50
+# repos × 3 gh calls = 150 GraphQL ops/run → 4,500/hr. With a 4-min TTL on
+# PR data (the most time-critical) and 5-min TTLs on issues/master-CI, we serve
+# from cache on every other run and refresh in the next, cutting load by ~50%
+# without changing cadence.
+#
+# Override via env: GH_CACHE_TTL_PR / GH_CACHE_TTL_ISSUE / GH_CACHE_TTL_RUN (seconds).
+# Set any to 0 to bypass the cache (useful for diagnostics).
+GH_CACHE_DIR="${GH_CACHE_DIR:-$STATE_DIR/gh-cache}"
+GH_CACHE_TTL_PR="${GH_CACHE_TTL_PR:-240}"
+GH_CACHE_TTL_ISSUE="${GH_CACHE_TTL_ISSUE:-300}"
+GH_CACHE_TTL_RUN="${GH_CACHE_TTL_RUN:-300}"
+
+# Read cached value if fresh enough, else run the producer command and cache its
+# stdout. The producer is passed as a single shell-evaluated string so callers
+# can include flags and pipes.
+#
+# Args:
+#   $1 — cache key (filesystem-safe; will be normalized)
+#   $2 — TTL seconds (0 = no cache)
+#   $3 — producer command (eval'd in subshell)
+gh_cache_get_or_fetch() {
+    local key="$1" ttl="$2" producer="$3"
+    if [ "$ttl" -le 0 ]; then
+        eval "$producer"
+        return $?
+    fi
+    mkdir -p "$GH_CACHE_DIR" 2>/dev/null || true
+    # Normalize key: replace slashes with `-`
+    local safe_key="${key//\//-}"
+    local cache_file="$GH_CACHE_DIR/${safe_key}.json"
+    if [ -f "$cache_file" ]; then
+        local mtime
+        mtime=$(stat -c %Y "$cache_file" 2>/dev/null || stat -f %m "$cache_file" 2>/dev/null || echo "")
+        if [ -n "$mtime" ]; then
+            local age=$(( $(date +%s) - mtime ))
+            if [ "$age" -lt "$ttl" ]; then
+                cat "$cache_file"
+                return 0
+            fi
+        fi
+    fi
+    local out
+    out=$(eval "$producer")
+    local rc=$?
+    if [ $rc -eq 0 ] && [ -n "$out" ]; then
+        printf '%s' "$out" > "$cache_file"
+    fi
+    printf '%s' "$out"
+    return $rc
+}
+
 # Fetch all PR data once per repo, with all fields needed by every check function.
-# This replaces 3 separate `gh pr list` calls with a single one.
+# This replaces 3 separate `gh pr list` calls with a single one. Cached at
+# GH_CACHE_TTL_PR (default 240s) since the gate cadence is 120s.
 fetch_pr_data() {
     local repo=$1
     # Filter out draft PRs — they're intentionally deprioritized/not on merge path
-    gh pr list --repo "$repo" --author "$AUTHOR" --state open \
-        --json number,title,updatedAt,comments,latestReviews,statusCheckRollup,mergeable,mergeStateStatus,headRefOid,isDraft \
-        --jq '[.[] | select(.isDraft | not)]' \
-        2>/dev/null || echo "[]"
+    gh_cache_get_or_fetch "pr-${repo}" "$GH_CACHE_TTL_PR" \
+        "gh pr list --repo '$repo' --author '$AUTHOR' --state open \
+            --json number,title,updatedAt,comments,latestReviews,statusCheckRollup,mergeable,mergeStateStatus,headRefOid,isDraft \
+            --jq '[.[] | select(.isDraft | not)]' \
+            2>/dev/null || echo '[]'"
 }
 
 # Check whether the last activity on a PR was from someone worth responding to.
@@ -352,12 +406,15 @@ check_ci_failures() {
     done
 }
 
-# Check for assigned issues with new activity (state-tracked like PRs)
+# Check for assigned issues with new activity (state-tracked like PRs).
+# Cached at GH_CACHE_TTL_ISSUE (default 300s); assigned-issue updates aren't
+# 2-min-urgent — the gate's state-tracking still fires when cache refreshes.
 check_assigned_issues() {
     local repo=$1
     local issues
-    issues=$(gh issue list --repo "$repo" --assignee "$AUTHOR" --state open \
-        --json number,title,updatedAt 2>/dev/null || echo "[]")
+    issues=$(gh_cache_get_or_fetch "issue-${repo}" "$GH_CACHE_TTL_ISSUE" \
+        "gh issue list --repo '$repo' --assignee '$AUTHOR' --state open \
+            --json number,title,updatedAt 2>/dev/null || echo '[]'")
     [ "$issues" = "[]" ] || [ -z "$issues" ] && return 0
 
     echo "$issues" | jq -c '.[]' | while read -r issue_data; do
@@ -387,12 +444,14 @@ check_assigned_issues() {
 check_master_ci() {
     local repo=$1
     local runs
-    runs=$(gh run list --repo "$repo" --branch master --limit 3 \
-        --json databaseId,name,conclusion,createdAt 2>/dev/null || echo "[]")
+    runs=$(gh_cache_get_or_fetch "run-master-${repo}" "$GH_CACHE_TTL_RUN" \
+        "gh run list --repo '$repo' --branch master --limit 3 \
+            --json databaseId,name,conclusion,createdAt 2>/dev/null || echo '[]'")
     # Also try 'main' if master returned nothing
     if [ "$runs" = "[]" ]; then
-        runs=$(gh run list --repo "$repo" --branch main --limit 3 \
-            --json databaseId,name,conclusion,createdAt 2>/dev/null || echo "[]")
+        runs=$(gh_cache_get_or_fetch "run-main-${repo}" "$GH_CACHE_TTL_RUN" \
+            "gh run list --repo '$repo' --branch main --limit 3 \
+                --json databaseId,name,conclusion,createdAt 2>/dev/null || echo '[]'")
     fi
     [ "$runs" = "[]" ] || [ -z "$runs" ] && return 0
 

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -73,10 +73,12 @@
 #   first-time discovery DOES emit immediately — merge-ready PRs are actionable.
 #   State-tracked with 12-hour cooldown; re-emits on HEAD SHA change.
 #
-#   API efficiency: PR data is fetched once per repo via fetch_pr_data() and
-#   shared across check_pr_updates, check_ci_failures, check_merge_conflicts,
-#   and check_merge_ready.
-#   This reduces gh pr list calls from 3N to N (where N = number of repos).
+#   API efficiency: cached PR data is fetched once per repo via fetch_pr_data()
+#   and shared across the state-tracked checks (PR updates, CI failures,
+#   Greptile sweep). Merge-sensitive checks (merge conflicts, merge-ready) use
+#   a live PR fetch each run so they don't inherit cache staleness.
+#   This reduces gh pr list calls from 3N to ~1.5N on average (where N = number
+#   of repos), while preserving the "nag every run" merge-conflict contract.
 #   The repo list from discover_repos() is cached for 1 hour.
 #
 #   Parallelism: Per-repo work runs concurrently (up to 8 repos at once).
@@ -271,18 +273,31 @@ gh_cache_get_or_fetch() {
     return 1
 }
 
-# Fetch all PR data once per repo, with all fields needed by every check function.
-# This replaces 3 separate `gh pr list` calls with a single one. Cached at
-# GH_CACHE_TTL_PR (default 240s) since the gate cadence is 120s.
-fetch_pr_data() {
+# Fetch all PR data once per repo, with all fields needed by every check
+# function. Cache state-tracked checks, but let merge-sensitive callers opt out
+# so they always see live merge status.
+fetch_pr_data_with_ttl() {
     local repo=$1
+    local ttl=$2
     # Filter out draft PRs — they're intentionally deprioritized/not on merge path
-    gh_cache_get_or_fetch "pr-${repo}" "$GH_CACHE_TTL_PR" \
+    gh_cache_get_or_fetch "pr-${repo}" "$ttl" \
         "gh pr list --repo '$repo' --author '$AUTHOR' --state open \
             --json number,title,updatedAt,comments,latestReviews,statusCheckRollup,mergeable,mergeStateStatus,headRefOid,isDraft \
             --jq '[.[] | select(.isDraft | not)]' \
             2>/dev/null" \
         "[]"
+}
+
+# Cached view for state-tracked checks; default TTL is tuned to the 2-minute gate
+# cadence to cut GraphQL load roughly in half.
+fetch_pr_data() {
+    fetch_pr_data_with_ttl "$1" "$GH_CACHE_TTL_PR"
+}
+
+# Live view for merge-sensitive checks. They intentionally bypass the cache so
+# conflict nagging and merge readiness reflect the current branch state.
+fetch_live_pr_data() {
+    fetch_pr_data_with_ttl "$1" 0
 }
 
 # Check whether the last activity on a PR was from someone worth responding to.
@@ -501,7 +516,7 @@ check_master_ci() {
 
 # Check for merge conflicts on open PRs (DIRTY or CONFLICTING status).
 # Intentionally NOT state-tracked — conflicts should nag every run until resolved.
-# Accepts pre-fetched PR data from fetch_pr_data() to avoid redundant API calls.
+# Callers should pass live PR data (fetch_live_pr_data), not the cached view.
 check_merge_conflicts() {
     local repo=$1
     local prs=$2
@@ -857,8 +872,10 @@ running=0
 for repo in $all_repos; do
     repo_safe="${repo//\//-}"
     (
-        # Fetch all PR data once per repo (replaces 3 separate gh pr list calls)
+        # Cached PR data drives the state-tracked checks.
         pr_data=$(fetch_pr_data "$repo")
+        # Merge-sensitive checks need live status every run, regardless of cache.
+        live_pr_data=$(fetch_live_pr_data "$repo")
         repo_items=""
 
         items=$(check_pr_updates "$repo" "$pr_data" 2>/dev/null || true)
@@ -873,13 +890,13 @@ for repo in $all_repos; do
         items=$(check_master_ci "$repo" 2>/dev/null || true)
         [ -n "$items" ] && repo_items+="$items"$'\n'
 
-        items=$(check_merge_conflicts "$repo" "$pr_data" 2>/dev/null || true)
+        items=$(check_merge_conflicts "$repo" "$live_pr_data" 2>/dev/null || true)
         [ -n "$items" ] && repo_items+="$items"$'\n'
 
         items=$(check_greptile_scores "$repo" "$pr_data" 2>/dev/null || true)
         [ -n "$items" ] && repo_items+="$items"$'\n'
 
-        items=$(check_merge_ready "$repo" "$pr_data" 2>/dev/null || true)
+        items=$(check_merge_ready "$repo" "$live_pr_data" 2>/dev/null || true)
         [ -n "$items" ] && repo_items+="$items"$'\n'
 
         [ -n "$repo_items" ] && printf '%s' "$repo_items" > "$PARALLEL_TMPDIR/$repo_safe"

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -228,11 +228,18 @@ GH_CACHE_TTL_RUN="${GH_CACHE_TTL_RUN:-300}"
 #   $1 — cache key (filesystem-safe; will be normalized)
 #   $2 — TTL seconds (0 = no cache)
 #   $3 — producer command (eval'd in subshell)
+#   $4 — fallback stdout to emit on producer failure (optional; not cached)
 gh_cache_get_or_fetch() {
-    local key="$1" ttl="$2" producer="$3"
+    local key="$1" ttl="$2" producer="$3" fallback="${4-}"
     if [ "$ttl" -le 0 ]; then
-        eval "$producer"
-        return $?
+        if eval "$producer"; then
+            return 0
+        fi
+        if [ $# -ge 4 ]; then
+            printf '%s' "$fallback"
+            return 0
+        fi
+        return 1
     fi
     mkdir -p "$GH_CACHE_DIR" 2>/dev/null || true
     # Normalize key: replace slashes with `-`
@@ -250,13 +257,18 @@ gh_cache_get_or_fetch() {
         fi
     fi
     local out
-    out=$(eval "$producer")
-    local rc=$?
-    if [ $rc -eq 0 ] && [ -n "$out" ]; then
-        printf '%s' "$out" > "$cache_file"
+    if out=$(eval "$producer"); then
+        if [ -n "$out" ]; then
+            printf '%s' "$out" > "$cache_file"
+        fi
+        printf '%s' "$out"
+        return 0
     fi
-    printf '%s' "$out"
-    return $rc
+    if [ $# -ge 4 ]; then
+        printf '%s' "$fallback"
+        return 0
+    fi
+    return 1
 }
 
 # Fetch all PR data once per repo, with all fields needed by every check function.
@@ -269,7 +281,8 @@ fetch_pr_data() {
         "gh pr list --repo '$repo' --author '$AUTHOR' --state open \
             --json number,title,updatedAt,comments,latestReviews,statusCheckRollup,mergeable,mergeStateStatus,headRefOid,isDraft \
             --jq '[.[] | select(.isDraft | not)]' \
-            2>/dev/null || echo '[]'"
+            2>/dev/null" \
+        "[]"
 }
 
 # Check whether the last activity on a PR was from someone worth responding to.
@@ -414,7 +427,8 @@ check_assigned_issues() {
     local issues
     issues=$(gh_cache_get_or_fetch "issue-${repo}" "$GH_CACHE_TTL_ISSUE" \
         "gh issue list --repo '$repo' --assignee '$AUTHOR' --state open \
-            --json number,title,updatedAt 2>/dev/null || echo '[]'")
+            --json number,title,updatedAt 2>/dev/null" \
+        "[]")
     [ "$issues" = "[]" ] || [ -z "$issues" ] && return 0
 
     echo "$issues" | jq -c '.[]' | while read -r issue_data; do
@@ -446,12 +460,14 @@ check_master_ci() {
     local runs
     runs=$(gh_cache_get_or_fetch "run-master-${repo}" "$GH_CACHE_TTL_RUN" \
         "gh run list --repo '$repo' --branch master --limit 3 \
-            --json databaseId,name,conclusion,createdAt 2>/dev/null || echo '[]'")
+            --json databaseId,name,conclusion,createdAt 2>/dev/null" \
+        "[]")
     # Also try 'main' if master returned nothing
     if [ "$runs" = "[]" ]; then
         runs=$(gh_cache_get_or_fetch "run-main-${repo}" "$GH_CACHE_TTL_RUN" \
             "gh run list --repo '$repo' --branch main --limit 3 \
-                --json databaseId,name,conclusion,createdAt 2>/dev/null || echo '[]'")
+                --json databaseId,name,conclusion,createdAt 2>/dev/null" \
+            "[]")
     fi
     [ "$runs" = "[]" ] || [ -z "$runs" ] && return 0
 

--- a/tests/test_activity_gate_gh_cache.py
+++ b/tests/test_activity_gate_gh_cache.py
@@ -1,0 +1,114 @@
+"""Tests for per-repo gh list caching in activity-gate.sh.
+
+Regression for PR #934 review feedback: failed `gh` producers must not cache the
+fallback `[]`, or the gate will suppress activity for the full TTL.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "github" / "activity-gate.sh"
+
+TEST_REPO = "testorg/testrepo"
+
+FAKE_GH = r"""#!/usr/bin/env python3
+from __future__ import annotations
+import os, sys
+from pathlib import Path
+
+argv = sys.argv[1:]
+count_file = Path(os.environ["GH_PR_LIST_CALL_COUNT"])
+fail_pr_list = os.environ.get("TEST_FAIL_PR_LIST") == "1"
+
+def bump() -> None:
+    n = int(count_file.read_text().strip()) if count_file.exists() else 0
+    count_file.write_text(str(n + 1))
+
+if not argv:
+    sys.exit(2)
+
+if argv[0] == "pr" and len(argv) > 1 and argv[1] == "list":
+    bump()
+    if fail_pr_list:
+        sys.exit(1)
+    print("[]")
+    sys.exit(0)
+
+if argv[0] == "issue" and len(argv) > 1 and argv[1] == "list":
+    print("[]")
+    sys.exit(0)
+
+if argv[0] == "run" and len(argv) > 1 and argv[1] == "list":
+    print("[]")
+    sys.exit(0)
+
+if argv[0] == "repo" and len(argv) > 1 and argv[1] == "list":
+    sys.exit(0)
+
+if argv[0] == "api":
+    print("[]")
+    sys.exit(0)
+
+sys.exit(0)
+"""
+
+
+def _run_gate(
+    tmp: Path,
+    state_dir: Path,
+    *,
+    fail_pr_list: bool,
+) -> tuple[subprocess.CompletedProcess[str], int]:
+    fake_gh = tmp / "gh"
+    fake_gh.write_text(FAKE_GH)
+    fake_gh.chmod(fake_gh.stat().st_mode | stat.S_IXUSR)
+
+    count_file = tmp / "pr-list-count.txt"
+
+    env = os.environ.copy()
+    env["GH_PR_LIST_CALL_COUNT"] = str(count_file)
+    env["TEST_FAIL_PR_LIST"] = "1" if fail_pr_list else "0"
+    env["PATH"] = f"{tmp}:{env['PATH']}"
+
+    result = subprocess.run(
+        [
+            str(SCRIPT),
+            "--author",
+            "test-author",
+            "--org",
+            "testorg",
+            "--repo",
+            TEST_REPO,
+            "--state-dir",
+            str(state_dir),
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    count = int(count_file.read_text().strip()) if count_file.exists() else 0
+    return result, count
+
+
+def test_failed_pr_fetch_does_not_seed_cache() -> None:
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+        cache_file = state_dir / "gh-cache" / "pr-testorg-testrepo.json"
+
+        first, first_count = _run_gate(tmp, state_dir, fail_pr_list=True)
+        assert first.returncode in (0, 1), first.stderr
+        assert first_count == 1
+        assert not cache_file.exists(), "failed gh pr list must not populate cache"
+
+        second, second_count = _run_gate(tmp, state_dir, fail_pr_list=False)
+        assert second.returncode in (0, 1), second.stderr
+        assert second_count == 2, "second run should re-fetch after prior failure"
+        assert cache_file.exists(), "successful gh pr list should populate cache"

--- a/tests/test_activity_gate_gh_cache.py
+++ b/tests/test_activity_gate_gh_cache.py
@@ -2,6 +2,9 @@
 
 Regression for PR #934 review feedback: failed `gh` producers must not cache the
 fallback `[]`, or the gate will suppress activity for the full TTL.
+
+Also verifies that merge-conflict detection still bypasses the PR cache so the
+"nag every run" contract remains true even within the cache window.
 """
 
 from __future__ import annotations
@@ -105,10 +108,130 @@ def test_failed_pr_fetch_does_not_seed_cache() -> None:
 
         first, first_count = _run_gate(tmp, state_dir, fail_pr_list=True)
         assert first.returncode in (0, 1), first.stderr
-        assert first_count == 1
+        assert first_count == 2
         assert not cache_file.exists(), "failed gh pr list must not populate cache"
 
         second, second_count = _run_gate(tmp, state_dir, fail_pr_list=False)
         assert second.returncode in (0, 1), second.stderr
-        assert second_count == 2, "second run should re-fetch after prior failure"
+        assert second_count == 4, "second run should re-fetch after prior failure"
         assert cache_file.exists(), "successful gh pr list should populate cache"
+
+
+FAKE_GH_CONFLICT_REGRESSION = r"""#!/usr/bin/env python3
+from __future__ import annotations
+import json, os, sys
+from pathlib import Path
+
+argv = sys.argv[1:]
+count_file = Path(os.environ["GH_PR_LIST_CALL_COUNT"])
+
+def bump() -> int:
+    n = int(count_file.read_text().strip()) if count_file.exists() else 0
+    n += 1
+    count_file.write_text(str(n))
+    return n
+
+if not argv:
+    sys.exit(2)
+
+if argv[0] == "pr" and len(argv) > 1 and argv[1] == "list":
+    call = bump()
+    merge_state = "CLEAN"
+    mergeable = "MERGEABLE"
+    # First run does two PR fetches (cached + live), both clean. The next run's
+    # live merge-status fetch flips to conflict even though the cached PR data
+    # is still fresh.
+    if call >= 3:
+        merge_state = "DIRTY"
+        mergeable = "CONFLICTING"
+    pr = [{
+        "number": 17,
+        "title": "Conflicting PR",
+        "updatedAt": "2026-05-19T00:00:00Z",
+        "comments": [],
+        "latestReviews": [],
+        "statusCheckRollup": None,
+        "mergeable": mergeable,
+        "mergeStateStatus": merge_state,
+        "headRefOid": "deadbeef",
+        "isDraft": False,
+    }]
+    print(json.dumps(pr))
+    sys.exit(0)
+
+if argv[0] == "issue" and len(argv) > 1 and argv[1] == "list":
+    print("[]")
+    sys.exit(0)
+
+if argv[0] == "run" and len(argv) > 1 and argv[1] == "list":
+    print("[]")
+    sys.exit(0)
+
+if argv[0] == "repo" and len(argv) > 1 and argv[1] == "list":
+    sys.exit(0)
+
+if argv[0] == "api":
+    # No Greptile comments, no notifications.
+    sys.exit(0)
+
+sys.exit(0)
+"""
+
+
+def _run_gate_jsonl(
+    tmp: Path,
+    state_dir: Path,
+    fake_gh_source: str,
+) -> tuple[subprocess.CompletedProcess[str], int]:
+    fake_gh = tmp / "gh"
+    fake_gh.write_text(fake_gh_source)
+    fake_gh.chmod(fake_gh.stat().st_mode | stat.S_IXUSR)
+
+    count_file = tmp / "pr-list-count.txt"
+
+    env = os.environ.copy()
+    env["GH_PR_LIST_CALL_COUNT"] = str(count_file)
+    env["PATH"] = f"{tmp}:{env['PATH']}"
+
+    result = subprocess.run(
+        [
+            str(SCRIPT),
+            "--author",
+            "test-author",
+            "--org",
+            "testorg",
+            "--repo",
+            TEST_REPO,
+            "--state-dir",
+            str(state_dir),
+            "--format",
+            "jsonl",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    count = int(count_file.read_text().strip()) if count_file.exists() else 0
+    return result, count
+
+
+def test_merge_conflict_check_bypasses_pr_cache() -> None:
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+
+        first, first_count = _run_gate_jsonl(
+            tmp, state_dir, FAKE_GH_CONFLICT_REGRESSION
+        )
+        assert first.returncode in (0, 1), first.stderr
+        assert first_count == 2, "first run should do cached + live PR fetches"
+
+        second, second_count = _run_gate_jsonl(
+            tmp, state_dir, FAKE_GH_CONFLICT_REGRESSION
+        )
+        assert second.returncode in (0, 1), second.stderr
+        assert (
+            second_count == 3
+        ), "second run should skip cached producer but still do one live PR fetch"
+        assert '"type":"merge_conflict"' in second.stdout, second.stdout


### PR DESCRIPTION
## Summary

`project-monitoring` runs `activity-gate.sh` every 2 minutes against ~50 repos in the `gptme` org. Each gate run makes 3 GraphQL calls per repo (pr-list, issue-list, run-list), so 50 × 3 × 30 runs/hr = ~4,500 GraphQL ops/hr. That exhausts the 5,000/hr pool and starves everything else (per-session `context.sh`, agent tool-use, `pr-quality-penalties`). Observed today (2026-05-19): hours-long 0% GraphQL with every gate run hitting `SKIP: GraphQL rate limit at 0%`.

## Change

Add a per-repo, per-call-type file cache with TTLs tuned to gate cadence:

| Env var | Default | Purpose |
|---|---|---|
| `GH_CACHE_TTL_PR` | 240s | PR data — misses every other 2-min run |
| `GH_CACHE_TTL_ISSUE` | 300s | assigned issues — less urgent at 2-min |
| `GH_CACHE_TTL_RUN` | 300s | master/main CI runs |

State-tracking via `.state` files (keyed by `updatedAt`) still fires correctly when the cache refreshes — a PR updated during the cache window is reported on the next refresh, at most 240s later. Set any TTL to 0 to bypass.

Expected reduction: roughly 25-30% with the current always-live merge-sensitive PR fetch. That is still enough to buy headroom immediately without changing gate cadence.

## Why not switch to REST?

REST was previously saturated (separate quota, lower per-endpoint limits). Ping-ponging between REST and GraphQL each time one saturates is a treadmill. Caching the GraphQL responses we already have is more durable.

## Best end state (deferred)

The structural fix is a **single batched GraphQL query using aliases**:

```graphql
query {
  r0: repository(owner:"gptme", name:"gptme") {
    pullRequests(first: 20, states: OPEN) { nodes { ... } }
    issues(first: 20, filterBy: {assignee: "TimeToBuildBob"}, states: OPEN) { nodes { ... } }
  }
  r1: repository(owner:"gptme", name:"gptme-contrib") { ... }
}
```

That collapses 50N calls into `ceil(50/batch_size)` calls per gate run (typically 5-10 repos per batch given GitHub's per-query node limits). Deferred because it needs:

- Query template + schema-aware result parsing
- Per-repo error isolation (one bad repo shouldn't fail the whole batch)
- Pagination handling when a repo has >20 PRs/issues

The cache here buys meaningful short-term headroom now while that batched-query design lands.

## Test plan

- [x] `bash -n` passes
- [x] Smoke test: 1st fetch hits producer; 2nd fetch (within TTL) serves cache; TTL=0 bypasses; distinct keys fetch independently
- [ ] Run for 1h post-merge; verify GraphQL `used/limit` stays under ~3,000/hr
- [ ] Verify PR/issue/CI-failure events still fire (just within the cache-staleness window)
