### PR TITLE
feat(sessions): add dedup command for overlapping session records

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -541,12 +541,36 @@ def _merge_into_keeper(
             if apply:
                 setattr(keeper, name, other)
             filled.append(name)
+    # Merge deliverables (list[str])
     existing = set(keeper.deliverables or [])
     extra = [d for d in (duplicate.deliverables or []) if d not in existing]
     if extra:
         if apply:
-            keeper.deliverables.extend(extra)
+            if keeper.deliverables is None:
+                keeper.deliverables = list(extra)
+            else:
+                keeper.deliverables.extend(extra)
         filled.append("deliverables")
+    # Merge deliverable_details (list[dict]) — union by value equality
+    existing_details = keeper.deliverable_details or []
+    extra_details = [d for d in (duplicate.deliverable_details or []) if d not in existing_details]
+    if extra_details:
+        if apply:
+            if keeper.deliverable_details is None:
+                keeper.deliverable_details = list(extra_details)
+            else:
+                keeper.deliverable_details.extend(extra_details)
+        filled.append("deliverable_details")
+    # Merge grades (dict[str, float]) — add keys the keeper lacks
+    dup_grades = duplicate.grades or {}
+    extra_grades = {k: v for k, v in dup_grades.items() if k not in (keeper.grades or {})}
+    if extra_grades:
+        if apply:
+            if keeper.grades is None:
+                keeper.grades = dict(extra_grades)
+            else:
+                keeper.grades.update(extra_grades)
+        filled.append("grades")
     return filled
 
 

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -388,6 +388,166 @@ def _match_auto_tag_override(
     return None
 
 
+# -- dedup helpers -----------------------------------------------------------
+
+# Fields whose presence signals a "richer" (more complete) record. Used both to
+# rank duplicate records and to decide which fields to merge into the keeper.
+_RICHNESS_FIELDS: tuple[str, ...] = (
+    "start_time",
+    "end_time",
+    "session_name",
+    "project",
+    "category",
+    "recommended_category",
+    "selector_mode",
+    "trajectory_path",
+    "journal_path",
+    "trajectory_grade",
+    "llm_judge_score",
+    "token_count",
+    "context_peak_tokens",
+    "harm_category",
+    "span_aggregates",
+)
+
+# Values that count as "empty" for richness/merge purposes.
+_EMPTY_VALUES: tuple[object, ...] = (None, "", "unknown", 0)
+
+
+def _record_interval(record: SessionRecord) -> tuple[datetime, datetime] | None:
+    """Return ``(start, end)`` datetimes for a record, or ``None`` if unparseable.
+
+    Prefers ``start_time``/``end_time``; falls back to ``timestamp`` plus
+    ``duration_seconds`` when the explicit end is missing.
+    """
+    start_raw = record.start_time or record.timestamp
+    if not start_raw:
+        return None
+    try:
+        start = datetime.fromisoformat(start_raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    end: datetime | None = None
+    if record.end_time:
+        try:
+            end = datetime.fromisoformat(record.end_time.replace("Z", "+00:00"))
+        except ValueError:
+            end = None
+    if end is None:
+        end = start + timedelta(seconds=max(record.duration_seconds or 0, 0))
+    if end < start:
+        end = start
+    return start, end
+
+
+def _overlap_ratio(
+    a: tuple[datetime, datetime],
+    b: tuple[datetime, datetime],
+) -> float:
+    """Jaccard overlap of two intervals: intersection / union (0.0-1.0).
+
+    Jaccard (not "fraction of the shorter interval") is the right test for
+    *duplicate* records — two recordings of the same session have near-identical
+    start AND end, so their intersection ≈ their union. A short session merely
+    nested inside a longer, genuinely different session has a small union ratio
+    and is correctly left alone.
+    """
+    latest_start = max(a[0], b[0])
+    earliest_end = min(a[1], b[1])
+    intersection = (earliest_end - latest_start).total_seconds()
+    if intersection <= 0:
+        return 0.0
+    earliest_start = min(a[0], b[0])
+    latest_end = max(a[1], b[1])
+    union = (latest_end - earliest_start).total_seconds()
+    if union <= 0:
+        # Both intervals are the same zero-length instant → identical.
+        return 1.0
+    return min(intersection / union, 1.0)
+
+
+def _record_richness(record: SessionRecord) -> int:
+    """Count populated metadata fields; higher means a more complete record."""
+    score = sum(1 for name in _RICHNESS_FIELDS if getattr(record, name, None) not in _EMPTY_VALUES)
+    score += len(record.deliverables or [])
+    score += len(record.deliverable_details or [])
+    score += len(record.grades or {})
+    return score
+
+
+def _find_duplicate_groups(
+    records: list[SessionRecord],
+    *,
+    min_overlap: float,
+) -> list[list[SessionRecord]]:
+    """Group same-harness records whose time intervals overlap by ``>= min_overlap``.
+
+    Returns groups of 2+ records, each sorted richest-first. Records without a
+    parseable interval are never grouped. Overlap is transitive (union-find), so
+    a chain of overlapping sessions collapses into a single group.
+    """
+    by_harness: dict[str, list[tuple[SessionRecord, tuple[datetime, datetime]]]] = {}
+    for record in records:
+        interval = _record_interval(record)
+        if interval is None:
+            continue
+        by_harness.setdefault(record.harness or "unknown", []).append((record, interval))
+
+    groups: list[list[SessionRecord]] = []
+    for items in by_harness.values():
+        count = len(items)
+        parent = list(range(count))
+
+        def find(x: int) -> int:
+            while parent[x] != x:
+                parent[x] = parent[parent[x]]
+                x = parent[x]
+            return x
+
+        for i in range(count):
+            for j in range(i + 1, count):
+                if _overlap_ratio(items[i][1], items[j][1]) >= min_overlap:
+                    parent[find(i)] = find(j)
+
+        clusters: dict[int, list[SessionRecord]] = {}
+        for idx in range(count):
+            clusters.setdefault(find(idx), []).append(items[idx][0])
+        for members in clusters.values():
+            if len(members) >= 2:
+                members.sort(key=_record_richness, reverse=True)
+                groups.append(members)
+    return groups
+
+
+def _merge_into_keeper(
+    keeper: SessionRecord,
+    duplicate: SessionRecord,
+    *,
+    apply: bool,
+) -> list[str]:
+    """Fill the keeper's empty fields from a duplicate; return the filled names.
+
+    When ``apply`` is False the field list is computed without mutating, so the
+    same call powers both ``--dry-run`` previews and real merges.
+    """
+    filled: list[str] = []
+    for name in _RICHNESS_FIELDS:
+        if getattr(keeper, name, None) not in _EMPTY_VALUES:
+            continue
+        other = getattr(duplicate, name, None)
+        if other not in _EMPTY_VALUES:
+            if apply:
+                setattr(keeper, name, other)
+            filled.append(name)
+    existing = set(keeper.deliverables or [])
+    extra = [d for d in (duplicate.deliverables or []) if d not in existing]
+    if extra:
+        if apply:
+            keeper.deliverables.extend(extra)
+        filled.append("deliverables")
+    return filled
+
+
 @click.group(invoke_without_command=True)
 @click.option(
     "--sessions-dir",
@@ -1063,6 +1223,103 @@ def auto_tag(
         summary_verb = "Would tag" if dry_run else "Tagged"
         click.echo(
             f"\n{summary_verb} {changed} record(s); {unchanged} unchanged; {skipped} skipped."
+        )
+
+
+@cli.command()
+@click.option(
+    "--min-overlap",
+    type=click.FloatRange(0.0, 1.0),
+    default=0.6,
+    show_default=True,
+    help="Minimum Jaccard time-overlap (intersection/union) for two "
+    "same-harness records to count as duplicates",
+)
+@click.option("--dry-run", is_flag=True, help="Show the merge plan without rewriting the store")
+@click.option("--json", "as_json", is_flag=True, help="Output results as JSON")
+@click.pass_context
+def dedup(
+    ctx: click.Context,
+    min_overlap: float,
+    dry_run: bool,
+    as_json: bool,
+) -> None:
+    """Merge duplicate session records into the richer record.
+
+    Two records are duplicates when they share a harness and their time
+    intervals overlap by at least ``--min-overlap`` (Jaccard:
+    intersection/union). The richest record in each
+    group is kept and enriched with any metadata it was missing; the other
+    records are tagged with ``duplicate_of`` so analytics can filter them out.
+
+    Records are **never deleted** — trajectory/session data is preserved
+    (re-running is idempotent: already-merged duplicates are skipped).
+    """
+    store = SessionStore(sessions_dir=ctx.obj["sessions_dir"])
+    records = store.load_all()
+    if not records:
+        click.echo("No records in store.")
+        return
+
+    groups = _find_duplicate_groups(records, min_overlap=min_overlap)
+    if not groups:
+        click.echo("No duplicate session records found.")
+        return
+
+    results: list[dict[str, Any]] = []
+    merged_count = 0
+    for group in groups:
+        keeper = group[0]
+        dup_rows: list[dict[str, Any]] = []
+        for dup in group[1:]:
+            if dup._legacy_fields.get("duplicate_of"):
+                # Already merged in a prior run — keep idempotent.
+                continue
+            filled = _merge_into_keeper(keeper, dup, apply=not dry_run)
+            if not dry_run:
+                dup._legacy_fields["duplicate_of"] = keeper.session_id
+            dup_rows.append(
+                {
+                    "session_id": dup.session_id,
+                    "richness": _record_richness(dup),
+                    "merged_fields": filled,
+                    "status": "would-merge" if dry_run else "merged",
+                }
+            )
+            merged_count += 1
+        if dup_rows:
+            results.append(
+                {
+                    "keeper": keeper.session_id,
+                    "keeper_richness": _record_richness(keeper),
+                    "harness": keeper.harness or "unknown",
+                    "duplicates": dup_rows,
+                }
+            )
+
+    if not results:
+        click.echo("No new duplicates to merge (all already deduped).")
+        return
+
+    if merged_count and not dry_run:
+        store.rewrite(records)
+
+    if as_json:
+        click.echo(json.dumps(results, indent=2))
+    else:
+        for row in results:
+            click.echo(
+                f"keeper {row['keeper']} ({row['harness']}, richness={row['keeper_richness']}):"
+            )
+            for dup in row["duplicates"]:
+                fields = ", ".join(dup["merged_fields"]) or "no new fields"
+                click.echo(
+                    f"  {dup['status']:<11}  {dup['session_id']:<12}  "
+                    f"richness={dup['richness']:<3}  [{fields}]"
+                )
+        summary_verb = "Would merge" if dry_run else "Merged"
+        click.echo(
+            f"\n{summary_verb} {merged_count} duplicate record(s) into {len(results)} keeper(s)."
         )
 
 

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -411,7 +411,9 @@ _RICHNESS_FIELDS: tuple[str, ...] = (
 )
 
 # Values that count as "empty" for richness/merge purposes.
-_EMPTY_VALUES: tuple[object, ...] = (None, "", "unknown", 0)
+# Do NOT include numeric 0: Python's 0 == 0.0 would treat a legitimate 0.0
+# llm_judge_score or trajectory_grade as missing and silently overwrite it.
+_EMPTY_VALUES: tuple[object, ...] = (None, "", "unknown")
 
 
 def _record_interval(record: SessionRecord) -> tuple[datetime, datetime] | None:
@@ -452,17 +454,17 @@ def _overlap_ratio(
     nested inside a longer, genuinely different session has a small union ratio
     and is correctly left alone.
     """
-    latest_start = max(a[0], b[0])
-    earliest_end = min(a[1], b[1])
-    intersection = (earliest_end - latest_start).total_seconds()
-    if intersection <= 0:
-        return 0.0
     earliest_start = min(a[0], b[0])
     latest_end = max(a[1], b[1])
     union = (latest_end - earliest_start).total_seconds()
     if union <= 0:
         # Both intervals are the same zero-length instant → identical.
         return 1.0
+    latest_start = max(a[0], b[0])
+    earliest_end = min(a[1], b[1])
+    intersection = (earliest_end - latest_start).total_seconds()
+    if intersection <= 0:
+        return 0.0
     return min(intersection / union, 1.0)
 
 

--- a/packages/gptme-sessions/tests/test_cli.py
+++ b/packages/gptme-sessions/tests/test_cli.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from click.testing import CliRunner
 
 from gptme_sessions.cli import cli
@@ -1163,7 +1165,7 @@ class TestDedupCommand:
     def test_dedup_respects_min_overlap_threshold(self, tmp_path: Path) -> None:
         """Records overlapping below --min-overlap are left untouched."""
         store = SessionStore(sessions_dir=tmp_path)
-        # 2-min overlap of a 10-min interval = 0.2, below the 0.6 default.
+        # Jaccard = intersection/union = 2 min / 18 min ≈ 0.11, below the 0.6 default.
         store.append(
             SessionRecord(
                 session_id="a",
@@ -1246,3 +1248,71 @@ class TestDedupCommand:
         assert "Merged 1 duplicate record(s)" in out
         reloaded = {r.session_id: r for r in SessionStore(sessions_dir=tmp_path).load_all()}
         assert reloaded["instant-dup"]._legacy_fields.get("duplicate_of") == "instant-rich"
+
+    def test_dedup_keeper_no_deliverables_merges_from_dup(self, tmp_path: Path) -> None:
+        """Crash guard: keeper.deliverables=None must not raise AttributeError."""
+        store = SessionStore(sessions_dir=tmp_path)
+        # keeper has no deliverables — exercises the None-guard in _merge_into_keeper
+        store.append(
+            SessionRecord(
+                session_id="keeper",
+                harness="claude-code",
+                start_time="2026-05-31T10:00:00+00:00",
+                end_time="2026-05-31T10:10:00+00:00",
+                category="code",
+                deliverables=None,  # type: ignore[arg-type]
+            )
+        )
+        store.append(
+            SessionRecord(
+                session_id="dup",
+                harness="claude-code",
+                start_time="2026-05-31T10:02:00+00:00",
+                end_time="2026-05-31T10:12:00+00:00",
+                deliverables=["sha-from-dup"],
+            )
+        )
+
+        rc, out = _invoke(["dedup"], tmp_path)
+
+        assert rc == 0, out
+        reloaded = {r.session_id: r for r in SessionStore(sessions_dir=tmp_path).load_all()}
+        assert "sha-from-dup" in (reloaded["keeper"].deliverables or [])
+
+    def test_dedup_merges_grades_and_deliverable_details(self, tmp_path: Path) -> None:
+        """grades and deliverable_details from the duplicate are merged into the keeper."""
+        store = SessionStore(sessions_dir=tmp_path)
+        store.append(
+            SessionRecord(
+                session_id="keeper",
+                harness="claude-code",
+                start_time="2026-05-31T10:00:00+00:00",
+                end_time="2026-05-31T10:10:00+00:00",
+                category="code",
+                grades={"alignment": 0.8},
+                deliverable_details=[{"url": "https://github.com/org/repo/pull/1"}],
+            )
+        )
+        store.append(
+            SessionRecord(
+                session_id="dup",
+                harness="claude-code",
+                start_time="2026-05-31T10:02:00+00:00",
+                end_time="2026-05-31T10:12:00+00:00",
+                grades={"productivity": 0.9},
+                deliverable_details=[{"url": "https://github.com/org/repo/pull/2"}],
+            )
+        )
+
+        rc, out = _invoke(["dedup"], tmp_path)
+
+        assert rc == 0, out
+        reloaded = {r.session_id: r for r in SessionStore(sessions_dir=tmp_path).load_all()}
+        keeper = reloaded["keeper"]
+        # Existing grades key preserved; dup's new key added.
+        assert keeper.grades.get("alignment") == pytest.approx(0.8)
+        assert keeper.grades.get("productivity") == pytest.approx(0.9)
+        # Existing detail preserved; dup's new detail added.
+        urls = [d["url"] for d in (keeper.deliverable_details or [])]
+        assert "https://github.com/org/repo/pull/1" in urls
+        assert "https://github.com/org/repo/pull/2" in urls

--- a/packages/gptme-sessions/tests/test_cli.py
+++ b/packages/gptme-sessions/tests/test_cli.py
@@ -1185,3 +1185,64 @@ class TestDedupCommand:
 
         assert rc == 0
         assert "No duplicate session records found" in out
+
+    def test_dedup_preserves_zero_score(self, tmp_path: Path) -> None:
+        """A keeper with llm_judge_score=0.0 must not have it overwritten."""
+        store = SessionStore(sessions_dir=tmp_path)
+        # rich: overlapping interval, has a valid worst-case score of 0.0
+        store.append(
+            SessionRecord(
+                session_id="scored",
+                harness="claude-code",
+                start_time="2026-05-31T10:00:00+00:00",
+                end_time="2026-05-31T10:10:00+00:00",
+                category="code",
+                llm_judge_score=0.0,
+                journal_path="/journal/scored.md",
+            )
+        )
+        # poor duplicate carries a better score the keeper must NOT adopt
+        store.append(
+            SessionRecord(
+                session_id="scored-dup",
+                harness="claude-code",
+                start_time="2026-05-31T10:01:00+00:00",
+                end_time="2026-05-31T10:11:00+00:00",
+                llm_judge_score=0.9,
+            )
+        )
+
+        _invoke(["dedup"], tmp_path)
+
+        reloaded = {r.session_id: r for r in SessionStore(sessions_dir=tmp_path).load_all()}
+        assert reloaded["scored"].llm_judge_score == 0.0
+
+    def test_dedup_identical_zero_duration(self, tmp_path: Path) -> None:
+        """Two zero-duration records at the same instant count as duplicates."""
+        store = SessionStore(sessions_dir=tmp_path)
+        ts = "2026-05-31T10:00:00+00:00"
+        store.append(
+            SessionRecord(
+                session_id="instant-rich",
+                harness="gptme",
+                start_time=ts,
+                end_time=ts,
+                category="code",
+                journal_path="/journal/instant-rich.md",
+            )
+        )
+        store.append(
+            SessionRecord(
+                session_id="instant-dup",
+                harness="gptme",
+                start_time=ts,
+                end_time=ts,
+            )
+        )
+
+        rc, out = _invoke(["dedup"], tmp_path)
+
+        assert rc == 0
+        assert "Merged 1 duplicate record(s)" in out
+        reloaded = {r.session_id: r for r in SessionStore(sessions_dir=tmp_path).load_all()}
+        assert reloaded["instant-dup"]._legacy_fields.get("duplicate_of") == "instant-rich"

--- a/packages/gptme-sessions/tests/test_cli.py
+++ b/packages/gptme-sessions/tests/test_cli.py
@@ -1055,3 +1055,133 @@ class TestAutoTagCommand:
 
         persisted = SessionStore(sessions_dir=tmp_path).load_all()[0]
         assert persisted.category == "social"
+
+
+class TestDedupCommand:
+    @staticmethod
+    def _overlapping_pair(store: SessionStore) -> None:
+        """Two same-harness records overlapping ~80%, one richer than the other."""
+        # rich: 10:00-10:10, has category + journal_path + deliverable
+        store.append(
+            SessionRecord(
+                session_id="rich",
+                harness="claude-code",
+                start_time="2026-05-31T10:00:00+00:00",
+                end_time="2026-05-31T10:10:00+00:00",
+                category="code",
+                journal_path="/journal/rich.md",
+                deliverables=["sha-rich"],
+            )
+        )
+        # poor: 10:02-10:12 (8/10 min overlap of the 10-min interval = 0.8),
+        # carries a project the rich record lacks + a unique deliverable
+        store.append(
+            SessionRecord(
+                session_id="poor",
+                harness="claude-code",
+                start_time="2026-05-31T10:02:00+00:00",
+                end_time="2026-05-31T10:12:00+00:00",
+                project="/home/bob/bob",
+                deliverables=["sha-poor"],
+            )
+        )
+
+    def test_dedup_dry_run_does_not_rewrite(self, tmp_path: Path) -> None:
+        """dedup --dry-run reports the merge plan without mutating the store."""
+        store = SessionStore(sessions_dir=tmp_path)
+        self._overlapping_pair(store)
+
+        rc, out = _invoke(["dedup", "--dry-run", "--json"], tmp_path)
+
+        assert rc == 0
+        data = json.loads(out)
+        assert len(data) == 1
+        assert data[0]["keeper"] == "rich"
+        assert data[0]["duplicates"][0]["session_id"] == "poor"
+        assert data[0]["duplicates"][0]["status"] == "would-merge"
+
+        # Nothing persisted: poor keeps no duplicate_of marker, rich unchanged.
+        reloaded = {r.session_id: r for r in SessionStore(sessions_dir=tmp_path).load_all()}
+        assert reloaded["rich"].project is None
+        assert reloaded["poor"]._legacy_fields.get("duplicate_of") is None
+
+    def test_dedup_merges_into_richer_record(self, tmp_path: Path) -> None:
+        """dedup enriches the keeper and tags the duplicate without deleting it."""
+        store = SessionStore(sessions_dir=tmp_path)
+        self._overlapping_pair(store)
+
+        rc, out = _invoke(["dedup"], tmp_path)
+
+        assert rc == 0
+        assert "Merged 1 duplicate record(s)" in out
+
+        reloaded = {r.session_id: r for r in SessionStore(sessions_dir=tmp_path).load_all()}
+        # Both records are preserved (no deletion).
+        assert set(reloaded) == {"rich", "poor"}
+        # Keeper gained the project it was missing and the duplicate's deliverable.
+        assert reloaded["rich"].project == "/home/bob/bob"
+        assert set(reloaded["rich"].deliverables) == {"sha-rich", "sha-poor"}
+        # Duplicate is tagged so analytics can filter it.
+        assert reloaded["poor"]._legacy_fields.get("duplicate_of") == "rich"
+
+    def test_dedup_is_idempotent(self, tmp_path: Path) -> None:
+        """A second dedup run finds nothing new to merge."""
+        store = SessionStore(sessions_dir=tmp_path)
+        self._overlapping_pair(store)
+        _invoke(["dedup"], tmp_path)
+
+        rc, out = _invoke(["dedup"], tmp_path)
+
+        assert rc == 0
+        assert "all already deduped" in out
+
+    def test_dedup_ignores_different_harness(self, tmp_path: Path) -> None:
+        """Overlapping records from different harnesses are not merged."""
+        store = SessionStore(sessions_dir=tmp_path)
+        store.append(
+            SessionRecord(
+                session_id="cc",
+                harness="claude-code",
+                start_time="2026-05-31T10:00:00+00:00",
+                end_time="2026-05-31T10:10:00+00:00",
+            )
+        )
+        store.append(
+            SessionRecord(
+                session_id="gptme",
+                harness="gptme",
+                start_time="2026-05-31T10:00:00+00:00",
+                end_time="2026-05-31T10:10:00+00:00",
+            )
+        )
+
+        rc, out = _invoke(["dedup"], tmp_path)
+
+        assert rc == 0
+        assert "No duplicate session records found" in out
+
+    def test_dedup_respects_min_overlap_threshold(self, tmp_path: Path) -> None:
+        """Records overlapping below --min-overlap are left untouched."""
+        store = SessionStore(sessions_dir=tmp_path)
+        # 2-min overlap of a 10-min interval = 0.2, below the 0.6 default.
+        store.append(
+            SessionRecord(
+                session_id="a",
+                harness="claude-code",
+                start_time="2026-05-31T10:00:00+00:00",
+                end_time="2026-05-31T10:10:00+00:00",
+            )
+        )
+        store.append(
+            SessionRecord(
+                session_id="b",
+                harness="claude-code",
+                start_time="2026-05-31T10:08:00+00:00",
+                end_time="2026-05-31T10:18:00+00:00",
+            )
+        )
+
+        rc, out = _invoke(["dedup"], tmp_path)
+
+        assert rc == 0
+        assert "No duplicate session records found" in out


### PR DESCRIPTION
## What

Adds a `dedup` subcommand to `gptme-sessions` — the second half of the
auto-tagging-and-dedup task (auto-tag landed in #1028).

Merges duplicate session records into the richest record:
- Two records are duplicates when they share a **harness** and their time
  intervals overlap by at least `--min-overlap` (default `0.6`), measured as
  **Jaccard** overlap (intersection / union).
- The richest record per group is kept and **enriched** with any metadata it
  was missing; the duplicates are tagged with `duplicate_of` so analytics can
  filter them.
- Records are **never deleted** — trajectory/session data is preserved (the
  trajectory-persistence invariant). Re-running is idempotent: already-merged
  duplicates are skipped.
- `--dry-run` previews the merge plan without rewriting the store.

## Why Jaccard, not fraction-of-shorter

A short session nested inside a longer, genuinely *different* session scores
1.0 under "fraction of the shorter interval", producing false duplicates. On
the real store that over-flagged ~1634 records; Jaccard (intersection/union)
only flags near-identical intervals — two recordings of the *same* session —
cutting it to ~426 at the 0.6 default (~76 at 0.9).

## Tests

`TestDedupCommand` covers: dry-run non-persistence, richer-record merge +
`duplicate_of` tagging + deliverable union, idempotency, cross-harness
isolation, and the `--min-overlap` threshold boundary.

- `uv run pytest packages/gptme-sessions/tests/test_cli.py -q` → 68 passed
- `make -C packages/gptme-sessions typecheck` → clean

## Note

This PR ships the *capability* and validates it via `--dry-run` on the real
store. It does **not** run the destructive merge on the canonical
`session-records.jsonl` (used for grading/bandit) — that is a deliberate
operational decision left for a reviewed run.