### PR TITLE
feat(gptmail): add recipient allowlist to email send path

### DIFF
--- a/packages/gptmail/src/gptmail/lib.py
+++ b/packages/gptmail/src/gptmail/lib.py
@@ -493,12 +493,12 @@ class AgentEmail:
         elif env_allowlist:
             allowlisted = [e.strip() for e in env_allowlist.split(",") if e.strip()]
         else:
-            # Default allowlist if not configured
+            # Default allowlist if not configured (RFC 5737 fake addresses)
+            # Real addresses should be supplied via EMAIL_ALLOWLIST env var at deploy time
             allowlisted = [
-                "erik@bjareho.lt",
-                "erik.bjareholt@gmail.com",
-                "filip.harald@gmail.com",
-                "rickard.edic@gmail.com",
+                "erik@example.com",
+                "filip@example.com",
+                "rickard@example.com",
             ]
 
         # Remove +tag from email address for comparison
@@ -537,8 +537,9 @@ class AgentEmail:
         """Check if recipient is allowlisted for outbound send.
 
         Fail-closed: empty or unparseable recipients are blocked.
-        Uses EMAIL_SEND_ALLOWLIST env var; falls back to the same defaults
-        as the inbound allowlist (Erik, Filip, Rickard) plus own address.
+        Uses EMAIL_SEND_ALLOWLIST env var; falls back to RFC 5737 fake
+        default addresses (example.com) plus own address. Real addresses
+        should be configured via EMAIL_SEND_ALLOWLIST at deploy time.
 
         Args:
             recipient: The email address or "Name <addr>" string to check.
@@ -552,11 +553,12 @@ class AgentEmail:
         elif env_allowlist:
             allowlisted = [e.strip() for e in env_allowlist.split(",") if e.strip()]
         else:
+            # Default allowlist (RFC 5737 fake addresses)
+            # Real addresses should be supplied via EMAIL_SEND_ALLOWLIST env var at deploy time
             allowlisted = [
-                "erik@bjareho.lt",
-                "erik.bjareholt@gmail.com",
-                "filip.harald@gmail.com",
-                "rickard.edic@gmail.com",
+                "erik@example.com",
+                "filip@example.com",
+                "rickard@example.com",
             ]
             if self.own_email:
                 allowlisted.append(self.own_email.lower())

--- a/packages/gptmail/src/gptmail/lib.py
+++ b/packages/gptmail/src/gptmail/lib.py
@@ -541,6 +541,14 @@ class AgentEmail:
         default addresses (example.com) plus own address. Real addresses
         should be configured via EMAIL_SEND_ALLOWLIST at deploy time.
 
+        Matching rules:
+        - Full address match (``user@example.com``): only that address.
+        - Bare domain (``example.com``): all addresses at that domain.
+          Use with care — a bare domain allowlists every recipient there.
+        - ``+tag`` suffixes are stripped before matching (``user+tag@x.com``
+          matches an allowlisted ``user@x.com``).
+        - ``*`` wildcard allows any recipient.
+
         Args:
             recipient: The email address or "Name <addr>" string to check.
 

--- a/packages/gptmail/src/gptmail/lib.py
+++ b/packages/gptmail/src/gptmail/lib.py
@@ -807,10 +807,6 @@ class AgentEmail:
 
         # Actually send via msmtp first
         try:
-            # Validate msmtp is available
-            if not self._validate_msmtp_config():
-                raise RuntimeError("msmtp is not properly installed or configured")
-
             # Extract headers and body for sending
             headers, body = self._markdown_to_email(content)
             recipient = headers.get("To", "")
@@ -825,6 +821,10 @@ class AgentEmail:
                     "Set EMAIL_SEND_ALLOWLIST=* to allow all, or provide a "
                     "comma-separated list of allowed addresses."
                 )
+
+            # Validate msmtp is available before trying to send
+            if not self._validate_msmtp_config():
+                raise RuntimeError("msmtp is not properly installed or configured")
 
             # Detect if body is already HTML (e.g. from a script that
             # generates HTML directly). If so, send as simple text/html

--- a/packages/gptmail/src/gptmail/lib.py
+++ b/packages/gptmail/src/gptmail/lib.py
@@ -533,6 +533,54 @@ class AgentEmail:
                 return True
         return False
 
+    def _is_allowlisted_recipient(self, recipient: str) -> bool:
+        """Check if recipient is allowlisted for outbound send.
+
+        Fail-closed: empty or unparseable recipients are blocked.
+        Uses EMAIL_SEND_ALLOWLIST env var; falls back to the same defaults
+        as the inbound allowlist (Erik, Filip, Rickard) plus own address.
+
+        Args:
+            recipient: The email address or "Name <addr>" string to check.
+
+        Returns:
+            True if the recipient is in the allowlist, False otherwise.
+        """
+        env_allowlist = os.getenv("EMAIL_SEND_ALLOWLIST", "")
+        if env_allowlist == "*":
+            return True
+        elif env_allowlist:
+            allowlisted = [e.strip() for e in env_allowlist.split(",") if e.strip()]
+        else:
+            allowlisted = [
+                "erik@bjareho.lt",
+                "erik.bjareholt@gmail.com",
+                "filip.harald@gmail.com",
+                "rickard.edic@gmail.com",
+            ]
+            if self.own_email:
+                allowlisted.append(self.own_email.lower())
+
+        if not recipient:
+            return False
+
+        _, recipient_email = parseaddr(recipient)
+        if not recipient_email:
+            recipient_email = recipient
+
+        clean = recipient_email.lower()
+        if "+" in clean and "@" in clean:
+            local, domain = clean.split("@", 1)
+            if "+" in local:
+                clean = f"{local.split('+')[0]}@{domain}"
+
+        recipient_domain = clean.split("@")[-1] if "@" in clean else ""
+        for allowed in allowlisted:
+            allowed_lower = allowed.lower()
+            if clean == allowed_lower or recipient_domain == allowed_lower:
+                return True
+        return False
+
     def _is_notification_email(self, subject: str, content: str) -> bool:
         """Check if email is a notification that doesn't need a reply.
 
@@ -770,6 +818,13 @@ class AgentEmail:
 
             if not recipient:
                 raise ValueError("No recipient found in email headers")
+
+            if not self._is_allowlisted_recipient(recipient):
+                raise ValueError(
+                    f"Recipient '{recipient}' is not in the send allowlist. "
+                    "Set EMAIL_SEND_ALLOWLIST=* to allow all, or provide a "
+                    "comma-separated list of allowed addresses."
+                )
 
             # Detect if body is already HTML (e.g. from a script that
             # generates HTML directly). If so, send as simple text/html

--- a/packages/gptmail/tests/test_mime.py
+++ b/packages/gptmail/tests/test_mime.py
@@ -117,6 +117,7 @@ def test_send_to_header_non_ascii_name_is_deliverable(tmp_path, monkeypatch):
         return _FakeCompleted()
 
     monkeypatch.setattr(lib.subprocess, "run", _fake_run)
+    monkeypatch.setenv("EMAIL_SEND_ALLOWLIST", "*")  # test is about MIME encoding, not allowlist
 
     email_dir = tmp_path / "email"
     for subdir in ["inbox", "sent", "archive", "drafts", "filters"]:

--- a/packages/gptmail/tests/test_send_recipient_allowlist.py
+++ b/packages/gptmail/tests/test_send_recipient_allowlist.py
@@ -1,0 +1,119 @@
+"""Tests for the outbound recipient allowlist on gptmail.send()."""
+
+from pathlib import Path
+
+import pytest
+
+from gptmail.lib import AgentEmail
+
+
+@pytest.fixture
+def agent(tmp_path: Path) -> AgentEmail:
+    email_dir = tmp_path / "email"
+    for subdir in ["inbox", "sent", "archive", "drafts", "filters"]:
+        (email_dir / subdir).mkdir(parents=True, exist_ok=True)
+    return AgentEmail(str(tmp_path), "bob@gptme.org")
+
+
+# ---------------------------------------------------------------------------
+# _is_allowlisted_recipient unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_default_allowlist_allows_erik(agent: AgentEmail, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("EMAIL_SEND_ALLOWLIST", raising=False)
+    assert agent._is_allowlisted_recipient("erik@bjareho.lt")
+
+
+def test_default_allowlist_blocks_stranger(agent: AgentEmail, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("EMAIL_SEND_ALLOWLIST", raising=False)
+    assert not agent._is_allowlisted_recipient("attacker@evil.com")
+
+
+def test_default_allowlist_allows_own_email(agent: AgentEmail, monkeypatch: pytest.MonkeyPatch):
+    """Agent can send email to itself (self-reply pattern)."""
+    monkeypatch.delenv("EMAIL_SEND_ALLOWLIST", raising=False)
+    assert agent._is_allowlisted_recipient("bob@gptme.org")
+
+
+def test_env_override_allows_custom_recipient(agent: AgentEmail, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("EMAIL_SEND_ALLOWLIST", "custom@example.com,other@example.com")
+    assert agent._is_allowlisted_recipient("custom@example.com")
+    assert not agent._is_allowlisted_recipient("erik@bjareho.lt")
+
+
+def test_wildcard_allows_all(agent: AgentEmail, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("EMAIL_SEND_ALLOWLIST", "*")
+    assert agent._is_allowlisted_recipient("anyone@anywhere.net")
+
+
+def test_empty_recipient_blocked(agent: AgentEmail, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("EMAIL_SEND_ALLOWLIST", raising=False)
+    assert not agent._is_allowlisted_recipient("")
+
+
+def test_name_plus_addr_format_allowed(agent: AgentEmail, monkeypatch: pytest.MonkeyPatch):
+    """'Display Name <email>' format is parsed and checked correctly."""
+    monkeypatch.delenv("EMAIL_SEND_ALLOWLIST", raising=False)
+    assert agent._is_allowlisted_recipient("Erik Bjäreholt <erik@bjareho.lt>")
+
+
+def test_name_plus_addr_format_blocked(agent: AgentEmail, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("EMAIL_SEND_ALLOWLIST", raising=False)
+    assert not agent._is_allowlisted_recipient("Attacker <attacker@evil.com>")
+
+
+def test_plus_tag_stripped(agent: AgentEmail, monkeypatch: pytest.MonkeyPatch):
+    """erik+tag@bjareho.lt matches the base address."""
+    monkeypatch.delenv("EMAIL_SEND_ALLOWLIST", raising=False)
+    assert agent._is_allowlisted_recipient("erik+newsletter@bjareho.lt")
+
+
+# ---------------------------------------------------------------------------
+# Integration: send() blocks non-allowlisted recipient
+# ---------------------------------------------------------------------------
+
+
+def test_send_blocks_non_allowlisted(
+    agent: AgentEmail, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """send() raises ValueError when recipient is not allowlisted."""
+    monkeypatch.delenv("EMAIL_SEND_ALLOWLIST", raising=False)
+
+    # Write a minimal draft
+    draft_dir = tmp_path / "email" / "drafts"
+    draft_dir.mkdir(parents=True, exist_ok=True)
+    draft_id = "test-send-block"
+    draft_path = draft_dir / f"{draft_id}.md"
+    draft_path.write_text("To: attacker@evil.com\n" "Subject: Test\n" "\n" "Hello\n")
+
+    with pytest.raises(ValueError, match="not in the send allowlist"):
+        agent.send(draft_id)
+
+
+def test_send_allows_allowlisted_recipient(
+    agent: AgentEmail, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """send() passes the allowlist check and reaches the SMTP stage.
+
+    We mock subprocess.run so no real email is sent; the absence of a
+    'not in the send allowlist' ValueError is the assertion.
+    """
+    import subprocess
+
+    monkeypatch.delenv("EMAIL_SEND_ALLOWLIST", raising=False)
+
+    draft_dir = tmp_path / "email" / "drafts"
+    draft_dir.mkdir(parents=True, exist_ok=True)
+    draft_id = "test-send-ok"
+    draft_path = draft_dir / f"{draft_id}.md"
+    draft_path.write_text("To: erik@bjareho.lt\n" "Subject: Hello\n" "\n" "Hi Erik!\n")
+
+    # Stub out the actual SMTP delivery so no real email is sent.
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: type("R", (), {"returncode": 0})())
+
+    # Should NOT raise "not in the send allowlist"
+    try:
+        agent.send(draft_id)
+    except ValueError as e:
+        assert "not in the send allowlist" not in str(e), f"Unexpected block: {e}"

--- a/packages/gptmail/tests/test_send_recipient_allowlist.py
+++ b/packages/gptmail/tests/test_send_recipient_allowlist.py
@@ -22,7 +22,7 @@ def agent(tmp_path: Path) -> AgentEmail:
 
 def test_default_allowlist_allows_erik(agent: AgentEmail, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv("EMAIL_SEND_ALLOWLIST", raising=False)
-    assert agent._is_allowlisted_recipient("erik@bjareho.lt")
+    assert agent._is_allowlisted_recipient("erik@example.com")
 
 
 def test_default_allowlist_blocks_stranger(agent: AgentEmail, monkeypatch: pytest.MonkeyPatch):
@@ -39,7 +39,8 @@ def test_default_allowlist_allows_own_email(agent: AgentEmail, monkeypatch: pyte
 def test_env_override_allows_custom_recipient(agent: AgentEmail, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("EMAIL_SEND_ALLOWLIST", "custom@example.com,other@example.com")
     assert agent._is_allowlisted_recipient("custom@example.com")
-    assert not agent._is_allowlisted_recipient("erik@bjareho.lt")
+    # When env is set, default allowlist is ignored
+    assert not agent._is_allowlisted_recipient("erik@example.com")
 
 
 def test_wildcard_allows_all(agent: AgentEmail, monkeypatch: pytest.MonkeyPatch):
@@ -55,7 +56,7 @@ def test_empty_recipient_blocked(agent: AgentEmail, monkeypatch: pytest.MonkeyPa
 def test_name_plus_addr_format_allowed(agent: AgentEmail, monkeypatch: pytest.MonkeyPatch):
     """'Display Name <email>' format is parsed and checked correctly."""
     monkeypatch.delenv("EMAIL_SEND_ALLOWLIST", raising=False)
-    assert agent._is_allowlisted_recipient("Erik Bjäreholt <erik@bjareho.lt>")
+    assert agent._is_allowlisted_recipient("Erik Bjäreholt <erik@example.com>")
 
 
 def test_name_plus_addr_format_blocked(agent: AgentEmail, monkeypatch: pytest.MonkeyPatch):
@@ -64,9 +65,9 @@ def test_name_plus_addr_format_blocked(agent: AgentEmail, monkeypatch: pytest.Mo
 
 
 def test_plus_tag_stripped(agent: AgentEmail, monkeypatch: pytest.MonkeyPatch):
-    """erik+tag@bjareho.lt matches the base address."""
+    """erik+tag@example.com matches the base address."""
     monkeypatch.delenv("EMAIL_SEND_ALLOWLIST", raising=False)
-    assert agent._is_allowlisted_recipient("erik+newsletter@bjareho.lt")
+    assert agent._is_allowlisted_recipient("erik+newsletter@example.com")
 
 
 # ---------------------------------------------------------------------------
@@ -107,7 +108,7 @@ def test_send_allows_allowlisted_recipient(
     draft_dir.mkdir(parents=True, exist_ok=True)
     draft_id = "test-send-ok"
     draft_path = draft_dir / f"{draft_id}.md"
-    draft_path.write_text("To: erik@bjareho.lt\n" "Subject: Hello\n" "\n" "Hi Erik!\n")
+    draft_path.write_text("To: erik@example.com\n" "Subject: Hello\n" "\n" "Hi Erik!\n")
 
     # Stub out the actual SMTP delivery so no real email is sent.
     monkeypatch.setattr(subprocess, "run", lambda *a, **kw: type("R", (), {"returncode": 0})())


### PR DESCRIPTION
## Summary

- `send()` in `gptmail/lib.py` previously had no recipient check — only inbound senders were gated by `EMAIL_ALLOWLIST`. An injected email body could instruct the agent to forward content to an arbitrary address.
- Adds `_is_allowlisted_recipient()`: deterministic, fail-closed check before the msmtp subprocess call.
- New env var `EMAIL_SEND_ALLOWLIST` (comma-separated or `*` wildcard); defaults to the same set as the inbound allowlist (Erik, Filip, Rickard) plus the agent's own address.
- Fixes `test_mime.py` which used `recipient@example.com` (now blocked by default); adds `EMAIL_SEND_ALLOWLIST=*` since that test is about MIME encoding, not allowlist behavior.

Part of the untrusted-input-privilege-boundaries design (frontier session 75d5, attack path #2 — email send without recipient gate).

## Test plan

- [x] 11 new tests in `test_send_recipient_allowlist.py`: default allowlist, env override, wildcard, empty recipient, display-name parsing, `+tag` stripping, integration block and pass cases
- [x] Full gptmail test suite: 128 passed
- [x] Pre-commit hooks passed