### PR TITLE
feat(subscription): add live token-probe script with refresh-aware stale-slot detection

### DIFF
--- a/packages/gptme-subscription/tests/test_subscription_token_probe.py
+++ b/packages/gptme-subscription/tests/test_subscription_token_probe.py
@@ -1,0 +1,382 @@
+"""Tests for scripts/subscription-token-probe.py.
+
+Covers live token-validity probe logic: API probe, stale-token handling,
+TOKEN-DEAD marker management, and probe_all integration.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+PROBE_SCRIPT = (
+    Path(__file__).resolve().parents[3] / "scripts" / "subscription-token-probe.py"
+)
+
+
+def _load_probe():
+    """Load subscription-token-probe.py as a module."""
+    spec = importlib.util.spec_from_file_location(
+        "subscription_token_probe", PROBE_SCRIPT
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _make_cred_file(path: Path, expires_in_seconds: int = 3600) -> None:
+    """Write a minimal valid credential file."""
+    now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+    expires_at_ms = now_ms + expires_in_seconds * 1000
+    path.write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "fake-access-token-abc123",
+                    "refreshToken": "fake-refresh-token-xyz789",
+                    "expiresAt": expires_at_ms,
+                    "subscriptionType": "claude_max",
+                    "scopes": ["user:inference"],
+                }
+            }
+        )
+    )
+
+
+def _make_http_response(status: int, body: bytes = b'{"input_tokens": 1}') -> MagicMock:
+    """Return a mock HTTP response object."""
+    resp = MagicMock()
+    resp.status = status
+    resp.__enter__ = lambda s: s
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+# ---- _probe_slot ----
+
+
+class TestProbeSlot:
+    """Unit tests for _probe_slot(slot, token)."""
+
+    def test_valid_200_returns_valid(self):
+        """200 from the API → status='valid'."""
+        mod = _load_probe()
+        resp = _make_http_response(200)
+        with patch.object(urllib.request, "urlopen", return_value=resp):
+            result = mod._probe_slot("bob", "fake-token")
+        assert result["status"] == "valid"
+        assert result["slot"] == "bob"
+        assert result["http_code"] == 200
+        assert result["error"] is None
+
+    def test_401_returns_dead(self):
+        """401 → token is server-side dead."""
+        mod = _load_probe()
+        exc = urllib.error.HTTPError(
+            url="https://api.anthropic.com/v1/messages/count_tokens",
+            code=401,
+            msg="Unauthorized",
+            hdrs=None,  # type: ignore[arg-type]
+            fp=BytesIO(b'{"error": "invalid_token"}'),
+        )
+        with patch.object(urllib.request, "urlopen", side_effect=exc):
+            result = mod._probe_slot("bob", "dead-token")
+        assert result["status"] == "dead"
+        assert result["http_code"] == 401
+
+    def test_403_returns_dead(self):
+        """403 → token is server-side dead."""
+        mod = _load_probe()
+        exc = urllib.error.HTTPError(
+            url="https://api.anthropic.com/v1/messages/count_tokens",
+            code=403,
+            msg="Forbidden",
+            hdrs=None,  # type: ignore[arg-type]
+            fp=BytesIO(b'{"error": "forbidden"}'),
+        )
+        with patch.object(urllib.request, "urlopen", side_effect=exc):
+            result = mod._probe_slot("alice", "bad-token")
+        assert result["status"] == "dead"
+        assert result["http_code"] == 403
+
+    def test_429_returns_error_not_dead(self):
+        """429 rate-limit → status='error', not 'dead' (token may still be alive)."""
+        mod = _load_probe()
+        exc = urllib.error.HTTPError(
+            url="https://api.anthropic.com/v1/messages/count_tokens",
+            code=429,
+            msg="Too Many Requests",
+            hdrs=None,  # type: ignore[arg-type]
+            fp=BytesIO(b'{"error": "rate_limited"}'),
+        )
+        with patch.object(urllib.request, "urlopen", side_effect=exc):
+            result = mod._probe_slot("bob", "ok-token")
+        assert result["status"] == "error"
+        assert result["error"] == "rate_limited"
+
+    def test_network_error_returns_error(self):
+        """Network failure → status='error'."""
+        mod = _load_probe()
+        exc = urllib.error.URLError("connection refused")
+        with patch.object(urllib.request, "urlopen", side_effect=exc):
+            result = mod._probe_slot("bob", "some-token")
+        assert result["status"] == "error"
+        assert "connection" in (result["error"] or "").lower()
+
+    def test_result_includes_checked_at(self):
+        """Result always includes a checked_at ISO timestamp."""
+        mod = _load_probe()
+        resp = _make_http_response(200)
+        with patch.object(urllib.request, "urlopen", return_value=resp):
+            result = mod._probe_slot("bob", "fake-token")
+        assert "checked_at" in result
+        datetime.fromisoformat(result["checked_at"])
+
+
+# ---- _offline_probe_error ----
+
+
+class TestOfflineProbeError:
+    """Unit tests for _offline_probe_error(slot) fast-reject path."""
+
+    def test_fresh_token_probeable(self, tmp_path, monkeypatch):
+        """A token expiring in 1 hour is probeable."""
+        mod = _load_probe()
+        cred = tmp_path / ".credentials.json.bob"
+        _make_cred_file(cred, expires_in_seconds=3600)
+        monkeypatch.setattr(mod, "CREDS_DIR", tmp_path)
+        assert mod._offline_probe_error("bob") is None
+
+    def test_expired_token_still_probeable(self, tmp_path, monkeypatch):
+        """A lapsed access token is stale, not dead; live probe can refresh it."""
+        mod = _load_probe()
+        cred = tmp_path / ".credentials.json.bob"
+        _make_cred_file(cred, expires_in_seconds=-300)
+        monkeypatch.setattr(mod, "CREDS_DIR", tmp_path)
+        assert mod._offline_probe_error("bob") is None
+
+    def test_missing_file_returns_error(self, tmp_path, monkeypatch):
+        """Missing credential file cannot be live-probed."""
+        mod = _load_probe()
+        monkeypatch.setattr(mod, "CREDS_DIR", tmp_path)
+        result = mod._offline_probe_error("noexist")
+        assert result is not None
+        assert result["status"] == "error"
+        assert result["credential_status"] == "missing"
+
+
+# ---- _write_dead_markers ----
+
+
+class TestWriteDeadMarkers:
+    """Unit tests for _write_dead_markers(results, dead_slot_dir)."""
+
+    def test_creates_marker_for_dead_slot(self, tmp_path):
+        """Dead slot → TOKEN-DEAD-<slot> marker file is created."""
+        mod = _load_probe()
+        results = [
+            {"slot": "bob", "status": "dead", "checked_at": "2026-01-01T00:00:00"}
+        ]
+        mod._write_dead_markers(results, tmp_path)
+        marker = tmp_path / "slot-TOKEN-DEAD-bob"
+        assert marker.exists(), "TOKEN-DEAD marker should exist for dead slot"
+
+    def test_no_marker_for_valid_slot(self, tmp_path):
+        """Valid slot → no TOKEN-DEAD marker."""
+        mod = _load_probe()
+        results = [
+            {"slot": "alice", "status": "valid", "checked_at": "2026-01-01T00:00:00"}
+        ]
+        mod._write_dead_markers(results, tmp_path)
+        marker = tmp_path / "slot-TOKEN-DEAD-alice"
+        assert not marker.exists()
+
+    def test_clears_stale_markers_on_recovery(self, tmp_path):
+        """When a previously dead slot recovers, its stale marker is removed."""
+        mod = _load_probe()
+
+        stale_marker = tmp_path / "slot-TOKEN-DEAD-bob"
+        stale_marker.write_text("stale dead marker\n")
+
+        results = [
+            {"slot": "bob", "status": "valid", "checked_at": "2026-01-01T00:00:00"}
+        ]
+        mod._write_dead_markers(results, tmp_path)
+
+        assert not stale_marker.exists(), "Stale marker should be cleared on recovery"
+
+    def test_mixed_results(self, tmp_path):
+        """Dead slot gets marker; valid slot does not; stale marker for third cleared."""
+        mod = _load_probe()
+
+        (tmp_path / "slot-TOKEN-DEAD-alice").write_text("old\n")
+
+        results = [
+            {"slot": "alice", "status": "valid", "checked_at": "t"},
+            {"slot": "erik", "status": "dead", "checked_at": "t"},
+        ]
+        mod._write_dead_markers(results, tmp_path)
+
+        assert not (tmp_path / "slot-TOKEN-DEAD-alice").exists()
+        assert (tmp_path / "slot-TOKEN-DEAD-erik").exists()
+
+    def test_non_token_dead_files_untouched(self, tmp_path):
+        """Files in dead_slot_dir that don't start with 'slot-TOKEN-DEAD-' are preserved."""
+        mod = _load_probe()
+
+        other = tmp_path / "some-other-marker.txt"
+        other.write_text("unrelated\n")
+
+        mod._write_dead_markers(
+            [{"slot": "bob", "status": "valid", "checked_at": "t"}], tmp_path
+        )
+
+        assert other.exists(), "Non-TOKEN-DEAD files must not be removed"
+
+    def test_noop_when_dir_is_none(self, tmp_path):
+        """When dead_slot_dir is None, no files are created."""
+        mod = _load_probe()
+        mod._write_dead_markers(
+            [{"slot": "bob", "status": "dead", "checked_at": "t"}], None
+        )
+        # Just confirm no exception and no side effects
+
+
+# ---- probe_all ----
+
+
+class TestProbeAll:
+    """Integration tests for probe_all()."""
+
+    def test_skips_active_slot(self, tmp_path, monkeypatch):
+        """probe_all never probes the slot the live symlink points to."""
+        mod = _load_probe()
+        monkeypatch.setattr(mod, "_active_slot", lambda: "bob")
+
+        probed: list[str] = []
+
+        def fake_probe(slot: str, usage_script=None) -> dict:
+            probed.append(slot)
+            return {
+                "slot": slot,
+                "status": "valid",
+                "http_code": 200,
+                "checked_at": "t",
+                "error": None,
+            }
+
+        monkeypatch.setattr(mod, "_offline_probe_error", lambda s: None)
+        monkeypatch.setattr(mod, "_probe_slot_with_refresh", fake_probe)
+
+        out = tmp_path / "health.json"
+        mod.probe_all(slots=["bob", "alice", "erik"], output=out)
+
+        assert "bob" not in probed, "Active slot must not be probed"
+        assert "alice" in probed
+        assert "erik" in probed
+
+    def test_writes_state_file(self, tmp_path, monkeypatch):
+        """probe_all writes results to the output JSON file."""
+        mod = _load_probe()
+        monkeypatch.setattr(mod, "_active_slot", lambda: "bob")
+        monkeypatch.setattr(mod, "_offline_probe_error", lambda s: None)
+        monkeypatch.setattr(
+            mod,
+            "_probe_slot_with_refresh",
+            lambda slot, usage_script=None: {
+                "slot": slot,
+                "status": "valid",
+                "http_code": 200,
+                "checked_at": "t",
+                "error": None,
+            },
+        )
+
+        out = tmp_path / "health.json"
+        mod.probe_all(slots=["bob", "alice"], output=out)
+
+        assert out.exists()
+        data = json.loads(out.read_text())
+        assert isinstance(data, list)
+        slots_in_file = {r["slot"] for r in data}
+        assert "alice" in slots_in_file
+
+    def test_no_output_file_when_output_is_none(self, tmp_path, monkeypatch):
+        """probe_all returns results without writing to disk when output=None."""
+        mod = _load_probe()
+        monkeypatch.setattr(mod, "_active_slot", lambda: "bob")
+        monkeypatch.setattr(mod, "_offline_probe_error", lambda s: None)
+        monkeypatch.setattr(
+            mod,
+            "_probe_slot_with_refresh",
+            lambda slot, usage_script=None: {
+                "slot": slot,
+                "status": "valid",
+                "checked_at": "t",
+                "error": None,
+            },
+        )
+
+        results = mod.probe_all(slots=["bob", "alice"], output=None)
+        assert isinstance(results, list)
+        assert len(results) == 1  # only alice (bob is active)
+
+    def test_dead_slot_creates_marker(self, tmp_path, monkeypatch):
+        """When probe_all finds a dead slot, the TOKEN-DEAD marker is written."""
+        mod = _load_probe()
+        quota_dir = tmp_path / "quota"
+        monkeypatch.setattr(mod, "_active_slot", lambda: "bob")
+        monkeypatch.setattr(mod, "_offline_probe_error", lambda s: None)
+
+        def dead_probe(slot: str, usage_script=None) -> dict:
+            return {
+                "slot": slot,
+                "status": "dead",
+                "http_code": 401,
+                "checked_at": "t",
+                "error": "HTTP 401",
+            }
+
+        monkeypatch.setattr(mod, "_probe_slot_with_refresh", dead_probe)
+
+        out = tmp_path / "health.json"
+        mod.probe_all(slots=["bob", "alice"], output=out, dead_slot_dir=quota_dir)
+
+        assert (quota_dir / "slot-TOKEN-DEAD-alice").exists()
+
+    def test_stale_access_tokens_are_live_probed(self, tmp_path, monkeypatch):
+        """Slots with lapsed access tokens still use the refresh-aware probe."""
+        mod = _load_probe()
+        creds = tmp_path / "creds"
+        monkeypatch.setattr(mod, "CREDS_DIR", creds)
+        creds.mkdir()
+        _make_cred_file(creds / ".credentials.json.alice", expires_in_seconds=-300)
+        _make_cred_file(creds / ".credentials.json.erik", expires_in_seconds=-300)
+
+        monkeypatch.setattr(mod, "_active_slot", lambda: "bob")
+
+        probed: list[str] = []
+
+        def fake_probe(slot: str, usage_script=None) -> dict:
+            probed.append(slot)
+            return {
+                "slot": slot,
+                "status": "valid",
+                "http_code": 200,
+                "checked_at": "t",
+                "error": None,
+            }
+
+        monkeypatch.setattr(mod, "_probe_slot_with_refresh", fake_probe)
+
+        out = tmp_path / "health.json"
+        mod.probe_all(slots=["bob", "alice", "erik"], output=out)
+
+        assert probed == ["alice", "erik"]

--- a/scripts/subscription-token-probe.py
+++ b/scripts/subscription-token-probe.py
@@ -117,7 +117,14 @@ def _offline_probe_error(slot: str) -> dict[str, Any] | None:
 
 
 def _probe_slot(slot: str, token: str) -> dict[str, Any]:
-    """Make live API call to verify a slot's token is valid server-side.
+    """Make a direct HTTP probe with an explicit token string.
+
+    This is the unit-testable inner implementation — callers supply the token
+    directly, making it easy to mock HTTP responses in tests.  The production
+    path goes through ``_probe_slot_with_refresh``, which reads credentials from
+    disk and handles stale-token refresh before delegating the live probe to
+    ``probe_credential``.  ``_probe_slot`` is kept separate so test suites can
+    exercise 200/401/403/429/network paths without needing real credential files.
 
     Returns a result dict with:
         slot, status (valid/dead/error), http_code, checked_at, error
@@ -272,13 +279,18 @@ def probe_all(
 
     merged = {r["slot"]: r for r in results}
     for slot_name, record in existing.items():
-        if slot_name not in merged:
+        # Skip the active slot — don't carry forward a stale "dead" record from a
+        # prior cycle where that slot was inactive; it is live now.
+        if slot_name not in merged and slot_name != active:
             merged[slot_name] = record
 
     merged_list = sorted(merged.values(), key=lambda r: r.get("slot", ""))
 
-    # Write TOKEN-DEAD markers for vitals integration
-    _write_dead_markers(merged_list, dead_slot_dir)
+    # Write TOKEN-DEAD markers for vitals integration.
+    # Guard on output so callers that pass output=None get no side effects
+    # (consistent with the documented "results returned but not written" contract).
+    if output is not None:
+        _write_dead_markers(merged_list, dead_slot_dir)
 
     # Write JSON state file
     if output is not None:
@@ -321,6 +333,7 @@ def format_context(results: list[dict[str, Any]]) -> str:
         if status == "valid":
             parts.append(f"{slot}=ok")
         elif status == "expired_offline":
+            # Legacy label from pre-stale-fix; kept for backwards-compatible display of old state files
             parts.append(f"{slot}=expired({at})")
         elif status == "dead":
             parts.append(f"{slot}=DEAD({at})")
@@ -332,7 +345,10 @@ def format_context(results: list[dict[str, Any]]) -> str:
 def _resolve_usage_script(arg: Path | None) -> Path | None:
     """Resolve the usage script path from arg, env var, or common locations."""
     if arg is not None:
-        return arg if arg.exists() else None
+        if not arg.exists():
+            print(f"warning: --usage-script path not found: {arg}", file=sys.stderr)
+            return None
+        return arg
 
     env_val = os.environ.get("GPTME_CLAUDE_USAGE_SCRIPT", "")
     if env_val:
@@ -426,6 +442,7 @@ def main() -> int:
     dead = []
     for r in results:
         status = r.get("status", "?")
+        # expired_offline: legacy label kept for backwards-compatible display of old state files
         icon = {"valid": "✓", "dead": "✗", "expired_offline": "~", "error": "⚠"}.get(
             status, "?"
         )

--- a/scripts/subscription-token-probe.py
+++ b/scripts/subscription-token-probe.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env -S uv run python3
+"""Live token-validity probe for inactive subscription slots.
+
+Catches server-side token invalidation that mtime-based staleness and offline
+expiresAt checks both miss.  In the 2026-06-02→03 credential-rot outage, a
+slot's credential file had a recent mtime and a valid-looking expiresAt, but
+the refresh token had been rotated server-side.  The offline check reported a
+false green.  This probe prevents that: for every inactive slot with a
+non-terminal credential file, it makes ONE live call through the
+refresh-aware probe path to confirm the token actually works.
+
+Results are written to a configurable state file and optionally accompanied
+by TOKEN-DEAD marker files consumable by vitals scripts.
+
+Configuration (priority: CLI arg > env var > default):
+    Output path:     --output / GPTME_SUBSCRIPTION_HEALTH_OUTPUT
+    Dead-slot dir:   --dead-slot-dir / GPTME_SUBSCRIPTION_DEAD_SLOT_DIR
+    Usage script:    --usage-script / GPTME_CLAUDE_USAGE_SCRIPT
+    Slot list:       --slots / GPTME_SUBSCRIPTION_SLOTS (comma-separated)
+
+Usage:
+    # Probe all inactive slots (using env vars for paths)
+    ./scripts/subscription-token-probe.py
+
+    # Explicit paths
+    ./scripts/subscription-token-probe.py \\
+        --output ~/bob/state/subscription-token-health.json \\
+        --dead-slot-dir ~/bob/state/backend-quota \\
+        --usage-script ~/bob/scripts/check-claude-usage.sh
+
+    # Print compact context snippet from last run
+    ./scripts/subscription-token-probe.py --context
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from gptme_subscription.auth import check_credential_file, probe_credential
+
+CREDS_DIR = Path.home() / ".claude"
+
+# Minimal payload for count_tokens — costs effectively $0, not inference
+_COUNT_TOKENS_BODY = (
+    b'{"model": "claude-sonnet-4-5", "messages": [{"role": "user", "content": "x"}]}'
+)
+_API_URL = "https://api.anthropic.com/v1/messages/count_tokens"
+_REQUEST_TIMEOUT = 75  # seconds
+
+
+def _default_slots() -> list[str]:
+    """Return slots from env var or default to bob/alice/erik."""
+    raw = os.environ.get("GPTME_SUBSCRIPTION_SLOTS", "")
+    parsed = [s.strip() for s in raw.split(",") if s.strip()]
+    return parsed or ["bob", "alice", "erik"]
+
+
+def _active_slot() -> str | None:
+    """Detect which slot the live symlink points to."""
+    live = CREDS_DIR / ".credentials.json"
+    try:
+        target = live.resolve().name
+    except OSError:
+        return None
+    return (
+        target.rsplit(".", 1)[-1] if target.startswith(".credentials.json.") else None
+    )
+
+
+def _slot_path(slot: str) -> Path:
+    return CREDS_DIR / f".credentials.json.{slot}"
+
+
+def _read_slot_token(slot: str) -> str | None:
+    """Read the accessToken from a slot's credential file."""
+    p = _slot_path(slot)
+    if not p.exists():
+        return None
+    try:
+        data = json.loads(p.read_text())
+        oauth = data.get("claudeAiOauth")
+        if not isinstance(oauth, dict):
+            return None
+        token = oauth.get("accessToken")
+        return str(token) if token else None
+    except (OSError, json.JSONDecodeError, KeyError):
+        return None
+
+
+def _offline_probe_error(slot: str) -> dict[str, Any] | None:
+    """Return an error result for credentials that cannot be probed offline.
+
+    A lapsed ``expiresAt`` only means the access token is stale; Claude Code can
+    refresh it through the refresh token on next use. Do not reject stale tokens
+    here. Only missing/malformed/unreadable credential files are terminal before
+    the live probe.
+    """
+    info = check_credential_file(_slot_path(slot), slot)
+    if info.status in ("valid", "stale"):
+        return None
+    return {
+        "slot": slot,
+        "status": "error",
+        "credential_status": info.status,
+        "http_code": None,
+        "checked_at": datetime.now(timezone.utc).isoformat(),
+        "error": info.error or f"cannot probe: {info.status}",
+    }
+
+
+def _probe_slot(slot: str, token: str) -> dict[str, Any]:
+    """Make live API call to verify a slot's token is valid server-side.
+
+    Returns a result dict with:
+        slot, status (valid/dead/error), http_code, checked_at, error
+    """
+    result: dict[str, Any] = {
+        "slot": slot,
+        "status": "unknown",
+        "http_code": None,
+        "checked_at": datetime.now(timezone.utc).isoformat(),
+        "error": None,
+    }
+
+    req = urllib.request.Request(
+        _API_URL,
+        method="POST",
+        data=_COUNT_TOKENS_BODY,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT) as resp:
+            result["http_code"] = resp.status
+            if resp.status == 200:
+                result["status"] = "valid"
+            else:
+                result["status"] = "dead"
+    except urllib.error.HTTPError as e:
+        result["http_code"] = e.code
+        if e.code in (401, 403):
+            result["status"] = "dead"
+            body_preview = e.read().decode(errors="replace")[:200]
+            result["error"] = f"HTTP {e.code}: {body_preview}"
+        elif e.code == 429:
+            result["status"] = "error"
+            result["error"] = "rate_limited"
+        else:
+            result["status"] = "error"
+            result["error"] = f"HTTP {e.code}"
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        result["status"] = "error"
+        result["error"] = str(e)
+
+    return result
+
+
+def _probe_slot_with_refresh(
+    slot: str, usage_script: Path | None = None
+) -> dict[str, Any]:
+    """Probe a slot through the same refresh-aware path as --check-auth --probe."""
+    info, probe_ok, probe_msg = probe_credential(
+        _slot_path(slot),
+        slot,
+        usage_script=usage_script,
+        timeout=_REQUEST_TIMEOUT,
+    )
+    result: dict[str, Any] = {
+        "slot": slot,
+        "status": "valid" if probe_ok else "dead",
+        "credential_status": info.status,
+        "expires_in_seconds": info.expires_in_seconds,
+        "subscription_type": info.subscription_type,
+        "http_code": None,
+        "checked_at": datetime.now(timezone.utc).isoformat(),
+        "error": None if probe_ok else probe_msg,
+        "probe_message": probe_msg,
+    }
+    if info.status in ("missing", "malformed", "unreadable"):
+        result["status"] = "error"
+    return result
+
+
+def _write_dead_markers(
+    results: list[dict[str, Any]], dead_slot_dir: Path | None = None
+) -> None:
+    """Write/remove TOKEN-DEAD file markers consumable by vitals scripts.
+
+    Creates ``slot-TOKEN-DEAD-<slot>`` files for dead tokens and removes
+    stale markers for slots that have recovered. Skips marker management
+    when ``dead_slot_dir`` is None.
+    """
+    if dead_slot_dir is None:
+        return
+
+    dead_slot_dir.mkdir(parents=True, exist_ok=True)
+
+    # Remove all existing TOKEN-DEAD markers first (clean slate)
+    for entry in list(dead_slot_dir.iterdir()):
+        if entry.name.startswith("slot-TOKEN-DEAD-"):
+            entry.unlink()
+
+    # Write markers for currently dead slots
+    for r in results:
+        if r.get("status") == "dead":
+            marker = dead_slot_dir / f"slot-TOKEN-DEAD-{r['slot']}"
+            marker.write_text(f"Token server-side dead at {r.get('checked_at', '?')}\n")
+
+
+def probe_all(
+    slots: list[str] | None = None,
+    output: Path | None = None,
+    dead_slot_dir: Path | None = None,
+    usage_script: Path | None = None,
+) -> list[dict[str, Any]]:
+    """Probe all inactive subscription slots and save results.
+
+    Args:
+        slots: List of slot names to probe. If None, detect from env/default.
+        output: Path to write results JSON. If None, results are returned but
+            not written to disk and dead-slot markers are not updated.
+        dead_slot_dir: Directory for TOKEN-DEAD marker files. If None,
+            marker management is skipped.
+        usage_script: Path to the check-claude-usage.sh script used for
+            refresh-aware probing. If None, probes skip the refresh step.
+
+    Returns:
+        List of probe result dicts (one per inactive slot probed).
+    """
+    if slots is None:
+        slots = _default_slots()
+
+    active = _active_slot()
+    results: list[dict[str, Any]] = []
+
+    for slot in slots:
+        if slot == active:
+            # Skip the active slot — we know it works (this script runs on it)
+            continue
+
+        offline_error = _offline_probe_error(slot)
+        if offline_error is not None:
+            results.append(offline_error)
+            continue
+
+        result = _probe_slot_with_refresh(slot, usage_script=usage_script)
+        results.append(result)
+
+    # Preserve existing results for slots we didn't probe this cycle,
+    # so the state file always has complete data
+    existing: dict[str, dict[str, Any]] = {}
+    if output and output.exists():
+        try:
+            existing_data = json.loads(output.read_text())
+            existing_records = existing_data if isinstance(existing_data, list) else []
+            for r in existing_records:
+                if isinstance(r, dict):
+                    existing[r.get("slot", "")] = r
+        except (OSError, json.JSONDecodeError):
+            pass
+
+    merged = {r["slot"]: r for r in results}
+    for slot_name, record in existing.items():
+        if slot_name not in merged:
+            merged[slot_name] = record
+
+    merged_list = sorted(merged.values(), key=lambda r: r.get("slot", ""))
+
+    # Write TOKEN-DEAD markers for vitals integration
+    _write_dead_markers(merged_list, dead_slot_dir)
+
+    # Write JSON state file
+    if output is not None:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(merged_list, indent=2) + "\n")
+
+    return merged_list
+
+
+def load_results(path: Path) -> list[dict[str, Any]]:
+    """Load the latest probe results from a state file."""
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text())
+        return data if isinstance(data, list) else []
+    except (OSError, json.JSONDecodeError):
+        return []
+
+
+def has_dead_slots(results: list[dict[str, Any]]) -> bool:
+    """Check if any slot has a dead token."""
+    return any(r.get("status") == "dead" for r in results)
+
+
+def dead_slot_names(results: list[dict[str, Any]]) -> list[str]:
+    """Return names of slots with dead tokens."""
+    return [r["slot"] for r in results if r.get("status") == "dead"]
+
+
+def format_context(results: list[dict[str, Any]]) -> str:
+    """Format probe results as a compact context snippet."""
+    if not results:
+        return "token-probe: no data"
+    parts = []
+    for r in sorted(results, key=lambda x: x.get("slot", "")):
+        status = r.get("status", "unknown")
+        slot = r.get("slot", "?")
+        at = r.get("checked_at", "")[:16]  # YYYY-MM-DDTHH:MM
+        if status == "valid":
+            parts.append(f"{slot}=ok")
+        elif status == "expired_offline":
+            parts.append(f"{slot}=expired({at})")
+        elif status == "dead":
+            parts.append(f"{slot}=DEAD({at})")
+        else:
+            parts.append(f"{slot}={status}({at})")
+    return "token-probe: " + ", ".join(parts)
+
+
+def _resolve_usage_script(arg: Path | None) -> Path | None:
+    """Resolve the usage script path from arg, env var, or common locations."""
+    if arg is not None:
+        return arg if arg.exists() else None
+
+    env_val = os.environ.get("GPTME_CLAUDE_USAGE_SCRIPT", "")
+    if env_val:
+        p = Path(env_val)
+        return p if p.exists() else None
+
+    # Auto-detect common agent workspace layouts
+    for candidate in [
+        Path.home() / "bob" / "scripts" / "check-claude-usage.sh",
+        Path.home() / "alice" / "scripts" / "check-claude-usage.sh",
+        Path.home() / "scripts" / "check-claude-usage.sh",
+    ]:
+        if candidate.exists():
+            return candidate
+
+    return None
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    default_output = os.environ.get("GPTME_SUBSCRIPTION_HEALTH_OUTPUT", "")
+    default_dead_dir = os.environ.get("GPTME_SUBSCRIPTION_DEAD_SLOT_DIR", "")
+    parser = argparse.ArgumentParser(
+        description="Probe inactive subscription slots for live token validity"
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path(default_output) if default_output else None,
+        help=(
+            "Output path for health JSON "
+            "(env: GPTME_SUBSCRIPTION_HEALTH_OUTPUT; default: no output file)"
+        ),
+    )
+    parser.add_argument(
+        "--dead-slot-dir",
+        type=Path,
+        default=Path(default_dead_dir) if default_dead_dir else None,
+        help=(
+            "Directory for TOKEN-DEAD marker files "
+            "(env: GPTME_SUBSCRIPTION_DEAD_SLOT_DIR; default: disabled)"
+        ),
+    )
+    parser.add_argument(
+        "--usage-script",
+        type=Path,
+        default=None,
+        help=(
+            "Path to check-claude-usage.sh for refresh-aware probing "
+            "(env: GPTME_CLAUDE_USAGE_SCRIPT; auto-detected from common locations)"
+        ),
+    )
+    parser.add_argument(
+        "--slots",
+        default=None,
+        help="Comma-separated slot names (env: GPTME_SUBSCRIPTION_SLOTS; default: bob,alice,erik)",
+    )
+    parser.add_argument(
+        "--context",
+        action="store_true",
+        help="Print compact context snippet from last run and exit",
+    )
+    return parser.parse_args(argv)
+
+
+def main() -> int:
+    args = _parse_args()
+
+    if args.context:
+        if args.output is None:
+            print("token-probe: no output path configured (use --output)")
+            return 1
+        results = load_results(args.output)
+        print(format_context(results))
+        return 0
+
+    slots = (
+        [s.strip() for s in args.slots.split(",") if s.strip()]
+        if args.slots
+        else _default_slots()
+    )
+    usage_script = _resolve_usage_script(args.usage_script)
+
+    results = probe_all(
+        slots=slots,
+        output=args.output,
+        dead_slot_dir=args.dead_slot_dir,
+        usage_script=usage_script,
+    )
+
+    print(f"Probed {len(results)} inactive slot(s):")
+    dead = []
+    for r in results:
+        status = r.get("status", "?")
+        icon = {"valid": "✓", "dead": "✗", "expired_offline": "~", "error": "⚠"}.get(
+            status, "?"
+        )
+        print(f"  {r['slot']}: {icon} {status}")
+        if r.get("error"):
+            print(f"      error: {r['error']}")
+        if status == "dead":
+            dead.append(r)
+
+    if dead:
+        print(f"\n⚠ {len(dead)} dead slot(s): {', '.join(r['slot'] for r in dead)}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Upstreams `scripts/subscription-token-probe.py` from the bob brain repo to gptme-contrib so any agent workspace can use the probe without copy-pasting (requested in [ErikBjare/bob#918](https://github.com/ErikBjare/bob/issues/918))
- Key correctness fix carried from brain-repo commit `0cd3edf266`: stale access tokens (`expiresAt < now`) are no longer rejected offline — CC auto-refreshes them on next use; only missing/malformed/unreadable credential files are terminal before the live probe
- Made paths fully configurable (no brain-repo `REPO_ROOT` hardcoding): output file, dead-slot dir, and usage-script are all env-var + CLI-arg driven
- 20 new tests covering API probe (200/401/403/429/network), stale-token handling, TOKEN-DEAD marker management, and `probe_all` integration

## Background

In the 2026-06-02→03 credential-rot outage, a slot's access token had lapsed (`expiresAt < now`) but its refresh token was still valid. The old probe rejected it as `expired_offline` without attempting a live refresh. The fix: treat `stale` (lapsed access token) the same as `valid` for the offline pre-check; only send tokens through the live refresh-aware probe path.

## Changes for generic use

| Brain-repo | gptme-contrib |
|---|---|
| `REPO_ROOT` hardcoded | All paths via CLI args + env vars |
| `DEAD_SLOT_DIR` always written | `--dead-slot-dir` opt-in |
| `USAGE_SCRIPT` from `REPO_ROOT/scripts/` | Auto-detected from common layouts + `GPTME_CLAUDE_USAGE_SCRIPT` |
| `probe_all(output=...)` always writes | `output=None` returns results without file I/O |

## Test plan

- [x] 20 unit tests pass: `uv run --all-packages pytest packages/gptme-subscription/tests/test_subscription_token_probe.py`
- [x] Full subscription package suite (104 tests) pass: no regressions
- [x] `ruff check` + `ruff format` on new files: clean
- [x] `mypy scripts/subscription-token-probe.py --ignore-missing-imports`: no issues