### PR TITLE
fix(greptile-helper): SHA-based re-review staleness (not date heuristic)

### DIFF
--- a/scripts/github/greptile-helper.sh
+++ b/scripts/github/greptile-helper.sh
@@ -127,20 +127,44 @@ _has_greptile_review() {
 
 # --- Helper: check if re-review is needed (new commits since latest review) ---
 # Returns 0 = re-review needed, 1 = no re-review needed
+#
+# PRIMARY (robust): compare the commit Greptile actually reviewed (the latest
+# greptile PR-review's commit_id) against the current PR head SHA. This is immune
+# to the timestamp/timezone and in-place comment-update quirks the date heuristic
+# below missed — e.g. ErikBjare/bob#890 (2026-06-14): a fix commit landed after
+# the review but the date compare skipped the re-trigger, leaving a hardened PR
+# stuck on a stale low score. A SHA mismatch is unambiguous and loop-safe: once
+# Greptile reviews the head, reviewed_sha == head_sha → it stops re-triggering.
+#
+# FALLBACK (date-based): when Greptile posted only an issue comment and no PR
+# review object carries a commit_id, fall back to the original committer.date
+# heuristic so behaviour is unchanged for that case.
 _needs_re_review() {
-    local info reviewed_at new_commits
+    local reviewed_sha head_sha info reviewed_at new_commits
+    reviewed_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate 2>/dev/null \
+        | jq -rs '[.[][]
+              | select((.user.login // "") | test("greptile"; "i"))
+              | select((.commit_id // "") != "")]
+            | sort_by(.submitted_at) | last | (.commit_id // "")' 2>/dev/null) || reviewed_sha=""
+
+    if [ -n "$reviewed_sha" ]; then
+        head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha // ""' 2>/dev/null) || head_sha=""
+        if [ -n "$head_sha" ]; then
+            # Re-review needed iff Greptile's last review was on a different commit.
+            [ "$reviewed_sha" != "$head_sha" ]
+            return
+        fi
+    fi
+
+    # Fallback: no PR-review commit_id available → use the date heuristic.
     info=$(_greptile_review_info) || return 1
     reviewed_at=$(echo "$info" | _json_field "reviewed_at") || reviewed_at=""
-
-    # No review timestamp → can't determine whether review is stale.
     if [ -z "$reviewed_at" ]; then
         return 1
     fi
-
     new_commits=$(gh api "repos/$REPO/pulls/$PR_NUMBER/commits" --paginate \
         2>/dev/null | jq -s "[.[][] | select(.commit.committer.date > \"$reviewed_at\")] | length" \
         2>/dev/null) || new_commits="0"
-
     [ "${new_commits:-0}" -gt 0 ]
 }
 

--- a/tests/test_greptile_helper.py
+++ b/tests/test_greptile_helper.py
@@ -81,6 +81,8 @@ elif endpoint.endswith(f"/issues/{pr_number}/comments"):
     data = fixture.get("raw_comments", [])
 elif endpoint.endswith(f"/pulls/{pr_number}/commits"):
     data = fixture.get("raw_commits", [])
+elif endpoint.endswith(f"/pulls/{pr_number}/reviews"):
+    data = fixture.get("raw_reviews", [])
 elif endpoint.endswith(f"/pulls/{pr_number}"):
     data = fixture.get("raw_pr", {"created_at": "2020-01-01T00:00:00Z"})
 elif endpoint.endswith("/reactions"):
@@ -314,6 +316,78 @@ def test_rereview_ignores_old_trigger_from_previous_review_cycle():
 
     status = _run_helper("status", fixture)
     assert status.stdout.strip() == "needs-re-review"
+
+
+def _make_greptile_review(commit_id: str, submitted_at: str) -> dict:
+    return {
+        "user": {"login": "greptile-apps[bot]"},
+        "commit_id": commit_id,
+        "submitted_at": submitted_at,
+        "state": "COMMENTED",
+        "body": "Greptile review",
+    }
+
+
+def test_sha_mismatch_forces_re_review_even_when_date_says_no():
+    """SHA-based primary: a fix commit after Greptile's review must re-trigger even
+    when the date heuristic would skip it (regression for ErikBjare/bob#890).
+
+    Greptile reviewed commit OLDSHA; PR head is now NEWSHA. raw_commits has only an
+    OLD commit (date BEFORE the review), so the date fallback alone would say "no
+    re-review" — but the SHA mismatch correctly forces it.
+    """
+    reviewed_at = _iso_ago(minutes=30)
+    fixture = {
+        "pr_number": 123,
+        "raw_comments": [
+            _make_greptile_comment(4, reviewed_at=reviewed_at, updated_at=reviewed_at),
+        ],
+        "raw_reviews": [_make_greptile_review("OLDSHA", reviewed_at)],
+        "raw_pr": {"head": {"sha": "NEWSHA"}, "created_at": _iso_ago(minutes=120)},
+        # Date heuristic would NOT fire: the only commit predates the review.
+        "raw_commits": [_make_commit(_iso_ago(minutes=90))],
+        "bot_reaction_count": 1,
+    }
+    status = _run_helper("status", fixture)
+    assert status.stdout.strip() == "needs-re-review", f"stderr: {status.stderr}"
+
+
+def test_sha_match_skips_re_review_even_when_date_says_yes():
+    """SHA-based primary is loop-safe: when Greptile already reviewed the current
+    head, do NOT re-trigger even if the date heuristic sees "new" commits."""
+    reviewed_at = _iso_ago(minutes=30)
+    fixture = {
+        "pr_number": 123,
+        "raw_comments": [
+            _make_greptile_comment(5, reviewed_at=reviewed_at, updated_at=reviewed_at),
+        ],
+        "raw_reviews": [_make_greptile_review("HEADSHA", reviewed_at)],
+        "raw_pr": {"head": {"sha": "HEADSHA"}, "created_at": _iso_ago(minutes=120)},
+        # A "new" commit (after the review) — date heuristic would say re-review,
+        # but the SHA already matches head, so we must NOT re-trigger (loop-safe).
+        "raw_commits": [_make_commit(_iso_ago(minutes=5))],
+        "bot_reaction_count": 1,
+    }
+    status = _run_helper("status", fixture)
+    assert status.stdout.strip() == "already-reviewed", f"stderr: {status.stderr}"
+
+
+def test_no_pr_review_object_falls_back_to_date_heuristic():
+    """When Greptile posted only an issue comment (no PR review with commit_id),
+    fall back to the date heuristic — behaviour unchanged for that case."""
+    reviewed_at = _iso_ago(minutes=30)
+    fixture = {
+        "pr_number": 123,
+        "raw_comments": [
+            _make_greptile_comment(4, reviewed_at=reviewed_at, updated_at=reviewed_at),
+        ],
+        "raw_reviews": [],  # no PR-review commit_id → fallback
+        "raw_pr": {"created_at": _iso_ago(minutes=120)},
+        "raw_commits": [_make_commit(_iso_ago(minutes=5))],  # new commit → re-review
+        "bot_reaction_count": 1,
+    }
+    status = _run_helper("status", fixture)
+    assert status.stdout.strip() == "needs-re-review", f"stderr: {status.stderr}"
 
 
 def test_fresh_pr_awaits_initial_review():


### PR DESCRIPTION
## Problem
`_needs_re_review` decided whether a Greptile re-review was needed by comparing each commit's `committer.date` against the greptile **issue comment's** `updated_at`. That heuristic is fragile to timezones, in-place comment updates, and API timing.

On ErikBjare/bob#890 (2026-06-14) a fix commit landed **after** Greptile's review (which had flagged two data-loss bugs), both bugs were fixed — but the date compare skipped the re-trigger, so the PR stayed stuck on a stale low score and couldn't reach the 5/5 needed to self-merge. The helper printed `already reviewed (no new commits)` despite a newer commit existing.

## Fix
Make the **primary** signal SHA-based: compare the latest greptile **PR-review's** `commit_id` against the PR **head SHA**. A mismatch unambiguously means "Greptile hasn't reviewed the current head" → re-review needed. It's **loop-safe**: once `reviewed_sha == head_sha` it stops re-triggering (the original date approach had caused infinite loops, which this avoids by construction).

Keep the date heuristic as a **fallback** for PRs where Greptile posted only an issue comment and no PR-review object carries a `commit_id` — behaviour there is unchanged.

## Tests
+3 (`test_greptile_helper.py`), and the fake `gh` stub gains a `/pulls/{pr}/reviews` endpoint:
- SHA mismatch forces re-review **even when the date heuristic would skip** (the #890 regression)
- SHA match skips re-review **even when the date heuristic would fire** (loop-safe)
- no PR-review object → falls back to the date heuristic

**22 pass, shellcheck clean.**