### PR TITLE
fix(tests): make flaky tests deterministic

### DIFF
--- a/packages/gptmail/tests/test_token_expiry.py
+++ b/packages/gptmail/tests/test_token_expiry.py
@@ -21,14 +21,14 @@ def test_is_not_expired_with_utc_aware() -> None:
 
 def test_is_expired_with_naive_datetime() -> None:
     """Naive datetime (legacy) still works — treated as UTC."""
-    expired = datetime.utcnow() - timedelta(hours=1)
+    expired = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(hours=1)
     info = TokenInfo(token="t", expires_at=expired)
     assert info.is_expired() is True
 
 
 def test_is_not_expired_with_naive_datetime() -> None:
     """Naive datetime (legacy) future token works."""
-    future = datetime.utcnow() + timedelta(hours=2)
+    future = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(hours=2)
     info = TokenInfo(token="t", expires_at=future)
     assert info.is_expired() is False
 

--- a/packages/gptme-codegraph/tests/test_commit_map.py
+++ b/packages/gptme-codegraph/tests/test_commit_map.py
@@ -476,8 +476,10 @@ def test_stat_fingerprint_changes_on_mtime(tmp_path):
     assert count1 == 2
     assert fp1 == fp2  # stable when nothing changes
 
-    # Touch a file — fingerprint must change.
-    (d / "a.py").write_text("x = 2")
+    # Modify a file — fingerprint must change.
+    # Use different-length content so the size field changes reliably; mtime_ns can be
+    # identical for sequential writes on fast SSDs within the same kernel timer tick.
+    (d / "a.py").write_text("x = 2\n")
     with patch.object(
         commit_map,
         "_tracked_source_files",
@@ -485,5 +487,5 @@ def test_stat_fingerprint_changes_on_mtime(tmp_path):
     ):
         fp3, count3 = commit_map._stat_fingerprint(d)
 
-    assert fp3 != fp1  # mtime/size changed
+    assert fp3 != fp1  # mtime_ns or size changed
     assert count3 == 2


### PR DESCRIPTION
## Summary

Two independent test reliability fixes:

**gptme-codegraph: `test_stat_fingerprint_changes_on_mtime`**
- Used same-size content (`'x = 1'` → `'x = 2'`, both 5 bytes). Sequential writes on fast SSDs can produce identical `mtime_ns` values within the same kernel timer tick, causing `fp3 != fp1` to fail when neither mtime nor size changed.
- Fix: use different-length content (`"x = 2\n"` = 6 bytes) so the size field changes reliably regardless of timing.
- Root cause confirmed by reproducing: `mtime_changed: False, size_changed: False, fp_changed: False` on two rapid sequential writes.

**gptmail: `test_token_expiry.py`**
- Replace deprecated `datetime.utcnow()` with timezone-aware equivalent (`datetime.now(timezone.utc).replace(tzinfo=None)`) to avoid `DeprecationWarning` in Python 3.12+.

## Test plan
- [ ] `uv run pytest packages/gptme-codegraph/tests/test_commit_map.py::test_stat_fingerprint_changes_on_mtime` passes
- [ ] `uv run pytest packages/gptme-codegraph/tests/` all pass
- [ ] `uv run pytest packages/gptmail/tests/test_token_expiry.py` all pass