### PR TITLE
fix(gptodo): accept date-only created field in task validation

### DIFF
--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -689,7 +689,10 @@ def validate_task_file(file: Path, post: fmPost) -> List[str]:
     # Check required fields
     required_fields: Dict[str, type | tuple[type, ...]] = {
         "state": str,
-        "created": (str, datetime),  # Can be string or datetime
+        # Accept date too: an unquoted YAML date-only value (e.g. `created:
+        # 2026-05-27`) parses to a datetime.date, which is NOT a datetime
+        # instance — datetime subclasses date, not the reverse.
+        "created": (str, date, datetime),
     }
 
     for field_name, expected_type in required_fields.items():
@@ -719,8 +722,6 @@ def validate_task_file(file: Path, post: fmPost) -> List[str]:
         except ValueError:
             # Try parsing as date-only
             try:
-                from datetime import date
-
                 date.fromisoformat(metadata["created"])
             except ValueError:
                 issues.append("Created date must be ISO format (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS)")
@@ -850,8 +851,6 @@ def load_tasks(
                     return datetime.fromisoformat(value_str)
                 except ValueError:
                     # Try parsing as date-only
-                    from datetime import date
-
                     date_obj = date.fromisoformat(value_str)
                     return datetime.combine(date_obj, datetime.min.time())
 

--- a/packages/gptodo/tests/test_validate_task_file.py
+++ b/packages/gptodo/tests/test_validate_task_file.py
@@ -1,0 +1,46 @@
+"""Regression tests for validate_task_file's `created` field typing.
+
+An unquoted YAML date-only value (``created: 2026-05-27``) is parsed by PyYAML
+as a ``datetime.date``. Because ``datetime`` subclasses ``date`` (not the
+reverse), ``isinstance(a_date, datetime)`` is False — so the validator
+previously rejected date-only created values with
+"Field created must be str or datetime", even though gptodo's own task
+generator writes date-only ISO dates (``date.today().isoformat()``).
+"""
+
+from datetime import date, datetime
+
+from gptodo.frontmatter_compat import loads
+from gptodo.utils import validate_task_file
+
+
+def _post(created_value: str):
+    return loads(f"---\nstate: backlog\ncreated: {created_value}\n---\n# Task\n")
+
+
+def test_date_only_created_is_valid(tmp_path):
+    """`created: 2026-05-27` (parsed as datetime.date) must validate cleanly."""
+    post = _post("2026-05-27")
+    assert isinstance(post.metadata["created"], date)
+    assert not isinstance(post.metadata["created"], datetime)
+
+    issues = validate_task_file(tmp_path / "task.md", post)
+    assert issues == [], f"date-only created should be valid, got: {issues}"
+
+
+def test_full_datetime_created_is_valid(tmp_path):
+    """Full ISO timestamps (parsed as datetime) remain valid."""
+    post = _post("2026-05-27T12:00:00+00:00")
+    assert isinstance(post.metadata["created"], datetime)
+
+    issues = validate_task_file(tmp_path / "task.md", post)
+    assert issues == [], f"datetime created should be valid, got: {issues}"
+
+
+def test_quoted_string_created_is_valid(tmp_path):
+    """Quoted ISO date strings remain valid."""
+    post = _post("'2026-05-27'")
+    assert isinstance(post.metadata["created"], str)
+
+    issues = validate_task_file(tmp_path / "task.md", post)
+    assert issues == [], f"string created should be valid, got: {issues}"


### PR DESCRIPTION
## Problem

A task file with an unquoted YAML date-only `created` field fails `gptodo` validation:

```yaml
---
state: new
created: 2026-05-27   # parsed by PyYAML as datetime.date
---
```

`gptodo check`/`status` reports `Field created must be str or datetime`, and the task is dropped from the dependency tree / queue logic. This bit me in the alice workspace — 4 freshly-created tasks were silently invisible to `gptodo`.

## Root cause

`validate_task_file` accepted `(str, datetime)` for `created`. PyYAML parses a date-only scalar as `datetime.date`, and since `datetime` *subclasses* `date` (not the reverse), `isinstance(a_date, datetime)` is `False`. So date-only values were rejected — even though gptodo's own generator writes date-only ISO dates via `date.today().isoformat()` (`lib.py`).

## Fix

- Accept `date` in the required-type tuple for `created`.
- Remove two redundant function-local `from datetime import date` imports. These shadowed the module-level import, making `date` a function-local name for the whole function and triggering `UnboundLocalError` once `date` is referenced earlier.
- Add regression tests covering date-only, full-datetime, and quoted-string `created` values.

## Testing

`200 passed` (full gptodo suite), ruff check + format clean.