### PR TITLE
fix(ci): update dashboard Pages deploy action

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -57,4 +57,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
- update the dashboard GitHub Pages deployment action from `actions/deploy-pages@v4` to `@v5`
- removes the deprecated Node 20 action runtime path; `v5` runs on Node 24

## Context
Master run https://github.com/gptme/gptme-contrib/actions/runs/28720281391 failed twice in the Pages deploy step after the artifact was accepted:

`Deployment failed, try again later.`

The build job and artifact upload succeeded. Recent dashboard deploys show the same Pages-side failure intermittently, so this keeps the workflow on GitHub's current deploy action before trying more invasive changes.

## Verification
- `uv run python3 -c 'from pathlib import Path; import yaml; p=Path("/tmp/worktrees/gptme-contrib-dashboard-v5/.github/workflows/dashboard.yml"); data=yaml.safe_load(p.read_text()); assert data["jobs"]["deploy"]["steps"][0]["uses"] == "actions/deploy-pages@v5"; print("dashboard workflow YAML ok")'`
- `uv run prek run --files .github/workflows/dashboard.yml`
