### PR TITLE
fix(self-merge): treat green StatusContext checks as passing

### DIFF
--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -682,6 +682,13 @@ def checks_green(status_checks: list[dict[str, Any]]) -> bool:
     Returns True when no checks are configured (no CI), treating the
     absence of CI as neutral rather than failing. Individual checks with no
     status and no conclusion are treated as indeterminate, not passing.
+
+    Handles both check shapes in ``statusCheckRollup``:
+    - ``CheckRun`` (GitHub Actions) — result in ``status``/``conclusion``
+    - ``StatusContext`` (legacy commit statuses, e.g. ``codecov/patch``) —
+      result in ``state`` alone, with no ``status``/``conclusion``. Reading
+      only status/conclusion would treat a green StatusContext as
+      indeterminate and falsely flag CI as not green.
     """
     if not status_checks:
         return True
@@ -689,6 +696,12 @@ def checks_green(status_checks: list[dict[str, Any]]) -> bool:
     for check in status_checks:
         conclusion = (check.get("conclusion") or "").upper()
         status = (check.get("status") or "").upper()
+        state = (check.get("state") or "").upper()
+        # StatusContext entries carry their result in `state` alone.
+        if state and not status and not conclusion:
+            if state not in allowed:
+                return False
+            continue
         if not status and not conclusion:
             return False
         if status and status != "COMPLETED":

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -41,6 +41,37 @@ def test_checks_green_allows_empty_list() -> None:
     assert self_merge_check.checks_green([])
 
 
+def test_checks_green_allows_success_statuscontext() -> None:
+    # StatusContext (legacy commit status, e.g. codecov/patch) carries its
+    # result in `state` with no status/conclusion. A green one must pass.
+    assert self_merge_check.checks_green(
+        [
+            {
+                "__typename": "StatusContext",
+                "context": "codecov/patch",
+                "state": "SUCCESS",
+            }
+        ]
+    )
+
+
+def test_checks_green_rejects_non_success_statuscontext() -> None:
+    for bad in ("PENDING", "FAILURE", "ERROR", "EXPECTED"):
+        assert not self_merge_check.checks_green(
+            [{"__typename": "StatusContext", "context": "ci", "state": bad}]
+        )
+
+
+def test_checks_green_mixed_checkrun_and_statuscontext() -> None:
+    # A green CheckRun alongside a green StatusContext should pass.
+    assert self_merge_check.checks_green(
+        [
+            {"status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"state": "SUCCESS"},
+        ]
+    )
+
+
 def test_parse_pr_target_rejects_malformed_url() -> None:
     """Malformed URL missing owner/repo path segments must raise ValueError."""
     import pytest


### PR DESCRIPTION
## Problem

`checks_green()` in `self-merge-check.py` only reads `status`/`conclusion`, which exist on **CheckRun** entries (GitHub Actions). **StatusContext** entries — legacy GitHub commit statuses such as `codecov/patch` — carry their result in a `state` field with no `status`/`conclusion`. They fell through to the indeterminate branch (`not status and not conclusion → return False`), so a PR was flagged "CI is not fully green" even when every check was SUCCESS/SKIPPED.

This is a **false negative**: it rejects mergeable PRs whenever a green commit-status check is present.

## How it was found

Auditing the self-merge fast-path rollout (Alice's `port-bob-self-merge-orchestration` task). The deployed checker reported `gptme/gptme-contrib#790` as "CI is not fully green", while the counterfactual backfill (which uses an `all SUCCESS/SKIPPED` rule) considered it green. #790's rollup:

```
1 SUCCESS StatusContext  codecov/patch   <- result in .state, not .status/.conclusion
+ 14 CheckRun (SUCCESS) / 4 CheckRun (SKIPPED)
```

The two scripts feeding the same auto-merge decision disagreed on a basic fact. Root cause is this bug.

## Fix

Read `state` for StatusContext entries; a StatusContext passes only when `state ∈ {SUCCESS, NEUTRAL, SKIPPED}` (PENDING/ERROR/FAILURE/EXPECTED still fail). CheckRun handling is unchanged.

Verified: after the fix, `self-merge-check.py --repo gptme/gptme-contrib 790` no longer reports the CI reason (only the expected "PR state is MERGED").

## Tests

Adds coverage for green StatusContext, non-success StatusContext, and mixed CheckRun+StatusContext rollups. Full `test_self_merge_check.py` passes (67).