### PR TITLE
fix(codegraph): pin committed repo-map directory to '.' for portability

### DIFF
--- a/packages/gptme-codegraph/src/gptme_codegraph/commit_map.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/commit_map.py
@@ -145,6 +145,14 @@ def generate_map(
 
     return {
         **repo_map,
+        # The committed artifact lives in the repo it maps, so the absolute
+        # build path from build_repo_map() is non-portable: it leaks the
+        # generating machine's filesystem layout and churns the diff across
+        # clones/CI. Per-file paths are already repo-relative; pin the
+        # top-level directory to "." so the artifact is reproducible anywhere.
+        # (The live MCP server keeps the absolute path — it is a query
+        # response, not a committed file.)
+        "directory": ".",
         "version": ARTIFACT_VERSION,
         "generated": datetime.now(timezone.utc).isoformat(),
         "generator": "gptme-codegraph-commit-map",

--- a/packages/gptme-codegraph/src/gptme_codegraph/commit_map.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/commit_map.py
@@ -248,7 +248,7 @@ def cmd_generate(args: argparse.Namespace) -> int:
     symbols_shown = map_data.get("symbols_shown", 0)
     print(f"Saved repo map to {output_path}")
     print(f"  {files_shown} files, {symbols_shown} symbols shown")
-    print(format_repo_map(map_data))
+    print(format_repo_map({**map_data, "directory": str(directory)}))
 
     return 0
 

--- a/packages/gptme-codegraph/tests/test_commit_map.py
+++ b/packages/gptme-codegraph/tests/test_commit_map.py
@@ -177,6 +177,25 @@ def test_generate_map_metadata_not_overwritten_by_repo_map(tmp_path):
     assert result["source_file_count"] == 5
 
 
+def test_generate_map_directory_is_portable(tmp_path):
+    # build_repo_map() returns an absolute build path, but the committed
+    # artifact must be reproducible across clones/CI — the top-level directory
+    # is pinned to "." regardless of where the map was generated.
+    abs_dir_repo_map = {
+        "directory": str(tmp_path),
+        "files": [],
+        "files_shown": 0,
+    }
+    with (
+        patch.object(commit_map, "build_repo_map", return_value=abs_dir_repo_map),
+        patch.object(commit_map, "_git_sha", return_value="sha"),
+        patch.object(commit_map, "_source_digest", return_value=("digest", 1)),
+    ):
+        result = commit_map.generate_map(tmp_path)
+
+    assert result["directory"] == "."
+
+
 def test_cmd_refresh_force_regenerates_fresh_map(tmp_path):
     # --refresh --force must regenerate even when the map is already fresh.
     output = tmp_path / commit_map.DEFAULT_OUTPUT_FILE


### PR DESCRIPTION
## Problem

The committed repo-map artifact CLI (`gptme-codegraph-commit-map`, #1012) stores `build_repo_map()`'s **absolute** build path in the top-level `directory` field:

```json
{ "directory": "/tmp/worktrees/gptme-codegraph-map", ... }
```

For a *committed* artifact (the whole point of the feature — "analyze once, commit the graph, teammates skip the pipeline") this is wrong:
- It leaks the generating machine's filesystem layout into the repo.
- It churns the diff across clones/CI — every contributor who regenerates writes their own absolute path.

## Fix

Pin the committed artifact's top-level `directory` to `"."`. Per-file paths are already repo-relative, so the artifact becomes fully reproducible regardless of where it was generated.

The live MCP server (`mcp_server.py`) is intentionally **unchanged** — it returns the absolute path as a query response, not a committed file.

Nothing reads the stored `directory` field for freshness logic (`_map_is_fresh` keys off `source_digest` / `version` / age), so this is safe.

## Test

- New `test_generate_map_directory_is_portable` asserts `generate_map()` returns `directory == "."` even when `build_repo_map()` yields an absolute path.
- End-to-end: regenerating gptme's map now writes `"directory": "."`.
- Full suite: 14 passed; ruff + mypy clean.

Unblocks a clean gptme/gptme adoption (committing the artifact without baking in a build path). Ref: ErikBjare/bob codegraph-committed-artifact-phase2.