### PR TITLE
fix(lessons): remove self-referential keywords across 6 shared lessons

### DIFF
--- a/lessons/autonomous/autonomous-session-pivot-strategies.md
+++ b/lessons/autonomous/autonomous-session-pivot-strategies.md
@@ -5,7 +5,7 @@ match:
   - pivot when blocked
   - switch tasks when stuck
   - alternative value-creation
-  - autonomous session pivot
+  - session pivot lesson
 status: active
 ---
 

--- a/lessons/autonomous/autonomous-session-structure.md
+++ b/lessons/autonomous/autonomous-session-structure.md
@@ -2,7 +2,7 @@
 description: "Use the structured 4-phase approach (status, selection, execution, completion) for every autonomous session"
 match:
   keywords:
-  - autonomous session structure
+  - session structure lesson
   - 4-phase session
   - session phase planning
   - structured autonomous session

--- a/lessons/autonomous/strategic-focus-during-autonomous-sessions.md
+++ b/lessons/autonomous/strategic-focus-during-autonomous-sessions.md
@@ -8,15 +8,15 @@ tags:
 - focus
 match:
   keywords:
-  - strategic focus discipline
-  - darwinian trap avoidance
-  - "strategic focus"
-  - "productivity trap"
-  - "darwinian trap"
-  - "busy work"
-  - "productivity theater"
+
+
+  - straying from highest-leverage
+  - trapped in maintenance loops
+  - self-reinforcing bad behavior
+  - churning on low-value tasks
+  - looking busy without shipping
   - "anti-monotony guard"
-  - "category_monotony"
+  - plateau detector says category_monotony
   - "idea backlog"
   session_categories: [strategic, self-review]
 status: active

--- a/lessons/autonomous/strategic-focus-during-autonomous-sessions.md
+++ b/lessons/autonomous/strategic-focus-during-autonomous-sessions.md
@@ -15,7 +15,6 @@ match:
   - self-reinforcing bad behavior
   - churning on low-value tasks
   - looking busy without shipping
-  - "anti-monotony guard"
   - plateau detector says category_monotony
   - "idea backlog"
   session_categories: [strategic, self-review]

--- a/lessons/patterns/indexed-knowledge-base-for-llm-retrieval.md
+++ b/lessons/patterns/indexed-knowledge-base-for-llm-retrieval.md
@@ -1,7 +1,7 @@
 ---
 match:
   keywords:
-    - knowledge base
+
     - knowledge retrieval
 status: active
 ---

--- a/lessons/patterns/indexed-knowledge-base-for-llm-retrieval.md
+++ b/lessons/patterns/indexed-knowledge-base-for-llm-retrieval.md
@@ -1,7 +1,6 @@
 ---
 match:
   keywords:
-
     - knowledge retrieval
 status: active
 ---

--- a/lessons/tools/notion-mcp-integration.md
+++ b/lessons/tools/notion-mcp-integration.md
@@ -1,10 +1,10 @@
 ---
 match:
   keywords:
-    - "notion"
+
     - "notion mcp"
-    - "notion integration"
-    - "notion api"
+
+
     - "notion token"
     - "NOTION_TOKEN"
 category: tools

--- a/lessons/tools/notion-mcp-integration.md
+++ b/lessons/tools/notion-mcp-integration.md
@@ -1,10 +1,7 @@
 ---
 match:
   keywords:
-
     - "notion mcp"
-
-
     - "notion token"
     - "NOTION_TOKEN"
 category: tools

--- a/lessons/workflow/measure-before-optimize.md
+++ b/lessons/workflow/measure-before-optimize.md
@@ -11,7 +11,7 @@ match:
   - "before/after timing"
   - "p50 = "
   - "is the bottleneck"
-  - "premature optimization"
+  - optimized before measuring
   - "pytest --profile"
   session_categories: [code, infrastructure]
 status: active


### PR DESCRIPTION
Self-referential keywords (phrases that appear verbatim in the lesson's own description/detection sections) cause false-positive keyword matches. The keyword-health audit flagged 27 red (severe) and 90 yellow (moderate) lessons across both repos.

This batch fixes the 6 shared lessons in gptme-contrib:
- autonomous-session-pivot-strategies: 'autonomous session pivot' → 'session pivot'
- autonomous-session-structure: 'autonomous session structure' → 'session structure'
- strategic-focus-during-autonomous-sessions: 8 keyword fixes (broad phrases like 'strategic focus', 'productivity trap', 'category_monotony' → symptom descriptions)
- indexed-knowledge-base-for-llm-retrieval: removed 'knowledge base'
- notion-mcp-integration: removed overly broad 'notion', 'notion integration', 'notion api'
- measure-before-optimize: 'premature optimization' → 'optimized before measuring'

See the companion script at scripts/lesson-self-ref-cleanup.py in the bob workspace for the full audit methodology.