### PR TITLE
fix(gptme-sessions): avoid real filesystem scan in stats/query-stats tests

### DIFF
--- a/packages/gptme-sessions/tests/test_cli.py
+++ b/packages/gptme-sessions/tests/test_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -12,6 +13,14 @@ from click.testing import CliRunner
 from gptme_sessions.cli import cli
 from gptme_sessions.record import SessionRecord
 from gptme_sessions.store import SessionStore
+
+# Patch _discover_all to avoid scanning the real filesystem during tests.
+# The discovery code walks CC/gptme/codex session directories; on a loaded
+# system with hundreds of sessions this takes 20-30s and makes tests flaky
+# under the default pytest-timeout. Tests that specifically need discovery
+# behaviour (test_stats_empty_store_no_duplicate_hint, test_discovery.py)
+# supply their own patches or run in test_discovery.py.
+_NO_DISCOVER = patch("gptme_sessions.cli._discover_all", return_value=[])
 
 
 # -- Helpers -----------------------------------------------------------------
@@ -114,7 +123,8 @@ class TestQueryCommand:
     def test_query_stats_flag(self, tmp_path: Path):
         """query --stats shows statistics (format_stats writes to sys.stdout)."""
         _seed_store(tmp_path)
-        rc, out = _invoke(["query", "--stats"], tmp_path)
+        with _NO_DISCOVER:
+            rc, out = _invoke(["query", "--stats"], tmp_path)
         assert rc == 0
         # format_stats writes to sys.stdout, not click.echo — verify via --json
         rc2, out2 = _invoke(["query", "--stats", "--json"], tmp_path)
@@ -229,7 +239,8 @@ class TestStatsCommand:
     def test_stats_basic(self, tmp_path: Path):
         """stats shows summary for all records."""
         _seed_store(tmp_path)
-        rc, out = _invoke(["stats"], tmp_path)
+        with _NO_DISCOVER:
+            rc, out = _invoke(["stats"], tmp_path)
         assert rc == 0
         # format_stats writes to sys.stdout directly, not click.echo
         # Validate content via --json variant instead

--- a/packages/gptme-sessions/tests/test_cli.py
+++ b/packages/gptme-sessions/tests/test_cli.py
@@ -910,7 +910,8 @@ class TestStatsDefaults:
     def test_stats_defaults_to_30d(self, tmp_path: Path):
         """stats without --since defaults to 30d window."""
         _seed_store(tmp_path)
-        rc, out = _invoke(["stats"], tmp_path)
+        with _NO_DISCOVER:
+            rc, out = _invoke(["stats"], tmp_path)
         assert rc == 0
         # Should show the 30-day header
         assert "30 days" in out.lower() or "all-time" in out.lower()


### PR DESCRIPTION
## Problem

`stats` and `query --stats` CLI commands call `_count_unsynced()` → `_discover_all()` which scans all CC/gptme/codex session directories for the last 30 days. On a loaded system with hundreds of sessions in a day, this takes ~30 seconds per test invocation, making `test_stats_basic` and `test_query_stats_flag` flake under pytest-timeout when running the full package suite.

Root cause: tests use `tmp_path` as the session store, but `_discover_all()` unconditionally scans the real filesystem (not the tmp store).

## Fix

Add a module-level `_NO_DISCOVER` patch context manager and wrap the two non-json stats invocations that trigger real filesystem scanning:

- `test_stats_basic`: first `stats` invocation (without `--json`) triggers `_count_unsynced`
- `test_query_stats_flag`: `query --stats` invocation triggers `_count_unsynced`

The `--json` path skips `_count_unsynced` entirely (see `if not as_json and not showed_fallback:` in cli.py), so no patch is needed there.

## Verification

Before: `test_stats_basic` takes ~30s in isolation on a loaded system, flakes in full suite.
After: both tests run in **0.21s total** (99% speedup). Full 952-test suite: all passed.

Pattern matches the existing `test_stats_empty_store_no_duplicate_hint` test which already patches `_discover_all` for the empty-store code path.