### PR TITLE
refactor(lessons): remove keywords matching always-injected context files

### DIFF
--- a/lessons/autonomous/effective-autonomous-work-execution.md
+++ b/lessons/autonomous/effective-autonomous-work-execution.md
@@ -2,7 +2,8 @@
 description: "Follow a structured 4-phase approach (status check, task selection, execution, commit) for autonomous sessions to maximise productivity and proper task management"
 match:
   keywords:
-  - "autonomous session"
+  - "4-phase work execution"
+  - "structured session phases"
   session_categories: [strategic, self-review]
 status: active
 ---

--- a/lessons/autonomous/strategic-focus-during-autonomous-sessions.md
+++ b/lessons/autonomous/strategic-focus-during-autonomous-sessions.md
@@ -15,7 +15,6 @@ match:
   - churning on low-value tasks
   - looking busy without shipping
   - plateau detector says category_monotony
-  - "idea backlog"
   session_categories: [strategic, self-review]
 status: active
 ---

--- a/lessons/autonomous/strategic-focus-during-autonomous-sessions.md
+++ b/lessons/autonomous/strategic-focus-during-autonomous-sessions.md
@@ -8,8 +8,6 @@ tags:
 - focus
 match:
   keywords:
-
-
   - straying from highest-leverage
   - trapped in maintenance loops
   - churning on low-value tasks

--- a/lessons/workflow/absolute-paths-for-workspace-files.md
+++ b/lessons/workflow/absolute-paths-for-workspace-files.md
@@ -4,7 +4,6 @@ match:
   - "save file to"
   - "write journal entry"
   - "mkdir -p journal"
-  - "file path"
   - "wrong directory"
   - "file ended up in wrong"
   - "journal created in external repo"

--- a/lessons/workflow/agent-orchestrator-patterns.md
+++ b/lessons/workflow/agent-orchestrator-patterns.md
@@ -3,7 +3,6 @@ status: active
 match:
   keywords:
     - "orchestrator"
-    - "multi-agent"
     - "standup missing"
     - "agent coordination"
     - "inference utilization"

--- a/lessons/workflow/git-commit-format.md
+++ b/lessons/workflow/git-commit-format.md
@@ -2,7 +2,6 @@
 description: "Format commits as Conventional Commits (type(scope): description) with focused, atomic changes per commit"
 match:
   keywords:
-  - "conventional commits"
   - "commit message format"
   - "write commit message"
   - "commit type prefix"

--- a/lessons/workflow/git-worktree-workflow.md
+++ b/lessons/workflow/git-worktree-workflow.md
@@ -1,8 +1,6 @@
 ---
 match:
   keywords:
-  - "git worktree"
-  - "worktree"
   - "submit PR to external"
   - "PR to gptme"
   - "branch from origin/master"

--- a/lessons/workflow/pre-landing-self-review.md
+++ b/lessons/workflow/pre-landing-self-review.md
@@ -1,7 +1,7 @@
 ---
 description: "Before landing significant changes, run the self-review checklist to catch correctness issues CI won't catch"
 match:
-  keywords: ["pre-landing", "review iteration", "landing significant changes", "substantial change"]
+  keywords: ["pre-landing", "review iteration", "landing a significant change", "substantial change"]
   session_categories: [code, self-review]
 status: active
 ---

--- a/lessons/workflow/pre-landing-self-review.md
+++ b/lessons/workflow/pre-landing-self-review.md
@@ -1,7 +1,7 @@
 ---
 description: "Before landing significant changes, run the self-review checklist to catch correctness issues CI won't catch"
 match:
-  keywords: ["self-review", "pre-landing", "review iteration", "code review", "substantial change"]
+  keywords: ["pre-landing", "review iteration", "landing significant changes", "substantial change"]
   session_categories: [code, self-review]
 status: active
 ---

--- a/lessons/workflow/worktree-push-trap.md
+++ b/lessons/workflow/worktree-push-trap.md
@@ -2,10 +2,10 @@
 description: "After `git worktree add -b BRANCH origin/master`, push with explicit refspec `git push -u origin BRANCH:BRANCH` — bare `git push -u origin BRANCH` targets master due to push.default=upstream"
 match:
   keywords:
-    - "git worktree add"
     - "git push -u origin"
     - "branch from master"
-    - "push.default=upstream"
+    - "feature branch pushed to master"
+    - "refspec pushes to wrong branch"
   session_categories: [code, cross-repo]
 target_grade: [harm, productivity]
 status: active


### PR DESCRIPTION
## Summary

8 lessons had keywords that fired every session because those exact phrases appear in `CLAUDE.md`/`AGENTS.md`/`ABOUT.md`/`ARCHITECTURE.md`/`TASKS.md` (always-injected core files). This defeats the keyword-matching purpose and burns context on irrelevant injections.

- `effective-autonomous-work-execution`: replace `'autonomous session'` with scenario-specific phrases
- `strategic-focus-during-autonomous-sessions`: remove `'idea backlog'` (fires from 3 core files)
- `absolute-paths-for-workspace-files`: remove `'file path'` (too broad)
- `agent-orchestrator-patterns`: remove `'multi-agent'`
- `git-commit-format`: remove `'conventional commits'`
- `git-worktree-workflow`: remove `'git worktree'` and `'worktree'`
- `pre-landing-self-review`: remove `'self-review'` and `'code review'`
- `worktree-push-trap`: remove `'git worktree add'` and `'push.default=upstream'`

Replacements use scenario-specific phrases not present in core files. Lessons that had no remaining keywords now rely on `session_categories` or more targeted trigger phrases.

## Verification

- `lesson-keyword-health.py --autoloaded-context` no longer flags these lessons (only `markdown-codeblock-syntax` self-match remains as expected)
- All 8 edited lessons pass the lesson validator
- Pre-commit hooks passed