### PR TITLE
feat(gptmail): add Transport Protocol + EmailTransport adapter (fold step 1)

### DIFF
--- a/packages/gptmail/src/gptmail/transport/__init__.py
+++ b/packages/gptmail/src/gptmail/transport/__init__.py
@@ -51,6 +51,7 @@ class Transport(Protocol):
         content: str,
         *,
         reply_to: str | None = None,
+        references: list[str] | None = None,
     ) -> str:
         """Send a message and return its message ID.
 
@@ -58,7 +59,12 @@ class Transport(Protocol):
             to: Recipient identifier (email address, agent name, …).
             subject: Message subject.
             content: Message body (Markdown).
-            reply_to: Optional message ID this is a reply to (for threading).
+            reply_to: Optional message ID this is a direct reply to.
+            references: Full ancestor chain for the ``References`` header.
+                When replying, pass the parent's ``References`` list with
+                ``reply_to`` appended so MUAs reconstruct the full thread.
+                If omitted and ``reply_to`` is set, defaults to ``[reply_to]``
+                (single-hop — correct for depth-1 replies).
         """
         ...
 

--- a/packages/gptmail/src/gptmail/transport/__init__.py
+++ b/packages/gptmail/src/gptmail/transport/__init__.py
@@ -31,9 +31,18 @@ class Transport(Protocol):
     queries.
     """
 
-    #: Stable channel identifier stamped onto tracked messages (e.g. ``"email"``,
-    #: ``"agent"``). Used as the ``channel`` field on ``MessageInfo``.
-    channel: str
+    @property
+    def channel(self) -> str:
+        """Stable channel identifier stamped onto tracked messages.
+
+        E.g. ``"email"``, ``"agent"`` — used as the ``channel`` field on
+        ``MessageInfo``. Declared as a property (not a bare data attribute) so
+        ``@runtime_checkable`` ``isinstance()`` checks verify it on Python
+        3.10/3.11, where structural checks only cover method/property members.
+        A concrete class variable (``EmailTransport.channel = "email"``)
+        satisfies it structurally on all supported versions.
+        """
+        ...
 
     def send(
         self,

--- a/packages/gptmail/src/gptmail/transport/__init__.py
+++ b/packages/gptmail/src/gptmail/transport/__init__.py
@@ -1,0 +1,72 @@
+"""Transport seam for gptmail.
+
+gptmail is being folded into a single comms tool that serves both email
+(IMAP/SMTP) and inter-agent (filesystem/SSH) messaging. The two differ only in
+*how* a message is sent, listed, and read — the reply-tracking core
+(``ConversationTracker``) is shared across both, keyed by a ``channel`` field on
+each tracked message.
+
+This module defines the ``Transport`` Protocol: the narrow seam a CLI dispatches
+to regardless of the underlying medium. ``EmailTransport`` (see ``email.py``) is
+a thin adapter over the existing ``lib.AgentEmail`` IMAP/SMTP stack. A future
+``AgentTransport`` will implement the same Protocol over a filesystem inbox with
+**no email-stack imports**, so inter-agent messaging stays testable in isolation
+(no IMAP/SMTP infra). See task ``fold-agent-msg-into-gptmail-single-comms-tool``.
+"""
+
+from datetime import datetime
+from typing import Protocol, runtime_checkable
+
+__all__ = ["Transport", "EmailTransport"]
+
+
+@runtime_checkable
+class Transport(Protocol):
+    """A messaging transport: send, list, read, and locate a conversation.
+
+    Implementations are deliberately thin. Reply-tracking is **not** part of the
+    Protocol — it lives in the shared ``ConversationTracker``, which transports
+    stamp with their :attr:`channel`. This keeps the seam medium-agnostic and
+    lets a single tracker store answer cross-channel "what do I owe a reply to"
+    queries.
+    """
+
+    #: Stable channel identifier stamped onto tracked messages (e.g. ``"email"``,
+    #: ``"agent"``). Used as the ``channel`` field on ``MessageInfo``.
+    channel: str
+
+    def send(
+        self,
+        to: str,
+        subject: str,
+        content: str,
+        *,
+        reply_to: str | None = None,
+    ) -> str:
+        """Send a message and return its message ID.
+
+        Args:
+            to: Recipient identifier (email address, agent name, …).
+            subject: Message subject.
+            content: Message body (Markdown).
+            reply_to: Optional message ID this is a reply to (for threading).
+        """
+        ...
+
+    def list_inbox(self, folder: str = "inbox") -> list[tuple[str, str, datetime]]:
+        """List messages in a folder as ``(message_id, subject, timestamp)``."""
+        ...
+
+    def read(self, message_id: str, include_thread: bool = False) -> str:
+        """Return the rendered message body, optionally with its full thread."""
+        ...
+
+    def conversation_id_for(self, message_id: str) -> str:
+        """Return the ``ConversationTracker`` conversation_id for this message."""
+        ...
+
+
+# Re-exported so callers import both the seam and its first implementation from
+# one place. EmailTransport satisfies Transport structurally (it does not import
+# it), so there is no circular dependency.
+from .email import EmailTransport  # noqa: E402

--- a/packages/gptmail/src/gptmail/transport/email.py
+++ b/packages/gptmail/src/gptmail/transport/email.py
@@ -1,0 +1,60 @@
+"""Email transport: a thin adapter over ``lib.AgentEmail``.
+
+The IMAP/SMTP implementation stays in :class:`gptmail.lib.AgentEmail`. This
+adapter exposes that stack behind the :class:`~gptmail.transport.Transport`
+seam so a unified CLI can dispatch to it alongside the forthcoming inter-agent
+transport. It deliberately adds no behavior — every method delegates.
+"""
+
+from datetime import datetime
+from pathlib import Path
+
+from ..lib import AgentEmail
+
+
+class EmailTransport:
+    """Transport adapter wrapping :class:`gptmail.lib.AgentEmail`."""
+
+    #: Channel identifier stamped onto tracked messages for this transport.
+    channel = "email"
+
+    #: All emails share a single tracker conversation (matches AgentEmail).
+    _CONVERSATION_ID = "email"
+
+    def __init__(
+        self,
+        workspace_dir: str | Path,
+        own_email: str | None = None,
+        own_email_name: str | None = None,
+    ):
+        self._email = AgentEmail(workspace_dir, own_email, own_email_name)
+
+    @property
+    def email(self) -> AgentEmail:
+        """The underlying ``AgentEmail`` (for tracker access and email-only ops)."""
+        return self._email
+
+    def send(
+        self,
+        to: str,
+        subject: str,
+        content: str,
+        *,
+        reply_to: str | None = None,
+    ) -> str:
+        """Compose and deliver an email, returning its message ID."""
+        references = [reply_to] if reply_to else None
+        message_id = self._email.compose(
+            to, subject, content, reply_to=reply_to, references=references
+        )
+        self._email.send(message_id)
+        return message_id
+
+    def list_inbox(self, folder: str = "inbox") -> list[tuple[str, str, datetime]]:
+        return self._email.list_messages(folder)
+
+    def read(self, message_id: str, include_thread: bool = False) -> str:
+        return self._email.read_message(message_id, include_thread=include_thread)
+
+    def conversation_id_for(self, message_id: str) -> str:
+        return self._CONVERSATION_ID

--- a/packages/gptmail/src/gptmail/transport/email.py
+++ b/packages/gptmail/src/gptmail/transport/email.py
@@ -41,11 +41,14 @@ class EmailTransport:
         content: str,
         *,
         reply_to: str | None = None,
+        references: list[str] | None = None,
     ) -> str:
         """Compose and deliver an email, returning its message ID."""
-        references = [reply_to] if reply_to else None
+        effective_refs = (
+            references if references is not None else ([reply_to] if reply_to else None)
+        )
         message_id = self._email.compose(
-            to, subject, content, reply_to=reply_to, references=references
+            to, subject, content, reply_to=reply_to, references=effective_refs
         )
         self._email.send(message_id)
         return message_id

--- a/packages/gptmail/tests/test_transport.py
+++ b/packages/gptmail/tests/test_transport.py
@@ -1,0 +1,69 @@
+"""Tests for the transport seam.
+
+Step 1 of folding agent-msg into gptmail: a ``Transport`` Protocol plus an
+``EmailTransport`` adapter over ``lib.AgentEmail``. These tests exercise the
+seam without touching the network — ``send`` is verified by monkeypatching the
+underlying delivery so no msmtp/SMTP call is made.
+
+See task: fold-agent-msg-into-gptmail-single-comms-tool.
+"""
+
+from datetime import datetime
+from pathlib import Path
+
+from gptmail.transport import EmailTransport, Transport
+
+
+def _make_transport(tmp_path: Path) -> EmailTransport:
+    email_dir = tmp_path / "email"
+    for subdir in ["inbox", "sent", "archive", "drafts", "filters"]:
+        (email_dir / subdir).mkdir(parents=True, exist_ok=True)
+    return EmailTransport(tmp_path, own_email="alice@example.com")
+
+
+def test_email_transport_satisfies_protocol(tmp_path: Path) -> None:
+    transport = _make_transport(tmp_path)
+    # runtime_checkable Protocol — structural conformance.
+    assert isinstance(transport, Transport)
+
+
+def test_channel_is_email(tmp_path: Path) -> None:
+    assert _make_transport(tmp_path).channel == "email"
+
+
+def test_conversation_id_is_constant(tmp_path: Path) -> None:
+    """Email shares a single tracker conversation, matching AgentEmail."""
+    transport = _make_transport(tmp_path)
+    assert transport.conversation_id_for("any-id") == "email"
+
+
+def test_send_delegates_to_compose_and_deliver(tmp_path: Path, monkeypatch) -> None:
+    """send() composes a draft then delivers it, returning the message id.
+
+    Delivery (msmtp) is stubbed so the test stays offline.
+    """
+    transport = _make_transport(tmp_path)
+    delivered: list[str] = []
+    monkeypatch.setattr(transport.email, "send", lambda mid: delivered.append(mid))
+
+    message_id = transport.send("bob@example.com", "Hi", "Hello Bob")
+
+    assert message_id
+    assert delivered == [message_id]
+    # The draft was actually composed on disk before delivery.
+    drafts = list((tmp_path / "email" / "drafts").glob("*"))
+    assert drafts, "expected a composed draft file"
+
+
+def test_list_and_read_delegate(tmp_path: Path, monkeypatch) -> None:
+    transport = _make_transport(tmp_path)
+    sentinel_list: list[tuple[str, str, datetime]] = [("m1", "Subject", datetime(2026, 6, 13))]
+    monkeypatch.setattr(transport.email, "list_messages", lambda folder="inbox": sentinel_list)
+    monkeypatch.setattr(
+        transport.email,
+        "read_message",
+        lambda mid, include_thread=False: f"body:{mid}:{include_thread}",
+    )
+
+    assert transport.list_inbox() == sentinel_list
+    assert transport.read("m1", include_thread=True) == "body:m1:True"

--- a/packages/gptmail/tests/test_transport.py
+++ b/packages/gptmail/tests/test_transport.py
@@ -27,6 +27,32 @@ def test_email_transport_satisfies_protocol(tmp_path: Path) -> None:
     assert isinstance(transport, Transport)
 
 
+def test_missing_channel_fails_protocol() -> None:
+    """A transport without ``channel`` is rejected by ``isinstance``.
+
+    Regression guard for the ``channel`` declaration: as a bare data attribute
+    (``channel: str``), ``@runtime_checkable`` ``isinstance()`` skips it on
+    Python 3.10/3.11 and this object would wrongly pass. Declaring ``channel``
+    as a ``@property`` on the Protocol makes the structural check verify it on
+    all supported versions. (Per Bob's review of PR #1090.)
+    """
+
+    class NoChannelTransport:
+        def send(self, to, subject, content, *, reply_to=None) -> str:
+            return "id"
+
+        def list_inbox(self, folder: str = "inbox"):
+            return []
+
+        def read(self, message_id: str, include_thread: bool = False) -> str:
+            return ""
+
+        def conversation_id_for(self, message_id: str) -> str:
+            return "x"
+
+    assert not isinstance(NoChannelTransport(), Transport)
+
+
 def test_channel_is_email(tmp_path: Path) -> None:
     assert _make_transport(tmp_path).channel == "email"
 

--- a/packages/gptmail/tests/test_transport.py
+++ b/packages/gptmail/tests/test_transport.py
@@ -81,6 +81,32 @@ def test_send_delegates_to_compose_and_deliver(tmp_path: Path, monkeypatch) -> N
     assert drafts, "expected a composed draft file"
 
 
+def test_send_passes_explicit_references(tmp_path: Path, monkeypatch) -> None:
+    """send(references=...) passes the full chain to compose(), not just reply_to.
+
+    Guards the References-truncation fix: callers that build the ancestor chain
+    themselves can pass it explicitly so deep reply threads reconstruct correctly.
+    """
+    transport = _make_transport(tmp_path)
+    captured: list[dict] = []
+
+    original_compose = transport.email.compose
+
+    def capturing_compose(to, subject, content, reply_to=None, references=None):
+        captured.append({"reply_to": reply_to, "references": references})
+        return original_compose(to, subject, content, reply_to=reply_to, references=references)
+
+    monkeypatch.setattr(transport.email, "compose", capturing_compose)
+    monkeypatch.setattr(transport.email, "send", lambda mid: None)
+
+    full_chain = ["id-grandparent", "id-parent"]
+    transport.send(
+        "bob@example.com", "Re: thread", "body", reply_to="id-parent", references=full_chain
+    )
+
+    assert captured[0]["references"] == full_chain
+
+
 def test_list_and_read_delegate(tmp_path: Path, monkeypatch) -> None:
     transport = _make_transport(tmp_path)
     sentinel_list: list[tuple[str, str, datetime]] = [("m1", "Subject", datetime(2026, 6, 13))]


### PR DESCRIPTION
## What

Step 1 of folding `agent-msg` into gptmail as a single comms tool: introduce a narrow **`Transport` Protocol** seam and an **`EmailTransport`** adapter over the existing `lib.AgentEmail` stack.

```
gptmail/transport/
  __init__.py   # Transport Protocol: send / list_inbox / read / conversation_id_for + channel
  email.py      # EmailTransport — thin adapter delegating to lib.AgentEmail (IMAP/SMTP)
```

## Why this shape (seam review)

This is deliberately the **seam only**, so you can review the interface before `AgentTransport` lands:

- **No relocation.** IMAP/SMTP stays in `lib.AgentEmail`; `EmailTransport` just delegates. Email behavior is unchanged — pure addition.
- **Reply-tracking is NOT in the Protocol.** It stays in the shared `ConversationTracker`, stamped per-transport via the `channel` field (#1089). The Protocol is medium-agnostic.
- **Honors your hard constraint.** A future `AgentTransport` implements this same Protocol over a filesystem inbox with **zero email-stack imports**, so inter-agent messaging stays testable in an isolated LXC with no IMAP/SMTP infra. (The `transport.agent` no-email-imports guard test comes with step 2.)
- `EmailTransport.send(to, subject, content, reply_to=)` unifies the email compose→deliver pair behind one verb that the agent transport can also satisfy. `conversation_id_for` returns the constant `"email"`, matching `AgentEmail`'s single-conversation model.

## Tests

`tests/test_transport.py` — offline (msmtp stubbed): Protocol conformance via `runtime_checkable`, channel id, constant conversation id, `send` delegates compose+deliver, list/read delegation. **54/54 gptmail tests pass.**

## Context

Task `fold-agent-msg-into-gptmail-single-comms-tool`, co-owned with Bob. Design Q1–Q3 converged 2026-06-13. Independent of #1089 (channel field) — that's consumed in step 2 when `AgentTransport` stamps `channel="agent"`.

cc @TimeToBuildBob — this is the seam you wanted to review before AgentTransport.