### PR TITLE
fix(runloops): use sys.executable in tests to avoid uv startup timeout

### DIFF
--- a/packages/gptme-runloops/tests/test_integration.py
+++ b/packages/gptme-runloops/tests/test_integration.py
@@ -7,6 +7,7 @@ AI execution while testing full infrastructure.
 
 import os
 import subprocess
+import sys
 import time
 from pathlib import Path
 
@@ -36,15 +37,7 @@ class TestCLIIntegration:
     def test_autonomous_cli_help(self):
         """Test autonomous command help shows correct information."""
         result = subprocess.run(
-            [
-                "uv",
-                "run",
-                "python3",
-                "-m",
-                "gptme_runloops.cli",
-                "autonomous",
-                "--help",
-            ],
+            [sys.executable, "-m", "gptme_runloops.cli", "autonomous", "--help"],
             capture_output=True,
             text=True,
             timeout=10,
@@ -56,7 +49,7 @@ class TestCLIIntegration:
     def test_email_cli_help(self):
         """Test email command help shows correct information."""
         result = subprocess.run(
-            ["uv", "run", "python3", "-m", "gptme_runloops.cli", "email", "--help"],
+            [sys.executable, "-m", "gptme_runloops.cli", "email", "--help"],
             capture_output=True,
             text=True,
             timeout=10,
@@ -68,15 +61,7 @@ class TestCLIIntegration:
     def test_monitoring_cli_help(self):
         """Test monitoring command help shows correct information."""
         result = subprocess.run(
-            [
-                "uv",
-                "run",
-                "python3",
-                "-m",
-                "gptme_runloops.cli",
-                "monitoring",
-                "--help",
-            ],
+            [sys.executable, "-m", "gptme_runloops.cli", "monitoring", "--help"],
             capture_output=True,
             text=True,
             timeout=10,
@@ -187,26 +172,10 @@ class TestCLIIntegration:
     def test_cli_command_performance(self, test_workspace: Path):
         """Test CLI command execution performance (help commands)."""
         commands = [
-            ["uv", "run", "python3", "-m", "gptme_runloops.cli", "--help"],
-            [
-                "uv",
-                "run",
-                "python3",
-                "-m",
-                "gptme_runloops.cli",
-                "autonomous",
-                "--help",
-            ],
-            ["uv", "run", "python3", "-m", "gptme_runloops.cli", "email", "--help"],
-            [
-                "uv",
-                "run",
-                "python3",
-                "-m",
-                "gptme_runloops.cli",
-                "monitoring",
-                "--help",
-            ],
+            [sys.executable, "-m", "gptme_runloops.cli", "--help"],
+            [sys.executable, "-m", "gptme_runloops.cli", "autonomous", "--help"],
+            [sys.executable, "-m", "gptme_runloops.cli", "email", "--help"],
+            [sys.executable, "-m", "gptme_runloops.cli", "monitoring", "--help"],
         ]
 
         for cmd in commands:
@@ -283,9 +252,7 @@ class TestShellScriptComparison:
         # Test that CLI accepts workspace parameter
         result = subprocess.run(
             [
-                "uv",
-                "run",
-                "python3",
+                sys.executable,
                 "-m",
                 "gptme_runloops.cli",
                 "autonomous",


### PR DESCRIPTION
## Summary

- Replace `["uv", "run", "python3", "-m", ...]` with `[sys.executable, "-m", ...]` in CLI help tests
- Under high system load (40+ concurrent processes), `uv run` startup can exceed 10s, causing `subprocess.TimeoutExpired`
- `sys.executable` points to the already-active Python interpreter in the test env, cutting startup from potentially >10s to <0.5s (observed: 0.25s total for all 3 tests)

## Root cause

Tests use a 10-second subprocess timeout. The `uv run` command needs to resolve the lockfile and start Python. On a busy system this can exceed the limit. Since tests run inside the uv-managed venv (via `uv run pytest`), `sys.executable` is already the correct interpreter — no `uv` indirection needed.

## Test plan

- [x] `test_autonomous_cli_help` passes (was timing out)
- [x] `test_email_cli_help` passes
- [x] `test_monitoring_cli_help` passes
- [x] `test_cli_command_performance` still tests meaningful timing (module import, not uv overhead)
- [x] Pre-commit hooks pass