### PR TITLE
fix(twitter): preserve content from legacy `tweet:` key drafts

### DIFF
--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -275,7 +275,7 @@ class TweetDraft:
         """Create from dictionary.
 
         Resilient to alternate field names used in manually-created draft files:
-        - ``content`` as fallback for ``text``
+        - ``content`` and legacy ``tweet`` as fallbacks for ``text``
         - ``created`` as fallback for ``created_at``
         - ``context`` is optional (defaults to empty dict)
         """
@@ -283,7 +283,7 @@ class TweetDraft:
         # Unescape literal \\n sequences that some LLMs emit in JSON/YAML.
         # This fixes tweets that leak escape sequences like "line1\\nline2".
         # Uses the shared _unescape_literal_newlines helper from twitter.llm.
-        raw_text = data.get("text", data.get("content", ""))
+        raw_text = data.get("text", data.get("content", data.get("tweet", "")))
         fixed_text: str = (
             _unescape_literal_newlines(raw_text) if isinstance(raw_text, str) else ""
         )

--- a/tests/test_twitter_workflow_drafts.py
+++ b/tests/test_twitter_workflow_drafts.py
@@ -97,6 +97,7 @@ def _load_workflow_module() -> tuple[Any, dict[str, Any]]:
         data=SimpleNamespace(id=0)
     )
     twitter_api_stub.load_twitter_client = lambda *args, **kwargs: None
+    twitter_api_stub._find_placeholder_in_text = lambda *args, **kwargs: None
 
     stubbed_modules: dict[str, Any] = {
         "gptmail": gptmail_stub,
@@ -198,6 +199,26 @@ def test_tweet_draft_loads_markdown_frontmatter_body_as_text(
     assert draft.text == "Manual markdown draft body."
     assert draft.type == "reply"
     assert draft.in_reply_to == "12345"
+
+
+def test_tweet_draft_loads_legacy_tweet_key_as_text(
+    workflow_module: Any, tmp_path: Path
+) -> None:
+    # Legacy drafts used `tweet:` as the content key instead of `text:`.
+    # Without a fallback, from_dict() blanks the content on load and a
+    # subsequent save() overwrites the file with an empty tweet.
+    draft_path = tmp_path / "legacy-draft.yml"
+    draft_path.write_text(
+        "tweet: |\n"
+        "  Legacy content line one.\n"
+        "  Legacy content line two.\n"
+        "tags: [a, b]\n"
+        "created: 2026-05-28\n"
+    )
+
+    draft = workflow_module.TweetDraft.load(draft_path)
+
+    assert draft.text.strip() == "Legacy content line one.\nLegacy content line two."
 
 
 def test_list_and_find_drafts_include_markdown_files(


### PR DESCRIPTION
## Summary
- `TweetDraft.from_dict()` fell back `text → content` but not the legacy `tweet:` content key. Loading an old-schema draft (e.g. `tweets/new/the-lie-of-podrunning-20260528.yml`, `tweets/posted/supply-chain-defense-depth-2026-03-28.yml`) yielded **empty text**, and a subsequent `save()` overwrote the file with `text: ''` — silent content loss. Observed live: a draft was blanked in Bob's working tree before this fix.
- Add `tweet` as a fallback key (one line), matching the existing `content` resilience pattern.
- Add a regression test for legacy-key loading.
- Fix the test module's `twitter.twitter` stub, which was missing `_find_placeholder_in_text` and erroring the **entire** `test_twitter_workflow_drafts.py` file on import (all 18 tests).

## Test plan
- [x] `pytest tests/test_twitter_workflow_drafts.py` → 18 passed (was 18 errors on load before the stub fix)
- [x] New `test_tweet_draft_loads_legacy_tweet_key_as_text` fails without the `from_dict` fix, passes with it