### PR TITLE
docs(lessons): add description fields to autonomous and workflow lessons for hybrid matcher

### DIFF
--- a/lessons/autonomous/agent-event-watch-workflow.md
+++ b/lessons/autonomous/agent-event-watch-workflow.md
@@ -1,4 +1,5 @@
 ---
+description: "When significant upcoming events could change strategy, watch for them proactively rather than missing them"
 status: active
 match:
   keywords:

--- a/lessons/autonomous/autonomous-operation-safety.md
+++ b/lessons/autonomous/autonomous-operation-safety.md
@@ -1,4 +1,5 @@
 ---
+description: "Never combine private data access, untrusted content, and external comms in one step — apply containment principles"
 match:
   keywords:
   - lethal trifecta

--- a/lessons/autonomous/autonomous-session-pivot-strategies.md
+++ b/lessons/autonomous/autonomous-session-pivot-strategies.md
@@ -1,4 +1,5 @@
 ---
+description: "When technical blockers appear in autonomous mode, pivot quickly to alternative work instead of spending time debugging"
 match:
   keywords:
   - pivot when blocked

--- a/lessons/autonomous/autonomous-session-structure.md
+++ b/lessons/autonomous/autonomous-session-structure.md
@@ -1,4 +1,5 @@
 ---
+description: "Use the structured 4-phase approach (status, selection, execution, completion) for every autonomous session"
 match:
   keywords:
   - autonomous session structure

--- a/lessons/autonomous/blocked-period-status-check-trap.md
+++ b/lessons/autonomous/blocked-period-status-check-trap.md
@@ -1,4 +1,5 @@
 ---
+description: "When blocked for extended periods, stop creating repetitive status-check commits — do real work or write a lesson"
 match:
   keywords:
     - blocked period

--- a/lessons/autonomous/effective-autonomous-work-execution.md
+++ b/lessons/autonomous/effective-autonomous-work-execution.md
@@ -1,4 +1,5 @@
 ---
+description: "Execute autonomous work by completing real deliverables rather than spending time on meta-analysis or planning"
 match:
   keywords:
   - "autonomous session"

--- a/lessons/autonomous/effective-autonomous-work-execution.md
+++ b/lessons/autonomous/effective-autonomous-work-execution.md
@@ -1,5 +1,5 @@
 ---
-description: "Execute autonomous work by completing real deliverables rather than spending time on meta-analysis or planning"
+description: "Follow a structured 4-phase approach (status check, task selection, execution, commit) for autonomous sessions to maximise productivity and proper task management"
 match:
   keywords:
   - "autonomous session"

--- a/lessons/autonomous/escalation-vs-autonomy.md
+++ b/lessons/autonomous/escalation-vs-autonomy.md
@@ -1,4 +1,5 @@
 ---
+description: "When uncertain whether an action requires human approval, apply the reversibility and blast-radius tests before proceeding"
 match:
   keywords:
   - "should I ask the user or proceed autonomously"

--- a/lessons/autonomous/lesson-quality-standards.md
+++ b/lessons/autonomous/lesson-quality-standards.md
@@ -1,4 +1,5 @@
 ---
+description: "Write lessons that match specific observable failure signals, not general advice that applies to all situations"
 category: autonomous
 tags:
 - lesson-quality

--- a/lessons/autonomous/maintaining-readiness-during-blocked-periods.md
+++ b/lessons/autonomous/maintaining-readiness-during-blocked-periods.md
@@ -1,4 +1,5 @@
 ---
+description: "When waiting on blockers, maintain readiness by doing small improvements that keep the workspace healthy"
 match:
   keywords:
     - maintaining readiness when blocked

--- a/lessons/autonomous/multi-issue-coordination-patterns.md
+++ b/lessons/autonomous/multi-issue-coordination-patterns.md
@@ -1,4 +1,5 @@
 ---
+description: "When working across multiple issues/PRs, claim one issue at a time to avoid coordination failures"
 match:
   keywords:
   - multiple tasks blocked

--- a/lessons/autonomous/pre-mortem-for-risky-actions.md
+++ b/lessons/autonomous/pre-mortem-for-risky-actions.md
@@ -1,4 +1,5 @@
 ---
+description: "Before taking irreversible or high-blast-radius actions, name what could go wrong and verify safeguards are in place"
 match:
   keywords:
   - pre-mortem for risky actions

--- a/lessons/autonomous/rule-driven-session-gating.md
+++ b/lessons/autonomous/rule-driven-session-gating.md
@@ -1,4 +1,5 @@
 ---
+description: "Gate autonomous sessions on rule checks (claim verification, scope discipline) before executing significant work"
 status: active
 category: autonomous
 tags:

--- a/lessons/autonomous/safe-operation-patterns.md
+++ b/lessons/autonomous/safe-operation-patterns.md
@@ -1,4 +1,5 @@
 ---
+description: "Apply safe operation defaults (claim before execute, verify before delete, prefer reversible) in all autonomous work"
 match:
   keywords:
   - "classify operation before executing"

--- a/lessons/autonomous/scope-discipline-in-autonomous-work.md
+++ b/lessons/autonomous/scope-discipline-in-autonomous-work.md
@@ -1,4 +1,5 @@
 ---
+description: "Stay within the declared scope of a task — don't expand work or create adjacent PRs without declaring the new lane"
 match:
   keywords:
   - "while working on X noticed Y could be improved"

--- a/lessons/autonomous/strategic-completion-leverage-when-blocked.md
+++ b/lessons/autonomous/strategic-completion-leverage-when-blocked.md
@@ -1,4 +1,5 @@
 ---
+description: "When the primary task is blocked, identify and complete high-leverage adjacent work that unblocks future sessions"
 match:
   keywords:
   - blocked on external

--- a/lessons/autonomous/strategic-focus-during-autonomous-sessions.md
+++ b/lessons/autonomous/strategic-focus-during-autonomous-sessions.md
@@ -1,4 +1,5 @@
 ---
+description: "Prioritize tasks by strategic value and verifiability rather than picking the easiest visible work"
 category: autonomous
 tags:
 - autonomous-sessions

--- a/lessons/autonomous/thompson-sampling-work-categories.md
+++ b/lessons/autonomous/thompson-sampling-work-categories.md
@@ -1,5 +1,4 @@
 ---
-description: "Use Thompson sampling to select work categories based on historical success rates rather than fixed rotation"
 status: deprecated
 category: autonomous
 tags:

--- a/lessons/autonomous/thompson-sampling-work-categories.md
+++ b/lessons/autonomous/thompson-sampling-work-categories.md
@@ -1,4 +1,5 @@
 ---
+description: "Use Thompson sampling to select work categories based on historical success rates rather than fixed rotation"
 status: deprecated
 category: autonomous
 tags:

--- a/lessons/workflow/agent-workspace-setup-maintenance.md
+++ b/lessons/workflow/agent-workspace-setup-maintenance.md
@@ -1,4 +1,5 @@
 ---
+description: "Keep the agent workspace clean and functional by running periodic health checks and fixing broken invariants"
 match:
   keywords:
     - "setting up new agent workspace"

--- a/lessons/workflow/check-existing-prs.md
+++ b/lessons/workflow/check-existing-prs.md
@@ -1,4 +1,5 @@
 ---
+description: "Before opening a new PR, check for existing open PRs on the same branch or topic to avoid duplicates"
 match:
   keywords:
   - gh api graphql

--- a/lessons/workflow/communication-loop-closure-patterns.md
+++ b/lessons/workflow/communication-loop-closure-patterns.md
@@ -1,4 +1,5 @@
 ---
+description: "Close communication loops explicitly — every mention/ping deserves a reply that resolves or routes the request"
 match:
   keywords:
   - close the communication loop

--- a/lessons/workflow/documentation-principle.md
+++ b/lessons/workflow/documentation-principle.md
@@ -1,4 +1,5 @@
 ---
+description: "Only document something when the documentation will be read soon; skip just-in-case docs that clutter context"
 match:
   keywords:
   - "let me document this"

--- a/lessons/workflow/fork-pr-secrets.md
+++ b/lessons/workflow/fork-pr-secrets.md
@@ -1,4 +1,5 @@
 ---
+description: "When submitting PRs from a fork, secrets in the parent repo are not available — avoid workflows that require them"
 match:
   keywords:
     - "ANTHROPIC_API_KEY not set"

--- a/lessons/workflow/git-commit-format.md
+++ b/lessons/workflow/git-commit-format.md
@@ -1,4 +1,5 @@
 ---
+description: "Format commits as Conventional Commits (type(scope): description) with focused, atomic changes per commit"
 match:
   keywords:
   - "conventional commits"

--- a/lessons/workflow/gptme-contrib-contribution-pattern.md
+++ b/lessons/workflow/gptme-contrib-contribution-pattern.md
@@ -1,4 +1,5 @@
 ---
+description: "When improving gptme-contrib, create a feature branch, PR, wait for merge, then advance the submodule pointer"
 match:
   keywords: ["contrib PR"]
   session_categories: [cross-repo, code]

--- a/lessons/workflow/measure-before-optimize.md
+++ b/lessons/workflow/measure-before-optimize.md
@@ -1,4 +1,5 @@
 ---
+description: "Measure actual performance or behavior before optimizing — don't optimize based on assumptions or guesses"
 match:
   keywords:
   - "should drop to"

--- a/lessons/workflow/pr-recovery-after-accidental-closure.md
+++ b/lessons/workflow/pr-recovery-after-accidental-closure.md
@@ -1,4 +1,5 @@
 ---
+description: "When a PR is accidentally closed, recover it cleanly rather than opening a duplicate with the same diff"
 match:
   keywords:
     - closed pr

--- a/lessons/workflow/pre-issue-creation-checklist.md
+++ b/lessons/workflow/pre-issue-creation-checklist.md
@@ -1,4 +1,5 @@
 ---
+description: "Before creating an issue, verify it doesn't already exist and that it's clearly scoped and actionable"
 match:
   keywords:
     - "duplicate prevention"

--- a/lessons/workflow/pre-landing-self-review.md
+++ b/lessons/workflow/pre-landing-self-review.md
@@ -1,4 +1,5 @@
 ---
+description: "Before landing significant changes, run the self-review checklist to catch correctness issues CI won't catch"
 match:
   keywords: ["self-review", "pre-landing", "review iteration", "code review", "substantial change"]
   session_categories: [code, self-review]

--- a/lessons/workflow/proactive-correction-in-agent-messages.md
+++ b/lessons/workflow/proactive-correction-in-agent-messages.md
@@ -1,4 +1,5 @@
 ---
+description: "When a message contains a factual error or misunderstanding, correct it immediately rather than letting it propagate"
 status: active
 tags: [inter-agent, correction, orchestration, epistemic-integrity, communication]
 match:

--- a/lessons/workflow/progress-despite-blockers.md
+++ b/lessons/workflow/progress-despite-blockers.md
@@ -1,4 +1,5 @@
 ---
+description: "When the primary path is blocked, find adjacent unblocked work that keeps the session productive"
 match:
   keywords:
   - "completely blocked"

--- a/lessons/workflow/session-ending-protocol.md
+++ b/lessons/workflow/session-ending-protocol.md
@@ -1,5 +1,4 @@
 ---
-description: "End sessions with a committed journal entry, pushed changes, and task state updates — never leave sessions undocumented"
 match:
   keywords: ["session complete", "ending a session", "wrap up the session", "land the plane", "session ending checklist", "before completing"]
   session_categories: [code, cross-repo, infrastructure, cleanup]

--- a/lessons/workflow/session-ending-protocol.md
+++ b/lessons/workflow/session-ending-protocol.md
@@ -1,4 +1,5 @@
 ---
+description: "End sessions with a committed journal entry, pushed changes, and task state updates — never leave sessions undocumented"
 match:
   keywords: ["session complete", "ending a session", "wrap up the session", "land the plane", "session ending checklist", "before completing"]
   session_categories: [code, cross-repo, infrastructure, cleanup]

--- a/lessons/workflow/session-startup-recent-actions-review.md
+++ b/lessons/workflow/session-startup-recent-actions-review.md
@@ -1,4 +1,5 @@
 ---
+description: "At session start, review recent commits and active tasks to avoid duplicating parallel session work"
 match:
   keywords:
     - "skipped recent actions review"

--- a/lessons/workflow/stated-intention-follow-through.md
+++ b/lessons/workflow/stated-intention-follow-through.md
@@ -1,4 +1,5 @@
 ---
+description: "When you state an intention (I will do X), follow through on it in the same session — unmet stated intentions erode trust"
 status: active
 match:
   keywords:

--- a/lessons/workflow/verifiable-tasks-principle.md
+++ b/lessons/workflow/verifiable-tasks-principle.md
@@ -1,4 +1,5 @@
 ---
+description: "Prefer tasks with strong verification (tests, CI, benchmarks) over subjective tasks where success is ambiguous"
 match:
   keywords:
   - "how do I know when this is done"

--- a/lessons/workflow/when-to-rebase-prs.md
+++ b/lessons/workflow/when-to-rebase-prs.md
@@ -1,4 +1,5 @@
 ---
+description: "Rebase a PR only when its branch is behind master and conflicts prevent merge — don't rebase for aesthetic reasons"
 match:
   keywords:
     - commits behind

--- a/lessons/workflow/worktree-push-trap.md
+++ b/lessons/workflow/worktree-push-trap.md
@@ -1,4 +1,5 @@
 ---
+description: "After `git worktree add -b BRANCH origin/master`, always push with explicit `git push -u origin BRANCH` not bare `git push`"
 match:
   keywords:
     - "git worktree add"

--- a/lessons/workflow/worktree-push-trap.md
+++ b/lessons/workflow/worktree-push-trap.md
@@ -1,5 +1,5 @@
 ---
-description: "After `git worktree add -b BRANCH origin/master`, always push with explicit `git push -u origin BRANCH` not bare `git push`"
+description: "After `git worktree add -b BRANCH origin/master`, push with explicit refspec `git push -u origin BRANCH:BRANCH` — bare `git push -u origin BRANCH` targets master due to push.default=upstream"
 match:
   keywords:
     - "git worktree add"


### PR DESCRIPTION
## Summary

- Adds `description:` field to YAML frontmatter of 36 lesson files across `lessons/autonomous/` (17 files) and `lessons/workflow/` (19 files)
- These single-sentence descriptions are used by gptme's newly-shipped hybrid lesson retrieval system (gptme/gptme#2469) for semantic matching via the `description` field
- Descriptions capture the core behavioral guidance of each lesson in one sentence, enabling semantic retrieval to complement keyword matching

## Motivation

gptme/gptme#2469 added hybrid lesson retrieval that uses `description` fields for semantic search. Without descriptions, lessons fall back to keyword-only matching. Adding descriptions improves recall for sessions where the relevant lesson keywords don't appear verbatim but the intent matches.

## Test plan

- [ ] Verify all modified lesson files still pass the lesson validator: `find lessons -name "*.md" -not -name "README.md" -print0 | xargs -0 python3 packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py`
- [ ] Confirm descriptions are single-sentence and accurately capture each lesson's core rule