### PR TITLE
feat(aw-watcher-agent): add emit-activity command

### DIFF
--- a/packages/aw-watcher-agent/src/aw_watcher_agent/cli.py
+++ b/packages/aw-watcher-agent/src/aw_watcher_agent/cli.py
@@ -229,7 +229,7 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     try:
         return int(args.func(args))
-    except (AWClientError, OSError) as exc:
+    except (AWClientError, OSError, ValueError) as exc:
         msg = f"aw-watcher-agent: {exc}"
         if args.strict:
             print(msg, file=sys.stderr)

--- a/packages/aw-watcher-agent/src/aw_watcher_agent/cli.py
+++ b/packages/aw-watcher-agent/src/aw_watcher_agent/cli.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import argparse
 import socket
 import sys
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 
 from .client import AWClient, AWClientError, Event, utc_now_iso
 from . import core
@@ -122,6 +122,28 @@ def cmd_emit_end(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_emit_activity(args: argparse.Namespace) -> int:
+    client = AWClient(args.server)
+    host = _hostname(args.hostname)
+    bid = core.activity_bucket_id(host)
+    client.ensure_bucket(bid, core.ACTIVITY_BUCKET_TYPE, core.CLIENT_NAME, host)
+
+    duration_ms = max(int(args.duration_ms or 0), 0)
+    duration_s = duration_ms / 1000.0
+    start = datetime.now(timezone.utc) - timedelta(milliseconds=duration_ms)
+    event = Event(
+        timestamp=start.isoformat(),
+        duration=duration_s,
+        data=core.activity_data(vars(args)),
+    )
+    event_id = client.heartbeat(bid, event, pulsetime=float(args.pulsetime))
+    print(
+        f"activity emitted: {bid} event_id={event_id} "
+        f"tool={args.tool} duration_ms={duration_ms}"
+    )
+    return 0
+
+
 def cmd_tail_codex(args: argparse.Namespace) -> int:
     from pathlib import Path
 
@@ -159,6 +181,29 @@ def build_parser() -> argparse.ArgumentParser:
     p_end.add_argument("--outcome", help="productive / blocked / noop")
     p_end.add_argument("--duration", type=float, help="fallback duration (s) if no start state")
     p_end.set_defaults(func=cmd_emit_end)
+
+    p_activity = sub.add_parser("emit-activity", help="record one tool activity heartbeat")
+    _add_session_args(p_activity)
+    p_activity.add_argument("--tool", required=True, help="tool name, e.g. shell")
+    p_activity.add_argument(
+        "--status",
+        default="success",
+        help="coarse tool status, e.g. success / error / completed",
+    )
+    p_activity.add_argument(
+        "--duration-ms",
+        dest="duration_ms",
+        type=int,
+        default=0,
+        help="tool duration in milliseconds",
+    )
+    p_activity.add_argument(
+        "--pulsetime",
+        type=float,
+        default=5.0,
+        help="heartbeat merge window in seconds (default: 5.0)",
+    )
+    p_activity.set_defaults(func=cmd_emit_activity)
 
     p_tail = sub.add_parser(
         "tail-codex", help="emit per-tool activity from a Codex rollout transcript"

--- a/packages/aw-watcher-agent/src/aw_watcher_agent/core.py
+++ b/packages/aw-watcher-agent/src/aw_watcher_agent/core.py
@@ -34,7 +34,16 @@ ACTIVITY_BUCKET_TYPE = "app.agent.activity"
 
 # Stable session fields (everything except outcome, which is end-only).
 START_FIELDS = ("harness", "model", "category", "session_id", "trigger", "workspace")
-ACTIVITY_FIELDS = ("harness", "session_id", "tool", "status")
+ACTIVITY_FIELDS = (
+    "harness",
+    "session_id",
+    "tool",
+    "status",
+    "model",
+    "category",
+    "trigger",
+    "workspace",
+)
 
 
 def bucket_id(hostname: str) -> str:
@@ -93,5 +102,11 @@ def session_data(args: dict[str, Any], *, outcome: str | None = None) -> dict[st
 
 
 def activity_data(args: dict[str, Any]) -> dict[str, str]:
-    """Build per-tool activity event data, dropping empty values."""
+    """Build per-tool activity event data, dropping empty values.
+
+    Raises ValueError if 'tool' is absent or empty — it is the semantic
+    discriminator for per-tool heartbeats and cannot be safely omitted.
+    """
+    if not args.get("tool"):
+        raise ValueError("activity_data: 'tool' is required but missing or empty")
     return {f: str(args[f]) for f in ACTIVITY_FIELDS if args.get(f)}

--- a/packages/aw-watcher-agent/src/aw_watcher_agent/core.py
+++ b/packages/aw-watcher-agent/src/aw_watcher_agent/core.py
@@ -34,6 +34,7 @@ ACTIVITY_BUCKET_TYPE = "app.agent.activity"
 
 # Stable session fields (everything except outcome, which is end-only).
 START_FIELDS = ("harness", "model", "category", "session_id", "trigger", "workspace")
+ACTIVITY_FIELDS = ("harness", "session_id", "tool", "status")
 
 
 def bucket_id(hostname: str) -> str:
@@ -89,3 +90,8 @@ def session_data(args: dict[str, Any], *, outcome: str | None = None) -> dict[st
     if outcome:
         data["outcome"] = str(outcome)
     return data
+
+
+def activity_data(args: dict[str, Any]) -> dict[str, str]:
+    """Build per-tool activity event data, dropping empty values."""
+    return {f: str(args[f]) for f in ACTIVITY_FIELDS if args.get(f)}

--- a/packages/aw-watcher-agent/src/aw_watcher_agent/tailer.py
+++ b/packages/aw-watcher-agent/src/aw_watcher_agent/tailer.py
@@ -94,9 +94,14 @@ class ToolActivity:
     def to_event(self, *, min_duration_s: float = 0.0) -> Event:
         """Build an AW event. ``data`` excludes duration so same-tool/status
         calls merge under heartbeat; the per-call duration drives the block."""
-        data = {"tool": self.tool, "status": self.status}
-        if self.session_id:
-            data["session_id"] = self.session_id
+        data = core.activity_data(
+            {
+                "harness": "codex",
+                "session_id": self.session_id,
+                "tool": self.tool,
+                "status": self.status,
+            }
+        )
         return Event(
             timestamp=self.timestamp,
             duration=max(self.duration_ms / 1000.0, min_duration_s),

--- a/packages/aw-watcher-agent/tests/test_aw_watcher_agent.py
+++ b/packages/aw-watcher-agent/tests/test_aw_watcher_agent.py
@@ -45,14 +45,24 @@ def test_activity_data_drops_empty():
         "session_id": "8531",
         "tool": "shell",
         "status": "success",
-        "workspace": "bob",  # not part of activity payload
+        "workspace": "bob",
+        "model": "",  # dropped — falsy
+        "category": None,  # dropped — falsy
     }
     assert core.activity_data(args) == {
         "harness": "gptme",
         "session_id": "8531",
         "tool": "shell",
         "status": "success",
+        "workspace": "bob",
     }
+
+
+def test_activity_data_raises_on_missing_tool():
+    with pytest.raises(ValueError, match="tool"):
+        core.activity_data({"harness": "gptme", "tool": "", "status": "success"})
+    with pytest.raises(ValueError, match="tool"):
+        core.activity_data({"harness": "gptme", "status": "success"})
 
 
 def test_state_roundtrip(tmp_path, monkeypatch):
@@ -256,6 +266,7 @@ def test_emit_activity_uses_activity_bucket_and_duration(monkeypatch):
         "session_id": "abc1",
         "tool": "shell",
         "status": "success",
+        "workspace": "bob",
     }
     assert pulsetime == 3.0
 

--- a/packages/aw-watcher-agent/tests/test_aw_watcher_agent.py
+++ b/packages/aw-watcher-agent/tests/test_aw_watcher_agent.py
@@ -215,6 +215,24 @@ def test_emit_end_preserves_start_metadata(tmp_path, monkeypatch):
     assert final_data.get("outcome") == "productive"
 
 
+def test_main_empty_tool_is_nonfatal(monkeypatch, capsys):
+    """Empty --tool raises ValueError in activity_data(); main() must catch it non-fatally."""
+    from aw_watcher_agent import cli
+
+    # ensure_bucket: GET /api/0/buckets/ (empty → not found) + POST create.
+    # activity_data() is called after that and raises ValueError for empty tool.
+    monkeypatch.setattr(cli, "AWClient", lambda _url: _FakeClient([(200, {}), (200, None)]))
+    rc = cli.main(["emit-activity", "--tool", "", "--session-id", "s1"])
+    assert rc == 0, "non-strict: empty --tool should exit 0, not raise"
+    captured = capsys.readouterr()
+    assert "ignored" in captured.err, "should print the ignored-error message to stderr"
+
+    # With --strict the same error should propagate as exit 1.
+    monkeypatch.setattr(cli, "AWClient", lambda _url: _FakeClient([(200, {}), (200, None)]))
+    rc_strict = cli.main(["--strict", "emit-activity", "--tool", "", "--session-id", "s1"])
+    assert rc_strict == 1
+
+
 def test_emit_activity_uses_activity_bucket_and_duration(monkeypatch):
     from aw_watcher_agent import cli
     import argparse

--- a/packages/aw-watcher-agent/tests/test_aw_watcher_agent.py
+++ b/packages/aw-watcher-agent/tests/test_aw_watcher_agent.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -36,6 +37,22 @@ def test_session_data_drops_empty_and_adds_outcome():
     assert "outcome" not in start
     end = core.session_data(args, outcome="productive")
     assert end["outcome"] == "productive"
+
+
+def test_activity_data_drops_empty():
+    args = {
+        "harness": "gptme",
+        "session_id": "8531",
+        "tool": "shell",
+        "status": "success",
+        "workspace": "bob",  # not part of activity payload
+    }
+    assert core.activity_data(args) == {
+        "harness": "gptme",
+        "session_id": "8531",
+        "tool": "shell",
+        "status": "success",
+    }
 
 
 def test_state_roundtrip(tmp_path, monkeypatch):
@@ -188,6 +205,61 @@ def test_emit_end_preserves_start_metadata(tmp_path, monkeypatch):
     assert final_data.get("outcome") == "productive"
 
 
+def test_emit_activity_uses_activity_bucket_and_duration(monkeypatch):
+    from aw_watcher_agent import cli
+    import argparse
+
+    args = argparse.Namespace(
+        server="http://localhost:5600",
+        hostname="host",
+        harness="gptme",
+        model=None,
+        category=None,
+        session_id="abc1",
+        trigger=None,
+        workspace="bob",
+        tool="shell",
+        status="success",
+        duration_ms=1500,
+        pulsetime=3.0,
+        strict=False,
+    )
+
+    captured: dict[str, object] = {}
+
+    class _CapturingClient(_FakeClient):
+        def __init__(self):
+            super().__init__([])
+
+        def ensure_bucket(self, bid, etype, client_name, host):
+            captured["ensure"] = (bid, etype, client_name, host)
+            return True
+
+        def heartbeat(self, bid, event, pulsetime):
+            captured["heartbeat"] = (bid, event, pulsetime)
+            return 99
+
+    monkeypatch.setattr(cli, "AWClient", lambda _url: _CapturingClient())
+    rc = cli.cmd_emit_activity(args)
+    assert rc == 0
+    assert captured["ensure"] == (
+        "aw-watcher-agent-activity_host",
+        "app.agent.activity",
+        "aw-watcher-agent",
+        "host",
+    )
+    bid, event, pulsetime = cast(tuple[str, Event, float], captured["heartbeat"])
+    assert bid == "aw-watcher-agent-activity_host"
+    assert event.duration == 1.5
+    assert event.data == {
+        "harness": "gptme",
+        "session_id": "abc1",
+        "tool": "shell",
+        "status": "success",
+    }
+    assert pulsetime == 3.0
+
+
 # --- Codex log-tailer (Phase 2) ---------------------------------------------
 
 import json as _json  # noqa: E402
@@ -280,7 +352,12 @@ def test_activity_to_event_excludes_duration_from_data():
         session_id="sess-1",
     )
     ev = act.to_event()
-    assert ev.data == {"tool": "exec_command", "status": "success", "session_id": "sess-1"}
+    assert ev.data == {
+        "harness": "codex",
+        "tool": "exec_command",
+        "status": "success",
+        "session_id": "sess-1",
+    }
     assert ev.duration == 1.5
     assert "duration_ms" not in ev.data  # keeps same-tool/status blocks mergeable
 
@@ -320,7 +397,12 @@ def test_emit_file_ensures_bucket_and_heartbeats(tmp_path):
     assert seen[1] == (
         "hb",
         "aw-watcher-agent-activity_bob",
-        {"tool": "exec_command", "status": "success", "session_id": "sess-1"},
+        {
+            "harness": "codex",
+            "tool": "exec_command",
+            "status": "success",
+            "session_id": "sess-1",
+        },
         3.0,
     )
 


### PR DESCRIPTION
## Summary
- add an `emit-activity` subcommand for per-tool `app.agent.activity` heartbeats
- reuse a shared activity payload builder for both CLI emission and the Codex tailer
- extend the watcher tests to cover the new CLI path and updated event payload shape

## Testing
- `PYTHONPATH=/tmp/gptme-contrib-aw-416b/packages/aw-watcher-agent/src /home/bob/bob/.venv/bin/pytest /tmp/gptme-contrib-aw-416b/packages/aw-watcher-agent/tests/test_aw_watcher_agent.py -q`