### PR TITLE
fix(lessons): remove 4 dead keywords (zero match in full trajectory window)

### DIFF
--- a/lessons/autonomous/autonomous-session-pivot-strategies.md
+++ b/lessons/autonomous/autonomous-session-pivot-strategies.md
@@ -5,7 +5,6 @@ match:
   - pivot when blocked
   - switch tasks when stuck
   - alternative value-creation
-  - session pivot lesson
 status: active
 ---
 

--- a/lessons/autonomous/autonomous-session-structure.md
+++ b/lessons/autonomous/autonomous-session-structure.md
@@ -2,7 +2,6 @@
 description: "Use the structured 4-phase approach (status, selection, execution, completion) for every autonomous session"
 match:
   keywords:
-  - session structure lesson
   - 4-phase session
   - session phase planning
   - structured autonomous session

--- a/lessons/autonomous/strategic-focus-during-autonomous-sessions.md
+++ b/lessons/autonomous/strategic-focus-during-autonomous-sessions.md
@@ -12,7 +12,6 @@ match:
 
   - straying from highest-leverage
   - trapped in maintenance loops
-  - self-reinforcing bad behavior
   - churning on low-value tasks
   - looking busy without shipping
   - plateau detector says category_monotony

--- a/lessons/workflow/measure-before-optimize.md
+++ b/lessons/workflow/measure-before-optimize.md
@@ -11,7 +11,6 @@ match:
   - "before/after timing"
   - "p50 = "
   - "is the bottleneck"
-  - optimized before measuring
   - "pytest --profile"
   session_categories: [code, infrastructure]
 status: active


### PR DESCRIPTION
## Summary

Removes 4 keywords from 4 lesson files that are confirmed dead — zero matches in the full trajectory window (not just the 14d windowed report).

| Lesson | Removed keyword |
|--------|----------------|
| `autonomous/strategic-focus-during-autonomous-sessions.md` | `self-reinforcing bad behavior` |
| `workflow/measure-before-optimize.md` | `optimized before measuring` |
| `autonomous/autonomous-session-pivot-strategies.md` | `session pivot lesson` |
| `autonomous/autonomous-session-structure.md` | `session structure lesson` |

## Validation method

Each keyword was validated with `lesson-keyword-health.py --validate "<keyword>"` against the full trajectory window (~2134 sessions), returning `❌ No matches found in trajectory data`.

Keywords flagged as dead in the 14d window but showing ≥1 match in the full window were **preserved** (boundary-rare scenario coverage, per `lesson-keyword-silent-replace-trap` guidance).

Other keywords in these lessons (e.g. `straying from highest-leverage`, `trapped in maintenance loops`, `churning on low-value tasks`) were validated as HEALTHY and kept.

## Test plan

- [x] Pre-commit hooks pass
- [x] All removed keywords confirmed zero-match in full historical window
- [x] Remaining keywords in each lesson are HEALTHY (boundary-rare or better)