### PR TITLE
fix(activity-gate): validate greptile score is a digit before using

### DIFF
--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -656,6 +656,17 @@ check_greptile_scores() {
         # Guard against both empty string and literal "null" from jq
         [ -z "$greptile_score" ] || [ "$greptile_score" = "null" ] && continue
 
+        # Guard: score must be a single decimal digit [0-9]. Non-digit values
+        # (e.g. "}" from a failed jq capture whose tail -1 picks up the closing
+        # brace of an empty object, or quoted strings like "5" when jq lacks -r)
+        # bypass all numeric comparisons and silently fall through to
+        # greptile_needs_improvement. Wipe the state file so the next sweep
+        # re-fetches from the API instead of serving the corrupt cache forever.
+        if ! [[ "$greptile_score" =~ ^[0-9]$ ]]; then
+            rm -f "$state_file"
+            continue
+        fi
+
         # Score 5 = clean — update state file (so check_merge_ready sees
         # the perfect score instead of a stale sub-5 entry) and skip.
         if [ "$greptile_score" -ge 5 ] 2>/dev/null; then


### PR DESCRIPTION
## Summary

- `check_greptile_scores()` was dispatching `greptile_needs_improvement` for PRs with no Greptile review because a corrupt state file containing `}` as the score bypassed all numeric guards
- Adds a `[[ "$greptile_score" =~ ^[0-9]$ ]]` check after the existing empty/null guard; on invalid score, wipes the state file so the next sweep re-fetches from the API

## Root Cause

The jq filter uses `capture("Score: (?<n>[0-9])/5") | .n // empty` piped through `tail -1`. In an edge case (e.g. paginated fetch where one page's filter produces a multi-line result including `{}`), `tail -1` picks up `}` as the score. This value:
- Is not empty → passes the empty check
- Is not `"null"` → passes the null check
- Is not a valid integer → `[ } -ge 5 ]` fails silently (2>/dev/null suppressed)
- `[ } -lt 4 ]` also fails → `else` branch sets `item_type=greptile_needs_improvement`
- Emits with title `"Greptile score: }/5"`

**Observed incident**: `ActivityWatch/aw-webui#893` (zero Greptile comments) dispatching `greptile_needs_improvement` with garbled score `}/5`. State file `/tmp/bob-project-monitoring-state/ActivityWatch-aw-webui-pr-893-greptile.state` contained `}:1783116079:adcf111d427a6ef93e12b1005b9796f62c7bed3c`.

## Test plan

- [ ] Wipe the corrupt state file at `/tmp/bob-project-monitoring-state/ActivityWatch-aw-webui-pr-893-greptile.state` on the live host after merge
- [ ] Verify next PM sweep does NOT dispatch `greptile_needs_improvement` for aw-webui#893
- [ ] Verify PRs with real sub-5 Greptile scores still trigger correctly (digit check passes for `4`, `3`, etc.)