### PR TITLE
fix(gptodo): status UX — double blank, date-only 'today', dedup --summary

### DIFF
--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -762,51 +762,64 @@ def _build_status_json(dir_type: str, results: Dict[str, List[TaskInfo]]) -> Dic
 
 
 def check_directory(
-    console: Console, dir_type: str, repo_root: Path, compact: bool = False
+    console: Console,
+    dir_type: str,
+    repo_root: Path,
+    compact: bool = False,
+    summary_only: bool = False,
 ) -> Dict[str, List[TaskInfo]]:
-    """Check and display status for a single directory type."""
+    """Check and display status for a single directory type.
+
+    ``summary_only`` prints just the header and the summary line, skipping the
+    per-state task listing (used by ``--summary``, whose contract is "only show
+    summary"). The summary itself always prints, so callers must not print it a
+    second time.
+    """
     config = CONFIGS[dir_type]
     checker = StateChecker(repo_root, config)
     results = checker.check_all()
 
-    # Print header with type-specific color
+    # Print header with type-specific color. No trailing newline: the first
+    # section (and the summary) already lead with a blank line, so a trailing
+    # one here would double the gap under the header.
     style, _ = STATE_STYLES.get(config.states[0], ("white", "•"))
-    console.print(f"\n[bold {style}]{config.emoji} {config.type_name.title()} Status[/]\n")
+    console.print(f"\n[bold {style}]{config.emoji} {config.type_name.title()} Status[/]")
 
-    # Print sections in order
-    if results["issues"]:
-        print_status_section(
-            console,
-            "Issues Found",
-            results["issues"],
-            show_state=True,
-        )
-
-    if results["untracked"]:
-        print_status_section(
-            console,
-            "Untracked Files",
-            results["untracked"],
-        )
-
-    # Determine which states to show based on compact mode.
-    # Compact = the active work funnel: untriaged, triaged, in-flight,
-    # and awaiting verification. Exclude blocked, deferred, and terminal
-    # states so the short view stays focused on real work.
-    states_to_show = (
-        [s for s in ("backlog", "todo", "active", "ready_for_review") if s in config.states]
-        if compact
-        else config.states
-    )
-
-    # Print active states in order
-    for state in states_to_show:
-        if state in config.states and results.get(state):
+    if not summary_only:
+        # Print sections in order
+        if results["issues"]:
             print_status_section(
                 console,
-                state,
-                results[state],
+                "Issues Found",
+                results["issues"],
+                show_state=True,
             )
+
+        if results["untracked"]:
+            print_status_section(
+                console,
+                "Untracked Files",
+                results["untracked"],
+            )
+
+        # Determine which states to show based on compact mode.
+        # Compact = the active work funnel: untriaged, triaged, in-flight,
+        # and awaiting verification. Exclude blocked, deferred, and terminal
+        # states so the short view stays focused on real work.
+        states_to_show = (
+            [s for s in ("backlog", "todo", "active", "ready_for_review") if s in config.states]
+            if compact
+            else config.states
+        )
+
+        # Print active states in order
+        for state in states_to_show:
+            if state in config.states and results.get(state):
+                print_status_section(
+                    console,
+                    state,
+                    results[state],
+                )
 
     # Print summary
     print_summary(console, results, config)
@@ -1005,7 +1018,7 @@ def status(type, all, compact, summary, issues, github, github_repo, output_json
     if all:
         # Check all directory types
         for type_name in CONFIGS.keys():
-            results = check_directory(console, type_name, repo_root, compact)
+            results = check_directory(console, type_name, repo_root, compact, summary_only=summary)
             if results:  # Only include directories with items
                 all_results[type_name] = results
 
@@ -1020,7 +1033,7 @@ def status(type, all, compact, summary, issues, github, github_repo, output_json
 
     else:
         # Check single directory type
-        results = check_directory(console, type, repo_root, compact)
+        results = check_directory(console, type, repo_root, compact, summary_only=summary)
         if results:
             all_results[type] = results
 
@@ -1039,11 +1052,8 @@ def status(type, all, compact, summary, issues, github, github_repo, output_json
         if not has_issues:
             console.print("\n[green]No issues found![/]")
 
-    elif summary:
-        # Show only the summary for each type
-        for dir_type, results in all_results.items():
-            config = CONFIGS[dir_type]
-            print_summary(console, results, config)
+    # Note: --summary is handled inside check_directory (summary_only), which
+    # prints the summary once. Re-printing it here would duplicate it.
 
     # Show GitHub issues not yet tracked as task files
     if github:

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -573,7 +573,9 @@ def format_time_ago(dt: datetime) -> str:
     # Date-only (midnight) → calendar-day resolution, not fake hour precision.
     if dt.time() == time(0, 0, 0, 0):
         days = (now.date() - dt.date()).days
-        if days <= 0:
+        if days < 0:
+            return "future"
+        elif days == 0:
             return "today"
         elif days == 1:
             return "yesterday"

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -16,7 +16,7 @@ import re
 import subprocess
 import warnings
 from dataclasses import dataclass, field
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, time, timedelta
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -556,11 +556,32 @@ def find_repo_root(start_path: Path) -> Path:
 
 
 def format_time_ago(dt: datetime) -> str:
-    """Format a datetime as a human-readable time ago string."""
+    """Format a datetime as a human-readable time ago string.
+
+    Date-only sources (midnight, i.e. no HH:MM:SS — the resolution most task
+    frontmatter offers, e.g. ``created: 2026-07-02``) carry no sub-day
+    precision, so rendering "16h ago" is spuriously precise. For those, report
+    at day resolution (today / yesterday / Nd ago) — the actual resolution the
+    value provides. Timestamps that include a time component keep the finer
+    just-now / Nm / Nh precision.
+    """
     # Convert to naive datetime if timezone-aware
     if dt.tzinfo:
         dt = dt.astimezone().replace(tzinfo=None)
     now = datetime.now()
+
+    # Date-only (midnight) → calendar-day resolution, not fake hour precision.
+    if dt.time() == time(0, 0, 0, 0):
+        days = (now.date() - dt.date()).days
+        if days <= 0:
+            return "today"
+        elif days == 1:
+            return "yesterday"
+        elif days < 30:
+            return f"{days}d ago"
+        else:
+            return dt.strftime("%Y-%m-%d")
+
     delta = now - dt
 
     if delta < timedelta(minutes=1):

--- a/packages/gptodo/tests/test_status_compact.py
+++ b/packages/gptodo/tests/test_status_compact.py
@@ -5,11 +5,13 @@ It must NOT hide todo/ready_for_review tasks (regression from the original
 ["backlog", "active"]-only filter).
 """
 
+from datetime import datetime, timedelta
 from pathlib import Path
 
 from click.testing import CliRunner
 
 from gptodo.cli import cli
+from gptodo.utils import format_time_ago
 
 
 def write_task(tasks_dir: Path, name: str, **metadata: object) -> None:
@@ -77,3 +79,54 @@ def test_status_compact_excludes_hidden_states(tmp_path: Path, monkeypatch) -> N
     assert "done-task" not in output
     assert "cancelled-task" not in output
     assert "someday-task" not in output
+
+
+def test_status_no_double_blank_under_header(tmp_path: Path, monkeypatch) -> None:
+    """The 'Tasks Status' header must not be followed by two blank lines."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(tasks_dir, "active-task", state="active", created="2026-01-01T00:00:00")
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(cli, ["status", "--compact"])
+    assert result.exit_code == 0, result.output
+    # A double blank line renders as three consecutive newlines.
+    assert "\n\n\n" not in result.output, "double blank line under header"
+
+
+def test_status_summary_flag_shows_summary_once_and_no_listing(tmp_path: Path, monkeypatch) -> None:
+    """--summary shows exactly one summary and omits the task listing (no duplicate)."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(tasks_dir, "active-task", state="active", created="2026-01-01T00:00:00")
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(cli, ["status", "--summary"])
+    assert result.exit_code == 0, result.output
+    assert result.output.count("Summary:") == 1, "summary must not be duplicated"
+    assert "active-task" not in result.output, "--summary must not print the task listing"
+
+
+def test_status_default_and_compact_have_single_summary(tmp_path: Path, monkeypatch) -> None:
+    """Every mode prints the summary exactly once, never twice."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(tasks_dir, "active-task", state="active", created="2026-01-01T00:00:00")
+    monkeypatch.chdir(tmp_path)
+    for args in (["status"], ["status", "--compact"], ["status", "--compact", "--summary"]):
+        result = CliRunner().invoke(cli, args)
+        assert result.exit_code == 0, result.output
+        assert result.output.count("Summary:") == 1, f"{args}: summary count"
+
+
+def test_format_time_ago_date_only_uses_day_resolution() -> None:
+    """Date-only (midnight) timestamps report day resolution, not fake hours."""
+    now = datetime.now()
+    today_midnight = datetime(now.year, now.month, now.day)
+    assert format_time_ago(today_midnight) == "today"
+    assert format_time_ago(today_midnight - timedelta(days=1)) == "yesterday"
+    assert format_time_ago(today_midnight - timedelta(days=3)) == "3d ago"
+
+
+def test_format_time_ago_with_time_component_keeps_precision() -> None:
+    """Timestamps that carry a time-of-day keep hour/minute precision."""
+    dt = datetime.now() - timedelta(hours=3, minutes=1, seconds=7)
+    assert format_time_ago(dt) == "3h ago"

--- a/packages/gptodo/tests/test_status_compact.py
+++ b/packages/gptodo/tests/test_status_compact.py
@@ -126,6 +126,13 @@ def test_format_time_ago_date_only_uses_day_resolution() -> None:
     assert format_time_ago(today_midnight - timedelta(days=3)) == "3d ago"
 
 
+def test_format_time_ago_future_date_only_reports_future() -> None:
+    """Future date-only timestamps must not be mislabeled as today."""
+    now = datetime.now()
+    tomorrow_midnight = datetime(now.year, now.month, now.day) + timedelta(days=1)
+    assert format_time_ago(tomorrow_midnight) == "future"
+
+
 def test_format_time_ago_with_time_component_keeps_precision() -> None:
     """Timestamps that carry a time-of-day keep hour/minute precision."""
     dt = datetime.now() - timedelta(hours=3, minutes=1, seconds=7)


### PR DESCRIPTION
Three `gptodo status` UX fixes (reported by Erik/Bob during operator work):

## 1. Extra blank line under the header
`check_directory` printed the `Tasks Status` header with a **trailing** newline, and the first section already prints a **leading** one → a double blank line. Dropped the trailing newline.

## 2. `(16h ago)` on date-only tasks → `(today)`
Task frontmatter `created:`/`modified:` is usually date-only (`2026-07-02`, no `HH:MM:SS`), so it parses to midnight. Reporting "16h ago" is spuriously precise. `format_time_ago` now renders date-only (midnight) values at **day resolution**: `today` / `yesterday` / `Nd ago`. Timestamps that *do* carry a time component keep `just now`/`Nm`/`Nh` precision.

## 3. `--summary` duplicated the summary
`check_directory` already prints a summary at the end, and `status()` printed it **again** under `--summary` (on top of the full listing). `--summary` now means *summary-only* (its documented "Only show summary") via a `summary_only` gate; the duplicate print is removed. Every mode now prints the summary exactly once.

## Tests
+5 tests: no double blank, `--summary` prints one summary and no listing, all modes single-summary, date-only→day-resolution, time-component→precision retained. Full suite green (`ruff` clean, existing status tests pass).