### PR TITLE
feat(gptmail): unread-default + read markers for `gptmail agent list`

### DIFF
--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -308,15 +308,36 @@ def broadcast(subject: str, content: str | None) -> None:
 
 @agent.command(name="list")
 @click.argument("folder", default="inbox")
-def list_cmd(folder: str) -> None:
-    """List messages in a folder (default: inbox)."""
+@click.option("--all", "-a", "show_all", is_flag=True, help="Include already-read messages.")
+def list_cmd(folder: str, show_all: bool) -> None:
+    """List messages in a folder (default: inbox, unread only).
+
+    Mirrors ``agent-msg.py list``: the inbox shows only unread messages by
+    default (each line prefixed ``*``); pass ``--all`` to include read ones.
+    Non-inbox folders (outbox/sent) always list everything. The line format
+    ``  {marker} [{ts}] {sender}: {subject}  ({file})`` matches agent-msg.py so
+    the planned thin shim is a faithful drop-in.
+    """
+    if "/" in folder or folder.startswith("."):
+        raise click.ClickException(f"Invalid folder name: {folder!r}")
     transport = _transport()
     rows = transport.list_inbox(folder)
-    if not rows:
-        click.echo(f"No messages in {folder}.")
-        return
-    for message_id, subject, ts in rows:
-        click.echo(f"{ts:%Y-%m-%d %H:%M}  {message_id}  {subject}")
+    folder_dir = _messages_dir() / folder
+    unread_only = folder == "inbox" and not show_all
+    shown = 0
+    for message_id, _subject, _ts in rows:
+        meta = meta_of(folder_dir / message_id) or {}
+        is_read = bool(meta.get("read"))
+        if unread_only and is_read:
+            continue
+        ts = meta.get("timestamp", "unknown")
+        sender = str(meta.get("from", "unknown"))
+        subject = str(meta.get("subject", "(no subject)"))
+        marker = " " if is_read else "*"
+        click.echo(f"  {marker} [{ts}] {sender}: {subject}  ({message_id})")
+        shown += 1
+    if shown == 0:
+        click.echo("No unread messages." if unread_only else f"No messages in {folder}.")
 
 
 @agent.command()

--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -32,6 +32,7 @@ Wiring:
 
 from __future__ import annotations
 
+import functools
 import os
 import re
 import shlex
@@ -61,8 +62,14 @@ def _reply_window_days() -> int:
         return 7
 
 
+@functools.lru_cache(maxsize=1)
 def _repo_root() -> Path:
-    """Workspace root via ``git rev-parse --show-toplevel`` (symlink-correct)."""
+    """Workspace root via ``git rev-parse --show-toplevel`` (symlink-correct).
+
+    Cached: a CLI invocation calls this several times (``_messages_dir`` is hit
+    by both the command body and ``_transport``) but cwd is fixed for the
+    process, so one ``git rev-parse`` per run suffices.
+    """
     try:
         out = subprocess.run(
             ["git", "rev-parse", "--show-toplevel"],
@@ -80,6 +87,21 @@ def _repo_root() -> Path:
 def _messages_dir() -> Path:
     """Messages directory for the current agent (``<repo>/messages``)."""
     return _repo_root() / "messages"
+
+
+def _within(base: Path, *parts: str) -> Path | None:
+    """Resolve ``base/parts`` and return it only if it stays inside ``base``.
+
+    Resolve-based containment: defeats both ``..`` traversal and symlinks whose
+    names look benign but point outside ``base``. Returns ``None`` when the
+    resolved path escapes ``base`` (callers decide whether that's a silent skip
+    or a hard error).
+    """
+    base_resolved = base.resolve()
+    candidate = base.joinpath(*parts).resolve()
+    if str(candidate).startswith(str(base_resolved) + os.sep):
+        return candidate
+    return None
 
 
 def _self_name() -> str:
@@ -245,9 +267,8 @@ def _pending_messages(messages_dir: Path, self_name: str, window: int) -> list[d
 
 def _mark_replied(messages_dir: Path, message_id: str) -> None:
     """Stamp an inbox message ``replied: true`` (and ``read: true``). Idempotent."""
-    path = (messages_dir / "inbox" / message_id).resolve()
-    inbox = (messages_dir / "inbox").resolve()
-    if not str(path).startswith(str(inbox) + os.sep) or not path.exists():
+    path = _within(messages_dir / "inbox", message_id)
+    if path is None or not path.exists():
         return
     content = path.read_text()
     if not content.startswith("---"):
@@ -318,11 +339,11 @@ def list_cmd(folder: str, show_all: bool) -> None:
     ``  {marker} [{ts}] {sender}: {subject}  ({file})`` matches agent-msg.py so
     the planned thin shim is a faithful drop-in.
     """
-    if "/" in folder or folder.startswith("."):
+    folder_dir = _within(_messages_dir(), folder)
+    if folder_dir is None:
         raise click.ClickException(f"Invalid folder name: {folder!r}")
     transport = _transport()
     rows = transport.list_inbox(folder)
-    folder_dir = _messages_dir() / folder
     unread_only = folder == "inbox" and not show_all
     shown = 0
     for message_id, _subject, _ts in rows:
@@ -359,9 +380,8 @@ def read(message_id: str, thread: bool) -> None:
 def reply(message_id: str, content: str | None) -> None:
     """Reply to an inbox message, threading via in_reply_to."""
     messages_dir = _messages_dir()
-    inbox_dir = (messages_dir / "inbox").resolve()
-    msg_path = (messages_dir / "inbox" / message_id).resolve()
-    if not str(msg_path).startswith(str(inbox_dir) + os.sep):
+    msg_path = _within(messages_dir / "inbox", message_id)
+    if msg_path is None:
         click.echo(f"Error: message not found: {message_id}", err=True)
         sys.exit(1)
     original = meta_of(msg_path)

--- a/packages/gptmail/tests/test_agent_cli.py
+++ b/packages/gptmail/tests/test_agent_cli.py
@@ -164,6 +164,20 @@ def test_list_rejects_path_traversal_folder(workspace: Path) -> None:
     assert "Invalid folder name" in result.output
 
 
+def test_list_rejects_symlink_escaping_messages_dir(workspace: Path) -> None:
+    """A plainly-named symlink inside messages/ that points outside is rejected.
+
+    The old ``"/" in folder`` string check passed this (the name has no slash);
+    the resolve-based guard follows the link and sees it escapes messages/.
+    """
+    secret = workspace / "secret"
+    secret.mkdir()
+    (workspace / "messages" / "escape").symlink_to(secret, target_is_directory=True)
+    result = CliRunner().invoke(agent, ["list", "escape"])
+    assert result.exit_code != 0
+    assert "Invalid folder name" in result.output
+
+
 def test_read_marks_read(workspace: Path) -> None:
     name = _seed_inbox(workspace)
     result = CliRunner().invoke(agent, ["read", name])

--- a/packages/gptmail/tests/test_agent_cli.py
+++ b/packages/gptmail/tests/test_agent_cli.py
@@ -129,6 +129,39 @@ def test_list_shows_inbox(workspace: Path) -> None:
     result = CliRunner().invoke(agent, ["list"])
     assert result.exit_code == 0
     assert name in result.output
+    # Unread messages are prefixed with the agent-msg.py "*" marker and the
+    # sender, e.g. ``  * [..] bob: Q  (file.md)``.
+    assert "* [" in result.output
+    assert "bob: Q" in result.output
+
+
+def test_list_unread_default_hides_read(workspace: Path) -> None:
+    """Default ``list`` mirrors agent-msg.py: only unread messages show."""
+    name = _seed_inbox(workspace)
+    CliRunner().invoke(agent, ["read", name])  # marks it read
+    result = CliRunner().invoke(agent, ["list"])
+    assert result.exit_code == 0
+    assert name not in result.output
+    assert "No unread messages." in result.output
+
+
+def test_list_all_includes_read(workspace: Path) -> None:
+    """``--all`` shows read messages too, with a blank (space) marker."""
+    name = _seed_inbox(workspace)
+    CliRunner().invoke(agent, ["read", name])
+    result = CliRunner().invoke(agent, ["list", "--all"])
+    assert result.exit_code == 0
+    assert name in result.output
+    # Read messages render with a blank marker (no leading "*"): the line is
+    # ``    [..] bob: Q  (file.md)`` — agent-msg.py's read-marker convention.
+    line = next(ln for ln in result.output.splitlines() if name in ln)
+    assert not line.lstrip().startswith("*")
+
+
+def test_list_rejects_path_traversal_folder(workspace: Path) -> None:
+    result = CliRunner().invoke(agent, ["list", "../secrets"])
+    assert result.exit_code != 0
+    assert "Invalid folder name" in result.output
 
 
 def test_read_marks_read(workspace: Path) -> None:


### PR DESCRIPTION
## What

Brings `gptmail agent list` to **byte-for-byte output parity** with `scripts/agent-msg.py list`. This is the prerequisite for converting `agent-msg.py` into a thin shim (fold-agent-msg-into-gptmail step 4) — the shim can only be a faithful drop-in if `gptmail agent list` matches the command it's replacing.

### Before
`gptmail agent list` dumped **all** inbox messages (read + unread) in a terse `ts  id  subject` format — a busy inbox printed everything every time.

### After
- **inbox defaults to unread-only** (matches `agent-msg.py list`); `--all`/`-a` includes read messages.
- line format `  {marker} [{ts}] {sender}: {subject}  ({file})` with `*` marking unread — identical to `agent-msg.py`.
- non-inbox folders (`outbox`/`sent`) still list everything (no read-semantics there).
- `folder` arg validated against path traversal, mirroring the transport guard.

## Why this is also a standalone UX win

Unread-default is better behavior regardless of the shim: an agent checking its inbox wants the unanswered messages, not a re-dump of everything it's already read.

## Verification

Ran both tools against the live workspace inbox (12 messages) — output is identical for both default (unread-only) and `--all`:

```
    [2026-02-19 12:15:23+00:00] bob: Hello from Bob  (20260219-121523-bob-Hello-from-Bob.md)
    ...
```

4 new/expanded tests (unread-default hides read, `--all` includes read with blank marker, `*` marker on unread, path-traversal folder rejected). **95/95 gptmail tests pass.** Stays email-stack-free (import guard still green).

## Context

Part of the agent-msg → gptmail consolidation (steps 1–3 merged: #1089, #1090, #1094, #1097). cc @TimeToBuildBob — this is the last parity gap before the agent-msg.py shim; no rush, flagging for review when convenient.