### PR TITLE
fix(monitoring): increase GraphQL cache TTL defaults to reduce budget pressure

### DIFF
--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -218,9 +218,14 @@ discover_repos() {
 # Override via env: GH_CACHE_TTL_PR / GH_CACHE_TTL_ISSUE / GH_CACHE_TTL_RUN (seconds).
 # Set any to 0 to bypass the cache (useful for diagnostics).
 GH_CACHE_DIR="${GH_CACHE_DIR:-$STATE_DIR/gh-cache}"
-GH_CACHE_TTL_PR="${GH_CACHE_TTL_PR:-240}"
-GH_CACHE_TTL_ISSUE="${GH_CACHE_TTL_ISSUE:-300}"
-GH_CACHE_TTL_RUN="${GH_CACHE_TTL_RUN:-300}"
+# Increased from 240→480 and 300→600 (2026-05-21) after GraphQL rate-limit regression.
+# Project-monitoring runs every 2 minutes across 50 repos. At 4-min TTL, every
+# other run re-fetches (50% cache hit). At 8-min TTL: 3 out of 4 runs serve from
+# cache (75% hit), cutting GraphQL budget burn from ~$burn_rate to ~half.
+# See: tasks/github-graphql-rate-limit-regression.md
+GH_CACHE_TTL_PR="${GH_CACHE_TTL_PR:-480}"
+GH_CACHE_TTL_ISSUE="${GH_CACHE_TTL_ISSUE:-600}"
+GH_CACHE_TTL_RUN="${GH_CACHE_TTL_RUN:-600}"
 
 # Read cached value if fresh enough, else run the producer command and cache its
 # stdout. The producer is passed as a single shell-evaluated string so callers

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -179,9 +179,10 @@ emit_item() {
 }
 
 discover_repos() {
-    # Cache repo list for 1 hour — org membership rarely changes
+    # Cache repo list for 1 hour by default — org membership rarely changes.
+    # Override with GH_CACHE_TTL_REPO (seconds).
     local cache_file="$STATE_DIR/repo-list-${ORG}.cache"
-    local cache_max_age=3600  # seconds
+    local cache_max_age="${GH_CACHE_TTL_REPO:-3600}"
 
     if [ -f "$cache_file" ]; then
         local cache_age
@@ -209,19 +210,18 @@ discover_repos() {
     for r in "${EXTRA_REPOS[@]}"; do echo "$r"; done
 }
 
-# Per-repo GraphQL response cache. Default cadence is every 2 minutes across 50
-# repos × 3 gh calls = 150 GraphQL ops/run → 4,500/hr. With a 4-min TTL on
-# PR data (the most time-critical) and 5-min TTLs on issues/master-CI, we serve
-# from cache on every other run and refresh in the next, cutting load by ~50%
-# without changing cadence.
+# Per-repo GraphQL response cache. Project monitoring runs every 2 minutes
+# across 50 repos, so the old defaults implied roughly 750 PR-data fetches/hr
+# plus 500/hr each for assigned-issue and master-CI fetches (~1,750/hr total).
+# Raising the defaults to 480s / 600s / 600s drops those lanes to ~375 / 300 /
+# 300 fetches/hr (~975/hr total) without changing cadence.
 #
 # Override via env: GH_CACHE_TTL_PR / GH_CACHE_TTL_ISSUE / GH_CACHE_TTL_RUN (seconds).
 # Set any to 0 to bypass the cache (useful for diagnostics).
 GH_CACHE_DIR="${GH_CACHE_DIR:-$STATE_DIR/gh-cache}"
 # Increased from 240→480 and 300→600 (2026-05-21) after GraphQL rate-limit regression.
-# Project-monitoring runs every 2 minutes across 50 repos. At 4-min TTL, every
-# other run re-fetches (50% cache hit). At 8-min TTL: 3 out of 4 runs serve from
-# cache (75% hit), cutting GraphQL budget burn from ~$burn_rate to ~half.
+# At a 2-minute cadence, the PR-data lane drops from ~750 fetches/hr to ~375/hr
+# (75% cache hit instead of 50%).
 # See: tasks/github-graphql-rate-limit-regression.md
 GH_CACHE_TTL_PR="${GH_CACHE_TTL_PR:-480}"
 GH_CACHE_TTL_ISSUE="${GH_CACHE_TTL_ISSUE:-600}"


### PR DESCRIPTION
## Problem

GraphQL rate-limit exhaustion has regressed - observed `gh pr create` failure at 08:54 UTC today. The March 2026 audit shipped fixes but they've degraded over time.

Root cause analysis shows the `activity-gate.sh` default cache TTLs are too aggressive for the concurrent-consumer environment:

| Consumer | Before | After |
|---|---|---|
| PR data (`fetch_pr_data_with_ttl`) | 240s (4 min) | 480s (8 min) |
| Issue data | 300s (5 min) | 600s (10 min) |
| Master CI runs | 300s (5 min) | 600s (10 min) |
| Repo discovery | 3600s hardcoded | 3600s default via `GH_CACHE_TTL_REPO` |

## Changes

```txt
GH_CACHE_TTL_PR:    240s -> 480s
GH_CACHE_TTL_ISSUE: 300s -> 600s
GH_CACHE_TTL_RUN:   300s -> 600s
GH_CACHE_TTL_REPO:  new env override, default 3600s
```

## Testing

- `bash -n scripts/github/activity-gate.sh`
- `git diff --check`
- `prek run --files scripts/github/activity-gate.sh`
