### PR TITLE
fix(twitter): block dead blog links before posting

### DIFF
--- a/scripts/twitter/twitter.py
+++ b/scripts/twitter/twitter.py
@@ -52,6 +52,7 @@ For OAuth 2.0 setup:
 """
 
 import os
+import re
 import sys
 import warnings
 from datetime import datetime, timedelta, timezone
@@ -118,6 +119,50 @@ def _get_user_auth(client) -> bool:
     Set by load_twitter_client() as client._use_user_auth.
     """
     return getattr(client, "_use_user_auth", False)
+
+
+def _validate_urls_in_text(text: str) -> list[tuple[str, int]]:
+    """HEAD-check URLs and return deterministic HTTP failures."""
+    import urllib.error
+    import urllib.request
+
+    url_pattern = re.compile(r"https?://[^\s\"'<>)]+")
+    bad: list[tuple[str, int]] = []
+    for url in url_pattern.findall(text):
+        url = url.rstrip(".,;:!?")
+        try:
+            req = urllib.request.Request(url, method="HEAD")
+            req.add_header("User-Agent", "Mozilla/5.0 (URL checker)")
+            with urllib.request.urlopen(req, timeout=5):
+                pass
+        except urllib.error.HTTPError as e:
+            bad.append((url, e.code))
+        except Exception:
+            pass
+    return bad
+
+
+def _abort_on_bad_urls(messages: list[str]) -> None:
+    """Fail closed on dead self-links before posting live tweets."""
+    bad: list[tuple[str, int]] = []
+    seen: set[tuple[str, int]] = set()
+
+    for text in messages:
+        if not text:
+            continue
+        for issue in _validate_urls_in_text(text):
+            if issue in seen:
+                continue
+            seen.add(issue)
+            bad.append(issue)
+
+    if not bad:
+        return
+
+    for url, status in bad:
+        console.print(f"[red]✗ URL returns {status}: {url}[/red]")
+    console.print("[red]Aborting post — fix dead URLs before tweeting.[/red]")
+    sys.exit(1)
 
 
 def _verify_account_identity(username: str, console) -> None:
@@ -614,6 +659,7 @@ def post(text: str, reply_to: str | None, thread: bool) -> None:
     # Handle thread posting
     if thread:
         thread_messages = split_thread(text)
+        _abort_on_bad_urls([message.text for message in thread_messages])
         reply_to_id: str | None = None
 
         for message in thread_messages:
@@ -641,6 +687,7 @@ def post(text: str, reply_to: str | None, thread: bool) -> None:
             console.print(f"[green]Posted tweet: {message.text}")
     else:
         # Single tweet
+        _abort_on_bad_urls([text])
         response = client.create_tweet(
             text=text, in_reply_to_tweet_id=reply_to, user_auth=_get_user_auth(client)
         )

--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -790,6 +790,23 @@ def _validate_urls_in_text(text: str) -> list[tuple[str, int]]:
     return bad
 
 
+def _validate_draft_urls(draft: TweetDraft) -> list[tuple[str, int]]:
+    """Validate URLs across both the main tweet text and any thread follow-ups."""
+    bad: list[tuple[str, int]] = []
+    seen: set[tuple[str, int]] = set()
+
+    for text in [draft.text, *draft.thread]:
+        if not text:
+            continue
+        for issue in _validate_urls_in_text(text):
+            if issue in seen:
+                continue
+            seen.add(issue)
+            bad.append(issue)
+
+    return bad
+
+
 @cli.command()
 @click.argument("text")
 @click.option(
@@ -1319,13 +1336,13 @@ def post(
             continue
 
         # URL validation: catch 404s before asking for confirmation
-        if not skip_url_check and draft.text:
-            bad_urls = _validate_urls_in_text(draft.text)
+        if not skip_url_check:
+            bad_urls = _validate_draft_urls(draft)
             if bad_urls:
                 for url, status in bad_urls:
                     console.print(f"[red]✗ URL returns {status}: {url}[/red]")
                 console.print(
-                    "[red]Skipping draft — fix URLs or pass --skip-url-check.[/red]"
+                    "[red]Skipping draft — fix dead URLs in the tweet or thread, or pass --skip-url-check.[/red]"
                 )
                 move_draft(path, "rejected")
                 continue
@@ -1663,6 +1680,24 @@ def process_timeline_tweets(
                             f"[green]Auto-posting reply to trusted user @{author_username}"
                         )
                         try:
+                            bad_urls = _validate_draft_urls(draft)
+                            if bad_urls:
+                                for url, status in bad_urls:
+                                    console.print(
+                                        f"[red]✗ URL returns {status}: {url}[/red]"
+                                    )
+                                draft.reject_reason = (
+                                    "Auto-post blocked: dead URL in tweet or thread"
+                                )
+                                path = save_draft(draft, "new")
+                                console.print(
+                                    f"[yellow]Saved as draft for manual URL fix: {path}"
+                                )
+                                drafts_generated += 1
+                                if draft.in_reply_to is not None:
+                                    _replied_tweet_ids.add(str(draft.in_reply_to))
+                                continue
+
                             client_for_post = load_twitter_client(
                                 require_auth=True, headless=True
                             )
@@ -2190,6 +2225,16 @@ def auto(
                     console.print(
                         f"[cyan]Thread: {len(draft.thread)} follow-up tweet(s)"
                     )
+
+                bad_urls = _validate_draft_urls(draft)
+                if bad_urls:
+                    for url, http_status in bad_urls:
+                        console.print(f"[red]✗ URL returns {http_status}: {url}[/red]")
+                    console.print(
+                        "[red]Skipping draft — fix dead URLs in the tweet or thread.[/red]"
+                    )
+                    move_draft(path, "rejected")
+                    continue
 
                 try:
                     response = client.create_tweet(

--- a/tests/test_twitter_post_url_guard.py
+++ b/tests/test_twitter_post_url_guard.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from collections.abc import Generator
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TWITTER_PATH = REPO_ROOT / "scripts" / "twitter" / "twitter.py"
+
+
+def _make_pkg(name: str) -> types.ModuleType:
+    mod = types.ModuleType(name)
+    mod.__path__ = []
+    return mod
+
+
+def _load_twitter_module() -> Any:
+    click_stub: Any = types.ModuleType("click")
+
+    def _passthrough_decorator(*args, **kwargs):
+        def _decorator(func):
+            return func
+
+        return _decorator
+
+    def _group_decorator(*args, **kwargs):
+        def _decorator(func):
+            func.command = _passthrough_decorator
+            return func
+
+        return _decorator
+
+    click_stub.group = _group_decorator
+    click_stub.command = _passthrough_decorator
+    click_stub.option = _passthrough_decorator
+    click_stub.argument = _passthrough_decorator
+    click_stub.Choice = lambda choices: choices
+    click_stub.IntRange = lambda *args, **kwargs: None
+
+    tweepy_stub: Any = types.ModuleType("tweepy")
+    tweepy_stub.Client = object
+    tweepy_stub.TweepyException = Exception
+    tweepy_stub.Tweet = object
+    tweepy_stub.Response = object
+
+    dotenv_stub: Any = types.ModuleType("dotenv")
+    dotenv_stub.load_dotenv = lambda *args, **kwargs: None
+    dotenv_stub.find_dotenv = lambda *args, **kwargs: ""
+
+    auth_stub: Any = types.ModuleType("gptmail.communication_utils.auth")
+    auth_stub.refresh_twitter_token_if_needed = lambda *args, **kwargs: (None, None)
+    auth_stub.run_oauth_callback = lambda *args, **kwargs: (None, None)
+    auth_stub.save_tokens_to_env = lambda *args, **kwargs: None
+
+    auth_oauth_stub: Any = types.ModuleType("gptmail.communication_utils.auth.oauth")
+    auth_oauth_stub.OAuthManager = SimpleNamespace(
+        for_twitter=lambda *args, **kwargs: None
+    )
+
+    auth_tokens_stub: Any = types.ModuleType("gptmail.communication_utils.auth.tokens")
+    auth_tokens_stub.TokenInfo = SimpleNamespace
+
+    messaging_stub: Any = types.ModuleType("gptmail.communication_utils.messaging")
+    messaging_stub.split_thread = lambda text: [SimpleNamespace(text=text)]
+
+    rich_stub = _make_pkg("rich")
+    rich_console_stub: Any = types.ModuleType("rich.console")
+    rich_console_stub.Console = lambda *args, **kwargs: SimpleNamespace(
+        print=lambda *print_args, **print_kwargs: None
+    )
+
+    gptmail_stub = _make_pkg("gptmail")
+    gptmail_comm_stub = _make_pkg("gptmail.communication_utils")
+
+    stubbed_modules: dict[str, Any] = {
+        "click": click_stub,
+        "tweepy": tweepy_stub,
+        "dotenv": dotenv_stub,
+        "rich": rich_stub,
+        "rich.console": rich_console_stub,
+        "gptmail": gptmail_stub,
+        "gptmail.communication_utils": gptmail_comm_stub,
+        "gptmail.communication_utils.auth": auth_stub,
+        "gptmail.communication_utils.auth.oauth": auth_oauth_stub,
+        "gptmail.communication_utils.auth.tokens": auth_tokens_stub,
+        "gptmail.communication_utils.messaging": messaging_stub,
+    }
+
+    for name, stub in stubbed_modules.items():
+        sys.modules.setdefault(name, stub)
+
+    spec = importlib.util.spec_from_file_location(
+        "twitter_post_guard_under_test", TWITTER_PATH
+    )
+    assert spec and spec.loader
+    module: Any = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def twitter_module() -> Generator[Any, None, None]:
+    stub_keys = (
+        "click",
+        "tweepy",
+        "dotenv",
+        "rich",
+        "rich.console",
+        "gptmail",
+        "gptmail.communication_utils",
+        "gptmail.communication_utils.auth",
+        "gptmail.communication_utils.auth.oauth",
+        "gptmail.communication_utils.auth.tokens",
+        "gptmail.communication_utils.messaging",
+        "twitter_post_guard_under_test",
+    )
+    pre_existing = {key for key in stub_keys if key in sys.modules}
+    module = _load_twitter_module()
+    yield module
+    for key in stub_keys:
+        if key not in pre_existing:
+            sys.modules.pop(key, None)
+
+
+def test_post_aborts_before_single_tweet_with_dead_url(
+    twitter_module: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    posted: list[str] = []
+
+    monkeypatch.setattr(
+        twitter_module,
+        "_validate_urls_in_text",
+        lambda text: [("https://timetobuildbob.github.io/blog/missing/", 404)],
+    )
+    monkeypatch.setattr(
+        twitter_module,
+        "load_twitter_client",
+        lambda require_auth=True: SimpleNamespace(
+            create_tweet=lambda **kwargs: posted.append(kwargs["text"])
+        ),
+    )
+
+    with pytest.raises(SystemExit):
+        twitter_module.post(
+            "https://timetobuildbob.github.io/blog/missing/", None, False
+        )
+
+    assert posted == []
+
+
+def test_post_aborts_before_thread_with_dead_followup_url(
+    twitter_module: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    posted: list[str] = []
+
+    monkeypatch.setattr(
+        twitter_module,
+        "split_thread",
+        lambda text: [
+            SimpleNamespace(text="main tweet"),
+            SimpleNamespace(text="https://timetobuildbob.github.io/blog/missing/"),
+        ],
+    )
+    monkeypatch.setattr(
+        twitter_module,
+        "_validate_urls_in_text",
+        lambda text: (
+            [("https://timetobuildbob.github.io/blog/missing/", 404)]
+            if "missing" in text
+            else []
+        ),
+    )
+    monkeypatch.setattr(
+        twitter_module,
+        "load_twitter_client",
+        lambda require_auth=True: SimpleNamespace(
+            create_tweet=lambda **kwargs: posted.append(kwargs["text"])
+        ),
+    )
+
+    with pytest.raises(SystemExit):
+        twitter_module.post("ignored", None, True)
+
+    assert posted == []

--- a/tests/test_twitter_post_url_guard.py
+++ b/tests/test_twitter_post_url_guard.py
@@ -12,6 +12,7 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 TWITTER_PATH = REPO_ROOT / "scripts" / "twitter" / "twitter.py"
+_MISSING = object()
 
 
 def _make_pkg(name: str) -> types.ModuleType:
@@ -20,7 +21,7 @@ def _make_pkg(name: str) -> types.ModuleType:
     return mod
 
 
-def _load_twitter_module() -> Any:
+def _load_twitter_module() -> tuple[Any, dict[str, Any]]:
     click_stub: Any = types.ModuleType("click")
 
     def _passthrough_decorator(*args, **kwargs):
@@ -92,8 +93,11 @@ def _load_twitter_module() -> Any:
         "gptmail.communication_utils.messaging": messaging_stub,
     }
 
+    original_modules = {
+        name: sys.modules.get(name, _MISSING) for name in stubbed_modules
+    }
     for name, stub in stubbed_modules.items():
-        sys.modules.setdefault(name, stub)
+        sys.modules[name] = stub
 
     spec = importlib.util.spec_from_file_location(
         "twitter_post_guard_under_test", TWITTER_PATH
@@ -102,31 +106,19 @@ def _load_twitter_module() -> Any:
     module: Any = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
-    return module
+    return module, original_modules
 
 
 @pytest.fixture(scope="module")
 def twitter_module() -> Generator[Any, None, None]:
-    stub_keys = (
-        "click",
-        "tweepy",
-        "dotenv",
-        "rich",
-        "rich.console",
-        "gptmail",
-        "gptmail.communication_utils",
-        "gptmail.communication_utils.auth",
-        "gptmail.communication_utils.auth.oauth",
-        "gptmail.communication_utils.auth.tokens",
-        "gptmail.communication_utils.messaging",
-        "twitter_post_guard_under_test",
-    )
-    pre_existing = {key for key in stub_keys if key in sys.modules}
-    module = _load_twitter_module()
+    module, original_modules = _load_twitter_module()
     yield module
-    for key in stub_keys:
-        if key not in pre_existing:
+    sys.modules.pop("twitter_post_guard_under_test", None)
+    for key, original in original_modules.items():
+        if original is _MISSING:
             sys.modules.pop(key, None)
+        else:
+            sys.modules[key] = original
 
 
 def test_post_aborts_before_single_tweet_with_dead_url(

--- a/tests/test_twitter_workflow_drafts.py
+++ b/tests/test_twitter_workflow_drafts.py
@@ -15,6 +15,7 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 WORKFLOW_PATH = REPO_ROOT / "scripts" / "twitter" / "workflow.py"
+_MISSING = object()
 
 
 def _make_pkg(name: str) -> types.ModuleType:
@@ -23,7 +24,7 @@ def _make_pkg(name: str) -> types.ModuleType:
     return mod
 
 
-def _load_workflow_module() -> Any:
+def _load_workflow_module() -> tuple[Any, dict[str, Any]]:
     class _Operation:
         def complete(self, *args, **kwargs) -> None:
             return None
@@ -114,8 +115,11 @@ def _load_workflow_module() -> Any:
         "twitter.twitter": twitter_api_stub,
     }
 
+    original_modules = {
+        name: sys.modules.get(name, _MISSING) for name in stubbed_modules
+    }
     for name, stub in stubbed_modules.items():
-        sys.modules.setdefault(name, stub)
+        sys.modules[name] = stub
 
     spec = importlib.util.spec_from_file_location(
         "twitter_workflow_under_test", WORKFLOW_PATH
@@ -124,34 +128,19 @@ def _load_workflow_module() -> Any:
     module: Any = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
-    return module
+    return module, original_modules
 
 
 @pytest.fixture(scope="module")
 def workflow_module() -> Generator[Any, None, None]:
-    stub_keys = (
-        "gptmail",
-        "gptmail.communication_utils",
-        "gptmail.communication_utils.monitoring",
-        "gptme",
-        "gptme.init",
-        "dotenv",
-        "click",
-        "rich",
-        "rich.console",
-        "rich.prompt",
-        "trusted_users",
-        "twitter",
-        "twitter.llm",
-        "twitter.twitter",
-        "twitter_workflow_under_test",
-    )
-    pre_existing = {key for key in stub_keys if key in sys.modules}
-    module = _load_workflow_module()
+    module, original_modules = _load_workflow_module()
     yield module
-    for key in stub_keys:
-        if key not in pre_existing:
+    sys.modules.pop("twitter_workflow_under_test", None)
+    for key, original in original_modules.items():
+        if original is _MISSING:
             sys.modules.pop(key, None)
+        else:
+            sys.modules[key] = original
 
 
 def _set_status_dirs(module: Any, tmp_path: Path) -> None:

--- a/tests/test_twitter_workflow_drafts.py
+++ b/tests/test_twitter_workflow_drafts.py
@@ -5,6 +5,8 @@ import logging
 import sys
 import types
 from collections.abc import Generator
+from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -301,6 +303,138 @@ def test_duplicate_reply_detection_includes_rejected_and_review(
         "review": [review_path],
         "rejected": [rejected_path],
     }
+
+
+def test_validate_draft_urls_checks_thread_followups(
+    workflow_module: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[str] = []
+
+    def fake_validate(text: str) -> list[tuple[str, int]]:
+        calls.append(text)
+        if "dead-link" in text:
+            return [("https://timetobuildbob.github.io/blog/missing/", 404)]
+        return []
+
+    monkeypatch.setattr(workflow_module, "_validate_urls_in_text", fake_validate)
+
+    draft = workflow_module.TweetDraft(
+        text="Main tweet has no URL.",
+        thread=["https://timetobuildbob.github.io/blog/missing/ dead-link"],
+    )
+
+    assert workflow_module._validate_draft_urls(draft) == [
+        ("https://timetobuildbob.github.io/blog/missing/", 404)
+    ]
+    assert calls == [
+        "Main tweet has no URL.",
+        "https://timetobuildbob.github.io/blog/missing/ dead-link",
+    ]
+
+
+def test_trusted_user_autopost_with_bad_url_saves_draft_instead_of_posting(
+    workflow_module: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_status_dirs(workflow_module, tmp_path)
+
+    @dataclass
+    class EvalResult:
+        action: str
+        relevance: int
+        priority: int
+
+    @dataclass
+    class Response:
+        text: str
+        type: str
+        thread_needed: bool
+        follow_up: str | None
+
+    tweet = SimpleNamespace(
+        id="4242",
+        author_id="7",
+        text="You should link the post.",
+        created_at=datetime.now(timezone.utc),
+        public_metrics={},
+        conversation_id=None,
+    )
+    user = SimpleNamespace(
+        id="7",
+        username="ErikBjare",
+        public_metrics={"followers_count": 1},
+    )
+
+    saved: list[tuple[str, str, str | None]] = []
+
+    def fake_save_draft(draft: Any, status: str = "new") -> Path:
+        saved.append((status, draft.text, draft.reject_reason))
+        path = Path(workflow_module.NEW_DIR) / "saved.yml"
+        path.write_text("text: saved\n")
+        return path
+
+    class PostingClient:
+        def create_tweet(self, *args: Any, **kwargs: Any) -> Any:
+            raise AssertionError("auto-post should not happen for dead URLs")
+
+    monkeypatch.setattr(
+        workflow_module,
+        "cached_get_me",
+        lambda *a, **k: SimpleNamespace(data=SimpleNamespace(id="999")),
+    )
+    monkeypatch.setattr(
+        workflow_module, "should_evaluate_tweet", lambda *a, **k: (True, "")
+    )
+    monkeypatch.setattr(workflow_module, "is_reply_restricted", lambda *a, **k: False)
+    monkeypatch.setattr(workflow_module, "is_tweet_cached", lambda *a, **k: False)
+    monkeypatch.setattr(
+        workflow_module,
+        "process_tweet",
+        lambda *a, **k: (
+            EvalResult("respond", 100, 100),
+            Response(
+                "Read this https://timetobuildbob.github.io/blog/missing/",
+                "reply",
+                False,
+                None,
+            ),
+        ),
+    )
+    monkeypatch.setattr(workflow_module, "save_to_cache", lambda *a, **k: None)
+    monkeypatch.setattr(
+        workflow_module, "is_trusted_user", lambda username: username == "ErikBjare"
+    )
+    monkeypatch.setattr(
+        workflow_module, "_check_for_duplicate_replies_internal", lambda draft: {}
+    )
+    monkeypatch.setattr(
+        workflow_module,
+        "_validate_draft_urls",
+        lambda draft: [("https://timetobuildbob.github.io/blog/missing/", 404)],
+    )
+    monkeypatch.setattr(workflow_module, "save_draft", fake_save_draft)
+    monkeypatch.setattr(
+        workflow_module, "load_twitter_client", lambda *a, **k: PostingClient()
+    )
+    monkeypatch.setattr(workflow_module, "_git_commit_posted", lambda *a, **k: None)
+
+    drafts_generated = workflow_module.process_timeline_tweets(
+        [tweet],
+        [user],
+        source="mentions",
+        client=object(),
+        times=1,
+        dry_run=False,
+        max_drafts=10,
+    )
+
+    assert drafts_generated == 1
+    assert saved == [
+        (
+            "new",
+            "Read this https://timetobuildbob.github.io/blog/missing/",
+            "Auto-post blocked: dead URL in tweet or thread",
+        )
+    ]
 
 
 def test_find_live_duplicate_reply_ids_matches_own_replies(


### PR DESCRIPTION
## Summary
- validate URLs across both the main tweet text and thread follow-ups in `workflow.py` posting paths
- block trusted-user auto-post replies when the generated tweet or follow-up contains a dead blog URL
- fail closed in direct `twitter.py post` and add regression coverage for both paths

## Testing
- uv run pytest /home/bob/bob/gptme-contrib/tests/test_twitter_workflow_drafts.py /home/bob/bob/gptme-contrib/tests/test_twitter_post_url_guard.py -q
- python3 -m py_compile /home/bob/bob/gptme-contrib/scripts/twitter/workflow.py /home/bob/bob/gptme-contrib/scripts/twitter/twitter.py