### PR TITLE
feat(codegraph): add Kotlin language support

### DIFF
--- a/packages/gptme-codegraph/README.md
+++ b/packages/gptme-codegraph/README.md
@@ -5,8 +5,8 @@ Structural code retrieval for gptme via [tree-sitter](https://tree-sitter.github
 ## Features
 
 - **9 MCP tools**: `codegraph_parse`, `codegraph_index`, `codegraph_map`, `codegraph_def`, `codegraph_callers`, `codegraph_callees`, `codegraph_refs`, `codegraph_blast`, `codegraph_impact`
-- **Multi-language symbol extraction** for Python, JavaScript/TypeScript, and Rust
-- **Cross-file import resolution** for Python, plus early JS/TS import capture for named and namespace imports
+- **Multi-language symbol extraction** for Python, JavaScript/TypeScript, Rust, Go, Java, C#, Ruby, C, C++, PHP, and Kotlin
+- **Cross-file import capture** across supported languages, with strongest semantic resolution on Python
 - **Qualified symbol IDs** (`module::Class.method`) for unambiguous cross-file references
 - **SQLite index cache** — optional persistent cache for large codebases
 - **Blast/impact semantics split**: `blast` = dependency closure (what X needs), `impact` = what breaks if you change X
@@ -76,8 +76,9 @@ gptme-codegraph-commit-map path/to/repo --check
 gptme-codegraph-commit-map path/to/repo --refresh
 ```
 
-Freshness is keyed off a digest of the tracked source files (`*.py`, `*.ts`,
-`*.tsx`, `*.js`, `*.rs`), not `HEAD` — so an artifact regenerated in a
+Freshness is keyed off a digest of supported source files (`*.py`, `*.ts`,
+`*.tsx`, `*.js`, `*.rs`, `*.go`, `*.java`, `*.cs`, `*.rb`, `*.c`, `*.cpp`,
+`*.php`, `*.kt`, `*.kts`), not `HEAD` — so an artifact regenerated in a
 pre-commit hook stays fresh after the commit that contains it lands. The default
 staleness window is 1 day (`--stale-after-days N` to change it). The artifact is
 structural only (paths, class/function names, nesting) — no source, comments, or
@@ -125,9 +126,10 @@ print(radius)  # {"depth_0": {…}, "depth_1": {…}, …}
 
 ## Status
 
-Experimental package — Python support is the deepest path today, with Phase 1
-JavaScript/TypeScript and Rust extraction now wired into the same surface.
-Cross-file resolution remains strongest on Python; JS/TS import handling is
-currently best-effort rather than fully semantic.
+Experimental package — Python support is the deepest path today, with broad
+tree-sitter extraction now wired into the same surface for common web, systems,
+JVM, scripting, and PHP/Kotlin codebases. Cross-file resolution remains
+strongest on Python; non-Python import handling is best-effort rather than fully
+semantic.
 
 > Namespace packages (`import google.cloud.storage` without `__init__.py`) are a known v1.1 gap.

--- a/packages/gptme-codegraph/pyproject.toml
+++ b/packages/gptme-codegraph/pyproject.toml
@@ -23,6 +23,7 @@ treesitter = [
     "tree-sitter-ruby>=0.23.0",
     "tree-sitter-c>=0.23.0",
     "tree-sitter-php>=0.24.0",
+    "tree-sitter-kotlin>=1.1.0",
 ]
 mcp = [
     "mcp>=1.0.0",

--- a/packages/gptme-codegraph/src/gptme_codegraph/core.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/core.py
@@ -3,8 +3,8 @@
 Complementary to gptme-rag (text chunks), this retrieves code *structure*:
 function/class definitions, call graphs, and blast radius.
 
-Supports Python, TypeScript/JavaScript, Rust, Go, Java, C#, Ruby, C, C++, and PHP via tree-sitter
-grammars.
+Supports Python, TypeScript/JavaScript, Rust, Go, Java, C#, Ruby, C, C++, PHP,
+and Kotlin via tree-sitter grammars.
 To add a new language: add grammar dep to pyproject.toml, extend _LANG_MAP
 and _load_language, then add extractor functions.
 
@@ -58,6 +58,8 @@ _LANG_MAP: dict[str, str] = {
     ".hxx": "cpp",
     ".rb": "ruby",
     ".php": "php",
+    ".kt": "kotlin",
+    ".kts": "kotlin",
     ".c": "c",
 }
 
@@ -74,6 +76,7 @@ _GRAMMAR_MODULES: dict[str, str] = {
     "cpp": "tree_sitter_cpp",
     "ruby": "tree_sitter_ruby",
     "php": "tree_sitter_php",
+    "kotlin": "tree_sitter_kotlin",
     "c": "tree_sitter_c",
 }
 
@@ -179,6 +182,12 @@ def _load_language(name: str):
         import tree_sitter_php as tsphp  # type: ignore[import-not-found,unused-ignore]
 
         grammar_map["php"] = tsphp.language_php()
+    except ImportError:
+        pass
+    try:
+        import tree_sitter_kotlin as tskotlin  # type: ignore[import-not-found,unused-ignore]
+
+        grammar_map["kotlin"] = tskotlin.language()
     except ImportError:
         pass
 
@@ -767,6 +776,19 @@ def _extract_calls(node) -> list[str]:
                 func_node = cursor.node.child_by_field_name("function")
                 if func_node:
                     calls.append(_text(func_node))
+                elif cursor.node.type == "call_expression":
+                    # Kotlin call_expression nodes do not expose a named
+                    # function field; the callee is the first named child.
+                    callee = next(
+                        (
+                            child
+                            for child in cursor.node.named_children
+                            if child.type != "value_arguments"
+                        ),
+                        None,
+                    )
+                    if callee:
+                        calls.append(_text(callee))
                 else:
                     # Ruby: call nodes carry the callee in a "method" field
                     method_node = cursor.node.child_by_field_name("method")
@@ -2352,6 +2374,132 @@ def _extract_imports_php(root) -> list[ImportInfo]:
     return imports
 
 
+# ---------------------------------------------------------------------------
+# Kotlin extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_symbols_kotlin(root, filepath: str) -> list[Symbol]:
+    """Extract classes, objects, methods, and top-level functions from Kotlin."""
+    symbols: list[Symbol] = []
+
+    def _function_symbol(node, parent_class: str | None) -> None:
+        name_node = node.child_by_field_name("name")
+        if name_node is None:
+            return
+        body = next(
+            (child for child in node.named_children if child.type == "function_body"),
+            None,
+        )
+        calls = _extract_calls(body) if body is not None else []
+        symbols.append(
+            Symbol(
+                name=_text(name_node),
+                kind="method" if parent_class else "function",
+                file=filepath,
+                start_line=node.start_point[0] + 1,
+                end_line=node.end_point[0] + 1,
+                parent_class=parent_class,
+                calls=list(set(calls)),
+            )
+        )
+
+    def _walk(node, parent_class: str | None = None) -> None:
+        if node.type in {"class_declaration", "object_declaration"}:
+            name_node = node.child_by_field_name("name")
+            class_name = _text(name_node) if name_node else ""
+            if class_name:
+                symbols.append(
+                    Symbol(
+                        name=class_name,
+                        kind="class",
+                        file=filepath,
+                        start_line=node.start_point[0] + 1,
+                        end_line=node.end_point[0] + 1,
+                        parent_class=parent_class,
+                    )
+                )
+            body = next(
+                (child for child in node.named_children if child.type == "class_body"),
+                None,
+            )
+            if body is not None:
+                _walk(body, class_name or parent_class)
+            return
+
+        if node.type == "companion_object":
+            body = next(
+                (child for child in node.named_children if child.type == "class_body"),
+                None,
+            )
+            if body is not None:
+                _walk(body, parent_class)
+            return
+
+        if node.type == "function_declaration":
+            _function_symbol(node, parent_class)
+            return
+
+        for child in node.named_children:
+            _walk(child, parent_class)
+
+    _walk(root)
+    return symbols
+
+
+def _split_kotlin_import(qualified: str, is_wildcard: bool) -> tuple[str, str]:
+    """Split a Kotlin import into ``(module, name)`` pieces."""
+    if is_wildcard:
+        return qualified, "*"
+    if "." not in qualified:
+        return "", qualified
+    module, name = qualified.rsplit(".", 1)
+    return module, name
+
+
+def _extract_imports_kotlin(root) -> list[ImportInfo]:
+    """Extract Kotlin import declarations, including aliases and wildcards."""
+    imports: list[ImportInfo] = []
+
+    for node in root.named_children:
+        if node.type != "import":
+            continue
+        qualified_node = next(
+            (
+                child
+                for child in node.named_children
+                if child.type == "qualified_identifier"
+            ),
+            None,
+        )
+        if qualified_node is None:
+            continue
+        qualified = _text(qualified_node)
+        if not qualified:
+            continue
+        is_wildcard = any(child.type == "*" for child in node.children)
+        module, name = _split_kotlin_import(qualified, is_wildcard)
+        alias_node = next(
+            (
+                child
+                for child in node.named_children
+                if child.type == "identifier" and child is not qualified_node
+            ),
+            None,
+        )
+        imports.append(
+            ImportInfo(
+                file="",
+                module=module,
+                name=name,
+                alias=_text(alias_node) if alias_node is not None else None,
+                is_from=True,
+            )
+        )
+
+    return imports
+
+
 # C++ extraction
 # ---------------------------------------------------------------------------
 
@@ -2592,7 +2740,7 @@ def parse_file(filepath: Path) -> FileParseResult:
 
     Detects language from file extension and dispatches to the correct
     tree-sitter grammar. Supports Python, TypeScript/JavaScript, Rust, Go,
-    Java, C#, Ruby, C, C++, and PHP.
+    Java, C#, Ruby, C, C++, PHP, and Kotlin.
     """
     code = filepath.read_bytes()
     lang_name = _detect_language(filepath)
@@ -2635,6 +2783,9 @@ def parse_file(filepath: Path) -> FileParseResult:
     elif lang_name == "php":
         symbols = _extract_symbols_php(root, filename)
 
+    elif lang_name == "kotlin":
+        symbols = _extract_symbols_kotlin(root, filename)
+
     imports: list[ImportInfo] = []
     if lang_name == "python":
         imports = _extract_imports(root)
@@ -2656,6 +2807,8 @@ def parse_file(filepath: Path) -> FileParseResult:
         imports = _extract_imports_c(root)
     elif lang_name == "php":
         imports = _extract_imports_php(root)
+    elif lang_name == "kotlin":
+        imports = _extract_imports_kotlin(root)
 
     for imp in imports:
         imp.file = filename

--- a/packages/gptme-codegraph/src/gptme_codegraph/core.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/core.py
@@ -776,9 +776,15 @@ def _extract_calls(node) -> list[str]:
                 func_node = cursor.node.child_by_field_name("function")
                 if func_node:
                     calls.append(_text(func_node))
-                elif cursor.node.type == "call_expression":
-                    # Kotlin call_expression nodes do not expose a named
-                    # function field; the callee is the first named child.
+                elif cursor.node.type == "call_expression" and any(
+                    child.type == "value_arguments"
+                    for child in cursor.node.named_children
+                ):
+                    # Kotlin call_expression: no named "function" field; the
+                    # callee is the first named child that is not value_arguments.
+                    # Guarded by value_arguments presence (Kotlin-specific type)
+                    # so JS/TS/Go/Rust call_expression edge cases fall through
+                    # to the Ruby else branch instead of applying this path.
                     callee = next(
                         (
                             child
@@ -2391,7 +2397,10 @@ def _extract_symbols_kotlin(root, filepath: str) -> list[Symbol]:
             (child for child in node.named_children if child.type == "function_body"),
             None,
         )
-        calls = _extract_calls(body) if body is not None else []
+        # For expression-body functions (e.g. `fun greet() = println("hi")`)
+        # tree-sitter-kotlin emits no function_body child; fall back to walking
+        # the whole declaration so calls in the expression are still captured.
+        calls = _extract_calls(body if body is not None else node)
         symbols.append(
             Symbol(
                 name=_text(name_node),

--- a/packages/gptme-codegraph/tests/test_multilang.py
+++ b/packages/gptme-codegraph/tests/test_multilang.py
@@ -2115,6 +2115,8 @@ class Calculator(private var value: Int = 0) {
 
     fun current(): Int = value
 
+    fun clamped(n: Int): Int = max(n, 0)
+
     companion object {
         fun create(initial: Int): Calculator {
             return Calculator(initial)
@@ -2211,6 +2213,16 @@ def test_parse_kotlin_calls(kotlin_module: Path):
     helper = next(s for s in result.symbols if s.name == "helper")
     assert any("trim" in call for call in helper.calls)
     assert any("uppercase" in call for call in helper.calls)
+
+
+@_skip_no_kotlin
+def test_parse_kotlin_expression_body_calls(kotlin_module: Path):
+    """Kotlin: calls in expression-body functions (fun f() = expr) are captured."""
+    result = parse_file(kotlin_module)
+    clamped = next(s for s in result.symbols if s.name == "clamped")
+    assert "max" in clamped.calls, (
+        "expression-body call 'max' not captured; " f"got calls={clamped.calls!r}"
+    )
 
 
 @_skip_no_kotlin

--- a/packages/gptme-codegraph/tests/test_multilang.py
+++ b/packages/gptme-codegraph/tests/test_multilang.py
@@ -1,7 +1,7 @@
-"""Tests for multi-language support in gptme-codegraph (JS/TS, Rust, Go, Java, C#, Ruby, C++).
+"""Tests for multi-language support in gptme-codegraph (JS/TS, Rust, Go, Java, C#, Ruby, C++, Kotlin).
 
 Verifies that parse_file, extract_symbols, and build_index work correctly
-for JavaScript, TypeScript, Rust, Go, Java, C#, Ruby, and C++ source files.
+for JavaScript, TypeScript, Rust, Go, Java, C#, Ruby, C++, and Kotlin source files.
 """
 
 from __future__ import annotations
@@ -61,6 +61,10 @@ _skip_no_ruby = pytest.mark.skipif(
 _skip_no_php = pytest.mark.skipif(
     not _has_grammar("php"),
     reason="tree-sitter-php not installed",
+)
+_skip_no_kotlin = pytest.mark.skipif(
+    not _has_grammar("kotlin"),
+    reason="tree-sitter-kotlin not installed",
 )
 
 
@@ -2085,6 +2089,151 @@ function processItems(array $items): void {
     assert (
         "doSomethingElse" in proc.calls
     ), f"Expected 'doSomethingElse' in calls, got {proc.calls}"
+
+
+# ---------------------------------------------------------------------------
+# Kotlin extraction tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def kotlin_module() -> Generator[Path, None, None]:
+    """A Kotlin file with imports, classes, methods, object, and top-level functions."""
+    code = """\
+package app.service
+
+import kotlin.math.max
+import app.model.User as DomainUser
+import app.util.*
+
+class Calculator(private var value: Int = 0) {
+    fun add(n: Int): Calculator {
+        value += n
+        log("added")
+        return this
+    }
+
+    fun current(): Int = value
+
+    companion object {
+        fun create(initial: Int): Calculator {
+            return Calculator(initial)
+        }
+    }
+}
+
+interface Describable {
+    fun describe(): String
+}
+
+object Logger {
+    fun log(msg: String) {
+        println(msg)
+    }
+}
+
+fun helper(name: String): String {
+    return name.trim().uppercase()
+}
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".kt", delete=False) as f:
+        f.write(code)
+        path = Path(f.name)
+    yield path
+    path.unlink(missing_ok=True)
+
+
+@_skip_no_kotlin
+def test_language_detection_kotlin(kotlin_module: Path):
+    """Kotlin: .kt files are detected as Kotlin."""
+    result = parse_file(kotlin_module)
+    assert result.language == "kotlin"
+
+
+@_skip_no_kotlin
+def test_language_detection_kotlin_script(tmp_path: Path):
+    """Kotlin: .kts scripts are detected as Kotlin."""
+    script = tmp_path / "build.kts"
+    script.write_text("fun configure() {}\n")
+    result = parse_file(script)
+    assert result.language == "kotlin"
+    assert any(sym.name == "configure" for sym in result.symbols)
+
+
+@_skip_no_kotlin
+def test_parse_kotlin_classes_and_objects(kotlin_module: Path):
+    """Kotlin: classes, interfaces, and objects are extracted as class symbols."""
+    result = parse_file(kotlin_module)
+    classes = {s.name for s in result.symbols if s.kind == "class"}
+    assert "Calculator" in classes
+    assert "Describable" in classes
+    assert "Logger" in classes
+
+
+@_skip_no_kotlin
+def test_parse_kotlin_methods(kotlin_module: Path):
+    """Kotlin: member, companion object, and interface functions are methods."""
+    result = parse_file(kotlin_module)
+    methods = {(s.name, s.parent_class) for s in result.symbols if s.kind == "method"}
+    assert ("add", "Calculator") in methods
+    assert ("current", "Calculator") in methods
+    assert ("create", "Calculator") in methods
+    assert ("describe", "Describable") in methods
+    assert ("log", "Logger") in methods
+
+
+@_skip_no_kotlin
+def test_parse_kotlin_top_level_function(kotlin_module: Path):
+    """Kotlin: top-level functions are extracted as functions."""
+    result = parse_file(kotlin_module)
+    functions = {s.name for s in result.symbols if s.kind == "function"}
+    assert "helper" in functions
+
+
+@_skip_no_kotlin
+def test_parse_kotlin_imports(kotlin_module: Path):
+    """Kotlin: imports include module/name split, aliases, and wildcards."""
+    result = parse_file(kotlin_module)
+    imports = {(imp.module, imp.name, imp.alias) for imp in result.imports}
+    assert ("kotlin.math", "max", None) in imports
+    assert ("app.model", "User", "DomainUser") in imports
+    assert ("app.util", "*", None) in imports
+
+
+@_skip_no_kotlin
+def test_parse_kotlin_calls(kotlin_module: Path):
+    """Kotlin: call expressions are extracted from function bodies."""
+    result = parse_file(kotlin_module)
+    add = next(s for s in result.symbols if s.name == "add")
+    assert "log" in add.calls
+    create = next(s for s in result.symbols if s.name == "create")
+    assert "Calculator" in create.calls
+    helper = next(s for s in result.symbols if s.name == "helper")
+    assert any("trim" in call for call in helper.calls)
+    assert any("uppercase" in call for call in helper.calls)
+
+
+@_skip_no_kotlin
+def test_parse_kotlin_line_numbers(kotlin_module: Path):
+    """Kotlin: symbol line numbers are positive and ordered."""
+    result = parse_file(kotlin_module)
+    assert result.symbols
+    for sym in result.symbols:
+        assert sym.start_line >= 1
+        assert sym.end_line >= sym.start_line
+
+
+@_skip_no_kotlin
+def test_build_index_kotlin(kotlin_module: Path):
+    """Kotlin: build_index picks up symbols from .kt files."""
+    import shutil
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as d:
+        shutil.copy(kotlin_module, d)
+        index = build_index(d)
+        assert index.lookup("Calculator"), "Calculator not found in index"
+        assert index.lookup("helper"), "helper not found in index"
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -1352,6 +1352,7 @@ treesitter = [
     { name = "tree-sitter-go" },
     { name = "tree-sitter-java" },
     { name = "tree-sitter-javascript" },
+    { name = "tree-sitter-kotlin" },
     { name = "tree-sitter-php" },
     { name = "tree-sitter-python" },
     { name = "tree-sitter-ruby" },
@@ -1371,6 +1372,7 @@ requires-dist = [
     { name = "tree-sitter-go", marker = "extra == 'treesitter'", specifier = ">=0.23.0" },
     { name = "tree-sitter-java", marker = "extra == 'treesitter'", specifier = ">=0.23.0" },
     { name = "tree-sitter-javascript", marker = "extra == 'treesitter'", specifier = ">=0.21.0" },
+    { name = "tree-sitter-kotlin", marker = "extra == 'treesitter'", specifier = ">=1.1.0" },
     { name = "tree-sitter-php", marker = "extra == 'treesitter'", specifier = ">=0.24.0" },
     { name = "tree-sitter-python", marker = "extra == 'treesitter'", specifier = ">=0.21.0" },
     { name = "tree-sitter-ruby", marker = "extra == 'treesitter'", specifier = ">=0.23.0" },
@@ -5196,6 +5198,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/89/9b773dee0f8961d1bb8d7baf0a204ab587618df19897c1ef260916f318ec/tree_sitter_javascript-0.25.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1b852d3aee8a36186dbcc32c798b11b4869f9b5041743b63b65c2ef793db7a54", size = 98377, upload-time = "2025-09-01T07:13:41.838Z" },
     { url = "https://files.pythonhosted.org/packages/3b/dc/d90cb1790f8cec9b4878d278ad9faf7c8f893189ce0f855304fd704fc274/tree_sitter_javascript-0.25.0-cp310-abi3-win_amd64.whl", hash = "sha256:e5ed840f5bd4a3f0272e441d19429b26eedc257abe5574c8546da6b556865e3c", size = 62975, upload-time = "2025-09-01T07:13:42.828Z" },
     { url = "https://files.pythonhosted.org/packages/2e/1f/f9eba1038b7d4394410f3c0a6ec2122b590cd7acb03f196e52fa57ebbe72/tree_sitter_javascript-0.25.0-cp310-abi3-win_arm64.whl", hash = "sha256:622a69d677aa7f6ee2931d8c77c981a33f0ebb6d275aa9d43d3397c879a9bb0b", size = 61668, upload-time = "2025-09-01T07:13:43.803Z" },
+]
+
+[[package]]
+name = "tree-sitter-kotlin"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/bb/bdab3665eeca21246130eec79c76e42456cfa72d59606266ecdbf37f9a96/tree_sitter_kotlin-1.1.0.tar.gz", hash = "sha256:322a35bdae75e25ae64dae6027be609c5422fab282084117816c4ebcda6168da", size = 1095728, upload-time = "2025-01-09T19:02:18.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/a5/ce5a2ba7b97db8d90c89516674f5c46e2d41503e00dd743ba7aad4661097/tree_sitter_kotlin-1.1.0-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:6cca5ef06d090e8494ac1d9f0aac71ed32207d412766b5df7da00d94334181a2", size = 312883, upload-time = "2025-01-09T19:02:02.931Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/20/66105b6e94d062440955d374e64d030c3173cf4f592f6a6a3c426b3c94d0/tree_sitter_kotlin-1.1.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:910b41a580dae00d319e555075f3886a41386d1067931b14c7de504eeae3ae2a", size = 337016, upload-time = "2025-01-09T19:02:04.174Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/4c/e1ef38fe412fa9851403fc75a653f2b69bbe1e11e2e7faf219631ebe7e4a/tree_sitter_kotlin-1.1.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:906e5444ebb01db439cb3ad65913598a4ea957b0e068aa973265926a17eb00e0", size = 359927, upload-time = "2025-01-09T19:02:06.312Z" },
+    { url = "https://files.pythonhosted.org/packages/65/bd/0f3aac45eb88b6b3173ac9c23bc41d8865943cbbe1caaafc001cd1b73c90/tree_sitter_kotlin-1.1.0-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a92afe24b634cf914c5812af0f5c53184b1c18bdf6ee5505c83afac81f6bf6c", size = 339269, upload-time = "2025-01-09T19:02:08.644Z" },
+    { url = "https://files.pythonhosted.org/packages/08/dc/4944abf3a8bc630262e93e0857bd7044d521995c1f6af50650e4fe1fdde0/tree_sitter_kotlin-1.1.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5960034a5c5bcc7ccb21dc7a29e4267ac4f0ef37884f39d75695eac7f004deff", size = 328921, upload-time = "2025-01-09T19:02:10.346Z" },
+    { url = "https://files.pythonhosted.org/packages/24/c9/5cca0a44db41224f7f10992450af17ff432c1a336852efb312246d5705e5/tree_sitter_kotlin-1.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:d4d3f330f515ba8b91da04a5335eb9ff3ce071c7b7855958912f2560f6e14976", size = 315933, upload-time = "2025-01-09T19:02:12.637Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/b9/12fa97f63d2b7517c6f5d16938f0c5bfe84d925c652c75ff1c5e29bf6a44/tree_sitter_kotlin-1.1.0-cp39-abi3-win_arm64.whl", hash = "sha256:e030f127a7d07952907adb9070248bd42fb86dc76fd92744727551b50e131ee7", size = 310414, upload-time = "2025-01-09T19:02:16.23Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

Adds Kotlin support to `gptme-codegraph` as the next idea #315 multilang slice:

- detects `.kt` and `.kts` files as Kotlin
- loads `tree-sitter-kotlin` through the `treesitter` extra
- extracts Kotlin classes, interfaces, objects, member functions, companion-object functions, top-level functions, imports, aliases, wildcards, and call expressions
- refreshes the package README to reflect the broader supported-language set

## Validation

- `uv run --package gptme-codegraph --extra treesitter pytest packages/gptme-codegraph/tests/test_multilang.py -k kotlin -q` — 9 passed
- `uv run --package gptme-codegraph --extra treesitter pytest packages/gptme-codegraph/tests/test_multilang.py -q` — 117 passed
- `uv run --package gptme-codegraph --extra treesitter --extra dev pytest packages/gptme-codegraph/tests -q` — 240 passed, 1 skipped
- `uv run ruff check packages/gptme-codegraph/src/gptme_codegraph/core.py packages/gptme-codegraph/tests/test_multilang.py` — passed
- `uv run --package gptme-codegraph --extra dev mypy packages/gptme-codegraph/src/gptme_codegraph/core.py` — passed
- `prek run --files packages/gptme-codegraph/README.md packages/gptme-codegraph/pyproject.toml packages/gptme-codegraph/src/gptme_codegraph/core.py packages/gptme-codegraph/tests/test_multilang.py uv.lock` — passed
