### PR TITLE
fix(lessons-extras): exclude TODO.md and lesson-template.md from discovery

### DIFF
--- a/packages/gptme-lessons-extras/src/gptme_lessons_extras/discovery.py
+++ b/packages/gptme-lessons-extras/src/gptme_lessons_extras/discovery.py
@@ -16,6 +16,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Set, Tuple
 
+from gptme_lessons_extras.similarity import NON_LESSON_FILES
+
 # Try importing sklearn, but provide fallback
 try:
     from sklearn.feature_extraction.text import TfidfVectorizer  # type: ignore
@@ -25,12 +27,6 @@ try:
 except ImportError:
     SKLEARN_AVAILABLE = False
     print("Warning: scikit-learn not available. Using simpler similarity metrics.")
-
-
-# Files that live under lessons/ but are not themselves lessons; they must be
-# excluded from recommendation, similarity, and duplicate scoring. Kept in sync
-# with similarity.py's NON_LESSON_FILES.
-NON_LESSON_FILES = ("README.md", "TODO.md", "lesson-template.md")
 
 
 @dataclass

--- a/packages/gptme-lessons-extras/src/gptme_lessons_extras/discovery.py
+++ b/packages/gptme-lessons-extras/src/gptme_lessons_extras/discovery.py
@@ -27,6 +27,12 @@ except ImportError:
     print("Warning: scikit-learn not available. Using simpler similarity metrics.")
 
 
+# Files that live under lessons/ but are not themselves lessons; they must be
+# excluded from recommendation, similarity, and duplicate scoring. Kept in sync
+# with similarity.py's NON_LESSON_FILES.
+NON_LESSON_FILES = ("README.md", "TODO.md", "lesson-template.md")
+
+
 @dataclass
 class LessonFeatures:
     """Extracted features from a lesson file."""
@@ -282,7 +288,7 @@ class LessonDiscovery:
         # Score all lessons
         scores = []
         for lesson_file in self.lessons_dir.rglob("*.md"):
-            if lesson_file.name == "README.md":
+            if lesson_file.name in NON_LESSON_FILES:
                 continue
 
             features = self.extract_features(lesson_file)
@@ -401,7 +407,7 @@ class LessonDiscovery:
         # Compare with all other lessons
         results = []
         for lesson_file in self.lessons_dir.rglob("*.md"):
-            if lesson_file.name == "README.md" or lesson_file == target_path:
+            if lesson_file.name in NON_LESSON_FILES or lesson_file == target_path:
                 continue
 
             compare_features = self.extract_features(lesson_file)
@@ -452,7 +458,7 @@ class LessonDiscovery:
         processed = set()
 
         lesson_files = [
-            f for f in self.lessons_dir.rglob("*.md") if f.name != "README.md"
+            f for f in self.lessons_dir.rglob("*.md") if f.name not in NON_LESSON_FILES
         ]
 
         for i, lesson_a in enumerate(lesson_files):

--- a/packages/gptme-lessons-extras/tests/test_discovery.py
+++ b/packages/gptme-lessons-extras/tests/test_discovery.py
@@ -124,6 +124,61 @@ def test_recommend_excludes_non_lesson_files(tmp_path: Path) -> None:
     assert "README" not in ids
 
 
+def test_find_similar_excludes_non_lesson_files(tmp_path: Path) -> None:
+    """Non-lesson files must not appear in find_similar results."""
+    lessons_dir = tmp_path / "lessons"
+    # Target lesson
+    _write_lesson(lessons_dir / "tools" / "reference.md", "Reference")
+    # A similar real lesson (same template → high text similarity)
+    _write_lesson(lessons_dir / "tools" / "similar.md", "Similar")
+    # Non-lesson files sharing the lesson directory
+    _write_lesson(lessons_dir / "templates" / "lesson-template.md", "Template")
+    _write_lesson(lessons_dir / "TODO.md", "Todo")
+    _write_lesson(lessons_dir / "README.md", "Readme")
+
+    discovery = LessonDiscovery(
+        lessons_dir=lessons_dir, history_dir=tmp_path / ".lessons-history"
+    )
+
+    results = discovery.find_similar("reference", threshold=0.0)
+
+    result_ids = [r.lesson_b for r in results]
+    assert "similar" in result_ids
+    assert "lesson-template" not in result_ids
+    assert "TODO" not in result_ids
+    assert "README" not in result_ids
+
+
+def test_find_all_duplicates_excludes_non_lesson_files(tmp_path: Path) -> None:
+    """Non-lesson files must not appear in find_all_duplicates results."""
+    lessons_dir = tmp_path / "lessons"
+    # Two lessons with identical template → high text similarity → duplicate
+    _write_lesson(lessons_dir / "tools" / "dup-a.md", "DupA")
+    _write_lesson(lessons_dir / "tools" / "dup-b.md", "DupB")
+    # Non-lesson files
+    _write_lesson(lessons_dir / "templates" / "lesson-template.md", "Template")
+    _write_lesson(lessons_dir / "TODO.md", "Todo")
+    _write_lesson(lessons_dir / "README.md", "Readme")
+
+    discovery = LessonDiscovery(
+        lessons_dir=lessons_dir, history_dir=tmp_path / ".lessons-history"
+    )
+
+    results = discovery.find_all_duplicates(threshold=0.0)
+
+    # At least one real-lesson pair should be found
+    assert len(results) >= 1
+    result_ids = set()
+    for a, b, _ in results:
+        result_ids.add(a)
+        result_ids.add(b)
+    assert "dup-a" in result_ids
+    assert "dup-b" in result_ids
+    assert "lesson-template" not in result_ids
+    assert "TODO" not in result_ids
+    assert "README" not in result_ids
+
+
 def test_recommend_uses_file_recency_when_metrics_are_missing(tmp_path: Path) -> None:
     """Recent files should get a freshness boost even without metrics data."""
     lessons_dir = tmp_path / "lessons" / "tools"

--- a/packages/gptme-lessons-extras/tests/test_discovery.py
+++ b/packages/gptme-lessons-extras/tests/test_discovery.py
@@ -102,6 +102,28 @@ def test_recommend_uses_loaded_metrics_scores(tmp_path: Path) -> None:
     assert recommendations[1].adoption_score == 0.0
 
 
+def test_recommend_excludes_non_lesson_files(tmp_path: Path) -> None:
+    """README, TODO, and lesson-template must not be scored as real lessons."""
+    lessons_dir = tmp_path / "lessons"
+    _write_lesson(lessons_dir / "tools" / "real.md", "Real")
+    # Non-lesson files that share the lesson keyword shape and would otherwise
+    # be picked up by rglob("*.md") and scored as lessons.
+    _write_lesson(lessons_dir / "templates" / "lesson-template.md", "Template")
+    _write_lesson(lessons_dir / "TODO.md", "Todo")
+    _write_lesson(lessons_dir / "README.md", "Readme")
+
+    discovery = LessonDiscovery(
+        lessons_dir=lessons_dir, history_dir=tmp_path / ".lessons-history"
+    )
+
+    ids = [rec.lesson_id for rec in discovery.recommend(keywords=["shell"], top_k=10)]
+
+    assert "real" in ids
+    assert "lesson-template" not in ids
+    assert "TODO" not in ids
+    assert "README" not in ids
+
+
 def test_recommend_uses_file_recency_when_metrics_are_missing(tmp_path: Path) -> None:
     """Recent files should get a freshness boost even without metrics data."""
     lessons_dir = tmp_path / "lessons" / "tools"


### PR DESCRIPTION
## Problem

`LessonDiscovery` iterates lessons with `rglob("*.md")` but filtered only `README.md` at its three scoring sites. So `lessons/templates/lesson-template.md` (and any `TODO.md`) were treated as **real lessons** — they got scored in recommendations, compared in similarity, and flagged in duplicate detection. `similarity.py` already excludes all three via its `NON_LESSON_FILES` tuple; `discovery.py` had drifted out of sync.

Verified live: `lessons/templates/lesson-template.md` exists in the workspace, and before this fix `discovery.recommend()` returns it as a lesson.

## Fix

- Add a module-level `NON_LESSON_FILES` constant to `discovery.py` (kept in sync with `similarity.py`'s canonical tuple).
- Use it at all three filter sites (was three inline `== "README.md"` checks).

## Test

Added `test_recommend_excludes_non_lesson_files` — asserts `README`/`TODO`/`lesson-template` are excluded while a real lesson is kept. Confirmed RED before the fix, GREEN after.

```
4 passed in 1.00s   # test_discovery.py
```

Note: `test_similarity_scores.py::TestSelectBestLesson::test_falls_back_to_mtime_when_no_scores` fails on master independently of this change (deterministic, untouched code) — out of scope here.

Co-authored-by: Bob <bob@superuserlabs.org>