### PR TITLE
fix(greptile-helper): scope re-trigger guard to current review cycle

### DIFF
--- a/scripts/github/greptile-helper.sh
+++ b/scripts/github/greptile-helper.sh
@@ -228,6 +228,10 @@ _needs_re_review() {
     # Fallback: no PR-review commit_id available → use the date heuristic.
     info=$(_greptile_review_info) || return 1
     reviewed_at=$(echo "$info" | _json_field "reviewed_at") || reviewed_at=""
+    # Defense-in-depth: jq outputs literal "null" on null JSON via -r flag.
+    # _json_field uses Python (handles None correctly), but guard against
+    # future refactors that switch to jq-based extraction.
+    if [ "$reviewed_at" = "null" ]; then reviewed_at=""; fi
     if [ -z "$reviewed_at" ]; then
         return 1
     fi

--- a/scripts/github/greptile-helper.sh
+++ b/scripts/github/greptile-helper.sh
@@ -63,26 +63,39 @@ _json_field() {
 
 _no_new_commit_since_our_last_trigger() {
     # Returns 0 (true) when the PR head commit is NOT newer than our most recent
-    # `@greptileai review` trigger — i.e. we already triggered for the current head
-    # and nothing has been pushed since. Re-triggering then is exactly the "re-reviewing
-    # without pushing anything" spam Erik flagged on gptme#2908: the SHA-based
-    # _needs_re_review stays true forever when Greptile acks a trigger but never advances
-    # its review commit_id to head, so without this guard each grace window re-fires.
-    # Gating on OUR last trigger (not the last review) makes a re-review with no new
-    # commit structurally impossible — the lifetime ceiling is only a backstop above this.
-    # Fail-OPEN to 1 (allow) when there's no prior trigger or head can't be read, so a
+    # `@greptileai review` trigger IN THE CURRENT REVIEW CYCLE — i.e. we already
+    # triggered for the current head and nothing has been pushed since. Re-triggering
+    # then is exactly the "re-reviewing without pushing anything" spam Erik flagged on
+    # gptme#2908: the SHA-based _needs_re_review stays true forever when Greptile acks a
+    # trigger but never advances its review commit_id to head, so without this guard each
+    # grace window re-fires.
+    #
+    # IMPORTANT: Only triggers AFTER review_cutoff are in-scope (current review cycle).
+    # Pre-review triggers are "spent" — Greptile already responded to them. When Greptile
+    # updates its review comment in-place (advancing reviewed_at), old triggers become spent
+    # and must NOT gate the next re-review. Root cause: gptme/gptme#2987 commit e07b1a4b
+    # had committer.date 10s before our last trigger (written locally, then pushed). The
+    # pre-cutoff trigger made last_trigger_date land after the commit date, so the guard
+    # incorrectly suppressed a legitimate re-review. Fix: compare only within-cycle triggers.
+    #
+    # Fail-OPEN to 1 (allow) when there's no in-cycle trigger or head can't be read, so a
     # transient API failure never permanently suppresses a legitimate re-review.
+    local review_cutoff="${1:-}"
     local head_date last_trigger_date
+    local cycle_filter=""
+    if [ -n "$review_cutoff" ]; then
+        cycle_filter="| select(.created_at > \"$review_cutoff\")"
+    fi
     head_date=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/commits" 2>/dev/null \
         | jq -rs '[.[][] | .commit.committer.date] | sort | last // ""' 2>/dev/null) || head_date=""
     last_trigger_date=$(_issue_comments_json \
-        | jq -r "[.[][] | select(.user.login == \"$GITHUB_AUTHOR\" and (.body | test(\"@greptileai review\"))) | .created_at] | sort | last // \"\"" 2>/dev/null) || last_trigger_date=""
-    [ -z "$last_trigger_date" ] && return 1   # no prior trigger → allow
+        | jq -r "[.[][] | select(.user.login == \"$GITHUB_AUTHOR\" and (.body | test(\"@greptileai review\"))) $cycle_filter | .created_at] | sort | last // \"\"" 2>/dev/null) || last_trigger_date=""
+    [ -z "$last_trigger_date" ] && return 1   # no in-cycle trigger → allow (nothing to gate against)
     [ -z "$head_date" ] && return 1           # can't read head → allow (fail-open)
     if _timestamp_gt "$head_date" "$last_trigger_date" 2>/dev/null; then
-        return 1   # a commit landed AFTER our last trigger → re-review is legitimate
+        return 1   # a commit landed AFTER our in-cycle trigger → re-review is legitimate
     fi
-    return 0       # nothing pushed since our last trigger → suppress
+    return 0       # nothing pushed since our in-cycle trigger → suppress
 }
 
 _timestamp_gt() {
@@ -361,11 +374,13 @@ check)
             if [ "$trigger_status" = "in-progress" ]; then
                 exit 1  # Re-review trigger in-flight
             fi
-            # Root guard: no new commit since our last trigger → not safe to trigger.
+            # Root guard: no new commit since our last in-cycle trigger → not safe to trigger.
             # Exception: trigger_status=stale means Greptile acked but never reviewed —
             # skip this guard so the stale-retry path can fire and recover the stuck PR.
-            if [ "$trigger_status" != "stale" ] && _no_new_commit_since_our_last_trigger; then
-                exit 2  # Nothing pushed since our last trigger — treat as up-to-date.
+            # Pass reviewed_at so the guard only considers triggers from the current review
+            # cycle (pre-review "spent" triggers must not gate the next re-review).
+            if [ "$trigger_status" != "stale" ] && _no_new_commit_since_our_last_trigger "$reviewed_at"; then
+                exit 2  # Nothing pushed since our last in-cycle trigger — treat as up-to-date.
             fi
             exit 0  # Re-review needed
         fi
@@ -411,12 +426,13 @@ trigger)
                 echo "  [greptile] Re-review trigger in-flight on $REPO#$PR_NUMBER. Skipping."
                 exit 0
             fi
-            # ROOT GUARD: never re-review without a new commit since OUR last trigger.
+            # ROOT GUARD: never re-review without a new commit since OUR last in-cycle trigger.
             # _needs_re_review (SHA-based) stays true when Greptile acks but doesn't advance
             # its review commit_id to head, so this catches the "re-reviewing without pushing"
             # spam (gptme#2908). Exception: trigger_status=stale means Greptile acked but
             # never reviewed — skip the guard and allow re-trigger to escape the stuck state.
-            if [ "$trigger_status" != "stale" ] && _no_new_commit_since_our_last_trigger; then
+            # Pass reviewed_at: guard must only fire against in-cycle triggers (post-review).
+            if [ "$trigger_status" != "stale" ] && _no_new_commit_since_our_last_trigger "$reviewed_at"; then
                 echo "  [greptile] SKIP: $REPO#$PR_NUMBER has no new commits since our last @greptileai review trigger. Not re-reviewing (nothing was pushed)."
                 exit 0
             fi
@@ -458,9 +474,9 @@ status)
                 trigger_status=$(_our_trigger_status "$reviewed_at" || echo "in-progress")
                 if [ "$trigger_status" = "in-progress" ]; then
                     echo "in-progress"
-                # Root guard: no new commit since our last trigger → report as up-to-date.
+                # Root guard: no new commit since our last in-cycle trigger → report as up-to-date.
                 # Exception: stale means Greptile acked but never reviewed → needs-re-review.
-                elif [ "$trigger_status" != "stale" ] && _no_new_commit_since_our_last_trigger; then
+                elif [ "$trigger_status" != "stale" ] && _no_new_commit_since_our_last_trigger "$reviewed_at"; then
                     echo "already-reviewed"
                 else
                     echo "needs-re-review"

--- a/tests/test_greptile_helper.py
+++ b/tests/test_greptile_helper.py
@@ -318,6 +318,57 @@ def test_rereview_ignores_old_trigger_from_previous_review_cycle():
     assert status.stdout.strip() == "needs-re-review"
 
 
+def test_spent_trigger_with_backdated_commit_does_not_suppress():
+    """Regression for gptme/gptme#2987: Greptile updates its comment in-place
+    (advancing reviewed_at), making our prior trigger 'spent'. The new commit has
+    committer.date BEFORE the trigger timestamp (written locally then pushed), so the
+    date comparison incorrectly reports 'no new commits since our last trigger'.
+    The fix: only consider in-cycle triggers (after review_cutoff) when gating.
+
+    Timeline:
+      R1 = 60min ago   Greptile posts initial PR review on commit OLDSHA
+      T1 = 40min ago   We trigger re-review (@greptileai review comment)
+      R2 = 20min ago   Greptile updates its issue comment in-place (reviewed_at = R2)
+                       → T1 is now 'spent' (T1 < R2, trigger_status = 'none')
+                       → Greptile's PR review commit_id still points at OLDSHA
+      D  = 45min ago   New commit pushed (HEAD = NEWSHA), committer.date = 45min ago
+                       → committer.date (45min) < T1 (40min) in absolute time
+                       → Old guard: head_date < last_trigger_date → SUPPRESS (bug!)
+                       → New guard: no trigger after R2 → allow ✓
+    """
+    # Greptile created comment 60min ago, updated in-place 20min ago (reviewed_at = R2)
+    reviewed_at = _iso_ago(minutes=20)
+    fixture = {
+        "pr_number": 2987,
+        "raw_comments": [
+            _make_greptile_comment(
+                4, reviewed_at=_iso_ago(minutes=60), updated_at=reviewed_at
+            ),
+            # T1 = 40min ago, "spent" because T1 (40min) < R2 (20min) in absolute time
+            _make_trigger_comment("test-user", _iso_ago(minutes=40)),
+        ],
+        # SHA-based primary path: Greptile reviewed OLDSHA, PR head is NEWSHA
+        "raw_reviews": [_make_greptile_review("OLDSHA", _iso_ago(minutes=60))],
+        "raw_pr": {"head": {"sha": "NEWSHA"}, "created_at": _iso_ago(minutes=120)},
+        "raw_commits": [
+            # Commit pushed to PR after T1, but committer.date = 45min ago (before T1=40min)
+            _make_commit(_iso_ago(minutes=45)),
+        ],
+        "bot_reaction_count": 0,
+    }
+    # Must NOT suppress: the "spent" pre-review trigger must not gate the new re-review
+    result = _run_helper("check", fixture)
+    assert result.returncode == 0, (
+        f"Spent trigger with backdated commit must not suppress re-review. "
+        f"stderr: {result.stderr}"
+    )
+
+    status = _run_helper("status", fixture)
+    assert (
+        status.stdout.strip() == "needs-re-review"
+    ), f"Expected needs-re-review, got: {status.stdout.strip()}"
+
+
 def _make_greptile_review(commit_id: str, submitted_at: str) -> dict:
     return {
         "user": {"login": "greptile-apps[bot]"},

--- a/tests/test_greptile_helper.py
+++ b/tests/test_greptile_helper.py
@@ -368,6 +368,16 @@ def test_spent_trigger_with_backdated_commit_does_not_suppress():
         status.stdout.strip() == "needs-re-review"
     ), f"Expected needs-re-review, got: {status.stdout.strip()}"
 
+    # Trigger must also succeed: spent trigger + no in-cycle trigger → allow
+    result, log = _run_helper("trigger", fixture, capture_gh_log=True)
+    assert result.returncode == 0, (
+        f"Spent trigger with backdated commit must allow re-trigger. "
+        f"stdout: {result.stdout}, stderr: {result.stderr}"
+    )
+    assert (
+        "@greptileai review" in log
+    ), f"Trigger must post a review comment. log: {log}"
+
 
 def _make_greptile_review(commit_id: str, submitted_at: str) -> dict:
     return {


### PR DESCRIPTION
## Summary

- **Bug**: `_no_new_commit_since_our_last_trigger` compared HEAD commit date against ALL prior trigger timestamps, including triggers from before the current Greptile review cycle. When Greptile updates its comment in-place (advancing `reviewed_at`), old triggers become 'spent' — but their timestamps still gated new re-reviews.
- **Fix**: Pass `review_cutoff` (the current `reviewed_at`) to scope comparison to in-cycle triggers only. If no in-cycle triggers exist, return 1 (allow).
- **Test**: Regression test `test_spent_trigger_with_backdated_commit_does_not_suppress` reproduces the exact PR #2987 timeline.

## Root Cause (PR gptme/gptme#2987)

```
T=12:08:41  Commit pushed (committer.date = 12:08:41, backdated locally)
T=12:08:51  We post trigger T1 (@greptileai review)
T=12:12:04  Greptile updates its issue comment in-place (reviewed_at advances to 12:12)
            → T1 is now 'spent' (T1 < reviewed_at, trigger_status = "none")

Old guard:
  head_date (12:08:41) < last_trigger_date (12:08:51) → SUPPRESS (wrong!)

New guard:
  No in-cycle trigger (no trigger after review_cutoff=12:12) → ALLOW ✓
```

## Anti-spam invariants preserved

- `MAX_RE_TRIGGERS` ceiling still applies
- Flock and age guard unchanged
- In-cycle triggers (triggers AFTER last review) still gate normally
- `_no_new_commit_since_our_last_trigger` with no review_cutoff falls back to original behavior (safe default)

## Test plan
- [x] 23/23 tests pass (`uv run pytest tests/test_greptile_helper.py -v`)
- [x] New regression test covers the #2987 timeline exactly
- [x] ShellCheck, ruff, mypy all pass