### PR TITLE
fix(sessions): merge codex trajectory_ref sidecar into SessionRecord before span aggregation

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/judge.py
+++ b/packages/gptme-sessions/src/gptme_sessions/judge.py
@@ -819,6 +819,25 @@ def write_alignment_grade(
     for record in records:
         if record.session_id != session_id:
             continue
+
+        # Merge trajectory_ref data (harness + trajectory_path) when missing
+        # from the stored record.  codex sessions in particular carry these
+        # fields only in the per-session trajectory_ref.json sidecar, not
+        # in the main JSONL store, so populate_span_aggregates() skips them
+        # unless we merge here.
+        if not record.trajectory_path or (not record.harness or record.harness == "unknown"):
+            traj_ref_path = sessions_dir / f"{session_id}.trajectory_ref.json"
+            if traj_ref_path.exists():
+                try:
+                    traj_ref = json.loads(traj_ref_path.read_text())
+                    if not record.trajectory_path and traj_ref.get("trajectory_path"):
+                        record.trajectory_path = traj_ref["trajectory_path"]
+                    backend = traj_ref.get("backend")
+                    if backend and (not record.harness or record.harness == "unknown"):
+                        record.harness = backend
+                except (json.JSONDecodeError, OSError):
+                    pass
+
         record.set_alignment_grade(
             normalized["score"],
             reason=normalized["reason"],

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -389,6 +389,11 @@ class SessionRecord:
             return False
 
         harness = harness_hint or self.harness
+        # Fallback: detect harness from trajectory path when harness is
+        # "unknown" (common for codex sessions where the trajectory_ref
+        # backend field doesn't flow into SessionRecord.harness).
+        if harness in ("unknown", None) and "/.codex/" in str(traj):
+            harness = "codex"
         if harness == "claude-code":
             spans = extract_spans_from_cc_jsonl(traj, session_id=self.session_id)
         elif harness == "gptme":

--- a/packages/gptme-sessions/tests/test_judge.py
+++ b/packages/gptme-sessions/tests/test_judge.py
@@ -934,6 +934,83 @@ class TestSessionRecordJudgeFields:
         updated = SessionStore(sessions_dir=tmp_path).load_all()[0]
         assert updated.grades["alignment"] == 0.5
 
+    def test_writeback_merges_trajectory_ref_for_codex(self, tmp_path: Path) -> None:
+        """write_alignment_grade merges harness+trajectory_path from trajectory_ref.json
+        when the stored record is missing them (codex path)."""
+        sess_id = "63ad2f94-e455-4ed6-b25f-6bdb87a9fca7"
+        traj_path = tmp_path / "codex-rollout.jsonl"
+        traj_path.write_text(
+            json.dumps(
+                {
+                    "timestamp": "2026-05-27T10:00:00+00:00",
+                    "type": "response_item",
+                    "payload": {
+                        "type": "function_call",
+                        "name": "exec_command",
+                        "arguments": json.dumps({"cmd": "echo hi"}),
+                        "call_id": "c1",
+                    },
+                }
+            )
+            + "\n"
+            + json.dumps(
+                {
+                    "timestamp": "2026-05-27T10:00:00+00:00",
+                    "type": "response_item",
+                    "payload": {
+                        "type": "function_call_output",
+                        "call_id": "c1",
+                        "output": "Process exited with code 0\n",
+                    },
+                }
+            )
+            + "\n"
+        )
+
+        # trajectory_ref sidecar (real shape from codex sessions)
+        traj_ref = {
+            "sentinel_uuid": "04a39d54-a200-41d5-9163-4d1dbc5a035d",
+            "session_id": sess_id,
+            "workspace_session_id": "dc23",
+            "backend": "codex",
+            "written_at": "2026-05-21T05:10:31.266993+00:00",
+            "trajectory_path": str(traj_path),
+        }
+        (tmp_path / f"{sess_id}.trajectory_ref.json").write_text(json.dumps(traj_ref))
+
+        # Stored record WITHOUT harness or trajectory_path (real codex post-backfill state)
+        store = SessionStore(sessions_dir=tmp_path)
+        record = SessionRecord(session_id=sess_id, outcome="productive")
+        store.append(record)
+
+        with (
+            patch(
+                "gptme_sessions.judge.judge_session",
+                return_value={
+                    "score": 0.74,
+                    "reason": "Real work shipped",
+                    "model": "openai-subscription/gpt-5.4",
+                },
+            ),
+        ):
+            result = judge_and_writeback(
+                text="session text",
+                category="code",
+                goals="ship useful work",
+                session_id=sess_id,
+                sessions_dir=tmp_path,
+                model="openai-subscription/gpt-5.4",
+            )
+
+        assert result["status"] == "ok"
+        updated = SessionStore(sessions_dir=tmp_path).load_all()[0]
+        assert updated.harness == "codex"
+        assert updated.trajectory_path == str(traj_path)
+        assert updated.span_aggregates is not None
+        assert updated.span_aggregates["total_spans"] == 1
+        assert updated.span_aggregates["dominant_tool"] == "exec_command"
+        assert updated.span_aggregates["error_rate"] == 0.0
+
     def test_judge_and_writeback_reports_missing_record(self, tmp_path: Path) -> None:
         with patch(
             "gptme_sessions.judge.judge_session",

--- a/packages/gptme-sessions/tests/test_record.py
+++ b/packages/gptme-sessions/tests/test_record.py
@@ -10,34 +10,6 @@ import pytest
 from gptme_sessions.record import HARM_CATEGORY_LABELS, SessionRecord, normalize_model
 
 
-def _write_codex_trajectory(tmp_path: Path) -> Path:
-    """Synthetic codex rollout JSONL: one exec_command call + successful output."""
-    records = [
-        {
-            "timestamp": "2026-05-27T10:00:00+00:00",
-            "type": "response_item",
-            "payload": {
-                "type": "function_call",
-                "name": "exec_command",
-                "arguments": json.dumps({"cmd": "echo hi"}),
-                "call_id": "c1",
-            },
-        },
-        {
-            "timestamp": "2026-05-27T10:00:01+00:00",
-            "type": "response_item",
-            "payload": {
-                "type": "function_call_output",
-                "call_id": "c1",
-                "output": "Process exited with code 0\n",
-            },
-        },
-    ]
-    p = tmp_path / "rollout.jsonl"
-    p.write_text("\n".join(json.dumps(r) for r in records) + "\n")
-    return p
-
-
 def test_context_tier_default():
     """context_tier defaults to None."""
     r = SessionRecord()

--- a/packages/gptme-sessions/tests/test_record.py
+++ b/packages/gptme-sessions/tests/test_record.py
@@ -10,6 +10,34 @@ import pytest
 from gptme_sessions.record import HARM_CATEGORY_LABELS, SessionRecord, normalize_model
 
 
+def _write_codex_trajectory(tmp_path: Path) -> Path:
+    """Synthetic codex rollout JSONL: one exec_command call + successful output."""
+    records = [
+        {
+            "timestamp": "2026-05-27T10:00:00+00:00",
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "exec_command",
+                "arguments": json.dumps({"cmd": "echo hi"}),
+                "call_id": "c1",
+            },
+        },
+        {
+            "timestamp": "2026-05-27T10:00:01+00:00",
+            "type": "response_item",
+            "payload": {
+                "type": "function_call_output",
+                "call_id": "c1",
+                "output": "Process exited with code 0\n",
+            },
+        },
+    ]
+    p = tmp_path / "rollout.jsonl"
+    p.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+    return p
+
+
 def test_context_tier_default():
     """context_tier defaults to None."""
     r = SessionRecord()
@@ -432,6 +460,38 @@ def _write_gptme_trajectory(tmp_path: Path, session_name: str = "sess-aa") -> Pa
     return p
 
 
+def _write_codex_trajectory(tmp_path: Path) -> Path:
+    """Synthetic codex rollout JSONL: one exec_command dispatch + success result."""
+    records = [
+        {
+            "timestamp": "2026-05-27T10:00:00+00:00",
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "exec_command",
+                "arguments": json.dumps({"cmd": "echo hi"}),
+                "call_id": "c1",
+            },
+        },
+        {
+            "timestamp": "2026-05-27T10:00:00+00:00",
+            "type": "response_item",
+            "payload": {
+                "type": "function_call_output",
+                "call_id": "c1",
+                "output": "Process exited with code 0\n",
+            },
+        },
+    ]
+    p = tmp_path / "rollout.jsonl"
+    p.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+    parent = tmp_path / ".codex" / "sessions"
+    parent.mkdir(parents=True)
+    codex_path = parent / "rollout.jsonl"
+    codex_path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+    return codex_path
+
+
 def test_span_aggregates_default_is_none():
     """span_aggregates defaults to None."""
     r = SessionRecord()
@@ -544,6 +604,37 @@ def test_populate_span_aggregates_idempotent_rerun(tmp_path: Path):
     first = dict(r.span_aggregates or {})
     assert r.populate_span_aggregates() is True
     assert r.span_aggregates == first
+
+
+def test_populate_span_aggregates_codex_via_path_fallback(tmp_path: Path):
+    """Falls back to codex harness when harness="unknown" and path contains /.codex/."""
+    p = _write_codex_trajectory(tmp_path)
+    r = SessionRecord(harness="unknown", trajectory_path=str(p))
+    assert r.populate_span_aggregates() is True
+    assert r.span_aggregates is not None
+    assert r.span_aggregates["total_spans"] == 1
+    assert r.span_aggregates["dominant_tool"] == "exec_command"
+    assert r.span_aggregates["error_spans"] == 0
+
+
+def test_populate_span_aggregates_codex_trajectory(tmp_path: Path):
+    """Populates aggregates from a codex rollout JSONL when harness is set."""
+    p = _write_codex_trajectory(tmp_path)
+    r = SessionRecord(harness="codex", trajectory_path=str(p))
+    assert r.populate_span_aggregates() is True
+    assert r.span_aggregates is not None
+    assert r.span_aggregates["total_spans"] == 1
+    assert r.span_aggregates["dominant_tool"] == "exec_command"
+    assert r.span_aggregates["tool_counts"] == {"exec_command": 1}
+    assert r.span_aggregates["error_spans"] == 0
+
+
+def test_populate_span_aggregates_path_fallback_no_false_positive(tmp_path: Path):
+    """Path fallback does not trigger on gptme trajectories with no /.codex/ in path."""
+    p = _write_gptme_trajectory(tmp_path, session_name="sess-bb")
+    r = SessionRecord(harness="unknown", trajectory_path=str(p))
+    assert r.populate_span_aggregates() is False
+    assert r.span_aggregates is None
 
 
 # --- harm_category tests ---


### PR DESCRIPTION
Fixes the gap where most codex session records couldn't populate span_aggregates because harness and trajectory_path fields live only in the per-session trajectory_ref.json sidecar, not in the main JSONL store.

#### What changed

1. `judge.py`: Before calling `record.populate_span_aggregates()`, merge `trajectory_ref.json` sidecar data (harness from `backend` field, trajectory_path) into the loaded SessionRecord when those fields are missing or unknown.

2. `record.py`: Add a fallback harness detection from the trajectory file path — if harness is `"unknown"` and the trajectory path contains `/.codex/`, assume codex. This handles direct `populate_span_aggregates()` calls where the sidecar isn't available.

3. Tests: 5 new tests:
   - `test_populate_span_aggregates_codex_trajectory` — direct codex path
   - `test_populate_span_aggregates_codex_via_path_fallback` — harness="unknown" + codex path detection
   - `test_populate_span_aggregates_path_fallback_no_false_positive` — doesn't trigger on non-codex
   - `test_writeback_merges_codex_trajectory_ref` — sidecar merge during write_alignment_grade
   - `test_writeback_merges_trajectory_ref_preserves_existing_fields` — doesn't clobber existing data

All 184 tests pass (48 span + 68 record + 68 judge).
