### PR TITLE
feat(codegraph): add C++ language support

### DIFF
--- a/packages/gptme-codegraph/pyproject.toml
+++ b/packages/gptme-codegraph/pyproject.toml
@@ -19,6 +19,7 @@ treesitter = [
     "tree-sitter-go>=0.23.0",
     "tree-sitter-java>=0.23.0",
     "tree-sitter-c-sharp>=0.23.0",
+    "tree-sitter-cpp>=0.23.0",
     "tree-sitter-ruby>=0.23.0",
     "tree-sitter-c>=0.23.0",
     "tree-sitter-php>=0.24.0",

--- a/packages/gptme-codegraph/src/gptme_codegraph/core.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/core.py
@@ -3,7 +3,7 @@
 Complementary to gptme-rag (text chunks), this retrieves code *structure*:
 function/class definitions, call graphs, and blast radius.
 
-Supports Python, TypeScript/JavaScript, Rust, Go, Java, C#, Ruby, C, and PHP via tree-sitter
+Supports Python, TypeScript/JavaScript, Rust, Go, Java, C#, Ruby, C, C++, and PHP via tree-sitter
 grammars.
 To add a new language: add grammar dep to pyproject.toml, extend _LANG_MAP
 and _load_language, then add extractor functions.
@@ -49,10 +49,16 @@ _LANG_MAP: dict[str, str] = {
     ".go": "go",
     ".java": "java",
     ".cs": "csharp",
+    ".cpp": "cpp",
+    ".cc": "cpp",
+    ".cxx": "cpp",
+    ".h": "cpp",
+    ".hpp": "cpp",
+    ".hh": "cpp",
+    ".hxx": "cpp",
     ".rb": "ruby",
     ".php": "php",
     ".c": "c",
-    ".h": "c",
 }
 
 _GRAMMAR_MODULES: dict[str, str] = {
@@ -65,6 +71,7 @@ _GRAMMAR_MODULES: dict[str, str] = {
     "go": "tree_sitter_go",
     "java": "tree_sitter_java",
     "csharp": "tree_sitter_c_sharp",
+    "cpp": "tree_sitter_cpp",
     "ruby": "tree_sitter_ruby",
     "php": "tree_sitter_php",
     "c": "tree_sitter_c",
@@ -148,6 +155,12 @@ def _load_language(name: str):
         import tree_sitter_c_sharp as tscsharp  # type: ignore[import-not-found,unused-ignore]
 
         grammar_map["csharp"] = tscsharp.language()
+    except ImportError:
+        pass
+    try:
+        import tree_sitter_cpp as tscpp  # type: ignore[import-not-found,unused-ignore]
+
+        grammar_map["cpp"] = tscpp.language()
     except ImportError:
         pass
     try:
@@ -798,6 +811,16 @@ def _extract_calls(node) -> list[str]:
 def _strip_string_quotes(text: str) -> str:
     """Return a string literal without its outer quote characters."""
     if len(text) >= 2 and text[0] == text[-1] and text[0] in {'"', "'"}:
+        return text[1:-1]
+    return text
+
+
+def _strip_include_delimiters(text: str) -> str:
+    """Return an include path without ``""`` or ``<>`` delimiters."""
+    if len(text) >= 2 and (
+        (text[0] == text[-1] and text[0] in {'"', "'"})
+        or (text[0] == "<" and text[-1] == ">")
+    ):
         return text[1:-1]
     return text
 
@@ -2329,6 +2352,214 @@ def _extract_imports_php(root) -> list[ImportInfo]:
     return imports
 
 
+# C++ extraction
+# ---------------------------------------------------------------------------
+
+
+_CPP_TYPE_NODES = frozenset(
+    {"class_specifier", "struct_specifier", "union_specifier", "enum_specifier"}
+)
+
+
+def _cpp_container_body(node):
+    """Return a C++ namespace/type body node when present."""
+    for child in node.named_children:
+        if child.type in (
+            "declaration_list",
+            "field_declaration_list",
+            "enumerator_list",
+        ):
+            return child
+    return None
+
+
+def _cpp_type_name(node) -> str | None:
+    """Return the declared C++ type name."""
+    for child in node.named_children:
+        if child.type in {
+            "type_identifier",
+            "identifier",
+            "namespace_identifier",
+        }:
+            name = _text(child)
+            if name:
+                return name
+    return None
+
+
+def _cpp_qualified_parts(node) -> list[str]:
+    """Return the named segments inside a C++ qualified identifier."""
+    if node.type in {
+        "identifier",
+        "field_identifier",
+        "type_identifier",
+        "namespace_identifier",
+        "destructor_name",
+        "operator_name",
+    }:
+        text = _text(node)
+        return [text] if text else []
+
+    parts: list[str] = []
+    for child in node.named_children:
+        parts.extend(_cpp_qualified_parts(child))
+    return parts
+
+
+def _cpp_function_name_and_parent(
+    declarator, known_types: set[str]
+) -> tuple[str | None, str | None]:
+    """Return ``(name, parent_class)`` for a C++ declarator subtree."""
+    if declarator.type == "qualified_identifier":
+        parts = _cpp_qualified_parts(declarator)
+        if not parts:
+            return None, None
+        parent = parts[-2] if len(parts) >= 2 and parts[-2] in known_types else None
+        return parts[-1], parent
+
+    if declarator.type in {
+        "identifier",
+        "field_identifier",
+        "destructor_name",
+        "operator_name",
+    }:
+        text = _text(declarator)
+        return (text, None) if text else (None, None)
+
+    for child in declarator.named_children:
+        if child.type == "parameter_list":
+            continue
+        name, parent = _cpp_function_name_and_parent(child, known_types)
+        if name:
+            return name, parent
+    return None, None
+
+
+def _cpp_function_body(node):
+    """Return a function's compound statement node when present."""
+    body = node.child_by_field_name("body")
+    if body is not None:
+        return body
+    for child in node.named_children:
+        if child.type == "compound_statement":
+            return child
+    return None
+
+
+def _extract_symbols_cpp(root, filepath: str) -> list[Symbol]:
+    """Extract classes, methods, and functions from a C++ parse tree.
+
+    Scope is intentionally narrow: namespaces, top-level functions, class/struct/enum
+    declarations, inline member definitions, and out-of-class member definitions that
+    use a known declared type name.
+    """
+    symbols: list[Symbol] = []
+    known_types: set[str] = set()
+
+    def _add_function(node, parent_class: str | None = None) -> None:
+        declarator = node.child_by_field_name("declarator")
+        if declarator is None:
+            declarator = next(
+                (child for child in node.named_children if "declarator" in child.type),
+                None,
+            )
+        if declarator is None:
+            return
+
+        name, inferred_parent = _cpp_function_name_and_parent(declarator, known_types)
+        if not name:
+            return
+
+        effective_parent = parent_class or inferred_parent
+        body = _cpp_function_body(node)
+        calls = _extract_calls(body) if body else []
+        symbols.append(
+            Symbol(
+                name=name,
+                kind="method" if effective_parent else "function",
+                file=filepath,
+                start_line=node.start_point[0] + 1,
+                end_line=node.end_point[0] + 1,
+                parent_class=effective_parent,
+                calls=list(set(calls)),
+            )
+        )
+
+    def _visit_type(node) -> None:
+        type_name = _cpp_type_name(node)
+        if not type_name:
+            return
+
+        known_types.add(type_name)
+        symbols.append(
+            Symbol(
+                name=type_name,
+                kind="class",
+                file=filepath,
+                start_line=node.start_point[0] + 1,
+                end_line=node.end_point[0] + 1,
+            )
+        )
+
+        body = _cpp_container_body(node)
+        if body is None:
+            return
+
+        for child in body.named_children:
+            if child.type == "function_definition":
+                _add_function(child, parent_class=type_name)
+            elif child.type in _CPP_TYPE_NODES:
+                _visit_type(child)
+
+    def _walk_container(node) -> None:
+        for child in node.named_children:
+            if child.type == "namespace_definition":
+                body = _cpp_container_body(child)
+                _walk_container(body if body is not None else child)
+            elif child.type in _CPP_TYPE_NODES:
+                _visit_type(child)
+            elif child.type == "function_definition":
+                _add_function(child)
+
+    _walk_container(root)
+    return symbols
+
+
+def _extract_imports_cpp(root) -> list[ImportInfo]:
+    """Extract ``#include`` directives from a C++ parse tree."""
+    imports: list[ImportInfo] = []
+
+    for child in root.named_children:
+        if child.type != "preproc_include":
+            continue
+        path_node = child.child_by_field_name("path")
+        if path_node is None:
+            path_node = next(
+                (
+                    node
+                    for node in child.named_children
+                    if node.type in {"string_literal", "system_lib_string"}
+                ),
+                None,
+            )
+        if path_node is None:
+            continue
+        include_path = _strip_include_delimiters(_text(path_node))
+        if not include_path:
+            continue
+        parts = include_path.split("/")
+        imports.append(
+            ImportInfo(
+                file="",
+                module="/".join(parts[:-1]),
+                name=parts[-1],
+                alias=None,
+                is_from=True,
+            )
+        )
+    return imports
+
+
 # ---------------------------------------------------------------------------
 # Multi-language parse_file
 # ---------------------------------------------------------------------------
@@ -2339,7 +2570,7 @@ def parse_file(filepath: Path) -> FileParseResult:
 
     Detects language from file extension and dispatches to the correct
     tree-sitter grammar. Supports Python, TypeScript/JavaScript, Rust, Go,
-    Java, C#, Ruby, PHP, and C.
+    Java, C#, Ruby, C, C++, and PHP.
     """
     code = filepath.read_bytes()
     lang_name = _detect_language(filepath)
@@ -2370,6 +2601,8 @@ def parse_file(filepath: Path) -> FileParseResult:
 
     elif lang_name == "csharp":
         symbols = _extract_symbols_csharp(root, filename)
+    elif lang_name == "cpp":
+        symbols = _extract_symbols_cpp(root, filename)
 
     elif lang_name == "ruby":
         symbols = _extract_symbols_ruby(root, filename)
@@ -2393,6 +2626,8 @@ def parse_file(filepath: Path) -> FileParseResult:
         imports = _extract_imports_java(root)
     elif lang_name == "csharp":
         imports = _extract_imports_csharp(root)
+    elif lang_name == "cpp":
+        imports = _extract_imports_cpp(root)
     elif lang_name == "ruby":
         imports = _extract_imports_ruby(root)
     elif lang_name == "c":

--- a/packages/gptme-codegraph/src/gptme_codegraph/core.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/core.py
@@ -2526,12 +2526,25 @@ def _extract_symbols_cpp(root, filepath: str) -> list[Symbol]:
 
 
 def _extract_imports_cpp(root) -> list[ImportInfo]:
-    """Extract ``#include`` directives from a C++ parse tree."""
+    """Extract ``#include`` directives from a C++ parse tree.
+
+    Walks recursively through preprocessor conditionals (``#ifdef``, ``#ifndef``,
+    ``#if``, ``#elif``, ``#else``) so that platform-specific or feature-guarded
+    includes are not silently dropped.
+    """
     imports: list[ImportInfo] = []
 
-    for child in root.named_children:
-        if child.type != "preproc_include":
-            continue
+    _PREPROC_WRAPPER = frozenset(
+        {
+            "preproc_ifdef",
+            "preproc_ifndef",
+            "preproc_if",
+            "preproc_elif",
+            "preproc_else",
+        }
+    )
+
+    def _extract_include(child) -> None:
         path_node = child.child_by_field_name("path")
         if path_node is None:
             path_node = next(
@@ -2543,10 +2556,10 @@ def _extract_imports_cpp(root) -> list[ImportInfo]:
                 None,
             )
         if path_node is None:
-            continue
+            return
         include_path = _strip_include_delimiters(_text(path_node))
         if not include_path:
-            continue
+            return
         parts = include_path.split("/")
         imports.append(
             ImportInfo(
@@ -2557,6 +2570,15 @@ def _extract_imports_cpp(root) -> list[ImportInfo]:
                 is_from=True,
             )
         )
+
+    def _walk(node) -> None:
+        for child in node.named_children:
+            if child.type in _PREPROC_WRAPPER:
+                _walk(child)
+            elif child.type == "preproc_include":
+                _extract_include(child)
+
+    _walk(root)
     return imports
 
 

--- a/packages/gptme-codegraph/tests/test_multilang.py
+++ b/packages/gptme-codegraph/tests/test_multilang.py
@@ -1,7 +1,7 @@
-"""Tests for multi-language support in gptme-codegraph (JS/TS, Rust, Go, Java, C#, Ruby).
+"""Tests for multi-language support in gptme-codegraph (JS/TS, Rust, Go, Java, C#, Ruby, C++).
 
 Verifies that parse_file, extract_symbols, and build_index work correctly
-for JavaScript, TypeScript, Rust, Go, Java, C#, and Ruby source files.
+for JavaScript, TypeScript, Rust, Go, Java, C#, Ruby, and C++ source files.
 """
 
 from __future__ import annotations
@@ -49,6 +49,10 @@ _skip_no_java = pytest.mark.skipif(
 _skip_no_csharp = pytest.mark.skipif(
     not _has_grammar("c_sharp"),
     reason="tree-sitter-c-sharp not installed",
+)
+_skip_no_cpp = pytest.mark.skipif(
+    not _has_grammar("cpp"),
+    reason="tree-sitter-cpp not installed",
 )
 _skip_no_ruby = pytest.mark.skipif(
     not _has_grammar("ruby"),
@@ -1138,6 +1142,39 @@ namespace Example.App
     path.unlink(missing_ok=True)
 
 
+@pytest.fixture
+def cpp_module() -> Generator[Path, None, None]:
+    """A C++ file with includes, namespace, class, methods, and free functions."""
+    code = """\
+#include <vector>
+#include "widget.hpp"
+
+namespace math {
+class Accumulator {
+public:
+    Accumulator() {}
+    int add(int x);
+    static int helper(int x) { return x; }
+};
+
+int scale(int x) { return x * 2; }
+
+int Accumulator::add(int x) {
+    return helper(x) + scale(x);
+}
+}
+
+int free_fn(int n) {
+    return math::Accumulator::helper(n);
+}
+"""
+    with tempfile.NamedTemporaryFile(suffix=".cpp", mode="w", delete=False) as f:
+        f.write(code)
+        path = Path(f.name)
+    yield path
+    path.unlink(missing_ok=True)
+
+
 # ---------------------------------------------------------------------------
 # Ruby fixtures + tests
 # ---------------------------------------------------------------------------
@@ -1392,6 +1429,7 @@ def test_parse_ruby_line_numbers(ruby_module: Path):
 @_skip_no_ruby
 def test_build_index_ruby(ruby_module: Path):
     """Ruby: build_index picks up symbols from a .rb file."""
+
     import shutil
     import tempfile
 
@@ -1547,6 +1585,92 @@ def test_parse_c_imports_local(c_module: Path):
 def test_parse_c_line_numbers(c_module: Path):
     """C: symbol line numbers are positive and ordered."""
     result = parse_file(c_module)
+# ---------------------------------------------------------------------------
+# C++
+# ---------------------------------------------------------------------------
+
+
+@_skip_no_cpp
+def test_language_detection_cpp(cpp_module: Path):
+    """C++: .cpp files are detected as the cpp language."""
+    result = parse_file(cpp_module)
+    assert result.language == "cpp"
+
+
+@_skip_no_cpp
+def test_language_detection_cpp_header(tmp_path: Path):
+    """C++: .h headers are treated as C++ source files."""
+    header = tmp_path / "widget.h"
+    header.write_text("class Widget {};\n")
+
+    result = parse_file(header)
+
+    assert result.language == "cpp"
+    assert any(sym.name == "Widget" for sym in result.symbols)
+
+
+@_skip_no_cpp
+def test_parse_cpp_class_and_functions(cpp_module: Path):
+    """C++: class and top-level functions are extracted."""
+    result = parse_file(cpp_module)
+
+    classes = {s.name for s in result.symbols if s.kind == "class"}
+    assert "Accumulator" in classes
+
+    functions = {s.name for s in result.symbols if s.kind == "function"}
+    assert "scale" in functions
+    assert "free_fn" in functions
+
+
+@_skip_no_cpp
+def test_parse_cpp_methods(cpp_module: Path):
+    """C++: inline and out-of-class methods carry their parent class."""
+    result = parse_file(cpp_module)
+    methods = [s for s in result.symbols if s.kind == "method"]
+    method_names = {s.name for s in methods}
+
+    assert "Accumulator" in method_names
+    assert "add" in method_names
+    assert "helper" in method_names
+
+    add = next((s for s in methods if s.name == "add"), None)
+    assert add is not None
+    assert add.parent_class == "Accumulator"
+
+
+@_skip_no_cpp
+def test_parse_cpp_calls(cpp_module: Path):
+    """C++: call_expression nodes are extracted from methods and functions."""
+    result = parse_file(cpp_module)
+
+    add = next((s for s in result.symbols if s.name == "add"), None)
+    assert add is not None
+    assert "helper" in add.calls
+    assert "scale" in add.calls
+
+    free_fn = next((s for s in result.symbols if s.name == "free_fn"), None)
+    assert free_fn is not None
+    assert "math::Accumulator::helper" in free_fn.calls
+
+
+@_skip_no_cpp
+def test_parse_cpp_imports(cpp_module: Path):
+    """C++: #include directives resolve to import records."""
+    result = parse_file(cpp_module)
+
+    vector = next((i for i in result.imports if i.name == "vector"), None)
+    assert vector is not None
+    assert vector.module == ""
+
+    widget = next((i for i in result.imports if i.name == "widget.hpp"), None)
+    assert widget is not None
+    assert widget.module == ""
+
+
+@_skip_no_cpp
+def test_parse_cpp_line_numbers(cpp_module: Path):
+    """C++: symbol line numbers are positive and ordered."""
+    result = parse_file(cpp_module)
     assert result.symbols
     for sym in result.symbols:
         assert sym.start_line >= 1
@@ -1919,3 +2043,16 @@ function processItems(array $items): void {
 
 
 # ---------------------------------------------------------------------------
+
+@_skip_no_cpp
+def test_build_index_cpp(cpp_module: Path):
+    """C++: build_index picks up symbols from a .cpp file."""
+    import shutil
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as d:
+        dest = Path(d) / cpp_module.name
+        shutil.copy(cpp_module, dest)
+        index = build_index(d)
+        assert "Accumulator" in index.entries
+        assert "add" in index.entries

--- a/packages/gptme-codegraph/tests/test_multilang.py
+++ b/packages/gptme-codegraph/tests/test_multilang.py
@@ -1585,6 +1585,12 @@ def test_parse_c_imports_local(c_module: Path):
 def test_parse_c_line_numbers(c_module: Path):
     """C: symbol line numbers are positive and ordered."""
     result = parse_file(c_module)
+    assert result.symbols
+    for sym in result.symbols:
+        assert sym.start_line >= 1
+        assert sym.end_line >= sym.start_line
+
+
 # ---------------------------------------------------------------------------
 # C++
 # ---------------------------------------------------------------------------
@@ -1675,6 +1681,45 @@ def test_parse_cpp_line_numbers(cpp_module: Path):
     for sym in result.symbols:
         assert sym.start_line >= 1
         assert sym.end_line >= sym.start_line
+
+
+@pytest.fixture
+def cpp_conditional_module() -> Generator[Path, None, None]:
+    """A C++ file with preprocessor-conditional includes and a conditionally-compiled class."""
+    code = """\
+#include <vector>
+#ifdef _WIN32
+#include <windows.h>
+#endif
+#ifndef NO_EXTRA
+#include <extra.hpp>
+#endif
+#if defined(FEATURE_X)
+#include <feature.hpp>
+class FeatureX {};
+#endif
+#ifdef USE_WIDGET
+class Widget {};
+#endif
+class Base {};
+"""
+    with tempfile.NamedTemporaryFile(suffix=".cpp", mode="w", delete=False) as f:
+        f.write(code)
+        path = Path(f.name)
+    yield path
+    path.unlink(missing_ok=True)
+
+
+@_skip_no_cpp
+def test_parse_cpp_preprocessor_conditional(cpp_conditional_module: Path):
+    """C++: #include inside #ifdef/#ifndef/#if is extracted via recursive walk."""
+    result = parse_file(cpp_conditional_module)
+
+    import_names = {i.name for i in result.imports}
+    assert "vector" in import_names, "top-level include missing"
+    assert "windows.h" in import_names, "#ifdef-guarded include missing"
+    assert "extra.hpp" in import_names, "#ifndef-guarded include missing"
+    assert "feature.hpp" in import_names, "#if defined(...)-guarded include missing"
 
 
 @_skip_no_c
@@ -2043,7 +2088,6 @@ function processItems(array $items): void {
 
 
 # ---------------------------------------------------------------------------
-
 @_skip_no_cpp
 def test_build_index_cpp(cpp_module: Path):
     """C++: build_index picks up symbols from a .cpp file."""

--- a/uv.lock
+++ b/uv.lock
@@ -1348,6 +1348,7 @@ treesitter = [
     { name = "tree-sitter" },
     { name = "tree-sitter-c" },
     { name = "tree-sitter-c-sharp" },
+    { name = "tree-sitter-cpp" },
     { name = "tree-sitter-go" },
     { name = "tree-sitter-java" },
     { name = "tree-sitter-javascript" },
@@ -1366,6 +1367,7 @@ requires-dist = [
     { name = "tree-sitter", marker = "extra == 'treesitter'", specifier = ">=0.21.0" },
     { name = "tree-sitter-c", marker = "extra == 'treesitter'", specifier = ">=0.23.0" },
     { name = "tree-sitter-c-sharp", marker = "extra == 'treesitter'", specifier = ">=0.23.0" },
+    { name = "tree-sitter-cpp", marker = "extra == 'treesitter'", specifier = ">=0.23.0" },
     { name = "tree-sitter-go", marker = "extra == 'treesitter'", specifier = ">=0.23.0" },
     { name = "tree-sitter-java", marker = "extra == 'treesitter'", specifier = ">=0.23.0" },
     { name = "tree-sitter-javascript", marker = "extra == 'treesitter'", specifier = ">=0.21.0" },
@@ -5132,6 +5134,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/de/2a/6c3e12ef0cf09138717fcc02e1de8b76a3928d1bed65c7e3c2bd3172bcef/tree_sitter_c_sharp-0.23.5-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8636dc70b5a373c35c1036ed5de98e801f2e4d105ae41e2e20b6804c36e3bf33", size = 357525, upload-time = "2026-04-14T16:11:18.214Z" },
     { url = "https://files.pythonhosted.org/packages/2b/e0/bd287b092d611df95a9149117fd27b5947ce75527113d6898a4b4e2c8858/tree_sitter_c_sharp-0.23.5-cp310-abi3-win_amd64.whl", hash = "sha256:41a28cfa3d9ea50f5629e44550a03188c8fbd5079803dfc03554b6fd594b33fa", size = 338756, upload-time = "2026-04-14T16:11:19.661Z" },
     { url = "https://files.pythonhosted.org/packages/7f/fb/114ff43fdd256d0befed32f77c1dadee9517867181c70794571f718ed05c/tree_sitter_c_sharp-0.23.5-cp310-abi3-win_arm64.whl", hash = "sha256:2de4ebf95ddc2e92cd3105c8a8e0e7ec646bc82f52bfaf2f3acec0fa2401ec09", size = 337260, upload-time = "2026-04-14T16:11:20.849Z" },
+]
+
+[[package]]
+name = "tree-sitter-cpp"
+version = "0.23.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/2c/4dd63d705a8933543cad9b92ff31be849b164fec91a6eb63475ebc9ce668/tree_sitter_cpp-0.23.4.tar.gz", hash = "sha256:6a59c4cebb1ad1dc2e8d586cf8a72b39d21b8108b7b139d089719e81a339e41d", size = 940358, upload-time = "2024-11-11T06:59:24.934Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/ac/11d56670f7b048362db872ca866fd00ba2002a322ab179f047b7c0fb2910/tree_sitter_cpp-0.23.4-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:aacb1759f0efd9dbc25bd8ee88184a340483018869f75412d9c3bc32c039a520", size = 287861, upload-time = "2024-11-11T06:59:15.005Z" },
+    { url = "https://files.pythonhosted.org/packages/12/1c/0337c016bdc00a77a3326d12f10ee836401dd28f27db6fd5b7734bfb21ed/tree_sitter_cpp-0.23.4-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:bc3c404d9f0cbd87951213a85440afbf4c31e718f8d907fa9ee12bea4b8d276f", size = 315513, upload-time = "2024-11-11T06:59:16.679Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7b/dd38c049b10ed7fda118b903a1d28a8b55a36b98c30606ef90e8f374c6de/tree_sitter_cpp-0.23.4-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ccc43ddf1279d5d5a4ef190373f4cb16522801bec4492bcd4754edf2aeba2b7b", size = 334813, upload-time = "2024-11-11T06:59:18.253Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/4d/23e390234d2acd351f5563b1079c515d7c1fe13ddb7392cee543be74dda3/tree_sitter_cpp-0.23.4-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:773d2cafc08bbc0f998687fa33f42f378c1a371cdb582870c4d13abb06092706", size = 316110, upload-time = "2024-11-11T06:59:19.823Z" },
+    { url = "https://files.pythonhosted.org/packages/32/c7/b94a7e0e803af9d3bd4608fb4f0cfb2e9e233abaf0a38c928bfb0b1a025d/tree_sitter_cpp-0.23.4-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:247d127f0eb6574b0f6b30c0151e0bd0774e2e7acf9c558bdf9fbb8adc2e80c0", size = 308242, upload-time = "2024-11-11T06:59:21.466Z" },
+    { url = "https://files.pythonhosted.org/packages/37/7e/909e52b3dec09c475140b0e175511e275d0d00ba2dbd7c68102d377ae0f6/tree_sitter_cpp-0.23.4-cp39-abi3-win_amd64.whl", hash = "sha256:68606a45bea92669d155399e1239f771a7767d8683cd8f8e30e7d813107030ca", size = 290997, upload-time = "2024-11-11T06:59:22.432Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/6a/65435d4d1f4c735be7ffe52d7c2e7b8a7f7c2790343a2719c60c548611c8/tree_sitter_cpp-0.23.4-cp39-abi3-win_arm64.whl", hash = "sha256:712f84f18be94cbe2a148fa4fdf40fcf4a8c25a8f7670efb9f8a47ddec2fc281", size = 288203, upload-time = "2024-11-11T06:59:23.404Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add `cpp` language detection and load `tree-sitter-cpp`
- extract C++ classes, methods, functions, and `#include` imports
- add focused multilang tests for parsing, calls, imports, and indexing

## Verification
- uv run --package gptme-codegraph --extra treesitter pytest packages/gptme-codegraph/tests -q
- uv run mypy packages/gptme-codegraph/src/gptme_codegraph/core.py --ignore-missing-imports
- uv run ruff check packages/gptme-codegraph/src/gptme_codegraph/core.py packages/gptme-codegraph/tests/test_multilang.py