### PR TITLE
fix(resolver): restore job.workflow_sha for cross-repo reusable workflow

### DIFF
--- a/.github/workflows/issue-resolver.yml
+++ b/.github/workflows/issue-resolver.yml
@@ -102,10 +102,18 @@ jobs:
         # runner.temp before the resolver touches git. Keeping the helper repo
         # outside the target worktree prevents `git add -A` in the resolver
         # from staging the scripts directory as a broken submodule reference.
+        #
+        # In reusable workflows, the `github` context belongs to the CALLER.
+        # `github.workflow_sha` resolves to the caller's workflow file SHA
+        # (e.g. the ErikBjare/bob commit), NOT gptme-contrib's SHA — so it
+        # will not exist in gptme-contrib and the checkout fails with
+        # "not our ref". Use `job.workflow_sha` / `job.workflow_repository`
+        # instead: these always resolve to THIS reusable workflow's own
+        # revision and repo, even when called cross-repo.
         uses: actions/checkout@v4
         with:
-          repository: gptme/gptme-contrib
-          ref: ${{ github.workflow_sha }}
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: .gptme-resolver-stage
           sparse-checkout: |
             scripts/github_resolver


### PR DESCRIPTION
## Problem

The `issue-resolver.yml` reusable workflow broke for cross-repo callers (e.g. `ErikBjare/bob`) after #994.

In a `workflow_call` context, `github.workflow_sha` resolves to the **caller's** workflow-file SHA — not gptme-contrib's SHA. The "Fetch resolver scripts from gptme-contrib" step then tries to fetch that caller SHA from `gptme/gptme-contrib`, which fails:

```
fatal: remote error: upload-pack: not our ref 3c6cc6c6b0fd796638ccf2f0bb21a493f8c23645
```

(`3c6cc6c6b0...` is a commit in `ErikBjare/bob`, not in `gptme-contrib`.)

## Root cause

`9475e9a` (part of #994) changed:
- `repository: ${{ job.workflow_repository }}` → `repository: gptme/gptme-contrib` (hardcoded — fine)
- `ref: ${{ job.workflow_sha }}` → `ref: ${{ github.workflow_sha }}` (**broken in reusable context**)

`job.workflow_sha` / `job.workflow_repository` always resolve to the reusable workflow's own revision and repo, regardless of which repo calls it. `github.workflow_sha` resolves to the caller's workflow file SHA.

## Fix

Restore `ref: ${{ job.workflow_sha }}` and `repository: ${{ job.workflow_repository }}`. Add a comment explaining the distinction so it doesn't regress again.

This was correct in `474613d` (#993) and accidentally broken in `9475e9a` (#994).

## Test

The fix can be verified by triggering `/gptme-resolve` in any cross-repo caller (e.g. `ErikBjare/bob`) — the checkout step will now correctly fetch from `gptme-contrib` at the reusable workflow's own SHA.