### PR TITLE
fix(resolver): prompt model to validate patch success and retry on failure

### DIFF
--- a/scripts/github_resolver/prompts/issue-resolver.md
+++ b/scripts/github_resolver/prompts/issue-resolver.md
@@ -34,6 +34,15 @@ Read the issue and decide:
   for that.
 - If tests exist and your change is code-touching, add or update the most
   obviously relevant test.
+
+- **Validate your changes took effect.** After calling `save` or `patch`,
+  verify the tool succeeded. If you see an error like `Patch failed: original
+  chunk not found in file`, retry at least 2 more times — read the current
+  file content and rewrite the patch with correct line matches, or fall back
+  to a full-file `save`. If still failing after retries, do NOT claim
+  `RESOLVER_STATUS: changes` — emit `no_changes` instead with the failure
+  reason.
+
 - If you make changes, end your run with a short summary in this exact format:
 
     ```
@@ -49,4 +58,7 @@ Read the issue and decide:
     ```
 
 The workflow parses those final markers to decide whether to open a draft PR
-or post a failure comment. Keep the markers verbatim.
+or post a failure comment. Keep the markers verbatim. Only emit
+`RESOLVER_STATUS: changes` when file content was **actually modified** on
+disk. If a tool call failed or the file was unchanged, always emit
+`no_changes`.

--- a/scripts/github_resolver/prompts/issue-resolver.md
+++ b/scripts/github_resolver/prompts/issue-resolver.md
@@ -37,7 +37,7 @@ Read the issue and decide:
 
 - **Validate your changes took effect.** After calling `save` or `patch`,
   verify the tool succeeded. If you see an error like `Patch failed: original
-  chunk not found in file`, retry at least 2 more times — read the current
+  chunk not found in file`, retry up to 2 more times — read the current
   file content and rewrite the patch with correct line matches, or fall back
   to a full-file `save`. If still failing after retries, do NOT claim
   `RESOLVER_STATUS: changes` — emit `no_changes` instead with the failure


### PR DESCRIPTION
## Problem

The live canary (ErikBjare/bob#821, Actions run 26675942774) showed the model
emitting `RESOLVER_STATUS: changes` after `Patch failed: original chunk not found in file`,
without retrying the edit. The orchestrator's `has_git_changes()` caught the
inconsistency, but the draft PR was never created because the worktree was clean.

## Fix

The prompt now instructs the model to:
1. Verify `save`/`patch` tool calls succeeded.
2. On `Patch failed`, read the current file content and retry (up to 2 more times).
3. Only emit `RESOLVER_STATUS: changes` when files are actually modified on disk.
4. Fall back to `no_changes` with the failure reason if retries exhaust.

The orchestrator already has a defensive check (`has_git_changes()` catches
false-positive `changes` claims from clean worktrees), but fixing the source
of false-positives is better than relying on the safety net.

## Verification

- [x] `pytest scripts/github_resolver/test_resolve_issue.py -v` — 17 passed
- [x] Changed only the prompt file (no logic change to the orchestrator)