### PR TITLE
docs(lessons): add description fields to 60 remaining lesson files for hybrid matcher

### DIFF
--- a/lessons/autonomous/thompson-sampling-work-categories.md
+++ b/lessons/autonomous/thompson-sampling-work-categories.md
@@ -13,6 +13,7 @@ match:
   - category selection explore exploit
   - work category bandit setup
   session_categories: [monitoring, self-review]
+description: "Use Thompson sampling over *work categories* (code, triage, infrastructure, content), not *session modes* (autonomous, monitoring, email)."
 ---
 
 # Thompson Sampling for Work Category Optimization

--- a/lessons/communication/github-comment-formatting.md
+++ b/lessons/communication/github-comment-formatting.md
@@ -10,6 +10,7 @@ tags:
 - file-references
 - formatting
 status: active
+description: "Always format file references in GitHub comments as clickable links using proper markdown syntax for the repository context."
 ---
 
 # GitHub Comment Formatting for File References

--- a/lessons/communication/github-issue-follow-through.md
+++ b/lessons/communication/github-issue-follow-through.md
@@ -9,6 +9,7 @@ match:
     - missing follow-up response
     - broken communication loop
 status: deprecated
+description: "ALWAYS respond in the original issue thread when completing any action requested in that thread."
 ---
 
 # GitHub Issue Follow-Through Pattern

--- a/lessons/communication/responding-to-code-review-feedback.md
+++ b/lessons/communication/responding-to-code-review-feedback.md
@@ -9,6 +9,7 @@ match:
   - "review feedback needs response"
   - "address review feedback"
 status: active
+description: "Respond promptly and constructively to code review feedback, providing clear action plans and seeking clarification when feedback is ambiguous."
 ---
 
 # Responding to Code Review Feedback

--- a/lessons/concepts/gepa-genetic-pareto.md
+++ b/lessons/concepts/gepa-genetic-pareto.md
@@ -8,6 +8,7 @@ match:
     - "mutate lesson"
   session_categories: [monitoring]
 status: active
+description: "Use GEPA-inspired mutation to fix underperforming lessons: diagnose first, mutate content/keywords, validate with LLM-as-judge before applying."
 ---
 
 # GEPA-Based Lesson Optimization

--- a/lessons/concepts/hierarchical-context-management.md
+++ b/lessons/concepts/hierarchical-context-management.md
@@ -5,6 +5,7 @@ match:
   - organize context across steps
   - prune older conversation context
 status: active
+description: "**Hierarchical Context Management**: Context architecture pattern used in advanced agent systems like Factory's Droid."
 ---
 
 # Hierarchical Context Management (Droid Architecture)

--- a/lessons/concepts/llmlingua-compression.md
+++ b/lessons/concepts/llmlingua-compression.md
@@ -5,6 +5,7 @@ match:
     - "llmlingua compression"
     - "prompt compression technique"
 status: deprecated
+description: "**LLMLingua**: LLM-based prompt compression technique."
 ---
 # LLMLingua (Compression Technique)
 

--- a/lessons/infrastructure/trajectory-persistence.md
+++ b/lessons/infrastructure/trajectory-persistence.md
@@ -13,6 +13,7 @@ match:
 target_grade: alignment
 status: active
 confound_note: "cleanup-selection-bias — LOO-negative because it fires in inherently higher-harm cleanup contexts, not because it causes harm"
+description: "Never delete trajectory files, session records, session data directories, or any data that captures what happened in agent sessions."
 ---
 
 # Trajectory Persistence

--- a/lessons/patterns/avoid-deep-nesting.md
+++ b/lessons/patterns/avoid-deep-nesting.md
@@ -4,6 +4,7 @@ match:
   - "deeply nested"
   - "early return"
 status: active
+description: "Refactor code when nesting exceeds 3-4 levels using guard clauses, function extraction, or condition inversion."
 ---
 
 # Avoid Deeply Nested Code Structures

--- a/lessons/patterns/avoid-excessive-setup-when-dir.md
+++ b/lessons/patterns/avoid-excessive-setup-when-dir.md
@@ -5,6 +5,7 @@ match:
     - "5+ chains on prerequisites"
     - "need to understand full pipeline before testing"
 status: active
+description: "If you spend >5 chains on prerequisites (finding files, understanding pipelines, setting up dependencies), stop and identify a minimal test case."
 ---
 
 # Avoid Excessive Setup When Testing Components

--- a/lessons/patterns/avoid-long-try-blocks.md
+++ b/lessons/patterns/avoid-long-try-blocks.md
@@ -10,6 +10,7 @@ match:
   - "wrap in try"
   session_categories: [code]
 status: active
+description: "Keep try blocks focused on single operations (≤10 lines) to make errors identifiable and patches manageable."
 ---
 
 # Avoid Long Try/Catch Blocks

--- a/lessons/patterns/close-the-loop.md
+++ b/lessons/patterns/close-the-loop.md
@@ -14,6 +14,7 @@ match:
     - "waiting for human input"
     - "human bottleneck"
 status: active
+description: "Every point where an agent would stop and wait for human input is an opportunity for automation."
 ---
 
 # Close the Loop

--- a/lessons/patterns/data-loader-pr-quality.md
+++ b/lessons/patterns/data-loader-pr-quality.md
@@ -5,7 +5,7 @@ match:
   - assert path
   session_categories: [code]
 status: active
-description: "When writing data loader PRs for any data pipeline, apply these six patterns to produce."
+description: "When writing data loader PRs for any data pipeline, apply these six patterns to produce production-quality code that passes automated review on the first cycle."
 ---
 
 # Data Loader PR Quality Patterns

--- a/lessons/patterns/data-loader-pr-quality.md
+++ b/lessons/patterns/data-loader-pr-quality.md
@@ -5,6 +5,7 @@ match:
   - assert path
   session_categories: [code]
 status: active
+description: "When writing data loader PRs for any data pipeline, apply these six patterns to produce."
 ---
 
 # Data Loader PR Quality Patterns

--- a/lessons/patterns/loop-detection.md
+++ b/lessons/patterns/loop-detection.md
@@ -6,6 +6,7 @@ match:
     - "repeating failed action without progress"
     - "detected repetitive tool calls"
 status: active
+description: "Detect when performing the same action repeatedly (3+ times) and break the loop."
 ---
 
 # Detect and Break Repetitive Action Loops

--- a/lessons/patterns/persist-before-noting.md
+++ b/lessons/patterns/persist-before-noting.md
@@ -10,6 +10,7 @@ match:
     - "for next time"
     - "should write this down"
 status: active
+description: "When you say you have noted or learned something, immediately persist it to a core file before continuing."
 ---
 
 # Persist Before Noting

--- a/lessons/patterns/progressive-disclosure.md
+++ b/lessons/patterns/progressive-disclosure.md
@@ -6,6 +6,7 @@ match:
     - "context budget consumed by rarely-needed content"
   session_categories: [knowledge, cleanup]
 status: active
+description: "Restructure large documentation files (>500 lines, >5k tokens) into slim indexes with on-demand detail directories."
 ---
 
 # Progressive Disclosure for Documentation

--- a/lessons/patterns/simplify-before-optimize.md
+++ b/lessons/patterns/simplify-before-optimize.md
@@ -13,6 +13,7 @@ match:
   session_categories: [code, infrastructure]
 status: active
 target_grade: alignment
+description: "Always simplify a system BEFORE optimizing it."
 ---
 
 # Simplify Before Optimize

--- a/lessons/social/github-issue-engagement.md
+++ b/lessons/social/github-issue-engagement.md
@@ -14,6 +14,7 @@ match:
   - "check if already commented"
   - "before posting any comment"
 status: active
+description: "Always search for existing issues/PRs before creating new ones, read full context before engaging, check your own previous comments before posting, and update issues/PRs after completing work."
 ---
 
 # GitHub Issue and PR Engagement

--- a/lessons/tools/add-new-package-paths-to-mypy-.md
+++ b/lessons/tools/add-new-package-paths-to-mypy-.md
@@ -7,6 +7,7 @@ match:
     - "type checking fails after adding package"
     - "add package to mypy.ini"
 status: active
+description: "When creating a new workspace package, immediately add 'packages/PACKAGE_NAME/src' to the mypy_path setting in mypy."
 ---
 
 # Add New Package Paths to mypy Configuration

--- a/lessons/tools/ast-grep-refactoring.md
+++ b/lessons/tools/ast-grep-refactoring.md
@@ -5,6 +5,7 @@ match:
   - ast-grep structural search
   - code refactoring across files
 status: active
+description: "Use ast-grep (sg) for structural code search and refactoring when patterns are complex or language-specific."
 ---
 
 # Using ast-grep for Code Refactoring

--- a/lessons/tools/browser-verification.md
+++ b/lessons/tools/browser-verification.md
@@ -7,6 +7,7 @@ match:
   - "javascript fix without testing"
   session_categories: [code]
 status: active
+description: "Always verify web changes by checking console outputs and visual rendering before declaring them fixed."
 ---
 
 # Browser Verification for Web Changes

--- a/lessons/tools/check-cli---help-before-readin.md
+++ b/lessons/tools/check-cli---help-before-readin.md
@@ -5,6 +5,7 @@ match:
     - "wrap the command to add"
     - "before patching the wrapper"
 status: active
+description: "Before examining source code or making assumptions about a CLI tool's capabilities, run the command with --help to discover available options, subcommands, and flags that can simplify your approach."
 ---
 
 # Check CLI --help Before Reading Source Code

--- a/lessons/tools/configure-pytest-pythonpath-fo.md
+++ b/lessons/tools/configure-pytest-pythonpath-fo.md
@@ -7,6 +7,7 @@ match:
     - "workspace package not found"
     - "cannot import in tests"
 status: active
+description: "Configure pytest pythonpath in pyproject."
 ---
 
 # Configure pytest pythonpath for Monorepo

--- a/lessons/tools/configure-pytest-pythonpath-fo.md
+++ b/lessons/tools/configure-pytest-pythonpath-fo.md
@@ -7,7 +7,7 @@ match:
     - "workspace package not found"
     - "cannot import in tests"
 status: active
-description: "Configure pytest pythonpath in pyproject."
+description: "Configure pytest pythonpath in pyproject.toml to include all workspace package source directories when working in a monorepo structure."
 ---
 
 # Configure pytest pythonpath for Monorepo

--- a/lessons/tools/gh-pr-checks-exit-code-8.md
+++ b/lessons/tools/gh-pr-checks-exit-code-8.md
@@ -12,6 +12,7 @@ generated_from:
   sessions: 538
   tool: bash
   error_signature: "Exit code 8"
+description: "When `gh pr checks --watch` exits with code 8, it means checks are still in progress — treat it as try again later, not as a failure."
 ---
 
 # gh pr checks --watch Exits 8 for Pending Checks (Not a Failure)

--- a/lessons/tools/gh-pr-review-extension.md
+++ b/lessons/tools/gh-pr-review-extension.md
@@ -8,6 +8,7 @@ match:
     - "close conversation thread"
     - "mark thread resolved"
 status: archived
+description: "Use the `gh-pr-review` extension to manage PR review threads: **comment + resolve** when the issue is resolved (pushed fix OR explained why it's not an issue), **comment only** when seeking."
 ---
 
 # gh-pr-review Extension for Review Thread Management

--- a/lessons/tools/gh-pr-review-extension.md
+++ b/lessons/tools/gh-pr-review-extension.md
@@ -8,7 +8,7 @@ match:
     - "close conversation thread"
     - "mark thread resolved"
 status: archived
-description: "Use the `gh-pr-review` extension to manage PR review threads: **comment + resolve** when the issue is resolved (pushed fix OR explained why it's not an issue), **comment only** when seeking."
+description: "Use the `gh-pr-review` extension to manage PR review threads: **comment + resolve** when the issue is resolved (pushed fix OR explained why it's not an issue), **comment only** when seeking clarification or deferring."
 ---
 
 # gh-pr-review Extension for Review Thread Management

--- a/lessons/tools/linear-api-integration.md
+++ b/lessons/tools/linear-api-integration.md
@@ -7,7 +7,7 @@ match:
   session_categories: [triage, infrastructure]
 category: tools
 status: active
-description: "Use `linear-activity."
+description: "Use `linear-activity.py` CLI for common operations; fall back to GraphQL API only when CLI doesn't support the operation."
 ---
 # Linear API Integration
 

--- a/lessons/tools/linear-api-integration.md
+++ b/lessons/tools/linear-api-integration.md
@@ -7,6 +7,7 @@ match:
   session_categories: [triage, infrastructure]
 category: tools
 status: active
+description: "Use `linear-activity."
 ---
 # Linear API Integration
 

--- a/lessons/tools/markdown-codeblock-syntax.md
+++ b/lessons/tools/markdown-codeblock-syntax.md
@@ -14,6 +14,7 @@ automation:
   enforcement: warning
   automated_date: 2025-11-26
 status: active
+description: "Always specify language tags for markdown codeblocks (```txt, ```csv, ```ascii, ```diagram) to prevent parsing cut-offs."
 ---
 
 # Markdown Codeblock Syntax

--- a/lessons/tools/match-mypy-error-codes-to-actu.md
+++ b/lessons/tools/match-mypy-error-codes-to-actu.md
@@ -7,6 +7,7 @@ match:
     - "import-untyped"
     - "Cannot find implementation or library stub"
 status: active
+description: "Match mypy error codes to the actual error type when using `type: ignore` comments."
 ---
 
 # Match mypy Error Codes to Actual Error Type

--- a/lessons/tools/mcp-cli-token-efficiency.md
+++ b/lessons/tools/mcp-cli-token-efficiency.md
@@ -8,6 +8,7 @@ match:
     - "lazy MCP"
 category: tools
 status: active
+description: "Use `mcp-cli` to interact with MCP servers on-demand instead of loading all tool schemas into context at startup."
 ---
 # mcp-cli for Token-Efficient MCP Interactions
 

--- a/lessons/tools/notion-mcp-integration.md
+++ b/lessons/tools/notion-mcp-integration.md
@@ -9,6 +9,7 @@ match:
     - "NOTION_TOKEN"
 category: tools
 status: active
+description: "Use mcp-cli with the Notion MCP server for reading and writing Notion content."
 ---
 # Notion MCP Integration
 

--- a/lessons/tools/python-file-execution.md
+++ b/lessons/tools/python-file-execution.md
@@ -7,6 +7,7 @@ match:
   - "shebang python execution"
   - "ModuleNotFoundError when dependencies should be available"
 status: active
+description: "Choose the correct Python execution method based on script type and context: uv scripts with shebang use direct execution, poetry projects use `poetry run`, standalone scripts use appropriate tooling."
 ---
 
 # Python File Execution

--- a/lessons/tools/python-invocation.md
+++ b/lessons/tools/python-invocation.md
@@ -13,6 +13,7 @@ match:
   - "python not installed"
   - "use python3"
 status: active
+description: "Always use `python3` explicitly instead of `python` in shell commands and scripts."
 ---
 
 # Python Invocation

--- a/lessons/tools/shell-command-chaining.md
+++ b/lessons/tools/shell-command-chaining.md
@@ -6,6 +6,7 @@ match:
   - "chain shell commands"
   - "command chaining"
 status: active
+description: "Chain related shell commands in a single block instead of multiple separate executions."
 ---
 
 # Shell Command Chaining

--- a/lessons/tools/shell-output-filtering.md
+++ b/lessons/tools/shell-output-filtering.md
@@ -6,6 +6,7 @@ match:
   - large output 1000+ lines
   - token efficiency shell
 status: deprecated
+description: "Always filter shell output with grep/head/tail when expecting large results (>1000 lines)."
 ---
 
 # Shell Output Filtering for Token Efficiency

--- a/lessons/tools/shell-path-quoting.md
+++ b/lessons/tools/shell-path-quoting.md
@@ -5,6 +5,7 @@ match:
   - quoted path
   - spaces quoting
 status: active
+description: "Always quote paths that may contain spaces in shell commands."
 ---
 
 # Shell Path Quoting for Spaces

--- a/lessons/tools/sibling-tool-call-errored.md
+++ b/lessons/tools/sibling-tool-call-errored.md
@@ -5,6 +5,7 @@ match:
     - "parallel tool call failed"
     - "tool call error in batch"
 status: active
+description: "When a tool in a parallel batch reports Sibling tool call errored, find the *real* failing call first — then retry only that one, not all calls in the batch."
 ---
 
 # Sibling Tool Call Errored Cascades from One Failed Tool in a Batch

--- a/lessons/tools/stage-files-before-commit.md
+++ b/lessons/tools/stage-files-before-commit.md
@@ -7,6 +7,7 @@ match:
     - "prek shows old errors"
     - "commit untracked file"
 status: active
+description: "Always `git add <files>` before committing or running prek."
 ---
 
 # Stage Files with git add Before Commit/prek

--- a/lessons/tools/tmux-long-running-processes.md
+++ b/lessons/tools/tmux-long-running-processes.md
@@ -8,6 +8,7 @@ match:
   - "120-second shell timeout"
   - "long-running command needs tmux"
 status: active
+description: "Always use tmux (not shell tool) for processes exceeding 120-second shell timeout."
 ---
 
 # Tmux for Long-Running Processes

--- a/lessons/tools/todoist-mcp-integration.md
+++ b/lessons/tools/todoist-mcp-integration.md
@@ -9,6 +9,7 @@ match:
     - "TODOIST_API_TOKEN"
 category: tools
 status: active
+description: "Use mcp-cli with the Todoist MCP server for task management."
 ---
 # Todoist MCP Integration
 

--- a/lessons/tools/uv-sync-all-packages-after-changes.md
+++ b/lessons/tools/uv-sync-all-packages-after-changes.md
@@ -8,6 +8,7 @@ match:
     - "uv sync all packages after changes"
   session_categories: [code, infrastructure]
 status: active
+description: "After modifying workspace structure (adding dependencies or creating new packages), run 'uv sync --all-packages' to install all workspace packages and make them importable."
 ---
 
 # Run uv sync --all-packages After Workspace Changes

--- a/lessons/workflow/absolute-paths-for-workspace-files.md
+++ b/lessons/workflow/absolute-paths-for-workspace-files.md
@@ -9,6 +9,7 @@ match:
   - "file ended up in wrong"
   - "journal created in external repo"
 status: active
+description: "Always use absolute paths when saving/appending to workspace files."
 ---
 
 # Always Use Absolute Paths for Workspace Files

--- a/lessons/workflow/agent-credential-management.md
+++ b/lessons/workflow/agent-credential-management.md
@@ -6,6 +6,7 @@ match:
     - "API key for agent workspace"
     - "store credentials in .env"
 status: active
+description: "When needing to store or retrieve credentials, use a GPG-encrypted credential system in the agent's `secrets/` directory."
 ---
 
 # Agent Credential Management

--- a/lessons/workflow/agent-orchestrator-patterns.md
+++ b/lessons/workflow/agent-orchestrator-patterns.md
@@ -11,6 +11,7 @@ match:
     - "standup report"
     - "inference spend"
   session_categories: [monitoring, cross-repo]
+description: "As agent orchestrator, your job is to keep the agent team healthy — surfacing blockers and."
 ---
 
 # Agent Orchestrator Patterns

--- a/lessons/workflow/agent-orchestrator-patterns.md
+++ b/lessons/workflow/agent-orchestrator-patterns.md
@@ -11,7 +11,7 @@ match:
     - "standup report"
     - "inference spend"
   session_categories: [monitoring, cross-repo]
-description: "As agent orchestrator, your job is to keep the agent team healthy — surfacing blockers and."
+description: "As agent orchestrator, your job is to keep the agent team healthy — surfacing blockers and utilization issues before they compound, not doing reactive status checks."
 ---
 
 # Agent Orchestrator Patterns

--- a/lessons/workflow/agent-workspace-maintenance.md
+++ b/lessons/workflow/agent-workspace-maintenance.md
@@ -6,6 +6,7 @@ match:
     - "submodule is behind"
   session_categories: [cleanup]
 status: active
+description: "When doing periodic workspace maintenance, update the gptme-contrib submodule and verify that shared infrastructure symlinks are intact."
 ---
 
 # Agent Workspace Maintenance

--- a/lessons/workflow/bold-refactoring.md
+++ b/lessons/workflow/bold-refactoring.md
@@ -7,6 +7,7 @@ match:
     - "PR adds code without removing old"
     - "refactor when adding abstraction"
 status: active
+description: "When creating shared modules or abstractions, immediately refactor existing code to use them."
 ---
 
 # Bold Refactoring

--- a/lessons/workflow/branch-from-master.md
+++ b/lessons/workflow/branch-from-master.md
@@ -3,6 +3,7 @@ match:
   keywords: ["create branch", "git checkout -b"]
   session_categories: [code, cross-repo, infrastructure]
 status: active
+description: "Create new branches from `origin/master`, never from local HEAD with uncommitted work."
 ---
 
 # Always Branch From Remote Master

--- a/lessons/workflow/ci-failure-resolution-precommit-maintenance.md
+++ b/lessons/workflow/ci-failure-resolution-precommit-maintenance.md
@@ -6,6 +6,7 @@ match:
     - "restore corrupted pre-commit scripts"
     - "prek run failing with persistent errors"
     - "CI status red on master branch"
+description: "When CI is red on master or pre-commit scripts are corrupted, diagnose systematically before fixing: check failure pattern, run locally, fix root cause, verify."
 ---
 
 # CI Failure Resolution and Pre-commit Infrastructure Maintenance

--- a/lessons/workflow/clean-pr-creation.md
+++ b/lessons/workflow/clean-pr-creation.md
@@ -7,6 +7,7 @@ match:
     - cherry-pick commits
     - PR hygiene
 status: active
+description: "Always create feature branches from `origin/master`, not from local branches that may have accumulated other work."
 ---
 
 # Clean PR Creation

--- a/lessons/workflow/code-coverage-principle.md
+++ b/lessons/workflow/code-coverage-principle.md
@@ -7,6 +7,7 @@ match:
   - "pytest coverage"
   - "missing tests"
 status: archived
+description: "Pursue code coverage improvements strategically, focusing on bug prevention and refactoring safety, not metric improvement."
 ---
 
 # Code Coverage Principle

--- a/lessons/workflow/cross-agent-workspace-review.md
+++ b/lessons/workflow/cross-agent-workspace-review.md
@@ -2,6 +2,7 @@
 match:
   keywords: ["cross-agent review", "workspace review patterns", "reviewing other agent's work"]
 status: active
+description: "Conduct mutual workspace reviews between agents to identify improvement opportunities and share proven patterns."
 ---
 
 # Cross-Agent Workspace Review

--- a/lessons/workflow/git-workflow.md
+++ b/lessons/workflow/git-workflow.md
@@ -8,7 +8,7 @@ match:
   - "submodule update sequence"
   - "committed to master by accident"
 status: active
-description: "Stage only intended files explicitly, never use `git add."
+description: "Stage only intended files explicitly, never use `git add .` or `git commit -a`, and commit trivial docs/journal directly to master while using branches/PRs for non-trivial changes."
 ---
 
 # Git Workflow

--- a/lessons/workflow/git-workflow.md
+++ b/lessons/workflow/git-workflow.md
@@ -8,6 +8,7 @@ match:
   - "submodule update sequence"
   - "committed to master by accident"
 status: active
+description: "Stage only intended files explicitly, never use `git add."
 ---
 
 # Git Workflow

--- a/lessons/workflow/git-worktree-workflow.md
+++ b/lessons/workflow/git-worktree-workflow.md
@@ -13,6 +13,7 @@ match:
   - "work on PR in separate directory"
   session_categories: [cross-repo, code]
 status: active
+description: "**ALWAYS branch from `origin/master`, NEVER from local `master`."
 ---
 
 # Git Worktree Workflow for External Repositories

--- a/lessons/workflow/git-worktree-workflow.md
+++ b/lessons/workflow/git-worktree-workflow.md
@@ -13,7 +13,7 @@ match:
   - "work on PR in separate directory"
   session_categories: [cross-repo, code]
 status: active
-description: "**ALWAYS branch from `origin/master`, NEVER from local `master`."
+description: "Always branch from `origin/master`, never from local `master` — fetch first, then create the branch from `origin/master`."
 ---
 
 # Git Worktree Workflow for External Repositories

--- a/lessons/workflow/inter-agent-communication.md
+++ b/lessons/workflow/inter-agent-communication.md
@@ -2,6 +2,7 @@
 match:
   keywords: ["inter-agent communication", "agent-to-agent messaging", "cross-agent coordination", "communicate with other agent", "message another agent"]
 status: active
+description: "Use a channel that the other agent can actually read."
 ---
 
 # Inter-Agent Communication

--- a/lessons/workflow/memory-failure-prevention.md
+++ b/lessons/workflow/memory-failure-prevention.md
@@ -12,6 +12,7 @@ match:
   - issue creation
   - memory follow-through
 status: archived
+description: "Always close communication loops by responding in the original thread after completing requested actions, and check for previous work before creating new issues."
 ---
 
 # Memory Failure Prevention

--- a/lessons/workflow/prefer-brain-over-local-memory.md
+++ b/lessons/workflow/prefer-brain-over-local-memory.md
@@ -5,6 +5,7 @@ match:
     - brain repo
   session_categories: [self-review, infrastructure]
 status: active
+description: "When an agent has a brain repo (git workspace), persist knowledge there — not in runtime-local memory systems like Claude Code's `~/."
 ---
 
 # Prefer Brain Repo Over Local Machine Memory

--- a/lessons/workflow/prefer-brain-over-local-memory.md
+++ b/lessons/workflow/prefer-brain-over-local-memory.md
@@ -5,7 +5,7 @@ match:
     - brain repo
   session_categories: [self-review, infrastructure]
 status: active
-description: "When an agent has a brain repo (git workspace), persist knowledge there — not in runtime-local memory systems like Claude Code's `~/."
+description: "When an agent has a brain repo (git workspace), persist knowledge there — not in runtime-local memory systems like Claude Code's `~/.claude/projects/*/memory/`."
 ---
 
 # Prefer Brain Repo Over Local Machine Memory

--- a/lessons/workflow/project-monitoring-session-patterns.md
+++ b/lessons/workflow/project-monitoring-session-patterns.md
@@ -15,6 +15,7 @@ match:
     - "act vs defer"
   session_categories: [monitoring, triage]
 status: active
+description: "Use systematic classification and time-boxed execution for monitoring sessions: classify notifications as ACT (action required) vs DEF (deferred), then execute only ACT items."
 ---
 
 # Project Monitoring Session Patterns

--- a/lessons/workflow/read-full-github-context.md
+++ b/lessons/workflow/read-full-github-context.md
@@ -6,6 +6,7 @@ match:
     - "gh pr view --comments"
   session_categories: [cross-repo, code]
 status: active
+description: "NEVER truncate GitHub comment output."
 ---
 
 # Read Full GitHub Context

--- a/lessons/workflow/read-pr-reviews-comprehensively.md
+++ b/lessons/workflow/read-pr-reviews-comprehensively.md
@@ -7,6 +7,7 @@ match:
     - "maintainer says you didn't address review comments"
     - "unresolved review threads on PR"
 status: active
+description: "Always read ALL review sources without truncation using jq for compact output, and reply to individual review comment threads when acknowledging fixes."
 ---
 
 # Read PR Reviews Comprehensively

--- a/lessons/workflow/requirement-validation.md
+++ b/lessons/workflow/requirement-validation.md
@@ -7,6 +7,7 @@ match:
   - seems like a good idea without requester
   - building before validating need
 status: active
+description: "Before implementing any feature, validate: WHO requested it, WHAT problem it solves, HOW to measure success, and WHAT'S the minimal solution."
 ---
 
 # Requirement Validation Before Implementation

--- a/lessons/workflow/session-ending-protocol.md
+++ b/lessons/workflow/session-ending-protocol.md
@@ -3,6 +3,7 @@ match:
   keywords: ["session complete", "ending a session", "wrap up the session", "land the plane", "session ending checklist", "before completing"]
   session_categories: [code, cross-repo, infrastructure, cleanup]
 status: archived
+description: "Before completing any session, follow the Land the Plane checklist to ensure clean handoff."
 ---
 
 # Session Ending Protocol


### PR DESCRIPTION
## Summary

- Adds `description:` field to YAML frontmatter of 60 remaining lesson files across all gptme-contrib lesson categories
- Covers: `autonomous/` (1 remaining), `communication/` (3), `concepts/` (3), `infrastructure/` (1), `patterns/` (10), `social/` (1), `tools/` (23), `workflow/` (18) — the full remaining set after PR #969 shipped 36 autonomous/workflow files
- These single-sentence descriptions enable gptme's hybrid lesson retrieval system (gptme/gptme#2469) to do semantic matching via the `description` field

## Motivation

PR #969 added descriptions to 36 lesson files in `autonomous/` and `workflow/`. This PR covers the remaining 60 files across all other categories, giving the hybrid matcher full coverage of the gptme-contrib lesson corpus.

## Test plan

- [ ] Verify all modified lesson files still pass the lesson validator: `'find lessons -name "*.md" -not -name "README.md" -print0 | xargs -0 python3 packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py'`
- [ ] Confirm descriptions are single-sentence and accurately capture each lesson's core rule