### PR TITLE
test(gptme-runloops): mock _record_session in run() integration tests

### DIFF
--- a/packages/gptme-runloops/tests/test_autonomous.py
+++ b/packages/gptme-runloops/tests/test_autonomous.py
@@ -32,10 +32,11 @@ def test_autonomous_run_cycle():
 
         run = AutonomousRun(workspace)
 
-        # Mock external calls
+        # Mock external calls (including _record_session to avoid live store writes)
         with (
             patch("gptme_runloops.base.git_pull_with_retry") as mock_pull,
             patch("gptme_runloops.utils.executor.execute_gptme") as mock_execute,
+            patch.object(run, "_record_session"),
         ):
             mock_pull.return_value = True
             mock_execute.return_value = ExecutionResult(exit_code=0)

--- a/packages/gptme-runloops/tests/test_executor.py
+++ b/packages/gptme-runloops/tests/test_executor.py
@@ -482,7 +482,10 @@ def test_full_cycle_with_custom_executor():
         (workspace / "logs").mkdir()
         loop = TestLoop(workspace, "test", executor=mock_executor)
 
-        with patch("gptme_runloops.base.git_pull_with_retry", return_value=True):
+        with (
+            patch("gptme_runloops.base.git_pull_with_retry", return_value=True),
+            patch.object(loop, "_record_session"),
+        ):
             exit_code = loop.run()
             assert exit_code == 0
 


### PR DESCRIPTION
## Summary

- Two integration tests (`test_full_cycle_with_custom_executor`, `test_autonomous_run_cycle`) called `BaseRunLoop.run()` without patching `_record_session()`, causing every test run to write synthetic rows into the live `GPTME_SESSIONS_DIR`.
- Fix: add `patch.object(run, "_record_session")` to both tests, consistent with `test_base_run_full_cycle` in `test_base.py` which already handled this correctly.

## Impact

117 synthetic rows (`harness=mock`/`run_type=test` and `harness=gptme`/`run_type=autonomous`/`duration_seconds=0`) had leaked into `state/sessions/session-records.jsonl` since 2026-07-02. Those were scrubbed in a companion brain-repo commit.

## Test plan

- [x] `pytest gptme-contrib/packages/gptme-runloops/tests/test_executor.py::test_full_cycle_with_custom_executor` passes
- [x] `pytest gptme-contrib/packages/gptme-runloops/tests/test_autonomous.py::test_autonomous_run_cycle` passes
- [x] Full `pytest gptme-contrib/packages/gptme-runloops/` suite: 329 passed