### PR TITLE
fix(pr-queue-health): treat SKIPPED/NEUTRAL checks as passing

### DIFF
--- a/scripts/github/pr-queue-health.py
+++ b/scripts/github/pr-queue-health.py
@@ -161,7 +161,12 @@ def parse_datetime(dt_str: str) -> datetime | None:
 
 
 def get_ci_status(pr: dict[str, Any]) -> str:
-    """Extract CI status from PR check rollup."""
+    """Extract CI status from PR check rollup.
+
+    SKIPPED and NEUTRAL checks are treated as acceptable (not failures):
+    GitHub does not let them block a PR from being mergeable, so a PR whose
+    only non-SUCCESS checks are SKIPPED/NEUTRAL is classified as "passing".
+    """
     checks = pr.get("statusCheckRollup") or []
     if not checks:
         return "none"
@@ -171,7 +176,7 @@ def get_ci_status(pr: dict[str, Any]) -> str:
         return "failing"
     if any(s in ("PENDING", "IN_PROGRESS", "QUEUED") for s in states):
         return "pending"
-    if all(s == "SUCCESS" for s in states):
+    if all(s in ("SUCCESS", "SKIPPED", "NEUTRAL") for s in states):
         return "passing"
     return "mixed"
 

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -84,3 +84,28 @@ def test_main_returns_2_when_all_repo_fetches_fail(
     assert code == 2
     captured = capsys.readouterr()
     assert "failed to fetch prs for all tracked repositories" in captured.err.lower()
+
+
+def _pr_with_checks(*conclusions: str) -> dict[str, object]:
+    return {"statusCheckRollup": [{"conclusion": c} for c in conclusions]}
+
+
+@pytest.mark.parametrize(
+    "conclusions,expected",
+    [
+        ((), "none"),
+        (("SUCCESS", "SUCCESS"), "passing"),
+        (("SUCCESS", "SKIPPED"), "passing"),
+        (("SUCCESS", "NEUTRAL"), "passing"),
+        (("SKIPPED", "NEUTRAL"), "passing"),
+        (("FAILURE", "SUCCESS"), "failing"),
+        (("FAILURE", "SKIPPED"), "failing"),
+        (("SUCCESS", "PENDING"), "pending"),
+        (("SUCCESS", "IN_PROGRESS"), "pending"),
+        (("SUCCESS", "ACTION_REQUIRED"), "mixed"),
+    ],
+)
+def test_get_ci_status_treats_skipped_neutral_as_passing(
+    conclusions: tuple[str, ...], expected: str
+) -> None:
+    assert pr_queue_health.get_ci_status(_pr_with_checks(*conclusions)) == expected


### PR DESCRIPTION
## Problem

`get_ci_status` in `scripts/github/pr-queue-health.py` returned `mixed` (🔶) whenever any check had `conclusion=SKIPPED` or `NEUTRAL`, because `all(s == "SUCCESS" for s in states)` fails when those acceptable states are present. GitHub does not let SKIPPED/NEUTRAL checks block a PR from being mergeable, so such a PR is effectively CI-green and should be classified as `passing`.

This produced false 🔶 "mixed" rows in the PR-queue-health dashboard for PRs that were actually mergeable.

## Fix

```python
if all(s in ("SUCCESS", "SKIPPED", "NEUTRAL") for s in states):
    return "passing"
```

Adds parametrized tests covering SUCCESS/SKIPPED/NEUTRAL/PENDING/FAILURE/mixed/none combinations.

## Context

This fix previously lived only as a local override in Bob's copy of the script (`upstream-first-shrink-wrapper` drift). Porting it upstream lets Bob's local file return to a thin wrapper.

## Verification

- `pytest tests/test_pr_queue_health.py -q` → 15 passed
- prek hooks (ruff, ruff-format, mypy) pass