### PR TITLE
fix(gptme-imagen): wrap functions with ToolFunction.from_callable()

### DIFF
--- a/plugins/gptme-imagen/src/gptme_imagen/tools/image_gen.py
+++ b/plugins/gptme-imagen/src/gptme_imagen/tools/image_gen.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 try:
-    from gptme.tools.base import ToolSpec
+    from gptme.tools.base import ToolFunction, ToolSpec
 
     _HAS_GPTME = True
 except ImportError:
@@ -1256,10 +1256,10 @@ generate_image(
     """,
         execute=_execute_image_gen_block,
         functions=[
-            generate_image,
-            generate_variation,
-            batch_generate,
-            compare_providers,
+            ToolFunction.from_callable(generate_image),
+            ToolFunction.from_callable(generate_variation),
+            ToolFunction.from_callable(batch_generate),
+            ToolFunction.from_callable(compare_providers),
         ],
         block_types=["image_gen"],
     )


### PR DESCRIPTION
## Summary

The `image_gen` tool was passing plain Python callables in its `functions=` list, but `ToolSpec.functions` expects `ToolFunction` objects. This caused:

```
AttributeError: 'function' object has no attribute 'fn'
```

during `init_tools()` when gptme's python tool tried to register the callables.

## Fix

- Import `ToolFunction` from `gptme.tools.base`
- Wrap all four functions (`generate_image`, `generate_variation`, `batch_generate`, `compare_providers`) with `ToolFunction.from_callable()`

## Test plan

- [ ] `gptme-imagen` plugin loads without `AttributeError` when `init_tools()` is called
- [ ] Tests that import `gptme.init.init` no longer fail due to this plugin