### PR TITLE
fix(tools): use specific mypy error codes for type: ignore comments

### DIFF
--- a/scripts/perplexity.py
+++ b/scripts/perplexity.py
@@ -93,7 +93,7 @@ class PerplexitySearch:
             with open(config_path, "rb") as f:
                 config = tomllib.load(f)
                 if api_key := config.get("env", {}).get("PERPLEXITY_API_KEY"):
-                    return api_key  # type: ignore
+                    return api_key  # type: ignore[no-any-return]
 
         raise ValueError(
             f"Perplexity API key not found. Set PERPLEXITY_API_KEY environment variable or add 'PERPLEXITY_API_KEY' to the env section in {config_path}"

--- a/scripts/twitter/twitter.py
+++ b/scripts/twitter/twitter.py
@@ -601,7 +601,7 @@ def format_tweet_time(tweet: tweepy.Tweet) -> str:
     """Format tweet timestamp"""
     if not hasattr(tweet, "created_at"):
         return "N/A"
-    return tweet.created_at.strftime("%Y-%m-%d %H:%M")  # type: ignore
+    return tweet.created_at.strftime("%Y-%m-%d %H:%M")  # type: ignore[no-any-return]
 
 
 def display_tweet(tweet: tweepy.Tweet, author_info: str | None = None) -> None:

--- a/tools/rss_reader.py
+++ b/tools/rss_reader.py
@@ -39,7 +39,7 @@ import click
 import feedparser
 import requests
 import yaml
-from bs4 import BeautifulSoup  # type: ignore
+from bs4 import BeautifulSoup  # type: ignore[import-untyped]
 from dotenv import load_dotenv
 from rich.console import Console
 from rich.table import Table


### PR DESCRIPTION
## Summary
- ruff's `PGH003` rule flagged 3 blanket `# type: ignore` comments in `tools/` scripts.
- `scripts/perplexity.py:96` and `scripts/twitter/twitter.py:604` were suppressing a real `no-any-return` (returning `Any` from an attribute/dict-get chain in a function typed to return `str`) — narrowed to `# type: ignore[no-any-return]`.
- `tools/rss_reader.py:42` (`from bs4 import BeautifulSoup`) narrowed to `# type: ignore[import-untyped]` (no stub package installed for bs4).

## Test plan
- [x] `uv run ruff check scripts/perplexity.py scripts/twitter/twitter.py tools/rss_reader.py` — clean
- [x] `uv run pytest tests/test_perplexity.py tests/test_twitter_workflow_drafts.py tests/test_twitter_eval_prompt.py tests/test_twitter_post_url_guard.py -q` — 51 passed
- [x] pre-commit (mypy hook) passes on the changed files