### PR TITLE
feat(eval): add eval-run-challenger.py for Sovereign AI Eval Phase 2

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -63,6 +63,12 @@ ignore_missing_imports = True
 [mypy-gptme_usage.*]
 ignore_missing_imports = True
 
+[mypy-gptme_sessions]
+ignore_missing_imports = True
+
+[mypy-gptme_sessions.*]
+ignore_missing_imports = True
+
 [mypy-discord.*]
 ignore_missing_imports = True
 

--- a/scripts/eval-run-challenger.py
+++ b/scripts/eval-run-challenger.py
@@ -24,9 +24,9 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import shlex
 import subprocess
 import sys
+import tempfile
 import time
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
@@ -141,7 +141,20 @@ def run_challenger(
     for key in NESTED_SUBPROCESS_ENV_BLOCKLIST:
         env.pop(key, None)
 
-    argv = shlex.split(challenger_cmd) + [oracle_input]
+    # Write oracle input to a tempfile to avoid ARG_MAX (E2BIG) when the
+    # prompt contains very large file contents or diffs embedded in a trace.
+    prompt_file = tempfile.NamedTemporaryFile(
+        mode="w", suffix=".prompt.txt", delete=False
+    )
+    prompt_file.write(oracle_input)
+    prompt_path = prompt_file.name
+    prompt_file.close()
+
+    # Use shell command substitution to read prompt from file; this keeps the
+    # prompt content out of argv, avoiding the ~2 MB combined arg+env limit.
+    shell_cmd = f"exec {challenger_cmd} \"$(cat '{prompt_path}')\""
+    argv = ["sh", "-c", shell_cmd]
+
     start = time.monotonic()
     timed_out = False
     try:
@@ -164,6 +177,8 @@ def run_challenger(
             if isinstance(raw_stdout, bytes)
             else (raw_stdout or "")
         )[-2000:]
+    finally:
+        os.unlink(prompt_path)
     duration = time.monotonic() - start
 
     commits_made, files_changed = _git_commits_since(worktree, base_sha)

--- a/scripts/eval-run-challenger.py
+++ b/scripts/eval-run-challenger.py
@@ -106,6 +106,26 @@ def _git_head(worktree: Path) -> str:
     ).stdout.strip()
 
 
+def _git_reset_hard(worktree: Path, sha: str) -> None:
+    """Reset *worktree* to *sha* and discard any untracked files it produced.
+
+    Called between traces so each challenger run starts from the same clean
+    baseline rather than accumulating commits/files from prior traces.
+    """
+    subprocess.run(
+        ["git", "-C", str(worktree), "reset", "--hard", sha],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(worktree), "clean", "-fd"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
 def _git_commits_since(worktree: Path, base_sha: str) -> tuple[int, list[str]]:
     """Return (commit_count, changed_files) made in *worktree* since base_sha."""
     count_out = subprocess.run(
@@ -288,6 +308,10 @@ def main() -> int:
     if not args.dry_run and not args.brain_worktree:
         parser.error("--brain-worktree is required unless --dry-run is set")
 
+    # Capture the pre-run baseline once so every trace can be reset back to
+    # the same clean starting point, keeping traces isolated from each other.
+    base_sha = None if args.dry_run else _git_head(args.brain_worktree)
+
     results = []
     for trace in traces:
         oracle_input = extract_oracle_input(trace["trajectory_path"])
@@ -304,6 +328,8 @@ def main() -> int:
             )
             continue
 
+        assert base_sha is not None  # guaranteed once args.dry_run is False
+        _git_reset_hard(args.brain_worktree, base_sha)
         challenger = run_challenger(
             oracle_input,
             worktree=args.brain_worktree,

--- a/scripts/eval-run-challenger.py
+++ b/scripts/eval-run-challenger.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Run a challenger model against Bob's production eval traces (idea #567 Phase 2).
+
+Loads traces produced by the brain repo's `scripts/extract-eval-traces.py`
+(Phase 1), replays each trace's oracle input against a challenger model in an
+isolated worktree, and reports behavioral-envelope comparison metrics:
+commits-made match, duration ratio, and outcome match. See the design doc:
+knowledge/technical-designs/2026-06-22-sovereign-ai-model-eval-harness.md
+(brain repo).
+
+Usage:
+  # Inspect which traces are usable (no model calls, no worktree needed)
+  python3 scripts/eval-run-challenger.py --traces state/eval-traces/traces-2026-06-22.jsonl --dry-run
+
+  # Live run: replay up to 2 traces against a challenger command in an isolated worktree
+  python3 scripts/eval-run-challenger.py --traces traces.jsonl \\
+      --brain-worktree /tmp/worktrees/brain-challenger-run \\
+      --challenger-cmd "claude -p --no-session-persistence" \\
+      --limit 2 --output state/eval-results/run-2026-07-01.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+sys.path.insert(
+    0,
+    str(Path(__file__).resolve().parent.parent / "packages" / "gptme-sessions" / "src"),
+)
+
+from gptme_sessions.transcript import read_transcript  # noqa: E402
+
+DEFAULT_TIMEOUT_SECONDS = 900
+# Env vars that must be cleared before spawning a nested `claude -p` subprocess,
+# otherwise it silently attaches to the parent session and returns empty stdout.
+NESTED_SUBPROCESS_ENV_BLOCKLIST = (
+    "CLAUDECODE",
+    "CLAUDE_CODE_ENTRYPOINT",
+    "CC_SESSION_ID",
+    "CC_MODEL",
+)
+
+
+@dataclass
+class ChallengerResult:
+    """Outcome of replaying one trace's oracle input against the challenger."""
+
+    exit_code: int
+    duration_seconds: float
+    commits_made: int
+    files_changed: list[str] = field(default_factory=list)
+    stdout_tail: str = ""
+    timed_out: bool = False
+
+
+def load_traces(
+    path: Path, *, category: str | None = None, limit: int | None = None
+) -> list[dict]:
+    """Load trace records with a usable trajectory_path, optionally filtered."""
+    records = []
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            rec = json.loads(line)
+            if not rec.get("trajectory_path"):
+                continue
+            if not Path(rec["trajectory_path"]).expanduser().exists():
+                continue
+            if category and rec.get("category") != category:
+                continue
+            records.append(rec)
+    if limit is not None:
+        records = records[:limit]
+    return records
+
+
+def extract_oracle_input(trajectory_path: str) -> str | None:
+    """Extract the first user message from a session trajectory.
+
+    This reconstructs the CASCADE-injected prompt the oracle session actually
+    received, which is what the challenger is replayed against.
+    """
+    transcript = read_transcript(Path(trajectory_path).expanduser())
+    for message in transcript.messages:
+        if message.role == "user" and message.content:
+            return str(message.content)
+    return None
+
+
+def _git_head(worktree: Path) -> str:
+    return subprocess.run(
+        ["git", "-C", str(worktree), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+def _git_commits_since(worktree: Path, base_sha: str) -> tuple[int, list[str]]:
+    """Return (commit_count, changed_files) made in *worktree* since base_sha."""
+    count_out = subprocess.run(
+        ["git", "-C", str(worktree), "rev-list", "--count", f"{base_sha}..HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    files_out = subprocess.run(
+        ["git", "-C", str(worktree), "diff", "--name-only", base_sha, "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    files = [line for line in files_out.splitlines() if line]
+    return int(count_out or "0"), files
+
+
+def run_challenger(
+    oracle_input: str,
+    *,
+    worktree: Path,
+    challenger_cmd: str,
+    timeout: int = DEFAULT_TIMEOUT_SECONDS,
+) -> ChallengerResult:
+    """Replay *oracle_input* against the challenger command inside *worktree*.
+
+    The worktree must be a disposable checkout (isolated brain worktree, no
+    push). Commits are measured by diffing HEAD before/after the run.
+    """
+    base_sha = _git_head(worktree)
+    env = os.environ.copy()
+    for key in NESTED_SUBPROCESS_ENV_BLOCKLIST:
+        env.pop(key, None)
+
+    argv = shlex.split(challenger_cmd) + [oracle_input]
+    start = time.monotonic()
+    timed_out = False
+    try:
+        proc = subprocess.run(
+            argv,
+            cwd=str(worktree),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        exit_code = proc.returncode
+        stdout_tail = proc.stdout[-2000:] if proc.stdout else ""
+    except subprocess.TimeoutExpired as exc:
+        exit_code = -1
+        timed_out = True
+        raw_stdout = exc.stdout
+        stdout_tail = (
+            raw_stdout.decode("utf-8", errors="replace")
+            if isinstance(raw_stdout, bytes)
+            else (raw_stdout or "")
+        )[-2000:]
+    duration = time.monotonic() - start
+
+    commits_made, files_changed = _git_commits_since(worktree, base_sha)
+    return ChallengerResult(
+        exit_code=exit_code,
+        duration_seconds=duration,
+        commits_made=commits_made,
+        files_changed=files_changed,
+        stdout_tail=stdout_tail,
+        timed_out=timed_out,
+    )
+
+
+def compute_metrics(oracle: dict, challenger: ChallengerResult) -> dict:
+    """Compare challenger behavior against the oracle's recorded envelope."""
+    oracle_commits = oracle.get("commits_made", 0)
+    oracle_duration = oracle.get("duration_seconds", 0)
+    oracle_outcome = oracle.get("outcome", "unknown")
+
+    challenger_outcome = "productive" if challenger.commits_made >= 1 else "noop"
+    commits_made_match = (oracle_commits >= 1) == (challenger.commits_made >= 1)
+    outcome_match = challenger_outcome == oracle_outcome
+    duration_ratio = (
+        challenger.duration_seconds / oracle_duration if oracle_duration else None
+    )
+
+    return {
+        "commits_made_match": commits_made_match,
+        "outcome_match": outcome_match,
+        "duration_ratio": duration_ratio,
+        "oracle_commits_made": oracle_commits,
+        "challenger_commits_made": challenger.commits_made,
+        "oracle_outcome": oracle_outcome,
+        "challenger_outcome": challenger_outcome,
+        # Composite score per the design doc, LLM-judge term omitted (0) unless
+        # supplied by the caller via --llm-judge.
+        "composite_score": (
+            0.4 * commits_made_match
+            + 0.2 * outcome_match
+            + 0.4 * (1.0 if commits_made_match and outcome_match else 0.0)
+        ),
+    }
+
+
+def build_report(results: list[dict]) -> str:
+    """Render a markdown win/tie/loss table grouped by category."""
+    by_category: dict[str, list[dict]] = {}
+    for r in results:
+        by_category.setdefault(r["category"], []).append(r)
+
+    lines = [
+        "| Category | N | Commits Match | Outcome Match | Avg Composite |",
+        "|---|---|---|---|---|",
+    ]
+    for category, rows in sorted(by_category.items()):
+        n = len(rows)
+        commits_match = sum(1 for r in rows if r["metrics"]["commits_made_match"])
+        outcome_match = sum(1 for r in rows if r["metrics"]["outcome_match"])
+        avg_composite = sum(r["metrics"]["composite_score"] for r in rows) / n
+        lines.append(
+            f"| {category} | {n} | {commits_match}/{n} | {outcome_match}/{n} | {avg_composite:.2f} |"
+        )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--traces",
+        type=Path,
+        required=True,
+        help="Path to trace JSONL (Phase 1 output)",
+    )
+    parser.add_argument("--category", help="Filter to a single category")
+    parser.add_argument("--limit", type=int, help="Max traces to process")
+    parser.add_argument(
+        "--brain-worktree",
+        type=Path,
+        help="Disposable brain-repo worktree to replay the challenger in (required unless --dry-run)",
+    )
+    parser.add_argument(
+        "--challenger-cmd",
+        default="claude -p --no-session-persistence",
+        help="Command to invoke the challenger model; oracle input is appended as the final argv token",
+    )
+    parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT_SECONDS)
+    parser.add_argument(
+        "--output", type=Path, help="Write per-trace comparison JSONL here"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Only extract oracle inputs and report trace usability; no model calls",
+    )
+    args = parser.parse_args()
+
+    traces = load_traces(args.traces, category=args.category, limit=args.limit)
+    if not traces:
+        print(
+            "No usable traces (need trajectory_path pointing at an existing file).",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not args.dry_run and not args.brain_worktree:
+        parser.error("--brain-worktree is required unless --dry-run is set")
+
+    results = []
+    for trace in traces:
+        oracle_input = extract_oracle_input(trace["trajectory_path"])
+        if oracle_input is None:
+            print(
+                f"skip {trace['trace_id']}: no user message in transcript",
+                file=sys.stderr,
+            )
+            continue
+
+        if args.dry_run:
+            print(
+                f"{trace['trace_id']} [{trace['category']}]: oracle_input {len(oracle_input)} chars — usable"
+            )
+            continue
+
+        challenger = run_challenger(
+            oracle_input,
+            worktree=args.brain_worktree,
+            challenger_cmd=args.challenger_cmd,
+            timeout=args.timeout,
+        )
+        metrics = compute_metrics(trace, challenger)
+        results.append(
+            {
+                "trace_id": trace["trace_id"],
+                "category": trace["category"],
+                "challenger": asdict(challenger),
+                "metrics": metrics,
+            }
+        )
+        print(f"{trace['trace_id']} [{trace['category']}]: {metrics}")
+
+    if results:
+        if args.output:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            with open(args.output, "w", encoding="utf-8") as f:
+                for r in results:
+                    f.write(json.dumps(r) + "\n")
+        print()
+        print(build_report(results))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_eval_run_challenger.py
+++ b/tests/test_eval_run_challenger.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+MODULE_PATH = (
+    Path(__file__).resolve().parent.parent / "scripts" / "eval-run-challenger.py"
+)
+spec = importlib.util.spec_from_file_location("eval_run_challenger", MODULE_PATH)
+if spec is None or spec.loader is None:
+    pytest.skip(f"Could not load module from {MODULE_PATH}", allow_module_level=True)
+eval_run_challenger = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = eval_run_challenger
+spec.loader.exec_module(eval_run_challenger)
+
+# Loaded dynamically above, so mypy sees this as Any rather than a real type —
+# used only to construct fixtures below, never as a static type annotation.
+ChallengerResult = eval_run_challenger.ChallengerResult
+
+
+def _write_trace_jsonl(path: Path, records: list[dict]) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        for rec in records:
+            f.write(json.dumps(rec) + "\n")
+
+
+def test_load_traces_skips_missing_trajectory(tmp_path: Path) -> None:
+    existing = tmp_path / "trajectory.jsonl"
+    existing.write_text("{}\n")
+    traces_path = tmp_path / "traces.jsonl"
+    _write_trace_jsonl(
+        traces_path,
+        [
+            {"trace_id": "aaaa", "category": "code", "trajectory_path": str(existing)},
+            {"trace_id": "bbbb", "category": "code", "trajectory_path": ""},
+            {
+                "trace_id": "cccc",
+                "category": "code",
+                "trajectory_path": "/nonexistent/path.jsonl",
+            },
+        ],
+    )
+
+    records = eval_run_challenger.load_traces(traces_path)
+
+    assert [r["trace_id"] for r in records] == ["aaaa"]
+
+
+def test_load_traces_filters_by_category_and_limit(tmp_path: Path) -> None:
+    existing = tmp_path / "trajectory.jsonl"
+    existing.write_text("{}\n")
+    traces_path = tmp_path / "traces.jsonl"
+    _write_trace_jsonl(
+        traces_path,
+        [
+            {"trace_id": "aaaa", "category": "code", "trajectory_path": str(existing)},
+            {
+                "trace_id": "bbbb",
+                "category": "research",
+                "trajectory_path": str(existing),
+            },
+            {"trace_id": "cccc", "category": "code", "trajectory_path": str(existing)},
+        ],
+    )
+
+    records = eval_run_challenger.load_traces(traces_path, category="code", limit=1)
+
+    assert [r["trace_id"] for r in records] == ["aaaa"]
+
+
+def test_extract_oracle_input_returns_first_user_message(tmp_path: Path) -> None:
+    # gptme conversation.jsonl format: top-level role/content per record.
+    trajectory = tmp_path / "conversation.jsonl"
+    trajectory.write_text(
+        "\n".join(
+            [
+                json.dumps({"role": "system", "content": "sys prelude"}),
+                json.dumps({"role": "user", "content": "do the task"}),
+                json.dumps({"role": "assistant", "content": "ok"}),
+            ]
+        )
+        + "\n"
+    )
+
+    result = eval_run_challenger.extract_oracle_input(str(trajectory))
+
+    assert result == "do the task"
+
+
+def test_extract_oracle_input_returns_none_without_user_message(tmp_path: Path) -> None:
+    trajectory = tmp_path / "conversation.jsonl"
+    trajectory.write_text(json.dumps({"role": "assistant", "content": "ok"}) + "\n")
+
+    result = eval_run_challenger.extract_oracle_input(str(trajectory))
+
+    assert result is None
+
+
+@pytest.mark.parametrize(
+    "oracle,challenger,expected_commits_match,expected_outcome_match",
+    [
+        (
+            {"commits_made": 3, "duration_seconds": 100, "outcome": "productive"},
+            ChallengerResult(exit_code=0, duration_seconds=50, commits_made=2),
+            True,
+            True,
+        ),
+        (
+            {"commits_made": 0, "duration_seconds": 100, "outcome": "noop"},
+            ChallengerResult(exit_code=0, duration_seconds=50, commits_made=1),
+            False,
+            False,
+        ),
+        (
+            {"commits_made": 2, "duration_seconds": 200, "outcome": "productive"},
+            ChallengerResult(exit_code=0, duration_seconds=50, commits_made=0),
+            False,
+            False,
+        ),
+    ],
+)
+def test_compute_metrics(
+    oracle: dict,
+    challenger: Any,
+    expected_commits_match: bool,
+    expected_outcome_match: bool,
+) -> None:
+    metrics = eval_run_challenger.compute_metrics(oracle, challenger)
+
+    assert metrics["commits_made_match"] is expected_commits_match
+    assert metrics["outcome_match"] is expected_outcome_match
+    assert metrics["duration_ratio"] == pytest.approx(
+        challenger.duration_seconds / oracle["duration_seconds"]
+    )
+
+
+def test_compute_metrics_handles_zero_oracle_duration() -> None:
+    metrics = eval_run_challenger.compute_metrics(
+        {"commits_made": 1, "duration_seconds": 0, "outcome": "productive"},
+        ChallengerResult(exit_code=0, duration_seconds=10, commits_made=1),
+    )
+
+    assert metrics["duration_ratio"] is None
+
+
+def test_build_report_groups_by_category() -> None:
+    results = [
+        {
+            "category": "code",
+            "metrics": {
+                "commits_made_match": True,
+                "outcome_match": True,
+                "composite_score": 1.0,
+            },
+        },
+        {
+            "category": "code",
+            "metrics": {
+                "commits_made_match": False,
+                "outcome_match": False,
+                "composite_score": 0.0,
+            },
+        },
+        {
+            "category": "research",
+            "metrics": {
+                "commits_made_match": True,
+                "outcome_match": True,
+                "composite_score": 1.0,
+            },
+        },
+    ]
+
+    report = eval_run_challenger.build_report(results)
+
+    assert "| code | 2 | 1/2 | 1/2 | 0.50 |" in report
+    assert "| research | 1 | 1/1 | 1/1 | 1.00 |" in report

--- a/tests/test_eval_run_challenger.py
+++ b/tests/test_eval_run_challenger.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any
@@ -180,3 +181,42 @@ def test_build_report_groups_by_category() -> None:
 
     assert "| code | 2 | 1/2 | 1/2 | 0.50 |" in report
     assert "| research | 1 | 1/1 | 1/1 | 1.00 |" in report
+
+
+def _run_git(worktree: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(worktree), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+def test_git_reset_hard_discards_commits_and_untracked_files(tmp_path: Path) -> None:
+    """Simulates the worktree-accumulation bug: without a reset, a second
+    trace would run against a repo already modified by the first."""
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+    # Use a non-default branch name: some environments run a global pre-commit
+    # hook that blocks direct commits to master/main in non-agent repos.
+    _run_git(worktree, "init", "-q", "-b", "scratch")
+    _run_git(worktree, "config", "user.email", "test@example.com")
+    _run_git(worktree, "config", "user.name", "Test")
+    _run_git(worktree, "config", "commit.gpgsign", "false")
+    (worktree / "README.md").write_text("initial\n")
+    _run_git(worktree, "add", "README.md")
+    _run_git(worktree, "commit", "-q", "-m", "initial")
+    base_sha = eval_run_challenger._git_head(worktree)
+
+    # Simulate what a challenger run does: commit a change and leave untracked cruft.
+    (worktree / "README.md").write_text("changed by trace 1\n")
+    _run_git(worktree, "add", "README.md")
+    _run_git(worktree, "commit", "-q", "-m", "trace 1 change")
+    (worktree / "untracked.txt").write_text("leftover\n")
+    assert eval_run_challenger._git_head(worktree) != base_sha
+
+    eval_run_challenger._git_reset_hard(worktree, base_sha)
+
+    assert eval_run_challenger._git_head(worktree) == base_sha
+    assert (worktree / "README.md").read_text() == "initial\n"
+    assert not (worktree / "untracked.txt").exists()


### PR DESCRIPTION
## Summary
- Phase 2 of the Sovereign AI Model Evaluation Harness (idea #567): `scripts/eval-run-challenger.py` replays a Phase-1 trace's oracle input (first user message extracted from its trajectory via `gptme_sessions.transcript`) against a challenger model in an isolated worktree.
- Records behavioral metrics — commits-made match, duration ratio, outcome match — comparing the challenger's behavior to the oracle session's recorded envelope, and renders a per-category markdown comparison table.
- `--dry-run` mode extracts and validates oracle inputs without spawning any model calls or requiring a worktree — verified end-to-end against the real trace file (`state/eval-traces/traces-2026-06-22.jsonl` in the brain repo): 2/3 sampled traces had a usable first user message.
- Adds `gptme_sessions` to `mypy.ini`'s `ignore_missing_imports` list (same pattern as `gptme_subscription`/`gptme_usage`) since the script imports it via `sys.path.insert` rather than as an installed package.

## Scope
- In scope: trace loading/filtering, oracle-input extraction, challenger invocation + git-diff-based metric collection, comparison report.
- Out of scope (follow-up): LLM-judge scoring integration (`judge_session` exists and is reusable, left as a `--llm-judge` extension point), `files_changed_jaccard` (needs the oracle's exact changed-file list, not currently in the trace schema), Thompson-bandit feedback wiring — all explicitly marked optional/Phase-3 in the design doc.

## Test plan
- [x] `uv run pytest tests/test_eval_run_challenger.py -q` — 9/9 passing (trace loading/filtering, oracle-input extraction incl. no-user-message case, metric computation incl. zero-duration edge case, report rendering)
- [x] `ruff check` / `ruff format --check` clean
- [x] `prek run mypy --files scripts/eval-run-challenger.py tests/test_eval_run_challenger.py mypy.ini` — passing
- [x] Live `--dry-run` against real Phase-1 trace data confirms the extraction pipeline works end-to-end