### PR TITLE
fix(test-plugins): install pytest-timeout and plugin itself in local test runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ test-plugins:  ## Run tests for all plugins with test directories
 	for plugin in $(PLUGIN_DIRS); do \
 		if [ -d "$$plugin/tests" ]; then \
 			echo "\n=== Testing $$(basename $$plugin) ==="; \
-			uv run --with pytest pytest "$$plugin/tests" -v -m "not slow" --timeout=30 || failed=1; \
+			uv run --with pytest --with pytest-timeout --with "./$$plugin[test]" pytest "$$plugin/tests" -v -m "not slow" --timeout=30 || failed=1; \
 		fi \
 	done; \
 	if [ -n "$$failed" ]; then exit 1; fi


### PR DESCRIPTION
## Summary

- **Bug**: `make test-plugins` was failing with two errors:
  1. `unrecognized arguments: --timeout=30` — pytest-timeout plugin not installed
  2. `ModuleNotFoundError` for plugins that import themselves (gptme-gptodo, gptme-ralph, gptme-tooloutput-trimmer, etc.)
- **Root cause**: `uv run --with pytest` creates an isolated venv with only pytest, missing pytest-timeout and the plugin packages under test
- **Fix**: Add `--with pytest-timeout` and `--with "./$plugin[test]"` to the plugin test runner — mirrors what CI already does correctly (`pip install pytest pytest-timeout` + `pip install -e plugins/$plugin[test]`)

## Before / After

```makefile
# Before (broken)
uv run --with pytest pytest "$plugin/tests" -v -m "not slow" --timeout=30

# After (fixed)
uv run --with pytest --with pytest-timeout --with "./$plugin[test]" pytest "$plugin/tests" -v -m "not slow" --timeout=30
```

## Test plan

- [x] All 16/17 plugins pass locally (1 pre-existing `test_register` failure in gptme-hooks-examples on master, unrelated to this change)
- [x] `make test-plugins` completes without `--timeout=30` unrecognized argument error
- [x] Plugins that import themselves (gptme-gptodo, gptme-ralph, gptme-tooloutput-trimmer) collect and run correctly