### PR TITLE
perf(activity-gate): skip live PR fetch for repos with no open PRs

### DIFF
--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -885,8 +885,18 @@ for repo in $all_repos; do
     (
         # Cached PR data drives the state-tracked checks.
         pr_data=$(fetch_pr_data "$repo")
-        # Merge-sensitive checks need live status every run, regardless of cache.
-        live_pr_data=$(fetch_live_pr_data "$repo")
+        # Merge-sensitive checks need live status every run, but only for repos
+        # that actually have open author PRs. When the cached lane already shows
+        # no open PRs, a live merge-status fetch can only return the same empty
+        # set, so skip the GraphQL call. On a multi-repo org most repos have zero
+        # open author PRs at any moment, so this removes the dominant idle-time
+        # GraphQL burner without weakening live merge detection for repos that do
+        # have PRs. See tasks/github-graphql-rate-limit-regression.md.
+        if [ "$(printf '%s' "$pr_data" | jq 'length' 2>/dev/null || echo 0)" -gt 0 ]; then
+            live_pr_data=$(fetch_live_pr_data "$repo")
+        else
+            live_pr_data="[]"
+        fi
         repo_items=""
 
         items=$(check_pr_updates "$repo" "$pr_data" 2>/dev/null || true)

--- a/tests/test_activity_gate_gh_cache.py
+++ b/tests/test_activity_gate_gh_cache.py
@@ -108,12 +108,17 @@ def test_failed_pr_fetch_does_not_seed_cache() -> None:
 
         first, first_count = _run_gate(tmp, state_dir, fail_pr_list=True)
         assert first.returncode in (0, 1), first.stderr
-        assert first_count == 2
+        # Failed cached fetch returns the empty fallback, so the live merge-status
+        # fetch is skipped (re-calling a failing API would only burn another
+        # GraphQL call). One PR-list call total this run.
+        assert first_count == 1
         assert not cache_file.exists(), "failed gh pr list must not populate cache"
 
         second, second_count = _run_gate(tmp, state_dir, fail_pr_list=False)
         assert second.returncode in (0, 1), second.stderr
-        assert second_count == 4, "second run should re-fetch after prior failure"
+        # Re-fetch succeeds and seeds the cache; the result is an empty PR list,
+        # so the live fetch is still skipped (no open PRs to check). +1 call.
+        assert second_count == 2, "second run should re-fetch after prior failure"
         assert cache_file.exists(), "successful gh pr list should populate cache"
 
 
@@ -235,3 +240,58 @@ def test_merge_conflict_check_bypasses_pr_cache() -> None:
             second_count == 3
         ), "second run should skip cached producer but still do one live PR fetch"
         assert '"type":"merge_conflict"' in second.stdout, second.stdout
+
+
+# Empty-repo stub: no open author PRs. The cached PR-list fetch returns [],
+# so the live merge-status fetch must be skipped (it could only return [] too).
+FAKE_GH_EMPTY_PRS = r"""#!/usr/bin/env python3
+from __future__ import annotations
+import os, sys
+from pathlib import Path
+
+argv = sys.argv[1:]
+count_file = Path(os.environ["GH_PR_LIST_CALL_COUNT"])
+
+def bump() -> int:
+    n = int(count_file.read_text().strip()) if count_file.exists() else 0
+    n += 1
+    count_file.write_text(str(n))
+    return n
+
+if not argv:
+    sys.exit(2)
+
+if argv[0] == "pr" and len(argv) > 1 and argv[1] == "list":
+    bump()
+    print("[]")
+    sys.exit(0)
+
+if argv[0] in ("issue", "run") and len(argv) > 1 and argv[1] == "list":
+    print("[]")
+    sys.exit(0)
+
+# repo list / api / anything else: succeed silently.
+sys.exit(0)
+"""
+
+
+def test_empty_repo_skips_live_pr_fetch() -> None:
+    """A repo with no open author PRs should do exactly one PR-list fetch
+    per run (the cached lane). The live merge-status fetch is skipped because
+    it could only re-fetch the same empty set — this removes the dominant
+    idle-time GraphQL burner. See github-graphql-rate-limit-regression."""
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+
+        first, first_count = _run_gate_jsonl(tmp, state_dir, FAKE_GH_EMPTY_PRS)
+        assert first.returncode in (0, 1), first.stderr
+        # Only the cached fetch fires; live fetch is skipped (was 2 before).
+        assert first_count == 1, "empty repo should do one PR fetch, not two"
+
+        # Second run: cached [] is still fresh, live still skipped -> no calls.
+        second, second_count = _run_gate_jsonl(tmp, state_dir, FAKE_GH_EMPTY_PRS)
+        assert second.returncode in (0, 1), second.stderr
+        assert second_count == 1, "second run should add no PR fetches for empty repo"
+        assert "merge_conflict" not in second.stdout, second.stdout


### PR DESCRIPTION
## Problem

`activity-gate.sh` runs via `bob-project-monitoring` every ~2 min. For **every** discovered repo, the loop does two `gh pr list` calls:

- `fetch_pr_data` (cached, 8-min TTL) — drives state-tracked checks
- `fetch_live_pr_data` (**TTL 0, always live**) — drives the merge-sensitive checks (`merge_conflict`, `merge_ready`)

Both query identical fields (`...mergeable,mergeStateStatus,statusCheckRollup,...`), which route through **GraphQL**. The live, cache-bypassing fetch fires for every repo on every run.

A post-reset measurement on 2026-05-22 attributed **~87% of all GraphQL usage to `activity-gate.sh`** (~810 raw / ~372 calibrated points across 180 calls in 8 min), almost entirely from these per-repo live fetches. With ~13 repos polled but only 2-3 carrying open author PRs at any moment, ~80% of those live fetches return an empty set and cost a GraphQL call for nothing.

## Fix

Skip the live merge-status fetch when the cached PR lane already shows **no open PRs** for the repo — a live fetch could only return the same empty set. Live merge detection is preserved for repos that actually have PRs (the only place it matters), so the "nag every run" merge-conflict contract is unchanged where it applies.

This removes the dominant idle-time GraphQL burner without weakening any check that has work to do.

## Tests

- `test_merge_conflict_check_bypasses_pr_cache` — **unchanged, still passes** (uses a non-empty PR list, so the live fetch still fires every run).
- `test_failed_pr_fetch_does_not_seed_cache` — call-count assertions updated: a *failing* cached fetch now also skips the doomed live call (one fewer GraphQL call during an API/rate-limit outage — exactly when we want to conserve). Core assertions (no cache seeding on failure, re-fetch on next run) preserved.
- `test_empty_repo_skips_live_pr_fetch` — **new**, covers the empty-repo skip.

```
11 passed in 5.95s
```
shellcheck clean.

Refs: ErikBjare/bob — `tasks/github-graphql-rate-limit-regression.md`