### PR TITLE
feat(gptodo): add pool field to task schema (general/frontier)

### DIFF
--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -168,6 +168,8 @@ KNOWN_FRONTMATTER_FIELDS: set[str] = {
     "tracking",
     "tracking_issue",
     "upstream_coordination_id",
+    # Work-pool routing (see frontier-pool-routing design)
+    "pool",
     # Multi-agent coordination
     "parallelizable",
     "isolation",
@@ -900,6 +902,11 @@ def validate_task_file(file: Path, post: fmPost) -> List[str]:
         priority = metadata["priority"]
         if priority not in ("high", "medium", "low", None):
             issues.append("Priority must be 'high', 'medium', or 'low'")
+
+    if "pool" in metadata:
+        pool = metadata["pool"]
+        if pool not in ("general", "frontier", None):
+            issues.append("pool must be 'general' or 'frontier'")
 
     if "tags" in metadata and not isinstance(metadata["tags"], list):
         issues.append("Tags must be a list")

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -906,7 +906,7 @@ def validate_task_file(file: Path, post: fmPost) -> List[str]:
     if "pool" in metadata:
         pool = metadata["pool"]
         if pool not in ("general", "frontier", None):
-            issues.append("pool must be 'general' or 'frontier'")
+            issues.append("pool must be 'general', 'frontier', or null")
 
     if "tags" in metadata and not isinstance(metadata["tags"], list):
         issues.append("Tags must be a list")

--- a/packages/gptodo/tests/test_validate_frontmatter.py
+++ b/packages/gptodo/tests/test_validate_frontmatter.py
@@ -295,6 +295,15 @@ def test_pool_frontier_passes_schema(tmp_path):
     assert validate_schema(p) == []
 
 
+def test_pool_null_passes_schema(tmp_path):
+    """pool: null is accepted (treated as unset, defaults to general)."""
+    p = _write_task(
+        tmp_path,
+        "---\nstate: backlog\ncreated: 2026-07-01\npool: null\n---\n# task\n",
+    )
+    assert validate_schema(p) == []
+
+
 def test_pool_absent_passes_schema(tmp_path):
     """pool is optional; omitting it is valid (defaults to general)."""
     p = _write_task(

--- a/packages/gptodo/tests/test_validate_frontmatter.py
+++ b/packages/gptodo/tests/test_validate_frontmatter.py
@@ -272,3 +272,42 @@ def test_opaque_session_at_host_passes_schema(tmp_path):
         "---\nstate: backlog\ncreated: 2026-07-01\nassigned_to: a3f9@bob\n---\n# task\n",
     )
     assert validate_schema(p) == []
+
+
+# ---------------------------------------------------------------------------
+# pool field validation
+# ---------------------------------------------------------------------------
+
+
+def test_pool_general_passes_schema(tmp_path):
+    p = _write_task(
+        tmp_path,
+        "---\nstate: backlog\ncreated: 2026-07-01\npool: general\n---\n# task\n",
+    )
+    assert validate_schema(p) == []
+
+
+def test_pool_frontier_passes_schema(tmp_path):
+    p = _write_task(
+        tmp_path,
+        "---\nstate: backlog\ncreated: 2026-07-01\npool: frontier\n---\n# task\n",
+    )
+    assert validate_schema(p) == []
+
+
+def test_pool_absent_passes_schema(tmp_path):
+    """pool is optional; omitting it is valid (defaults to general)."""
+    p = _write_task(
+        tmp_path,
+        "---\nstate: backlog\ncreated: 2026-07-01\n---\n# task\n",
+    )
+    assert validate_schema(p) == []
+
+
+def test_pool_invalid_value_rejected(tmp_path):
+    p = _write_task(
+        tmp_path,
+        "---\nstate: backlog\ncreated: 2026-07-01\npool: premium\n---\n# task\n",
+    )
+    errors = validate_schema(p)
+    assert any("pool" in e for e in errors)


### PR DESCRIPTION
## Summary

- Adds `pool` as a known gptodo frontmatter field with enum validation (`general` | `frontier`)
- `pool` is optional; absent means `general` (the default pool)
- 5 new tests in `test_validate_frontmatter.py` covering both valid values, absent field, and an invalid value rejection

## Motivation

The `pool` field is the durable primitive for work-pool routing across all agents that share the gptodo schema (Bob, Alice, Gordon, Sven). Tasks marked `pool: frontier` should only be claimed by frontier-tier sessions; enforcement lives at the claim gate in each agent's router — gptodo defines and validates the field only.

Design doc: `knowledge/technical-designs/frontier-pool-routing.md` in Bob's workspace.

## Test plan

- [x] `uv run pytest packages/gptodo/tests/ -q` → 311 passed
- [x] `ruff check` → clean
- [x] `prek` hooks → all passed