### PR TITLE
feat(self-merge-check): gate behind GitHub GraphQL rate-limit health

### DIFF
--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -1019,6 +1019,57 @@ def main() -> int:
     args = parser.parse_args()
     workspace_repos = _resolve_workspace_repos(args)
 
+    # GraphQL rate-limit gate. self-merge-check fires a multi-page GraphQL
+    # query (reviewThreads + commits + status checks) — easily 50-200
+    # points per invocation. When the GraphQL bucket is over the configured
+    # threshold, defer rather than dig the hole deeper.
+    #
+    # Gate is OPTIONAL — controlled by $BOB_GH_RATE_LIMIT_HELPER or by
+    # finding a sibling `github-rate-limit-health.sh` in the parent
+    # workspace. When the helper isn't present this code path is a no-op,
+    # so gptme-contrib remains standalone-usable.
+    #
+    # Operators who explicitly want to force-check can bypass with
+    # $BOB_FORCE_SELF_MERGE_CHECK=1.
+    if not os.environ.get("BOB_FORCE_SELF_MERGE_CHECK"):
+        gate_helper = os.environ.get("BOB_GH_RATE_LIMIT_HELPER")
+        if not gate_helper:
+            # Probe common locations relative to this script. Walk up to
+            # find a workspace-level helper without requiring an env var.
+            here = os.path.dirname(os.path.abspath(__file__))
+            for _ in range(4):
+                candidate = os.path.join(here, "github-rate-limit-health.sh")
+                if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+                    gate_helper = candidate
+                    break
+                parent = os.path.dirname(here)
+                if parent == here:
+                    break
+                here = parent
+        if gate_helper and os.access(gate_helper, os.X_OK):
+            try:
+                gate = subprocess.run(
+                    [gate_helper, "--gate"],
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+                if gate.returncode == 76:
+                    msg = (
+                        "self-merge-check deferred: GitHub API rate limit "
+                        "over threshold (gate exit 76). Set "
+                        "BOB_FORCE_SELF_MERGE_CHECK=1 to override."
+                    )
+                    if args.json:
+                        print(json.dumps({"deferred": True, "reason": msg}))
+                    else:
+                        print(msg, file=sys.stderr)
+                    return 76
+            except (subprocess.TimeoutExpired, OSError):
+                # Gate itself failed — don't block the real check on a
+                # broken health helper. Fall through to the normal path.
+                pass
+
     try:
         repo, number = parse_pr_target(args.pr, args.repo, args.number)
         result = evaluate_pr(


### PR DESCRIPTION
## Summary

`self-merge-check` fires a multi-page GraphQL query (reviewThreads + commits + status checks) — easily **50-200 points per invocation**. When the GraphQL bucket is already over threshold, this is the kind of consumer that turns "near the limit" into "fully exhausted" and blocks `gh pr create` for the rest of the hour.

Adds a defensive gate at the top of `main()`:

- If a sibling `github-rate-limit-health.sh --gate` helper is available (env var `BOB_GH_RATE_LIMIT_HELPER` or auto-probed up the tree from the script's location), call it. Exit 76 from the helper means "over threshold, defer". We propagate that exit code, print a deferred reason (JSON-shaped under `--json`), and return without burning the budget.
- **Gate is OPTIONAL** — when the helper isn't present, the gate is a no-op and `self-merge-check` behaves exactly as before. gptme-contrib remains standalone-usable.
- Operator override: `BOB_FORCE_SELF_MERGE_CHECK=1` bypasses the gate.

## This is a circuit breaker, not a cost fix

Important framing: `--gate` prevents the *last* fraction of the budget from being torched once we're already near exhaustion. It does **not** reduce per-call cost or frequency. A consumer that costs 100 points × 50 calls/hour will still exhaust the budget — the gate just changes *when in the hour* it lands.

Real cost-reduction work (drop the underlying points/hour, not just defer):
- **Measure** actual per-call cost via the attribution log (response-header `X-RateLimit-Used` deltas) rather than eyeballing query shape.
- **Split the query** — most fields self-merge-check needs (CI status, approval, commits) are REST-cheap. Only the review-thread resolution state genuinely needs GraphQL.
- **Cache short** — 60-120s per-PR sidecar; the answer rarely changes minute-to-minute during one PR's review cycle.
- **Drop frequency** — audit the callers, not just the script.

This PR is still worth landing because the gate is the right *primitive* for "is GraphQL exhausted right now?" and avoids the worst failure mode (full exhaustion mid-budget). The cost-reduction follow-ups belong in separate PRs.

## Test plan

- [x] Verified during the live 2026-05-21 incident:
  - **Without override**: `BOB_GH_RATE_LIMIT_HELPER=... self-merge-check 947` deferred cleanly with zero GraphQL calls.
  - **With override**: `BOB_FORCE_SELF_MERGE_CHECK=1 ... self-merge-check 947` proceeds to GraphQL, hits the same exhaustion error — confirms the gate genuinely saved the call.
- [x] pre-commit clean (ruff, mypy)

Tracking task (with the cost-reduction follow-ups): `tasks/github-graphql-rate-limit-regression.md` in Bob's workspace.