### PR TITLE
feat(gptmail): add fleet pending recipient view

### DIFF
--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -33,6 +33,7 @@ Wiring:
 from __future__ import annotations
 
 import functools
+import json
 import os
 import re
 import shlex
@@ -430,6 +431,124 @@ def _pending_for_mailboxes(
     return pending
 
 
+def _outbox_rows_for_recipient(
+    mailboxes: list[str],
+    *,
+    recipient: str,
+    self_name: str,
+) -> list[dict]:
+    target = recipient.lower()
+    rows: list[dict] = []
+    workspace = str(_repo_root())
+    for mailbox in mailboxes:
+        outbox = _mailbox_root(mailbox) / "outbox"
+        if not outbox.exists():
+            continue
+        for message_path in sorted(outbox.glob("*.md")):
+            meta = meta_of(message_path)
+            if not meta or not _addressed_to(meta, target):
+                continue
+            row = dict(meta)
+            row["agent"] = str(row.get("from") or self_name)
+            row["file"] = message_path.name
+            row["mailbox"] = str(row.get("mailbox") or mailbox)
+            row["workspace"] = workspace
+            rows.append(row)
+    rows.sort(
+        key=lambda meta: (
+            str(meta.get("timestamp", "")),
+            str(meta.get("agent", "")),
+            str(meta.get("mailbox", "")),
+            str(meta.get("file", "")),
+        )
+    )
+    return rows
+
+
+def _remote_pending_rows(
+    agent_name: str,
+    agent: dict[str, str],
+    *,
+    recipient: str,
+    mailboxes: list[str],
+) -> list[dict]:
+    missing = [k for k in ("ssh", "workspace") if not agent.get(k)]
+    if missing:
+        return []
+    cmd = ["uv", "run", "gptmail", "agent", "pending", "--for", recipient, "--json", "--local-only"]
+    if len(mailboxes) == 1:
+        cmd.extend(["--mailbox", mailboxes[0]])
+    else:
+        cmd.append("--all-mailboxes")
+    remote_cmd = " && ".join(
+        [
+            f"cd {shlex.quote(agent['workspace'])}",
+            f"AGENT_NAME={shlex.quote(agent_name)} {shlex.join(cmd)}",
+        ]
+    )
+    try:
+        result = subprocess.run(
+            ["ssh", "-o", "ConnectTimeout=5", "-o", "BatchMode=yes", agent["ssh"], remote_cmd],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=20,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+        click.echo(f"Warning: failed to collect pending rows from {agent_name}: {e}", err=True)
+        return []
+    try:
+        payload = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError as e:
+        click.echo(f"Warning: invalid pending JSON from {agent_name}: {e}", err=True)
+        return []
+    if not isinstance(payload, list):
+        click.echo(f"Warning: invalid pending payload from {agent_name}: expected a list", err=True)
+        return []
+    rows: list[dict] = []
+    for item in payload:
+        if not isinstance(item, dict):
+            continue
+        row = dict(item)
+        row["agent"] = str(row.get("agent") or agent_name)
+        row["workspace"] = str(row.get("workspace") or agent["workspace"])
+        rows.append(row)
+    return rows
+
+
+def _fleet_pending_rows(
+    mailboxes: list[str],
+    *,
+    recipient: str,
+    self_name: str,
+    agents: dict[str, dict[str, str]],
+    fleet: bool,
+) -> list[dict]:
+    rows = _outbox_rows_for_recipient(mailboxes, recipient=recipient, self_name=self_name)
+    if not fleet:
+        return rows
+    for agent_name, agent in agents.items():
+        if agent_name == self_name:
+            continue
+        rows.extend(
+            _remote_pending_rows(
+                agent_name,
+                agent,
+                recipient=recipient,
+                mailboxes=mailboxes,
+            )
+        )
+    rows.sort(
+        key=lambda meta: (
+            str(meta.get("timestamp", "")),
+            str(meta.get("agent", "")),
+            str(meta.get("mailbox", "")),
+            str(meta.get("file", "")),
+        )
+    )
+    return rows
+
+
 # -- CLI ---------------------------------------------------------------------
 
 
@@ -607,13 +726,62 @@ def reply(message_id: str, content: str | None, mailbox: str | None) -> None:
 @agent.command()
 @click.option("--mailbox", default="default", show_default=True, help="Mailbox to inspect.")
 @click.option("--all-mailboxes", is_flag=True, help="Scan default plus every named mailbox.")
-def pending(mailbox: str, all_mailboxes: bool) -> None:
+@click.option("--for", "for_recipient", default=None, help="Show messages pending for a recipient.")
+@click.option("--fleet", is_flag=True, help="Fan out across all registered agents.")
+@click.option("--json", "json_output", is_flag=True, help="Emit machine-readable JSON.")
+@click.option("--local-only", is_flag=True, hidden=True, help="Skip fleet fan-out.")
+def pending(
+    mailbox: str,
+    all_mailboxes: bool,
+    for_recipient: str | None,
+    fleet: bool,
+    json_output: bool,
+    local_only: bool,
+) -> None:
     """Show inbox messages awaiting a reply (timely-reply SLA)."""
     agents = _load_agents(warn_missing=False)
     mailboxes = _selected_mailboxes(mailbox, all_mailboxes)
+    self_name = _self_name()
+    if for_recipient:
+        if fleet and local_only:
+            raise click.BadParameter("--fleet and --local-only are mutually exclusive")
+        rows = _fleet_pending_rows(
+            mailboxes,
+            recipient=for_recipient,
+            self_name=self_name,
+            agents=agents,
+            fleet=fleet and not local_only,
+        )
+        if json_output:
+            click.echo(json.dumps(rows, indent=2, sort_keys=True, default=str))
+            return
+        if not rows:
+            click.echo(f"No messages pending for {for_recipient.lower()}.")
+            return
+        click.echo(f"{len(rows)} message(s) pending for {for_recipient.lower()}:")
+        show_prefix = all_mailboxes or any(
+            str(row.get("mailbox", "default")) != "default" for row in rows
+        )
+        for row in rows:
+            prefix = _format_mailbox_prefix(str(row.get("mailbox", "default")), show=show_prefix)
+            timestamp = str(row.get("timestamp", "unknown"))
+            subject = str(row.get("subject", ""))
+            agent_name = str(row.get("agent", "unknown"))
+            file_name = str(row.get("file", ""))
+            workspace = str(row.get("workspace", ""))
+            click.echo(
+                f"  {agent_name} {prefix}[{timestamp}] {subject}  ({file_name} @ {workspace})"
+            )
+        return
+    if fleet:
+        raise click.BadParameter("--fleet requires --for", param_hint="--fleet")
+    if json_output:
+        raise click.BadParameter("--json requires --for", param_hint="--json")
+    if local_only:
+        raise click.BadParameter("--local-only requires --for", param_hint="--local-only")
     msgs = _pending_for_mailboxes(
         mailboxes,
-        self_name=_self_name(),
+        self_name=self_name,
         window=_reply_window_days(),
         agents=agents,
     )

--- a/packages/gptmail/tests/test_agent_cli.py
+++ b/packages/gptmail/tests/test_agent_cli.py
@@ -9,6 +9,7 @@ Parity target: ``scripts/agent-msg.py`` (send/broadcast/list/read/reply/pending)
 See task: fold-agent-msg-into-gptmail-single-comms-tool.
 """
 
+import json
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
@@ -247,6 +248,29 @@ def _seed_inbox(
     (inbox / name).write_text(
         f"---\nfrom: {sender}\nto: alice\n"
         f"timestamp: {timestamp}\nsubject: {subject}\nread: false\nmailbox: {mailbox}\n---\n\nplease advise\n"
+    )
+    return name
+
+
+def _seed_outbox(
+    workspace: Path,
+    recipient: str,
+    subject: str,
+    *,
+    mailbox: str = "default",
+    sender: str = "alice",
+) -> str:
+    """Drop a sent message into the outbox; return its filename."""
+    outbox = workspace / "messages" / "outbox"
+    if mailbox != "default":
+        outbox = workspace / "messages" / "mailboxes" / mailbox / "outbox"
+        outbox.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    name = f"{ts}-000000-{sender}-{subject}.md"
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    (outbox / name).write_text(
+        f"---\nfrom: {sender}\nto: {recipient}\n"
+        f"timestamp: {timestamp}\nsubject: {subject}\nread: false\nmailbox: {mailbox}\n---\n\nbody\n"
     )
     return name
 
@@ -511,6 +535,76 @@ def test_pending_all_mailboxes_combines_default_and_named(workspace: Path) -> No
     assert ops_msg in result.output
     assert "[default]" in result.output
     assert "[ops]" in result.output
+
+
+def test_pending_for_recipient_scans_local_outbox_across_mailboxes(workspace: Path) -> None:
+    default_msg = _seed_outbox(workspace, "erik", "Default")
+    ops_msg = _seed_outbox(workspace, "erik", "Ops", mailbox="ops")
+
+    result = CliRunner().invoke(agent, ["pending", "--for", "erik", "--all-mailboxes"])
+    assert result.exit_code == 0, result.output
+    assert "2 message(s) pending for erik" in result.output
+    assert default_msg in result.output
+    assert ops_msg in result.output
+    assert "[default]" in result.output
+    assert "[ops]" in result.output
+    assert "alice " in result.output
+
+
+def test_pending_for_recipient_json_emits_machine_readable_rows(workspace: Path) -> None:
+    default_msg = _seed_outbox(workspace, "erik", "Default")
+    ops_msg = _seed_outbox(workspace, "erik", "Ops", mailbox="ops")
+
+    result = CliRunner().invoke(
+        agent,
+        ["pending", "--for", "erik", "--all-mailboxes", "--json", "--local-only"],
+    )
+    assert result.exit_code == 0, result.output
+    rows = json.loads(result.output)
+    assert [row["file"] for row in rows] == [default_msg, ops_msg]
+    assert rows[0]["agent"] == "alice"
+    assert rows[0]["workspace"] == str(workspace)
+    assert rows[0]["mailbox"] == "default"
+    assert rows[1]["mailbox"] == "ops"
+
+
+def test_pending_for_recipient_fleet_merges_remote_rows(
+    workspace: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    local_msg = _seed_outbox(workspace, "erik", "Local")
+    ops_msg = _seed_outbox(workspace, "erik", "Ops", mailbox="ops")
+
+    def _fake_remote_pending_rows(
+        agent_name: str,
+        agent_cfg: dict[str, str],
+        *,
+        recipient: str,
+        mailboxes: list[str],
+    ) -> list[dict]:
+        assert agent_name == "bob"
+        assert recipient == "erik"
+        assert mailboxes == ["default", "ops"]
+        return [
+            {
+                "agent": "bob",
+                "file": "20260616-remote.md",
+                "mailbox": "ops",
+                "subject": "Remote",
+                "timestamp": "2026-06-16T12:00:00Z",
+                "to": "erik",
+                "workspace": agent_cfg["workspace"],
+            }
+        ]
+
+    monkeypatch.setattr(agent_cli, "_remote_pending_rows", _fake_remote_pending_rows)
+    result = CliRunner().invoke(
+        agent,
+        ["pending", "--for", "erik", "--fleet", "--all-mailboxes", "--json"],
+    )
+    assert result.exit_code == 0, result.output
+    rows = json.loads(result.output)
+    assert {row["agent"] for row in rows} == {"alice", "bob"}
+    assert {row["file"] for row in rows} == {local_msg, ops_msg, "20260616-remote.md"}
 
 
 def test_pending_stays_silent_without_registry(


### PR DESCRIPTION
## Summary
- add `gptmail agent pending --for <recipient>` to aggregate unread/pending messages for one human recipient
- support `--fleet` fan-out plus hidden `--local-only` for remote collection and machine-readable `--json` output
- cover local aggregation, JSON output, and fleet merge behavior with focused CLI tests

## Why
This is phase 2 after named mailboxes: Erik asked for one fleet-wide pending view so he can triage all agent mail without hopping through per-agent outboxes.

## Testing
- `uv run --package gptmail pytest packages/gptmail/tests/test_agent_cli.py -q`
- `uv run --package gptmail ruff check packages/gptmail/src/gptmail/agent_cli.py packages/gptmail/tests/test_agent_cli.py`
- `git diff --check -- packages/gptmail/src/gptmail/agent_cli.py packages/gptmail/tests/test_agent_cli.py`
- `python3 -m compileall packages/gptmail/src/gptmail/agent_cli.py`
