### PR TITLE
fix(subscription): reorder reauth instructions so ln -sf comes last

### DIFF
--- a/packages/gptme-subscription/src/gptme_subscription/auth.py
+++ b/packages/gptme-subscription/src/gptme_subscription/auth.py
@@ -182,21 +182,24 @@ REAUTH_INSTRUCTIONS = """\
 Re-authenticate a Claude Code slot
 ==================================
 
-1. Make the broken slot the live credential:
-
-       ln -sf .credentials.json.{sub} ~/.claude/.credentials.json
-
-2. Launch Claude Code interactively and run /login:
+1. Launch Claude Code interactively and run /login:
 
        claude
        > /login
 
-   This opens a browser, runs the OAuth flow, and writes the new tokens
-   to ~/.claude/.credentials.json.
+   This opens a browser, runs the OAuth flow, and writes fresh tokens to
+   ~/.claude/.credentials.json. Note: /login (and routine token refresh)
+   REPLACES the live symlink with a regular file, so the symlink must be
+   restored at the end (step 3) — don't put `ln -sf` before /login, it just
+   gets clobbered.
 
-3. Persist the refreshed tokens back into the named slot:
+2. Persist the fresh tokens into the named slot:
 
        cp ~/.claude/.credentials.json ~/.claude/.credentials.json.{sub}
+
+3. Restore the live symlink to the slot (do this LAST):
+
+       ln -sf .credentials.json.{sub} ~/.claude/.credentials.json
 
 4. (Optional, if you use identity drift detection) re-baseline the slot:
 
@@ -205,7 +208,8 @@ Re-authenticate a Claude Code slot
 Common failure modes:
   - "Login failed" / "rate limited":   wait 5 min, retry
   - browser does not open:             use --headless or copy the URL manually
-  - slot accepts login but probes 401: another slot is symlinked; redo step 1
+  - slot accepts login but probes 401: another slot is symlinked; restore the
+                                       slot symlink (step 3) and re-probe
 """
 
 

--- a/packages/gptme-subscription/tests/test_auth.py
+++ b/packages/gptme-subscription/tests/test_auth.py
@@ -146,6 +146,21 @@ def test_format_reauth_instructions_includes_slot(tmp_path: Path) -> None:
     assert "/login" in out
 
 
+def test_format_reauth_instructions_relinks_after_login() -> None:
+    """The ln -sf step must come AFTER /login.
+
+    /login (and routine token refresh) replaces the live symlink with a regular
+    file, so re-linking before /login is clobbered and leaves credential drift.
+    The symlink restore must be the last filesystem step. Regression guard for
+    the 2026-05-22 reauth-order fix.
+    """
+    out = format_reauth_instructions("bob")
+    login_idx = out.index("/login")
+    relink_idx = out.index("ln -sf .credentials.json.bob ~/.claude/.credentials.json")
+    cp_idx = out.index("cp ~/.claude/.credentials.json ~/.claude/.credentials.json.bob")
+    assert login_idx < cp_idx < relink_idx
+
+
 def test_to_dict_omits_none_fields(tmp_path: Path) -> None:
     info = check_credential_file(tmp_path / "missing.json", "alice")
     d = info.to_dict()


### PR DESCRIPTION
## Problem

`/login` (and routine token refresh) **replaces** the live `~/.claude/.credentials.json` symlink with a regular file — it does not write through the symlink. The old `REAUTH_INSTRUCTIONS` order put `ln -sf <slot>` as **step 1**, before `/login`:

```
1. ln -sf .credentials.json.{sub} ~/.claude/.credentials.json   # symlink
2. claude /login                                                # clobbers it into a file
3. cp ~/.claude/.credentials.json ~/.claude/.credentials.json.{sub}
   (no final re-link)
```

So step 1's symlink gets destroyed by `/login`, and with no final `ln -sf`, the procedure leaves the live credential as a **standalone file = credential drift** instead of a symlink to the slot. Hit for real on 2026-05-22 (an operator session had to clean up exactly this drift).

## Fix

Reorder so the symlink restore is the **last** filesystem step:

```
1. claude /login            # fresh tokens land in a regular file
2. cp -> slot               # persist fresh tokens to the named slot
3. ln -sf -> slot           # restore the symlink (last, authoritative)
4. --baseline-identity      # optional re-baseline
```

Ending on `ln -sf` guarantees the live credential is always a proper symlink, regardless of what `/login` did to it.

## Tests

- Adds `test_format_reauth_instructions_relinks_after_login` asserting `/login` precedes `cp` precedes `ln -sf`.
- Existing `test_format_reauth_instructions_includes_slot` still passes.
- `uv run pytest tests/test_auth.py` → 13 passed.

Co-Authored-By: Bob <bob@superuserlabs.org>