### PR TITLE
fix(greptile-helper): suppress re-trigger when Greptile responded via in-place comment update

### DIFF
--- a/scripts/github/greptile-helper.sh
+++ b/scripts/github/greptile-helper.sh
@@ -219,9 +219,29 @@ _needs_re_review() {
     if [ -n "$reviewed_sha" ]; then
         head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha // ""' 2>/dev/null) || head_sha=""
         if [ -n "$head_sha" ]; then
-            # Re-review needed iff Greptile's last review was on a different commit.
-            [ "$reviewed_sha" != "$head_sha" ]
-            return
+            if [ "$reviewed_sha" = "$head_sha" ]; then
+                return 1  # Formal PR review is on the current head — no re-review needed.
+            fi
+            # SHA mismatch: Greptile's formal PR review is on a stale commit. However,
+            # Greptile often responds to re-review triggers via in-place issue comment
+            # update rather than a new formal PR review. If the issue comment was updated
+            # AFTER the current HEAD commit date, Greptile has already processed our trigger
+            # for this commit — suppress to avoid spam.
+            # Root cause of #1246 spam (3 triggers in 2.5h, 2026-07-09): SHA mismatch kept
+            # returning "re-review needed" indefinitely, while in-place comment updates
+            # advanced review_cutoff past the in-cycle trigger, causing
+            # _no_new_commit_since_our_last_trigger to fail open on every PM cycle.
+            local _sha_info _sha_reviewed_at _sha_head_commit_date
+            _sha_info=$(_greptile_review_info) || _sha_info=""
+            _sha_reviewed_at=$(echo "$_sha_info" | _json_field "reviewed_at") || _sha_reviewed_at=""
+            if [ -n "$_sha_reviewed_at" ] && [ "$_sha_reviewed_at" != "null" ]; then
+                _sha_head_commit_date=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/commits" 2>/dev/null \
+                    | jq -rs '[.[][] | .commit.committer.date] | sort | last // ""' 2>/dev/null) || _sha_head_commit_date=""
+                if [ -n "$_sha_head_commit_date" ] && _timestamp_gt "$_sha_reviewed_at" "$_sha_head_commit_date" 2>/dev/null; then
+                    return 1  # Issue comment updated after HEAD commit — Greptile responded, no re-trigger.
+                fi
+            fi
+            return 0  # Re-review needed: formal review is stale and no recent issue-comment response.
         fi
     fi
 

--- a/scripts/github/greptile-helper.sh
+++ b/scripts/github/greptile-helper.sh
@@ -194,6 +194,22 @@ _has_greptile_review() {
     echo "$info" | python3 -c "import sys,json; d=json.load(sys.stdin); exit(0 if d.get('has_review') else 1)" 2>/dev/null
 }
 
+# --- Helper: extract the head-SHA marker from a trigger comment body ---
+# Trigger comments embed the PR head SHA they were posted for (see trigger command):
+#   @greptileai review\n\n<!-- greptile-helper head-sha: <sha> -->
+# Reads a comment JSON object on stdin, prints the marker SHA or "".
+_marker_sha_from_body() {
+    # Reset EXIT trap — runs in a $() subshell that inherits the parent's trap.
+    trap - EXIT
+    jq -r '.body // "" | [capture("greptile-helper head-sha: (?<s>[0-9a-fA-F]{7,40})")] | if length == 0 then "" else .[0].s end' 2>/dev/null
+}
+
+# --- Helper: our most recent @greptileai trigger comment (JSON object or {}) ---
+_our_last_trigger_json() {
+    trap - EXIT
+    _issue_comments_json | jq "[.[][] | select(.user.login == \"$GITHUB_AUTHOR\" and (.body | test(\"@greptileai review\")))] | sort_by(.created_at) | last // {}" 2>/dev/null || echo "{}"
+}
+
 # --- Helper: check if re-review is needed (new commits since latest review) ---
 # Returns 0 = re-review needed, 1 = no re-review needed
 #
@@ -204,6 +220,9 @@ _has_greptile_review() {
 # the review but the date compare skipped the re-trigger, leaving a hardened PR
 # stuck on a stale low score. A SHA mismatch is unambiguous and loop-safe: once
 # Greptile reviews the head, reviewed_sha == head_sha → it stops re-triggering.
+# On SHA mismatch, one more server-side check runs before declaring "re-review
+# needed": Greptile often responds to triggers via in-place issue-comment update
+# (never advancing the formal review's commit_id) — see the marker check inline.
 #
 # FALLBACK (date-based): when Greptile posted only an issue comment and no PR
 # review object carries a commit_id, fall back to the original committer.date
@@ -224,24 +243,37 @@ _needs_re_review() {
             fi
             # SHA mismatch: Greptile's formal PR review is on a stale commit. However,
             # Greptile often responds to re-review triggers via in-place issue comment
-            # update rather than a new formal PR review. If the issue comment was updated
-            # AFTER the current HEAD commit date, Greptile has already processed our trigger
-            # for this commit — suppress to avoid spam.
+            # update rather than a new formal PR review, so the formal review's commit_id
+            # can stay stale forever while Greptile is in fact up to date.
             # Root cause of #1246 spam (3 triggers in 2.5h, 2026-07-09): SHA mismatch kept
             # returning "re-review needed" indefinitely, while in-place comment updates
             # advanced review_cutoff past the in-cycle trigger, causing
             # _no_new_commit_since_our_last_trigger to fail open on every PM cycle.
-            local _sha_info _sha_reviewed_at _sha_head_commit_date
-            _sha_info=$(_greptile_review_info) || _sha_info=""
-            _sha_reviewed_at=$(echo "$_sha_info" | _json_field "reviewed_at") || _sha_reviewed_at=""
-            if [ -n "$_sha_reviewed_at" ] && [ "$_sha_reviewed_at" != "null" ]; then
-                _sha_head_commit_date=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/commits" 2>/dev/null \
-                    | jq -rs '[.[][] | .commit.committer.date] | sort | last // ""' 2>/dev/null) || _sha_head_commit_date=""
-                if [ -n "$_sha_head_commit_date" ] && _timestamp_gt "$_sha_reviewed_at" "$_sha_head_commit_date" 2>/dev/null; then
-                    return 1  # Issue comment updated after HEAD commit — Greptile responded, no re-trigger.
+            #
+            # Detection uses server-side data ONLY: our trigger comments embed the head
+            # SHA they were posted for (see trigger command). If our latest trigger was
+            # for the CURRENT head and Greptile's issue comment was updated after that
+            # trigger, Greptile already processed this head — suppress the re-trigger.
+            # Deliberately NOT a committer.date comparison: commit dates lag push time
+            # (written locally, pushed later — gptme#2987), so a date compare masks
+            # genuinely-new heads (Greptile P1 on #1247). SHA equality plus comment
+            # timestamps are both server-side and unambiguous.
+            # Legacy triggers without the marker fall through to "re-review needed"
+            # (pre-#1247 behavior); the next marker-carrying trigger self-heals the PR.
+            local _last_trigger _trig_sha _trig_created _sha_info _sha_reviewed_at
+            _last_trigger=$(_our_last_trigger_json)
+            _trig_sha=$(echo "$_last_trigger" | _marker_sha_from_body) || _trig_sha=""
+            if [ -n "$_trig_sha" ] && [ "$_trig_sha" = "$head_sha" ]; then
+                _trig_created=$(echo "$_last_trigger" | _json_field "created_at") || _trig_created=""
+                _sha_info=$(_greptile_review_info) || _sha_info=""
+                _sha_reviewed_at=$(echo "$_sha_info" | _json_field "reviewed_at") || _sha_reviewed_at=""
+                if [ -n "$_trig_created" ] \
+                    && [ -n "$_sha_reviewed_at" ] && [ "$_sha_reviewed_at" != "null" ] \
+                    && _timestamp_gt "$_sha_reviewed_at" "$_trig_created" 2>/dev/null; then
+                    return 1  # Greptile responded (in-place) after our trigger for this exact head.
                 fi
             fi
-            return 0  # Re-review needed: formal review is stale and no recent issue-comment response.
+            return 0  # Re-review needed: formal review is stale, no confirmed response for this head.
         fi
     fi
 
@@ -461,9 +493,21 @@ trigger)
                 exit 0
             fi
             echo "  [greptile] Re-triggering @greptileai review on $REPO#$PR_NUMBER (new commits landed after the last review)..."
+            # Embed the current head SHA so _needs_re_review can later tell whether an
+            # in-place Greptile comment update was a response to a trigger for THIS head
+            # (SHA equality instead of committer.date heuristics — see gptme#2987).
+            # If the head can't be read, post a plain trigger: the marker is an
+            # optimization, and _needs_re_review treats marker-less triggers as legacy.
+            _head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha // ""' 2>/dev/null) || _head_sha=""
+            _trigger_body="@greptileai review"
+            if [ -n "$_head_sha" ]; then
+                _trigger_body="$_trigger_body
+
+<!-- greptile-helper head-sha: $_head_sha -->"
+            fi
             # Use REST API instead of `gh pr comment` (GraphQL) — REST has a
             # separate 5000/hour quota that's rarely exhausted.
-            if gh api "repos/$REPO/issues/$PR_NUMBER/comments" -f body="@greptileai review" --silent 2>/dev/null; then
+            if gh api "repos/$REPO/issues/$PR_NUMBER/comments" -f body="$_trigger_body" --silent 2>/dev/null; then
                 # Record trigger timestamp locally — fast-path guard against GitHub API
                 # propagation delay that causes sequential callers to see "no trigger"
                 # and re-trigger. See: 2026-03-19 INCIDENT #5.

--- a/tests/test_greptile_helper.py
+++ b/tests/test_greptile_helper.py
@@ -118,13 +118,18 @@ def _make_greptile_comment(
     }
 
 
-def _make_trigger_comment(author: str, created_at: str) -> dict:
+def _make_trigger_comment(
+    author: str, created_at: str, head_sha: str | None = None
+) -> dict:
+    body = "@greptileai review"
+    if head_sha:
+        body += f"\n\n<!-- greptile-helper head-sha: {head_sha} -->"
     return {
         "id": 12345,
         "user": {"login": author},
         "created_at": created_at,
         "updated_at": created_at,
-        "body": "@greptileai review",
+        "body": body,
     }
 
 
@@ -431,6 +436,128 @@ def test_sha_match_skips_re_review_even_when_date_says_yes():
     }
     status = _run_helper("status", fixture)
     assert status.stdout.strip() == "already-reviewed", f"stderr: {status.stderr}"
+
+
+def test_inplace_comment_response_to_marker_trigger_suppresses_re_review():
+    """Regression for gptme-contrib#1246 spam: Greptile responds to a re-review
+    trigger by updating its issue comment in-place, never advancing the formal
+    review's commit_id. The SHA mismatch alone would say "re-review needed"
+    forever. Our trigger comment carries a head-SHA marker matching the current
+    head, and Greptile's comment was updated after that trigger → Greptile has
+    already processed this head → suppress."""
+    fixture = {
+        "pr_number": 1246,
+        "raw_comments": [
+            # Greptile comment created 90min ago, updated in-place 20min ago
+            _make_greptile_comment(
+                4, reviewed_at=_iso_ago(minutes=90), updated_at=_iso_ago(minutes=20)
+            ),
+            # Our trigger 40min ago, posted for the current head
+            _make_trigger_comment(
+                "test-user", _iso_ago(minutes=40), head_sha="beef1234"
+            ),
+        ],
+        # Formal review stuck on a stale commit (SHA mismatch with head)
+        "raw_reviews": [_make_greptile_review("0abc1234", _iso_ago(minutes=90))],
+        "raw_pr": {"head": {"sha": "beef1234"}, "created_at": _iso_ago(minutes=180)},
+        "raw_commits": [_make_commit(_iso_ago(minutes=60))],
+        "bot_reaction_count": 1,
+    }
+    result = _run_helper("check", fixture)
+    assert result.returncode == 2, (
+        f"In-place response for current head must suppress re-trigger. "
+        f"stderr: {result.stderr}"
+    )
+
+    status = _run_helper("status", fixture)
+    assert (
+        status.stdout.strip() == "already-reviewed"
+    ), f"Expected already-reviewed, got: {status.stdout.strip()}"
+
+    result, gh_log = _run_helper("trigger", fixture, capture_gh_log=True)
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert not gh_log, f"Should NOT have posted a trigger, got: {gh_log}"
+
+
+def test_marker_trigger_does_not_mask_new_backdated_head():
+    """Greptile P1 on gptme-contrib#1247: a new HEAD whose committer.date is older
+    than Greptile's comment edit must still get a re-review. The marker shows our
+    trigger was for the PREVIOUS head; the current head differs → re-review needed,
+    regardless of commit dates (written-locally-then-pushed commits look old)."""
+    fixture = {
+        "pr_number": 1247,
+        "raw_comments": [
+            # Greptile responded in-place 20min ago...
+            _make_greptile_comment(
+                4, reviewed_at=_iso_ago(minutes=90), updated_at=_iso_ago(minutes=20)
+            ),
+            # ...to our trigger for the previous head
+            _make_trigger_comment(
+                "test-user", _iso_ago(minutes=40), head_sha="beef1234"
+            ),
+        ],
+        "raw_reviews": [_make_greptile_review("0abc1234", _iso_ago(minutes=90))],
+        # New head pushed after Greptile's comment edit, but with an OLD
+        # committer.date (45min ago) — a date compare would wrongly suppress.
+        "raw_pr": {"head": {"sha": "f00d5678"}, "created_at": _iso_ago(minutes=180)},
+        "raw_commits": [_make_commit(_iso_ago(minutes=45))],
+        "bot_reaction_count": 0,
+    }
+    status = _run_helper("status", fixture)
+    assert (
+        status.stdout.strip() == "needs-re-review"
+    ), f"New head must not be masked by comment timestamp, got: {status.stdout.strip()}"
+
+
+def test_marker_trigger_without_response_does_not_suppress():
+    """Marker matches the current head but Greptile's comment was last updated
+    BEFORE our trigger (no response yet) → not proof of processing → the
+    SHA-mismatch path must still report re-review needed (downstream in-flight
+    guards handle pacing)."""
+    fixture = {
+        "pr_number": 1249,
+        "raw_comments": [
+            # Greptile comment last updated 50min ago — BEFORE our 30min-ago trigger
+            _make_greptile_comment(
+                4, reviewed_at=_iso_ago(minutes=90), updated_at=_iso_ago(minutes=50)
+            ),
+            _make_trigger_comment(
+                "test-user", _iso_ago(minutes=30), head_sha="beef1234"
+            ),
+        ],
+        "raw_reviews": [_make_greptile_review("0abc1234", _iso_ago(minutes=90))],
+        "raw_pr": {"head": {"sha": "beef1234"}, "created_at": _iso_ago(minutes=180)},
+        "raw_commits": [_make_commit(_iso_ago(minutes=60))],
+        "bot_reaction_count": 0,
+    }
+    status = _run_helper("status", fixture)
+    assert (
+        status.stdout.strip() == "needs-re-review"
+    ), f"Unanswered trigger must not suppress, got: {status.stdout.strip()}"
+
+
+def test_trigger_embeds_head_sha_marker():
+    """A posted trigger comment must embed the current head SHA so future
+    _needs_re_review calls can match in-place responses to this exact head."""
+    reviewed_at = _iso_ago(minutes=30)
+    fixture = {
+        "pr_number": 780,
+        "raw_comments": [
+            _make_greptile_comment(
+                4, reviewed_at=_iso_ago(minutes=60), updated_at=reviewed_at
+            ),
+        ],
+        "raw_commits": [_make_commit(_iso_ago(minutes=10))],
+        "raw_pr": {"head": {"sha": "beef1234"}, "created_at": _iso_ago(minutes=120)},
+        "bot_reaction_count": 0,
+    }
+    result, gh_log = _run_helper("trigger", fixture, capture_gh_log=True)
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert "Re-triggered successfully" in result.stdout
+    assert "@greptileai review" in gh_log
+    assert (
+        "greptile-helper head-sha: beef1234" in gh_log
+    ), f"Trigger body must embed the head SHA marker. log: {gh_log}"
 
 
 def test_no_pr_review_object_falls_back_to_date_heuristic():


### PR DESCRIPTION
## Problem

When Greptile's formal PR review (`commit_id`) diverges from the current HEAD SHA, `_needs_re_review()` returns "re-review needed" indefinitely — even after Greptile has responded to a re-review trigger. This caused 3 triggers on #1246 in 2.5 hours (2026-07-09).

### Root cause

Greptile sometimes responds to `@greptileai review` triggers by updating its existing issue comment in-place rather than posting a new formal PR review with an updated `commit_id`. When this happens:

1. `_needs_re_review()` PRIMARY path: `reviewed_sha ≠ head_sha` → "re-review needed" (stays true forever)
2. Greptile's in-place comment update advances `reviewed_at` past the in-cycle trigger timestamp
3. `_no_new_commit_since_our_last_trigger` finds no in-cycle triggers (they're now "spent") → fails open
4. After the ack grace window, PM posts another trigger — every cycle, indefinitely

## Fix (v2 — head-SHA markers)

The first iteration compared Greptile's comment `updated_at` against the head commit's `committer.date`. Greptile's P1 correctly flagged that commit dates lag push time (written-locally-then-pushed commits look old — same failure class as gptme#2987), which masks genuinely-new heads. That version also broke two existing regression tests (`test_spent_trigger_with_backdated_commit_does_not_suppress`, `test_sha_mismatch_forces_re_review_even_when_date_says_no`); CI missed it due to path-filtered test jobs.

The fix now uses **server-side data only**:

- The `trigger` command embeds the PR head SHA in the trigger comment: `@greptileai review` + `<!-- greptile-helper head-sha: <sha> -->`
- In the SHA-mismatch branch, re-trigger is suppressed **only** when both hold:
  1. our latest trigger's marker SHA == current head SHA (the trigger was for exactly this head)
  2. Greptile's issue comment was updated *after* that trigger (a response landed)
- Legacy marker-less triggers keep pre-existing behavior ("re-review needed"); the next marker-carrying trigger self-heals the PR — at most one extra trigger per already-affected PR after deploy.

SHA equality + comment timestamps are both unforgeable server-side facts; no `committer.date` heuristics. (GraphQL `Commit.pushedDate` was considered but GitHub removed that field in 2023.)

## Testing

- All 27 tests pass, including the two regression tests the v1 approach broke
- 4 new tests: in-place-response suppression (#1246 case), backdated-new-head (the P1 case), unanswered-trigger non-suppression, marker embedding in posted triggers