### PR TITLE
feat(gptmail): add named local mailboxes to agent CLI

### DIFF
--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -119,16 +119,17 @@ def _known_mailboxes() -> list[str]:
 
 def _selected_mailboxes(mailbox: str, all_mailboxes: bool) -> list[str]:
     if all_mailboxes:
+        if mailbox not in (None, "default"):
+            raise click.BadParameter(
+                "--mailbox and --all-mailboxes are mutually exclusive",
+                param_hint="--mailbox",
+            )
         return _known_mailboxes()
     return [_normalize_mailbox(mailbox)]
 
 
-def _mailbox_label(mailbox: str) -> str:
-    return mailbox if mailbox != "default" else "default"
-
-
 def _format_mailbox_prefix(mailbox: str, *, show: bool) -> str:
-    return f"[{_mailbox_label(mailbox)}] " if show else ""
+    return f"[{mailbox}] " if show else ""
 
 
 def _within(base: Path, *parts: str) -> Path | None:
@@ -379,6 +380,8 @@ def _pending_messages(
 
 def _mark_replied(path: Path) -> None:
     """Stamp an inbox message ``replied: true`` (and ``read: true``). Idempotent."""
+    if not path.exists():
+        return
     content = path.read_text()
     if not content.startswith("---"):
         return
@@ -646,8 +649,7 @@ def status(mailbox: str, all_mailboxes: bool) -> None:
     click.echo(f"Agent:    {_self_name()}")
     click.echo(f"Registry: {', '.join(agents) or '(none)'}")
     click.echo(
-        "Mailbox:  "
-        + (_mailbox_label(mailboxes[0]) if len(mailboxes) == 1 else ", ".join(mailboxes))
+        f"Mailbox:  {mailboxes[0] if len(mailboxes) == 1 else ', '.join(mailboxes)}"
     )
     click.echo(f"Inbox:    {inbox_count}")
     click.echo(f"Outbox:   {outbox_count}")

--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -89,6 +89,48 @@ def _messages_dir() -> Path:
     return _repo_root() / "messages"
 
 
+def _normalize_mailbox(mailbox: str) -> str:
+    try:
+        return AgentTransport._normalize_mailbox(mailbox)
+    except ValueError as e:
+        raise click.BadParameter(str(e), param_hint="--mailbox")
+
+
+def _mailbox_root(mailbox: str = "default") -> Path:
+    return AgentTransport.mailbox_dir(_messages_dir(), _normalize_mailbox(mailbox))
+
+
+def _known_mailboxes() -> list[str]:
+    mailboxes = ["default"]
+    root = _messages_dir() / "mailboxes"
+    if not root.exists():
+        return mailboxes
+    for child in sorted(root.iterdir()):
+        if not child.is_dir():
+            continue
+        try:
+            name = _normalize_mailbox(child.name)
+        except click.BadParameter:
+            continue
+        if name != "default":
+            mailboxes.append(name)
+    return mailboxes
+
+
+def _selected_mailboxes(mailbox: str, all_mailboxes: bool) -> list[str]:
+    if all_mailboxes:
+        return _known_mailboxes()
+    return [_normalize_mailbox(mailbox)]
+
+
+def _mailbox_label(mailbox: str) -> str:
+    return mailbox if mailbox != "default" else "default"
+
+
+def _format_mailbox_prefix(mailbox: str, *, show: bool) -> str:
+    return f"[{_mailbox_label(mailbox)}] " if show else ""
+
+
 def _within(base: Path, *parts: str) -> Path | None:
     """Resolve ``base/parts`` and return it only if it stays inside ``base``.
 
@@ -131,7 +173,7 @@ def _tracker() -> ConversationTracker:
     return ConversationTracker(_messages_dir() / ".tracking")
 
 
-def _ssh_deliver(agents: dict[str, dict[str, str]]) -> Deliver:
+def _ssh_deliver(agents: dict[str, dict[str, str]], *, mailbox: str = "default") -> Deliver:
     """Build a ``deliver`` hook that SCPs a message into a recipient's inbox.
 
     Returns False (so the transport stamps ``delivered: false``) on unknown
@@ -160,7 +202,11 @@ def _ssh_deliver(agents: dict[str, dict[str, str]]) -> Deliver:
             )
             return False
         ssh_target = agent["ssh"]
-        remote_inbox = f"{agent['workspace']}/messages/inbox/"
+        remote_root = f"{agent['workspace']}/messages"
+        if mailbox == "default":
+            remote_inbox = f"{remote_root}/inbox/"
+        else:
+            remote_inbox = f"{remote_root}/mailboxes/{mailbox}/inbox/"
         ssh_opts = ["-o", "ConnectTimeout=5", "-o", "BatchMode=yes"]
         try:
             subprocess.run(
@@ -188,18 +234,23 @@ def _ssh_deliver(agents: dict[str, dict[str, str]]) -> Deliver:
     return _deliver
 
 
-def _transport(deliver: Deliver | None = None) -> AgentTransport:
-    return AgentTransport(_messages_dir(), _self_name(), deliver=deliver)
+def _transport(*, deliver: Deliver | None = None, mailbox: str = "default") -> AgentTransport:
+    return AgentTransport(
+        _messages_dir(),
+        _self_name(),
+        mailbox=_normalize_mailbox(mailbox),
+        deliver=deliver,
+    )
 
 
-def _delivery_failed(message_id: str) -> bool:
+def _delivery_failed(message_id: str, *, mailbox: str = "default") -> bool:
     """True if the just-sent outbox message was stamped ``delivered: false``.
 
     The transport stamps that field only when the deliver hook reports failure;
     a successful send leaves it absent. Lets the CLI report real failures (and
     exit non-zero) instead of always printing "Sent".
     """
-    path = _messages_dir() / "outbox" / message_id
+    path = _mailbox_root(mailbox) / "outbox" / message_id
     try:
         content = path.read_text()
     except OSError:
@@ -326,11 +377,8 @@ def _pending_messages(
     return pending
 
 
-def _mark_replied(messages_dir: Path, message_id: str) -> None:
+def _mark_replied(path: Path) -> None:
     """Stamp an inbox message ``replied: true`` (and ``read: true``). Idempotent."""
-    path = _within(messages_dir / "inbox", message_id)
-    if path is None or not path.exists():
-        return
     content = path.read_text()
     if not content.startswith("---"):
         return
@@ -345,6 +393,40 @@ def _mark_replied(messages_dir: Path, message_id: str) -> None:
     path.write_text("---".join([parts[0], fm, parts[2]]))
 
 
+def _resolve_message(
+    message_id: str,
+    *,
+    folder: str = "inbox",
+    mailbox: str | None = None,
+) -> tuple[str, Path] | None:
+    mailboxes = [_normalize_mailbox(mailbox)] if mailbox is not None else _known_mailboxes()
+    for mailbox_name in mailboxes:
+        path = _within(_mailbox_root(mailbox_name) / folder, message_id)
+        if path is not None and path.exists():
+            return mailbox_name, path
+    return None
+
+
+def _pending_for_mailboxes(
+    mailboxes: list[str],
+    *,
+    self_name: str,
+    window: int,
+    agents: dict[str, dict[str, str]],
+) -> list[dict]:
+    pending: list[dict] = []
+    for mailbox in mailboxes:
+        messages = _pending_messages(_mailbox_root(mailbox), self_name, window, agents=agents)
+        for meta in messages:
+            row = dict(meta)
+            row["mailbox"] = str(row.get("mailbox") or mailbox)
+            pending.append(row)
+    pending.sort(
+        key=lambda meta: str(meta.get("timestamp", "")),
+    )
+    return pending
+
+
 # -- CLI ---------------------------------------------------------------------
 
 
@@ -357,7 +439,8 @@ def agent() -> None:
 @click.argument("to")
 @click.argument("subject")
 @click.argument("content", required=False)
-def send(to: str, subject: str, content: str | None) -> None:
+@click.option("--mailbox", default="default", show_default=True, help="Mailbox to send from.")
+def send(to: str, subject: str, content: str | None, mailbox: str) -> None:
     """Send a message to another agent."""
     body = content if content is not None else sys.stdin.read()
     agents = _load_agents()
@@ -367,10 +450,11 @@ def send(to: str, subject: str, content: str | None) -> None:
     if to.lower() not in agents:
         click.echo(f"Error: unknown agent '{to}'. Known: {', '.join(agents)}", err=True)
         sys.exit(1)
-    transport = _transport(deliver=_ssh_deliver(agents))
+    mailbox = _normalize_mailbox(mailbox)
+    transport = _transport(deliver=_ssh_deliver(agents, mailbox=mailbox), mailbox=mailbox)
     message_id = transport.send(to, subject, body)
     _track_sent(transport, message_id, reply_to=None)
-    if _delivery_failed(message_id):
+    if _delivery_failed(message_id, mailbox=mailbox):
         click.echo(
             f"Delivery to {to.lower()} FAILED — saved to outbox (delivered: false). "
             "It was NOT received.",
@@ -383,11 +467,13 @@ def send(to: str, subject: str, content: str | None) -> None:
 @agent.command()
 @click.argument("subject")
 @click.argument("content", required=False)
-def broadcast(subject: str, content: str | None) -> None:
+@click.option("--mailbox", default="default", show_default=True, help="Mailbox to send from.")
+def broadcast(subject: str, content: str | None, mailbox: str) -> None:
     """Send a message to every agent in the registry except self."""
     body = content if content is not None else sys.stdin.read()
     agents = _load_agents()
-    transport = _transport(deliver=_ssh_deliver(agents))
+    mailbox = _normalize_mailbox(mailbox)
+    transport = _transport(deliver=_ssh_deliver(agents, mailbox=mailbox), mailbox=mailbox)
     recipients = [name for name in agents if name != _self_name()]
     if not recipients:
         click.echo("No other agents in registry.", err=True)
@@ -396,7 +482,7 @@ def broadcast(subject: str, content: str | None) -> None:
     for name in recipients:
         message_id = transport.send(name, subject, body)
         _track_sent(transport, message_id, reply_to=None)
-        if _delivery_failed(message_id):
+        if _delivery_failed(message_id, mailbox=mailbox):
             click.echo(f"Delivery to {name} FAILED (delivered: false).", err=True)
             failures.append(name)
         else:
@@ -409,7 +495,9 @@ def broadcast(subject: str, content: str | None) -> None:
 @agent.command(name="list")
 @click.argument("folder", default="inbox")
 @click.option("--all", "-a", "show_all", is_flag=True, help="Include already-read messages.")
-def list_cmd(folder: str, show_all: bool) -> None:
+@click.option("--mailbox", default="default", show_default=True, help="Mailbox to inspect.")
+@click.option("--all-mailboxes", is_flag=True, help="Scan default plus every named mailbox.")
+def list_cmd(folder: str, show_all: bool, mailbox: str, all_mailboxes: bool) -> None:
     """List messages in a folder (default: inbox, unread only).
 
     Mirrors ``agent-msg.py list``: the inbox shows only unread messages by
@@ -418,34 +506,45 @@ def list_cmd(folder: str, show_all: bool) -> None:
     ``  {marker} [{ts}] {sender}: {subject}  ({file})`` matches agent-msg.py so
     the planned thin shim is a faithful drop-in.
     """
-    folder_dir = _within(_messages_dir(), folder)
-    if folder_dir is None:
-        raise click.ClickException(f"Invalid folder name: {folder!r}")
-    transport = _transport()
-    rows = transport.list_inbox(folder)
+    mailboxes = _selected_mailboxes(mailbox, all_mailboxes)
     unread_only = folder == "inbox" and not show_all
     shown = 0
-    for message_id, _subject, _ts in rows:
-        meta = meta_of(folder_dir / message_id) or {}
-        is_read = bool(meta.get("read"))
-        if unread_only and is_read:
-            continue
-        ts = meta.get("timestamp", "unknown")
-        sender = str(meta.get("from", "unknown"))
-        subject = str(meta.get("subject", "(no subject)"))
-        marker = " " if is_read else "*"
-        click.echo(f"  {marker} [{ts}] {sender}: {subject}  ({message_id})")
-        shown += 1
+    show_prefix = all_mailboxes or any(name != "default" for name in mailboxes)
+    for mailbox_name in mailboxes:
+        folder_dir = _within(_mailbox_root(mailbox_name), folder)
+        if folder_dir is None:
+            raise click.ClickException(f"Invalid folder name: {folder!r}")
+        transport = _transport(mailbox=mailbox_name)
+        rows = transport.list_inbox(folder)
+        for message_id, _subject, _ts in rows:
+            meta = meta_of(folder_dir / message_id) or {}
+            is_read = bool(meta.get("read"))
+            if unread_only and is_read:
+                continue
+            ts = meta.get("timestamp", "unknown")
+            sender = str(meta.get("from", "unknown"))
+            subject = str(meta.get("subject", "(no subject)"))
+            marker = " " if is_read else "*"
+            prefix = _format_mailbox_prefix(mailbox_name, show=show_prefix)
+            click.echo(f"  {marker} {prefix}[{ts}] {sender}: {subject}  ({message_id})")
+            shown += 1
     if shown == 0:
-        click.echo("No unread messages." if unread_only else f"No messages in {folder}.")
+        scope = "across mailboxes" if all_mailboxes else f"in {folder}"
+        click.echo("No unread messages." if unread_only else f"No messages {scope}.")
 
 
 @agent.command()
 @click.argument("message_id")
 @click.option("--thread", is_flag=True, help="Include locally-available ancestors.")
-def read(message_id: str, thread: bool) -> None:
+@click.option("--mailbox", default=None, help="Restrict lookup to a specific mailbox.")
+def read(message_id: str, thread: bool, mailbox: str | None) -> None:
     """Read a message (marks it read), optionally with its thread."""
-    transport = _transport()
+    resolved = _resolve_message(message_id, folder="inbox", mailbox=mailbox)
+    if resolved is None:
+        click.echo(f"Error: message not found: {message_id}", err=True)
+        sys.exit(1)
+    mailbox_name, _path = resolved
+    transport = _transport(mailbox=mailbox_name)
     try:
         click.echo(transport.read(message_id, include_thread=thread))
     except FileNotFoundError as e:
@@ -456,13 +555,14 @@ def read(message_id: str, thread: bool) -> None:
 @agent.command()
 @click.argument("message_id")
 @click.argument("content", required=False)
-def reply(message_id: str, content: str | None) -> None:
+@click.option("--mailbox", default=None, help="Restrict lookup to a specific mailbox.")
+def reply(message_id: str, content: str | None, mailbox: str | None) -> None:
     """Reply to an inbox message, threading via in_reply_to."""
-    messages_dir = _messages_dir()
-    msg_path = _within(messages_dir / "inbox", message_id)
-    if msg_path is None:
+    resolved = _resolve_message(message_id, folder="inbox", mailbox=mailbox)
+    if resolved is None:
         click.echo(f"Error: message not found: {message_id}", err=True)
         sys.exit(1)
+    mailbox_name, msg_path = resolved
     original = meta_of(msg_path)
     if original is None:
         click.echo(f"Error: message not found: {message_id}", err=True)
@@ -484,9 +584,12 @@ def reply(message_id: str, content: str | None) -> None:
         subject = f"Re: {subject}"
     body = content if content is not None else sys.stdin.read()
     agents = _load_agents()
-    transport = _transport(deliver=_ssh_deliver(agents))
+    transport = _transport(
+        deliver=_ssh_deliver(agents, mailbox=mailbox_name),
+        mailbox=mailbox_name,
+    )
     reply_id = transport.send(recipient, subject, body, reply_to=message_id)
-    if _delivery_failed(reply_id):
+    if _delivery_failed(reply_id, mailbox=mailbox_name):
         click.echo(
             f"Delivery to {recipient} FAILED — saved to outbox (delivered: false). "
             "It was NOT received.",
@@ -494,35 +597,60 @@ def reply(message_id: str, content: str | None) -> None:
         )
         sys.exit(1)
     _track_sent(transport, reply_id, reply_to=message_id)
-    _mark_replied(messages_dir, message_id)
+    _mark_replied(msg_path)
     click.echo(f"Replied to {recipient}: {subject}")
 
 
 @agent.command()
-def pending() -> None:
+@click.option("--mailbox", default="default", show_default=True, help="Mailbox to inspect.")
+@click.option("--all-mailboxes", is_flag=True, help="Scan default plus every named mailbox.")
+def pending(mailbox: str, all_mailboxes: bool) -> None:
     """Show inbox messages awaiting a reply (timely-reply SLA)."""
-    msgs = _pending_messages(_messages_dir(), _self_name(), _reply_window_days())
+    agents = _load_agents(warn_missing=False)
+    mailboxes = _selected_mailboxes(mailbox, all_mailboxes)
+    msgs = _pending_for_mailboxes(
+        mailboxes,
+        self_name=_self_name(),
+        window=_reply_window_days(),
+        agents=agents,
+    )
     if not msgs:
         click.echo("No messages awaiting reply.")
         return
     click.echo(f"{len(msgs)} message(s) awaiting reply:")
+    show_prefix = all_mailboxes or any(name != "default" for name in mailboxes)
     for m in msgs:
-        click.echo(f"  {m['file']}  from {m.get('from')}: {m.get('subject', '')}")
+        prefix = _format_mailbox_prefix(str(m.get("mailbox", "default")), show=show_prefix)
+        click.echo(f"  {prefix}{m['file']}  from {m.get('from')}: {m.get('subject', '')}")
 
 
 @agent.command()
-def status() -> None:
+@click.option("--mailbox", default="default", show_default=True, help="Mailbox to inspect.")
+@click.option("--all-mailboxes", is_flag=True, help="Scan default plus every named mailbox.")
+def status(mailbox: str, all_mailboxes: bool) -> None:
     """Show messaging status (self, registry, inbox/outbox/pending counts)."""
-    messages_dir = _messages_dir()
-    transport = _transport()
     agents = _load_agents()
-    inbox = transport.list_inbox("inbox")
-    outbox = transport.list_inbox("outbox")
-    pend = _pending_messages(messages_dir, _self_name(), _reply_window_days(), agents=agents)
+    mailboxes = _selected_mailboxes(mailbox, all_mailboxes)
+    inbox_count = 0
+    outbox_count = 0
+    for mailbox_name in mailboxes:
+        transport = _transport(mailbox=mailbox_name)
+        inbox_count += len(transport.list_inbox("inbox"))
+        outbox_count += len(transport.list_inbox("outbox"))
+    pend = _pending_for_mailboxes(
+        mailboxes,
+        self_name=_self_name(),
+        window=_reply_window_days(),
+        agents=agents,
+    )
     click.echo(f"Agent:    {_self_name()}")
     click.echo(f"Registry: {', '.join(agents) or '(none)'}")
-    click.echo(f"Inbox:    {len(inbox)}")
-    click.echo(f"Outbox:   {len(outbox)}")
+    click.echo(
+        "Mailbox:  "
+        + (_mailbox_label(mailboxes[0]) if len(mailboxes) == 1 else ", ".join(mailboxes))
+    )
+    click.echo(f"Inbox:    {inbox_count}")
+    click.echo(f"Outbox:   {outbox_count}")
     click.echo(f"Pending:  {len(pend)}")
 
 

--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -648,9 +648,7 @@ def status(mailbox: str, all_mailboxes: bool) -> None:
     )
     click.echo(f"Agent:    {_self_name()}")
     click.echo(f"Registry: {', '.join(agents) or '(none)'}")
-    click.echo(
-        f"Mailbox:  {mailboxes[0] if len(mailboxes) == 1 else ', '.join(mailboxes)}"
-    )
+    click.echo(f"Mailbox:  {mailboxes[0] if len(mailboxes) == 1 else ', '.join(mailboxes)}")
     click.echo(f"Inbox:    {inbox_count}")
     click.echo(f"Outbox:   {outbox_count}")
     click.echo(f"Pending:  {len(pend)}")

--- a/packages/gptmail/src/gptmail/transport/agent.py
+++ b/packages/gptmail/src/gptmail/transport/agent.py
@@ -41,6 +41,7 @@ Deliver = Callable[[Path, str], bool]
 # sanitised subjects contain long runs of dashes (like "...candidate----gptma.md").
 # The correct delimiter is three dashes occupying an entire line.
 _FM_DELIM = re.compile(r"^---[ \t]*$", re.MULTILINE)
+_MAILBOX_NAME = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
 
 
 def meta_of(path: Path) -> dict | None:
@@ -80,12 +81,40 @@ class AgentTransport:
         messages_dir: str | Path,
         self_name: str,
         *,
+        mailbox: str = "default",
         deliver: Deliver | None = None,
     ) -> None:
-        self._dir = Path(messages_dir)
+        self._root = Path(messages_dir)
+        self._mailbox = self._normalize_mailbox(mailbox)
+        self._dir = self.mailbox_dir(self._root, self._mailbox)
         self._self = self_name.lower()
         self._deliver = deliver
         self._ensure_dirs()
+
+    @staticmethod
+    def _normalize_mailbox(mailbox: str) -> str:
+        name = mailbox.strip().lower()
+        if not name:
+            raise ValueError("Mailbox name cannot be empty.")
+        if name == "default":
+            return name
+        if not _MAILBOX_NAME.fullmatch(name):
+            raise ValueError(
+                f"Invalid mailbox name: {mailbox!r}. Use lowercase letters, digits, '-' or '_'."
+            )
+        return name
+
+    @classmethod
+    def mailbox_dir(cls, messages_dir: str | Path, mailbox: str = "default") -> Path:
+        root = Path(messages_dir)
+        name = cls._normalize_mailbox(mailbox)
+        if name == "default":
+            return root
+        return root / "mailboxes" / name
+
+    @property
+    def mailbox(self) -> str:
+        return self._mailbox
 
     @property
     def inbox(self) -> Path:
@@ -114,6 +143,7 @@ class AgentTransport:
         recipient: str,
         subject: str,
         body: str,
+        mailbox: str = "default",
         in_reply_to: str | None = None,
     ) -> str:
         ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -123,6 +153,7 @@ class AgentTransport:
             "timestamp": ts,
             "subject": subject,
             "read": False,
+            "mailbox": mailbox,
         }
         if in_reply_to:
             meta["in_reply_to"] = in_reply_to
@@ -171,7 +202,14 @@ class AgentTransport:
         filename = self._make_filename(self._self, subject)
         local_path = self.outbox / filename
         local_path.write_text(
-            self._format(self._self, to.lower(), subject, content, in_reply_to=reply_to)
+            self._format(
+                self._self,
+                to.lower(),
+                subject,
+                content,
+                mailbox=self.mailbox,
+                in_reply_to=reply_to,
+            )
         )
         if self._deliver is not None and not self._deliver(local_path, to.lower()):
             self._stamp_delivery_failed(local_path)

--- a/packages/gptmail/tests/test_agent_cli.py
+++ b/packages/gptmail/tests/test_agent_cli.py
@@ -20,6 +20,7 @@ from click.testing import CliRunner
 from gptmail import agent_cli
 from gptmail.agent_cli import agent
 from gptmail.communication_utils.state.tracking import ConversationTracker, MessageState
+from gptmail.transport.agent import meta_of
 
 
 @pytest.fixture
@@ -42,10 +43,19 @@ def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setattr(agent_cli, "_repo_root", lambda: tmp_path)
 
     # Replace SSH/SCP delivery with a local copy into the peer's inbox.
-    def _local_deliver(agents):
+    def _local_deliver(agents, *, mailbox="default"):
         from gptmail.transport.agent import AgentTransport
 
-        return AgentTransport.local_deliver(peer_inbox)
+        def _deliver(local_path: Path, _recipient: str) -> bool:
+            meta = meta_of(local_path) or {}
+            target_mailbox = str(meta.get("mailbox", mailbox))
+            if target_mailbox == "default":
+                destination = peer_inbox
+            else:
+                destination = tmp_path / "bob" / "messages" / "mailboxes" / target_mailbox / "inbox"
+            return AgentTransport.local_deliver(destination)(local_path, _recipient)
+
+        return _deliver
 
     monkeypatch.setattr(agent_cli, "_ssh_deliver", _local_deliver)
     return tmp_path
@@ -101,7 +111,7 @@ def test_send_reports_delivery_failure_and_exits_nonzero(
     deliver hook; the CLI must surface that rather than reporting false success.
     """
 
-    def _failing_deliver(_agents):
+    def _failing_deliver(_agents, *, mailbox="default"):
         def _deliver(_local_path: Path, _recipient: str) -> bool:
             return False
 
@@ -126,7 +136,7 @@ def test_reply_reports_delivery_failure_and_keeps_pending(
     The inbox message must stay in ``pending`` so the sender still has a reminder to follow up.
     """
 
-    def _failing_deliver(_agents):
+    def _failing_deliver(_agents, *, mailbox="default"):
         def _deliver(_local_path: Path, _recipient: str) -> bool:
             return False
 
@@ -219,15 +229,24 @@ def test_send_stamps_tracker_channel_agent(workspace: Path) -> None:
     assert pending[0].channel == "agent"
 
 
-def _seed_inbox(workspace: Path, sender: str = "bob", subject: str = "Q") -> str:
+def _seed_inbox(
+    workspace: Path,
+    sender: str = "bob",
+    subject: str = "Q",
+    *,
+    mailbox: str = "default",
+) -> str:
     """Drop a message from ``sender`` into alice's inbox; return its filename."""
     inbox = workspace / "messages" / "inbox"
+    if mailbox != "default":
+        inbox = workspace / "messages" / "mailboxes" / mailbox / "inbox"
+        inbox.mkdir(parents=True, exist_ok=True)
     ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
     name = f"{ts}-000000-{sender}-{subject}.md"
     timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     (inbox / name).write_text(
         f"---\nfrom: {sender}\nto: alice\n"
-        f"timestamp: {timestamp}\nsubject: {subject}\nread: false\n---\n\nplease advise\n"
+        f"timestamp: {timestamp}\nsubject: {subject}\nread: false\nmailbox: {mailbox}\n---\n\nplease advise\n"
     )
     return name
 
@@ -436,6 +455,64 @@ def test_status_reports_counts(workspace: Path) -> None:
     assert "Pending:  1" in result.output
 
 
+def test_send_named_mailbox_writes_mailbox_outbox_and_list_shows_it(workspace: Path) -> None:
+    result = CliRunner().invoke(agent, ["send", "--mailbox", "ops", "bob", "Hello", "body text"])
+    assert result.exit_code == 0, result.output
+
+    outbox = workspace / "messages" / "mailboxes" / "ops" / "outbox"
+    files = list(outbox.glob("*.md"))
+    assert len(files) == 1
+    meta = _frontmatter(files[0])
+    assert meta["mailbox"] == "ops"
+
+    listed = CliRunner().invoke(agent, ["list", "outbox", "--mailbox", "ops", "--all"])
+    assert listed.exit_code == 0, listed.output
+    assert files[0].name in listed.output
+    assert "[ops]" in listed.output
+
+
+def test_pending_named_mailbox_reply_preserves_mailbox_and_clears_only_that_mailbox(
+    workspace: Path,
+) -> None:
+    default_msg = _seed_inbox(workspace, subject="Default")
+    ops_msg = _seed_inbox(workspace, subject="Ops", mailbox="ops")
+
+    before = CliRunner().invoke(agent, ["pending", "--mailbox", "ops"])
+    assert before.exit_code == 0, before.output
+    assert ops_msg in before.output
+    assert default_msg not in before.output
+
+    reply = CliRunner().invoke(agent, ["reply", ops_msg, "handled"])
+    assert reply.exit_code == 0, reply.output
+    assert "Replied to bob: Re: Ops" in reply.output
+
+    ops_inbox = workspace / "messages" / "mailboxes" / "ops" / "inbox" / ops_msg
+    assert _frontmatter(ops_inbox)["replied"] is True
+
+    ops_outbox = list((workspace / "messages" / "mailboxes" / "ops" / "outbox").glob("*.md"))
+    assert len(ops_outbox) == 1
+    assert _frontmatter(ops_outbox[0])["mailbox"] == "ops"
+
+    after_ops = CliRunner().invoke(agent, ["pending", "--mailbox", "ops"])
+    assert "No messages awaiting reply" in after_ops.output
+
+    after_default = CliRunner().invoke(agent, ["pending"])
+    assert default_msg in after_default.output
+
+
+def test_pending_all_mailboxes_combines_default_and_named(workspace: Path) -> None:
+    default_msg = _seed_inbox(workspace, subject="Default")
+    ops_msg = _seed_inbox(workspace, subject="Ops", mailbox="ops")
+
+    result = CliRunner().invoke(agent, ["pending", "--all-mailboxes"])
+    assert result.exit_code == 0, result.output
+    assert "2 message(s) awaiting reply" in result.output
+    assert default_msg in result.output
+    assert ops_msg in result.output
+    assert "[default]" in result.output
+    assert "[ops]" in result.output
+
+
 def test_pending_stays_silent_without_registry(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -490,12 +567,21 @@ def multi_peer_workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Pat
     monkeypatch.setenv("AGENT_NAME", "alice")
     monkeypatch.setattr(agent_cli, "_repo_root", lambda: tmp_path)
 
-    def _routing_deliver(_agents):
+    def _routing_deliver(_agents, *, mailbox="default"):
         def _deliver(local_path: Path, recipient: str) -> bool:
             dest = inboxes.get(recipient)
             if dest is None:
                 return False
-            shutil.copy2(local_path, dest / local_path.name)
+            meta = meta_of(local_path) or {}
+            target_mailbox = str(meta.get("mailbox", mailbox))
+            if target_mailbox == "default":
+                final_dest = dest
+            else:
+                final_dest = (
+                    tmp_path / recipient / "messages" / "mailboxes" / target_mailbox / "inbox"
+                )
+            final_dest.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(local_path, final_dest / local_path.name)
             return True
 
         return _deliver
@@ -535,11 +621,24 @@ def test_broadcast_reports_partial_delivery_failure(
     ``delivered: false`` and surfaced.
     """
 
-    def _bob_only_deliver(_agents):
+    def _bob_only_deliver(_agents, *, mailbox="default"):
         def _deliver(local_path: Path, recipient: str) -> bool:
             if recipient != "bob":
                 return False  # gordon unreachable
-            dest = multi_peer_workspace / "bob" / "messages" / "inbox"
+            meta = meta_of(local_path) or {}
+            target_mailbox = str(meta.get("mailbox", mailbox))
+            if target_mailbox == "default":
+                dest = multi_peer_workspace / "bob" / "messages" / "inbox"
+            else:
+                dest = (
+                    multi_peer_workspace
+                    / "bob"
+                    / "messages"
+                    / "mailboxes"
+                    / target_mailbox
+                    / "inbox"
+                )
+                dest.mkdir(parents=True, exist_ok=True)
             shutil.copy2(local_path, dest / local_path.name)
             return True
 

--- a/packages/gptmail/tests/test_agent_transport.py
+++ b/packages/gptmail/tests/test_agent_transport.py
@@ -54,6 +54,14 @@ def test_send_records_reply_to(tmp_path: Path) -> None:
     assert _frontmatter(t.outbox / mid)["in_reply_to"] == "parent.md"
 
 
+def test_send_named_mailbox_writes_under_mailbox_root(tmp_path: Path) -> None:
+    t = AgentTransport(tmp_path / "messages", "alice", mailbox="ops")
+    mid = t.send("bob", "Hello", "body text")
+    out = tmp_path / "messages" / "mailboxes" / "ops" / "outbox" / mid
+    assert out.exists()
+    assert _frontmatter(out)["mailbox"] == "ops"
+
+
 def test_send_with_deliver_hook_places_in_recipient_inbox(tmp_path: Path) -> None:
     bob_inbox = tmp_path / "bob" / "messages" / "inbox"
     t = _transport(tmp_path, deliver=AgentTransport.local_deliver(bob_inbox))


### PR DESCRIPTION
## Summary
- add mailbox-aware path resolution to `AgentTransport` and stamp mailbox metadata on agent messages
- add `--mailbox` / `--all-mailboxes` support to `gptmail agent send`, `broadcast`, `list`, `pending`, and `status`
- auto-resolve `read` and `reply` across named mailboxes, with regression coverage for named-mailbox pending/reply behavior

## Testing
- `uv run --package gptmail pytest packages/gptmail/tests/test_agent_transport.py packages/gptmail/tests/test_agent_cli.py -q`
- `uv run --package gptmail pytest packages/gptmail/tests/test_agent_cli_no_email_imports.py packages/gptmail/tests/test_agent_transport_no_email_imports.py -q`
- `uv run ruff check packages/gptmail/src/gptmail/agent_cli.py packages/gptmail/src/gptmail/transport/agent.py packages/gptmail/tests/test_agent_cli.py packages/gptmail/tests/test_agent_transport.py`
- `uv run ruff format --check packages/gptmail/src/gptmail/agent_cli.py packages/gptmail/src/gptmail/transport/agent.py packages/gptmail/tests/test_agent_cli.py packages/gptmail/tests/test_agent_transport.py`