### PR TITLE
feat(judge): temperature param + calibration anchors for score spread

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/judge.py
+++ b/packages/gptme-sessions/src/gptme_sessions/judge.py
@@ -446,6 +446,16 @@ def _strip_anthropic_prefix(model: str) -> str:
     return model.removeprefix("anthropic/") if model.startswith("anthropic/") else model
 
 
+# Models that require temperature=1.0 (Anthropic extended-thinking variants).
+_EXTENDED_THINKING_PREFIXES = ("claude-3-7-",)
+
+
+def _is_extended_thinking_model(model: str) -> bool:
+    """Return True for models that require temperature=1.0 (extended-thinking API constraint)."""
+    bare = _strip_anthropic_prefix(model)
+    return any(bare.startswith(p) for p in _EXTENDED_THINKING_PREFIXES)
+
+
 def _judge_backend(model: str) -> str:
     if _is_anthropic_direct_model(model):
         return "anthropic-direct"
@@ -587,6 +597,16 @@ def _judge_via_anthropic_direct(
         logger.warning("No Anthropic API key found; direct judge unavailable")
         return None
 
+    # Extended-thinking models require temperature=1.0; guard against future
+    # DEFAULT_JUDGE_MODEL changes that would otherwise cause an API 400.
+    effective_temperature = 1.0 if _is_extended_thinking_model(model) else temperature
+    if effective_temperature != temperature:
+        logger.debug(
+            "Extended-thinking model %s requires temperature=1.0; overriding %.2f",
+            model,
+            temperature,
+        )
+
     try:
         client = anthropic.Anthropic(api_key=key)
         response = client.messages.create(
@@ -594,7 +614,7 @@ def _judge_via_anthropic_direct(
             max_tokens=150,
             system=JUDGE_SYSTEM,
             messages=[{"role": "user", "content": prompt}],
-            temperature=temperature,
+            temperature=effective_temperature,
         )
         text = getattr(response.content[0], "text", "").strip()
     except Exception as exc:

--- a/packages/gptme-sessions/src/gptme_sessions/judge.py
+++ b/packages/gptme-sessions/src/gptme_sessions/judge.py
@@ -63,7 +63,8 @@ class JudgeVerdict(TypedDict, total=False):
 JUDGE_SYSTEM = """\
 You are evaluating an AI agent's work session for strategic value.
 Return ONLY a JSON object with two keys: "score" (float 0.0-1.0) and "reason" (string, 1 sentence).
-Do not wrap in markdown code blocks."""
+Do not wrap in markdown code blocks.
+IMPORTANT: Use the FULL 0.0-1.0 range. Do not cluster scores at 0.7-0.8. Reserve 0.9+ for exceptional sessions; assign 0.1-0.3 for minimal or blocked sessions."""
 
 JUDGE_PROMPT_TEMPLATE = """\
 ## Session Category
@@ -141,9 +142,27 @@ scores ~0.72 because:
   automated verification — the impact is mediated through future sessions'
   ability to use the insight.
 
-Key principle across all three: the grade follows from *within-category*
+**Example 4 (code, ~0.92)**: A session ships a new subagent cancellation API
+(``subagent_cancel()``), adds 12 unit tests covering normal completion and
+timeout, gets Greptile 5/5, and merges cleanly. This session scores ~0.92 because:
+- It directly advances a top-priority goal (subagent reliability, a P1 feature).
+- The artifact is self-verifying (tests), durable (merged), and has no rework.
+- 0.92 rather than 1.0 because no end-to-end integration test was added.
+
+**Example 5 (infrastructure, ~0.15)**: A session starts planning a memory
+cleanup, but every file it tries to modify is locked by a parallel session's
+git stash. It re-checks task state, finds the work already done, writes a
+one-line journal entry, and ends. This session scores ~0.15 because:
+- No artifact was produced — the work was already done by someone else.
+- The only output is a journal entry acknowledging the NOOP.
+- 0.15 rather than 0.0 because the loose-end check and duplicate detection
+  were correct agent behavior — pure NOOP would be 0.0.
+
+Key principle across all five: the grade follows from *within-category*
 execution quality, compounding value, and durability — not from whether the
-category number matches a top goal.
+category number matches a top goal. Use scores below 0.5 when output is
+minimal, blocked, or duplicated, and scores above 0.85 only for sessions
+that ship a durable, high-impact deliverable.
 
 ## Forbidden Constructions
 Do NOT invoke any of the following as a penalty rationale:
@@ -554,6 +573,7 @@ def _judge_via_anthropic_direct(
     *,
     model: str,
     api_key: str | None,
+    temperature: float = 0.3,
 ) -> dict | None:
     """Call the judge via the direct Anthropic SDK (legacy path)."""
     try:
@@ -574,6 +594,7 @@ def _judge_via_anthropic_direct(
             max_tokens=150,
             system=JUDGE_SYSTEM,
             messages=[{"role": "user", "content": prompt}],
+            temperature=temperature,
         )
         text = getattr(response.content[0], "text", "").strip()
     except Exception as exc:
@@ -584,7 +605,13 @@ def _judge_via_anthropic_direct(
 
 
 def _judge_via_gptme(prompt: str, *, model: str) -> dict | None:
-    """Call the judge via ``gptme.llm.reply`` for non-Anthropic-direct models."""
+    """Call the judge via ``gptme.llm.reply`` for non-Anthropic-direct models.
+
+    Temperature is not explicitly set here — gptme.llm.reply defaults to the
+    model API default (typically 1.0 for Claude), which already provides
+    sufficient variance. The caller's ``temperature`` param is applied by
+    the anthropic-direct path only.
+    """
     try:
         from gptme.init import init as init_gptme
         from gptme.llm import reply
@@ -633,6 +660,7 @@ def judge_session(
     api_key: str | None = None,
     cascade_context: dict | None = None,
     intent: dict | None = None,
+    temperature: float = 0.3,
 ) -> dict | None:
     """Score a session's strategic value using an LLM judge.
 
@@ -663,6 +691,9 @@ def judge_session(
             Expected keys: ``session_id``, ``lane``, ``objective``,
             ``expected_artifact``, and optionally ``outcome_alignment``
             (self-assigned pre-closeout verdict).
+        temperature: Sampling temperature for the judge model (default 0.3).
+            Higher values increase score variance; 0.0 produces near-constant
+            scores that undermine calibration.
 
     Returns:
         Dict with keys ``score`` (float), ``reason`` (str), ``model`` (str),
@@ -685,7 +716,9 @@ def judge_session(
     )
 
     if _is_anthropic_direct_model(model):
-        return _judge_via_anthropic_direct(prompt, model=model, api_key=api_key)
+        return _judge_via_anthropic_direct(
+            prompt, model=model, api_key=api_key, temperature=temperature
+        )
     return _judge_via_gptme(prompt, model=model)
 
 
@@ -699,6 +732,7 @@ def judge_session_with_fallback(
     api_key: str | None = None,
     cascade_context: dict | None = None,
     intent: dict | None = None,
+    temperature: float = 0.3,
 ) -> dict | None:
     """Score a session, trying fallback models if the primary is unavailable.
 
@@ -711,6 +745,7 @@ def judge_session_with_fallback(
         api_key: Anthropic API key (Anthropic-direct path only).
         cascade_context: Optional CASCADE selector payload. See :func:`judge_session`.
         intent: Optional pre-session intent dict. See :func:`judge_session`.
+        temperature: Sampling temperature forwarded to :func:`judge_session`.
 
     Returns:
         Dict with keys ``score``, ``reason``, ``model`` or ``None`` if all models fail.
@@ -731,6 +766,7 @@ def judge_session_with_fallback(
             api_key=api_key,
             cascade_context=cascade_context,
             intent=intent,
+            temperature=temperature,
         )
         if result is not None:
             return result
@@ -879,6 +915,7 @@ def judge_and_writeback(
     api_key: str | None = None,
     cascade_context: dict | None = None,
     intent: dict | None = None,
+    temperature: float = 0.3,
 ) -> dict[str, Any]:
     """Judge a session and persist the verdict via SessionStore.
 
@@ -895,6 +932,7 @@ def judge_and_writeback(
             api_key=api_key,
             cascade_context=cascade_context,
             intent=intent,
+            temperature=temperature,
         )
     else:
         verdict = judge_session(
@@ -905,6 +943,7 @@ def judge_and_writeback(
             api_key=api_key,
             cascade_context=cascade_context,
             intent=intent,
+            temperature=temperature,
         )
     if verdict is None:
         return {"status": "failed"}


### PR DESCRIPTION
## Summary

The dual-session-grading correlation analysis (2026-06-14) found that System B
(gptme-sessions judge) produces near-constant scores in the 0.75–0.85 range
(variance 0.0013 across 18 sessions), making correlation analysis between the two
grading systems meaningless. Root causes:

1. **Prompt examples cluster at 0.72–0.78** — all three worked examples show
   medium-high sessions, anchoring the judge's sense of "normal" in that range.
2. **anthropic-direct path defaults to whatever temp the SDK picks** — with
   Haiku, this produces near-deterministic greedy scoring.

## Changes

**`gptme-sessions/judge.py`**:

1. Add `temperature: float = 0.3` parameter to `judge_session`,
   `judge_session_with_fallback`, and `judge_and_writeback`. Applied to the
   anthropic-direct path. The gptme-fallback path already uses the model API
   default (~1.0), so temperature is not forwarded there (backward compatible).

2. Add spread directive to `JUDGE_SYSTEM`:
   ```
   IMPORTANT: Use the FULL 0.0-1.0 range. Do not cluster scores at 0.7-0.8.
   Reserve 0.9+ for exceptional sessions; assign 0.1-0.3 for minimal or blocked sessions.
   ```

3. Add two extreme worked examples to `JUDGE_PROMPT_TEMPLATE`:
   - **Example 4 (~0.92)**: Session ships a well-tested feature (subagent cancel API,
     12 tests, Greptile 5/5, merged) — explains why this earns ~0.92 and not 0.75.
   - **Example 5 (~0.15)**: Blocked/NOOP session finds the work was already done by
     a parallel session — explains why minimal output earns 0.15, not 0.75.

## Test plan

- [x] All 65 existing judge tests pass (`pytest packages/gptme-sessions/tests/test_judge.py`)
- [x] `mypy packages/gptme-sessions/src/gptme_sessions/judge.py` clean (no new errors)
- [x] `temperature` param is backward-compatible (default 0.3; callers not passing it get the calibrated default)
- [ ] Re-run `scripts/dual-grading-correlation.py --limit 20 --json` after merge to verify score variance improves