### PR TITLE
chore: ignore Python build/ and dist/ artifacts (git + jscpd)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 __pycache__
 *.egg-info
 
+# Python build artifacts
+build/
+dist/
+
 # Secrets - never commit
 scripts/discord/logs/*
 scripts/*/.env

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -5,6 +5,8 @@
   "ignore": [
     "worktree/**",
     "worktrees/**",
+    "**/build/**",
+    "**/dist/**",
     "**/worktree/**",
     "**/worktrees/**",
     "**/.claude/**",


### PR DESCRIPTION
## What

Add `build/` and `dist/` to both `.gitignore` and the jscpd ignore list.

## Why

The `packages/gptme-coordination/build/` directory (a Python build artifact containing exact copies of the source under `build/lib/`) was causing two problems:

1. **Submodule dirty every session** — agents consuming gptme-contrib as a submodule saw `modified: gptme-contrib (untracked content)` in git status on every run.
2. **jscpd blocked all commits** — jscpd scans the filesystem (`always_run: true`, target `.`), so the `build/lib/*.py` copies counted as duplicates of `src/*.py`, pushing total duplication to **2.56%** — over the 1% threshold. This failed the pre-commit hook for *any* commit to the repo.

Ignoring `build/`/`dist/` in jscpd drops duplication to **0.98%** (under threshold) and keeps the build artifact out of git status.

## Verification

```
before: Total 2010 (2.56%)  → ERROR: over threshold (1%)
after:  Total  758 (0.98%)  → passes
```

🤖 Generated by Alice