### PR TITLE
fix(activity-gate): suppress merge_ready churn on pull-only repos

### DIFF
--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -923,9 +923,11 @@ has_maintainer_waiting_comment() {
 # session can't merge and has nothing else to do), so merge_ready should be
 # suppressed there and handed to a maintainer instead.
 #
-# FAIL-OPEN: on any API error or unexpected output we return 0 (assume mergeable)
-# so a transient gh failure never silently hides a genuinely mergeable PR. The
-# cost is one bounded gh call per repo per cycle (cached by the caller).
+# FAIL-OPEN: on any API error or unexpected output we return 0 (assume the bot
+# can merge), so an API failure doesn't silently suppress a genuinely mergeable
+# PR. Stderr is swallowed intentionally — API blips are transient, and noise on
+# every cycle is worse than a missed permission downgrade (the next cycle retries).
+# Cost: one bounded gh call per repo per cycle (cached by the caller).
 bot_can_merge() {
     local repo=$1
     local can
@@ -1059,10 +1061,13 @@ check_merge_ready() {
         fi
         if [ "$bot_lacks_merge" = "1" ]; then
             # Only post from a real (jsonl) dispatch pass, not a markdown preview.
+            # Only write the state file when the comment is actually posted: in
+            # markdown mode we skip without writing, so the next jsonl run still
+            # sees this PR as fresh and can post the maintainer-waiting comment.
             if [ "$FORMAT" = "jsonl" ]; then
                 post_maintainer_waiting_comment "$repo" "$pr_number" "$greptile_score"
+                echo "${head_sha}:${now}" > "$state_file"
             fi
-            echo "${head_sha}:${now}" > "$state_file"
             continue
         fi
 

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -915,6 +915,47 @@ has_maintainer_waiting_comment() {
     return 1
 }
 
+# Return 0 if the bot account has merge permission on $repo, 1 if it does not.
+#
+# A bot contributing to an external/upstream repo via a fork typically has
+# pull-only access — it can open PRs but can NEVER self-merge. Dispatching a
+# monitoring session for a merge-ready PR on such a repo is always a NOOP (the
+# session can't merge and has nothing else to do), so merge_ready should be
+# suppressed there and handed to a maintainer instead.
+#
+# FAIL-OPEN: on any API error or unexpected output we return 0 (assume mergeable)
+# so a transient gh failure never silently hides a genuinely mergeable PR. The
+# cost is one bounded gh call per repo per cycle (cached by the caller).
+bot_can_merge() {
+    local repo=$1
+    local can
+    can=$(gh api "repos/$repo" \
+        --jq '.permissions | ((.push // false) or (.maintain // false) or (.admin // false))' \
+        2>/dev/null) || return 0
+    [ "$can" = "true" ]
+}
+
+# Post a one-time "waiting only on a maintainer click" status comment on a
+# merge-ready PR the bot cannot self-merge (pull-only access to an external
+# repo). This does two things at once:
+#   1. Surfaces the ready PR to the maintainer (optionally @-mentioning
+#      $MAINTAINER_HANDLE) so the ready-to-merge backlog is visible.
+#   2. Arms has_maintainer_waiting_comment (the comment contains the canonical
+#      anchor phrase), so subsequent cycles suppress the re-emit churn.
+# Best-effort: a failed comment post is non-fatal (the next cycle retries).
+post_maintainer_waiting_comment() {
+    local repo=$1 number=$2 score=$3
+    local mention=""
+    [ -n "${MAINTAINER_HANDLE:-}" ] && mention="@${MAINTAINER_HANDLE} "
+    local greptile_note=""
+    [ -n "$score" ] && [ "$score" != "null" ] && greptile_note=" (Greptile ${score}/5)"
+    local body
+    body="CI-green and mergeable${greptile_note} — **waiting only on a maintainer click**.
+
+${mention}This PR is ready to merge, but the bot has pull-only access to this repo and can't self-merge — surfacing it here so it isn't lost. The monitoring loop will stop re-flagging it now that this note is posted."
+    gh pr comment "$number" --repo "$repo" --body "$body" >/dev/null 2>&1 || true
+}
+
 # Find PRs that are ready to merge: CI green, no conflicts, and Greptile score
 # is acceptable (>= 5/5, or no Greptile review at all for simple PRs).
 #
@@ -930,9 +971,17 @@ has_maintainer_waiting_comment() {
 # that HEAD even after the cooldown expires. The state file is still bumped so
 # subsequent runs follow the normal cooldown path once a new HEAD arrives.
 #
+# Permission suppression: If the bot lacks merge permission on the repo (pull-only
+# access to an external/upstream repo), it can never self-merge, so a dispatched
+# session is always a NOOP. Instead of emitting (and re-emitting every cooldown),
+# we post a one-time maintainer-waiting comment (see post_maintainer_waiting_comment)
+# to surface the ready PR to a human, then suppress — the comment arms
+# has_maintainer_waiting_comment so future cycles take the suppression path above.
+#
 # API cost: +1 comments fetch per CLEAN/MERGEABLE candidate that passes the
-# Greptile and cooldown gates. Typical workload is a handful of PRs per cycle,
-# so the added cost is negligible compared to the existing PR search calls.
+# Greptile and cooldown gates, plus +1 permissions fetch per repo (once per cycle,
+# only when the repo has such a candidate). Typical workload is a handful of PRs
+# per cycle, so the added cost is negligible compared to the existing PR search calls.
 check_merge_ready() {
     local repo=$1
     local prs=$2
@@ -940,6 +989,12 @@ check_merge_ready() {
 
     local repo_safe="${repo//\//-}"
     local cooldown_seconds=43200  # 12 hours
+
+    # Resolve merge permission once per repo (not per PR): pull-only repos can
+    # never self-merge, so their ready PRs are handed to a maintainer instead of
+    # dispatched as NOOP sessions. Computed lazily below on first candidate so a
+    # repo with zero merge-ready PRs pays no permission-check cost.
+    local bot_lacks_merge=""  # "": unknown, "0": can merge, "1": cannot
 
     # Filter to PRs with CLEAN merge state and MERGEABLE status
     echo "$prs" | jq -c '.[] | select(.mergeStateStatus == "CLEAN" and .mergeable == "MERGEABLE")' | while read -r pr_data; do
@@ -990,6 +1045,23 @@ check_merge_ready() {
         # new review, CI change that forces the "waiting" comment to be
         # refreshed into a different status).
         if has_maintainer_waiting_comment "$repo" "$pr_number"; then
+            echo "${head_sha}:${now}" > "$state_file"
+            continue
+        fi
+
+        # Permission suppression: if the bot can't self-merge this repo (pull-only
+        # access), emitting merge_ready only dispatches a NOOP session. Instead,
+        # surface the ready PR to a maintainer once (which also arms the comment
+        # suppression above for future cycles), then skip the emit. Permission is
+        # per-repo, so resolve it lazily on the first candidate and reuse.
+        if [ -z "$bot_lacks_merge" ]; then
+            if bot_can_merge "$repo"; then bot_lacks_merge="0"; else bot_lacks_merge="1"; fi
+        fi
+        if [ "$bot_lacks_merge" = "1" ]; then
+            # Only post from a real (jsonl) dispatch pass, not a markdown preview.
+            if [ "$FORMAT" = "jsonl" ]; then
+                post_maintainer_waiting_comment "$repo" "$pr_number" "$greptile_score"
+            fi
             echo "${head_sha}:${now}" > "$state_file"
             continue
         fi

--- a/tests/test_activity_gate_merge_permission.py
+++ b/tests/test_activity_gate_merge_permission.py
@@ -93,7 +93,12 @@ sys.exit(0)
 
 
 def _run_gate(
-    tmp: Path, state_dir: Path, *, can_merge: str, marker: Path
+    tmp: Path,
+    state_dir: Path,
+    *,
+    can_merge: str,
+    marker: Path,
+    fmt: str = "jsonl",
 ) -> subprocess.CompletedProcess[str]:
     fake_gh = tmp / "gh"
     fake_gh.write_text(FAKE_GH)
@@ -119,7 +124,7 @@ def _run_gate(
             "--state-dir",
             str(state_dir),
             "--format",
-            "jsonl",
+            fmt,
         ],
         capture_output=True,
         text=True,
@@ -154,3 +159,41 @@ def test_mergeable_repo_still_emits_merge_ready() -> None:
         assert result.returncode in (0, 1), result.stderr
         assert "merge_ready" in result.stdout, result.stdout
         assert not marker.exists(), "no maintainer comment should be posted"
+
+
+def test_markdown_mode_does_not_write_state_file() -> None:
+    """In markdown preview mode, pull-only repos must NOT write the state file.
+
+    If the state file were written during a markdown pass, the subsequent jsonl
+    dispatch pass (the one that actually posts comments and emits items) would
+    see the state file within its 12 h cooldown window and skip the PR entirely
+    — the maintainer-waiting comment would never be posted.
+    """
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+        marker = tmp / "comment_marker"
+
+        # First pass: markdown mode (preview) — pull-only repo
+        result = _run_gate(
+            tmp, state_dir, can_merge="false", marker=marker, fmt="markdown"
+        )
+        assert result.returncode in (0, 1), result.stderr
+        assert "merge_ready" not in result.stdout
+
+        # No comment should be posted in markdown mode
+        assert not marker.exists(), "no comment should be posted in markdown mode"
+
+        # No state file should be written — the next jsonl pass must still fire
+        state_files = list(state_dir.glob("*-merge-ready.state"))
+        assert not state_files, f"state file written during markdown pass; next jsonl run would skip the PR: {state_files}"
+
+        # Second pass: jsonl mode — NOW the comment should be posted
+        result2 = _run_gate(
+            tmp, state_dir, can_merge="false", marker=marker, fmt="jsonl"
+        )
+        assert result2.returncode in (0, 1), result2.stderr
+        assert "merge_ready" not in result2.stdout
+        assert marker.exists(), "jsonl run must post the maintainer-waiting comment"
+        assert marker.read_text().count("comment:") == 1, marker.read_text()

--- a/tests/test_activity_gate_merge_permission.py
+++ b/tests/test_activity_gate_merge_permission.py
@@ -1,0 +1,156 @@
+"""Regression tests for merge-permission suppression in activity-gate.sh.
+
+A merge-ready PR on a repo where the bot has pull-only access (e.g. an external
+upstream contributed to via a fork) can NEVER be self-merged, so dispatching a
+monitoring session for it is always a NOOP. check_merge_ready must instead post a
+one-time maintainer-waiting comment (surfacing the ready PR to a human and arming
+has_maintainer_waiting_comment) and suppress the emit. On a repo the bot CAN
+merge, merge_ready must still emit as normal.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "github" / "activity-gate.sh"
+
+TEST_REPO = "testorg/testrepo"
+TEST_PR = 42
+TEST_HEAD_SHA = "deadbeef1234"
+
+# Fake gh: drives check_merge_ready. Permission is env-controlled (TEST_CAN_MERGE),
+# the PR is CLEAN/MERGEABLE, there are no prior bot comments (so the existing
+# comment-suppression does not fire), and `pr comment` records to COMMENT_MARKER.
+FAKE_GH = r"""#!/usr/bin/env python3
+from __future__ import annotations
+import os, sys, json
+
+argv = sys.argv[1:]
+repo = os.environ.get("TEST_REPO", "testorg/testrepo")
+pr_number = int(os.environ.get("TEST_PR_NUMBER", "42"))
+head_sha = os.environ.get("TEST_HEAD_SHA", "abc123")
+can_merge = os.environ.get("TEST_CAN_MERGE", "true")
+marker = os.environ.get("COMMENT_MARKER", "")
+
+if not argv:
+    sys.exit(2)
+
+# `gh pr comment <n> --repo R --body ...` — record that a comment was posted.
+if argv[0] == "pr" and len(argv) > 1 and argv[1] == "comment":
+    if marker:
+        with open(marker, "a") as fh:
+            fh.write("comment:%s\n" % (argv[2] if len(argv) > 2 else "?"))
+    sys.exit(0)
+
+if argv[0] == "pr" and len(argv) > 1 and argv[1] == "list":
+    pr = [{
+        "number": pr_number,
+        "title": "Test PR #%d" % pr_number,
+        "updatedAt": "2026-06-12T00:00:00Z",
+        "comments": [],
+        "latestReviews": [],
+        "statusCheckRollup": None,
+        "mergeable": "MERGEABLE",
+        "mergeStateStatus": "CLEAN",
+        "headRefOid": head_sha,
+        "isDraft": False,
+    }]
+    print(json.dumps(pr))
+    sys.exit(0)
+
+if argv[0] == "repo" and len(argv) > 1 and argv[1] == "list":
+    sys.exit(0)
+
+if argv[0] in ("issue", "run") and len(argv) > 1 and argv[1] == "list":
+    print("[]")
+    sys.exit(0)
+
+if argv[0] == "api" and len(argv) > 1 and argv[1] == "notifications":
+    sys.exit(0)
+
+if argv[0] == "api" and len(argv) > 1:
+    path = argv[1]
+    jq = argv[argv.index("--jq") + 1] if "--jq" in argv else ""
+    # Permission probe: `gh api repos/<repo> --jq '.permissions | ...'`
+    if path == "repos/" + repo and "permissions" in jq:
+        print(can_merge)
+        sys.exit(0)
+    # Bot comment history (has_maintainer_waiting_comment) — no prior comments.
+    if "comments" in path:
+        sys.exit(0)
+    if "--jq" in argv:
+        sys.exit(0)
+    print("[]")
+    sys.exit(0)
+
+sys.exit(0)
+"""
+
+
+def _run_gate(
+    tmp: Path, state_dir: Path, *, can_merge: str, marker: Path
+) -> subprocess.CompletedProcess[str]:
+    fake_gh = tmp / "gh"
+    fake_gh.write_text(FAKE_GH)
+    fake_gh.chmod(fake_gh.stat().st_mode | stat.S_IXUSR)
+
+    env = os.environ.copy()
+    env["TEST_REPO"] = TEST_REPO
+    env["TEST_PR_NUMBER"] = str(TEST_PR)
+    env["TEST_HEAD_SHA"] = TEST_HEAD_SHA
+    env["TEST_CAN_MERGE"] = can_merge
+    env["COMMENT_MARKER"] = str(marker)
+    env["PATH"] = f"{tmp}:{env['PATH']}"
+
+    return subprocess.run(
+        [
+            str(SCRIPT),
+            "--author",
+            "test-author",
+            "--org",
+            "testorg",
+            "--repo",
+            TEST_REPO,
+            "--state-dir",
+            str(state_dir),
+            "--format",
+            "jsonl",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_pull_only_repo_suppresses_merge_ready_and_posts_comment() -> None:
+    """Bot lacks merge permission → no merge_ready emit, one maintainer comment."""
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+        marker = tmp / "comment_marker"
+
+        result = _run_gate(tmp, state_dir, can_merge="false", marker=marker)
+        assert result.returncode in (0, 1), result.stderr
+        assert "merge_ready" not in result.stdout, result.stdout
+        assert marker.exists(), "expected a maintainer-waiting comment to be posted"
+        assert marker.read_text().count("comment:") == 1, marker.read_text()
+
+
+def test_mergeable_repo_still_emits_merge_ready() -> None:
+    """Bot has merge permission → merge_ready emits, no comment posted."""
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+        marker = tmp / "comment_marker"
+
+        result = _run_gate(tmp, state_dir, can_merge="true", marker=marker)
+        assert result.returncode in (0, 1), result.stderr
+        assert "merge_ready" in result.stdout, result.stdout
+        assert not marker.exists(), "no maintainer comment should be posted"


### PR DESCRIPTION
## Problem

`check_merge_ready` in `activity-gate.sh` emits a `merge_ready` work item for any CLEAN + MERGEABLE + Greptile-passing PR. But on a repo where the bot has **pull-only access** (an external/upstream repo contributed to via a fork), the bot can *never* self-merge — so every emitted `merge_ready` dispatches a monitoring session that has nothing it can do (a NOOP), and the item re-emits every 12h cooldown forever.

The existing anti-churn guard (`has_maintainer_waiting_comment`) only suppresses once a *"waiting only on a maintainer click"* comment already exists — but nothing posted one, so the loop never converged. Observed live: 4 aw-webui PRs (bot has `pull:true` only) re-emitting on the 12h cadence with 0 maintainer-waiting comments despite 3–11 bot comments each.

## Fix

- **`bot_can_merge <repo>`** — probes `repos/<repo>` permissions (`push`/`maintain`/`admin`). **Fail-open**: on any API error it returns "can merge" so a transient `gh` failure never silently hides a genuinely mergeable PR.
- **`post_maintainer_waiting_comment`** — posts a one-time status comment containing the canonical *"waiting only on a maintainer click"* anchor (optionally `@`-mentioning `$MAINTAINER_HANDLE`). This both **surfaces the ready PR to a human** and **arms `has_maintainer_waiting_comment`** so future cycles take the existing suppression path.
- **`check_merge_ready`** — resolves permission once per repo (lazily, only when a candidate exists), and when the bot lacks merge permission, posts the comment (jsonl/dispatch pass only) + skips the emit.

Repos the bot *can* merge are unaffected — `merge_ready` still emits as normal.

### Why at the gate

The gate runs **upstream of the backend split**, so this one change fixes the churn on both the shell (claude-code) and Python `run_loops` (gptme) monitoring paths, and forks inherit it via the already-parameterized `BOT_USERNAME` / new optional `MAINTAINER_HANDLE`.

## Tests

`tests/test_activity_gate_merge_permission.py`:
- pull-only repo → **no** `merge_ready` emit + exactly one maintainer-waiting comment posted
- mergeable repo → `merge_ready` **still emits**, no comment

`shellcheck` clean. Existing activity-gate tests unchanged (the one pre-existing `test_activity_gate_notif_followup` failure reproduces on master without this change).

## API cost

+1 permissions fetch per repo per cycle, only when that repo has a merge-ready candidate — negligible vs the existing PR-search calls.