### PR TITLE
feat(gptme-sessions): add replay command

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -8,6 +8,7 @@ import re
 import sys
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
+from typing import cast
 
 import click
 
@@ -32,6 +33,12 @@ from .discovery import (
     session_datetime_from_path,
 )
 from .post_session import VALID_AB_GROUPS, VALID_CONTEXT_TIERS, post_session
+from .replay import (
+    ToolResultsMode,
+    render_replay,
+    resolve_replay_target,
+    resolve_session_record_prefix,
+)
 from .record import SessionRecord, normalize_run_type
 from .signals import extract_from_path
 from .store import (
@@ -458,20 +465,10 @@ def show(ctx: click.Context, session_id: str, as_json: bool) -> None:
     if not session_id:
         raise click.UsageError("Session ID must not be empty.")
     store = SessionStore(sessions_dir=ctx.obj["sessions_dir"])
-    records = store.load_all()
-    matches = [r for r in records if r.session_id.startswith(session_id)]
-    if not matches:
-        raise click.ClickException(
-            f"No session found matching '{session_id}'. "
-            "Run 'gptme-sessions query' to list available session IDs."
-        )
-    if len(matches) > 1:
-        raise click.ClickException(
-            f"Ambiguous prefix '{session_id}' matches {len(matches)} sessions: "
-            + ", ".join(r.session_id for r in matches)
-            + ". Run 'gptme-sessions query' to list available session IDs."
-        )
-    record = matches[0]
+    try:
+        record = resolve_session_record_prefix(store.load_all(), session_id)
+    except ValueError as exc:
+        raise click.ClickException(str(exc))
 
     if as_json:
         click.echo(json.dumps(record.to_dict(), indent=2))
@@ -1243,6 +1240,65 @@ def transcript(path: Path, as_json: bool, messages_only: bool) -> None:
             else:
                 content_preview = (msg.content or "")[:80].replace("\n", "\\n")
                 click.echo(f"  {ts_str}{msg.role}: {content_preview}")
+
+
+@cli.command()
+@click.argument("target")
+@click.option(
+    "--raw-system",
+    is_flag=True,
+    help="Show initial system messages instead of collapsing them",
+)
+@click.option(
+    "--tool-input",
+    is_flag=True,
+    help="Show structured tool inputs for tool calls",
+)
+@click.option(
+    "--tool-results",
+    type=click.Choice(["summary", "full", "hide"], case_sensitive=False),
+    default="summary",
+    show_default=True,
+    help="How to render tool result payloads",
+)
+@click.option(
+    "--tail",
+    type=click.IntRange(min=1),
+    help="Render only the last N normalized messages",
+)
+@click.pass_context
+def replay(
+    ctx: click.Context,
+    target: str,
+    raw_system: bool,
+    tool_input: bool,
+    tool_results: str,
+    tail: int | None,
+) -> None:
+    """Replay a completed session in the terminal.
+
+    TARGET can be either a trajectory path or a session-record ID prefix.
+    """
+    try:
+        transcript = resolve_replay_target(target, sessions_dir=ctx.obj["sessions_dir"])
+    except (FileNotFoundError, ValueError) as exc:
+        raise click.ClickException(str(exc))
+    except PermissionError:
+        raise click.ClickException(f"cannot read {target}: permission denied")
+    except UnicodeDecodeError:
+        raise click.ClickException(f"{target} contains non-UTF-8 content")
+
+    tool_results_mode = cast(ToolResultsMode, tool_results)
+    click.echo(
+        render_replay(
+            transcript,
+            raw_system=raw_system,
+            show_tool_input=tool_input,
+            tool_results=tool_results_mode,
+            tail=tail,
+        ),
+        nl=False,
+    )
 
 
 # -- sync --------------------------------------------------------------------

--- a/packages/gptme-sessions/src/gptme_sessions/replay.py
+++ b/packages/gptme-sessions/src/gptme_sessions/replay.py
@@ -1,0 +1,192 @@
+"""Replay helpers for human-readable session transcript inspection."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Literal
+
+from .record import SessionRecord
+from .store import SessionStore
+from .transcript import NormalizedMessage, SessionTranscript, read_transcript
+
+ToolResultsMode = Literal["summary", "full", "hide"]
+
+
+def resolve_session_record_prefix(records: list[SessionRecord], prefix: str) -> SessionRecord:
+    """Resolve a session record from a full ID or prefix."""
+    if not prefix:
+        raise ValueError("Session ID must not be empty.")
+
+    matches = [record for record in records if record.session_id.startswith(prefix)]
+    if not matches:
+        raise ValueError(
+            f"No session found matching '{prefix}'. "
+            "Run 'gptme-sessions query' to list available session IDs."
+        )
+    if len(matches) > 1:
+        raise ValueError(
+            f"Ambiguous prefix '{prefix}' matches {len(matches)} sessions: "
+            + ", ".join(record.session_id for record in matches)
+            + ". Run 'gptme-sessions query' to list available session IDs."
+        )
+    return matches[0]
+
+
+def resolve_replay_target(target: str, *, sessions_dir: Path) -> SessionTranscript:
+    """Resolve *target* to a transcript via path or session-record ID prefix."""
+    if not target:
+        raise ValueError("Replay target must not be empty.")
+
+    path = Path(target).expanduser()
+    if path.exists():
+        return read_transcript(path)
+
+    store = SessionStore(sessions_dir=sessions_dir)
+    record = resolve_session_record_prefix(store.load_all(), target)
+    if not record.trajectory_path:
+        raise ValueError(f"Session '{record.session_id}' has no trajectory_path; cannot replay it.")
+    return read_transcript(Path(record.trajectory_path).expanduser())
+
+
+def render_replay(
+    transcript: SessionTranscript,
+    *,
+    raw_system: bool = False,
+    show_tool_input: bool = False,
+    tool_results: ToolResultsMode = "summary",
+    tail: int | None = None,
+) -> str:
+    """Render a transcript for terminal replay."""
+    messages = list(transcript.messages)
+    collapsed_count = 0
+    collapsed_bytes = 0
+
+    if not raw_system:
+        for message in messages:
+            if message.role != "system":
+                break
+            collapsed_count += 1
+            collapsed_bytes += len((message.content or "").encode("utf-8"))
+        messages = messages[collapsed_count:]
+
+    if tail is not None:
+        messages = messages[-tail:]
+
+    lines = [
+        f"Session:       {transcript.session_id}",
+        f"Harness:       {transcript.harness}",
+    ]
+    if transcript.session_name:
+        lines.append(f"Session name:  {transcript.session_name}")
+    if transcript.model:
+        lines.append(f"Model:         {transcript.model}")
+    if transcript.project:
+        lines.append(f"Project:       {transcript.project}")
+    if transcript.started_at:
+        lines.append(f"Started at:    {transcript.started_at}")
+    if transcript.last_activity:
+        lines.append(f"Last activity: {transcript.last_activity}")
+    lines.extend(
+        [
+            f"Messages:      {len(transcript.messages)}",
+            f"Source:        {transcript.trajectory_path}",
+        ]
+    )
+
+    if collapsed_count:
+        noun = "message" if collapsed_count == 1 else "messages"
+        lines.extend(
+            [
+                "",
+                (
+                    f"[system prelude collapsed: {collapsed_count} {noun}, "
+                    f"{_format_bytes(collapsed_bytes)}]"
+                ),
+            ]
+        )
+
+    if messages:
+        lines.append("")
+
+    for idx, message in enumerate(messages):
+        if idx:
+            lines.append("")
+        lines.extend(
+            _render_message(
+                message,
+                show_tool_input=show_tool_input,
+                tool_results=tool_results,
+            )
+        )
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _render_message(
+    message: NormalizedMessage,
+    *,
+    show_tool_input: bool,
+    tool_results: ToolResultsMode,
+) -> list[str]:
+    """Render a single normalized message."""
+    if message.tool_name:
+        lines = [f"TOOL CALL  {message.tool_name}"]
+        if message.timestamp:
+            lines.append(f"time: {message.timestamp}")
+        if show_tool_input and message.tool_input is not None:
+            lines.append(json.dumps(message.tool_input, indent=2, sort_keys=True))
+        return lines
+
+    if message.role == "tool_result":
+        heading = "TOOL RESULT"
+        if message.is_error:
+            heading += "  [ERROR]"
+        lines = [heading]
+        if message.timestamp:
+            lines.append(f"time: {message.timestamp}")
+        if tool_results == "hide":
+            lines.append("[hidden]")
+        else:
+            content = message.tool_result or message.content or ""
+            if tool_results == "full":
+                lines.append(content or "[empty]")
+            else:
+                lines.append(_summarize_text(content))
+        return lines
+
+    heading = message.role.upper()
+    lines = [heading]
+    if message.timestamp:
+        lines.append(f"time: {message.timestamp}")
+    lines.append(message.content or "[empty]")
+    return lines
+
+
+def _summarize_text(text: str, *, max_lines: int = 4, max_chars: int = 320) -> str:
+    """Return a stable compact summary of tool output."""
+    stripped = text.strip()
+    if not stripped:
+        return "[empty]"
+
+    lines = stripped.splitlines()
+    truncated = False
+    if len(lines) > max_lines:
+        lines = lines[:max_lines]
+        truncated = True
+
+    summary = "\n".join(lines)
+    if len(summary) > max_chars:
+        summary = summary[: max_chars - 3].rstrip()
+        truncated = True
+
+    if truncated:
+        summary = summary.rstrip() + "\n..."
+    return summary
+
+
+def _format_bytes(byte_count: int) -> str:
+    """Format a byte count for replay summaries."""
+    if byte_count >= 1024:
+        return f"{byte_count / 1024:.1f} KB"
+    return f"{byte_count} B"

--- a/packages/gptme-sessions/src/gptme_sessions/replay.py
+++ b/packages/gptme-sessions/src/gptme_sessions/replay.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import Literal
 
@@ -11,6 +12,7 @@ from .store import SessionStore
 from .transcript import NormalizedMessage, SessionTranscript, read_transcript
 
 ToolResultsMode = Literal["summary", "full", "hide"]
+logger = logging.getLogger(__name__)
 
 
 def resolve_session_record_prefix(records: list[SessionRecord], prefix: str) -> SessionRecord:
@@ -40,6 +42,12 @@ def resolve_replay_target(target: str, *, sessions_dir: Path) -> SessionTranscri
 
     path = Path(target).expanduser()
     if path.exists():
+        logger.debug(
+            "Replay target %r resolved as existing path %s (cwd=%s); skipping session ID lookup.",
+            target,
+            path.resolve(),
+            Path.cwd(),
+        )
         return read_transcript(path)
 
     store = SessionStore(sessions_dir=sessions_dir)
@@ -72,6 +80,7 @@ def render_replay(
 
     if tail is not None:
         messages = messages[-tail:]
+    displayed_count = len(messages)
 
     lines = [
         f"Session:       {transcript.session_id}",
@@ -89,7 +98,7 @@ def render_replay(
         lines.append(f"Last activity: {transcript.last_activity}")
     lines.extend(
         [
-            f"Messages:      {len(transcript.messages)}",
+            f"Messages:      {_format_message_count(displayed_count, len(transcript.messages))}",
             f"Source:        {transcript.trajectory_path}",
         ]
     )
@@ -170,19 +179,28 @@ def _summarize_text(text: str, *, max_lines: int = 4, max_chars: int = 320) -> s
         return "[empty]"
 
     lines = stripped.splitlines()
-    truncated = False
+    truncated_by_lines = False
     if len(lines) > max_lines:
         lines = lines[:max_lines]
-        truncated = True
+        truncated_by_lines = True
 
     summary = "\n".join(lines)
+    truncated_by_chars = False
     if len(summary) > max_chars:
         summary = summary[: max_chars - 3].rstrip()
-        truncated = True
+        truncated_by_chars = True
 
-    if truncated:
-        summary = summary.rstrip() + "\n..."
+    if truncated_by_lines or truncated_by_chars:
+        suffix = "\n..." if truncated_by_lines or "\n" in summary else "..."
+        summary = summary.rstrip() + suffix
     return summary
+
+
+def _format_message_count(displayed_count: int, total_count: int) -> str:
+    """Format replay message counts for rendered output."""
+    if displayed_count == total_count:
+        return str(total_count)
+    return f"{displayed_count} displayed ({total_count} total)"
 
 
 def _format_bytes(byte_count: int) -> str:

--- a/packages/gptme-sessions/src/gptme_sessions/transcript.py
+++ b/packages/gptme-sessions/src/gptme_sessions/transcript.py
@@ -384,6 +384,42 @@ def _normalize_copilot(msgs: list[dict]) -> list[NormalizedMessage]:
 # ---------------------------------------------------------------------------
 
 
+def _extract_model(fmt: str, msgs: list[dict], path: Path) -> str | None:
+    """Extract a model string for the detected harness when possible."""
+    if fmt == "claude_code":
+        from .discovery import extract_cc_model
+
+        return extract_cc_model(path)
+
+    if fmt == "gptme":
+        session_dir = path.parent if path.suffix == ".jsonl" else path
+        from .discovery import parse_gptme_config
+
+        return parse_gptme_config(session_dir).get("model") or None
+
+    if fmt == "codex":
+        for record in msgs:
+            if record.get("type") != "session_meta":
+                continue
+            payload = record.get("payload") or {}
+            model = payload.get("model")
+            if model:
+                return str(model)
+        return None
+
+    if fmt == "copilot":
+        for record in msgs:
+            if record.get("type") != "session.start":
+                continue
+            data = record.get("data") or {}
+            model = data.get("selectedModel")
+            if model:
+                return str(model)
+        return None
+
+    return None
+
+
 def read_transcript(path: Path) -> SessionTranscript:
     """Read a trajectory file and return a normalized SessionTranscript.
 
@@ -449,19 +485,7 @@ def read_transcript(path: Path) -> SessionTranscript:
     session_name = extract_session_name(harness, path)
     project = extract_project(harness, path)
 
-    # Model extraction: for CC we can read from the first assistant message
-    model: str | None = None
-    if fmt == "claude_code":
-        from .discovery import extract_cc_model
-
-        model = extract_cc_model(path)
-    elif fmt == "gptme":
-        # Check parent dir config.toml
-        session_dir = path.parent if path.suffix == ".jsonl" else path
-        from .discovery import parse_gptme_config
-
-        model = parse_gptme_config(session_dir).get("model") or None
-    # For codex/copilot, model is in usage/context records (not extracted here to keep lean)
+    model = _extract_model(fmt, msgs, path)
 
     # Session ID: use path stem (UUID for CC, session dir name for gptme, etc.)
     session_id = path.stem if path.suffix == ".jsonl" else path.name

--- a/packages/gptme-sessions/tests/test_replay.py
+++ b/packages/gptme-sessions/tests/test_replay.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 
 import pytest
@@ -80,6 +81,7 @@ class TestReplayCli:
         runner = CliRunner()
         result = runner.invoke(cli, ["replay", str(codex_replay_jsonl)])
         assert result.exit_code == 0, result.output
+        assert "Messages:      4 displayed (5 total)" in result.output
         assert "[system prelude collapsed: 1 message" in result.output
         assert "System prelude that should collapse." not in result.output
         assert "TOOL CALL  exec_command" in result.output
@@ -123,6 +125,7 @@ class TestReplayCli:
         runner = CliRunner()
         result = runner.invoke(cli, ["replay", str(codex_replay_jsonl), "--tail", "2"])
         assert result.exit_code == 0, result.output
+        assert "Messages:      2 displayed (5 total)" in result.output
         assert "TOOL CALL  exec_command" in result.output
         assert "TOOL RESULT" in result.output
         assert "Show me the files." not in result.output
@@ -160,3 +163,38 @@ class TestReplayCli:
         result = runner.invoke(cli, ["--sessions-dir", str(sessions_dir), "replay", "abcd"])
         assert result.exit_code != 0
         assert "has no trajectory_path" in result.output
+
+
+def test_replay_summary_uses_inline_ellipsis_for_single_line_char_truncation():
+    from gptme_sessions.replay import _summarize_text
+
+    summary = _summarize_text("x" * 400, max_chars=20)
+
+    assert summary.endswith("...")
+    assert "\n..." not in summary
+
+
+def test_replay_logs_when_existing_path_wins_over_session_id_prefix(
+    tmp_path: Path, codex_replay_jsonl: Path, monkeypatch: pytest.MonkeyPatch, caplog
+):
+    from gptme_sessions.replay import resolve_replay_target
+
+    shadow_path = tmp_path / "abcd1234"
+    shadow_path.write_text(codex_replay_jsonl.read_text())
+
+    sessions_dir = tmp_path / "sessions"
+    store = SessionStore(sessions_dir=sessions_dir)
+    store.append(
+        SessionRecord(
+            session_id="abcd1234-session",
+            harness="codex",
+            trajectory_path=str(codex_replay_jsonl),
+        )
+    )
+
+    monkeypatch.chdir(tmp_path)
+    with caplog.at_level(logging.DEBUG, logger="gptme_sessions.replay"):
+        transcript = resolve_replay_target("abcd1234", sessions_dir=sessions_dir)
+
+    assert transcript.trajectory_path == str(shadow_path.resolve())
+    assert "skipping session ID lookup" in caplog.text

--- a/packages/gptme-sessions/tests/test_replay.py
+++ b/packages/gptme-sessions/tests/test_replay.py
@@ -1,0 +1,162 @@
+"""Tests for the replay surface."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gptme_sessions.record import SessionRecord
+from gptme_sessions.store import SessionStore
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> Path:
+    path.write_text("\n".join(json.dumps(record) for record in records) + "\n")
+    return path
+
+
+@pytest.fixture
+def codex_replay_jsonl(tmp_path: Path) -> Path:
+    records = [
+        {
+            "type": "session_meta",
+            "timestamp": "2026-03-01T09:59:59.000Z",
+            "payload": {"originator": "codex_exec", "model": "gpt-5.4"},
+        },
+        {
+            "type": "response_item",
+            "timestamp": "2026-03-01T10:00:00.000Z",
+            "payload": {
+                "type": "message",
+                "role": "system",
+                "content": [{"type": "text", "text": "System prelude that should collapse."}],
+            },
+        },
+        {
+            "type": "response_item",
+            "timestamp": "2026-03-01T10:00:01.000Z",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "text", "text": "Show me the files."}],
+            },
+        },
+        {
+            "type": "response_item",
+            "timestamp": "2026-03-01T10:00:02.000Z",
+            "payload": {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Listing files now."}],
+            },
+        },
+        {
+            "type": "response_item",
+            "timestamp": "2026-03-01T10:00:03.000Z",
+            "payload": {
+                "type": "function_call",
+                "name": "exec_command",
+                "arguments": json.dumps({"cmd": "ls", "yield_time_ms": 1000}),
+            },
+        },
+        {
+            "type": "response_item",
+            "timestamp": "2026-03-01T10:00:04.000Z",
+            "payload": {
+                "type": "function_call_output",
+                "output": "line1\nline2\nline3\nline4\nline5\nline6",
+            },
+        },
+    ]
+    return _write_jsonl(tmp_path / "rollout.jsonl", records)
+
+
+class TestReplayCli:
+    def test_replay_path_collapses_initial_system_prelude(self, codex_replay_jsonl: Path):
+        from click.testing import CliRunner
+        from gptme_sessions.cli import cli
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["replay", str(codex_replay_jsonl)])
+        assert result.exit_code == 0, result.output
+        assert "[system prelude collapsed: 1 message" in result.output
+        assert "System prelude that should collapse." not in result.output
+        assert "TOOL CALL  exec_command" in result.output
+        assert "TOOL RESULT" in result.output
+        assert "Model:         gpt-5.4" in result.output
+
+    def test_replay_raw_system_shows_prelude(self, codex_replay_jsonl: Path):
+        from click.testing import CliRunner
+        from gptme_sessions.cli import cli
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["replay", str(codex_replay_jsonl), "--raw-system"])
+        assert result.exit_code == 0, result.output
+        assert "[system prelude collapsed:" not in result.output
+        assert "SYSTEM" in result.output
+        assert "System prelude that should collapse." in result.output
+
+    def test_replay_tool_input_and_full_results(self, codex_replay_jsonl: Path):
+        from click.testing import CliRunner
+        from gptme_sessions.cli import cli
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "replay",
+                str(codex_replay_jsonl),
+                "--tool-input",
+                "--tool-results",
+                "full",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert '"cmd": "ls"' in result.output
+        assert "line6" in result.output
+
+    def test_replay_tail_renders_only_last_normalized_messages(self, codex_replay_jsonl: Path):
+        from click.testing import CliRunner
+        from gptme_sessions.cli import cli
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["replay", str(codex_replay_jsonl), "--tail", "2"])
+        assert result.exit_code == 0, result.output
+        assert "TOOL CALL  exec_command" in result.output
+        assert "TOOL RESULT" in result.output
+        assert "Show me the files." not in result.output
+        assert "Listing files now." not in result.output
+
+    def test_replay_resolves_session_id_prefix(self, tmp_path: Path, codex_replay_jsonl: Path):
+        from click.testing import CliRunner
+        from gptme_sessions.cli import cli
+
+        sessions_dir = tmp_path / "sessions"
+        store = SessionStore(sessions_dir=sessions_dir)
+        store.append(
+            SessionRecord(
+                session_id="abcd1234",
+                harness="codex",
+                trajectory_path=str(codex_replay_jsonl),
+            )
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--sessions-dir", str(sessions_dir), "replay", "abcd"])
+        assert result.exit_code == 0, result.output
+        assert "Harness:       codex" in result.output
+        assert f"Source:        {codex_replay_jsonl.resolve()}" in result.output
+
+    def test_replay_missing_trajectory_path_fails_cleanly(self, tmp_path: Path):
+        from click.testing import CliRunner
+        from gptme_sessions.cli import cli
+
+        sessions_dir = tmp_path / "sessions"
+        store = SessionStore(sessions_dir=sessions_dir)
+        store.append(SessionRecord(session_id="abcd1234", harness="codex"))
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--sessions-dir", str(sessions_dir), "replay", "abcd"])
+        assert result.exit_code != 0
+        assert "has no trajectory_path" in result.output

--- a/packages/gptme-sessions/tests/test_transcript.py
+++ b/packages/gptme-sessions/tests/test_transcript.py
@@ -322,11 +322,13 @@ class TestReadTranscript:
     def test_codex_transcript(self, codex_jsonl: Path):
         t = read_transcript(codex_jsonl)
         assert t.harness == "codex"
+        assert t.model == "gpt-5.3-codex"
         assert len(t.messages) > 0
 
     def test_copilot_transcript(self, copilot_jsonl: Path):
         t = read_transcript(copilot_jsonl)
         assert t.harness == "copilot"
+        assert t.model == "gpt-5.4"
         assert len(t.messages) > 0
 
     def test_started_at_and_last_activity(self, gptme_jsonl: Path):


### PR DESCRIPTION
## Summary
- add a read-only `gptme-sessions replay TARGET` command for transcript inspection
- resolve `TARGET` from either a trajectory path or a session-record ID prefix and collapse the initial system prelude by default
- extract Codex and Copilot models into transcript metadata and cover the replay flow with focused tests

## Testing
- `uv run pytest tests/test_replay.py tests/test_transcript.py -q`
- `uv run ruff check src/gptme_sessions/cli.py src/gptme_sessions/transcript.py src/gptme_sessions/replay.py tests/test_replay.py tests/test_transcript.py`
- `uv run --with mypy mypy src/ --ignore-missing-imports`
