### PR TITLE
fix(gptme-tts): make plugin discoverable and fix stale hook names

### DIFF
--- a/.jscpd.json
+++ b/.jscpd.json
@@ -5,6 +5,9 @@
   "ignore": [
     "worktree/**",
     "worktrees/**",
+    "**/worktree/**",
+    "**/worktrees/**",
+    "**/.claude/**",
     "**/__pycache__/**",
     "**/node_modules/**",
     "**/.venv/**",

--- a/plugins/gptme-tts/pyproject.toml
+++ b/plugins/gptme-tts/pyproject.toml
@@ -10,6 +10,9 @@ dependencies = [
     "sounddevice>=0.5.1",
 ]
 
+[project.entry-points."gptme.plugins"]
+gptme-tts = "gptme_tts:plugin"
+
 [project.optional-dependencies]
 test = [
     "pytest>=8.0.0",

--- a/plugins/gptme-tts/src/gptme_tts/__init__.py
+++ b/plugins/gptme-tts/src/gptme_tts/__init__.py
@@ -21,3 +21,11 @@ try:
     from .tts import tool  # noqa: F401
 except ImportError:
     pass
+
+from gptme.plugins import GptmePlugin
+
+# Entry-point plugin manifest. Registered via the ``gptme.plugins`` group in
+# pyproject.toml so an installed package is discovered without configuring
+# plugin search paths. The tool module is imported lazily by gptme's tool
+# discovery, so heavy/optional deps don't break plugin registration.
+plugin = GptmePlugin(name="gptme-tts", tool_modules=["gptme_tts.tts"])

--- a/plugins/gptme-tts/src/gptme_tts/__init__.py
+++ b/plugins/gptme-tts/src/gptme_tts/__init__.py
@@ -22,10 +22,16 @@ try:
 except ImportError:
     pass
 
-from gptme.plugins import GptmePlugin
-
 # Entry-point plugin manifest. Registered via the ``gptme.plugins`` group in
 # pyproject.toml so an installed package is discovered without configuring
 # plugin search paths. The tool module is imported lazily by gptme's tool
 # discovery, so heavy/optional deps don't break plugin registration.
-plugin = GptmePlugin(name="gptme-tts", tool_modules=["gptme_tts.tts"])
+#
+# Guarded so the package still imports on older gptme releases that predate the
+# unified plugin system (the tool then loads via folder-based discovery instead).
+try:
+    from gptme.plugins import GptmePlugin
+
+    plugin = GptmePlugin(name="gptme-tts", tool_modules=["gptme_tts.tts"])
+except ImportError:
+    pass

--- a/plugins/gptme-tts/src/gptme_tts/tts.py
+++ b/plugins/gptme-tts/src/gptme_tts/tts.py
@@ -22,6 +22,7 @@ Uses Kokoro for local TTS generation.
 - ``GPTME_TTS_VOICE``: Set the voice to use for TTS. Available voices depend on the TTS server.
 - ``GPTME_TTS_SPEED``: Playback speed multiplier (default ``1.0``).
 - ``GPTME_VOICE_FINISH``: If set to "true" or "1", waits for speech to finish before exiting. This is useful when you want to ensure the full message is spoken.
+- ``GPTME_TTS_TIMEOUT``: Per-request timeout in seconds (default ``30``). Increase for slow backends like chatterbox.
 """
 
 import io
@@ -48,6 +49,25 @@ log = logging.getLogger(__name__)
 
 host = "localhost"
 port = 8765
+
+# Per-request timeout (seconds). The chatterbox backend proxies to a remote
+# gradio service and can take well over the old hardcoded 10s, especially on a
+# cold start. Configurable via GPTME_TTS_TIMEOUT.
+DEFAULT_REQUEST_TIMEOUT = 30.0
+
+
+def _request_timeout() -> float:
+    """Per-request TTS timeout in seconds (env GPTME_TTS_TIMEOUT, default 30)."""
+    raw = os.getenv("GPTME_TTS_TIMEOUT")
+    if raw:
+        try:
+            value = float(raw)
+            if value > 0:
+                return value
+        except ValueError:
+            pass
+    return DEFAULT_REQUEST_TIMEOUT
+
 
 # Check for TTS-specific imports
 has_tts_imports = False
@@ -340,8 +360,18 @@ def _tts_processor_thread_fn():
                 params["voice"] = voice
 
             try:
-                response = requests.get(url, params=params, timeout=10)
-            except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
+                response = requests.get(url, params=params, timeout=_request_timeout())
+            except requests.exceptions.Timeout:
+                # Not a dead server — the backend (e.g. chatterbox) was slower
+                # than the request timeout. Raise GPTME_TTS_TIMEOUT for slow backends.
+                log.warning(
+                    f"TTS request timed out after {_request_timeout():.0f}s "
+                    f"(slow backend?); skipping chunk. "
+                    f"Set GPTME_TTS_TIMEOUT to increase the limit."
+                )
+                tts_request_queue.task_done()
+                continue
+            except requests.exceptions.ConnectionError:
                 log.warning(f"TTS server unavailable at {url}")
                 tts_request_queue.task_done()
                 continue

--- a/plugins/gptme-tts/src/gptme_tts/tts.py
+++ b/plugins/gptme-tts/src/gptme_tts/tts.py
@@ -104,6 +104,13 @@ tts_request_queue: queue.Queue[str | None] = queue.Queue()
 tts_processor_thread: threading.Thread | None = None
 current_speed = 1.0
 
+# Streaming-speech state (see speak_on_chunk). Tracks the raw text streamed so
+# far this generation and how many characters of its *cleaned* form have already
+# been spoken, so we can voice complete sentences as they arrive.
+_stream_raw = ""
+_stream_spoken_chars = 0
+_stream_first_segment = True
+
 
 # Regular expressions for cleaning text
 re_thinking = re.compile(r"<think(ing)?>.*?(\n</think(ing)?>|$)", flags=re.DOTALL)
@@ -487,18 +494,82 @@ def speak(text, block=False, interrupt=True, clean=True):
 
 # Hook functions for automatic TTS integration
 
+# Matches a sentence end (.!?  not followed by another word char, so decimals
+# like "3.14" are left intact) or a line break — both are natural speech flush
+# points while streaming.
+_re_speak_boundary = re.compile(r"[.!?](?=\s|$)|\n")
+
+
+def _last_speak_boundary(text: str) -> int:
+    """Return the index just past the last sentence/line boundary, or -1."""
+    last = -1
+    for match in _re_speak_boundary.finditer(text):
+        last = match.end()
+    return last
+
+
+def _reset_stream_state() -> None:
+    global _stream_raw, _stream_spoken_chars, _stream_first_segment
+    _stream_raw = ""
+    _stream_spoken_chars = 0
+    _stream_first_segment = True
+
+
+def reset_stream_on_generation(*args, **kwargs):
+    """Hook: Reset streaming-speech state before each generation.
+
+    Registered for GENERATION_PRE so a new response interrupts leftover speech
+    and starts buffering from scratch.
+    """
+    _reset_stream_state()
+    yield  # Hooks must be generators
+
+
+def speak_on_chunk(chunk, **kwargs):
+    """Hook: Speak complete sentences as the response streams in.
+
+    Registered for GENERATION_CHUNK. Accumulates streamed text, cleans it (which
+    strips tool blocks / markup, including blocks still being streamed), and
+    voices each newly-completed sentence. The remainder is voiced at
+    generation.post by speak_on_generation.
+    """
+    global _stream_raw, _stream_spoken_chars, _stream_first_segment
+    _stream_raw += chunk
+    cleaned = clean_for_speech(_stream_raw)
+    boundary = _last_speak_boundary(cleaned)
+    if boundary > _stream_spoken_chars:
+        segment = cleaned[_stream_spoken_chars:boundary].strip()
+        _stream_spoken_chars = boundary
+        if segment:
+            speak(segment, interrupt=_stream_first_segment, clean=False)
+            _stream_first_segment = False
+    yield  # Hooks must be generators
+
 
 def speak_on_generation(message, workspace=None, **kwargs):
     """Hook: Speak assistant messages after generation.
 
-    Registered for GENERATION_POST hook.
+    Registered for GENERATION_POST hook. When the response was streamed,
+    speak_on_chunk has already voiced most of it, so only the trailing
+    not-yet-spoken remainder is flushed here. For non-streamed responses
+    (no chunks seen), the whole message is spoken.
     """
     # Only speak assistant messages
     if message.role != "assistant":
         return
 
-    # Speak the message content
-    speak(message.content)
+    global _stream_raw, _stream_spoken_chars, _stream_first_segment
+    if _stream_raw:
+        # Streamed: flush whatever sentence tail wasn't voiced during streaming.
+        cleaned = clean_for_speech(_stream_raw)
+        if len(cleaned) > _stream_spoken_chars:
+            tail = cleaned[_stream_spoken_chars:].strip()
+            if tail:
+                speak(tail, interrupt=_stream_first_segment, clean=False)
+        _reset_stream_state()
+    else:
+        # Non-streamed fallback: speak the whole message.
+        speak(message.content)
     yield  # Hooks must be generators
 
 
@@ -536,6 +607,16 @@ tool = ToolSpec(
     functions=[speak, set_speed, set_volume, stop],
     init=init,
     hooks={
+        "reset_stream": (
+            "generation.pre",
+            reset_stream_on_generation,
+            0,  # Normal priority
+        ),
+        "speak_on_chunk": (
+            "generation.chunk",
+            speak_on_chunk,
+            0,  # Normal priority
+        ),
         "speak_on_generation": (
             "generation.post",
             speak_on_generation,

--- a/plugins/gptme-tts/src/gptme_tts/tts.py
+++ b/plugins/gptme-tts/src/gptme_tts/tts.py
@@ -537,12 +537,12 @@ tool = ToolSpec(
     init=init,
     hooks={
         "speak_on_generation": (
-            "generation_post",
+            "generation.post",
             speak_on_generation,
             0,  # Normal priority
         ),
         "wait_on_session_end": (
-            "session_end",
+            "session.end",
             wait_on_session_end,
             0,  # Normal priority
         ),

--- a/plugins/gptme-tts/src/gptme_tts/tts.py
+++ b/plugins/gptme-tts/src/gptme_tts/tts.py
@@ -23,6 +23,8 @@ Uses Kokoro for local TTS generation.
 - ``GPTME_TTS_SPEED``: Playback speed multiplier (default ``1.0``).
 - ``GPTME_VOICE_FINISH``: If set to "true" or "1", waits for speech to finish before exiting. This is useful when you want to ensure the full message is spoken.
 - ``GPTME_TTS_TIMEOUT``: Per-request timeout in seconds (default ``30``). Increase for slow backends like chatterbox.
+- ``GPTME_TTS_BACKEND``: ``server`` (default, uses the local tts_server.py) or ``openrouter`` (calls OpenRouter speech models directly, no local server needed — requires ``OPENROUTER_API_KEY``).
+- ``GPTME_TTS_MODEL``: OpenRouter speech model when ``GPTME_TTS_BACKEND=openrouter`` (default ``x-ai/grok-voice-tts-1.0``; e.g. ``microsoft/mai-voice-2``). Set ``GPTME_TTS_VOICE`` to a voice the model supports (Grok: ``Ara``, ``Eve``, ``Rex``, ``Gork``, ``Leo``; default ``Ara``).
 """
 
 import io
@@ -72,6 +74,7 @@ def _request_timeout() -> float:
 # Check for TTS-specific imports
 has_tts_imports = False
 try:
+    import numpy as np  # fmt: skip
     import scipy.io.wavfile as wavfile  # fmt: skip
 
     has_tts_imports = True
@@ -79,12 +82,53 @@ except (ImportError, OSError):
     has_tts_imports = False
 
 
+# --- Backend selection -------------------------------------------------------
+# "server"     -> local tts_server.py on localhost:8765 (kokoro/chatterbox/...)
+# "openrouter" -> OpenRouter speech models directly (no local server needed)
+
+OPENROUTER_TTS_URL = "https://openrouter.ai/api/v1/audio/speech"
+# Default to Grok voice TTS. Valid voices include Ara, Eve, Rex, Gork, Leo,
+# default. Override with GPTME_TTS_MODEL / GPTME_TTS_VOICE for other models
+# (e.g. microsoft/mai-voice-2 with voice en-US-Harper:MAI-Voice-2). Note: the
+# pcm response format is required here, so mp3-only models (e.g. Mistral Voxtral)
+# are not yet supported.
+DEFAULT_OPENROUTER_MODEL = "x-ai/grok-voice-tts-1.0"
+DEFAULT_OPENROUTER_VOICE = "Ara"
+# OpenRouter "pcm" output is uncompressed mono signed-16-bit little-endian @ 24kHz.
+OPENROUTER_PCM_SAMPLE_RATE = 24000
+
+
+def _backend() -> str:
+    """Active TTS backend: 'server' (default) or 'openrouter'."""
+    return (os.getenv("GPTME_TTS_BACKEND") or "server").lower()
+
+
+def _openrouter_model() -> str:
+    return os.getenv("GPTME_TTS_MODEL") or DEFAULT_OPENROUTER_MODEL
+
+
+def _get_openrouter_api_key() -> str | None:
+    """Resolve the OpenRouter API key from env or gptme config."""
+    if key := os.getenv("OPENROUTER_API_KEY"):
+        return key
+    try:
+        from gptme.config import get_config
+
+        return get_config().get_env("OPENROUTER_API_KEY")
+    except Exception:
+        return None
+
+
 def is_available() -> bool:
-    """Check if the TTS server is available."""
+    """Check whether TTS can run with the active backend."""
     if not has_tts_imports or not is_audio_available():
         return False
 
-    # available if a server is running on localhost:8765
+    if _backend() == "openrouter":
+        # No local server needed — just an API key.
+        return bool(_get_openrouter_api_key())
+
+    # server backend: available if a server is running on localhost:8765
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     try:
         server_available = sock.connect_ex((host, port)) == 0
@@ -110,10 +154,14 @@ def init() -> ToolSpec:
             console.log(f"Warning: Invalid GPTME_TTS_SPEED={speed_env}, using default")
 
     if is_available():
-        if speed_env:
-            console.log(f"Using TTS (speed: {current_speed:.2f}x)")
+        backend = _backend()
+        suffix = f" (speed: {current_speed:.2f}x)" if speed_env else ""
+        if backend == "openrouter":
+            console.log(f"Using TTS via OpenRouter [{_openrouter_model()}]{suffix}")
         else:
-            console.log("Using TTS")
+            console.log(f"Using TTS{suffix}")
+    elif _backend() == "openrouter":
+        console.log("TTS disabled: OPENROUTER_API_KEY not set")
     else:
         console.log("TTS disabled: server not available")
     return tool
@@ -335,6 +383,95 @@ def clean_for_speech(content: str) -> str:
     return content.strip()
 
 
+def _synthesize_server(chunk: str):
+    """Synthesize a chunk via the local tts_server.py. Returns (sample_rate, data)."""
+    url = f"http://{host}:{port}/tts"
+    params: dict[str, str | float] = {"text": chunk, "speed": current_speed}
+    if voice := os.getenv("GPTME_TTS_VOICE"):
+        params["voice"] = voice
+
+    try:
+        response = requests.get(url, params=params, timeout=_request_timeout())
+    except requests.exceptions.Timeout:
+        # Not a dead server — the backend (e.g. chatterbox) was slower than the
+        # request timeout. Raise GPTME_TTS_TIMEOUT for slow backends.
+        log.warning(
+            f"TTS request timed out after {_request_timeout():.0f}s "
+            f"(slow backend?); skipping chunk. "
+            f"Set GPTME_TTS_TIMEOUT to increase the limit."
+        )
+        return None
+    except requests.exceptions.ConnectionError:
+        log.warning(f"TTS server unavailable at {url}")
+        return None
+
+    if response.status_code != 200:
+        log.error(f"TTS server returned status {response.status_code}")
+        if response.content:
+            log.error(f"Error content: {response.content.decode()} for {chunk}")
+        return None
+
+    return wavfile.read(io.BytesIO(response.content))
+
+
+def _synthesize_openrouter(chunk: str):
+    """Synthesize a chunk via OpenRouter's speech API. Returns (sample_rate, data).
+
+    Uses the ``pcm`` response format (uncompressed 16-bit mono @ 24kHz) so no
+    audio decoder is needed and latency stays low.
+    """
+    api_key = _get_openrouter_api_key()
+    if not api_key:
+        log.warning("OpenRouter TTS backend selected but OPENROUTER_API_KEY is not set")
+        return None
+
+    payload: dict[str, str | float] = {
+        "model": _openrouter_model(),
+        "input": chunk,
+        "voice": os.getenv("GPTME_TTS_VOICE") or DEFAULT_OPENROUTER_VOICE,
+        "response_format": "pcm",
+        "speed": current_speed,
+    }
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+    try:
+        response = requests.post(
+            OPENROUTER_TTS_URL,
+            headers=headers,
+            json=payload,
+            timeout=_request_timeout(),
+        )
+    except requests.exceptions.Timeout:
+        log.warning(
+            f"OpenRouter TTS timed out after {_request_timeout():.0f}s; skipping chunk. "
+            f"Set GPTME_TTS_TIMEOUT to increase the limit."
+        )
+        return None
+    except requests.exceptions.ConnectionError:
+        log.warning("OpenRouter TTS unreachable (connection error); skipping chunk")
+        return None
+
+    if response.status_code != 200:
+        # Non-200 responses carry a JSON error body (e.g. invalid voice/model).
+        log.error(f"OpenRouter TTS returned status {response.status_code}")
+        if response.content:
+            log.error(f"Error content: {response.content.decode(errors='replace')}")
+        return None
+
+    data = np.frombuffer(response.content, dtype="<i2")
+    return OPENROUTER_PCM_SAMPLE_RATE, data
+
+
+def _synthesize(chunk: str):
+    """Synthesize a chunk with the active backend. Returns (sample_rate, data) or None."""
+    if _backend() == "openrouter":
+        return _synthesize_openrouter(chunk)
+    return _synthesize_server(chunk)
+
+
 def _tts_processor_thread_fn():
     """Background thread for processing TTS requests."""
     log.debug("TTS processor ready")
@@ -350,43 +487,12 @@ def _tts_processor_thread_fn():
                     pass  # stop() may have already reset unfinished_tasks to 0
                 break
 
-            # Make request to the TTS server
-            url = f"http://{host}:{port}/tts"
-            params: dict[str, str | float] = {
-                "text": chunk,
-                "speed": current_speed,
-            }
-            if voice := os.getenv("GPTME_TTS_VOICE"):
-                params["voice"] = voice
-
-            try:
-                response = requests.get(url, params=params, timeout=_request_timeout())
-            except requests.exceptions.Timeout:
-                # Not a dead server — the backend (e.g. chatterbox) was slower
-                # than the request timeout. Raise GPTME_TTS_TIMEOUT for slow backends.
-                log.warning(
-                    f"TTS request timed out after {_request_timeout():.0f}s "
-                    f"(slow backend?); skipping chunk. "
-                    f"Set GPTME_TTS_TIMEOUT to increase the limit."
-                )
-                tts_request_queue.task_done()
-                continue
-            except requests.exceptions.ConnectionError:
-                log.warning(f"TTS server unavailable at {url}")
+            result = _synthesize(chunk)
+            if result is None:
                 tts_request_queue.task_done()
                 continue
 
-            if response.status_code != 200:
-                log.error(f"TTS server returned status {response.status_code}")
-                if response.content:
-                    log.error(f"Error content: {response.content.decode()} for {chunk}")
-                tts_request_queue.task_done()
-                continue
-
-            # Process audio response
-            audio_data = io.BytesIO(response.content)
-            sample_rate, data = wavfile.read(audio_data)
-
+            sample_rate, data = result
             # Play audio using the sound utility
             play_audio_data(data, sample_rate, block=False)
             tts_request_queue.task_done()

--- a/plugins/gptme-tts/tests/test_tts.py
+++ b/plugins/gptme-tts/tests/test_tts.py
@@ -163,10 +163,69 @@ def test_hooks_registered():
 
     assert "speak_on_generation" in tool.hooks
     assert "wait_on_session_end" in tool.hooks
+    assert "speak_on_chunk" in tool.hooks
+    assert "reset_stream" in tool.hooks
 
-    # Check hook types
-    assert tool.hooks["speak_on_generation"][0] == "generation_post"
-    assert tool.hooks["wait_on_session_end"][0] == "session_end"
+    # Hook types use the current dot-notation HookType values.
+    assert tool.hooks["reset_stream"][0] == "generation.pre"
+    assert tool.hooks["speak_on_chunk"][0] == "generation.chunk"
+    assert tool.hooks["speak_on_generation"][0] == "generation.post"
+    assert tool.hooks["wait_on_session_end"][0] == "session.end"
+
+
+def test_speak_on_chunk_streams_sentences():
+    """speak_on_chunk voices complete sentences as they stream, skipping code."""
+    import gptme_tts.tts as tts_mod
+    from gptme_tts.tts import (
+        reset_stream_on_generation,
+        speak_on_chunk,
+        speak_on_generation,
+    )
+
+    spoken: list[tuple[str, bool]] = []
+
+    def fake_speak(text, block=False, interrupt=True, clean=True):
+        spoken.append((text, interrupt))
+
+    with patch.object(tts_mod, "speak", fake_speak):
+        list(reset_stream_on_generation())
+        for chunk in [
+            "Hi there!\n",
+            "How are you?\n",
+            "```python\n",
+            "print(1)\n",
+            "```\n",
+            "All done now.",
+        ]:
+            list(speak_on_chunk(chunk))
+
+        msg = MagicMock()
+        msg.role = "assistant"
+        list(speak_on_generation(message=msg))
+
+    texts = [t for t, _ in spoken]
+    # Sentences voiced incrementally; the code block is never spoken.
+    assert "Hi there!" in texts
+    assert "How are you?" in texts
+    assert not any("print(1)" in t for t in texts)
+    assert any("All done now." in t for t in texts)
+    # The very first segment interrupts prior speech; later ones queue.
+    assert spoken[0][1] is True
+    assert all(interrupt is False for _, interrupt in spoken[1:])
+
+
+def test_speak_on_generation_non_streamed_speaks_whole_message():
+    """Without prior chunks, generation.post speaks the full message (fallback)."""
+    import gptme_tts.tts as tts_mod
+    from gptme_tts.tts import reset_stream_on_generation, speak_on_generation
+
+    with patch.object(tts_mod, "speak") as mock_speak:
+        list(reset_stream_on_generation())  # no chunks streamed
+        msg = MagicMock()
+        msg.role = "assistant"
+        msg.content = "Hello, world!"
+        list(speak_on_generation(message=msg))
+        mock_speak.assert_called_once_with("Hello, world!")
 
 
 @pytest.mark.skipif(not _has_gptme(), reason="gptme not installed")

--- a/plugins/gptme-tts/tests/test_tts.py
+++ b/plugins/gptme-tts/tests/test_tts.py
@@ -174,6 +174,59 @@ def test_request_timeout_configurable(monkeypatch):
     assert _request_timeout() == DEFAULT_REQUEST_TIMEOUT
 
 
+def test_backend_selection(monkeypatch):
+    """GPTME_TTS_BACKEND selects the backend (default 'server')."""
+    import gptme_tts.tts as tts_mod
+
+    monkeypatch.delenv("GPTME_TTS_BACKEND", raising=False)
+    assert tts_mod._backend() == "server"
+    monkeypatch.setenv("GPTME_TTS_BACKEND", "OpenRouter")
+    assert tts_mod._backend() == "openrouter"
+
+
+def test_synthesize_openrouter_builds_request_and_decodes_pcm(monkeypatch):
+    """OpenRouter backend posts the right body and decodes pcm bytes to int16."""
+    import gptme_tts.tts as tts_mod
+    import numpy as np
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
+    monkeypatch.setenv("GPTME_TTS_MODEL", "x-ai/grok-voice-tts-1.0")
+    monkeypatch.setenv("GPTME_TTS_VOICE", "ringo")
+
+    pcm_bytes = np.array([0, 100, -100, 32767], dtype="<i2").tobytes()
+    captured: dict = {}
+
+    class FakeResp:
+        status_code = 200
+        content = pcm_bytes
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        captured.update(url=url, headers=headers, json=json)
+        return FakeResp()
+
+    monkeypatch.setattr(tts_mod.requests, "post", fake_post)
+
+    sample_rate, data = tts_mod._synthesize_openrouter("Hello")
+
+    assert sample_rate == 24000
+    assert list(data) == [0, 100, -100, 32767]
+    assert captured["url"] == "https://openrouter.ai/api/v1/audio/speech"
+    assert captured["headers"]["Authorization"] == "Bearer sk-test"
+    body = captured["json"]
+    assert body["model"] == "x-ai/grok-voice-tts-1.0"
+    assert body["input"] == "Hello"
+    assert body["voice"] == "ringo"
+    assert body["response_format"] == "pcm"
+
+
+def test_synthesize_openrouter_no_api_key(monkeypatch):
+    """OpenRouter backend skips (returns None) when no API key is available."""
+    import gptme_tts.tts as tts_mod
+
+    monkeypatch.setattr(tts_mod, "_get_openrouter_api_key", lambda: None)
+    assert tts_mod._synthesize_openrouter("hi") is None
+
+
 def test_hooks_registered():
     """Test that TTS hooks are properly registered in the tool spec."""
     from gptme_tts.tts import tool

--- a/plugins/gptme-tts/tests/test_tts.py
+++ b/plugins/gptme-tts/tests/test_tts.py
@@ -157,6 +157,23 @@ def test_clean_for_speech():
     assert re_tool_use.sub("", "```tool\ncontents\n```\nRan tool").strip() == "Ran tool"
 
 
+def test_request_timeout_configurable(monkeypatch):
+    """Per-request timeout defaults to 30s and is overridable via env."""
+    from gptme_tts.tts import DEFAULT_REQUEST_TIMEOUT, _request_timeout
+
+    monkeypatch.delenv("GPTME_TTS_TIMEOUT", raising=False)
+    assert _request_timeout() == DEFAULT_REQUEST_TIMEOUT
+
+    monkeypatch.setenv("GPTME_TTS_TIMEOUT", "60")
+    assert _request_timeout() == 60.0
+
+    # Invalid / non-positive values fall back to the default.
+    monkeypatch.setenv("GPTME_TTS_TIMEOUT", "not-a-number")
+    assert _request_timeout() == DEFAULT_REQUEST_TIMEOUT
+    monkeypatch.setenv("GPTME_TTS_TIMEOUT", "0")
+    assert _request_timeout() == DEFAULT_REQUEST_TIMEOUT
+
+
 def test_hooks_registered():
     """Test that TTS hooks are properly registered in the tool spec."""
     from gptme_tts.tts import tool

--- a/plugins/gptme-tts/tts_server.py
+++ b/plugins/gptme-tts/tts_server.py
@@ -9,9 +9,11 @@
 #   "kokoro>=0.9.0",
 #   "kittentts",
 #   "scipy",
+#   "pip",
 # ]
 # [tool.uv]
 # exclude-newer = "2025-06-01T00:00:00Z"
+# exclude-newer-package = { kittentts = "2026-06-01T00:00:00Z" }
 # ///
 """
 Multi-backend TTS server supporting Kokoro and Chatterbox TTS.


### PR DESCRIPTION
## Summary

Wires `gptme-tts` into gptme's plugin system, fixes bugs that kept it from working, restores incremental (streaming) speech, and adds a server-less OpenRouter backend.

- **Entry-point manifest** — add a `GptmePlugin` to `src/gptme_tts/__init__.py` + `[project.entry-points."gptme.plugins"]`, so an installed package is discovered via the unified plugin registry.
- **Fix stale hook names** — the `tts` ToolSpec used `generation_post` / `session_end`, but current gptme `HookType` uses dotted values (`generation.post` / `session.end`). With the old names the hooks silently failed to register, so the tool loaded but never spoke.
- **Streaming speech** — add a `generation.chunk` hook (`speak_on_chunk`) that voices complete sentences as the response streams, resetting on `generation.pre` and flushing the tail on `generation.post` (which still speaks the whole message for non-streamed responses). Tool/code blocks are stripped, including blocks still mid-stream. Requires the `generation.chunk` hook added in gptme/gptme#2781.
- **Configurable request timeout** — the hardcoded 10s per-request timeout was too short for the chatterbox backend (proxies to a remote gradio service), producing a misleading "TTS server unavailable" on a healthy server. Default to 30s, configurable via `GPTME_TTS_TIMEOUT`, and distinguish a timeout from a real connection error.
- **OpenRouter backend** — `GPTME_TTS_BACKEND=openrouter` synthesizes via OpenRouter's `/api/v1/audio/speech` directly, with **no local server**. Returns `pcm` (24kHz s16le mono) decoded straight to samples (no decoder dep). `is_available()` just checks for `OPENROUTER_API_KEY`. Defaults to `x-ai/grok-voice-tts-1.0` / voice `Ara`; configurable via `GPTME_TTS_MODEL` / `GPTME_TTS_VOICE`. (pcm-only for now, so mp3-only models like Mistral Voxtral aren't supported yet.)
- **Fix `tts_server.py` resolution** — `uv run tts_server.py` failed out of the box: `kittentts` had no releases before the script's `exclude-newer` cutoff, and Kokoro's spacy model download shells out to `pip` (absent in the uv env). Add `pip` and a per-package `exclude-newer-package` override.
- **jscpd** — exclude nested `.claude/worktrees/**` so the duplicate-code hook stops scanning transient agent-worktree copies.

## Test plan

- [x] `tests/test_tts.py` — hook registration (dotted names + chunk/reset), streaming sentence segmentation w/ code-block stripping, timeout config, backend selection, OpenRouter request/pcm-decode, missing-key skip (24 tests)
- [x] `uv run tts_server.py --help` resolves; Kokoro server serves `/health` + `/tts`
- [x] `gptme -t +tts --non-interactive` speaks the reply, incrementally on multi-line responses, no "Failed to register hook" warning
- [x] `GPTME_TTS_BACKEND=openrouter gptme -t +tts ...` speaks via Grok with no local server running

Companion: gptme/gptme#2781 (src-layout discovery, lenient `+tool` CLI, user `[plugins]` layering, `ToolSpec` entry-point support, `generation.chunk` hook).