### PR TITLE
fix(daily-briefing): catch TypeError in collect_blockers when API returns non-list

### DIFF
--- a/packages/gptme-daily-briefing/src/gptme_daily_briefing/collectors.py
+++ b/packages/gptme-daily-briefing/src/gptme_daily_briefing/collectors.py
@@ -74,9 +74,12 @@ def collect_blockers(repo: str, label: str, limit: int = 6) -> list[str]:
         return []
     if not isinstance(data, list):
         return []
-    blockers = [
-        f"#{item['number']}: {item['title']}" for item in data if "pull_request" not in item
-    ]
+    try:
+        blockers = [
+            f"#{item['number']}: {item['title']}" for item in data if "pull_request" not in item
+        ]
+    except KeyError:
+        return []
     return blockers[:limit]
 
 

--- a/packages/gptme-daily-briefing/src/gptme_daily_briefing/collectors.py
+++ b/packages/gptme-daily-briefing/src/gptme_daily_briefing/collectors.py
@@ -69,14 +69,15 @@ def collect_blockers(repo: str, label: str, limit: int = 6) -> list[str]:
     if not out:
         return []
     try:
-        blockers = [
-            f"#{item['number']}: {item['title']}"
-            for item in json.loads(out)
-            if "pull_request" not in item
-        ]
-        return blockers[:limit]
-    except (json.JSONDecodeError, KeyError, TypeError):
+        data = json.loads(out)
+    except json.JSONDecodeError:
         return []
+    if not isinstance(data, list):
+        return []
+    blockers = [
+        f"#{item['number']}: {item['title']}" for item in data if "pull_request" not in item
+    ]
+    return blockers[:limit]
 
 
 def collect_active_tasks(workspace_root: Path, limit: int = 6) -> list[str]:

--- a/packages/gptme-daily-briefing/src/gptme_daily_briefing/collectors.py
+++ b/packages/gptme-daily-briefing/src/gptme_daily_briefing/collectors.py
@@ -75,7 +75,7 @@ def collect_blockers(repo: str, label: str, limit: int = 6) -> list[str]:
             if "pull_request" not in item
         ]
         return blockers[:limit]
-    except (json.JSONDecodeError, KeyError):
+    except (json.JSONDecodeError, KeyError, TypeError):
         return []
 
 


### PR DESCRIPTION
## Summary

- `collect_blockers()` crashes with `TypeError: string indices must be integers` when the GitHub API returns an error object (a dict like `{"message": "..."}`) instead of a list of issues
- Iterating over a dict yields string keys; `item['number']` then raises `TypeError` rather than `KeyError`, which the original except clause didn't catch
- Fix: add `TypeError` to the except tuple so the function returns `[]` gracefully on any malformed GitHub API response

## Root Cause

The briefing pipeline ran `bob-daily-briefing.service` and hit a GitHub API error response (e.g. rate-limited or transient 5xx). The JSON parsed successfully but returned a dict not a list. The except only covered `json.JSONDecodeError` and `KeyError`, letting `TypeError` propagate and crash the pipeline.

## Test plan
- [ ] Confirm `collect_blockers()` returns `[]` when API returns `{"message": "Not Found"}` or similar error dict
- [ ] Daily briefing service runs to completion after this fix