### PR TITLE
fix(gptmail): use anchored regex in _mark_replied to prevent frontmatter corruption

### DIFF
--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "click>=8.0.0",
+#   "pyyaml>=6.0",
+# ]
+# ///
+"""CLI subgroup ``gptmail agent`` — inter-agent SSH messaging over AgentTransport.
+
+This is the unified-comms home for the inter-agent messaging that
+``scripts/agent-msg.py`` implements today (fold task
+``fold-agent-msg-into-gptmail-single-comms-tool``). It is **email-free by
+construction**: it imports only :class:`~gptmail.transport.agent.AgentTransport`
+and the shared :class:`~gptmail.communication_utils.state.tracking.ConversationTracker`,
+never ``gptmail.lib``/``imaplib``/``smtplib``. So ``gptmail agent …`` runs in
+isolated LXC sessions with no email infra (Bob's hard constraint). A guard test
+(``test_agent_cli_no_email_imports.py``) locks that in.
+
+Wiring:
+
+- Transport file I/O (send/list/read/reply) goes through ``AgentTransport``.
+- SSH/SCP delivery is the injected ``deliver`` hook (sync layer lives here, not
+  in the transport — Q2 sync-agnostic).
+- Each sent/replied message is also stamped into the shared ``ConversationTracker``
+  with ``channel="agent"`` so the unified store can answer cross-channel
+  "what do I owe a reply to" queries.
+- ``pending`` is an authoritative filesystem scan of inbox/outbox (the proven
+  ``agent-msg.py`` ``needs_reply_messages`` logic), so it works cross-agent
+  without depending on tracker state being populated on every host.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import click
+import yaml
+
+from gptmail.communication_utils.state.tracking import (
+    ConversationTracker,
+    MessageState,
+)
+from gptmail.transport.agent import AgentTransport, Deliver
+
+
+# Inbox messages older than this (days) are assumed handled and no longer
+# flagged as awaiting a reply — a timely-reply SLA, not an unbounded backlog.
+# Override with AGENT_MSG_REPLY_WINDOW_DAYS (0 = no age limit). Mirrors
+# scripts/agent-msg.py so behaviour is identical during the migration.
+def _reply_window_days() -> int:
+    try:
+        return int(os.environ.get("AGENT_MSG_REPLY_WINDOW_DAYS", "7"))
+    except ValueError:
+        return 7
+
+
+def _repo_root() -> Path:
+    """Workspace root via ``git rev-parse --show-toplevel`` (symlink-correct)."""
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        if isinstance(e, FileNotFoundError):
+            raise RuntimeError("git not found in PATH; gptmail agent requires git.")
+        raise RuntimeError("Not in a git repository; run gptmail agent from a workspace.")
+    return Path(out.stdout.strip())
+
+
+def _messages_dir() -> Path:
+    """Messages directory for the current agent (``<repo>/messages``)."""
+    return _repo_root() / "messages"
+
+
+def _self_name() -> str:
+    """Current agent name from the environment."""
+    return os.environ.get("AGENT_NAME", os.environ.get("USER", "unknown")).lower()
+
+
+def _load_agents() -> dict[str, dict[str, str]]:
+    """Load the agent registry from ``messages/agents.yaml`` ({} if absent)."""
+    config_path = _messages_dir() / "agents.yaml"
+    if not config_path.exists():
+        click.echo(
+            f"Warning: no agent registry at {config_path}\n"
+            "Create messages/agents.yaml with agent SSH targets.",
+            err=True,
+        )
+        return {}
+    return yaml.safe_load(config_path.read_text()) or {}
+
+
+def _tracker() -> ConversationTracker:
+    """Shared conversation tracker (state under ``messages/.tracking``)."""
+    return ConversationTracker(_messages_dir() / ".tracking")
+
+
+def _ssh_deliver(agents: dict[str, dict[str, str]]) -> Deliver:
+    """Build a ``deliver`` hook that SCPs a message into a recipient's inbox.
+
+    Returns False (so the transport stamps ``delivered: false``) on unknown
+    recipient or any SSH/SCP failure — the same contract agent-msg.py relies on.
+    """
+
+    def _deliver(local_path: Path, recipient: str) -> bool:
+        agent = agents.get(recipient)
+        if not agent:
+            click.echo(
+                f"Error: unknown agent '{recipient}'. Known: {', '.join(agents)}",
+                err=True,
+            )
+            return False
+        ssh_target = agent["ssh"]
+        remote_inbox = f"{agent['workspace']}/messages/inbox/"
+        ssh_opts = ["-o", "ConnectTimeout=5", "-o", "BatchMode=yes"]
+        try:
+            subprocess.run(
+                ["ssh", *ssh_opts, ssh_target, f"mkdir -p {shlex.quote(remote_inbox)}"],
+                check=True,
+                capture_output=True,
+                timeout=10,
+            )
+            subprocess.run(
+                [
+                    "scp",
+                    *ssh_opts,
+                    str(local_path),
+                    f"{ssh_target}:{shlex.quote(remote_inbox + local_path.name)}",
+                ],
+                check=True,
+                capture_output=True,
+                timeout=15,
+            )
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+            click.echo(f"Error delivering to {recipient}: {e}", err=True)
+            return False
+        return True
+
+    return _deliver
+
+
+def _transport(deliver: Deliver | None = None) -> AgentTransport:
+    return AgentTransport(_messages_dir(), _self_name(), deliver=deliver)
+
+
+def _track_sent(transport: AgentTransport, message_id: str, reply_to: str | None) -> None:
+    """Stamp a sent message into the shared tracker (channel='agent')."""
+    tracker = _tracker()
+    conv = transport.conversation_id_for(message_id)
+    tracker.track_message(conv, message_id, in_reply_to=reply_to, channel="agent")
+    if reply_to:
+        # The inbound message we just answered is no longer pending.
+        tracker.set_message_state(
+            conv, reply_to, MessageState.COMPLETED, metadata={"reply_id": message_id}
+        )
+
+
+# -- frontmatter scan helpers (authoritative pending check) ------------------
+
+
+def _meta_of(path: Path) -> dict | None:
+    try:
+        content = path.read_text()
+    except OSError:
+        return None
+    if not content.startswith("---"):
+        return None
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        return None
+    try:
+        meta = yaml.safe_load(parts[1])
+    except yaml.YAMLError:
+        return None
+    return meta if isinstance(meta, dict) else None
+
+
+def _age_days(meta: dict, now: datetime) -> float | None:
+    ts = meta.get("timestamp")
+    if not ts:
+        return None
+    try:
+        dt = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return (now - dt).total_seconds() / 86400.0
+
+
+def _addressed_to(meta: dict, self_name: str) -> bool:
+    to = meta.get("to")
+    if to is None:
+        return True
+    if isinstance(to, (list, tuple, set)):  # noqa: UP038
+        return self_name in {str(t).lower() for t in to}
+    return str(to).lower() == self_name
+
+
+def _pending_messages(messages_dir: Path, self_name: str, window: int) -> list[dict]:
+    """Inbox messages addressed to us that we haven't replied to (timely SLA).
+
+    A reply requirement is satisfied by an inbox ``replied: true`` stamp or by
+    any successfully-delivered outbox message whose ``in_reply_to`` points at it.
+    """
+    inbox = messages_dir / "inbox"
+    outbox = messages_dir / "outbox"
+    now = datetime.now(timezone.utc)
+
+    replied_to: set[str] = set()
+    if outbox.exists():
+        for f in outbox.glob("*.md"):
+            m = _meta_of(f)
+            if m and m.get("in_reply_to") and m.get("delivered") is not False:
+                replied_to.add(str(m["in_reply_to"]))
+
+    pending: list[dict] = []
+    if not inbox.exists():
+        return pending
+    for f in sorted(inbox.glob("*.md")):
+        m = _meta_of(f)
+        if not m:
+            continue
+        if m.get("from") in (None, self_name):
+            continue
+        if not _addressed_to(m, self_name):
+            continue
+        if m.get("replied"):
+            continue
+        if f.name in replied_to:
+            continue
+        if window > 0:
+            age = _age_days(m, now)
+            if age is not None and age > window:
+                continue
+        m["file"] = f.name
+        pending.append(m)
+    return pending
+
+
+def _mark_replied(messages_dir: Path, message_id: str) -> None:
+    """Stamp an inbox message ``replied: true`` (and ``read: true``). Idempotent."""
+    path = (messages_dir / "inbox" / message_id).resolve()
+    inbox = (messages_dir / "inbox").resolve()
+    if not str(path).startswith(str(inbox) + os.sep) or not path.exists():
+        return
+    content = path.read_text()
+    if not content.startswith("---"):
+        return
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        return
+    fm = parts[1].replace("read: false", "read: true")
+    if "replied:" not in fm:
+        fm = fm.rstrip("\n") + "\nreplied: true\n"
+    else:
+        fm = fm.replace("replied: false", "replied: true")
+    path.write_text("---".join([parts[0], fm, parts[2]]))
+
+
+# -- CLI ---------------------------------------------------------------------
+
+
+@click.group(name="agent")
+def agent() -> None:
+    """Inter-agent SSH messaging (filesystem inbox/outbox over AgentTransport)."""
+
+
+@agent.command()
+@click.argument("to")
+@click.argument("subject")
+@click.argument("content", required=False)
+def send(to: str, subject: str, content: str | None) -> None:
+    """Send a message to another agent."""
+    body = content if content is not None else sys.stdin.read()
+    agents = _load_agents()
+    if to.lower() not in agents:
+        click.echo(f"Error: unknown agent '{to}'. Known: {', '.join(agents)}", err=True)
+        sys.exit(1)
+    transport = _transport(deliver=_ssh_deliver(agents))
+    message_id = transport.send(to, subject, body)
+    _track_sent(transport, message_id, reply_to=None)
+    click.echo(f"Sent to {to.lower()}: {subject}")
+
+
+@agent.command()
+@click.argument("subject")
+@click.argument("content", required=False)
+def broadcast(subject: str, content: str | None) -> None:
+    """Send a message to every agent in the registry except self."""
+    body = content if content is not None else sys.stdin.read()
+    agents = _load_agents()
+    transport = _transport(deliver=_ssh_deliver(agents))
+    recipients = [name for name in agents if name != _self_name()]
+    if not recipients:
+        click.echo("No other agents in registry.", err=True)
+        return
+    for name in recipients:
+        message_id = transport.send(name, subject, body)
+        _track_sent(transport, message_id, reply_to=None)
+        click.echo(f"Sent to {name}: {subject}")
+
+
+@agent.command(name="list")
+@click.argument("folder", default="inbox")
+def list_cmd(folder: str) -> None:
+    """List messages in a folder (default: inbox)."""
+    transport = _transport()
+    rows = transport.list_inbox(folder)
+    if not rows:
+        click.echo(f"No messages in {folder}.")
+        return
+    for message_id, subject, ts in rows:
+        click.echo(f"{ts:%Y-%m-%d %H:%M}  {message_id}  {subject}")
+
+
+@agent.command()
+@click.argument("message_id")
+@click.option("--thread", is_flag=True, help="Include locally-available ancestors.")
+def read(message_id: str, thread: bool) -> None:
+    """Read a message (marks it read), optionally with its thread."""
+    transport = _transport()
+    try:
+        click.echo(transport.read(message_id, include_thread=thread))
+    except FileNotFoundError as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+
+
+@agent.command()
+@click.argument("message_id")
+@click.argument("content", required=False)
+def reply(message_id: str, content: str | None) -> None:
+    """Reply to an inbox message, threading via in_reply_to."""
+    messages_dir = _messages_dir()
+    original = _meta_of(messages_dir / "inbox" / message_id)
+    if original is None:
+        click.echo(f"Error: message not found: {message_id}", err=True)
+        sys.exit(1)
+    recipient = str(original.get("from", "")).lower()
+    if not recipient:
+        click.echo(f"Error: cannot determine sender of {message_id}", err=True)
+        sys.exit(1)
+    subject = str(original.get("subject", ""))
+    if not subject.lower().startswith("re:"):
+        subject = f"Re: {subject}"
+    body = content if content is not None else sys.stdin.read()
+    agents = _load_agents()
+    transport = _transport(deliver=_ssh_deliver(agents))
+    reply_id = transport.send(recipient, subject, body, reply_to=message_id)
+    _mark_replied(messages_dir, message_id)
+    _track_sent(transport, reply_id, reply_to=message_id)
+    click.echo(f"Replied to {recipient}: {subject}")
+
+
+@agent.command()
+def pending() -> None:
+    """Show inbox messages awaiting a reply (timely-reply SLA)."""
+    msgs = _pending_messages(_messages_dir(), _self_name(), _reply_window_days())
+    if not msgs:
+        click.echo("No messages awaiting reply.")
+        return
+    click.echo(f"{len(msgs)} message(s) awaiting reply:")
+    for m in msgs:
+        click.echo(f"  {m['file']}  from {m.get('from')}: {m.get('subject', '')}")
+
+
+@agent.command()
+def status() -> None:
+    """Show messaging status (self, registry, inbox/outbox/pending counts)."""
+    messages_dir = _messages_dir()
+    transport = _transport()
+    agents = _load_agents()
+    inbox = transport.list_inbox("inbox")
+    outbox = transport.list_inbox("outbox")
+    pend = _pending_messages(messages_dir, _self_name(), _reply_window_days())
+    click.echo(f"Agent:    {_self_name()}")
+    click.echo(f"Registry: {', '.join(agents) or '(none)'}")
+    click.echo(f"Inbox:    {len(inbox)}")
+    click.echo(f"Outbox:   {len(outbox)}")
+    click.echo(f"Pending:  {len(pend)}")
+
+
+if __name__ == "__main__":
+    agent()

--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -33,6 +33,7 @@ Wiring:
 from __future__ import annotations
 
 import os
+import re
 import shlex
 import subprocess
 import sys
@@ -259,11 +260,11 @@ def _mark_replied(messages_dir: Path, message_id: str) -> None:
     parts = content.split("---", 2)
     if len(parts) < 3:
         return
-    fm = parts[1].replace("read: false", "read: true")
-    if "replied:" not in fm:
-        fm = fm.rstrip("\n") + "\nreplied: true\n"
+    fm = re.sub(r"^read: false$", "read: true", parts[1], flags=re.MULTILINE)
+    if re.search(r"^replied:", fm, flags=re.MULTILINE):
+        fm = re.sub(r"^replied: false$", "replied: true", fm, flags=re.MULTILINE)
     else:
-        fm = fm.replace("replied: false", "replied: true")
+        fm = fm.rstrip("\n") + "\nreplied: true\n"
     path.write_text("---".join([parts[0], fm, parts[2]]))
 
 

--- a/packages/gptmail/src/gptmail/cli.py
+++ b/packages/gptmail/src/gptmail/cli.py
@@ -76,6 +76,14 @@ def cli() -> None:
     pass
 
 
+# Inter-agent SSH messaging lives in its own email-free module so it stays
+# importable/testable in isolated LXC sessions with no email infra. Registered
+# here only as a subgroup for muscle-memory ergonomics (`gptmail agent …`).
+from gptmail.agent_cli import agent as _agent_group  # noqa: E402
+
+cli.add_command(_agent_group)
+
+
 @cli.command()
 @click.argument("to")
 @click.argument("subject")

--- a/packages/gptmail/tests/test_agent_cli.py
+++ b/packages/gptmail/tests/test_agent_cli.py
@@ -1,0 +1,164 @@
+"""Tests for the ``gptmail agent`` CLI subgroup (agent_cli).
+
+Step 3 of folding agent-msg into gptmail: the CLI surface over ``AgentTransport``
+plus ``ConversationTracker`` stamping. Exercised over a temp ``messages/`` dir
+with no network and no git — ``_repo_root`` is patched to the temp workspace and
+the SSH deliver hook is replaced with a local-copy stub (single-host delivery).
+
+Parity target: ``scripts/agent-msg.py`` (send/broadcast/list/read/reply/pending).
+See task: fold-agent-msg-into-gptmail-single-comms-tool.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from gptmail import agent_cli
+from gptmail.agent_cli import agent
+from gptmail.communication_utils.state.tracking import ConversationTracker, MessageState
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A temp workspace with a messages/ dir, agents.yaml, and patched seams.
+
+    ``alice`` is self; ``bob`` is a peer whose inbox is a local directory so the
+    SSH deliver hook can be swapped for a local copy (no network).
+    """
+    messages = tmp_path / "messages"
+    (messages / "inbox").mkdir(parents=True)
+    (messages / "outbox").mkdir(parents=True)
+    peer_inbox = tmp_path / "bob" / "messages" / "inbox"
+    peer_inbox.mkdir(parents=True)
+    (messages / "agents.yaml").write_text(
+        yaml.dump({"bob": {"ssh": "bob@bob", "workspace": str(tmp_path / "bob")}})
+    )
+
+    monkeypatch.setenv("AGENT_NAME", "alice")
+    monkeypatch.setattr(agent_cli, "_repo_root", lambda: tmp_path)
+
+    # Replace SSH/SCP delivery with a local copy into the peer's inbox.
+    def _local_deliver(agents):
+        from gptmail.transport.agent import AgentTransport
+
+        return AgentTransport.local_deliver(peer_inbox)
+
+    monkeypatch.setattr(agent_cli, "_ssh_deliver", _local_deliver)
+    return tmp_path
+
+
+def _frontmatter(path: Path) -> dict:
+    return yaml.safe_load(path.read_text().split("---", 2)[1])
+
+
+def _only_outbox_msg(workspace: Path) -> Path:
+    files = list((workspace / "messages" / "outbox").glob("*.md"))
+    assert len(files) == 1, files
+    return files[0]
+
+
+def test_send_writes_outbox_and_delivers(workspace: Path) -> None:
+    result = CliRunner().invoke(agent, ["send", "bob", "Hello", "body text"])
+    assert result.exit_code == 0, result.output
+    assert "Sent to bob: Hello" in result.output
+
+    out = _only_outbox_msg(workspace)
+    meta = _frontmatter(out)
+    assert meta["from"] == "alice"
+    assert meta["to"] == "bob"
+    assert meta["subject"] == "Hello"
+    assert "delivered" not in meta  # successful delivery leaves no failure stamp
+
+    delivered = list((workspace / "bob" / "messages" / "inbox").glob("*.md"))
+    assert len(delivered) == 1
+
+
+def test_send_unknown_agent_errors(workspace: Path) -> None:
+    result = CliRunner().invoke(agent, ["send", "nobody", "Hi", "x"])
+    assert result.exit_code == 1
+    assert "unknown agent" in result.output.lower()
+
+
+def test_send_stamps_tracker_channel_agent(workspace: Path) -> None:
+    CliRunner().invoke(agent, ["send", "bob", "Hello", "body"])
+    tracker = ConversationTracker(workspace / "messages" / ".tracking")
+    pending = tracker.get_pending_messages("agent:alice|bob")
+    assert len(pending) == 1
+    assert pending[0].channel == "agent"
+
+
+def _seed_inbox(workspace: Path, sender: str = "bob", subject: str = "Q") -> str:
+    """Drop a message from ``sender`` into alice's inbox; return its filename."""
+    inbox = workspace / "messages" / "inbox"
+    name = "20260613-000000-000000-bob-Q.md"
+    (inbox / name).write_text(
+        f"---\nfrom: {sender}\nto: alice\n"
+        f"timestamp: 2026-06-13T00:00:00Z\nsubject: {subject}\nread: false\n---\n\nplease advise\n"
+    )
+    return name
+
+
+def test_list_shows_inbox(workspace: Path) -> None:
+    _seed_inbox(workspace)
+    result = CliRunner().invoke(agent, ["list"])
+    assert result.exit_code == 0
+    assert "20260613-000000-000000-bob-Q.md" in result.output
+
+
+def test_read_marks_read(workspace: Path) -> None:
+    name = _seed_inbox(workspace)
+    result = CliRunner().invoke(agent, ["read", name])
+    assert result.exit_code == 0
+    assert "please advise" in result.output
+    assert _frontmatter(workspace / "messages" / "inbox" / name)["read"] is True
+
+
+def test_pending_lists_unanswered_then_clears_on_reply(workspace: Path) -> None:
+    name = _seed_inbox(workspace)
+
+    before = CliRunner().invoke(agent, ["pending"])
+    assert "1 message(s) awaiting reply" in before.output
+    assert name in before.output
+
+    reply = CliRunner().invoke(agent, ["reply", name, "here is my advice"])
+    assert reply.exit_code == 0, reply.output
+    assert "Replied to bob: Re: Q" in reply.output
+
+    # Inbox stamped replied + reply delivered + threaded.
+    assert _frontmatter(workspace / "messages" / "inbox" / name)["replied"] is True
+    out = _only_outbox_msg(workspace)
+    assert _frontmatter(out)["in_reply_to"] == name
+
+    after = CliRunner().invoke(agent, ["pending"])
+    assert "No messages awaiting reply" in after.output
+
+
+def test_reply_marks_original_completed_in_tracker(workspace: Path) -> None:
+    name = _seed_inbox(workspace)
+    CliRunner().invoke(agent, ["reply", name, "advice"])
+    tracker = ConversationTracker(workspace / "messages" / ".tracking")
+    state = tracker.get_message_state("agent:alice|bob", name)
+    assert state is not None
+    assert state.state == MessageState.COMPLETED
+
+
+def test_pending_respects_reply_window(workspace: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # An old message (well past the 7-day SLA) is not flagged.
+    inbox = workspace / "messages" / "inbox"
+    (inbox / "old.md").write_text(
+        "---\nfrom: bob\nto: alice\ntimestamp: 2020-01-01T00:00:00Z\n"
+        "subject: ancient\nread: false\n---\n\nold question\n"
+    )
+    result = CliRunner().invoke(agent, ["pending"])
+    assert "No messages awaiting reply" in result.output
+
+
+def test_status_reports_counts(workspace: Path) -> None:
+    _seed_inbox(workspace)
+    result = CliRunner().invoke(agent, ["status"])
+    assert result.exit_code == 0
+    assert "Agent:    alice" in result.output
+    assert "Inbox:    1" in result.output
+    assert "Pending:  1" in result.output

--- a/packages/gptmail/tests/test_agent_cli.py
+++ b/packages/gptmail/tests/test_agent_cli.py
@@ -162,3 +162,35 @@ def test_status_reports_counts(workspace: Path) -> None:
     assert "Agent:    alice" in result.output
     assert "Inbox:    1" in result.output
     assert "Pending:  1" in result.output
+
+
+def test_reply_with_subject_containing_replied_false(workspace: Path) -> None:
+    """Regression: reply to a message whose subject contains 'replied: false' or 'read: false'.
+
+    The ``_mark_replied`` helper originally used unanchored ``.replace()`` calls
+    that could corrupt frontmatter when the subject line happened to contain
+    those literal strings (Greptile P1, gptme/gptme-contrib#1097).
+    """
+    inbox = workspace / "messages" / "inbox"
+    name = "20260613-000000-000000-bob-cmd.md"
+    subject = "run command with replied: false and read: false status"
+    (inbox / name).write_text(
+        "---\n"
+        "from: bob\n"
+        "to: alice\n"
+        "timestamp: 2026-06-13T00:00:00Z\n"
+        f"subject: '{subject}'\n"
+        "read: false\n"
+        "---\n\n"
+        "please run the command\n"
+    )
+
+    reply = CliRunner().invoke(agent, ["reply", name, "done"])
+    assert reply.exit_code == 0, reply.output
+
+    fm = _frontmatter(inbox / name)
+    # read and replied must be true
+    assert fm["read"] is True
+    assert fm["replied"] is True
+    # subject must NOT be corrupted by the replace
+    assert fm["subject"] == subject

--- a/packages/gptmail/tests/test_agent_cli_no_email_imports.py
+++ b/packages/gptmail/tests/test_agent_cli_no_email_imports.py
@@ -1,0 +1,40 @@
+"""Guard: the ``gptmail agent`` CLI subgroup is email-stack-free.
+
+Same constraint as the transport guard, one layer up: importing ``agent_cli``
+(the ``gptmail agent`` commands) must not pull in ``imaplib``/``smtplib``/
+``gptmail.lib``/``gptmail.transport.email``, so the inter-agent CLI runs in
+isolated LXC sessions with no email infra. The unified ``gptmail`` entry point
+(``cli.py``) deliberately *does* import the email stack — that's why the agent
+commands live in their own module and are tested for isolation here, not via
+``cli``. See task ``fold-agent-msg-into-gptmail-single-comms-tool``.
+"""
+
+import subprocess
+import sys
+
+FORBIDDEN = ["imaplib", "smtplib", "gptmail.lib", "gptmail.transport.email"]
+
+_PROBE = """
+import sys
+from gptmail.agent_cli import agent  # noqa: F401
+
+forbidden = {forbidden!r}
+leaked = [m for m in forbidden if m in sys.modules]
+if leaked:
+    print("LEAKED:" + ",".join(leaked))
+    sys.exit(1)
+print("CLEAN")
+""".format(forbidden=FORBIDDEN)
+
+
+def test_agent_cli_imports_no_email_stack() -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", _PROBE],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"agent_cli pulled in the email stack.\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert "CLEAN" in result.stdout


### PR DESCRIPTION
Fixes the P1 bug identified in Greptile review of #1097.

The `_mark_replied` helper used unanchored `.replace()` calls for
`read: false` and `replied: false`, which corrupts frontmatter
when a message subject happens to contain those literal strings.

Replaces #1097 (same fix, pushed to main repo instead of Alice's fork).

**Changes:**
- Replace `.replace('read: false', 'read: true')` with anchored `re.sub(r'^read: false$', ..., re.MULTILINE)`
- Replace `.replace('replied: false', 'replied: true')` with anchored `re.sub(r'^replied: false$', ..., re.MULTILINE)`
- Fix `'replied:' not in fm` detection to use anchored `re.search(r'^replied:', ..., re.MULTILINE)`
- Add regression test: subject containing `replied: false` does not corrupt frontmatter

Closes #1097