### PR TITLE
fix(gptmail): make completion-status CLI read from the conversation tracker

### DIFF
--- a/packages/gptmail/src/gptmail/cli.py
+++ b/packages/gptmail/src/gptmail/cli.py
@@ -8,7 +8,6 @@
 # ///
 """CLI interface for the email system."""
 
-import json
 import os
 import subprocess
 import sys
@@ -19,6 +18,7 @@ from pathlib import Path
 
 import click
 
+from gptmail.communication_utils.state.tracking import MessageState
 from gptmail.lib import AgentEmail
 
 
@@ -403,11 +403,23 @@ def list_completed(status: str) -> None:
     workspace_dir = get_workspace_dir()
     email = AgentEmail(workspace_dir)
 
-    try:
-        replies_data = json.loads(email.replies_state_file.read_text())
-    except (json.JSONDecodeError, FileNotFoundError):
-        click.echo("No completed emails found.")
-        return
+    # Completion state lives in the conversation tracker, not a flat file.
+    # Map tracker MessageState -> the display schema used below.
+    replies_data: dict[str, dict] = {}
+    for msg in email.tracker.get_completed_messages("email"):
+        completed_at = msg.updated_at or msg.created_at or "unknown"
+        if msg.state == MessageState.COMPLETED:
+            replies_data[msg.message_id] = {
+                "status": "replied",
+                "replied_at": completed_at,
+                "reply_id": msg.reply_id or "unknown",
+            }
+        else:  # NO_REPLY_NEEDED
+            replies_data[msg.message_id] = {
+                "status": "no_reply_needed",
+                "completed_at": completed_at,
+                "reason": msg.reason or "no reason given",
+            }
 
     if not replies_data:
         click.echo("No completed emails found.")
@@ -604,24 +616,19 @@ def check_completion_status(message_id: str) -> None:
     is_completed = email._is_completed(message_id)
     click.echo(f"Is completed: {is_completed}")
 
-    # Show what's actually in the replies state file
-    try:
-        replies_data = json.loads(email.replies_state_file.read_text())
-        click.echo("\nEntries in replies_state.json:")
-        matching_entries = []
-        for stored_id, data in replies_data.items():
-            if stored_id == message_id or stored_id == normalized_id or stored_id == with_brackets:
-                matching_entries.append((stored_id, data))
+    # Show what's actually tracked for this message (tracker keys are normalized).
+    msg_info = email.tracker.get_message_state("email", normalized_id)
+    if msg_info is None:
+        click.echo("\nNo tracker entry found for this message.")
+        return
 
-        if matching_entries:
-            for stored_id, data in matching_entries:
-                click.echo(f"  {stored_id}: {data}")
-        else:
-            click.echo("  No matching entries found")
-            click.echo(f"  Total entries in file: {len(replies_data)}")
-
-    except (json.JSONDecodeError, FileNotFoundError):
-        click.echo("No replies_state.json file found or invalid JSON")
+    click.echo("\nTracker entry:")
+    click.echo(f"  Message ID: {msg_info.message_id}")
+    click.echo(f"  State: {msg_info.state.value}")
+    if msg_info.reason:
+        click.echo(f"  Reason: {msg_info.reason}")
+    if msg_info.reply_id:
+        click.echo(f"  Reply ID: {msg_info.reply_id}")
 
 
 @cli.command()

--- a/packages/gptmail/src/gptmail/communication_utils/state/tracking.py
+++ b/packages/gptmail/src/gptmail/communication_utils/state/tracking.py
@@ -6,7 +6,7 @@ messages, and completion status across platforms.
 """
 
 import json
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, fields
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
@@ -35,6 +35,8 @@ class MessageInfo:
     created_at: str | None = None
     updated_at: str | None = None
     error: str | None = None
+    reason: str | None = None
+    reply_id: str | None = None
 
     def to_dict(self) -> dict:
         """Convert to dictionary for JSON serialization."""
@@ -44,8 +46,13 @@ class MessageInfo:
 
     @classmethod
     def from_dict(cls, data: dict) -> "MessageInfo":
-        """Create from dictionary."""
-        data = data.copy()
+        """Create from dictionary, ignoring unknown keys.
+
+        Legacy/foreign trackers may store extra fields (e.g. ``platform``,
+        ``status``); filtering to known dataclass fields keeps loading robust.
+        """
+        known = {f.name for f in fields(cls)}
+        data = {k: v for k, v in data.items() if k in known}
         data["state"] = MessageState(data["state"])
         return cls(**data)
 
@@ -107,6 +114,7 @@ class ConversationTracker:
         message_id: str,
         state: MessageState,
         error: str | None = None,
+        metadata: dict | None = None,
     ) -> None:
         """
         Update message state.
@@ -116,6 +124,8 @@ class ConversationTracker:
             message_id: Message identifier
             state: New message state
             error: Optional error message if state is FAILED
+            metadata: Optional extra fields to merge into the message record
+                (e.g. ``reason`` for no-reply-needed, ``reply_id`` for replies)
         """
         state_file = self._get_state_file(conversation_id)
 
@@ -141,6 +151,9 @@ class ConversationTracker:
 
             if error:
                 data["messages"][message_id]["error"] = error
+
+            if metadata:
+                data["messages"][message_id].update(metadata)
 
             # Save updated state
             with open(state_file, "w") as f:
@@ -212,6 +225,33 @@ class ConversationTracker:
             for msg_data in data.get("messages", {}).values():
                 msg_info = MessageInfo.from_dict(msg_data)
                 if msg_info.state == MessageState.PENDING:
+                    messages.append(msg_info)
+
+            return messages
+
+    def get_completed_messages(self, conversation_id: str) -> list[MessageInfo]:
+        """
+        Get all completed messages (replied or no-reply-needed) for a conversation.
+
+        Args:
+            conversation_id: Conversation identifier
+
+        Returns:
+            List of completed MessageInfo objects
+        """
+        completed_states = (MessageState.COMPLETED, MessageState.NO_REPLY_NEEDED)
+        state_file = self._get_state_file(conversation_id)
+        if not state_file.exists():
+            return []
+
+        with file_lock(self._get_lock_file(conversation_id)):
+            with open(state_file) as f:
+                data = json.load(f)
+
+            messages = []
+            for msg_data in data.get("messages", {}).values():
+                msg_info = MessageInfo.from_dict(msg_data)
+                if msg_info.state in completed_states:
                     messages.append(msg_info)
 
             return messages

--- a/packages/gptmail/src/gptmail/lib.py
+++ b/packages/gptmail/src/gptmail/lib.py
@@ -278,6 +278,7 @@ class AgentEmail:
             conversation_id=conversation_id,
             message_id=normalized_id,
             state=MessageState.COMPLETED,
+            metadata={"reply_id": reply_message_id},
         )
 
     def _mark_no_reply_needed(self, message_id: str, reason: str = "no reply needed") -> None:
@@ -296,6 +297,7 @@ class AgentEmail:
             conversation_id=conversation_id,
             message_id=normalized_id,
             state=MessageState.NO_REPLY_NEEDED,
+            metadata={"reason": reason},
         )
 
     def _is_completed(self, message_id: str) -> bool:

--- a/packages/gptmail/tests/test_cli_completion.py
+++ b/packages/gptmail/tests/test_cli_completion.py
@@ -1,0 +1,76 @@
+"""Tests for tracker-backed completion status CLI commands."""
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+import gptmail.cli as gptmail_cli
+from gptmail.lib import AgentEmail
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Create a minimal workspace for CLI completion tests."""
+    email_dir = tmp_path / "email"
+    for subdir in ["inbox", "sent", "archive", "drafts", "filters"]:
+        (email_dir / subdir).mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setenv("EMAIL_ALLOWLIST", "friend@example.com")
+    monkeypatch.setattr(gptmail_cli, "get_workspace_dir", lambda: tmp_path)
+    return tmp_path
+
+
+def test_list_completed_and_status_show_no_reply_reason(workspace: Path) -> None:
+    agent = AgentEmail(str(workspace), "test@example.com")
+    agent._mark_no_reply_needed("<thread@example.com>", "Informational only")
+
+    runner = CliRunner()
+
+    result = runner.invoke(gptmail_cli.cli, ["list-completed"])
+    assert result.exit_code == 0
+    assert "Found 1 completed emails:" in result.output
+    assert "no_reply_needed" in result.output
+    assert "Reason: Informational only" in result.output
+    assert "thread@example.com" in result.output
+
+    status_result = runner.invoke(
+        gptmail_cli.cli, ["check-completion-status", "<thread@example.com>"]
+    )
+    assert status_result.exit_code == 0
+    assert "Is completed: True" in status_result.output
+    assert "thread@example.com" in status_result.output
+    assert "Informational only" in status_result.output
+
+
+def test_list_completed_maps_completed_state_to_replied(workspace: Path) -> None:
+    agent = AgentEmail(str(workspace), "test@example.com")
+    agent._mark_replied("<thread@example.com>", "<reply@example.com>")
+
+    runner = CliRunner()
+    result = runner.invoke(gptmail_cli.cli, ["list-completed", "--status", "replied"])
+
+    assert result.exit_code == 0
+    assert "Found 1 completed emails:" in result.output
+    assert "replied" in result.output
+    assert "Reply ID: <reply@example.com>" in result.output
+    assert "thread@example.com" in result.output
+
+
+def test_list_completed_tolerates_legacy_extra_tracker_fields(workspace: Path) -> None:
+    agent = AgentEmail(str(workspace), "test@example.com")
+    agent._mark_no_reply_needed("<legacy@example.com>", "Legacy entry")
+
+    state_file = workspace / "email" / "locks" / "email.json"
+    state_data = json.loads(state_file.read_text())
+    state_data["messages"]["legacy@example.com"]["platform"] = "email"
+    state_data["messages"]["legacy@example.com"]["status"] = "no_reply_needed"
+    state_file.write_text(json.dumps(state_data, indent=2))
+
+    runner = CliRunner()
+    result = runner.invoke(gptmail_cli.cli, ["list-completed"])
+
+    assert result.exit_code == 0
+    assert "legacy@example.com" in result.output
+    assert "Reason: Legacy entry" in result.output

--- a/packages/gptmail/tests/test_cli_completion.py
+++ b/packages/gptmail/tests/test_cli_completion.py
@@ -18,6 +18,7 @@ def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
         (email_dir / subdir).mkdir(parents=True, exist_ok=True)
 
     monkeypatch.setenv("EMAIL_ALLOWLIST", "friend@example.com")
+    monkeypatch.setenv("AGENT_EMAIL", "test@example.com")
     monkeypatch.setattr(gptmail_cli, "get_workspace_dir", lambda: tmp_path)
     return tmp_path
 


### PR DESCRIPTION
## Problem

`gptmail list-completed` and `gptmail check-completion-status` both crash:

```
AttributeError: 'AgentEmail' object has no attribute 'replies_state_file'
```

They reference `email.replies_state_file`, which never existed. Completion state
actually lives in the `ConversationTracker` (single conversation `"email"`), but
the feature was only half-wired:

- `_mark_no_reply_needed(message_id, reason)` accepted a `reason` but discarded it.
- `_mark_replied(original, reply_id)` discarded the reply id.
- `ConversationTracker.set_message_state` had no way to store extra fields.
- The CLI display code expected a `{msg_id: {status, completed_at, reply_id, reason}}`
  dict that nothing produced.

## Fix

- **`ConversationTracker`**: `set_message_state` gains an optional `metadata` dict
  that merges into the message record; `MessageInfo` gains `reason`/`reply_id`
  fields; `from_dict` now ignores unknown keys (tolerates legacy/foreign tracker
  fields like `platform`/`status`); add `get_completed_messages()`.
- **`AgentEmail`**: persist `reason` / `reply_id` through the new metadata path.
- **CLI**: source both commands from `email.tracker` instead of the missing
  attribute. `MessageState.COMPLETED` maps to the `replied` display status.

## Tests

New `test_cli_completion.py` (reproduces the original crash, now green):
- no-reply reason surfaces in `list-completed` and `check-completion-status`
- `COMPLETED` state maps to `replied` with the reply id shown
- legacy extra tracker fields are tolerated

Full gptmail suite: 49 passed.