### PR TITLE
fix(match-lessons): skip node_modules and tool dirs during lesson scan

### DIFF
--- a/scripts/claude-code-hooks/match-lessons.py
+++ b/scripts/claude-code-hooks/match-lessons.py
@@ -452,11 +452,20 @@ def scan_lessons(lesson_dirs: list[Path]) -> list[dict]:
     seen_paths: set[str] = set()
     seen_names: set[str] = set()  # filename-based dedup: first dir wins
 
+    # Directories inside lesson dirs that should never be scanned for lessons.
+    # node_modules: npm packages (e.g. Playwright) ship *.agent.md skill files
+    # that get injected as harmful lessons when they match on keywords.
+    _SKIP_DIR_PARTS = frozenset({"node_modules", ".git", "__pycache__", ".venv"})
+
     for lesson_dir in lesson_dirs:
         if not lesson_dir.exists():
             continue
         for f in sorted(lesson_dir.rglob("*.md")):
             if f.name == "README.md":
+                continue
+
+            # Skip files inside tool/cache directories — not lesson content.
+            if _SKIP_DIR_PARTS & set(f.relative_to(lesson_dir).parts):
                 continue
 
             # Dedup by resolved path (handles symlinks across dirs)

--- a/scripts/claude-code-hooks/match-lessons.py
+++ b/scripts/claude-code-hooks/match-lessons.py
@@ -76,6 +76,10 @@ MIN_PREDICTION_LIFT = 2.0
 MIN_PREDICTION_TS = 0.30
 # State directory for cross-invocation dedup (in /tmp, not workspace)
 STATE_DIR = Path(os.environ.get("TMPDIR", "/tmp")) / "claude-lesson-match"
+# Directories inside lesson dirs that should never be scanned for lessons.
+# node_modules: npm packages (e.g. Playwright) ship *.agent.md skill files
+# that get injected as harmful lessons when they match on keywords.
+_SKIP_DIR_PARTS = frozenset({"node_modules", ".git", "__pycache__", ".venv"})
 _SHORT_DESCRIPTOR_TOKENS = {
     "ai",
     "api",
@@ -451,11 +455,6 @@ def scan_lessons(lesson_dirs: list[Path]) -> list[dict]:
     lessons = []
     seen_paths: set[str] = set()
     seen_names: set[str] = set()  # filename-based dedup: first dir wins
-
-    # Directories inside lesson dirs that should never be scanned for lessons.
-    # node_modules: npm packages (e.g. Playwright) ship *.agent.md skill files
-    # that get injected as harmful lessons when they match on keywords.
-    _SKIP_DIR_PARTS = frozenset({"node_modules", ".git", "__pycache__", ".venv"})
 
     for lesson_dir in lesson_dirs:
         if not lesson_dir.exists():

--- a/tests/test_cc_match_lessons.py
+++ b/tests/test_cc_match_lessons.py
@@ -100,6 +100,49 @@ def test_scan_lessons_skips_readme(hook, tmp_path):
     assert result[0]["title"] == "Real"
 
 
+def test_scan_lessons_skips_node_modules(hook, tmp_path):
+    """Files under node_modules must not be included, even with valid frontmatter."""
+    lessons_dir = tmp_path / "skills"
+    lessons_dir.mkdir()
+    # A legitimate skill
+    (lessons_dir / "real-skill.md").write_text(
+        "---\nname: real-skill\ndescription: A real skill\nstatus: active\n---\n# Real Skill\n\nContent.\n"
+    )
+    # An npm package agent file — should be excluded
+    node_agents = (
+        lessons_dir / "my-tool" / "node_modules" / "playwright" / "lib" / "agents"
+    )
+    node_agents.mkdir(parents=True)
+    (node_agents / "playwright-test-generator.agent.md").write_text(
+        "---\nname: playwright-test-generator\ndescription: Use this agent to generate Playwright tests\n---\n# Generator\n\nContent.\n"
+    )
+    result = hook.scan_lessons([lessons_dir])
+    paths = [r["path"] for r in result]
+    assert all(
+        "node_modules" not in p for p in paths
+    ), f"node_modules file leaked into scan: {paths}"
+    assert len(result) == 1
+    assert result[0]["title"] == "Real Skill"
+
+
+def test_scan_lessons_skips_git_and_cache(hook, tmp_path):
+    """Files under .git / __pycache__ / .venv must not be included."""
+    lessons_dir = tmp_path / "lessons"
+    lessons_dir.mkdir()
+    (lessons_dir / "good.md").write_text(
+        '---\nmatch:\n  keywords:\n    - "good"\nstatus: active\n---\n# Good\n\nContent.\n'
+    )
+    for skip_dir in (".git", "__pycache__", ".venv"):
+        d = lessons_dir / skip_dir
+        d.mkdir()
+        (d / "hidden.md").write_text(
+            '---\nmatch:\n  keywords:\n    - "hidden"\nstatus: active\n---\n# Hidden\n\nContent.\n'
+        )
+    result = hook.scan_lessons([lessons_dir])
+    assert len(result) == 1
+    assert result[0]["title"] == "Good"
+
+
 def test_scan_lessons_dedup_by_filename(hook, tmp_path):
     """First-dir-wins deduplication by filename."""
     dir1 = tmp_path / "dir1"
@@ -295,11 +338,12 @@ def test_scan_lessons_dedupes_top_level_keywords_and_patterns(hook, tmp_path):
     assert matches[0]["matched_by"].count("pattern:duplicate.*pattern") == 1
 
 
-def test_detect_harness_defaults_to_claude_code(hook, monkeypatch):
+def test_detect_harness_defaults_to_gptme(hook, monkeypatch):
+    # No env vars set → fall back to gptme (the primary harness)
     monkeypatch.delenv("CLAUDECODE", raising=False)
     monkeypatch.delenv("CODEX", raising=False)
     monkeypatch.delenv("CODEX_INSTALLED", raising=False)
-    assert hook.detect_harness() == "claude-code"
+    assert hook.detect_harness() == "gptme"
 
 
 # --- build_pretool_match_text ---


### PR DESCRIPTION
## Summary

- **Bug**: `scan_lessons()` uses `rglob("*.md")` which recursively descends into `node_modules/` directories. Playwright (npm package) ships `.agent.md` files with YAML frontmatter `name:` fields, causing them to be loaded as lessons and injected into Claude Code sessions.
- **Impact**: Two Playwright agent files had negative LOO deltas over 47 combined sessions (playwright-test-healer Δ=-0.118, n=26; playwright-test-generator Δ=-0.087, n=21) — active harm to session quality.
- **Fix**: Added `_SKIP_DIR_PARTS = frozenset({"node_modules", ".git", "__pycache__", ".venv"})` check before adding any lesson to the scan results.
- **Bonus fix**: Updated a stale test (`test_detect_harness_defaults_to_claude_code`) that was broken by the previous commit which changed the default harness to `gptme`.

## Test plan

- [x] `uv run pytest tests/test_cc_match_lessons.py -v` → 45 passed (2 new tests added, 1 stale test fixed)
- [x] All pre-commit hooks pass (ruff, mypy, typecheck)
- [x] `test_scan_lessons_skips_node_modules` — npm agent files with valid frontmatter are excluded
- [x] `test_scan_lessons_skips_git_and_cache` — `.git`/`__pycache__`/`.venv` exclusion