### PR TITLE
fix(twitter): add placeholder guard to prevent literal placeholder text in posts

### DIFF
--- a/scripts/twitter/llm.py
+++ b/scripts/twitter/llm.py
@@ -348,6 +348,10 @@ Response Guidelines:
 7. Add value to the discussion
 8. Demonstrate understanding of specific context from the thread
 9. Reference relevant details to show you've understood the conversation
+10. NEVER write placeholder text like "[link would go here]", "[URL here]", "[insert link]",
+    "[media here]", or any bracket-enclosed instruction. If you don't have a specific URL
+    or media item to include, write a complete response without referencing it — either
+    omit the link entirely or say you'll share it separately as plain prose.
 
 Few-shot examples:
 {yaml.dump(config["templates"]["examples"])}"""

--- a/scripts/twitter/twitter.py
+++ b/scripts/twitter/twitter.py
@@ -52,6 +52,7 @@ For OAuth 2.0 setup:
 """
 
 import os
+import re
 import sys
 import warnings
 from datetime import datetime, timedelta, timezone
@@ -121,8 +122,53 @@ def _get_user_auth(client) -> bool:
     return getattr(client, "_use_user_auth", False)
 
 
+PLACEHOLDER_PATTERNS = [
+    r"\[link would go here\]",
+    r"\[link\s+here\]",
+    r"\[media\s+here\]",
+    r"\[image\s+here\]",
+    r"\[video\s+here\]",
+    r"\[gif\s+here\]",
+    r"\[TODO\]",
+    r"\[FIXME\]",
+    r"\[TBD\]",
+    r"\[PLACEHOLDER\]",
+]
+
+COMPILED_PLACEHOLDERS = [re.compile(p, re.IGNORECASE) for p in PLACEHOLDER_PATTERNS]
+
+
+def _find_placeholder_in_text(text: str) -> str | None:
+    """Return the first unresolved placeholder match in text, or None."""
+    for compiled in COMPILED_PLACEHOLDERS:
+        m = compiled.search(text)
+        if m:
+            return m.group(0)
+    return None
+
+
+def _abort_on_placeholder_patterns(messages: list[str]) -> None:
+    """Abort if any message contains an unresolved placeholder pattern."""
+    for text in messages:
+        if not text:
+            continue
+        hit = _find_placeholder_in_text(text)
+        if hit:
+            console.print(f"[red]✗ Unresolved placeholder: '{hit}'[/red]")
+            console.print(
+                "[red]Aborting — the text contains an unresolved placeholder."
+                " This is a bug in the LLM drafting pipeline (the LLM emitted a"
+                " placeholder because it could not resolve the needed content at"
+                " draft time). Fix the pipeline to resolve any required URLs or"
+                " media before drafting, or write a concrete reply without the"
+                " placeholder.[/red]"
+            )
+            sys.exit(1)
+
+
 def _abort_on_bad_urls(messages: list[str]) -> None:
-    """Abort on HTTP 4xx/5xx URLs before posting — network errors pass through as non-fatal."""
+    """Abort on HTTP 4xx/5xx URLs or unresolved placeholders before posting."""
+    _abort_on_placeholder_patterns(messages)
     bad: list[tuple[str, int]] = []
     seen: set[tuple[str, int]] = set()
 

--- a/scripts/twitter/twitter.py
+++ b/scripts/twitter/twitter.py
@@ -125,6 +125,8 @@ def _get_user_auth(client) -> bool:
 PLACEHOLDER_PATTERNS = [
     r"\[link would go here\]",
     r"\[link\s+here\]",
+    r"\[URL\s+here\]",
+    r"\[insert\s+link\]",
     r"\[media\s+here\]",
     r"\[image\s+here\]",
     r"\[video\s+here\]",

--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -28,6 +28,7 @@ Usage:
 # Import stdlib email.message BEFORE sys.path manipulation
 # This ensures the stdlib module is cached and not shadowed by any local directories
 import email.message  # noqa: F401
+import re
 import sys
 from pathlib import Path as _Path
 
@@ -764,6 +765,19 @@ def cli(model: str | None = None) -> None:
     )
 
 
+# Patterns that indicate the LLM emitted a placeholder instead of a real value.
+# These are never valid in published tweets and must be caught before posting.
+_PLACEHOLDER_PATTERNS: list[tuple[str, str]] = [
+    (r"\[link would go here\]", "unresolved link placeholder"),
+    (r"\[link\s*(would go|goes)?\s*here\]", "unresolved link placeholder"),
+    (r"\[TODO[^\]]*\]", "TODO marker left in draft"),
+    (r"\[TBD[^\]]*\]", "TBD marker left in draft"),
+    (r"\[insert [^\]]+\]", "insert-instruction placeholder"),
+    (r"\[add [^\]]+\]", "add-instruction placeholder"),
+    (r"\[click here\]", "generic 'click here' placeholder"),
+]
+
+
 def _validate_draft_urls(draft: TweetDraft) -> list[tuple[str, int]]:
     """Validate URLs across both the main tweet text and any thread follow-ups."""
     bad: list[tuple[str, int]] = []
@@ -779,6 +793,23 @@ def _validate_draft_urls(draft: TweetDraft) -> list[tuple[str, int]]:
             bad.append(issue)
 
     return bad
+
+
+def _validate_draft_placeholders(draft: TweetDraft) -> list[str]:
+    """Reject drafts containing unresolved LLM placeholders like '[link would go here]'.
+
+    These are emitted by the LLM when it composes a reply that references a URL
+    but doesn't yet know the resolved value. They must never reach the posting
+    stage — the draft should either be rewritten with a real URL or dropped.
+    """
+    hits: list[str] = []
+    for text in [draft.text, *draft.thread]:
+        if not text:
+            continue
+        for pattern, label in _PLACEHOLDER_PATTERNS:
+            if re.search(pattern, text, re.IGNORECASE):
+                hits.append(label)
+    return list(dict.fromkeys(hits))  # deduplicate, preserve order
 
 
 @cli.command()
@@ -804,6 +835,21 @@ def draft(
     op = metrics.start_operation("draft_creation", "twitter")
 
     try:
+        # Guard: reject drafts with unresolved LLM placeholders
+        text_hits: list[str] = []
+        for pattern, label in _PLACEHOLDER_PATTERNS:
+            if re.search(pattern, text, re.IGNORECASE):
+                text_hits.append(label)
+        if text_hits:
+            console.print(
+                f"[red]✗ Text contains unresolved placeholders: {', '.join(dict.fromkeys(text_hits))}[/red]",
+            )
+            console.print(
+                "[red]Aborting draft — rewrite without unresolved placeholders.[/red]"
+            )
+            op.complete(success=False, error="placeholder")
+            sys.exit(1)
+
         if not skip_url_check:
             bad_urls = validate_urls_in_text(text)
             if bad_urls:
@@ -1309,6 +1355,18 @@ def post(
             console.print(f"[blue]Draft ID: {path.stem}[/blue]")
             continue
 
+        # Placeholder validation: catch unresolved LLM placeholders before posting
+        placeholder_hits = _validate_draft_placeholders(draft)
+        if placeholder_hits:
+            console.print(
+                f"[red]✗ Draft contains unresolved placeholders: {', '.join(placeholder_hits)}[/red]"
+            )
+            console.print(
+                "[red]Skipping draft — fix or rewrite the draft to remove unresolved placeholders.[/red]"
+            )
+            move_draft(path, "rejected")
+            continue
+
         # URL validation: catch 404s before asking for confirmation
         if not skip_url_check:
             bad_urls = _validate_draft_urls(draft)
@@ -1654,6 +1712,23 @@ def process_timeline_tweets(
                             f"[green]Auto-posting reply to trusted user @{author_username}"
                         )
                         try:
+                            placeholder_hits = _validate_draft_placeholders(draft)
+                            if placeholder_hits:
+                                console.print(
+                                    f"[red]✗ Auto-post blocked: unresolved placeholders: {', '.join(placeholder_hits)}[/red]"
+                                )
+                                draft.reject_reason = (
+                                    "Auto-post blocked: unresolved LLM placeholders"
+                                )
+                                path = save_draft(draft, "new")
+                                console.print(
+                                    f"[yellow]Saved as draft for manual fix: {path}"
+                                )
+                                drafts_generated += 1
+                                if draft.in_reply_to is not None:
+                                    _replied_tweet_ids.add(str(draft.in_reply_to))
+                                continue
+
                             bad_urls = _validate_draft_urls(draft)
                             if bad_urls:
                                 for url, status in bad_urls:
@@ -2199,6 +2274,17 @@ def auto(
                     console.print(
                         f"[cyan]Thread: {len(draft.thread)} follow-up tweet(s)"
                     )
+
+                placeholder_hits = _validate_draft_placeholders(draft)
+                if placeholder_hits:
+                    console.print(
+                        f"[red]✗ Draft contains unresolved placeholders: {', '.join(placeholder_hits)}[/red]"
+                    )
+                    console.print(
+                        "[red]Skipping draft — fix or rewrite the draft to remove unresolved placeholders.[/red]"
+                    )
+                    move_draft(path, "rejected")
+                    continue
 
                 bad_urls = _validate_draft_urls(draft)
                 if bad_urls:

--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -28,7 +28,6 @@ Usage:
 # Import stdlib email.message BEFORE sys.path manipulation
 # This ensures the stdlib module is cached and not shadowed by any local directories
 import email.message  # noqa: F401
-import re
 import sys
 from pathlib import Path as _Path
 
@@ -71,7 +70,11 @@ from twitter.llm import (
     process_tweet,
     verify_draft,
 )
-from twitter.twitter import cached_get_me, load_twitter_client
+from twitter.twitter import (
+    _find_placeholder_in_text,
+    cached_get_me,
+    load_twitter_client,
+)
 from url_utils import validate_urls_in_text  # type: ignore[import-not-found]
 
 logger = get_logger(__name__, "twitter")
@@ -765,19 +768,6 @@ def cli(model: str | None = None) -> None:
     )
 
 
-# Patterns that indicate the LLM emitted a placeholder instead of a real value.
-# These are never valid in published tweets and must be caught before posting.
-_PLACEHOLDER_PATTERNS: list[tuple[str, str]] = [
-    (r"\[link would go here\]", "unresolved link placeholder"),
-    (r"\[link\s*(would go|goes)?\s*here\]", "unresolved link placeholder"),
-    (r"\[TODO[^\]]*\]", "TODO marker left in draft"),
-    (r"\[TBD[^\]]*\]", "TBD marker left in draft"),
-    (r"\[insert [^\]]+\]", "insert-instruction placeholder"),
-    (r"\[add [^\]]+\]", "add-instruction placeholder"),
-    (r"\[click here\]", "generic 'click here' placeholder"),
-]
-
-
 def _validate_draft_urls(draft: TweetDraft) -> list[tuple[str, int]]:
     """Validate URLs across both the main tweet text and any thread follow-ups."""
     bad: list[tuple[str, int]] = []
@@ -806,9 +796,9 @@ def _validate_draft_placeholders(draft: TweetDraft) -> list[str]:
     for text in [draft.text, *draft.thread]:
         if not text:
             continue
-        for pattern, label in _PLACEHOLDER_PATTERNS:
-            if re.search(pattern, text, re.IGNORECASE):
-                hits.append(label)
+        hit = _find_placeholder_in_text(text)
+        if hit:
+            hits.append(hit)
     return list(dict.fromkeys(hits))  # deduplicate, preserve order
 
 
@@ -836,13 +826,10 @@ def draft(
 
     try:
         # Guard: reject drafts with unresolved LLM placeholders
-        text_hits: list[str] = []
-        for pattern, label in _PLACEHOLDER_PATTERNS:
-            if re.search(pattern, text, re.IGNORECASE):
-                text_hits.append(label)
-        if text_hits:
+        text_hit = _find_placeholder_in_text(text)
+        if text_hit:
             console.print(
-                f"[red]✗ Text contains unresolved placeholders: {', '.join(dict.fromkeys(text_hits))}[/red]",
+                f"[red]✗ Text contains unresolved placeholder: '{text_hit}'[/red]",
             )
             console.print(
                 "[red]Aborting draft — rewrite without unresolved placeholders.[/red]"


### PR DESCRIPTION
Reject any draft containing unresolved LLM placeholders before posting.

The LLM emits these when it composes a reply that references a URL/media but can't resolve the value at draft time — the draft literally contains `[link would go here]` or similar, which then gets posted verbatim.

## Changes

- **twitter.py**: Add `PLACEHOLDER_PATTERNS` list (11 patterns), compile them, `_find_placeholder_in_text()`, `_abort_on_placeholder_patterns()`, and wire into `_abort_on_bad_urls()` so the CLI `post` command catches them
- **workflow.py**: Add `_validate_draft_placeholders()` with the same patterns, wire into all three post paths (review/publish, trusted-user auto-post, step-3 approved batch post) plus the `draft` command

## Testing

- Smoke tests pass (5 scenarios: exact bug, clean text, thread placeholder, TODO, TBD)
- CLI integration test: `twitter.py post` correctly exits 1 on placeholder text
- All 3 posting paths in workflow.py now reject placeholders

Fixes the placeholder bug found in `thread_20260527_164402.yml` where Erik asked Bob to share the Gource viz and the reply contained a literal `[link would go here]`.

Ref: ErikBjare/bob#808