### PR TITLE
fix(gptmail): reply-once for pull-based recipients (no duplicate replies)

### DIFF
--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -109,15 +109,16 @@ def _self_name() -> str:
     return os.environ.get("AGENT_NAME", os.environ.get("USER", "unknown")).lower()
 
 
-def _load_agents() -> dict[str, dict[str, str]]:
+def _load_agents(*, warn_missing: bool = True) -> dict[str, dict[str, str]]:
     """Load the agent registry from ``messages/agents.yaml`` ({} if absent)."""
     config_path = _messages_dir() / "agents.yaml"
     if not config_path.exists():
-        click.echo(
-            f"Warning: no agent registry at {config_path}\n"
-            "Create messages/agents.yaml with agent SSH targets.",
-            err=True,
-        )
+        if warn_missing:
+            click.echo(
+                f"Warning: no agent registry at {config_path}\n"
+                "Create messages/agents.yaml with agent SSH targets.",
+                err=True,
+            )
         return {}
     raw = yaml.safe_load(config_path.read_text()) or {}
     # Normalise keys to lowercase so lookups (which use ``to.lower()``) match
@@ -259,7 +260,12 @@ def _is_push_reachable(recipient: str, agents: dict[str, dict[str, str]]) -> boo
     return all(agent.get(k) for k in ("ssh", "workspace"))
 
 
-def _pending_messages(messages_dir: Path, self_name: str, window: int) -> list[dict]:
+def _pending_messages(
+    messages_dir: Path,
+    self_name: str,
+    window: int,
+    agents: dict[str, dict[str, str]] | None = None,
+) -> list[dict]:
     """Inbox messages addressed to us that we haven't replied to (timely SLA).
 
     A reply requirement is satisfied by an inbox ``replied: true`` stamp or by an
@@ -273,7 +279,8 @@ def _pending_messages(messages_dir: Path, self_name: str, window: int) -> list[d
     inbox = messages_dir / "inbox"
     outbox = messages_dir / "outbox"
     now = datetime.now(timezone.utc)
-    agents = _load_agents()
+    if agents is None:
+        agents = _load_agents(warn_missing=False)
 
     replied_to: set[str] = set()
     my_outbox_ids: set[str] = set()
@@ -497,7 +504,7 @@ def status() -> None:
     agents = _load_agents()
     inbox = transport.list_inbox("inbox")
     outbox = transport.list_inbox("outbox")
-    pend = _pending_messages(messages_dir, _self_name(), _reply_window_days())
+    pend = _pending_messages(messages_dir, _self_name(), _reply_window_days(), agents=agents)
     click.echo(f"Agent:    {_self_name()}")
     click.echo(f"Registry: {', '.join(agents) or '(none)'}")
     click.echo(f"Inbox:    {len(inbox)}")

--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -244,23 +244,47 @@ def _addressed_to(meta: dict, self_name: str) -> bool:
     return str(to).lower() == self_name
 
 
+def _is_push_reachable(recipient: str, agents: dict[str, dict[str, str]]) -> bool:
+    """True if ``recipient`` has a working push transport in the registry.
+
+    Mirrors the ``_ssh_deliver`` contract: a recipient is push-reachable only if
+    it is registered with non-empty ``ssh`` and ``workspace`` keys. Pull-based
+    recipients (not in the registry, or missing those keys — e.g. Erik, who polls
+    the outbox) can never be delivered to, so their replies stay ``delivered:
+    false`` permanently rather than as a transient, retryable failure.
+    """
+    agent = agents.get(recipient.lower())
+    if not agent:
+        return False
+    return all(agent.get(k) for k in ("ssh", "workspace"))
+
+
 def _pending_messages(messages_dir: Path, self_name: str, window: int) -> list[dict]:
     """Inbox messages addressed to us that we haven't replied to (timely SLA).
 
-    A reply requirement is satisfied by an inbox ``replied: true`` stamp or by
-    any successfully-delivered outbox message whose ``in_reply_to`` points at it.
+    A reply requirement is satisfied by an inbox ``replied: true`` stamp or by an
+    outbox message whose ``in_reply_to`` points at it. Reply-once: a draft reply
+    counts even when stamped ``delivered: false`` **if the recipient is
+    pull-based** (no push transport), where that stamp is the permanent steady
+    state — otherwise every poll re-composes a fresh, non-identical reply (the
+    duplicate-reply bug). For push-reachable recipients, ``delivered: false``
+    still means a transient failure, so the message stays pending to retry.
     """
     inbox = messages_dir / "inbox"
     outbox = messages_dir / "outbox"
     now = datetime.now(timezone.utc)
+    agents = _load_agents()
 
     replied_to: set[str] = set()
     my_outbox_ids: set[str] = set()
     if outbox.exists():
         for f in outbox.glob("*.md"):
             m = meta_of(f)
-            if m and m.get("in_reply_to") and m.get("delivered") is not False:
-                replied_to.add(str(m["in_reply_to"]))
+            if m and m.get("in_reply_to"):
+                recipient = str(m.get("to") or "")
+                delivered_ok = m.get("delivered") is not False
+                if delivered_ok or not _is_push_reachable(recipient, agents):
+                    replied_to.add(str(m["in_reply_to"]))
             my_outbox_ids.add(f.name)
 
     pending: list[dict] = []

--- a/packages/gptmail/tests/test_agent_cli.py
+++ b/packages/gptmail/tests/test_agent_cli.py
@@ -319,6 +319,56 @@ def test_pending_excludes_replies_to_my_messages(workspace: Path) -> None:
     assert "No messages awaiting reply" in result.output, result.output
 
 
+def test_pending_reply_once_for_pull_based_recipient(workspace: Path) -> None:
+    """An undelivered reply to a pull-based recipient satisfies reply-once.
+
+    Regression for the duplicate-reply bug: a recipient absent from the registry
+    (e.g. Erik, who polls the outbox) can never be delivered to, so replies stay
+    ``delivered: false`` permanently. Counting only delivered replies made every
+    poll re-compose a fresh, non-identical reply. A draft reply to a pull-based
+    recipient must clear the inbound message from pending.
+    """
+    now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    inbox = workspace / "messages" / "inbox"
+    msg = "20260615-120000-000000-erik-question.md"
+    (inbox / msg).write_text(
+        f"---\nfrom: erik\nto: alice\ntimestamp: {now_iso}\n"
+        "subject: question\nread: false\n---\n\nplease advise\n"
+    )
+    # We drafted a reply, but delivery is impossible (erik is not in the registry).
+    outbox = workspace / "messages" / "outbox"
+    (outbox / "20260615-120100-000000-alice-Re-question.md").write_text(
+        f"---\nfrom: alice\nto: erik\ntimestamp: {now_iso}\n"
+        f"subject: 'Re: question'\nin_reply_to: {msg}\ndelivered: false\n---\n\nmy reply\n"
+    )
+    result = CliRunner().invoke(agent, ["pending"])
+    assert "No messages awaiting reply" in result.output, result.output
+
+
+def test_pending_keeps_undelivered_reply_to_push_recipient(workspace: Path) -> None:
+    """An undelivered reply to a push-reachable recipient stays pending (retry).
+
+    ``bob`` is registered with ssh+workspace, so ``delivered: false`` means a
+    transient delivery failure, not a permanent pull-based state — the message
+    must remain pending so the next cycle retries delivery.
+    """
+    now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    inbox = workspace / "messages" / "inbox"
+    msg = "20260615-120000-000000-bob-question.md"
+    (inbox / msg).write_text(
+        f"---\nfrom: bob\nto: alice\ntimestamp: {now_iso}\n"
+        "subject: question\nread: false\n---\n\nplease advise\n"
+    )
+    outbox = workspace / "messages" / "outbox"
+    (outbox / "20260615-120100-000000-alice-Re-question.md").write_text(
+        f"---\nfrom: alice\nto: bob\ntimestamp: {now_iso}\n"
+        f"subject: 'Re: question'\nin_reply_to: {msg}\ndelivered: false\n---\n\nmy reply\n"
+    )
+    result = CliRunner().invoke(agent, ["pending"])
+    assert "1 message(s) awaiting reply" in result.output, result.output
+    assert msg in result.output
+
+
 def test_reply_does_not_corrupt_subject_containing_read_false(workspace: Path) -> None:
     # Regression: _mark_replied must anchor its frontmatter rewrite. A subject
     # containing the literal "read: false" must survive replying intact.

--- a/packages/gptmail/tests/test_agent_cli.py
+++ b/packages/gptmail/tests/test_agent_cli.py
@@ -395,6 +395,35 @@ def test_status_reports_counts(workspace: Path) -> None:
     assert "Pending:  1" in result.output
 
 
+def test_pending_stays_silent_without_registry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    messages = tmp_path / "messages"
+    (messages / "inbox").mkdir(parents=True)
+    (messages / "outbox").mkdir(parents=True)
+    monkeypatch.setenv("AGENT_NAME", "alice")
+    monkeypatch.setattr(agent_cli, "_repo_root", lambda: tmp_path)
+
+    result = CliRunner().invoke(agent, ["pending"])
+    assert result.exit_code == 0
+    assert "Warning: no agent registry" not in result.output
+    assert "No messages awaiting reply." in result.output
+
+
+def test_status_warns_once_without_registry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    messages = tmp_path / "messages"
+    (messages / "inbox").mkdir(parents=True)
+    (messages / "outbox").mkdir(parents=True)
+    monkeypatch.setenv("AGENT_NAME", "alice")
+    monkeypatch.setattr(agent_cli, "_repo_root", lambda: tmp_path)
+
+    result = CliRunner().invoke(agent, ["status"])
+    assert result.exit_code == 0
+    assert result.output.count("Warning: no agent registry") == 1
+
+
 @pytest.fixture
 def multi_peer_workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """A workspace with two peers (bob, gordon) plus self (alice) in the registry.


### PR DESCRIPTION
## Problem

Erik received **three near-duplicate replies** to a single inbound agent message (gptmail). Root cause: `_pending_messages` (which feeds `gptmail agent pending` → the cascade work source) counted an outbox reply toward reply-once **only when it was delivered** (`delivered is not False`).

Recipients with no push transport — absent from `messages/agents.yaml` (e.g. Erik, who *polls* the outbox rather than receiving SCP pushes) — always get their replies stamped `delivered: false`. That stamp is their **permanent steady state**, not a transient failure. So a drafted reply never satisfied the pending check, and every poll cycle re-listed the inbound message and **re-composed a fresh, non-identical reply**.

## Fix

A draft reply now satisfies reply-once when it was delivered **OR** when the recipient is **pull-based** (no working registry `ssh`+`workspace` entry). Push-reachable recipients keep the existing transient-retry behavior: `delivered: false` still leaves the inbound message pending so the next cycle retries delivery.

- New `_is_push_reachable()` mirrors the `_ssh_deliver` contract (registered + non-empty `ssh` and `workspace`).
- `_pending_messages` consults the registry to distinguish permanent pull-based undelivered from transient push failures.

## Tests

- `test_pending_reply_once_for_pull_based_recipient` — reproduces Erik's bug (fails on `master`, passes with the fix): an undelivered reply to an unregistered recipient clears the inbound message from pending.
- `test_pending_keeps_undelivered_reply_to_push_recipient` — guards the retry path: an undelivered reply to a registered (push-reachable) recipient stays pending.

Full gptmail suite: 104 passed. `ruff` + `mypy` clean.

Reported by Erik via gptmail agent message (2026-06-15). Closes the messaging-layer half of the dedup ask (the cascade-scheduling half landed separately).