### PR TITLE
feat(codegraph): add committed repo-map artifact CLI

### DIFF
--- a/packages/gptme-codegraph/README.md
+++ b/packages/gptme-codegraph/README.md
@@ -59,6 +59,30 @@ gptme-codegraph path/to/file.py def my_function
 gptme-codegraph path/to/repo map
 ```
 
+### Committed repo-map artifact
+
+"Analyze once, commit the graph." Generate a `.gptme-codegraph-map.json` that
+teammates and agents can read for a repo's structural outline without re-running
+the tree-sitter pipeline:
+
+```bash
+# Generate and save the artifact at <repo>/.gptme-codegraph-map.json
+gptme-codegraph-commit-map path/to/repo
+
+# Check freshness (exit 0 = fresh, 1 = stale/missing) — for pre-commit/CI gating
+gptme-codegraph-commit-map path/to/repo --check
+
+# Regenerate only if stale (use in a pre-commit hook); --force always regenerates
+gptme-codegraph-commit-map path/to/repo --refresh
+```
+
+Freshness is keyed off a digest of the tracked source files (`*.py`, `*.ts`,
+`*.tsx`, `*.js`, `*.rs`), not `HEAD` — so an artifact regenerated in a
+pre-commit hook stays fresh after the commit that contains it lands. The default
+staleness window is 1 day (`--stale-after-days N` to change it). The artifact is
+structural only (paths, class/function names, nesting) — no source, comments, or
+values — so it is safe to commit to any repo.
+
 ### MCP Server
 
 ```bash

--- a/packages/gptme-codegraph/pyproject.toml
+++ b/packages/gptme-codegraph/pyproject.toml
@@ -28,6 +28,7 @@ dev = [
 [project.scripts]
 gptme-codegraph = "gptme_codegraph.core:main"
 gptme-codegraph-mcp = "gptme_codegraph.mcp_server:main"
+gptme-codegraph-commit-map = "gptme_codegraph.commit_map:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/packages/gptme-codegraph/src/gptme_codegraph/commit_map.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/commit_map.py
@@ -71,8 +71,8 @@ def _git_toplevel(directory: Path) -> Path | None:
     return None
 
 
-def _tracked_source_files(directory: Path) -> list[Path] | None:
-    """Return tracked source files for digesting, or None on git failure."""
+def _tracked_source_files(directory: Path) -> tuple[list[Path], Path] | None:
+    """Return (tracked source files, repo_root) or None on git failure."""
     repo_root = _git_toplevel(directory)
     if repo_root is None:
         return None
@@ -103,20 +103,17 @@ def _tracked_source_files(directory: Path) -> list[Path] | None:
         path = repo_root / rel_path
         if path.is_file():
             files.append(path)
-    return files
+    return files, repo_root
 
 
 def _source_digest(directory: Path) -> tuple[str | None, int]:
     """Return a stable digest of tracked source files plus the file count."""
-    tracked = _tracked_source_files(directory)
-    if tracked is None:
+    result = _tracked_source_files(directory)
+    if result is None:
         return None, 0
 
+    tracked, repo_root = result
     digest = hashlib.sha256()
-    repo_root = _git_toplevel(directory)
-    if repo_root is None:
-        return None, 0
-
     count = 0
     for path in tracked:
         try:
@@ -206,7 +203,10 @@ def _map_is_fresh(
     # Backward-compat fallback for older artifacts without a source_digest.
     current_sha = _git_sha(directory)
     map_sha = existing.get("git_sha")
-    if current_sha and map_sha and current_sha != map_sha:
+    if current_sha is None:
+        # Git unavailable: can't verify freshness, treat as stale to be safe.
+        return False
+    if map_sha and current_sha != map_sha:
         return False
 
     return True

--- a/packages/gptme-codegraph/src/gptme_codegraph/commit_map.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/commit_map.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Generate, save, and refresh committed gptme-codegraph repo-map artifacts.
+
+A committed ``.gptme-codegraph-map.json`` lets teammates and agents read a
+repo's structural outline without re-running the tree-sitter pipeline
+("analyze once, commit the graph"). Freshness is keyed off a digest of the
+tracked source files, so a pre-commit-generated artifact stays fresh after the
+commit lands (unlike a naive ``git_sha == HEAD`` check, which goes stale the
+instant the commit that contains it is created).
+
+Usage:
+    python3 -m gptme_codegraph.commit_map <repo-dir> [--output FILE]
+    python3 -m gptme_codegraph.commit_map <repo-dir> --check
+    python3 -m gptme_codegraph.commit_map <repo-dir> --refresh
+    python3 -m gptme_codegraph.commit_map <repo-dir> --stale-after-days N
+
+Or via the installed console script:
+    gptme-codegraph-commit-map <repo-dir> --refresh
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from .core import build_repo_map, format_repo_map
+
+DEFAULT_OUTPUT_FILE = ".gptme-codegraph-map.json"
+DEFAULT_STALE_DAYS = 1
+ARTIFACT_VERSION = 1
+SOURCE_PATTERNS = ("*.py", "*.ts", "*.tsx", "*.js", "*.rs")
+
+
+def _git_sha(directory: Path) -> str | None:
+    """Get the current HEAD SHA for a directory."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(directory), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except (subprocess.TimeoutExpired, OSError):
+        pass
+    return None
+
+
+def _git_toplevel(directory: Path) -> Path | None:
+    """Return the git top-level directory for a path, or None if unavailable."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(directory), "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            return Path(result.stdout.strip())
+    except (subprocess.TimeoutExpired, OSError):
+        pass
+    return None
+
+
+def _tracked_source_files(directory: Path) -> list[Path] | None:
+    """Return tracked source files for digesting, or None on git failure."""
+    repo_root = _git_toplevel(directory)
+    if repo_root is None:
+        return None
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(directory),
+                "ls-files",
+                "-z",
+                "--full-name",
+                "--",
+                *SOURCE_PATTERNS,
+            ],
+            capture_output=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return None
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+
+    files: list[Path] = []
+    for rel_path in result.stdout.decode("utf-8", errors="ignore").split("\0"):
+        if not rel_path:
+            continue
+        path = repo_root / rel_path
+        if path.is_file():
+            files.append(path)
+    return files
+
+
+def _source_digest(directory: Path) -> tuple[str | None, int]:
+    """Return a stable digest of tracked source files plus the file count."""
+    tracked = _tracked_source_files(directory)
+    if tracked is None:
+        return None, 0
+
+    digest = hashlib.sha256()
+    repo_root = _git_toplevel(directory)
+    if repo_root is None:
+        return None, 0
+
+    count = 0
+    for path in tracked:
+        try:
+            rel_path = path.relative_to(repo_root).as_posix()
+            digest.update(rel_path.encode("utf-8"))
+            digest.update(b"\0")
+            digest.update(path.read_bytes())
+            digest.update(b"\0")
+            count += 1
+        except OSError:
+            return None, 0
+
+    return digest.hexdigest(), count
+
+
+def generate_map(
+    directory: Path,
+    *,
+    max_files: int = 20,
+    max_symbols_per_file: int = 12,
+) -> dict[str, object]:
+    """Generate a repo map with metadata, matching build_repo_map() output."""
+    source_digest, source_file_count = _source_digest(directory)
+    repo_map = build_repo_map(
+        str(directory),
+        max_files=max_files,
+        max_symbols_per_file=max_symbols_per_file,
+    )
+
+    return {
+        "version": ARTIFACT_VERSION,
+        "generated": datetime.now(timezone.utc).isoformat(),
+        "generator": "gptme-codegraph-commit-map",
+        "git_sha": _git_sha(directory),
+        "source_digest": source_digest,
+        "source_file_count": source_file_count,
+        **repo_map,
+        "max_files": max_files,
+        "max_symbols_per_file": max_symbols_per_file,
+    }
+
+
+def _load_existing_map(path: Path) -> dict[str, object] | None:
+    """Load an existing map file, returning None if missing or unparseable."""
+    if not path.exists():
+        return None
+    try:
+        with open(path) as f:
+            return json.load(f)  # type: ignore[no-any-return]
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _map_is_fresh(
+    existing: dict[str, object],
+    directory: Path,
+    stale_after_days: int,
+) -> bool:
+    """Return True if the existing map is still valid (fresh + matching source)."""
+    # Check version compatibility
+    version = existing.get("version")
+    if version != ARTIFACT_VERSION:
+        return False
+
+    # Check staleness by age
+    generated_str = existing.get("generated")
+    if isinstance(generated_str, str):
+        try:
+            generated = datetime.fromisoformat(generated_str)
+            age = datetime.now(timezone.utc) - generated
+            if age > timedelta(days=stale_after_days):
+                return False
+        except ValueError:
+            return False
+    else:
+        return False
+
+    # New contract: freshness tracks source content, not HEAD. A committed
+    # artifact generated pre-commit should still be fresh after the commit lands.
+    source_digest = existing.get("source_digest")
+    if isinstance(source_digest, str) and source_digest:
+        current_digest, _ = _source_digest(directory)
+        if current_digest is None:
+            return False
+        return current_digest == source_digest
+
+    # Backward-compat fallback for older artifacts without a source_digest.
+    current_sha = _git_sha(directory)
+    map_sha = existing.get("git_sha")
+    if current_sha and map_sha and current_sha != map_sha:
+        return False
+
+    return True
+
+
+def save_map(directory: Path, output_path: Path, map_data: dict[str, object]) -> None:
+    """Write the map to disk with atomic semantics (write tmp, then rename)."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = output_path.with_suffix(output_path.suffix + ".tmp")
+    with open(tmp_path, "w") as f:
+        json.dump(map_data, f, indent=2, sort_keys=True, default=str)
+    os.replace(tmp_path, output_path)
+
+
+def cmd_generate(args: argparse.Namespace) -> int:
+    """Generate a new map and save it."""
+    directory = Path(args.directory).resolve()
+    if not directory.is_dir():
+        print(f"Error: not a directory: {directory}", file=sys.stderr)
+        return 1
+
+    output_path = directory / (args.output or DEFAULT_OUTPUT_FILE)
+    map_data = generate_map(
+        directory,
+        max_files=args.max_files,
+        max_symbols_per_file=args.max_symbols_per_file,
+    )
+    save_map(directory, output_path, map_data)
+
+    files_shown = map_data.get("files_shown", 0)
+    symbols_shown = map_data.get("symbols_shown", 0)
+    print(f"Saved repo map to {output_path}")
+    print(f"  {files_shown} files, {symbols_shown} symbols shown")
+    print(format_repo_map(map_data))
+
+    return 0
+
+
+def cmd_check(args: argparse.Namespace) -> int:
+    """Check freshness of existing map. Exit 0 if fresh, 1 if stale/missing."""
+    directory = Path(args.directory).resolve()
+    output_path = directory / (args.output or DEFAULT_OUTPUT_FILE)
+
+    existing = _load_existing_map(output_path)
+    if existing is None:
+        print(f"STALE: no map found at {output_path}")
+        return 1
+
+    stale_days = getattr(args, "stale_after_days", DEFAULT_STALE_DAYS)
+    if _map_is_fresh(existing, directory, stale_days):
+        generated = existing.get("generated", "unknown")
+        sha = existing.get("git_sha", "unknown")
+        print(f"FRESH: generated {generated}, sha {sha}")
+        return 0
+    else:
+        generated = existing.get("generated", "unknown")
+        current_sha = _git_sha(directory) or "unknown"
+        map_sha = existing.get("git_sha", "unknown")
+        print(
+            f"STALE: generated {generated}, "
+            f"map sha {map_sha}, current sha {current_sha}"
+        )
+        return 1
+
+
+def cmd_refresh(args: argparse.Namespace) -> int:
+    """Check freshness and regenerate if stale."""
+    check_args = argparse.Namespace(
+        directory=args.directory,
+        output=args.output,
+        stale_after_days=args.stale_after_days,
+    )
+    if cmd_check(check_args) == 0 and not args.force:
+        print("Map is fresh, no refresh needed (use --force to override)")
+        return 0
+
+    print("Map is stale or missing, regenerating...")
+    return cmd_generate(args)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate, save, and refresh committed gptme-codegraph repo-map artifacts",
+    )
+    parser.add_argument("directory", help="Repository directory to map")
+    parser.add_argument(
+        "--output",
+        "-o",
+        default=DEFAULT_OUTPUT_FILE,
+        help=f"Output filename (default: {DEFAULT_OUTPUT_FILE})",
+    )
+    parser.add_argument(
+        "--max-files",
+        type=int,
+        default=20,
+        help="Maximum files to include in map",
+    )
+    parser.add_argument(
+        "--max-symbols-per-file",
+        type=int,
+        default=12,
+        help="Maximum symbols per file",
+    )
+    parser.add_argument(
+        "--stale-after-days",
+        type=int,
+        default=DEFAULT_STALE_DAYS,
+        help=f"Treat map as stale after N days (default: {DEFAULT_STALE_DAYS})",
+    )
+
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--check", action="store_true", help="Check freshness (exit 0=fresh, 1=stale)"
+    )
+    mode.add_argument(
+        "--refresh",
+        action="store_true",
+        help="Check freshness and regenerate if stale",
+    )
+    mode.add_argument(
+        "--force", action="store_true", help="Force refresh even if fresh"
+    )
+
+    args = parser.parse_args()
+
+    if args.check:
+        sys.exit(cmd_check(args))
+    elif args.refresh or args.force:
+        sys.exit(cmd_refresh(args))
+    else:
+        sys.exit(cmd_generate(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/gptme-codegraph/src/gptme_codegraph/commit_map.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/commit_map.py
@@ -186,7 +186,7 @@ def _map_is_fresh(
             age = datetime.now(timezone.utc) - generated
             if age > timedelta(days=stale_after_days):
                 return False
-        except ValueError:
+        except (ValueError, TypeError):
             return False
     else:
         return False

--- a/packages/gptme-codegraph/src/gptme_codegraph/commit_map.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/commit_map.py
@@ -12,10 +12,12 @@ Usage:
     python3 -m gptme_codegraph.commit_map <repo-dir> [--output FILE]
     python3 -m gptme_codegraph.commit_map <repo-dir> --check
     python3 -m gptme_codegraph.commit_map <repo-dir> --refresh
+    python3 -m gptme_codegraph.commit_map <repo-dir> --refresh --force
     python3 -m gptme_codegraph.commit_map <repo-dir> --stale-after-days N
 
 Or via the installed console script:
     gptme-codegraph-commit-map <repo-dir> --refresh
+    gptme-codegraph-commit-map <repo-dir> --refresh --force
 """
 
 from __future__ import annotations
@@ -145,13 +147,13 @@ def generate_map(
     )
 
     return {
+        **repo_map,
         "version": ARTIFACT_VERSION,
         "generated": datetime.now(timezone.utc).isoformat(),
         "generator": "gptme-codegraph-commit-map",
         "git_sha": _git_sha(directory),
         "source_digest": source_digest,
         "source_file_count": source_file_count,
-        **repo_map,
         "max_files": max_files,
         "max_symbols_per_file": max_symbols_per_file,
     }
@@ -324,8 +326,10 @@ def main() -> None:
         action="store_true",
         help="Check freshness and regenerate if stale",
     )
-    mode.add_argument(
-        "--force", action="store_true", help="Force refresh even if fresh"
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Force refresh even if fresh (use with --refresh)",
     )
 
     args = parser.parse_args()

--- a/packages/gptme-codegraph/tests/test_commit_map.py
+++ b/packages/gptme-codegraph/tests/test_commit_map.py
@@ -71,6 +71,19 @@ def test_map_is_fresh_rejects_old_age():
     assert commit_map._map_is_fresh(existing, Path("/tmp"), 1) is False
 
 
+def test_map_is_fresh_rejects_timezone_naive_generated():
+    # A hand-crafted or older-tool artifact may omit the UTC offset.
+    # datetime.fromisoformat("2024-01-01T12:00:00") succeeds but the
+    # subsequent subtraction from timezone.utc raises TypeError — must return False, not crash.
+    naive_iso = "2024-01-01T12:00:00"  # no "+00:00"
+    existing = {
+        "version": commit_map.ARTIFACT_VERSION,
+        "generated": naive_iso,
+        "source_digest": "digest",
+    }
+    assert commit_map._map_is_fresh(existing, Path("/tmp"), 365) is False
+
+
 def test_map_is_fresh_rejects_version_mismatch():
     existing = {
         "version": commit_map.ARTIFACT_VERSION + 1,

--- a/packages/gptme-codegraph/tests/test_commit_map.py
+++ b/packages/gptme-codegraph/tests/test_commit_map.py
@@ -91,6 +91,9 @@ def test_map_is_fresh_backward_compat_git_sha_fallback():
         assert commit_map._map_is_fresh(existing, Path("/tmp"), 1) is True
     with patch.object(commit_map, "_git_sha", return_value="sha-2"):
         assert commit_map._map_is_fresh(existing, Path("/tmp"), 1) is False
+    # Git unavailable: can't verify, must treat as stale (not silently fresh).
+    with patch.object(commit_map, "_git_sha", return_value=None):
+        assert commit_map._map_is_fresh(existing, Path("/tmp"), 1) is False
 
 
 def test_save_and_load_roundtrip(tmp_path):

--- a/packages/gptme-codegraph/tests/test_commit_map.py
+++ b/packages/gptme-codegraph/tests/test_commit_map.py
@@ -1,0 +1,139 @@
+"""Tests for gptme_codegraph.commit_map (committed repo-map artifact contract)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+from gptme_codegraph import commit_map
+
+
+def test_generate_map_includes_source_digest_metadata(tmp_path):
+    with (
+        patch.object(
+            commit_map,
+            "build_repo_map",
+            return_value={"directory": str(tmp_path), "files": [], "files_shown": 0},
+        ),
+        patch.object(commit_map, "_git_sha", return_value="abc123"),
+        patch.object(commit_map, "_source_digest", return_value=("digest", 7)),
+    ):
+        result = commit_map.generate_map(tmp_path)
+
+    assert result["version"] == commit_map.ARTIFACT_VERSION
+    assert result["git_sha"] == "abc123"
+    assert result["source_digest"] == "digest"
+    assert result["source_file_count"] == 7
+    assert result["generator"] == "gptme-codegraph-commit-map"
+
+
+def test_map_is_fresh_prefers_source_digest_over_git_sha():
+    # Source digest matches but git_sha differs -> still fresh. This is the
+    # whole point of the contract: a committed artifact stays fresh after the
+    # commit that contains it lands and moves HEAD.
+    existing = {
+        "version": commit_map.ARTIFACT_VERSION,
+        "generated": datetime.now(timezone.utc).isoformat(),
+        "source_digest": "digest",
+        "git_sha": "old-sha",
+    }
+
+    with (
+        patch.object(commit_map, "_source_digest", return_value=("digest", 9)),
+        patch.object(commit_map, "_git_sha", return_value="new-sha"),
+    ):
+        assert commit_map._map_is_fresh(existing, Path("/tmp"), 1) is True
+
+
+def test_map_is_fresh_rejects_digest_mismatch():
+    existing = {
+        "version": commit_map.ARTIFACT_VERSION,
+        "generated": datetime.now(timezone.utc).isoformat(),
+        "source_digest": "digest-a",
+        "git_sha": "same-sha",
+    }
+
+    with patch.object(commit_map, "_source_digest", return_value=("digest-b", 9)):
+        assert commit_map._map_is_fresh(existing, Path("/tmp"), 1) is False
+
+
+def test_map_is_fresh_rejects_old_age():
+    old = datetime.now(timezone.utc) - timedelta(days=3)
+    existing = {
+        "version": commit_map.ARTIFACT_VERSION,
+        "generated": old.isoformat(),
+        "source_digest": "digest",
+    }
+    # Age check fires before the digest check, so no source_digest patch needed.
+    assert commit_map._map_is_fresh(existing, Path("/tmp"), 1) is False
+
+
+def test_map_is_fresh_rejects_version_mismatch():
+    existing = {
+        "version": commit_map.ARTIFACT_VERSION + 1,
+        "generated": datetime.now(timezone.utc).isoformat(),
+        "source_digest": "digest",
+    }
+    assert commit_map._map_is_fresh(existing, Path("/tmp"), 1) is False
+
+
+def test_map_is_fresh_backward_compat_git_sha_fallback():
+    # Older artifacts without source_digest fall back to git_sha equality.
+    existing = {
+        "version": commit_map.ARTIFACT_VERSION,
+        "generated": datetime.now(timezone.utc).isoformat(),
+        "git_sha": "sha-1",
+    }
+    with patch.object(commit_map, "_git_sha", return_value="sha-1"):
+        assert commit_map._map_is_fresh(existing, Path("/tmp"), 1) is True
+    with patch.object(commit_map, "_git_sha", return_value="sha-2"):
+        assert commit_map._map_is_fresh(existing, Path("/tmp"), 1) is False
+
+
+def test_save_and_load_roundtrip(tmp_path):
+    output = tmp_path / commit_map.DEFAULT_OUTPUT_FILE
+    data = {"version": 1, "files": [], "source_digest": "d"}
+    commit_map.save_map(tmp_path, output, data)
+
+    assert output.exists()
+    loaded = commit_map._load_existing_map(output)
+    assert loaded == data
+    # Atomic-write tmp file must not linger.
+    assert not output.with_suffix(output.suffix + ".tmp").exists()
+
+
+def test_load_existing_map_handles_corrupt_json(tmp_path):
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not valid json")
+    assert commit_map._load_existing_map(bad) is None
+
+
+def test_cmd_check_missing_map_is_stale(tmp_path):
+    args = argparse.Namespace(
+        directory=str(tmp_path),
+        output=commit_map.DEFAULT_OUTPUT_FILE,
+        stale_after_days=1,
+    )
+    assert commit_map.cmd_check(args) == 1
+
+
+def test_cmd_check_fresh_map_exits_zero(tmp_path):
+    output = tmp_path / commit_map.DEFAULT_OUTPUT_FILE
+    data = {
+        "version": commit_map.ARTIFACT_VERSION,
+        "generated": datetime.now(timezone.utc).isoformat(),
+        "source_digest": "digest",
+        "git_sha": "sha",
+    }
+    output.write_text(json.dumps(data))
+
+    args = argparse.Namespace(
+        directory=str(tmp_path),
+        output=commit_map.DEFAULT_OUTPUT_FILE,
+        stale_after_days=1,
+    )
+    with patch.object(commit_map, "_source_digest", return_value=("digest", 1)):
+        assert commit_map.cmd_check(args) == 0

--- a/packages/gptme-codegraph/tests/test_commit_map.py
+++ b/packages/gptme-codegraph/tests/test_commit_map.py
@@ -137,3 +137,64 @@ def test_cmd_check_fresh_map_exits_zero(tmp_path):
     )
     with patch.object(commit_map, "_source_digest", return_value=("digest", 1)):
         assert commit_map.cmd_check(args) == 0
+
+
+def test_generate_map_metadata_not_overwritten_by_repo_map(tmp_path):
+    # If build_repo_map returns keys that collide with freshness metadata, the
+    # explicit metadata values must win.
+    colliding_repo_map = {
+        "version": 999,
+        "source_digest": "WRONG",
+        "source_file_count": 0,
+        "files": [],
+        "files_shown": 2,
+    }
+    with (
+        patch.object(commit_map, "build_repo_map", return_value=colliding_repo_map),
+        patch.object(commit_map, "_git_sha", return_value="sha"),
+        patch.object(commit_map, "_source_digest", return_value=("correct-digest", 5)),
+    ):
+        result = commit_map.generate_map(tmp_path)
+
+    assert result["version"] == commit_map.ARTIFACT_VERSION
+    assert result["source_digest"] == "correct-digest"
+    assert result["source_file_count"] == 5
+
+
+def test_cmd_refresh_force_regenerates_fresh_map(tmp_path):
+    # --refresh --force must regenerate even when the map is already fresh.
+    output = tmp_path / commit_map.DEFAULT_OUTPUT_FILE
+    data = {
+        "version": commit_map.ARTIFACT_VERSION,
+        "generated": datetime.now(timezone.utc).isoformat(),
+        "source_digest": "digest",
+        "git_sha": "sha",
+    }
+    output.write_text(json.dumps(data))
+
+    args = argparse.Namespace(
+        directory=str(tmp_path),
+        output=commit_map.DEFAULT_OUTPUT_FILE,
+        stale_after_days=1,
+        max_files=20,
+        max_symbols_per_file=12,
+        force=True,
+    )
+
+    with (
+        patch.object(commit_map, "_source_digest", return_value=("digest", 1)),
+        patch.object(
+            commit_map,
+            "build_repo_map",
+            return_value={"files": [], "files_shown": 0, "symbols_shown": 0},
+        ),
+        patch.object(commit_map, "_git_sha", return_value="sha"),
+        patch.object(commit_map, "format_repo_map", return_value=""),
+    ):
+        result = commit_map.cmd_refresh(args)
+
+    assert result == 0
+    # Map must have been rewritten (new generated timestamp differs from original).
+    loaded = commit_map._load_existing_map(output)
+    assert loaded is not None
+    assert loaded.get("source_file_count") == 1


### PR DESCRIPTION
## What

Adds a `gptme-codegraph-commit-map` CLI to the gptme-codegraph package for generating, checking, and refreshing a committed `.gptme-codegraph-map.json` repo-map artifact — the "analyze once, commit the graph" pattern.

## Why

The generator previously lived as a workspace-local script (in Bob's repo) that imported `gptme_codegraph.core` via a brittle `sys.path` hack. Promoting it into the package itself means **any** repo (gptme, gptme-cloud, agent workspaces) can adopt the pattern via a clean console script — teammates and agents read a repo's structural outline without re-running the tree-sitter pipeline.

## Changes

- New module `gptme_codegraph.commit_map` with `generate` / `--check` / `--refresh` / `--force` modes
- Console entry point `gptme-codegraph-commit-map`
- Freshness keyed off a **digest of tracked source files** (not `HEAD`), so an artifact regenerated in a pre-commit hook stays fresh after the commit that contains it lands — a naive `git_sha == HEAD` check goes stale the instant the commit is created
- Backward-compat `git_sha` fallback for older artifacts without a digest
- 10 unit tests covering freshness contract (digest match/mismatch, age, version, backward-compat), roundtrip save/load, corrupt-JSON handling, and CLI check modes
- README section documenting the CLI

## Verification

- `pytest tests/test_commit_map.py` → 10 passed
- `ruff check` + `mypy` clean
- Smoke: generate then `--check` reports FRESH against a real directory

The artifact is structural only (paths, class/function names, nesting) — no source, comments, or values — safe to commit to any repo. The MCP server remains the source of truth; the committed artifact is a cache layer for faster cold-session startup.