### PR TITLE
test(gptme-codegraph): cover SQLite search-document cache helpers

### DIFF
--- a/packages/gptme-codegraph/tests/conftest.py
+++ b/packages/gptme-codegraph/tests/conftest.py
@@ -15,6 +15,9 @@ def isolated_cache_dir(tmp_path, monkeypatch):
     monkeypatch.setattr(commit_map, "_CACHE_DIR", tmp_path / "gptme-codegraph-cache")
 
 
+_TREESITTER_FREE = {"test_search_cache"}
+
+
 def pytest_collection_modifyitems(config, items):
     try:
         import tree_sitter  # type: ignore[import-untyped]  # noqa: F401
@@ -24,5 +27,5 @@ def pytest_collection_modifyitems(config, items):
             reason="tree-sitter not installed — run: uv sync --all-extras"
         )
         for item in items:
-            if "codegraph" in str(item.path):
+            if "codegraph" in str(item.path) and item.path.stem not in _TREESITTER_FREE:
                 item.add_marker(skip_mark)

--- a/packages/gptme-codegraph/tests/test_search_cache.py
+++ b/packages/gptme-codegraph/tests/test_search_cache.py
@@ -1,0 +1,147 @@
+"""Tests for the SQLite search-document cache helpers in search.py.
+
+These cover ``save_search_documents`` / ``load_search_documents`` /
+``_ensure_search_tables`` — the wired-but-not-yet-integrated cache layer
+(see the ``TODO(phase-2)`` in search.py). Locking the round-trip contract
+now means the eventual CLI/MCP integration can't silently regress field
+fidelity, directory isolation, or replace-on-resave semantics.
+"""
+
+import sqlite3
+
+from gptme_codegraph.search import (
+    SearchDocument,
+    load_search_documents,
+    save_search_documents,
+)
+
+
+def _doc(qualified_id: str, **overrides) -> SearchDocument:
+    base = dict(
+        qualified_id=qualified_id,
+        kind="function",
+        name=qualified_id.rsplit(".", 1)[-1],
+        file="pkg/mod.py",
+        start_line=10,
+        end_line=20,
+        parent_class=None,
+        docstring="does a thing",
+        calls=["helper", "other"],
+        snippet="def f():\n    return helper()",
+    )
+    base.update(overrides)
+    return SearchDocument(**base)
+
+
+def _conn() -> sqlite3.Connection:
+    return sqlite3.connect(":memory:")
+
+
+class TestSearchDocumentCacheRoundtrip:
+    def test_roundtrip_preserves_all_fields(self):
+        conn = _conn()
+        doc = _doc(
+            "pkg.mod.f",
+            parent_class="Klass",
+            docstring="multi\nline doc",
+            calls=["a", "b", "c"],
+            snippet="line1\nline2",
+        )
+        save_search_documents(conn, "/proj", [doc])
+        loaded = load_search_documents(conn, "/proj")
+
+        assert len(loaded) == 1
+        got = loaded[0]
+        # Field-by-field: a json (de)serialization bug or a constructor
+        # argument-order slip would surface here.
+        assert got.qualified_id == doc.qualified_id
+        assert got.kind == doc.kind
+        assert got.name == doc.name
+        assert got.file == doc.file
+        assert got.start_line == doc.start_line
+        assert got.end_line == doc.end_line
+        assert got.parent_class == doc.parent_class
+        assert got.docstring == doc.docstring
+        assert got.calls == doc.calls
+        assert got.snippet == doc.snippet
+
+    def test_roundtrip_multiple_docs(self):
+        conn = _conn()
+        docs = [_doc(f"pkg.mod.f{i}", start_line=i) for i in range(5)]
+        save_search_documents(conn, "/proj", docs)
+        loaded = load_search_documents(conn, "/proj")
+
+        assert {d.qualified_id for d in loaded} == {d.qualified_id for d in docs}
+
+    def test_defaults_survive_roundtrip(self):
+        # parent_class=None, empty calls — make sure load's .get() defaults
+        # don't corrupt an explicitly-empty document.
+        conn = _conn()
+        doc = _doc(
+            "pkg.mod.bare", parent_class=None, docstring="", calls=[], snippet=""
+        )
+        save_search_documents(conn, "/proj", [doc])
+        got = load_search_documents(conn, "/proj")[0]
+
+        assert got.parent_class is None
+        assert got.docstring == ""
+        assert got.calls == []
+        assert got.snippet == ""
+
+
+class TestSearchDocumentCacheSemantics:
+    def test_load_empty_returns_empty_list(self):
+        conn = _conn()
+        # _ensure_search_tables must create the table on the read path too,
+        # so loading from a fresh DB yields [] rather than raising.
+        assert load_search_documents(conn, "/never-saved") == []
+
+    def test_resave_replaces_directory_contents(self):
+        conn = _conn()
+        save_search_documents(
+            conn, "/proj", [_doc("pkg.mod.old1"), _doc("pkg.mod.old2")]
+        )
+        save_search_documents(conn, "/proj", [_doc("pkg.mod.new")])
+
+        loaded = load_search_documents(conn, "/proj")
+        assert [d.qualified_id for d in loaded] == ["pkg.mod.new"]
+
+    def test_directories_are_isolated(self):
+        conn = _conn()
+        save_search_documents(conn, "/a", [_doc("a.mod.f")])
+        save_search_documents(conn, "/b", [_doc("b.mod.f")])
+
+        assert [d.qualified_id for d in load_search_documents(conn, "/a")] == [
+            "a.mod.f"
+        ]
+        assert [d.qualified_id for d in load_search_documents(conn, "/b")] == [
+            "b.mod.f"
+        ]
+
+    def test_content_hash_is_populated_and_stable(self):
+        conn = _conn()
+        doc = _doc("pkg.mod.f")
+        save_search_documents(conn, "/proj", [doc])
+        first = conn.execute(
+            "SELECT content_hash FROM search_documents WHERE qualified_id = ?",
+            (doc.qualified_id,),
+        ).fetchone()[0]
+
+        assert first and len(first) == 16  # 16-char truncated sha256
+
+        # Re-saving identical content yields the same hash (deterministic).
+        save_search_documents(conn, "/proj", [doc])
+        second = conn.execute(
+            "SELECT content_hash FROM search_documents WHERE qualified_id = ?",
+            (doc.qualified_id,),
+        ).fetchone()[0]
+        assert first == second
+
+    def test_content_hash_changes_with_content(self):
+        conn = _conn()
+        save_search_documents(conn, "/proj", [_doc("pkg.mod.f", docstring="v1")])
+        h1 = conn.execute("SELECT content_hash FROM search_documents").fetchone()[0]
+        save_search_documents(conn, "/proj", [_doc("pkg.mod.f", docstring="v2")])
+        h2 = conn.execute("SELECT content_hash FROM search_documents").fetchone()[0]
+
+        assert h1 != h2

--- a/packages/gptme-codegraph/tests/test_search_cache.py
+++ b/packages/gptme-codegraph/tests/test_search_cache.py
@@ -140,8 +140,14 @@ class TestSearchDocumentCacheSemantics:
     def test_content_hash_changes_with_content(self):
         conn = _conn()
         save_search_documents(conn, "/proj", [_doc("pkg.mod.f", docstring="v1")])
-        h1 = conn.execute("SELECT content_hash FROM search_documents").fetchone()[0]
+        h1 = conn.execute(
+            "SELECT content_hash FROM search_documents WHERE directory = ? AND qualified_id = ?",
+            ("/proj", "pkg.mod.f"),
+        ).fetchone()[0]
         save_search_documents(conn, "/proj", [_doc("pkg.mod.f", docstring="v2")])
-        h2 = conn.execute("SELECT content_hash FROM search_documents").fetchone()[0]
+        h2 = conn.execute(
+            "SELECT content_hash FROM search_documents WHERE directory = ? AND qualified_id = ?",
+            ("/proj", "pkg.mod.f"),
+        ).fetchone()[0]
 
         assert h1 != h2


### PR DESCRIPTION
## Problem
The SQLite search-document cache layer in `gptme_codegraph/search.py` — `save_search_documents`, `load_search_documents`, `_ensure_search_tables` — had **zero** test coverage. These are the wired-but-not-yet-integrated helpers flagged by the `TODO(phase-2)` comment ("Cache helpers are wired but not yet integrated into the CLI search path... will be connected once the local embedding backend lands").

## What this does
Adds `tests/test_search_cache.py` (test-only, no behavior change) to lock the cache round-trip contract **before** that integration lands, so it can't silently regress:

- field-by-field round-trip fidelity, including `None`/empty defaults (`parent_class=None`, empty `calls`/`docstring`/`snippet`)
- directory isolation + replace-on-resave semantics (save replaces a directory's docs)
- empty-load creates the table on the read path (returns `[]` rather than raising)
- `content_hash` is populated (16-char truncated sha256), deterministic across identical re-saves, and changes when content changes

## Scope
- **In:** regression tests for the existing cache helpers, as-is.
- **Out (explicitly):** integrating the cache into the CLI/MCP search path — that's the deferred phase-2 work gated on the embedding backend; this PR respects that deferral.

## Verification
8/8 passing in the full env (`uv sync --all-extras`); non-vacuity confirmed by mutation (corrupting `load`'s field mapping fails the round-trip test). The package conftest skips when tree-sitter isn't installed, so CI's full-extras run exercises them.