### PR TITLE
fix(skills): add explicit category to home-assistant skill for catalog

### DIFF
--- a/skills/home-assistant/SKILL.md
+++ b/skills/home-assistant/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: home-assistant
 description: Query a Home Assistant instance for presence, sensor data, calendar events, and cameras
+category: Agent Infrastructure
 tags: [home-assistant, iot, context, location, presence]
 license: MIT
 compatibility: "Requires HA_HOST and HA_API_KEY env vars"


### PR DESCRIPTION
Adds `category: Agent Infrastructure` to the home-assistant skill frontmatter.

Previously the skill fell into Uncategorized in the autogenerated skill catalog because its tags (home-assistant, iot, context, location, presence) didn't match any tag-needle in CATEGORY_MAP. The explicit category field was added in the catalog generator to handle exactly this case (idea #464).

After this fix: Uncategorized count drops 2→1 (only `template-skill` empty-frontmatter remains).

Related: idea-backlog #464