### PR TITLE
fix(lessons): replace dead keywords with more specific trigger phrases

### DIFF
--- a/lessons/autonomous/agent-event-watch-workflow.md
+++ b/lessons/autonomous/agent-event-watch-workflow.md
@@ -24,7 +24,7 @@ Events like trade settlements, deployment completions, PR reviews, or external d
 
 ## Pattern
 
-**Watch task structure** (4 sections):
+**Event watch structure** (4 sections):
 1. **Context**: What the event is, why it matters, baseline metrics
 2. **Trigger**: Exact condition that fires the task (file path, PR state, etc.)
 3. **Analysis**: What to compute once data is in

--- a/lessons/autonomous/agent-event-watch-workflow.md
+++ b/lessons/autonomous/agent-event-watch-workflow.md
@@ -4,7 +4,7 @@ status: active
 match:
   keywords:
     - named watch task
-    - watch task structure
+    - watch for event results
   session_categories: [cross-repo, strategic]
 ---
 

--- a/lessons/autonomous/rule-driven-session-gating.md
+++ b/lessons/autonomous/rule-driven-session-gating.md
@@ -10,8 +10,9 @@ tags:
 - orchestration
 match:
   keywords:
-    - "skip monitoring session"
-    - "rule-based session gate"
+    - "skip sessions when nothing to do"
+    - "lightweight check before spawning"
+    - "session gating"
   session_categories: [autonomous, infrastructure]
 ---
 

--- a/lessons/workflow/fork-pr-secrets.md
+++ b/lessons/workflow/fork-pr-secrets.md
@@ -2,8 +2,9 @@
 description: "When submitting PRs from a fork, secrets in the parent repo are not available — avoid workflows that require them"
 match:
   keywords:
-    - "CI fails on fork PR"
-    - "fork: push directly"
+    - "fork PR secrets"
+    - "secret is empty"
+    - "push directly to org"
   session_categories: [code, cross-repo]
 status: active
 ---

--- a/lessons/workflow/fork-pr-secrets.md
+++ b/lessons/workflow/fork-pr-secrets.md
@@ -3,7 +3,7 @@ description: "When submitting PRs from a fork, secrets in the parent repo are no
 match:
   keywords:
     - "fork PR secrets"
-    - "secret is empty"
+    - "fork CI missing secrets"
     - "push directly to org"
   session_categories: [code, cross-repo]
 status: active


### PR DESCRIPTION
## Summary

Lesson keyword health check (14-day window, 4817 sessions) found 5 keywords that never fired in recent trajectories. Replaced them with phrases that better match how these scenarios are actually discussed in agent sessions.

**Changes:**
- `fork-pr-secrets.md`: Replace `'CI fails on fork PR'`, `'fork: push directly'` → `'fork PR secrets'`, `'secret is empty'`, `'push directly to org'`
- `rule-driven-session-gating.md`: Replace `'skip monitoring session'`, `'rule-based session gate'` → `'skip sessions when nothing to do'`, `'lightweight check before spawning'`, `'session gating'`
- `agent-event-watch-workflow.md`: Replace `'watch task structure'` → `'watch for event results'`

All 3 lessons still fire via `session_categories`; keyword replacements add more specific, phrase-matched triggers aligned with real agent phrasing.

## Test plan

- [ ] Lesson files pass validation (confirmed all 3 valid locally)
- [ ] No over-broad keywords introduced (all new phrases are 3+ words or specific domain terms)