### PR TITLE
feat(gptme-sessions): add --file filter to sessions search

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -2940,6 +2940,9 @@ def cost(
 @click.option("--case-sensitive", is_flag=True, help="Case-sensitive search")
 @click.option("--no-snippets", is_flag=True, help="Show only session IDs, no text excerpts")
 @click.option("--json", "as_json", is_flag=True, help="Output JSON instead of formatted text")
+@click.option(
+    "--file", "file_path", default=None, help="Only show sessions that touched this file path"
+)
 def search(
     query: str,
     days: int,
@@ -2948,24 +2951,31 @@ def search(
     case_sensitive: bool,
     no_snippets: bool,
     as_json: bool,
+    file_path: str | None,
 ) -> None:
     """Search session transcripts for a query string.
 
     Performs case-insensitive substring search across session transcripts
     and returns matching sessions ranked by recency then hit count.
 
-    Example:
+    Use --file to narrow results to sessions that touched a specific file:
+
         gptme sessions search "module not found" --days 30
+        gptme sessions search "refactor" --file src/mymodule.py
     """
     from .search import search_sessions
 
-    click.echo(f"Searching {days}-day window for: {query!r}", err=True)
+    msg = f"Searching {days}-day window for: {query!r}"
+    if file_path:
+        msg += f" (filtered to sessions touching {file_path!r})"
+    click.echo(msg, err=True)
     results = search_sessions(
         query=query,
         harness=harness,
         days=days,
         max_results=max_results,
         case_sensitive=case_sensitive,
+        file_path=file_path,
     )
 
     if as_json:

--- a/packages/gptme-sessions/src/gptme_sessions/search.py
+++ b/packages/gptme-sessions/src/gptme_sessions/search.py
@@ -69,13 +69,22 @@ def _make_snippet(content: str, pattern: re.Pattern) -> str | None:
     return snippet
 
 
-def _search_path(path: Path, pattern: re.Pattern) -> SearchResult | None:
+def _search_path(
+    path: Path,
+    pattern: re.Pattern,
+    file_pattern: re.Pattern | None = None,
+) -> SearchResult | None:
     """Search a single session file and return a result, or None if no match."""
     try:
         transcript = read_transcript(path)
     except Exception as exc:
         logger.debug("skipping %s: %s", path, exc)
         return None
+
+    # Pre-filter: if file_pattern specified, skip sessions that don't mention the file
+    if file_pattern is not None:
+        if not any(msg.content and file_pattern.search(msg.content) for msg in transcript.messages):
+            return None
 
     total_hits = 0
     snippets: list[Snippet] = []
@@ -118,6 +127,7 @@ def search_sessions(
     days: int = 30,
     max_results: int = 20,
     case_sensitive: bool = False,
+    file_path: str | None = None,
 ) -> list[SearchResult]:
     """Search session transcripts and return results ranked by recency then hit count.
 
@@ -137,9 +147,13 @@ def search_sessions(
         Maximum number of sessions to return.
     case_sensitive:
         If True, perform a case-sensitive search.
+    file_path:
+        If provided, only return sessions that mention this file path in their
+        transcript (catches Read, Edit, Write, and tool calls referencing the file).
     """
     flags = 0 if case_sensitive else re.IGNORECASE
     pattern = re.compile(re.escape(query), flags)
+    file_pattern = re.compile(re.escape(file_path), flags) if file_path else None
 
     today = date.today()
     start = today - timedelta(days=days)
@@ -156,7 +170,7 @@ def search_sessions(
 
     results: list[SearchResult] = []
     for path in paths:
-        result = _search_path(path, pattern)
+        result = _search_path(path, pattern, file_pattern)
         if result is not None:
             results.append(result)
 

--- a/packages/gptme-sessions/src/gptme_sessions/search.py
+++ b/packages/gptme-sessions/src/gptme_sessions/search.py
@@ -69,6 +69,25 @@ def _make_snippet(content: str, pattern: re.Pattern) -> str | None:
     return snippet
 
 
+def _value_mentions_file(value: object, file_pattern: re.Pattern) -> bool:
+    """Return True when a structured tool input contains the file path."""
+    if isinstance(value, str):
+        return bool(file_pattern.search(value))
+    if isinstance(value, dict):
+        return any(_value_mentions_file(v, file_pattern) for v in value.values())
+    if isinstance(value, list):
+        return any(_value_mentions_file(v, file_pattern) for v in value)
+    return False
+
+
+def _message_mentions_file(msg, file_pattern: re.Pattern) -> bool:
+    """Return True when a normalized message mentions the file path."""
+    return bool(
+        (msg.content and file_pattern.search(msg.content))
+        or (msg.tool_input and _value_mentions_file(msg.tool_input, file_pattern))
+    )
+
+
 def _search_path(
     path: Path,
     pattern: re.Pattern,
@@ -83,7 +102,7 @@ def _search_path(
 
     # Pre-filter: if file_pattern specified, skip sessions that don't mention the file
     if file_pattern is not None:
-        if not any(msg.content and file_pattern.search(msg.content) for msg in transcript.messages):
+        if not any(_message_mentions_file(msg, file_pattern) for msg in transcript.messages):
             return None
 
     total_hits = 0

--- a/packages/gptme-sessions/tests/test_search.py
+++ b/packages/gptme-sessions/tests/test_search.py
@@ -16,6 +16,7 @@ from gptme_sessions.search import (
     _search_path,
     search_sessions,
 )
+from gptme_sessions.transcript import NormalizedMessage, SessionTranscript
 
 
 # ---------------------------------------------------------------------------
@@ -55,6 +56,35 @@ def _cc_session(tmp_path: Path, text: str, ts: str = "2026-03-01T10:00:00.000Z")
                 "content": [{"type": "text", "text": text}],
             },
         }
+    ]
+    _write_jsonl(jsonl, records)
+    return jsonl
+
+
+def _cc_tool_use_session(
+    tmp_path: Path,
+    user_text: str,
+    tool_input: dict,
+    ts: str = "2026-03-01T10:00:00.000Z",
+) -> Path:
+    """Create a Claude Code session where the file path exists only in tool input."""
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    jsonl = tmp_path / "tool-use.jsonl"
+    records = [
+        {
+            "type": "user",
+            "timestamp": ts,
+            "message": {"role": "user", "content": [{"type": "text", "text": user_text}]},
+        },
+        {
+            "type": "assistant",
+            "timestamp": ts,
+            "message": {
+                "role": "assistant",
+                "model": "claude-sonnet-4-6",
+                "content": [{"type": "tool_use", "name": "Read", "input": tool_input}],
+            },
+        },
     ]
     _write_jsonl(jsonl, records)
     return jsonl
@@ -461,6 +491,31 @@ class TestSearchPathFileFilter:
         result = _search_path(session, re.compile("notfound"), file_pattern)
         assert result is None
 
+    def test_matches_file_path_from_tool_input(self, tmp_path: Path):
+        import re
+
+        transcript = SessionTranscript(
+            schema_version=1,
+            session_id="abc123",
+            harness="claude-code",
+            trajectory_path=str(tmp_path / "abc123.jsonl"),
+            started_at="2026-03-01T10:00:00+00:00",
+            messages=[
+                NormalizedMessage(role="user", content="please fix the auth bug"),
+                NormalizedMessage(
+                    role="assistant",
+                    content="",
+                    tool_name="Read",
+                    tool_input={"path": "/src/auth.py"},
+                ),
+            ],
+        )
+        file_pattern = re.compile(re.escape("/src/auth.py"), re.IGNORECASE)
+        with patch("gptme_sessions.search.read_transcript", return_value=transcript):
+            result = _search_path(tmp_path / "abc123.jsonl", re.compile("auth bug"), file_pattern)
+        assert result is not None
+        assert result.hit_count == 1
+
 
 # ---------------------------------------------------------------------------
 # Integration tests: search_sessions with file_path
@@ -504,3 +559,19 @@ class TestSearchSessionsFileFilter:
         ):
             results = search_sessions("fix", file_path=None)
         assert len(results) == 2
+
+    def test_file_filter_matches_cc_tool_input(self, tmp_path: Path):
+        cc = _cc_tool_use_session(
+            tmp_path,
+            user_text="fix the auth bug",
+            tool_input={"path": "/src/auth.py"},
+        )
+        with (
+            patch("gptme_sessions.search.discover_gptme_sessions", return_value=[]),
+            patch("gptme_sessions.search.discover_cc_sessions", return_value=[cc]),
+            patch("gptme_sessions.search.discover_codex_sessions", return_value=[]),
+            patch("gptme_sessions.search.discover_copilot_sessions", return_value=[]),
+        ):
+            results = search_sessions("auth bug", file_path="/src/auth.py")
+        assert len(results) == 1
+        assert results[0].harness == "claude-code"

--- a/packages/gptme-sessions/tests/test_search.py
+++ b/packages/gptme-sessions/tests/test_search.py
@@ -392,3 +392,115 @@ class TestSearchCLI:
         runner = CliRunner()
         result = runner.invoke(cli, ["search", "test", "--harness", "invalid-harness"])
         assert result.exit_code != 0
+
+    def test_search_file_filter_in_help(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["search", "--help"])
+        assert result.exit_code == 0
+        assert "--file" in result.output
+
+    def test_search_file_filter_narrows_results(self, tmp_path: Path):
+        session_with_file = _gptme_session(
+            tmp_path / "with",
+            [("assistant", "target found, editing /src/mymodule.py now")],
+        )
+        session_without_file = _gptme_session(
+            tmp_path / "without",
+            [("assistant", "target found, but no file reference")],
+        )
+        runner = CliRunner()
+        with (
+            patch(
+                "gptme_sessions.search.discover_gptme_sessions",
+                return_value=[session_with_file, session_without_file],
+            ),
+            patch("gptme_sessions.search.discover_cc_sessions", return_value=[]),
+            patch("gptme_sessions.search.discover_codex_sessions", return_value=[]),
+            patch("gptme_sessions.search.discover_copilot_sessions", return_value=[]),
+        ):
+            result = runner.invoke(cli, ["search", "target", "--file", "/src/mymodule.py"])
+        assert result.exit_code == 0
+        assert "1 session(s)" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _search_path with file_pattern
+# ---------------------------------------------------------------------------
+
+
+class TestSearchPathFileFilter:
+    def test_returns_none_when_file_not_mentioned(self, tmp_path: Path):
+        import re
+
+        session = _gptme_session(tmp_path, [("assistant", "some content without the file")])
+        file_pattern = re.compile(re.escape("/src/mymodule.py"), re.IGNORECASE)
+        result = _search_path(session, re.compile("content"), file_pattern)
+        assert result is None
+
+    def test_returns_result_when_file_mentioned(self, tmp_path: Path):
+        import re
+
+        session = _gptme_session(
+            tmp_path, [("assistant", "editing /src/mymodule.py to fix the bug")]
+        )
+        file_pattern = re.compile(re.escape("/src/mymodule.py"), re.IGNORECASE)
+        result = _search_path(session, re.compile("fix", re.IGNORECASE), file_pattern)
+        assert result is not None
+        assert result.hit_count == 1
+
+    def test_requires_both_query_and_file_to_match(self, tmp_path: Path):
+        import re
+
+        session = _gptme_session(
+            tmp_path,
+            [
+                ("assistant", "the file /src/mymodule.py exists but no query word here"),
+            ],
+        )
+        file_pattern = re.compile(re.escape("/src/mymodule.py"), re.IGNORECASE)
+        result = _search_path(session, re.compile("notfound"), file_pattern)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: search_sessions with file_path
+# ---------------------------------------------------------------------------
+
+
+class TestSearchSessionsFileFilter:
+    def test_file_filter_excludes_sessions_without_file(self, tmp_path: Path):
+        session_with = _gptme_session(
+            tmp_path / "with",
+            [("assistant", "worked on /src/auth.py")],
+        )
+        session_without = _gptme_session(
+            tmp_path / "without",
+            [("assistant", "worked on unrelated things")],
+        )
+        with (
+            patch(
+                "gptme_sessions.search.discover_gptme_sessions",
+                return_value=[session_with, session_without],
+            ),
+            patch("gptme_sessions.search.discover_cc_sessions", return_value=[]),
+            patch("gptme_sessions.search.discover_codex_sessions", return_value=[]),
+            patch("gptme_sessions.search.discover_copilot_sessions", return_value=[]),
+        ):
+            results = search_sessions("worked", file_path="/src/auth.py")
+        assert len(results) == 1
+        assert results[0].path == str(session_with)
+
+    def test_file_filter_none_returns_all_matches(self, tmp_path: Path):
+        session_a = _gptme_session(tmp_path / "a", [("assistant", "fix the bug")])
+        session_b = _gptme_session(tmp_path / "b", [("assistant", "fix the config")])
+        with (
+            patch(
+                "gptme_sessions.search.discover_gptme_sessions",
+                return_value=[session_a, session_b],
+            ),
+            patch("gptme_sessions.search.discover_cc_sessions", return_value=[]),
+            patch("gptme_sessions.search.discover_codex_sessions", return_value=[]),
+            patch("gptme_sessions.search.discover_copilot_sessions", return_value=[]),
+        ):
+            results = search_sessions("fix", file_path=None)
+        assert len(results) == 2


### PR DESCRIPTION
## Summary

- Adds `--file PATH` option to `gptme sessions search` that narrows results to sessions which mentioned a file path in their transcript
- Catches all tool calls (Read, Edit, Write, NotebookEdit) that reference the file — not just writes
- 8 new tests covering the filter at unit, integration, and CLI levels

## Background

The HN post ["Show HN: ctx – Search the coding agent history already on your machine"](https://github.com/ctxrs/ctx) hit 108 points. ctx's key differentiating feature is `--file PATH` ("which agent sessions touched this file?"). gptme-sessions already had all the data (transcripts mention file paths in tool call content) but no search surface over it.

## Usage

```bash
# Which sessions worked on this file?
gptme sessions search "refactor" --file src/mymodule.py

# Combine with harness and time filters
gptme sessions search "error" --file auth.py --harness claude-code --days 7

# JSON output for scripting
gptme sessions search "fix" --file server.py --json
```

## Implementation

`file_path` compiles to a `re.Pattern` passed to `_search_path()` as a pre-filter before the full text search runs. Sessions where no message mentions the path are skipped early — O(messages) cost, same as a second search pass.

## Test plan

- [x] `--file` appears in `--help` output
- [x] Sessions mentioning the file path are returned, others are excluded
- [x] `file_path=None` (default) returns all matches as before
- [x] Both query AND file must match for a session to be included
- [x] All 36 tests pass including 8 new ones