### PR TITLE
feat(codegraph): add C language support (symbol + import extraction)

### DIFF
--- a/packages/gptme-codegraph/pyproject.toml
+++ b/packages/gptme-codegraph/pyproject.toml
@@ -20,6 +20,7 @@ treesitter = [
     "tree-sitter-java>=0.23.0",
     "tree-sitter-c-sharp>=0.23.0",
     "tree-sitter-ruby>=0.23.0",
+    "tree-sitter-c>=0.23.0",
 ]
 mcp = [
     "mcp>=1.0.0",

--- a/packages/gptme-codegraph/src/gptme_codegraph/core.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/core.py
@@ -3,7 +3,7 @@
 Complementary to gptme-rag (text chunks), this retrieves code *structure*:
 function/class definitions, call graphs, and blast radius.
 
-Supports Python, TypeScript/JavaScript, Rust, Go, Java, C#, and Ruby via tree-sitter
+Supports Python, TypeScript/JavaScript, Rust, Go, Java, C#, Ruby, and C via tree-sitter
 grammars.
 To add a new language: add grammar dep to pyproject.toml, extend _LANG_MAP
 and _load_language, then add extractor functions.
@@ -50,6 +50,8 @@ _LANG_MAP: dict[str, str] = {
     ".java": "java",
     ".cs": "csharp",
     ".rb": "ruby",
+    ".c": "c",
+    ".h": "c",
 }
 
 _GRAMMAR_MODULES: dict[str, str] = {
@@ -63,6 +65,7 @@ _GRAMMAR_MODULES: dict[str, str] = {
     "java": "tree_sitter_java",
     "csharp": "tree_sitter_c_sharp",
     "ruby": "tree_sitter_ruby",
+    "c": "tree_sitter_c",
 }
 
 _SOURCE_EXTENSIONS: tuple[str, ...] = tuple(_LANG_MAP.keys())
@@ -149,6 +152,12 @@ def _load_language(name: str):
         import tree_sitter_ruby as tsruby  # type: ignore[import-not-found,unused-ignore]
 
         grammar_map["ruby"] = tsruby.language()
+    except ImportError:
+        pass
+    try:
+        import tree_sitter_c as tsc  # type: ignore[import-not-found,unused-ignore]
+
+        grammar_map["c"] = tsc.language()
     except ImportError:
         pass
 
@@ -1911,6 +1920,147 @@ def _extract_imports_csharp(root) -> list[ImportInfo]:
 
 
 # ---------------------------------------------------------------------------
+# C extraction helpers
+# ---------------------------------------------------------------------------
+
+
+def _c_find_function_name(declarator) -> str | None:
+    """Walk a C declarator chain to find the function name identifier.
+
+    Handles both direct function_declarator and pointer_declarator wrapping
+    (e.g. ``int *foo(void)``).
+    """
+    if declarator is None:
+        return None
+    if declarator.type == "function_declarator":
+        name_node = declarator.child_by_field_name("declarator")
+        if name_node is not None:
+            return _text(name_node) if name_node.type == "identifier" else None
+    elif declarator.type == "pointer_declarator":
+        inner = declarator.child_by_field_name("declarator")
+        return _c_find_function_name(inner)
+    return None
+
+
+def _extract_symbols_c(root, filepath: str) -> list[Symbol]:
+    """Extract function definitions and typedef'd struct types from a C parse tree.
+
+    Functions are extracted as ``kind="function"``.  Named ``struct`` definitions
+    and ``typedef struct { ... } Name`` patterns are extracted as ``kind="class"``
+    to stay consistent with how structs are represented across other languages.
+    """
+    symbols: list[Symbol] = []
+
+    for node in root.named_children:
+        if node.type == "function_definition":
+            outer_decl = node.child_by_field_name("declarator")
+            name = _c_find_function_name(outer_decl)
+            if not name:
+                continue
+            body = node.child_by_field_name("body")
+            calls = _extract_calls(body) if body else []
+            symbols.append(
+                Symbol(
+                    name=name,
+                    kind="function",
+                    file=filepath,
+                    start_line=node.start_point[0] + 1,
+                    end_line=node.end_point[0] + 1,
+                    calls=list(set(calls)),
+                )
+            )
+        elif node.type == "struct_specifier":
+            # Named struct at top level: `struct Foo { ... };`
+            name_node = node.child_by_field_name("name")
+            if name_node:
+                symbols.append(
+                    Symbol(
+                        name=_text(name_node),
+                        kind="class",
+                        file=filepath,
+                        start_line=node.start_point[0] + 1,
+                        end_line=node.end_point[0] + 1,
+                    )
+                )
+        elif node.type == "type_definition":
+            # typedef struct { ... } Name; or typedef struct Named Name;
+            has_struct = any(
+                c.type == "struct_specifier" for c in node.named_children
+            )
+            if has_struct:
+                # The typedef name is the type_identifier child at the end
+                type_id = next(
+                    (
+                        c
+                        for c in reversed(node.named_children)
+                        if c.type == "type_identifier"
+                    ),
+                    None,
+                )
+                if type_id:
+                    symbols.append(
+                        Symbol(
+                            name=_text(type_id),
+                            kind="class",
+                            file=filepath,
+                            start_line=node.start_point[0] + 1,
+                            end_line=node.end_point[0] + 1,
+                        )
+                    )
+
+    return symbols
+
+
+def _extract_imports_c(root) -> list[ImportInfo]:
+    """Extract ``#include`` directives from a C parse tree.
+
+    Handles both angle-bracket forms (``<stdio.h>``) and quoted forms
+    (``"myheader.h"``).  The include path is split on ``/`` to populate
+    ``module`` (the leading directory, e.g. ``sys``) and ``name`` (the
+    filename, e.g. ``types.h``).
+    """
+    imports: list[ImportInfo] = []
+
+    for node in root.named_children:
+        if node.type != "preproc_include":
+            continue
+        path_node = node.child_by_field_name("path")
+        if path_node is None:
+            continue
+        if path_node.type == "system_lib_string":
+            raw = _text(path_node)
+            include_path = raw.strip("<>")
+        elif path_node.type == "string_literal":
+            content = next(
+                (c for c in path_node.named_children if c.type == "string_content"),
+                None,
+            )
+            include_path = _text(content) if content else _strip_string_quotes(_text(path_node))
+        else:
+            include_path = _text(path_node).strip("<>\"'")
+
+        if not include_path:
+            continue
+
+        if "/" in include_path:
+            slash = include_path.rfind("/")
+            module, name = include_path[:slash], include_path[slash + 1 :]
+        else:
+            module, name = "", include_path
+
+        imports.append(
+            ImportInfo(
+                file="",
+                module=module,
+                name=name,
+                is_from=False,
+            )
+        )
+
+    return imports
+
+
+# ---------------------------------------------------------------------------
 # Multi-language parse_file
 # ---------------------------------------------------------------------------
 
@@ -1920,7 +2070,7 @@ def parse_file(filepath: Path) -> FileParseResult:
 
     Detects language from file extension and dispatches to the correct
     tree-sitter grammar. Supports Python, TypeScript/JavaScript, Rust, Go,
-    Java, C#, and Ruby.
+    Java, C#, Ruby, and C.
     """
     code = filepath.read_bytes()
     lang_name = _detect_language(filepath)
@@ -1955,6 +2105,9 @@ def parse_file(filepath: Path) -> FileParseResult:
     elif lang_name == "ruby":
         symbols = _extract_symbols_ruby(root, filename)
 
+    elif lang_name == "c":
+        symbols = _extract_symbols_c(root, filename)
+
     imports: list[ImportInfo] = []
     if lang_name == "python":
         imports = _extract_imports(root)
@@ -1970,6 +2123,8 @@ def parse_file(filepath: Path) -> FileParseResult:
         imports = _extract_imports_csharp(root)
     elif lang_name == "ruby":
         imports = _extract_imports_ruby(root)
+    elif lang_name == "c":
+        imports = _extract_imports_c(root)
 
     for imp in imports:
         imp.file = filename

--- a/packages/gptme-codegraph/src/gptme_codegraph/core.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/core.py
@@ -1927,18 +1927,38 @@ def _extract_imports_csharp(root) -> list[ImportInfo]:
 def _c_find_function_name(declarator) -> str | None:
     """Walk a C declarator chain to find the function name identifier.
 
-    Handles both direct function_declarator and pointer_declarator wrapping
-    (e.g. ``int *foo(void)``).
+    Handles direct ``function_declarator``, ``pointer_declarator`` wrapping
+    (e.g. ``int *foo(void)``), and ``parenthesized_declarator`` wrapping
+    (e.g. ``int (*(foo))(void)``).
     """
     if declarator is None:
         return None
+    if declarator.type == "identifier":
+        return _text(declarator)
     if declarator.type == "function_declarator":
+        # The function name is in the "declarator" child, which may be a
+        # plain identifier ("int foo(void)") or a wrapping node such as
+        # parenthesized_declarator ("int (*(foo))(void)").
         name_node = declarator.child_by_field_name("declarator")
         if name_node is not None:
-            return _text(name_node) if name_node.type == "identifier" else None
+            if name_node.type == "identifier":
+                return _text(name_node)
+            # Recurse into wrapping node (e.g. parenthesized_declarator)
+            return _c_find_function_name(name_node)
     elif declarator.type == "pointer_declarator":
         inner = declarator.child_by_field_name("declarator")
         return _c_find_function_name(inner)
+    elif declarator.type == "parenthesized_declarator":
+        # Walk through parentheses to find the inner declarator chain.
+        # The content inside the parens (e.g. identifier, pointer_declarator,
+        # or another parenthesized_declarator) is in a child node.
+        for child in declarator.children:
+            if child.type in (
+                "identifier",
+                "pointer_declarator",
+                "parenthesized_declarator",
+            ):
+                return _c_find_function_name(child)
     return None
 
 
@@ -1948,66 +1968,85 @@ def _extract_symbols_c(root, filepath: str) -> list[Symbol]:
     Functions are extracted as ``kind="function"``.  Named ``struct`` definitions
     and ``typedef struct { ... } Name`` patterns are extracted as ``kind="class"``
     to stay consistent with how structs are represented across other languages.
+
+    Walks recursively through preprocessor conditionals (``#ifdef``, ``#ifndef``,
+    ``#if``, ``#elif``, ``#else``) so that functions and structs guarded by
+    platform-specific or feature-test macros are not silently dropped.
     """
     symbols: list[Symbol] = []
 
-    for node in root.named_children:
-        if node.type == "function_definition":
-            outer_decl = node.child_by_field_name("declarator")
-            name = _c_find_function_name(outer_decl)
-            if not name:
-                continue
-            body = node.child_by_field_name("body")
-            calls = _extract_calls(body) if body else []
-            symbols.append(
-                Symbol(
-                    name=name,
-                    kind="function",
-                    file=filepath,
-                    start_line=node.start_point[0] + 1,
-                    end_line=node.end_point[0] + 1,
-                    calls=list(set(calls)),
-                )
-            )
-        elif node.type == "struct_specifier":
-            # Named struct at top level: `struct Foo { ... };`
-            name_node = node.child_by_field_name("name")
-            if name_node:
+    # Preprocessor conditional node types that may wrap symbols
+    _PREPROC_WRAPPER = frozenset(
+        {
+            "preproc_ifdef",
+            "preproc_ifndef",
+            "preproc_if",
+            "preproc_elif",
+            "preproc_else",
+        }
+    )
+
+    def _walk(node) -> None:
+        for child in node.named_children:
+            if child.type in _PREPROC_WRAPPER:
+                _walk(child)
+            elif child.type == "function_definition":
+                outer_decl = child.child_by_field_name("declarator")
+                name = _c_find_function_name(outer_decl)
+                if not name:
+                    continue
+                body = child.child_by_field_name("body")
+                calls = _extract_calls(body) if body else []
                 symbols.append(
                     Symbol(
-                        name=_text(name_node),
-                        kind="class",
+                        name=name,
+                        kind="function",
                         file=filepath,
-                        start_line=node.start_point[0] + 1,
-                        end_line=node.end_point[0] + 1,
+                        start_line=child.start_point[0] + 1,
+                        end_line=child.end_point[0] + 1,
+                        calls=list(set(calls)),
                     )
                 )
-        elif node.type == "type_definition":
-            # typedef struct { ... } Name; or typedef struct Named Name;
-            has_struct = any(
-                c.type == "struct_specifier" for c in node.named_children
-            )
-            if has_struct:
-                # The typedef name is the type_identifier child at the end
-                type_id = next(
-                    (
-                        c
-                        for c in reversed(node.named_children)
-                        if c.type == "type_identifier"
-                    ),
-                    None,
-                )
-                if type_id:
+            elif child.type == "struct_specifier":
+                # Named struct at top level: `struct Foo { ... };`
+                name_node = child.child_by_field_name("name")
+                if name_node:
                     symbols.append(
                         Symbol(
-                            name=_text(type_id),
+                            name=_text(name_node),
                             kind="class",
                             file=filepath,
-                            start_line=node.start_point[0] + 1,
-                            end_line=node.end_point[0] + 1,
+                            start_line=child.start_point[0] + 1,
+                            end_line=child.end_point[0] + 1,
                         )
                     )
+            elif child.type == "type_definition":
+                # typedef struct { ... } Name; or typedef struct Named Name;
+                has_struct = any(
+                    c.type == "struct_specifier" for c in child.named_children
+                )
+                if has_struct:
+                    # The typedef name is the type_identifier child at the end
+                    type_id = next(
+                        (
+                            c
+                            for c in reversed(child.named_children)
+                            if c.type == "type_identifier"
+                        ),
+                        None,
+                    )
+                    if type_id:
+                        symbols.append(
+                            Symbol(
+                                name=_text(type_id),
+                                kind="class",
+                                file=filepath,
+                                start_line=child.start_point[0] + 1,
+                                end_line=child.end_point[0] + 1,
+                            )
+                        )
 
+    _walk(root)
     return symbols
 
 
@@ -2018,15 +2057,35 @@ def _extract_imports_c(root) -> list[ImportInfo]:
     (``"myheader.h"``).  The include path is split on ``/`` to populate
     ``module`` (the leading directory, e.g. ``sys``) and ``name`` (the
     filename, e.g. ``types.h``).
+
+    Walks recursively through preprocessor conditionals (``#ifdef``, ``#ifndef``,
+    ``#if``, ``#elif``, ``#else``) so that platform-specific or feature-guarded
+    includes are not silently dropped.
     """
     imports: list[ImportInfo] = []
 
-    for node in root.named_children:
-        if node.type != "preproc_include":
-            continue
+    # Preprocessor conditional node types that may wrap #include directives
+    _PREPROC_WRAPPER = frozenset(
+        {
+            "preproc_ifdef",
+            "preproc_ifndef",
+            "preproc_if",
+            "preproc_elif",
+            "preproc_else",
+        }
+    )
+
+    def _walk(node) -> None:
+        for child in node.named_children:
+            if child.type in _PREPROC_WRAPPER:
+                _walk(child)
+            elif child.type == "preproc_include":
+                _extract_include(child)
+
+    def _extract_include(node) -> None:
         path_node = node.child_by_field_name("path")
         if path_node is None:
-            continue
+            return
         if path_node.type == "system_lib_string":
             raw = _text(path_node)
             include_path = raw.strip("<>")
@@ -2035,12 +2094,14 @@ def _extract_imports_c(root) -> list[ImportInfo]:
                 (c for c in path_node.named_children if c.type == "string_content"),
                 None,
             )
-            include_path = _text(content) if content else _strip_string_quotes(_text(path_node))
+            include_path = (
+                _text(content) if content else _strip_string_quotes(_text(path_node))
+            )
         else:
             include_path = _text(path_node).strip("<>\"'")
 
         if not include_path:
-            continue
+            return
 
         if "/" in include_path:
             slash = include_path.rfind("/")
@@ -2057,6 +2118,7 @@ def _extract_imports_c(root) -> list[ImportInfo]:
             )
         )
 
+    _walk(root)
     return imports
 
 

--- a/packages/gptme-codegraph/tests/test_multilang.py
+++ b/packages/gptme-codegraph/tests/test_multilang.py
@@ -1296,6 +1296,7 @@ def test_build_index_csharp(csharp_module: Path):
         assert "Calculator" in index.entries
         assert "Add" in index.entries
 
+
 @_skip_no_ruby
 def test_parse_ruby_module(ruby_module: Path):
     """Ruby: module is extracted as a class-kind namespace symbol."""

--- a/packages/gptme-codegraph/tests/test_multilang.py
+++ b/packages/gptme-codegraph/tests/test_multilang.py
@@ -1559,3 +1559,65 @@ def test_build_index_c(c_module: Path):
         index = build_index(d)
         assert "add" in index.entries
         assert "multiply" in index.entries
+
+
+@pytest.fixture
+def c_conditional_module() -> Generator[Path, None, None]:
+    """A C file with preprocessor-conditional includes and a conditionally-compiled function."""
+    code = """\
+#include <stdio.h>
+#ifdef _WIN32
+#include <windows.h>
+#endif
+#ifndef NO_EXTRA
+#include <extra.h>
+#endif
+#if defined(FEATURE_X)
+#include <feature.h>
+int feature_x_init(void) { return 0; }
+#endif
+#ifdef USE_BAR
+int bar(void) { return 2; }
+#endif
+int main(void) { return 0; }
+"""
+    with tempfile.NamedTemporaryFile(suffix=".c", mode="w", delete=False) as f:
+        f.write(code)
+        path = Path(f.name)
+    yield path
+    path.unlink(missing_ok=True)
+
+
+@_skip_no_c
+def test_parse_c_preprocessor_conditional(c_conditional_module: Path):
+    """C: #include inside #ifdef/#ifndef/#if is extracted via recursive walk."""
+    result = parse_file(c_conditional_module)
+
+    import_names = {i.name for i in result.imports}
+    assert "stdio.h" in import_names, "top-level include missing"
+    assert "windows.h" in import_names, "#ifdef-guarded include missing"
+    assert "extra.h" in import_names, "#ifndef-guarded include missing"
+    assert "feature.h" in import_names, "#if defined(...)-guarded include missing"
+
+    symbol_names = {s.name for s in result.symbols}
+    assert "feature_x_init" in symbol_names, "function inside #if defined(...) missing"
+    assert "bar" in symbol_names, "function inside #ifdef missing"
+    assert "main" in symbol_names
+
+
+@_skip_no_c
+def test_parse_c_parenthesized_declarator(c_conditional_module: Path):
+    """C: int (*(foo))(void) — parenthesized_declarator wraps a pointer_declarator."""
+    # The default c_module fixture doesn't have this pattern, but our
+    # _c_find_function_name handles it.  Test with a separate fixture.
+    code = "int (*(inner_func))(void) { return NULL; }\n"
+    with tempfile.NamedTemporaryFile(suffix=".c", mode="w", delete=False) as f:
+        f.write(code)
+        path = Path(f.name)
+    try:
+        result = parse_file(path)
+        assert any(
+            s.name == "inner_func" for s in result.symbols
+        ), f"Expected inner_func in symbols, got: {[s.name for s in result.symbols]}"
+    finally:
+        path.unlink(missing_ok=True)

--- a/packages/gptme-codegraph/tests/test_multilang.py
+++ b/packages/gptme-codegraph/tests/test_multilang.py
@@ -1296,7 +1296,6 @@ def test_build_index_csharp(csharp_module: Path):
         assert "Calculator" in index.entries
         assert "Add" in index.entries
 
-
 @_skip_no_ruby
 def test_parse_ruby_module(ruby_module: Path):
     """Ruby: module is extracted as a class-kind namespace symbol."""
@@ -1396,3 +1395,167 @@ def test_build_index_ruby(ruby_module: Path):
         index = build_index(d)
         assert "Circle" in index.entries
         assert "area" in index.entries
+
+
+_skip_no_c = pytest.mark.skipif(
+    not _has_grammar("c"),
+    reason="tree-sitter-c not installed",
+)
+
+
+@pytest.fixture
+def c_module() -> Generator[Path, None, None]:
+    """A C file with includes, a typedef'd struct, a named struct, and functions."""
+    code = """\
+#include <stdio.h>
+#include <sys/types.h>
+#include "utils.h"
+
+typedef struct {
+    int x;
+    int y;
+} Point;
+
+struct Config {
+    int width;
+    int height;
+};
+
+static int add(int a, int b) {
+    return a + b;
+}
+
+int multiply(int a, int b) {
+    int result = add(a, b);
+    printf("%d", result);
+    return result;
+}
+
+int *alloc_point(void) {
+    return NULL;
+}
+
+int main(void) {
+    int r = multiply(3, 4);
+    return 0;
+}
+"""
+    with tempfile.NamedTemporaryFile(suffix=".c", mode="w", delete=False) as f:
+        f.write(code)
+        path = Path(f.name)
+    yield path
+    path.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# C tests
+# ---------------------------------------------------------------------------
+
+
+@_skip_no_c
+def test_language_detection_c(c_module: Path):
+    """C: .c files are detected as the c language."""
+    result = parse_file(c_module)
+    assert result.language == "c"
+
+
+@_skip_no_c
+def test_parse_c_functions(c_module: Path):
+    """C: function definitions are extracted with kind='function'."""
+    result = parse_file(c_module)
+    names = [s.name for s in result.symbols]
+    assert "add" in names
+    assert "multiply" in names
+    assert "main" in names
+    for s in result.symbols:
+        if s.name in ("add", "multiply", "main"):
+            assert s.kind == "function"
+
+
+@_skip_no_c
+def test_parse_c_pointer_return(c_module: Path):
+    """C: function with pointer return type (int *foo) is still extracted."""
+    result = parse_file(c_module)
+    assert any(s.name == "alloc_point" for s in result.symbols)
+
+
+@_skip_no_c
+def test_parse_c_typedef_struct(c_module: Path):
+    """C: typedef struct { ... } Name is extracted as kind='class'."""
+    result = parse_file(c_module)
+    sym = next((s for s in result.symbols if s.name == "Point"), None)
+    assert sym is not None
+    assert sym.kind == "class"
+
+
+@_skip_no_c
+def test_parse_c_named_struct(c_module: Path):
+    """C: named struct declarations are extracted as kind='class'."""
+    result = parse_file(c_module)
+    sym = next((s for s in result.symbols if s.name == "Config"), None)
+    assert sym is not None
+    assert sym.kind == "class"
+
+
+@_skip_no_c
+def test_parse_c_calls(c_module: Path):
+    """C: function calls inside a body are extracted."""
+    result = parse_file(c_module)
+    multiply_sym = next((s for s in result.symbols if s.name == "multiply"), None)
+    assert multiply_sym is not None
+    assert any(
+        "add" in c for c in multiply_sym.calls
+    ), f"Expected 'add' in calls, got: {multiply_sym.calls}"
+    assert any(
+        "printf" in c for c in multiply_sym.calls
+    ), f"Expected 'printf' in calls, got: {multiply_sym.calls}"
+
+
+@_skip_no_c
+def test_parse_c_imports_stdlib(c_module: Path):
+    """C: angle-bracket includes are extracted with correct name."""
+    result = parse_file(c_module)
+    stdio = next((i for i in result.imports if i.name == "stdio.h"), None)
+    assert stdio is not None
+    assert stdio.module == ""
+
+
+@_skip_no_c
+def test_parse_c_imports_nested(c_module: Path):
+    """C: nested include paths (sys/types.h) split into module and name."""
+    result = parse_file(c_module)
+    types = next((i for i in result.imports if i.name == "types.h"), None)
+    assert types is not None
+    assert types.module == "sys"
+
+
+@_skip_no_c
+def test_parse_c_imports_local(c_module: Path):
+    """C: quoted local includes are extracted."""
+    result = parse_file(c_module)
+    utils = next((i for i in result.imports if i.name == "utils.h"), None)
+    assert utils is not None
+
+
+@_skip_no_c
+def test_parse_c_line_numbers(c_module: Path):
+    """C: symbol line numbers are positive and ordered."""
+    result = parse_file(c_module)
+    assert result.symbols
+    for sym in result.symbols:
+        assert sym.start_line >= 1
+        assert sym.end_line >= sym.start_line
+
+
+@_skip_no_c
+def test_build_index_c(c_module: Path):
+    """C: build_index picks up functions from a .c file."""
+    import shutil
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as d:
+        dest = Path(d) / c_module.name
+        shutil.copy(c_module, dest)
+        index = build_index(d)
+        assert "add" in index.entries
+        assert "multiply" in index.entries

--- a/uv.lock
+++ b/uv.lock
@@ -1346,6 +1346,8 @@ mcp = [
 ]
 treesitter = [
     { name = "tree-sitter" },
+    { name = "tree-sitter-c" },
+    { name = "tree-sitter-c-sharp" },
     { name = "tree-sitter-go" },
     { name = "tree-sitter-java" },
     { name = "tree-sitter-javascript" },
@@ -1361,6 +1363,8 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "tree-sitter", marker = "extra == 'treesitter'", specifier = ">=0.21.0" },
+    { name = "tree-sitter-c", marker = "extra == 'treesitter'", specifier = ">=0.23.0" },
+    { name = "tree-sitter-c-sharp", marker = "extra == 'treesitter'", specifier = ">=0.23.0" },
     { name = "tree-sitter-go", marker = "extra == 'treesitter'", specifier = ">=0.23.0" },
     { name = "tree-sitter-java", marker = "extra == 'treesitter'", specifier = ">=0.23.0" },
     { name = "tree-sitter-javascript", marker = "extra == 'treesitter'", specifier = ">=0.21.0" },
@@ -5094,6 +5098,38 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/57/e2/d42d55bf56360987c32bc7b16adb06744e425670b823fb8a5786a1cea991/tree_sitter-0.25.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7d2ee1acbacebe50ba0f85fff1bc05e65d877958f00880f49f9b2af38dce1af0", size = 631522, upload-time = "2025-09-25T17:37:55.833Z" },
     { url = "https://files.pythonhosted.org/packages/03/87/af9604ebe275a9345d88c3ace0cf2a1341aa3f8ef49dd9fc11662132df8a/tree_sitter-0.25.2-cp314-cp314-win_amd64.whl", hash = "sha256:4973b718fcadfb04e59e746abfbb0288694159c6aeecd2add59320c03368c721", size = 130864, upload-time = "2025-09-25T17:37:57.453Z" },
     { url = "https://files.pythonhosted.org/packages/a6/6e/e64621037357acb83d912276ffd30a859ef117f9c680f2e3cb955f47c680/tree_sitter-0.25.2-cp314-cp314-win_arm64.whl", hash = "sha256:b8d4429954a3beb3e844e2872610d2a4800ba4eb42bb1990c6a4b1949b18459f", size = 117470, upload-time = "2025-09-25T17:37:58.431Z" },
+]
+
+[[package]]
+name = "tree-sitter-c"
+version = "0.24.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/c9/3834f3d9278251aea7312274971bc4c45b17aec2490fd4b884d93bd7019a/tree_sitter_c-0.24.2.tar.gz", hash = "sha256:1628584df0299b5a340aa63f8e67b6c97c91517f52fa7e7a4c557e40adb330a9", size = 228397, upload-time = "2026-04-22T08:06:14.491Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/c1/26ed17730ec2c17bedc1b673349e5e0a466c578e3eb0327c3b73cf52bf97/tree_sitter_c-0.24.2-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:4d4579a8b54f0a442f903d88d3304cab77cd5c2031d4015baa4f2f8e15d6dcb7", size = 81016, upload-time = "2026-04-22T08:06:07.208Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/1c/1140db75e7e375cda3c68792a33826c4fd40b5b98c3259d93c75f6c8368f/tree_sitter_c-0.24.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:97bc80a224d48215d4e6e6376bf30d114f4c317b8145ff1b02afe785d4ba7bdd", size = 86213, upload-time = "2026-04-22T08:06:08.136Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/8c/0dfb88d726f8821d1c4c36042f092be974a800afd734307a595b8604190c/tree_sitter_c-0.24.2-cp310-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5041ef67eb68ce6bc8bb0b1f8ef3a5585ce523dae0c7eec109ab0627dd75aede", size = 94264, upload-time = "2026-04-22T08:06:08.918Z" },
+    { url = "https://files.pythonhosted.org/packages/87/78/47dc570e7aee6b0a1ecc2520b30639cc2b06003154c9ab0672d86bf720d5/tree_sitter_c-0.24.2-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c098bedcd5ac86ff93fa734d51d1dd86aed40fd5ed7d634c7af11380a0469969", size = 94560, upload-time = "2026-04-22T08:06:09.852Z" },
+    { url = "https://files.pythonhosted.org/packages/29/37/75d59d3f74f4cfc00f04472917e933d8a9c9fdc6eff980ef9552e010e6aa/tree_sitter_c-0.24.2-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:82842c5a5f2acd93f4de10038c33ac179c8979defc39376f990348d6289e933b", size = 94023, upload-time = "2026-04-22T08:06:10.682Z" },
+    { url = "https://files.pythonhosted.org/packages/64/57/8fc655d5a446a70a637e92b98bd2fdaab88bf5bb5b36076ac4add544808d/tree_sitter_c-0.24.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e2b42e8e22202c251f8629306f9321233542e07a6e01611b5fe83489272143eb", size = 94160, upload-time = "2026-04-22T08:06:11.497Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f7/72a1d6b42dd31fd37e03ff67e7dc5ee572301499e6b216002b8dd42a1714/tree_sitter_c-0.24.2-cp310-abi3-win_amd64.whl", hash = "sha256:abb549225091f7b25df2dd3a0143ece6e208f7055d8bcb4700b41ee79b9ef1e1", size = 84669, upload-time = "2026-04-22T08:06:12.347Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/9d/7475d9ae8ef679aa36c7dfe6c903ab78e573651c68b6ef9862d6a3f994db/tree_sitter_c-0.24.2-cp310-abi3-win_arm64.whl", hash = "sha256:4a2f4371cd816cc3153458f69062135ebb2ea5f275ddd90494e5c823d778204a", size = 82956, upload-time = "2026-04-22T08:06:13.364Z" },
+]
+
+[[package]]
+name = "tree-sitter-c-sharp"
+version = "0.23.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/fb/7e2962bc1901daf264e7ce263b168e0139304a5f8f66c9b2baf20e550f87/tree_sitter_c_sharp-0.23.5.tar.gz", hash = "sha256:2635c7d5ec93e59f2e831b571bed99c4cc68a5d183a0994020aa769e1b990a71", size = 1147914, upload-time = "2026-04-14T16:11:22.441Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/c4/86d8d469400a856757a464a6ac01af97d8cdacbb595e62bdb98bf1e9db90/tree_sitter_c_sharp-0.23.5-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:61e1981cf21b09ee547b9c4c68e64fb4394325f8fc8d5f6d50d41471eba923ea", size = 333658, upload-time = "2026-04-14T16:11:11.288Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/13/593c8603f834eaf15082b81e079289fc9f062b4c0ab5b9489134084eec06/tree_sitter_c_sharp-0.23.5-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:a75994a11f6fed3f5b8c36ad6a00e5dc43205bd912c43af3a2a54fdf649664eb", size = 376296, upload-time = "2026-04-14T16:11:12.972Z" },
+    { url = "https://files.pythonhosted.org/packages/41/5a/a8855cbb5bbab28adb29c2c7f0e7be5a9f1d21450c13b3c3e613190d9b8c/tree_sitter_c_sharp-0.23.5-cp310-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:aa88a780204cd153c4c1ae2d59c654cee1402212fa0d069823d6d34301587438", size = 358333, upload-time = "2026-04-14T16:11:14.214Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/c8/e0f391e343f5424d0627e3b6886c77baeb1249a3f10986be00b0b64ecdab/tree_sitter_c_sharp-0.23.5-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ea38fb095d85d360dc5a0bec2fa605e496228876f798c9e089d5f0e72bcef46", size = 359448, upload-time = "2026-04-14T16:11:15.419Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/fc/10f807ac79f928241c5e0d827fdaf91e97dfba662fc7e07d7bd664140ec1/tree_sitter_c_sharp-0.23.5-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:05a9256415e7f24d4f133133794a9c224c60d19f677a04e2f6a94c25090b6d65", size = 358144, upload-time = "2026-04-14T16:11:17.087Z" },
+    { url = "https://files.pythonhosted.org/packages/de/2a/6c3e12ef0cf09138717fcc02e1de8b76a3928d1bed65c7e3c2bd3172bcef/tree_sitter_c_sharp-0.23.5-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8636dc70b5a373c35c1036ed5de98e801f2e4d105ae41e2e20b6804c36e3bf33", size = 357525, upload-time = "2026-04-14T16:11:18.214Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e0/bd287b092d611df95a9149117fd27b5947ce75527113d6898a4b4e2c8858/tree_sitter_c_sharp-0.23.5-cp310-abi3-win_amd64.whl", hash = "sha256:41a28cfa3d9ea50f5629e44550a03188c8fbd5079803dfc03554b6fd594b33fa", size = 338756, upload-time = "2026-04-14T16:11:19.661Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/fb/114ff43fdd256d0befed32f77c1dadee9517867181c70794571f718ed05c/tree_sitter_c_sharp-0.23.5-cp310-abi3-win_arm64.whl", hash = "sha256:2de4ebf95ddc2e92cd3105c8a8e0e7ec646bc82f52bfaf2f3acec0fa2401ec09", size = 337260, upload-time = "2026-04-14T16:11:20.849Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds **C** as the 9th language supported by `gptme-codegraph` (after Python, TypeScript, JavaScript, Rust, Go, Java, C#, Ruby — see #1030 #1033 #1035 #1036).

- `.c` and `.h` extensions → `"c"` language detection
- `_extract_symbols_c`: functions as `kind="function"` (handles pointer-return types like `int *foo(void)` via declarator chain walk); `typedef struct { ... } Name` and named `struct Foo { ... }` as `kind="class"` for consistency with other languages
- `_extract_imports_c`: `#include` directives (both angle-bracket and quoted forms); nested paths like `<sys/types.h>` split into `module="sys"`, `name="types.h"`
- Function call extraction reuses `_extract_calls` (already handles `call_expression` nodes that C uses)
- `tree-sitter-c>=0.23.0` added to `treesitter` optional group; `uv.lock` pinned to 0.24.2
- 11 new tests in `test_multilang.py` using `skipif`-on-missing-grammar pattern; all pass

## Test plan

- [ ] `pytest packages/gptme-codegraph/tests/test_multilang.py -k "test_language_detection_c or test_parse_c or test_build_index_c"` → 11 passed
- [ ] `ruff check` clean
- [ ] `mypy packages/gptme-codegraph/src/gptme_codegraph/core.py --ignore-missing-imports` clean
- [ ] CI passes