### PR TITLE
feat(dashboard): add Community Extensions section with GitHub topic-based discovery

### DIFF
--- a/.github/workflows/community-plugins.yml
+++ b/.github/workflows/community-plugins.yml
@@ -1,0 +1,32 @@
+name: Update Community Plugins
+
+on:
+  schedule:
+    - cron: '0 4 * * 1'  # Monday 04:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch community plugins
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 scripts/fetch-community-plugins.py
+
+      - name: Commit if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add state/community_plugins.json
+          if git diff --cached --quiet; then
+            echo "No changes to community_plugins.json"
+          else
+            git commit -m "chore(community-plugins): weekly refresh"
+            git push
+          fi

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -9,6 +9,7 @@ on:
       - 'packages/**'
       - 'skills/**'
       - 'gptme.toml'
+      - 'state/community_plugins.json'
       - '.github/workflows/dashboard.yml'
   workflow_dispatch:
 

--- a/packages/gptme-dashboard/src/gptme_dashboard/generate.py
+++ b/packages/gptme-dashboard/src/gptme_dashboard/generate.py
@@ -1028,6 +1028,41 @@ def scan_skills(workspace: Path, source: str = "") -> list[dict]:
     return skills
 
 
+def scan_community_plugins(workspace: Path) -> list[dict]:
+    """Load community/external gptme extensions from state/community_plugins.json.
+
+    Returns an empty list when the file is missing (graceful degradation for
+    workspaces that don't run the fetch script).
+
+    The JSON file has this shape::
+
+        {
+            "fetched_at": "2026-06-29T00:00:00Z",
+            "entries": [
+                {
+                    "name": "owner/repo",
+                    "type": "plugin",          # plugin | skill | mcp-server
+                    "description": "...",
+                    "url": "https://github.com/owner/repo",
+                    "stars": 42,
+                    "language": "Python",
+                    "topics": ["gptme-plugin"]
+                },
+                ...
+            ]
+        }
+    """
+    json_path = workspace / "state" / "community_plugins.json"
+    if not json_path.exists():
+        return []
+    try:
+        data = json.loads(json_path.read_text())
+        return list(data.get("entries", []))
+    except Exception as exc:
+        logger.warning("Failed to load community_plugins.json: %s", exc)
+        return []
+
+
 def scan_readme(workspace: Path) -> dict:
     """Read the workspace README.md for display as an About section.
 
@@ -1560,6 +1595,7 @@ def collect_workspace_data(
     plugins = scan_plugins(workspace, enabled_plugins=enabled_plugins)
     packages = scan_packages(workspace)
     skills = scan_skills(workspace)
+    community_plugins = scan_community_plugins(workspace)
 
     # Scan submodules for additional content
     submodules = detect_submodules(workspace)
@@ -1693,6 +1729,7 @@ def collect_workspace_data(
         "task_states": task_states,
         "total_summaries": total_summaries_count,
         "lesson_categories": lesson_categories,
+        "total_community_plugins": len(community_plugins),
     }
 
     workspace_name = config.get("agent_name", workspace.resolve().name)
@@ -1717,6 +1754,7 @@ def collect_workspace_data(
         "submodules": submodule_names,
         "sources": sources,
         "kpi": kpi,
+        "community_plugins": community_plugins,
     }
 
 

--- a/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
+++ b/packages/gptme-dashboard/src/gptme_dashboard/templates/index.html
@@ -615,6 +615,7 @@ tr:hover { background: var(--accent-dim); }
       <div class="dashboard-nav-links">
         <a href="#packages"><span>Packages</span><span class="nav-count">{{ stats.total_packages }}</span></a>
         <a href="#plugins"><span>Plugins</span><span class="nav-count">{{ stats.total_plugins }}</span></a>
+        {% if community_plugins %}<a href="#community-plugins"><span>Community</span><span class="nav-count">{{ stats.total_community_plugins }}</span></a>{% endif %}
         <a href="#guidance"><span>Lessons &amp; Skills</span><span class="nav-count">{{ stats.total_guidance }}</span></a>
       </div>
     </div>
@@ -943,6 +944,31 @@ tr:hover { background: var(--accent-dim); }
     </table>
   </section>
 </div>
+
+<!-- Community Extensions (third-party repos tagged with gptme topics) -->
+{% if community_plugins %}
+<section id="community-plugins">
+  <h2>Community Extensions <span class="count-badge">({{ community_plugins | length }})</span></h2>
+  <p style="color:var(--text-dim);font-size:0.85rem;margin:0.25rem 0 0.75rem">
+    Third-party repos tagged with <code>gptme-plugin</code>, <code>gptme-skill</code>, or <code>gptme-mcp-server</code> on GitHub.
+    To get listed, <a href="https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/classifying-your-repository-with-topics">add a topic</a> to your repo.
+  </p>
+  <table>
+    <thead><tr><th>Repo</th><th>Type</th><th>Language</th><th>⭐</th><th>Description</th></tr></thead>
+    <tbody>
+    {% for ext in community_plugins %}
+      <tr>
+        <td><strong><a href="{{ ext.url }}" target="_blank" rel="noopener">{{ ext.name }}</a></strong></td>
+        <td>{% for t in ext.topics %}<span class="tag">{{ t | replace("gptme-", "") }}</span> {% endfor %}</td>
+        <td>{{ ext.language or "" }}</td>
+        <td>{{ ext.stars or "" }}</td>
+        <td>{{ ext.description or "" }}</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</section>
+{% endif %}
 
 <!-- Lessons & Skills (reference — collapsed by default) -->
 <section id="guidance">

--- a/scripts/fetch-community-plugins.py
+++ b/scripts/fetch-community-plugins.py
@@ -49,14 +49,20 @@ def search_topic(topic: str) -> list[dict]:
     return items
 
 
-def fetch_all() -> list[dict]:
-    """Fetch all repos across all gptme topics, deduplicated by full_name."""
+def fetch_all() -> tuple[list[dict], list[str]]:
+    """Fetch all repos across all gptme topics, deduplicated by full_name.
+
+    Returns (entries, failed_topics) — failed_topics is non-empty when any
+    individual topic search raised an error (partial-failure case).
+    """
     seen: dict[str, dict] = {}
+    failed_topics: list[str] = []
     for topic in TOPICS:
         try:
             repos = search_topic(topic)
         except subprocess.CalledProcessError as exc:
             print(f"Warning: failed to search topic {topic}: {exc}", file=sys.stderr)
+            failed_topics.append(topic)
             continue
         for repo in repos:
             name = repo["full_name"]
@@ -80,7 +86,7 @@ def fetch_all() -> list[dict]:
             "topics": topics,
         }
         entries.append(entry)
-    return entries
+    return entries, failed_topics
 
 
 def main() -> int:
@@ -99,19 +105,19 @@ def main() -> int:
     args = parser.parse_args()
 
     print(f"Searching GitHub for topics: {', '.join(TOPICS)}", file=sys.stderr)
-    entries = fetch_all()
+    entries, failed_topics = fetch_all()
     print(f"Found {len(entries)} community repos", file=sys.stderr)
 
-    # Refuse to overwrite a non-empty file with an empty result set — all topic
-    # searches failing (rate-limit, auth expiry, outage) must not silently wipe
-    # the dashboard data.
-    if not entries and not args.dry_run and args.output.exists():
+    # Refuse to overwrite when any topic search failed (partial or total) and the
+    # previous file has entries — a partial failure silently drops repos that are
+    # exclusively tagged with the failing topic, which is just as bad as a total wipe.
+    if failed_topics and not args.dry_run and args.output.exists():
         try:
             prev = json.loads(args.output.read_text())
             if prev.get("entries"):
                 print(
-                    "Error: all searches returned 0 results but previous file has entries."
-                    " Refusing to overwrite — check GitHub API access.",
+                    f"Error: topic search(es) failed: {', '.join(failed_topics)}."
+                    " Refusing to overwrite previous data — check GitHub API access.",
                     file=sys.stderr,
                 )
                 return 1

--- a/scripts/fetch-community-plugins.py
+++ b/scripts/fetch-community-plugins.py
@@ -39,7 +39,14 @@ def search_topic(topic: str) -> list[dict]:
         check=True,
     )
     data: dict = json.loads(result.stdout)
-    return cast(list[dict], data.get("items", []))
+    items = cast(list[dict], data.get("items", []))
+    if len(items) >= 100:
+        print(
+            f"Warning: topic {topic!r} returned 100 results — may be truncated;"
+            " consider adding pagination if the ecosystem grows.",
+            file=sys.stderr,
+        )
+    return items
 
 
 def fetch_all() -> list[dict]:
@@ -94,6 +101,22 @@ def main() -> int:
     print(f"Searching GitHub for topics: {', '.join(TOPICS)}", file=sys.stderr)
     entries = fetch_all()
     print(f"Found {len(entries)} community repos", file=sys.stderr)
+
+    # Refuse to overwrite a non-empty file with an empty result set — all topic
+    # searches failing (rate-limit, auth expiry, outage) must not silently wipe
+    # the dashboard data.
+    if not entries and not args.dry_run and args.output.exists():
+        try:
+            prev = json.loads(args.output.read_text())
+            if prev.get("entries"):
+                print(
+                    "Error: all searches returned 0 results but previous file has entries."
+                    " Refusing to overwrite — check GitHub API access.",
+                    file=sys.stderr,
+                )
+                return 1
+        except (json.JSONDecodeError, KeyError):
+            pass
 
     output = {
         "fetched_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),

--- a/scripts/fetch-community-plugins.py
+++ b/scripts/fetch-community-plugins.py
@@ -30,33 +30,6 @@ EXCLUDE_NAMES = {"gptme/gptme-contrib"}
 DEFAULT_OUTPUT = Path(__file__).parent.parent / "state" / "community_plugins.json"
 
 
-def gh_api(path: str) -> dict | list:
-    """Call GitHub API via gh CLI."""
-    result = subprocess.run(
-        ["gh", "api", path, "--paginate"],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    # --paginate returns multiple JSON objects concatenated; wrap into array if needed
-    raw = result.stdout.strip()
-    # gh --paginate outputs valid JSON arrays that get concatenated, merge them
-    if raw.startswith("[") and raw.endswith("]"):
-        # single page or already merged
-        return cast(list, json.loads(raw))
-    # multiple pages: each line is a JSON array
-    merged: list = []
-    for line in raw.splitlines():
-        line = line.strip()
-        if line:
-            chunk = json.loads(line)
-            if isinstance(chunk, list):
-                merged.extend(chunk)
-            elif isinstance(chunk, dict):
-                merged.append(chunk)
-    return merged
-
-
 def search_topic(topic: str) -> list[dict]:
     """Search GitHub for repos with the given topic."""
     result = subprocess.run(
@@ -84,9 +57,7 @@ def fetch_all() -> list[dict]:
                 continue
             if name not in seen:
                 seen[name] = repo
-            else:
-                # merge topics from duplicate hits
-                seen[name].setdefault("_extra_topics", set()).add(topic)
+            # else: merged topics from duplicate hits tracked by TOPICS
 
     entries = []
     for name, repo in sorted(

--- a/scripts/fetch-community-plugins.py
+++ b/scripts/fetch-community-plugins.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Fetch community gptme extensions from GitHub topics and update state/community_plugins.json.
+
+Searches GitHub for repos tagged with gptme-plugin, gptme-skill, or gptme-mcp-server
+topics and writes the results to state/community_plugins.json for use by gptme-dashboard.
+
+Usage:
+    python3 scripts/fetch-community-plugins.py
+    python3 scripts/fetch-community-plugins.py --output path/to/output.json
+    python3 scripts/fetch-community-plugins.py --dry-run
+
+Requires GITHUB_TOKEN env var (or gh CLI auth) for the GitHub search API.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import cast
+
+TOPICS = ["gptme-plugin", "gptme-skill", "gptme-mcp-server"]
+
+# Repos to exclude (the contrib repo itself, which is the host)
+EXCLUDE_NAMES = {"gptme/gptme-contrib"}
+
+DEFAULT_OUTPUT = Path(__file__).parent.parent / "state" / "community_plugins.json"
+
+
+def gh_api(path: str) -> dict | list:
+    """Call GitHub API via gh CLI."""
+    result = subprocess.run(
+        ["gh", "api", path, "--paginate"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    # --paginate returns multiple JSON objects concatenated; wrap into array if needed
+    raw = result.stdout.strip()
+    # gh --paginate outputs valid JSON arrays that get concatenated, merge them
+    if raw.startswith("[") and raw.endswith("]"):
+        # single page or already merged
+        return cast(list, json.loads(raw))
+    # multiple pages: each line is a JSON array
+    merged: list = []
+    for line in raw.splitlines():
+        line = line.strip()
+        if line:
+            chunk = json.loads(line)
+            if isinstance(chunk, list):
+                merged.extend(chunk)
+            elif isinstance(chunk, dict):
+                merged.append(chunk)
+    return merged
+
+
+def search_topic(topic: str) -> list[dict]:
+    """Search GitHub for repos with the given topic."""
+    result = subprocess.run(
+        ["gh", "api", f"search/repositories?q=topic:{topic}&per_page=100&sort=stars"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    data: dict = json.loads(result.stdout)
+    return cast(list[dict], data.get("items", []))
+
+
+def fetch_all() -> list[dict]:
+    """Fetch all repos across all gptme topics, deduplicated by full_name."""
+    seen: dict[str, dict] = {}
+    for topic in TOPICS:
+        try:
+            repos = search_topic(topic)
+        except subprocess.CalledProcessError as exc:
+            print(f"Warning: failed to search topic {topic}: {exc}", file=sys.stderr)
+            continue
+        for repo in repos:
+            name = repo["full_name"]
+            if name in EXCLUDE_NAMES:
+                continue
+            if name not in seen:
+                seen[name] = repo
+            else:
+                # merge topics from duplicate hits
+                seen[name].setdefault("_extra_topics", set()).add(topic)
+
+    entries = []
+    for name, repo in sorted(
+        seen.items(), key=lambda x: -(x[1].get("stargazers_count") or 0)
+    ):
+        topics = [t for t in repo.get("topics", []) if t in TOPICS]
+        entry = {
+            "name": name,
+            "description": (repo.get("description") or "").strip(),
+            "url": repo["html_url"],
+            "stars": repo.get("stargazers_count", 0),
+            "language": repo.get("language") or "",
+            "topics": topics,
+        }
+        entries.append(entry)
+    return entries
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Fetch community gptme extensions from GitHub"
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help="Output JSON file (default: state/community_plugins.json)",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Print result without writing"
+    )
+    args = parser.parse_args()
+
+    print(f"Searching GitHub for topics: {', '.join(TOPICS)}", file=sys.stderr)
+    entries = fetch_all()
+    print(f"Found {len(entries)} community repos", file=sys.stderr)
+
+    output = {
+        "fetched_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "source": "github-topics: " + ", ".join(TOPICS),
+        "entries": entries,
+    }
+
+    json_str = json.dumps(output, indent=2, ensure_ascii=False)
+
+    if args.dry_run:
+        print(json_str)
+        return 0
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json_str + "\n")
+    print(f"Written {len(entries)} entries to {args.output}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/state/community_plugins.json
+++ b/state/community_plugins.json
@@ -1,0 +1,78 @@
+{
+  "fetched_at": "2026-06-29T00:00:00Z",
+  "source": "seeded from gptme/registry.gptme.org registry.json (2026-06-29); future updates via scripts/fetch-community-plugins.py",
+  "entries": [
+    {
+      "name": "gptme/gptme-rag",
+      "description": "RAG plugin for gptme — semantic document search and retrieval-augmented generation.",
+      "url": "https://github.com/gptme/gptme-rag",
+      "stars": 17,
+      "language": "Python",
+      "topics": ["gptme-plugin"]
+    },
+    {
+      "name": "gptme/gptme-vim",
+      "description": "Vim plugin for gptme — use gptme from within vim/neovim.",
+      "url": "https://github.com/gptme/gptme.vim",
+      "stars": 7,
+      "language": "Vim Script",
+      "topics": ["gptme-plugin"]
+    },
+    {
+      "name": "gptme/gptme-tauri",
+      "description": "Desktop app for gptme built with Tauri — GUI wrapper with system tray integration.",
+      "url": "https://github.com/gptme/gptme-tauri",
+      "stars": 6,
+      "language": "Rust",
+      "topics": ["gptme-plugin", "gptme-skill"]
+    },
+    {
+      "name": "gptme/gptme-webui",
+      "description": "Web UI for gptme — browser-based chat interface for remote agents.",
+      "url": "https://github.com/gptme/gptme-webui",
+      "stars": 5,
+      "language": "TypeScript",
+      "topics": ["gptme-plugin", "gptme-skill"]
+    },
+    {
+      "name": "gptme/gptme-voice",
+      "description": "Voice interface for gptme — Twilio telephony and OpenAI Realtime API integration.",
+      "url": "https://github.com/gptme/gptme-voice",
+      "stars": 4,
+      "language": "Python",
+      "topics": ["gptme-skill"]
+    },
+    {
+      "name": "gptme/gptme-codegraph",
+      "description": "Code knowledge graph MCP server for gptme — repository structure awareness.",
+      "url": "https://github.com/gptme/gptme-codegraph",
+      "stars": 3,
+      "language": "Python",
+      "topics": ["gptme-plugin", "gptme-mcp-server"]
+    },
+    {
+      "name": "gptme/gptme-forum",
+      "description": "Forum interaction skill for gptme agents — read and post to online discussion boards.",
+      "url": "https://github.com/gptme/gptme-forum",
+      "stars": 3,
+      "language": "Python",
+      "topics": ["gptme-skill"]
+    },
+    {
+      "name": "gptme/gptme-daily-briefing",
+      "description": "Daily briefing skill — summaries of repos, threads, and contacts for autonomous agents.",
+      "url": "https://github.com/gptme/gptme-daily-briefing",
+      "stars": 3,
+      "language": "Python",
+      "topics": ["gptme-skill"]
+    },
+    {
+      "name": "gptme/gptme-subscription",
+      "description": "Subscription management skill — quota-aware harness selection and rotation.",
+      "url": "https://github.com/gptme/gptme-subscription",
+      "stars": 2,
+      "language": "Python",
+      "topics": ["gptme-skill"]
+    }
+  ]
+}

--- a/state/community_plugins.json
+++ b/state/community_plugins.json
@@ -11,7 +11,7 @@
       "topics": ["gptme-plugin"]
     },
     {
-      "name": "gptme/gptme-vim",
+      "name": "gptme/gptme.vim",
       "description": "Vim plugin for gptme — use gptme from within vim/neovim.",
       "url": "https://github.com/gptme/gptme.vim",
       "stars": 7,


### PR DESCRIPTION
## Summary

Adds a **Community Extensions** section to the gptme-contrib dashboard at https://gptme.github.io/gptme-contrib/, showing third-party repos tagged with `gptme-plugin`, `gptme-skill`, or `gptme-mcp-server` topics on GitHub.

This consolidates ecosystem plugin discovery from the standalone `gptme/registry.gptme.org` repo into gptme-contrib, per Erik's decision in gptme/registry.gptme.org#1.

## Changes

- **`packages/gptme-dashboard/src/gptme_dashboard/generate.py`**: `scan_community_plugins()` reads `state/community_plugins.json` and returns the entries (gracefully returns `[]` if the file is absent, so existing workspaces are unaffected)
- **`packages/gptme-dashboard/src/gptme_dashboard/templates/index.html`**: Community Extensions section + nav link (both hidden when no data)
- **`state/community_plugins.json`**: Initial seed from registry.gptme.org registry.json (9 known gptme ecosystem repos)
- **`scripts/fetch-community-plugins.py`**: Script to refresh the JSON file via GitHub topics API (`gh` CLI)
- **`.github/workflows/community-plugins.yml`**: Weekly refresh (Monday 04:00 UTC) with auto-commit
- **`.github/workflows/dashboard.yml`**: Trigger dashboard rebuild when `community_plugins.json` changes

## Design decisions

- **File-based over live API**: The dashboard generator reads from a pre-fetched JSON file rather than hitting the GitHub API at build time. This avoids build-time rate-limiting and lets the weekly refresh cadence be independent of dashboard deploys.
- **Graceful degradation**: `scan_community_plugins()` returns `[]` when the file is missing — other workspaces using gptme-dashboard are unaffected and the section simply doesn't appear.
- **Seed content**: The initial 9 entries come from `registry.gptme.org/registry.json`, which can be archived once this lands.

## Test plan

- [ ] All 380 existing dashboard tests pass (`uv run pytest packages/gptme-dashboard/tests/ -q`)
- [ ] `scan_community_plugins()` returns 9 entries when pointed at the seeded JSON
- [ ] Dashboard renders without errors (`gptme-dashboard --workspace . --output /tmp/test-site`)
- [ ] Community section appears in output HTML; hidden when JSON file absent