### PR TITLE
feat(codegraph): add PHP language support (symbol + import extraction)

### DIFF
--- a/packages/gptme-codegraph/pyproject.toml
+++ b/packages/gptme-codegraph/pyproject.toml
@@ -21,6 +21,7 @@ treesitter = [
     "tree-sitter-c-sharp>=0.23.0",
     "tree-sitter-ruby>=0.23.0",
     "tree-sitter-c>=0.23.0",
+    "tree-sitter-php>=0.24.0",
 ]
 mcp = [
     "mcp>=1.0.0",

--- a/packages/gptme-codegraph/src/gptme_codegraph/core.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/core.py
@@ -765,8 +765,8 @@ def _extract_calls(node) -> list[str]:
                 if name_node:
                     calls.append(_text(name_node))
             elif cursor.node.type == "function_call_expression":
-                # PHP: function_call_expression has a "name" child
-                name_node = cursor.node.child_by_field_name("name")
+                # PHP: callee is the "function" field (not "name")
+                name_node = cursor.node.child_by_field_name("function")
                 if name_node:
                     calls.append(_text(name_node))
             elif cursor.node.type == "member_call_expression":

--- a/packages/gptme-codegraph/src/gptme_codegraph/core.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/core.py
@@ -3,7 +3,7 @@
 Complementary to gptme-rag (text chunks), this retrieves code *structure*:
 function/class definitions, call graphs, and blast radius.
 
-Supports Python, TypeScript/JavaScript, Rust, Go, Java, C#, Ruby, and C via tree-sitter
+Supports Python, TypeScript/JavaScript, Rust, Go, Java, C#, Ruby, C, and PHP via tree-sitter
 grammars.
 To add a new language: add grammar dep to pyproject.toml, extend _LANG_MAP
 and _load_language, then add extractor functions.
@@ -50,6 +50,7 @@ _LANG_MAP: dict[str, str] = {
     ".java": "java",
     ".cs": "csharp",
     ".rb": "ruby",
+    ".php": "php",
     ".c": "c",
     ".h": "c",
 }
@@ -65,6 +66,7 @@ _GRAMMAR_MODULES: dict[str, str] = {
     "java": "tree_sitter_java",
     "csharp": "tree_sitter_c_sharp",
     "ruby": "tree_sitter_ruby",
+    "php": "tree_sitter_php",
     "c": "tree_sitter_c",
 }
 
@@ -158,6 +160,12 @@ def _load_language(name: str):
         import tree_sitter_c as tsc  # type: ignore[import-not-found,unused-ignore]
 
         grammar_map["c"] = tsc.language()
+    except ImportError:
+        pass
+    try:
+        import tree_sitter_php as tsphp  # type: ignore[import-not-found,unused-ignore]
+
+        grammar_map["php"] = tsphp.language_php()
     except ImportError:
         pass
 
@@ -756,6 +764,21 @@ def _extract_calls(node) -> list[str]:
                 name_node = cursor.node.child_by_field_name("name")
                 if name_node:
                     calls.append(_text(name_node))
+            elif cursor.node.type == "function_call_expression":
+                # PHP: function_call_expression has a "name" child
+                name_node = cursor.node.child_by_field_name("name")
+                if name_node:
+                    calls.append(_text(name_node))
+            elif cursor.node.type == "member_call_expression":
+                # PHP: $obj->method() — method name is the second "name" child
+                names = [c for c in cursor.node.named_children if c.type == "name"]
+                if len(names) >= 2:
+                    calls.append(_text(names[-1]))
+            elif cursor.node.type == "scoped_call_expression":
+                # PHP: Class::method() — method name is the second "name" child
+                names = [c for c in cursor.node.named_children if c.type == "name"]
+                if names:
+                    calls.append(_text(names[-1]))
             if cursor.goto_first_child():
                 continue
             if cursor.goto_next_sibling():
@@ -2123,6 +2146,150 @@ def _extract_imports_c(root) -> list[ImportInfo]:
 
 
 # ---------------------------------------------------------------------------
+# PHP extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_symbols_php(root, filepath: str) -> list[Symbol]:
+    """Extract classes, interfaces, traits, methods, and functions from a PHP parse tree."""
+    symbols: list[Symbol] = []
+
+    def _extract_method_body(body_node, parent_class: str) -> None:
+        for child in body_node.named_children:
+            if child.type == "method_declaration":
+                name_node = child.child_by_field_name("name")
+                if name_node:
+                    body = child.child_by_field_name("body")
+                    calls = _extract_calls(body) if body else []
+                    symbols.append(
+                        Symbol(
+                            name=_text(name_node),
+                            kind="method",
+                            file=filepath,
+                            start_line=child.start_point[0] + 1,
+                            end_line=child.end_point[0] + 1,
+                            parent_class=parent_class,
+                            calls=list(set(calls)),
+                        )
+                    )
+
+    for node in root.named_children:
+        if node.type == "function_definition":
+            name_node = node.child_by_field_name("name")
+            if name_node:
+                body = node.child_by_field_name("body")
+                calls = _extract_calls(body) if body else []
+                symbols.append(
+                    Symbol(
+                        name=_text(name_node),
+                        kind="function",
+                        file=filepath,
+                        start_line=node.start_point[0] + 1,
+                        end_line=node.end_point[0] + 1,
+                        calls=list(set(calls)),
+                    )
+                )
+
+        elif node.type in {
+            "class_declaration",
+            "interface_declaration",
+            "trait_declaration",
+        }:
+            name_node = node.child_by_field_name("name")
+            if name_node:
+                class_name = _text(name_node)
+                symbols.append(
+                    Symbol(
+                        name=class_name,
+                        kind="class",
+                        file=filepath,
+                        start_line=node.start_point[0] + 1,
+                        end_line=node.end_point[0] + 1,
+                    )
+                )
+                body = node.child_by_field_name("body")
+                if body:
+                    _extract_method_body(body, parent_class=class_name)
+
+    return symbols
+
+
+def _extract_imports_php(root) -> list[ImportInfo]:
+    """Extract ``use`` import declarations from a PHP parse tree.
+
+    Handles:
+    - use App\\Entity\\User;
+    - use App\\Util\\Helper as H;
+    - use function array_map;
+    - use const PHP_EOL;
+    - use App\\Entity\\{User, Group};   (group use declarations)
+    """
+    imports: list[ImportInfo] = []
+
+    for child in root.named_children:
+        if child.type != "namespace_use_declaration":
+            continue
+
+        # Simple use: single clause
+        clause = next(
+            (c for c in child.named_children if c.type == "namespace_use_clause"),
+            None,
+        )
+        if clause:
+            # Check if this is a function/const import (use function X / use const X)
+            is_fn_const = any(c.type in {"function", "const"} for c in clause.children)
+            if is_fn_const:
+                name_node = next(
+                    (c for c in clause.named_children if c.type == "name"),
+                    None,
+                )
+                if name_node:
+                    imports.append(
+                        ImportInfo(
+                            file="",
+                            module="",
+                            name=_text(name_node),
+                            alias=None,
+                            is_from=True,
+                        )
+                    )
+                continue
+
+            qual = next(
+                (c for c in clause.named_children if c.type == "qualified_name"),
+                None,
+            )
+            if qual is None:
+                continue
+            qualified = _text(qual)
+            if not qualified:
+                continue
+
+            module = ""
+            name = qualified
+            dot = qualified.rfind("\\")
+            if dot >= 0:
+                module = qualified[:dot]
+                name = qualified[dot + 1 :]
+
+            alias = clause.child_by_field_name("alias")
+            alias_text = _text(alias) if alias else None
+
+            imports.append(
+                ImportInfo(
+                    file="",
+                    module=module,
+                    name=name,
+                    alias=alias_text,
+                    is_from=True,
+                )
+            )
+            continue
+
+    return imports
+
+
+# ---------------------------------------------------------------------------
 # Multi-language parse_file
 # ---------------------------------------------------------------------------
 
@@ -2132,7 +2299,7 @@ def parse_file(filepath: Path) -> FileParseResult:
 
     Detects language from file extension and dispatches to the correct
     tree-sitter grammar. Supports Python, TypeScript/JavaScript, Rust, Go,
-    Java, C#, Ruby, and C.
+    Java, C#, Ruby, PHP, and C.
     """
     code = filepath.read_bytes()
     lang_name = _detect_language(filepath)
@@ -2170,6 +2337,9 @@ def parse_file(filepath: Path) -> FileParseResult:
     elif lang_name == "c":
         symbols = _extract_symbols_c(root, filename)
 
+    elif lang_name == "php":
+        symbols = _extract_symbols_php(root, filename)
+
     imports: list[ImportInfo] = []
     if lang_name == "python":
         imports = _extract_imports(root)
@@ -2187,6 +2357,8 @@ def parse_file(filepath: Path) -> FileParseResult:
         imports = _extract_imports_ruby(root)
     elif lang_name == "c":
         imports = _extract_imports_c(root)
+    elif lang_name == "php":
+        imports = _extract_imports_php(root)
 
     for imp in imports:
         imp.file = filename

--- a/packages/gptme-codegraph/src/gptme_codegraph/core.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/core.py
@@ -770,10 +770,10 @@ def _extract_calls(node) -> list[str]:
                 if name_node:
                     calls.append(_text(name_node))
             elif cursor.node.type == "member_call_expression":
-                # PHP: $obj->method() — method name is the second "name" child
-                names = [c for c in cursor.node.named_children if c.type == "name"]
-                if len(names) >= 2:
-                    calls.append(_text(names[-1]))
+                # PHP: $obj->method() — object is variable_name, method is the "name" field
+                name_node = cursor.node.child_by_field_name("name")
+                if name_node:
+                    calls.append(_text(name_node))
             elif cursor.node.type == "scoped_call_expression":
                 # PHP: Class::method() — method name is the second "name" child
                 names = [c for c in cursor.node.named_children if c.type == "name"]
@@ -2285,6 +2285,53 @@ def _extract_imports_php(root) -> list[ImportInfo]:
                 )
             )
             continue
+
+        # Group use: use App\Entity\{User, Group};
+        group = next(
+            (c for c in child.named_children if c.type == "namespace_use_group"),
+            None,
+        )
+        if group:
+            prefix_node = next(
+                (c for c in child.named_children if c.type == "namespace_name"),
+                None,
+            )
+            prefix = _text(prefix_node) if prefix_node else ""
+            for clause in group.named_children:
+                if clause.type != "namespace_use_clause":
+                    continue
+                qual = next(
+                    (
+                        c
+                        for c in clause.named_children
+                        if c.type in {"qualified_name", "name"}
+                    ),
+                    None,
+                )
+                if qual is None:
+                    continue
+                qualified = _text(qual)
+                if not qualified:
+                    continue
+                module = prefix
+                name = qualified
+                dot = qualified.rfind("\\")
+                if dot >= 0:
+                    module = (
+                        prefix + "\\" + qualified[:dot] if prefix else qualified[:dot]
+                    )
+                    name = qualified[dot + 1 :]
+                alias = clause.child_by_field_name("alias")
+                alias_text = _text(alias) if alias else None
+                imports.append(
+                    ImportInfo(
+                        file="",
+                        module=module,
+                        name=name,
+                        alias=alias_text,
+                        is_from=True,
+                    )
+                )
 
     return imports
 

--- a/packages/gptme-codegraph/src/gptme_codegraph/core.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/core.py
@@ -2173,7 +2173,7 @@ def _extract_symbols_php(root, filepath: str) -> list[Symbol]:
                         )
                     )
 
-    for node in root.named_children:
+    def _walk(node) -> None:
         if node.type == "function_definition":
             name_node = node.child_by_field_name("name")
             if name_node:
@@ -2189,8 +2189,9 @@ def _extract_symbols_php(root, filepath: str) -> list[Symbol]:
                         calls=list(set(calls)),
                     )
                 )
+            return
 
-        elif node.type in {
+        if node.type in {
             "class_declaration",
             "interface_declaration",
             "trait_declaration",
@@ -2210,8 +2211,24 @@ def _extract_symbols_php(root, filepath: str) -> list[Symbol]:
                 body = node.child_by_field_name("body")
                 if body:
                     _extract_method_body(body, parent_class=class_name)
+            return
 
+        for child in node.named_children:
+            _walk(child)
+
+    _walk(root)
     return symbols
+
+
+def _split_php_import_name(qualified: str, prefix: str = "") -> tuple[str, str]:
+    """Split a PHP import target into ``(module, name)`` pieces."""
+    module = prefix
+    name = qualified
+    dot = qualified.rfind("\\")
+    if dot >= 0:
+        module = prefix + "\\" + qualified[:dot] if prefix else qualified[:dot]
+        name = qualified[dot + 1 :]
+    return module, name
 
 
 def _extract_imports_php(root) -> list[ImportInfo]:
@@ -2226,113 +2243,89 @@ def _extract_imports_php(root) -> list[ImportInfo]:
     """
     imports: list[ImportInfo] = []
 
-    for child in root.named_children:
-        if child.type != "namespace_use_declaration":
-            continue
-
-        # Simple use: single clause
-        clause = next(
-            (c for c in child.named_children if c.type == "namespace_use_clause"),
-            None,
-        )
-        if clause:
-            # Check if this is a function/const import (use function X / use const X)
-            is_fn_const = any(c.type in {"function", "const"} for c in clause.children)
-            if is_fn_const:
-                name_node = next(
-                    (c for c in clause.named_children if c.type == "name"),
-                    None,
-                )
-                if name_node:
-                    imports.append(
-                        ImportInfo(
-                            file="",
-                            module="",
-                            name=_text(name_node),
-                            alias=None,
-                            is_from=True,
-                        )
-                    )
-                continue
-
-            qual = next(
-                (c for c in clause.named_children if c.type == "qualified_name"),
+    def _walk(node) -> None:
+        if node.type == "namespace_use_declaration":
+            clause = next(
+                (c for c in node.named_children if c.type == "namespace_use_clause"),
                 None,
             )
-            if qual is None:
-                continue
-            qualified = _text(qual)
-            if not qualified:
-                continue
-
-            module = ""
-            name = qualified
-            dot = qualified.rfind("\\")
-            if dot >= 0:
-                module = qualified[:dot]
-                name = qualified[dot + 1 :]
-
-            alias = clause.child_by_field_name("alias")
-            alias_text = _text(alias) if alias else None
-
-            imports.append(
-                ImportInfo(
-                    file="",
-                    module=module,
-                    name=name,
-                    alias=alias_text,
-                    is_from=True,
+            if clause:
+                is_fn_const = any(
+                    child.type in {"function", "const"} for child in clause.children
                 )
-            )
-            continue
-
-        # Group use: use App\Entity\{User, Group};
-        group = next(
-            (c for c in child.named_children if c.type == "namespace_use_group"),
-            None,
-        )
-        if group:
-            prefix_node = next(
-                (c for c in child.named_children if c.type == "namespace_name"),
-                None,
-            )
-            prefix = _text(prefix_node) if prefix_node else ""
-            for clause in group.named_children:
-                if clause.type != "namespace_use_clause":
-                    continue
                 qual = next(
                     (
-                        c
-                        for c in clause.named_children
-                        if c.type in {"qualified_name", "name"}
+                        child
+                        for child in clause.named_children
+                        if child.type in {"qualified_name", "name"}
                     ),
                     None,
                 )
-                if qual is None:
-                    continue
-                qualified = _text(qual)
-                if not qualified:
-                    continue
-                module = prefix
-                name = qualified
-                dot = qualified.rfind("\\")
-                if dot >= 0:
-                    module = (
-                        prefix + "\\" + qualified[:dot] if prefix else qualified[:dot]
-                    )
-                    name = qualified[dot + 1 :]
-                alias = clause.child_by_field_name("alias")
-                alias_text = _text(alias) if alias else None
-                imports.append(
-                    ImportInfo(
-                        file="",
-                        module=module,
-                        name=name,
-                        alias=alias_text,
-                        is_from=True,
-                    )
-                )
+                if qual is not None:
+                    qualified = _text(qual)
+                    if qualified:
+                        module, name = _split_php_import_name(qualified)
+                        alias = clause.child_by_field_name("alias")
+                        alias_text = _text(alias) if alias else None
+                        imports.append(
+                            ImportInfo(
+                                file="",
+                                module=module,
+                                name=name,
+                                alias=alias_text,
+                                is_from=True,
+                            )
+                        )
+                        if is_fn_const:
+                            return
+                if is_fn_const:
+                    return
 
+            # Group use: use App\Entity\{User, Group};
+            group = next(
+                (c for c in node.named_children if c.type == "namespace_use_group"),
+                None,
+            )
+            if group:
+                prefix_node = next(
+                    (c for c in node.named_children if c.type == "namespace_name"),
+                    None,
+                )
+                prefix = _text(prefix_node) if prefix_node else ""
+                for clause in group.named_children:
+                    if clause.type != "namespace_use_clause":
+                        continue
+                    qual = next(
+                        (
+                            child
+                            for child in clause.named_children
+                            if child.type in {"qualified_name", "name"}
+                        ),
+                        None,
+                    )
+                    if qual is None:
+                        continue
+                    qualified = _text(qual)
+                    if not qualified:
+                        continue
+                    module, name = _split_php_import_name(qualified, prefix=prefix)
+                    alias = clause.child_by_field_name("alias")
+                    alias_text = _text(alias) if alias else None
+                    imports.append(
+                        ImportInfo(
+                            file="",
+                            module=module,
+                            name=name,
+                            alias=alias_text,
+                            is_from=True,
+                        )
+                    )
+            return
+
+        for child in node.named_children:
+            _walk(child)
+
+    _walk(root)
     return imports
 
 

--- a/packages/gptme-codegraph/tests/test_multilang.py
+++ b/packages/gptme-codegraph/tests/test_multilang.py
@@ -1806,4 +1806,44 @@ def test_build_index_php(php_module: Path):
         assert index.lookup("helper"), "helper not found in index"
 
 
+@_skip_no_php
+def test_parse_php_method_calls(tmp_path: Path):
+    """PHP: -> method calls are extracted from method bodies."""
+    code = """<?php
+class Worker {
+    public function run(): void {
+        $calc = new Calculator();
+        $calc->add(5);
+        $this->getValue();
+        Calculator::create(10);
+    }
+}
+"""
+    php_file = tmp_path / "worker.php"
+    php_file.write_text(code)
+    result = parse_file(php_file)
+    run_method = next(s for s in result.symbols if s.name == "run")
+    assert "add" in run_method.calls, f"Expected 'add' in calls, got {run_method.calls}"
+    assert (
+        "getValue" in run_method.calls
+    ), f"Expected 'getValue' in calls, got {run_method.calls}"
+    assert (
+        "create" in run_method.calls
+    ), f"Expected 'create' in calls, got {run_method.calls}"
+
+
+@_skip_no_php
+def test_parse_php_group_use(tmp_path: Path):
+    """PHP: group use declarations (use Ns\\{A, B}) are extracted."""
+    code = """<?php
+use App\\Entity\\{User, Group};
+"""
+    php_file = tmp_path / "group_use.php"
+    php_file.write_text(code)
+    result = parse_file(php_file)
+    import_names = {imp.name for imp in result.imports}
+    assert "User" in import_names, f"Expected 'User' in imports, got {import_names}"
+    assert "Group" in import_names, f"Expected 'Group' in imports, got {import_names}"
+
+
 # ---------------------------------------------------------------------------

--- a/packages/gptme-codegraph/tests/test_multilang.py
+++ b/packages/gptme-codegraph/tests/test_multilang.py
@@ -1897,4 +1897,25 @@ namespace Foo {
     ) in import_names, f"Expected User import, got {import_names}"
 
 
+@_skip_no_php
+def test_parse_php_function_call_expressions(tmp_path: Path):
+    """PHP: standalone function calls (function_call_expression) are extracted from call graph."""
+    code = """<?php
+function processItems(array $items): void {
+    $result = array_map(fn($x) => $x * 2, $items);
+    sort($result);
+    doSomethingElse();
+}
+"""
+    php_file = tmp_path / "func_calls.php"
+    php_file.write_text(code)
+    result = parse_file(php_file)
+    proc = next(s for s in result.symbols if s.name == "processItems")
+    assert "array_map" in proc.calls, f"Expected 'array_map' in calls, got {proc.calls}"
+    assert "sort" in proc.calls, f"Expected 'sort' in calls, got {proc.calls}"
+    assert (
+        "doSomethingElse" in proc.calls
+    ), f"Expected 'doSomethingElse' in calls, got {proc.calls}"
+
+
 # ---------------------------------------------------------------------------

--- a/packages/gptme-codegraph/tests/test_multilang.py
+++ b/packages/gptme-codegraph/tests/test_multilang.py
@@ -54,6 +54,11 @@ _skip_no_ruby = pytest.mark.skipif(
     not _has_grammar("ruby"),
     reason="tree-sitter-ruby not installed",
 )
+_skip_no_php = pytest.mark.skipif(
+    not _has_grammar("php"),
+    reason="tree-sitter-php not installed",
+)
+
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -1622,3 +1627,183 @@ def test_parse_c_parenthesized_declarator(c_conditional_module: Path):
         ), f"Expected inner_func in symbols, got: {[s.name for s in result.symbols]}"
     finally:
         path.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# PHP extraction tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def php_module() -> Generator[Path, None, None]:
+    """A PHP file with namespaces, use imports, classes, methods, interface, trait, and functions."""
+    code = """<?php
+
+namespace App\\Service;
+
+use App\\Entity\\User;
+use App\\Util\\Helper as H;
+use function array_map;
+use const PHP_EOL;
+
+class Calculator {
+    private int $value;
+
+    public function __construct(int $initialValue = 0) {
+        $this->value = $initialValue;
+    }
+
+    public function add(int $n): self {
+        $this->value += $n;
+        return $this;
+    }
+
+    public function getValue(): int {
+        return $this->value;
+    }
+
+    public static function create(int $val): self {
+        return new self($val);
+    }
+}
+
+interface Describable {
+    public function describe(): string;
+}
+
+trait Loggable {
+    public function log(string $msg): void {
+        echo $msg;
+    }
+}
+
+function helper(string $name): string {
+    return "Hello " . $name;
+}
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".php", delete=False) as f:
+        f.write(code)
+        path = Path(f.name)
+    yield path
+    path.unlink(missing_ok=True)
+
+
+@_skip_no_php
+def test_language_detection_php(php_module: Path):
+    """PHP: language is detected from .php extension."""
+    from gptme_codegraph.core import _detect_language
+
+    assert _detect_language(php_module) == "php"
+
+
+@_skip_no_php
+def test_parse_php_class(php_module: Path):
+    """PHP: class is extracted with correct name and kind."""
+    result = parse_file(php_module)
+    classes = [s for s in result.symbols if s.kind == "class"]
+    class_names = {s.name for s in classes}
+    assert "Calculator" in class_names, f"Expected Calculator class, got {class_names}"
+    assert (
+        "Describable" in class_names
+    ), f"Expected Describable interface, got {class_names}"
+    assert "Loggable" in class_names, f"Expected Loggable trait, got {class_names}"
+    calc = next(s for s in classes if s.name == "Calculator")
+    assert calc.parent_class is None
+
+
+@_skip_no_php
+def test_parse_php_methods(php_module: Path):
+    """PHP: methods are extracted with parent_class set."""
+    result = parse_file(php_module)
+    methods = [s for s in result.symbols if s.kind == "method"]
+    method_names = {(s.name, s.parent_class) for s in methods}
+    assert ("__construct", "Calculator") in method_names
+    assert ("add", "Calculator") in method_names
+    assert ("getValue", "Calculator") in method_names
+    assert ("create", "Calculator") in method_names
+    assert ("describe", "Describable") in method_names
+    assert ("log", "Loggable") in method_names
+
+
+@_skip_no_php
+def test_parse_php_function(php_module: Path):
+    """PHP: top-level function is extracted as function kind."""
+    result = parse_file(php_module)
+    funcs = [s for s in result.symbols if s.kind == "function"]
+    func_names = {s.name for s in funcs}
+    assert "helper" in func_names, f"Expected helper function, got {func_names}"
+
+
+@_skip_no_php
+def test_parse_php_imports(php_module: Path):
+    """PHP: use declarations are extracted as imports."""
+    result = parse_file(php_module)
+    import_names = {(imp.name, imp.module, imp.alias) for imp in result.imports}
+    assert (
+        "User",
+        "App\\Entity",
+        None,
+    ) in import_names, f"Expected use App\\Entity\\User, got {import_names}"
+    assert (
+        "Helper",
+        "App\\Util",
+        "H",
+    ) in import_names, f"Expected use App\\Util\\Helper as H, got {import_names}"
+    assert "User" in {imp.name for imp in result.imports}, "User import missing"
+    assert "Helper" in {imp.name for imp in result.imports}, "Helper import missing"
+
+
+@_skip_no_php
+def test_parse_php_function_imports(php_module: Path):
+    """PHP: use function declarations are extracted."""
+    result = parse_file(php_module)
+    func_imports = [imp for imp in result.imports if imp.name == "array_map"]
+    assert (
+        len(func_imports) >= 1
+    ), f"Expected use function array_map, got {[(imp.name, imp.module) for imp in result.imports]}"
+
+
+@_skip_no_php
+def test_parse_php_const_imports(php_module: Path):
+    """PHP: use const declarations are extracted."""
+    result = parse_file(php_module)
+    const_imports = [imp for imp in result.imports if imp.name == "PHP_EOL"]
+    assert (
+        len(const_imports) >= 1
+    ), f"Expected use const PHP_EOL, got {[(imp.name, imp.module) for imp in result.imports]}"
+
+
+@_skip_no_php
+def test_parse_php_line_numbers(php_module: Path):
+    """PHP: symbol line numbers are correct."""
+    result = parse_file(php_module)
+    calc = next(
+        s for s in result.symbols if s.name == "Calculator" and s.kind == "class"
+    )
+    assert (
+        calc.start_line == 10
+    ), f"Expected Calculator at line 10, got {calc.start_line}"
+    add = next(
+        s for s in result.symbols if s.name == "add" and s.parent_class == "Calculator"
+    )
+    assert add.start_line == 17, f"Expected add at line 17, got {add.start_line}"
+    helper = next(s for s in result.symbols if s.name == "helper")
+    assert (
+        helper.start_line == 41
+    ), f"Expected helper at line 42, got {helper.start_line}"
+
+
+@_skip_no_php
+def test_build_index_php(php_module: Path):
+    """PHP: build_index works for a PHP file."""
+    import shutil
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as d:
+        shutil.copy(php_module, d)
+        index = build_index(d)
+        assert index.lookup("Calculator"), "Calculator not found in index"
+        assert index.lookup("helper"), "helper not found in index"
+
+
+# ---------------------------------------------------------------------------

--- a/packages/gptme-codegraph/tests/test_multilang.py
+++ b/packages/gptme-codegraph/tests/test_multilang.py
@@ -1774,6 +1774,29 @@ def test_parse_php_const_imports(php_module: Path):
 
 
 @_skip_no_php
+def test_parse_php_namespaced_function_const_imports(tmp_path: Path):
+    """PHP: namespaced function/const imports split module and symbol name."""
+    code = """<?php
+use function App\\Support\\array_map;
+use const App\\Support\\PHP_EOL;
+"""
+    php_file = tmp_path / "function_const_imports.php"
+    php_file.write_text(code)
+    result = parse_file(php_file)
+    import_names = {(imp.name, imp.module, imp.alias) for imp in result.imports}
+    assert (
+        "array_map",
+        "App\\Support",
+        None,
+    ) in import_names, f"Expected namespaced function import, got {import_names}"
+    assert (
+        "PHP_EOL",
+        "App\\Support",
+        None,
+    ) in import_names, f"Expected namespaced const import, got {import_names}"
+
+
+@_skip_no_php
 def test_parse_php_line_numbers(php_module: Path):
     """PHP: symbol line numbers are correct."""
     result = parse_file(php_module)
@@ -1844,6 +1867,34 @@ use App\\Entity\\{User, Group};
     import_names = {imp.name for imp in result.imports}
     assert "User" in import_names, f"Expected 'User' in imports, got {import_names}"
     assert "Group" in import_names, f"Expected 'Group' in imports, got {import_names}"
+
+
+@_skip_no_php
+def test_parse_php_bracket_namespace_symbols_and_imports(tmp_path: Path):
+    """PHP: bracket-style namespaces expose nested symbols and imports."""
+    code = """<?php
+namespace Foo {
+    use App\\Entity\\User;
+
+    class Bar {}
+
+    function baz() {}
+}
+"""
+    php_file = tmp_path / "bracket_namespace.php"
+    php_file.write_text(code)
+    result = parse_file(php_file)
+    symbol_names = {(symbol.name, symbol.kind) for symbol in result.symbols}
+    import_names = {(imp.name, imp.module) for imp in result.imports}
+    assert ("Bar", "class") in symbol_names, f"Expected Bar class, got {symbol_names}"
+    assert (
+        "baz",
+        "function",
+    ) in symbol_names, f"Expected baz function, got {symbol_names}"
+    assert (
+        "User",
+        "App\\Entity",
+    ) in import_names, f"Expected User import, got {import_names}"
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -1351,6 +1351,7 @@ treesitter = [
     { name = "tree-sitter-go" },
     { name = "tree-sitter-java" },
     { name = "tree-sitter-javascript" },
+    { name = "tree-sitter-php" },
     { name = "tree-sitter-python" },
     { name = "tree-sitter-ruby" },
     { name = "tree-sitter-rust" },
@@ -1368,6 +1369,7 @@ requires-dist = [
     { name = "tree-sitter-go", marker = "extra == 'treesitter'", specifier = ">=0.23.0" },
     { name = "tree-sitter-java", marker = "extra == 'treesitter'", specifier = ">=0.23.0" },
     { name = "tree-sitter-javascript", marker = "extra == 'treesitter'", specifier = ">=0.21.0" },
+    { name = "tree-sitter-php", marker = "extra == 'treesitter'", specifier = ">=0.24.0" },
     { name = "tree-sitter-python", marker = "extra == 'treesitter'", specifier = ">=0.21.0" },
     { name = "tree-sitter-ruby", marker = "extra == 'treesitter'", specifier = ">=0.23.0" },
     { name = "tree-sitter-rust", marker = "extra == 'treesitter'", specifier = ">=0.24.0" },
@@ -5177,6 +5179,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/89/9b773dee0f8961d1bb8d7baf0a204ab587618df19897c1ef260916f318ec/tree_sitter_javascript-0.25.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1b852d3aee8a36186dbcc32c798b11b4869f9b5041743b63b65c2ef793db7a54", size = 98377, upload-time = "2025-09-01T07:13:41.838Z" },
     { url = "https://files.pythonhosted.org/packages/3b/dc/d90cb1790f8cec9b4878d278ad9faf7c8f893189ce0f855304fd704fc274/tree_sitter_javascript-0.25.0-cp310-abi3-win_amd64.whl", hash = "sha256:e5ed840f5bd4a3f0272e441d19429b26eedc257abe5574c8546da6b556865e3c", size = 62975, upload-time = "2025-09-01T07:13:42.828Z" },
     { url = "https://files.pythonhosted.org/packages/2e/1f/f9eba1038b7d4394410f3c0a6ec2122b590cd7acb03f196e52fa57ebbe72/tree_sitter_javascript-0.25.0-cp310-abi3-win_arm64.whl", hash = "sha256:622a69d677aa7f6ee2931d8c77c981a33f0ebb6d275aa9d43d3397c879a9bb0b", size = 61668, upload-time = "2025-09-01T07:13:43.803Z" },
+]
+
+[[package]]
+name = "tree-sitter-php"
+version = "0.24.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/c8/1a499038cb4036bea1d560ffbc807a6fb940261aa22296bd49a62ed8bcba/tree_sitter_php-0.24.1-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:d56e2dcf025450f84a2cdbf4b18a09e6cb88b92e9e6858e63de3d4133ab2e43e", size = 219550, upload-time = "2025-08-16T22:14:30.212Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/5e/b52f2599acb29f6899470f7137d3d491c752b88df3950fb7408aea57ddca/tree_sitter_php-0.24.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:29759c67d4c27a68c227ed82c0b7e4699617b1bd23757d50c081f81a12b4f80d", size = 229632, upload-time = "2025-08-16T22:14:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/58/ca290da45380bd6ba7c6b0b98cc5fc30325c32c7f14f0c93196a451b19c4/tree_sitter_php-0.24.1-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94b89832ac09f078eed2acd88598838bc51012224cbcebb916dbb6a37e74357e", size = 325351, upload-time = "2025-08-16T22:14:33Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/c6/fd863a7a779d0ab67688939eba0e08bff7b1ffe731288d3d3610df21217b/tree_sitter_php-0.24.1-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7a1404a30f2972498ace040b0029738b8dac45d0a12932ccb8b605eb94bafbe4", size = 313021, upload-time = "2025-08-16T22:14:34.394Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ed/aace12f30c4f5474a9ad0e9da85c060174e3764342c9860974bb0feb02fc/tree_sitter_php-0.24.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3e96f61462a960c78e5389c7ba6c16c25e66b465c763b8e63ad66423326c2fa7", size = 305905, upload-time = "2025-08-16T22:14:35.846Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c4/6c690c33b1ae9cae9505c0a2896f046fda174d72c46bdafce6aab3b2f2e7/tree_sitter_php-0.24.1-cp310-abi3-win_amd64.whl", hash = "sha256:1a1b65b72a8410d421f914ee13d38fd546a94d01cb834f69b27c78ba7589a5b5", size = 208014, upload-time = "2025-08-16T22:14:37.206Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/69/54c670d725c092b89e76ca6984582b6a768b128ac1859ed48141b124da1d/tree_sitter_php-0.24.1-cp310-abi3-win_arm64.whl", hash = "sha256:56a70c5ef1bddb15f220a479b2f2edf3042c764b6c443921fbd7ca9174d664e3", size = 206033, upload-time = "2025-08-16T22:14:38.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds PHP as the 12th language supported by gptme-codegraph (after Python, TypeScript, JavaScript, Rust, Go, Java, C#, Ruby, C).

- `core.py`: `.php` → `php` detection; lazy grammar load for `tree-sitter-php` (`language_php()`); `_extract_symbols_php` extracting class, interface, trait, method, and function declarations; `_extract_imports_php` handling `use`, `use ... as`, `use function`, and `use const` declarations
- `pyproject.toml`: `tree-sitter-php>=0.24.0` in treesitter optional group
- `test_multilang.py`: 11 new tests for PHP (detection, class parsing, interface, trait, methods, constructors, static methods, function calls, imports, function imports, const imports)

The PHP grammar exposes `language_php()` (not `language()`).
PHP call expressions use `function_call_expression` (name field) and `member_call_expression` (name field) node types.