### PR TITLE
fix(voice): block fake live lookup narration

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
@@ -130,8 +130,13 @@ def _load_project_instructions(workspace: str | None = None) -> str:
         "- Use the subagent tool ONLY for small, specific lookups: a single task status, "
         "a recent journal entry, a quick file check. One focused question per call.\n"
         "- If you need a live lookup, you may say one short acknowledgement before "
-        "calling subagent (for example: 'One moment, checking that.'). After dispatch, "
-        "wait for the actual subagent result instead of narrating progress or guessing.\n"
+        "calling subagent (for example: 'One moment, checking that.'). That "
+        "acknowledgement is only allowed when you call the subagent tool in the same "
+        "turn. After dispatch, wait for the actual subagent result instead of "
+        "narrating progress or guessing.\n"
+        "- Do NOT say you are checking, looking it up, or using the subagent unless "
+        "you call the subagent tool in the same turn. If you are not calling the tool, "
+        "answer from current context or say you cannot verify it live yet.\n"
         "- Do NOT dispatch broad investigation tasks (e.g. 'investigate the whole system', "
         "'run a full review') — these always time out and leave the call hanging.\n"
         "- NEVER use the subagent tool to run post-call analysis, summarise the session, "
@@ -393,8 +398,9 @@ class OpenAIRealtimeClient:
                         "one recent fact. Do not use it for broad investigations, full "
                         "reviews, or post-call analysis. Say at most one brief "
                         "acknowledgement before calling it, then wait for the real "
-                        "subagent result instead of answering early. Describe one "
-                        "concrete request in natural language."
+                        "subagent result instead of answering early. Never narrate "
+                        "or promise a lookup without actually emitting the tool "
+                        "call. Describe one concrete request in natural language."
                     ),
                     "parameters": {
                         "type": "object",

--- a/packages/gptme-voice/tests/test_openai_client.py
+++ b/packages/gptme-voice/tests/test_openai_client.py
@@ -101,6 +101,7 @@ def test_connect_exposes_subagent_tool_as_focused_lookup_only() -> None:
         assert "broad investigations" in description
         assert "post-call analysis" in description
         assert "wait for the real subagent result" in description
+        assert "promise a lookup without actually emitting the tool call" in description
         assert fake_ws.closed is True
 
     asyncio.run(_exercise())
@@ -289,6 +290,28 @@ def test_load_project_instructions_includes_post_call_follow_up_guard(
 
     # Acknowledging automatic post-call follow-up is still allowed.
     assert "happen automatically after" in instructions
+
+
+def test_load_project_instructions_blocks_fake_live_lookup_narration(
+    tmp_path: Path,
+) -> None:
+    """Live-call prompt must forbid fake 'I'm checking' narration without a tool call."""
+    (tmp_path / "gptme.toml").write_text(
+        '[prompt]\nfiles = ["ABOUT.md"]\n',
+    )
+    (tmp_path / "ABOUT.md").write_text("# ABOUT\nYou are Bob.\n")
+
+    instructions = _load_project_instructions(str(tmp_path))
+
+    assert "call the subagent tool in the same turn" in instructions
+    assert (
+        "Do NOT say you are checking, looking it up, or using the subagent"
+        in instructions
+    )
+    assert (
+        "answer from current context or say you cannot verify it live yet"
+        in instructions
+    )
 
 
 def test_send_audio_buffers_until_session_created() -> None:

--- a/packages/gptme-voice/tests/test_tool_bridge.py
+++ b/packages/gptme-voice/tests/test_tool_bridge.py
@@ -309,9 +309,7 @@ def test_execute_passes_bounded_transcript_tail_to_wrapper() -> None:
         assert "--transcript-tail-turns" in args
         assert captured["tail_turns"] == "3"
         assert captured["tail_text"] == (
-            "Assistant: first answer\n"
-            "User: second question\n"
-            "Assistant: second answer"
+            "Assistant: first answer\nUser: second question\nAssistant: second answer"
         )
 
     asyncio.run(_exercise())
@@ -658,6 +656,43 @@ def test_subagent_status_lists_pending_dispatch() -> None:
             assert "spawn_to_first_output_seconds" not in entry["timings"]
 
             # Clean up the background task
+            await bridge.handle_function_call("subagent_cancel", {"task_id": task_id})
+
+    asyncio.run(_exercise())
+
+
+def test_subagent_dispatch_defaults_to_fast_mode() -> None:
+    """Missing mode should still dispatch on the fast live-call path."""
+
+    async def _exercise() -> None:
+        class _SlowProcess(_FakeProcess):
+            async def wait(self) -> int:
+                await asyncio.sleep(5)
+                return 0
+
+        async def _fake_create_subprocess_exec(*_args, **_kwargs):
+            return _SlowProcess(returncode=0)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+            bridge = GptmeToolBridge(workspace="/fake/workspace", timeout=10)
+
+            dispatch = await bridge.handle_function_call(
+                "subagent", {"task": "check one thing"}
+            )
+            assert dispatch["status"] == "dispatched"
+            task_id = dispatch["task_id"]
+
+            await asyncio.sleep(0)
+
+            status = await bridge.handle_function_call("subagent_status", {})
+            assert status["status"] == "ok"
+            assert status["pending_count"] == 1
+            entry = status["pending"][0]
+            assert entry["task_id"] == task_id
+            assert entry["mode"] == "fast"
+            assert entry["model"] == bridge.model_fast
+
             await bridge.handle_function_call("subagent_cancel", {"task_id": task_id})
 
     asyncio.run(_exercise())


### PR DESCRIPTION
## Summary
- harden the live-call subagent instructions so "I'm checking" language is only allowed with a same-turn tool call
- mirror that constraint in the subagent tool description sent to the realtime provider
- add regressions for the no-fake-lookup prompt guard and default-fast subagent dispatch

## Why
A 2026-05-19 Grok voice call showed Bob saying he would check logs with the subagent, but the server logs contained no `Function call: subagent(...)` event and the archived call contained no `subagent_timings`. The bug was not the fast/smart default; it was that the provider narrated a lookup without actually calling the tool.

## Testing
- `uv run pytest -q /home/bob/bob/gptme-contrib/packages/gptme-voice/tests/test_openai_client.py /home/bob/bob/gptme-contrib/packages/gptme-voice/tests/test_tool_bridge.py`
- `uv run ruff check /home/bob/bob/gptme-contrib/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py /home/bob/bob/gptme-contrib/packages/gptme-voice/tests/test_openai_client.py /home/bob/bob/gptme-contrib/packages/gptme-voice/tests/test_tool_bridge.py`
- `uv run ruff format --check /home/bob/bob/gptme-contrib/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py /home/bob/bob/gptme-contrib/packages/gptme-voice/tests/test_openai_client.py /home/bob/bob/gptme-contrib/packages/gptme-voice/tests/test_tool_bridge.py`