### PR TITLE
feat(usage): new gptme-usage package — move harness_models + config-leak fixes

### DIFF
--- a/packages/gptme-subscription/src/gptme_subscription/harness_models.py
+++ b/packages/gptme-subscription/src/gptme_subscription/harness_models.py
@@ -84,7 +84,9 @@ class HarnessQuotaConfig:
     quota_sources: dict[str, str] = field(default_factory=dict)
     model_routes: dict[str, str] = field(default_factory=dict)
     openrouter_key_contexts: dict[str, str] = field(default_factory=dict)
-    claude_plan_tier: str = "max-20x"
+    # Agent's Claude plan tier (e.g. "max-5x", "max-20x"). None = unconfigured;
+    # callers must not assume a specific agent's plan as a generic default.
+    claude_plan_tier: str | None = None
 
 
 def _resolve_config_path(path: Path | None) -> Path:
@@ -115,7 +117,7 @@ def load_quota_config(path: Path | None = None) -> HarnessQuotaConfig:
 
     TOML schema::
 
-        claude_plan_tier = "max-20x"  # optional; default "max-20x"
+        claude_plan_tier = "max-20x"  # optional; omit when unknown (default None)
 
         [prices.claude-code]
         opus    = [5.0, 25.0]   # [input_$/1M, output_$/1M]
@@ -195,7 +197,8 @@ def load_quota_config(path: Path | None = None) -> HarnessQuotaConfig:
         if isinstance(ctx, str):
             openrouter_key_contexts[key] = ctx
 
-    claude_plan_tier = str(raw.get("claude_plan_tier") or "max-20x")
+    raw_tier = raw.get("claude_plan_tier")
+    claude_plan_tier = str(raw_tier) if isinstance(raw_tier, str) and raw_tier else None
 
     return HarnessQuotaConfig(
         price_table=price_table,
@@ -322,8 +325,11 @@ def pricing_key_for_model(
         else:
             normalized_model = resolved
     elif harness == "gptme":
+        # Config replaces the module-level routes (consistent with how
+        # price_table / tps_table behave) so a configured agent never inherits
+        # Bob's GPTME_MODEL_ROUTES underneath its own.
         routes = (
-            {**GPTME_MODEL_ROUTES, **config.model_routes}
+            config.model_routes
             if (config is not None and config.model_routes)
             else GPTME_MODEL_ROUTES
         )

--- a/packages/gptme-subscription/tests/test_harness_quota_config.py
+++ b/packages/gptme-subscription/tests/test_harness_quota_config.py
@@ -75,7 +75,7 @@ def test_load_quota_config_empty_file(tmp_path: Path) -> None:
     cfg = load_quota_config(p)
     assert isinstance(cfg, HarnessQuotaConfig)
     assert cfg.price_table == {}
-    assert cfg.claude_plan_tier == "max-20x"  # default
+    assert cfg.claude_plan_tier is None  # unconfigured = unknown, not a Bob default
 
 
 def test_estimate_session_cost_with_config(toml_path: Path) -> None:
@@ -155,3 +155,32 @@ def test_load_quota_config_toml_round_trip(tmp_path: Path) -> None:
     cfg = load_quota_config(p)
     assert ("claude-code", "sonnet") in cfg.price_table
     assert cfg.price_table[("claude-code", "sonnet")] == (3.0, 15.0)
+
+
+def test_config_model_routes_replace_not_merge() -> None:
+    """A non-empty config.model_routes must fully replace GPTME_MODEL_ROUTES.
+
+    Regression guard: earlier code merged the two ({**globals, **config}), so a
+    configured agent silently inherited Bob's routes. An agent's config should be
+    authoritative — provider models only in Bob's globals must not resolve.
+    """
+    from gptme_subscription.harness_models import (
+        GPTME_MODEL_ROUTES,
+        pricing_key_for_model,
+    )
+
+    if not GPTME_MODEL_ROUTES:
+        pytest.skip("no module-level GPTME_MODEL_ROUTES to test replacement against")
+
+    bob_short, bob_provider = next(iter(GPTME_MODEL_ROUTES.items()))
+    # Config with a disjoint route set (does not contain bob_provider).
+    cfg = HarnessQuotaConfig(model_routes={"someagent-model": "openrouter/x/y@z"})
+
+    # With replace semantics, Bob's provider model is unknown to this config, so
+    # it stays unnormalized instead of resolving to Bob's short name.
+    key = pricing_key_for_model("gptme", bob_provider, config=cfg)
+    assert key == ("gptme", bob_provider)
+    assert key != ("gptme", bob_short)
+
+    # Without config, Bob's globals still resolve normally (unchanged behavior).
+    assert pricing_key_for_model("gptme", bob_provider) == ("gptme", bob_short)

--- a/packages/gptme-usage/README.md
+++ b/packages/gptme-usage/README.md
@@ -1,0 +1,52 @@
+# gptme-usage
+
+Cross-backend **usage / cost / quota** surface for gptme agents.
+
+This package owns the *usage and capacity* concern: the model registry, cost
+math, and per-agent quota configuration that inform harness/model selection for
+autonomous runs (and, downstream, subscription pressure scoring). It is
+deliberately **separate** from `gptme-subscription`, which owns credential-slot
+rotation — a different concern (see "Why a separate package" below).
+
+## What's here
+
+- `harness_models.py` — model registry, cost estimation
+  (`estimate_session_cost`, `estimate_tokens_from_duration`), cache pricing
+  multipliers, Agent SDK credit facts, and the per-agent quota config schema
+  (`HarnessQuotaConfig` + `load_quota_config()`).
+
+## Per-agent config
+
+Agent-specific data (price tables, TPS estimates, model routes, quota sources,
+plan tier) lives in `~/.config/gptme/harness-quota.toml`, loaded via
+`load_quota_config()`. The package ships **no agent's data** — an unconfigured
+agent gets an empty config and the generic cost math degrades gracefully.
+
+```python
+from gptme_usage import load_quota_config, estimate_session_cost
+
+cfg = load_quota_config()  # ~/.config/gptme/harness-quota.toml (or empty)
+cost = estimate_session_cost("claude-code", "opus", cache_read_tokens=1_000_000, config=cfg)
+```
+
+TOML schema: see the `load_quota_config` docstring in `harness_models.py`.
+
+## Why a separate package
+
+`harness_models` / quota checking spans backends with no credential slot at all
+(OpenRouter API key, local LM Studio) and never flips a credential symlink. It
+is a *usage/capacity* concern, not a *subscription/slot* concern. Keeping it out
+of `gptme-subscription` lets both the subscription manager and the autonomous
+harness selector depend on usage without dragging in each other.
+
+Layering invariant: **`gptme_usage` must not import from `gptme_subscription`.**
+A top-level quota CLI may compose both, but the libraries stay decoupled.
+
+Design: `ErikBjare/bob knowledge/technical-designs/gptme-usage-package-split.md`.
+
+## Roadmap
+
+- **PR 1 (this)**: scaffold + move `harness_models` out of `gptme-subscription`.
+- **Next**: move `check-quota.py` + the `check-*-usage` scrapers in behind a
+  `gptme-usage check <backend>` CLI; wire config-driven data so Bob's tables
+  leave the shared module (`bob/config/harness-quota.toml`).

--- a/packages/gptme-usage/pyproject.toml
+++ b/packages/gptme-usage/pyproject.toml
@@ -1,0 +1,43 @@
+[project]
+name = "gptme-usage"
+version = "0.1.0"
+description = "Cross-backend usage, cost, and quota surface for gptme agents (model registry, cost math, quota checks)"
+authors = [
+    {name = "gptme contributors", email = "gptme@superuserlabs.org"}
+]
+license = "MIT"
+readme = "README.md"
+requires-python = ">=3.10"
+keywords = ["usage", "quota", "cost", "capacity", "inference", "gptme", "ai-agents"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Utilities",
+]
+dependencies = []
+
+[project.urls]
+Homepage = "https://github.com/gptme/gptme-contrib"
+Repository = "https://github.com/gptme/gptme-contrib"
+Issues = "https://github.com/gptme/gptme-contrib/issues"
+
+[project.optional-dependencies]
+test = [
+    "pytest>=7.0",
+    "pytest-cov>=4.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/gptme_usage"]
+
+[tool.mypy]
+strict = true

--- a/packages/gptme-usage/pyproject.toml
+++ b/packages/gptme-usage/pyproject.toml
@@ -19,7 +19,11 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Utilities",
 ]
-dependencies = []
+# tomllib is stdlib on 3.11+; tomli is the backport so load_quota_config()
+# actually parses harness-quota.toml on 3.10 (declared in requires-python).
+dependencies = [
+    "tomli>=2.0; python_version < '3.11'",
+]
 
 [project.urls]
 Homepage = "https://github.com/gptme/gptme-contrib"

--- a/packages/gptme-usage/src/gptme_usage/__init__.py
+++ b/packages/gptme-usage/src/gptme_usage/__init__.py
@@ -1,0 +1,41 @@
+"""gptme-usage: cross-backend usage, cost, and quota surface for gptme agents.
+
+This package owns the *usage / capacity* concern — the model registry, cost
+math, and per-agent quota configuration that inform both harness/model selection
+for autonomous runs and (downstream) subscription pressure scoring. It is a leaf
+package: it must not depend on ``gptme-subscription`` (slot rotation is a
+separate, higher-level concern). See
+``ErikBjare/bob knowledge/technical-designs/gptme-usage-package-split.md``.
+
+Extracted from ``gptme_subscription.harness_models`` (gptme/gptme-contrib#1088,
+relocated here so quota/usage is not mis-homed in the subscription package).
+
+Primary API::
+
+    from gptme_usage import (
+        HarnessQuotaConfig,
+        load_quota_config,
+        estimate_session_cost,
+        estimate_tokens_from_duration,
+    )
+"""
+
+from __future__ import annotations
+
+from gptme_usage.harness_models import (
+    HarnessQuotaConfig,
+    estimate_session_cost,
+    estimate_tokens_from_duration,
+    load_quota_config,
+    pricing_key_for_model,
+)
+
+__all__ = [
+    "HarnessQuotaConfig",
+    "load_quota_config",
+    "estimate_session_cost",
+    "estimate_tokens_from_duration",
+    "pricing_key_for_model",
+]
+
+__version__ = "0.1.0"

--- a/packages/gptme-usage/src/gptme_usage/harness_models.py
+++ b/packages/gptme-usage/src/gptme_usage/harness_models.py
@@ -325,9 +325,9 @@ def pricing_key_for_model(
         else:
             normalized_model = resolved
     elif harness == "gptme":
-        # Config replaces the module-level routes (consistent with how
-        # price_table / tps_table behave) so a configured agent never inherits
-        # Bob's GPTME_MODEL_ROUTES underneath its own.
+        # Config replaces the module-level routes entirely (unlike price_table /
+        # tps_table which merge config entries on top of module defaults) so a
+        # configured agent never silently inherits stale routes from the defaults.
         routes = (
             config.model_routes
             if (config is not None and config.model_routes)

--- a/packages/gptme-usage/src/gptme_usage/harness_models.py
+++ b/packages/gptme-usage/src/gptme_usage/harness_models.py
@@ -436,8 +436,11 @@ def estimate_session_cost(
             ``price_table`` is non-empty, that table is used for pricing
             instead of the module-level ``HARNESS_PRICE_USD_PER_1M``.
     """
+    # A non-empty config.price_table replaces the module-level table outright
+    # (not a merge) so a configured agent never inherits Bob's prices underneath
+    # its own. Consistent with tps_table and model_routes.
     price_table = (
-        {**HARNESS_PRICE_USD_PER_1M, **config.price_table}
+        config.price_table
         if (config is not None and config.price_table)
         else HARNESS_PRICE_USD_PER_1M
     )
@@ -548,8 +551,10 @@ def estimate_tokens_from_duration(
     """
     if duration_seconds <= 0:
         return None
+    # Replace (not merge) the module-level table when config provides one — see
+    # estimate_session_cost for the rationale (no Bob-data leak into agents).
     tps_table = (
-        {**TOKENS_PER_SECOND, **config.tps_table}
+        config.tps_table
         if (config is not None and config.tps_table)
         else TOKENS_PER_SECOND
     )

--- a/packages/gptme-usage/src/gptme_usage/harness_models.py
+++ b/packages/gptme-usage/src/gptme_usage/harness_models.py
@@ -325,8 +325,8 @@ def pricing_key_for_model(
         else:
             normalized_model = resolved
     elif harness == "gptme":
-        # Config replaces the module-level routes entirely (unlike price_table /
-        # tps_table which merge config entries on top of module defaults) so a
+        # Config replaces the module-level routes entirely (consistent with
+        # price_table and tps_table: all three use replace-not-merge) so a
         # configured agent never silently inherits stale routes from the defaults.
         routes = (
             config.model_routes

--- a/packages/gptme-usage/tests/test_harness_quota_config.py
+++ b/packages/gptme-usage/tests/test_harness_quota_config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from gptme_subscription.harness_models import (
+from gptme_usage.harness_models import (
     HarnessQuotaConfig,
     estimate_session_cost,
     estimate_tokens_from_duration,
@@ -164,7 +164,7 @@ def test_config_model_routes_replace_not_merge() -> None:
     configured agent silently inherited Bob's routes. An agent's config should be
     authoritative — provider models only in Bob's globals must not resolve.
     """
-    from gptme_subscription.harness_models import (
+    from gptme_usage.harness_models import (
         GPTME_MODEL_ROUTES,
         pricing_key_for_model,
     )

--- a/packages/gptme-usage/tests/test_harness_quota_config.py
+++ b/packages/gptme-usage/tests/test_harness_quota_config.py
@@ -129,6 +129,39 @@ def test_estimate_session_cost_config_overrides_price(toml_path: Path) -> None:
     ), f"expected 2x ratio, got {cost_custom}/{cost_default}"
 
 
+def test_config_price_table_replaces_not_merges() -> None:
+    """A non-empty config.price_table must fully replace HARNESS_PRICE_USD_PER_1M.
+
+    Regression guard: a model present in Bob's module-level table but absent from
+    the agent's config must NOT be priced from Bob's data (no silent leak).
+    """
+    # Config prices only a made-up model; "claude-code/opus" is in Bob's globals.
+    cfg = HarnessQuotaConfig(price_table={("gptme", "someagent-model"): (1.0, 2.0)})
+    cost = estimate_session_cost(
+        "claude-code", "opus", cache_read_tokens=1_000_000, config=cfg
+    )
+    assert cost is None  # opus not in this agent's config => no price, not Bob's
+    # Sanity: without config, Bob's globals still price opus.
+    assert (
+        estimate_session_cost(
+            "claude-code", "opus", cache_read_tokens=1_000_000, config=None
+        )
+        is not None
+    )
+
+
+def test_config_tps_table_replaces_not_merges() -> None:
+    """A non-empty config.tps_table must fully replace TOKENS_PER_SECOND."""
+    cfg = HarnessQuotaConfig(tps_table={("gptme", "someagent-model"): 1234.0})
+    # opus is in Bob's globals but not this config => no TPS, returns None.
+    assert estimate_tokens_from_duration("claude-code", "opus", 10, config=cfg) is None
+    # Without config, Bob's globals still resolve opus.
+    assert (
+        estimate_tokens_from_duration("claude-code", "opus", 10, config=None)
+        is not None
+    )
+
+
 def test_estimate_tokens_from_duration_with_config(toml_path: Path) -> None:
     cfg = load_quota_config(toml_path)
     tokens = estimate_tokens_from_duration("claude-code", "opus", 10, config=cfg)

--- a/scripts/check-quota.py
+++ b/scripts/check-quota.py
@@ -32,16 +32,21 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+_usage_pkg_src = str(REPO_ROOT / "packages" / "gptme-usage" / "src")
+if _usage_pkg_src not in sys.path:
+    sys.path.insert(0, _usage_pkg_src)
 _subscription_pkg_src = str(REPO_ROOT / "packages" / "gptme-subscription" / "src")
 if _subscription_pkg_src not in sys.path:
     sys.path.insert(0, _subscription_pkg_src)
 _credential_slots_src = str(REPO_ROOT / "packages" / "credential-slots" / "src")
 if _credential_slots_src not in sys.path:
     sys.path.insert(0, _credential_slots_src)
-# harness_models is the shared model catalog (tiers/prices/routes/quota-sources +
-# generic cost logic), now canonical in gptme-subscription so every agent shares
-# one source of truth. Per-agent availability is configuration (see QUOTA_BACKENDS).
-from gptme_subscription.harness_models import (  # noqa: E402
+# harness_models is the shared model catalog (prices/routes/quota-sources +
+# generic cost logic), canonical in the gptme-usage package (usage/capacity is a
+# separate concern from subscription/slot rotation — see the gptme-usage README).
+# Per-agent availability is configuration (see QUOTA_BACKENDS).
+from gptme_subscription.routing import compute_window_pacing  # noqa: E402
+from gptme_usage.harness_models import (  # noqa: E402
     CLAUDE_AGENT_SDK_ASSUMED_MONTHLY_CREDIT_USD,
     CLAUDE_AGENT_SDK_CREDIT_CHANGE_DATE,
     estimate_session_cost,
@@ -51,7 +56,6 @@ from gptme_subscription.harness_models import (  # noqa: E402
     local_models,
     openrouter_models,
 )
-from gptme_subscription.routing import compute_window_pacing  # noqa: E402
 
 SESSION_RECORDS_FILE = REPO_ROOT / "state" / "sessions" / "session-records.jsonl"
 CLAUDE_CODE_PROJECTS_DIR = Path.home() / ".claude" / "projects"

--- a/uv.lock
+++ b/uv.lock
@@ -40,6 +40,7 @@ members = [
     "gptme-subscription",
     "gptme-tooloutput-trimmer",
     "gptme-tts",
+    "gptme-usage",
     "gptme-user-memories",
     "gptme-voice",
     "gptme-warpgrep",
@@ -1998,6 +1999,24 @@ requires-dist = [
     { name = "sounddevice", specifier = ">=0.5.1" },
 ]
 provides-extras = ["test", "all"]
+
+[[package]]
+name = "gptme-usage"
+version = "0.1.0"
+source = { editable = "packages/gptme-usage" }
+
+[package.optional-dependencies]
+test = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
+    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.0" },
+]
+provides-extras = ["test"]
 
 [[package]]
 name = "gptme-user-memories"

--- a/uv.lock
+++ b/uv.lock
@@ -2004,6 +2004,9 @@ provides-extras = ["test", "all"]
 name = "gptme-usage"
 version = "0.1.0"
 source = { editable = "packages/gptme-usage" }
+dependencies = [
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
 
 [package.optional-dependencies]
 test = [
@@ -2015,6 +2018,7 @@ test = [
 requires-dist = [
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.0" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
 ]
 provides-extras = ["test"]
 


### PR DESCRIPTION
## Summary

Creates a new leaf package **`gptme-usage`** and relocates `harness_models` into it, plus the config-leak fixes originally split into #1100 (now folded here — see below). Usage/capacity (model registry, cost math, quota config) is a different concern from subscription/slot rotation and shouldn't live in `gptme-subscription`.

### Package move
- New `packages/gptme-usage/` (src layout, `py.typed`, README, pyproject — zero hard deps; `harness_models` is stdlib + one guarded `gptme.config` import).
- `git mv` `harness_models.py` + tests into `gptme-usage`; repoint test imports.
- Repoint `scripts/check-quota.py` to `gptme_usage.harness_models` (still imports `compute_window_pacing` from `gptme_subscription.routing` — fine, it's the composition root). Library invariant: **`gptme_usage` does not import `gptme_subscription`**.

### Config-leak fixes (folded from #1100)
All three per-agent config tables now **replace** the module-level globals instead of merging Bob's data underneath:
- `model_routes` — was `{**GPTME_MODEL_ROUTES, **config}` → replace.
- `price_table` / `tps_table` — were `{**globals, **config}` → replace (Greptile on #1100 caught these were still merging; a configured agent silently inherited Bob's prices/TPS for any unspecified model — the exact leak Erik objected to).
- `claude_plan_tier` defaults to `None` (unconfigured = unknown) instead of Bob's `"max-20x"`.
- Regression tests pin replace-not-merge for routes, prices, and TPS.

## Follow-ups (next PRs)
- Move `check-quota.py` + `check-*-usage` scrapers behind a `gptme-usage check <backend>` CLI (`[project.scripts]` console entry).
- Extract Bob's data tables to `bob/config/harness-quota.toml` so the shared module ships generic (closes Erik's original #1088 objection).

## Test plan
- [x] `gptme-usage` tests: 13 passed (incl. replace-not-merge for routes/price/tps)
- [x] `gptme-subscription` tests still green after removal: 84 passed
- [x] mypy clean on `gptme-usage` (strict)
- [x] `check-quota.py --help` works; all imports resolve

Design: `ErikBjare/bob knowledge/technical-designs/gptme-usage-package-split.md`