### PR TITLE
docs: add Ecosystem section with external projects and topic-based discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,32 @@ Standalone scripts for automation. See each directory's README for details.
 
 Shared lessons provide reusable prompts and workflow patterns. See [lessons/README.md](./lessons/README.md).
 
+## Ecosystem
+
+gptme has a broader ecosystem of standalone repos beyond gptme-contrib.
+
+### External Projects
+
+| Project | Description | Status |
+|---------|-------------|--------|
+| [gptme-rag](https://github.com/gptme/gptme-rag) | Local RAG — semantic document search as a CLI or gptme tool | Active |
+| [gptme-tauri](https://github.com/gptme/gptme-tauri) | Desktop app built with Tauri | Archived |
+| [gptme-webui](https://github.com/gptme/gptme-webui) | Web UI for gptme | Archived |
+
+### Discover More
+
+To make your own plugin or skill discoverable, add a GitHub topic to your repo:
+
+| Topic | For |
+|-------|-----|
+| `gptme-plugin` | Python plugin packages |
+| `gptme-skill` | SKILL.md skill bundles |
+| `gptme-mcp-server` | MCP servers for gptme |
+
+```bash
+gh repo edit owner/your-repo --add-topic gptme-plugin
+```
+
 ## Dependencies
 
 Some scripts require additional dependencies:


### PR DESCRIPTION
## Summary

- Adds a new **Ecosystem** section to the README covering external gptme repos not included in gptme-contrib
- Lists `gptme-rag` (active), `gptme-tauri` (archived), and `gptme-webui` (archived) with their status
- Documents the GitHub topic convention (`gptme-plugin`, `gptme-skill`, `gptme-mcp-server`) for community discovery
- Consolidates the plugin/skill discovery content previously only in [registry.gptme.org](https://github.com/gptme/registry.gptme.org), enabling that repo to be archived

## Context

Erik confirmed (2026-06-18) that ecosystem-wide discovery should live on the gptme-contrib site rather than the separate registry.gptme.org repo. This PR covers the unique content from registry.gptme.org so it can be safely archived afterward.

## Test plan
- [ ] README renders correctly on GitHub
- [ ] All external repo links are valid (gptme-rag is active; tauri/webui are archived)
- [ ] No existing content removed