### PR TITLE
feat(codegraph): add C# language support

### DIFF
--- a/packages/gptme-codegraph/pyproject.toml
+++ b/packages/gptme-codegraph/pyproject.toml
@@ -18,6 +18,7 @@ treesitter = [
     "tree-sitter-rust>=0.24.0",
     "tree-sitter-go>=0.23.0",
     "tree-sitter-java>=0.23.0",
+    "tree-sitter-c-sharp>=0.23.0",
 ]
 mcp = [
     "mcp>=1.0.0",

--- a/packages/gptme-codegraph/src/gptme_codegraph/core.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/core.py
@@ -3,7 +3,8 @@
 Complementary to gptme-rag (text chunks), this retrieves code *structure*:
 function/class definitions, call graphs, and blast radius.
 
-Supports Python, TypeScript/JavaScript, Rust, and Go via tree-sitter grammars.
+Supports Python, TypeScript/JavaScript, Rust, Go, Java, and C# via tree-sitter
+grammars.
 To add a new language: add grammar dep to pyproject.toml, extend _LANG_MAP
 and _load_language, then add extractor functions.
 
@@ -47,6 +48,7 @@ _LANG_MAP: dict[str, str] = {
     ".rs": "rust",
     ".go": "go",
     ".java": "java",
+    ".cs": "csharp",
 }
 
 _GRAMMAR_MODULES: dict[str, str] = {
@@ -58,6 +60,7 @@ _GRAMMAR_MODULES: dict[str, str] = {
     "rust": "tree_sitter_rust",
     "go": "tree_sitter_go",
     "java": "tree_sitter_java",
+    "csharp": "tree_sitter_c_sharp",
 }
 
 _SOURCE_EXTENSIONS: tuple[str, ...] = tuple(_LANG_MAP.keys())
@@ -132,6 +135,12 @@ def _load_language(name: str):
         import tree_sitter_java as tsjava  # type: ignore[import-not-found,unused-ignore]
 
         grammar_map["java"] = tsjava.language()
+    except ImportError:
+        pass
+    try:
+        import tree_sitter_c_sharp as tscsharp  # type: ignore[import-not-found,unused-ignore]
+
+        grammar_map["csharp"] = tscsharp.language()
     except ImportError:
         pass
 
@@ -714,7 +723,9 @@ def _extract_calls(node) -> list[str]:
         cursor = node.walk()
         reached_root = False
         while not reached_root:
-            if cursor.node.type in {"call", "call_expression"}:
+            if cursor.node.type in {"call", "call_expression", "invocation_expression"}:
+                # Python "call", JS/TS/Rust/Go "call_expression", C#
+                # "invocation_expression" all expose a "function" field.
                 func_node = cursor.node.child_by_field_name("function")
                 if func_node:
                     calls.append(_text(func_node))
@@ -1637,6 +1648,152 @@ def _extract_imports_java(root) -> list[ImportInfo]:
 
 
 # ---------------------------------------------------------------------------
+# C# extraction
+# ---------------------------------------------------------------------------
+
+
+_CSHARP_TYPE_NODES = frozenset(
+    {
+        "class_declaration",
+        "struct_declaration",
+        "record_declaration",
+        "interface_declaration",
+        "enum_declaration",
+    }
+)
+_CSHARP_NAMESPACE_NODES = frozenset(
+    {"namespace_declaration", "file_scoped_namespace_declaration"}
+)
+
+
+def _csharp_body(node):
+    """Return a C# type's member-list node (the ``body`` field or a child
+    ``declaration_list``/``enum_member_declaration_list``)."""
+    body = node.child_by_field_name("body")
+    if body is not None:
+        return body
+    for child in node.named_children:
+        if child.type in ("declaration_list", "enum_member_declaration_list"):
+            return child
+    return None
+
+
+def _extract_symbols_csharp(root, filepath: str) -> list[Symbol]:
+    """Extract classes, structs, records, interfaces, enums, and their methods
+    from a C# parse tree.
+
+    C# declarations may be nested inside ``namespace`` blocks (block-scoped or
+    file-scoped), so containers are walked recursively.
+    """
+    symbols: list[Symbol] = []
+
+    def _members(body_node, parent_class: str) -> None:
+        for member in body_node.named_children:
+            if member.type in ("method_declaration", "constructor_declaration"):
+                name_node = member.child_by_field_name("name")
+                if name_node:
+                    body = member.child_by_field_name("body")
+                    calls = _extract_calls(body) if body else []
+                    symbols.append(
+                        Symbol(
+                            name=_text(name_node),
+                            kind="method",
+                            file=filepath,
+                            start_line=member.start_point[0] + 1,
+                            end_line=member.end_point[0] + 1,
+                            parent_class=parent_class,
+                            calls=list(set(calls)),
+                        )
+                    )
+            elif member.type in _CSHARP_TYPE_NODES:
+                _type_decl(member)
+
+    def _type_decl(node) -> None:
+        name_node = node.child_by_field_name("name")
+        if not name_node:
+            return
+        type_name = _text(name_node)
+        symbols.append(
+            Symbol(
+                name=type_name,
+                kind="class",
+                file=filepath,
+                start_line=node.start_point[0] + 1,
+                end_line=node.end_point[0] + 1,
+            )
+        )
+        body = _csharp_body(node)
+        if body is not None:
+            _members(body, parent_class=type_name)
+
+    def _walk_container(node) -> None:
+        for child in node.named_children:
+            if child.type in _CSHARP_NAMESPACE_NODES:
+                body = _csharp_body(child)
+                _walk_container(body if body is not None else child)
+            elif child.type in _CSHARP_TYPE_NODES:
+                _type_decl(child)
+
+    _walk_container(root)
+    return symbols
+
+
+def _extract_imports_csharp(root) -> list[ImportInfo]:
+    """Extract ``using`` directives from a C# parse tree.
+
+    Handles ``using System;``, ``using System.Collections.Generic;``,
+    ``using static System.Math;``, and ``using Foo = System.Bar;`` (alias).
+    """
+    imports: list[ImportInfo] = []
+
+    def _walk(node) -> None:
+        for child in node.named_children:
+            if child.type == "using_directive":
+                # For `using Alias = Some.Namespace;` the "name" field holds the
+                # alias identifier; plain/`static` usings have no "name" field and
+                # carry the namespace as an unnamed qualified_name/identifier child.
+                alias_node = child.child_by_field_name("name")
+                alias = _text(alias_node) if alias_node is not None else None
+                ns_node = next(
+                    (c for c in child.named_children if c.type == "qualified_name"),
+                    None,
+                )
+                if ns_node is None:
+                    ns_node = next(
+                        (
+                            c
+                            for c in child.named_children
+                            if c.type == "identifier"
+                            and (alias is None or _text(c) != alias)
+                        ),
+                        None,
+                    )
+                qualified = _text(ns_node) if ns_node is not None else ""
+                if not qualified:
+                    continue
+                if "." in qualified:
+                    dot = qualified.rfind(".")
+                    module, name = qualified[:dot], qualified[dot + 1 :]
+                else:
+                    module, name = "", qualified
+                imports.append(
+                    ImportInfo(
+                        file="",
+                        module=module,
+                        name=name,
+                        alias=alias,
+                        is_from=True,
+                    )
+                )
+            elif child.type in _CSHARP_NAMESPACE_NODES:
+                body = _csharp_body(child)
+                _walk(body if body is not None else child)
+
+    _walk(root)
+    return imports
+
+
+# ---------------------------------------------------------------------------
 # Multi-language parse_file
 # ---------------------------------------------------------------------------
 
@@ -1645,7 +1802,8 @@ def parse_file(filepath: Path) -> FileParseResult:
     """Extract all symbols and imports from a source file.
 
     Detects language from file extension and dispatches to the correct
-    tree-sitter grammar. Supports Python, TypeScript/JavaScript, Rust, Go, and Java.
+    tree-sitter grammar. Supports Python, TypeScript/JavaScript, Rust, Go,
+    Java, and C#.
     """
     code = filepath.read_bytes()
     lang_name = _detect_language(filepath)
@@ -1674,6 +1832,9 @@ def parse_file(filepath: Path) -> FileParseResult:
     elif lang_name == "java":
         symbols = _extract_symbols_java(root, filename)
 
+    elif lang_name == "csharp":
+        symbols = _extract_symbols_csharp(root, filename)
+
     imports: list[ImportInfo] = []
     if lang_name == "python":
         imports = _extract_imports(root)
@@ -1685,6 +1846,8 @@ def parse_file(filepath: Path) -> FileParseResult:
         imports = _extract_imports_go(root)
     elif lang_name == "java":
         imports = _extract_imports_java(root)
+    elif lang_name == "csharp":
+        imports = _extract_imports_csharp(root)
 
     for imp in imports:
         imp.file = filename

--- a/packages/gptme-codegraph/tests/test_multilang.py
+++ b/packages/gptme-codegraph/tests/test_multilang.py
@@ -1,7 +1,7 @@
-"""Tests for multi-language support in gptme-codegraph (JS/TS, Rust, Go, Java).
+"""Tests for multi-language support in gptme-codegraph (JS/TS, Rust, Go, Java, C#).
 
 Verifies that parse_file, extract_symbols, and build_index work correctly
-for JavaScript, TypeScript, Rust, Go, and Java source files.
+for JavaScript, TypeScript, Rust, Go, Java, and C# source files.
 """
 
 from __future__ import annotations
@@ -45,6 +45,10 @@ _skip_no_rust = pytest.mark.skipif(
 _skip_no_java = pytest.mark.skipif(
     not _has_grammar("java"),
     reason="tree-sitter-java not installed",
+)
+_skip_no_csharp = pytest.mark.skipif(
+    not _has_grammar("c_sharp"),
+    reason="tree-sitter-c-sharp not installed",
 )
 
 # ---------------------------------------------------------------------------
@@ -285,7 +289,7 @@ def multilang_project(tmp_path: Path) -> Generator[Path, None, None]:
     rust_dir = proj / "src" / "rust"
     rust_dir.mkdir(parents=True)
     (rust_dir / "lib.rs").write_text(
-        "pub fn init() -> bool { true }\n" "pub struct State { pub ready: bool }\n"
+        "pub fn init() -> bool { true }\npub struct State { pub ready: bool }\n"
     )
 
     yield proj
@@ -1070,3 +1074,175 @@ def test_build_index_java(java_module: Path):
         index = build_index(d)
         assert "Calculator" in index.entries
         assert "add" in index.entries
+
+
+@pytest.fixture
+def csharp_module() -> Generator[Path, None, None]:
+    """A C# file with a namespace, class, interface, enum, methods, usings."""
+    code = """\
+using System;
+using System.Collections.Generic;
+using static System.Math;
+using Json = System.Text.Json;
+
+namespace Example.App
+{
+    public class Calculator
+    {
+        private int value;
+
+        public Calculator(int initial)
+        {
+            this.value = initial;
+        }
+
+        public int Add(int n)
+        {
+            return value + n;
+        }
+
+        public static Calculator FromList(List<int> values)
+        {
+            Console.WriteLine(values[0]);
+            return new Calculator(values[0]);
+        }
+    }
+
+    public interface IDescribable
+    {
+        string Describe();
+        int Size();
+    }
+
+    public enum Operation
+    {
+        Add,
+        Multiply,
+        Subtract
+    }
+}
+"""
+    with tempfile.NamedTemporaryFile(suffix=".cs", mode="w", delete=False) as f:
+        f.write(code)
+        path = Path(f.name)
+    yield path
+    path.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# C# tests
+# ---------------------------------------------------------------------------
+
+
+@_skip_no_csharp
+def test_language_detection_csharp(csharp_module: Path):
+    """C#: .cs files are detected as the csharp language."""
+    result = parse_file(csharp_module)
+    assert result.language == "csharp"
+
+
+@_skip_no_csharp
+def test_parse_csharp_class(csharp_module: Path):
+    """C#: class nested in a namespace is extracted with correct kind."""
+    result = parse_file(csharp_module)
+    cls = next((s for s in result.symbols if s.name == "Calculator"), None)
+    assert cls is not None
+    assert cls.kind == "class"
+
+
+@_skip_no_csharp
+def test_parse_csharp_methods(csharp_module: Path):
+    """C#: methods carry their parent class."""
+    result = parse_file(csharp_module)
+    add = next((s for s in result.symbols if s.name == "Add"), None)
+    assert add is not None
+    assert add.kind == "method"
+    assert add.parent_class == "Calculator"
+
+
+@_skip_no_csharp
+def test_parse_csharp_constructor(csharp_module: Path):
+    """C#: constructor_declaration is extracted as a method."""
+    result = parse_file(csharp_module)
+    ctors = [s for s in result.symbols if s.name == "Calculator" and s.kind == "method"]
+    assert len(ctors) == 1
+    assert ctors[0].parent_class == "Calculator"
+
+
+@_skip_no_csharp
+def test_parse_csharp_interface(csharp_module: Path):
+    """C#: interface is extracted as a class symbol with its methods."""
+    result = parse_file(csharp_module)
+    iface = next((s for s in result.symbols if s.name == "IDescribable"), None)
+    assert iface is not None
+    assert iface.kind == "class"
+    describe = next((s for s in result.symbols if s.name == "Describe"), None)
+    assert describe is not None
+    assert describe.parent_class == "IDescribable"
+
+
+@_skip_no_csharp
+def test_parse_csharp_enum(csharp_module: Path):
+    """C#: enum is extracted as a class symbol."""
+    result = parse_file(csharp_module)
+    enum_sym = next((s for s in result.symbols if s.name == "Operation"), None)
+    assert enum_sym is not None
+    assert enum_sym.kind == "class"
+
+
+@_skip_no_csharp
+def test_parse_csharp_imports_basic(csharp_module: Path):
+    """C#: using directives resolve to module + last-segment name."""
+    result = parse_file(csharp_module)
+    generic = next((i for i in result.imports if i.name == "Generic"), None)
+    assert generic is not None
+    assert generic.module == "System.Collections"
+
+    system = next((i for i in result.imports if i.name == "System"), None)
+    assert system is not None
+    assert system.module == ""
+
+
+@_skip_no_csharp
+def test_parse_csharp_imports_alias(csharp_module: Path):
+    """C#: aliased using (using Json = System.Text.Json) records the alias."""
+    result = parse_file(csharp_module)
+    aliased = next((i for i in result.imports if i.alias == "Json"), None)
+    assert aliased is not None
+    assert aliased.name == "Json"
+    assert aliased.module == "System.Text"
+
+
+@_skip_no_csharp
+def test_parse_csharp_calls(csharp_module: Path):
+    """C#: invocation_expression nodes are extracted as calls."""
+    result = parse_file(csharp_module)
+    from_list = next((s for s in result.symbols if s.name == "FromList"), None)
+    assert from_list is not None
+    assert any(
+        "WriteLine" in c for c in from_list.calls
+    ), f"Expected a WriteLine call, got: {from_list.calls}"
+
+
+@_skip_no_csharp
+def test_parse_csharp_line_numbers(csharp_module: Path):
+    """C#: symbol line numbers are positive and ordered."""
+    result = parse_file(csharp_module)
+    assert result.symbols
+    for sym in result.symbols:
+        assert sym.start_line >= 1
+        assert sym.end_line >= sym.start_line
+
+
+@_skip_no_csharp
+def test_build_index_csharp(csharp_module: Path):
+    """C#: build_index picks up symbols from a .cs file."""
+    import shutil
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as d:
+        dest = Path(d) / csharp_module.name
+        shutil.copy(csharp_module, dest)
+        index = build_index(d)
+        assert "Calculator" in index.entries
+        assert "Add" in index.entries


### PR DESCRIPTION
## What

Adds **C#** as the 7th language to `gptme-codegraph`'s multi-language parser, after Python, TypeScript/JavaScript, Rust, Go, and Java.

## Why

`gptme-codegraph` powers structural code retrieval (callers/callees/blast radius) and `semble search`. C# is a major language with no coverage; this lets the tooling index `.cs` codebases the same way it already handles the other six.

## Changes

- `.cs` extension detected as the `csharp` language; `tree_sitter_c_sharp` grammar lazy-loaded (graceful skip when absent, matching every other grammar).
- `_extract_symbols_csharp`: extracts classes, structs, records, interfaces, enums and their methods/constructors. Recurses into **block-scoped and file-scoped namespaces** (C#-specific — declarations are usually namespace-wrapped).
- `_extract_imports_csharp`: extracts `using` directives — plain (`using System;`), static (`using static System.Math;`), and aliased (`using Json = System.Text.Json;`, recording the alias).
- `invocation_expression` folded into the shared `_extract_calls` (C# call-graph), alongside the existing `call`/`call_expression`/`method_invocation` node types.
- `tree-sitter-c-sharp>=0.23.0` added to the `treesitter` optional-dependency group.

## Tests

11 new tests in `test_multilang.py` (class, methods, constructor, interface + interface methods, enum, basic/static/aliased imports, call extraction, line numbers, build_index). They follow the existing per-language pattern and `skipif` cleanly when the grammar isn't installed.

Verified locally: `175 passed, 11 skipped` across the full `gptme-codegraph` suite; `ruff check` clean; scoped `mypy` clean.

Advances ErikBjare/bob idea #315 (multi-language codegraph).