### PR TITLE
fix(lessons): add description + keywords to greptile-pr-reviews

### DIFF
--- a/lessons/tools/greptile-pr-reviews.md
+++ b/lessons/tools/greptile-pr-reviews.md
@@ -3,7 +3,10 @@ match:
   keywords:
     - "greptile score"
     - "trigger greptile"
+    - "fresh greptile review"
+    - "greptile after fixing"
   session_categories: [cross-repo, code]
+description: "Trigger a fresh Greptile score after fixing P1 issues — use greptile-helper.sh to retrigger idempotently and avoid duplicate review spam"
 status: active
 ---
 


### PR DESCRIPTION
Adds `description:` field and two more keywords to the greptile-pr-reviews lesson.

The description field improves IDF-based retrieval (used in `prompt_lessons.py` scoring) — without it the lesson scored 0 via the description path, making it invisible to the resolver-eval benchmark. Also adds `"fresh greptile review"` and `"greptile after fixing"` as trigger phrases to cover natural language like "trigger greptile after fixing P1 issues".

Easy-mode resolver-eval: adds 1 hit (greptile-retrigger case passes after this change).