### PR TITLE
fix(sessions): don't trust short/misattributed trajectory for noop determination

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -340,9 +340,12 @@ def post_session(
     7. Unreliable-trajectory guard: a trajectory whose covered wall-clock is
        far below the caller-reported ``duration_seconds`` is likely truncated
        or misattributed (two concurrent same-backend sessions resolving to the
-       same log dir). When such a trajectory says ``"noop"`` but the caller
-       supplied git-range deliverables, those commits are kept and the outcome
-       is ``"productive"`` instead of a false ``"noop"``.
+       same log dir). When such a trajectory says ``"noop"``:
+       - If the caller supplied git-range deliverables, those commits are kept
+         and the outcome is ``"productive"`` instead of a false ``"noop"``.
+       - If the caller has no deliverables either, the outcome is ``"unknown"``
+         (recording ``"noop"`` would unfairly penalize the backend's bandit
+         weight for a session whose real work can't be observed).
     """
     if context_tier is not None and context_tier not in VALID_CONTEXT_TIERS:
         raise ValueError(
@@ -559,6 +562,18 @@ def post_session(
             # than the session ran — likely truncated or misattributed) and the
             # caller observed real git-range commits. Trust the commits.
             outcome = "productive"
+        elif not trajectory_reliable and not caller_deliverables:
+            # Trajectory is unreliable (truncated/misattributed) and no caller
+            # deliverables exist — outcome is genuinely unknown.  Recording noop
+            # here would penalize the backend in bandit scoring for a session
+            # whose real work we can't observe.
+            assert signals is not None  # implied by traj_productive is not None
+            logger.warning(
+                "Trajectory says noop but is unreliable (%d%% coverage); "
+                "no caller deliverables — recording unknown",
+                int(100 * (signals.get("session_duration_s", 0) / max(duration_seconds, 1))),
+            )
+            outcome = "unknown"
         else:
             outcome = "noop"
     elif start_commit is not None and end_commit is not None:

--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -111,6 +111,33 @@ def _merge_deliverable_details(
     )
 
 
+def _trajectory_duration_reliable(
+    signals: dict[str, Any] | None,
+    duration_seconds: int,
+    *,
+    min_coverage: float = 0.5,
+) -> bool:
+    """Whether the assigned trajectory plausibly covers the whole session.
+
+    Two concurrent same-backend sessions can resolve to the same gptme log
+    directory, so a session's assigned trajectory may actually belong to a
+    different (shorter) run. When the trajectory's message timestamps span far
+    less wall-clock than the caller-reported duration, the trajectory is not a
+    trustworthy productivity oracle: trusting it drops real
+    ``start_commit..HEAD`` deliverables and records a false noop (see
+    ErikBjare/bob "gptme false noop detection").
+
+    Returns ``True`` when there is no basis to doubt coverage (no signals, no
+    caller duration, or a missing/invalid trajectory span).
+    """
+    if not signals or duration_seconds <= 0:
+        return True
+    traj_span = signals.get("session_duration_s")
+    if not isinstance(traj_span, (int, float)) or traj_span <= 0:
+        return True
+    return traj_span >= min_coverage * duration_seconds
+
+
 #: Default path for grading weights config (Phase 3 multivariate grading).
 _GRADING_WEIGHTS_PATH = (
     Path(__file__).resolve().parent.parent.parent.parent.parent.parent
@@ -310,6 +337,12 @@ def post_session(
        explicit deliverables and the trajectory found no deliverables
        of its own (i.e. the trajectory couldn't validate or contradict
        the caller's evidence), upgrade to ``"productive"``.
+    7. Unreliable-trajectory guard: a trajectory whose covered wall-clock is
+       far below the caller-reported ``duration_seconds`` is likely truncated
+       or misattributed (two concurrent same-backend sessions resolving to the
+       same log dir). When such a trajectory says ``"noop"`` but the caller
+       supplied git-range deliverables, those commits are kept and the outcome
+       is ``"productive"`` instead of a false ``"noop"``.
     """
     if context_tier is not None and context_tier not in VALID_CONTEXT_TIERS:
         raise ValueError(
@@ -388,6 +421,13 @@ def post_session(
             if traj_model:
                 model = traj_model
 
+    # Whether the assigned trajectory plausibly covers the whole session. A
+    # trajectory spanning far less wall-clock than the caller's duration is
+    # likely truncated or misattributed (two concurrent same-backend sessions
+    # resolving to the same gptme log dir), so it must not be allowed to drop
+    # real git-range deliverables and record a false noop.
+    trajectory_reliable = _trajectory_duration_reliable(signals, duration_seconds)
+
     # --- Resolve deliverables ---
     # Trajectory is the authoritative source when available.  Git-range commits
     # (caller-supplied via start_commit..HEAD) pick up commits from concurrent
@@ -453,7 +493,7 @@ def post_session(
                 )
         else:
             # Trajectory ran but found no deliverables.
-            if traj_productive is False:
+            if traj_productive is False and trajectory_reliable:
                 # Trajectory explicitly says this was noop — caller SHAs are
                 # from concurrent sessions.
                 if caller_deliverables:
@@ -464,19 +504,24 @@ def post_session(
                     )
                 deliverables = []
             else:
-                # Trajectory didn't catalog deliverables but didn't rule out
-                # work.  Keep caller items as best evidence.
+                # Either the trajectory didn't rule out work, or it is
+                # unreliable (covers far less wall-clock than the session ran,
+                # so it is likely truncated or misattributed). Keep caller items
+                # as best evidence.
+                reason = "trajectory_unreliable" if traj_productive is False else "trajectory_empty"
                 if caller_deliverables:
                     logger.warning(
-                        "Trajectory ran but found no deliverables; keeping %d "
-                        "caller-supplied deliverable(s)",
+                        "Trajectory %s; keeping %d caller-supplied deliverable(s)",
+                        "is unreliable (duration mismatch)"
+                        if reason == "trajectory_unreliable"
+                        else "ran but found no deliverables",
                         len(caller_deliverables),
                     )
                 deliverables = list(dict.fromkeys(caller_deliverables))
                 extra_deliverable_details = _build_caller_deliverable_details(
                     caller_deliverables,
                     provenance_class="fallback_observed",
-                    evidence={"source": "caller", "reason": "trajectory_empty"},
+                    evidence={"source": "caller", "reason": reason},
                 )
     # else: no trajectory (signals is None) — keep caller git-range as fallback.
     elif caller_deliverables:
@@ -507,7 +552,15 @@ def post_session(
     if exit_code not in (0, 124):
         outcome = "failed"
     elif traj_productive is not None:
-        outcome = "productive" if traj_productive else "noop"
+        if traj_productive:
+            outcome = "productive"
+        elif not trajectory_reliable and caller_deliverables:
+            # Trajectory says noop but is unreliable (covers far less wall-clock
+            # than the session ran — likely truncated or misattributed) and the
+            # caller observed real git-range commits. Trust the commits.
+            outcome = "productive"
+        else:
+            outcome = "noop"
     elif start_commit is not None and end_commit is not None:
         outcome = "productive" if start_commit != end_commit else "noop"
     elif (start_commit is None) != (end_commit is None):

--- a/packages/gptme-sessions/tests/test_post_session.py
+++ b/packages/gptme-sessions/tests/test_post_session.py
@@ -689,6 +689,77 @@ def test_post_session_caller_deliverables_no_outcome_override_when_traj_noop(tmp
     assert result.record.deliverable_details == []
 
 
+def test_post_session_unreliable_trajectory_keeps_caller_deliverables(tmp_path: Path):
+    """A trajectory covering far less wall-clock than the session duration is
+    treated as unreliable (truncated/misattributed). Its noop verdict must NOT
+    drop the caller's real git-range commits or record a false noop.
+
+    Reproduces ErikBjare/bob session 36d9: two concurrent gptme sessions
+    resolved to the same log dir, so 36d9's 1158s run was assigned 026d's 214s
+    noop trajectory, dropping 36d9's real commits and recording a false noop.
+    """
+    store = SessionStore(sessions_dir=tmp_path)
+    fake_traj = tmp_path / "trajectory.jsonl"
+    fake_traj.write_text("")
+
+    # Trajectory says noop and covers only 214s of wall-clock...
+    fake_signals = {
+        "session_duration_s": 214,
+        "productive": False,
+        "deliverables": [],
+    }
+    real_sha = "abc1234567890abcdef1234567890abcdef1234"
+    with patch.object(_post_session_mod, "extract_from_path", return_value=fake_signals):
+        result = post_session(
+            store=store,
+            harness="gptme",
+            model="deepseek-v4-flash",
+            # ...but the session actually ran 1158s and made a real commit.
+            duration_seconds=1158,
+            trajectory_path=fake_traj,
+            deliverables=[real_sha],
+        )
+
+    assert result.record.outcome == "productive"
+    assert result.record.deliverables == [real_sha]
+    assert result.record.deliverable_details == [
+        {
+            "value": real_sha,
+            "kind": "commit",
+            "provenance_class": "fallback_observed",
+            "evidence": {"source": "caller", "reason": "trajectory_unreliable"},
+        }
+    ]
+
+
+def test_post_session_reliable_trajectory_still_drops_concurrent_commits(tmp_path: Path):
+    """Guard regression: when the trajectory span matches the session duration,
+    a trajectory-determined noop still drops caller git-range commits, so the
+    concurrent-session contamination filter stays intact."""
+    store = SessionStore(sessions_dir=tmp_path)
+    fake_traj = tmp_path / "trajectory.jsonl"
+    fake_traj.write_text("")
+
+    fake_signals = {
+        "session_duration_s": 600,
+        "productive": False,
+        "deliverables": [],
+    }
+    concurrent_sha = "deadbeef" + "01234567" * 4
+    with patch.object(_post_session_mod, "extract_from_path", return_value=fake_signals):
+        result = post_session(
+            store=store,
+            harness="gptme",
+            model="opus",
+            duration_seconds=620,  # trajectory covers ~97% — reliable
+            trajectory_path=fake_traj,
+            deliverables=[concurrent_sha],
+        )
+
+    assert result.record.outcome == "noop"
+    assert result.record.deliverables == []
+
+
 def test_post_session_trajectory_empty_deliverables_keeps_caller_when_productive(
     tmp_path: Path, caplog
 ):

--- a/packages/gptme-sessions/tests/test_post_session.py
+++ b/packages/gptme-sessions/tests/test_post_session.py
@@ -732,6 +732,40 @@ def test_post_session_unreliable_trajectory_keeps_caller_deliverables(tmp_path: 
     ]
 
 
+def test_post_session_unreliable_trajectory_no_caller_deliverables_records_unknown(
+    tmp_path: Path, caplog
+):
+    """When trajectory is unreliable (truncated/misattributed) and says noop,
+    but no caller deliverables exist either, record unknown — don't penalize
+    the backend with a false noop."""
+    import logging
+
+    store = SessionStore(sessions_dir=tmp_path)
+    fake_traj = tmp_path / "trajectory.jsonl"
+    fake_traj.write_text("")
+
+    fake_signals = {
+        "session_duration_s": 214,  # 3.5 minutes
+        "productive": False,
+        "deliverables": [],
+    }
+    with (
+        patch.object(_post_session_mod, "extract_from_path", return_value=fake_signals),
+        caplog.at_level(logging.INFO),
+    ):
+        result = post_session(
+            store=store,
+            harness="gptme",
+            model="opus",
+            duration_seconds=1158,  # 19 min real session
+            trajectory_path=fake_traj,
+            deliverables=[],  # no caller commits either
+        )
+
+    assert result.record.outcome == "unknown"
+    assert result.record.deliverables == []
+
+
 def test_post_session_reliable_trajectory_still_drops_concurrent_commits(tmp_path: Path):
     """Guard regression: when the trajectory span matches the session duration,
     a trajectory-determined noop still drops caller git-range commits, so the


### PR DESCRIPTION
## Problem

When two concurrent same-backend (gptme) autonomous sessions resolve to the **same** gptme log directory, a session can be assigned a `trajectory_path` that actually belongs to a different, shorter run. `post_session()` treats the trajectory as the authoritative productivity oracle, so a `noop` verdict from the *wrong* trajectory:

1. drops the session's real `start_commit..HEAD` git-range commits, and
2. records a false `noop`.

False noops corrupt CASCADE bandit reward signals — gptme sessions doing real work get penalized as unproductive, unfairly suppressing the gptme backend's Thompson-sampling weight.

### Confirmed case (ErikBjare/bob session 36d9)

| | duration | trajectory span | outcome | real commits |
|---|---|---|---|---|
| `026d` | 228s | 214s (matches) | noop (correct) | 0 |
| `36d9` | **1158s** | **214s** (18.5%) | noop (**false**) | 2+ |

Both records shared `session_name=run-autonomous-research-20260523030156-026d` and the same `trajectory_path`. That trajectory (a 3-minute noop ending 03:05:32) belongs to `026d`. `36d9` ran 19 min and committed at 03:11 / 03:19 — *after* the trajectory ends — so its commits were dropped.

## Fix

Add a **duration-coverage guard**: when the assigned trajectory's covered wall-clock (`session_duration_s`) is far below the caller-reported `duration_seconds` (< 50%), treat the trajectory as unreliable (truncated/misattributed). In that case:

- keep caller-supplied git-range deliverables instead of dropping them, and
- record `productive` instead of a false `noop`.

The concurrent-session contamination filter stays fully intact for trajectories whose span matches the session duration — those still drop git-range commits as before.

## Tests

- `test_post_session_unreliable_trajectory_keeps_caller_deliverables` — reproduces the 36d9 case (214s span / 1158s duration → productive, commits kept, `reason: trajectory_unreliable`).
- `test_post_session_reliable_trajectory_still_drops_concurrent_commits` — guard regression: matching span still drops concurrent commits → noop.
- Full suite: `794 passed`, mypy clean.

Ref: ErikBjare/bob "gptme false noop detection" task.