### PR TITLE
feat(sessions): add dropout_selected, dropout_reason, dropout_depth fields to SessionRecord

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -23,6 +23,9 @@ HARM_CATEGORY_TAXONOMY: dict[str, str] = {
 }
 HARM_CATEGORY_LABELS: list[str] = list(HARM_CATEGORY_TAXONOMY.keys())
 
+# Valid values for the dropout_depth field.
+DROPOUT_DEPTH_VALUES: list[str] = ["shallow", "deep"]
+
 # Normalize model names to short canonical forms
 MODEL_ALIASES: dict[str, str] = {
     # Anthropic Claude models (bare) — dash and dot variants
@@ -294,6 +297,9 @@ class SessionRecord:
         # so downstream --by-category consumers never see unexpected keys.
         if self.harm_category is not None and self.harm_category not in HARM_CATEGORY_LABELS:
             self.harm_category = None
+        # Discard unrecognized dropout_depth values so typos don't silently reach consumers.
+        if self.dropout_depth is not None and self.dropout_depth not in DROPOUT_DEPTH_VALUES:
+            self.dropout_depth = None
 
     def set_productivity_grade(self, score: float) -> None:
         """Store the productivity dimension alongside the legacy scalar field."""

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -245,6 +245,14 @@ class SessionRecord:
     # retrospective quality analysis independent of the regular judge queue.
     dropout_selection: bool | None = None
 
+    # Random dropout sampling (ErikBjare/bob#793)
+    # Flag set by the autonomous-run.sh reconcile pass when the session is
+    # drawn for deeper post-hoc review. Dropout sessions get a richer secondary
+    # analysis beyond the standard LLM judge run.
+    dropout_selected: bool | None = None
+    dropout_reason: str | None = None  # "random_sampling" for selected sessions; None otherwise
+    dropout_depth: str | None = None  # "shallow" (standard judge) or "deep" (extra analysis)
+
     # Per-tool-call span aggregates (Phase 3 of span-level tracing, idea #158).
     # Dict shape mirrors SpanAggregates fields (total_spans, error_spans,
     # error_rate, dominant_tool, avg_duration_ms, max_duration_ms,

--- a/packages/gptme-sessions/tests/test_record.py
+++ b/packages/gptme-sessions/tests/test_record.py
@@ -582,3 +582,62 @@ def test_harm_category_corrupt_jsonl_roundtrip():
     raw = {"session_id": "abc123", "harm_category": "unknown_garbage"}
     r = SessionRecord.from_dict(raw)
     assert r.harm_category is None
+
+
+def test_dropout_fields_default():
+    """dropout_selected defaults to None and dropout_reason/dropout_depth
+    default to None."""
+    r = SessionRecord()
+    assert r.dropout_selected is None
+    assert r.dropout_reason is None
+    assert r.dropout_depth is None
+
+
+def test_dropout_fields_roundtrip():
+    """dropout_selected, dropout_reason, and dropout_depth survive
+    to_dict/from_dict round-trip."""
+    import json
+
+    r = SessionRecord(
+        session_id="test-dropout",
+        dropout_selected=True,
+        dropout_reason="random_sampling",
+        dropout_depth="deep",
+    )
+
+    d = r.to_dict()
+    assert d["dropout_selected"] is True
+    assert d["dropout_reason"] == "random_sampling"
+    assert d["dropout_depth"] == "deep"
+
+    r2 = SessionRecord.from_dict(d)
+    assert r2.dropout_selected is True
+    assert r2.dropout_reason == "random_sampling"
+    assert r2.dropout_depth == "deep"
+
+    # Also verify they survive the JSON path
+    parsed = json.loads(r.to_json())
+    assert parsed["dropout_selected"] is True
+    assert parsed["dropout_reason"] == "random_sampling"
+    assert parsed["dropout_depth"] == "deep"
+
+
+def test_dropout_fields_null_roundtrip():
+    """dropout fields default to None and survive null round-trip."""
+    import json
+
+    r = SessionRecord(session_id="test-no-dropout")
+    d = r.to_dict()
+    assert d["dropout_selected"] is None
+    assert d["dropout_reason"] is None
+    assert d["dropout_depth"] is None
+
+    r2 = SessionRecord.from_dict(d)
+    assert r2.dropout_selected is None
+    assert r2.dropout_reason is None
+    assert r2.dropout_depth is None
+
+    parsed = json.loads(r.to_json())
+    assert parsed["dropout_selected"] is None
+    assert parsed["dropout_reason"] is None
+    assert parsed["dropout_depth"] is None

--- a/packages/gptme-sessions/tests/test_record.py
+++ b/packages/gptme-sessions/tests/test_record.py
@@ -641,3 +641,10 @@ def test_dropout_fields_null_roundtrip():
     assert parsed["dropout_selected"] is None
     assert parsed["dropout_reason"] is None
     assert parsed["dropout_depth"] is None
+
+
+def test_dropout_depth_corrupt_jsonl_roundtrip():
+    """Unrecognized dropout_depth from JSONL is silently dropped on load."""
+    raw = {"session_id": "abc123", "dropout_depth": "depp"}
+    r = SessionRecord.from_dict(raw)
+    assert r.dropout_depth is None


### PR DESCRIPTION
Part of TimeToBuildBob/bob#793 (random dropout sampling).

## What
Three new fields on `SessionRecord`:
- `dropout_selected: bool | None` (default `None`) — `None` means the reconcile pass has not yet run; `True` means the session was randomly sampled for deeper post-hoc review; `False` means it was explicitly not selected. **Tristate is intentional** — `None` vs `False` are distinct states.
- `dropout_reason: str | None` — `"random_sampling"` for selected sessions; `None` otherwise
- `dropout_depth: str | None` — `"shallow"` (standard judge) or `"deep"` (extra analysis); unrecognized values are silently rejected in `__post_init__` (same pattern as `harm_category`)

## Why
Bob's autonomous-run.sh already writes `dropout_selected`/`dropout_reason`/`dropout_depth` into session records via the reconcile pass. The SessionRecord dataclass needs matching fields so the load->mutate->rewrite cycle preserves them instead of routing them to `_legacy_fields`.

## Verification
- 63 record tests pass (existing + 5 new tests: defaults, round-trip, JSON serialization, null round-trip, corrupt-JSONL rejection for `dropout_depth`)
- Backward compatible: older readers that don't know about these fields will capture them in `_legacy_fields` and preserve them on rewrite