### PR TITLE
[codex] fix(lessons): honor duplicate checks in evolution generator

### DIFF
--- a/packages/gptme-lessons-extras/src/gptme_lessons_extras/generate.py
+++ b/packages/gptme-lessons-extras/src/gptme_lessons_extras/generate.py
@@ -79,6 +79,48 @@ def save_lesson_draft(lesson_markdown: str, title: str, output_dir: Path) -> Pat
     return filepath
 
 
+def _prepare_existing_lesson_check(
+    check_existing: bool,
+    existing_lessons_dir: Path | None,
+) -> tuple[bool, Path | None]:
+    """Normalize existing-lesson duplicate-check configuration."""
+    if not check_existing:
+        return False, existing_lessons_dir
+
+    if existing_lessons_dir is None:
+        existing_lessons_dir = Path("lessons")
+
+    if not existing_lessons_dir.exists():
+        click.echo(
+            f"Warning: Existing lessons directory not found: {existing_lessons_dir}"
+        )
+        click.echo("Skipping duplicate check.")
+        return False, None
+
+    return True, existing_lessons_dir
+
+
+def _check_existing_lesson_similarity(
+    title: str,
+    context: str,
+    existing_lessons_dir: Path,
+    similarity_threshold: float,
+) -> list[dict]:
+    """Return similar existing lessons for a pending lesson draft."""
+    from .utils.similarity import check_against_existing_lessons
+
+    temp_lesson = {
+        "title": title,
+        "context": str(context or ""),
+        "filepath": Path("temp"),
+    }
+    return check_against_existing_lessons(
+        temp_lesson,
+        existing_lessons_dir,
+        threshold=similarity_threshold,
+    )
+
+
 def generate_lessons_with_evolution(
     analysis_file: Path,
     output_dir: Path,
@@ -135,6 +177,10 @@ def generate_lessons_with_evolution(
     if max_lessons:
         experiences = experiences[:max_lessons]
 
+    check_existing, existing_lessons_dir = _prepare_existing_lesson_check(
+        check_existing, existing_lessons_dir
+    )
+
     if verbose:
         print("\n📚 Generating lessons with GEPA-lite evolution")
         print(f"  Source: {analysis_file.name}")
@@ -151,8 +197,30 @@ def generate_lessons_with_evolution(
             print(f"Experience {i}/{len(experiences)}: {title}")
             print(f"{'=' * 60}")
 
-        # TODO: Add preliminary similarity check using check_against_existing_lessons()
-        # For now, let deduplication system handle similar lessons after generation
+        if check_existing and existing_lessons_dir is not None:
+            similar_lessons = _check_existing_lesson_similarity(
+                title=title,
+                context=moment.get("context", ""),
+                existing_lessons_dir=existing_lessons_dir,
+                similarity_threshold=similarity_threshold,
+            )
+
+            if similar_lessons:
+                top_match = similar_lessons[0]
+                similarity_pct = int(top_match["similarity"] * 100)
+                click.echo(
+                    f"    ⚠️  Similar lesson found ({similarity_pct}% match): {top_match['title']}"
+                )
+                click.echo(
+                    "       Location: "
+                    f"{top_match['filepath'].relative_to(existing_lessons_dir)}"
+                )
+
+                if skip_duplicates:
+                    click.echo("    ⏭️  Skipping (duplicate detection enabled)")
+                    continue
+
+                click.echo("    ⚠️  Generating anyway (--no-skip-duplicates)")
 
         # Run GEPA-lite evolution
         try:
@@ -261,17 +329,9 @@ def generate_lessons_from_analysis(
     if max_lessons is not None and len(high_confidence_moments) > max_lessons:
         high_confidence_moments = high_confidence_moments[:max_lessons]
 
-    # Set up existing lessons directory if checking is enabled
-    if check_existing:
-        if existing_lessons_dir is None:
-            existing_lessons_dir = Path("lessons")
-
-        if not existing_lessons_dir.exists():
-            click.echo(
-                f"Warning: Existing lessons directory not found: {existing_lessons_dir}"
-            )
-            click.echo("Skipping duplicate check.")
-            check_existing = False
+    check_existing, existing_lessons_dir = _prepare_existing_lesson_check(
+        check_existing, existing_lessons_dir
+    )
 
     click.echo(f"Generating {len(high_confidence_moments)} lessons using LLM Author...")
     if check_existing:
@@ -286,17 +346,11 @@ def generate_lessons_from_analysis(
 
         # Check against existing lessons if enabled
         if check_existing and existing_lessons_dir is not None:
-            from .utils.similarity import check_against_existing_lessons
-
-            # Create a temporary lesson info for similarity checking
-            temp_lesson = {
-                "title": title,
-                "context": moment.get("context", ""),
-                "filepath": Path("temp"),  # Dummy path for checking
-            }
-
-            similar_lessons = check_against_existing_lessons(
-                temp_lesson, existing_lessons_dir, threshold=similarity_threshold
+            similar_lessons = _check_existing_lesson_similarity(
+                title=title,
+                context=moment.get("context", ""),
+                existing_lessons_dir=existing_lessons_dir,
+                similarity_threshold=similarity_threshold,
             )
 
             if similar_lessons:

--- a/packages/gptme-lessons-extras/tests/test_generate.py
+++ b/packages/gptme-lessons-extras/tests/test_generate.py
@@ -1,0 +1,179 @@
+# ruff: noqa: E402
+
+import json
+import sys
+import types
+from pathlib import Path
+
+fake_gptme = types.ModuleType("gptme")
+fake_llm = types.ModuleType("gptme.llm")
+fake_message = types.ModuleType("gptme.message")
+
+
+def _unused_reply(*args, **kwargs):
+    raise NotImplementedError
+
+
+class _FakeMessage:
+    def __init__(self, role: str, content: str):
+        self.role = role
+        self.content = content
+
+
+fake_llm.reply = _unused_reply
+fake_message.Message = _FakeMessage
+fake_gptme.llm = fake_llm
+fake_gptme.message = fake_message
+
+sys.modules.setdefault("gptme", fake_gptme)
+sys.modules.setdefault("gptme.llm", fake_llm)
+sys.modules.setdefault("gptme.message", fake_message)
+
+from gptme_lessons_extras import generate
+
+
+def _write_analysis(path: Path, title: str, context: str) -> None:
+    analysis = {
+        "conversation_id": "conv-123",
+        "experiences": [
+            {
+                "title": title,
+                "context": context,
+                "confidence": 0.95,
+            }
+        ],
+    }
+    path.write_text(json.dumps(analysis), encoding="utf-8")
+
+
+def _write_existing_lesson(path: Path, title: str, context: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"""---
+status: active
+---
+# {title}
+
+## Context
+{context}
+""",
+        encoding="utf-8",
+    )
+
+
+def _fake_save_lesson_draft(lesson_markdown: str, title: str, output_dir: Path) -> Path:
+    path = output_dir / "patterns" / "generated.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(lesson_markdown, encoding="utf-8")
+    return path
+
+
+def test_generate_lessons_with_evolution_skips_similar_existing_lessons(
+    monkeypatch, tmp_path: Path
+) -> None:
+    analysis_file = tmp_path / "analysis.json"
+    lessons_dir = tmp_path / "lessons"
+    output_dir = tmp_path / "out"
+    title = "Avoid duplicate lessons"
+    context = "When the same lesson already exists, skip regeneration."
+
+    _write_analysis(analysis_file, title, context)
+    _write_existing_lesson(lessons_dir / "patterns" / "existing.md", title, context)
+
+    called = False
+
+    def fake_gepa_lite_evolve(**kwargs):
+        nonlocal called
+        called = True
+        return "", {"scores": {"quality": 1.0}}, []
+
+    monkeypatch.setattr(generate, "gepa_lite_evolve", fake_gepa_lite_evolve)
+
+    generated = generate.generate_lessons_with_evolution(
+        analysis_file=analysis_file,
+        output_dir=output_dir,
+        check_existing=True,
+        existing_lessons_dir=lessons_dir,
+        skip_duplicates=True,
+    )
+
+    assert generated == []
+    assert called is False
+
+
+def test_generate_lessons_with_evolution_generates_when_duplicates_allowed(
+    monkeypatch, tmp_path: Path
+) -> None:
+    analysis_file = tmp_path / "analysis.json"
+    lessons_dir = tmp_path / "lessons"
+    output_dir = tmp_path / "out"
+    title = "Avoid duplicate lessons"
+    context = "When the same lesson already exists, skip regeneration."
+
+    _write_analysis(analysis_file, title, context)
+    _write_existing_lesson(lessons_dir / "patterns" / "existing.md", title, context)
+
+    calls = {"count": 0}
+
+    def fake_gepa_lite_evolve(**kwargs):
+        calls["count"] += 1
+        return (
+            "---\nstatus: active\n---\n# Fresh lesson\n",
+            {"scores": {"quality": 1.0}},
+            [],
+        )
+
+    monkeypatch.setattr(generate, "gepa_lite_evolve", fake_gepa_lite_evolve)
+    monkeypatch.setattr(generate, "save_lesson_draft", _fake_save_lesson_draft)
+
+    generated = generate.generate_lessons_with_evolution(
+        analysis_file=analysis_file,
+        output_dir=output_dir,
+        check_existing=True,
+        existing_lessons_dir=lessons_dir,
+        skip_duplicates=False,
+    )
+
+    assert calls["count"] == 1
+    assert generated == [output_dir / "patterns" / "generated.md"]
+
+
+def test_generate_lessons_with_evolution_ignores_missing_existing_dir(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    analysis_file = tmp_path / "analysis.json"
+    missing_lessons_dir = tmp_path / "missing-lessons"
+    output_dir = tmp_path / "out"
+
+    _write_analysis(
+        analysis_file,
+        "Generate without existing lessons directory",
+        "Missing lesson directories should disable duplicate checks cleanly.",
+    )
+
+    calls = {"count": 0}
+
+    def fake_gepa_lite_evolve(**kwargs):
+        calls["count"] += 1
+        return (
+            "---\nstatus: active\n---\n# Fresh lesson\n",
+            {"scores": {"quality": 1.0}},
+            [],
+        )
+
+    monkeypatch.setattr(generate, "gepa_lite_evolve", fake_gepa_lite_evolve)
+    monkeypatch.setattr(generate, "save_lesson_draft", _fake_save_lesson_draft)
+
+    generated = generate.generate_lessons_with_evolution(
+        analysis_file=analysis_file,
+        output_dir=output_dir,
+        check_existing=True,
+        existing_lessons_dir=missing_lessons_dir,
+        skip_duplicates=True,
+    )
+
+    captured = capsys.readouterr()
+
+    assert "Skipping duplicate check." in captured.out
+    assert calls["count"] == 1
+    assert generated == [output_dir / "patterns" / "generated.md"]

--- a/packages/gptme-lessons-extras/tests/test_generate.py
+++ b/packages/gptme-lessons-extras/tests/test_generate.py
@@ -46,6 +46,22 @@ def _write_analysis(path: Path, title: str, context: str) -> None:
     path.write_text(json.dumps(analysis), encoding="utf-8")
 
 
+def _write_author_analysis(path: Path, title: str, context: str) -> None:
+    analysis = {
+        "conversation_id": "conv-123",
+        "metadata": {
+            "experiences": [
+                {
+                    "title": title,
+                    "context": context,
+                    "confidence": 0.95,
+                }
+            ]
+        },
+    }
+    path.write_text(json.dumps(analysis), encoding="utf-8")
+
+
 def _write_existing_lesson(path: Path, title: str, context: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
@@ -66,6 +82,10 @@ def _fake_save_lesson_draft(lesson_markdown: str, title: str, output_dir: Path) 
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(lesson_markdown, encoding="utf-8")
     return path
+
+
+def _fake_lesson_markdown(moment, conversation_id: str) -> str:
+    return "---\nstatus: active\n---\n# Fresh lesson\n"
 
 
 def test_generate_lessons_with_evolution_skips_similar_existing_lessons(
@@ -176,4 +196,69 @@ def test_generate_lessons_with_evolution_ignores_missing_existing_dir(
 
     assert "Skipping duplicate check." in captured.out
     assert calls["count"] == 1
+    assert generated == [output_dir / "patterns" / "generated.md"]
+
+
+def test_generate_lessons_from_analysis_skips_duplicate_check_when_disabled(
+    monkeypatch, tmp_path: Path
+) -> None:
+    analysis_file = tmp_path / "analysis.json"
+    output_dir = tmp_path / "out"
+    title = "Generate without duplicate checks"
+    context = "Disabled duplicate checks should bypass similarity lookups."
+
+    _write_author_analysis(analysis_file, title, context)
+
+    similarity_called = False
+
+    def fake_similarity(**kwargs):
+        nonlocal similarity_called
+        similarity_called = True
+        return []
+
+    monkeypatch.setattr(generate, "_check_existing_lesson_similarity", fake_similarity)
+    monkeypatch.setattr(generate, "llm_author_reflect", _fake_lesson_markdown)
+    monkeypatch.setattr(generate, "save_lesson_draft", _fake_save_lesson_draft)
+
+    generated = generate.generate_lessons_from_analysis(
+        analysis_file=analysis_file,
+        output_dir=output_dir,
+        check_existing=False,
+    )
+
+    assert similarity_called is False
+    assert generated == [output_dir / "patterns" / "generated.md"]
+
+
+def test_generate_lessons_from_analysis_uses_default_lessons_dir(
+    monkeypatch, tmp_path: Path
+) -> None:
+    analysis_file = tmp_path / "analysis.json"
+    output_dir = tmp_path / "out"
+    title = "Use default lessons directory"
+    context = "When no lessons dir is passed, the default lessons/ path should be used."
+    lessons_dir = tmp_path / "lessons"
+
+    _write_author_analysis(analysis_file, title, context)
+    lessons_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    seen = {}
+
+    def fake_similarity(**kwargs):
+        seen["existing_lessons_dir"] = kwargs["existing_lessons_dir"]
+        return []
+
+    monkeypatch.setattr(generate, "_check_existing_lesson_similarity", fake_similarity)
+    monkeypatch.setattr(generate, "llm_author_reflect", _fake_lesson_markdown)
+    monkeypatch.setattr(generate, "save_lesson_draft", _fake_save_lesson_draft)
+
+    generated = generate.generate_lessons_from_analysis(
+        analysis_file=analysis_file,
+        output_dir=output_dir,
+        check_existing=True,
+        existing_lessons_dir=None,
+    )
+
+    assert seen["existing_lessons_dir"].resolve() == lessons_dir.resolve()
     assert generated == [output_dir / "patterns" / "generated.md"]


### PR DESCRIPTION
## Summary
- honor `check_existing` / `skip_duplicates` in `generate_lessons_with_evolution()` before GEPA runs
- share existing-lesson duplicate-check setup between the single-shot and evolution generators
- add focused tests for skip, warn-and-generate, and missing-directory fallback paths

## Why
The `evolve` CLI already exposed duplicate-check flags, but the evolution generator ignored them and always burned LLM work even when a near-identical lesson already existed. This patch makes those flags real instead of decorative.

## Validation
- `PYTHONPATH=/tmp/worktrees/gptme-contrib-generate-similarity-5dbf/packages/gptme-lessons-extras/src uv run pytest /tmp/worktrees/gptme-contrib-generate-similarity-5dbf/packages/gptme-lessons-extras/tests/test_generate.py -q`
- `uv run ruff check /tmp/worktrees/gptme-contrib-generate-similarity-5dbf/packages/gptme-lessons-extras/src/gptme_lessons_extras/generate.py /tmp/worktrees/gptme-contrib-generate-similarity-5dbf/packages/gptme-lessons-extras/tests/test_generate.py`
- `uv run ruff format --check /tmp/worktrees/gptme-contrib-generate-similarity-5dbf/packages/gptme-lessons-extras/src/gptme_lessons_extras/generate.py /tmp/worktrees/gptme-contrib-generate-similarity-5dbf/packages/gptme-lessons-extras/tests/test_generate.py`
- `python3 -m py_compile /tmp/worktrees/gptme-contrib-generate-similarity-5dbf/packages/gptme-lessons-extras/src/gptme_lessons_extras/generate.py /tmp/worktrees/gptme-contrib-generate-similarity-5dbf/packages/gptme-lessons-extras/tests/test_generate.py`
- pre-commit via `git commit`
