### PR TITLE
fix(subscription): add stale-cache fallback to check_usage()

### DIFF
--- a/packages/gptme-subscription/src/gptme_subscription/cli.py
+++ b/packages/gptme-subscription/src/gptme_subscription/cli.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+import tempfile
 from pathlib import Path
 
 from gptme_subscription.auth import (
@@ -503,7 +504,9 @@ def _cmd_evaluate(args: argparse.Namespace, sm: SubscriptionManager) -> int:
     active = sm.get_active_subscription()
     # Fall back to the per-slot stale cache when the live probe fails (e.g. lock
     # contention from a concurrent subscription-usage-history.py scrape).
-    stale_cache = Path(f"/tmp/claude-usage-{active}.json") if active else None
+    stale_cache = (
+        Path(tempfile.gettempdir()) / f"claude-usage-{active}.json" if active else None
+    )
     usage = sm.check_usage(stale_cache=stale_cache)
     rebalance_state = sm.load_rebalance_state()
     decision = sm.evaluate(usage, active, rebalance_state=rebalance_state)

--- a/packages/gptme-subscription/src/gptme_subscription/cli.py
+++ b/packages/gptme-subscription/src/gptme_subscription/cli.py
@@ -501,7 +501,10 @@ def _cmd_evaluate(args: argparse.Namespace, sm: SubscriptionManager) -> int:
     sm.detect_external_switch()
 
     active = sm.get_active_subscription()
-    usage = sm.check_usage()
+    # Fall back to the per-slot stale cache when the live probe fails (e.g. lock
+    # contention from a concurrent subscription-usage-history.py scrape).
+    stale_cache = Path(f"/tmp/claude-usage-{active}.json") if active else None
+    usage = sm.check_usage(stale_cache=stale_cache)
     rebalance_state = sm.load_rebalance_state()
     decision = sm.evaluate(usage, active, rebalance_state=rebalance_state)
     decision_dict = decision.to_dict()

--- a/packages/gptme-subscription/src/gptme_subscription/manager.py
+++ b/packages/gptme-subscription/src/gptme_subscription/manager.py
@@ -256,7 +256,17 @@ class SubscriptionManager:
 
     # ---- Usage check ----
 
-    def check_usage(self, no_cache: bool = False) -> dict[str, Any] | None:
+    def check_usage(
+        self, no_cache: bool = False, stale_cache: Path | None = None
+    ) -> dict[str, Any] | None:
+        """Return usage data, with optional stale-cache fallback on lock contention.
+
+        When the usage script fails (e.g. `/tmp/claude-usage-scrape.lock` held
+        by a concurrent ``subscription-usage-history.py`` run), passing
+        ``stale_cache`` causes us to fall back to the last-known-good JSON file
+        instead of propagating ``None`` to the caller.  The caller decides which
+        slot file to use; ``cli._cmd_evaluate`` passes the active-slot path.
+        """
         script = self.config.usage_script
         if script is None or not script.exists():
             return None
@@ -269,6 +279,14 @@ class SubscriptionManager:
                 return dict(json.loads(result.stdout))
         except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError):
             pass
+        # Stale-cache fallback: prefer a degraded reading over "could not check usage"
+        if stale_cache is not None and stale_cache.exists():
+            try:
+                data = json.loads(stale_cache.read_text())
+                if data.get("_ok"):
+                    return dict(data)
+            except (json.JSONDecodeError, OSError):
+                pass
         return None
 
     # ---- Rate limit ----

--- a/packages/gptme-subscription/src/gptme_subscription/manager.py
+++ b/packages/gptme-subscription/src/gptme_subscription/manager.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import glob
 import json
+import logging
 import os
 import re
 import subprocess
@@ -30,6 +31,8 @@ from gptme_subscription.observation import (
 from gptme_subscription.routing import (
     compute_window_pacing,
 )
+
+logger = logging.getLogger(__name__)
 
 # ---- Public types ----
 
@@ -280,11 +283,28 @@ class SubscriptionManager:
         except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError):
             pass
         # Stale-cache fallback: prefer a degraded reading over "could not check usage"
+        _STALE_MAX_AGE_S = 4 * 3600  # 4 hours — don't route on an ancient snapshot
         if stale_cache is not None and stale_cache.exists():
             try:
-                data = json.loads(stale_cache.read_text())
-                if data.get("_ok"):
-                    return dict(data)
+                age_s = (
+                    datetime.now(tz=timezone.utc).timestamp()
+                    - stale_cache.stat().st_mtime
+                )
+                if age_s > _STALE_MAX_AGE_S:
+                    logger.warning(
+                        "check_usage: stale cache %s is %.0fh old (max %.0fh) — skipping",
+                        stale_cache,
+                        age_s / 3600,
+                        _STALE_MAX_AGE_S / 3600,
+                    )
+                else:
+                    data = json.loads(stale_cache.read_text())
+                    if data.get("_ok"):
+                        logger.warning(
+                            "check_usage: live probe failed, returning stale cache (age %.0fs)",
+                            age_s,
+                        )
+                        return {**data, "_stale": True}
             except (json.JSONDecodeError, OSError):
                 pass
         return None

--- a/packages/gptme-subscription/src/gptme_subscription/manager.py
+++ b/packages/gptme-subscription/src/gptme_subscription/manager.py
@@ -628,6 +628,7 @@ class SubscriptionManager:
             active
             and isinstance(_weekly_resets_in, int | float)
             and _weekly_resets_in > 0
+            and not usage.get("_stale")
         ):
             self.record_sub_reset_time(active, float(_weekly_resets_in), usage)
 

--- a/packages/gptme-subscription/tests/test_cli.py
+++ b/packages/gptme-subscription/tests/test_cli.py
@@ -79,7 +79,9 @@ class FakeManager:
     def get_active_subscription(self) -> str:
         return self._active
 
-    def check_usage(self, no_cache: bool = False) -> dict[str, object]:
+    def check_usage(
+        self, no_cache: bool = False, stale_cache: Path | None = None
+    ) -> dict[str, object]:
         self.check_usage_calls.append(no_cache)
         return self._post_switch_usage if no_cache else self._initial_usage
 

--- a/packages/gptme-subscription/tests/test_subscription_manager.py
+++ b/packages/gptme-subscription/tests/test_subscription_manager.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import os
+import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -80,6 +82,26 @@ def test_check_usage_stale_cache_fallback_on_script_failure(tmp_path: Path) -> N
     result = sm.check_usage(stale_cache=stale_cache)
     assert result is not None
     assert result["seven_day"]["utilization"] == pytest.approx(0.3)
+    assert (
+        result.get("_stale") is True
+    ), "stale fallback must be flagged with _stale=True"
+
+
+def test_check_usage_stale_cache_rejected_when_too_old(tmp_path: Path) -> None:
+    usage_script = tmp_path / "check-usage.sh"
+    usage_script.write_text("#!/bin/sh\nexec ''  # always fail\n")
+    usage_script.chmod(0o755)
+    sm = _make_manager(tmp_path, usage_script=usage_script)
+
+    stale_data = {"seven_day": {"utilization": 0.3}, "_ok": True}
+    stale_cache = tmp_path / "stale-old.json"
+    stale_cache.write_text(json.dumps(stale_data))
+    # Back-date the file past the 4-hour max-age limit
+    old_mtime = time.time() - (5 * 3600)
+    os.utime(stale_cache, (old_mtime, old_mtime))
+
+    # Cache is too old → must not be used even though _ok=True
+    assert sm.check_usage(stale_cache=stale_cache) is None
 
 
 def test_check_usage_stale_cache_not_used_when_script_succeeds(tmp_path: Path) -> None:

--- a/packages/gptme-subscription/tests/test_subscription_manager.py
+++ b/packages/gptme-subscription/tests/test_subscription_manager.py
@@ -233,6 +233,28 @@ def test_evaluate_records_observation_for_active_primary(tmp_path: Path) -> None
     assert entry["sonnet_weekly_utilization"] == pytest.approx(0.30)
 
 
+def test_evaluate_does_not_record_observation_for_stale_usage(
+    tmp_path: Path,
+) -> None:
+    """``evaluate`` must skip ``record_sub_reset_time`` when usage came from the
+    stale-cache fallback.  Stale ``resets_in_seconds`` stamped against ``now``
+    computes a reset deadline hours too far in the future.
+    """
+    sm = _make_manager(tmp_path)
+    usage = {
+        "seven_day": {"utilization": 0.42, "resets_in_seconds": 3 * 24 * 3600},
+        "five_hour": {"utilization": 0.10, "resets_in_seconds": 3 * 3600},
+        "seven_day_sonnet": {"utilization": 0.30},
+        "_stale": True,
+    }
+
+    sm.evaluate(usage, "bob")
+
+    assert (
+        not sm.config.reset_times_file.exists()
+    ), "record_sub_reset_time must not be called when usage._stale=True"
+
+
 def test_evaluate_skips_stale_fallback_picks_fresh(tmp_path: Path) -> None:
     sm = _make_manager(tmp_path)
     # alice is stale (17 days), erik is fresh

--- a/packages/gptme-subscription/tests/test_subscription_manager.py
+++ b/packages/gptme-subscription/tests/test_subscription_manager.py
@@ -61,6 +61,62 @@ def test_check_usage_returns_none_for_non_executable_script(tmp_path: Path) -> N
     assert sm.check_usage() is None
 
 
+def test_check_usage_stale_cache_fallback_on_script_failure(tmp_path: Path) -> None:
+    # Script exists but is not executable → simulates lock-contention failure
+    usage_script = tmp_path / "check-usage.sh"
+    usage_script.write_text("#!/bin/sh\necho '{}'\n")
+    usage_script.chmod(0o644)
+    sm = _make_manager(tmp_path, usage_script=usage_script)
+
+    stale_data = {
+        "seven_day": {"utilization": 0.3},
+        "five_hour": {"utilization": 0.1},
+        "_ok": True,
+        "_sub": "bob",
+    }
+    stale_cache = tmp_path / "stale-bob.json"
+    stale_cache.write_text(json.dumps(stale_data))
+
+    result = sm.check_usage(stale_cache=stale_cache)
+    assert result is not None
+    assert result["seven_day"]["utilization"] == pytest.approx(0.3)
+
+
+def test_check_usage_stale_cache_not_used_when_script_succeeds(tmp_path: Path) -> None:
+    fresh_data = {"seven_day": {"utilization": 0.9}, "five_hour": {"utilization": 0.5}}
+    usage_script = tmp_path / "check-usage.sh"
+    usage_script.write_text(f"#!/bin/sh\necho '{json.dumps(fresh_data)}'\n")
+    usage_script.chmod(0o755)
+    sm = _make_manager(tmp_path, usage_script=usage_script)
+
+    stale_data = {
+        "seven_day": {"utilization": 0.1},
+        "five_hour": {"utilization": 0.0},
+        "_ok": True,
+    }
+    stale_cache = tmp_path / "stale.json"
+    stale_cache.write_text(json.dumps(stale_data))
+
+    result = sm.check_usage(stale_cache=stale_cache)
+    # Should return the fresh result, not the stale fallback
+    assert result is not None
+    assert result["seven_day"]["utilization"] == pytest.approx(0.9)
+
+
+def test_check_usage_stale_cache_skipped_when_not_ok(tmp_path: Path) -> None:
+    usage_script = tmp_path / "check-usage.sh"
+    usage_script.write_text("#!/bin/sh\nexit 1\n")
+    usage_script.chmod(0o755)
+    sm = _make_manager(tmp_path, usage_script=usage_script)
+
+    stale_data = {"seven_day": {"utilization": 0.5}, "_ok": False}
+    stale_cache = tmp_path / "stale.json"
+    stale_cache.write_text(json.dumps(stale_data))
+
+    # _ok=False → stale cache should not be used
+    assert sm.check_usage(stale_cache=stale_cache) is None
+
+
 def test_detect_external_switch_ignores_unreadable_log(tmp_path: Path) -> None:
     sm = _make_manager(tmp_path)
     sm.config.switch_log.mkdir()


### PR DESCRIPTION
## Problem

`manage-subscription.py --execute` intermittently returns \"could not check usage\" when the usage script fails due to lock contention — `/tmp/claude-usage-scrape.lock` held by a concurrent `subscription-usage-history.py` scraping run. This causes `check_decision()` to fall through to \"stay, could not check usage\" even when a recent valid reading is available on disk.

## Fix

Add optional `stale_cache: Path | None = None` parameter to `check_usage()`. When the live probe fails, fall back to the last-known-good JSON file **only when** `_ok: True` is present (a prior valid reading). The caller decides which slot file to use; `cli._cmd_evaluate()` passes `/tmp/claude-usage-<active>.json`.

The fallback is degraded but better than returning `None` — the subscriber can still make a routing decision based on the most recent valid reading.

## Changes

- `manager.py`: `check_usage()` gains `stale_cache` param with fallback guarded by `_ok`
- `cli.py`: `_cmd_evaluate()` computes per-slot stale path and passes it through
- `tests/test_subscription_manager.py`: 3 new tests covering fallback on failure, fresh-beats-stale, and `_ok=False` guard

## Test plan

- [x] All 22 tests pass (`uv run pytest packages/gptme-subscription/`)
- [x] Stale cache is NOT used when fresh probe succeeds
- [x] Stale cache is NOT used when `_ok=False`
- [x] Stale cache IS used when live probe fails and `_ok=True`