### PR TITLE
feat(sessions): add deliverable provenance sidecar

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -94,6 +94,9 @@ def _apply_extract_result_to_record(record: SessionRecord, result: dict) -> bool
         record, "duration_seconds", int(result.get("session_duration_s") or 0)
     )
     changed |= _assign_if_missing(record, "deliverables", result.get("deliverables", []))
+    changed |= _assign_if_missing(
+        record, "deliverable_details", result.get("deliverable_details", [])
+    )
     changed |= _assign_if_missing(record, "category", result.get("inferred_category"))
 
     usage = result.get("usage")
@@ -109,6 +112,7 @@ def _apply_extract_result_to_kwargs(record_kwargs: dict, result: dict) -> None:
     record_kwargs["outcome"] = "productive" if result.get("productive") else "noop"
     record_kwargs["duration_seconds"] = int(result.get("session_duration_s") or 0)
     record_kwargs["deliverables"] = result.get("deliverables", [])
+    record_kwargs["deliverable_details"] = result.get("deliverable_details", [])
     if result.get("inferred_category"):
         record_kwargs["category"] = result["inferred_category"]
 

--- a/packages/gptme-sessions/src/gptme_sessions/deliverables.py
+++ b/packages/gptme-sessions/src/gptme_sessions/deliverables.py
@@ -1,0 +1,65 @@
+"""Helpers for structured deliverable provenance records."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def looks_like_sha(value: str) -> bool:
+    """Return True for bare SHA-like hex strings used as deliverables."""
+    lowered = value.lower().strip()
+    return 7 <= len(lowered) <= 40 and all(c in "0123456789abcdef" for c in lowered)
+
+
+def deliverable_kind(value: str) -> str:
+    """Infer the deliverable kind for file, commit, and PR-style values."""
+    stripped = value.strip()
+    if stripped.startswith("merge-commit (") and stripped.endswith(")"):
+        return "merge_commit"
+    if stripped.startswith("merge PR #") or stripped.startswith("PR #") or "/pull/" in stripped:
+        return "pull_request"
+    if looks_like_sha(stripped):
+        return "commit"
+    if stripped.endswith(")") and "(" in stripped:
+        candidate = stripped[stripped.rfind("(") + 1 : -1]
+        if looks_like_sha(candidate):
+            return "commit"
+    return "file"
+
+
+def build_deliverable_detail(
+    value: str,
+    *,
+    provenance_class: str,
+    evidence: Mapping[str, Any],
+    kind: str | None = None,
+) -> dict[str, Any]:
+    """Build one structured deliverable detail entry."""
+    compact_evidence = {
+        key: val for key, val in evidence.items() if val not in (None, "", [], {}, ())
+    }
+    return {
+        "value": value,
+        "kind": kind or deliverable_kind(value),
+        "provenance_class": provenance_class,
+        "evidence": compact_evidence,
+    }
+
+
+def project_deliverable_details(
+    deliverables: list[str],
+    detail_by_value: Mapping[str, dict[str, Any]],
+    *,
+    fallback_evidence: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    """Return one detail per deliverable in legacy order, gap-filling when needed."""
+    return [
+        detail_by_value.get(value)
+        or build_deliverable_detail(
+            value,
+            provenance_class="fallback_observed",
+            evidence=fallback_evidence,
+        )
+        for value in deliverables
+    ]

--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -34,6 +35,13 @@ from .signals import extract_from_path
 from .store import SessionStore
 
 logger = logging.getLogger(__name__)
+_FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def _looks_like_sha(value: str) -> bool:
+    """Return True for bare SHA-like hex strings used as deliverables."""
+    lowered = value.lower().strip()
+    return 7 <= len(lowered) <= 40 and all(c in "0123456789abcdef" for c in lowered)
 
 
 def _extract_traj_sha_prefixes(traj_deliverables: list[str]) -> set[str]:
@@ -58,6 +66,92 @@ def _caller_sha_in_traj(sha: str, traj_sha_prefixes: set[str]) -> bool:
     """Return True if a full 40-char SHA from the caller appears in trajectory commits."""
     sha_lower = sha.lower().strip()
     return any(sha_lower.startswith(prefix) for prefix in traj_sha_prefixes)
+
+
+def _deliverable_kind(value: str) -> str:
+    """Infer the deliverable kind for caller-supplied fallback values."""
+    stripped = value.strip()
+    lowered = stripped.lower()
+    if stripped.startswith("merge-commit (") and stripped.endswith(")"):
+        return "merge_commit"
+    if stripped.startswith("merge PR #") or stripped.startswith("PR #") or "/pull/" in stripped:
+        return "pull_request"
+    if _FULL_SHA_RE.fullmatch(lowered) or _looks_like_sha(stripped):
+        return "commit"
+    if stripped.endswith(")") and "(" in stripped:
+        candidate = stripped[stripped.rfind("(") + 1 : -1].lower()
+        if 7 <= len(candidate) <= 40 and all(c in "0123456789abcdef" for c in candidate):
+            return "commit"
+    return "file"
+
+
+def _build_deliverable_detail(
+    value: str,
+    *,
+    provenance_class: str,
+    evidence: dict[str, Any],
+) -> dict[str, Any]:
+    """Build one structured deliverable detail entry."""
+    compact_evidence = {
+        key: val for key, val in evidence.items() if val not in (None, "", [], {}, ())
+    }
+    return {
+        "value": value,
+        "kind": _deliverable_kind(value),
+        "provenance_class": provenance_class,
+        "evidence": compact_evidence,
+    }
+
+
+def _build_caller_deliverable_details(
+    values: list[str],
+    *,
+    provenance_class: str,
+    evidence: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Build caller-side deliverable details in stable first-seen order."""
+    details: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for value in values:
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        details.append(
+            _build_deliverable_detail(
+                value,
+                provenance_class=provenance_class,
+                evidence=evidence,
+            )
+        )
+    return details
+
+
+def _merge_deliverable_details(
+    *,
+    deliverables: list[str],
+    trajectory_details: list[dict[str, Any]],
+    extra_details: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Project trajectory + caller details into the final deliverable order."""
+    detail_by_value: dict[str, dict[str, Any]] = {}
+    for raw in trajectory_details + extra_details:
+        if not isinstance(raw, dict):
+            continue
+        value = raw.get("value")
+        if not isinstance(value, str) or not value or value in detail_by_value:
+            continue
+        detail_by_value[value] = raw
+
+    merged: list[dict[str, Any]] = []
+    for value in deliverables:
+        if value not in detail_by_value:
+            detail_by_value[value] = _build_deliverable_detail(
+                value,
+                provenance_class="fallback_observed",
+                evidence={"source": "projection_fallback"},
+            )
+        merged.append(detail_by_value[value])
+    return merged
 
 
 #: Default path for grading weights config (Phase 3 multivariate grading).
@@ -347,6 +441,8 @@ def post_session(
     # override below (no-trajectory fallback) sees only pre-trajectory items.
     caller_deliverables: list[str] = list(deliverables) if deliverables else []
     traj_deliverables = signals.get("deliverables", []) if signals else []
+    traj_deliverable_details = signals.get("deliverable_details", []) if signals else []
+    extra_deliverable_details: list[dict[str, Any]] = []
 
     if not deliverables:
         # No caller deliverables: use trajectory exclusively.
@@ -371,11 +467,21 @@ def post_session(
                         unvalidated[:5],
                     )
                 deliverables = list(dict.fromkeys(traj_deliverables + validated))
+                extra_deliverable_details = _build_caller_deliverable_details(
+                    validated,
+                    provenance_class="session_committed",
+                    evidence={"source": "caller", "validation": "trajectory_sha_prefix"},
+                )
             else:
                 # Trajectory has no SHAs (file paths only) — can't validate
                 # caller SHAs.  Keep both sets, caller items first to preserve
                 # the pre-existing deliverable ordering convention.
                 deliverables = list(dict.fromkeys(caller_deliverables + traj_deliverables))
+                extra_deliverable_details = _build_caller_deliverable_details(
+                    caller_deliverables,
+                    provenance_class="fallback_observed",
+                    evidence={"source": "caller", "reason": "trajectory_has_no_sha"},
+                )
         else:
             # Trajectory ran but found no deliverables.
             if traj_productive is False:
@@ -398,7 +504,26 @@ def post_session(
                         len(caller_deliverables),
                     )
                 deliverables = list(dict.fromkeys(caller_deliverables))
+                extra_deliverable_details = _build_caller_deliverable_details(
+                    caller_deliverables,
+                    provenance_class="fallback_observed",
+                    evidence={"source": "caller", "reason": "trajectory_empty"},
+                )
     # else: no trajectory (signals is None) — keep caller git-range as fallback.
+    elif caller_deliverables:
+        extra_deliverable_details = _build_caller_deliverable_details(
+            caller_deliverables,
+            provenance_class="fallback_observed",
+            evidence={"source": "caller", "reason": "no_trajectory"},
+        )
+
+    deliverable_details = _merge_deliverable_details(
+        deliverables=deliverables,
+        trajectory_details=traj_deliverable_details
+        if isinstance(traj_deliverable_details, list)
+        else [],
+        extra_details=extra_deliverable_details,
+    )
 
     # --- Determine outcome ---
     # Priority order (highest → lowest):
@@ -471,6 +596,7 @@ def post_session(
         "start_time": start_time_str,
         "end_time": end_time_str,
         "deliverables": deliverables,
+        "deliverable_details": deliverable_details,
     }
     if context_tier is not None:
         record_kwargs["context_tier"] = context_tier

--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -24,24 +24,17 @@ from __future__ import annotations
 import json
 import logging
 import os
-import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from .deliverables import build_deliverable_detail, project_deliverable_details
 from .discovery import extract_project, extract_session_name
 from .record import SessionRecord
 from .signals import extract_from_path
 from .store import SessionStore
 
 logger = logging.getLogger(__name__)
-_FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
-
-
-def _looks_like_sha(value: str) -> bool:
-    """Return True for bare SHA-like hex strings used as deliverables."""
-    lowered = value.lower().strip()
-    return 7 <= len(lowered) <= 40 and all(c in "0123456789abcdef" for c in lowered)
 
 
 def _extract_traj_sha_prefixes(traj_deliverables: list[str]) -> set[str]:
@@ -68,41 +61,6 @@ def _caller_sha_in_traj(sha: str, traj_sha_prefixes: set[str]) -> bool:
     return any(sha_lower.startswith(prefix) for prefix in traj_sha_prefixes)
 
 
-def _deliverable_kind(value: str) -> str:
-    """Infer the deliverable kind for caller-supplied fallback values."""
-    stripped = value.strip()
-    lowered = stripped.lower()
-    if stripped.startswith("merge-commit (") and stripped.endswith(")"):
-        return "merge_commit"
-    if stripped.startswith("merge PR #") or stripped.startswith("PR #") or "/pull/" in stripped:
-        return "pull_request"
-    if _FULL_SHA_RE.fullmatch(lowered) or _looks_like_sha(stripped):
-        return "commit"
-    if stripped.endswith(")") and "(" in stripped:
-        candidate = stripped[stripped.rfind("(") + 1 : -1].lower()
-        if 7 <= len(candidate) <= 40 and all(c in "0123456789abcdef" for c in candidate):
-            return "commit"
-    return "file"
-
-
-def _build_deliverable_detail(
-    value: str,
-    *,
-    provenance_class: str,
-    evidence: dict[str, Any],
-) -> dict[str, Any]:
-    """Build one structured deliverable detail entry."""
-    compact_evidence = {
-        key: val for key, val in evidence.items() if val not in (None, "", [], {}, ())
-    }
-    return {
-        "value": value,
-        "kind": _deliverable_kind(value),
-        "provenance_class": provenance_class,
-        "evidence": compact_evidence,
-    }
-
-
 def _build_caller_deliverable_details(
     values: list[str],
     *,
@@ -117,7 +75,7 @@ def _build_caller_deliverable_details(
             continue
         seen.add(value)
         details.append(
-            _build_deliverable_detail(
+            build_deliverable_detail(
                 value,
                 provenance_class=provenance_class,
                 evidence=evidence,
@@ -142,16 +100,11 @@ def _merge_deliverable_details(
             continue
         detail_by_value[value] = raw
 
-    merged: list[dict[str, Any]] = []
-    for value in deliverables:
-        if value not in detail_by_value:
-            detail_by_value[value] = _build_deliverable_detail(
-                value,
-                provenance_class="fallback_observed",
-                evidence={"source": "projection_fallback"},
-            )
-        merged.append(detail_by_value[value])
-    return merged
+    return project_deliverable_details(
+        deliverables,
+        detail_by_value,
+        fallback_evidence={"source": "projection_fallback"},
+    )
 
 
 #: Default path for grading weights config (Phase 3 multivariate grading).

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -219,6 +219,7 @@ class SessionRecord:
 
     # Artifacts
     deliverables: list[str] = field(default_factory=list)  # commit SHAs, PR URLs
+    deliverable_details: list[dict[str, Any]] = field(default_factory=list)
     trajectory_path: str | None = None  # path to trajectory JSONL file (for deduplication)
     journal_path: str | None = None  # path to human-written journal entry
 
@@ -267,6 +268,8 @@ class SessionRecord:
         # Guard against JSON null for integer field
         if self.duration_seconds is None:
             self.duration_seconds = 0
+        if self.deliverable_details is None:
+            self.deliverable_details = []
         if self.grades is None:
             self.grades = {}
         if self.grade_reasons is None:

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -71,6 +71,52 @@ _ISSUE_CLOSE_CMD_RE = re.compile(r"\bgh\s+issue\s+close\b")
 _GH_PR_MERGE_CMD_RE = re.compile(r"\bgh\s+pr\s+merge\b")
 
 
+def _build_deliverable_detail(
+    value: str,
+    *,
+    kind: str,
+    provenance_class: str,
+    evidence: dict[str, object],
+) -> dict[str, object]:
+    """Build one structured deliverable detail entry."""
+    compact_evidence = {
+        key: val for key, val in evidence.items() if val not in (None, "", [], {}, ())
+    }
+    return {
+        "value": value,
+        "kind": kind,
+        "provenance_class": provenance_class,
+        "evidence": compact_evidence,
+    }
+
+
+def _record_deliverable_detail(
+    detail_by_value: dict[str, dict[str, object]],
+    *,
+    value: str,
+    kind: str,
+    provenance_class: str,
+    evidence: dict[str, object],
+) -> None:
+    """Record first-seen structured detail for a deliverable value."""
+    if not value or value in detail_by_value:
+        return
+    detail_by_value[value] = _build_deliverable_detail(
+        value,
+        kind=kind,
+        provenance_class=provenance_class,
+        evidence=evidence,
+    )
+
+
+def _ordered_deliverable_details(
+    deliverables: list[str],
+    detail_by_value: dict[str, dict[str, object]],
+) -> list[dict[str, object]]:
+    """Project structured details into the legacy deliverable order."""
+    return [detail_by_value[value] for value in deliverables if value in detail_by_value]
+
+
 def _as_int(value: object) -> int | None:
     """Return integer token counters without accepting bools or lossy floats."""
     if isinstance(value, bool):
@@ -270,6 +316,7 @@ def extract_signals(msgs: list[dict]) -> dict:
     retry_candidates: list[str] = []
     timestamps: list[datetime] = []
     steps = 0  # number of assistant turns that yielded to await tool results
+    detail_by_value: dict[str, dict[str, object]] = {}
 
     # Track recent (tool, path) pairs for retry detection
     recent_sigs: list[str] = []
@@ -302,6 +349,13 @@ def extract_signals(msgs: list[dict]) -> dict:
                     if path:
                         if "/journal/" not in path:
                             file_writes.append(path)
+                            _record_deliverable_detail(
+                                detail_by_value,
+                                value=path,
+                                kind="file",
+                                provenance_class="tool_authored",
+                                evidence={"source": "trajectory", "tool_name": tool},
+                            )
                             sig = f"{tool}:{path}"
                             if sig in recent_sigs:
                                 retry_candidates.append(tool)
@@ -334,7 +388,15 @@ def extract_signals(msgs: list[dict]) -> dict:
             for commit_match in _COMMIT_RE.finditer(content[:500]):
                 commit_hash = commit_match.group(1)
                 commit_msg = commit_match.group(2).strip()
-                git_commits.append(f"{commit_msg} ({commit_hash})")
+                commit_value = f"{commit_msg} ({commit_hash})"
+                git_commits.append(commit_value)
+                _record_deliverable_detail(
+                    detail_by_value,
+                    value=commit_value,
+                    kind="commit",
+                    provenance_class="session_committed",
+                    evidence={"source": "trajectory", "tool_name": "shell"},
+                )
 
     # Session duration
     duration_s = 0
@@ -343,6 +405,7 @@ def extract_signals(msgs: list[dict]) -> dict:
 
     # Combine deliverables: git commits + distinct file writes
     deliverables = list(dict.fromkeys(git_commits + file_writes))
+    deliverable_details = _ordered_deliverable_details(deliverables, detail_by_value)
     retry_count = len(retry_candidates)
 
     return {
@@ -355,6 +418,7 @@ def extract_signals(msgs: list[dict]) -> dict:
         "session_duration_s": duration_s,
         "retry_count": retry_count,
         "deliverables": deliverables,
+        "deliverable_details": deliverable_details,
     }
 
 
@@ -547,6 +611,7 @@ def extract_signals_cc(msgs: list[dict]) -> dict:
     # PR number extracted from `gh pr merge <N>` command (may be absent if the
     # command used `gh pr merge` without an explicit number). Keyed by tool_use_id.
     _pr_merge_num_by_tool_id: dict[str, int] = {}
+    detail_by_value: dict[str, dict[str, object]] = {}
 
     for record in msgs:
         rec_type = record.get("type", "")
@@ -591,6 +656,13 @@ def extract_signals_cc(msgs: list[dict]) -> dict:
                     if path:
                         if "/journal/" not in path:
                             file_writes.append(path)
+                            _record_deliverable_detail(
+                                detail_by_value,
+                                value=path,
+                                kind="file",
+                                provenance_class="tool_authored",
+                                evidence={"source": "trajectory", "tool_name": tool},
+                            )
                             sig = f"{tool}:{path}"
                             if sig in recent_sigs:
                                 retry_candidates.append(tool)
@@ -767,8 +839,16 @@ def extract_signals_cc(msgs: list[dict]) -> dict:
                         if commit_hash in _all_direct_commit_hashes:
                             continue  # already seen in an earlier tool result
                         commit_msg = commit_match.group(2).strip()
-                        git_commits.append(f"{commit_msg} ({commit_hash})")
+                        commit_value = f"{commit_msg} ({commit_hash})"
+                        git_commits.append(commit_value)
                         _all_direct_commit_hashes.add(commit_hash)
+                        _record_deliverable_detail(
+                            detail_by_value,
+                            value=commit_value,
+                            kind="commit",
+                            provenance_class="session_committed",
+                            evidence={"source": "trajectory", "tool_name": "Bash"},
+                        )
 
                     # Background bash tasks: when CC runs a command in background mode,
                     # the tool result only contains a pointer to an output file like:
@@ -784,8 +864,20 @@ def extract_signals_cc(msgs: list[dict]) -> dict:
                                 if commit_hash in _all_direct_commit_hashes:
                                     continue  # already captured from a direct result
                                 commit_msg = commit_match.group(2).strip()
-                                git_commits.append(f"{commit_msg} ({commit_hash})")
+                                commit_value = f"{commit_msg} ({commit_hash})"
+                                git_commits.append(commit_value)
                                 _all_direct_commit_hashes.add(commit_hash)
+                                _record_deliverable_detail(
+                                    detail_by_value,
+                                    value=commit_value,
+                                    kind="commit",
+                                    provenance_class="session_committed",
+                                    evidence={
+                                        "source": "trajectory",
+                                        "tool_name": "Bash",
+                                        "background": True,
+                                    },
+                                )
                         except OSError:
                             pass  # File may not exist if session ran on a different host
 
@@ -805,6 +897,17 @@ def extract_signals_cc(msgs: list[dict]) -> dict:
                         for merge_match in _PR_MERGE_RE.finditer(result_str):
                             pr_num = merge_match.group(1)
                             pr_merges.append(f"PR #{pr_num}")
+                            _record_deliverable_detail(
+                                detail_by_value,
+                                value=f"merge PR #{pr_num}",
+                                kind="pull_request",
+                                provenance_class="session_committed",
+                                evidence={
+                                    "source": "trajectory",
+                                    "tool_name": "Bash",
+                                    "action": "gh_pr_merge",
+                                },
+                            )
                             # Prefer repo extracted from the command itself;
                             # do NOT overwrite context captured earlier from
                             # the gh pr create URL output.
@@ -885,6 +988,13 @@ def extract_signals_cc(msgs: list[dict]) -> dict:
         commit_entry = f"merge-commit ({sha})"
         if commit_entry not in git_commits:
             git_commits.append(commit_entry)
+        _record_deliverable_detail(
+            detail_by_value,
+            value=commit_entry,
+            kind="merge_commit",
+            provenance_class="server_generated",
+            evidence={"source": "gh_api", "action": "gh_pr_merge"},
+        )
 
     # pr_merges entries in deliverables: "merge PR #N" format for readability.
     # git_commits now includes any resolved merge SHAs from the loop above, so
@@ -892,6 +1002,7 @@ def extract_signals_cc(msgs: list[dict]) -> dict:
     deliverables = list(
         dict.fromkeys(git_commits + [f"merge {m}" for m in pr_merges] + file_writes)
     )
+    deliverable_details = _ordered_deliverable_details(deliverables, detail_by_value)
 
     # Summarize per-tool-call timing: total and max per tool name.
     # Enables detection of slow tests, long pre-commit hooks, and stalled tools.
@@ -924,6 +1035,7 @@ def extract_signals_cc(msgs: list[dict]) -> dict:
         "issues_created": issues_created,
         "ci_fixed": ci_fixed,
         "deliverables": deliverables,
+        "deliverable_details": deliverable_details,
     }
 
 
@@ -1211,6 +1323,7 @@ def extract_signals_codex(msgs: list[dict]) -> dict:
     timestamps: list[datetime] = []
     steps = 0
     recent_sigs: list[str] = []
+    detail_by_value: dict[str, dict[str, object]] = {}
 
     # Track function_call ids for matching with their outputs
     call_id_to_name: dict[str, str] = {}
@@ -1254,6 +1367,13 @@ def extract_signals_codex(msgs: list[dict]) -> dict:
                             journal_paths.append(path)
                         else:
                             file_writes.append(path)
+                            _record_deliverable_detail(
+                                detail_by_value,
+                                value=path,
+                                kind="file",
+                                provenance_class="tool_authored",
+                                evidence={"source": "trajectory", "tool_name": "apply_patch"},
+                            )
                             sig = f"apply_patch:{path}"
                             if sig in recent_sigs:
                                 retry_candidates.append("apply_patch")
@@ -1293,6 +1413,16 @@ def extract_signals_codex(msgs: list[dict]) -> dict:
                                     journal_paths.append(path)
                                 else:
                                     file_writes.append(path)
+                                    _record_deliverable_detail(
+                                        detail_by_value,
+                                        value=path,
+                                        kind="file",
+                                        provenance_class="tool_authored",
+                                        evidence={
+                                            "source": "trajectory",
+                                            "tool_name": "exec_command",
+                                        },
+                                    )
                                     sig = f"exec_command:{path}"
                                     if sig in recent_sigs:
                                         retry_candidates.append("exec_command")
@@ -1322,7 +1452,15 @@ def extract_signals_codex(msgs: list[dict]) -> dict:
                     for commit_match in _COMMIT_RE.finditer(output[:8000]):
                         commit_hash = commit_match.group(1)
                         commit_msg = commit_match.group(2).strip()
-                        git_commits.append(f"{commit_msg} ({commit_hash})")
+                        commit_value = f"{commit_msg} ({commit_hash})"
+                        git_commits.append(commit_value)
+                        _record_deliverable_detail(
+                            detail_by_value,
+                            value=commit_value,
+                            kind="commit",
+                            provenance_class="session_committed",
+                            evidence={"source": "trajectory", "tool_name": tool_name},
+                        )
 
     # Finalize the last turn (not followed by another turn_context)
     if current_turn_has_tool:
@@ -1333,6 +1471,7 @@ def extract_signals_codex(msgs: list[dict]) -> dict:
         duration_s = int((max(timestamps) - min(timestamps)).total_seconds())
 
     deliverables = list(dict.fromkeys(git_commits + file_writes))
+    deliverable_details = _ordered_deliverable_details(deliverables, detail_by_value)
     return {
         "tool_calls": tool_calls,
         "steps": steps,
@@ -1343,6 +1482,7 @@ def extract_signals_codex(msgs: list[dict]) -> dict:
         "session_duration_s": duration_s,
         "retry_count": len(retry_candidates),
         "deliverables": deliverables,
+        "deliverable_details": deliverable_details,
     }
 
 
@@ -1370,6 +1510,7 @@ def extract_signals_copilot(msgs: list[dict]) -> dict:
     timestamps: list[datetime] = []
     steps = 0
     recent_sigs: list[str] = []
+    detail_by_value: dict[str, dict[str, object]] = {}
 
     # Map toolCallId → tool name for filtering commit detection to bash only
     call_id_to_name: dict[str, str] = {}
@@ -1412,6 +1553,13 @@ def extract_signals_copilot(msgs: list[dict]) -> dict:
                     if path:
                         if "/journal/" not in path:
                             file_writes.append(path)
+                            _record_deliverable_detail(
+                                detail_by_value,
+                                value=path,
+                                kind="file",
+                                provenance_class="tool_authored",
+                                evidence={"source": "trajectory", "tool_name": tool},
+                            )
                             sig = f"{tool}:{path}"
                             if sig in recent_sigs:
                                 retry_candidates.append(tool)
@@ -1441,7 +1589,15 @@ def extract_signals_copilot(msgs: list[dict]) -> dict:
                     for commit_match in _COMMIT_RE.finditer(content[:500]):
                         commit_hash = commit_match.group(1)
                         commit_msg = commit_match.group(2).strip()
-                        git_commits.append(f"{commit_msg} ({commit_hash})")
+                        commit_value = f"{commit_msg} ({commit_hash})"
+                        git_commits.append(commit_value)
+                        _record_deliverable_detail(
+                            detail_by_value,
+                            value=commit_value,
+                            kind="commit",
+                            provenance_class="session_committed",
+                            evidence={"source": "trajectory", "tool_name": "bash"},
+                        )
 
         elif rec_type == "session.error":
             error_count += 1
@@ -1451,6 +1607,7 @@ def extract_signals_copilot(msgs: list[dict]) -> dict:
         duration_s = int((max(timestamps) - min(timestamps)).total_seconds())
 
     deliverables = list(dict.fromkeys(git_commits + file_writes))
+    deliverable_details = _ordered_deliverable_details(deliverables, detail_by_value)
     return {
         "tool_calls": tool_calls,
         "steps": steps,
@@ -1461,6 +1618,7 @@ def extract_signals_copilot(msgs: list[dict]) -> dict:
         "session_duration_s": duration_s,
         "retry_count": len(retry_candidates),
         "deliverables": deliverables,
+        "deliverable_details": deliverable_details,
     }
 
 

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -23,6 +23,8 @@ import subprocess
 from datetime import datetime
 from pathlib import Path
 
+from .deliverables import build_deliverable_detail, project_deliverable_details
+
 # Regex for git commit lines in shell output (works for both harnesses)
 _COMMIT_RE = re.compile(r"\[(?:master|main|[a-zA-Z0-9_/-]+)\s+([0-9a-f]{7,12})\]\s+(.+?)(?:\n|$)")
 
@@ -71,25 +73,6 @@ _ISSUE_CLOSE_CMD_RE = re.compile(r"\bgh\s+issue\s+close\b")
 _GH_PR_MERGE_CMD_RE = re.compile(r"\bgh\s+pr\s+merge\b")
 
 
-def _build_deliverable_detail(
-    value: str,
-    *,
-    kind: str,
-    provenance_class: str,
-    evidence: dict[str, object],
-) -> dict[str, object]:
-    """Build one structured deliverable detail entry."""
-    compact_evidence = {
-        key: val for key, val in evidence.items() if val not in (None, "", [], {}, ())
-    }
-    return {
-        "value": value,
-        "kind": kind,
-        "provenance_class": provenance_class,
-        "evidence": compact_evidence,
-    }
-
-
 def _record_deliverable_detail(
     detail_by_value: dict[str, dict[str, object]],
     *,
@@ -101,7 +84,7 @@ def _record_deliverable_detail(
     """Record first-seen structured detail for a deliverable value."""
     if not value or value in detail_by_value:
         return
-    detail_by_value[value] = _build_deliverable_detail(
+    detail_by_value[value] = build_deliverable_detail(
         value,
         kind=kind,
         provenance_class=provenance_class,
@@ -113,8 +96,12 @@ def _ordered_deliverable_details(
     deliverables: list[str],
     detail_by_value: dict[str, dict[str, object]],
 ) -> list[dict[str, object]]:
-    """Project structured details into the legacy deliverable order."""
-    return [detail_by_value[value] for value in deliverables if value in detail_by_value]
+    """Project structured details into legacy order and fill any missing entries."""
+    return project_deliverable_details(
+        deliverables,
+        detail_by_value,
+        fallback_evidence={"source": "projection_fallback"},
+    )
 
 
 def _as_int(value: object) -> int | None:

--- a/packages/gptme-sessions/tests/test_deliverables.py
+++ b/packages/gptme-sessions/tests/test_deliverables.py
@@ -1,0 +1,46 @@
+from gptme_sessions.deliverables import build_deliverable_detail, project_deliverable_details
+
+
+def test_build_deliverable_detail_allows_explicit_kind_override():
+    detail = build_deliverable_detail(
+        "fix: ship thing (abc1234)",
+        kind="commit",
+        provenance_class="session_committed",
+        evidence={"source": "trajectory", "tool_name": "shell"},
+    )
+
+    assert detail == {
+        "value": "fix: ship thing (abc1234)",
+        "kind": "commit",
+        "provenance_class": "session_committed",
+        "evidence": {"source": "trajectory", "tool_name": "shell"},
+    }
+
+
+def test_project_deliverable_details_gap_fills_missing_entries():
+    details = project_deliverable_details(
+        ["src/app.py", "abc1234567890abcdef1234567890abcdef1234"],
+        {
+            "src/app.py": build_deliverable_detail(
+                "src/app.py",
+                provenance_class="tool_authored",
+                evidence={"source": "trajectory", "tool_name": "Write"},
+            )
+        },
+        fallback_evidence={"source": "projection_fallback"},
+    )
+
+    assert details == [
+        {
+            "value": "src/app.py",
+            "kind": "file",
+            "provenance_class": "tool_authored",
+            "evidence": {"source": "trajectory", "tool_name": "Write"},
+        },
+        {
+            "value": "abc1234567890abcdef1234567890abcdef1234",
+            "kind": "commit",
+            "provenance_class": "fallback_observed",
+            "evidence": {"source": "projection_fallback"},
+        },
+    ]

--- a/packages/gptme-sessions/tests/test_post_session.py
+++ b/packages/gptme-sessions/tests/test_post_session.py
@@ -518,6 +518,14 @@ def test_post_session_trajectory_deliverables_take_precedence(tmp_path: Path):
         "session_duration_s": 60,
         "productive": True,
         "deliverables": [traj_deliverable],
+        "deliverable_details": [
+            {
+                "value": traj_deliverable,
+                "kind": "commit",
+                "provenance_class": "session_committed",
+                "evidence": {"source": "trajectory", "tool_name": "Bash"},
+            }
+        ],
     }
     with patch.object(_post_session_mod, "extract_from_path", return_value=fake_signals):
         result = post_session(
@@ -537,6 +545,20 @@ def test_post_session_trajectory_deliverables_take_precedence(tmp_path: Path):
     assert len(result.record.deliverables) == 2
     assert result.record.deliverables[0] == traj_deliverable
     assert result.record.deliverables[1] == "abc1234567890abcdef1234567890abcdef1234"
+    assert result.record.deliverable_details == [
+        {
+            "value": traj_deliverable,
+            "kind": "commit",
+            "provenance_class": "session_committed",
+            "evidence": {"source": "trajectory", "tool_name": "Bash"},
+        },
+        {
+            "value": "abc1234567890abcdef1234567890abcdef1234",
+            "kind": "commit",
+            "provenance_class": "session_committed",
+            "evidence": {"source": "caller", "validation": "trajectory_sha_prefix"},
+        },
+    ]
 
 
 def test_post_session_caller_only_deliverables_when_no_trajectory(tmp_path: Path):
@@ -554,6 +576,14 @@ def test_post_session_caller_only_deliverables_when_no_trajectory(tmp_path: Path
 
     assert len(result.record.deliverables) == 1
     assert result.record.outcome == "productive"
+    assert result.record.deliverable_details == [
+        {
+            "value": "abc1234567890abcdef1234567890abcdef1234",
+            "kind": "commit",
+            "provenance_class": "fallback_observed",
+            "evidence": {"source": "caller", "reason": "no_trajectory"},
+        }
+    ]
 
 
 def test_post_session_caller_deliverables_no_outcome_override_when_traj_noop(tmp_path: Path):
@@ -581,6 +611,7 @@ def test_post_session_caller_deliverables_no_outcome_override_when_traj_noop(tmp
 
     assert result.record.outcome == "noop"
     assert result.record.deliverables == []
+    assert result.record.deliverable_details == []
 
 
 def test_post_session_trajectory_empty_deliverables_keeps_caller_when_productive(
@@ -613,6 +644,14 @@ def test_post_session_trajectory_empty_deliverables_keeps_caller_when_productive
             )
 
     assert result.record.deliverables == [caller_sha]
+    assert result.record.deliverable_details == [
+        {
+            "value": caller_sha,
+            "kind": "commit",
+            "provenance_class": "fallback_observed",
+            "evidence": {"source": "caller", "reason": "trajectory_empty"},
+        }
+    ]
     assert any(
         "Trajectory ran but found no deliverables; keeping" in r.message for r in caplog.records
     )

--- a/packages/gptme-sessions/tests/test_record.py
+++ b/packages/gptme-sessions/tests/test_record.py
@@ -33,6 +33,34 @@ def test_context_tier_roundtrip():
     assert r2.context_tier == "massive"
 
 
+def test_deliverable_details_roundtrip():
+    """deliverable_details survives to_dict/from_dict round-trip."""
+    r = SessionRecord(
+        deliverables=["src/app.py"],
+        deliverable_details=[
+            {
+                "value": "src/app.py",
+                "kind": "file",
+                "provenance_class": "tool_authored",
+                "evidence": {"source": "trajectory", "tool_name": "Edit"},
+            }
+        ],
+    )
+
+    d = r.to_dict()
+    assert d["deliverable_details"] == [
+        {
+            "value": "src/app.py",
+            "kind": "file",
+            "provenance_class": "tool_authored",
+            "evidence": {"source": "trajectory", "tool_name": "Edit"},
+        }
+    ]
+
+    r2 = SessionRecord.from_dict(d)
+    assert r2.deliverable_details == d["deliverable_details"]
+
+
 def test_context_tier_none_roundtrip():
     """context_tier=None round-trips correctly."""
     r = SessionRecord(model="sonnet")

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -3182,6 +3182,20 @@ def test_post_session_deliverables_from_trajectory(tmp_path: Path):
     )
     assert "/tmp/foo.py" in result.record.deliverables
     assert "/tmp/bar.py" in result.record.deliverables
+    assert result.record.deliverable_details == [
+        {
+            "value": "/tmp/foo.py",
+            "kind": "file",
+            "provenance_class": "tool_authored",
+            "evidence": {"source": "trajectory", "tool_name": "Write"},
+        },
+        {
+            "value": "/tmp/bar.py",
+            "kind": "file",
+            "provenance_class": "tool_authored",
+            "evidence": {"source": "trajectory", "tool_name": "Edit"},
+        },
+    ]
 
 
 def test_post_session_metadata_fields(tmp_path: Path):

--- a/packages/gptme-sessions/tests/test_signals_merge_sha.py
+++ b/packages/gptme-sessions/tests/test_signals_merge_sha.py
@@ -244,6 +244,18 @@ def test_extract_signals_cc_includes_resolved_merge_sha():
     assert any(
         FAKE_SHA in d for d in sigs["deliverables"]
     ), f"expected {FAKE_SHA} in deliverables, got {sigs['deliverables']}"
+    assert any(
+        detail["value"] == "merge PR #42"
+        and detail["kind"] == "pull_request"
+        and detail["provenance_class"] == "session_committed"
+        for detail in sigs["deliverable_details"]
+    )
+    assert any(
+        detail["value"] == f"merge-commit ({FAKE_SHA})"
+        and detail["kind"] == "merge_commit"
+        and detail["provenance_class"] == "server_generated"
+        for detail in sigs["deliverable_details"]
+    )
 
     # Exactly one gh-view call — for PR #42.
     mock_run.assert_called_once()
@@ -315,6 +327,12 @@ def test_extract_signals_cc_gh_failure_does_not_break_extraction():
     assert not any(FAKE_SHA in c for c in sigs["git_commits"])
     # deliverables still contains the human-readable "merge PR #42" entry.
     assert any("merge PR #42" in d for d in sigs["deliverables"])
+    assert any(
+        detail["value"] == "merge PR #42"
+        and detail["kind"] == "pull_request"
+        and detail["provenance_class"] == "session_committed"
+        for detail in sigs["deliverable_details"]
+    )
 
 
 def test_extract_signals_cc_no_pr_merges_no_gh_calls():


### PR DESCRIPTION
## Summary
- add a structured `deliverable_details` sidecar on session records
- preserve the legacy `deliverables` projection while tagging tool-authored, session-committed, server-generated, and fallback-observed artifacts
- cover the new provenance flow with record, signal extraction, and post-session regression tests

## Testing
- uv run pytest packages/gptme-sessions/tests/test_record.py packages/gptme-sessions/tests/test_post_session.py packages/gptme-sessions/tests/test_sessions.py -k "deliverable or extract_from_path_codex or extract_from_path_copilot or extract_from_path_gptme or gh_pr_merge"

## Notes
- stacked on top of #942 so the trajectory-authoritative attribution fix lands first
- follow-up for #943