### PR TITLE
fix(gptme-usage): mark Agent SDK credit change as paused

### DIFF
--- a/packages/gptme-usage/src/gptme_usage/harness_models.py
+++ b/packages/gptme-usage/src/gptme_usage/harness_models.py
@@ -27,13 +27,20 @@ from typing import TypedDict
 # to large context and tool transcripts, so we keep output share conservative.
 DEFAULT_OUTPUT_TOKEN_SHARE = 0.05
 
-# --- Agent SDK credit change (June 15, 2026) ---
-# Starting on this date, `claude -p` / Agent SDK usage no longer counts toward
-# Claude Max subscription usage limits. Instead, a separate monthly credit applies:
+# --- Agent SDK credit change (June 15, 2026) — PAUSED ---
+# Originally announced to take effect June 15, 2026: `claude -p` / Agent SDK
+# usage would move from subscription rate limits to a separate monthly credit:
 #   Max 5x:  $100/month
 #   Max 20x: $200/month
 # Source: https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan
+#
+# On June 16, 2026, Anthropic sent an email pausing the change indefinitely:
+# "We're working to update the plan to better support how users build with
+#  Claude subscriptions. Nothing changes for now."
+# CLAUDE_AGENT_SDK_CREDIT_CHANGE_PAUSED must be set to False and the date
+# updated once Anthropic announces a new effective date.
 CLAUDE_AGENT_SDK_CREDIT_CHANGE_DATE = datetime(2026, 6, 15, tzinfo=UTC)
+CLAUDE_AGENT_SDK_CREDIT_CHANGE_PAUSED = True
 
 # Monthly Agent SDK credit by subscription plan (USD).
 # After CLAUDE_AGENT_SDK_CREDIT_CHANGE_DATE, agent sessions draw from this
@@ -55,7 +62,14 @@ CLAUDE_AGENT_SDK_ASSUMED_MONTHLY_CREDIT_USD = CLAUDE_AGENT_SDK_MONTHLY_CREDIT_US
 
 
 def is_post_agent_sdk_credit_change(now: datetime | None = None) -> bool:
-    """Return True if the Anthropic Agent SDK credit change has taken effect."""
+    """Return True if the Anthropic Agent SDK credit change has taken effect.
+
+    Returns False while CLAUDE_AGENT_SDK_CREDIT_CHANGE_PAUSED is True, regardless
+    of the date.  Update PAUSED=False and CREDIT_CHANGE_DATE when Anthropic
+    announces a new effective date.
+    """
+    if CLAUDE_AGENT_SDK_CREDIT_CHANGE_PAUSED:
+        return False
     if now is None:
         now = datetime.now(UTC)
     return now >= CLAUDE_AGENT_SDK_CREDIT_CHANGE_DATE

--- a/packages/gptme-usage/src/gptme_usage/harness_models.py
+++ b/packages/gptme-usage/src/gptme_usage/harness_models.py
@@ -291,8 +291,9 @@ def quota_pool_label(
     the module-level ``GPTME_QUOTA_SOURCE`` (now empty; config must be provided
     for per-agent quota pool labels).
 
-    Note: After CLAUDE_AGENT_SDK_CREDIT_CHANGE_DATE (June 15, 2026), claude-code
-    sessions draw from a $200/month Agent SDK credit pool instead of the
+    Note: Once the Agent SDK credit change takes effect (originally June 15, 2026,
+    currently paused — see CLAUDE_AGENT_SDK_CREDIT_CHANGE_PAUSED), claude-code
+    sessions will draw from a $200/month Agent SDK credit pool instead of the
     subscription usage limits. The label remains "claude-max" for continuity
     but the underlying budget model changes. See is_post_agent_sdk_credit_change().
     """

--- a/packages/gptme-usage/tests/test_harness_quota_config.py
+++ b/packages/gptme-usage/tests/test_harness_quota_config.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 from gptme_usage.config import merge_with_module_defaults
 from gptme_usage.harness_models import (
+    CLAUDE_AGENT_SDK_CREDIT_CHANGE_PAUSED,
     GPTME_MODEL_ROUTES,
     GPTME_QUOTA_SOURCE,
     HARNESS_PRICE_USD_PER_1M,
@@ -365,16 +366,16 @@ def test_resolve_cc_version(input_model: str, expected: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_is_post_agent_sdk_credit_change_before_cutover() -> None:
+def test_is_post_agent_sdk_credit_change_paused() -> None:
+    """While the credit change is paused, the function must always return False."""
+    assert CLAUDE_AGENT_SDK_CREDIT_CHANGE_PAUSED, (
+        "Update this test when the pause is lifted: set PAUSED=False and "
+        "restore date-based assertions."
+    )
     before = datetime(2026, 6, 14, 23, 59, 59, tzinfo=timezone.utc)
-    assert not is_post_agent_sdk_credit_change(before)
-
-
-def test_is_post_agent_sdk_credit_change_at_exact_cutover() -> None:
-    cutover = datetime(2026, 6, 15, 0, 0, 0, tzinfo=timezone.utc)
-    assert is_post_agent_sdk_credit_change(cutover)
-
-
-def test_is_post_agent_sdk_credit_change_after_cutover() -> None:
+    at_cutover = datetime(2026, 6, 15, 0, 0, 0, tzinfo=timezone.utc)
     after = datetime(2026, 6, 16, 12, 0, 0, tzinfo=timezone.utc)
-    assert is_post_agent_sdk_credit_change(after)
+    for ts in (before, at_cutover, after, None):
+        assert not is_post_agent_sdk_credit_change(
+            ts
+        ), f"Expected False while paused, got True for ts={ts!r}"

--- a/packages/gptme-usage/tests/test_harness_quota_config.py
+++ b/packages/gptme-usage/tests/test_harness_quota_config.py
@@ -370,7 +370,7 @@ def test_is_post_agent_sdk_credit_change_paused() -> None:
     """While the credit change is paused, the function must always return False."""
     assert CLAUDE_AGENT_SDK_CREDIT_CHANGE_PAUSED, (
         "Update this test when the pause is lifted: set PAUSED=False and "
-        "restore date-based assertions."
+        "restore date-based assertions (see skeleton below)."
     )
     before = datetime(2026, 6, 14, 23, 59, 59, tzinfo=timezone.utc)
     at_cutover = datetime(2026, 6, 15, 0, 0, 0, tzinfo=timezone.utc)
@@ -379,3 +379,19 @@ def test_is_post_agent_sdk_credit_change_paused() -> None:
         assert not is_post_agent_sdk_credit_change(
             ts
         ), f"Expected False while paused, got True for ts={ts!r}"
+
+
+# Skeleton tests to restore when CLAUDE_AGENT_SDK_CREDIT_CHANGE_PAUSED is set back to False.
+# Uncomment and adjust CREDIT_CHANGE_DATE if the cutover date changes.
+#
+# def test_is_post_agent_sdk_credit_change_before_cutover() -> None:
+#     before = datetime(2026, 6, 14, 23, 59, 59, tzinfo=timezone.utc)
+#     assert not is_post_agent_sdk_credit_change(before)
+#
+# def test_is_post_agent_sdk_credit_change_at_exact_cutover() -> None:
+#     at_cutover = datetime(2026, 6, 15, 0, 0, 0, tzinfo=timezone.utc)
+#     assert is_post_agent_sdk_credit_change(at_cutover)
+#
+# def test_is_post_agent_sdk_credit_change_after_cutover() -> None:
+#     after = datetime(2026, 6, 16, 12, 0, 0, tzinfo=timezone.utc)
+#     assert is_post_agent_sdk_credit_change(after)


### PR DESCRIPTION
## Summary

Anthropic sent an email on June 16, 2026 pausing the June 15 Agent SDK credit change indefinitely:

> "We're not making this change today. We're working to update the plan to better support how users build with Claude subscriptions."

`is_post_agent_sdk_credit_change()` was returning `True` as of June 16 (past the original date), incorrectly indicating the credit model changed. This would cause wrong cost/quota tracking for any caller checking this flag.

**Fix**: Add `CLAUDE_AGENT_SDK_CREDIT_CHANGE_PAUSED = True` constant. The function short-circuits to `False` while paused, regardless of the date. Tests updated to assert `False` for all timestamps during the pause, with an inline reminder to restore date-based assertions when unpaused.

## Context

- Email forwarded by Erik: "We're pausing the Agent SDK credit change"
- Follow-up to merged PR #1132 which added coverage for this function
- When Anthropic announces a new date: set `PAUSED=False` and update `CREDIT_CHANGE_DATE`

## Test plan

- [x] `test_is_post_agent_sdk_credit_change_paused` — asserts `False` for before/at/after/None timestamps
- [x] 35 existing gptme-usage tests still pass