### PR TITLE
fix(gptme-rag): on_moved delete-by-filter + stale collection handle recovery

### DIFF
--- a/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
@@ -280,6 +280,20 @@ class Indexer:
         )
         logger.debug(f"Reset collection: {self.collection_name}")
 
+    def _refresh_collection(self) -> None:
+        """Re-bind the collection handle without wiping data.
+
+        Use this to recover from a stale Collection object after chromadb
+        internally recreated the collection (e.g. during a reset_collection
+        call on a concurrent path).  Unlike reset_collection, this never
+        deletes documents — it only refreshes the cached reference.
+        """
+        self.collection = self.client.get_collection(
+            name=self.collection_name,
+            embedding_function=self.embedding_function,
+        )
+        logger.debug(f"Refreshed collection handle: {self.collection_name}")
+
     def add_document(self, document: Document) -> None:
         """Add a single document to the index."""
         document = self._generate_doc_id(document)
@@ -304,6 +318,13 @@ class Indexer:
         try:
             self.collection.delete(where=where)
             logger.debug(f"Deleted documents matching: {where}")
+        except NotFoundError:
+            # The cached Collection object is stale (collection was recreated).
+            # Re-bind and retry once — never wipe the index to recover from this.
+            logger.debug("Collection handle stale on delete; refreshing and retrying")
+            self._refresh_collection()
+            self.collection.delete(where=where)
+            logger.debug(f"Deleted documents matching: {where} (after refresh)")
         except Exception as e:
             # A failed delete must not escalate into deleting the whole
             # collection. Surface the error to the caller instead.

--- a/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
@@ -322,9 +322,18 @@ class Indexer:
             # The cached Collection object is stale (collection was recreated).
             # Re-bind and retry once — never wipe the index to recover from this.
             logger.debug("Collection handle stale on delete; refreshing and retrying")
-            self._refresh_collection()
-            self.collection.delete(where=where)
-            logger.debug(f"Deleted documents matching: {where} (after refresh)")
+            try:
+                self._refresh_collection()
+                self.collection.delete(where=where)
+                logger.debug(f"Deleted documents matching: {where} (after refresh)")
+            except NotFoundError as retry_err:
+                # Collection still missing after refresh (race condition).
+                # Surface the error to the caller instead.
+                logger.error(
+                    f"Error deleting documents (stale handle, recovery failed): {retry_err}",
+                    exc_info=True,
+                )
+                raise
         except Exception as e:
             # A failed delete must not escalate into deleting the whole
             # collection. Surface the error to the caller instead.

--- a/packages/gptme-rag/src/gptme_rag/indexing/watcher.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/watcher.py
@@ -173,13 +173,11 @@ class IndexEventHandler(FileSystemEventHandler):
             # Remove old file from index if it was being tracked
             if self._should_process(src_str):
                 logger.debug(f"Removing old path from index: {src_path}")
-                old_docs = self.indexer.search("", n_results=100, where={"source": str(src_path)})[
-                    0
-                ]
-                for doc in old_docs:
-                    if doc.doc_id is not None:
-                        self.indexer.delete_document(doc.doc_id)
-                        logger.debug(f"Deleted old document: {doc.doc_id}")
+                try:
+                    self.indexer.delete_documents({"source": str(src_path)})
+                    logger.debug(f"Deleted old documents for: {src_path}")
+                except Exception as e:
+                    logger.warning(f"Error removing old path {src_path} from index: {e}")
 
             # Index the file at its new location if it matches our patterns
             if self._should_process(dest_str):


### PR DESCRIPTION
## Problem

Two bugs in `IndexEventHandler.on_moved` and `Indexer.delete_documents`:

1. **`on_moved` uses fragile empty-string search** — `search("", n_results=100, where={"source": ...})` embeds an empty string (wasteful/fragile) and the 100-result cap silently orphans chunks from files with >100 chunks, leaving stale data in the index after a file move.

2. **Stale `Collection` handle raises `NotFoundError`** — `self.collection` can become stale after chromadb internally recreates the collection (e.g. a concurrent `reset_collection` call). Calling `self.collection.delete(where=...)` on a stale handle raises `chromadb.errors.NotFoundError: Collection [uuid] does not exist`, crashing the update path.

## Changes

**`watcher.py`**: Replace the search+delete-by-id loop in `on_moved` with `delete_documents(where={"source": str(src_path)})` — the same API already used by `_process_deletion` and `_process_update`.

**`indexer.py`**:
- Add `_refresh_collection()`: non-destructive re-bind via `client.get_collection()` — never wipes data, unlike `reset_collection`.
- Catch `NotFoundError` in `delete_documents`, refresh the handle, and retry once.

## Test plan

- [x] All 7 existing watcher tests pass (`test_file_watcher_basic`, `test_file_watcher_move`, etc.) — 187s run with real filesystem event delays
- [x] Pre-commit hooks pass (prek)