### PR TITLE
feat(codegraph): add Swift language support

### DIFF
--- a/packages/gptme-codegraph/README.md
+++ b/packages/gptme-codegraph/README.md
@@ -5,7 +5,7 @@ Structural code retrieval for gptme via [tree-sitter](https://tree-sitter.github
 ## Features
 
 - **9 MCP tools**: `codegraph_parse`, `codegraph_index`, `codegraph_map`, `codegraph_def`, `codegraph_callers`, `codegraph_callees`, `codegraph_refs`, `codegraph_blast`, `codegraph_impact`
-- **Multi-language symbol extraction** for Python, JavaScript/TypeScript, Rust, Go, Java, C#, Ruby, C, C++, PHP, and Kotlin
+- **Multi-language symbol extraction** for Python, JavaScript/TypeScript, Rust, Go, Java, C#, Ruby, C, C++, PHP, Kotlin, and Swift
 - **Cross-file import capture** across supported languages, with strongest semantic resolution on Python
 - **Qualified symbol IDs** (`module::Class.method`) for unambiguous cross-file references
 - **SQLite index cache** — optional persistent cache for large codebases
@@ -78,7 +78,7 @@ gptme-codegraph-commit-map path/to/repo --refresh
 
 Freshness is keyed off a digest of supported source files (`*.py`, `*.ts`,
 `*.tsx`, `*.js`, `*.rs`, `*.go`, `*.java`, `*.cs`, `*.rb`, `*.c`, `*.cpp`,
-`*.php`, `*.kt`, `*.kts`), not `HEAD` — so an artifact regenerated in a
+`*.php`, `*.kt`, `*.kts`, `*.swift`), not `HEAD` — so an artifact regenerated in a
 pre-commit hook stays fresh after the commit that contains it lands. The default
 staleness window is 1 day (`--stale-after-days N` to change it). The artifact is
 structural only (paths, class/function names, nesting) — no source, comments, or
@@ -128,7 +128,7 @@ print(radius)  # {"depth_0": {…}, "depth_1": {…}, …}
 
 Experimental package — Python support is the deepest path today, with broad
 tree-sitter extraction now wired into the same surface for common web, systems,
-JVM, scripting, and PHP/Kotlin codebases. Cross-file resolution remains
+JVM, scripting, PHP/Kotlin, and Swift codebases. Cross-file resolution remains
 strongest on Python; non-Python import handling is best-effort rather than fully
 semantic.
 

--- a/packages/gptme-codegraph/pyproject.toml
+++ b/packages/gptme-codegraph/pyproject.toml
@@ -24,6 +24,7 @@ treesitter = [
     "tree-sitter-c>=0.23.0",
     "tree-sitter-php>=0.24.0",
     "tree-sitter-kotlin>=1.1.0",
+    "tree-sitter-swift>=0.7.3",
 ]
 mcp = [
     "mcp>=1.0.0",

--- a/packages/gptme-codegraph/src/gptme_codegraph/core.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/core.py
@@ -4,7 +4,7 @@ Complementary to gptme-rag (text chunks), this retrieves code *structure*:
 function/class definitions, call graphs, and blast radius.
 
 Supports Python, TypeScript/JavaScript, Rust, Go, Java, C#, Ruby, C, C++, PHP,
-and Kotlin via tree-sitter grammars.
+Kotlin, and Swift via tree-sitter grammars.
 To add a new language: add grammar dep to pyproject.toml, extend _LANG_MAP
 and _load_language, then add extractor functions.
 
@@ -60,6 +60,7 @@ _LANG_MAP: dict[str, str] = {
     ".php": "php",
     ".kt": "kotlin",
     ".kts": "kotlin",
+    ".swift": "swift",
     ".c": "c",
 }
 
@@ -77,6 +78,7 @@ _GRAMMAR_MODULES: dict[str, str] = {
     "ruby": "tree_sitter_ruby",
     "php": "tree_sitter_php",
     "kotlin": "tree_sitter_kotlin",
+    "swift": "tree_sitter_swift",
     "c": "tree_sitter_c",
 }
 
@@ -113,7 +115,7 @@ def _load_language(name: str):
 
     Returns None if the grammar is not installed.
     """
-    from tree_sitter import Language  # type: ignore[import-untyped,unused-ignore]
+    import tree_sitter as ts  # type: ignore[import-not-found,import-untyped,unused-ignore]
 
     # Lazy import each grammar; missing grammars silently return None
     grammar_map: dict[str, object] = {}
@@ -190,6 +192,12 @@ def _load_language(name: str):
         grammar_map["kotlin"] = tskotlin.language()
     except ImportError:
         pass
+    try:
+        import tree_sitter_swift as tsswift  # type: ignore[import-not-found,unused-ignore]
+
+        grammar_map["swift"] = tsswift.language()
+    except ImportError:
+        pass
 
     lang = grammar_map.get(name)
     if lang is None:
@@ -200,7 +208,7 @@ def _load_language(name: str):
             lang = grammar_map.get("javascript")
     if lang is None:
         return None
-    return Language(lang)
+    return ts.Language(lang)
 
 
 def _module_path(filepath: str, directory: str | None = None) -> str:
@@ -694,7 +702,7 @@ def _missing_grammar_diagnostic(lang_name: str) -> dict[str, str]:
 def _tree_sitter_parse_attempt(code: bytes, lang_name: str = "python") -> _ParseAttempt:
     """Parse source code with tree-sitter and preserve missing-dependency diagnostics."""
     try:
-        from tree_sitter import Parser  # type: ignore[import-untyped,unused-ignore]
+        import tree_sitter as ts  # type: ignore[import-not-found,import-untyped,unused-ignore]
     except ImportError:
         return _ParseAttempt(
             diagnostic={
@@ -707,7 +715,7 @@ def _tree_sitter_parse_attempt(code: bytes, lang_name: str = "python") -> _Parse
             }
         )
 
-    parser = Parser()
+    parser = ts.Parser()
     language = _load_language(lang_name)
     if language is None:
         diagnostic = None
@@ -763,6 +771,21 @@ def _extract_docstring(body_node) -> str | None:
         return None
 
 
+def _last_swift_navigation_name(node) -> str | None:
+    """Return the final member name in a Swift navigation expression."""
+    suffix = node.child_by_field_name("suffix")
+    if suffix is not None:
+        suffix_name = suffix.child_by_field_name("suffix")
+        text = _text(suffix_name) if suffix_name is not None else _text(suffix)
+        return text.lstrip(".") or None
+
+    for child in reversed(node.named_children):
+        found = _last_swift_navigation_name(child)
+        if found:
+            return found
+    return None
+
+
 def _extract_calls(node) -> list[str]:
     """Extract all called function names from a tree-sitter node subtree."""
     calls = []
@@ -795,6 +818,23 @@ def _extract_calls(node) -> list[str]:
                     )
                     if callee:
                         calls.append(_text(callee))
+                elif cursor.node.type == "call_expression" and any(
+                    child.type == "call_suffix" for child in cursor.node.named_children
+                ):
+                    # Swift call_expression: first named child is the callee;
+                    # member calls wrap it in navigation_expression.
+                    callee = next(
+                        (
+                            child
+                            for child in cursor.node.named_children
+                            if child.type != "call_suffix"
+                        ),
+                        None,
+                    )
+                    if callee:
+                        calls.append(
+                            _last_swift_navigation_name(callee) or _text(callee)
+                        )
                 else:
                     # Ruby: call nodes carry the callee in a "method" field
                     method_node = cursor.node.child_by_field_name("method")
@@ -2509,6 +2549,147 @@ def _extract_imports_kotlin(root) -> list[ImportInfo]:
     return imports
 
 
+# ---------------------------------------------------------------------------
+# Swift extraction
+# ---------------------------------------------------------------------------
+
+
+def _swift_container_body(node):
+    """Return a Swift declaration body node when present."""
+    for child in node.named_children:
+        if child.type in {"class_body", "protocol_body", "enum_class_body"}:
+            return child
+    return None
+
+
+def _swift_declaration_name(node) -> str | None:
+    """Return the declared Swift type/function name."""
+    name_node = node.child_by_field_name("name")
+    if name_node is not None:
+        text = _text(name_node)
+        if text:
+            return text
+
+    for child in node.named_children:
+        if child.type in {"simple_identifier", "type_identifier"}:
+            text = _text(child)
+            if text:
+                return text
+        if child.type == "user_type":
+            text = _text(child)
+            if text:
+                return text
+    return None
+
+
+def _extract_symbols_swift(root, filepath: str) -> list[Symbol]:
+    """Extract Swift types, protocols, methods, initializers, and functions."""
+    symbols: list[Symbol] = []
+
+    def _add_function(node, parent_class: str | None) -> None:
+        name: str | None
+        if node.type == "init_declaration":
+            name = "init"
+        else:
+            name = _swift_declaration_name(node)
+        if not name:
+            return
+
+        body = node.child_by_field_name("body")
+        if body is None:
+            body = next(
+                (
+                    child
+                    for child in node.named_children
+                    if child.type == "function_body"
+                ),
+                None,
+            )
+        calls = _extract_calls(body) if body is not None else []
+        symbols.append(
+            Symbol(
+                name=name,
+                kind="method" if parent_class else "function",
+                file=filepath,
+                start_line=node.start_point[0] + 1,
+                end_line=node.end_point[0] + 1,
+                parent_class=parent_class,
+                calls=list(set(calls)),
+            )
+        )
+
+    def _walk(node, parent_class: str | None = None) -> None:
+        if node.type in {"class_declaration", "protocol_declaration"}:
+            type_name = _swift_declaration_name(node)
+            if type_name:
+                symbols.append(
+                    Symbol(
+                        name=type_name,
+                        kind="class",
+                        file=filepath,
+                        start_line=node.start_point[0] + 1,
+                        end_line=node.end_point[0] + 1,
+                        parent_class=parent_class,
+                    )
+                )
+            body = _swift_container_body(node)
+            if body is not None:
+                _walk(body, type_name or parent_class)
+            return
+
+        if node.type in {
+            "function_declaration",
+            "protocol_function_declaration",
+            "init_declaration",
+        }:
+            _add_function(node, parent_class)
+            return
+
+        for child in node.named_children:
+            _walk(child, parent_class)
+
+    _walk(root)
+    return symbols
+
+
+def _split_swift_import(qualified: str) -> tuple[str, str]:
+    """Split a Swift import into ``(module, name)`` pieces."""
+    if "." not in qualified:
+        return "", qualified
+    module, name = qualified.rsplit(".", 1)
+    return module, name
+
+
+def _extract_imports_swift(root) -> list[ImportInfo]:
+    """Extract Swift import declarations."""
+    imports: list[ImportInfo] = []
+
+    for node in root.named_children:
+        if node.type != "import_declaration":
+            continue
+        ident = next(
+            (child for child in node.named_children if child.type == "identifier"),
+            None,
+        )
+        if ident is None:
+            continue
+        qualified = _text(ident)
+        if not qualified:
+            continue
+        module, name = _split_swift_import(qualified)
+        imports.append(
+            ImportInfo(
+                file="",
+                module=module,
+                name=name,
+                alias=None,
+                is_from=True,
+            )
+        )
+
+    return imports
+
+
 # C++ extraction
 # ---------------------------------------------------------------------------
 
@@ -2749,7 +2930,7 @@ def parse_file(filepath: Path) -> FileParseResult:
 
     Detects language from file extension and dispatches to the correct
     tree-sitter grammar. Supports Python, TypeScript/JavaScript, Rust, Go,
-    Java, C#, Ruby, C, C++, PHP, and Kotlin.
+    Java, C#, Ruby, C, C++, PHP, Kotlin, and Swift.
     """
     code = filepath.read_bytes()
     lang_name = _detect_language(filepath)
@@ -2795,6 +2976,9 @@ def parse_file(filepath: Path) -> FileParseResult:
     elif lang_name == "kotlin":
         symbols = _extract_symbols_kotlin(root, filename)
 
+    elif lang_name == "swift":
+        symbols = _extract_symbols_swift(root, filename)
+
     imports: list[ImportInfo] = []
     if lang_name == "python":
         imports = _extract_imports(root)
@@ -2818,6 +3002,8 @@ def parse_file(filepath: Path) -> FileParseResult:
         imports = _extract_imports_php(root)
     elif lang_name == "kotlin":
         imports = _extract_imports_kotlin(root)
+    elif lang_name == "swift":
+        imports = _extract_imports_swift(root)
 
     for imp in imports:
         imp.file = filename

--- a/packages/gptme-codegraph/src/gptme_codegraph/core.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/core.py
@@ -2555,7 +2555,14 @@ def _extract_imports_kotlin(root) -> list[ImportInfo]:
 
 
 def _swift_container_body(node):
-    """Return a Swift declaration body node when present."""
+    """Return a Swift declaration body node when present.
+
+    alex-pinkus/tree-sitter-swift uses a unified ``class_body`` node for all
+    nominal-type bodies (class, struct, extension, actor).  Only
+    ``protocol_body`` and ``enum_class_body`` are distinct.  If a future
+    grammar version introduces ``struct_body`` or ``actor_body``, update this
+    set to include them so methods inside those types are not silently skipped.
+    """
     for child in node.named_children:
         if child.type in {"class_body", "protocol_body", "enum_class_body"}:
             return child
@@ -2619,6 +2626,11 @@ def _extract_symbols_swift(root, filepath: str) -> list[Symbol]:
         )
 
     def _walk(node, parent_class: str | None = None) -> None:
+        # alex-pinkus/tree-sitter-swift emits ``class_declaration`` for all
+        # nominal types: class, struct, extension, and actor.  Only
+        # ``protocol_declaration`` is a distinct node.  If a future grammar
+        # version introduces ``extension_declaration`` or ``actor_declaration``,
+        # add them to this set so their members are not silently dropped.
         if node.type in {"class_declaration", "protocol_declaration"}:
             type_name = _swift_declaration_name(node)
             if type_name:

--- a/packages/gptme-codegraph/src/gptme_codegraph/core.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/core.py
@@ -779,10 +779,15 @@ def _last_swift_navigation_name(node) -> str | None:
         text = _text(suffix_name) if suffix_name is not None else _text(suffix)
         return text.lstrip(".") or None
 
+    # Only recurse into navigation_expression children in the fallback
+    # path.  Unrestricted recursion across all named_children can descend
+    # into argument sub-expressions (e.g. foo.bar(baz.qux())), yielding a
+    # name from an argument call rather than from the callee itself.
     for child in reversed(node.named_children):
-        found = _last_swift_navigation_name(child)
-        if found:
-            return found
+        if child.type == "navigation_expression":
+            found = _last_swift_navigation_name(child)
+            if found:
+                return found
     return None
 
 

--- a/packages/gptme-codegraph/tests/test_multilang.py
+++ b/packages/gptme-codegraph/tests/test_multilang.py
@@ -1,7 +1,8 @@
-"""Tests for multi-language support in gptme-codegraph (JS/TS, Rust, Go, Java, C#, Ruby, C++, Kotlin).
+"""Tests for multi-language support in gptme-codegraph (JS/TS, Rust, Go, Java, C#, Ruby, C++, Kotlin, Swift).
 
 Verifies that parse_file, extract_symbols, and build_index work correctly
-for JavaScript, TypeScript, Rust, Go, Java, C#, Ruby, C++, and Kotlin source files.
+for JavaScript, TypeScript, Rust, Go, Java, C#, Ruby, C++, Kotlin, and Swift
+source files.
 """
 
 from __future__ import annotations
@@ -65,6 +66,10 @@ _skip_no_php = pytest.mark.skipif(
 _skip_no_kotlin = pytest.mark.skipif(
     not _has_grammar("kotlin"),
     reason="tree-sitter-kotlin not installed",
+)
+_skip_no_swift = pytest.mark.skipif(
+    not _has_grammar("swift"),
+    reason="tree-sitter-swift not installed",
 )
 
 
@@ -2220,9 +2225,9 @@ def test_parse_kotlin_expression_body_calls(kotlin_module: Path):
     """Kotlin: calls in expression-body functions (fun f() = expr) are captured."""
     result = parse_file(kotlin_module)
     clamped = next(s for s in result.symbols if s.name == "clamped")
-    assert "max" in clamped.calls, (
-        "expression-body call 'max' not captured; " f"got calls={clamped.calls!r}"
-    )
+    assert (
+        "max" in clamped.calls
+    ), f"expression-body call 'max' not captured; got calls={clamped.calls!r}"
 
 
 @_skip_no_kotlin
@@ -2246,6 +2251,178 @@ def test_build_index_kotlin(kotlin_module: Path):
         index = build_index(d)
         assert index.lookup("Calculator"), "Calculator not found in index"
         assert index.lookup("helper"), "helper not found in index"
+
+
+# ---------------------------------------------------------------------------
+# Swift extraction tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def swift_module() -> Generator[Path, None, None]:
+    """A Swift file with imports, protocols, types, methods, and functions."""
+    code = """\
+import Foundation
+import class UIKit.UIViewController
+import struct SwiftUI.View
+
+protocol Describable {
+    func describe() -> String
+}
+
+class Calculator: Describable {
+    private var value: Int
+
+    init(value: Int = 0) {
+        self.value = value
+    }
+
+    func add(_ n: Int) -> Calculator {
+        value += n
+        log("added")
+        return self
+    }
+
+    func current() -> Int { value }
+
+    static func create(_ initial: Int) -> Calculator {
+        return Calculator(value: initial)
+    }
+}
+
+struct Logger {
+    func log(_ message: String) {
+        print(message)
+    }
+}
+
+enum Mode {
+    case fast
+}
+
+func helper(_ name: String) -> String {
+    return name.trimmingCharacters(in: .whitespaces).uppercased()
+}
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".swift", delete=False) as f:
+        f.write(code)
+        path = Path(f.name)
+    yield path
+    path.unlink(missing_ok=True)
+
+
+@_skip_no_swift
+def test_language_detection_swift(swift_module: Path):
+    """Swift: .swift files are detected as Swift."""
+    result = parse_file(swift_module)
+    assert result.language == "swift"
+
+
+@_skip_no_swift
+def test_parse_swift_types(swift_module: Path):
+    """Swift: classes, structs, enums, and protocols are class-kind symbols."""
+    result = parse_file(swift_module)
+    classes = {s.name for s in result.symbols if s.kind == "class"}
+    assert "Calculator" in classes
+    assert "Logger" in classes
+    assert "Mode" in classes
+    assert "Describable" in classes
+
+
+@_skip_no_swift
+def test_parse_swift_methods(swift_module: Path):
+    """Swift: methods, initializers, static methods, and protocol functions parse."""
+    result = parse_file(swift_module)
+    methods = {(s.name, s.parent_class) for s in result.symbols if s.kind == "method"}
+    assert ("init", "Calculator") in methods
+    assert ("add", "Calculator") in methods
+    assert ("current", "Calculator") in methods
+    assert ("create", "Calculator") in methods
+    assert ("describe", "Describable") in methods
+    assert ("log", "Logger") in methods
+
+
+@_skip_no_swift
+def test_parse_swift_top_level_function(swift_module: Path):
+    """Swift: top-level functions are extracted as functions."""
+    result = parse_file(swift_module)
+    functions = {s.name for s in result.symbols if s.kind == "function"}
+    assert "helper" in functions
+
+
+@_skip_no_swift
+def test_parse_swift_imports(swift_module: Path):
+    """Swift: import declarations split module and imported name."""
+    result = parse_file(swift_module)
+    imports = {(imp.module, imp.name, imp.alias) for imp in result.imports}
+    assert ("", "Foundation", None) in imports
+    assert ("UIKit", "UIViewController", None) in imports
+    assert ("SwiftUI", "View", None) in imports
+
+
+@_skip_no_swift
+def test_parse_swift_calls(swift_module: Path):
+    """Swift: simple and chained call expressions are extracted."""
+    result = parse_file(swift_module)
+    add = next(s for s in result.symbols if s.name == "add")
+    assert "log" in add.calls
+    create = next(s for s in result.symbols if s.name == "create")
+    assert "Calculator" in create.calls
+    log = next(s for s in result.symbols if s.name == "log")
+    assert "print" in log.calls
+    helper = next(s for s in result.symbols if s.name == "helper")
+    assert "trimmingCharacters" in helper.calls
+    assert "uppercased" in helper.calls
+
+
+@_skip_no_swift
+def test_parse_swift_line_numbers(swift_module: Path):
+    """Swift: symbol line numbers are positive and ordered."""
+    result = parse_file(swift_module)
+    assert result.symbols
+    for sym in result.symbols:
+        assert sym.start_line >= 1
+        assert sym.end_line >= sym.start_line
+
+
+@_skip_no_swift
+def test_build_index_swift(swift_module: Path):
+    """Swift: build_index picks up symbols from a .swift file."""
+    import shutil
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as d:
+        shutil.copy(swift_module, d)
+        index = build_index(d)
+        assert index.lookup("Calculator"), "Calculator not found in index"
+        assert index.lookup("helper"), "helper not found in index"
+
+
+@_skip_no_swift
+def test_parse_swift_extension_and_actor(tmp_path: Path):
+    """Swift: extensions and actors provide a parent container for methods."""
+    swift_file = tmp_path / "extensions.swift"
+    swift_file.write_text(
+        """\
+extension Calculator {
+    func reset() {
+        clear()
+    }
+}
+
+actor Store {
+    func save() {
+        persist()
+    }
+}
+"""
+    )
+    result = parse_file(swift_file)
+    methods = {(s.name, s.parent_class) for s in result.symbols if s.kind == "method"}
+    assert ("reset", "Calculator") in methods
+    assert ("save", "Store") in methods
+    reset = next(s for s in result.symbols if s.name == "reset")
+    assert "clear" in reset.calls
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -1357,6 +1357,7 @@ treesitter = [
     { name = "tree-sitter-python" },
     { name = "tree-sitter-ruby" },
     { name = "tree-sitter-rust" },
+    { name = "tree-sitter-swift" },
     { name = "tree-sitter-typescript" },
 ]
 
@@ -1377,6 +1378,7 @@ requires-dist = [
     { name = "tree-sitter-python", marker = "extra == 'treesitter'", specifier = ">=0.21.0" },
     { name = "tree-sitter-ruby", marker = "extra == 'treesitter'", specifier = ">=0.23.0" },
     { name = "tree-sitter-rust", marker = "extra == 'treesitter'", specifier = ">=0.24.0" },
+    { name = "tree-sitter-swift", marker = "extra == 'treesitter'", specifier = ">=0.7.3" },
     { name = "tree-sitter-typescript", marker = "extra == 'treesitter'", specifier = ">=0.23.0" },
 ]
 provides-extras = ["treesitter", "mcp", "dev"]
@@ -5274,6 +5276,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/e1/3519f866a4679ca36acd9f5a06a779ecb8a92b18887c5546458d521df557/tree_sitter_rust-0.24.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:da2b86099028fd42c6cd32878b7b16b01f8aac0f7b0e98742b7fa6bc3cf09b89", size = 162403, upload-time = "2026-03-27T21:08:52.588Z" },
     { url = "https://files.pythonhosted.org/packages/34/71/7ef609894dbfe5699eb16f7471f9b8af1d958d8ba3e29c238d7607e8cb47/tree_sitter_rust-0.24.2-cp39-abi3-win_amd64.whl", hash = "sha256:4529c125d928882ddfb879fdc6bc0704913261ecc078b6fa7902559e0daf200d", size = 129422, upload-time = "2026-03-27T21:08:54.031Z" },
     { url = "https://files.pythonhosted.org/packages/b9/d8/050a781172745bc345f98abb7c56e72022ea0790f8e793de981c83c2ef15/tree_sitter_rust-0.24.2-cp39-abi3-win_arm64.whl", hash = "sha256:66ba90f61bd54f4c4f5d30434957daf64507c16b0313df76becb37d63f70a227", size = 128245, upload-time = "2026-03-27T21:08:54.803Z" },
+]
+
+[[package]]
+name = "tree-sitter-swift"
+version = "0.7.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/aa/8e7b789bb74ad7b9efb784bfb7d42bbcf064288d7716a72b68211ac6c3d4/tree_sitter_swift-0.7.3.tar.gz", hash = "sha256:a87f1dba3050a346ee3442aad8d727afd74555dea258e31c71c7934d8c04af9b", size = 1015814, upload-time = "2026-06-01T00:42:20.528Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/9d/df190b08548dcfa67790d3197442989b3dd5e46d31ee61a1b9ecea35d57b/tree_sitter_swift-0.7.3-cp38-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2531ec866c22ea52384e2786e07f3b2bb396c6446428a2df02cc74af3f7e6b6a", size = 357955, upload-time = "2026-06-01T00:42:10.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/37/84e2bc7826eb9007c531f47e5557461c5a48fd14bd3ea82424afa3d06b5f/tree_sitter_swift-0.7.3-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:ee627e027d0868c552beca13dcdfa9944662b126f642464c5038ee3204e68340", size = 381009, upload-time = "2026-06-01T00:42:12.182Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/9a/55f6cc9aad9079facf166d616472fd8e05007cbee9c62b749e153bf0521d/tree_sitter_swift-0.7.3-cp38-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f38feeb4f7350c8b30d567a0dc08bf1eeaa67c241b6888d72a45a8b1a4aa7187", size = 386994, upload-time = "2026-06-01T00:42:13.609Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/38/0b7c4d195d03396c19a7968a13342c89cb8322d97c4882bb7c4240adf419/tree_sitter_swift-0.7.3-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eee02fecb60a07267edd123148c583d6ec9efc5d7fcb25e53da4e56869fd4cf3", size = 381113, upload-time = "2026-06-01T00:42:14.776Z" },
+    { url = "https://files.pythonhosted.org/packages/81/34/48014e4cee1e2cf194675beeb435612a781f5cfa3c6f0e14b023b70c5cd7/tree_sitter_swift-0.7.3-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f30c30831f090ebe245f54ddcd280d2c5f7020ba17d6bbec1662bbfae140c467", size = 380282, upload-time = "2026-06-01T00:42:15.818Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1c/7ed9e76f14918106a27c548efc64f123af4b8e6424fcae13481683bb09a4/tree_sitter_swift-0.7.3-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:01c1e812289a2f7f01f63627a5d94a0b57d69332e8b52624becfe79ee8061651", size = 385590, upload-time = "2026-06-01T00:42:16.92Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/bb/e4e12fa0523c1acb2f9c4cebc454cd5415e94c915ad7f0b4b151ad13bc30/tree_sitter_swift-0.7.3-cp38-abi3-win_amd64.whl", hash = "sha256:4b1de6122cbd82b2cea6d3a295f9f5f9297601b829061119e161da17a7ba7d17", size = 365047, upload-time = "2026-06-01T00:42:18.02Z" },
+    { url = "https://files.pythonhosted.org/packages/70/7b/faf0fa8a99a217952b57aa43ed1b85ede798b3e8af51344cb5234766f718/tree_sitter_swift-0.7.3-cp38-abi3-win_arm64.whl", hash = "sha256:af44acc50d16f284abb607ae0cf7f81011d5566283d6c62a045a549a9331a653", size = 359248, upload-time = "2026-06-01T00:42:19.135Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add `.swift` detection and `tree-sitter-swift` grammar loading
- extract Swift types, protocols, methods, initializers, top-level functions, imports, and call expressions
- document Swift in the codegraph README and commit-map freshness extension list

## Verification
- `uv run --package gptme-codegraph --extra treesitter pytest packages/gptme-codegraph/tests -q` (250 passed, 1 skipped)
- `uv run --package gptme-codegraph --extra treesitter mypy packages/gptme-codegraph/src/gptme_codegraph/core.py`
- `prek run --files packages/gptme-codegraph/README.md packages/gptme-codegraph/pyproject.toml packages/gptme-codegraph/src/gptme_codegraph/core.py packages/gptme-codegraph/tests/test_multilang.py uv.lock`
