### PR TITLE
refactor(twitter): extract URL validator to shared url_utils module

### DIFF
--- a/scripts/twitter/twitter.py
+++ b/scripts/twitter/twitter.py
@@ -52,7 +52,6 @@ For OAuth 2.0 setup:
 """
 
 import os
-import re
 import sys
 import warnings
 from datetime import datetime, timedelta, timezone
@@ -82,6 +81,7 @@ from gptmail.communication_utils.messaging import (  # type: ignore[import-not-f
     split_thread,
 )
 from rich.console import Console
+from url_utils import validate_urls_in_text  # type: ignore[import-not-found]
 
 DEFAULT_SINCE = "7d"
 DEFAULT_LIMIT = 10
@@ -121,36 +121,15 @@ def _get_user_auth(client) -> bool:
     return getattr(client, "_use_user_auth", False)
 
 
-def _validate_urls_in_text(text: str) -> list[tuple[str, int]]:
-    """HEAD-check URLs and return deterministic HTTP failures."""
-    import urllib.error
-    import urllib.request
-
-    url_pattern = re.compile(r"https?://[^\s\"'<>)]+")
-    bad: list[tuple[str, int]] = []
-    for url in url_pattern.findall(text):
-        url = url.rstrip(".,;:!?")
-        try:
-            req = urllib.request.Request(url, method="HEAD")
-            req.add_header("User-Agent", "Mozilla/5.0 (URL checker)")
-            with urllib.request.urlopen(req, timeout=5):
-                pass
-        except urllib.error.HTTPError as e:
-            bad.append((url, e.code))
-        except Exception:
-            pass
-    return bad
-
-
 def _abort_on_bad_urls(messages: list[str]) -> None:
-    """Fail closed on dead self-links before posting live tweets."""
+    """Abort on HTTP 4xx/5xx URLs before posting — network errors pass through as non-fatal."""
     bad: list[tuple[str, int]] = []
     seen: set[tuple[str, int]] = set()
 
     for text in messages:
         if not text:
             continue
-        for issue in _validate_urls_in_text(text):
+        for issue in validate_urls_in_text(text):
             if issue in seen:
                 continue
             seen.add(issue)

--- a/scripts/twitter/url_utils.py
+++ b/scripts/twitter/url_utils.py
@@ -1,0 +1,28 @@
+"""Shared URL validation utilities for twitter scripts."""
+
+import re
+import urllib.error
+import urllib.request
+
+
+def validate_urls_in_text(text: str) -> list[tuple[str, int]]:
+    """HEAD-check any http(s) URLs in tweet text. Return [(url, status)] for unreachable ones (4xx/5xx).
+
+    Network errors are treated as non-fatal (returns nothing for those URLs) — the goal is to
+    catch deterministic 404s like the recurring `/YYYY/MM/DD/title/` vs `/blog/title/` permalink
+    bug, not to require connectivity. Mirrors the check in scripts/twitter/post-blog-tweet.py.
+    """
+    url_pattern = re.compile(r"https?://[^\s\"'<>)]+")
+    bad: list[tuple[str, int]] = []
+    for url in url_pattern.findall(text):
+        url = url.rstrip(".,;:!?")
+        try:
+            req = urllib.request.Request(url, method="HEAD")
+            req.add_header("User-Agent", "Mozilla/5.0 (URL checker)")
+            with urllib.request.urlopen(req, timeout=5):
+                pass  # 4xx/5xx raise HTTPError before reaching here
+        except urllib.error.HTTPError as e:
+            bad.append((url, e.code))
+        except Exception:
+            pass
+    return bad

--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -71,6 +71,7 @@ from twitter.llm import (
     verify_draft,
 )
 from twitter.twitter import cached_get_me, load_twitter_client
+from url_utils import validate_urls_in_text  # type: ignore[import-not-found]
 
 logger = get_logger(__name__, "twitter")
 metrics = MetricsCollector()
@@ -763,33 +764,6 @@ def cli(model: str | None = None) -> None:
     )
 
 
-def _validate_urls_in_text(text: str) -> list[tuple[str, int]]:
-    """HEAD-check any http(s) URLs in tweet text. Return [(url, status)] for unreachable ones (4xx/5xx).
-
-    Network errors are treated as non-fatal (returns nothing for those URLs) — the goal is to
-    catch deterministic 404s like the recurring `/YYYY/MM/DD/title/` vs `/blog/title/` permalink
-    bug, not to require connectivity. Mirrors the check in scripts/twitter/post-blog-tweet.py.
-    """
-    import re
-    import urllib.error
-    import urllib.request
-
-    url_pattern = re.compile(r"https?://[^\s\"'<>)]+")
-    bad: list[tuple[str, int]] = []
-    for url in url_pattern.findall(text):
-        url = url.rstrip(".,;:!?")
-        try:
-            req = urllib.request.Request(url, method="HEAD")
-            req.add_header("User-Agent", "Mozilla/5.0 (URL checker)")
-            with urllib.request.urlopen(req, timeout=5):
-                pass  # 4xx/5xx raise HTTPError before reaching here
-        except urllib.error.HTTPError as e:
-            bad.append((url, e.code))
-        except Exception:
-            pass
-    return bad
-
-
 def _validate_draft_urls(draft: TweetDraft) -> list[tuple[str, int]]:
     """Validate URLs across both the main tweet text and any thread follow-ups."""
     bad: list[tuple[str, int]] = []
@@ -798,7 +772,7 @@ def _validate_draft_urls(draft: TweetDraft) -> list[tuple[str, int]]:
     for text in [draft.text, *draft.thread]:
         if not text:
             continue
-        for issue in _validate_urls_in_text(text):
+        for issue in validate_urls_in_text(text):
             if issue in seen:
                 continue
             seen.add(issue)
@@ -831,7 +805,7 @@ def draft(
 
     try:
         if not skip_url_check:
-            bad_urls = _validate_urls_in_text(text)
+            bad_urls = validate_urls_in_text(text)
             if bad_urls:
                 for url, status in bad_urls:
                     console.print(

--- a/tests/test_twitter_post_url_guard.py
+++ b/tests/test_twitter_post_url_guard.py
@@ -21,7 +21,7 @@ def _make_pkg(name: str) -> types.ModuleType:
     return mod
 
 
-def _load_twitter_module() -> tuple[Any, dict[str, Any]]:
+def _load_twitter_module() -> tuple[Any, dict[str, Any], list[str]]:
     click_stub: Any = types.ModuleType("click")
 
     def _passthrough_decorator(*args, **kwargs):
@@ -96,8 +96,10 @@ def _load_twitter_module() -> tuple[Any, dict[str, Any]]:
     original_modules = {
         name: sys.modules.get(name, _MISSING) for name in stubbed_modules
     }
+    original_sys_path = sys.path.copy()
     for name, stub in stubbed_modules.items():
         sys.modules[name] = stub
+    sys.path.insert(0, str(TWITTER_PATH.parent))
 
     spec = importlib.util.spec_from_file_location(
         "twitter_post_guard_under_test", TWITTER_PATH
@@ -106,13 +108,14 @@ def _load_twitter_module() -> tuple[Any, dict[str, Any]]:
     module: Any = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
-    return module, original_modules
+    return module, original_modules, original_sys_path
 
 
 @pytest.fixture(scope="module")
 def twitter_module() -> Generator[Any, None, None]:
-    module, original_modules = _load_twitter_module()
+    module, original_modules, original_sys_path = _load_twitter_module()
     yield module
+    sys.path[:] = original_sys_path
     sys.modules.pop("twitter_post_guard_under_test", None)
     for key, original in original_modules.items():
         if original is _MISSING:

--- a/tests/test_twitter_post_url_guard.py
+++ b/tests/test_twitter_post_url_guard.py
@@ -128,7 +128,7 @@ def test_post_aborts_before_single_tweet_with_dead_url(
 
     monkeypatch.setattr(
         twitter_module,
-        "_validate_urls_in_text",
+        "validate_urls_in_text",
         lambda text: [("https://timetobuildbob.github.io/blog/missing/", 404)],
     )
     monkeypatch.setattr(
@@ -162,7 +162,7 @@ def test_post_aborts_before_thread_with_dead_followup_url(
     )
     monkeypatch.setattr(
         twitter_module,
-        "_validate_urls_in_text",
+        "validate_urls_in_text",
         lambda text: (
             [("https://timetobuildbob.github.io/blog/missing/", 404)]
             if "missing" in text

--- a/tests/test_twitter_workflow_drafts.py
+++ b/tests/test_twitter_workflow_drafts.py
@@ -305,7 +305,7 @@ def test_validate_draft_urls_checks_thread_followups(
             return [("https://timetobuildbob.github.io/blog/missing/", 404)]
         return []
 
-    monkeypatch.setattr(workflow_module, "_validate_urls_in_text", fake_validate)
+    monkeypatch.setattr(workflow_module, "validate_urls_in_text", fake_validate)
 
     draft = workflow_module.TweetDraft(
         text="Main tweet has no URL.",


### PR DESCRIPTION
## Summary

- Extracts the verbatim-duplicated `_validate_urls_in_text` function from `twitter.py` and `workflow.py` into a new `scripts/twitter/url_utils.py` shared module
- Fixes misleading `_abort_on_bad_urls` docstring: "fail closed" implied network errors also abort, but they're non-fatal by design (only HTTP 4xx/5xx aborts)
- Updates tests to monkeypatch `validate_urls_in_text` on the module namespace instead of the removed private function

## Test plan
- [ ] All 19 twitter URL guard / workflow draft tests pass (`uv run pytest tests/test_twitter_workflow_drafts.py tests/test_twitter_post_url_guard.py -q`)
- [ ] Both scripts still parse without errors (`python3 -c "import ast; ast.parse(open('scripts/twitter/twitter.py').read())"`)

Greptile P2 follow-up from #981.