### PR TITLE
fix(self-merge): gate eligibility on actual merge permission

### DIFF
--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -219,6 +219,10 @@ def merge_permission(repo: str) -> bool | None:
         return None
     if not isinstance(perms, dict):
         return None
+    # If none of the expected keys are present the payload shape is unexpected —
+    # treat as unknown so a future API schema change doesn't false-disqualify.
+    if not any(k in perms for k in ("push", "maintain", "admin")):
+        return None
     return bool(perms.get("push") or perms.get("maintain") or perms.get("admin"))
 
 

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -198,6 +198,30 @@ def get_gh_user() -> str:
     return run_gh(["api", "user", "-q", ".login"]) or ""
 
 
+@cache
+def merge_permission(repo: str) -> bool | None:
+    """Whether the authenticated user can merge PRs in ``repo``.
+
+    Returns True if the user has push/maintain/admin on the repo, False if they
+    explicitly lack it, or None if the permission could not be determined (gh
+    error / unexpected payload). None is treated as "unknown" by the caller —
+    a warning, not a disqualifier — so a transient API hiccup doesn't block a
+    legitimate self-merge. A definitive False does disqualify: it means the
+    merge attempt would fail with a permissions error (e.g. an agent that
+    contributes to an upstream repo via a fork has pull-only access).
+    """
+    raw = run_gh(["api", f"repos/{repo}", "-q", ".permissions"])
+    if not raw:
+        return None
+    try:
+        perms = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(perms, dict):
+        return None
+    return bool(perms.get("push") or perms.get("maintain") or perms.get("admin"))
+
+
 def _resolve_gate_helper(script_path: Path | None = None) -> str | None:
     """Resolve the optional GitHub API rate-limit gate helper."""
 
@@ -1082,6 +1106,23 @@ def evaluate_pr(
     )
     result.reasons.extend(cross_repo_reasons)
     result.warnings.extend(cross_repo_warnings)
+
+    # Merge-permission check: an allowlisted repo the agent cannot actually merge
+    # (pull-only access, e.g. an upstream repo contributed to via a fork) would
+    # otherwise report eligible=YES and then fail the merge with a GitHub
+    # permissions error. Disqualify on a definitive lack of permission; treat an
+    # indeterminate result (gh error) as a non-blocking warning.
+    can_merge = merge_permission(repo)
+    if can_merge is False:
+        result.reasons.append(
+            f"Authenticated user lacks merge permission on {repo} "
+            "(pull-only access; merge would fail). Open a PR for a maintainer to merge."
+        )
+    elif can_merge is None:
+        result.warnings.append(
+            f"Could not determine merge permission on {repo}; "
+            "merge may fail if access is pull-only."
+        )
 
     if pr.get("isDraft"):
         result.reasons.append("PR is still a draft")

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -787,6 +787,13 @@ def test_merge_permission_raw_helper() -> None:
         assert raw("gptme/gptme-contrib") is None
     with patch.object(self_merge_check, "run_gh", return_value="not json"):
         assert raw("gptme/gptme-contrib") is None
+    # Dict present but all three expected keys absent — unknown, not disqualified
+    with patch.object(
+        self_merge_check,
+        "run_gh",
+        return_value='{"pull": true, "triage": true}',
+    ):
+        assert raw("gptme/gptme-contrib") is None
 
 
 def test_greptile_summary_score_ignores_signal_disable_env() -> None:

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -23,6 +23,24 @@ self_merge_check = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = self_merge_check
 spec.loader.exec_module(self_merge_check)
 
+# Real (unpatched) helper, captured before the autouse fixture swaps it for a Mock.
+_REAL_MERGE_PERMISSION = self_merge_check.merge_permission.__wrapped__
+
+
+@pytest.fixture(autouse=True)
+def _stub_merge_permission():
+    """Default merge_permission to True so evaluate_pr tests don't make a live
+    gh call (and aren't sensitive to the test runner's actual repo access).
+
+    merge_permission is @cache'd, so clear the cache around each test to keep
+    per-test patches (True/False/None) isolated. Tests exercising the
+    permission gate itself patch merge_permission explicitly.
+    """
+    self_merge_check.merge_permission.cache_clear()
+    with patch.object(self_merge_check, "merge_permission", return_value=True):
+        yield
+    self_merge_check.merge_permission.cache_clear()
+
 
 def test_checks_green_rejects_indeterminate_check() -> None:
     assert not self_merge_check.checks_green([{"status": None, "conclusion": None}])
@@ -689,6 +707,86 @@ def test_evaluate_pr_warns_when_workspace_repos_empty() -> None:
     assert (
         result.eligible
     ), f"Explicit opt-out should not disqualify; reasons: {result.reasons}"
+
+
+def _eligible_pr_data() -> dict:
+    return {
+        "author": {"login": "TimeToBuildBob"},
+        "title": "Test PR",
+        "url": "https://github.com/gptme/gptme-contrib/pull/999",
+        "files": [{"path": "tests/test_example.py"}],
+        "statusCheckRollup": [{"status": "COMPLETED", "conclusion": "SUCCESS"}],
+        "isDraft": False,
+        "state": "OPEN",
+        "reviewDecision": None,
+    }
+
+
+def _evaluate_otherwise_eligible(merge_perm):
+    """Evaluate an otherwise-eligible PR with a given merge_permission result."""
+    with (
+        patch.object(self_merge_check, "fetch_pr", return_value=_eligible_pr_data()),
+        patch.object(self_merge_check, "get_gh_user", return_value="TimeToBuildBob"),
+        patch.object(
+            self_merge_check, "_fetch_greptile_review_data", return_value=None
+        ),
+        patch.object(
+            self_merge_check,
+            "fetch_greptile_status",
+            return_value={"has_review": True, "unresolved": 0, "total": 1},
+        ),
+        patch.object(self_merge_check, "greptile_summary_score", return_value=5),
+        patch.object(
+            self_merge_check,
+            "fetch_unresolved_human_threads",
+            return_value={"unresolved": 0, "total": 0, "authors": []},
+        ),
+        patch.object(self_merge_check, "merge_permission", return_value=merge_perm),
+    ):
+        return self_merge_check.evaluate_pr(
+            "gptme/gptme-contrib",
+            999,
+            workspace_repos=["gptme/gptme-contrib"],
+        )
+
+
+def test_evaluate_pr_blocks_when_no_merge_permission() -> None:
+    """A definitive lack of merge permission disqualifies (would fail the merge)."""
+    result = _evaluate_otherwise_eligible(False)
+    assert not result.eligible
+    assert any("lacks merge permission" in r for r in result.reasons)
+
+
+def test_evaluate_pr_warns_when_merge_permission_unknown() -> None:
+    """An indeterminate merge permission is a warning, not a disqualifier."""
+    result = _evaluate_otherwise_eligible(None)
+    assert result.eligible, f"reasons: {result.reasons}"
+    assert any("determine merge permission" in w for w in result.warnings)
+
+
+def test_evaluate_pr_eligible_with_merge_permission() -> None:
+    """Explicit merge permission keeps an otherwise-eligible PR eligible."""
+    result = _evaluate_otherwise_eligible(True)
+    assert result.eligible, f"reasons: {result.reasons}"
+
+
+def test_merge_permission_raw_helper() -> None:
+    """The underlying helper maps gh permission payloads to a bool/None."""
+    raw = _REAL_MERGE_PERMISSION
+    with patch.object(
+        self_merge_check, "run_gh", return_value='{"push": true, "admin": false}'
+    ):
+        assert raw("gptme/gptme-contrib") is True
+    with patch.object(
+        self_merge_check,
+        "run_gh",
+        return_value='{"push": false, "maintain": false, "admin": false}',
+    ):
+        assert raw("gptme/gptme-contrib") is False
+    with patch.object(self_merge_check, "run_gh", return_value=""):
+        assert raw("gptme/gptme-contrib") is None
+    with patch.object(self_merge_check, "run_gh", return_value="not json"):
+        assert raw("gptme/gptme-contrib") is None
 
 
 def test_greptile_summary_score_ignores_signal_disable_env() -> None:


### PR DESCRIPTION
## Problem

The self-merge checker classified PRs as eligible based on the workspace-repo allowlist alone. For repos an agent contributes to via a **fork** (pull-only access), the checker reports `eligible: YES`, the agent then attempts `gh pr merge`, and it fails:

```
GraphQL: TimeToLearnAlice does not have the correct permissions to execute `MergePullRequest`
```

Observed **11 such failed merge attempts in 7 days** in Alice's monitoring loop — `gptme/gptme-contrib` and `ErikBjare/quantifiedme` are both on the trusted allowlist but Alice has `push: false` on both. Each cycle burns a wasted merge attempt and pollutes the counterfactual "would-merge" accuracy tracking.

## Fix

Add `merge_permission(repo)` — checks the authenticated user's `push`/`maintain`/`admin` on the target repo via `gh api repos/{repo}`:

- **Definitive `False`** → disqualify (the merge would fail anyway), with a clear reason pointing the agent to open a PR for a maintainer.
- **Indeterminate (`None`, gh error)** → non-blocking warning, so a transient API hiccup doesn't block a legitimate self-merge.

Agents that *do* have merge permission (e.g. Bob on his own repos) are unaffected — they stay eligible. This is the correct layer: the allowlist documents *intent* (trusted repos), the permission gate enforces *reality*. If Alice is later granted push on contrib, it just works with no config change.

## Tests

- Autouse fixture stubs `merge_permission=True` so the 7 existing `evaluate_pr` tests are env-independent (they no longer make a live `gh` call).
- New gate coverage: `False` disqualifies, `None` warns + stays eligible, `True` eligible.
- Raw-helper test for the gh permission-payload parsing (push/maintain/admin → bool, empty/garbage → None).

86 passed locally; ruff + mypy clean.