### PR TITLE
feat(sessions): wire smell_score into post_session recording

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -36,6 +36,7 @@ from .deliverables import (
 from .discovery import extract_project, extract_session_name
 from .record import SessionRecord
 from .signals import extract_from_path
+from .smell import compute_smell_score
 from .store import SessionStore
 
 logger = logging.getLogger(__name__)
@@ -669,6 +670,14 @@ def post_session(
             logger.info("Auto-detected journal_path from trajectory: %s", journal_path)
     if journal_path is not None:
         record_kwargs["journal_path"] = journal_path
+        # Voice-quality signal: scan the journal prose for regex LLM smells.
+        # Cheap (stdlib regex), best-effort — never let it break recording.
+        try:
+            smell = compute_smell_score(journal_path)
+            if smell is not None:
+                record_kwargs["smell_score"] = smell
+        except Exception:  # pragma: no cover - defensive; smell is non-critical
+            logger.debug("smell-score computation failed", exc_info=True)
     if session_id is not None:
         record_kwargs["session_id"] = session_id
     if token_count is not None:

--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -677,7 +677,7 @@ def post_session(
             if smell is not None:
                 record_kwargs["smell_score"] = smell
         except Exception:  # pragma: no cover - defensive; smell is non-critical
-            logger.debug("smell-score computation failed", exc_info=True)
+            logger.warning("smell-score computation failed", exc_info=True)
     if session_id is not None:
         record_kwargs["session_id"] = session_id
     if token_count is not None:

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -238,6 +238,12 @@ class SessionRecord:
     llm_judge_reason: str | None = None  # 1-sentence explanation
     llm_judge_model: str | None = None  # model used for judging (e.g. claude-haiku-4-5)
 
+    # Regex-based LLM "smell" score (0.0-1.0, voice-quality / blandness signal).
+    # Computed from the journal text at post_session time by gptme_sessions.smell.
+    # Higher = more machine-generated tells (hedging, vocab tics, canned voice).
+    # ``None`` when no journal_path was available to scan.
+    smell_score: float | None = None
+
     # Optional harm category tag (idea #191).  Populated by the
     # --classify-harm-category classifier in compute-harm-signal.py.
     # One of HARM_CATEGORY_LABELS, or None when not classified.

--- a/packages/gptme-sessions/tests/test_post_session.py
+++ b/packages/gptme-sessions/tests/test_post_session.py
@@ -906,3 +906,29 @@ def test_post_session_smell_score_none_without_journal(tmp_path: Path):
         duration_seconds=60,
     )
     assert result.record.smell_score is None
+
+
+def test_post_session_smell_score_zero_for_clean_journal(tmp_path: Path):
+    """Clean technical prose with no LLM-smell hits produces smell_score=0.0, not None."""
+    store = SessionStore(sessions_dir=tmp_path)
+    journal = tmp_path / "session.md"
+    journal.write_text(
+        "Fixed the IndexError in parse_tokens by checking slice bounds before access. "
+        "Added a unit test covering the empty-list path. "
+        "CI passes on Python 3.10, 3.11, and 3.12. Pushed the fix.",
+        encoding="utf-8",
+    )
+
+    result = post_session(
+        store=store,
+        harness="claude-code",
+        model="opus",
+        duration_seconds=60,
+        journal_path=str(journal),
+    )
+
+    assert result.record.smell_score == 0.0
+
+    # Persists through store reload — 0.0 is stored, not collapsed to None.
+    records = SessionStore(sessions_dir=tmp_path).load_all()
+    assert records[0].smell_score == 0.0

--- a/packages/gptme-sessions/tests/test_post_session.py
+++ b/packages/gptme-sessions/tests/test_post_session.py
@@ -865,3 +865,44 @@ def test_caller_sha_in_traj():
     assert _caller_sha_in_traj("dead123456789abcdef0000000000000000000", prefixes) is True
     assert _caller_sha_in_traj("cafe000000000000000000000000000000000", prefixes) is False
     assert _caller_sha_in_traj("ABC1234567890ABCDEF", prefixes) is True  # case-insensitive
+
+
+def test_post_session_populates_smell_score(tmp_path: Path):
+    """post_session computes a smell_score from the journal prose and persists it."""
+    store = SessionStore(sessions_dir=tmp_path)
+    journal = tmp_path / "session.md"
+    journal.write_text(
+        "It's worth noting that this is a testament to our ever-evolving "
+        "tapestry of solutions. Let's delve into the realm of possibilities. "
+        "It's not just a feature, it's a game-changer. In conclusion, I'd be "
+        "happy to help. Great question! Moreover, this showcases a comprehensive "
+        "approach.",
+        encoding="utf-8",
+    )
+
+    result = post_session(
+        store=store,
+        harness="claude-code",
+        model="opus",
+        duration_seconds=60,
+        journal_path=str(journal),
+    )
+
+    assert result.record.smell_score is not None
+    assert 0.0 < result.record.smell_score <= 1.0
+
+    # Persists through store reload.
+    records = SessionStore(sessions_dir=tmp_path).load_all()
+    assert records[0].smell_score == result.record.smell_score
+
+
+def test_post_session_smell_score_none_without_journal(tmp_path: Path):
+    """No journal_path means smell_score stays None (no crash)."""
+    store = SessionStore(sessions_dir=tmp_path)
+    result = post_session(
+        store=store,
+        harness="claude-code",
+        model="opus",
+        duration_seconds=60,
+    )
+    assert result.record.smell_score is None


### PR DESCRIPTION
## What

Wires the regex-based LLM **smell detector** (`gptme_sessions.smell`, added in #1013) into the post-session recording pipeline. The module was complete and tested but never actually called — this activates it.

Every recorded session now gets a `smell_score` (0.0–1.0 voice-quality / blandness signal) computed from its journal prose, sitting alongside the existing `llm_judge_score`. Higher = more machine-generated tells (hedging openers, ChatGPT vocab tics, negative parallelism, canned voice, em-dash abuse).

## Changes

- **`record.py`**: add `SessionRecord.smell_score: float | None`. Serialized automatically via `asdict` and filtered by `from_dict` like the other scalar score fields — old records (no field) round-trip as `None`.
- **`post_session.py`**: compute `smell_score` from `journal_path` (best-effort; wrapped so a smell failure never breaks recording). `None` when no journal is available.
- **tests**: `test_post_session_populates_smell_score` (populated + persists through store reload) and `test_post_session_smell_score_none_without_journal`.

## Why

The smell signal catches a stylistic dimension (voice drift / blandness) that an LLM judge trained on the same distribution tends to overlook. Wiring it at `post_session` time makes it available to **any** agent workspace without a Bob-relative import — Bob already has `collect_smell_score_signal` locally, but other agents didn't.

## Verification

- `pytest packages/gptme-sessions/tests/test_post_session.py test_smell.py test_record.py` → **115 passed**
- mypy clean on `gptme-sessions` (`Success: no issues found in 16 source files`); ruff check + format clean

Closes the wiring step of the gptme-sessions smell-detector task (idea backlog #382, Phase 1).