### PR TITLE
fix(self-merge): treat loop-control scripts as sensitive

### DIFF
--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -78,8 +78,13 @@ SENSITIVE_PATH_PREFIXES = (
     "scripts/github/self-merge-check",
     "scripts/github/pr-greptile-trigger",
     "scripts/github/greptile-helper",
+    # Downstream agent workspaces commonly use these loop-control entrypoints.
+    # Guard both hyphenated and underscored spellings so naming drift still
+    # forces human review.
     "scripts/session-bandit",
+    "scripts/session_bandit",
     "scripts/state-delta",
+    "scripts/state_delta",
     "infra/",
     "k8s/",
     "secrets/",

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -78,6 +78,8 @@ SENSITIVE_PATH_PREFIXES = (
     "scripts/github/self-merge-check",
     "scripts/github/pr-greptile-trigger",
     "scripts/github/greptile-helper",
+    "scripts/session-bandit",
+    "scripts/state-delta",
     "infra/",
     "k8s/",
     "secrets/",

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -366,6 +366,22 @@ def test_is_sensitive_path_handles_deploy_word_forms(path: str, expected: bool) 
     assert self_merge_check.is_sensitive_path(path) is expected
 
 
+@pytest.mark.parametrize(
+    "path",
+    [
+        "scripts/session-bandit.py",
+        "scripts/session-bandit-v2.py",
+        "scripts/session_bandit.py",
+        "scripts/state-delta.py",
+        "scripts/state_delta.py",
+    ],
+)
+def test_classify_loop_control_paths_blocked(path: str) -> None:
+    category, reasons = self_merge_check.classify_category([path])
+    assert category is None
+    assert any("sensitive" in reason.lower() for reason in reasons)
+
+
 def test_evaluate_pr_warns_when_workspace_repos_empty() -> None:
     """Explicit opt-out (workspace_repos=[]) emits a warning but does not disqualify."""
     pr_data = {


### PR DESCRIPTION
## Summary

- Classifies `scripts/session-bandit*` and `scripts/state-delta*` as sensitive paths in the self-merge checker
- These loop-orchestration scripts are critical infrastructure; changes require human review
- Motivated by Alice's counterfactual note about self-merge trust signals on 2026-05-20

## Changes

`scripts/github/self-merge-check.py` — 2 lines: adds the two path patterns to the sensitive list

## Context

Session fd81 implemented this fix and pushed the branch, but the PR couldn't be created at that time due to GraphQL rate-limit exhaustion. Creating now that API budget has recovered.