### PR TITLE
fix(activity-gate): add flock-based thundering-herd prevention to cache fetches

### DIFF
--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -225,7 +225,8 @@ discover_repos() {
 # Raising the defaults to 480s / 600s / 600s drops those lanes to ~375 / 300 /
 # 300 fetches/hr (~975/hr total) without changing cadence.
 #
-# Override via env: GH_CACHE_TTL_PR / GH_CACHE_TTL_ISSUE / GH_CACHE_TTL_RUN (seconds).
+# Override via env: GH_CACHE_TTL_PR / GH_CACHE_TTL_ISSUE / GH_CACHE_TTL_RUN (seconds),
+# GH_CACHE_LOCK_TIMEOUT (seconds).
 # Set any to 0 to bypass the cache (useful for diagnostics).
 GH_CACHE_DIR="${GH_CACHE_DIR:-$STATE_DIR/gh-cache}"
 # Increased from 240→480 and 300→600 (2026-05-21) after GraphQL rate-limit regression.
@@ -235,6 +236,30 @@ GH_CACHE_DIR="${GH_CACHE_DIR:-$STATE_DIR/gh-cache}"
 GH_CACHE_TTL_PR="${GH_CACHE_TTL_PR:-480}"
 GH_CACHE_TTL_ISSUE="${GH_CACHE_TTL_ISSUE:-600}"
 GH_CACHE_TTL_RUN="${GH_CACHE_TTL_RUN:-600}"
+GH_CACHE_LOCK_TIMEOUT="${GH_CACHE_LOCK_TIMEOUT:-30}"
+
+gh_cache_fetch_and_store() {
+    local producer="$1" cache_file="$2" safe_key="$3" has_fallback="$4" fallback="${5-}"
+    local out tmp_file
+    if out=$(eval "$producer"); then
+        if [ -n "$out" ]; then
+            tmp_file=$(mktemp "$GH_CACHE_DIR/${safe_key}.json.tmp.XXXXXX" 2>/dev/null || printf '')
+            if [ -n "$tmp_file" ]; then
+                # Write via temp file + rename so readers never observe partial JSON.
+                if ! printf '%s' "$out" > "$tmp_file" || ! mv "$tmp_file" "$cache_file"; then
+                    rm -f "$tmp_file"
+                fi
+            fi
+        fi
+        printf '%s' "$out"
+        return 0
+    fi
+    if [ "$has_fallback" = "1" ]; then
+        printf '%s' "$fallback"
+        return 0
+    fi
+    return 1
+}
 
 # Read cached value if fresh enough, else run the producer command and cache its
 # stdout. The producer is passed as a single shell-evaluated string so callers
@@ -285,11 +310,13 @@ gh_cache_get_or_fetch() {
     # After acquiring the lock, re-check the cache (double-checked locking):
     # a sibling session may have populated it while we waited.
     local lock_file="$GH_CACHE_DIR/${safe_key}.lock"
-    local out tmp_file
+    local has_fallback=0
+    [ $# -ge 4 ] && has_fallback=1
     if command -v flock &>/dev/null; then
         {
-        flock -w "${GH_CACHE_LOCK_TIMEOUT:-30}" -x 200 2>/dev/null || true
-        # Double-check after acquiring lock: another session may have populated cache
+        flock -w "$GH_CACHE_LOCK_TIMEOUT" -x 200 2>/dev/null || true
+        # Double-check after waiting for the lock: another session may have populated cache.
+        # If the lock timed out, the fetch below proceeds without blocking forever.
         if [ -f "$cache_file" ]; then
             local mtime2
             mtime2=$(stat -c %Y "$cache_file" 2>/dev/null || stat -f %m "$cache_file" 2>/dev/null || echo "")
@@ -301,45 +328,11 @@ gh_cache_get_or_fetch() {
                 fi
             fi
         fi
-        if out=$(eval "$producer"); then
-            if [ -n "$out" ]; then
-                tmp_file=$(mktemp "$GH_CACHE_DIR/${safe_key}.json.tmp.XXXXXX" 2>/dev/null || printf '')
-                if [ -n "$tmp_file" ]; then
-                    # Write via temp file + rename so readers never observe partial JSON.
-                    if ! printf '%s' "$out" > "$tmp_file" || ! mv "$tmp_file" "$cache_file"; then
-                        rm -f "$tmp_file"
-                    fi
-                fi
-            fi
-            printf '%s' "$out"
-            return 0
-        fi
-        if [ $# -ge 4 ]; then
-            printf '%s' "$fallback"
-            return 0
-        fi
-        return 1
+        gh_cache_fetch_and_store "$producer" "$cache_file" "$safe_key" "$has_fallback" "$fallback"
     } 200>"$lock_file"
     else
         # flock not available (macOS, Alpine, minimal containers): direct fetch
-        if out=$(eval "$producer"); then
-            if [ -n "$out" ]; then
-                tmp_file=$(mktemp "$GH_CACHE_DIR/${safe_key}.json.tmp.XXXXXX" 2>/dev/null || printf '')
-                if [ -n "$tmp_file" ]; then
-                    # Write via temp file + rename so readers never observe partial JSON.
-                    if ! printf '%s' "$out" > "$tmp_file" || ! mv "$tmp_file" "$cache_file"; then
-                        rm -f "$tmp_file"
-                    fi
-                fi
-            fi
-            printf '%s' "$out"
-            return 0
-        fi
-        if [ $# -ge 4 ]; then
-            printf '%s' "$fallback"
-            return 0
-        fi
-        return 1
+        gh_cache_fetch_and_store "$producer" "$cache_file" "$safe_key" "$has_fallback" "$fallback"
     fi
 }
 

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -286,8 +286,9 @@ gh_cache_get_or_fetch() {
     # a sibling session may have populated it while we waited.
     local lock_file="$GH_CACHE_DIR/${safe_key}.lock"
     local out tmp_file
-    {
-        flock -x 200
+    if command -v flock &>/dev/null; then
+        {
+        flock -w "${GH_CACHE_LOCK_TIMEOUT:-30}" -x 200 2>/dev/null || true
         # Double-check after acquiring lock: another session may have populated cache
         if [ -f "$cache_file" ]; then
             local mtime2
@@ -319,6 +320,27 @@ gh_cache_get_or_fetch() {
         fi
         return 1
     } 200>"$lock_file"
+    else
+        # flock not available (macOS, Alpine, minimal containers): direct fetch
+        if out=$(eval "$producer"); then
+            if [ -n "$out" ]; then
+                tmp_file=$(mktemp "$GH_CACHE_DIR/${safe_key}.json.tmp.XXXXXX" 2>/dev/null || printf '')
+                if [ -n "$tmp_file" ]; then
+                    # Write via temp file + rename so readers never observe partial JSON.
+                    if ! printf '%s' "$out" > "$tmp_file" || ! mv "$tmp_file" "$cache_file"; then
+                        rm -f "$tmp_file"
+                    fi
+                fi
+            fi
+            printf '%s' "$out"
+            return 0
+        fi
+        if [ $# -ge 4 ]; then
+            printf '%s' "$fallback"
+            return 0
+        fi
+        return 1
+    fi
 }
 
 # Fetch all PR data once per repo, with all fields needed by every check

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -240,6 +240,12 @@ GH_CACHE_TTL_RUN="${GH_CACHE_TTL_RUN:-600}"
 # stdout. The producer is passed as a single shell-evaluated string so callers
 # can include flags and pipes.
 #
+# Thundering-herd prevention: when the cache is stale, a flock-based lock
+# serializes concurrent callers. The first caller acquires the lock, fetches,
+# and writes the cache. Subsequent callers, after the lock is released,
+# find the cache fresh via double-checked locking and return immediately
+# without making another GitHub API call. Requires util-linux flock (Linux).
+#
 # Args:
 #   $1 — cache key (filesystem-safe; will be normalized)
 #   $2 — TTL seconds (0 = no cache)
@@ -261,6 +267,7 @@ gh_cache_get_or_fetch() {
     # Normalize key: replace slashes with `-`
     local safe_key="${key//\//-}"
     local cache_file="$GH_CACHE_DIR/${safe_key}.json"
+    # Fast path: cache is fresh — return without acquiring a lock
     if [ -f "$cache_file" ]; then
         local mtime
         mtime=$(stat -c %Y "$cache_file" 2>/dev/null || stat -f %m "$cache_file" 2>/dev/null || echo "")
@@ -272,25 +279,46 @@ gh_cache_get_or_fetch() {
             fi
         fi
     fi
+    # Slow path: cache is stale or missing. Serialize with flock to prevent the
+    # thundering-herd pattern where N concurrent monitoring sessions simultaneously
+    # see an expired cache and each fires a separate GitHub API call.
+    # After acquiring the lock, re-check the cache (double-checked locking):
+    # a sibling session may have populated it while we waited.
+    local lock_file="$GH_CACHE_DIR/${safe_key}.lock"
     local out tmp_file
-    if out=$(eval "$producer"); then
-        if [ -n "$out" ]; then
-            tmp_file=$(mktemp "$GH_CACHE_DIR/${safe_key}.json.tmp.XXXXXX" 2>/dev/null || printf '')
-            if [ -n "$tmp_file" ]; then
-                # Write via temp file + rename so readers never observe partial JSON.
-                if ! printf '%s' "$out" > "$tmp_file" || ! mv "$tmp_file" "$cache_file"; then
-                    rm -f "$tmp_file"
+    {
+        flock -x 200
+        # Double-check after acquiring lock: another session may have populated cache
+        if [ -f "$cache_file" ]; then
+            local mtime2
+            mtime2=$(stat -c %Y "$cache_file" 2>/dev/null || stat -f %m "$cache_file" 2>/dev/null || echo "")
+            if [ -n "$mtime2" ]; then
+                local age2=$(( $(date +%s) - mtime2 ))
+                if [ "$age2" -lt "$ttl" ]; then
+                    cat "$cache_file"
+                    return 0
                 fi
             fi
         fi
-        printf '%s' "$out"
-        return 0
-    fi
-    if [ $# -ge 4 ]; then
-        printf '%s' "$fallback"
-        return 0
-    fi
-    return 1
+        if out=$(eval "$producer"); then
+            if [ -n "$out" ]; then
+                tmp_file=$(mktemp "$GH_CACHE_DIR/${safe_key}.json.tmp.XXXXXX" 2>/dev/null || printf '')
+                if [ -n "$tmp_file" ]; then
+                    # Write via temp file + rename so readers never observe partial JSON.
+                    if ! printf '%s' "$out" > "$tmp_file" || ! mv "$tmp_file" "$cache_file"; then
+                        rm -f "$tmp_file"
+                    fi
+                fi
+            fi
+            printf '%s' "$out"
+            return 0
+        fi
+        if [ $# -ge 4 ]; then
+            printf '%s' "$fallback"
+            return 0
+        fi
+        return 1
+    } 200>"$lock_file"
 }
 
 # Fetch all PR data once per repo, with all fields needed by every check


### PR DESCRIPTION
## Problem

`activity-gate.sh` is the top GraphQL consumer, responsible for ~170 of every 200 recent GitHub API calls. The root cause is a **thundering herd** in `gh_cache_get_or_fetch`: when N concurrent monitoring sessions simultaneously see an expired per-repo PR cache, each independently fires a `gh pr list` GraphQL query for the same repo. The existing atomic write (temp file + mv) prevents corrupt cache reads but does nothing to prevent concurrent fetches.

On a hot multi-session day with 5 monitoring sessions running in parallel, this causes 5× the expected GraphQL cost: 5 processes × 16 repos = 80 GraphQL calls instead of 16.

## Fix

Add **flock-based double-checked locking** to the slow path of `gh_cache_get_or_fetch`:

1. **Fast path unchanged**: if the cache is fresh, return immediately — no lock overhead.
2. **Slow path**: wrap in a per-key flock. The first process acquires the exclusive lock and fetches. Subsequent processes block on the lock, then re-check the cache (double-checked locking). They find it fresh and return without making another API call.

Lock files sit alongside cache files in `GH_CACHE_DIR`. They're tiny (empty files used only for flock) and don't need cleanup.

Requires `flock` from util-linux (always present on Linux; this script already has other Linux-specific code).

## Expected impact

On a burst where 5 sessions simultaneously see expired caches for 16 repos: reduces GraphQL calls from 80 to 16 (5× reduction). More typically (2-3 concurrent sessions): reduces calls by 50–67% for that burst window.

## Test plan

- [x] `shellcheck` passes cleanly
- [x] Pre-commit hooks pass
- Manual: run two concurrent instances of `activity-gate.sh --author TimeToBuildBob --org gptme` against the same `STATE_DIR` and verify only one `gh pr list` call per repo appears in the GraphQL log