### PR TITLE
fix(voice): truthful runtime-identity self-report (no more confabulated model)

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -478,6 +478,38 @@ _PROVIDER_GROK = "grok"
 _VALID_PROVIDERS = (_PROVIDER_OPENAI, _PROVIDER_GROK)
 _VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh")
 
+# Friendly provider descriptions for truthful runtime self-reporting. The
+# realtime voice model otherwise confabulates an unrelated identity (observed
+# 2026-06-05: claiming "Claude 3.5 Sonnet" on a Grok-powered call) when a caller
+# asks what is powering the conversation.
+_PROVIDER_DISPLAY = {
+    _PROVIDER_OPENAI: "OpenAI's realtime voice API",
+    _PROVIDER_GROK: "xAI's Grok realtime voice API",
+}
+
+
+def _build_runtime_identity_instructions(provider: str, model: str | None) -> str:
+    """Return a truthful runtime-identity block for the active voice provider.
+
+    The realtime model has no inherent knowledge of which provider/model is
+    serving the live call, so when asked "what model are you running on?" it
+    confabulates. This block states the ground truth so the model answers
+    honestly instead of guessing an unrelated vendor.
+    """
+    display = _PROVIDER_DISPLAY.get(provider, f"the {provider} realtime voice API")
+    model_clause = f" (model: {model})" if model else ""
+    return (
+        "RUNTIME IDENTITY:\n"
+        f"- This live voice conversation is served by {display}{model_clause}.\n"
+        "- If the caller asks what model or provider is powering this call, answer "
+        "truthfully with that. Do NOT claim to be Claude, GPT, or any other model "
+        "unless it matches the provider above.\n"
+        "- Your text-based gptme persona and code-lookup subagent may run on a "
+        "different model; only describe the live voice provider above when asked "
+        "about the current call. If you are genuinely unsure, say so rather than "
+        "guessing a vendor."
+    )
+
 
 def _get_twilio_field(payload: dict, camel_name: str, snake_name: str) -> str | None:
     """Read Twilio fields, preferring the documented camelCase form."""
@@ -523,7 +555,16 @@ class VoiceServer:
         else:
             self._api_key = openai_api_key or _get_openai_api_key()
         self.workspace = workspace or _detect_agent_repo()
-        self._instructions = _load_project_instructions(self.workspace)
+        # Prepend a truthful runtime-identity block so the voice model can answer
+        # "what model is powering this call?" honestly instead of confabulating.
+        # Built from self.provider/self.model, so it applies to every downstream
+        # call path (caller, resume, standup, handoff) that derives from
+        # self._instructions.
+        self._instructions = (
+            _build_runtime_identity_instructions(self.provider, self.model)
+            + "\n\n"
+            + _load_project_instructions(self.workspace)
+        )
         self.resume_window_seconds = int(
             _get_config_env("GPTME_VOICE_RESUME_WINDOW_SECONDS")
             or _DEFAULT_RESUME_WINDOW_SECONDS

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -18,6 +18,7 @@ from gptme_voice.realtime.server import (
     _assistant_committed_hangup,
     _build_caller_instructions,
     _build_resume_instructions,
+    _build_runtime_identity_instructions,
     _get_twilio_field,
     _lookup_caller_identity,
     _should_trigger_hangup_transcript_fallback,
@@ -130,6 +131,38 @@ def test_build_caller_instructions_known_number_from_people_dir() -> None:
     assert "Erik Bjäreholt" in result
     assert "+46700000001" in result
     assert "You are Bob." in result
+
+
+def test_build_runtime_identity_instructions_grok() -> None:
+    result = _build_runtime_identity_instructions("grok", None)
+    assert "Grok" in result
+    assert "xAI" in result
+    # Must explicitly forbid the observed confabulation.
+    assert "Claude" in result
+    assert "GPT" in result
+    assert "truthfully" in result.lower()
+    # No model alias supplied → no model clause.
+    assert "model:" not in result
+
+
+def test_build_runtime_identity_instructions_openai_with_model() -> None:
+    result = _build_runtime_identity_instructions("openai", "gpt-realtime")
+    assert "OpenAI" in result
+    assert "gpt-realtime" in result
+    assert "model: gpt-realtime" in result
+
+
+def test_build_runtime_identity_instructions_unknown_provider() -> None:
+    # Unknown provider should still produce a non-confabulating block.
+    result = _build_runtime_identity_instructions("anthropic", None)
+    assert "anthropic" in result
+
+
+def test_voice_server_prepends_runtime_identity_to_instructions() -> None:
+    server = VoiceServer(provider="grok")
+    # The runtime-identity block leads the base instructions for every call path.
+    assert server._instructions.startswith("RUNTIME IDENTITY:")
+    assert "Grok" in server._instructions
 
 
 def test_lookup_caller_identity_uses_call_name_when_present() -> None:


### PR DESCRIPTION
## Problem

A 2026-06-05 inbound Twilio voice call exposed a self-report bug: when Erik asked what model was powering the call, Bob answered **"Claude 3.5 Sonnet"** — but the call metadata shows `provider: grok`. Erik flagged the answer as false.

Root cause: the realtime voice model has no inherent knowledge of which provider/model is serving the live call. The `VoiceServer` knows `self.provider`/`self.model` at runtime, but never tells the model — so when asked, it confabulates an unrelated vendor.

## Fix

Prepend a `RUNTIME IDENTITY` block (built from the server's known provider/model) to the session instructions. It states the ground truth and instructs the model to answer truthfully — or admit uncertainty — instead of guessing, and explicitly not to claim Claude/GPT unless that matches the active provider.

Wired into `__init__` so it leads `self._instructions`, applying to **every** call path (caller, resume, standup, handoff) since all derive from it.

## Tests

- `_build_runtime_identity_instructions` for grok (no model), openai (with model alias), and unknown-provider fallback
- `VoiceServer` bootstrap integration: instructions lead with the identity block
- Full `test_server.py` passes locally (55 tests)

## Scope note

This addresses the **model self-report** half of ErikBjare/bob's voice-regression task. The separate **barge-in/interrupt** regression from the same call needs live diagnosis and is tracked separately.