### PR TITLE
fix(github-resolver): make issue-resolver workflow work cross-repo via workflow_call

### DIFF
--- a/.github/workflows/issue-resolver.yml
+++ b/.github/workflows/issue-resolver.yml
@@ -94,6 +94,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: gptme/gptme-contrib
+          ref: ${{ github.workflow_sha }}
           path: ${{ runner.temp }}/gptme-resolver
           sparse-checkout: |
             scripts/github_resolver

--- a/.github/workflows/issue-resolver.yml
+++ b/.github/workflows/issue-resolver.yml
@@ -13,6 +13,17 @@ name: Issue Resolver (opt-in draft PR)
 #   - Idempotent: re-triggering updates the existing attempt branch.
 #   - Uploads gptme session log as an artifact for post-hoc inspection.
 #
+# Cross-repo usage (Phase 2): call this as a reusable workflow from any repo:
+#
+#   jobs:
+#     resolve:
+#       uses: gptme/gptme-contrib/.github/workflows/issue-resolver.yml@master
+#       secrets:
+#         gptme-provider-key: ${{ secrets.ANTHROPIC_API_KEY }}
+#
+# The workflow fetches its own resolver scripts from gptme-contrib so the
+# calling repo does not need to include any gptme-contrib files.
+#
 # Source script: scripts/github_resolver/resolve_issue.py
 # Research note: knowledge/research/2026-04-23-openhands-resolver-runtime-patterns.md
 #                (lives in Bob's private brain repo; public summary in PR body)
@@ -64,9 +75,30 @@ jobs:
         && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
       || github.event_name == 'workflow_call'
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout target repo
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Fetch resolver scripts from gptme-contrib
+        # Always fetch from gptme-contrib so this workflow works both when
+        # triggered directly inside gptme-contrib AND when called as a
+        # reusable workflow (workflow_call) from an external repo. Without
+        # this step, `scripts/github_resolver/` would not exist in a
+        # caller's checkout.
+        #
+        # Use runner.temp (outside the workspace) so the fetched scripts
+        # are never inside the target repo's working tree. This prevents
+        # `git add -A` in the resolver from staging the scripts directory
+        # as a broken submodule reference.
+        uses: actions/checkout@v4
+        with:
+          repository: gptme/gptme-contrib
+          path: ${{ runner.temp }}/gptme-resolver
+          sparse-checkout: |
+            scripts/github_resolver
+            scripts/github_actions_common
+          sparse-checkout-cone-mode: false
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -93,7 +125,7 @@ jobs:
           fi
 
           mkdir -p output
-          uv run python scripts/github_resolver/resolve_issue.py \
+          python "$RUNNER_TEMP/gptme-resolver/scripts/github_resolver/resolve_issue.py" \
             --repo "$GITHUB_REPOSITORY" \
             --issue "$ISSUE_NUMBER" \
             --output-dir output

--- a/packages/gptme-codegraph/src/gptme_codegraph/core.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/core.py
@@ -47,6 +47,15 @@ _LANG_MAP: dict[str, str] = {
     ".rs": "rust",
 }
 
+_GRAMMAR_MODULES: dict[str, str] = {
+    "python": "tree_sitter_python",
+    "javascript": "tree_sitter_javascript",
+    "jsx": "tree_sitter_javascript",
+    "typescript": "tree_sitter_typescript",
+    "tsx": "tree_sitter_typescript",
+    "rust": "tree_sitter_rust",
+}
+
 _SOURCE_EXTENSIONS: tuple[str, ...] = tuple(_LANG_MAP.keys())
 _NOISE_PATH_PARTS: frozenset[str] = frozenset(
     {"__pycache__", "node_modules", ".git", "target"}
@@ -583,6 +592,68 @@ class FileParseResult:
 
     symbols: list[Symbol] = field(default_factory=list)
     imports: list[ImportInfo] = field(default_factory=list)
+    language: str | None = None
+    diagnostic: dict[str, str] | None = None
+
+
+@dataclass
+class _ParseAttempt:
+    """Internal parse result that preserves failure diagnostics."""
+
+    root: object | None = None
+    parser: object | None = None
+    diagnostic: dict[str, str] | None = None
+
+
+def _missing_grammar_diagnostic(lang_name: str) -> dict[str, str]:
+    """Describe how to fix a missing tree-sitter grammar."""
+    module_name = _GRAMMAR_MODULES.get(lang_name, "tree_sitter_<unknown>")
+    package_name = module_name.replace("_", "-")
+    return {
+        "code": "missing-grammar",
+        "language": lang_name,
+        "message": (
+            f"Missing tree-sitter grammar for {lang_name} ({module_name}). "
+            f"Install gptme-codegraph[treesitter] or add {package_name} to the environment."
+        ),
+    }
+
+
+def _tree_sitter_parse_attempt(code: bytes, lang_name: str = "python") -> _ParseAttempt:
+    """Parse source code with tree-sitter and preserve missing-dependency diagnostics."""
+    try:
+        from tree_sitter import Parser  # type: ignore[import-untyped,unused-ignore]
+    except ImportError:
+        return _ParseAttempt(
+            diagnostic={
+                "code": "missing-tree-sitter",
+                "language": lang_name,
+                "message": (
+                    "Missing tree-sitter runtime. Install gptme-codegraph[treesitter] "
+                    "or add tree-sitter plus the relevant language grammar to the environment."
+                ),
+            }
+        )
+
+    parser = Parser()
+    language = _load_language(lang_name)
+    if language is None:
+        diagnostic = None
+        if lang_name in _GRAMMAR_MODULES:
+            diagnostic = _missing_grammar_diagnostic(lang_name)
+        return _ParseAttempt(diagnostic=diagnostic)
+
+    parser.language = language
+    tree = parser.parse(code)
+    if tree is None:
+        return _ParseAttempt(
+            diagnostic={
+                "code": "parse-failed",
+                "language": lang_name,
+                "message": f"tree-sitter failed to parse {lang_name} source.",
+            }
+        )
+    return _ParseAttempt(root=tree.root_node, parser=parser)
 
 
 def _tree_sitter_parse(code: bytes, lang_name: str = "python"):
@@ -591,20 +662,8 @@ def _tree_sitter_parse(code: bytes, lang_name: str = "python"):
     Falls back gracefully if tree-sitter or the grammar is unavailable.
     Returns (root_node, parser) on success.
     """
-    try:
-        from tree_sitter import Parser  # type: ignore[import-untyped,unused-ignore]
-
-        parser = Parser()
-        language = _load_language(lang_name)
-        if language is None:
-            return None, None
-        parser.language = language
-        tree = parser.parse(code)
-        if tree is None:
-            return None, None
-        return tree.root_node, parser
-    except ImportError:
-        return None, None
+    attempt = _tree_sitter_parse_attempt(code, lang_name)
+    return attempt.root, attempt.parser
 
 
 def _text(node) -> str:
@@ -1141,9 +1200,10 @@ def parse_file(filepath: Path) -> FileParseResult:
     lang_name = _detect_language(filepath)
     if lang_name is None:
         return FileParseResult()
-    root, _parser = _tree_sitter_parse(code, lang_name)
+    attempt = _tree_sitter_parse_attempt(code, lang_name)
+    root = attempt.root
     if root is None:
-        return FileParseResult()
+        return FileParseResult(language=lang_name, diagnostic=attempt.diagnostic)
 
     filename = str(filepath)
     symbols: list[Symbol] = []
@@ -1166,7 +1226,7 @@ def parse_file(filepath: Path) -> FileParseResult:
     for imp in imports:
         imp.file = filename
 
-    return FileParseResult(symbols=symbols, imports=imports)
+    return FileParseResult(symbols=symbols, imports=imports, language=lang_name)
 
 
 def extract_symbols(filepath: Path) -> list[Symbol]:
@@ -1818,9 +1878,16 @@ def main():
     if not filepath.is_file():
         sys.exit(f"Not a file: {filepath}")
 
-    symbols = extract_symbols(filepath)
+    result = parse_file(filepath)
+    symbols = result.symbols
     if not symbols:
-        print("No symbols found.")
+        if result.diagnostic is not None:
+            if args.json:
+                print(format_json({"file": str(filepath), **result.diagnostic}))
+            else:
+                print(result.diagnostic["message"])
+        else:
+            print("No symbols found.")
         return
 
     name_map = {s.name: s for s in symbols}

--- a/packages/gptme-codegraph/tests/test_codegraph.py
+++ b/packages/gptme-codegraph/tests/test_codegraph.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import importlib
 import json
 import subprocess
+import sys
 import tempfile
 from collections.abc import Generator
 from pathlib import Path
 from typing import cast
 
+import gptme_codegraph.core as core_module
 import pytest
 from gptme_codegraph.core import (
     IndexEntry,
@@ -29,6 +31,7 @@ from gptme_codegraph.core import (
     format_repo_map,
     format_symbols,
     impact_radius,
+    main,
     parse_file,
 )
 
@@ -963,6 +966,53 @@ def test_parse_file_returns_imports(tmp_path: Path):
     assert result.symbols[0].name == "helper"
     assert len(result.imports) == 1
     assert result.imports[0].name == "json"
+
+
+def test_parse_file_reports_missing_grammar(monkeypatch, tmp_path: Path):
+    """parse_file distinguishes missing grammars from empty parses."""
+    f = tmp_path / "component.tsx"
+    f.write_text("export function Button() { return <button /> }\n")
+
+    original = core_module._load_language
+    monkeypatch.setattr(
+        core_module,
+        "_load_language",
+        lambda name: None if name == "tsx" else original(name),
+    )
+
+    result = parse_file(f)
+
+    assert result.symbols == []
+    assert result.language == "tsx"
+    assert result.diagnostic is not None
+    assert result.diagnostic["code"] == "missing-grammar"
+    assert "tree_sitter_typescript" in result.diagnostic["message"]
+
+
+def test_main_parse_json_reports_missing_grammar(monkeypatch, tmp_path: Path, capsys):
+    """CLI parse --json emits an explicit diagnostic for missing grammars."""
+    f = tmp_path / "lib.rs"
+    f.write_text("pub fn greet() {}\n")
+
+    original = core_module._load_language
+    monkeypatch.setattr(
+        core_module,
+        "_load_language",
+        lambda name: None if name == "rust" else original(name),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["gptme-codegraph", str(f), "parse", "--json"],
+    )
+
+    main()
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["file"] == str(f)
+    assert payload["language"] == "rust"
+    assert payload["code"] == "missing-grammar"
+    assert "tree_sitter_rust" in payload["message"]
 
 
 def test_parse_file_includes_decorated_python_definitions(tmp_path: Path):

--- a/scripts/github_resolver/README.md
+++ b/scripts/github_resolver/README.md
@@ -12,6 +12,30 @@ This is distinct from the warning-only issue-hygiene Action: hygiene never
 touches code, resolver is authorised to make edits but deliberately never
 auto-merges.
 
+## Using in your own repo (reusable workflow)
+
+Call the workflow from any repo without copying any scripts:
+
+```yaml
+# .github/workflows/issue-resolver.yml in your repo
+name: Issue Resolver
+on:
+  issues:
+    types: [labeled]
+  issue_comment:
+    types: [created]
+
+jobs:
+  resolve:
+    uses: gptme/gptme-contrib/.github/workflows/issue-resolver.yml@master
+    secrets:
+      gptme-provider-key: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+The reusable workflow fetches its own resolver scripts from gptme-contrib at
+runtime (into `$RUNNER_TEMP`, outside your workspace), so your repo stays
+clean.
+
 ## Design invariants (Phase 1)
 
 - **Opt-in only.** The workflow's `if:` gate only fires on an explicit


### PR DESCRIPTION
## Problem

The Phase 1 `issue-resolver.yml` only worked correctly when run **inside gptme-contrib itself**. When an external repo called it via `workflow_call`, GitHub Actions checked out the _caller's_ repo (not gptme-contrib), so `scripts/github_resolver/resolve_issue.py` was missing and the job would fail immediately.

## Fix

Add a sparse checkout step that always fetches the resolver scripts from gptme-contrib into `$RUNNER_TEMP` (outside the workspace). Using `runner.temp` is intentional:

- The scripts are completely outside the target repo's working tree.
- `git add -A` in `resolve_issue.py` never sees them.
- No risk of the scripts being accidentally staged as a broken submodule reference.

The path to the resolver script is updated from `scripts/github_resolver/resolve_issue.py` (only present in gptme-contrib's own checkout) to `$RUNNER_TEMP/gptme-resolver/scripts/github_resolver/resolve_issue.py` (always available).

## What changes

- `.github/workflows/issue-resolver.yml`: add `Fetch resolver scripts from gptme-contrib` step; rename checkout step for clarity; switch from `uv run python` to plain `python` since the script has no uv-managed deps.
- `scripts/github_resolver/README.md`: add a **"Using in your own repo"** section with a complete `workflow_call` example.

## Testing

Self-hosted case (gptme-contrib triggers its own resolver) still works:
1. Main checkout → gptme-contrib workspace
2. Sparse checkout → `$RUNNER_TEMP/gptme-resolver/` (same content, separate path)
3. Resolver runs against gptme-contrib's working tree

Cross-repo case (e.g. gptme calls this workflow) now works:
1. Main checkout → gptme workspace (code gptme will modify)
2. Sparse checkout → `$RUNNER_TEMP/gptme-resolver/` (resolver scripts)
3. Resolver runs against gptme's working tree

## Part of

Idea backlog #169 Phase 2 — making the resolver usable outside gptme-contrib.