### PR TITLE
fix(subscription): export pacing snapshot helpers

### DIFF
--- a/packages/gptme-subscription/src/gptme_subscription/__init__.py
+++ b/packages/gptme-subscription/src/gptme_subscription/__init__.py
@@ -26,12 +26,16 @@ from gptme_subscription.observation import (
     subscription_pressure_from_usage,
 )
 from gptme_subscription.routing import (
+    PacingSnapshot,
     RebalanceState,
     best_lower_pressure_fallback,
     capacity_aware_fallback_order,
     clear_rebalance_state,
+    combine_window_pacing_snapshots,
+    compute_pacing_snapshot,
     compute_rebalance_hold_seconds,
     compute_window_pacing,
+    compute_window_pacing_snapshot,
     load_rebalance_state,
     save_rebalance_state,
     soonest_resetting_fallback,
@@ -48,6 +52,10 @@ __all__ = [
     "pressure_from_observation",
     "SubscriptionObservation",
     # Routing
+    "PacingSnapshot",
+    "compute_pacing_snapshot",
+    "compute_window_pacing_snapshot",
+    "combine_window_pacing_snapshots",
     "compute_window_pacing",
     "compute_rebalance_hold_seconds",
     "capacity_aware_fallback_order",

--- a/packages/gptme-subscription/src/gptme_subscription/routing.py
+++ b/packages/gptme-subscription/src/gptme_subscription/routing.py
@@ -182,7 +182,7 @@ def compute_window_pacing(
         window_seconds: Total window duration in seconds.
 
     Returns:
-        ``(elapsed_frac, gap, status)`` or None.
+        ``(target_utilization, gap, status)`` or None.
         gap > 0 = overusing, gap < 0 = underusing, ≈ 0 = on track.
         Status is ``"overusing"``, ``"underusing"``, or ``"on_track"``.
     """

--- a/packages/gptme-subscription/src/gptme_subscription/routing.py
+++ b/packages/gptme-subscription/src/gptme_subscription/routing.py
@@ -171,7 +171,7 @@ def compute_window_pacing(
     target_utilization: float = 1.0,
     threshold: float = 0.05,
 ) -> tuple[float, float, str] | None:
-    """Compute pacing (elapsed_frac, gap, status) for a quota window.
+    """Compute pacing (target_utilization, gap, status) for a quota window.
 
     Uses the headroom model: if remaining budget is less than remaining time,
     the gap is positive (overusing). Returns None for invalid inputs.

--- a/packages/gptme-subscription/src/gptme_subscription/routing.py
+++ b/packages/gptme-subscription/src/gptme_subscription/routing.py
@@ -145,7 +145,7 @@ def combine_window_pacing_snapshots(
     target_utilization: float = 1.0,
     threshold: float = 0.05,
 ) -> PacingSnapshot | None:
-    """Return the most over-budget pacing snapshot across multiple windows."""
+    """Return the pacing snapshot with the highest pace_gap across multiple windows."""
 
     snapshots: list[PacingSnapshot] = []
     for utilization, resets_in_seconds, window_seconds in windows:

--- a/packages/gptme-subscription/src/gptme_subscription/routing.py
+++ b/packages/gptme-subscription/src/gptme_subscription/routing.py
@@ -7,8 +7,8 @@ and how to manage persistent rebalance state.
 from __future__ import annotations
 
 import json
-from collections.abc import Mapping
-from dataclasses import dataclass, field
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -55,10 +55,121 @@ class RebalanceState:
 # --- Window pacing ---
 
 
+@dataclass(frozen=True)
+class PacingSnapshot:
+    """Normalized pacing view for a subscription quota window.
+
+    Canonical convention:
+    - ``headroom = 1 - utilization``
+    - ``pace_gap = utilization - target_utilization``
+    - ``pace_gap > 0`` means ahead of the target burn curve / overusing
+    - ``pace_gap < 0`` means behind the target burn curve / underusing
+    """
+
+    utilization: float
+    headroom: float
+    elapsed_fraction: float
+    target_utilization: float
+    pace_gap: float
+    status: str
+
+    def as_dict(self) -> dict[str, float | str]:
+        return dict(asdict(self))
+
+
+def _clamp_unit(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+def compute_pacing_snapshot(
+    utilization: float,
+    *,
+    elapsed_fraction: float,
+    target_utilization: float = 1.0,
+    threshold: float = 0.05,
+) -> PacingSnapshot:
+    """Return a canonical pacing snapshot for a quota window.
+
+    ``target_utilization`` is a policy knob, not part of the sign convention.
+    For a plain "use quota evenly until reset" curve, keep it at ``1.0``.
+    Dashboard/rebalance surfaces can pass lower values such as ``0.95`` or
+    ``0.90`` while still getting the same ``headroom`` / ``pace_gap`` meaning.
+    """
+
+    utilization_clamped = _clamp_unit(utilization)
+    elapsed_clamped = _clamp_unit(elapsed_fraction)
+    target_fraction = max(0.0, target_utilization)
+    target = _clamp_unit(elapsed_clamped * target_fraction)
+    gap = utilization_clamped - target
+    if gap > threshold:
+        status = "overusing"
+    elif gap < -threshold:
+        status = "underusing"
+    else:
+        status = "on_track"
+    return PacingSnapshot(
+        utilization=utilization_clamped,
+        headroom=_clamp_unit(1.0 - utilization_clamped),
+        elapsed_fraction=elapsed_clamped,
+        target_utilization=target,
+        pace_gap=gap,
+        status=status,
+    )
+
+
+def compute_window_pacing_snapshot(
+    utilization: float,
+    resets_in_seconds: int,
+    window_seconds: int,
+    *,
+    target_utilization: float = 1.0,
+    threshold: float = 0.05,
+) -> PacingSnapshot | None:
+    """Compute a pacing snapshot from utilization and reset countdown."""
+
+    if window_seconds <= 0 or resets_in_seconds <= 0:
+        return None
+    remaining_time_frac = _clamp_unit(resets_in_seconds / window_seconds)
+    elapsed_frac = 1.0 - remaining_time_frac
+    return compute_pacing_snapshot(
+        utilization,
+        elapsed_fraction=elapsed_frac,
+        target_utilization=target_utilization,
+        threshold=threshold,
+    )
+
+
+def combine_window_pacing_snapshots(
+    windows: Sequence[tuple[float, int, int]],
+    *,
+    target_utilization: float = 1.0,
+    threshold: float = 0.05,
+) -> PacingSnapshot | None:
+    """Return the most over-budget pacing snapshot across multiple windows."""
+
+    snapshots: list[PacingSnapshot] = []
+    for utilization, resets_in_seconds, window_seconds in windows:
+        snapshot = compute_window_pacing_snapshot(
+            utilization,
+            resets_in_seconds,
+            window_seconds,
+            target_utilization=target_utilization,
+            threshold=threshold,
+        )
+        if snapshot is not None:
+            snapshots.append(snapshot)
+    if not snapshots:
+        return None
+    return max(snapshots, key=lambda snapshot: snapshot.pace_gap)
+
+
 def compute_window_pacing(
     utilization: float,
     resets_in_seconds: int,
     window_seconds: int,
+    *,
+    target_utilization: float = 1.0,
+    threshold: float = 0.05,
 ) -> tuple[float, float, str] | None:
     """Compute pacing (elapsed_frac, gap, status) for a quota window.
 
@@ -75,18 +186,16 @@ def compute_window_pacing(
         gap > 0 = overusing, gap < 0 = underusing, ≈ 0 = on track.
         Status is ``"overusing"``, ``"underusing"``, or ``"on_track"``.
     """
-    if window_seconds <= 0 or resets_in_seconds <= 0:
+    snapshot = compute_window_pacing_snapshot(
+        utilization,
+        resets_in_seconds,
+        window_seconds,
+        target_utilization=target_utilization,
+        threshold=threshold,
+    )
+    if snapshot is None:
         return None
-    remaining_time_frac = min(1.0, resets_in_seconds / window_seconds)
-    elapsed_frac = 1.0 - remaining_time_frac
-    gap = utilization - elapsed_frac
-    if gap > 0.05:
-        status = "overusing"
-    elif gap < -0.05:
-        status = "underusing"
-    else:
-        status = "on_track"
-    return elapsed_frac, gap, status
+    return snapshot.target_utilization, snapshot.pace_gap, snapshot.status
 
 
 def compute_rebalance_hold_seconds(

--- a/packages/gptme-subscription/tests/test_routing.py
+++ b/packages/gptme-subscription/tests/test_routing.py
@@ -4,15 +4,35 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from gptme_subscription.routing import (
     clear_rebalance_state,
+    combine_window_pacing_snapshots,
+    compute_pacing_snapshot,
     compute_rebalance_hold_seconds,
     compute_window_pacing,
+    compute_window_pacing_snapshot,
     load_rebalance_state,
     save_rebalance_state,
 )
 
 WEEK = 7 * 24 * 3600
+
+
+class TestComputePacingSnapshot:
+    def test_keeps_positive_gap_for_overuse(self) -> None:
+        result = compute_pacing_snapshot(0.8, elapsed_fraction=0.5)
+        assert result.pace_gap == pytest.approx(0.3)
+        assert result.headroom == pytest.approx(0.2)
+        assert result.status == "overusing"
+
+    def test_supports_custom_target_policy(self) -> None:
+        result = compute_pacing_snapshot(
+            0.5, elapsed_fraction=0.5, target_utilization=0.9
+        )
+        assert result.target_utilization == pytest.approx(0.45)
+        assert result.pace_gap == pytest.approx(0.05)
+        assert result.status == "on_track"
 
 
 class TestComputeWindowPacing:
@@ -51,6 +71,20 @@ class TestComputeWindowPacing:
     def test_returns_none_for_invalid_inputs(self) -> None:
         assert compute_window_pacing(0.5, 0, WEEK) is None
         assert compute_window_pacing(0.5, 3600, 0) is None
+
+    def test_window_snapshot_exposes_headroom(self) -> None:
+        result = compute_window_pacing_snapshot(0.7, int(WEEK * 0.25), WEEK)
+        assert result is not None
+        assert result.headroom == pytest.approx(0.3)
+        assert result.target_utilization == pytest.approx(0.75)
+
+    def test_combine_prefers_most_over_budget_window(self) -> None:
+        result = combine_window_pacing_snapshots(
+            [(0.2, 3600, 18000), (0.6, 302400, 604800)]
+        )
+        assert result is not None
+        assert result.pace_gap > 0
+        assert result.status == "overusing"
 
 
 class TestComputeRebalanceHoldSeconds:


### PR DESCRIPTION
Exports `PacingSnapshot`, `compute_window_pacing_snapshot`, and `combine_window_pacing_snapshots` from `gptme_subscription.routing`.

`scripts/check-quota.py` and its test suite (`tests/test_check_quota.py`) import these helpers, causing master CI to fail with `ImportError: cannot import name 'combine_window_pacing_snapshots'` on every commit.

## Changes
- `routing.py`: add `PacingSnapshot` dataclass + `compute_window_pacing_snapshot` / `combine_window_pacing_snapshots` helpers
- `__init__.py`: re-export all new public symbols
- `tests/test_routing.py`: regression tests for the new helpers

## Fixes
Unblocks `ErikBjare/bob` master CI.