### PR TITLE
feat(github): add resolve-greptile-threads.py (resolveReviewThread primitive)

### DIFF
--- a/scripts/github/README.md
+++ b/scripts/github/README.md
@@ -18,7 +18,7 @@ existed. See `scripts/workflow/read-the-task-before-reinvestigating` patterns.)
 | Trigger / re-trigger review | `greptile-helper.sh` (anti-spam: flock, ack-detect, max-retriggers) · `pr-greptile-trigger.py` (batch) | NEVER post raw `@greptileai review` |
 | Read the score signal | `greptile-merge-signal.py` (summary score ≥ threshold + "Safe to merge") | reusable; default 5/5 |
 | Address findings, push | (agent session) | fix the code |
-| **Resolve addressed threads** | `resolve-greptile-threads.py` *(Alice-contributed)* | the `resolveReviewThread` mutation; fix-first |
+| **Resolve addressed threads** | `resolve-greptile-threads.py` | the `resolveReviewThread` mutation; fix-first; resolves Greptile-bot threads only |
 | Gate the merge | `self-merge-check.py` | CI green + Greptile present + no unresolved threads + **score floor** (`SELF_MERGE_MIN_GREPTILE_SCORE`, default 5/5) + category/sensitive-path filter |
 | Merge | `self-merge-if-eligible.sh` / `pr-address-wait-and-merge.sh` *(Bob)* | bounded poll-budget wait → merge |
 
@@ -328,6 +328,29 @@ low-scored PR. Parse failure does not block (the thread/category gates still app
 ```bash
 python3 scripts/github/greptile-merge-signal.py --repo owner/repo 123   # JSON; exit 0 eligible, 1 not
 ```
+
+### resolve-greptile-threads.py
+
+Resolves **addressed** Greptile review threads via the `resolveReviewThread` GraphQL mutation —
+the gap that blocks `self-merge-check.py` (it requires *no unresolved threads*, but we reply to
+nitpicks rather than resolve them, so the deterministic merge path never fires on nitpick-laden
+PRs). Call it **after** addressing findings (fix-first), or with `--outdated-only` for the
+conservative "code changed since the comment" heuristic. **Safety:** only ever resolves
+Greptile-bot-authored threads — never touches human threads. Paginates `reviewThreads` so it
+can't silently undercount; per-thread resolve failures are non-fatal (the loop continues).
+
+```bash
+# Dry-run first — list what would be resolved
+python3 scripts/github/resolve-greptile-threads.py owner/repo#123 --dry-run
+
+# Resolve all addressed Greptile threads (JSON summary on stdout, progress on stderr)
+python3 scripts/github/resolve-greptile-threads.py owner/repo#123 --json
+
+# Conservative: only resolve threads whose code changed since the comment
+python3 scripts/github/resolve-greptile-threads.py owner/repo 123 --outdated-only
+```
+
+**Exit codes:** 0 = ok (prints count resolved), 2 = arg/gh error.
 
 ## Related
 

--- a/scripts/github/resolve-greptile-threads.py
+++ b/scripts/github/resolve-greptile-threads.py
@@ -73,7 +73,10 @@ def parse_pr(spec: str, second: str | None) -> tuple[str, str, int]:
         return owner, name, int(num)
     if second and "/" in spec:
         owner, name = spec.split("/", 1)
-        return owner, name, int(second)
+        try:
+            return owner, name, int(second)
+        except ValueError:
+            _die(f"PR number must be an integer, got {second!r}.")
     _die(f"Unrecognized PR specifier: {spec!r}. Use OWNER/REPO#NUM or OWNER/REPO NUM.")
 
 
@@ -152,7 +155,14 @@ def resolve_thread(thread_id: str) -> bool:
             file=sys.stderr,
         )
         return False
-    return bool(body["data"]["resolveReviewThread"]["thread"]["isResolved"])
+    try:
+        return bool(body["data"]["resolveReviewThread"]["thread"]["isResolved"])
+    except (KeyError, TypeError) as exc:
+        print(
+            f"  ! resolve {thread_id}: unexpected response shape: {exc}",
+            file=sys.stderr,
+        )
+        return False
 
 
 def main() -> int:

--- a/scripts/github/resolve-greptile-threads.py
+++ b/scripts/github/resolve-greptile-threads.py
@@ -168,6 +168,15 @@ def resolve_thread(thread_id: str) -> bool:
         return False
 
 
+def filter_targets(threads: list[dict], outdated_only: bool) -> list[dict]:
+    """Return unresolved threads eligible for resolution."""
+    return [
+        t
+        for t in threads
+        if not t["isResolved"] and (t["isOutdated"] or not outdated_only)
+    ]
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("pr")
@@ -185,11 +194,7 @@ def main() -> int:
 
     owner, name, num = parse_pr(a.pr, a.num)
     threads = fetch_greptile_threads(owner, name, num)
-    targets = [
-        t
-        for t in threads
-        if not t["isResolved"] and (t["isOutdated"] or not a.outdated_only)
-    ]
+    targets = filter_targets(threads, a.outdated_only)
 
     # When emitting JSON, per-thread progress goes to stderr so stdout stays parseable.
     log = sys.stderr if a.json else sys.stdout

--- a/scripts/github/resolve-greptile-threads.py
+++ b/scripts/github/resolve-greptile-threads.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Resolve addressed Greptile review threads on a PR (the resolveReviewThread gap).
+
+Our self-merge gate (`gptme-contrib/scripts/github/self-merge-check.py`) blocks on ANY
+unresolved Greptile review thread. But nothing ever resolves them — we reply, never
+resolve — so the deterministic self-merge path can't fire on nitpick-laden PRs. greptile's
+own `greploop` skill resolves threads via the `resolveReviewThread` GraphQL mutation after
+addressing each comment; this is that primitive for our flow.
+
+SAFETY: only ever resolves threads authored by Greptile (bot). Never touches human threads.
+Intended to be called by an agent session AFTER it has addressed the findings (or with
+--outdated-only for the conservative "code changed since the comment" heuristic).
+
+Usage:
+  resolve-greptile-threads.py OWNER/REPO#NUM [--dry-run] [--outdated-only] [--json]
+  resolve-greptile-threads.py OWNER/REPO NUM  [...]
+
+Exit: 0 ok (prints count resolved), 2 on arg/gh error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from typing import NoReturn
+
+GREPTILE_LOGINS = ("greptile-apps", "greptile-apps[bot]", "greptile-apps-staging[bot]")
+
+
+def _run_gh(args: list[str]) -> tuple[int, str, str]:
+    p = subprocess.run(["gh", *args], capture_output=True, text=True, timeout=30)
+    return p.returncode, p.stdout.strip(), p.stderr.strip()
+
+
+def _die(msg: str) -> NoReturn:
+    """Print to stderr and exit 2 (the documented arg/gh-error code)."""
+    print(msg, file=sys.stderr)
+    raise SystemExit(2)
+
+
+def _graphql_data(args: list[str]) -> dict:
+    """Run a gh graphql query and return its ``data`` object, or die cleanly.
+
+    GitHub's GraphQL API can return ``{"data": null, "errors": [...]}`` with HTTP 200,
+    so rc==0 is not sufficient — inspect the body before subscripting ``data``.
+    """
+    rc, out, err = _run_gh(args)
+    if rc != 0:
+        _die(f"gh graphql failed: {err or out}")
+    try:
+        body = json.loads(out)
+    except json.JSONDecodeError:
+        _die(f"gh graphql returned non-JSON: {out[:200]}")
+    if body.get("errors"):
+        _die(f"GraphQL errors: {body['errors']}")
+    data = body.get("data")
+    if not isinstance(data, dict):
+        _die("GraphQL returned null/empty data")
+    return data
+
+
+def parse_pr(spec: str, second: str | None) -> tuple[str, str, int]:
+    """Accept 'owner/repo#123', 'owner/repo 123', or a PR URL."""
+    m = re.search(r"github\.com/([^/]+)/([^/]+)/pull/(\d+)", spec)
+    if m:
+        return m.group(1), m.group(2), int(m.group(3))
+    if "#" in spec:
+        repo, num = spec.split("#", 1)
+        owner, name = repo.split("/", 1)
+        return owner, name, int(num)
+    if second and "/" in spec:
+        owner, name = spec.split("/", 1)
+        return owner, name, int(second)
+    _die(f"Unrecognized PR specifier: {spec!r}. Use OWNER/REPO#NUM or OWNER/REPO NUM.")
+
+
+def fetch_greptile_threads(owner: str, name: str, num: int) -> list[dict]:
+    """Return Greptile-authored review threads with id/isResolved/isOutdated."""
+    query = """
+    query($owner:String!,$name:String!,$num:Int!,$cursor:String){
+      repository(owner:$owner,name:$name){
+        pullRequest(number:$num){
+          reviewThreads(first:100,after:$cursor){
+            pageInfo{hasNextPage endCursor}
+            nodes{ id isResolved isOutdated
+              comments(first:1){nodes{author{login} path}} }
+          }
+        }
+      }
+    }"""
+    threads: list[dict] = []
+    cursor = None
+    while True:
+        args = [
+            "api",
+            "graphql",
+            "-f",
+            f"query={query}",
+            "-F",
+            f"owner={owner}",
+            "-F",
+            f"name={name}",
+            "-F",
+            f"num={num}",
+        ]
+        if cursor:
+            args += ["-F", f"cursor={cursor}"]
+        gdata = _graphql_data(args)
+        pr = (gdata.get("repository") or {}).get("pullRequest")
+        if not pr:
+            _die(f"{owner}/{name}#{num}: repository or PR not found")
+        data = pr["reviewThreads"]
+        for n in data["nodes"]:
+            cnodes = n.get("comments", {}).get("nodes", [])
+            login = (cnodes[0].get("author") or {}).get("login", "") if cnodes else ""
+            if login in GREPTILE_LOGINS:
+                threads.append(
+                    {
+                        "id": n["id"],
+                        "isResolved": n["isResolved"],
+                        "isOutdated": n["isOutdated"],
+                        "path": (cnodes[0].get("path") if cnodes else "") or "",
+                    }
+                )
+        if not data["pageInfo"]["hasNextPage"]:
+            break
+        cursor = data["pageInfo"]["endCursor"]
+    return threads
+
+
+def resolve_thread(thread_id: str) -> bool:
+    """Resolve one thread. Non-fatal: returns False on any error (already-resolved,
+    permission, HTTP-200 GraphQL error) so the caller's loop continues."""
+    mutation = "mutation($id:ID!){resolveReviewThread(input:{threadId:$id}){thread{isResolved}}}"
+    rc, out, err = _run_gh(
+        ["api", "graphql", "-f", f"query={mutation}", "-F", f"id={thread_id}"]
+    )
+    if rc != 0:
+        print(f"  ! failed to resolve {thread_id}: {err or out}", file=sys.stderr)
+        return False
+    try:
+        body = json.loads(out)
+    except json.JSONDecodeError:
+        print(f"  ! resolve {thread_id}: non-JSON response", file=sys.stderr)
+        return False
+    if body.get("errors") or not isinstance(body.get("data"), dict):
+        print(
+            f"  ! resolve {thread_id}: {body.get('errors') or 'null data'}",
+            file=sys.stderr,
+        )
+        return False
+    return bool(body["data"]["resolveReviewThread"]["thread"]["isResolved"])
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("pr")
+    ap.add_argument("num", nargs="?")
+    ap.add_argument(
+        "--dry-run", action="store_true", help="list what would be resolved"
+    )
+    ap.add_argument(
+        "--outdated-only",
+        action="store_true",
+        help="only resolve threads whose code changed since the comment (isOutdated) — conservative",
+    )
+    ap.add_argument("--json", action="store_true")
+    a = ap.parse_args()
+
+    owner, name, num = parse_pr(a.pr, a.num)
+    threads = fetch_greptile_threads(owner, name, num)
+    targets = [
+        t
+        for t in threads
+        if not t["isResolved"] and (t["isOutdated"] or not a.outdated_only)
+    ]
+
+    # When emitting JSON, per-thread progress goes to stderr so stdout stays parseable.
+    log = sys.stderr if a.json else sys.stdout
+    resolved = []
+    for t in targets:
+        if a.dry_run:
+            print(
+                f"  [dry-run] would resolve {t['id']} ({t['path']}, outdated={t['isOutdated']})",
+                file=log,
+            )
+            continue
+        if resolve_thread(t["id"]):
+            resolved.append(t["id"])
+            print(f"  resolved {t['id']} ({t['path']})", file=log)
+
+    summary = {
+        "repo": f"{owner}/{name}",
+        "pr": num,
+        "greptile_threads": len(threads),
+        "unresolved": len([t for t in threads if not t["isResolved"]]),
+        "targeted": len(targets),
+        "resolved": len(resolved),
+        "dry_run": a.dry_run,
+    }
+    if a.json:
+        print(json.dumps(summary))
+    else:
+        print(
+            f"{summary['repo']}#{num}: {summary['unresolved']} unresolved greptile thread(s), "
+            f"{'would resolve' if a.dry_run else 'resolved'} {summary['targeted'] if a.dry_run else summary['resolved']}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/github/resolve-greptile-threads.py
+++ b/scripts/github/resolve-greptile-threads.py
@@ -69,6 +69,8 @@ def parse_pr(spec: str, second: str | None) -> tuple[str, str, int]:
         return m.group(1), m.group(2), int(m.group(3))
     if "#" in spec:
         repo, num = spec.split("#", 1)
+        if "/" not in repo:
+            _die(f"Invalid PR specifier {spec!r}: expected OWNER/REPO#NUM.")
         owner, name = repo.split("/", 1)
         try:
             return owner, name, int(num)

--- a/scripts/github/resolve-greptile-threads.py
+++ b/scripts/github/resolve-greptile-threads.py
@@ -70,7 +70,10 @@ def parse_pr(spec: str, second: str | None) -> tuple[str, str, int]:
     if "#" in spec:
         repo, num = spec.split("#", 1)
         owner, name = repo.split("/", 1)
-        return owner, name, int(num)
+        try:
+            return owner, name, int(num)
+        except ValueError:
+            _die(f"PR number must be an integer, got {num!r}.")
     if second and "/" in spec:
         owner, name = spec.split("/", 1)
         try:

--- a/tests/test_resolve_greptile_threads.py
+++ b/tests/test_resolve_greptile_threads.py
@@ -20,6 +20,7 @@ sys.modules[spec.name] = resolve_greptile_threads
 spec.loader.exec_module(resolve_greptile_threads)
 
 parse_pr = resolve_greptile_threads.parse_pr
+resolve_thread = resolve_greptile_threads.resolve_thread
 
 
 def test_parse_pr_hash_form() -> None:
@@ -52,6 +53,24 @@ def test_parse_pr_non_numeric_second_exits_2() -> None:
     with pytest.raises(SystemExit) as exc:
         parse_pr("gptme/gptme-contrib", "foo")
     assert exc.value.code == 2
+
+
+def test_parse_pr_non_numeric_hash_exits_2() -> None:
+    """Hash form with non-numeric number should exit 2 via _die(), not raise ValueError."""
+    with pytest.raises(SystemExit) as exc:
+        parse_pr("gptme/gptme-contrib#abc", None)
+    assert exc.value.code == 2
+
+
+def test_resolve_thread_unexpected_shape_returns_false(monkeypatch) -> None:
+    """rc==0 with a valid-but-unexpected body (null thread node) must return False,
+    not raise out of the caller's loop."""
+    monkeypatch.setattr(
+        resolve_greptile_threads,
+        "_run_gh",
+        lambda args: (0, '{"data": {"resolveReviewThread": null}}', ""),
+    )
+    assert resolve_thread("THREAD_ID") is False
 
 
 def test_targeting_excludes_resolved() -> None:

--- a/tests/test_resolve_greptile_threads.py
+++ b/tests/test_resolve_greptile_threads.py
@@ -63,6 +63,14 @@ def test_parse_pr_non_numeric_hash_exits_2() -> None:
     assert exc.value.code == 2
 
 
+def test_parse_pr_hash_form_missing_slash_exits_2() -> None:
+    """Hash form without a slash in the repo part should exit 2 via _die(),
+    not raise a raw ValueError from the owner/name unpack."""
+    with pytest.raises(SystemExit) as exc:
+        parse_pr("myrepo#123", None)
+    assert exc.value.code == 2
+
+
 def test_resolve_thread_unexpected_shape_returns_false(monkeypatch) -> None:
     """rc==0 with a valid-but-unexpected body (null thread node) must return False,
     not raise out of the caller's loop."""

--- a/tests/test_resolve_greptile_threads.py
+++ b/tests/test_resolve_greptile_threads.py
@@ -21,6 +21,7 @@ spec.loader.exec_module(resolve_greptile_threads)
 
 parse_pr = resolve_greptile_threads.parse_pr
 resolve_thread = resolve_greptile_threads.resolve_thread
+filter_targets = resolve_greptile_threads.filter_targets
 
 
 def test_parse_pr_hash_form() -> None:
@@ -74,18 +75,10 @@ def test_resolve_thread_unexpected_shape_returns_false(monkeypatch) -> None:
 
 
 def test_targeting_excludes_resolved() -> None:
-    # Mirrors main()'s target filter: skip resolved; honor --outdated-only.
     threads = [
         {"id": "a", "isResolved": True, "isOutdated": True, "path": "x"},
         {"id": "b", "isResolved": False, "isOutdated": False, "path": "y"},
         {"id": "c", "isResolved": False, "isOutdated": True, "path": "z"},
     ]
-    all_targets = [
-        t for t in threads if not t["isResolved"] and (t["isOutdated"] or not False)
-    ]
-    assert {t["id"] for t in all_targets} == {"b", "c"}
-
-    outdated_targets = [
-        t for t in threads if not t["isResolved"] and (t["isOutdated"] or not True)
-    ]
-    assert {t["id"] for t in outdated_targets} == {"c"}
+    assert {t["id"] for t in filter_targets(threads, outdated_only=False)} == {"b", "c"}
+    assert {t["id"] for t in filter_targets(threads, outdated_only=True)} == {"c"}

--- a/tests/test_resolve_greptile_threads.py
+++ b/tests/test_resolve_greptile_threads.py
@@ -47,6 +47,13 @@ def test_parse_pr_invalid_exits_2() -> None:
     assert exc.value.code == 2
 
 
+def test_parse_pr_non_numeric_second_exits_2() -> None:
+    """Two-argument form with non-numeric second should exit 2 via _die()."""
+    with pytest.raises(SystemExit) as exc:
+        parse_pr("gptme/gptme-contrib", "foo")
+    assert exc.value.code == 2
+
+
 def test_targeting_excludes_resolved() -> None:
     # Mirrors main()'s target filter: skip resolved; honor --outdated-only.
     threads = [

--- a/tests/test_resolve_greptile_threads.py
+++ b/tests/test_resolve_greptile_threads.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "scripts"
+    / "github"
+    / "resolve-greptile-threads.py"
+)
+spec = importlib.util.spec_from_file_location("resolve_greptile_threads", MODULE_PATH)
+if spec is None or spec.loader is None:
+    pytest.skip(f"Could not load module from {MODULE_PATH}", allow_module_level=True)
+resolve_greptile_threads = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = resolve_greptile_threads
+spec.loader.exec_module(resolve_greptile_threads)
+
+parse_pr = resolve_greptile_threads.parse_pr
+
+
+def test_parse_pr_hash_form() -> None:
+    assert parse_pr("gptme/gptme-contrib#123", None) == ("gptme", "gptme-contrib", 123)
+
+
+def test_parse_pr_two_arg_form() -> None:
+    assert parse_pr("gptme/gptme-contrib", "456") == ("gptme", "gptme-contrib", 456)
+
+
+def test_parse_pr_url_form() -> None:
+    url = "https://github.com/gptme/gptme/pull/789"
+    assert parse_pr(url, None) == ("gptme", "gptme", 789)
+
+
+def test_parse_pr_url_takes_precedence_over_second_arg() -> None:
+    # A URL should be parsed as-is even when a stray second arg is present.
+    url = "https://github.com/owner/repo/pull/12"
+    assert parse_pr(url, "99") == ("owner", "repo", 12)
+
+
+def test_parse_pr_invalid_exits_2() -> None:
+    with pytest.raises(SystemExit) as exc:
+        parse_pr("not-a-pr-spec", None)
+    assert exc.value.code == 2
+
+
+def test_targeting_excludes_resolved() -> None:
+    # Mirrors main()'s target filter: skip resolved; honor --outdated-only.
+    threads = [
+        {"id": "a", "isResolved": True, "isOutdated": True, "path": "x"},
+        {"id": "b", "isResolved": False, "isOutdated": False, "path": "y"},
+        {"id": "c", "isResolved": False, "isOutdated": True, "path": "z"},
+    ]
+    all_targets = [
+        t for t in threads if not t["isResolved"] and (t["isOutdated"] or not False)
+    ]
+    assert {t["id"] for t in all_targets} == {"b", "c"}
+
+    outdated_targets = [
+        t for t in threads if not t["isResolved"] and (t["isOutdated"] or not True)
+    ]
+    assert {t["id"] for t in outdated_targets} == {"c"}


### PR DESCRIPTION
## What

Adds `scripts/github/resolve-greptile-threads.py` — resolves **addressed** Greptile review threads via the `resolveReviewThread` GraphQL mutation.

## Why

`self-merge-check.py` blocks on *any* unresolved Greptile review thread. But our flow replies to nitpicks rather than resolving them, so the deterministic self-merge path never fires on nitpick-laden PRs. This is the missing primitive (modeled on greptileai's MIT greploop skill): call it fix-first after addressing findings, or with `--outdated-only` for the conservative 'code changed since the comment' heuristic.

The README hub added in #1080 already advertised this tool as 'Alice-contributed', but the file was never landed — **this closes that gap** (README now points at a real file).

## Safety / robustness

- Only ever resolves Greptile-**bot**-authored threads — never human threads.
- Paginates `reviewThreads` so it can't silently undercount unresolved threads.
- Per-thread resolve failures are non-fatal (loop continues); GraphQL HTTP-200-with-errors handled.

## Tests

`tests/test_resolve_greptile_threads.py` — `parse_pr` (hash / two-arg / URL / invalid) + the targeting filter (resolved-exclusion, `--outdated-only`). 6 passing.

## Usage

```bash
python3 scripts/github/resolve-greptile-threads.py owner/repo#123 --dry-run
python3 scripts/github/resolve-greptile-threads.py owner/repo#123 --json
```

cc @TimeToBuildBob — this is the net-new piece from the greploop consolidation; pairs with your `pr-address-wait-and-merge.sh` + the score floor (#1080).