### PR TITLE
fix(perplexity): use current sonar model; extract citations

### DIFF
--- a/scripts/perplexity.py
+++ b/scripts/perplexity.py
@@ -57,7 +57,9 @@ def _extract_citations(response: object) -> list[str]:
     data = response.model_dump() if hasattr(response, "model_dump") else {}
     citations = data.get("citations")
     if citations:
-        return [c for c in citations if isinstance(c, str)]
+        urls = [c for c in citations if isinstance(c, str)]
+        if urls:
+            return urls
     results = data.get("search_results") or []
     return [r["url"] for r in results if isinstance(r, dict) and r.get("url")]
 

--- a/scripts/perplexity.py
+++ b/scripts/perplexity.py
@@ -31,6 +31,11 @@ logger = logging.getLogger("perplexity")
 
 console = Console()
 
+# Perplexity retired the `llama-3.1-sonar-*` models on 2025-02-22; the current
+# online search models are `sonar` (default) and `sonar-pro`. Override with the
+# PERPLEXITY_MODEL env var.
+DEFAULT_MODEL = "sonar"
+
 
 @dataclass
 class SearchResult:
@@ -41,15 +46,37 @@ class SearchResult:
     query: str
 
 
+def _extract_citations(response: object) -> list[str]:
+    """Pull source URLs from a Perplexity response.
+
+    Perplexity returns citations as extra, non-OpenAI fields on the response.
+    Older responses expose a flat ``citations`` list of URL strings; newer ones
+    use ``search_results`` (objects with a ``url``). Read whichever is present
+    without assuming the OpenAI SDK typed it.
+    """
+    data = response.model_dump() if hasattr(response, "model_dump") else {}
+    citations = data.get("citations")
+    if citations:
+        return [c for c in citations if isinstance(c, str)]
+    results = data.get("search_results") or []
+    return [r["url"] for r in results if isinstance(r, dict) and r.get("url")]
+
+
 class PerplexitySearch:
     """Handles searching with Perplexity's API"""
 
-    def __init__(self, api_key: str | None = None):
+    def __init__(self, api_key: str | None = None, model: str | None = None):
         self.api_key = api_key or self._get_api_key()
+        self.model = model or self._get_model()
         self.client = OpenAI(
             api_key=self.api_key,
             base_url="https://api.perplexity.ai",
         )
+
+    @staticmethod
+    def _get_model() -> str:
+        """Resolve the Perplexity model, honoring the PERPLEXITY_MODEL override."""
+        return os.getenv("PERPLEXITY_MODEL") or DEFAULT_MODEL
 
     def _get_api_key(self) -> str:
         """Get API key from environment or config file"""
@@ -80,7 +107,7 @@ class PerplexitySearch:
         """
         with Live(Spinner("runner", "Researching query..."), refresh_per_second=10):
             response = self.client.chat.completions.create(
-                model="llama-3.1-sonar-large-128k-online",
+                model=self.model,
                 messages=[
                     {
                         "role": "system",
@@ -93,11 +120,12 @@ class PerplexitySearch:
                 ],
             )
         msg = response.choices[0].message
-        assert msg.content
+        if not msg.content:
+            raise RuntimeError("Perplexity returned an empty response")
 
         return SearchResult(
             answer=msg.content,
-            sources=[],
+            sources=_extract_citations(response),
             query=query,
         )
 

--- a/tests/test_perplexity.py
+++ b/tests/test_perplexity.py
@@ -1,0 +1,74 @@
+"""Tests for scripts/perplexity.py model resolution and citation extraction."""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# Add scripts dir to path so we can import the PEP 723 script module
+SCRIPT_DIR = Path(__file__).parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR))
+
+# `openai` is a PEP 723 inline dep of the script, not a gptme-contrib package
+# dep, so it may be absent in the test env. Inject a stub before import (same
+# pattern as tests/test_twitter_eval_prompt.py).
+if "openai" not in sys.modules:
+    _fake_openai = types.ModuleType("openai")
+    _fake_openai.OpenAI = object  # type: ignore[attr-defined]
+    sys.modules["openai"] = _fake_openai
+
+spec = importlib.util.spec_from_file_location(
+    "perplexity",
+    SCRIPT_DIR / "perplexity.py",
+)
+assert spec is not None and spec.loader is not None
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+
+class _FakeResponse:
+    """Minimal stand-in for an OpenAI response exposing model_dump()."""
+
+    def __init__(self, payload: dict):
+        self._payload = payload
+
+    def model_dump(self) -> dict:
+        return self._payload
+
+
+def test_default_model_is_a_current_sonar_model():
+    """Guard against regressing to a retired llama-3.1-sonar-* model."""
+    assert mod.DEFAULT_MODEL == "sonar"
+    assert "llama" not in mod.DEFAULT_MODEL
+
+
+def test_get_model_defaults_when_env_unset(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("PERPLEXITY_MODEL", raising=False)
+    assert mod.PerplexitySearch._get_model() == mod.DEFAULT_MODEL
+
+
+def test_get_model_honors_env_override(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("PERPLEXITY_MODEL", "sonar-pro")
+    assert mod.PerplexitySearch._get_model() == "sonar-pro"
+
+
+def test_extract_citations_prefers_flat_citations_list():
+    resp = _FakeResponse({"citations": ["https://a.example", "https://b.example"]})
+    assert mod._extract_citations(resp) == ["https://a.example", "https://b.example"]
+
+
+def test_extract_citations_falls_back_to_search_results():
+    resp = _FakeResponse(
+        {"search_results": [{"url": "https://c.example"}, {"title": "no url"}]}
+    )
+    assert mod._extract_citations(resp) == ["https://c.example"]
+
+
+def test_extract_citations_empty_when_no_sources():
+    assert mod._extract_citations(_FakeResponse({})) == []
+
+
+def test_extract_citations_handles_object_without_model_dump():
+    assert mod._extract_citations(object()) == []

--- a/tests/test_perplexity.py
+++ b/tests/test_perplexity.py
@@ -66,6 +66,16 @@ def test_extract_citations_falls_back_to_search_results():
     assert mod._extract_citations(resp) == ["https://c.example"]
 
 
+def test_extract_citations_falls_back_when_citations_have_no_urls():
+    resp = _FakeResponse(
+        {
+            "citations": [{"text": "not a url"}],
+            "search_results": [{"url": "https://x.example"}],
+        }
+    )
+    assert mod._extract_citations(resp) == ["https://x.example"]
+
+
 def test_extract_citations_empty_when_no_sources():
     assert mod._extract_citations(_FakeResponse({})) == []
 


### PR DESCRIPTION
## Problem

`scripts/perplexity.py` (exposed as Bob's `tools/perplexity.py` research tool) pinned the model `llama-3.1-sonar-large-128k-online`, which **Perplexity retired on 2025-02-22**. Every live search through this tool has errored with an invalid-model response since then.

## Changes

- Default to the current **`sonar`** online model; allow override via `PERPLEXITY_MODEL` env var (`DEFAULT_MODEL` constant).
- Populate `SearchResult.sources` from the response's `citations` / `search_results` (previously hardcoded to `[]`, so the "Sources:" output never worked).
- Replace the bare `assert msg.content` with a clear `RuntimeError` on an empty response.

## Tests

`tests/test_perplexity.py` — 7 network-free regression tests covering model resolution (default + env override + a guard against regressing to a retired `llama-3.1-sonar-*` model) and citation extraction (flat `citations`, `search_results` fallback, empty, and non-`model_dump` inputs). `openai` is stubbed via `sys.modules` because it's a PEP 723 inline dep, not a package dep (same pattern as `tests/test_twitter_eval_prompt.py`).

All pass locally; `ruff check` + `ruff format` clean.