### PR TITLE
fix(lessons-extras): error on companion link referencing a nonexistent file

### DIFF
--- a/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
+++ b/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
@@ -537,6 +537,13 @@ class LessonValidator:
                 f"Consider creating companion: knowledge/lessons/{self.filepath.stem}.md"
             )
 
+        # If lesson links a companion that does not exist, that is a dead reference
+        if has_companion_link and not has_companion:
+            self.errors.append(
+                f"Links a companion doc that does not exist. Create it or remove the "
+                f"link: knowledge/lessons/{self.filepath.stem}.md"
+            )
+
         # If companion exists but not linked, warn
         if has_companion and not has_companion_link:
             self.warnings.append(

--- a/packages/gptme-lessons-extras/tests/test_validate.py
+++ b/packages/gptme-lessons-extras/tests/test_validate.py
@@ -42,7 +42,9 @@ example
 - Benefit 1
 """
 
-# A fully valid two-file-format lesson (includes Related section).
+# A fully valid lesson for testing non-companion fields (version, target_grade, etc.).
+# Intentionally has no companion link so tests that expect zero errors pass regardless
+# of whether knowledge/lessons/test-lesson.md exists on disk.
 _VALID_LESSON = """\
 ---
 match:
@@ -73,7 +75,7 @@ example
 - Benefit 1
 
 ## Related
-- Full context: knowledge/lessons/test-lesson.md
+- See also: some-other-resource
 """
 
 
@@ -486,3 +488,63 @@ def test_active_long_lesson_still_warns():
         validator.validate()
         length_warnings = [w for w in validator.warnings if "lines (target" in w]
         assert length_warnings, "Active long lesson should still warn about length"
+
+
+# A concise lesson (<100 lines) that links a companion doc that does not exist.
+_LESSON_WITH_DEAD_COMPANION_LINK = """\
+---
+match:
+  keywords:
+    - "test keyword phrase"
+status: active
+---
+
+# Test Lesson With Dead Companion Link
+
+## Rule
+Test rule.
+
+## Context
+Test context.
+
+## Detection
+- Signal 1
+
+## Pattern
+```txt
+example
+```
+
+## Outcome
+- Benefit 1
+
+## Related
+- Full context: [knowledge/lessons/test-lesson.md](../../knowledge/lessons/test-lesson.md)
+"""
+
+
+def test_dead_companion_link_raises_error():
+    """A lesson that links a companion doc that doesn't exist should error."""
+    with tempfile.TemporaryDirectory() as tmp:
+        path = _write_lesson(Path(tmp), _LESSON_WITH_DEAD_COMPANION_LINK)
+        validator = LessonValidator(path)
+        validator.validate()
+        companion_errors = [e for e in validator.errors if "companion" in e.lower()]
+        assert (
+            companion_errors
+        ), "Lesson linking a nonexistent companion doc should raise an error"
+
+
+def test_dead_companion_link_archived_skips():
+    """Archived lessons skip companion checks, so dead links are not flagged."""
+    content = _LESSON_WITH_DEAD_COMPANION_LINK.replace(
+        "status: active", "status: archived"
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        path = _write_lesson(Path(tmp), content)
+        validator = LessonValidator(path)
+        validator.validate()
+        companion_errors = [e for e in validator.errors if "companion" in e.lower()]
+        assert (
+            not companion_errors
+        ), f"Archived lesson should not flag dead companion link: {companion_errors}"


### PR DESCRIPTION
## Summary

- Adds the missing branch in `_check_companion_doc()`: a concise lesson (<100 lines) that links `knowledge/lessons/<stem>.md` in its Related section but has no companion file on disk previously passed validation silently with exit 0
- New rule: `has_companion_link and not has_companion` → error (broken cross-reference)
- Archived lessons continue to skip all companion checks

## Why

The asymmetry was the inverse of the existing check: the validator warned when a companion **exists but is not linked**, but had no check for the reverse — a lesson **linking a companion that doesn't exist**.

Surfaced when `lessons/infrastructure/watchdog-starvation-death-spiral.md` shipped with a Related section pointing at a nonexistent companion; a sibling session created it within minutes, so the fleet self-corrected — but the validator should have caught the dead link.

## Corpus impact

Corpus sweep (307 lessons, brain root CWD): **1 real dead companion link** detected:
- `lessons/tools/browser-automation-on-lxc.md` — Related section contains a `(if expanded)` placeholder reference that was never backed by a companion file

That lesson will be fixed in the brain repo separately. The companion link regex only matches real `knowledge/lessons/...md` path patterns, not arbitrary text.

## Test plan

- [x] `test_dead_companion_link_raises_error` — concise lesson linking a nonexistent companion → error
- [x] `test_dead_companion_link_archived_skips` — archived lessons are exempt (skip companion checks entirely)
- [x] `test_archived_lesson_skips_companion_warning` — existing archived test still passes
- [x] 31 total tests passing
- [x] Corpus sweep clean (1 known finding, pre-existing dead placeholder)