### PR TITLE
feat(pm-dispatch): wire PmModelBandit into LaneDispatcher for model routing

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/pm_bandit.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_bandit.py
@@ -52,7 +52,6 @@ PM_WORK_TYPES: set[str] = {
     "ci-fix",
     "greptile-fix",
     "pr-review",
-    "issue-triage",
     "merge-conflict",
     "assigned-issue",
     "notification-triage",

--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -332,11 +332,21 @@ def classify_item_work_type(types: list[str]) -> str:
     return "notification-triage"
 
 
-def _bandit_observation_count(bandit: Any, work_type: str) -> int:
-    """Count total recorded outcomes for work_type across all models in bandit."""
+def _bandit_observation_count(
+    bandit: Any, work_type: str, models: list[str] | None = None
+) -> int:
+    """Count recorded outcomes for work_type, optionally filtered to specific models.
+
+    When *models* is provided, only counts observations for those model names.
+    When None, counts across all models (legacy — prefer passing available models
+    to avoid threshold crossings driven by retired model arms).
+    """
     total = 0
     try:
-        for model_data in bandit.summary().get(work_type, {}).values():
+        summary = bandit.summary().get(work_type, {})
+        for model_name, model_data in summary.items():
+            if models is not None and model_name not in models:
+                continue
             total += int(model_data.get("selections", 0))
     except (AttributeError, TypeError):
         pass
@@ -359,11 +369,12 @@ def _resolve_model_with_bandit(
     if bandit is None:
         return resolve_lane_model(lane, model, fast_model)
     work_type = classify_item_work_type(item_types)
-    if _bandit_observation_count(bandit, work_type) < MIN_BANDIT_OBSERVATIONS:
-        return resolve_lane_model(lane, model, fast_model)
     available = [m for m in [model, fast_model] if m]
     if not available:
         available = ["sonnet"]
+    obs = _bandit_observation_count(bandit, work_type, models=available)
+    if obs < MIN_BANDIT_OBSERVATIONS:
+        return resolve_lane_model(lane, model, fast_model)
     return bandit.resolve_model(work_type, available)
 
 
@@ -1084,10 +1095,16 @@ def _record_bandit_outcome_main(argv: list[str]) -> int:
     )
     args = parser.parse_args(argv)
 
+    _VALID_OUTCOMES = {"productive", "failed"}
     outcome_val: str | float
     try:
         outcome_val = float(args.outcome)
     except ValueError:
+        if args.outcome not in _VALID_OUTCOMES:
+            parser.error(
+                f"--outcome must be 'productive', 'failed', or a float 0-1; "
+                f"got {args.outcome!r}"
+            )
         outcome_val = args.outcome
 
     bandit = PmModelBandit(state_dir=args.state_dir)

--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -1095,6 +1095,14 @@ def _record_bandit_outcome_main(argv: list[str]) -> int:
     )
     args = parser.parse_args(argv)
 
+    from gptme_runloops.pm_bandit import PM_WORK_TYPES
+
+    if args.work_type not in PM_WORK_TYPES:
+        parser.error(
+            f"--work-type {args.work_type!r} is not a known PM work type; "
+            f"valid values: {sorted(PM_WORK_TYPES)}"
+        )
+
     _VALID_OUTCOMES = {"productive", "failed"}
     outcome_val: str | float
     try:

--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -41,6 +41,9 @@ DEFAULT_SLOT_CAP = 3
 # Default number of fast-lane burst slots above cap
 DEFAULT_FAST_BURST_ALLOWANCE = 1
 
+# Minimum bandit observations before preferring bandit routing over static fallback
+MIN_BANDIT_OBSERVATIONS = 5
+
 logger = logging.getLogger(__name__)
 
 
@@ -304,6 +307,66 @@ def classify_lane(types: list[str]) -> str:
     return "fast"
 
 
+def classify_item_work_type(types: list[str]) -> str:
+    """Map SlotItem.types to a PM bandit work type string.
+
+    Priority order is significant: ci-fix and greptile-fix take precedence over
+    pr-review since a PR with a CI failure should route to the CI-fix arm, not
+    the generic PR-review arm.
+
+    Returns one of the PM_WORK_TYPES strings defined in pm_bandit.
+    """
+    types_set = set(types)
+    if "strategy" in types_set:
+        return "strategy-reply"
+    if types_set & {"ci_failure", "master_ci_failure"}:
+        return "ci-fix"
+    if types_set & {"greptile_needs_fix", "greptile_needs_improvement"}:
+        return "greptile-fix"
+    if "merge_conflict" in types_set:
+        return "merge-conflict"
+    if "pr_update" in types_set:
+        return "pr-review"
+    if "assigned" in types_set:
+        return "assigned-issue"
+    return "notification-triage"
+
+
+def _bandit_observation_count(bandit: Any, work_type: str) -> int:
+    """Count total recorded outcomes for work_type across all models in bandit."""
+    total = 0
+    try:
+        for model_data in bandit.summary().get(work_type, {}).values():
+            total += int(model_data.get("selections", 0))
+    except (AttributeError, TypeError):
+        pass
+    return total
+
+
+def _resolve_model_with_bandit(
+    item_types: list[str],
+    lane: str,
+    model: str | None,
+    fast_model: str | None,
+    bandit: Any | None,
+) -> str | None:
+    """Resolve the dispatch model for an item.
+
+    When a bandit is provided and has ≥ MIN_BANDIT_OBSERVATIONS for the
+    inferred work type, use Thompson sampling to select the model.
+    Otherwise fall back to the static resolve_lane_model() split.
+    """
+    if bandit is None:
+        return resolve_lane_model(lane, model, fast_model)
+    work_type = classify_item_work_type(item_types)
+    if _bandit_observation_count(bandit, work_type) < MIN_BANDIT_OBSERVATIONS:
+        return resolve_lane_model(lane, model, fast_model)
+    available = [m for m in [model, fast_model] if m]
+    if not available:
+        available = ["sonnet"]
+    return bandit.resolve_model(work_type, available)
+
+
 def partition_items(items: list[SlotItem]) -> tuple[list[SlotItem], list[SlotItem]]:
     """Partition items into (fast_items, slow_items)."""
     fast: list[SlotItem] = []
@@ -414,6 +477,7 @@ class LaneDispatcher:
         model: str | None = None,
         script_path: str | None = None,
         fast_model: str | None = None,
+        bandit: Any = None,
     ) -> tuple[int, int]:
         """Dispatch items via transient systemd units.
 
@@ -427,6 +491,12 @@ class LaneDispatcher:
         ``fast_model`` (falling back to the ``BOB_PM_FAST_LANE_MODEL`` env var)
         opts the fast lane onto a cheaper model; unset preserves the single
         ``model`` for every lane (ErikBjare/bob#860).
+
+        ``bandit``, when provided, overrides the static lane-based split with
+        Thompson-sampling routing per work type once ≥ MIN_BANDIT_OBSERVATIONS
+        outcomes have been recorded. Falls back to ``resolve_lane_model()``
+        below the threshold. Pass a :class:`~gptme_runloops.pm_bandit.PmModelBandit`
+        instance.
 
         Returns:
             (launched_count, deferred_count)
@@ -470,7 +540,7 @@ class LaneDispatcher:
                     deferred += 1
                     continue
 
-                # Launch (fast lane may run on a cheaper model)
+                # Launch — bandit-driven model selection when observations ≥ threshold
                 success = self._launch_unit(
                     unit_name=unit_name,
                     legacy_name=legacy_name,
@@ -478,7 +548,9 @@ class LaneDispatcher:
                     lane=lane,
                     item=item,
                     backend=backend,
-                    model=resolve_lane_model(lane, model, fast_model),
+                    model=_resolve_model_with_bandit(
+                        item.types, lane, model, fast_model, bandit
+                    ),
                     script_path=script_path,
                 )
 
@@ -973,6 +1045,62 @@ def _append_ledger_main(argv: list[str]) -> int:
     return 0
 
 
+def _record_bandit_outcome_main(argv: list[str]) -> int:
+    """CLI handler for the ``record-bandit-outcome`` subcommand.
+
+    Loads the PmModelBandit and records one dispatch outcome. Designed for
+    bash post-session hooks to call after a slot session completes.
+
+    Example::
+
+        python3 -m gptme_runloops.pm_dispatch record-bandit-outcome \\
+            --work-type ci-fix --model haiku --outcome productive
+    """
+    import argparse
+
+    from gptme_runloops.pm_bandit import PmModelBandit
+
+    parser = argparse.ArgumentParser(
+        prog="pm_dispatch record-bandit-outcome",
+        description="Record a PM dispatch outcome into the bandit state.",
+    )
+    parser.add_argument(
+        "--work-type",
+        required=True,
+        help="PM work type (e.g. ci-fix, greptile-fix, pr-review)",
+    )
+    parser.add_argument(
+        "--model", required=True, help="Model that handled the dispatch (e.g. haiku)"
+    )
+    parser.add_argument(
+        "--outcome",
+        required=True,
+        help="Session outcome: 'productive', 'failed', or a float 0-1",
+    )
+    parser.add_argument(
+        "--state-dir",
+        default=None,
+        help="Override bandit state directory (default: state/pm-dispatch)",
+    )
+    args = parser.parse_args(argv)
+
+    outcome_val: str | float
+    try:
+        outcome_val = float(args.outcome)
+    except ValueError:
+        outcome_val = args.outcome
+
+    bandit = PmModelBandit(state_dir=args.state_dir)
+    bandit.record_outcome(args.work_type, args.model, outcome_val)
+    logger.info(
+        "Recorded outcome: work_type=%s model=%s outcome=%s",
+        args.work_type,
+        args.model,
+        args.outcome,
+    )
+    return 0
+
+
 def _records_aggregate_main(argv: list[str]) -> int:
     """CLI handler for the ``records-aggregate`` subcommand.
 
@@ -1018,6 +1146,9 @@ def main() -> None:
 
       records-aggregate --records-dir DIR
         Aggregate per-item JSON records into a single JSON array on stdout.
+
+      record-bandit-outcome --work-type W --model M --outcome O
+        Record a dispatch outcome into the PmModelBandit state.
     """
     import sys as _sys
 
@@ -1028,6 +1159,8 @@ def main() -> None:
         _sys.exit(_append_ledger_main(argv[1:]))
     if argv and argv[0] == "records-aggregate":
         _sys.exit(_records_aggregate_main(argv[1:]))
+    if argv and argv[0] == "record-bandit-outcome":
+        _sys.exit(_record_bandit_outcome_main(argv[1:]))
     if argv and argv[0] == "partition":
         argv = argv[1:]
 

--- a/packages/gptme-runloops/tests/test_pm_bandit.py
+++ b/packages/gptme-runloops/tests/test_pm_bandit.py
@@ -200,7 +200,6 @@ def test_work_type_classification():
         "pr-review",
         "merge-conflict",
         "strategy-reply",
-        "issue-triage",
         "assigned-issue",
         "notification-triage",
     ]:

--- a/packages/gptme-runloops/tests/test_pm_dispatch.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch.py
@@ -1479,6 +1479,47 @@ class TestRecordBanditOutcomeCLI:
         arm = data["arms"]["pm-model:pr-review:sonnet"]
         assert arm["alpha"] == pytest.approx(1.75)
 
+    def test_record_work_type_rejects_unknown(self, tmp_path, capsys):
+        from gptme_runloops.pm_dispatch import _record_bandit_outcome_main
+
+        with pytest.raises(SystemExit) as exc_info:
+            _record_bandit_outcome_main(
+                [
+                    "--work-type",
+                    "ci_fix",  # underscore instead of hyphen — must be rejected
+                    "--model",
+                    "haiku",
+                    "--outcome",
+                    "productive",
+                    "--state-dir",
+                    str(tmp_path),
+                ]
+            )
+        assert exc_info.value.code != 0
+        # Error message should enumerate valid types so the hook author can self-correct
+        captured = capsys.readouterr()
+        assert "valid values" in captured.err
+        assert "ci-fix" in captured.err
+
+    def test_record_work_type_accepts_all_known(self, tmp_path):
+        from gptme_runloops.pm_bandit import PM_WORK_TYPES
+        from gptme_runloops.pm_dispatch import _record_bandit_outcome_main
+
+        for wt in PM_WORK_TYPES:
+            rc = _record_bandit_outcome_main(
+                [
+                    "--work-type",
+                    wt,
+                    "--model",
+                    "haiku",
+                    "--outcome",
+                    "productive",
+                    "--state-dir",
+                    str(tmp_path),
+                ]
+            )
+            assert rc == 0, f"expected {wt!r} to be accepted"
+
     def test_record_outcome_rejects_invalid_string(self, tmp_path):
         from gptme_runloops.pm_dispatch import _record_bandit_outcome_main
 

--- a/packages/gptme-runloops/tests/test_pm_dispatch.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch.py
@@ -10,15 +10,19 @@ import pytest
 from gptme_runloops.pm_dispatch import (
     DEFAULT_FAST_BURST_ALLOWANCE,
     DEFAULT_SLOT_CAP,
+    MIN_BANDIT_OBSERVATIONS,
     SLOW_LANE_TYPES,
     DispatchLedger,
     LaneDispatcher,
     LedgerEntry,
     SlotItem,
     SlotManager,
+    _bandit_observation_count,
     _partition_jsonl_io,
+    _resolve_model_with_bandit,
     append_full_ledger_entry,
     build_full_ledger_entry,
+    classify_item_work_type,
     classify_lane,
     derive_slot_key,
     dispatch_grouped_items,
@@ -1226,3 +1230,211 @@ class TestRecordsAggregateMain:
         rc = _records_aggregate_main(["--records-dir", str(tmp_path / "nope")])
         assert rc == 0
         assert json.loads(capsys.readouterr().out) == []
+
+
+# --- classify_item_work_type ---
+
+
+class TestClassifyItemWorkType:
+    def test_ci_failure(self):
+        assert classify_item_work_type(["ci_failure"]) == "ci-fix"
+
+    def test_master_ci_failure(self):
+        assert classify_item_work_type(["master_ci_failure"]) == "ci-fix"
+
+    def test_greptile_fix(self):
+        assert classify_item_work_type(["greptile_needs_fix"]) == "greptile-fix"
+
+    def test_greptile_improvement(self):
+        assert classify_item_work_type(["greptile_needs_improvement"]) == "greptile-fix"
+
+    def test_merge_conflict(self):
+        assert classify_item_work_type(["merge_conflict"]) == "merge-conflict"
+
+    def test_pr_update(self):
+        assert classify_item_work_type(["pr_update"]) == "pr-review"
+
+    def test_assigned(self):
+        assert classify_item_work_type(["assigned"]) == "assigned-issue"
+
+    def test_strategy(self):
+        assert classify_item_work_type(["strategy"]) == "strategy-reply"
+
+    def test_notification_fallback(self):
+        assert classify_item_work_type(["notification"]) == "notification-triage"
+        assert classify_item_work_type([]) == "notification-triage"
+        assert classify_item_work_type(["unknown_type"]) == "notification-triage"
+
+    def test_ci_beats_pr(self):
+        # A PR with a CI failure should route to ci-fix, not pr-review
+        assert classify_item_work_type(["pr_update", "ci_failure"]) == "ci-fix"
+
+    def test_greptile_beats_pr(self):
+        assert (
+            classify_item_work_type(["pr_update", "greptile_needs_fix"])
+            == "greptile-fix"
+        )
+
+    def test_strategy_highest_priority(self):
+        assert classify_item_work_type(["strategy", "ci_failure"]) == "strategy-reply"
+
+
+# --- _bandit_observation_count and _resolve_model_with_bandit ---
+
+
+class _StubBandit:
+    """Minimal bandit stub for testing dispatch wiring without real PmModelBandit."""
+
+    def __init__(self, counts: dict[str, int], model: str = "haiku"):
+        self._counts = counts
+        self._model = model
+
+    def summary(self) -> dict:
+        return {wt: {"m1": {"selections": cnt}} for wt, cnt in self._counts.items()}
+
+    def resolve_model(self, work_type: str, available: list[str]) -> str:
+        return self._model
+
+
+class TestBanditObservationCount:
+    def test_empty(self):
+        bandit = _StubBandit({})
+        assert _bandit_observation_count(bandit, "ci-fix") == 0
+
+    def test_with_observations(self):
+        bandit = _StubBandit({"ci-fix": 7})
+        assert _bandit_observation_count(bandit, "ci-fix") == 7
+
+    def test_different_work_type(self):
+        bandit = _StubBandit({"ci-fix": 7})
+        assert _bandit_observation_count(bandit, "pr-review") == 0
+
+    def test_malformed_bandit_returns_zero(self):
+        assert _bandit_observation_count(None, "ci-fix") == 0
+
+
+class TestResolveModelWithBandit:
+    def test_no_bandit_delegates_to_static(self):
+        result = _resolve_model_with_bandit(
+            ["ci_failure"], "slow", "sonnet", "haiku", None
+        )
+        # slow lane with no fast_model override → base model
+        assert result == "sonnet"
+
+    def test_bandit_below_threshold_falls_back(self):
+        bandit = _StubBandit({"ci-fix": MIN_BANDIT_OBSERVATIONS - 1}, model="haiku")
+        result = _resolve_model_with_bandit(
+            ["ci_failure"], "slow", "sonnet", "haiku-fast", bandit
+        )
+        # Below threshold → static resolution (slow lane → base model)
+        assert result == "sonnet"
+
+    def test_bandit_at_threshold_uses_bandit(self):
+        bandit = _StubBandit({"ci-fix": MIN_BANDIT_OBSERVATIONS}, model="haiku")
+        result = _resolve_model_with_bandit(
+            ["ci_failure"], "slow", "sonnet", "haiku-fast", bandit
+        )
+        assert result == "haiku"
+
+    def test_bandit_above_threshold_uses_bandit(self):
+        bandit = _StubBandit({"ci-fix": MIN_BANDIT_OBSERVATIONS + 10}, model="sonnet")
+        result = _resolve_model_with_bandit(
+            ["ci_failure"], "fast", "sonnet", "haiku", bandit
+        )
+        assert result == "sonnet"
+
+    def test_bandit_no_available_models_defaults_sonnet(self):
+        bandit = _StubBandit({"ci-fix": 10}, model="sonnet")
+        result = _resolve_model_with_bandit(["ci_failure"], "slow", None, None, bandit)
+        assert result == "sonnet"
+
+
+# --- LaneDispatcher with bandit ---
+
+
+class TestLaneDispatcherWithBandit:
+    def _make_dispatcher(self, launched: list, deferred: list):
+        """Return a LaneDispatcher whose callback captures routing decisions."""
+
+        def callback(slot_unit, slot_key, lane, item, backend, model, script_path):
+            launched.append({"slot_key": slot_key, "lane": lane, "model": model})
+            return True
+
+        mgr = SlotManager(
+            slot_cap=10,
+            count_running=lambda: 0,
+            count_running_lane=lambda lane: 0,
+            is_busy=lambda unit: False,
+        )
+        return LaneDispatcher(slot_manager=mgr, dispatch_callback=callback)
+
+    def test_dispatch_without_bandit_uses_static(self):
+        launched = []
+        dispatcher = self._make_dispatcher(launched, [])
+        items = [SlotItem("r/r", 1, ["ci_failure"], "CI fix")]
+        dispatcher.dispatch(items, model="sonnet", fast_model="haiku", bandit=None)
+        assert len(launched) == 1
+        # ci_failure is slow lane → base model (no fast model in slow lane)
+        assert launched[0]["model"] == "sonnet"
+
+    def test_dispatch_with_bandit_below_threshold_uses_static(self):
+        launched = []
+        dispatcher = self._make_dispatcher(launched, [])
+        bandit = _StubBandit({"ci-fix": MIN_BANDIT_OBSERVATIONS - 1}, model="haiku")
+        items = [SlotItem("r/r", 1, ["ci_failure"], "CI fix")]
+        dispatcher.dispatch(items, model="sonnet", fast_model="haiku-f", bandit=bandit)
+        assert launched[0]["model"] == "sonnet"  # static fallback
+
+    def test_dispatch_with_bandit_above_threshold_uses_bandit(self):
+        launched = []
+        dispatcher = self._make_dispatcher(launched, [])
+        bandit = _StubBandit({"ci-fix": MIN_BANDIT_OBSERVATIONS + 5}, model="haiku")
+        items = [SlotItem("r/r", 1, ["ci_failure"], "CI fix")]
+        dispatcher.dispatch(items, model="sonnet", fast_model="haiku-f", bandit=bandit)
+        assert launched[0]["model"] == "haiku"  # bandit choice
+
+
+# --- record-bandit-outcome CLI ---
+
+
+class TestRecordBanditOutcomeCLI:
+    def test_record_outcome_persists(self, tmp_path):
+        from gptme_runloops.pm_dispatch import _record_bandit_outcome_main
+
+        rc = _record_bandit_outcome_main(
+            [
+                "--work-type",
+                "ci-fix",
+                "--model",
+                "haiku",
+                "--outcome",
+                "productive",
+                "--state-dir",
+                str(tmp_path),
+            ]
+        )
+        assert rc == 0
+        state_file = tmp_path / "bandit-state.json"
+        assert state_file.exists()
+        data = json.loads(state_file.read_text())
+        assert "pm-model:ci-fix:haiku" in data["arms"]
+
+    def test_record_outcome_float(self, tmp_path):
+        from gptme_runloops.pm_dispatch import _record_bandit_outcome_main
+
+        rc = _record_bandit_outcome_main(
+            [
+                "--work-type",
+                "pr-review",
+                "--model",
+                "sonnet",
+                "--outcome",
+                "0.75",
+                "--state-dir",
+                str(tmp_path),
+            ]
+        )
+        assert rc == 0
+        data = json.loads((tmp_path / "bandit-state.json").read_text())
+        arm = data["arms"]["pm-model:pr-review:sonnet"]
+        assert arm["alpha"] == pytest.approx(1.75)

--- a/packages/gptme-runloops/tests/test_pm_dispatch.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch.py
@@ -1290,10 +1290,12 @@ class _StubBandit:
         self._model = model
 
     def summary(self) -> dict:
-        return {wt: {"m1": {"selections": cnt}} for wt, cnt in self._counts.items()}
+        return {
+            wt: {self._model: {"selections": cnt}} for wt, cnt in self._counts.items()
+        }
 
     def resolve_model(self, work_type: str, available: list[str]) -> str:
-        return self._model
+        return self._model if self._model in available else available[0]
 
 
 class TestBanditObservationCount:
@@ -1330,11 +1332,11 @@ class TestResolveModelWithBandit:
         assert result == "sonnet"
 
     def test_bandit_at_threshold_uses_bandit(self):
-        bandit = _StubBandit({"ci-fix": MIN_BANDIT_OBSERVATIONS}, model="haiku")
+        bandit = _StubBandit({"ci-fix": MIN_BANDIT_OBSERVATIONS}, model="haiku-fast")
         result = _resolve_model_with_bandit(
             ["ci_failure"], "slow", "sonnet", "haiku-fast", bandit
         )
-        assert result == "haiku"
+        assert result == "haiku-fast"
 
     def test_bandit_above_threshold_uses_bandit(self):
         bandit = _StubBandit({"ci-fix": MIN_BANDIT_OBSERVATIONS + 10}, model="sonnet")
@@ -1388,10 +1390,10 @@ class TestLaneDispatcherWithBandit:
     def test_dispatch_with_bandit_above_threshold_uses_bandit(self):
         launched = []
         dispatcher = self._make_dispatcher(launched, [])
-        bandit = _StubBandit({"ci-fix": MIN_BANDIT_OBSERVATIONS + 5}, model="haiku")
+        bandit = _StubBandit({"ci-fix": MIN_BANDIT_OBSERVATIONS + 5}, model="haiku-f")
         items = [SlotItem("r/r", 1, ["ci_failure"], "CI fix")]
         dispatcher.dispatch(items, model="sonnet", fast_model="haiku-f", bandit=bandit)
-        assert launched[0]["model"] == "haiku"  # bandit choice
+        assert launched[0]["model"] == "haiku-f"  # bandit choice
 
 
 # --- record-bandit-outcome CLI ---
@@ -1438,3 +1440,20 @@ class TestRecordBanditOutcomeCLI:
         data = json.loads((tmp_path / "bandit-state.json").read_text())
         arm = data["arms"]["pm-model:pr-review:sonnet"]
         assert arm["alpha"] == pytest.approx(1.75)
+
+    def test_record_outcome_rejects_invalid_string(self, tmp_path):
+        from gptme_runloops.pm_dispatch import _record_bandit_outcome_main
+
+        with pytest.raises(SystemExit):
+            _record_bandit_outcome_main(
+                [
+                    "--work-type",
+                    "ci-fix",
+                    "--model",
+                    "haiku",
+                    "--outcome",
+                    "Productive",  # capital P — not in allowlist
+                    "--state-dir",
+                    str(tmp_path),
+                ]
+            )

--- a/packages/gptme-runloops/tests/test_pm_dispatch.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch.py
@@ -1314,6 +1314,26 @@ class TestBanditObservationCount:
     def test_malformed_bandit_returns_zero(self):
         assert _bandit_observation_count(None, "ci-fix") == 0
 
+    def test_model_scoping_excludes_stale_models(self):
+        """Available-model filter must exclude retired/renamed model arms."""
+
+        class _MultiModelStub:
+            def summary(self):  # type: ignore[override]
+                return {
+                    "ci-fix": {
+                        "haiku": {"selections": 5},
+                        "old-sonnet": {"selections": 3},
+                    }
+                }
+
+        bandit = _MultiModelStub()
+        # Unfiltered: counts all historical models
+        assert _bandit_observation_count(bandit, "ci-fix") == 8
+        # Filtered to available: retired arm excluded
+        assert _bandit_observation_count(bandit, "ci-fix", models=["haiku"]) == 5
+        # Entirely different available set: zero (neither arm matches)
+        assert _bandit_observation_count(bandit, "ci-fix", models=["sonnet"]) == 0
+
 
 class TestResolveModelWithBandit:
     def test_no_bandit_delegates_to_static(self):
@@ -1349,6 +1369,24 @@ class TestResolveModelWithBandit:
         bandit = _StubBandit({"ci-fix": 10}, model="sonnet")
         result = _resolve_model_with_bandit(["ci_failure"], "slow", None, None, bandit)
         assert result == "sonnet"
+
+    def test_stale_models_dont_trigger_bandit_early(self):
+        """Stale model observations must not satisfy the MIN_BANDIT_OBSERVATIONS threshold."""
+
+        class _MultiModelStub:
+            def summary(self):  # type: ignore[override]
+                # old-sonnet has 100 observations — retired model
+                return {"ci-fix": {"old-sonnet": {"selections": 100}}}
+
+            def resolve_model(self, work_type: str, available: list) -> str:
+                return available[0]
+
+        bandit = _MultiModelStub()
+        # available=[sonnet, haiku], but old-sonnet doesn't match → below threshold → static
+        result = _resolve_model_with_bandit(
+            ["ci_failure"], "slow", "sonnet", "haiku", bandit
+        )
+        assert result == "sonnet"  # static fallback: slow lane → base model
 
 
 # --- LaneDispatcher with bandit ---


### PR DESCRIPTION
## Summary

- Adds `classify_item_work_type()` to map `SlotItem.types` → PM bandit work type strings (`ci-fix`, `greptile-fix`, `pr-review`, `merge-conflict`, `assigned-issue`, `strategy-reply`, `notification-triage`) with correct priority ordering (ci-fix beats pr-review when both apply)
- Adds `_resolve_model_with_bandit()` — uses Thompson sampling when ≥5 outcomes recorded for the work type, falls back to static `resolve_lane_model()` below the threshold
- Wires bandit routing into `LaneDispatcher.dispatch()` via optional `bandit=None` parameter (fully backward-compatible)
- Adds `record-bandit-outcome` CLI subcommand for bash post-session hooks to feed outcomes back into the bandit state
- 26 new tests covering all paths including the static fallback, threshold boundary, and CLI integration

Completes the wiring gap from #1077 (the `pm_bandit.py` module from #1075 was never connected to the actual dispatch path).

## Test plan

- [ ] `uv run pytest packages/gptme-runloops/tests/test_pm_dispatch.py packages/gptme-runloops/tests/test_pm_bandit.py` — all 145 pass
- [ ] Typecheck: `mypy -p run_loops` clean
- [ ] Dispatch without bandit arg behaves identically to before (no observable change until `bandit=` is passed)
- [ ] Once ≥5 outcomes are recorded per work type, dispatch uses Thompson sampling