### PR TITLE
feat(pm-dispatch): route direct Erik @mentions to base model in Python dispatch

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -399,7 +399,7 @@ def _resolve_model_with_bandit(
     ``resolve_lane_model()`` split.
     """
     # Direct @mention override: never downgrade to the cheap fast-lane model.
-    if detail and is_direct_mention(detail):
+    if is_direct_mention(detail):
         return model
 
     if bandit is None:

--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -47,6 +47,30 @@ MIN_BANDIT_OBSERVATIONS = 5
 logger = logging.getLogger(__name__)
 
 
+def is_direct_mention(detail: str) -> bool:
+    """Return True when *detail* marks a direct Erik @Bob mention handoff.
+
+    Mirrors the bash ``item_detail_is_direct_mention()`` function in
+    ``project-monitoring-dispatch.sh``.  Two upstream sources produce
+    different marker shapes:
+
+    * ``activity-gate.sh`` emits the raw GitHub notification ``reason`` as
+      detail tokens joined by ``"; "``.  A bare ``"mention"`` token means a
+      direct @Bob mention; ``"team_mention"`` and others do not qualify.
+    * ``assigned_issue_pending_reply.py`` embeds
+      ``source: direct_mention_handoff`` inside the detail string.
+
+    Direct Erik mentions are high-signal asks — dispatching them to the
+    cheap fast-lane model causes NOOPs (ErikBjare/bob#907).
+    """
+    if "direct_mention_handoff" in detail:
+        return True
+    for tok in detail.split(";"):
+        if tok.strip() == "mention":
+            return True
+    return False
+
+
 # --- Data classes ---
 
 
@@ -62,6 +86,7 @@ class SlotItem:
     types: list[str]
     title: str = ""
     url: str = ""
+    detail: str = ""
 
 
 @dataclass
@@ -359,13 +384,24 @@ def _resolve_model_with_bandit(
     model: str | None,
     fast_model: str | None,
     bandit: Any | None,
+    detail: str = "",
 ) -> str | None:
     """Resolve the dispatch model for an item.
 
-    When a bandit is provided and has ≥ MIN_BANDIT_OBSERVATIONS for the
-    inferred work type, use Thompson sampling to select the model.
-    Otherwise fall back to the static resolve_lane_model() split.
+    Direct Erik @mention items (``is_direct_mention(detail) == True``) always
+    get the base *model* — never the cheap *fast_model* — regardless of lane or
+    bandit state.  This mirrors the bash ``select_slot_model()`` precedence rule
+    and prevents the NOOP failure from ErikBjare/bob#907.
+
+    For all other items: when a bandit is provided and has ≥
+    MIN_BANDIT_OBSERVATIONS for the inferred work type, use Thompson sampling
+    to select the model.  Otherwise fall back to the static
+    ``resolve_lane_model()`` split.
     """
+    # Direct @mention override: never downgrade to the cheap fast-lane model.
+    if detail and is_direct_mention(detail):
+        return model
+
     if bandit is None:
         return resolve_lane_model(lane, model, fast_model)
     work_type = classify_item_work_type(item_types)
@@ -560,7 +596,7 @@ class LaneDispatcher:
                     item=item,
                     backend=backend,
                     model=_resolve_model_with_bandit(
-                        item.types, lane, model, fast_model, bandit
+                        item.types, lane, model, fast_model, bandit, item.detail
                     ),
                     script_path=script_path,
                 )

--- a/packages/gptme-runloops/tests/test_pm_dispatch.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch.py
@@ -27,6 +27,7 @@ from gptme_runloops.pm_dispatch import (
     classify_lane,
     derive_slot_key,
     dispatch_grouped_items,
+    is_direct_mention,
     partition_items,
     resolve_lane_model,
 )
@@ -1338,6 +1339,42 @@ class TestBanditObservationCount:
         assert _bandit_observation_count(bandit, "ci-fix", models=["sonnet"]) == 0
 
 
+class TestIsDirectMention:
+    """Tests for is_direct_mention() — mirrors bash item_detail_is_direct_mention()."""
+
+    def test_bare_mention_token(self):
+        assert is_direct_mention("mention") is True
+
+    def test_mention_in_semicolon_list(self):
+        assert is_direct_mention("comment; mention") is True
+
+    def test_mention_with_whitespace(self):
+        assert is_direct_mention("  mention  ") is True
+        assert is_direct_mention("assign;   mention") is True
+
+    def test_direct_mention_handoff_source(self):
+        assert is_direct_mention("source: direct_mention_handoff") is True
+
+    def test_team_mention_does_not_qualify(self):
+        assert is_direct_mention("team_mention") is False
+
+    def test_comment_reason_does_not_qualify(self):
+        assert is_direct_mention("comment") is False
+
+    def test_assign_reason_does_not_qualify(self):
+        assert is_direct_mention("assign") is False
+
+    def test_empty_detail_returns_false(self):
+        assert is_direct_mention("") is False
+
+    def test_substring_mention_does_not_match(self):
+        # "team_mention" contains "mention" as a substring — must not match
+        assert is_direct_mention("team_mention; review") is False
+
+    def test_multiple_tokens_with_mention(self):
+        assert is_direct_mention("review; mention; assign") is True
+
+
 class TestResolveModelWithBandit:
     def test_no_bandit_delegates_to_static(self):
         result = _resolve_model_with_bandit(
@@ -1390,6 +1427,56 @@ class TestResolveModelWithBandit:
             ["ci_failure"], "slow", "sonnet", "haiku", bandit
         )
         assert result == "sonnet"  # static fallback: slow lane → base model
+
+    # --- direct-mention override (ErikBjare/bob#907) ---
+
+    def test_direct_mention_bypasses_fast_model_no_bandit(self):
+        """A direct mention in fast lane must NOT get the cheap fast_model."""
+        result = _resolve_model_with_bandit(
+            ["notification"], "fast", "sonnet", "haiku-cheap", None, detail="mention"
+        )
+        assert result == "sonnet"
+
+    def test_direct_mention_bypasses_fast_model_with_bandit(self):
+        """Direct mention overrides bandit as well — bandit must not downgrade the model."""
+        bandit = _StubBandit(
+            {"notification-triage": MIN_BANDIT_OBSERVATIONS + 10}, model="haiku-cheap"
+        )
+        result = _resolve_model_with_bandit(
+            ["notification"],
+            "fast",
+            "sonnet",
+            "haiku-cheap",
+            bandit,
+            detail="comment; mention",
+        )
+        assert result == "sonnet"
+
+    def test_direct_mention_handoff_source_bypasses_fast_model(self):
+        """assigned_issue_pending_reply.py handoff marker also triggers the override."""
+        result = _resolve_model_with_bandit(
+            ["notification"],
+            "fast",
+            "sonnet",
+            "haiku-cheap",
+            None,
+            detail="source: direct_mention_handoff",
+        )
+        assert result == "sonnet"
+
+    def test_non_mention_fast_lane_still_uses_fast_model(self):
+        """Non-mention fast-lane items are unaffected — still get fast_model."""
+        result = _resolve_model_with_bandit(
+            ["notification"], "fast", "sonnet", "haiku-cheap", None, detail="comment"
+        )
+        assert result == "haiku-cheap"
+
+    def test_empty_detail_fast_lane_still_uses_fast_model(self):
+        """Empty detail is not a mention — fast lane still uses fast_model."""
+        result = _resolve_model_with_bandit(
+            ["notification"], "fast", "sonnet", "haiku-cheap", None, detail=""
+        )
+        assert result == "haiku-cheap"
 
 
 # --- LaneDispatcher with bandit ---


### PR DESCRIPTION
## Summary

- Mirrors the bash `select_slot_model()` precedence rule in `pm_dispatch.py`
- Before this, a direct Erik @mention arriving as `notification`-type was dispatched with `BOB_PM_FAST_LANE_MODEL` (the cheap model), causing the session to NOOP on the ask (ErikBjare/bob#907)
- The bash path (`project-monitoring-dispatch.sh`) already had this routing; Python dispatch was the gap

## Changes

- Add `detail: str = ""` field to `SlotItem` to carry raw GitHub notification `reason` tokens
- Add `is_direct_mention(detail)` — mirrors bash `item_detail_is_direct_mention()`, matching bare `"mention"` tokens and `"direct_mention_handoff"` source markers
- Update `_resolve_model_with_bandit()` to bypass `fast_model` for direct mentions (regardless of bandit state)
- Pass `item.detail` at the dispatch call site
- 11 new tests covering `is_direct_mention()` and the model-override path

## Test plan

- [ ] `uv run pytest packages/gptme-runloops/tests/test_pm_dispatch.py -q` — 147 tests pass
- [ ] `mypy packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py` — clean