### PR TITLE
fix(gptmail): support recipient aliases

### DIFF
--- a/packages/gptmail/src/gptmail/lib.py
+++ b/packages/gptmail/src/gptmail/lib.py
@@ -46,7 +46,7 @@ from email.message import EmailMessage, Message
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.policy import default
-from email.utils import format_datetime, parseaddr, parsedate_to_datetime
+from email.utils import format_datetime, getaddresses, parseaddr, parsedate_to_datetime
 from pathlib import Path
 from typing import Any, Dict, NamedTuple, Tuple
 
@@ -178,6 +178,12 @@ class AgentEmail:
             raise ValueError(
                 "own_email must be provided or AGENT_EMAIL environment variable must be set"
             )
+        aliases = [
+            alias.strip().lower()
+            for alias in os.getenv("AGENT_EMAIL_ALIASES", "").split(",")
+            if alias.strip()
+        ]
+        self.own_emails: tuple[str, ...] = tuple(dict.fromkeys([self.own_email.lower(), *aliases]))
         # Optional display name for the agent's email
         self.own_email_name: str | None = (
             own_email_name if own_email_name is not None else os.getenv("AGENT_EMAIL_NAME")
@@ -359,9 +365,17 @@ class AgentEmail:
 
                     # Skip if not addressed to the agent's email
                     # (only process emails sent TO the agent, not CC'd or other recipients)
-                    if to_match and self.own_email:
-                        to_line = to_match.group(1).lower()
-                        if self.own_email.lower() not in to_line:
+                    if to_match and self.own_emails:
+                        to_line = to_match.group(1)
+                        to_addrs = {addr.lower() for _, addr in getaddresses([to_line]) if addr}
+                        if to_addrs:
+                            is_addressed_to_agent = bool(to_addrs.intersection(self.own_emails))
+                        else:
+                            lower_to_line = to_line.lower()
+                            is_addressed_to_agent = any(
+                                own_email in lower_to_line for own_email in self.own_emails
+                            )
+                        if not is_addressed_to_agent:
                             continue
 
                     # Extract email from "Name <email>" format

--- a/packages/gptmail/tests/test_unreplied_emails.py
+++ b/packages/gptmail/tests/test_unreplied_emails.py
@@ -179,6 +179,38 @@ def test_get_unreplied_emails_returns_typed_records(agent: AgentEmail) -> None:
     ]
 
 
+def test_get_unreplied_emails_accepts_agent_email_aliases(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    email_dir = tmp_path / "email"
+    for subdir in ["inbox", "sent", "archive", "drafts", "filters"]:
+        (email_dir / subdir).mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("EMAIL_ALLOWLIST", "friend@example.com")
+    monkeypatch.setenv("AGENT_EMAIL_ALIASES", "alias@example.com")
+    agent = AgentEmail(str(tmp_path), "test@example.com")
+
+    _write_email(
+        email_dir / "inbox" / "alias-recipient.md",
+        message_id="<alias@example.com>",
+        subject="Alias recipient",
+        sender="friend@example.com",
+        recipient="Bob <alias@example.com>",
+        date=datetime(2026, 5, 16, 11, 30, tzinfo=timezone.utc),
+    )
+    _write_email(
+        email_dir / "inbox" / "other-recipient.md",
+        message_id="<other@example.com>",
+        subject="Other recipient",
+        sender="friend@example.com",
+        recipient="other@example.com",
+        date=datetime(2026, 5, 16, 11, 31, tzinfo=timezone.utc),
+    )
+
+    unreplied = agent.get_unreplied_emails()
+
+    assert [entry.message_id for entry in unreplied] == ["<alias@example.com>"]
+
+
 def test_process_unreplied_emails_keeps_legacy_callback_contract(agent: AgentEmail) -> None:
     inbox = agent.email_dir / "inbox"
     expected_date = datetime(2026, 5, 16, 12, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary\n- add AGENT_EMAIL_ALIASES support for unreplied-email recipient filtering\n- parse To headers with email.utils.getaddresses before falling back to substring matching\n- cover alias recipients while preserving filtering for unrelated recipients\n\n## Tests\n- uv run pytest packages/gptmail/tests/test_unreplied_emails.py -q