### PR TITLE
fix(lessons-extras): deterministic mtime in select_best_lesson fallback test

### DIFF
--- a/packages/gptme-lessons-extras/tests/test_similarity_scores.py
+++ b/packages/gptme-lessons-extras/tests/test_similarity_scores.py
@@ -1,5 +1,6 @@
 """Tests for lesson similarity score parsing."""
 
+import os
 from pathlib import Path
 from textwrap import dedent
 
@@ -344,8 +345,12 @@ class TestSelectBestLesson:
             No scores.
             """,
         )
-        # Ensure mtime ordering
-        newer.touch()  # touch to make newer the most recent
+        # Set explicit, distinct mtimes. Relying on write order + touch() is
+        # flaky: consecutive writes can land in the same filesystem mtime tick,
+        # leaving older/newer with identical mtimes. select_best_lesson's stable
+        # sort then preserves cluster order and returns "Older".
+        older_mtime = older.stat().st_mtime
+        os.utime(newer, (older_mtime + 10, older_mtime + 10))
 
         cluster = [_info(older), _info(newer)]
         chosen = select_best_lesson(cluster)


### PR DESCRIPTION
## Problem

`test_falls_back_to_mtime_when_no_scores` fails **deterministically** on master:
the test expects `select_best_lesson` to return "Newer" but it returns "Older".

## Root cause

The test established mtime ordering by write-order + `newer.touch()`. Consecutive `write_text` calls can land in the **same filesystem mtime tick** — verified empirically that `older.md` and `newer_lesson.md` get identical `st_mtime_ns`, and `touch()` doesn't bump it because the wall clock hasn't advanced. With equal mtimes, `select_best_lesson`'s stable sort preserves cluster order `[older, newer]` and returns the first element ("Older").

The **implementation is correct** (newest mtime wins); only the test's timing-dependent mtime setup was at fault.

## Fix

Set explicit, distinct mtimes via `os.utime()` instead of relying on wall-clock timing. Removes the flake entirely.

## Verification

```
17 passed in 0.25s
```
(full `test_similarity_scores.py`, including the other mtime-dependent test `test_score_beats_mtime`)

Found incidentally while shipping #1166 (out of scope there).