### PR TITLE
fix(subscription): make usage tracking robust across credential switches

### DIFF
--- a/packages/gptme-subscription/src/gptme_subscription/manager.py
+++ b/packages/gptme-subscription/src/gptme_subscription/manager.py
@@ -579,16 +579,21 @@ class SubscriptionManager:
         d.five_hour_utilization = five_hour
         d.sonnet_weekly_utilization = sonnet_weekly
 
-        if active != primary:
-            # Record reset time for this fallback so future calls can rank.
-            _weekly_resets_in = usage.get("seven_day", {}).get("resets_in_seconds")
-            if (
-                active
-                and isinstance(_weekly_resets_in, int | float)
-                and _weekly_resets_in > 0
-            ):
-                self.record_sub_reset_time(active, float(_weekly_resets_in), usage)
+        # Record the live observation for *whichever* slot is active, not just
+        # fallbacks. The earlier gate (`active != primary`) was correct for
+        # rebalance hold logic but left ``reset-times.json`` permanently empty
+        # for the primary slot — downstream readers (Bob's vitals subscription
+        # pacing, ``subscription-usage-history.py``) then can't pick up the
+        # primary's weekly_utilization between probes.
+        _weekly_resets_in = usage.get("seven_day", {}).get("resets_in_seconds")
+        if (
+            active
+            and isinstance(_weekly_resets_in, int | float)
+            and _weekly_resets_in > 0
+        ):
+            self.record_sub_reset_time(active, float(_weekly_resets_in), usage)
 
+        if active != primary:
             if rebalance_state is not None:
                 hold_until = rebalance_state.get("hold_until")
                 blocked, _ = self.is_subscription_blocked(usage, config=cfg)

--- a/packages/gptme-subscription/tests/test_subscription_manager.py
+++ b/packages/gptme-subscription/tests/test_subscription_manager.py
@@ -127,6 +127,34 @@ def _write_cred(sm: SubscriptionManager, slot: str, *, age_days: float) -> None:
     os.utime(path, (old_ts, old_ts))
 
 
+def test_evaluate_records_observation_for_active_primary(tmp_path: Path) -> None:
+    """``evaluate`` must record the live observation for the active slot even
+    when it is the primary. Previously gated on ``active != primary``, which
+    silently left the primary's weekly_utilization out of reset-times.json and
+    broke downstream readers (Bob's vitals subscription pacing, the
+    subscription-usage-history dashboard panel) for the slot that actually
+    matters most.
+    """
+    sm = _make_manager(tmp_path)
+    usage = {
+        "seven_day": {"utilization": 0.42, "resets_in_seconds": 3 * 24 * 3600},
+        "five_hour": {"utilization": 0.10, "resets_in_seconds": 3 * 3600},
+        "seven_day_sonnet": {
+            "utilization": 0.30,
+            "resets_in_seconds": 3 * 24 * 3600,
+        },
+    }
+
+    sm.evaluate(usage, "bob")
+
+    reset_times = json.loads(sm.config.reset_times_file.read_text())
+    assert "bob" in reset_times, "primary slot observation was not recorded"
+    entry = reset_times["bob"]
+    assert entry["weekly_utilization"] == pytest.approx(0.42)
+    assert entry["five_hour_utilization"] == pytest.approx(0.10)
+    assert entry["sonnet_weekly_utilization"] == pytest.approx(0.30)
+
+
 def test_evaluate_skips_stale_fallback_picks_fresh(tmp_path: Path) -> None:
     sm = _make_manager(tmp_path)
     # alice is stale (17 days), erik is fresh

--- a/scripts/check-claude-usage.sh
+++ b/scripts/check-claude-usage.sh
@@ -348,6 +348,11 @@ try:
     _st = _os.stat('$CREDS_FILE')  # follows symlinks by default
     result['_cred_fingerprint'] = f'{_st.st_ino}:{int(_st.st_mtime)}'
 except OSError:
+    # Bash _creds_fingerprint() falls back to the literal 0:0 on stat failure;
+    # we write an empty string so the non-empty-check guard in the bash reader
+    # forces a cache bypass when credentials were absent at write time.
+    # This is intentional — matching the reader's own 0:0 fallback would
+    # incorrectly serve stale N/A data from a previous cache write.
     result['_cred_fingerprint'] = ''
 
 # Write cache file (always, for both modes)

--- a/scripts/check-claude-usage.sh
+++ b/scripts/check-claude-usage.sh
@@ -42,12 +42,27 @@ done
 
 CACHE_FILE="/tmp/claude-usage-cache.json"
 CACHE_TTL="${CLAUDE_USAGE_CACHE_TTL:-600}"  # 10 minutes default
+CREDS_FILE="${HOME}/.claude/.credentials.json"
+
+# Fingerprint = "<target_inode>:<target_mtime>" of the resolved credentials file.
+# Changes when the slot is rewritten (token refresh / `cp` into slot) or the
+# live symlink retargets a different slot. Used to invalidate the cache across
+# a credential switch — the cache key is the file path, not the credential
+# identity, so a /login or `ln -sfn` would otherwise serve a stale-shaped
+# response for up to CACHE_TTL seconds.
+_creds_fingerprint() {
+    stat -Lc '%i:%Y' "$CREDS_FILE" 2>/dev/null \
+        || stat -Lf '%i:%m' "$CREDS_FILE" 2>/dev/null \
+        || echo "0:0"
+}
 
 # --- Cache check (JSON and human-readable modes only, not --raw) ---
 if [ "$MODE" != "raw" ] && [ "$NO_CACHE" = false ] && [ -f "$CACHE_FILE" ]; then
     # stat mtime: -c %Y on Linux, -f %m on macOS/BSD
     CACHE_AGE=$(( $(date +%s) - $(stat -c %Y "$CACHE_FILE" 2>/dev/null || stat -f %m "$CACHE_FILE" 2>/dev/null || echo 0) ))
-    if [ "$CACHE_AGE" -lt "$CACHE_TTL" ]; then
+    CURRENT_FP=$(_creds_fingerprint)
+    CACHED_FP=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('_cred_fingerprint',''))" "$CACHE_FILE" 2>/dev/null || echo "")
+    if [ "$CACHE_AGE" -lt "$CACHE_TTL" ] && [ -n "$CACHED_FP" ] && [ "$CURRENT_FP" = "$CACHED_FP" ]; then
         if [ "$MODE" = "json" ]; then
             cat "$CACHE_FILE"
             exit 0
@@ -323,6 +338,17 @@ if seven_day and seven_day.get('resets_in_seconds') is not None:
         'pace_gap': round(gap, 3),
         'status': 'underusing' if gap > 0.05 else ('overusing' if gap < -0.05 else 'on_track'),
     }
+
+# Stamp the credential fingerprint into the cache so a later cache read can
+# detect a credential switch (different slot or rewritten slot) and bypass.
+# Format: '<resolved-target-inode>:<resolved-target-mtime>' (mtime as int).
+# See _creds_fingerprint() in the surrounding bash for the matching reader.
+import os as _os
+try:
+    _st = _os.stat('$CREDS_FILE')  # follows symlinks by default
+    result['_cred_fingerprint'] = f'{_st.st_ino}:{int(_st.st_mtime)}'
+except OSError:
+    result['_cred_fingerprint'] = ''
 
 # Write cache file (always, for both modes)
 cache_path = '$CACHE_FILE'

--- a/scripts/check-claude-usage.sh
+++ b/scripts/check-claude-usage.sh
@@ -343,7 +343,7 @@ if seven_day and seven_day.get('resets_in_seconds') is not None:
 # detect a credential switch (different slot or rewritten slot) and bypass.
 # Format: '<resolved-target-inode>:<resolved-target-mtime>' (mtime as int).
 # See _creds_fingerprint() in the surrounding bash for the matching reader.
-import os as _os
+# (os already imported above in the off-peak block)
 try:
     _st = _os.stat('$CREDS_FILE')  # follows symlinks by default
     result['_cred_fingerprint'] = f'{_st.st_ino}:{int(_st.st_mtime)}'


### PR DESCRIPTION
## Summary

Two related fixes to the CC subscription usage-tracking pipeline that surfaced after a `/login` swap on Bob today. The vitals subscription-pacing panel showed the previous slot's quota (53/96/80%) while CC's own `/usage` correctly showed ~0% — a >9-minute disagreement for what is supposed to be live data.

### 1. `check-claude-usage.sh`: fingerprint-keyed cache

The cache (`/tmp/claude-usage-cache.json`) was keyed by file path, not by credential identity. After any swap — `/login`, `cp` into a slot, `ln -sfn` retarget — the same path still pointed at a cache written against the *previous* credentials. Within the 10-minute TTL, every reader saw stale numbers.

Fix: stamp `_cred_fingerprint = "<resolved-target-inode>:<resolved-target-mtime>"` into the cache on write. On read, recompute and bypass the cache if it doesn't match. Catches both content rewrites (`cp` into the slot, `/login` writing through the symlink) and symlink retargets (`ln -sfn` to a different slot).

Verified locally:
- Fresh cache write now includes `_cred_fingerprint`.
- Forged mismatch correctly bypasses cache (7.7s probe).
- Matching fingerprint stays fast (40ms cat).

### 2. `manager.evaluate()`: record observation for active primary too

`record_sub_reset_time` was gated on `if active != primary`. So when bob (the primary) was active, the live `/usage` probe ran successfully but the result was **never written to `reset-times.json`** — leaving Bob's vitals subscription-pacing card and the `subscription-usage-history.py` staleness panel permanently missing the most important slot's weekly_utilization between probes.

Fix: move the `record_sub_reset_time` call outside the `active != primary` gate. The rebalance hold logic still requires the gate and stays inside it. The recording itself was never primary-specific.

Adds a regression test (`test_evaluate_records_observation_for_active_primary`) that fails without the fix.

## Test plan

- [x] 80/80 gptme-subscription tests green
- [x] Fingerprint round-trip verified (write → read → match/mismatch paths)
- [x] New regression test fails on master, passes with fix
- [ ] After merge + submodule bump: confirm Bob's vitals "Subscription staleness (days since last probe)" panel returns to ~0d for the active slot within 15 min of the next history-record tick