### PR TITLE
fix(self-merge): scope spec-like-doc gate to repo root only

### DIFF
--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -769,7 +769,14 @@ def is_doc_file(path: str) -> bool:
 
 
 def is_spec_like_doc(path: str) -> bool:
-    return Path(path).name in SPEC_LIKE_DOCS
+    """Spec-like identity docs (README/ARCHITECTURE/CLAUDE/…) require human review.
+
+    Only matches at the REPOSITORY ROOT. These filenames denote a project's
+    top-level identity/spec docs; a *nested* package README (e.g.
+    ``packages/foo/README.md``) is ordinary package documentation, not a spec,
+    and shouldn't block self-merge of an otherwise low-risk tooling PR.
+    """
+    return "/" not in path.replace("\\", "/") and Path(path).name in SPEC_LIKE_DOCS
 
 
 def is_test_file(path: str) -> bool:

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -776,7 +776,8 @@ def is_spec_like_doc(path: str) -> bool:
     ``packages/foo/README.md``) is ordinary package documentation, not a spec,
     and shouldn't block self-merge of an otherwise low-risk tooling PR.
     """
-    return "/" not in path.replace("\\", "/") and Path(path).name in SPEC_LIKE_DOCS
+    normalized = path.replace("\\", "/").removeprefix("./")
+    return "/" not in normalized and Path(path).name in SPEC_LIKE_DOCS
 
 
 def is_test_file(path: str) -> bool:

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -1252,3 +1252,37 @@ def test_check_result_head_sha_in_json_output() -> None:
     d = dataclasses.asdict(result)
     assert d["head_sha"] == "deadbeef1234"
     assert "head_sha" in json.dumps(d)
+
+
+# --- spec-like docs are root-only (nested package READMEs are ordinary docs) ---
+def test_root_identity_docs_are_spec_like() -> None:
+    for name in ("README.md", "ARCHITECTURE.md", "CLAUDE.md", "AGENTS.md", "GOALS.md"):
+        assert self_merge_check.is_spec_like_doc(name) is True
+
+
+def test_nested_package_readme_is_not_spec_like() -> None:
+    # A nested package README is package docs, not a top-level spec.
+    assert self_merge_check.is_spec_like_doc("packages/gptme-usage/README.md") is False
+    assert self_merge_check.is_spec_like_doc("gptme/server/README.md") is False
+    assert self_merge_check.is_spec_like_doc("docs/ARCHITECTURE.md") is False
+
+
+def test_nested_readme_does_not_disqualify_low_risk_pr() -> None:
+    # Regression: a clean tooling PR touching a nested package README + code +
+    # tests must classify into an allowed category, not be blocked as spec-like.
+    paths = [
+        "packages/gptme-usage/README.md",
+        "packages/gptme-usage/harness-quota.example.toml",
+        "packages/gptme-usage/src/gptme_usage/harness_models.py",
+        "packages/gptme-usage/tests/test_harness_quota_config.py",
+        "scripts/check-quota.py",
+    ]
+    category, reasons = self_merge_check.classify_category(paths, "gptme/gptme-contrib")
+    assert category is not None, reasons
+    assert reasons == []
+
+
+def test_root_readme_still_blocks_self_merge() -> None:
+    category, reasons = self_merge_check.classify_category(["README.md"], "gptme/gptme")
+    assert category is None
+    assert any("spec-like" in r for r in reasons)

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -1286,3 +1286,9 @@ def test_root_readme_still_blocks_self_merge() -> None:
     category, reasons = self_merge_check.classify_category(["README.md"], "gptme/gptme")
     assert category is None
     assert any("spec-like" in r for r in reasons)
+
+
+def test_dot_slash_prefixed_root_readme_is_spec_like() -> None:
+    # GitHub API never produces ./-prefixed paths, but harden against it anyway.
+    assert self_merge_check.is_spec_like_doc("./README.md") is True
+    assert self_merge_check.is_spec_like_doc("./ARCHITECTURE.md") is True


### PR DESCRIPTION
## Why
The recurring reason clean, Greptile-5/5, green-CI PRs still need a manual merge: `is_spec_like_doc()` treats **any** `README.md` (and ARCHITECTURE/CLAUDE/AGENTS/GOALS/…) as a spec-like identity doc requiring human review — including **nested package READMEs** like `packages/gptme-usage/README.md`. A nested package README is ordinary package documentation, not a project spec.

## What
`is_spec_like_doc()` now matches those filenames **only at the repository root**, where they actually denote a project's identity/spec. Nested READMEs classify as docs / internal-tooling and no longer block self-merge of an otherwise low-risk PR.

## Evidence
gptme-contrib#1102 (config-driven quota — README + example.toml + harness_models.py + tests + check-quota.py) goes from:
```
category: (None, ['Touches spec-like documentation requiring human review'])
```
to:
```
category: ('internal-tooling', [])
```
Root identity files stay gated (`README.md`, `ARCHITECTURE.md`, `CLAUDE.md` → still spec-like).

## Tests
4 new tests (root-only matching + the #1102 regression + root-README still blocks); 90 pass, ruff clean.

## Note
This widens the self-merge surface (a **policy** change), so flagging for human review rather than self-merging — a PR that loosens the self-merge gate shouldn't merge itself. cc @ErikBjare