### PR TITLE
fix(gptmail agent): exclude peer replies to my messages from pending

### DIFF
--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -235,11 +235,13 @@ def _pending_messages(messages_dir: Path, self_name: str, window: int) -> list[d
     now = datetime.now(timezone.utc)
 
     replied_to: set[str] = set()
+    my_outbox_ids: set[str] = set()
     if outbox.exists():
         for f in outbox.glob("*.md"):
             m = meta_of(f)
             if m and m.get("in_reply_to") and m.get("delivered") is not False:
                 replied_to.add(str(m["in_reply_to"]))
+            my_outbox_ids.add(f.name)
 
     pending: list[dict] = []
     if not inbox.exists():
@@ -255,6 +257,8 @@ def _pending_messages(messages_dir: Path, self_name: str, window: int) -> list[d
         if m.get("replied"):
             continue
         if f.name in replied_to:
+            continue
+        if m.get("in_reply_to") in my_outbox_ids:
             continue
         if window > 0:
             age = _age_days(m, now)

--- a/packages/gptmail/tests/test_agent_cli.py
+++ b/packages/gptmail/tests/test_agent_cli.py
@@ -226,6 +226,31 @@ def test_pending_respects_reply_window(workspace: Path, monkeypatch: pytest.Monk
     assert "No messages awaiting reply" in result.output
 
 
+def test_pending_excludes_replies_to_my_messages(workspace: Path) -> None:
+    """Replies to my own sent messages must not appear in pending.
+
+    If bob replies to something I sent (in_reply_to points at my outbox ID), that
+    message is bob answering me — not a new request requiring my reply. Without this
+    filter, every ack or response from a peer inflates the pending count.
+    """
+    # Alice sends first, producing an outbox message.
+    CliRunner().invoke(agent, ["send", "bob", "Question", "what do you think?"])
+    outbox_files = list((workspace / "messages" / "outbox").glob("*.md"))
+    assert len(outbox_files) == 1
+    my_msg_id = outbox_files[0].name
+
+    # Bob replies — inbox message whose in_reply_to points at alice's outbox message.
+    inbox = workspace / "messages" / "inbox"
+    reply_name = "20260613-120000-000000-bob-Re-Question.md"
+    (inbox / reply_name).write_text(
+        f"---\nfrom: bob\nto: alice\ntimestamp: 2026-06-13T12:00:00Z\n"
+        f"subject: Re: Question\nread: false\nin_reply_to: {my_msg_id}\n---\n\nbob's answer\n"
+    )
+
+    result = CliRunner().invoke(agent, ["pending"])
+    assert "No messages awaiting reply" in result.output, result.output
+
+
 def test_reply_does_not_corrupt_subject_containing_read_false(workspace: Path) -> None:
     # Regression: _mark_replied must anchor its frontmatter rewrite. A subject
     # containing the literal "read: false" must survive replying intact.

--- a/packages/gptmail/tests/test_agent_cli.py
+++ b/packages/gptmail/tests/test_agent_cli.py
@@ -241,9 +241,10 @@ def test_pending_excludes_replies_to_my_messages(workspace: Path) -> None:
 
     # Bob replies — inbox message whose in_reply_to points at alice's outbox message.
     inbox = workspace / "messages" / "inbox"
+    now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     reply_name = "20260613-120000-000000-bob-Re-Question.md"
     (inbox / reply_name).write_text(
-        f"---\nfrom: bob\nto: alice\ntimestamp: 2026-06-13T12:00:00Z\n"
+        f"---\nfrom: bob\nto: alice\ntimestamp: {now_iso}\n"
         f"subject: Re: Question\nread: false\nin_reply_to: {my_msg_id}\n---\n\nbob's answer\n"
     )
 


### PR DESCRIPTION
## Summary

The `pending` command was overcounting: if bob replies to something I sent (`in_reply_to` points at my outbox message ID), that inbox message is bob answering me — not a new request requiring my reply. Without this filter, every ack or reply from a peer adds a false pending obligation that never clears.

**Fix**: In `_pending_messages`, collect all outbox message IDs alongside the existing `replied_to` set. Skip any inbox message whose `in_reply_to` is in `my_outbox_ids`.

**Test**: `test_pending_excludes_replies_to_my_messages` — seeds an outbox message, drops a reply in the inbox referencing it, asserts `pending` reports no messages awaiting reply.

## Related

- Companion fix to #1109 (delivery-failure hardening)
- Design confirmed by Bob: "filter from `pending` any message where `in_reply_to` is in my outbox IDs — stops the ack-ping-pong at one hop"