### PR TITLE
fix(tooloutput-trimmer): run summarizer first (priority 199 → 202)

### DIFF
--- a/plugins/gptme-tooloutput-trimmer/src/tooloutput_trimmer/hooks/summarizer.py
+++ b/plugins/gptme-tooloutput-trimmer/src/tooloutput_trimmer/hooks/summarizer.py
@@ -1,6 +1,7 @@
 """Summarization pass for evicted tool outputs.
 
-Runs at priority 199 (before the trimmer at 200). When summarization is enabled
+Runs at priority 202 (before the headroom compressor at 201 and the trimmer at
+200, all of which use higher-priority-runs-first ordering). When summarization is enabled
 and tool output messages are evicted beyond the recency window, the W most
 recently evicted pairs are summarized using an LLM and replaced with a single
 summary message, instead of being preview-truncated by the trimmer.
@@ -261,9 +262,10 @@ def generation_pre_hook(
 ) -> Generator[Message | StopPropagation, None, None]:
     """Summarize evicted tool outputs before the trimmer runs.
 
-    Registered at priority 199 (before trimmer at 200). When summarization is
-    enabled, replaces W evicted tool output pairs with a single LLM-generated
-    summary. Otherwise, acts as a no-op and the trimmer handles truncation.
+    Registered at priority 202 (runs before the headroom compressor at 201 and
+    the trimmer at 200). When summarization is enabled, replaces W evicted tool
+    output pairs with a single LLM-generated summary. Otherwise, acts as a no-op
+    and the trimmer handles truncation.
     """
     if _check_bypass_env():
         return
@@ -282,10 +284,11 @@ def generation_pre_hook(
 
 
 def register() -> None:
-    """Register the summarization hook at priority 199 (before trimmer at 200)."""
+    """Register the summarization hook at priority 202 (runs before the headroom
+    compressor at 201 and the trimmer at 200)."""
     register_hook(
         name="tooloutput_trimmer.summarizer",
         hook_type=HookType.GENERATION_PRE,
         func=generation_pre_hook,
-        priority=199,
+        priority=202,
     )


### PR DESCRIPTION
## Problem

The tool-output summarizer hook is registered at `priority=199`, but the trimmer runs at `200` and the headroom compressor at `201`. Since **higher priority runs first**, the actual order was:

1. headroom compressor (201) — lossless compress
2. trimmer (200) — truncate long outputs to previews
3. summarizer (199) — summarize evicted pairs (now operating on **already-truncated** preview text)

So the summarizer was building summaries from truncated previews, degrading summary quality. Bob's config has both summarizer and trimmer enabled, so this is the live ordering.

## Fix

Bump the summarizer to `priority=202` so it runs **first**, summarizing full evicted tool-output pairs before the compressor/trimmer touch them:

1. summarizer (202) — summarize old pairs while still full
2. headroom compressor (201) — lossless compress remaining
3. trimmer (200) — truncate anything still oversized

Also fixes three docstrings that wrongly claimed priority 199 runs "before the trimmer at 200" (199 < 200 means it ran *after*).

## Notes

- Behavior-only ordering fix; no logic change.
- All 23 plugin tests pass.
- Context: implements correct ordering for the summarization lever from "Less Context, Better Agents" (arXiv:2606.10209), already shipped in #1069.