### PR TITLE
fix(lessons): remove 8 dead keywords from 4 active lessons

### DIFF
--- a/lessons/concepts/gepa-genetic-pareto.md
+++ b/lessons/concepts/gepa-genetic-pareto.md
@@ -4,8 +4,6 @@ match:
     - "gepa-lesson-optimizer"
     - "gepa optimizer"
     - "bottom performing lesson"
-    - "lesson mutation"
-    - "mutate lesson"
   session_categories: [monitoring]
 status: active
 description: "Use GEPA-inspired mutation to fix underperforming lessons: diagnose first, mutate content/keywords, validate with LLM-as-judge before applying."

--- a/lessons/tools/python-file-execution.md
+++ b/lessons/tools/python-file-execution.md
@@ -2,10 +2,8 @@
 match:
   keywords:
   - "python script permission denied"
-  - "bash: script.py: Permission denied"
   - "choose correct python execution method"
   - "shebang python execution"
-  - "ModuleNotFoundError when dependencies should be available"
 status: active
 description: "Choose the correct Python execution method based on script type and context: uv scripts with shebang use direct execution, poetry projects use `poetry run`, standalone scripts use appropriate tooling."
 ---

--- a/lessons/tools/sibling-tool-call-errored.md
+++ b/lessons/tools/sibling-tool-call-errored.md
@@ -2,8 +2,6 @@
 match:
   keywords:
     - "sibling tool call errored"
-    - "parallel tool call failed"
-    - "tool call error in batch"
 status: active
 description: "When a tool in a parallel batch reports Sibling tool call errored, find the *real* failing call first — then retry only that one, not all calls in the batch."
 ---

--- a/lessons/workflow/agent-workspace-maintenance.md
+++ b/lessons/workflow/agent-workspace-maintenance.md
@@ -2,8 +2,6 @@
 match:
   keywords:
     - "update gptme-contrib"
-    - "update submodule to latest"
-    - "submodule is behind"
   session_categories: [cleanup]
 status: active
 description: "When doing periodic workspace maintenance, update the gptme-contrib submodule and verify that shared infrastructure symlinks are intact."


### PR DESCRIPTION
## Summary

Removes 8 confirmed-dead keywords from 4 active lessons. Each keyword was verified dead over both 7-day and 14-day trajectory windows using `lesson-keyword-health.py`. All lessons retain live trigger keywords.

**Changes:**
- `sibling-tool-call-errored`: remove `"parallel tool call failed"` and `"tool call error in batch"` — descriptive phrases that don't match actual error text (keep `"sibling tool call errored"` which matches verbatim)
- `agent-workspace-maintenance`: remove `"update submodule to latest"` and `"submodule is behind"` — too generic (keep `"update gptme-contrib"` + `session_categories: [cleanup]`)
- `gepa-genetic-pareto`: remove `"lesson mutation"` and `"mutate lesson"` — too generic (keep 3 tool-specific keywords + `session_categories: [monitoring]`)
- `python-file-execution`: remove `"bash: script.py: Permission denied"` (wrong format — actual bash error has `./` prefix) and `"ModuleNotFoundError when dependencies should be available"` (commentary phrase, not the actual Python error message)

## Test plan
- [x] All 4 lesson files validate via `gptme-lessons-extras` validator
- [x] Each lesson retains at least one live keyword or `session_categories` to keep it triggering
- [x] Pre-commit hooks pass