### PR TITLE
fix(gptmail): fix frontmatter split on dashes and add pull-only delivery type

### DIFF
--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -145,6 +145,12 @@ def _ssh_deliver(agents: dict[str, dict[str, str]]) -> Deliver:
                 err=True,
             )
             return False
+        # Pull-only recipients (e.g. humans who poll the outbox) have no SSH
+        # target — write the message to the outbox and report success so the
+        # message is NOT stamped ``delivered: false`` (which would make every
+        # poll re-compose a fresh, duplicate reply).
+        if agent.get("delivery") == "pull-only":
+            return True
         missing = [k for k in ("ssh", "workspace") if not agent.get(k)]
         if missing:
             click.echo(

--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -48,7 +48,7 @@ from gptmail.communication_utils.state.tracking import (
     ConversationTracker,
     MessageState,
 )
-from gptmail.transport.agent import AgentTransport, Deliver, meta_of
+from gptmail.transport.agent import AgentTransport, Deliver, _FM_DELIM, meta_of
 
 
 # Inbox messages older than this (days) are assumed handled and no longer
@@ -205,7 +205,7 @@ def _delivery_failed(message_id: str) -> bool:
         return False
     if not content.startswith("---"):
         return False
-    parts = content.split("---", 2)
+    parts = _FM_DELIM.split(content, maxsplit=2)
     return len(parts) >= 3 and any(
         line.strip() == "delivered: false" for line in parts[1].splitlines()
     )
@@ -303,7 +303,7 @@ def _mark_replied(messages_dir: Path, message_id: str) -> None:
     content = path.read_text()
     if not content.startswith("---"):
         return
-    parts = content.split("---", 2)
+    parts = _FM_DELIM.split(content, maxsplit=2)
     if len(parts) < 3:
         return
     fm = re.sub(r"^read: false$", "read: true", parts[1], flags=re.MULTILINE)

--- a/packages/gptmail/src/gptmail/transport/agent.py
+++ b/packages/gptmail/src/gptmail/transport/agent.py
@@ -36,6 +36,12 @@ import yaml
 # delivery succeeded. None means local-only (tests, single-host).
 Deliver = Callable[[Path, str], bool]
 
+# YAML frontmatter delimiter: "---" on its own line.  A plain str.split("---")
+# would also split on "---" inside YAML values, e.g. inbox filenames whose
+# sanitised subjects contain long runs of dashes (like "...candidate----gptma.md").
+# The correct delimiter is three dashes occupying an entire line.
+_FM_DELIM = re.compile(r"^---[ \t]*$", re.MULTILINE)
+
 
 def meta_of(path: Path) -> dict | None:
     """Parse the YAML frontmatter of a message file (``None`` if absent/invalid).
@@ -49,7 +55,7 @@ def meta_of(path: Path) -> dict | None:
         return None
     if not content.startswith("---"):
         return None
-    parts = content.split("---", 2)
+    parts = _FM_DELIM.split(content, maxsplit=2)
     if len(parts) < 3:
         return None
     try:
@@ -176,7 +182,7 @@ class AgentTransport:
         content = local_path.read_text()
         if not content.startswith("---"):
             return
-        parts = content.split("---", 2)
+        parts = _FM_DELIM.split(content, maxsplit=2)
         if len(parts) < 3:
             return
         fm = parts[1]
@@ -231,7 +237,7 @@ class AgentTransport:
     def _mark_read(self, path: Path) -> str:
         content = path.read_text()
         if content.startswith("---"):
-            parts = content.split("---", 2)
+            parts = _FM_DELIM.split(content, maxsplit=2)
             if len(parts) >= 3 and "read: false" in parts[1]:
                 parts[1] = re.sub(r"^read: false$", "read: true", parts[1], flags=re.MULTILINE)
                 content = "---".join(parts)

--- a/packages/gptmail/tests/test_agent_cli.py
+++ b/packages/gptmail/tests/test_agent_cli.py
@@ -170,6 +170,47 @@ def test_ssh_deliver_missing_key_returns_false(tmp_path: Path, entry: dict) -> N
     assert deliver(msg, "bob") is False
 
 
+def test_ssh_deliver_pull_only_returns_true(tmp_path: Path) -> None:
+    """A pull-only registry entry returns True without any SSH/SCP attempt.
+
+    Pull-only recipients (e.g. Erik, who polls outboxes) have no inbound SSH
+    target.  Returning True signals successful 'delivery' so the outbox message
+    is NOT stamped ``delivered: false``.
+    """
+    deliver = agent_cli._ssh_deliver({"erik": {"delivery": "pull-only"}})
+    msg = tmp_path / "msg.md"
+    msg.write_text("---\nto: erik\n---\n\nbody\n")
+    assert deliver(msg, "erik") is True
+
+
+def test_send_to_pull_only_recipient_exits_zero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``send`` to a pull-only recipient writes to outbox, exits 0, no failure stamp.
+
+    Regression for the 'unknown agent' exit-1 bug: Erik is registered as pull-only
+    (no ssh/workspace keys), so ``send``/``reply`` must write to the outbox and
+    return 0 rather than failing with "unknown agent" or stamping delivered:false.
+    """
+    messages = tmp_path / "messages"
+    (messages / "inbox").mkdir(parents=True)
+    (messages / "outbox").mkdir(parents=True)
+    (messages / "agents.yaml").write_text(yaml.dump({"erik": {"delivery": "pull-only"}}))
+    monkeypatch.setenv("AGENT_NAME", "alice")
+    monkeypatch.setattr(agent_cli, "_repo_root", lambda: tmp_path)
+    # Do NOT patch _ssh_deliver — we want the real pull-only path to run.
+
+    result = CliRunner().invoke(agent, ["send", "erik", "Hello Erik", "body text"])
+    assert result.exit_code == 0, result.output
+    assert "Sent to erik" in result.output
+
+    files = list((messages / "outbox").glob("*.md"))
+    assert len(files) == 1
+    meta = yaml.safe_load(files[0].read_text().split("---", 2)[1])
+    assert meta["to"] == "erik"
+    assert "delivered" not in meta  # pull-only returns True → no failure stamp
+
+
 def test_send_stamps_tracker_channel_agent(workspace: Path) -> None:
     CliRunner().invoke(agent, ["send", "bob", "Hello", "body"])
     tracker = ConversationTracker(workspace / "messages" / ".tracking")

--- a/packages/gptmail/tests/test_agent_transport.py
+++ b/packages/gptmail/tests/test_agent_transport.py
@@ -12,10 +12,9 @@ See task: fold-agent-msg-into-gptmail-single-comms-tool.
 from pathlib import Path
 
 import pytest
-import yaml
 
 from gptmail.transport import Transport
-from gptmail.transport.agent import AgentTransport
+from gptmail.transport.agent import AgentTransport, meta_of
 
 
 def _transport(tmp_path: Path, deliver=None) -> AgentTransport:
@@ -23,8 +22,9 @@ def _transport(tmp_path: Path, deliver=None) -> AgentTransport:
 
 
 def _frontmatter(path: Path) -> dict:
-    parts = path.read_text().split("---", 2)
-    return yaml.safe_load(parts[1])
+    meta = meta_of(path)
+    assert meta is not None, f"No valid YAML frontmatter in {path}"
+    return meta
 
 
 def test_satisfies_protocol(tmp_path: Path) -> None:
@@ -170,3 +170,66 @@ def test_conversation_id_is_order_free_pair(tmp_path: Path) -> None:
 
 def test_conversation_id_falls_back_when_unknown(tmp_path: Path) -> None:
     assert _transport(tmp_path).conversation_id_for("ghost.md") == "agent:ghost.md"
+
+
+# -- Regression: naive str.split("---") splits inside YAML values ------------
+
+
+def test_meta_of_survives_dashes_in_in_reply_to(tmp_path: Path) -> None:
+    """meta_of must not be confused by '---' appearing inside a YAML value.
+
+    Inbox filenames are sanitised from message subjects and can contain long
+    runs of dashes (e.g. '...blog-candidate----gptma.md').  Storing such a
+    filename in the ``in_reply_to`` field and then splitting the whole file
+    content on the literal string '---' truncates the value and corrupts
+    threading.  The fix: split only on '---' that occupies an entire line.
+    """
+    tricky_id = "20260615-120000-000000-erik-ty-vs-mypy-eval--blog-candidate----gptma.md"
+    msg_path = tmp_path / "tricky.md"
+    msg_path.write_text(
+        f"---\nfrom: bob\nto: alice\ntimestamp: 2026-06-15T12:00:00Z\n"
+        f"subject: Reply\nread: false\nin_reply_to: {tricky_id}\n---\n\nbody\n"
+    )
+    meta = meta_of(msg_path)
+    assert meta is not None
+    assert (
+        meta["in_reply_to"] == tricky_id
+    ), f"in_reply_to was truncated: {meta.get('in_reply_to')!r}"
+    assert meta["from"] == "bob"
+
+
+def test_delivery_failure_stamp_survives_dashes_in_in_reply_to(tmp_path: Path) -> None:
+    """_stamp_delivery_failed must not corrupt frontmatter with '---' in values."""
+    tricky_id = "20260615-120000-000000-erik-ty-vs-mypy-eval--blog-candidate----gptma.md"
+    t = _transport(tmp_path)
+    # Write a pre-formed outbox file with the tricky in_reply_to
+    out_path = t.outbox / "reply.md"
+    out_path.write_text(
+        f"---\nfrom: alice\nto: bob\ntimestamp: 2026-06-15T12:00:00Z\n"
+        f"subject: Reply\nread: false\nin_reply_to: {tricky_id}\n---\n\nbody\n"
+    )
+    t._stamp_delivery_failed(out_path)
+    meta = _frontmatter(out_path)
+    assert (
+        meta["in_reply_to"] == tricky_id
+    ), f"in_reply_to was corrupted: {meta.get('in_reply_to')!r}"
+    assert meta["delivered"] is False
+
+
+def test_mark_read_survives_dashes_in_in_reply_to(tmp_path: Path) -> None:
+    """_mark_read must not corrupt frontmatter with '---' inside a value."""
+    tricky_id = "20260615-120000-000000-erik-ty-vs-mypy-eval--blog-candidate----gptma.md"
+    t = _transport(tmp_path)
+    # Manually place a message with the tricky in_reply_to in alice's inbox
+    inbox_path = t.inbox / "tricky.md"
+    inbox_path.write_text(
+        f"---\nfrom: bob\nto: alice\ntimestamp: 2026-06-15T12:00:00Z\n"
+        f"subject: Reply\nread: false\nin_reply_to: {tricky_id}\n---\n\nbody\n"
+    )
+    content = t.read("tricky.md")
+    assert "body" in content
+    meta = _frontmatter(inbox_path)
+    assert meta["read"] is True
+    assert (
+        meta["in_reply_to"] == tricky_id
+    ), f"in_reply_to was corrupted: {meta.get('in_reply_to')!r}"


### PR DESCRIPTION
## Summary

Fixes two confirmed bugs in `gptmail agent reply` reported by Erik:

**Bug 1 — frontmatter split on embedded `---`**

`meta_of`, `_stamp_delivery_failed`, and `_mark_read` all used `content.split("---", 2)`, which also splits on `---` embedded inside YAML values. Inbox filenames are sanitised from message subjects and can contain long runs of dashes (e.g. `...blog-candidate----gptma.md`). Storing such a filename in `in_reply_to` and then calling `split("---")` truncates the value and corrupts message threading.

Fix: replace all three calls with a compiled regex `_FM_DELIM = re.compile(r"^---[ \t]*$", re.MULTILINE)` that matches only a delimiter occupying an entire line.

**Bug 2 — `reply` to `erik` exits 1 with `delivered: false`**

`_ssh_deliver` raised "unknown agent" for `erik` because he has no inbound SSH entry in `agents.yaml`. Erik deliberately has no inbound SSH target — he polls agent outboxes instead. Delivering to him should write to the outbox cleanly and return exit 0 (no `delivered: false` stamp, or every poll would compose a fresh duplicate reply).

Fix: add a `delivery: pull-only` registry type to `agents.yaml`; `_ssh_deliver` returns `True` immediately for pull-only recipients.

## Test plan

- [x] `test_meta_of_survives_dashes_in_in_reply_to` — regression for Bug 1 in `meta_of`
- [x] `test_delivery_failure_stamp_survives_dashes_in_in_reply_to` — regression for Bug 1 in `_stamp_delivery_failed`
- [x] `test_mark_read_survives_dashes_in_in_reply_to` — regression for Bug 1 in `_mark_read`
- [x] `test_ssh_deliver_pull_only_returns_true` — regression for Bug 2 in `_ssh_deliver`
- [x] `test_send_to_pull_only_recipient_exits_zero` — end-to-end regression for Bug 2
- [x] All 107 gptmail tests pass locally