### PR TITLE
feat(aw-watcher-agent): ActivityWatch watcher for AI coding assistants (phase 1)

### DIFF
--- a/packages/aw-watcher-agent/README.md
+++ b/packages/aw-watcher-agent/README.md
@@ -1,0 +1,62 @@
+# aw-watcher-agent
+
+An [ActivityWatch](https://activitywatch.net) watcher for **AI coding
+assistants** (gptme, Claude Code, Codex). It logs assistant session activity to
+your **local** aw-server so AI work shows up in aw-webui's Timeline alongside
+window/AFK data — instead of being logged as idle while an autonomous agent does
+the most valuable work.
+
+This is the controller use case behind
+[ActivityWatch/activitywatch#1215](https://github.com/ActivityWatch/activitywatch/issues/1215).
+
+## Design
+
+- **Local-only, privacy-first.** Writes go only to your own aw-server. No hosted
+  aggregation, no transcripts — only coarse metadata (harness, model, category,
+  counts).
+- **Zero heavy deps.** Vendored ~150-line stdlib REST client; no `aw-client` /
+  `aw-core` dependency, so it stays pip-installable and light enough to call from
+  a lifecycle hook.
+- **One clean Timeline block per session.** `emit-start` posts a zero-duration
+  placeholder; `emit-end` deletes it and posts a single event with the full
+  duration plus `outcome`.
+
+Full design note (bucket schema, event taxonomy, phased plan):
+`knowledge/technical-designs/aw-watcher-agent-design.md` in the Bob workspace.
+
+## Install
+
+```bash
+pip install -e packages/aw-watcher-agent
+```
+
+## Usage
+
+```bash
+# Create the session bucket (idempotent)
+aw-watcher-agent ensure-bucket
+
+# At session start
+aw-watcher-agent emit-start \
+  --harness claude-code --model claude-opus-4-7 \
+  --category code --session-id 8531 --trigger autonomous --workspace bob
+
+# At session end (reads the start state, records duration + outcome)
+aw-watcher-agent emit-end --session-id 8531 --outcome productive
+```
+
+The bucket `aw-watcher-agent_<hostname>` (type `app.agent.session`) appears in
+aw-webui automatically.
+
+### Wiring Claude Code hooks
+
+Point `SessionStart` / `Stop` hooks (in `~/.claude/settings.json`) at the
+`emit-start` / `emit-end` subcommands. Failures are non-fatal by default
+(`--strict` to opt in) so a watcher problem never breaks the agent session it
+observes.
+
+## Status
+
+Phase 1 (MVP): session bucket + CLI + REST client, dogfooded against a local
+aw-server. Phase 2 adds per-tool activity heartbeats and a gptme-native plugin
+hook; Phase 3 adds an aw-webui "AI work" view.

--- a/packages/aw-watcher-agent/pyproject.toml
+++ b/packages/aw-watcher-agent/pyproject.toml
@@ -1,0 +1,44 @@
+[project]
+name = "aw-watcher-agent"
+version = "0.1.0"
+description = "ActivityWatch watcher for AI coding assistants (gptme, Claude Code, Codex)"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.10"
+keywords = ["activitywatch", "aw-watcher", "gptme", "ai-agents", "time-tracking"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+# Zero heavy deps by design: vendored stdlib REST client, no aw-client/aw-core.
+dependencies = []
+
+[project.optional-dependencies]
+test = ["pytest>=7.0"]
+dev = ["pytest>=7.0", "mypy>=1.0.0"]
+
+[project.scripts]
+aw-watcher-agent = "aw_watcher_agent.cli:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/aw_watcher_agent"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.mypy]
+python_version = "3.10"
+check_untyped_defs = true
+warn_return_any = true
+warn_unused_configs = true
+ignore_missing_imports = true

--- a/packages/aw-watcher-agent/src/aw_watcher_agent/__init__.py
+++ b/packages/aw-watcher-agent/src/aw_watcher_agent/__init__.py
@@ -1,0 +1,6 @@
+"""aw-watcher-agent: log AI coding-assistant sessions to a local aw-server."""
+
+from .client import AWClient, AWClientError, Event, DEFAULT_SERVER, utc_now_iso
+
+__all__ = ["AWClient", "AWClientError", "Event", "DEFAULT_SERVER", "utc_now_iso"]
+__version__ = "0.1.0"

--- a/packages/aw-watcher-agent/src/aw_watcher_agent/cli.py
+++ b/packages/aw-watcher-agent/src/aw_watcher_agent/cli.py
@@ -70,7 +70,7 @@ def cmd_emit_start(args: argparse.Namespace) -> int:
     event_id = client.heartbeat(bid, event, pulsetime=0.0)
 
     sid = args.session_id or start
-    core.write_state(sid, {"bucket_id": bid, "event_id": event_id, "start": start})
+    core.write_state(sid, {"bucket_id": bid, "event_id": event_id, "start": start, "data": data})
     print(f"session start emitted: {bid} event_id={event_id} session_id={sid}")
     return 0
 
@@ -96,7 +96,14 @@ def cmd_emit_end(args: argparse.Namespace) -> int:
         start = end
         duration = float(args.duration or 0.0)
 
-    data = core.session_data(vars(args), outcome=args.outcome)
+    # Merge saved start metadata with any fields supplied at emit-end time.
+    # CLI args at emit-end take precedence (allows corrections), outcome appended.
+    saved_data: dict[str, str] = (state.get("data") or {}) if state else {}
+    cli_overrides = core.session_data(vars(args))
+    merged = {**saved_data, **cli_overrides}
+    if args.outcome:
+        merged["outcome"] = str(args.outcome)
+    data = merged
     event = Event(timestamp=start, duration=max(duration, 0.0), data=data)
     # pulsetime=0 forces a fresh event (the outcome field differs from any prior
     # block anyway); heartbeat returns the id for logging where POST does not.

--- a/packages/aw-watcher-agent/src/aw_watcher_agent/cli.py
+++ b/packages/aw-watcher-agent/src/aw_watcher_agent/cli.py
@@ -90,7 +90,12 @@ def cmd_emit_end(args: argparse.Namespace) -> int:
         duration = (_parse_iso(end) - _parse_iso(start)).total_seconds()
         # Drop the zero-duration placeholder so we end with one clean block.
         if state.get("event_id") is not None:
-            client.delete_event(state.get("bucket_id", bid), state["event_id"])
+            if not client.delete_event(state.get("bucket_id", bid), state["event_id"]):
+                print(
+                    f"warning: failed to delete placeholder event {state['event_id']} "
+                    f"from {state.get('bucket_id', bid)} — timeline may contain duplicate block",
+                    file=sys.stderr,
+                )
     else:
         # No recorded start (crash / hook gap): fall back to provided duration.
         start = end

--- a/packages/aw-watcher-agent/src/aw_watcher_agent/cli.py
+++ b/packages/aw-watcher-agent/src/aw_watcher_agent/cli.py
@@ -1,0 +1,152 @@
+"""``aw-watcher-agent`` CLI: emit AI-assistant session activity to a local aw-server.
+
+Subcommands:
+    ensure-bucket   Create the session bucket if missing.
+    emit-start      Record the start of an AI session (zero-duration placeholder).
+    emit-end        Replace the placeholder with one event carrying duration + outcome.
+
+Designed to be called from harness lifecycle hooks (e.g. Claude Code
+SessionStart/Stop). Failures are non-fatal by default (``--strict`` to opt in)
+so a watcher problem never breaks the agent session it observes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import socket
+import sys
+from datetime import datetime
+
+from .client import AWClient, AWClientError, Event, utc_now_iso
+from . import core
+
+
+def _hostname(explicit: str | None) -> str:
+    return explicit or socket.gethostname()
+
+
+def _parse_iso(ts: str) -> datetime:
+    return datetime.fromisoformat(ts)
+
+
+def _add_session_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument("--harness", help="gptme / claude-code / codex")
+    p.add_argument("--model", help="resolved model id, e.g. claude-opus-4-7")
+    p.add_argument("--category", help="session category if known")
+    p.add_argument("--session-id", dest="session_id", help="harness session hash")
+    p.add_argument("--trigger", help="autonomous / interactive / timer")
+    p.add_argument("--workspace", help="workspace / agent name")
+    p.add_argument("--hostname", help="override hostname (default: socket.gethostname())")
+    p.add_argument("--server", default=core_default_server(), help="aw-server base URL")
+
+
+def core_default_server() -> str:
+    from .client import DEFAULT_SERVER
+
+    return DEFAULT_SERVER
+
+
+def cmd_ensure_bucket(args: argparse.Namespace) -> int:
+    client = AWClient(args.server)
+    host = _hostname(args.hostname)
+    bid = core.bucket_id(host)
+    created = client.ensure_bucket(bid, core.BUCKET_TYPE, core.CLIENT_NAME, host)
+    print(f"bucket {bid}: {'created' if created else 'already exists'}")
+    return 0
+
+
+def cmd_emit_start(args: argparse.Namespace) -> int:
+    client = AWClient(args.server)
+    host = _hostname(args.hostname)
+    bid = core.bucket_id(host)
+    client.ensure_bucket(bid, core.BUCKET_TYPE, core.CLIENT_NAME, host)
+
+    start = utc_now_iso()
+    data = core.session_data(vars(args))
+    event = Event(timestamp=start, duration=0.0, data=data)
+    # Use heartbeat, not POST /events: aw-server's events endpoint returns null,
+    # but heartbeat returns the created event (with id) so emit-end can delete
+    # this placeholder and leave a single clean block.
+    event_id = client.heartbeat(bid, event, pulsetime=0.0)
+
+    sid = args.session_id or start
+    core.write_state(sid, {"bucket_id": bid, "event_id": event_id, "start": start})
+    print(f"session start emitted: {bid} event_id={event_id} session_id={sid}")
+    return 0
+
+
+def cmd_emit_end(args: argparse.Namespace) -> int:
+    client = AWClient(args.server)
+    host = _hostname(args.hostname)
+    bid = core.bucket_id(host)
+    client.ensure_bucket(bid, core.BUCKET_TYPE, core.CLIENT_NAME, host)
+
+    sid = args.session_id or ""
+    state = core.read_state(sid) if sid else None
+    end = utc_now_iso()
+
+    if state and state.get("start"):
+        start = state["start"]
+        duration = (_parse_iso(end) - _parse_iso(start)).total_seconds()
+        # Drop the zero-duration placeholder so we end with one clean block.
+        if state.get("event_id") is not None:
+            client.delete_event(state.get("bucket_id", bid), state["event_id"])
+    else:
+        # No recorded start (crash / hook gap): fall back to provided duration.
+        start = end
+        duration = float(args.duration or 0.0)
+
+    data = core.session_data(vars(args), outcome=args.outcome)
+    event = Event(timestamp=start, duration=max(duration, 0.0), data=data)
+    # pulsetime=0 forces a fresh event (the outcome field differs from any prior
+    # block anyway); heartbeat returns the id for logging where POST does not.
+    event_id = client.heartbeat(bid, event, pulsetime=0.0)
+    if sid:
+        core.clear_state(sid)
+    print(
+        f"session end emitted: {bid} event_id={event_id} "
+        f"duration={duration:.1f}s outcome={args.outcome}"
+    )
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="aw-watcher-agent", description=__doc__)
+    parser.add_argument("--strict", action="store_true", help="exit non-zero on errors")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_ensure = sub.add_parser("ensure-bucket", help="create the session bucket")
+    p_ensure.add_argument("--hostname")
+    p_ensure.add_argument("--server", default=core_default_server())
+    p_ensure.set_defaults(func=cmd_ensure_bucket)
+
+    p_start = sub.add_parser("emit-start", help="record session start")
+    _add_session_args(p_start)
+    p_start.set_defaults(func=cmd_emit_start)
+
+    p_end = sub.add_parser("emit-end", help="record session end with outcome")
+    _add_session_args(p_end)
+    p_end.add_argument("--outcome", help="productive / blocked / noop")
+    p_end.add_argument("--duration", type=float, help="fallback duration (s) if no start state")
+    p_end.set_defaults(func=cmd_emit_end)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return int(args.func(args))
+    except (AWClientError, OSError) as exc:
+        msg = f"aw-watcher-agent: {exc}"
+        if args.strict:
+            print(msg, file=sys.stderr)
+            return 1
+        # Non-fatal by default: observing a session must never break it.
+        print(f"{msg} (ignored; use --strict to fail)", file=sys.stderr)
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/aw-watcher-agent/src/aw_watcher_agent/client.py
+++ b/packages/aw-watcher-agent/src/aw_watcher_agent/client.py
@@ -1,0 +1,150 @@
+"""Thin vendored ActivityWatch REST client (stdlib-only).
+
+Phase 1 of aw-watcher-agent keeps zero heavy dependencies: it talks to a local
+aw-server over its documented REST API using ``urllib`` instead of pulling in
+``aw-client``/``aw-core``. The watcher therefore stays pip-installable and light
+enough to ship as a hook target.
+
+API shapes were verified against a live aw-server v0.13.2:
+
+- ``GET  /api/0/info`` -> ``{hostname, version, ...}``
+- ``GET  /api/0/buckets/`` -> ``{bucket_id: {id, type, client, hostname, ...}}``
+- ``POST /api/0/buckets/{id}`` -> create bucket (idempotent-ish; 304 if exists)
+- ``POST /api/0/buckets/{id}/events`` -> insert event(s); returns event with ``id``
+- ``DELETE /api/0/buckets/{id}/events/{event_id}`` -> remove an event
+- ``POST /api/0/buckets/{id}/heartbeat?pulsetime=N`` -> merge-extend an event
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+DEFAULT_SERVER = "http://127.0.0.1:5600"
+
+
+def utc_now_iso() -> str:
+    """Current UTC time as an ISO 8601 string aw-server accepts."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass
+class Event:
+    """An ActivityWatch event: a timestamped, durationed bag of string data."""
+
+    timestamp: str
+    duration: float
+    data: dict[str, Any]
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "timestamp": self.timestamp,
+            "duration": self.duration,
+            "data": self.data,
+        }
+
+
+class AWClientError(RuntimeError):
+    """Raised when the aw-server returns an unrecoverable error."""
+
+
+class AWClient:
+    """Minimal aw-server REST client over the stdlib."""
+
+    def __init__(self, server: str = DEFAULT_SERVER, timeout: float = 5.0) -> None:
+        self.server = server.rstrip("/")
+        self.timeout = timeout
+
+    def _request(self, method: str, path: str, body: Any | None = None) -> tuple[int, Any]:
+        url = f"{self.server}{path}"
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(url, data=data, method=method)
+        if data is not None:
+            req.add_header("Content-Type", "application/json")
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+                raw = resp.read()
+                parsed = json.loads(raw) if raw else None
+                return resp.status, parsed
+        except urllib.error.HTTPError as exc:
+            raw = exc.read()
+            try:
+                parsed = json.loads(raw) if raw else None
+            except json.JSONDecodeError:
+                parsed = raw.decode(errors="replace")
+            return exc.code, parsed
+
+    # --- read ---------------------------------------------------------------
+
+    def info(self) -> dict[str, Any]:
+        status, body = self._request("GET", "/api/0/info")
+        if status != 200 or not isinstance(body, dict):
+            raise AWClientError(f"unexpected /info response: {status} {body!r}")
+        return body
+
+    def buckets(self) -> dict[str, Any]:
+        status, body = self._request("GET", "/api/0/buckets/")
+        if status != 200 or not isinstance(body, dict):
+            raise AWClientError(f"unexpected /buckets response: {status} {body!r}")
+        return body
+
+    # --- bucket lifecycle ---------------------------------------------------
+
+    def ensure_bucket(
+        self,
+        bucket_id: str,
+        event_type: str,
+        client_name: str,
+        hostname: str,
+    ) -> bool:
+        """Create the bucket if missing. Returns True if newly created.
+
+        Idempotent: an already-existing bucket is treated as success rather than
+        an error, so the watcher can call this on every session start.
+        """
+        if bucket_id in self.buckets():
+            return False
+        payload = {
+            "client": client_name,
+            "type": event_type,
+            "hostname": hostname,
+        }
+        status, body = self._request("POST", f"/api/0/buckets/{bucket_id}", payload)
+        # 200/201 = created, 304 = already existed (race with a parallel start)
+        if status in (200, 201, 304):
+            return status != 304
+        raise AWClientError(f"failed to create bucket {bucket_id}: {status} {body!r}")
+
+    # --- events -------------------------------------------------------------
+
+    def post_event(self, bucket_id: str, event: Event) -> int | None:
+        """Insert a single event. Returns the server-assigned event id if present."""
+        status, body = self._request(
+            "POST", f"/api/0/buckets/{bucket_id}/events", event.to_payload()
+        )
+        if status not in (200, 201):
+            raise AWClientError(f"failed to post event to {bucket_id}: {status} {body!r}")
+        if isinstance(body, dict):
+            return body.get("id")
+        if isinstance(body, list) and body and isinstance(body[0], dict):
+            return body[0].get("id")
+        return None
+
+    def delete_event(self, bucket_id: str, event_id: int) -> bool:
+        status, _ = self._request("DELETE", f"/api/0/buckets/{bucket_id}/events/{event_id}")
+        return status in (200, 204)
+
+    def heartbeat(self, bucket_id: str, event: Event, pulsetime: float) -> int | None:
+        """Merge-extend the latest event whose data matches, within ``pulsetime``."""
+        status, body = self._request(
+            "POST",
+            f"/api/0/buckets/{bucket_id}/heartbeat?pulsetime={pulsetime}",
+            event.to_payload(),
+        )
+        if status not in (200, 201):
+            raise AWClientError(f"failed to heartbeat {bucket_id}: {status} {body!r}")
+        return body.get("id") if isinstance(body, dict) else None

--- a/packages/aw-watcher-agent/src/aw_watcher_agent/core.py
+++ b/packages/aw-watcher-agent/src/aw_watcher_agent/core.py
@@ -1,0 +1,78 @@
+"""Session bucket conventions and crash-robust state for aw-watcher-agent.
+
+A session is modelled as a single event in the ``app.agent.session`` bucket.
+``emit-start`` posts a zero-duration start event and records its server id; on
+``emit-end`` we delete that placeholder and post one clean event carrying the
+full duration plus ``outcome``. This yields exactly one Timeline block per
+session with complete metadata.
+
+Why not heartbeat-extend the start event? ActivityWatch only merges consecutive
+events with *identical* ``data``. ``outcome`` is unknown until the session ends
+and changes the payload, so a heartbeat with the outcome would not merge with
+the start event. Delete-then-repost keeps a single block while still recording
+the outcome. If ``emit-end`` never runs (crash), the zero-duration start event
+still marks that the session began.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+BUCKET_TYPE = "app.agent.session"
+CLIENT_NAME = "aw-watcher-agent"
+
+# Stable session fields (everything except outcome, which is end-only).
+START_FIELDS = ("harness", "model", "category", "session_id", "trigger", "workspace")
+
+
+def bucket_id(hostname: str) -> str:
+    """Bucket id following the ``aw-watcher-<name>_<hostname>`` convention."""
+    return f"{CLIENT_NAME}_{hostname}"
+
+
+def state_dir() -> Path:
+    """Per-session state directory (honors XDG_STATE_HOME)."""
+    base = os.environ.get("XDG_STATE_HOME") or os.path.expanduser("~/.local/state")
+    return Path(base) / CLIENT_NAME
+
+
+def state_path(session_id: str) -> Path:
+    safe = "".join(c if c.isalnum() or c in "-_." else "_" for c in session_id)
+    return state_dir() / f"session-{safe}.json"
+
+
+def write_state(session_id: str, payload: dict[str, Any]) -> Path:
+    path = state_path(session_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload))
+    return path
+
+
+def read_state(session_id: str) -> dict[str, Any] | None:
+    path = state_path(session_id)
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def clear_state(session_id: str) -> None:
+    path = state_path(session_id)
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def session_data(args: dict[str, Any], *, outcome: str | None = None) -> dict[str, str]:
+    """Build the event ``data`` map from CLI args, dropping empty values."""
+    data = {f: str(args[f]) for f in START_FIELDS if args.get(f)}
+    if outcome:
+        data["outcome"] = str(outcome)
+    return data

--- a/packages/aw-watcher-agent/src/aw_watcher_agent/core.py
+++ b/packages/aw-watcher-agent/src/aw_watcher_agent/core.py
@@ -47,7 +47,7 @@ def state_path(session_id: str) -> Path:
 def write_state(session_id: str, payload: dict[str, Any]) -> Path:
     path = state_path(session_id)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload))
+    path.write_text(json.dumps(payload), encoding="utf-8")
     return path
 
 
@@ -56,7 +56,7 @@ def read_state(session_id: str) -> dict[str, Any] | None:
     if not path.exists():
         return None
     try:
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
         return None
     return data if isinstance(data, dict) else None

--- a/packages/aw-watcher-agent/tests/test_aw_watcher_agent.py
+++ b/packages/aw-watcher-agent/tests/test_aw_watcher_agent.py
@@ -115,3 +115,73 @@ def test_info_validates_shape():
     c2 = _FakeClient([(200, "not-a-dict")])
     with pytest.raises(AWClientError):
         c2.info()
+
+
+# --- CLI emit-start / emit-end metadata persistence -------------------------
+
+
+def test_emit_end_preserves_start_metadata(tmp_path, monkeypatch):
+    """emit-end must carry harness/model/workspace even when not re-supplied."""
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    from aw_watcher_agent import cli
+
+    # Simulate what emit-start writes into the state file.
+    saved_data = {
+        "harness": "claude-code",
+        "model": "claude-opus-4-7",
+        "session_id": "abc1",
+        "workspace": "bob",
+    }
+    core.write_state(
+        "abc1",
+        {
+            "bucket_id": "aw-watcher-agent_host",
+            "event_id": 42,
+            "start": "2026-01-01T00:00:00+00:00",
+            "data": saved_data,
+        },
+    )
+
+    # emit-end is called with only --session-id and --outcome (the typical case).
+    import argparse
+
+    args = argparse.Namespace(
+        server="http://localhost:5600",
+        hostname="host",  # matches the bucket_id saved in state above
+        session_id="abc1",
+        outcome="productive",
+        harness=None,
+        model=None,
+        category=None,
+        trigger=None,
+        workspace=None,
+        duration=None,
+        strict=False,
+    )
+
+    posted_events: list[dict] = []
+
+    class _CapturingClient(_FakeClient):
+        def __init__(self):
+            # ensure_bucket check, delete placeholder, heartbeat for final event
+            super().__init__(
+                [
+                    (200, {"aw-watcher-agent_host": {}}),  # ensure_bucket
+                    (200, None),  # delete_event
+                    (200, {"id": 99, "timestamp": "t", "duration": 0}),  # heartbeat
+                ]
+            )
+
+        def heartbeat(self, bid, event, pulsetime):
+            posted_events.append(event.data)
+            return super().heartbeat(bid, event, pulsetime)
+
+    monkeypatch.setattr(cli, "AWClient", lambda _url: _CapturingClient())
+    rc = cli.cmd_emit_end(args)
+    assert rc == 0
+    assert posted_events, "no heartbeat was posted"
+    final_data = posted_events[-1]
+    assert final_data.get("harness") == "claude-code", "harness lost from final event"
+    assert final_data.get("model") == "claude-opus-4-7", "model lost from final event"
+    assert final_data.get("workspace") == "bob", "workspace lost from final event"
+    assert final_data.get("outcome") == "productive"

--- a/packages/aw-watcher-agent/tests/test_aw_watcher_agent.py
+++ b/packages/aw-watcher-agent/tests/test_aw_watcher_agent.py
@@ -1,0 +1,117 @@
+"""Tests for aw-watcher-agent: core conventions, state, and the REST client."""
+
+from __future__ import annotations
+
+
+import pytest
+
+from aw_watcher_agent import core
+from aw_watcher_agent.client import AWClient, AWClientError, Event
+
+
+# --- core ------------------------------------------------------------------
+
+
+def test_bucket_id_convention():
+    assert core.bucket_id("bob") == "aw-watcher-agent_bob"
+
+
+def test_session_data_drops_empty_and_adds_outcome():
+    args = {
+        "harness": "claude-code",
+        "model": "claude-opus-4-7",
+        "category": "",  # dropped
+        "session_id": "8531",
+        "trigger": None,  # dropped
+        "workspace": "bob",
+    }
+    start = core.session_data(args)
+    assert start == {
+        "harness": "claude-code",
+        "model": "claude-opus-4-7",
+        "session_id": "8531",
+        "workspace": "bob",
+    }
+    assert "outcome" not in start
+    end = core.session_data(args, outcome="productive")
+    assert end["outcome"] == "productive"
+
+
+def test_state_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    assert core.read_state("abc") is None
+    core.write_state("abc", {"bucket_id": "b", "event_id": 7, "start": "t"})
+    assert core.read_state("abc") == {"bucket_id": "b", "event_id": 7, "start": "t"}
+    core.clear_state("abc")
+    assert core.read_state("abc") is None
+
+
+def test_state_path_sanitizes_session_id(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    path = core.state_path("a/b c")
+    assert "/" not in path.name
+    assert path.name == "session-a_b_c.json"
+
+
+# --- client (mocked transport) ---------------------------------------------
+
+
+class _FakeClient(AWClient):
+    """AWClient with ``_request`` stubbed by a scripted response queue."""
+
+    def __init__(self, responses):
+        super().__init__("http://test")
+        self._responses = list(responses)
+        self.calls = []
+
+    def _request(self, method, path, body=None):
+        self.calls.append((method, path, body))
+        return self._responses.pop(0)
+
+
+def test_ensure_bucket_creates_when_missing():
+    c = _FakeClient([(200, {}), (200, None)])  # buckets(), POST create
+    assert c.ensure_bucket("aw-watcher-agent_bob", "app.agent.session", "x", "bob") is True
+    assert c.calls[1][0] == "POST"
+
+
+def test_ensure_bucket_idempotent_when_present():
+    c = _FakeClient([(200, {"aw-watcher-agent_bob": {}})])
+    assert c.ensure_bucket("aw-watcher-agent_bob", "app.agent.session", "x", "bob") is False
+    assert len(c.calls) == 1  # no POST
+
+
+def test_post_event_returns_id_from_dict():
+    c = _FakeClient([(200, {"id": 42, "timestamp": "t", "duration": 0})])
+    eid = c.post_event("b", Event("t", 0.0, {"harness": "gptme"}))
+    assert eid == 42
+    assert c.calls[0] == (
+        "POST",
+        "/api/0/buckets/b/events",
+        {"timestamp": "t", "duration": 0.0, "data": {"harness": "gptme"}},
+    )
+
+
+def test_post_event_returns_id_from_list():
+    c = _FakeClient([(201, [{"id": 9}])])
+    assert c.post_event("b", Event("t", 1.0, {})) == 9
+
+
+def test_post_event_raises_on_error():
+    c = _FakeClient([(500, "boom")])
+    with pytest.raises(AWClientError):
+        c.post_event("b", Event("t", 0.0, {}))
+
+
+def test_delete_event():
+    c = _FakeClient([(200, None)])
+    assert c.delete_event("b", 5) is True
+    assert c.calls[0] == ("DELETE", "/api/0/buckets/b/events/5", None)
+
+
+def test_info_validates_shape():
+    c = _FakeClient([(200, {"hostname": "bob"})])
+    assert c.info()["hostname"] == "bob"
+    c2 = _FakeClient([(200, "not-a-dict")])
+    with pytest.raises(AWClientError):
+        c2.info()

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,7 @@ resolution-markers = [
 
 [manifest]
 members = [
+    "aw-watcher-agent",
     "credential-slots",
     "gptmail",
     "gptme-ace",
@@ -370,6 +371,28 @@ sdist = { url = "https://files.pythonhosted.org/packages/97/a8/995d460e4c18c6994
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/39/3fa82d04ce85f252f5cb5b9fdbb4761a80617997799486e8aea883ac1bf1/aw_core-0.5.13-py3-none-any.whl", hash = "sha256:dc77b19701a120dd4c86a8b75203230a23fff2bdc3017d50093098c138b8ae08", size = 47586, upload-time = "2023-05-15T07:57:55.655Z" },
 ]
+
+[[package]]
+name = "aw-watcher-agent"
+version = "0.1.0"
+source = { editable = "packages/aw-watcher-agent" }
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+]
+test = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
+]
+provides-extras = ["test", "dev"]
 
 [[package]]
 name = "backports-asyncio-runner"


### PR DESCRIPTION
## Summary

A new `aw-watcher-agent` package: an [ActivityWatch](https://activitywatch.net) watcher that logs **AI coding-assistant** session activity (gptme / Claude Code / Codex) to the user's **local** aw-server, so AI work shows up in aw-webui's Timeline instead of being logged as idle while an autonomous agent does the most valuable work.

This is the controller use case behind [ActivityWatch/activitywatch#1215](https://github.com/ActivityWatch/activitywatch/issues/1215), and a natural gptme ↔ ActivityWatch cross-sell (both Erik's projects).

## What's in phase 1 (MVP)

- **Vendored stdlib REST client** (`client.py`) — zero `aw-client`/`aw-core` dependency, so the watcher stays pip-installable and light enough to call from a lifecycle hook.
- **CLI** (`cli.py`): `ensure-bucket`, `emit-start`, `emit-end`.
- **One clean Timeline block per session**: `emit-start` posts a zero-duration placeholder via `heartbeat` (which returns the event id — aw-server's `POST /events` returns `null`), and `emit-end` deletes that placeholder and posts a single event carrying the full duration plus `outcome`.
- **Privacy-first**: local-only writes, coarse metadata (harness, model, category, counts), never prompts/transcripts.
- **Non-fatal by default** (`--strict` to opt in) so a watcher problem never breaks the agent session it observes.

Bucket `aw-watcher-agent_<hostname>` (type `app.agent.session`) appears in aw-webui automatically.

## Verification

- Dogfooded end-to-end against a live aw-server **v0.13.2**: confirmed exactly one clean event lands with correct duration and `outcome=productive`.
- 11 unit tests (core conventions + state + mocked REST transport), `ruff` + `mypy` clean.

## Not in this PR (follow-ups)

- Claude Code `SessionStart`/`Stop` hook wiring (mechanical; needs the package installed/merged first — README documents the exact commands).
- Phase 2: per-tool `app.agent.activity` heartbeats; gptme-native plugin hook; Codex log-tailer.
- Phase 3: aw-webui "AI work" view.

Full design note lives in the Bob workspace: `knowledge/technical-designs/aw-watcher-agent-design.md`.

## Test plan

- [ ] `uv sync --all-packages` registers the new workspace member
- [ ] `cd packages/aw-watcher-agent && PYTHONPATH=src pytest tests/ -q` → 11 passed
- [ ] With a local aw-server running: `aw-watcher-agent ensure-bucket`, `emit-start ...`, `emit-end ... --outcome productive` → one event in `aw-watcher-agent_<hostname>`