### PR TITLE
fix(resolver): route provider key by prefix, not hardcoded OPENAI_API_KEY

### DIFF
--- a/.github/workflows/issue-resolver.yml
+++ b/.github/workflows/issue-resolver.yml
@@ -21,6 +21,11 @@ name: Issue Resolver (opt-in draft PR)
 #       secrets:
 #         gptme-provider-key: ${{ secrets.ANTHROPIC_API_KEY }}
 #
+# The `gptme-provider-key` secret is provider-agnostic: the resolve step routes
+# it to the env var gptme expects based on the key prefix (sk-ant- → Anthropic,
+# sk-or- → OpenRouter, AIza → Gemini, else → OpenAI). Pass whichever provider
+# key the calling repo has configured.
+#
 # The workflow fetches its own resolver scripts from gptme-contrib so the
 # calling repo does not need to include any gptme-contrib files.
 #
@@ -117,12 +122,27 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPTME_MODEL: ${{ inputs.model }}
-          OPENAI_API_KEY: ${{ secrets.gptme-provider-key }}
+          GPTME_PROVIDER_KEY: ${{ secrets.gptme-provider-key }}
         run: |
           ISSUE_NUMBER="${{ inputs.issue-number || github.event.issue.number }}"
           if [ -z "$ISSUE_NUMBER" ]; then
             echo "No issue number available; nothing to do."
             exit 0
+          fi
+
+          # Route the provider key to the env var gptme expects for that
+          # provider. gptme auto-detects the provider by env var NAME (see
+          # gptme/init.py), so an Anthropic key in OPENAI_API_KEY would be
+          # used as an OpenAI key and 401. Detect by key prefix, mirroring
+          # gptme's own get_model_from_api_key(). Default → OPENAI_API_KEY,
+          # so existing OpenAI callers are unaffected.
+          if [ -n "$GPTME_PROVIDER_KEY" ]; then
+            case "$GPTME_PROVIDER_KEY" in
+              sk-ant-*) export ANTHROPIC_API_KEY="$GPTME_PROVIDER_KEY" ;;
+              sk-or-*)  export OPENROUTER_API_KEY="$GPTME_PROVIDER_KEY" ;;
+              AIza*)    export GEMINI_API_KEY="$GPTME_PROVIDER_KEY" ;;
+              *)        export OPENAI_API_KEY="$GPTME_PROVIDER_KEY" ;;
+            esac
           fi
 
           mkdir -p output

--- a/.github/workflows/issue-resolver.yml
+++ b/.github/workflows/issue-resolver.yml
@@ -60,7 +60,7 @@ on:
         default: "/gptme-resolve"
     secrets:
       gptme-provider-key:
-        description: "API key gptme should use (e.g. OPENAI_API_KEY)."
+        description: "Provider key for gptme (any prefix: sk-ant- → Anthropic, sk-or- → OpenRouter, AIza → Gemini, else → OpenAI)."
         required: false
 
 permissions:
@@ -143,6 +143,7 @@ jobs:
               AIza*)    export GEMINI_API_KEY="$GPTME_PROVIDER_KEY" ;;
               *)        export OPENAI_API_KEY="$GPTME_PROVIDER_KEY" ;;
             esac
+            unset GPTME_PROVIDER_KEY
           fi
 
           mkdir -p output


### PR DESCRIPTION
## Problem

The reusable `issue-resolver.yml` workflow wired the generic `gptme-provider-key` secret straight into `OPENAI_API_KEY`:

```yaml
env:
  OPENAI_API_KEY: ${{ secrets.gptme-provider-key }}
```

gptme auto-detects the provider by env var **name** (`gptme/init.py`), so an Anthropic key (`sk-ant-...`) passed as the provider key landed in `OPENAI_API_KEY` and was used as an OpenAI key → 401.

The workflow's own header doc already shows the intended usage as:

```yaml
secrets:
  gptme-provider-key: ${{ secrets.ANTHROPIC_API_KEY }}
```

…so the documented behavior was simply broken.

## Fix

Route the key to the env var gptme expects based on **key prefix**, mirroring gptme's own `get_model_from_api_key()`:

| Prefix | Env var |
|--------|---------|
| `sk-ant-` | `ANTHROPIC_API_KEY` |
| `sk-or-` | `OPENROUTER_API_KEY` |
| `AIza` | `GEMINI_API_KEY` |
| else | `OPENAI_API_KEY` (unchanged default) |

- **Backward-compatible**: existing OpenAI callers fall through to the default case → identical behavior.
- **General**: one secret, any provider — no new per-provider secrets.
- Routing snippet is shellcheck-clean; workflow YAML validated.

## Why

Unblocks rolling out the opt-in resolver to Anthropic-only repos (e.g. ErikBjare/bob, which only has `ANTHROPIC_API_KEY` configured). Part of idea #169 Phase 2 rollout.