### PR TITLE
fix(voice): surface recently-completed subagent outcomes in subagent_status

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -16,6 +16,7 @@ import logging
 import os
 import tempfile
 import time
+from collections import deque
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Awaitable, Callable, Sequence
@@ -48,6 +49,9 @@ _IGNORABLE_ERROR_SUBSTRINGS = ("terminated by signal 13",)
 # These mean "ran out of time", not a generic crash.
 _TIMEOUT_RETURNCODES = frozenset({124, 143})
 _KILLED_RETURNCODE = 137  # 128 + SIGKILL (timeout kill-after or OOM kill)
+# How many recently-completed task records to keep for subagent_status queries.
+# The model can see these to understand whether a task succeeded, timed out, or errored.
+_MAX_RECENT_COMPLETIONS = 5
 _DEFAULT_TRANSCRIPT_TAIL_TURNS = 8
 _DEFAULT_TRANSCRIPT_TAIL_CHARS = 1_600
 
@@ -132,6 +136,9 @@ class GptmeToolBridge:
         self._pending_tasks: dict[str, PendingTask] = {}
         self._task_counter = 0
         self._completed_timings: list[dict[str, object]] = []
+        # Short-lived buffer of recently-completed tasks so subagent_status can
+        # distinguish "timed out" from "succeeded" from "never started".
+        self._recent_completions: deque[dict] = deque(maxlen=_MAX_RECENT_COMPLETIONS)
 
     @staticmethod
     def _parse_env_int(name: str, *, default: int, minimum: int = 0) -> int:
@@ -440,6 +447,34 @@ class GptmeToolBridge:
 
         logger.info(f"Task {task_id} complete: {response_text[:100]}...")
 
+        # Record completion for subagent_status queries so the model can
+        # distinguish timed-out tasks from successful ones.
+        completion_status = (
+            "success"
+            if result.success
+            else (
+                "timed_out"
+                if (pending is not None and pending.returncode in _TIMEOUT_RETURNCODES)
+                else "error"
+            )
+        )
+        self._recent_completions.append(
+            {
+                "task_id": task_id,
+                "task": task[:_MAX_TASK_PREVIEW],
+                "status": completion_status,
+                "returncode": pending.returncode if pending is not None else None,
+                "elapsed_seconds": round(
+                    (pending.completed_at or time.monotonic()) - pending.started_at, 1
+                )
+                if pending is not None
+                else None,
+                "output_preview": (result.output or "")[:200]
+                if result.success
+                else None,
+            }
+        )
+
         # Inject result into conversation
         if self.on_result:
             await self.on_result(response_text)
@@ -707,10 +742,12 @@ class GptmeToolBridge:
                 for tid, entry in self._pending_tasks.items()
                 if not entry.task.done()
             ]
+            recent = list(self._recent_completions)
             return {
                 "status": "ok",
                 "pending_count": len(pending),
                 "pending": pending,
+                "recent_completions": recent,
             }
 
         if name == "subagent_cancel":

--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -567,6 +567,12 @@ class GptmeToolBridge:
                 )
             except asyncio.TimeoutError:
                 process.kill()
+                # on_completed is never called by the subprocess path when
+                # Python's asyncio.wait_for fires, so pending.returncode stays
+                # None.  Set it explicitly so _handle_subagent_result records
+                # "timed_out" rather than "error" in recent_completions.
+                if on_completed:
+                    on_completed(124, time.monotonic())
                 return ToolResult(
                     success=False,
                     output="",

--- a/packages/gptme-voice/tests/test_tool_bridge.py
+++ b/packages/gptme-voice/tests/test_tool_bridge.py
@@ -763,6 +763,76 @@ def test_subagent_status_lists_pending_dispatch() -> None:
     asyncio.run(_exercise())
 
 
+def test_subagent_status_shows_recent_completion_on_success() -> None:
+    """After a task completes, subagent_status should list it in recent_completions."""
+
+    async def _exercise() -> None:
+        async def _fake_create_subprocess_exec(*_args, **_kwargs):
+            return _FakeProcess(
+                returncode=0, stdout="Dashboard has 3 sub-dashboards.\n"
+            )
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+            bridge = GptmeToolBridge(workspace="/fake/workspace", timeout=10)
+
+            dispatch = await bridge.handle_function_call(
+                "subagent", {"task": "list dashboards", "mode": "fast"}
+            )
+            task_id = dispatch["task_id"]
+
+            # Let the background task finish
+            for _ in range(20):
+                await asyncio.sleep(0)
+
+            status = await bridge.handle_function_call("subagent_status", {})
+            assert status["pending_count"] == 0
+            recent = status["recent_completions"]
+            assert len(recent) == 1
+            entry = recent[0]
+            assert entry["task_id"] == task_id
+            assert entry["status"] == "success"
+            assert entry["returncode"] == 0
+            assert entry["elapsed_seconds"] is not None
+            assert "list dashboards" in entry["task"]
+
+    asyncio.run(_exercise())
+
+
+def test_subagent_status_shows_recent_timeout() -> None:
+    """A timed-out task (returncode=124) should appear as 'timed_out' in recent_completions."""
+
+    async def _exercise() -> None:
+        # Simulate a timeout: process exits immediately with rc=124 (UNIX timeout cmd)
+        async def _fake_create_subprocess_exec(*_args, **_kwargs):
+            return _FakeProcess(returncode=124, stdout="partial result\n")
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+            bridge = GptmeToolBridge(workspace="/fake/workspace", timeout=10)
+
+            dispatch = await bridge.handle_function_call(
+                "subagent", {"task": "explore dashboard portal", "mode": "fast"}
+            )
+            task_id = dispatch["task_id"]
+
+            # Let the background task finish
+            for _ in range(20):
+                await asyncio.sleep(0)
+
+            status = await bridge.handle_function_call("subagent_status", {})
+            assert status["pending_count"] == 0
+            recent = status["recent_completions"]
+            assert len(recent) == 1
+            entry = recent[0]
+            assert entry["task_id"] == task_id
+            assert entry["status"] == "timed_out"
+            assert entry["returncode"] == 124
+            assert "explore dashboard portal" in entry["task"]
+
+    asyncio.run(_exercise())
+
+
 def test_subagent_dispatch_defaults_to_fast_mode() -> None:
     """Missing mode should still dispatch on the fast live-call path."""
 

--- a/packages/gptme-voice/tests/test_tool_bridge.py
+++ b/packages/gptme-voice/tests/test_tool_bridge.py
@@ -833,6 +833,53 @@ def test_subagent_status_shows_recent_timeout() -> None:
     asyncio.run(_exercise())
 
 
+def test_subagent_status_shows_asyncio_timeout() -> None:
+    """Python asyncio.TimeoutError path records 'timed_out', not 'error'.
+
+    When asyncio.wait_for fires (Python-side timeout), on_completed is never
+    called by the subprocess path, so pending.returncode stays None without the
+    fix.  Verify the explicit on_completed(124, ...) call in the handler makes
+    the status surface correctly.
+    """
+
+    async def _exercise() -> None:
+        class _SlowProcess(_FakeProcess):
+            async def wait(self) -> int:
+                await asyncio.sleep(1000)
+                return 0  # never reached
+
+        async def _fake_create_subprocess_exec(*_args, **_kwargs):
+            return _SlowProcess(returncode=0)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+            # Very short timeout so asyncio.wait_for fires immediately
+            bridge = GptmeToolBridge(workspace="/fake/workspace", timeout=0.01)
+
+            dispatch = await bridge.handle_function_call(
+                "subagent",
+                {"task": "slow task that triggers asyncio timeout", "mode": "fast"},
+            )
+            task_id = dispatch["task_id"]
+
+            # Let the background task run and hit the timeout
+            for _ in range(50):
+                await asyncio.sleep(0.001)
+
+            status = await bridge.handle_function_call("subagent_status", {})
+            assert status["pending_count"] == 0
+            recent = status["recent_completions"]
+            assert len(recent) == 1
+            entry = recent[0]
+            assert entry["task_id"] == task_id
+            assert (
+                entry["status"] == "timed_out"
+            ), f"expected timed_out, got {entry['status']}"
+            assert entry["returncode"] == 124
+
+    asyncio.run(_exercise())
+
+
 def test_subagent_dispatch_defaults_to_fast_mode() -> None:
     """Missing mode should still dispatch on the fast live-call path."""
 


### PR DESCRIPTION
## Problem

When a voice subagent times out or errors, it's removed from `_pending_tasks` and `subagent_status` returns `pending_count: 0` with no indication of what happened. The voice model then reports "no pending tasks" — misleading when the task had just timed out with `returncode=124`.

Root cause: voice call `20260605T165918Z-081` where two dashboard-lookup subagents both timed out at 25s (`rc=124`) but the model reported confusing statuses because completed tasks were invisible. Transcript included: *"I don't know what your sub-agent status screen looks like or if lying to us"*.

## Fix

Add `_recent_completions: deque[dict]` (maxlen=5) that records each completed task with:
- `status`: `"success"` / `"timed_out"` / `"error"`
- `returncode`: the raw exit code
- `elapsed_seconds`: wall time from dispatch to completion
- `output_preview`: first 200 chars of output on success

`subagent_status` now includes `recent_completions` in its response so the voice model can say *"task-1 timed out 5s ago (rc=124)"* rather than *"no pending tasks"*.

## Tests

- `test_subagent_status_shows_recent_completion_on_success` — verifies success case
- `test_subagent_status_shows_recent_timeout` — verifies `rc=124` maps to `"timed_out"`

All 48 tests pass.

## Tracking

ErikBjare/bob#651