### PR TITLE
refactor(discord): scope tool policy per request

### DIFF
--- a/scripts/discord/discord_bot.py
+++ b/scripts/discord/discord_bot.py
@@ -56,6 +56,7 @@ from gptme.telemetry import init_telemetry, shutdown_telemetry
 from gptme.tools import (
     ToolSpec,
     ToolUse,
+    clear_tools,
     get_tools,
     init_tools,
 )
@@ -96,10 +97,16 @@ conversation_tracker = ConversationTracker(state_dir)
 metrics = MetricsCollector()
 
 # Basic tools only for testing
-tool_allowlist = frozenset(["read", "save", "append", "patch", "shell"])
-# tool_allowlist = ["read", "save", "append", "patch", "shell", "ipython", "browser"]
+DEFAULT_TOOL_ALLOWLIST: tuple[str, ...] = (
+    "read",
+    "save",
+    "append",
+    "patch",
+    "shell",
+)
+# DEFAULT_TOOL_ALLOWLIST = ("read", "save", "append", "patch", "shell", "ipython", "browser")
 
-tools: list[ToolSpec] = []
+default_tools: list[ToolSpec] = []
 
 # Load environment variables
 env_files = [".env", ".env.discord"]
@@ -231,6 +238,7 @@ async def async_step(
     log: Log,
     channel_id: int,
     channel: discord.abc.Messageable,
+    tool_allowlist: tuple[str, ...],
 ) -> AsyncGenerator[Message, None]:
     """Async wrapper around gptme.chat.step that supports multiple tool executions."""
 
@@ -267,9 +275,11 @@ async def async_step(
 
     while True:
         try:
-            # init tools in async thread with copied context
+            # Rebuild the tool context for this request so narrower allowlists
+            # do not inherit tools from a broader startup context.
             await loop.run_in_executor(
-                None, lambda: ctx.run(init_tools, list(tool_allowlist))
+                None,
+                lambda: ctx.run(load_tools_for_allowlist, tool_allowlist),
             )
 
             # debug
@@ -373,9 +383,35 @@ def get_settings(channel_id: ChannelID) -> ChannelSettings:
     return channel_settings[channel_id]
 
 
-def get_conversation(channel_id: ChannelID) -> Log:
+def load_tools_for_allowlist(tool_allowlist: tuple[str, ...]) -> list[ToolSpec]:
+    """Return the exact tool set for an allowlist in the current context."""
+    clear_tools()
+    init_tools(list(tool_allowlist))
+    loaded_tools = list(get_tools())
+    if not loaded_tools:
+        raise RuntimeError(
+            f"No tools loaded for allowlist: {', '.join(tool_allowlist) or '(empty)'}"
+        )
+    return loaded_tools
+
+
+def get_prompt_tools_for_allowlist(tool_allowlist: tuple[str, ...]) -> list[ToolSpec]:
+    """Resolve prompt tool descriptions without mutating the caller's context."""
+    if default_tools and tool_allowlist == DEFAULT_TOOL_ALLOWLIST:
+        return list(default_tools)
+
+    ctx = contextvars.copy_context()
+    return ctx.run(load_tools_for_allowlist, tool_allowlist)
+
+
+def is_trusted_user_name(user_name: str) -> bool:
+    """Return whether a Discord username currently has full bot access."""
+    return user_name.lower() in {"erikbjare"}
+
+
+def get_conversation(channel_id: ChannelID, prompt_tools: list[ToolSpec]) -> Log:
     """Get or create a conversation for a channel."""
-    initial_msgs = get_prompt(tools=tools)
+    initial_msgs = get_prompt(tools=prompt_tools)
     assert initial_msgs
 
     # Initialize a new conversation
@@ -793,7 +829,11 @@ async def status(ctx: commands.Context) -> None:
         assistant_msgs = sum(1 for m in log if m.role == "assistant")
 
         # Get current tools
-        tools_str = ", ".join(t.name for t in tools) if tools else "No tools loaded"
+        tools_str = (
+            ", ".join(t.name for t in default_tools)
+            if default_tools
+            else "No tools loaded"
+        )
 
         await ctx.send(
             f"Conversation status:\n"
@@ -924,6 +964,7 @@ async def handle_new_dm(message: discord.Message) -> None:
 async def process_conversation_step(
     message: discord.Message,
     channel_id: int,
+    tool_allowlist: tuple[str, ...],
     current_response: discord.Message | None = None,
 ) -> tuple[discord.Message | None, bool]:
     """Process a single conversation step."""
@@ -931,7 +972,10 @@ async def process_conversation_step(
     accumulated_content = ""
 
     async for msg in async_step(
-        conversations[channel_id].log, channel_id, message.channel
+        conversations[channel_id].log,
+        channel_id,
+        message.channel,
+        tool_allowlist,
     ):
         logger.info(f"Processing response msg: {msg}")
         (
@@ -983,7 +1027,7 @@ async def on_message(message: discord.Message) -> None:
         return
 
     # Only allow trusted users (temporary security measure)
-    is_trusted = message.author.name.lower() in ["erikbjare"]
+    is_trusted = is_trusted_user_name(message.author.name)
     if not is_trusted:
         if is_mentioned:
             await message.channel.send(
@@ -1001,9 +1045,12 @@ async def on_message(message: discord.Message) -> None:
         content = content.replace(f"<@{bot.user.id}>", "").strip()
         content = content.replace(f"<@!{bot.user.id}>", "").strip()
 
+    message_tool_allowlist = DEFAULT_TOOL_ALLOWLIST
+    prompt_tools = get_prompt_tools_for_allowlist(message_tool_allowlist)
+
     # Initialize conversation
     channel_id = message.channel.id
-    log = get_conversation(channel_id)
+    log = get_conversation(channel_id, prompt_tools)
     logger.info(f"Lenght of log: {len(log)}")
 
     # Check if this is a new DM conversation by looking at message history
@@ -1034,7 +1081,10 @@ async def on_message(message: discord.Message) -> None:
         current_response = None
         async with message.channel.typing():
             current_response, had_error = await process_conversation_step(
-                message, channel_id, current_response
+                message,
+                channel_id,
+                message_tool_allowlist,
+                current_response,
             )
 
         # Update reaction based on result
@@ -1087,27 +1137,28 @@ def main() -> None:
 
     # Initialize gptme
     try:
-        # Restrict tools
-        # TODO: do this in a non-global way
-        global tools
+        global default_tools
 
-        # Initialize gptme and tools
+        # Bootstrap the default tool context; per-request tool policies are
+        # rebuilt in async_step() so future trust tiers can narrow tools safely.
         init(
             model=MODEL,
             interactive=False,
-            tool_allowlist=list(tool_allowlist),
+            tool_allowlist=list(DEFAULT_TOOL_ALLOWLIST),
             tool_format="markdown",
         )
-        tools = init_tools(list(tool_allowlist))
-        tools = get_tools()
-        if not tools:
+        default_tools = list(get_tools())
+        if not default_tools:
             logger.error("No tools loaded in gptme")
             return
         logger.info(
-            f"Loaded {len(tools)} gptme tools: {', '.join(t.name for t in tools)}"
+            "Loaded %d gptme tools: %s",
+            len(default_tools),
+            ", ".join(t.name for t in default_tools),
         )
         logger.info(
-            f"Successfully initialized gptme with tools ({', '.join(tool_allowlist)})"
+            "Successfully initialized gptme with tools (%s)",
+            ", ".join(DEFAULT_TOOL_ALLOWLIST),
         )
     except Exception as e:
         logger.error(f"Failed to initialize gptme tools: {e}")

--- a/scripts/discord/discord_bot.py
+++ b/scripts/discord/discord_bot.py
@@ -273,15 +273,15 @@ async def async_step(
     # This is needed because run_in_executor doesn't propagate ContextVars to thread pool workers
     ctx = contextvars.copy_context()
 
+    # Rebuild the tool context once per request so narrower allowlists do not
+    # inherit tools from a broader startup context.
+    await loop.run_in_executor(
+        None,
+        lambda: ctx.run(load_tools_for_allowlist, tool_allowlist),
+    )
+
     while True:
         try:
-            # Rebuild the tool context for this request so narrower allowlists
-            # do not inherit tools from a broader startup context.
-            await loop.run_in_executor(
-                None,
-                lambda: ctx.run(load_tools_for_allowlist, tool_allowlist),
-            )
-
             # debug
             # print("\n---\n".join([f"{msg.role} - {msg.content[:20]}..." for msg in current_log]))
 

--- a/scripts/discord/discord_bot.py
+++ b/scripts/discord/discord_bot.py
@@ -431,7 +431,8 @@ def get_conversation(channel_id: ChannelID, prompt_tools: list[ToolSpec]) -> Log
         msgs.insert(0, msg)
 
     assert msgs
-    return Log(msgs)
+    conversations[channel_id].log = Log(msgs)
+    return conversations[channel_id].log
 
 
 def check_rate_limit(

--- a/scripts/discord/discord_bot.py
+++ b/scripts/discord/discord_bot.py
@@ -404,6 +404,20 @@ def get_prompt_tools_for_allowlist(tool_allowlist: tuple[str, ...]) -> list[Tool
     return ctx.run(load_tools_for_allowlist, tool_allowlist)
 
 
+async def get_prompt_tools_for_allowlist_async(
+    tool_allowlist: tuple[str, ...],
+) -> list[ToolSpec]:
+    """Resolve prompt tool descriptions without blocking the event loop."""
+    if default_tools and tool_allowlist == DEFAULT_TOOL_ALLOWLIST:
+        return list(default_tools)
+
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(
+        None,
+        lambda: get_prompt_tools_for_allowlist(tool_allowlist),
+    )
+
+
 def is_trusted_user_name(user_name: str) -> bool:
     """Return whether a Discord username currently has full bot access."""
     return user_name.lower() in {"erikbjare"}
@@ -1047,7 +1061,7 @@ async def on_message(message: discord.Message) -> None:
         content = content.replace(f"<@!{bot.user.id}>", "").strip()
 
     message_tool_allowlist = DEFAULT_TOOL_ALLOWLIST
-    prompt_tools = get_prompt_tools_for_allowlist(message_tool_allowlist)
+    prompt_tools = await get_prompt_tools_for_allowlist_async(message_tool_allowlist)
 
     # Initialize conversation
     channel_id = message.channel.id

--- a/scripts/discord/test_discord_tool_policy.py
+++ b/scripts/discord/test_discord_tool_policy.py
@@ -148,7 +148,7 @@ def test_get_prompt_tools_uses_default_snapshot_without_mutating_context(
     assert events == []
 
 
-def test_get_conversation_refreshes_system_prompt_from_explicit_tools(
+def test_get_conversation_refreshes_stored_system_prompt_from_explicit_tools(
     tmp_path: Path,
 ) -> None:
     (
@@ -169,4 +169,5 @@ def test_get_conversation_refreshes_system_prompt_from_explicit_tools(
 
     assert first_log.messages[0].content == "tools:read,shell"
     assert second_log.messages[0].content == "tools:read"
+    assert _ns["conversations"][42].log.messages[0].content == "tools:read"
     assert captured_prompts == [["read", "shell"], ["read"]]

--- a/scripts/discord/test_discord_tool_policy.py
+++ b/scripts/discord/test_discord_tool_policy.py
@@ -8,6 +8,7 @@ import contextvars
 import threading
 from pathlib import Path
 from types import SimpleNamespace
+from typing import AsyncGenerator
 
 import pytest
 
@@ -17,6 +18,18 @@ SCRIPT_PATH = Path(__file__).with_name("discord_bot.py")
 class FakeLog:
     def __init__(self, messages):
         self.messages = list(messages)
+
+    def __len__(self):
+        return len(self.messages)
+
+    def __getitem__(self, index):
+        return self.messages[index]
+
+    def append(self, message):
+        return type(self)(self.messages + [message])
+
+    def replace(self, *, messages):
+        return type(self)(messages)
 
 
 class FakeLogManager:
@@ -122,6 +135,75 @@ def _load_helpers(tmp_path: Path):
     )
 
 
+def _load_async_step(tmp_path: Path):
+    tree = ast.parse(SCRIPT_PATH.read_text(), filename=str(SCRIPT_PATH))
+    async_step_node = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "async_step"
+    )
+    module = ast.Module(body=[async_step_node], type_ignores=[])
+
+    step_calls: list[list[str]] = []
+    tool_load_calls: list[tuple[str, ...]] = []
+    completion_events: list[dict[str, object]] = []
+
+    class FakeOperation:
+        def complete(self, **kwargs) -> None:
+            completion_events.append(kwargs)
+
+    class FakeMetrics:
+        def start_operation(self, *_args) -> FakeOperation:
+            return FakeOperation()
+
+    class FakeToolUse:
+        @staticmethod
+        def iter_from_content(content: str):
+            if content == "tool:run":
+                return [SimpleNamespace(is_runnable=True)]
+            return []
+
+    class FakeContext:
+        def run(self, fn, *args):
+            return fn(*args)
+
+    class FakeLogger:
+        def exception(self, _message: str) -> None:
+            return None
+
+    def fake_step(current_log, **_kwargs):
+        step_calls.append([msg.content for msg in current_log.messages])
+        if len(step_calls) == 1:
+            return [SimpleNamespace(role="assistant", content="tool:run")]
+        return [SimpleNamespace(role="assistant", content="done")]
+
+    async def fake_fetch_discord_history(_channel) -> str:
+        return ""
+
+    def fake_load_tools_for_allowlist(tool_allowlist: tuple[str, ...]):
+        tool_load_calls.append(tool_allowlist)
+        return [SimpleNamespace(name=name) for name in tool_allowlist]
+
+    namespace = {
+        "AsyncGenerator": AsyncGenerator,
+        "Log": FakeLog,
+        "Message": SimpleNamespace,
+        "ToolUse": FakeToolUse,
+        "asyncio": asyncio,
+        "contextvars": SimpleNamespace(copy_context=lambda: FakeContext()),
+        "discord": SimpleNamespace(abc=SimpleNamespace(Messageable=object)),
+        "fetch_discord_history": fake_fetch_discord_history,
+        "get_settings": lambda _channel_id: SimpleNamespace(model="test-model"),
+        "load_tools_for_allowlist": fake_load_tools_for_allowlist,
+        "logger": FakeLogger(),
+        "metrics": FakeMetrics(),
+        "step": fake_step,
+        "workspace_root": tmp_path,
+    }
+    exec(compile(module, str(SCRIPT_PATH), "exec"), namespace)
+    return namespace["async_step"], step_calls, tool_load_calls, completion_events
+
+
 def test_load_tools_for_allowlist_resets_context_before_init(tmp_path: Path) -> None:
     (
         load_tools_for_allowlist,
@@ -217,3 +299,26 @@ async def test_get_prompt_tools_async_offloads_non_default_allowlist(
     assert events == ["clear", ("init", ("read",)), "get"]
     assert tool_threads
     assert any(thread_id != main_thread_id for thread_id in tool_threads)
+
+
+@pytest.mark.asyncio
+async def test_async_step_reloads_tools_once_per_request(tmp_path: Path) -> None:
+    async_step, step_calls, tool_load_calls, completion_events = _load_async_step(
+        tmp_path
+    )
+
+    log = FakeLog([SimpleNamespace(role="user", content="hello")])
+    messages = [
+        msg
+        async for msg in async_step(
+            log,
+            42,
+            SimpleNamespace(),
+            ("read", "shell"),
+        )
+    ]
+
+    assert [msg.content for msg in messages] == ["tool:run", "done"]
+    assert step_calls == [["hello"], ["hello", "tool:run"]]
+    assert tool_load_calls == [("read", "shell")]
+    assert completion_events == [{"success": True}]

--- a/scripts/discord/test_discord_tool_policy.py
+++ b/scripts/discord/test_discord_tool_policy.py
@@ -1,0 +1,172 @@
+"""Regression tests for Discord bot tool-policy helpers."""
+
+from __future__ import annotations
+
+import ast
+import contextvars
+from pathlib import Path
+from types import SimpleNamespace
+
+SCRIPT_PATH = Path(__file__).with_name("discord_bot.py")
+
+
+class FakeLog:
+    def __init__(self, messages):
+        self.messages = list(messages)
+
+
+class FakeLogManager:
+    def __init__(self, messages):
+        self.log = FakeLog(messages)
+
+    @classmethod
+    def load(cls, _logpath, initial_msgs, create=False):
+        assert create is True
+        return cls(initial_msgs)
+
+
+class FakeLogger:
+    def info(self, _message: str) -> None:
+        return None
+
+
+def _load_helpers(tmp_path: Path):
+    tree = ast.parse(SCRIPT_PATH.read_text(), filename=str(SCRIPT_PATH))
+    selected_nodes: list[ast.stmt] = []
+    names = {
+        "DEFAULT_TOOL_ALLOWLIST",
+        "default_tools",
+        "load_tools_for_allowlist",
+        "get_prompt_tools_for_allowlist",
+        "get_conversation",
+    }
+
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id in names
+            for target in node.targets
+        ):
+            selected_nodes.append(node)
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            if node.target.id in names:
+                selected_nodes.append(node)
+        elif isinstance(node, ast.FunctionDef) and node.name in names:
+            selected_nodes.append(node)
+
+    module = ast.Module(body=selected_nodes, type_ignores=[])
+
+    events: list[object] = []
+    current_tools: list[SimpleNamespace] = []
+    captured_prompts: list[list[str]] = []
+
+    def fake_clear_tools() -> None:
+        events.append("clear")
+        current_tools.clear()
+
+    def fake_init_tools(allowlist: list[str]) -> None:
+        events.append(("init", tuple(allowlist)))
+        current_tools[:] = [SimpleNamespace(name=name) for name in allowlist]
+
+    def fake_get_tools() -> list[SimpleNamespace]:
+        events.append("get")
+        return list(current_tools)
+
+    def fake_get_prompt(*, tools):
+        captured_prompts.append([tool.name for tool in tools])
+        return [
+            SimpleNamespace(
+                role="system",
+                content="tools:" + ",".join(tool.name for tool in tools),
+            )
+        ]
+
+    namespace = {
+        "ChannelID": int,
+        "Log": FakeLog,
+        "LogManager": FakeLogManager,
+        "ToolSpec": object,
+        "contextvars": contextvars,
+        "clear_tools": fake_clear_tools,
+        "copy": lambda items: list(items),
+        "conversations": {},
+        "default_tools": [],
+        "get_prompt": fake_get_prompt,
+        "get_tools": fake_get_tools,
+        "init_tools": fake_init_tools,
+        "logger": FakeLogger(),
+        "logsdir": tmp_path,
+    }
+    exec(compile(module, str(SCRIPT_PATH), "exec"), namespace)
+    return (
+        namespace["load_tools_for_allowlist"],
+        namespace["get_prompt_tools_for_allowlist"],
+        namespace["get_conversation"],
+        namespace["DEFAULT_TOOL_ALLOWLIST"],
+        namespace,
+        events,
+        captured_prompts,
+    )
+
+
+def test_load_tools_for_allowlist_resets_context_before_init(tmp_path: Path) -> None:
+    (
+        load_tools_for_allowlist,
+        _prompt_tools,
+        _get_conversation,
+        _default_allowlist,
+        _ns,
+        events,
+        _captured,
+    ) = _load_helpers(tmp_path)
+
+    tools = load_tools_for_allowlist(("read", "shell"))
+
+    assert [tool.name for tool in tools] == ["read", "shell"]
+    assert events == ["clear", ("init", ("read", "shell")), "get"]
+
+
+def test_get_prompt_tools_uses_default_snapshot_without_mutating_context(
+    tmp_path: Path,
+) -> None:
+    (
+        _load_tools,
+        get_prompt_tools,
+        _get_conversation,
+        default_allowlist,
+        namespace,
+        events,
+        _captured,
+    ) = _load_helpers(tmp_path)
+    namespace["default_tools"] = [
+        SimpleNamespace(name="read"),
+        SimpleNamespace(name="shell"),
+    ]
+
+    prompt_tools = get_prompt_tools(default_allowlist)
+
+    assert [tool.name for tool in prompt_tools] == ["read", "shell"]
+    assert events == []
+
+
+def test_get_conversation_refreshes_system_prompt_from_explicit_tools(
+    tmp_path: Path,
+) -> None:
+    (
+        _load_tools,
+        _prompt_tools,
+        get_conversation,
+        _default_allowlist,
+        _ns,
+        _events,
+        captured_prompts,
+    ) = _load_helpers(tmp_path)
+
+    first_tools = [SimpleNamespace(name="read"), SimpleNamespace(name="shell")]
+    second_tools = [SimpleNamespace(name="read")]
+
+    first_log = get_conversation(42, first_tools)
+    second_log = get_conversation(42, second_tools)
+
+    assert first_log.messages[0].content == "tools:read,shell"
+    assert second_log.messages[0].content == "tools:read"
+    assert captured_prompts == [["read", "shell"], ["read"]]

--- a/scripts/discord/test_discord_tool_policy.py
+++ b/scripts/discord/test_discord_tool_policy.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 import ast
+import asyncio
 import contextvars
+import threading
 from pathlib import Path
 from types import SimpleNamespace
+
+import pytest
 
 SCRIPT_PATH = Path(__file__).with_name("discord_bot.py")
 
@@ -38,6 +42,7 @@ def _load_helpers(tmp_path: Path):
         "default_tools",
         "load_tools_for_allowlist",
         "get_prompt_tools_for_allowlist",
+        "get_prompt_tools_for_allowlist_async",
         "get_conversation",
     }
 
@@ -52,23 +57,29 @@ def _load_helpers(tmp_path: Path):
                 selected_nodes.append(node)
         elif isinstance(node, ast.FunctionDef) and node.name in names:
             selected_nodes.append(node)
+        elif isinstance(node, ast.AsyncFunctionDef) and node.name in names:
+            selected_nodes.append(node)
 
     module = ast.Module(body=selected_nodes, type_ignores=[])
 
     events: list[object] = []
     current_tools: list[SimpleNamespace] = []
     captured_prompts: list[list[str]] = []
+    tool_threads: list[int] = []
 
     def fake_clear_tools() -> None:
         events.append("clear")
+        tool_threads.append(threading.get_ident())
         current_tools.clear()
 
     def fake_init_tools(allowlist: list[str]) -> None:
         events.append(("init", tuple(allowlist)))
+        tool_threads.append(threading.get_ident())
         current_tools[:] = [SimpleNamespace(name=name) for name in allowlist]
 
     def fake_get_tools() -> list[SimpleNamespace]:
         events.append("get")
+        tool_threads.append(threading.get_ident())
         return list(current_tools)
 
     def fake_get_prompt(*, tools):
@@ -85,6 +96,7 @@ def _load_helpers(tmp_path: Path):
         "Log": FakeLog,
         "LogManager": FakeLogManager,
         "ToolSpec": object,
+        "asyncio": asyncio,
         "contextvars": contextvars,
         "clear_tools": fake_clear_tools,
         "copy": lambda items: list(items),
@@ -100,11 +112,13 @@ def _load_helpers(tmp_path: Path):
     return (
         namespace["load_tools_for_allowlist"],
         namespace["get_prompt_tools_for_allowlist"],
+        namespace["get_prompt_tools_for_allowlist_async"],
         namespace["get_conversation"],
         namespace["DEFAULT_TOOL_ALLOWLIST"],
         namespace,
         events,
         captured_prompts,
+        tool_threads,
     )
 
 
@@ -112,11 +126,13 @@ def test_load_tools_for_allowlist_resets_context_before_init(tmp_path: Path) -> 
     (
         load_tools_for_allowlist,
         _prompt_tools,
+        _prompt_tools_async,
         _get_conversation,
         _default_allowlist,
         _ns,
         events,
         _captured,
+        _tool_threads,
     ) = _load_helpers(tmp_path)
 
     tools = load_tools_for_allowlist(("read", "shell"))
@@ -131,11 +147,13 @@ def test_get_prompt_tools_uses_default_snapshot_without_mutating_context(
     (
         _load_tools,
         get_prompt_tools,
+        _prompt_tools_async,
         _get_conversation,
         default_allowlist,
         namespace,
         events,
         _captured,
+        _tool_threads,
     ) = _load_helpers(tmp_path)
     namespace["default_tools"] = [
         SimpleNamespace(name="read"),
@@ -154,11 +172,13 @@ def test_get_conversation_refreshes_stored_system_prompt_from_explicit_tools(
     (
         _load_tools,
         _prompt_tools,
+        _prompt_tools_async,
         get_conversation,
         _default_allowlist,
         _ns,
         _events,
         captured_prompts,
+        _tool_threads,
     ) = _load_helpers(tmp_path)
 
     first_tools = [SimpleNamespace(name="read"), SimpleNamespace(name="shell")]
@@ -171,3 +191,29 @@ def test_get_conversation_refreshes_stored_system_prompt_from_explicit_tools(
     assert second_log.messages[0].content == "tools:read"
     assert _ns["conversations"][42].log.messages[0].content == "tools:read"
     assert captured_prompts == [["read", "shell"], ["read"]]
+
+
+@pytest.mark.asyncio
+async def test_get_prompt_tools_async_offloads_non_default_allowlist(
+    tmp_path: Path,
+) -> None:
+    (
+        _load_tools,
+        _prompt_tools,
+        get_prompt_tools_async,
+        _get_conversation,
+        _default_allowlist,
+        _ns,
+        events,
+        _captured,
+        tool_threads,
+    ) = _load_helpers(tmp_path)
+
+    main_thread_id = threading.get_ident()
+
+    prompt_tools = await get_prompt_tools_async(("read",))
+
+    assert [tool.name for tool in prompt_tools] == ["read"]
+    assert events == ["clear", ("init", ("read",)), "get"]
+    assert tool_threads
+    assert any(thread_id != main_thread_id for thread_id in tool_threads)


### PR DESCRIPTION
## Summary

- rebuild the Discord bot tool context from an explicit allowlist on each request instead of inheriting whatever tools were loaded at startup
- refresh conversation system prompts from the request's prompt-tool snapshot rather than the old global tool list
- add regression tests for the reset-before-init path and prompt refresh behavior

## Why

The bot still hard-blocks untrusted users today, but the old plumbing made any future trust-tier work flaky: a narrower allowlist would inherit tools from a broader startup context, and the conversation prompt would keep advertising the startup-global tool set. This change makes the request-scoped boundary real without changing the current trusted-user gate.

## Test plan

- `uv run pytest scripts/discord/test_discord_tool_policy.py -q`
- `uv run pytest scripts/discord/test_discord_bot_message_splitting.py -q`
- `uv run ruff check scripts/discord/discord_bot.py scripts/discord/test_discord_tool_policy.py`
- `uv run ruff format --check scripts/discord/discord_bot.py scripts/discord/test_discord_tool_policy.py`
