### PR TITLE
fix(git-safe-commit): always auto-stage explicit pathspecs

### DIFF
--- a/scripts/git/git-safe-commit
+++ b/scripts/git/git-safe-commit
@@ -324,15 +324,22 @@ check_clean_worktree_for_hooks() {
     fi
 }
 
-stage_explicit_pathspecs_for_hooks() {
+stage_explicit_pathspecs() {
     if [ "${#PATHSPECS[@]}" -eq 0 ]; then
         return 0
     fi
 
     # The documented wrapper usage is `git-safe-commit file1 file2 -m ...`.
-    # Stage those explicit paths under the commit lock so the pre-commit dirty
-    # worktree guard still blocks unrelated files without forcing callers to
-    # remember a separate `git add`.
+    # Stage those explicit paths under the commit lock so callers don't need
+    # a separate `git add` step for untracked files, and so the pre-commit
+    # dirty worktree guard (when hooks run) sees the explicit set already
+    # staged.
+    #
+    # Runs unconditionally — including under --no-verify — because the
+    # convenience is mode-independent. Without unconditional staging,
+    # `git commit <path>` rejects untracked pathspecs with "did not match
+    # any file(s) known to git", which forces an awkward `git add` step
+    # exactly when the wrapper is supposed to remove it.
     git add -- "${PATHSPECS[@]}"
 }
 
@@ -363,9 +370,10 @@ fi
 
 check_index_corruption
 
+stage_explicit_pathspecs
+
 MANUAL_PRECOMMIT_RAN=0
 if [ "$NO_VERIFY" -ne 1 ]; then
-    stage_explicit_pathspecs_for_hooks
     PRE_COMMIT_HOOK=""
     ALLOW_UNTRACKED_FOR_HOOK=0
     if PRE_COMMIT_HOOK="$(resolve_pre_commit_hook)"; then

--- a/tests/test_git_safe_commit.py
+++ b/tests/test_git_safe_commit.py
@@ -336,6 +336,50 @@ def test_safe_commit_allows_dirty_worktree_with_no_verify(git_repo: Path):
     assert "test: dirty worktree allowed" in log.stdout
 
 
+def test_safe_commit_stages_untracked_pathspecs_under_no_verify(git_repo: Path):
+    """--no-verify with an untracked pathspec should auto-stage and commit.
+
+    Regression for the case where `git-safe-commit foo.md --no-verify -m ...`
+    on a fresh untracked file failed with "pathspec did not match any file(s)
+    known to git" because the auto-stage step was gated on hooks-run mode.
+    """
+    fresh = git_repo / "fresh.txt"
+    fresh.write_text("brand new\n")
+
+    result = subprocess.run(
+        [
+            str(SAFE_COMMIT),
+            "fresh.txt",
+            "--no-verify",
+            "-m",
+            "test: untracked under --no-verify",
+        ],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    log = subprocess.run(
+        ["git", "log", "--oneline", "-1"],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "test: untracked under --no-verify" in log.stdout
+
+    status = subprocess.run(
+        ["git", "status", "--short"],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert status.stdout == ""
+
+
 def test_safe_commit_allows_untracked_worktree_by_default_with_auto_stage_hook(
     git_repo: Path,
 ):


### PR DESCRIPTION
## Summary

`git-safe-commit foo.md --no-verify -m ...` on an untracked file fails with
`pathspec did not match any file(s) known to git`, even though the wrapper's
documented usage is `git-safe-commit <files> -m ...` with no separate `git add`.

The auto-stage step (`stage_explicit_pathspecs_for_hooks`) was gated on the
hooks-running path. `--no-verify` skipped staging entirely, so explicit untracked
pathspecs reached `git commit` raw and got rejected.

This bit me when committing orphan session journals via the documented
dirty-worktree recovery path (CLAUDE.md): scoped `prek run --files ...`,
then `git-safe-commit <files> --no-verify -m ...`. The recovery path
explicitly uses `--no-verify`, which is exactly the path where this fails.

## Fix

- Hoist `stage_explicit_pathspecs` out of the `NO_VERIFY != 1` gate so it runs
  unconditionally (the convenience is mode-independent).
- Rename from `stage_explicit_pathspecs_for_hooks` since the rationale broadens.
- Updated docstring to reflect why it must run under `--no-verify` too.

## Test plan

- [x] New regression test `test_safe_commit_stages_untracked_pathspecs_under_no_verify`
      exercises the `--no-verify` + untracked pathspec path end-to-end and asserts
      a clean status after commit.
- [x] Full `tests/test_git_safe_commit.py` suite still passes (28/28).