### PR TITLE
feat(gptmail): add channel field to MessageInfo tracker

### DIFF
--- a/packages/gptmail/src/gptmail/communication_utils/state/tracking.py
+++ b/packages/gptmail/src/gptmail/communication_utils/state/tracking.py
@@ -37,6 +37,7 @@ class MessageInfo:
     error: str | None = None
     reason: str | None = None
     reply_id: str | None = None
+    channel: str | None = None
 
     def to_dict(self) -> dict:
         """Convert to dictionary for JSON serialization."""
@@ -164,6 +165,7 @@ class ConversationTracker:
         conversation_id: str,
         message_id: str,
         in_reply_to: str | None = None,
+        channel: str | None = None,
     ) -> MessageInfo:
         """
         Start tracking a new message.
@@ -172,6 +174,9 @@ class ConversationTracker:
             conversation_id: Conversation identifier
             message_id: Message identifier
             in_reply_to: Optional parent message ID
+            channel: Optional transport channel (e.g. "email", "agent") so a
+                single tracker store can serve multiple transports and answer
+                cross-channel "what do I owe a reply to" queries.
 
         Returns:
             Created MessageInfo
@@ -193,6 +198,7 @@ class ConversationTracker:
                 in_reply_to=in_reply_to,
                 state=MessageState.PENDING,
                 created_at=datetime.now().isoformat(),
+                channel=channel,
             )
 
             data["messages"][message_id] = message_info.to_dict()

--- a/packages/gptmail/tests/test_tracking_channel.py
+++ b/packages/gptmail/tests/test_tracking_channel.py
@@ -1,0 +1,72 @@
+"""Tests for the ``channel`` field on tracked messages.
+
+The channel field lets a single ConversationTracker store serve multiple
+transports (email, inter-agent) and answer cross-channel "what do I owe a
+reply to" queries. See task: fold-agent-msg-into-gptmail-single-comms-tool.
+"""
+
+import json
+from pathlib import Path
+
+from gptmail.communication_utils.state.tracking import (
+    ConversationTracker,
+    MessageInfo,
+    MessageState,
+)
+
+
+def test_track_message_records_channel(tmp_path: Path) -> None:
+    tracker = ConversationTracker(tmp_path)
+    info = tracker.track_message("conv1", "msg1", channel="agent")
+    assert info.channel == "agent"
+
+    # Round-trips through the on-disk JSON store.
+    reloaded = tracker.get_message_state("conv1", "msg1")
+    assert reloaded is not None
+    assert reloaded.channel == "agent"
+
+
+def test_channel_defaults_to_none(tmp_path: Path) -> None:
+    """Email transport (and existing callers) omit channel; it stays None."""
+    tracker = ConversationTracker(tmp_path)
+    tracker.track_message("conv1", "msg1")
+    reloaded = tracker.get_message_state("conv1", "msg1")
+    assert reloaded is not None
+    assert reloaded.channel is None
+
+
+def test_legacy_records_without_channel_load(tmp_path: Path) -> None:
+    """Pre-channel #1085 state files must load unchanged (backward compatible)."""
+    state_file = tmp_path / "conv1.json"
+    state_file.write_text(
+        json.dumps(
+            {
+                "conversation_id": "conv1",
+                "messages": {
+                    "msg1": {
+                        "message_id": "msg1",
+                        "conversation_id": "conv1",
+                        "state": "pending",
+                        "created_at": "2026-06-01T00:00:00",
+                    }
+                },
+            }
+        )
+    )
+    tracker = ConversationTracker(tmp_path)
+    info = tracker.get_message_state("conv1", "msg1")
+    assert info is not None
+    assert info.channel is None
+    assert info.state == MessageState.PENDING
+
+
+def test_from_dict_filters_unknown_but_keeps_channel() -> None:
+    info = MessageInfo.from_dict(
+        {
+            "message_id": "m",
+            "state": "pending",
+            "channel": "agent",
+            "platform": "legacy-ignored",
+        }
+    )
+    assert info.channel == "agent"


### PR DESCRIPTION
## What

Adds an optional `channel: str | None = None` field to `MessageInfo` and a `channel` parameter to `ConversationTracker.track_message()`.

## Why

Foundation for folding `agent-msg` into gptmail as a single comms tool (Alice task: `fold-agent-msg-into-gptmail-single-comms-tool`). A single `ConversationTracker` store can now serve multiple transports (email, inter-agent) and answer cross-channel "what do I owe a reply to" queries by filtering on `channel`.

This resolves **Q1** of the gptmail consolidation design (single tracker + channel field), agreed with Bob 2026-06-13.

## Compatibility

Additive and backward-compatible:
- Defaults to `None`, so existing callers (email transport) are unaffected.
- `from_dict` already filters unknown keys, so pre-channel state files (e.g. from #1085) load unchanged.

## Tests

`tests/test_tracking_channel.py`:
- channel round-trips through the on-disk JSON store
- defaults to `None` when omitted
- legacy records without `channel` load fine
- `from_dict` keeps `channel` while filtering unknown fields

cc @TimeToBuildBob — co-owned gptmail work; this is the seam before AgentTransport lands.