### PR TITLE
feat(gptodo): add --pool/--exclude-pool filtering to selection subcommands

### DIFF
--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -126,6 +126,7 @@ from gptodo.utils import (
     lint_frontmatter_fields,
     task_has_waiting_blocker,
     task_is_waiting_for_date,
+    task_matches_pool_filter,
     load_cache,
     load_tasks,
     normalize_state,
@@ -415,7 +416,19 @@ def effective(task_id: str):
     is_flag=True,
     help="Output as JSONL (one task per line) - compact for LLM consumption",
 )
-def list_(sort, active_only, context, output_json, output_jsonl):
+@click.option(
+    "--pool",
+    "pool_filter",
+    default=None,
+    help="Only show tasks in this pool (e.g. 'frontier', 'general')",
+)
+@click.option(
+    "--exclude-pool",
+    "exclude_pool",
+    default=None,
+    help="Exclude tasks in this pool (e.g. '--exclude-pool frontier')",
+)
+def list_(sort, active_only, context, output_json, output_jsonl, pool_filter, exclude_pool):
     """List all tasks in a table format."""
     console = Console()
     repo_root = find_repo_root(Path.cwd())
@@ -474,6 +487,24 @@ def list_(sort, active_only, context, output_json, output_jsonl):
             return
         if not output_json and not output_jsonl:
             console.print(f"[blue]Showing tasks with context tag '{context_tag}'[/]\n")
+
+    # Apply pool filter
+    if pool_filter is not None or exclude_pool is not None:
+        tasks = [
+            task
+            for task in tasks
+            if task_matches_pool_filter(task, pool=pool_filter, exclude_pool=exclude_pool)
+        ]
+        if not tasks:
+            if output_json:
+                print("No tasks found matching pool filter", file=sys.stderr)
+                print(json.dumps({"tasks": [], "count": 0}, indent=2))
+                return
+            if output_jsonl:
+                print("No tasks found matching pool filter", file=sys.stderr)
+                return
+            console.print("[yellow]No tasks found matching pool filter[/]")
+            return
 
     # Sort tasks for display based on option
     if sort == "state":
@@ -991,7 +1022,21 @@ def _show_github_issues(
     is_flag=True,
     help="Emit machine-readable JSON instead of rendered output (stable contract for scripts)",
 )
-def status(type, all, compact, summary, issues, github, github_repo, output_json):
+@click.option(
+    "--pool",
+    "pool_filter",
+    default=None,
+    help="Only show tasks in this pool (e.g. 'frontier', 'general'); applies to --json output",
+)
+@click.option(
+    "--exclude-pool",
+    "exclude_pool",
+    default=None,
+    help="Exclude tasks in this pool (e.g. '--exclude-pool frontier'); applies to --json output",
+)
+def status(
+    type, all, compact, summary, issues, github, github_repo, output_json, pool_filter, exclude_pool
+):
     """Show status of tasks and other tracked items."""
     console = Console()
     repo_root = find_repo_root(Path.cwd())
@@ -1009,6 +1054,27 @@ def status(type, all, compact, summary, issues, github, github_repo, output_json
         else:
             results = StateChecker(repo_root, CONFIGS[type]).check_all()
             payload = _build_status_json(type, results)
+        # Apply pool filter to JSON task list (post-processing; avoids touching check_all())
+        if pool_filter is not None or exclude_pool is not None:
+
+            def _pool_of_task_dict(t: Dict[str, Any]) -> str:
+                return str(t.get("pool", "general"))
+
+            def _passes(t: Dict[str, Any]) -> bool:
+                p = _pool_of_task_dict(t)
+                if pool_filter is not None and p != pool_filter:
+                    return False
+                if exclude_pool is not None and p == exclude_pool:
+                    return False
+                return True
+
+            if "types" in payload:
+                for v in payload["types"].values():
+                    v["tasks"] = [t for t in v["tasks"] if _passes(t)]
+                    v["summary"]["total"] = len(v["tasks"])
+            else:
+                payload["tasks"] = [t for t in payload["tasks"] if _passes(t)]
+                payload["summary"]["total"] = len(payload["tasks"])
         print(json.dumps(payload, indent=2))
         return
 
@@ -2292,7 +2358,19 @@ def tags(state: str | None, show_tasks: bool, filter_tags: tuple[str, ...]):
     is_flag=True,
     help="Check URL-based requires against cached states (run 'fetch' first)",
 )
-def ready(state, output_json, output_jsonl, use_cache):
+@click.option(
+    "--pool",
+    "pool_filter",
+    default=None,
+    help="Only show tasks in this pool (e.g. 'frontier', 'general')",
+)
+@click.option(
+    "--exclude-pool",
+    "exclude_pool",
+    default=None,
+    help="Exclude tasks in this pool (e.g. '--exclude-pool frontier')",
+)
+def ready(state, output_json, output_jsonl, use_cache, pool_filter, exclude_pool):
     """List all ready (unblocked) tasks.
 
     Shows tasks that have no dependencies or whose dependencies are all completed.
@@ -2301,6 +2379,7 @@ def ready(state, output_json, output_jsonl, use_cache):
     Use --json for machine-readable output in autonomous workflows.
     Use --jsonl for compact one-task-per-line output (better with head -n).
     Use --use-cache to also check URL-based 'requires' against cached issue states.
+    Use --pool/--exclude-pool to filter by work pool (e.g. 'frontier', 'general').
     """
     console = Console()
     repo_root = find_repo_root(Path.cwd())
@@ -2345,6 +2424,14 @@ def ready(state, output_json, output_jsonl, use_cache):
         ]
     else:  # both
         filtered_tasks = [task for task in all_tasks if task.state in ["backlog", "active"]]
+
+    # Apply pool filter
+    if pool_filter is not None or exclude_pool is not None:
+        filtered_tasks = [
+            task
+            for task in filtered_tasks
+            if task_matches_pool_filter(task, pool=pool_filter, exclude_pool=exclude_pool)
+        ]
 
     # Filter for ready (unblocked) tasks.
     # ready_for_review tasks: work is done; skip dependency checks, only check waiting_for.
@@ -2463,7 +2550,19 @@ def ready(state, output_json, output_jsonl, use_cache):
     is_flag=True,
     help="Check URL-based requires against cached states (run 'fetch' first)",
 )
-def next_(output_json, use_cache):
+@click.option(
+    "--pool",
+    "pool_filter",
+    default=None,
+    help="Only consider tasks in this pool (e.g. 'frontier', 'general')",
+)
+@click.option(
+    "--exclude-pool",
+    "exclude_pool",
+    default=None,
+    help="Exclude tasks in this pool (e.g. '--exclude-pool frontier')",
+)
+def next_(output_json, use_cache, pool_filter, exclude_pool):
     """Show the highest priority ready (unblocked) task.
 
     Picks from new or active tasks that have no dependencies
@@ -2471,6 +2570,7 @@ def next_(output_json, use_cache):
 
     Use --json for machine-readable output in autonomous workflows.
     Use --use-cache to also check URL-based 'requires' against cached issue states.
+    Use --pool/--exclude-pool to filter by work pool (e.g. 'frontier', 'general').
     """
     console = Console()
     repo_root = find_repo_root(Path.cwd())
@@ -2502,6 +2602,15 @@ def next_(output_json, use_cache):
 
     # Filter for new or active tasks
     workable_tasks = [task for task in all_tasks if task.state in ["backlog", "active"]]
+
+    # Apply pool filter
+    if pool_filter is not None or exclude_pool is not None:
+        workable_tasks = [
+            task
+            for task in workable_tasks
+            if task_matches_pool_filter(task, pool=pool_filter, exclude_pool=exclude_pool)
+        ]
+
     if not workable_tasks:
         if output_json:
             print("No new or active tasks found", file=sys.stderr)
@@ -2598,19 +2707,39 @@ def next_(output_json, use_cache):
     is_flag=True,
     help="Output as JSONL (one task per line) - compact for LLM consumption",
 )
-def stale(days: int, state: str, output_json: bool, output_jsonl: bool):
+@click.option(
+    "--pool",
+    "pool_filter",
+    default=None,
+    help="Only show tasks in this pool (e.g. 'frontier', 'general')",
+)
+@click.option(
+    "--exclude-pool",
+    "exclude_pool",
+    default=None,
+    help="Exclude tasks in this pool (e.g. '--exclude-pool frontier')",
+)
+def stale(
+    days: int,
+    state: str,
+    output_json: bool,
+    output_jsonl: bool,
+    pool_filter: str | None,
+    exclude_pool: str | None,
+):
     """List stale tasks that haven't been modified recently.
 
     Identifies tasks that may need review for completion, archival, or reassessment.
     By default shows active tasks not modified in 30+ days.
 
     Examples:
-        gptodo stale                    # Active tasks unchanged for 30+ days
-        gptodo stale --days 60          # Active tasks unchanged for 60+ days
-        gptodo stale --state all        # All tasks regardless of state
-        gptodo stale --state paused     # Only paused stale tasks
-        gptodo stale --json             # Machine-readable output
-        gptodo stale --jsonl            # One task per line (LLM-friendly)
+        gptodo stale                              # Active tasks unchanged for 30+ days
+        gptodo stale --days 60                    # Active tasks unchanged for 60+ days
+        gptodo stale --state all                  # All tasks regardless of state
+        gptodo stale --state paused               # Only paused stale tasks
+        gptodo stale --json                       # Machine-readable output
+        gptodo stale --jsonl                      # One task per line (LLM-friendly)
+        gptodo stale --exclude-pool frontier      # Skip frontier-pool tasks
     """
     console = Console()
 
@@ -2649,6 +2778,14 @@ def stale(days: int, state: str, output_json: bool, output_jsonl: bool):
 
     # Filter for stale tasks (not modified since cutoff)
     stale_tasks = [task for task in state_filtered if task.modified < cutoff]
+
+    # Apply pool filter
+    if pool_filter is not None or exclude_pool is not None:
+        stale_tasks = [
+            task
+            for task in stale_tasks
+            if task_matches_pool_filter(task, pool=pool_filter, exclude_pool=exclude_pool)
+        ]
 
     if not stale_tasks:
         if output_json:
@@ -4747,6 +4884,18 @@ def spawn_cmd(
     default=1,
     help="Number of parallel agents (1 = sequential)",
 )
+@click.option(
+    "--pool",
+    "pool_filter",
+    default=None,
+    help="Only process tasks in this pool (e.g. 'frontier', 'general')",
+)
+@click.option(
+    "--exclude-pool",
+    "exclude_pool",
+    default=None,
+    help="Exclude tasks in this pool (e.g. '--exclude-pool frontier')",
+)
 def loop_cmd(
     max_tasks: int,
     agent_type: str,
@@ -4755,6 +4904,8 @@ def loop_cmd(
     timeout: int,
     dry_run: bool,
     parallel: int,
+    pool_filter: str | None,
+    exclude_pool: str | None,
 ):
     """Process ready tasks in a loop.
 
@@ -4765,11 +4916,13 @@ def loop_cmd(
     through ready work without manual intervention.
 
     Examples:
-        gptodo loop                    # Process up to 5 ready tasks
-        gptodo loop -n 10              # Process up to 10 tasks
-        gptodo loop --dry-run          # Show what would run
-        gptodo loop -p 3               # Run 3 tasks in parallel
-        gptodo loop --backend claude   # Use Claude backend
+        gptodo loop                              # Process up to 5 ready tasks
+        gptodo loop -n 10                        # Process up to 10 tasks
+        gptodo loop --dry-run                    # Show what would run
+        gptodo loop -p 3                         # Run 3 tasks in parallel
+        gptodo loop --backend claude             # Use Claude backend
+        gptodo loop --pool frontier              # Only frontier-pool tasks
+        gptodo loop --exclude-pool frontier      # Skip frontier-pool tasks
     """
     repo_root = find_repo_root(Path.cwd())
     tasks_dir = repo_root / "tasks"
@@ -4779,6 +4932,14 @@ def loop_cmd(
     # Convert to dict for is_task_ready
     all_tasks_dict: Dict[str, TaskInfo] = {t.name: t for t in all_tasks_list if t.name}
     ready_tasks = [t for t in all_tasks_list if t.name and is_task_ready(t, all_tasks_dict)]
+
+    # Apply pool filter
+    if pool_filter is not None or exclude_pool is not None:
+        ready_tasks = [
+            t
+            for t in ready_tasks
+            if task_matches_pool_filter(t, pool=pool_filter, exclude_pool=exclude_pool)
+        ]
 
     if not ready_tasks:
         console.print("[yellow]No ready tasks found[/]")

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -1038,6 +1038,9 @@ def status(
     type, all, compact, summary, issues, github, github_repo, output_json, pool_filter, exclude_pool
 ):
     """Show status of tasks and other tracked items."""
+    if not output_json and (pool_filter is not None or exclude_pool is not None):
+        raise click.UsageError("--pool/--exclude-pool are only supported with --json")
+
     console = Console()
     repo_root = find_repo_root(Path.cwd())
 

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -792,6 +792,30 @@ def _build_status_json(dir_type: str, results: Dict[str, List[TaskInfo]]) -> Dic
     }
 
 
+def _build_status_summary_from_task_dicts(tasks: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Build the status JSON summary from a serialized task list."""
+    by_state: Dict[str, int] = {}
+    issues = 0
+    untracked = 0
+
+    for task in tasks:
+        state = task.get("state")
+        has_issues = bool(task.get("has_issues"))
+        if state:
+            by_state[state] = by_state.get(state, 0) + 1
+        elif not has_issues:
+            untracked += 1
+        if has_issues:
+            issues += 1
+
+    return {
+        "total": len(tasks),
+        "by_state": by_state,
+        "issues": issues,
+        "untracked": untracked,
+    }
+
+
 def check_directory(
     console: Console,
     dir_type: str,
@@ -1074,10 +1098,10 @@ def status(
             if "types" in payload:
                 for v in payload["types"].values():
                     v["tasks"] = [t for t in v["tasks"] if _passes(t)]
-                    v["summary"]["total"] = len(v["tasks"])
+                    v["summary"] = _build_status_summary_from_task_dicts(v["tasks"])
             else:
                 payload["tasks"] = [t for t in payload["tasks"] if _passes(t)]
-                payload["summary"]["total"] = len(payload["tasks"])
+                payload["summary"] = _build_status_summary_from_task_dicts(payload["tasks"])
         print(json.dumps(payload, indent=2))
         return
 

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -127,6 +127,7 @@ from gptodo.utils import (
     task_has_waiting_blocker,
     task_is_waiting_for_date,
     task_matches_pool_filter,
+    task_pool,
     load_cache,
     load_tasks,
     normalize_state,
@@ -419,8 +420,8 @@ def effective(task_id: str):
 @click.option(
     "--pool",
     "pool_filter",
-    default=None,
-    help="Only show tasks in this pool (e.g. 'frontier', 'general')",
+    default="general",
+    help="Only show tasks in this pool. Use 'all' to see every pool, 'frontier' for frontier only. Default: 'general' (non-default pools hidden).",
 )
 @click.option(
     "--exclude-pool",
@@ -488,23 +489,22 @@ def list_(sort, active_only, context, output_json, output_jsonl, pool_filter, ex
         if not output_json and not output_jsonl:
             console.print(f"[blue]Showing tasks with context tag '{context_tag}'[/]\n")
 
-    # Apply pool filter
-    if pool_filter is not None or exclude_pool is not None:
-        tasks = [
-            task
-            for task in tasks
-            if task_matches_pool_filter(task, pool=pool_filter, exclude_pool=exclude_pool)
-        ]
-        if not tasks:
-            if output_json:
-                print("No tasks found matching pool filter", file=sys.stderr)
-                print(json.dumps({"tasks": [], "count": 0}, indent=2))
-                return
-            if output_jsonl:
-                print("No tasks found matching pool filter", file=sys.stderr)
-                return
-            console.print("[yellow]No tasks found matching pool filter[/]")
+    # Apply pool filter (default: general only; --pool all to see every pool)
+    tasks = [
+        task
+        for task in tasks
+        if task_matches_pool_filter(task, pool=pool_filter, exclude_pool=exclude_pool)
+    ]
+    if not tasks:
+        if output_json:
+            print("No tasks found matching pool filter", file=sys.stderr)
+            print(json.dumps({"tasks": [], "count": 0}, indent=2))
             return
+        if output_jsonl:
+            print("No tasks found matching pool filter", file=sys.stderr)
+            return
+        console.print("[yellow]No tasks found matching pool filter[/]")
+        return
 
     # Sort tasks for display based on option
     if sort == "state":
@@ -878,6 +878,26 @@ def check_directory(
 
     # Print summary
     print_summary(console, results, config)
+
+    # Discoverability: show hidden non-default pool counts so they are never silently orphaned.
+    all_tasks_flat = [t for lst in results.values() for t in lst]
+    non_default = [t for t in all_tasks_flat if task_pool(t) != "general"]
+    if non_default:
+        pool_totals: Dict[str, list] = {}
+        for t in non_default:
+            p = task_pool(t)
+            if p not in pool_totals:
+                pool_totals[p] = [0, 0]  # [total, actionable]
+            pool_totals[p][0] += 1
+            if t.state in ("backlog", "active"):
+                pool_totals[p][1] += 1
+        parts = ", ".join(
+            f"{p}: {counts[0]} ({counts[1]} actionable)"
+            for p, counts in sorted(pool_totals.items())
+        )
+        console.print(
+            f"  [dim]Other pools: {parts} (use --pool {next(iter(pool_totals))} to view)[/]"
+        )
 
     return results
 
@@ -2388,8 +2408,8 @@ def tags(state: str | None, show_tasks: bool, filter_tags: tuple[str, ...]):
 @click.option(
     "--pool",
     "pool_filter",
-    default=None,
-    help="Only show tasks in this pool (e.g. 'frontier', 'general')",
+    default="general",
+    help="Only show tasks in this pool. Use 'all' to see every pool, 'frontier' for frontier only. Default: 'general' (non-default pools hidden).",
 )
 @click.option(
     "--exclude-pool",
@@ -2406,7 +2426,8 @@ def ready(state, output_json, output_jsonl, use_cache, pool_filter, exclude_pool
     Use --json for machine-readable output in autonomous workflows.
     Use --jsonl for compact one-task-per-line output (better with head -n).
     Use --use-cache to also check URL-based 'requires' against cached issue states.
-    Use --pool/--exclude-pool to filter by work pool (e.g. 'frontier', 'general').
+    Use --pool to filter by work pool; default hides non-default pools (e.g. frontier).
+    Use --pool all to see every pool; --pool frontier for frontier only.
     """
     console = Console()
     repo_root = find_repo_root(Path.cwd())
@@ -2452,13 +2473,12 @@ def ready(state, output_json, output_jsonl, use_cache, pool_filter, exclude_pool
     else:  # both
         filtered_tasks = [task for task in all_tasks if task.state in ["backlog", "active"]]
 
-    # Apply pool filter
-    if pool_filter is not None or exclude_pool is not None:
-        filtered_tasks = [
-            task
-            for task in filtered_tasks
-            if task_matches_pool_filter(task, pool=pool_filter, exclude_pool=exclude_pool)
-        ]
+    # Apply pool filter (default: general only; --pool all to see every pool)
+    filtered_tasks = [
+        task
+        for task in filtered_tasks
+        if task_matches_pool_filter(task, pool=pool_filter, exclude_pool=exclude_pool)
+    ]
 
     # Filter for ready (unblocked) tasks.
     # ready_for_review tasks: work is done; skip dependency checks, only check waiting_for.
@@ -2580,8 +2600,8 @@ def ready(state, output_json, output_jsonl, use_cache, pool_filter, exclude_pool
 @click.option(
     "--pool",
     "pool_filter",
-    default=None,
-    help="Only consider tasks in this pool (e.g. 'frontier', 'general')",
+    default="general",
+    help="Only consider tasks in this pool. Use 'all' to see every pool, 'frontier' for frontier only. Default: 'general' (non-default pools hidden).",
 )
 @click.option(
     "--exclude-pool",
@@ -2597,7 +2617,8 @@ def next_(output_json, use_cache, pool_filter, exclude_pool):
 
     Use --json for machine-readable output in autonomous workflows.
     Use --use-cache to also check URL-based 'requires' against cached issue states.
-    Use --pool/--exclude-pool to filter by work pool (e.g. 'frontier', 'general').
+    Use --pool to filter by work pool; default hides non-default pools (e.g. frontier).
+    Use --pool all to see every pool; --pool frontier for frontier sessions only.
     """
     console = Console()
     repo_root = find_repo_root(Path.cwd())
@@ -2630,13 +2651,12 @@ def next_(output_json, use_cache, pool_filter, exclude_pool):
     # Filter for new or active tasks
     workable_tasks = [task for task in all_tasks if task.state in ["backlog", "active"]]
 
-    # Apply pool filter
-    if pool_filter is not None or exclude_pool is not None:
-        workable_tasks = [
-            task
-            for task in workable_tasks
-            if task_matches_pool_filter(task, pool=pool_filter, exclude_pool=exclude_pool)
-        ]
+    # Apply pool filter (default: general only; --pool all to see every pool)
+    workable_tasks = [
+        task
+        for task in workable_tasks
+        if task_matches_pool_filter(task, pool=pool_filter, exclude_pool=exclude_pool)
+    ]
 
     if not workable_tasks:
         if output_json:
@@ -4914,8 +4934,8 @@ def spawn_cmd(
 @click.option(
     "--pool",
     "pool_filter",
-    default=None,
-    help="Only process tasks in this pool (e.g. 'frontier', 'general')",
+    default="general",
+    help="Only process tasks in this pool. Use 'all' to see every pool, 'frontier' for frontier only. Default: 'general' (non-default pools hidden).",
 )
 @click.option(
     "--exclude-pool",
@@ -4960,13 +4980,12 @@ def loop_cmd(
     all_tasks_dict: Dict[str, TaskInfo] = {t.name: t for t in all_tasks_list if t.name}
     ready_tasks = [t for t in all_tasks_list if t.name and is_task_ready(t, all_tasks_dict)]
 
-    # Apply pool filter
-    if pool_filter is not None or exclude_pool is not None:
-        ready_tasks = [
-            t
-            for t in ready_tasks
-            if task_matches_pool_filter(t, pool=pool_filter, exclude_pool=exclude_pool)
-        ]
+    # Apply pool filter (default: general only; --pool all to see every pool)
+    ready_tasks = [
+        t
+        for t in ready_tasks
+        if task_matches_pool_filter(t, pool=pool_filter, exclude_pool=exclude_pool)
+    ]
 
     if not ready_tasks:
         console.print("[yellow]No ready tasks found[/]")

--- a/packages/gptodo/src/gptodo/generate_queue.py
+++ b/packages/gptodo/src/gptodo/generate_queue.py
@@ -136,8 +136,11 @@ def _gq_task_is_frontier(task_id: str, metadata: dict) -> bool:
     Mirrors the detection logic in scripts/claim-cascade-task.py so
     generate-queue pool filtering is consistent with the claim gate.
     """
-    if metadata.get("pool") == "frontier":
-        return True
+    # Explicit frontmatter field wins over all implicit signals.
+    pool = metadata.get("pool")
+    if pool is not None:
+        return bool(pool == "frontier")
+    # Back-compat implicit signals (no explicit pool field in frontmatter).
     if task_id.lower().startswith("frontier-"):
         return True
     tags = metadata.get("tags", []) or []

--- a/packages/gptodo/src/gptodo/generate_queue.py
+++ b/packages/gptodo/src/gptodo/generate_queue.py
@@ -130,6 +130,22 @@ class Task:
         return "\n".join(lines)
 
 
+def _gq_task_is_frontier(task_id: str, metadata: dict) -> bool:
+    """Return True when a task belongs to the frontier pool.
+
+    Mirrors the detection logic in scripts/claim-cascade-task.py so
+    generate-queue pool filtering is consistent with the claim gate.
+    """
+    if metadata.get("pool") == "frontier":
+        return True
+    if task_id.lower().startswith("frontier-"):
+        return True
+    tags = metadata.get("tags", []) or []
+    if "frontier" in tags:
+        return True
+    return False
+
+
 class QueueGenerator:
     """Generate work queue from task files and GitHub issues."""
 
@@ -141,6 +157,8 @@ class QueueGenerator:
         tasks_dir: str = "tasks",
         state_dir: str = "state",
         user: str | None = None,
+        pool_filter: str | None = None,
+        exclude_pool: str | None = None,
     ):
         self.workspace = workspace_path
         self.github_username = github_username
@@ -148,6 +166,8 @@ class QueueGenerator:
         self.state_dir = self.workspace / state_dir
         self.journal_dir = self.workspace / journal_dir
         self.user = user  # Filter tasks by assigned_to field
+        self.pool_filter = pool_filter  # Only include tasks in this pool
+        self.exclude_pool = exclude_pool  # Exclude tasks in this pool
 
         # Output filename includes user if specified
         if user:
@@ -216,6 +236,15 @@ class QueueGenerator:
                     assigned_to = post.metadata.get("assigned_to", "agent")
                     # Include if assigned to specified user or "both"
                     if assigned_to != self.user and assigned_to != "both":
+                        continue
+
+                # Apply pool filter
+                if self.pool_filter is not None or self.exclude_pool is not None:
+                    is_frontier = _gq_task_is_frontier(task_file.stem, post.metadata)
+                    effective_pool = "frontier" if is_frontier else "general"
+                    if self.pool_filter is not None and effective_pool != self.pool_filter:
+                        continue
+                    if self.exclude_pool is not None and effective_pool == self.exclude_pool:
                         continue
 
                 # Filter by priority (high or urgent only) - skip if filtering by user
@@ -616,6 +645,18 @@ class QueueGenerator:
     default="state",
     help="State directory name (default: state)",
 )
+@click.option(
+    "--pool",
+    "pool_filter",
+    default=None,
+    help="Only include tasks in this pool (e.g. 'frontier', 'general')",
+)
+@click.option(
+    "--exclude-pool",
+    "exclude_pool",
+    default=None,
+    help="Exclude tasks in this pool (e.g. '--exclude-pool frontier')",
+)
 def generate_queue(
     workspace: Path,
     github_username: str | None,
@@ -623,6 +664,8 @@ def generate_queue(
     journal_dir: str,
     tasks_dir: str,
     state_dir: str,
+    pool_filter: str | None,
+    exclude_pool: str | None,
 ) -> None:
     """Generate work queue from task files and GitHub issues."""
     # Get GitHub username if not provided
@@ -637,6 +680,8 @@ def generate_queue(
         tasks_dir=tasks_dir,
         state_dir=state_dir,
         user=user,
+        pool_filter=pool_filter,
+        exclude_pool=exclude_pool,
     )
 
     generator.generate()

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -441,6 +441,9 @@ class TaskInfo:
     spawned_tasks: List[str] = field(default_factory=list)  # Child tasks
     coordination_mode: str | None = None  # sequential, parallel, fan-out-fan-in
     success_criterion: str | None = None  # Verifiable "done" gate (Outcomes-style)
+    pool: str | None = (
+        None  # Work pool: "frontier" for frontier-tier-only; None/"general" for general
+    )
 
     @property
     def id(self) -> str:
@@ -499,6 +502,45 @@ def task_has_waiting_blocker(task: "TaskInfo") -> bool:
     if state == "waiting":
         return True
     return bool(task.metadata.get("waiting_for"))
+
+
+def task_pool(task: "TaskInfo") -> str:
+    """Return effective pool for a task: 'frontier' or 'general'.
+
+    Mirrors the frontier-detection logic in scripts/claim-cascade-task.py
+    (_task_is_frontier) so CLI pool filtering is consistent with claim-gate
+    enforcement. Recognizes:
+    - pool: frontier  (explicit frontmatter field)
+    - frontier- id prefix  (back-compat naming convention)
+    - frontier tag          (back-compat tag)
+    """
+    if task.pool == "frontier":
+        return "frontier"
+    if (task.name or "").lower().startswith("frontier-"):
+        return "frontier"
+    if "frontier" in (task.tags or []):
+        return "frontier"
+    return "general"
+
+
+def task_matches_pool_filter(
+    task: "TaskInfo",
+    pool: str | None = None,
+    exclude_pool: str | None = None,
+) -> bool:
+    """Return True if the task passes --pool / --exclude-pool filters.
+
+    Args:
+        task: Task to evaluate.
+        pool: If given, only tasks in this pool pass.
+        exclude_pool: If given, tasks in this pool are excluded.
+    """
+    effective = task_pool(task)
+    if pool is not None and effective != pool:
+        return False
+    if exclude_pool is not None and effective == exclude_pool:
+        return False
+    return True
 
 
 def find_repo_root(start_path: Path) -> Path:
@@ -1124,6 +1166,7 @@ def load_tasks(
                 spawned_tasks=metadata.get("spawned_tasks", []),
                 coordination_mode=metadata.get("coordination_mode"),
                 success_criterion=metadata.get("success_criterion"),
+                pool=metadata.get("pool"),
             )
             tasks.append(task)
 
@@ -1188,6 +1231,7 @@ def task_to_dict(task: TaskInfo) -> Dict[str, Any]:
         "spawned_from": task.spawned_from,
         "spawned_tasks": task.spawned_tasks,
         "coordination_mode": task.coordination_mode,
+        "pool": task_pool(task),
     }
 
 

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -532,11 +532,18 @@ def task_matches_pool_filter(
 ) -> bool:
     """Return True if the task passes --pool / --exclude-pool filters.
 
+    Special pool value ``"all"`` disables all filtering (shows every pool).
+    Default (pool=None, exclude_pool=None) passes everything; selection
+    commands default to pool="general" to hide non-default pools.
+
     Args:
         task: Task to evaluate.
-        pool: If given, only tasks in this pool pass.
+        pool: If given, only tasks in this pool pass. Use ``"all"`` to
+              bypass all pool filtering.
         exclude_pool: If given, tasks in this pool are excluded.
     """
+    if pool == "all":
+        return True
     effective = task_pool(task)
     if pool is not None and effective != pool:
         return False

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -514,8 +514,10 @@ def task_pool(task: "TaskInfo") -> str:
     - frontier- id prefix  (back-compat naming convention)
     - frontier tag          (back-compat tag)
     """
-    if task.pool == "frontier":
-        return "frontier"
+    # Explicit frontmatter field wins over all implicit signals.
+    if task.pool is not None:
+        return "frontier" if task.pool == "frontier" else "general"
+    # Back-compat implicit signals (no explicit pool field in frontmatter).
     if (task.name or "").lower().startswith("frontier-"):
         return "frontier"
     if "frontier" in (task.tags or []):

--- a/packages/gptodo/tests/test_pool_filter.py
+++ b/packages/gptodo/tests/test_pool_filter.py
@@ -313,6 +313,33 @@ class TestTaskToDictPool:
         assert result.exit_code == 2
         assert "--pool/--exclude-pool are only supported with --json" in result.stderr
 
+    def test_status_pool_filter_recomputes_summary(self, tmp_path: Path, monkeypatch) -> None:
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        write_task(
+            tasks_dir,
+            "frontier-active",
+            state="active",
+            created="2026-01-01T00:00:00",
+            pool="frontier",
+        )
+        write_task(tasks_dir, "frontier-broken", state="backlog", pool="frontier")
+        write_task(tasks_dir, "general-active", state="active", created="2026-01-01T00:00:00")
+
+        monkeypatch.chdir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["status", "--json", "--pool", "frontier"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+
+        assert {t["id"] for t in data["tasks"]} == {"frontier-active", "frontier-broken"}
+        assert data["summary"] == {
+            "total": 2,
+            "by_state": {"active": 1, "backlog": 1},
+            "issues": 1,
+            "untracked": 0,
+        }
+
 
 # ---------------------------------------------------------------------------
 # Regression: frontier-routing tag must NOT be treated as pool=frontier

--- a/packages/gptodo/tests/test_pool_filter.py
+++ b/packages/gptodo/tests/test_pool_filter.py
@@ -315,7 +315,7 @@ class TestTaskToDictPool:
         tasks_dir.mkdir()
         write_task(tasks_dir, "frontier-task", state="backlog", created="2026-01-01T00:00:00")
         monkeypatch.chdir(tmp_path)
-        runner = CliRunner()
+        runner = cli_runner_separate_stderr()
         result = runner.invoke(cli, ["status", "--pool", "frontier"])
         assert result.exit_code == 2
         assert "--pool/--exclude-pool are only supported with --json" in result.stderr

--- a/packages/gptodo/tests/test_pool_filter.py
+++ b/packages/gptodo/tests/test_pool_filter.py
@@ -147,6 +147,14 @@ class TestTaskMatchesPoolFilter:
         t = self._make_task(tmp_path, "anything")
         assert task_matches_pool_filter(t) is True
 
+    def test_pool_all_passes_frontier_task(self, tmp_path: Path) -> None:
+        t = self._make_task(tmp_path, "frontier-x", pool="frontier")
+        assert task_matches_pool_filter(t, pool="all") is True
+
+    def test_pool_all_passes_general_task(self, tmp_path: Path) -> None:
+        t = self._make_task(tmp_path, "general-x")
+        assert task_matches_pool_filter(t, pool="all") is True
+
     def test_pool_frontier_passes_frontier_task(self, tmp_path: Path) -> None:
         t = self._make_task(tmp_path, "frontier-x", pool="frontier")
         assert task_matches_pool_filter(t, pool="frontier") is True
@@ -219,7 +227,8 @@ class TestReadyPoolFilter:
         assert "frontier-design" not in ids
         assert "tag-frontier-task" not in ids
 
-    def test_no_pool_filter_returns_all(self, tmp_path: Path, monkeypatch) -> None:
+    def test_no_pool_filter_returns_general_only(self, tmp_path: Path, monkeypatch) -> None:
+        """Default (no --pool flag) hides non-default pools; only general pool shown."""
         self.setup_tasks(tmp_path)
         monkeypatch.chdir(tmp_path)
         runner = CliRunner()
@@ -228,7 +237,21 @@ class TestReadyPoolFilter:
         data = json.loads(result.output)
         ids = [t["id"] for t in data["ready_tasks"]]
         assert "general-work" in ids
+        assert "frontier-design" not in ids
+        assert "tag-frontier-task" not in ids
+
+    def test_pool_all_returns_all(self, tmp_path: Path, monkeypatch) -> None:
+        """--pool all is the escape hatch that shows tasks from every pool."""
+        self.setup_tasks(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["ready", "--json", "--pool", "all"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        ids = [t["id"] for t in data["ready_tasks"]]
+        assert "general-work" in ids
         assert "frontier-design" in ids
+        assert "tag-frontier-task" in ids
 
 
 # ---------------------------------------------------------------------------
@@ -249,6 +272,17 @@ class TestNextPoolFilter:
             pool="frontier",
         )
 
+    def test_next_default_returns_general_only(self, tmp_path: Path, monkeypatch) -> None:
+        """Default gptodo next hides frontier tasks; general session can't see frontier work."""
+        self.setup_tasks(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["next", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["next_task"] is not None
+        assert data["next_task"]["id"] == "general-work"
+
     def test_next_pool_frontier_returns_frontier_task(self, tmp_path: Path, monkeypatch) -> None:
         self.setup_tasks(tmp_path)
         monkeypatch.chdir(tmp_path)
@@ -258,6 +292,16 @@ class TestNextPoolFilter:
         data = json.loads(result.output)
         assert data["next_task"] is not None
         assert data["next_task"]["id"] == "frontier-task"
+
+    def test_next_pool_all_returns_highest_priority(self, tmp_path: Path, monkeypatch) -> None:
+        """--pool all shows every pool; general session can opt in to full view."""
+        self.setup_tasks(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["next", "--json", "--pool", "all"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["next_task"] is not None
 
     def test_next_exclude_pool_frontier_returns_general(self, tmp_path: Path, monkeypatch) -> None:
         self.setup_tasks(tmp_path)
@@ -319,6 +363,33 @@ class TestTaskToDictPool:
         result = runner.invoke(cli, ["status", "--pool", "frontier"])
         assert result.exit_code == 2
         assert "--pool/--exclude-pool are only supported with --json" in result.stderr
+
+    def test_status_shows_hidden_pools_discoverability(self, tmp_path: Path, monkeypatch) -> None:
+        """Human-readable status shows 'Other pools: frontier: N' so non-default pools
+        are never silently orphaned when unflagged selection hides them."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        write_task(tasks_dir, "general-task", state="backlog", created="2026-01-01T00:00:00")
+        write_task(
+            tasks_dir,
+            "frontier-active",
+            state="active",
+            created="2026-01-01T00:00:00",
+            pool="frontier",
+        )
+        write_task(
+            tasks_dir,
+            "frontier-done",
+            state="done",
+            created="2026-01-01T00:00:00",
+            pool="frontier",
+        )
+        monkeypatch.chdir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["status"])
+        assert result.exit_code == 0
+        assert "Other pools:" in result.output
+        assert "frontier:" in result.output
 
     def test_status_pool_filter_recomputes_summary(self, tmp_path: Path, monkeypatch) -> None:
         tasks_dir = tmp_path / "tasks"

--- a/packages/gptodo/tests/test_pool_filter.py
+++ b/packages/gptodo/tests/test_pool_filter.py
@@ -66,6 +66,35 @@ class TestTaskPool:
         task = load_tasks(tasks_dir)[0]
         assert task_pool(task) == "frontier"
 
+    def test_explicit_pool_general_overrides_frontier_prefix(self, tmp_path: Path) -> None:
+        """Explicit pool:general frontmatter wins over implicit frontier- id prefix."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        write_task(
+            tasks_dir,
+            "frontier-override-test",
+            state="backlog",
+            created="2026-01-01T00:00:00",
+            pool="general",
+        )
+        task = load_tasks(tasks_dir)[0]
+        assert task_pool(task) == "general"
+
+    def test_explicit_pool_general_overrides_frontier_tag(self, tmp_path: Path) -> None:
+        """Explicit pool:general frontmatter wins over implicit frontier tag."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        write_task(
+            tasks_dir,
+            "some-task",
+            state="backlog",
+            created="2026-01-01T00:00:00",
+            pool="general",
+            tags=["frontier", "feature"],
+        )
+        task = load_tasks(tasks_dir)[0]
+        assert task_pool(task) == "general"
+
     def test_frontier_tag_returns_frontier(self, tmp_path: Path) -> None:
         tasks_dir = tmp_path / "tasks"
         tasks_dir.mkdir()

--- a/packages/gptodo/tests/test_pool_filter.py
+++ b/packages/gptodo/tests/test_pool_filter.py
@@ -28,6 +28,13 @@ def write_task(tasks_dir: Path, name: str, **metadata: object) -> None:
     (tasks_dir / f"{name}.md").write_text("\n".join(lines))
 
 
+def cli_runner_separate_stderr() -> CliRunner:
+    try:
+        return CliRunner(mix_stderr=False)
+    except TypeError:
+        return CliRunner()
+
+
 # ---------------------------------------------------------------------------
 # task_pool() helper — unit tests covering all three frontier signals
 # ---------------------------------------------------------------------------
@@ -269,7 +276,7 @@ class TestNextPoolFilter:
         tasks_dir.mkdir()
         write_task(tasks_dir, "general-only", state="backlog", created="2026-01-01T00:00:00")
         monkeypatch.chdir(tmp_path)
-        runner = CliRunner()
+        runner = cli_runner_separate_stderr()
         result = runner.invoke(cli, ["next", "--json", "--pool", "frontier"])
         assert result.exit_code == 0
         data = json.loads(result.stdout)

--- a/packages/gptodo/tests/test_pool_filter.py
+++ b/packages/gptodo/tests/test_pool_filter.py
@@ -272,10 +272,9 @@ class TestNextPoolFilter:
         runner = CliRunner()
         result = runner.invoke(cli, ["next", "--json", "--pool", "frontier"])
         assert result.exit_code == 0
-        # Click merges stderr into output; strip the stderr message before parsing JSON
-        json_text = result.output.split("\nNo new or active tasks found", 1)[0]
-        data = json.loads(json_text)
+        data = json.loads(result.stdout)
         assert data["next_task"] is None
+        assert "No new or active tasks found" in result.stderr
 
 
 # ---------------------------------------------------------------------------
@@ -303,6 +302,16 @@ class TestTaskToDictPool:
         tasks_by_id = {t["id"]: t for t in data["tasks"]}
         assert tasks_by_id["frontier-task"]["pool"] == "frontier"
         assert tasks_by_id["general-task"]["pool"] == "general"
+
+    def test_status_pool_filter_requires_json(self, tmp_path: Path, monkeypatch) -> None:
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        write_task(tasks_dir, "frontier-task", state="backlog", created="2026-01-01T00:00:00")
+        monkeypatch.chdir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["status", "--pool", "frontier"])
+        assert result.exit_code == 2
+        assert "--pool/--exclude-pool are only supported with --json" in result.stderr
 
 
 # ---------------------------------------------------------------------------

--- a/packages/gptodo/tests/test_pool_filter.py
+++ b/packages/gptodo/tests/test_pool_filter.py
@@ -1,0 +1,306 @@
+"""Tests for --pool / --exclude-pool filtering across gptodo selection subcommands."""
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from gptodo.cli import cli
+from gptodo.utils import load_tasks, task_matches_pool_filter, task_pool
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def write_task(tasks_dir: Path, name: str, **metadata: object) -> None:
+    """Write a minimal task file with YAML frontmatter."""
+    lines = ["---"]
+    for key, value in metadata.items():
+        if isinstance(value, list):
+            lines.append(f"{key}:")
+            for item in value:
+                lines.append(f"  - {item}")
+        else:
+            lines.append(f"{key}: {value}")
+    lines.extend(["---", f"# {name}"])
+    (tasks_dir / f"{name}.md").write_text("\n".join(lines))
+
+
+# ---------------------------------------------------------------------------
+# task_pool() helper — unit tests covering all three frontier signals
+# ---------------------------------------------------------------------------
+
+
+class TestTaskPool:
+    def test_general_task_returns_general(self, tmp_path: Path) -> None:
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        write_task(tasks_dir, "do-something", state="backlog", created="2026-01-01T00:00:00")
+        task = load_tasks(tasks_dir)[0]
+        assert task_pool(task) == "general"
+
+    def test_pool_frontier_field_returns_frontier(self, tmp_path: Path) -> None:
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        write_task(
+            tasks_dir, "my-task", state="backlog", created="2026-01-01T00:00:00", pool="frontier"
+        )
+        task = load_tasks(tasks_dir)[0]
+        assert task_pool(task) == "frontier"
+
+    def test_pool_general_field_returns_general(self, tmp_path: Path) -> None:
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        write_task(
+            tasks_dir, "my-task", state="backlog", created="2026-01-01T00:00:00", pool="general"
+        )
+        task = load_tasks(tasks_dir)[0]
+        assert task_pool(task) == "general"
+
+    def test_frontier_id_prefix_returns_frontier(self, tmp_path: Path) -> None:
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        write_task(tasks_dir, "frontier-big-design", state="backlog", created="2026-01-01T00:00:00")
+        task = load_tasks(tasks_dir)[0]
+        assert task_pool(task) == "frontier"
+
+    def test_frontier_tag_returns_frontier(self, tmp_path: Path) -> None:
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        write_task(
+            tasks_dir,
+            "some-task",
+            state="backlog",
+            created="2026-01-01T00:00:00",
+            tags=["feature", "frontier"],
+        )
+        task = load_tasks(tasks_dir)[0]
+        assert task_pool(task) == "frontier"
+
+    def test_frontier_routing_tag_does_not_trigger(self, tmp_path: Path) -> None:
+        """frontier-routing tag must NOT be treated as pool=frontier (regression guard)."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        write_task(
+            tasks_dir,
+            "gptodo-next-pool-filter",
+            state="active",
+            created="2026-07-04T00:00:00",
+            tags=["gptodo", "tooling", "frontier-routing", "routing", "cli"],
+        )
+        task = load_tasks(tasks_dir)[0]
+        assert task_pool(task) == "general"
+
+
+# ---------------------------------------------------------------------------
+# task_matches_pool_filter() — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestTaskMatchesPoolFilter:
+    def _make_task(self, tmp_path: Path, name: str, **meta: object):
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir(exist_ok=True)
+        write_task(tasks_dir, name, state="backlog", created="2026-01-01T00:00:00", **meta)
+        tasks = {t.name: t for t in load_tasks(tasks_dir)}
+        return tasks[name]
+
+    def test_no_filter_passes_all(self, tmp_path: Path) -> None:
+        t = self._make_task(tmp_path, "anything")
+        assert task_matches_pool_filter(t) is True
+
+    def test_pool_frontier_passes_frontier_task(self, tmp_path: Path) -> None:
+        t = self._make_task(tmp_path, "frontier-x", pool="frontier")
+        assert task_matches_pool_filter(t, pool="frontier") is True
+
+    def test_pool_frontier_blocks_general_task(self, tmp_path: Path) -> None:
+        t = self._make_task(tmp_path, "ordinary-task")
+        assert task_matches_pool_filter(t, pool="frontier") is False
+
+    def test_pool_general_blocks_frontier_task(self, tmp_path: Path) -> None:
+        t = self._make_task(tmp_path, "frontier-x", pool="frontier")
+        assert task_matches_pool_filter(t, pool="general") is False
+
+    def test_exclude_pool_frontier_blocks_frontier_task(self, tmp_path: Path) -> None:
+        t = self._make_task(tmp_path, "frontier-x", pool="frontier")
+        assert task_matches_pool_filter(t, exclude_pool="frontier") is False
+
+    def test_exclude_pool_frontier_passes_general_task(self, tmp_path: Path) -> None:
+        t = self._make_task(tmp_path, "ordinary-task")
+        assert task_matches_pool_filter(t, exclude_pool="frontier") is True
+
+
+# ---------------------------------------------------------------------------
+# CLI integration — gptodo ready --pool / --exclude-pool
+# ---------------------------------------------------------------------------
+
+
+class TestReadyPoolFilter:
+    def setup_tasks(self, tmp_path: Path) -> None:
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        write_task(tasks_dir, "general-work", state="backlog", created="2026-01-01T00:00:00")
+        write_task(
+            tasks_dir,
+            "frontier-design",
+            state="backlog",
+            created="2026-01-01T00:00:00",
+            pool="frontier",
+        )
+        write_task(
+            tasks_dir,
+            "tag-frontier-task",
+            state="backlog",
+            created="2026-01-01T00:00:00",
+            tags=["frontier"],
+        )
+
+    def test_pool_frontier_returns_only_frontier_tasks(self, tmp_path: Path, monkeypatch) -> None:
+        self.setup_tasks(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["ready", "--json", "--pool", "frontier"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        ids = [t["id"] for t in data["ready_tasks"]]
+        assert "general-work" not in ids
+        assert "frontier-design" in ids
+        assert "tag-frontier-task" in ids
+
+    def test_exclude_pool_frontier_returns_only_general_tasks(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        self.setup_tasks(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["ready", "--json", "--exclude-pool", "frontier"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        ids = [t["id"] for t in data["ready_tasks"]]
+        assert "general-work" in ids
+        assert "frontier-design" not in ids
+        assert "tag-frontier-task" not in ids
+
+    def test_no_pool_filter_returns_all(self, tmp_path: Path, monkeypatch) -> None:
+        self.setup_tasks(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["ready", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        ids = [t["id"] for t in data["ready_tasks"]]
+        assert "general-work" in ids
+        assert "frontier-design" in ids
+
+
+# ---------------------------------------------------------------------------
+# CLI integration — gptodo next --pool / --exclude-pool
+# ---------------------------------------------------------------------------
+
+
+class TestNextPoolFilter:
+    def setup_tasks(self, tmp_path: Path) -> None:
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        write_task(tasks_dir, "general-work", state="backlog", created="2026-01-01T00:00:00")
+        write_task(
+            tasks_dir,
+            "frontier-task",
+            state="backlog",
+            created="2026-01-01T00:00:00",
+            pool="frontier",
+        )
+
+    def test_next_pool_frontier_returns_frontier_task(self, tmp_path: Path, monkeypatch) -> None:
+        self.setup_tasks(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["next", "--json", "--pool", "frontier"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["next_task"] is not None
+        assert data["next_task"]["id"] == "frontier-task"
+
+    def test_next_exclude_pool_frontier_returns_general(self, tmp_path: Path, monkeypatch) -> None:
+        self.setup_tasks(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["next", "--json", "--exclude-pool", "frontier"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["next_task"] is not None
+        assert data["next_task"]["id"] == "general-work"
+
+    def test_next_pool_frontier_returns_none_when_no_frontier(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        write_task(tasks_dir, "general-only", state="backlog", created="2026-01-01T00:00:00")
+        monkeypatch.chdir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["next", "--json", "--pool", "frontier"])
+        assert result.exit_code == 0
+        # Click merges stderr into output; strip the stderr message before parsing JSON
+        json_text = result.output.split("\nNo new or active tasks found", 1)[0]
+        data = json.loads(json_text)
+        assert data["next_task"] is None
+
+
+# ---------------------------------------------------------------------------
+# task_to_dict pool field — verify it appears in JSON output
+# ---------------------------------------------------------------------------
+
+
+class TestTaskToDictPool:
+    def test_pool_field_in_status_json(self, tmp_path: Path, monkeypatch) -> None:
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        write_task(
+            tasks_dir,
+            "frontier-task",
+            state="backlog",
+            created="2026-01-01T00:00:00",
+            pool="frontier",
+        )
+        write_task(tasks_dir, "general-task", state="backlog", created="2026-01-01T00:00:00")
+        monkeypatch.chdir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["status", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        tasks_by_id = {t["id"]: t for t in data["tasks"]}
+        assert tasks_by_id["frontier-task"]["pool"] == "frontier"
+        assert tasks_by_id["general-task"]["pool"] == "general"
+
+
+# ---------------------------------------------------------------------------
+# Regression: frontier-routing tag must NOT be treated as pool=frontier
+# ---------------------------------------------------------------------------
+
+
+def test_frontier_routing_tag_is_general_pool(tmp_path: Path, monkeypatch) -> None:
+    """frontier-routing tag must not trigger the frontier pool claim gate.
+
+    This is a regression guard for the 2026-07-04 incident where the
+    gptodo-next-pool-filter task itself was incorrectly denied a claim
+    because its 'frontier' tag was a renamed 'frontier-routing' tag.
+    """
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(
+        tasks_dir,
+        "gptodo-next-pool-filter",
+        state="active",
+        created="2026-07-04T00:00:00",
+        tags=["gptodo", "tooling", "frontier-routing", "routing", "cli"],
+    )
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["ready", "--json", "--pool", "general", "--state", "active"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    ids = [t["id"] for t in data["ready_tasks"]]
+    assert "gptodo-next-pool-filter" in ids


### PR DESCRIPTION
## Summary

- Add `--pool`/`--exclude-pool` filtering to `next`, `ready`, `loop`, `list`, `status`, `stale`, and `generate-queue` subcommands
- A frontier dispatcher can now call `gptodo next --pool frontier` to pull only its pool; a general selector can call `gptodo next --exclude-pool frontier` to skip frontier-only tasks
- `task_pool()` mirrors the existing claim-gate logic in `scripts/claim-cascade-task.py::_task_is_frontier`: recognizes `pool: frontier` frontmatter field, `frontier-` id prefix, and exact `frontier` tag — so CLI filtering is consistent with claim enforcement

## Implementation details

- `TaskInfo.pool` field added, populated from frontmatter
- `task_pool()` and `task_matches_pool_filter()` helpers in `utils.py` — shared predicate applied per subcommand
- `generate_queue.py` has a standalone `_gq_task_is_frontier()` since it uses its own internal `Task` model (not `TaskInfo`)
- `status --json` applies the filter as a post-processing step on the serialized payload dict

## Test plan

- 20 new tests in `test_pool_filter.py`:
  - `task_pool()` unit tests (general task, explicit field, id prefix, exact tag, frontier-routing tag regression)
  - `task_matches_pool_filter()` unit tests
  - CLI `ready --pool frontier` / `--exclude-pool frontier` / no filter
  - CLI `next --pool frontier` / `--exclude-pool frontier` / empty result
  - `task_to_dict` pool field presence
  - Regression: `frontier-routing` tag must NOT trigger frontier pool
- All 332 existing gptodo tests still pass