### PR TITLE
feat(plugin): add gptme-action-receipts — append-only audit ledger for tool actions

### DIFF
--- a/plugins/gptme-action-receipts/README.md
+++ b/plugins/gptme-action-receipts/README.md
@@ -1,7 +1,7 @@
 # gptme-action-receipts
 
 Append-only audit ledger for gptme tool actions. Before each tool executes,
-this plugin emits a tamper-evident receipt to `~/.local/share/gptme/receipts.jsonl`.
+this plugin emits a hashed receipt to `~/.local/share/gptme/receipts.jsonl`.
 
 ## Motivation
 
@@ -23,6 +23,11 @@ This plugin provides the audit trail.
   "receipt_hash": "sha256:abc123..."
 }
 ```
+
+The `receipt_hash` is a deterministic SHA-256 digest of the receipt fields. It
+can detect accidental corruption of a receipt line, but it is not an adversarial
+tamper-proofing mechanism: a writer with access to the ledger can modify a line
+and recompute the hash. Harder deletion/rewriting resistance is future work.
 
 ## Usage
 
@@ -46,6 +51,7 @@ register()
 |---|---|---|
 | `GPTME_RECEIPTS_LEDGER` | `~/.local/share/gptme/receipts.jsonl` | Override ledger path |
 | `GPTME_SESSION_ID` | `"unknown"` | Session ID fallback when not in a gptme session |
+| `GPTME_MODEL` | `"unknown"` | Model attribution; falls back to `CC_MODEL` if unset |
 
 ## Ledger inspection
 

--- a/plugins/gptme-action-receipts/README.md
+++ b/plugins/gptme-action-receipts/README.md
@@ -1,0 +1,69 @@
+# gptme-action-receipts
+
+Append-only audit ledger for gptme tool actions. Before each tool executes,
+this plugin emits a tamper-evident receipt to `~/.local/share/gptme/receipts.jsonl`.
+
+## Motivation
+
+The [gptme-contrib#1175 unauthorized self-merge incident](https://github.com/gptme/gptme-contrib/issues/1175)
+would have been caught at a pre-action gate: the merge action was out of operator
+scope, and a receipt system forces the agent to record scope before executing.
+This plugin provides the audit trail.
+
+## Receipt format
+
+```json
+{
+  "session_id": "ses-abc123",
+  "model": "claude-sonnet-4-6",
+  "action_type": "shell",
+  "target": "gh pr merge --squash 625",
+  "workspace": "/home/bob/projects/gptme",
+  "timestamp": "2026-07-04T18:00:00+00:00",
+  "receipt_hash": "sha256:abc123..."
+}
+```
+
+## Usage
+
+### Via gptme.toml (recommended)
+
+```toml
+[plugin.action_receipts]
+# no options needed — the plugin self-registers on load
+```
+
+### Manual registration
+
+```python
+from gptme_action_receipts import register
+register()
+```
+
+## Configuration
+
+| Env var | Default | Description |
+|---|---|---|
+| `GPTME_RECEIPTS_LEDGER` | `~/.local/share/gptme/receipts.jsonl` | Override ledger path |
+| `GPTME_SESSION_ID` | `"unknown"` | Session ID fallback when not in a gptme session |
+
+## Ledger inspection
+
+```bash
+# View last 10 receipts
+tail -10 ~/.local/share/gptme/receipts.jsonl | python3 -m json.tool
+
+# Find all shell actions in a session
+jq 'select(.action_type == "shell" and .session_id == "ses-abc123")' \
+  ~/.local/share/gptme/receipts.jsonl
+
+# Count actions by type
+jq -r '.action_type' ~/.local/share/gptme/receipts.jsonl | sort | uniq -c | sort -rn
+```
+
+## Roadmap
+
+- **Phase 1 (this plugin)**: Ledger + receipt emission. No blocking gate.
+- **Phase 2**: Scope-check gate — abort out-of-scope actions before execution.
+  See [gptme/gptme#2547](https://github.com/gptme/gptme/issues/2547) for the
+  community schema discussion.

--- a/plugins/gptme-action-receipts/README.md
+++ b/plugins/gptme-action-receipts/README.md
@@ -24,6 +24,8 @@ This plugin provides the audit trail.
 }
 ```
 
+The `target` field contains the first 512 characters of the tool's content (e.g., shell command for shell tools, file content for write operations, etc.). Truncation keeps ledger lines compact.
+
 The `receipt_hash` is a deterministic SHA-256 digest of the receipt fields. It
 can detect accidental corruption of a receipt line, but it is not an adversarial
 tamper-proofing mechanism: a writer with access to the ledger can modify a line

--- a/plugins/gptme-action-receipts/pyproject.toml
+++ b/plugins/gptme-action-receipts/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "gptme-action-receipts"
 version = "0.1.0"
-description = "Append-only audit ledger for gptme tool actions — emit a tamper-evident receipt before each tool execution"
+description = "Append-only audit ledger for gptme tool actions — emit a hashed receipt before each tool execution"
 requires-python = ">=3.10"
 dependencies = [
     "gptme>=0.27.0",
@@ -12,6 +12,9 @@ test = [
     "pytest>=8.0.0",
     "pytest-mock>=3.12.0",
 ]
+
+[project.entry-points."gptme.plugins"]
+action_receipts = "gptme_action_receipts:register"
 
 [build-system]
 requires = ["hatchling"]

--- a/plugins/gptme-action-receipts/pyproject.toml
+++ b/plugins/gptme-action-receipts/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "gptme-action-receipts"
+version = "0.1.0"
+description = "Append-only audit ledger for gptme tool actions — emit a tamper-evident receipt before each tool execution"
+requires-python = ">=3.10"
+dependencies = [
+    "gptme>=0.27.0",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=8.0.0",
+    "pytest-mock>=3.12.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/gptme_action_receipts"]

--- a/plugins/gptme-action-receipts/src/gptme_action_receipts/__init__.py
+++ b/plugins/gptme-action-receipts/src/gptme_action_receipts/__init__.py
@@ -1,0 +1,5 @@
+"""gptme-action-receipts: append-only audit ledger for gptme tool actions."""
+
+from .hooks.receipt_hook import register
+
+__all__ = ["register"]

--- a/plugins/gptme-action-receipts/src/gptme_action_receipts/hooks/__init__.py
+++ b/plugins/gptme-action-receipts/src/gptme_action_receipts/hooks/__init__.py
@@ -1,0 +1,1 @@
+# hooks package

--- a/plugins/gptme-action-receipts/src/gptme_action_receipts/hooks/receipt_hook.py
+++ b/plugins/gptme-action-receipts/src/gptme_action_receipts/hooks/receipt_hook.py
@@ -40,9 +40,9 @@ logger = logging.getLogger(__name__)
 
 _PATH_TARGET_TOOLS = {"save", "append", "patch", "patch_anchored", "morph"}
 
-# Default ledger path — respects XDG_DATA_HOME if set.
+# Default ledger path — respects XDG_DATA_HOME if set and non-empty.
 _DEFAULT_LEDGER = (
-    Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local/share"))
+    Path(os.environ.get("XDG_DATA_HOME") or str(Path.home() / ".local/share"))
     / "gptme"
     / "receipts.jsonl"
 )

--- a/plugins/gptme-action-receipts/src/gptme_action_receipts/hooks/receipt_hook.py
+++ b/plugins/gptme-action-receipts/src/gptme_action_receipts/hooks/receipt_hook.py
@@ -38,6 +38,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_PATH_TARGET_TOOLS = {"save", "append", "patch", "patch_anchored", "morph"}
+
 # Default ledger path — respects XDG_DATA_HOME if set.
 _DEFAULT_LEDGER = (
     Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local/share"))
@@ -76,6 +78,18 @@ def _make_receipt(
     return payload
 
 
+def _target_descriptor(tool_use: object) -> str:
+    """Return a bounded action target without logging file-write bodies."""
+    tool_name = getattr(tool_use, "tool", "unknown") or "unknown"
+    args = getattr(tool_use, "args", None) or []
+
+    if tool_name in _PATH_TARGET_TOOLS:
+        return str(args[0])[:512].strip() if args else ""
+
+    raw_content = getattr(tool_use, "content", "") or ""
+    return raw_content[:512].strip()
+
+
 def _receipt_pre(
     data: ToolExecutePreData,
 ) -> Generator[Message | StopPropagation, None, None]:
@@ -84,9 +98,7 @@ def _receipt_pre(
         return
 
     tool_name = getattr(data.tool_use, "tool", "unknown") or "unknown"
-    # Use content as the target descriptor (first 512 chars to keep lines reasonable).
-    raw_content = getattr(data.tool_use, "content", "") or ""
-    target = raw_content[:512].strip()
+    target = _target_descriptor(data.tool_use)
 
     session_id = current_session_id.get()
     receipt = _make_receipt(tool_name, target, data.workspace, session_id)

--- a/plugins/gptme-action-receipts/src/gptme_action_receipts/hooks/receipt_hook.py
+++ b/plugins/gptme-action-receipts/src/gptme_action_receipts/hooks/receipt_hook.py
@@ -1,0 +1,110 @@
+"""Pre-action audit receipt hook for gptme.
+
+Before each tool executes, appends one JSON line to an append-only ledger
+at ``~/.local/share/gptme/receipts.jsonl``.  The receipt captures enough
+context to answer "who authorized this action, when, and in what scope" —
+the minimal audit trail that would have surfaced the gptme-contrib#1175
+unauthorized self-merge incident at response time.
+
+Phase 1 (this module): ledger + receipt emission only — no blocking gate.
+Phase 2 (future): wire a scope-check that aborts out-of-scope actions.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from collections.abc import Generator
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from gptme.hooks import HookType, register_hook
+from gptme.hooks.server_confirm import current_session_id
+
+if TYPE_CHECKING:
+    from gptme.hooks import StopPropagation
+    from gptme.hooks.types import ToolExecutePreData
+    from gptme.message import Message
+
+logger = logging.getLogger(__name__)
+
+# Default ledger path — respects XDG_DATA_HOME if set.
+_DEFAULT_LEDGER = (
+    Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local/share"))
+    / "gptme"
+    / "receipts.jsonl"
+)
+
+
+def _ledger_path() -> Path:
+    """Return the active ledger path, honouring GPTME_RECEIPTS_LEDGER env override."""
+    override = os.environ.get("GPTME_RECEIPTS_LEDGER")
+    return Path(override) if override else _DEFAULT_LEDGER
+
+
+def _make_receipt(
+    tool_name: str,
+    target: str,
+    workspace: Path | None,
+    session_id: str | None,
+) -> dict:
+    ts = datetime.now(UTC).isoformat(timespec="seconds")
+    payload = {
+        "session_id": session_id or os.environ.get("GPTME_SESSION_ID", "unknown"),
+        "model": (
+            os.environ.get("CC_MODEL") or os.environ.get("GPTME_MODEL") or "unknown"
+        ),
+        "action_type": tool_name,
+        "target": target,
+        "workspace": str(workspace) if workspace else None,
+        "timestamp": ts,
+    }
+    # Deterministic hash of the receipt content for tamper-evidence.
+    blob = json.dumps(payload, sort_keys=True).encode()
+    payload["receipt_hash"] = "sha256:" + hashlib.sha256(blob).hexdigest()
+    return payload
+
+
+def _receipt_pre(
+    data: ToolExecutePreData,
+) -> Generator[Message | StopPropagation, None, None]:
+    """Emit one receipt line to the ledger before the tool executes."""
+    if data.tool_use is None:
+        return
+
+    tool_name = getattr(data.tool_use, "tool", "unknown") or "unknown"
+    # Use content as the target descriptor (first 512 chars to keep lines reasonable).
+    raw_content = getattr(data.tool_use, "content", "") or ""
+    target = raw_content[:512].strip()
+
+    session_id = current_session_id.get()
+    receipt = _make_receipt(tool_name, target, data.workspace, session_id)
+
+    ledger = _ledger_path()
+    try:
+        ledger.parent.mkdir(parents=True, exist_ok=True)
+        with ledger.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(receipt) + "\n")
+        logger.debug("action-receipts: emitted receipt for %s", tool_name)
+    except OSError as exc:
+        # Never crash the agent over an audit write failure — log and move on.
+        logger.warning("action-receipts: failed to write receipt: %s", exc)
+
+    return
+    yield  # make this a generator
+
+
+def register() -> None:
+    """Register the action receipt hook with gptme."""
+    register_hook(
+        "action_receipts.pre",
+        HookType.TOOL_EXECUTE_PRE,
+        _receipt_pre,
+        # Low priority — run after higher-priority hooks (confirm, snapshot).
+        # Negative so user hooks at 0 still fire first.
+        priority=-50,
+    )
+    logger.info("action-receipts: hook registered (ledger: %s)", _ledger_path())

--- a/plugins/gptme-action-receipts/src/gptme_action_receipts/hooks/receipt_hook.py
+++ b/plugins/gptme-action-receipts/src/gptme_action_receipts/hooks/receipt_hook.py
@@ -17,12 +17,19 @@ import json
 import logging
 import os
 from collections.abc import Generator
-from datetime import UTC, datetime
+from contextvars import ContextVar
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from gptme.hooks import HookType, register_hook
-from gptme.hooks.server_confirm import current_session_id
+
+try:
+    from gptme.hooks import current_session_id
+except ImportError:  # pragma: no cover - compatibility fallback for older gptme.
+    current_session_id: ContextVar[str | None] = ContextVar(
+        "current_session_id", default=None
+    )
 
 if TYPE_CHECKING:
     from gptme.hooks import StopPropagation
@@ -50,19 +57,20 @@ def _make_receipt(
     target: str,
     workspace: Path | None,
     session_id: str | None,
+    timestamp: str | None = None,
 ) -> dict:
-    ts = datetime.now(UTC).isoformat(timespec="seconds")
+    ts = timestamp or datetime.now(timezone.utc).isoformat(timespec="seconds")
     payload = {
         "session_id": session_id or os.environ.get("GPTME_SESSION_ID", "unknown"),
         "model": (
-            os.environ.get("CC_MODEL") or os.environ.get("GPTME_MODEL") or "unknown"
+            os.environ.get("GPTME_MODEL") or os.environ.get("CC_MODEL") or "unknown"
         ),
         "action_type": tool_name,
         "target": target,
         "workspace": str(workspace) if workspace else None,
         "timestamp": ts,
     }
-    # Deterministic hash of the receipt content for tamper-evidence.
+    # Deterministic hash of the receipt content for accidental-corruption checks.
     blob = json.dumps(payload, sort_keys=True).encode()
     payload["receipt_hash"] = "sha256:" + hashlib.sha256(blob).hexdigest()
     return payload

--- a/plugins/gptme-action-receipts/tests/test_receipt_hook.py
+++ b/plugins/gptme-action-receipts/tests/test_receipt_hook.py
@@ -35,8 +35,9 @@ class TestMakeReceipt:
         assert r["receipt_hash"].startswith("sha256:")
 
     def test_hash_is_deterministic(self):
-        r1 = _make_receipt("shell", "ls", None, "s1")
-        r2 = _make_receipt("shell", "ls", None, "s1")
+        timestamp = "2026-07-04T18:00:00+00:00"
+        r1 = _make_receipt("shell", "ls", None, "s1", timestamp=timestamp)
+        r2 = _make_receipt("shell", "ls", None, "s1", timestamp=timestamp)
         # Hashes must be identical for the same inputs.
         assert r1["receipt_hash"] == r2["receipt_hash"]
 
@@ -53,6 +54,14 @@ class TestMakeReceipt:
     def test_no_workspace(self):
         r = _make_receipt("save", "file.py", None, "s1")
         assert r["workspace"] is None
+
+    def test_prefers_gptme_model_env(self, monkeypatch):
+        monkeypatch.setenv("GPTME_MODEL", "gptme-model")
+        monkeypatch.setenv("CC_MODEL", "claude-code-model")
+
+        r = _make_receipt("shell", "ls", None, "s1")
+
+        assert r["model"] == "gptme-model"
 
 
 class TestReceiptPreHook:

--- a/plugins/gptme-action-receipts/tests/test_receipt_hook.py
+++ b/plugins/gptme-action-receipts/tests/test_receipt_hook.py
@@ -131,3 +131,20 @@ class TestReceiptPreHook:
 
         receipt = json.loads(ledger.read_text().strip())
         assert len(receipt["target"]) == 512
+
+    def test_file_write_target_uses_path_not_content(self, tmp_path, monkeypatch):
+        ledger = tmp_path / "receipts.jsonl"
+        monkeypatch.setenv("GPTME_RECEIPTS_LEDGER", str(ledger))
+
+        data = _MockPreData(
+            tool_use=_MockToolUse(
+                tool="save",
+                args=[".env"],
+                content="API_KEY=secret-token\n",
+            ),
+        )
+        list(_receipt_pre(data))
+
+        receipt = json.loads(ledger.read_text().strip())
+        assert receipt["target"] == ".env"
+        assert "secret-token" not in receipt["target"]

--- a/plugins/gptme-action-receipts/tests/test_receipt_hook.py
+++ b/plugins/gptme-action-receipts/tests/test_receipt_hook.py
@@ -6,7 +6,10 @@ import json
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from gptme_action_receipts.hooks.receipt_hook import _make_receipt, _receipt_pre
+from gptme_action_receipts.hooks.receipt_hook import (
+    _make_receipt,
+    _receipt_pre,
+)
 
 
 @dataclass
@@ -148,3 +151,29 @@ class TestReceiptPreHook:
         receipt = json.loads(ledger.read_text().strip())
         assert receipt["target"] == ".env"
         assert "secret-token" not in receipt["target"]
+
+
+class TestDefaultLedgerPath:
+    def test_empty_xdg_data_home_falls_back_to_home(self, monkeypatch):
+        """Empty XDG_DATA_HOME must not produce a CWD-relative ledger path."""
+        monkeypatch.setenv("XDG_DATA_HOME", "")
+        # Re-import to pick up the env var change — or verify the fallback directly.
+        import importlib
+
+        import gptme_action_receipts.hooks.receipt_hook as mod
+
+        importlib.reload(mod)
+        assert (
+            mod._DEFAULT_LEDGER.is_absolute()
+        ), f"Expected absolute path, got: {mod._DEFAULT_LEDGER}"
+        assert str(mod._DEFAULT_LEDGER).endswith("gptme/receipts.jsonl")
+
+    def test_set_xdg_data_home_is_used(self, tmp_path, monkeypatch):
+        """A valid XDG_DATA_HOME value is honoured."""
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        import importlib
+
+        import gptme_action_receipts.hooks.receipt_hook as mod
+
+        importlib.reload(mod)
+        assert str(mod._DEFAULT_LEDGER) == str(tmp_path / "gptme" / "receipts.jsonl")

--- a/plugins/gptme-action-receipts/tests/test_receipt_hook.py
+++ b/plugins/gptme-action-receipts/tests/test_receipt_hook.py
@@ -1,0 +1,124 @@
+"""Tests for the action-receipts pre-tool hook."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from gptme_action_receipts.hooks.receipt_hook import _make_receipt, _receipt_pre
+
+
+@dataclass
+class _MockToolUse:
+    tool: str
+    content: str
+    args: list[str] = field(default_factory=list)
+    kwargs: dict = field(default_factory=dict)
+
+
+@dataclass
+class _MockPreData:
+    tool_use: _MockToolUse | None = None
+    workspace: Path | None = None
+    log: object = None
+
+
+class TestMakeReceipt:
+    def test_fields_present(self):
+        r = _make_receipt("shell", "ls -la", Path("/workspace"), "ses-001")
+        assert r["action_type"] == "shell"
+        assert r["target"] == "ls -la"
+        assert r["workspace"] == "/workspace"
+        assert r["session_id"] == "ses-001"
+        assert r["timestamp"]
+        assert r["receipt_hash"].startswith("sha256:")
+
+    def test_hash_is_deterministic(self):
+        r1 = _make_receipt("shell", "ls", None, "s1")
+        r2 = _make_receipt("shell", "ls", None, "s1")
+        # Hashes must be identical for the same inputs.
+        assert r1["receipt_hash"] == r2["receipt_hash"]
+
+    def test_hash_changes_on_different_target(self):
+        r1 = _make_receipt("shell", "ls", None, "s1")
+        r2 = _make_receipt("shell", "rm -rf /", None, "s1")
+        assert r1["receipt_hash"] != r2["receipt_hash"]
+
+    def test_long_target_truncated_by_caller(self):
+        long_cmd = "x" * 600
+        r = _make_receipt("shell", long_cmd[:512], None, "s1")
+        assert len(r["target"]) == 512
+
+    def test_no_workspace(self):
+        r = _make_receipt("save", "file.py", None, "s1")
+        assert r["workspace"] is None
+
+
+class TestReceiptPreHook:
+    def test_writes_receipt_to_ledger(self, tmp_path, monkeypatch):
+        ledger = tmp_path / "receipts.jsonl"
+        monkeypatch.setenv("GPTME_RECEIPTS_LEDGER", str(ledger))
+
+        data = _MockPreData(
+            tool_use=_MockToolUse(tool="shell", content="echo hello"),
+            workspace=tmp_path,
+        )
+        list(_receipt_pre(data))  # exhaust generator
+
+        assert ledger.exists()
+        lines = ledger.read_text().strip().splitlines()
+        assert len(lines) == 1
+        receipt = json.loads(lines[0])
+        assert receipt["action_type"] == "shell"
+        assert receipt["target"] == "echo hello"
+
+    def test_no_crash_on_unwritable_ledger(self, tmp_path, monkeypatch):
+        unwritable = tmp_path / "no_perms" / "receipts.jsonl"
+        # Parent dir doesn't exist and we make it unwritable.
+        (tmp_path / "no_perms").mkdir()
+        (tmp_path / "no_perms").chmod(0o444)
+        monkeypatch.setenv("GPTME_RECEIPTS_LEDGER", str(unwritable))
+
+        data = _MockPreData(
+            tool_use=_MockToolUse(tool="shell", content="ls"),
+        )
+        # Must not raise — the hook falls back to a warning.
+        list(_receipt_pre(data))
+
+    def test_noop_when_tool_use_is_none(self, tmp_path, monkeypatch):
+        ledger = tmp_path / "receipts.jsonl"
+        monkeypatch.setenv("GPTME_RECEIPTS_LEDGER", str(ledger))
+
+        data = _MockPreData(tool_use=None)
+        list(_receipt_pre(data))
+
+        assert not ledger.exists()
+
+    def test_multiple_tool_calls_append(self, tmp_path, monkeypatch):
+        ledger = tmp_path / "receipts.jsonl"
+        monkeypatch.setenv("GPTME_RECEIPTS_LEDGER", str(ledger))
+
+        for cmd in ("ls", "pwd", "echo hi"):
+            data = _MockPreData(
+                tool_use=_MockToolUse(tool="shell", content=cmd),
+            )
+            list(_receipt_pre(data))
+
+        lines = ledger.read_text().strip().splitlines()
+        assert len(lines) == 3
+        targets = [json.loads(line)["target"] for line in lines]
+        assert targets == ["ls", "pwd", "echo hi"]
+
+    def test_content_truncated_to_512_chars(self, tmp_path, monkeypatch):
+        ledger = tmp_path / "receipts.jsonl"
+        monkeypatch.setenv("GPTME_RECEIPTS_LEDGER", str(ledger))
+
+        long_cmd = "a" * 1000
+        data = _MockPreData(
+            tool_use=_MockToolUse(tool="shell", content=long_cmd),
+        )
+        list(_receipt_pre(data))
+
+        receipt = json.loads(ledger.read_text().strip())
+        assert len(receipt["target"]) == 512

--- a/uv.lock
+++ b/uv.lock
@@ -15,6 +15,7 @@ members = [
     "credential-slots",
     "gptmail",
     "gptme-ace",
+    "gptme-action-receipts",
     "gptme-activity-summary",
     "gptme-attention-tracker",
     "gptme-cc-memory",
@@ -1332,6 +1333,28 @@ requires-dist = [
     { name = "sentence-transformers", marker = "extra == 'embeddings'", specifier = ">=2.2.0" },
 ]
 provides-extras = ["embeddings", "full", "dev"]
+
+[[package]]
+name = "gptme-action-receipts"
+version = "0.1.0"
+source = { editable = "plugins/gptme-action-receipts" }
+dependencies = [
+    { name = "gptme" },
+]
+
+[package.optional-dependencies]
+test = [
+    { name = "pytest" },
+    { name = "pytest-mock" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "gptme", git = "https://github.com/gptme/gptme.git?branch=master" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
+    { name = "pytest-mock", marker = "extra == 'test'", specifier = ">=3.12.0" },
+]
+provides-extras = ["test"]
 
 [[package]]
 name = "gptme-activity-summary"


### PR DESCRIPTION
## Summary

- Adds a new plugin `gptme-action-receipts` that hooks into `TOOL_EXECUTE_PRE` to emit a tamper-evident receipt to an append-only JSONL ledger before each tool executes
- Receipt captures: `session_id`, `model`, `action_type`, `target` (first 512 chars of command/path), `workspace`, `timestamp`, and `sha256` content hash
- Never blocks/crashes the agent — write failures are logged as warnings and execution continues
- Phase 1 (audit-only); Phase 2 scope-check gate is a follow-up

## Motivation

The [gptme-contrib#1175](https://github.com/gptme/gptme-contrib/issues/1175) unauthorized self-merge incident would have been surfaced by this ledger — the merge action was out of operator scope, and incident response could have pinpointed which session authorized it. Closes the audit-trail gap for autonomous agents.

## How to activate

```toml
# gptme.toml
[plugin.action_receipts]
```

## Inspecting the ledger

```bash
# View last 10 receipts
tail -10 ~/.local/share/gptme/receipts.jsonl | python3 -m json.tool

# Find shell actions in a session
jq 'select(.action_type == "shell" and .session_id == "my-session")' \
  ~/.local/share/gptme/receipts.jsonl
```

## Test plan

- [x] `test_writes_receipt_to_ledger` — verifies receipt is emitted
- [x] `test_no_crash_on_unwritable_ledger` — verifies agent continues on write failure
- [x] `test_noop_when_tool_use_is_none` — no write when no tool use
- [x] `test_multiple_tool_calls_append` — ledger is append-only
- [x] `test_content_truncated_to_512_chars` — long commands don't balloon the ledger
- [x] Receipt hash is deterministic and changes on different inputs
- [x] All 10 tests pass