### PR TITLE
fix(lessons): expand avoid-deep-nesting keywords to match natural usage

### DIFF
--- a/lessons/patterns/avoid-deep-nesting.md
+++ b/lessons/patterns/avoid-deep-nesting.md
@@ -2,6 +2,11 @@
 match:
   keywords:
   - "deeply nested"
+  - "deep nesting"
+  - "nesting levels"
+  - "nested conditionals"
+  - "guard clause"
+  - "guard clauses"
   - "early return"
 status: active
 description: "Refactor code when nesting exceeds 3-4 levels using guard clauses, function extraction, or condition inversion."


### PR DESCRIPTION
## Summary

The `avoid-deep-nesting` lesson was completely silent in 14 days of session trajectories — its keywords (`deeply nested`, `early return`) never appeared in any real session text. This PR adds natural variants that actually show up in code review and refactoring discussions.

## Changes

- Added `deep nesting`, `nesting levels`, `nested conditionals`, `guard clause`, `guard clauses`
- Kept the original `deeply nested` and `early return` for backward compat

## Evidence

From `lesson-keyword-journal-crossref.py --suggest --days 14`:
```
True silent (1):
  - avoid-deep-nesting
    keywords: ['deeply nested', 'early return']
    (0 appearances in 14-day trajectory window)
```

## Test plan

- [x] Lesson passes validator (`validate.py`)
- New keywords are common refactoring terms that appear naturally in coding sessions