### PR TITLE
fix(gptodo): strip stale next_action/waiting fields on terminal transition

### DIFF
--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -1827,6 +1827,16 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask):
             # and full ISO datetime via datetime.fromisoformat().
             post.metadata["waiting_since"] = _dt.now(_tz.utc).isoformat(timespec="seconds")
 
+        # Strip now-stale actionable/blocker metadata when the edit lands the task
+        # in a terminal state (TASKS.md best-practice #7: terminal tasks must not
+        # keep next_action/waiting_for/waiting_since/wait). Recurring tasks reset to
+        # todo further below and must keep these fields, so skip when recur is set.
+        # tracking_issue / upstream_coordination_id are intentionally preserved for
+        # permanent traceability.
+        if post.metadata.get("state") in ("done", "cancelled") and not post.metadata.get("recur"):
+            for _stale_field in ("next_action", "waiting_for", "waiting_since", "wait"):
+                post.metadata.pop(_stale_field, None)
+
         # Save changes
         with open(task.path, "w") as f:
             f.write(frontmatter.dumps(post))

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -1833,7 +1833,11 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask):
         # todo further below and must keep these fields, so skip when recur is set.
         # tracking_issue / upstream_coordination_id are intentionally preserved for
         # permanent traceability.
-        if post.metadata.get("state") in ("done", "cancelled") and not post.metadata.get("recur"):
+        # cancelled is terminal regardless of recur; done skips cleanup only when recurring
+        # (recurrence reset below handles it).
+        if post.metadata.get("state") == "cancelled" or (
+            post.metadata.get("state") == "done" and not post.metadata.get("recur")
+        ):
             for _stale_field in ("next_action", "waiting_for", "waiting_since", "wait"):
                 post.metadata.pop(_stale_field, None)
 

--- a/packages/gptodo/tests/test_edit_terminal_cleanup.py
+++ b/packages/gptodo/tests/test_edit_terminal_cleanup.py
@@ -83,6 +83,21 @@ def test_cancelled_strips_waiting_fields(tmp_path: Path, monkeypatch) -> None:
         assert field not in meta
 
 
+def test_recurring_cancelled_strips_fields(tmp_path: Path, monkeypatch) -> None:
+    """Recurring cancelled is terminal — stale fields must be stripped."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "recurring.md").write_text(RECURRING_TASK)
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(cli, ["edit", "recurring", "--set", "state", "cancelled"])
+    assert result.exit_code == 0, result.output
+
+    meta = _meta(tasks_dir, "recurring")
+    assert meta["state"] == "cancelled"
+    assert "next_action" not in meta
+
+
 def test_recurring_done_keeps_fields(tmp_path: Path, monkeypatch) -> None:
     """Recurring tasks reset to todo and must retain next_action."""
     tasks_dir = tmp_path / "tasks"

--- a/packages/gptodo/tests/test_edit_terminal_cleanup.py
+++ b/packages/gptodo/tests/test_edit_terminal_cleanup.py
@@ -1,0 +1,99 @@
+"""Tests for stripping stale actionable/blocker metadata on terminal transitions.
+
+When `gptodo edit --set state done|cancelled` lands a task in a terminal state,
+the now-stale `next_action`, `waiting_for`, `waiting_since`, and `wait` fields
+should be removed (TASKS.md best-practice #7). `tracking_issue` and
+`upstream_coordination_id` are preserved for permanent traceability, and
+recurring tasks (which reset to todo) keep their fields.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from gptodo.cli import cli
+from gptodo.utils import load_tasks
+
+ACTIVE_WITH_NEXT_ACTION = """\
+---
+state: active
+created: 2026-06-01T00:00:00+00:00
+next_action: Run the thing
+tracking_issue: https://github.com/org/repo/issues/1
+---
+# Active Task
+"""
+
+WAITING_TASK = """\
+---
+state: waiting
+created: 2026-06-01T00:00:00+00:00
+waiting_for: some-dependency
+waiting_since: 2026-06-01
+wait: 2026-06-20T00:00:00+00:00
+---
+# Waiting Task
+"""
+
+RECURRING_TASK = """\
+---
+state: active
+created: 2026-06-01T00:00:00+00:00
+next_action: Do the recurring thing
+recur: 7d
+---
+# Recurring Task
+"""
+
+
+def _meta(tasks_dir: Path, task_id: str) -> dict:
+    return next(t for t in load_tasks(tasks_dir) if t.id == task_id).metadata
+
+
+def test_done_strips_next_action_keeps_tracking_issue(tmp_path: Path, monkeypatch) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "my-task.md").write_text(ACTIVE_WITH_NEXT_ACTION)
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(cli, ["edit", "my-task", "--set", "state", "done"])
+    assert result.exit_code == 0, result.output
+
+    meta = _meta(tasks_dir, "my-task")
+    assert meta["state"] == "done"
+    assert "next_action" not in meta
+    # Traceability fields are preserved.
+    assert meta["tracking_issue"] == "https://github.com/org/repo/issues/1"
+
+
+def test_cancelled_strips_waiting_fields(tmp_path: Path, monkeypatch) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "blocked.md").write_text(WAITING_TASK)
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(cli, ["edit", "blocked", "--set", "state", "cancelled"])
+    assert result.exit_code == 0, result.output
+
+    meta = _meta(tasks_dir, "blocked")
+    assert meta["state"] == "cancelled"
+    for field in ("waiting_for", "waiting_since", "wait"):
+        assert field not in meta
+
+
+def test_recurring_done_keeps_fields(tmp_path: Path, monkeypatch) -> None:
+    """Recurring tasks reset to todo and must retain next_action."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "recurring.md").write_text(RECURRING_TASK)
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(cli, ["edit", "recurring", "--set", "state", "done"])
+    assert result.exit_code == 0, result.output
+
+    meta = _meta(tasks_dir, "recurring")
+    # Recur logic resets to todo and keeps next_action.
+    assert meta["state"] == "todo"
+    assert meta["next_action"] == "Do the recurring thing"


### PR DESCRIPTION
## Problem

When `gptodo edit --set state done|cancelled` lands a task in a terminal state, the now-stale `next_action`, `waiting_for`, `waiting_since`, and `wait` fields linger. TASKS.md best-practice #7 says terminal tasks must not carry actionable/blocker metadata. These leftovers repeatedly trip the `workspace-invariants` `task-terminal-no-next-action` check — and because that invariant's `--fix` is not run on any timer, the warnings accumulate until a session hand-cleans them (which is what surfaced this).

## What changed

In `gptodo edit`, after applying changes and before saving, when the resulting state is terminal and the task is **not** recurring, pop `next_action`/`waiting_for`/`waiting_since`/`wait`. This mirrors the existing `waiting_for` clearing already done in the unblock/watch paths.

- **Recurring tasks** reset to `todo` further down and legitimately keep these fields, so the cleanup is guarded on `recur` being unset.
- `tracking_issue` / `upstream_coordination_id` are intentionally **preserved** for permanent traceability (per best-practice #7).

## Tests

New `tests/test_edit_terminal_cleanup.py`:
- `done` strips `next_action`, keeps `tracking_issue`
- `cancelled` strips `waiting_for`/`waiting_since`/`wait`
- recurring `done` resets to `todo` and keeps `next_action`

All 3 pass; 52 existing edit/recur/wait tests still green. `ruff check` + `ruff format` clean.

Co-authored-by: Bob <bob@superuserlabs.org>