### PR TITLE
feat(gptodo): auto-set waiting_since when transitioning to waiting state

### DIFF
--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -1628,14 +1628,11 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask):
                 else:
                     value = parsed.isoformat()
             elif field == "waiting_since":
-                # waiting_since is a date-only field (YYYY-MM-DD), not a datetime
+                # Accepts YYYY-MM-DD or full ISO datetime (e.g. YYYY-MM-DDTHH:MM:SS+00:00)
                 try:
-                    from datetime import date as _date
-
-                    parsed_date = _date.fromisoformat(value[:10])  # accept YYYY-MM-DD prefix
-                    value = parsed_date.isoformat()
+                    datetime.fromisoformat(value)
                 except ValueError:
-                    console.print(f"[red]Invalid {field} format. Use YYYY-MM-DD[/]")
+                    console.print(f"[red]Invalid {field} format. Use YYYY-MM-DD or ISO datetime[/]")
                     return
             else:
                 try:
@@ -1807,11 +1804,16 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask):
                         value = normalize_state(value, warn=False)
 
                     post.metadata[field] = value
-        # Auto-set waiting_since when transitioning to waiting state
-        if post.metadata.get("state") == "waiting" and not post.metadata.get("waiting_since"):
-            from datetime import date as _date
+        # Auto-set waiting_since only when THIS edit explicitly sets state to waiting.
+        # Checking `changes` (not just current state) prevents stamping today's date
+        # when editing an unrelated field on a pre-existing waiting task.
+        transitioning_to_waiting = any(
+            op == "set" and field == "state" and value == "waiting" for op, field, value in changes
+        )
+        if transitioning_to_waiting and not post.metadata.get("waiting_since"):
+            from datetime import datetime as _dt, timezone as _tz
 
-            post.metadata["waiting_since"] = _date.today().isoformat()
+            post.metadata["waiting_since"] = _dt.now(_tz.utc).isoformat(timespec="seconds")
 
         # Save changes
         with open(task.path, "w") as f:

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -1804,13 +1804,21 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask):
                         value = normalize_state(value, warn=False)
 
                     post.metadata[field] = value
-        # Auto-set waiting_since only when THIS edit explicitly sets state to waiting.
-        # Checking `changes` (not just current state) prevents stamping today's date
-        # when editing an unrelated field on a pre-existing waiting task.
+        # Auto-set waiting_since only when THIS edit explicitly sets state to waiting
+        # AND waiting_for is either already present or being set in the same edit.
+        # Guarding on waiting_for prevents an injected waiting_since from triggering
+        # the pre-commit hook error "waiting_since requires waiting_for".
         transitioning_to_waiting = any(
             op == "set" and field == "state" and value == "waiting" for op, field, value in changes
         )
-        if transitioning_to_waiting and not post.metadata.get("waiting_since"):
+        waiting_for_present = post.metadata.get("waiting_for") or any(
+            op == "set" and field == "waiting_for" for op, field, value in changes
+        )
+        if (
+            transitioning_to_waiting
+            and waiting_for_present
+            and not post.metadata.get("waiting_since")
+        ):
             from datetime import datetime as _dt, timezone as _tz
 
             post.metadata["waiting_since"] = _dt.now(_tz.utc).isoformat(timespec="seconds")

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -1812,7 +1812,8 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask):
             op == "set" and field == "state" and value == "waiting" for op, field, value in changes
         )
         waiting_for_present = post.metadata.get("waiting_for") or any(
-            op == "set" and field == "waiting_for" for op, field, value in changes
+            op == "set" and field == "waiting_for" and value is not None
+            for op, field, value in changes
         )
         if (
             transitioning_to_waiting

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -1821,6 +1821,9 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask):
         ):
             from datetime import datetime as _dt, timezone as _tz
 
+            # Full ISO datetime for intra-day resolution (ErikBjare request, 2026-06-16).
+            # validate_task_frontmatter.py's validate_timestamp() accepts both YYYY-MM-DD
+            # and full ISO datetime via datetime.fromisoformat().
             post.metadata["waiting_since"] = _dt.now(_tz.utc).isoformat(timespec="seconds")
 
         # Save changes

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -1627,6 +1627,16 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask):
                     value = parsed.isoformat()
                 else:
                     value = parsed.isoformat()
+            elif field == "waiting_since":
+                # waiting_since is a date-only field (YYYY-MM-DD), not a datetime
+                try:
+                    from datetime import date as _date
+
+                    parsed_date = _date.fromisoformat(value[:10])  # accept YYYY-MM-DD prefix
+                    value = parsed_date.isoformat()
+                except ValueError:
+                    console.print(f"[red]Invalid {field} format. Use YYYY-MM-DD[/]")
+                    return
             else:
                 try:
                     created_dt = datetime.fromisoformat(value)
@@ -1797,6 +1807,12 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask):
                         value = normalize_state(value, warn=False)
 
                     post.metadata[field] = value
+        # Auto-set waiting_since when transitioning to waiting state
+        if post.metadata.get("state") == "waiting" and not post.metadata.get("waiting_since"):
+            from datetime import date as _date
+
+            post.metadata["waiting_since"] = _date.today().isoformat()
+
         # Save changes
         with open(task.path, "w") as f:
             f.write(frontmatter.dumps(post))

--- a/packages/gptodo/tests/test_edit_state_waiting.py
+++ b/packages/gptodo/tests/test_edit_state_waiting.py
@@ -1,14 +1,14 @@
 """Tests for auto-injection of waiting_since when editing state to waiting.
 
 When `gptodo edit --set state waiting` is called, `waiting_since` should be
-automatically populated with today's date if it is not already present.
-This prevents the pre-commit `validate-task-frontmatter` hook from rejecting
+automatically populated with the current UTC datetime if it is not already set.
+This prevents the `validate-task-frontmatter` pre-commit hook from rejecting
 commits that transition tasks to waiting state.
 """
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import datetime, timezone
 from pathlib import Path
 
 from click.testing import CliRunner
@@ -35,18 +35,29 @@ waiting_since: 2026-06-01
 # Already Waiting Task
 """
 
+WAITING_WITHOUT_SINCE = """\
+---
+state: waiting
+created: 2026-06-01T00:00:00+00:00
+waiting_for: some-dependency
+---
+# Pre-existing Waiting Task Without waiting_since
+"""
+
 
 def test_edit_state_waiting_auto_sets_waiting_since(tmp_path: Path, monkeypatch) -> None:
-    """Transitioning to waiting auto-injects waiting_since with today's date."""
+    """Transitioning to waiting auto-injects waiting_since as a UTC ISO datetime."""
     tasks_dir = tmp_path / "tasks"
     tasks_dir.mkdir()
     (tasks_dir / "my-task.md").write_text(ACTIVE_TASK)
 
     monkeypatch.chdir(tmp_path)
+    before = datetime.now(timezone.utc).replace(microsecond=0)
     result = CliRunner().invoke(
         cli,
         ["edit", "my-task", "--set", "state", "waiting"],
     )
+    after = datetime.now(timezone.utc)
 
     assert result.exit_code == 0, f"edit failed: {result.output}"
 
@@ -55,7 +66,35 @@ def test_edit_state_waiting_auto_sets_waiting_since(tmp_path: Path, monkeypatch)
     task = tasks[0]
     assert task.metadata["state"] == "waiting"
     assert "waiting_since" in task.metadata, "waiting_since should be auto-set"
-    assert task.metadata["waiting_since"] == date.today().isoformat()
+    injected = datetime.fromisoformat(str(task.metadata["waiting_since"]))
+    if injected.tzinfo is None:
+        injected = injected.replace(tzinfo=timezone.utc)
+    assert (
+        before <= injected <= after
+    ), f"waiting_since {injected!r} not between {before!r} and {after!r}"
+
+
+def test_edit_unrelated_field_on_waiting_task_does_not_inject_waiting_since(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Editing an unrelated field on a pre-existing waiting task must NOT inject waiting_since."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "my-task.md").write_text(WAITING_WITHOUT_SINCE)
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(
+        cli,
+        ["edit", "my-task", "--set", "priority", "high"],
+    )
+
+    assert result.exit_code == 0, f"edit failed: {result.output}"
+
+    tasks = load_tasks(tasks_dir)
+    assert len(tasks) == 1
+    assert (
+        "waiting_since" not in tasks[0].metadata
+    ), "waiting_since must not be injected when only editing an unrelated field"
 
 
 def test_edit_state_waiting_does_not_override_existing_waiting_since(

--- a/packages/gptodo/tests/test_edit_state_waiting.py
+++ b/packages/gptodo/tests/test_edit_state_waiting.py
@@ -1,0 +1,112 @@
+"""Tests for auto-injection of waiting_since when editing state to waiting.
+
+When `gptodo edit --set state waiting` is called, `waiting_since` should be
+automatically populated with today's date if it is not already present.
+This prevents the pre-commit `validate-task-frontmatter` hook from rejecting
+commits that transition tasks to waiting state.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from gptodo.cli import cli
+from gptodo.utils import load_tasks
+
+
+ACTIVE_TASK = """\
+---
+state: active
+created: 2026-06-16T00:00:00+00:00
+---
+# Some Active Task
+"""
+
+ALREADY_WAITING_TASK = """\
+---
+state: waiting
+created: 2026-06-01T00:00:00+00:00
+waiting_for: some-dependency
+waiting_since: 2026-06-01
+---
+# Already Waiting Task
+"""
+
+
+def test_edit_state_waiting_auto_sets_waiting_since(tmp_path: Path, monkeypatch) -> None:
+    """Transitioning to waiting auto-injects waiting_since with today's date."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "my-task.md").write_text(ACTIVE_TASK)
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(
+        cli,
+        ["edit", "my-task", "--set", "state", "waiting"],
+    )
+
+    assert result.exit_code == 0, f"edit failed: {result.output}"
+
+    tasks = load_tasks(tasks_dir)
+    assert len(tasks) == 1
+    task = tasks[0]
+    assert task.metadata["state"] == "waiting"
+    assert "waiting_since" in task.metadata, "waiting_since should be auto-set"
+    assert task.metadata["waiting_since"] == date.today().isoformat()
+
+
+def test_edit_state_waiting_does_not_override_existing_waiting_since(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """If waiting_since is already set, it should not be overwritten."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "my-task.md").write_text(ALREADY_WAITING_TASK)
+
+    monkeypatch.chdir(tmp_path)
+    # Re-set to waiting (no-op transition, but tests the guard)
+    result = CliRunner().invoke(
+        cli,
+        ["edit", "my-task", "--set", "state", "waiting"],
+    )
+
+    assert result.exit_code == 0, f"edit failed: {result.output}"
+
+    tasks = load_tasks(tasks_dir)
+    assert len(tasks) == 1
+    # YAML parses bare date strings as datetime.date objects; compare via str()
+    assert (
+        str(tasks[0].metadata["waiting_since"]) == "2026-06-01"
+    ), "pre-existing date must not change"
+
+
+def test_edit_state_waiting_explicit_waiting_since_wins(tmp_path: Path, monkeypatch) -> None:
+    """Explicit --set waiting_since takes precedence over auto-injection."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "my-task.md").write_text(ACTIVE_TASK)
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(
+        cli,
+        [
+            "edit",
+            "my-task",
+            "--set",
+            "state",
+            "waiting",
+            "--set",
+            "waiting_since",
+            "2026-06-10",
+        ],
+    )
+
+    assert result.exit_code == 0, f"edit failed: {result.output}"
+
+    tasks = load_tasks(tasks_dir)
+    assert len(tasks) == 1
+    # Explicit date stored as date string; YAML may parse back as datetime.date
+    assert str(tasks[0].metadata["waiting_since"]) == "2026-06-10", "explicit date should win"

--- a/packages/gptodo/tests/test_edit_state_waiting.py
+++ b/packages/gptodo/tests/test_edit_state_waiting.py
@@ -46,7 +46,7 @@ waiting_for: some-dependency
 
 
 def test_edit_state_waiting_auto_sets_waiting_since(tmp_path: Path, monkeypatch) -> None:
-    """Transitioning to waiting auto-injects waiting_since as a UTC ISO datetime."""
+    """Transitioning to waiting auto-injects waiting_since as a UTC ISO datetime when waiting_for is set."""
     tasks_dir = tmp_path / "tasks"
     tasks_dir.mkdir()
     (tasks_dir / "my-task.md").write_text(ACTIVE_TASK)
@@ -55,7 +55,7 @@ def test_edit_state_waiting_auto_sets_waiting_since(tmp_path: Path, monkeypatch)
     before = datetime.now(timezone.utc).replace(microsecond=0)
     result = CliRunner().invoke(
         cli,
-        ["edit", "my-task", "--set", "state", "waiting"],
+        ["edit", "my-task", "--set", "state", "waiting", "--set", "waiting_for", "some-blocker"],
     )
     after = datetime.now(timezone.utc)
 
@@ -72,6 +72,33 @@ def test_edit_state_waiting_auto_sets_waiting_since(tmp_path: Path, monkeypatch)
     assert (
         before <= injected <= after
     ), f"waiting_since {injected!r} not between {before!r} and {after!r}"
+
+
+def test_edit_state_waiting_without_waiting_for_does_not_inject_waiting_since(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Transitioning to waiting WITHOUT waiting_for must NOT inject waiting_since.
+
+    Injecting waiting_since when waiting_for is absent would cause the pre-commit
+    hook to reject the commit with 'waiting_since requires waiting_for'.
+    """
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "my-task.md").write_text(ACTIVE_TASK)
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(
+        cli,
+        ["edit", "my-task", "--set", "state", "waiting"],
+    )
+
+    assert result.exit_code == 0, f"edit failed: {result.output}"
+
+    tasks = load_tasks(tasks_dir)
+    assert len(tasks) == 1
+    assert (
+        "waiting_since" not in tasks[0].metadata
+    ), "waiting_since must not be injected when waiting_for is absent"
 
 
 def test_edit_unrelated_field_on_waiting_task_does_not_inject_waiting_since(

--- a/packages/gptodo/tests/test_edit_state_waiting.py
+++ b/packages/gptodo/tests/test_edit_state_waiting.py
@@ -165,6 +165,9 @@ def test_edit_state_waiting_explicit_waiting_since_wins(tmp_path: Path, monkeypa
             "state",
             "waiting",
             "--set",
+            "waiting_for",
+            "some-blocker",
+            "--set",
             "waiting_since",
             "2026-06-10",
         ],
@@ -176,3 +179,30 @@ def test_edit_state_waiting_explicit_waiting_since_wins(tmp_path: Path, monkeypa
     assert len(tasks) == 1
     # Explicit date stored as date string; YAML may parse back as datetime.date
     assert str(tasks[0].metadata["waiting_since"]) == "2026-06-10", "explicit date should win"
+
+
+def test_edit_clearing_waiting_for_does_not_inject_waiting_since(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """--set waiting_for none (clearing) must NOT trigger waiting_since injection.
+
+    The any(...) guard must check value is not None so that clearing waiting_for
+    is not mistaken for setting it.
+    """
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "my-task.md").write_text(ACTIVE_TASK)
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(
+        cli,
+        ["edit", "my-task", "--set", "state", "waiting", "--set", "waiting_for", "none"],
+    )
+
+    assert result.exit_code == 0, f"edit failed: {result.output}"
+
+    tasks = load_tasks(tasks_dir)
+    assert len(tasks) == 1
+    assert (
+        "waiting_since" not in tasks[0].metadata
+    ), "clearing waiting_for must not trigger waiting_since injection"


### PR DESCRIPTION
## Summary

When \`gptodo edit <task> --set state waiting\` is used, the \`waiting_since\` field is now automatically populated with the current UTC datetime if it is not already set.

This prevents the \`validate-task-frontmatter\` pre-commit hook from rejecting commits where a task transitions to \`waiting\` state without explicitly setting \`waiting_since\`.

## Changes

- **Auto-injection**: \`waiting_since\` is set to \`datetime.now(UTC).isoformat(timespec="seconds")\` (e.g. \`2026-06-16T22:30:00+00:00\`) when \`state\` is transitioned to \`waiting\` and \`waiting_for\` is present. Full datetime gives intra-day resolution.
- **Transition-scoped guard**: Injection only fires when the current edit explicitly sets \`state=waiting\` — not when editing unrelated fields on a pre-existing waiting task.
- **waiting_for guard**: Auto-injection also requires \`waiting_for\` to be present (or being set in the same edit), preventing \`waiting_since\` from appearing without its required companion.
- **Pre-existing values preserved**: Pre-existing \`waiting_since\` values are never overwritten.
- **Explicit wins**: If \`--set waiting_since YYYY-MM-DD\` or \`--set waiting_since YYYY-MM-DDTHH:MM:SS+00:00\` is also passed, that value takes precedence.
- **Format note**: \`validate_task_frontmatter.py\`'s \`validate_timestamp()\` uses \`datetime.fromisoformat()\`, which accepts both bare \`YYYY-MM-DD\` and full ISO datetime strings.

## Test Plan

- [x] \`test_edit_state_waiting_auto_sets_waiting_since\` — verifies auto-injection on new waiting tasks
- [x] \`test_edit_state_waiting_does_not_override_existing_waiting_since\` — verifies pre-existing value is preserved
- [x] \`test_edit_state_waiting_explicit_waiting_since_wins\` — verifies explicit \`--set\` takes precedence
- [x] \`test_edit_no_injection_without_waiting_for\` — verifies no injection when \`waiting_for\` absent
- [x] \`test_edit_no_injection_on_unrelated_field_change\` — verifies pre-existing waiting task not re-stamped on unrelated edits