### PR TITLE
fix(resolver): use GITHUB_WORKFLOW_REF instead of github.workflow_sha for reusable-workflow self-checkout

### DIFF
--- a/.github/workflows/issue-resolver.yml
+++ b/.github/workflows/issue-resolver.yml
@@ -94,9 +94,9 @@ jobs:
         # github.workflow_sha resolves to the CALLER'S repo SHA in reusable
         # workflow context, not gptme-contrib's SHA. GITHUB_WORKFLOW_REF is
         # documented to be the reusable workflow's own path@ref (gptme-contrib),
-        # so we extract the SHA from it instead.
+        # so we extract the ref from it instead (may be a SHA or branch ref).
         id: resolver-ref
-        run: echo "sha=${GITHUB_WORKFLOW_REF##*@}" >> "$GITHUB_OUTPUT"
+        run: echo "ref=${GITHUB_WORKFLOW_REF##*@}" >> "$GITHUB_OUTPUT"
 
       - name: Fetch resolver scripts from gptme-contrib
         # Always fetch from gptme-contrib so this workflow works both when
@@ -113,7 +113,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: gptme/gptme-contrib
-          ref: ${{ steps.resolver-ref.outputs.sha }}
+          ref: ${{ steps.resolver-ref.outputs.ref }}
           path: .gptme-resolver-stage
           sparse-checkout: |
             scripts/github_resolver

--- a/.github/workflows/issue-resolver.yml
+++ b/.github/workflows/issue-resolver.yml
@@ -90,6 +90,14 @@ jobs:
           # closed even if the model ignores the prompt contract.
           persist-credentials: false
 
+      - name: Determine resolver script ref
+        # github.workflow_sha resolves to the CALLER'S repo SHA in reusable
+        # workflow context, not gptme-contrib's SHA. GITHUB_WORKFLOW_REF is
+        # documented to be the reusable workflow's own path@ref (gptme-contrib),
+        # so we extract the SHA from it instead.
+        id: resolver-ref
+        run: echo "sha=${GITHUB_WORKFLOW_REF##*@}" >> "$GITHUB_OUTPUT"
+
       - name: Fetch resolver scripts from gptme-contrib
         # Always fetch from gptme-contrib so this workflow works both when
         # triggered directly inside gptme-contrib AND when called as a
@@ -105,7 +113,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: gptme/gptme-contrib
-          ref: ${{ github.workflow_sha }}
+          ref: ${{ steps.resolver-ref.outputs.sha }}
           path: .gptme-resolver-stage
           sparse-checkout: |
             scripts/github_resolver


### PR DESCRIPTION
## Summary

- `github.workflow_sha` resolves to the **caller's** repo SHA in reusable workflow context, not gptme-contrib's SHA
- When triggered from ErikBjare/bob, the self-checkout tried to check out gptme-contrib at `3c6cc6c6b0fd...` (an ErikBjare/bob SHA) → git exit 128
- Fix: extract SHA from `GITHUB_WORKFLOW_REF`, which is documented to be the reusable workflow's own path@ref (`gptme/gptme-contrib/.github/workflows/issue-resolver.yml@SHA`), always pointing into gptme-contrib

## Root Cause

GitHub Actions documents two SHA env vars:
- `github.workflow_sha`: SHA of the **workflow file that triggered the job** — in `workflow_call` context, this is the CALLER's SHA
- `GITHUB_WORKFLOW_REF`: **The reusable workflow's own path@ref** (e.g. `gptme/gptme-contrib/.github/workflows/issue-resolver.yml@17d46bc...`) — always points into gptme-contrib

The old code used `github.workflow_sha` for the `ref:` on the self-checkout step, which breaks whenever the reusable workflow is called cross-repo.

## Evidence

Canary run ErikBjare/bob Actions run `26548201309` failed with:
```
Error: fatal: reference is not a tree: 3c6cc6c6b0fd...
Error: Process completed with exit code 128.
```

The SHA `3c6cc6c6b0fd` is an ErikBjare/bob commit, not a gptme-contrib commit.

## Fix

Added a `Determine resolver script ref` step that extracts the SHA from `GITHUB_WORKFLOW_REF` using bash parameter expansion:
```bash
echo "sha=${GITHUB_WORKFLOW_REF##*@}" >> "$GITHUB_OUTPUT"
```

Then uses `${{ steps.resolver-ref.outputs.sha }}` as the `ref:` for the gptme-contrib self-checkout.

## Fallback Behavior

When triggered **directly inside gptme-contrib** (not as a reusable workflow), `GITHUB_WORKFLOW_REF` still includes the gptme-contrib SHA, so the checkout works correctly in both cases.

## Follow-up

After this merges, ErikBjare/bob's `gptme-resolver.yml` will need its pinned SHA bumped to include this fix, then a new canary run will verify draft-PR creation works end-to-end.

Relates to: gptme/gptme-contrib#994 (branch-safety hardening)
Canary issue: ErikBjare/bob#812