### PR TITLE
fix(ci): open community plugin refresh PR

### DIFF
--- a/.github/workflows/community-plugins.yml
+++ b/.github/workflows/community-plugins.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   update:
@@ -20,6 +21,8 @@ jobs:
         run: python3 scripts/fetch-community-plugins.py
 
       - name: Commit if changed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -27,6 +30,18 @@ jobs:
           if git diff --cached --quiet; then
             echo "No changes to community_plugins.json"
           else
+            branch="automation/community-plugins"
+            git checkout -B "$branch"
             git commit -m "chore(community-plugins): weekly refresh"
-            git push
+            git push --force-with-lease origin "HEAD:refs/heads/$branch"
+            if pr_url="$(gh pr view "$branch" --repo "$GITHUB_REPOSITORY" --json url --jq .url 2>/dev/null)"; then
+              echo "Updated existing pull request: $pr_url"
+            else
+              gh pr create \
+                --repo "$GITHUB_REPOSITORY" \
+                --base master \
+                --head "$branch" \
+                --title "chore(community-plugins): weekly refresh" \
+                --body "Automated weekly refresh of state/community_plugins.json."
+            fi
           fi

--- a/.github/workflows/community-plugins.yml
+++ b/.github/workflows/community-plugins.yml
@@ -33,13 +33,13 @@ jobs:
             branch="automation/community-plugins"
             git checkout -B "$branch"
             git commit -m "chore(community-plugins): weekly refresh"
-            git push --force-with-lease origin "HEAD:refs/heads/$branch"
+            git push --force origin "HEAD:refs/heads/$branch"
             if pr_url="$(gh pr view "$branch" --repo "$GITHUB_REPOSITORY" --json url --jq .url 2>/dev/null)"; then
               echo "Updated existing pull request: $pr_url"
             else
               gh pr create \
                 --repo "$GITHUB_REPOSITORY" \
-                --base master \
+                --base ${{ github.event.repository.default_branch }} \
                 --head "$branch" \
                 --title "chore(community-plugins): weekly refresh" \
                 --body "Automated weekly refresh of state/community_plugins.json."


### PR DESCRIPTION
## Summary

- make the scheduled community plugin refresh push changes to an automation branch
- open or update a pull request instead of pushing directly to protected `master`
- grant the workflow `pull-requests: write` so `gh pr create` can run

## Why

The scheduled run failed because branch protection rejects direct pushes to `master`:

```text
remote: - Changes must be made through a pull request.
```

Addresses gptme/gptme-contrib#1233.

## Verification

- `python3` YAML parse check for `.github/workflows/community-plugins.yml`
- `prek run --files .github/workflows/community-plugins.yml` passed visible scoped checks, then hung after output stopped; reran `git diff --check -- .github/workflows/community-plugins.yml`
- commit hook completed successfully via `git commit`
