### PR TITLE
feat(gptodo): add 'status --json' for machine-readable output

### DIFF
--- a/packages/gptodo/README.md
+++ b/packages/gptodo/README.md
@@ -60,6 +60,38 @@ gptodo list --priority high
 gptodo list --state active
 ```
 
+### Machine-Readable Output (`--json`)
+
+Scripts should parse `--json` rather than grep the rendered human output (the
+emoji/formatting are not a stable contract).
+
+```bash
+# Detect whether any task is active (used by autonomous-run gates)
+gptodo status --json | jq -e 'any(.tasks[]; .state == "active")'
+
+# Per-state counts
+gptodo status --json | jq '.summary.by_state'
+```
+
+Single-type shape (default):
+
+```json
+{
+  "type": "tasks",
+  "tasks": [ { "id": "...", "state": "active", "priority": "high", ... } ],
+  "summary": {
+    "total": 12,
+    "by_state": { "active": 1, "backlog": 11 },
+    "issues": 0,
+    "untracked": 0
+  }
+}
+```
+
+With `--all`, results are grouped under `types` keyed by directory type, each
+holding the same `{type, tasks, summary}` shape. `gptodo list`, `ready`, and
+`next` also support `--json` (and `--jsonl`).
+
 ### Generate Work Queue
 
 ```bash

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -740,6 +740,13 @@ def _build_status_json(dir_type: str, results: Dict[str, List[TaskInfo]]) -> Dic
     tasks.extend(task_to_dict(t) for t in issues)
     tasks.extend(task_to_dict(t) for t in untracked)
 
+    # Tasks with validation issues are bucketed separately in check_all() and
+    # excluded from state buckets, so we count them into by_state here to keep
+    # by_state consistent with tasks[] (both should reflect actual task state).
+    for task in issues:
+        if task.state:
+            by_state[task.state] = by_state.get(task.state, 0) + 1
+
     return {
         "type": dir_type,
         "tasks": tasks,

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -707,6 +707,51 @@ def print_summary(console: Console, results: Dict[str, List[TaskInfo]], config: 
         console.print(f"\n{config.emoji} Summary: {total} total ({', '.join(summary_parts)})")
 
 
+def _build_status_json(dir_type: str, results: Dict[str, List[TaskInfo]]) -> Dict[str, Any]:
+    """Build a JSON-serializable status payload for one directory type.
+
+    Shape:
+        {
+          "type": "tasks",
+          "tasks": [<task_to_dict>, ...],   # every task, all states
+          "summary": {
+            "total": int,
+            "by_state": {"active": int, "backlog": int, ...},
+            "issues": int,      # tasks with validation problems
+            "untracked": int,   # files with no state
+          }
+        }
+
+    Each task in check_all() lands in exactly one bucket, so the flattened
+    "tasks" list has no duplicates and `total` equals its length.
+    """
+    config = CONFIGS[dir_type]
+    by_state: Dict[str, int] = {}
+    tasks: List[Dict[str, Any]] = []
+
+    for state in config.states:
+        items = results.get(state, [])
+        if items:
+            by_state[state] = len(items)
+            tasks.extend(task_to_dict(t) for t in items)
+
+    issues = results.get("issues", [])
+    untracked = results.get("untracked", [])
+    tasks.extend(task_to_dict(t) for t in issues)
+    tasks.extend(task_to_dict(t) for t in untracked)
+
+    return {
+        "type": dir_type,
+        "tasks": tasks,
+        "summary": {
+            "total": len(tasks),
+            "by_state": by_state,
+            "issues": len(issues),
+            "untracked": len(untracked),
+        },
+    }
+
+
 def check_directory(
     console: Console, dir_type: str, repo_root: Path, compact: bool = False
 ) -> Dict[str, List[TaskInfo]]:
@@ -907,10 +952,32 @@ def _show_github_issues(
     default=None,
     help="GitHub repo for --github (default: auto-detect via gh CLI)",
 )
-def status(type, all, compact, summary, issues, github, github_repo):
+@click.option(
+    "--json",
+    "output_json",
+    is_flag=True,
+    help="Emit machine-readable JSON instead of rendered output (stable contract for scripts)",
+)
+def status(type, all, compact, summary, issues, github, github_repo, output_json):
     """Show status of tasks and other tracked items."""
     console = Console()
     repo_root = find_repo_root(Path.cwd())
+
+    # Machine-readable output: stable contract for scripts (avoids grepping
+    # rich-rendered human output, which depends on emoji/formatting). The
+    # display-only flags (--compact/--summary/--issues/--github) are ignored;
+    # consumers filter the full task list themselves.
+    if output_json:
+        if all:
+            payload: Dict[str, Any] = {"all": True, "types": {}}
+            for type_name in CONFIGS.keys():
+                results = StateChecker(repo_root, CONFIGS[type_name]).check_all()
+                payload["types"][type_name] = _build_status_json(type_name, results)
+        else:
+            results = StateChecker(repo_root, CONFIGS[type]).check_all()
+            payload = _build_status_json(type, results)
+        print(json.dumps(payload, indent=2))
+        return
 
     # Collect results from all directories
     all_results = {}

--- a/packages/gptodo/tests/test_status_json.py
+++ b/packages/gptodo/tests/test_status_json.py
@@ -100,6 +100,36 @@ def test_status_json_all_groups_by_type(tmp_path: Path, monkeypatch) -> None:
     assert payload["types"]["tasks"]["summary"]["total"] == 1
 
 
+def test_status_json_by_state_consistent_with_tasks_for_issue_tasks(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """by_state must count active tasks even when they have validation issues.
+
+    A task with state="active" but a missing 'created' field lands in the
+    "issues" bucket in check_all(), not the "active" bucket. Without the fix,
+    by_state["active"] would be 0 while tasks[] has an entry with state="active",
+    making by_state inconsistent with tasks[].
+    """
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    # Valid task
+    write_task(tasks_dir, "clean", state="active", created="2026-03-28T00:00:00")
+    # Task with validation issue (missing 'created') but state="active"
+    write_task(tasks_dir, "broken", state="active")
+
+    payload = _run_status_json(tmp_path, monkeypatch)
+
+    # Both tasks appear in tasks[]
+    task_states = {t["id"]: t["state"] for t in payload["tasks"]}
+    assert task_states.get("clean") == "active"
+    assert task_states.get("broken") == "active"
+
+    # by_state["active"] must count both (clean + broken)
+    assert payload["summary"]["by_state"].get("active", 0) == 2
+    # issues counter reflects the broken task
+    assert payload["summary"]["issues"] == 1
+
+
 def test_status_json_includes_serialized_task_fields(tmp_path: Path, monkeypatch) -> None:
     tasks_dir = tmp_path / "tasks"
     tasks_dir.mkdir()

--- a/packages/gptodo/tests/test_status_json.py
+++ b/packages/gptodo/tests/test_status_json.py
@@ -1,0 +1,120 @@
+"""Tests for `gptodo status --json` machine-readable output.
+
+The autonomous-run scripts must not grep rich-rendered human output to detect
+active work — `--json` is the stable contract they parse instead.
+"""
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from gptodo.cli import cli
+
+
+def write_task(tasks_dir: Path, name: str, **metadata: object) -> None:
+    """Write a minimal task file with YAML frontmatter."""
+    lines = ["---"]
+    for key, value in metadata.items():
+        if isinstance(value, list):
+            lines.append(f"{key}:")
+            for item in value:
+                lines.append(f"  - {item}")
+        else:
+            lines.append(f"{key}: {value}")
+    lines.extend(["---", f"# {name}"])
+    (tasks_dir / f"{name}.md").write_text("\n".join(lines))
+
+
+def _run_status_json(tmp_path: Path, monkeypatch, *extra_args: str) -> dict:
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(cli, ["status", "--json", *extra_args])
+    assert result.exit_code == 0, result.output
+    return json.loads(result.output)
+
+
+def test_status_json_emits_valid_parseable_json(tmp_path: Path, monkeypatch) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(tasks_dir, "a", state="active", created="2026-03-28T00:00:00")
+    write_task(tasks_dir, "b", state="backlog", created="2026-03-28T00:00:00")
+
+    payload = _run_status_json(tmp_path, monkeypatch)
+
+    assert payload["type"] == "tasks"
+    assert {t["id"] for t in payload["tasks"]} == {"a", "b"}
+    assert payload["summary"]["total"] == 2
+
+
+def test_status_json_summary_counts_by_state(tmp_path: Path, monkeypatch) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(tasks_dir, "a", state="active", created="2026-03-28T00:00:00")
+    write_task(tasks_dir, "b", state="backlog", created="2026-03-28T00:00:00")
+    write_task(tasks_dir, "c", state="backlog", created="2026-03-28T00:00:00")
+    write_task(tasks_dir, "d", state="done", created="2026-03-28T00:00:00")
+
+    payload = _run_status_json(tmp_path, monkeypatch)
+
+    by_state = payload["summary"]["by_state"]
+    assert by_state == {"active": 1, "backlog": 2, "done": 1}
+    # total == flattened task count (no double counting across buckets)
+    assert payload["summary"]["total"] == len(payload["tasks"]) == 4
+
+
+def test_status_json_active_detection_contract(tmp_path: Path, monkeypatch) -> None:
+    """The contract autonomous-run-cc.sh relies on: detect any active task."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(tasks_dir, "only-backlog", state="backlog", created="2026-03-28T00:00:00")
+
+    payload = _run_status_json(tmp_path, monkeypatch)
+    has_active = any(t["state"] == "active" for t in payload["tasks"])
+    assert has_active is False
+
+    write_task(tasks_dir, "now-active", state="active", created="2026-03-28T00:00:00")
+    payload = _run_status_json(tmp_path, monkeypatch)
+    has_active = any(t["state"] == "active" for t in payload["tasks"])
+    assert has_active is True
+
+
+def test_status_json_empty_directory(tmp_path: Path, monkeypatch) -> None:
+    (tmp_path / "tasks").mkdir()
+
+    payload = _run_status_json(tmp_path, monkeypatch)
+
+    assert payload["tasks"] == []
+    assert payload["summary"]["total"] == 0
+    assert payload["summary"]["by_state"] == {}
+
+
+def test_status_json_all_groups_by_type(tmp_path: Path, monkeypatch) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(tasks_dir, "a", state="active", created="2026-03-28T00:00:00")
+
+    payload = _run_status_json(tmp_path, monkeypatch, "--all")
+
+    assert payload["all"] is True
+    assert "tasks" in payload["types"]
+    assert payload["types"]["tasks"]["summary"]["total"] == 1
+
+
+def test_status_json_includes_serialized_task_fields(tmp_path: Path, monkeypatch) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(
+        tasks_dir,
+        "rich-task",
+        state="active",
+        priority="high",
+        created="2026-03-28T00:00:00",
+        tags=["infra", "tooling"],
+    )
+
+    payload = _run_status_json(tmp_path, monkeypatch)
+    task = next(t for t in payload["tasks"] if t["id"] == "rich-task")
+    assert task["state"] == "active"
+    assert task["priority"] == "high"
+    assert task["tags"] == ["infra", "tooling"]
+    assert task["subtasks"] == {"completed": 0, "total": 0}


### PR DESCRIPTION
## What

Adds a `--json` flag to `gptodo status` so scripts can parse a stable contract instead of grepping the rich-rendered human output.

## Why

`autonomous-run-cc.sh` currently detects active work by matching `🏃 ACTIVE \([1-9]` against rendered `gptodo status` output, in two places (the activity-gate work-signal check and the exhaustion-gate active-task bypass). Grepping rendered output is fragile — it depends on the emoji, the exact `ACTIVE (N)` formatting, and rich's terminal rendering. A `--json` flag gives a parseable, formatting-independent contract.

## Shape

Single type (default):

```json
{
  "type": "tasks",
  "tasks": [ { "id": "...", "state": "active", "priority": "high", ... } ],
  "summary": { "total": 12, "by_state": { "active": 1, "backlog": 11 }, "issues": 0, "untracked": 0 }
}
```

`--all` groups results under `types` keyed by directory type, each holding the same `{type, tasks, summary}` shape.

Reuses the existing `task_to_dict` serializer — same task shape as `list`/`ready`/`next --json`.

The detection contract scripts will use:

```bash
gptodo status --json | jq -e 'any(.tasks[]; .state == "active")'
```

## Tests

`tests/test_status_json.py` — 6 cases including empty dir, by-state counts, the any-active detection contract, `--all` grouping, and serialized task fields. Full suite: 210 passed.

## Follow-up (separate, agent-local)

After this lands and the installed gptodo is upgraded, refactor the two `autonomous-run-cc.sh` grep sites to use `gptodo status --json | jq` (tracked in alice task `gptodo-status-json-output`).