### PR TITLE
fix(twitter): unescape literal \n sequences in tweet text

### DIFF
--- a/scripts/twitter/llm.py
+++ b/scripts/twitter/llm.py
@@ -114,6 +114,16 @@ class EvaluationResponse:
         )
 
 
+def _unescape_literal_newlines(text: str) -> str:
+    """Replace literal two-character '\\n' sequences with actual newlines.
+
+    Some LLMs emit JSON where newlines are double-escaped (\\n instead of \n).
+    json.loads leaves these as literal backslash-n pairs. This helper fixes
+    them so tweets render correctly instead of leaking escape sequences.
+    """
+    return text.replace("\\n", "\n")
+
+
 @dataclass
 class TweetResponse:
     """Generated tweet response"""
@@ -129,10 +139,12 @@ class TweetResponse:
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "TweetResponse":
         return cls(
-            text=str(data["text"]),
+            text=_unescape_literal_newlines(str(data["text"])),
             type=str(data["type"]),
             thread_needed=bool(data["thread_needed"]),
-            follow_up=str(data["follow_up"]) if data.get("follow_up") else None,
+            follow_up=_unescape_literal_newlines(str(data["follow_up"]))
+            if data.get("follow_up")
+            else None,
             reasoning=str(data["reasoning"]),
         )
 

--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -273,8 +273,26 @@ class TweetDraft:
         - ``created`` as fallback for ``created_at``
         - ``context`` is optional (defaults to empty dict)
         """
+
+        # Unescape literal \\n sequences that some LLMs emit in JSON/YAML.
+        # This fixes tweets that leak escape sequences like "line1\\nline2".
+        def _fix(text: str | None) -> str | None:
+            if text is None:
+                return None
+            return text.replace("\\n", "\n")
+
+        raw_text = data.get("text", data.get("content", ""))
+        fixed_text: str | None = _fix(raw_text) if isinstance(raw_text, str) else None
+        if fixed_text is None:
+            fixed_text = ""
+
+        raw_thread = data.get("thread")
+        fixed_thread: list[str] | None = None
+        if isinstance(raw_thread, list):
+            fixed_thread = [_fix(t) if isinstance(t, str) else "" for t in raw_thread]
+
         draft = cls(
-            text=data.get("text", data.get("content", "")),
+            text=fixed_text,
             type=data.get("type", "tweet"),
             in_reply_to=data.get("in_reply_to"),
             scheduled_time=(
@@ -289,7 +307,7 @@ class TweetDraft:
             context=data.get("context", {}),
             reject_reason=data.get("reject_reason"),  # Optional, backward compatible
             quality_score=data.get("quality_score"),  # Optional, backward compatible
-            thread=data.get("thread"),  # Optional, backward compatible
+            thread=fixed_thread,
         )
         created_at = data.get("created_at", data.get("created"))
         if created_at is None:

--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -276,9 +276,7 @@ class TweetDraft:
 
         # Unescape literal \\n sequences that some LLMs emit in JSON/YAML.
         # This fixes tweets that leak escape sequences like "line1\\nline2".
-        def _fix(text: str | None) -> str | None:
-            if text is None:
-                return None
+        def _fix(text: str) -> str:
             return text.replace("\\n", "\n")
 
         raw_text = data.get("text", data.get("content", ""))

--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -66,6 +66,7 @@ from trusted_users import is_trusted_user  # type: ignore
 from twitter.llm import (
     EvaluationResponse,
     TweetResponse,
+    _unescape_literal_newlines,
     process_tweet,
     verify_draft,
 )
@@ -276,18 +277,19 @@ class TweetDraft:
 
         # Unescape literal \\n sequences that some LLMs emit in JSON/YAML.
         # This fixes tweets that leak escape sequences like "line1\\nline2".
-        def _fix(text: str) -> str:
-            return text.replace("\\n", "\n")
-
+        # Uses the shared _unescape_literal_newlines helper from twitter.llm.
         raw_text = data.get("text", data.get("content", ""))
-        fixed_text: str | None = _fix(raw_text) if isinstance(raw_text, str) else None
-        if fixed_text is None:
-            fixed_text = ""
+        fixed_text: str = (
+            _unescape_literal_newlines(raw_text) if isinstance(raw_text, str) else ""
+        )
 
         raw_thread = data.get("thread")
         fixed_thread: list[str] | None = None
         if isinstance(raw_thread, list):
-            fixed_thread = [_fix(t) if isinstance(t, str) else "" for t in raw_thread]
+            fixed_thread = [
+                _unescape_literal_newlines(t) if isinstance(t, str) else ""
+                for t in raw_thread
+            ]
 
         draft = cls(
             text=fixed_text,

--- a/tests/test_twitter_workflow_drafts.py
+++ b/tests/test_twitter_workflow_drafts.py
@@ -87,6 +87,7 @@ def _load_workflow_module() -> Any:
     twitter_llm_stub.TweetResponse = type("TweetResponse", (), {})
     twitter_llm_stub.process_tweet = lambda *args, **kwargs: None
     twitter_llm_stub.verify_draft = lambda *args, **kwargs: (True, None)
+    twitter_llm_stub._unescape_literal_newlines = lambda text: text.replace("\\n", "\n")
 
     twitter_api_stub: Any = types.ModuleType("twitter.twitter")
     twitter_api_stub.cached_get_me = lambda *args, **kwargs: SimpleNamespace(


### PR DESCRIPTION
Some LLMs (Codex, GPT-5.4/5.5) emit JSON/YAML with double-escaped newlines (\\n instead of \n). json.loads leaves these as literal backslash-n pairs, causing tweets to leak escape sequences like 'line1\nline2' instead of rendering actual line breaks.

Changes:
- llm.py: add _unescape_literal_newlines() helper, apply to TweetResponse.from_dict
- workflow.py: apply same fix in TweetDraft.from_dict for YAML-loaded drafts

Tested: existing tests pass (test_twitter_workflow_drafts.py 15 passed, test_twitter_eval_prompt.py 13 passed)

Fixes: ErikBjare/bob#794