### PR TITLE
fix(gptme-coordination): deny complete() on expired claims

### DIFF
--- a/packages/gptme-coordination/src/gptme_coordination/work.py
+++ b/packages/gptme-coordination/src/gptme_coordination/work.py
@@ -399,6 +399,10 @@ class WorkClaimManager:
     ) -> bool:
         """Mark a claimed task as completed. Returns True if successful.
 
+        An expired claim (``expires_at < now``) cannot be completed — without
+        this guard a session that outlives its TTL can ghost-complete a task in
+        the window before another session reclaims it.
+
         When ``dry_run`` is true, validates the completion path without
         persisting the status change.
         """
@@ -408,7 +412,8 @@ class WorkClaimManager:
             rows = conn.execute(
                 """UPDATE work SET status = 'completed', result = ?,
                     completed_at = datetime('now')
-                WHERE task_id = ? AND claimer = ? AND status = 'claimed'""",
+                WHERE task_id = ? AND claimer = ? AND status = 'claimed'
+                  AND expires_at >= datetime('now')""",
                 (result, task_id, agent_id),
             )
             ok = bool(rows.rowcount > 0)

--- a/packages/gptme-coordination/tests/test_work.py
+++ b/packages/gptme-coordination/tests/test_work.py
@@ -101,6 +101,20 @@ class TestComplete:
         ok = work.complete("agent-a", "task-1")
         assert not ok
 
+    def test_complete_after_expiry_is_denied(self, work: WorkClaimManager) -> None:
+        """An expired claim must not be completable (ghost-complete prevention)."""
+        work.claim("agent-a", "task-1")
+        work.db.conn.execute(
+            "UPDATE work SET expires_at = datetime('now', '-1 seconds') WHERE task_id = ?",
+            ("task-1",),
+        )
+        ok = work.complete("agent-a", "task-1")
+        assert not ok
+        # Task should remain in claimed state, reclaimable by another agent
+        claim = work.get("task-1")
+        assert claim is not None
+        assert claim.status == "claimed"
+
 
 class TestAbandon:
     def test_abandon_claimed_task(self, work: WorkClaimManager) -> None:


### PR DESCRIPTION
## Summary

- Adds `AND expires_at >= datetime('now')` to the `WHERE` clause in `WorkClaimManager.complete()`
- Without this guard, a session that outlives its TTL can ghost-complete a task in the window before another agent reclaims it, violating the coordination contract
- Adds `test_complete_after_expiry_is_denied` to cover the gap

## Motivation

Bob's local `coordination` package already has this fix ([`364a2d1e37`](https://github.com/ErikBjare/bob/commit/364a2d1e37)) — found during a concurrency audit that identified the `complete()` TTL gap as a real bug class. This PR ports it upstream.

## Test plan

- [x] `uv run pytest tests/test_work.py -v` — 25 passed (was 24)
- [x] New test explicitly backdates `expires_at` to `-1 second` and asserts `complete()` returns `False`, and the task stays in `claimed` state (reclaimable)