### PR TITLE
fix(lessons): retarget 2 shared lessons from trajectory_grade to alignment

### DIFF
--- a/lessons/autonomous/pre-mortem-for-risky-actions.md
+++ b/lessons/autonomous/pre-mortem-for-risky-actions.md
@@ -12,7 +12,7 @@ match:
   - "DROP TABLE"
   - "production change"
   session_categories: [code, infrastructure, cleanup]
-target_grade: trajectory_grade
+target_grade: alignment
 status: active
 ---
 

--- a/lessons/infrastructure/trajectory-persistence.md
+++ b/lessons/infrastructure/trajectory-persistence.md
@@ -10,7 +10,7 @@ match:
     - "log cleanup"
     - "retention policy"
   session_categories: [infrastructure, cleanup]
-target_grade: trajectory_grade
+target_grade: alignment
 status: active
 confound_note: "cleanup-selection-bias — LOO-negative because it fires in inherently higher-harm cleanup contexts, not because it causes harm"
 ---


### PR DESCRIPTION
## What

Follow-up on #939. Erik's feedback:

> @TimeToBuildBob Feels like you took the easy way out here. Fix the system fully. `trajectory_grade` is a pretty bad name for the type of eval/scoring. Isn't it just `productivity` or `alignment` together somehow?

These two lessons are clearly **alignment** (not productivity or the catch-all trajectory_grade):

- **pre-mortem-for-risky-actions.md**: Preventing destructive ops and data loss is about respecting user trust and operational safety → `alignment`
- **trajectory-persistence.md**: Not overriding user-configured retention settings is about alignment with user intent → `alignment`

## Verification
- `alignment` is in `VALID_TARGET_GRADE_FIELDS`: productivity, alignment, harm, trajectory_grade
- Pre-commit passed (prek)
- Each file changed exactly one frontmatter field

Closes the deeper issue Erik identified: assigning lessons to the trajectory_grade aggregate when they map to a specific dimension.

Ref: https://github.com/gptme/gptme-contrib/pull/939#issuecomment-4496879394