### PR TITLE
fix(lessons): strengthen greptile-pr-reviews description (symptom-focused rewrite)

### DIFF
--- a/lessons/tools/greptile-pr-reviews.md
+++ b/lessons/tools/greptile-pr-reviews.md
@@ -6,7 +6,7 @@ match:
     - "fresh greptile review"
     - "greptile after fixing"
   session_categories: [cross-repo, code]
-description: "After pushing new commits that address an automated code-review bot's (greptile-apps) feedback on a PR, request a re-review via greptile-helper.sh so the bot takes another look without spamming duplicate review comments"
+description: "After new commits land on a PR, retrigger the automated code-quality scoring pass by running greptile-helper.sh to get a fresh evaluation — posting raw bot-trigger comments directly causes duplicate scoring spam when concurrent sessions fire"
 status: active
 ---
 

--- a/lessons/tools/greptile-pr-reviews.md
+++ b/lessons/tools/greptile-pr-reviews.md
@@ -5,6 +5,7 @@ match:
     - "trigger greptile"
     - "fresh greptile review"
     - "greptile after fixing"
+    - "greptile re-review"
   session_categories: [cross-repo, code]
 description: "After new commits land on a PR, retrigger the automated code-quality scoring pass by running greptile-helper.sh to get a fresh evaluation — posting raw bot-trigger comments directly causes duplicate scoring spam when concurrent sessions fire"
 status: active


### PR DESCRIPTION
## Summary

Follow-up to #972 — further strengthen the `description:` field in `greptile-pr-reviews.md` for better hybrid keyword+semantic retrieval.

**Before**: "After pushing new commits that address an automated code-review bot's (greptile-apps) feedback on a PR, request a re-review via greptile-helper.sh so the bot takes another look without spamming duplicate review comments"

**After**: "After new commits land on a PR, retrigger the automated code-quality scoring pass by running greptile-helper.sh to get a fresh evaluation — posting raw bot-trigger comments directly causes duplicate scoring spam when concurrent sessions fire"

Changes:
- Removes narrow trigger assumption ("addressing feedback") → fires for any new commits
- Explains WHY the helper is needed (concurrent sessions → duplicate scoring spam)
- More symptom-focused language matches how sessions phrase the need