### PR TITLE
fix(match-lessons): default harness to 'gptme' when no env vars set

### DIFF
--- a/scripts/claude-code-hooks/match-lessons.py
+++ b/scripts/claude-code-hooks/match-lessons.py
@@ -570,7 +570,7 @@ def detect_harness() -> str:
         return "claude-code"
     if os.environ.get("CODEX") or os.environ.get("CODEX_INSTALLED"):
         return "codex"
-    return "claude-code"
+    return "gptme"
 
 
 def filter_by_harness(lessons: list[dict], harness: str) -> list[dict]:


### PR DESCRIPTION
## Summary

- `detect_harness()` was returning `"claude-code"` as its default fallback even when `CLAUDECODE` env var was not set
- This caused `test_detect_harness_gptme` in ErikBjare/bob to fail: the test monkeypatches away `CLAUDECODE` and expects `"gptme"` back
- Fix: change the final `return "claude-code"` to `return "gptme"` — gptme is the correct default harness

## Test plan

- [ ] `uv run pytest tests/test_match_lessons_hook.py::test_detect_harness_gptme` passes
- [ ] All other match-lessons tests still pass