### PR TITLE
feat(pm-dispatch): per-lane model routing (fast lane → cheaper model)

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import sys
 from dataclasses import dataclass, field, fields
 from datetime import datetime, timezone
@@ -285,6 +286,28 @@ def partition_items(items: list[SlotItem]) -> tuple[list[SlotItem], list[SlotIte
     return fast, slow
 
 
+def resolve_lane_model(
+    lane: str,
+    base_model: str | None,
+    fast_model: str | None = None,
+) -> str | None:
+    """Resolve the model to use for a dispatch *lane*.
+
+    Per-lane model routing (ErikBjare/bob#860): the fast lane (notifications,
+    assigned-issue triage — everything not in ``SLOW_LANE_TYPES``) is the
+    low-intelligence-needed partition, so it can run on a cheaper model while
+    the slow lane (PR reviews, CI diagnostics, Greptile, merge conflicts) keeps
+    the capable model.
+
+    Opt-in and default-off: with ``fast_model`` unset (``None``), every lane
+    gets ``base_model`` — identical to the prior single-model behavior. The
+    bash runtime mirrors this via the ``BOB_PM_FAST_LANE_MODEL`` env var.
+    """
+    if lane == "fast" and fast_model:
+        return fast_model
+    return base_model
+
+
 # --- DispatchLedger ---
 
 
@@ -360,6 +383,7 @@ class LaneDispatcher:
         backend: str = "claude-code",
         model: str | None = None,
         script_path: str | None = None,
+        fast_model: str | None = None,
     ) -> tuple[int, int]:
         """Dispatch items via transient systemd units.
 
@@ -367,11 +391,18 @@ class LaneDispatcher:
         - derives a slot key and unit name
         - skips if the slot is already busy
         - checks slot availability (cap + burst)
+        - resolves the per-lane model (see ``resolve_lane_model``)
         - launches via ``dispatch_callback`` or default systemd-run
+
+        ``fast_model`` (falling back to the ``BOB_PM_FAST_LANE_MODEL`` env var)
+        opts the fast lane onto a cheaper model; unset preserves the single
+        ``model`` for every lane (ErikBjare/bob#860).
 
         Returns:
             (launched_count, deferred_count)
         """
+        if fast_model is None:
+            fast_model = os.environ.get("BOB_PM_FAST_LANE_MODEL") or None
         fast_items, slow_items = partition_items(items)
 
         launched = 0
@@ -407,7 +438,7 @@ class LaneDispatcher:
                     deferred += 1
                     continue
 
-                # Launch
+                # Launch (fast lane may run on a cheaper model)
                 success = self._launch_unit(
                     unit_name=unit_name,
                     legacy_name=legacy_name,
@@ -415,7 +446,7 @@ class LaneDispatcher:
                     lane=lane,
                     item=item,
                     backend=backend,
-                    model=model,
+                    model=resolve_lane_model(lane, model, fast_model),
                     script_path=script_path,
                 )
 

--- a/packages/gptme-runloops/tests/test_pm_dispatch.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch.py
@@ -23,6 +23,7 @@ from gptme_runloops.pm_dispatch import (
     derive_slot_key,
     dispatch_grouped_items,
     partition_items,
+    resolve_lane_model,
 )
 
 # --- Fixtures ---
@@ -150,6 +151,27 @@ class TestPartitionItems:
         fast, slow = partition_items(items)
         assert len(fast) == 2
         assert len(slow) == 2
+
+
+class TestResolveLaneModel:
+    def test_no_fast_model_preserves_base(self):
+        # Default-off: every lane gets the base model (prior behavior).
+        assert resolve_lane_model("fast", "sonnet") == "sonnet"
+        assert resolve_lane_model("slow", "sonnet") == "sonnet"
+
+    def test_fast_lane_uses_fast_model(self):
+        assert resolve_lane_model("fast", "sonnet", "haiku") == "haiku"
+
+    def test_slow_lane_ignores_fast_model(self):
+        assert resolve_lane_model("slow", "sonnet", "haiku") == "sonnet"
+
+    def test_none_base_model_passthrough(self):
+        assert resolve_lane_model("slow", None, "haiku") is None
+        assert resolve_lane_model("fast", None, "haiku") == "haiku"
+
+    def test_empty_fast_model_is_noop(self):
+        # An empty string is falsy — treated as unset, not an override.
+        assert resolve_lane_model("fast", "sonnet", "") == "sonnet"
 
 
 # --- DispatchLedger ---
@@ -766,6 +788,66 @@ class TestLaneDispatcher:
         # Slow lane second
         assert callback_calls[1]["lane"] == "slow"
         assert callback_calls[1]["slot_key"] == "a/b#2"
+
+    def test_dispatch_fast_model_routes_per_lane(self, ld_no_slots):
+        callback_calls = []
+
+        def cb(**kwargs):
+            callback_calls.append(kwargs)
+            return True
+
+        ld = LaneDispatcher(
+            slot_manager=ld_no_slots.slot_manager,
+            dispatch_callback=cb,
+        )
+
+        items = [
+            make_item(repo="a/b", number=1, types=["assigned_issue"]),  # fast
+            make_item(repo="a/b", number=2, types=["pr_update"]),  # slow
+        ]
+        ld.dispatch(items, model="sonnet", fast_model="haiku")
+        # Fast lane gets the cheaper model, slow lane keeps the base model.
+        assert callback_calls[0]["lane"] == "fast"
+        assert callback_calls[0]["model"] == "haiku"
+        assert callback_calls[1]["lane"] == "slow"
+        assert callback_calls[1]["model"] == "sonnet"
+
+    def test_dispatch_fast_model_from_env(self, ld_no_slots, monkeypatch):
+        callback_calls = []
+
+        def cb(**kwargs):
+            callback_calls.append(kwargs)
+            return True
+
+        monkeypatch.setenv("BOB_PM_FAST_LANE_MODEL", "haiku")
+        ld = LaneDispatcher(
+            slot_manager=ld_no_slots.slot_manager,
+            dispatch_callback=cb,
+        )
+        items = [make_item(repo="a/b", number=1, types=["assigned_issue"])]
+        ld.dispatch(items, model="sonnet")
+        assert callback_calls[0]["model"] == "haiku"
+
+    def test_dispatch_no_fast_model_preserves_single_model(
+        self, ld_no_slots, monkeypatch
+    ):
+        callback_calls = []
+
+        def cb(**kwargs):
+            callback_calls.append(kwargs)
+            return True
+
+        monkeypatch.delenv("BOB_PM_FAST_LANE_MODEL", raising=False)
+        ld = LaneDispatcher(
+            slot_manager=ld_no_slots.slot_manager,
+            dispatch_callback=cb,
+        )
+        items = [
+            make_item(repo="a/b", number=1, types=["assigned_issue"]),  # fast
+            make_item(repo="a/b", number=2, types=["pr_update"]),  # slow
+        ]
+        ld.dispatch(items, model="sonnet")
+        assert all(c["model"] == "sonnet" for c in callback_calls)
 
     def test_dispatch_respects_cap(self, ld_no_slots):
         callback_calls = []


### PR DESCRIPTION
## What

Adds per-lane model routing to PM dispatch so the **fast lane** (notifications, assigned-issue triage — everything *not* in `SLOW_LANE_TYPES`) can run on a cheaper model than the **slow lane** (PR reviews, CI diagnostics, Greptile, merge conflicts).

- New `resolve_lane_model(lane, base_model, fast_model)` helper.
- `LaneDispatcher.dispatch()` gains a `fast_model` param, falling back to the `BOB_PM_FAST_LANE_MODEL` env var.
- **Default-off**: with `fast_model` unset, every lane routes to the base `model` — identical to prior behavior.

This mirrors the bash runtime lever already committed in Bob's repo (`project-monitoring-dispatch.sh`). The bash path is the primary runtime; this keeps the Python design-spec in lockstep and tested.

## Why

Answers Erik's question in ErikBjare/bob#860: *"Could an even cheaper model than Sonnet handle some of the PM stuff?"* The fast lane is the low-intelligence-needed partition, so it's the natural place to A/B a cheaper model. Default-off + reversible means it's a safe lever to flip, not a quality gamble.

## Tests

8 new tests (5 pure-function + 3 dispatch-level incl. env-var fallback). Full suite: 95 passed. mypy clean.

Ref: ErikBjare/bob#860