### PR TITLE
fix(voice): default subagent mode to Fast for live-call lookups

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
@@ -407,10 +407,11 @@ class OpenAIRealtimeClient:
                                 "type": "string",
                                 "enum": ["smart", "fast"],
                                 "description": (
-                                    "Response urgency. 'fast' uses a smaller model for speed — "
-                                    "prefer this for simple lookups. 'smart' (default) uses a "
-                                    "larger model when accuracy matters. Both are for small, "
-                                    "focused lookups only — never for broad investigations."
+                                    "Response urgency. 'fast' (default) uses a smaller model for speed — "
+                                    "prefer this for most live-call lookups. 'smart' uses a "
+                                    "larger model when accuracy matters more than latency. "
+                                    "Both are for small, focused lookups only — never for broad "
+                                    "investigations."
                                 ),
                             },
                         },

--- a/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
@@ -405,7 +405,7 @@ class OpenAIRealtimeClient:
                             },
                             "mode": {
                                 "type": "string",
-                                "enum": ["smart", "fast"],
+                                "enum": ["fast", "smart"],
                                 "description": (
                                     "Response urgency. 'fast' (default) uses a smaller model for speed — "
                                     "prefer this for most live-call lookups. 'smart' uses a "

--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -368,7 +368,7 @@ class GptmeToolBridge:
             copies.append(copy)
         return copies
 
-    async def _run_subagent(self, task_id: str, task: str, mode: str = "smart") -> None:
+    async def _run_subagent(self, task_id: str, task: str, mode: str = "fast") -> None:
         """Run a subagent in the background and inject result when done."""
         pending = self._pending_tasks.get(task_id)
 
@@ -430,7 +430,7 @@ class GptmeToolBridge:
     async def _execute(
         self,
         task: str,
-        mode: str = "smart",
+        mode: str = "fast",
         on_started: Callable[[float], None] | None = None,
         on_progress: Callable[[str, float], None] | None = None,
         on_completed: Callable[[int, float], None] | None = None,
@@ -619,9 +619,9 @@ class GptmeToolBridge:
             if not task:
                 return {"error": "No task provided"}
 
-            mode = arguments.get("mode", "smart")
+            mode = arguments.get("mode", "fast")
             if mode not in ("fast", "smart"):
-                mode = "smart"
+                mode = "fast"
             model = self.model_fast if mode == "fast" else self.model_smart
 
             # Assign task ID and dispatch in background


### PR DESCRIPTION
Fix subagent default mode to Fast per Erik's feedback. Default mode is now fast instead of smart. Smart still available when explicitly requested.