### PR TITLE
refactor(lessons-extras): extract NON_LESSON_FILES constant

### DIFF
--- a/packages/gptme-lessons-extras/src/gptme_lessons_extras/similarity.py
+++ b/packages/gptme-lessons-extras/src/gptme_lessons_extras/similarity.py
@@ -33,6 +33,10 @@ from typing import Dict, List, Set, Tuple
 
 import frontmatter
 
+# Non-lesson markdown files that live alongside lessons but must be excluded
+# from similarity/staleness analysis.
+NON_LESSON_FILES = ("README.md", "TODO.md", "lesson-template.md")
+
 
 @dataclass
 class SimilarityScore:
@@ -232,7 +236,7 @@ def find_similar_lessons(
 
     # Compare against all other lessons
     for other_path in lessons_dir.rglob("*.md"):
-        if other_path.name in ("README.md", "TODO.md", "lesson-template.md"):
+        if other_path.name in NON_LESSON_FILES:
             continue
         if other_path == lesson_path:
             continue
@@ -341,7 +345,7 @@ def calculate_recency_scores(
     now = datetime.now().astimezone()
 
     for lesson_path in lessons_dir.rglob("*.md"):
-        if lesson_path.name in ("README.md", "TODO.md", "lesson-template.md"):
+        if lesson_path.name in NON_LESSON_FILES:
             continue
 
         # Get git modification date
@@ -402,11 +406,7 @@ def find_duplicates(
     """
     duplicates = []
     lessons = list(lessons_dir.rglob("*.md"))
-    lessons = [
-        lesson
-        for lesson in lessons
-        if lesson.name not in ("README.md", "TODO.md", "lesson-template.md")
-    ]
+    lessons = [lesson for lesson in lessons if lesson.name not in NON_LESSON_FILES]
 
     # Compare all pairs
     for i, lesson1 in enumerate(lessons):


### PR DESCRIPTION
## What

Replace the triplicated `("README.md", "TODO.md", "lesson-template.md")` tuple in `gptme_lessons_extras/similarity.py` with a single module-level `NON_LESSON_FILES` constant.

## Why

The same literal exclusion list appeared in three call sites (`find_similar_lessons`, `score_lesson_recency`, and the staleness report). Adding a new non-lesson file (or fixing the list) required editing all three in sync — a classic DRY hazard. The constant gives one source of truth.

## Verification

- `make typecheck` clean
- `uv run pytest packages/gptme-lessons-extras` — 87 passed (in-place); similarity tests 17/17 on the branch
- No behavior change — pure refactor (7 insertions, 7 deletions)