### PR TITLE
fix(gptmail): add reply-once idempotency guard to agent reply

### DIFF
--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -426,23 +426,18 @@ def reply(message_id: str, content: str | None) -> None:
     if msg_path is None:
         click.echo(f"Error: message not found: {message_id}", err=True)
         sys.exit(1)
-    # Idempotency guard: if this message already carries replied:true (from a
-    # prior reply by this or another concurrent session), do not send a
-    # duplicate.  This protects against the inbox handler reprocessing the same
-    # inbound message on multiple cascade passes or convergent autonomous
-    # sessions — the reply-once property lives at the messaging layer, not in
-    # the cascade scheduling layer.
-    precheck = meta_of(msg_path)
-    if precheck and precheck.get("replied"):
+    original = meta_of(msg_path)
+    if original is None:
+        click.echo(f"Error: message not found: {message_id}", err=True)
+        sys.exit(1)
+    # Idempotency guard: skip if a prior session already stamped replied:true.
+    # Protects against cascade reprocessing sending duplicate replies.
+    if original.get("replied"):
         click.echo(
             f"Skipping {message_id}: already replied (idempotency guard).",
             err=True,
         )
         return
-    original = meta_of(msg_path)
-    if original is None:
-        click.echo(f"Error: message not found: {message_id}", err=True)
-        sys.exit(1)
     recipient = str(original.get("from", "")).lower()
     if not recipient:
         click.echo(f"Error: cannot determine sender of {message_id}", err=True)

--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -426,6 +426,19 @@ def reply(message_id: str, content: str | None) -> None:
     if msg_path is None:
         click.echo(f"Error: message not found: {message_id}", err=True)
         sys.exit(1)
+    # Idempotency guard: if this message already carries replied:true (from a
+    # prior reply by this or another concurrent session), do not send a
+    # duplicate.  This protects against the inbox handler reprocessing the same
+    # inbound message on multiple cascade passes or convergent autonomous
+    # sessions — the reply-once property lives at the messaging layer, not in
+    # the cascade scheduling layer.
+    precheck = meta_of(msg_path)
+    if precheck and precheck.get("replied"):
+        click.echo(
+            f"Skipping {message_id}: already replied (idempotency guard).",
+            err=True,
+        )
+        return
     original = meta_of(msg_path)
     if original is None:
         click.echo(f"Error: message not found: {message_id}", err=True)


### PR DESCRIPTION
Pre-check `replied:true` frontmatter before sending a reply, so concurrent autonomous sessions and multi-pass inbox handlers never send duplicate replies to the same inbound message.

Erik reported 3 duplicate replies to a single ty-vs-mypy message from the cascade inbox handler reprocessing the same message on multiple passes. The guard lives at the messaging layer (`gptmail agent reply`), not the scheduling layer, because reply-once is a messaging property independent of how the inbox lane is scheduled.

## Change
- `agent_cli.py`: `reply()` now reads the message file's frontmatter before sending and short-circuits with `Skipping <id>: already replied (idempotency guard)` if `replied:true` is already set.

## Verification
- Existing 210 coordination tests pass
- Manual: calling `gptmail agent reply <id>` on an already-replied message now exits cleanly instead of sending a duplicate