### PR TITLE
fix(gptme-runloops): resolve 10 mypy type errors in pm_dispatch

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -21,7 +21,7 @@ import sys
 from dataclasses import dataclass, field, fields
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, cast
 
 # Slow-lane item types — items that need deep investigation (PR reviews,
 # CI diagnostics, merge conflicts, Greptile issues). Fast lane is anything
@@ -375,7 +375,7 @@ def _resolve_model_with_bandit(
     obs = _bandit_observation_count(bandit, work_type, models=available)
     if obs < MIN_BANDIT_OBSERVATIONS:
         return resolve_lane_model(lane, model, fast_model)
-    return bandit.resolve_model(work_type, available)
+    return cast(str, bandit.resolve_model(work_type, available))
 
 
 def partition_items(items: list[SlotItem]) -> tuple[list[SlotItem], list[SlotItem]]:

--- a/packages/gptme-runloops/tests/test_pm_dispatch.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch.py
@@ -55,7 +55,9 @@ def make_item(
         number=number,
         types=types or ["pr_update"],
         title=title,
-        url=f"https://github.com/{repo}/pull/{number}",
+        url=f"https://github.com/{repo}/pull/{number}"
+        if number is not None
+        else f"https://github.com/{repo}",
     )
 
 

--- a/packages/gptme-runloops/tests/test_pm_dispatch.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import io
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 from gptme_runloops.pm_dispatch import (
@@ -45,7 +46,7 @@ def ledger(ledger_path: Path) -> DispatchLedger:
 
 def make_item(
     repo: str = "owner/repo",
-    number: int = 42,
+    number: int | None = 42,
     types: list[str] | None = None,
     title: str = "Test item",
 ) -> SlotItem:
@@ -1318,7 +1319,7 @@ class TestBanditObservationCount:
         """Available-model filter must exclude retired/renamed model arms."""
 
         class _MultiModelStub:
-            def summary(self):  # type: ignore[override]
+            def summary(self):
                 return {
                     "ci-fix": {
                         "haiku": {"selections": 5},
@@ -1374,11 +1375,11 @@ class TestResolveModelWithBandit:
         """Stale model observations must not satisfy the MIN_BANDIT_OBSERVATIONS threshold."""
 
         class _MultiModelStub:
-            def summary(self):  # type: ignore[override]
+            def summary(self):
                 # old-sonnet has 100 observations — retired model
                 return {"ci-fix": {"old-sonnet": {"selections": 100}}}
 
-            def resolve_model(self, work_type: str, available: list) -> str:
+            def resolve_model(self, work_type: str, available: list[str]) -> str:
                 return available[0]
 
         bandit = _MultiModelStub()
@@ -1409,7 +1410,7 @@ class TestLaneDispatcherWithBandit:
         return LaneDispatcher(slot_manager=mgr, dispatch_callback=callback)
 
     def test_dispatch_without_bandit_uses_static(self):
-        launched = []
+        launched: list[dict[str, Any]] = []
         dispatcher = self._make_dispatcher(launched, [])
         items = [SlotItem("r/r", 1, ["ci_failure"], "CI fix")]
         dispatcher.dispatch(items, model="sonnet", fast_model="haiku", bandit=None)
@@ -1418,7 +1419,7 @@ class TestLaneDispatcherWithBandit:
         assert launched[0]["model"] == "sonnet"
 
     def test_dispatch_with_bandit_below_threshold_uses_static(self):
-        launched = []
+        launched: list[dict[str, Any]] = []
         dispatcher = self._make_dispatcher(launched, [])
         bandit = _StubBandit({"ci-fix": MIN_BANDIT_OBSERVATIONS - 1}, model="haiku")
         items = [SlotItem("r/r", 1, ["ci_failure"], "CI fix")]
@@ -1426,7 +1427,7 @@ class TestLaneDispatcherWithBandit:
         assert launched[0]["model"] == "sonnet"  # static fallback
 
     def test_dispatch_with_bandit_above_threshold_uses_bandit(self):
-        launched = []
+        launched: list[dict[str, Any]] = []
         dispatcher = self._make_dispatcher(launched, [])
         bandit = _StubBandit({"ci-fix": MIN_BANDIT_OBSERVATIONS + 5}, model="haiku-f")
         items = [SlotItem("r/r", 1, ["ci_failure"], "CI fix")]


### PR DESCRIPTION
## Summary

Found 10 mypy type errors in `packages/gptme-runloops/` that were visible with `uv run mypy packages/gptme-runloops/ --ignore-missing-imports` but not surfaced by the default `make typecheck` (which excludes test files and uses per-package config).

**Changes:**
- `pm_dispatch.py`: add `cast` import; wrap `bandit.resolve_model()` return with `cast(str, ...)` since `bandit` is typed `Any` but the function promises `str | None`
- `test_pm_dispatch.py`: widen `make_item(number: int)` → `int | None` (CI failure items correctly pass `number=None`); remove two stale `# type: ignore[override]` comments that mypy no longer needs; annotate `resolve_model(available: list)` → `list[str]`; add `launched: list[dict[str, Any]]` annotations in `TestLaneDispatcherWithBandit`

## Test plan

- [x] All 132 `test_pm_dispatch.py` tests pass
- [x] `uv run mypy packages/gptme-runloops/ --ignore-missing-imports` → Success: no issues found in 46 source files