### PR TITLE
fix(self-merge-check): harden optional gate helper

### DIFF
--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -214,7 +214,9 @@ def _resolve_gate_helper(script_path: Path | None = None) -> str | None:
 def _maybe_defer_for_rate_limit(
     *, json_output: bool, script_path: Path | None = None
 ) -> int | None:
-    if os.environ.get(FORCE_SELF_MERGE_CHECK_ENV):
+    if os.environ.get(FORCE_SELF_MERGE_CHECK_ENV) or os.environ.get(
+        FORCE_SELF_MERGE_CHECK_ENV_LEGACY
+    ):
         return None
 
     gate_helper = _resolve_gate_helper(script_path)
@@ -238,7 +240,7 @@ def _maybe_defer_for_rate_limit(
     msg = (
         "self-merge-check deferred: GitHub API rate limit over threshold "
         f"(gate exit {GATE_DEFER_EXIT}). Set {FORCE_SELF_MERGE_CHECK_ENV}=1 "
-        "to override."
+        f"(or {FORCE_SELF_MERGE_CHECK_ENV_LEGACY}=1) to override."
     )
     if json_output:
         print(json.dumps({"deferred": True, "reason": msg}))

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -190,12 +190,17 @@ def _resolve_gate_helper(script_path: Path | None = None) -> str | None:
     )
     if explicit_helper:
         helper = Path(explicit_helper).expanduser()
+        # Determine which env var actually supplied the value for error messages
+        source_env = (
+            GATE_HELPER_ENV
+            if GATE_HELPER_ENV in os.environ
+            and os.environ[GATE_HELPER_ENV] == explicit_helper
+            else GATE_HELPER_ENV_LEGACY
+        )
         if not helper.is_file():
-            raise RuntimeError(
-                f"{GATE_HELPER_ENV} points to a missing helper: {helper}"
-            )
+            raise RuntimeError(f"{source_env} points to a missing helper: {helper}")
         if not os.access(helper, os.X_OK):
-            raise RuntimeError(f"{GATE_HELPER_ENV} is not executable: {helper}")
+            raise RuntimeError(f"{source_env} is not executable: {helper}")
         return str(helper)
 
     script = (script_path or Path(__file__)).resolve()

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -27,6 +27,13 @@ Usage:
     python3 scripts/github/self-merge-check.py --json <pr-url>
 
 Environment:
+    BOB_GH_RATE_LIMIT_HELPER
+                    Optional explicit path to a GitHub API rate-limit gate
+                    helper. When set, it must point to an executable helper or
+                    the script exits with code 2 instead of silently bypassing
+                    the gate.
+    BOB_FORCE_SELF_MERGE_CHECK
+                    Set to bypass the optional GitHub API rate-limit gate.
     WORKSPACE_REPO  Allowlist of workspace repos (owner/name), comma- or
                     whitespace-separated. Auto-detected single repo used when
                     unset. Set to empty string to disable the cross-repo
@@ -37,6 +44,12 @@ Environment:
                     "owner/repo:path-glob[,owner/repo:path-glob...]".
                     Uses repo-relative segment globs (* stays within one
                     directory segment; ** matches zero or more directories).
+
+Exit codes:
+    0   Eligible for self-merge
+    1   Not eligible for self-merge
+    2   Error (invalid args, gh failure, or explicit gate-helper misconfig)
+    76  Deferred by the GitHub API rate-limit gate
 """
 
 from __future__ import annotations
@@ -124,6 +137,9 @@ BOT_CONFIG_FILES = {
 }
 BOT_CONFIG_PREFIXES = (".github/",)
 SELF_MERGE_ALLOWED_PATHS_ENV = "SELF_MERGE_ALLOWED_PATHS"
+GATE_HELPER_ENV = "BOB_GH_RATE_LIMIT_HELPER"
+FORCE_SELF_MERGE_CHECK_ENV = "BOB_FORCE_SELF_MERGE_CHECK"
+GATE_DEFER_EXIT = 76
 
 
 @dataclass
@@ -160,6 +176,69 @@ def run_gh(args: list[str], timeout: int = 30) -> str:
 
 def get_gh_user() -> str:
     return run_gh(["api", "user", "-q", ".login"]) or ""
+
+
+def _resolve_gate_helper(script_path: Path | None = None) -> str | None:
+    """Resolve the optional GitHub API rate-limit gate helper."""
+
+    explicit_helper = os.environ.get(GATE_HELPER_ENV)
+    if explicit_helper:
+        helper = Path(explicit_helper).expanduser()
+        if not helper.is_file():
+            raise RuntimeError(
+                f"{GATE_HELPER_ENV} points to a missing helper: {helper}"
+            )
+        if not os.access(helper, os.X_OK):
+            raise RuntimeError(f"{GATE_HELPER_ENV} is not executable: {helper}")
+        return str(helper)
+
+    script = (script_path or Path(__file__)).resolve()
+    if len(script.parents) < 3:
+        return None
+
+    # Auto-probe one explicit workspace-sibling location instead of walking
+    # arbitrary ancestors and executing the first matching filename we find.
+    repo_root = script.parents[2]
+    candidate = repo_root.parent / "scripts" / "github-rate-limit-health.sh"
+    if candidate.is_file() and os.access(candidate, os.X_OK):
+        return str(candidate)
+    return None
+
+
+def _maybe_defer_for_rate_limit(
+    *, json_output: bool, script_path: Path | None = None
+) -> int | None:
+    if os.environ.get(FORCE_SELF_MERGE_CHECK_ENV):
+        return None
+
+    gate_helper = _resolve_gate_helper(script_path)
+    if not gate_helper:
+        return None
+
+    try:
+        gate = subprocess.run(
+            [gate_helper, "--gate"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        # Gate itself failed — don't block the real check on a broken helper.
+        return None
+
+    if gate.returncode != GATE_DEFER_EXIT:
+        return None
+
+    msg = (
+        "self-merge-check deferred: GitHub API rate limit over threshold "
+        f"(gate exit {GATE_DEFER_EXIT}). Set {FORCE_SELF_MERGE_CHECK_ENV}=1 "
+        "to override."
+    )
+    if json_output:
+        print(json.dumps({"deferred": True, "reason": msg}))
+    else:
+        print(msg, file=sys.stderr)
+    return GATE_DEFER_EXIT
 
 
 def detect_workspace_repo() -> str:
@@ -1019,58 +1098,10 @@ def main() -> int:
     args = parser.parse_args()
     workspace_repos = _resolve_workspace_repos(args)
 
-    # GraphQL rate-limit gate. self-merge-check fires a multi-page GraphQL
-    # query (reviewThreads + commits + status checks) — easily 50-200
-    # points per invocation. When the GraphQL bucket is over the configured
-    # threshold, defer rather than dig the hole deeper.
-    #
-    # Gate is OPTIONAL — controlled by $BOB_GH_RATE_LIMIT_HELPER or by
-    # finding a sibling `github-rate-limit-health.sh` in the parent
-    # workspace. When the helper isn't present this code path is a no-op,
-    # so gptme-contrib remains standalone-usable.
-    #
-    # Operators who explicitly want to force-check can bypass with
-    # $BOB_FORCE_SELF_MERGE_CHECK=1.
-    if not os.environ.get("BOB_FORCE_SELF_MERGE_CHECK"):
-        gate_helper = os.environ.get("BOB_GH_RATE_LIMIT_HELPER")
-        if not gate_helper:
-            # Probe common locations relative to this script. Walk up to
-            # find a workspace-level helper without requiring an env var.
-            here = os.path.dirname(os.path.abspath(__file__))
-            for _ in range(4):
-                candidate = os.path.join(here, "github-rate-limit-health.sh")
-                if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
-                    gate_helper = candidate
-                    break
-                parent = os.path.dirname(here)
-                if parent == here:
-                    break
-                here = parent
-        if gate_helper and os.access(gate_helper, os.X_OK):
-            try:
-                gate = subprocess.run(
-                    [gate_helper, "--gate"],
-                    capture_output=True,
-                    text=True,
-                    timeout=10,
-                )
-                if gate.returncode == 76:
-                    msg = (
-                        "self-merge-check deferred: GitHub API rate limit "
-                        "over threshold (gate exit 76). Set "
-                        "BOB_FORCE_SELF_MERGE_CHECK=1 to override."
-                    )
-                    if args.json:
-                        print(json.dumps({"deferred": True, "reason": msg}))
-                    else:
-                        print(msg, file=sys.stderr)
-                    return 76
-            except (subprocess.TimeoutExpired, OSError):
-                # Gate itself failed — don't block the real check on a
-                # broken health helper. Fall through to the normal path.
-                pass
-
     try:
+        deferred = _maybe_defer_for_rate_limit(json_output=args.json)
+        if deferred is not None:
+            return deferred
         repo, number = parse_pr_target(args.pr, args.repo, args.number)
         result = evaluate_pr(
             repo,

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -27,13 +27,15 @@ Usage:
     python3 scripts/github/self-merge-check.py --json <pr-url>
 
 Environment:
-    BOB_GH_RATE_LIMIT_HELPER
+    GH_RATE_LIMIT_HELPER
                     Optional explicit path to a GitHub API rate-limit gate
                     helper. When set, it must point to an executable helper or
                     the script exits with code 2 instead of silently bypassing
                     the gate.
-    BOB_FORCE_SELF_MERGE_CHECK
+                    Falls back to BOB_GH_RATE_LIMIT_HELPER for compatibility.
+    FORCE_SELF_MERGE_CHECK
                     Set to bypass the optional GitHub API rate-limit gate.
+                    Falls back to BOB_FORCE_SELF_MERGE_CHECK for compatibility.
     WORKSPACE_REPO  Allowlist of workspace repos (owner/name), comma- or
                     whitespace-separated. Auto-detected single repo used when
                     unset. Set to empty string to disable the cross-repo
@@ -137,8 +139,10 @@ BOT_CONFIG_FILES = {
 }
 BOT_CONFIG_PREFIXES = (".github/",)
 SELF_MERGE_ALLOWED_PATHS_ENV = "SELF_MERGE_ALLOWED_PATHS"
-GATE_HELPER_ENV = "BOB_GH_RATE_LIMIT_HELPER"
-FORCE_SELF_MERGE_CHECK_ENV = "BOB_FORCE_SELF_MERGE_CHECK"
+GATE_HELPER_ENV = "GH_RATE_LIMIT_HELPER"
+GATE_HELPER_ENV_LEGACY = "BOB_GH_RATE_LIMIT_HELPER"
+FORCE_SELF_MERGE_CHECK_ENV = "FORCE_SELF_MERGE_CHECK"
+FORCE_SELF_MERGE_CHECK_ENV_LEGACY = "BOB_FORCE_SELF_MERGE_CHECK"
 GATE_DEFER_EXIT = 76
 
 
@@ -181,7 +185,9 @@ def get_gh_user() -> str:
 def _resolve_gate_helper(script_path: Path | None = None) -> str | None:
     """Resolve the optional GitHub API rate-limit gate helper."""
 
-    explicit_helper = os.environ.get(GATE_HELPER_ENV)
+    explicit_helper = os.environ.get(GATE_HELPER_ENV) or os.environ.get(
+        GATE_HELPER_ENV_LEGACY
+    )
     if explicit_helper:
         helper = Path(explicit_helper).expanduser()
         if not helper.is_file():

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -315,6 +315,50 @@ def test_resolve_gate_helper_rejects_non_executable_explicit_path(
             self_merge_check._resolve_gate_helper()
 
 
+def test_maybe_defer_for_rate_limit_honors_force_self_merge_check(
+    tmp_path: Path,
+) -> None:
+    """FORCE_SELF_MERGE_CHECK=1 should bypass the rate-limit gate entirely."""
+    # Set up a valid helper so the ONLY reason we skip is the force env var
+    helper = tmp_path / "gate-helper.sh"
+    helper.write_text("#!/bin/sh\necho 'rate limited'; exit 76\n")
+    helper.chmod(0o755)
+
+    with patch.dict(
+        "os.environ",
+        {
+            self_merge_check.FORCE_SELF_MERGE_CHECK_ENV: "1",
+            self_merge_check.GATE_HELPER_ENV: str(helper),
+        },
+        clear=True,
+    ):
+        result = self_merge_check._maybe_defer_for_rate_limit(json_output=False)
+
+    # The force bypass means the gate is never run — return None to proceed.
+    assert result is None
+
+
+def test_maybe_defer_for_rate_limit_honors_legacy_force_self_merge_check(
+    tmp_path: Path,
+) -> None:
+    """BOB_FORCE_SELF_MERGE_CHECK=1 (legacy name) should also bypass the gate."""
+    helper = tmp_path / "gate-helper.sh"
+    helper.write_text("#!/bin/sh\necho 'rate limited'; exit 76\n")
+    helper.chmod(0o755)
+
+    with patch.dict(
+        "os.environ",
+        {
+            self_merge_check.FORCE_SELF_MERGE_CHECK_ENV_LEGACY: "1",
+            self_merge_check.GATE_HELPER_ENV: str(helper),
+        },
+        clear=True,
+    ):
+        result = self_merge_check._maybe_defer_for_rate_limit(json_output=False)
+
+    assert result is None
+
+
 def test_fetch_pr_uses_paginated_rest_files_api() -> None:
     pr_metadata = {
         "number": 504,

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -315,6 +315,65 @@ def test_resolve_gate_helper_rejects_non_executable_explicit_path(
             self_merge_check._resolve_gate_helper()
 
 
+def test_resolve_gate_helper_rejects_missing_explicit_path_legacy_env(
+    tmp_path: Path,
+) -> None:
+    """A legacy BOB_GH_RATE_LIMIT_HELPER pointing to a missing file must name the legacy var in its error."""
+    missing = tmp_path / "missing-helper.sh"
+
+    with patch.dict(
+        "os.environ",
+        {self_merge_check.GATE_HELPER_ENV_LEGACY: str(missing)},
+        clear=True,
+    ):
+        with pytest.raises(
+            RuntimeError,
+            match=f"{self_merge_check.GATE_HELPER_ENV_LEGACY} points to a missing helper",
+        ):
+            self_merge_check._resolve_gate_helper()
+
+
+def test_resolve_gate_helper_rejects_non_executable_legacy_env(
+    tmp_path: Path,
+) -> None:
+    """A legacy BOB_GH_RATE_LIMIT_HELPER pointing to a non-executable file must name the legacy var in its error."""
+    non_exec = tmp_path / "not-executable.sh"
+    non_exec.write_text("#!/bin/sh\nexit 0\n")
+    non_exec.chmod(0o644)
+
+    with patch.dict(
+        "os.environ",
+        {self_merge_check.GATE_HELPER_ENV_LEGACY: str(non_exec)},
+        clear=True,
+    ):
+        with pytest.raises(
+            RuntimeError,
+            match=f"{self_merge_check.GATE_HELPER_ENV_LEGACY} is not executable",
+        ):
+            self_merge_check._resolve_gate_helper()
+
+
+def test_resolve_gate_helper_primary_env_takes_precedence_in_error_message(
+    tmp_path: Path,
+) -> None:
+    """When both GATE_HELPER_ENV and BOB_GH_RATE_LIMIT_HELPER are set, only the primary var is named in error."""
+    missing = tmp_path / "missing-helper.sh"
+
+    with patch.dict(
+        "os.environ",
+        {
+            self_merge_check.GATE_HELPER_ENV: str(missing),
+            self_merge_check.GATE_HELPER_ENV_LEGACY: "/some/other/path",
+        },
+        clear=True,
+    ):
+        with pytest.raises(
+            RuntimeError,
+            match=f"{self_merge_check.GATE_HELPER_ENV} points to a missing helper",
+        ):
+            self_merge_check._resolve_gate_helper()
+
+
 def test_maybe_defer_for_rate_limit_honors_force_self_merge_check(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -228,6 +228,76 @@ def test_detect_workspace_repo_falls_back_when_cwd_remote_is_not_github() -> Non
     assert mock_run.call_count == 2
 
 
+def test_resolve_gate_helper_uses_workspace_sibling(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    script_path = (
+        workspace / "gptme-contrib" / "scripts" / "github" / "self-merge-check.py"
+    )
+    helper = workspace / "scripts" / "github-rate-limit-health.sh"
+    helper.parent.mkdir(parents=True)
+    helper.write_text("#!/bin/sh\nexit 0\n")
+    helper.chmod(0o755)
+
+    with patch.dict("os.environ", {}, clear=True):
+        resolved = self_merge_check._resolve_gate_helper(script_path)
+
+    assert resolved == str(helper)
+
+
+def test_resolve_gate_helper_does_not_walk_arbitrary_ancestors(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    script_path = (
+        workspace / "gptme-contrib" / "scripts" / "github" / "self-merge-check.py"
+    )
+    unsafe_helper = workspace / "gptme-contrib" / "github-rate-limit-health.sh"
+    unsafe_helper.parent.mkdir(parents=True)
+    unsafe_helper.write_text("#!/bin/sh\nexit 0\n")
+    unsafe_helper.chmod(0o755)
+
+    with patch.dict("os.environ", {}, clear=True):
+        resolved = self_merge_check._resolve_gate_helper(script_path)
+
+    assert resolved is None
+
+
+def test_resolve_gate_helper_rejects_missing_explicit_path(tmp_path: Path) -> None:
+    missing = tmp_path / "missing-helper.sh"
+
+    with patch.dict(
+        "os.environ",
+        {self_merge_check.GATE_HELPER_ENV: str(missing)},
+        clear=True,
+    ):
+        with pytest.raises(RuntimeError, match="points to a missing helper"):
+            self_merge_check._resolve_gate_helper()
+
+
+def test_main_returns_error_for_missing_explicit_gate_helper(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    missing = tmp_path / "missing-helper.sh"
+
+    with (
+        patch.dict(
+            "os.environ",
+            {self_merge_check.GATE_HELPER_ENV: str(missing)},
+            clear=True,
+        ),
+        patch.object(
+            self_merge_check.sys,
+            "argv",
+            ["self-merge-check.py", "--repo", "gptme/gptme-contrib", "123"],
+        ),
+    ):
+        rc = self_merge_check.main()
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert (
+        f"{self_merge_check.GATE_HELPER_ENV} points to a missing helper" in captured.err
+    )
+
+
 def test_fetch_pr_uses_paginated_rest_files_api() -> None:
     pr_metadata = {
         "number": 504,

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -298,6 +298,23 @@ def test_main_returns_error_for_missing_explicit_gate_helper(
     )
 
 
+def test_resolve_gate_helper_rejects_non_executable_explicit_path(
+    tmp_path: Path,
+) -> None:
+    """A configured GATE_HELPER_ENV pointing to a non-executable file must fail."""
+    non_exec = tmp_path / "not-executable.sh"
+    non_exec.write_text("#!/bin/sh\nexit 0\n")
+    non_exec.chmod(0o644)  # readable but not executable
+
+    with patch.dict(
+        "os.environ",
+        {self_merge_check.GATE_HELPER_ENV: str(non_exec)},
+        clear=True,
+    ):
+        with pytest.raises(RuntimeError, match="is not executable"):
+            self_merge_check._resolve_gate_helper()
+
+
 def test_fetch_pr_uses_paginated_rest_files_api() -> None:
     pr_metadata = {
         "number": 504,


### PR DESCRIPTION
## Summary

Follow-up to #950.

- treat explicit `BOB_GH_RATE_LIMIT_HELPER` as required so missing or non-executable paths fail closed with exit code `2` instead of silently bypassing the gate
- replace the ancestor walk with one explicit workspace-sibling probe for `scripts/github-rate-limit-health.sh`
- document exit code `76` and add regression coverage for the helper resolution paths

## Test plan

- `uv run ruff check scripts/github/self-merge-check.py tests/test_self_merge_check.py`
- `uv run pytest tests/test_self_merge_check.py -q`