### PR TITLE
fix(resolver): probe for existing PR explicitly instead of matching gh stderr

### DIFF
--- a/scripts/github_resolver/resolve_issue.py
+++ b/scripts/github_resolver/resolve_issue.py
@@ -545,7 +545,7 @@ def _existing_pr_url(repo: str, branch: str) -> str | None:
                 ".[0].url // empty",
             ]
         )
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
         return None
     return raw.strip() or None
 

--- a/scripts/github_resolver/resolve_issue.py
+++ b/scripts/github_resolver/resolve_issue.py
@@ -505,15 +505,49 @@ def open_draft_pr(repo: str, issue_number: int, branch: str, summary: str) -> st
             ]
         )
     except subprocess.CalledProcessError as e:
-        # Only treat as "PR already exists" when gh explicitly says so.
-        # A bare except used to swallow unrelated errors (e.g. missing --base
-        # outside a git workdir, auth issues) and mask the real failure with a
-        # confusing "no pull requests found for branch" secondary error.
-        stderr = (e.stderr or "").lower()
-        if "already exists" not in stderr:
-            raise
-        raw = gh(["pr", "view", "--repo", repo, "--json", "url", "-q", ".url", branch])
+        # `gh pr create` fails for many reasons (auth, missing --base outside a
+        # git workdir, GraphQL errors), not only because a PR already exists.
+        # Probe explicitly for an open PR on this branch rather than
+        # pattern-matching gh's (locale-dependent) stderr.
+        existing = _existing_pr_url(repo, branch)
+        if existing:
+            return existing
+        # No existing PR: surface the real create failure so the resolver
+        # reports the actual reason instead of a confusing secondary error.
+        if e.stderr:
+            sys.stderr.write(f"gh pr create failed:\n{e.stderr}\n")
+        raise
     return raw.strip().splitlines()[-1] if raw.strip() else ""
+
+
+def _existing_pr_url(repo: str, branch: str) -> str | None:
+    """Return the URL of an open PR for *branch*, or None if there is none.
+
+    Used as an explicit probe after `gh pr create` fails, so a create failure
+    is only treated as "PR already exists" when a PR genuinely does. Fails
+    soft: any error while probing returns None so the caller can surface the
+    original create failure instead of masking it.
+    """
+    try:
+        raw = gh(
+            [
+                "pr",
+                "list",
+                "--repo",
+                repo,
+                "--head",
+                branch,
+                "--state",
+                "open",
+                "--json",
+                "url",
+                "-q",
+                ".[0].url // empty",
+            ]
+        )
+    except subprocess.CalledProcessError:
+        return None
+    return raw.strip() or None
 
 
 def comment_on_issue(

--- a/scripts/github_resolver/test_resolve_issue.py
+++ b/scripts/github_resolver/test_resolve_issue.py
@@ -455,9 +455,9 @@ def test_main_reclassifies_status_when_two_identical_write_errors_despite_dirty_
 
 
 def test_open_draft_pr_retrigger_returns_existing_url(monkeypatch):
-    # On re-trigger, `gh pr create` exits 1 ("a pull request … already exists").
-    # open_draft_pr must catch CalledProcessError and return the existing PR URL
-    # via `gh pr view` so the caller can still post the issue comment.
+    # On re-trigger, `gh pr create` exits 1. open_draft_pr must probe for an
+    # existing open PR via `gh pr list --head` and return its URL so the caller
+    # can still post the issue comment — without relying on gh's stderr wording.
     calls: list[list[str]] = []
 
     def fake_gh(args, **_kw):
@@ -468,7 +468,7 @@ def test_open_draft_pr_retrigger_returns_existing_url(monkeypatch):
                 "a pull request for branch 'gptme-resolver/issue-42' already exists"
             )
             raise err
-        if args[0] == "pr" and args[1] == "view":
+        if args[0] == "pr" and args[1] == "list":
             return "https://github.com/gptme/gptme-contrib/pull/99\n"
         return ""
 
@@ -477,8 +477,34 @@ def test_open_draft_pr_retrigger_returns_existing_url(monkeypatch):
         "gptme/gptme-contrib", 42, "gptme-resolver/issue-42", "fixed the crash"
     )
     assert url == "https://github.com/gptme/gptme-contrib/pull/99"
-    # Verify we fell back to `gh pr view`
-    assert any(a[0] == "pr" and a[1] == "view" for a in calls)
+    # Verify we probed with `gh pr list --head` rather than assuming.
+    list_call = next(c for c in calls if c[0] == "pr" and c[1] == "list")
+    assert "--head" in list_call and "gptme-resolver/issue-42" in list_call
+
+
+def test_open_draft_pr_reraises_when_probe_finds_no_pr(monkeypatch):
+    """A create failure with no existing PR must propagate the original error.
+
+    Even when stderr happens to mention "already exists", the explicit probe is
+    authoritative: if `gh pr list` returns no PR, surface the create failure
+    instead of masking it.
+    """
+    calls: list[list[str]] = []
+
+    def fake_gh(args, **_kw):
+        calls.append(args)
+        if args[0] == "pr" and args[1] == "create":
+            raise _cpe(stderr="HTTP 422: validation failed (no commits between …)")
+        if args[0] == "pr" and args[1] == "list":
+            return ""  # no open PR for this branch
+        return ""
+
+    monkeypatch.setattr(resolve_issue, "gh", fake_gh)
+    with pytest.raises(subprocess.CalledProcessError):
+        resolve_issue.open_draft_pr(
+            "org/repo", 42, "gptme-resolver/issue-42", "summary"
+        )
+    assert any(c[0] == "pr" and c[1] == "list" for c in calls)
 
 
 def test_run_gptme_uses_restricted_tools_and_sanitized_env(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Closes #1020 (the remaining robustness work after #1021).

`open_draft_pr()` decided that a `gh pr create` failure meant a PR already existed by string-matching gh's stderr for `already exists`. That match is locale- and wording-dependent, and a genuine failure with no existing PR fell through to a confusing secondary error.

## Change

- Add `_existing_pr_url(repo, branch)` — an explicit probe via `gh pr list --head <branch> --state open --json url`. Fails soft (returns `None` on any probe error).
- On `gh pr create` failure, `open_draft_pr()` now:
  1. probes for an open PR on the branch; returns its URL only if one genuinely exists,
  2. otherwise writes the real create stderr to stderr and re-raises the original error.

This satisfies all three desired behaviors from #1020: only fall back when a PR truly exists, surface the original create failure otherwise, and probe explicitly rather than pattern-matching stderr.

## Tests

- Updated `test_open_draft_pr_retrigger_returns_existing_url` to assert the `gh pr list --head` probe path.
- Added `test_open_draft_pr_reraises_when_probe_finds_no_pr` (create fails, no PR found → original error propagates).
- Full resolver suite: 35 passed; ruff clean.