### PR TITLE
feat(aw-watcher-agent): Codex log-tailer for per-tool activity heartbeats

### DIFF
--- a/packages/aw-watcher-agent/README.md
+++ b/packages/aw-watcher-agent/README.md
@@ -55,8 +55,30 @@ Point `SessionStart` / `Stop` hooks (in `~/.claude/settings.json`) at the
 (`--strict` to opt in) so a watcher problem never breaks the agent session it
 observes.
 
+### Per-tool activity from Codex (log-tailer)
+
+Codex can't host an in-process hook, so per-tool observability comes from
+tailing its rollout transcripts (`~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`).
+`tail-codex` pairs each `function_call` with its `function_call_output`, derives
+a coarse `success`/`error`/`completed` status, and emits one
+`app.agent.activity` event per tool call:
+
+```bash
+# Process the most recent rollout transcript
+aw-watcher-agent tail-codex
+
+# Or a specific transcript, with a custom heartbeat merge window
+aw-watcher-agent tail-codex --file ~/.codex/sessions/2026/05/29/rollout-...jsonl --pulsetime 5
+```
+
+Events land in `aw-watcher-agent-activity_<hostname>` (type `app.agent.activity`),
+a sibling of the session bucket. Adjacent same-tool/same-status calls within
+`--pulsetime` seconds merge into one Timeline block. Run it on a timer (or after
+each Codex run) to keep the bucket current.
+
 ## Status
 
 Phase 1 (MVP): session bucket + CLI + REST client, dogfooded against a local
-aw-server. Phase 2 adds per-tool activity heartbeats and a gptme-native plugin
-hook; Phase 3 adds an aw-webui "AI work" view.
+aw-server. Phase 2 (in progress): per-tool `app.agent.activity` heartbeats —
+the Codex log-tailer (`tail-codex`) is shipped; the gptme-native plugin hook is
+the remaining deliverable. Phase 3 adds an aw-webui "AI work" view.

--- a/packages/aw-watcher-agent/src/aw_watcher_agent/cli.py
+++ b/packages/aw-watcher-agent/src/aw_watcher_agent/cli.py
@@ -122,6 +122,24 @@ def cmd_emit_end(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_tail_codex(args: argparse.Namespace) -> int:
+    from pathlib import Path
+
+    from . import tailer
+
+    client = AWClient(args.server)
+    host = _hostname(args.hostname)
+
+    path: Path | None = Path(args.file) if args.file else tailer.latest_rollout()
+    if path is None:
+        print("no Codex rollout transcripts found", file=sys.stderr)
+        return 0
+    count = tailer.emit_file(client, host, path, pulsetime=args.pulsetime)
+    bid = core.activity_bucket_id(host)
+    print(f"codex activity emitted: {bid} events={count} file={path.name}")
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="aw-watcher-agent", description=__doc__)
     parser.add_argument("--strict", action="store_true", help="exit non-zero on errors")
@@ -141,6 +159,22 @@ def build_parser() -> argparse.ArgumentParser:
     p_end.add_argument("--outcome", help="productive / blocked / noop")
     p_end.add_argument("--duration", type=float, help="fallback duration (s) if no start state")
     p_end.set_defaults(func=cmd_emit_end)
+
+    p_tail = sub.add_parser(
+        "tail-codex", help="emit per-tool activity from a Codex rollout transcript"
+    )
+    p_tail.add_argument(
+        "--file", help="rollout JSONL to process (default: latest under ~/.codex/sessions)"
+    )
+    p_tail.add_argument(
+        "--pulsetime",
+        type=float,
+        default=5.0,
+        help="heartbeat merge window in seconds (default: 5.0)",
+    )
+    p_tail.add_argument("--hostname")
+    p_tail.add_argument("--server", default=core_default_server())
+    p_tail.set_defaults(func=cmd_tail_codex)
 
     return parser
 

--- a/packages/aw-watcher-agent/src/aw_watcher_agent/core.py
+++ b/packages/aw-watcher-agent/src/aw_watcher_agent/core.py
@@ -24,6 +24,14 @@ from typing import Any
 BUCKET_TYPE = "app.agent.session"
 CLIENT_NAME = "aw-watcher-agent"
 
+# Per-tool activity events live in their own bucket type. Phase 2 originally
+# proposed reusing the session bucket to keep "AI work" as a single Timeline
+# lane, but session events (one long block spanning the whole run) and per-tool
+# events (many short blocks) overlap in time, which ActivityWatch cannot render
+# as a single clean lane. A sibling bucket keeps both lanes honest; aw-webui can
+# still stack them. See the Phase 2 PR for the design note.
+ACTIVITY_BUCKET_TYPE = "app.agent.activity"
+
 # Stable session fields (everything except outcome, which is end-only).
 START_FIELDS = ("harness", "model", "category", "session_id", "trigger", "workspace")
 
@@ -31,6 +39,11 @@ START_FIELDS = ("harness", "model", "category", "session_id", "trigger", "worksp
 def bucket_id(hostname: str) -> str:
     """Bucket id following the ``aw-watcher-<name>_<hostname>`` convention."""
     return f"{CLIENT_NAME}_{hostname}"
+
+
+def activity_bucket_id(hostname: str) -> str:
+    """Bucket id for per-tool activity events (sibling of the session bucket)."""
+    return f"{CLIENT_NAME}-activity_{hostname}"
 
 
 def state_dir() -> Path:

--- a/packages/aw-watcher-agent/src/aw_watcher_agent/tailer.py
+++ b/packages/aw-watcher-agent/src/aw_watcher_agent/tailer.py
@@ -31,9 +31,6 @@ from . import core
 # Codex marks shell exits as "Process exited with code N" / "exited with code N".
 _EXIT_CODE_RE = re.compile(r"exited with code (\d+)")
 
-# Default duration (s) for a call whose output we never saw (crash / truncation).
-_UNPAIRED_DURATION = 0.0
-
 
 def default_sessions_dir() -> Path:
     """Root of Codex rollout transcripts (honors ``CODEX_HOME``)."""
@@ -44,6 +41,8 @@ def default_sessions_dir() -> Path:
 def latest_rollout(sessions_dir: Path | None = None) -> Path | None:
     """Most recently modified ``rollout-*.jsonl`` under ``sessions_dir``."""
     root = sessions_dir or default_sessions_dir()
+    if not root.exists():
+        return None
     files = sorted(root.rglob("rollout-*.jsonl"), key=lambda p: p.stat().st_mtime)
     return files[-1] if files else None
 
@@ -129,7 +128,7 @@ def parse_rollout(lines: Iterable[str]) -> tuple[str, list[ToolActivity]]:
 
         if ptype == "function_call":
             call_id = payload.get("call_id")
-            if not isinstance(call_id, str):
+            if not isinstance(call_id, str) or call_id in pending:
                 continue
             pending[call_id] = {
                 "tool": str(payload.get("name") or "unknown"),

--- a/packages/aw-watcher-agent/src/aw_watcher_agent/tailer.py
+++ b/packages/aw-watcher-agent/src/aw_watcher_agent/tailer.py
@@ -89,6 +89,7 @@ class ToolActivity:
     timestamp: str  # ISO 8601 start time (the function_call timestamp)
     call_id: str
     session_id: str
+    paired: bool = True  # False when function_call_output not yet in transcript
 
     def to_event(self, *, min_duration_s: float = 0.0) -> Event:
         """Build an AW event. ``data`` excludes duration so same-tool/status
@@ -194,6 +195,7 @@ def parse_rollout(lines: Iterable[str]) -> tuple[str, list[ToolActivity]]:
                 timestamp=start,
                 call_id=call_id,
                 session_id=session_id,
+                paired="end" in call,
             )
         )
     return session_id, activities
@@ -226,13 +228,24 @@ def emit_file(
     if not new:
         return 0
 
+    # Stop short of trailing unpaired (in-flight) calls so the cursor never
+    # advances past a call whose output hasn't arrived yet.  Unpaired calls in
+    # the middle of the list (orphaned by a crash) are still emitted.
+    last_paired_pos = len(new) - 1
+    while last_paired_pos >= 0 and not new[last_paired_pos].paired:
+        last_paired_pos -= 1
+
+    to_emit = new[: last_paired_pos + 1]
+    if not to_emit:
+        return 0
+
     bucket = core.activity_bucket_id(hostname)
     client.ensure_bucket(bucket, core.ACTIVITY_BUCKET_TYPE, core.CLIENT_NAME, hostname)
-    for activity in new:
+    for activity in to_emit:
         client.heartbeat(bucket, activity.to_event(), pulsetime=pulsetime)
 
-    # Advance the cursor to the last activity we just emitted.
-    final_index = last_index + len(new)
-    final_ts = new[-1].timestamp
+    # Advance the cursor to the last emitted (paired) activity.
+    final_index = last_index + len(to_emit)
+    final_ts = to_emit[-1].timestamp
     _write_cursor(path, final_index, final_ts)
-    return len(new)
+    return len(to_emit)

--- a/packages/aw-watcher-agent/src/aw_watcher_agent/tailer.py
+++ b/packages/aw-watcher-agent/src/aw_watcher_agent/tailer.py
@@ -23,13 +23,45 @@ import re
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Iterable, cast
 
 from .client import AWClient, Event
 from . import core
 
 # Codex marks shell exits as "Process exited with code N" / "exited with code N".
 _EXIT_CODE_RE = re.compile(r"exited with code (\d+)")
+
+
+# ---------------------------------------------------------------------------
+# Cursor helpers: prevent duplicate emission when tail-codex is re-run on the
+# same rollout file (e.g. from a timer).  We persist the 0-based index and
+# timestamp of the last emitted activity so emit_file only sends new calls.
+# ---------------------------------------------------------------------------
+
+
+def _cursor_path(rollout_path: Path) -> Path:
+    """Path to the cursor state file for a given rollout."""
+    safe = re.sub(r"[^a-zA-Z0-9._-]", "_", str(rollout_path.absolute()))
+    return core.state_dir() / f"cursor-{safe}.json"
+
+
+def _read_cursor(rollout_path: Path) -> dict[str, Any] | None:
+    """Last-emitted cursor for *rollout_path*, or ``None``."""
+    path = _cursor_path(rollout_path)
+    if not path.exists():
+        return None
+    try:
+        return cast(dict[str, Any], json.loads(path.read_text(encoding="utf-8")))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _write_cursor(rollout_path: Path, last_index: int, last_timestamp: str) -> None:
+    """Persist the cursor after emitting activities."""
+    path = _cursor_path(rollout_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload: dict[str, Any] = {"last_index": last_index, "last_timestamp": last_timestamp}
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
 
 
 def default_sessions_dir() -> Path:
@@ -174,17 +206,33 @@ def emit_file(
     *,
     pulsetime: float = 5.0,
 ) -> int:
-    """Parse one rollout file and emit its tool activities. Returns the count.
+    """Parse one rollout file and emit **new** tool activities since the last run.
+
+    Uses a cursor file (alongside the rollout) to skip previously-emitted
+    calls, so timer-driven runs do not duplicate historical heartbeats.
+    Returns the count of activities actually emitted this invocation.
 
     ``pulsetime`` controls heartbeat merging: consecutive same-tool/same-status
     calls within this many seconds collapse into a single Timeline block.
     """
+    cursor = _read_cursor(path)
+    last_index = cursor.get("last_index", -1) if cursor else -1
+
     text = path.read_text(encoding="utf-8", errors="replace")
     _, activities = parse_rollout(text.splitlines())
-    if not activities:
+
+    # Only emit calls that are new since the last cursor position.
+    new = activities[last_index + 1 :]
+    if not new:
         return 0
+
     bucket = core.activity_bucket_id(hostname)
     client.ensure_bucket(bucket, core.ACTIVITY_BUCKET_TYPE, core.CLIENT_NAME, hostname)
-    for activity in activities:
+    for activity in new:
         client.heartbeat(bucket, activity.to_event(), pulsetime=pulsetime)
-    return len(activities)
+
+    # Advance the cursor to the last activity we just emitted.
+    final_index = last_index + len(new)
+    final_ts = new[-1].timestamp
+    _write_cursor(path, final_index, final_ts)
+    return len(new)

--- a/packages/aw-watcher-agent/src/aw_watcher_agent/tailer.py
+++ b/packages/aw-watcher-agent/src/aw_watcher_agent/tailer.py
@@ -1,0 +1,191 @@
+"""Codex transcript log-tailer: emit per-tool ``app.agent.activity`` heartbeats.
+
+Phase 2 fallback for harnesses that cannot host an in-process gptme plugin hook.
+Codex writes rollout transcripts to ``~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl``.
+Each line is ``{"timestamp", "type", "payload"}``. A tool call is a
+``response_item`` whose ``payload.type == "function_call"`` (carrying ``name``,
+``call_id``, ``arguments``); its result is a later ``function_call_output`` with
+the matching ``call_id``. We pair them, compute a duration, derive a coarse
+status from the output, and emit one activity event per call into the
+``aw-watcher-agent-activity_<hostname>`` bucket.
+
+The parser (:func:`parse_rollout`) is pure and stdlib-only so it is testable
+without a live aw-server or a real Codex session. Emission (:func:`emit_file`)
+reuses the vendored :class:`~aw_watcher_agent.client.AWClient` and heartbeats so
+adjacent calls of the same tool merge into a single Timeline block.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterable
+
+from .client import AWClient, Event
+from . import core
+
+# Codex marks shell exits as "Process exited with code N" / "exited with code N".
+_EXIT_CODE_RE = re.compile(r"exited with code (\d+)")
+
+# Default duration (s) for a call whose output we never saw (crash / truncation).
+_UNPAIRED_DURATION = 0.0
+
+
+def default_sessions_dir() -> Path:
+    """Root of Codex rollout transcripts (honors ``CODEX_HOME``)."""
+    base = os.environ.get("CODEX_HOME") or os.path.expanduser("~/.codex")
+    return Path(base) / "sessions"
+
+
+def latest_rollout(sessions_dir: Path | None = None) -> Path | None:
+    """Most recently modified ``rollout-*.jsonl`` under ``sessions_dir``."""
+    root = sessions_dir or default_sessions_dir()
+    files = sorted(root.rglob("rollout-*.jsonl"), key=lambda p: p.stat().st_mtime)
+    return files[-1] if files else None
+
+
+@dataclass
+class ToolActivity:
+    """One paired Codex tool call: name, coarse status, and wall-clock duration."""
+
+    tool: str
+    status: str
+    duration_ms: int
+    timestamp: str  # ISO 8601 start time (the function_call timestamp)
+    call_id: str
+    session_id: str
+
+    def to_event(self, *, min_duration_s: float = 0.0) -> Event:
+        """Build an AW event. ``data`` excludes duration so same-tool/status
+        calls merge under heartbeat; the per-call duration drives the block."""
+        data = {"tool": self.tool, "status": self.status}
+        if self.session_id:
+            data["session_id"] = self.session_id
+        return Event(
+            timestamp=self.timestamp,
+            duration=max(self.duration_ms / 1000.0, min_duration_s),
+            data=data,
+        )
+
+
+def _status_from_output(output: Any) -> str:
+    """Coarse success/error/completed status from a function_call_output."""
+    if not isinstance(output, str) or not output.strip():
+        return "completed"
+    match = _EXIT_CODE_RE.search(output)
+    if match:
+        return "success" if match.group(1) == "0" else "error"
+    return "completed"
+
+
+def _parse_ts(ts: str) -> datetime | None:
+    try:
+        # Codex stamps RFC3339 with a trailing 'Z'; fromisoformat wants +00:00.
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None
+
+
+def _iter_records(lines: Iterable[str]) -> Iterable[dict[str, Any]]:
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            yield obj
+
+
+def parse_rollout(lines: Iterable[str]) -> tuple[str, list[ToolActivity]]:
+    """Parse Codex rollout JSONL into ``(session_id, [ToolActivity, ...])``.
+
+    Pairs each ``function_call`` with its matching ``function_call_output`` by
+    ``call_id``. A call with no output (crash/truncation) is still emitted with
+    a zero duration and ``completed`` status so the Timeline marks that it ran.
+    """
+    session_id = ""
+    # Preserve call order; map call_id -> pending call record.
+    pending: dict[str, dict[str, Any]] = {}
+    order: list[str] = []
+
+    for rec in _iter_records(lines):
+        payload = rec.get("payload")
+        if not isinstance(payload, dict):
+            continue
+        ptype = payload.get("type")
+
+        if rec.get("type") == "session_meta" and not session_id:
+            sid = payload.get("id")
+            if isinstance(sid, str):
+                session_id = sid
+            continue
+
+        if ptype == "function_call":
+            call_id = payload.get("call_id")
+            if not isinstance(call_id, str):
+                continue
+            pending[call_id] = {
+                "tool": str(payload.get("name") or "unknown"),
+                "start": rec.get("timestamp"),
+            }
+            order.append(call_id)
+        elif ptype == "function_call_output":
+            call_id = payload.get("call_id")
+            call = pending.get(call_id) if isinstance(call_id, str) else None
+            if call is not None:
+                call["end"] = rec.get("timestamp")
+                call["status"] = _status_from_output(payload.get("output"))
+
+    activities: list[ToolActivity] = []
+    for call_id in order:
+        call = pending[call_id]
+        start = call.get("start")
+        if not isinstance(start, str):
+            continue
+        duration_ms = 0
+        end = call.get("end")
+        if isinstance(end, str):
+            t0, t1 = _parse_ts(start), _parse_ts(end)
+            if t0 and t1:
+                duration_ms = max(int((t1 - t0).total_seconds() * 1000), 0)
+        activities.append(
+            ToolActivity(
+                tool=call["tool"],
+                status=call.get("status", "completed"),
+                duration_ms=duration_ms,
+                timestamp=start,
+                call_id=call_id,
+                session_id=session_id,
+            )
+        )
+    return session_id, activities
+
+
+def emit_file(
+    client: AWClient,
+    hostname: str,
+    path: Path,
+    *,
+    pulsetime: float = 5.0,
+) -> int:
+    """Parse one rollout file and emit its tool activities. Returns the count.
+
+    ``pulsetime`` controls heartbeat merging: consecutive same-tool/same-status
+    calls within this many seconds collapse into a single Timeline block.
+    """
+    text = path.read_text(encoding="utf-8", errors="replace")
+    _, activities = parse_rollout(text.splitlines())
+    if not activities:
+        return 0
+    bucket = core.activity_bucket_id(hostname)
+    client.ensure_bucket(bucket, core.ACTIVITY_BUCKET_TYPE, core.CLIENT_NAME, hostname)
+    for activity in activities:
+        client.heartbeat(bucket, activity.to_event(), pulsetime=pulsetime)
+    return len(activities)

--- a/packages/aw-watcher-agent/tests/test_aw_watcher_agent.py
+++ b/packages/aw-watcher-agent/tests/test_aw_watcher_agent.py
@@ -460,6 +460,67 @@ def test_emit_file_incremental_appends_new_calls(tmp_path, monkeypatch):
     assert seen == ["read_file"], "only new call should emit"
 
 
+def test_emit_file_does_not_advance_cursor_past_inflight_tail_call(tmp_path, monkeypatch):
+    """Cursor stops short of in-flight tail calls; they emit correctly after output arrives."""
+    monkeypatch.setattr(tailer.core, "state_dir", lambda: tmp_path)
+    rollout = tmp_path / "rollout-inflight.jsonl"
+
+    # c1 is paired; c2 is in-flight (no output yet).
+    rollout.write_text(
+        "\n".join(
+            _rollout_lines(
+                [
+                    {"type": "session_meta", "payload": {"id": "sess-1", "type": None}},
+                    _call("c1", "exec_command", "2026-05-29T05:19:56.055Z"),
+                    _output("c1", "2026-05-29T05:19:56.255Z", "Process exited with code 0"),
+                    _call("c2", "apply_patch", "2026-05-29T05:20:00.000Z"),
+                    # c2 output not yet written — in-flight
+                ]
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    seen: list[str] = []
+
+    class _Client(_FakeClient):
+        def __init__(self):
+            super().__init__([])
+
+        def ensure_bucket(self, bid, etype, client_name, host):
+            return True
+
+        def heartbeat(self, bid, event, pulsetime):
+            seen.append(event.data["tool"])
+            return 1
+
+    # Run 1: only c1 emitted; cursor stops before in-flight c2.
+    count1 = tailer.emit_file(_Client(), "bob", rollout)
+    assert count1 == 1
+    assert seen == ["exec_command"]
+    cur = tailer._read_cursor(rollout)
+    assert cur is not None
+    assert cur["last_index"] == 0  # cursor stopped before in-flight c2
+
+    # Simulate c2's output arriving.
+    seen.clear()
+    with open(rollout, "a", encoding="utf-8") as f:
+        f.write(
+            "\n"
+            + _rollout_lines(
+                [_output("c2", "2026-05-29T05:20:00.500Z", "exited with code 1\nboom")]
+            )[0]
+        )
+
+    # Run 2: c2 now has output and emits with correct status/duration.
+    count2 = tailer.emit_file(_Client(), "bob", rollout)
+    assert count2 == 1
+    assert seen == ["apply_patch"]
+    cur = tailer._read_cursor(rollout)
+    assert cur is not None
+    assert cur["last_index"] == 1  # cursor now covers c2
+
+
 def test_emit_file_no_cursor_on_empty_activities(tmp_path, monkeypatch):
     """No-op when the rollout file has no tool calls (no cursor written)."""
     monkeypatch.setattr(tailer.core, "state_dir", lambda: tmp_path)

--- a/packages/aw-watcher-agent/tests/test_aw_watcher_agent.py
+++ b/packages/aw-watcher-agent/tests/test_aw_watcher_agent.py
@@ -185,3 +185,140 @@ def test_emit_end_preserves_start_metadata(tmp_path, monkeypatch):
     assert final_data.get("model") == "claude-opus-4-7", "model lost from final event"
     assert final_data.get("workspace") == "bob", "workspace lost from final event"
     assert final_data.get("outcome") == "productive"
+
+
+# --- Codex log-tailer (Phase 2) ---------------------------------------------
+
+import json as _json  # noqa: E402
+
+from aw_watcher_agent import tailer  # noqa: E402
+
+
+def _rollout_lines(records):
+    return [_json.dumps(r) for r in records]
+
+
+def _call(call_id, name, ts):
+    return {
+        "timestamp": ts,
+        "type": "response_item",
+        "payload": {"type": "function_call", "name": name, "call_id": call_id},
+    }
+
+
+def _output(call_id, ts, output):
+    return {
+        "timestamp": ts,
+        "type": "response_item",
+        "payload": {"type": "function_call_output", "call_id": call_id, "output": output},
+    }
+
+
+def test_activity_bucket_id_is_sibling():
+    assert core.activity_bucket_id("bob") == "aw-watcher-agent-activity_bob"
+    assert core.activity_bucket_id("bob") != core.bucket_id("bob")
+
+
+def test_parse_rollout_pairs_calls_with_outputs():
+    lines = _rollout_lines(
+        [
+            {"type": "session_meta", "payload": {"id": "sess-1", "type": None}},
+            _call("c1", "exec_command", "2026-05-29T05:19:56.055Z"),
+            _output("c1", "2026-05-29T05:19:58.265Z", "Process exited with code 0\nOutput:\nok"),
+            _call("c2", "apply_patch", "2026-05-29T05:20:00.000Z"),
+            _output("c2", "2026-05-29T05:20:00.500Z", "exited with code 1\nboom"),
+        ]
+    )
+    session_id, acts = tailer.parse_rollout(lines)
+    assert session_id == "sess-1"
+    assert [a.tool for a in acts] == ["exec_command", "apply_patch"]
+    assert acts[0].status == "success"
+    assert acts[0].duration_ms == 2210  # 58.265 - 56.055 = 2.210s
+    assert acts[0].session_id == "sess-1"
+    assert acts[1].status == "error"
+    assert acts[1].duration_ms == 500
+
+
+def test_parse_rollout_unpaired_call_gets_zero_duration():
+    lines = _rollout_lines([_call("c9", "read_file", "2026-05-29T05:19:56.055Z")])
+    _, acts = tailer.parse_rollout(lines)
+    assert len(acts) == 1
+    assert acts[0].duration_ms == 0
+    assert acts[0].status == "completed"
+
+
+def test_parse_rollout_ignores_non_tool_records():
+    lines = _rollout_lines(
+        [
+            {"type": "event_msg", "payload": {"type": "agent_message", "message": "hi"}},
+            {"type": "response_item", "payload": {"type": "reasoning", "summary": []}},
+            {"type": "turn_context", "payload": None},
+            "not json at all",
+        ]
+    )
+    session_id, acts = tailer.parse_rollout(lines)
+    assert session_id == ""
+    assert acts == []
+
+
+def test_status_from_output_variants():
+    assert tailer._status_from_output("Process exited with code 0") == "success"
+    assert tailer._status_from_output("exited with code 127") == "error"
+    assert tailer._status_from_output("some normal tool result") == "completed"
+    assert tailer._status_from_output("") == "completed"
+    assert tailer._status_from_output(None) == "completed"
+
+
+def test_activity_to_event_excludes_duration_from_data():
+    act = tailer.ToolActivity(
+        tool="exec_command",
+        status="success",
+        duration_ms=1500,
+        timestamp="2026-05-29T05:19:56.055Z",
+        call_id="c1",
+        session_id="sess-1",
+    )
+    ev = act.to_event()
+    assert ev.data == {"tool": "exec_command", "status": "success", "session_id": "sess-1"}
+    assert ev.duration == 1.5
+    assert "duration_ms" not in ev.data  # keeps same-tool/status blocks mergeable
+
+
+def test_emit_file_ensures_bucket_and_heartbeats(tmp_path):
+    rollout = tmp_path / "rollout-test.jsonl"
+    rollout.write_text(
+        "\n".join(
+            _rollout_lines(
+                [
+                    {"type": "session_meta", "payload": {"id": "sess-1", "type": None}},
+                    _call("c1", "exec_command", "2026-05-29T05:19:56.055Z"),
+                    _output("c1", "2026-05-29T05:19:56.255Z", "Process exited with code 0"),
+                ]
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    seen: list[tuple] = []
+
+    class _Client(_FakeClient):
+        def __init__(self):
+            super().__init__([(200, {})])  # buckets() lookup for ensure_bucket
+
+        def ensure_bucket(self, bid, etype, client_name, host):
+            seen.append(("ensure", bid, etype))
+            return True
+
+        def heartbeat(self, bid, event, pulsetime):
+            seen.append(("hb", bid, event.data, pulsetime))
+            return 1
+
+    count = tailer.emit_file(_Client(), "bob", rollout, pulsetime=3.0)
+    assert count == 1
+    assert seen[0] == ("ensure", "aw-watcher-agent-activity_bob", "app.agent.activity")
+    assert seen[1] == (
+        "hb",
+        "aw-watcher-agent-activity_bob",
+        {"tool": "exec_command", "status": "success", "session_id": "sess-1"},
+        3.0,
+    )

--- a/packages/aw-watcher-agent/tests/test_aw_watcher_agent.py
+++ b/packages/aw-watcher-agent/tests/test_aw_watcher_agent.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 
 import pytest
 
@@ -322,3 +323,162 @@ def test_emit_file_ensures_bucket_and_heartbeats(tmp_path):
         {"tool": "exec_command", "status": "success", "session_id": "sess-1"},
         3.0,
     )
+
+
+# ---------------------------------------------------------------------------
+# Cursor tests: verify incremental emission prevents duplicate heartbeats.
+# ---------------------------------------------------------------------------
+
+
+def test_cursor_path_is_stable_and_distinct(tmp_path, monkeypatch):
+    monkeypatch.setattr(tailer.core, "state_dir", lambda: tmp_path)
+    p1 = tailer._cursor_path(Path("/tmp/sessions/2026/05/29/rollout-abc.jsonl"))
+    p2 = tailer._cursor_path(Path("/tmp/sessions/2026/05/29/rollout-abc.jsonl"))
+    p3 = tailer._cursor_path(Path("/tmp/sessions/2026/05/29/rollout-def.jsonl"))
+    assert str(p1) == str(p2), "same rollout → same cursor path"
+    assert str(p1) != str(p3), "different rollout → different cursor path"
+
+
+def test_cursor_read_write_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setattr(tailer.core, "state_dir", lambda: tmp_path)
+    rollout = Path("/fake/rollout.jsonl")
+    tailer._write_cursor(rollout, 5, "2026-05-29T05:30:00Z")
+    cur = tailer._read_cursor(rollout)
+    assert cur is not None
+    assert cur["last_index"] == 5
+    assert cur["last_timestamp"] == "2026-05-29T05:30:00Z"
+
+
+def test_cursor_read_missing_returns_none(tmp_path, monkeypatch):
+    monkeypatch.setattr(tailer.core, "state_dir", lambda: tmp_path)
+    cur = tailer._read_cursor(Path("/nonexistent/rollout.jsonl"))
+    assert cur is None
+
+
+def test_emit_file_incremental_only_emits_new_calls(tmp_path, monkeypatch):
+    """First run emits all 2 calls; second run emits 0 (cursor advanced)."""
+    monkeypatch.setattr(tailer.core, "state_dir", lambda: tmp_path)
+    rollout = tmp_path / "rollout-test.jsonl"
+    rollout.write_text(
+        "\n".join(
+            _rollout_lines(
+                [
+                    {"type": "session_meta", "payload": {"id": "sess-1", "type": None}},
+                    _call("c1", "exec_command", "2026-05-29T05:19:56.055Z"),
+                    _output("c1", "2026-05-29T05:19:56.255Z", "Process exited with code 0"),
+                    _call("c2", "apply_patch", "2026-05-29T05:20:00.000Z"),
+                    _output("c2", "2026-05-29T05:20:00.500Z", "exited with code 1\nboom"),
+                ]
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    seen: list[tuple] = []
+
+    class _Client(_FakeClient):
+        def __init__(self):
+            super().__init__([])
+
+        def ensure_bucket(self, bid, etype, client_name, host):
+            seen.append(("ensure", bid))
+            return True
+
+        def heartbeat(self, bid, event, pulsetime):
+            seen.append(("hb", bid, event.data["tool"]))
+            return 1
+
+    # First run: emits both calls, writes cursor.
+    count1 = tailer.emit_file(_Client(), "bob", rollout, pulsetime=3.0)
+    assert count1 == 2
+    assert seen == [
+        ("ensure", "aw-watcher-agent-activity_bob"),
+        ("hb", "aw-watcher-agent-activity_bob", "exec_command"),
+        ("hb", "aw-watcher-agent-activity_bob", "apply_patch"),
+    ]
+
+    # Verify cursor was written.
+    cur = tailer._read_cursor(rollout)
+    assert cur is not None
+    assert cur["last_index"] == 1  # 0-based index of the last (2nd) activity
+    assert cur["last_timestamp"] == "2026-05-29T05:20:00.000Z"  # start of apply_patch
+
+    # Second run: nothing emitted (file unchanged, cursor already advanced).
+    seen.clear()
+    count2 = tailer.emit_file(_Client(), "bob", rollout, pulsetime=3.0)
+    assert count2 == 0
+    assert seen == []  # No ensure, no heartbeats — everything already emitted.
+
+
+def test_emit_file_incremental_appends_new_calls(tmp_path, monkeypatch):
+    """First run emits calls 1-2; after appending a 3rd call, only call 3 emits."""
+    monkeypatch.setattr(tailer.core, "state_dir", lambda: tmp_path)
+    rollout = tmp_path / "rollout-test.jsonl"
+
+    # Write initial 2-call transcript.
+    initial_lines = _rollout_lines(
+        [
+            {"type": "session_meta", "payload": {"id": "sess-1", "type": None}},
+            _call("c1", "exec_command", "2026-05-29T05:19:56.055Z"),
+            _output("c1", "2026-05-29T05:19:56.255Z", "Process exited with code 0"),
+            _call("c2", "apply_patch", "2026-05-29T05:20:00.000Z"),
+            _output("c2", "2026-05-29T05:20:00.500Z", "exited with code 1\nboom"),
+        ]
+    )
+    rollout.write_text("\n".join(initial_lines), encoding="utf-8")
+
+    seen: list[str] = []
+
+    class _Client(_FakeClient):
+        def __init__(self):
+            super().__init__([])
+
+        def ensure_bucket(self, bid, etype, client_name, host):
+            return True
+
+        def heartbeat(self, bid, event, pulsetime):
+            seen.append(event.data["tool"])
+            return 1
+
+    # First run.
+    tailer.emit_file(_Client(), "bob", rollout)
+    assert seen == ["exec_command", "apply_patch"]
+    seen.clear()
+
+    # Append a 3rd call.
+    extra_lines = _rollout_lines(
+        [
+            _call("c3", "read_file", "2026-05-29T05:21:00.000Z"),
+            _output("c3", "2026-05-29T05:21:00.350Z", "Process exited with code 0"),
+        ]
+    )
+    with open(rollout, "a", encoding="utf-8") as f:
+        f.write("\n" + "\n".join(extra_lines))
+
+    # Second run: only the new call emits.
+    tailer.emit_file(_Client(), "bob", rollout)
+    assert seen == ["read_file"], "only new call should emit"
+
+
+def test_emit_file_no_cursor_on_empty_activities(tmp_path, monkeypatch):
+    """No-op when the rollout file has no tool calls (no cursor written)."""
+    monkeypatch.setattr(tailer.core, "state_dir", lambda: tmp_path)
+    rollout = tmp_path / "empty.jsonl"
+    rollout.write_text(
+        "\n".join(
+            _rollout_lines([{"type": "session_meta", "payload": {"id": "sess-1", "type": None}}])
+        ),
+        encoding="utf-8",
+    )
+
+    class _Client(_FakeClient):
+        def __init__(self):
+            super().__init__([])
+
+        def ensure_bucket(self, bid, etype, client_name, host):
+            return True
+
+    count = tailer.emit_file(_Client(), "bob", rollout)
+    assert count == 0
+    # Cursor should NOT be created when there's nothing to emit.
+    assert tailer._read_cursor(rollout) is None


### PR DESCRIPTION
## What

Phase 2 of `aw-watcher-agent`: a **Codex log-tailer** that emits per-tool `app.agent.activity` heartbeats, so Codex sessions surface per-tool observability in the local AW Timeline even though Codex can't host an in-process gptme hook.

Follows Phase 1 (#975, session-level events + CC `SessionStart`/`Stop` hooks).

## How

- `tailer.parse_rollout()` — pure, stdlib-only parser of Codex rollout transcripts (`~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`). Pairs each `function_call` with its `function_call_output` by `call_id`, computes wall-clock `duration_ms`, and derives a coarse `success`/`error`/`completed` status from the output (`exited with code N`).
- `tailer.emit_file()` — reuses the vendored `AWClient`; heartbeats each activity so adjacent same-tool/same-status calls merge into one Timeline block.
- New CLI subcommand `aw-watcher-agent tail-codex [--file PATH] [--pulsetime S]` (defaults to the latest rollout).

## Design note (for review)

The original Phase 2 sketch proposed reusing the **session** bucket to keep "AI work" as a single lane. I instead emit to a **sibling** bucket `aw-watcher-agent-activity_<host>` (type `app.agent.activity`): session events are one long block spanning the whole run, while per-tool events are many short blocks — they overlap in time and can't render as a single clean non-overlapping lane in one bucket. aw-webui can still stack the two lanes. Happy to revisit if you'd rather force one bucket.

## Verification

- 19 unit tests pass (`PYTHONPATH=src pytest tests/`), parser tested without a live aw-server.
- ruff + mypy clean (pre-commit green).
- Smoke-tested against a **real** 65-tool-call Codex rollout: correct session_id, `exec_command` ×56 / `write_stdin` ×9, statuses success 51 / completed 9 / error 5, realistic durations.

## Not in this PR (remaining Phase 2 work)

- gptme-native plugin hook (the in-process per-tool subscriber) — separate deliverable, blocked on the gptme plugin API path settling.
- A `--follow` / daemon mode; for now run `tail-codex` on a timer or post-run.

Co-Authored-By: Bob <bob@superuserlabs.org>