### PR TITLE
fix(tests): remove spurious @patch decorator leaking MagicMock/ to workspace root

### DIFF
--- a/packages/gptme-runloops/tests/test_project_monitoring.py
+++ b/packages/gptme-runloops/tests/test_project_monitoring.py
@@ -209,7 +209,6 @@ def test_discover_repositories_failure(mock_run, workspace):
     assert repos == []
 
 
-@patch("gptme_runloops.project_monitoring.subprocess.run")
 def test_should_post_comment_first_time(workspace):
     """Test posting comment for first time."""
     run = ProjectMonitoringRun(workspace)


### PR DESCRIPTION
## Summary

- `test_should_post_comment_first_time` had a `@patch` decorator on the outer function but no mock parameter in the signature
- Python's `@patch` injects the mock as the first positional argument, so `workspace` received a `MagicMock` instead of the pytest fixture
- `ProjectMonitoringRun(MagicMock)` → `Path(MagicMock)` → `RunLoopLock.__init__` called `mkdir` on `MagicMock/run/<id>/logs`, creating a stray directory at the workspace root
- The interior `with patch(...) as mock_run:` context manager already provides the subprocess mock where needed — the outer decorator was fully redundant

## Test plan

- [x] All 309 tests in `packages/gptme-runloops` pass locally
- [x] The workspace-root `_fail_on_magicmock_leak` fixture no longer fires for this test