### PR TITLE
fix(gptmail): use SSH ControlMaster for agent delivery to halve logind sessions

### DIFF
--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -209,7 +209,26 @@ def _ssh_deliver(agents: dict[str, dict[str, str]], *, mailbox: str = "default")
             remote_inbox = f"{remote_root}/inbox/"
         else:
             remote_inbox = f"{remote_root}/mailboxes/{mailbox}/inbox/"
-        ssh_opts = ["-o", "ConnectTimeout=5", "-o", "BatchMode=yes"]
+        # ControlMaster reuses one TCP connection (and one PAM/logind session) for
+        # both the mkdir and scp calls instead of opening two separate connections.
+        # Each recipient gets its own ControlPath keyed by user+host to avoid
+        # cross-host master conflicts.  ControlPersist=60 keeps the master alive for
+        # 60 s so burst deliveries to the same host share it; it auto-closes after
+        # that — no persistent background process.
+        ctl_key = re.sub(r"[^a-zA-Z0-9]", "_", ssh_target)
+        ctl_path = f"/tmp/.ssh-ctl-{os.getuid()}-{ctl_key}"
+        ssh_opts = [
+            "-o",
+            "ConnectTimeout=5",
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "ControlMaster=auto",
+            "-o",
+            f"ControlPath={ctl_path}",
+            "-o",
+            "ControlPersist=60",
+        ]
         try:
             subprocess.run(
                 ["ssh", *ssh_opts, ssh_target, f"mkdir -p {shlex.quote(remote_inbox)}"],

--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -33,6 +33,7 @@ Wiring:
 from __future__ import annotations
 
 import functools
+import hashlib
 import json
 import os
 import re
@@ -175,6 +176,21 @@ def _tracker() -> ConversationTracker:
     return ConversationTracker(_messages_dir() / ".tracking")
 
 
+def _ssh_control_path(ssh_target: str) -> str:
+    """Build a bounded SSH ControlPath for the given SSH target.
+
+    Uses SHA-256 truncated to 32 hex chars for deterministic, collision-resistant
+    keying that stays under the 107-char Unix domain socket path limit.
+
+    Places the socket in ``XDG_RUNTIME_DIR`` (user-private, mode 0700) when
+    available, falling back to ``~/.ssh/`` — avoids predictable paths in the
+    world-writable ``/tmp`` directory.
+    """
+    ctl_key = hashlib.sha256(ssh_target.encode()).hexdigest()[:32]
+    ctl_dir = os.environ.get("XDG_RUNTIME_DIR") or os.path.expanduser("~/.ssh")
+    return os.path.join(ctl_dir, f"ssh-ctl-{os.getuid()}-{ctl_key}")
+
+
 def _ssh_deliver(agents: dict[str, dict[str, str]], *, mailbox: str = "default") -> Deliver:
     """Build a ``deliver`` hook that SCPs a message into a recipient's inbox.
 
@@ -215,8 +231,7 @@ def _ssh_deliver(agents: dict[str, dict[str, str]], *, mailbox: str = "default")
         # cross-host master conflicts.  ControlPersist=60 keeps the master alive for
         # 60 s so burst deliveries to the same host share it; it auto-closes after
         # that — no persistent background process.
-        ctl_key = re.sub(r"[^a-zA-Z0-9]", "_", ssh_target)
-        ctl_path = f"/tmp/.ssh-ctl-{os.getuid()}-{ctl_key}"
+        ctl_path = _ssh_control_path(ssh_target)
         ssh_opts = [
             "-o",
             "ConnectTimeout=5",

--- a/packages/gptmail/tests/test_agent_cli.py
+++ b/packages/gptmail/tests/test_agent_cli.py
@@ -10,6 +10,7 @@ See task: fold-agent-msg-into-gptmail-single-comms-tool.
 """
 
 import json
+import os
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
@@ -808,3 +809,31 @@ def test_broadcast_reports_partial_delivery_failure(
     }
     assert by_to["gordon"]["delivered"] is False
     assert "delivered" not in by_to["bob"]
+
+
+def test_ssh_control_path_stays_under_socket_limit() -> None:
+    """ControlPath must stay under the 107-char Unix domain socket path limit."""
+    long_target = f"user@{'x' * 200}.example.com"
+    ctl_path = agent_cli._ssh_control_path(long_target)
+    assert len(ctl_path) <= 107, f"ControlPath too long: {len(ctl_path)} chars: {ctl_path}"
+    basename = os.path.basename(ctl_path)
+    assert basename.startswith("ssh-ctl-")
+    uid, hash_part = basename.removeprefix("ssh-ctl-").split("-", 1)
+    assert uid.isdigit()
+    assert len(hash_part) == 32
+    int(hash_part, 16)  # must be valid hex
+
+
+def test_ssh_control_path_deterministic() -> None:
+    """Same SSH target must produce the same ControlPath."""
+    target = "bob@bob.lxc"
+    p1 = agent_cli._ssh_control_path(target)
+    p2 = agent_cli._ssh_control_path(target)
+    assert p1 == p2
+
+
+def test_ssh_control_path_different_targets_differ() -> None:
+    """Different SSH targets must produce different ControlPaths."""
+    p1 = agent_cli._ssh_control_path("alice@alice.lxc")
+    p2 = agent_cli._ssh_control_path("bob@bob.lxc")
+    assert p1 != p2


### PR DESCRIPTION
## Summary

- Each SCP delivery to a peer agent currently opens **two** SSH connections (one for `mkdir -p`, one for `scp`), creating two PAM/logind sessions on the recipient host.
- On LXC containers, logind sessions from non-interactive SSH connections get stuck in `State=closing` and never get reaped (a known LXC cgroup-management issue). This causes them to accumulate — Bob observed 3353 phantom sessions, causing `w` to hang and report thousands of users.
- Add `ControlMaster=auto` + `ControlPersist=60` so both calls reuse a single SSH connection → **1 session per delivery instead of 2**, and burst deliveries within 60 s share the same master (0 new sessions for the burst).

The ControlPath is keyed per `UID + sanitized SSH target` to avoid cross-host master conflicts. After `ControlPersist=60` the master exits cleanly — no persistent background processes.

This is a **mitigation** (halves the rate of phantom session accumulation). The root fix (gating `pam_systemd` in `/etc/pam.d/common-session` on TTY presence) requires root and is tracked separately.

## Test plan
- [x] 61 existing gptmail tests pass (`uv run pytest packages/gptmail/...`)
- [x] ControlMaster/ControlPersist options accepted by both `ssh` and `scp` (standard OpenSSH ≥5.7)
- Manual smoke: `python3 scripts/agent-msg.py send alice "test" "hello"` — only 1 new logind session appears on alice's host instead of 2