### PR TITLE
fix(codegraph): link receiver method calls

### DIFF
--- a/packages/gptme-codegraph/src/gptme_codegraph/core.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/core.py
@@ -836,6 +836,35 @@ def _extract_calls(node) -> list[str]:
     return calls
 
 
+def _rust_receiver_call_aliases(calls: list[str]) -> list[str]:
+    """Return local method aliases for Rust receiver/associated self calls."""
+    aliases: list[str] = []
+    for call in calls:
+        if call.startswith("self."):
+            method = call.removeprefix("self.")
+            if method and "." not in method:
+                aliases.append(method)
+        elif call.startswith("Self::"):
+            method = call.removeprefix("Self::")
+            if method and "::" not in method:
+                aliases.append(method)
+    return aliases
+
+
+def _go_receiver_call_aliases(calls: list[str], receiver_name: str | None) -> list[str]:
+    """Return local method aliases for Go calls through the method receiver."""
+    if not receiver_name:
+        return []
+    prefix = f"{receiver_name}."
+    aliases: list[str] = []
+    for call in calls:
+        if call.startswith(prefix):
+            method = call.removeprefix(prefix)
+            if method and "." not in method:
+                aliases.append(method)
+    return aliases
+
+
 def _strip_string_quotes(text: str) -> str:
     """Return a string literal without its outer quote characters."""
     if len(text) >= 2 and text[0] == text[-1] and text[0] in {'"', "'"}:
@@ -1334,6 +1363,8 @@ def _extract_symbols_rust(root, filepath: str) -> list[Symbol]:
                 kind = "method" if parent_kind == "impl" else "function"
                 parent_class = parent_scope if kind == "method" else None
                 calls = _extract_calls(body_node) if body_node else []
+                if kind == "method":
+                    calls.extend(_rust_receiver_call_aliases(calls))
                 symbols.append(
                     Symbol(
                         name=name,
@@ -1459,6 +1490,16 @@ def _receiver_type_go(receiver_node) -> str | None:
     return None
 
 
+def _receiver_name_go(receiver_node) -> str | None:
+    """Extract the variable name from a Go receiver parameter_list."""
+    for child in receiver_node.named_children:
+        if child.type == "parameter_declaration":
+            name_node = child.child_by_field_name("name")
+            if name_node is not None:
+                return _text(name_node)
+    return None
+
+
 def _extract_symbols_go(root, filepath: str) -> list[Symbol]:
     """Extract functions, methods, and named types from a Go parse tree."""
     symbols: list[Symbol] = []
@@ -1486,8 +1527,12 @@ def _extract_symbols_go(root, filepath: str) -> list[Symbol]:
                 parent_class = (
                     _receiver_type_go(receiver_node) if receiver_node else None
                 )
+                receiver_name = (
+                    _receiver_name_go(receiver_node) if receiver_node else None
+                )
                 body_node = node.child_by_field_name("body")
                 calls = _extract_calls(body_node) if body_node else []
+                calls.extend(_go_receiver_call_aliases(calls, receiver_name))
                 symbols.append(
                     Symbol(
                         name=_text(name_node),

--- a/packages/gptme-codegraph/src/gptme_codegraph/core.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/core.py
@@ -860,24 +860,116 @@ def _rust_receiver_call_aliases(
     return aliases
 
 
+def _go_node_declares_identifier(node, name: str) -> bool:
+    """Return True when a Go declaration node binds ``name`` on its left side."""
+    if node is None:
+        return False
+    if node.type == "range_clause" and ":=" not in _text(node):
+        return False
+    if node.type not in {
+        "short_var_declaration",
+        "range_clause",
+        "var_declaration",
+        "var_spec",
+        "parameter_declaration",
+    }:
+        return False
+
+    left_node = (
+        node.child_by_field_name("left")
+        or node.child_by_field_name("name")
+        or node.child_by_field_name("parameters")
+    )
+    search_node = left_node or node
+    stack = list(search_node.named_children)
+    while stack:
+        child = stack.pop()
+        if child.type == "identifier" and _text(child) == name:
+            return True
+        stack.extend(child.named_children)
+    return False
+
+
+def _go_selector_method_name(node, receiver_name: str) -> str | None:
+    """Return the method name for ``receiver.method()`` Go call expressions."""
+    if node.type != "call_expression":
+        return None
+    function_node = node.child_by_field_name("function")
+    if function_node is None or function_node.type != "selector_expression":
+        return None
+    operand_node = function_node.child_by_field_name("operand")
+    field_node = function_node.child_by_field_name("field")
+    if (
+        operand_node is None
+        or field_node is None
+        or operand_node.type != "identifier"
+        or _text(operand_node) != receiver_name
+    ):
+        return None
+    method = _text(field_node)
+    return method if method else None
+
+
 def _go_receiver_call_aliases(
-    calls: list[str], receiver_name: str | None, parent_class: str | None
+    body_node, receiver_name: str | None, parent_class: str | None
 ) -> list[str]:
-    """Return local method aliases for Go calls through the method receiver.
+    """Return local method aliases for unshadowed Go receiver calls.
 
     Aliases are qualified as ParentClass.method to avoid bare-name
     collisions when multiple types in the same file define methods with
-    the same name.
+    the same name.  They are only emitted for selector calls that still
+    refer to the method receiver; local variables that shadow the receiver
+    name must not create self-call edges.
     """
-    if not receiver_name or not parent_class:
+    if not body_node or not receiver_name or not parent_class:
         return []
-    prefix = f"{receiver_name}."
+
     aliases: list[str] = []
-    for call in calls:
-        if call.startswith(prefix):
-            method = call.removeprefix(prefix)
-            if method and "." not in method:
-                aliases.append(f"{parent_class}.{method}")
+
+    def visit(node, receiver_shadowed: bool = False) -> None:
+        method = _go_selector_method_name(node, receiver_name)
+        if method and not receiver_shadowed:
+            aliases.append(f"{parent_class}.{method}")
+
+        if node.type in {"block", "statement_list"}:
+            local_shadowed = receiver_shadowed
+            for child in node.named_children:
+                visit(child, local_shadowed)
+                if _go_node_declares_identifier(child, receiver_name):
+                    local_shadowed = True
+            return
+
+        if node.type == "if_statement":
+            initializer = node.child_by_field_name("initializer")
+            if initializer is not None:
+                visit(initializer, receiver_shadowed)
+            initializer_shadows = _go_node_declares_identifier(
+                initializer, receiver_name
+            )
+            scoped_shadowed = receiver_shadowed or initializer_shadows
+            for field in ("condition", "consequence", "alternative"):
+                child = node.child_by_field_name(field)
+                if child is not None:
+                    visit(child, scoped_shadowed)
+            return
+
+        if node.type == "for_statement":
+            body = node.child_by_field_name("body")
+            for_child_shadowed = receiver_shadowed
+            for child in node.named_children:
+                if child == body:
+                    continue
+                visit(child, receiver_shadowed)
+                if _go_node_declares_identifier(child, receiver_name):
+                    for_child_shadowed = True
+            if body is not None:
+                visit(body, receiver_shadowed or for_child_shadowed)
+            return
+
+        for child in node.named_children:
+            visit(child, receiver_shadowed)
+
+    visit(body_node)
     return aliases
 
 
@@ -1549,7 +1641,7 @@ def _extract_symbols_go(root, filepath: str) -> list[Symbol]:
                 body_node = node.child_by_field_name("body")
                 calls = _extract_calls(body_node) if body_node else []
                 calls.extend(
-                    _go_receiver_call_aliases(calls, receiver_name, parent_class)
+                    _go_receiver_call_aliases(body_node, receiver_name, parent_class)
                 )
                 symbols.append(
                     Symbol(
@@ -2942,8 +3034,9 @@ def build_call_graph(
         # Add qualified-name entries for methods with a parent class.
         # This prevents bare-name collisions when two types define a
         # method with the same name (common with "log", "String", etc.).
-        # Aliases from _rust/go_receiver_call_aliases are bare names,
-        # but _resolve_call below tries the qualified form on collision.
+        # Receiver-call aliases are qualified, so self/receiver-local method
+        # calls can resolve without colliding with same-named methods on
+        # other types.
         if s.parent_class and s.name:
             qualified_key = f"{s.parent_class}.{s.name}"
             name_to_qid[qualified_key] = qid

--- a/packages/gptme-codegraph/src/gptme_codegraph/core.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/core.py
@@ -836,24 +836,40 @@ def _extract_calls(node) -> list[str]:
     return calls
 
 
-def _rust_receiver_call_aliases(calls: list[str]) -> list[str]:
-    """Return local method aliases for Rust receiver/associated self calls."""
+def _rust_receiver_call_aliases(
+    calls: list[str], parent_class: str | None
+) -> list[str]:
+    """Return local method aliases for Rust receiver/associated self calls.
+
+    Aliases are qualified as ParentClass.method to avoid bare-name
+    collisions when multiple types in the same file define methods with
+    the same name.
+    """
+    if not parent_class:
+        return []
     aliases: list[str] = []
     for call in calls:
         if call.startswith("self."):
             method = call.removeprefix("self.")
             if method and "." not in method:
-                aliases.append(method)
+                aliases.append(f"{parent_class}.{method}")
         elif call.startswith("Self::"):
             method = call.removeprefix("Self::")
             if method and "::" not in method:
-                aliases.append(method)
+                aliases.append(f"{parent_class}.{method}")
     return aliases
 
 
-def _go_receiver_call_aliases(calls: list[str], receiver_name: str | None) -> list[str]:
-    """Return local method aliases for Go calls through the method receiver."""
-    if not receiver_name:
+def _go_receiver_call_aliases(
+    calls: list[str], receiver_name: str | None, parent_class: str | None
+) -> list[str]:
+    """Return local method aliases for Go calls through the method receiver.
+
+    Aliases are qualified as ParentClass.method to avoid bare-name
+    collisions when multiple types in the same file define methods with
+    the same name.
+    """
+    if not receiver_name or not parent_class:
         return []
     prefix = f"{receiver_name}."
     aliases: list[str] = []
@@ -861,7 +877,7 @@ def _go_receiver_call_aliases(calls: list[str], receiver_name: str | None) -> li
         if call.startswith(prefix):
             method = call.removeprefix(prefix)
             if method and "." not in method:
-                aliases.append(method)
+                aliases.append(f"{parent_class}.{method}")
     return aliases
 
 
@@ -1364,7 +1380,7 @@ def _extract_symbols_rust(root, filepath: str) -> list[Symbol]:
                 parent_class = parent_scope if kind == "method" else None
                 calls = _extract_calls(body_node) if body_node else []
                 if kind == "method":
-                    calls.extend(_rust_receiver_call_aliases(calls))
+                    calls.extend(_rust_receiver_call_aliases(calls, parent_class))
                 symbols.append(
                     Symbol(
                         name=name,
@@ -1532,7 +1548,9 @@ def _extract_symbols_go(root, filepath: str) -> list[Symbol]:
                 )
                 body_node = node.child_by_field_name("body")
                 calls = _extract_calls(body_node) if body_node else []
-                calls.extend(_go_receiver_call_aliases(calls, receiver_name))
+                calls.extend(
+                    _go_receiver_call_aliases(calls, receiver_name, parent_class)
+                )
                 symbols.append(
                     Symbol(
                         name=_text(name_node),
@@ -2917,14 +2935,43 @@ def build_call_graph(
     """
     known_names = {s.name for s in symbols}
     # Map bare names → qualified IDs for the single-file case.
-    # Within one file, name collisions don't occur, so this is 1:1.
     name_to_qid: dict[str, str] = {}
     for s in symbols:
         qid = s.qualified_id()
         name_to_qid[s.name] = qid
+        # Add qualified-name entries for methods with a parent class.
+        # This prevents bare-name collisions when two types define a
+        # method with the same name (common with "log", "String", etc.).
+        # Aliases from _rust/go_receiver_call_aliases are bare names,
+        # but _resolve_call below tries the qualified form on collision.
+        if s.parent_class and s.name:
+            qualified_key = f"{s.parent_class}.{s.name}"
+            name_to_qid[qualified_key] = qid
+            known_names.add(qualified_key)
 
     callees: dict[str, set[str]] = {}
     callers: dict[str, set[str]] = defaultdict(set)
+
+    # Detect bare-name collisions across types (e.g., two types both
+    # defining a "log" method).  When a caller with a known parent_class
+    # references a colliding bare name, prefer the qualified lookup
+    # ("ParentClass.method") to avoid wrong-type edges.
+    _collision_names = {
+        name
+        for name in known_names
+        if "." not in name and sum(1 for s in symbols if s.name == name) > 1
+    }
+
+    def _resolve_call(call: str, sym: Symbol) -> str | None:
+        qid = name_to_qid.get(call)
+        if qid is None:
+            return None
+        if call in _collision_names and sym.parent_class:
+            qualified_c = f"{sym.parent_class}.{call}"
+            qid_preferred = name_to_qid.get(qualified_c)
+            if qid_preferred is not None:
+                return qid_preferred
+        return qid
 
     for sym in symbols:
         if sym.kind == "class":
@@ -2932,7 +2979,11 @@ def build_call_graph(
         qid = name_to_qid.get(sym.name, sym.qualified_id())
         # Filter to known symbols only: excludes external builtins and dotted
         # attribute calls like 'calc.add' that can't be resolved locally.
-        filtered_calls = {name_to_qid[c] for c in sym.calls if c in known_names}
+        filtered_calls = {
+            resolved
+            for c in sym.calls
+            if c in known_names and (resolved := _resolve_call(c, sym)) is not None
+        }
         callees[qid] = filtered_calls
         for called_qid in filtered_calls:
             callers[called_qid].add(qid)

--- a/packages/gptme-codegraph/tests/test_multilang.py
+++ b/packages/gptme-codegraph/tests/test_multilang.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 from gptme_codegraph.core import (
     _tree_sitter_parse,
+    build_call_graph,
     build_index,
     extract_symbols,
     parse_file,
@@ -641,6 +642,52 @@ def test_parse_rust_impl_method_calls(rust_module: Path):
     assert with_max.calls == []
 
 
+@_skip_no_rust
+def test_parse_rust_receiver_method_calls_link_call_graph(tmp_path: Path):
+    """Rust: self/Self method calls are linked to local impl methods."""
+    rust_file = tmp_path / "receiver_calls.rs"
+    rust_file.write_text(
+        """\
+struct Client;
+
+impl Client {
+    fn run(&self) -> i32 {
+        self.prepare();
+        Self::make();
+        helper()
+    }
+
+    fn prepare(&self) {}
+
+    fn make() -> i32 {
+        1
+    }
+}
+
+fn helper() -> i32 {
+    1
+}
+"""
+    )
+    result = parse_file(rust_file)
+    run = next(
+        (s for s in result.symbols if s.name == "run" and s.parent_class == "Client"),
+        None,
+    )
+    assert run is not None, "run method not found in parse result"
+    assert "self.prepare" in run.calls
+    assert "prepare" in run.calls
+    assert "Self::make" in run.calls
+    assert "make" in run.calls
+
+    callees, callers = build_call_graph(result.symbols)
+    assert "::Client.prepare" in callees["::Client.run"]
+    assert "::Client.make" in callees["::Client.run"]
+    assert "::helper" in callees["::Client.run"]
+    assert "::Client.run" in callers["::Client.prepare"]
+    assert "::Client.run" in callers["::Client.make"]
+
+
 # ---------------------------------------------------------------------------
 # Rust import extraction
 # ---------------------------------------------------------------------------
@@ -861,6 +908,47 @@ def test_parse_go_method_calls(go_module: Path):
     )
     assert add is not None
     assert any("Println" in c for c in add.calls)
+
+
+@_skip_no_go
+def test_parse_go_receiver_method_calls_link_call_graph(tmp_path: Path):
+    """Go: receiver method calls are linked to local methods."""
+    go_file = tmp_path / "receiver_calls.go"
+    go_file.write_text(
+        """\
+package main
+
+type Calculator struct{}
+
+func (c *Calculator) Add(a, b int) int {
+    c.log()
+    return helper(a + b)
+}
+
+func (c *Calculator) log() {}
+
+func helper(v int) int {
+    return v
+}
+"""
+    )
+    result = parse_file(go_file)
+    add = next(
+        (
+            s
+            for s in result.symbols
+            if s.name == "Add" and s.parent_class == "Calculator"
+        ),
+        None,
+    )
+    assert add is not None, "Add method not found in parse result"
+    assert "c.log" in add.calls
+    assert "log" in add.calls
+
+    callees, callers = build_call_graph(result.symbols)
+    assert "::Calculator.log" in callees["::Calculator.Add"]
+    assert "::helper" in callees["::Calculator.Add"]
+    assert "::Calculator.Add" in callers["::Calculator.log"]
 
 
 @_skip_no_go

--- a/packages/gptme-codegraph/tests/test_multilang.py
+++ b/packages/gptme-codegraph/tests/test_multilang.py
@@ -952,6 +952,53 @@ func helper(v int) int {
 
 
 @_skip_no_go
+def test_parse_go_receiver_aliases_skip_shadowed_locals(tmp_path: Path):
+    """Go: receiver aliases don't treat same-named locals as self calls."""
+    go_file = tmp_path / "receiver_shadow.go"
+    go_file.write_text(
+        """\
+package main
+
+type Client struct{}
+type Call struct{}
+
+func (c *Call) doX() {}
+
+func (c *Client) Run(calls []Call) {
+    c.log()
+    for _, c := range calls {
+        c.doX()
+    }
+    {
+        var c Call
+        c.doX()
+    }
+    c.finish()
+}
+
+func (c *Client) log() {}
+func (c *Client) finish() {}
+func (c *Client) doX() {}
+"""
+    )
+    result = parse_file(go_file)
+    run = next(
+        (s for s in result.symbols if s.name == "Run" and s.parent_class == "Client"),
+        None,
+    )
+    assert run is not None, "Run method not found in parse result"
+    assert "Client.log" in run.calls
+    assert "Client.finish" in run.calls
+    assert "Client.doX" not in run.calls
+
+    callees, _callers = build_call_graph(result.symbols)
+    assert "::Client.log" in callees["::Client.Run"]
+    assert "::Client.finish" in callees["::Client.Run"]
+    assert "::Client.doX" not in callees["::Client.Run"]
+    assert "::Call.doX" not in callees["::Client.Run"]
+
+
+@_skip_no_go
 def test_parse_go_imports_basic(go_module: Path):
     """Go: plain imports are extracted."""
     result = parse_file(go_module)

--- a/packages/gptme-codegraph/tests/test_multilang.py
+++ b/packages/gptme-codegraph/tests/test_multilang.py
@@ -676,9 +676,9 @@ fn helper() -> i32 {
     )
     assert run is not None, "run method not found in parse result"
     assert "self.prepare" in run.calls
-    assert "prepare" in run.calls
+    assert "Client.prepare" in run.calls
     assert "Self::make" in run.calls
-    assert "make" in run.calls
+    assert "Client.make" in run.calls
 
     callees, callers = build_call_graph(result.symbols)
     assert "::Client.prepare" in callees["::Client.run"]
@@ -943,7 +943,7 @@ func helper(v int) int {
     )
     assert add is not None, "Add method not found in parse result"
     assert "c.log" in add.calls
-    assert "log" in add.calls
+    assert "Calculator.log" in add.calls
 
     callees, callers = build_call_graph(result.symbols)
     assert "::Calculator.log" in callees["::Calculator.Add"]
@@ -2349,3 +2349,73 @@ def test_build_index_cpp(cpp_module: Path):
         index = build_index(d)
         assert "Accumulator" in index.entries
         assert "add" in index.entries
+
+
+@_skip_no_go
+def test_parse_go_receiver_calls_no_collision_across_types(tmp_path: Path):
+    """Go: receiver aliases are qualified so same-named methods across types don't collide."""
+    go_file = tmp_path / "multitype.go"
+    go_file.write_text(
+        """\
+package main
+
+type Log struct{}
+func (l *Log) format() string { return "" }
+
+type Report struct{}
+func (r *Report) format() string { return "" }
+
+func (r *Report) Generate() string {
+    r.format()
+    return ""
+}
+"""
+    )
+    result = parse_file(go_file)
+
+    report_gen = next(
+        s for s in result.symbols if s.name == "Generate" and s.parent_class == "Report"
+    )
+    # The alias should be "Report.format", not bare "format"
+    assert "Report.format" in report_gen.calls  # qualified alias
+    assert "format" not in report_gen.calls  # bare name should not appear
+
+    callees, callers = build_call_graph(result.symbols)
+    # Report.Generate should call Report.format, not Log.format
+    assert "::Report.format" in callees["::Report.Generate"]
+    assert "::Log.format" not in callees["::Report.Generate"]
+
+
+@_skip_no_rust
+def test_parse_rust_receiver_calls_no_collision_across_types(tmp_path: Path):
+    """Rust: receiver aliases are qualified so same-named methods across types don't collide."""
+    rs_file = tmp_path / "multitype.rs"
+    rs_file.write_text(
+        """\
+struct Counter {}
+impl Counter {
+    fn reset(&self) {}
+    fn tick(&self) {
+        self.reset();
+    }
+}
+
+struct Timer {}
+impl Timer {
+    fn reset(&self) {}
+}
+"""
+    )
+    result = parse_file(rs_file)
+
+    tick = next(
+        s for s in result.symbols if s.name == "tick" and s.parent_class == "Counter"
+    )
+    # The alias should be "Counter.reset", not bare "reset"
+    assert "Counter.reset" in tick.calls  # qualified alias
+    assert "reset" not in tick.calls  # bare name should not appear
+
+    callees, callers = build_call_graph(result.symbols)
+    # Counter.tick should call Counter.reset, not Timer.reset
+    assert "::Counter.reset" in callees["::Counter.tick"]
+    assert "::Timer.reset" not in callees["::Counter.tick"]


### PR DESCRIPTION
## Summary
- add Rust receiver aliases for `self.method()` and `Self::method()` calls so impl-local methods appear in call graphs
- add Go receiver aliases for `c.method()` calls so receiver-local methods appear in call graphs
- cover both cases with call graph tests

## Verification
- `uv run --package gptme-codegraph --extra treesitter --extra mcp --extra dev python3 -m pytest packages/gptme-codegraph/tests -q`
- `uv run --package gptme-codegraph --extra treesitter --extra dev python3 -m mypy packages/gptme-codegraph/src/gptme_codegraph/core.py`
- `prek run --files packages/gptme-codegraph/src/gptme_codegraph/core.py packages/gptme-codegraph/tests/test_multilang.py`