### PR TITLE
fix(gptodo): include todo + ready_for_review in status --compact

### DIFF
--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -788,7 +788,7 @@ def check_directory(
         )
 
     # Determine which states to show based on compact mode
-    states_to_show = ["backlog", "active"] if compact else config.states
+    states_to_show = ["backlog", "todo", "active", "ready_for_review"] if compact else config.states
 
     # Print active states in order
     for state in states_to_show:
@@ -945,7 +945,9 @@ def _show_github_issues(
 @cli.command()
 @click.option("--type", type=click.Choice(list(CONFIGS.keys())), default="tasks")
 @click.option("--all", is_flag=True, help="Check all directory types")
-@click.option("--compact", is_flag=True, help="Only show new and active tasks")
+@click.option(
+    "--compact", is_flag=True, help="Only show backlog/todo/active/ready_for_review tasks"
+)
 @click.option("--summary", is_flag=True, help="Only show summary")
 @click.option("--issues", is_flag=True, help="Only show items with issues")
 @click.option(

--- a/packages/gptodo/tests/test_status_compact.py
+++ b/packages/gptodo/tests/test_status_compact.py
@@ -60,11 +60,12 @@ def test_status_compact_includes_ready_for_review_tasks(tmp_path: Path, monkeypa
     assert "rfr-task" in output, "compact mode must show ready_for_review tasks"
 
 
-def test_status_compact_excludes_terminal_states(tmp_path: Path, monkeypatch) -> None:
-    """Compact mode must not show done, cancelled, or someday tasks."""
+def test_status_compact_excludes_hidden_states(tmp_path: Path, monkeypatch) -> None:
+    """Compact mode must not show waiting, done, cancelled, or someday tasks."""
     tasks_dir = tmp_path / "tasks"
     tasks_dir.mkdir()
     write_task(tasks_dir, "active-task", state="active", created="2026-01-01T00:00:00")
+    write_task(tasks_dir, "waiting-task", state="waiting", created="2026-01-01T00:00:00")
     write_task(tasks_dir, "done-task", state="done", created="2026-01-01T00:00:00")
     write_task(tasks_dir, "cancelled-task", state="cancelled", created="2026-01-01T00:00:00")
     write_task(tasks_dir, "someday-task", state="someday", created="2026-01-01T00:00:00")
@@ -72,6 +73,7 @@ def test_status_compact_excludes_terminal_states(tmp_path: Path, monkeypatch) ->
     output = _run_status_compact(tmp_path, monkeypatch)
 
     assert "active-task" in output
+    assert "waiting-task" not in output
     assert "done-task" not in output
     assert "cancelled-task" not in output
     assert "someday-task" not in output

--- a/packages/gptodo/tests/test_status_compact.py
+++ b/packages/gptodo/tests/test_status_compact.py
@@ -1,0 +1,77 @@
+"""Tests for `gptodo status --compact` mode.
+
+Compact mode should show backlog, todo, active, and ready_for_review tasks.
+It must NOT hide todo/ready_for_review tasks (regression from the original
+["backlog", "active"]-only filter).
+"""
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from gptodo.cli import cli
+
+
+def write_task(tasks_dir: Path, name: str, **metadata: object) -> None:
+    lines = ["---"]
+    for key, value in metadata.items():
+        if isinstance(value, list):
+            lines.append(f"{key}:")
+            for item in value:
+                lines.append(f"  - {item}")
+        else:
+            lines.append(f"{key}: {value}")
+    lines.extend(["---", f"# {name}"])
+    (tasks_dir / f"{name}.md").write_text("\n".join(lines))
+
+
+def _run_status_compact(tmp_path: Path, monkeypatch) -> str:
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(cli, ["status", "--compact"])
+    assert result.exit_code == 0, result.output
+    return result.output
+
+
+def test_status_compact_includes_todo_tasks(tmp_path: Path, monkeypatch) -> None:
+    """Compact mode must show todo tasks, not just backlog/active."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(tasks_dir, "backlog-task", state="backlog", created="2026-01-01T00:00:00")
+    write_task(tasks_dir, "todo-task", state="todo", created="2026-01-01T00:00:00")
+    write_task(tasks_dir, "active-task", state="active", created="2026-01-01T00:00:00")
+
+    output = _run_status_compact(tmp_path, monkeypatch)
+
+    assert "backlog-task" in output
+    assert "todo-task" in output, "compact mode must show todo tasks"
+    assert "active-task" in output
+
+
+def test_status_compact_includes_ready_for_review_tasks(tmp_path: Path, monkeypatch) -> None:
+    """Compact mode must show ready_for_review tasks."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(tasks_dir, "active-task", state="active", created="2026-01-01T00:00:00")
+    write_task(tasks_dir, "rfr-task", state="ready_for_review", created="2026-01-01T00:00:00")
+
+    output = _run_status_compact(tmp_path, monkeypatch)
+
+    assert "active-task" in output
+    assert "rfr-task" in output, "compact mode must show ready_for_review tasks"
+
+
+def test_status_compact_excludes_terminal_states(tmp_path: Path, monkeypatch) -> None:
+    """Compact mode must not show done, cancelled, or someday tasks."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(tasks_dir, "active-task", state="active", created="2026-01-01T00:00:00")
+    write_task(tasks_dir, "done-task", state="done", created="2026-01-01T00:00:00")
+    write_task(tasks_dir, "cancelled-task", state="cancelled", created="2026-01-01T00:00:00")
+    write_task(tasks_dir, "someday-task", state="someday", created="2026-01-01T00:00:00")
+
+    output = _run_status_compact(tmp_path, monkeypatch)
+
+    assert "active-task" in output
+    assert "done-task" not in output
+    assert "cancelled-task" not in output
+    assert "someday-task" not in output


### PR DESCRIPTION
## Summary

- `gptodo status --compact` was filtering to only `backlog` and `active` states, hiding `todo` and `ready_for_review` tasks from the compact overview
- Agents relying on `--compact` for quick status checks would miss tasks in the `scheduled` and `review-ready` lanes entirely
- Fix adds both states to the compact filter and updates the `--help` text
- 3 new regression tests covering the four displayed states and confirming terminal states are excluded

## Test plan

- [x] `test_status_compact_includes_todo_tasks` — confirms `todo` tasks appear in compact output
- [x] `test_status_compact_includes_ready_for_review_tasks` — confirms `ready_for_review` tasks appear
- [x] `test_status_compact_excludes_terminal_states` — confirms `done`/`cancelled`/`someday` are still hidden
- [x] Full 224-test suite passes with no regressions

---

Note: Gordon (gordon agent) identified this bug and had a fix ready on `gordon/gptodo-compact-fix-jul1` in his local checkout, but couldn't push due to a 403 PAT scope issue. This PR covers the same core fix (`status --compact`) based on his bug report.