### PR TITLE
fix(gptmail): stamp read: true on pull-fetched msgs with no read: key

### DIFF
--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -405,7 +405,13 @@ def _mark_replied(path: Path) -> None:
     parts = _FM_DELIM.split(content, maxsplit=2)
     if len(parts) < 3:
         return
-    fm = re.sub(r"^read: false$", "read: true", parts[1], flags=re.MULTILINE)
+    fm = parts[1]
+    # Mark read — handles "read: false" flip and missing-key insertion (pull-fetched msgs).
+    if not re.search(r"^read: true$", fm, flags=re.MULTILINE):
+        if re.search(r"^read:", fm, flags=re.MULTILINE):
+            fm = re.sub(r"^read: false$", "read: true", fm, flags=re.MULTILINE)
+        else:
+            fm = fm.rstrip("\n") + "\nread: true\n"
     if "replied:" not in fm:
         fm = fm.rstrip("\n") + "\nreplied: true\n"
     else:

--- a/packages/gptmail/src/gptmail/transport/agent.py
+++ b/packages/gptmail/src/gptmail/transport/agent.py
@@ -276,10 +276,16 @@ class AgentTransport:
         content = path.read_text()
         if content.startswith("---"):
             parts = _FM_DELIM.split(content, maxsplit=2)
-            if len(parts) >= 3 and "read: false" in parts[1]:
-                parts[1] = re.sub(r"^read: false$", "read: true", parts[1], flags=re.MULTILINE)
-                content = "---".join(parts)
-                path.write_text(content)
+            if len(parts) >= 3:
+                fm = parts[1]
+                if not re.search(r"^read: true$", fm, flags=re.MULTILINE):
+                    if re.search(r"^read:", fm, flags=re.MULTILINE):
+                        fm = re.sub(r"^read: false$", "read: true", fm, flags=re.MULTILINE)
+                    else:
+                        fm = fm.rstrip("\n") + "\nread: true\n"
+                    parts[1] = fm
+                    content = "---".join(parts)
+                    path.write_text(content)
         return content
 
     def _lookup_meta(self, message_id: str) -> dict | None:

--- a/packages/gptmail/tests/test_agent_cli.py
+++ b/packages/gptmail/tests/test_agent_cli.py
@@ -337,6 +337,33 @@ def test_read_marks_read(workspace: Path) -> None:
     assert _frontmatter(workspace / "messages" / "inbox" / name)["read"] is True
 
 
+def test_read_marks_read_no_existing_key(workspace: Path) -> None:
+    """read on a pull-fetched msg with no read: key stamps read: true (insert-if-missing)."""
+    inbox = workspace / "messages" / "inbox"
+    name = "20260101-000000-erik-Q.md"
+    (inbox / name).write_text(
+        "---\nfrom: erik\nto: alice\ntimestamp: 2026-01-01T00:00:00Z\n"
+        "subject: Q\n---\n\nplease advise\n"
+    )
+    result = CliRunner().invoke(agent, ["read", name])
+    assert result.exit_code == 0
+    assert _frontmatter(workspace / "messages" / "inbox" / name)["read"] is True
+
+
+def test_reply_marks_read_no_existing_key(workspace: Path) -> None:
+    """reply on a pull-fetched msg with no read: key stamps read: true (insert-if-missing)."""
+    inbox = workspace / "messages" / "inbox"
+    name = "20260101-000000-bob-Q.md"
+    (inbox / name).write_text(
+        "---\nfrom: bob\nto: alice\ntimestamp: 2026-01-01T00:00:00Z\n"
+        "subject: Q\n---\n\nplease advise\n"
+    )
+    CliRunner().invoke(agent, ["reply", name, "my answer"])
+    fm = _frontmatter(workspace / "messages" / "inbox" / name)
+    assert fm["read"] is True
+    assert fm["replied"] is True
+
+
 def test_pending_lists_unanswered_then_clears_on_reply(workspace: Path) -> None:
     name = _seed_inbox(workspace)
 


### PR DESCRIPTION
## Problem

`gptmail agent read <id>` was a silent no-op for read-state on pull-fetched messages. Erik's inbox accumulated ~65 unread messages because nothing he reads ever cleared.

**Root cause (two sites):**

1. `AgentTransport._mark_read` only acted when `"read: false"` was present in frontmatter. Pull-fetched messages (SCP'd from agent outboxes — the only way Erik receives since his laptop has no inbound SSH) have **no `read:` key at all**, so the condition `"read: false" in parts[1]` is always false → silent no-op.

2. `agent_cli._mark_replied` had the same gap: `re.sub(r"^read: false$", ...)` only flips the existing `false` value but never inserts the key if it's missing. So `reply` wouldn't mark pull-fetched messages read either.

## Fix

Both sites now check for the key's presence and insert `read: true` when absent:

```
read: false present  →  flip to read: true   (existing path)
read: key missing    →  append read: true    (new insert-if-missing path)
read: true already   →  no-op               (idempotent)
```

## Tests

Two new regression tests cover the missing-key case:
- `test_read_marks_read_no_existing_key` — messages with no `read:` key
- `test_reply_marks_read_no_existing_key` — same for reply path

All 40 tests pass.