### PR TITLE
fix(lessons): add session_categories to persist-before-noting (false-negative fix)

### DIFF
--- a/lessons/patterns/persist-before-noting.md
+++ b/lessons/patterns/persist-before-noting.md
@@ -9,6 +9,7 @@ match:
     - "won't forget"
     - "for next time"
     - "should write this down"
+  session_categories: [research, cleanup, code, infrastructure, strategic, knowledge]
 status: active
 description: "When you say you have noted or learned something, immediately persist it to a core file before continuing."
 ---


### PR DESCRIPTION
## Problem

`lesson-keyword-journal-crossref.py --suggest` flags **persist-before-noting** as a *false negative*: its keywords matched ≥2 distinct sessions in the 7d window (8 hits — `noted for future reference` ×3, `I'll remember this` ×3, `will keep this in mind` ×2) but the lesson was **never injected**.

This is a pipeline issue, **not** a keyword issue — the keywords already match. Adding more keywords does not help (the crossref tool explicitly notes this). Likely causes: PreToolUse tail-window vs full-corpus mismatch, injection dedup, or the `MAX_PRETOOL_LESSONS` cap beating it out.

## Fix

Add `session_categories` so the lesson is **bundle-delivered** for matching session categories — the documented false-negative remediation (see `skills/lesson-keyword-analysis/SKILL.md`).

Categories mirror the sibling lesson `persistent-learning.md` (`[research, cleanup, code, infrastructure, strategic, knowledge]`) — the discovery-heavy rooms where empty "noted!" acknowledgments actually occur, without injecting into every session (which would be noise).

## Verification

- `validate.py` → ✅ valid (two-file format)
- One-line frontmatter addition, no keyword or body changes