### PR TITLE
fix(dashboard): show "N of TOTAL" when summaries are capped

### DIFF
--- a/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
+++ b/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
@@ -875,7 +875,7 @@ tr:hover { background: var(--accent-dim); }
     </tbody>
   </table>
   {% if summaries | length > 10 %}
-  <button class="show-more-btn" data-noun="summaries" onclick="toggleRows(this, 'summaries-table')">Show all {{ summaries | length }} summaries</button>
+  <button class="show-more-btn" data-noun="summaries" onclick="toggleRows(this, 'summaries-table')">Show all {{ summaries | length }}{% if stats.total_summaries and stats.total_summaries > summaries | length %} rendered{% endif %} summaries</button>
   {% endif %}
 </section>
 {% endif %}

--- a/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
+++ b/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
@@ -859,7 +859,7 @@ tr:hover { background: var(--accent-dim); }
 {% if summaries %}
 <!-- Knowledge Summaries -->
 <section id="summaries">
-  <h2>Summaries <span class="count-badge">({{ summaries | length }})</span></h2>
+  <h2>Summaries <span class="count-badge">({% if stats.total_summaries and stats.total_summaries > summaries | length %}{{ summaries | length }} of {{ stats.total_summaries }}{% else %}{{ summaries | length }}{% endif %})</span></h2>
   <table id="summaries-table">
     <thead>
       <tr><th>Period</th><th>Type</th><th>Preview</th></tr>

--- a/packages/gptme-dashboard/tests/test_generate.py
+++ b/packages/gptme-dashboard/tests/test_generate.py
@@ -2019,6 +2019,20 @@ def test_generate_html_includes_summaries(workspace: Path, tmp_path: Path):
     assert "2026-03-07" in html
 
 
+def test_summaries_header_shows_capped_of_total(workspace: Path, tmp_path: Path):
+    """When more summaries exist than are rendered, the section header shows
+    'N of TOTAL' so it stops contradicting the stat card (which reports TOTAL)."""
+    daily_dir = workspace / "knowledge" / "summaries" / "daily"
+    daily_dir.mkdir(parents=True)
+    for i in range(1, 26):  # 25 > default rendered cap of 20
+        (daily_dir / f"2026-01-{i:02d}.md").write_text(f"# Day {i}\n\nContent.\n")
+
+    output = tmp_path / "site"
+    generate(workspace, output)
+    html = (output / "index.html").read_text()
+    assert "(20 of 25)" in html
+
+
 def test_render_markdown_lists():
     """Lists after a paragraph should render as <li> elements."""
     md = "External resources:\n- LLM evaluation benchmarks\n- Agent evaluation research"


### PR DESCRIPTION
## Summary

Dogfooded `gptme-dashboard generate` on Bob's full workspace (350 lessons, 60 skills, 293 tasks, 239 summaries on disk) and hit a UI contradiction in the **Summaries** section.

The summaries stat card reports the true on-disk count (e.g. `239`), but the section table and detail pages only render the recent 20 (intentional, tested behavior — `scan_summaries(..., limit=20)`). On the same page this surfaced as:

- Stat card: **239**
- Section header: **(20)** + button "Show all **20** summaries"

So the page claims 239 summaries but only 20 are browsable, with no "of 239" indication.

## Change

Make the section header honest — render `(20 of 239)` when the rendered list is capped below the total, and plain `(20)` otherwise. This keeps the intentional design (stat counts all files on disk; recent 20 rendered) while removing the contradiction.

- `templates/index.html`: header badge shows `N of TOTAL` when capped
- `tests/test_generate.py`: regression test `test_summaries_header_shows_capped_of_total` (25 summaries → header shows `(20 of 25)`)

## Test plan

- [x] `pytest packages/gptme-dashboard/tests/` — 385 passed
- [x] Regenerated Bob's real workspace dashboard: header now reads `(20 of 239)`, matching the stat card