### PR TITLE
fix(gptmail): tighten fleet pending recipient filtering

### DIFF
--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -304,6 +304,21 @@ def _addressed_to(meta: dict, self_name: str) -> bool:
     return str(to).lower() == self_name
 
 
+def _matches_recipient(meta: dict, recipient: str) -> bool:
+    """True only when ``meta['to']`` explicitly targets ``recipient``.
+
+    Inbox scans treat a missing ``to`` as addressed-to-self for legacy
+    frontmatter-free messages. Outbox recipient filtering is stricter: a missing
+    recipient is malformed and must not leak into every ``pending --for`` view.
+    """
+    to = meta.get("to")
+    if to is None:
+        return False
+    if isinstance(to, (list, tuple, set)):  # noqa: UP038
+        return recipient in {str(t).lower() for t in to}
+    return str(to).lower() == recipient
+
+
 def _is_push_reachable(recipient: str, agents: dict[str, dict[str, str]]) -> bool:
     """True if ``recipient`` has a working push transport in the registry.
 
@@ -446,7 +461,7 @@ def _outbox_rows_for_recipient(
             continue
         for message_path in sorted(outbox.glob("*.md")):
             meta = meta_of(message_path)
-            if not meta or not _addressed_to(meta, target):
+            if not meta or not _matches_recipient(meta, target):
                 continue
             row = dict(meta)
             row["agent"] = str(row.get("from") or self_name)
@@ -474,6 +489,10 @@ def _remote_pending_rows(
 ) -> list[dict]:
     missing = [k for k in ("ssh", "workspace") if not agent.get(k)]
     if missing:
+        click.echo(
+            f"Warning: skipping {agent_name}; missing required key(s): {', '.join(missing)}",
+            err=True,
+        )
         return []
     cmd = ["uv", "run", "gptmail", "agent", "pending", "--for", recipient, "--json", "--local-only"]
     if len(mailboxes) == 1:

--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -314,6 +314,7 @@ def _matches_recipient(meta: dict, recipient: str) -> bool:
     to = meta.get("to")
     if to is None:
         return False
+    recipient = recipient.lower()
     if isinstance(to, (list, tuple, set)):  # noqa: UP038
         return recipient in {str(t).lower() for t in to}
     return str(to).lower() == recipient

--- a/packages/gptmail/tests/test_agent_cli.py
+++ b/packages/gptmail/tests/test_agent_cli.py
@@ -568,6 +568,18 @@ def test_pending_for_recipient_json_emits_machine_readable_rows(workspace: Path)
     assert rows[1]["mailbox"] == "ops"
 
 
+def test_pending_for_recipient_ignores_outbox_rows_without_to_field(workspace: Path) -> None:
+    outbox = workspace / "messages" / "outbox"
+    malformed = outbox / "20260616-120000-000000-alice-missing-to.md"
+    malformed.write_text(
+        "---\nfrom: alice\ntimestamp: 2026-06-16T12:00:00Z\nsubject: Missing to\n---\n\nbody\n"
+    )
+
+    result = CliRunner().invoke(agent, ["pending", "--for", "erik", "--json", "--local-only"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == []
+
+
 def test_pending_for_recipient_fleet_merges_remote_rows(
     workspace: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -605,6 +617,19 @@ def test_pending_for_recipient_fleet_merges_remote_rows(
     rows = json.loads(result.output)
     assert {row["agent"] for row in rows} == {"alice", "bob"}
     assert {row["file"] for row in rows} == {local_msg, ops_msg, "20260616-remote.md"}
+
+
+def test_remote_pending_rows_warns_on_missing_transport(capsys: pytest.CaptureFixture[str]) -> None:
+    rows = agent_cli._remote_pending_rows(
+        "bob",
+        {"workspace": "/tmp/bob"},
+        recipient="erik",
+        mailboxes=["default"],
+    )
+
+    captured = capsys.readouterr()
+    assert rows == []
+    assert "Warning: skipping bob; missing required key(s): ssh" in captured.err
 
 
 def test_pending_stays_silent_without_registry(

--- a/packages/gptmail/tests/test_agent_cli.py
+++ b/packages/gptmail/tests/test_agent_cli.py
@@ -580,6 +580,10 @@ def test_pending_for_recipient_ignores_outbox_rows_without_to_field(workspace: P
     assert json.loads(result.output) == []
 
 
+def test_matches_recipient_normalizes_recipient_argument() -> None:
+    assert agent_cli._matches_recipient({"to": ["Erik"]}, "ERIK")
+
+
 def test_pending_for_recipient_fleet_merges_remote_rows(
     workspace: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- stop `pending --for <recipient>` from treating malformed outbox messages with no `to:` field as matches for every recipient
- warn when fleet aggregation skips an agent because its registry entry is missing `ssh` or `workspace`
- cover both regressions with focused CLI tests

## Why
PR #1127 was merged before the Greptile review landed. This follow-up addresses the concrete P1/P2 issues from that review.

## Testing
- `uv run --with pyyaml pytest packages/gptmail/tests/test_agent_cli.py -q`
- `uv run --package gptmail ruff check packages/gptmail/src/gptmail/agent_cli.py packages/gptmail/tests/test_agent_cli.py`
- `git diff --check -- packages/gptmail/src/gptmail/agent_cli.py packages/gptmail/tests/test_agent_cli.py`
