### PR TITLE
feat(git-hooks): validate commit identity in the global pre-commit hook

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,15 @@
+# Canonicalize commit attribution (display-only; does not rewrite history).
+#
+# Bob's canonical identity is `Bob <bob@superuserlabs.org>`. Historical drift put
+# some commits under non-canonical identities:
+#   - timetolearnbob@gmail.com — a typo-blend of Bob's two real accounts, from a
+#     repo-local user.email override that shadowed the correct global config
+#     (fixed by the global identity guard, gptme-contrib#1245).
+#   - Bob <timetolearnalice@gmail.com> — Bob-authored commits that went out under
+#     Alice's email. Mapped by NAME+email so Alice's own commits are untouched.
+#   - timetobuildbob@gmail.com / GitHub noreply — valid alternate Bob identities,
+#     consolidated for clean `git shortlog` / attribution.
+Bob <bob@superuserlabs.org> <timetolearnbob@gmail.com>
+Bob <bob@superuserlabs.org> Bob <timetolearnalice@gmail.com>
+Bob <bob@superuserlabs.org> <timetobuildbob@gmail.com>
+Bob <bob@superuserlabs.org> <189876176+TimeToBuildBob@users.noreply.github.com>

--- a/dotfiles/.config/git/hooks/pre-commit
+++ b/dotfiles/.config/git/hooks/pre-commit
@@ -53,6 +53,43 @@ else
     fi
 fi
 
+# --- Part 0.5: Validate git commit identity (~1ms, runs unconditionally) ---
+# Guards against a repo-local user.email override that shadows the correct global
+# identity. Historical corruption: bob@timetobuildbob.com and timetolearnbob@gmail.com
+# (typo-blends of Bob's two real identities) landed in submodules/worktrees whose
+# local config overrode ~/.gitconfig. The brain repo enforces this via prek, but
+# that only covers the brain — this GLOBAL hook covers EVERY repo Bob commits in
+# (submodules like gptme-contrib, projects/*, /tmp worktrees).
+# Bypass (rare, deliberate): ALLOW_GIT_IDENTITY=1 git commit ...
+# Forkable: an optional allowed-identities.conf (next to allowed-repos.conf) may
+# define IDENTITY_ALLOWLIST=(...) to override the built-in Bob defaults.
+if [ "${ALLOW_GIT_IDENTITY:-0}" != "1" ]; then
+    IDENTITY_ALLOWLIST=(
+        "bob@superuserlabs.org"
+        "timetobuildbob@gmail.com"
+    )
+    # shellcheck source=/dev/null
+    source "$HOOK_DIR/../allowed-identities.conf" 2>/dev/null || true
+    COMMIT_EMAIL="$(git config user.email 2>/dev/null || echo "")"
+    if [ -z "$COMMIT_EMAIL" ]; then
+        echo -e "${RED}ABORT: git user.email is not set — refusing to commit with an unknown identity.${NC}"
+        echo    "   Fix: git config user.email bob@superuserlabs.org"
+        exit 1
+    fi
+    _identity_ok=false
+    for _allowed in "${IDENTITY_ALLOWLIST[@]}"; do
+        [ "$COMMIT_EMAIL" = "$_allowed" ] && { _identity_ok=true; break; }
+    done
+    if [ "$_identity_ok" != "true" ]; then
+        echo -e "${RED}ABORT: git user.email '${COMMIT_EMAIL}' is NOT an allowed identity.${NC}"
+        echo    "   Allowed: ${IDENTITY_ALLOWLIST[*]}"
+        echo    "   This usually means a repo-local config override shadowed the correct global identity."
+        echo    "   Fix in THIS repo:  git config user.email bob@superuserlabs.org"
+        echo    "   (bypass if truly intended: ALLOW_GIT_IDENTITY=1 git commit ...)"
+        exit 1
+    fi
+fi
+
 # --- Part 1: Prevent master commits (allowlist approach) ---
 # By default, master/main commits are blocked in ALL repos.
 # Only repos matching ALLOWED_PATTERNS or detected as agent workspaces are allowed.

--- a/tests/integration/test_git_hooks.py
+++ b/tests/integration/test_git_hooks.py
@@ -310,6 +310,100 @@ def test_hooks_exist():
     assert (HOOKS_DIR / "pre-commit").exists(), "pre-commit hook not found"
 
 
+def run_pre_commit_hook(repo_path: Path, email: str) -> subprocess.CompletedProcess:
+    """Stage a change and invoke the pre-commit hook directly with a given
+    committing identity. Runs the hook script directly (the fixture disables
+    core.hooksPath) so we exercise the hook logic, not git's dispatch."""
+    hook_path = repo_path / ".git" / "hooks" / "pre-commit"
+    if not hook_path.exists():
+        pytest.skip("pre-commit hook not found")
+
+    clean_env = _clean_git_env()
+    # Put the repo on a feature branch so the master-commit guard is not the
+    # thing that aborts (we want to isolate the identity check).
+    subprocess.run(
+        ["git", "checkout", "-q", "-b", "feature-identity-test"],
+        cwd=repo_path,
+        capture_output=True,
+        env=clean_env,
+    )
+    subprocess.run(
+        ["git", "config", "--local", "user.email", email],
+        cwd=repo_path,
+        check=True,
+        capture_output=True,
+        env=clean_env,
+    )
+    (repo_path / "change.txt").write_text("content")
+    subprocess.run(
+        ["git", "add", "change.txt"],
+        cwd=repo_path,
+        check=True,
+        capture_output=True,
+        env=clean_env,
+    )
+    return subprocess.run(
+        ["bash", str(hook_path)],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+        env=clean_env,
+    )
+
+
+class TestGitIdentityValidation:
+    """Part 0.5 of the pre-commit hook: block non-allowlisted commit identities."""
+
+    def test_disallowed_email_is_blocked(self, hook_env):
+        """A typo-blend / wrong identity (the historical corruption) must abort."""
+        result = run_pre_commit_hook(hook_env, "timetolearnbob@gmail.com")
+        assert result.returncode != 0
+        assert "NOT an allowed identity" in (result.stdout + result.stderr)
+
+    def test_allowed_email_passes_identity_check(self, hook_env):
+        """A canonical Bob identity must NOT trip the identity guard."""
+        result = run_pre_commit_hook(hook_env, "bob@superuserlabs.org")
+        # The hook may exit non-zero for unrelated later parts (e.g. no prek),
+        # but the identity guard specifically must not fire.
+        assert "NOT an allowed identity" not in (result.stdout + result.stderr)
+        assert "user.email is not set" not in (result.stdout + result.stderr)
+
+    def test_bypass_env_skips_identity_check(self, hook_env):
+        """ALLOW_GIT_IDENTITY=1 skips the guard for deliberate exceptions."""
+        hook_path = hook_env / ".git" / "hooks" / "pre-commit"
+        clean_env = _clean_git_env()
+        clean_env["ALLOW_GIT_IDENTITY"] = "1"
+        subprocess.run(
+            ["git", "checkout", "-q", "-b", "feature-bypass-test"],
+            cwd=hook_env,
+            capture_output=True,
+            env=clean_env,
+        )
+        subprocess.run(
+            ["git", "config", "--local", "user.email", "timetolearnbob@gmail.com"],
+            cwd=hook_env,
+            check=True,
+            capture_output=True,
+            env=clean_env,
+        )
+        (hook_env / "b.txt").write_text("x")
+        subprocess.run(
+            ["git", "add", "b.txt"],
+            cwd=hook_env,
+            check=True,
+            capture_output=True,
+            env=clean_env,
+        )
+        result = subprocess.run(
+            ["bash", str(hook_path)],
+            cwd=hook_env,
+            capture_output=True,
+            text=True,
+            env=clean_env,
+        )
+        assert "NOT an allowed identity" not in (result.stdout + result.stderr)
+
+
 if __name__ == "__main__":
     # Allow running as standalone script
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problem

The global pre-commit hook in `dotfiles/.config/git/hooks/pre-commit` (wired via `core.hooksPath`) runs in **every** repo an agent commits in, and validates branch / master-protection / mass-delete / submodules — but **never the committing identity**. Identity was only enforced in one consuming repo's own prek config.

As a result, a **repo-local `user.email` override** that shadows the correct global `~/.gitconfig` goes completely uncaught in submodules, `projects/*`, and `/tmp` worktrees. In practice this landed dozens of commits under a typo-blend identity (`timetolearnbob@gmail.com` — a blend of two real accounts) before anyone noticed, because the guard that would have caught it only ran in the main repo.

## Fix

Add **Part 0.5** to the hook: validate the *effective* `git user.email` against an allowlist, unconditionally and early (~1ms), before the commit proceeds.

- **Forkable**: an optional `allowed-identities.conf` (next to the existing `allowed-repos.conf`) may define `IDENTITY_ALLOWLIST=(...)` to override the built-in defaults, so each agent deployment sets its own identities without editing the hook.
- **Bypass**: `ALLOW_GIT_IDENTITY=1 git commit ...` for deliberate exceptions.
- **Fail-safe**: aborts on an unset email too (unknown identity).

## Tests

`tests/integration/test_git_hooks.py::TestGitIdentityValidation` (3 cases): disallowed email blocked, allowed email passes the identity guard, bypass env skips it. Uses the existing `hook_env` fixture (copies hooks into an isolated temp repo). Full git-hooks suite green (13 passed); `shellcheck` clean.

## Note

The built-in default allowlist in this PR uses the author's identities as a sensible default; downstream forks override via `allowed-identities.conf`. Open to making the default empty (allow-all unless configured) if maintainers prefer a fully identity-agnostic upstream default — easy change.