### PR TITLE
fix(activity-gate): seed notifications on first sight to stop noop storms

### DIFF
--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -952,7 +952,9 @@ check_notifications() {
 
     # Cap emitted notifications per run to avoid flooding the dispatcher when
     # a filter change (e.g. adding new reasons) unlocks a large backlog.
-    # Only emitted notifications get state files — unemitted ones retry next run.
+    # First-seen notifications are always seeded (state written, not emitted).
+    # The cap only gates emit-eligible items (strictly-newer updated_at): those
+    # skipped by the cap get neither emitted nor persisted, so they retry next run.
     local max_notif_per_run=5
 
     # Notification state files store the most recently seen `updated_at`. GitHub

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -977,9 +977,17 @@ check_notifications() {
             state_file="$STATE_DIR/notif-${notif_id}.state"
             prior=""
             [ -f "$state_file" ] && prior=$(cat "$state_file" 2>/dev/null || true)
-            # Re-emit if no state file yet OR stored timestamp is older than current.
-            # String comparison works on ISO-8601 timestamps.
-            if [ -z "$prior" ] || [ "$prior" \< "$notif_updated" ]; then
+            # Seed-on-first-sight: when there's no prior state (first run, or after the
+            # state dir is reset/cleaned), record the timestamp but do NOT emit. This
+            # matches the documented contract ("On first run, all items are seeded but
+            # NOT reported") and every other check here (check_pr_updates,
+            # check_greptile_scores). Without it, a wiped state dir makes the whole
+            # unread backlog look "new" and fires a noop session investigating already-
+            # resolved threads. Only a strictly-newer updated_at (genuine follow-up
+            # activity) emits. String comparison works on ISO-8601 timestamps.
+            if [ -z "$prior" ]; then
+                printf '%s' "$notif_updated" > "$state_file"
+            elif [ "$prior" \< "$notif_updated" ]; then
                 _notif_emitted=$((_notif_emitted + 1))
                 if [ "$_notif_emitted" -le "$max_notif_per_run" ]; then
                     # Emit first so a jq failure leaves the state file untouched and the
@@ -999,7 +1007,12 @@ check_notifications() {
             state_file="$STATE_DIR/notif-${notif_id}.state"
             prior=""
             [ -f "$state_file" ] && prior=$(cat "$state_file" 2>/dev/null || true)
-            if [ -z "$prior" ] || [ "$prior" \< "$notif_updated" ]; then
+            # Seed-on-first-sight (see jsonl branch above for rationale): a first-seen
+            # notification is recorded but not counted, so a reset state dir doesn't
+            # report the whole unread backlog as "new" and trigger a noop session.
+            if [ -z "$prior" ]; then
+                printf '%s' "$notif_updated" > "$state_file"
+            elif [ "$prior" \< "$notif_updated" ]; then
                 printf '%s' "$notif_updated" > "$state_file"
                 new_count=$((new_count + 1))
             fi


### PR DESCRIPTION
## Problem

`check_notifications` reported **every first-seen notification** as actionable "new" work — unlike `check_pr_updates` and `check_greptile_scores`, which seed-on-first-sight and only report on a *subsequent* change. This violates the script's own documented contract (header: *"On first run, all items are seeded (state created) but NOT reported — only changes after the first run trigger output"*).

### Impact

The state dir resets in normal operation — a fresh dir, or after the routine 14-day cleanup of `*.state` files. On the next run, the **entire unread notification backlog** is reported as actionable. In the case that surfaced this (Alice's presession gate), that was **41 stale `author`/`mention` notifications on already-merged PRs**.

The autonomous runner treats any gate exit-0 as "work found", so this fired a session that then **noop'd** investigating long-resolved threads — a direct, repeating noop driver tied to state-dir lifecycle rather than any real activity.

## Fix

When there is no prior state for a notification, record its `updated_at` but **do not emit/count it**. Only a strictly-newer `updated_at` (genuine follow-up activity on the thread) emits. Applied to both `jsonl` and `markdown` output modes. No change to the reason filter or any other check.

## Verification

```
Run 1 (fresh state dir):   seeds 41 notif state files, emits 0 notifications
Run 2 (no advance):        emits 0 notifications (exit 1)
Run 3 (one ts rolled back): emits exactly 1 notification (genuine activity still fires)
```

`shellcheck` clean; pre-commit passed.

This is shared infra Bob's monitoring uses too, so the seed-on-first-sight consistency benefits both agents.