### PR TITLE
fix(lessons): archive 2 LOO-identified harmful lessons

### DIFF
--- a/lessons/tools/python-file-execution.md
+++ b/lessons/tools/python-file-execution.md
@@ -4,7 +4,7 @@ match:
   - "python script permission denied"
   - "choose correct python execution method"
   - "shebang python execution"
-status: active
+status: archived
 description: "Choose the correct Python execution method based on script type and context: uv scripts with shebang use direct execution, poetry projects use `poetry run`, standalone scripts use appropriate tooling."
 ---
 

--- a/lessons/workflow/when-to-rebase-prs.md
+++ b/lessons/workflow/when-to-rebase-prs.md
@@ -8,7 +8,7 @@ match:
     - mergeable=false
     - rebase based on behind count
     - rebasing without checking for conflicts
-status: active
+status: archived
 ---
 
 # When to Rebase PRs


### PR DESCRIPTION
## Summary

Category-controlled LOO analysis (2026-07-03/04) identified 2 lessons with statistically significant negative delta:

- `lessons/tools/python-file-execution.md`: Δ=-0.0695, p=0.000, n=56
- `lessons/workflow/when-to-rebase-prs.md`: Δ=-0.1010, p=0.000, n=55

Both show strong causal signal (p=0.000) with 100% directional consistency across categories. Setting `status: archived` stops injection while preserving content for historical reference.

## Test plan

- [x] Pre-commit hooks pass
- [x] LOO analysis identifies these as archive candidates (δ < -0.06, p < 0.05)
- [x] No content deleted — only status field updated to stop injection