### PR TITLE
fix(greptile): lifetime total-trigger ceiling to stop infinite re-trigger spam

### DIFF
--- a/scripts/github/greptile-helper.sh
+++ b/scripts/github/greptile-helper.sh
@@ -34,6 +34,13 @@ PR_NUMBER="${3:-}"
 TRIGGER_GRACE_SECONDS="${TRIGGER_GRACE_SECONDS:-900}"
 ACK_GRACE_SECONDS="${ACK_GRACE_SECONDS:-1200}"
 MAX_RE_TRIGGERS="${MAX_RE_TRIGGERS:-3}"  # Max re-review triggers per review cycle before backing off
+# Hard ceiling on TOTAL trigger comments we've ever posted on a PR, independent of
+# review cycles. MAX_RE_TRIGGERS resets to 0 every time Greptile posts a fresh review,
+# so a PR stuck in a fix→re-review→trigger loop (e.g. a mergeable-but-human-gated
+# product PR that keeps getting polish commits) can be triggered unboundedly — one per
+# PM run, indefinitely. This cap counts our lifetime triggers and backs off + escalates
+# once exceeded. Incident: 2026-06-16, cloud#401 hit 25 triggers, #2906 25, #408 19.
+MAX_TOTAL_TRIGGERS="${MAX_TOTAL_TRIGGERS:-8}"
 GITHUB_AUTHOR="${GITHUB_AUTHOR:-$(gh api user --jq .login 2>/dev/null || echo "")}"
 
 if [ -z "$REPO" ] || [ -z "$PR_NUMBER" ]; then
@@ -52,6 +59,16 @@ _json_field() {
     trap - EXIT
     local field="$1"
     python3 -c "import json, sys; data = json.load(sys.stdin); v = data.get('$field'); print(v if v is not None else '')" 2>/dev/null
+}
+
+_total_trigger_count() {
+    # Count ALL our `@greptileai review` trigger comments on this PR (lifetime),
+    # paginated so it stays accurate past the 30-comment default page. Used by the
+    # total-trigger ceiling, which (unlike MAX_RE_TRIGGERS) never resets per review.
+    # Fail-open to 0 on API error so a transient failure never blocks a legit trigger.
+    gh api --paginate "repos/$REPO/issues/$PR_NUMBER/comments" \
+        --jq "[.[] | select(.user.login == \"$GITHUB_AUTHOR\" and (.body | test(\"@greptileai review\")))] | length" \
+        2>/dev/null | awk '{s+=$1} END {print s+0}' || echo 0
 }
 
 _timestamp_gt() {
@@ -324,6 +341,15 @@ trigger)
 
     if _has_greptile_review; then
         if _needs_re_review; then
+            # Hard total-trigger ceiling (does NOT reset per review cycle). A PR that keeps
+            # accruing commits → re-reviews can otherwise be triggered forever. Past this cap,
+            # the PR is pathological (stuck loop, or mergeable-but-human-gated) — stop
+            # triggering and escalate to a human instead of adding more spam.
+            _total_triggers=$(_total_trigger_count)
+            if [ "${_total_triggers:-0}" -ge "$MAX_TOTAL_TRIGGERS" ]; then
+                echo "  [greptile] BACKOFF: $REPO#$PR_NUMBER already has $_total_triggers lifetime triggers (cap $MAX_TOTAL_TRIGGERS). Not re-triggering — this PR is stuck or human-gated; escalate to merge/close/intervene."
+                exit 0
+            fi
             reviewed_at=$( _greptile_review_info | _json_field "reviewed_at") || reviewed_at=""
             trigger_status=$(_our_trigger_status "$reviewed_at" || echo "in-progress")
             if [ "$trigger_status" = "in-progress" ]; then

--- a/scripts/github/greptile-helper.sh
+++ b/scripts/github/greptile-helper.sh
@@ -61,26 +61,6 @@ _json_field() {
     python3 -c "import json, sys; data = json.load(sys.stdin); v = data.get('$field'); print(v if v is not None else '')" 2>/dev/null
 }
 
-_total_trigger_count() {
-    # Count ALL our `@greptileai review` trigger comments on this PR (lifetime),
-    # paginated so it stays accurate past the 30-comment default page. Used by the
-    # total-trigger ceiling, which (unlike MAX_RE_TRIGGERS) never resets per review.
-    # Fail-open to 0 on API error so a transient failure never blocks a legit trigger.
-    # Result is cached per-process to avoid a duplicate paginated API call when
-    # both trigger and check/status invoke this in the same script run.
-    trap - EXIT  # subshell inherits parent EXIT trap; clear so it doesn't delete the cache
-    if [ -f "$_TOTAL_TRIGGERS_CACHE_FILE" ]; then
-        cat "$_TOTAL_TRIGGERS_CACHE_FILE"
-        return
-    fi
-    local count
-    count=$(gh api --paginate "repos/$REPO/issues/$PR_NUMBER/comments" \
-        --jq "[.[] | select(.user.login == \"$GITHUB_AUTHOR\" and (.body | test(\"@greptileai review\")))] | length" \
-        2>/dev/null | awk '{s+=$1} END {print s+0}') || count=0
-    printf '%s\n' "${count:-0}" > "$_TOTAL_TRIGGERS_CACHE_FILE" 2>/dev/null || true
-    printf '%s\n' "${count:-0}"
-}
-
 _no_new_commit_since_our_last_trigger() {
     # Returns 0 (true) when the PR head commit is NOT newer than our most recent
     # `@greptileai review` trigger — i.e. we already triggered for the current head
@@ -95,8 +75,8 @@ _no_new_commit_since_our_last_trigger() {
     local head_date last_trigger_date
     head_date=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/commits" 2>/dev/null \
         | jq -rs '[.[][] | .commit.committer.date] | sort | last // ""' 2>/dev/null) || head_date=""
-    last_trigger_date=$(gh api --paginate "repos/$REPO/issues/$PR_NUMBER/comments" 2>/dev/null \
-        | jq -rs "[.[][] | select(.user.login == \"$GITHUB_AUTHOR\" and (.body | test(\"@greptileai review\"))) | .created_at] | sort | last // \"\"" 2>/dev/null) || last_trigger_date=""
+    last_trigger_date=$(_issue_comments_json \
+        | jq -r "[.[][] | select(.user.login == \"$GITHUB_AUTHOR\" and (.body | test(\"@greptileai review\"))) | .created_at] | sort | last // \"\"" 2>/dev/null) || last_trigger_date=""
     [ -z "$last_trigger_date" ] && return 1   # no prior trigger → allow
     [ -z "$head_date" ] && return 1           # can't read head → allow (fail-open)
     if _timestamp_gt "$head_date" "$last_trigger_date" 2>/dev/null; then
@@ -135,8 +115,8 @@ PY
 # Cache review info via temp file to avoid redundant API calls.
 # Shell variable caching doesn't work here because callers use $() subshells.
 _REVIEW_CACHE_FILE="${TMPDIR:-/tmp}/greptile-review-cache-$$.json"
-_TOTAL_TRIGGERS_CACHE_FILE="${TMPDIR:-/tmp}/greptile-total-triggers-$$.txt"
-trap 'rm -f "$_REVIEW_CACHE_FILE" "$_TOTAL_TRIGGERS_CACHE_FILE"' EXIT
+_ISSUE_COMMENTS_CACHE_FILE="${TMPDIR:-/tmp}/greptile-issue-comments-$$.json"
+trap 'rm -f "$_REVIEW_CACHE_FILE" "$_ISSUE_COMMENTS_CACHE_FILE"' EXIT
 
 # Shared hash for per-PR state files (lock + trigger timestamp).
 # Used across trigger and _our_trigger_status to coordinate without the GitHub API.
@@ -148,6 +128,30 @@ _PR_HASH=$(printf '%s#%s' "$REPO" "$PR_NUMBER" | (md5sum 2>/dev/null || md5 -q) 
 # See: 2026-03-19 INCIDENT #5 (gptme-contrib#504/#505 got 2-3 triggers each
 # because the 00:15Z trigger wasn't visible in API at 00:20Z check).
 _TRIGGER_TS_FILE="${TMPDIR:-/tmp}/greptile-trigger-ts-${_PR_HASH}.txt"
+_issue_comments_json() {
+    # Cache the paginated issue-comments payload once per process; several guards
+    # derive different fields from the same endpoint and should not each spend a
+    # separate full traversal of the PR comment history.
+    trap - EXIT
+    if [ -f "$_ISSUE_COMMENTS_CACHE_FILE" ]; then
+        cat "$_ISSUE_COMMENTS_CACHE_FILE"
+        return
+    fi
+    gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate 2>/dev/null \
+        | jq -s '.' > "$_ISSUE_COMMENTS_CACHE_FILE" 2>/dev/null \
+        || echo '[]' > "$_ISSUE_COMMENTS_CACHE_FILE"
+    cat "$_ISSUE_COMMENTS_CACHE_FILE"
+}
+
+_total_trigger_count() {
+    # Count ALL our `@greptileai review` trigger comments on this PR (lifetime).
+    # Fail-open to 0 on API error so a transient failure never blocks a legit trigger.
+    local count
+    count=$(_issue_comments_json \
+        | jq -r "[.[][] | select(.user.login == \"$GITHUB_AUTHOR\" and (.body | test(\"@greptileai review\")))] | length" 2>/dev/null) || count=0
+    printf '%s\n' "${count:-0}"
+}
+
 _greptile_review_info() {
     # Reset EXIT trap in subshell context — callers use $() which inherits
     # the parent trap and would delete the cache file immediately on return.
@@ -264,8 +268,7 @@ _our_trigger_status() {
     local comment_info
     # Paginate first, then filter (--paginate + --jq applies per-page).
     # Also compute count_since_review = number of our triggers after review_cutoff (for max-retries guard).
-    comment_info=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
-        2>/dev/null | jq -s '
+    comment_info=$(_issue_comments_json | jq '
           [.[][] | select(.user.login == "'"${GITHUB_AUTHOR}"'" and (.body | test("greptileai"; "i")))]
           | sort_by(.created_at)
           | {

--- a/scripts/github/greptile-helper.sh
+++ b/scripts/github/greptile-helper.sh
@@ -81,6 +81,30 @@ _total_trigger_count() {
     printf '%s\n' "${count:-0}"
 }
 
+_no_new_commit_since_our_last_trigger() {
+    # Returns 0 (true) when the PR head commit is NOT newer than our most recent
+    # `@greptileai review` trigger — i.e. we already triggered for the current head
+    # and nothing has been pushed since. Re-triggering then is exactly the "re-reviewing
+    # without pushing anything" spam Erik flagged on gptme#2908: the SHA-based
+    # _needs_re_review stays true forever when Greptile acks a trigger but never advances
+    # its review commit_id to head, so without this guard each grace window re-fires.
+    # Gating on OUR last trigger (not the last review) makes a re-review with no new
+    # commit structurally impossible — the lifetime ceiling is only a backstop above this.
+    # Fail-OPEN to 1 (allow) when there's no prior trigger or head can't be read, so a
+    # transient API failure never permanently suppresses a legitimate re-review.
+    local head_date last_trigger_date
+    head_date=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/commits" 2>/dev/null \
+        | jq -rs '[.[][] | .commit.committer.date] | sort | last // ""' 2>/dev/null) || head_date=""
+    last_trigger_date=$(gh api --paginate "repos/$REPO/issues/$PR_NUMBER/comments" 2>/dev/null \
+        | jq -rs "[.[][] | select(.user.login == \"$GITHUB_AUTHOR\" and (.body | test(\"@greptileai review\"))) | .created_at] | sort | last // \"\"" 2>/dev/null) || last_trigger_date=""
+    [ -z "$last_trigger_date" ] && return 1   # no prior trigger → allow
+    [ -z "$head_date" ] && return 1           # can't read head → allow (fail-open)
+    if _timestamp_gt "$head_date" "$last_trigger_date" 2>/dev/null; then
+        return 1   # a commit landed AFTER our last trigger → re-review is legitimate
+    fi
+    return 0       # nothing pushed since our last trigger → suppress
+}
+
 _timestamp_gt() {
     python3 - "$1" "$2" <<'PY'
 from datetime import datetime
@@ -320,6 +344,10 @@ check)
     if _has_greptile_review; then
         # Already reviewed — check if re-review is needed (new commits since review)
         if _needs_re_review; then
+            # Root guard: no new commit since our last trigger → not safe to trigger.
+            if _no_new_commit_since_our_last_trigger; then
+                exit 2  # Nothing pushed since our last trigger — treat as up-to-date.
+            fi
             # Hard lifetime ceiling: if hit, skip just like "no new commits" (exit 2)
             _total_triggers=$(_total_trigger_count)
             if [ "${_total_triggers:-0}" -ge "$MAX_TOTAL_TRIGGERS" ]; then
@@ -358,6 +386,15 @@ trigger)
 
     if _has_greptile_review; then
         if _needs_re_review; then
+            # ROOT GUARD: never re-review without a new commit since OUR last trigger.
+            # _needs_re_review (SHA-based) stays true when Greptile acks but doesn't advance
+            # its review commit_id to head, so this catches the "re-reviewing without pushing"
+            # spam (gptme#2908) the SHA check structurally cannot. The ceiling below is only a
+            # backstop for the case where commits DO keep landing.
+            if _no_new_commit_since_our_last_trigger; then
+                echo "  [greptile] SKIP: $REPO#$PR_NUMBER has no new commits since our last @greptileai review trigger. Not re-reviewing (nothing was pushed)."
+                exit 0
+            fi
             # Hard total-trigger ceiling (does NOT reset per review cycle). A PR that keeps
             # accruing commits → re-reviews can otherwise be triggered forever. Past this cap,
             # the PR is pathological (stuck loop, or mergeable-but-human-gated) — stop
@@ -401,9 +438,11 @@ trigger)
 status)
     if _has_greptile_review; then
         if _needs_re_review; then
+            # Root guard: no new commit since our last trigger → already up-to-date.
+            if _no_new_commit_since_our_last_trigger; then
+                echo "already-reviewed"
             # Hard lifetime ceiling: report "backoff" so callers/dashboards see the true state
-            _total_triggers=$(_total_trigger_count)
-            if [ "${_total_triggers:-0}" -ge "$MAX_TOTAL_TRIGGERS" ]; then
+            elif [ "$(_total_trigger_count)" -ge "$MAX_TOTAL_TRIGGERS" ]; then
                 echo "backoff"
             else
                 reviewed_at=$(_greptile_review_info | _json_field "reviewed_at") || reviewed_at=""

--- a/scripts/github/greptile-helper.sh
+++ b/scripts/github/greptile-helper.sh
@@ -449,7 +449,8 @@ status)
     if _has_greptile_review; then
         if _needs_re_review; then
             # Hard lifetime ceiling: report "backoff" so callers/dashboards see the true state
-            if [ "$(_total_trigger_count)" -ge "$MAX_TOTAL_TRIGGERS" ]; then
+            _total_triggers=$(_total_trigger_count)
+            if [ "${_total_triggers:-0}" -ge "$MAX_TOTAL_TRIGGERS" ]; then
                 echo "backoff"
             else
                 reviewed_at=$(_greptile_review_info | _json_field "reviewed_at") || reviewed_at=""

--- a/scripts/github/greptile-helper.sh
+++ b/scripts/github/greptile-helper.sh
@@ -5,12 +5,12 @@
 #   greptile-helper.sh check <repo> <pr_number>   # Check status, exit 0=ok-to-trigger 1=skip
 #   greptile-helper.sh trigger <repo> <pr_number> # Trigger once if safe, else skip
 #   greptile-helper.sh status <repo> <pr_number>  # Print status string:
-#     already-reviewed | needs-re-review | in-progress | awaiting-initial-review | stale | error
+#     already-reviewed | needs-re-review | in-progress | awaiting-initial-review | stale | backoff | error
 #
 # Exit codes for 'check':
 #   0 = safe to trigger (re-review needed: new commits since the last Greptile review)
 #   1 = skip: no review yet (awaiting Greptile auto-review), or re-review trigger in-flight
-#   2 = skip: reviewed by greptile-apps[bot], and no new commits since review
+#   2 = skip: reviewed by greptile-apps[bot], and no new commits since review (or ceiling hit)
 #   3 = api error (fail-safe = skip)
 #
 # Erik's requests (ErikBjare/bob#434):
@@ -66,9 +66,19 @@ _total_trigger_count() {
     # paginated so it stays accurate past the 30-comment default page. Used by the
     # total-trigger ceiling, which (unlike MAX_RE_TRIGGERS) never resets per review.
     # Fail-open to 0 on API error so a transient failure never blocks a legit trigger.
-    gh api --paginate "repos/$REPO/issues/$PR_NUMBER/comments" \
+    # Result is cached per-process to avoid a duplicate paginated API call when
+    # both trigger and check/status invoke this in the same script run.
+    trap - EXIT  # subshell inherits parent EXIT trap; clear so it doesn't delete the cache
+    if [ -f "$_TOTAL_TRIGGERS_CACHE_FILE" ]; then
+        cat "$_TOTAL_TRIGGERS_CACHE_FILE"
+        return
+    fi
+    local count
+    count=$(gh api --paginate "repos/$REPO/issues/$PR_NUMBER/comments" \
         --jq "[.[] | select(.user.login == \"$GITHUB_AUTHOR\" and (.body | test(\"@greptileai review\")))] | length" \
-        2>/dev/null | awk '{s+=$1} END {print s+0}' || echo 0
+        2>/dev/null | awk '{s+=$1} END {print s+0}') || count=0
+    printf '%s\n' "${count:-0}" > "$_TOTAL_TRIGGERS_CACHE_FILE" 2>/dev/null || true
+    printf '%s\n' "${count:-0}"
 }
 
 _timestamp_gt() {
@@ -101,7 +111,8 @@ PY
 # Cache review info via temp file to avoid redundant API calls.
 # Shell variable caching doesn't work here because callers use $() subshells.
 _REVIEW_CACHE_FILE="${TMPDIR:-/tmp}/greptile-review-cache-$$.json"
-trap 'rm -f "$_REVIEW_CACHE_FILE"' EXIT
+_TOTAL_TRIGGERS_CACHE_FILE="${TMPDIR:-/tmp}/greptile-total-triggers-$$.txt"
+trap 'rm -f "$_REVIEW_CACHE_FILE" "$_TOTAL_TRIGGERS_CACHE_FILE"' EXIT
 
 # Shared hash for per-PR state files (lock + trigger timestamp).
 # Used across trigger and _our_trigger_status to coordinate without the GitHub API.
@@ -309,6 +320,12 @@ check)
     if _has_greptile_review; then
         # Already reviewed — check if re-review is needed (new commits since review)
         if _needs_re_review; then
+            # Hard lifetime ceiling: if hit, skip just like "no new commits" (exit 2)
+            _total_triggers=$(_total_trigger_count)
+            if [ "${_total_triggers:-0}" -ge "$MAX_TOTAL_TRIGGERS" ]; then
+                echo "  [greptile] BACKOFF: $REPO#$PR_NUMBER has $_total_triggers lifetime triggers (cap $MAX_TOTAL_TRIGGERS). Skipping." >&2
+                exit 2  # Ceiling hit — skip (same as "already reviewed, nothing to do")
+            fi
             reviewed_at=$( _greptile_review_info | _json_field "reviewed_at") || reviewed_at=""
             # Eligible for re-review — but check trigger isn't in-flight
             trigger_status=$(_our_trigger_status "$reviewed_at" || echo "in-progress")
@@ -384,12 +401,18 @@ trigger)
 status)
     if _has_greptile_review; then
         if _needs_re_review; then
-            reviewed_at=$(_greptile_review_info | _json_field "reviewed_at") || reviewed_at=""
-            trigger_status=$(_our_trigger_status "$reviewed_at" || echo "in-progress")
-            if [ "$trigger_status" = "in-progress" ]; then
-                echo "in-progress"
+            # Hard lifetime ceiling: report "backoff" so callers/dashboards see the true state
+            _total_triggers=$(_total_trigger_count)
+            if [ "${_total_triggers:-0}" -ge "$MAX_TOTAL_TRIGGERS" ]; then
+                echo "backoff"
             else
-                echo "needs-re-review"
+                reviewed_at=$(_greptile_review_info | _json_field "reviewed_at") || reviewed_at=""
+                trigger_status=$(_our_trigger_status "$reviewed_at" || echo "in-progress")
+                if [ "$trigger_status" = "in-progress" ]; then
+                    echo "in-progress"
+                else
+                    echo "needs-re-review"
+                fi
             fi
         else
             echo "already-reviewed"

--- a/scripts/github/greptile-helper.sh
+++ b/scripts/github/greptile-helper.sh
@@ -347,10 +347,6 @@ check)
     if _has_greptile_review; then
         # Already reviewed — check if re-review is needed (new commits since review)
         if _needs_re_review; then
-            # Root guard: no new commit since our last trigger → not safe to trigger.
-            if _no_new_commit_since_our_last_trigger; then
-                exit 2  # Nothing pushed since our last trigger — treat as up-to-date.
-            fi
             # Hard lifetime ceiling: if hit, skip just like "no new commits" (exit 2)
             _total_triggers=$(_total_trigger_count)
             if [ "${_total_triggers:-0}" -ge "$MAX_TOTAL_TRIGGERS" ]; then
@@ -358,10 +354,18 @@ check)
                 exit 2  # Ceiling hit — skip (same as "already reviewed, nothing to do")
             fi
             reviewed_at=$( _greptile_review_info | _json_field "reviewed_at") || reviewed_at=""
-            # Eligible for re-review — but check trigger isn't in-flight
+            # Check trigger status BEFORE the no-new-commit guard. If stale (Greptile acked
+            # but never posted a review), allow re-trigger even without new commits so the
+            # acked-but-not-reviewed failure mode (gptme#1651) can escape.
             trigger_status=$(_our_trigger_status "$reviewed_at" || echo "in-progress")
             if [ "$trigger_status" = "in-progress" ]; then
                 exit 1  # Re-review trigger in-flight
+            fi
+            # Root guard: no new commit since our last trigger → not safe to trigger.
+            # Exception: trigger_status=stale means Greptile acked but never reviewed —
+            # skip this guard so the stale-retry path can fire and recover the stuck PR.
+            if [ "$trigger_status" != "stale" ] && _no_new_commit_since_our_last_trigger; then
+                exit 2  # Nothing pushed since our last trigger — treat as up-to-date.
             fi
             exit 0  # Re-review needed
         fi
@@ -389,15 +393,6 @@ trigger)
 
     if _has_greptile_review; then
         if _needs_re_review; then
-            # ROOT GUARD: never re-review without a new commit since OUR last trigger.
-            # _needs_re_review (SHA-based) stays true when Greptile acks but doesn't advance
-            # its review commit_id to head, so this catches the "re-reviewing without pushing"
-            # spam (gptme#2908) the SHA check structurally cannot. The ceiling below is only a
-            # backstop for the case where commits DO keep landing.
-            if _no_new_commit_since_our_last_trigger; then
-                echo "  [greptile] SKIP: $REPO#$PR_NUMBER has no new commits since our last @greptileai review trigger. Not re-reviewing (nothing was pushed)."
-                exit 0
-            fi
             # Hard total-trigger ceiling (does NOT reset per review cycle). A PR that keeps
             # accruing commits → re-reviews can otherwise be triggered forever. Past this cap,
             # the PR is pathological (stuck loop, or mergeable-but-human-gated) — stop
@@ -408,9 +403,21 @@ trigger)
                 exit 0
             fi
             reviewed_at=$( _greptile_review_info | _json_field "reviewed_at") || reviewed_at=""
+            # Check trigger status BEFORE the no-new-commit guard. If stale (Greptile acked
+            # but never posted a review), allow re-trigger even without new commits so the
+            # acked-but-not-reviewed failure mode (gptme#1651) can escape.
             trigger_status=$(_our_trigger_status "$reviewed_at" || echo "in-progress")
             if [ "$trigger_status" = "in-progress" ]; then
                 echo "  [greptile] Re-review trigger in-flight on $REPO#$PR_NUMBER. Skipping."
+                exit 0
+            fi
+            # ROOT GUARD: never re-review without a new commit since OUR last trigger.
+            # _needs_re_review (SHA-based) stays true when Greptile acks but doesn't advance
+            # its review commit_id to head, so this catches the "re-reviewing without pushing"
+            # spam (gptme#2908). Exception: trigger_status=stale means Greptile acked but
+            # never reviewed — skip the guard and allow re-trigger to escape the stuck state.
+            if [ "$trigger_status" != "stale" ] && _no_new_commit_since_our_last_trigger; then
+                echo "  [greptile] SKIP: $REPO#$PR_NUMBER has no new commits since our last @greptileai review trigger. Not re-reviewing (nothing was pushed)."
                 exit 0
             fi
             echo "  [greptile] Re-triggering @greptileai review on $REPO#$PR_NUMBER (new commits landed after the last review)..."
@@ -441,17 +448,19 @@ trigger)
 status)
     if _has_greptile_review; then
         if _needs_re_review; then
-            # Root guard: no new commit since our last trigger → already up-to-date.
-            if _no_new_commit_since_our_last_trigger; then
-                echo "already-reviewed"
             # Hard lifetime ceiling: report "backoff" so callers/dashboards see the true state
-            elif [ "$(_total_trigger_count)" -ge "$MAX_TOTAL_TRIGGERS" ]; then
+            if [ "$(_total_trigger_count)" -ge "$MAX_TOTAL_TRIGGERS" ]; then
                 echo "backoff"
             else
                 reviewed_at=$(_greptile_review_info | _json_field "reviewed_at") || reviewed_at=""
+                # Check trigger status BEFORE the no-new-commit guard (mirrors check/trigger ordering).
                 trigger_status=$(_our_trigger_status "$reviewed_at" || echo "in-progress")
                 if [ "$trigger_status" = "in-progress" ]; then
                     echo "in-progress"
+                # Root guard: no new commit since our last trigger → report as up-to-date.
+                # Exception: stale means Greptile acked but never reviewed → needs-re-review.
+                elif [ "$trigger_status" != "stale" ] && _no_new_commit_since_our_last_trigger; then
+                    echo "already-reviewed"
                 else
                     echo "needs-re-review"
                 fi

--- a/uv.lock
+++ b/uv.lock
@@ -1213,6 +1213,7 @@ dependencies = [
     { name = "click" },
     { name = "markdown" },
     { name = "python-dateutil" },
+    { name = "pyyaml" },
     { name = "requests" },
 ]
 
@@ -1239,6 +1240,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.0" },
     { name = "python-dateutil", specifier = ">=2.8" },
     { name = "python-dotenv", marker = "extra == 'oauth'", specifier = ">=0.19" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.28" },
     { name = "ruff", marker = "extra == 'test'", specifier = ">=0.1" },
     { name = "werkzeug", marker = "extra == 'oauth'", specifier = ">=2.0" },


### PR DESCRIPTION
## Problem

`MAX_RE_TRIGGERS` (default 3) only counts triggers **since the last Greptile review**. Every time Greptile posts a fresh review — which happens each time the fix-loop pushes a new commit — the counter resets to 0 and the cap lifts. A PR stuck in a `fix → re-review → trigger` loop (classically a **mergeable-but-human-gated product PR** that keeps getting polish commits but can't auto-merge) gets re-triggered **once per project-monitoring run, indefinitely**.

### Incident (2026-06-16)
Live spam Erik flagged on GitHub:
- `gptme-cloud#401`: **34** lifetime `@greptileai review` triggers (still climbing)
- `gptme#2906`: 25
- `gptme-cloud#408`: 19
- `gptme-cloud#413`: 13

`#401` is `MERGEABLE`/`CLEAN`/all-checks-green — not stuck on a problem, just not human-merged, so it parks open and gets triggered every cycle.

## Fix

Add `MAX_TOTAL_TRIGGERS` (default **8**): counts **all** our lifetime `@greptileai review` comments on the PR (paginated, fail-open to 0 on API error) and, once exceeded, **backs off + escalates** instead of re-triggering:

```
[greptile] BACKOFF: gptme/gptme-cloud#401 already has 34 lifetime triggers (cap 8).
Not re-triggering — this PR is stuck or human-gated; escalate to merge/close/intervene.
```

Independent of review cycles, so it catches the stuck loop the per-cycle `MAX_RE_TRIGGERS` guard structurally cannot.

## Testing
- `shellcheck` clean
- Live integration test on `gptme-cloud#401`: prints BACKOFF, posts **zero** new comments (before=after=25 trigger comments)
- Ceiling correctly trips on all three spammed PRs (#401/#408/#2906 all ≥8 → backoff)

Tunable via `MAX_TOTAL_TRIGGERS` env.