### PR TITLE
fix(validate-task-frontmatter): accept date-only created/timestamp fields

### DIFF
--- a/scripts/precommit/validate_task_frontmatter.py
+++ b/scripts/precommit/validate_task_frontmatter.py
@@ -18,7 +18,7 @@ Checks:
 """
 
 import sys
-from datetime import datetime
+from datetime import date, datetime
 from pathlib import Path
 from typing import List, cast
 
@@ -49,9 +49,15 @@ VALID_PRIORITIES = ["low", "medium", "high"]
 VALID_TASK_TYPES = ["project", "action"]
 
 
-def validate_timestamp(ts: str | datetime) -> str | None:
-    """Validate an ISO 8601 timestamp or datetime object."""
-    if isinstance(ts, datetime):
+def validate_timestamp(ts: str | datetime | date) -> str | None:
+    """Validate an ISO 8601 timestamp or datetime/date object.
+
+    YAML parses a bare ``2026-06-24`` value into a ``datetime.date`` (not a
+    ``datetime`` or ``str``). A date is a valid ISO 8601 timestamp at date
+    precision, so accept it rather than rejecting it as an invalid type.
+    """
+    # datetime is a subclass of date, so this covers both object forms.
+    if isinstance(ts, date):
         return None
     elif isinstance(ts, str):
         try:

--- a/scripts/precommit/validate_task_frontmatter.py
+++ b/scripts/precommit/validate_task_frontmatter.py
@@ -98,7 +98,7 @@ def validate_frontmatter(file: Path, type_name: str = "tasks") -> List[str]:
     # Validate timestamps
     for field in ["created", "modified"]:
         if field in metadata:
-            if error := validate_timestamp(cast("str | datetime", metadata[field])):
+            if error := validate_timestamp(cast("str | datetime | date", metadata[field])):
                 errors.append(f"Field '{field}': {error}")
 
     # Validate optional fields
@@ -137,7 +137,7 @@ def validate_frontmatter(file: Path, type_name: str = "tasks") -> List[str]:
     # Validate waiting_since timestamp
     if "waiting_since" in metadata:
         if error := validate_timestamp(
-            cast("str | datetime", metadata["waiting_since"])
+            cast("str | datetime | date", metadata["waiting_since"])
         ):
             errors.append(f"Field 'waiting_since': {error}")
 

--- a/scripts/precommit/validate_task_frontmatter.py
+++ b/scripts/precommit/validate_task_frontmatter.py
@@ -98,7 +98,9 @@ def validate_frontmatter(file: Path, type_name: str = "tasks") -> List[str]:
     # Validate timestamps
     for field in ["created", "modified"]:
         if field in metadata:
-            if error := validate_timestamp(cast("str | datetime | date", metadata[field])):
+            if error := validate_timestamp(
+                cast("str | datetime | date", metadata[field])
+            ):
                 errors.append(f"Field '{field}': {error}")
 
     # Validate optional fields

--- a/tests/test_validate_task_frontmatter_exit.py
+++ b/tests/test_validate_task_frontmatter_exit.py
@@ -48,6 +48,18 @@ def test_exits_zero_on_valid_task(tmp_path: Path) -> None:
     assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
 
 
+def test_exits_zero_on_date_only_created(tmp_path: Path) -> None:
+    """A bare `created: 2026-03-02` is parsed by YAML as a datetime.date, not a
+    str or datetime. A date is a valid ISO 8601 timestamp at date precision, so
+    the validator must accept it rather than rejecting the type."""
+    f = _make_task(
+        tmp_path,
+        "---\nstate: active\ncreated: 2026-03-02\n---\n# Task\n",
+    )
+    result = _run([str(f)])
+    assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+
+
 def test_exits_nonzero_on_unparseable_yaml(tmp_path: Path) -> None:
     """Reproducer: unquoted block scalar with `:1` (backtick-colon-digit)
     causes PyYAML to parse the continuation as a mapping."""


### PR DESCRIPTION
## Problem

YAML parses a bare `created: 2026-06-24` value into a Python `datetime.date` — which is neither `str` nor `datetime`. `validate_timestamp()` only handled those two types and rejected a `date` with `Invalid timestamp type: <class 'datetime.date'>`.

Because the pre-commit hook only validates **changed** files, ~20 already-committed task files with date-only `created` silently pass — until a later session edits one (e.g. to set `state: waiting` + `waiting_since`), at which point the commit fails with a confusing type error that looks unrelated to the edit. (Hit live in ErikBjare/bob today; cost a long debug detour.)

## Fix

Accept `date` in `validate_timestamp()`. A date is a valid ISO 8601 timestamp at date precision. Since `datetime` is a subclass of `date`, one `isinstance(ts, date)` check covers both object forms; the `str` branch (with `fromisoformat`) is unchanged, so genuinely malformed strings still fail.

## Tests

Added `test_exits_zero_on_date_only_created`. Full suite: 6 passed. `ruff check` + `ruff format --check` clean.

This fixes the whole latent class without touching the ~20 off-spec task files (their date-only `created` is valid ISO 8601, just date-precision).