### PR TITLE
fix(scripts): treat partial-null limit_remaining as available in check-openrouter-usage

### DIFF
--- a/scripts/check-openrouter-usage.sh
+++ b/scripts/check-openrouter-usage.sh
@@ -75,7 +75,7 @@ usage_daily = raw.get('usage_daily') or 0
 usage_weekly = raw.get('usage_weekly') or 0
 is_unlimited = limit is None and limit_remaining is None
 result = {
-    'available': True if is_unlimited else (limit_remaining or 0) > 0.5,
+    'available': True if is_unlimited else (limit_remaining is None or limit_remaining > 0.5),
     'utilization': 0.0 if limit is None else round(usage_daily / max(limit, 0.01), 3),
     'limit': limit,
     'limit_remaining': None if limit_remaining is None else round(limit_remaining, 2),


### PR DESCRIPTION
## Summary

- Fixes remaining Greptile P1 finding from PR #1086: `(limit_remaining or 0) > 0.5` incorrectly reports an OpenRouter account as EXHAUSTED when the API returns `limit=N, limit_remaining=null`
- New logic: `limit_remaining is None or limit_remaining > 0.5` — if remaining is unknown, assume available (consistent with how `limit_remaining` is exposed in the JSON output)

## Root cause

OpenRouter can return a partial-null response where `limit` is set but `limit_remaining` is null. The `is_unlimited` guard (`limit is None and limit_remaining is None`) correctly excludes this case, but then the `available` calculation fell through to `(None or 0) > 0.5 = False`, incorrectly marking the account as exhausted.

## Cases covered

| limit | limit_remaining | Before | After |
|-------|----------------|--------|-------|
| null  | null           | True (unlimited) | True (unlimited) ✓ |
| 10    | 5.0            | True | True ✓ |
| 10    | 0.0            | False (exhausted) | False ✓ |
| 10    | null           | **False (wrong!)** | **True ✓** |

## Test plan

- [ ] Verify script handles standard limited account (limit + limit_remaining both set)
- [ ] Verify unlimited account (both null) still reported as available
- [ ] Verify exhausted account (limit_remaining = 0) still reported as exhausted