### PR TITLE
fix(gptmail): agent read command now marks message read

### DIFF
--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -395,6 +395,26 @@ def _pending_messages(
     return pending
 
 
+def _mark_read(path: Path) -> None:
+    """Stamp an inbox message ``read: true``. Idempotent. Handles missing key (pull-fetched msgs)."""
+    if not path.exists():
+        return
+    content = path.read_text()
+    if not content.startswith("---"):
+        return
+    parts = _FM_DELIM.split(content, maxsplit=2)
+    if len(parts) < 3:
+        return
+    fm = parts[1]
+    if re.search(r"^read: true$", fm, flags=re.MULTILINE):
+        return
+    if re.search(r"^read:", fm, flags=re.MULTILINE):
+        fm = re.sub(r"^read: false$", "read: true", fm, flags=re.MULTILINE)
+    else:
+        fm = fm.rstrip("\n") + "\nread: true\n"
+    path.write_text("---".join([parts[0], fm, parts[2]]))
+
+
 def _mark_replied(path: Path) -> None:
     """Stamp an inbox message ``replied: true`` (and ``read: true``). Idempotent."""
     if not path.exists():
@@ -691,13 +711,14 @@ def read(message_id: str, thread: bool, mailbox: str | None) -> None:
     if resolved is None:
         click.echo(f"Error: message not found: {message_id}", err=True)
         sys.exit(1)
-    mailbox_name, _path = resolved
+    mailbox_name, msg_path = resolved
     transport = _transport(mailbox=mailbox_name)
     try:
         click.echo(transport.read(message_id, include_thread=thread))
     except FileNotFoundError as e:
         click.echo(f"Error: {e}", err=True)
         sys.exit(1)
+    _mark_read(msg_path)
 
 
 @agent.command()


### PR DESCRIPTION
## Problem

`gptmail agent read <id>` was a **silent no-op** for read-state. It printed the
message body and exited 0, but the path variable was named `_path` (intentionally
discarded), so the inbox file was never touched. Every read message stayed
permanently unread in `gptmail agent list`.

This led to Erik's inbox accumulating ~65 unread messages that no amount of
reading would clear.

## Root cause

Two issues in `read()`:
1. The path from `_resolve_message()` was discarded (`_path` naming convention)
2. No `_mark_read()` function existed to call even if we'd kept the path

Note: `_mark_replied()` already handles `read: true` stamping correctly
(including the insert-if-missing fix from #1139), but `read()` never called it.

## Fix

- Add `_mark_read(path: Path)` — same pattern as `_mark_replied`, stamps
  `read: true` only (no `replied:` side-effect). Handles:
  - `read: false` → `read: true` flip
  - Missing `read:` key insertion (pull-fetched messages from `_mark_replied` fix)
  - Already `read: true` → idempotent no-op
- Rename `_path` → `msg_path` in `read()` to retain the path
- Call `_mark_read(msg_path)` after echoing the body

## Tests

Two pre-written TDD tests that were failing now pass:
- `test_read_marks_read` — standard `read: false` → `read: true` flip
- `test_read_marks_read_no_existing_key` — pull-fetched msg with no `read:` key gets stamped

## Related

Follows #1139 which fixed `_mark_replied` for pull-fetched messages. This PR
fixes the companion issue: `read` (not just `reply`) should also mark messages read.