### PR TITLE
fix(project-monitoring): serialize should_post_comment with flock to prevent duplicate comments

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/project_monitoring.py
+++ b/packages/gptme-runloops/src/gptme_runloops/project_monitoring.py
@@ -1,5 +1,6 @@
 """Project monitoring run loop implementation."""
 
+import fcntl
 import json
 import re
 import subprocess
@@ -559,9 +560,12 @@ class ProjectMonitoringRun(BaseRunLoop):
         state_file = (
             self.state_dir / f"{repo.replace('/', '-')}-pr-{pr_number}-comment.state"
         )
+        # Separate lock file prevents a concurrent session from racing through
+        # the check-then-write window and posting a duplicate comment.
+        lock_file = state_file.with_suffix(".lock")
 
         try:
-            # Get PR's current update time
+            # Get PR's current update time (outside the lock — network call)
             result = subprocess.run(
                 [
                     "gh",
@@ -588,71 +592,76 @@ class ProjectMonitoringRun(BaseRunLoop):
 
             current_updated = result.stdout.strip()
 
-            # Check previous comment state
-            if state_file.exists():
-                state_data = state_file.read_text().strip().split()
-                if len(state_data) >= 3:
-                    prev_type, prev_time, pr_updated = (
-                        state_data[0],
-                        state_data[1],
-                        state_data[2],
-                    )
+            # Exclusive lock serializes concurrent sessions on this PR's state.
+            # flock is released automatically when the file handle is closed.
+            with open(lock_file, "w") as lf:
+                fcntl.flock(lf, fcntl.LOCK_EX)
 
-                    # Rule 1: PR updated since last comment (new commits/reviews)
-                    if current_updated > pr_updated:
-                        # Check if last activity was by agent (skip own comments)
-                        if self._is_last_activity_by_self(repo, pr_number):
+                # Check previous comment state
+                if state_file.exists():
+                    state_data = state_file.read_text().strip().split()
+                    if len(state_data) >= 3:
+                        prev_type, prev_time, pr_updated = (
+                            state_data[0],
+                            state_data[1],
+                            state_data[2],
+                        )
+
+                        # Rule 1: PR updated since last comment (new commits/reviews)
+                        if current_updated > pr_updated:
+                            # Check if last activity was by agent (skip own comments)
+                            if self._is_last_activity_by_self(repo, pr_number):
+                                self.logger.info(
+                                    f"PR {repo}#{pr_number} updated by self, skipping"
+                                )
+                                # Update state to avoid repeated checks
+                                state_file.write_text(
+                                    f"{comment_type} {datetime.now().isoformat()} {current_updated}"
+                                )
+                                return False
+
                             self.logger.info(
-                                f"PR {repo}#{pr_number} updated by self, skipping"
+                                f"PR {repo}#{pr_number} updated since last comment"
                             )
-                            # Update state to avoid repeated checks
                             state_file.write_text(
                                 f"{comment_type} {datetime.now().isoformat()} {current_updated}"
                             )
-                            return False
+                            return True
 
+                        # Rule 2: Comment type changed
+                        if comment_type != prev_type:
+                            self.logger.info(
+                                f"Comment type changed for {repo}#{pr_number}: {prev_type} -> {comment_type}"
+                            )
+                            state_file.write_text(
+                                f"{comment_type} {datetime.now().isoformat()} {current_updated}"
+                            )
+                            return True
+
+                        # Rule 3: Comment stale (24+ hours)
+                        prev_time_dt = datetime.fromisoformat(prev_time)
+                        age = datetime.now() - prev_time_dt
+                        if age > timedelta(hours=24):
+                            self.logger.info(
+                                f"Comment stale for {repo}#{pr_number} (age: {age})"
+                            )
+                            state_file.write_text(
+                                f"{comment_type} {datetime.now().isoformat()} {current_updated}"
+                            )
+                            return True
+
+                        # Don't post duplicate
                         self.logger.info(
-                            f"PR {repo}#{pr_number} updated since last comment"
+                            f"Skipping duplicate comment on {repo}#{pr_number} (type: {comment_type})"
                         )
-                        state_file.write_text(
-                            f"{comment_type} {datetime.now().isoformat()} {current_updated}"
-                        )
-                        return True
+                        return False
 
-                    # Rule 2: Comment type changed
-                    if comment_type != prev_type:
-                        self.logger.info(
-                            f"Comment type changed for {repo}#{pr_number}: {prev_type} -> {comment_type}"
-                        )
-                        state_file.write_text(
-                            f"{comment_type} {datetime.now().isoformat()} {current_updated}"
-                        )
-                        return True
-
-                    # Rule 3: Comment stale (24+ hours)
-                    prev_time_dt = datetime.fromisoformat(prev_time)
-                    age = datetime.now() - prev_time_dt
-                    if age > timedelta(hours=24):
-                        self.logger.info(
-                            f"Comment stale for {repo}#{pr_number} (age: {age})"
-                        )
-                        state_file.write_text(
-                            f"{comment_type} {datetime.now().isoformat()} {current_updated}"
-                        )
-                        return True
-
-                    # Don't post duplicate
-                    self.logger.info(
-                        f"Skipping duplicate comment on {repo}#{pr_number} (type: {comment_type})"
-                    )
-                    return False
-
-            # No previous comment: post it (Rule 0)
-            self.logger.info(f"First comment for {repo}#{pr_number}")
-            state_file.write_text(
-                f"{comment_type} {datetime.now().isoformat()} {current_updated}"
-            )
-            return True
+                # No previous comment: post it (Rule 0)
+                self.logger.info(f"First comment for {repo}#{pr_number}")
+                state_file.write_text(
+                    f"{comment_type} {datetime.now().isoformat()} {current_updated}"
+                )
+                return True
 
         except Exception as e:
             self.logger.error(

--- a/packages/gptme-runloops/src/gptme_runloops/project_monitoring.py
+++ b/packages/gptme-runloops/src/gptme_runloops/project_monitoring.py
@@ -1,12 +1,16 @@
 """Project monitoring run loop implementation."""
 
-import fcntl
 import json
 import re
 import subprocess
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+
+try:
+    import fcntl as _fcntl
+except ImportError:
+    _fcntl = None  # type: ignore[assignment]
 
 from gptme_runloops.base import BaseRunLoop
 from gptme_runloops.utils.execution import ExecutionResult
@@ -565,7 +569,8 @@ class ProjectMonitoringRun(BaseRunLoop):
         lock_file = state_file.with_suffix(".lock")
 
         try:
-            # Get PR's current update time (outside the lock — network call)
+            # Fetch PR update time and last comment author in one call (outside
+            # the lock — network I/O must not be held inside the critical section).
             result = subprocess.run(
                 [
                     "gh",
@@ -575,9 +580,9 @@ class ProjectMonitoringRun(BaseRunLoop):
                     "--repo",
                     repo,
                     "--json",
-                    "updatedAt",
+                    "updatedAt,comments",
                     "--jq",
-                    ".updatedAt",
+                    '{"updatedAt": .updatedAt, "lastCommentAuthor": (.comments | sort_by(.createdAt) | last | .author.login // "")}',
                 ],
                 capture_output=True,
                 text=True,
@@ -585,17 +590,18 @@ class ProjectMonitoringRun(BaseRunLoop):
             )
 
             if result.returncode != 0 or not result.stdout.strip():
-                self.logger.warning(
-                    f"Could not get PR update time for {repo}#{pr_number}"
-                )
+                self.logger.warning(f"Could not get PR info for {repo}#{pr_number}")
                 return False
 
-            current_updated = result.stdout.strip()
+            pr_info = json.loads(result.stdout)
+            current_updated = pr_info["updatedAt"]
+            last_activity_by_self = pr_info.get("lastCommentAuthor") == self.author
 
             # Exclusive lock serializes concurrent sessions on this PR's state.
             # flock is released automatically when the file handle is closed.
             with open(lock_file, "w") as lf:
-                fcntl.flock(lf, fcntl.LOCK_EX)
+                if _fcntl is not None:
+                    _fcntl.flock(lf, _fcntl.LOCK_EX)
 
                 # Check previous comment state
                 if state_file.exists():
@@ -610,7 +616,7 @@ class ProjectMonitoringRun(BaseRunLoop):
                         # Rule 1: PR updated since last comment (new commits/reviews)
                         if current_updated > pr_updated:
                             # Check if last activity was by agent (skip own comments)
-                            if self._is_last_activity_by_self(repo, pr_number):
+                            if last_activity_by_self:
                                 self.logger.info(
                                     f"PR {repo}#{pr_number} updated by self, skipping"
                                 )

--- a/packages/gptme-runloops/tests/test_project_monitoring.py
+++ b/packages/gptme-runloops/tests/test_project_monitoring.py
@@ -214,11 +214,11 @@ def test_should_post_comment_first_time(workspace):
     """Test posting comment for first time."""
     run = ProjectMonitoringRun(workspace)
 
-    # Mock gh pr view to return updated time
+    # Mock gh pr view to return updated time and last comment author
     with patch("gptme_runloops.project_monitoring.subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(
             returncode=0,
-            stdout="2025-11-25T10:00:00Z",
+            stdout='{"updatedAt": "2025-11-25T10:00:00Z", "lastCommentAuthor": ""}',
             stderr="",
         )
 
@@ -246,7 +246,7 @@ def test_should_post_comment_duplicate(workspace):
     with patch("gptme_runloops.project_monitoring.subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(
             returncode=0,
-            stdout="2025-11-25T09:00:00Z",
+            stdout='{"updatedAt": "2025-11-25T09:00:00Z", "lastCommentAuthor": ""}',
             stderr="",
         )
 
@@ -270,7 +270,7 @@ def test_should_post_comment_pr_updated(workspace):
     with patch("gptme_runloops.project_monitoring.subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(
             returncode=0,
-            stdout="2025-11-25T11:00:00Z",  # Newer than state file
+            stdout='{"updatedAt": "2025-11-25T11:00:00Z", "lastCommentAuthor": "other-user"}',  # Newer than state file, not by self
             stderr="",
         )
 
@@ -294,7 +294,7 @@ def test_should_post_comment_type_changed(workspace):
     with patch("gptme_runloops.project_monitoring.subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(
             returncode=0,
-            stdout="2025-11-25T10:00:00Z",
+            stdout='{"updatedAt": "2025-11-25T10:00:00Z", "lastCommentAuthor": ""}',
             stderr="",
         )
 
@@ -318,7 +318,7 @@ def test_should_post_comment_stale(workspace):
     with patch("gptme_runloops.project_monitoring.subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(
             returncode=0,
-            stdout="2025-11-25T10:00:00Z",
+            stdout='{"updatedAt": "2025-11-25T10:00:00Z", "lastCommentAuthor": ""}',
             stderr="",
         )
 
@@ -344,7 +344,7 @@ def test_should_post_comment_concurrent_first_time(workspace):
         with patch("gptme_runloops.project_monitoring.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(
                 returncode=0,
-                stdout="2025-11-25T10:00:00Z",
+                stdout='{"updatedAt": "2025-11-25T10:00:00Z", "lastCommentAuthor": ""}',
                 stderr="",
             )
             # Sync both threads at the gate so they enter should_post_comment
@@ -380,11 +380,14 @@ def test_check_pr_updates_new_pr(mock_run, workspace):
             }
         ]
     )
-    mock_run.return_value = MagicMock(
-        returncode=0,
-        stdout=pr_data,
-        stderr="",
-    )
+    comment_state = '{"updatedAt": "2025-11-25T10:00:00Z", "lastCommentAuthor": ""}'
+
+    def side_effect(args, **kwargs):
+        if "updatedAt,comments" in args:
+            return MagicMock(returncode=0, stdout=comment_state, stderr="")
+        return MagicMock(returncode=0, stdout=pr_data, stderr="")
+
+    mock_run.side_effect = side_effect
 
     run = ProjectMonitoringRun(workspace)
     work_items = run.check_pr_updates("gptme/gptme")
@@ -409,11 +412,14 @@ def test_check_pr_updates_no_change(mock_run, workspace):
             }
         ]
     )
-    mock_run.return_value = MagicMock(
-        returncode=0,
-        stdout=pr_data,
-        stderr="",
-    )
+    comment_state = '{"updatedAt": "2025-11-25T10:00:00Z", "lastCommentAuthor": ""}'
+
+    def side_effect(args, **kwargs):
+        if "updatedAt,comments" in args:
+            return MagicMock(returncode=0, stdout=comment_state, stderr="")
+        return MagicMock(returncode=0, stdout=pr_data, stderr="")
+
+    mock_run.side_effect = side_effect
 
     run = ProjectMonitoringRun(workspace)
 
@@ -446,7 +452,14 @@ def test_check_pr_updates_surfaces_draft(mock_run, workspace):
             }
         ]
     )
-    mock_run.return_value = MagicMock(returncode=0, stdout=pr_data, stderr="")
+    comment_state = '{"updatedAt": "2026-05-12T20:17:24Z", "lastCommentAuthor": ""}'
+
+    def side_effect(args, **kwargs):
+        if "updatedAt,comments" in args:
+            return MagicMock(returncode=0, stdout=comment_state, stderr="")
+        return MagicMock(returncode=0, stdout=pr_data, stderr="")
+
+    mock_run.side_effect = side_effect
 
     run = ProjectMonitoringRun(workspace)
     work_items = run.check_pr_updates("gptme/gptme")
@@ -507,11 +520,14 @@ def test_check_ci_failures(mock_run, workspace):
             }
         ]
     )
-    mock_run.return_value = MagicMock(
-        returncode=0,
-        stdout=pr_data,
-        stderr="",
-    )
+    comment_state = '{"updatedAt": "2025-11-25T10:00:00Z", "lastCommentAuthor": ""}'
+
+    def side_effect(args, **kwargs):
+        if "updatedAt,comments" in args:
+            return MagicMock(returncode=0, stdout=comment_state, stderr="")
+        return MagicMock(returncode=0, stdout=pr_data, stderr="")
+
+    mock_run.side_effect = side_effect
 
     run = ProjectMonitoringRun(workspace)
     work_items = run.check_ci_failures("gptme/gptme")

--- a/packages/gptme-runloops/tests/test_project_monitoring.py
+++ b/packages/gptme-runloops/tests/test_project_monitoring.py
@@ -327,6 +327,45 @@ def test_should_post_comment_stale(workspace):
         assert should_post is True
 
 
+def test_should_post_comment_concurrent_first_time(workspace):
+    """Race condition: two sessions on the same PR with no prior state.
+
+    Only one should return True (post). Without flock the check-then-write
+    window lets both sessions see state_file.exists()==False and both post.
+    """
+    import threading
+    from unittest.mock import MagicMock, patch
+
+    results = []
+    barrier = threading.Barrier(2)
+
+    def call_should_post():
+        run = ProjectMonitoringRun(workspace)
+        with patch("gptme_runloops.project_monitoring.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="2025-11-25T10:00:00Z",
+                stderr="",
+            )
+            # Sync both threads at the gate so they enter should_post_comment
+            # at the same time, maximising the chance of hitting the race.
+            barrier.wait()
+            result = run.should_post_comment("gptme/gptme", 456, "update")
+            results.append(result)
+
+    t1 = threading.Thread(target=call_should_post)
+    t2 = threading.Thread(target=call_should_post)
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    # Exactly one session should have won the race and posted.
+    assert (
+        results.count(True) == 1
+    ), f"Expected exactly 1 True (one poster), got {results}"
+
+
 @patch("gptme_runloops.project_monitoring.subprocess.run")
 def test_check_pr_updates_new_pr(mock_run, workspace):
     """Test detecting new PR updates."""


### PR DESCRIPTION
## Problem

Multiple concurrent project-monitoring sessions on the same PR can each call
`should_post_comment()` simultaneously. Because the check-then-write on
`state_file` is non-atomic, both sessions see `state_file.exists() == False`,
both write state, and both return `True` — resulting in duplicate GitHub
comments. This was reported by a community member (0xbrazy) on
ActivityWatch/aw-server-rust#597.

## Root cause

`should_post_comment()` had a classic TOCTOU race:

```txt
Session A: state_file.exists() → False
Session B: state_file.exists() → False
Session A: state_file.write_text(...) → posts comment
Session B: state_file.write_text(...) → posts comment (duplicate!)
```

## Fix

Wrap the entire state-file read/check/write block with an exclusive `fcntl.flock`
on a per-PR `.lock` file. This serializes concurrent sessions: the second caller
blocks until the first releases the lock, then sees `state_file.exists() == True`
and correctly skips.

The network call (`subprocess.run` to get the PR's `updated_at`) is kept outside
the lock to avoid holding it during I/O.

## Test

Added `test_should_post_comment_concurrent_first_time` — uses `threading.Barrier(2)`
to guarantee both threads enter `should_post_comment()` simultaneously on a PR with
no prior state. Asserts exactly one returns `True`.

```
27 passed in 0.14s
```