### PR TITLE
fix(gptmail): line-anchor frontmatter split so '---' in in_reply_to can't corrupt threading

### DIFF
--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -48,7 +48,12 @@ from gptmail.communication_utils.state.tracking import (
     ConversationTracker,
     MessageState,
 )
-from gptmail.transport.agent import AgentTransport, Deliver, meta_of
+from gptmail.transport.agent import (
+    AgentTransport,
+    Deliver,
+    meta_of,
+    split_frontmatter,
+)
 
 
 # Inbox messages older than this (days) are assumed handled and no longer
@@ -197,12 +202,10 @@ def _delivery_failed(message_id: str) -> bool:
         content = path.read_text()
     except OSError:
         return False
-    if not content.startswith("---"):
+    parts = split_frontmatter(content)
+    if parts is None:
         return False
-    parts = content.split("---", 2)
-    return len(parts) >= 3 and any(
-        line.strip() == "delivered: false" for line in parts[1].splitlines()
-    )
+    return any(line.strip() == "delivered: false" for line in parts[1].splitlines())
 
 
 def _track_sent(transport: AgentTransport, message_id: str, reply_to: str | None) -> None:
@@ -295,10 +298,8 @@ def _mark_replied(messages_dir: Path, message_id: str) -> None:
     if path is None or not path.exists():
         return
     content = path.read_text()
-    if not content.startswith("---"):
-        return
-    parts = content.split("---", 2)
-    if len(parts) < 3:
+    parts = split_frontmatter(content)
+    if parts is None:
         return
     fm = re.sub(r"^read: false$", "read: true", parts[1], flags=re.MULTILINE)
     if "replied:" not in fm:

--- a/packages/gptmail/src/gptmail/transport/agent.py
+++ b/packages/gptmail/src/gptmail/transport/agent.py
@@ -36,6 +36,47 @@ import yaml
 # delivery succeeded. None means local-only (tests, single-host).
 Deliver = Callable[[Path, str], bool]
 
+# Matches a ``---`` that occupies its own line (the closing frontmatter fence),
+# so a ``---`` *inside* a value (e.g. an ``in_reply_to`` filename ending in
+# ``----foo.md``) can never be mistaken for the end of the block.
+_CLOSE_FENCE = re.compile(r"\n---[ \t]*(?=\n|$)")
+
+
+def split_frontmatter(content: str) -> list[str] | None:
+    """Split YAML frontmatter on line-anchored ``---`` fences.
+
+    Returns ``["", frontmatter, rest]`` — the same 3-part shape as
+    ``content.split("---", 2)`` and losslessly rejoinable via
+    ``"---".join(parts)`` — but only a ``---`` on its own line ends the block.
+
+    ``content.split("---", 2)`` is wrong for frontmatter: a value containing
+    ``---`` (an ``in_reply_to`` filename like ``...blog-candidate----gptma.md``)
+    truncates the block, and the rewrite paths then reinsert keys into the middle
+    of that value (silent threading corruption). This splitter is fence-anchored
+    so such values stay intact. Returns ``None`` when there is no well-formed
+    block.
+    """
+    # Opening fence must be on its own line.
+    if not (content.startswith("---\n") or content.rstrip("\n") == "---"):
+        return None
+    m = _CLOSE_FENCE.search(content, 3)
+    if m is None:
+        return None
+    close = m.start() + 1  # position of the literal closing "---"
+    return ["", content[3:close], content[close + 3 :]]
+
+
+def _slug(text: str, maxlen: int) -> str:
+    """Filename-safe slug with dash-runs collapsed so it never contains ``---``.
+
+    Message IDs are filenames embedded into the ``in_reply_to`` frontmatter
+    value; collapsing runs of ``-`` guarantees that value never carries a
+    ``---`` a parser could mistake for a fence (defends external consumers too).
+    """
+    s = "".join(c if c.isalnum() or c in "-_" else "-" for c in text)
+    s = re.sub(r"-{2,}", "-", s)
+    return s[:maxlen].strip("-")
+
 
 def meta_of(path: Path) -> dict | None:
     """Parse the YAML frontmatter of a message file (``None`` if absent/invalid).
@@ -47,10 +88,8 @@ def meta_of(path: Path) -> dict | None:
         content = path.read_text()
     except OSError:
         return None
-    if not content.startswith("---"):
-        return None
-    parts = content.split("---", 2)
-    if len(parts) < 3:
+    parts = split_frontmatter(content)
+    if parts is None:
         return None
     try:
         meta = yaml.safe_load(parts[1])
@@ -96,10 +135,8 @@ class AgentTransport:
     @staticmethod
     def _make_filename(sender: str, subject: str) -> str:
         ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S-%f")
-        safe_sender = "".join(c if c.isalnum() or c in "-_" else "-" for c in sender)
-        safe_sender = safe_sender[:20].strip("-")
-        safe_subject = "".join(c if c.isalnum() or c in "-_" else "-" for c in subject)
-        safe_subject = safe_subject[:40].strip("-")
+        safe_sender = _slug(sender, 20)
+        safe_subject = _slug(subject, 40)
         return f"{ts}-{safe_sender}-{safe_subject}.md"
 
     @staticmethod
@@ -174,10 +211,8 @@ class AgentTransport:
     def _stamp_delivery_failed(self, local_path: Path) -> None:
         """Mark an outbox file ``delivered: false`` so reply-tracking skips it."""
         content = local_path.read_text()
-        if not content.startswith("---"):
-            return
-        parts = content.split("---", 2)
-        if len(parts) < 3:
+        parts = split_frontmatter(content)
+        if parts is None:
             return
         fm = parts[1]
         if not re.search(r"^delivered:", fm, flags=re.MULTILINE):
@@ -230,12 +265,11 @@ class AgentTransport:
 
     def _mark_read(self, path: Path) -> str:
         content = path.read_text()
-        if content.startswith("---"):
-            parts = content.split("---", 2)
-            if len(parts) >= 3 and "read: false" in parts[1]:
-                parts[1] = re.sub(r"^read: false$", "read: true", parts[1], flags=re.MULTILINE)
-                content = "---".join(parts)
-                path.write_text(content)
+        parts = split_frontmatter(content)
+        if parts is not None and "read: false" in parts[1]:
+            parts[1] = re.sub(r"^read: false$", "read: true", parts[1], flags=re.MULTILINE)
+            content = "---".join(parts)
+            path.write_text(content)
         return content
 
     def _lookup_meta(self, message_id: str) -> dict | None:

--- a/packages/gptmail/tests/test_agent_cli.py
+++ b/packages/gptmail/tests/test_agent_cli.py
@@ -20,6 +20,10 @@ from click.testing import CliRunner
 from gptmail import agent_cli
 from gptmail.agent_cli import agent
 from gptmail.communication_utils.state.tracking import ConversationTracker, MessageState
+from gptmail.transport.agent import meta_of
+
+
+DASHRUN_ID = "20260615-123532-377975-erik-ty-vs-mypy-eval--blog-candidate----gptma.md"
 
 
 @pytest.fixture
@@ -52,7 +56,9 @@ def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 
 def _frontmatter(path: Path) -> dict:
-    return yaml.safe_load(path.read_text().split("---", 2)[1])
+    meta = meta_of(path)
+    assert meta is not None
+    return meta
 
 
 def _only_outbox_msg(workspace: Path) -> Path:
@@ -144,9 +150,9 @@ def test_reply_reports_delivery_failure_and_keeps_pending(
     # The ConversationTracker must NOT mark the original as COMPLETED — delivery never happened.
     tracker = ConversationTracker(workspace / "messages" / ".tracking")
     state = tracker.get_message_state("agent:alice|bob", name)
-    assert (
-        state is None or state.state != MessageState.COMPLETED
-    ), "tracker must not mark original as COMPLETED when delivery failed"
+    assert state is None or state.state != MessageState.COMPLETED, (
+        "tracker must not mark original as COMPLETED when delivery failed"
+    )
 
 
 @pytest.mark.parametrize(
@@ -334,6 +340,23 @@ def test_reply_does_not_corrupt_subject_containing_read_false(workspace: Path) -
     assert fm["subject"] == "Auto-retry if read: false"  # subject untouched
     assert fm["read"] is True
     assert fm["replied"] is True
+
+
+def test_reply_preserves_dashrun_in_reply_to_when_marking_replied(workspace: Path) -> None:
+    # Regression: _mark_replied rewrites inbox frontmatter too. An in_reply_to
+    # containing ``---`` must survive the replied/read stamp intact.
+    inbox = workspace / "messages" / "inbox"
+    name = "20260615-000000-000000-bob-dashrun.md"
+    (inbox / name).write_text(
+        "---\nfrom: bob\nto: alice\ntimestamp: 2026-06-15T00:00:00Z\n"
+        f'subject: "Re: dashrun"\nread: false\nin_reply_to: {DASHRUN_ID}\n---\n\nplease advise\n'
+    )
+    result = CliRunner().invoke(agent, ["reply", name, "advice"])
+    assert result.exit_code == 0, result.output
+    fm = _frontmatter(inbox / name)
+    assert fm["read"] is True
+    assert fm["replied"] is True
+    assert fm["in_reply_to"] == DASHRUN_ID
 
 
 def test_status_reports_counts(workspace: Path) -> None:

--- a/packages/gptmail/tests/test_agent_transport.py
+++ b/packages/gptmail/tests/test_agent_transport.py
@@ -15,7 +15,13 @@ import pytest
 import yaml
 
 from gptmail.transport import Transport
-from gptmail.transport.agent import AgentTransport
+from gptmail.transport.agent import AgentTransport, meta_of, split_frontmatter
+
+# A message-id (inbox filename) whose sanitized-subject tail leaves a run of
+# dashes plus a ``.md`` suffix — i.e. it literally contains ``---``. Carried
+# verbatim into ``in_reply_to``, this used to truncate the frontmatter via a
+# naive ``content.split("---", 2)``. Erik bug report 2026-06-15.
+DASHRUN_ID = "20260615-123532-377975-erik-ty-vs-mypy-eval--blog-candidate----gptma.md"
 
 
 def _transport(tmp_path: Path, deliver=None) -> AgentTransport:
@@ -23,8 +29,9 @@ def _transport(tmp_path: Path, deliver=None) -> AgentTransport:
 
 
 def _frontmatter(path: Path) -> dict:
-    parts = path.read_text().split("---", 2)
-    return yaml.safe_load(parts[1])
+    meta = meta_of(path)
+    assert meta is not None
+    return meta
 
 
 def test_satisfies_protocol(tmp_path: Path) -> None:
@@ -170,3 +177,58 @@ def test_conversation_id_is_order_free_pair(tmp_path: Path) -> None:
 
 def test_conversation_id_falls_back_when_unknown(tmp_path: Path) -> None:
     assert _transport(tmp_path).conversation_id_for("ghost.md") == "agent:ghost.md"
+
+
+# -- frontmatter ``---``-in-value corruption (Erik bug report 2026-06-15) -----
+
+
+def test_split_frontmatter_value_containing_fence_is_lossless() -> None:
+    # A ``---`` inside the in_reply_to value must NOT end the block, and the
+    # split must rejoin losslessly so rewrite paths don't corrupt the file.
+    doc = f"---\nfrom: bob\nto: erik\nin_reply_to: {DASHRUN_ID}\nread: false\n---\n\nthe body\n"
+    parts = split_frontmatter(doc)
+    assert parts is not None
+    assert "---".join(parts) == doc
+    meta = yaml.safe_load(parts[1])
+    assert meta["in_reply_to"] == DASHRUN_ID
+
+
+def test_split_frontmatter_none_without_block() -> None:
+    assert split_frontmatter("no frontmatter here\n") is None
+    assert split_frontmatter("---\nunterminated: true\n") is None
+
+
+def test_reply_to_with_dashrun_roundtrips(tmp_path: Path) -> None:
+    t = _transport(tmp_path)
+    mid = t.send("bob", "Re: x", "reply body", reply_to=DASHRUN_ID)
+    assert _frontmatter(t.outbox / mid)["in_reply_to"] == DASHRUN_ID
+
+
+def test_read_preserves_dashrun_in_reply_to(tmp_path: Path) -> None:
+    # Marking ``read: false`` -> ``read: true`` must not mangle an in_reply_to
+    # that contains ``---`` (the rewrite path used a naive split).
+    alice = _transport(tmp_path)
+    bob = AgentTransport(
+        tmp_path / "bob-messages", "bob", deliver=AgentTransport.local_deliver(alice.inbox)
+    )
+    mid = bob.send("alice", "Re: thread", "answer", reply_to=DASHRUN_ID)
+    alice.read(mid)
+    meta = _frontmatter(alice.inbox / mid)
+    assert meta["read"] is True
+    assert meta["in_reply_to"] == DASHRUN_ID
+
+
+def test_delivery_failure_preserves_dashrun_in_reply_to(tmp_path: Path) -> None:
+    # The delivered:false stamp rewrites frontmatter too — must stay intact.
+    t = _transport(tmp_path, deliver=lambda path, recipient: False)
+    mid = t.send("bob", "Re: x", "body", reply_to=DASHRUN_ID)
+    meta = _frontmatter(t.outbox / mid)
+    assert meta["delivered"] is False
+    assert meta["in_reply_to"] == DASHRUN_ID
+
+
+def test_make_filename_never_contains_fence(tmp_path: Path) -> None:
+    # New message-ids must never carry a ``---`` run (protects external pollers).
+    t = _transport(tmp_path)
+    mid = t.send("bob", "ty vs mypy eval -- blog candidate -- gptma", "body")
+    assert "---" not in mid


### PR DESCRIPTION
## Problem (Erik bug report, 2026-06-15)

A reply's `in_reply_to` carries the source inbox **filename**. Sanitized subjects can leave a run of dashes + a `.md` tail (e.g. `...blog-candidate----gptma.md`), so the value literally contains `---`. Every frontmatter parser in the agent transport used `content.split("---", 2)`, which splits on the `---` **inside that value** — truncating the YAML block. The rewrite paths (read-stamp, delivered-false, replied) then reinserted keys into the *middle* of the value, silently corrupting threading:

```
in_reply_to: 20260615-...--blog-candidate
read: true
delivered: false
----gptma.md          <- leaked filename tail, breaks the YAML block
---
```

## Why quoting alone doesn't fix it

Erik suggested quoting the value on emit. That doesn't fix it: a quoted value *still contains* `---`, so a naive-split parser still truncates — worse, it cuts mid-quote so `yaml.safe_load` fails and the **whole** meta is lost. The structural fix is a line-anchored parser.

## Fix

- **`split_frontmatter()`** — splits only on a `---` occupying its own line; returns the same 3-part shape as `split("---", 2)` and is losslessly rejoinable via `"---".join(parts)`. Routed `meta_of` + all four rewrite/parse sites through it (transport: `meta_of`, delivered-false, mark-read; `agent_cli`: `_delivery_failed`, `_mark_replied`).
- **`_slug()`** — collapses dash-runs in `_make_filename` so new message-ids never contain `---`, defending external consumers (Erik's outbox poller) too.

## Tests

5 regression tests: fence-in-value lossless split, `reply_to` round-trip, read-stamp + delivered-false preservation, filename no-fence. Full gptmail suite: **108 passed**. gptmail mypy clean.

Addresses Bug 1 of Erik's report. Bug 2 (pull-only recipient type for `erik`) is tracked separately.

Co-Authored-By: Bob <bob@superuserlabs.org>