### PR TITLE
fix(gptme-activity-summary): patch SingleInstance in no-server test

### DIFF
--- a/packages/gptme-activity-summary/tests/test_aw_data.py
+++ b/packages/gptme-activity-summary/tests/test_aw_data.py
@@ -113,13 +113,18 @@ def test_format_aw_activity_domain_minutes():
 
 def test_fetch_aw_activity_returns_unavailable_when_no_server():
     """fetch_aw_activity returns empty activity if AW server not running."""
+    from unittest.mock import patch
+
     from gptme_activity_summary import aw_data
 
     original_server = aw_data.AW_SERVER
     aw_data.AW_SERVER = "http://localhost:59999"
 
     try:
-        activity = fetch_aw_activity(date.today(), date.today())
+        # Patch SingleInstance so a co-running AW process doesn't block client creation.
+        # The real "no server" failure happens at get_info() when :59999 is unreachable.
+        with patch("aw_client.singleinstance.SingleInstance"):
+            activity = fetch_aw_activity(date.today(), date.today())
         assert not activity.available
         assert activity.top_apps == []
         assert activity.total_active_seconds == 0.0


### PR DESCRIPTION
## Summary

- Patches `aw_client.singleinstance.SingleInstance` in `test_fetch_aw_activity_returns_unavailable_when_no_server` so the test works when AW is already running on the host
- Without the patch, `ActivityWatchClient()` constructor calls `SingleInstance` which calls `sys.exit(-1)` when another AW client holds the lock — this happens before any network call, so the "no server" scenario can't be tested

## Root cause

`ActivityWatchClient.__init__` creates a `SingleInstance("gptme-activity-summary")` lock to prevent duplicate clients. On Bob's VM, `bob-activitywatch.service` holds this lock, causing `SystemExit(-1)` before the bogus-port connection attempt.

## Fix

Add `with patch("aw_client.singleinstance.SingleInstance"):` around the `fetch_aw_activity()` call. The test still exercises the real "get_info() fails → available=False" path; we just bypass the unrelated singleton gate that blocks `ActivityWatchClient` creation.

## Test plan
- [x] `uv run pytest packages/gptme-activity-summary/tests/test_aw_data.py::test_fetch_aw_activity_returns_unavailable_when_no_server -v` — passes (verified on Bob's VM with AW running)
- [x] Full test file still passes