### PR TITLE
docs(activity-summary): fix human-mode CLI syntax and add successor story

### DIFF
--- a/packages/gptme-activity-summary/README.md
+++ b/packages/gptme-activity-summary/README.md
@@ -31,16 +31,16 @@ No agent workspace or journal required — works for any human user.
 gptme-activity-summary daily --mode human --date yesterday
 
 # Daily with GitHub activity overlaid
-gptme-activity-summary daily --mode human --date yesterday --github-user ErikBjare
+gptme-activity-summary daily --mode human --date yesterday --github-user your-github-username
 
 # Weekly report (AW + GitHub)
-gptme-activity-summary weekly --mode human --week last --github-user ErikBjare
+gptme-activity-summary weekly --mode human --week last --github-user your-github-username
 
 # Monthly report
-gptme-activity-summary monthly --mode human --month last --github-user ErikBjare
+gptme-activity-summary monthly --mode human --month last --github-user your-github-username
 
 # Raw data — skip LLM summarization, print source data only
-gptme-activity-summary weekly --mode human --week last --github-user ErikBjare --raw
+gptme-activity-summary weekly --mode human --week last --github-user your-github-username --raw
 ```
 
 **ActivityWatch is the primary data source.** Install and run [ActivityWatch](https://activitywatch.net) on your machine for time-tracking data. If AW is not running, AW data is skipped gracefully and GitHub-only reports still work.

--- a/packages/gptme-activity-summary/README.md
+++ b/packages/gptme-activity-summary/README.md
@@ -1,16 +1,17 @@
 # gptme-activity-summary
 
-Activity summarization for gptme agents and humans — journals, GitHub, sessions, tweets, email.
+Activity summarization for gptme agents and humans — journals, GitHub, sessions, tweets, email, and local time tracking.
+
+> **Supersedes [whatdidyougetdone](https://github.com/TimeToBuildBob/whatdidyougetdone)** — the human work-report use case lives here now, with ActivityWatch as the primary time-tracking source and GitHub as an optional overlay.
 
 ## Features
 
-- **Daily Summarization**: Generate daily summaries from journal entries
-- **Weekly Aggregation**: Aggregate daily summaries into weekly summaries
-- **Monthly Aggregation**: Aggregate weekly summaries into monthly summaries
-- **GitHub User Mode**: Summarize any GitHub user's activity (no agent workspace needed)
-- **Claude Code Backend**: High-quality summarization using Claude Code
-- **Real Data Sources**: GitHub activity, gptme session stats, posted tweets, sent emails
-- **Model Usage Tracking**: Per-model token/cost breakdown from conversation logs
+- **Human Mode**: ActivityWatch time tracking as the primary source, GitHub as optional overlay — no agent workspace needed
+- **Agent Mode**: Journal-based summaries with GitHub, session stats, tweets, and email
+- **Daily/Weekly/Monthly**: All three periods work in both modes
+- **LLM Synthesis**: Claude Code backend for narrative summaries (or `--raw` for plain data)
+- **Real Data Sources**: ActivityWatch, GitHub activity, gptme session stats, posted tweets, sent emails
+- **Model Usage Tracking**: Per-model token/cost breakdown from agent session logs
 
 ## Installation
 
@@ -20,10 +21,34 @@ pip install gptme-activity-summary
 
 ## Usage
 
+### Human Mode (ActivityWatch + optional GitHub)
+
+Generate work reports from local time tracking with optional GitHub overlay.
+No agent workspace or journal required — works for any human user.
+
+```bash
+# Daily report (ActivityWatch only)
+gptme-activity-summary daily --mode human --date yesterday
+
+# Daily with GitHub activity overlaid
+gptme-activity-summary daily --mode human --date yesterday --github-user ErikBjare
+
+# Weekly report (AW + GitHub)
+gptme-activity-summary weekly --mode human --week last --github-user ErikBjare
+
+# Monthly report
+gptme-activity-summary monthly --mode human --month last --github-user ErikBjare
+
+# Raw data — skip LLM summarization, print source data only
+gptme-activity-summary weekly --mode human --week last --github-user ErikBjare --raw
+```
+
+**ActivityWatch is the primary data source.** Install and run [ActivityWatch](https://activitywatch.net) on your machine for time-tracking data. If AW is not running, AW data is skipped gracefully and GitHub-only reports still work.
+
 ### Agent Mode (journal-based)
 
 ```bash
-# Daily summary
+# Daily summary from journal entries
 gptme-activity-summary daily --date yesterday
 
 # Weekly summary
@@ -32,31 +57,14 @@ gptme-activity-summary weekly --week last
 # Monthly summary
 gptme-activity-summary monthly --month last
 
-# Smart mode (auto-triggers weekly/monthly when appropriate)
+# Smart mode — auto-triggers weekly/monthly when appropriate
 gptme-activity-summary smart --date yesterday
 ```
 
-### GitHub User Mode (human activity)
+## Requirements
 
-Summarize any GitHub user's activity without requiring a journal or agent workspace:
-
-```bash
-# Weekly GitHub activity summary
-gptme-activity-summary github --user ErikBjare --period weekly
-
-# Monthly summary
-gptme-activity-summary github --user ErikBjare --period monthly
-
-# Raw data (no LLM summarization)
-gptme-activity-summary github --user ErikBjare --period weekly --raw
-
-# Custom date range reference
-gptme-activity-summary github --user ErikBjare --period weekly --date 2026-02-10
-```
-
-## Integration with gptme
-
-This package is designed to work with gptme agents' journal systems. The `github` command also works standalone for summarizing human GitHub activity — useful for profile READMEs, newsletters, and activity reports.
+- **Human mode**: [ActivityWatch](https://activitywatch.net) (optional, for time tracking) + `gh` CLI (optional, for GitHub data)
+- **Agent mode**: gptme agent workspace with a `journal/` directory
 
 ## License
 


### PR DESCRIPTION
## Summary

The README showed a non-existent `github` subcommand; all human-mode examples were broken and would fail immediately for anyone trying to follow them.

- **Fix broken commands**: `github --user X --period weekly` → `weekly --mode human --github-user X` (matching the actual CLI)
- **Reorder sections**: Human Mode first (the use case without an agent workspace), Agent Mode second
- **Add whatdidyougetdone supersession notice** at the top so people landing from the old project know where they are
- **Surface ActivityWatch as primary source**, GitHub as optional overlay — matching how `_run_human_summary()` actually works
- **Replace vague "Integration with gptme" section** with a concrete Requirements list

## Dogfooding notes

Verified both paths locally before patching:
- `gptme-activity-summary daily --mode human --date yesterday --raw` → works, shows AW time data
- `gptme-activity-summary weekly --mode human --week last --github-user ErikBjare --raw` → works, shows full GitHub activity

The broken `github --user X` commands in the old README fail immediately with `No such command 'github'`.