### PR TITLE
fix(gptmail agent): report delivery failures + guard self-send

### DIFF
--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -435,8 +435,15 @@ def reply(message_id: str, content: str | None) -> None:
     agents = _load_agents()
     transport = _transport(deliver=_ssh_deliver(agents))
     reply_id = transport.send(recipient, subject, body, reply_to=message_id)
-    _mark_replied(messages_dir, message_id)
     _track_sent(transport, reply_id, reply_to=message_id)
+    if _delivery_failed(reply_id):
+        click.echo(
+            f"Delivery to {recipient} FAILED — saved to outbox (delivered: false). "
+            "It was NOT received.",
+            err=True,
+        )
+        sys.exit(1)
+    _mark_replied(messages_dir, message_id)
     click.echo(f"Replied to {recipient}: {subject}")
 
 

--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -185,6 +185,24 @@ def _transport(deliver: Deliver | None = None) -> AgentTransport:
     return AgentTransport(_messages_dir(), _self_name(), deliver=deliver)
 
 
+def _delivery_failed(message_id: str) -> bool:
+    """True if the just-sent outbox message was stamped ``delivered: false``.
+
+    The transport stamps that field only when the deliver hook reports failure;
+    a successful send leaves it absent. Lets the CLI report real failures (and
+    exit non-zero) instead of always printing "Sent".
+    """
+    path = _messages_dir() / "outbox" / message_id
+    try:
+        content = path.read_text()
+    except OSError:
+        return False
+    if not content.startswith("---"):
+        return False
+    parts = content.split("---", 2)
+    return len(parts) >= 3 and "delivered: false" in parts[1]
+
+
 def _track_sent(transport: AgentTransport, message_id: str, reply_to: str | None) -> None:
     """Stamp a sent message into the shared tracker (channel='agent')."""
     tracker = _tracker()
@@ -300,12 +318,22 @@ def send(to: str, subject: str, content: str | None) -> None:
     """Send a message to another agent."""
     body = content if content is not None else sys.stdin.read()
     agents = _load_agents()
+    if to.lower() == _self_name():
+        click.echo("Error: cannot send a message to yourself.", err=True)
+        sys.exit(1)
     if to.lower() not in agents:
         click.echo(f"Error: unknown agent '{to}'. Known: {', '.join(agents)}", err=True)
         sys.exit(1)
     transport = _transport(deliver=_ssh_deliver(agents))
     message_id = transport.send(to, subject, body)
     _track_sent(transport, message_id, reply_to=None)
+    if _delivery_failed(message_id):
+        click.echo(
+            f"Delivery to {to.lower()} FAILED — saved to outbox (delivered: false). "
+            "It was NOT received.",
+            err=True,
+        )
+        sys.exit(1)
     click.echo(f"Sent to {to.lower()}: {subject}")
 
 
@@ -321,10 +349,18 @@ def broadcast(subject: str, content: str | None) -> None:
     if not recipients:
         click.echo("No other agents in registry.", err=True)
         return
+    failures = []
     for name in recipients:
         message_id = transport.send(name, subject, body)
         _track_sent(transport, message_id, reply_to=None)
-        click.echo(f"Sent to {name}: {subject}")
+        if _delivery_failed(message_id):
+            click.echo(f"Delivery to {name} FAILED (delivered: false).", err=True)
+            failures.append(name)
+        else:
+            click.echo(f"Sent to {name}: {subject}")
+    if failures:
+        click.echo(f"Broadcast incomplete: {len(failures)} delivery failure(s).", err=True)
+        sys.exit(1)
 
 
 @agent.command(name="list")

--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -435,7 +435,6 @@ def reply(message_id: str, content: str | None) -> None:
     agents = _load_agents()
     transport = _transport(deliver=_ssh_deliver(agents))
     reply_id = transport.send(recipient, subject, body, reply_to=message_id)
-    _track_sent(transport, reply_id, reply_to=message_id)
     if _delivery_failed(reply_id):
         click.echo(
             f"Delivery to {recipient} FAILED — saved to outbox (delivered: false). "
@@ -443,6 +442,7 @@ def reply(message_id: str, content: str | None) -> None:
             err=True,
         )
         sys.exit(1)
+    _track_sent(transport, reply_id, reply_to=message_id)
     _mark_replied(messages_dir, message_id)
     click.echo(f"Replied to {recipient}: {subject}")
 

--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -200,7 +200,9 @@ def _delivery_failed(message_id: str) -> bool:
     if not content.startswith("---"):
         return False
     parts = content.split("---", 2)
-    return len(parts) >= 3 and "delivered: false" in parts[1]
+    return len(parts) >= 3 and any(
+        line.strip() == "delivered: false" for line in parts[1].splitlines()
+    )
 
 
 def _track_sent(transport: AgentTransport, message_id: str, reply_to: str | None) -> None:

--- a/packages/gptmail/tests/test_agent_cli.py
+++ b/packages/gptmail/tests/test_agent_cli.py
@@ -140,6 +140,12 @@ def test_reply_reports_delivery_failure_and_keeps_pending(
     # The original inbox message must NOT be marked replied — it stays in pending.
     fm = _frontmatter(workspace / "messages" / "inbox" / name)
     assert not fm.get("replied"), "inbox message must stay unreplied on delivery failure"
+    # The ConversationTracker must NOT mark the original as COMPLETED — delivery never happened.
+    tracker = ConversationTracker(workspace / "messages" / ".tracking")
+    state = tracker.get_message_state("agent:alice|bob", name)
+    assert (
+        state is None or state.state != MessageState.COMPLETED
+    ), "tracker must not mark original as COMPLETED when delivery failed"
 
 
 @pytest.mark.parametrize(

--- a/packages/gptmail/tests/test_agent_cli.py
+++ b/packages/gptmail/tests/test_agent_cli.py
@@ -82,6 +82,40 @@ def test_send_unknown_agent_errors(workspace: Path) -> None:
     assert "unknown agent" in result.output.lower()
 
 
+def test_send_to_self_blocked(workspace: Path) -> None:
+    """Self-send is rejected (regression: agent-msg.py had this guard, port lost it)."""
+    result = CliRunner().invoke(agent, ["send", "alice", "Hi", "x"])
+    assert result.exit_code == 1
+    assert "yourself" in result.output.lower()
+    # Nothing written to the outbox.
+    assert not list((workspace / "messages" / "outbox").glob("*.md"))
+
+
+def test_send_reports_delivery_failure_and_exits_nonzero(
+    workspace: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed delivery must NOT print 'Sent' and must exit non-zero.
+
+    Core-infra reliability: the transport stamps ``delivered: false`` on a failed
+    deliver hook; the CLI must surface that rather than reporting false success.
+    """
+
+    def _failing_deliver(_agents):
+        def _deliver(_local_path: Path, _recipient: str) -> bool:
+            return False
+
+        return _deliver
+
+    monkeypatch.setattr(agent_cli, "_ssh_deliver", _failing_deliver)
+    result = CliRunner().invoke(agent, ["send", "bob", "Hello", "body"])
+    assert result.exit_code == 1, result.output
+    assert "Sent to bob" not in result.output
+    assert "failed" in result.output.lower()
+    # The message is still saved to the outbox, stamped delivered: false.
+    out = _only_outbox_msg(workspace)
+    assert _frontmatter(out)["delivered"] is False
+
+
 @pytest.mark.parametrize(
     "entry",
     [

--- a/packages/gptmail/tests/test_agent_cli.py
+++ b/packages/gptmail/tests/test_agent_cli.py
@@ -116,6 +116,32 @@ def test_send_reports_delivery_failure_and_exits_nonzero(
     assert _frontmatter(out)["delivered"] is False
 
 
+def test_reply_reports_delivery_failure_and_keeps_pending(
+    workspace: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed reply delivery must NOT mark the original as replied and must exit non-zero.
+
+    Mirror of test_send_reports_delivery_failure_and_exits_nonzero for the reply command.
+    The inbox message must stay in ``pending`` so the sender still has a reminder to follow up.
+    """
+
+    def _failing_deliver(_agents):
+        def _deliver(_local_path: Path, _recipient: str) -> bool:
+            return False
+
+        return _deliver
+
+    name = _seed_inbox(workspace)
+    monkeypatch.setattr(agent_cli, "_ssh_deliver", _failing_deliver)
+    result = CliRunner().invoke(agent, ["reply", name, "here is my advice"])
+    assert result.exit_code == 1, result.output
+    assert "Replied to bob" not in result.output
+    assert "failed" in result.output.lower()
+    # The original inbox message must NOT be marked replied — it stays in pending.
+    fm = _frontmatter(workspace / "messages" / "inbox" / name)
+    assert not fm.get("replied"), "inbox message must stay unreplied on delivery failure"
+
+
 @pytest.mark.parametrize(
     "entry",
     [


### PR DESCRIPTION
## Why
Found via the comms-channel acceptance test (core inter-agent comms was just consolidated into gptmail, #1097/#1105). Two robustness gaps at the **CLI layer** — the transport itself is sound (it stamps `delivered: false` when the deliver hook fails); the CLI just didn't act on it.

## Bugs
1. **No self-send guard.** `gptmail agent send <self>` wasn't blocked. agent-msg.py had `if recipient == self_name: error`; the port dropped it. → now errors + exits 1.
2. **False success on delivery failure** (the serious one for a comms channel). `send`/`broadcast` printed `Sent to X` and exited 0 **even when SSH/SCP delivery failed** — a send to an unreachable agent looked successful. Repro: `agent send <unreachable>` → "Error delivering… 255" **then** "Sent to …" + exit 0. → CLI now checks the `delivered: false` stamp, warns on stderr, and exits non-zero (broadcast exits 1 if any recipient failed).

## Changes
- `agent_cli.py`: `_delivery_failed(message_id)` helper; self-send guard + delivery check in `send`; per-recipient delivery check + failure exit in `broadcast`. No transport/Protocol change.
- Tests: self-send blocked (nothing written to outbox); delivery-failure reported + non-zero exit + outbox stamped `delivered: false`.

## Test
`pytest packages/gptmail/tests/test_agent_cli.py` → 19 passed. Pre-commit clean.