### PR TITLE
fix(twitter): fall back to CC subprocess when ANTHROPIC_API_KEY is a dummy

### DIFF
--- a/scripts/twitter/llm.py
+++ b/scripts/twitter/llm.py
@@ -520,6 +520,10 @@ def _reply_with_cc_subprocess(messages: list[Message], model_name: str) -> Messa
     # Clear CC session vars so the subprocess doesn't attach to the parent session.
     for k in ("CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT", "CC_SESSION_ID", "CC_MODEL"):
         env.pop(k, None)
+    # This fallback exists specifically to bypass ANTHROPIC_API_KEY (absent or a
+    # dummy placeholder), so never forward it — the CLI would otherwise try to
+    # authenticate with it directly instead of using the OAuth subscription.
+    env.pop("ANTHROPIC_API_KEY", None)
 
     # Build a combined prompt: system instructions followed by conversation turns.
     parts = []

--- a/scripts/twitter/llm.py
+++ b/scripts/twitter/llm.py
@@ -507,6 +507,53 @@ def _resolve_scoped_openrouter_api_key() -> str:
     return ""
 
 
+def _reply_with_cc_subprocess(messages: list[Message]) -> Message:
+    """Call Claude via CC OAuth subprocess, bypassing ANTHROPIC_API_KEY.
+
+    Fallback for when ANTHROPIC_API_KEY is absent or a placeholder (e.g. 'dummy-key').
+    The 'claude -p' CLI uses the OAuth subscription rather than a direct API key,
+    so it works even when the gptme config sets a dummy key to prevent CC conflicts.
+    """
+    import subprocess
+
+    env = os.environ.copy()
+    # Clear CC session vars so the subprocess doesn't attach to the parent session.
+    for k in ("CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT", "CC_SESSION_ID", "CC_MODEL"):
+        env.pop(k, None)
+
+    # Build a combined prompt: system instructions followed by user message.
+    parts = []
+    for msg in messages:
+        if msg.role == "system":
+            parts.append(f"<system>\n{msg.content}\n</system>")
+        elif msg.role == "user":
+            parts.append(msg.content)
+    prompt = "\n\n".join(parts)
+
+    try:
+        result = subprocess.run(
+            ["claude", "-p", "--no-session-persistence", prompt],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=120,
+        )
+    except subprocess.TimeoutExpired:
+        logging.warning("CC subprocess timed out for twitter LLM call")
+        return Message("assistant", "")
+    except FileNotFoundError:
+        logging.warning("'claude' CLI not found; CC subprocess fallback unavailable")
+        return Message("assistant", "")
+
+    if result.returncode != 0:
+        logging.warning(
+            "CC subprocess failed (exit %d): %s", result.returncode, result.stderr[:200]
+        )
+        return Message("assistant", "")
+
+    return Message("assistant", result.stdout.strip())
+
+
 def _reply_with_max_tokens(messages: list[Message], model_name: str) -> Message:
     """Call LLM with explicit max_tokens to control OpenRouter budget reservation.
 
@@ -518,10 +565,19 @@ def _reply_with_max_tokens(messages: list[Message], model_name: str) -> Message:
     Use gptme's reply() by default now that it supports max_tokens. Keep the
     direct OpenRouter call only for Twitter/social-specific key overrides, since
     gptme caches provider clients and cannot yet swap OPENROUTER_API_KEY per call.
+    Falls back to CC subprocess when ANTHROPIC_API_KEY is absent or a placeholder.
     """
     scoped_api_key = _resolve_scoped_openrouter_api_key()
     shared_api_key = os.environ.get("OPENROUTER_API_KEY", "")
     if not scoped_api_key or scoped_api_key == shared_api_key:
+        # Use CC subprocess when ANTHROPIC_API_KEY is absent or a placeholder,
+        # since gptme.llm.reply() would fail with an authentication error.
+        anthropic_key = os.environ.get("ANTHROPIC_API_KEY", "")
+        if not anthropic_key or anthropic_key.lower().startswith("dummy"):
+            logging.debug(
+                "Using CC subprocess fallback (ANTHROPIC_API_KEY is dummy/absent)"
+            )
+            return _reply_with_cc_subprocess(messages)
         return reply(
             messages,
             model_name,

--- a/scripts/twitter/llm.py
+++ b/scripts/twitter/llm.py
@@ -507,7 +507,7 @@ def _resolve_scoped_openrouter_api_key() -> str:
     return ""
 
 
-def _reply_with_cc_subprocess(messages: list[Message]) -> Message:
+def _reply_with_cc_subprocess(messages: list[Message], model_name: str) -> Message:
     """Call Claude via CC OAuth subprocess, bypassing ANTHROPIC_API_KEY.
 
     Fallback for when ANTHROPIC_API_KEY is absent or a placeholder (e.g. 'dummy-key').
@@ -521,18 +521,20 @@ def _reply_with_cc_subprocess(messages: list[Message]) -> Message:
     for k in ("CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT", "CC_SESSION_ID", "CC_MODEL"):
         env.pop(k, None)
 
-    # Build a combined prompt: system instructions followed by user message.
+    # Build a combined prompt: system instructions followed by conversation turns.
     parts = []
     for msg in messages:
         if msg.role == "system":
             parts.append(f"<system>\n{msg.content}\n</system>")
         elif msg.role == "user":
             parts.append(msg.content)
+        elif msg.role == "assistant":
+            parts.append(f"<assistant>\n{msg.content}\n</assistant>")
     prompt = "\n\n".join(parts)
 
     try:
         result = subprocess.run(
-            ["claude", "-p", "--no-session-persistence", prompt],
+            ["claude", "-p", "--no-session-persistence", "--model", model_name, prompt],
             capture_output=True,
             text=True,
             env=env,
@@ -572,12 +574,16 @@ def _reply_with_max_tokens(messages: list[Message], model_name: str) -> Message:
     if not scoped_api_key or scoped_api_key == shared_api_key:
         # Use CC subprocess when ANTHROPIC_API_KEY is absent or a placeholder,
         # since gptme.llm.reply() would fail with an authentication error.
+        # But only if there's no usable OpenRouter key either.
         anthropic_key = os.environ.get("ANTHROPIC_API_KEY", "")
-        if not anthropic_key or anthropic_key.lower().startswith("dummy"):
+        any_openrouter_key = _resolve_openrouter_api_key()
+        if (
+            not anthropic_key or anthropic_key.lower().startswith("dummy")
+        ) and not any_openrouter_key:
             logging.debug(
-                "Using CC subprocess fallback (ANTHROPIC_API_KEY is dummy/absent)"
+                "Using CC subprocess fallback (ANTHROPIC_API_KEY is dummy/absent and no OpenRouter key available)"
             )
-            return _reply_with_cc_subprocess(messages)
+            return _reply_with_cc_subprocess(messages, model_name)
         return reply(
             messages,
             model_name,

--- a/tests/test_twitter_eval_prompt.py
+++ b/tests/test_twitter_eval_prompt.py
@@ -267,6 +267,8 @@ def test_reply_with_max_tokens_delegates_when_scoped_key_matches_shared_key(
 ) -> None:
     monkeypatch.setenv("OPENROUTER_API_KEY", "shared-key")
     monkeypatch.setenv("OPENROUTER_API_KEY_TWITTER", "shared-key")
+    # Set a real API key so the CC-subprocess fallback is not triggered.
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test-real-key")
 
     expected = llm_module.Message("assistant", "delegated")
     calls: dict[str, Any] = {}
@@ -358,6 +360,107 @@ def test_reply_with_max_tokens_keeps_direct_openrouter_call_for_scoped_override(
     ]
     assert result.role == "assistant"
     assert result.content == "scoped override"
+
+
+def test_reply_with_max_tokens_uses_cc_subprocess_for_dummy_key(
+    llm_module: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ANTHROPIC_API_KEY is a dummy placeholder, use CC subprocess fallback."""
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY_TWITTER", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY_SOCIAL", raising=False)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "dummy-key")
+
+    cc_calls: list[list[Any]] = []
+    expected = llm_module.Message("assistant", "cc response")
+
+    def fake_cc_subprocess(messages: list[Any]) -> Any:
+        cc_calls.append(messages)
+        return expected
+
+    monkeypatch.setattr(llm_module, "_reply_with_cc_subprocess", fake_cc_subprocess)
+    monkeypatch.setattr(
+        llm_module,
+        "reply",
+        lambda *a, **k: pytest.fail("reply() must not be called with dummy key"),
+    )
+
+    messages = [llm_module.Message("user", "hello")]
+    result = llm_module._reply_with_max_tokens(messages, "anthropic/claude-sonnet-4-5")
+
+    assert result is expected
+    assert len(cc_calls) == 1
+    assert cc_calls[0] == messages
+
+
+def test_reply_with_max_tokens_uses_cc_subprocess_when_no_key(
+    llm_module: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ANTHROPIC_API_KEY is absent entirely, use CC subprocess fallback."""
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY_TWITTER", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY_SOCIAL", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    cc_calls: list[list[Any]] = []
+    expected = llm_module.Message("assistant", "cc response")
+
+    def fake_cc_subprocess(messages: list[Any]) -> Any:
+        cc_calls.append(messages)
+        return expected
+
+    monkeypatch.setattr(llm_module, "_reply_with_cc_subprocess", fake_cc_subprocess)
+    monkeypatch.setattr(
+        llm_module,
+        "reply",
+        lambda *a, **k: pytest.fail("reply() must not be called without key"),
+    )
+
+    messages = [llm_module.Message("user", "hello")]
+    result = llm_module._reply_with_max_tokens(messages, "anthropic/claude-sonnet-4-5")
+
+    assert result is expected
+    assert len(cc_calls) == 1
+
+
+def test_reply_with_cc_subprocess_success(
+    llm_module: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CC subprocess path builds combined prompt and returns assistant Message."""
+    import subprocess as subprocess_mod
+
+    run_calls: list[dict[str, Any]] = []
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+        run_calls.append({"cmd": cmd, "kwargs": kwargs})
+        return types.SimpleNamespace(
+            returncode=0, stdout="review response\n", stderr=""
+        )
+
+    # subprocess is imported inline inside _reply_with_cc_subprocess; patching
+    # the cached module object is sufficient since all imports share one instance.
+    monkeypatch.setattr(subprocess_mod, "run", fake_run)
+
+    messages = [
+        llm_module.Message("system", "You are a helpful agent."),
+        llm_module.Message("user", "Review this tweet."),
+    ]
+    result = llm_module._reply_with_cc_subprocess(messages)
+
+    assert result.role == "assistant"
+    assert result.content == "review response"
+    assert len(run_calls) == 1
+    cmd = run_calls[0]["cmd"]
+    assert cmd[0] == "claude"
+    assert "-p" in cmd
+    assert "--no-session-persistence" in cmd
+    # Combined prompt must contain both system and user parts
+    prompt_arg = cmd[-1]
+    assert "You are a helpful agent." in prompt_arg
+    assert "Review this tweet." in prompt_arg
 
 
 def test_our_handle_in_thread_context_triggers_identity_note(

--- a/tests/test_twitter_eval_prompt.py
+++ b/tests/test_twitter_eval_prompt.py
@@ -372,11 +372,11 @@ def test_reply_with_max_tokens_uses_cc_subprocess_for_dummy_key(
     monkeypatch.delenv("OPENROUTER_API_KEY_SOCIAL", raising=False)
     monkeypatch.setenv("ANTHROPIC_API_KEY", "dummy-key")
 
-    cc_calls: list[list[Any]] = []
+    cc_calls: list[tuple[list[Any], str]] = []
     expected = llm_module.Message("assistant", "cc response")
 
-    def fake_cc_subprocess(messages: list[Any]) -> Any:
-        cc_calls.append(messages)
+    def fake_cc_subprocess(messages: list[Any], model_name: str) -> Any:
+        cc_calls.append((messages, model_name))
         return expected
 
     monkeypatch.setattr(llm_module, "_reply_with_cc_subprocess", fake_cc_subprocess)
@@ -387,11 +387,12 @@ def test_reply_with_max_tokens_uses_cc_subprocess_for_dummy_key(
     )
 
     messages = [llm_module.Message("user", "hello")]
-    result = llm_module._reply_with_max_tokens(messages, "anthropic/claude-sonnet-4-5")
+    model = "anthropic/claude-sonnet-4-5"
+    result = llm_module._reply_with_max_tokens(messages, model)
 
     assert result is expected
     assert len(cc_calls) == 1
-    assert cc_calls[0] == messages
+    assert cc_calls[0] == (messages, model)
 
 
 def test_reply_with_max_tokens_uses_cc_subprocess_when_no_key(
@@ -404,11 +405,11 @@ def test_reply_with_max_tokens_uses_cc_subprocess_when_no_key(
     monkeypatch.delenv("OPENROUTER_API_KEY_SOCIAL", raising=False)
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
 
-    cc_calls: list[list[Any]] = []
+    cc_calls: list[tuple[list[Any], str]] = []
     expected = llm_module.Message("assistant", "cc response")
 
-    def fake_cc_subprocess(messages: list[Any]) -> Any:
-        cc_calls.append(messages)
+    def fake_cc_subprocess(messages: list[Any], model_name: str) -> Any:
+        cc_calls.append((messages, model_name))
         return expected
 
     monkeypatch.setattr(llm_module, "_reply_with_cc_subprocess", fake_cc_subprocess)
@@ -419,10 +420,12 @@ def test_reply_with_max_tokens_uses_cc_subprocess_when_no_key(
     )
 
     messages = [llm_module.Message("user", "hello")]
-    result = llm_module._reply_with_max_tokens(messages, "anthropic/claude-sonnet-4-5")
+    model = "anthropic/claude-sonnet-4-5"
+    result = llm_module._reply_with_max_tokens(messages, model)
 
     assert result is expected
     assert len(cc_calls) == 1
+    assert cc_calls[0] == (messages, model)
 
 
 def test_reply_with_cc_subprocess_success(
@@ -448,7 +451,9 @@ def test_reply_with_cc_subprocess_success(
         llm_module.Message("system", "You are a helpful agent."),
         llm_module.Message("user", "Review this tweet."),
     ]
-    result = llm_module._reply_with_cc_subprocess(messages)
+    result = llm_module._reply_with_cc_subprocess(
+        messages, "anthropic/claude-sonnet-4-5"
+    )
 
     assert result.role == "assistant"
     assert result.content == "review response"
@@ -457,6 +462,8 @@ def test_reply_with_cc_subprocess_success(
     assert cmd[0] == "claude"
     assert "-p" in cmd
     assert "--no-session-persistence" in cmd
+    assert "--model" in cmd
+    assert "anthropic/claude-sonnet-4-5" in cmd
     # Combined prompt must contain both system and user parts
     prompt_arg = cmd[-1]
     assert "You are a helpful agent." in prompt_arg


### PR DESCRIPTION
## Problem

When `~/.config/gptme/config.toml` sets `ANTHROPIC_API_KEY=dummy-key` (intentional, to prevent Claude Code from using the raw API key instead of the OAuth subscription), `gptme.llm.reply()` raises `anthropic.AuthenticationError: invalid x-api-key`. This causes the twitter-loop's auto-review step to fail — every draft ends up stuck in 'needs human review' and must be manually approved.

## Fix

Add a `_reply_with_cc_subprocess()` helper that calls `claude -p --no-session-persistence` (uses OAuth subscription, no `ANTHROPIC_API_KEY` required) as a fallback. `_reply_with_max_tokens()` now checks whether `ANTHROPIC_API_KEY` is absent or starts with `"dummy"` before routing to this fallback.

Priority order:
1. Scoped OpenRouter key (`OPENROUTER_API_KEY_TWITTER` / `OPENROUTER_API_KEY_SOCIAL`) → direct call
2. `ANTHROPIC_API_KEY` is absent or dummy → `claude -p` CC subprocess (new)
3. Real `ANTHROPIC_API_KEY` set → `gptme.llm.reply()` as before

## Changes

- `scripts/twitter/llm.py`: add `_reply_with_cc_subprocess()`, update `_reply_with_max_tokens()` routing
- `tests/test_twitter_eval_prompt.py`: 3 new tests (dummy key, absent key, subprocess prompt-building); update existing test to set a real `ANTHROPIC_API_KEY` so gptme path is still exercised

## Test plan

- [ ] `uv run pytest tests/test_twitter_eval_prompt.py tests/test_twitter_workflow_drafts.py tests/test_twitter_post_url_guard.py` — 46 passed