### PR TITLE
feat(plugin): add Phase 2 scope-check gate to gptme-action-receipts

### DIFF
--- a/plugins/gptme-action-receipts/examples/scope.yaml
+++ b/plugins/gptme-action-receipts/examples/scope.yaml
@@ -1,0 +1,31 @@
+# gptme-action-receipts scope manifest — example/template
+# Copy to ~/.config/gptme/scope.yaml and customize for your workspace.
+#
+# violation_action: 'warn'  — log a warning but allow the action (default, safe for soak)
+#                   'block' — abort the action and show an error to the agent
+#
+# Scope lists use fnmatch glob patterns:
+#   ErikBjare/*   matches any repo under ErikBjare
+#   ErikBjare/bob matches only that exact repo
+#
+# Incident motivator: gptme-contrib#1175 (unauthorized self-merge, 2026-06-30).
+# That command — "gh pr merge 1175 --squash --repo gptme/gptme-contrib" — would have
+# hit the merge_repos gate (gptme/gptme-contrib absent from the list) and been blocked.
+
+version: 1
+violation_action: warn   # flip to 'block' after 7-day soak with no false positives
+
+scopes:
+  # Repos where 'gh pr merge' is authorized.
+  merge_repos:
+    - ErikBjare/bob        # brain repo — autonomous self-merges are explicitly allowed
+
+  # Repos where 'git push --force' is authorized.
+  force_push_repos:
+    - ErikBjare/bob        # worktree branches in own repo
+
+  # Repos where 'gh repo delete' is authorized (leave empty to deny all).
+  repo_delete: []
+
+  # Repos where 'gh release delete' is authorized.
+  release_delete: []

--- a/plugins/gptme-action-receipts/pyproject.toml
+++ b/plugins/gptme-action-receipts/pyproject.toml
@@ -5,12 +5,14 @@ description = "Append-only audit ledger for gptme tool actions — emit a hashed
 requires-python = ">=3.10"
 dependencies = [
     "gptme>=0.27.0",
+    "pyyaml>=6.0",
 ]
 
 [project.optional-dependencies]
 test = [
     "pytest>=8.0.0",
     "pytest-mock>=3.12.0",
+    "pyyaml>=6.0",
 ]
 
 [project.entry-points."gptme.plugins"]

--- a/plugins/gptme-action-receipts/src/gptme_action_receipts/hooks/receipt_hook.py
+++ b/plugins/gptme-action-receipts/src/gptme_action_receipts/hooks/receipt_hook.py
@@ -6,8 +6,10 @@ context to answer "who authorized this action, when, and in what scope" —
 the minimal audit trail that would have surfaced the gptme-contrib#1175
 unauthorized self-merge incident at response time.
 
-Phase 1 (this module): ledger + receipt emission only — no blocking gate.
-Phase 2 (future): wire a scope-check that aborts out-of-scope actions.
+Phase 1 (this module): ledger + receipt emission.
+Phase 2 (this module): scope-check gate — aborts out-of-scope actions when
+    violation_action is 'block', or emits a warning when 'warn' (default).
+    Configure via ``~/.config/gptme/scope.yaml`` or GPTME_SCOPE_MANIFEST.
 """
 
 from __future__ import annotations
@@ -35,6 +37,8 @@ if TYPE_CHECKING:
     from gptme.hooks import StopPropagation
     from gptme.hooks.types import ToolExecutePreData
     from gptme.message import Message
+
+from .scope_gate import check_scope, violation_action
 
 logger = logging.getLogger(__name__)
 
@@ -112,6 +116,20 @@ def _receipt_pre(
     except OSError as exc:
         # Never crash the agent over an audit write failure — log and move on.
         logger.warning("action-receipts: failed to write receipt: %s", exc)
+
+    # Phase 2: scope-check gate.
+    violation = check_scope(tool_name, target, data.workspace)
+    if violation:
+        action = violation_action()
+        if action == "block":
+            from gptme.hooks import StopPropagation  # noqa: PLC0415
+
+            yield StopPropagation(f"[scope-gate] BLOCKED: {violation}")
+            return
+        else:
+            logger.warning(
+                "action-receipts: SCOPE VIOLATION (warn only): %s", violation
+            )
 
     return
     yield  # make this a generator

--- a/plugins/gptme-action-receipts/src/gptme_action_receipts/hooks/receipt_hook.py
+++ b/plugins/gptme-action-receipts/src/gptme_action_receipts/hooks/receipt_hook.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     from gptme.hooks.types import ToolExecutePreData
     from gptme.message import Message
 
-from .scope_gate import check_scope, violation_action
+from .scope_gate import check_scope_decision
 
 logger = logging.getLogger(__name__)
 
@@ -118,17 +118,17 @@ def _receipt_pre(
         logger.warning("action-receipts: failed to write receipt: %s", exc)
 
     # Phase 2: scope-check gate.
-    violation = check_scope(tool_name, target, data.workspace)
-    if violation:
-        action = violation_action()
-        if action == "block":
+    decision = check_scope_decision(tool_name, target, data.workspace)
+    if decision.violation:
+        if decision.action == "block":
             from gptme.hooks import StopPropagation  # noqa: PLC0415
 
-            yield StopPropagation(f"[scope-gate] BLOCKED: {violation}")
+            yield StopPropagation(f"[scope-gate] BLOCKED: {decision.violation}")
             return
         else:
             logger.warning(
-                "action-receipts: SCOPE VIOLATION (warn only): %s", violation
+                "action-receipts: SCOPE VIOLATION (warn only): %s",
+                decision.violation,
             )
 
     return

--- a/plugins/gptme-action-receipts/src/gptme_action_receipts/hooks/scope_gate.py
+++ b/plugins/gptme-action-receipts/src/gptme_action_receipts/hooks/scope_gate.py
@@ -1,0 +1,217 @@
+"""Scope-check gate for gptme-action-receipts — Phase 2.
+
+Runs synchronously after the ledger write (Phase 1) and before tool execution.
+Returns a violation description string when an out-of-scope action is detected,
+or None when the action is permitted.
+
+The gate is intentionally conservative and fail-open: any extraction or config
+error falls back to warn-mode with no crash.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import logging
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Timeout for subprocess repo-extraction calls (ms → s).
+_EXTRACT_TIMEOUT = 0.2
+
+
+# --------------------------------------------------------------------------- #
+# Sensitive-action patterns                                                    #
+# --------------------------------------------------------------------------- #
+
+_REPO_PATTERN = r"[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+"
+
+
+def _extract_gh_repo(command: str, workspace: Path | None) -> str | None:
+    """Extract owner/repo from a gh command.
+
+    Resolution order:
+    1. ``--repo OWNER/REPO`` flag (explicit)
+    2. First positional ``OWNER/REPO`` argument (e.g. ``gh repo delete OWNER/REPO``)
+    3. Workspace git remote origin fallback
+    """
+    m = re.search(r"--repo\s+(" + _REPO_PATTERN + r")", command)
+    if m:
+        return m.group(1)
+    # Positional owner/repo: gh repo delete / gh release delete / gh repo view
+    m = re.search(r"(?:delete|view|clone|archive)\s+(" + _REPO_PATTERN + r")", command)
+    if m:
+        return m.group(1)
+    if workspace:
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(workspace), "remote", "get-url", "origin"],
+                capture_output=True,
+                text=True,
+                timeout=_EXTRACT_TIMEOUT,
+            )
+            if result.returncode == 0:
+                return _parse_repo_from_url(result.stdout.strip())
+        except Exception:
+            pass
+    return None
+
+
+def _extract_git_push_repo(command: str, workspace: Path | None) -> str | None:
+    """Extract owner/repo for a git push command via remote URL resolution."""
+    # Try to find the remote name in the command (git push <remote> ...).
+    m = re.search(r"git\s+push\s+([A-Za-z0-9_\-]+)", command)
+    remote = m.group(1) if m else "origin"
+    if workspace:
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(workspace), "remote", "get-url", remote],
+                capture_output=True,
+                text=True,
+                timeout=_EXTRACT_TIMEOUT,
+            )
+            if result.returncode == 0:
+                return _parse_repo_from_url(result.stdout.strip())
+        except Exception:
+            pass
+    return None
+
+
+def _parse_repo_from_url(url: str) -> str | None:
+    """Convert git remote URL to 'owner/repo' string."""
+    # SSH: git@github.com:owner/repo.git
+    m = re.search(r"[:/]([A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+?)(?:\.git)?$", url)
+    return m.group(1) if m else None
+
+
+# Each entry: (pattern_re, scope_key, extractor_fn)
+_SCOPE_CHECKS: list[tuple[str, str, Any]] = [
+    (r"gh\s+pr\s+merge\b", "merge_repos", _extract_gh_repo),
+    (r"git\s+push(?:\s+\S+)?\s+.*--force", "force_push_repos", _extract_git_push_repo),
+    (r"gh\s+repo\s+delete\b", "repo_delete", _extract_gh_repo),
+    (r"gh\s+release\s+delete\b", "release_delete", _extract_gh_repo),
+]
+
+
+# --------------------------------------------------------------------------- #
+# Config loading                                                               #
+# --------------------------------------------------------------------------- #
+
+_DEFAULT_CONFIG: dict[str, Any] = {
+    "version": 1,
+    "violation_action": "warn",
+    "scopes": {
+        "merge_repos": [],
+        "force_push_repos": [],
+        "repo_delete": [],
+        "release_delete": [],
+    },
+}
+
+
+def _scope_manifest_path() -> Path | None:
+    """Return the scope manifest path to use, or None if scope-checking is disabled."""
+    import os
+
+    env = os.environ.get("GPTME_SCOPE_MANIFEST")
+    if env:
+        return Path(env)
+    default = Path.home() / ".config" / "gptme" / "scope.yaml"
+    if default.exists():
+        return default
+    return None
+
+
+def _load_scope_config() -> dict[str, Any]:
+    """Load scope manifest, falling back to conservative defaults on any error."""
+    path = _scope_manifest_path()
+    if path is None:
+        return _DEFAULT_CONFIG.copy()
+    try:
+        import yaml  # type: ignore[import-untyped]
+
+        text = path.read_text(encoding="utf-8")
+        loaded = yaml.safe_load(text) or {}
+        cfg = _DEFAULT_CONFIG.copy()
+        cfg.update(loaded)
+        # Merge nested scopes dict so missing keys use defaults.
+        scopes = dict(_DEFAULT_CONFIG["scopes"])
+        scopes.update(loaded.get("scopes", {}))
+        cfg["scopes"] = scopes
+        return cfg
+    except Exception as exc:
+        logger.warning(
+            "action-receipts scope-gate: could not load %s — falling back to defaults (%s)",
+            path,
+            exc,
+        )
+        return _DEFAULT_CONFIG.copy()
+
+
+# --------------------------------------------------------------------------- #
+# Public API                                                                   #
+# --------------------------------------------------------------------------- #
+
+
+def check_scope(
+    tool_name: str,
+    target: str,
+    workspace: Path | None,
+) -> str | None:
+    """Check whether a tool action is within authorized scope.
+
+    Returns a violation description if out-of-scope, None if permitted.
+    Never raises — all errors are logged and fall back to 'no violation'.
+    """
+    try:
+        return _check_scope_inner(tool_name, target, workspace)
+    except Exception as exc:
+        logger.warning("action-receipts scope-gate: unexpected error: %s", exc)
+        return None
+
+
+def _check_scope_inner(
+    tool_name: str,
+    target: str,
+    workspace: Path | None,
+) -> str | None:
+    """Inner scope check — may raise; callers should wrap in try/except."""
+    # Only inspect shell/bash tool calls.
+    if tool_name not in ("shell", "bash", "execute"):
+        return None
+
+    cfg = _load_scope_config()
+    scopes: dict[str, list[str]] = cfg.get("scopes", {})
+
+    for pattern, scope_key, extractor in _SCOPE_CHECKS:
+        if not re.search(pattern, target, re.IGNORECASE):
+            continue
+
+        allowed: list[str] = scopes.get(scope_key, [])
+        repo = extractor(target, workspace)
+
+        if repo is None:
+            logger.debug(
+                "action-receipts scope-gate: could not extract repo for %s — skipping check",
+                scope_key,
+            )
+            continue
+
+        if not _is_authorized(repo, allowed):
+            return f"action '{scope_key}' on '{repo}' not in allowlist {allowed!r}"
+
+    return None
+
+
+def _is_authorized(repo: str, allowed: list[str]) -> bool:
+    return any(fnmatch.fnmatch(repo, pattern) for pattern in allowed)
+
+
+def violation_action(cfg: dict[str, Any] | None = None) -> str:
+    """Return the configured violation action ('warn' or 'block')."""
+    if cfg is None:
+        cfg = _load_scope_config()
+    return str(cfg.get("violation_action", "warn"))

--- a/plugins/gptme-action-receipts/src/gptme_action_receipts/hooks/scope_gate.py
+++ b/plugins/gptme-action-receipts/src/gptme_action_receipts/hooks/scope_gate.py
@@ -10,10 +10,13 @@ error falls back to warn-mode with no crash.
 
 from __future__ import annotations
 
+import copy
 import fnmatch
 import logging
 import re
+import shlex
 import subprocess
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -62,9 +65,14 @@ def _extract_gh_repo(command: str, workspace: Path | None) -> str | None:
 
 def _extract_git_push_repo(command: str, workspace: Path | None) -> str | None:
     """Extract owner/repo for a git push command via remote URL resolution."""
-    # Try to find the remote name in the command (git push <remote> ...).
-    m = re.search(r"git\s+push\s+([A-Za-z0-9_\-]+)", command)
-    remote = m.group(1) if m else "origin"
+    remote = _extract_git_push_remote(command)
+    if remote is None:
+        remote = "origin"
+
+    repo = _parse_repo_from_url(remote)
+    if repo is not None:
+        return repo
+
     if workspace:
         try:
             result = subprocess.run(
@@ -80,6 +88,47 @@ def _extract_git_push_repo(command: str, workspace: Path | None) -> str | None:
     return None
 
 
+def _extract_git_push_remote(command: str) -> str | None:
+    """Return the git push remote argument, ignoring flags before the remote."""
+    try:
+        parts = shlex.split(command)
+    except ValueError:
+        return None
+
+    try:
+        push_index = next(
+            i
+            for i in range(len(parts) - 1)
+            if parts[i] == "git" and parts[i + 1] == "push"
+        )
+    except StopIteration:
+        return None
+
+    tokens = parts[push_index + 2 :]
+    skip_next = False
+    options_with_values = {
+        "--receive-pack",
+        "--exec",
+        "--push-option",
+        "--repo",
+        "-o",
+    }
+    for token in tokens:
+        if skip_next:
+            skip_next = False
+            continue
+        if token == "--":
+            continue
+        if token.startswith("-"):
+            opt = token.split("=", 1)[0]
+            if opt in options_with_values and "=" not in token:
+                skip_next = True
+            continue
+        return token
+
+    return None
+
+
 def _parse_repo_from_url(url: str) -> str | None:
     """Convert git remote URL to 'owner/repo' string."""
     # SSH: git@github.com:owner/repo.git
@@ -90,7 +139,11 @@ def _parse_repo_from_url(url: str) -> str | None:
 # Each entry: (pattern_re, scope_key, extractor_fn)
 _SCOPE_CHECKS: list[tuple[str, str, Any]] = [
     (r"gh\s+pr\s+merge\b", "merge_repos", _extract_gh_repo),
-    (r"git\s+push(?:\s+\S+)?\s+.*--force", "force_push_repos", _extract_git_push_repo),
+    (
+        r"git\s+push\b(?=.*(?:--force(?:-[A-Za-z]+)*(?:[=\s]|$)|-[A-Za-z]*f[A-Za-z]*(?:\s|$)))",
+        "force_push_repos",
+        _extract_git_push_repo,
+    ),
     (r"gh\s+repo\s+delete\b", "repo_delete", _extract_gh_repo),
     (r"gh\s+release\s+delete\b", "release_delete", _extract_gh_repo),
 ]
@@ -112,6 +165,14 @@ _DEFAULT_CONFIG: dict[str, Any] = {
 }
 
 
+@dataclass(frozen=True)
+class ScopeDecision:
+    """Scope-check result plus the action read from the same config."""
+
+    violation: str | None
+    action: str
+
+
 def _scope_manifest_path() -> Path | None:
     """Return the scope manifest path to use, or None if scope-checking is disabled."""
     import os
@@ -129,7 +190,7 @@ def _load_scope_config() -> dict[str, Any]:
     """Load scope manifest, falling back to conservative defaults on any error."""
     path = _scope_manifest_path()
     if path is None:
-        return _DEFAULT_CONFIG.copy()
+        return copy.deepcopy(_DEFAULT_CONFIG)
     try:
         import yaml  # type: ignore[import-untyped]
 
@@ -148,7 +209,7 @@ def _load_scope_config() -> dict[str, Any]:
             path,
             exc,
         )
-        return _DEFAULT_CONFIG.copy()
+        return copy.deepcopy(_DEFAULT_CONFIG)
 
 
 # --------------------------------------------------------------------------- #
@@ -167,23 +228,39 @@ def check_scope(
     Never raises — all errors are logged and fall back to 'no violation'.
     """
     try:
-        return _check_scope_inner(tool_name, target, workspace)
+        cfg = _load_scope_config()
+        return _check_scope_inner(tool_name, target, workspace, cfg)
     except Exception as exc:
         logger.warning("action-receipts scope-gate: unexpected error: %s", exc)
         return None
+
+
+def check_scope_decision(
+    tool_name: str,
+    target: str,
+    workspace: Path | None,
+) -> ScopeDecision:
+    """Check scope and return the violation action from the same config read."""
+    try:
+        cfg = _load_scope_config()
+        violation = _check_scope_inner(tool_name, target, workspace, cfg)
+        return ScopeDecision(violation=violation, action=violation_action(cfg))
+    except Exception as exc:
+        logger.warning("action-receipts scope-gate: unexpected error: %s", exc)
+        return ScopeDecision(violation=None, action="warn")
 
 
 def _check_scope_inner(
     tool_name: str,
     target: str,
     workspace: Path | None,
+    cfg: dict[str, Any],
 ) -> str | None:
     """Inner scope check — may raise; callers should wrap in try/except."""
     # Only inspect shell/bash tool calls.
     if tool_name not in ("shell", "bash", "execute"):
         return None
 
-    cfg = _load_scope_config()
     scopes: dict[str, list[str]] = cfg.get("scopes", {})
 
     for pattern, scope_key, extractor in _SCOPE_CHECKS:

--- a/plugins/gptme-action-receipts/src/gptme_action_receipts/hooks/scope_gate.py
+++ b/plugins/gptme-action-receipts/src/gptme_action_receipts/hooks/scope_gate.py
@@ -37,11 +37,11 @@ def _extract_gh_repo(command: str, workspace: Path | None) -> str | None:
     """Extract owner/repo from a gh command.
 
     Resolution order:
-    1. ``--repo OWNER/REPO`` flag (explicit)
+    1. ``--repo OWNER/REPO`` / ``--repo=OWNER/REPO`` flag (explicit)
     2. First positional ``OWNER/REPO`` argument (e.g. ``gh repo delete OWNER/REPO``)
     3. Workspace git remote origin fallback
     """
-    m = re.search(r"--repo\s+(" + _REPO_PATTERN + r")", command)
+    m = re.search(r"--repo(?:\s+|=)(" + _REPO_PATTERN + r")", command)
     if m:
         return m.group(1)
     # Positional owner/repo: gh repo delete / gh release delete / gh repo view

--- a/plugins/gptme-action-receipts/tests/test_scope_gate.py
+++ b/plugins/gptme-action-receipts/tests/test_scope_gate.py
@@ -9,9 +9,12 @@ from unittest.mock import patch
 import pytest
 import yaml
 from gptme_action_receipts.hooks.scope_gate import (
+    _extract_git_push_remote,
     _is_authorized,
+    _load_scope_config,
     _parse_repo_from_url,
     check_scope,
+    check_scope_decision,
 )
 
 # --------------------------------------------------------------------------- #
@@ -164,6 +167,44 @@ class TestCheckScopeUnauthorized:
         assert violation is not None
         assert "gptme-contrib" in violation
 
+    @pytest.mark.parametrize(
+        ("command", "expected_remote"),
+        [
+            ("git push -f origin HEAD", "origin"),
+            ("git push origin HEAD -f", "origin"),
+            ("git push --force origin HEAD", "origin"),
+            ("git push --force-with-lease origin HEAD", "origin"),
+        ],
+    )
+    def test_force_push_flag_variants_flagged(
+        self,
+        command: str,
+        expected_remote: str,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        path = tmp_path / "scope.yaml"
+        path.write_text(yaml.dump({"scopes": {"force_push_repos": []}}))
+        monkeypatch.setenv("GPTME_SCOPE_MANIFEST", str(path))
+        fake_url = "https://github.com/gptme/gptme-contrib.git"
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout=fake_url, stderr=""
+            )
+            violation = check_scope("shell", command, tmp_path)
+
+        assert violation is not None
+        assert "gptme-contrib" in violation
+        assert mock_run.call_args.args[0] == [
+            "git",
+            "-C",
+            str(tmp_path),
+            "remote",
+            "get-url",
+            expected_remote,
+        ]
+
     def test_repo_delete_flagged(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         path = tmp_path / "scope.yaml"
         path.write_text(yaml.dump({"scopes": {"repo_delete": []}}))
@@ -238,6 +279,39 @@ class TestCheckScopeResilience:
         )
         assert violation is not None  # defaults deny
 
+    def test_default_config_scopes_are_isolated(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("GPTME_SCOPE_MANIFEST", str(tmp_path / "nonexistent.yaml"))
+
+        cfg = _load_scope_config()
+        cfg["scopes"]["merge_repos"].append("mutated/repo")
+
+        assert _load_scope_config()["scopes"]["merge_repos"] == []
+
+    def test_scope_decision_reuses_detection_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        path = tmp_path / "scope.yaml"
+        path.write_text(
+            yaml.dump(
+                {
+                    "violation_action": "block",
+                    "scopes": {"merge_repos": ["ErikBjare/bob"]},
+                }
+            )
+        )
+        monkeypatch.setenv("GPTME_SCOPE_MANIFEST", str(path))
+
+        decision = check_scope_decision(
+            "shell",
+            "gh pr merge 1175 --squash --repo gptme/gptme-contrib",
+            None,
+        )
+
+        assert decision.violation is not None
+        assert decision.action == "block"
+
     def test_subprocess_error_during_extraction_no_crash(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
@@ -250,3 +324,18 @@ class TestCheckScopeResilience:
             result = check_scope("shell", "gh pr merge 42 --squash", tmp_path)
         # No --repo + subprocess failure → repo extraction fails → no violation
         assert result is None
+
+
+class TestExtractGitPushRemote:
+    @pytest.mark.parametrize(
+        ("command", "remote"),
+        [
+            ("git push origin HEAD --force", "origin"),
+            ("git push --force origin HEAD", "origin"),
+            ("git push -f origin HEAD", "origin"),
+            ("git push --force-with-lease=main origin HEAD", "origin"),
+            ("git push -o ci.skip origin HEAD -f", "origin"),
+        ],
+    )
+    def test_skips_flags_before_remote(self, command: str, remote: str):
+        assert _extract_git_push_remote(command) == remote

--- a/plugins/gptme-action-receipts/tests/test_scope_gate.py
+++ b/plugins/gptme-action-receipts/tests/test_scope_gate.py
@@ -149,6 +149,15 @@ class TestCheckScopeUnauthorized:
         assert violation is not None
         assert "gptme/gptme-contrib" in violation
 
+    def test_unauthorized_merge_equals_repo_flag_flagged(self, authed_merge_yaml: Path):
+        violation = check_scope(
+            "shell",
+            "gh pr merge 1175 --squash --repo=gptme/gptme-contrib",
+            None,
+        )
+        assert violation is not None
+        assert "gptme/gptme-contrib" in violation
+
     def test_force_push_flagged(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         path = tmp_path / "scope.yaml"
         path.write_text(yaml.dump({"scopes": {"force_push_repos": []}}))

--- a/plugins/gptme-action-receipts/tests/test_scope_gate.py
+++ b/plugins/gptme-action-receipts/tests/test_scope_gate.py
@@ -1,0 +1,252 @@
+"""Tests for the Phase 2 scope-check gate."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+from gptme_action_receipts.hooks.scope_gate import (
+    _is_authorized,
+    _parse_repo_from_url,
+    check_scope,
+)
+
+# --------------------------------------------------------------------------- #
+# Helpers                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture()
+def scope_yaml(tmp_path: Path):
+    """Write a scope.yaml to tmp_path and point GPTME_SCOPE_MANIFEST at it."""
+    path = tmp_path / "scope.yaml"
+
+    def _write(content: dict) -> Path:
+        path.write_text(yaml.dump(content), encoding="utf-8")
+        return path
+
+    return _write
+
+
+@pytest.fixture()
+def authed_merge_yaml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """scope.yaml that authorizes ErikBjare/bob merges only."""
+    path = tmp_path / "scope.yaml"
+    path.write_text(
+        yaml.dump(
+            {
+                "version": 1,
+                "violation_action": "warn",
+                "scopes": {"merge_repos": ["ErikBjare/bob"]},
+            }
+        )
+    )
+    monkeypatch.setenv("GPTME_SCOPE_MANIFEST", str(path))
+    return path
+
+
+# --------------------------------------------------------------------------- #
+# _is_authorized                                                               #
+# --------------------------------------------------------------------------- #
+
+
+class TestIsAuthorized:
+    def test_exact_match(self):
+        assert _is_authorized("ErikBjare/bob", ["ErikBjare/bob"])
+
+    def test_glob_org_wildcard(self):
+        assert _is_authorized("ErikBjare/bob", ["ErikBjare/*"])
+
+    def test_not_in_list(self):
+        assert not _is_authorized("gptme/gptme-contrib", ["ErikBjare/bob"])
+
+    def test_empty_list_denies(self):
+        assert not _is_authorized("anything/repo", [])
+
+    def test_partial_match_not_enough(self):
+        assert not _is_authorized("gptme/gptme", ["ErikBjare/*"])
+
+
+# --------------------------------------------------------------------------- #
+# _parse_repo_from_url                                                         #
+# --------------------------------------------------------------------------- #
+
+
+class TestParseRepoFromUrl:
+    def test_ssh_url(self):
+        assert (
+            _parse_repo_from_url("git@github.com:ErikBjare/bob.git") == "ErikBjare/bob"
+        )
+
+    def test_https_url(self):
+        assert (
+            _parse_repo_from_url("https://github.com/ErikBjare/bob.git")
+            == "ErikBjare/bob"
+        )
+
+    def test_https_no_dot_git(self):
+        assert (
+            _parse_repo_from_url("https://github.com/gptme/gptme-contrib")
+            == "gptme/gptme-contrib"
+        )
+
+    def test_returns_none_on_garbage(self):
+        assert _parse_repo_from_url("not-a-url") is None
+
+
+# --------------------------------------------------------------------------- #
+# check_scope — authorized actions                                             #
+# --------------------------------------------------------------------------- #
+
+
+class TestCheckScopeAuthorized:
+    def test_authorized_merge_allowed(self, authed_merge_yaml: Path):
+        violation = check_scope(
+            "shell",
+            "gh pr merge 42 --squash --repo ErikBjare/bob",
+            None,
+        )
+        assert violation is None
+
+    def test_non_sensitive_command_passes_through(self, authed_merge_yaml: Path):
+        for cmd in ("ls -la", "echo hello", "uv run pytest", "git status"):
+            assert check_scope("shell", cmd, None) is None
+
+    def test_non_shell_tool_skipped(self, authed_merge_yaml: Path):
+        # save/patch tools are never scope-checked
+        assert (
+            check_scope(
+                "save", "gh pr merge 1175 --squash --repo gptme/gptme-contrib", None
+            )
+            is None
+        )
+
+    def test_glob_org_authorizes(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        path = tmp_path / "scope.yaml"
+        path.write_text(yaml.dump({"scopes": {"merge_repos": ["ErikBjare/*"]}}))
+        monkeypatch.setenv("GPTME_SCOPE_MANIFEST", str(path))
+        assert check_scope("shell", "gh pr merge 7 --repo ErikBjare/bob", None) is None
+
+
+# --------------------------------------------------------------------------- #
+# check_scope — unauthorized actions                                           #
+# --------------------------------------------------------------------------- #
+
+
+class TestCheckScopeUnauthorized:
+    def test_unauthorized_merge_flagged(self, authed_merge_yaml: Path):
+        violation = check_scope(
+            "shell",
+            "gh pr merge 1175 --squash --repo gptme/gptme-contrib",
+            None,
+        )
+        assert violation is not None
+        assert "gptme/gptme-contrib" in violation
+
+    def test_force_push_flagged(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        path = tmp_path / "scope.yaml"
+        path.write_text(yaml.dump({"scopes": {"force_push_repos": []}}))
+        monkeypatch.setenv("GPTME_SCOPE_MANIFEST", str(path))
+        # git push --force resolves the repo via workspace remote
+        fake_url = "https://github.com/gptme/gptme-contrib.git"
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout=fake_url, stderr=""
+            )
+            violation = check_scope(
+                "shell",
+                "git push origin HEAD:refs/heads/main --force",
+                tmp_path,
+            )
+        assert violation is not None
+        assert "gptme-contrib" in violation
+
+    def test_repo_delete_flagged(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        path = tmp_path / "scope.yaml"
+        path.write_text(yaml.dump({"scopes": {"repo_delete": []}}))
+        monkeypatch.setenv("GPTME_SCOPE_MANIFEST", str(path))
+        violation = check_scope("shell", "gh repo delete gptme/old-repo --yes", None)
+        assert violation is not None
+        assert "old-repo" in violation
+
+
+# --------------------------------------------------------------------------- #
+# check_scope — workspace remote fallback                                      #
+# --------------------------------------------------------------------------- #
+
+
+class TestCheckScopeWorkspaceFallback:
+    def test_uses_workspace_remote_when_no_repo_flag(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Without --repo flag, extraction falls back to workspace git remote."""
+        scope = tmp_path / "scope.yaml"
+        scope.write_text(yaml.dump({"scopes": {"merge_repos": []}}))
+        monkeypatch.setenv("GPTME_SCOPE_MANIFEST", str(scope))
+
+        # Fake git remote returning gptme-contrib URL
+        fake_remote = "https://github.com/gptme/gptme-contrib.git"
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout=fake_remote, stderr=""
+            )
+            violation = check_scope("shell", "gh pr merge 42 --squash", tmp_path)
+
+        assert violation is not None
+        assert "gptme-contrib" in violation
+
+    def test_no_workspace_skips_check_gracefully(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Without workspace and no --repo flag, no violation (can't extract)."""
+        scope = tmp_path / "scope.yaml"
+        scope.write_text(yaml.dump({"scopes": {"merge_repos": []}}))
+        monkeypatch.setenv("GPTME_SCOPE_MANIFEST", str(scope))
+
+        # No --repo flag, no workspace → extraction returns None → skip check
+        violation = check_scope("shell", "gh pr merge 42 --squash", None)
+        assert violation is None
+
+
+# --------------------------------------------------------------------------- #
+# check_scope — failure resilience                                             #
+# --------------------------------------------------------------------------- #
+
+
+class TestCheckScopeResilience:
+    def test_bad_manifest_no_crash(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        bad = tmp_path / "scope.yaml"
+        bad.write_text(": this is : not : valid yaml :\n  - [unclosed")
+        monkeypatch.setenv("GPTME_SCOPE_MANIFEST", str(bad))
+        # Falls back to defaults (warn, all empty) — no crash, returns None
+        result = check_scope("shell", "gh pr merge 1 --repo ErikBjare/bob", None)
+        # Default allows no merges (empty list) → violation expected
+        assert isinstance(result, str | type(None))  # no exception
+
+    def test_missing_manifest_uses_defaults(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("GPTME_SCOPE_MANIFEST", str(tmp_path / "nonexistent.yaml"))
+        # Default config → empty merge_repos → violation
+        violation = check_scope(
+            "shell", "gh pr merge 1175 --squash --repo gptme/gptme-contrib", None
+        )
+        assert violation is not None  # defaults deny
+
+    def test_subprocess_error_during_extraction_no_crash(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        scope = tmp_path / "scope.yaml"
+        scope.write_text(yaml.dump({"scopes": {"merge_repos": []}}))
+        monkeypatch.setenv("GPTME_SCOPE_MANIFEST", str(scope))
+
+        with patch("subprocess.run", side_effect=OSError("no git")):
+            # Should not crash — falls back gracefully
+            result = check_scope("shell", "gh pr merge 42 --squash", tmp_path)
+        # No --repo + subprocess failure → repo extraction fails → no violation
+        assert result is None

--- a/uv.lock
+++ b/uv.lock
@@ -1340,12 +1340,14 @@ version = "0.1.0"
 source = { editable = "plugins/gptme-action-receipts" }
 dependencies = [
     { name = "gptme" },
+    { name = "pyyaml" },
 ]
 
 [package.optional-dependencies]
 test = [
     { name = "pytest" },
     { name = "pytest-mock" },
+    { name = "pyyaml" },
 ]
 
 [package.metadata]
@@ -1353,6 +1355,8 @@ requires-dist = [
     { name = "gptme", git = "https://github.com/gptme/gptme.git?branch=master" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
     { name = "pytest-mock", marker = "extra == 'test'", specifier = ">=3.12.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
+    { name = "pyyaml", marker = "extra == 'test'", specifier = ">=6.0" },
 ]
 provides-extras = ["test"]
 


### PR DESCRIPTION
## Summary

- Adds `scope_gate.py` to `gptme-action-receipts` — a synchronous scope-check that fires after the Phase 1 ledger write and **before** tool execution
- The gate detects out-of-scope sensitive operations (`gh pr merge`, `git push --force`, `gh repo delete/release delete`) by matching patterns and extracting the target repo (via `--repo` flag, positional arg, or workspace `git remote` fallback)
- Default mode: `violation_action: warn` — logs a warning and continues; flip to `block` after 7-day soak
- 22 new tests in `test_scope_gate.py` covering: authorized/unauthorized merges, force-push, repo-delete, workspace remote fallback, bad manifest resilience

## Motivation

The #1175 unauthorized self-merge incident (2026-06-30): `gh pr merge 1175 --squash --repo gptme/gptme-contrib`. Phase 1 logged the receipt; Phase 2 would have flagged `gptme/gptme-contrib` absent from the `merge_repos` allowlist before the command ran.

## Usage

Install `~/.config/gptme/scope.yaml` (template in `examples/scope.yaml`):

```yaml
version: 1
violation_action: warn  # flip to 'block' after soak
scopes:
  merge_repos:
    - ErikBjare/bob  # only allow self-merges in brain repo
```

Or set `GPTME_SCOPE_MANIFEST=/path/to/scope.yaml`.

## Test plan

- [x] `35 passed` — all Phase 1 + Phase 2 tests green
- [x] ruff lint + format clean
- [x] prek hooks passed

## Related

- Phase 1: #1217 (merged 2026-07-04)
- Incident: ErikBjare/bob#1015