### PR TITLE
feat(trimmer): add tool-output summarization pass (priority 199)

### DIFF
--- a/plugins/gptme-tooloutput-trimmer/src/tooloutput_trimmer/__init__.py
+++ b/plugins/gptme-tooloutput-trimmer/src/tooloutput_trimmer/__init__.py
@@ -18,9 +18,10 @@ except ModuleNotFoundError:
 
 
 def _register_hooks() -> None:
-    from .hooks import register
+    from .hooks import register_summarizer, register_trimmer
 
-    register()
+    register_trimmer()
+    register_summarizer()
 
 
 plugin = GptmePlugin(

--- a/plugins/gptme-tooloutput-trimmer/src/tooloutput_trimmer/hooks/__init__.py
+++ b/plugins/gptme-tooloutput-trimmer/src/tooloutput_trimmer/hooks/__init__.py
@@ -1,5 +1,17 @@
 """Hook exports for the tool-output trimmer plugin."""
 
+from .summarizer import (
+    SUMMARIZATION_PROMPT,
+    SummarizerConfig,
+    apply_summarization,
+    get_summarizer_config,
+)
+from .summarizer import (
+    generation_pre_hook as summarization_generation_pre_hook,
+)
+from .summarizer import (
+    register as register_summarizer,
+)
 from .trimmer import (
     BYPASS_ENV_VAR,
     DEFAULT_MAX_OUTPUT_CHARS,
@@ -17,8 +29,10 @@ from .trimmer import (
     estimate_billed_chars,
     generation_pre_hook,
     get_trimmer_config,
-    register,
     reset_state,
+)
+from .trimmer import (
+    register as register_trimmer,
 )
 
 __all__ = [
@@ -27,17 +41,23 @@ __all__ = [
     "DEFAULT_PREVIEW_CHARS",
     "DEFAULT_PRESSURE_CHARS",
     "DEFAULT_RECENT_TURNS",
+    "SUMMARIZATION_PROMPT",
+    "SummarizerConfig",
     "TOOL_OUTPUT_PREFIXES",
     "TRIMMED_MARKER",
     "TrimSummary",
     "TriggerDecision",
     "TrimmerConfig",
+    "apply_summarization",
     "apply_tool_output_trimmer",
     "build_trimmed_content",
     "determine_trigger",
     "estimate_billed_chars",
     "generation_pre_hook",
+    "get_summarizer_config",
     "get_trimmer_config",
-    "register",
+    "register_summarizer",
+    "register_trimmer",
     "reset_state",
+    "summarization_generation_pre_hook",
 ]

--- a/plugins/gptme-tooloutput-trimmer/src/tooloutput_trimmer/hooks/summarizer.py
+++ b/plugins/gptme-tooloutput-trimmer/src/tooloutput_trimmer/hooks/summarizer.py
@@ -36,7 +36,10 @@ except ModuleNotFoundError:
 
 from .trimmer import (
     SUMMARIZATION_MARKER,
+    SUMMARIZE_ENV_VAR,
     TrimmerConfig,
+    _coerce_int,
+    _get_plugin_settings,
     _is_tool_output_message,
     get_trimmer_config,
 )
@@ -74,24 +77,10 @@ def _get_summarization_enabled() -> bool:
     """Check if summarization is enabled via env var or plugin config."""
     settings = _get_plugin_settings()
     config = get_config()
-    env_val = config.get_env_bool("GPTME_SUMMARIZE_TOOL_OUTPUTS")
+    env_val = config.get_env_bool(SUMMARIZE_ENV_VAR)
     if env_val is not None:
         return env_val
     return bool(settings.get("summarize", DEFAULT_SUMMARIZATION_ENABLED))
-
-
-def _get_plugin_settings() -> dict[str, Any]:
-    """Read summarization settings from plugin config."""
-    config = get_config()
-    user_cfg = {}
-    project_cfg = {}
-    if config.user and hasattr(config.user, "plugin"):
-        user_cfg = getattr(config.user, "plugin", {}).get("tooloutput_trimmer", {})
-    if config.project and hasattr(config.project, "plugin"):
-        project_cfg = getattr(config.project, "plugin", {}).get(
-            "tooloutput_trimmer", {}
-        )
-    return {**user_cfg, **project_cfg}
 
 
 def get_summarizer_config() -> SummarizerConfig:
@@ -104,14 +93,6 @@ def get_summarizer_config() -> SummarizerConfig:
             minimum=1,
         ),
     )
-
-
-def _coerce_int(value: Any, default: int, *, minimum: int) -> int:
-    try:
-        parsed = int(value)
-    except (TypeError, ValueError):
-        return default
-    return max(minimum, parsed)
 
 
 def _find_evictable_tool_output_indices(
@@ -265,17 +246,16 @@ def generation_pre_hook(
     enabled, replaces W evicted tool output pairs with a single LLM-generated
     summary. Otherwise, acts as a no-op and the trimmer handles truncation.
     """
+    # Capture count before in-place update so the scan sees the original list
+    n_evictable = len(
+        _find_evictable_tool_output_indices(messages, get_trimmer_config())
+    )
     rewritten, did_summarize = apply_summarization(messages)
     if did_summarize:
         messages[:] = rewritten
         logger.info(
             "summarizer: replaced %d evicted pairs with summary",
-            min(
-                get_summarizer_config().window,
-                len(
-                    _find_evictable_tool_output_indices(messages, get_trimmer_config())
-                ),
-            ),
+            min(get_summarizer_config().window, n_evictable),
         )
     yield from ()
 

--- a/plugins/gptme-tooloutput-trimmer/src/tooloutput_trimmer/hooks/summarizer.py
+++ b/plugins/gptme-tooloutput-trimmer/src/tooloutput_trimmer/hooks/summarizer.py
@@ -38,6 +38,7 @@ from .trimmer import (
     SUMMARIZATION_MARKER,
     SUMMARIZE_ENV_VAR,
     TrimmerConfig,
+    _check_bypass_env,
     _coerce_int,
     _is_tool_output_message,
     get_trimmer_config,
@@ -264,6 +265,8 @@ def generation_pre_hook(
     enabled, replaces W evicted tool output pairs with a single LLM-generated
     summary. Otherwise, acts as a no-op and the trimmer handles truncation.
     """
+    if _check_bypass_env():
+        return
     # Capture count before in-place update so the scan sees the original list
     n_evictable = len(
         _find_evictable_tool_output_indices(messages, get_trimmer_config())

--- a/plugins/gptme-tooloutput-trimmer/src/tooloutput_trimmer/hooks/summarizer.py
+++ b/plugins/gptme-tooloutput-trimmer/src/tooloutput_trimmer/hooks/summarizer.py
@@ -1,0 +1,290 @@
+"""Summarization pass for evicted tool outputs.
+
+Runs at priority 199 (before the trimmer at 200). When summarization is enabled
+and tool output messages are evicted beyond the recency window, the W most
+recently evicted pairs are summarized using an LLM and replaced with a single
+summary message, instead of being preview-truncated by the trimmer.
+
+Based on Algorithm 1 from "Less Context, Better Agents" (arXiv:2606.10209,
+Lodha et al., Microsoft, 2026). Summarization adds ~+12.6pp reliability over
+pruning alone at ~+3.4% token cost.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Generator
+from dataclasses import dataclass
+from typing import Any
+
+from gptme.config import get_config
+from gptme.hooks import HookType, StopPropagation, register_hook
+from gptme.message import Message
+
+try:
+    from gptme.llm import _chat_complete, get_default_model_summary
+except ModuleNotFoundError:
+
+    def _chat_complete(
+        messages: list[Message], model: str, tools: Any = None, **kwargs: Any
+    ) -> tuple[str, Any]:
+        raise RuntimeError("LLM summarization not available (old gptme)")
+
+    def get_default_model_summary() -> Any:
+        return None
+
+
+from .trimmer import (
+    SUMMARIZATION_MARKER,
+    TrimmerConfig,
+    _is_tool_output_message,
+    get_trimmer_config,
+)
+
+logger = logging.getLogger(__name__)
+
+# Default summarization settings
+DEFAULT_SUMMARIZATION_ENABLED = False  # off by default for MVP
+DEFAULT_SUMMARIZATION_WINDOW = 3  # W=3 matches paper's optimum
+
+
+SUMMARIZATION_PROMPT = """Summarize the following tool execution results for an AI assistant. Focus on what commands were executed, what key results were discovered or created, and what task-level progress was made.
+
+Tool outputs to summarize:
+{context}
+
+Format:
+Summary of previous tool calls:
+- [action]: [result]
+- [action]: [result]
+- Task-level progress: [what's been done, what's pending]"""
+
+
+@dataclass
+class SummarizerConfig:
+    """Configuration for the summarization pass."""
+
+    enabled: bool = False
+    window: int = (
+        DEFAULT_SUMMARIZATION_WINDOW  # W — number of evicted pairs to summarize
+    )
+
+
+def _get_summarization_enabled() -> bool:
+    """Check if summarization is enabled via env var or plugin config."""
+    settings = _get_plugin_settings()
+    config = get_config()
+    env_val = config.get_env_bool("GPTME_SUMMARIZE_TOOL_OUTPUTS")
+    if env_val is not None:
+        return env_val
+    return bool(settings.get("summarize", DEFAULT_SUMMARIZATION_ENABLED))
+
+
+def _get_plugin_settings() -> dict[str, Any]:
+    """Read summarization settings from plugin config."""
+    config = get_config()
+    user_cfg = {}
+    project_cfg = {}
+    if config.user and hasattr(config.user, "plugin"):
+        user_cfg = getattr(config.user, "plugin", {}).get("tooloutput_trimmer", {})
+    if config.project and hasattr(config.project, "plugin"):
+        project_cfg = getattr(config.project, "plugin", {}).get(
+            "tooloutput_trimmer", {}
+        )
+    return {**user_cfg, **project_cfg}
+
+
+def get_summarizer_config() -> SummarizerConfig:
+    """Read summarizer config from env + plugin settings."""
+    return SummarizerConfig(
+        enabled=_get_summarization_enabled(),
+        window=_coerce_int(
+            _get_plugin_settings().get("summarize_window"),
+            DEFAULT_SUMMARIZATION_WINDOW,
+            minimum=1,
+        ),
+    )
+
+
+def _coerce_int(value: Any, default: int, *, minimum: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(minimum, parsed)
+
+
+def _find_evictable_tool_output_indices(
+    messages: list[Message],
+    trimmer_config: TrimmerConfig,
+) -> list[int]:
+    """Find indices of tool output messages beyond the recency window.
+
+    Uses the same cutoff logic as the trimmer: messages before the Nth-last
+    assistant turn are eligible for eviction/summarization.
+    """
+    assistant_positions = [
+        index for index, message in enumerate(messages) if message.role == "assistant"
+    ]
+    if len(assistant_positions) <= trimmer_config.recent_turns:
+        return []
+
+    cutoff = assistant_positions[-trimmer_config.recent_turns]
+
+    evictable: list[int] = []
+    for index in range(cutoff):
+        if _is_tool_output_message(
+            messages[index],
+            max_output_chars=trimmer_config.max_output_chars,
+            raw_prefixes=trimmer_config.raw_tool_prefixes,
+        ):
+            evictable.append(index)
+
+    return evictable
+
+
+def _build_summarization_context(
+    messages: list[Message],
+    evictable_indices: list[int],
+    window: int,
+) -> str:
+    """Build context string from the W most recently evicted pairs.
+
+    Includes the preceding assistant message (tool call) and the tool output
+    for each evicted pair, truncated to a reasonable size for summarization.
+    """
+    # Take the W most recently evicted pairs (last in the list = closest to present)
+    recent_evicted = evictable_indices[-window:]
+
+    parts: list[str] = []
+    for idx in recent_evicted:
+        # Include preceding assistant message if available
+        if idx > 0 and messages[idx - 1].role == "assistant":
+            call_preview = messages[idx - 1].content[:300].replace("\n", " ")
+            parts.append(f"Tool call: {call_preview}")
+        # Include first 1000 chars of the tool output
+        output_preview = messages[idx].content[:1000].replace("\n", " ")
+        parts.append(f"Tool output: {output_preview}")
+
+    return "\n\n".join(parts)
+
+
+def _call_summarizer(context: str) -> str | None:
+    """Call the summarizer LLM to produce a summary of the given context.
+
+    Returns the summary text, or None if summarization fails.
+    """
+    model = get_default_model_summary()
+    if not model:
+        logger.warning("summarizer: no default model set, skipping")
+        return None
+
+    prompt = SUMMARIZATION_PROMPT.format(context=context)
+    msgs = [
+        Message(
+            "system",
+            content="You are a helpful assistant that summarizes tool execution results concisely.",
+        ),
+        Message("user", content=prompt),
+    ]
+
+    try:
+        summary, _metadata = _chat_complete(msgs, model.full, None)
+        if not summary:
+            logger.warning("summarizer: LLM returned empty summary")
+            return None
+        logger.debug(
+            "summarizer: produced %d chars",
+            len(summary),
+        )
+        return summary.strip()
+    except Exception:
+        logger.exception("summarizer: LLM call failed")
+        return None
+
+
+def apply_summarization(
+    messages: list[Message],
+    *,
+    trimmer_config: TrimmerConfig | None = None,
+) -> tuple[list[Message], bool]:
+    """Apply summarization to evictable tool output pairs.
+
+    Returns (rewritten_messages, did_summarize) where did_summarize is True
+    if any summarization was performed.
+
+    Can optionally pass a TrimmerConfig to use for eviction detection
+    (useful in tests). Otherwise reads from plugin config.
+    """
+    config = get_summarizer_config()
+    if not config.enabled:
+        return list(messages), False
+
+    trimmer_config = trimmer_config or get_trimmer_config()
+    evictable = _find_evictable_tool_output_indices(messages, trimmer_config)
+
+    if not evictable:
+        return list(messages), False
+
+    # Build context from the W most recently evicted pairs
+    context = _build_summarization_context(messages, evictable, config.window)
+
+    # Call summarizer
+    summary = _call_summarizer(context)
+    if summary is None:
+        return list(messages), False  # fall back to preview truncation
+
+    # Take the W most recently evicted pairs
+    recent_evicted = evictable[-config.window :]
+    # Build the summary message content
+    summary_content = f"{SUMMARIZATION_MARKER}\n" f"{summary}"
+    summary_msg = messages[recent_evicted[0]].replace(content=summary_content)
+
+    # Rebuild message list: replace the first evicted position with summary,
+    # remove the rest
+    evicted_set = set(recent_evicted)
+    rewritten: list[Message] = []
+    for idx, msg in enumerate(messages):
+        if idx == recent_evicted[0]:
+            rewritten.append(summary_msg)
+        elif idx in evicted_set:
+            continue  # skip other evicted positions
+        else:
+            rewritten.append(msg)
+
+    return rewritten, True
+
+
+def generation_pre_hook(
+    messages: list[Message],
+    **kwargs: Any,
+) -> Generator[Message | StopPropagation, None, None]:
+    """Summarize evicted tool outputs before the trimmer runs.
+
+    Registered at priority 199 (before trimmer at 200). When summarization is
+    enabled, replaces W evicted tool output pairs with a single LLM-generated
+    summary. Otherwise, acts as a no-op and the trimmer handles truncation.
+    """
+    rewritten, did_summarize = apply_summarization(messages)
+    if did_summarize:
+        messages[:] = rewritten
+        logger.info(
+            "summarizer: replaced %d evicted pairs with summary",
+            min(
+                get_summarizer_config().window,
+                len(
+                    _find_evictable_tool_output_indices(messages, get_trimmer_config())
+                ),
+            ),
+        )
+    yield from ()
+
+
+def register() -> None:
+    """Register the summarization hook at priority 199 (before trimmer at 200)."""
+    register_hook(
+        name="tooloutput_trimmer.summarizer",
+        hook_type=HookType.GENERATION_PRE,
+        func=generation_pre_hook,
+        priority=199,
+    )

--- a/plugins/gptme-tooloutput-trimmer/src/tooloutput_trimmer/hooks/summarizer.py
+++ b/plugins/gptme-tooloutput-trimmer/src/tooloutput_trimmer/hooks/summarizer.py
@@ -39,10 +39,28 @@ from .trimmer import (
     SUMMARIZE_ENV_VAR,
     TrimmerConfig,
     _coerce_int,
-    _get_plugin_settings,
     _is_tool_output_message,
     get_trimmer_config,
 )
+
+
+def _get_plugin_settings() -> dict[str, Any]:
+    """Read tooloutput_trimmer plugin settings, merging user and project config.
+
+    Defined locally (not imported from trimmer) so that patching
+    `summarizer.get_config` in tests correctly intercepts this lookup.
+    """
+    config = get_config()
+    user_cfg: dict[str, Any] = {}
+    project_cfg: dict[str, Any] = {}
+    if config.user and hasattr(config.user, "plugin"):
+        user_cfg = getattr(config.user, "plugin", {}).get("tooloutput_trimmer", {})
+    if config.project and hasattr(config.project, "plugin"):
+        project_cfg = getattr(config.project, "plugin", {}).get(
+            "tooloutput_trimmer", {}
+        )
+    return {**user_cfg, **project_cfg}
+
 
 logger = logging.getLogger(__name__)
 

--- a/plugins/gptme-tooloutput-trimmer/src/tooloutput_trimmer/hooks/trimmer.py
+++ b/plugins/gptme-tooloutput-trimmer/src/tooloutput_trimmer/hooks/trimmer.py
@@ -25,20 +25,6 @@ from gptme.hooks import HookType, StopPropagation, register_hook
 from gptme.message import Message
 
 try:
-    from gptme.llm import _chat_complete, get_default_model_summary, len_tokens
-except ModuleNotFoundError:
-
-    def _chat_complete(messages, model, tools=None, **kwargs):  # type: ignore
-        raise RuntimeError("LLM summarization not available (old gptme)")
-
-    def get_default_model_summary():  # type: ignore
-        return None
-
-    def len_tokens(*args, **kwargs):  # type: ignore
-        return 0
-
-
-try:
     from gptme.util.cost_tracker import CostTracker, SessionCosts
 except ModuleNotFoundError:
     SessionCosts = Any

--- a/plugins/gptme-tooloutput-trimmer/src/tooloutput_trimmer/hooks/trimmer.py
+++ b/plugins/gptme-tooloutput-trimmer/src/tooloutput_trimmer/hooks/trimmer.py
@@ -25,6 +25,20 @@ from gptme.hooks import HookType, StopPropagation, register_hook
 from gptme.message import Message
 
 try:
+    from gptme.llm import _chat_complete, get_default_model_summary, len_tokens
+except ModuleNotFoundError:
+
+    def _chat_complete(messages, model, tools=None, **kwargs):  # type: ignore
+        raise RuntimeError("LLM summarization not available (old gptme)")
+
+    def get_default_model_summary():  # type: ignore
+        return None
+
+    def len_tokens(*args, **kwargs):  # type: ignore
+        return 0
+
+
+try:
     from gptme.util.cost_tracker import CostTracker, SessionCosts
 except ModuleNotFoundError:
     SessionCosts = Any
@@ -47,7 +61,11 @@ ANTHROPIC_CACHE_TTL_SECS = 5 * 60
 TOOL_OUTPUT_PREFIXES = ("Ran command: `", "Executed code block.")
 TRIMMED_MARKER = "[Tool output trimmed"
 HEADROOM_MARKER = "[Headroom compressed"  # skip messages already losslessly compressed
+SUMMARIZATION_MARKER = (
+    "[Summarized previous tool outputs]"  # marker for summarization inserts
+)
 BYPASS_ENV_VAR = "GPTME_TRIM_BYPASS"
+SUMMARIZE_ENV_VAR = "GPTME_SUMMARIZE_TOOL_OUTPUTS"
 
 
 @dataclass(frozen=True)

--- a/plugins/gptme-tooloutput-trimmer/tests/test_summarizer.py
+++ b/plugins/gptme-tooloutput-trimmer/tests/test_summarizer.py
@@ -130,10 +130,14 @@ def test_apply_summarization_noop_when_disabled() -> None:
         _msg("user", "u1"),
         _msg("assistant", "a1"),
     ]
-    rewritten, did_summarize = apply_summarization(
-        messages,
-        trimmer_config=_default_trimmer_config(),
-    )
+    with patch(
+        "tooloutput_trimmer.hooks.summarizer.get_config",
+        return_value=_make_config(summarize_enabled=False),
+    ):
+        rewritten, did_summarize = apply_summarization(
+            messages,
+            trimmer_config=_default_trimmer_config(),
+        )
     assert not did_summarize
     assert len(rewritten) == len(messages)
 

--- a/plugins/gptme-tooloutput-trimmer/tests/test_summarizer.py
+++ b/plugins/gptme-tooloutput-trimmer/tests/test_summarizer.py
@@ -1,0 +1,365 @@
+"""Tests for the tool-output summarization pass."""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from gptme.message import Message
+
+# Add plugin source to path once at module load.
+_plugin_src = str(Path(__file__).parent.parent / "src")
+if _plugin_src not in sys.path:
+    sys.path.insert(0, _plugin_src)
+
+from tooloutput_trimmer.hooks.summarizer import (  # noqa: E402
+    _build_summarization_context,
+    _call_summarizer,
+    _find_evictable_tool_output_indices,
+    apply_summarization,
+    get_summarizer_config,
+)
+from tooloutput_trimmer.hooks.trimmer import (  # noqa: E402
+    SUMMARIZATION_MARKER,
+    TrimmerConfig,
+)
+
+
+def _msg(role: str, content: str, **kwargs: object) -> Message:
+    return Message(role, content, timestamp=datetime.now(timezone.utc), **kwargs)
+
+
+def _big_shell_output(name: str = "ls", repeats: int = 200) -> str:
+    body = "\n".join(f"line-{i}" for i in range(repeats))
+    return f"Ran command: `{name}`\n{body}"
+
+
+def _make_config(
+    *,
+    enabled: bool = True,
+    summarize_enabled: bool = False,
+    plugin_settings: dict[str, object] | None = None,
+) -> SimpleNamespace:
+    plugin_cfg: dict[str, object] = {
+        "tooloutput_trimmer": {
+            "max_output_chars": 200,
+            "recent_turns": 1,
+            "preview_chars": 40,
+            "pressure_chars": 1_000,
+        }
+    }
+    if summarize_enabled:
+        plugin_cfg["tooloutput_trimmer"]["summarize"] = True  # type: ignore[assignment]
+    if plugin_settings:
+        plugin_cfg["tooloutput_trimmer"].update(plugin_settings)  # type: ignore[assignment]
+    return SimpleNamespace(
+        get_env_bool=lambda key: (
+            enabled if key == "GPTME_READ_TIME_TRIMMER" else None
+        ),
+        user=SimpleNamespace(plugin={}),
+        project=SimpleNamespace(plugin=plugin_cfg),
+    )
+
+
+def test_find_evictable_finds_old_tool_outputs() -> None:
+    """Evictable indices should include tool outputs before recency cutoff."""
+    messages = [
+        _msg("user", "u0"),
+        _msg("assistant", "a0"),
+        _msg("system", _big_shell_output("old1")),
+        _msg("user", "u1"),
+        _msg("assistant", "a1"),
+        _msg("system", _big_shell_output("old2")),
+        _msg("user", "u2"),
+        _msg("assistant", "a2"),
+    ]
+    config = TrimmerConfig(
+        enabled=True,
+        max_output_chars=200,
+        recent_turns=1,
+        preview_chars=40,
+        pressure_chars=10_000,
+    )
+    evictable = _find_evictable_tool_output_indices(messages, config)
+    # Only 1 recent turn means cutoff is at the last assistant position.
+    # old1 (idx 2) and old2 (idx 5) are before that cutoff.
+    assert 2 in evictable
+    assert 5 in evictable
+
+
+def test_find_evictable_empty_when_no_cutoff() -> None:
+    """When messages fit within recency window, nothing is evictable."""
+    messages = [
+        _msg("user", "u0"),
+        _msg("assistant", "a0"),
+        _msg("system", _big_shell_output("recent")),
+        _msg("user", "u1"),
+        _msg("assistant", "a1"),
+    ]
+    config = TrimmerConfig(
+        enabled=True,
+        max_output_chars=200,
+        recent_turns=5,  # larger than assistant count
+        preview_chars=40,
+        pressure_chars=10_000,
+    )
+    assert _find_evictable_tool_output_indices(messages, config) == []
+
+
+def _default_trimmer_config(
+    recent_turns: int = 1,
+) -> TrimmerConfig:
+    return TrimmerConfig(
+        enabled=True,
+        max_output_chars=200,
+        recent_turns=recent_turns,
+        preview_chars=40,
+        pressure_chars=10_000,
+    )
+
+
+def test_apply_summarization_noop_when_disabled() -> None:
+    """When summarization is disabled, no changes are made."""
+    messages = [
+        _msg("user", "u0"),
+        _msg("assistant", "a0"),
+        _msg("system", _big_shell_output("old")),
+        _msg("user", "u1"),
+        _msg("assistant", "a1"),
+    ]
+    rewritten, did_summarize = apply_summarization(
+        messages,
+        trimmer_config=_default_trimmer_config(),
+    )
+    assert not did_summarize
+    assert len(rewritten) == len(messages)
+
+
+def test_apply_summarization_skips_when_summarizer_fails() -> None:
+    """When the summarizer LLM call fails, fall back to no summarization."""
+    messages = [
+        _msg("user", "u0"),
+        _msg("assistant", "a0"),
+        _msg("system", _big_shell_output("old")),
+        _msg("user", "u1"),
+        _msg("assistant", "a1"),
+    ]
+
+    with patch(
+        "tooloutput_trimmer.hooks.summarizer.get_default_model_summary",
+        return_value=None,
+    ):
+        with patch(
+            "tooloutput_trimmer.hooks.summarizer.get_config",
+            return_value=_make_config(summarize_enabled=True),
+        ):
+            rewritten, did_summarize = apply_summarization(
+                messages,
+                trimmer_config=_default_trimmer_config(),
+            )
+
+    assert not did_summarize
+    assert len(rewritten) == len(messages)
+
+
+def test_apply_summarization_replaces_evicted_pairs_with_summary() -> None:
+    """When summarization succeeds, W evicted pairs are replaced with a summary
+    message."""
+    messages = [
+        _msg("user", "u0"),
+        _msg("assistant", "a0"),
+        _msg("system", _big_shell_output("old1")),
+        _msg("user", "u1"),
+        _msg("system", _big_shell_output("old2")),
+        _msg("assistant", "a1"),
+        _msg("user", "u2"),
+        _msg("assistant", "a2"),
+    ]
+
+    with patch(
+        "tooloutput_trimmer.hooks.summarizer.get_default_model_summary",
+        return_value=SimpleNamespace(full="openai/gpt-4o"),
+    ):
+        with patch(
+            "tooloutput_trimmer.hooks.summarizer._call_summarizer",
+            return_value="- Executed command: found result\n- Task-level progress: done",
+        ):
+            with patch(
+                "tooloutput_trimmer.hooks.summarizer.get_config",
+                return_value=_make_config(summarize_enabled=True),
+            ):
+                rewritten, did_summarize = apply_summarization(
+                    messages,
+                    trimmer_config=_default_trimmer_config(),
+                )
+
+    assert did_summarize
+    # Evicted pairs at idx 2 and idx 4 → replaced with 1 summary at idx 2
+    # New order: idx 2 = summary, idx 3 = u1, idx 4 = a1 (was idx 5),
+    # idx 5 = u2 (was idx 6), idx 6 = a2 (was idx 7) = total 7
+    assert len(rewritten) == len(messages) - 1
+
+    # The summary message is at position 2 (the first evicted position)
+    assert rewritten[2].content.startswith(SUMMARIZATION_MARKER)
+    assert "Executed command" in rewritten[2].content
+
+    # Recent messages should be unaffected
+    assert rewritten[4].content == "a1"  # a1, was at idx 5, shifted to idx 4
+    assert rewritten[5].content == "u2"  # u2, was at idx 6, shifted to idx 5
+    assert rewritten[6].content == "a2"  # a2, was at idx 7, shifted to idx 6
+
+
+def test_apply_summarization_noop_when_no_evictable_pairs() -> None:
+    """When no tool outputs are beyond the recency window, no-op."""
+    messages = [
+        _msg("user", "u0"),
+        _msg("assistant", "a0"),
+        _msg("system", _big_shell_output("recent")),
+        _msg("user", "u1"),
+        _msg("assistant", "a1"),
+    ]
+    # Use recent_turns=3 to keep the single tool output within the window
+    tc = _default_trimmer_config(recent_turns=3)
+
+    with patch(
+        "tooloutput_trimmer.hooks.summarizer.get_default_model_summary",
+        return_value=SimpleNamespace(full="openai/gpt-4o"),
+    ):
+        with patch(
+            "tooloutput_trimmer.hooks.summarizer.get_config",
+            return_value=_make_config(summarize_enabled=True),
+        ):
+            rewritten, did_summarize = apply_summarization(
+                messages,
+                trimmer_config=tc,
+            )
+
+    assert not did_summarize
+    assert len(rewritten) == len(messages)
+
+
+def test_build_summarization_context_includes_tool_call_and_output() -> None:
+    """Context should include the preceding assistant message and tool output."""
+    messages = [
+        _msg("user", "u0"),
+        _msg("assistant", "check files"),
+        _msg("system", _big_shell_output("ls", repeats=210)),
+        _msg("user", "u1"),
+        _msg("assistant", "read config"),
+        _msg("system", _big_shell_output("cat config.py", repeats=210)),
+        _msg("user", "u2"),
+        _msg("assistant", "a2"),
+    ]
+    config = TrimmerConfig(
+        enabled=True,
+        max_output_chars=200,
+        recent_turns=1,
+        preview_chars=40,
+        pressure_chars=10_000,
+    )
+    evictable = _find_evictable_tool_output_indices(messages, config)
+    context = _build_summarization_context(messages, evictable, window=2)
+
+    assert "Tool call: check files" in context
+    assert "Tool call: read config" in context
+    assert "Tool output: Ran command: `ls`" in context
+    assert "Tool output: Ran command: `cat config.py`" in context
+
+
+def test_call_summarizer_returns_none_on_failure() -> None:
+    """When the summarizer LLM call fails, return None."""
+    with patch(
+        "tooloutput_trimmer.hooks.summarizer.get_default_model_summary",
+        return_value=SimpleNamespace(full="openai/gpt-4o"),
+    ):
+        with patch(
+            "tooloutput_trimmer.hooks.summarizer._chat_complete",
+            side_effect=RuntimeError("API error"),
+        ):
+            result = _call_summarizer("some context")
+    assert result is None
+
+
+def test_get_summarizer_config_defaults() -> None:
+    """Defaults should be disabled with window=3."""
+    with patch(
+        "tooloutput_trimmer.hooks.summarizer.get_config",
+        return_value=SimpleNamespace(
+            get_env_bool=lambda key: None,
+            user=SimpleNamespace(plugin={}),
+            project=SimpleNamespace(plugin={}),
+        ),
+    ):
+        config = get_summarizer_config()
+
+    assert config.enabled is False
+    assert config.window == 3
+
+
+def test_get_summarizer_config_from_env() -> None:
+    """GPTME_SUMMARIZE_TOOL_OUTPUTS env var should enable summarization."""
+    with patch(
+        "tooloutput_trimmer.hooks.summarizer.get_config",
+        return_value=SimpleNamespace(
+            get_env_bool=lambda key: (
+                True if key == "GPTME_SUMMARIZE_TOOL_OUTPUTS" else None
+            ),
+            user=SimpleNamespace(plugin={}),
+            project=SimpleNamespace(plugin={}),
+        ),
+    ):
+        config = get_summarizer_config()
+
+    assert config.enabled is True
+
+
+def test_apply_summarization_respects_window_limit() -> None:
+    """Only W most recent evicted pairs should be summarized, not all."""
+    # Create messages with 4 evictable tool outputs
+    messages = [
+        _msg("user", "u0"),
+        _msg("assistant", "a0"),
+        _msg("system", _big_shell_output("old1")),
+        _msg("user", "u1"),
+        _msg("system", _big_shell_output("old2")),
+        _msg("user", "u2"),
+        _msg("system", _big_shell_output("old3")),
+        _msg("user", "u3"),
+        _msg("system", _big_shell_output("old4")),
+        _msg("assistant", "a1"),
+        _msg("user", "u4"),
+        _msg("assistant", "a2"),
+    ]
+
+    with patch(
+        "tooloutput_trimmer.hooks.summarizer.get_default_model_summary",
+        return_value=SimpleNamespace(full="openai/gpt-4o"),
+    ):
+        with patch(
+            "tooloutput_trimmer.hooks.summarizer._call_summarizer",
+            return_value="- Summary of latest evicted",
+        ):
+            with patch(
+                "tooloutput_trimmer.hooks.summarizer.get_config",
+                return_value=_make_config(summarize_enabled=True),
+            ):
+                rewritten, did_summarize = apply_summarization(
+                    messages,
+                    trimmer_config=_default_trimmer_config(),
+                )
+
+    assert did_summarize
+    # W=3, evicted=[2,4,6,8], recent_evicted=[4,6,8] (3 most recent)
+    # Indices 4,6,8 → replaced with 1 summary at idx 4
+    # Net: -2 messages (12 → 10)
+    # Oldest evicted pair (idx 2) stays as-is
+    assert len(rewritten) == len(messages) - 2
+
+    # Summary should be at position 4 (the first of the 3 evicted recent pairs)
+    assert rewritten[4].content.startswith(SUMMARIZATION_MARKER)
+
+    # The oldest evicted pair (idx 2) should still be there as-is
+    assert rewritten[2].content == messages[2].content

--- a/plugins/gptme-tooloutput-trimmer/tests/test_summarizer.py
+++ b/plugins/gptme-tooloutput-trimmer/tests/test_summarizer.py
@@ -15,11 +15,13 @@ _plugin_src = str(Path(__file__).parent.parent / "src")
 if _plugin_src not in sys.path:
     sys.path.insert(0, _plugin_src)
 
+import pytest  # noqa: E402
 from tooloutput_trimmer.hooks.summarizer import (  # noqa: E402
     _build_summarization_context,
     _call_summarizer,
     _find_evictable_tool_output_indices,
     apply_summarization,
+    generation_pre_hook,
     get_summarizer_config,
 )
 from tooloutput_trimmer.hooks.trimmer import (  # noqa: E402
@@ -367,3 +369,25 @@ def test_apply_summarization_respects_window_limit() -> None:
 
     # The oldest evicted pair (idx 2) should still be there as-is
     assert rewritten[2].content == messages[2].content
+
+
+def test_generation_pre_hook_noop_when_bypass_env_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When GPTME_TRIM_BYPASS is set the summarizer hook must not fire."""
+    monkeypatch.setenv("GPTME_TRIM_BYPASS", "1")
+
+    messages = [
+        _msg("user", "u0"),
+        _msg("assistant", "a0"),
+        _msg("system", _big_shell_output("bypass-test")),
+        _msg("user", "u1"),
+        _msg("assistant", "a1"),
+    ]
+    original = list(messages)
+
+    # generation_pre_hook is a generator; exhaust it
+    list(generation_pre_hook(messages, model="test-model"))
+
+    # messages must be unchanged — no LLM call, no summarization
+    assert messages == original


### PR DESCRIPTION
Adds an LLM-based summarization pass that replaces evicted tool output pairs with a compact summary, based on Algorithm 1 from 'Less Context, Better Agents' (arXiv:2606.10209).

- New summarizer.py module with hook at priority 199 (before trimmer at 200)
- Summarizes W=3 most recently evicted pairs using gptme's default summarization model
- Falls back to preview-truncation on summarizer failure
- Config via GPTME_SUMMARIZE_TOOL_OUTPUTS env var or plugin settings (disabled by default)
- 11 new tests