### PR TITLE
fix(resolver): require reading files before patching

### DIFF
--- a/scripts/github_resolver/prompts/issue-resolver.md
+++ b/scripts/github_resolver/prompts/issue-resolver.md
@@ -35,6 +35,13 @@ Read the issue and decide:
 - If tests exist and your change is code-touching, add or update the most
   obviously relevant test.
 
+- **Read existing files before editing them.** Before calling `patch` or
+  `save` on any file that already exists, first read the current on-disk
+  content from `$PWD` (for example with `cat path/to/file`). Build your edit
+  from that exact content. Do NOT write patch chunks from memory, issue text,
+  or assumed file contents. If the file does not exist yet, you may create it
+  directly.
+
 - **Validate your changes took effect.** After calling `save` or `patch`,
   verify the tool succeeded. If you see an error like `Patch failed: original
   chunk not found in file`, retry up to 2 more times — read the current

--- a/scripts/github_resolver/test_resolve_issue.py
+++ b/scripts/github_resolver/test_resolve_issue.py
@@ -141,6 +141,13 @@ def test_prompt_template_mentions_both_markers():
     assert "RESOLVER_REASON" in template
 
 
+def test_prompt_template_requires_read_before_editing_existing_files():
+    template = TEMPLATE_PATH.read_text()
+    assert "Before calling `patch` or" in template
+    assert "`save` on any file that already exists" in template
+    assert "Do NOT write patch chunks from memory" in template
+
+
 def test_status_regex_ignores_prose_mentions():
     # The model often echoes the words "RESOLVER_STATUS" in the middle of a
     # sentence while explaining what it's about to do. Only an anchored line


### PR DESCRIPTION
## Summary
Strengthen the issue-resolver prompt so the model must read an existing file before trying to patch or save it, instead of constructing chunks from memory.

## Why
The Bob canary on ErikBjare/bob#823 showed the model trying to patch `.github/workflows/gptme-resolver.yml` before reading it, producing `Patch failed: original chunk not found in file` and then bailing out.

## Changes
- add an explicit read-before-edit rule for existing files in `issue-resolver.md`
- add a prompt contract test so this instruction does not silently regress

## Verification
- `uv run pytest scripts/github_resolver/test_resolve_issue.py -q`

Refs ErikBjare/bob#823.
