### PR TITLE
fix(lessons): precheck GEPA duplicates

### DIFF
--- a/packages/gptme-lessons-extras/src/gptme_lessons_extras/generate.py
+++ b/packages/gptme-lessons-extras/src/gptme_lessons_extras/generate.py
@@ -135,6 +135,19 @@ def generate_lessons_with_evolution(
     if max_lessons:
         experiences = experiences[:max_lessons]
 
+    # Set up existing lessons directory if checking is enabled
+    if check_existing:
+        if existing_lessons_dir is None:
+            existing_lessons_dir = Path("lessons")
+
+        if not existing_lessons_dir.exists():
+            if verbose:
+                print(
+                    f"  Warning: Existing lessons directory not found: {existing_lessons_dir}"
+                )
+                print("  Skipping duplicate check.")
+            check_existing = False
+
     if verbose:
         print("\n📚 Generating lessons with GEPA-lite evolution")
         print(f"  Source: {analysis_file.name}")
@@ -151,8 +164,35 @@ def generate_lessons_with_evolution(
             print(f"Experience {i}/{len(experiences)}: {title}")
             print(f"{'=' * 60}")
 
-        # TODO: Add preliminary similarity check using check_against_existing_lessons()
-        # For now, let deduplication system handle similar lessons after generation
+        if check_existing and existing_lessons_dir is not None:
+            from .utils.similarity import check_against_existing_lessons
+
+            temp_lesson = {
+                "title": title,
+                "context": moment.get("context", ""),
+                "filepath": Path("temp"),
+            }
+            similar_lessons = check_against_existing_lessons(
+                temp_lesson, existing_lessons_dir, threshold=similarity_threshold
+            )
+            if similar_lessons:
+                top_match = similar_lessons[0]
+                similarity_pct = int(top_match["similarity"] * 100)
+                if verbose:
+                    print(
+                        f"  ⚠️  Similar lesson found ({similarity_pct}% match): {top_match['title']}"
+                    )
+                    print(
+                        "     Location: "
+                        f"{top_match['filepath'].relative_to(existing_lessons_dir)}"
+                    )
+
+                if skip_duplicates:
+                    if verbose:
+                        print("  ⏭️  Skipping (duplicate detection enabled)")
+                    continue
+                elif verbose:
+                    print("  ⚠️  Generating anyway (--no-skip-duplicates)")
 
         # Run GEPA-lite evolution
         try:

--- a/packages/gptme-lessons-extras/src/gptme_lessons_extras/generate.py
+++ b/packages/gptme-lessons-extras/src/gptme_lessons_extras/generate.py
@@ -79,6 +79,14 @@ def save_lesson_draft(lesson_markdown: str, title: str, output_dir: Path) -> Pat
     return filepath
 
 
+def _format_lesson_location(filepath: Path, lessons_dir: Path) -> str:
+    """Format a lesson path relative to the lessons dir when possible."""
+    try:
+        return str(filepath.relative_to(lessons_dir))
+    except ValueError:
+        return str(filepath)
+
+
 def generate_lessons_with_evolution(
     analysis_file: Path,
     output_dir: Path,
@@ -141,11 +149,10 @@ def generate_lessons_with_evolution(
             existing_lessons_dir = Path("lessons")
 
         if not existing_lessons_dir.exists():
-            if verbose:
-                print(
-                    f"  Warning: Existing lessons directory not found: {existing_lessons_dir}"
-                )
-                print("  Skipping duplicate check.")
+            click.echo(
+                f"  Warning: Existing lessons directory not found: {existing_lessons_dir}"
+            )
+            click.echo("  Skipping duplicate check.")
             check_existing = False
 
     if verbose:
@@ -178,21 +185,18 @@ def generate_lessons_with_evolution(
             if similar_lessons:
                 top_match = similar_lessons[0]
                 similarity_pct = int(top_match["similarity"] * 100)
-                if verbose:
-                    print(
-                        f"  ⚠️  Similar lesson found ({similarity_pct}% match): {top_match['title']}"
-                    )
-                    print(
-                        "     Location: "
-                        f"{top_match['filepath'].relative_to(existing_lessons_dir)}"
-                    )
+                click.echo(
+                    f"  ⚠️  Similar lesson found ({similarity_pct}% match): {top_match['title']}"
+                )
+                click.echo(
+                    "     Location: "
+                    f"{_format_lesson_location(top_match['filepath'], existing_lessons_dir)}"
+                )
 
                 if skip_duplicates:
-                    if verbose:
-                        print("  ⏭️  Skipping (duplicate detection enabled)")
+                    click.echo("  ⏭️  Skipping (duplicate detection enabled)")
                     continue
-                elif verbose:
-                    print("  ⚠️  Generating anyway (--no-skip-duplicates)")
+                click.echo("  ⚠️  Generating anyway (--no-skip-duplicates)")
 
         # Run GEPA-lite evolution
         try:
@@ -346,7 +350,8 @@ def generate_lessons_from_analysis(
                     f"    ⚠️  Similar lesson found ({similarity_pct}% match): {top_match['title']}"
                 )
                 click.echo(
-                    f"       Location: {top_match['filepath'].relative_to(existing_lessons_dir)}"
+                    "       Location: "
+                    f"{_format_lesson_location(top_match['filepath'], existing_lessons_dir)}"
                 )
 
                 if skip_duplicates:

--- a/packages/gptme-lessons-extras/tests/test_generate.py
+++ b/packages/gptme-lessons-extras/tests/test_generate.py
@@ -1,0 +1,115 @@
+"""Tests for lesson generation duplicate pre-checks."""
+
+import json
+from pathlib import Path
+
+from gptme_lessons_extras.generate import generate_lessons_with_evolution
+
+
+def _write_analysis(path: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "conversation_id": "conv-123",
+                "experiences": [
+                    {
+                        "title": "Duplicate-prone lesson",
+                        "context": "Repeated mistake context",
+                        "confidence": 0.9,
+                    }
+                ],
+            }
+        )
+    )
+
+
+def test_generate_lessons_with_evolution_skips_duplicates(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Duplicate pre-check should stop GEPA generation when skipping is enabled."""
+    analysis_file = tmp_path / "analysis.json"
+    _write_analysis(analysis_file)
+    existing_lessons_dir = tmp_path / "lessons"
+    existing_lessons_dir.mkdir()
+
+    def fail_if_called(**_kwargs):
+        raise AssertionError("GEPA should not run when duplicate pre-check skips")
+
+    monkeypatch.setattr(
+        "gptme_lessons_extras.generate.gepa_lite_evolve",
+        fail_if_called,
+    )
+    monkeypatch.setattr(
+        "gptme_lessons_extras.utils.similarity.check_against_existing_lessons",
+        lambda *_args, **_kwargs: [
+            {
+                "title": "Existing duplicate",
+                "filepath": existing_lessons_dir / "patterns" / "existing.md",
+                "similarity": 0.91,
+            }
+        ],
+    )
+
+    generated = generate_lessons_with_evolution(
+        analysis_file=analysis_file,
+        output_dir=tmp_path / "output",
+        existing_lessons_dir=existing_lessons_dir,
+        verbose=False,
+    )
+
+    assert generated == []
+
+
+def test_generate_lessons_with_evolution_warns_only_when_duplicates_allowed(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Warn-only mode should still run GEPA and save the generated lesson."""
+    analysis_file = tmp_path / "analysis.json"
+    _write_analysis(analysis_file)
+    existing_lessons_dir = tmp_path / "lessons"
+    existing_lessons_dir.mkdir()
+    output_dir = tmp_path / "output"
+
+    monkeypatch.setattr(
+        "gptme_lessons_extras.generate.gepa_lite_evolve",
+        lambda **_kwargs: (
+            "generated lesson markdown",
+            {"scores": {"quality": 0.9, "specificity": 0.9}},
+            [],
+        ),
+    )
+    monkeypatch.setattr(
+        "gptme_lessons_extras.generate.save_lesson_draft",
+        lambda lesson_markdown, _title, output_dir: _write_generated_file(
+            output_dir, lesson_markdown
+        ),
+    )
+    monkeypatch.setattr(
+        "gptme_lessons_extras.utils.similarity.check_against_existing_lessons",
+        lambda *_args, **_kwargs: [
+            {
+                "title": "Existing duplicate",
+                "filepath": existing_lessons_dir / "patterns" / "existing.md",
+                "similarity": 0.91,
+            }
+        ],
+    )
+
+    generated = generate_lessons_with_evolution(
+        analysis_file=analysis_file,
+        output_dir=output_dir,
+        existing_lessons_dir=existing_lessons_dir,
+        skip_duplicates=False,
+        verbose=False,
+    )
+
+    assert len(generated) == 1
+    assert generated[0].exists()
+    assert generated[0].read_text() == "generated lesson markdown"
+
+
+def _write_generated_file(output_dir: Path, lesson_markdown: str) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    filepath = output_dir / "generated.md"
+    filepath.write_text(lesson_markdown)
+    return filepath

--- a/packages/gptme-lessons-extras/tests/test_generate.py
+++ b/packages/gptme-lessons-extras/tests/test_generate.py
@@ -61,7 +61,7 @@ def test_generate_lessons_with_evolution_skips_duplicates(
 
 
 def test_generate_lessons_with_evolution_warns_only_when_duplicates_allowed(
-    tmp_path: Path, monkeypatch
+    tmp_path: Path, monkeypatch, capsys
 ) -> None:
     """Warn-only mode should still run GEPA and save the generated lesson."""
     analysis_file = tmp_path / "analysis.json"
@@ -106,6 +106,99 @@ def test_generate_lessons_with_evolution_warns_only_when_duplicates_allowed(
     assert len(generated) == 1
     assert generated[0].exists()
     assert generated[0].read_text() == "generated lesson markdown"
+    captured = capsys.readouterr()
+    assert "Similar lesson found (91% match): Existing duplicate" in captured.out
+    assert "Location: patterns/existing.md" in captured.out
+    assert "Generating anyway (--no-skip-duplicates)" in captured.out
+
+
+def test_generate_lessons_with_evolution_warns_when_lessons_dir_missing(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """Missing lessons dir should warn even without verbose output."""
+    analysis_file = tmp_path / "analysis.json"
+    _write_analysis(analysis_file)
+    missing_lessons_dir = tmp_path / "missing-lessons"
+    output_dir = tmp_path / "output"
+
+    monkeypatch.setattr(
+        "gptme_lessons_extras.generate.gepa_lite_evolve",
+        lambda **_kwargs: (
+            "generated lesson markdown",
+            {"scores": {"quality": 0.9, "specificity": 0.9}},
+            [],
+        ),
+    )
+    monkeypatch.setattr(
+        "gptme_lessons_extras.generate.save_lesson_draft",
+        lambda lesson_markdown, _title, output_dir: _write_generated_file(
+            output_dir, lesson_markdown
+        ),
+    )
+
+    generated = generate_lessons_with_evolution(
+        analysis_file=analysis_file,
+        output_dir=output_dir,
+        existing_lessons_dir=missing_lessons_dir,
+        verbose=False,
+    )
+
+    assert len(generated) == 1
+    captured = capsys.readouterr()
+    assert (
+        f"Warning: Existing lessons directory not found: {missing_lessons_dir}"
+        in captured.out
+    )
+    assert "Skipping duplicate check." in captured.out
+
+
+def test_generate_lessons_with_evolution_handles_non_relative_match_location(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """Duplicate reporting should not crash on out-of-tree match paths."""
+    analysis_file = tmp_path / "analysis.json"
+    _write_analysis(analysis_file)
+    existing_lessons_dir = tmp_path / "lessons"
+    existing_lessons_dir.mkdir()
+    external_match = tmp_path / "other-root" / "existing.md"
+    output_dir = tmp_path / "output"
+
+    monkeypatch.setattr(
+        "gptme_lessons_extras.generate.gepa_lite_evolve",
+        lambda **_kwargs: (
+            "generated lesson markdown",
+            {"scores": {"quality": 0.9, "specificity": 0.9}},
+            [],
+        ),
+    )
+    monkeypatch.setattr(
+        "gptme_lessons_extras.generate.save_lesson_draft",
+        lambda lesson_markdown, _title, output_dir: _write_generated_file(
+            output_dir, lesson_markdown
+        ),
+    )
+    monkeypatch.setattr(
+        "gptme_lessons_extras.utils.similarity.check_against_existing_lessons",
+        lambda *_args, **_kwargs: [
+            {
+                "title": "External duplicate",
+                "filepath": external_match,
+                "similarity": 0.91,
+            }
+        ],
+    )
+
+    generated = generate_lessons_with_evolution(
+        analysis_file=analysis_file,
+        output_dir=output_dir,
+        existing_lessons_dir=existing_lessons_dir,
+        skip_duplicates=False,
+        verbose=False,
+    )
+
+    assert len(generated) == 1
+    captured = capsys.readouterr()
+    assert f"Location: {external_match}" in captured.out
 
 
 def _write_generated_file(output_dir: Path, lesson_markdown: str) -> Path:


### PR DESCRIPTION
## Summary
- honor existing duplicate-check flags in  before running GEPA
- skip GEPA work when a similar lesson is found and duplicate skipping is enabled
- add regression tests for skip-vs-warn duplicate behavior

## Testing
- ..                                                                       [100%]
2 passed in 0.35s
- All checks passed!
