### PR TITLE
feat(gptme-sessions): add violated_policy outcome class

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -990,7 +990,7 @@ def append(
 @click.option(
     "--outcome",
     default=None,
-    type=click.Choice(["productive", "noop", "failed", "unknown"]),
+    type=click.Choice(["productive", "noop", "failed", "unknown", "violated_policy"]),
     help="Override outcome",
 )
 @click.option(

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -202,7 +202,7 @@ class SessionRecord:
     cascade_intent: dict[str, Any] | None = None  # structured CASCADE reasons + constraints dict
 
     # Outcome
-    outcome: str = "unknown"  # productive, noop, failed
+    outcome: str = "unknown"  # productive, noop, violated_policy, failed
     exit_code: int | None = None  # process exit code (124 = timeout)
     duration_seconds: int = 0
     token_count: int | None = None

--- a/packages/gptme-sessions/src/gptme_sessions/store.py
+++ b/packages/gptme-sessions/src/gptme_sessions/store.py
@@ -230,6 +230,7 @@ class SessionStore:
         total = len(records)
         productive = sum(1 for r in records if r.outcome == "productive")
         noop = sum(1 for r in records if r.outcome == "noop")
+        violated_policy = sum(1 for r in records if r.outcome == "violated_policy")
 
         # Model breakdown (uses normalized names for grouping)
         model_stats: dict[str, dict[str, int]] = {}
@@ -314,6 +315,7 @@ class SessionStore:
             "total": total,
             "productive": productive,
             "noop": noop,
+            "violated_policy": violated_policy,
             "success_rate": productive / total if total > 0 else 0,
             "duration": duration_stats,
             "by_model": {m: _rate(s) for m, s in sorted(model_stats.items())},
@@ -335,8 +337,11 @@ def format_stats(stats: dict, out: TextIO = sys.stdout) -> None:
         return
 
     rate = stats.get("success_rate", 0)
+    violated = stats.get("violated_policy", 0)
     out.write(f"Sessions: {total} total, {stats['productive']} productive ")
     out.write(f"({rate:.0%} success rate)\n")
+    if violated:
+        out.write(f"  Policy violations: {violated} session(s)\n")
 
     dur = stats.get("duration", {})
     if dur:

--- a/packages/gptme-sessions/src/gptme_sessions/thompson_sampling.py
+++ b/packages/gptme-sessions/src/gptme_sessions/thompson_sampling.py
@@ -245,7 +245,8 @@ class BanditState:
         Args:
             active_arms: Arm IDs that were active in this session.
             outcome: Session outcome. Accepts:
-                - str: 'productive' (1.0), 'noop'/'failed' (0.0)
+                - str: 'productive' (1.0), 'noop'/'failed' (0.0),
+                  'violated_policy' (0.0, counted as policy violation)
                 - float in [0, 1]: Graded reward for nuanced learning.
             context: Optional context tuple. When provided, updates both
                      the contextual arm AND the global arm.
@@ -258,12 +259,13 @@ class BanditState:
         if isinstance(outcome, str):
             if outcome == "productive":
                 base_reward = 1.0
-            elif outcome in ("noop", "failed"):
+            elif outcome in ("noop", "failed", "violated_policy"):
                 base_reward = 0.0
             else:
                 raise ValueError(
                     f"Unknown string outcome: {outcome!r}. "
-                    "Expected 'productive', 'noop', 'failed', or a float in [0, 1]."
+                    "Expected 'productive', 'noop', 'failed', 'violated_policy', "
+                    "or a float in [0, 1]."
                 )
         else:
             base_reward = float(outcome)
@@ -470,7 +472,7 @@ class Bandit:
         Args:
             active_arms: Arm IDs that were active.
             outcome: Session outcome: 'productive'/1.0, 'noop'/'failed'/0.0,
-                     or a graded float in [0, 1].
+                     'violated_policy'/0.0, or a graded float in [0, 1].
             context: Optional context tuple for contextual arms.
             decay_rate: If set, apply exponential decay before updating.
             per_arm_rewards: Optional per-arm rewards for salience-weighted credit.
@@ -762,7 +764,7 @@ def sample(
 @click.option(
     "--outcome",
     required=True,
-    help="Session outcome: productive/noop/failed or a float in [0,1]",
+    help="Session outcome: productive/noop/failed/violated_policy or a float in [0,1]",
 )
 @click.option("--arms", multiple=True, required=True, help="Active arm IDs")
 @click.option("--context", multiple=True, help="Context tuple, e.g. --context infrastructure opus")
@@ -788,9 +790,9 @@ def update(
             print("Error: float outcome must be in [0, 1]", file=sys.stderr)
             raise click.exceptions.Exit(1)
     except ValueError:
-        if outcome not in ("productive", "noop", "failed"):
+        if outcome not in ("productive", "noop", "failed", "violated_policy"):
             print(
-                "Error: outcome must be productive/noop/failed or a float in [0,1]",
+                "Error: outcome must be productive/noop/failed/violated_policy or a float in [0,1]",
                 file=sys.stderr,
             )
             raise click.exceptions.Exit(1)

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -187,6 +187,22 @@ def test_session_store_stats(tmp_path: Path):
     assert s["by_model_run_type"]["sonnet×monitoring"]["rate"] == 0.5
 
 
+def test_session_store_violated_policy_stats(tmp_path: Path):
+    """violated_policy outcome is tracked separately and excluded from productive count."""
+    store = SessionStore(sessions_dir=tmp_path)
+    store.append(SessionRecord(model="haiku", outcome="productive"))
+    store.append(SessionRecord(model="haiku", outcome="violated_policy"))
+    store.append(SessionRecord(model="haiku", outcome="noop"))
+
+    s = store.stats()
+    assert s["total"] == 3
+    assert s["productive"] == 1
+    assert s["violated_policy"] == 1
+    assert s["noop"] == 1
+    # success_rate counts only productive, not violated_policy
+    assert s["success_rate"] == pytest.approx(1 / 3)
+
+
 def test_session_store_empty(tmp_path: Path):
     """Empty store returns sensible defaults."""
     store = SessionStore(sessions_dir=tmp_path)

--- a/packages/gptme-sessions/tests/test_thompson_sampling.py
+++ b/packages/gptme-sessions/tests/test_thompson_sampling.py
@@ -133,6 +133,16 @@ def test_bandit_state_update_session_string_outcome():
     assert state.total_sessions == 2
 
 
+def test_bandit_state_update_session_violated_policy_outcome():
+    """violated_policy outcome maps to 0.0 reward (same as noop/failed)."""
+    state = BanditState()
+    state.update_session(["code"], outcome="productive")
+    state.update_session(["code"], outcome="violated_policy")
+    assert state.arms["code"].beta == pytest.approx(2.0)
+    assert state.arms["code"].alpha == pytest.approx(2.0)
+    assert state.total_sessions == 2
+
+
 def test_bandit_state_update_session_float_outcome():
     """Float outcomes produce fractional alpha/beta updates."""
     state = BanditState()


### PR DESCRIPTION
## Summary

- Adds `violated_policy` as a recognized `outcome` string alongside `productive`/`noop`/`failed`
- `store.stats()` now tracks `violated_policy` count separately and displays it in `format_stats()` when non-zero
- `violated_policy` is excluded from `success_rate` (correctly penalizes policy-bypass sessions in KPI)
- Test coverage added for the new outcome class

## Context

Addresses Erik's ask on [ErikBjare/bob#1015](https://github.com/ErikBjare/bob/issues/1015):
> "off-policy behavior should be harm-attributed to ensure we keep track of when it happens/recurs"

The specific incident (session `6a5eee59`, unauthorized gptme-contrib#1175 self-merge) was recorded
as `outcome=productive` with no harm signal, making it invisible in KPI metrics. This PR adds the
vocabulary; the backfill script (`scripts/annotate-policy-violation.py` in ErikBjare/bob) runs the
annotation during a calm fleet window.

## Bandit behavior

No change to `thompson_sampling.py` needed — `_session_rewards()` already maps any non-`productive`
string to `0.0` reward, so `violated_policy` gets penalized correctly.

## What's left (ErikBjare/bob, separate task)

- `scripts/annotate-policy-violation.py` — one-shot backfill for session 6a5eee59 (calm window)
- `update-harness-bandit.py` — adds `violated_policy` to `--outcome` choices
- Future: pm-react sessions that self-report incidents → auto-set `violated_policy` outcome