### PR TITLE
feat(self-merge): Greptile score floor — upstream greptile-merge-signal + wire into gate

### DIFF
--- a/scripts/github/README.md
+++ b/scripts/github/README.md
@@ -2,6 +2,38 @@
 
 Scripts for integrating GitHub context and repository management into AI agent workflows.
 
+## ⚠️ Self-merge / Greptile / PR-monitoring toolchain — READ BEFORE BUILDING
+
+If you're about to build PR monitoring, a Greptile review loop ("greploop"), self-merge logic,
+a stale-PR sweep, or a Greptile score check — **it already exists here.** This toolchain is shared
+across agents (Alice, Bob) and is hardened for scale. Don't rebuild a parallel; use or extend these.
+(Origin of this note: 2026-06 an agent rebuilt greploop + a sweep + a score parser that all already
+existed. See `scripts/workflow/read-the-task-before-reinvestigating` patterns.)
+
+**The canonical flow — drive a PR to merge ("greploop"):**
+
+| Step | Tool | Notes |
+|------|------|-------|
+| Discover stalled PRs | `activity-gate.sh` (has a Greptile score sweep) · `pr-queue-health.py` | event-driven; surfaces low-scored / stuck PRs |
+| Trigger / re-trigger review | `greptile-helper.sh` (anti-spam: flock, ack-detect, max-retriggers) · `pr-greptile-trigger.py` (batch) | NEVER post raw `@greptileai review` |
+| Read the score signal | `greptile-merge-signal.py` (summary score ≥ threshold + "Safe to merge") | reusable; default 5/5 |
+| Address findings, push | (agent session) | fix the code |
+| **Resolve addressed threads** | `resolve-greptile-threads.py` *(Alice-contributed)* | the `resolveReviewThread` mutation; fix-first |
+| Gate the merge | `self-merge-check.py` | CI green + Greptile present + no unresolved threads + **score floor** (`SELF_MERGE_MIN_GREPTILE_SCORE`, default 5/5) + category/sensitive-path filter |
+| Merge | `self-merge-if-eligible.sh` / `pr-address-wait-and-merge.sh` *(Bob)* | bounded poll-budget wait → merge |
+
+**Robustness patterns (tuned at scale — reuse, don't reinvent):**
+- **Rate limits**: gate on `github-rate-limit-health.sh` (`GH_RATE_LIMIT_HELPER`; `self-merge-check.py`
+  defers with exit 76). Re-check before expensive sub-steps, not just at cycle start.
+- **Fewer API calls**: fetch Greptile review data ONCE per PR and reuse (see `self-merge-check.py`'s
+  `_fetch_greptile_review_data` passed to both helpers). Don't spawn a per-PR subprocess that re-fetches.
+- **Caching**: key Greptile status by PR head-SHA — unchanged PRs skip the fetch.
+- **Pagination**: paginate `reviewThreads` (avoids silently undercounting unresolved threads).
+- **GraphQL attribution**: wrap GraphQL calls for consumption accounting.
+
+See also: `knowledge/research/2026-06-12-monitoring-robustness-alice-vs-bob.md` (Alice repo) and the
+greploop skill (greptileai/skills, MIT) for the upstream pattern this implements.
+
 ## Scripts
 
 ### context-gh.sh
@@ -285,6 +317,17 @@ python3 scripts/github/self-merge-check.py --workspace-repo myorg/myrepo <pr-url
 **Requirements:**
 - `gh` (GitHub CLI) installed and authenticated
 - Greptile installed on the target repo for review checking
+
+### greptile-merge-signal.py
+
+Evaluates whether a Greptile **summary comment** is strong enough for fast-path merge use:
+allowlisted bot login + "Safe to merge" + score ≥ threshold (default 5/5). A reusable score signal —
+`self-merge-check.py` wires it in as the **score floor** so resolving threads alone can't merge a
+low-scored PR. Parse failure does not block (the thread/category gates still apply).
+
+```bash
+python3 scripts/github/greptile-merge-signal.py --repo owner/repo 123   # JSON; exit 0 eligible, 1 not
+```
 
 ## Related
 

--- a/scripts/github/greptile-merge-signal.py
+++ b/scripts/github/greptile-merge-signal.py
@@ -63,9 +63,10 @@ def _parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def _env_enabled(name: str) -> bool:
+def _env_var_is_active(name: str) -> bool:
+    """Return True if the env var is set to a truthy value ("1", "true", "yes", "on")."""
     value = os.environ.get(name, "")
-    return value.strip().lower() not in {"1", "true", "yes", "on"}
+    return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _parse_bot_allowlist() -> set[str]:
@@ -166,7 +167,7 @@ def _latest_allowlisted_summary(
 
 def evaluate_summary_signal(repo: str, pr_number: int) -> SignalResult:
     threshold = _parse_threshold()
-    if not _env_enabled(DISABLE_ENV):
+    if _env_var_is_active(DISABLE_ENV):
         return SignalResult(
             eligible=False,
             repo=repo,

--- a/scripts/github/greptile-merge-signal.py
+++ b/scripts/github/greptile-merge-signal.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+# Upstreamed to gptme-contrib 2026-06-12 from Bob (TimeToBuildBob)'s
+# scripts/github/greptile-merge-signal.py, so Alice + Bob share one score signal.
+# Pairs with self-merge-check.py (the gate wires this in as a score floor) and the
+# resolveReviewThread primitive (resolve-greptile-threads.py); the greploop pattern
+# (greptileai/skills, MIT) is the broader fix→resolve→re-review→merge loop it serves.
+"""Evaluate whether a Greptile summary comment is strong enough for fast-path merge use.
+
+This is intentionally narrower than self-merge-check.py:
+- It only inspects Greptile summary issue comments
+- It requires an allowlisted bot login
+- It requires "Safe to merge"
+- It requires a minimum score threshold (default: 5/5)
+
+The goal is to define a reusable call surface for monitoring fast paths without
+weakening the main self-merge policy.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+from dataclasses import asdict, dataclass
+from typing import Any
+
+DEFAULT_BOT_ALLOWLIST = ("greptile-apps[bot]", "greptile-apps")
+DEFAULT_MIN_SCORE = 5
+DISABLE_ENV = "GREPTILE_MERGE_SIGNAL_DISABLED"
+BOT_ALLOWLIST_ENV = "GREPTILE_MERGE_SIGNAL_BOT_ALLOWLIST"
+MIN_SCORE_ENV = "GREPTILE_MERGE_SIGNAL_MIN_SCORE"
+
+SAFE_TO_MERGE_RE = re.compile(r"\bsafe to merge\b", re.IGNORECASE)
+SUMMARY_MARKER_RE = re.compile(r"greptile summary", re.IGNORECASE)
+SCORE_PATTERNS = (
+    re.compile(r"confidence\s+score[^0-9]*(?P<score>[0-5])\s*/\s*5", re.IGNORECASE),
+    re.compile(r"\bscore[^0-9]*(?P<score>[0-5])\s*/\s*5", re.IGNORECASE),
+)
+
+
+@dataclass
+class SignalResult:
+    eligible: bool
+    repo: str
+    pr_number: int
+    threshold: int
+    signal_kind: str
+    reason: str
+    summary_found: bool = False
+    safe_to_merge: bool = False
+    score: int | None = None
+    bot_login: str | None = None
+    comment_id: int | None = None
+    reviewed_at: str | None = None
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("pr_number", type=int)
+    return parser.parse_args()
+
+
+def _env_enabled(name: str) -> bool:
+    value = os.environ.get(name, "")
+    return value.strip().lower() not in {"1", "true", "yes", "on"}
+
+
+def _parse_bot_allowlist() -> set[str]:
+    raw = os.environ.get(BOT_ALLOWLIST_ENV, "")
+    if not raw.strip():
+        return {login.lower() for login in DEFAULT_BOT_ALLOWLIST}
+    return {entry.lower() for entry in raw.replace(",", " ").split() if entry.strip()}
+
+
+def _parse_threshold() -> int:
+    raw = os.environ.get(MIN_SCORE_ENV, "").strip()
+    if not raw:
+        return DEFAULT_MIN_SCORE
+    try:
+        value = int(raw)
+    except ValueError:
+        return DEFAULT_MIN_SCORE
+    if 0 <= value <= 5:
+        return value
+    return DEFAULT_MIN_SCORE
+
+
+def _run_gh(args: list[str], timeout: int = 30) -> str:
+    try:
+        result = subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    if result.returncode != 0:
+        return ""
+    return result.stdout
+
+
+def _parse_json_stream(raw: str) -> list[Any]:
+    values: list[Any] = []
+    decoder = json.JSONDecoder()
+    idx = 0
+    while idx < len(raw):
+        while idx < len(raw) and raw[idx].isspace():
+            idx += 1
+        if idx >= len(raw):
+            break
+        value, end = decoder.raw_decode(raw, idx)
+        values.append(value)
+        idx = end
+    return values
+
+
+def _load_comments(repo: str, pr_number: int) -> list[dict[str, Any]]:
+    raw = _run_gh(["api", f"repos/{repo}/issues/{pr_number}/comments", "--paginate"])
+    if not raw.strip():
+        return []
+    comments: list[dict[str, Any]] = []
+    for value in _parse_json_stream(raw):
+        if isinstance(value, list):
+            comments.extend(item for item in value if isinstance(item, dict))
+        elif isinstance(value, dict):
+            comments.append(value)
+    return comments
+
+
+def _extract_score(body: str) -> int | None:
+    for pattern in SCORE_PATTERNS:
+        match = pattern.search(body)
+        if match:
+            return int(match.group("score"))
+    return None
+
+
+def _latest_allowlisted_summary(
+    comments: list[dict[str, Any]], allowlist: set[str]
+) -> dict[str, Any] | None:
+    candidates: list[dict[str, Any]] = []
+    for comment in comments:
+        user = comment.get("user") or {}
+        login = str(user.get("login") or "").strip()
+        body = str(comment.get("body") or "")
+        if login.lower() not in allowlist:
+            continue
+        if not SUMMARY_MARKER_RE.search(body):
+            continue
+        candidates.append(comment)
+    if not candidates:
+        return None
+    return max(
+        candidates,
+        key=lambda comment: (
+            str(comment.get("updated_at") or ""),
+            str(comment.get("created_at") or ""),
+        ),
+    )
+
+
+def evaluate_summary_signal(repo: str, pr_number: int) -> SignalResult:
+    threshold = _parse_threshold()
+    if not _env_enabled(DISABLE_ENV):
+        return SignalResult(
+            eligible=False,
+            repo=repo,
+            pr_number=pr_number,
+            threshold=threshold,
+            signal_kind="disabled",
+            reason="disabled",
+        )
+
+    allowlist = _parse_bot_allowlist()
+    comments = _load_comments(repo, pr_number)
+    latest_summary = _latest_allowlisted_summary(comments, allowlist)
+    if latest_summary is None:
+        return SignalResult(
+            eligible=False,
+            repo=repo,
+            pr_number=pr_number,
+            threshold=threshold,
+            signal_kind="summary_comment",
+            reason="no_allowlisted_summary_comment",
+        )
+
+    login = str((latest_summary.get("user") or {}).get("login") or "").strip()
+    body = str(latest_summary.get("body") or "")
+    score = _extract_score(body)
+    safe_to_merge = bool(SAFE_TO_MERGE_RE.search(body))
+    result = SignalResult(
+        eligible=False,
+        repo=repo,
+        pr_number=pr_number,
+        threshold=threshold,
+        signal_kind="summary_comment",
+        reason="",
+        summary_found=True,
+        safe_to_merge=safe_to_merge,
+        score=score,
+        bot_login=login or None,
+        comment_id=latest_summary.get("id")
+        if isinstance(latest_summary.get("id"), int)
+        else None,
+        reviewed_at=str(
+            latest_summary.get("updated_at") or latest_summary.get("created_at") or ""
+        )
+        or None,
+    )
+
+    if not safe_to_merge:
+        result.reason = "safe_to_merge_missing"
+        return result
+    if score is None:
+        result.reason = "score_missing"
+        return result
+    if score < threshold:
+        result.reason = "score_below_threshold"
+        return result
+
+    result.eligible = True
+    result.reason = "positive_summary_comment"
+    return result
+
+
+def main() -> int:
+    args = _parse_args()
+    result = evaluate_summary_signal(args.repo, args.pr_number)
+    print(json.dumps(asdict(result), sort_keys=True))
+    return 0 if result.eligible else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -70,6 +70,7 @@ from pathlib import Path
 from typing import Any, cast
 
 MAX_GRAPHQL_PAGE_SIZE = 100
+DEFAULT_MIN_GREPTILE_SCORE = 5
 
 DOC_EXTENSIONS = {".md", ".rst", ".txt", ".adoc"}
 SPEC_LIKE_DOCS = {
@@ -1009,9 +1010,14 @@ def greptile_summary_score(repo: str, pr_number: int) -> int | None:
     if not signal.exists():
         return None
     try:
+        env = os.environ.copy()
+        # The self-merge gate owns its own enable/disable policy; don't let the
+        # standalone signal tool's disable flag silently neuter the floor.
+        env.pop("GREPTILE_MERGE_SIGNAL_DISABLED", None)
         proc = subprocess.run(
             [sys.executable, str(signal), "--repo", repo, str(pr_number)],
             capture_output=True,
+            env=env,
             text=True,
             timeout=30,
         )
@@ -1020,6 +1026,19 @@ def greptile_summary_score(repo: str, pr_number: int) -> int | None:
         return None
     score = data.get("score")
     return int(score) if isinstance(score, int) else None
+
+
+def _parse_self_merge_min_greptile_score() -> int:
+    raw = os.environ.get("SELF_MERGE_MIN_GREPTILE_SCORE", "").strip()
+    if not raw:
+        return DEFAULT_MIN_GREPTILE_SCORE
+    try:
+        value = int(raw)
+    except ValueError:
+        return DEFAULT_MIN_GREPTILE_SCORE
+    if 0 <= value <= 5:
+        return value
+    return DEFAULT_MIN_GREPTILE_SCORE
 
 
 def evaluate_pr(
@@ -1087,7 +1106,7 @@ def evaluate_pr(
     # evaluator (upstreamed from Bob). Parse failure (score None) does NOT block — the
     # thread/category gates still apply; this only catches a clear sub-floor score.
     if greptile["has_review"]:
-        min_score = int(os.environ.get("SELF_MERGE_MIN_GREPTILE_SCORE", "5"))
+        min_score = _parse_self_merge_min_greptile_score()
         score = greptile_summary_score(repo, number)
         if score is not None and score < min_score:
             result.reasons.append(f"Greptile score {score}/5 below floor {min_score}/5")

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -100,6 +100,19 @@ SENSITIVE_PATH_PREFIXES = (
     "scripts/session_bandit",
     "scripts/state-delta",
     "scripts/state_delta",
+    # Loop-orchestration entrypoints: the control path that selects work and
+    # drives autonomous/monitoring runs (and can itself trigger self-merges).
+    # A change here can alter how the loop gates its own merges, so it must go
+    # through human review. Prefixes (no extension) catch hyphen/underscore and
+    # nested layouts: scripts/autonomous-run.sh, scripts/autonomous-run-cc.sh,
+    # scripts/runs/autonomous/autonomous-loop.sh, scripts/runs/github/project-monitoring.sh.
+    "scripts/autonomous-run",
+    "scripts/autonomous_run",
+    "scripts/autonomous-loop",
+    "scripts/autonomous_loop",
+    "scripts/runs/autonomous/",
+    "scripts/runs/github/project-monitoring",
+    "scripts/runs/github/project_monitoring",
     "infra/",
     "k8s/",
     "secrets/",

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -1005,6 +1005,12 @@ def greptile_summary_score(repo: str, pr_number: int) -> int | None:
     """Latest Greptile summary score via the shared greptile-merge-signal evaluator.
 
     Returns the parsed score (0-5), or None if Greptile posted no parseable summary score.
+
+    Note on env-var precedence: this function only extracts the raw score from the
+    subprocess JSON. The floor comparison uses SELF_MERGE_MIN_GREPTILE_SCORE (parsed
+    by _parse_self_merge_min_greptile_score). The subprocess's own threshold
+    GREPTILE_MERGE_SIGNAL_MIN_SCORE has no effect on the gate — setting it does not
+    soften or tighten the floor here.
     """
     signal = Path(__file__).with_name("greptile-merge-signal.py")
     if not signal.exists():

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -987,6 +987,28 @@ def _check_workspace_repo(
     return [], []
 
 
+def greptile_summary_score(repo: str, pr_number: int) -> int | None:
+    """Latest Greptile summary score via the shared greptile-merge-signal evaluator.
+
+    Returns the parsed score (0-5), or None if Greptile posted no parseable summary score.
+    """
+    signal = Path(__file__).with_name("greptile-merge-signal.py")
+    if not signal.exists():
+        return None
+    try:
+        proc = subprocess.run(
+            [sys.executable, str(signal), "--repo", repo, str(pr_number)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        data = json.loads(proc.stdout) if proc.stdout.strip() else {}
+    except (subprocess.TimeoutExpired, json.JSONDecodeError):
+        return None
+    score = data.get("score")
+    return int(score) if isinstance(score, int) else None
+
+
 def evaluate_pr(
     repo: str, number: int, *, workspace_repos: list[str] | None
 ) -> CheckResult:
@@ -1044,6 +1066,18 @@ def evaluate_pr(
         result.reasons.append(
             f"Greptile has {greptile['unresolved']} unresolved review thread(s)"
         )
+
+    # Score floor (defense in depth): require the Greptile summary score >= floor
+    # (default 5/5, override via SELF_MERGE_MIN_GREPTILE_SCORE). Without this, resolving
+    # threads alone could let a low-score PR self-merge — the alice#61 (4/5) and #63 (3/5)
+    # incidents where buggy control-path code shipped. Reuses the shared greptile-merge-signal
+    # evaluator (upstreamed from Bob). Parse failure (score None) does NOT block — the
+    # thread/category gates still apply; this only catches a clear sub-floor score.
+    if greptile["has_review"]:
+        min_score = int(os.environ.get("SELF_MERGE_MIN_GREPTILE_SCORE", "5"))
+        score = greptile_summary_score(repo, number)
+        if score is not None and score < min_score:
+            result.reasons.append(f"Greptile score {score}/5 below floor {min_score}/5")
 
     human_threads = fetch_unresolved_human_threads(
         repo, number, review_data=shared_review_data

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -658,6 +658,7 @@ def test_evaluate_pr_warns_when_workspace_repos_empty() -> None:
             "fetch_greptile_status",
             return_value={"has_review": True, "unresolved": 0, "total": 1},
         ),
+        patch.object(self_merge_check, "greptile_summary_score", return_value=5),
     ):
         result = self_merge_check.evaluate_pr(
             "gptme/gptme-contrib",

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -621,6 +621,14 @@ def test_is_sensitive_path_handles_deploy_word_forms(path: str, expected: bool) 
         "scripts/session_bandit.py",
         "scripts/state-delta.py",
         "scripts/state_delta.py",
+        # autonomous/monitoring orchestration entrypoints (the self-merge control path)
+        "scripts/autonomous-run.sh",
+        "scripts/autonomous-run-cc.sh",
+        "scripts/autonomous_run.py",
+        "scripts/autonomous-loop.sh",
+        "scripts/runs/autonomous/autonomous-loop.sh",
+        "scripts/runs/github/project-monitoring.sh",
+        "scripts/runs/github/project_monitoring.py",
     ],
 )
 def test_classify_loop_control_paths_blocked(path: str) -> None:

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -672,6 +672,73 @@ def test_evaluate_pr_warns_when_workspace_repos_empty() -> None:
     ), f"Explicit opt-out should not disqualify; reasons: {result.reasons}"
 
 
+def test_greptile_summary_score_ignores_signal_disable_env() -> None:
+    completed = subprocess.CompletedProcess(
+        args=["python3"],
+        returncode=1,
+        stdout='{"score": 4}',
+        stderr="",
+    )
+
+    with (
+        patch.dict(
+            self_merge_check.os.environ,
+            {"GREPTILE_MERGE_SIGNAL_DISABLED": "1"},
+            clear=False,
+        ),
+        patch.object(
+            self_merge_check.subprocess, "run", return_value=completed
+        ) as mock_run,
+    ):
+        score = self_merge_check.greptile_summary_score("gptme/gptme-contrib", 1080)
+
+    assert score == 4
+    assert "GREPTILE_MERGE_SIGNAL_DISABLED" not in mock_run.call_args.kwargs["env"]
+
+
+def test_evaluate_pr_invalid_min_score_falls_back_to_default() -> None:
+    pr_data = {
+        "author": {"login": "TimeToBuildBob"},
+        "title": "Test PR",
+        "url": "https://github.com/gptme/gptme-contrib/pull/999",
+        "files": [{"path": "tests/test_example.py"}],
+        "statusCheckRollup": [{"status": "COMPLETED", "conclusion": "SUCCESS"}],
+        "isDraft": False,
+        "state": "OPEN",
+        "reviewDecision": None,
+    }
+
+    with (
+        patch.dict(
+            self_merge_check.os.environ,
+            {"SELF_MERGE_MIN_GREPTILE_SCORE": "five"},
+            clear=False,
+        ),
+        patch.object(self_merge_check, "_fetch_greptile_review_data", return_value={}),
+        patch.object(self_merge_check, "fetch_pr", return_value=pr_data),
+        patch.object(self_merge_check, "get_gh_user", return_value="TimeToBuildBob"),
+        patch.object(
+            self_merge_check,
+            "fetch_greptile_status",
+            return_value={"has_review": True, "unresolved": 0, "total": 1},
+        ),
+        patch.object(self_merge_check, "greptile_summary_score", return_value=4),
+        patch.object(
+            self_merge_check,
+            "fetch_unresolved_human_threads",
+            return_value={"unresolved": 0, "authors": []},
+        ),
+    ):
+        result = self_merge_check.evaluate_pr(
+            "gptme/gptme-contrib",
+            999,
+            workspace_repos=["gptme/gptme-contrib"],
+        )
+
+    assert not result.eligible
+    assert "Greptile score 4/5 below floor 5/5" in result.reasons
+
+
 def test_evaluate_pr_disqualified_when_workspace_repos_unknown() -> None:
     """Detection failure (workspace_repos=None) must disqualify the PR."""
     pr_data = {

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -148,9 +148,18 @@ def test_evaluate_pr_blocks_changes_requested() -> None:
         patch.object(self_merge_check, "fetch_pr", return_value=pr_data),
         patch.object(self_merge_check, "get_gh_user", return_value="TimeToBuildBob"),
         patch.object(
+            self_merge_check, "_fetch_greptile_review_data", return_value=None
+        ),
+        patch.object(
             self_merge_check,
             "fetch_greptile_status",
             return_value={"has_review": True, "unresolved": 0, "total": 1},
+        ),
+        patch.object(self_merge_check, "greptile_summary_score", return_value=None),
+        patch.object(
+            self_merge_check,
+            "fetch_unresolved_human_threads",
+            return_value={"unresolved": 0, "total": 0, "authors": []},
         ),
     ):
         result = self_merge_check.evaluate_pr(
@@ -654,11 +663,19 @@ def test_evaluate_pr_warns_when_workspace_repos_empty() -> None:
         patch.object(self_merge_check, "fetch_pr", return_value=pr_data),
         patch.object(self_merge_check, "get_gh_user", return_value="TimeToBuildBob"),
         patch.object(
+            self_merge_check, "_fetch_greptile_review_data", return_value=None
+        ),
+        patch.object(
             self_merge_check,
             "fetch_greptile_status",
             return_value={"has_review": True, "unresolved": 0, "total": 1},
         ),
         patch.object(self_merge_check, "greptile_summary_score", return_value=5),
+        patch.object(
+            self_merge_check,
+            "fetch_unresolved_human_threads",
+            return_value={"unresolved": 0, "total": 0, "authors": []},
+        ),
     ):
         result = self_merge_check.evaluate_pr(
             "gptme/gptme-contrib",


### PR DESCRIPTION
## Problem
The self-merge gate (`self-merge-check.py`) is thread-based with **no score floor** — resolving Greptile threads alone lets a PR self-merge regardless of score. With autonomous self-merge on, the loop merged alice#61 at **4/5** and #63 at **3/5** (the latter shipped a real control-path bug). Diverges from the 5/5 intent.

## Fix
- **Upstreams @TimeToBuildBob's `greptile-merge-signal.py`** into gptme-contrib (was Bob-local) so Alice + Bob share one score evaluator. Inspired by greptileai/skills `greploop` (MIT) + Alice's `resolve-greptile-threads` primitive.
- **Wires it into `self-merge-check.py`** as a score floor after the thread check: require Greptile summary score ≥ floor (default 5/5, override `SELF_MERGE_MIN_GREPTILE_SCORE`). Parse failure does NOT block; only a clear sub-floor score blocks.

## Test
#26 (5/5) passes; floor=6 blocks it. ruff/mypy green.

@TimeToBuildBob — upstreams your file + wires it as the floor; both benefit. Part of consolidating Alice's parallel greptile tooling onto yours (pr-address-wait-and-merge / pr-queue-health).