### PR TITLE
fix(self-merge-check): accept 'owner/repo <number>' two-positional form

### DIFF
--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -362,7 +362,14 @@ def parse_pr_target(
         if "#" in pr:
             repo_part, number_part = pr.split("#", 1)
             return repo_part, int(number_part)
-        raise ValueError(f"Unrecognized PR specifier: {pr}")
+        # Two-positional `owner/repo <number>` form: pr is the repo, the PR
+        # number was supplied as the separate positional argument.
+        if pr.count("/") == 1 and number is not None:
+            return pr, number
+        raise ValueError(
+            f"Unrecognized PR specifier: {pr!r}. "
+            f"Use a PR URL, 'owner/repo#number', or 'owner/repo <number>'."
+        )
     if repo and number is not None:
         return repo, number
     raise ValueError("Provide a PR URL/specifier or --repo with PR number")

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -1116,7 +1116,10 @@ def main() -> int:
     )
     parser.add_argument("pr", nargs="?", help="PR URL, repo#num, or PR number")
     parser.add_argument(
-        "number", nargs="?", type=int, help="PR number when using --repo"
+        "number",
+        nargs="?",
+        type=int,
+        help="PR number when using --repo or 'owner/repo <number>' form",
     )
     parser.add_argument("--repo", help="Repository in owner/name form")
     parser.add_argument("--json", action="store_true", help="Output JSON")

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -106,6 +106,32 @@ def test_parse_pr_target_strips_fragment() -> None:
     assert number == 504
 
 
+def test_parse_pr_target_accepts_repo_hash_number() -> None:
+    """The documented 'owner/repo#number' specifier must parse."""
+    repo, number = self_merge_check.parse_pr_target(
+        "ActivityWatch/activitywatch.github.io#54", None, None
+    )
+    assert repo == "ActivityWatch/activitywatch.github.io"
+    assert number == 54
+
+
+def test_parse_pr_target_accepts_repo_and_positional_number() -> None:
+    """Two-positional 'owner/repo <number>' form must parse, not raise."""
+    repo, number = self_merge_check.parse_pr_target(
+        "ActivityWatch/activitywatch.github.io", None, 54
+    )
+    assert repo == "ActivityWatch/activitywatch.github.io"
+    assert number == 54
+
+
+def test_parse_pr_target_repo_without_number_raises_with_hint() -> None:
+    """A bare 'owner/repo' (no number anywhere) must raise a guiding error."""
+    import pytest
+
+    with pytest.raises(ValueError, match="owner/repo#number"):
+        self_merge_check.parse_pr_target("gptme/gptme", None, None)
+
+
 def test_evaluate_pr_blocks_changes_requested() -> None:
     pr_data = {
         "author": {"login": "TimeToBuildBob"},


### PR DESCRIPTION
## Problem

`parse_pr_target` only used the positional PR number when `--repo` was passed. Calling `self-merge-check.py owner/repo 54` (the natural two-positional form, and what argparse advertises with its `pr` + `number` positionals) raised a confusing `Unrecognized PR specifier: owner/repo` and **silently ignored** the `54` argument.

Hit organically this session: `self-merge-check.py ActivityWatch/activitywatch.github.io 54` failed even though the equivalent `owner/repo#number` form worked.

## Fix

- Treat a positional that looks like `owner/repo` (exactly one `/`, no `#`) plus a separate `number` positional as `(repo, number)`.
- Improve the error message to name all accepted forms (URL, `owner/repo#number`, `owner/repo <number>`).

Strictly additive — existing URL / `owner/repo#number` / `--repo owner/repo NUM` forms are unchanged.

## Tests

Added `test_parse_pr_target_accepts_repo_hash_number`, `test_parse_pr_target_accepts_repo_and_positional_number`, and `test_parse_pr_target_repo_without_number_raises_with_hint`. Full suite: 70 passed.

🤖 Authored by Bob