### PR TITLE
feat(sessions): add dropout_selected, dropout_reason, dropout_depth fields to SessionRecord

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -24,7 +24,7 @@ HARM_CATEGORY_TAXONOMY: dict[str, str] = {
 HARM_CATEGORY_LABELS: list[str] = list(HARM_CATEGORY_TAXONOMY.keys())
 
 # Valid values for the dropout_depth field.
-DROPOUT_DEPTH_VALUES: list[str] = ["shallow", "deep"]
+DROPOUT_DEPTH_VALUES: frozenset[str] = frozenset(["shallow", "deep"])
 
 # Normalize model names to short canonical forms
 MODEL_ALIASES: dict[str, str] = {
@@ -294,6 +294,12 @@ class SessionRecord:
             self.harm_category = None
         # Discard unrecognized dropout_depth values so typos don't silently reach consumers.
         if self.dropout_depth is not None and self.dropout_depth not in DROPOUT_DEPTH_VALUES:
+            self.dropout_depth = None
+        # Cross-field consistency: when explicitly not selected (False), the detail fields
+        # have no meaning — clear them to prevent downstream consumers from reading an
+        # inconsistent combination (e.g. dropout_selected=False, dropout_depth="deep").
+        if self.dropout_selected is False:
+            self.dropout_reason = None
             self.dropout_depth = None
 
     def set_productivity_grade(self, score: float) -> None:

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -243,11 +243,6 @@ class SessionRecord:
     # One of HARM_CATEGORY_LABELS, or None when not classified.
     harm_category: str | None = None
 
-    # Dropout selection flag (idea #793): when True, this session was randomly
-    # selected for deeper post-hoc review (random dropout sampling). Allows
-    # retrospective quality analysis independent of the regular judge queue.
-    dropout_selection: bool | None = None
-
     # Random dropout sampling (ErikBjare/bob#793)
     # Flag set by the autonomous-run.sh reconcile pass when the session is
     # drawn for deeper post-hoc review. Dropout sessions get a richer secondary

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -452,6 +452,14 @@ class SessionRecord:
             and not filtered["journal_path"].endswith(".md")
         ):
             filtered["trajectory_path"] = filtered.pop("journal_path")
+        # Migrate legacy records: dropout_selection (bool, added in #963) was
+        # replaced by dropout_selected/dropout_reason/dropout_depth in #965.
+        # Forward the flag so records written between the two deploys aren't silently lost.
+        if "dropout_selection" in legacy and "dropout_selected" not in filtered:
+            if legacy["dropout_selection"]:
+                filtered["dropout_selected"] = True
+                filtered["dropout_reason"] = "random_sampling"
+            del legacy["dropout_selection"]
         if legacy:
             filtered["_legacy_fields"] = legacy
         return cls(**filtered)

--- a/packages/gptme-sessions/tests/test_record.py
+++ b/packages/gptme-sessions/tests/test_record.py
@@ -648,3 +648,20 @@ def test_dropout_depth_corrupt_jsonl_roundtrip():
     raw = {"session_id": "abc123", "dropout_depth": "depp"}
     r = SessionRecord.from_dict(raw)
     assert r.dropout_depth is None
+
+
+def test_dropout_selection_migration():
+    """Legacy dropout_selection=True is migrated to dropout_selected + reason."""
+    raw = {"session_id": "abc123", "dropout_selection": True}
+    r = SessionRecord.from_dict(raw)
+    assert r.dropout_selected is True
+    assert r.dropout_reason == "random_sampling"
+    assert "dropout_selection" not in r._legacy_fields
+
+
+def test_dropout_selection_false_not_migrated():
+    """Legacy dropout_selection=False does not set dropout_selected."""
+    raw = {"session_id": "abc123", "dropout_selection": False}
+    r = SessionRecord.from_dict(raw)
+    assert r.dropout_selected is None
+    assert r.dropout_reason is None

--- a/packages/gptme-sessions/tests/test_record.py
+++ b/packages/gptme-sessions/tests/test_record.py
@@ -665,3 +665,36 @@ def test_dropout_selection_false_not_migrated():
     r = SessionRecord.from_dict(raw)
     assert r.dropout_selected is None
     assert r.dropout_reason is None
+
+
+def test_dropout_cross_field_consistency_not_selected():
+    """dropout_reason and dropout_depth are cleared when dropout_selected=False."""
+    r = SessionRecord(
+        session_id="abc123",
+        dropout_selected=False,
+        dropout_reason="random_sampling",
+        dropout_depth="deep",
+    )
+    assert r.dropout_selected is False
+    assert r.dropout_reason is None
+    assert r.dropout_depth is None
+
+
+def test_dropout_cross_field_consistency_selected():
+    """dropout_reason and dropout_depth are preserved when dropout_selected=True."""
+    r = SessionRecord(
+        session_id="abc123",
+        dropout_selected=True,
+        dropout_reason="random_sampling",
+        dropout_depth="deep",
+    )
+    assert r.dropout_selected is True
+    assert r.dropout_reason == "random_sampling"
+    assert r.dropout_depth == "deep"
+
+
+def test_dropout_cross_field_consistency_none():
+    """dropout_reason and dropout_depth are preserved when dropout_selected=None (pending)."""
+    r = SessionRecord(session_id="abc123", dropout_selected=None, dropout_depth="shallow")
+    assert r.dropout_selected is None
+    assert r.dropout_depth == "shallow"


### PR DESCRIPTION
## Summary

Replaces the earlier `dropout_selection: bool` field (merged in #963) with a richer three-field schema for the random dropout sampling system (ErikBjare/bob#793):

- **`dropout_selected: bool | None`** — whether this session was drawn for deeper review
- **`dropout_reason: str | None`** — reason string for selected sessions (e.g. `"random_sampling"`)
- **`dropout_depth: str | None`** — analysis depth: `"shallow"` (standard judge) or `"deep"` (extra analysis)
- **`DROPOUT_DEPTH_VALUES`** constant for validated set of valid depth values

Validation in `__post_init__` discards unrecognized `dropout_depth` values, same pattern as `harm_category`. Tests cover all three fields and the validation boundary.

## Test plan

- [x] `pytest packages/gptme-sessions/tests/test_record.py -vx` passes
- [x] Existing `dropout_selection` consumers (none yet — field was just added in #963) transparently receive `None` from the new fields