### PR TITLE
fix(greptile): lower MAX_RE_TRIGGERS 3→1 and MAX_TOTAL_TRIGGERS 8→3 to stop review spam

### DIFF
--- a/scripts/github/greptile-helper.sh
+++ b/scripts/github/greptile-helper.sh
@@ -324,7 +324,7 @@ _our_trigger_status() {
     # Max-retries guard: if we've already triggered N times since the last Greptile review
     # without a new review landing, stop retrying. Prevents infinite loops when Greptile
     # acks (reacts with +1) but never posts a review (e.g., gptme#1651: 7 triggers, 0 reviews).
-    if [ -n "$review_cutoff" ] && [ "${count_since_review:-0}" -ge "${MAX_RE_TRIGGERS:-3}" ]; then
+    if [ -n "$review_cutoff" ] && [ "${count_since_review:-0}" -ge "${MAX_RE_TRIGGERS:-1}" ]; then
         echo "in-progress"
         return 0
     fi

--- a/scripts/github/greptile-helper.sh
+++ b/scripts/github/greptile-helper.sh
@@ -33,14 +33,14 @@ REPO="${2:-}"
 PR_NUMBER="${3:-}"
 TRIGGER_GRACE_SECONDS="${TRIGGER_GRACE_SECONDS:-900}"
 ACK_GRACE_SECONDS="${ACK_GRACE_SECONDS:-1200}"
-MAX_RE_TRIGGERS="${MAX_RE_TRIGGERS:-3}"  # Max re-review triggers per review cycle before backing off
+MAX_RE_TRIGGERS="${MAX_RE_TRIGGERS:-1}"  # Max re-review triggers per review cycle before backing off
 # Hard ceiling on TOTAL trigger comments we've ever posted on a PR, independent of
 # review cycles. MAX_RE_TRIGGERS resets to 0 every time Greptile posts a fresh review,
 # so a PR stuck in a fix→re-review→trigger loop (e.g. a mergeable-but-human-gated
 # product PR that keeps getting polish commits) can be triggered unboundedly — one per
 # PM run, indefinitely. This cap counts our lifetime triggers and backs off + escalates
 # once exceeded. Incident: 2026-06-16, cloud#401 hit 25 triggers, #2906 25, #408 19.
-MAX_TOTAL_TRIGGERS="${MAX_TOTAL_TRIGGERS:-8}"
+MAX_TOTAL_TRIGGERS="${MAX_TOTAL_TRIGGERS:-3}"
 GITHUB_AUTHOR="${GITHUB_AUTHOR:-$(gh api user --jq .login 2>/dev/null || echo "")}"
 
 if [ -z "$REPO" ] || [ -z "$PR_NUMBER" ]; then

--- a/tests/test_greptile_helper.py
+++ b/tests/test_greptile_helper.py
@@ -606,7 +606,7 @@ def test_trigger_re_reviews_after_score_5_when_new_commits_land():
 
 
 def test_max_retries_guard_blocks_after_repeated_triggers():
-    """3 triggers since last review (Greptile acked but never reviewed) → blocked.
+    """1 trigger since last review (== MAX_RE_TRIGGERS=1) → blocked per-cycle.
 
     Regression test for gptme#1651 (2026-03-18): 7 @greptileai review comments
     posted in one day because the 20-min ACK_GRACE_SECONDS expiry kept marking
@@ -617,16 +617,14 @@ def test_max_retries_guard_blocks_after_repeated_triggers():
         "pr_number": 1651,
         "raw_comments": [
             _make_greptile_comment(4, reviewed_at=reviewed_at),
-            # Three re-review triggers posted after the review, none responded to
-            _make_trigger_comment("test-user", _iso_ago(minutes=90)),
+            # One re-review trigger posted after the review (at the per-cycle threshold of 1)
             _make_trigger_comment("test-user", _iso_ago(minutes=60)),
-            _make_trigger_comment("test-user", _iso_ago(minutes=30)),
         ],
         "raw_commits": [
             _make_commit(_iso_ago(minutes=10)),  # New commits since review
         ],
         "raw_pr": {"created_at": _iso_ago(minutes=180)},
-        "bot_reaction_count": 1,  # Greptile acks each trigger but never posts a review
+        "bot_reaction_count": 1,  # Greptile acks the trigger but never posts a review
     }
     # check: should block (max retries reached)
     result = _run_helper("check", fixture)
@@ -647,7 +645,7 @@ def test_max_retries_guard_blocks_after_repeated_triggers():
 
 
 def test_max_retries_guard_allows_below_threshold():
-    """2 triggers since last review (< MAX_RE_TRIGGERS=3) → NOT blocked, should re-trigger.
+    """0 triggers since last review (< MAX_RE_TRIGGERS=1) → NOT blocked, should re-trigger.
 
     Lower-bound boundary check: the guard only fires at >= threshold, not below.
     """
@@ -656,9 +654,7 @@ def test_max_retries_guard_allows_below_threshold():
         "pr_number": 1651,
         "raw_comments": [
             _make_greptile_comment(4, reviewed_at=reviewed_at),
-            # Two re-review triggers posted after the review (below the threshold of 3)
-            _make_trigger_comment("test-user", _iso_ago(minutes=60)),
-            _make_trigger_comment("test-user", _iso_ago(minutes=30)),
+            # No re-review triggers posted after the review (below the threshold of 1)
         ],
         "raw_commits": [
             _make_commit(_iso_ago(minutes=10)),  # New commits since review
@@ -670,7 +666,7 @@ def test_max_retries_guard_allows_below_threshold():
     status = _run_helper("status", fixture)
     assert (
         status.stdout.strip() != "in-progress"
-    ), f"Should NOT block at count=2 (< MAX_RE_TRIGGERS=3), got: {status.stdout.strip()}"
+    ), f"Should NOT block at count=0 (< MAX_RE_TRIGGERS=1), got: {status.stdout.strip()}"
 
 
 # --- Tests for local trigger-timestamp file (API propagation delay guard) ---
@@ -688,11 +684,11 @@ def test_trigger_writes_local_timestamp_on_success():
         "pr_number": 555,
         "raw_comments": [
             _make_greptile_comment(3, reviewed_at=reviewed_at),
-            _make_trigger_comment("test-user", _iso_ago(minutes=45)),
+            # No prior triggers in this review cycle (so MAX_RE_TRIGGERS=1 doesn't block)
         ],
         "raw_commits": [_make_commit(_iso_ago(minutes=10))],
         "raw_pr": {"created_at": _iso_ago(minutes=120)},
-        "bot_reaction_count": 1,
+        "bot_reaction_count": 0,
     }
     result, ts_content = _run_helper("trigger", fixture, capture_ts_file=True)
     assert result.returncode == 0, f"stderr: {result.stderr}"


### PR DESCRIPTION
## Summary

- Lower `MAX_RE_TRIGGERS` default from 3 → 1 (one re-trigger per review cycle, then escalate)
- Lower `MAX_TOTAL_TRIGGERS` default from 8 → 3 (3 total lifetime triggers per PR, then escalate)
- Update test fixtures to match new threshold boundaries

## Motivation

Erik flagged Greptile spam/looping on gptme-contrib#1246:
> "Re-requesting Greptile review spam/looping, like in other PRs of yours recently."

With `MAX_RE_TRIGGERS=3`, PM sessions would post up to 3 `@greptileai review` comments per review cycle. With `MAX_TOTAL_TRIGGERS=8`, a single PR could accumulate 8 Greptile triggers before escalating. This is excessive — one re-review per cycle is enough to confirm a fix, and 3 total reviews is a natural escalation point.

## What changes

Both values remain overridable via environment variables, so callers with special requirements can still set higher limits.

## Test plan

- [x] `uv run pytest tests/test_greptile_helper.py -q` — all 23 tests pass
- [x] Pre-commit hooks (prek) pass cleanly