### PR TITLE
[codex] test stale subscription credential probes

### DIFF
--- a/packages/gptme-subscription/tests/test_auth.py
+++ b/packages/gptme-subscription/tests/test_auth.py
@@ -125,6 +125,27 @@ sys.exit(0 if target.name == "alice.json" and "fake-refresh" in text else 7)
     assert msg == "probe ok"
 
 
+def test_probe_credential_probes_stale_access_token(tmp_path: Path) -> None:
+    path = tmp_path / "alice.json"
+    _write_credential(path, expires_at_ms=int((time.time() - 3600) * 1000))
+    marker = tmp_path / "probe-ran.txt"
+    script = tmp_path / "probe.py"
+    script.write_text(
+        f"""#!/usr/bin/env python3
+from pathlib import Path
+Path({str(marker)!r}).write_text("ran")
+"""
+    )
+    script.chmod(0o755)
+
+    info, ok, msg = probe_credential(path, "alice", usage_script=script)
+
+    assert info.status == "stale"
+    assert ok is True
+    assert msg == "probe ok"
+    assert marker.read_text() == "ran"
+
+
 def test_probe_credential_reports_probe_os_error(tmp_path: Path) -> None:
     path = tmp_path / "alice.json"
     _write_credential(path, expires_at_ms=int((time.time() + 3600) * 1000))


### PR DESCRIPTION
## Summary

Upstream follow-up for ErikBjare/bob#918.

`gptme_subscription.auth.probe_credential()` already allows `status="stale"` credentials to continue into the live probe path. This adds a regression test for that behavior so callers like Bob's `subscription-token-probe.py` can safely rely on it instead of treating lapsed `expiresAt` values as dead credentials.

## Validation

- `uv run --package gptme-subscription pytest /tmp/worktrees/gptme-contrib-stale-probe/packages/gptme-subscription/tests/test_auth.py -q`
- `uv run ruff check /tmp/worktrees/gptme-contrib-stale-probe/packages/gptme-subscription/tests/test_auth.py`
- `git diff --check -- /tmp/worktrees/gptme-contrib-stale-probe/packages/gptme-subscription/tests/test_auth.py`
- commit pre-commit hooks passed
