### PR TITLE
fix(ci): use --force-with-lease with pre-fetch for community-plugins push

### DIFF
--- a/.github/workflows/community-plugins.yml
+++ b/.github/workflows/community-plugins.yml
@@ -33,7 +33,8 @@ jobs:
             branch="automation/community-plugins"
             git checkout -B "$branch"
             git commit -m "chore(community-plugins): weekly refresh"
-            git push --force origin "HEAD:refs/heads/$branch"
+            git fetch origin "$branch" 2>/dev/null || true
+            git push --force-with-lease origin "HEAD:refs/heads/$branch"
             if pr_url="$(gh pr view "$branch" --repo "$GITHUB_REPOSITORY" --json url --jq .url 2>/dev/null)"; then
               echo "Updated existing pull request: $pr_url"
             else

--- a/.github/workflows/community-plugins.yml
+++ b/.github/workflows/community-plugins.yml
@@ -33,7 +33,15 @@ jobs:
             branch="automation/community-plugins"
             git checkout -B "$branch"
             git commit -m "chore(community-plugins): weekly refresh"
-            git fetch origin "$branch" 2>/dev/null || true
+            if git ls-remote --exit-code --heads origin "$branch" >/dev/null; then
+              git fetch origin "$branch"
+            else
+              status=$?
+              if [ "$status" -ne 2 ]; then
+                exit "$status"
+              fi
+              echo "Remote branch $branch does not exist yet; pushing new branch"
+            fi
             git push --force-with-lease origin "HEAD:refs/heads/$branch"
             if pr_url="$(gh pr view "$branch" --repo "$GITHUB_REPOSITORY" --json url --jq .url 2>/dev/null)"; then
               echo "Updated existing pull request: $pr_url"


### PR DESCRIPTION
## Summary

- Fetch `automation/community-plugins` from origin before pushing so `--force-with-lease` has a local tracking ref to compare against
- Switch from `--force` to `--force-with-lease` — without the pre-fetch, the lease check was silently skipped (no local ref = no check)

`actions/checkout@v4` only fetches the default branch, so `origin/automation/community-plugins` doesn't exist as a tracking ref after checkout. The lease check requires a known remote ref to validate against; without one it degrades silently to `--force`.

Closes #1235

## Test plan

- [ ] Workflow YAML validates (no syntax errors)
- [ ] On next scheduled or manual run, the push succeeds when the branch already exists (lease check passes because the fetch populated the ref)
- [ ] If someone force-pushed the remote branch between checkout and this push, `--force-with-lease` will correctly refuse (the safety goal)

<!-- gptme-id:v1:gai_RMmazlm3udklrK8ZbjunVoAndMXv6SbIN7sUU3nmhDQ -->