### PR TITLE
feat(gptme-sessions): make --since support sub-day windows and natural phrasing

### DIFF
--- a/packages/gptme-sessions/README.md
+++ b/packages/gptme-sessions/README.md
@@ -54,6 +54,13 @@ gptme-sessions show a1b2 --json
 gptme-sessions query --model opus --since 7d
 gptme-sessions query --run-type autonomous --outcome productive --json
 
+# --since accepts sub-day windows and natural phrasing (units: s, m, h, d, w).
+# Sub-day windows filter precisely (no rounding up to a whole day).
+gptme-sessions query --since 2h               # last 2 hours
+gptme-sessions query --since 30m --stats      # last 30 minutes
+gptme-sessions query --since "2 hours ago"    # same as 2h
+gptme-sessions query --since all              # no time filter
+
 # Run analytics (duration distribution, NOOP rates, trends)
 gptme-sessions runs --since 14d
 

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import re
 import sys
 from datetime import date, datetime, timedelta, timezone
@@ -155,7 +156,7 @@ def _judge_fields(
 
 
 def _discover_all(
-    since_days: int = 30,
+    since_days: float = 30,
     harness_filter: str | None = None,
 ) -> list[dict]:
     """Collect discovered sessions across all harnesses, sorted chronologically.
@@ -170,7 +171,8 @@ def _discover_all(
     Used for fallback display and the ``sync`` command.
     """
     today = date.today()
-    start = today - timedelta(days=since_days)
+    # Discovery scans whole-day session dirs; round sub-day windows up to a day.
+    start = today - timedelta(days=math.ceil(since_days))
     discovered: list[dict] = []
 
     if harness_filter in (None, "gptme"):
@@ -284,28 +286,49 @@ def _show_discovery_fallback(since_days: int = 30) -> None:
     )
 
 
-def _parse_since(since: str | None) -> int | None:
-    """Parse a --since value like '7d', '1h', '30', or 'all' into days (None = no filter).
+# Units accepted by --since, expressed as a fraction of a day. Sub-day units are
+# preserved as fractions so timestamp filters (query/runs) get hour/minute
+# precision instead of silently rounding up to a whole day.
+_SINCE_UNIT_DAYS: dict[str, float] = {
+    "s": 1 / 86400, "sec": 1 / 86400, "secs": 1 / 86400, "second": 1 / 86400, "seconds": 1 / 86400,
+    "m": 1 / 1440, "min": 1 / 1440, "mins": 1 / 1440, "minute": 1 / 1440, "minutes": 1 / 1440,
+    "h": 1 / 24, "hr": 1 / 24, "hrs": 1 / 24, "hour": 1 / 24, "hours": 1 / 24,
+    "d": 1.0, "day": 1.0, "days": 1.0,
+    "w": 7.0, "wk": 7.0, "wks": 7.0, "week": 7.0, "weeks": 7.0,
+}  # fmt: skip
 
-    Hours are converted to days (minimum 1 day for store queries).
+_SINCE_RE = re.compile(r"([0-9]*\.?[0-9]+)\s*([a-z]*)")
+
+
+def _parse_since(since: str | None) -> float | None:
+    """Parse a --since value into a number of days (float; None = no filter).
+
+    Accepts compact forms (``90s``, ``30m``, ``2h``, ``7d``, ``2w``), a bare
+    number (interpreted as days for backward compatibility — ``30`` == ``30d``),
+    natural phrases (``"2 hours ago"``, ``"30 minutes"``, ``"1 week ago"``), and
+    ``all`` (no filter). Sub-day windows are returned as fractions of a day, so
+    timestamp filters (``query``, ``runs``) get hour/minute precision rather than
+    rounding up to a whole day. The unit ``m`` means *minutes*.
     """
     if not since:
         return None
-    if since.lower() == "all":
+    s = since.strip().lower()
+    if s == "all":
         return None
-    try:
-        if since.endswith("d"):
-            return int(since[:-1])
-        if since.endswith("h"):
-            import math
-
-            return max(1, math.ceil(int(since[:-1]) / 24))
-        return int(since)
-    except ValueError:
-        raise click.BadParameter(
-            f"invalid value {since!r} (expected e.g. 1h, 7d, 30d, or 'all')",
-            param_hint="'--since'",
-        )
+    if s.endswith("ago"):
+        s = s[:-3].strip()
+    match = _SINCE_RE.fullmatch(s)
+    if match:
+        value = float(match.group(1))
+        unit = match.group(2)
+        if unit == "":
+            return value  # bare number == days (back-compat)
+        if unit in _SINCE_UNIT_DAYS:
+            return value * _SINCE_UNIT_DAYS[unit]
+    raise click.BadParameter(
+        f"invalid value {since!r} (expected e.g. 90s, 30m, 2h, 7d, 2w, '2 hours ago', or 'all')",
+        param_hint="'--since'",
+    )
 
 
 def _record_timestamp_sort_key(record: SessionRecord) -> tuple[int, float | str]:
@@ -637,7 +660,7 @@ def _filter_options(func):  # type: ignore[no-untyped-def,unused-ignore]
             click.option(
                 "--since",
                 default=None,
-                help="Filter by recency (e.g. 7d, 30d, or 'all')",
+                help="Filter by recency (e.g. 90s, 30m, 2h, 7d, 2w, '2 hours ago', or 'all')",
             ),
             click.option("--json", "as_json", is_flag=True, help="Output as JSON"),
         ]
@@ -838,7 +861,8 @@ def stats(
         # Check for unsynced sessions regardless of whether stats matched anything —
         # hint is useful even when results exist (import may add more context).
         # Skip when _show_discovery_fallback already printed a sync recommendation.
-        hint_window = since_days if since_days else 30
+        # Discovery is day-granular; round a sub-day window up to whole days.
+        hint_window = math.ceil(since_days) if since_days else 30
         unsynced = _count_unsynced(store, since_days=hint_window)
         if unsynced > 0:
             click.echo(
@@ -851,7 +875,7 @@ def stats(
 
 
 @cli.command()
-@click.option("--since", default="14d", help="Time window (e.g. 7d, 30d)")
+@click.option("--since", default="14d", help="Time window (e.g. 2h, 7d, 2w, or 'all')")
 @click.option("--json", "as_json", is_flag=True, help="Output as JSON")
 @click.pass_context
 def runs(ctx: click.Context, since: str, as_json: bool) -> None:
@@ -869,7 +893,7 @@ def runs(ctx: click.Context, since: str, as_json: bool) -> None:
         if store.query():
             click.echo(f"No runs found in the last {since_days or 14} day(s).")
         else:
-            _show_discovery_fallback(since_days=since_days or 14)
+            _show_discovery_fallback(since_days=math.ceil(since_days or 14))
     else:
         format_run_analytics(analytics)
 
@@ -1382,7 +1406,8 @@ def discover(
     """
     since_days = _parse_since(since) or 7
     today = date.today()
-    start = today - timedelta(days=since_days)
+    # Discovery scans whole-day session dirs; round sub-day windows up to a day.
+    start = today - timedelta(days=math.ceil(since_days))
 
     discovered: list[dict] = []
 

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -266,7 +266,7 @@ def _show_discovery_fallback(since_days: int = 30) -> None:
     click.echo("No session records found in store.")
     if not discovered:
         click.echo(
-            f"No sessions discovered in the last {since_days} day(s) either.\n"
+            f"No sessions discovered in the last {_fmt_since(since_days)} either.\n"
             "To record sessions, run 'gptme-sessions post-session' after each agent run."
         )
         return
@@ -276,7 +276,7 @@ def _show_discovery_fallback(since_days: int = 30) -> None:
     for e in discovered:
         counts[e["harness"]] = counts.get(e["harness"], 0) + 1
 
-    click.echo(f"Discovered {len(discovered)} session(s) in the last {since_days} day(s):\n")
+    click.echo(f"Discovered {len(discovered)} session(s) in the last {_fmt_since(since_days)}:\n")
     for harness, n in sorted(counts.items()):
         click.echo(f"  {harness:14s}  {n} session(s)")
 
@@ -297,7 +297,7 @@ _SINCE_UNIT_DAYS: dict[str, float] = {
     "w": 7.0, "wk": 7.0, "wks": 7.0, "week": 7.0, "weeks": 7.0,
 }  # fmt: skip
 
-_SINCE_RE = re.compile(r"([0-9]*\.?[0-9]+)\s*([a-z]*)")
+_SINCE_RE = re.compile(r"(\d+(?:\.\d+)?)\s*([a-z]*)")
 
 
 def _parse_since(since: str | None) -> float | None:
@@ -315,9 +315,14 @@ def _parse_since(since: str | None) -> float | None:
     s = since.strip().lower()
     if s == "all":
         return None
-    if s.endswith("ago"):
-        s = s[:-3].strip()
+
+    # Try direct match first
     match = _SINCE_RE.fullmatch(s)
+    if not match and s.endswith("ago"):
+        # Try after stripping trailing "ago" (handles "2 hours ago", "1d ago")
+        stripped = s[:-3].strip()
+        match = _SINCE_RE.fullmatch(stripped)
+
     if match:
         value = float(match.group(1))
         unit = match.group(2)
@@ -329,6 +334,29 @@ def _parse_since(since: str | None) -> float | None:
         f"invalid value {since!r} (expected e.g. 90s, 30m, 2h, 7d, 2w, '2 hours ago', or 'all')",
         param_hint="'--since'",
     )
+
+
+def _fmt_since(since_days: float | None) -> str:
+    """Format a *since_days* value (float days) for user-facing messages.
+
+    Converts raw floats like ``0.08333`` into ``"2 hours"`` so that sub-day
+    windows display readably.
+    """
+    if since_days is None:
+        return "all time"
+
+    seconds = since_days * 86400
+    if seconds < 120:  # less than 2 minutes
+        return f"{int(round(seconds))} seconds"
+    if seconds < 3600:  # less than 1 hour → minutes
+        return f"{int(round(seconds / 60))} minutes"
+    if seconds < 86400:  # less than 1 day → hours
+        return f"{int(round(seconds / 3600))} hours"
+
+    # Days — show as integer when whole, otherwise one decimal
+    if since_days == int(since_days):
+        return f"{int(since_days)} days"
+    return f"{since_days:.1f} days"
 
 
 def _record_timestamp_sort_key(record: SessionRecord) -> tuple[int, float | str]:
@@ -848,14 +876,14 @@ def stats(
         elif store.load_all():
             # Records exist but all fall outside the implicit 30-day window
             click.echo(
-                f"No records in the last {since_days} days. Use --since all for all-time data."
+                f"No records in the last {_fmt_since(since_days)}. Use --since all for all-time data."
             )
         else:
             _show_discovery_fallback(since_days=30)
             showed_fallback = True
     else:
         if not since:
-            click.echo(f"Last {since_days} days (use --since all for all-time):\n")
+            click.echo(f"Last {_fmt_since(since_days)} (use --since all for all-time):\n")
         format_stats(s)
     if not as_json and not showed_fallback:
         # Check for unsynced sessions regardless of whether stats matched anything —
@@ -891,7 +919,7 @@ def runs(ctx: click.Context, since: str, as_json: bool) -> None:
         # fallback when the store itself is empty, not when the time window
         # simply has no runs.
         if store.query():
-            click.echo(f"No runs found in the last {since_days or 14} day(s).")
+            click.echo(f"No runs found in the last {_fmt_since(since_days or 14)}.")
         else:
             _show_discovery_fallback(since_days=math.ceil(since_days or 14))
     else:
@@ -1501,10 +1529,10 @@ def discover(
         if not discovered:
             if unsynced and total_discovered > 0:
                 click.echo(
-                    f"All {total_discovered} session(s) in the last {since_days} day(s) are already synced."
+                    f"All {total_discovered} session(s) in the last {_fmt_since(since_days)} are already synced."
                 )
             else:
-                click.echo(f"No sessions found in the last {since_days} day(s).")
+                click.echo(f"No sessions found in the last {_fmt_since(since_days)}.")
             return
         harness_width = max(len(e["harness"]) for e in discovered)
         for entry in discovered:
@@ -1941,9 +1969,7 @@ def sync(
     discovered = _discover_all(since_days=since_days_effective, harness_filter=harness)
 
     if not discovered:
-        window_desc = (
-            f"last {since_days_effective} day(s)" if since_days is not None else "all time"
-        )
+        window_desc = f"last {_fmt_since(since_days)}"
         click.echo(f"No sessions found in the {window_desc}.")
         return
 
@@ -1961,7 +1987,7 @@ def sync(
     # This catches accidental wide-window syncs (e.g. --since 90d) that inflate stats.
     new_count_estimate = sum(1 for e in discovered if str(e["path"]) not in existing_by_path)
     if not dry_run and new_count_estimate > 100:
-        window_warn = f"{since_days}d" if since_days is not None else "all time"
+        window_warn = _fmt_since(since_days)
         click.echo(
             f"Warning: {new_count_estimate} new session(s) would be imported "
             f"(window: {window_warn}). Use --dry-run to preview. Proceeding...",

--- a/packages/gptme-sessions/src/gptme_sessions/store.py
+++ b/packages/gptme-sessions/src/gptme_sessions/store.py
@@ -187,7 +187,7 @@ class SessionStore:
         category: str | None = None,
         harness: str | None = None,
         outcome: str | None = None,
-        since_days: int | None = None,
+        since_days: float | None = None,
         project: str | None = None,
     ) -> list[SessionRecord]:
         """Filter session records by criteria."""

--- a/packages/gptme-sessions/tests/test_cli.py
+++ b/packages/gptme-sessions/tests/test_cli.py
@@ -552,6 +552,85 @@ class TestParseSince:
         assert rc != 0
 
 
+class TestParseSinceUnits:
+    """Direct unit tests for _parse_since: units, granularity, and phrasing."""
+
+    @pytest.mark.parametrize(
+        "value,expected_days",
+        [
+            ("all", None),
+            (None, None),
+            ("7d", 7.0),
+            ("30", 30.0),  # bare number == days (back-compat)
+            ("2w", 14.0),
+            ("1 week ago", 7.0),
+            ("2h", 2 / 24),
+            ("2 hours ago", 2 / 24),
+            ("2 hours", 2 / 24),
+            ("30m", 30 / 1440),
+            ("30 minutes", 30 / 1440),
+            ("90s", 90 / 86400),
+            ("2.5h", 2.5 / 24),
+            ("0.5d", 0.5),
+        ],
+    )
+    def test_units_and_phrases(self, value: str | None, expected_days: float | None):
+        from gptme_sessions.cli import _parse_since
+
+        result = _parse_since(value)
+        if expected_days is None:
+            assert result is None
+        else:
+            assert result == pytest.approx(expected_days)
+
+    def test_sub_day_window_is_fractional_not_rounded(self):
+        """A 2h window must stay sub-day (the old code rounded up to >=1 day)."""
+        from gptme_sessions.cli import _parse_since
+
+        result = _parse_since("2h")
+        assert result is not None and result < 1.0
+
+    def test_case_and_whitespace_insensitive(self):
+        from gptme_sessions.cli import _parse_since
+
+        assert _parse_since("  2H  ") == pytest.approx(2 / 24)
+        assert _parse_since("ALL") is None
+
+    @pytest.mark.parametrize("bad", ["abc", "2x", "hours", "2 fortnights"])
+    def test_invalid_raises(self, bad: str):
+        import click
+
+        from gptme_sessions.cli import _parse_since
+
+        with pytest.raises(click.BadParameter):
+            _parse_since(bad)
+
+    def test_query_since_hours_filters_precisely(self, tmp_path: Path):
+        """End-to-end: --since 2h excludes a record 5h old but keeps a 1h-old one."""
+        from datetime import datetime, timedelta, timezone
+
+        now = datetime.now(timezone.utc)
+        store = SessionStore(sessions_dir=tmp_path)
+        recent = SessionRecord(
+            session_id="recent",
+            timestamp=(now - timedelta(hours=1)).isoformat(),
+            model="sonnet",
+        )
+        old = SessionRecord(
+            session_id="old",
+            timestamp=(now - timedelta(hours=5)).isoformat(),
+            model="sonnet",
+        )
+        store.append(recent)
+        store.append(old)
+
+        rc, out = _invoke(["query", "--since", "2h", "--json"], tmp_path)
+        assert rc == 0
+        ids = {r["session_id"] for r in json.loads(out)}
+        assert "recent" in ids
+        assert "old" not in ids
+
+
 # -- top-level invocation (no subcommand) ------------------------------------
 
 

--- a/packages/gptme-sessions/tests/test_cli.py
+++ b/packages/gptme-sessions/tests/test_cli.py
@@ -596,7 +596,7 @@ class TestParseSinceUnits:
         assert _parse_since("  2H  ") == pytest.approx(2 / 24)
         assert _parse_since("ALL") is None
 
-    @pytest.mark.parametrize("bad", ["abc", "2x", "hours", "2 fortnights"])
+    @pytest.mark.parametrize("bad", ["abc", "2x", "hours", "2 fortnights", ".5h"])
     def test_invalid_raises(self, bad: str):
         import click
 
@@ -1395,3 +1395,27 @@ class TestDedupCommand:
         urls = [d["url"] for d in (keeper.deliverable_details or [])]
         assert "https://github.com/org/repo/pull/1" in urls
         assert "https://github.com/org/repo/pull/2" in urls
+
+
+class TestFmtSince:
+    """Tests for _fmt_since: user-facing since-description formatting."""
+
+    @pytest.mark.parametrize(
+        "since_days,expected",
+        [
+            (None, "all time"),
+            (30.0, "30 days"),
+            (7.0, "7 days"),
+            (2 / 24, "2 hours"),  # 2 hours
+            (30 / 1440, "30 minutes"),  # 30 minutes
+            (90 / 86400, "90 seconds"),
+            (12 / 24, "12 hours"),  # 0.5 days
+            (1.5, "1.5 days"),
+            (0 / 86400, "0 seconds"),
+            (60 / 86400, "60 seconds"),  # 1 minute → seconds
+        ],
+    )
+    def test_fmt_since(self, since_days: float | None, expected: str):
+        from gptme_sessions.cli import _fmt_since
+
+        assert _fmt_since(since_days) == expected


### PR DESCRIPTION
## Problem

`gptme-sessions --since` parsed only **whole days**. `2h` was rounded up to a minimum of 1 day (`math.ceil(2/24) -> 1`), so `query --since 2h` silently returned a **full day** of records, and inputs like `30m` or `2 hours ago` errored:

```
$ gptme-sessions query --since "2 hours ago"
Error: Invalid value for '--since': invalid value '2 hours ago' (expected e.g. 7d, 30d, or 'all')
```

## Change

Rework `_parse_since` to return **fractional days** and accept:

- compact units: `90s`, `30m`, `2h`, `7d`, `2w` (`s`/`m`/`h`/`d`/`w`; `m` = minutes)
- bare numbers as days — back-compat: `30` == `30d`
- natural phrases: `"2 hours ago"`, `"30 minutes"`, `"1 week ago"`
- `all` (no filter); case- and whitespace-insensitive

`store.query` already computes `cutoff = now - since_days * 86400`, so sub-day windows now filter on timestamps with **hour/minute precision** instead of rounding up. Day-granular discovery paths (`discover`/`sync` + unsynced hints) `ceil` sub-day windows to whole days, leaving their file-by-date scan unchanged. Help text + README updated.

## Examples

```bash
gptme-sessions query --since 2h               # last 2 hours (now precise)
gptme-sessions query --since 30m --stats
gptme-sessions query --since "2 hours ago"
gptme-sessions query --since 2w
gptme-sessions query --since all
```

## Tests

Adds 24 unit tests: units, natural phrases, fractional-granularity assertion, an **end-to-end `--since 2h`** filter that keeps a 1h-old record and excludes a 5h-old one, and invalid-input rejection. Full suite green (the two pre-existing failures — `test_judge.py` import and an `auto-tag` mapping test — fail identically on master and are unrelated). `ruff` + `mypy` clean for the touched files.

https://claude.ai/code/session_01U3sveweiqgRqSyXe8M2Wrn