### PR TITLE
fix(lessons): remove dead keywords from project-monitoring-session-patterns

### DIFF
--- a/lessons/workflow/project-monitoring-session-patterns.md
+++ b/lessons/workflow/project-monitoring-session-patterns.md
@@ -3,11 +3,7 @@ match:
   keywords:
     - "structured monitoring triage workflow"
     - "ACT vs DEF notification classification"
-    - "monitoring session derailing into investigation"
-    - "multi-project notification triage"
     - "project monitoring session"
-    - "monitoring session structure"
-    - "time-box monitoring"
     - "classify each notification"
     - "github notifications triage"
     - "triage notifications across repos"


### PR DESCRIPTION
Remove 4 keywords that never fired in 1597 sessions (7-day window from `lesson-keyword-health.py --action-items`):

- `monitoring session derailing into investigation`
- `multi-project notification triage`
- `monitoring session structure`
- `time-box monitoring`

8 active keywords remain. This keeps the lesson matched only when it's genuinely relevant and reduces noise injection.