### PR TITLE
feat(gptme-runloops): add grok-build executor

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/utils/executor.py
+++ b/packages/gptme-runloops/src/gptme_runloops/utils/executor.py
@@ -17,6 +17,25 @@ from gptme_runloops.utils.execution import ExecutionResult, execute_gptme
 logger = logging.getLogger(__name__)
 
 
+def _read_system_prompt(path: Path | None) -> str | None:
+    """Return system prompt text when available."""
+    if path and path.exists():
+        return path.read_text()
+    return None
+
+
+def _resolve_grok_build_binary() -> str | None:
+    """Resolve the Grok Build CLI from PATH or the default install location."""
+    path = shutil.which("grok")
+    if path:
+        return path
+
+    fallback = Path.home() / ".grok" / "bin" / "grok"
+    if fallback.is_file():
+        return str(fallback)
+    return None
+
+
 class Executor(ABC):
     """Backend-agnostic execution interface.
 
@@ -185,11 +204,101 @@ class ClaudeCodeExecutor(Executor):
             return ExecutionResult(exit_code=124, timed_out=True)
 
 
+class GrokBuildExecutor(Executor):
+    """Executor for xAI's Grok Build CLI."""
+
+    name = "grok-build"
+
+    @property
+    def _binary_name(self) -> str:
+        return "grok"
+
+    def is_available(self) -> bool:
+        return _resolve_grok_build_binary() is not None
+
+    def execute(
+        self,
+        prompt: str,
+        workspace: Path,
+        timeout: int,
+        *,
+        model: str | None = None,
+        tool_format: str | None = None,
+        tools: str | None = None,
+        env: dict[str, str] | None = None,
+        run_type: str = "run",
+        system_prompt_file: Path | None = None,
+    ) -> ExecutionResult:
+        # Grok Build currently has no allowlist contract compatible with TeamRun's
+        # `tools` string, so ignore it instead of pretending the restriction applied.
+        if tools:
+            logger.warning(
+                "GrokBuildExecutor: 'tools' parameter is not supported by Grok Build "
+                "and will be ignored."
+            )
+        if tool_format:
+            logger.warning(
+                "GrokBuildExecutor: 'tool_format' parameter is not supported by Grok Build "
+                "and will be ignored."
+            )
+
+        binary = _resolve_grok_build_binary()
+        if not binary:
+            raise RuntimeError(
+                "Backend 'grok-build' is not available ('grok' not found)"
+            )
+
+        cmd = [
+            "stdbuf",
+            "-oL",
+            "-eL",
+            binary,
+            "--single",
+            prompt,
+            "--cwd",
+            str(workspace),
+            "--no-memory",
+            "--output-format",
+            "streaming-json",
+            "--permission-mode",
+            "bypassPermissions",
+        ]
+        if model:
+            cmd += ["--model", model]
+
+        system_prompt = _read_system_prompt(system_prompt_file)
+        if system_prompt:
+            cmd += ["--system-prompt-override", system_prompt]
+
+        run_env = os.environ.copy()
+        if env:
+            run_env.update(env)
+
+        try:
+            result = subprocess.run(
+                cmd,
+                cwd=workspace,
+                env=run_env,
+                timeout=timeout,
+                capture_output=True,
+                text=True,
+                stdin=subprocess.DEVNULL,
+            )
+            if result.stdout:
+                print(result.stdout, end="")
+            if result.stderr:
+                print(result.stderr, end="", file=sys.stderr)
+            return ExecutionResult(exit_code=result.returncode)
+        except subprocess.TimeoutExpired:
+            return ExecutionResult(exit_code=124, timed_out=True)
+
+
 # --- Backend registry ---
 
 EXECUTORS: dict[str, type[Executor]] = {
     "gptme": GptmeExecutor,
     "claude-code": ClaudeCodeExecutor,
+    "grok-build": GrokBuildExecutor,
 }
 
 

--- a/packages/gptme-runloops/src/gptme_runloops/utils/executor.py
+++ b/packages/gptme-runloops/src/gptme_runloops/utils/executor.py
@@ -248,11 +248,10 @@ class GrokBuildExecutor(Executor):
                 "Backend 'grok-build' is not available ('grok' not found)"
             )
 
-        cmd = [
-            "stdbuf",
-            "-oL",
-            "-eL",
-            binary,
+        # Use stdbuf if available (GNU coreutils) to prevent libc block-buffering
+        # hangs when stdout is piped in headless mode. Not available on stock macOS.
+        stdbuf = shutil.which("stdbuf")
+        cmd = ([stdbuf, "-oL", "-eL", binary] if stdbuf else [binary]) + [
             "--single",
             prompt,
             "--cwd",

--- a/packages/gptme-runloops/tests/test_executor.py
+++ b/packages/gptme-runloops/tests/test_executor.py
@@ -1,5 +1,7 @@
 """Tests for the executor abstraction."""
 
+import os
+import shutil
 import subprocess
 import tempfile
 from pathlib import Path
@@ -217,7 +219,9 @@ def test_claude_code_executor_system_prompt():
     with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
         f.write("You are a helpful assistant.")
         f.flush()
+        tmp_path = f.name
 
+    try:
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
 
@@ -225,11 +229,13 @@ def test_claude_code_executor_system_prompt():
                 prompt="test",
                 workspace=Path("/tmp"),
                 timeout=60,
-                system_prompt_file=Path(f.name),
+                system_prompt_file=Path(tmp_path),
             )
 
             cmd = mock_run.call_args[0][0]
             assert "--append-system-prompt" in cmd
+    finally:
+        os.unlink(tmp_path)
 
 
 def test_claude_code_executor_timeout():
@@ -554,7 +560,12 @@ def test_grok_build_executor_basic_execution():
         assert result.exit_code == 0
 
         cmd = mock_run.call_args[0][0]
-        assert cmd[:4] == ["stdbuf", "-oL", "-eL", "/usr/bin/grok"]
+        # stdbuf is optional (unavailable on stock macOS); check by basename
+        if shutil.which("stdbuf"):
+            assert os.path.basename(cmd[0]) == "stdbuf"
+            assert cmd[1:4] == ["-oL", "-eL", "/usr/bin/grok"]
+        else:
+            assert cmd[0] == "/usr/bin/grok"
         assert "--single" in cmd
         assert "--output-format" in cmd
         assert "streaming-json" in cmd
@@ -568,7 +579,9 @@ def test_grok_build_executor_system_prompt():
     with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
         f.write("You are a helpful assistant.")
         f.flush()
+        tmp_path = f.name
 
+    try:
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
 
@@ -580,11 +593,13 @@ def test_grok_build_executor_system_prompt():
                     prompt="test",
                     workspace=Path("/tmp"),
                     timeout=60,
-                    system_prompt_file=Path(f.name),
+                    system_prompt_file=Path(tmp_path),
                 )
 
             cmd = mock_run.call_args[0][0]
             assert "--system-prompt-override" in cmd
+    finally:
+        os.unlink(tmp_path)
 
 
 def test_grok_build_executor_timeout():

--- a/packages/gptme-runloops/tests/test_executor.py
+++ b/packages/gptme-runloops/tests/test_executor.py
@@ -11,6 +11,7 @@ from gptme_runloops.utils.executor import (
     ClaudeCodeExecutor,
     Executor,
     GptmeExecutor,
+    GrokBuildExecutor,
     get_executor,
     list_backends,
 )
@@ -293,6 +294,7 @@ def test_list_backends():
     backends = list_backends()
     assert "gptme" in backends
     assert "claude-code" in backends
+    assert "grok-build" in backends
     assert backends == sorted(backends)  # Should be sorted
 
 
@@ -308,6 +310,14 @@ def test_get_executor_claude_code():
     with patch("shutil.which", return_value="/usr/bin/claude"):
         executor = get_executor("claude-code")
         assert isinstance(executor, ClaudeCodeExecutor)
+
+
+def test_get_executor_grok_build():
+    """Test getting grok-build executor by name."""
+    with patch("gptme_runloops.utils.executor._resolve_grok_build_binary") as mock_bin:
+        mock_bin.return_value = "/usr/bin/grok"
+        executor = get_executor("grok-build")
+        assert isinstance(executor, GrokBuildExecutor)
 
 
 def test_get_executor_unknown():
@@ -488,3 +498,131 @@ def test_claude_code_executor_no_warn_without_tools():
                 timeout=60,
             )
             mock_logger.warning.assert_not_called()
+
+
+# --- GrokBuildExecutor tests ---
+
+
+def test_grok_build_executor_name():
+    executor = GrokBuildExecutor()
+    assert executor.name == "grok-build"
+
+
+def test_grok_build_executor_binary_name():
+    executor = GrokBuildExecutor()
+    assert executor._binary_name == "grok"
+
+
+def test_grok_build_executor_is_available_from_path():
+    executor = GrokBuildExecutor()
+
+    with patch("shutil.which", return_value="/usr/bin/grok"):
+        assert executor.is_available()
+
+
+def test_grok_build_executor_is_available_from_home_fallback(monkeypatch, tmp_path):
+    executor = GrokBuildExecutor()
+    grok_home = tmp_path / ".grok" / "bin"
+    grok_home.mkdir(parents=True)
+    grok_bin = grok_home / "grok"
+    grok_bin.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+
+    monkeypatch.setattr("shutil.which", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    assert executor.is_available()
+
+
+def test_grok_build_executor_basic_execution():
+    executor = GrokBuildExecutor()
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch(
+            "gptme_runloops.utils.executor._resolve_grok_build_binary"
+        ) as mock_bin:
+            mock_bin.return_value = "/usr/bin/grok"
+
+            result = executor.execute(
+                prompt="test prompt",
+                workspace=Path("/tmp"),
+                timeout=300,
+            )
+
+        assert result.success
+        assert result.exit_code == 0
+
+        cmd = mock_run.call_args[0][0]
+        assert cmd[:4] == ["stdbuf", "-oL", "-eL", "/usr/bin/grok"]
+        assert "--single" in cmd
+        assert "--output-format" in cmd
+        assert "streaming-json" in cmd
+        assert "--permission-mode" in cmd
+        assert "bypassPermissions" in cmd
+
+
+def test_grok_build_executor_system_prompt():
+    executor = GrokBuildExecutor()
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+        f.write("You are a helpful assistant.")
+        f.flush()
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+            with patch(
+                "gptme_runloops.utils.executor._resolve_grok_build_binary"
+            ) as mock_bin:
+                mock_bin.return_value = "/usr/bin/grok"
+                executor.execute(
+                    prompt="test",
+                    workspace=Path("/tmp"),
+                    timeout=60,
+                    system_prompt_file=Path(f.name),
+                )
+
+            cmd = mock_run.call_args[0][0]
+            assert "--system-prompt-override" in cmd
+
+
+def test_grok_build_executor_timeout():
+    executor = GrokBuildExecutor()
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="grok", timeout=60)
+
+        with patch(
+            "gptme_runloops.utils.executor._resolve_grok_build_binary"
+        ) as mock_bin:
+            mock_bin.return_value = "/usr/bin/grok"
+            result = executor.execute(
+                prompt="test",
+                workspace=Path("/tmp"),
+                timeout=60,
+            )
+
+        assert not result.success
+        assert result.exit_code == 124
+        assert result.timed_out
+
+
+def test_grok_build_executor_uses_devnull_stdin():
+    executor = GrokBuildExecutor()
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch(
+            "gptme_runloops.utils.executor._resolve_grok_build_binary"
+        ) as mock_bin:
+            mock_bin.return_value = "/usr/bin/grok"
+            executor.execute(
+                prompt="test",
+                workspace=Path("/tmp"),
+                timeout=60,
+            )
+
+        call_kwargs = mock_run.call_args[1]
+        assert call_kwargs["stdin"] == subprocess.DEVNULL


### PR DESCRIPTION
## Summary

Adds `GrokBuildExecutor` to the executor abstraction layer in `gptme-runloops`, enabling autonomous run loops to use xAI's Grok Build CLI (SuperGrok Heavy subscription) as a backend alongside gptme and Claude Code.

- New `GrokBuildExecutor` class wraps `grok --single ... --output-format streaming-json` with `stdbuf -oL -eL` prefix (required to prevent libc block-buffering hang in headless mode)
- Binary auto-resolved via `shutil.which("grok")` with fallback to `~/.grok/bin/grok`
- Session isolation via `--no-memory`; workspace isolation via `--cwd`
- `--permission-mode bypassPermissions` for autonomous runs (equivalent to CC's `--dangerously-skip-permissions`)
- `--system-prompt-override` support wired through
- `is_available()` checks for the `grok` binary without hard-coding PATH
- 138 tests covering all three executor types (GptmeExecutor, ClaudeCodeExecutor, GrokBuildExecutor) — availability mocks, timeout handling, env passthrough, streaming-json format flag, stdbuf prefix

## Key gotcha: `stdbuf` is required

`grok -p` uses libc buffering by default. Without `stdbuf -oL -eL`, the process hangs silently when stdout is piped. This is analogous to the issue gptme has with its own output streaming.

## Context

ErikBjare/bob#794 — Erik has a SuperGrok Heavy subscription. Auth is via device-auth OAuth (same pattern as Claude Max). Headless mode confirmed working on Bob's container.