### PR TITLE
fix(lessons): narrow pre-mortem keywords to reduce over-triggering

### DIFF
--- a/lessons/autonomous/pre-mortem-for-risky-actions.md
+++ b/lessons/autonomous/pre-mortem-for-risky-actions.md
@@ -8,9 +8,7 @@ match:
   - "risk assessment before action"
   - "what could go wrong with this change"
   - "irreversible change"
-  - "force push"
-  - "rm -rf"
-  session_categories: [code, infrastructure, cleanup]
+  session_categories: [infrastructure, cleanup]
 target_grade: alignment
 status: active
 ---


### PR DESCRIPTION
## Summary

- **Causal LOO evidence**: `pre-mortem-for-risky-actions` shows Δ=-0.0619, p=0.021 in randomized-dropout analysis (2026-07-09) — statistically significant harm signal
- **Root cause**: standalone `"force push"` and `"rm -rf"` keywords fire whenever a session discusses these terms, not only when actually performing risky operations; adds unnecessary pre-mortem overhead in routine sessions
- **Fix**: remove the 2 broad single-phrase keywords; narrow `session_categories` from `[code, infrastructure, cleanup]` → `[infrastructure, cleanup]` (`code` is the most common category, causing injection in non-risky sessions)
- **Content unchanged**: only the trigger surface is narrowed; the lesson guidance itself is correct

## Verification

- `validate.py` passes on the modified file
- The multi-word `"force push or destructive git operation"` keyword remains — still fires in genuinely risky contexts

Co-Authored-By: Bob <bob@superuserlabs.org>