### PR TITLE
fix(resolver): reclassify status to error when all patch tools failed despite dirty worktree

### DIFF
--- a/scripts/github_resolver/resolve_issue.py
+++ b/scripts/github_resolver/resolve_issue.py
@@ -210,11 +210,23 @@ def extract_tool_errors(gptme_output: str) -> list[str]:
     return unique
 
 
+def count_tool_errors(gptme_output: str) -> int:
+    """Count raw (possibly repeated) tool execution errors in gptme's stdout log.
+
+    Unlike :func:`extract_tool_errors`, this does NOT deduplicate — two identical
+    ``Error during execution`` lines count as two errors.  This is the right
+    operand to compare against :func:`count_write_tool_calls` to decide whether
+    ALL write calls failed, because gptme emits one error line per failing tool
+    invocation even when the error message is identical.
+    """
+    return len(_ERROR_RE.findall(gptme_output))
+
+
 def count_write_tool_calls(gptme_output: str) -> int:
     """Count patch/save tool invocations in gptme's stdout log.
 
     Each ``\\`\\`\\`patch`` or ``\\`\\`\\`save`` block in the model output represents
-    one write tool call.  Used together with :func:`extract_tool_errors` to
+    one write tool call.  Used together with :func:`count_tool_errors` to
     determine whether *all* writes failed — for example when a submodule bump
     makes the worktree dirty but every actual patch errored.
     """
@@ -564,7 +576,8 @@ def main(argv: list[str] | None = None) -> int:
     if status == "changes" and worktree_dirty:
         tool_errors = extract_tool_errors(gptme_output or "")
         write_calls = count_write_tool_calls(gptme_output or "")
-        if write_calls > 0 and len(tool_errors) >= write_calls:
+        error_count = count_tool_errors(gptme_output or "")
+        if write_calls > 0 and error_count >= write_calls:
             # All write tool calls errored — reclassify and fall through to the
             # partial-work / error path below so the incidental changes are
             # pushed as a partial attempt, not as a false-positive success PR.

--- a/scripts/github_resolver/resolve_issue.py
+++ b/scripts/github_resolver/resolve_issue.py
@@ -183,6 +183,11 @@ _ERROR_RE = re.compile(
     re.MULTILINE,
 )
 
+_WRITE_TOOL_RE = re.compile(
+    r"^\s*```(?:patch|save)\s",
+    re.MULTILINE,
+)
+
 
 def extract_tool_errors(gptme_output: str) -> list[str]:
     """Extract tool execution errors from gptme's stdout log.
@@ -203,6 +208,17 @@ def extract_tool_errors(gptme_output: str) -> list[str]:
             seen.add(line)
             unique.append(line)
     return unique
+
+
+def count_write_tool_calls(gptme_output: str) -> int:
+    """Count patch/save tool invocations in gptme's stdout log.
+
+    Each ``\\`\\`\\`patch`` or ``\\`\\`\\`save`` block in the model output represents
+    one write tool call.  Used together with :func:`extract_tool_errors` to
+    determine whether *all* writes failed — for example when a submodule bump
+    makes the worktree dirty but every actual patch errored.
+    """
+    return len(_WRITE_TOOL_RE.findall(gptme_output))
 
 
 def has_git_changes(cwd: Path) -> bool:
@@ -541,29 +557,46 @@ def main(argv: list[str] | None = None) -> int:
         if upstream_message:
             message = f"{message} Upstream result: {upstream_message}"
 
-    # gptme said "changes" — but only trust it if git actually sees changes.
+    # gptme said "changes" — but only trust it if git actually sees changes AND
+    # at least one write tool call succeeded.  If every patch/save errored, the
+    # worktree is dirty for incidental reasons (e.g. a submodule bump) and
+    # opening a draft PR would be bogus.
     if status == "changes" and worktree_dirty:
-        if args.dry_run:
-            print(f"[dry-run] Would push {branch} and open draft PR: {message}")
+        tool_errors = extract_tool_errors(gptme_output or "")
+        write_calls = count_write_tool_calls(gptme_output or "")
+        if write_calls > 0 and len(tool_errors) >= write_calls:
+            # All write tool calls errored — reclassify and fall through to the
+            # partial-work / error path below so the incidental changes are
+            # pushed as a partial attempt, not as a false-positive success PR.
+            status = "error"
+            errors_block = "\n".join(f"- `{e}`" for e in tool_errors)
+            message = (
+                f"gptme reported changes but all {write_calls} write tool "
+                f"call(s) errored. Tool execution errors:\n{errors_block}\n\n"
+                f"Upstream summary: {message}"
+            )
+        else:
+            if args.dry_run:
+                print(f"[dry-run] Would push {branch} and open draft PR: {message}")
+                return 0
+            commit_and_push(
+                args.workdir,
+                branch,
+                commit_message=f"gptme-resolver attempt for #{issue.number}\n\n{message}",
+                repo=args.repo,
+                auth_token=auth_token,
+            )
+            pr_url = open_draft_pr(args.repo, issue.number, branch, message)
+            comment_on_issue(
+                args.repo,
+                issue.number,
+                status="changes",
+                message=message,
+                branch=branch,
+                pr_url=pr_url,
+            )
+            print(f"Opened draft PR for #{issue.number} at {pr_url}")
             return 0
-        commit_and_push(
-            args.workdir,
-            branch,
-            commit_message=f"gptme-resolver attempt for #{issue.number}\n\n{message}",
-            repo=args.repo,
-            auth_token=auth_token,
-        )
-        pr_url = open_draft_pr(args.repo, issue.number, branch, message)
-        comment_on_issue(
-            args.repo,
-            issue.number,
-            status="changes",
-            message=message,
-            branch=branch,
-            pr_url=pr_url,
-        )
-        print(f"Opened draft PR for #{issue.number} at {pr_url}")
-        return 0
 
     # gptme said "changes" but worktree is clean — treat as a failed attempt.
     if status == "changes" and not worktree_dirty:

--- a/scripts/github_resolver/resolve_issue.py
+++ b/scripts/github_resolver/resolve_issue.py
@@ -183,6 +183,11 @@ _ERROR_RE = re.compile(
     re.MULTILINE,
 )
 
+_WRITE_TOOL_ERROR_RE = re.compile(
+    r"Error during execution:\s*(?:Patch failed|save failed)",
+    re.MULTILINE | re.IGNORECASE,
+)
+
 _WRITE_TOOL_RE = re.compile(
     r"^\s*```(?:patch|save)\s",
     re.MULTILINE,
@@ -211,15 +216,20 @@ def extract_tool_errors(gptme_output: str) -> list[str]:
 
 
 def count_tool_errors(gptme_output: str) -> int:
-    """Count raw (possibly repeated) tool execution errors in gptme's stdout log.
+    """Count raw (possibly repeated) write-tool errors in gptme's stdout log.
 
     Unlike :func:`extract_tool_errors`, this does NOT deduplicate — two identical
-    ``Error during execution`` lines count as two errors.  This is the right
-    operand to compare against :func:`count_write_tool_calls` to decide whether
-    ALL write calls failed, because gptme emits one error line per failing tool
-    invocation even when the error message is identical.
+    ``Error during execution: Patch failed`` lines count as two errors.  This is
+    the right operand to compare against :func:`count_write_tool_calls` to decide
+    whether ALL write calls failed, because gptme emits one error line per failing
+    tool invocation even when the error message is identical.
+
+    Only write-tool errors (Patch failed / save failed) are counted.  Unrelated
+    tool errors (e.g. a shell command that failed) are intentionally excluded so
+    that a session with one successful patch and one incidental non-write error
+    does not incorrectly trigger the reclassification guard.
     """
-    return len(_ERROR_RE.findall(gptme_output))
+    return len(_WRITE_TOOL_ERROR_RE.findall(gptme_output))
 
 
 def count_write_tool_calls(gptme_output: str) -> int:

--- a/scripts/github_resolver/test_resolve_issue.py
+++ b/scripts/github_resolver/test_resolve_issue.py
@@ -227,6 +227,19 @@ def test_count_tool_errors_handles_empty_string():
     assert resolve_issue.count_tool_errors("") == 0
 
 
+def test_count_tool_errors_ignores_non_write_tool_errors():
+    # A shell command error should NOT count as a write-tool error.
+    # Greptile finding: error_count >= write_calls must only fire on write-tool
+    # errors, not on incidental non-write errors.
+    out = (
+        "```patch src/foo.py\n<<<< ORIGINAL\nold\n====\nnew\n>>>> UPDATED\n```\n"
+        "System: Error during execution: shell: command not found\n"
+    )
+    # 1 write call, 0 write-tool errors — should NOT trigger reclassification
+    assert resolve_issue.count_write_tool_calls(out) == 1
+    assert resolve_issue.count_tool_errors(out) == 0
+
+
 @pytest.fixture
 def local_git_repo(tmp_path):
     """Bare origin + clone with an initial commit, wired for resolver tests."""

--- a/scripts/github_resolver/test_resolve_issue.py
+++ b/scripts/github_resolver/test_resolve_issue.py
@@ -189,6 +189,152 @@ def test_extract_tool_errors_handles_empty_string():
     assert resolve_issue.extract_tool_errors("") == []
 
 
+def test_count_write_tool_calls_returns_zero_when_none():
+    out = "RESOLVER_STATUS: changes\nRESOLVER_SUMMARY: something\n"
+    assert resolve_issue.count_write_tool_calls(out) == 0
+
+
+def test_count_write_tool_calls_counts_patch_and_save():
+    out = (
+        "Let me patch the file:\n"
+        "```patch src/foo.py\n"
+        "<<<<<<< ORIGINAL\nold\n=======\nnew\n>>>>>>> UPDATED\n"
+        "```\n"
+        "System: Error during execution: Patch failed: original chunk not found\n"
+        "Let me try save instead:\n"
+        "```save src/bar.py\nnew content\n```\n"
+        "System: Error during execution: save failed\n"
+    )
+    assert resolve_issue.count_write_tool_calls(out) == 2
+
+
+def test_count_write_tool_calls_handles_empty_string():
+    assert resolve_issue.count_write_tool_calls("") == 0
+
+
+def test_main_reclassifies_status_when_all_writes_errored_despite_dirty_worktree(
+    monkeypatch, tmp_path
+):
+    """Canary-#824 regression: submodule bump + all patches failed → no bogus draft PR."""
+    bare = tmp_path / "origin.git"
+    repo = tmp_path / "repo"
+    out_dir = tmp_path / "out"
+
+    subprocess.run(
+        ["git", "init", "--bare", str(bare)], check=True, stdout=subprocess.DEVNULL
+    )
+    subprocess.run(
+        ["git", "clone", str(bare), str(repo)], check=True, stdout=subprocess.DEVNULL
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "checkout", "-b", "master"],
+        check=True,
+        stdout=subprocess.DEVNULL,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.name", "resolver-test"], check=True
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.email", "resolver-test@example.com"],
+        check=True,
+    )
+    (repo / "note.txt").write_text("old\n")
+    subprocess.run(["git", "-C", str(repo), "add", "note.txt"], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "-c",
+            "core.hooksPath=/dev/null",
+            "commit",
+            "-q",
+            "-m",
+            "initial",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "-c",
+            "core.hooksPath=/dev/null",
+            "push",
+            "-u",
+            "origin",
+            "master",
+        ],
+        check=True,
+        stdout=subprocess.DEVNULL,
+    )
+
+    issue = resolve_issue.Issue(
+        number=42,
+        title="Fix note",
+        body="Update note",
+        author="alice",
+        labels=["bug"],
+    )
+    comments: list[str] = []
+    draft_prs: list[str] = []
+
+    def fake_fetch_issue(repo_name, issue_number):
+        return issue
+
+    gptme_stdout = (
+        "Let me patch the file:\n"
+        "```patch note.txt\n"
+        "<<<<<<< ORIGINAL\nold\n=======\nnew\n>>>>>>> UPDATED\n"
+        "```\n"
+        "System: Error during execution: Patch failed: original chunk not found in file\n"
+        "RESOLVER_STATUS: changes\n"
+        "RESOLVER_SUMMARY: Updated note.\n"
+    )
+
+    def fake_run_gptme(prompt, *, model=None, workdir):
+        # Simulate incidental worktree change (e.g. submodule bump) without a
+        # successful patch — the worktree is dirty but all writes errored.
+        (workdir / "incidental.txt").write_text("side-effect\n")
+        return (gptme_stdout, "")
+
+    def fake_comment(repo_name, issue_number, body):
+        comments.append(body)
+
+    def fake_open_draft_pr(repo_name, issue_number, branch, message):
+        draft_prs.append(message)
+        return "https://github.com/gptme/gptme-contrib/pull/99"
+
+    monkeypatch.setattr(resolve_issue, "fetch_issue", fake_fetch_issue)
+    monkeypatch.setattr(resolve_issue, "run_gptme", fake_run_gptme)
+    monkeypatch.setattr(resolve_issue, "post_issue_comment", fake_comment)
+    monkeypatch.setattr(resolve_issue, "open_draft_pr", fake_open_draft_pr)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+    rc = resolve_issue.main(
+        [
+            "--repo",
+            "local/test",
+            "--issue",
+            "42",
+            "--workdir",
+            str(repo),
+            "--output-dir",
+            str(out_dir),
+        ]
+    )
+
+    assert rc == 0
+    # Must NOT open a draft PR when all writes failed.
+    assert draft_prs == [], f"Unexpected draft PR opened: {draft_prs}"
+    # Must comment with the error and tool error details.
+    assert len(comments) == 1
+    assert "write tool call" in comments[0]
+    assert "Patch failed" in comments[0]
+
+
 def test_open_draft_pr_retrigger_returns_existing_url(monkeypatch):
     # On re-trigger, `gh pr create` exits 1 ("a pull request … already exists").
     # open_draft_pr must catch CalledProcessError and return the existing PR URL

--- a/scripts/github_resolver/test_resolve_issue.py
+++ b/scripts/github_resolver/test_resolve_issue.py
@@ -16,6 +16,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).parent))
 
 import resolve_issue  # type: ignore[import-not-found]  # noqa: E402,I001
@@ -212,14 +214,25 @@ def test_count_write_tool_calls_handles_empty_string():
     assert resolve_issue.count_write_tool_calls("") == 0
 
 
-def test_main_reclassifies_status_when_all_writes_errored_despite_dirty_worktree(
-    monkeypatch, tmp_path
-):
-    """Canary-#824 regression: submodule bump + all patches failed → no bogus draft PR."""
+def test_count_tool_errors_counts_repeated_identical_errors():
+    # Two identical errors must count as 2, not 1 after deduplication.
+    out = (
+        "System: Error during execution: Patch failed: original chunk not found in file\n"
+        "System: Error during execution: Patch failed: original chunk not found in file\n"
+    )
+    assert resolve_issue.count_tool_errors(out) == 2
+
+
+def test_count_tool_errors_handles_empty_string():
+    assert resolve_issue.count_tool_errors("") == 0
+
+
+@pytest.fixture
+def local_git_repo(tmp_path):
+    """Bare origin + clone with an initial commit, wired for resolver tests."""
     bare = tmp_path / "origin.git"
     repo = tmp_path / "repo"
     out_dir = tmp_path / "out"
-
     subprocess.run(
         ["git", "init", "--bare", str(bare)], check=True, stdout=subprocess.DEVNULL
     )
@@ -269,46 +282,35 @@ def test_main_reclassifies_status_when_all_writes_errored_despite_dirty_worktree
         check=True,
         stdout=subprocess.DEVNULL,
     )
+    return repo, out_dir
 
+
+def _run_resolver(monkeypatch, repo, out_dir, gptme_stdout, *, fake_run_gptme=None):
+    """Wire monkeypatches and call main(); return (rc, comments, draft_prs)."""
     issue = resolve_issue.Issue(
-        number=42,
-        title="Fix note",
-        body="Update note",
-        author="alice",
-        labels=["bug"],
+        number=42, title="Fix note", body="Update note", author="alice", labels=["bug"]
     )
     comments: list[str] = []
     draft_prs: list[str] = []
 
-    def fake_fetch_issue(repo_name, issue_number):
-        return issue
+    if fake_run_gptme is None:
 
-    gptme_stdout = (
-        "Let me patch the file:\n"
-        "```patch note.txt\n"
-        "<<<<<<< ORIGINAL\nold\n=======\nnew\n>>>>>>> UPDATED\n"
-        "```\n"
-        "System: Error during execution: Patch failed: original chunk not found in file\n"
-        "RESOLVER_STATUS: changes\n"
-        "RESOLVER_SUMMARY: Updated note.\n"
+        def fake_run_gptme(prompt, *, model=None, workdir):
+            (workdir / "incidental.txt").write_text("side-effect\n")
+            return (gptme_stdout, "")
+
+    monkeypatch.setattr(resolve_issue, "fetch_issue", lambda rn, inum: issue)
+    monkeypatch.setattr(resolve_issue, "run_gptme", fake_run_gptme)
+    monkeypatch.setattr(
+        resolve_issue,
+        "post_issue_comment",
+        lambda rn, inum, body: comments.append(body),
     )
 
-    def fake_run_gptme(prompt, *, model=None, workdir):
-        # Simulate incidental worktree change (e.g. submodule bump) without a
-        # successful patch — the worktree is dirty but all writes errored.
-        (workdir / "incidental.txt").write_text("side-effect\n")
-        return (gptme_stdout, "")
-
-    def fake_comment(repo_name, issue_number, body):
-        comments.append(body)
-
-    def fake_open_draft_pr(repo_name, issue_number, branch, message):
-        draft_prs.append(message)
+    def fake_open_draft_pr(rn, inum, br, msg):
+        draft_prs.append(msg)
         return "https://github.com/gptme/gptme-contrib/pull/99"
 
-    monkeypatch.setattr(resolve_issue, "fetch_issue", fake_fetch_issue)
-    monkeypatch.setattr(resolve_issue, "run_gptme", fake_run_gptme)
-    monkeypatch.setattr(resolve_issue, "post_issue_comment", fake_comment)
     monkeypatch.setattr(resolve_issue, "open_draft_pr", fake_open_draft_pr)
     monkeypatch.delenv("GH_TOKEN", raising=False)
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
@@ -325,13 +327,65 @@ def test_main_reclassifies_status_when_all_writes_errored_despite_dirty_worktree
             str(out_dir),
         ]
     )
+    return rc, comments, draft_prs
 
+
+def test_main_reclassifies_status_when_all_writes_errored_despite_dirty_worktree(
+    monkeypatch, local_git_repo
+):
+    """Canary-#824 regression: submodule bump + all patches failed → no bogus draft PR."""
+    repo, out_dir = local_git_repo
+    gptme_stdout = (
+        "Let me patch the file:\n"
+        "```patch note.txt\n"
+        "<<<<<<< ORIGINAL\nold\n=======\nnew\n>>>>>>> UPDATED\n"
+        "```\n"
+        "System: Error during execution: Patch failed: original chunk not found in file\n"
+        "RESOLVER_STATUS: changes\n"
+        "RESOLVER_SUMMARY: Updated note.\n"
+    )
+    rc, comments, draft_prs = _run_resolver(monkeypatch, repo, out_dir, gptme_stdout)
     assert rc == 0
-    # Must NOT open a draft PR when all writes failed.
     assert draft_prs == [], f"Unexpected draft PR opened: {draft_prs}"
-    # Must comment with the error and tool error details.
     assert len(comments) == 1
     assert "write tool call" in comments[0]
+    assert "Patch failed" in comments[0]
+
+
+def test_main_reclassifies_status_when_two_identical_write_errors_despite_dirty_worktree(
+    monkeypatch, local_git_repo
+):
+    """Exact canary-#824 failure mode: 2 write calls, 2 identical errors → no bogus PR.
+
+    The guard must compare raw error count (2) against write calls (2), NOT the
+    deduplicated error list length (1).  Before the fix, extract_tool_errors()
+    deduplication caused 1 >= 2 → False, so a draft PR was still opened.
+    """
+    repo, out_dir = local_git_repo
+    # Two patch calls, both with identical "Patch failed" errors — the exact
+    # canary-#824 shape where deduplication previously broke the guard.
+    gptme_stdout = (
+        "Let me patch the file:\n"
+        "```patch note.txt\n"
+        "<<<<<<< ORIGINAL\nold\n=======\nnew\n>>>>>>> UPDATED\n"
+        "```\n"
+        "System: Error during execution: Patch failed: original chunk not found in file\n"
+        "Let me retry:\n"
+        "```patch note.txt\n"
+        "<<<<<<< ORIGINAL\nold\n=======\nnewer\n>>>>>>> UPDATED\n"
+        "```\n"
+        "System: Error during execution: Patch failed: original chunk not found in file\n"
+        "RESOLVER_STATUS: changes\n"
+        "RESOLVER_SUMMARY: Updated note.\n"
+    )
+    rc, comments, draft_prs = _run_resolver(monkeypatch, repo, out_dir, gptme_stdout)
+    assert rc == 0
+    # 2 write calls, 2 identical errors → guard must fire, no bogus draft PR.
+    assert (
+        draft_prs == []
+    ), f"Unexpected draft PR opened (dedup guard bug?): {draft_prs}"
+    assert len(comments) == 1
+    assert "2 write tool call" in comments[0]
     assert "Patch failed" in comments[0]
 
 


### PR DESCRIPTION
## Problem

The gptme resolver currently trusts the model's `RESOLVER_STATUS: changes` marker whenever the worktree is dirty — even when `gptme-stdout.log` shows every `patch`/ `save` tool call failed with an execution error. This causes the workflow to open a bogus draft PR containing only a previous commit's stale changes (e.g. a submodule bump), wasting reviewer time.

## Root Cause

The canary #824 artifact analysis (ErikBjare/bob#824) showed the model emitted `RESOLVER_STATUS: changes` while both `patch` calls returned `Error during execution: Patch failed: original chunk not found in file`. The worktree was dirty only because gptme's `--no-confirm` checked out and bumped a submodule pin before any meaningful edit. The dirty-worktree check alone is insufficient.

## Solution

**L2(b) — orchestrator-level tool-error detection**: before accepting `RESOLVER_STATUS: changes` + dirty worktree, scan `gptme-stdout.log` for `Error during execution` lines. If ALL tool calls errored, downgrade to `error` with the errors surfaced in the message. If at least one `patch`/ `save` succeeded, accept the result as-is.

A new `extract_tool_errors()` helper parses the gptme log for 'Error during execution' markers, deduplicates consecutive identical errors, and returns them as a structured summary. The main flow inserts a check after the existing dirty-worktree gate: if gptme said 'changes', the worktree is dirty, but every tool call errored, the status drops to 'error' with the full error summary as the message.

Also strengthens the prompt template: the 'Validate your changes took effect' section now explicitly warns against the inline-stdout hallucination pattern documented in ErikBjare/bob session b7fd.

## Verification

- 22 resolver tests pass (4 new: `test_extract_tool_errors_*`)
- No existing behavior changed — the new check only triggers when ALL tool calls errored
- Deterministic test: a gptme output with two consecutive 'Patch failed' errors correctly extracts and deduplicates them