### PR TITLE
fix(self-merge-check): raise on PR number mismatch in fetch_pr

### DIFF
--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -472,6 +472,20 @@ def fetch_pr(repo: str, number: int) -> dict[str, Any]:
         raise RuntimeError(f"Failed to fetch PR metadata for {repo}#{number}")
 
     pr = cast(dict[str, Any], json.loads(raw))
+
+    # Defensive check: the returned PR number must match what was requested.
+    # A cache key collision in the gh shim (e.g. graphql-attribution.sh with a
+    # stride-2 hash) can return stale data for a different PR number, producing
+    # wrong url/head_sha while the correct number comes from the function argument.
+    # Incident: gptme-contrib#1257 returned #1256's url+SHA after stride-2 collision.
+    returned_number = pr.get("number")
+    if returned_number is not None and returned_number != number:
+        raise RuntimeError(
+            f"PR data mismatch for {repo}#{number}: gh returned data for #{returned_number}. "
+            f"Possible cache key collision in gh wrapper. "
+            f"Try GH_API_CACHE_TTL=0 to bypass the cache."
+        )
+
     pr["files"] = _fetch_pr_files(repo, number)
     return pr
 

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -479,10 +479,10 @@ def fetch_pr(repo: str, number: int) -> dict[str, Any]:
     # wrong url/head_sha while the correct number comes from the function argument.
     # Incident: gptme-contrib#1257 returned #1256's url+SHA after stride-2 collision.
     returned_number = pr.get("number")
-    if returned_number is not None and returned_number != number:
+    if returned_number != number:
         raise RuntimeError(
-            f"PR data mismatch for {repo}#{number}: gh returned data for #{returned_number}. "
-            f"Possible cache key collision in gh wrapper. "
+            f"PR data mismatch for {repo}#{number}: gh returned data for #{returned_number!r}. "
+            f"Possible cache key collision in gh wrapper or malformed payload. "
             f"Try GH_API_CACHE_TTL=0 to bypass the cache."
         )
 

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -1374,3 +1374,40 @@ def test_dot_slash_prefixed_root_readme_is_spec_like() -> None:
     # GitHub API never produces ./-prefixed paths, but harden against it anyway.
     assert self_merge_check.is_spec_like_doc("./README.md") is True
     assert self_merge_check.is_spec_like_doc("./ARCHITECTURE.md") is True
+
+
+# --- fetch_pr PR-number mismatch guard ---
+
+
+def test_fetch_pr_raises_on_number_mismatch() -> None:
+    """fetch_pr must raise RuntimeError when the gh response carries a different PR number.
+
+    Root cause: graphql-attribution.sh's on-disk cache had a stride-2 hash that
+    caused PR numbers differing by 1 (e.g. 1256 vs 1257) to collide. The cache
+    returned stale data with the wrong url/head_sha while the caller-supplied number
+    was used for CheckResult.number, producing a silent mismatch.
+    """
+    # Simulate the shim returning cached data for PR #1256 when #1257 was requested.
+    stale_payload = json.dumps(
+        {
+            "number": 1256,
+            "title": "stale cached PR",
+            "url": "https://github.com/gptme/gptme-contrib/pull/1256",
+            "author": {"login": "TimeToBuildBob"},
+            "statusCheckRollup": [],
+            "isDraft": False,
+            "state": "OPEN",
+            "reviewDecision": None,
+            "headRefOid": "8a27c142stale",
+            "mergeStateStatus": "CLEAN",
+        }
+    )
+
+    with (
+        patch.object(self_merge_check, "run_gh", return_value=stale_payload),
+        patch.object(self_merge_check, "_fetch_pr_files", return_value=[]),
+    ):
+        with pytest.raises(
+            RuntimeError, match="PR data mismatch.*1257.*returned.*1256"
+        ):
+            self_merge_check.fetch_pr("gptme/gptme-contrib", 1257)

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -1411,3 +1411,34 @@ def test_fetch_pr_raises_on_number_mismatch() -> None:
             RuntimeError, match="PR data mismatch.*1257.*returned.*1256"
         ):
             self_merge_check.fetch_pr("gptme/gptme-contrib", 1257)
+
+
+def test_fetch_pr_raises_on_missing_number() -> None:
+    """fetch_pr must raise when the gh response omits the 'number' field entirely.
+
+    A malformed or truncated cache payload with no 'number' key previously
+    passed the guard (None is not None → False) and let stale url/headRefOid
+    through. With the is-not-None guard removed, None != requested_number
+    triggers the same RuntimeError, ensuring fail-closed behaviour.
+    """
+    malformed_payload = json.dumps(
+        {
+            # 'number' key intentionally absent
+            "title": "malformed PR",
+            "url": "https://github.com/gptme/gptme-contrib/pull/9999",
+            "author": {"login": "TimeToBuildBob"},
+            "statusCheckRollup": [],
+            "isDraft": False,
+            "state": "OPEN",
+            "reviewDecision": None,
+            "headRefOid": "deadbeefmalformed",
+            "mergeStateStatus": "CLEAN",
+        }
+    )
+
+    with (
+        patch.object(self_merge_check, "run_gh", return_value=malformed_payload),
+        patch.object(self_merge_check, "_fetch_pr_files", return_value=[]),
+    ):
+        with pytest.raises(RuntimeError, match="PR data mismatch.*1257.*None"):
+            self_merge_check.fetch_pr("gptme/gptme-contrib", 1257)


### PR DESCRIPTION
## Summary

- **Root cause**: `graphql-attribution.sh` (Bob's `gh` shim) has a 300s TTL on-disk cache for `gh pr view` calls. The cache key used a stride-2 hash that caused PR numbers differing at odd positions (e.g. `1256` vs `1257`) to collide. When `self-merge-check.py` fetched PR #1257, the cache returned stale data for #1256: `url` and `head_sha` came from the wrong PR, while `number` came from the function argument — silently pointing the merge gate at the wrong PR.

- **Root cause fix**: Already shipped in bob@`c033595` (full-character hash in `graphql-attribution.sh`).

- **This PR** adds a defensive guard in `fetch_pr` that compares the returned `pr["number"]` against the requested `number` and raises `RuntimeError` on mismatch, preventing any future cache collision (or other data integrity issue) from silently producing wrong `url`/`head_sha` in `CheckResult`.

- Adds `test_fetch_pr_raises_on_number_mismatch` to exercise the guard.

## Test plan

- [x] `pytest tests/test_self_merge_check.py` — 94/94 pass
- [x] New test `test_fetch_pr_raises_on_number_mismatch` confirms the guard fires on a mocked stride-2 collision scenario
- [x] Existing head_sha tests unchanged (no regression)