### PR TITLE
fix(voice): surface subagent timeouts clearly, filter SIGPIPE shell noise

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -37,6 +37,19 @@ _IGNORABLE_ERROR_PREFIXES = (
     "WARNING  Failed to load plugin ",  # gptme plugin discovery noise
     "WARNING  OpenTelemetry dependencies not available",
 )
+# Substrings that mark benign shell-pipeline noise from commands the subagent
+# itself ran (e.g. `find ... | xargs grep ... | head`).  SIGPIPE (signal 13) /
+# broken-pipe is the normal result of a downstream consumer closing the pipe
+# early; it is never the real reason a lookup failed and must not be surfaced
+# as the subagent error.
+_IGNORABLE_ERROR_SUBSTRINGS = (
+    "terminated by signal 13",  # xargs/child killed by SIGPIPE
+    "Broken pipe",  # coreutils write-error phrasing for SIGPIPE
+)
+# Returncodes that indicate the subagent was killed by a timeout wrapper
+# (`timeout` exits 124 on expiry; 143 = 128+SIGTERM, 137 = 128+SIGKILL for the
+# kill-after fallback).  These mean "ran out of time", not a generic crash.
+_TIMEOUT_RETURNCODES = frozenset({124, 137, 143})
 _DEFAULT_TRANSCRIPT_TAIL_TURNS = 8
 _DEFAULT_TRANSCRIPT_TAIL_CHARS = 1_600
 
@@ -139,7 +152,9 @@ class GptmeToolBridge:
             stripped = line.strip()
             if stripped in _IGNORABLE_ERROR_LINES:
                 return True
-            return any(stripped.startswith(p) for p in _IGNORABLE_ERROR_PREFIXES)
+            if any(stripped.startswith(p) for p in _IGNORABLE_ERROR_PREFIXES):
+                return True
+            return any(s in stripped for s in _IGNORABLE_ERROR_SUBSTRINGS)
 
         stderr_lines = [
             line.strip()
@@ -552,6 +567,25 @@ class GptmeToolBridge:
 
             if on_completed:
                 on_completed(process.returncode, time.monotonic())
+
+            if process.returncode in _TIMEOUT_RETURNCODES:
+                # The wrapper's timeout fired before the subagent could write a
+                # clean response file. Surface a clear, actionable signal rather
+                # than whatever stderr line happened to be last (often benign
+                # SIGPIPE noise from an in-flight shell pipeline).
+                logger.warning(
+                    "Subagent timed out (exit %s) after producing %d chars of output",
+                    process.returncode,
+                    len(output),
+                )
+                return ToolResult(
+                    success=False,
+                    output=output,
+                    error=(
+                        "Subagent timed out before it could finish. "
+                        "Try a narrower, more specific question."
+                    ),
+                )
 
             if process.returncode != 0:
                 logger.error(

--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -38,18 +38,16 @@ _IGNORABLE_ERROR_PREFIXES = (
     "WARNING  OpenTelemetry dependencies not available",
 )
 # Substrings that mark benign shell-pipeline noise from commands the subagent
-# itself ran (e.g. `find ... | xargs grep ... | head`).  SIGPIPE (signal 13) /
-# broken-pipe is the normal result of a downstream consumer closing the pipe
-# early; it is never the real reason a lookup failed and must not be surfaced
-# as the subagent error.
-_IGNORABLE_ERROR_SUBSTRINGS = (
-    "terminated by signal 13",  # xargs/child killed by SIGPIPE
-    "Broken pipe",  # coreutils write-error phrasing for SIGPIPE
-)
+# itself ran (e.g. `find ... | xargs grep ... | head`).  SIGPIPE (signal 13) is
+# the normal result of a downstream consumer closing the pipe early; it is
+# never the real reason a lookup failed and must not be surfaced as the
+# subagent error.
+_IGNORABLE_ERROR_SUBSTRINGS = ("terminated by signal 13",)
 # Returncodes that indicate the subagent was killed by a timeout wrapper
-# (`timeout` exits 124 on expiry; 143 = 128+SIGTERM, 137 = 128+SIGKILL for the
-# kill-after fallback).  These mean "ran out of time", not a generic crash.
-_TIMEOUT_RETURNCODES = frozenset({124, 137, 143})
+# (`timeout` exits 124 on expiry; 143 = 128+SIGTERM from the timeout wrapper).
+# These mean "ran out of time", not a generic crash.
+_TIMEOUT_RETURNCODES = frozenset({124, 143})
+_KILLED_RETURNCODE = 137  # 128 + SIGKILL (timeout kill-after or OOM kill)
 _DEFAULT_TRANSCRIPT_TAIL_TURNS = 8
 _DEFAULT_TRANSCRIPT_TAIL_CHARS = 1_600
 
@@ -148,13 +146,20 @@ class GptmeToolBridge:
 
     @staticmethod
     def _extract_error_text(stdout: str, stderr: str, output: str) -> str:
+        def _is_ignorable_broken_pipe(line: str) -> bool:
+            return line.endswith("Broken pipe") and (
+                ": write failed: " in line or ": error writing " in line
+            )
+
         def _is_ignorable(line: str) -> bool:
             stripped = line.strip()
             if stripped in _IGNORABLE_ERROR_LINES:
                 return True
             if any(stripped.startswith(p) for p in _IGNORABLE_ERROR_PREFIXES):
                 return True
-            return any(s in stripped for s in _IGNORABLE_ERROR_SUBSTRINGS)
+            if any(s in stripped for s in _IGNORABLE_ERROR_SUBSTRINGS):
+                return True
+            return _is_ignorable_broken_pipe(stripped)
 
         stderr_lines = [
             line.strip()
@@ -583,6 +588,22 @@ class GptmeToolBridge:
                     output=output,
                     error=(
                         "Subagent timed out before it could finish. "
+                        "Try a narrower, more specific question."
+                    ),
+                )
+
+            if process.returncode == _KILLED_RETURNCODE:
+                logger.warning(
+                    "Subagent was killed (exit %s) after producing %d chars of output",
+                    process.returncode,
+                    len(output),
+                )
+                return ToolResult(
+                    success=False,
+                    output=output,
+                    error=(
+                        "Subagent was killed before it could finish "
+                        "(timeout or out-of-memory). "
                         "Try a narrower, more specific question."
                     ),
                 )

--- a/packages/gptme-voice/tests/test_tool_bridge.py
+++ b/packages/gptme-voice/tests/test_tool_bridge.py
@@ -509,12 +509,18 @@ def test_extract_error_text_filters_sigpipe_shell_noise() -> None:
     assert error == ""
 
 
-def test_extract_error_text_filters_broken_pipe_noise() -> None:
+def test_extract_error_text_filters_known_broken_pipe_noise() -> None:
     stderr = "sort: write failed: standard output: Broken pipe"
     stdout = "[11:13:00] ERROR    Error code: 429 too many requests"
     error = GptmeToolBridge._extract_error_text(stdout, stderr, output="")
     assert "Broken pipe" not in error
     assert "Error code: 429" in error
+
+
+def test_extract_error_text_keeps_generic_broken_pipe_error() -> None:
+    stderr = "ERROR: Broken pipe on database connection socket"
+    error = GptmeToolBridge._extract_error_text("", stderr, output="")
+    assert error == stderr
 
 
 def test_execute_timeout_exit_code_reports_clear_message_not_shell_noise() -> None:
@@ -566,6 +572,30 @@ def test_execute_sigterm_exit_code_reported_as_timeout() -> None:
         assert result.success is False
         assert result.error is not None
         assert "timed out" in result.error.lower()
+
+    asyncio.run(_exercise())
+
+
+def test_execute_sigkill_exit_code_reports_killed_not_timeout() -> None:
+    async def _exercise() -> None:
+        bridge = GptmeToolBridge(workspace="/fake/workspace")
+
+        async def _fake_create_subprocess_exec(*_args, **_kwargs):
+            return _FakeProcess(
+                returncode=137,
+                stdout="partial work",
+                stderr="sort: write failed: standard output: Broken pipe",
+            )
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+            result = await bridge._execute("long lookup", mode="fast")
+
+        assert result.success is False
+        assert result.error is not None
+        assert "killed" in result.error.lower()
+        assert "out-of-memory" in result.error.lower()
+        assert "broken pipe" not in result.error.lower()
 
     asyncio.run(_exercise())
 

--- a/packages/gptme-voice/tests/test_tool_bridge.py
+++ b/packages/gptme-voice/tests/test_tool_bridge.py
@@ -498,6 +498,78 @@ def test_execute_reports_timeout() -> None:
     asyncio.run(_exercise())
 
 
+def test_extract_error_text_filters_sigpipe_shell_noise() -> None:
+    """A SIGPIPE (signal 13) from a shell command the subagent ran internally
+    (e.g. `find ... | xargs grep ... | head`) is benign downstream-pipe-close
+    noise and must not be surfaced as the subagent error."""
+    stderr = "xargs: grep: terminated by signal 13"
+    error = GptmeToolBridge._extract_error_text("", stderr, output="")
+    assert "terminated by signal 13" not in error
+    # With no other meaningful signal, fall through to the empty -> exit-code path.
+    assert error == ""
+
+
+def test_extract_error_text_filters_broken_pipe_noise() -> None:
+    stderr = "sort: write failed: standard output: Broken pipe"
+    stdout = "[11:13:00] ERROR    Error code: 429 too many requests"
+    error = GptmeToolBridge._extract_error_text(stdout, stderr, output="")
+    assert "Broken pipe" not in error
+    assert "Error code: 429" in error
+
+
+def test_execute_timeout_exit_code_reports_clear_message_not_shell_noise() -> None:
+    """Regression for the 2026-05-26 live-call failure: the fast subagent was
+    killed by the wrapper's `timeout` (exit 124) mid-exploration, and the last
+    stderr line was a benign `xargs: grep: terminated by signal 13` SIGPIPE.
+    The user-facing error used to be that misleading shell line. It should be a
+    clear, actionable timeout message instead."""
+
+    async def _exercise() -> None:
+        bridge = GptmeToolBridge(workspace="/fake/workspace")
+
+        async def _fake_create_subprocess_exec(*_args, **_kwargs):
+            return _FakeProcess(
+                returncode=124,
+                stdout="[12:55:30] thinking... searching the workspace",
+                stderr="xargs: grep: terminated by signal 13",
+            )
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+            result = await bridge._execute(
+                "Summarize the software factory in this workspace", mode="fast"
+            )
+
+        assert result.success is False
+        assert result.error is not None
+        assert "timed out" in result.error.lower()
+        assert "signal 13" not in result.error
+        assert "124" not in result.error
+
+    asyncio.run(_exercise())
+
+
+def test_execute_sigterm_exit_code_reported_as_timeout() -> None:
+    """143 = 128 + SIGTERM — the kill the wrapper sends on expiry — is also a
+    timeout, not a generic crash."""
+
+    async def _exercise() -> None:
+        bridge = GptmeToolBridge(workspace="/fake/workspace")
+
+        async def _fake_create_subprocess_exec(*_args, **_kwargs):
+            return _FakeProcess(returncode=143, stdout="partial work")
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+            result = await bridge._execute("long lookup", mode="fast")
+
+        assert result.success is False
+        assert result.error is not None
+        assert "timed out" in result.error.lower()
+
+    asyncio.run(_exercise())
+
+
 def test_handle_function_call_hangup_fires_callback_when_wired() -> None:
     """hangup triggers on_hangup callback with optional reason."""
 


### PR DESCRIPTION
## Problem

A live Twilio call (2026-05-26) asked the Fast voice subagent to summarize the workspace. It timed out and surfaced this to the caller:

```
Subagent error: xargs: grep: terminated by signal 13
```

Two real defects in `tool_bridge.py`:

1. **Timeout-kills were reported as generic failures.** The voice wrapper (`voice-subagent.sh`) runs gptme under `timeout --signal=TERM 45s`. On expiry the wrapper exits **124** (or 143/137 on SIGTERM/SIGKILL). The bridge treated any non-zero exit identically and surfaced whatever the last stderr line happened to be.
2. **That last line was benign SIGPIPE noise.** The subagent had run an internal shell pipeline (`find … | xargs grep … | head`); the downstream `head` closed the pipe early, so `xargs`/`grep` died with SIGPIPE (signal 13). That is normal, never the real failure — but it became the user-facing error.

Evidence from the call archive: `returncode: 124`, `output_elapsed_seconds: 43.6` (ran the full budget), model `claude-haiku-4.5`.

## Fix

- Recognize timeout returncodes (`124`, `143`, `137`) and return a clear, actionable message: *"Subagent timed out before it could finish. Try a narrower, more specific question."* — something the voice model can act on, instead of an opaque shell line or "Exit code 124".
- Filter SIGPIPE / broken-pipe lines (`terminated by signal 13`, `Broken pipe`) from `_extract_error_text` so internal-pipeline noise is never surfaced as the error.

## Tests

4 new regression tests reproducing the live failure (timeout exit 124 with SIGPIPE stderr → clear timeout message, not the shell line; SIGTERM 143 → timeout; SIGPIPE/broken-pipe filtering). All 44 tool_bridge tests pass.

Ref: ErikBjare/bob#651, ErikBjare/bob#804

Co-authored-by: Bob <bob@superuserlabs.org>