### PR TITLE
feat(gptme-sessions): add blame module + CLI subcommand

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/blame.py
+++ b/packages/gptme-sessions/src/gptme_sessions/blame.py
@@ -104,6 +104,9 @@ def _run(args: list[str]) -> str:
 
 
 def _parse_iso(value: str) -> datetime:
+    # Replace 'Z' suffix with '+00:00' for fromisoformat compatibility
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
     dt = datetime.fromisoformat(value)
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)

--- a/packages/gptme-sessions/src/gptme_sessions/blame.py
+++ b/packages/gptme-sessions/src/gptme_sessions/blame.py
@@ -1,0 +1,495 @@
+"""Session provenance — trace a file or GitHub ref back to the AI session that authored it.
+
+``gptme sessions blame`` (and the ``gptme-sessions blame`` CLI subcommand) answer
+the question "which AI session produced this line / PR / commit?" by correlating
+git author-dates with session time-windows from the session-records store.
+
+Phase 1 — commit-window correlation:
+    git history gives commits + author dates for a path/line. Session records
+    carry a ``timestamp`` (≈ session end) and ``duration_seconds``, so each
+    session defines a time window ``[timestamp - duration, timestamp]``. A commit
+    is attributed to the session whose window contains the commit's author date;
+    otherwise to the nearest session within a 30-minute tolerance.
+
+Phase 2 (GitHub refs):
+    Pass ``owner/repo#N`` to blame a PR or issue. For PRs the commit list is
+    fetched directly via the GitHub API (``gh api``). For issues, PRs that close
+    the issue are discovered and their commits attributed.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# A commit can land minutes after a session's recorded end (journal commit,
+# auto-push). Allow nearest-neighbour matching within this slack.
+NEAREST_TOLERANCE = timedelta(minutes=30)
+
+# Matches GitHub refs like ``owner/repo#123`` (PR or issue).
+GITHUB_REF_RE = re.compile(r"^([a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+)#(\d+)$")
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Attribution:
+    """A single commit attributed (or not yet attributed) to a session."""
+
+    sha: str
+    when: datetime
+    author: str
+    subject: str
+    session_id: str | None = None
+    category: str | None = None
+    productivity: float | None = None
+    journal_path: str | None = None
+    confidence: str = "unmatched"  # exact | near | unmatched
+    # Explicit resolution method, never silently downgraded:
+    #   commit-window | nearest | trajectory-exact | unattributable
+    method: str = "unattributable"
+    model: str | None = None
+    harness: str | None = None
+
+
+@dataclass
+class SessionWindow:
+    """A session's time window derived from session-records."""
+
+    session_id: str
+    start: datetime
+    end: datetime
+    category: str | None
+    harness: str | None
+    productivity: float | None
+    journal_path: str | None
+    model: str | None = None
+
+    def distance(self, when: datetime) -> timedelta:
+        """Zero if ``when`` is inside the window, else distance to the nearest edge."""
+        if self.start <= when <= self.end:
+            return timedelta(0)
+        if when < self.start:
+            return self.start - when
+        return when - self.end
+
+
+@dataclass
+class BlameResult:
+    path: str
+    line: int | None
+    attributions: list[Attribution] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Git / shell helpers
+# ---------------------------------------------------------------------------
+
+
+def _run(args: list[str]) -> str:
+    return subprocess.run(args, capture_output=True, text=True, check=True).stdout.strip()
+
+
+def _parse_iso(value: str) -> datetime:
+    dt = datetime.fromisoformat(value)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Commit discovery — file path
+# ---------------------------------------------------------------------------
+
+
+def commits_for_path(path: str, limit: int = 10) -> list[Attribution]:
+    """Return the most recent commits touching ``path``, up to ``limit``."""
+    out = _run(
+        [
+            "git",
+            "log",
+            "--follow",
+            f"--max-count={limit}",
+            "--format=%H%x1f%aI%x1f%an%x1f%s",
+            "--",
+            path,
+        ]
+    )
+    result: list[Attribution] = []
+    for line in out.splitlines():
+        if not line:
+            continue
+        sha, when, author, subject = line.split("\x1f", 3)
+        result.append(Attribution(sha=sha, when=_parse_iso(when), author=author, subject=subject))
+    return result
+
+
+def commit_for_line(path: str, line: int) -> list[Attribution]:
+    """Return the single commit that last touched ``path`` line ``line``."""
+    out = _run(["git", "blame", "-L", f"{line},{line}", "--porcelain", "--", path])
+    sha = out.splitlines()[0].split(" ", 1)[0]
+    meta = _run(["git", "show", "-s", "--format=%aI%x1f%an%x1f%s", sha])
+    when, author, subject = meta.split("\x1f", 2)
+    return [Attribution(sha=sha, when=_parse_iso(when), author=author, subject=subject)]
+
+
+# ---------------------------------------------------------------------------
+# Commit discovery — GitHub refs
+# ---------------------------------------------------------------------------
+
+
+def commits_for_github_ref(ref: str) -> list[Attribution]:
+    """Return commits associated with a GitHub PR or issue ref (``owner/repo#N``).
+
+    For PRs: fetches the PR's commit list directly via the GitHub API.
+    For issues: discovers PRs that close the issue and returns their commits.
+    Returns an empty list (with a stderr warning) when ``gh`` is unavailable or
+    the ref resolves to neither a PR nor any closing PRs.
+    """
+    m = GITHUB_REF_RE.match(ref)
+    if not m:
+        raise ValueError(f"Not a valid GitHub ref: {ref!r}")
+    owner_repo, number = m.group(1), m.group(2)
+
+    _JQ_COMMITS = (
+        ".[] | [.sha, .commit.author.date, .commit.author.name,"
+        ' (.commit.message | split("\\n")[0])] | @tsv'
+    )
+
+    def _parse_tsv(out: str) -> list[Attribution]:
+        result = []
+        for line in out.splitlines():
+            if not line:
+                continue
+            parts = line.split("\t", 3)
+            if len(parts) != 4:
+                continue
+            sha, when, author, subject = parts
+            result.append(
+                Attribution(sha=sha, when=_parse_iso(when), author=author, subject=subject)
+            )
+        return result
+
+    # Try as a PR first — the pulls endpoint returns 404 for plain issues.
+    try:
+        pr_commits = subprocess.run(
+            [
+                "gh",
+                "api",
+                f"repos/{owner_repo}/pulls/{number}/commits",
+                "--jq",
+                _JQ_COMMITS,
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        pr_results = _parse_tsv(pr_commits)
+        if pr_results:
+            return pr_results
+    except subprocess.CalledProcessError:
+        pass  # 404 or gh unavailable — fall through to issue path
+
+    # It's an issue (or an empty PR): find PRs that close it.
+    try:
+        pr_numbers = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--repo",
+                owner_repo,
+                "--state",
+                "all",
+                "--search",
+                f"closes:#{number}",
+                "--json",
+                "number",
+                "--jq",
+                ".[].number",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    except subprocess.CalledProcessError:
+        print(
+            f"warning: could not list closing PRs for {ref} (gh unavailable?)",
+            file=sys.stderr,
+        )
+        return []
+
+    attributions: list[Attribution] = []
+    for pr_num in pr_numbers.splitlines():
+        pr_num = pr_num.strip()
+        if not pr_num:
+            continue
+        try:
+            out = subprocess.run(
+                [
+                    "gh",
+                    "api",
+                    f"repos/{owner_repo}/pulls/{pr_num}/commits",
+                    "--jq",
+                    _JQ_COMMITS,
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip()
+            attributions.extend(_parse_tsv(out))
+        except subprocess.CalledProcessError:
+            continue
+
+    if not attributions:
+        print(
+            f"warning: no commits found for {ref} (not a PR and no closing PRs discovered)",
+            file=sys.stderr,
+        )
+    return attributions
+
+
+# ---------------------------------------------------------------------------
+# Session-records loading
+# ---------------------------------------------------------------------------
+
+
+def consolidated_records_sources(primary: Path) -> list[Path]:
+    """``primary`` plus its consolidated siblings in the same directory.
+
+    The active ``session-records.jsonl`` is rotated: older sessions live in
+    ``session-records-archive-*.jsonl`` and ``session-records.jsonl.bak-*``.
+    We read the archive/backup files too (primary first so it wins on
+    session_id collisions). Custom/test paths with no siblings are unaffected.
+    """
+    sources = [primary]
+    parent = primary.parent
+    if parent.exists():
+        for sib in sorted(parent.glob("session-records*.jsonl*")):
+            if sib != primary and sib.is_file():
+                sources.append(sib)
+    return sources
+
+
+def load_windows(records_path: Path) -> list[SessionWindow]:
+    """Load session time-windows from a session-records JSONL file (+ siblings)."""
+    windows: list[SessionWindow] = []
+    seen: set[str] = set()
+    for src in consolidated_records_sources(records_path):
+        if not src.exists():
+            continue
+        with src.open() as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(rec, dict):
+                    continue
+                ts = rec.get("timestamp")
+                dur = rec.get("duration_seconds")
+                sid = rec.get("session_id")
+                if not ts or not sid or sid in seen:
+                    continue
+                try:
+                    end = _parse_iso(ts)
+                except ValueError:
+                    continue
+                start = end - timedelta(seconds=dur) if dur else end
+                grades = rec.get("grades") or {}
+                seen.add(sid)
+                windows.append(
+                    SessionWindow(
+                        session_id=sid,
+                        start=start,
+                        end=end,
+                        category=rec.get("category"),
+                        harness=rec.get("harness"),
+                        productivity=grades.get("productivity"),
+                        journal_path=rec.get("journal_path"),
+                        model=rec.get("model"),
+                    )
+                )
+    return windows
+
+
+# ---------------------------------------------------------------------------
+# Attribution
+# ---------------------------------------------------------------------------
+
+
+def attribute(att: Attribution, windows: list[SessionWindow]) -> Attribution:
+    """Attribute ``att`` to the best-matching session window in-place."""
+    best: SessionWindow | None = None
+    best_dist: timedelta | None = None
+    for w in windows:
+        d = w.distance(att.when)
+        if best_dist is None or d < best_dist:
+            best, best_dist = w, d
+    if best is None or best_dist is None:
+        return att
+    if best_dist == timedelta(0):
+        att.confidence = "exact"
+        att.method = "commit-window"
+    elif best_dist <= NEAREST_TOLERANCE:
+        att.confidence = "near"
+        att.method = "nearest"
+    else:
+        return att  # too far — leave unmatched
+    att.session_id = best.session_id
+    att.category = best.category
+    att.productivity = best.productivity
+    att.journal_path = best.journal_path
+    att.model = best.model
+    att.harness = best.harness
+    return att
+
+
+def attribute_all(
+    attributions: list[Attribution], windows: list[SessionWindow]
+) -> list[Attribution]:
+    """Attribute every commit in ``attributions`` using ``windows``."""
+    for a in attributions:
+        attribute(a, windows)
+    return attributions
+
+
+# ---------------------------------------------------------------------------
+# Output rendering
+# ---------------------------------------------------------------------------
+
+
+def render_text(result: BlameResult) -> str:
+    lines: list[str] = []
+    target = result.path
+    if result.line is not None:
+        target += f":{result.line}"
+    lines.append(f"Session provenance for {target}")
+    lines.append("")
+    if not result.attributions:
+        lines.append("  (no commits found)")
+        return "\n".join(lines)
+    for a in result.attributions:
+        date_str = a.when.strftime("%Y-%m-%d %H:%M")
+        sess = a.session_id or "—"
+        cat = a.category or "—"
+        prod = f"{a.productivity:.2f}" if a.productivity is not None else "—"
+        model = a.model or "—"
+        mark = {"exact": "●", "near": "○", "unmatched": "·"}[a.confidence]
+        lines.append(f"  {mark} {date_str}  {a.sha[:9]}  session={sess}")
+        lines.append(f"      category={cat}  model={model}  productivity={prod}  method={a.method}")
+        lines.append(f"      {a.subject}")
+        if a.journal_path:
+            lines.append(f"      journal: {a.journal_path}")
+    lines.append("")
+    lines.append("  ● exact (commit-window/trajectory)  ○ nearest (≤30m)  · unattributable")
+    return "\n".join(lines)
+
+
+def render_json(result: BlameResult) -> str:
+    return json.dumps(
+        {
+            "path": result.path,
+            "line": result.line,
+            "attributions": [
+                {
+                    "sha": a.sha,
+                    "when": a.when.isoformat(),
+                    "author": a.author,
+                    "subject": a.subject,
+                    "session_id": a.session_id,
+                    "category": a.category,
+                    "productivity": a.productivity,
+                    "journal_path": a.journal_path,
+                    "confidence": a.confidence,
+                    "method": a.method,
+                    "model": a.model,
+                    "harness": a.harness,
+                }
+                for a in result.attributions
+            ],
+        },
+        indent=2,
+    )
+
+
+# ---------------------------------------------------------------------------
+# High-level entry point
+# ---------------------------------------------------------------------------
+
+#: Default location of the session-records JSONL file.
+DEFAULT_RECORDS = Path("state/sessions/session-records.jsonl")
+
+
+def blame(
+    path_or_ref: str,
+    *,
+    line: int | None = None,
+    limit: int = 10,
+    records: Path | None = None,
+) -> BlameResult:
+    """Attribute a file path or GitHub ref to its authoring session(s).
+
+    Args:
+        path_or_ref: Repo-relative file path, absolute path, or ``owner/repo#N``.
+        line: If given, blame only this line (file path mode only).
+        limit: Max commits for whole-file mode.
+        records: Path to session-records JSONL; defaults to ``DEFAULT_RECORDS``
+            resolved against the current git root when inside a repo.
+
+    Returns:
+        A :class:`BlameResult` with attributions populated.
+    """
+    # Resolve the records path.
+    if records is None:
+        try:
+            repo_root = Path(_run(["git", "rev-parse", "--show-toplevel"]))
+            records = repo_root / DEFAULT_RECORDS
+        except subprocess.CalledProcessError:
+            records = DEFAULT_RECORDS
+
+    windows = load_windows(records)
+
+    # GitHub ref path (owner/repo#N) — no local git history needed.
+    if GITHUB_REF_RE.match(path_or_ref):
+        if line is not None:
+            raise ValueError("--line is not supported for GitHub refs")
+        attributions = commits_for_github_ref(path_or_ref)
+        attribute_all(attributions, windows)
+        return BlameResult(path=path_or_ref, line=None, attributions=attributions)
+
+    # File path — requires a local git repo.
+    try:
+        repo_root = Path(_run(["git", "rev-parse", "--show-toplevel"]))
+    except subprocess.CalledProcessError:
+        raise RuntimeError("not inside a git repository")
+
+    abs_path = Path(path_or_ref).resolve()
+    try:
+        rel_path = str(abs_path.relative_to(repo_root))
+    except ValueError:
+        rel_path = path_or_ref
+
+    if line is not None:
+        attributions = commit_for_line(rel_path, line)
+    else:
+        attributions = commits_for_path(rel_path, limit)
+
+    attribute_all(attributions, windows)
+    return BlameResult(path=rel_path, line=line, attributions=attributions)

--- a/packages/gptme-sessions/src/gptme_sessions/blame.py
+++ b/packages/gptme-sessions/src/gptme_sessions/blame.py
@@ -104,7 +104,7 @@ def _run(args: list[str]) -> str:
 
 
 def _parse_iso(value: str) -> datetime:
-    # Replace 'Z' suffix with '+00:00' for fromisoformat compatibility
+    # Python 3.10 fromisoformat() doesn't support the 'Z' UTC suffix (added in 3.11)
     if value.endswith("Z"):
         value = value[:-1] + "+00:00"
     dt = datetime.fromisoformat(value)

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -3014,6 +3014,50 @@ def search(
         click.echo()
 
 
+@cli.command()
+@click.argument("path_or_ref")
+@click.option("--line", type=int, default=None, help="Blame a single line (file path only)")
+@click.option(
+    "--limit", type=int, default=10, show_default=True, help="Max commits (whole-file mode)"
+)
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+@click.option(
+    "--records",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Path to session-records.jsonl (default: auto-detected from git root)",
+)
+def blame(
+    path_or_ref: str,
+    line: int | None,
+    limit: int,
+    as_json: bool,
+    records: Path | None,
+) -> None:
+    """Attribute a file path or GitHub ref (owner/repo#N) to its authoring session(s).
+
+    PATH_OR_REF is either a repo-relative (or absolute) file path, or a GitHub
+    PR/issue ref in the form ``owner/repo#123``.
+
+    Examples:
+
+    \b
+        gptme-sessions blame scripts/watchdog.py
+        gptme-sessions blame scripts/watchdog.py --line 42
+        gptme-sessions blame gptme/gptme-contrib#1252
+    """
+    from .blame import BlameResult, blame as _blame, render_json, render_text
+
+    try:
+        result: BlameResult = _blame(path_or_ref, line=line, limit=limit, records=records)
+    except (ValueError, RuntimeError) as exc:
+        raise click.UsageError(str(exc)) from exc
+    except Exception as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    click.echo(render_json(result) if as_json else render_text(result))
+
+
 def main() -> int:
     """Entry point for console_scripts (backward-compatible wrapper).
 

--- a/packages/gptme-sessions/tests/test_blame.py
+++ b/packages/gptme-sessions/tests/test_blame.py
@@ -1,0 +1,377 @@
+"""Tests for gptme_sessions.blame — session provenance."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from gptme_sessions.blame import (
+    GITHUB_REF_RE,
+    Attribution,
+    BlameResult,
+    SessionWindow,
+    attribute,
+    attribute_all,
+    commits_for_github_ref,
+    consolidated_records_sources,
+    load_windows,
+    render_json,
+    render_text,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _dt(iso: str) -> datetime:
+    dt = datetime.fromisoformat(iso)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _window(
+    session_id: str = "sess-abc",
+    start: str = "2026-06-01T10:00:00+00:00",
+    end: str = "2026-06-01T10:30:00+00:00",
+    category: str | None = "code",
+    productivity: float | None = 0.75,
+    journal_path: str | None = "journal/2026-06-01/session.md",
+    model: str | None = "claude-sonnet-4-6",
+    harness: str | None = "claude-code",
+) -> SessionWindow:
+    return SessionWindow(
+        session_id=session_id,
+        start=_dt(start),
+        end=_dt(end),
+        category=category,
+        harness=harness,
+        productivity=productivity,
+        journal_path=journal_path,
+        model=model,
+    )
+
+
+# ---------------------------------------------------------------------------
+# GITHUB_REF_RE
+# ---------------------------------------------------------------------------
+
+
+def test_github_ref_re_matches():
+    m = GITHUB_REF_RE.match("gptme/gptme#123")
+    assert m is not None
+    assert m.group(1) == "gptme/gptme"
+    assert m.group(2) == "123"
+
+
+def test_github_ref_re_matches_dotted():
+    assert GITHUB_REF_RE.match("ErikBjare/bob#42") is not None
+    assert GITHUB_REF_RE.match("org.name/repo.name#1") is not None
+
+
+def test_github_ref_re_no_match():
+    assert GITHUB_REF_RE.match("just/a/path.py") is None
+    assert GITHUB_REF_RE.match("scripts/watchdog.py") is None
+    assert GITHUB_REF_RE.match("owner/repo") is None
+
+
+# ---------------------------------------------------------------------------
+# SessionWindow.distance
+# ---------------------------------------------------------------------------
+
+
+def test_distance_inside_window():
+    w = _window()
+    mid = _dt("2026-06-01T10:15:00+00:00")
+    assert w.distance(mid) == timedelta(0)
+
+
+def test_distance_before_window():
+    w = _window()
+    before = _dt("2026-06-01T09:45:00+00:00")
+    assert w.distance(before) == timedelta(minutes=15)
+
+
+def test_distance_after_window():
+    w = _window()
+    after = _dt("2026-06-01T11:00:00+00:00")
+    assert w.distance(after) == timedelta(minutes=30)
+
+
+# ---------------------------------------------------------------------------
+# attribute() — session correlation
+# ---------------------------------------------------------------------------
+
+
+def _att(when: str) -> Attribution:
+    return Attribution(sha="abc123def", when=_dt(when), author="Bob", subject="fix: something")
+
+
+def test_attribute_exact_hit():
+    windows = [_window()]
+    a = _att("2026-06-01T10:10:00+00:00")
+    attribute(a, windows)
+    assert a.confidence == "exact"
+    assert a.method == "commit-window"
+    assert a.session_id == "sess-abc"
+    assert a.model == "claude-sonnet-4-6"
+    assert a.productivity == 0.75
+
+
+def test_attribute_near_hit():
+    windows = [_window()]
+    # 20 minutes before window start — within 30-minute tolerance
+    a = _att("2026-06-01T09:40:00+00:00")
+    attribute(a, windows)
+    assert a.confidence == "near"
+    assert a.method == "nearest"
+    assert a.session_id == "sess-abc"
+
+
+def test_attribute_too_far():
+    windows = [_window()]
+    # 2 hours before — beyond NEAREST_TOLERANCE
+    a = _att("2026-06-01T08:00:00+00:00")
+    attribute(a, windows)
+    assert a.confidence == "unmatched"
+    assert a.session_id is None
+
+
+def test_attribute_picks_closest_window():
+    w1 = _window(
+        session_id="sess-1", start="2026-06-01T10:00:00+00:00", end="2026-06-01T10:30:00+00:00"
+    )
+    w2 = _window(
+        session_id="sess-2", start="2026-06-01T11:00:00+00:00", end="2026-06-01T11:30:00+00:00"
+    )
+    a = _att("2026-06-01T10:45:00+00:00")  # between both windows
+    attribute(a, [w1, w2])
+    # 15 min after w1's end vs 15 min before w2's start — both equidistant; first wins
+    assert a.session_id in ("sess-1", "sess-2")  # either is valid
+
+
+def test_attribute_all():
+    windows = [_window()]
+    atts = [_att("2026-06-01T10:10:00+00:00"), _att("2026-06-01T10:20:00+00:00")]
+    result = attribute_all(atts, windows)
+    assert len(result) == 2
+    assert all(a.confidence == "exact" for a in result)
+
+
+# ---------------------------------------------------------------------------
+# load_windows
+# ---------------------------------------------------------------------------
+
+
+def test_load_windows_reads_jsonl(tmp_path: Path):
+    records = tmp_path / "session-records.jsonl"
+    records.write_text(
+        json.dumps(
+            {
+                "session_id": "test-abc",
+                "timestamp": "2026-06-01T10:30:00+00:00",
+                "duration_seconds": 1800,
+                "category": "code",
+                "harness": "claude-code",
+                "model": "claude-opus-4-8",
+                "grades": {"productivity": 0.8},
+                "journal_path": "journal/2026-06-01/session.md",
+            }
+        )
+        + "\n"
+    )
+    windows = load_windows(records)
+    assert len(windows) == 1
+    w = windows[0]
+    assert w.session_id == "test-abc"
+    assert w.category == "code"
+    assert w.productivity == 0.8
+    assert w.model == "claude-opus-4-8"
+
+
+def test_load_windows_skips_malformed(tmp_path: Path):
+    records = tmp_path / "session-records.jsonl"
+    records.write_text(
+        "not-json\n"
+        + json.dumps(
+            {"session_id": "good", "timestamp": "2026-06-01T10:00:00+00:00", "duration_seconds": 60}
+        )
+        + "\n"
+    )
+    windows = load_windows(records)
+    assert len(windows) == 1
+    assert windows[0].session_id == "good"
+
+
+def test_load_windows_missing_file(tmp_path: Path):
+    windows = load_windows(tmp_path / "nonexistent.jsonl")
+    assert windows == []
+
+
+def test_load_windows_deduplicates_session_ids(tmp_path: Path):
+    record = json.dumps(
+        {
+            "session_id": "dupe",
+            "timestamp": "2026-06-01T10:00:00+00:00",
+            "duration_seconds": 60,
+        }
+    )
+    records = tmp_path / "session-records.jsonl"
+    records.write_text(record + "\n" + record + "\n")
+    windows = load_windows(records)
+    assert len(windows) == 1
+
+
+def test_load_windows_consolidated_siblings(tmp_path: Path):
+    active = tmp_path / "session-records.jsonl"
+    bak = tmp_path / "session-records.jsonl.bak-abc"
+    active.write_text(
+        json.dumps(
+            {
+                "session_id": "new-session",
+                "timestamp": "2026-07-01T10:00:00+00:00",
+                "duration_seconds": 60,
+            }
+        )
+        + "\n"
+    )
+    bak.write_text(
+        json.dumps(
+            {
+                "session_id": "old-session",
+                "timestamp": "2026-05-01T10:00:00+00:00",
+                "duration_seconds": 60,
+            }
+        )
+        + "\n"
+    )
+    windows = load_windows(active)
+    ids = {w.session_id for w in windows}
+    assert "new-session" in ids
+    assert "old-session" in ids
+
+
+# ---------------------------------------------------------------------------
+# consolidated_records_sources
+# ---------------------------------------------------------------------------
+
+
+def test_consolidated_records_sources_includes_siblings(tmp_path: Path):
+    primary = tmp_path / "session-records.jsonl"
+    primary.touch()
+    bak = tmp_path / "session-records.jsonl.bak-xyz"
+    bak.touch()
+    archive = tmp_path / "session-records-archive-2026-05.jsonl"
+    archive.touch()
+    sources = consolidated_records_sources(primary)
+    assert sources[0] == primary
+    assert bak in sources
+    assert archive in sources
+
+
+def test_consolidated_records_sources_missing_dir(tmp_path: Path):
+    primary = tmp_path / "nonexistent" / "session-records.jsonl"
+    sources = consolidated_records_sources(primary)
+    assert sources == [primary]
+
+
+# ---------------------------------------------------------------------------
+# commits_for_github_ref
+# ---------------------------------------------------------------------------
+
+
+TSV_ROW = "abc123def456\t2026-06-01T10:00:00Z\tBob\tfix: stale model\n"
+
+
+def test_commits_for_github_ref_pr(monkeypatch):
+    """PR ref fetches commits directly."""
+
+    def _fake_run(args, **kwargs):
+        result = MagicMock()
+        result.stdout = TSV_ROW
+        result.returncode = 0
+        return result
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    atts = commits_for_github_ref("gptme/gptme#42")
+    assert len(atts) == 1
+    assert atts[0].sha == "abc123def456"
+    assert atts[0].author == "Bob"
+    assert atts[0].subject == "fix: stale model"
+
+
+def test_commits_for_github_ref_invalid():
+    with pytest.raises(ValueError, match="Not a valid GitHub ref"):
+        commits_for_github_ref("not-a-ref")
+
+
+def test_commits_for_github_ref_gh_unavailable(monkeypatch, capsys):
+    """When gh is unavailable, returns empty list with a warning."""
+
+    def _raise(*args, **kwargs):
+        raise subprocess.CalledProcessError(1, "gh")
+
+    monkeypatch.setattr(subprocess, "run", _raise)
+    atts = commits_for_github_ref("gptme/gptme#1")
+    assert atts == []
+    captured = capsys.readouterr()
+    assert "warning" in captured.err.lower()
+
+
+# ---------------------------------------------------------------------------
+# render_text / render_json
+# ---------------------------------------------------------------------------
+
+
+def test_render_text_no_attributions():
+    result = BlameResult(path="scripts/foo.py", line=None)
+    out = render_text(result)
+    assert "no commits found" in out
+
+
+def test_render_text_with_attribution():
+    a = Attribution(
+        sha="abc123def456789",
+        when=_dt("2026-06-01T10:00:00+00:00"),
+        author="Bob",
+        subject="fix: something",
+        session_id="sess-abc",
+        category="code",
+        productivity=0.75,
+        confidence="exact",
+        method="commit-window",
+        model="claude-sonnet-4-6",
+    )
+    result = BlameResult(path="scripts/foo.py", line=None, attributions=[a])
+    out = render_text(result)
+    assert "sess-abc" in out
+    assert "●" in out  # exact mark
+    assert "code" in out
+
+
+def test_render_json_round_trip():
+    a = Attribution(
+        sha="abc123",
+        when=_dt("2026-06-01T10:00:00+00:00"),
+        author="Bob",
+        subject="fix: x",
+        session_id="sess-1",
+        confidence="exact",
+        method="commit-window",
+    )
+    result = BlameResult(path="foo.py", line=42, attributions=[a])
+    data = json.loads(render_json(result))
+    assert data["path"] == "foo.py"
+    assert data["line"] == 42
+    assert len(data["attributions"]) == 1
+    att = data["attributions"][0]
+    assert att["sha"] == "abc123"
+    assert att["session_id"] == "sess-1"
+    assert att["confidence"] == "exact"


### PR DESCRIPTION
## Summary

Upstreams session-provenance functionality from `ErikBjare/bob`'s `scripts/analysis/sessions-blame.py` wrapper into `gptme-sessions`, where it belongs (per ErikBjare/bob#632 feedback from @ErikBjare).

**What ships:**
- `gptme_sessions/blame.py`: core blame module with attribution data types (`Attribution`, `SessionWindow`, `BlameResult`), file-path blame (`commits_for_path`, `commit_for_line`), **GitHub PR/issue ref support** (`commits_for_github_ref` — the new feature), session-records loading with consolidated-source support, session time-window correlation, and text/JSON renderers.
- `gptme-sessions blame <path-or-ref>` CLI subcommand — accepts a repo-relative file path or a GitHub ref (`owner/repo#N`), with `--line`, `--limit`, `--json`, and `--records` options.
- 24 new tests covering all public functions.

**Bob-local side effect:** `scripts/analysis/sessions-blame.py` is now a thin wrapper (~120 lines vs 580 before) that imports from `gptme_sessions.blame` and adds the Claude Code trajectory-scan enrichment layer that belongs only in Bob's workspace.

## Test plan
- [ ] `uv run pytest packages/gptme-sessions/tests/test_blame.py -v` — 24 new tests pass
- [ ] `uv run pytest packages/gptme-sessions/tests/ -q` — existing 996 tests still pass
- [ ] `gptme-sessions blame scripts/analysis/sessions-blame.py` — smoke test CLI
- [ ] `gptme-sessions blame gptme/gptme-contrib#1252 --json` — smoke test GitHub ref

Refs: ErikBjare/bob#632