### PR TITLE
docs(codegraph): add 'when to use' decision rule (codegraph vs grep vs semantic)

### DIFF
--- a/packages/gptme-codegraph/README.md
+++ b/packages/gptme-codegraph/README.md
@@ -12,6 +12,16 @@ Structural code retrieval for gptme via [tree-sitter](https://tree-sitter.github
 - **Blast/impact semantics split**: `blast` = dependency closure (what X needs), `impact` = what breaks if you change X
 - **Repo map / symbol skeletons** for token-cheap default codebase context
 
+## When to use
+
+Reach for the right retrieval tool by the *shape* of the question, not by habit:
+
+- **codegraph** — structural / symbol questions: *where is `X` defined?*, *who calls `X`?*, *what breaks if I change `X`?*, *give me a repo skeleton*. Use it when you care about definitions, call graphs, blast radius, or impact.
+- **grep / ripgrep** — exact strings and known patterns: a literal identifier, an error message, a config key. Fastest when you already know the text to match.
+- **semantic search (gptme-rag / semble)** — conceptual queries where you don't know the exact tokens: *how does auth work here?*, *where is retry logic?*. Matches by meaning over text chunks.
+
+Rule of thumb: exact text → grep; "what does this concept look like" → semantic; "how is this symbol wired" → codegraph.
+
 ## Install
 
 ```bash

--- a/packages/gptme-codegraph/src/gptme_codegraph/mcp_server.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/mcp_server.py
@@ -4,11 +4,12 @@ Exposes codegraph tools as MCP resources so any MCP-compatible agent
 (Claude Code, Cursor, Codex, gptme) can query code structure without
 a separate CLI invocation.
 
-When to use codegraph: structural / symbol questions — where is `X` defined,
-who calls `X`, what breaks if I change `X`, or "give me a repo skeleton". For
-exact strings use grep/ripgrep; for conceptual "how does this work" questions
-where you don't know the tokens, use semantic search (gptme-rag). Rule of
-thumb: exact text -> grep; concept -> semantic; symbol wiring -> codegraph.
+Use codegraph when you need symbol structure — definitions, call graphs, or
+impact analysis — without chaining multiple grep passes. It gives you precise,
+structured answers about how code is wired together. Reserve grep for exact
+string/pattern lookups and semantic search (gptme-rag) for conceptual queries
+where you don't know the exact tokens.
+Rule of thumb: exact text → grep; concept → semantic; symbol wiring → codegraph.
 
 Usage:
     # As an MCP server (stdio transport)

--- a/packages/gptme-codegraph/src/gptme_codegraph/mcp_server.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/mcp_server.py
@@ -4,6 +4,12 @@ Exposes codegraph tools as MCP resources so any MCP-compatible agent
 (Claude Code, Cursor, Codex, gptme) can query code structure without
 a separate CLI invocation.
 
+When to use codegraph: structural / symbol questions — where is `X` defined,
+who calls `X`, what breaks if I change `X`, or "give me a repo skeleton". For
+exact strings use grep/ripgrep; for conceptual "how does this work" questions
+where you don't know the tokens, use semantic search (gptme-rag). Rule of
+thumb: exact text -> grep; concept -> semantic; symbol wiring -> codegraph.
+
 Usage:
     # As an MCP server (stdio transport)
     gptme-codegraph-mcp


### PR DESCRIPTION
## What

Adds a short, discoverable "when to use codegraph vs grep/semantic search" decision rule so agents reach for codegraph at the right time (structural/symbol queries) instead of defaulting to text search.

Two surfaces:
- **README** — new `## When to use` section mapping query *shape* to tool (codegraph = symbol wiring; grep = exact text; semantic/gptme-rag = conceptual).
- **MCP server module docstring** — same rule inline, so it surfaces at call time for MCP-compatible agents (Claude Code, Cursor, Codex, gptme).

## Why

The README tagline says codegraph is "complementary to gptme-rag," but nowhere did it state the explicit decision rule, so agents default to grep even for symbol/structure questions. This is a tiny, no-logic doc change.

Rule of thumb shipped: **exact text → grep; concept → semantic; symbol wiring → codegraph.**

## Verification
- `python3 -m py_compile mcp_server.py` ✅ (docstring-only change)
- pre-commit (prek) ✅

Closes ErikBjare/bob task `codegraph-when-to-use-instruction-surface` (mined from `knowledge/research/2026-05-17-gptme-codegraph-multi-language-dogfood.md`).