### PR TITLE
feat(match-lessons): suppress archived lessons + prevent contrib re-injection

### DIFF
--- a/scripts/claude-code-hooks/match-lessons.py
+++ b/scripts/claude-code-hooks/match-lessons.py
@@ -269,8 +269,11 @@ def scan_lessons(lesson_dirs: list[Path]) -> list[dict]:
                     # lesson_dir. Lexicographic sort puts archive/foo.md before foo.md
                     # so naively registering here would suppress the active copy.
                     active_copy = next(
-                        (p for p in lesson_dir.rglob(f.name)
-                         if "archive" not in p.relative_to(lesson_dir).parts),
+                        (
+                            p
+                            for p in lesson_dir.rglob(f.name)
+                            if "archive" not in p.relative_to(lesson_dir).parts
+                        ),
                         None,
                     )
                     if active_copy is None:

--- a/scripts/claude-code-hooks/match-lessons.py
+++ b/scripts/claude-code-hooks/match-lessons.py
@@ -265,7 +265,16 @@ def scan_lessons(lesson_dirs: list[Path]) -> list[dict]:
             # living under /home/alice/archive/…) don't trigger false suppression.
             if "archive" in f.relative_to(lesson_dir).parts:
                 if f.name != "SKILL.md":
-                    seen_names.add(f.name)
+                    # Only suppress if no active (non-archived) copy exists in this
+                    # lesson_dir. Lexicographic sort puts archive/foo.md before foo.md
+                    # so naively registering here would suppress the active copy.
+                    active_copy = next(
+                        (p for p in lesson_dir.rglob(f.name)
+                         if "archive" not in p.relative_to(lesson_dir).parts),
+                        None,
+                    )
+                    if active_copy is None:
+                        seen_names.add(f.name)
                 continue
 
             # Dedup by filename (first lesson dir wins — local overrides contrib).

--- a/scripts/claude-code-hooks/match-lessons.py
+++ b/scripts/claude-code-hooks/match-lessons.py
@@ -259,6 +259,13 @@ def scan_lessons(lesson_dirs: list[Path]) -> list[dict]:
                 continue
             seen_paths.add(resolved)
 
+            # Skip archived lessons — but still register their name so that
+            # contrib copies are also suppressed (local archive wins over contrib).
+            if "archive" in f.parts:
+                if f.name != "SKILL.md":
+                    seen_names.add(f.name)
+                continue
+
             # Dedup by filename (first lesson dir wins — local overrides contrib).
             # Exception: SKILL.md files are always different skills, not duplicates.
             if f.name != "SKILL.md" and f.name in seen_names:

--- a/scripts/claude-code-hooks/match-lessons.py
+++ b/scripts/claude-code-hooks/match-lessons.py
@@ -261,7 +261,9 @@ def scan_lessons(lesson_dirs: list[Path]) -> list[dict]:
 
             # Skip archived lessons — but still register their name so that
             # contrib copies are also suppressed (local archive wins over contrib).
-            if "archive" in f.parts:
+            # Use relative_to(lesson_dir) so parent path segments (e.g. a workspace
+            # living under /home/alice/archive/…) don't trigger false suppression.
+            if "archive" in f.relative_to(lesson_dir).parts:
                 if f.name != "SKILL.md":
                     seen_names.add(f.name)
                 continue


### PR DESCRIPTION
## Summary

- Adds archive-suppression logic to `match-lessons.py`: if an agent archives a lesson locally (moves it to an `archive/` subdirectory), that copy registers its filename in `seen_names` so the contrib canonical copy is also suppressed
- **Local archive wins over contrib** — prevents re-injection of intentionally archived lessons
- `SKILL.md` files are excluded from name-dedup (each is a unique skill)

## Motivation

Upstreamed from Alice's workspace where this logic was developed locally. Part of the fleet-wide match-lessons symlink adoption (all agents → contrib canonical).

## Test plan

- [ ] Archive a lesson locally in an agent workspace (`mv lessons/foo.md lessons/archive/foo.md`)
- [ ] Verify the archived lesson is NOT injected (even if `gptme-contrib/lessons/foo.md` exists)
- [ ] Verify non-archived lessons still inject normally
- [ ] Verify `SKILL.md` files are unaffected by archive-suppression