### PR TITLE
fix(gptme-runloops): record gptme sessions via post_session() after each run

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/base.py
+++ b/packages/gptme-runloops/src/gptme_runloops/base.py
@@ -288,6 +288,7 @@ class BaseRunLoop(ABC):
             result: Result from execution
         """
         self._record_session(result)
+        result.cleanup_tmpdir()
 
     def _record_session(self, result: ExecutionResult) -> None:
         """Write a session record via gptme-sessions post_session().

--- a/packages/gptme-runloops/src/gptme_runloops/base.py
+++ b/packages/gptme-runloops/src/gptme_runloops/base.py
@@ -279,12 +279,50 @@ class BaseRunLoop(ABC):
     def post_run(self, result: ExecutionResult) -> None:
         """Perform post-run cleanup and logging.
 
-        Override in subclasses for run-specific cleanup.
+        Records the session to the gptme-sessions store so harness metrics,
+        bandit posteriors, and quality analysis stay accurate. Subclasses that
+        override this method should call super().post_run(result) to preserve
+        recording, or call _record_session(result) explicitly.
 
         Args:
             result: Result from execution
         """
-        pass
+        self._record_session(result)
+
+    def _record_session(self, result: ExecutionResult) -> None:
+        """Write a session record via gptme-sessions post_session().
+
+        Non-fatal: logs a warning on failure rather than disrupting the run loop.
+        Uses GPTME_SESSIONS_DIR env var (set in .env) for the store path.
+        """
+        try:
+            from gptme_sessions.post_session import post_session
+            from gptme_sessions.store import SessionStore
+        except ImportError:
+            self.logger.debug(
+                "gptme_sessions not available — skipping session recording"
+            )
+            return
+
+        duration = (
+            int(time.time() - self._start_time) if self._start_time is not None else 0
+        )
+        try:
+            post_session(
+                store=SessionStore(),  # uses GPTME_SESSIONS_DIR env var
+                harness=self.executor.name,
+                model=self.model,
+                run_type=self.run_type,
+                exit_code=result.exit_code,
+                duration_seconds=duration,
+                trajectory_path=result.trajectory_path,
+            )
+            self.logger.info(
+                f"Session recorded (harness={self.executor.name}, "
+                f"trajectory={'yes' if result.trajectory_path else 'no'})"
+            )
+        except Exception as e:
+            self.logger.warning(f"Session recording failed (non-fatal): {e}")
 
     def cleanup(self) -> None:
         """Release lock and cleanup resources."""

--- a/packages/gptme-runloops/src/gptme_runloops/email.py
+++ b/packages/gptme-runloops/src/gptme_runloops/email.py
@@ -269,3 +269,6 @@ Complete when all emails are addressed.
                     self._record_backoff_success()
         except Exception as e:
             self.logger.error(f"Post-run email check failed: {e}")
+
+        # Chain to base class to record session and cleanup tmpdir
+        super().post_run(result)

--- a/packages/gptme-runloops/src/gptme_runloops/utils/execution.py
+++ b/packages/gptme-runloops/src/gptme_runloops/utils/execution.py
@@ -5,6 +5,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import tempfile
 from datetime import datetime
 from pathlib import Path
 
@@ -16,10 +17,19 @@ GLOBAL_LOG_DIR.mkdir(parents=True, exist_ok=True)
 class ExecutionResult:
     """Result from gptme execution."""
 
-    def __init__(self, exit_code: int, timed_out: bool = False):
+    def __init__(
+        self,
+        exit_code: int,
+        timed_out: bool = False,
+        trajectory_path: Path | None = None,
+    ):
         self.exit_code = exit_code
         self.timed_out = timed_out
         self.success = exit_code == 0
+        # Path to conversation.jsonl written by this gptme session (if any).
+        # Populated when GPTME_LOGS_HOME isolation is used — lets callers
+        # record the session via post_session() without fragile mtime searches.
+        self.trajectory_path = trajectory_path
 
 
 def execute_gptme(
@@ -58,6 +68,14 @@ def execute_gptme(
     prompt_file = workspace / f".gptme-prompt-{os.getpid()}.txt"
     prompt_file.write_text(prompt)
 
+    # Isolate gptme session logs to a private tmpdir so trajectory discovery is
+    # reliable. When gptme runs with --workspace pointing to a dir that has an
+    # [agent] section in gptme.toml, it ignores --name and creates random
+    # YYYY-MM-DD-adjective-noun "petname" directories instead — breaking any
+    # pattern-based lookup. GPTME_LOGS_HOME redirects all logs for this process
+    # to a known private dir, making the conversation.jsonl always findable.
+    gptme_logs_dir = Path(tempfile.mkdtemp(prefix="gptme-session-"))
+
     try:
         # Build gptme command
         # Find gptme in PATH (typically pipx-managed)
@@ -89,6 +107,7 @@ def execute_gptme(
         run_env = os.environ.copy()
         run_env["GPTME_SHELL_TIMEOUT"] = str(shell_timeout)
         run_env["GPTME_CHAT_HISTORY"] = "true"
+        run_env["GPTME_LOGS_HOME"] = str(gptme_logs_dir)
 
         if env:
             run_env.update(env)
@@ -107,6 +126,9 @@ def execute_gptme(
             f.write(f"Shell timeout: {shell_timeout}s\n\n")
             f.write("=== Output ===\n")
 
+        trajectory_path: Path | None = None
+        timed_out = False
+
         # Execute with tee - streams to both stdout and log file
         try:
             result = subprocess.run(
@@ -122,7 +144,7 @@ def execute_gptme(
                 f.write("\n=== Execution completed ===\n")
                 f.write(f"Exit code: {result.returncode}\n")
 
-            return ExecutionResult(exit_code=result.returncode)
+            exit_code = result.returncode
 
         except subprocess.TimeoutExpired:
             # Log timeout to file (append to preserve tee output)
@@ -131,9 +153,22 @@ def execute_gptme(
                 f.write(f"Status: TIMED OUT after {timeout}s\n")
 
             print(f"ERROR: Execution timed out after {timeout}s", file=sys.stderr)
-            return ExecutionResult(exit_code=124, timed_out=True)
+            exit_code = 124
+            timed_out = True
+
+        # Discover conversation.jsonl written by this session.
+        # gptme creates one session dir per run under GPTME_LOGS_HOME.
+        trajs = list(gptme_logs_dir.rglob("conversation.jsonl"))
+        if trajs:
+            trajectory_path = trajs[0]
+
+        return ExecutionResult(
+            exit_code=exit_code,
+            timed_out=timed_out,
+            trajectory_path=trajectory_path,
+        )
 
     finally:
-        # Clean up prompt file
+        # Clean up prompt file (gptme_logs_dir is preserved — caller records session)
         if prompt_file.exists():
             prompt_file.unlink()

--- a/packages/gptme-runloops/src/gptme_runloops/utils/execution.py
+++ b/packages/gptme-runloops/src/gptme_runloops/utils/execution.py
@@ -22,6 +22,7 @@ class ExecutionResult:
         exit_code: int,
         timed_out: bool = False,
         trajectory_path: Path | None = None,
+        tmpdir: Path | None = None,
     ):
         self.exit_code = exit_code
         self.timed_out = timed_out
@@ -30,6 +31,21 @@ class ExecutionResult:
         # Populated when GPTME_LOGS_HOME isolation is used — lets callers
         # record the session via post_session() without fragile mtime searches.
         self.trajectory_path = trajectory_path
+        # Temporary directory holding the isolated gptme session logs.
+        # Owned by this result; caller must call cleanup_tmpdir() after
+        # post_session() has ingested the trajectory, or use the context
+        # manager form.
+        self.tmpdir = tmpdir
+
+    def cleanup_tmpdir(self) -> None:
+        """Delete the isolated gptme session logs directory.
+
+        Call this after post_session() has processed trajectory_path to avoid
+        accumulating stale tmpdir entries across many runs.
+        """
+        if self.tmpdir and self.tmpdir.exists():
+            shutil.rmtree(self.tmpdir, ignore_errors=True)
+            self.tmpdir = None
 
 
 def execute_gptme(
@@ -182,11 +198,13 @@ def execute_gptme(
             exit_code=exit_code,
             timed_out=timed_out,
             trajectory_path=trajectory_path,
+            tmpdir=gptme_logs_dir,
         )
 
     finally:
         # Clean up prompt file and the private GPTME_LOGS_HOME staging dir.
-        # trajectory_path points to a durable copy under GLOBAL_LOG_DIR.
+        # trajectory_path points to a durable copy under GLOBAL_LOG_DIR;
+        # cleanup_tmpdir() on the result is a no-op since the dir is gone.
         if prompt_file.exists():
             prompt_file.unlink()
         shutil.rmtree(gptme_logs_dir, ignore_errors=True)

--- a/packages/gptme-runloops/src/gptme_runloops/utils/execution.py
+++ b/packages/gptme-runloops/src/gptme_runloops/utils/execution.py
@@ -123,10 +123,12 @@ def execute_gptme(
         run_env = os.environ.copy()
         run_env["GPTME_SHELL_TIMEOUT"] = str(shell_timeout)
         run_env["GPTME_CHAT_HISTORY"] = "true"
-        run_env["GPTME_LOGS_HOME"] = str(gptme_logs_dir)
 
         if env:
             run_env.update(env)
+
+        # Must be set after caller env merge so it cannot be clobbered.
+        run_env["GPTME_LOGS_HOME"] = str(gptme_logs_dir)
 
         # Use tee to stream output to both terminal and log file
         # This gives us real-time journald logging AND complete log file

--- a/packages/gptme-runloops/src/gptme_runloops/utils/execution.py
+++ b/packages/gptme-runloops/src/gptme_runloops/utils/execution.py
@@ -158,9 +158,25 @@ def execute_gptme(
 
         # Discover conversation.jsonl written by this session.
         # gptme creates one session dir per run under GPTME_LOGS_HOME.
-        trajs = list(gptme_logs_dir.rglob("conversation.jsonl"))
+        trajs = sorted(gptme_logs_dir.rglob("conversation.jsonl"))
         if trajs:
-            trajectory_path = trajs[0]
+            selected_traj = trajs[0]
+            if len(trajs) > 1:
+                with log_file.open("a") as f:
+                    f.write("\n=== Multiple conversation.jsonl files found ===\n")
+                    f.write(f"Using: {selected_traj}\n")
+                    f.write("All candidates:\n")
+                    for traj in trajs:
+                        f.write(f"- {traj}\n")
+
+            durable_session_dir = Path(
+                tempfile.mkdtemp(
+                    prefix=f"{run_type}-{timestamp}-session-",
+                    dir=GLOBAL_LOG_DIR,
+                )
+            )
+            trajectory_path = durable_session_dir / "conversation.jsonl"
+            shutil.copy2(selected_traj, trajectory_path)
 
         return ExecutionResult(
             exit_code=exit_code,
@@ -169,6 +185,8 @@ def execute_gptme(
         )
 
     finally:
-        # Clean up prompt file (gptme_logs_dir is preserved — caller records session)
+        # Clean up prompt file and the private GPTME_LOGS_HOME staging dir.
+        # trajectory_path points to a durable copy under GLOBAL_LOG_DIR.
         if prompt_file.exists():
             prompt_file.unlink()
+        shutil.rmtree(gptme_logs_dir, ignore_errors=True)

--- a/packages/gptme-runloops/tests/test_base.py
+++ b/packages/gptme-runloops/tests/test_base.py
@@ -127,6 +127,43 @@ def test_base_run_records_session_on_success():
             mock_record.assert_called_once_with(result)
 
 
+def test_post_run_cleans_up_tmpdir():
+    """Test that post_run() deletes the gptme session tmpdir after recording."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        workspace = Path(tmpdir)
+        (workspace / "logs").mkdir()
+
+        run = TestRunLoop(workspace, "test")
+        # Create a fake tmpdir as execute_gptme would
+        session_tmpdir = Path(tempfile.mkdtemp(prefix="gptme-session-"))
+        (session_tmpdir / "conversation.jsonl").write_text("{}")
+        result = ExecutionResult(
+            exit_code=0,
+            trajectory_path=session_tmpdir / "conversation.jsonl",
+            tmpdir=session_tmpdir,
+        )
+
+        with patch.object(run, "_record_session"):
+            run.post_run(result)
+
+        # tmpdir must be deleted after post_run
+        assert not session_tmpdir.exists(), "gptme session tmpdir leaked after post_run"
+        assert result.tmpdir is None
+
+
+def test_cleanup_tmpdir_is_idempotent():
+    """Test that cleanup_tmpdir() is safe to call multiple times."""
+    session_tmpdir = Path(tempfile.mkdtemp(prefix="gptme-session-"))
+    result = ExecutionResult(exit_code=0, tmpdir=session_tmpdir)
+
+    result.cleanup_tmpdir()
+    assert not session_tmpdir.exists()
+    assert result.tmpdir is None
+
+    # Second call must not raise
+    result.cleanup_tmpdir()
+
+
 def test_base_run_exception_handling():
     """Test exception handling in run cycle."""
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/packages/gptme-runloops/tests/test_base.py
+++ b/packages/gptme-runloops/tests/test_base.py
@@ -93,10 +93,11 @@ def test_base_run_full_cycle():
 
         run = TestRunLoop(workspace, "test")
 
-        # Mock all external calls
+        # Mock all external calls (including _record_session to avoid real store writes)
         with (
             patch("gptme_runloops.base.git_pull_with_retry") as mock_pull,
             patch("gptme_runloops.utils.executor.execute_gptme") as mock_execute,
+            patch.object(run, "_record_session") as mock_record,
         ):
             mock_pull.return_value = True
             mock_execute.return_value = ExecutionResult(exit_code=0)
@@ -107,6 +108,22 @@ def test_base_run_full_cycle():
             assert exit_code == 0
             mock_pull.assert_called_once()
             mock_execute.assert_called_once()
+            # post_run() must call _record_session() with the execution result
+            mock_record.assert_called_once()
+
+
+def test_base_run_records_session_on_success():
+    """Test that post_run() calls _record_session() on a successful run."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        workspace = Path(tmpdir)
+        (workspace / "logs").mkdir()
+
+        run = TestRunLoop(workspace, "test")
+        result = ExecutionResult(exit_code=0)
+
+        with patch.object(run, "_record_session") as mock_record:
+            run.post_run(result)
+            mock_record.assert_called_once_with(result)
 
 
 def test_base_run_exception_handling():

--- a/packages/gptme-runloops/tests/test_base.py
+++ b/packages/gptme-runloops/tests/test_base.py
@@ -100,7 +100,8 @@ def test_base_run_full_cycle():
             patch.object(run, "_record_session") as mock_record,
         ):
             mock_pull.return_value = True
-            mock_execute.return_value = ExecutionResult(exit_code=0)
+            result = ExecutionResult(exit_code=0)
+            mock_execute.return_value = result
 
             # Run full cycle
             exit_code = run.run()
@@ -109,7 +110,7 @@ def test_base_run_full_cycle():
             mock_pull.assert_called_once()
             mock_execute.assert_called_once()
             # post_run() must call _record_session() with the execution result
-            mock_record.assert_called_once()
+            mock_record.assert_called_once_with(result)
 
 
 def test_base_run_records_session_on_success():

--- a/packages/gptme-runloops/tests/test_executor.py
+++ b/packages/gptme-runloops/tests/test_executor.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from gptme_runloops.utils import execution as execution_mod
 from gptme_runloops.utils.execution import ExecutionResult
 from gptme_runloops.utils.executor import (
     ClaudeCodeExecutor,
@@ -105,6 +106,78 @@ def test_gptme_executor_passes_run_type():
 
         call_kwargs = mock.call_args
         assert call_kwargs[1]["run_type"] == "autonomous"
+
+
+def test_execute_gptme_persists_trajectory_and_removes_isolated_logs(
+    tmp_path, monkeypatch
+):
+    """execute_gptme copies conversation.jsonl durably and removes GPTME_LOGS_HOME."""
+    global_log_dir = tmp_path / "global-logs"
+    global_log_dir.mkdir()
+    monkeypatch.setattr(execution_mod, "GLOBAL_LOG_DIR", global_log_dir)
+    monkeypatch.setattr(execution_mod.shutil, "which", lambda _: "/usr/bin/gptme")
+
+    isolated_log_dirs: list[Path] = []
+
+    def fake_run(cmd, *, env, **kwargs):
+        isolated_logs = Path(env["GPTME_LOGS_HOME"])
+        isolated_log_dirs.append(isolated_logs)
+        session_dir = isolated_logs / "2026-07-02-test-session"
+        session_dir.mkdir(parents=True)
+        (session_dir / "conversation.jsonl").write_text('{"role": "user"}\n')
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(execution_mod.subprocess, "run", fake_run)
+
+    result = execution_mod.execute_gptme(
+        "Test prompt",
+        workspace=tmp_path,
+        timeout=60,
+        run_type="test",
+    )
+
+    assert result.success
+    assert result.trajectory_path is not None
+    assert result.trajectory_path.exists()
+    assert result.trajectory_path.parent.parent == global_log_dir
+    assert isolated_log_dirs
+    assert isolated_log_dirs[0] not in result.trajectory_path.parents
+    assert not isolated_log_dirs[0].exists()
+    assert not list(tmp_path.glob(".gptme-prompt-*.txt"))
+
+
+def test_execute_gptme_logs_duplicate_conversation_files(tmp_path, monkeypatch):
+    """Unexpected duplicate conversation.jsonl files are visible in the run log."""
+    global_log_dir = tmp_path / "global-logs"
+    global_log_dir.mkdir()
+    monkeypatch.setattr(execution_mod, "GLOBAL_LOG_DIR", global_log_dir)
+    monkeypatch.setattr(execution_mod.shutil, "which", lambda _: "/usr/bin/gptme")
+
+    def fake_run(cmd, *, env, **kwargs):
+        isolated_logs = Path(env["GPTME_LOGS_HOME"])
+        session_a = isolated_logs / "a-session"
+        session_b = isolated_logs / "b-session"
+        session_a.mkdir(parents=True)
+        session_b.mkdir(parents=True)
+        (session_a / "conversation.jsonl").write_text('{"session": "a"}\n')
+        (session_b / "conversation.jsonl").write_text('{"session": "b"}\n')
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(execution_mod.subprocess, "run", fake_run)
+
+    result = execution_mod.execute_gptme(
+        "Test prompt",
+        workspace=tmp_path,
+        timeout=60,
+        run_type="duplicate",
+    )
+
+    assert result.trajectory_path is not None
+    assert result.trajectory_path.read_text() == '{"session": "a"}\n'
+    log_text = "\n".join(path.read_text() for path in global_log_dir.glob("*.log"))
+    assert "Multiple conversation.jsonl files found" in log_text
+    assert "a-session/conversation.jsonl" in log_text
+    assert "b-session/conversation.jsonl" in log_text
 
 
 def test_gptme_executor_is_available():


### PR DESCRIPTION
## Problem

All gptme sessions dispatched via `run_loops` (project-monitoring, autonomous) were silently unrecorded since at least 2026-06-23. The vitals harness panel showed `gptme=0` while ~20 real gptme work sessions ran per day.

Root cause: `execute_gptme()` ran gptme as a subprocess but never called `post_session()`, so every run was invisible to:
- Vitals/harness metrics (`collect_harness_model_counts`)
- Harness bandit posteriors (model selection was biased against gptme by zero data)
- Quality/grade tracking

## Changes

**`execution.py`**: Set `GPTME_LOGS_HOME` to an isolated `tempfile.mkdtemp()` dir before each gptme invocation. After gptme exits, find `conversation.jsonl` under that dir and return it as `ExecutionResult.trajectory_path`. 

This is necessary because gptme's `--workspace` agent mode (triggered by `[agent]` in `gptme.toml`) ignores `--name` for directory creation and instead uses random `YYYY-MM-DD-adjective-noun` "petname" dirs — making all pattern-based trajectory discovery unreliable.

**`base.py`**: `BaseRunLoop.post_run()` now calls `_record_session()`, which writes a session record via `gptme_sessions.post_session()` using `GPTME_SESSIONS_DIR` env var for the store path. Non-fatal (warns on failure). `gptme_sessions` is an optional import — recording silently skips if the package is unavailable.

**`test_base.py`**: Mock `_record_session` in the full-cycle test to prevent real store writes in CI; add a test that `post_run()` calls `_record_session()`.

## Test plan

- [ ] All 55 existing tests pass (`pytest packages/gptme-runloops/tests/test_base.py packages/gptme-runloops/tests/test_executor.py`)
- [ ] Session records appear in `state/sessions/session-records.jsonl` with `harness=gptme` after the next project-monitoring run
- [ ] `recorder-vs-trajectory-health.py` (wired into `bob-health-check-hourly.service` in the agent workspace) no longer alerts