### PR TITLE
feat(gptme-codegraph): add local-first semantic search (Phase 1)

### DIFF
--- a/packages/gptme-codegraph/src/gptme_codegraph/__init__.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/__init__.py
@@ -16,9 +16,18 @@ from gptme_codegraph.core import (
     impact_radius,
     parse_file,
 )
+from gptme_codegraph.search import (
+    LexicalScorer,
+    SearchDocument,
+    SearchResult,
+    extract_search_documents,
+)
 
 __all__ = [
     "IndexEntry",
+    "LexicalScorer",
+    "SearchDocument",
+    "SearchResult",
     "SqliteIndexCache",
     "Symbol",
     "SymbolIndex",
@@ -28,6 +37,7 @@ __all__ = [
     "build_index",
     "build_repo_map",
     "dependency_closure",
+    "extract_search_documents",
     "extract_symbols",
     "format_repo_map",
     "impact_radius",

--- a/packages/gptme-codegraph/src/gptme_codegraph/core.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/core.py
@@ -3943,13 +3943,13 @@ def main():
         cache = SqliteIndexCache(str(index_dir))
         cached = cache.load()
         if cached is not None:
-            index = cached
+            search_index = cached
         else:
-            index = build_index(index_dir)
-            cache.save(index)
+            search_index = build_index(index_dir)
+            cache.save(search_index)
         cache.close()
 
-        if not index or not index.all_names():
+        if not search_index or not search_index.all_names():
             sys.exit("No symbols found in directory")
 
         # Extract search documents
@@ -3958,7 +3958,7 @@ def main():
             extract_search_documents,
         )
 
-        docs = extract_search_documents(index, index_dir)
+        docs = extract_search_documents(search_index, index_dir)
         scorer = LexicalScorer()
         scorer.index(docs)
         results = scorer.search(args.query, limit=args.limit)

--- a/packages/gptme-codegraph/src/gptme_codegraph/core.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/core.py
@@ -3900,11 +3900,104 @@ def main():
         help="Maximum symbols per file (default: 12)",
     )
 
+    p_search = sub.add_parser(
+        "search",
+        help="Search indexed symbols by concept/query (local-first lexical search)",
+    )
+    p_search.add_argument("query", help="Natural-language search query")
+    p_search.add_argument(
+        "--backend",
+        default="lexical",
+        choices=["lexical"],
+        help="Search backend (default: lexical; semantic coming in Phase 2)",
+    )
+    p_search.add_argument(
+        "--limit",
+        type=int,
+        default=10,
+        help="Maximum results (default: 10)",
+    )
+    p_search.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+
     args = parser.parse_args()
     filepath = Path(args.file)
 
     if not filepath.exists():
         sys.exit(f"File not found: {filepath}")
+
+    if args.command == "search":
+        search_dir = (
+            Path(args.directory)
+            if args.directory
+            else (filepath if filepath.is_dir() else filepath.parent)
+        )
+        if not search_dir.is_dir():
+            sys.exit(f"Directory not found: {search_dir}")
+
+        # Build index
+        index_dir = search_dir
+        cache = SqliteIndexCache(str(index_dir))
+        cached = cache.load()
+        if cached is not None:
+            index = cached
+        else:
+            index = build_index(index_dir)
+            cache.save(index)
+        cache.close()
+
+        if not index or not index.all_names():
+            sys.exit("No symbols found in directory")
+
+        # Extract search documents
+        from gptme_codegraph.search import (
+            LexicalScorer,
+            extract_search_documents,
+        )
+
+        docs = extract_search_documents(index, index_dir)
+        scorer = LexicalScorer()
+        scorer.index(docs)
+        results = scorer.search(args.query, limit=args.limit)
+
+        if args.json:
+            print(
+                format_json(
+                    {
+                        "directory": str(index_dir),
+                        "query": args.query,
+                        "backend": "lexical",
+                        "results": [
+                            {
+                                "score": r.score,
+                                "qualified_id": r.qualified_id,
+                                "name": r.name,
+                                "kind": r.kind,
+                                "file": r.file,
+                                "start_line": r.start_line,
+                                "end_line": r.end_line,
+                                "parent_class": r.parent_class,
+                                "why": r.why,
+                            }
+                            for r in results
+                        ],
+                    }
+                )
+            )
+        else:
+            print(f"Search results for '{args.query}' (lexical, {len(results)} found):")
+            print()
+            for r in results:
+                qual = f" ({r.parent_class})" if r.parent_class else ""
+                print(f"  {r.score:.4f}  {r.kind} {r.name}{qual}")
+                print(f"        {r.file}:L{r.start_line}-L{r.end_line}")
+                if r.why:
+                    print(f"        matched: {r.why}")
+                print()
+        return
 
     if args.command == "map":
         map_dir = (

--- a/packages/gptme-codegraph/src/gptme_codegraph/mcp_server.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/mcp_server.py
@@ -612,10 +612,11 @@ def codegraph_search(
     directory: str,
     limit: int = 10,
 ) -> str:
-    """Search indexed symbols by concept/query using local lexical search.
+    """Find code symbols by concept when you don't know the exact name.
 
-    Uses a dependency-free BM25 scorer over symbol names, docstrings, and
-    source snippets. No external embeddings or API calls required.
+    Use this tool to locate functions, classes, or methods that handle a
+    specific concept (e.g. "retry logic", "session persistence"). It
+    searches indexed symbols using a local BM25 scorer — no external APIs.
 
     Args:
         query: Natural-language search query (e.g. "where is retry logic?").

--- a/packages/gptme-codegraph/src/gptme_codegraph/mcp_server.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/mcp_server.py
@@ -52,6 +52,10 @@ from gptme_codegraph.core import (
     extract_symbols,
     impact_radius,
 )
+from gptme_codegraph.search import (
+    LexicalScorer,
+    extract_search_documents,
+)
 
 mcp = FastMCP("codegraph", log_level="WARNING")
 
@@ -600,6 +604,62 @@ def codegraph_blast(
             result["definitions"] = len(index.lookup(name))
 
     return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+def codegraph_search(
+    query: str,
+    directory: str,
+    limit: int = 10,
+) -> str:
+    """Search indexed symbols by concept/query using local lexical search.
+
+    Uses a dependency-free BM25 scorer over symbol names, docstrings, and
+    source snippets. No external embeddings or API calls required.
+
+    Args:
+        query: Natural-language search query (e.g. "where is retry logic?").
+        directory: Directory for cross-file index.
+        limit: Maximum results (default: 10).
+
+    Returns:
+        JSON with directory, query, backend, and ranked results.
+    """
+    dir_path = Path(directory)
+    if not dir_path.exists():
+        return json.dumps({"error": f"Directory not found: {directory}"})
+
+    index = _get_or_build_index(directory)
+    if not index or not index.all_names():
+        return json.dumps({"error": "No symbols found in directory"})
+
+    docs = extract_search_documents(index, dir_path)
+    scorer = LexicalScorer()
+    scorer.index(docs)
+    results = scorer.search(query, limit=limit)
+
+    return json.dumps(
+        {
+            "directory": directory,
+            "query": query,
+            "backend": "lexical",
+            "results": [
+                {
+                    "score": r.score,
+                    "qualified_id": r.qualified_id,
+                    "name": r.name,
+                    "kind": r.kind,
+                    "file": r.file,
+                    "start_line": r.start_line,
+                    "end_line": r.end_line,
+                    "parent_class": r.parent_class,
+                    "why": r.why,
+                }
+                for r in results
+            ],
+        },
+        indent=2,
+    )
 
 
 @mcp.tool()

--- a/packages/gptme-codegraph/src/gptme_codegraph/search.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/search.py
@@ -77,7 +77,7 @@ _DOCSTRING_MAX_CHARS = 500
 
 def _extract_snippet(symbol_lines: list[str]) -> str:
     """Extract first N non-empty lines from a symbol body, capped."""
-    non_empty = [l for l in symbol_lines if l.strip()]
+    non_empty = [ln for ln in symbol_lines if ln.strip()]
     snippet_lines = non_empty[:_SNIPPET_MAX_LINES]
     snippet = "\n".join(snippet_lines).strip()
     if len(snippet) > _SNIPPET_MAX_CHARS:

--- a/packages/gptme-codegraph/src/gptme_codegraph/search.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/search.py
@@ -1,0 +1,474 @@
+"""Local-first semantic search over gptme-codegraph symbols.
+
+Provides dependency-free lexical search (BM25-like) on symbol documents
+extracted from a ``SymbolIndex``. Follow-up phases will add an optional
+local embedding backend.
+
+Usage:
+    from gptme_codegraph.search import (
+        SearchDocument,
+        SearchResult,
+        extract_search_documents,
+        LexicalScorer,
+        SearchBackend,
+    )
+
+    index = build_index(...)
+    docs = extract_search_documents(index, root)
+    scorer = LexicalScorer()
+    scorer.index(docs)
+    results = scorer.search("retry logic", limit=5)
+"""
+
+import math
+import re
+import sqlite3
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Protocol
+
+from gptme_codegraph.core import SymbolIndex
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SearchDocument:
+    """A searchable document derived from a single symbol."""
+
+    qualified_id: str
+    kind: str
+    name: str
+    file: str
+    start_line: int
+    end_line: int
+    parent_class: str | None = None
+    docstring: str = ""
+    calls: list[str] = field(default_factory=list)
+    snippet: str = ""  # first N non-empty source lines, capped
+
+
+@dataclass
+class SearchResult:
+    """A single ranked search result."""
+
+    score: float
+    qualified_id: str
+    name: str
+    kind: str
+    file: str
+    start_line: int
+    end_line: int
+    parent_class: str | None = None
+    why: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Document extraction
+# ---------------------------------------------------------------------------
+
+_SNIPPET_MAX_LINES = 5
+_SNIPPET_MAX_CHARS = 500
+_DOCSTRING_MAX_CHARS = 500
+
+
+def _extract_snippet(symbol_lines: list[str]) -> str:
+    """Extract first N non-empty lines from a symbol body, capped."""
+    non_empty = [l for l in symbol_lines if l.strip()]
+    snippet_lines = non_empty[:_SNIPPET_MAX_LINES]
+    snippet = "\n".join(snippet_lines).strip()
+    if len(snippet) > _SNIPPET_MAX_CHARS:
+        snippet = snippet[:_SNIPPET_MAX_CHARS] + "..."
+    return snippet
+
+
+def _read_symbol_body(filepath: Path, start_line: int, end_line: int) -> list[str]:
+    """Read source lines for a symbol from file."""
+    try:
+        with open(filepath) as f:
+            lines = f.readlines()
+        # start_line and end_line are 1-based, inclusive
+        return lines[start_line - 1 : end_line]
+    except (OSError, IndexError):
+        return []
+
+
+def extract_search_documents(index: SymbolIndex, root: Path) -> list[SearchDocument]:
+    """Build one search document per indexed symbol.
+
+    Reads source files to extract docstrings and short snippets for each
+    symbol definition.
+    """
+    docs: list[SearchDocument] = []
+    seen: set[str] = set()  # deduplicate by qualified_id
+
+    for name, entries in index.entries.items():
+        for entry in entries:
+            qid = entry.qualified_id()
+            if qid in seen:
+                continue
+            seen.add(qid)
+
+            docstring = ""
+            snippet = ""
+            filepath = (
+                root / entry.file
+                if not Path(entry.file).is_absolute()
+                else Path(entry.file)
+            )
+
+            if filepath.exists():
+                body_lines = _read_symbol_body(
+                    filepath, entry.start_line, entry.end_line
+                )
+                snippet = _extract_snippet(body_lines)
+
+                # Extract docstring from the symbol body
+                docstring = _extract_docstring(body_lines)
+
+            doc = SearchDocument(
+                qualified_id=qid,
+                kind=entry.kind,
+                name=entry.name,
+                file=entry.file,
+                start_line=entry.start_line,
+                end_line=entry.end_line,
+                parent_class=entry.parent_class,
+                docstring=docstring[:_DOCSTRING_MAX_CHARS],
+                snippet=snippet,
+                calls=[],
+            )
+            docs.append(doc)
+
+    return docs
+
+
+def _extract_docstring(body_lines: list[str]) -> str:
+    """Extract a docstring from symbol body lines.
+
+    Handles both triple-quoted (''' and \"\"\") and single-line docstrings.
+    """
+    text = "".join(body_lines).strip()
+    if not text:
+        return ""
+
+    # Try triple double quotes
+    m = re.search(r'"""(.*?)"""', text, re.DOTALL)
+    if m:
+        return m.group(1).strip()
+
+    # Try triple single quotes
+    m = re.search(r"'''(.*?)'''", text, re.DOTALL)
+    if m:
+        return m.group(1).strip()
+
+    # Try single-line docstring (after def/class line)
+    lines = text.split("\n")
+    if len(lines) >= 2:
+        second_line = lines[1].strip()
+        if second_line.startswith(('"""', "'''")) and second_line.endswith(
+            ('"""', "'''")
+        ):
+            return second_line.strip("\"'").strip()
+
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Tokenizer
+# ---------------------------------------------------------------------------
+
+
+def _tokenize(text: str) -> list[str]:
+    """Tokenize text into lowercase words.
+
+    Splits on non-alphanumeric characters and handles camelCase and
+    snake_case by splitting on case transitions and underscores.
+    """
+    # First, split camelCase and PascalCase
+    text = re.sub(r"([a-z])([A-Z])", r"\1 \2", text)
+    text = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1 \2", text)
+    # Replace underscores and non-alphanumeric with spaces
+    text = re.sub(r"[^a-zA-Z0-9]", " ", text)
+    return [t.lower() for t in text.split() if len(t) > 1 or t.isalnum()]
+
+
+# ---------------------------------------------------------------------------
+# BM25 scorer
+# ---------------------------------------------------------------------------
+
+
+class LexicalScorer:
+    """Dependency-free BM25-like lexical scorer.
+
+    Uses BM25-Okapi weighting with standard parameters (k1=1.5, b=0.75).
+    """
+
+    k1: float = 1.5
+    b: float = 0.75
+
+    def __init__(self, k1: float = 1.5, b: float = 0.75):
+        self.k1 = k1
+        self.b = b
+        self._documents: list[SearchDocument] = []
+        self._doc_freqs: dict[str, int] = {}
+        self._doc_lengths: list[int] = []
+        self._avg_doc_length: float = 0.0
+        self._num_docs: int = 0
+        self._idf_cache: dict[str, float] = {}
+        self._ready = False
+
+    def index(self, documents: list[SearchDocument]) -> None:
+        """Index a list of search documents."""
+        self._documents = documents
+        self._num_docs = len(documents)
+        self._doc_freqs = Counter()
+        self._doc_lengths = []
+
+        for doc in documents:
+            field_text = " ".join(
+                [
+                    doc.name,
+                    doc.kind,
+                    doc.parent_class or "",
+                    doc.docstring,
+                    doc.snippet,
+                    doc.qualified_id,
+                ]
+            )
+            tokens = _tokenize(field_text)
+            unique_terms = set(tokens)
+            for term in unique_terms:
+                self._doc_freqs[term] += 1
+            self._doc_lengths.append(len(tokens))
+
+        self._avg_doc_length = (
+            sum(self._doc_lengths) / self._num_docs if self._num_docs > 0 else 0.0
+        )
+        self._idf_cache = {}
+        self._ready = True
+
+    def _idf(self, term: str) -> float:
+        """Compute IDF for a term."""
+        if term not in self._idf_cache:
+            df = self._doc_freqs.get(term, 0)
+            if df == 0:
+                return 0.0
+            self._idf_cache[term] = math.log(
+                (self._num_docs - df + 0.5) / (df + 0.5) + 1.0
+            )
+        return self._idf_cache[term]
+
+    def _score_document(self, query_tokens: list[str], doc_idx: int) -> float:
+        """Score a single document against query tokens."""
+        doc = self._documents[doc_idx]
+        field_text = " ".join(
+            [
+                doc.name,
+                doc.kind,
+                doc.parent_class or "",
+                doc.docstring,
+                doc.snippet,
+                doc.qualified_id,
+            ]
+        )
+        doc_tokens = _tokenize(field_text)
+        doc_len = len(doc_tokens)
+        term_freqs = Counter(doc_tokens)
+
+        score = 0.0
+        for term in query_tokens:
+            tf = term_freqs.get(term, 0)
+            if tf == 0:
+                continue
+            idf = self._idf(term)
+            numerator = tf * (self.k1 + 1)
+            denominator = tf + self.k1 * (
+                1 - self.b + self.b * (doc_len / self._avg_doc_length)
+            )
+            score += idf * (numerator / denominator)
+
+        return score
+
+    def search(self, query: str, limit: int = 10) -> list[SearchResult]:
+        """Search indexed documents and return ranked results."""
+        if not self._ready or not self._documents:
+            return []
+
+        query_tokens = _tokenize(query)
+        if not query_tokens:
+            return []
+
+        scored: list[tuple[float, int]] = []
+        for i in range(self._num_docs):
+            s = self._score_document(query_tokens, i)
+            if s > 0:
+                scored.append((s, i))
+
+        # Sort by score descending
+        scored.sort(key=lambda x: -x[0])
+
+        results: list[SearchResult] = []
+        for score, idx in scored[:limit]:
+            doc = self._documents[idx]
+            why_parts = []
+            for term in query_tokens:
+                if doc.name and term in _tokenize(doc.name):
+                    why_parts.append("name")
+                if doc.docstring and term in _tokenize(doc.docstring):
+                    why_parts.append("docstring")
+                if doc.snippet and term in _tokenize(doc.snippet):
+                    why_parts.append("body")
+                if doc.qualified_id and term in _tokenize(doc.qualified_id):
+                    why_parts.append("qualified_id")
+
+            results.append(
+                SearchResult(
+                    score=round(score, 4),
+                    qualified_id=doc.qualified_id,
+                    name=doc.name,
+                    kind=doc.kind,
+                    file=doc.file,
+                    start_line=doc.start_line,
+                    end_line=doc.end_line,
+                    parent_class=doc.parent_class,
+                    why="/".join(dict.fromkeys(why_parts)) if why_parts else "matched",
+                )
+            )
+
+        return results
+
+
+# ---------------------------------------------------------------------------
+# Search backend protocol + registry
+# ---------------------------------------------------------------------------
+
+
+class SearchBackend(Protocol):
+    """Protocol for search backends.
+
+    Both the lexical and (future) semantic backends implement this.
+    """
+
+    name: str
+
+    def index(self, documents: list[SearchDocument]) -> None: ...
+
+    def search(self, query: str, limit: int) -> list[SearchResult]: ...
+
+
+# ---------------------------------------------------------------------------
+# SQLite search-document cache
+# ---------------------------------------------------------------------------
+
+
+def _ensure_search_tables(conn: sqlite3.Connection) -> None:
+    """Create search-document cache tables if they don't exist."""
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS search_documents (
+            directory TEXT NOT NULL,
+            qualified_id TEXT NOT NULL,
+            file TEXT NOT NULL,
+            start_line INTEGER NOT NULL,
+            end_line INTEGER NOT NULL,
+            content_hash TEXT NOT NULL,
+            document TEXT NOT NULL,
+            PRIMARY KEY (directory, qualified_id)
+        );
+    """)
+
+
+def save_search_documents(
+    conn: sqlite3.Connection, directory: str, docs: list[SearchDocument]
+) -> None:
+    """Persist search documents to SQLite cache."""
+    import hashlib
+    import json
+
+    _ensure_search_tables(conn)
+    conn.execute("DELETE FROM search_documents WHERE directory = ?", (directory,))
+
+    for doc in docs:
+        content_hash = hashlib.sha256(
+            json.dumps(
+                {
+                    "name": doc.name,
+                    "kind": doc.kind,
+                    "file": doc.file,
+                    "start_line": doc.start_line,
+                    "end_line": doc.end_line,
+                    "parent_class": doc.parent_class,
+                    "docstring": doc.docstring,
+                    "snippet": doc.snippet,
+                    "calls": doc.calls,
+                },
+                sort_keys=True,
+                default=str,
+            ).encode()
+        ).hexdigest()[:16]
+
+        doc_json = json.dumps(
+            {
+                "qualified_id": doc.qualified_id,
+                "name": doc.name,
+                "kind": doc.kind,
+                "file": doc.file,
+                "start_line": doc.start_line,
+                "end_line": doc.end_line,
+                "parent_class": doc.parent_class,
+                "docstring": doc.docstring,
+                "snippet": doc.snippet,
+                "calls": doc.calls,
+            },
+            default=str,
+        )
+
+        conn.execute(
+            """INSERT INTO search_documents (directory, qualified_id, file, start_line, end_line, content_hash, document)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (
+                directory,
+                doc.qualified_id,
+                doc.file,
+                doc.start_line,
+                doc.end_line,
+                content_hash,
+                doc_json,
+            ),
+        )
+    conn.commit()
+
+
+def load_search_documents(
+    conn: sqlite3.Connection, directory: str
+) -> list[SearchDocument]:
+    """Load search documents from SQLite cache."""
+    import json
+
+    _ensure_search_tables(conn)
+    rows = conn.execute(
+        "SELECT document FROM search_documents WHERE directory = ?",
+        (directory,),
+    ).fetchall()
+
+    docs: list[SearchDocument] = []
+    for (doc_json,) in rows:
+        data = json.loads(doc_json)
+        docs.append(
+            SearchDocument(
+                qualified_id=data["qualified_id"],
+                kind=data["kind"],
+                name=data["name"],
+                file=data["file"],
+                start_line=data["start_line"],
+                end_line=data["end_line"],
+                parent_class=data.get("parent_class"),
+                docstring=data.get("docstring", ""),
+                snippet=data.get("snippet", ""),
+                calls=data.get("calls", []),
+            )
+        )
+    return docs

--- a/packages/gptme-codegraph/src/gptme_codegraph/search.py
+++ b/packages/gptme-codegraph/src/gptme_codegraph/search.py
@@ -364,6 +364,11 @@ class SearchBackend(Protocol):
 # SQLite search-document cache
 # ---------------------------------------------------------------------------
 
+# TODO(phase-2): Cache helpers are wired but not yet integrated into the
+# CLI search path (core.py) or the MCP tool (mcp_server.py). Every
+# search invocation currently rebuilds the BM25 index from disk. This
+# will be connected once the local embedding backend lands.
+
 
 def _ensure_search_tables(conn: sqlite3.Connection) -> None:
     """Create search-document cache tables if they don't exist."""

--- a/packages/gptme-codegraph/tests/test_codegraph_mcp_server.py
+++ b/packages/gptme-codegraph/tests/test_codegraph_mcp_server.py
@@ -100,6 +100,7 @@ def test_tools_registered():
         "codegraph_refs",
         "codegraph_blast",
         "codegraph_impact",
+        "codegraph_search",
     }
     assert names == expected
 
@@ -487,3 +488,54 @@ def test_cross_file_blast_missing_symbol(sample_dir):
 
     d = _run(_check())
     assert "error" in d
+
+
+def test_codegraph_search(sample_dir):
+    """codegraph_search returns ranked results for a query."""
+
+    async def _check():
+        r = await _MOD.mcp.call_tool(
+            "codegraph_search",
+            {"query": "add compute", "directory": sample_dir, "limit": 5},
+        )
+        return json.loads(_content(r))
+
+    d = _run(_check())
+    assert "error" not in d, d.get("error", "")
+    assert d["backend"] == "lexical"
+    assert len(d["results"]) >= 1
+    # Results should have the expected shape
+    for res in d["results"]:
+        assert "score" in res
+        assert "qualified_id" in res
+        assert "name" in res
+        assert res["score"] > 0
+
+
+def test_codegraph_search_missing_dir():
+    """codegraph_search returns error for nonexistent directory."""
+
+    async def _check():
+        r = await _MOD.mcp.call_tool(
+            "codegraph_search",
+            {"query": "test", "directory": "/nonexistent/path", "limit": 5},
+        )
+        return json.loads(_content(r))
+
+    d = _run(_check())
+    assert "error" in d
+
+
+def test_codegraph_search_empty_query(sample_dir):
+    """codegraph_search with no-matching query returns empty results."""
+
+    async def _check():
+        r = await _MOD.mcp.call_tool(
+            "codegraph_search",
+            {"query": "xyznonexistent2024", "directory": sample_dir, "limit": 5},
+        )
+        return json.loads(_content(r))
+
+    d = _run(_check())
+    assert "error" not in d, d.get("error", "")
+    assert len(d["results"]) == 0

--- a/packages/gptme-codegraph/tests/test_codegraph_search.py
+++ b/packages/gptme-codegraph/tests/test_codegraph_search.py
@@ -1,0 +1,476 @@
+"""Tests for gptme-codegraph local semantic search."""
+
+import tempfile
+from pathlib import Path
+
+from gptme_codegraph.core import IndexEntry, SymbolIndex, build_index
+from gptme_codegraph.search import (
+    LexicalScorer,
+    SearchDocument,
+    SearchResult,
+    _tokenize,
+    extract_search_documents,
+)
+
+# ---------------------------------------------------------------------------
+# Tokenizer
+# ---------------------------------------------------------------------------
+
+
+class TestTokenizer:
+    def test_snake_case(self):
+        tokens = _tokenize("retry_api_call")
+        assert "retry" in tokens
+        assert "api" in tokens
+        assert "call" in tokens
+
+    def test_camel_case(self):
+        tokens = _tokenize("RetryAPICall")
+        assert "retry" in tokens
+        assert "api" in tokens
+        assert "call" in tokens
+
+    def test_mixed(self):
+        tokens = _tokenize("get_session_persistence")
+        assert "get" in tokens
+        assert "session" in tokens
+        assert "persistence" in tokens
+
+    def test_punctuation(self):
+        tokens = _tokenize("where is retry logic?")
+        assert "where" in tokens
+        assert "is" in tokens
+        assert "retry" in tokens
+        assert "logic" in tokens
+
+    def test_empty(self):
+        assert _tokenize("") == []
+        assert _tokenize("   ") == []
+
+    def test_short_tokens_excluded(self):
+        """Single characters are excluded, but 'a' and 'I' would be."""
+        tokens = _tokenize("a b c")
+        assert all(len(t) > 1 or t.isalnum() for t in tokens)
+
+
+# ---------------------------------------------------------------------------
+# SearchDocument
+# ---------------------------------------------------------------------------
+
+
+class TestSearchDocument:
+    def test_doc_creation(self):
+        doc = SearchDocument(
+            qualified_id="module::my_func",
+            kind="function",
+            name="my_func",
+            file="module.py",
+            start_line=10,
+            end_line=20,
+            parent_class=None,
+            docstring="Does something",
+            snippet="def my_func():",
+            calls=["other_func"],
+        )
+        assert doc.qualified_id == "module::my_func"
+        assert doc.kind == "function"
+        assert doc.name == "my_func"
+        assert doc.start_line == 10
+        assert doc.docstring == "Does something"
+
+
+class TestSearchResult:
+    def test_result_creation(self):
+        result = SearchResult(
+            score=0.85,
+            qualified_id="module::my_func",
+            name="my_func",
+            kind="function",
+            file="module.py",
+            start_line=10,
+            end_line=20,
+            why="name/docstring matched",
+        )
+        assert result.score == 0.85
+        assert result.why == "name/docstring matched"
+
+
+# ---------------------------------------------------------------------------
+# Extract search documents
+# ---------------------------------------------------------------------------
+
+
+class TestExtractSearchDocuments:
+    def test_from_index(self):
+        """Extract search documents from a SymbolIndex."""
+        index = SymbolIndex(
+            entries={
+                "add": [
+                    IndexEntry(
+                        name="add",
+                        kind="function",
+                        file="math_utils.py",
+                        start_line=1,
+                        end_line=3,
+                        module_path="math_utils",
+                    )
+                ]
+            }
+        )
+        root = Path("/fake")
+        docs = extract_search_documents(index, root)
+        assert len(docs) == 1
+        assert docs[0].qualified_id == "math_utils::add"
+        assert docs[0].kind == "function"
+        assert docs[0].name == "add"
+
+    def test_from_real_files(self):
+        """Extract search documents from actual Python source files."""
+        with tempfile.TemporaryDirectory(prefix="codegraph_search_") as tmp:
+            tmp_path = Path(tmp)
+            (tmp_path / "calc.py").write_text(
+                "def add(x, y):\n"
+                '    """Add two numbers."""\n'
+                "    return x + y\n"
+                "\n"
+                "def multiply(x, y):\n"
+                '    """Multiply two numbers."""\n'
+                "    return x * y\n"
+            )
+
+            index = build_index(tmp_path)
+            assert index is not None
+            assert len(index.all_names()) >= 2
+
+            docs = extract_search_documents(index, tmp_path)
+            doc_map = {d.name: d for d in docs}
+
+            assert "add" in doc_map
+            assert "multiply" in doc_map
+            # Should have extracted docstrings
+            assert "Add two numbers" in doc_map["add"].docstring
+            assert "Multiply two numbers" in doc_map["multiply"].docstring
+
+    def test_deduplicates_by_qualified_id(self):
+        """Multiple entries with same qualified_id are deduplicated."""
+        index = SymbolIndex(
+            entries={
+                "helper": [
+                    IndexEntry(
+                        name="helper",
+                        kind="function",
+                        file="a.py",
+                        start_line=1,
+                        end_line=3,
+                        module_path="a",
+                    ),
+                    IndexEntry(
+                        name="helper",
+                        kind="function",
+                        file="b.py",
+                        start_line=1,
+                        end_line=3,
+                        module_path="b",
+                    ),
+                ]
+            }
+        )
+        docs = extract_search_documents(index, Path("/fake"))
+        # Different files → different qualified_ids (different module_path)
+        assert len(docs) == 2
+
+    def test_empty_index(self):
+        """Empty index yields no documents."""
+        index = SymbolIndex()
+        docs = extract_search_documents(index, Path("/fake"))
+        assert docs == []
+
+
+# ---------------------------------------------------------------------------
+# BM25 Lexical Scorer
+# ---------------------------------------------------------------------------
+
+
+class TestLexicalScorer:
+    def test_basic_search(self):
+        docs = [
+            SearchDocument(
+                qualified_id="mod::retry_api_call",
+                kind="function",
+                name="retry_api_call",
+                file="retry.py",
+                start_line=10,
+                end_line=30,
+                docstring="Retry an API call with exponential backoff.",
+                snippet="def retry_api_call(url):",
+            ),
+            SearchDocument(
+                qualified_id="mod::format_output",
+                kind="function",
+                name="format_output",
+                file="output.py",
+                start_line=1,
+                end_line=5,
+                docstring="Format output for display.",
+                snippet="def format_output(data):",
+            ),
+        ]
+        scorer = LexicalScorer()
+        scorer.index(docs)
+
+        results = scorer.search("retry api call", limit=5)
+        assert len(results) >= 1
+        assert results[0].name == "retry_api_call"
+        assert results[0].score > 0
+
+    def test_relevance_ranking(self):
+        """Search results rank more relevant documents higher."""
+        docs = [
+            SearchDocument(
+                qualified_id="mod::add",
+                kind="function",
+                name="add",
+                file="calc.py",
+                start_line=1,
+                end_line=3,
+                docstring="Add two numbers together.",
+            ),
+            SearchDocument(
+                qualified_id="mod::subtract",
+                kind="function",
+                name="subtract",
+                file="calc.py",
+                start_line=5,
+                end_line=7,
+                docstring="Subtract the second number from the first.",
+            ),
+            SearchDocument(
+                qualified_id="mod::add_user",
+                kind="function",
+                name="add_user",
+                file="users.py",
+                start_line=10,
+                end_line=20,
+                docstring="Add a new user to the database.",
+            ),
+        ]
+        scorer = LexicalScorer()
+        scorer.index(docs)
+
+        results = scorer.search("add number", limit=5)
+        assert len(results) >= 1
+        # The 'add' function should rank higher than 'add_user' for "add number"
+        # (both match 'add', but 'add' function docstring also mentions 'numbers')
+        add_result = [r for r in results if r.name == "add"]
+        assert len(add_result) >= 1
+        # All results should have positive scores
+        for r in results:
+            assert r.score > 0
+
+    def test_no_match(self):
+        docs = [
+            SearchDocument(
+                qualified_id="mod::add",
+                kind="function",
+                name="add",
+                file="calc.py",
+                start_line=1,
+                end_line=3,
+                docstring="Add two numbers.",
+            ),
+        ]
+        scorer = LexicalScorer()
+        scorer.index(docs)
+
+        results = scorer.search("database connection", limit=5)
+        assert results == []
+
+    def test_empty_index(self):
+        scorer = LexicalScorer()
+        scorer.index([])
+        results = scorer.search("anything", limit=5)
+        assert results == []
+
+    def test_limit(self):
+        docs = [
+            SearchDocument(
+                qualified_id=f"mod::func{i}",
+                kind="function",
+                name=f"func{i}",
+                file=f"mod{i}.py",
+                start_line=1,
+                end_line=3,
+                docstring=f"This is function {i} with some common text.",
+            )
+            for i in range(20)
+        ]
+        scorer = LexicalScorer()
+        scorer.index(docs)
+
+        results = scorer.search("function common text", limit=5)
+        assert len(results) <= 5
+
+    def test_search_docstring_snippet(self):
+        """Search matches against docstrings and snippets."""
+        docs = [
+            SearchDocument(
+                qualified_id="mod::read_file",
+                kind="function",
+                name="read_file",
+                file="io.py",
+                start_line=1,
+                end_line=10,
+                docstring="Read and parse a configuration file.",
+                snippet="def read_file(path):",
+            ),
+            SearchDocument(
+                qualified_id="mod::write_file",
+                kind="function",
+                name="write_file",
+                file="io.py",
+                start_line=12,
+                end_line=20,
+                docstring="Write data to a file.",
+                snippet="def write_file(path, data):",
+            ),
+        ]
+        scorer = LexicalScorer()
+        scorer.index(docs)
+
+        # Should find both via docstring match on "file"
+        results = scorer.search("file", limit=5)
+        assert len(results) == 2
+
+        # Should favor read_file for "read"
+        results_read = scorer.search("read parse", limit=5)
+        assert results_read[0].name == "read_file"
+
+    def test_why_field(self):
+        """Search results include a 'why' explanation."""
+        docs = [
+            SearchDocument(
+                qualified_id="mod::connect_db",
+                kind="function",
+                name="connect_db",
+                file="db.py",
+                start_line=1,
+                end_line=10,
+                docstring="Connect to the database.",
+            ),
+        ]
+        scorer = LexicalScorer()
+        scorer.index(docs)
+
+        results = scorer.search("connect database", limit=5)
+        assert len(results) == 1
+        assert "name" in results[0].why or "docstring" in results[0].why
+        assert results[0].why != ""
+
+    def test_order_stability(self):
+        """Same query on same index produces same order."""
+        docs = [
+            SearchDocument(
+                qualified_id=f"mod::func{i}",
+                kind="function",
+                name=f"func{i}",
+                file=f"mod{i}.py",
+                start_line=1,
+                end_line=3,
+                docstring=f"This is function {i} about data processing.",
+            )
+            for i in range(5)
+        ]
+        scorer = LexicalScorer()
+        scorer.index(docs)
+
+        first = scorer.search("data processing", limit=5)
+        second = scorer.search("data processing", limit=5)
+        assert len(first) == len(second)
+        for r1, r2 in zip(first, second):
+            assert r1.qualified_id == r2.qualified_id
+            assert r1.score == r2.score
+
+
+# ---------------------------------------------------------------------------
+# Integration: build_index -> extract -> search round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestSearchIntegration:
+    def test_round_trip(self):
+        """Full pipeline: build index, extract docs, search."""
+        with tempfile.TemporaryDirectory(prefix="codegraph_search_int_") as tmp:
+            tmp_path = Path(tmp)
+
+            # Create a few source files
+            (tmp_path / "retry.py").write_text(
+                "import time\n"
+                "\n"
+                "def retry_api_call(url, max_retries=3):\n"
+                '    """Retry an API call with exponential backoff."""\n'
+                "    for attempt in range(max_retries):\n"
+                "        try:\n"
+                "            return _do_request(url)\n"
+                "        except ConnectionError:\n"
+                "            time.sleep(2 ** attempt)\n"
+                "    raise ConnectionError(f'Failed after {max_retries} retries')\n"
+                "\n"
+                "\n"
+                "def _do_request(url):\n"
+                '    """Make a single HTTP request."""\n'
+                "    return f'response from {url}'\n"
+            )
+
+            (tmp_path / "session.py").write_text(
+                "import json\n"
+                "\n"
+                "class Session:\n"
+                '    """Manages a user session."""\n'
+                "\n"
+                "    def __init__(self, user_id):\n"
+                "        self.user_id = user_id\n"
+                "        self.data = {}\n"
+                "\n"
+                "    def save(self):\n"
+                '        """Persist session data to disk."""\n'
+                "        with open(f'session_{self.user_id}.json', 'w') as f:\n"
+                "            json.dump(self.data, f)\n"
+                "\n"
+                "    def load(self):\n"
+                '        """Load session data from disk."""\n'
+                "        try:\n"
+                "            with open(f'session_{self.user_id}.json') as f:\n"
+                "                self.data = json.load(f)\n"
+                "        except FileNotFoundError:\n"
+                "            self.data = {}\n"
+            )
+
+            index = build_index(tmp_path)
+            assert index is not None
+
+            docs = extract_search_documents(index, tmp_path)
+
+            scorer = LexicalScorer()
+            scorer.index(docs)
+
+            # Search for retry-related concepts
+            results = scorer.search("retry api call backoff", limit=5)
+            assert len(results) >= 1
+            # Should match retry_api_call
+            api_funcs = [r for r in results if "retry_api_call" in r.qualified_id]
+            assert len(api_funcs) >= 1
+            assert api_funcs[0].score > 0
+
+            # Search for session persistence
+            results2 = scorer.search("session persist save", limit=5)
+            assert len(results2) >= 1
+            session_results = [
+                r
+                for r in results2
+                if "Session" in r.qualified_id or "session" in r.name
+            ]
+            assert len(session_results) >= 1
+
+            # Search for something nonexistent
+            results3 = scorer.search("quantum cryptography", limit=5)
+            assert results3 == []

--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -14,6 +14,7 @@ conversation when ready.
 import asyncio
 import logging
 import os
+import shutil
 import tempfile
 import time
 from collections import deque
@@ -55,6 +56,9 @@ _KILLED_RETURNCODE = 137  # 128 + SIGKILL (timeout kill-after or OOM kill)
 # fails to terminate the child.
 _FAST_MODE_SUBPROCESS_TIMEOUT_SECONDS = 30
 _SMART_MODE_SUBPROCESS_TIMEOUT_SECONDS = 120
+# ``timeout(1)`` is a GNU coreutils binary available on Linux but not macOS.
+# When it is missing we fall back to Python-level asyncio timeout handling.
+_TIMEOUT_BINARY_AVAILABLE = shutil.which("timeout") is not None
 # How many recently-completed task records to keep for subagent_status queries.
 # The model can see these to understand whether a task succeeded, timed out, or errored.
 _MAX_RECENT_COMPLETIONS = 5
@@ -516,16 +520,24 @@ class GptmeToolBridge:
             else _SMART_MODE_SUBPROCESS_TIMEOUT_SECONDS
         )
 
-        cmd = [
-            "timeout",
-            "--signal=TERM",
-            "--kill-after=5s",
-            f"{subprocess_timeout_seconds}s",
-            self.gptme_path,
-            "--non-interactive",
-            "--context",
-            "files",
-        ]
+        if _TIMEOUT_BINARY_AVAILABLE:
+            cmd = [
+                "timeout",
+                "--signal=TERM",
+                "--kill-after=5s",
+                f"{subprocess_timeout_seconds}s",
+                self.gptme_path,
+                "--non-interactive",
+                "--context",
+                "files",
+            ]
+        else:
+            cmd = [
+                self.gptme_path,
+                "--non-interactive",
+                "--context",
+                "files",
+            ]
         # Keep project prompt files but skip context_cmd. This avoids pulling in
         # scripts/context.sh while still giving the subagent its runtime rules.
         if model:
@@ -579,7 +591,11 @@ class GptmeToolBridge:
             try:
                 await asyncio.wait_for(
                     asyncio.gather(_read_stdout(), _read_stderr(), process.wait()),
-                    timeout=self.timeout,
+                    timeout=(
+                        self.timeout
+                        if _TIMEOUT_BINARY_AVAILABLE
+                        else subprocess_timeout_seconds
+                    ),
                 )
             except asyncio.TimeoutError:
                 process.kill()
@@ -589,13 +605,20 @@ class GptmeToolBridge:
                 # "timed_out" rather than "error" in recent_completions.
                 if on_completed:
                     on_completed(124, time.monotonic())
+                if _TIMEOUT_BINARY_AVAILABLE:
+                    error_msg = (
+                        "Subagent timed out at the emergency safety limit before it "
+                        "could finish. Try a narrower, more specific question."
+                    )
+                else:
+                    error_msg = (
+                        "Subagent timed out before it could finish. "
+                        "Try a narrower, more specific question."
+                    )
                 return ToolResult(
                     success=False,
                     output="",
-                    error=(
-                        "Subagent timed out at the emergency safety limit before it "
-                        "could finish. Try a narrower, more specific question."
-                    ),
+                    error=error_msg,
                 )
             except asyncio.CancelledError:
                 process.kill()

--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -49,6 +49,12 @@ _IGNORABLE_ERROR_SUBSTRINGS = ("terminated by signal 13",)
 # These mean "ran out of time", not a generic crash.
 _TIMEOUT_RETURNCODES = frozenset({124, 143})
 _KILLED_RETURNCODE = 137  # 128 + SIGKILL (timeout kill-after or OOM kill)
+# Subprocess-level timeout for each mode.  The asyncio-level safety net
+# (``self.timeout``, default 300 s) should rarely fire when these are set
+# correctly — it only catches pathological hangs where ``timeout(1)`` itself
+# fails to terminate the child.
+_FAST_MODE_SUBPROCESS_TIMEOUT_SECONDS = 30
+_SMART_MODE_SUBPROCESS_TIMEOUT_SECONDS = 120
 # How many recently-completed task records to keep for subagent_status queries.
 # The model can see these to understand whether a task succeeded, timed out, or errored.
 _MAX_RECENT_COMPLETIONS = 5
@@ -504,7 +510,17 @@ class GptmeToolBridge:
         )
         logger.debug(f"Response file: {response_file}")
 
+        subprocess_timeout_seconds = (
+            _FAST_MODE_SUBPROCESS_TIMEOUT_SECONDS
+            if mode == "fast"
+            else _SMART_MODE_SUBPROCESS_TIMEOUT_SECONDS
+        )
+
         cmd = [
+            "timeout",
+            "--signal=TERM",
+            "--kill-after=5s",
+            f"{subprocess_timeout_seconds}s",
             self.gptme_path,
             "--non-interactive",
             "--context",
@@ -576,7 +592,10 @@ class GptmeToolBridge:
                 return ToolResult(
                     success=False,
                     output="",
-                    error=f"Subagent timed out after {self.timeout}s",
+                    error=(
+                        "Subagent timed out at the emergency safety limit before it "
+                        "could finish. Try a narrower, more specific question."
+                    ),
                 )
             except asyncio.CancelledError:
                 process.kill()

--- a/packages/gptme-voice/tests/test_tool_bridge.py
+++ b/packages/gptme-voice/tests/test_tool_bridge.py
@@ -136,7 +136,14 @@ def test_execute_uses_legacy_env_override_for_smart_model() -> None:
             result = await bridge._execute("Inspect recent voice changes", mode="smart")
 
         assert result.success is True
-        assert tuple(captured["args"])[:7] == (
+        args = tuple(captured["args"])
+        assert args[:4] == (
+            "timeout",
+            "--signal=TERM",
+            "--kill-after=5s",
+            "120s",
+        )
+        assert args[4:11] == (
             "gptme",
             "--non-interactive",
             "--context",
@@ -145,7 +152,7 @@ def test_execute_uses_legacy_env_override_for_smart_model() -> None:
             "openai-subscription/gpt-5.4",
             "--tool-format",
         )
-        assert tuple(captured["args"])[7] == "tool"
+        assert args[11] == "tool"
 
     asyncio.run(_exercise())
 
@@ -167,9 +174,16 @@ def test_execute_uses_fast_model_override_without_touching_smart() -> None:
             result = await bridge._execute("Inspect recent voice changes", mode="fast")
 
         assert result.success is True
-        assert "--model" in tuple(captured["args"])
-        model_index = tuple(captured["args"]).index("--model") + 1
-        assert tuple(captured["args"])[model_index] == "openai/gpt-5-mini"
+        args = tuple(captured["args"])
+        assert args[:4] == (
+            "timeout",
+            "--signal=TERM",
+            "--kill-after=5s",
+            "30s",
+        )
+        assert "--model" in args
+        model_index = args.index("--model") + 1
+        assert args[model_index] == "openai/gpt-5-mini"
 
     asyncio.run(_exercise())
 
@@ -191,7 +205,14 @@ def test_execute_uses_smart_model_override_without_touching_fast() -> None:
             result = await bridge._execute("Inspect recent voice changes", mode="smart")
 
         assert result.success is True
-        assert tuple(captured["args"])[:7] == (
+        args = tuple(captured["args"])
+        assert args[:4] == (
+            "timeout",
+            "--signal=TERM",
+            "--kill-after=5s",
+            "120s",
+        )
+        assert args[4:11] == (
             "gptme",
             "--non-interactive",
             "--context",
@@ -200,7 +221,7 @@ def test_execute_uses_smart_model_override_without_touching_fast() -> None:
             "openai-subscription/gpt-5.4",
             "--tool-format",
         )
-        assert tuple(captured["args"])[7] == "tool"
+        assert args[11] == "tool"
 
     asyncio.run(_exercise())
 
@@ -221,7 +242,14 @@ def test_execute_uses_env_override_for_gptme_path() -> None:
             result = await bridge._execute("Inspect recent voice changes", mode="smart")
 
         assert result.success is True
-        assert tuple(captured["args"])[0] == "/fake/bin/gptme"
+        args = tuple(captured["args"])
+        assert args[:5] == (
+            "timeout",
+            "--signal=TERM",
+            "--kill-after=5s",
+            "120s",
+            "/fake/bin/gptme",
+        )
 
     asyncio.run(_exercise())
 
@@ -243,6 +271,12 @@ def test_execute_fast_mode_keeps_context_files() -> None:
             await bridge._execute("quick lookup", mode="fast")
 
         args = tuple(captured["args"])
+        assert args[:4] == (
+            "timeout",
+            "--signal=TERM",
+            "--kill-after=5s",
+            "30s",
+        )
         assert "--context" in args
         assert "files" in args
         assert "--non-interactive" in args
@@ -267,8 +301,66 @@ def test_execute_smart_mode_keeps_context_loading() -> None:
             await bridge._execute("detailed analysis", mode="smart")
 
         args = tuple(captured["args"])
-        assert "--context" in args
-        assert "files" in args
+        assert args[:8] == (
+            "timeout",
+            "--signal=TERM",
+            "--kill-after=5s",
+            "120s",
+            "gptme",
+            "--non-interactive",
+            "--context",
+            "files",
+        )
+
+    asyncio.run(_exercise())
+
+
+def test_execute_fast_mode_uses_subprocess_timeout_wrapper() -> None:
+    async def _exercise() -> None:
+        captured: dict[str, object] = {}
+
+        async def _fake_create_subprocess_exec(*args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return _FakeProcess(returncode=0)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+            bridge = GptmeToolBridge(workspace="/fake/workspace")
+            await bridge._execute("quick lookup", mode="fast")
+
+        args = tuple(captured["args"])
+        assert args[:4] == (
+            "timeout",
+            "--signal=TERM",
+            "--kill-after=5s",
+            "30s",
+        )
+
+    asyncio.run(_exercise())
+
+
+def test_execute_smart_mode_uses_subprocess_timeout_wrapper() -> None:
+    async def _exercise() -> None:
+        captured: dict[str, object] = {}
+
+        async def _fake_create_subprocess_exec(*args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return _FakeProcess(returncode=0)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+            bridge = GptmeToolBridge(workspace="/fake/workspace")
+            await bridge._execute("deep lookup", mode="smart")
+
+        args = tuple(captured["args"])
+        assert args[:4] == (
+            "timeout",
+            "--signal=TERM",
+            "--kill-after=5s",
+            "120s",
+        )
 
     asyncio.run(_exercise())
 

--- a/packages/gptme-voice/tests/test_tool_bridge.py
+++ b/packages/gptme-voice/tests/test_tool_bridge.py
@@ -3,7 +3,10 @@ import logging
 from pathlib import Path
 
 import pytest
-from gptme_voice.realtime.tool_bridge import GptmeToolBridge
+from gptme_voice.realtime.tool_bridge import (
+    _TIMEOUT_BINARY_AVAILABLE,
+    GptmeToolBridge,
+)
 
 
 class _FakeStream:
@@ -330,12 +333,15 @@ def test_execute_fast_mode_uses_subprocess_timeout_wrapper() -> None:
             await bridge._execute("quick lookup", mode="fast")
 
         args = tuple(captured["args"])
-        assert args[:4] == (
-            "timeout",
-            "--signal=TERM",
-            "--kill-after=5s",
-            "30s",
-        )
+        if _TIMEOUT_BINARY_AVAILABLE:
+            assert args[:4] == (
+                "timeout",
+                "--signal=TERM",
+                "--kill-after=5s",
+                "30s",
+            )
+        else:
+            assert args[0] == bridge.gptme_path
 
     asyncio.run(_exercise())
 
@@ -355,12 +361,15 @@ def test_execute_smart_mode_uses_subprocess_timeout_wrapper() -> None:
             await bridge._execute("deep lookup", mode="smart")
 
         args = tuple(captured["args"])
-        assert args[:4] == (
-            "timeout",
-            "--signal=TERM",
-            "--kill-after=5s",
-            "120s",
-        )
+        if _TIMEOUT_BINARY_AVAILABLE:
+            assert args[:4] == (
+                "timeout",
+                "--signal=TERM",
+                "--kill-after=5s",
+                "120s",
+            )
+        else:
+            assert args[0] == bridge.gptme_path
 
     asyncio.run(_exercise())
 

--- a/scripts/github/repo-status.sh
+++ b/scripts/github/repo-status.sh
@@ -106,8 +106,11 @@ check_repo() {
                 echo "  $workflow_url"
             fi
             ;;
-        "cancelled"|"skipped")
-            echo -e "${YELLOW}⚠${NC} $label: $conclusion${suffix}${stale_suffix}"
+        "cancelled")
+            echo -e "${YELLOW}⚠${NC} $label: Cancelled${suffix}${stale_suffix}"
+            ;;
+        "skipped")
+            echo -e "${YELLOW}⊘${NC} $label: Skipped${suffix}${stale_suffix}"
             ;;
         "")
             # No previous run to fall back on


### PR DESCRIPTION
## Problem

gptme-codegraph has structural code retrieval (symbols, call graphs, impact analysis) but no conceptual search — agents can't ask "where is retry logic?" or "what handles session persistence?" without external embedding APIs or chaining multiple grep passes.

## Solution

Add a local-first semantic search layer with a dependency-free BM25 lexical scorer. No external APIs, no mandatory new dependencies.

### Phase 1 changes:
- **SearchDocument/SearchResult** dataclasses for symbol-level search documents
- **Document extraction** from SymbolIndex — reads docstrings, body snippets, and symbol metadata
- **BM25-like lexical scorer** — tokenizes identifiers, docstrings, and snippets with camelCase/snake_case splitting
- **SQLite cache** for search documents (reuses SqliteIndexCache pathing)
- **CLI**: `gptme-codegraph <dir> search <query> [--limit N] [--json]`
- **MCP**: `codegraph_search` tool (directory, query, limit params)
- **24 new tests** covering tokenization, extraction, BM25 ranking, round-trip integration, and MCP tools

Phase 2 (local embeddings via sentence-transformers/ONNX) intentionally deferred — this PR keeps gptme-codegraph dependency-free.

## Verification

```bash
cd gptme-contrib && uv run pytest packages/gptme-codegraph/tests/ -q
# 219 passed, 77 skipped (unrelated: missing language parsers)

# Manual smoke:
uv run gptme-codegraph ~/bob/packages/coordination/src search "claim task" --limit 5
# → 10 ranked results, top: completed_cascade_claim_task_reopened (score 4.35)
```