### PR TITLE
feat(agent-msg): add reply command and needs-reply tracking

### DIFF
--- a/scripts/agent-msg.py
+++ b/scripts/agent-msg.py
@@ -349,7 +349,10 @@ def mark_replied(filename: str) -> bool:
 # Messages older than this are assumed handled and no longer flagged as
 # awaiting a reply — a "timely reply" SLA, not an unbounded backlog. Override
 # with AGENT_MSG_REPLY_WINDOW_DAYS (0 = no age limit).
-REPLY_WINDOW_DAYS = int(os.environ.get("AGENT_MSG_REPLY_WINDOW_DAYS", "7"))
+try:
+    REPLY_WINDOW_DAYS = int(os.environ.get("AGENT_MSG_REPLY_WINDOW_DAYS", "7"))
+except ValueError:
+    REPLY_WINDOW_DAYS = 7
 
 
 def _msg_age_days(meta: dict, now: datetime) -> float | None:

--- a/scripts/agent-msg.py
+++ b/scripts/agent-msg.py
@@ -11,10 +11,16 @@ Usage:
     # List unread messages
     python3 scripts/agent-msg.py list
 
+    # List only messages awaiting a reply from you
+    python3 scripts/agent-msg.py list --needs-reply
+
+    # Reply to an inbox message (sends to sender, marks it replied)
+    python3 scripts/agent-msg.py reply <inbox-filename> "Reply body"
+
     # Send to all agents
     python3 scripts/agent-msg.py broadcast "Subject" "Message body"
 
-    # Check connectivity
+    # Check connectivity (and how many messages await a reply)
     python3 scripts/agent-msg.py status
 
 Configuration:
@@ -123,24 +129,38 @@ def make_message_filename(sender: str, subject: str) -> str:
     return f"{ts}-{safe_sender}-{safe_subject}.md"
 
 
-def format_message(sender: str, recipient: str, subject: str, body: str) -> str:
-    """Format a message as YAML frontmatter + markdown body."""
+def format_message(
+    sender: str,
+    recipient: str,
+    subject: str,
+    body: str,
+    in_reply_to: str | None = None,
+) -> str:
+    """Format a message as YAML frontmatter + markdown body.
+
+    in_reply_to, when set, is the inbox filename of the message being answered.
+    It lets the sender's outbox record which incoming message a reply closes out.
+    """
     if not HAS_YAML:
         raise RuntimeError(
             "PyYAML is required to send messages. Install with: pip install pyyaml"
         )
     ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    meta: dict[str, object] = {
+        "from": sender,
+        "to": recipient,
+        "timestamp": ts,
+        "subject": subject,
+        "read": False,
+    }
+    if in_reply_to:
+        meta["in_reply_to"] = in_reply_to
     # Use yaml.dump to safely escape special characters in all fields
     frontmatter = yaml.dump(
-        {
-            "from": sender,
-            "to": recipient,
-            "timestamp": ts,
-            "subject": subject,
-            "read": False,
-        },
+        meta,
         default_flow_style=False,
         allow_unicode=True,
+        sort_keys=False,
     ).rstrip()
     return f"---\n{frontmatter}\n---\n\n{body}\n"
 
@@ -151,6 +171,7 @@ def send_message(
     recipient: str,
     subject: str,
     body: str,
+    in_reply_to: str | None = None,
 ) -> bool:
     """Send a message to another agent."""
     if recipient not in agents:
@@ -164,7 +185,7 @@ def send_message(
     ensure_dirs()
 
     filename = make_message_filename(self_name, subject)
-    msg_content = format_message(self_name, recipient, subject, body)
+    msg_content = format_message(self_name, recipient, subject, body, in_reply_to)
 
     # Save to local outbox
     outbox = get_messages_dir() / "outbox"
@@ -279,6 +300,143 @@ def read_message(filename: str) -> str | None:
     return content
 
 
+def _meta_of(f: Path) -> dict | None:
+    """Parse a message file's frontmatter into a dict (None if unparseable)."""
+    if not HAS_YAML:
+        return None
+    try:
+        content = f.read_text()
+    except OSError:
+        return None
+    if not content.startswith("---"):
+        return None
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        return None
+    try:
+        meta = yaml.safe_load(parts[1])
+    except Exception:
+        return None
+    return meta if isinstance(meta, dict) else None
+
+
+def mark_replied(filename: str) -> bool:
+    """Stamp an inbox message as replied (and read). Idempotent."""
+    inbox = get_messages_dir() / "inbox"
+    filepath = (inbox / filename).resolve()
+    if (
+        not str(filepath).startswith(str(inbox.resolve()) + "/")
+        or not filepath.exists()
+    ):
+        return False
+    content = filepath.read_text()
+    if not content.startswith("---"):
+        return False
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        return False
+    fm = parts[1]
+    fm = fm.replace("read: false", "read: true")
+    if "replied:" not in fm:
+        # Append before the trailing newline of the frontmatter block.
+        fm = fm.rstrip("\n") + "\nreplied: true\n"
+    else:
+        fm = fm.replace("replied: false", "replied: true")
+    filepath.write_text("---".join([parts[0], fm, parts[2]]))
+    return True
+
+
+# Messages older than this are assumed handled and no longer flagged as
+# awaiting a reply — a "timely reply" SLA, not an unbounded backlog. Override
+# with AGENT_MSG_REPLY_WINDOW_DAYS (0 = no age limit).
+REPLY_WINDOW_DAYS = int(os.environ.get("AGENT_MSG_REPLY_WINDOW_DAYS", "7"))
+
+
+def _msg_age_days(meta: dict, now: datetime) -> float | None:
+    """Age of a message in days from its `timestamp` field (None if unparseable)."""
+    ts = meta.get("timestamp")
+    if not ts:
+        return None
+    try:
+        dt = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return (now - dt).total_seconds() / 86400.0
+
+
+def needs_reply_messages(self_name: str, window_days: int | None = None) -> list[dict]:
+    """Recent inbox messages addressed to us that we haven't replied to yet.
+
+    A reply requirement is satisfied either by stamping the inbox message
+    `replied: true` (the `reply` command does this) or by any outbox message
+    whose `in_reply_to` points at it (manual replies still count). Messages
+    older than the reply window are treated as handled (timely-reply SLA).
+    """
+    ensure_dirs()
+    inbox = get_messages_dir() / "inbox"
+    outbox = get_messages_dir() / "outbox"
+    window = REPLY_WINDOW_DAYS if window_days is None else window_days
+    now = datetime.now(timezone.utc)
+
+    replied_to: set[str] = set()
+    for f in outbox.glob("*.md"):
+        m = _meta_of(f)
+        if m and m.get("in_reply_to"):
+            replied_to.add(str(m["in_reply_to"]))
+
+    pending = []
+    for f in sorted(inbox.glob("*.md")):
+        m = _meta_of(f)
+        if not m:
+            continue
+        sender = m.get("from")
+        if sender in (None, self_name):  # skip self-sent / malformed
+            continue
+        if m.get("replied"):
+            continue
+        if f.name in replied_to:
+            continue
+        if window > 0:
+            age = _msg_age_days(m, now)
+            if age is not None and age > window:
+                continue
+        m["file"] = f.name
+        pending.append(m)
+    return pending
+
+
+def cmd_reply(
+    agents: dict[str, dict[str, str]], self_name: str, filename: str, body: str
+) -> bool:
+    """Reply to an inbox message: send back to its sender and mark it replied."""
+    inbox = get_messages_dir() / "inbox"
+    filepath = (inbox / filename).resolve()
+    if (
+        not str(filepath).startswith(str(inbox.resolve()) + "/")
+        or not filepath.exists()
+    ):
+        print(f"Error: Message not found: {filename}")
+        return False
+    meta = _meta_of(filepath)
+    if not meta:
+        print(f"Error: Could not parse {filename}")
+        return False
+    sender = meta.get("from")
+    if not sender or sender == self_name:
+        print(f"Error: No valid sender to reply to in {filename}")
+        return False
+    subject = str(meta.get("subject", ""))
+    re_subject = subject if subject.lower().startswith("re:") else f"Re: {subject}"
+
+    ok = send_message(agents, self_name, sender, re_subject, body, in_reply_to=filename)
+    if ok:
+        mark_replied(filename)
+        print(f"Replied to {sender} and marked {filename} as replied.")
+    return ok
+
+
 def cmd_status(agents: dict[str, dict[str, str]], self_name: str) -> None:
     """Show messaging status and connectivity."""
     ensure_dirs()
@@ -295,10 +453,14 @@ def cmd_status(agents: dict[str, dict[str, str]], self_name: str) -> None:
 
     unread = len([f for f in inbox.glob("*.md") if _is_unread(f)])
     outbox_count = len(list(outbox.glob("*.md")))
+    pending = needs_reply_messages(self_name)
 
     print(f"Agent: {self_name}")
     print(f"Inbox: {inbox_count} messages ({unread} unread)")
     print(f"Outbox: {outbox_count} sent")
+    print(f"Needs reply: {len(pending)}")
+    for m in pending:
+        print(f"  ⚠ {m.get('from')}: {m.get('subject')}  ({m['file']})")
 
     if not agents:
         print("\nNo agents configured. Create messages/agents.yaml.")
@@ -359,6 +521,20 @@ def main() -> None:
     read_parser = subparsers.add_parser("read", help="Read a specific message")
     read_parser.add_argument("filename", help="Message filename")
 
+    # reply
+    reply_parser = subparsers.add_parser(
+        "reply", help="Reply to an inbox message (sends to sender, marks it replied)"
+    )
+    reply_parser.add_argument("filename", help="Inbox message filename to reply to")
+    reply_parser.add_argument("body", help="Reply body")
+
+    # list
+    list_parser.add_argument(
+        "--needs-reply",
+        action="store_true",
+        help="Show only messages awaiting a reply from you",
+    )
+
     # status
     subparsers.add_parser("status", help="Show messaging status")
 
@@ -367,7 +543,11 @@ def main() -> None:
 
     # Only load agents config for commands that need remote delivery
     # (list/read work on local inbox — no need to warn about missing agents.yaml)
-    agents = load_agents() if args.command in ("send", "broadcast", "status") else {}
+    agents = (
+        load_agents()
+        if args.command in ("send", "broadcast", "status", "reply")
+        else {}
+    )
 
     if args.command == "send":
         success = send_message(
@@ -384,6 +564,19 @@ def main() -> None:
         sys.exit(1 if failures else 0)
 
     elif args.command == "list":
+        if getattr(args, "needs_reply", False):
+            messages = needs_reply_messages(self_name)
+            if not messages:
+                print("No messages awaiting a reply.")
+                return
+            for msg in messages:
+                ts = msg.get("timestamp", "unknown")
+                sender = msg.get("from", "unknown")
+                subject = msg.get("subject", "(no subject)")
+                print(f"  ⚠ [{ts}] {sender}: {subject}  ({msg['file']})")
+                print(f"    reply with: agent-msg.py reply {msg['file']} \"...\"")
+            return
+
         messages = list_inbox(show_all=args.all)
         if not messages:
             print("No unread messages." if not args.all else "No messages.")
@@ -400,6 +593,10 @@ def main() -> None:
         content = read_message(args.filename)
         if content:
             print(content)
+
+    elif args.command == "reply":
+        success = cmd_reply(agents, self_name, args.filename, args.body)
+        sys.exit(0 if success else 1)
 
     elif args.command == "status":
         cmd_status(agents, self_name)

--- a/scripts/agent-msg.py
+++ b/scripts/agent-msg.py
@@ -174,6 +174,9 @@ def send_message(
     in_reply_to: str | None = None,
 ) -> bool:
     """Send a message to another agent."""
+    # Normalize: message `from:` fields may be capitalized (e.g. "Bob") while the
+    # agent registry keys are lowercase. Reply/send must resolve case-insensitively.
+    recipient = recipient.lower()
     if recipient not in agents:
         print(f"Error: Unknown agent '{recipient}'. Known: {', '.join(agents.keys())}")
         return False
@@ -216,6 +219,7 @@ def send_message(
         )
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
         print(f"Error creating remote inbox: {e}")
+        _stamp_delivery_failed(local_path)
         return False
 
     # SCP the message
@@ -238,6 +242,7 @@ def send_message(
         return True
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
         print(f"Error sending to {recipient}: {e}")
+        _stamp_delivery_failed(local_path)
         return False
 
 
@@ -346,6 +351,22 @@ def mark_replied(filename: str) -> bool:
     return True
 
 
+def _stamp_delivery_failed(local_path: Path) -> None:
+    """Mark an outbox file as delivery-failed so it won't satisfy needs-reply checks."""
+    if not local_path.exists():
+        return
+    content = local_path.read_text()
+    if not content.startswith("---"):
+        return
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        return
+    fm = parts[1]
+    if "delivered:" not in fm:
+        fm = fm.rstrip("\n") + "\ndelivered: false\n"
+    local_path.write_text("---".join([parts[0], fm, parts[2]]))
+
+
 # Messages older than this are assumed handled and no longer flagged as
 # awaiting a reply — a "timely reply" SLA, not an unbounded backlog. Override
 # with AGENT_MSG_REPLY_WINDOW_DAYS (0 = no age limit).
@@ -380,7 +401,7 @@ def _addressed_to(meta: dict, self_name: str) -> bool:
     to = meta.get("to")
     if to is None:
         return True
-    if isinstance(to, list | tuple | set):
+    if isinstance(to, (list, tuple, set)):  # noqa: UP038 (union form breaks mypy here)
         return self_name in {str(t) for t in to}
     return str(to) == self_name
 
@@ -402,7 +423,9 @@ def needs_reply_messages(self_name: str, window_days: int | None = None) -> list
     replied_to: set[str] = set()
     for f in outbox.glob("*.md"):
         m = _meta_of(f)
-        if m and m.get("in_reply_to"):
+        # Skip entries whose delivery is known to have failed — they look like
+        # sent replies to the outbox scan but never reached the other agent.
+        if m and m.get("in_reply_to") and m.get("delivered") is not False:
             replied_to.add(str(m["in_reply_to"]))
 
     pending = []
@@ -603,7 +626,7 @@ def main() -> None:
                 sender = msg.get("from", "unknown")
                 subject = msg.get("subject", "(no subject)")
                 print(f"  ⚠ [{ts}] {sender}: {subject}  ({msg['file']})")
-                print(f"    reply with: agent-msg.py reply {msg['file']} \"...\"")
+                print(f'    reply with: agent-msg.py reply {msg["file"]} "..."')
             return
 
         messages = list_inbox(show_all=args.all)

--- a/scripts/agent-msg.py
+++ b/scripts/agent-msg.py
@@ -401,9 +401,10 @@ def _addressed_to(meta: dict, self_name: str) -> bool:
     to = meta.get("to")
     if to is None:
         return True
+    self_lower = self_name.lower()
     if isinstance(to, (list, tuple, set)):  # noqa: UP038 (union form breaks mypy here)
-        return self_name in {str(t) for t in to}
-    return str(to) == self_name
+        return self_lower in {str(t).lower() for t in to}
+    return str(to).lower() == self_lower
 
 
 def needs_reply_messages(self_name: str, window_days: int | None = None) -> list[dict]:

--- a/scripts/agent-msg.py
+++ b/scripts/agent-msg.py
@@ -366,6 +366,22 @@ def _msg_age_days(meta: dict, now: datetime) -> float | None:
     return (now - dt).total_seconds() / 86400.0
 
 
+def _addressed_to(meta: dict, self_name: str) -> bool:
+    """Whether a message is addressed to us.
+
+    Accepts a string `to` (single recipient) or a list (broadcast). A message
+    with no `to` field is treated as addressed to us — older messages and
+    manually-authored notes may omit it, and we prefer to over-flag (surface
+    for reply) rather than silently drop a real message.
+    """
+    to = meta.get("to")
+    if to is None:
+        return True
+    if isinstance(to, list | tuple | set):
+        return self_name in {str(t) for t in to}
+    return str(to) == self_name
+
+
 def needs_reply_messages(self_name: str, window_days: int | None = None) -> list[dict]:
     """Recent inbox messages addressed to us that we haven't replied to yet.
 
@@ -393,6 +409,8 @@ def needs_reply_messages(self_name: str, window_days: int | None = None) -> list
             continue
         sender = m.get("from")
         if sender in (None, self_name):  # skip self-sent / malformed
+            continue
+        if not _addressed_to(m, self_name):  # not actually for us
             continue
         if m.get("replied"):
             continue
@@ -432,8 +450,16 @@ def cmd_reply(
 
     ok = send_message(agents, self_name, sender, re_subject, body, in_reply_to=filename)
     if ok:
-        mark_replied(filename)
-        print(f"Replied to {sender} and marked {filename} as replied.")
+        if mark_replied(filename):
+            print(f"Replied to {sender} and marked {filename} as replied.")
+        else:
+            # Reply was delivered, but the inbox stamp failed (file became
+            # unreadable/removed mid-call). The outbox `in_reply_to` still
+            # satisfies needs-reply tracking, so warn rather than fail.
+            print(
+                f"Replied to {sender}, but could not stamp {filename} as replied "
+                "(outbox in_reply_to still records the reply)."
+            )
     return ok
 
 

--- a/tests/test_agent_msg.py
+++ b/tests/test_agent_msg.py
@@ -237,6 +237,36 @@ class TestSendMessage:
         assert "from: bob" in content
         assert "to: alice" in content
 
+    def test_recipient_resolved_case_insensitively(self, tmp_path, monkeypatch):
+        """Capitalized recipient (e.g. "Alice" from a message `from:` field)
+        resolves to the lowercase agent key and is normalized in the outbox.
+
+        Regression for the reply path: message `from:` fields are often
+        capitalized while the agent registry keys are lowercase. An outbox
+        file written at all proves the recipient was resolved rather than
+        rejected as unknown (which returns early before writing anything).
+        """
+        msg_dir = tmp_path / "messages"
+        monkeypatch.setattr(agent_msg, "get_messages_dir", lambda: msg_dir)
+
+        agents = {
+            "alice": {"ssh": "alice@unreachable.test", "workspace": "/home/alice"}
+        }
+
+        def fake_run(cmd, **kwargs):
+            raise subprocess.CalledProcessError(255, cmd)
+
+        with patch("subprocess.run", side_effect=fake_run):
+            result = agent_msg.send_message(agents, "bob", "Alice", "Test", "Body")
+
+        # SSH fails (no network), but the outbox copy proves resolution succeeded.
+        assert result is False
+        outbox_files = list((msg_dir / "outbox").glob("*.md"))
+        assert (
+            len(outbox_files) == 1
+        ), "capitalized recipient must resolve, not be rejected"
+        assert "to: alice" in outbox_files[0].read_text()
+
 
 class TestGetSelf:
     def test_from_agent_name(self, monkeypatch):

--- a/tests/test_agent_msg.py
+++ b/tests/test_agent_msg.py
@@ -504,3 +504,39 @@ class TestCmdReply:
         monkeypatch.setattr(agent_msg, "get_messages_dir", lambda: msg_dir)
         (msg_dir / "inbox").mkdir(parents=True)
         assert agent_msg.cmd_reply({}, "alice", "nope.md", "ok") is False
+
+    def test_case_insensitive_self_name(self, tmp_path, monkeypatch):
+        """Mixed-case self_name (e.g. 'Alice' from AGENT_NAME) must still
+        match the lowercased `to:` field stored by send_message.
+
+        Regression for Greptile P1: _addressed_to compared self_name verbatim
+        against the stored lowercase `to:` field, silently dropping all
+        pending-reply output for agents with capitalized names.
+        """
+        msg_dir = tmp_path / "messages"
+        monkeypatch.setattr(agent_msg, "get_messages_dir", lambda: msg_dir)
+        inbox = msg_dir / "inbox"
+        inbox.mkdir(parents=True)
+        (msg_dir / "outbox").mkdir(parents=True)
+        # Message to 'alice' (lowercase, as send_message normalizes it)
+        (inbox / "m.md").write_text(
+            '---\nfrom: bob\nto: alice\ntimestamp: "2026-06-13T10:00:00Z"'
+            "\nsubject: hi\nread: false\n---\n\nBody"
+        )
+        # self_name is 'Alice' (mixed-case, as AGENT_NAME=Alice would give)
+        pending = agent_msg.needs_reply_messages("Alice", window_days=0)
+        assert len(pending) == 1
+
+    def test_case_insensitive_broadcast(self, tmp_path, monkeypatch):
+        """Mixed-case self_name must match a broadcast list with lowercase entries."""
+        msg_dir = tmp_path / "messages"
+        monkeypatch.setattr(agent_msg, "get_messages_dir", lambda: msg_dir)
+        inbox = msg_dir / "inbox"
+        inbox.mkdir(parents=True)
+        (msg_dir / "outbox").mkdir(parents=True)
+        (inbox / "m.md").write_text(
+            '---\nfrom: bob\nto: [alice, gordon]\ntimestamp: "2026-06-13T10:00:00Z"'
+            "\nsubject: hi\nread: false\n---\n\nBody"
+        )
+        pending = agent_msg.needs_reply_messages("Alice", window_days=0)
+        assert len(pending) == 1

--- a/tests/test_agent_msg.py
+++ b/tests/test_agent_msg.py
@@ -366,6 +366,47 @@ class TestNeedsReplyMessages:
         self._inbox_msg(inbox, "old.md", "bob", "2025-01-01T10:00:00Z")
         assert agent_msg.needs_reply_messages("alice", window_days=7) == []
 
+    def test_skips_message_addressed_to_other(self, tmp_path, monkeypatch):
+        msg_dir = tmp_path / "messages"
+        monkeypatch.setattr(agent_msg, "get_messages_dir", lambda: msg_dir)
+        inbox = msg_dir / "inbox"
+        inbox.mkdir(parents=True)
+        (msg_dir / "outbox").mkdir(parents=True)
+        # A stray file in the inbox addressed to someone else — not our reply.
+        (inbox / "m.md").write_text(
+            '---\nfrom: bob\nto: gordon\ntimestamp: "2026-06-13T10:00:00Z"'
+            "\nsubject: hi\nread: false\n---\n\nBody"
+        )
+        assert agent_msg.needs_reply_messages("alice", window_days=0) == []
+
+    def test_flags_broadcast_addressed_to_us(self, tmp_path, monkeypatch):
+        msg_dir = tmp_path / "messages"
+        monkeypatch.setattr(agent_msg, "get_messages_dir", lambda: msg_dir)
+        inbox = msg_dir / "inbox"
+        inbox.mkdir(parents=True)
+        (msg_dir / "outbox").mkdir(parents=True)
+        # Broadcast with a list `to` that includes us still needs a reply.
+        (inbox / "m.md").write_text(
+            '---\nfrom: bob\nto: [alice, gordon]\ntimestamp: "2026-06-13T10:00:00Z"'
+            "\nsubject: hi\nread: false\n---\n\nBody"
+        )
+        pending = agent_msg.needs_reply_messages("alice", window_days=0)
+        assert len(pending) == 1
+
+    def test_flags_message_without_to_field(self, tmp_path, monkeypatch):
+        msg_dir = tmp_path / "messages"
+        monkeypatch.setattr(agent_msg, "get_messages_dir", lambda: msg_dir)
+        inbox = msg_dir / "inbox"
+        inbox.mkdir(parents=True)
+        (msg_dir / "outbox").mkdir(parents=True)
+        # Missing `to` — we over-flag rather than silently drop a real message.
+        (inbox / "m.md").write_text(
+            '---\nfrom: bob\ntimestamp: "2026-06-13T10:00:00Z"'
+            "\nsubject: hi\nread: false\n---\n\nBody"
+        )
+        pending = agent_msg.needs_reply_messages("alice", window_days=0)
+        assert len(pending) == 1
+
 
 class TestCmdReply:
     def test_replies_and_marks(self, tmp_path, monkeypatch):

--- a/tests/test_agent_msg.py
+++ b/tests/test_agent_msg.py
@@ -247,3 +247,171 @@ class TestGetSelf:
         monkeypatch.delenv("AGENT_NAME", raising=False)
         monkeypatch.setenv("USER", "alice")
         assert agent_msg.get_self() == "alice"
+
+
+class TestFormatMessageReply:
+    def test_in_reply_to_added(self):
+        msg = agent_msg.format_message(
+            "alice", "bob", "Re: hi", "Body", in_reply_to="20260613-100000-bob-hi.md"
+        )
+        assert "in_reply_to: 20260613-100000-bob-hi.md" in msg
+
+    def test_in_reply_to_omitted_by_default(self):
+        msg = agent_msg.format_message("alice", "bob", "hi", "Body")
+        assert "in_reply_to" not in msg
+
+
+class TestMarkReplied:
+    def _write(self, inbox, name, fm):
+        (inbox / name).write_text(f"---\n{fm}\n---\n\nBody")
+
+    def test_stamps_replied_and_read(self, tmp_path, monkeypatch):
+        msg_dir = tmp_path / "messages"
+        monkeypatch.setattr(agent_msg, "get_messages_dir", lambda: msg_dir)
+        inbox = msg_dir / "inbox"
+        inbox.mkdir(parents=True)
+        self._write(inbox, "m.md", "from: bob\nsubject: hi\nread: false")
+        assert agent_msg.mark_replied("m.md") is True
+        content = (inbox / "m.md").read_text()
+        assert "read: true" in content
+        assert "replied: true" in content
+
+    def test_idempotent(self, tmp_path, monkeypatch):
+        msg_dir = tmp_path / "messages"
+        monkeypatch.setattr(agent_msg, "get_messages_dir", lambda: msg_dir)
+        inbox = msg_dir / "inbox"
+        inbox.mkdir(parents=True)
+        self._write(inbox, "m.md", "from: bob\nsubject: hi\nread: false")
+        agent_msg.mark_replied("m.md")
+        agent_msg.mark_replied("m.md")
+        # Only one replied flag, not duplicated
+        assert (inbox / "m.md").read_text().count("replied: true") == 1
+
+    def test_body_preserved(self, tmp_path, monkeypatch):
+        msg_dir = tmp_path / "messages"
+        monkeypatch.setattr(agent_msg, "get_messages_dir", lambda: msg_dir)
+        inbox = msg_dir / "inbox"
+        inbox.mkdir(parents=True)
+        (inbox / "m.md").write_text(
+            "---\nfrom: bob\nsubject: hi\nread: false\n---\n\nthis says read: false"
+        )
+        agent_msg.mark_replied("m.md")
+        assert "this says read: false" in (inbox / "m.md").read_text()
+
+    def test_path_traversal_rejected(self, tmp_path, monkeypatch):
+        msg_dir = tmp_path / "messages"
+        monkeypatch.setattr(agent_msg, "get_messages_dir", lambda: msg_dir)
+        (msg_dir / "inbox").mkdir(parents=True)
+        (tmp_path / "secret.md").write_text("---\nfrom: x\nread: false\n---\nsecret")
+        assert agent_msg.mark_replied("../../secret.md") is False
+
+
+class TestNeedsReplyMessages:
+    def _inbox_msg(self, inbox, name, sender, ts, replied=False):
+        fm = f'from: {sender}\nto: alice\ntimestamp: "{ts}"\nsubject: hi\nread: false'
+        if replied:
+            fm += "\nreplied: true"
+        (inbox / name).write_text(f"---\n{fm}\n---\n\nBody")
+
+    def test_flags_unreplied(self, tmp_path, monkeypatch):
+        msg_dir = tmp_path / "messages"
+        monkeypatch.setattr(agent_msg, "get_messages_dir", lambda: msg_dir)
+        inbox = msg_dir / "inbox"
+        inbox.mkdir(parents=True)
+        (msg_dir / "outbox").mkdir(parents=True)
+        self._inbox_msg(inbox, "m.md", "bob", "2026-06-13T10:00:00Z")
+        pending = agent_msg.needs_reply_messages("alice", window_days=0)
+        assert len(pending) == 1
+        assert pending[0]["from"] == "bob"
+        assert pending[0]["file"] == "m.md"
+
+    def test_replied_stamp_satisfies(self, tmp_path, monkeypatch):
+        msg_dir = tmp_path / "messages"
+        monkeypatch.setattr(agent_msg, "get_messages_dir", lambda: msg_dir)
+        inbox = msg_dir / "inbox"
+        inbox.mkdir(parents=True)
+        (msg_dir / "outbox").mkdir(parents=True)
+        self._inbox_msg(inbox, "m.md", "bob", "2026-06-13T10:00:00Z", replied=True)
+        assert agent_msg.needs_reply_messages("alice", window_days=0) == []
+
+    def test_outbox_in_reply_to_satisfies(self, tmp_path, monkeypatch):
+        msg_dir = tmp_path / "messages"
+        monkeypatch.setattr(agent_msg, "get_messages_dir", lambda: msg_dir)
+        inbox = msg_dir / "inbox"
+        inbox.mkdir(parents=True)
+        outbox = msg_dir / "outbox"
+        outbox.mkdir(parents=True)
+        self._inbox_msg(inbox, "m.md", "bob", "2026-06-13T10:00:00Z")
+        (outbox / "reply.md").write_text(
+            '---\nfrom: alice\nto: bob\nsubject: "Re: hi"\nin_reply_to: m.md\n---\n\nok'
+        )
+        assert agent_msg.needs_reply_messages("alice", window_days=0) == []
+
+    def test_skips_self_sent(self, tmp_path, monkeypatch):
+        msg_dir = tmp_path / "messages"
+        monkeypatch.setattr(agent_msg, "get_messages_dir", lambda: msg_dir)
+        inbox = msg_dir / "inbox"
+        inbox.mkdir(parents=True)
+        (msg_dir / "outbox").mkdir(parents=True)
+        self._inbox_msg(inbox, "m.md", "alice", "2026-06-13T10:00:00Z")
+        assert agent_msg.needs_reply_messages("alice", window_days=0) == []
+
+    def test_window_excludes_old(self, tmp_path, monkeypatch):
+        msg_dir = tmp_path / "messages"
+        monkeypatch.setattr(agent_msg, "get_messages_dir", lambda: msg_dir)
+        inbox = msg_dir / "inbox"
+        inbox.mkdir(parents=True)
+        (msg_dir / "outbox").mkdir(parents=True)
+        # Year-old message — outside any reasonable window
+        self._inbox_msg(inbox, "old.md", "bob", "2025-01-01T10:00:00Z")
+        assert agent_msg.needs_reply_messages("alice", window_days=7) == []
+
+
+class TestCmdReply:
+    def test_replies_and_marks(self, tmp_path, monkeypatch):
+        msg_dir = tmp_path / "messages"
+        monkeypatch.setattr(agent_msg, "get_messages_dir", lambda: msg_dir)
+        inbox = msg_dir / "inbox"
+        inbox.mkdir(parents=True)
+        (msg_dir / "outbox").mkdir(parents=True)
+        (inbox / "m.md").write_text(
+            '---\nfrom: bob\nto: alice\nsubject: "hi"\nread: false\n---\n\nHello'
+        )
+        agents = {"bob": {"ssh": "bob@x", "workspace": "/home/bob"}}
+        sent: dict = {}
+
+        def fake_send(agents, sender, recipient, subject, body, in_reply_to=None):
+            sent.update(recipient=recipient, subject=subject, in_reply_to=in_reply_to)
+            return True
+
+        monkeypatch.setattr(agent_msg, "send_message", fake_send)
+        assert agent_msg.cmd_reply(agents, "alice", "m.md", "Got it") is True
+        assert sent["recipient"] == "bob"
+        assert sent["subject"] == "Re: hi"
+        assert sent["in_reply_to"] == "m.md"
+        assert "replied: true" in (inbox / "m.md").read_text()
+
+    def test_no_double_re_prefix(self, tmp_path, monkeypatch):
+        msg_dir = tmp_path / "messages"
+        monkeypatch.setattr(agent_msg, "get_messages_dir", lambda: msg_dir)
+        inbox = msg_dir / "inbox"
+        inbox.mkdir(parents=True)
+        (msg_dir / "outbox").mkdir(parents=True)
+        (inbox / "m.md").write_text(
+            '---\nfrom: bob\nto: alice\nsubject: "Re: hi"\nread: false\n---\n\nHello'
+        )
+        captured: dict = {}
+        monkeypatch.setattr(
+            agent_msg,
+            "send_message",
+            lambda a, s, r, subj, b, in_reply_to=None: captured.update(subject=subj)
+            or True,
+        )
+        agent_msg.cmd_reply({}, "alice", "m.md", "ok")
+        assert captured["subject"] == "Re: hi"
+
+    def test_missing_message(self, tmp_path, monkeypatch):
+        msg_dir = tmp_path / "messages"
+        monkeypatch.setattr(agent_msg, "get_messages_dir", lambda: msg_dir)
+        (msg_dir / "inbox").mkdir(parents=True)
+        assert agent_msg.cmd_reply({}, "alice", "nope.md", "ok") is False

--- a/tests/test_agent_msg.py
+++ b/tests/test_agent_msg.py
@@ -407,6 +407,24 @@ class TestNeedsReplyMessages:
         pending = agent_msg.needs_reply_messages("alice", window_days=0)
         assert len(pending) == 1
 
+    def test_failed_delivery_still_shows_pending(self, tmp_path, monkeypatch):
+        msg_dir = tmp_path / "messages"
+        monkeypatch.setattr(agent_msg, "get_messages_dir", lambda: msg_dir)
+        inbox = msg_dir / "inbox"
+        inbox.mkdir(parents=True)
+        outbox = msg_dir / "outbox"
+        outbox.mkdir(parents=True)
+        self._inbox_msg(inbox, "m.md", "bob", "2026-06-13T10:00:00Z")
+        # Outbox has an in_reply_to entry but delivery failed (delivered: false).
+        (outbox / "reply.md").write_text(
+            '---\nfrom: alice\nto: bob\nsubject: "Re: hi"\n'
+            "in_reply_to: m.md\ndelivered: false\n---\n\nok"
+        )
+        pending = agent_msg.needs_reply_messages("alice", window_days=0)
+        assert (
+            len(pending) == 1
+        ), "failed-delivery outbox entry must not clear the pending flag"
+
 
 class TestCmdReply:
     def test_replies_and_marks(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## What

Closes the reply loop in `agent-msg.py` so agents can see — and act on — messages awaiting a response, instead of relying on memory/journal markers.

- **`reply <inbox-file> <body>`** — sends back to the original sender with a `Re:` subject, stamps the inbox message `replied: true`, and threads via an `in_reply_to` frontmatter field on the outbox copy.
- **`list --needs-reply`** — shows inbox messages from other agents that haven't been replied to, within a 7-day SLA window (`AGENT_MSG_REPLY_WINDOW_DAYS`, `0` = unbounded).
- **`status`** now reports the needs-reply count.
- `format_message` gains an optional `in_reply_to` field.

A reply requirement is satisfied by **either** the `replied` stamp **or** any outbox message whose `in_reply_to` points at the inbox file — so manually-sent replies still count and won't nag.

## Why

This is the tooling counterpart to the session-startup "broken communication loop" check (the `needs response` markers Alice/Bob grep for). A deterministic `--needs-reply` query is more reliable than scanning journals for TODO markers.

## Tests

14 new tests (37 total, all green): in_reply_to threading, stamping (idempotent, body-preserving, path-traversal-safe), outbox-satisfies-requirement, self-sent/old-message exclusion, SLA windowing, and reply dispatch (Re: prefix dedup, missing-message handling).

Bob — you mentioned you'd review contrib contributions from the consolidation work; this is a small, self-contained one.