### PR TITLE
fix(codegraph): surface missing grammars in repo map

### DIFF
--- a/packages/gptme-codegraph/src/gptme_codegraph/core.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/core.py
@@ -1626,10 +1626,32 @@ def build_repo_map(
     files = _iter_source_files(root)
     file_rows: list[dict[str, object]] = []
     total_symbols = 0
+    # Languages whose grammar is unavailable parse to zero symbols for an
+    # environment reason, not a real "no symbols" miss. Keyed by language so the
+    # repo map surfaces one diagnostic per language instead of silently
+    # reporting an empty skeleton (e.g. a Rust repo with no rust grammar would
+    # otherwise look identical to a repo with no extractable symbols).
+    missing_grammars: dict[str, dict[str, object]] = {}
 
     for fp in files:
         result = parse_file(fp)
         if not result.symbols:
+            diag = result.diagnostic
+            if diag is not None and diag.get("code") in (
+                "missing-grammar",
+                "missing-tree-sitter",
+            ):
+                lang = str(diag.get("language", "unknown"))
+                entry = missing_grammars.setdefault(
+                    lang,
+                    {
+                        "language": lang,
+                        "code": diag.get("code"),
+                        "message": diag.get("message"),
+                        "files_skipped": 0,
+                    },
+                )
+                entry["files_skipped"] = cast(int, entry["files_skipped"]) + 1
             continue
 
         outline = _build_file_outline(result.symbols)
@@ -1683,6 +1705,10 @@ def build_repo_map(
         "max_files": max_files,
         "max_symbols_per_file": max_symbols_per_file,
         "files": files_payload,
+        "missing_grammars": sorted(
+            missing_grammars.values(),
+            key=lambda d: str(d["language"]),
+        ),
     }
 
 
@@ -1726,6 +1752,18 @@ def format_repo_map(repo_map: dict[str, object]) -> str:
             f"Symbols shown: {repo_map['symbols_shown']}/{repo_map['symbols_total']}"
         ),
     ]
+
+    # Surface missing-grammar diagnostics so an empty skeleton caused by an
+    # absent tree-sitter grammar is distinguishable from a real empty parse.
+    missing = repo_map.get("missing_grammars")
+    if isinstance(missing, list):
+        for entry_obj in missing:
+            if not isinstance(entry_obj, dict):
+                continue
+            entry = cast(dict[str, object], entry_obj)
+            skipped = entry.get("files_skipped", "?")
+            message = entry.get("message", "missing grammar")
+            lines.append(f"⚠ {skipped} file(s) skipped: {message}")
 
     files = repo_map.get("files")
     if not isinstance(files, list):

--- a/packages/gptme-codegraph/src/gptme_codegraph/core.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/core.py
@@ -1641,9 +1641,14 @@ def build_repo_map(
                 "missing-grammar",
                 "missing-tree-sitter",
             ):
+                code = str(diag.get("code", "unknown"))
                 lang = str(diag.get("language", "unknown"))
+                # "missing-tree-sitter" is an environment-level problem with a single
+                # fix regardless of how many languages are affected, so key by code to
+                # deduplicate. "missing-grammar" is per-language, so key by lang.
+                key = lang if code == "missing-grammar" else code
                 entry = missing_grammars.setdefault(
-                    lang,
+                    key,
                     {
                         "language": lang,
                         "code": diag.get("code"),

--- a/packages/gptme-codegraph/tests/test_codegraph.py
+++ b/packages/gptme-codegraph/tests/test_codegraph.py
@@ -1041,6 +1041,35 @@ def test_build_repo_map_reports_missing_grammar(monkeypatch, tmp_path: Path):
     assert "2 file(s) skipped" in output
 
 
+def test_build_repo_map_deduplicates_missing_tree_sitter(monkeypatch, tmp_path: Path):
+    """missing-tree-sitter entries collapse to one regardless of how many languages fail."""
+    (tmp_path / "a.py").write_text("def one(): pass\n")
+    (tmp_path / "b.rs").write_text("pub fn two() {}\n")
+
+    monkeypatch.setattr(
+        core_module,
+        "_tree_sitter_parse_attempt",
+        lambda code, lang_name="python": core_module._ParseAttempt(
+            diagnostic={
+                "code": "missing-tree-sitter",
+                "language": lang_name,
+                "message": "Missing tree-sitter runtime. Install gptme-codegraph[treesitter].",
+            }
+        ),
+    )
+
+    repo_map = build_repo_map(tmp_path, max_files=10, max_symbols_per_file=10)
+
+    missing = cast(list[dict[str, object]], repo_map["missing_grammars"])
+    assert len(missing) == 1, "All missing-tree-sitter entries should collapse into one"
+    assert missing[0]["code"] == "missing-tree-sitter"
+    assert cast(int, missing[0]["files_skipped"]) == 2
+
+    output = format_repo_map(repo_map)
+    assert "2 file(s) skipped" in output
+    assert output.count("Missing tree-sitter") == 1
+
+
 def test_build_repo_map_no_missing_grammars_when_all_parse(multi_file_project: Path):
     """A healthy repo map reports an empty missing-grammars list."""
     repo_map = build_repo_map(multi_file_project, max_files=10, max_symbols_per_file=10)

--- a/packages/gptme-codegraph/tests/test_codegraph.py
+++ b/packages/gptme-codegraph/tests/test_codegraph.py
@@ -1015,6 +1015,39 @@ def test_main_parse_json_reports_missing_grammar(monkeypatch, tmp_path: Path, ca
     assert "tree_sitter_rust" in payload["message"]
 
 
+def test_build_repo_map_reports_missing_grammar(monkeypatch, tmp_path: Path):
+    """Repo map surfaces missing grammars instead of a silent empty skeleton."""
+    (tmp_path / "a.rs").write_text("pub fn one() {}\n")
+    (tmp_path / "b.rs").write_text("pub fn two() {}\n")
+
+    original = core_module._load_language
+    monkeypatch.setattr(
+        core_module,
+        "_load_language",
+        lambda name: None if name == "rust" else original(name),
+    )
+
+    repo_map = build_repo_map(tmp_path, max_files=10, max_symbols_per_file=10)
+
+    assert repo_map["files_with_symbols"] == 0
+    missing = cast(list[dict[str, object]], repo_map["missing_grammars"])
+    assert len(missing) == 1
+    assert missing[0]["language"] == "rust"
+    assert missing[0]["code"] == "missing-grammar"
+    assert missing[0]["files_skipped"] == 2
+
+    output = format_repo_map(repo_map)
+    assert "tree_sitter_rust" in output
+    assert "2 file(s) skipped" in output
+
+
+def test_build_repo_map_no_missing_grammars_when_all_parse(multi_file_project: Path):
+    """A healthy repo map reports an empty missing-grammars list."""
+    repo_map = build_repo_map(multi_file_project, max_files=10, max_symbols_per_file=10)
+    assert repo_map["missing_grammars"] == []
+    assert "skipped" not in format_repo_map(repo_map)
+
+
 def test_parse_file_includes_decorated_python_definitions(tmp_path: Path):
     """parse_file preserves decorated Python functions and methods."""
     f = tmp_path / "decorated.py"


### PR DESCRIPTION
## Problem

`build_repo_map` silently skips files that parse to zero symbols (`if not result.symbols: continue`), discarding the per-file diagnostic. A repo whose tree-sitter grammar is unavailable — e.g. a Rust repo with no `tree_sitter_rust` installed — was indistinguishable from a repo with no extractable symbols. Both rendered as:

```
Files shown: 0/0  Symbols shown: 0/0
```

This was the repo-map half of the runtime-grammar-contract gap flagged in the 2026-05-21 structure-quality reality check (the single-file CLI parse path already surfaced diagnostics via edef401).

## Fix

- Collect missing-grammar diagnostics per language during `build_repo_map`, deduped by language with a `files_skipped` count.
- Expose them as a new `missing_grammars` field on the repo-map payload (JSON consumers get structured diagnostics for free).
- Surface a concise warning line per language in `format_repo_map`:

```
⚠ 2 file(s) skipped: Missing tree-sitter grammar for rust (tree_sitter_rust). Install gptme-codegraph[treesitter] or add tree-sitter-rust to the environment.
```

## Tests

- `test_build_repo_map_reports_missing_grammar` — monkeypatches `_load_language` to simulate a missing rust grammar, asserts the diagnostic is collected (count + language + code) and surfaced in formatted output.
- `test_build_repo_map_no_missing_grammars_when_all_parse` — healthy repo reports an empty `missing_grammars` list and no 'skipped' line.

Full package suite: 133 passed, 1 skipped. mypy clean on `core.py`.

## Why it matters

An agent reading a repo map can now tell 'this language's grammar is missing, install it' apart from 'this code genuinely has no symbols' — the difference between a fixable environment problem and a real empty result.