### PR TITLE
fix(subscription): protect manual --switch with a hold

### DIFF
--- a/packages/gptme-subscription/src/gptme_subscription/cli.py
+++ b/packages/gptme-subscription/src/gptme_subscription/cli.py
@@ -351,7 +351,11 @@ def _cmd_switch(args: argparse.Namespace, sm: SubscriptionManager) -> int:
         return 0
     ok = sm.switch_to(target, f"manual switch via --switch {target}", force=True)
     if ok:
-        sm.clear_rebalance_state()
+        # Protect the operator's explicit choice: write a manual-switch hold so a
+        # concurrent automated --execute doesn't immediately rebalance / forward-
+        # route away from it. Previously this cleared all hold state, leaving the
+        # manual switch unprotected for the next decision.
+        sm.record_manual_switch_hold(target)
         print(f"Switched to {target}")
         sm.check_usage(no_cache=True)
         return 0

--- a/packages/gptme-subscription/src/gptme_subscription/manager.py
+++ b/packages/gptme-subscription/src/gptme_subscription/manager.py
@@ -375,6 +375,32 @@ class SubscriptionManager:
     def clear_rebalance_state(self) -> None:
         self.config.rebalance_state_file.unlink(missing_ok=True)
 
+    def record_manual_switch_hold(
+        self, target: str, now: datetime | None = None
+    ) -> None:
+        """Persist a hold protecting an operator's explicit ``--switch``.
+
+        Without this, an automated ``--execute`` (rebalance / forward-routing)
+        running seconds later — e.g. at the start of a concurrent autonomous
+        session — would re-decide and immediately route away from the slot the
+        operator just selected. The hold lasts ``forward_routing_hold_seconds``,
+        matching the duration the automated paths use for their own switches.
+        """
+        current_time = now or datetime.now(timezone.utc)
+        hold_seconds = self.config.forward_routing_hold_seconds
+        hold_until = current_time + timedelta(seconds=hold_seconds)
+        self.save_rebalance_state(
+            {
+                "active": target,
+                "action": "stay",
+                "target": target,
+                "reason": f"manual switch via --switch {target}",
+                "mode": "manual-switch",
+                "hold_until": hold_until.isoformat(),
+                "hold_seconds": hold_seconds,
+            }
+        )
+
     def compute_rebalance_hold_seconds(self, pace_overage: float) -> int:
         cfg = self.config
         if pace_overage <= 0:
@@ -589,6 +615,13 @@ class SubscriptionManager:
                             f"{format_duration(remaining)} ({hold_reason})"
                         )
                         d.mode = "capacity-rebalance-hold"
+                    elif hold_mode == "manual-switch":
+                        hold_reason = rebalance_state.get("reason", "manual switch")
+                        d.reason = (
+                            f"manual-switch hold active for "
+                            f"{format_duration(remaining)} ({hold_reason})"
+                        )
+                        d.mode = "manual-switch-hold"
                     else:
                         raw_pace_overage = rebalance_state.get("pace_overage")
                         pace_overage = (
@@ -736,6 +769,28 @@ class SubscriptionManager:
             else:
                 d.reason += " — no fallback defined"
             return d
+
+        # Respect an operator manual-switch hold on a healthy primary too: don't
+        # proactively rebalance / forward-route away from an explicit operator
+        # choice. (The exhaustion fallback above already fired if needed, so we
+        # never strand on an exhausted primary.)
+        if rebalance_state is not None:
+            manual_hold_until = rebalance_state.get("hold_until")
+            if (
+                rebalance_state.get("mode") == "manual-switch"
+                and isinstance(manual_hold_until, datetime)
+                and manual_hold_until > current_time
+            ):
+                remaining = int((manual_hold_until - current_time).total_seconds())
+                hold_reason = rebalance_state.get("reason", "manual switch")
+                d.reason = (
+                    f"manual-switch hold active for "
+                    f"{format_duration(remaining)} ({hold_reason})"
+                )
+                d.mode = "manual-switch-hold"
+                d.hold_until = manual_hold_until.isoformat()
+                d.hold_seconds = remaining
+                return d
 
         # Healthy primary — check pacing for rebalance / forward-routing.
         rebalance_stale_note: str | None = None

--- a/packages/gptme-subscription/src/gptme_subscription/manager.py
+++ b/packages/gptme-subscription/src/gptme_subscription/manager.py
@@ -592,10 +592,12 @@ class SubscriptionManager:
             if rebalance_state is not None:
                 hold_until = rebalance_state.get("hold_until")
                 blocked, _ = self.is_subscription_blocked(usage, config=cfg)
+                hold_target = rebalance_state.get("target")
                 if (
                     isinstance(hold_until, datetime)
                     and hold_until > current_time
                     and not blocked
+                    and hold_target == active
                 ):
                     remaining = int((hold_until - current_time).total_seconds())
                     hold_mode = rebalance_state.get("mode", "rebalance")
@@ -776,10 +778,12 @@ class SubscriptionManager:
         # never strand on an exhausted primary.)
         if rebalance_state is not None:
             manual_hold_until = rebalance_state.get("hold_until")
+            manual_hold_target = rebalance_state.get("target")
             if (
                 rebalance_state.get("mode") == "manual-switch"
                 and isinstance(manual_hold_until, datetime)
                 and manual_hold_until > current_time
+                and manual_hold_target == active
             ):
                 remaining = int((manual_hold_until - current_time).total_seconds())
                 hold_reason = rebalance_state.get("reason", "manual switch")

--- a/packages/gptme-subscription/tests/test_cli.py
+++ b/packages/gptme-subscription/tests/test_cli.py
@@ -8,7 +8,11 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
 
-from gptme_subscription.cli import _cmd_evaluate, _execute_switch_decision
+from gptme_subscription.cli import (
+    _cmd_evaluate,
+    _cmd_switch,
+    _execute_switch_decision,
+)
 from gptme_subscription.manager import Decision, SubscriptionManager
 
 
@@ -27,6 +31,7 @@ class FakeManager:
     ) -> None:
         self.config = SimpleNamespace(
             primary=primary,
+            subscriptions=[primary, "alice", "erik"],
             probe_primary_cooldown=1800,
             rate_limit_file=Path("/tmp/nonexistent-rate-limit-flag"),
         )
@@ -64,6 +69,7 @@ class FakeManager:
         self.switch_calls: list[tuple[str, str]] = []
         self.saved_decision: dict[str, object] | None = None
         self.cleared_rebalance = 0
+        self.manual_hold_calls: list[str] = []
         self.recorded_reset: tuple[str, float, dict[str, object]] | None = None
         self.last_switch_deferred = False
 
@@ -88,7 +94,7 @@ class FakeManager:
     def seconds_since_last_primary_departure(self) -> None:
         return None
 
-    def switch_to(self, sub: str, reason: str) -> bool:
+    def switch_to(self, sub: str, reason: str, force: bool = False) -> bool:
         self.switch_calls.append((sub, reason))
         ok, deferred = self._switch_results.pop(0)
         self.last_switch_deferred = deferred
@@ -99,6 +105,9 @@ class FakeManager:
 
     def clear_rebalance_state(self) -> None:
         self.cleared_rebalance += 1
+
+    def record_manual_switch_hold(self, target: str) -> None:
+        self.manual_hold_calls.append(target)
 
     def is_subscription_blocked(
         self, usage: dict[str, object], *, config
@@ -306,3 +315,39 @@ def test_execute_switch_decision_no_alert_on_deferred_switch(capsys) -> None:
     assert payload.get("deferred") is True
     captured = capsys.readouterr()
     assert "[ALERT]" not in captured.err
+
+
+def test_cmd_switch_execute_writes_manual_hold_not_clear() -> None:
+    # A successful manual --switch must record a protective hold (so a concurrent
+    # automated --execute can't immediately route away), not clear hold state.
+    sm = FakeManager(active="bob")
+    args = argparse.Namespace(switch="alice", execute=True, dry_run=False)
+
+    rc = _cmd_switch(args, cast(SubscriptionManager, sm))
+
+    assert rc == 0
+    assert sm.switch_calls == [("alice", "manual switch via --switch alice")]
+    assert sm.manual_hold_calls == ["alice"]
+    assert sm.cleared_rebalance == 0
+
+
+def test_cmd_switch_unknown_slot_returns_error(capsys) -> None:
+    sm = FakeManager(active="bob")
+    args = argparse.Namespace(switch="nobody", execute=True, dry_run=False)
+
+    rc = _cmd_switch(args, cast(SubscriptionManager, sm))
+
+    assert rc == 1
+    assert sm.switch_calls == []
+    assert sm.manual_hold_calls == []
+
+
+def test_cmd_switch_dry_run_does_not_switch_or_hold(capsys) -> None:
+    sm = FakeManager(active="bob")
+    args = argparse.Namespace(switch="alice", execute=False, dry_run=True)
+
+    rc = _cmd_switch(args, cast(SubscriptionManager, sm))
+
+    assert rc == 0
+    assert sm.switch_calls == []
+    assert sm.manual_hold_calls == []

--- a/packages/gptme-subscription/tests/test_subscription_manager.py
+++ b/packages/gptme-subscription/tests/test_subscription_manager.py
@@ -311,6 +311,45 @@ def test_manual_switch_hold_does_not_strand_on_exhausted_fallback(
     assert decision.mode != "manual-switch-hold"
 
 
+def test_manual_switch_hold_does_not_block_wrong_slot(tmp_path: Path) -> None:
+    """A hold targeting slot A must not block routing when active is slot B."""
+    sm = _make_manager(tmp_path)
+    _write_cred(sm, "alice", age_days=1)
+    _write_cred(sm, "erik", age_days=1)
+    now = datetime.now(timezone.utc)
+    decision = sm.evaluate(
+        _healthy_usage(),
+        "bob",
+        now=now,
+        rebalance_state=_manual_hold(now, target="alice"),
+    )
+
+    # The hold is for alice, but bob is active — it should not block routing.
+    assert decision.action == "switch"
+    assert decision.mode != "manual-switch-hold"
+    assert decision.target in ("alice", "erik")
+
+
+def test_manual_switch_hold_does_not_block_wrong_slot_fallback(
+    tmp_path: Path,
+) -> None:
+    """A hold targeting slot A must not block routing when active is slot B
+    (fallback lane)."""
+    sm = _make_manager(tmp_path)
+    _write_cred(sm, "erik", age_days=1)
+    now = datetime.now(timezone.utc)
+    decision = sm.evaluate(
+        _healthy_usage(),
+        "alice",
+        now=now,
+        rebalance_state=_manual_hold(now, target="bob"),
+    )
+
+    # The hold is for bob, but alice is the active fallback.
+    assert decision.action == "switch"
+    assert decision.mode != "manual-switch-hold"
+
+
 def test_record_manual_switch_hold_persists_state(tmp_path: Path) -> None:
     sm = _make_manager(tmp_path)
     now = datetime.now(timezone.utc)

--- a/packages/gptme-subscription/tests/test_subscription_manager.py
+++ b/packages/gptme-subscription/tests/test_subscription_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -217,3 +218,113 @@ def test_evaluate_rebalance_skipped_annotates_reason_when_all_fallbacks_stale(
     assert decision.action == "stay"
     assert "rebalance skipped" in decision.reason
     assert "all fallbacks stale" in decision.reason
+
+
+def _healthy_usage() -> dict:
+    """Healthy usage, ~43% of the weekly period elapsed (would trigger
+    proactive forward-routing absent a hold)."""
+    return {
+        "seven_day": {"utilization": 0.10, "resets_in_seconds": 4 * 24 * 3600},
+        "five_hour": {"utilization": 0.05, "resets_in_seconds": 3600},
+        "seven_day_sonnet": {"utilization": 0.05, "resets_in_seconds": 4 * 24 * 3600},
+    }
+
+
+def _manual_hold(now: datetime, target: str = "alice") -> dict:
+    return {
+        "active": target,
+        "action": "stay",
+        "target": target,
+        "reason": f"manual switch via --switch {target}",
+        "mode": "manual-switch",
+        "hold_until": now + timedelta(hours=8),
+        "hold_seconds": 8 * 3600,
+    }
+
+
+def test_manual_switch_hold_blocks_routing_on_fallback(tmp_path: Path) -> None:
+    # On a fallback (alice), a manual-switch hold must keep us there instead of
+    # forward-routing away the way the unprotected path used to.
+    sm = _make_manager(tmp_path)
+    now = datetime.now(timezone.utc)
+    decision = sm.evaluate(
+        _healthy_usage(), "alice", now=now, rebalance_state=_manual_hold(now)
+    )
+
+    assert decision.action == "stay"
+    assert decision.mode == "manual-switch-hold"
+    assert "manual-switch hold active" in decision.reason
+
+
+def test_manual_switch_hold_respected_on_healthy_primary(tmp_path: Path) -> None:
+    # An operator who manually switches back to the primary should also be held,
+    # not proactively rebalanced/forward-routed off it.
+    sm = _make_manager(tmp_path)
+    now = datetime.now(timezone.utc)
+    decision = sm.evaluate(
+        _healthy_usage(),
+        "bob",
+        now=now,
+        rebalance_state=_manual_hold(now, target="bob"),
+    )
+
+    assert decision.action == "stay"
+    assert decision.mode == "manual-switch-hold"
+
+
+def test_manual_switch_hold_does_not_strand_on_exhausted_primary(
+    tmp_path: Path,
+) -> None:
+    # A manual hold must never strand us on an exhausted slot — exhaustion
+    # fallback takes precedence over the hold.
+    sm = _make_manager(tmp_path)
+    _write_cred(sm, "alice", age_days=1)
+    _write_cred(sm, "erik", age_days=1)
+    now = datetime.now(timezone.utc)
+    decision = sm.evaluate(
+        _exhausted_usage(),
+        "bob",
+        now=now,
+        rebalance_state=_manual_hold(now, target="bob"),
+    )
+
+    assert decision.action == "switch"
+    assert decision.mode != "manual-switch-hold"
+    assert decision.target in ("alice", "erik")
+
+
+def test_manual_switch_hold_does_not_strand_on_exhausted_fallback(
+    tmp_path: Path,
+) -> None:
+    # Safety: a manual hold on a fallback that is (or becomes) exhausted must not
+    # trap us there — the `not blocked` guard lets failover proceed.
+    sm = _make_manager(tmp_path)
+    now = datetime.now(timezone.utc)
+    decision = sm.evaluate(
+        _exhausted_usage(),
+        "alice",
+        now=now,
+        rebalance_state=_manual_hold(now, target="alice"),
+    )
+
+    assert decision.action == "switch"
+    assert decision.mode != "manual-switch-hold"
+
+
+def test_record_manual_switch_hold_persists_state(tmp_path: Path) -> None:
+    sm = _make_manager(tmp_path)
+    now = datetime.now(timezone.utc)
+    sm.record_manual_switch_hold("alice", now=now)
+
+    payload = json.loads(sm.config.rebalance_state_file.read_text())
+    assert payload["mode"] == "manual-switch"
+    assert payload["target"] == "alice"
+    assert payload["hold_seconds"] == sm.config.forward_routing_hold_seconds
+    assert datetime.fromisoformat(payload["hold_until"]) > now
+
+    # The persisted hold is honored by a subsequent evaluate() on the fallback.
+    loaded = sm.load_rebalance_state(now=now)
+    assert loaded is not None
+    decision = sm.evaluate(_healthy_usage(), "alice", now=now, rebalance_state=loaded)
+    assert decision.action == "stay"
+    assert decision.mode == "manual-switch-hold"


### PR DESCRIPTION
## Problem

A manual `manage-subscription.py --switch <slot> --execute` flips the symlink, then calls `clear_rebalance_state()` — deleting any hold and writing none. So the operator's explicit choice is **unprotected**: the next automated `--execute` re-runs `evaluate()`, sees no hold, and (when the weekly period is >25% elapsed and another slot has been idle) **forward-routes away within seconds**.

Observed live: an operator switched to `alice` (8% weekly, 92% free), and 12s later three concurrent autonomous sessions each ran `--execute` at session-start and forward-routed `alice → erik`. The `"manual-switch"` mode was already allow-listed in `save_rebalance_state()` but **never produced** — the fix was scaffolded and abandoned.

## Fix

- `_cmd_switch` now records an 8h `manual-switch` hold (via a new `record_manual_switch_hold()`) instead of clearing state.
- `evaluate()` gives the manual-switch hold a proper label, and respects it on a **healthy primary** too (placed *after* exhaustion failover).

## Safety: can this trap us on a bad subscription?

No — verified on every path:

| Case | Behavior |
|------|----------|
| Switch to an **expired/unreadable** slot | `SlotManager.switch_to` refuses *regardless of `force`* → switch fails → **no hold written** (it's inside `if ok:`) |
| Held slot becomes **exhausted** (any of weekly / 5h / Sonnet) | fallback hold is guarded by `not blocked` → failover proceeds |
| Manual hold on an **exhausted primary** | exhaustion failover runs *before* the hold check → fails over |
| Slot **unreachable** (`usage is None`) | pre-existing `stay` short-circuit, unaffected by the hold |

## Tests

8 new tests: fallback hold, primary hold, exhaustion-failover precedence (fallback + primary), state persistence + reload, and the CLI write-not-clear / unknown-slot / dry-run paths. Full package suite green; all pre-commit hooks pass.