### PR TITLE
feat(subscription): add live token-probe script with refresh-aware stale-slot detection

### DIFF
--- a/packages/gptme-subscription/tests/test_probe.py
+++ b/packages/gptme-subscription/tests/test_probe.py
@@ -1,0 +1,469 @@
+"""Tests for scripts/subscription-token-probe.py.
+
+Covers the live token-validity probe: API probe logic, TOKEN-DEAD marker
+writes/removals, refresh-aware probing for stale/missing access tokens,
+and the format_context/has_dead_slots helper functions.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import urllib.error
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from io import BytesIO
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+PROBE_SCRIPT = (
+    Path(__file__).resolve().parent.parent.parent.parent
+    / "scripts"
+    / "subscription-token-probe.py"
+)
+
+
+def _load_probe():
+    """Load subscription-token-probe.py as a module."""
+    spec = importlib.util.spec_from_file_location(
+        "subscription_token_probe", PROBE_SCRIPT
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _make_cred_file(path: Path, expires_in_seconds: int = 3600) -> None:
+    """Write a minimal valid credential file."""
+    now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+    expires_at_ms = now_ms + expires_in_seconds * 1000
+    path.write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "fake-access-token-abc123",
+                    "refreshToken": "fake-refresh-token-xyz789",
+                    "expiresAt": expires_at_ms,
+                    "subscriptionType": "claude_max",
+                    "scopes": ["user:inference"],
+                }
+            }
+        )
+    )
+
+
+def _make_http_response(status: int, body: bytes = b'{"input_tokens": 1}') -> MagicMock:
+    """Return a mock HTTP response object."""
+    resp = MagicMock()
+    resp.status = status
+    resp.__enter__ = lambda s: s
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+# ---- _probe_slot ----
+
+
+class TestProbeSlot:
+    """Unit tests for _probe_slot(slot, token)."""
+
+    def test_valid_200_returns_valid(self):
+        """200 from the API → status='valid'."""
+        mod = _load_probe()
+        resp = _make_http_response(200)
+        with patch.object(urllib.request, "urlopen", return_value=resp):
+            result = mod._probe_slot("bob", "fake-token")
+        assert result["status"] == "valid"
+        assert result["slot"] == "bob"
+        assert result["http_code"] == 200
+        assert result["error"] is None
+
+    def test_401_returns_dead(self):
+        """401 → token is server-side dead."""
+        mod = _load_probe()
+        exc = urllib.error.HTTPError(
+            url="https://api.anthropic.com/v1/messages/count_tokens",
+            code=401,
+            msg="Unauthorized",
+            hdrs=None,  # type: ignore[arg-type]
+            fp=BytesIO(b'{"error": "invalid_token"}'),
+        )
+        with patch.object(urllib.request, "urlopen", side_effect=exc):
+            result = mod._probe_slot("bob", "dead-token")
+        assert result["status"] == "dead"
+        assert result["http_code"] == 401
+
+    def test_403_returns_dead(self):
+        """403 → token is server-side dead."""
+        mod = _load_probe()
+        exc = urllib.error.HTTPError(
+            url="https://api.anthropic.com/v1/messages/count_tokens",
+            code=403,
+            msg="Forbidden",
+            hdrs=None,  # type: ignore[arg-type]
+            fp=BytesIO(b'{"error": "forbidden"}'),
+        )
+        with patch.object(urllib.request, "urlopen", side_effect=exc):
+            result = mod._probe_slot("alice", "bad-token")
+        assert result["status"] == "dead"
+        assert result["http_code"] == 403
+
+    def test_429_returns_error_not_dead(self):
+        """429 rate-limit → status='error', not 'dead' (token may still be alive)."""
+        mod = _load_probe()
+        exc = urllib.error.HTTPError(
+            url="https://api.anthropic.com/v1/messages/count_tokens",
+            code=429,
+            msg="Too Many Requests",
+            hdrs=None,  # type: ignore[arg-type]
+            fp=BytesIO(b'{"error": "rate_limited"}'),
+        )
+        with patch.object(urllib.request, "urlopen", side_effect=exc):
+            result = mod._probe_slot("bob", "ok-token")
+        assert result["status"] == "error"
+        assert result["error"] == "rate_limited"
+
+    def test_network_error_returns_error(self):
+        """Network failure → status='error'."""
+        mod = _load_probe()
+        exc = urllib.error.URLError("connection refused")
+        with patch.object(urllib.request, "urlopen", side_effect=exc):
+            result = mod._probe_slot("bob", "some-token")
+        assert result["status"] == "error"
+        assert "connection" in (result["error"] or "").lower()
+
+    def test_result_includes_checked_at(self):
+        """Result always includes a checked_at ISO timestamp."""
+        mod = _load_probe()
+        resp = _make_http_response(200)
+        with patch.object(urllib.request, "urlopen", return_value=resp):
+            result = mod._probe_slot("bob", "fake-token")
+        assert "checked_at" in result
+        datetime.fromisoformat(result["checked_at"])
+
+
+# ---- _offline_probe_error ----
+
+
+class TestOfflineProbeError:
+    """Unit tests for _offline_probe_error(slot) fast-reject path."""
+
+    def test_fresh_token_probeable(self, tmp_path, monkeypatch):
+        """A token expiring in 1 hour is probeable."""
+        mod = _load_probe()
+        cred = tmp_path / ".credentials.json.bob"
+        _make_cred_file(cred, expires_in_seconds=3600)
+        monkeypatch.setattr(mod, "CREDS_DIR", tmp_path)
+        assert mod._offline_probe_error("bob") is None
+
+    def test_expired_token_still_probeable(self, tmp_path, monkeypatch):
+        """A lapsed access token is stale, not dead; live probe can refresh it."""
+        mod = _load_probe()
+        cred = tmp_path / ".credentials.json.bob"
+        _make_cred_file(cred, expires_in_seconds=-300)
+        monkeypatch.setattr(mod, "CREDS_DIR", tmp_path)
+        assert mod._offline_probe_error("bob") is None
+
+    def test_missing_file_returns_error(self, tmp_path, monkeypatch):
+        """Missing credential file cannot be live-probed."""
+        mod = _load_probe()
+        monkeypatch.setattr(mod, "CREDS_DIR", tmp_path)
+        result = mod._offline_probe_error("noexist")
+        assert result is not None
+        assert result["status"] == "error"
+        assert result["credential_status"] == "missing"
+
+
+# ---- _write_dead_markers ----
+
+
+class TestWriteDeadMarkers:
+    """Unit tests for _write_dead_markers(results)."""
+
+    def test_noop_when_dead_slot_dir_is_none(self, tmp_path, monkeypatch):
+        """When DEAD_SLOT_DIR is None, _write_dead_markers is a no-op."""
+        mod = _load_probe()
+        monkeypatch.setattr(mod, "DEAD_SLOT_DIR", None)
+        results = [{"slot": "bob", "status": "dead", "checked_at": "t"}]
+        mod._write_dead_markers(results)
+        # No exception, no files written elsewhere
+
+    def test_creates_marker_for_dead_slot(self, tmp_path, monkeypatch):
+        """Dead slot → TOKEN-DEAD-<slot> marker file is created."""
+        mod = _load_probe()
+        monkeypatch.setattr(mod, "DEAD_SLOT_DIR", tmp_path)
+        results = [
+            {"slot": "bob", "status": "dead", "checked_at": "2026-01-01T00:00:00"}
+        ]
+        mod._write_dead_markers(results)
+        marker = tmp_path / "slot-TOKEN-DEAD-bob"
+        assert marker.exists(), "TOKEN-DEAD marker should exist for dead slot"
+
+    def test_no_marker_for_valid_slot(self, tmp_path, monkeypatch):
+        """Valid slot → no TOKEN-DEAD marker."""
+        mod = _load_probe()
+        monkeypatch.setattr(mod, "DEAD_SLOT_DIR", tmp_path)
+        results = [
+            {"slot": "alice", "status": "valid", "checked_at": "2026-01-01T00:00:00"}
+        ]
+        mod._write_dead_markers(results)
+        marker = tmp_path / "slot-TOKEN-DEAD-alice"
+        assert not marker.exists()
+
+    def test_clears_stale_markers_on_recovery(self, tmp_path, monkeypatch):
+        """When a previously dead slot recovers, its stale marker is removed."""
+        mod = _load_probe()
+        monkeypatch.setattr(mod, "DEAD_SLOT_DIR", tmp_path)
+
+        stale_marker = tmp_path / "slot-TOKEN-DEAD-bob"
+        stale_marker.write_text("stale dead marker\n")
+
+        results = [
+            {"slot": "bob", "status": "valid", "checked_at": "2026-01-01T00:00:00"}
+        ]
+        mod._write_dead_markers(results)
+
+        assert not stale_marker.exists(), "Stale marker should be cleared on recovery"
+
+    def test_mixed_results(self, tmp_path, monkeypatch):
+        """Dead slot gets marker; valid slot does not; stale marker cleared."""
+        mod = _load_probe()
+        monkeypatch.setattr(mod, "DEAD_SLOT_DIR", tmp_path)
+
+        (tmp_path / "slot-TOKEN-DEAD-alice").write_text("old\n")
+
+        results = [
+            {"slot": "alice", "status": "valid", "checked_at": "t"},
+            {"slot": "erik", "status": "dead", "checked_at": "t"},
+        ]
+        mod._write_dead_markers(results)
+
+        assert not (tmp_path / "slot-TOKEN-DEAD-alice").exists()
+        assert (tmp_path / "slot-TOKEN-DEAD-erik").exists()
+
+    def test_non_token_dead_files_untouched(self, tmp_path, monkeypatch):
+        """Files in DEAD_SLOT_DIR that don't start with 'slot-TOKEN-DEAD-' are preserved."""
+        mod = _load_probe()
+        monkeypatch.setattr(mod, "DEAD_SLOT_DIR", tmp_path)
+
+        other = tmp_path / "some-other-marker.txt"
+        other.write_text("unrelated\n")
+
+        mod._write_dead_markers([{"slot": "bob", "status": "valid", "checked_at": "t"}])
+
+        assert other.exists(), "Non-TOKEN-DEAD files must not be removed"
+
+
+# ---- probe_all ----
+
+
+class TestProbeAll:
+    """Integration tests for probe_all()."""
+
+    def test_skips_active_slot(self, tmp_path, monkeypatch):
+        """probe_all never probes the slot the live symlink points to."""
+        mod = _load_probe()
+        monkeypatch.setattr(mod, "DEAD_SLOT_DIR", None)
+        monkeypatch.setattr(mod, "CREDS_DIR", tmp_path / "creds")
+        (tmp_path / "creds").mkdir()
+
+        monkeypatch.setattr(mod, "_active_slot", lambda: "bob")
+
+        probed: list[str] = []
+
+        def fake_probe(slot: str) -> dict:
+            probed.append(slot)
+            return {
+                "slot": slot,
+                "status": "valid",
+                "http_code": 200,
+                "checked_at": "t",
+                "error": None,
+            }
+
+        monkeypatch.setattr(mod, "_offline_probe_error", lambda s: None)
+        monkeypatch.setattr(mod, "_probe_slot_with_refresh", fake_probe)
+
+        out = tmp_path / "health.json"
+        mod.probe_all(slots=["bob", "alice", "erik"], output=out)
+
+        assert "bob" not in probed, "Active slot must not be probed"
+        assert "alice" in probed
+        assert "erik" in probed
+
+    def test_writes_state_file(self, tmp_path, monkeypatch):
+        """probe_all writes results to the output JSON file."""
+        mod = _load_probe()
+        monkeypatch.setattr(mod, "DEAD_SLOT_DIR", None)
+        monkeypatch.setattr(mod, "CREDS_DIR", tmp_path / "creds")
+        (tmp_path / "creds").mkdir()
+
+        monkeypatch.setattr(mod, "_active_slot", lambda: "bob")
+        monkeypatch.setattr(mod, "_offline_probe_error", lambda s: None)
+        monkeypatch.setattr(
+            mod,
+            "_probe_slot_with_refresh",
+            lambda slot: {
+                "slot": slot,
+                "status": "valid",
+                "http_code": 200,
+                "checked_at": "t",
+                "error": None,
+            },
+        )
+
+        out = tmp_path / "health.json"
+        mod.probe_all(slots=["bob", "alice"], output=out)
+
+        assert out.exists()
+        data = json.loads(out.read_text())
+        assert isinstance(data, list)
+        slots_in_file = {r["slot"] for r in data}
+        assert "alice" in slots_in_file
+
+    def test_dead_slot_creates_marker(self, tmp_path, monkeypatch):
+        """When probe_all finds a dead slot, the TOKEN-DEAD marker is written."""
+        mod = _load_probe()
+        quota_dir = tmp_path / "quota"
+        quota_dir.mkdir()
+        monkeypatch.setattr(mod, "DEAD_SLOT_DIR", quota_dir)
+        monkeypatch.setattr(mod, "CREDS_DIR", tmp_path / "creds")
+        (tmp_path / "creds").mkdir()
+
+        monkeypatch.setattr(mod, "_active_slot", lambda: "bob")
+        monkeypatch.setattr(mod, "_offline_probe_error", lambda s: None)
+
+        def dead_probe(slot: str) -> dict:
+            return {
+                "slot": slot,
+                "status": "dead",
+                "http_code": 401,
+                "checked_at": "t",
+                "error": "HTTP 401",
+            }
+
+        monkeypatch.setattr(mod, "_probe_slot_with_refresh", dead_probe)
+
+        out = tmp_path / "health.json"
+        mod.probe_all(slots=["bob", "alice"], output=out)
+
+        assert (quota_dir / "slot-TOKEN-DEAD-alice").exists()
+
+    def test_stale_access_tokens_are_live_probed(self, tmp_path, monkeypatch):
+        """Slots with lapsed access tokens still use the refresh-aware probe."""
+        mod = _load_probe()
+        monkeypatch.setattr(mod, "DEAD_SLOT_DIR", None)
+        creds = tmp_path / "creds"
+        monkeypatch.setattr(mod, "CREDS_DIR", creds)
+        creds.mkdir()
+        _make_cred_file(creds / ".credentials.json.alice", expires_in_seconds=-300)
+        _make_cred_file(creds / ".credentials.json.erik", expires_in_seconds=-300)
+
+        monkeypatch.setattr(mod, "_active_slot", lambda: "bob")
+
+        probed: list[str] = []
+
+        def fake_probe(slot: str) -> dict:
+            probed.append(slot)
+            return {
+                "slot": slot,
+                "status": "valid",
+                "http_code": 200,
+                "checked_at": "t",
+                "error": None,
+            }
+
+        monkeypatch.setattr(mod, "_probe_slot_with_refresh", fake_probe)
+
+        out = tmp_path / "health.json"
+        mod.probe_all(slots=["bob", "alice", "erik"], output=out)
+
+        assert probed == ["alice", "erik"]
+
+    def test_missing_access_token_still_uses_refresh_probe(self, tmp_path, monkeypatch):
+        """A parseable slot can still live-probe through refresh without accessToken."""
+        mod = _load_probe()
+        monkeypatch.setattr(mod, "DEAD_SLOT_DIR", None)
+        creds = tmp_path / "creds"
+        monkeypatch.setattr(mod, "CREDS_DIR", creds)
+        creds.mkdir()
+        (creds / ".credentials.json.alice").write_text(
+            json.dumps(
+                {
+                    "claudeAiOauth": {
+                        "refreshToken": "fake-refresh-token-xyz789",
+                        "expiresAt": int(
+                            (
+                                datetime.now(timezone.utc) + timedelta(hours=1)
+                            ).timestamp()
+                            * 1000
+                        ),
+                        "subscriptionType": "claude_max",
+                    }
+                }
+            )
+        )
+
+        monkeypatch.setattr(mod, "_active_slot", lambda: "bob")
+
+        info = SimpleNamespace(
+            status="valid",
+            error=None,
+            expires_in_seconds=3600,
+            subscription_type="claude_max",
+        )
+
+        monkeypatch.setattr(mod, "check_credential_file", lambda path, slot: info)
+        probed: list[str] = []
+
+        def fake_probe_credential(path, slot, usage_script=None, timeout=None):
+            probed.append(slot)
+            return info, True, "ok"
+
+        monkeypatch.setattr(mod, "probe_credential", fake_probe_credential)
+
+        out = tmp_path / "health.json"
+        mod.probe_all(slots=["bob", "alice"], output=out)
+
+        assert (
+            "alice" in probed
+        ), "alice should be live-probed despite missing accessToken"
+
+
+# ---- format_context / has_dead_slots ----
+
+
+class TestHelpers:
+    """Unit tests for format_context and has_dead_slots."""
+
+    def test_format_context_no_data(self):
+        mod = _load_probe()
+        assert mod.format_context([]) == "token-probe: no data"
+
+    def test_format_context_valid_slots(self):
+        mod = _load_probe()
+        results = [
+            {"slot": "alice", "status": "valid", "checked_at": "2026-01-01T10:00:00"},
+            {"slot": "erik", "status": "valid", "checked_at": "2026-01-01T10:00:00"},
+        ]
+        ctx = mod.format_context(results)
+        assert "alice=ok" in ctx
+        assert "erik=ok" in ctx
+
+    def test_format_context_dead_slot(self):
+        mod = _load_probe()
+        results = [
+            {"slot": "alice", "status": "dead", "checked_at": "2026-01-01T10:00:00"},
+        ]
+        ctx = mod.format_context(results)
+        assert "alice=DEAD(" in ctx
+
+    def test_has_dead_slots_true(self):
+        mod = _load_probe()
+        assert mod.has_dead_slots([{"slot": "alice", "status": "dead"}])
+
+    def test_has_dead_slots_false(self):
+        mod = _load_probe()
+        assert not mod.has_dead_slots([{"slot": "alice", "status": "valid"}])

--- a/scripts/subscription-token-probe.py
+++ b/scripts/subscription-token-probe.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+"""Live token-validity probe for inactive subscription slots.
+
+Catches server-side token invalidation that mtime-based staleness and
+offline expiresAt checks both miss. For every inactive slot with a
+non-missing/non-malformed credential file, it makes ONE live API call
+(count_tokens, ~$0, not inference) to verify the token actually works.
+
+Background: in a 2026-06-02→03 credential-rot outage, a credential file
+had a recent mtime and a valid-looking expiresAt, but the refresh token had
+been rotated server-side. The offline check reported "ok" — a false green.
+This probe prevents that.
+
+Usage:
+    # Probe all inactive slots (results to XDG state dir or GPTME_SUBSCRIPTION_STATE_DIR)
+    ./scripts/subscription-token-probe.py
+
+    # Write results to a specific path
+    ./scripts/subscription-token-probe.py --output path/to/file.json
+
+    # Print compact context snippet (reads last results; does not probe)
+    ./scripts/subscription-token-probe.py --context
+
+Configuration (via env vars):
+    GPTME_SUBSCRIPTION_SLOTS           comma-separated slot names (default: bob,alice,erik)
+    GPTME_SUBSCRIPTION_STATE_DIR       directory for state file (default: XDG_STATE_HOME/gptme-subscription)
+    GPTME_SUBSCRIPTION_DEAD_SLOT_DIR   directory for TOKEN-DEAD marker files (optional)
+    GPTME_SUBSCRIPTION_USAGE_SCRIPT    path to a check-claude-usage.sh-style probe (optional)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from gptme_subscription.auth import check_credential_file, probe_credential
+
+# ---- Configurable paths ----
+
+CREDS_DIR = Path.home() / ".claude"
+
+_state_dir_env = os.environ.get("GPTME_SUBSCRIPTION_STATE_DIR", "")
+_xdg_state = (
+    Path(os.environ.get("XDG_STATE_HOME", "")) or Path.home() / ".local" / "state"
+)
+_STATE_DIR = (
+    Path(_state_dir_env) if _state_dir_env else _xdg_state / "gptme-subscription"
+)
+DEFAULT_OUTPUT = _STATE_DIR / "token-health.json"
+
+# Dead-slot marker directory (optional; set GPTME_SUBSCRIPTION_DEAD_SLOT_DIR to enable)
+_dead_slot_dir_env = os.environ.get("GPTME_SUBSCRIPTION_DEAD_SLOT_DIR", "")
+DEAD_SLOT_DIR: Path | None = Path(_dead_slot_dir_env) if _dead_slot_dir_env else None
+
+# Optional usage script for refresh-aware probing
+_usage_script_env = os.environ.get("GPTME_SUBSCRIPTION_USAGE_SCRIPT", "")
+USAGE_SCRIPT: Path | None = Path(_usage_script_env) if _usage_script_env else None
+
+# Minimal payload for count_tokens — costs effectively $0, not inference
+_COUNT_TOKENS_BODY = (
+    b'{"model": "claude-sonnet-4-5", "messages": [{"role": "user", "content": "x"}]}'
+)
+_API_URL = "https://api.anthropic.com/v1/messages/count_tokens"
+_REQUEST_TIMEOUT = 75  # seconds
+
+
+def _default_slots() -> list[str]:
+    """Return slots from env var or default to bob/alice/erik."""
+    raw = os.environ.get("GPTME_SUBSCRIPTION_SLOTS", "")
+    parsed = [s.strip() for s in raw.split(",") if s.strip()]
+    return parsed or ["bob", "alice", "erik"]
+
+
+def _active_slot() -> str | None:
+    """Detect which slot the live symlink points to."""
+    live = CREDS_DIR / ".credentials.json"
+    try:
+        target = live.resolve().name
+    except OSError:
+        return None
+    return (
+        target.rsplit(".", 1)[-1] if target.startswith(".credentials.json.") else None
+    )
+
+
+def _slot_path(slot: str) -> Path:
+    return CREDS_DIR / f".credentials.json.{slot}"
+
+
+def _offline_probe_error(slot: str) -> dict[str, Any] | None:
+    """Return an error result for credentials that cannot be probed offline.
+
+    A lapsed ``expiresAt`` only means the access token is stale; Claude Code can
+    refresh it through the refresh token on next use. Do not reject stale tokens
+    here. Only missing/malformed/unreadable credential files are terminal before
+    the live probe.
+    """
+    info = check_credential_file(_slot_path(slot), slot)
+    if info.status in ("valid", "stale"):
+        return None
+    return {
+        "slot": slot,
+        "status": "error",
+        "credential_status": info.status,
+        "http_code": None,
+        "checked_at": datetime.now(timezone.utc).isoformat(),
+        "error": info.error or f"cannot probe: {info.status}",
+    }
+
+
+def _probe_slot(slot: str, token: str) -> dict[str, Any]:
+    """Make live API call to verify a slot's token is valid server-side.
+
+    Returns a result dict with:
+        slot, status (valid/dead/error), http_code, checked_at, error
+    """
+    result: dict[str, Any] = {
+        "slot": slot,
+        "status": "unknown",
+        "http_code": None,
+        "checked_at": datetime.now(timezone.utc).isoformat(),
+        "error": None,
+    }
+
+    req = urllib.request.Request(
+        _API_URL,
+        method="POST",
+        data=_COUNT_TOKENS_BODY,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT) as resp:
+            result["http_code"] = resp.status
+            if resp.status == 200:
+                result["status"] = "valid"
+            else:
+                result["status"] = "dead"
+    except urllib.error.HTTPError as e:
+        result["http_code"] = e.code
+        if e.code in (401, 403):
+            result["status"] = "dead"
+            body_preview = e.read().decode(errors="replace")[:200]
+            result["error"] = f"HTTP {e.code}: {body_preview}"
+        elif e.code == 429:
+            result["status"] = "error"
+            result["error"] = "rate_limited"
+        else:
+            result["status"] = "error"
+            result["error"] = f"HTTP {e.code}"
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        result["status"] = "error"
+        result["error"] = str(e)
+
+    return result
+
+
+def _probe_slot_with_refresh(slot: str) -> dict[str, Any]:
+    """Probe a slot through the same refresh-aware path as --check-auth --probe.
+
+    Works even when the stored accessToken is stale/missing — the refresh token
+    flow can still succeed server-side.
+    """
+    info, probe_ok, probe_msg = probe_credential(
+        _slot_path(slot),
+        slot,
+        usage_script=USAGE_SCRIPT if USAGE_SCRIPT and USAGE_SCRIPT.exists() else None,
+        timeout=_REQUEST_TIMEOUT,
+    )
+    result: dict[str, Any] = {
+        "slot": slot,
+        "status": "valid" if probe_ok else "dead",
+        "credential_status": info.status,
+        "expires_in_seconds": info.expires_in_seconds,
+        "subscription_type": info.subscription_type,
+        "http_code": None,
+        "checked_at": datetime.now(timezone.utc).isoformat(),
+        "error": None if probe_ok else probe_msg,
+        "probe_message": probe_msg,
+    }
+    if info.status in ("missing", "malformed", "unreadable"):
+        result["status"] = "error"
+    return result
+
+
+def _write_dead_markers(results: list[dict[str, Any]]) -> None:
+    """Write/remove TOKEN-DEAD file markers in DEAD_SLOT_DIR (if configured).
+
+    Creates ``slot-TOKEN-DEAD-<slot>`` files for dead slots, removes them for
+    slots that recovered. Agents can read these to surface dead-token warnings.
+    """
+    if DEAD_SLOT_DIR is None:
+        return
+
+    DEAD_SLOT_DIR.mkdir(parents=True, exist_ok=True)
+
+    # Remove all existing TOKEN-DEAD markers first (clean slate)
+    for entry in list(DEAD_SLOT_DIR.iterdir()):
+        if entry.name.startswith("slot-TOKEN-DEAD-"):
+            entry.unlink()
+
+    # Write markers for currently dead slots
+    for r in results:
+        if r.get("status") == "dead":
+            marker = DEAD_SLOT_DIR / f"slot-TOKEN-DEAD-{r['slot']}"
+            marker.write_text(f"Token server-side dead at {r.get('checked_at', '?')}\n")
+
+
+def probe_all(
+    slots: list[str] | None = None, output: Path | None = None
+) -> list[dict[str, Any]]:
+    """Probe all inactive subscription slots and save results.
+
+    Args:
+        slots: List of slot names to probe. If None, detect from env/default.
+        output: Path to write results. If None, use DEFAULT_OUTPUT.
+
+    Returns:
+        List of probe result dicts (one per inactive slot).
+    """
+    if slots is None:
+        slots = _default_slots()
+
+    active = _active_slot()
+    results: list[dict[str, Any]] = []
+
+    for slot in slots:
+        if slot == active:
+            # Skip the active slot — we know it works (this script runs on it)
+            continue
+
+        offline_error = _offline_probe_error(slot)
+        if offline_error is not None:
+            results.append(offline_error)
+            continue
+
+        result = _probe_slot_with_refresh(slot)
+        results.append(result)
+
+    # Preserve existing results for slots we didn't probe this cycle,
+    # so the state file always has complete data
+    existing: dict[str, dict[str, Any]] = {}
+    if output and output.exists():
+        try:
+            existing_data = json.loads(output.read_text())
+            existing_records = existing_data if isinstance(existing_data, list) else []
+            for r in existing_records:
+                if isinstance(r, dict):
+                    existing[r.get("slot", "")] = r
+        except (OSError, json.JSONDecodeError):
+            pass
+
+    merged = {r["slot"]: r for r in results}
+    for slot_name, record in existing.items():
+        if slot_name not in merged:
+            merged[slot_name] = record
+
+    merged_list = sorted(merged.values(), key=lambda r: r.get("slot", ""))
+
+    # Write TOKEN-DEAD markers if a dead-slot dir is configured
+    _write_dead_markers(merged_list)
+
+    # Write JSON state file
+    out_path = output or DEFAULT_OUTPUT
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(merged_list, indent=2) + "\n")
+
+    return merged_list
+
+
+def load_results(path: Path | None = None) -> list[dict[str, Any]]:
+    """Load the latest probe results from the state file."""
+    p = path or DEFAULT_OUTPUT
+    if not p.exists():
+        return []
+    try:
+        data = json.loads(p.read_text())
+        return data if isinstance(data, list) else []
+    except (OSError, json.JSONDecodeError):
+        return []
+
+
+def has_dead_slots(results: list[dict[str, Any]]) -> bool:
+    """Check if any slot has a dead token."""
+    return any(r.get("status") == "dead" for r in results)
+
+
+def dead_slot_names(results: list[dict[str, Any]]) -> list[str]:
+    """Return names of slots with dead tokens."""
+    return [r["slot"] for r in results if r.get("status") == "dead"]
+
+
+def format_context(results: list[dict[str, Any]]) -> str:
+    """Format probe results as a compact context snippet."""
+    if not results:
+        return "token-probe: no data"
+    parts = []
+    for r in sorted(results, key=lambda x: x.get("slot", "")):
+        status = r.get("status", "unknown")
+        slot = r.get("slot", "?")
+        at = r.get("checked_at", "")[:16]  # YYYY-MM-DDTHH:MM
+        if status == "valid":
+            parts.append(f"{slot}=ok")
+        elif status == "dead":
+            parts.append(f"{slot}=DEAD({at})")
+        else:
+            parts.append(f"{slot}={status}({at})")
+    return "token-probe: " + ", ".join(parts)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Probe inactive subscription slots for live token validity"
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help=f"Output path (default: {DEFAULT_OUTPUT})",
+    )
+    parser.add_argument(
+        "--context",
+        action="store_true",
+        help="Print compact context snippet and exit",
+    )
+    return parser.parse_args(argv)
+
+
+def main() -> int:
+    args = _parse_args()
+
+    if args.context:
+        results = load_results(args.output)
+        print(format_context(results))
+        return 0
+
+    results = probe_all(output=args.output)
+
+    print(f"Probed {len(results)} inactive slot(s):")
+    dead = []
+    for r in results:
+        status = r.get("status", "?")
+        icon = {"valid": "✓", "dead": "✗", "error": "⚠"}.get(status, "?")
+        print(f"  {r['slot']}: {icon} {status}")
+        if r.get("error"):
+            print(f"      error: {r['error']}")
+        if status == "dead":
+            dead.append(r)
+
+    if dead:
+        print(f"\n⚠ {len(dead)} dead slot(s): {', '.join(r['slot'] for r in dead)}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What changed

Adds `scripts/subscription-token-probe.py` — an hourly-runnable script that live-probes inactive subscription slots using one `count_tokens` API call (~\$0, not inference) per slot.

**The problem it solves**: In the 2026-06-02→03 credential-rot outage, a slot's refresh token was rotated server-side, but mtime-based staleness and offline `expiresAt` checks both reported "ok". The credential file had a recent mtime and a valid-looking timestamp — a false green that cascaded into a 10-hour outage.

**Key design decisions**:
- Uses `probe_credential()` (the same refresh-aware path as `gptme-subscription --check-auth --probe`) so slots with a lapsed `accessToken` are still probed via the refresh token flow — not skipped as "no token found" (the original bug)
- State paths configurable via env vars (`GPTME_SUBSCRIPTION_STATE_DIR`, `GPTME_SUBSCRIPTION_DEAD_SLOT_DIR`, `GPTME_SUBSCRIPTION_USAGE_SCRIPT`) with `XDG_STATE_HOME` fallback — no hard-coded agent paths
- Optional `TOKEN-DEAD` marker files in `DEAD_SLOT_DIR` for vitals/health-check integration
- Preserves existing results for unprobed slots between cycles (merge-by-slot, so the state file always has complete data)

## Tests

Adds `packages/gptme-subscription/tests/test_probe.py` with 25 tests covering:
- API status codes (200 → valid, 401/403 → dead, 429 → error, network failure)
- Offline fast-reject: fresh tokens probeable, lapsed tokens still probeable (stale, not dead)
- Dead-marker lifecycle: create on dead, clear on recovery, no-op when `DEAD_SLOT_DIR` is None
- `probe_all` orchestration: skip active slot, write state file, dead marker integration
- Missing `accessToken` live-probe via refresh (the regression test for the original bug)
- `format_context` and `has_dead_slots` helpers

## Related

- Refs ErikBjare/bob#918 (subscription probe reliability)
- ErikBjare/bob#921 (previous request to merge the bob-local version — this is the upstreamed, reviewed version)