### PR TITLE
fix(lessons): restore hook skill routing metadata

### DIFF
--- a/scripts/claude-code-hooks/match-lessons.py
+++ b/scripts/claude-code-hooks/match-lessons.py
@@ -259,6 +259,66 @@ def match_keyword(keyword: str, text_lower: str) -> bool:
     return bool(pattern.search(text_lower))
 
 
+def _extract_scalar_frontmatter_field(fm_str: str, field: str) -> str | None:
+    """Extract a simple top-level YAML scalar or block scalar without PyYAML."""
+    lines = fm_str.splitlines()
+    field_pattern = re.compile(rf"^{re.escape(field)}:\s*(.*)$")
+
+    for index, line in enumerate(lines):
+        match = field_pattern.match(line)
+        if not match:
+            continue
+
+        raw_value = match.group(1).strip()
+        if raw_value and raw_value[0] in "|>":
+            block_lines: list[str] = []
+            for next_line in lines[index + 1 :]:
+                if next_line and not next_line.startswith((" ", "\t")):
+                    break
+                block_lines.append(next_line)
+
+            if not block_lines:
+                return ""
+
+            indents = [
+                len(block_line) - len(block_line.lstrip(" "))
+                for block_line in block_lines
+                if block_line.strip()
+            ]
+            trim = min(indents) if indents else 0
+            normalized = [
+                block_line[trim:] if trim else block_line for block_line in block_lines
+            ]
+            text = "\n".join(normalized).strip()
+            if raw_value[0] == ">":
+                return " ".join(
+                    part.strip() for part in text.splitlines() if part.strip()
+                )
+            return text
+
+        value = raw_value
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+            value = value[1:-1]
+        return value.strip()
+
+    return None
+
+
+def _dedupe_strings(values: list[object]) -> list[str]:
+    """Strip and deduplicate strings while preserving first-seen order."""
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if not isinstance(value, str):
+            continue
+        cleaned = value.strip()
+        if not cleaned or cleaned in seen:
+            continue
+        seen.add(cleaned)
+        deduped.append(cleaned)
+    return deduped
+
+
 def extract_frontmatter(content: str) -> tuple[dict[str, object], str]:
     """Extract YAML frontmatter and body from markdown."""
     if not content.startswith("---"):
@@ -300,17 +360,10 @@ def extract_frontmatter(content: str) -> tuple[dict[str, object], str]:
     if m:
         fm["status"] = m.group(1)
 
-    name_m = re.search(r"^name:\s*(.+)$", fm_str, re.MULTILINE)
-    if name_m:
-        fm["name"] = name_m.group(1).strip()
-
-    description_m = re.search(r'^description:\s*"?(.*?)"?$', fm_str, re.MULTILINE)
-    if description_m:
-        fm["description"] = description_m.group(1).strip()
-
-    when_to_use_m = re.search(r'^when_to_use:\s*"?(.*?)"?$', fm_str, re.MULTILINE)
-    if when_to_use_m:
-        fm["when_to_use"] = when_to_use_m.group(1).strip()
+    for field in ("name", "description", "when_to_use"):
+        value = _extract_scalar_frontmatter_field(fm_str, field)
+        if value is not None:
+            fm[field] = value
 
     return fm, body
 
@@ -460,26 +513,14 @@ def scan_lessons(lesson_dirs: list[Path]) -> list[dict]:
 
             if isinstance(raw_keywords, str):
                 raw_keywords = [raw_keywords]
-            # Deduplicate: same keyword appearing in both match.keywords and
-            # the top-level keywords field should not double-count in scoring.
-            keywords = list(
-                dict.fromkeys(
-                    k
-                    for k in [*raw_keywords, *_string_list(fm.get("keywords"))]
-                    if isinstance(k, str) and k.strip()
-                )
+            keywords = _dedupe_strings(
+                [*raw_keywords, *_string_list(fm.get("keywords"))]
             )
 
             if isinstance(raw_patterns, str):
                 raw_patterns = [raw_patterns]
-            # Deduplicate: same pattern in both match.patterns and top-level
-            # patterns field should not double-count in scoring.
-            patterns = list(
-                dict.fromkeys(
-                    p
-                    for p in [*raw_patterns, *_string_list(fm.get("patterns"))]
-                    if isinstance(p, str) and p.strip()
-                )
+            patterns = _dedupe_strings(
+                [*raw_patterns, *_string_list(fm.get("patterns"))]
             )
 
             skill_name = fm.get("name") if isinstance(fm.get("name"), str) else None
@@ -529,7 +570,7 @@ def detect_harness() -> str:
         return "claude-code"
     if os.environ.get("CODEX") or os.environ.get("CODEX_INSTALLED"):
         return "codex"
-    return "gptme"
+    return "claude-code"
 
 
 def filter_by_harness(lessons: list[dict], harness: str) -> list[dict]:

--- a/tests/test_cc_match_lessons.py
+++ b/tests/test_cc_match_lessons.py
@@ -2,6 +2,7 @@
 
 import builtins
 import importlib.util
+import sys
 from pathlib import Path
 
 import pytest
@@ -247,6 +248,10 @@ def test_extract_frontmatter_regex_fallback_keeps_multiline_scalars(hook, monkey
             raise ImportError
         return real_import(name, *args, **kwargs)
 
+    # Remove yaml from the import cache so builtins.__import__ is actually called.
+    # Without this, `import yaml` inside extract_frontmatter resolves from sys.modules
+    # without invoking __import__, silently exercising the yaml path instead.
+    monkeypatch.delitem(sys.modules, "yaml", raising=False)
     monkeypatch.setattr(builtins, "__import__", fake_import)
     content = (
         "---\n"

--- a/tests/test_cc_match_lessons.py
+++ b/tests/test_cc_match_lessons.py
@@ -1,5 +1,6 @@
 """Tests for the Claude Code match-lessons hook."""
 
+import builtins
 import importlib.util
 from pathlib import Path
 
@@ -236,6 +237,64 @@ def test_extract_frontmatter_archived_excluded(hook, lesson_dir):
     lessons = hook.scan_lessons([lesson_dir])
     titles = [lesson["title"] for lesson in lessons]
     assert "Archived Lesson" not in titles
+
+
+def test_extract_frontmatter_regex_fallback_keeps_multiline_scalars(hook, monkeypatch):
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "yaml":
+            raise ImportError
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    content = (
+        "---\n"
+        "description: |\n"
+        "  First line.\n"
+        "  Second line.\n"
+        "when_to_use: >\n"
+        "  Use this skill\n"
+        "  when routing work.\n"
+        "---\n\n"
+        "# Title\n"
+    )
+
+    fm, _ = hook.extract_frontmatter(content)
+
+    assert fm["description"] == "First line.\nSecond line."
+    assert fm["when_to_use"] == "Use this skill when routing work."
+
+
+def test_scan_lessons_dedupes_top_level_keywords_and_patterns(hook, tmp_path):
+    lessons_dir = tmp_path / "lessons"
+    lessons_dir.mkdir()
+    (lessons_dir / "dedupe.md").write_text(
+        "---\n"
+        "match:\n"
+        '  keywords:\n    - "duplicate keyword"\n'
+        '  patterns:\n    - "duplicate.*pattern"\n'
+        'keywords: ["duplicate keyword", "extra keyword"]\n'
+        'patterns: ["duplicate.*pattern"]\n'
+        "status: active\n"
+        "---\n"
+        "# Dedupe\n"
+    )
+
+    lessons = hook.scan_lessons([lessons_dir])
+    assert lessons[0]["keywords"] == ["duplicate keyword", "extra keyword"]
+    assert lessons[0]["patterns"] == ["duplicate.*pattern"]
+
+    matches = hook.score_lessons(lessons, "duplicate keyword and duplicateXpattern")
+    assert matches[0]["matched_by"].count("duplicate keyword") == 1
+    assert matches[0]["matched_by"].count("pattern:duplicate.*pattern") == 1
+
+
+def test_detect_harness_defaults_to_claude_code(hook, monkeypatch):
+    monkeypatch.delenv("CLAUDECODE", raising=False)
+    monkeypatch.delenv("CODEX", raising=False)
+    monkeypatch.delenv("CODEX_INSTALLED", raising=False)
+    assert hook.detect_harness() == "claude-code"
 
 
 # --- build_pretool_match_text ---


### PR DESCRIPTION
## Summary
- restore top-level skill keywords in the Claude lesson hook scanner
- include skill description/tags/when_to_use in routing matches
- expose and apply harness filtering so gptme-only lessons are excluded in Claude Code/Codex sessions

## Verification
- `uv run ruff check /home/bob/bob/gptme-contrib/scripts/claude-code-hooks/match-lessons.py`
- `uv run pytest /home/bob/bob/tests/test_match_lessons_hook.py -q`
