### PR TITLE
feat(skills): add missing YAML frontmatter to gptme-wrapped and plugin-development

### DIFF
--- a/skills/gptme-wrapped/SKILL.md
+++ b/skills/gptme-wrapped/SKILL.md
@@ -2,7 +2,7 @@
 name: gptme-wrapped
 description: Analyze your gptme conversation history for insights like token usage, costs, model preferences, and usage patterns — inspired by Spotify Wrapped.
 license: MIT
-compatibility: "Requires gptme"
+compatibility: "Requires gptme>=0.27.0"
 metadata:
   author: bob
   version: "1.0.0"

--- a/skills/gptme-wrapped/SKILL.md
+++ b/skills/gptme-wrapped/SKILL.md
@@ -1,3 +1,16 @@
+---
+name: gptme-wrapped
+description: Analyze your gptme conversation history for insights like token usage, costs, model preferences, and usage patterns — inspired by Spotify Wrapped.
+license: MIT
+compatibility: "Requires gptme"
+metadata:
+  author: bob
+  version: "1.0.0"
+  tags: [analytics, conversations, tokens, costs, usage-patterns]
+  requires_tools: []
+  requires_skills: []
+---
+
 # gptme Wrapped - Conversation Analytics
 
 **Description:** Analyze your gptme conversation history for insights like token usage, costs, model preferences, and usage patterns - inspired by Spotify Wrapped.

--- a/skills/plugin-development/SKILL.md
+++ b/skills/plugin-development/SKILL.md
@@ -1,3 +1,16 @@
+---
+name: plugin-development
+description: Guide to creating gptme plugins with tools, hooks, and commands — covers ToolSpec, lifecycle hooks, custom /commands, testing, and pyproject.toml setup.
+license: MIT
+compatibility: "Requires gptme>=0.27.0"
+metadata:
+  author: bob
+  version: "1.0.0"
+  tags: [plugins, tools, hooks, commands, development]
+  requires_tools: []
+  requires_skills: []
+---
+
 # gptme Plugin Development
 
 **Description:** Guide to creating gptme plugins with tools, hooks, and commands.


### PR DESCRIPTION
## Summary

- `gptme-wrapped/SKILL.md` and `plugin-development/SKILL.md` were flagged by `generate-skill-catalog.py --check` for missing `name:` and `description:` frontmatter fields
- Adds the standard YAML frontmatter block (name, description, license, compatibility, metadata with author/version/tags) to both skills
- Both skills now validate cleanly with the lessons-extras validator

## Test plan

- [x] `validate.py` reports ✅ for both SKILL.md files
- [x] `python3 scripts/generate-skill-catalog.py --check` reports catalog is up to date
- [ ] CI passes