### PR TITLE
feat(sessions): attribute token usage to tool spans

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/spans.py
+++ b/packages/gptme-sessions/src/gptme_sessions/spans.py
@@ -193,7 +193,8 @@ def _gptme_turn_usage(record: dict) -> _TurnUsage | None:
     metadata = record.get("metadata") or {}
     if not isinstance(metadata, dict):
         metadata = {}
-    usage = metadata.get("usage") or metadata
+    raw_usage = metadata.get("usage")
+    usage = raw_usage if isinstance(raw_usage, dict) else metadata
     if not isinstance(usage, dict):
         usage = {}
     model = metadata.get("model") or record.get("model")

--- a/packages/gptme-sessions/src/gptme_sessions/spans.py
+++ b/packages/gptme-sessions/src/gptme_sessions/spans.py
@@ -95,6 +95,119 @@ def _exit_code(content: object) -> int | None:
     return int(m.group(1)) if m else None
 
 
+def _as_int(value: object) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if not isinstance(value, str):
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+def _as_float(value: object) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if not isinstance(value, str):
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def _split_int(value: int | None, parts: int, index: int) -> int | None:
+    if value is None:
+        return None
+    if parts <= 1:
+        return value
+    base, remainder = divmod(value, parts)
+    return base + (1 if index < remainder else 0)
+
+
+def _split_float(value: float | None, parts: int) -> float | None:
+    if value is None:
+        return None
+    return value / parts if parts > 1 else value
+
+
+@dataclass(frozen=True)
+class _TurnUsage:
+    model: str | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    cache_creation_tokens: int | None = None
+    cache_read_tokens: int | None = None
+    cost_usd: float | None = None
+
+    def split(self, parts: int, index: int) -> _TurnUsage:
+        return _TurnUsage(
+            model=self.model,
+            input_tokens=_split_int(self.input_tokens, parts, index),
+            output_tokens=_split_int(self.output_tokens, parts, index),
+            cache_creation_tokens=_split_int(self.cache_creation_tokens, parts, index),
+            cache_read_tokens=_split_int(self.cache_read_tokens, parts, index),
+            cost_usd=_split_float(self.cost_usd, parts),
+        )
+
+
+def _usage_has_data(usage: _TurnUsage) -> bool:
+    return any(
+        value is not None
+        for value in (
+            usage.model,
+            usage.input_tokens,
+            usage.output_tokens,
+            usage.cache_creation_tokens,
+            usage.cache_read_tokens,
+            usage.cost_usd,
+        )
+    )
+
+
+def _cc_turn_usage(message: object) -> _TurnUsage | None:
+    if not isinstance(message, dict):
+        return None
+    usage = message.get("usage") or {}
+    if not isinstance(usage, dict):
+        usage = {}
+    model = message.get("model")
+    turn_usage = _TurnUsage(
+        model=model if isinstance(model, str) and model else None,
+        input_tokens=_as_int(usage.get("input_tokens")),
+        output_tokens=_as_int(usage.get("output_tokens")),
+        cache_creation_tokens=_as_int(usage.get("cache_creation_input_tokens")),
+        cache_read_tokens=_as_int(usage.get("cache_read_input_tokens")),
+    )
+    return turn_usage if _usage_has_data(turn_usage) else None
+
+
+def _gptme_turn_usage(record: dict) -> _TurnUsage | None:
+    metadata = record.get("metadata") or {}
+    if not isinstance(metadata, dict):
+        metadata = {}
+    usage = metadata.get("usage") or metadata
+    if not isinstance(usage, dict):
+        usage = {}
+    model = metadata.get("model") or record.get("model")
+    turn_usage = _TurnUsage(
+        model=model if isinstance(model, str) and model else None,
+        input_tokens=_as_int(usage.get("input_tokens")),
+        output_tokens=_as_int(usage.get("output_tokens")),
+        cache_creation_tokens=_as_int(usage.get("cache_creation_tokens")),
+        cache_read_tokens=_as_int(usage.get("cache_read_tokens")),
+        cost_usd=_as_float(metadata.get("cost")),
+    )
+    return turn_usage if _usage_has_data(turn_usage) else None
+
+
 @dataclass
 class ToolSpan:
     """A single tool invocation within an agent session.
@@ -112,6 +225,13 @@ class ToolSpan:
         exit_code: For Bash spans, the subprocess exit code when annotated
             in the result text ("Exit code: N"). None otherwise.
         turn_index: 0-indexed assistant turn that dispatched this tool call.
+        model: Model used for the assistant turn, when present in the
+            trajectory.
+        input_tokens/output_tokens/cache_*: Optional per-turn token usage
+            attributed to this tool call. Batched tool calls split the
+            assistant turn's usage evenly across dispatched calls.
+        cost_usd: Optional per-turn cost attributed to this call when the
+            trajectory records cost directly.
     """
 
     span_id: str
@@ -125,6 +245,12 @@ class ToolSpan:
     exit_code: int | None
     turn_index: int
     matched_lessons: list[str] = field(default_factory=list)
+    model: str | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    cache_creation_tokens: int | None = None
+    cache_read_tokens: int | None = None
+    cost_usd: float | None = None
 
 
 @dataclass
@@ -229,8 +355,9 @@ def extract_spans_from_cc_jsonl(
     if session_id is None:
         session_id = path.stem
 
-    # pending maps tool_use_id → (tool_name, dispatch_ts, dispatch_ts_str, input_size, turn_index)
-    pending: dict[str, tuple[str, datetime | None, str, int, int]] = {}
+    # pending maps tool_use_id → (tool_name, dispatch_ts, dispatch_ts_str,
+    #                             input_size, turn_index, attributed_usage)
+    pending: dict[str, tuple[str, datetime | None, str, int, int, _TurnUsage | None]] = {}
     spans: list[ToolSpan] = []
     turn_index = 0
 
@@ -253,21 +380,25 @@ def extract_spans_from_cc_jsonl(
         ts_str = record.get("timestamp", "")
 
         if rec_type == "assistant":
-            content = record.get("message", {}).get("content", [])
+            message = record.get("message", {})
+            content = message.get("content", []) if isinstance(message, dict) else []
             if not isinstance(content, list):
                 continue
-            dispatched_this_turn = False
-            for item in content:
-                if not isinstance(item, dict) or item.get("type") != "tool_use":
-                    continue
+            tool_items = [
+                item
+                for item in content
+                if isinstance(item, dict) and item.get("type") == "tool_use" and item.get("id")
+            ]
+            if not tool_items:
+                continue
+            turn_usage = _cc_turn_usage(message)
+            for idx, item in enumerate(tool_items):
                 tool_id = item.get("id", "")
                 tool_name = item.get("name", "unknown")
                 isize = _input_size(item.get("input", {}))
-                if tool_id:
-                    pending[tool_id] = (tool_name, ts, ts_str, isize, turn_index)
-                    dispatched_this_turn = True
-            if dispatched_this_turn:
-                turn_index += 1
+                usage_share = turn_usage.split(len(tool_items), idx) if turn_usage else None
+                pending[tool_id] = (tool_name, ts, ts_str, isize, turn_index, usage_share)
+            turn_index += 1
 
         elif rec_type == "user":
             content = record.get("message", {}).get("content", [])
@@ -279,7 +410,9 @@ def extract_spans_from_cc_jsonl(
                 tool_use_id = item.get("tool_use_id", "")
                 if tool_use_id not in pending:
                     continue
-                tool_name, dispatch_ts, dispatch_ts_str, isize, tidx = pending.pop(tool_use_id)
+                tool_name, dispatch_ts, dispatch_ts_str, isize, tidx, usage = pending.pop(
+                    tool_use_id
+                )
                 is_error = bool(item.get("is_error"))
                 result_content = item.get("content", "")
                 osize = _output_size(result_content)
@@ -307,6 +440,12 @@ def extract_spans_from_cc_jsonl(
                         output_size=osize,
                         exit_code=exit_code,
                         turn_index=tidx,
+                        model=usage.model if usage else None,
+                        input_tokens=usage.input_tokens if usage else None,
+                        output_tokens=usage.output_tokens if usage else None,
+                        cache_creation_tokens=usage.cache_creation_tokens if usage else None,
+                        cache_read_tokens=usage.cache_read_tokens if usage else None,
+                        cost_usd=usage.cost_usd if usage else None,
                     )
                 )
 
@@ -361,8 +500,9 @@ def extract_spans_from_gptme_jsonl(
         return []
 
     # Pending tool dispatches awaiting their result.
-    # Each entry: (tool_name, call_id, dispatch_ts, dispatch_ts_str, input_size, turn_index)
-    pending: list[tuple[str, str, datetime | None, str, int, int]] = []
+    # Each entry: (tool_name, call_id, dispatch_ts, dispatch_ts_str,
+    #              input_size, turn_index, attributed_usage)
+    pending: list[tuple[str, str, datetime | None, str, int, int, _TurnUsage | None]] = []
     spans: list[ToolSpan] = []
     turn_index = 0
 
@@ -386,7 +526,8 @@ def extract_spans_from_gptme_jsonl(
             matches = list(_GPTME_TOOL_RE.finditer(content))
             if not matches:
                 continue
-            for m in matches:
+            turn_usage = _gptme_turn_usage(record)
+            for idx, m in enumerate(matches):
                 tool_name = m.group(1)
                 call_id = m.group(2)
                 args_str = m.group(3) or ""
@@ -395,7 +536,8 @@ def extract_spans_from_gptme_jsonl(
                 except json.JSONDecodeError:
                     args = args_str  # fall back to raw string length
                 isize = _input_size(args)
-                pending.append((tool_name, call_id, ts, ts_str, isize, turn_index))
+                usage_share = turn_usage.split(len(matches), idx) if turn_usage else None
+                pending.append((tool_name, call_id, ts, ts_str, isize, turn_index, usage_share))
             turn_index += 1
 
         elif role == "system":
@@ -406,7 +548,7 @@ def extract_spans_from_gptme_jsonl(
             if not pending:
                 continue
 
-            tool_name, _call_id, dispatch_ts, dispatch_ts_str, isize, tidx = pending.pop(0)
+            tool_name, _call_id, dispatch_ts, dispatch_ts_str, isize, tidx, usage = pending.pop(0)
             osize = len(content)
 
             dur_ms = -1
@@ -438,6 +580,12 @@ def extract_spans_from_gptme_jsonl(
                     output_size=osize,
                     exit_code=exit_code,
                     turn_index=tidx,
+                    model=usage.model if usage else None,
+                    input_tokens=usage.input_tokens if usage else None,
+                    output_tokens=usage.output_tokens if usage else None,
+                    cache_creation_tokens=usage.cache_creation_tokens if usage else None,
+                    cache_read_tokens=usage.cache_read_tokens if usage else None,
+                    cost_usd=usage.cost_usd if usage else None,
                 )
             )
 
@@ -507,11 +655,12 @@ def extract_spans_from_codex_jsonl(
         return []
 
     # pending maps call_id → (tool_name, dispatch_ts, dispatch_ts_str,
-    #                         input_size, turn_index, is_custom)
-    pending: dict[str, tuple[str, datetime | None, str, int, int, bool]] = {}
+    #                         input_size, turn_index, is_custom, model)
+    pending: dict[str, tuple[str, datetime | None, str, int, int, bool, str | None]] = {}
     spans: list[ToolSpan] = []
     turn_index = 0
     new_turn = False  # set by a turn marker; the next dispatch opens a new turn
+    current_model: str | None = None
 
     for line in text.splitlines():
         line = line.strip()
@@ -520,6 +669,12 @@ def extract_spans_from_codex_jsonl(
         try:
             record = json.loads(line)
         except json.JSONDecodeError:
+            continue
+
+        if record.get("type") == "turn_context":
+            payload = record.get("payload")
+            if isinstance(payload, dict) and isinstance(payload.get("model"), str):
+                current_model = payload["model"]
             continue
 
         if record.get("type") != "response_item":
@@ -555,13 +710,23 @@ def extract_spans_from_codex_jsonl(
             if new_turn:
                 turn_index += 1
                 new_turn = False
-            pending[call_id] = (tool_name, ts, ts_str, isize, turn_index, is_custom)
+            pending[call_id] = (
+                tool_name,
+                ts,
+                ts_str,
+                isize,
+                turn_index,
+                is_custom,
+                current_model,
+            )
 
         elif ptype in ("function_call_output", "custom_tool_call_output"):
             call_id = payload.get("call_id", "")
             if call_id not in pending:
                 continue
-            tool_name, dispatch_ts, dispatch_ts_str, isize, tidx, is_custom = pending.pop(call_id)
+            tool_name, dispatch_ts, dispatch_ts_str, isize, tidx, is_custom, model = pending.pop(
+                call_id
+            )
             output = payload.get("output", "")
             output_str = output if isinstance(output, str) else str(output)
             osize = len(output_str)
@@ -594,6 +759,7 @@ def extract_spans_from_codex_jsonl(
                     output_size=osize,
                     exit_code=exit_code,
                     turn_index=tidx,
+                    model=model,
                 )
             )
 

--- a/packages/gptme-sessions/tests/test_spans.py
+++ b/packages/gptme-sessions/tests/test_spans.py
@@ -488,6 +488,43 @@ def test_gptme_usage_metadata_attached_to_span(tmp_path: Path) -> None:
     assert spans[0].cost_usd == 0.012
 
 
+def test_gptme_usage_split_across_batched_tool_calls(tmp_path: Path) -> None:
+    records = [
+        {
+            "role": "assistant",
+            "timestamp": "2026-04-21T10:00:00",
+            "content": "\n".join(
+                [
+                    '@shell(call-abc-0): {"command": "echo a"}',
+                    '@shell(call-def-1): {"command": "echo b"}',
+                ]
+            ),
+            "metadata": {
+                "model": "gpt-5.5",
+                "usage": {
+                    "input_tokens": 101,
+                    "output_tokens": 51,
+                    "cache_creation_tokens": 3,
+                    "cache_read_tokens": 7,
+                },
+                "cost": 0.12,
+            },
+        },
+        _gptme_result("Ran command: `echo a`\n\na", "2026-04-21T10:00:01"),
+        _gptme_result("Ran command: `echo b`\n\nb", "2026-04-21T10:00:02"),
+    ]
+    p = _write_gptme_session(tmp_path, records, "sess")
+    spans = extract_spans_from_gptme_jsonl(p)
+
+    assert len(spans) == 2
+    assert [s.model for s in spans] == ["gpt-5.5", "gpt-5.5"]
+    assert [s.input_tokens for s in spans] == [51, 50]
+    assert [s.output_tokens for s in spans] == [26, 25]
+    assert [s.cache_creation_tokens for s in spans] == [2, 1]
+    assert [s.cache_read_tokens for s in spans] == [4, 3]
+    assert [s.cost_usd for s in spans] == [0.06, 0.06]
+
+
 def test_gptme_error_result_detected(tmp_path: Path) -> None:
     records = [
         _gptme_assistant("gh", "abc-0", {"url": "bad"}, "2026-04-21T10:00:00"),

--- a/packages/gptme-sessions/tests/test_spans.py
+++ b/packages/gptme-sessions/tests/test_spans.py
@@ -165,6 +165,49 @@ def test_batched_tool_calls(tmp_path: Path) -> None:
     assert spans[0].turn_index == spans[1].turn_index == 0
 
 
+def test_cc_usage_split_across_batched_tool_calls(tmp_path: Path) -> None:
+    records = [
+        {
+            "type": "assistant",
+            "timestamp": "2026-04-21T10:00:00+00:00",
+            "message": {
+                "model": "claude-sonnet-4-6",
+                "usage": {
+                    "input_tokens": 101,
+                    "output_tokens": 51,
+                    "cache_creation_input_tokens": 3,
+                    "cache_read_input_tokens": 7,
+                },
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tid1",
+                        "name": "Read",
+                        "input": {"file_path": "a.py"},
+                    },
+                    {
+                        "type": "tool_use",
+                        "id": "tid2",
+                        "name": "Read",
+                        "input": {"file_path": "b.py"},
+                    },
+                ],
+            },
+        },
+        _cc_result("tid1", "content a", "2026-04-21T10:00:01+00:00"),
+        _cc_result("tid2", "content b", "2026-04-21T10:00:02+00:00"),
+    ]
+    p = _write_jsonl(tmp_path, records)
+    spans = extract_spans_from_cc_jsonl(p)
+
+    assert len(spans) == 2
+    assert [s.model for s in spans] == ["claude-sonnet-4-6", "claude-sonnet-4-6"]
+    assert [s.input_tokens for s in spans] == [51, 50]
+    assert [s.output_tokens for s in spans] == [26, 25]
+    assert [s.cache_creation_tokens for s in spans] == [2, 1]
+    assert [s.cache_read_tokens for s in spans] == [4, 3]
+
+
 def test_timestamp_is_dispatch_time(tmp_path: Path) -> None:
     """span.timestamp must reflect dispatch time, not result-arrival time."""
     dispatch_ts = "2026-04-21T10:00:00+00:00"
@@ -414,6 +457,37 @@ def test_gptme_single_shell_span(tmp_path: Path) -> None:
     assert s.output_size > 0
 
 
+def test_gptme_usage_metadata_attached_to_span(tmp_path: Path) -> None:
+    records = [
+        {
+            "role": "assistant",
+            "timestamp": "2026-04-21T10:00:00",
+            "content": '\n@shell(call-abc-0): {"command": "echo hi"}',
+            "metadata": {
+                "model": "gpt-5.5",
+                "usage": {
+                    "input_tokens": 100,
+                    "output_tokens": 20,
+                    "cache_creation_tokens": 10,
+                    "cache_read_tokens": 400,
+                },
+                "cost": 0.012,
+            },
+        },
+        _gptme_result("Ran command: `echo hi`\n\nhi", "2026-04-21T10:00:01"),
+    ]
+    p = _write_gptme_session(tmp_path, records, "sess")
+    spans = extract_spans_from_gptme_jsonl(p)
+
+    assert len(spans) == 1
+    assert spans[0].model == "gpt-5.5"
+    assert spans[0].input_tokens == 100
+    assert spans[0].output_tokens == 20
+    assert spans[0].cache_creation_tokens == 10
+    assert spans[0].cache_read_tokens == 400
+    assert spans[0].cost_usd == 0.012
+
+
 def test_gptme_error_result_detected(tmp_path: Path) -> None:
     records = [
         _gptme_assistant("gh", "abc-0", {"url": "bad"}, "2026-04-21T10:00:00"),
@@ -648,6 +722,24 @@ def test_codex_single_exec_span(tmp_path: Path) -> None:
     assert s.success is True
     assert s.exit_code == 0
     assert s.turn_index == 0
+
+
+def test_codex_model_from_turn_context(tmp_path: Path) -> None:
+    records = [
+        {
+            "type": "turn_context",
+            "payload": {"model": "gpt-5.5"},
+        },
+        _codex_function_call(
+            "exec_command", "c1", {"cmd": "git status"}, "2026-05-27T10:00:00+00:00"
+        ),
+        _codex_function_output("c1", "Process exited with code 0\n", "2026-05-27T10:00:01+00:00"),
+    ]
+    p = _write_jsonl(tmp_path, records, name="rollout-x.jsonl")
+    spans = extract_spans_from_codex_jsonl(p)
+
+    assert len(spans) == 1
+    assert spans[0].model == "gpt-5.5"
 
 
 def test_codex_exec_nonzero_exit_is_error(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add nullable model/token/cost attribution fields to ToolSpan
- populate per-turn usage for Claude Code and gptme trajectories, splitting batched tool-call turns evenly across spans
- preserve Codex model metadata from turn_context when available

## Validation
- uv run pytest packages/gptme-sessions/tests/test_spans.py
- uv run ruff check packages/gptme-sessions/src/gptme_sessions/spans.py packages/gptme-sessions/tests/test_spans.py
- uv run --with mypy --with types-PyYAML mypy src/ --ignore-missing-imports (from packages/gptme-sessions)
