### PR TITLE
fix(resolver): harden branch safety and strip agent creds

### DIFF
--- a/.github/workflows/issue-resolver.yml
+++ b/.github/workflows/issue-resolver.yml
@@ -84,6 +84,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # Do not leave a write-capable token configured in the worktree the
+          # agent edits. The orchestrator pushes explicitly with GH_TOKEN after
+          # validating the result, so direct agent-side `git push` attempts fail
+          # closed even if the model ignores the prompt contract.
+          persist-credentials: false
 
       - name: Fetch resolver scripts from gptme-contrib
         # Always fetch from gptme-contrib so this workflow works both when

--- a/scripts/github_resolver/README.md
+++ b/scripts/github_resolver/README.md
@@ -50,6 +50,12 @@ clean.
   comment.
 - **Observable.** The gptme stdout log + final status JSON are uploaded as a
   workflow artifact (`gptme-resolver-output`, 30-day retention).
+- **Branch-safe execution.** The agent run gets a restricted tool set
+  (`read,save,patch,shell`), a shimmed `git`/`gh`, and no GitHub credentials;
+  only the orchestrator is allowed to push branches, open PRs, or comment.
+- **Fail-closed git invariant.** If the agent still changes HEAD or switches
+  branches directly, the orchestrator treats that as an error and preserves the
+  result on the attempt branch instead of trusting the run as a clean success.
 
 ## How trusted users invoke it
 

--- a/scripts/github_resolver/resolve_issue.py
+++ b/scripts/github_resolver/resolve_issue.py
@@ -42,10 +42,13 @@ import argparse
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
+from urllib.parse import quote
 
 # Make the sibling `github_actions_common` package importable when the script
 # is run directly inside the Action workflow (no editable install).
@@ -64,6 +67,28 @@ STATUS_RE = re.compile(r"^RESOLVER_STATUS:\s*(changes|no_changes)\s*$", re.MULTI
 SUMMARY_RE = re.compile(r"^RESOLVER_SUMMARY:\s*(.+?)\s*$", re.MULTILINE)
 REASON_RE = re.compile(r"^RESOLVER_REASON:\s*(.+?)\s*$", re.MULTILINE)
 BRANCH_PREFIX = "gptme-resolver/issue-"
+RESOLVER_TOOL_ALLOWLIST = "read,save,patch,shell"
+READONLY_GIT_SUBCOMMANDS = (
+    "blame",
+    "cat-file",
+    "describe",
+    "diff",
+    "grep",
+    "log",
+    "ls-files",
+    "rev-parse",
+    "show",
+    "status",
+    "symbolic-ref",
+)
+BLOCKED_AGENT_ENV_VARS = (
+    "GH_ENTERPRISE_TOKEN",
+    "GH_TOKEN",
+    "GITHUB_TOKEN",
+    "GIT_ASKPASS",
+    "GIT_SSH_COMMAND",
+    "SSH_AUTH_SOCK",
+)
 
 
 @dataclass
@@ -72,6 +97,12 @@ class ResolverOutcome:
     summary: str
     branch: str | None
     pr_url: str | None
+
+
+@dataclass(frozen=True)
+class RepoState:
+    head: str
+    branch: str | None
 
 
 def git(args: list[str], *, check: bool = True, cwd: Path | None = None) -> str:
@@ -97,18 +128,29 @@ def run_gptme(
     prompt: str, *, model: str | None = None, workdir: Path
 ) -> tuple[str, str]:
     """Invoke gptme non-interactively. Fail soft: return (stdout, stderr)."""
-    cmd = ["gptme", "--non-interactive", "--no-confirm", "-"]
+    cmd = [
+        "gptme",
+        "--non-interactive",
+        "--no-confirm",
+        "--tools",
+        RESOLVER_TOOL_ALLOWLIST,
+    ]
     if model:
         cmd.extend(["--model", model])
+    cmd.append("-")
     try:
-        result = subprocess.run(
-            cmd,
-            input=prompt,
-            capture_output=True,
-            text=True,
-            check=False,
-            cwd=workdir,
-        )
+        with tempfile.TemporaryDirectory(prefix="gptme-resolver-shims-") as shim_dir:
+            shim_path = Path(shim_dir)
+            write_resolver_command_shims(shim_path)
+            result = subprocess.run(
+                cmd,
+                input=prompt,
+                capture_output=True,
+                text=True,
+                check=False,
+                cwd=workdir,
+                env=build_agent_env(os.environ, shim_path),
+            )
     except FileNotFoundError:
         msg = "gptme not found on PATH; skipping resolver.\n"
         sys.stderr.write(msg)
@@ -141,8 +183,115 @@ def has_git_changes(cwd: Path) -> bool:
     return bool(out.strip())
 
 
+def current_branch(cwd: Path) -> str | None:
+    out = git(["symbolic-ref", "--quiet", "--short", "HEAD"], check=False, cwd=cwd)
+    branch = out.strip()
+    return branch or None
+
+
+def capture_repo_state(cwd: Path) -> RepoState:
+    return RepoState(
+        head=git(["rev-parse", "HEAD"], cwd=cwd).strip(),
+        branch=current_branch(cwd),
+    )
+
+
+def detect_repo_state_violation(before: RepoState, cwd: Path) -> str | None:
+    after = capture_repo_state(cwd)
+    violations: list[str] = []
+    if after.branch != before.branch:
+        before_branch = before.branch or "(detached HEAD)"
+        after_branch = after.branch or "(detached HEAD)"
+        violations.append(f"branch changed from {before_branch} to {after_branch}")
+    if after.head != before.head:
+        branch_desc = after.branch or before.branch or "(detached HEAD)"
+        violations.append(
+            f"HEAD moved from {before.head[:12]} to {after.head[:12]} on {branch_desc}"
+        )
+    if not violations:
+        return None
+    return (
+        "gptme mutated git state directly ("
+        + "; ".join(violations)
+        + "). The resolver agent must leave branch and history changes to the orchestrator."
+    )
+
+
 def branch_for_issue(issue_number: int) -> str:
     return f"{BRANCH_PREFIX}{issue_number}"
+
+
+def build_agent_env(
+    base_env: os._Environ[str] | dict[str, str], shim_dir: Path
+) -> dict[str, str]:
+    env = dict(base_env)
+    for key in BLOCKED_AGENT_ENV_VARS:
+        env.pop(key, None)
+    path_parts = [str(shim_dir)]
+    if env.get("PATH"):
+        path_parts.append(env["PATH"])
+    env["PATH"] = os.pathsep.join(path_parts)
+    return env
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content)
+    path.chmod(0o755)
+
+
+def write_resolver_command_shims(shim_dir: Path) -> None:
+    real_git = shutil.which("git")
+    if not real_git:
+        raise FileNotFoundError("git not found on PATH")
+    allowed_subcommands = "|".join(READONLY_GIT_SUBCOMMANDS)
+    _write_executable(
+        shim_dir / "git",
+        f"""#!/bin/sh
+set -eu
+subcmd="${{1:-}}"
+case "$subcmd" in
+  {allowed_subcommands})
+    exec {real_git} "$@"
+    ;;
+  *)
+    echo "gptme resolver blocked direct git command: git ${{subcmd:-<none>}}" >&2
+    exit 1
+    ;;
+esac
+""",
+    )
+    _write_executable(
+        shim_dir / "gh",
+        """#!/bin/sh
+echo "gptme resolver blocked direct GitHub CLI usage; the orchestrator owns PR and comment actions." >&2
+exit 1
+""",
+    )
+
+
+def github_push_url(repo: str, auth_token: str) -> str:
+    return f"https://x-access-token:{quote(auth_token, safe='')}@github.com/{repo}.git"
+
+
+def push_branch(
+    cwd: Path,
+    branch: str,
+    *,
+    repo: str | None = None,
+    auth_token: str | None = None,
+) -> None:
+    if auth_token and repo:
+        git(
+            [
+                "push",
+                "--force-with-lease",
+                github_push_url(repo, auth_token),
+                f"HEAD:refs/heads/{branch}",
+            ],
+            cwd=cwd,
+        )
+        return
+    git(["push", "--force-with-lease", "origin", branch], cwd=cwd)
 
 
 def commit_and_push(
@@ -150,6 +299,8 @@ def commit_and_push(
     branch: str,
     *,
     commit_message: str,
+    repo: str | None = None,
+    auth_token: str | None = None,
     author_name: str = "gptme-resolver",
     author_email: str = "gptme-resolver@users.noreply.github.com",
 ) -> None:
@@ -170,7 +321,19 @@ def commit_and_push(
         ],
         cwd=cwd,
     )
-    git(["push", "--force-with-lease", "origin", branch], cwd=cwd)
+    push_branch(cwd, branch, repo=repo, auth_token=auth_token)
+
+
+def push_existing_head(
+    cwd: Path,
+    branch: str,
+    *,
+    repo: str | None = None,
+    auth_token: str | None = None,
+) -> None:
+    """Preserve the current HEAD on ``branch`` without creating a new commit."""
+    git(["checkout", "-B", branch], cwd=cwd)
+    push_branch(cwd, branch, repo=repo, auth_token=auth_token)
 
 
 def open_draft_pr(repo: str, issue_number: int, branch: str, summary: str) -> str:
@@ -263,6 +426,8 @@ def main(argv: list[str] | None = None) -> int:
     issue = fetch_issue(args.repo, args.issue)
     template = args.prompt_file.read_text()
     prompt = render_prompt(template, repo=args.repo, issue=issue)
+    baseline_state = capture_repo_state(args.workdir)
+    auth_token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
 
     gptme_output, gptme_stderr = run_gptme(
         prompt, model=os.environ.get("GPTME_MODEL"), workdir=args.workdir
@@ -279,9 +444,22 @@ def main(argv: list[str] | None = None) -> int:
 
     branch = branch_for_issue(issue.number)
     pr_url: str | None = None
+    worktree_dirty = has_git_changes(args.workdir)
+    repo_state_violation = detect_repo_state_violation(baseline_state, args.workdir)
+    preserve_existing_head = (
+        repo_state_violation is not None
+        and capture_repo_state(args.workdir).head != baseline_state.head
+    )
+
+    if repo_state_violation is not None:
+        status = "error"
+        upstream_message = message
+        message = repo_state_violation
+        if upstream_message:
+            message = f"{message} Upstream result: {upstream_message}"
 
     # gptme said "changes" — but only trust it if git actually sees changes.
-    if status == "changes" and has_git_changes(args.workdir):
+    if status == "changes" and worktree_dirty:
         if args.dry_run:
             print(f"[dry-run] Would push {branch} and open draft PR: {message}")
             return 0
@@ -289,6 +467,8 @@ def main(argv: list[str] | None = None) -> int:
             args.workdir,
             branch,
             commit_message=f"gptme-resolver attempt for #{issue.number}\n\n{message}",
+            repo=args.repo,
+            auth_token=auth_token,
         )
         pr_url = open_draft_pr(args.repo, issue.number, branch, message)
         comment_on_issue(
@@ -303,27 +483,41 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     # gptme said "changes" but worktree is clean — treat as a failed attempt.
-    if status == "changes" and not has_git_changes(args.workdir):
+    if status == "changes" and not worktree_dirty:
         status = "error"
         message = (
             "gptme reported changes but no files were modified. "
             f"Upstream message: {message}"
         )
 
-    # no_changes / error: preserve partial work if present.
+    # no_changes / error: preserve partial work if present, including an
+    # unsolicited direct commit that moved HEAD but left the worktree clean.
     partial_branch: str | None = None
-    if has_git_changes(args.workdir):
+    if worktree_dirty or preserve_existing_head:
         if args.dry_run:
-            print(f"[dry-run] Would push partial attempt to {branch}")
-        else:
-            commit_and_push(
-                args.workdir,
-                branch,
-                commit_message=(
-                    f"gptme-resolver partial attempt for #{issue.number}\n\n"
-                    f"Status: {status}\n\n{message}"
-                ),
+            action = (
+                "push partial attempt" if worktree_dirty else "preserve mutated HEAD"
             )
+            print(f"[dry-run] Would {action} on {branch}")
+        else:
+            if worktree_dirty:
+                commit_and_push(
+                    args.workdir,
+                    branch,
+                    commit_message=(
+                        f"gptme-resolver partial attempt for #{issue.number}\n\n"
+                        f"Status: {status}\n\n{message}"
+                    ),
+                    repo=args.repo,
+                    auth_token=auth_token,
+                )
+            else:
+                push_existing_head(
+                    args.workdir,
+                    branch,
+                    repo=args.repo,
+                    auth_token=auth_token,
+                )
             partial_branch = branch
 
     if args.dry_run:

--- a/scripts/github_resolver/resolve_issue.py
+++ b/scripts/github_resolver/resolve_issue.py
@@ -248,7 +248,31 @@ def write_resolver_command_shims(shim_dir: Path) -> None:
         shim_dir / "git",
         f"""#!/bin/sh
 set -eu
-subcmd="${{1:-}}"
+# Find the real subcommand by skipping any global flags that appear before it.
+# Single-arg flags (--no-pager, --bare, -P, etc.) are skipped as-is.
+# Two-arg flags (-C <path>, -c <key=val>, --git-dir <path>, --work-tree <path>)
+# consume the following token as their value.
+subcmd=""
+skip_next=0
+for arg in "$@"; do
+  if [ "$skip_next" -eq 1 ]; then
+    skip_next=0
+    continue
+  fi
+  case "$arg" in
+    -C|-c|--git-dir|--work-tree|--namespace|--super-prefix|--exec-path)
+      skip_next=1
+      continue
+      ;;
+    --*|-*)
+      continue
+      ;;
+    *)
+      subcmd="$arg"
+      break
+      ;;
+  esac
+done
 case "$subcmd" in
   {allowed_subcommands})
     exec {real_git} "$@"

--- a/scripts/github_resolver/test_resolve_issue.py
+++ b/scripts/github_resolver/test_resolve_issue.py
@@ -11,6 +11,8 @@ wrappers exercised in the staged rollout, not in unit tests.
 from __future__ import annotations
 
 import json
+import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -171,3 +173,291 @@ def test_open_draft_pr_retrigger_returns_existing_url(monkeypatch):
     assert url == "https://github.com/gptme/gptme-contrib/pull/99"
     # Verify we fell back to `gh pr view`
     assert any(a[0] == "pr" and a[1] == "view" for a in calls)
+
+
+def test_run_gptme_uses_restricted_tools_and_sanitized_env(monkeypatch, tmp_path):
+    captured: dict[str, object] = {}
+    shim_root = tmp_path / "shims"
+    shim_root.mkdir()
+
+    class FakeResult:
+        returncode = 0
+        stdout = "ok"
+        stderr = ""
+
+    class FakeTemporaryDirectory:
+        def __init__(self, *args, **kwargs):
+            del args, kwargs
+
+        def __enter__(self):
+            return str(shim_root)
+
+        def __exit__(self, exc_type, exc, tb):
+            del exc_type, exc, tb
+            return False
+
+    def fake_run(*args, **kwargs):
+        captured["args"] = args[0]
+        captured["env"] = kwargs["env"]
+        captured["cwd"] = kwargs["cwd"]
+        return FakeResult()
+
+    monkeypatch.setenv("GH_TOKEN", "gh-secret")
+    monkeypatch.setenv("GITHUB_TOKEN", "github-secret")
+    monkeypatch.setenv("PATH", "/usr/bin")
+    monkeypatch.setattr(resolve_issue.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        resolve_issue.tempfile, "TemporaryDirectory", FakeTemporaryDirectory
+    )
+
+    stdout, stderr = resolve_issue.run_gptme(
+        "prompt", model="claude-sonnet", workdir=tmp_path
+    )
+
+    assert stdout == "ok"
+    assert stderr == ""
+    assert captured["args"] == [
+        "gptme",
+        "--non-interactive",
+        "--no-confirm",
+        "--tools",
+        resolve_issue.RESOLVER_TOOL_ALLOWLIST,
+        "--model",
+        "claude-sonnet",
+        "-",
+    ]
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert "GH_TOKEN" not in env
+    assert "GITHUB_TOKEN" not in env
+    assert Path(env["PATH"].split(os.pathsep)[0]) == shim_root
+    assert (shim_root / "git").exists()
+    assert (shim_root / "gh").exists()
+    assert captured["cwd"] == tmp_path
+
+
+def test_detect_repo_state_violation_on_unexpected_commit(tmp_path):
+    subprocess.run(["git", "init", "-q", "-b", "master"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "config", "user.name", "resolver-test"], cwd=tmp_path, check=True
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "resolver-test@example.com"],
+        cwd=tmp_path,
+        check=True,
+    )
+    (tmp_path / "note.txt").write_text("old\n")
+    subprocess.run(["git", "add", "note.txt"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "-c", "core.hooksPath=/dev/null", "commit", "-q", "-m", "initial"],
+        cwd=tmp_path,
+        check=True,
+    )
+
+    baseline = resolve_issue.capture_repo_state(tmp_path)
+
+    (tmp_path / "note.txt").write_text("new\n")
+    subprocess.run(["git", "add", "note.txt"], cwd=tmp_path, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "core.hooksPath=/dev/null",
+            "commit",
+            "-q",
+            "-m",
+            "agent direct commit",
+        ],
+        cwd=tmp_path,
+        check=True,
+    )
+
+    violation = resolve_issue.detect_repo_state_violation(baseline, tmp_path)
+    assert violation is not None
+    assert "HEAD moved" in violation
+    assert "master" in violation
+    assert resolve_issue.has_git_changes(tmp_path) is False
+
+
+def test_push_branch_uses_explicit_github_token(monkeypatch, tmp_path):
+    calls: list[list[str]] = []
+
+    def fake_git(args, *, check=True, cwd=None):
+        del check
+        assert cwd == tmp_path
+        calls.append(args)
+        return ""
+
+    monkeypatch.setattr(resolve_issue, "git", fake_git)
+
+    resolve_issue.push_branch(
+        tmp_path,
+        "gptme-resolver/issue-42",
+        repo="gptme/gptme-contrib",
+        auth_token="token-123",
+    )
+
+    assert calls == [
+        [
+            "push",
+            "--force-with-lease",
+            "https://x-access-token:token-123@github.com/gptme/gptme-contrib.git",
+            "HEAD:refs/heads/gptme-resolver/issue-42",
+        ]
+    ]
+
+
+def test_main_preserves_direct_commit_as_partial_attempt(monkeypatch, tmp_path):
+    bare = tmp_path / "origin.git"
+    repo = tmp_path / "repo"
+    out_dir = tmp_path / "out"
+
+    subprocess.run(
+        ["git", "init", "--bare", str(bare)], check=True, stdout=subprocess.DEVNULL
+    )
+    subprocess.run(
+        ["git", "clone", str(bare), str(repo)], check=True, stdout=subprocess.DEVNULL
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "checkout", "-b", "master"],
+        check=True,
+        stdout=subprocess.DEVNULL,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.name", "resolver-test"], check=True
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.email", "resolver-test@example.com"],
+        check=True,
+    )
+    (repo / "note.txt").write_text("old\n")
+    subprocess.run(["git", "-C", str(repo), "add", "note.txt"], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "-c",
+            "core.hooksPath=/dev/null",
+            "commit",
+            "-q",
+            "-m",
+            "initial",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "-c",
+            "core.hooksPath=/dev/null",
+            "push",
+            "-u",
+            "origin",
+            "master",
+        ],
+        check=True,
+        stdout=subprocess.DEVNULL,
+    )
+
+    issue = resolve_issue.Issue(
+        number=42,
+        title="Fix note",
+        body="Update note",
+        author="alice",
+        labels=["bug"],
+    )
+    comments: list[str] = []
+
+    def fake_fetch_issue(repo_name, issue_number):
+        assert repo_name == "local/test"
+        assert issue_number == 42
+        return issue
+
+    def fake_run_gptme(prompt, *, model=None, workdir):
+        del prompt, model
+        (workdir / "note.txt").write_text("new\n")
+        subprocess.run(["git", "-C", str(workdir), "add", "note.txt"], check=True)
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(workdir),
+                "-c",
+                "core.hooksPath=/dev/null",
+                "commit",
+                "-q",
+                "-m",
+                "agent direct commit",
+            ],
+            check=True,
+        )
+        return ("RESOLVER_STATUS: changes\nRESOLVER_SUMMARY: Updated note.\n", "")
+
+    def fake_comment(repo_name, issue_number, body):
+        assert repo_name == "local/test"
+        assert issue_number == 42
+        comments.append(body)
+
+    def fail_gh(args, *, check=True):
+        del check
+        raise AssertionError(f"unsafe direct-commit path must not call gh: {args}")
+
+    monkeypatch.setattr(resolve_issue, "fetch_issue", fake_fetch_issue)
+    monkeypatch.setattr(resolve_issue, "run_gptme", fake_run_gptme)
+    monkeypatch.setattr(resolve_issue, "post_issue_comment", fake_comment)
+    monkeypatch.setattr(resolve_issue, "gh", fail_gh)
+
+    rc = resolve_issue.main(
+        [
+            "--repo",
+            "local/test",
+            "--issue",
+            "42",
+            "--workdir",
+            str(repo),
+            "--output-dir",
+            str(out_dir),
+        ]
+    )
+
+    assert rc == 0
+    assert len(comments) == 1
+    assert "mutated git state directly" in comments[0]
+    assert (
+        "Partial attempt preserved on branch `gptme-resolver/issue-42`." in comments[0]
+    )
+
+    refs = subprocess.run(
+        [
+            "git",
+            "--git-dir",
+            str(bare),
+            "for-each-ref",
+            "--format=%(refname:short)",
+            "refs/heads",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.splitlines()
+    assert "master" in refs
+    assert "gptme-resolver/issue-42" in refs
+
+    branch_head = subprocess.run(
+        [
+            "git",
+            "--git-dir",
+            str(bare),
+            "log",
+            "--oneline",
+            "gptme-resolver/issue-42",
+            "-1",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert "agent direct commit" in branch_head

--- a/scripts/github_resolver/test_resolve_issue.py
+++ b/scripts/github_resolver/test_resolve_issue.py
@@ -409,6 +409,10 @@ def test_main_preserves_direct_commit_as_partial_attempt(monkeypatch, tmp_path):
     monkeypatch.setattr(resolve_issue, "run_gptme", fake_run_gptme)
     monkeypatch.setattr(resolve_issue, "post_issue_comment", fake_comment)
     monkeypatch.setattr(resolve_issue, "gh", fail_gh)
+    # Prevent GitHub Actions' auto-injected GITHUB_TOKEN / GH_TOKEN from
+    # routing push_branch to the real GitHub instead of the local bare repo.
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
 
     rc = resolve_issue.main(
         [


### PR DESCRIPTION
## Summary
- restrict resolver runs to `read,save,patch,shell`, strip GitHub/SSH credential env, and shim `git`/`gh` so the agent cannot commit, push, or comment directly
- disable persisted checkout credentials and make orchestrator pushes use explicit token auth
- fail closed if the agent still moves HEAD or switches branches, preserving the result on the attempt branch instead of trusting a clean worktree
- add unit coverage for env/tool restriction, git-state violation detection, tokenized pushes, and the direct-commit partial-attempt path

## Verification
- `uv run pytest /home/bob/bob/gptme-contrib/scripts/github_resolver/test_resolve_issue.py -q`
- `uv run ruff check /home/bob/bob/gptme-contrib/scripts/github_resolver/resolve_issue.py /home/bob/bob/gptme-contrib/scripts/github_resolver/test_resolve_issue.py`
- `uv run mypy /home/bob/bob/gptme-contrib/scripts/github_resolver/resolve_issue.py /home/bob/bob/gptme-contrib/scripts/github_resolver/test_resolve_issue.py`