### PR TITLE
fix(voice): clear Twilio playback buffer on barge-in

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
@@ -260,6 +260,7 @@ class OpenAIRealtimeClient:
         on_ai_transcript: Callable[[str], None] | None = None,
         on_user_transcript: Callable[[str], None] | None = None,
         on_function_call: Callable[[str, dict], Any] | None = None,
+        on_speech_started: Callable[[], None] | None = None,
         hold_initial_response: bool = False,
     ):
         self.api_key = api_key or _get_openai_api_key()
@@ -275,6 +276,7 @@ class OpenAIRealtimeClient:
         self.on_ai_transcript = on_ai_transcript
         self.on_user_transcript = on_user_transcript
         self.on_function_call = on_function_call
+        self.on_speech_started = on_speech_started
 
         self._ws: websockets.WebSocketClientProtocol | None = None
         self._receive_task: asyncio.Task | None = None
@@ -834,6 +836,8 @@ class OpenAIRealtimeClient:
         # VAD events
         elif event_type == "input_audio_buffer.speech_started":
             logger.debug("Speech detected")
+            if self.on_speech_started:
+                await self._call_callback(self.on_speech_started)
         elif event_type == "input_audio_buffer.speech_stopped":
             logger.debug("Speech ended")
 

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -1558,7 +1558,18 @@ class VoiceServer:
 
                         return _on_audio
 
+                    def _make_on_speech_started(_stream_sid: str):
+                        async def _on_speech_started() -> None:
+                            logger.debug(
+                                "Caller speech detected; clearing Twilio playback buffer for %s",
+                                _stream_sid,
+                            )
+                            await self._send_twilio_clear(websocket, _stream_sid)
+
+                        return _on_speech_started
+
                     on_audio = _make_on_audio(stream_sid)
+                    on_speech_started = _make_on_speech_started(stream_sid)
                     on_ai_transcript, on_user_transcript, _twilio_hangup = (
                         self._make_transcript_callbacks(
                             transcript=transcript,
@@ -1581,6 +1592,7 @@ class VoiceServer:
                         realtime_client.on_audio = on_audio
                         realtime_client.on_ai_transcript = on_ai_transcript
                         realtime_client.on_user_transcript = on_user_transcript
+                        realtime_client.on_speech_started = on_speech_started
                     else:
                         # Cold path: build session from scratch
                         bootstrap = await self._build_session_bootstrap(
@@ -1604,6 +1616,7 @@ class VoiceServer:
                             on_audio=on_audio,
                             on_ai_transcript=on_ai_transcript,
                             on_user_transcript=on_user_transcript,
+                            on_speech_started=on_speech_started,
                         )
 
                     # Wire tool bridge BEFORE connect/activate so on_function_call
@@ -1679,6 +1692,13 @@ class VoiceServer:
             "media": {"payload": audio_b64},
         }
         await websocket.send_text(json.dumps(message))
+
+    async def _send_twilio_clear(self, websocket, stream_sid: str) -> None:
+        """Flush any queued assistant audio from Twilio's playback buffer."""
+
+        await websocket.send_text(
+            json.dumps({"event": "clear", "streamSid": stream_sid})
+        )
 
     def _build_session_config(
         self,

--- a/packages/gptme-voice/tests/test_openai_client.py
+++ b/packages/gptme-voice/tests/test_openai_client.py
@@ -701,6 +701,25 @@ def test_disconnect_drains_late_transcript_events_without_sending_late_audio() -
     asyncio.run(_exercise())
 
 
+def test_speech_started_event_invokes_callback() -> None:
+    async def _exercise() -> None:
+        callback_hits: list[str] = []
+
+        async def _on_speech_started() -> None:
+            callback_hits.append("speech")
+
+        client = OpenAIRealtimeClient(
+            api_key="test-key",
+            on_speech_started=_on_speech_started,
+        )
+
+        await client._handle_event({"type": "input_audio_buffer.speech_started"})
+
+        assert callback_hits == ["speech"]
+
+    asyncio.run(_exercise())
+
+
 def test_hold_initial_response_suppresses_greeting() -> None:
     """_hold_initial_response=True must block the initial greeting even after session ready."""
 

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -13,6 +13,7 @@ import pytest
 from gptme_voice.realtime.audio import AudioConverter
 from gptme_voice.realtime.server import (
     RecentCallRecord,
+    SessionBootstrap,
     TranscriptTurn,
     VoiceServer,
     _assistant_committed_hangup,
@@ -70,15 +71,40 @@ class _DummyBrowserWebSocket:
         self.binary_messages.append(message)
 
 
+class _DummyTwilioWebSocket(_DummyWebSocket):
+    def __init__(self, incoming: list[dict[str, object]]) -> None:
+        super().__init__()
+        self._incoming = [json.dumps(message) for message in incoming]
+        self.accepted = False
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    def iter_text(self):
+        async def _gen():
+            for message in self._incoming:
+                yield message
+
+        return _gen()
+
+    @property
+    def query_params(self) -> dict[str, str]:
+        return {}
+
+
 class _FakeRealtimeClient:
     def __init__(self) -> None:
         self.sent_audio: list[bytes] = []
         self.commit_count = 0
         self.disconnect_kwargs: dict[str, object] | None = None
+        self.activate_session_count = 0
         self.on_function_call = None
 
     async def connect(self) -> None:
         return None
+
+    async def activate_session(self) -> None:
+        self.activate_session_count += 1
 
     async def send_audio(self, audio_data: bytes) -> None:
         self.sent_audio.append(audio_data)
@@ -384,6 +410,114 @@ def test_handle_browser_websocket_resamples_binary_pcm_and_commits(
     assert fake_client.commit_count == 1
     assert fake_client.disconnect_kwargs is not None
     assert fake_client.disconnect_kwargs["commit_audio"] is True
+
+
+def test_handle_twilio_websocket_wires_speech_started_clear_callback_cold_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _exercise() -> None:
+        server = VoiceServer()
+        websocket = _DummyTwilioWebSocket(
+            [
+                {"event": "connected"},
+                {
+                    "event": "start",
+                    "start": {
+                        "streamSid": "MZ123",
+                        "callSid": "CA123",
+                        "customParameters": {},
+                    },
+                },
+                {"event": "stop"},
+            ]
+        )
+        fake_client = _FakeRealtimeClient()
+        captured_kwargs: dict[str, object] = {}
+
+        async def _fake_build_session_bootstrap(
+            *,
+            caller_id: str,
+            from_number: str = "",
+            handoff_id: str | None = None,
+            standup_brief: str | None = None,
+        ) -> SessionBootstrap:
+            return SessionBootstrap("You are Bob.")
+
+        def _fake_make_client(_session_cfg, **kwargs):
+            captured_kwargs.update(kwargs)
+            return fake_client
+
+        async def _fake_on_call_end(*args, **kwargs) -> None:
+            return None
+
+        monkeypatch.setattr(
+            server, "_build_session_bootstrap", _fake_build_session_bootstrap
+        )
+        monkeypatch.setattr(server, "_make_client", _fake_make_client)
+        monkeypatch.setattr(server, "_on_call_end", _fake_on_call_end)
+        monkeypatch.setattr(
+            "gptme_voice.realtime.server.GptmeToolBridge", _DummyToolBridge
+        )
+
+        await server.handle_twilio_websocket(websocket)
+
+        assert websocket.accepted is True
+        assert "on_speech_started" in captured_kwargs
+
+        on_speech_started = captured_kwargs["on_speech_started"]
+        assert callable(on_speech_started)
+        await on_speech_started()
+
+        assert [json.loads(message) for message in websocket.messages] == [
+            {"event": "clear", "streamSid": "MZ123"}
+        ]
+
+    asyncio.run(_exercise())
+
+
+def test_handle_twilio_websocket_rebinds_speech_started_clear_callback_on_prewarm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _exercise() -> None:
+        server = VoiceServer()
+        websocket = _DummyTwilioWebSocket(
+            [
+                {"event": "connected"},
+                {
+                    "event": "start",
+                    "start": {
+                        "streamSid": "MZ123",
+                        "callSid": "CA123",
+                        "customParameters": {"from_number": "+46700000001"},
+                    },
+                },
+                {"event": "stop"},
+            ]
+        )
+        fake_client = _FakeRealtimeClient()
+
+        async def _fake_on_call_end(*args, **kwargs) -> None:
+            return None
+
+        monkeypatch.setattr(server, "_claim_prewarm", lambda _from_number: fake_client)
+        monkeypatch.setattr(server, "_on_call_end", _fake_on_call_end)
+        monkeypatch.setattr(
+            "gptme_voice.realtime.server.GptmeToolBridge", _DummyToolBridge
+        )
+
+        await server.handle_twilio_websocket(websocket)
+
+        assert websocket.accepted is True
+        assert fake_client.activate_session_count == 1
+        assert callable(fake_client.on_speech_started)
+
+        await fake_client.on_speech_started()
+
+        assert [json.loads(message) for message in websocket.messages] == [
+            {"event": "clear", "streamSid": "MZ123"}
+        ]
+
+    asyncio.run(_exercise())
 
 
 def test_build_resume_instructions_includes_prior_transcript() -> None:

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -468,8 +468,8 @@ def test_handle_twilio_websocket_wires_speech_started_clear_callback_cold_path(
         assert callable(on_speech_started)
         await on_speech_started()
 
-        assert [json.loads(message) for message in websocket.messages] == [
-            {"event": "clear", "streamSid": "MZ123"}
+        assert {"event": "clear", "streamSid": "MZ123"} in [
+            json.loads(m) for m in websocket.messages
         ]
 
     asyncio.run(_exercise())
@@ -513,8 +513,8 @@ def test_handle_twilio_websocket_rebinds_speech_started_clear_callback_on_prewar
 
         await fake_client.on_speech_started()
 
-        assert [json.loads(message) for message in websocket.messages] == [
-            {"event": "clear", "streamSid": "MZ123"}
+        assert {"event": "clear", "streamSid": "MZ123"} in [
+            json.loads(m) for m in websocket.messages
         ]
 
     asyncio.run(_exercise())


### PR DESCRIPTION
## Summary
- add a realtime `on_speech_started` callback hook for VAD speech-start events
- wire the Twilio voice server to send a Twilio `clear` event when the caller barges in
- cover both cold and prewarmed Twilio call paths with regression tests

## Why
Twilio was continuing to play already-buffered assistant audio even after server-side VAD detected caller speech, so interruptions sounded broken on live calls.

## Testing
- `uv run --directory /tmp/gptme-contrib-bargein-648f/packages/gptme-voice pytest /tmp/gptme-contrib-bargein-648f/packages/gptme-voice/tests/test_openai_client.py /tmp/gptme-contrib-bargein-648f/packages/gptme-voice/tests/test_server.py -q`
- `uv run --directory /tmp/gptme-contrib-bargein-648f/packages/gptme-voice ruff check /tmp/gptme-contrib-bargein-648f/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py /tmp/gptme-contrib-bargein-648f/packages/gptme-voice/src/gptme_voice/realtime/server.py /tmp/gptme-contrib-bargein-648f/packages/gptme-voice/tests/test_openai_client.py /tmp/gptme-contrib-bargein-648f/packages/gptme-voice/tests/test_server.py`
