### PR TITLE
feat(quota-gate): capture underlying error on check failure

### DIFF
--- a/scripts/quota-gate.sh
+++ b/scripts/quota-gate.sh
@@ -38,19 +38,20 @@ quota_gate_check() {
         return 0
     fi
 
-    local quota_json quota_err
+    local quota_json quota_err quota_err_file
+    quota_err_file=$(mktemp /tmp/quota-gate-err.XXXXXX)
+    # shellcheck disable=SC2064  # local var: expand now, not when RETURN fires
+    trap "rm -f '${quota_err_file}'" RETURN
     # Capture stderr so a failure window is diagnosable. The first echo MUST keep
     # ending in "proceeding" — standup health-counting greps anchor on
     # `proceeding$` (see scripts/runs/standup/agent-standup.sh). The underlying
     # error goes on a separate continuation line so the anchor stays intact.
-    if ! quota_json=$("$QUOTA_CHECK_SCRIPT" --json 2>/tmp/quota-gate-err.$$); then
-        quota_err=$(head -c 300 /tmp/quota-gate-err.$$ 2>/dev/null | tr '\n' ' ')
-        rm -f /tmp/quota-gate-err.$$
+    if ! quota_json=$("$QUOTA_CHECK_SCRIPT" --json 2>"$quota_err_file"); then
+        quota_err=$(head -c 300 "$quota_err_file" 2>/dev/null | tr '\n' ' ')
         echo "$log_prefix quota check failed (non-fatal), proceeding" >&2
         echo "$log_prefix   └─ underlying error: ${quota_err:-<no stderr captured>}" >&2
         return 0
     fi
-    rm -f /tmp/quota-gate-err.$$ 2>/dev/null
 
     local five_hour_util seven_day_util session_ok weekly_ok
     five_hour_util=$(echo "$quota_json" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('five_hour',{}).get('utilization',0))" 2>/dev/null || echo "0")

--- a/scripts/quota-gate.sh
+++ b/scripts/quota-gate.sh
@@ -38,11 +38,19 @@ quota_gate_check() {
         return 0
     fi
 
-    local quota_json
-    if ! quota_json=$("$QUOTA_CHECK_SCRIPT" --json 2>/dev/null); then
+    local quota_json quota_err
+    # Capture stderr so a failure window is diagnosable. The first echo MUST keep
+    # ending in "proceeding" — standup health-counting greps anchor on
+    # `proceeding$` (see scripts/runs/standup/agent-standup.sh). The underlying
+    # error goes on a separate continuation line so the anchor stays intact.
+    if ! quota_json=$("$QUOTA_CHECK_SCRIPT" --json 2>/tmp/quota-gate-err.$$); then
+        quota_err=$(head -c 300 /tmp/quota-gate-err.$$ 2>/dev/null | tr '\n' ' ')
+        rm -f /tmp/quota-gate-err.$$
         echo "$log_prefix quota check failed (non-fatal), proceeding" >&2
+        echo "$log_prefix   └─ underlying error: ${quota_err:-<no stderr captured>}" >&2
         return 0
     fi
+    rm -f /tmp/quota-gate-err.$$ 2>/dev/null
 
     local five_hour_util seven_day_util session_ok weekly_ok
     five_hour_util=$(echo "$quota_json" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('five_hour',{}).get('utilization',0))" 2>/dev/null || echo "0")


### PR DESCRIPTION
## What

The non-fatal failure path in `quota-gate.sh` discarded stderr (`2>/dev/null`), so when the quota check fails we log only `quota check failed (non-fatal), proceeding` with no indication of *why*.

## Why

On alice-vm, the quota check failed 76× over a ~13h window (Jun 23 20:00 → Jun 24 09:25 UTC) then self-resolved. Because stderr was discarded, there's no trace of the underlying cause (network? auth? upstream TUI format change?). This made a real degradation undiagnosable after the fact.

## Change

Capture the underlying stderr and log it on a continuation line:
```
[quota-gate] quota check failed (non-fatal), proceeding
[quota-gate]   └─ underlying error: <stderr>
```

The first line **keeps ending in `proceeding`** so the standup health-count grep (anchored on `proceeding$` in alice's `agent-standup.sh`) still matches exactly one line per failure. Verified the anchor still matches and the error line renders correctly.

Fail-open behavior is unchanged (still `return 0`).