### PR TITLE
feat(codegraph): add Ruby language support (symbol + import extraction)

### DIFF
--- a/packages/gptme-codegraph/pyproject.toml
+++ b/packages/gptme-codegraph/pyproject.toml
@@ -19,6 +19,7 @@ treesitter = [
     "tree-sitter-go>=0.23.0",
     "tree-sitter-java>=0.23.0",
     "tree-sitter-c-sharp>=0.23.0",
+    "tree-sitter-ruby>=0.23.0",
 ]
 mcp = [
     "mcp>=1.0.0",

--- a/packages/gptme-codegraph/src/gptme_codegraph/core.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/core.py
@@ -3,7 +3,7 @@
 Complementary to gptme-rag (text chunks), this retrieves code *structure*:
 function/class definitions, call graphs, and blast radius.
 
-Supports Python, TypeScript/JavaScript, Rust, Go, Java, and C# via tree-sitter
+Supports Python, TypeScript/JavaScript, Rust, Go, Java, C#, and Ruby via tree-sitter
 grammars.
 To add a new language: add grammar dep to pyproject.toml, extend _LANG_MAP
 and _load_language, then add extractor functions.
@@ -49,6 +49,7 @@ _LANG_MAP: dict[str, str] = {
     ".go": "go",
     ".java": "java",
     ".cs": "csharp",
+    ".rb": "ruby",
 }
 
 _GRAMMAR_MODULES: dict[str, str] = {
@@ -61,6 +62,7 @@ _GRAMMAR_MODULES: dict[str, str] = {
     "go": "tree_sitter_go",
     "java": "tree_sitter_java",
     "csharp": "tree_sitter_c_sharp",
+    "ruby": "tree_sitter_ruby",
 }
 
 _SOURCE_EXTENSIONS: tuple[str, ...] = tuple(_LANG_MAP.keys())
@@ -141,6 +143,12 @@ def _load_language(name: str):
         import tree_sitter_c_sharp as tscsharp  # type: ignore[import-not-found,unused-ignore]
 
         grammar_map["csharp"] = tscsharp.language()
+    except ImportError:
+        pass
+    try:
+        import tree_sitter_ruby as tsruby  # type: ignore[import-not-found,unused-ignore]
+
+        grammar_map["ruby"] = tsruby.language()
     except ImportError:
         pass
 
@@ -729,6 +737,11 @@ def _extract_calls(node) -> list[str]:
                 func_node = cursor.node.child_by_field_name("function")
                 if func_node:
                     calls.append(_text(func_node))
+                else:
+                    # Ruby: call nodes carry the callee in a "method" field
+                    method_node = cursor.node.child_by_field_name("method")
+                    if method_node:
+                        calls.append(_text(method_node))
             elif cursor.node.type == "method_invocation":
                 # Java: method calls use method_invocation with a "name" field
                 name_node = cursor.node.child_by_field_name("name")
@@ -1647,6 +1660,111 @@ def _extract_imports_java(root) -> list[ImportInfo]:
     return imports
 
 
+def _extract_symbols_ruby(root, filepath: str) -> list[Symbol]:
+    """Extract modules, classes, and methods from a Ruby parse tree.
+
+    Ruby modules and classes both map to ``kind="class"`` (namespacing
+    containers); ``def`` and ``def self.`` map to ``kind="method"`` when nested
+    in a class/module and ``kind="function"`` at the top level.
+    """
+    symbols: list[Symbol] = []
+
+    def _text(node) -> str:
+        try:
+            return node.text.decode("utf-8") if node.text else ""
+        except Exception:
+            return ""
+
+    def _walk(node, parent: str | None) -> None:
+        for child in node.named_children:
+            if child.type in ("class", "module"):
+                name_node = child.child_by_field_name("name")
+                name = _text(name_node) if name_node else ""
+                if name:
+                    symbols.append(
+                        Symbol(
+                            name=name,
+                            kind="class",
+                            file=filepath,
+                            start_line=child.start_point[0] + 1,
+                            end_line=child.end_point[0] + 1,
+                            parent_class=parent,
+                        )
+                    )
+                body = child.child_by_field_name("body")
+                if body is not None:
+                    _walk(body, parent=name or parent)
+            elif child.type in ("method", "singleton_method"):
+                name_node = child.child_by_field_name("name")
+                if name_node:
+                    body = child.child_by_field_name("body")
+                    calls = _extract_calls(body) if body is not None else []
+                    symbols.append(
+                        Symbol(
+                            name=_text(name_node),
+                            kind="method" if parent else "function",
+                            file=filepath,
+                            start_line=child.start_point[0] + 1,
+                            end_line=child.end_point[0] + 1,
+                            parent_class=parent,
+                            calls=list(set(calls)),
+                        )
+                    )
+            elif child.type == "body_statement":
+                _walk(child, parent)
+
+    _walk(root, parent=None)
+    return symbols
+
+
+def _extract_imports_ruby(root) -> list[ImportInfo]:
+    """Extract ``require`` / ``require_relative`` calls from a Ruby parse tree.
+
+    Ruby has no static import syntax; dependencies are loaded at runtime via
+    ``require``/``require_relative``/``load`` with a string path argument. The
+    loaded path is recorded as the module, with name ``*`` (whole-file load).
+    """
+    imports: list[ImportInfo] = []
+
+    def _text(node) -> str:
+        try:
+            return node.text.decode("utf-8") if node.text else ""
+        except Exception:
+            return ""
+
+    require_methods = {"require", "require_relative", "load"}
+
+    def _walk(node) -> None:
+        if node.type == "call":
+            method_node = node.child_by_field_name("method")
+            receiver = node.child_by_field_name("receiver")
+            if (
+                method_node is not None
+                and receiver is None
+                and _text(method_node) in require_methods
+            ):
+                args = node.child_by_field_name("arguments")
+                if args is not None:
+                    for arg in args.named_children:
+                        if arg.type == "string":
+                            path = _strip_string_quotes(_text(arg))
+                            if path:
+                                imports.append(
+                                    ImportInfo(
+                                        file="",
+                                        module=path,
+                                        name="*",
+                                        alias=None,
+                                        is_from=False,
+                                    )
+                                )
+        for child in node.children:
+            _walk(child)
+
+    _walk(root)
+    return imports
+
+
 # ---------------------------------------------------------------------------
 # C# extraction
 # ---------------------------------------------------------------------------
@@ -1803,7 +1921,7 @@ def parse_file(filepath: Path) -> FileParseResult:
 
     Detects language from file extension and dispatches to the correct
     tree-sitter grammar. Supports Python, TypeScript/JavaScript, Rust, Go,
-    Java, and C#.
+    Java, C#, and Ruby.
     """
     code = filepath.read_bytes()
     lang_name = _detect_language(filepath)
@@ -1835,6 +1953,9 @@ def parse_file(filepath: Path) -> FileParseResult:
     elif lang_name == "csharp":
         symbols = _extract_symbols_csharp(root, filename)
 
+    elif lang_name == "ruby":
+        symbols = _extract_symbols_ruby(root, filename)
+
     imports: list[ImportInfo] = []
     if lang_name == "python":
         imports = _extract_imports(root)
@@ -1848,6 +1969,8 @@ def parse_file(filepath: Path) -> FileParseResult:
         imports = _extract_imports_java(root)
     elif lang_name == "csharp":
         imports = _extract_imports_csharp(root)
+    elif lang_name == "ruby":
+        imports = _extract_imports_ruby(root)
 
     for imp in imports:
         imp.file = filename

--- a/packages/gptme-codegraph/src/gptme_codegraph/core.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/core.py
@@ -1734,7 +1734,9 @@ def _extract_imports_ruby(root) -> list[ImportInfo]:
 
     require_methods = {"require", "require_relative", "load"}
 
-    def _walk(node) -> None:
+    stack = [root]
+    while stack:
+        node = stack.pop()
         if node.type == "call":
             method_node = node.child_by_field_name("method")
             receiver = node.child_by_field_name("receiver")
@@ -1758,10 +1760,7 @@ def _extract_imports_ruby(root) -> list[ImportInfo]:
                                         is_from=False,
                                     )
                                 )
-        for child in node.children:
-            _walk(child)
-
-    _walk(root)
+        stack.extend(node.children)
     return imports
 
 

--- a/packages/gptme-codegraph/tests/test_multilang.py
+++ b/packages/gptme-codegraph/tests/test_multilang.py
@@ -1,7 +1,7 @@
-"""Tests for multi-language support in gptme-codegraph (JS/TS, Rust, Go, Java, C#).
+"""Tests for multi-language support in gptme-codegraph (JS/TS, Rust, Go, Java, C#, Ruby).
 
 Verifies that parse_file, extract_symbols, and build_index work correctly
-for JavaScript, TypeScript, Rust, Go, Java, and C# source files.
+for JavaScript, TypeScript, Rust, Go, Java, C#, and Ruby source files.
 """
 
 from __future__ import annotations
@@ -49,6 +49,10 @@ _skip_no_java = pytest.mark.skipif(
 _skip_no_csharp = pytest.mark.skipif(
     not _has_grammar("c_sharp"),
     reason="tree-sitter-c-sharp not installed",
+)
+_skip_no_ruby = pytest.mark.skipif(
+    not _has_grammar("ruby"),
+    reason="tree-sitter-ruby not installed",
 )
 
 # ---------------------------------------------------------------------------
@@ -1130,6 +1134,51 @@ namespace Example.App
 
 
 # ---------------------------------------------------------------------------
+# Ruby fixtures + tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def ruby_module() -> Generator[Path, None, None]:
+    """A Ruby source file exercising modules, classes, methods, and requires."""
+    code = """\
+require "json"
+require_relative "support/base"
+
+module Geometry
+  PI = 3.14159
+
+  class Circle < Shape
+    def initialize(radius)
+      @radius = radius
+    end
+
+    def area
+      compute(PI * @radius * @radius)
+    end
+
+    def self.unit
+      new(1)
+    end
+  end
+
+  def describe
+    puts "geometry"
+  end
+end
+
+def main
+  Geometry::Circle.unit.area
+end
+"""
+    with tempfile.NamedTemporaryFile(suffix=".rb", mode="w", delete=False) as f:
+        f.write(code)
+        path = Path(f.name)
+    yield path
+    path.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
 # C# tests
 # ---------------------------------------------------------------------------
 
@@ -1246,3 +1295,104 @@ def test_build_index_csharp(csharp_module: Path):
         index = build_index(d)
         assert "Calculator" in index.entries
         assert "Add" in index.entries
+
+
+@_skip_no_ruby
+def test_parse_ruby_module(ruby_module: Path):
+    """Ruby: module is extracted as a class-kind namespace symbol."""
+    result = parse_file(ruby_module)
+    geometry = next((s for s in result.symbols if s.name == "Geometry"), None)
+    assert geometry is not None
+    assert geometry.kind == "class"
+    assert geometry.parent_class is None
+
+
+@_skip_no_ruby
+def test_parse_ruby_class(ruby_module: Path):
+    """Ruby: a class nested in a module records the module as parent."""
+    result = parse_file(ruby_module)
+    circle = next((s for s in result.symbols if s.name == "Circle"), None)
+    assert circle is not None
+    assert circle.kind == "class"
+    assert circle.parent_class == "Geometry"
+
+
+@_skip_no_ruby
+def test_parse_ruby_methods(ruby_module: Path):
+    """Ruby: instance methods are extracted with their class as parent."""
+    result = parse_file(ruby_module)
+    area = next((s for s in result.symbols if s.name == "area"), None)
+    assert area is not None
+    assert area.kind == "method"
+    assert area.parent_class == "Circle"
+
+
+@_skip_no_ruby
+def test_parse_ruby_singleton_method(ruby_module: Path):
+    """Ruby: def self.x singleton methods are extracted."""
+    result = parse_file(ruby_module)
+    unit = next((s for s in result.symbols if s.name == "unit"), None)
+    assert unit is not None
+    assert unit.kind == "method"
+    assert unit.parent_class == "Circle"
+
+
+@_skip_no_ruby
+def test_parse_ruby_module_level_method(ruby_module: Path):
+    """Ruby: a def directly inside a module is parented to the module."""
+    result = parse_file(ruby_module)
+    describe = next((s for s in result.symbols if s.name == "describe"), None)
+    assert describe is not None
+    assert describe.parent_class == "Geometry"
+
+
+@_skip_no_ruby
+def test_parse_ruby_top_level_function(ruby_module: Path):
+    """Ruby: a top-level def has no parent and is a function."""
+    result = parse_file(ruby_module)
+    main = next((s for s in result.symbols if s.name == "main"), None)
+    assert main is not None
+    assert main.kind == "function"
+    assert main.parent_class is None
+
+
+@_skip_no_ruby
+def test_parse_ruby_calls(ruby_module: Path):
+    """Ruby: call nodes (method field) are extracted into calls."""
+    result = parse_file(ruby_module)
+    area = next((s for s in result.symbols if s.name == "area"), None)
+    assert area is not None
+    assert "compute" in area.calls, f"Expected 'compute' in calls, got: {area.calls}"
+
+
+@_skip_no_ruby
+def test_parse_ruby_requires(ruby_module: Path):
+    """Ruby: require and require_relative are extracted as imports."""
+    result = parse_file(ruby_module)
+    modules = {imp.module for imp in result.imports}
+    assert "json" in modules
+    assert "support/base" in modules
+
+
+@_skip_no_ruby
+def test_parse_ruby_line_numbers(ruby_module: Path):
+    """Ruby: symbols carry sensible 1-based line numbers."""
+    result = parse_file(ruby_module)
+    circle = next((s for s in result.symbols if s.name == "Circle"), None)
+    assert circle is not None
+    assert circle.start_line >= 1
+    assert circle.end_line >= circle.start_line
+
+
+@_skip_no_ruby
+def test_build_index_ruby(ruby_module: Path):
+    """Ruby: build_index picks up symbols from a .rb file."""
+    import shutil
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as d:
+        dest = Path(d) / ruby_module.name
+        shutil.copy(ruby_module, dest)
+        index = build_index(d)
+        assert "Circle" in index.entries
+        assert "area" in index.entries

--- a/uv.lock
+++ b/uv.lock
@@ -1350,6 +1350,7 @@ treesitter = [
     { name = "tree-sitter-java" },
     { name = "tree-sitter-javascript" },
     { name = "tree-sitter-python" },
+    { name = "tree-sitter-ruby" },
     { name = "tree-sitter-rust" },
     { name = "tree-sitter-typescript" },
 ]
@@ -1364,6 +1365,7 @@ requires-dist = [
     { name = "tree-sitter-java", marker = "extra == 'treesitter'", specifier = ">=0.23.0" },
     { name = "tree-sitter-javascript", marker = "extra == 'treesitter'", specifier = ">=0.21.0" },
     { name = "tree-sitter-python", marker = "extra == 'treesitter'", specifier = ">=0.21.0" },
+    { name = "tree-sitter-ruby", marker = "extra == 'treesitter'", specifier = ">=0.23.0" },
     { name = "tree-sitter-rust", marker = "extra == 'treesitter'", specifier = ">=0.24.0" },
     { name = "tree-sitter-typescript", marker = "extra == 'treesitter'", specifier = ">=0.23.0" },
 ]
@@ -5155,6 +5157,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/75/69/4946da3d6c0df316ccb938316ce007fb565d08f89d02d854f2d308f0309f/tree_sitter_python-0.25.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:71959832fc5d9642e52c11f2f7d79ae520b461e63334927e93ca46cd61cd9683", size = 107268, upload-time = "2025-09-11T06:47:54.388Z" },
     { url = "https://files.pythonhosted.org/packages/ed/a2/996fc2dfa1076dc460d3e2f3c75974ea4b8f02f6bc925383aaae519920e8/tree_sitter_python-0.25.0-cp310-abi3-win_amd64.whl", hash = "sha256:9bcde33f18792de54ee579b00e1b4fe186b7926825444766f849bf7181793a76", size = 76073, upload-time = "2025-09-11T06:47:55.773Z" },
     { url = "https://files.pythonhosted.org/packages/07/19/4b5569d9b1ebebb5907d11554a96ef3fa09364a30fcfabeff587495b512f/tree_sitter_python-0.25.0-cp310-abi3-win_arm64.whl", hash = "sha256:0fbf6a3774ad7e89ee891851204c2e2c47e12b63a5edbe2e9156997731c128bb", size = 74169, upload-time = "2025-09-11T06:47:56.747Z" },
+]
+
+[[package]]
+name = "tree-sitter-ruby"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/5b/6d24be4fde4743481bd8e3fd24b434870cb6612238c8544b71fe129ed850/tree_sitter_ruby-0.23.1.tar.gz", hash = "sha256:886ed200bfd1f3ca7628bf1c9fefd42421bbdba70c627363abda67f662caa21e", size = 489602, upload-time = "2024-11-11T04:51:30.328Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/2e/2717b9451c712b60f833827a696baf29d8e50a0f7dccbf22a8d7006cc19e/tree_sitter_ruby-0.23.1-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:39f391322d2210843f07081182dbf00f8f69cfbfa4687b9575cac6d324bae443", size = 177959, upload-time = "2024-11-11T04:51:19.958Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/38/c41ecf7692b8ecccd26861d3293a88150a4a52fc081abe60f837030d7315/tree_sitter_ruby-0.23.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:aa4ee7433bd42fac22e2dad4a3c0f332292ecf482e610316828c711a0bb7f794", size = 195069, upload-time = "2024-11-11T04:51:21.82Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/01/14ef2d5107e6f42b64a400c3bbc3dd3b8fd24c3cef5306004ae03668f231/tree_sitter_ruby-0.23.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:62b36813a56006b7569db7868f6b762caa3f4e419bd0f8cf9ccbb4abb1b6254c", size = 226761, upload-time = "2024-11-11T04:51:23.021Z" },
+    { url = "https://files.pythonhosted.org/packages/23/dd/1171b5dd25da10f768732a20fb62d2e3ae66e3b42329351f2ce5bf723abb/tree_sitter_ruby-0.23.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f7bcd93972b4ca2803856d4fe0fbd04123ff29c4592bbb9f12a27528bd252341", size = 214427, upload-time = "2024-11-11T04:51:24.854Z" },
+    { url = "https://files.pythonhosted.org/packages/60/bc/de76c877a90fd8a62cd60f496d7832efddc1b18a148593d9aa9b4a9ce5e0/tree_sitter_ruby-0.23.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66c65d6c2a629783ca4ab2bab539bd6f271ce6f77cacb62845831e11665b5bd3", size = 210409, upload-time = "2024-11-11T04:51:26.093Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/4a/f5bcca350b84cdf75a53e918b8efa06c46ed650d99d3ef22195e9d8020cc/tree_sitter_ruby-0.23.1-cp39-abi3-win_amd64.whl", hash = "sha256:02e2c19ebefe29226c14aa63e11e291d990f5b5c20a99940ab6e7eda44e744e5", size = 179843, upload-time = "2024-11-11T04:51:27.265Z" },
+    { url = "https://files.pythonhosted.org/packages/71/5c/a2e068ad4b2c4ba9b774a88b24149168d3bcd94f58b964e49dcabfe5fd24/tree_sitter_ruby-0.23.1-cp39-abi3-win_arm64.whl", hash = "sha256:ed042007e89f2cceeb1cbdd8b0caa68af1e2ce54c7eb2053ace760f90657ac9f", size = 178025, upload-time = "2024-11-11T04:51:29.051Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds **Ruby** as the 8th language for `gptme-codegraph`, after Python, TypeScript/JavaScript, Rust, Go, Java, and C# (#1035). Follows the established multi-language extractor pattern.

## What it extracts

- **Modules and classes** → `kind="class"`. Module/class nesting is tracked via `parent_class` (a class inside `module Geometry` records `parent_class="Geometry"`).
- **Methods** → `kind="method"` when nested in a class/module, `kind="function"` at the top level. Both `def x` and singleton `def self.x` methods are captured.
- **Call edges** — Ruby `call` nodes carry the callee in a `method` field (not the `function` field used by JS/Python), so `_extract_calls` gets a Ruby fallback branch.
- **Imports** — `require` / `require_relative` / `load` string-arg calls, recorded as `ImportInfo` (loaded path as module, name `*`).

## Changes

- `core.py`: `.rb`→`ruby` detection, lazy `tree_sitter_ruby` grammar load, `_extract_symbols_ruby`, `_extract_imports_ruby`, `parse_file` dispatch, `_extract_calls` Ruby `method`-field handling.
- `pyproject.toml`: `tree-sitter-ruby>=0.23.0` added to the `treesitter` optional group.
- `uv.lock`: tree-sitter-ruby 0.23.1 pinned.
- `tests/test_multilang.py`: 10 new tests using the existing `skipif`-on-missing-grammar pattern (module/class/method/singleton/top-level-function/calls/requires/line-numbers/build_index).

## Verification

- `174 passed, 11 skipped` across the full `gptme-codegraph` suite (worktree source via PYTHONPATH + a venv with the Ruby grammar).
- `ruff check` clean; scoped `mypy core.py` clean.

Refs: idea #315 (multi-language gptme-codegraph). Next candidates (same low-risk pattern): C, C++, PHP.