### PR TITLE
fix(coordination): check BOB_WORKSPACE/AGENT_WORKSPACE before git-root discovery

### DIFF
--- a/packages/gptme-coordination/src/gptme_coordination/db.py
+++ b/packages/gptme-coordination/src/gptme_coordination/db.py
@@ -88,8 +88,15 @@ def resolve_coordination_db_path(
     Priority order:
     1. ``COORDINATION_DB`` environment variable
     2. Explicit ``repo_root`` from the caller
-    3. Git root discovered from ``cwd`` (or the current directory)
-    4. ``cwd``-relative fallback outside a git repo
+    3. Workspace env vars: ``BOB_WORKSPACE``, ``AGENT_WORKSPACE``, ``WORKSPACE``
+    4. Git root discovered from ``cwd`` (or the current directory)
+    5. ``cwd``-relative fallback outside a git repo
+
+    The workspace env var check (3) sits before the git-root discovery so that
+    scripts running from inside a submodule (e.g. ``gptme-contrib/``) do not
+    inadvertently write state into the submodule directory instead of the brain
+    repo.  Any agent that sets ``BOB_WORKSPACE`` or ``AGENT_WORKSPACE`` gets the
+    correct DB path regardless of its working directory.
     """
 
     environment = os.environ if env is None else env
@@ -98,6 +105,13 @@ def resolve_coordination_db_path(
 
     if repo_root is not None:
         return Path(repo_root) / DEFAULT_DB_PATH
+
+    # Check agent workspace env vars before running git rev-parse.  A script
+    # running with CWD inside a submodule (e.g. gptme-contrib) would otherwise
+    # resolve the git root to the submodule root and write state there.
+    for var in ("BOB_WORKSPACE", "AGENT_WORKSPACE", "WORKSPACE"):
+        if workspace := environment.get(var):
+            return Path(workspace) / DEFAULT_DB_PATH
 
     base_dir = Path.cwd() if cwd is None else Path(cwd)
     try:

--- a/packages/gptme-coordination/src/gptme_coordination/db.py
+++ b/packages/gptme-coordination/src/gptme_coordination/db.py
@@ -88,7 +88,7 @@ def resolve_coordination_db_path(
     Priority order:
     1. ``COORDINATION_DB`` environment variable
     2. Explicit ``repo_root`` from the caller
-    3. Workspace env vars: ``BOB_WORKSPACE``, ``AGENT_WORKSPACE``, ``WORKSPACE``
+    3. Workspace env vars: ``BOB_WORKSPACE``, ``AGENT_WORKSPACE``
     4. Git root discovered from ``cwd`` (or the current directory)
     5. ``cwd``-relative fallback outside a git repo
 
@@ -97,6 +97,10 @@ def resolve_coordination_db_path(
     inadvertently write state into the submodule directory instead of the brain
     repo.  Any agent that sets ``BOB_WORKSPACE`` or ``AGENT_WORKSPACE`` gets the
     correct DB path regardless of its working directory.
+
+    Note: the generic ``WORKSPACE`` variable is intentionally excluded — it is
+    set by GitHub Actions and many CI systems to the checkout directory, which
+    would silently redirect coordination state in unrelated environments.
     """
 
     environment = os.environ if env is None else env
@@ -109,9 +113,12 @@ def resolve_coordination_db_path(
     # Check agent workspace env vars before running git rev-parse.  A script
     # running with CWD inside a submodule (e.g. gptme-contrib) would otherwise
     # resolve the git root to the submodule root and write state there.
-    for var in ("BOB_WORKSPACE", "AGENT_WORKSPACE", "WORKSPACE"):
+    # Only accept absolute paths to guard against relative or tilde values.
+    for var in ("BOB_WORKSPACE", "AGENT_WORKSPACE"):
         if workspace := environment.get(var):
-            return Path(workspace) / DEFAULT_DB_PATH
+            p = Path(workspace)
+            if p.is_absolute():
+                return p / DEFAULT_DB_PATH
 
     base_dir = Path.cwd() if cwd is None else Path(cwd)
     try:

--- a/packages/gptme-coordination/tests/test_db.py
+++ b/packages/gptme-coordination/tests/test_db.py
@@ -38,13 +38,15 @@ class TestResolveCoordinationDbPath:
             # Use a subdirectory as cwd so git-discovery result differs from fallback.
             subdir = git_root / "sub"
             subdir.mkdir()
-            result = resolve_coordination_db_path(cwd=subdir)
+            # Pass empty env so workspace env vars don't shadow git-root discovery.
+            result = resolve_coordination_db_path(cwd=subdir, env={})
             assert result == git_root / "state/coordination/coord.db"
 
     def test_fallback_when_not_in_git_repo(self):
         """Falls back to cwd-relative path when outside a git repo."""
         with tempfile.TemporaryDirectory() as tmp:
-            result = resolve_coordination_db_path(cwd=tmp)
+            # Pass empty env so workspace env vars don't shadow the cwd fallback.
+            result = resolve_coordination_db_path(cwd=tmp, env={})
             assert result == Path(tmp) / "state/coordination/coord.db"
 
     def test_env_overrides_git_root(self):
@@ -56,6 +58,64 @@ class TestResolveCoordinationDbPath:
             subprocess.run(["git", "init"], cwd=git_root, capture_output=True)
             env = {"COORDINATION_DB": str(custom)}
             result = resolve_coordination_db_path(cwd=git_root, env=env)
+            assert result == custom
+
+    def test_bob_workspace_beats_git_root(self):
+        """BOB_WORKSPACE takes priority over git root discovery."""
+        with tempfile.TemporaryDirectory() as tmp:
+            brain_dir = Path(tmp) / "brain"
+            brain_dir.mkdir()
+            # cwd points at a submodule git root (gptme-contrib equivalent)
+            submodule = Path(tmp) / "gptme-contrib"
+            submodule.mkdir()
+            subprocess.run(["git", "init"], cwd=submodule, capture_output=True)
+            env = {"BOB_WORKSPACE": str(brain_dir)}
+            result = resolve_coordination_db_path(cwd=submodule, env=env)
+            assert result == brain_dir / "state/coordination/coord.db"
+
+    def test_agent_workspace_beats_git_root(self):
+        """AGENT_WORKSPACE takes priority over git root discovery."""
+        with tempfile.TemporaryDirectory() as tmp:
+            brain_dir = Path(tmp) / "brain"
+            brain_dir.mkdir()
+            submodule = Path(tmp) / "gptme-contrib"
+            submodule.mkdir()
+            subprocess.run(["git", "init"], cwd=submodule, capture_output=True)
+            env = {"AGENT_WORKSPACE": str(brain_dir)}
+            result = resolve_coordination_db_path(cwd=submodule, env=env)
+            assert result == brain_dir / "state/coordination/coord.db"
+
+    def test_workspace_beats_git_root(self):
+        """WORKSPACE takes priority over git root discovery."""
+        with tempfile.TemporaryDirectory() as tmp:
+            brain_dir = Path(tmp) / "brain"
+            brain_dir.mkdir()
+            submodule = Path(tmp) / "gptme-contrib"
+            submodule.mkdir()
+            subprocess.run(["git", "init"], cwd=submodule, capture_output=True)
+            env = {"WORKSPACE": str(brain_dir)}
+            result = resolve_coordination_db_path(cwd=submodule, env=env)
+            assert result == brain_dir / "state/coordination/coord.db"
+
+    def test_bob_workspace_priority_over_agent_workspace(self):
+        """BOB_WORKSPACE takes priority over AGENT_WORKSPACE."""
+        with tempfile.TemporaryDirectory() as tmp:
+            bob_dir = Path(tmp) / "bob"
+            agent_dir = Path(tmp) / "agent"
+            bob_dir.mkdir()
+            agent_dir.mkdir()
+            env = {"BOB_WORKSPACE": str(bob_dir), "AGENT_WORKSPACE": str(agent_dir)}
+            result = resolve_coordination_db_path(cwd=tmp, env=env)
+            assert result == bob_dir / "state/coordination/coord.db"
+
+    def test_coordination_db_beats_workspace_vars(self):
+        """COORDINATION_DB still wins even when BOB_WORKSPACE is set."""
+        with tempfile.TemporaryDirectory() as tmp:
+            brain_dir = Path(tmp) / "brain"
+            brain_dir.mkdir()
+            custom = Path(tmp) / "explicit.db"
+            env = {"COORDINATION_DB": str(custom), "BOB_WORKSPACE": str(brain_dir)}
+            result = resolve_coordination_db_path(cwd=tmp, env=env)
             assert result == custom
 
     def test_default_env_defaults_to_os_environ(self):

--- a/packages/gptme-coordination/tests/test_db.py
+++ b/packages/gptme-coordination/tests/test_db.py
@@ -85,8 +85,8 @@ class TestResolveCoordinationDbPath:
             result = resolve_coordination_db_path(cwd=submodule, env=env)
             assert result == brain_dir / "state/coordination/coord.db"
 
-    def test_workspace_beats_git_root(self):
-        """WORKSPACE takes priority over git root discovery."""
+    def test_workspace_env_var_ignored(self):
+        """Generic WORKSPACE env var (e.g. from GitHub Actions) is ignored."""
         with tempfile.TemporaryDirectory() as tmp:
             brain_dir = Path(tmp) / "brain"
             brain_dir.mkdir()
@@ -95,7 +95,17 @@ class TestResolveCoordinationDbPath:
             subprocess.run(["git", "init"], cwd=submodule, capture_output=True)
             env = {"WORKSPACE": str(brain_dir)}
             result = resolve_coordination_db_path(cwd=submodule, env=env)
-            assert result == brain_dir / "state/coordination/coord.db"
+            # WORKSPACE is intentionally not consulted — should fall back to git root
+            assert result == submodule / "state/coordination/coord.db"
+
+    def test_relative_workspace_path_ignored(self):
+        """Relative BOB_WORKSPACE paths are skipped (absolute paths only)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            result = resolve_coordination_db_path(
+                cwd=tmp, env={"BOB_WORKSPACE": "relative/path"}
+            )
+            # relative path is ignored — falls back to git root or cwd
+            assert result == Path(tmp) / "state/coordination/coord.db"
 
     def test_bob_workspace_priority_over_agent_workspace(self):
         """BOB_WORKSPACE takes priority over AGENT_WORKSPACE."""


### PR DESCRIPTION
## Problem

When a script runs with `CWD` inside a submodule (e.g. `gptme-contrib/`), `git rev-parse --show-toplevel` returns the submodule root. `resolve_coordination_db_path` then builds the DB path as `gptme-contrib/state/coordination/coord.db`, writing coordination state into the submodule directory instead of the brain repo.

This was the root cause of the file writes tracked in #1250 (runtime state dirs appearing in gptme-contrib). Reported and diagnosed in #1255.

## Fix

Add `BOB_WORKSPACE`, `AGENT_WORKSPACE`, and `WORKSPACE` checks between the explicit-`repo_root` step and the git-root discovery:

**New priority order:**
1. `COORDINATION_DB` env var (unchanged — highest priority explicit override)
2. Explicit `repo_root` argument (unchanged)
3. `BOB_WORKSPACE` / `AGENT_WORKSPACE` / `WORKSPACE` env vars **[NEW]**
4. `git rev-parse --show-toplevel` from `cwd` (unchanged)
5. `cwd`-relative fallback outside a git repo (unchanged)

Any agent that sets `BOB_WORKSPACE` or `AGENT_WORKSPACE` now always writes coordination state to the correct directory regardless of its working directory. This is consistent with how `scripts/github/graphql-attribution.sh` resolves the log directory.

## Tests

- Updated 2 existing tests (`test_git_root_discovery`, `test_fallback_when_not_in_git_repo`) to pass `env={}` so a live `BOB_WORKSPACE` in the dev environment doesn't shadow the paths under test.
- Added 5 new tests covering the full priority ordering: `BOB_WORKSPACE` beats git root, `AGENT_WORKSPACE` beats git root, `WORKSPACE` beats git root, `BOB_WORKSPACE` beats `AGENT_WORKSPACE`, `COORDINATION_DB` beats all workspace vars.

All 18 tests pass.

## Related

Closes #1255
Partially addresses #1250 (the `coordination/` writes; the gh-api-cache and graphql-log entries are already fixed in `graphql-attribution.sh`)