### PR TITLE
feat(cc-hook): session_categories gating + BM25 semantic scoring

### DIFF
--- a/packages/gptme-subscription/tests/test_routing.py
+++ b/packages/gptme-subscription/tests/test_routing.py
@@ -210,9 +210,9 @@ class TestCapacityAwareFallbackOrder:
         _write_obs(tmp_path, "bob", "seven_day", (now - timedelta(days=6)).isoformat())
 
         result = capacity_aware_fallback_order(["bob", "alice"], tmp_path, now=now)
-        assert (
-            result[0] == "alice"
-        ), f"alice (low pressure) should sort first; got {result}"
+        assert result[0] == "alice", (
+            f"alice (low pressure) should sort first; got {result}"
+        )
         assert result[1] == "bob"
 
     def test_unknown_sub_ranks_by_unknown_pressure(self, tmp_path: Path) -> None:
@@ -225,9 +225,9 @@ class TestCapacityAwareFallbackOrder:
         # bob has no observation → gets unknown_pressure = 0.5
 
         result = capacity_aware_fallback_order(["alice", "bob"], tmp_path, now=now)
-        assert (
-            result[0] == "bob"
-        ), "bob (unknown=0.5) < alice (~0.71); should sort first"
+        assert result[0] == "bob", (
+            "bob (unknown=0.5) < alice (~0.71); should sort first"
+        )
 
 
 class TestSoonestResettingFallback:

--- a/packages/gptme-subscription/tests/test_routing.py
+++ b/packages/gptme-subscription/tests/test_routing.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import json
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
 from gptme_subscription.routing import (
+    capacity_aware_fallback_order,
     clear_rebalance_state,
     combine_window_pacing_snapshots,
     compute_pacing_snapshot,
@@ -14,6 +17,7 @@ from gptme_subscription.routing import (
     compute_window_pacing_snapshot,
     load_rebalance_state,
     save_rebalance_state,
+    soonest_resetting_fallback,
 )
 
 WEEK = 7 * 24 * 3600
@@ -135,3 +139,140 @@ class TestRebalanceStatePersistence:
 
     def test_clear_nonexistent_does_not_error(self, tmp_path: Path) -> None:
         clear_rebalance_state(tmp_path / "nonexistent.json")
+
+    def test_load_empty_file_returns_none(self, tmp_path: Path) -> None:
+        state_path = tmp_path / "rebalance.json"
+        state_path.write_text("")
+        assert load_rebalance_state(state_path) is None
+
+    def test_load_invalid_json_returns_none(self, tmp_path: Path) -> None:
+        state_path = tmp_path / "rebalance.json"
+        state_path.write_text("{not valid json")
+        assert load_rebalance_state(state_path) is None
+
+    def test_load_non_dict_json_returns_none(self, tmp_path: Path) -> None:
+        state_path = tmp_path / "rebalance.json"
+        state_path.write_text("[1, 2, 3]")
+        assert load_rebalance_state(state_path) is None
+
+
+class TestComputePacingSnapshotEdgeCases:
+    def test_zero_utilization_is_underusing(self) -> None:
+        result = compute_pacing_snapshot(0.0, elapsed_fraction=0.5)
+        assert result.utilization == pytest.approx(0.0)
+        assert result.headroom == pytest.approx(1.0)
+        assert result.status == "underusing"
+
+    def test_full_utilization_at_end_is_on_track(self) -> None:
+        """100% used at 100% elapsed = on track (gap = 0)."""
+        result = compute_pacing_snapshot(1.0, elapsed_fraction=1.0)
+        assert result.pace_gap == pytest.approx(0.0)
+        assert result.status == "on_track"
+
+    def test_clamping_above_one(self) -> None:
+        """Values above 1.0 are clamped to 1.0."""
+        result = compute_pacing_snapshot(1.5, elapsed_fraction=0.5)
+        assert result.utilization == pytest.approx(1.0)
+        assert result.headroom == pytest.approx(0.0)
+
+    def test_at_positive_threshold_boundary_is_overusing(self) -> None:
+        """Gap just above threshold (default 0.05) is overusing."""
+        result = compute_pacing_snapshot(0.6, elapsed_fraction=0.5, threshold=0.05)
+        assert result.pace_gap == pytest.approx(0.1)
+        assert result.status == "overusing"
+
+
+def _write_obs(obs_dir: Path, sub: str, metric_key: str, reset_ts: str) -> None:
+    """Write a minimal observation JSON file for testing."""
+    obs_dir.mkdir(parents=True, exist_ok=True)
+    (obs_dir / f"{sub}.json").write_text(
+        json.dumps({"track_resets": {metric_key: reset_ts}}) + "\n"
+    )
+
+
+class TestCapacityAwareFallbackOrder:
+    def test_no_observations_preserves_input_order(self, tmp_path: Path) -> None:
+        """When no observation files exist, all subs get unknown_pressure and
+        the stable sort preserves the original input order."""
+        order = ["alice", "bob", "erik"]
+        result = capacity_aware_fallback_order(order, tmp_path)
+        assert result == order
+
+    def test_recently_reset_sub_sorted_first(self, tmp_path: Path) -> None:
+        """A sub that reset recently (low elapsed time → low pressure) sorts before
+        one that reset a long time ago (high elapsed → higher pressure)."""
+        now = datetime(2026, 7, 9, 12, 0, 0, tzinfo=timezone.utc)
+        # alice reset 1 day ago → 6 days remaining → low pressure
+        _write_obs(
+            tmp_path, "alice", "seven_day", (now - timedelta(days=1)).isoformat()
+        )
+        # bob reset 6 days ago → 1 day remaining → high pressure
+        _write_obs(tmp_path, "bob", "seven_day", (now - timedelta(days=6)).isoformat())
+
+        result = capacity_aware_fallback_order(["bob", "alice"], tmp_path, now=now)
+        assert (
+            result[0] == "alice"
+        ), f"alice (low pressure) should sort first; got {result}"
+        assert result[1] == "bob"
+
+    def test_unknown_sub_ranks_by_unknown_pressure(self, tmp_path: Path) -> None:
+        """A sub with no observation file gets unknown_pressure (default 0.5)."""
+        now = datetime(2026, 7, 9, 12, 0, 0, tzinfo=timezone.utc)
+        # alice reset 5 days ago → pressure ~5/7 ≈ 0.71 > 0.5 (unknown)
+        _write_obs(
+            tmp_path, "alice", "seven_day", (now - timedelta(days=5)).isoformat()
+        )
+        # bob has no observation → gets unknown_pressure = 0.5
+
+        result = capacity_aware_fallback_order(["alice", "bob"], tmp_path, now=now)
+        assert (
+            result[0] == "bob"
+        ), "bob (unknown=0.5) < alice (~0.71); should sort first"
+
+
+class TestSoonestResettingFallback:
+    def test_returns_none_with_no_observations(self, tmp_path: Path) -> None:
+        result = soonest_resetting_fallback("bob", ["alice", "erik"], tmp_path)
+        assert result is None
+
+    def test_picks_sub_with_least_remaining_time(self, tmp_path: Path) -> None:
+        """The sub whose next reset is closest in time (soonest remaining) wins."""
+        now = datetime(2026, 7, 9, 12, 0, 0, tzinfo=timezone.utc)
+        # alice: reset 6.9 days ago → resets in ~0.1 days (8640s)
+        _write_obs(
+            tmp_path,
+            "alice",
+            "seven_day",
+            (now - timedelta(days=6, hours=21, minutes=36)).isoformat(),
+        )
+        # erik: reset 6.0 days ago → resets in ~1 day (86400s)
+        _write_obs(
+            tmp_path,
+            "erik",
+            "seven_day",
+            (now - timedelta(days=6)).isoformat(),
+        )
+
+        result = soonest_resetting_fallback("bob", ["alice", "erik"], tmp_path, now=now)
+        assert result == "alice", f"alice resets soonest; got {result}"
+
+    def test_skips_active_subscription(self, tmp_path: Path) -> None:
+        """The active subscription is never returned even if it would reset soonest."""
+        now = datetime(2026, 7, 9, 12, 0, 0, tzinfo=timezone.utc)
+        # bob (active): reset 6.9 days ago → soonest reset
+        _write_obs(
+            tmp_path,
+            "bob",
+            "seven_day",
+            (now - timedelta(days=6, hours=23)).isoformat(),
+        )
+        # alice: reset 4 days ago → resets in 3 days
+        _write_obs(
+            tmp_path,
+            "alice",
+            "seven_day",
+            (now - timedelta(days=4)).isoformat(),
+        )
+
+        result = soonest_resetting_fallback("bob", ["bob", "alice"], tmp_path, now=now)
+        assert result == "alice", f"active sub 'bob' must be skipped; got {result}"

--- a/packages/gptme-subscription/tests/test_routing.py
+++ b/packages/gptme-subscription/tests/test_routing.py
@@ -210,9 +210,9 @@ class TestCapacityAwareFallbackOrder:
         _write_obs(tmp_path, "bob", "seven_day", (now - timedelta(days=6)).isoformat())
 
         result = capacity_aware_fallback_order(["bob", "alice"], tmp_path, now=now)
-        assert result[0] == "alice", (
-            f"alice (low pressure) should sort first; got {result}"
-        )
+        assert (
+            result[0] == "alice"
+        ), f"alice (low pressure) should sort first; got {result}"
         assert result[1] == "bob"
 
     def test_unknown_sub_ranks_by_unknown_pressure(self, tmp_path: Path) -> None:
@@ -225,9 +225,9 @@ class TestCapacityAwareFallbackOrder:
         # bob has no observation → gets unknown_pressure = 0.5
 
         result = capacity_aware_fallback_order(["alice", "bob"], tmp_path, now=now)
-        assert result[0] == "bob", (
-            "bob (unknown=0.5) < alice (~0.71); should sort first"
-        )
+        assert (
+            result[0] == "bob"
+        ), "bob (unknown=0.5) < alice (~0.71); should sort first"
 
 
 class TestSoonestResettingFallback:

--- a/scripts/claude-code-hooks/match-lessons.py
+++ b/scripts/claude-code-hooks/match-lessons.py
@@ -547,7 +547,7 @@ def scan_lessons(lesson_dirs: list[Path]) -> list[dict]:
             harness_restrict = _string_list(metadata.get("harness"))
 
             _raw_sc = (
-                match_data.get("session_categories", [])
+                match_data.get("session_categories") or []
                 if isinstance(match_data, dict)
                 else []
             )

--- a/scripts/claude-code-hooks/match-lessons.py
+++ b/scripts/claude-code-hooks/match-lessons.py
@@ -640,7 +640,7 @@ def filter_by_session_category(
     filtered = []
     for lesson in lessons:
         cats = lesson.get("session_categories") or []
-        if not cats or category in cats:
+        if not cats or category in {c.lower() for c in cats}:
             filtered.append(lesson)
     return filtered
 

--- a/scripts/claude-code-hooks/match-lessons.py
+++ b/scripts/claude-code-hooks/match-lessons.py
@@ -54,6 +54,7 @@ under workspace/state/ and created automatically on first use.
 """
 
 import json
+import math
 import os
 import random
 import re
@@ -545,6 +546,15 @@ def scan_lessons(lesson_dirs: list[Path]) -> list[dict]:
             tags = _string_list(metadata.get("tags"))
             harness_restrict = _string_list(metadata.get("harness"))
 
+            _raw_sc = (
+                match_data.get("session_categories", [])
+                if isinstance(match_data, dict)
+                else []
+            )
+            session_categories = _dedupe_strings(
+                [_raw_sc] if isinstance(_raw_sc, str) else _raw_sc
+            )
+
             # Need at least some way to match
             if not keywords and not patterns and not skill_name:
                 continue
@@ -565,6 +575,7 @@ def scan_lessons(lesson_dirs: list[Path]) -> list[dict]:
                     "when_to_use": when_to_use,
                     "tags": tags,
                     "harness_restrict": harness_restrict,
+                    "session_categories": session_categories,
                     "is_skill": f.name == "SKILL.md" or skill_name is not None,
                     "body": body,
                     "n_keywords": len(keywords),
@@ -592,6 +603,44 @@ def filter_by_harness(lessons: list[dict], harness: str) -> list[dict]:
             continue
         allowed = {str(value).strip() for value in restrict if str(value).strip()}
         if harness in allowed:
+            filtered.append(lesson)
+    return filtered
+
+
+def detect_session_category() -> "str | None":
+    """Detect the current session category from environment variables.
+
+    Autonomous sessions set CASCADE_CATEGORY via autonomous-run.sh.
+    Other run types may set GRADE_CATEGORY or WORKER_CATEGORY.
+    Returns lowercase category string, or None if unknown.
+    """
+    for var in (
+        "CASCADE_CATEGORY",
+        "CASCADE_EXECUTION_CATEGORY",
+        "GRADE_CATEGORY",
+        "WORKER_CATEGORY",
+    ):
+        val = os.environ.get(var, "").strip()
+        if val:
+            return val.lower()
+    return None
+
+
+def filter_by_session_category(
+    lessons: list[dict], category: "str | None"
+) -> list[dict]:
+    """Keep lessons with no session_categories restriction or matching current category.
+
+    Lessons that explicitly restrict to specific session categories are filtered out
+    when running in a different category, reducing irrelevant lesson injection.
+    If category is unknown (None), all lessons pass through.
+    """
+    if not category:
+        return lessons
+    filtered = []
+    for lesson in lessons:
+        cats = lesson.get("session_categories") or []
+        if not cats or category in cats:
             filtered.append(lesson)
     return filtered
 
@@ -787,17 +836,86 @@ def get_predicted_lessons(
     return results
 
 
-def score_lessons(lessons: list[dict], prompt: str, max_results: int = 5) -> list[dict]:
+# --- BM25 semantic scoring ---
+
+_BM25_K1 = 1.2
+_BM25_B = 0.75
+_BM25_WEIGHT = 0.4  # additive weight for BM25 score contribution
+_BM25_MIN_SCORE = 0.8  # minimum BM25 score to add contribution
+
+
+def _build_bm25_index(lessons: list[dict]) -> dict:
+    """Build BM25 index over lesson descriptions, titles, and keywords.
+
+    Used to semantically score lessons against match text, complementing
+    keyword matching with soft semantic overlap detection.
+    """
+    corpus: list[list[str]] = []
+    for lesson in lessons:
+        doc = " ".join(
+            [
+                lesson.get("description") or "",
+                lesson.get("title") or "",
+                " ".join(lesson.get("keywords") or []),
+                lesson.get("when_to_use") or "",
+            ]
+        )
+        corpus.append(re.findall(r"[a-z0-9]+", doc.lower()))
+
+    N = len(corpus)
+    avg_dl = sum(len(d) for d in corpus) / max(N, 1)
+    df: dict[str, int] = {}
+    for doc_tokens in corpus:  # renamed: avoids shadowing the str `doc` defined above
+        for term in set(doc_tokens):
+            df[term] = df.get(term, 0) + 1
+
+    return {"corpus": corpus, "df": df, "N": N, "avg_dl": avg_dl}
+
+
+def _bm25_score(query_terms: list[str], doc_terms: list[str], index: dict) -> float:
+    """Compute BM25 score for query_terms against a document's term list."""
+    k1, b = _BM25_K1, _BM25_B
+    N, avg_dl = index["N"], index["avg_dl"]
+    dl = len(doc_terms)
+    if not dl or not query_terms:
+        return 0.0
+
+    tf: dict[str, int] = {}
+    for term in doc_terms:
+        tf[term] = tf.get(term, 0) + 1
+
+    df = index["df"]
+    score = 0.0
+    for term in query_terms:
+        if term not in tf:
+            continue
+        tf_td = tf[term]
+        df_t = df.get(term, 0)
+        idf = math.log((N - df_t + 0.5) / (df_t + 0.5) + 1)
+        tf_norm = (tf_td * (k1 + 1)) / (tf_td + k1 * (1 - b + b * dl / max(avg_dl, 1)))
+        score += idf * tf_norm
+
+    return score
+
+
+def score_lessons(
+    lessons: list[dict],
+    prompt: str,
+    max_results: int = 5,
+    bm25_index: "dict | None" = None,
+) -> list[dict]:
     """Match lessons against prompt text. Returns scored results.
 
-    Scoring: keyword/pattern matches + Thompson sampling posterior mean boost.
+    Scoring: keyword/pattern matches + BM25 semantic overlap + Thompson sampling posterior mean boost.
     TS re-ranks by adding TS_WEIGHT * posterior_mean to keyword scores.
     Lessons without TS data get the default 0.5 (neutral prior).
+    BM25 adds semantic scoring over description/title/keywords when an index is provided.
     """
     prompt_lower = prompt.lower()
+    query_terms = re.findall(r"[a-z0-9]+", prompt_lower) if bm25_index else []
     results = []
 
-    for lesson in lessons:
+    for i, lesson in enumerate(lessons):
         score = 0.0
         matched_by: list[str] = []
 
@@ -831,6 +949,14 @@ def score_lessons(lessons: list[dict], prompt: str, max_results: int = 5) -> lis
         if descriptor_score > 0:
             score += descriptor_score
             matched_by.extend(descriptor_matches)
+
+        # BM25 semantic scoring (soft matching over description + title + keywords)
+        if bm25_index is not None and query_terms:
+            doc_terms = bm25_index["corpus"][i]
+            bm_score = _bm25_score(query_terms, doc_terms, bm25_index)
+            if bm_score >= _BM25_MIN_SCORE:
+                score += _BM25_WEIGHT * bm_score
+                matched_by.append(f"bm25:{bm_score:.2f}")
 
         if score > 0:
             results.append({**lesson, "score": score, "matched_by": matched_by})
@@ -1387,13 +1513,18 @@ def main():
     lesson_dirs = load_lesson_dirs(workspace)
     lessons = scan_lessons(lesson_dirs)
     lessons = filter_by_harness(lessons, detect_harness())
+    session_cat = detect_session_category()
+    lessons = filter_by_session_category(lessons, session_cat)
+    bm25_index = _build_bm25_index(lessons) if lessons else None
     holdout_lessons = parse_holdout_lessons_env()
 
     if not lessons:
         emit_empty(event_type)
         sys.exit(0)
 
-    raw_matches = score_lessons(lessons, match_text, max_results=max_results)
+    raw_matches = score_lessons(
+        lessons, match_text, max_results=max_results, bm25_index=bm25_index
+    )
     if not raw_matches:
         emit_empty(event_type)
         sys.exit(0)

--- a/tests/test_cc_match_lessons.py
+++ b/tests/test_cc_match_lessons.py
@@ -533,7 +533,9 @@ def test_filter_by_session_category_case_insensitive(hook, tmp_path):
     lessons = hook.scan_lessons([lessons_dir])
     # detect_session_category always returns lowercase; YAML "Code" must still match
     kept = hook.filter_by_session_category(lessons, "code")
-    assert len(kept) == 1, "Mixed-case YAML category should match lowercase env-var category"
+    assert (
+        len(kept) == 1
+    ), "Mixed-case YAML category should match lowercase env-var category"
     dropped = hook.filter_by_session_category(lessons, "cleanup")
     assert len(dropped) == 0
 

--- a/tests/test_cc_match_lessons.py
+++ b/tests/test_cc_match_lessons.py
@@ -533,9 +533,7 @@ def test_filter_by_session_category_case_insensitive(hook, tmp_path):
     lessons = hook.scan_lessons([lessons_dir])
     # detect_session_category always returns lowercase; YAML "Code" must still match
     kept = hook.filter_by_session_category(lessons, "code")
-    assert (
-        len(kept) == 1
-    ), "Mixed-case YAML category should match lowercase env-var category"
+    assert len(kept) == 1, "Mixed-case YAML category should match lowercase env-var category"
     dropped = hook.filter_by_session_category(lessons, "cleanup")
     assert len(dropped) == 0
 

--- a/tests/test_cc_match_lessons.py
+++ b/tests/test_cc_match_lessons.py
@@ -476,3 +476,149 @@ def test_scan_lessons_includes_id(hook, tmp_path):
     by_title = {r["title"]: r for r in results}
     assert by_title["With ID"]["id"] == "custom-lesson-id"
     assert by_title["No ID"]["id"] is None
+
+
+# --- session_categories ---
+
+
+def test_scan_lessons_extracts_session_categories(hook, tmp_path):
+    """scan_lessons populates session_categories from match.session_categories."""
+    lessons_dir = tmp_path / "lessons"
+    lessons_dir.mkdir()
+    (lessons_dir / "categorized.md").write_text(
+        "---\nmatch:\n  keywords:\n    - trigger\n  session_categories:\n    - code\n    - infrastructure\nstatus: active\n---\n# Categorized\n\nContent.\n"
+    )
+    (lessons_dir / "uncategorized.md").write_text(
+        "---\nmatch:\n  keywords:\n    - other\nstatus: active\n---\n# Uncategorized\n\nContent.\n"
+    )
+    results = hook.scan_lessons([lessons_dir])
+    by_title = {r["title"]: r for r in results}
+    assert by_title["Categorized"]["session_categories"] == ["code", "infrastructure"]
+    assert by_title["Uncategorized"]["session_categories"] == []
+
+
+def test_filter_by_session_category_keeps_unrestricted(hook, tmp_path):
+    """Lessons without session_categories pass through regardless of category."""
+    lessons_dir = tmp_path / "lessons"
+    lessons_dir.mkdir()
+    (lessons_dir / "unrestricted.md").write_text(
+        "---\nmatch:\n  keywords:\n    - keyword\nstatus: active\n---\n# Unrestricted\n\nContent.\n"
+    )
+    lessons = hook.scan_lessons([lessons_dir])
+    result = hook.filter_by_session_category(lessons, "cleanup")
+    assert len(result) == 1
+
+
+def test_filter_by_session_category_keeps_matching(hook, tmp_path):
+    """Lessons whose session_categories include current category are kept."""
+    lessons_dir = tmp_path / "lessons"
+    lessons_dir.mkdir()
+    (lessons_dir / "code-only.md").write_text(
+        "---\nmatch:\n  keywords:\n    - code\n  session_categories:\n    - code\nstatus: active\n---\n# Code Only\n\nContent.\n"
+    )
+    lessons = hook.scan_lessons([lessons_dir])
+    kept = hook.filter_by_session_category(lessons, "code")
+    assert len(kept) == 1
+    dropped = hook.filter_by_session_category(lessons, "cleanup")
+    assert len(dropped) == 0
+
+
+def test_filter_by_session_category_none_keeps_all(hook, tmp_path):
+    """Unknown category (None) keeps all lessons unchanged."""
+    lessons_dir = tmp_path / "lessons"
+    lessons_dir.mkdir()
+    (lessons_dir / "restricted.md").write_text(
+        "---\nmatch:\n  keywords:\n    - x\n  session_categories:\n    - strategic\nstatus: active\n---\n# Restricted\n\nContent.\n"
+    )
+    lessons = hook.scan_lessons([lessons_dir])
+    result = hook.filter_by_session_category(lessons, None)
+    assert len(result) == 1
+
+
+def test_detect_session_category_from_env(hook, monkeypatch):
+    """detect_session_category reads CASCADE_CATEGORY env var."""
+    monkeypatch.setenv("CASCADE_CATEGORY", "research")
+    for var in ("CASCADE_EXECUTION_CATEGORY", "GRADE_CATEGORY", "WORKER_CATEGORY"):
+        monkeypatch.delenv(var, raising=False)
+    assert hook.detect_session_category() == "research"
+
+
+def test_detect_session_category_fallback_vars(hook, monkeypatch):
+    """detect_session_category falls back to GRADE_CATEGORY when CASCADE_CATEGORY unset."""
+    monkeypatch.delenv("CASCADE_CATEGORY", raising=False)
+    monkeypatch.delenv("CASCADE_EXECUTION_CATEGORY", raising=False)
+    monkeypatch.setenv("GRADE_CATEGORY", "social")
+    monkeypatch.delenv("WORKER_CATEGORY", raising=False)
+    assert hook.detect_session_category() == "social"
+
+
+def test_detect_session_category_none_when_unset(hook, monkeypatch):
+    """detect_session_category returns None when no category env vars are set."""
+    for var in (
+        "CASCADE_CATEGORY",
+        "CASCADE_EXECUTION_CATEGORY",
+        "GRADE_CATEGORY",
+        "WORKER_CATEGORY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    assert hook.detect_session_category() is None
+
+
+# --- BM25 scoring ---
+
+
+def test_bm25_index_built_from_lessons(hook, tmp_path):
+    """_build_bm25_index returns a valid index with corpus matching lesson count."""
+    lessons_dir = tmp_path / "lessons"
+    lessons_dir.mkdir()
+    for i in range(3):
+        (lessons_dir / f"lesson{i}.md").write_text(
+            f"---\ndescription: lesson about topic {i}\nmatch:\n  keywords:\n    - kw{i}\nstatus: active\n---\n# Lesson {i}\n\nContent.\n"
+        )
+    lessons = hook.scan_lessons([lessons_dir])
+    index = hook._build_bm25_index(lessons)
+    assert len(index["corpus"]) == 3
+    assert index["N"] == 3
+    assert index["avg_dl"] > 0
+
+
+def test_bm25_score_relevant_higher_than_unrelated(hook):
+    """_bm25_score gives higher scores to relevant docs than unrelated ones."""
+    doc_relevant = ["python", "merge", "conflict", "resolution"]
+    doc_unrelated = ["javascript", "async", "promise", "then"]
+    index = {
+        "corpus": [doc_relevant, doc_unrelated],
+        "df": {
+            "python": 1,
+            "merge": 1,
+            "conflict": 1,
+            "resolution": 1,
+            "javascript": 1,
+            "async": 1,
+            "promise": 1,
+            "then": 1,
+        },
+        "N": 2,
+        "avg_dl": 4.0,
+    }
+    query = ["merge", "conflict"]
+    score_relevant = hook._bm25_score(query, doc_relevant, index)
+    score_unrelated = hook._bm25_score(query, doc_unrelated, index)
+    assert score_relevant > score_unrelated
+    assert score_unrelated == 0.0
+
+
+def test_score_lessons_with_bm25_index(hook, tmp_path):
+    """score_lessons accepts bm25_index and does not crash."""
+    lessons_dir = tmp_path / "lessons"
+    lessons_dir.mkdir()
+    (lessons_dir / "lesson.md").write_text(
+        "---\ndescription: handles merge conflict resolution\nmatch:\n  keywords:\n    - merge conflict\nstatus: active\n---\n# Merge Lesson\n\nContent.\n"
+    )
+    lessons = hook.scan_lessons([lessons_dir])
+    index = hook._build_bm25_index(lessons)
+    results = hook.score_lessons(lessons, "merge conflict resolution", bm25_index=index)
+    assert len(results) == 1
+    # BM25 match tag should appear in matched_by
+    has_bm25 = any("bm25" in tag for tag in results[0].get("matched_by", []))
+    assert has_bm25

--- a/tests/test_cc_match_lessons.py
+++ b/tests/test_cc_match_lessons.py
@@ -523,6 +523,23 @@ def test_filter_by_session_category_keeps_matching(hook, tmp_path):
     assert len(dropped) == 0
 
 
+def test_filter_by_session_category_case_insensitive(hook, tmp_path):
+    """YAML session_categories are matched case-insensitively against the detected (lowercase) category."""
+    lessons_dir = tmp_path / "lessons"
+    lessons_dir.mkdir()
+    (lessons_dir / "code-only.md").write_text(
+        "---\nmatch:\n  keywords:\n    - code\n  session_categories:\n    - Code\nstatus: active\n---\n# Code Only Mixed Case\n\nContent.\n"
+    )
+    lessons = hook.scan_lessons([lessons_dir])
+    # detect_session_category always returns lowercase; YAML "Code" must still match
+    kept = hook.filter_by_session_category(lessons, "code")
+    assert (
+        len(kept) == 1
+    ), "Mixed-case YAML category should match lowercase env-var category"
+    dropped = hook.filter_by_session_category(lessons, "cleanup")
+    assert len(dropped) == 0
+
+
 def test_filter_by_session_category_none_keeps_all(hook, tmp_path):
     """Unknown category (None) keeps all lessons unchanged."""
     lessons_dir = tmp_path / "lessons"


### PR DESCRIPTION
## Summary

- **session_categories filtering**: CC hook now reads `session_categories` from lesson frontmatter and drops lessons that don't match the active session category (detected from `CASCADE_CATEGORY` / `CASCADE_EXECUTION_CATEGORY` / `GRADE_CATEGORY` / `WORKER_CATEGORY` env vars). Lessons with no `session_categories` list pass through unconditionally.
- **BM25 semantic scoring**: Okapi BM25 term-frequency scoring added as a secondary signal (weight=0.4, min_score=0.8 threshold). Implemented from stdlib only (`math.log`, dict) — no new package dependencies.
- **10 new tests** covering all new functions

## Motivation

The `cc-matcher-ignores-session-categories` memory note confirmed the CC hook was completely ignoring `session_categories` frontmatter despite gptme's own LessonMatcher supporting it. This means category-restricted lessons (e.g. only relevant during `code` sessions) were firing in `research` sessions and vice versa, contributing to the negative `lesson_delta` trend (-0.009 composite, all-negative across 476 sessions).

BM25 adds semantic recall for lessons that match by concept but not by exact keyword.

## Test plan

- [ ] `uv run pytest tests/test_cc_match_lessons.py -q` — 53 pass (2 pre-existing env failures skipped)
- [ ] `uv run mypy scripts/claude-code-hooks/match-lessons.py --ignore-missing-imports` — clean (yaml stubs warning only, pre-existing)
- [ ] Live effect: active CC sessions with `CASCADE_CATEGORY=research` will skip code/infrastructure-only lessons