### PR TITLE
feat(lessons): parse judge scores from frontmatter for similarity dedupe

### DIFF
--- a/packages/gptme-lessons-extras/src/gptme_lessons_extras/utils/similarity.py
+++ b/packages/gptme-lessons-extras/src/gptme_lessons_extras/utils/similarity.py
@@ -144,13 +144,73 @@ def find_similar_lessons(lesson_dir: Path, threshold: float = 0.7) -> List[List[
     return result
 
 
+def _coerce_numeric_scores(scores_dict: Dict) -> Dict[str, float]:
+    """Extract only numeric score entries, dropping non-numeric ones."""
+    result: Dict[str, float] = {}
+    for key, value in scores_dict.items():
+        if isinstance(value, (int, float)):
+            result[str(key)] = float(value)
+    return result
+
+
 def get_lesson_scores(lesson_info: Dict) -> Dict[str, float]:
     """Extract judge scores from lesson content if available.
 
+    Supports three score formats (checked in order):
+    1. Frontmatter `scores:` block with numeric values per dimension
+    2. Frontmatter `quality:` block with `scores:` sub-block
+    3. LOO-style effectiveness score under `effectiveness:`
+
+    Each score value must be numeric (int or float). Non-numeric values are
+    silently ignored so a malformed single dimension doesn't poison the
+    entire selection.
+
     Returns empty dict if no scores found.
     """
-    # TODO: Parse judge scores from lesson content or metadata
-    # For now, return empty dict (implement when we have score storage)
+    import yaml
+
+    content = lesson_info.get("content", "")
+    if not content:
+        return {}
+
+    # Parse YAML frontmatter
+    fm = {}
+    if content.startswith("---"):
+        parts = content.split("---", 2)
+        if len(parts) >= 3:
+            try:
+                fm = yaml.safe_load(parts[1]) or {}
+            except yaml.YAMLError:
+                pass
+
+    if not isinstance(fm, dict):
+        return {}
+
+    # Format 1: direct `scores:` block
+    scores_raw = fm.get("scores")
+    if isinstance(scores_raw, dict):
+        result = _coerce_numeric_scores(scores_raw)
+        if result:
+            return result
+
+    # Format 2: `quality:` block with nested `scores:`
+    quality_raw = fm.get("quality")
+    if isinstance(quality_raw, dict):
+        scores_raw = quality_raw.get("scores")
+        if isinstance(scores_raw, dict):
+            result = _coerce_numeric_scores(scores_raw)
+            if result:
+                return result
+
+    # Format 3: LOO-style `effectiveness:` with an `average:` or numeric value
+    effectiveness = fm.get("effectiveness")
+    if isinstance(effectiveness, dict):
+        avg = effectiveness.get("average")
+        if isinstance(avg, (int, float)):
+            return {"effectiveness": float(avg)}
+    elif isinstance(effectiveness, (int, float)):
+        return {"effectiveness": float(effectiveness)}
+
     return {}
 
 

--- a/packages/gptme-lessons-extras/src/gptme_lessons_extras/utils/similarity.py
+++ b/packages/gptme-lessons-extras/src/gptme_lessons_extras/utils/similarity.py
@@ -148,7 +148,7 @@ def _coerce_numeric_scores(scores_dict: Dict) -> Dict[str, float]:
     """Extract only numeric score entries, dropping non-numeric ones."""
     result: Dict[str, float] = {}
     for key, value in scores_dict.items():
-        if isinstance(value, (int, float)):
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
             result[str(key)] = float(value)
     return result
 
@@ -174,7 +174,7 @@ def get_lesson_scores(lesson_info: Dict) -> Dict[str, float]:
         return {}
 
     # Parse YAML frontmatter
-    fm = {}
+    fm: dict = {}
     if content.startswith("---"):
         parts = content.split("---", 2)
         if len(parts) >= 3:

--- a/packages/gptme-lessons-extras/src/gptme_lessons_extras/utils/similarity.py
+++ b/packages/gptme-lessons-extras/src/gptme_lessons_extras/utils/similarity.py
@@ -7,7 +7,7 @@ Uses text-based similarity (title + context) for fast comparison.
 
 from difflib import SequenceMatcher
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, TypeGuard
 
 
 def extract_lesson_info(filepath: Path) -> Dict:
@@ -144,11 +144,16 @@ def find_similar_lessons(lesson_dir: Path, threshold: float = 0.7) -> List[List[
     return result
 
 
+def _is_numeric_score_value(value: object) -> TypeGuard[int | float]:
+    """Return True only for real numeric score values, not booleans."""
+    return isinstance(value, int | float) and not isinstance(value, bool)
+
+
 def _coerce_numeric_scores(scores_dict: Dict) -> Dict[str, float]:
     """Extract only numeric score entries, dropping non-numeric ones."""
     result: Dict[str, float] = {}
     for key, value in scores_dict.items():
-        if isinstance(value, (int, float)) and not isinstance(value, bool):
+        if _is_numeric_score_value(value):
             result[str(key)] = float(value)
     return result
 
@@ -206,9 +211,9 @@ def get_lesson_scores(lesson_info: Dict) -> Dict[str, float]:
     effectiveness = fm.get("effectiveness")
     if isinstance(effectiveness, dict):
         avg = effectiveness.get("average")
-        if isinstance(avg, (int, float)):
+        if _is_numeric_score_value(avg):
             return {"effectiveness": float(avg)}
-    elif isinstance(effectiveness, (int, float)):
+    elif _is_numeric_score_value(effectiveness):
         return {"effectiveness": float(effectiveness)}
 
     return {}

--- a/packages/gptme-lessons-extras/tests/test_similarity_scores.py
+++ b/packages/gptme-lessons-extras/tests/test_similarity_scores.py
@@ -1,9 +1,9 @@
 """Tests for lesson similarity score parsing."""
 
-import tempfile
 from pathlib import Path
 from textwrap import dedent
 
+import pytest
 from gptme_lessons_extras.utils.similarity import (
     extract_lesson_info,
     get_lesson_scores,
@@ -152,6 +152,35 @@ class TestGetLessonScores:
         info = _info(fp)
         result = get_lesson_scores(info)
         assert result == {"correctness": 0.80, "brevity": 0.95}
+
+    def test_boolean_values_in_scores_are_ignored(self, tmp_path):
+        """Boolean values in scores are ignored (bool subclass of int trap)."""
+        fp = _write_lesson(
+            tmp_path,
+            "bool-scores.md",
+            """\
+            ---
+            scores:
+              correctness: 0.80
+              is_validated: true
+              brevity: 0.90
+              active: false
+            ---
+            # Boolean-in-Scores Lesson
+
+            ## Context
+            Should not coerce bool to 1.0/0.0.
+            """,
+        )
+        info = _info(fp)
+        result = get_lesson_scores(info)
+        # Only numeric values should survive; bool values are dropped
+        assert result == {"correctness": 0.80, "brevity": 0.90}
+        # Verify average is not skewed by bool -> 1.0 on is_validated
+        avg = sum(result.values()) / len(result)
+        assert avg == pytest.approx(
+            0.85
+        )  # (0.80 + 0.90) / 2, not (0.80 + 1.0 + 0.90 + 0.0) / 4
 
     def test_empty_scores_block_returns_empty(self, tmp_path):
         """A `scores:` block with no numeric children returns empty."""

--- a/packages/gptme-lessons-extras/tests/test_similarity_scores.py
+++ b/packages/gptme-lessons-extras/tests/test_similarity_scores.py
@@ -130,6 +130,43 @@ class TestGetLessonScores:
         result = get_lesson_scores(info)
         assert result == {"effectiveness": 0.65}
 
+    def test_effectiveness_average_boolean_is_ignored(self, tmp_path):
+        """Boolean `effectiveness.average` should not coerce to 1.0/0.0."""
+        fp = _write_lesson(
+            tmp_path,
+            "eff-bool-average.md",
+            """\
+            ---
+            effectiveness:
+              average: true
+            ---
+            # Effective Bool Average
+
+            ## Context
+            Invalid numeric signal.
+            """,
+        )
+        info = _info(fp)
+        assert get_lesson_scores(info) == {}
+
+    def test_effectiveness_direct_boolean_is_ignored(self, tmp_path):
+        """Boolean `effectiveness` should not coerce to 1.0/0.0."""
+        fp = _write_lesson(
+            tmp_path,
+            "eff-bool-direct.md",
+            """\
+            ---
+            effectiveness: false
+            ---
+            # Effective Bool Direct
+
+            ## Context
+            Invalid numeric signal.
+            """,
+        )
+        info = _info(fp)
+        assert get_lesson_scores(info) == {}
+
     def test_non_numeric_scores_are_ignored(self, tmp_path):
         """Non-numeric score values are dropped, not treated as zero."""
         fp = _write_lesson(

--- a/packages/gptme-lessons-extras/tests/test_similarity_scores.py
+++ b/packages/gptme-lessons-extras/tests/test_similarity_scores.py
@@ -1,0 +1,329 @@
+"""Tests for lesson similarity score parsing."""
+
+import tempfile
+from pathlib import Path
+from textwrap import dedent
+
+from gptme_lessons_extras.utils.similarity import (
+    extract_lesson_info,
+    get_lesson_scores,
+    select_best_lesson,
+)
+
+
+def _write_lesson(tmp_path: Path, filename: str, content: str) -> Path:
+    """Write a lesson file and return its path."""
+    filepath = tmp_path / filename
+    filepath.write_text(dedent(content))
+    return filepath
+
+
+def _info(filepath: Path) -> dict:
+    """Extract lesson info from a filepath."""
+    info = extract_lesson_info(filepath)
+    return info
+
+
+class TestGetLessonScores:
+    """Tests for get_lesson_scores() across supported score formats."""
+
+    def test_no_scores_in_plain_markdown(self, tmp_path):
+        """Returns empty dict when no scores are present."""
+        fp = _write_lesson(
+            tmp_path,
+            "plain.md",
+            """\
+            # Plain Lesson
+
+            ## Context
+            No scores here.
+
+            ## Rule
+            Do the right thing.
+            """,
+        )
+        info = _info(fp)
+        assert get_lesson_scores(info) == {}
+
+    def test_direct_scores_block(self, tmp_path):
+        """Parses a top-level `scores:` frontmatter block."""
+        fp = _write_lesson(
+            tmp_path,
+            "scored.md",
+            """\
+            ---
+            scores:
+              correctness: 0.85
+              specificity: 0.70
+              brevity: 0.90
+            ---
+            # Scored Lesson
+
+            ## Context
+            Testing.
+            """,
+        )
+        info = _info(fp)
+        result = get_lesson_scores(info)
+        assert result == {"correctness": 0.85, "specificity": 0.70, "brevity": 0.90}
+
+    def test_quality_nested_scores_block(self, tmp_path):
+        """Parses a `quality.scores:` nested frontmatter block."""
+        fp = _write_lesson(
+            tmp_path,
+            "quality-scored.md",
+            """\
+            ---
+            quality:
+              scores:
+                correctness: 0.92
+                evidence_use: 0.78
+              other: meta
+            ---
+            # Quality-Scored Lesson
+
+            ## Context
+            Nested.
+            """,
+        )
+        info = _info(fp)
+        result = get_lesson_scores(info)
+        assert result == {"correctness": 0.92, "evidence_use": 0.78}
+
+    def test_effectiveness_average(self, tmp_path):
+        """Parses an `effectiveness.average:` LOO-style frontmatter block."""
+        fp = _write_lesson(
+            tmp_path,
+            "effective.md",
+            """\
+            ---
+            effectiveness:
+              average: 0.76
+              samples: 42
+            ---
+            # Effective Lesson
+
+            ## Context
+            LOO-style.
+            """,
+        )
+        info = _info(fp)
+        result = get_lesson_scores(info)
+        assert result == {"effectiveness": 0.76}
+
+    def test_effectiveness_direct_numeric(self, tmp_path):
+        """Parses an `effectiveness:` direct numeric frontmatter value."""
+        fp = _write_lesson(
+            tmp_path,
+            "eff-num.md",
+            """\
+            ---
+            effectiveness: 0.65
+            ---
+            # Effective Num
+
+            ## Context
+            Direct.
+            """,
+        )
+        info = _info(fp)
+        result = get_lesson_scores(info)
+        assert result == {"effectiveness": 0.65}
+
+    def test_non_numeric_scores_are_ignored(self, tmp_path):
+        """Non-numeric score values are dropped, not treated as zero."""
+        fp = _write_lesson(
+            tmp_path,
+            "mixed.md",
+            """\
+            ---
+            scores:
+              correctness: 0.80
+              rationale: "good"
+              specificity: high
+              brevity: 0.95
+            ---
+            # Mixed Lesson
+
+            ## Context
+            Mixed types.
+            """,
+        )
+        info = _info(fp)
+        result = get_lesson_scores(info)
+        assert result == {"correctness": 0.80, "brevity": 0.95}
+
+    def test_empty_scores_block_returns_empty(self, tmp_path):
+        """A `scores:` block with no numeric children returns empty."""
+        fp = _write_lesson(
+            tmp_path,
+            "empty-scores.md",
+            """\
+            ---
+            scores:
+              comment: "all qualitative"
+            ---
+            # Empty Scores
+
+            ## Context
+            No numerics.
+            """,
+        )
+        info = _info(fp)
+        assert get_lesson_scores(info) == {}
+
+    def test_malformed_frontmatter_returns_empty(self, tmp_path):
+        """Malformed YAML frontmatter returns empty, does not crash."""
+        fp = _write_lesson(
+            tmp_path,
+            "malformed.md",
+            """\
+            ---
+            scores: [unclosed
+            ---
+            # Broken
+            """,
+        )
+        info = _info(fp)
+        # Should not raise
+        result = get_lesson_scores(info)
+        assert result == {}
+
+    def test_no_frontmatter_returns_empty(self, tmp_path):
+        """Content with no YAML frontmatter at all returns empty."""
+        fp = _write_lesson(
+            tmp_path,
+            "no-fm.md",
+            """\
+            # No Frontmatter
+
+            Just content.
+            """,
+        )
+        info = _info(fp)
+        assert get_lesson_scores(info) == {}
+
+    def test_integer_scores_coerced_to_float(self, tmp_path):
+        """Integer score values are coerced to float."""
+        fp = _write_lesson(
+            tmp_path,
+            "ints.md",
+            """\
+            ---
+            scores:
+              correctness: 1
+              brevity: 0
+            ---
+            # Int Scores
+            """,
+        )
+        info = _info(fp)
+        result = get_lesson_scores(info)
+        assert result == {"correctness": 1.0, "brevity": 0.0}
+        assert isinstance(result["correctness"], float)
+
+
+class TestSelectBestLesson:
+    """Tests for select_best_lesson() with and without scores."""
+
+    def test_selects_highest_scored_lesson(self, tmp_path):
+        """When multiple lessons have scores, the highest average wins."""
+        scored_content = """\
+            ---
+            scores:
+              correctness: 0.95
+              brevity: 0.90
+            ---
+            # Best
+
+            ## Context
+            High score.
+            """
+        fp_best = _write_lesson(tmp_path, "best.md", scored_content)
+
+        mid_content = """\
+            ---
+            scores:
+              correctness: 0.70
+              brevity: 0.60
+            ---
+            # Mid
+
+            ## Context
+            Medium score.
+            """
+        fp_mid = _write_lesson(tmp_path, "mid.md", mid_content)
+
+        cluster = [_info(fp_mid), _info(fp_best)]
+        chosen = select_best_lesson(cluster)
+        assert chosen["title"] == "Best"
+
+    def test_falls_back_to_mtime_when_no_scores(self, tmp_path):
+        """When no lesson has scores, falls back to most recent mtime."""
+        older = _write_lesson(
+            tmp_path,
+            "older.md",
+            """\
+            # Older
+            ## Context
+            No scores.
+            """,
+        )
+        newer = _write_lesson(
+            tmp_path,
+            "newer_lesson.md",
+            """\
+            # Newer
+            ## Context
+            No scores.
+            """,
+        )
+        # Ensure mtime ordering
+        newer.touch()  # touch to make newer the most recent
+
+        cluster = [_info(older), _info(newer)]
+        chosen = select_best_lesson(cluster)
+        assert chosen["title"] == "Newer"
+
+    def test_score_beats_mtime(self, tmp_path):
+        """A lower-mtime lesson with a high score beats a newer no-score lesson."""
+        scored_content = """\
+            ---
+            scores:
+              correctness: 0.99
+            ---
+            # Scored
+            ## Context
+            Has score.
+            """
+        fp_scored = _write_lesson(tmp_path, "scored.md", scored_content)
+
+        fp_unscored = _write_lesson(
+            tmp_path,
+            "unscored_newer.md",
+            """\
+            # Unscored But Newer
+            ## Context
+            No scores.
+            """,
+        )
+        fp_unscored.touch()  # make it newer
+
+        cluster = [_info(fp_unscored), _info(fp_scored)]
+        chosen = select_best_lesson(cluster)
+        assert chosen["title"] == "Scored"
+
+    def test_single_lesson_cluster(self, tmp_path):
+        """Cluster with a single lesson returns it directly."""
+        fp = _write_lesson(
+            tmp_path,
+            "solo.md",
+            """\
+            # Solo
+            ## Context
+            Alone.
+            """,
+        )
+        cluster = [_info(fp)]
+        chosen = select_best_lesson(cluster)
+        assert chosen["title"] == "Solo"


### PR DESCRIPTION
## What
Implements the TODO in `get_lesson_scores()` so the similarity deduplication path in `select_best_lesson()` can prefer higher-scored lessons over newer-unscored ones.

## How
`get_lesson_scores()` now parses three frontmatter score formats (checked in order):
1. Direct `scores:` block — per-dimension numeric values (from LLM-as-judge `llm_judge_score`)
2. Nested `quality.scores:` block — same shape, one level deeper
3. LOO-style `effectiveness:` — `average:` sub-field or direct numeric

Non-numeric score values are silently dropped (not treated as zero). `select_best_lesson()`'s existing score-preferred logic is now live instead of always falling through to mtime.

## Why
When duplicate/near-duplicate lessons exist, `newest file wins` is a weak default — it can keep a recently generated lower-quality lesson over an older lesson with better judge evidence. The similarity dedupe helper had the right policy shape but no real quality signal.

## Verification
- 14 new tests in `test_similarity_scores.py` covering all three formats plus edge cases (mixed types, malformed frontmatter, empty scores, integer-to-float coercion)
- Full suite: `uv run pytest packages/gptme-lessons-extras/tests/ -v` — 53 passed
- No regression: existing similarity tests (discovery, generate, validate) all green