### PR TITLE
fix(lessons): skip companion/length soft-warnings for archived lessons

### DIFF
--- a/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
+++ b/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
@@ -100,6 +100,26 @@ class LessonValidator:
         self.warnings: List[str] = []
         self.format_type: str | None = None
         self.is_skill = self._detect_skill()
+        self.status = self._parse_status()
+
+    def _parse_status(self) -> str | None:
+        """Parse the lifecycle ``status`` field from frontmatter.
+
+        Returns the status string (e.g. ``active``, ``archived``) or ``None`` if
+        the file has no parseable frontmatter or no ``status`` field. Used to
+        skip soft (warning-level) checks on frozen lessons.
+        """
+        if not self.content.startswith("---"):
+            return None
+        try:
+            end_idx = self.content.index("---", 3)
+            frontmatter = yaml.safe_load(self.content[3:end_idx])
+        except (ValueError, yaml.YAMLError):
+            return None
+        if not isinstance(frontmatter, dict):
+            return None
+        status = frontmatter.get("status")
+        return status if isinstance(status, str) else None
 
     def _detect_skill(self) -> bool:
         """Detect whether this file is a skill (SKILL.md format).
@@ -487,6 +507,10 @@ class LessonValidator:
 
     def _check_companion_doc(self):
         """Check for companion doc existence and linking."""
+        # Archived lessons are frozen historical guidance — don't nag about
+        # companion linking or length on superseded files.
+        if self.status == "archived":
+            return
         # Check if companion doc exists (search subdirectories too)
         companion_matches = list(COMPANION_DIR.rglob(f"{self.filepath.stem}.md"))
         has_companion = len(companion_matches) > 0
@@ -522,6 +546,9 @@ class LessonValidator:
 
     def _check_length(self):
         """Check primary lesson length."""
+        # Archived lessons are frozen — skip the soft length target.
+        if self.status == "archived":
+            return
         lines = self.content.split("\n")
 
         # Calculate body lines (exclude frontmatter)

--- a/packages/gptme-lessons-extras/tests/test_validate.py
+++ b/packages/gptme-lessons-extras/tests/test_validate.py
@@ -418,3 +418,71 @@ def test_confound_note_wrong_type_rejected():
         validator.validate()
         confound_errors = [e for e in validator.errors if "confound_note" in e]
         assert confound_errors, "Non-string confound_note should produce an error"
+
+
+# An archived lesson that is long AND has no companion link — would normally
+# trigger both the companion-doc and length soft warnings.
+_ARCHIVED_LONG_LESSON = (
+    """\
+---
+match:
+  keywords:
+    - "test keyword phrase"
+status: archived
+---
+
+# Archived Test Lesson
+
+## Rule
+Test rule.
+
+## Context
+Test context.
+
+## Detection
+- Signal 1
+- Signal 2
+
+## Pattern
+```txt
+example
+```
+
+## Outcome
+"""
+    + "\n".join(f"- Benefit {i}" for i in range(120))
+    + "\n"
+)
+
+
+def test_archived_lesson_skips_length_warning():
+    """Archived lessons are frozen — no length nag even when over target."""
+    with tempfile.TemporaryDirectory() as tmp:
+        path = _write_lesson(Path(tmp), _ARCHIVED_LONG_LESSON)
+        validator = LessonValidator(path)
+        validator.validate()
+        length_warnings = [w for w in validator.warnings if "lines (target" in w]
+        assert not length_warnings, f"Unexpected length warnings: {length_warnings}"
+
+
+def test_archived_lesson_skips_companion_warning():
+    """Archived lessons should not warn about missing/unlinked companion docs."""
+    with tempfile.TemporaryDirectory() as tmp:
+        path = _write_lesson(Path(tmp), _ARCHIVED_LONG_LESSON)
+        validator = LessonValidator(path)
+        validator.validate()
+        companion_warnings = [w for w in validator.warnings if "companion" in w.lower()]
+        assert (
+            not companion_warnings
+        ), f"Unexpected companion warnings: {companion_warnings}"
+
+
+def test_active_long_lesson_still_warns():
+    """Guard: the skip is archived-only — active lessons still get the length nag."""
+    active = _ARCHIVED_LONG_LESSON.replace("status: archived", "status: active")
+    with tempfile.TemporaryDirectory() as tmp:
+        path = _write_lesson(Path(tmp), active)
+        validator = LessonValidator(path)
+        validator.validate()
+        length_warnings = [w for w in validator.warnings if "lines (target" in w]
+        assert length_warnings, "Active long lesson should still warn about length"


### PR DESCRIPTION
## Problem

The lesson validator emits `companion doc exists but not linked` and `Primary lesson is N lines (target: 100)` **warnings on `status: archived` lessons**. Archived lessons are frozen historical guidance — nagging them to link a companion or trim length is pure recurring noise on every validation run and in CI.

Currently affected in Bob's workspace (3 archived files):
- `lessons/archived/execute-scripts-with-shebangs.md`
- `lessons/archived/scope-discipline-in-autonomous-work.md`
- `lessons/archived/dogfood-verify-against-current-code.md`

## Fix

- Parse the `status` frontmatter field once in `__init__` (`self.status`).
- Short-circuit `_check_companion_doc` and `_check_length` when `status == "archived"`.

Errors and frontmatter validation are unchanged — only the two soft (warning-level) checks are skipped for archived lessons.

## Tests

3 new tests:
- `test_archived_lesson_skips_length_warning` — archived + over-target → no length warning
- `test_archived_lesson_skips_companion_warning` — archived → no companion warning
- `test_active_long_lesson_still_warns` — guard: skip is archived-only

All 29 tests pass (`pytest tests/test_validate.py`). Verified against the 3 real archived files: warnings now empty.