### PR TITLE
fix(gptmail): GPTME_WORKSPACE override + lazy logging in watcher daemon

### DIFF
--- a/packages/gptmail/src/gptmail/README.md
+++ b/packages/gptmail/src/gptmail/README.md
@@ -42,7 +42,7 @@ your-agent-workspace/
 
 ## Configuration
 
-The system automatically detects the agent workspace by navigating up from the script location. For custom workspace locations, set environment variables (TODO: implement GPTME_WORKSPACE support).
+The watcher daemon detects the agent workspace from `GPTME_WORKSPACE` if set, otherwise by navigating up from the script location (`packages/gptmail/src/gptmail` -> workspace root). Set `GPTME_WORKSPACE=/path/to/workspace` for installed or symlinked layouts where the source-tree relative path does not hold.
 
 ## External Email Setup
 

--- a/packages/gptmail/src/gptmail/watcher.py
+++ b/packages/gptmail/src/gptmail/watcher.py
@@ -11,27 +11,59 @@
 """Simple email sync and response daemon."""
 
 import logging
+import os
 import subprocess
 import sys
 import time
+from collections.abc import Mapping
 from pathlib import Path
 
 from gptmail.communication_utils.state.locks import FileLock, LockError
 from gptmail.lib import AgentEmail
 
 # Configuration
-# Find workspace root: packages/gptmail/src/gptmail -> ../../../../
 SCRIPT_DIR = Path(__file__).parent
-WORKSPACE_DIR = SCRIPT_DIR.parent.parent.parent.parent
+
+
+def _resolve_workspace_dir(
+    env: Mapping[str, str] | None = None,
+    script_dir: Path | None = None,
+) -> Path:
+    """Resolve the workspace root for the email watcher daemon.
+
+    Prefers the ``GPTME_WORKSPACE`` environment override (the watcher runs as a
+    daemon, so cwd-based git resolution like ``agent_cli._repo_root`` is not
+    reliable here). Falls back to the file location:
+    ``packages/gptmail/src/gptmail`` -> ``../../../..``. The fallback only holds
+    when the package lives in the source tree, so the override exists for
+    installed/symlinked layouts.
+    """
+    env = os.environ if env is None else env
+    override = env.get("GPTME_WORKSPACE", "").strip()
+    if override:
+        return Path(override).expanduser().resolve()
+    script_dir = SCRIPT_DIR if script_dir is None else script_dir
+    return script_dir.parent.parent.parent.parent
+
+
+WORKSPACE_DIR = _resolve_workspace_dir()
 EMAIL_DIR = WORKSPACE_DIR / "email"
 INBOX_DIR = EMAIL_DIR / "inbox"
 
-# Setup logging
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s - %(message)s",
-    handlers=[logging.FileHandler(EMAIL_DIR / "watcher.log"), logging.StreamHandler()],
-)
+
+def _setup_logging() -> None:
+    """Configure daemon logging.
+
+    Called from the entry point rather than at import time so the module can be
+    imported (e.g. for tests or tooling) without eagerly opening a log file in a
+    directory that may not exist.
+    """
+    EMAIL_DIR.mkdir(parents=True, exist_ok=True)
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+        handlers=[logging.FileHandler(EMAIL_DIR / "watcher.log"), logging.StreamHandler()],
+    )
 
 
 def run_mbsync():
@@ -222,6 +254,7 @@ def run_daemon():
 
 
 if __name__ == "__main__":
+    _setup_logging()
     if len(sys.argv) > 1:
         command = sys.argv[1]
         if command == "once":

--- a/packages/gptmail/src/gptmail/watcher.py
+++ b/packages/gptmail/src/gptmail/watcher.py
@@ -41,9 +41,14 @@ def _resolve_workspace_dir(
     env = os.environ if env is None else env
     override = env.get("GPTME_WORKSPACE", "").strip()
     if override:
-        return Path(override).expanduser().resolve()
+        # Expand ~ using HOME from *env* (not os.environ["HOME"]), so test
+        # injection via an explicit env dict is self-contained.
+        if override.startswith("~/") or override == "~":
+            home = env.get("HOME", os.environ.get("HOME", ""))
+            override = home + override[1:]
+        return Path(override).resolve()
     script_dir = SCRIPT_DIR if script_dir is None else script_dir
-    return script_dir.parent.parent.parent.parent
+    return script_dir.parent.parent.parent.parent.resolve()
 
 
 WORKSPACE_DIR = _resolve_workspace_dir()

--- a/packages/gptmail/tests/test_watcher_workspace.py
+++ b/packages/gptmail/tests/test_watcher_workspace.py
@@ -1,0 +1,36 @@
+"""Tests for the email watcher's workspace-root resolution.
+
+Covers the ``GPTME_WORKSPACE`` override added so installed/symlinked layouts
+don't silently resolve to the wrong directory via the source-tree relative
+fallback.
+"""
+
+from pathlib import Path
+
+from gptmail.watcher import _resolve_workspace_dir
+
+
+def test_env_override_takes_precedence(tmp_path: Path) -> None:
+    ws = tmp_path / "my-workspace"
+    ws.mkdir()
+    resolved = _resolve_workspace_dir(env={"GPTME_WORKSPACE": str(ws)})
+    assert resolved == ws.resolve()
+
+
+def test_env_override_expands_user(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    resolved = _resolve_workspace_dir(env={"GPTME_WORKSPACE": "~/ws"})
+    assert resolved == (tmp_path / "ws").resolve()
+
+
+def test_blank_override_falls_back_to_script_dir() -> None:
+    # Mirrors the real layout: <ws>/packages/gptmail/src/gptmail -> <ws>
+    fake_script_dir = Path("/opt/ws/packages/gptmail/src/gptmail")
+    resolved = _resolve_workspace_dir(env={"GPTME_WORKSPACE": "  "}, script_dir=fake_script_dir)
+    assert resolved == Path("/opt/ws")
+
+
+def test_missing_override_uses_relative_fallback() -> None:
+    fake_script_dir = Path("/home/agent/packages/gptmail/src/gptmail")
+    resolved = _resolve_workspace_dir(env={}, script_dir=fake_script_dir)
+    assert resolved == Path("/home/agent")

--- a/packages/gptmail/tests/test_watcher_workspace.py
+++ b/packages/gptmail/tests/test_watcher_workspace.py
@@ -23,6 +23,14 @@ def test_env_override_expands_user(monkeypatch, tmp_path: Path) -> None:
     assert resolved == (tmp_path / "ws").resolve()
 
 
+def test_env_override_expands_user_from_env_home(tmp_path: Path) -> None:
+    # HOME in the env dict is used — no os.environ patch needed.
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    resolved = _resolve_workspace_dir(env={"GPTME_WORKSPACE": "~/ws", "HOME": str(home_dir)})
+    assert resolved == (home_dir / "ws").resolve()
+
+
 def test_blank_override_falls_back_to_script_dir() -> None:
     # Mirrors the real layout: <ws>/packages/gptmail/src/gptmail -> <ws>
     fake_script_dir = Path("/opt/ws/packages/gptmail/src/gptmail")


### PR DESCRIPTION
## Problem

The email watcher (`watcher.py`) resolved its workspace root purely by walking four parents up from `__file__`. Under the symlinked `packages/gptmail` layout (a symlink into this submodule), that resolves to the **wrong** root — the contrib repo instead of the agent workspace — and it breaks for any installed or symlinked layout. The README documented a `GPTME_WORKSPACE` override that was never actually implemented.

Separately, `logging.basicConfig` ran at **import time** with an eager `FileHandler`, so importing the module (for tests or tooling) opened a log file in a directory that may not exist — making the module un-importable outside a fully-populated workspace.

## Changes

- Add `_resolve_workspace_dir()`: honor `GPTME_WORKSPACE` first, fall back to the file-relative path. cwd-based `git rev-parse` (as in `agent_cli._repo_root`) isn't reliable for a long-running daemon, so the override is the right escape hatch.
- Move `logging.basicConfig` into `_setup_logging()` called from the entry point. Importing the module no longer has side effects; `mkdir(parents=True, exist_ok=True)` means a fresh workspace doesn't crash on first run.
- Document the override in the README; drop the stale TODO.
- Add 4 focused tests for the pure resolver.

## Verification

- `uv run pytest packages/gptmail/tests/` — 127 passed
- `uv run mypy packages/gptmail/src/gptmail/watcher.py` — clean
- `uv run ruff check` + `ruff format --check` — clean

Backward compatible: behavior is unchanged when `GPTME_WORKSPACE` is unset and the package lives in the source tree.