### PR TITLE
docs: add Browse links to topic discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,11 @@ gptme has a broader ecosystem of standalone repos beyond gptme-contrib.
 
 To make your own plugin or skill discoverable, add a GitHub topic to your repo:
 
-| Topic | For |
-|-------|-----|
-| `gptme-plugin` | Python plugin packages |
-| `gptme-skill` | SKILL.md skill bundles |
-| `gptme-mcp-server` | MCP servers for gptme |
+| Topic | For | Browse |
+|-------|-----|--------|
+| `gptme-plugin` | Python plugin packages | [↗](https://github.com/topics/gptme-plugin) |
+| `gptme-skill` | SKILL.md skill bundles | [↗](https://github.com/topics/gptme-skill) |
+| `gptme-mcp-server` | MCP servers for gptme | [↗](https://github.com/topics/gptme-mcp-server) |
 
 ```bash
 gh repo edit owner/your-repo --add-topic gptme-plugin


### PR DESCRIPTION
Follow-up to #1169 — addresses Greptile P2 finding on the merged Ecosystem section.

The merged `Discover More` table taught users how to **publish** a topic but had no clickable path to **browse** repos already tagged with the topic. This adds a `Browse` column linking to `https://github.com/topics/<topic>` for each of the three topics (`gptme-plugin`, `gptme-skill`, `gptme-mcp-server`), making the section useful for both publishers and consumers.

Suggested by @greptile-apps in [this review thread](https://github.com/gptme/gptme-contrib/pull/1169#discussion_r3494719261) on the original PR.