### PR TITLE
chore: add runtime state dirs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,13 @@ state/locks/
 # Session state files (runtime state)
 state/sessions/
 
+# Coordination runtime state
+state/coordination/
+
+# GitHub API cache (runtime)
+state/gh-api-cache/
+state/github-graphql-log.jsonl
+
 # Stale directory from tasks->gptodo rename (PR #171)
 packages/tasks/
 


### PR DESCRIPTION
## Summary

- Adds `state/coordination/`, `state/gh-api-cache/`, and `state/github-graphql-log.jsonl` to `.gitignore`
- These are created at runtime by the coordination system and GitHub API scripts
- Keeps `state/community_plugins.json` tracked (it's a committed plugin registry)

The existing `.gitignore` covered `state/locks/` and `state/sessions/` but missed these three runtime artifacts added by newer features. This caused `git status` to show untracked noise in repos using gptme-contrib.

## Test plan

- [ ] `git status` in a workspace using gptme-contrib no longer shows untracked state dirs