### PR TITLE
fix(resolver): install gptme with --prerelease=allow to support avatar field

### DIFF
--- a/.github/workflows/issue-resolver.yml
+++ b/.github/workflows/issue-resolver.yml
@@ -136,7 +136,12 @@ jobs:
         uses: astral-sh/setup-uv@v4
 
       - name: Install gptme
-        run: uv tool install gptme
+        # Use --prerelease=allow so the resolver gets the latest dev release, which
+        # includes the `avatar` field in AgentConfig (stable 0.31.0 predates #1198).
+        # Bob repos use gptme.toml with `[agent] avatar = "..."` and fail with
+        # `TypeError: AgentConfig.__init__() got an unexpected keyword argument 'avatar'`
+        # when gptme parses the config.
+        run: uv tool install --prerelease=allow gptme
 
       - name: Resolve issue
         id: resolve

--- a/.github/workflows/issue-resolver.yml
+++ b/.github/workflows/issue-resolver.yml
@@ -141,7 +141,9 @@ jobs:
         # Bob repos use gptme.toml with `[agent] avatar = "..."` and fail with
         # `TypeError: AgentConfig.__init__() got an unexpected keyword argument 'avatar'`
         # when gptme parses the config.
-        run: uv tool install --prerelease=allow gptme
+        # Version floor ensures we never pick up a build older than the avatar-field
+        # introduction, even as pre-releases cycle.
+        run: uv tool install --prerelease=allow "gptme>=0.32.0.dev0"
 
       - name: Resolve issue
         id: resolve


### PR DESCRIPTION
## Problem

The gptme Issue Resolver canary (ErikBjare/bob#813) failed with:

```
TypeError: AgentConfig.__init__() got an unexpected keyword argument 'avatar'
```

Bob's `gptme.toml` uses `[agent] avatar` which was added in gptme commit 69e6e24ae (dev release v0.31.1.dev20260227). The stable gptme 0.31.0 predates this field, and `uv tool install gptme` installs the latest stable release by default.

## Fix

Add `--prerelease=allow` to the `uv tool install gptme` step so the latest dev release is used, which includes the `avatar` field and other recent features.

## Test

Create a canary issue in `ErikBjare/bob` with the `gptme-resolve` label and verify the resolver's gptme session starts without the avatar error.