### PR TITLE
fix(twitter): redirect console output to stderr

### DIFF
--- a/scripts/twitter/twitter.py
+++ b/scripts/twitter/twitter.py
@@ -87,8 +87,9 @@ from url_utils import validate_urls_in_text  # type: ignore[import-not-found]
 DEFAULT_SINCE = "7d"
 DEFAULT_LIMIT = 10
 
-# Initialize rich console
-console = Console()
+# Initialize rich console (stderr=True so status messages don't pollute stdout
+# when callers capture stdout for JSON output, e.g. twitter-dispatch.sh)
+console = Console(stderr=True)
 
 
 @lru_cache(maxsize=1)


### PR DESCRIPTION
## Problem

`twitter-dispatch.sh` captures `twitter-dispatch.py`'s stdout for JSON parsing.
But `twitter.py`'s module-level `console = Console()` (Rich) uses stdout by default.
Auth status messages (`Using saved OAuth 2.0 access token`, `Successfully authenticated as @TimeToBuildBob`) 
are printed before the JSON array, causing the dispatch script to fail with:

```
ERROR: Detector produced non-array JSON output
```

## Fix

Change `Console()` to `Console(stderr=True)` so status/auth messages go to stderr 
and stdout is clean JSON for callers.

## Notes

A defensive workaround was also added to `twitter-dispatch.sh` (strips non-JSON 
prefix starting from the first `[`), but this is the proper root-cause fix.