### PR TITLE
feat(imagen): add execute function for image_gen blocks with inline webui preview

### DIFF
--- a/plugins/gptme-imagen/src/gptme_imagen/tools/image_gen.py
+++ b/plugins/gptme-imagen/src/gptme_imagen/tools/image_gen.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import base64
 import os
+from collections.abc import Generator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
@@ -899,6 +900,87 @@ def get_generation_history(
     return tracker.get_generation_history(limit, provider)
 
 
+def _execute_image_gen_block(
+    content: str | None,
+    args: list[str] | None,
+    kwargs: dict[str, str] | None,
+) -> Generator[Any, None, None]:
+    """Execute an image_gen block, yielding output with image file attachments."""
+    if not _HAS_GPTME:
+        return
+
+    from gptme.constants import DECLINED_CONTENT  # type: ignore[import-untyped]
+    from gptme.hooks import (  # type: ignore[import-untyped]
+        ConfirmAction,
+        get_confirmation,
+    )
+    from gptme.message import Message  # type: ignore[import-untyped]
+    from gptme.tools.python import (  # type: ignore[import-untyped]
+        _get_ipython,
+        capture_and_display,
+    )
+
+    if content is None:
+        yield Message("system", "No code to execute")
+        return
+
+    code = content.strip()
+
+    confirm = get_confirmation()
+    if confirm.action != ConfirmAction.CONFIRM:
+        yield Message("system", DECLINED_CONTENT)
+        return
+
+    ipython = _get_ipython()
+
+    with capture_and_display() as (stdout_capture, _stderr_capture):
+        result = ipython.run_cell(code, silent=False, store_history=False)
+
+    captured_stdout = stdout_capture.getvalue()
+
+    if result.error_in_exec:
+        error_text = f"Error: {result.error_in_exec}"
+        if captured_stdout:
+            error_text = f"{captured_stdout.strip()}\n{error_text}"
+        yield Message("system", error_text)
+        return
+
+    # If the code returned a Message (e.g. from view_image), yield it directly
+    if isinstance(result.result, Message):
+        yield result.result
+        return
+
+    # Collect image paths from ImageResult return values for inline preview
+    image_files: list[Path] = []
+    if isinstance(result.result, ImageResult):
+        image_files.append(result.result.image_path.absolute())
+    elif isinstance(result.result, list):
+        for r in result.result:
+            if isinstance(r, ImageResult):
+                image_files.append(r.image_path.absolute())
+
+    output = captured_stdout.strip()
+    if not output:
+        if image_files:
+            names = ", ".join(p.name for p in image_files)
+            output = f"Generated {len(image_files)} image(s): {names}"
+        else:
+            output = "Executed image_gen block"
+
+    # Yield the text result with image files attached (webui renders these inline)
+    yield Message("system", output, files=image_files if image_files else None)
+
+    # Also yield view_image messages so the LLM can see the generated images
+    if image_files:
+        try:
+            from gptme.tools.vision import view_image  # type: ignore[import-untyped]
+
+            for path in image_files:
+                yield view_image(path)
+        except ImportError:
+            pass
+
+
 # Tool specification (only available when gptme is installed)
 def _make_tool_spec() -> Any:
     if not _HAS_GPTME:
@@ -1166,6 +1248,7 @@ generate_image(
 > System: 🎨 Generating with gemini (using 1 reference image)...
 > ✅ Image saved: portrait_with_accessories.png
     """,
+        execute=_execute_image_gen_block,
         functions=[
             generate_image,
             generate_variation,

--- a/plugins/gptme-imagen/src/gptme_imagen/tools/image_gen.py
+++ b/plugins/gptme-imagen/src/gptme_imagen/tools/image_gen.py
@@ -979,6 +979,12 @@ def _execute_image_gen_block(
                 yield view_image(path)
         except ImportError:
             pass
+        except Exception:
+            import logging
+
+            logging.getLogger(__name__).exception(
+                "Failed to display generated image(s) to LLM"
+            )
 
 
 # Tool specification (only available when gptme is installed)

--- a/plugins/gptme-imagen/tests/conftest.py
+++ b/plugins/gptme-imagen/tests/conftest.py
@@ -14,8 +14,6 @@ import pytest
 # traversing .b.c via attribute access — NOT via sys.modules["a.b.c"] directly.
 # So the mock objects must be properly linked: sys.modules["a"].b must be sys.modules["a.b"].
 if "gptme" not in sys.modules:
-    from unittest.mock import MagicMock
-
     _gptme = MagicMock()
     _gptme_tools = MagicMock()
     _gptme_tools_vision = MagicMock()

--- a/plugins/gptme-imagen/tests/conftest.py
+++ b/plugins/gptme-imagen/tests/conftest.py
@@ -14,21 +14,54 @@ import pytest
 # traversing .b.c via attribute access — NOT via sys.modules["a.b.c"] directly.
 # So the mock objects must be properly linked: sys.modules["a"].b must be sys.modules["a.b"].
 if "gptme" not in sys.modules:
+    from unittest.mock import MagicMock
+
     _gptme = MagicMock()
     _gptme_tools = MagicMock()
     _gptme_tools_vision = MagicMock()
     _gptme_tools_base = MagicMock()
+    _gptme_tools_python = MagicMock()
     _gptme_config = MagicMock()
+    _gptme_message = MagicMock()
+    _gptme_hooks = MagicMock()
+    _gptme_constants = MagicMock()
+
     # Link the hierarchy so attribute traversal works correctly
     _gptme.tools = _gptme_tools
     _gptme_tools.vision = _gptme_tools_vision
     _gptme_tools.base = _gptme_tools_base
+    _gptme_tools.python = _gptme_tools_python
     _gptme.config = _gptme_config
+    _gptme.message = _gptme_message
+    _gptme.hooks = _gptme_hooks
+    _gptme.constants = _gptme_constants
+
+    # Set up ConfirmAction enum-like mock
+    _confirm_action = MagicMock()
+    _confirm_action.CONFIRM = "confirm"
+    _gptme_hooks.ConfirmAction = _confirm_action
+
+    # Set up DECLINED_CONTENT
+    _gptme_constants.DECLINED_CONTENT = "Declined."
+
+    # Set up a minimal Message class (not MagicMock) so isinstance() works
+    class _MessageStub:
+        def __init__(self, role: str, content: str, files=None, **kwargs):
+            self.role = role
+            self.content = content
+            self.files = files
+
+    _gptme_message.Message = _MessageStub
+
     sys.modules["gptme"] = _gptme
     sys.modules["gptme.tools"] = _gptme_tools
     sys.modules["gptme.tools.vision"] = _gptme_tools_vision
     sys.modules["gptme.tools.base"] = _gptme_tools_base
+    sys.modules["gptme.tools.python"] = _gptme_tools_python
     sys.modules["gptme.config"] = _gptme_config
+    sys.modules["gptme.message"] = _gptme_message
+    sys.modules["gptme.hooks"] = _gptme_hooks
+    sys.modules["gptme.constants"] = _gptme_constants
 
 if "openai" not in sys.modules:
     sys.modules["openai"] = MagicMock()

--- a/plugins/gptme-imagen/tests/test_execute_block.py
+++ b/plugins/gptme-imagen/tests/test_execute_block.py
@@ -1,0 +1,141 @@
+"""Tests for the image_gen block execute function and webui preview wiring."""
+
+from contextlib import contextmanager
+from io import StringIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def fake_image(tmp_path: Path) -> Path:
+    """A minimal PNG file for testing."""
+    png = tmp_path / "generated_test.png"
+    # Minimal 1x1 white PNG (valid PNG header + IHDR + IDAT + IEND)
+    png.write_bytes(
+        bytes.fromhex(
+            "89504e470d0a1a0a"  # PNG signature
+            "0000000d49484452"  # IHDR chunk length+type
+            "00000001000000010802000000906801f8"  # 1x1 RGB
+            "0000000a4944415408d76360000000020001e221bc330000000049454e44ae426082"
+        )
+    )
+    return png
+
+
+def _make_image_result(path: Path):
+    from gptme_imagen.tools.image_gen import ImageResult
+
+    return ImageResult(
+        provider="gemini",
+        prompt="test prompt",
+        image_path=path,
+        metadata={"model": "imagen-3", "size": "1024x1024", "quality": "standard"},
+    )
+
+
+@contextmanager
+def _mock_capture_and_display(stdout_content: str = ""):
+    """Context manager mock for capture_and_display that returns StringIO objects."""
+    stdout = StringIO(stdout_content)
+    stderr = StringIO()
+    # Make getvalue() return the content
+    stdout.getvalue = lambda: stdout_content  # type: ignore[method-assign]
+    stderr.getvalue = lambda: ""  # type: ignore[method-assign]
+    yield stdout, stderr
+
+
+def _run_execute(code: str, ipy_result_value, stdout_content: str = "", ipy_error=None):
+    """Helper to run _execute_image_gen_block with mocked IPython."""
+    from gptme_imagen.tools.image_gen import _execute_image_gen_block
+
+    mock_ipy_result = MagicMock()
+    mock_ipy_result.result = ipy_result_value
+    mock_ipy_result.error_in_exec = ipy_error
+
+    mock_ipython = MagicMock()
+    mock_ipython.run_cell.return_value = mock_ipy_result
+
+    mock_confirm = MagicMock()
+    mock_confirm.action = "confirm"
+
+    with (
+        patch("gptme.hooks.get_confirmation", return_value=mock_confirm),
+        patch("gptme.hooks.ConfirmAction") as mock_action_cls,
+        patch("gptme.tools.python._get_ipython", return_value=mock_ipython),
+        patch(
+            "gptme.tools.python.capture_and_display",
+            side_effect=lambda: _mock_capture_and_display(stdout_content),
+        ),
+    ):
+        mock_action_cls.CONFIRM = "confirm"
+        return list(_execute_image_gen_block(code, [], {}))
+
+
+class TestExecuteImageGenBlock:
+    """Tests for _execute_image_gen_block."""
+
+    def test_execute_function_is_wired(self):
+        """ToolSpec should have an execute function set."""
+        from gptme_imagen.tools.image_gen import image_gen_tool
+
+        assert image_gen_tool is not None, "image_gen_tool requires gptme installed"
+        assert image_gen_tool.execute is not None, "execute must be wired into ToolSpec"
+
+    def test_yields_message_with_image_files(self, fake_image: Path):
+        """Execute function should yield a Message with files=[image_path]."""
+        image_result = _make_image_result(fake_image)
+        messages = _run_execute(
+            "generate_image('sunset')", image_result, "Saved to: test.png"
+        )
+
+        assert len(messages) >= 1
+        first = messages[0]
+        assert first.files is not None, "Message needs files for inline webui preview"
+        assert len(first.files) >= 1
+        # The absolute path should be in the files list
+        assert fake_image.absolute() in [Path(f) for f in first.files]
+
+    def test_yields_no_files_when_no_image_result(self):
+        """Execute function should yield a plain message when no ImageResult is returned."""
+        messages = _run_execute("print('hello')", "some string result", "hello")
+
+        assert len(messages) >= 1
+        first = messages[0]
+        assert not first.files
+
+    def test_handles_error_gracefully(self):
+        """Execute function should yield an error message on IPython execution error."""
+        messages = _run_execute(
+            "generate_image('test')",
+            None,
+            "",
+            ipy_error=ValueError("API key not set"),
+        )
+
+        assert len(messages) == 1
+        assert "Error" in messages[0].content
+
+    def test_list_of_image_results(self, tmp_path: Path, fake_image: Path):
+        """Execute function should handle list of ImageResults (batch generation)."""
+        img2 = tmp_path / "generated_test2.png"
+        img2.write_bytes(fake_image.read_bytes())
+
+        image_results = [_make_image_result(fake_image), _make_image_result(img2)]
+        messages = _run_execute(
+            "batch_generate(['a','b'])", image_results, "Generated 2 images"
+        )
+
+        assert len(messages) >= 1
+        first = messages[0]
+        assert first.files is not None
+        assert len(first.files) == 2
+
+    def test_none_content_yields_error_message(self):
+        """Execute function should handle None content gracefully."""
+        from gptme_imagen.tools.image_gen import _execute_image_gen_block
+
+        messages = list(_execute_image_gen_block(None, [], {}))
+        assert len(messages) == 1
+        assert "No code" in messages[0].content

--- a/plugins/gptme-imagen/tests/test_execute_block.py
+++ b/plugins/gptme-imagen/tests/test_execute_block.py
@@ -180,7 +180,9 @@ class TestExecuteImageGenBlock:
         assert len(messages) == 1
         assert messages[0].content == "Declined."
 
-    def test_view_image_failure_does_not_abort_successful_result(self, fake_image: Path):
+    def test_view_image_failure_does_not_abort_successful_result(
+        self, fake_image: Path
+    ):
         """A failing view_image() call must not undo the successful attachment message."""
         image_result = _make_image_result(fake_image)
 

--- a/plugins/gptme-imagen/tests/test_execute_block.py
+++ b/plugins/gptme-imagen/tests/test_execute_block.py
@@ -180,9 +180,7 @@ class TestExecuteImageGenBlock:
         assert len(messages) == 1
         assert messages[0].content == "Declined."
 
-    def test_view_image_failure_does_not_abort_successful_result(
-        self, fake_image: Path
-    ):
+    def test_view_image_failure_does_not_abort_successful_result(self, fake_image: Path):
         """A failing view_image() call must not undo the successful attachment message."""
         image_result = _make_image_result(fake_image)
 

--- a/plugins/gptme-imagen/tests/test_execute_block.py
+++ b/plugins/gptme-imagen/tests/test_execute_block.py
@@ -73,6 +73,35 @@ def _run_execute(code: str, ipy_result_value, stdout_content: str = "", ipy_erro
         return list(_execute_image_gen_block(code, [], {}))
 
 
+def _run_execute_with_action(
+    code: str, ipy_result_value, action: str, stdout_content: str = "", ipy_error=None
+):
+    """Helper to run _execute_image_gen_block with a custom confirmation action."""
+    from gptme_imagen.tools.image_gen import _execute_image_gen_block
+
+    mock_ipy_result = MagicMock()
+    mock_ipy_result.result = ipy_result_value
+    mock_ipy_result.error_in_exec = ipy_error
+
+    mock_ipython = MagicMock()
+    mock_ipython.run_cell.return_value = mock_ipy_result
+
+    mock_confirm = MagicMock()
+    mock_confirm.action = action
+
+    with (
+        patch("gptme.hooks.get_confirmation", return_value=mock_confirm),
+        patch("gptme.hooks.ConfirmAction") as mock_action_cls,
+        patch("gptme.tools.python._get_ipython", return_value=mock_ipython),
+        patch(
+            "gptme.tools.python.capture_and_display",
+            side_effect=lambda: _mock_capture_and_display(stdout_content),
+        ),
+    ):
+        mock_action_cls.CONFIRM = "confirm"
+        return list(_execute_image_gen_block(code, [], {}))
+
+
 class TestExecuteImageGenBlock:
     """Tests for _execute_image_gen_block."""
 
@@ -139,3 +168,30 @@ class TestExecuteImageGenBlock:
         messages = list(_execute_image_gen_block(None, [], {}))
         assert len(messages) == 1
         assert "No code" in messages[0].content
+
+    def test_declined_confirmation_yields_declined_message(self):
+        """Execute function should stop immediately when confirmation is declined."""
+        messages = _run_execute_with_action(
+            "generate_image('test')",
+            None,
+            action="skip",
+        )
+
+        assert len(messages) == 1
+        assert messages[0].content == "Declined."
+
+    def test_view_image_failure_does_not_abort_successful_result(
+        self, fake_image: Path
+    ):
+        """A failing view_image() call must not undo the successful attachment message."""
+        image_result = _make_image_result(fake_image)
+
+        with patch(
+            "gptme.tools.vision.view_image",
+            side_effect=RuntimeError("bad image preview"),
+        ):
+            messages = _run_execute("generate_image('sunset')", image_result)
+
+        assert len(messages) == 1
+        assert messages[0].files is not None
+        assert fake_image.absolute() in [Path(f) for f in messages[0].files]


### PR DESCRIPTION
## Summary

- `image_gen` ToolSpec was missing an `execute` function — code blocks silently produced no output when the agent used them
- Add `_execute_image_gen_block()` that runs the block via IPython, captures `ImageResult` return values, and attaches image files to the output `Message` via `files=[]`
- The webui already renders `message.files` as inline `<img>` tags, so this fix closes the last gap in the end-to-end imagen preview flow
- Also yields `view_image()` messages so the LLM can see generated images in context
- Adds 6 tests covering the execute function and extends conftest.py with proper `Message`/`ConfirmAction` stubs for `isinstance()` correctness

## Background

Erik flagged ErikBjare/bob#841 as prematurely closed: "Premature close, finish the imagen work. I want a screenshot of a gptme webui session where the user asks to generate an image and the agent does it and displays it as a preview/attachment/artifact."

Root cause was two silent failures:
1. `image_gen` ToolSpec had no `execute` — blocks parsed but did nothing
2. `generate_image(view=True)` called `view_image()` internally but discarded the return `Message`

This PR fixes (1). The webui's `ChatMessage.tsx` already handles `message.files` rendering, so attaching the image path to the output message is sufficient for inline preview.

## Test plan

- [ ] `uv run pytest plugins/gptme-imagen/` — all 101 tests pass
- [ ] Live: start gptme with imagen plugin, ask agent to generate an image, verify it appears inline in webui