### PR TITLE
test(headroom-compressor): cover cost-tracker recording path + isolate config tests

### DIFF
--- a/plugins/gptme-headroom-compressor/tests/test_headroom_compressor.py
+++ b/plugins/gptme-headroom-compressor/tests/test_headroom_compressor.py
@@ -276,8 +276,15 @@ class TestGetCompressorConfig:
 
         self._get_config = get_compressor_config
 
-    def test_default_config_disabled(self):
+    def test_default_config_disabled(self, monkeypatch):
         """No env var, no config file → disabled."""
+        from types import SimpleNamespace
+
+        fake_config = SimpleNamespace(user=SimpleNamespace(plugin={}), project=None)
+        monkeypatch.setattr(
+            "headroom_compressor.hooks.compressor.get_config", lambda: fake_config
+        )
+        monkeypatch.delenv("GPTME_HEADROOM_ENABLED", raising=False)
         cfg = self._get_config()
         assert not cfg.enabled
         assert cfg.min_compress_chars == 2000
@@ -322,8 +329,15 @@ class TestGetCompressorConfig:
         cfg = self._get_config()
         assert not cfg.enabled
 
-    def test_file_empty_settings_stays_disabled(self):
+    def test_file_empty_settings_stays_disabled(self, monkeypatch):
         """Config file with no plugin section → disabled (but doesn't crash)."""
+        from types import SimpleNamespace
+
+        fake_config = SimpleNamespace(user=SimpleNamespace(plugin={}), project=None)
+        monkeypatch.setattr(
+            "headroom_compressor.hooks.compressor.get_config", lambda: fake_config
+        )
+        monkeypatch.delenv("GPTME_HEADROOM_ENABLED", raising=False)
         cfg = self._get_config()
         # Should not crash; default is disabled
         assert not cfg.enabled
@@ -579,3 +593,82 @@ class TestGenerationPreHook:
         assert len(matching) == 1
         assert matching[0].priority == 201
         assert matching[0].enabled is True
+
+    def test_hook_records_savings_to_cost_tracker(self, monkeypatch):
+        """When compression happens, savings are reported to CostTracker."""
+        from dataclasses import dataclass
+
+        from headroom_compressor.hooks import compressor
+
+        @dataclass
+        class FakeResult:
+            was_modified: bool = True
+            strategy: str = "test"
+            compressed: str = '{"items":"compressed"}'
+
+        class FakeCrusher:
+            def crush(self, data: str) -> FakeResult:
+                return FakeResult()
+
+        recorded: list[dict] = []
+
+        class FakeTracker:
+            def record_extra(self, **kwargs):
+                recorded.append(kwargs)
+
+        class FakeCostTracker:
+            @staticmethod
+            def get_session_costs():
+                return FakeTracker()
+
+        monkeypatch.setattr(compressor, "_get_crusher", lambda: FakeCrusher())
+        monkeypatch.setattr(compressor, "CostTracker", FakeCostTracker)
+
+        msg = _tool_message(_build_json_array(200))
+        msgs = [msg]
+        list(compressor.generation_pre_hook(msgs))
+
+        assert len(recorded) == 1
+        assert recorded[0]["key"] == "headroom_compressor"
+        assert recorded[0]["compressed_count"] == 1
+        assert recorded[0]["chars_saved"] > 0
+
+    def test_hook_swallows_cost_tracker_failure(self, monkeypatch):
+        """A failing record_extra must not break compression (graceful degrade).
+
+        Older gptme releases lack ``SessionCosts.record_extra``; the call raises
+        ``AttributeError``. Compression must still apply — cost tracking is
+        best-effort telemetry, never a hard dependency of the hook.
+        """
+        from dataclasses import dataclass
+
+        from headroom_compressor.hooks import compressor
+
+        @dataclass
+        class FakeResult:
+            was_modified: bool = True
+            strategy: str = "test"
+            compressed: str = '{"items":"compressed"}'
+
+        class FakeCrusher:
+            def crush(self, data: str) -> FakeResult:
+                return FakeResult()
+
+        class BrokenTracker:
+            def record_extra(self, **kwargs):
+                raise AttributeError("record_extra not available in this gptme")
+
+        class FakeCostTracker:
+            @staticmethod
+            def get_session_costs():
+                return BrokenTracker()
+
+        monkeypatch.setattr(compressor, "_get_crusher", lambda: FakeCrusher())
+        monkeypatch.setattr(compressor, "CostTracker", FakeCostTracker)
+
+        msg = _tool_message(_build_json_array(200))
+        msgs = [msg]
+        # Must not raise despite the tracker failure.
+        list(compressor.generation_pre_hook(msgs))
+
+        assert msgs[0].content.startswith("[Headroom compressed")


### PR DESCRIPTION
## What

Test-only changes to the `gptme-headroom-compressor` plugin.

**New coverage for the CostTracker telemetry path** in `generation_pre_hook` (added in #1049 but previously untested):
- `test_hook_records_savings_to_cost_tracker` — asserts `record_extra()` is called with `key="headroom_compressor"`, `compressed_count`, and `chars_saved>0` when compression happens.
- `test_hook_swallows_cost_tracker_failure` — asserts a failing `record_extra()` (e.g. an older gptme without the method) is swallowed so compression still applies. Cost tracking is best-effort telemetry, never a hard dependency.

**Test-isolation fix** for two pre-existing failures: `test_default_config_disabled` and `test_file_empty_settings_stays_disabled` read the *live* `gptme.toml`, so they failed once the plugin was enabled there (`enabled=true`). They now monkeypatch `get_config` to an empty config — the same pattern already used by `test_env_var_false_overrides_config_file_enabled`.

## Why

The `record_extra()` wiring records SmartCrusher token savings to the cost tracker (gptme `SessionCosts.record_extra`, gptme/gptme#2735). It shipped untested; the bare `except` silently swallows failures, so a regression here would be invisible. These tests pin both the success and graceful-degrade behavior.

## Verification

```
45 passed in 0.64s
```
(was 43 passed, 2 failed before — the 2 config tests are now isolated and green.)

Part of the headroom SmartCrusher Phase 2 integration (idea #458).