### PR TITLE
fix(lessons): retarget 2 shared lessons from harm to trajectory_grade

### DIFF
--- a/lessons/autonomous/pre-mortem-for-risky-actions.md
+++ b/lessons/autonomous/pre-mortem-for-risky-actions.md
@@ -12,7 +12,7 @@ match:
   - "DROP TABLE"
   - "production change"
   session_categories: [code, infrastructure, cleanup]
-target_grade: harm
+target_grade: trajectory_grade
 status: active
 ---
 

--- a/lessons/infrastructure/trajectory-persistence.md
+++ b/lessons/infrastructure/trajectory-persistence.md
@@ -10,7 +10,7 @@ match:
     - "log cleanup"
     - "retention policy"
   session_categories: [infrastructure, cleanup]
-target_grade: harm
+target_grade: trajectory_grade
 status: active
 confound_note: "cleanup-selection-bias — LOO-negative because it fires in inherently higher-harm cleanup contexts, not because it causes harm"
 ---


### PR DESCRIPTION
## Summary

Retargets 2 shared lessons from target_grade: harm to target_grade: trajectory_grade. Followup to bob-workspace change c28dc3e2c7 (46 local lessons).

LOO bandit state has zero harm reward data — lessons targeted at harm are evaluated against trajectory_grade fallback anyway, making harm-targeting unevaluable.

Changed:
- lessons/autonomous/pre-mortem-for-risky-actions.md
- lessons/infrastructure/trajectory-persistence.md

## Test plan
- prek run --all-files passes (lesson validator)
- Both files have target_grade: trajectory_grade