### PR TITLE
feat(sessions): extract span_aggregates for codex trajectories

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -365,7 +365,8 @@ class SessionRecord:
 
         Chooses the extractor based on ``harness_hint`` (or ``self.harness``
         when not given): ``"claude-code"`` → CC JSONL, ``"gptme"`` → gptme
-        JSONL. Stores ``SpanAggregates.from_spans(...)`` serialized as a dict
+        JSONL, ``"codex"`` → codex rollout JSONL. Stores
+        ``SpanAggregates.from_spans(...)`` serialized as a dict
         on ``self.span_aggregates`` (including the computed ``error_rate``).
 
         Returns ``True`` when aggregates were populated, ``False`` when the
@@ -377,6 +378,7 @@ class SessionRecord:
         from gptme_sessions.spans import (
             SpanAggregates,
             extract_spans_from_cc_jsonl,
+            extract_spans_from_codex_jsonl,
             extract_spans_from_gptme_jsonl,
         )
 
@@ -391,6 +393,8 @@ class SessionRecord:
             spans = extract_spans_from_cc_jsonl(traj, session_id=self.session_id)
         elif harness == "gptme":
             spans = extract_spans_from_gptme_jsonl(traj, session_id=self.session_id)
+        elif harness == "codex":
+            spans = extract_spans_from_codex_jsonl(traj, session_id=self.session_id)
         else:
             return False
 

--- a/packages/gptme-sessions/src/gptme_sessions/spans.py
+++ b/packages/gptme-sessions/src/gptme_sessions/spans.py
@@ -450,8 +450,8 @@ _CODEX_TURN_MARKERS = {"reasoning", "agent_message", "message"}
 
 def _codex_exec_exit_code(output: str) -> int | None:
     """Exit code from a codex ``exec_command`` plaintext output, if annotated."""
-    m = _CODEX_EXIT_CODE_RE.search(output)
-    return int(m.group(1)) if m else None
+    matches = _CODEX_EXIT_CODE_RE.findall(output)
+    return int(matches[-1]) if matches else None
 
 
 def _codex_custom_exit_code(output: str) -> int | None:

--- a/packages/gptme-sessions/src/gptme_sessions/spans.py
+++ b/packages/gptme-sessions/src/gptme_sessions/spans.py
@@ -5,7 +5,7 @@ timing, input/output sizes, and success recorded. Sessions produce
 sequences of spans that tell the per-turn story of what the agent did
 and how long each operation took.
 
-Supports Claude Code and gptme JSONL formats.
+Supports Claude Code, gptme, and codex JSONL formats.
 
 Design doc: knowledge/technical-designs/span-level-tracing-design.md
 """
@@ -20,6 +20,10 @@ from datetime import datetime
 from pathlib import Path
 
 _EXIT_CODE_RE = re.compile(r"(?:Exit code|exit code):\s*(\d+)")
+
+# codex exec_command annotates the subprocess exit in its plaintext output as
+# "Process exited with code N".
+_CODEX_EXIT_CODE_RE = re.compile(r"Process exited with code (\d+)")
 
 # gptme tool-use marker: `@tool_name(call-UUID-N): {json_args}` at the start
 # of a line. Args may be absent (e.g. `@todo(call-...-4): {}`).
@@ -421,6 +425,162 @@ def extract_spans_from_gptme_jsonl(
                 success = exit_code == 0
             else:
                 success = not _gptme_is_error_result(content)
+
+            spans.append(
+                ToolSpan(
+                    span_id=str(uuid.uuid4()),
+                    session_id=session_id,
+                    tool_name=tool_name,
+                    timestamp=dispatch_ts_str,
+                    duration_ms=dur_ms,
+                    success=success,
+                    input_size=isize,
+                    output_size=osize,
+                    exit_code=exit_code,
+                    turn_index=tidx,
+                )
+            )
+
+    return spans
+
+
+# codex payload types that mark a model "turn" boundary between tool dispatches.
+_CODEX_TURN_MARKERS = {"reasoning", "agent_message", "message"}
+
+
+def _codex_exec_exit_code(output: str) -> int | None:
+    """Exit code from a codex ``exec_command`` plaintext output, if annotated."""
+    m = _CODEX_EXIT_CODE_RE.search(output)
+    return int(m.group(1)) if m else None
+
+
+def _codex_custom_exit_code(output: str) -> int | None:
+    """Exit code from a codex ``custom_tool_call_output`` JSON metadata, if present.
+
+    The output is a JSON string shaped like
+    ``{"output": "...", "metadata": {"exit_code": 0, "duration_seconds": 0.0}}``.
+    Returns None when the payload isn't JSON or carries no integer exit code.
+    """
+    try:
+        parsed = json.loads(output)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    meta = parsed.get("metadata")
+    if not isinstance(meta, dict):
+        return None
+    code = meta.get("exit_code")
+    return code if isinstance(code, int) else None
+
+
+def extract_spans_from_codex_jsonl(
+    path: Path | str,
+    session_id: str | None = None,
+) -> list[ToolSpan]:
+    """Extract ToolSpan objects from a codex ``rollout-*.jsonl`` trajectory.
+
+    codex records tool use as ``response_item`` envelopes. Regular tools
+    (``exec_command``, ``write_stdin``, MCP calls) appear as
+    ``payload.type == "function_call"`` paired with ``function_call_output`` by
+    ``call_id``; patch edits appear as ``custom_tool_call`` paired with
+    ``custom_tool_call_output``. Success is read from the subprocess exit code
+    annotated in the output (``Process exited with code N`` for exec, or
+    ``metadata.exit_code`` for custom tools); calls with no exit annotation are
+    treated as successful absent an error signal.
+
+    Args:
+        path: Path to the codex ``rollout-*.jsonl`` file.
+        session_id: Session ID to assign to all spans. Defaults to the
+            filename stem.
+
+    Returns:
+        List of spans in chronological dispatch order.
+    """
+    path = Path(path)
+    if session_id is None:
+        session_id = path.stem
+
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+
+    # pending maps call_id → (tool_name, dispatch_ts, dispatch_ts_str,
+    #                         input_size, turn_index, is_custom)
+    pending: dict[str, tuple[str, datetime | None, str, int, int, bool]] = {}
+    spans: list[ToolSpan] = []
+    turn_index = 0
+    new_turn = False  # set by a turn marker; the next dispatch opens a new turn
+
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        if record.get("type") != "response_item":
+            continue
+        payload = record.get("payload")
+        if not isinstance(payload, dict):
+            continue
+        ptype = payload.get("type")
+        ts_str = record.get("timestamp", "")
+        ts = _parse_ts(ts_str)
+
+        if ptype in _CODEX_TURN_MARKERS:
+            new_turn = True
+            continue
+
+        if ptype in ("function_call", "custom_tool_call"):
+            call_id = payload.get("call_id", "")
+            if not call_id:
+                continue
+            tool_name = payload.get("name", "unknown")
+            is_custom = ptype == "custom_tool_call"
+            if is_custom:
+                isize = len(str(payload.get("input", "")))
+            else:
+                args_raw = payload.get("arguments", "")
+                try:
+                    args = json.loads(args_raw) if args_raw else {}
+                except (json.JSONDecodeError, TypeError):
+                    args = args_raw
+                isize = _input_size(args)
+            # A dispatch following a reasoning/message marker opens a new model
+            # turn; the very first dispatch stays at turn 0.
+            if new_turn:
+                turn_index += 1
+                new_turn = False
+            pending[call_id] = (tool_name, ts, ts_str, isize, turn_index, is_custom)
+
+        elif ptype in ("function_call_output", "custom_tool_call_output"):
+            call_id = payload.get("call_id", "")
+            if call_id not in pending:
+                continue
+            tool_name, dispatch_ts, dispatch_ts_str, isize, tidx, is_custom = pending.pop(call_id)
+            output = payload.get("output", "")
+            output_str = output if isinstance(output, str) else str(output)
+            osize = len(output_str)
+
+            if is_custom:
+                exit_code = _codex_custom_exit_code(output_str)
+            else:
+                exit_code = _codex_exec_exit_code(output_str)
+            # Missing exit annotation (MCP calls, plan updates) => no error signal.
+            success = exit_code in (None, 0)
+
+            dur_ms = -1
+            if dispatch_ts is not None and ts is not None:
+                try:
+                    delta = (ts - dispatch_ts).total_seconds()
+                    if delta >= 0:
+                        dur_ms = int(delta * 1000)
+                except TypeError:
+                    pass  # mixed tz-aware/naive timestamps – leave sentinel
 
             spans.append(
                 ToolSpan(

--- a/packages/gptme-sessions/tests/test_spans.py
+++ b/packages/gptme-sessions/tests/test_spans.py
@@ -11,6 +11,7 @@ from gptme_sessions.spans import (
     SpanAggregates,
     ToolSpan,
     extract_spans_from_cc_jsonl,
+    extract_spans_from_codex_jsonl,
     extract_spans_from_gptme_jsonl,
 )
 
@@ -561,3 +562,229 @@ def test_gptme_malformed_lines_skipped(tmp_path: Path) -> None:
     p.write_text("not json\n{}\n")
     spans = extract_spans_from_gptme_jsonl(p)
     assert spans == []
+
+
+# ── codex rollout JSONL fixtures ──────────────────────────────────────────────
+
+
+def _codex_function_call(name: str, call_id: str, args: dict, ts: str) -> dict:
+    return {
+        "timestamp": ts,
+        "type": "response_item",
+        "payload": {
+            "type": "function_call",
+            "name": name,
+            "arguments": json.dumps(args),
+            "call_id": call_id,
+        },
+    }
+
+
+def _codex_function_output(call_id: str, output: str, ts: str) -> dict:
+    return {
+        "timestamp": ts,
+        "type": "response_item",
+        "payload": {
+            "type": "function_call_output",
+            "call_id": call_id,
+            "output": output,
+        },
+    }
+
+
+def _codex_custom_call(name: str, call_id: str, tool_input: str, ts: str) -> dict:
+    return {
+        "timestamp": ts,
+        "type": "response_item",
+        "payload": {
+            "type": "custom_tool_call",
+            "status": "completed",
+            "name": name,
+            "input": tool_input,
+            "call_id": call_id,
+        },
+    }
+
+
+def _codex_custom_output(call_id: str, exit_code: int, ts: str, output_text: str = "ok") -> dict:
+    payload_output = json.dumps(
+        {"output": output_text, "metadata": {"exit_code": exit_code, "duration_seconds": 0.0}}
+    )
+    return {
+        "timestamp": ts,
+        "type": "response_item",
+        "payload": {
+            "type": "custom_tool_call_output",
+            "call_id": call_id,
+            "output": payload_output,
+        },
+    }
+
+
+def _codex_reasoning(ts: str) -> dict:
+    return {"timestamp": ts, "type": "response_item", "payload": {"type": "reasoning"}}
+
+
+# ── extract_spans_from_codex_jsonl ────────────────────────────────────────────
+
+
+def test_codex_single_exec_span(tmp_path: Path) -> None:
+    records = [
+        _codex_function_call(
+            "exec_command", "c1", {"cmd": "git status"}, "2026-05-27T10:00:00+00:00"
+        ),
+        _codex_function_output(
+            "c1", "Output:\nclean\nProcess exited with code 0\n", "2026-05-27T10:00:01+00:00"
+        ),
+    ]
+    p = _write_jsonl(tmp_path, records, name="rollout-x.jsonl")
+    spans = extract_spans_from_codex_jsonl(p)
+
+    assert len(spans) == 1
+    s = spans[0]
+    assert s.tool_name == "exec_command"
+    assert s.session_id == "rollout-x"
+    assert s.duration_ms == 1000
+    assert s.success is True
+    assert s.exit_code == 0
+    assert s.turn_index == 0
+
+
+def test_codex_exec_nonzero_exit_is_error(tmp_path: Path) -> None:
+    records = [
+        _codex_function_call("exec_command", "c1", {"cmd": "false"}, "2026-05-27T10:00:00+00:00"),
+        _codex_function_output("c1", "Process exited with code 2\n", "2026-05-27T10:00:00+00:00"),
+    ]
+    p = _write_jsonl(tmp_path, records, name="rollout-x.jsonl")
+    spans = extract_spans_from_codex_jsonl(p)
+
+    assert len(spans) == 1
+    assert spans[0].success is False
+    assert spans[0].exit_code == 2
+
+
+def test_codex_no_exit_annotation_is_success(tmp_path: Path) -> None:
+    """MCP / plan tools carry no exit annotation — treat as success absent a signal."""
+    records = [
+        _codex_function_call("_fetch_pr", "c1", {"number": 5}, "2026-05-27T10:00:00+00:00"),
+        _codex_function_output("c1", '{"title": "some PR"}', "2026-05-27T10:00:01+00:00"),
+    ]
+    p = _write_jsonl(tmp_path, records, name="rollout-x.jsonl")
+    spans = extract_spans_from_codex_jsonl(p)
+
+    assert len(spans) == 1
+    assert spans[0].tool_name == "_fetch_pr"
+    assert spans[0].success is True
+    assert spans[0].exit_code is None
+
+
+def test_codex_custom_tool_apply_patch(tmp_path: Path) -> None:
+    records = [
+        _codex_custom_call(
+            "apply_patch", "c1", "*** Begin Patch\n...\n", "2026-05-27T10:00:00+00:00"
+        ),
+        _codex_custom_output("c1", 0, "2026-05-27T10:00:00.2+00:00"),
+    ]
+    p = _write_jsonl(tmp_path, records, name="rollout-x.jsonl")
+    spans = extract_spans_from_codex_jsonl(p)
+
+    assert len(spans) == 1
+    s = spans[0]
+    assert s.tool_name == "apply_patch"
+    assert s.success is True
+    assert s.exit_code == 0
+    assert s.input_size > 0
+
+
+def test_codex_custom_tool_nonzero_exit_is_error(tmp_path: Path) -> None:
+    records = [
+        _codex_custom_call("apply_patch", "c1", "bad patch", "2026-05-27T10:00:00+00:00"),
+        _codex_custom_output("c1", 1, "2026-05-27T10:00:01+00:00", output_text="patch failed"),
+    ]
+    p = _write_jsonl(tmp_path, records, name="rollout-x.jsonl")
+    spans = extract_spans_from_codex_jsonl(p)
+
+    assert len(spans) == 1
+    assert spans[0].success is False
+    assert spans[0].exit_code == 1
+
+
+def test_codex_turn_index_increments_on_reasoning(tmp_path: Path) -> None:
+    """A reasoning marker between dispatches opens a new model turn."""
+    records = [
+        _codex_function_call("exec_command", "c1", {"cmd": "a"}, "2026-05-27T10:00:00+00:00"),
+        _codex_function_output("c1", "Process exited with code 0\n", "2026-05-27T10:00:01+00:00"),
+        _codex_reasoning("2026-05-27T10:00:02+00:00"),
+        _codex_function_call("exec_command", "c2", {"cmd": "b"}, "2026-05-27T10:00:03+00:00"),
+        _codex_function_output("c2", "Process exited with code 0\n", "2026-05-27T10:00:04+00:00"),
+    ]
+    p = _write_jsonl(tmp_path, records, name="rollout-x.jsonl")
+    spans = extract_spans_from_codex_jsonl(p)
+
+    assert len(spans) == 2
+    assert spans[0].turn_index == 0
+    assert spans[1].turn_index == 1
+
+
+def test_codex_consecutive_calls_same_turn(tmp_path: Path) -> None:
+    """Back-to-back dispatches with no reasoning marker stay in the same turn."""
+    records = [
+        _codex_function_call("exec_command", "c1", {"cmd": "a"}, "2026-05-27T10:00:00+00:00"),
+        _codex_function_call("exec_command", "c2", {"cmd": "b"}, "2026-05-27T10:00:00+00:00"),
+        _codex_function_output("c1", "Process exited with code 0\n", "2026-05-27T10:00:01+00:00"),
+        _codex_function_output("c2", "Process exited with code 0\n", "2026-05-27T10:00:01+00:00"),
+    ]
+    p = _write_jsonl(tmp_path, records, name="rollout-x.jsonl")
+    spans = extract_spans_from_codex_jsonl(p)
+
+    assert len(spans) == 2
+    assert spans[0].turn_index == spans[1].turn_index == 0
+
+
+def test_codex_timestamp_is_dispatch_time(tmp_path: Path) -> None:
+    dispatch_ts = "2026-05-27T10:00:00+00:00"
+    arrival_ts = "2026-05-27T10:00:05+00:00"
+    records = [
+        _codex_function_call("exec_command", "c1", {"cmd": "sleep 5"}, dispatch_ts),
+        _codex_function_output("c1", "Process exited with code 0\n", arrival_ts),
+    ]
+    p = _write_jsonl(tmp_path, records, name="rollout-x.jsonl")
+    spans = extract_spans_from_codex_jsonl(p)
+
+    assert spans[0].timestamp == dispatch_ts
+    assert spans[0].duration_ms == 5000
+
+
+def test_codex_unpaired_call_not_emitted(tmp_path: Path) -> None:
+    records = [
+        _codex_function_call("exec_command", "c1", {"cmd": "a"}, "2026-05-27T10:00:00+00:00"),
+    ]
+    p = _write_jsonl(tmp_path, records, name="rollout-x.jsonl")
+    spans = extract_spans_from_codex_jsonl(p)
+    assert spans == []
+
+
+def test_codex_session_id_override(tmp_path: Path) -> None:
+    records = [
+        _codex_function_call("exec_command", "c1", {"cmd": "a"}, "2026-05-27T10:00:00+00:00"),
+        _codex_function_output("c1", "Process exited with code 0\n", "2026-05-27T10:00:01+00:00"),
+    ]
+    p = _write_jsonl(tmp_path, records, name="rollout-x.jsonl")
+    spans = extract_spans_from_codex_jsonl(p, session_id="custom-codex-id")
+    assert spans[0].session_id == "custom-codex-id"
+
+
+def test_codex_empty_file(tmp_path: Path) -> None:
+    p = tmp_path / "rollout-empty.jsonl"
+    p.write_text("")
+    assert extract_spans_from_codex_jsonl(p) == []
+
+
+def test_codex_missing_file() -> None:
+    assert extract_spans_from_codex_jsonl(Path("/nonexistent/rollout-x.jsonl")) == []
+
+
+def test_codex_malformed_lines_skipped(tmp_path: Path) -> None:
+    p = tmp_path / "rollout-bad.jsonl"
+    p.write_text('not json\n{}\n{"type": "event_msg"}\n')
+    assert extract_spans_from_codex_jsonl(p) == []


### PR DESCRIPTION
## Why

The 2026-05-27 tier-routing audit found that **codex sessions emit zero `span_aggregates`** — 0/1814 all-time, vs claude-code 680/2066 and gptme 430/704. This made ~14–22% of discretionary harness routing **tier-invisible**: codex work collapsed into the `unknown` tier and could not be compared in `scripts/model-routing-tier-audit.py`. The AgentFloor cost lever (offload cheaper-tier work to cheaper models) can't be evaluated while codex tool-use is uninstrumented.

## What

- Add `extract_spans_from_codex_jsonl()` in `gptme_sessions/spans.py`, mirroring the existing CC and gptme extractors.
  - Parses codex `rollout-*.jsonl` `response_item` envelopes:
    - `function_call` / `function_call_output` (`exec_command`, `write_stdin`, MCP tools), paired by `call_id`
    - `custom_tool_call` / `custom_tool_call_output` (`apply_patch`), paired by `call_id`
  - Success from the annotated exit code: `Process exited with code N` for exec output, `metadata.exit_code` for custom-tool output. Calls with no exit annotation (MCP, plan updates) are treated as successful absent an error signal.
  - Turn boundaries advance on `reasoning` / `agent_message` / `message` markers.
- Wire `harness == "codex"` into `SessionRecord.populate_span_aggregates()`.

## Verification

- 12 new unit tests; full `test_spans.py` (48) and `test_record.py` (68) pass.
- End-to-end on a real rollout: 80 spans, dominant `exec_command`, `error_rate` 0.0375, tool_counts `{exec_command: 47, write_stdin: 27, apply_patch: 6}`.
- ruff + mypy clean on changed files (pre-existing `tomli` stub errors elsewhere are unrelated).

After merge + a writeback pass, codex sessions land in real routing tiers instead of `unknown`.

Ref: ErikBjare/bob task `codex-span-aggregates-instrumentation`; idea #220.