### PR TITLE
feat(lessons): add 'before executing' keyword to safe-operation-patterns

### DIFF
--- a/lessons/autonomous/safe-operation-patterns.md
+++ b/lessons/autonomous/safe-operation-patterns.md
@@ -3,7 +3,7 @@ description: "Apply safe operation defaults (claim before execute, verify before
 match:
   keywords:
   - "classify operation before executing"
-  - "before executing"
+  - "classify before executing"
   - "safe to execute autonomously"
   - "requires human approval"
 status: active

--- a/lessons/autonomous/safe-operation-patterns.md
+++ b/lessons/autonomous/safe-operation-patterns.md
@@ -3,6 +3,7 @@ description: "Apply safe operation defaults (claim before execute, verify before
 match:
   keywords:
   - "classify operation before executing"
+  - "before executing"
   - "safe to execute autonomously"
   - "requires human approval"
 status: active


### PR DESCRIPTION
## Summary

Expands the keyword match list for `lessons/autonomous/safe-operation-patterns.md` by adding the shorter natural-language variant `"before executing"`.

The lesson is about classifying operations **before executing** them. The phrase `"before executing"` is a common natural trigger in sessions that would benefit from this lesson — but the existing keywords are very specific (`"classify operation before executing"`, `"safe to execute autonomously"`, `"requires human approval"`), which limits recall.

### Why this keyword passes quality filters

- Not an article+noun pattern
- Not an error-signal phrase
- Not an all-generic-token phrase
- ≥2-distinct-session verification gate passed (surfaced via `state/lesson-keyword-crossref-queue.md`)

## Test plan

- [x] Lesson validator passes: `gptme-lessons-extras validate lessons/autonomous/safe-operation-patterns.md`
- [x] Change is purely additive (one line, no logic changes)