### PR TITLE
feat(usage): config-driven quota — ship generic, data via per-agent harness-quota.toml

### DIFF
--- a/packages/gptme-usage/README.md
+++ b/packages/gptme-usage/README.md
@@ -46,7 +46,10 @@ Design: `ErikBjare/bob knowledge/technical-designs/gptme-usage-package-split.md`
 
 ## Roadmap
 
-- **PR 1 (this)**: scaffold + move `harness_models` out of `gptme-subscription`.
+- **Done**: scaffold + move `harness_models` out of `gptme-subscription`.
+- **Done**: config-driven data. The module ships EMPTY tables; `check-quota.py`
+  loads `load_quota_config()` once and threads it through every call, so each
+  agent's `harness-quota.toml` drives cost/availability. See
+  `harness-quota.example.toml` for the schema.
 - **Next**: move `check-quota.py` + the `check-*-usage` scrapers in behind a
-  `gptme-usage check <backend>` CLI; wire config-driven data so Bob's tables
-  leave the shared module (`bob/config/harness-quota.toml`).
+  `gptme-usage check <backend>` console entry point.

--- a/packages/gptme-usage/harness-quota.example.toml
+++ b/packages/gptme-usage/harness-quota.example.toml
@@ -1,0 +1,44 @@
+# Example per-agent quota configuration for gptme-usage.
+#
+# Copy to ~/.config/gptme/harness-quota.toml and edit for your agent. The
+# gptme-usage package ships NO agent's real data — every agent supplies its own
+# model set, prices, throughput, routes, and quota sources here. Loaded by
+# gptme_usage.harness_models.load_quota_config(); a missing file degrades
+# gracefully to "no models configured".
+#
+# These values are illustrative placeholders, not live pricing — replace them.
+
+# Your Claude plan tier: "pro" | "max-5x" | "max-20x" | ... (optional).
+# Drives Agent SDK monthly-credit math. Omit if unknown.
+claude_plan_tier = "max-5x"
+
+# --- Model prices (USD per 1M tokens: [input, output]) ---
+# Keyed by [prices.<backend>] then "<model>" = [input, output].
+[prices.claude-code]
+opus   = [5.0, 25.0]
+sonnet = [3.0, 15.0]
+
+[prices.gptme]
+"example-openrouter-model" = [1.0, 3.0]
+
+# --- Tokens per second (empirical throughput; used to estimate tokens from
+#     session duration when token counts are missing) ---
+[tps.claude-code]
+opus   = 18000
+sonnet = 12000
+
+# --- gptme model quota sources: which pool each model draws from ---
+#     "openrouter" | "chatgpt" | "local"
+[quota_sources]
+"example-openrouter-model" = "openrouter"
+"example-local-model"      = "local"
+
+# --- gptme provider-qualified model routes (short name -> full route string) ---
+[model_routes]
+"example-openrouter-model" = "openrouter/vendor/example-model@vendor"
+"example-local-model"      = "lmstudio/vendor/example-local"
+
+# --- OpenRouter key contexts (which scoped API key a model's quota uses) ---
+#     "default" applies to any model not listed explicitly.
+[openrouter_key_contexts]
+default = "autonomous"

--- a/packages/gptme-usage/src/gptme_usage/harness_models.py
+++ b/packages/gptme-usage/src/gptme_usage/harness_models.py
@@ -47,7 +47,8 @@ CLAUDE_AGENT_SDK_MONTHLY_CREDIT_USD: dict[str, float] = {
     "enterprise-usage": 20.0,
     "enterprise-premium": 200.0,
 }
-# Default: assume Max 20x (highest credit) for Bob/Alice operations
+# Conservative default credit — callers that have a claude_plan_tier loaded
+# should use CLAUDE_AGENT_SDK_MONTHLY_CREDIT_USD[config.claude_plan_tier] instead.
 CLAUDE_AGENT_SDK_ASSUMED_MONTHLY_CREDIT_USD = CLAUDE_AGENT_SDK_MONTHLY_CREDIT_USD[
     "max-20x"
 ]
@@ -265,8 +266,16 @@ HARNESS_COST: dict[tuple[str, str], float] = {
 }
 
 
-def quota_pool_label(harness: str, model: str) -> str:
+def quota_pool_label(
+    harness: str,
+    model: str,
+    config: HarnessQuotaConfig | None = None,
+) -> str:
     """Return the quota/billing pool label for a harness/model pair.
+
+    Reads ``config.quota_sources`` when provided (per-agent), else falls back to
+    the module-level ``GPTME_QUOTA_SOURCE`` (now empty; config must be provided
+    for per-agent quota pool labels).
 
     Note: After CLAUDE_AGENT_SDK_CREDIT_CHANGE_DATE (June 15, 2026), claude-code
     sessions draw from a $200/month Agent SDK credit pool instead of the
@@ -282,7 +291,12 @@ def quota_pool_label(harness: str, model: str) -> str:
     if harness == "codex":
         return "chatgpt-sub (shared)"
     if harness == "gptme":
-        source = GPTME_QUOTA_SOURCE.get(model)
+        sources = (
+            config.quota_sources
+            if (config is not None and config.quota_sources)
+            else GPTME_QUOTA_SOURCE
+        )
+        source = sources.get(model)
         if source == "chatgpt":
             return "chatgpt-sub (shared)"
         if source == "openrouter":

--- a/packages/gptme-usage/src/gptme_usage/harness_models.py
+++ b/packages/gptme-usage/src/gptme_usage/harness_models.py
@@ -6,10 +6,11 @@ Provides:
 - Agent SDK credit facts (dates, plan table)
 - Cache pricing multipliers
 
-Agent-specific data (price tables, TPS, model routes, quota sources) should live
-in ~/.config/gptme/harness-quota.toml and be loaded via load_quota_config().
-The module-level globals (HARNESS_PRICE_USD_PER_1M etc.) are kept for backward
-compatibility but agents should prefer config-based lookup.
+Agent-specific data (price tables, TPS, model routes, quota sources) lives in
+~/.config/gptme/harness-quota.toml and is loaded via load_quota_config(). The
+module-level tables (HARNESS_PRICE_USD_PER_1M etc.) ship EMPTY — this package
+carries no single agent's config. Callers pass a loaded config; without one the
+cost/lookup helpers return None/empty. See harness-quota.example.toml.
 """
 
 from __future__ import annotations
@@ -229,30 +230,12 @@ def load_quota_config(path: Path | None = None) -> HarnessQuotaConfig:
 #   https://openrouter.ai/deepseek/deepseek-v4-flash, https://openrouter.ai/moonshotai/kimi-k2.6)
 # Copilot-backed models use the same underlying provider price floors as their
 # API equivalents so selector ordering stays anchored to real model cost.
-HARNESS_PRICE_USD_PER_1M: dict[tuple[str, str], tuple[float, float]] = {
-    ("claude-code", "opus"): (5.0, 25.0),
-    ("claude-code", "sonnet"): (3.0, 15.0),
-    # xAI does not publish list pricing for Grok Build subscription usage.
-    # Use a conservative Sonnet-like proxy floor so selector routing does not
-    # over-prefer an unevaluated subscription-backed arm.
-    ("grok-build", "grok-build"): (3.0, 15.0),
-    ("codex", "gpt-5.4"): (2.5, 15.0),
-    ("codex", "gpt-5.5"): (5.0, 30.0),
-    ("copilot-cli", "claude-opus-4.6"): (5.0, 25.0),
-    ("copilot-cli", "claude-sonnet-4.6"): (3.0, 15.0),
-    ("copilot-cli", "gpt-5.4"): (2.5, 15.0),
-    ("gptme", "gpt-5.4"): (2.5, 15.0),
-    ("gptme", "gpt-5.5"): (5.0, 30.0),
-    ("gptme", "deepseek-v4-pro"): (1.74, 3.48),
-    ("gptme", "deepseek-v4-flash"): (0.14, 0.28),
-    ("gptme", "kimi-k2.6"): (0.7448, 4.655),
-    ("gptme", "glm-5"): (0.72, 2.30),
-    ("gptme", "gemini-3.5-flash"): (1.50, 9.00),  # OpenRouter, GA 2026-05-19
-    ("gptme", "grok-4.20"): (2.0, 6.0),
-    ("gptme", "minimax-m3"): (0.30, 1.20),  # OpenRouter minimax/minimax-m3
-    ("gptme", "qwen3.7-max"): (1.25, 3.75),  # OpenRouter, GA 2026-05-20
-    ("gptme", "qwen3.6"): (0.01, 0.01),  # Local inference — near-zero marginal cost
-}
+# Per-agent data — supplied via ~/.config/gptme/harness-quota.toml ([prices.*])
+# and loaded into HarnessQuotaConfig.price_table. The module ships EMPTY so it
+# carries no single agent's config (see harness-quota.example.toml for the shape).
+# estimate_session_cost() falls back to this empty default only when called
+# without a config; production callers pass load_quota_config().
+HARNESS_PRICE_USD_PER_1M: dict[tuple[str, str], tuple[float, float]] = {}
 
 
 def blended_token_price(
@@ -508,28 +491,9 @@ TIER_RANK = {"high": 3, "medium": 2, "low": 1, "retired": 0}
 # near-100% cost estimation coverage (up from ~35%).
 # Source: analysis of 2,253 sessions across all (harness, model) pairs
 # with >= 10 data points. See knowledge/research/2026-05-01-token-coverage-backfill-analysis.md
-TOKENS_PER_SECOND: dict[tuple[str, str], float] = {
-    ("claude-code", "opus"): 18_899,
-    ("claude-code", "sonnet"): 12_804,
-    (
-        "grok-build",
-        "grok-build",
-    ): 9_000,  # conservative initial estimate until real session data lands
-    ("gptme", "grok-4.20"): 9_242,
-    ("gptme", "glm-5-turbo"): 8_304,
-    ("gptme", "minimax-m3"): 6_442,  # inherit m2.7 TPS until m3 data lands
-    ("gptme", "deepseek-v4-pro"): 9_574,
-    ("gptme", "kimi-k2.6"): 7_105,
-    ("gptme", "deepseek-v4-flash"): 14_248,
-    ("gptme", "glm-5.1"): 4_242,
-    ("gptme", "gpt-5.4"): 7_000,  # sparse data, conservative estimate
-    ("gptme", "gpt-5.5"): 8_000,  # sparse data, conservative estimate
-    ("codex", "gpt-5.4"): 8_000,  # sparse data, conservative estimate
-    ("codex", "gpt-5.5"): 9_000,  # sparse data, conservative estimate
-    ("copilot-cli", "claude-opus-4.6"): 12_000,  # sparse, proxied from cc:opus*0.65
-    ("copilot-cli", "claude-sonnet-4.6"): 8_000,  # sparse, proxied from cc:sonnet*0.65
-    ("copilot-cli", "gpt-5.4"): 6_000,  # sparse data, conservative estimate
-}
+# Per-agent data — supplied via harness-quota.toml ([tps.*]) into
+# HarnessQuotaConfig.tps_table. Ships EMPTY (no agent's config in the package).
+TOKENS_PER_SECOND: dict[tuple[str, str], float] = {}
 
 
 def estimate_tokens_from_duration(
@@ -573,38 +537,18 @@ def estimate_tokens_from_duration(
 # "openrouter" = OpenRouter API key with daily $ limit
 # "chatgpt" = ChatGPT subscription (separate pool)
 # Claude Code models don't appear here (they use CC subscription checks).
-GPTME_QUOTA_SOURCE: dict[str, str] = {
-    "gpt-5.4": "chatgpt",
-    "gpt-5.5": "chatgpt",
-    "deepseek-v4-pro": "openrouter",
-    "deepseek-v4-flash": "openrouter",
-    "kimi-k2.6": "openrouter",
-    "glm-5": "openrouter",
-    "gemini-3.5-flash": "openrouter",
-    "grok-4.20": "openrouter",
-    "minimax-m3": "openrouter",
-    "qwen3.7-max": "openrouter",
-    "qwen3.6": "local",  # LM Studio on erb-s1-win (Strix Halo)
-}
+# Per-agent data — supplied via harness-quota.toml ([quota_sources]) into
+# HarnessQuotaConfig.quota_sources. Ships EMPTY. openrouter_models() /
+# local_models() read the passed config; this default is the unconfigured case.
+GPTME_QUOTA_SOURCE: dict[str, str] = {}
 
 
 # --- Provider-qualified model strings ---
 # Maps short model names to full provider-prefixed strings for gptme.
-# Pin to official subproviders on OpenRouter for reliable inference.
-GPTME_MODEL_ROUTES: dict[str, str] = {
-    "gpt-5.4": "openai-subscription/gpt-5.4",
-    "gpt-5.5": "openai-subscription/gpt-5.5",
-    "deepseek-v4-pro": "openrouter/deepseek/deepseek-v4-pro@deepseek",
-    "deepseek-v4-flash": "openrouter/deepseek/deepseek-v4-flash@deepseek",
-    "kimi-k2.6": "openrouter/moonshotai/kimi-k2.6@moonshotai",
-    "glm-5": "openrouter/z-ai/glm-5@z-ai",  # @z-ai pins to official z.ai provider
-    "grok-4.20": "openrouter/x-ai/grok-4.20@x-ai",
-    "gemini-3.5-flash": "openrouter/google/gemini-3.5-flash",
-    # minimax-m3: 1M context + multimodal; base slug lets OpenRouter pick a provider
-    "minimax-m3": "openrouter/minimax/minimax-m3",
-    "qwen3.7-max": "openrouter/qwen/qwen3.7-max@qwen",
-    "qwen3.6": "lmstudio/qwen/qwen3.6-35b-a3b",
-}
+# Per-agent data — supplied via harness-quota.toml ([model_routes]) into
+# HarnessQuotaConfig.model_routes. Ships EMPTY; resolve_gptme_model() and
+# pricing_key_for_model() read the passed config.
+GPTME_MODEL_ROUTES: dict[str, str] = {}
 
 
 # --- Claude Code version aliases ---
@@ -635,32 +579,62 @@ CC_MODEL_VERSIONS: dict[str, str] = {
 }
 
 
-def openrouter_models() -> list[str]:
-    """Return list of gptme models that use OpenRouter quota."""
-    return [m for m, src in GPTME_QUOTA_SOURCE.items() if src == "openrouter"]
+def openrouter_models(config: HarnessQuotaConfig | None = None) -> list[str]:
+    """Return list of gptme models that use OpenRouter quota.
+
+    Reads ``config.quota_sources`` when provided (per-agent), else falls back to
+    the module-level ``GPTME_QUOTA_SOURCE``.
+    """
+    sources = (
+        config.quota_sources
+        if (config is not None and config.quota_sources)
+        else GPTME_QUOTA_SOURCE
+    )
+    return [m for m, src in sources.items() if src == "openrouter"]
 
 
-def gptme_openrouter_context(model: str) -> str:
+def gptme_openrouter_context(
+    model: str, config: HarnessQuotaConfig | None = None
+) -> str:
     """Return the OpenRouter key context an autonomous gptme call uses for model.
 
-    Mirrors the runtime refinement in
-    ``scripts/runs/autonomous/autonomous-run.sh``: deepseek models swap to the
-    dedicated ``autonomous_deepseek`` key (separate $/day budget) so their
-    quota is isolated from the shared ``autonomous`` key.
+    When ``config.openrouter_key_contexts`` is provided, look up the model there,
+    falling back to its ``"default"`` entry (or ``"autonomous"``). Without config,
+    use the legacy rule: deepseek models swap to the dedicated
+    ``autonomous_deepseek`` key (separate $/day budget) so their quota is isolated
+    from the shared ``autonomous`` key.
     """
+    if config is not None and config.openrouter_key_contexts:
+        ctx = config.openrouter_key_contexts
+        return ctx.get(model, ctx.get("default", "autonomous"))
     if "deepseek" in model:
         return "autonomous_deepseek"
     return "autonomous"
 
 
-def local_models() -> list[str]:
-    """Return list of gptme models served by local inference (LM Studio)."""
-    return [m for m, src in GPTME_QUOTA_SOURCE.items() if src == "local"]
+def local_models(config: HarnessQuotaConfig | None = None) -> list[str]:
+    """Return list of gptme models served by local inference (LM Studio).
+
+    Reads ``config.quota_sources`` when provided, else ``GPTME_QUOTA_SOURCE``.
+    """
+    sources = (
+        config.quota_sources
+        if (config is not None and config.quota_sources)
+        else GPTME_QUOTA_SOURCE
+    )
+    return [m for m, src in sources.items() if src == "local"]
 
 
-def resolve_gptme_model(short_name: str) -> str:
+def resolve_gptme_model(
+    short_name: str, config: HarnessQuotaConfig | None = None
+) -> str:
     """Resolve short model name to provider-qualified string for gptme."""
-    return GPTME_MODEL_ROUTES.get(short_name, short_name)
+    routes = (
+        config.model_routes
+        if (config is not None and config.model_routes)
+        else GPTME_MODEL_ROUTES
+    )
+    return routes.get(short_name, short_name)
 
 
 COPILOT_MODEL_ALIASES: dict[str, str] = {

--- a/packages/gptme-usage/tests/test_harness_quota_config.py
+++ b/packages/gptme-usage/tests/test_harness_quota_config.py
@@ -92,73 +92,83 @@ def test_estimate_session_cost_with_config(toml_path: Path) -> None:
     assert abs(cost - 0.5) < 0.001, f"expected ~0.5, got {cost}"
 
 
-def test_estimate_session_cost_falls_back_without_config() -> None:
-    cost = estimate_session_cost(
-        "claude-code",
-        "opus",
-        cache_read_tokens=1_000_000,
-        config=None,
+def test_module_ships_no_agent_data() -> None:
+    """The shared module must ship EMPTY tables — no agent's data baked in.
+
+    Per-agent data lives in harness-quota.toml; the package carries none.
+    """
+    from gptme_usage.harness_models import (
+        GPTME_MODEL_ROUTES,
+        GPTME_QUOTA_SOURCE,
+        HARNESS_PRICE_USD_PER_1M,
+        TOKENS_PER_SECOND,
     )
-    # Should still work using module-level HARNESS_PRICE_USD_PER_1M
-    assert cost is not None
-    assert cost > 0
+
+    assert HARNESS_PRICE_USD_PER_1M == {}
+    assert TOKENS_PER_SECOND == {}
+    assert GPTME_QUOTA_SOURCE == {}
+    assert GPTME_MODEL_ROUTES == {}
+
+
+def test_estimate_session_cost_without_config_returns_none() -> None:
+    """With no config and an empty module table, there is no price -> None."""
+    cost = estimate_session_cost(
+        "claude-code", "opus", cache_read_tokens=1_000_000, config=None
+    )
+    assert cost is None
 
 
 def test_estimate_session_cost_config_overrides_price(toml_path: Path) -> None:
-    # Modify the config with a custom price and verify it's used
-    cfg = load_quota_config(toml_path)
-    # Patch price_table with a custom price for testing
-    cfg.price_table[("claude-code", "opus")] = (10.0, 50.0)  # 2x normal
-    cost_custom = estimate_session_cost(
-        "claude-code",
-        "opus",
-        cache_read_tokens=1_000_000,
-        config=cfg,
-    )
-    cost_default = estimate_session_cost(
-        "claude-code",
-        "opus",
-        cache_read_tokens=1_000_000,
-        config=None,
-    )
-    assert cost_custom is not None
-    assert cost_default is not None
-    # Custom price is 2x, so cost should be ~2x default
-    assert (
-        abs(cost_custom / cost_default - 2.0) < 0.01
-    ), f"expected 2x ratio, got {cost_custom}/{cost_default}"
-
-
-def test_config_price_table_replaces_not_merges() -> None:
-    """A non-empty config.price_table must fully replace HARNESS_PRICE_USD_PER_1M.
-
-    Regression guard: a model present in Bob's module-level table but absent from
-    the agent's config must NOT be priced from Bob's data (no silent leak).
-    """
-    # Config prices only a made-up model; "claude-code/opus" is in Bob's globals.
-    cfg = HarnessQuotaConfig(price_table={("gptme", "someagent-model"): (1.0, 2.0)})
-    cost = estimate_session_cost(
+    # Compare two configs (the module ships no default to compare against).
+    cfg = load_quota_config(toml_path)  # opus = [5, 25]
+    cfg_2x = load_quota_config(toml_path)
+    cfg_2x.price_table[("claude-code", "opus")] = (10.0, 50.0)  # 2x
+    cost_base = estimate_session_cost(
         "claude-code", "opus", cache_read_tokens=1_000_000, config=cfg
     )
-    assert cost is None  # opus not in this agent's config => no price, not Bob's
-    # Sanity: without config, Bob's globals still price opus.
+    cost_2x = estimate_session_cost(
+        "claude-code", "opus", cache_read_tokens=1_000_000, config=cfg_2x
+    )
+    assert cost_base is not None and cost_2x is not None
+    assert (
+        abs(cost_2x / cost_base - 2.0) < 0.01
+    ), f"expected 2x ratio, got {cost_2x}/{cost_base}"
+
+
+def test_config_price_table_replaces_not_merges(toml_path: Path) -> None:
+    """A non-empty config.price_table is authoritative — no other data leaks in.
+
+    A model absent from the agent's config gets no price (None), even though the
+    config does price other models.
+    """
+    cfg = load_quota_config(toml_path)  # prices opus, sonnet, deepseek-v4-pro...
+    # opus IS in this config -> priced.
     assert (
         estimate_session_cost(
-            "claude-code", "opus", cache_read_tokens=1_000_000, config=None
+            "claude-code", "opus", cache_read_tokens=1_000_000, config=cfg
         )
         is not None
     )
-
-
-def test_config_tps_table_replaces_not_merges() -> None:
-    """A non-empty config.tps_table must fully replace TOKENS_PER_SECOND."""
-    cfg = HarnessQuotaConfig(tps_table={("gptme", "someagent-model"): 1234.0})
-    # opus is in Bob's globals but not this config => no TPS, returns None.
-    assert estimate_tokens_from_duration("claude-code", "opus", 10, config=cfg) is None
-    # Without config, Bob's globals still resolve opus.
+    # A model NOT in this config -> None (no fallback to any other table).
     assert (
-        estimate_tokens_from_duration("claude-code", "opus", 10, config=None)
-        is not None
+        estimate_session_cost(
+            "claude-code", "nonexistent-model", cache_read_tokens=1_000_000, config=cfg
+        )
+        is None
+    )
+
+
+def test_config_tps_table_replaces_not_merges(toml_path: Path) -> None:
+    """A non-empty config.tps_table is authoritative; unlisted models -> None."""
+    cfg = load_quota_config(toml_path)  # has claude-code/opus TPS
+    assert (
+        estimate_tokens_from_duration("claude-code", "opus", 10, config=cfg) is not None
+    )
+    assert (
+        estimate_tokens_from_duration(
+            "claude-code", "nonexistent-model", 10, config=cfg
+        )
+        is None
     )
 
 
@@ -168,18 +178,15 @@ def test_estimate_tokens_from_duration_with_config(toml_path: Path) -> None:
     assert tokens == 100_000  # 10s * 10000 TPS
 
 
-def test_estimate_tokens_from_duration_falls_back_without_config() -> None:
-    tokens = estimate_tokens_from_duration("claude-code", "opus", 10, config=None)
-    assert tokens is not None
-    assert tokens > 0
+def test_estimate_tokens_from_duration_without_config_returns_none() -> None:
+    """Empty module table + no config -> no TPS data -> None."""
+    assert estimate_tokens_from_duration("claude-code", "opus", 10, config=None) is None
 
 
-def test_estimate_tokens_from_duration_empty_config() -> None:
+def test_estimate_tokens_from_duration_empty_config_returns_none() -> None:
+    """An empty config has no TPS table and the module ships none -> None."""
     cfg = HarnessQuotaConfig()  # empty
-    # Should fall back to module-level TOKENS_PER_SECOND
-    tokens = estimate_tokens_from_duration("claude-code", "opus", 10, config=cfg)
-    assert tokens is not None
-    assert tokens > 0
+    assert estimate_tokens_from_duration("claude-code", "opus", 10, config=cfg) is None
 
 
 def test_load_quota_config_toml_round_trip(tmp_path: Path) -> None:
@@ -190,30 +197,54 @@ def test_load_quota_config_toml_round_trip(tmp_path: Path) -> None:
     assert cfg.price_table[("claude-code", "sonnet")] == (3.0, 15.0)
 
 
-def test_config_model_routes_replace_not_merge() -> None:
-    """A non-empty config.model_routes must fully replace GPTME_MODEL_ROUTES.
+def test_config_model_routes_drive_pricing_key() -> None:
+    """config.model_routes resolves a provider string back to its short name.
 
-    Regression guard: earlier code merged the two ({**globals, **config}), so a
-    configured agent silently inherited Bob's routes. An agent's config should be
-    authoritative — provider models only in Bob's globals must not resolve.
+    The module ships no routes, so resolution is fully config-driven; a provider
+    string absent from the config stays unnormalized.
     """
-    from gptme_usage.harness_models import (
-        GPTME_MODEL_ROUTES,
-        pricing_key_for_model,
+    from gptme_usage.harness_models import pricing_key_for_model
+
+    cfg = HarnessQuotaConfig(
+        model_routes={"deepseek-v4-pro": "openrouter/deepseek/deepseek-v4-pro@deepseek"}
+    )
+    # The configured provider string normalizes to the short name.
+    assert pricing_key_for_model(
+        "gptme", "openrouter/deepseek/deepseek-v4-pro@deepseek", config=cfg
+    ) == ("gptme", "deepseek-v4-pro")
+    # A provider string not in the config stays unnormalized.
+    assert pricing_key_for_model("gptme", "openrouter/other/model", config=cfg) == (
+        "gptme",
+        "openrouter/other/model",
     )
 
-    if not GPTME_MODEL_ROUTES:
-        pytest.skip("no module-level GPTME_MODEL_ROUTES to test replacement against")
 
-    bob_short, bob_provider = next(iter(GPTME_MODEL_ROUTES.items()))
-    # Config with a disjoint route set (does not contain bob_provider).
-    cfg = HarnessQuotaConfig(model_routes={"someagent-model": "openrouter/x/y@z"})
+def test_config_aware_model_source_helpers() -> None:
+    """openrouter_models / local_models / gptme_openrouter_context read config."""
+    from gptme_usage.harness_models import (
+        gptme_openrouter_context,
+        local_models,
+        openrouter_models,
+    )
 
-    # With replace semantics, Bob's provider model is unknown to this config, so
-    # it stays unnormalized instead of resolving to Bob's short name.
-    key = pricing_key_for_model("gptme", bob_provider, config=cfg)
-    assert key == ("gptme", bob_provider)
-    assert key != ("gptme", bob_short)
-
-    # Without config, Bob's globals still resolve normally (unchanged behavior).
-    assert pricing_key_for_model("gptme", bob_provider) == ("gptme", bob_short)
+    cfg = HarnessQuotaConfig(
+        quota_sources={
+            "deepseek-v4-pro": "openrouter",
+            "kimi-k2.6": "openrouter",
+            "qwen3.6": "local",
+        },
+        openrouter_key_contexts={
+            "default": "autonomous",
+            "deepseek-v4-pro": "autonomous_deepseek",
+        },
+    )
+    assert set(openrouter_models(cfg)) == {"deepseek-v4-pro", "kimi-k2.6"}
+    assert local_models(cfg) == ["qwen3.6"]
+    assert gptme_openrouter_context("deepseek-v4-pro", cfg) == "autonomous_deepseek"
+    assert gptme_openrouter_context("kimi-k2.6", cfg) == "autonomous"  # default
+    # Empty/no config: module ships no sources -> empty lists.
+    assert openrouter_models() == []
+    assert local_models() == []
+    # No config -> legacy deepseek heuristic still applies.
+    assert gptme_openrouter_context("deepseek-v4-pro") == "autonomous_deepseek"
+    assert gptme_openrouter_context("kimi-k2.6") == "autonomous"

--- a/scripts/check-quota.py
+++ b/scripts/check-quota.py
@@ -53,9 +53,17 @@ from gptme_usage.harness_models import (  # noqa: E402
     estimate_tokens_from_duration,
     gptme_openrouter_context,
     is_post_agent_sdk_credit_change,
+    load_quota_config,
     local_models,
     openrouter_models,
 )
+
+# Per-agent quota config (prices, TPS, model routes, quota sources) from
+# ~/.config/gptme/harness-quota.toml. Loaded once and threaded through every
+# harness_models call so THIS agent's config drives cost/availability — the
+# shared package ships no agent's data. Empty config (no file) degrades
+# gracefully to "no models configured".
+QUOTA_CONFIG = load_quota_config()
 
 SESSION_RECORDS_FILE = REPO_ROOT / "state" / "sessions" / "session-records.jsonl"
 CLAUDE_CODE_PROJECTS_DIR = Path.home() / ".claude" / "projects"
@@ -499,6 +507,7 @@ def _estimate_claude_agent_sdk_credit_usage_from_records(
                     cache_creation_tokens=rec.get("cache_creation_tokens"),
                     cache_read_tokens=rec.get("cache_read_tokens"),
                     token_count=rec.get("token_count"),
+                    config=QUOTA_CONFIG,
                 )
                 estimated = False
                 if cost is None:
@@ -508,12 +517,14 @@ def _estimate_claude_agent_sdk_credit_usage_from_records(
                             str(rec.get("harness") or ""),
                             str(rec.get("model") or ""),
                             int(duration),
+                            config=QUOTA_CONFIG,
                         )
                         if est_tokens is not None:
                             cost = estimate_session_cost(
                                 str(rec.get("harness") or ""),
                                 str(rec.get("model") or ""),
                                 token_count=est_tokens,
+                                config=QUOTA_CONFIG,
                             )
                             estimated = cost is not None
                 if cost is None:
@@ -590,6 +601,7 @@ def _estimate_claude_agent_sdk_credit_usage_from_logs(
                         output_tokens=usage.get("output_tokens"),
                         cache_creation_tokens=usage.get("cache_creation_input_tokens"),
                         cache_read_tokens=usage.get("cache_read_input_tokens"),
+                        config=QUOTA_CONFIG,
                     )
                     if cost is None:
                         session_uncosted = True
@@ -1923,9 +1935,9 @@ def check_all_quotas(
                 # its own daily $ budget (e.g. deepseek has a dedicated key).
                 # Cache per-context lookups so we don't re-shell-out per model.
                 or_quota_by_context: dict[str, dict] = {}
-                or_models = openrouter_models()
+                or_models = openrouter_models(QUOTA_CONFIG)
                 for model in or_models:
-                    ctx = gptme_openrouter_context(model)
+                    ctx = gptme_openrouter_context(model, QUOTA_CONFIG)
                     if ctx not in or_quota_by_context:
                         or_quota_by_context[ctx] = check_openrouter_quota(
                             ctx, fast=fast
@@ -1943,7 +1955,7 @@ def check_all_quotas(
                         )
                     )
                 # Local models (LM Studio) — zero cost, availability via API ping
-                for model in local_models():
+                for model in local_models(QUOTA_CONFIG):
                     results.append(check_local_model_quota(model, fast=fast))
             elif backend == "codex":
                 # gpt-5.4 and gpt-5.5 both use the ChatGPT Codex subscription


### PR DESCRIPTION
## Summary

Completes the data-extraction so `gptme-usage` ships **no agent's config** — the step that closes Erik's original #1088 objection and lets Alice/Gordon adopt the quota surface with their own data.

- **Empty the module's Bob-data tables**: `HARNESS_PRICE_USD_PER_1M`, `TOKENS_PER_SECOND`, `GPTME_QUOTA_SOURCE`, `GPTME_MODEL_ROUTES` now ship `{}`. Bob's values live in his `~/.config/gptme/harness-quota.toml` (already present, symlinked from `bob/config/`).
- **Config-aware helpers**: `openrouter_models` / `local_models` / `gptme_openrouter_context` / `resolve_gptme_model` take an optional `config` and read it (fall back to the now-empty tables when `None`).
- **Wire `check-quota.py`**: loads `load_quota_config()` once into `QUOTA_CONFIG` and threads it through every `estimate_session_cost` / `estimate_tokens_from_duration` / `openrouter_models` / `gptme_openrouter_context` / `local_models` call.
- Add `harness-quota.example.toml` template; update README/docstring/tests.

## Behavior-preserving for Bob (verified)

Bob's `harness-quota.toml` reproduces the old module globals **exactly** (prices, TPS, quota sources, routes, openrouter contexts — checked key-and-value). So `check-quota` output is unchanged: opus 1M cache-read = `$0.5`, same openrouter/local model sets, `deepseek → autonomous_deepseek` / others → `autonomous`. With **replace** semantics + a complete TOML, no costing regression.

## ⚠️ Stacked on #1101

Based on the #1101 branch; the first 5 commits belong to #1101. **Merge #1101 first**, then this (it'll reduce to the single `feat(usage): config-driven quota` commit after rebase onto master).

## Test plan

- [x] `gptme-usage` tests: 15 passed (incl. `module_ships_no_agent_data`, replace-not-merge for price/tps/routes, config-aware source helpers)
- [x] mypy strict clean
- [x] `check-quota.py --help` + end-to-end config load verified (opus cost = 0.5, model sets/contexts match pre-change)

Design: `ErikBjare/bob knowledge/technical-designs/gptme-usage-package-split.md`

## Next (final follow-up)

`gptme-usage check <backend>` console entry point — move `check-quota.py` + the `check-*-usage` scrapers into the package CLI.