### PR TITLE
feat(plugins): add gptme-headroom-compressor SmartCrusher hook

### DIFF
--- a/plugins/gptme-headroom-compressor/pyproject.toml
+++ b/plugins/gptme-headroom-compressor/pyproject.toml
@@ -8,8 +8,12 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+headroom = [
+    "headroom-ai>=0.1.0",
+]
 test = [
     "pytest>=8.0.0",
+    "headroom-ai>=0.1.0",
 ]
 
 [project.entry-points."gptme.plugins"]

--- a/plugins/gptme-headroom-compressor/pyproject.toml
+++ b/plugins/gptme-headroom-compressor/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "gptme-headroom-compressor"
+version = "0.1.0"
+description = "Headroom SmartCrusher lossless compression hook for gptme tool outputs"
+requires-python = ">=3.10"
+dependencies = [
+    "gptme>=0.29.0",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=8.0.0",
+]
+
+[project.entry-points."gptme.plugins"]
+headroom_compressor = "headroom_compressor:plugin"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/headroom_compressor"]

--- a/plugins/gptme-headroom-compressor/src/headroom_compressor/__init__.py
+++ b/plugins/gptme-headroom-compressor/src/headroom_compressor/__init__.py
@@ -1,0 +1,37 @@
+"""Read-time SmartCrusher compression plugin for gptme.
+
+Runs as a `generation_pre` hook at priority 201 (before the tooloutput-trimmer
+at 200). Applies SmartCrusher's lossless `crush()` to structured/tabular tool
+outputs before they reach the trimmer. Leaves unstructured outputs in place for
+the trimmer to handle.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+try:
+    from gptme.plugins.plugin import GptmePlugin
+except ModuleNotFoundError:
+
+    @dataclass(frozen=True)
+    class GptmePlugin:  # pragma: no cover - exercised in old-gptme envs
+        """Compatibility shim for pre-unified-plugin gptme releases."""
+
+        name: str
+        register_hooks: Callable[[], None] | None = None
+
+
+def _register_hooks() -> None:
+    from .hooks import register
+
+    register()
+
+
+plugin = GptmePlugin(
+    name="headroom_compressor",
+    register_hooks=_register_hooks,
+)
+
+__all__ = ["plugin"]

--- a/plugins/gptme-headroom-compressor/src/headroom_compressor/hooks/__init__.py
+++ b/plugins/gptme-headroom-compressor/src/headroom_compressor/hooks/__init__.py
@@ -1,0 +1,15 @@
+"""Hook exports for the headroom compressor plugin."""
+
+from .compressor import (
+    DEFAULT_MIN_COMPRESS_CHARS,
+    ENABLED_ENV_VAR,
+    generation_pre_hook,
+    register,
+)
+
+__all__ = [
+    "DEFAULT_MIN_COMPRESS_CHARS",
+    "ENABLED_ENV_VAR",
+    "generation_pre_hook",
+    "register",
+]

--- a/plugins/gptme-headroom-compressor/src/headroom_compressor/hooks/compressor.py
+++ b/plugins/gptme-headroom-compressor/src/headroom_compressor/hooks/compressor.py
@@ -40,6 +40,8 @@ def _get_crusher():
     """Lazy-init SmartCrusher. Returns None if headroom not available."""
     global _SmartCrusher
     if _SmartCrusher is not None:
+        if _SmartCrusher is False:  # sentinel — import previously failed
+            return None
         return _SmartCrusher()
 
     try:

--- a/plugins/gptme-headroom-compressor/src/headroom_compressor/hooks/compressor.py
+++ b/plugins/gptme-headroom-compressor/src/headroom_compressor/hooks/compressor.py
@@ -1,0 +1,157 @@
+"""Headroom SmartCrusher generation_pre hook for gptme.
+
+Applies lossless SmartCrusher compression to structured/tabular tool outputs
+before they reach the tooloutput-trimmer. Unstructured outputs pass through
+unchanged and are handled by the trimmer.
+
+SmartCrusher is imported lazily — if headroom-ai is not installed, the hook
+gracefully disables itself with a warning.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Generator
+from typing import Any
+
+from gptme.hooks import HookType, StopPropagation
+from gptme.message import Message
+
+logger = logging.getLogger(__name__)
+
+# Feature-flag env var
+ENABLED_ENV_VAR = "GPTME_HEADROOM_ENABLED"
+
+# Minimum content length to attempt compression
+DEFAULT_MIN_COMPRESS_CHARS = 2000
+
+# Tool output prefixes — same as the trimmer's TOOL_OUTPUT_PREFIXES
+TOOL_OUTPUT_PREFIXES = ("Ran command: `", "Executed code block.")
+
+# Sentinel string prepended to compressed content
+COMPRESSED_MARKER = "[Headroom compressed"
+
+# Lazy-loaded SmartCrusher
+_SmartCrusher = None  # type: ignore
+
+
+def _get_crusher():
+    """Lazy-init SmartCrusher. Returns None if headroom not available."""
+    global _SmartCrusher
+    if _SmartCrusher is not None:
+        return _SmartCrusher()
+
+    try:
+        from headroom.transforms.smart_crusher import SmartCrusher as _Cls
+
+        _SmartCrusher = _Cls
+        logger.info("headroom_compressor: SmartCrusher loaded")
+        return _SmartCrusher()
+    except ImportError:
+        logger.warning(
+            "headroom_compressor: headroom-ai not installed; "
+            "install with: pip install headroom-ai"
+        )
+        _SmartCrusher = False  # sentinel — don't retry
+        return None
+    except Exception:
+        logger.warning("headroom_compressor: SmartCrusher init failed", exc_info=True)
+        _SmartCrusher = False
+        return None
+
+
+def _check_enabled() -> bool:
+    val = os.environ.get(ENABLED_ENV_VAR, "").strip().lower()
+    return val in ("1", "true", "yes")
+
+
+def _is_compressible_message(
+    message: Message,
+    min_chars: int = DEFAULT_MIN_COMPRESS_CHARS,
+) -> bool:
+    """Check if a message is a tool output worth attempting compression on."""
+    if message.role != "system" or message.pinned:
+        return False
+    if not message.content:
+        return False
+    if message.content.startswith(COMPRESSED_MARKER):
+        return False
+    if not message.content.startswith(TOOL_OUTPUT_PREFIXES):
+        return False
+    if len(message.content) < min_chars:
+        return False
+    return True
+
+
+def generation_pre_hook(
+    messages: list[Message],
+    **kwargs: Any,
+) -> Generator[Message | StopPropagation, None, None]:
+    """Iterate tool output messages and apply SmartCrusher compression.
+
+    Runs at priority 201 (before the trimmer at 200). Transforms large
+    structured tool outputs losslessly. Unstructured/passthrough outputs
+    are left for the trimmer.
+    """
+    if not _check_enabled():
+        return
+
+    crusher = _get_crusher()
+    if crusher is None:
+        return
+
+    rewritten: list[Message] = []
+    compressed_count = 0
+    total_savings = 0
+
+    for message in messages:
+        if _is_compressible_message(message):
+            try:
+                result = crusher.crush(message.content)
+                if result.was_modified:
+                    original_len = len(result.original)
+                    compressed_len = len(result.compressed)
+                    savings_pct = round((1 - compressed_len / original_len) * 100)
+                    total_savings += original_len - compressed_len
+                    compressed_count += 1
+                    rewritten.append(
+                        message.replace(
+                            content=(
+                                f"{COMPRESSED_MARKER} "
+                                f"(orig={original_len}, "
+                                f"strategy={result.strategy}, "
+                                f"savings={savings_pct}%)]\n"
+                                f"{result.compressed}"
+                            )
+                        )
+                    )
+                    continue
+            except Exception:
+                logger.debug(
+                    "headroom_compressor: crush() failed on message",
+                    exc_info=True,
+                )
+        rewritten.append(message)
+
+    if compressed_count > 0:
+        messages[:] = rewritten
+        logger.info(
+            "headroom_compressor: compressed %d message(s), saved %d chars",
+            compressed_count,
+            total_savings,
+        )
+
+    yield from ()
+
+
+def register() -> None:
+    """Register the SmartCrusher generation_pre hook."""
+    from gptme.hooks import register_hook
+
+    register_hook(
+        name="headroom_compressor.generation_pre",
+        hook_type=HookType.GENERATION_PRE,
+        func=generation_pre_hook,
+        priority=201,
+    )

--- a/plugins/gptme-headroom-compressor/src/headroom_compressor/hooks/compressor.py
+++ b/plugins/gptme-headroom-compressor/src/headroom_compressor/hooks/compressor.py
@@ -86,6 +86,19 @@ def _is_compressible_message(
     return True
 
 
+def _split_tool_output(content: str) -> tuple[str, str]:
+    """Split tool output into (prefix_line, data).
+
+    The first line (command prefix like "Ran command: `...`") is separated
+    from the remaining data. SmartCrusher needs pure data to recognize
+    structured content types (JSON, tables, etc.).
+    """
+    idx = content.find("\n")
+    if idx == -1:
+        return content, ""
+    return content[: idx + 1], content[idx + 1 :]
+
+
 def generation_pre_hook(
     messages: list[Message],
     **kwargs: Any,
@@ -110,10 +123,11 @@ def generation_pre_hook(
     for message in messages:
         if _is_compressible_message(message):
             try:
-                result = crusher.crush(message.content)
+                prefix, data = _split_tool_output(message.content)
+                result = crusher.crush(data)
                 if result.was_modified:
-                    original_len = len(result.original)
-                    compressed_len = len(result.compressed)
+                    original_len = len(message.content)
+                    compressed_len = len(prefix) + len(result.compressed)
                     savings_pct = round((1 - compressed_len / original_len) * 100)
                     total_savings += original_len - compressed_len
                     compressed_count += 1
@@ -124,7 +138,7 @@ def generation_pre_hook(
                                 f"(orig={original_len}, "
                                 f"strategy={result.strategy}, "
                                 f"savings={savings_pct}%)]\n"
-                                f"{result.compressed}"
+                                f"{prefix}{result.compressed}"
                             )
                         )
                     )

--- a/plugins/gptme-headroom-compressor/tests/test_headroom_compressor.py
+++ b/plugins/gptme-headroom-compressor/tests/test_headroom_compressor.py
@@ -122,6 +122,13 @@ class TestGenerationPreHook:
     def _setup(self, monkeypatch):
         monkeypatch.setenv("GPTME_HEADROOM_ENABLED", "1")
 
+    def test_get_crusher_cached_import_failure_returns_none(self, monkeypatch):
+        """Cached import failure sentinel does not get called as a class."""
+        from headroom_compressor.hooks import compressor
+
+        monkeypatch.setattr(compressor, "_SmartCrusher", False)
+        assert compressor._get_crusher() is None
+
     def test_hook_enabled_flag(self, monkeypatch):
         """Feature flag gates the hook."""
         from headroom_compressor.hooks.compressor import generation_pre_hook
@@ -151,6 +158,36 @@ class TestGenerationPreHook:
         msgs = [msg]
         list(generation_pre_hook(msgs))
         assert "[Headroom compressed" not in msgs[0].content
+
+    def test_hook_compresses_structured_tool_output(self, monkeypatch):
+        """Structured tool output is compressed and keeps its command prefix."""
+        from dataclasses import dataclass
+
+        from headroom_compressor.hooks import compressor
+
+        @dataclass
+        class FakeResult:
+            was_modified: bool = True
+            strategy: str = "test"
+            compressed: str = '{"items":"compressed"}'
+
+        class FakeCrusher:
+            def crush(self, data: str) -> FakeResult:
+                assert data.startswith("[")
+                assert not data.startswith("Ran command:")
+                return FakeResult()
+
+        monkeypatch.setattr(compressor, "_get_crusher", lambda: FakeCrusher())
+        content = _build_json_array(200)
+        msg = _tool_message(content)
+        msgs = [msg]
+
+        list(compressor.generation_pre_hook(msgs))
+
+        assert msgs[0].content.startswith("[Headroom compressed")
+        assert "strategy=test" in msgs[0].content
+        assert "Ran command: `curl https://example.com/api/items/`" in msgs[0].content
+        assert '{"items":"compressed"}' in msgs[0].content
 
     def test_small_message_not_compressed(self, monkeypatch):
         """Small messages are not touched."""

--- a/plugins/gptme-headroom-compressor/tests/test_headroom_compressor.py
+++ b/plugins/gptme-headroom-compressor/tests/test_headroom_compressor.py
@@ -1,0 +1,181 @@
+"""Tests for the gptme headroom compressor hook."""
+
+from __future__ import annotations
+
+import pytest
+
+# ── helpers ────────────────────────────────────────────────────────
+
+
+def _tool_message(content: str):
+    """Build a Message-like object for testing."""
+    from dataclasses import dataclass
+
+    @dataclass
+    class FakeMessage:
+        role: str = "system"
+        content: str = ""
+        pinned: bool = False
+
+        def replace(self, **kwargs):
+            return FakeMessage(
+                **{  # type: ignore
+                    **{
+                        "role": self.role,
+                        "content": self.content,
+                        "pinned": self.pinned,
+                    },
+                    **kwargs,
+                }
+            )
+
+    return FakeMessage(role="system", content=content, pinned=False)
+
+
+def _build_grep_content(n: int = 500) -> str:
+    lines = [
+        f"./src/file_{i}.py:42:    return some_function_{i}(args)" for i in range(n)
+    ]
+    cmd = 'Ran command: `rg -n "pattern" src/`\n'
+    return cmd + "\n".join(lines)
+
+
+def _build_json_array(n: int = 500) -> str:
+    items = [
+        {
+            "id": i,
+            "name": f"item_{i}",
+            "status": "ok",
+            "version": i % 5,
+            "description": f"sample entry #{i} with enough text to be realistic",
+        }
+        for i in range(n)
+    ]
+    import json
+
+    cmd = "Ran command: `curl https://example.com/api/items/`\n"
+    return cmd + json.dumps(items)
+
+
+def _build_prose_content(n: int = 500) -> str:
+    para = (
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
+        "Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. "
+    )
+    cmd = "Ran command: `cat README.md`\n"
+    return cmd + para * n
+
+
+# ── _is_compressible_message tests ─────────────────────────────────
+
+
+class TestIsCompressibleMessage:
+    @pytest.fixture(autouse=True)
+    def _import(self):
+        from headroom_compressor.hooks.compressor import _is_compressible_message
+
+        self._check = _is_compressible_message
+
+    def test_compressible_grep_output(self):
+        msg = _tool_message(_build_grep_content(200))
+        assert self._check(msg, min_chars=1)
+
+    def test_compressible_json_array(self):
+        msg = _tool_message(_build_json_array(200))
+        assert self._check(msg, min_chars=1)
+
+    def test_small_message_not_compressible(self):
+        msg = _tool_message("Ran command: `ls`\nsmall")
+        assert not self._check(msg, min_chars=5000)
+
+    def test_non_tool_message_not_compressible(self):
+        msg = _tool_message("Just some random text without a tool prefix")
+        msg.role = "user"
+        assert not self._check(msg)
+
+    def test_pinned_message_not_compressible(self):
+        msg = _tool_message(_build_grep_content(200))
+        msg.pinned = True
+        assert not self._check(msg)
+
+    def test_already_compressed_skipped(self):
+        from headroom_compressor.hooks.compressor import COMPRESSED_MARKER
+
+        content = COMPRESSED_MARKER + " (orig=1000, strategy=passthrough)]\n..."
+        msg = _tool_message(content)
+        assert not self._check(msg)
+
+    def test_empty_content_skipped(self):
+        msg = _tool_message("")
+        assert not self._check(msg)
+
+    def test_below_min_chars(self):
+        msg = _tool_message("Ran command: `ls`\n" + "x" * 100)
+        assert not self._check(msg, min_chars=500)
+
+
+# ── generation_pre_hook tests ─────────────────────────────────────
+
+
+class TestGenerationPreHook:
+    @pytest.fixture(autouse=True)
+    def _setup(self, monkeypatch):
+        monkeypatch.setenv("GPTME_HEADROOM_ENABLED", "1")
+
+    def test_hook_enabled_flag(self, monkeypatch):
+        """Feature flag gates the hook."""
+        from headroom_compressor.hooks.compressor import generation_pre_hook
+
+        monkeypatch.setenv("GPTME_HEADROOM_ENABLED", "0")
+        msg = _tool_message(_build_grep_content(20))
+        msgs = [msg]
+        list(generation_pre_hook(msgs))
+
+    def test_hook_does_not_modify_when_disabled(self, monkeypatch):
+        """Disabled hook leaves messages unchanged."""
+        from headroom_compressor.hooks.compressor import generation_pre_hook
+
+        monkeypatch.delenv("GPTME_HEADROOM_ENABLED", raising=False)
+        content = _build_grep_content(200)
+        msg = _tool_message(content)
+        msgs = [msg]
+        list(generation_pre_hook(msgs))
+        assert msgs[0].content == content
+
+    def test_hook_passthrough_on_unstructured(self, monkeypatch):
+        """Unstructured/prose content is NOT compressed (left for trimmer)."""
+        from headroom_compressor.hooks.compressor import generation_pre_hook
+
+        content = _build_prose_content(100)
+        msg = _tool_message(content)
+        msgs = [msg]
+        list(generation_pre_hook(msgs))
+        assert "[Headroom compressed" not in msgs[0].content
+
+    def test_small_message_not_compressed(self, monkeypatch):
+        """Small messages are not touched."""
+        from headroom_compressor.hooks.compressor import generation_pre_hook
+
+        content = "Ran command: `ls`\nsmall"
+        msg = _tool_message(content)
+        msgs = [msg]
+        list(generation_pre_hook(msgs))
+        assert msgs[0].content == content
+
+    def test_register(self, monkeypatch):
+        """Registration produces a valid hook entry (name, priority)."""
+        from gptme.hooks import HookType, registry
+
+        fresh_registry = registry.HookRegistry()
+        # Monkeypatch at the re-export level so delayed imports in register() pick it up
+        monkeypatch.setattr("gptme.hooks.register_hook", fresh_registry.register)
+
+        from headroom_compressor.hooks.compressor import register
+
+        register()
+
+        hooks = fresh_registry.hooks.get(HookType.GENERATION_PRE, [])
+        matching = [h for h in hooks if h.name == "headroom_compressor.generation_pre"]
+        assert len(matching) == 1
+        assert matching[0].priority == 201
+        assert matching[0].enabled is True

--- a/plugins/gptme-headroom-compressor/tests/test_headroom_compressor.py
+++ b/plugins/gptme-headroom-compressor/tests/test_headroom_compressor.py
@@ -164,7 +164,12 @@ class TestGenerationPreHook:
 
     def test_register(self, monkeypatch):
         """Registration produces a valid hook entry (name, priority)."""
-        from gptme.hooks import HookType, registry
+        try:
+            from gptme.hooks import registry  # noqa: F401
+        except ImportError:
+            pytest.skip("gptme version does not expose hooks.registry")
+
+        from gptme.hooks import HookType
 
         fresh_registry = registry.HookRegistry()
         # Monkeypatch at the re-export level so delayed imports in register() pick it up

--- a/plugins/gptme-tooloutput-trimmer/src/tooloutput_trimmer/hooks/trimmer.py
+++ b/plugins/gptme-tooloutput-trimmer/src/tooloutput_trimmer/hooks/trimmer.py
@@ -46,6 +46,7 @@ DEFAULT_PRESSURE_CHARS = 100_000
 ANTHROPIC_CACHE_TTL_SECS = 5 * 60
 TOOL_OUTPUT_PREFIXES = ("Ran command: `", "Executed code block.")
 TRIMMED_MARKER = "[Tool output trimmed"
+HEADROOM_MARKER = "[Headroom compressed"  # skip messages already losslessly compressed
 BYPASS_ENV_VAR = "GPTME_TRIM_BYPASS"
 
 
@@ -220,6 +221,9 @@ def _is_tool_output_message(
     if message.role != "system" or message.pinned:
         return False
     if message.content.startswith(TRIMMED_MARKER):
+        return False
+    # Skip messages already losslessly compressed by headroom-compressor
+    if message.content.startswith(HEADROOM_MARKER):
         return False
     if len(message.content) <= max_output_chars:
         return False

--- a/uv.lock
+++ b/uv.lock
@@ -2,7 +2,8 @@ version = 1
 revision = 3
 requires-python = ">=3.10, <4.0"
 resolution-markers = [
-    "python_full_version >= '3.13'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
     "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
@@ -944,6 +945,69 @@ wheels = [
 ]
 
 [[package]]
+name = "fastuuid"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/7d/d9daedf0f2ebcacd20d599928f8913e9d2aea1d56d2d355a93bfa2b611d7/fastuuid-0.14.0.tar.gz", hash = "sha256:178947fc2f995b38497a74172adee64fdeb8b7ec18f2a5934d037641ba265d26", size = 18232, upload-time = "2025-10-19T22:19:22.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/b2/731a6696e37cd20eed353f69a09f37a984a43c9713764ee3f7ad5f57f7f9/fastuuid-0.14.0-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:6e6243d40f6c793c3e2ee14c13769e341b90be5ef0c23c82fa6515a96145181a", size = 516760, upload-time = "2025-10-19T22:25:21.509Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/79/c73c47be2a3b8734d16e628982653517f80bbe0570e27185d91af6096507/fastuuid-0.14.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:13ec4f2c3b04271f62be2e1ce7e95ad2dd1cf97e94503a3760db739afbd48f00", size = 264748, upload-time = "2025-10-19T22:41:52.873Z" },
+    { url = "https://files.pythonhosted.org/packages/24/c5/84c1eea05977c8ba5173555b0133e3558dc628bcf868d6bf1689ff14aedc/fastuuid-0.14.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b2fdd48b5e4236df145a149d7125badb28e0a383372add3fbaac9a6b7a394470", size = 254537, upload-time = "2025-10-19T22:33:55.603Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/23/4e362367b7fa17dbed646922f216b9921efb486e7abe02147e4b917359f8/fastuuid-0.14.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f74631b8322d2780ebcf2d2d75d58045c3e9378625ec51865fe0b5620800c39d", size = 278994, upload-time = "2025-10-19T22:26:17.631Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/72/3985be633b5a428e9eaec4287ed4b873b7c4c53a9639a8b416637223c4cd/fastuuid-0.14.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83cffc144dc93eb604b87b179837f2ce2af44871a7b323f2bfed40e8acb40ba8", size = 280003, upload-time = "2025-10-19T22:23:45.415Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/6d/6ef192a6df34e2266d5c9deb39cd3eea986df650cbcfeaf171aa52a059c3/fastuuid-0.14.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a771f135ab4523eb786e95493803942a5d1fc1610915f131b363f55af53b219", size = 303583, upload-time = "2025-10-19T22:26:00.756Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/11/8a2ea753c68d4fece29d5d7c6f3f903948cc6e82d1823bc9f7f7c0355db3/fastuuid-0.14.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4edc56b877d960b4eda2c4232f953a61490c3134da94f3c28af129fb9c62a4f6", size = 460955, upload-time = "2025-10-19T22:36:25.196Z" },
+    { url = "https://files.pythonhosted.org/packages/23/42/7a32c93b6ce12642d9a152ee4753a078f372c9ebb893bc489d838dd4afd5/fastuuid-0.14.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:bcc96ee819c282e7c09b2eed2b9bd13084e3b749fdb2faf58c318d498df2efbe", size = 480763, upload-time = "2025-10-19T22:24:28.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/e9/a5f6f686b46e3ed4ed3b93770111c233baac87dd6586a411b4988018ef1d/fastuuid-0.14.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:7a3c0bca61eacc1843ea97b288d6789fbad7400d16db24e36a66c28c268cfe3d", size = 452613, upload-time = "2025-10-19T22:25:06.827Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/c9/18abc73c9c5b7fc0e476c1733b678783b2e8a35b0be9babd423571d44e98/fastuuid-0.14.0-cp310-cp310-win32.whl", hash = "sha256:7f2f3efade4937fae4e77efae1af571902263de7b78a0aee1a1653795a093b2a", size = 155045, upload-time = "2025-10-19T22:28:32.732Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/8a/d9e33f4eb4d4f6d9f2c5c7d7e96b5cdbb535c93f3b1ad6acce97ee9d4bf8/fastuuid-0.14.0-cp310-cp310-win_amd64.whl", hash = "sha256:ae64ba730d179f439b0736208b4c279b8bc9c089b102aec23f86512ea458c8a4", size = 156122, upload-time = "2025-10-19T22:23:15.59Z" },
+    { url = "https://files.pythonhosted.org/packages/98/f3/12481bda4e5b6d3e698fbf525df4443cc7dce746f246b86b6fcb2fba1844/fastuuid-0.14.0-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:73946cb950c8caf65127d4e9a325e2b6be0442a224fd51ba3b6ac44e1912ce34", size = 516386, upload-time = "2025-10-19T22:42:40.176Z" },
+    { url = "https://files.pythonhosted.org/packages/59/19/2fc58a1446e4d72b655648eb0879b04e88ed6fa70d474efcf550f640f6ec/fastuuid-0.14.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:12ac85024637586a5b69645e7ed986f7535106ed3013640a393a03e461740cb7", size = 264569, upload-time = "2025-10-19T22:25:50.977Z" },
+    { url = "https://files.pythonhosted.org/packages/78/29/3c74756e5b02c40cfcc8b1d8b5bac4edbd532b55917a6bcc9113550e99d1/fastuuid-0.14.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:05a8dde1f395e0c9b4be515b7a521403d1e8349443e7641761af07c7ad1624b1", size = 254366, upload-time = "2025-10-19T22:29:49.166Z" },
+    { url = "https://files.pythonhosted.org/packages/52/96/d761da3fccfa84f0f353ce6e3eb8b7f76b3aa21fd25e1b00a19f9c80a063/fastuuid-0.14.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:09378a05020e3e4883dfdab438926f31fea15fd17604908f3d39cbeb22a0b4dc", size = 278978, upload-time = "2025-10-19T22:35:41.306Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/c2/f84c90167cc7765cb82b3ff7808057608b21c14a38531845d933a4637307/fastuuid-0.14.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bbb0c4b15d66b435d2538f3827f05e44e2baafcc003dd7d8472dc67807ab8fd8", size = 279692, upload-time = "2025-10-19T22:25:36.997Z" },
+    { url = "https://files.pythonhosted.org/packages/af/7b/4bacd03897b88c12348e7bd77943bac32ccf80ff98100598fcff74f75f2e/fastuuid-0.14.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cd5a7f648d4365b41dbf0e38fe8da4884e57bed4e77c83598e076ac0c93995e7", size = 303384, upload-time = "2025-10-19T22:29:46.578Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a2/584f2c29641df8bd810d00c1f21d408c12e9ad0c0dafdb8b7b29e5ddf787/fastuuid-0.14.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:c0a94245afae4d7af8c43b3159d5e3934c53f47140be0be624b96acd672ceb73", size = 460921, upload-time = "2025-10-19T22:36:42.006Z" },
+    { url = "https://files.pythonhosted.org/packages/24/68/c6b77443bb7764c760e211002c8638c0c7cce11cb584927e723215ba1398/fastuuid-0.14.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:2b29e23c97e77c3a9514d70ce343571e469098ac7f5a269320a0f0b3e193ab36", size = 480575, upload-time = "2025-10-19T22:28:18.975Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/87/93f553111b33f9bb83145be12868c3c475bf8ea87c107063d01377cc0e8e/fastuuid-0.14.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:1e690d48f923c253f28151b3a6b4e335f2b06bf669c68a02665bc150b7839e94", size = 452317, upload-time = "2025-10-19T22:25:32.75Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8c/a04d486ca55b5abb7eaa65b39df8d891b7b1635b22db2163734dc273579a/fastuuid-0.14.0-cp311-cp311-win32.whl", hash = "sha256:a6f46790d59ab38c6aa0e35c681c0484b50dc0acf9e2679c005d61e019313c24", size = 154804, upload-time = "2025-10-19T22:24:15.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/b2/2d40bf00820de94b9280366a122cbaa60090c8cf59e89ac3938cf5d75895/fastuuid-0.14.0-cp311-cp311-win_amd64.whl", hash = "sha256:e150eab56c95dc9e3fefc234a0eedb342fac433dacc273cd4d150a5b0871e1fa", size = 156099, upload-time = "2025-10-19T22:24:31.646Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a2/e78fcc5df65467f0d207661b7ef86c5b7ac62eea337c0c0fcedbeee6fb13/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77e94728324b63660ebf8adb27055e92d2e4611645bf12ed9d88d30486471d0a", size = 510164, upload-time = "2025-10-19T22:31:45.635Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b3/c846f933f22f581f558ee63f81f29fa924acd971ce903dab1a9b6701816e/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:caa1f14d2102cb8d353096bc6ef6c13b2c81f347e6ab9d6fbd48b9dea41c153d", size = 261837, upload-time = "2025-10-19T22:38:38.53Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ea/682551030f8c4fa9a769d9825570ad28c0c71e30cf34020b85c1f7ee7382/fastuuid-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d23ef06f9e67163be38cece704170486715b177f6baae338110983f99a72c070", size = 251370, upload-time = "2025-10-19T22:40:26.07Z" },
+    { url = "https://files.pythonhosted.org/packages/14/dd/5927f0a523d8e6a76b70968e6004966ee7df30322f5fc9b6cdfb0276646a/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c9ec605ace243b6dbe3bd27ebdd5d33b00d8d1d3f580b39fdd15cd96fd71796", size = 277766, upload-time = "2025-10-19T22:37:23.779Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6e/c0fb547eef61293153348f12e0f75a06abb322664b34a1573a7760501336/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:808527f2407f58a76c916d6aa15d58692a4a019fdf8d4c32ac7ff303b7d7af09", size = 278105, upload-time = "2025-10-19T22:26:56.821Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/b1/b9c75e03b768f61cf2e84ee193dc18601aeaf89a4684b20f2f0e9f52b62c/fastuuid-0.14.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2fb3c0d7fef6674bbeacdd6dbd386924a7b60b26de849266d1ff6602937675c8", size = 301564, upload-time = "2025-10-19T22:30:31.604Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/fa/f7395fdac07c7a54f18f801744573707321ca0cee082e638e36452355a9d/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab3f5d36e4393e628a4df337c2c039069344db5f4b9d2a3c9cea48284f1dd741", size = 459659, upload-time = "2025-10-19T22:31:32.341Z" },
+    { url = "https://files.pythonhosted.org/packages/66/49/c9fd06a4a0b1f0f048aacb6599e7d96e5d6bc6fa680ed0d46bf111929d1b/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:b9a0ca4f03b7e0b01425281ffd44e99d360e15c895f1907ca105854ed85e2057", size = 478430, upload-time = "2025-10-19T22:26:22.962Z" },
+    { url = "https://files.pythonhosted.org/packages/be/9c/909e8c95b494e8e140e8be6165d5fc3f61fdc46198c1554df7b3e1764471/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:3acdf655684cc09e60fb7e4cf524e8f42ea760031945aa8086c7eae2eeeabeb8", size = 450894, upload-time = "2025-10-19T22:27:01.647Z" },
+    { url = "https://files.pythonhosted.org/packages/90/eb/d29d17521976e673c55ef7f210d4cdd72091a9ec6755d0fd4710d9b3c871/fastuuid-0.14.0-cp312-cp312-win32.whl", hash = "sha256:9579618be6280700ae36ac42c3efd157049fe4dd40ca49b021280481c78c3176", size = 154374, upload-time = "2025-10-19T22:29:19.879Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/fc/f5c799a6ea6d877faec0472d0b27c079b47c86b1cdc577720a5386483b36/fastuuid-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:d9e4332dc4ba054434a9594cbfaf7823b57993d7d8e7267831c3e059857cf397", size = 156550, upload-time = "2025-10-19T22:27:49.658Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/83/ae12dd39b9a39b55d7f90abb8971f1a5f3c321fd72d5aa83f90dc67fe9ed/fastuuid-0.14.0-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77a09cb7427e7af74c594e409f7731a0cf887221de2f698e1ca0ebf0f3139021", size = 510720, upload-time = "2025-10-19T22:42:34.633Z" },
+    { url = "https://files.pythonhosted.org/packages/53/b0/a4b03ff5d00f563cc7546b933c28cb3f2a07344b2aec5834e874f7d44143/fastuuid-0.14.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:9bd57289daf7b153bfa3e8013446aa144ce5e8c825e9e366d455155ede5ea2dc", size = 262024, upload-time = "2025-10-19T22:30:25.482Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6d/64aee0a0f6a58eeabadd582e55d0d7d70258ffdd01d093b30c53d668303b/fastuuid-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ac60fc860cdf3c3f327374db87ab8e064c86566ca8c49d2e30df15eda1b0c2d5", size = 251679, upload-time = "2025-10-19T22:36:14.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f5/a7e9cda8369e4f7919d36552db9b2ae21db7915083bc6336f1b0082c8b2e/fastuuid-0.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab32f74bd56565b186f036e33129da77db8be09178cd2f5206a5d4035fb2a23f", size = 277862, upload-time = "2025-10-19T22:36:23.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/d3/8ce11827c783affffd5bd4d6378b28eb6cc6d2ddf41474006b8d62e7448e/fastuuid-0.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33e678459cf4addaedd9936bbb038e35b3f6b2061330fd8f2f6a1d80414c0f87", size = 278278, upload-time = "2025-10-19T22:29:43.809Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/51/680fb6352d0bbade04036da46264a8001f74b7484e2fd1f4da9e3db1c666/fastuuid-0.14.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1e3cc56742f76cd25ecb98e4b82a25f978ccffba02e4bdce8aba857b6d85d87b", size = 301788, upload-time = "2025-10-19T22:36:06.825Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/7c/2014b5785bd8ebdab04ec857635ebd84d5ee4950186a577db9eff0fb8ff6/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cb9a030f609194b679e1660f7e32733b7a0f332d519c5d5a6a0a580991290022", size = 459819, upload-time = "2025-10-19T22:35:31.623Z" },
+    { url = "https://files.pythonhosted.org/packages/01/d2/524d4ceeba9160e7a9bc2ea3e8f4ccf1ad78f3bde34090ca0c51f09a5e91/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:09098762aad4f8da3a888eb9ae01c84430c907a297b97166b8abc07b640f2995", size = 478546, upload-time = "2025-10-19T22:26:03.023Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/17/354d04951ce114bf4afc78e27a18cfbd6ee319ab1829c2d5fb5e94063ac6/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:1383fff584fa249b16329a059c68ad45d030d5a4b70fb7c73a08d98fd53bcdab", size = 450921, upload-time = "2025-10-19T22:31:02.151Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/be/d7be8670151d16d88f15bb121c5b66cdb5ea6a0c2a362d0dcf30276ade53/fastuuid-0.14.0-cp313-cp313-win32.whl", hash = "sha256:a0809f8cc5731c066c909047f9a314d5f536c871a7a22e815cc4967c110ac9ad", size = 154559, upload-time = "2025-10-19T22:36:36.011Z" },
+    { url = "https://files.pythonhosted.org/packages/22/1d/5573ef3624ceb7abf4a46073d3554e37191c868abc3aecd5289a72f9810a/fastuuid-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:0df14e92e7ad3276327631c9e7cec09e32572ce82089c55cb1bb8df71cf394ed", size = 156539, upload-time = "2025-10-19T22:33:35.898Z" },
+    { url = "https://files.pythonhosted.org/packages/16/c9/8c7660d1fe3862e3f8acabd9be7fc9ad71eb270f1c65cce9a2b7a31329ab/fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:b852a870a61cfc26c884af205d502881a2e59cc07076b60ab4a951cc0c94d1ad", size = 510600, upload-time = "2025-10-19T22:43:44.17Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/f4/a989c82f9a90d0ad995aa957b3e572ebef163c5299823b4027986f133dfb/fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c7502d6f54cd08024c3ea9b3514e2d6f190feb2f46e6dbcd3747882264bb5f7b", size = 262069, upload-time = "2025-10-19T22:43:38.38Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6c/a1a24f73574ac995482b1326cf7ab41301af0fabaa3e37eeb6b3df00e6e2/fastuuid-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1ca61b592120cf314cfd66e662a5b54a578c5a15b26305e1b8b618a6f22df714", size = 251543, upload-time = "2025-10-19T22:32:22.537Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/20/2a9b59185ba7a6c7b37808431477c2d739fcbdabbf63e00243e37bd6bf49/fastuuid-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa75b6657ec129d0abded3bec745e6f7ab642e6dba3a5272a68247e85f5f316f", size = 277798, upload-time = "2025-10-19T22:33:53.821Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/33/4105ca574f6ded0af6a797d39add041bcfb468a1255fbbe82fcb6f592da2/fastuuid-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8a0dfea3972200f72d4c7df02c8ac70bad1bb4c58d7e0ec1e6f341679073a7f", size = 278283, upload-time = "2025-10-19T22:29:02.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/8c/fca59f8e21c4deb013f574eae05723737ddb1d2937ce87cb2a5d20992dc3/fastuuid-0.14.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1bf539a7a95f35b419f9ad105d5a8a35036df35fdafae48fb2fd2e5f318f0d75", size = 301627, upload-time = "2025-10-19T22:35:54.985Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e2/f78c271b909c034d429218f2798ca4e89eeda7983f4257d7865976ddbb6c/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:9a133bf9cc78fdbd1179cb58a59ad0100aa32d8675508150f3658814aeefeaa4", size = 459778, upload-time = "2025-10-19T22:28:00.999Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f0/5ff209d865897667a2ff3e7a572267a9ced8f7313919f6d6043aed8b1caa/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_i686.whl", hash = "sha256:f54d5b36c56a2d5e1a31e73b950b28a0d83eb0c37b91d10408875a5a29494bad", size = 478605, upload-time = "2025-10-19T22:36:21.764Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/c8/2ce1c78f983a2c4987ea865d9516dbdfb141a120fd3abb977ae6f02ba7ca/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:ec27778c6ca3393ef662e2762dba8af13f4ec1aaa32d08d77f71f2a70ae9feb8", size = 450837, upload-time = "2025-10-19T22:34:37.178Z" },
+    { url = "https://files.pythonhosted.org/packages/df/60/dad662ec9a33b4a5fe44f60699258da64172c39bd041da2994422cdc40fe/fastuuid-0.14.0-cp314-cp314-win32.whl", hash = "sha256:e23fc6a83f112de4be0cc1990e5b127c27663ae43f866353166f87df58e73d06", size = 154532, upload-time = "2025-10-19T22:35:18.217Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/da4db31001e854025ffd26bc9ba0740a9cbba2c3259695f7c5834908b336/fastuuid-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:df61342889d0f5e7a32f7284e55ef95103f2110fee433c2ae7c2c0956d76ac8a", size = 156457, upload-time = "2025-10-19T22:33:44.579Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.20.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1625,16 +1689,22 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+headroom = [
+    { name = "headroom-ai" },
+]
 test = [
+    { name = "headroom-ai" },
     { name = "pytest" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "gptme", git = "https://github.com/gptme/gptme.git?branch=master" },
+    { name = "headroom-ai", marker = "extra == 'headroom'", specifier = ">=0.1.0" },
+    { name = "headroom-ai", marker = "extra == 'test'", specifier = ">=0.1.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
 ]
-provides-extras = ["test"]
+provides-extras = ["headroom", "test"]
 
 [[package]]
 name = "gptme-hooks-examples"
@@ -2118,6 +2188,22 @@ wheels = [
 ]
 
 [[package]]
+name = "headroom-ai"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "litellm" },
+    { name = "pydantic" },
+    { name = "rich" },
+    { name = "tiktoken" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/f0/eb498a7d5109384badf254cfb9f99b52a9aba02d107cb2cbd304f8ef82d8/headroom_ai-0.5.2.tar.gz", hash = "sha256:1c16360402275759ccc24a62c93a4bbfbd2e0a8e2c39b3dbf68be8e21dfb5e7a", size = 1245410, upload-time = "2026-03-20T21:06:30.823Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/c8/3044d2ad04efbac3246da46d51cc72bce1f701f8aa423f71694b38902ca7/headroom_ai-0.5.2-py3-none-any.whl", hash = "sha256:b8f25d24143178885a38ab2c216103f683a67147474163f683753ba373f4e9e3", size = 936203, upload-time = "2026-03-20T21:06:28.967Z" },
+]
+
+[[package]]
 name = "hf-xet"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2209,6 +2295,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
 ]
 
 [[package]]
@@ -2497,6 +2595,29 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/82/a8/4aaead9a06c795a318282aebf7d3e3e578fa889ff396e1b640c3be4c7806/librt-0.6.3-cp314-cp314t-win32.whl", hash = "sha256:f33462b19503ba68d80dac8a1354402675849259fb3ebf53b67de86421735a3a", size = 19465, upload-time = "2025-11-29T14:01:41.77Z" },
     { url = "https://files.pythonhosted.org/packages/3a/61/b7e6a02746c1731670c19ba07d86da90b1ae45d29e405c0b5615abf97cde/librt-0.6.3-cp314-cp314t-win_amd64.whl", hash = "sha256:04f8ce401d4f6380cfc42af0f4e67342bf34c820dae01343f58f472dbac75dcf", size = 21042, upload-time = "2025-11-29T14:01:42.865Z" },
     { url = "https://files.pythonhosted.org/packages/0e/3d/72cc9ec90bb80b5b1a65f0bb74a0f540195837baaf3b98c7fa4a7aa9718e/librt-0.6.3-cp314-cp314t-win_arm64.whl", hash = "sha256:afb39550205cc5e5c935762c6bf6a2bb34f7d21a68eadb25e2db7bf3593fecc0", size = 20246, upload-time = "2025-11-29T14:01:44.13Z" },
+]
+
+[[package]]
+name = "litellm"
+version = "1.80.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "click" },
+    { name = "fastuuid" },
+    { name = "httpx" },
+    { name = "importlib-metadata" },
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "tiktoken" },
+    { name = "tokenizers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/8c/48d533affdbc6d485b7ad4221cd3b40b8c12f9f5568edfe0be0b11e7b945/litellm-1.80.0.tar.gz", hash = "sha256:eeac733eb6b226f9e5fb020f72fe13a32b3354b001dc62bcf1bc4d9b526d6231", size = 11591976, upload-time = "2025-11-16T00:03:51.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/53/aa31e4d057b3746b3c323ca993003d6cf15ef987e7fe7ceb53681695ae87/litellm-1.80.0-py3-none-any.whl", hash = "sha256:fd0009758f4772257048d74bf79bb64318859adb4ea49a8b66fdbc718cd80b6e", size = 10492975, upload-time = "2025-11-16T00:03:49.182Z" },
 ]
 
 [[package]]
@@ -3002,7 +3123,8 @@ name = "networkx"
 version = "3.6.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
     "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
 ]
@@ -3081,7 +3203,8 @@ name = "numpy"
 version = "2.4.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
     "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
 ]
@@ -4474,7 +4597,8 @@ name = "scikit-learn"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
     "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
 ]
@@ -4588,7 +4712,8 @@ name = "scipy"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
     "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
 ]
@@ -5643,4 +5768,13 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/60/43/4104185a2eaa839daa693b30e15c37e7e58795e8e09ec414f22b3db54bec/youtube_transcript_api-1.2.4.tar.gz", hash = "sha256:b72d0e96a335df599d67cee51d49e143cff4f45b84bcafc202ff51291603ddcd", size = 469839, upload-time = "2026-01-29T09:09:17.088Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/95/129ea37efd6cd6ed00f62baae6543345c677810b8a3bf0026756e1d3cf3c/youtube_transcript_api-1.2.4-py3-none-any.whl", hash = "sha256:03878759356da5caf5edac77431780b91448fb3d8c21d4496015bdc8a7bc43ff", size = 485227, upload-time = "2026-01-29T09:09:15.427Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -26,6 +26,7 @@ members = [
     "gptme-forum",
     "gptme-gptodo",
     "gptme-gupp",
+    "gptme-headroom-compressor",
     "gptme-hooks-examples",
     "gptme-imagen",
     "gptme-lessons-extras",
@@ -1612,6 +1613,26 @@ requires-dist = [
     { name = "gptme", git = "https://github.com/gptme/gptme.git?branch=master" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
     { name = "pytest-mock", marker = "extra == 'test'", specifier = ">=3.12.0" },
+]
+provides-extras = ["test"]
+
+[[package]]
+name = "gptme-headroom-compressor"
+version = "0.1.0"
+source = { editable = "plugins/gptme-headroom-compressor" }
+dependencies = [
+    { name = "gptme" },
+]
+
+[package.optional-dependencies]
+test = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "gptme", git = "https://github.com/gptme/gptme.git?branch=master" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
 ]
 provides-extras = ["test"]
 


### PR DESCRIPTION
Implements idea #458 Phase 2: SmartCrusher lossless compression as a gptme-contrib `generation_pre` hook at priority 201 (before trimmer at 200).

- New plugin: gptme-headroom-compressor with generation_pre hook at priority 201, feature-flagged via `GPTME_HEADROOM_ENABLED` env var
- Applies SmartCrusher.crush() to structured tool outputs (grep, JSON, find results) — 87% lossless compression on structured outputs per benchmark; passthrough on unstructured prose
- Compressed messages get a `[Headroom compressed]` sentinel so downstream trimmer skips them
- 13 passing tests: compressible/uncompressible classification, passthrough, feature flag enable/disable, and hook registration
- `pyproject.toml` with `headroom-ai` dependency; editable install
- Tooloutput-trimmer: add `is_headroom_compressed()` guard to avoid double-processing already-compressed messages