### PR TITLE
fix(monitoring): emit own-PR Greptile review for BLOCKED PRs

### DIFF
--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -708,7 +708,11 @@ check_greptile_scores() {
 #   greptile = 4 (minor improvements)     → greptile_needs_improvement
 #   greptile >= 5                         → skip (perfect review is non-actionable here)
 #   DIRTY / CONFLICTING                   → skip (check_merge_conflicts handles)
-#   BLOCKED / UNKNOWN                     → skip (CI not yet settled)
+#   UNKNOWN                               → skip (GitHub still computing mergeability — transient)
+#   BLOCKED                               → emit (stable "needs required review/checks" state;
+#                                           a sub-5 Greptile score is actionable regardless of
+#                                           merge-readiness — branch-protected green PRs sit here,
+#                                           and skipping them left only the 1h-cooldown nag)
 #
 # State tracking: $STATE_DIR/${repo_safe}-pr-${number}-own-pr-review.state
 #   Format: "${head_sha}:${greptile_score}:${merge_state}:${timestamp}"
@@ -731,10 +735,13 @@ check_own_pr_review_state() {
         head_sha=$(echo "$pr_data" | jq -r '.headRefOid // "unknown"')
         merge_state=$(echo "$pr_data" | jq -r '.mergeStateStatus // "UNKNOWN"')
 
-        # Skip conflict/unsettled states — handled by other checks
+        # Skip conflict / genuinely-transient states — handled elsewhere or not yet settled.
+        # BLOCKED is intentionally NOT skipped: it is the stable state for a branch-protected
+        # green PR awaiting required review/approval, where a sub-5 Greptile score is still
+        # actionable. UNKNOWN means GitHub has not finished computing mergeability (transient).
         case "$merge_state" in
             DIRTY|CONFLICTING) continue ;;
-            BLOCKED|UNKNOWN) continue ;;
+            UNKNOWN) continue ;;
         esac
 
         # Read Greptile score and reviewed SHA from state file written by check_greptile_scores

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -718,6 +718,10 @@ check_greptile_scores() {
 #   Format: "${head_sha}:${greptile_score}:${merge_state}:${timestamp}"
 #   Emit exactly once per (head_sha, greptile_score, merge_state) signature.
 #   No timed cooldown re-emit — only re-emits when the signature changes.
+#   Note: a BLOCKED→CLEAN transition changes merge_state, so a PR that emitted
+#   at BLOCKED will emit again at CLEAN. This is intentional: the Greptile issue
+#   is still unresolved after approval, and the duplicate is handled by the
+#   downstream dispatcher's own dedup logic.
 #
 # API cost: zero — reads Greptile state files written by check_greptile_scores.
 # Requires: live PR data (fresh mergeStateStatus/headRefOid).

--- a/tests/test_activity_gate_own_pr_review.py
+++ b/tests/test_activity_gate_own_pr_review.py
@@ -148,3 +148,43 @@ def test_perfect_greptile_review_does_not_emit_improvement_for_behind_pr() -> No
         assert "greptile_needs_improvement" not in result.stdout, result.stdout
         assert "greptile_needs_fix" not in result.stdout, result.stdout
         assert not _own_review_state_file(state_dir).exists()
+
+
+def test_blocked_pr_with_low_greptile_emits_improvement() -> None:
+    """A branch-protected green PR sits in BLOCKED while awaiting required review.
+
+    A sub-5 Greptile score there is actionable, so check_own_pr_review_state must
+    emit on first discovery rather than waiting for the 1h check_greptile_scores
+    cooldown nag (the latency window that forced manual @-mentions).
+    """
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+
+        ts = int(time.time()) - 60
+        # Greptile 4/5 already on file for the current HEAD.
+        _greptile_state_file(state_dir).write_text(f"4:{ts}:{TEST_HEAD_SHA}")
+
+        result = _run_gate(tmp, state_dir, merge_state="BLOCKED")
+        assert result.returncode in (0, 1), result.stderr
+        assert "greptile_needs_improvement" in result.stdout, result.stdout
+        # The own-PR review path is what fired (identified by its detail string).
+        assert "own-PR review" in result.stdout, result.stdout
+        assert _own_review_state_file(state_dir).exists()
+
+
+def test_unknown_merge_state_still_skips_own_pr_review() -> None:
+    """UNKNOWN means GitHub is still computing mergeability — stay transient-safe."""
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+
+        ts = int(time.time()) - 60
+        _greptile_state_file(state_dir).write_text(f"4:{ts}:{TEST_HEAD_SHA}")
+
+        result = _run_gate(tmp, state_dir, merge_state="UNKNOWN")
+        assert result.returncode in (0, 1), result.stderr
+        assert "own-PR review" not in result.stdout, result.stdout
+        assert not _own_review_state_file(state_dir).exists()


### PR DESCRIPTION
## Problem

Erik repeatedly had to manually `@greptileai`-mention / nudge Bob about open contrib PRs with a Greptile 4/5 ("why aren't you picking it up in project monitoring? I shouldn't have to mention"). project-monitoring *is* running every 2 min and dispatching — but had a real latency gap for branch-protected green PRs.

## Root cause

`check_own_pr_review_state` in `activity-gate.sh` exists specifically to surface own-PR Greptile reviews on **first discovery** (because `check_greptile_scores` silently seeds on first sight and only re-emits after a 1-hour cooldown). But it blanket-skipped `mergeStateStatus` in {`BLOCKED`, `UNKNOWN`}.

`BLOCKED` is the **stable** state for a branch-protected, green-CI PR awaiting required review/approval — exactly where a sub-5 Greptile score is most actionable. Skipping it suppressed the first-discovery emit, so a 4/5 review on a green contrib PR could sit silent for up to an hour, forcing a manual mention.

## Fix

- Stop skipping `BLOCKED` — emit the Greptile improvement/fix item (a sub-5 score is actionable regardless of merge-readiness).
- Keep skipping `UNKNOWN` (GitHub still computing mergeability — genuinely transient) and `DIRTY`/`CONFLICTING` (owned by `check_merge_conflicts`).
- Emit dedup is unchanged (once per `(head_sha, greptile_score, merge_state)` signature), and the dispatch-layer cooldown still guards against spam.

## Tests

- New: `test_blocked_pr_with_low_greptile_emits_improvement` (BLOCKED 4/5 now emits via the own-PR path).
- New: `test_unknown_merge_state_still_skips_own_pr_review` (UNKNOWN stays transient-safe).
- Full activity-gate suite green (15 passed).