### PR TITLE
feat(twitter): add tweet length validation to draft and post commands

### DIFF
--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -808,13 +808,26 @@ def _validate_draft_placeholders(draft: TweetDraft) -> list[str]:
 _URL_RE = re.compile(r"https?://\S+")
 
 
+def _strip_url_trailing_punct(url: str) -> str:
+    """Strip trailing punctuation that Twitter's t.co shortener would trim.
+
+    Twitter strips common sentence-ending punctuation from URLs before
+    counting them toward the 23-char t.co limit.  A tweet like
+    \"Great article https://example.com.\" counts the URL as 23 chars,
+    not 24.
+    """
+    return url.rstrip(".,!?);:>\"'")
+
+
 def count_tweet_chars(text: str) -> int:
     """Count Twitter-weighted characters for the 280-char limit.
 
     Twitter shortens all http/https URLs to t.co links (23 chars each).
+    Strip trailing punctuation that t.co would remove before counting.
     """
     count = len(text)
     for url in _URL_RE.findall(text):
+        url = _strip_url_trailing_punct(url)
         count += TWITTER_URL_WEIGHT - len(url)
     return count
 
@@ -827,7 +840,7 @@ def _validate_draft_length(draft: "TweetDraft") -> list[tuple[str, int]]:
             continue
         n = count_tweet_chars(text)
         if n > TWITTER_MAX_CHARS:
-            over.append((text[:60], n))
+            over.append((text[:60] + ("..." if len(text) > 60 else ""), n))
     return over
 
 
@@ -1416,7 +1429,8 @@ def post(
             console.print(
                 "[red]Skipping draft — shorten the overlong tweet segment(s).[/red]"
             )
-            move_draft(path, "rejected")
+            rejected_path = move_draft(path, "rejected")
+            console.print(f"[red]Moved to {rejected_path}[/red]")
             continue
 
         if yes or Confirm.ask("Post this tweet?", default=True):

--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -39,6 +39,7 @@ sys.path.insert(0, str(_Path(__file__).parent.parent))
 import json
 import logging
 import os
+import re
 import time
 from dataclasses import asdict
 from datetime import date, datetime
@@ -144,6 +145,8 @@ REJECTED_DIR = TWEETS_DIR / "rejected"
 CACHE_DIR = TWEETS_DIR / "cache"
 MAX_POSTS_PER_CYCLE = 2  # Rate limit to prevent mass posting in auto mode
 DRAFT_FILE_SUFFIXES = (".yml", ".yaml", ".md")
+TWITTER_MAX_CHARS = 280
+TWITTER_URL_WEIGHT = 23  # Twitter shortens all URLs to t.co (23 chars)
 
 # Ensure directories exist
 for dir in [NEW_DIR, REVIEW_DIR, APPROVED_DIR, POSTED_DIR, REJECTED_DIR, CACHE_DIR]:
@@ -802,6 +805,32 @@ def _validate_draft_placeholders(draft: TweetDraft) -> list[str]:
     return list(dict.fromkeys(hits))  # deduplicate, preserve order
 
 
+_URL_RE = re.compile(r"https?://\S+")
+
+
+def count_tweet_chars(text: str) -> int:
+    """Count Twitter-weighted characters for the 280-char limit.
+
+    Twitter shortens all http/https URLs to t.co links (23 chars each).
+    """
+    count = len(text)
+    for url in _URL_RE.findall(text):
+        count += TWITTER_URL_WEIGHT - len(url)
+    return count
+
+
+def _validate_draft_length(draft: "TweetDraft") -> list[tuple[str, int]]:
+    """Return (text_snippet, weighted_char_count) for any tweet segment over the limit."""
+    over: list[tuple[str, int]] = []
+    for text in [draft.text, *draft.thread]:
+        if not text:
+            continue
+        n = count_tweet_chars(text)
+        if n > TWITTER_MAX_CHARS:
+            over.append((text[:60], n))
+    return over
+
+
 @cli.command()
 @click.argument("text")
 @click.option(
@@ -849,6 +878,17 @@ def draft(
                 )
                 op.complete(success=False, error="bad_url")
                 sys.exit(1)
+
+        char_count = count_tweet_chars(text)
+        if char_count > TWITTER_MAX_CHARS:
+            console.print(
+                f"[red]✗ Tweet is {char_count} chars (limit: {TWITTER_MAX_CHARS})[/red]"
+            )
+            console.print(
+                "[red]Aborting draft — shorten the text before drafting.[/red]"
+            )
+            op.complete(success=False, error="too_long")
+            sys.exit(1)
 
         scheduled_time = datetime.fromisoformat(schedule) if schedule else None
 
@@ -1365,6 +1405,19 @@ def post(
                 )
                 move_draft(path, "rejected")
                 continue
+
+        # Length validation: catch overlong drafts before they hit the API
+        over_limit = _validate_draft_length(draft)
+        if over_limit:
+            for snippet, char_count in over_limit:
+                console.print(
+                    f"[red]✗ Tweet segment is {char_count} chars (limit: {TWITTER_MAX_CHARS}): '{snippet}...'[/red]"
+                )
+            console.print(
+                "[red]Skipping draft — shorten the overlong tweet segment(s).[/red]"
+            )
+            move_draft(path, "rejected")
+            continue
 
         if yes or Confirm.ask("Post this tweet?", default=True):
             try:

--- a/tests/test_twitter_workflow_drafts.py
+++ b/tests/test_twitter_workflow_drafts.py
@@ -520,3 +520,61 @@ def test_is_reply_restricted_verified(workflow_module: Any) -> None:
 def test_is_reply_restricted_subscribers(workflow_module: Any) -> None:
     tweet = SimpleNamespace(reply_settings="subscribers")
     assert workflow_module.is_reply_restricted(tweet) is True
+
+
+# ── Tweet length validation ──────────────────────────────────────────────────
+
+
+def test_count_tweet_chars_plain_text(workflow_module: Any) -> None:
+    assert workflow_module.count_tweet_chars("Hello world!") == len("Hello world!")
+
+
+def test_count_tweet_chars_url_counts_as_23(workflow_module: Any) -> None:
+    long_url = "https://example.com/" + "x" * 100
+    text = f"Look at this {long_url}"
+    expected = len("Look at this ") + 23
+    assert workflow_module.count_tweet_chars(text) == expected
+
+
+def test_count_tweet_chars_exactly_280(workflow_module: Any) -> None:
+    text = "a" * 280
+    assert workflow_module.count_tweet_chars(text) == 280
+    assert workflow_module.count_tweet_chars(text) <= workflow_module.TWITTER_MAX_CHARS
+
+
+def test_count_tweet_chars_over_limit(workflow_module: Any) -> None:
+    text = "a" * 281
+    assert workflow_module.count_tweet_chars(text) == 281
+    assert workflow_module.count_tweet_chars(text) > workflow_module.TWITTER_MAX_CHARS
+
+
+def test_count_tweet_chars_long_url_reduces_count(workflow_module: Any) -> None:
+    long_url = "https://" + "x" * 300
+    assert workflow_module.count_tweet_chars(long_url) == 23
+
+
+def test_validate_draft_length_passes_under_limit(workflow_module: Any) -> None:
+    draft = workflow_module.TweetDraft(text="Short tweet", type="tweet")
+    assert workflow_module._validate_draft_length(draft) == []
+
+
+def test_validate_draft_length_fails_over_limit(workflow_module: Any) -> None:
+    over_text = "a" * 281
+    draft = workflow_module.TweetDraft(text=over_text, type="tweet")
+    violations = workflow_module._validate_draft_length(draft)
+    assert len(violations) == 1
+    snippet, count = violations[0]
+    assert count == 281
+    assert snippet in over_text
+
+
+def test_validate_draft_length_checks_thread(workflow_module: Any) -> None:
+    draft = workflow_module.TweetDraft(
+        text="Fine tweet",
+        type="thread",
+        thread=["Also fine", "b" * 281],
+    )
+    violations = workflow_module._validate_draft_length(draft)
+    assert len(violations) == 1
+    _, count = violations[0]
+    assert count == 281

--- a/tests/test_twitter_workflow_drafts.py
+++ b/tests/test_twitter_workflow_drafts.py
@@ -565,7 +565,8 @@ def test_validate_draft_length_fails_over_limit(workflow_module: Any) -> None:
     assert len(violations) == 1
     snippet, count = violations[0]
     assert count == 281
-    assert snippet in over_text
+    # snippet has "..." appended only when > 60 chars
+    assert snippet.rstrip(".") in over_text
 
 
 def test_validate_draft_length_checks_thread(workflow_module: Any) -> None:
@@ -578,3 +579,23 @@ def test_validate_draft_length_checks_thread(workflow_module: Any) -> None:
     assert len(violations) == 1
     _, count = violations[0]
     assert count == 281
+
+
+def test_count_tweet_chars_url_trailing_punctuation(workflow_module: Any) -> None:
+    """Trailing punctuation after a URL should NOT be counted as part of the URL.
+
+    Twitter's t.co shortener strips trailing punctuation, so a URL followed
+    by a period, comma, paren, etc. still counts as 23 chars.
+    """
+    url = "https://example.com/article"
+    text = f"Read {url}."
+    # Without the trailing-punct fix: url = "https://example.com/article." (24 chars weighted)
+    # With the fix:                   url = "https://example.com/article"   (23 chars weighted)
+    weighted = workflow_module.count_tweet_chars(text)
+    expected = len("Read ") + 23 + 1  # "Read " + URL(23) + "."
+    assert weighted == expected, f"Got {weighted}, expected {expected}"
+
+    # Also test comma, closing paren, exclamation mark
+    text2 = f"See {url}, amazing!"
+    weighted2 = workflow_module.count_tweet_chars(text2)
+    assert weighted2 < len(text2), "Punctuation after URL should not inflate count"


### PR DESCRIPTION
## Problem

Drafts over 280 characters were silently saved and would fail at post time — often in a way that was hard to debug (the API error is cryptic). URL length wasn't accounted for either (Twitter shortens all URLs to 23-char t.co links, so a tweet with a long URL can look short but count correctly).

## Changes

- `count_tweet_chars(text)` — URL-aware weighted character count (http/https URLs → 23 chars each, per Twitter's t.co behavior)
- Length gate in `draft` command: fails fast before saving with a clear error message if the tweet exceeds 280 chars
- Length gate in `post` command: rejects overlong drafts before the API call (defense-in-depth, for drafts that might have slipped through)
- Validates both main tweet text and thread segments

## Tests

8 new tests in `tests/test_twitter_workflow_drafts.py` covering:
- Plain text under/over the limit
- URLs at the t.co boundary (short URL 23 chars, long URL counts as 23)
- Mixed text+URL counting
- Thread segments validated independently