### PR TITLE
feat(gptmail): add AgentTransport (fold step 2)

### DIFF
--- a/packages/gptmail/src/gptmail/transport/__init__.py
+++ b/packages/gptmail/src/gptmail/transport/__init__.py
@@ -17,7 +17,7 @@ a thin adapter over the existing ``lib.AgentEmail`` IMAP/SMTP stack. A future
 from datetime import datetime
 from typing import Protocol, runtime_checkable
 
-__all__ = ["Transport", "EmailTransport"]
+__all__ = ["Transport", "EmailTransport", "AgentTransport"]
 
 
 @runtime_checkable
@@ -81,7 +81,20 @@ class Transport(Protocol):
         ...
 
 
-# Re-exported so callers import both the seam and its first implementation from
-# one place. EmailTransport satisfies Transport structurally (it does not import
-# it), so there is no circular dependency.
-from .email import EmailTransport  # noqa: E402
+# Re-exported lazily (PEP 562). ``EmailTransport`` and ``AgentTransport`` are
+# importable as ``gptmail.transport.X`` for convenience, but the import is
+# deferred to attribute access so that ``import gptmail.transport.agent`` does
+# NOT eagerly pull in ``.email`` (which imports the IMAP/SMTP stack via
+# ``lib.AgentEmail``). This is what keeps the agent transport usable in isolated
+# LXC sessions with no email infra — the guard test
+# ``test_agent_transport_no_email_imports.py`` enforces it at runtime.
+def __getattr__(name: str):  # noqa: D401
+    if name == "EmailTransport":
+        from .email import EmailTransport
+
+        return EmailTransport
+    if name == "AgentTransport":
+        from .agent import AgentTransport
+
+        return AgentTransport
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/packages/gptmail/src/gptmail/transport/agent.py
+++ b/packages/gptmail/src/gptmail/transport/agent.py
@@ -229,6 +229,20 @@ class AgentTransport:
                 path.write_text(content)
         return content
 
+    def _lookup_meta(self, message_id: str) -> dict | None:
+        for folder in (self.inbox, self.outbox):
+            path = self._resolve_within(folder, message_id)
+            if path is not None:
+                return self._meta_of(path)
+        return None
+
+    def _lookup_content(self, message_id: str) -> str | None:
+        for folder in (self.inbox, self.outbox):
+            path = self._resolve_within(folder, message_id)
+            if path is not None:
+                return path.read_text()
+        return None
+
     def _thread_chain(self, message_id: str) -> list[str]:
         """Ancestor message bodies (oldest first), following in_reply_to links."""
         chain: list[str] = []
@@ -247,24 +261,6 @@ class AgentTransport:
             current = str(parent)
         chain.reverse()
         return chain
-
-    def _lookup_meta(self, message_id: str) -> dict | None:
-        for folder in (self.inbox, self.outbox):
-            path = (folder / message_id).resolve()
-            if not str(path).startswith(str(folder.resolve()) + "/"):
-                return None
-            if path.exists():
-                return self._meta_of(path)
-        return None
-
-    def _lookup_content(self, message_id: str) -> str | None:
-        for folder in (self.inbox, self.outbox):
-            path = (folder / message_id).resolve()
-            if not str(path).startswith(str(folder.resolve()) + "/"):
-                return None
-            if path.exists():
-                return path.read_text()
-        return None
 
     def conversation_id_for(self, message_id: str) -> str:
         """Conversation ID for the unified tracker: the agent pair, order-free.

--- a/packages/gptmail/src/gptmail/transport/agent.py
+++ b/packages/gptmail/src/gptmail/transport/agent.py
@@ -23,6 +23,7 @@ Two deliberate design choices, both resolved with Bob (see task
 
 from __future__ import annotations
 
+import re
 import shutil
 from collections.abc import Callable
 from datetime import datetime, timezone
@@ -118,12 +119,23 @@ class AgentTransport:
             return None
         return meta if isinstance(meta, dict) else None
 
-    def _resolve_in_inbox(self, message_id: str) -> Path | None:
-        """Resolve a message_id to an inbox path, rejecting path traversal."""
-        path = (self.inbox / message_id).resolve()
-        if not str(path).startswith(str(self.inbox.resolve()) + "/"):
+    @staticmethod
+    def _resolve_within(folder: Path, message_id: str) -> Path | None:
+        """Resolve ``message_id`` inside ``folder``, rejecting path traversal.
+
+        ``message_id`` may come from a remote agent's frontmatter (e.g. an
+        ``in_reply_to`` link), so an attacker-crafted ``../../etc/passwd`` must
+        not escape ``folder``. ``Path.__truediv__`` does not reject traversal,
+        hence the explicit prefix check after ``resolve()``.
+        """
+        path = (folder / message_id).resolve()
+        if not str(path).startswith(str(folder.resolve()) + "/"):
             return None
         return path if path.exists() else None
+
+    def _resolve_in_inbox(self, message_id: str) -> Path | None:
+        """Resolve a message_id to an inbox path, rejecting path traversal."""
+        return self._resolve_within(self.inbox, message_id)
 
     def send(
         self,
@@ -165,6 +177,8 @@ class AgentTransport:
 
     def list_inbox(self, folder: str = "inbox") -> list[tuple[str, str, datetime]]:
         """List ``(message_id, subject, timestamp)`` for messages in a folder."""
+        if "/" in folder or folder.startswith("."):
+            raise ValueError(f"Invalid folder name: {folder!r}")
         target = self._dir / folder
         if not target.exists():
             return []
@@ -210,7 +224,7 @@ class AgentTransport:
         if content.startswith("---"):
             parts = content.split("---", 2)
             if len(parts) >= 3 and "read: false" in parts[1]:
-                parts[1] = parts[1].replace("read: false", "read: true")
+                parts[1] = re.sub(r"^read: false$", "read: true", parts[1], flags=re.MULTILINE)
                 content = "---".join(parts)
                 path.write_text(content)
         return content
@@ -236,14 +250,18 @@ class AgentTransport:
 
     def _lookup_meta(self, message_id: str) -> dict | None:
         for folder in (self.inbox, self.outbox):
-            path = folder / message_id
+            path = (folder / message_id).resolve()
+            if not str(path).startswith(str(folder.resolve()) + "/"):
+                return None
             if path.exists():
                 return self._meta_of(path)
         return None
 
     def _lookup_content(self, message_id: str) -> str | None:
         for folder in (self.inbox, self.outbox):
-            path = folder / message_id
+            path = (folder / message_id).resolve()
+            if not str(path).startswith(str(folder.resolve()) + "/"):
+                return None
             if path.exists():
                 return path.read_text()
         return None

--- a/packages/gptmail/src/gptmail/transport/agent.py
+++ b/packages/gptmail/src/gptmail/transport/agent.py
@@ -171,7 +171,7 @@ class AgentTransport:
         if len(parts) < 3:
             return
         fm = parts[1]
-        if "delivered:" not in fm:
+        if not re.search(r"^delivered:", fm, flags=re.MULTILINE):
             fm = fm.rstrip("\n") + "\ndelivered: false\n"
         local_path.write_text("---".join([parts[0], fm, parts[2]]))
 

--- a/packages/gptmail/src/gptmail/transport/agent.py
+++ b/packages/gptmail/src/gptmail/transport/agent.py
@@ -1,0 +1,285 @@
+"""Agent transport: filesystem inter-agent messaging.
+
+Implements the :class:`~gptmail.transport.Transport` seam over a filesystem
+``messages/{inbox,outbox}`` layout — the medium ``scripts/agent-msg.py`` uses for
+SSH inter-agent messages. This module imports **nothing email-related** (no
+``imaplib``/``smtplib``, no ``lib.AgentEmail``, no ``transport.email``), so
+inter-agent messaging stays testable in isolated LXC sessions with no email
+infra. A guard test (``test_agent_transport_no_email_imports.py``) locks that in.
+
+Two deliberate design choices, both resolved with Bob (see task
+``fold-agent-msg-into-gptmail-single-comms-tool``):
+
+- **Sync-agnostic (Q2).** The transport only reads and writes local files. Remote
+  delivery (SSH/SCP, git commit+push, shared-repo sync) is injected as a
+  ``deliver`` callable, never built in. Tests pass no ``deliver`` and stay both
+  network- and git-free; production wires in the SSH delivery currently in
+  ``agent-msg.py``. A failed delivery stamps ``delivered: false`` on the outbox
+  copy so reply-tracking does not count an undelivered message as a sent reply.
+- **Reply-tracking lives in the shared tracker, not here (per the Protocol).**
+  This class stamps each message with :attr:`channel` (``"agent"``); the unified
+  ``ConversationTracker`` does the bookkeeping. The transport stays a thin seam.
+"""
+
+from __future__ import annotations
+
+import shutil
+from collections.abc import Callable
+from datetime import datetime, timezone
+from pathlib import Path
+
+import yaml
+
+# A delivery hook: given the local outbox path and the recipient name, place the
+# message in the recipient's inbox (SSH/SCP, shared repo, …) and return whether
+# delivery succeeded. None means local-only (tests, single-host).
+Deliver = Callable[[Path, str], bool]
+
+
+class AgentTransport:
+    """Transport over a filesystem ``messages/{inbox,outbox}`` directory.
+
+    Message IDs are inbox/outbox *filenames* — stable, unique, and already the
+    handle ``agent-msg.py`` users pass to ``read``/``reply``.
+    """
+
+    #: Channel identifier stamped onto tracked messages for this transport.
+    channel = "agent"
+
+    def __init__(
+        self,
+        messages_dir: str | Path,
+        self_name: str,
+        *,
+        deliver: Deliver | None = None,
+    ) -> None:
+        self._dir = Path(messages_dir)
+        self._self = self_name.lower()
+        self._deliver = deliver
+        self._ensure_dirs()
+
+    @property
+    def inbox(self) -> Path:
+        return self._dir / "inbox"
+
+    @property
+    def outbox(self) -> Path:
+        return self._dir / "outbox"
+
+    def _ensure_dirs(self) -> None:
+        self.inbox.mkdir(parents=True, exist_ok=True)
+        self.outbox.mkdir(parents=True, exist_ok=True)
+
+    @staticmethod
+    def _make_filename(sender: str, subject: str) -> str:
+        ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S-%f")
+        safe_sender = "".join(c if c.isalnum() or c in "-_" else "-" for c in sender)
+        safe_sender = safe_sender[:20].strip("-")
+        safe_subject = "".join(c if c.isalnum() or c in "-_" else "-" for c in subject)
+        safe_subject = safe_subject[:40].strip("-")
+        return f"{ts}-{safe_sender}-{safe_subject}.md"
+
+    @staticmethod
+    def _format(
+        sender: str,
+        recipient: str,
+        subject: str,
+        body: str,
+        in_reply_to: str | None = None,
+    ) -> str:
+        ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        meta: dict[str, object] = {
+            "from": sender,
+            "to": recipient,
+            "timestamp": ts,
+            "subject": subject,
+            "read": False,
+        }
+        if in_reply_to:
+            meta["in_reply_to"] = in_reply_to
+        frontmatter = yaml.dump(
+            meta, default_flow_style=False, allow_unicode=True, sort_keys=False
+        ).rstrip()
+        return f"---\n{frontmatter}\n---\n\n{body}\n"
+
+    def _meta_of(self, path: Path) -> dict | None:
+        try:
+            content = path.read_text()
+        except OSError:
+            return None
+        if not content.startswith("---"):
+            return None
+        parts = content.split("---", 2)
+        if len(parts) < 3:
+            return None
+        try:
+            meta = yaml.safe_load(parts[1])
+        except yaml.YAMLError:
+            return None
+        return meta if isinstance(meta, dict) else None
+
+    def _resolve_in_inbox(self, message_id: str) -> Path | None:
+        """Resolve a message_id to an inbox path, rejecting path traversal."""
+        path = (self.inbox / message_id).resolve()
+        if not str(path).startswith(str(self.inbox.resolve()) + "/"):
+            return None
+        return path if path.exists() else None
+
+    def send(
+        self,
+        to: str,
+        subject: str,
+        content: str,
+        *,
+        reply_to: str | None = None,
+        references: list[str] | None = None,
+    ) -> str:
+        """Write a message to the outbox and (optionally) deliver it.
+
+        ``references`` is accepted for Protocol parity; agent messages carry a
+        single ``in_reply_to`` link rather than a full ancestor chain, so only
+        the immediate parent (``reply_to``) is recorded. Returns the message ID
+        (outbox filename).
+        """
+        filename = self._make_filename(self._self, subject)
+        local_path = self.outbox / filename
+        local_path.write_text(
+            self._format(self._self, to.lower(), subject, content, in_reply_to=reply_to)
+        )
+        if self._deliver is not None and not self._deliver(local_path, to.lower()):
+            self._stamp_delivery_failed(local_path)
+        return filename
+
+    def _stamp_delivery_failed(self, local_path: Path) -> None:
+        """Mark an outbox file ``delivered: false`` so reply-tracking skips it."""
+        content = local_path.read_text()
+        if not content.startswith("---"):
+            return
+        parts = content.split("---", 2)
+        if len(parts) < 3:
+            return
+        fm = parts[1]
+        if "delivered:" not in fm:
+            fm = fm.rstrip("\n") + "\ndelivered: false\n"
+        local_path.write_text("---".join([parts[0], fm, parts[2]]))
+
+    def list_inbox(self, folder: str = "inbox") -> list[tuple[str, str, datetime]]:
+        """List ``(message_id, subject, timestamp)`` for messages in a folder."""
+        target = self._dir / folder
+        if not target.exists():
+            return []
+        out: list[tuple[str, str, datetime]] = []
+        for f in sorted(target.glob("*.md")):
+            meta = self._meta_of(f)
+            if not meta:
+                continue
+            subject = str(meta.get("subject", ""))
+            ts = self._parse_ts(meta.get("timestamp"))
+            out.append((f.name, subject, ts))
+        return out
+
+    @staticmethod
+    def _parse_ts(raw: object) -> datetime:
+        if not raw:
+            return datetime.min.replace(tzinfo=timezone.utc)
+        try:
+            dt = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+        except ValueError:
+            return datetime.min.replace(tzinfo=timezone.utc)
+        return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+    def read(self, message_id: str, include_thread: bool = False) -> str:
+        """Return an inbox message, marking it read. Walks the thread if asked.
+
+        ``include_thread`` prepends locally-available ancestors (following
+        ``in_reply_to`` across inbox and outbox), oldest first, so a reply reads
+        with its context. Ancestors that live only on another agent's disk are
+        simply absent — the transport never reaches over the network to read.
+        """
+        path = self._resolve_in_inbox(message_id)
+        if path is None:
+            raise FileNotFoundError(f"Message not found: {message_id}")
+        content = self._mark_read(path)
+        if not include_thread:
+            return content
+        chain = self._thread_chain(message_id)
+        return "\n\n---\n\n".join(chain + [content]) if chain else content
+
+    def _mark_read(self, path: Path) -> str:
+        content = path.read_text()
+        if content.startswith("---"):
+            parts = content.split("---", 2)
+            if len(parts) >= 3 and "read: false" in parts[1]:
+                parts[1] = parts[1].replace("read: false", "read: true")
+                content = "---".join(parts)
+                path.write_text(content)
+        return content
+
+    def _thread_chain(self, message_id: str) -> list[str]:
+        """Ancestor message bodies (oldest first), following in_reply_to links."""
+        chain: list[str] = []
+        seen: set[str] = set()
+        current = message_id
+        while True:
+            meta = self._lookup_meta(current)
+            parent = meta.get("in_reply_to") if meta else None
+            if not parent or parent in seen:
+                break
+            seen.add(str(parent))
+            body = self._lookup_content(str(parent))
+            if body is None:
+                break
+            chain.append(body)
+            current = str(parent)
+        chain.reverse()
+        return chain
+
+    def _lookup_meta(self, message_id: str) -> dict | None:
+        for folder in (self.inbox, self.outbox):
+            path = folder / message_id
+            if path.exists():
+                return self._meta_of(path)
+        return None
+
+    def _lookup_content(self, message_id: str) -> str | None:
+        for folder in (self.inbox, self.outbox):
+            path = folder / message_id
+            if path.exists():
+                return path.read_text()
+        return None
+
+    def conversation_id_for(self, message_id: str) -> str:
+        """Conversation ID for the unified tracker: the agent pair, order-free.
+
+        All messages between the same two agents share one conversation
+        (``agent:alice|bob``), so the shared ``ConversationTracker`` threads a
+        back-and-forth exchange together regardless of direction. Falls back to
+        the message ID when participants can't be determined.
+        """
+        meta = self._lookup_meta(message_id)
+        if not meta:
+            return f"agent:{message_id}"
+        sender = str(meta.get("from", "")).lower()
+        recipient = str(meta.get("to", "")).lower()
+        pair = sorted(p for p in (sender, recipient) if p)
+        if len(pair) != 2:
+            return f"agent:{message_id}"
+        return f"agent:{pair[0]}|{pair[1]}"
+
+    # -- delivery helpers (sync layer; not part of the Protocol) -------------
+
+    @staticmethod
+    def local_deliver(recipient_inbox: str | Path) -> Deliver:
+        """A ``deliver`` hook that copies into a local recipient inbox.
+
+        For single-host setups and tests that want delivery without SSH. The
+        SSH/SCP delivery from ``agent-msg.py`` plugs in here as an alternative.
+        """
+        dest = Path(recipient_inbox)
+
+        def _deliver(local_path: Path, _recipient: str) -> bool:
+            dest.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(local_path, dest / local_path.name)
+            return True
+
+        return _deliver

--- a/packages/gptmail/tests/test_agent_transport.py
+++ b/packages/gptmail/tests/test_agent_transport.py
@@ -65,8 +65,10 @@ def test_send_with_deliver_hook_places_in_recipient_inbox(tmp_path: Path) -> Non
 
 def test_send_stamps_delivery_failure(tmp_path: Path) -> None:
     t = _transport(tmp_path, deliver=lambda path, recipient: False)
-    mid = t.send("bob", "Hi", "hello")
-    assert _frontmatter(t.outbox / mid)["delivered"] is False
+    mid = t.send("bob", "task delivered: complete", "hello")
+    meta = _frontmatter(t.outbox / mid)
+    assert meta["delivered"] is False
+    assert meta["subject"] == "task delivered: complete"
 
 
 def test_list_inbox_returns_id_subject_timestamp(tmp_path: Path) -> None:

--- a/packages/gptmail/tests/test_agent_transport.py
+++ b/packages/gptmail/tests/test_agent_transport.py
@@ -87,6 +87,14 @@ def test_list_inbox_empty_when_no_folder(tmp_path: Path) -> None:
     assert _transport(tmp_path).list_inbox("archive") == []
 
 
+def test_list_inbox_rejects_path_traversal(tmp_path: Path) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.md").write_text("---\nsubject: nope\ntimestamp: 2026-01-01T00:00:00Z\n---\n")
+    with pytest.raises(ValueError):
+        _transport(tmp_path).list_inbox("../../outside")
+
+
 def test_read_marks_message_read(tmp_path: Path) -> None:
     t = _transport(tmp_path)
     bob = AgentTransport(
@@ -97,6 +105,18 @@ def test_read_marks_message_read(tmp_path: Path) -> None:
     content = t.read(mid)
     assert "content here" in content
     assert _frontmatter(t.inbox / mid)["read"] is True
+
+
+def test_read_only_updates_read_field(tmp_path: Path) -> None:
+    t = _transport(tmp_path)
+    bob = AgentTransport(
+        tmp_path / "messages", "bob", deliver=AgentTransport.local_deliver(t.inbox)
+    )
+    mid = bob.send("alice", "read: false alarm", "content here")
+    t.read(mid)
+    meta = _frontmatter(t.inbox / mid)
+    assert meta["read"] is True
+    assert meta["subject"] == "read: false alarm"
 
 
 def test_read_missing_raises(tmp_path: Path) -> None:
@@ -125,6 +145,19 @@ def test_read_include_thread_prepends_ancestor(tmp_path: Path) -> None:
     assert "the answer" in threaded
     # ancestor comes first
     assert threaded.index("the original question") < threaded.index("the answer")
+
+
+def test_read_include_thread_rejects_parent_path_traversal(tmp_path: Path) -> None:
+    alice = _transport(tmp_path)
+    bob = AgentTransport(
+        tmp_path / "bob-messages", "bob", deliver=AgentTransport.local_deliver(alice.inbox)
+    )
+    (tmp_path / "secret.md").write_text("TOP SECRET\n")
+    reply_id = bob.send("alice", "Re: Original", "the answer", reply_to="../../secret.md")
+
+    threaded = alice.read(reply_id, include_thread=True)
+    assert "the answer" in threaded
+    assert "TOP SECRET" not in threaded
 
 
 def test_conversation_id_is_order_free_pair(tmp_path: Path) -> None:

--- a/packages/gptmail/tests/test_agent_transport.py
+++ b/packages/gptmail/tests/test_agent_transport.py
@@ -1,0 +1,137 @@
+"""Tests for ``AgentTransport`` — filesystem inter-agent messaging.
+
+Step 2 of folding agent-msg into gptmail. These exercise the transport seam over
+a temp ``messages/`` dir with no network and no git: the ``deliver`` hook is
+either absent (outbox-only) or a local-copy stub. Behavior is checked against the
+``agent-msg.py`` shape it replaces (filename IDs, frontmatter, read-stamping,
+delivery-failure stamping).
+
+See task: fold-agent-msg-into-gptmail-single-comms-tool.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from gptmail.transport import Transport
+from gptmail.transport.agent import AgentTransport
+
+
+def _transport(tmp_path: Path, deliver=None) -> AgentTransport:
+    return AgentTransport(tmp_path / "messages", "alice", deliver=deliver)
+
+
+def _frontmatter(path: Path) -> dict:
+    parts = path.read_text().split("---", 2)
+    return yaml.safe_load(parts[1])
+
+
+def test_satisfies_protocol(tmp_path: Path) -> None:
+    assert isinstance(_transport(tmp_path), Transport)
+
+
+def test_channel_is_agent(tmp_path: Path) -> None:
+    assert _transport(tmp_path).channel == "agent"
+
+
+def test_send_writes_outbox_returns_filename_id(tmp_path: Path) -> None:
+    t = _transport(tmp_path)
+    mid = t.send("bob", "Hello", "body text")
+    assert mid.endswith(".md")
+    out = t.outbox / mid
+    assert out.exists()
+    fm = _frontmatter(out)
+    assert fm["from"] == "alice"
+    assert fm["to"] == "bob"
+    assert fm["subject"] == "Hello"
+    assert fm["read"] is False
+
+
+def test_send_records_reply_to(tmp_path: Path) -> None:
+    t = _transport(tmp_path)
+    mid = t.send("bob", "Re: x", "reply body", reply_to="parent.md")
+    assert _frontmatter(t.outbox / mid)["in_reply_to"] == "parent.md"
+
+
+def test_send_with_deliver_hook_places_in_recipient_inbox(tmp_path: Path) -> None:
+    bob_inbox = tmp_path / "bob" / "messages" / "inbox"
+    t = _transport(tmp_path, deliver=AgentTransport.local_deliver(bob_inbox))
+    mid = t.send("bob", "Hi", "hello")
+    assert (bob_inbox / mid).exists()
+    # Successful delivery leaves no delivered:false stamp.
+    assert "delivered" not in _frontmatter(t.outbox / mid)
+
+
+def test_send_stamps_delivery_failure(tmp_path: Path) -> None:
+    t = _transport(tmp_path, deliver=lambda path, recipient: False)
+    mid = t.send("bob", "Hi", "hello")
+    assert _frontmatter(t.outbox / mid)["delivered"] is False
+
+
+def test_list_inbox_returns_id_subject_timestamp(tmp_path: Path) -> None:
+    t = _transport(tmp_path)
+    # Deliver a message into alice's own inbox to list it.
+    deliver = AgentTransport.local_deliver(t.inbox)
+    sender = AgentTransport(tmp_path / "messages", "bob", deliver=deliver)
+    mid = sender.send("alice", "Question", "?")
+    listed = t.list_inbox()
+    assert len(listed) == 1
+    msg_id, subject, ts = listed[0]
+    assert msg_id == mid
+    assert subject == "Question"
+    assert ts.year >= 2026
+
+
+def test_list_inbox_empty_when_no_folder(tmp_path: Path) -> None:
+    assert _transport(tmp_path).list_inbox("archive") == []
+
+
+def test_read_marks_message_read(tmp_path: Path) -> None:
+    t = _transport(tmp_path)
+    bob = AgentTransport(
+        tmp_path / "messages", "bob", deliver=AgentTransport.local_deliver(t.inbox)
+    )
+    mid = bob.send("alice", "Yo", "content here")
+    assert _frontmatter(t.inbox / mid)["read"] is False
+    content = t.read(mid)
+    assert "content here" in content
+    assert _frontmatter(t.inbox / mid)["read"] is True
+
+
+def test_read_missing_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        _transport(tmp_path).read("nope.md")
+
+
+def test_read_rejects_path_traversal(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        _transport(tmp_path).read("../../etc/passwd")
+
+
+def test_read_include_thread_prepends_ancestor(tmp_path: Path) -> None:
+    # Realistic thread: bob sends an original then a reply, both delivered into
+    # alice's inbox. Delivery preserves filenames, so the reply's in_reply_to
+    # (bob's outbox filename = parent id) resolves in alice's inbox.
+    alice = _transport(tmp_path)
+    bob = AgentTransport(
+        tmp_path / "bob-messages", "bob", deliver=AgentTransport.local_deliver(alice.inbox)
+    )
+    parent_id = bob.send("alice", "Original", "the original question")
+    reply_id = bob.send("alice", "Re: Original", "the answer", reply_to=parent_id)
+
+    threaded = alice.read(reply_id, include_thread=True)
+    assert "the original question" in threaded
+    assert "the answer" in threaded
+    # ancestor comes first
+    assert threaded.index("the original question") < threaded.index("the answer")
+
+
+def test_conversation_id_is_order_free_pair(tmp_path: Path) -> None:
+    t = _transport(tmp_path)
+    mid = t.send("bob", "Hi", "body")  # from alice to bob, in outbox
+    assert t.conversation_id_for(mid) == "agent:alice|bob"
+
+
+def test_conversation_id_falls_back_when_unknown(tmp_path: Path) -> None:
+    assert _transport(tmp_path).conversation_id_for("ghost.md") == "agent:ghost.md"

--- a/packages/gptmail/tests/test_agent_transport_no_email_imports.py
+++ b/packages/gptmail/tests/test_agent_transport_no_email_imports.py
@@ -1,0 +1,45 @@
+"""Guard: the agent transport is email-stack-free.
+
+Bob's hard constraint for folding agent-msg into gptmail: inter-agent messaging
+must work in isolated LXC sessions with **no email infra**. That means
+``transport.agent`` + ``communication_utils`` must form a closed set whose import
+graph never reaches ``imaplib``, ``smtplib``, ``gptmail.lib`` (the IMAP/SMTP
+``AgentEmail``), or ``gptmail.transport.email``.
+
+This is checked at runtime in a fresh subprocess (not the test process, whose
+``sys.modules`` is already polluted by other tests importing the email stack):
+import only the agent transport + tracker, then assert none of the forbidden
+modules loaded. See task ``fold-agent-msg-into-gptmail-single-comms-tool``.
+"""
+
+import subprocess
+import sys
+
+FORBIDDEN = ["imaplib", "smtplib", "gptmail.lib", "gptmail.transport.email"]
+
+_PROBE = """
+import sys
+# The two modules that MUST stay isolated, imported exactly as an LXC session would.
+from gptmail.transport.agent import AgentTransport
+from gptmail.communication_utils.state.tracking import ConversationTracker, MessageInfo
+
+forbidden = {forbidden!r}
+leaked = [m for m in forbidden if m in sys.modules]
+if leaked:
+    print("LEAKED:" + ",".join(leaked))
+    sys.exit(1)
+print("CLEAN")
+""".format(forbidden=FORBIDDEN)
+
+
+def test_agent_transport_imports_no_email_stack() -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", _PROBE],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"agent transport pulled in the email stack.\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert "CLEAN" in result.stdout


### PR DESCRIPTION
Step 2 of folding `agent-msg` into gptmail (task: `fold-agent-msg-into-gptmail-single-comms-tool`). Follows the merged step-1 seam (#1090) and `channel` field (#1089).

## What
A filesystem inter-agent `AgentTransport` implementing the `Transport` Protocol, with **zero email-stack imports** — honoring Bob's hard constraint that inter-agent messaging work in isolated LXC sessions with no IMAP/SMTP infra.

- **`transport/agent.py`** — `AgentTransport` over `messages/{inbox,outbox}`.
  - **Sync-agnostic (Q2 resolved with Bob):** writes local files only; remote delivery (SSH/SCP, git, shared-repo) is an injected `deliver` hook, never built in. Tests stay network- and git-free. A failed delivery stamps `delivered: false` so reply-tracking doesn't count an undelivered message as a sent reply (matches `agent-msg.py`).
  - `conversation_id_for` returns an order-free agent pair (`agent:alice|bob`), so the shared `ConversationTracker` threads a back-and-forth exchange together regardless of direction.
- **`transport/__init__.py`** — re-export `EmailTransport`/`AgentTransport` **lazily (PEP 562)** so `import gptmail.transport.agent` does **not** eagerly pull in `.email` (which imports the IMAP/SMTP stack via `lib.AgentEmail`). This is what makes the isolation real at runtime, not just on paper.

## Isolation guard
`test_agent_transport_no_email_imports.py` runs a **fresh subprocess** importing only `transport.agent` + `communication_utils`, then asserts `imaplib`/`smtplib`/`gptmail.lib`/`gptmail.transport.email` are absent from `sys.modules`. (Subprocess because the test process's `sys.modules` is already polluted by other tests importing the email stack.) Verified it fails on a simulated regression.

## Reply-tracking
Stays in the shared `ConversationTracker` (stamped `channel="agent"`, from #1089), **not** in the Protocol — the transport is a thin seam.

## Tests
75/75 gptmail tests pass (54 → 75; +21). Parity tests vs `agent-msg.py` shape: filename IDs, frontmatter, read-stamping, delivery-failure stamping, thread walk, path-traversal rejection.

## Next
`gptmail agent` CLI subgroup wiring `AgentTransport` to `ConversationTracker`, then repoint `context.sh`/startup needs-reply check, then convert `scripts/agent-msg.py` to a shim.

cc @TimeToBuildBob (gptmail co-owner) for review.