### PR TITLE
fix(runloops): lazy pm_dispatch re-export to silence runpy RuntimeWarning

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/__init__.py
+++ b/packages/gptme-runloops/src/gptme_runloops/__init__.py
@@ -1,18 +1,10 @@
 """Run loop framework for autonomous AI agent operation."""
 
+from typing import Any
+
 from gptme_runloops.autonomous import AutonomousRun
 from gptme_runloops.base import BaseRunLoop
 from gptme_runloops.email import EmailRun
-from gptme_runloops.pm_dispatch import (
-    DispatchLedger,
-    LaneDispatcher,
-    LedgerEntry,
-    SlotItem,
-    SlotManager,
-    classify_lane,
-    derive_slot_key,
-    partition_items,
-)
 from gptme_runloops.project_monitoring import ProjectMonitoringRun
 from gptme_runloops.team import TeamRun
 from gptme_runloops.utils.executor import (
@@ -22,6 +14,40 @@ from gptme_runloops.utils.executor import (
     get_executor,
     list_backends,
 )
+
+# pm_dispatch symbols are re-exported lazily (PEP 562) instead of eagerly. An
+# eager `from gptme_runloops.pm_dispatch import ...` here imports the submodule
+# during the parent package import, so running `python -m
+# gptme_runloops.pm_dispatch` finds it already in sys.modules before runpy
+# executes it as __main__ — emitting a RuntimeWarning on every invocation
+# (the project-monitoring loop runs `-m gptme_runloops.pm_dispatch` ~6x/run).
+# Lazy access keeps `from gptme_runloops import DispatchLedger` working while
+# avoiding the import at package-load time.
+_PM_DISPATCH_EXPORTS = frozenset(
+    {
+        "DispatchLedger",
+        "LaneDispatcher",
+        "LedgerEntry",
+        "SlotItem",
+        "SlotManager",
+        "classify_lane",
+        "derive_slot_key",
+        "partition_items",
+    }
+)
+
+
+def __getattr__(name: str) -> Any:
+    if name in _PM_DISPATCH_EXPORTS:
+        from gptme_runloops import pm_dispatch
+
+        return getattr(pm_dispatch, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)
+
 
 __all__ = [
     "BaseRunLoop",

--- a/packages/gptme-runloops/src/gptme_runloops/__init__.py
+++ b/packages/gptme-runloops/src/gptme_runloops/__init__.py
@@ -70,3 +70,7 @@ __all__ = [
     "derive_slot_key",
     "partition_items",
 ]
+
+assert (
+    _PM_DISPATCH_EXPORTS <= frozenset(__all__)
+), f"_PM_DISPATCH_EXPORTS has names not in __all__: {_PM_DISPATCH_EXPORTS - frozenset(__all__)}"

--- a/packages/gptme-runloops/tests/test_package_imports.py
+++ b/packages/gptme-runloops/tests/test_package_imports.py
@@ -1,0 +1,62 @@
+"""Regression tests for the package's public import surface.
+
+Covers the PEP 562 lazy re-export of ``pm_dispatch`` symbols and the runpy
+RuntimeWarning that the previous eager re-export emitted on every
+``python -m gptme_runloops.pm_dispatch`` invocation.
+"""
+
+import importlib
+import subprocess
+import sys
+
+import gptme_runloops
+
+
+def test_all_names_are_importable():
+    """Every name in __all__ resolves (eager imports + lazy pm_dispatch re-exports)."""
+    for name in gptme_runloops.__all__:
+        assert hasattr(gptme_runloops, name), f"{name} not accessible on package"
+
+
+def test_lazy_pm_dispatch_reexports():
+    """pm_dispatch symbols are re-exported and identical to the submodule's."""
+    pm = importlib.import_module("gptme_runloops.pm_dispatch")
+    for name in (
+        "DispatchLedger",
+        "LaneDispatcher",
+        "derive_slot_key",
+        "partition_items",
+    ):
+        assert getattr(gptme_runloops, name) is getattr(pm, name)
+
+
+def test_unknown_attribute_raises_attributeerror():
+    try:
+        gptme_runloops.does_not_exist  # noqa: B018
+    except AttributeError:
+        pass
+    else:  # pragma: no cover
+        raise AssertionError("expected AttributeError for unknown attribute")
+
+
+def test_run_as_module_emits_no_runpy_warning():
+    """`python -m gptme_runloops.pm_dispatch` must not emit the runpy RuntimeWarning.
+
+    The eager re-export pre-registered pm_dispatch in sys.modules during the
+    parent package import, so runpy warned "found in sys.modules ... prior to
+    execution" before running it as __main__.
+    """
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-W",
+            "error::RuntimeWarning",
+            "-m",
+            "gptme_runloops.pm_dispatch",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    combined = proc.stdout + proc.stderr
+    assert "RuntimeWarning" not in combined, combined
+    assert "found in sys.modules" not in combined, combined

--- a/packages/gptme-runloops/tests/test_package_imports.py
+++ b/packages/gptme-runloops/tests/test_package_imports.py
@@ -58,5 +58,6 @@ def test_run_as_module_emits_no_runpy_warning():
         text=True,
     )
     combined = proc.stdout + proc.stderr
+    assert proc.returncode in (0, 1), proc.stderr
     assert "RuntimeWarning" not in combined, combined
     assert "found in sys.modules" not in combined, combined


### PR DESCRIPTION
## Problem

`python -m gptme_runloops.pm_dispatch` — run ~6× per cycle by the project-monitoring loop (`scripts/github/project-monitoring-lib.sh`) — emits a RuntimeWarning on **every** invocation:

```
<frozen runpy>:128: RuntimeWarning: 'gptme_runloops.pm_dispatch' found in sys.modules after import of package 'gptme_runloops', but prior to execution of 'gptme_runloops.pm_dispatch'; this may result in unpredictable behaviour
```

That's ~4000+ lines/day of log noise across PM runs.

## Cause

The package `__init__.py` eagerly did `from gptme_runloops.pm_dispatch import (...)`. Running the module with `-m` first imports the parent package (executing `__init__`), which registers `pm_dispatch` in `sys.modules` **before** runpy executes it as `__main__` → the warning.

## Fix

Re-export the `pm_dispatch` symbols lazily via PEP 562 `__getattr__` instead of eagerly. The submodule is no longer imported at package-load time, so `-m` runs clean. Public API is unchanged — `from gptme_runloops import DispatchLedger` (etc.) still works. Verified no other eagerly-imported package module transitively imports `pm_dispatch`.

## Verification

- Adds `tests/test_package_imports.py`: asserts every `__all__` name resolves, lazy re-exports are identical to the submodule's, unknown attrs raise `AttributeError`, and `-m gptme_runloops.pm_dispatch` runs warning-free (under `-W error::RuntimeWarning`).
- `test_package_imports.py`: 4 passed. `test_pm_dispatch.py`: 95 passed (no regression).
- Direct repro: warning count 6 → 0.