### PR TITLE
fix(lessons): remove 20 dead keywords from 5 active lessons

### DIFF
--- a/lessons/autonomous/blocked-period-status-check-trap.md
+++ b/lessons/autonomous/blocked-period-status-check-trap.md
@@ -4,11 +4,6 @@ match:
   keywords:
     - blocked period
     - status check
-    - all tasks blocked
-    - nothing to do
-    - waiting for input
-    - strategic pause
-    - productive while blocked
   session_categories: [strategic, self-review, cleanup]
 status: active
 ---

--- a/lessons/patterns/avoid-deep-nesting.md
+++ b/lessons/patterns/avoid-deep-nesting.md
@@ -4,10 +4,6 @@ match:
   - "deeply nested"
   - "deep nesting"
   - "nesting levels"
-  - "nested conditionals"
-  - "guard clause"
-  - "guard clauses"
-  - "early return"
 status: active
 description: "Refactor code when nesting exceeds 3-4 levels using guard clauses, function extraction, or condition inversion."
 ---

--- a/lessons/tools/gh-pr-checks-exit-code-8.md
+++ b/lessons/tools/gh-pr-checks-exit-code-8.md
@@ -2,9 +2,6 @@
 match:
   keywords:
     - "exit code 8"
-    - "gh pr checks pending"
-    - "checks still pending"
-    - "checks still in progress"
     - "waiting for checks"
   session_categories: [cross-repo, code, monitoring]
 status: active

--- a/lessons/tools/python-invocation.md
+++ b/lessons/tools/python-invocation.md
@@ -8,9 +8,6 @@ match:
   - "use python3 instead of python"
   - "python vs python3"
   - "which python to use"
-  - "python3 not found"
-  - "python executable"
-  - "python not installed"
   - "use python3"
 status: active
 description: "Always use `python3` explicitly instead of `python` in shell commands and scripts."

--- a/lessons/workflow/project-monitoring-session-patterns.md
+++ b/lessons/workflow/project-monitoring-session-patterns.md
@@ -2,13 +2,8 @@
 match:
   keywords:
     - "structured monitoring triage workflow"
-    - "ACT vs DEF notification classification"
-    - "project monitoring session"
-    - "classify each notification"
-    - "github notifications triage"
     - "triage notifications across repos"
     - "monitoring run derailing"
-    - "act vs defer"
   session_categories: [monitoring, triage]
 status: active
 description: "Use systematic classification and time-boxed execution for monitoring sessions: classify notifications as ACT (action required) vs DEF (deferred), then execute only ACT items."


### PR DESCRIPTION
Batch 5 of the dead-keyword cleanup series (follow-up to #1143).

Removes keywords that never appear in recent trajectory data (7-day window, 3138 sessions, 33143 records) so these lessons continue to fire on their remaining live triggers.

## Changes

| File | Keywords removed | Keywords remaining |
|------|-----------------|-------------------|
| `workflow/project-monitoring-session-patterns.md` | 5 | 3 |
| `autonomous/blocked-period-status-check-trap.md` | 5 | 2 |
| `patterns/avoid-deep-nesting.md` | 4 | 3 |
| `tools/gh-pr-checks-exit-code-8.md` | 3 | 2 |
| `tools/python-invocation.md` | 3 | 6 |

**Total**: 20 keywords removed from 5 files.

All lessons retain ≥2 live keywords; no lessons were left with 0 keywords. Lessons with <2 keywords remaining (autonomous-operation-safety, strategic-focus-during-autonomous-sessions, pre-landing-self-review) were skipped.

## Validation

```
uv run python3 packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
```
All 5 edited lessons pass validation.