### PR TITLE
feat(gptme-sessions): track summarizer_fired in session records

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -372,6 +372,7 @@ def post_session(
     context_peak_bytes: int | None = None
     session_total_bytes: int | None = None
     traj_productive: bool | None = None
+    summarizer_fired: bool | None = None
 
     # --- Extract signals from trajectory ---
     if trajectory_path is not None and trajectory_path.is_file():
@@ -424,6 +425,14 @@ def post_session(
             traj_model = (signals.get("usage") or {}).get("model")
             if traj_model:
                 model = traj_model
+
+        # Detect whether the tool-output summarizer fired.  Only gptme-format
+        # trajectories populate this field (the trimmer plugin runs on gptme
+        # sessions only); CC/Codex/Copilot leave it absent.
+        if signals is not None:
+            sf = signals.get("summarizer_fired")
+            if sf is not None:
+                summarizer_fired = bool(sf)
 
     # Whether the assigned trajectory plausibly covers the whole session. A
     # trajectory spanning far less wall-clock than the caller's duration is
@@ -704,6 +713,8 @@ def post_session(
         record_kwargs["context_peak_bytes"] = context_peak_bytes
     if session_total_bytes is not None:
         record_kwargs["session_total_bytes"] = session_total_bytes
+    if summarizer_fired is not None:
+        record_kwargs["summarizer_fired"] = summarizer_fired
     record = SessionRecord(**record_kwargs)
     if grade is not None:
         record.set_productivity_grade(grade)

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -264,6 +264,12 @@ class SessionRecord:
     # importing gptme_sessions.spans. ``None`` means not yet populated.
     span_aggregates: dict[str, Any] | None = None
 
+    # Whether the tool-output summarizer fired at least once during this session.
+    # Detected by scanning the trajectory for the summarization marker text.
+    # True = summarizer ran; False = summarizer enabled but no eviction happened;
+    # None = trajectory unavailable or pre-dates this field.
+    summarizer_fired: bool | None = None
+
     # Preserve fields written by older schema versions so load→mutate→rewrite
     # round-trips don't silently drop data (e.g. ``inferred_category``,
     # ``failure_reason``, ``recommended_confidence``, ``notes``).

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -46,6 +46,11 @@ _BG_TASK_RE = re.compile(r"Output is being written to: (.+\.output)")
 # This does NOT match _COMMIT_RE (no branch/hash format), so needs separate detection.
 _PR_MERGE_RE = re.compile(r"(?:Squashed and merged|Rebased and merged|Merged) pull request #(\d+)")
 
+# Marker injected by gptme-tooloutput-trimmer's summarization pass
+# (tooloutput_trimmer.hooks.trimmer.SUMMARIZATION_MARKER).  Hardcoded to
+# avoid a hard dep on the plugin; must stay in sync with the plugin string.
+_SUMMARIZATION_MARKER = "[Summarized previous tool outputs]"
+
 # Regex for GitHub CLI interactions that represent productive work but don't
 # produce commits or file writes (PR reviews, issue comments, PR comments).
 # These should count toward session productivity to avoid floor-grading
@@ -304,10 +309,6 @@ def extract_signals(msgs: list[dict]) -> dict:
     timestamps: list[datetime] = []
     steps = 0  # number of assistant turns that yielded to await tool results
     detail_by_value: dict[str, dict[str, object]] = {}
-    # Marker injected by gptme-tooloutput-trimmer's summarization pass
-    # (tooloutput_trimmer.hooks.trimmer.SUMMARIZATION_MARKER).  Hardcoded to
-    # avoid a hard dep on the plugin; must stay in sync with the plugin string.
-    _SUMMARIZATION_MARKER = "[Summarized previous tool outputs]"
     summarizer_fired = False
 
     # Track recent (tool, path) pairs for retry detection

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -304,6 +304,11 @@ def extract_signals(msgs: list[dict]) -> dict:
     timestamps: list[datetime] = []
     steps = 0  # number of assistant turns that yielded to await tool results
     detail_by_value: dict[str, dict[str, object]] = {}
+    # Marker injected by gptme-tooloutput-trimmer's summarization pass
+    # (tooloutput_trimmer.hooks.trimmer.SUMMARIZATION_MARKER).  Hardcoded to
+    # avoid a hard dep on the plugin; must stay in sync with the plugin string.
+    _SUMMARIZATION_MARKER = "[Summarized previous tool outputs]"
+    summarizer_fired = False
 
     # Track recent (tool, path) pairs for retry detection
     recent_sigs: list[str] = []
@@ -361,6 +366,11 @@ def extract_signals(msgs: list[dict]) -> dict:
         elif role == "system" and ts_str:
             content_stripped = content.strip()
 
+            # Summarizer-fired detection: the trimmer plugin replaces evicted
+            # tool outputs with a system message starting with this marker.
+            if content_stripped.startswith(_SUMMARIZATION_MARKER):
+                summarizer_fired = True
+
             # Error detection (guard applies to all conditions, not just the last)
             if not content_stripped.startswith("Ran command:") and (
                 content_stripped.startswith("Error")
@@ -406,6 +416,7 @@ def extract_signals(msgs: list[dict]) -> dict:
         "retry_count": retry_count,
         "deliverables": deliverables,
         "deliverable_details": deliverable_details,
+        "summarizer_fired": summarizer_fired,
     }
 
 

--- a/packages/gptme-sessions/tests/test_signals_summarizer.py
+++ b/packages/gptme-sessions/tests/test_signals_summarizer.py
@@ -1,0 +1,92 @@
+"""Tests for summarizer_fired detection in extract_signals (gptme format)."""
+
+from __future__ import annotations
+
+from gptme_sessions.signals import extract_signals
+
+# Keep in sync with tooloutput_trimmer.hooks.trimmer.SUMMARIZATION_MARKER
+_SUMMARIZATION_MARKER = "[Summarized previous tool outputs]"
+
+
+def _msg(role: str, content: str, ts: str = "2026-01-01T10:00:00+00:00") -> dict:
+    return {"role": role, "content": content, "timestamp": ts}
+
+
+def _ts(n: int) -> str:
+    return f"2026-01-01T10:00:{n:02d}+00:00"
+
+
+def test_summarizer_fired_false_when_no_summary() -> None:
+    """summarizer_fired is False when no summary marker appears in the session."""
+    msgs = [
+        _msg("user", "Run ls", _ts(0)),
+        _msg("assistant", '@shell(c1): {"cmd": "ls"}', _ts(1)),
+        _msg("system", "Ran command: `ls`\nfile1.txt\nfile2.txt", _ts(2)),
+    ]
+    signals = extract_signals(msgs)
+    assert signals["summarizer_fired"] is False
+
+
+def test_summarizer_fired_true_when_marker_present() -> None:
+    """summarizer_fired is True when a system message starts with the marker."""
+    summary_content = (
+        f"{_SUMMARIZATION_MARKER}\n" "Summary of previous tool calls:\n" "- ls: listed files"
+    )
+    msgs = [
+        _msg("user", "Run ls", _ts(0)),
+        _msg("assistant", '@shell(c1): {"cmd": "ls"}', _ts(1)),
+        _msg("system", summary_content, _ts(2)),
+        _msg("assistant", '@shell(c2): {"cmd": "pwd"}', _ts(3)),
+        _msg("system", "Ran command: `pwd`\n/home/bob", _ts(4)),
+    ]
+    signals = extract_signals(msgs)
+    assert signals["summarizer_fired"] is True
+
+
+def test_summarizer_fired_false_for_empty_session() -> None:
+    """summarizer_fired is False for a session with no messages."""
+    signals = extract_signals([])
+    assert signals["summarizer_fired"] is False
+
+
+def test_summarizer_fired_false_when_marker_in_non_system_role() -> None:
+    """summarizer_fired is False when the marker appears in a non-system role (e.g., user)."""
+    msgs = [
+        _msg("user", f"{_SUMMARIZATION_MARKER}\nsome content", _ts(0)),
+        _msg("assistant", "ok", _ts(1)),
+    ]
+    signals = extract_signals(msgs)
+    assert signals["summarizer_fired"] is False
+
+
+def test_summarizer_fired_false_when_marker_not_at_start() -> None:
+    """summarizer_fired is False when marker appears mid-content (not at start of system msg)."""
+    msgs = [
+        _msg("user", "Run ls", _ts(0)),
+        _msg("assistant", '@shell(c1): {"cmd": "ls"}', _ts(1)),
+        _msg(
+            "system",
+            f"Ran command: `ls`\nsome stuff\n{_SUMMARIZATION_MARKER}",
+            _ts(2),
+        ),
+    ]
+    signals = extract_signals(msgs)
+    assert signals["summarizer_fired"] is False
+
+
+def test_summarizer_fired_true_even_with_other_signals() -> None:
+    """summarizer_fired is True alongside normal productivity signals (commits, writes)."""
+    summary_content = (
+        f"{_SUMMARIZATION_MARKER}\n" "Summary of previous tool calls:\n" "- patch: wrote foo.py"
+    )
+    commit_output = "[master abc1234] feat: add foo (abc1234)"
+    msgs = [
+        _msg("user", "Add foo.py", _ts(0)),
+        _msg("assistant", '@patch(c1): {"path": "foo.py", "content": "x=1"}', _ts(1)),
+        _msg("system", summary_content, _ts(2)),
+        _msg("assistant", '@shell(c2): {"cmd": "git commit -am feat: add foo"}', _ts(3)),
+        _msg("system", f"Ran command: `git commit`\n{commit_output}", _ts(4)),
+    ]
+    signals = extract_signals(msgs)
+    assert signals["summarizer_fired"] is True
+    assert signals["git_commits"]  # other signals still populated


### PR DESCRIPTION
## Summary

- Adds `summarizer_fired: bool | None` field to `SessionRecord` — answers "how often does the tool-output trimmer actually fire?"
- Detects the marker in `extract_signals()` (gptme-format trajectories only; CC/Codex/Copilot sessions leave the field `None`)
- Wires the signal through `post_session.py` via the existing signals dict
- 6 unit tests covering: marker absent, marker present, empty session, marker in wrong role, marker not at start of line, coexistence with other productivity signals

## Context

The gptme-tooloutput-trimmer plugin (#1069) landed June 2026 and evicts tool outputs by replacing them with a system message starting with `"[Summarized previous tool outputs]"`. Until now, session records had no way to distinguish "trimmer fired" from "trimmer never ran" — both appeared as identical JSONL records. This adds that signal so we can evaluate how often the summarizer actually activates in practice.

## Field semantics

| Value | Meaning |
|-------|---------|
| `True` | Summarizer fired ≥1 time during the session |
| `False` | Summarizer enabled but no eviction happened |
| `None` | Trajectory unavailable or harness doesn't use the trimmer (CC/Codex/Copilot) |

## Test plan

- [x] `uv run pytest packages/gptme-sessions/tests/test_signals_summarizer.py -v` — 6/6 pass
- [x] Full suite `uv run pytest packages/gptme-sessions/ --ignore=packages/gptme-sessions/tests/test_judge.py -q` — 815 pass, 0 failures
- [x] ruff-format, mypy, typecheck all clean