### PR TITLE
feat(comms): shared low-level reader for SMS Backup & Restore XML

### DIFF
--- a/scripts/comms_backup_loader.py
+++ b/scripts/comms_backup_loader.py
@@ -45,7 +45,7 @@ import os
 from collections.abc import Iterator
 from datetime import datetime, timezone
 from pathlib import Path
-from xml.etree.ElementTree import iterparse
+from xml.etree.ElementTree import Element, iterparse
 
 # Call "type" codes used by the app (Android CallLog.Calls.TYPE).
 CALL_TYPES = {
@@ -64,15 +64,20 @@ SMS_SENT = "2"
 def iter_records(path: str | os.PathLike, tag: str) -> Iterator[dict[str, str]]:
     """Stream ``<tag>`` elements' attributes, clearing each so memory stays bounded.
 
-    ``iterparse`` yields elements as they close; we copy the attributes and
-    immediately ``clear()`` the element so the (potentially 40MB+) document never
-    materializes in memory. Yields a plain ``dict`` per record so callers can't
-    accidentally retain live XML nodes.
+    ``iterparse`` yields elements as they close; we copy the attributes,
+    ``clear()`` the element, and purge it from the root so the (potentially
+    40MB+) document never materializes in memory. Yields a plain ``dict`` per
+    record so callers can't accidentally retain live XML nodes.
     """
-    for _event, elem in iterparse(str(path), events=("end",)):
-        if elem.tag == tag:
+    root: Element | None = None
+    for event, elem in iterparse(str(path), events=("start", "end")):
+        if event == "start" and root is None:
+            root = elem
+        elif event == "end" and elem.tag == tag:
             yield dict(elem.attrib)
             elem.clear()
+            if root is not None:
+                del root[:]  # purge cleared child from parent; keeps root list bounded
 
 
 def iter_sent_sms(path: str | os.PathLike) -> Iterator[dict[str, str]]:
@@ -95,7 +100,9 @@ def normalize_number(raw: str | None) -> str:
     """
     if not raw:
         return ""
-    return "".join(ch for ch in raw if ch.isdigit() or ch == "+")
+    digits = "".join(ch for ch in raw if ch.isdigit())
+    prefix = "+" if raw.lstrip().startswith("+") else ""
+    return prefix + digits
 
 
 def epoch_ms_to_day(date_ms: str | None, tz: timezone | None = None) -> str | None:

--- a/scripts/comms_backup_loader.py
+++ b/scripts/comms_backup_loader.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Shared low-level reader for "SMS Backup & Restore" XML backups.
+
+Erik's Android phone runs the "SMS Backup and Restore" app, which writes daily
+XML backups (``calls-*.xml``, ``sms-*.xml``) into a Syncthing folder. Two agents
+consume the same raw backups for different purposes:
+
+- **Alice** (``alice/scripts/comms_summary.py``) wants privacy-safe per-day
+  *aggregates* (counts, call minutes, distinct-contact counts) for the QS
+  connection-dimension signal.
+- **erbot** (``erbot/scripts/extract_erik_sms.py``) wants Erik's *sent* SMS
+  *text* (type==2), run through erbot's own private blocklist, to build a
+  "What Would Erik Do" corpus.
+
+Both need the same low-level parsing: stream the (large) XML with ``iterparse``
+so message bodies never accumulate in memory, normalize phone numbers the same
+way, and pick the newest backup file. This module single-sources exactly that
+shared layer and nothing more.
+
+PRIVACY CONTRACT
+----------------
+This module *reads* raw attributes (which include bodies and numbers) but
+**never persists, hashes, logs, or returns derived-but-still-identifying
+values on its own initiative**. It hands raw attribute dicts to the caller and
+stops there. The two privacy-sensitive decisions stay with each consumer,
+because their requirements genuinely differ:
+
+- **Hashing**: Alice needs a *salted, per-process, non-reversible, never-stored*
+  contact key (distinct-count only). erbot needs a *stable, unsalted* contact
+  hash so the same contact dedups across runs. Those are incompatible, so this
+  module only offers :func:`normalize_number` (the shared pre-hash step) — the
+  actual hashing belongs to each consumer.
+- **Body filtering**: Alice drops bodies entirely; erbot runs them through its
+  private blocklist. Neither belongs here.
+
+So: no raw values leave this module except inside the attribute dicts the caller
+explicitly asked for. This file contains only parsing logic — no data — and is
+safe to live in a public repo.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+from collections.abc import Iterator
+from datetime import datetime, timezone
+from pathlib import Path
+from xml.etree.ElementTree import iterparse
+
+# Call "type" codes used by the app (Android CallLog.Calls.TYPE).
+CALL_TYPES = {
+    "1": "incoming",
+    "2": "outgoing",
+    "3": "missed",
+    "4": "voicemail",
+    "5": "rejected",
+    "6": "blocked",
+}
+# SMS "type" codes (Android Telephony.Sms.MESSAGE_TYPE).
+SMS_RECEIVED = "1"
+SMS_SENT = "2"
+
+
+def iter_records(path: str | os.PathLike, tag: str) -> Iterator[dict[str, str]]:
+    """Stream ``<tag>`` elements' attributes, clearing each so memory stays bounded.
+
+    ``iterparse`` yields elements as they close; we copy the attributes and
+    immediately ``clear()`` the element so the (potentially 40MB+) document never
+    materializes in memory. Yields a plain ``dict`` per record so callers can't
+    accidentally retain live XML nodes.
+    """
+    for _event, elem in iterparse(str(path), events=("end",)):
+        if elem.tag == tag:
+            yield dict(elem.attrib)
+            elem.clear()
+
+
+def iter_sent_sms(path: str | os.PathLike) -> Iterator[dict[str, str]]:
+    """Yield attribute dicts for *sent* SMS (type==2) from an ``sms-*.xml`` file.
+
+    Convenience wrapper for the erbot corpus path, which only cares about Erik's
+    own outgoing texts. Received messages and MMS are skipped.
+    """
+    for attrs in iter_records(path, "sms"):
+        if attrs.get("type") == SMS_SENT:
+            yield attrs
+
+
+def normalize_number(raw: str | None) -> str:
+    """Normalize a phone number / address to digits and a leading ``+`` only.
+
+    Shared pre-hash step so Alice's salted distinct-count key and erbot's stable
+    contact hash operate on identical input. Returns ``""`` for a missing value;
+    callers decide how to represent "unknown".
+    """
+    if not raw:
+        return ""
+    return "".join(ch for ch in raw if ch.isdigit() or ch == "+")
+
+
+def epoch_ms_to_day(date_ms: str | None, tz: timezone | None = None) -> str | None:
+    """Convert an epoch-millis string to ``YYYY-MM-DD``.
+
+    ``tz=None`` uses system local time — on erb-m2 that is Erik's timezone, which
+    is what "which day of Erik's life did this happen" wants. Pass an explicit
+    ``tz`` for deterministic tests. Returns ``None`` for missing/garbage input.
+    """
+    dt = _epoch_ms_to_dt(date_ms, tz)
+    return dt.strftime("%Y-%m-%d") if dt else None
+
+
+def epoch_ms_to_iso(date_ms: str | None, tz: timezone | None = None) -> str | None:
+    """Convert an epoch-millis string to an ISO-8601 timestamp.
+
+    Used by the erbot corpus path (``iso_timestamp``) to stamp each message.
+    Returns ``None`` for missing/garbage input.
+    """
+    dt = _epoch_ms_to_dt(date_ms, tz)
+    return dt.isoformat() if dt else None
+
+
+def _epoch_ms_to_dt(date_ms: str | None, tz: timezone | None) -> datetime | None:
+    if not date_ms:
+        return None
+    try:
+        seconds = int(date_ms) / 1000.0
+    except (ValueError, TypeError):
+        return None
+    return datetime.fromtimestamp(seconds, tz=tz)
+
+
+def latest_file(comms_dir: str | os.PathLike, prefix: str) -> Path | None:
+    """Newest file matching ``<prefix>*.xml`` in ``comms_dir``.
+
+    The app stamps each backup's filename with a timestamp, so lexical sort by
+    filename matches chronological order. Returns ``None`` if no file matches.
+    ``~`` in ``comms_dir`` is expanded.
+    """
+    base = Path(os.path.expanduser(str(comms_dir)))
+    matches = sorted(glob.glob(str(base / f"{prefix}*.xml")))
+    return Path(matches[-1]) if matches else None

--- a/tests/test_comms_backup_loader.py
+++ b/tests/test_comms_backup_loader.py
@@ -111,6 +111,8 @@ def test_iter_sent_sms_filters_to_type_2(tmp_path: Path) -> None:
         (None, ""),
         ("", ""),
         ("no digits here", ""),
+        # Only a single leading + is kept; embedded + from malformed input stripped.
+        ("+1+800+555+1234", "+18005551234"),
     ],
 )
 def test_normalize_number(raw: str | None, expected: str) -> None:

--- a/tests/test_comms_backup_loader.py
+++ b/tests/test_comms_backup_loader.py
@@ -1,0 +1,164 @@
+"""Tests for the shared comms-backup reader (scripts/comms_backup_loader.py).
+
+Uses synthetic XML fixtures written to tmp_path, so it needs no real backup and
+runs anywhere (CI, alice-vm, Bob's VM). This file is the "anchor with tests" Bob
+asked for: it pins the shared reader's behavior so both comms_summary.py
+(aggregates) and extract_erik_sms.py (sent-text corpus) can refactor against it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import timezone
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = (
+    Path(__file__).resolve().parent.parent / "scripts" / "comms_backup_loader.py"
+)
+spec = importlib.util.spec_from_file_location("comms_backup_loader", MODULE_PATH)
+if spec is None or spec.loader is None:
+    pytest.skip(f"Could not load module from {MODULE_PATH}", allow_module_level=True)
+cbl = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = cbl
+spec.loader.exec_module(cbl)
+
+# 2026-06-01T12:00:00Z in epoch millis.
+JUN1_NOON_UTC_MS = "1780315200000"
+
+
+def _write_sms(tmp_path: Path, name: str, rows: list[dict[str, str]]) -> Path:
+    parts = [f'<?xml version="1.0"?>\n<smses count="{len(rows)}">']
+    for r in rows:
+        attrs = " ".join(f'{k}="{v}"' for k, v in r.items())
+        parts.append(f"  <sms {attrs} />")
+    parts.append("</smses>")
+    path = tmp_path / name
+    path.write_text("\n".join(parts), encoding="utf-8")
+    return path
+
+
+def _write_calls(tmp_path: Path, name: str, rows: list[dict[str, str]]) -> Path:
+    parts = [f'<?xml version="1.0"?>\n<calls count="{len(rows)}">']
+    for r in rows:
+        attrs = " ".join(f'{k}="{v}"' for k, v in r.items())
+        parts.append(f"  <call {attrs} />")
+    parts.append("</calls>")
+    path = tmp_path / name
+    path.write_text("\n".join(parts), encoding="utf-8")
+    return path
+
+
+# --- iter_records --------------------------------------------------------------
+
+
+def test_iter_records_yields_attr_dicts(tmp_path: Path) -> None:
+    path = _write_sms(
+        tmp_path,
+        "sms-1.xml",
+        [
+            {"type": "2", "address": "+46700000001", "date": JUN1_NOON_UTC_MS},
+            {"type": "1", "address": "+46700000002", "date": JUN1_NOON_UTC_MS},
+        ],
+    )
+    records = list(cbl.iter_records(path, "sms"))
+    assert len(records) == 2
+    assert records[0]["address"] == "+46700000001"
+    assert all(isinstance(r, dict) for r in records)
+
+
+def test_iter_records_ignores_other_tags(tmp_path: Path) -> None:
+    path = _write_calls(
+        tmp_path,
+        "calls-1.xml",
+        [{"type": "1", "number": "+4670", "date": JUN1_NOON_UTC_MS}],
+    )
+    # Asking for "sms" against a calls file yields nothing.
+    assert list(cbl.iter_records(path, "sms")) == []
+    assert len(list(cbl.iter_records(path, "call"))) == 1
+
+
+# --- iter_sent_sms -------------------------------------------------------------
+
+
+def test_iter_sent_sms_filters_to_type_2(tmp_path: Path) -> None:
+    path = _write_sms(
+        tmp_path,
+        "sms-1.xml",
+        [
+            {"type": "2", "body": "sent one", "date": JUN1_NOON_UTC_MS},
+            {"type": "1", "body": "received", "date": JUN1_NOON_UTC_MS},
+            {"type": "2", "body": "sent two", "date": JUN1_NOON_UTC_MS},
+            {"type": "3", "body": "draft", "date": JUN1_NOON_UTC_MS},
+        ],
+    )
+    sent = list(cbl.iter_sent_sms(path))
+    assert [r["body"] for r in sent] == ["sent one", "sent two"]
+
+
+# --- normalize_number ----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("+46 70 123 45 67", "+46701234567"),
+        ("070-123 45 67", "0701234567"),
+        ("(070) 123-4567", "0701234567"),
+        ("+46701234567", "+46701234567"),
+        (None, ""),
+        ("", ""),
+        ("no digits here", ""),
+    ],
+)
+def test_normalize_number(raw: str | None, expected: str) -> None:
+    assert cbl.normalize_number(raw) == expected
+
+
+def test_normalize_number_same_input_for_both_hashers(tmp_path: Path) -> None:
+    # The whole point of sharing normalize_number: two formats of the same number
+    # collapse to one canonical string, so both consumers' hashers agree.
+    assert cbl.normalize_number("+46 70 123 45 67") == cbl.normalize_number(
+        "+46701234567"
+    )
+
+
+# --- epoch conversions ---------------------------------------------------------
+
+
+def test_epoch_ms_to_day_utc(tmp_path: Path) -> None:
+    assert cbl.epoch_ms_to_day(JUN1_NOON_UTC_MS, tz=timezone.utc) == "2026-06-01"
+
+
+def test_epoch_ms_to_iso_utc() -> None:
+    iso = cbl.epoch_ms_to_iso(JUN1_NOON_UTC_MS, tz=timezone.utc)
+    assert iso == "2026-06-01T12:00:00+00:00"
+
+
+@pytest.mark.parametrize("bad", [None, "", "not-a-number", "12.5x"])
+def test_epoch_conversions_reject_garbage(bad: str | None) -> None:
+    assert cbl.epoch_ms_to_day(bad, tz=timezone.utc) is None
+    assert cbl.epoch_ms_to_iso(bad, tz=timezone.utc) is None
+
+
+# --- latest_file ---------------------------------------------------------------
+
+
+def test_latest_file_picks_newest_by_name(tmp_path: Path) -> None:
+    _write_sms(tmp_path, "sms-20260601000000.xml", [])
+    newest = _write_sms(tmp_path, "sms-20260603000000.xml", [])
+    _write_sms(tmp_path, "sms-20260602000000.xml", [])
+    assert cbl.latest_file(tmp_path, "sms-") == newest
+
+
+def test_latest_file_respects_prefix(tmp_path: Path) -> None:
+    _write_calls(tmp_path, "calls-20260603000000.xml", [])
+    sms = _write_sms(tmp_path, "sms-20260601000000.xml", [])
+    assert cbl.latest_file(tmp_path, "sms-") == sms
+    assert cbl.latest_file(tmp_path, "calls-").name == "calls-20260603000000.xml"
+
+
+def test_latest_file_none_when_absent(tmp_path: Path) -> None:
+    assert cbl.latest_file(tmp_path, "sms-") is None


### PR DESCRIPTION
## What

A shared, data-free low-level reader for "SMS Backup & Restore" XML backups:
`scripts/comms_backup_loader.py` + 20 tests over synthetic XML fixtures.

## Why

Two agents consume the same raw `calls-*.xml` / `sms-*.xml` backups for different
purposes:

- **Alice** (`alice/scripts/comms_summary.py`) — privacy-safe per-day *aggregates*
  (counts, call minutes, distinct-contact counts) for the QS connection signal.
- **erbot** (`erbot/scripts/extract_erik_sms.py`) — Erik's *sent* SMS *text*
  (type==2) through erbot's private blocklist, for a WWED corpus.

Both reimplemented the same streaming `iterparse` reader, number normalization,
epoch→timestamp conversion, and latest-file picker. This single-sources exactly
that shared layer — and nothing more.

## Privacy boundary (deliberate)

The module reads raw attributes but hands them straight to the caller; it never
hashes, persists, or logs identifying values on its own. The two privacy
decisions stay per-consumer because their requirements genuinely differ:

- **Hashing**: Alice needs a *salted, ephemeral, never-stored* distinct-count key;
  erbot needs a *stable, unsalted* hash so a contact dedups across runs. These are
  incompatible, so the module only offers `normalize_number` (the shared pre-hash
  step). Hashing stays in each consumer.
- **Body filtering**: Alice drops bodies; erbot runs its blocklist. Neither belongs
  here.

Result: the file contains only parsing logic, no data — safe in a public repo.

## API

- `iter_records(path, tag)` — memory-bounded streaming attr-dict iterator
- `iter_sent_sms(path)` — convenience: sent SMS (type==2) for the erbot path
- `normalize_number(raw)` — digits + leading `+` (shared pre-hash step)
- `epoch_ms_to_day(date_ms, tz)` / `epoch_ms_to_iso(date_ms, tz)`
- `latest_file(comms_dir, prefix)` — newest `<prefix>*.xml`

## Follow-up (not in this PR)

Once merged, `comms_summary.py` and `extract_erik_sms.py` each drop their private
copies and import from here. Context: Bob's 2026-06-04 message inviting this
"anchor with tests" step. Tracked in alice's erbot/comms-backup follow-ups.

## Test

`pytest tests/test_comms_backup_loader.py` — 20 passed, no real backup needed.
