### PR TITLE
feat(gptme-tts): actionable available_hint when TTS is unavailable

### DIFF
--- a/plugins/gptme-tts/src/gptme_tts/tts.py
+++ b/plugins/gptme-tts/src/gptme_tts/tts.py
@@ -744,7 +744,7 @@ _TTS_UNAVAILABLE_HINT = (
 )
 _hint_kwargs = (
     {"available_hint": _TTS_UNAVAILABLE_HINT}
-    if "available_hint" in getattr(ToolSpec, "__dataclass_fields__", {})
+    if hasattr(ToolSpec, "available_hint")
     else {}
 )
 

--- a/plugins/gptme-tts/src/gptme_tts/tts.py
+++ b/plugins/gptme-tts/src/gptme_tts/tts.py
@@ -735,11 +735,25 @@ def wait_on_session_end(manager, **kwargs):
     yield  # Hooks must be generators
 
 
+# Specific guidance shown when 'tts' is explicitly requested but unavailable.
+# Guarded so it works on gptme builds that predate ToolSpec.available_hint.
+_TTS_UNAVAILABLE_HINT = (
+    "TTS is unavailable. For the local server backend, start tts_server.py "
+    "(e.g. `uv run tts_server.py --backend kokoro`); for OpenRouter, set "
+    "GPTME_TTS_BACKEND=openrouter and OPENROUTER_API_KEY."
+)
+_hint_kwargs = (
+    {"available_hint": _TTS_UNAVAILABLE_HINT}
+    if "available_hint" in getattr(ToolSpec, "__dataclass_fields__", {})
+    else {}
+)
+
 tool = ToolSpec(
     "tts",
     desc="Text-to-speech (TTS) tool for generating audio from text.",
     instructions="Automatically voices your responses to the user. Use speak() to add spoken emphasis or deliver important messages audibly. Note: you cannot hear the output, so do not rely on it for confirmation.",
     available=is_available,
+    **_hint_kwargs,
     functions=[speak, set_speed, set_volume, stop],
     init=init,
     hooks={


### PR DESCRIPTION
## Summary

When `tts` is explicitly requested but unavailable, surface a tool-specific hint instead of gptme's generic "unavailable" message:

> TTS is unavailable. For the local server backend, start tts_server.py (e.g. `uv run tts_server.py --backend kokoro`); for OpenRouter, set GPTME_TTS_BACKEND=openrouter and OPENROUTER_API_KEY.

Set via the new `ToolSpec.available_hint`, guarded on `"available_hint" in ToolSpec.__dataclass_fields__` so the plugin still imports cleanly on gptme builds that predate the field (it just falls back to the generic message there).

Pairs with gptme/gptme#2809 (which adds `ToolSpec.available_hint` and stops reporting known-but-unavailable tools as "invalid choice").

## Test plan

- [x] Plugin tests pass (tool spec, hooks, backends)
- [x] Verified: hint is set when imported against gptme#2809, and silently skipped (no crash) against current released gptme