### PR TITLE
test(codegraph): add Python cross-module call resolution tests

### DIFF
--- a/packages/gptme-codegraph/tests/test_codegraph.py
+++ b/packages/gptme-codegraph/tests/test_codegraph.py
@@ -1288,6 +1288,32 @@ def test_cross_file_call_graph_typescript_namespace_import(tmp_path: Path):
     assert "main::main" in callers.get("utils::greet", set())
 
 
+def test_cross_file_call_graph_python_from_import(tmp_path: Path):
+    """Python from-import: from utils import greet; greet()."""
+    (tmp_path / "utils.py").write_text("def greet(): pass\n")
+    (tmp_path / "main.py").write_text(
+        "from utils import greet\ndef run():\n    greet()\n"
+    )
+
+    index = build_index(tmp_path)
+    callees, callers = build_cross_file_call_graph(index, tmp_path)
+
+    assert "utils::greet" in callees.get("main::run", set())
+    assert "main::run" in callers.get("utils::greet", set())
+
+
+def test_cross_file_call_graph_python_module_import(tmp_path: Path):
+    """Python module import: import utils; utils.greet()."""
+    (tmp_path / "utils.py").write_text("def greet(): pass\n")
+    (tmp_path / "main.py").write_text("import utils\ndef run():\n    utils.greet()\n")
+
+    index = build_index(tmp_path)
+    callees, callers = build_cross_file_call_graph(index, tmp_path)
+
+    assert "utils::greet" in callees.get("main::run", set())
+    assert "main::run" in callers.get("utils::greet", set())
+
+
 @_skip_no_go
 def test_cross_file_call_graph_go_pkg_qualified(tmp_path: Path):
     """Go package-qualified call: import 'pkg'; pkg.Func()."""


### PR DESCRIPTION
## Summary

Adds explicit tests for Python cross-module call resolution, which was already implemented but untested:

- `test_cross_file_call_graph_python_from_import` — verifies `from utils import greet; greet()` resolves to `utils::greet`
- `test_cross_file_call_graph_python_module_import` — verifies `import utils; utils.greet()` resolves to `utils::greet`

Both forms already worked (the logic is in `_resolve_imported_symbol`), but there were no tests locking in this behaviour. TypeScript, Go, and Rust cross-module tests were added in #1044.

## Testing

- 2 new tests pass with `--all-extras`
- No changes to production code