### PR TITLE
feat(sessions): add dropout_selection field to SessionRecord

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -240,6 +240,11 @@ class SessionRecord:
     # One of HARM_CATEGORY_LABELS, or None when not classified.
     harm_category: str | None = None
 
+    # Dropout selection flag (idea #793): when True, this session was randomly
+    # selected for deeper post-hoc review (random dropout sampling). Allows
+    # retrospective quality analysis independent of the regular judge queue.
+    dropout_selection: bool | None = None
+
     # Per-tool-call span aggregates (Phase 3 of span-level tracing, idea #158).
     # Dict shape mirrors SpanAggregates fields (total_spans, error_spans,
     # error_rate, dominant_tool, avg_duration_ms, max_duration_ms,


### PR DESCRIPTION
Adds an additive `dropout_selection: bool | None` field to `SessionRecord`.

## Why
Supports random dropout sampling (ErikBjare/bob#793). When an autonomous session is randomly selected (probability `DROP_OUT_FRACTION`, default 0.1) for deeper post-hoc quality review, this flag is recorded on the session record. A later review pipeline can then pull a stochastic sample of sessions independent of the regular LLM-judge queue — catching silent failures and subtle quality degradation the judge and the vent tool miss.

## Change
- One field, defaulting to `None` (not classified).
- `from_dict` already filters unknown keys, so existing records load unchanged and rollback is safe.

## Test
- `uv run pytest packages/gptme-sessions/tests/test_record.py` — 59 passed.

The Bob-side producer (sampling draw + flag write in `autonomous-run.sh`) lands separately in Bob's workspace.