### PR TITLE
fix(gptmail): parse frontmatter on delimiter line, not bare --- substring

### DIFF
--- a/packages/gptmail/src/gptmail/transport/agent.py
+++ b/packages/gptmail/src/gptmail/transport/agent.py
@@ -36,6 +36,28 @@ import yaml
 # delivery succeeded. None means local-only (tests, single-host).
 Deliver = Callable[[Path, str], bool]
 
+# Matches a leading frontmatter block, capturing the YAML between the opening
+# ``---`` line and the next ``---`` that is *alone on its own line*. Using the
+# line-anchored delimiter (``\n---`` then end-of-line) instead of a bare ``---``
+# substring is load-bearing: a frontmatter *value* can legitimately contain
+# ``---`` — e.g. an ``in_reply_to`` filename whose subject slug has ``---`` in it
+# ("Re: x — y" → ``...x---y.md``). Splitting on the bare substring truncated the
+# value mid-line and corrupted every subsequent field.
+_FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---(?:\n|$)", re.DOTALL)
+
+
+def _split_frontmatter(content: str) -> tuple[str, str] | None:
+    """Split ``content`` into ``(frontmatter_yaml, body)``.
+
+    ``body`` is everything after the closing delimiter line, so the original file
+    is reconstructed losslessly as ``f"---\\n{fm}\\n---\\n{body}"``. Returns None
+    when there's no well-formed leading frontmatter block.
+    """
+    m = _FRONTMATTER_RE.match(content)
+    if not m:
+        return None
+    return m.group(1), content[m.end() :]
+
 
 def meta_of(path: Path) -> dict | None:
     """Parse the YAML frontmatter of a message file (``None`` if absent/invalid).
@@ -47,13 +69,11 @@ def meta_of(path: Path) -> dict | None:
         content = path.read_text()
     except OSError:
         return None
-    if not content.startswith("---"):
-        return None
-    parts = content.split("---", 2)
-    if len(parts) < 3:
+    split = _split_frontmatter(content)
+    if split is None:
         return None
     try:
-        meta = yaml.safe_load(parts[1])
+        meta = yaml.safe_load(split[0])
     except yaml.YAMLError:
         return None
     return meta if isinstance(meta, dict) else None
@@ -174,15 +194,13 @@ class AgentTransport:
     def _stamp_delivery_failed(self, local_path: Path) -> None:
         """Mark an outbox file ``delivered: false`` so reply-tracking skips it."""
         content = local_path.read_text()
-        if not content.startswith("---"):
+        split = _split_frontmatter(content)
+        if split is None:
             return
-        parts = content.split("---", 2)
-        if len(parts) < 3:
-            return
-        fm = parts[1]
+        fm, body = split
         if not re.search(r"^delivered:", fm, flags=re.MULTILINE):
-            fm = fm.rstrip("\n") + "\ndelivered: false\n"
-        local_path.write_text("---".join([parts[0], fm, parts[2]]))
+            fm = fm.rstrip("\n") + "\ndelivered: false"
+        local_path.write_text(f"---\n{fm}\n---\n{body}")
 
     def list_inbox(self, folder: str = "inbox") -> list[tuple[str, str, datetime]]:
         """List ``(message_id, subject, timestamp)`` for messages in a folder."""
@@ -230,12 +248,11 @@ class AgentTransport:
 
     def _mark_read(self, path: Path) -> str:
         content = path.read_text()
-        if content.startswith("---"):
-            parts = content.split("---", 2)
-            if len(parts) >= 3 and "read: false" in parts[1]:
-                parts[1] = re.sub(r"^read: false$", "read: true", parts[1], flags=re.MULTILINE)
-                content = "---".join(parts)
-                path.write_text(content)
+        split = _split_frontmatter(content)
+        if split is not None and re.search(r"^read: false$", split[0], flags=re.MULTILINE):
+            fm = re.sub(r"^read: false$", "read: true", split[0], flags=re.MULTILINE)
+            content = f"---\n{fm}\n---\n{split[1]}"
+            path.write_text(content)
         return content
 
     def _lookup_meta(self, message_id: str) -> dict | None:

--- a/packages/gptmail/tests/test_agent_transport.py
+++ b/packages/gptmail/tests/test_agent_transport.py
@@ -12,8 +12,6 @@ See task: fold-agent-msg-into-gptmail-single-comms-tool.
 from pathlib import Path
 
 import pytest
-import yaml
-
 from gptmail.transport import Transport
 from gptmail.transport.agent import AgentTransport, meta_of
 
@@ -23,8 +21,9 @@ def _transport(tmp_path: Path, deliver=None) -> AgentTransport:
 
 
 def _frontmatter(path: Path) -> dict:
-    parts = path.read_text().split("---", 2)
-    return yaml.safe_load(parts[1])
+    result = meta_of(path)
+    assert result is not None
+    return result
 
 
 def test_satisfies_protocol(tmp_path: Path) -> None:

--- a/packages/gptmail/tests/test_agent_transport.py
+++ b/packages/gptmail/tests/test_agent_transport.py
@@ -15,7 +15,7 @@ import pytest
 import yaml
 
 from gptmail.transport import Transport
-from gptmail.transport.agent import AgentTransport
+from gptmail.transport.agent import AgentTransport, meta_of
 
 
 def _transport(tmp_path: Path, deliver=None) -> AgentTransport:
@@ -170,3 +170,48 @@ def test_conversation_id_is_order_free_pair(tmp_path: Path) -> None:
 
 def test_conversation_id_falls_back_when_unknown(tmp_path: Path) -> None:
     assert _transport(tmp_path).conversation_id_for("ghost.md") == "agent:ghost.md"
+
+
+# A parent filename whose subject slug contains ``---`` — e.g. a subject like
+# "Comms test — please ack" slugs to ``...Comms-test---please-ack...``. Replying
+# to it puts ``---`` inside the reply's ``in_reply_to`` value. A frontmatter
+# parser that splits on the bare ``---`` substring truncates the value mid-line
+# and corrupts the file. These pin the line-anchored delimiter parse.
+_DASHED_PARENT_ID = "20260615-130649-erik-Comms-test---please-ack--gptmail-agent-c.md"
+
+
+def test_reply_to_with_triple_dash_in_filename_round_trips(tmp_path: Path) -> None:
+    t = _transport(tmp_path)
+    mid = t.send("bob", "Re: Comms test", "ack body", reply_to=_DASHED_PARENT_ID)
+    meta = meta_of(t.outbox / mid)
+    assert meta is not None
+    # The full filename survives — not truncated at the first ``---``.
+    assert meta["in_reply_to"] == _DASHED_PARENT_ID
+    assert meta["subject"] == "Re: Comms test"
+    assert meta["from"] == "alice"
+    assert meta["to"] == "bob"
+
+
+def test_delivery_failure_stamp_preserves_dashed_in_reply_to(tmp_path: Path) -> None:
+    t = _transport(tmp_path, deliver=lambda path, recipient: False)
+    mid = t.send("bob", "Re: Comms test", "ack body", reply_to=_DASHED_PARENT_ID)
+    meta = meta_of(t.outbox / mid)
+    assert meta is not None
+    assert meta["delivered"] is False
+    # Stamping must not corrupt the dashed in_reply_to or drop other fields.
+    assert meta["in_reply_to"] == _DASHED_PARENT_ID
+    assert meta["subject"] == "Re: Comms test"
+    assert "ack body" in (t.outbox / mid).read_text()
+
+
+def test_read_preserves_dashed_in_reply_to(tmp_path: Path) -> None:
+    alice = _transport(tmp_path)
+    bob = AgentTransport(
+        tmp_path / "bob-messages", "bob", deliver=AgentTransport.local_deliver(alice.inbox)
+    )
+    mid = bob.send("alice", "Re: Comms test", "ack body", reply_to=_DASHED_PARENT_ID)
+    alice.read(mid)
+    meta = meta_of(alice.inbox / mid)
+    assert meta is not None
+    assert meta["read"] is True
+    assert meta["in_reply_to"] == _DASHED_PARENT_ID


### PR DESCRIPTION
## Problem

`agent-msg.py reply` corrupted the outbox message frontmatter when the parent's filename contained `---`. I hit this replying to Erik's "Comms test — please ack" message: the subject's `—` slugs to `Comms-test---please-ack...md`, so the reply's `in_reply_to` value contains `---`. The written file came out as:

```yaml
---
from: alice
in_reply_to: 20260615-130649-675828-erik-Comms-test
delivered: false
---please-ack--gptmail-agent-c.md
---
```

`in_reply_to` truncated mid-value, the filename tail leaked out as a stray line, and the frontmatter block was broken.

## Root cause

`meta_of`, `_stamp_delivery_failed`, and `_mark_read` all parse frontmatter with `content.split("---", 2)`, which splits on **any** `---` substring — including one inside a frontmatter *value*. Since `_format` writes `in_reply_to` (a filename that can contain `---`) on one line, the split breaks at the value instead of the closing delimiter line.

This is class-wide: any threaded reply to a message whose subject slug contains `---` (common — em-dashes and multi-word gaps both produce `---`) corrupts on send, delivery-failure stamping, and read-marking.

## Fix

Added a shared `_split_frontmatter` helper that matches the **line-anchored** delimiter (`\A---\n(.*?)\n---`) so a `---` inside a value is preserved, and routed all three call sites through it.

## Tests

3 regression tests (round-trip, delivery-failure stamp, read-mark) for a dashed `in_reply_to`. All three **fail on the old code** and pass with the fix. Full suite: 43 passed.

## Note

Separately, `erik` isn't in the agent registry (`agents.yaml` has only bob/alice/gordon), so `reply`/`send` to Erik exits 1 with "unknown agent 'erik'". Out of scope for this transport fix — flagged to Erik directly since it's a registry/config decision, not a parsing bug.