### PR TITLE
fix(subscription): skip stale fallback slots + alert on refused switch

### DIFF
--- a/packages/gptme-subscription/src/gptme_subscription/cli.py
+++ b/packages/gptme-subscription/src/gptme_subscription/cli.py
@@ -411,7 +411,16 @@ def _execute_switch_decision(
             payload["deferred"] = True
             payload["reason"] = "switch deferred by active locks"
             return 0, payload
-        payload["reason"] = "switch failed"
+        payload["reason"] = "switch refused"
+        # Refused switch (not deferred) is a capacity signal — emit a visible
+        # alert so a stale or broken fallback slot doesn't silently strand the
+        # system on the exhausted primary. See the 2026-05-22 incident.
+        if emit_text:
+            print(
+                f"\n[ALERT] switch to {target!r} refused — credential check failed. "
+                f"Reauth: gptme-subscription --reauth-instructions {target}",
+                file=sys.stderr,
+            )
         return 1, payload
 
     payload["executed"] = True

--- a/packages/gptme-subscription/src/gptme_subscription/manager.py
+++ b/packages/gptme-subscription/src/gptme_subscription/manager.py
@@ -222,6 +222,27 @@ class SubscriptionManager:
         )
         return result
 
+    def slot_credential_is_stale(
+        self, sub: str, stale_days: float = 7.0, *, now: datetime | None = None
+    ) -> tuple[bool, str]:
+        """True if the slot's credential file is missing or not refreshed recently.
+
+        A slot is considered stale when its credential file hasn't been written
+        in ``stale_days`` days — a healthy in-use slot gets its token rewritten
+        regularly by Claude Code. Missing files are always stale. Pure / no
+        network calls.
+        """
+        path = self.config.slot_path(sub)
+        current_ts = (now or datetime.now(timezone.utc)).timestamp()
+        try:
+            mtime = path.stat().st_mtime
+            age_days = (current_ts - mtime) / 86400.0
+        except OSError:
+            return True, "credential file missing"
+        if age_days > stale_days:
+            return True, f"{age_days:.1f}d old (>{stale_days:.0f}d threshold)"
+        return False, f"{age_days:.1f}d old"
+
     def detect_live_slot_drift(self) -> dict[str, Any] | None:
         drift = self._slot_manager.detect_live_slot_drift()
         return None if drift is None else dict(drift)
@@ -682,12 +703,28 @@ class SubscriptionManager:
         if exhausted:
             if cfg.fallback_order:
                 urgency_order = self.capacity_aware_fallback_order(now=current_time)
-                d.action = "switch"
-                d.target = urgency_order[0]
-                if urgency_order[0] != cfg.fallback_order[0]:
-                    d.reason += (
-                        f" → preferring {urgency_order[0]} "
-                        f"(lower pressure / expiry-aware)"
+                fresh_order: list[str] = []
+                stale_msgs: list[str] = []
+                for s in urgency_order:
+                    stale, msg = self.slot_credential_is_stale(s, now=current_time)
+                    if stale:
+                        stale_msgs.append(f"{s}: {msg}")
+                    else:
+                        fresh_order.append(s)
+                if fresh_order:
+                    d.action = "switch"
+                    d.target = fresh_order[0]
+                    if urgency_order[0] != cfg.fallback_order[0]:
+                        d.reason += (
+                            f" → preferring {fresh_order[0]} "
+                            f"(lower pressure / expiry-aware)"
+                        )
+                else:
+                    d.action = "stay"
+                    d.target = active
+                    d.reason = (
+                        f"{d.reason} — all fallbacks stale "
+                        f"({'; '.join(stale_msgs)}); reauth needed before switching"
                     )
             else:
                 d.reason += " — no fallback defined"
@@ -723,9 +760,14 @@ class SubscriptionManager:
             hold_seconds = self.compute_rebalance_hold_seconds(pace_overage)
             hold_until = current_time + timedelta(seconds=hold_seconds)
             urgency_order = self.capacity_aware_fallback_order(now=current_time)
-            if urgency_order:
+            fresh_rebalance = [
+                s
+                for s in urgency_order
+                if not self.slot_credential_is_stale(s, now=current_time)[0]
+            ]
+            if fresh_rebalance:
                 d.action = "switch"
-                d.target = urgency_order[0]
+                d.target = fresh_rebalance[0]
                 d.reason = (
                     f"rebalance: primary ahead of {label} pace by "
                     f"{pace_overage:.0%} "
@@ -750,6 +792,8 @@ class SubscriptionManager:
                 and cfg.fallback_order
             ):
                 for sub in cfg.fallback_order:
+                    if self.slot_credential_is_stale(sub, now=current_time)[0]:
+                        continue  # skip stale slots in forward routing
                     last_s = self.seconds_since_last_switch_to(sub)
                     if last_s is None or last_s > idle_threshold_s:
                         hold_until_ts = current_time + timedelta(

--- a/packages/gptme-subscription/src/gptme_subscription/manager.py
+++ b/packages/gptme-subscription/src/gptme_subscription/manager.py
@@ -714,7 +714,14 @@ class SubscriptionManager:
                 if fresh_order:
                     d.action = "switch"
                     d.target = fresh_order[0]
-                    if urgency_order[0] != cfg.fallback_order[0]:
+                    urgency_top = urgency_order[0]
+                    if urgency_top not in fresh_order:
+                        # urgency top-pick was stale; staleness drove the selection
+                        d.reason += (
+                            f" → {urgency_top} stale; selecting {fresh_order[0]}"
+                        )
+                    elif urgency_top != cfg.fallback_order[0]:
+                        # purely urgency-driven reordering (no stale filtering)
                         d.reason += (
                             f" → preferring {fresh_order[0]} "
                             f"(lower pressure / expiry-aware)"

--- a/packages/gptme-subscription/src/gptme_subscription/manager.py
+++ b/packages/gptme-subscription/src/gptme_subscription/manager.py
@@ -731,6 +731,7 @@ class SubscriptionManager:
             return d
 
         # Healthy primary — check pacing for rebalance / forward-routing.
+        rebalance_stale_note: str | None = None
         candidates: list[tuple[str, float, float]] = []
         pacing = usage.get("_pacing", {})
         actual_overall = float(pacing.get("actual_utilization", weekly))
@@ -779,6 +780,10 @@ class SubscriptionManager:
                 d.pace_overage = round(pace_overage, 3)
                 d.rebalance_trigger = label
                 return d
+            else:
+                rebalance_stale_note = (
+                    "rebalance skipped — all fallbacks stale, reauth needed"
+                )
 
         # Forward routing on healthy primary
         resets_in_weekly = usage.get("seven_day", {}).get("resets_in_seconds", 0)
@@ -819,6 +824,8 @@ class SubscriptionManager:
             f"primary quota healthy: {weekly:.0%} weekly, "
             f"{five_hour:.0%} 5h, {sonnet_weekly:.0%} Sonnet"
         )
+        if rebalance_stale_note:
+            d.reason += f"; {rebalance_stale_note}"
         return d
 
     # ---- External-switch detection (logs out-of-band symlink flips) ----

--- a/packages/gptme-subscription/tests/test_cli.py
+++ b/packages/gptme-subscription/tests/test_cli.py
@@ -145,7 +145,7 @@ def test_cmd_evaluate_json_execute_returns_failure_on_switch_error(capsys) -> No
     assert sm.switch_calls == [("alice", "rebalance to fresher slot")]
     payload = json.loads(capsys.readouterr().out)
     assert payload["executed"] is False
-    assert payload["reason"] == "switch failed"
+    assert payload["reason"] == "switch refused"
 
 
 def test_execute_switch_decision_does_not_claim_revert_when_usage_check_revert_fails() -> (
@@ -252,3 +252,57 @@ def test_execute_switch_decision_does_not_claim_revert_for_blocked_forward_routi
         ("alice", "rebalance to fresher slot"),
         ("bob", "auto-revert routing: alice blocked"),
     ]
+
+
+def test_execute_switch_decision_emits_alert_on_refused_switch(capsys) -> None:
+    """A refused (not deferred) switch should print [ALERT] to stderr."""
+    sm = FakeManager(
+        active="bob",
+        switch_results=[(False, False)],  # refused, not deferred
+        decision=Decision(
+            active="bob",
+            action="switch",
+            target="alice",
+            reason="weekly exhausted",
+        ),
+    )
+
+    rc, payload = _execute_switch_decision(
+        cast(SubscriptionManager, sm),
+        sm._decision,
+        "bob",
+        emit_text=True,
+    )
+
+    assert rc == 1
+    assert payload["reason"] == "switch refused"
+    captured = capsys.readouterr()
+    assert "[ALERT]" in captured.err
+    assert "alice" in captured.err
+    assert "reauth" in captured.err.lower()
+
+
+def test_execute_switch_decision_no_alert_on_deferred_switch(capsys) -> None:
+    """A deferred switch (active locks) must NOT emit [ALERT]."""
+    sm = FakeManager(
+        active="bob",
+        switch_results=[(False, True)],  # deferred by locks
+        decision=Decision(
+            active="bob",
+            action="switch",
+            target="alice",
+            reason="weekly exhausted",
+        ),
+    )
+
+    rc, payload = _execute_switch_decision(
+        cast(SubscriptionManager, sm),
+        sm._decision,
+        "bob",
+        emit_text=True,
+    )
+
+    assert rc == 0
+    assert payload.get("deferred") is True
+    captured = capsys.readouterr()
+    assert "[ALERT]" not in captured.err

--- a/packages/gptme-subscription/tests/test_subscription_manager.py
+++ b/packages/gptme-subscription/tests/test_subscription_manager.py
@@ -164,3 +164,32 @@ def test_evaluate_fresh_fallback_selected_normally(tmp_path: Path) -> None:
 
     assert decision.action == "switch"
     assert decision.target in ("alice", "erik")
+
+
+def _rebalancing_usage() -> dict:
+    """Usage that is healthy but overusing pace — triggers the rebalance path."""
+    return {
+        "seven_day": {"utilization": 0.75, "resets_in_seconds": 0},
+        "five_hour": {"utilization": 0.50, "resets_in_seconds": 3 * 3600},
+        "seven_day_sonnet": {"utilization": 0.20},
+        "_pacing": {
+            "actual_utilization": 0.75,
+            "target_utilization": 0.60,
+            "status": "overusing",
+        },
+    }
+
+
+def test_evaluate_rebalance_skipped_annotates_reason_when_all_fallbacks_stale(
+    tmp_path: Path,
+) -> None:
+    sm = _make_manager(tmp_path)
+    # No credential files written → all fallbacks stale (missing)
+    usage = _rebalancing_usage()
+    now = datetime.now(timezone.utc)
+
+    decision = sm.evaluate(usage, "bob", now=now)
+
+    assert decision.action == "stay"
+    assert "rebalance skipped" in decision.reason
+    assert "all fallbacks stale" in decision.reason

--- a/packages/gptme-subscription/tests/test_subscription_manager.py
+++ b/packages/gptme-subscription/tests/test_subscription_manager.py
@@ -65,3 +65,102 @@ def test_detect_external_switch_ignores_unreadable_log(tmp_path: Path) -> None:
     sm.get_active_subscription = lambda: "alice"  # type: ignore[method-assign]
 
     sm.detect_external_switch()
+
+
+# ---- slot_credential_is_stale ----
+
+
+def test_slot_credential_is_stale_missing_file(tmp_path: Path) -> None:
+    sm = _make_manager(tmp_path)
+    # No credential file written → missing
+    stale, msg = sm.slot_credential_is_stale("alice")
+    assert stale
+    assert "missing" in msg
+
+
+def test_slot_credential_is_stale_old_file(tmp_path: Path) -> None:
+    sm = _make_manager(tmp_path)
+    cred = sm.config.slot_path("alice")
+    cred.write_text("{}")
+    # Backdate mtime to 10 days ago
+    import os
+
+    old_ts = (datetime.now(timezone.utc) - timedelta(days=10)).timestamp()
+    os.utime(cred, (old_ts, old_ts))
+    now = datetime.now(timezone.utc)
+    stale, msg = sm.slot_credential_is_stale("alice", now=now)
+    assert stale
+    assert "10." in msg or "d old" in msg
+
+
+def test_slot_credential_is_stale_fresh_file(tmp_path: Path) -> None:
+    sm = _make_manager(tmp_path)
+    cred = sm.config.slot_path("alice")
+    cred.write_text("{}")
+    # File just written → fresh
+    now = datetime.now(timezone.utc)
+    stale, msg = sm.slot_credential_is_stale("alice", now=now)
+    assert not stale
+    assert "d old" in msg
+
+
+# ---- evaluate() stale-slot filtering ----
+
+
+def _exhausted_usage() -> dict:
+    return {
+        "seven_day": {"utilization": 0.95, "resets_in_seconds": 3 * 24 * 3600},
+        "five_hour": {"utilization": 0.95, "resets_in_seconds": 3 * 3600},
+        "seven_day_sonnet": {"utilization": 0.20},
+    }
+
+
+def _write_cred(sm: SubscriptionManager, slot: str, *, age_days: float) -> None:
+    """Write a slot credential file with a backdated mtime."""
+    import os
+
+    path = sm.config.slot_path(slot)
+    path.write_text("{}")
+    old_ts = (datetime.now(timezone.utc) - timedelta(days=age_days)).timestamp()
+    os.utime(path, (old_ts, old_ts))
+
+
+def test_evaluate_skips_stale_fallback_picks_fresh(tmp_path: Path) -> None:
+    sm = _make_manager(tmp_path)
+    # alice is stale (17 days), erik is fresh
+    _write_cred(sm, "alice", age_days=17)
+    _write_cred(sm, "erik", age_days=1)
+    usage = _exhausted_usage()
+    now = datetime.now(timezone.utc)
+
+    decision = sm.evaluate(usage, "bob", now=now)
+
+    assert decision.action == "switch"
+    assert decision.target == "erik"
+
+
+def test_evaluate_all_fallbacks_stale_stays(tmp_path: Path) -> None:
+    sm = _make_manager(tmp_path)
+    # Both fallbacks are stale (no file written → missing)
+    usage = _exhausted_usage()
+    now = datetime.now(timezone.utc)
+
+    decision = sm.evaluate(usage, "bob", now=now)
+
+    assert decision.action == "stay"
+    assert "all fallbacks stale" in decision.reason
+    assert "reauth needed" in decision.reason
+
+
+def test_evaluate_fresh_fallback_selected_normally(tmp_path: Path) -> None:
+    sm = _make_manager(tmp_path)
+    # Both fallbacks are fresh
+    _write_cred(sm, "alice", age_days=1)
+    _write_cred(sm, "erik", age_days=2)
+    usage = _exhausted_usage()
+    now = datetime.now(timezone.utc)
+
+    decision = sm.evaluate(usage, "bob", now=now)
+
+    assert decision.action == "switch"
+    assert decision.target in ("alice", "erik")

--- a/packages/gptme-subscription/tests/test_subscription_manager.py
+++ b/packages/gptme-subscription/tests/test_subscription_manager.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+import pytest
 from gptme_subscription.config import Config
 from gptme_subscription.manager import SubscriptionManager
 
@@ -137,6 +138,29 @@ def test_evaluate_skips_stale_fallback_picks_fresh(tmp_path: Path) -> None:
 
     assert decision.action == "switch"
     assert decision.target == "erik"
+
+
+def test_evaluate_stale_urgency_top_pick_reports_staleness_not_pressure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # P1: urgency reorders to put erik first, but erik is stale → alice is picked.
+    # The reason should say "erik stale", not "(lower pressure / expiry-aware)".
+    sm = _make_manager(tmp_path)
+    monkeypatch.setattr(
+        sm, "capacity_aware_fallback_order", lambda now=None: ["erik", "alice"]
+    )
+    _write_cred(sm, "alice", age_days=1)
+    # erik has no cred file → missing → stale
+    usage = _exhausted_usage()
+    now = datetime.now(timezone.utc)
+
+    decision = sm.evaluate(usage, "bob", now=now)
+
+    assert decision.action == "switch"
+    assert decision.target == "alice"
+    assert "erik" in decision.reason
+    assert "stale" in decision.reason
+    assert "lower pressure" not in decision.reason
 
 
 def test_evaluate_all_fallbacks_stale_stays(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- `evaluate()` now filters out stale credential slots (missing file or mtime > 7 days) when choosing a fallback during exhaustion, rebalance, and forward routing. If all fallbacks are stale, the decision is `action: "stay"` with a clear `"all fallbacks stale; reauth needed"` reason instead of pointing at a dead slot.
- `_execute_switch_decision()` emits `[ALERT]` to stderr when a switch is *refused* by the credential check (as opposed to merely *deferred* by autonomous session locks), so operators immediately know a fallback needs reauth.
- New `SubscriptionManager.slot_credential_is_stale(sub, stale_days=7.0, *, now)` — pure mtime check, `now`-injectable for deterministic tests.

## Motivation

The 2026-05-22 outage showed two gaps: the rebalancer recommended alice's slot even though its credential file hadn't been refreshed in 17 days, and the subsequent refusal during `--execute` produced no alert — a session bypassed the refusal with raw `ln -sf` and caused a ~2h CC outage.

## Test plan

- [ ] `uv run pytest packages/gptme-subscription/tests/ -q` — all 67 tests pass
- [ ] `ruff check + format` — clean
- [ ] `mypy` — clean

Related: ErikBjare/bob#788 incident journal, `lessons/workflow/refusal-is-information.md`