### PR TITLE
fix(activity-summary): retry claude -p on non-zero exit + log stderr

### DIFF
--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -22,19 +22,23 @@ _RETRY_DELAY_S = 5
 
 def call_claude_code(prompt: str, timeout: int = 120, max_retries: int = _MAX_RETRIES) -> str:
     """
-    Call Claude Code CLI with a prompt, retrying on empty responses.
+    Call Claude Code CLI with a prompt, retrying on non-zero exit or empty responses.
+
+    Retries with linear backoff (delay = _RETRY_DELAY_S * attempt_number) on:
+    - Non-zero exit codes (transient CC service failures)
+    - Empty stdout responses (nesting detection or transient failures)
 
     Args:
         prompt: The prompt to send to Claude Code
         timeout: Maximum time to wait for response (seconds)
-        max_retries: Maximum number of retry attempts on empty response
+        max_retries: Maximum number of retry attempts per failure type
 
     Returns:
         The response text from Claude Code
 
     Raises:
         subprocess.TimeoutExpired: If the command times out
-        subprocess.CalledProcessError: If the command fails (non-zero exit)
+        subprocess.CalledProcessError: If non-zero exit persists after all retries
     """
     import os
 
@@ -81,6 +85,10 @@ def call_claude_code(prompt: str, timeout: int = 120, max_retries: int = _MAX_RE
                 stderr_preview,
             )
             if attempt < max_retries:
+                # Retry all non-zero codes without discrimination. This addresses transient
+                # CC service failures (rate limits, temporary unavailability). Permanent errors
+                # (e.g., command-not-found, auth failure) will exhaust the retry window and
+                # then raise, which is acceptable since they're rare in normal operation.
                 time.sleep(_RETRY_DELAY_S * attempt)  # linear backoff
                 continue
             raise subprocess.CalledProcessError(

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -72,6 +72,17 @@ def call_claude_code(prompt: str, timeout: int = 120, max_retries: int = _MAX_RE
             env=env,
         )
         if result.returncode != 0:
+            stderr_preview = result.stderr.strip()[:500] if result.stderr else "(none)"
+            logger.warning(
+                "claude -p exited %d (attempt %d/%d). stderr: %s",
+                result.returncode,
+                attempt,
+                max_retries,
+                stderr_preview,
+            )
+            if attempt < max_retries:
+                time.sleep(_RETRY_DELAY_S * attempt)  # linear backoff
+                continue
             raise subprocess.CalledProcessError(
                 result.returncode, ["claude", "-p"], result.stdout, result.stderr
             )
@@ -82,7 +93,7 @@ def call_claude_code(prompt: str, timeout: int = 120, max_retries: int = _MAX_RE
 
         # Empty response — likely nesting detection or transient failure
         logger.warning(
-            "claude -p returned empty response (attempt %d/%d). " "stderr: %s",
+            "claude -p returned empty response (attempt %d/%d). stderr: %s",
             attempt,
             max_retries,
             result.stderr.strip()[:200] if result.stderr else "(none)",

--- a/packages/gptme-activity-summary/tests/test_cc_backend.py
+++ b/packages/gptme-activity-summary/tests/test_cc_backend.py
@@ -153,15 +153,47 @@ def test_call_claude_code_whitespace_only_counts_as_empty(mock_run, mock_sleep):
     assert mock_run.call_count == 2
 
 
+@patch("gptme_activity_summary.cc_backend.time.sleep")
 @patch("subprocess.run")
-def test_call_claude_code_nonzero_exit_raises(mock_run):
-    """Test non-zero exit code raises CalledProcessError immediately."""
-    mock_run.return_value = _make_completed_process(returncode=1, stderr="error msg")
+def test_call_claude_code_nonzero_exit_raises_after_retries(mock_run, mock_sleep):
+    """Test non-zero exit code raises CalledProcessError after exhausting retries."""
+    mock_run.return_value = _make_completed_process(returncode=1, stderr="rate limited")
     try:
-        call_claude_code("test prompt")
+        call_claude_code("test prompt", max_retries=3)
         assert False, "Should have raised CalledProcessError"
     except subprocess.CalledProcessError as e:
         assert e.returncode == 1
+    assert mock_run.call_count == 3  # retried 3 times, not raised immediately
+    assert mock_sleep.call_count == 2  # slept between attempts
+
+
+@patch("gptme_activity_summary.cc_backend.time.sleep")
+@patch("subprocess.run")
+def test_call_claude_code_nonzero_then_success(mock_run, mock_sleep):
+    """Test retry after non-zero exit eventually succeeds."""
+    mock_run.side_effect = [
+        _make_completed_process(returncode=1, stderr="transient error"),
+        _make_completed_process(stdout='{"ok": true}'),
+    ]
+    result = call_claude_code("test prompt", max_retries=3)
+    assert result == '{"ok": true}'
+    assert mock_run.call_count == 2
+    mock_sleep.assert_called_once()
+
+
+@patch("gptme_activity_summary.cc_backend.time.sleep")
+@patch("subprocess.run")
+def test_call_claude_code_nonzero_logs_stderr(mock_run, mock_sleep, caplog):
+    """Test that stderr is logged on non-zero exit."""
+    import logging
+
+    mock_run.return_value = _make_completed_process(returncode=1, stderr="quota exhausted")
+    with caplog.at_level(logging.WARNING):
+        try:
+            call_claude_code("test prompt", max_retries=1)
+        except subprocess.CalledProcessError:
+            pass
+    assert any("quota exhausted" in msg for msg in caplog.messages)
 
 
 @patch("gptme_activity_summary.cc_backend.time.sleep")


### PR DESCRIPTION
## Problem

`bob-activity-summary.service` fails on ~50% of daily runs (alternating days: Jul 01, 03 failed; Jul 02, 04 succeeded) with:

```
Daily: Failed - Command '['claude', '-p']' returned non-zero exit status 1
```

The root cause: `call_claude_code()` raised `CalledProcessError` **immediately** on any non-zero exit, with no retry and no stderr logging. The failure reason was completely invisible in logs.

The alternating-day pattern strongly suggests transient failures (slot rotation / block-file windows) — the same class of issue already handled by the empty-response retry path.

## Fix

- **Log stderr on non-zero exit** (up to 500 chars): makes `journalctl` useful for diagnosing what actually went wrong
- **Retry non-zero exits** with the same linear backoff already used for empty responses (up to `max_retries=3`, sleeping 5s/10s between attempts)
- `CalledProcessError` is raised only after all retries are exhausted

This mirrors how the code already handles empty responses — the two failure modes should be treated the same way.

## Tests

Updated existing `test_call_claude_code_nonzero_exit_raises` → `test_call_claude_code_nonzero_exit_raises_after_retries` to reflect new retry semantics.

Three new test cases:
- `test_call_claude_code_nonzero_then_success` — transient error recovers on retry
- `test_call_claude_code_nonzero_logs_stderr` — stderr appears in log output
- `test_call_claude_code_nonzero_exit_raises_after_retries` — raises after 3 attempts (not immediately)

All 22 tests pass.

## Related

- Task: `tasks/activity-summary-daily-generation-reliability.md`
- Sibling finding: `tasks/untracked-artifact-deletion-shared-worktree.md`