### PR TITLE
feat(imagen): register image_gen as a gptme.plugins entry point

### DIFF
--- a/plugins/gptme-imagen/pyproject.toml
+++ b/plugins/gptme-imagen/pyproject.toml
@@ -30,6 +30,9 @@ all = [
 [project.scripts]
 gptme-imagen = "gptme_imagen.cli:main"
 
+[project.entry-points."gptme.plugins"]
+gptme-imagen = "gptme_imagen.tools.image_gen:image_gen_tool"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
## What

Adds a `gptme.plugins` entry-point declaration to `gptme-imagen`'s `pyproject.toml` so its existing `image_gen` ToolSpec is discovered by gptme's plugin registry.

```toml
[project.entry-points."gptme.plugins"]
gptme-imagen = "gptme_imagen.tools.image_gen:image_gen_tool"
```

## Why

The plugin already defined a complete `ToolSpec` (`image_gen_tool = _make_tool_spec()`, `name="image_gen"`), but with no entry-point declaration gptme's `discover_entrypoint_plugins()` never loaded it. So image generation was unreachable from any gptme conversation, including webui — even though the artifacts API already renders `image`-kind results.

This is the thin **Slice C** of agentic image generation in webui (ErikBjare/bob#841): wire the tool into discovery. No code changes to the tool itself.

## Verification

Installed gptme + the plugin in a clean venv and confirmed discovery:

```
$ python3 -c 'from gptme.plugins.registry import discover_all_plugins; ...'
discovered: ['gptme-imagen', 'auto_snapshots', 'aw_watcher_agent']
imagen tools: ['image_gen']
VERIFY_OK: image_gen tool is discoverable via gptme.plugins entry point
```

Discovery accepts a bare `ToolSpec` export directly (see `_coerce_to_plugin`), matching the pattern used by sibling plugins.

Ref: ErikBjare/bob#841