### PR TITLE
fix(gptme-runloops): pass category to post_session in BaseRunLoop

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/base.py
+++ b/packages/gptme-runloops/src/gptme_runloops/base.py
@@ -87,6 +87,10 @@ class BaseRunLoop(ABC):
         self._start_time: float | None = None
         self._work_description: str | None = None  # Description of work found
 
+    # Subclasses may override to set a fixed CASCADE category for this run type.
+    # None means category is inferred from trajectory signals (the default).
+    _category: str | None = None
+
     # --- Backoff infrastructure ---
 
     @property
@@ -317,6 +321,7 @@ class BaseRunLoop(ABC):
                 exit_code=result.exit_code,
                 duration_seconds=duration,
                 trajectory_path=result.trajectory_path,
+                category=self._category,
             )
             self.logger.info(
                 f"Session recorded (harness={self.executor.name}, "

--- a/packages/gptme-runloops/src/gptme_runloops/project_monitoring.py
+++ b/packages/gptme-runloops/src/gptme_runloops/project_monitoring.py
@@ -41,6 +41,8 @@ class ProjectMonitoringRun(BaseRunLoop):
     - Execution-focused processing
     """
 
+    _category = "pm-react"
+
     def __init__(
         self,
         workspace: Path,


### PR DESCRIPTION
## Summary

- Add `_category: str | None = None` class attribute to `BaseRunLoop`
- Forward it as `category=self._category` in `_record_session()` → `post_session()`
- `ProjectMonitoringRun` overrides with `_category = "pm-react"`

## Why

Sessions recorded via the Python runloops framework (`gptme-runloops`) were
missing the `category` field in `state/sessions/session-records.jsonl`. The
shell-based `project-monitoring-worker.sh` already passes `category="pm-react"`
explicitly, but the Python `_record_session()` did not.

All 18 affected sessions were `project-monitoring` runs dispatched 2026-07-02+
using gptme with openrouter models (deepseek, glm-5.2, minimax). No commits or
file writes → `infer_category()` returned None → category missing.

## Test plan

- [ ] Check that `ProjectMonitoringRun._category == "pm-react"` (trivial attr check)
- [ ] Next project-monitoring run via gptme backend should have `category: pm-react` in the new session record