### PR TITLE
fix(evolution): mkdir parents before saving history/refinements with slashed lesson IDs

### DIFF
--- a/packages/gptme-lessons-extras/src/gptme_lessons_extras/evolution.py
+++ b/packages/gptme-lessons-extras/src/gptme_lessons_extras/evolution.py
@@ -211,6 +211,7 @@ class EvolutionTracker:
     def _save_history(self, history: LessonHistory) -> None:
         """Save lesson history to disk."""
         path = self._history_path(history.lesson_id)
+        path.parent.mkdir(parents=True, exist_ok=True)
         with open(path, "w") as f:
             json.dump(history.to_dict(), f, indent=2)
 
@@ -239,6 +240,7 @@ class EvolutionTracker:
 
         # Save
         path = self._refinements_path(lesson_id)
+        path.parent.mkdir(parents=True, exist_ok=True)
         with open(path, "w") as f:
             json.dump([r.to_dict() for r in refinements], f, indent=2)
 
@@ -268,6 +270,7 @@ class EvolutionTracker:
         refinements[suggestion_index].status = new_status
 
         path = self._refinements_path(lesson_id)
+        path.parent.mkdir(parents=True, exist_ok=True)
         with open(path, "w") as f:
             json.dump([r.to_dict() for r in refinements], f, indent=2)
 

--- a/packages/gptme-lessons-extras/src/gptme_lessons_extras/evolution.py
+++ b/packages/gptme-lessons-extras/src/gptme_lessons_extras/evolution.py
@@ -304,11 +304,14 @@ class EvolutionTracker:
 
         stats: dict[str, dict[str, Any]] = {}
 
-        for history_file in self.history_dir.glob("*.json"):
-            if history_file.parent.name == "refinements":
+        for history_file in self.history_dir.rglob("*.json"):
+            rel = history_file.relative_to(self.history_dir)
+            if rel.parts[0] == "refinements":
                 continue
 
-            history = self.load_history(history_file.stem)
+            # Reconstruct full lesson ID from relative path (e.g. "tools/some-lesson.md")
+            lesson_id = str(rel.with_suffix(""))
+            history = self.load_history(lesson_id)
             if not history:
                 continue
 

--- a/packages/gptme-lessons-extras/tests/test_evolution.py
+++ b/packages/gptme-lessons-extras/tests/test_evolution.py
@@ -286,3 +286,68 @@ def test_evolution_tracker_update_refinement_invalid_index(tmp_path):
 
     with pytest.raises(ValueError, match="Invalid suggestion index"):
         tracker.update_refinement_status("tools/x.md", 99, "accepted")
+
+
+# --- get_contributor_stats ---
+
+
+def test_get_contributor_stats_empty(tmp_path):
+    """Returns empty dict when no lessons exist."""
+    tracker = EvolutionTracker(history_dir=tmp_path / "history")
+    assert tracker.get_contributor_stats() == {}
+
+
+def test_get_contributor_stats_simple_id(tmp_path):
+    """Contributor stats work with flat (non-slashed) lesson IDs."""
+    tracker = EvolutionTracker(history_dir=tmp_path / "history")
+    tracker.initialize_lesson("test-lesson.md", "bob", "content")
+    tracker.track_change("test-lesson.md", "alice", "update", "v2")
+
+    stats = tracker.get_contributor_stats()
+    assert "bob" in stats
+    assert "alice" in stats
+    assert stats["bob"]["lessons_created"] == 1
+    assert stats["bob"]["versions_contributed"] == 1
+    assert stats["alice"]["lessons_created"] == 0
+    assert stats["alice"]["versions_contributed"] == 1
+
+
+def test_get_contributor_stats_slashed_id(tmp_path):
+    """Contributor stats correctly find lessons with slashed IDs (the glob bug)."""
+    tracker = EvolutionTracker(history_dir=tmp_path / "history")
+    tracker.initialize_lesson("tools/some-lesson.md", "bob", "content")
+    tracker.track_change("tools/some-lesson.md", "alice", "update", "v2")
+
+    stats = tracker.get_contributor_stats()
+    assert "bob" in stats, "bob should be found even with slashed lesson ID"
+    assert "alice" in stats, "alice should be found even with slashed lesson ID"
+    assert stats["bob"]["lessons_created"] == 1
+    assert stats["bob"]["versions_contributed"] == 1
+    assert stats["alice"]["versions_contributed"] == 1
+
+
+def test_get_contributor_stats_multiple_slashed_ids(tmp_path):
+    """Stats aggregate across multiple slashed-ID lessons."""
+    tracker = EvolutionTracker(history_dir=tmp_path / "history")
+    tracker.initialize_lesson("tools/x.md", "bob", "v1")
+    tracker.initialize_lesson("workflow/y.md", "bob", "v1")
+    tracker.initialize_lesson("tools/z.md", "alice", "v1")
+
+    stats = tracker.get_contributor_stats()
+    assert stats["bob"]["lessons_created"] == 2
+    assert stats["bob"]["versions_contributed"] == 2
+    assert stats["alice"]["lessons_created"] == 1
+    assert stats["alice"]["versions_contributed"] == 1
+
+
+def test_get_contributor_stats_excludes_refinements(tmp_path):
+    """Refinement JSON files are excluded from contributor stats."""
+    tracker = EvolutionTracker(history_dir=tmp_path / "history")
+    tracker.initialize_lesson("tools/x.md", "bob", "content")
+    tracker.suggest_refinement("tools/x.md", "alice", "clarity", "suggestion")
+
+    stats = tracker.get_contributor_stats()
+    assert "bob" in stats
+    assert stats["bob"]["lessons_created"] == 1
+    # Refinement files should not create phantom entries
+    assert len(stats) == 1

--- a/packages/gptme-lessons-extras/tests/test_evolution.py
+++ b/packages/gptme-lessons-extras/tests/test_evolution.py
@@ -1,0 +1,288 @@
+"""Tests for the lesson evolution tracking module."""
+
+import pytest
+from gptme_lessons_extras.evolution import (
+    EvolutionTracker,
+    LessonHistory,
+    LessonVersion,
+    RefinementSuggestion,
+)
+
+# --- LessonVersion ---
+
+
+def test_lesson_version_to_dict():
+    v = LessonVersion(
+        version=1,
+        timestamp="2026-06-01T00:00:00",
+        contributor="bob",
+        changes="Initial creation",
+        content_hash="abc12345",
+    )
+    d = v.to_dict()
+    assert d["version"] == 1
+    assert d["contributor"] == "bob"
+    assert d["changes"] == "Initial creation"
+    assert d["content_hash"] == "abc12345"
+
+
+def test_lesson_version_roundtrip():
+    v = LessonVersion(
+        version=2,
+        timestamp="2026-06-02T10:00:00",
+        contributor="alice",
+        changes="Added examples",
+        content_hash="def67890",
+    )
+    d = v.to_dict()
+    v2 = LessonVersion.from_dict(d)
+    assert v2.version == v.version
+    assert v2.contributor == v.contributor
+    assert v2.changes == v.changes
+    assert v2.content_hash == v.content_hash
+
+
+# --- LessonHistory ---
+
+
+def _make_history() -> LessonHistory:
+    return LessonHistory(
+        lesson_id="tools/some-lesson.md",
+        origin_agent="bob",
+        created="2026-06-01T00:00:00",
+        versions=[
+            LessonVersion(
+                version=1,
+                timestamp="2026-06-01T00:00:00",
+                contributor="bob",
+                changes="Initial creation",
+                content_hash="aaa",
+            ),
+            LessonVersion(
+                version=2,
+                timestamp="2026-06-02T00:00:00",
+                contributor="alice",
+                changes="Clarified examples",
+                content_hash="bbb",
+            ),
+        ],
+    )
+
+
+def test_lesson_history_to_dict():
+    h = _make_history()
+    d = h.to_dict()
+    assert d["lesson_id"] == "tools/some-lesson.md"
+    assert d["origin_agent"] == "bob"
+    assert len(d["versions"]) == 2
+
+
+def test_lesson_history_roundtrip():
+    h = _make_history()
+    d = h.to_dict()
+    h2 = LessonHistory.from_dict(d)
+    assert h2.lesson_id == h.lesson_id
+    assert h2.origin_agent == h.origin_agent
+    assert len(h2.versions) == len(h.versions)
+    assert h2.versions[0].version == 1
+    assert h2.versions[1].contributor == "alice"
+
+
+def test_lesson_history_latest_version():
+    h = _make_history()
+    latest = h.latest_version()
+    assert latest is not None
+    assert latest.version == 2
+
+
+def test_lesson_history_latest_version_empty():
+    h = LessonHistory(lesson_id="x", origin_agent="bob", created="2026-01-01")
+    assert h.latest_version() is None
+
+
+def test_lesson_history_get_version():
+    h = _make_history()
+    v1 = h.get_version(1)
+    assert v1 is not None
+    assert v1.changes == "Initial creation"
+
+    v2 = h.get_version(2)
+    assert v2 is not None
+    assert v2.contributor == "alice"
+
+
+def test_lesson_history_get_version_missing():
+    h = _make_history()
+    assert h.get_version(99) is None
+
+
+def test_lesson_history_contributors():
+    h = _make_history()
+    contributors = h.contributors()
+    assert "bob" in contributors
+    assert "alice" in contributors
+
+
+def test_lesson_history_contributors_unique():
+    h = LessonHistory(
+        lesson_id="x",
+        origin_agent="bob",
+        created="2026-01-01",
+        versions=[
+            LessonVersion(
+                version=1,
+                timestamp="t",
+                contributor="bob",
+                changes="init",
+                content_hash="h",
+            ),
+            LessonVersion(
+                version=2,
+                timestamp="t",
+                contributor="bob",
+                changes="fix",
+                content_hash="h2",
+            ),
+        ],
+    )
+    assert h.contributors().count("bob") == 1
+
+
+# --- RefinementSuggestion ---
+
+
+def test_refinement_suggestion_roundtrip():
+    r = RefinementSuggestion(
+        lesson_id="tools/x.md",
+        suggester="alice",
+        timestamp="2026-06-01T00:00:00",
+        category="clarity",
+        suggestion="Add an example",
+        priority="medium",
+        status="proposed",
+    )
+    d = r.to_dict()
+    r2 = RefinementSuggestion.from_dict(d)
+    assert r2.lesson_id == r.lesson_id
+    assert r2.suggester == r.suggester
+    assert r2.category == r.category
+    assert r2.status == r.status
+
+
+# --- EvolutionTracker ---
+
+
+def test_evolution_tracker_initialize_lesson(tmp_path):
+    tracker = EvolutionTracker(history_dir=tmp_path / "history")
+    history = tracker.initialize_lesson(
+        lesson_id="tools/some-lesson.md",
+        origin_agent="bob",
+        content="# Some lesson\n\nContent here.",
+    )
+    assert history.lesson_id == "tools/some-lesson.md"
+    assert history.origin_agent == "bob"
+    assert len(history.versions) == 1
+    assert history.versions[0].version == 1
+    assert history.versions[0].changes == "Initial creation"
+
+
+def test_evolution_tracker_persist_and_load(tmp_path):
+    tracker = EvolutionTracker(history_dir=tmp_path / "history")
+    tracker.initialize_lesson("tools/x.md", "bob", "content")
+
+    loaded = tracker.load_history("tools/x.md")
+    assert loaded is not None
+    assert loaded.lesson_id == "tools/x.md"
+    assert loaded.origin_agent == "bob"
+
+
+def test_evolution_tracker_load_missing(tmp_path):
+    tracker = EvolutionTracker(history_dir=tmp_path / "history")
+    assert tracker.load_history("does-not-exist.md") is None
+
+
+def test_evolution_tracker_track_change(tmp_path):
+    tracker = EvolutionTracker(history_dir=tmp_path / "history")
+    tracker.initialize_lesson("tools/x.md", "bob", "v1 content")
+
+    new_version = tracker.track_change(
+        lesson_id="tools/x.md",
+        contributor="alice",
+        changes="Improved examples",
+        content="v2 content",
+    )
+    assert new_version.version == 2
+    assert new_version.contributor == "alice"
+    assert new_version.changes == "Improved examples"
+
+    loaded = tracker.load_history("tools/x.md")
+    assert loaded is not None
+    assert len(loaded.versions) == 2
+    assert loaded.latest_version().version == 2  # type: ignore[union-attr]
+
+
+def test_evolution_tracker_track_change_uninitialized(tmp_path):
+    tracker = EvolutionTracker(history_dir=tmp_path / "history")
+    with pytest.raises(ValueError, match="No history found"):
+        tracker.track_change("tools/x.md", "bob", "changes", "content")
+
+
+def test_evolution_tracker_content_hash_differs(tmp_path):
+    tracker = EvolutionTracker(history_dir=tmp_path / "history")
+    tracker.initialize_lesson("tools/x.md", "bob", "content v1")
+    v2 = tracker.track_change("tools/x.md", "alice", "update", "content v2")
+
+    loaded = tracker.load_history("tools/x.md")
+    assert loaded is not None
+    v1_hash = loaded.versions[0].content_hash
+    assert v1_hash != v2.content_hash
+
+
+def test_evolution_tracker_suggest_refinement(tmp_path):
+    tracker = EvolutionTracker(history_dir=tmp_path / "history")
+    tracker.initialize_lesson("tools/x.md", "bob", "content")
+
+    ref = tracker.suggest_refinement(
+        lesson_id="tools/x.md",
+        suggester="alice",
+        category="clarity",
+        suggestion="Add a concrete example",
+        priority="high",
+    )
+    assert ref.lesson_id == "tools/x.md"
+    assert ref.status == "proposed"
+    assert ref.priority == "high"
+
+
+def test_evolution_tracker_load_refinements(tmp_path):
+    tracker = EvolutionTracker(history_dir=tmp_path / "history")
+    tracker.initialize_lesson("tools/x.md", "bob", "content")
+    tracker.suggest_refinement(
+        "tools/x.md", "alice", "clarity", "Add example", "medium"
+    )
+    tracker.suggest_refinement("tools/x.md", "bob", "pattern", "Add pattern", "low")
+
+    refs = tracker.load_refinements("tools/x.md")
+    assert len(refs) == 2
+    assert refs[0].category == "clarity"
+    assert refs[1].category == "pattern"
+
+
+def test_evolution_tracker_update_refinement_status(tmp_path):
+    tracker = EvolutionTracker(history_dir=tmp_path / "history")
+    tracker.initialize_lesson("tools/x.md", "bob", "content")
+    tracker.suggest_refinement("tools/x.md", "alice", "clarity", "suggestion", "medium")
+
+    tracker.update_refinement_status("tools/x.md", 0, "accepted")
+
+    refs = tracker.load_refinements("tools/x.md")
+    assert refs[0].status == "accepted"
+
+
+def test_evolution_tracker_update_refinement_invalid_index(tmp_path):
+    tracker = EvolutionTracker(history_dir=tmp_path / "history")
+    tracker.initialize_lesson("tools/x.md", "bob", "content")
+    tracker.suggest_refinement("tools/x.md", "alice", "clarity", "suggestion", "medium")
+
+    with pytest.raises(ValueError, match="Invalid suggestion index"):
+        tracker.update_refinement_status("tools/x.md", 99, "accepted")


### PR DESCRIPTION
## Summary

- `EvolutionTracker._save_history()`, `suggest_refinement()`, and `update_refinement_status()` all called `open(path, "w")` without first creating parent directories
- Lesson IDs like `"tools/some-lesson.md"` create paths where `history_dir/tools/` (and `refinements/tools/`) don't exist, causing `FileNotFoundError`
- Fix: add `path.parent.mkdir(parents=True, exist_ok=True)` before each `open(path, "w")` call (3 sites)
- Also adds 21 tests for `evolution.py`, which previously had zero test coverage

## Test plan

- [ ] `uv run pytest packages/gptme-lessons-extras/tests/test_evolution.py -v` — 21 tests pass
- [ ] Tests use realistic slashed lesson IDs (`"tools/some-lesson.md"`) to exercise the fixed code paths