### PR TITLE
fix(git-hooks): don't false-error pre-push on up-to-date push

### DIFF
--- a/dotfiles/.config/git/hooks/validate-worktree-tracking.sh
+++ b/dotfiles/.config/git/hooks/validate-worktree-tracking.sh
@@ -100,8 +100,7 @@ if [ "$upstream" = "origin/master" ] || [ "$upstream" = "origin/main" ]; then
             break
         fi
     done
-    # Also block when stdin was empty (e.g. plain `git push` with no refspecs)
-    if [ "$pushing_to_default" = true ] || [ ${#push_remote_refs[@]} -eq 0 ]; then
+    if [ "$pushing_to_default" = true ]; then
         echo "🚫 ERROR: Branch '$current_branch' tracks '$upstream'!"
         echo ""
         echo "   This will push your feature branch directly to master/main."

--- a/dotfiles/.config/git/hooks/validate-worktree-tracking.sh
+++ b/dotfiles/.config/git/hooks/validate-worktree-tracking.sh
@@ -27,6 +27,10 @@ push_remote_refs=()
 all_deletions=true
 any_pushed=false
 while read -r _local_ref local_sha remote_ref _remote_sha; do
+    # Skip blank lines. An up-to-date push ("Everything up-to-date") makes git
+    # invoke the hook with empty stdin; the caller may forward a single empty
+    # line. Treating that as a real ref produced a false "no upstream" error.
+    [ -z "$local_sha$remote_ref" ] && continue
     push_remote_refs+=("$remote_ref")
     any_pushed=true
     if [ "$local_sha" != "$ZERO" ]; then
@@ -34,9 +38,14 @@ while read -r _local_ref local_sha remote_ref _remote_sha; do
     fi
 done
 
+# Nothing actually being pushed (empty stdin / up-to-date) — nothing to validate.
+if [ "$any_pushed" = false ]; then
+    exit 0
+fi
+
 # Skip if push contains only branch deletions (e.g. `git push origin --delete BRANCH`).
 # The current branch's upstream is irrelevant when we're not pushing it.
-if [ "$any_pushed" = true ] && [ "$all_deletions" = true ]; then
+if [ "$all_deletions" = true ]; then
     exit 0
 fi
 


### PR DESCRIPTION
## Problem

`dotfiles/.config/git/hooks/validate-worktree-tracking.sh` hard-failed a legitimate **up-to-date** push:

```
❌ Error: Branch '<feature>' has no upstream tracking branch
```

### Root cause

On an "Everything up-to-date" push, git still invokes the pre-push hook but sends **no ref lines** on stdin. The `pre-push` wrapper forwards its stored lines via `printf '%s\n' "${STDIN_LINES[@]}"`, which for an empty array emits a single **empty line**. The validation script's read loop counted that empty line as a real push of an empty ref (`any_pushed=true`, `push_remote_refs=("")`). With no upstream set, the new-branch heuristic didn't match the empty ref, so it fell through to the hard error — blocking a harmless no-op push.

This surfaced when re-pushing an already-pushed fork branch (the branch tip already matched the remote).

## Fix

- Skip blank lines in the read loop.
- Exit 0 when nothing is actually being pushed (empty stdin / up-to-date).

## Verification

- `shellcheck` clean.
- Empty line / empty stdin → exit 0 (was: exit 1 false error).
- Real new-branch push → unchanged.
- **Master/main protection unchanged**: a feature branch tracking `origin/master` with a push destined for `master` still blocks (rc 1).
- Reproduced the original failure end-to-end (`git push fork <branch>:<branch>` on an up-to-date branch) → now prints `Everything up-to-date` instead of erroring.