### PR TITLE
fix(gptodo): include todo tasks in ready/next/actionable work filters

### DIFF
--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -457,7 +457,7 @@ def list_(sort, active_only, context, output_json, output_jsonl, pool_filter, ex
     # Filter tasks if active-only flag is set
     tasks = all_tasks
     if active_only:
-        tasks = [task for task in all_tasks if task.state in ["backlog", "active"]]
+        tasks = [task for task in all_tasks if task.state in ["backlog", "todo", "active"]]
         if not tasks:
             if output_json:
                 print("No new or active tasks found", file=sys.stderr)
@@ -568,7 +568,7 @@ def list_(sort, active_only, context, output_json, output_jsonl, pool_filter, ex
                 if dep in all_tasks_dict:
                     dep_task = all_tasks_dict[dep]
                     # If dependency is in filtered list, show its ID
-                    if not active_only or dep_task.state in ["backlog", "active"]:
+                    if not active_only or dep_task.state in ["backlog", "todo", "active"]:
                         dep_ids.append(str(name_to_enum_id[dep]))
                     else:
                         # Show task name and state for filtered out dependencies
@@ -630,7 +630,7 @@ def list_(sort, active_only, context, output_json, output_jsonl, pool_filter, ex
                     if dep in all_tasks_dict:
                         dep_task = all_tasks_dict[dep]
                         # If dependency is in filtered list, show its ID
-                        if not active_only or dep_task.state in ["backlog", "active"]:
+                        if not active_only or dep_task.state in ["backlog", "todo", "active"]:
                             dep_strs.append(f"{dep} ({name_to_enum_id[dep]})")
                         else:
                             # Show task name and state for filtered out dependencies
@@ -889,7 +889,7 @@ def check_directory(
             if p not in pool_totals:
                 pool_totals[p] = [0, 0]  # [total, actionable]
             pool_totals[p][0] += 1
-            if t.state in ("backlog", "active"):
+            if t.state in ("backlog", "todo", "active"):
                 pool_totals[p][1] += 1
         parts = ", ".join(
             f"{p}: {counts[0]} ({counts[1]} actionable)"
@@ -2378,11 +2378,13 @@ def tags(state: str | None, show_tasks: bool, filter_tags: tuple[str, ...]):
 @cli.command("ready")
 @click.option(
     "--state",
-    type=click.Choice(["backlog", "active", "ready_for_review", "someday", "both", "actionable"]),
+    type=click.Choice(
+        ["backlog", "todo", "active", "ready_for_review", "someday", "both", "actionable"]
+    ),
     default="both",
     help=(
-        "Filter by task state. 'both' = backlog+active (default, current behavior). "
-        "'actionable' = backlog+active+ready_for_review (everything locally workable). "
+        "Filter by task state. 'both' = backlog+todo+active (default). "
+        "'actionable' = backlog+todo+active+ready_for_review (everything locally workable). "
         "'ready_for_review' = only tasks awaiting local review/verification. "
         "'someday' = explicitly query deferred tasks."
     ),
@@ -2460,6 +2462,8 @@ def ready(state, output_json, output_jsonl, use_cache, pool_filter, exclude_pool
     # Filter by state first
     if state == "backlog":
         filtered_tasks = [task for task in all_tasks if task.state == "backlog"]
+    elif state == "todo":
+        filtered_tasks = [task for task in all_tasks if task.state == "todo"]
     elif state == "active":
         filtered_tasks = [task for task in all_tasks if task.state == "active"]
     elif state == "ready_for_review":
@@ -2468,10 +2472,12 @@ def ready(state, output_json, output_jsonl, use_cache, pool_filter, exclude_pool
         filtered_tasks = [task for task in all_tasks if task.state == "someday"]
     elif state == "actionable":
         filtered_tasks = [
-            task for task in all_tasks if task.state in ["backlog", "active", "ready_for_review"]
+            task
+            for task in all_tasks
+            if task.state in ["backlog", "todo", "active", "ready_for_review"]
         ]
     else:  # both
-        filtered_tasks = [task for task in all_tasks if task.state in ["backlog", "active"]]
+        filtered_tasks = [task for task in all_tasks if task.state in ["backlog", "todo", "active"]]
 
     # Apply pool filter (default: general only; --pool all to see every pool)
     filtered_tasks = [
@@ -2485,13 +2491,15 @@ def ready(state, output_json, output_jsonl, use_cache, pool_filter, exclude_pool
     if state == "ready_for_review":
         ready_tasks = [task for task in filtered_tasks if not task_has_waiting_blocker(task)]
     elif state == "actionable":
-        # backlog/active go through full is_task_ready; ready_for_review only needs waiting check
+        # backlog/todo/active go through full is_task_ready;
+        # ready_for_review only needs waiting check
         ready_tasks = [
             task
             for task in filtered_tasks
             if (task.state == "ready_for_review" and not task_has_waiting_blocker(task))
             or (
-                task.state in ["backlog", "active"] and is_task_ready(task, tasks_dict, issue_cache)
+                task.state in ["backlog", "todo", "active"]
+                and is_task_ready(task, tasks_dict, issue_cache)
             )
         ]
     else:
@@ -2649,7 +2657,7 @@ def next_(output_json, use_cache, pool_filter, exclude_pool):
         issue_cache = load_cache(cache_path)
 
     # Filter for new or active tasks
-    workable_tasks = [task for task in all_tasks if task.state in ["backlog", "active"]]
+    workable_tasks = [task for task in all_tasks if task.state in ["backlog", "todo", "active"]]
 
     # Apply pool filter (default: general only; --pool all to see every pool)
     workable_tasks = [

--- a/packages/gptodo/tests/test_ready_selection.py
+++ b/packages/gptodo/tests/test_ready_selection.py
@@ -327,3 +327,151 @@ def test_ready_for_review_not_silenced_by_stale_requires(tmp_path: Path, monkeyp
     payload = json.loads(payload_text)
     ids = [t["id"] for t in payload["ready_tasks"]]
     assert "review-task" in ids, "ready_for_review task must not be hidden by stale requires"
+
+
+def test_ready_default_includes_todo_tasks(tmp_path: Path, monkeypatch) -> None:
+    """`gptodo ready` (default) must surface todo tasks.
+
+    Regression: `todo` is canonical in VALID_TRANSITIONS (backlog → todo →
+    active) but was excluded from the default ready filter, so triaged
+    tasks were invisible to work selection until manually flipped to active.
+    """
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(
+        tasks_dir,
+        "triaged-task",
+        state="todo",
+        created="2026-07-06T00:00:00",
+    )
+    write_task(
+        tasks_dir,
+        "backlog-task",
+        state="backlog",
+        created="2026-07-06T01:00:00",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["ready", "--json"])
+
+    assert result.exit_code == 0
+    payload_text = result.output.split("\nNo ready tasks found", 1)[0]
+    payload = json.loads(payload_text)
+    ids = sorted(t["id"] for t in payload["ready_tasks"])
+    assert "triaged-task" in ids
+    assert "backlog-task" in ids
+
+
+def test_ready_actionable_includes_todo_tasks(tmp_path: Path, monkeypatch) -> None:
+    """`--state actionable` must include todo tasks (they are locally workable)."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(
+        tasks_dir,
+        "triaged-task",
+        state="todo",
+        created="2026-07-06T00:00:00",
+    )
+    write_task(
+        tasks_dir,
+        "review-task",
+        state="ready_for_review",
+        created="2026-07-06T01:00:00",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["ready", "--state", "actionable", "--json"])
+
+    assert result.exit_code == 0
+    payload_text = result.output.split("\nNo ready tasks found", 1)[0]
+    payload = json.loads(payload_text)
+    ids = sorted(t["id"] for t in payload["ready_tasks"])
+    assert ids == ["review-task", "triaged-task"]
+
+
+def test_ready_state_todo_filter(tmp_path: Path, monkeypatch) -> None:
+    """`--state todo` must be a valid explicit filter."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(
+        tasks_dir,
+        "triaged-task",
+        state="todo",
+        created="2026-07-06T00:00:00",
+    )
+    write_task(
+        tasks_dir,
+        "backlog-task",
+        state="backlog",
+        created="2026-07-06T01:00:00",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["ready", "--state", "todo", "--json"])
+
+    assert result.exit_code == 0
+    payload_text = result.output.split("\nNo ready tasks found", 1)[0]
+    payload = json.loads(payload_text)
+    ids = [t["id"] for t in payload["ready_tasks"]]
+    assert ids == ["triaged-task"]
+
+
+def test_ready_todo_task_still_respects_dependencies(tmp_path: Path, monkeypatch) -> None:
+    """A todo task blocked by an open dependency must NOT count as ready."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(
+        tasks_dir,
+        "blocked-todo",
+        state="todo",
+        created="2026-07-06T00:00:00",
+        requires=["open-dep"],
+    )
+    write_task(
+        tasks_dir,
+        "open-dep",
+        state="active",
+        created="2026-07-06T01:00:00",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["ready", "--json"])
+
+    assert result.exit_code == 0
+    payload_text = result.output.split("\nNo ready tasks found", 1)[0]
+    payload = json.loads(payload_text)
+    ids = [t["id"] for t in payload["ready_tasks"]]
+    assert "blocked-todo" not in ids
+    assert "open-dep" in ids
+
+
+def test_next_surfaces_todo_task(tmp_path: Path, monkeypatch) -> None:
+    """`gptodo next` must consider todo tasks as workable."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(
+        tasks_dir,
+        "triaged-task",
+        state="todo",
+        created="2026-07-06T00:00:00",
+        priority="high",
+    )
+    write_task(
+        tasks_dir,
+        "backlog-task",
+        state="backlog",
+        created="2026-07-06T01:00:00",
+        priority="low",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["next", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["next_task"]["id"] == "triaged-task"


### PR DESCRIPTION
## Problem

`todo` is a canonical state in `VALID_TRANSITIONS` (`backlog → todo → active`), and gptme/gptme-contrib#1183 already added it to the `status --compact` work funnel. But the work-selection commands still exclude it:

- `gptodo ready` default filter is `backlog+active`, so triaged tasks are invisible until manually flipped to `active`
- `ready --state actionable` (`backlog+active+ready_for_review`) skips `todo` despite it being locally workable
- `--state todo` isn't an accepted choice at all
- `gptodo next` only considers `backlog+active` as workable
- `list --active-only` (and its dependency-ID display) and the pool "actionable" counts have the same omission

In practice this makes agent work queues built on `ready --jsonl` silently empty when tasks sit in `todo` — that's how we hit it: our autonomous runner's queue came up empty while a batch of triaged `todo` tasks was waiting.

## Fix

Add `todo` to the open-work funnel in all of the filters above (same funnel definition #1183 used for `status --compact`). Dependency and `waiting_for` checks are unchanged — a blocked `todo` task still doesn't count as ready (covered by a test).

## Tests

5 regression tests added to `tests/test_ready_selection.py`; 4 of them fail without the fix (the fifth guards that dependency-blocking still applies to `todo` tasks). Full gptodo suite: 347 passed. `ruff check`/`ruff format` and package mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)