### PR TITLE
feat(gptodo): state-transition enforcement + expire command + lint + --compact fix

### DIFF
--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -789,8 +789,15 @@ def check_directory(
             results["untracked"],
         )
 
-    # Determine which states to show based on compact mode
-    states_to_show = ["backlog", "todo", "active", "ready_for_review"] if compact else config.states
+    # Determine which states to show based on compact mode.
+    # Compact = the active work funnel: untriaged, triaged, in-flight,
+    # and awaiting verification. Exclude blocked, deferred, and terminal
+    # states so the short view stays focused on real work.
+    states_to_show = (
+        [s for s in ("backlog", "todo", "active", "ready_for_review") if s in config.states]
+        if compact
+        else config.states
+    )
 
     # Print active states in order
     for state in states_to_show:
@@ -948,7 +955,9 @@ def _show_github_issues(
 @click.option("--type", type=click.Choice(list(CONFIGS.keys())), default="tasks")
 @click.option("--all", is_flag=True, help="Check all directory types")
 @click.option(
-    "--compact", is_flag=True, help="Only show backlog/todo/active/ready_for_review tasks"
+    "--compact",
+    is_flag=True,
+    help="Show only the active work funnel: backlog, todo, active, ready_for_review",
 )
 @click.option("--summary", is_flag=True, help="Only show summary")
 @click.option("--issues", is_flag=True, help="Only show items with issues")
@@ -2853,7 +2862,18 @@ def expire(days: int, states: tuple[str, ...], dry_run: bool, output_json: bool)
     all_tasks = load_tasks(tasks_dir)
     if not all_tasks:
         if output_json:
-            print(json.dumps({"expired": [], "count": 0, "dry_run": dry_run}, indent=2))
+            print(
+                json.dumps(
+                    {
+                        "expired": [],
+                        "count": 0,
+                        "days_threshold": days,
+                        "eligible_states": eligible,
+                        "dry_run": dry_run,
+                    },
+                    indent=2,
+                )
+            )
         else:
             console.print("[yellow]No tasks found![/]")
         return

--- a/packages/gptodo/tests/test_expire.py
+++ b/packages/gptodo/tests/test_expire.py
@@ -315,6 +315,24 @@ def test_expire_json_output(tmp_path: Path, monkeypatch) -> None:
     assert from_states == {"backlog", "todo"}
 
 
+def test_expire_json_empty_task_directory_uses_full_schema(tmp_path: Path, monkeypatch) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(cli, ["expire", "--json"])
+    assert result.exit_code == 0, result.output
+
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "expired": [],
+        "count": 0,
+        "days_threshold": 90,
+        "eligible_states": ["backlog", "todo", "someday"],
+        "dry_run": False,
+    }
+
+
 def test_expire_json_dry_run(tmp_path: Path, monkeypatch) -> None:
     tasks_dir = tmp_path / "tasks"
     tasks_dir.mkdir()


### PR DESCRIPTION
gptodo hygiene improvements across three commits. **This work is Gordon's** — I'm landing it because his fine-grained PAT gets a 403 on `git push` to gptme/gptme-contrib (repo API reports push:true but the push is denied). Fetched his rebase-clean branch over SSH and pushed with working creds.

## Commits
- **feat(gptodo): CLI-enforced state transitions + lint command** — enforces valid task state transitions at the CLI layer and adds a `lint` command that flags hallucinated/unknown frontmatter fields.
- **feat(gptodo): add `expire` command + `expired` state** — auto-reaping of stale tasks; `expire --dry-run --days 30` surfaces stale candidates without mutating.
- **fix(gptodo): include todo + ready_for_review in `status --compact`** — the compact status view was omitting `todo` and `ready_for_review`; now included.

## Testing
- Gordon: `uv run pytest -q` in packages/gptodo → **266 passed**; `gptodo expire --dry-run --days 30` flagged 41 stale tasks sanely; `lint`/`expire --help` render fine.
- Independent re-run (Bob, this checkout): `uv run pytest -q packages/gptodo` → **266 passed**.

Diff is scoped entirely to `packages/gptodo/` (8 files, +1738/-8): README, checker.py, cli.py, utils.py + 4 new test files.

Addresses Gordon's task `gptodo-upstream-document-state-semantics-and-lint-hallucinated`. Was blocked on his PAT 403.

Co-Authored-By: Gordon <gordon@superuserlabs.org>