### PR TITLE
fix(news): drop empty keywords in trending --filter parsing

### DIFF
--- a/scripts/fetch-github-trending.py
+++ b/scripts/fetch-github-trending.py
@@ -112,6 +112,21 @@ def parse_trending(html: str) -> list[dict]:
     return repos
 
 
+def parse_keywords(filter_arg: str | None) -> list[str] | None:
+    """Parse a comma-separated --filter argument into a keyword list.
+
+    Drops empty/whitespace-only entries so a trailing or doubled comma
+    (e.g. "agent,") does not inject an empty-string keyword. An empty string
+    is a substring of every text, which would silently match all repos and
+    disable filtering. Returns None when there are no usable keywords (filter
+    unset or all entries empty), matching the "no filter" sentinel.
+    """
+    if not filter_arg:
+        return None
+    keywords = [k.strip() for k in filter_arg.split(",") if k.strip()]
+    return keywords or None
+
+
 def format_compact(repos: list[dict], keywords: list[str] | None = None) -> str:
     """Format repos in compact format.
 
@@ -177,7 +192,7 @@ def main() -> None:
         )
         sys.exit(1)
 
-    keywords = [k.strip() for k in args.filter.split(",")] if args.filter else None
+    keywords = parse_keywords(args.filter)
 
     if args.json:
         filtered = repos

--- a/tests/test_fetch_github_trending.py
+++ b/tests/test_fetch_github_trending.py
@@ -1,0 +1,90 @@
+"""Tests for scripts/fetch-github-trending.py keyword parsing/filtering.
+
+Focus: parse_keywords() drops empty entries so a trailing/doubled comma in
+--filter does not silently disable filtering (an empty string is a substring
+of every text and would match all repos).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPT = REPO_ROOT / "scripts" / "fetch-github-trending.py"
+_spec = importlib.util.spec_from_file_location("fetch_github_trending", _SCRIPT)
+assert _spec is not None and _spec.loader is not None
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+parse_keywords = _mod.parse_keywords
+format_compact = _mod.format_compact
+
+
+REPO_AGENT = {
+    "name": "foo/agent-thing",
+    "description": "an llm agent",
+    "language": "Python",
+    "stars": 10,
+    "today_stars": 1,
+    "url": "https://github.com/foo/agent-thing",
+}
+REPO_WEB = {
+    "name": "bar/web-app",
+    "description": "a website",
+    "language": "JavaScript",
+    "stars": 20,
+    "today_stars": 2,
+    "url": "https://github.com/bar/web-app",
+}
+
+
+class TestParseKeywords:
+    def test_none_arg_returns_none(self) -> None:
+        assert parse_keywords(None) is None
+
+    def test_empty_string_returns_none(self) -> None:
+        assert parse_keywords("") is None
+
+    def test_single_keyword(self) -> None:
+        assert parse_keywords("agent") == ["agent"]
+
+    def test_multiple_keywords(self) -> None:
+        assert parse_keywords("agent,llm") == ["agent", "llm"]
+
+    def test_strips_whitespace(self) -> None:
+        assert parse_keywords(" agent , llm ") == ["agent", "llm"]
+
+    def test_trailing_comma_dropped(self) -> None:
+        # The bug: "agent," previously produced ["agent", ""]
+        assert parse_keywords("agent,") == ["agent"]
+
+    def test_doubled_comma_dropped(self) -> None:
+        assert parse_keywords("agent,,llm") == ["agent", "llm"]
+
+    def test_all_empty_returns_none(self) -> None:
+        # "," or ",," has no usable keywords -> no filter
+        assert parse_keywords(",") is None
+        assert parse_keywords(" , ") is None
+
+
+class TestFilterRegression:
+    """End-to-end: a trailing comma must not match every repo."""
+
+    def test_trailing_comma_does_not_match_all(self) -> None:
+        keywords = parse_keywords("agent,")
+        out = format_compact([REPO_AGENT, REPO_WEB], keywords)
+        assert "foo/agent-thing" in out
+        assert "bar/web-app" not in out
+
+    def test_real_filter_still_works(self) -> None:
+        keywords = parse_keywords("website")
+        out = format_compact([REPO_AGENT, REPO_WEB], keywords)
+        assert "bar/web-app" in out
+        assert "foo/agent-thing" not in out
+
+    def test_all_empty_filter_shows_all(self) -> None:
+        keywords = parse_keywords(",")
+        out = format_compact([REPO_AGENT, REPO_WEB], keywords)
+        assert "foo/agent-thing" in out
+        assert "bar/web-app" in out


### PR DESCRIPTION
## Problem

`fetch-github-trending.py --filter "agent,"` (trailing comma) — or any doubled comma — silently matched **every** repo instead of filtering. The keyword list was built with `[k.strip() for k in args.filter.split(",")]`, so a trailing/doubled comma injected an empty-string keyword. Since `"" in text` is always `True`, the filter degenerated to a match-all, misleading a news-consumption session into thinking everything matched.

## Fix

Extract `parse_keywords()` which drops empty/whitespace-only entries and returns `None` when no usable keywords remain (matching the existing "no filter" sentinel). Single construction point, so both the compact and `--json` output paths are fixed.

## Reproduction (before)

```
--filter "agent,"  ->  keywords = ["agent", ""]  ->  matches ALL repos
```

## Tests

New `tests/test_fetch_github_trending.py`:
- `parse_keywords` unit tests (trailing comma, doubled comma, whitespace, all-empty → None)
- end-to-end regression: `--filter "agent,"` no longer matches non-agent repos

11 passed; ruff check + format clean.