### PR TITLE
feat(codegraph): add Go language support (symbol + import extraction)

### DIFF
--- a/packages/gptme-codegraph/pyproject.toml
+++ b/packages/gptme-codegraph/pyproject.toml
@@ -16,6 +16,7 @@ treesitter = [
     "tree-sitter-javascript>=0.21.0",
     "tree-sitter-typescript>=0.23.0",
     "tree-sitter-rust>=0.24.0",
+    "tree-sitter-go>=0.23.0",
 ]
 mcp = [
     "mcp>=1.0.0",

--- a/packages/gptme-codegraph/src/gptme_codegraph/core.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/core.py
@@ -3,7 +3,7 @@
 Complementary to gptme-rag (text chunks), this retrieves code *structure*:
 function/class definitions, call graphs, and blast radius.
 
-Supports Python, TypeScript/JavaScript, and Rust via tree-sitter grammars.
+Supports Python, TypeScript/JavaScript, Rust, and Go via tree-sitter grammars.
 To add a new language: add grammar dep to pyproject.toml, extend _LANG_MAP
 and _load_language, then add extractor functions.
 
@@ -1305,18 +1305,37 @@ def _extract_symbols_rust(root, filepath: str) -> list[Symbol]:
 
 
 def _receiver_type_go(receiver_node) -> str | None:
-    """Extract the base type name from a Go receiver parameter_list."""
+    """Extract the base type name from a Go receiver parameter_list.
+
+    Handles plain, pointer, and generic receivers (Go 1.18+):
+      (r Foo)       → "Foo"
+      (r *Foo)      → "Foo"
+      (r Foo[T])    → "Foo"
+      (r *Foo[T])   → "Foo"
+    """
+
+    def _base_type(type_node) -> str | None:
+        if type_node.type == "type_identifier":
+            return _text(type_node)
+        if type_node.type == "pointer_type":
+            for sub in type_node.named_children:
+                result = _base_type(sub)
+                if result:
+                    return result
+        if type_node.type == "generic_type":
+            base = type_node.child_by_field_name("type")
+            if base is not None:
+                return _base_type(base)
+        return None
+
     for child in receiver_node.named_children:
         if child.type == "parameter_declaration":
             type_node = child.child_by_field_name("type")
             if type_node is None:
                 continue
-            if type_node.type == "pointer_type":
-                for sub in type_node.named_children:
-                    if sub.type == "type_identifier":
-                        return _text(sub)
-            elif type_node.type == "type_identifier":
-                return _text(type_node)
+            result = _base_type(type_node)
+            if result:
+                return result
     return None
 
 
@@ -1365,7 +1384,15 @@ def _extract_symbols_go(root, filepath: str) -> list[Symbol]:
                 if type_spec.type == "type_spec":
                     name_node = type_spec.child_by_field_name("name")
                     type_node = type_spec.child_by_field_name("type")
-                    if name_node and type_node:
+                    if (
+                        name_node
+                        and type_node
+                        and type_node.type
+                        in (
+                            "struct_type",
+                            "interface_type",
+                        )
+                    ):
                         symbols.append(
                             Symbol(
                                 name=_text(name_node),

--- a/packages/gptme-codegraph/src/gptme_codegraph/core.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/core.py
@@ -45,6 +45,7 @@ _LANG_MAP: dict[str, str] = {
     ".mjs": "javascript",
     ".cjs": "javascript",
     ".rs": "rust",
+    ".go": "go",
 }
 
 _GRAMMAR_MODULES: dict[str, str] = {
@@ -54,11 +55,12 @@ _GRAMMAR_MODULES: dict[str, str] = {
     "typescript": "tree_sitter_typescript",
     "tsx": "tree_sitter_typescript",
     "rust": "tree_sitter_rust",
+    "go": "tree_sitter_go",
 }
 
 _SOURCE_EXTENSIONS: tuple[str, ...] = tuple(_LANG_MAP.keys())
 _NOISE_PATH_PARTS: frozenset[str] = frozenset(
-    {"__pycache__", "node_modules", ".git", "target"}
+    {"__pycache__", "node_modules", ".git", "target", "vendor"}
 )
 
 
@@ -116,6 +118,12 @@ def _load_language(name: str):
         import tree_sitter_rust as tsrust  # type: ignore[import-not-found,unused-ignore]
 
         grammar_map["rust"] = tsrust.language()
+    except ImportError:
+        pass
+    try:
+        import tree_sitter_go as tsgo  # type: ignore[import-not-found,unused-ignore]
+
+        grammar_map["go"] = tsgo.language()
     except ImportError:
         pass
 
@@ -1292,6 +1300,142 @@ def _extract_symbols_rust(root, filepath: str) -> list[Symbol]:
 
 
 # ---------------------------------------------------------------------------
+# Go extraction
+# ---------------------------------------------------------------------------
+
+
+def _receiver_type_go(receiver_node) -> str | None:
+    """Extract the base type name from a Go receiver parameter_list."""
+    for child in receiver_node.named_children:
+        if child.type == "parameter_declaration":
+            type_node = child.child_by_field_name("type")
+            if type_node is None:
+                continue
+            if type_node.type == "pointer_type":
+                for sub in type_node.named_children:
+                    if sub.type == "type_identifier":
+                        return _text(sub)
+            elif type_node.type == "type_identifier":
+                return _text(type_node)
+    return None
+
+
+def _extract_symbols_go(root, filepath: str) -> list[Symbol]:
+    """Extract functions, methods, and named types from a Go parse tree."""
+    symbols: list[Symbol] = []
+
+    for node in root.named_children:
+        if node.type == "function_declaration":
+            name_node = node.child_by_field_name("name")
+            if name_node:
+                body_node = node.child_by_field_name("body")
+                calls = _extract_calls(body_node) if body_node else []
+                symbols.append(
+                    Symbol(
+                        name=_text(name_node),
+                        kind="function",
+                        file=filepath,
+                        start_line=node.start_point[0] + 1,
+                        end_line=node.end_point[0] + 1,
+                        calls=list(set(calls)),
+                    )
+                )
+        elif node.type == "method_declaration":
+            name_node = node.child_by_field_name("name")
+            receiver_node = node.child_by_field_name("receiver")
+            if name_node:
+                parent_class = (
+                    _receiver_type_go(receiver_node) if receiver_node else None
+                )
+                body_node = node.child_by_field_name("body")
+                calls = _extract_calls(body_node) if body_node else []
+                symbols.append(
+                    Symbol(
+                        name=_text(name_node),
+                        kind="method",
+                        file=filepath,
+                        start_line=node.start_point[0] + 1,
+                        end_line=node.end_point[0] + 1,
+                        parent_class=parent_class,
+                        calls=list(set(calls)),
+                    )
+                )
+        elif node.type == "type_declaration":
+            for type_spec in node.named_children:
+                if type_spec.type == "type_spec":
+                    name_node = type_spec.child_by_field_name("name")
+                    type_node = type_spec.child_by_field_name("type")
+                    if name_node and type_node:
+                        symbols.append(
+                            Symbol(
+                                name=_text(name_node),
+                                kind="class",
+                                file=filepath,
+                                start_line=type_spec.start_point[0] + 1,
+                                end_line=type_spec.end_point[0] + 1,
+                            )
+                        )
+
+    return symbols
+
+
+def _extract_imports_go(root) -> list[ImportInfo]:
+    """Extract import statements from a Go parse tree.
+
+    Handles:
+    - import "fmt"                  → name="fmt", module="fmt"
+    - import m "math"               → name="math", alias="m"
+    - import . "os"                 → name="os", is_from=True
+    - import _ "unused"             → name="unused", alias="_"
+    - import "github.com/foo/bar"   → name="bar", module="github.com/foo/bar"
+    """
+    imports: list[ImportInfo] = []
+
+    def _parse_import_spec(spec_node) -> None:
+        path_node = spec_node.child_by_field_name("path")
+        if path_node is None:
+            return
+        path_text = _strip_string_quotes(_text(path_node))
+        default_name = path_text.split("/")[-1]
+
+        alias = None
+        is_from = False
+        name_node = spec_node.child_by_field_name("name")
+        if name_node is not None:
+            alias_text = _text(name_node)
+            if alias_text == ".":
+                is_from = True
+            elif alias_text == "_":
+                alias = "_"
+            else:
+                alias = alias_text
+
+        imports.append(
+            ImportInfo(
+                file="",
+                name=default_name,
+                module=path_text,
+                is_from=is_from,
+                alias=alias,
+            )
+        )
+
+    try:
+        for node in root.named_children:
+            if node.type == "import_declaration":
+                for child in node.named_children:
+                    if child.type == "import_spec_list":
+                        for spec in child.named_children:
+                            if spec.type == "import_spec":
+                                _parse_import_spec(spec)
+                    elif child.type == "import_spec":
+                        _parse_import_spec(child)
+    except Exception:
+        pass
+    return imports
+
+
+# ---------------------------------------------------------------------------
 # Multi-language parse_file
 # ---------------------------------------------------------------------------
 
@@ -1300,7 +1444,7 @@ def parse_file(filepath: Path) -> FileParseResult:
     """Extract all symbols and imports from a source file.
 
     Detects language from file extension and dispatches to the correct
-    tree-sitter grammar. Supports Python, TypeScript/JavaScript, and Rust.
+    tree-sitter grammar. Supports Python, TypeScript/JavaScript, Rust, and Go.
     """
     code = filepath.read_bytes()
     lang_name = _detect_language(filepath)
@@ -1323,6 +1467,9 @@ def parse_file(filepath: Path) -> FileParseResult:
     elif lang_name == "rust":
         symbols = _extract_symbols_rust(root, filename)
 
+    elif lang_name == "go":
+        symbols = _extract_symbols_go(root, filename)
+
     imports: list[ImportInfo] = []
     if lang_name == "python":
         imports = _extract_imports(root)
@@ -1330,6 +1477,8 @@ def parse_file(filepath: Path) -> FileParseResult:
         imports = _extract_imports_javascript(root)
     elif lang_name == "rust":
         imports = _extract_imports_rust(root)
+    elif lang_name == "go":
+        imports = _extract_imports_go(root)
 
     for imp in imports:
         imp.file = filename

--- a/packages/gptme-codegraph/tests/test_multilang.py
+++ b/packages/gptme-codegraph/tests/test_multilang.py
@@ -1,7 +1,7 @@
-"""Tests for multi-language support in gptme-codegraph (JS/TS, Rust).
+"""Tests for multi-language support in gptme-codegraph (JS/TS, Rust, Go).
 
 Verifies that parse_file, extract_symbols, and build_index work correctly
-for JavaScript, TypeScript, and Rust source files.
+for JavaScript, TypeScript, Rust, and Go source files.
 """
 
 from __future__ import annotations
@@ -709,3 +709,173 @@ def test_parse_rust_imports_glob(rust_imports: Path):
     super_wild = [i for i in result.imports if i.module == "super" and i.name == "*"]
     assert len(super_wild) == 1
     assert super_wild[0].is_from is True
+
+
+# ---------------------------------------------------------------------------
+# Go
+# ---------------------------------------------------------------------------
+
+_skip_no_go = pytest.mark.skipif(
+    not _has_grammar("go"),
+    reason="tree-sitter-go not installed",
+)
+
+_GO_MODULE = """\
+package main
+
+import (
+\t"fmt"
+\tm "math"
+\t. "os"
+\t_ "io"
+)
+
+import "strings"
+
+type Calculator struct {
+\tprecision int
+}
+
+type Adder interface {
+\tAdd(a, b int) int
+}
+
+func NewCalc(p int) *Calculator {
+\treturn &Calculator{precision: p}
+}
+
+func (c *Calculator) Add(a, b int) int {
+\tfmt.Println("adding")
+\treturn a + b
+}
+
+func (c Calculator) Precision() int {
+\treturn c.precision
+}
+
+func helper() {
+\tm.Sqrt(2.0)
+\tstrings.Join(nil, "")
+}
+"""
+
+
+@pytest.fixture
+def go_module() -> Generator[Path, None, None]:
+    """A temporary Go source file with functions, methods, and types."""
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".go", delete=False, prefix="test_go_"
+    ) as f:
+        f.write(_GO_MODULE)
+        path = Path(f.name)
+    yield path
+    path.unlink(missing_ok=True)
+
+
+@_skip_no_go
+def test_language_detection_go(go_module: Path):
+    """parse_file detects .go files."""
+    result = parse_file(go_module)
+    assert result.language == "go"
+
+
+@_skip_no_go
+def test_parse_go_functions(go_module: Path):
+    """Go: top-level functions are extracted."""
+    result = parse_file(go_module)
+    names = {s.name for s in result.symbols if s.kind == "function"}
+    assert "NewCalc" in names
+    assert "helper" in names
+
+
+@_skip_no_go
+def test_parse_go_methods(go_module: Path):
+    """Go: methods are extracted with correct parent class."""
+    result = parse_file(go_module)
+    methods = [s for s in result.symbols if s.kind == "method"]
+    assert len(methods) >= 2
+
+    add = [m for m in methods if m.name == "Add"]
+    assert len(add) == 1
+    assert add[0].parent_class == "Calculator"
+
+    prec = [m for m in methods if m.name == "Precision"]
+    assert len(prec) == 1
+    assert prec[0].parent_class == "Calculator"
+
+
+@_skip_no_go
+def test_parse_go_types(go_module: Path):
+    """Go: struct and interface type declarations are extracted as class."""
+    result = parse_file(go_module)
+    classes = {s.name for s in result.symbols if s.kind == "class"}
+    assert "Calculator" in classes
+    assert "Adder" in classes
+
+
+@_skip_no_go
+def test_parse_go_function_calls(go_module: Path):
+    """Go: calls are extracted from function bodies."""
+    result = parse_file(go_module)
+    helper = next((s for s in result.symbols if s.name == "helper"), None)
+    assert helper is not None
+    assert any("Sqrt" in c for c in helper.calls)
+    assert any("Join" in c for c in helper.calls)
+
+
+@_skip_no_go
+def test_parse_go_method_calls(go_module: Path):
+    """Go: calls are extracted from method bodies."""
+    result = parse_file(go_module)
+    add = next(
+        (s for s in result.symbols if s.name == "Add" and s.kind == "method"), None
+    )
+    assert add is not None
+    assert any("Println" in c for c in add.calls)
+
+
+@_skip_no_go
+def test_parse_go_imports_basic(go_module: Path):
+    """Go: plain imports are extracted."""
+    result = parse_file(go_module)
+    imports = result.imports
+
+    fmt_imp = [i for i in imports if i.name == "fmt"]
+    assert len(fmt_imp) == 1
+    assert fmt_imp[0].module == "fmt"
+    assert fmt_imp[0].alias is None
+    assert fmt_imp[0].is_from is False
+
+    strings_imp = [i for i in imports if i.name == "strings"]
+    assert len(strings_imp) == 1
+    assert strings_imp[0].module == "strings"
+
+
+@_skip_no_go
+def test_parse_go_imports_alias(go_module: Path):
+    """Go: aliased imports (import m "math") are extracted."""
+    result = parse_file(go_module)
+    math_imp = [i for i in result.imports if i.name == "math"]
+    assert len(math_imp) == 1
+    assert math_imp[0].alias == "m"
+    assert math_imp[0].is_from is False
+
+
+@_skip_no_go
+def test_parse_go_imports_dot(go_module: Path):
+    """Go: dot imports (import . "os") set is_from=True."""
+    result = parse_file(go_module)
+    os_imp = [i for i in result.imports if i.name == "os"]
+    assert len(os_imp) == 1
+    assert os_imp[0].is_from is True
+    assert os_imp[0].alias is None
+
+
+@_skip_no_go
+def test_parse_go_imports_blank(go_module: Path):
+    """Go: blank imports (import _ "io") have alias="_"."""
+    result = parse_file(go_module)
+    io_imp = [i for i in result.imports if i.name == "io"]
+    assert len(io_imp) == 1
+    assert io_imp[0].alias == "_"
+    assert io_imp[0].is_from is False


### PR DESCRIPTION
## Summary

Extends `gptme-codegraph` to parse Go source files (`.go`) via `tree-sitter-go`.

**New functions:**
- `_extract_symbols_go` — extracts top-level functions (`function_declaration`), methods (`method_declaration` with receiver-type parent class), and named types (`type_declaration` → struct/interface → `kind=class`)
- `_extract_imports_go` — handles all Go import variants: plain, aliased (`import m "math"`), dot (`import . "os"`), blank (`import _ "io"`)
- `_receiver_type_go` — helper to extract base type from pointer/value receivers

**Config changes:**
- `_LANG_MAP`: `.go` → `go`
- `_GRAMMAR_MODULES`: `go` → `tree_sitter_go`
- `_load_language`: lazy-import block with `ImportError` guard
- `_NOISE_PATH_PARTS`: adds `vendor` (Go module vendor directory)
- `pyproject.toml`: `tree-sitter-go>=0.23.0` in `[treesitter]` optional extras
- `parse_file`: dispatch for Go symbol and import extraction

**Call extraction**: `_extract_calls` already handles `call_expression` (the node type Go uses), so calls are extracted from function/method bodies with no new code.

**10 new tests** in `test_multilang.py` (163 total, 1 skipped):
- Language detection, function/method/type extraction, call extraction
- All four import forms: plain, aliased, dot, blank
- `_skip_no_go` mark mirrors the Rust/JS/TS guard pattern
- Fixture follows the established pattern (yield outside `with` block so file is flushed before yielding)

Closes #1024 (Rust parts were already done in #1025/#1027; this PR adds Go)