### PR TITLE
fix(gptme-sessions): preserve non-SHA caller deliverables

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -28,7 +28,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from .deliverables import build_deliverable_detail, project_deliverable_details
+from .deliverables import (
+    build_deliverable_detail,
+    looks_like_sha,
+    project_deliverable_details,
+)
 from .discovery import extract_project, extract_session_name
 from .record import SessionRecord
 from .signals import extract_from_path
@@ -407,23 +411,35 @@ def post_session(
         if traj_deliverables:
             traj_sha_prefixes = _extract_traj_sha_prefixes(traj_deliverables)
             if traj_sha_prefixes:
-                # Trajectory has commit SHAs — validate caller SHAs against them.
-                validated = [
-                    d for d in caller_deliverables if _caller_sha_in_traj(d, traj_sha_prefixes)
+                # Trajectory has commit SHAs — validate caller SHAs against them
+                # and preserve non-SHA caller deliverables like PR URLs or files.
+                validated_shas = [
+                    d
+                    for d in caller_deliverables
+                    if looks_like_sha(d) and _caller_sha_in_traj(d, traj_sha_prefixes)
                 ]
-                unvalidated = [d for d in caller_deliverables if d not in validated]
-                if unvalidated:
+                unvalidated_shas = [
+                    d for d in caller_deliverables if looks_like_sha(d) and d not in validated_shas
+                ]
+                passthrough_non_sha = [d for d in caller_deliverables if not looks_like_sha(d)]
+                if unvalidated_shas:
                     logger.warning(
                         "Dropping %d git-range commit(s) absent from trajectory "
                         "(likely from a concurrent session): %s",
-                        len(unvalidated),
-                        unvalidated[:5],
+                        len(unvalidated_shas),
+                        unvalidated_shas[:5],
                     )
-                deliverables = list(dict.fromkeys(traj_deliverables + validated))
+                deliverables = list(
+                    dict.fromkeys(traj_deliverables + validated_shas + passthrough_non_sha)
+                )
                 extra_deliverable_details = _build_caller_deliverable_details(
-                    validated,
+                    validated_shas,
                     provenance_class="session_committed",
                     evidence={"source": "caller", "validation": "trajectory_sha_prefix"},
+                ) + _build_caller_deliverable_details(
+                    passthrough_non_sha,
+                    provenance_class="fallback_observed",
+                    evidence={"source": "caller", "reason": "non_sha_passthrough"},
                 )
             else:
                 # Trajectory has no SHAs (file paths only) — can't validate

--- a/packages/gptme-sessions/tests/test_post_session.py
+++ b/packages/gptme-sessions/tests/test_post_session.py
@@ -561,6 +561,81 @@ def test_post_session_trajectory_deliverables_take_precedence(tmp_path: Path):
     ]
 
 
+def test_post_session_trajectory_commit_validation_keeps_non_sha_caller_deliverables(
+    tmp_path: Path,
+):
+    """Trajectory SHA validation should not drop caller PR/file deliverables."""
+    store = SessionStore(sessions_dir=tmp_path)
+    fake_traj = tmp_path / "trajectory.jsonl"
+    fake_traj.write_text("")
+
+    traj_deliverable = "fix: something this session did (abc1234)"
+    caller_pr = "https://github.com/gptme/gptme-contrib/pull/944"
+    caller_file = "packages/gptme-sessions/src/gptme_sessions/post_session.py"
+    concurrent_sha = "deadbeef" + "01234567" * 4
+
+    fake_signals = {
+        "session_duration_s": 60,
+        "productive": True,
+        "deliverables": [traj_deliverable],
+        "deliverable_details": [
+            {
+                "value": traj_deliverable,
+                "kind": "commit",
+                "provenance_class": "session_committed",
+                "evidence": {"source": "trajectory", "tool_name": "Bash"},
+            }
+        ],
+    }
+    with patch.object(_post_session_mod, "extract_from_path", return_value=fake_signals):
+        result = post_session(
+            store=store,
+            harness="claude-code",
+            model="sonnet",
+            duration_seconds=0,
+            trajectory_path=fake_traj,
+            deliverables=[
+                "abc1234567890abcdef1234567890abcdef1234",
+                caller_pr,
+                caller_file,
+                concurrent_sha,
+            ],
+        )
+
+    assert result.record.deliverables == [
+        traj_deliverable,
+        "abc1234567890abcdef1234567890abcdef1234",
+        caller_pr,
+        caller_file,
+    ]
+    assert result.record.deliverable_details == [
+        {
+            "value": traj_deliverable,
+            "kind": "commit",
+            "provenance_class": "session_committed",
+            "evidence": {"source": "trajectory", "tool_name": "Bash"},
+        },
+        {
+            "value": "abc1234567890abcdef1234567890abcdef1234",
+            "kind": "commit",
+            "provenance_class": "session_committed",
+            "evidence": {"source": "caller", "validation": "trajectory_sha_prefix"},
+        },
+        {
+            "value": caller_pr,
+            "kind": "pull_request",
+            "provenance_class": "fallback_observed",
+            "evidence": {"source": "caller", "reason": "non_sha_passthrough"},
+        },
+        {
+            "value": caller_file,
+            "kind": "file",
+            "provenance_class": "fallback_observed",
+            "evidence": {"source": "caller", "reason": "non_sha_passthrough"},
+        },
+    ]
+
+
 def test_post_session_caller_only_deliverables_when_no_trajectory(tmp_path: Path):
     """Without a trajectory, caller-supplied (git-range) deliverables are used
     as-is and upgrade outcome from noop/unknown to productive."""


### PR DESCRIPTION
## Summary
- preserve caller PR/file deliverables when trajectory commit SHAs are present
- keep dropping only unmatched SHA-like caller deliverables as concurrent-session noise
- add a regression test covering mixed caller SHA + PR URL + file-path inputs

## Testing
- uv run pytest packages/gptme-sessions/tests/test_post_session.py packages/gptme-sessions/tests/test_deliverables.py
- uv run ruff check packages/gptme-sessions/src/gptme_sessions/post_session.py packages/gptme-sessions/tests/test_post_session.py

## Notes
- follow-up to #944 after verifying the merged code still dropped non-SHA caller deliverables in the trajectory-SHA validation branch