### PR TITLE
feat(gptme-usage): add merge_with_module_defaults helper

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -54,6 +54,12 @@ ignore_missing_imports = True
 [mypy-gptme_subscription.*]
 ignore_missing_imports = True
 
+[mypy-gptme_usage]
+ignore_missing_imports = True
+
+[mypy-gptme_usage.*]
+ignore_missing_imports = True
+
 [mypy-discord.*]
 ignore_missing_imports = True
 

--- a/packages/gptme-usage/src/gptme_usage/__init__.py
+++ b/packages/gptme-usage/src/gptme_usage/__init__.py
@@ -22,6 +22,7 @@ Primary API::
 
 from __future__ import annotations
 
+from gptme_usage.config import merge_with_module_defaults
 from gptme_usage.harness_models import (
     HarnessQuotaConfig,
     estimate_session_cost,
@@ -35,6 +36,7 @@ __all__ = [
     "load_quota_config",
     "estimate_session_cost",
     "estimate_tokens_from_duration",
+    "merge_with_module_defaults",
     "pricing_key_for_model",
 ]
 

--- a/packages/gptme-usage/src/gptme_usage/config.py
+++ b/packages/gptme-usage/src/gptme_usage/config.py
@@ -1,0 +1,60 @@
+"""Config merging utilities for HarnessQuotaConfig.
+
+Provides helpers to merge a caller-supplied partial config with module-level
+defaults, so agents that supply a subset of models still see defaults for
+anything not in their config.
+"""
+
+from __future__ import annotations
+
+from gptme_usage.harness_models import (
+    GPTME_MODEL_ROUTES,
+    GPTME_QUOTA_SOURCE,
+    HARNESS_PRICE_USD_PER_1M,
+    TOKENS_PER_SECOND,
+    HarnessQuotaConfig,
+)
+
+
+def merge_with_module_defaults(config: HarnessQuotaConfig) -> HarnessQuotaConfig:
+    """Merge a caller-supplied config with module-level defaults.
+
+    Returns a new ``HarnessQuotaConfig`` where entries from *config* take
+    priority, but any model/route/source present in the module-level defaults
+    (``HARNESS_PRICE_USD_PER_1M``, ``TOKENS_PER_SECOND``,
+    ``GPTME_QUOTA_SOURCE``, ``GPTME_MODEL_ROUTES``) that is *not* in the
+    caller's config is also included.
+
+    This gives callers with a **partial** config access to module defaults
+    for unlisted models, while still letting a fully-specified config
+    override anything.
+
+    For ``openrouter_key_contexts`` and ``claude_plan_tier`` (which have no
+    module-level defaults) the caller's values are used as-is.
+
+    **Replace semantics**: if you need *strict* replace (agent isolation,
+    no fallback to module defaults), pass the original config directly to
+    helpers instead of the merged result. This helper is opt-in — it never
+    changes the default behavior.
+    """
+    # Start with the module defaults.
+    merged_price = dict(HARNESS_PRICE_USD_PER_1M)
+    merged_tps = dict(TOKENS_PER_SECOND)
+    merged_quota = dict(GPTME_QUOTA_SOURCE)
+    merged_routes = dict(GPTME_MODEL_ROUTES)
+    merged_key_ctxs = dict(config.openrouter_key_contexts)
+
+    # Overlay with the caller's config — caller entries take priority.
+    merged_price.update(config.price_table)
+    merged_tps.update(config.tps_table)
+    merged_quota.update(config.quota_sources)
+    merged_routes.update(config.model_routes)
+
+    return HarnessQuotaConfig(
+        price_table=merged_price,
+        tps_table=merged_tps,
+        quota_sources=merged_quota,
+        model_routes=merged_routes,
+        openrouter_key_contexts=merged_key_ctxs,
+        claude_plan_tier=config.claude_plan_tier,
+    )

--- a/packages/gptme-usage/tests/test_harness_quota_config.py
+++ b/packages/gptme-usage/tests/test_harness_quota_config.py
@@ -102,7 +102,6 @@ def test_module_ships_no_agent_data() -> None:
     from gptme_usage.harness_models import (
         GPTME_MODEL_ROUTES,
         GPTME_QUOTA_SOURCE,
-        HARNESS_PRICE_USD_PER_1M,
         TOKENS_PER_SECOND,
     )
 
@@ -257,27 +256,51 @@ def test_config_aware_model_source_helpers() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_merge_with_module_defaults_caller_wins() -> None:
+def test_merge_with_module_defaults_caller_wins(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Caller-supplied entries take priority over module defaults."""
-    custom_price: dict[tuple[str, str], tuple[float, float]] = {
-        ("claude-code", "opus"): (99.0, 99.0),
+    import gptme_usage.config as config_mod
+
+    # Inject non-empty module defaults so the test is non-vacuous.
+    fake_defaults: dict[tuple[str, str], tuple[float, float]] = {
+        ("claude-code", "opus"): (3.0, 15.0),  # will be overridden by caller
+        ("gptme", "base-model"): (1.0, 5.0),  # unlisted in caller's config
     }
-    cfg = HarnessQuotaConfig(price_table=custom_price)
+    monkeypatch.setattr(config_mod, "HARNESS_PRICE_USD_PER_1M", fake_defaults)
+
+    caller_price: dict[tuple[str, str], tuple[float, float]] = {
+        ("claude-code", "opus"): (99.0, 99.0),  # overrides the module default
+    }
+    cfg = HarnessQuotaConfig(price_table=caller_price)
     merged = merge_with_module_defaults(cfg)
 
-    # Caller's override must survive.
+    # Caller's entry must win over the module default.
     assert merged.price_table[("claude-code", "opus")] == (99.0, 99.0)
-    # Module defaults for other models must also be present.
-    assert len(merged.price_table) >= len(HARNESS_PRICE_USD_PER_1M)
+    # Unlisted model from module defaults must also appear.
+    assert merged.price_table[("gptme", "base-model")] == (1.0, 5.0)
+    # Combined table contains both the caller's entry and the module default.
+    assert len(merged.price_table) == len(fake_defaults)
 
 
-def test_merge_with_module_defaults_fallback_for_unlisted() -> None:
+def test_merge_with_module_defaults_fallback_for_unlisted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Module defaults appear for models NOT in the caller's config."""
-    cfg = HarnessQuotaConfig()  # empty custom config
+    import gptme_usage.config as config_mod
+
+    # Inject non-empty module defaults so the for-loop actually executes.
+    fake_defaults: dict[tuple[str, str], tuple[float, float]] = {
+        ("gptme", "base-model"): (1.0, 5.0),
+        ("claude-code", "sonnet"): (3.0, 15.0),
+    }
+    monkeypatch.setattr(config_mod, "HARNESS_PRICE_USD_PER_1M", fake_defaults)
+
+    cfg = HarnessQuotaConfig()  # caller has no custom prices
     merged = merge_with_module_defaults(cfg)
 
-    # The merged table should contain everything from the module defaults.
-    for key, val in HARNESS_PRICE_USD_PER_1M.items():
+    # All module defaults must appear in the merged result.
+    for key, val in fake_defaults.items():
         assert merged.price_table[key] == val, f"missing/wrong default for {key}"
 
 

--- a/packages/gptme-usage/tests/test_harness_quota_config.py
+++ b/packages/gptme-usage/tests/test_harness_quota_config.py
@@ -1,11 +1,13 @@
-"""Tests for HarnessQuotaConfig and load_quota_config."""
+"""Tests for HarnessQuotaConfig, load_quota_config, and merge_with_module_defaults."""
 
 from __future__ import annotations
 
 from pathlib import Path
 
 import pytest
+from gptme_usage.config import merge_with_module_defaults
 from gptme_usage.harness_models import (
+    HARNESS_PRICE_USD_PER_1M,
     HarnessQuotaConfig,
     estimate_session_cost,
     estimate_tokens_from_duration,
@@ -248,3 +250,55 @@ def test_config_aware_model_source_helpers() -> None:
     # No config -> legacy deepseek heuristic still applies.
     assert gptme_openrouter_context("deepseek-v4-pro") == "autonomous_deepseek"
     assert gptme_openrouter_context("kimi-k2.6") == "autonomous"
+
+
+# ---------------------------------------------------------------------------
+# merge_with_module_defaults
+# ---------------------------------------------------------------------------
+
+
+def test_merge_with_module_defaults_caller_wins() -> None:
+    """Caller-supplied entries take priority over module defaults."""
+    custom_price: dict[tuple[str, str], tuple[float, float]] = {
+        ("claude-code", "opus"): (99.0, 99.0),
+    }
+    cfg = HarnessQuotaConfig(price_table=custom_price)
+    merged = merge_with_module_defaults(cfg)
+
+    # Caller's override must survive.
+    assert merged.price_table[("claude-code", "opus")] == (99.0, 99.0)
+    # Module defaults for other models must also be present.
+    assert len(merged.price_table) >= len(HARNESS_PRICE_USD_PER_1M)
+
+
+def test_merge_with_module_defaults_fallback_for_unlisted() -> None:
+    """Module defaults appear for models NOT in the caller's config."""
+    cfg = HarnessQuotaConfig()  # empty custom config
+    merged = merge_with_module_defaults(cfg)
+
+    # The merged table should contain everything from the module defaults.
+    for key, val in HARNESS_PRICE_USD_PER_1M.items():
+        assert merged.price_table[key] == val, f"missing/wrong default for {key}"
+
+
+def test_merge_with_module_defaults_preserves_caller_metadata() -> None:
+    """Non-table fields (openrouter_key_contexts, claude_plan_tier) pass through."""
+    cfg = HarnessQuotaConfig(
+        openrouter_key_contexts={"default": "my-ctx", "special": "other-ctx"},
+        claude_plan_tier="max-5x",
+    )
+    merged = merge_with_module_defaults(cfg)
+
+    assert merged.claude_plan_tier == "max-5x"
+    assert merged.openrouter_key_contexts == {
+        "default": "my-ctx",
+        "special": "other-ctx",
+    }
+
+
+def test_merge_with_module_defaults_does_not_mutate_input() -> None:
+    """merge_with_module_defaults returns a new object; it must not mutate *config*."""
+    cfg = HarnessQuotaConfig()
+    original_len = len(cfg.price_table)
+    merge_with_module_defaults(cfg)
+    assert len(cfg.price_table) == original_len, "input config was mutated"


### PR DESCRIPTION
## Summary

- Adds `gptme_usage/config.py` with a `merge_with_module_defaults()` helper function
- Updates `__init__.py` to export it from the package top-level
- Adds 4 tests covering caller-wins priority, fallback for unlisted models, metadata passthrough, and no-mutate guarantee

## What it does

Agents with a **partial** `HarnessQuotaConfig` (only their own models listed in `harness-quota.toml`) can call `merge_with_module_defaults()` to get module defaults for any model not in their config, while keeping their own entries as overrides. This is opt-in — the default behavior of config-driven pricing remains unchanged.

The function was originally orphaned in the `gptme-contrib` submodule working tree after session 9c8e; recovered from backup and shipped here.

## Test plan

- [x] 4 new tests in `test_harness_quota_config.py` — all 19 tests pass locally
- [x] mypy clean
- [x] ruff clean (auto-format applied by pre-commit)