### PR TITLE
fix(twitter): preserve workspace persona in reply prompt

### DIFF
--- a/scripts/twitter/llm.py
+++ b/scripts/twitter/llm.py
@@ -339,15 +339,15 @@ Evaluation:
 {json.dumps(eval_result, indent=2)}
 
 Response Guidelines:
-1. Maintain professional, helpful tone
-2. Focus on technical accuracy
-3. Keep under 280 characters
-4. Use 1-2 emojis maximum
-5. Put links in follow-up tweets
-6. Avoid controversial topics
-7. Add value to the discussion
-8. Demonstrate understanding of specific context from the thread
-9. Reference relevant details to show you've understood the conversation
+1. Use the workspace persona already loaded in the system prompt as the source of truth for voice
+2. Be direct, technical, and specific; sounding corporate, deferential, or sanitized is a failure
+3. Focus on technical accuracy
+4. Keep under 280 characters
+5. Use emojis only if they fit naturally; default to none
+6. Add concrete value to the discussion
+7. Demonstrate understanding of specific context from the thread and reference relevant details
+8. Do not promise follow-up, links, or artifacts unless they already exist in the provided context
+9. If a link is needed but unavailable, say so plainly instead of inserting a placeholder or vague promise
 10. NEVER write placeholder text like "[link would go here]", "[URL here]", "[insert link]",
     "[media here]", or any bracket-enclosed instruction. If you don't have a specific URL
     or media item to include, write a complete response without referencing it — either

--- a/tests/test_twitter_eval_prompt.py
+++ b/tests/test_twitter_eval_prompt.py
@@ -203,6 +203,42 @@ def test_unset_handle_raises_value_error(
         llm_module.create_tweet_eval_prompt(tweet, eval_config)
 
 
+def test_response_prompt_defers_to_workspace_persona(
+    llm_module: types.ModuleType,
+) -> None:
+    """Reply drafting should reinforce the loaded agent voice, not flatten it.
+
+    ErikBjare/bob#808 found that generic "professional helpful tone" guidance
+    suppressed Bob's direct, opinionated voice even though SOUL.md was loaded.
+    """
+    tweet = _base_tweet("@TimeToBuildBob loved the gource demo")
+    config = {
+        "templates": {
+            "examples": [
+                {
+                    "reasoning": "Specific technical response fits",
+                    "text": "Nice catch. The media path is still missing, but the post-tweet worker now closes the loop.",
+                    "type": "reply",
+                    "thread_needed": False,
+                    "follow_up": None,
+                }
+            ]
+        }
+    }
+
+    prompt = llm_module.create_response_prompt(
+        tweet,
+        {"action": "respond", "reasoning": "Direct mention"},
+        config,
+    )
+
+    assert "workspace persona already loaded in the system prompt" in prompt
+    assert "sounding corporate, deferential, or sanitized is a failure" in prompt
+    assert "Do not promise follow-up, links, or artifacts" in prompt
+    assert "professional, helpful tone" not in prompt
+    assert "Avoid controversial topics" not in prompt
+
+
 def test_openrouter_key_resolution_prefers_twitter_specific_key(
     llm_module: types.ModuleType,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- make Twitter reply drafting defer to the workspace persona already loaded in the system prompt
- remove the generic corporate/emoji/controversy boilerplate that was flattening Bob's voice
- add a regression test that locks the prompt away from that failure mode

## Root cause
`create_response_prompt()` in `scripts/twitter/llm.py` was layering generic guidance like "Maintain professional, helpful tone" and "Avoid controversial topics" on top of the loaded workspace context. In practice that overrode `SOUL.md` and produced flat, sanitized replies even when the agent persona was present.

This came out of the broader tweet-quality review in ErikBjare/bob#808.

## Validation
- `uv run pytest tests/test_twitter_eval_prompt.py -q`
