### PR TITLE
fix(lessons): broaden gh-pr-checks-exit-code-8 keywords + session_categories

### DIFF
--- a/lessons/tools/gh-pr-checks-exit-code-8.md
+++ b/lessons/tools/gh-pr-checks-exit-code-8.md
@@ -2,6 +2,11 @@
 match:
   keywords:
     - "exit code 8"
+    - "gh pr checks pending"
+    - "checks still pending"
+    - "checks still in progress"
+    - "waiting for checks"
+  session_categories: [cross-repo, code, monitoring]
 status: active
 generated_from:
   sessions: 538

--- a/packages/gptme-codegraph/tests/test_codegraph.py
+++ b/packages/gptme-codegraph/tests/test_codegraph.py
@@ -1077,7 +1077,6 @@ def test_build_repo_map_no_missing_grammars_when_all_parse(multi_file_project: P
     assert "skipped" not in format_repo_map(repo_map)
 
 
-
 def test_parse_file_includes_decorated_python_definitions(tmp_path: Path):
     """parse_file preserves decorated Python functions and methods."""
     f = tmp_path / "decorated.py"

--- a/packages/gptme-codegraph/tests/test_codegraph.py
+++ b/packages/gptme-codegraph/tests/test_codegraph.py
@@ -1077,6 +1077,7 @@ def test_build_repo_map_no_missing_grammars_when_all_parse(multi_file_project: P
     assert "skipped" not in format_repo_map(repo_map)
 
 
+
 def test_parse_file_includes_decorated_python_definitions(tmp_path: Path):
     """parse_file preserves decorated Python functions and methods."""
     f = tmp_path / "decorated.py"


### PR DESCRIPTION
## Summary

- Adds 4 broader early-turn keywords alongside the existing `exit code 8`
- Adds `session_categories: [cross-repo, code, monitoring]` so the lesson
  fires for any session where PR CI monitoring is inherently relevant

## Background

Phase 1 lesson recall analysis (7-day, 192 CC sessions) found this lesson
had **24 timing misses** — the sole keyword `exit code 8` appears in tool
output mid-session, never in the first user turn where the injection hook
fires. This is the highest-priority keyword fix from that analysis with
only one keyword to start with.

New keywords added: `gh pr checks pending`, `checks still pending`,
`checks still in progress`, `waiting for checks` — these are more likely
to appear early in session context or user prompts when someone is
actively monitoring CI.