### PR TITLE
feat(codegraph): add Java language support (symbol + import extraction)

### DIFF
--- a/packages/gptme-codegraph/pyproject.toml
+++ b/packages/gptme-codegraph/pyproject.toml
@@ -17,6 +17,7 @@ treesitter = [
     "tree-sitter-typescript>=0.23.0",
     "tree-sitter-rust>=0.24.0",
     "tree-sitter-go>=0.23.0",
+    "tree-sitter-java>=0.23.0",
 ]
 mcp = [
     "mcp>=1.0.0",

--- a/packages/gptme-codegraph/src/gptme_codegraph/core.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/core.py
@@ -46,6 +46,7 @@ _LANG_MAP: dict[str, str] = {
     ".cjs": "javascript",
     ".rs": "rust",
     ".go": "go",
+    ".java": "java",
 }
 
 _GRAMMAR_MODULES: dict[str, str] = {
@@ -56,6 +57,7 @@ _GRAMMAR_MODULES: dict[str, str] = {
     "tsx": "tree_sitter_typescript",
     "rust": "tree_sitter_rust",
     "go": "tree_sitter_go",
+    "java": "tree_sitter_java",
 }
 
 _SOURCE_EXTENSIONS: tuple[str, ...] = tuple(_LANG_MAP.keys())
@@ -124,6 +126,12 @@ def _load_language(name: str):
         import tree_sitter_go as tsgo  # type: ignore[import-not-found,unused-ignore]
 
         grammar_map["go"] = tsgo.language()
+    except ImportError:
+        pass
+    try:
+        import tree_sitter_java as tsjava  # type: ignore[import-not-found,unused-ignore]
+
+        grammar_map["java"] = tsjava.language()
     except ImportError:
         pass
 
@@ -1463,6 +1471,167 @@ def _extract_imports_go(root) -> list[ImportInfo]:
 
 
 # ---------------------------------------------------------------------------
+# Java extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_symbols_java(root, filepath: str) -> list[Symbol]:
+    """Extract classes, interfaces, enums, and methods from a Java parse tree."""
+    symbols: list[Symbol] = []
+
+    def _text(node) -> str:
+        try:
+            return node.text.decode("utf-8") if node.text else ""
+        except Exception:
+            return ""
+
+    def _extract_members(body_node, parent_class: str) -> None:
+        for member in body_node.named_children:
+            if member.type == "method_declaration":
+                name_node = member.child_by_field_name("name")
+                if name_node:
+                    body = member.child_by_field_name("body")
+                    calls = _extract_calls(body) if body else []
+                    symbols.append(
+                        Symbol(
+                            name=_text(name_node),
+                            kind="method",
+                            file=filepath,
+                            start_line=member.start_point[0] + 1,
+                            end_line=member.end_point[0] + 1,
+                            parent_class=parent_class,
+                            calls=list(set(calls)),
+                        )
+                    )
+            elif member.type == "constructor_declaration":
+                name_node = member.child_by_field_name("name")
+                if name_node:
+                    body = member.child_by_field_name("body")
+                    calls = _extract_calls(body) if body else []
+                    symbols.append(
+                        Symbol(
+                            name=_text(name_node),
+                            kind="method",
+                            file=filepath,
+                            start_line=member.start_point[0] + 1,
+                            end_line=member.end_point[0] + 1,
+                            parent_class=parent_class,
+                            calls=list(set(calls)),
+                        )
+                    )
+            elif member.type in (
+                "class_declaration",
+                "interface_declaration",
+                "enum_declaration",
+            ):
+                _extract_type_decl(member)
+
+    def _extract_type_decl(node) -> None:
+        if node.type == "class_declaration":
+            name_node = node.child_by_field_name("name")
+            if name_node:
+                class_name = _text(name_node)
+                symbols.append(
+                    Symbol(
+                        name=class_name,
+                        kind="class",
+                        file=filepath,
+                        start_line=node.start_point[0] + 1,
+                        end_line=node.end_point[0] + 1,
+                    )
+                )
+                body = node.child_by_field_name("body")
+                if body:
+                    _extract_members(body, parent_class=class_name)
+        elif node.type == "interface_declaration":
+            name_node = node.child_by_field_name("name")
+            if name_node:
+                iface_name = _text(name_node)
+                symbols.append(
+                    Symbol(
+                        name=iface_name,
+                        kind="class",
+                        file=filepath,
+                        start_line=node.start_point[0] + 1,
+                        end_line=node.end_point[0] + 1,
+                    )
+                )
+                body = node.child_by_field_name("body")
+                if body:
+                    for member in body.named_children:
+                        if member.type == "method_declaration":
+                            mn = member.child_by_field_name("name")
+                            if mn:
+                                symbols.append(
+                                    Symbol(
+                                        name=_text(mn),
+                                        kind="method",
+                                        file=filepath,
+                                        start_line=member.start_point[0] + 1,
+                                        end_line=member.end_point[0] + 1,
+                                        parent_class=iface_name,
+                                    )
+                                )
+        elif node.type == "enum_declaration":
+            name_node = node.child_by_field_name("name")
+            if name_node:
+                symbols.append(
+                    Symbol(
+                        name=_text(name_node),
+                        kind="class",
+                        file=filepath,
+                        start_line=node.start_point[0] + 1,
+                        end_line=node.end_point[0] + 1,
+                    )
+                )
+
+    for child in root.named_children:
+        _extract_type_decl(child)
+
+    return symbols
+
+
+def _extract_imports_java(root) -> list[ImportInfo]:
+    """Extract import declarations from a Java parse tree."""
+    imports: list[ImportInfo] = []
+
+    def _text(node) -> str:
+        try:
+            return node.text.decode("utf-8") if node.text else ""
+        except Exception:
+            return ""
+
+    for child in root.named_children:
+        if child.type == "import_declaration":
+            is_wildcard = any(c.type == "asterisk" for c in child.children)
+            qualified = next(
+                (
+                    _text(c)
+                    for c in child.named_children
+                    if c.type == "scoped_identifier"
+                ),
+                None,
+            ) or next(
+                (_text(c) for c in child.named_children if c.type == "identifier"),
+                None,
+            )
+            if not qualified:
+                continue
+            if is_wildcard:
+                module, name = qualified, "*"
+            elif "." in qualified:
+                dot = qualified.rfind(".")
+                module, name = qualified[:dot], qualified[dot + 1 :]
+            else:
+                module, name = "", qualified
+            imports.append(
+                ImportInfo(file="", module=module, name=name, alias=None, is_from=True)
+            )
+
+    return imports
+
+
+# ---------------------------------------------------------------------------
 # Multi-language parse_file
 # ---------------------------------------------------------------------------
 
@@ -1471,7 +1640,7 @@ def parse_file(filepath: Path) -> FileParseResult:
     """Extract all symbols and imports from a source file.
 
     Detects language from file extension and dispatches to the correct
-    tree-sitter grammar. Supports Python, TypeScript/JavaScript, Rust, and Go.
+    tree-sitter grammar. Supports Python, TypeScript/JavaScript, Rust, Go, and Java.
     """
     code = filepath.read_bytes()
     lang_name = _detect_language(filepath)
@@ -1497,6 +1666,9 @@ def parse_file(filepath: Path) -> FileParseResult:
     elif lang_name == "go":
         symbols = _extract_symbols_go(root, filename)
 
+    elif lang_name == "java":
+        symbols = _extract_symbols_java(root, filename)
+
     imports: list[ImportInfo] = []
     if lang_name == "python":
         imports = _extract_imports(root)
@@ -1506,6 +1678,8 @@ def parse_file(filepath: Path) -> FileParseResult:
         imports = _extract_imports_rust(root)
     elif lang_name == "go":
         imports = _extract_imports_go(root)
+    elif lang_name == "java":
+        imports = _extract_imports_java(root)
 
     for imp in imports:
         imp.file = filename

--- a/packages/gptme-codegraph/src/gptme_codegraph/core.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/core.py
@@ -718,6 +718,11 @@ def _extract_calls(node) -> list[str]:
                 func_node = cursor.node.child_by_field_name("function")
                 if func_node:
                     calls.append(_text(func_node))
+            elif cursor.node.type == "method_invocation":
+                # Java: method calls use method_invocation with a "name" field
+                name_node = cursor.node.child_by_field_name("name")
+                if name_node:
+                    calls.append(_text(name_node))
             if cursor.goto_first_child():
                 continue
             if cursor.goto_next_sibling():

--- a/packages/gptme-codegraph/tests/test_multilang.py
+++ b/packages/gptme-codegraph/tests/test_multilang.py
@@ -1,7 +1,7 @@
-"""Tests for multi-language support in gptme-codegraph (JS/TS, Rust, Go).
+"""Tests for multi-language support in gptme-codegraph (JS/TS, Rust, Go, Java).
 
 Verifies that parse_file, extract_symbols, and build_index work correctly
-for JavaScript, TypeScript, Rust, and Go source files.
+for JavaScript, TypeScript, Rust, Go, and Java source files.
 """
 
 from __future__ import annotations
@@ -41,6 +41,10 @@ _skip_no_ts = pytest.mark.skipif(
 _skip_no_rust = pytest.mark.skipif(
     not _has_grammar("rust"),
     reason="tree-sitter-rust not installed",
+)
+_skip_no_java = pytest.mark.skipif(
+    not _has_grammar("java"),
+    reason="tree-sitter-java not installed",
 )
 
 # ---------------------------------------------------------------------------
@@ -879,3 +883,176 @@ def test_parse_go_imports_blank(go_module: Path):
     assert len(io_imp) == 1
     assert io_imp[0].alias == "_"
     assert io_imp[0].is_from is False
+
+
+# ---------------------------------------------------------------------------
+# Java fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def java_module() -> Generator[Path, None, None]:
+    """A Java file with a class, interface, enum, methods, and imports."""
+    code = """\
+package com.example;
+
+import java.util.List;
+import java.util.ArrayList;
+import static java.lang.Math.PI;
+import java.io.*;
+
+public class Calculator {
+    private int value;
+
+    public Calculator(int initial) {
+        this.value = initial;
+    }
+
+    public int add(int n) {
+        return value + n;
+    }
+
+    public int multiply(int n) {
+        return value * n;
+    }
+
+    public static Calculator fromList(List<Integer> values) {
+        return new Calculator(values.get(0));
+    }
+}
+
+interface Describable {
+    String describe();
+    int size();
+}
+
+enum Operation {
+    ADD,
+    MULTIPLY,
+    SUBTRACT
+}
+"""
+    with tempfile.NamedTemporaryFile(suffix=".java", mode="w", delete=False) as f:
+        f.write(code)
+        path = Path(f.name)
+    yield path
+    path.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Java tests
+# ---------------------------------------------------------------------------
+
+
+@_skip_no_java
+def test_parse_java_class(java_module: Path):
+    """Java: class is extracted with correct name and kind."""
+    result = parse_file(java_module)
+    names = [s.name for s in result.symbols]
+    assert "Calculator" in names
+    calc = next(s for s in result.symbols if s.name == "Calculator")
+    assert calc.kind == "class"
+    assert calc.parent_class is None
+
+
+@_skip_no_java
+def test_parse_java_methods(java_module: Path):
+    """Java: methods are extracted with parent_class set."""
+    result = parse_file(java_module)
+    methods = [
+        s
+        for s in result.symbols
+        if s.kind == "method" and s.parent_class == "Calculator"
+    ]
+    method_names = {m.name for m in methods}
+    assert "add" in method_names
+    assert "multiply" in method_names
+    assert "fromList" in method_names
+
+
+@_skip_no_java
+def test_parse_java_constructor(java_module: Path):
+    """Java: constructors are extracted as methods with parent_class."""
+    result = parse_file(java_module)
+    ctors = [
+        s
+        for s in result.symbols
+        if s.name == "Calculator" and s.parent_class == "Calculator"
+    ]
+    assert len(ctors) >= 1
+
+
+@_skip_no_java
+def test_parse_java_interface(java_module: Path):
+    """Java: interface is extracted as a class symbol."""
+    result = parse_file(java_module)
+    iface = next((s for s in result.symbols if s.name == "Describable"), None)
+    assert iface is not None
+    assert iface.kind == "class"
+
+
+@_skip_no_java
+def test_parse_java_interface_methods(java_module: Path):
+    """Java: interface method declarations are extracted."""
+    result = parse_file(java_module)
+    iface_methods = [s for s in result.symbols if s.parent_class == "Describable"]
+    names = {m.name for m in iface_methods}
+    assert "describe" in names
+    assert "size" in names
+
+
+@_skip_no_java
+def test_parse_java_enum(java_module: Path):
+    """Java: enum is extracted as a class symbol."""
+    result = parse_file(java_module)
+    enum_sym = next((s for s in result.symbols if s.name == "Operation"), None)
+    assert enum_sym is not None
+    assert enum_sym.kind == "class"
+
+
+@_skip_no_java
+def test_parse_java_imports_basic(java_module: Path):
+    """Java: standard imports are extracted with correct module and name."""
+    result = parse_file(java_module)
+    imports = result.imports
+
+    list_imp = next((i for i in imports if i.name == "List"), None)
+    assert list_imp is not None
+    assert list_imp.module == "java.util"
+    assert list_imp.is_from is True
+
+    arraylist_imp = next((i for i in imports if i.name == "ArrayList"), None)
+    assert arraylist_imp is not None
+    assert arraylist_imp.module == "java.util"
+
+
+@_skip_no_java
+def test_parse_java_imports_wildcard(java_module: Path):
+    """Java: wildcard imports (java.io.*) set name='*' and correct module."""
+    result = parse_file(java_module)
+    wildcard = next((i for i in result.imports if i.name == "*"), None)
+    assert wildcard is not None
+    assert wildcard.module == "java.io"
+
+
+@_skip_no_java
+def test_parse_java_line_numbers(java_module: Path):
+    """Java: symbol line numbers are positive and ordered."""
+    result = parse_file(java_module)
+    for sym in result.symbols:
+        assert sym.start_line >= 1
+        assert sym.end_line >= sym.start_line
+
+
+@_skip_no_java
+def test_build_index_java(java_module: Path):
+    """Java: build_index picks up symbols from a .java file."""
+    import shutil
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as d:
+        dest = Path(d) / java_module.name
+        shutil.copy(java_module, dest)
+        index = build_index(d)
+        assert "Calculator" in index.entries
+        assert "add" in index.entries

--- a/packages/gptme-codegraph/tests/test_multilang.py
+++ b/packages/gptme-codegraph/tests/test_multilang.py
@@ -1045,6 +1045,16 @@ def test_parse_java_line_numbers(java_module: Path):
 
 
 @_skip_no_java
+def test_parse_java_calls(java_module: Path):
+    """Java: method_invocation nodes are extracted as calls."""
+    result = parse_file(java_module)
+    # fromList calls values.get(0) — a method_invocation
+    from_list = next((s for s in result.symbols if s.name == "fromList"), None)
+    assert from_list is not None
+    assert "get" in from_list.calls, f"Expected 'get' in calls, got: {from_list.calls}"
+
+
+@_skip_no_java
 def test_build_index_java(java_module: Path):
     """Java: build_index picks up symbols from a .java file."""
     import shutil

--- a/uv.lock
+++ b/uv.lock
@@ -1347,6 +1347,7 @@ mcp = [
 treesitter = [
     { name = "tree-sitter" },
     { name = "tree-sitter-go" },
+    { name = "tree-sitter-java" },
     { name = "tree-sitter-javascript" },
     { name = "tree-sitter-python" },
     { name = "tree-sitter-rust" },
@@ -1360,6 +1361,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "tree-sitter", marker = "extra == 'treesitter'", specifier = ">=0.21.0" },
     { name = "tree-sitter-go", marker = "extra == 'treesitter'", specifier = ">=0.23.0" },
+    { name = "tree-sitter-java", marker = "extra == 'treesitter'", specifier = ">=0.23.0" },
     { name = "tree-sitter-javascript", marker = "extra == 'treesitter'", specifier = ">=0.21.0" },
     { name = "tree-sitter-python", marker = "extra == 'treesitter'", specifier = ">=0.21.0" },
     { name = "tree-sitter-rust", marker = "extra == 'treesitter'", specifier = ">=0.24.0" },
@@ -5106,6 +5108,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/01/e2/ee5e09f63504fc286539535d374d2eaa0e7d489b80f8f744bb3962aff22a/tree_sitter_go-0.25.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5608e089d2a29fa8d2b327abeb2ad1cdb8e223c440a6b0ceab0d3fa80bdeebae", size = 66088, upload-time = "2025-08-29T06:20:22.336Z" },
     { url = "https://files.pythonhosted.org/packages/6e/b6/d9142583374720e79aca9ccb394b3795149a54c012e1dfd80738df2d984e/tree_sitter_go-0.25.0-cp310-abi3-win_amd64.whl", hash = "sha256:30d4ada57a223dfc2c32d942f44d284d40f3d1215ddcf108f96807fd36d53022", size = 48152, upload-time = "2025-08-29T06:20:23.089Z" },
     { url = "https://files.pythonhosted.org/packages/9e/00/9a2638e7339236f5b01622952a4d71c1474dd3783d1982a89555fc1f03b1/tree_sitter_go-0.25.0-cp310-abi3-win_arm64.whl", hash = "sha256:d5d62362059bf79997340773d47cc7e7e002883b527a05cca829c46e40b70ded", size = 46752, upload-time = "2025-08-29T06:20:24.235Z" },
+]
+
+[[package]]
+name = "tree-sitter-java"
+version = "0.23.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/dc/eb9c8f96304e5d8ae1663126d89967a622a80937ad2909903569ccb7ec8f/tree_sitter_java-0.23.5.tar.gz", hash = "sha256:f5cd57b8f1270a7f0438878750d02ccc79421d45cca65ff284f1527e9ef02e38", size = 138121, upload-time = "2024-12-21T18:24:26.936Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/21/b3399780b440e1567a11d384d0ebb1aea9b642d0d98becf30fa55c0e3a3b/tree_sitter_java-0.23.5-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:355ce0308672d6f7013ec913dee4a0613666f4cda9044a7824240d17f38209df", size = 58926, upload-time = "2024-12-21T18:24:12.53Z" },
+    { url = "https://files.pythonhosted.org/packages/57/ef/6406b444e2a93bc72a04e802f4107e9ecf04b8de4a5528830726d210599c/tree_sitter_java-0.23.5-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:24acd59c4720dedad80d548fe4237e43ef2b7a4e94c8549b0ca6e4c4d7bf6e69", size = 62288, upload-time = "2024-12-21T18:24:14.634Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/6c/74b1c150d4f69c291ab0b78d5dd1b59712559bbe7e7daf6d8466d483463f/tree_sitter_java-0.23.5-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9401e7271f0b333df39fc8a8336a0caf1b891d9a2b89ddee99fae66b794fc5b7", size = 85533, upload-time = "2024-12-21T18:24:16.695Z" },
+    { url = "https://files.pythonhosted.org/packages/29/09/e0d08f5c212062fd046db35c1015a2621c2631bc8b4aae5740d7adb276ad/tree_sitter_java-0.23.5-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:370b204b9500b847f6d0c5ad584045831cee69e9a3e4d878535d39e4a7e4c4f1", size = 84033, upload-time = "2024-12-21T18:24:18.758Z" },
+    { url = "https://files.pythonhosted.org/packages/43/56/7d06b23ddd09bde816a131aa504ee11a1bbe87c6b62ab9b2ed23849a3382/tree_sitter_java-0.23.5-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:aae84449e330363b55b14a2af0585e4e0dae75eb64ea509b7e5b0e1de536846a", size = 82564, upload-time = "2024-12-21T18:24:20.493Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d6/0528c7e1e88a18221dbd8ccee3825bf274b1fa300f745fd74eb343878043/tree_sitter_java-0.23.5-cp39-abi3-win_amd64.whl", hash = "sha256:1ee45e790f8d31d416bc84a09dac2e2c6bc343e89b8a2e1d550513498eedfde7", size = 60650, upload-time = "2024-12-21T18:24:22.902Z" },
+    { url = "https://files.pythonhosted.org/packages/72/57/5bab54d23179350356515526fff3cc0f3ac23bfbc1a1d518a15978d4880e/tree_sitter_java-0.23.5-cp39-abi3-win_arm64.whl", hash = "sha256:402efe136104c5603b429dc26c7e75ae14faaca54cfd319ecc41c8f2534750f4", size = 59059, upload-time = "2024-12-21T18:24:24.934Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Extends gptme-codegraph multi-language support to include Java (`.java` files) via the `tree-sitter-java` grammar.

**Extracted symbols**:
- Classes, interfaces, and enums → `kind='class'`
- Methods and constructors → `kind='method'` with `parent_class` set

**Extracted imports**:
- Standard: `import java.util.List;` → `module="java.util"`, `name="List"`
- Wildcard: `import java.io.*;` → `module="java.io"`, `name="*"`
- Static: `import static java.lang.Math.PI;` → parsed as from-import

**Changes**:
- `_LANG_MAP`: `.java` → `"java"`
- `_GRAMMAR_MODULES`: `"java"` → `"tree_sitter_java"`
- `_load_language()`: lazy import of `tree_sitter_java`
- `_extract_symbols_java()`: class/interface/enum/method/constructor extraction
- `_extract_imports_java()`: all import types
- `parse_file()`: Java dispatch for symbols and imports
- `pyproject.toml`: `tree-sitter-java>=0.23.0` added to `[treesitter]` optional deps
- `tests/test_multilang.py`: 10 new Java tests

## Test plan

- [ ] All 173 existing tests still pass
- [ ] 10 new Java-specific tests pass:
  - `test_parse_java_class` — class extracted, kind='class'
  - `test_parse_java_methods` — methods with parent_class
  - `test_parse_java_constructor` — constructor as method
  - `test_parse_java_interface` — interface extracted
  - `test_parse_java_interface_methods` — interface method declarations
  - `test_parse_java_enum` — enum extracted
  - `test_parse_java_imports_basic` — standard imports
  - `test_parse_java_imports_wildcard` — wildcard imports
  - `test_parse_java_line_numbers` — correct line ranges
  - `test_build_index_java` — build_index picks up Java symbols