### PR TITLE
fix(lessons): remove dead keywords in lesson frontmatter

### DIFF
--- a/lessons/autonomous/agent-event-watch-workflow.md
+++ b/lessons/autonomous/agent-event-watch-workflow.md
@@ -4,7 +4,7 @@ status: active
 match:
   keywords:
     - named watch task
-    - watch for event results
+    - upcoming event trigger
   session_categories: [cross-repo, strategic]
 ---
 

--- a/lessons/workflow/read-full-github-context.md
+++ b/lessons/workflow/read-full-github-context.md
@@ -2,7 +2,6 @@
 match:
   keywords:
     - "--comments | tail"
-    - "gh issue view --comments"
   session_categories: [cross-repo, code]
 status: active
 description: "NEVER truncate GitHub comment output."


### PR DESCRIPTION
## Summary

- **read-full-github-context**: remove `'gh issue view --comments'` (dead in 7-day trajectory window; `'--comments | tail'` still covers the truncation-detection trigger)
- **agent-event-watch-workflow**: replace dead `'watch for event results'` with `'upcoming event trigger'` which better matches the lesson's detection phrasing

## Why

`lesson-keyword-health.py --action-items` flagged both as dead keywords — they never fired in 2665 sessions. The remaining keywords in each lesson are healthy (TS > 0.49).

## Test plan

- [ ] Both lessons validate cleanly: `validate.py` reports `✅`
- [ ] No other lessons affected