### PR TITLE
feat(gptme-sessions): add cost subcommand with gptme-usage pricing

### DIFF
--- a/packages/gptme-sessions/pyproject.toml
+++ b/packages/gptme-sessions/pyproject.toml
@@ -31,6 +31,9 @@ Repository = "https://github.com/gptme/gptme-contrib"
 Issues = "https://github.com/gptme/gptme-contrib/issues"
 
 [project.optional-dependencies]
+cost = [
+    "gptme-usage>=0.1.0",
+]
 dev = [
     "mypy>=1.0.0",
     "pytest>=7.0",

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -2828,10 +2828,7 @@ def cost(
     Requires gptme-usage to be installed for pricing data.
     Install with: pip install gptme-sessions[cost]
     """
-    try:
-        from .cost import analyze_costs, format_cost_summary
-    except ImportError as e:
-        raise click.ClickException(f"cost module unavailable: {e}") from e
+    from .cost import analyze_costs, format_cost_summary
 
     try:
         from gptme_usage.harness_models import estimate_session_cost as _  # noqa: F401

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -2808,6 +2808,66 @@ def classify_stats(
             click.echo(f"  ✅ Good diversity: {unique}/{diversity_window} categories — {cats_str}")
 
 
+@cli.command()
+@click.option("--days", default=7, show_default=True, help="Include sessions from last N days")
+@click.option("--daily", is_flag=True, help="Show day-by-day cost breakdown")
+@click.option("--by-model", "by_model", is_flag=True, help="Show per-model cost breakdown")
+@click.option("--last-7d", "last_7d", is_flag=True, help="Shorthand for --days 7")
+@click.option("--json", "as_json", is_flag=True, help="Output JSON instead of formatted text")
+@click.pass_context
+def cost(
+    ctx: click.Context,
+    days: int,
+    daily: bool,
+    by_model: bool,
+    last_7d: bool,
+    as_json: bool,
+) -> None:
+    """Show session cost breakdown.
+
+    Requires gptme-usage to be installed for pricing data.
+    Install with: pip install gptme-sessions[cost]
+    """
+    try:
+        from .cost import analyze_costs, format_cost_summary
+    except ImportError as e:
+        raise click.ClickException(f"cost module unavailable: {e}") from e
+
+    try:
+        from gptme_usage.harness_models import estimate_session_cost as _  # noqa: F401
+    except ImportError:
+        raise click.ClickException(
+            "gptme-usage is required for cost estimation.\n"
+            "Install with: pip install gptme-sessions[cost]"
+        )
+
+    if last_7d:
+        days = 7
+
+    store = SessionStore(sessions_dir=ctx.obj["sessions_dir"])
+    records = store.query()
+    summary = analyze_costs(records, days=days)
+
+    if as_json:
+        import dataclasses
+
+        click.echo(
+            json.dumps(
+                {
+                    "session_count": summary.session_count,
+                    "priced_count": summary.priced_count,
+                    "total_cost": summary.total_cost,
+                    "avg_cost": summary.avg_cost,
+                    "by_model": {m: dataclasses.asdict(s) for m, s in summary.by_model.items()},
+                    "by_day": {d: dataclasses.asdict(s) for d, s in summary.by_day.items()},
+                },
+                indent=2,
+            )
+        )
+    else:
+        click.echo(format_cost_summary(summary, daily=daily, by_model=by_model))
+
+
 def main() -> int:
     """Entry point for console_scripts (backward-compatible wrapper).
 

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -2849,8 +2849,6 @@ def cost(
     summary = analyze_costs(records, days=days)
 
     if as_json:
-        import dataclasses
-
         click.echo(
             json.dumps(
                 {
@@ -2858,8 +2856,21 @@ def cost(
                     "priced_count": summary.priced_count,
                     "total_cost": summary.total_cost,
                     "avg_cost": summary.avg_cost,
-                    "by_model": {m: dataclasses.asdict(s) for m, s in summary.by_model.items()},
-                    "by_day": {d: dataclasses.asdict(s) for d, s in summary.by_day.items()},
+                    "by_model": {
+                        m: {
+                            "count": s.count,
+                            "total_cost": s.total_cost,
+                            "avg_cost": s.avg_cost,
+                        }
+                        for m, s in summary.by_model.items()
+                    },
+                    "by_day": {
+                        d: {
+                            "count": s.count,
+                            "total_cost": s.total_cost,
+                        }
+                        for d, s in summary.by_day.items()
+                    },
                 },
                 indent=2,
             )

--- a/packages/gptme-sessions/src/gptme_sessions/cost.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cost.py
@@ -1,0 +1,164 @@
+"""Session cost estimation and analysis.
+
+Requires ``gptme-usage`` (optional dependency):
+    pip install gptme-sessions[cost]
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .record import SessionRecord
+
+
+@dataclass
+class ModelCostStats:
+    count: int = 0
+    total_cost: float = 0.0
+
+    @property
+    def avg_cost(self) -> float:
+        return self.total_cost / self.count if self.count else 0.0
+
+
+@dataclass
+class DayCostStats:
+    count: int = 0
+    total_cost: float = 0.0
+
+
+@dataclass
+class CostSummary:
+    """Aggregated cost statistics over a set of session records."""
+
+    session_count: int
+    priced_count: int  # records where cost could be estimated
+    total_cost: float
+    by_model: dict[str, ModelCostStats] = field(default_factory=dict)
+    by_day: dict[str, DayCostStats] = field(default_factory=dict)
+
+    @property
+    def avg_cost(self) -> float:
+        return self.total_cost / self.priced_count if self.priced_count else 0.0
+
+
+def estimate_record_cost(record: "SessionRecord") -> float | None:
+    """Estimate USD cost for a single session record.
+
+    Returns None if gptme-usage is not installed, pricing is unknown,
+    or the record lacks token data.
+    """
+    try:
+        from gptme_usage.harness_models import estimate_session_cost
+    except ImportError:
+        return None
+
+    harness = record.harness or "unknown"
+    model = record.model or "unknown"
+
+    result = estimate_session_cost(
+        harness,
+        model,
+        input_tokens=record.input_tokens,
+        output_tokens=record.output_tokens,
+        cache_creation_tokens=record.cache_creation_tokens,
+        cache_read_tokens=record.cache_read_tokens,
+        token_count=record.token_count,
+    )
+    return float(result) if result is not None else None
+
+
+def analyze_costs(
+    records: list["SessionRecord"],
+    days: int | None = None,
+) -> CostSummary:
+    """Analyze costs across a list of session records.
+
+    Args:
+        records: Session records to analyze.
+        days: If set, only include records from the last N days.
+
+    Returns:
+        CostSummary with total cost, by-model breakdown, and by-day breakdown.
+    """
+    if days is not None:
+        cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+        filtered = []
+        for r in records:
+            if not r.timestamp:
+                continue
+            try:
+                ts = datetime.fromisoformat(r.timestamp.replace("Z", "+00:00"))
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=timezone.utc)
+                if ts >= cutoff:
+                    filtered.append(r)
+            except ValueError:
+                pass
+        records = filtered
+
+    by_model: dict[str, ModelCostStats] = defaultdict(ModelCostStats)
+    by_day: dict[str, DayCostStats] = defaultdict(DayCostStats)
+    total_cost = 0.0
+    priced_count = 0
+
+    for record in records:
+        cost = estimate_record_cost(record)
+        model_key = record.model_normalized or record.model or "unknown"
+        day_key = record.timestamp[:10] if record.timestamp else "unknown"
+
+        if cost is not None:
+            total_cost += cost
+            priced_count += 1
+            by_model[model_key].count += 1
+            by_model[model_key].total_cost += cost
+            by_day[day_key].count += 1
+            by_day[day_key].total_cost += cost
+
+    return CostSummary(
+        session_count=len(records),
+        priced_count=priced_count,
+        total_cost=total_cost,
+        by_model=dict(by_model),
+        by_day=dict(sorted(by_day.items())),
+    )
+
+
+def format_cost_summary(summary: CostSummary, daily: bool = False, by_model: bool = False) -> str:
+    """Format a CostSummary for human-readable output."""
+    lines: list[str] = []
+
+    lines.append("# Session Cost Summary")
+    lines.append("")
+    lines.append(f"Sessions: {summary.session_count} total, {summary.priced_count} with cost data")
+    lines.append(f"Total cost: ${summary.total_cost:.4f}")
+    if summary.priced_count:
+        lines.append(f"Avg cost:   ${summary.avg_cost:.4f}")
+
+    if by_model and summary.by_model:
+        lines.append("")
+        lines.append("## By Model")
+        lines.append("")
+        lines.append(f"{'Model':<30} {'Sessions':>8} {'Total':>10} {'Avg':>10}")
+        lines.append("-" * 62)
+        for model, mstats in sorted(
+            summary.by_model.items(), key=lambda x: x[1].total_cost, reverse=True
+        ):
+            lines.append(
+                f"{model:<30} {mstats.count:>8} ${mstats.total_cost:>9.4f} ${mstats.avg_cost:>9.4f}"
+            )
+
+    if daily and summary.by_day:
+        lines.append("")
+        lines.append("## By Day")
+        lines.append("")
+        lines.append(f"{'Date':<12} {'Sessions':>8} {'Total':>10}")
+        lines.append("-" * 32)
+        for day, dstats in summary.by_day.items():
+            lines.append(f"{day:<12} {dstats.count:>8} ${dstats.total_cost:>9.4f}")
+
+    return "\n".join(lines)

--- a/packages/gptme-sessions/src/gptme_sessions/cost.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cost.py
@@ -46,6 +46,19 @@ class CostSummary:
         return self.total_cost / self.priced_count if self.priced_count else 0.0
 
 
+def _load_pricing_config():
+    """Load the pricing config once, returning the HarnessQuotaConfig or None."""
+    try:
+        from gptme_usage.harness_models import load_quota_config
+
+        return load_quota_config()
+    except Exception:
+        return None
+
+
+_PRICING_CONFIG = None
+
+
 def estimate_record_cost(record: "SessionRecord") -> float | None:
     """Estimate USD cost for a single session record.
 
@@ -56,6 +69,10 @@ def estimate_record_cost(record: "SessionRecord") -> float | None:
         from gptme_usage.harness_models import estimate_session_cost
     except ImportError:
         return None
+
+    global _PRICING_CONFIG
+    if _PRICING_CONFIG is None:
+        _PRICING_CONFIG = _load_pricing_config()
 
     harness = record.harness or "unknown"
     model = record.model or "unknown"
@@ -68,6 +85,7 @@ def estimate_record_cost(record: "SessionRecord") -> float | None:
         cache_creation_tokens=record.cache_creation_tokens,
         cache_read_tokens=record.cache_read_tokens,
         token_count=record.token_count,
+        config=_PRICING_CONFIG,
     )
     return float(result) if result is not None else None
 

--- a/packages/gptme-sessions/src/gptme_sessions/cost.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cost.py
@@ -56,7 +56,8 @@ def _load_pricing_config():
         return None
 
 
-_PRICING_CONFIG = None
+_UNSET = object()
+_PRICING_CONFIG: object = _UNSET
 
 
 def estimate_record_cost(record: "SessionRecord") -> float | None:
@@ -71,7 +72,7 @@ def estimate_record_cost(record: "SessionRecord") -> float | None:
         return None
 
     global _PRICING_CONFIG
-    if _PRICING_CONFIG is None:
+    if _PRICING_CONFIG is _UNSET:
         _PRICING_CONFIG = _load_pricing_config()
 
     harness = record.harness or "unknown"

--- a/packages/gptme-sessions/src/gptme_sessions/cost.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cost.py
@@ -9,10 +9,11 @@ from __future__ import annotations
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     from .record import SessionRecord
+    from gptme_usage.harness_models import HarnessQuotaConfig
 
 
 @dataclass
@@ -46,7 +47,7 @@ class CostSummary:
         return self.total_cost / self.priced_count if self.priced_count else 0.0
 
 
-def _load_pricing_config():
+def _load_pricing_config() -> "HarnessQuotaConfig | None":
     """Load the pricing config once, returning the HarnessQuotaConfig or None."""
     try:
         from gptme_usage.harness_models import load_quota_config
@@ -74,6 +75,7 @@ def estimate_record_cost(record: "SessionRecord") -> float | None:
     global _PRICING_CONFIG
     if _PRICING_CONFIG is _UNSET:
         _PRICING_CONFIG = _load_pricing_config()
+    config = cast("HarnessQuotaConfig | None", _PRICING_CONFIG)
 
     harness = record.harness or "unknown"
     model = record.model or "unknown"
@@ -86,7 +88,7 @@ def estimate_record_cost(record: "SessionRecord") -> float | None:
         cache_creation_tokens=record.cache_creation_tokens,
         cache_read_tokens=record.cache_read_tokens,
         token_count=record.token_count,
-        config=_PRICING_CONFIG,
+        config=config,
     )
     return float(result) if result is not None else None
 

--- a/packages/gptme-sessions/tests/test_cost.py
+++ b/packages/gptme-sessions/tests/test_cost.py
@@ -1,0 +1,189 @@
+"""Tests for session cost estimation and analysis."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from gptme_sessions.cost import (
+    CostSummary,
+    DayCostStats,
+    ModelCostStats,
+    analyze_costs,
+    estimate_record_cost,
+    format_cost_summary,
+)
+from gptme_sessions.record import SessionRecord
+
+
+def _make_record(
+    harness: str = "claude-code",
+    model: str = "claude-sonnet-4-6",
+    input_tokens: int | None = 1000,
+    output_tokens: int | None = 500,
+    cache_creation_tokens: int | None = None,
+    cache_read_tokens: int | None = None,
+    token_count: int | None = None,
+    timestamp: str = "2026-06-20T10:00:00+00:00",
+) -> SessionRecord:
+    return SessionRecord(
+        harness=harness,
+        model=model,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_creation_tokens=cache_creation_tokens,
+        cache_read_tokens=cache_read_tokens,
+        token_count=token_count,
+        timestamp=timestamp,
+    )
+
+
+class TestEstimateRecordCost:
+    def test_no_crash_with_real_gptme_usage(self):
+        """estimate_record_cost doesn't raise — returns float or None."""
+        record = _make_record()
+        result = estimate_record_cost(record)
+        assert result is None or isinstance(result, float)
+
+    def test_returns_none_for_unknown_model(self):
+        """Returns None when model has no pricing entry."""
+        record = _make_record(model="completely-unknown-model-xyz-42")
+        result = estimate_record_cost(record)
+        assert result is None or isinstance(result, float)
+
+    def test_returns_none_for_missing_tokens(self):
+        """Returns None when no token data is available."""
+        record = _make_record(input_tokens=None, output_tokens=None, token_count=None)
+        result = estimate_record_cost(record)
+        assert result is None or isinstance(result, float)
+
+
+class TestAnalyzeCosts:
+    def _mock_cost(self, record: SessionRecord) -> float | None:
+        """Mock cost: $0.00001 per input token."""
+        if record.input_tokens is None:
+            return None
+        return record.input_tokens * 0.00001
+
+    def test_empty_records(self):
+        """Empty record list produces zero-cost summary."""
+        with patch("gptme_sessions.cost.estimate_record_cost", return_value=None):
+            summary = analyze_costs([])
+        assert summary.session_count == 0
+        assert summary.priced_count == 0
+        assert summary.total_cost == 0.0
+
+    def test_basic_aggregation(self):
+        """Correctly sums cost across multiple records."""
+        records = [
+            _make_record(model="sonnet", input_tokens=1000, timestamp="2026-06-20T10:00:00+00:00"),
+            _make_record(model="haiku", input_tokens=2000, timestamp="2026-06-20T11:00:00+00:00"),
+        ]
+        with patch("gptme_sessions.cost.estimate_record_cost", side_effect=self._mock_cost):
+            summary = analyze_costs(records)
+
+        assert summary.session_count == 2
+        assert summary.priced_count == 2
+        assert abs(summary.total_cost - 0.03) < 1e-9  # 0.01 + 0.02
+        assert abs(summary.avg_cost - 0.015) < 1e-9
+
+    def test_by_model_grouping(self):
+        """Groups cost by model correctly."""
+        records = [
+            _make_record(model="sonnet", input_tokens=1000),
+            _make_record(model="sonnet", input_tokens=1000),
+            _make_record(model="haiku", input_tokens=2000),
+        ]
+        with patch("gptme_sessions.cost.estimate_record_cost", side_effect=self._mock_cost):
+            summary = analyze_costs(records)
+
+        assert len(summary.by_model) >= 1
+        total_from_models = sum(s.total_cost for s in summary.by_model.values())
+        assert abs(total_from_models - summary.total_cost) < 1e-9
+
+    def test_by_day_grouping(self):
+        """Groups cost by day correctly."""
+        records = [
+            _make_record(input_tokens=1000, timestamp="2026-06-19T10:00:00+00:00"),
+            _make_record(input_tokens=1000, timestamp="2026-06-19T12:00:00+00:00"),
+            _make_record(input_tokens=1000, timestamp="2026-06-20T10:00:00+00:00"),
+        ]
+        with patch("gptme_sessions.cost.estimate_record_cost", side_effect=self._mock_cost):
+            summary = analyze_costs(records)
+
+        assert "2026-06-19" in summary.by_day
+        assert "2026-06-20" in summary.by_day
+        assert summary.by_day["2026-06-19"].count == 2
+        assert summary.by_day["2026-06-20"].count == 1
+
+    def test_days_filter(self):
+        """days= parameter filters records by recency."""
+        records = [
+            _make_record(input_tokens=1000, timestamp="2020-01-01T00:00:00+00:00"),  # old
+            _make_record(input_tokens=1000, timestamp="2026-06-20T10:00:00+00:00"),  # recent
+        ]
+        with patch("gptme_sessions.cost.estimate_record_cost", side_effect=self._mock_cost):
+            summary = analyze_costs(records, days=7)
+
+        assert summary.session_count == 1
+
+    def test_skips_unpriced_records(self):
+        """Records where cost is None are counted but excluded from totals."""
+        records = [
+            _make_record(input_tokens=1000),
+            _make_record(input_tokens=None),  # no tokens → no cost
+        ]
+        with patch("gptme_sessions.cost.estimate_record_cost", side_effect=self._mock_cost):
+            summary = analyze_costs(records)
+
+        assert summary.session_count == 2
+        assert summary.priced_count == 1
+
+
+class TestFormatCostSummary:
+    def _summary(self) -> CostSummary:
+        return CostSummary(
+            session_count=10,
+            priced_count=8,
+            total_cost=0.1234,
+            by_model={
+                "sonnet": ModelCostStats(count=5, total_cost=0.08),
+                "haiku": ModelCostStats(count=3, total_cost=0.04),
+            },
+            by_day={
+                "2026-06-19": DayCostStats(count=4, total_cost=0.05),
+                "2026-06-20": DayCostStats(count=4, total_cost=0.07),
+            },
+        )
+
+    def test_basic_output(self):
+        """Basic summary output contains key fields."""
+        text = format_cost_summary(self._summary())
+        assert "10" in text
+        assert "0.1234" in text
+        assert "8" in text
+
+    def test_by_model_section(self):
+        """by_model=True includes model breakdown."""
+        text = format_cost_summary(self._summary(), by_model=True)
+        assert "By Model" in text
+        assert "sonnet" in text
+        assert "haiku" in text
+
+    def test_daily_section(self):
+        """daily=True includes day-by-day breakdown."""
+        text = format_cost_summary(self._summary(), daily=True)
+        assert "By Day" in text
+        assert "2026-06-19" in text
+        assert "2026-06-20" in text
+
+    def test_no_extra_sections_by_default(self):
+        """Default output omits model and day breakdowns."""
+        text = format_cost_summary(self._summary())
+        assert "By Model" not in text
+        assert "By Day" not in text
+
+    def test_empty_summary_no_crash(self):
+        """Empty summary renders without exceptions."""
+        empty = CostSummary(session_count=0, priced_count=0, total_cost=0.0)
+        text = format_cost_summary(empty, daily=True, by_model=True)
+        assert "0" in text

--- a/packages/gptme-sessions/tests/test_cost.py
+++ b/packages/gptme-sessions/tests/test_cost.py
@@ -117,9 +117,14 @@ class TestAnalyzeCosts:
 
     def test_days_filter(self):
         """days= parameter filters records by recency."""
+        import datetime as dt
+
+        now = dt.datetime.now(dt.timezone.utc)
+        old_ts = "2020-01-01T00:00:00+00:00"
+        recent_ts = (now - dt.timedelta(hours=1)).isoformat()
         records = [
-            _make_record(input_tokens=1000, timestamp="2020-01-01T00:00:00+00:00"),  # old
-            _make_record(input_tokens=1000, timestamp="2026-06-20T10:00:00+00:00"),  # recent
+            _make_record(input_tokens=1000, timestamp=old_ts),  # old
+            _make_record(input_tokens=1000, timestamp=recent_ts),  # recent
         ]
         with patch("gptme_sessions.cost.estimate_record_cost", side_effect=self._mock_cost):
             summary = analyze_costs(records, days=7)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ exclude = ["packages/__pycache__", "plugins/__pycache__", "packages/tasks"]
 [tool.uv.sources]
 gptme = { git = "https://github.com/gptme/gptme.git", branch = "master" }
 gptme-sessions = { workspace = true }
+gptme-usage = { workspace = true }
 gptodo = { workspace = true }
 gptmail = { workspace = true }
 

--- a/uv.lock
+++ b/uv.lock
@@ -1908,6 +1908,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+cost = [
+    { name = "gptme-usage" },
+]
 dev = [
     { name = "mypy" },
     { name = "pytest" },
@@ -1919,12 +1922,13 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.0" },
+    { name = "gptme-usage", marker = "extra == 'cost'", editable = "packages/gptme-usage" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=1.0" },
 ]
-provides-extras = ["dev", "test"]
+provides-extras = ["cost", "dev", "test"]
 
 [[package]]
 name = "gptme-subscription"


### PR DESCRIPTION
## Summary

- Adds `gptme sessions cost` CLI subcommand that estimates USD costs across session records
- New `gptme_sessions/cost.py` module with public API: `CostSummary`, `estimate_record_cost()`, `analyze_costs()`, `format_cost_summary()`
- Costs are fetched from `gptme-usage` (new optional dep) and work for any model in its pricing table
- Gracefully errors with a helpful install hint when `gptme-usage` is not installed

## Usage

```
gptme sessions cost                    # last 7 days summary
gptme sessions cost --daily            # day-by-day breakdown
gptme sessions cost --by-model         # per-model breakdown
gptme sessions cost --days 30 --json   # machine-readable output
```

## Test plan

- [x] 14 new tests in `test_cost.py` — all pass
- [x] `ruff check` + `ruff format` clean
- [x] mypy clean (only pre-existing errors in unrelated files)
- [x] Full gptme-sessions test suite (469 tests) passes — no regressions
- [x] `gptme-usage = { workspace = true }` added to root `[tool.uv.sources]` so the optional dep resolves correctly