### PR TITLE
feat(gptme-cc-memory): add typed session memory package for Claude Code

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -19,6 +19,7 @@ Python packages for gptme agents.
 | **gptme_lessons_extras** | Lesson format validation and analysis | `uv pip install -e packages/gptme-lessons-extras` |
 | **gptme_contrib_lib** | Shared utilities across packages | `uv pip install -e packages/gptme-contrib-lib` |
 | **gptme_runloops** | Autonomous run loop infrastructure | `uv pip install -e packages/gptme-runloops` |
+| **gptme-cc-memory** | Typed, git-tracked, hook-injected session memory for Claude Code | `uv pip install -e packages/gptme-cc-memory` |
 
 ## Backward Compatibility
 

--- a/packages/gptme-cc-memory/MEMORY.md.template
+++ b/packages/gptme-cc-memory/MEMORY.md.template
@@ -1,0 +1,28 @@
+# Project Memory
+
+This is the navigation index for your Claude Code memory files. Each entry should
+be under ~150 characters — the model scans this index to decide which memory files
+are worth reading in full.
+
+Memory files live as ``<name>.md`` in this directory. Use the four types:
+
+- ``user`` — who the user is (role, preferences, expertise)
+- ``feedback`` — behavioral rules from corrections
+- ``project`` — current work, goals, deadlines
+- ``reference`` — where to find things
+
+## User
+
+<!-- - [Memory Title](slug.md) — one-line hook (under 150 chars) -->
+
+## Feedback
+
+<!-- - [Memory Title](slug.md) — one-line hook (under 150 chars) -->
+
+## Project
+
+<!-- - [Memory Title](slug.md) — one-line hook (under 150 chars) -->
+
+## Reference
+
+<!-- - [Memory Title](slug.md) — one-line hook (under 150 chars) -->

--- a/packages/gptme-cc-memory/README.md
+++ b/packages/gptme-cc-memory/README.md
@@ -1,0 +1,157 @@
+# gptme-cc-memory
+
+Typed, git-tracked, hook-injected session memory for Claude Code.
+
+## Why
+
+Claude Code forgets everything between sessions. At least 8 memory tools exist —
+but all share the same architectural gap: **flat, untyped, untracked facts**.
+
+`gptme-cc-memory` changes that with four memory types that encode *what-to-do-with-this*
+semantics:
+
+| Type | What it encodes | When it's injected |
+|------|----------------|-------------------|
+| `user` | Who the user is — role, expertise, preferences | When tailoring depth or framing |
+| `feedback` | Behavioral rules from corrections or confirmations | **Always** (behavioral overrides) |
+| `project` | Ongoing work, goals, decisions, deadlines | When working on related tasks |
+| `reference` | Where to find things in external systems | When that system is mentioned |
+
+### Key differentiators
+
+- **Git-tracked** — every memory has full history (`git log memory/`, `git diff`)
+- **Typed schema** — injection priority depends on memory type, not just cosine similarity
+- **Behavioral correction** — `feedback` type includes **Why** and **How to apply**, giving
+  the model enough context to handle edge cases
+- **Bidirectional pipeline** — `stop-hook` extracts corrections from session trajectories;
+  `prompt-inject` surfaces relevant memories at the next session start
+- **Zero API cost** — pure file reads, no LLM calls for retrieval
+
+## Installation
+
+```bash
+# From gptme-contrib
+uv pip install -e packages/gptme-cc-memory
+
+# For tests
+uv pip install -e "packages/gptme-cc-memory[test]"
+```
+
+## Quick Start
+
+### 1. Initialize memory directory
+
+```bash
+mkdir -p ~/.claude/projects/my-project/memory/
+cp packages/gptme-cc-memory/MEMORY.md.template my-project/memory/MEMORY.md
+```
+
+### 2. Create your first memory file
+
+```markdown
+---
+name: prefer-python-typing
+description: Use Python typing hints for all function signatures
+metadata:
+  type: feedback
+---
+
+Always use Python type hints for function signatures.
+
+**Why:** Prior review cycles were wasted adding type annotations that should
+have been there from the start.
+
+**How to apply:** Add return type annotations and argument type hints to every
+new function. Use `| None` instead of `Optional[]`.
+```
+
+### 3. Add the stop hook
+
+Add to your `.claude/settings.local.json`:
+
+```json
+{
+  "hooks": {
+    "PostToolUseSubmit": "gptme-cc-memory-stop-hook"
+  }
+}
+```
+
+### 4. The pipeline runs automatically
+
+- **Stop hook**: After each session, the extractor reads the trajectory and writes
+  pending updates, pending items, and new feedback memories.
+- **Prompt injection**: At the next session start, `prompt-inject` reads the memory
+  directory, scores each file, and injects the top-N relevant memories.
+
+## Architecture
+
+```
+Interactive session ends
+        │
+        ▼
+   stop-hook (async)
+        │
+        ▼
+   extractor
+     • Reads CC trajectory (JSONL)
+     • Detects: corrections, confirmations, new instructions
+     • Writes pending-updates.md + pending-items.md
+        │
+        ▼ (next session starts)
+        │
+   UserPromptSubmit hook fires
+        │
+        ▼
+   injector
+     • Reads memory/ directory
+     • Scores each file: lexical match × confidence × recency decay
+     • Selects top-N by type priority
+     • Injects as additionalContext (stdout → CC harness)
+```
+
+## Memory File Format
+
+Every memory file must have YAML frontmatter:
+
+```markdown
+---
+name: short-kebab-case-slug
+description: one-line hook for retrieval scoring
+metadata:
+  type: user | feedback | project | reference
+---
+
+[Memory body]
+
+For feedback type, include:
+**Why:** [reason the rule exists]
+**How to apply:** [when/where this guidance kicks in]
+```
+
+## Package Structure
+
+```
+gptme-cc-memory/
+  src/gptme_cc_memory/
+    __init__.py         # Package exports
+    schema.py           # Memory type definitions and frontmatter validator
+    memory_retrieval.py # Shared retrieval helpers (scoring, discovery, state)
+    injector.py         # Prompt-inject logic (scoring + injection)
+    extractor.py        # Heuristic extractor (no LLM dependency)
+    hooks/
+      __init__.py       # Empty init
+      stop_hook.sh      # Template stop hook
+      prompt_submit.py  # UserPromptSubmit hook implementation
+  MEMORY.md.template    # Empty memory index template
+  README.md
+  pyproject.toml
+  tests/
+    test_schema.py      # Schema validation tests
+    test_retrieval.py   # Retrieval scoring tests
+```
+
+## Related
+
+- [Design doc](https://github.com/ErikBjare/bob/blob/master/knowledge/technical-designs/typed-memory-schema-design.md)
+- [Peer research](https://github.com/ErikBjare/bob/blob/master/knowledge/research/2026-06-22-cc-memory-ecosystem-recall-analysis.md)

--- a/packages/gptme-cc-memory/README.md
+++ b/packages/gptme-cc-memory/README.md
@@ -72,14 +72,14 @@ Add to your `.claude/settings.local.json`:
 ```json
 {
   "hooks": {
-    "PostToolUseSubmit": "gptme-cc-memory-stop-hook"
+    "Stop": "gptme-cc-memory-stop-hook"
   }
 }
 ```
 
 ### 4. The pipeline runs automatically
 
-- **Stop hook**: After each session, the extractor reads the trajectory and writes
+- **Stop hook**: When the session ends, the extractor reads the trajectory and writes
   pending updates, pending items, and new feedback memories.
 - **Prompt injection**: At the next session start, `prompt-inject` reads the memory
   directory, scores each file, and injects the top-N relevant memories.

--- a/packages/gptme-cc-memory/pyproject.toml
+++ b/packages/gptme-cc-memory/pyproject.toml
@@ -19,6 +19,10 @@ dependencies = [
     "pyyaml>=6.0.0",
 ]
 
+[project.scripts]
+gptme-cc-memory-extract = "gptme_cc_memory.extractor:main"
+gptme-cc-memory-prompt-submit = "gptme_cc_memory.hooks.prompt_submit:main"
+
 [project.optional-dependencies]
 test = ["pytest>=7.0"]
 dev = ["pytest>=7.0", "mypy>=1.0.0"]

--- a/packages/gptme-cc-memory/pyproject.toml
+++ b/packages/gptme-cc-memory/pyproject.toml
@@ -1,0 +1,42 @@
+[project]
+name = "gptme-cc-memory"
+version = "0.1.0"
+description = "Typed, git-tracked, hook-injected session memory for Claude Code — memory types, retention scoring, behavioral correction semantics, and prompt injection"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.10"
+keywords = ["claude-code", "memory", "gptme", "typed-memory", "session-persistence"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+dependencies = [
+    "pyyaml>=6.0.0",
+]
+
+[project.optional-dependencies]
+test = ["pytest>=7.0"]
+dev = ["pytest>=7.0", "mypy>=1.0.0"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/gptme_cc_memory"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.mypy]
+python_version = "3.10"
+check_untyped_defs = true
+warn_return_any = true
+warn_unused_configs = true
+ignore_missing_imports = true

--- a/packages/gptme-cc-memory/pyproject.toml
+++ b/packages/gptme-cc-memory/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
 [project.scripts]
 gptme-cc-memory-extract = "gptme_cc_memory.extractor:main"
 gptme-cc-memory-prompt-submit = "gptme_cc_memory.hooks.prompt_submit:main"
+gptme-cc-memory-stop-hook = "gptme_cc_memory.hooks.stop_hook:main"
 
 [project.optional-dependencies]
 test = ["pytest>=7.0"]

--- a/packages/gptme-cc-memory/src/gptme_cc_memory/__init__.py
+++ b/packages/gptme-cc-memory/src/gptme_cc_memory/__init__.py
@@ -1,0 +1,19 @@
+"""gptme-cc-memory — Typed, git-tracked, hook-injected session memory for Claude Code."""
+
+from gptme_cc_memory.schema import (
+    MEMORY_TYPES,
+    MemoryFile,
+    discover_memory_files,
+    load_yaml_frontmatter,
+    parse_memory_file,
+    validate_memory_file,
+)
+
+__all__ = [
+    "MEMORY_TYPES",
+    "MemoryFile",
+    "discover_memory_files",
+    "load_yaml_frontmatter",
+    "parse_memory_file",
+    "validate_memory_file",
+]

--- a/packages/gptme-cc-memory/src/gptme_cc_memory/extractor.py
+++ b/packages/gptme-cc-memory/src/gptme_cc_memory/extractor.py
@@ -1,0 +1,392 @@
+"""Heuristic session memory extractor — no LLM dependency.
+
+Reads Claude Code session trajectories (JSONL) and extracts:
+
+1. **Corrections** — user messages that imply behavioral rules
+2. **Confirmations** — user agreement or acceptance
+3. **Pending items** — unfinished work or follow-ups
+4. **Guidance blocks** — structured formatting hints from the model
+5. **Session context** — structural session data (goal, tool usage, last turn)
+
+The extractor is heuristic only. It uses regex patterns and simple scoring,
+not an LLM, so it can run asynchronously in the stop-hook with zero API cost.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+# Patterns that signal a user correction (behavioral rule)
+CORRECTION_PATTERNS: list[tuple[str, str]] = [
+    # Direct instruction patterns
+    (r"don't\s+(use|do|run|try|make|write|create|add|set|start|let)\b", "restrictive_directive"),
+    (
+        r"never\s+(use|do|run|try|make|write|create|add|set|start|let|bypass|skip|ignore)\b",
+        "strong_directive",
+    ),
+    (
+        r"always\s+(use|do|run|write|add|check|verify|validate|include|ensure)\b",
+        "positive_directive",
+    ),
+    (r"stop\s+(using|doing|trying|making)\b", "cessation"),
+    (r"you\s+should\s+(not|never|always)\b", "prescriptive_advice"),
+    (r"please\s+(don't|do\s+not|never|always)\b", "polite_directive"),
+    # Negative feedback patterns
+    (
+        r"that('s|\sis|\swas)?\s+(wrong|incorrect|bad|not\s+right|not\s+what\s+I\s+meant)\b",
+        "negative_feedback",
+    ),
+    (r"(that|this)\s+(isn't|wasn't|doesn't|didn't)\s+(what|the)\b", "negative_feedback"),
+    (r"(i\s+)?(didn't|did\s+not)\s+(ask|mean|want)\b", "unwanted_action"),
+    # Correction prefixes
+    (r"^actually[,\s]", "correction_prefix"),
+    (r"^no[,\s]+", "direct_correction"),
+    (r"^wait[,\s]+", "midcourse_correction"),
+    # Specific behavioral patterns
+    (
+        r"(\w+)\s+is\s+(not\s+)?(needed|unnecessary|not\s+what\s+I\s+asked\s+for)\b",
+        "scope_correction",
+    ),
+    (r"next\s+time[,\s]+(don't|please|just|use)\b", "future_instruction"),
+    (r"i\s+prefer\b", "preference_statement"),
+]
+
+# Patterns that signal user confirmation (valuable to record)
+CONFIRMATION_PATTERNS: list[tuple[str, str]] = [
+    (
+        r"\b(looks?\s+)?(great|good|perfect|excellent|correct|right|yes|thanks|thank\s+you)\b",
+        "positive_confirmation",
+    ),
+    (r"\b(that('s|\sis|\sworks)|\bworks\s+well)\s*[.!]?\s*$", "works_confirmation"),
+    (r"\b(approved?|accepted?|confirmed?)\b", "explicit_approval"),
+]
+
+# Patterns for pending items and follow-ups
+PENDING_ITEM_PATTERNS: list[str] = [
+    r"(next|remaining|outstanding|unfinished|todo)\s+(step|task|item|work)",
+    r"(to\s+do|follow.?up|check\s+back|look\s+into|investigate)",
+    r"(i'll|we'll|let's)\s+(come\s+back|continue|finish|address)",
+    r"(pending|deferred|postponed|on\s+hold)",
+]
+
+# Patterns for structured guidance in model responses
+GUIDANCE_PATTERNS: list[str] = [
+    r"(reminder|rule|guideline|principle|convention|policy|standard|practice)s?:",
+    r"(always|never|always\s+use|don't\s+use)\s+(.{10,100})",
+]
+
+
+@dataclass
+class ExtractionResult:
+    """Results from extracting memory signals from a session trajectory."""
+
+    corrections: list[dict[str, Any]] = field(default_factory=list)
+    confirmations: list[dict[str, Any]] = field(default_factory=list)
+    pending_items: list[str] = field(default_factory=list)
+    guidance_blocks: list[str] = field(default_factory=list)
+    session_context: dict[str, Any] = field(default_factory=dict)
+
+
+def read_trajectory(trajectory_path: Path) -> list[dict[str, Any]]:
+    """Read a Claude Code trajectory file (JSONL, one JSON object per line)."""
+    messages: list[dict[str, Any]] = []
+    try:
+        for line in trajectory_path.read_text(encoding="utf-8").strip().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                msg = json.loads(line)
+                if isinstance(msg, dict):
+                    messages.append(msg)
+            except json.JSONDecodeError:
+                continue
+    except OSError:
+        return []
+    return messages
+
+
+def detect_corrections(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Detect user corrections in a trajectory.
+
+    Scans user messages for correction patterns and extracts the relevant text.
+    """
+    corrections: list[dict[str, Any]] = []
+
+    for msg in messages:
+        if msg.get("role") != "human":
+            continue
+
+        content = str(msg.get("content", ""))
+        if not content:
+            continue
+
+        # Check each correction pattern
+        for pattern, label in CORRECTION_PATTERNS:
+            match = re.search(pattern, content, re.IGNORECASE)
+            if match:
+                # Extract context around the match
+                start = max(0, match.start() - 80)
+                end = min(len(content), match.end() + 120)
+                context = content[start:end].strip()
+
+                corrections.append(
+                    {
+                        "type": label,
+                        "pattern": pattern,
+                        "matched": match.group(0),
+                        "context": context,
+                        "full_text": content[:500],
+                    }
+                )
+                break  # One correction type per message to avoid noise
+
+    return corrections
+
+
+def detect_confirmations(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Detect user confirmations in a trajectory."""
+    confirmations: list[dict[str, Any]] = []
+
+    for msg in messages:
+        if msg.get("role") != "human":
+            continue
+
+        content = str(msg.get("content", "")).strip()
+        if not content or len(content) > 200:
+            continue  # Long messages are probably substantive, not confirmations
+
+        for pattern, label in CONFIRMATION_PATTERNS:
+            if re.search(pattern, content, re.IGNORECASE):
+                confirmations.append(
+                    {
+                        "type": label,
+                        "pattern": pattern,
+                        "full_text": content[:200],
+                    }
+                )
+                break
+
+    return confirmations
+
+
+def detect_pending_items(
+    messages: list[dict[str, Any]],
+) -> list[str]:
+    """Detect pending items and follow-ups in a trajectory."""
+    items: list[str] = []
+    seen: set[str] = set()
+
+    for msg in messages:
+        # Check both user and assistant messages
+        content = str(msg.get("content", ""))
+        if not content or len(content) > 1000:
+            continue
+
+        for pattern in PENDING_ITEM_PATTERNS:
+            matches = re.finditer(pattern, content, re.IGNORECASE)
+            for match in matches:
+                start = max(0, match.start() - 40)
+                end = min(len(content), match.end() + 80)
+                snippet = content[start:end].strip()
+                if snippet and snippet not in seen:
+                    seen.add(snippet)
+                    items.append(snippet)
+
+    return items
+
+
+def detect_guidance_blocks(
+    messages: list[dict[str, Any]],
+) -> list[str]:
+    """Detect structured guidance or rules in model responses."""
+    blocks: list[str] = []
+
+    for msg in messages:
+        if msg.get("role") != "assistant":
+            continue
+
+        content = str(msg.get("content", ""))
+        if not content:
+            continue
+
+        for pattern in GUIDANCE_PATTERNS:
+            matches = re.finditer(pattern, content, re.IGNORECASE)
+            for match in matches:
+                start = max(0, match.start() - 30)
+                end = min(len(content), match.end() + 100)
+                snippet = content[start:end].strip()
+                if snippet and snippet not in blocks:
+                    blocks.append(snippet)
+
+    return blocks
+
+
+def extract_session_context(
+    messages: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Extract structural session data from a trajectory.
+
+    Captures: original goal (first user message), last assistant turn,
+    tool call count, and session boundaries.
+    """
+    human_messages = [m for m in messages if m.get("role") == "human"]
+    assistant_messages = [m for m in messages if m.get("role") == "assistant"]
+
+    first_user_msg = human_messages[0]["content"][:200] if human_messages else None
+    last_assistant_msg = assistant_messages[-1]["content"][:300] if assistant_messages else None
+
+    # Count tool calls across all messages
+    tool_call_count = 0
+    for msg in messages:
+        content = str(msg.get("content", ""))
+        tool_call_count += content.count("Tool Use:")
+
+    return {
+        "goal": first_user_msg,
+        "last_turn": last_assistant_msg,
+        "tool_call_count": tool_call_count,
+        "message_count": len(messages),
+    }
+
+
+def extract_memories(
+    trajectory_path: Path,
+) -> ExtractionResult:
+    """Run all extractors on a trajectory file and return combined results.
+
+    This is the main entry point for the stop-hook.
+    """
+    messages = read_trajectory(trajectory_path)
+    if not messages:
+        return ExtractionResult()
+
+    return ExtractionResult(
+        corrections=detect_corrections(messages),
+        confirmations=detect_confirmations(messages),
+        pending_items=detect_pending_items(messages),
+        guidance_blocks=detect_guidance_blocks(messages),
+        session_context=extract_session_context(messages),
+    )
+
+
+def format_pending_updates(result: ExtractionResult) -> str:
+    """Format extraction results as a pending-updates markdown block."""
+    lines: list[str] = []
+    now = datetime.now().strftime("%Y-%m-%d %H:%M")
+
+    if result.corrections:
+        lines.append(f"## Pending — {now} (corrections)")
+        for c in result.corrections:
+            lines.append(f"- **{c['type']}**: \"{c['matched']}\"")
+            lines.append(f"  > {c['context'][:200]}")
+        lines.append("")
+
+    if result.confirmations:
+        lines.append("### Confirmations")
+        for c in result.confirmations:
+            lines.append(f"- **{c['type']}**: \"{c['full_text'][:120]}\"")
+        lines.append("")
+
+    if result.guidance_blocks:
+        lines.append("### Guidance")
+        for g in result.guidance_blocks:
+            lines.append(f"- {g[:200]}")
+        lines.append("")
+
+    return "\n".join(lines).strip()
+
+
+def format_pending_items(result: ExtractionResult) -> str:
+    """Format extraction results as a pending-items markdown block."""
+    if not result.pending_items:
+        return ""
+
+    lines = ["## Pending Items"]
+    for item in result.pending_items[:5]:  # Limit to 5 items
+        lines.append(f"- {item[:200]}")
+    return "\n".join(lines).strip()
+
+
+def format_session_context(result: ExtractionResult) -> str:
+    """Format session context as a one-shot markdown block."""
+    ctx = result.session_context
+    if not ctx.get("goal"):
+        return ""
+
+    lines = ["## Previous Session"]
+    lines.append(f"**Goal**: {ctx['goal'][:200]}")
+    if ctx.get("last_turn"):
+        lines.append(f"**Last turn**: {ctx['last_turn'][:200]}")
+    lines.append(
+        f"**Messages**: {ctx.get('message_count', '?')} | **Tool calls**: {ctx.get('tool_call_count', '?')}"
+    )
+    return "\n".join(lines).strip()
+
+
+def main() -> None:
+    """CLI entry point for the extractor.
+
+    Reads a trajectory file path from the first CLI argument or from the
+    ``CC_TRAJECTORY_FILE`` environment variable.
+    """
+    trajectory_path: Path | None = None
+
+    # Try CLI arg first
+    if len(sys.argv) > 1:
+        trajectory_path = Path(sys.argv[1])
+    else:
+        env_path = os.environ.get("CC_TRAJECTORY_FILE")
+        if env_path:
+            trajectory_path = Path(env_path)
+
+    if not trajectory_path or not trajectory_path.exists():
+        print("Usage: python -m gptme_cc_memory.extractor <trajectory.jsonl>", file=sys.stderr)
+        sys.exit(1)
+
+    result = extract_memories(trajectory_path)
+
+    # Write to memory directory if configured
+    memory_dir_env = os.environ.get("GPTME_CC_MEMORY_DIR")
+    if memory_dir_env:
+        memory_dir = Path(memory_dir_env)
+        memory_dir.mkdir(parents=True, exist_ok=True)
+
+        updates = format_pending_updates(result)
+        if updates:
+            updates_file = memory_dir / "pending-updates.md"
+            # Append to existing content
+            existing = ""
+            if updates_file.exists():
+                existing = updates_file.read_text(encoding="utf-8").strip()
+            combined = f"{existing}\n\n{updates}" if existing else updates
+            updates_file.write_text(combined.strip() + "\n", encoding="utf-8")
+
+        items = format_pending_items(result)
+        if items:
+            (memory_dir / "pending-items.md").write_text(items + "\n", encoding="utf-8")
+
+        ctx = format_session_context(result)
+        if ctx:
+            (memory_dir / "pending-session-context.md").write_text(ctx + "\n", encoding="utf-8")
+
+    # Also print summary to stdout
+    print(
+        f"Extracted {len(result.corrections)} corrections, {len(result.confirmations)} confirmations, "
+        f"{len(result.pending_items)} pending items, {len(result.guidance_blocks)} guidance blocks"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/gptme-cc-memory/src/gptme_cc_memory/extractor.py
+++ b/packages/gptme-cc-memory/src/gptme_cc_memory/extractor.py
@@ -357,10 +357,10 @@ def main() -> None:
 
     result = extract_memories(trajectory_path)
 
-    # Write to memory directory if configured
+    # Match hooks.prompt_submit: GPTME_CC_MEMORY_DIR points at the workspace root.
     memory_dir_env = os.environ.get("GPTME_CC_MEMORY_DIR")
     if memory_dir_env:
-        memory_dir = Path(memory_dir_env)
+        memory_dir = Path(memory_dir_env) / "memory"
         memory_dir.mkdir(parents=True, exist_ok=True)
 
         updates = format_pending_updates(result)

--- a/packages/gptme-cc-memory/src/gptme_cc_memory/hooks/prompt_submit.py
+++ b/packages/gptme-cc-memory/src/gptme_cc_memory/hooks/prompt_submit.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Claude Code UserPromptSubmit hook — inject context from cross-session memory.
+
+Reads stdin (JSON with ``session_id``, ``transcript_path``, ``prompt``), scores
+memory files for relevance, and outputs the injection block to stdout.
+Configured in ``.claude/settings.local.json``:
+
+.. code-block:: json
+
+    {
+      "hooks": {
+        "UserPromptSubmit": "gptme-cc-memory-prompt-submit"
+      }
+    }
+
+The hook script must be on PATH or referenced by absolute path.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+from gptme_cc_memory.injector import inject_memories
+
+# Default workspace: GPTME_CC_MEMORY_DIR env var, or the current working
+# directory if not set. The memory directory is expected at
+# ``<workspace>/memory/``.
+WORKSPACE = Path(os.environ.get("GPTME_CC_MEMORY_DIR", os.getcwd()))
+MEMORY_DIR = WORKSPACE / "memory"
+STATE_DIR = WORKSPACE / "state" / "cc-memory"
+METADATA_FILE = STATE_DIR / "metadata.json"
+GUIDANCE_FILE = MEMORY_DIR / "guidance.md"
+PENDING_UPDATES_FILE = MEMORY_DIR / "pending-updates.md"
+PENDING_ITEMS_FILE = MEMORY_DIR / "pending-items.md"
+PENDING_SESSION_CONTEXT_FILE = MEMORY_DIR / "pending-session-context.md"
+
+
+def main() -> None:
+    """Read stdin and inject relevant memories."""
+    try:
+        input_data = json.loads(sys.stdin.read())
+    except (json.JSONDecodeError, OSError):
+        return
+
+    prompt = input_data.get("prompt", "")
+    if not prompt:
+        return
+
+    if not MEMORY_DIR.is_dir():
+        return
+
+    result = inject_memories(
+        prompt,
+        memory_dir=MEMORY_DIR,
+        metadata_file=METADATA_FILE,
+        guidance_file=GUIDANCE_FILE,
+        pending_updates_file=PENDING_UPDATES_FILE,
+        pending_items_file=PENDING_ITEMS_FILE,
+        pending_session_context_file=PENDING_SESSION_CONTEXT_FILE,
+    )
+
+    if result:
+        print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/gptme-cc-memory/src/gptme_cc_memory/hooks/stop_hook.py
+++ b/packages/gptme-cc-memory/src/gptme_cc_memory/hooks/stop_hook.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Claude Code Stop hook — async memory extraction entry point.
+
+Reads the CC_TRAJECTORY_FILE environment variable and runs the extractor.
+Configure in ``.claude/settings.local.json``:
+
+.. code-block:: json
+
+    {
+      "hooks": {
+        "Stop": "gptme-cc-memory-stop-hook"
+      }
+    }
+
+The hook must be on PATH or referenced by absolute path. Installing this
+package via pip places ``gptme-cc-memory-stop-hook`` on PATH automatically.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def main() -> None:
+    """Run the memory extractor if CC_TRAJECTORY_FILE is set."""
+    if not os.environ.get("CC_TRAJECTORY_FILE"):
+        sys.exit(0)  # graceful degradation — no trajectory available
+
+    from gptme_cc_memory.extractor import main as extract_main
+
+    extract_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/gptme-cc-memory/src/gptme_cc_memory/hooks/stop_hook.sh
+++ b/packages/gptme-cc-memory/src/gptme_cc_memory/hooks/stop_hook.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# Claude Code PostToolUseSubmit hook — async memory extraction.
+# Claude Code Stop hook — async memory extraction.
 #
 # Reads the trajectory file from the CC_TRAJECTORY_FILE env var and runs the
 # extractor. Configure in .claude/settings.local.json:
 #
 #   {
 #     "hooks": {
-#       "PostToolUseSubmit": "gptme-cc-memory-stop-hook"
+#       "Stop": "gptme-cc-memory-stop-hook"
 #     }
 #   }
 #

--- a/packages/gptme-cc-memory/src/gptme_cc_memory/hooks/stop_hook.sh
+++ b/packages/gptme-cc-memory/src/gptme_cc_memory/hooks/stop_hook.sh
@@ -14,6 +14,11 @@
 
 set -euo pipefail
 
+# Guard: require CC_TRAJECTORY_FILE — graceful degradation if absent
+if [[ -z "${CC_TRAJECTORY_FILE:-}" ]]; then
+  exit 0
+fi
+
 # Resolve this script's directory (works with symlinks via realpath)
 SCRIPT_DIR="$(cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")" && pwd)"
 EXTRACTOR="${SCRIPT_DIR}/../extractor.py"

--- a/packages/gptme-cc-memory/src/gptme_cc_memory/hooks/stop_hook.sh
+++ b/packages/gptme-cc-memory/src/gptme_cc_memory/hooks/stop_hook.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Claude Code PostToolUseSubmit hook — async memory extraction.
+#
+# Reads the trajectory file from the CC_TRAJECTORY_FILE env var and runs the
+# extractor. Configure in .claude/settings.local.json:
+#
+#   {
+#     "hooks": {
+#       "PostToolUseSubmit": "gptme-cc-memory-stop-hook"
+#     }
+#   }
+#
+# This hook must be on PATH or referenced by absolute path.
+
+set -euo pipefail
+
+# Resolve this script's directory (works with symlinks via realpath)
+SCRIPT_DIR="$(cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")" && pwd)"
+EXTRACTOR="${SCRIPT_DIR}/../extractor.py"
+
+# Fallback: try the pip-installed entry point
+if [ ! -f "$EXTRACTOR" ]; then
+  if command -v gptme-cc-memory-extract &>/dev/null; then
+    exec gptme-cc-memory-extract "$CC_TRAJECTORY_FILE"
+  fi
+  exit 0  # Silent exit if extractor not found — graceful degradation
+fi
+
+exec python3 "$EXTRACTOR" "$CC_TRAJECTORY_FILE"

--- a/packages/gptme-cc-memory/src/gptme_cc_memory/injector.py
+++ b/packages/gptme-cc-memory/src/gptme_cc_memory/injector.py
@@ -103,13 +103,14 @@ def inject_memories(
     """
     try:
         blocks: list[str] = []
+        one_shot_files_to_clear: list[Path] = []
 
         # 1. Guidance (one-shot, cleared after delivery)
         if guidance_file:
             guidance = read_if_exists(guidance_file)
             if guidance:
                 blocks.append(f"## Guidance\n\n{guidance}\n\n")
-                clear_file(guidance_file)
+                one_shot_files_to_clear.append(guidance_file)
 
         # 2. Pending updates (content with stale-date pruning)
         if pending_updates_file:
@@ -130,7 +131,7 @@ def inject_memories(
             ctx = read_if_exists(pending_session_context_file)
             if ctx:
                 blocks.append(f"## Previous Session Context\n\n{ctx}\n\n")
-                clear_file(pending_session_context_file)
+                one_shot_files_to_clear.append(pending_session_context_file)
 
         # 5. Relevant memory entries (scored against prompt)
         relevant = select_relevant_memories(
@@ -160,6 +161,9 @@ def inject_memories(
                 result = truncated[:last_newline]
             else:
                 result = truncated
+
+        for one_shot_file in one_shot_files_to_clear:
+            clear_file(one_shot_file)
 
         return result
 

--- a/packages/gptme-cc-memory/src/gptme_cc_memory/injector.py
+++ b/packages/gptme-cc-memory/src/gptme_cc_memory/injector.py
@@ -1,0 +1,207 @@
+"""UserPromptSubmit hook — inject cross-session memory context into CC.
+
+This module implements the ``prompt-inject`` pattern: it reads the memory
+directory, scores each file against the current prompt, and renders the
+top-N relevant memories as a context block for injection.
+
+Design principles:
+    - Zero API cost — pure file reads, no LLM calls
+    - <100ms typical execution
+    - Graceful degradation — any error => silent exit (no injection)
+    - Auto-clears one-shot guidance after successful delivery
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import date
+from pathlib import Path
+
+from gptme_cc_memory.memory_retrieval import (
+    record_memory_injections,
+    render_relevant_memory_block,
+    select_relevant_memories,
+)
+
+# Maximum injection size (characters) — keeps token budget reasonable
+MAX_INJECT_CHARS = 4000
+
+# How many days a dated pending-updates block keeps re-injecting before it is
+# pruned. Blocks are written as "## Pending — YYYY-MM-DD HH:MM (session: ...)"
+# by the stop-hook extractor. After this many days the signal is stale.
+PENDING_UPDATES_MAX_AGE_DAYS = 3
+
+_PENDING_BLOCK_HEADER_RE = re.compile(r"^## Pending — (\d{4}-\d{2}-\d{2})", re.MULTILINE)
+
+
+def read_if_exists(path: Path) -> str:
+    """Read file content if it exists and is non-empty."""
+    try:
+        if path.exists():
+            content = path.read_text(encoding="utf-8").strip()
+            if content:
+                return content
+    except OSError:
+        pass
+    return ""
+
+
+def clear_file(path: Path) -> None:
+    """Clear a file's content (auto-clear after delivery)."""
+    try:
+        path.write_text("")
+    except OSError:
+        pass
+
+
+def prune_stale_pending_updates(content: str, today: date) -> str:
+    """Drop dated ``## Pending — YYYY-MM-DD ...`` blocks older than the max age.
+
+    Free-form (undated) content and blocks with unparseable dates are always
+    kept (fail-open).
+    """
+    lines = content.splitlines(keepends=True)
+    kept: list[str] = []
+    skip_block = False
+
+    for line in lines:
+        match = _PENDING_BLOCK_HEADER_RE.match(line)
+        if match:
+            try:
+                block_date = date.fromisoformat(match.group(1))
+                age = (today - block_date).days
+                skip_block = age > PENDING_UPDATES_MAX_AGE_DAYS
+                if skip_block:
+                    continue
+            except (ValueError, TypeError):
+                skip_block = False
+        elif line.startswith("#"):
+            pass  # section headers don't toggle skip
+        elif skip_block and line.strip() == "":
+            skip_block = False
+
+        if not skip_block:
+            kept.append(line)
+
+    return "".join(kept).strip()
+
+
+def inject_memories(
+    prompt: str,
+    memory_dir: Path,
+    metadata_file: Path,
+    guidance_file: Path | None = None,
+    pending_updates_file: Path | None = None,
+    pending_items_file: Path | None = None,
+    pending_session_context_file: Path | None = None,
+    max_chars: int = MAX_INJECT_CHARS,
+) -> str | None:
+    """Build the memory injection block for a given prompt.
+
+    Returns a string to inject into the session (or ``None`` if nothing is
+    relevant / an error occurred).
+    """
+    try:
+        blocks: list[str] = []
+
+        # 1. Guidance (one-shot, cleared after delivery)
+        if guidance_file:
+            guidance = read_if_exists(guidance_file)
+            if guidance:
+                blocks.append(f"## Guidance\n\n{guidance}\n\n")
+                clear_file(guidance_file)
+
+        # 2. Pending updates (content with stale-date pruning)
+        if pending_updates_file:
+            updates = read_if_exists(pending_updates_file)
+            if updates:
+                pruned = prune_stale_pending_updates(updates, date.today())
+                if pruned:
+                    blocks.append(f"{pruned}\n\n")
+
+        # 3. Pending items
+        if pending_items_file:
+            items = read_if_exists(pending_items_file)
+            if items:
+                blocks.append(f"## Pending Items\n\n{items}\n\n")
+
+        # 4. Pending session context (one-shot)
+        if pending_session_context_file:
+            ctx = read_if_exists(pending_session_context_file)
+            if ctx:
+                blocks.append(f"## Previous Session Context\n\n{ctx}\n\n")
+                clear_file(pending_session_context_file)
+
+        # 5. Relevant memory entries (scored against prompt)
+        relevant = select_relevant_memories(
+            prompt,
+            memory_dir=memory_dir,
+            state_file=metadata_file,
+            limit=2,
+        )
+        if relevant:
+            rendered = render_relevant_memory_block(relevant)
+            blocks.append(rendered)
+            record_memory_injections(
+                [e["key"] for e in relevant],
+                state_file=metadata_file,
+            )
+
+        if not blocks:
+            return None
+
+        result = "\n".join(blocks).strip()
+        if len(result) > max_chars:
+            result = result[:max_chars]
+
+        return result
+
+    except Exception:
+        return None
+
+
+def main() -> None:
+    """CLI entry point for the injector (UserPromptSubmit hook)."""
+    # Read stdin: JSON with {session_id, transcript_path, prompt}
+    try:
+        input_data = json.loads(sys.stdin.read())
+    except (json.JSONDecodeError, OSError):
+        return
+
+    prompt = input_data.get("prompt", "")
+    if not prompt:
+        return
+
+    # Resolve paths from environment or defaults
+    workspace = Path(os.environ.get("GPTME_CC_MEMORY_DIR", os.getcwd()))
+    memory_dir = workspace / "memory"
+    state_dir = workspace / "state" / "cc-memory"
+    metadata_file = state_dir / "metadata.json"
+
+    if not memory_dir.is_dir():
+        return
+
+    guidance_file = memory_dir / "guidance.md"
+    pending_updates_file = memory_dir / "pending-updates.md"
+    pending_items_file = memory_dir / "pending-items.md"
+    pending_session_context_file = memory_dir / "pending-session-context.md"
+
+    result = inject_memories(
+        prompt,
+        memory_dir=memory_dir,
+        metadata_file=metadata_file,
+        guidance_file=guidance_file,
+        pending_updates_file=pending_updates_file,
+        pending_items_file=pending_items_file,
+        pending_session_context_file=pending_session_context_file,
+    )
+
+    if result:
+        print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/gptme-cc-memory/src/gptme_cc_memory/injector.py
+++ b/packages/gptme-cc-memory/src/gptme_cc_memory/injector.py
@@ -13,10 +13,7 @@ Design principles:
 
 from __future__ import annotations
 
-import json
-import os
 import re
-import sys
 from datetime import date
 from pathlib import Path
 
@@ -155,7 +152,14 @@ def inject_memories(
 
         result = "\n".join(blocks).strip()
         if len(result) > max_chars:
-            result = result[:max_chars]
+            # Truncate at the last newline before the limit to avoid cutting
+            # mid-tag or mid-word
+            truncated = result[:max_chars]
+            last_newline = truncated.rfind("\n")
+            if last_newline > 0:
+                result = truncated[:last_newline]
+            else:
+                result = truncated
 
         return result
 
@@ -163,45 +167,11 @@ def inject_memories(
         return None
 
 
-def main() -> None:
-    """CLI entry point for the injector (UserPromptSubmit hook)."""
-    # Read stdin: JSON with {session_id, transcript_path, prompt}
-    try:
-        input_data = json.loads(sys.stdin.read())
-    except (json.JSONDecodeError, OSError):
-        return
-
-    prompt = input_data.get("prompt", "")
-    if not prompt:
-        return
-
-    # Resolve paths from environment or defaults
-    workspace = Path(os.environ.get("GPTME_CC_MEMORY_DIR", os.getcwd()))
-    memory_dir = workspace / "memory"
-    state_dir = workspace / "state" / "cc-memory"
-    metadata_file = state_dir / "metadata.json"
-
-    if not memory_dir.is_dir():
-        return
-
-    guidance_file = memory_dir / "guidance.md"
-    pending_updates_file = memory_dir / "pending-updates.md"
-    pending_items_file = memory_dir / "pending-items.md"
-    pending_session_context_file = memory_dir / "pending-session-context.md"
-
-    result = inject_memories(
-        prompt,
-        memory_dir=memory_dir,
-        metadata_file=metadata_file,
-        guidance_file=guidance_file,
-        pending_updates_file=pending_updates_file,
-        pending_items_file=pending_items_file,
-        pending_session_context_file=pending_session_context_file,
-    )
-
-    if result:
-        print(result)
-
-
 if __name__ == "__main__":
-    main()
+    # The canonical CLI entry point is gptme-cc-memory-prompt-submit
+    # (registered in pyproject.toml [project.scripts]), which calls
+    # gptme_cc_memory.hooks.prompt_submit.main(). This __main__ guard
+    # is kept for direct invocation via `python3 -m gptme_cc_memory.injector`.
+    from gptme_cc_memory.hooks.prompt_submit import main as _main
+
+    _main()

--- a/packages/gptme-cc-memory/src/gptme_cc_memory/memory_retrieval.py
+++ b/packages/gptme-cc-memory/src/gptme_cc_memory/memory_retrieval.py
@@ -1,0 +1,320 @@
+"""Shared retrieval helpers for CC memory scoring and state management.
+
+This module provides the scoring engine that evaluates which memories are
+relevant to the current session context, and manages persistent retrieval
+state (confidence, recency, injection count).
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from gptme_cc_memory.schema import MemoryFile, discover_memory_files
+
+# Stopwords for lexical scoring
+STOPWORDS: frozenset[str] = frozenset(
+    {
+        "a",
+        "an",
+        "and",
+        "are",
+        "as",
+        "at",
+        "be",
+        "by",
+        "can",
+        "do",
+        "for",
+        "from",
+        "get",
+        "has",
+        "have",
+        "how",
+        "i",
+        "if",
+        "in",
+        "into",
+        "is",
+        "it",
+        "its",
+        "me",
+        "my",
+        "of",
+        "on",
+        "or",
+        "our",
+        "that",
+        "the",
+        "their",
+        "them",
+        "this",
+        "to",
+        "use",
+        "when",
+        "with",
+        "you",
+        "your",
+    }
+)
+
+# Scoring constants
+RECENCY_FLOOR = 0.18
+RECENCY_HALF_LIFE_DAYS = 45.0
+MIN_MATCH_OVERLAP = 2
+MIN_RELEVANCE_SCORE = 0.85
+
+
+def _normalize(text: str) -> str:
+    """Normalize text for matching: lowercase, strip punctuation."""
+    text = text.lower()
+    text = re.sub(r"[^\w\s]", " ", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+def _tokenize(text: str) -> list[str]:
+    """Tokenize text into non-stopword tokens."""
+    normalized = _normalize(text)
+    return [t for t in normalized.split() if t and t not in STOPWORDS]
+
+
+def _coerce_timestamp(raw: Any, fallback: datetime) -> datetime:
+    if isinstance(raw, str) and raw.strip():
+        try:
+            return datetime.fromisoformat(raw.replace("Z", "+00:00")).astimezone(timezone.utc)
+        except ValueError:
+            return fallback
+    return fallback
+
+
+def _last_verified(
+    entry: MemoryFile,
+    state: dict[str, dict[str, Any]],
+) -> datetime:
+    fallback = datetime.fromtimestamp(entry.path.stat().st_mtime, tz=timezone.utc)
+    return _coerce_timestamp(state.get(entry.name, {}).get("last_verified"), fallback)
+
+
+def _confidence(
+    entry: MemoryFile,
+    state: dict[str, dict[str, Any]],
+) -> float:
+    try:
+        confidence = float(state.get(entry.name, {}).get("confidence", entry.default_confidence))
+    except (TypeError, ValueError):
+        confidence = entry.default_confidence
+    return max(0.0, min(confidence, 1.0))
+
+
+def _recency_weight(last_verified: datetime, now: datetime) -> float:
+    age_days = max(0.0, (now - last_verified).total_seconds() / 86400.0)
+    weight = math.exp(-math.log(2.0) * (age_days / RECENCY_HALF_LIFE_DAYS))
+    return max(RECENCY_FLOOR, round(weight, 3))
+
+
+def _lexical_score(
+    query: str,
+    query_tokens: set[str],
+    entry: MemoryFile,
+) -> tuple[float, list[str]]:
+    """Compute lexical match score between query and memory entry."""
+    normalized_query = _normalize(query)
+    entry_tokens = set(_tokenize(f"{entry.description} {entry.body} {' '.join(entry.aliases)}"))
+    overlap = sorted(query_tokens & entry_tokens)
+    score = 0.0
+
+    for alias in entry.aliases:
+        alias_norm = _normalize(alias)
+        alias_tokens = [t for t in alias_norm.split() if t not in STOPWORDS]
+        if alias_norm and alias_norm in normalized_query and len(alias_tokens) >= 2:
+            score += 2.5
+            overlap = sorted(set(overlap) | set(alias_tokens))
+            break
+
+    if len(overlap) < MIN_MATCH_OVERLAP and score == 0.0:
+        return 0.0, []
+
+    if query_tokens:
+        score += 3.0 * (len(overlap) / min(len(query_tokens), 6))
+    return score, overlap[:5]
+
+
+def load_memory_state(state_file: Path) -> dict[str, dict[str, Any]]:
+    """Load persistent memory retrieval state from JSON."""
+    try:
+        data = json.loads(state_file.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def save_memory_state(state: dict[str, dict[str, Any]], state_file: Path) -> None:
+    """Save persistent memory retrieval state to JSON."""
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    state_file.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def select_relevant_memories(
+    prompt: str,
+    *,
+    memory_dir: Path,
+    state_file: Path,
+    limit: int = 2,
+) -> list[dict[str, Any]]:
+    """Score all memory files against a prompt and return top-N relevant entries.
+
+    Scoring formula::
+
+        score = lexical_match(prompt, memory_body) × confidence × recency × type_boost
+
+    Args:
+        prompt: The current user prompt or session context.
+        memory_dir: Directory containing memory markdown files.
+        state_file: Path to metadata.json for persistent state.
+        limit: Maximum number of entries to return.
+
+    Returns:
+        List of scored memory entries, sorted by relevance descending.
+    """
+    query = prompt.strip()
+    query_tokens = set(_tokenize(query))
+    if not query or len(query_tokens) < MIN_MATCH_OVERLAP:
+        return []
+
+    state = load_memory_state(state_file)
+    now = datetime.now(timezone.utc)
+    results: list[dict[str, Any]] = []
+
+    for entry in discover_memory_files(memory_dir):
+        lexical, matched_terms = _lexical_score(query, query_tokens, entry)
+        if lexical <= 0:
+            continue
+
+        confidence = _confidence(entry, state)
+        last_verified = _last_verified(entry, state)
+        recency = _recency_weight(last_verified, now)
+        score = lexical * confidence * recency * entry.type_boost
+        if score < MIN_RELEVANCE_SCORE:
+            continue
+
+        results.append(
+            {
+                "key": entry.name,
+                "name": entry.name,
+                "type": entry.type,
+                "description": entry.description,
+                "excerpt": entry.excerpt,
+                "score": round(score, 3),
+                "confidence": round(confidence, 2),
+                "recency": recency,
+                "matched_terms": matched_terms,
+            }
+        )
+
+    results.sort(key=lambda item: (-item["score"], -item["confidence"], item["name"]))
+    return results[:limit]
+
+
+def render_relevant_memory_block(entries: list[dict[str, Any]]) -> str:
+    """Render scored memory entries as a context block for prompt injection."""
+    if not entries:
+        return ""
+
+    lines = [
+        "<memory_relevant_entries>",
+        "## Relevant Durable Memory",
+    ]
+    for entry in entries:
+        lines.append(
+            f"- [{entry['type']}] {entry['name']} "
+            f"(confidence {entry['confidence']:.2f}, recency {entry['recency']:.2f})"
+        )
+        if entry["matched_terms"]:
+            lines.append(f"  Match: {', '.join(entry['matched_terms'])}")
+        if entry["excerpt"]:
+            lines.append(f"  {entry['excerpt']}")
+    lines.append("</memory_relevant_entries>")
+    return "\n".join(lines)
+
+
+def record_memory_injections(
+    keys: list[str],
+    *,
+    state_file: Path,
+) -> None:
+    """Record that specific memory files were injected into a session."""
+    if not keys:
+        return
+    state = load_memory_state(state_file)
+    now = datetime.now(timezone.utc).isoformat()
+    for key in keys:
+        entry_state = state.get(key, {})
+        entry_state["last_injected"] = now
+        entry_state["injections"] = int(entry_state.get("injections", 0)) + 1
+        state[key] = entry_state
+    save_memory_state(state, state_file)
+
+
+def _entry_referenced(
+    normalized_text: str,
+    text_tokens: set[str],
+    entry: MemoryFile,
+) -> bool:
+    """Check whether a text references a memory entry by alias."""
+    for alias in entry.aliases:
+        alias_norm = _normalize(alias)
+        alias_tokens = [t for t in alias_norm.split() if t not in STOPWORDS]
+        if len(alias_tokens) >= 2 and alias_norm and alias_norm in normalized_text:
+            return True
+        if len(alias_tokens) >= 3:
+            overlap = len(set(alias_tokens) & text_tokens)
+            if overlap / len(alias_tokens) >= 0.75:
+                return True
+        if len(alias_tokens) >= 3 and set(alias_tokens).issubset(text_tokens):
+            return True
+    return False
+
+
+def update_memory_state_from_text(
+    text: str,
+    *,
+    memory_dir: Path,
+    state_file: Path,
+) -> list[str]:
+    """Update memory confidence when a text references memory entries.
+
+    Reads the full text (e.g. a session trajectory), finds referenced memory
+    files by alias, and boosts their confidence + updates last_verified.
+
+    Returns the list of memory keys that were updated.
+    """
+    normalized_text = _normalize(text)
+    text_tokens = set(_tokenize(text))
+    if len(text_tokens) < MIN_MATCH_OVERLAP:
+        return []
+
+    state = load_memory_state(state_file)
+    now = datetime.now(timezone.utc).isoformat()
+    matched: list[str] = []
+
+    for entry in discover_memory_files(memory_dir):
+        if not _entry_referenced(normalized_text, text_tokens, entry):
+            continue
+        matched.append(entry.name)
+        entry_state = state.get(entry.name, {})
+        confidence = max(_confidence(entry, state), entry.default_confidence)
+        entry_state["confidence"] = round(min(1.0, confidence + 0.05), 2)
+        entry_state["last_verified"] = now
+        entry_state["references"] = int(entry_state.get("references", 0)) + 1
+        state[entry.name] = entry_state
+
+    if matched:
+        save_memory_state(state, state_file)
+    return matched

--- a/packages/gptme-cc-memory/src/gptme_cc_memory/memory_retrieval.py
+++ b/packages/gptme-cc-memory/src/gptme_cc_memory/memory_retrieval.py
@@ -277,8 +277,6 @@ def _entry_referenced(
             overlap = len(set(alias_tokens) & text_tokens)
             if overlap / len(alias_tokens) >= 0.75:
                 return True
-        if len(alias_tokens) >= 3 and set(alias_tokens).issubset(text_tokens):
-            return True
     return False
 
 

--- a/packages/gptme-cc-memory/src/gptme_cc_memory/schema.py
+++ b/packages/gptme-cc-memory/src/gptme_cc_memory/schema.py
@@ -1,0 +1,212 @@
+"""Memory type definitions, frontmatter parsing, and file validation.
+
+The four memory types encode different *what-to-do-with-this* semantics:
+
+- **user**: Who the user is — role, expertise, preferences, context
+- **feedback**: Behavioral rules from corrections or confirmations (always inject)
+- **project**: Ongoing work, goals, decisions, deadlines (situational)
+- **reference**: Where to find things in external systems (system-triggered)
+
+Every memory file must have YAML frontmatter with at minimum a ``name`` and
+``metadata.type`` field.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# Valid memory types and their display order / priority tier
+MEMORY_TYPES = frozenset({"user", "feedback", "project", "reference"})
+
+# Files that are not memory entries
+SPECIAL_MEMORY_FILES = frozenset(
+    {
+        "MEMORY.md",
+        "guidance.md",
+        "pending-items.md",
+        "pending-updates.md",
+        "pending-session-context.md",
+    }
+)
+
+# Type priority for injection (higher = always inject first)
+TYPE_INJECTION_PRIORITY: dict[str, int] = {
+    "feedback": 4,
+    "user": 3,
+    "project": 2,
+    "reference": 1,
+}
+
+# Default confidence by type (used when metadata.json has no entry)
+DEFAULT_CONFIDENCE_BY_TYPE: dict[str, float] = {
+    "feedback": 0.88,
+    "project": 0.78,
+    "reference": 0.72,
+}
+
+# Score boost by type for retrieval
+TYPE_BOOST: dict[str, float] = {
+    "feedback": 1.10,
+    "project": 1.00,
+    "reference": 0.96,
+}
+
+
+@dataclass
+class MemoryFile:
+    """A parsed memory file with validated frontmatter."""
+
+    path: Path
+    name: str
+    description: str
+    type: str
+    body: str
+    excerpt: str
+    aliases: list[str]
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def default_confidence(self) -> float:
+        return DEFAULT_CONFIDENCE_BY_TYPE.get(self.type, 0.7)
+
+    @property
+    def type_boost(self) -> float:
+        return TYPE_BOOST.get(self.type, 1.0)
+
+    @property
+    def injection_priority(self) -> int:
+        return TYPE_INJECTION_PRIORITY.get(self.type, 0)
+
+
+def load_yaml_frontmatter(content: str) -> tuple[dict[str, Any], str]:
+    """Extract YAML frontmatter from a markdown file.
+
+    Returns (metadata, body) where metadata is the parsed YAML and body is
+    everything after the frontmatter delimiter.
+    """
+    content = content.strip()
+    if not content.startswith("---"):
+        return {}, content
+
+    # Strip the opening --- delimiter
+    after_opening = content[3:].lstrip("\n")
+    consumed = len(content) - len(after_opening)
+
+    # Find closing --- on its own line
+    end_match = re.search(r"^---\s*$", after_opening, re.MULTILINE)
+    if not end_match:
+        return {}, content
+
+    # YAML text is everything between the two delimiters
+    yaml_text = after_opening[: end_match.start()].strip()
+    body_start = consumed + end_match.end()
+    body = content[body_start:].strip()
+
+    try:
+        metadata = yaml.safe_load(yaml_text) or {}
+    except yaml.YAMLError:
+        return {}, body
+
+    if not isinstance(metadata, dict):
+        return {}, body
+
+    return metadata, body
+
+
+def validate_memory_file(metadata: dict[str, Any], body: str) -> list[str]:
+    """Validate a memory file's frontmatter and body.
+
+    Returns a list of validation error messages (empty list = valid).
+    """
+    errors: list[str] = []
+
+    if (
+        "name" not in metadata
+        or not isinstance(metadata["name"], str)
+        or not metadata["name"].strip()
+    ):
+        errors.append("Missing or empty 'name' field in frontmatter")
+
+    if "description" not in metadata or not isinstance(metadata["description"], str):
+        errors.append("Missing or non-string 'description' field in frontmatter")
+
+    mem_type = metadata.get("metadata", {}).get("type", "")
+    if not mem_type or mem_type not in MEMORY_TYPES:
+        valid_types = ", ".join(sorted(MEMORY_TYPES))
+        errors.append(
+            f"Invalid or missing 'metadata.type': got {mem_type!r}, "
+            f"expected one of: {valid_types}"
+        )
+
+    if not body or not body.strip():
+        errors.append("Memory body is empty")
+
+    return errors
+
+
+def parse_memory_file(path: Path) -> MemoryFile | None:
+    """Parse and validate a single memory file."""
+    try:
+        content = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+    metadata, body = load_yaml_frontmatter(content)
+    if not metadata:
+        return None
+
+    mem_type = str(metadata.get("metadata", {}).get("type", "memory")).strip().lower()
+    if mem_type not in MEMORY_TYPES:
+        mem_type = "memory"
+
+    name = str(metadata.get("name", path.stem)).strip()
+    description = str(metadata.get("description", "")).strip()
+
+    # Build excerpt
+    text = re.sub(r"\s+", " ", body).strip()
+    excerpt = text[:217] + "..." if len(text) > 220 else text
+
+    # Build aliases from name, filename, and explicit aliases field
+    aliases: list[str] = []
+    seen: set[str] = set()
+    for candidate in [name, path.stem] + metadata.get("aliases", []):
+        normalized = candidate.strip().lower()
+        if normalized and normalized not in seen:
+            seen.add(normalized)
+            aliases.append(candidate.strip())
+
+    return MemoryFile(
+        path=path,
+        name=name,
+        description=description,
+        type=mem_type,
+        body=body.strip(),
+        excerpt=excerpt,
+        aliases=aliases,
+        metadata=metadata.get("metadata", {}),
+    )
+
+
+def discover_memory_files(memory_dir: Path) -> list[MemoryFile]:
+    """Discover all valid memory files in a directory.
+
+    Skips special files (MEMORY.md, guidance.md, pending-*.md) and files that
+    fail to parse.
+    """
+    entries: list[MemoryFile] = []
+    if not memory_dir.is_dir():
+        return entries
+
+    for path in sorted(memory_dir.glob("*.md")):
+        if path.name in SPECIAL_MEMORY_FILES:
+            continue
+        entry = parse_memory_file(path)
+        if entry is not None:
+            entries.append(entry)
+
+    return entries

--- a/packages/gptme-cc-memory/src/gptme_cc_memory/schema.py
+++ b/packages/gptme-cc-memory/src/gptme_cc_memory/schema.py
@@ -45,6 +45,7 @@ TYPE_INJECTION_PRIORITY: dict[str, int] = {
 # Default confidence by type (used when metadata.json has no entry)
 DEFAULT_CONFIDENCE_BY_TYPE: dict[str, float] = {
     "feedback": 0.88,
+    "user": 0.75,
     "project": 0.78,
     "reference": 0.72,
 }

--- a/packages/gptme-cc-memory/tests/test_extractor.py
+++ b/packages/gptme-cc-memory/tests/test_extractor.py
@@ -1,0 +1,176 @@
+"""Tests for gptme_cc_memory.extractor — heuristic extraction from trajectories."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+from gptme_cc_memory.extractor import (
+    detect_corrections,
+    detect_confirmations,
+    detect_guidance_blocks,
+    detect_pending_items,
+    extract_memories,
+    extract_session_context,
+    format_pending_items,
+    format_pending_updates,
+    format_session_context,
+)
+
+
+# Sample trajectory: one correction + confirmation
+CORRECTION_TRAJECTORY = [
+    {"role": "human", "content": "Don't use --no-verify, fix the pre-commit failure instead"},
+    {"role": "assistant", "content": "You're right, I should fix the hook failure."},
+    {"role": "human", "content": "Great, that works!"},
+]
+
+# Sample trajectory with a pending item
+PENDING_TRAJECTORY = [
+    {"role": "human", "content": "Let's start the database migration"},
+    {"role": "assistant", "content": "I'll begin with the schema changes."},
+    {"role": "human", "content": "The next step is to handle the rollback script"},
+]
+
+# Sample trajectory with guidance
+GUIDANCE_TRAJECTORY = [
+    {"role": "human", "content": "Check the code style"},
+    {"role": "assistant", "content": "Reminder: always use type hints for function signatures."},
+    {"role": "human", "content": "Good."},
+]
+
+# Empty trajectory
+EMPTY_TRAJECTORY: list[dict] = []
+
+
+class TestDetectCorrections:
+    def test_detects_correction(self):
+        result = detect_corrections(CORRECTION_TRAJECTORY)
+        assert len(result) >= 1
+        assert any("--no-verify" in c.get("context", "") for c in result)
+
+    def test_no_corrections_in_empty(self):
+        assert detect_corrections(EMPTY_TRAJECTORY) == []
+
+    def test_no_false_positive_on_positive_messages(self):
+        messages = [
+            {"role": "human", "content": "This looks great, thanks!"},
+            {"role": "human", "content": "Perfect, let's ship it."},
+        ]
+        result = detect_corrections(messages)
+        assert len(result) == 0
+
+
+class TestDetectConfirmations:
+    def test_detects_confirmation(self):
+        result = detect_confirmations(CORRECTION_TRAJECTORY)
+        assert len(result) >= 1
+        assert any("Great" in c.get("full_text", "") for c in result)
+
+    def test_no_confirmations_in_empty(self):
+        assert detect_confirmations(EMPTY_TRAJECTORY) == []
+
+    def test_skips_long_messages(self):
+        messages = [
+            {"role": "human", "content": "Great, that works!" * 50}  # >200 chars
+        ]
+        result = detect_confirmations(messages)
+        assert len(result) == 0
+
+
+class TestDetectPendingItems:
+    def test_detects_pending_items(self):
+        result = detect_pending_items(PENDING_TRAJECTORY)
+        assert len(result) >= 1
+
+    def test_no_items_in_empty(self):
+        assert detect_pending_items(EMPTY_TRAJECTORY) == []
+
+
+class TestDetectGuidanceBlocks:
+    def test_detects_guidance(self):
+        result = detect_guidance_blocks(GUIDANCE_TRAJECTORY)
+        assert len(result) >= 1
+        assert any("type hints" in g for g in result)
+
+    def test_no_guidance_in_empty(self):
+        assert detect_guidance_blocks(EMPTY_TRAJECTORY) == []
+
+
+class TestExtractSessionContext:
+    def test_extracts_goal(self):
+        result = extract_session_context(CORRECTION_TRAJECTORY)
+        assert result["goal"] is not None
+
+    def test_extracts_last_turn(self):
+        result = extract_session_context(CORRECTION_TRAJECTORY)
+        assert result["last_turn"] is not None
+
+    def test_counts_tool_calls(self):
+        messages = [
+            {"role": "human", "content": "hello"},
+            {"role": "assistant", "content": "Let me check.\nTool Use: cat\nTool Use: grep"},
+        ]
+        result = extract_session_context(messages)
+        assert result["tool_call_count"] == 2
+
+    def test_empty_trajectory(self):
+        result = extract_session_context(EMPTY_TRAJECTORY)
+        assert result["goal"] is None
+        assert result["tool_call_count"] == 0
+
+
+class TestExtractMemories:
+    def test_extract_from_trajectory_file(self, tmp_path: Path):
+        traj = tmp_path / "trajectory.jsonl"
+        with open(traj, "w") as f:
+            for msg in CORRECTION_TRAJECTORY:
+                f.write(json.dumps(msg) + "\n")
+
+        result = extract_memories(traj)
+        assert len(result.corrections) >= 1
+        assert len(result.confirmations) >= 1
+
+
+class TestFormatOutput:
+    def test_format_pending_updates(self):
+        # Test with a mock result
+        from gptme_cc_memory.extractor import ExtractionResult
+
+        r = ExtractionResult(
+            corrections=[
+                {
+                    "type": "negative_feedback",
+                    "matched": "don't use",
+                    "context": "Don't use --no-verify",
+                }
+            ],
+            confirmations=[{"type": "positive_confirmation", "full_text": "Great, that works"}],
+        )
+        output = format_pending_updates(r)
+        assert "don't use" in output
+        assert "Great, that works" in output
+
+    def test_format_pending_items(self):
+        from gptme_cc_memory.extractor import ExtractionResult
+
+        r = ExtractionResult(pending_items=["Finish the migration", "Write tests"])
+        output = format_pending_items(r)
+        assert "Finish" in output
+        assert "Write tests" in output
+
+    def test_format_session_context(self):
+        from gptme_cc_memory.extractor import ExtractionResult
+
+        r = ExtractionResult(
+            session_context={
+                "goal": "Fix the bug",
+                "last_turn": "Done",
+                "message_count": 3,
+                "tool_call_count": 2,
+            }
+        )
+        output = format_session_context(r)
+        assert "Fix the bug" in output
+        assert "Messages" in output

--- a/packages/gptme-cc-memory/tests/test_extractor.py
+++ b/packages/gptme-cc-memory/tests/test_extractor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 
@@ -131,6 +132,27 @@ class TestExtractMemories:
         result = extract_memories(traj)
         assert len(result.corrections) >= 1
         assert len(result.confirmations) >= 1
+
+    def test_main_writes_pending_files_under_workspace_memory_dir(
+        self, tmp_path: Path, monkeypatch
+    ):
+        from gptme_cc_memory import extractor
+
+        traj = tmp_path / "trajectory.jsonl"
+        workspace = tmp_path / "workspace"
+        memory_dir = workspace / "memory"
+
+        with open(traj, "w", encoding="utf-8") as f:
+            for msg in CORRECTION_TRAJECTORY:
+                f.write(json.dumps(msg) + "\n")
+
+        monkeypatch.setenv("GPTME_CC_MEMORY_DIR", str(workspace))
+        monkeypatch.setattr(sys, "argv", ["extractor", str(traj)])
+
+        extractor.main()
+
+        assert (memory_dir / "pending-updates.md").exists()
+        assert (memory_dir / "pending-session-context.md").exists()
 
 
 class TestFormatOutput:

--- a/packages/gptme-cc-memory/tests/test_injector.py
+++ b/packages/gptme-cc-memory/tests/test_injector.py
@@ -1,0 +1,125 @@
+"""Tests for gptme_cc_memory.injector — memory injection logic."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+
+from gptme_cc_memory.injector import (
+    clear_file,
+    inject_memories,
+    prune_stale_pending_updates,
+    read_if_exists,
+)
+
+
+class TestReadIfExists:
+    def test_reads_file(self, tmp_path: Path):
+        f = tmp_path / "test.txt"
+        f.write_text("hello world")
+        assert read_if_exists(f) == "hello world"
+
+    def test_nonexistent_file(self, tmp_path: Path):
+        assert read_if_exists(tmp_path / "nonexistent.txt") == ""
+
+    def test_empty_file(self, tmp_path: Path):
+        f = tmp_path / "empty.txt"
+        f.write_text("")
+        assert read_if_exists(f) == ""
+
+
+class TestClearFile:
+    def test_clears_file(self, tmp_path: Path):
+        f = tmp_path / "test.txt"
+        f.write_text("some content")
+        clear_file(f)
+        assert f.read_text() == ""
+
+    def test_nonexistent_file(self, tmp_path: Path):
+        clear_file(tmp_path / "nonexistent.txt")  # Should not raise
+
+
+class TestPruneStalePendingUpdates:
+    def test_keeps_recent_date(self):
+        today = date(2026, 6, 22)
+        content = "## Pending — 2026-06-22 10:00 (session: abc)\nSome update here."
+        result = prune_stale_pending_updates(content, today)
+        assert "2026-06-22" in result
+
+    def test_prunes_old_date(self):
+        today = date(2026, 6, 22)
+        content = "## Pending — 2026-06-10 10:00 (session: abc)\nStale update here."
+        result = prune_stale_pending_updates(content, today)
+        assert result == ""
+
+    def test_mixed_dates(self):
+        today = date(2026, 6, 22)
+        content = """\
+## Pending — 2026-06-10 10:00
+Stale update.
+
+## Pending — 2026-06-22 14:00
+Fresh update.
+"""
+        result = prune_stale_pending_updates(content, today)
+        assert "Fresh" in result
+        assert "Stale" not in result
+
+    def test_keeps_undated_content(self):
+        today = date(2026, 6, 22)
+        content = "## Some section\nUndated content here."
+        result = prune_stale_pending_updates(content, today)
+        assert "Undated" in result
+
+    def test_empty_content(self):
+        today = date(2026, 6, 22)
+        assert prune_stale_pending_updates("", today) == ""
+
+
+class TestInjectMemories:
+    def test_empty_memory_dir(self, tmp_path: Path):
+        mem_dir = tmp_path / "memory"
+        mem_dir.mkdir()
+        meta_file = tmp_path / "metadata.json"
+        result = inject_memories(
+            "test prompt",
+            memory_dir=mem_dir,
+            metadata_file=meta_file,
+        )
+        assert result is None  # Nothing to inject
+
+    def test_with_guidance(self, tmp_path: Path):
+        mem_dir = tmp_path / "memory"
+        mem_dir.mkdir()
+        meta_file = tmp_path / "metadata.json"
+        guidance = mem_dir / "guidance.md"
+        guidance.write_text("Remember to check tests first.")
+
+        result = inject_memories(
+            "test prompt",
+            memory_dir=mem_dir,
+            metadata_file=meta_file,
+            guidance_file=guidance,
+        )
+        assert result is not None
+        assert "Remember to check tests first" in result
+
+        # Guidance should be cleared after injection
+        assert not guidance.read_text()
+
+    def test_with_pending_items(self, tmp_path: Path):
+        mem_dir = tmp_path / "memory"
+        mem_dir.mkdir()
+        meta_file = tmp_path / "metadata.json"
+        items = mem_dir / "pending-items.md"
+        items.write_text("## Pending Items\n- Finish the migration")
+
+        result = inject_memories(
+            "test prompt",
+            memory_dir=mem_dir,
+            metadata_file=meta_file,
+            pending_items_file=items,
+        )
+        assert result is not None
+        assert "Finish the migration" in result

--- a/packages/gptme-cc-memory/tests/test_injector.py
+++ b/packages/gptme-cc-memory/tests/test_injector.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import date
 from pathlib import Path
+from typing import Any
 
 
 from gptme_cc_memory.injector import (
@@ -12,6 +13,17 @@ from gptme_cc_memory.injector import (
     prune_stale_pending_updates,
     read_if_exists,
 )
+
+VALID_FEEDBACK_MD = """\
+---
+name: never-skip-precommit
+description: Never bypass pre-commit hooks with --no-verify
+metadata:
+  type: feedback
+---
+
+Never use --no-verify to bypass pre-commit hooks.
+"""
 
 
 class TestReadIfExists:
@@ -123,3 +135,35 @@ class TestInjectMemories:
         )
         assert result is not None
         assert "Finish the migration" in result
+
+    def test_preserves_one_shot_files_when_recording_injections_fails(
+        self, tmp_path: Path, monkeypatch: Any
+    ):
+        mem_dir = tmp_path / "memory"
+        mem_dir.mkdir()
+        meta_file = tmp_path / "metadata.json"
+        guidance = mem_dir / "guidance.md"
+        pending_context = mem_dir / "pending-session-context.md"
+        guidance.write_text("Remember to check tests first.")
+        pending_context.write_text("Continue the pre-commit hook review.")
+        (mem_dir / "feedback-precommit.md").write_text(VALID_FEEDBACK_MD)
+
+        def raise_recording_error(*args: object, **kwargs: object) -> None:
+            raise OSError("metadata state unavailable")
+
+        monkeypatch.setattr(
+            "gptme_cc_memory.injector.record_memory_injections",
+            raise_recording_error,
+        )
+
+        result = inject_memories(
+            "Don't bypass pre-commit hooks with --no-verify",
+            memory_dir=mem_dir,
+            metadata_file=meta_file,
+            guidance_file=guidance,
+            pending_session_context_file=pending_context,
+        )
+
+        assert result is None
+        assert guidance.read_text() == "Remember to check tests first."
+        assert pending_context.read_text() == "Continue the pre-commit hook review."

--- a/packages/gptme-cc-memory/tests/test_retrieval.py
+++ b/packages/gptme-cc-memory/tests/test_retrieval.py
@@ -1,0 +1,208 @@
+"""Tests for gptme_cc_memory.memory_retrieval — scoring and state."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gptme_cc_memory.memory_retrieval import (
+    load_memory_state,
+    record_memory_injections,
+    render_relevant_memory_block,
+    save_memory_state,
+    select_relevant_memories,
+    update_memory_state_from_text,
+)
+
+VALID_FEEDBACK_MD = """\
+---
+name: never-skip-precommit
+description: Never bypass pre-commit hooks with --no-verify
+metadata:
+  type: feedback
+---
+
+Never use --no-verify to bypass pre-commit hooks.
+
+**Why:** Prior incident where bypassing hooks caused a broken migration.
+**How to apply:** Fix the underlying hook failure; investigate before bypassing.
+"""
+
+VALID_PROJECT_MD = """\
+---
+name: database-migration-sprint
+description: Database migration sprint — zero downtime constraint
+metadata:
+  type: project
+---
+
+Current sprint: PostgreSQL migration. Key constraint: zero downtime.
+Don't change schema in ways that require table rewrites.
+"""
+
+# A memory about Python typing (relevant when user talks about Python)
+USER_TYPING_MD = """\
+---
+name: prefers-python-typing
+description: User prefers type hints on all function signatures
+metadata:
+  type: user
+---
+
+Always use Python type hints.
+
+**Why:** The user values type safety and IDE support.
+**How to apply:** Add return type annotations to every function definition.
+"""
+
+
+@pytest.fixture
+def memory_dir(tmp_path: Path) -> Path:
+    mem = tmp_path / "memory"
+    mem.mkdir()
+    (mem / "feedback-precommit.md").write_text(VALID_FEEDBACK_MD)
+    (mem / "project-db-migration.md").write_text(VALID_PROJECT_MD)
+    (mem / "user-python-typing.md").write_text(USER_TYPING_MD)
+    return mem
+
+
+@pytest.fixture
+def state_file(tmp_path: Path) -> Path:
+    sf = tmp_path / "cc-memory" / "metadata.json"
+    sf.parent.mkdir(parents=True)
+    return sf
+
+
+class TestSelectRelevantMemories:
+    def test_relevant_to_precommit(self, memory_dir: Path, state_file: Path):
+        results = select_relevant_memories(
+            "Don't use --no-verify to bypass pre-commit hooks",
+            memory_dir=memory_dir,
+            state_file=state_file,
+            limit=2,
+        )
+        assert len(results) >= 1
+        assert any(r["name"] == "never-skip-precommit" for r in results)
+
+    def test_relevant_to_database(self, memory_dir: Path, state_file: Path):
+        results = select_relevant_memories(
+            "Let's work on PostgreSQL migration with zero downtime",
+            memory_dir=memory_dir,
+            state_file=state_file,
+            limit=2,
+        )
+        assert len(results) >= 1
+        assert any(r["name"] == "database-migration-sprint" for r in results)
+
+    def test_relevant_to_typing(self, memory_dir: Path, state_file: Path):
+        results = select_relevant_memories(
+            "Add type hints to the Python function signatures",
+            memory_dir=memory_dir,
+            state_file=state_file,
+            limit=2,
+        )
+        assert len(results) >= 1
+        assert any("typing" in r["name"] for r in results)
+
+    def test_empty_prompt(self, memory_dir: Path, state_file: Path):
+        results = select_relevant_memories(
+            "",
+            memory_dir=memory_dir,
+            state_file=state_file,
+        )
+        assert results == []
+
+    def test_short_query_no_match(self, memory_dir: Path, state_file: Path):
+        results = select_relevant_memories(
+            "hello world foo bar",
+            memory_dir=memory_dir,
+            state_file=state_file,
+        )
+        assert results == []
+
+    def test_limit_respected(self, memory_dir: Path, state_file: Path):
+        results = select_relevant_memories(
+            "Don't use --no-verify to bypass pre-commit hooks. "
+            "Also add Python type hints. Don't change schema.",
+            memory_dir=memory_dir,
+            state_file=state_file,
+            limit=1,
+        )
+        assert len(results) == 1
+
+
+class TestMemoryState:
+    def test_load_empty_state(self, state_file: Path):
+        assert load_memory_state(state_file) == {}
+
+    def test_save_and_load(self, state_file: Path):
+        state = {"memory1": {"confidence": 0.9, "references": 3}}
+        save_memory_state(state, state_file)
+        assert state_file.exists()
+        loaded = load_memory_state(state_file)
+        assert loaded["memory1"]["confidence"] == 0.9
+        assert loaded["memory1"]["references"] == 3
+
+    def test_record_injection(self, state_file: Path):
+        record_memory_injections(["memory-a", "memory-b"], state_file=state_file)
+        state = load_memory_state(state_file)
+        assert state["memory-a"]["injections"] == 1
+        assert state["memory-b"]["injections"] == 1
+
+    def test_injection_increments(self, state_file: Path):
+        record_memory_injections(["memory-a"], state_file=state_file)
+        record_memory_injections(["memory-a"], state_file=state_file)
+        state = load_memory_state(state_file)
+        assert state["memory-a"]["injections"] == 2
+
+    def test_corrupted_state_returns_empty(self, state_file: Path):
+        state_file.write_text("not valid json")
+        assert load_memory_state(state_file) == {}
+
+
+class TestRenderRelevantMemoryBlock:
+    def test_empty_entries(self):
+        assert render_relevant_memory_block([]) == ""
+
+    def test_single_entry(self):
+        entries = [
+            {
+                "type": "feedback",
+                "name": "never-skip-precommit",
+                "confidence": 0.88,
+                "recency": 0.95,
+                "matched_terms": ["precommit", "hooks"],
+                "excerpt": "Never use --no-verify...",
+            }
+        ]
+        result = render_relevant_memory_block(entries)
+        assert "<memory_relevant_entries>" in result
+        assert "never-skip-precommit" in result
+        assert "feedback" in result
+        assert "0.88" in result
+        assert "0.95" in result
+        assert "</memory_relevant_entries>" in result
+
+
+class TestUpdateMemoryState:
+    def test_detect_reference(self, memory_dir: Path, state_file: Path):
+        """Text referencing a memory alias should boost its confidence."""
+        matched = update_memory_state_from_text(
+            "I noticed you used never-skip-precommit — that's a good rule",
+            memory_dir=memory_dir,
+            state_file=state_file,
+        )
+        assert "never-skip-precommit" in matched
+
+        state = load_memory_state(state_file)
+        entry = state.get("never-skip-precommit", {})
+        assert entry.get("references", 0) >= 1
+
+    def test_no_match(self, memory_dir: Path, state_file: Path):
+        matched = update_memory_state_from_text(
+            "This is totally unrelated content about gardening.",
+            memory_dir=memory_dir,
+            state_file=state_file,
+        )
+        assert matched == []

--- a/packages/gptme-cc-memory/tests/test_schema.py
+++ b/packages/gptme-cc-memory/tests/test_schema.py
@@ -1,0 +1,188 @@
+"""Tests for gptme_cc_memory.schema — frontmatter parsing and validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+from gptme_cc_memory.schema import (
+    discover_memory_files,
+    load_yaml_frontmatter,
+    validate_memory_file,
+)
+
+# Valid feedback memory
+VALID_FEEDBACK_MD = """\
+---
+name: never-skip-precommit
+description: Never bypass pre-commit hooks with --no-verify
+metadata:
+  type: feedback
+---
+
+Never use --no-verify to bypass pre-commit hooks.
+
+**Why:** Prior incident where bypassing hooks caused a broken migration.
+**How to apply:** Fix the underlying hook failure.
+"""
+
+# Valid user memory
+VALID_USER_MD = """\
+---
+name: prefers-python-typing
+description: User prefers Python type hints on all signatures
+metadata:
+  type: user
+---
+
+Always use Python typing hints.
+
+**Why:** The user values type safety.
+**How to apply:** Add return type annotations to all functions.
+"""
+
+# Valid project memory
+VALID_PROJECT_MD = """\
+---
+name: current-sprint-migration
+description: Database migration sprint goals and constraints
+metadata:
+  type: project
+---
+
+Current sprint focuses on PostgreSQL migration. Key constraint: zero downtime.
+Don't change the schema in ways that require table rewrites.
+"""
+
+# Invalid — missing name
+MISSING_NAME_MD = """\
+---
+metadata:
+  type: feedback
+---
+
+No name field here.
+"""
+
+# Invalid — wrong type
+WRONG_TYPE_MD = """\
+---
+name: some-memory
+description: A test memory
+metadata:
+  type: invalid_type
+---
+
+This has an invalid type.
+"""
+
+# No frontmatter at all
+NO_FRONTMATTER_MD = """\
+Just a plain markdown file without frontmatter.
+"""
+
+
+class TestLoadYamlFrontmatter:
+    def test_valid_frontmatter(self):
+        metadata, body = load_yaml_frontmatter(VALID_FEEDBACK_MD)
+        assert metadata["name"] == "never-skip-precommit"
+        assert metadata["metadata"]["type"] == "feedback"
+        assert "Never use --no-verify" in body
+
+    def test_no_frontmatter(self):
+        metadata, body = load_yaml_frontmatter(NO_FRONTMATTER_MD)
+        assert metadata == {}
+        assert "plain markdown" in body
+
+    def test_empty_string(self):
+        metadata, body = load_yaml_frontmatter("")
+        assert metadata == {}
+        assert body == ""
+
+
+class TestValidateMemoryFile:
+    def test_valid_feedback(self):
+        metadata, body = load_yaml_frontmatter(VALID_FEEDBACK_MD)
+        errors = validate_memory_file(metadata, body)
+        assert errors == []
+
+    def test_valid_user(self):
+        metadata, body = load_yaml_frontmatter(VALID_USER_MD)
+        errors = validate_memory_file(metadata, body)
+        assert errors == []
+
+    def test_valid_project(self):
+        metadata, body = load_yaml_frontmatter(VALID_PROJECT_MD)
+        errors = validate_memory_file(metadata, body)
+        assert errors == []
+
+    def test_missing_name(self):
+        metadata, body = load_yaml_frontmatter(MISSING_NAME_MD)
+        errors = validate_memory_file(metadata, body)
+        error_texts = " ".join(errors).lower()
+        assert "name" in error_texts
+
+    def test_invalid_type(self):
+        metadata, body = load_yaml_frontmatter(WRONG_TYPE_MD)
+        errors = validate_memory_file(metadata, body)
+        error_texts = " ".join(errors).lower()
+        assert "invalid_type" in error_texts
+        assert "type" in error_texts
+
+    def test_no_frontmatter_validates(self):
+        metadata, body = load_yaml_frontmatter(NO_FRONTMATTER_MD)
+        errors = validate_memory_file(metadata, body)
+        assert len(errors) >= 1  # Missing name, type, etc.
+
+
+class TestDiscoverMemoryFiles:
+    def test_discover_files(self, tmp_path: Path):
+        # Create a few valid memory files
+        mem_dir = tmp_path / "memory"
+        mem_dir.mkdir()
+
+        (mem_dir / "feedback-precommit.md").write_text(VALID_FEEDBACK_MD)
+        (mem_dir / "user-typing.md").write_text(VALID_USER_MD)
+        (mem_dir / "project-db.md").write_text(VALID_PROJECT_MD)
+
+        # Special files should be skipped
+        (mem_dir / "MEMORY.md").write_text("# Index")
+        (mem_dir / "guidance.md").write_text("Some guidance")
+        (mem_dir / "pending-items.md").write_text("Items")
+
+        # Invalid file
+        (mem_dir / "invalid.md").write_text(NO_FRONTMATTER_MD)
+
+        entries = discover_memory_files(mem_dir)
+        assert len(entries) == 3
+
+        types = {e.type for e in entries}
+        assert types == {"feedback", "user", "project"}
+
+    def test_empty_directory(self, tmp_path: Path):
+        entries = discover_memory_files(tmp_path / "nonexistent")
+        assert entries == []
+
+        entries = discover_memory_files(tmp_path)
+        assert entries == []
+
+    def test_memory_file_type_default(self, tmp_path: Path):
+        # A file with type "memory" (not in MEMORY_TYPES) should be treated as
+        # a generic entry — parseable but with a fallback type string.
+        md = """\
+---
+name: generic-entry
+description: Something useful
+metadata:
+  type: memory
+---
+
+Some useful content.
+"""
+        mem_dir = tmp_path / "memory"
+        mem_dir.mkdir()
+        (mem_dir / "generic.md").write_text(md)
+
+        entries = discover_memory_files(mem_dir)
+        assert len(entries) == 1
+        assert entries[0].type == "memory"

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,7 @@ members = [
     "gptme-ace",
     "gptme-activity-summary",
     "gptme-attention-tracker",
+    "gptme-cc-memory",
     "gptme-claude-code",
     "gptme-codegraph",
     "gptme-consortium",
@@ -1388,6 +1389,32 @@ requires-dist = [
     { name = "pytest-mock", marker = "extra == 'test'", specifier = ">=3.12.0" },
 ]
 provides-extras = ["test"]
+
+[[package]]
+name = "gptme-cc-memory"
+version = "0.1.0"
+source = { editable = "packages/gptme-cc-memory" }
+dependencies = [
+    { name = "pyyaml" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+]
+test = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
+    { name = "pyyaml", specifier = ">=6.0.0" },
+]
+provides-extras = ["test", "dev"]
 
 [[package]]
 name = "gptme-claude-code"


### PR DESCRIPTION
## Summary

Package Bob's typed memory pipeline as a reusable gptme-contrib package: four memory types (user/feedback/project/reference) with behavioral correction semantics, git-tracking, and zero-API-cost prompt injection.

Closes idea #569 in ErikBjare/bob.

## Key Components

- **schema.py**: Memory type definitions, YAML frontmatter parsing and validation
- **memory_retrieval.py**: Scoring engine (lexical × confidence × recency), persistent state management
- **injector.py**: UserPromptSubmit hook that scores and injects relevant memories
- **extractor.py**: Heuristic session trajectory reader (no LLM dependency) that detects corrections, confirmations, pending items
- **hooks/**: CC hook integration (stop_hook.sh, prompt_submit.py)
- **MEMORY.md.template**: Empty memory index starter

## Testing

- 58 tests across schema, retrieval, injector, extractor
- All CI checks pass
- mypy clean, ruff clean, pre-commit clean

## Background

Design doc: ErikBjare/bob/blob/master/knowledge/technical-designs/typed-memory-schema-design.md
Peer research: ErikBjare/bob/blob/master/knowledge/research/2026-06-22-cc-memory-ecosystem-recall-analysis.md