### PR TITLE
fix(gptodo): skip high-priority tasks in expire command

### DIFF
--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -2776,6 +2776,7 @@ def _task_is_expirable(task: TaskInfo, cutoff: datetime, eligible_states: List[s
       - task.created is on/before `cutoff`
       - task has no `recur:` field (recurring tasks are legitimately dormant)
       - task has no future `wait:` date (waited-on tasks aren't stale)
+      - task.priority is not "high" (high-priority tasks are intentionally kept)
     """
     if task.state not in eligible_states:
         return False
@@ -2785,6 +2786,9 @@ def _task_is_expirable(task: TaskInfo, cutoff: datetime, eligible_states: List[s
         return False
     # Future wait: means the task is intentionally hidden until then; not stale.
     if task_is_waiting_for_date(task):
+        return False
+    # High-priority tasks are explicitly important; don't silently reap them.
+    if task.priority == "high":
         return False
     return True
 
@@ -2836,6 +2840,7 @@ def expire(days: int, states: tuple[str, ...], dry_run: bool, output_json: bool)
       - Tasks in active/waiting/ready_for_review (live work).
       - Tasks with `recur:` set (legitimately dormant between fires).
       - Tasks with a future `wait:` date (intentionally hidden).
+      - Tasks with `priority: high` (explicitly important, never silently reaped).
 
     Examples:
         gptodo expire                       # 90d default, all eligible states

--- a/packages/gptodo/tests/test_expire.py
+++ b/packages/gptodo/tests/test_expire.py
@@ -9,7 +9,7 @@ point is to unclutter, not to permanently kill.
 These tests cover:
 
   1. Default 90d window reaps only tasks that meet ALL predicates
-     (state, age, no recur, no future wait).
+     (state, age, no recur, no future wait, non-high priority).
   2. --days N adjusts the window.
   3. --state restricts which eligible states get reaped.
   4. --dry-run reports but does not mutate.
@@ -23,6 +23,7 @@ These tests cover:
      nothing new to expire.
  11. --json emits a stable machine-readable contract.
  12. Expired tasks are excluded from `gptodo ready` and `gptodo next`.
+ 13. High-priority tasks are never reaped regardless of age.
 """
 
 from __future__ import annotations
@@ -464,3 +465,42 @@ def test_expire_env_var_overrides_default_days(tmp_path: Path, monkeypatch) -> N
     assert result.exit_code == 0, result.output
     tasks = load_tasks(tasks_dir)
     assert tasks[0].metadata["state"] == "expired"
+
+
+# ---------- Priority guard -----------------------------------------------------
+
+
+def test_expire_skips_high_priority_tasks(tmp_path: Path, monkeypatch) -> None:
+    """High-priority tasks are never reaped regardless of age."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    _write(tasks_dir, "high-prio", "someday", _iso(200), extra="priority: high")
+    _write(tasks_dir, "medium-prio", "someday", _iso(200), extra="priority: medium")
+    _write(tasks_dir, "no-prio", "someday", _iso(200))
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(cli, ["expire"])
+    assert result.exit_code == 0, result.output
+
+    by_name = {t.name: t for t in load_tasks(tasks_dir)}
+    assert by_name["high-prio"].metadata["state"] == "someday"  # protected
+    assert by_name["medium-prio"].metadata["state"] == "expired"
+    assert by_name["no-prio"].metadata["state"] == "expired"
+
+
+def test_expire_high_priority_excluded_from_json_output(tmp_path: Path, monkeypatch) -> None:
+    """High-priority tasks must not appear in --json expired list."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    _write(tasks_dir, "high-prio", "backlog", _iso(200), extra="priority: high")
+    _write(tasks_dir, "low-prio", "backlog", _iso(200), extra="priority: low")
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(cli, ["expire", "--json"])
+    assert result.exit_code == 0, result.output
+
+    payload = json.loads(result.stdout)
+    assert payload["count"] == 1
+    ids = {r["id"] for r in payload["expired"]}
+    assert "low-prio" in ids
+    assert "high-prio" not in ids


### PR DESCRIPTION
## Summary

`gptodo expire` auto-reaps long-quiet tasks (backlog/todo/someday older than N days) to unclutter the queue. High-priority tasks were not exempt — a `priority: high` task that had been parked in `someday` for 90+ days would be silently transitioned to `expired`, even if it was waiting on a human decision or time gate.

This is wrong: high-priority tasks are explicitly flagged as important and should require intentional human action (not auto-reaped silently).

## Changes

- `_task_is_expirable()`: add priority guard — returns `False` when `task.priority == "high"`
- `expire` command docstring: document the new skip rule
- Two new tests:
  - `test_expire_skips_high_priority_tasks`: high-prio stays in someday; medium and no-priority are reaped
  - `test_expire_high_priority_excluded_from_json_output`: high-prio absent from `--json` expired list

## Test plan

- [x] All 25 expire tests pass (`uv run pytest packages/gptodo/tests/test_expire.py -v`)
- [x] Pre-commit hooks pass
- [x] Verified against real task corpus: `security-defense-in-depth-followup` (priority: high, someday, 95d) is no longer a candidate for auto-expire