### PR TITLE
fix(resolver): use plain push for new branches, --force-with-lease for existing

### DIFF
--- a/scripts/github_resolver/prompts/issue-resolver.md
+++ b/scripts/github_resolver/prompts/issue-resolver.md
@@ -43,12 +43,14 @@ Read the issue and decide:
   directly.
 
 - **Validate your changes took effect.** After calling `save` or `patch`,
-  verify the tool succeeded. If you see an error like `Patch failed: original
-  chunk not found in file`, retry up to 2 more times — read the current
-  file content and rewrite the patch with correct line matches, or fall back
-  to a full-file `save`. If still failing after retries, do NOT claim
-  `RESOLVER_STATUS: changes` — emit `no_changes` instead with the failure
-  reason.
+  always check the tool result. A `System:` response that says `Error during
+  execution: Patch failed: original chunk not found in file` means the write
+  **did not happen** — the file on disk was NOT modified. If you see such an
+  error, retry up to 2 more times: read the current file content again and
+  rewrite the patch with correct line matches, or fall back to a full-file
+  `save`. If still failing after retries, do NOT claim `RESOLVER_STATUS:
+  changes` — emit `no_changes` instead with the failure reason. A patch error
+  is not a change.
 
 - If you make changes, end your run with a short summary in this exact format:
 

--- a/scripts/github_resolver/resolve_issue.py
+++ b/scripts/github_resolver/resolve_issue.py
@@ -353,16 +353,15 @@ def push_branch(
         # ``--force-with-lease`` requires a remote tracking ref to compare
         # against.  When pushing via an explicit URL (no named remote) the
         # tracking ref is never updated, so a re-trigger run always sees a
-        # "stale" ref and fails.  Use plain ``--force`` for the URL path:
-        # the resolver branch is exclusively owned by the resolver workflow
-        # and concurrent runs are serialised by the caller's ``concurrency``
-        # group, so ``--force`` is safe here.
-        exists = remote_branch_exists(cwd, branch, remote_url=push_url)
-        flag = "--force-with-lease" if exists else "--force"
+        # "stale" ref and is rejected.  Use plain ``--force`` for the URL
+        # path: the resolver branch is exclusively owned by the resolver
+        # workflow and concurrent runs are serialised by the caller's
+        # ``concurrency`` group, so ``--force`` is safe for both new
+        # branches and re-trigger pushes.
         git(
             [
                 "push",
-                flag,
+                "--force",
                 push_url,
                 f"HEAD:refs/heads/{branch}",
             ],

--- a/scripts/github_resolver/resolve_issue.py
+++ b/scripts/github_resolver/resolve_issue.py
@@ -324,6 +324,23 @@ def github_push_url(repo: str, auth_token: str) -> str:
     return f"https://x-access-token:{quote(auth_token, safe='')}@github.com/{repo}.git"
 
 
+def remote_branch_exists(
+    cwd: Path,
+    branch: str,
+    *,
+    remote_url: str | None = None,
+) -> bool:
+    """Return True if *branch* already exists on the remote.
+
+    Uses the explicit *remote_url* when given (token-authenticated CI path),
+    otherwise queries the ``origin`` remote.  The check is done with
+    ``git ls-remote --heads`` which works without a configured remote name.
+    """
+    remote = remote_url or "origin"
+    output = git(["ls-remote", "--heads", remote, branch], cwd=cwd)
+    return bool(output.strip())
+
+
 def push_branch(
     cwd: Path,
     branch: str,
@@ -332,17 +349,33 @@ def push_branch(
     auth_token: str | None = None,
 ) -> None:
     if auth_token and repo:
+        push_url = github_push_url(repo, auth_token)
+        # ``--force-with-lease`` requires a remote tracking ref to compare
+        # against.  When pushing via an explicit URL (no named remote) the
+        # tracking ref is never updated, so a re-trigger run always sees a
+        # "stale" ref and fails.  Use plain ``--force`` for the URL path:
+        # the resolver branch is exclusively owned by the resolver workflow
+        # and concurrent runs are serialised by the caller's ``concurrency``
+        # group, so ``--force`` is safe here.
+        exists = remote_branch_exists(cwd, branch, remote_url=push_url)
+        flag = "--force-with-lease" if exists else "--force"
         git(
             [
                 "push",
-                "--force-with-lease",
-                github_push_url(repo, auth_token),
+                flag,
+                push_url,
                 f"HEAD:refs/heads/{branch}",
             ],
             cwd=cwd,
         )
         return
-    git(["push", "--force-with-lease", "origin", branch], cwd=cwd)
+    # Named-remote path (local / non-CI use): --force-with-lease works
+    # correctly because git can track the remote ref via origin.
+    exists = remote_branch_exists(cwd, branch)
+    if exists:
+        git(["push", "--force-with-lease", "origin", branch], cwd=cwd)
+    else:
+        git(["push", "-u", "origin", branch], cwd=cwd)
 
 
 def commit_and_push(

--- a/scripts/github_resolver/resolve_issue.py
+++ b/scripts/github_resolver/resolve_issue.py
@@ -178,6 +178,33 @@ def parse_status(gptme_output: str) -> tuple[str, str]:
     return "no_changes", (m.group(1).strip() if m else "(no reason provided)")
 
 
+_ERROR_RE = re.compile(
+    r"Error during execution:\s*(.+)",
+    re.MULTILINE,
+)
+
+
+def extract_tool_errors(gptme_output: str) -> list[str]:
+    """Extract tool execution errors from gptme's stdout log.
+
+    gptme emits ``System: Error during execution: <description>`` when a tool
+    call raises.  The model often ignores these and hallucinates success.  This
+    helper surfaces the raw failure evidence for the orchestrator's error
+    message so a human reviewing the issue comment sees actionable diagnostics
+    without downloading the session artifact.
+    """
+    errors = _ERROR_RE.findall(gptme_output)
+    # Deduplicate while preserving order (same error repeated N times).
+    seen: set[str] = set()
+    unique: list[str] = []
+    for e in errors:
+        line = e.strip()
+        if line not in seen:
+            seen.add(line)
+            unique.append(line)
+    return unique
+
+
 def has_git_changes(cwd: Path) -> bool:
     out = git(["status", "--porcelain"], cwd=cwd)
     return bool(out.strip())
@@ -509,10 +536,22 @@ def main(argv: list[str] | None = None) -> int:
     # gptme said "changes" but worktree is clean — treat as a failed attempt.
     if status == "changes" and not worktree_dirty:
         status = "error"
-        message = (
-            "gptme reported changes but no files were modified. "
-            f"Upstream message: {message}"
-        )
+        # Surface tool execution errors so the issue comment shows actionable
+        # diagnostics without downloading the session artifact.  If no tool
+        # errors are found, fall back to the generic description.
+        tool_errors = extract_tool_errors(gptme_output or "")
+        if tool_errors:
+            errors_block = "\n".join(f"- `{e}`" for e in tool_errors)
+            message = (
+                "gptme reported changes but no files were modified. "
+                f"Tool execution errors found in the session log:\n{errors_block}\n\n"
+                f"Upstream summary: {message}"
+            )
+        else:
+            message = (
+                "gptme reported changes but no files were modified. "
+                f"Upstream message: {message}"
+            )
 
     # no_changes / error: preserve partial work if present, including an
     # unsolicited direct commit that moved HEAD but left the worktree clean.

--- a/scripts/github_resolver/test_resolve_issue.py
+++ b/scripts/github_resolver/test_resolve_issue.py
@@ -318,45 +318,14 @@ def test_detect_repo_state_violation_on_unexpected_commit(tmp_path):
     assert resolve_issue.has_git_changes(tmp_path) is False
 
 
-def test_push_branch_uses_explicit_github_token_new_branch(monkeypatch, tmp_path):
-    """First push of a resolver branch (no prior remote): uses --force."""
+def test_push_branch_uses_explicit_github_token(monkeypatch, tmp_path):
+    """URL-based push always uses --force (no tracking ref available via URL)."""
     calls: list[list[str]] = []
 
     def fake_git(args, *, check=True, cwd=None):
         del check
         assert cwd == tmp_path
         calls.append(args)
-        return ""  # empty ls-remote → branch does not exist yet
-
-    monkeypatch.setattr(resolve_issue, "git", fake_git)
-
-    resolve_issue.push_branch(
-        tmp_path,
-        "gptme-resolver/issue-42",
-        repo="gptme/gptme-contrib",
-        auth_token="token-123",
-    )
-
-    push_url = "https://x-access-token:token-123@github.com/gptme/gptme-contrib.git"
-    assert calls == [
-        # First call: ls-remote to check existence
-        ["ls-remote", "--heads", push_url, "gptme-resolver/issue-42"],
-        # Second call: plain --force (no tracking ref available via URL)
-        ["push", "--force", push_url, "HEAD:refs/heads/gptme-resolver/issue-42"],
-    ]
-
-
-def test_push_branch_uses_force_with_lease_on_existing_branch(monkeypatch, tmp_path):
-    """Re-trigger push (branch already exists on remote): uses --force-with-lease."""
-    calls: list[list[str]] = []
-
-    def fake_git(args, *, check=True, cwd=None):
-        del check
-        assert cwd == tmp_path
-        calls.append(args)
-        # Simulate ls-remote returning a ref line (branch exists)
-        if args[0] == "ls-remote":
-            return "abc123\trefs/heads/gptme-resolver/issue-42\n"
         return ""
 
     monkeypatch.setattr(resolve_issue, "git", fake_git)
@@ -370,13 +339,38 @@ def test_push_branch_uses_force_with_lease_on_existing_branch(monkeypatch, tmp_p
 
     push_url = "https://x-access-token:token-123@github.com/gptme/gptme-contrib.git"
     assert calls == [
-        ["ls-remote", "--heads", push_url, "gptme-resolver/issue-42"],
-        [
-            "push",
-            "--force-with-lease",
-            push_url,
-            "HEAD:refs/heads/gptme-resolver/issue-42",
-        ],
+        ["push", "--force", push_url, "HEAD:refs/heads/gptme-resolver/issue-42"],
+    ]
+
+
+def test_push_branch_uses_force_on_existing_branch(monkeypatch, tmp_path):
+    """Re-trigger push (branch already exists on remote): still uses --force.
+
+    --force-with-lease requires a local tracking ref that URL-based pushes never
+    create, so it always fails on re-trigger.  --force is safe because the
+    resolver branch is exclusively owned by the resolver workflow and concurrent
+    runs are serialised by the caller's concurrency group.
+    """
+    calls: list[list[str]] = []
+
+    def fake_git(args, *, check=True, cwd=None):
+        del check
+        assert cwd == tmp_path
+        calls.append(args)
+        return ""
+
+    monkeypatch.setattr(resolve_issue, "git", fake_git)
+
+    resolve_issue.push_branch(
+        tmp_path,
+        "gptme-resolver/issue-42",
+        repo="gptme/gptme-contrib",
+        auth_token="token-123",
+    )
+
+    push_url = "https://x-access-token:token-123@github.com/gptme/gptme-contrib.git"
+    assert calls == [
+        ["push", "--force", push_url, "HEAD:refs/heads/gptme-resolver/issue-42"],
     ]
 
 

--- a/scripts/github_resolver/test_resolve_issue.py
+++ b/scripts/github_resolver/test_resolve_issue.py
@@ -318,13 +318,45 @@ def test_detect_repo_state_violation_on_unexpected_commit(tmp_path):
     assert resolve_issue.has_git_changes(tmp_path) is False
 
 
-def test_push_branch_uses_explicit_github_token(monkeypatch, tmp_path):
+def test_push_branch_uses_explicit_github_token_new_branch(monkeypatch, tmp_path):
+    """First push of a resolver branch (no prior remote): uses --force."""
     calls: list[list[str]] = []
 
     def fake_git(args, *, check=True, cwd=None):
         del check
         assert cwd == tmp_path
         calls.append(args)
+        return ""  # empty ls-remote → branch does not exist yet
+
+    monkeypatch.setattr(resolve_issue, "git", fake_git)
+
+    resolve_issue.push_branch(
+        tmp_path,
+        "gptme-resolver/issue-42",
+        repo="gptme/gptme-contrib",
+        auth_token="token-123",
+    )
+
+    push_url = "https://x-access-token:token-123@github.com/gptme/gptme-contrib.git"
+    assert calls == [
+        # First call: ls-remote to check existence
+        ["ls-remote", "--heads", push_url, "gptme-resolver/issue-42"],
+        # Second call: plain --force (no tracking ref available via URL)
+        ["push", "--force", push_url, "HEAD:refs/heads/gptme-resolver/issue-42"],
+    ]
+
+
+def test_push_branch_uses_force_with_lease_on_existing_branch(monkeypatch, tmp_path):
+    """Re-trigger push (branch already exists on remote): uses --force-with-lease."""
+    calls: list[list[str]] = []
+
+    def fake_git(args, *, check=True, cwd=None):
+        del check
+        assert cwd == tmp_path
+        calls.append(args)
+        # Simulate ls-remote returning a ref line (branch exists)
+        if args[0] == "ls-remote":
+            return "abc123\trefs/heads/gptme-resolver/issue-42\n"
         return ""
 
     monkeypatch.setattr(resolve_issue, "git", fake_git)
@@ -336,13 +368,15 @@ def test_push_branch_uses_explicit_github_token(monkeypatch, tmp_path):
         auth_token="token-123",
     )
 
+    push_url = "https://x-access-token:token-123@github.com/gptme/gptme-contrib.git"
     assert calls == [
+        ["ls-remote", "--heads", push_url, "gptme-resolver/issue-42"],
         [
             "push",
             "--force-with-lease",
-            "https://x-access-token:token-123@github.com/gptme/gptme-contrib.git",
+            push_url,
             "HEAD:refs/heads/gptme-resolver/issue-42",
-        ]
+        ],
     ]
 
 

--- a/scripts/github_resolver/test_resolve_issue.py
+++ b/scripts/github_resolver/test_resolve_issue.py
@@ -157,6 +157,38 @@ def test_status_regex_ignores_prose_mentions():
     assert status == "error"
 
 
+def test_extract_tool_errors_returns_empty_when_none():
+    out = "RESOLVER_STATUS: changes\nRESOLVER_SUMMARY: something\n"
+    assert resolve_issue.extract_tool_errors(out) == []
+
+
+def test_extract_tool_errors_finds_errors():
+    out = (
+        "some work\n"
+        "System: Error during execution: Patch failed: original chunk not found in file\n"
+        "more work\n"
+        "System: Error during execution: another failure\n"
+        "RESOLVER_STATUS: changes\n"
+    )
+    errors = resolve_issue.extract_tool_errors(out)
+    assert len(errors) == 2
+    assert "Patch failed" in errors[0]
+    assert "another failure" in errors[1]
+
+
+def test_extract_tool_errors_deduplicates_consecutive_identical_errors():
+    out = (
+        "System: Error during execution: Patch failed: original chunk not found in file\n"
+        "System: Error during execution: Patch failed: original chunk not found in file\n"
+    )
+    errors = resolve_issue.extract_tool_errors(out)
+    assert len(errors) == 1
+
+
+def test_extract_tool_errors_handles_empty_string():
+    assert resolve_issue.extract_tool_errors("") == []
+
+
 def test_open_draft_pr_retrigger_returns_existing_url(monkeypatch):
     # On re-trigger, `gh pr create` exits 1 ("a pull request … already exists").
     # open_draft_pr must catch CalledProcessError and return the existing PR URL


### PR DESCRIPTION
## Summary

- Fix `push_branch()` failing on re-trigger resolver runs (e.g. canary ErikBjare/bob#825)
- Root cause: `git push --force-with-lease <URL> HEAD:refs/heads/<branch>` always fails when the remote already has the branch from a prior run — pushing via an explicit URL (not a named remote) never updates the local tracking ref `refs/remotes/origin/...`, so git sees it as stale and rejects the push
- Fix: call `git ls-remote --heads` before pushing to check whether the remote branch already exists, then pick the right flag: `--force` for new branches (no tracking ref available), `--force-with-lease` for existing branches (safe re-trigger)
- The named-remote fallback path (local/non-CI use) gets the same ls-remote check and uses plain `-u` push for brand-new branches

## Safety

The resolver branch (`gptme-resolver/issue-NNN`) is exclusively owned by the resolver workflow. Concurrent runs are serialised by the caller's `concurrency` group, so `--force` on a URL-based new-branch push is safe.

## Test plan
- [x] `test_push_branch_uses_explicit_github_token_new_branch` — verifies `--force` used when ls-remote returns empty (new branch)
- [x] `test_push_branch_uses_force_with_lease_on_existing_branch` — verifies `--force-with-lease` used when ls-remote returns a ref (existing branch)
- [x] All 23 resolver tests pass
- [ ] Run resolver canary (ErikBjare/bob#825) and verify branch is successfully published