### PR TITLE
fix(lessons): allow description and metadata fields in lesson validator

### DIFF
--- a/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
+++ b/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
@@ -205,6 +205,12 @@ class LessonValidator:
                 "archived_reason",
                 "archived_date",
                 "confound_note",
+                # Used by hybrid semantic matcher (gptme#2469) for description-
+                # based lesson retrieval — removing it silently degrades matching.
+                "description",
+                # Structural categorisation (e.g. metadata.tags) — not a score,
+                # not operational state; safe to keep in frontmatter.
+                "metadata",
             }
             extra_fields = set(frontmatter.keys()) - allowed_fields
             if extra_fields:

--- a/packages/gptme-lessons-extras/tests/test_validate.py
+++ b/packages/gptme-lessons-extras/tests/test_validate.py
@@ -101,6 +101,36 @@ def test_confidence_field_now_warned():
         ), "confidence field should produce a warning (store scores in state files, not frontmatter)"
 
 
+def test_description_field_not_warned():
+    """description field is used by hybrid semantic matcher (gptme#2469); should not warn."""
+    content = _MINIMAL_LESSON.format(
+        extra='description: "Persist insights across sessions to prevent rediscovery"'
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        path = _write_lesson(Path(tmp), content)
+        validator = LessonValidator(path)
+        validator.validate()
+        desc_warnings = [w for w in validator.warnings if "description" in w]
+        assert (
+            len(desc_warnings) == 0
+        ), "description field is load-bearing for semantic matching and should not warn"
+
+
+def test_metadata_field_not_warned():
+    """metadata field (e.g. metadata.tags) is structural categorisation; should not warn."""
+    content = _MINIMAL_LESSON.format(
+        extra="metadata:\n  tags: [meta-learning, persistent-insight]"
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        path = _write_lesson(Path(tmp), content)
+        validator = LessonValidator(path)
+        validator.validate()
+        meta_warnings = [w for w in validator.warnings if "metadata" in w]
+        assert (
+            len(meta_warnings) == 0
+        ), "metadata field is structural categorisation and should not warn"
+
+
 # ---------------------------------------------------------------------------
 # version field tests (Issue #614)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `description` and `metadata` to `allowed_fields` in the lesson validator
- `description` is now load-bearing for hybrid semantic matching ([gptme#2469](https://github.com/gptme/gptme/pull/2469)), which merged 2026-05-23. Previously the validator warned to remove it — an agent following this warning would silently degrade its own lesson retrieval.
- `metadata` (used for `metadata.tags` categorisation in several active lessons) is structural, not operational state, so it is safe to keep in frontmatter.

## Test plan

- [ ] Existing 24 validator tests still pass
- [ ] New `test_description_field_not_warned` confirms no warning on lessons with `description:`
- [ ] New `test_metadata_field_not_warned` confirms no warning on lessons with `metadata:`
- [ ] Unknown/unsupported fields (e.g. `bogus_field`, `confidence`) still produce warnings