### PR TITLE
fix(pm): per-check slot key for concurrent master-CI failures

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -12,6 +12,7 @@ remain the primary dispatch path (see project-monitoring-upstream-overhaul).
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -253,9 +254,17 @@ def _slugify_check(name: str) -> str:
 
     Lowercases, collapses non-alphanumerics to single dashes, trims dashes.
     Empty/whitespace-only names fall back to ``"unknown"``.
+    All-punctuation inputs (non-blank but produce an empty slug) use a short
+    hash so they never collide with a check literally named ``"unknown"``.
     """
     slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
-    return slug or "unknown"
+    if slug:
+        return slug
+    if not name.strip():
+        return "unknown"
+    # Non-blank name but all-punctuation: use a hash to avoid collision with
+    # a check literally named "unknown".
+    return "x" + hashlib.sha1(name.encode()).hexdigest()[:6]
 
 
 def derive_slot_key(

--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import sys
 from dataclasses import dataclass, field, fields
 from datetime import datetime, timezone
@@ -247,14 +248,34 @@ def append_full_ledger_entry(
 # --- Slot key derivation ---
 
 
-def derive_slot_key(repo: str, number: int | None, types: list[str]) -> str:
+def _slugify_check(name: str) -> str:
+    """Slugify a CI check/workflow name for use in a slot key.
+
+    Lowercases, collapses non-alphanumerics to single dashes, trims dashes.
+    Empty/whitespace-only names fall back to ``"unknown"``.
+    """
+    slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+    return slug or "unknown"
+
+
+def derive_slot_key(
+    repo: str, number: int | None, types: list[str], check: str | None = None
+) -> str:
     """Derive a slot key from a work item.
 
     Matches the bash ``derive_slot_key()`` logic:
-      - master_ci_failure types → ``{repo}#master-ci``
+      - master_ci_failure types → ``{repo}#master-ci:{check-slug}`` when a
+        check/workflow name is known, else ``{repo}#master-ci``
       - others → ``{repo}#{number}``
+
+    The per-check slug is what keeps two *concurrent* master-CI failures on the
+    same repo (e.g. ``test-e2e`` and ``Conformance Check``) from collapsing into
+    one slot — a long-running failure on check A must never mask detection or
+    dispatch of a new failure on check B.
     """
     if "master_ci_failure" in types:
+        if check and check.strip():
+            return f"{repo}#master-ci:{_slugify_check(check)}"
         return f"{repo}#master-ci"
     if number is not None:
         return f"{repo}#{number}"
@@ -422,7 +443,9 @@ class LaneDispatcher:
 
         for lane, lane_items in [("fast", fast_items), ("slow", slow_items)]:
             for item in lane_items:
-                slot_key = derive_slot_key(item.repo, item.number, item.types)
+                slot_key = derive_slot_key(
+                    item.repo, item.number, item.types, item.title
+                )
                 unit_name = _derive_unit_name(slot_key, lane)
                 legacy_name = _derive_legacy_unit_name(slot_key)
 
@@ -846,7 +869,7 @@ def dispatch_grouped_items(
 
     for lane, lane_items in [("fast", fast), ("slow", slow)]:
         for item in lane_items:
-            key = derive_slot_key(item.repo, item.number, item.types)
+            key = derive_slot_key(item.repo, item.number, item.types, item.title)
 
             if _is_busy(key):
                 result.skipped_active += 1

--- a/packages/gptme-runloops/tests/test_pm_dispatch.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch.py
@@ -73,6 +73,38 @@ class TestDeriveSlotKey:
     def test_no_number(self):
         assert derive_slot_key("o/r", None, ["pr_update"]) == "o/r#unknown"
 
+    def test_master_ci_with_check_slug(self):
+        assert (
+            derive_slot_key("o/r", 99, ["master_ci_failure"], "test-e2e")
+            == "o/r#master-ci:test-e2e"
+        )
+
+    def test_master_ci_check_slugified(self):
+        # Names with spaces/caps/punctuation collapse to a stable slug.
+        assert (
+            derive_slot_key("o/r", 99, ["master_ci_failure"], "Conformance Check")
+            == "o/r#master-ci:conformance-check"
+        )
+
+    def test_master_ci_blank_check_falls_back(self):
+        # Whitespace-only / empty check name falls back to the bare key.
+        assert (
+            derive_slot_key("o/r", 99, ["master_ci_failure"], "  ") == "o/r#master-ci"
+        )
+
+    def test_concurrent_master_ci_failures_distinct_slots(self):
+        # Two simultaneous master-CI failures on one repo must NOT collapse into
+        # one slot — a long-running failure on check A never masks check B.
+        key_a = derive_slot_key("o/r", 100, ["master_ci_failure"], "test-e2e")
+        key_b = derive_slot_key("o/r", 101, ["master_ci_failure"], "Conformance Check")
+        assert key_a != key_b
+        assert key_a == "o/r#master-ci:test-e2e"
+        assert key_b == "o/r#master-ci:conformance-check"
+
+    def test_non_master_ci_ignores_check(self):
+        # The check slug only applies to master_ci_failure items.
+        assert derive_slot_key("o/r", 99, ["pr_update"], "test-e2e") == "o/r#99"
+
 
 # --- Lane classification ---
 
@@ -985,10 +1017,27 @@ class TestLaneDispatcher:
         )
 
         items = [
-            make_item(repo="gptme/gptme", number=None, types=["master_ci_failure"]),
+            make_item(
+                repo="gptme/gptme",
+                number=None,
+                types=["master_ci_failure"],
+                title="test-e2e",
+            ),
+            make_item(
+                repo="gptme/gptme",
+                number=None,
+                types=["master_ci_failure"],
+                title="Conformance Check",
+            ),
         ]
         ld.dispatch(items)
-        assert callback_calls[0]["slot_key"] == "gptme/gptme#master-ci"
+        # Two concurrent master-CI failures on one repo get distinct, per-check
+        # slot keys — neither masks the other.
+        slot_keys = {c["slot_key"] for c in callback_calls}
+        assert slot_keys == {
+            "gptme/gptme#master-ci:test-e2e",
+            "gptme/gptme#master-ci:conformance-check",
+        }
 
 
 class TestPartitionJsonlIO:

--- a/packages/gptme-runloops/tests/test_pm_dispatch.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch.py
@@ -92,6 +92,16 @@ class TestDeriveSlotKey:
             derive_slot_key("o/r", 99, ["master_ci_failure"], "  ") == "o/r#master-ci"
         )
 
+    def test_master_ci_all_punctuation_check_no_unknown_collision(self):
+        # An all-punctuation name like "---" slugifies to "" but must NOT fall
+        # back to "unknown" — that would collide with a check literally named
+        # "unknown".  Expect a hash-based slug distinct from "unknown".
+        key = derive_slot_key("o/r", 99, ["master_ci_failure"], "---")
+        assert key.startswith("o/r#master-ci:")
+        suffix = key.removeprefix("o/r#master-ci:")
+        assert suffix != "unknown"
+        assert suffix.startswith("x")
+
     def test_concurrent_master_ci_failures_distinct_slots(self):
         # Two simultaneous master-CI failures on one repo must NOT collapse into
         # one slot — a long-running failure on check A never masks check B.


### PR DESCRIPTION
## Problem

`derive_slot_key()` collapsed **every** master-CI failure for a repo into one slot key `{repo}#master-ci`. So if a repo's master had **two** failing checks at once (e.g. gptme-cloud had `Conformance Check` AND `test-e2e` red), they shared ONE slot — only one got tracked/dispatched, the other was **invisible** and could fester for hours, blocking every open PR that inherited the red.

**Evidence (2026-06-17):** gptme-cloud master was red on `test-e2e` from PR #421 onward, but the dispatch ledger had zero `master_ci_failure` entries for gptme-cloud that day — only `Conformance Check` entries from 06-16. The test-e2e master-red was never dispatched; it only surfaced when Erik noticed manually.

## Fix

- `derive_slot_key(repo, number, types, check=None)` — add an optional check/workflow name, slugified into the key as `{repo}#master-ci:{check-slug}`. Backward compatible: no check name → bare `{repo}#master-ci`.
- Both `LaneDispatcher` dispatch paths now pass `item.title` (the workflow name).
- Mirrored in the bash twin (`scripts/github/project-monitoring-lib.sh` in ErikBjare/bob): `build_grouped_jsonl` jq grouping now buckets master_ci_failure per check title, and the `derive_slot_key` wrapper passes the check through. Verified end-to-end that bash and Python produce identical slot keys.

## Test

`test_concurrent_master_ci_failures_distinct_slots` + dispatch-level test: two simultaneous master-CI failures on one repo → two distinct slot keys, neither masks the other. Plus slugify edge cases (caps/spaces/punctuation, blank fallback). 277 runloops tests pass.

## Acceptance

Two simultaneous master-CI failures on the same repo produce two distinct slots/dispatches; a long-running failure on check A never prevents detection/dispatch of a new failure on check B.

Tracked: ErikBjare/bob `tasks/pm-master-ci-slot-collapse-fix.md`. Sibling (escalation half): `tasks/master-red-escalation-watchdog.md`.