### PR TITLE
test(gptme-sessions): mock _discover_all in tests that scan real filesystem

### DIFF
--- a/packages/gptme-sessions/tests/test_cli.py
+++ b/packages/gptme-sessions/tests/test_cli.py
@@ -265,9 +265,10 @@ class TestStatsCommand:
         assert data["total"] == 2
 
     def test_stats_empty_store(self, tmp_path: Path):
-        """stats on empty store shows discovery fallback."""
+        """stats on empty store shows discovery fallback (no real sessions found)."""
         SessionStore(sessions_dir=tmp_path)
-        rc, out = _invoke(["stats"], tmp_path)
+        with _NO_DISCOVER:
+            rc, out = _invoke(["stats"], tmp_path)
         assert rc == 0
         assert "discover" in out.lower() or "sync" in out.lower() or "session" in out.lower()
 
@@ -295,7 +296,8 @@ class TestStatsCommand:
     def test_stats_no_matches_with_filter(self, tmp_path: Path):
         """stats with filter that matches nothing shows appropriate message."""
         _seed_store(tmp_path)
-        rc, out = _invoke(["stats", "--model", "nonexistent"], tmp_path)
+        with _NO_DISCOVER:
+            rc, out = _invoke(["stats", "--model", "nonexistent"], tmp_path)
         assert rc == 0
         assert "no records" in out.lower()
 
@@ -649,7 +651,8 @@ class TestTopLevelCli:
     def test_no_subcommand_shows_stats(self, tmp_path: Path):
         """Invoking without subcommand shows stats (format_stats → sys.stdout)."""
         _seed_store(tmp_path)
-        rc, out = _invoke([], tmp_path)
+        with _NO_DISCOVER:
+            rc, out = _invoke([], tmp_path)
         assert rc == 0
         # format_stats writes to sys.stdout (not captured by CliRunner)
         # but the tip line IS captured via click.echo
@@ -658,7 +661,8 @@ class TestTopLevelCli:
     def test_no_subcommand_empty_store(self, tmp_path: Path):
         """Empty store without subcommand shows discovery message."""
         SessionStore(sessions_dir=tmp_path)
-        rc, out = _invoke([], tmp_path)
+        with _NO_DISCOVER:
+            rc, out = _invoke([], tmp_path)
         assert rc == 0
         assert "discover" in out.lower() or "sync" in out.lower() or "session" in out.lower()
 
@@ -728,17 +732,18 @@ class TestSyncTimestamp:
 
         store_dir = tmp_path / "store"
         runner = CliRunner()
-        result = runner.invoke(
-            cli,
-            [
-                "--sessions-dir",
-                str(store_dir),
-                "sync",
-                "--since",
-                "30d",
-            ],
-            env={"GPTME_LOGS_DIR": str(logs_dir)},
-        )
+        with _NO_DISCOVER:
+            result = runner.invoke(
+                cli,
+                [
+                    "--sessions-dir",
+                    str(store_dir),
+                    "sync",
+                    "--since",
+                    "30d",
+                ],
+                env={"GPTME_LOGS_DIR": str(logs_dir)},
+            )
         assert result.exit_code == 0
 
         # Load the store and check the timestamp

--- a/packages/gptme-sessions/tests/test_cli.py
+++ b/packages/gptme-sessions/tests/test_cli.py
@@ -724,6 +724,8 @@ class TestClassifyStatsCommand:
 class TestSyncTimestamp:
     def test_sync_uses_session_date_not_now(self, tmp_path: Path):
         """sync should use session date from discovery, not datetime.now()."""
+        from datetime import date
+
         # Create a gptme session directory with a known date
         logs_dir = tmp_path / "logs"
         session_dir = logs_dir / "2026-03-10-test-session"
@@ -732,7 +734,19 @@ class TestSyncTimestamp:
 
         store_dir = tmp_path / "store"
         runner = CliRunner()
-        with _NO_DISCOVER:
+
+        # Mock _discover_all to return this test session instead of scanning filesystem
+        mock_discovered = [
+            {
+                "harness": "gptme",
+                "path": session_dir,
+                "model": None,
+                "session_date": date(2026, 3, 10),
+                "session_name": "test-session",
+                "project": None,
+            }
+        ]
+        with patch("gptme_sessions.cli._discover_all", return_value=mock_discovered):
             result = runner.invoke(
                 cli,
                 [
@@ -751,9 +765,9 @@ class TestSyncTimestamp:
         records = store.load_all()
         # Should have imported one record
         gptme_records = [r for r in records if r.harness == "gptme"]
-        if gptme_records:
-            # The timestamp should start with the session date, not today
-            assert gptme_records[0].timestamp.startswith("2026-03-10")
+        assert len(gptme_records) == 1
+        # The timestamp should start with the session date, not today
+        assert gptme_records[0].timestamp.startswith("2026-03-10")
 
     def test_sync_imports_real_start_time_from_trajectory(self, tmp_path: Path):
         """sync should record the real start time, not a noon-UTC placeholder.

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -5278,6 +5278,7 @@ def test_runs_fallback_to_discovery_when_empty(tmp_path: Path, capsys, monkeypat
 def test_stats_no_fallback_when_records_exist(tmp_path: Path, capsys, monkeypatch):
     """stats does not show discovery fallback when records exist in the store."""
     import sys
+    from unittest.mock import patch
 
     from gptme_sessions.cli import main
     from gptme_sessions import SessionRecord, SessionStore
@@ -5289,7 +5290,8 @@ def test_stats_no_fallback_when_records_exist(tmp_path: Path, capsys, monkeypatc
     monkeypatch.setattr(
         sys, "argv", ["gptme-sessions", "--sessions-dir", str(sessions_dir), "stats"]
     )
-    rc = main()
+    with patch("gptme_sessions.cli._discover_all", return_value=[]):
+        rc = main()
     assert rc == 0
     # _show_discovery_fallback uses click.echo() which capsys captures.
     # The absence of the fallback message confirms normal stats were shown.


### PR DESCRIPTION
## Summary

- `_discover_all` scans all CC/gptme/codex session files on disk; on a machine with thousands of sessions this reads ~3000 × 512KB = 1.5GB and exceeds pytest's 30s timeout, making tests non-deterministically fail
- Add `_NO_DISCOVER = patch("gptme_sessions.cli._discover_all", return_value=[])` mock to 6 tests that call `stats` or `sync` without it
- The mock was already defined at the top of `test_cli.py`; this just applies it consistently

**Affected tests:**
- `TestStatsCommand::test_stats_empty_store`
- `TestStatsCommand::test_stats_no_matches_with_filter`
- `TestTopLevelCli::test_no_subcommand_shows_stats`
- `TestTopLevelCli::test_no_subcommand_empty_store`
- `TestSyncTimestamp::test_sync_uses_session_date_not_now`
- `test_stats_no_fallback_when_records_exist` (in `test_sessions.py`)

## Test plan

- [ ] All 6 tests pass under 1s with the mock applied
- [ ] Tests that specifically need real discovery (e.g. `test_discovery.py`) are unaffected