### PR TITLE
fix(resolver): lower gptme version floor to >=0.31.1.dev0

### DIFF
--- a/.github/workflows/issue-resolver.yml
+++ b/.github/workflows/issue-resolver.yml
@@ -141,9 +141,10 @@ jobs:
         # Bob repos use gptme.toml with `[agent] avatar = "..."` and fail with
         # `TypeError: AgentConfig.__init__() got an unexpected keyword argument 'avatar'`
         # when gptme parses the config.
-        # Version floor ensures we never pick up a build older than the avatar-field
-        # introduction, even as pre-releases cycle.
-        run: uv tool install --prerelease=allow "gptme>=0.32.0.dev0"
+        # Version floor: avatar (#1198) landed 2026-01-29 in the 0.31.1 dev series
+        # (v0.31.0 stable was released 2025-12-10, before #1198). 0.31.1.dev0+ is
+        # the smallest floor that guarantees avatar support.
+        run: uv tool install --prerelease=allow "gptme>=0.31.1.dev0"
 
       - name: Resolve issue
         id: resolve


### PR DESCRIPTION
## Problem

The resolver workflow installs gptme with:
```
uv tool install --prerelease=allow "gptme>=0.32.0.dev0"
```

But `gptme 0.32.0.dev0` does not exist on PyPI (latest is `0.31.1.dev202604277`), so the install step always fails:

```
× No solution found when resolving dependencies:
╰─▶ Because only gptme<=0.31.1.dev202604277 is available and you require
    gptme>=0.32.0.dev0, we can conclude that your requirements are
    unsatisfiable.
```

This causes every resolver run to fail before gptme is even installed.

## Root cause

PR #1000 added the floor to guarantee the `avatar` field in `AgentConfig` (#1198).
The comment says "stable 0.31.0 predates #1198" — which is correct (v0.31.0 was
released 2025-12-10, before #1198 landed 2026-01-29). But the floor was set to
`0.32.0.dev0` when the correct floor is `0.31.1.dev0` (the dev series where avatar
first appeared).

## Fix

Change `>=0.32.0.dev0` → `>=0.31.1.dev0`. This:
- Still requires `--prerelease=allow` (to get the latest dev build)
- Correctly excludes v0.31.0 stable (which lacks avatar)
- Matches the latest published version `0.31.1.dev202604277`
- Will continue working when 0.32.0 eventually lands on PyPI

## Test

Verified locally:
```
uv tool install --prerelease=allow "gptme>=0.31.1.dev0"
# → Resolves to gptme 0.31.1.dev202604277 ✓
```