### PR TITLE
feat(pm): surface own-PR Greptile review via notification-blind detector

### DIFF
--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -706,7 +706,7 @@ check_greptile_scores() {
 # Routing:
 #   greptile < 4 (significant findings)   → greptile_needs_fix
 #   greptile = 4 (minor improvements)     → greptile_needs_improvement
-#   greptile >= 5 + CLEAN/MERGEABLE       → skip (check_merge_ready handles this)
+#   greptile >= 5                         → skip (perfect review is non-actionable here)
 #   DIRTY / CONFLICTING                   → skip (check_merge_conflicts handles)
 #   BLOCKED / UNKNOWN                     → skip (CI not yet settled)
 #
@@ -747,8 +747,9 @@ check_own_pr_review_state() {
         # No Greptile review on file yet — skip
         [ -z "$greptile_score" ] || [ "$greptile_score" = "null" ] && continue
 
-        # Greptile 5/5 + CLEAN/MERGEABLE → check_merge_ready already covers this
-        if [ "$greptile_score" -ge 5 ] 2>/dev/null && [ "$merge_state" = "CLEAN" ]; then
+        # Greptile 5/5 is already a perfect review. Whether the PR is ready to
+        # merge is handled separately by check_merge_ready / merge-status checks.
+        if [ "$greptile_score" -ge 5 ] 2>/dev/null; then
             continue
         fi
 

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -737,15 +737,24 @@ check_own_pr_review_state() {
             BLOCKED|UNKNOWN) continue ;;
         esac
 
-        # Read Greptile score from state file written by check_greptile_scores
+        # Read Greptile score and reviewed SHA from state file written by check_greptile_scores
+        # Format: score:timestamp:sha
         local greptile_state_file="$STATE_DIR/${repo_safe}-pr-${pr_number}-greptile.state"
-        local greptile_score=""
+        local greptile_score="" greptile_reviewed_sha=""
         if [ -f "$greptile_state_file" ]; then
             greptile_score=$(cut -d: -f1 < "$greptile_state_file")
+            greptile_reviewed_sha=$(cut -d: -f3 < "$greptile_state_file")
         fi
 
         # No Greptile review on file yet — skip
         [ -z "$greptile_score" ] || [ "$greptile_score" = "null" ] && continue
+
+        # Skip if the cached score is for a different SHA — Greptile hasn't reviewed
+        # the current HEAD yet. Without this guard, a push within the 8-min pr_data
+        # cache window produces a spurious dispatch pairing the new SHA with a stale score.
+        if [ -n "$greptile_reviewed_sha" ] && [ "$greptile_reviewed_sha" != "$head_sha" ]; then
+            continue
+        fi
 
         # Greptile 5/5 is already a perfect review. Whether the PR is ready to
         # merge is handled separately by check_merge_ready / merge-status checks.

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -694,6 +694,93 @@ check_greptile_scores() {
     done
 }
 
+# Surface own-PR Greptile review results that are invisible to the notification path.
+#
+# Bob opening his own PR and receiving a bot (Greptile/Codecov) review does NOT
+# generate a review_requested/mention notification. check_greptile_scores seeds
+# (and does NOT emit) on first discovery to avoid flooding when a repo is first
+# onboarded — so a new PR's first Greptile result is silently recorded and only
+# re-emitted after the 1-hour cooldown. This function closes that gap by emitting
+# on first discovery of a changed signature for bot-authored PRs.
+#
+# Routing:
+#   greptile < 4 (significant findings)   → greptile_needs_fix
+#   greptile = 4 (minor improvements)     → greptile_needs_improvement
+#   greptile >= 5 + CLEAN/MERGEABLE       → skip (check_merge_ready handles this)
+#   DIRTY / CONFLICTING                   → skip (check_merge_conflicts handles)
+#   BLOCKED / UNKNOWN                     → skip (CI not yet settled)
+#
+# State tracking: $STATE_DIR/${repo_safe}-pr-${number}-own-pr-review.state
+#   Format: "${head_sha}:${greptile_score}:${merge_state}:${timestamp}"
+#   Emit exactly once per (head_sha, greptile_score, merge_state) signature.
+#   No timed cooldown re-emit — only re-emits when the signature changes.
+#
+# API cost: zero — reads Greptile state files written by check_greptile_scores.
+# Requires: live PR data (fresh mergeStateStatus/headRefOid).
+check_own_pr_review_state() {
+    local repo=$1
+    local prs=$2  # live PR data (fetch_live_pr_data)
+    [ "$prs" = "[]" ] || [ -z "$prs" ] && return 0
+
+    local repo_safe="${repo//\//-}"
+
+    echo "$prs" | jq -c '.[]' | while read -r pr_data; do
+        local pr_number pr_title head_sha merge_state
+        pr_number=$(echo "$pr_data" | jq -r '.number')
+        pr_title=$(echo "$pr_data" | jq -r '.title')
+        head_sha=$(echo "$pr_data" | jq -r '.headRefOid // "unknown"')
+        merge_state=$(echo "$pr_data" | jq -r '.mergeStateStatus // "UNKNOWN"')
+
+        # Skip conflict/unsettled states — handled by other checks
+        case "$merge_state" in
+            DIRTY|CONFLICTING) continue ;;
+            BLOCKED|UNKNOWN) continue ;;
+        esac
+
+        # Read Greptile score from state file written by check_greptile_scores
+        local greptile_state_file="$STATE_DIR/${repo_safe}-pr-${pr_number}-greptile.state"
+        local greptile_score=""
+        if [ -f "$greptile_state_file" ]; then
+            greptile_score=$(cut -d: -f1 < "$greptile_state_file")
+        fi
+
+        # No Greptile review on file yet — skip
+        [ -z "$greptile_score" ] || [ "$greptile_score" = "null" ] && continue
+
+        # Greptile 5/5 + CLEAN/MERGEABLE → check_merge_ready already covers this
+        if [ "$greptile_score" -ge 5 ] 2>/dev/null && [ "$merge_state" = "CLEAN" ]; then
+            continue
+        fi
+
+        # Determine item type from Greptile score
+        local item_type
+        if [ "$greptile_score" -lt 4 ] 2>/dev/null; then
+            item_type="greptile_needs_fix"
+        else
+            item_type="greptile_needs_improvement"
+        fi
+
+        # Emit once per (head_sha, greptile_score, merge_state) signature.
+        # The last colon-delimited field is the timestamp; strip it for comparison.
+        local state_file="$STATE_DIR/${repo_safe}-pr-${pr_number}-own-pr-review.state"
+        local signature="${head_sha}:${greptile_score}:${merge_state}"
+        local now
+        now=$(date +%s)
+
+        if [ -f "$state_file" ]; then
+            local last_state last_sig
+            last_state=$(cat "$state_file")
+            last_sig="${last_state%:*}"  # drop trailing :timestamp
+            [ "$last_sig" = "$signature" ] && continue  # same state — already dispatched
+        fi
+
+        # New or changed signature — record and emit
+        echo "${signature}:${now}" > "$state_file"
+        emit_item "$item_type" "$repo" "$pr_number" "$pr_title" \
+            "own-PR review: Greptile ${greptile_score}/5 (merge_state: ${merge_state})"
+    done
+}
+
 # Check if the bot account has already posted a maintainer-facing status comment
 # on this PR indicating that the ball is in the maintainer's court.
 #
@@ -949,6 +1036,11 @@ for repo in $all_repos; do
         [ -n "$items" ] && repo_items+="$items"$'\n'
 
         items=$(check_greptile_scores "$repo" "$pr_data" 2>/dev/null || true)
+        [ -n "$items" ] && repo_items+="$items"$'\n'
+
+        # Must run AFTER check_greptile_scores (reads its state files) and with
+        # live_pr_data (needs fresh mergeStateStatus for routing decisions).
+        items=$(check_own_pr_review_state "$repo" "$live_pr_data" 2>/dev/null || true)
         [ -n "$items" ] && repo_items+="$items"$'\n'
 
         items=$(check_merge_ready "$repo" "$live_pr_data" 2>/dev/null || true)

--- a/tests/test_activity_gate_own_pr_review.py
+++ b/tests/test_activity_gate_own_pr_review.py
@@ -59,6 +59,10 @@ if argv[0] == "api" and len(argv) > 1 and argv[1] == "notifications":
     sys.exit(0)
 
 if argv[0] == "api":
+    # When --jq is passed, simulate real jq-filtered output: no greptile comments
+    # means the filter produces empty output (not the raw "[]" array).
+    if "--jq" in argv:
+        sys.exit(0)
     print("[]")
     sys.exit(0)
 
@@ -107,6 +111,27 @@ def _run_gate(
         text=True,
         env=env,
     )
+
+
+def test_stale_greptile_sha_does_not_emit_for_new_head() -> None:
+    """Greptile state for an old SHA must not dispatch against the new HEAD."""
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+
+        old_sha = "oldsha0000"
+        ts = int(time.time()) - 60
+        # State file records a review for old_sha, but live PR is at TEST_HEAD_SHA
+        _greptile_state_file(state_dir).write_text(f"3:{ts}:{old_sha}")
+
+        result = _run_gate(tmp, state_dir, merge_state="CLEAN")
+        assert result.returncode in (0, 1), result.stderr
+        # check_own_pr_review_state must NOT emit — checked via the specific detail string
+        # and the absence of its state file. (check_greptile_scores may emit separately
+        # for the SHA change; that's expected and not what this test covers.)
+        assert "own-PR review" not in result.stdout, result.stdout
+        assert not _own_review_state_file(state_dir).exists()
 
 
 def test_perfect_greptile_review_does_not_emit_improvement_for_behind_pr() -> None:

--- a/tests/test_activity_gate_own_pr_review.py
+++ b/tests/test_activity_gate_own_pr_review.py
@@ -1,0 +1,125 @@
+"""Regression tests for own-PR Greptile review detection in activity-gate.sh."""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "github" / "activity-gate.sh"
+
+TEST_REPO = "testorg/testrepo"
+TEST_PR = 42
+TEST_HEAD_SHA = "deadbeef1234"
+
+FAKE_GH = r"""#!/usr/bin/env python3
+from __future__ import annotations
+import json, os, sys
+
+argv = sys.argv[1:]
+pr_number = int(os.environ.get("TEST_PR_NUMBER", "42"))
+head_sha = os.environ.get("TEST_HEAD_SHA", "abc123")
+merge_state = os.environ.get("TEST_MERGE_STATE", "BEHIND")
+
+if not argv:
+    sys.exit(2)
+
+if argv[0] == "repo" and len(argv) > 1 and argv[1] == "list":
+    sys.exit(0)
+
+if argv[0] == "pr" and len(argv) > 1 and argv[1] == "list":
+    pr = [{
+        "number": pr_number,
+        "title": f"Test PR #{pr_number}",
+        "updatedAt": "2026-06-12T00:00:00Z",
+        "comments": [],
+        "latestReviews": [],
+        "statusCheckRollup": None,
+        "mergeable": "MERGEABLE",
+        "mergeStateStatus": merge_state,
+        "headRefOid": head_sha,
+        "isDraft": False,
+    }]
+    print(json.dumps(pr))
+    sys.exit(0)
+
+if argv[0] == "issue" and len(argv) > 1 and argv[1] == "list":
+    print("[]")
+    sys.exit(0)
+
+if argv[0] == "run" and len(argv) > 1 and argv[1] == "list":
+    print("[]")
+    sys.exit(0)
+
+if argv[0] == "api" and len(argv) > 1 and argv[1] == "notifications":
+    sys.exit(0)
+
+if argv[0] == "api":
+    print("[]")
+    sys.exit(0)
+
+sys.exit(0)
+"""
+
+
+def _greptile_state_file(state_dir: Path) -> Path:
+    repo_safe = TEST_REPO.replace("/", "-")
+    return state_dir / f"{repo_safe}-pr-{TEST_PR}-greptile.state"
+
+
+def _own_review_state_file(state_dir: Path) -> Path:
+    repo_safe = TEST_REPO.replace("/", "-")
+    return state_dir / f"{repo_safe}-pr-{TEST_PR}-own-pr-review.state"
+
+
+def _run_gate(
+    tmp: Path, state_dir: Path, *, merge_state: str
+) -> subprocess.CompletedProcess[str]:
+    fake_gh = tmp / "gh"
+    fake_gh.write_text(FAKE_GH)
+    fake_gh.chmod(fake_gh.stat().st_mode | stat.S_IXUSR)
+
+    env = os.environ.copy()
+    env["TEST_PR_NUMBER"] = str(TEST_PR)
+    env["TEST_HEAD_SHA"] = TEST_HEAD_SHA
+    env["TEST_MERGE_STATE"] = merge_state
+    env["PATH"] = f"{tmp}:{env['PATH']}"
+
+    return subprocess.run(
+        [
+            str(SCRIPT),
+            "--author",
+            "test-author",
+            "--org",
+            "testorg",
+            "--repo",
+            TEST_REPO,
+            "--state-dir",
+            str(state_dir),
+            "--format",
+            "jsonl",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_perfect_greptile_review_does_not_emit_improvement_for_behind_pr() -> None:
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+
+        ts = int(time.time()) - 60
+        _greptile_state_file(state_dir).write_text(f"5:{ts}:{TEST_HEAD_SHA}")
+
+        result = _run_gate(tmp, state_dir, merge_state="BEHIND")
+        assert result.returncode in (0, 1), result.stderr
+        assert "greptile_needs_improvement" not in result.stdout, result.stdout
+        assert "greptile_needs_fix" not in result.stdout, result.stdout
+        assert not _own_review_state_file(state_dir).exists()


### PR DESCRIPTION
## Problem

When Bob opens his own PR, neither the PR creation nor subsequent Greptile/Codecov bot reviews generate `review_requested` or `mention` notifications. Additionally, `check_greptile_scores` intentionally seeds (doesn't emit) on first discovery to avoid flooding when a new repo is onboarded. Combined, this means a brand-new PR's first Greptile review is silently recorded and only re-emitted after the 1-hour cooldown window — by which time a manual intervention is often needed anyway.

**Concrete case**: `gptme/gptme#2860` received a Greptile 3/5 review and was invisible to project-monitoring for ~1h. The existing cooldown-based re-emit eventually fired, but the detection gap is unnecessary.

## Solution

Add `check_own_pr_review_state()` to `activity-gate.sh`:

- **Zero extra API cost**: reads Greptile state files written by `check_greptile_scores` (must run after it)
- **Emits on first discovery** of a changed `(head_sha, greptile_score, merge_state)` signature — no seed-only behavior
- **Routes correctly**:
  - `greptile < 4` → `greptile_needs_fix`
  - `greptile = 4` → `greptile_needs_improvement`
  - `greptile >= 5` + `CLEAN` → skip (`check_merge_ready` already handles this)
  - `DIRTY`/`CONFLICTING` → skip (`check_merge_conflicts` handles)
  - `BLOCKED`/`UNKNOWN` → skip (CI not yet settled)
- **Anti-repeat**: one dispatch per signature; re-dispatches only when the signature changes (new commit, re-review, or merge-state change)

## What existing primitives can't do

`check_greptile_scores` seeds on first discovery by design (onboarding noise prevention). There's no way to ask it "emit on first discovery for own-PRs only" without forking its logic. This function is a thin reader over its state files, not a duplicate of its API-calling logic.

## Testing

Manually verified on the `activity-gate.sh` shellcheck + bash syntax check pass:
```bash
bash -n scripts/github/activity-gate.sh  # syntax OK
shellcheck scripts/github/activity-gate.sh  # no errors
```