### PR TITLE
feat(pm-dispatch): LRU ordering within lanes — slot-starvation fairness

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -884,6 +884,71 @@ class DispatchResult:
     fallback_items: list[SlotItem] = field(default_factory=list)
 
 
+# --- LRU lane ordering (slot-starvation fairness) ---
+
+# Same convention as the bash runtime's per-slot dispatch cooldown markers
+# (``record_slot_dispatch`` in project-monitoring-dispatch.sh writes
+# ``<slot_safe>.ts`` files holding an epoch timestamp).
+DISPATCH_COOLDOWN_DIR_ENV = "PM_DISPATCH_COOLDOWN_DIR"
+DEFAULT_DISPATCH_COOLDOWN_DIR = "/tmp/bob-pm-dispatch-cooldown"
+
+
+def _item_types(data: dict[str, Any]) -> list[str]:
+    item_types = data.get("types") or []
+    if not isinstance(item_types, list) or not item_types:
+        t = data.get("type")
+        item_types = [t] if isinstance(t, str) else []
+    return item_types
+
+
+def _item_slot_safe(data: dict[str, Any]) -> str:
+    """Slot-key of a grouped-item dict, sanitized like the bash slot_safe."""
+    key = derive_slot_key(
+        str(data.get("repo") or ""),
+        data.get("number"),
+        _item_types(data),
+        data.get("title"),
+    )
+    return _sanitize_unit_name(key)
+
+
+def _last_dispatch_epoch(slot_safe: str, cooldown_dir: Path) -> int:
+    """Epoch of the slot's last dispatch, 0 when never dispatched / unreadable."""
+    try:
+        return int((cooldown_dir / f"{slot_safe}.ts").read_text().strip())
+    except (OSError, ValueError):
+        return 0
+
+
+def order_lane_lru(
+    lane_items: list[dict[str, Any]], cooldown_dir: Path | None = None
+) -> list[dict[str, Any]]:
+    """Order a lane's items least-recently-dispatched first (starvation fairness).
+
+    The dispatch loop consumes each lane file top-to-bottom under a global slot
+    cap, so without ordering, whatever the gate pipeline emitted first wins the
+    remaining cap every cycle and long-blocked items (e.g. sub-floor-Greptile
+    PRs) starve indefinitely (observed 2026-07-09: ``skipped_cap`` 13-31/hour
+    while the same early items re-dispatched).
+
+    Ordering: never-dispatched items first (no cooldown marker → epoch 0), then
+    ascending by last-dispatch epoch. The sort is stable, so ties — including a
+    fresh cooldown dir after reboot — preserve the original gate order, i.e.
+    this degrades gracefully to the previous behavior. Freshness is preserved:
+    a brand-new mention has no marker and therefore sorts first anyway.
+    """
+    if cooldown_dir is None:
+        cooldown_dir = Path(
+            os.environ.get(DISPATCH_COOLDOWN_DIR_ENV) or DEFAULT_DISPATCH_COOLDOWN_DIR
+        )
+    if not cooldown_dir.is_dir():
+        return list(lane_items)
+    return sorted(
+        lane_items,
+        key=lambda data: _last_dispatch_epoch(_item_slot_safe(data), cooldown_dir),
+    )
+
+
 def _partition_jsonl_io(
     fast_path: Path,
     slow_path: Path,
@@ -892,8 +957,9 @@ def _partition_jsonl_io(
     """Partition grouped items JSONL from stdin or *items* into fast/slow lane files.
 
     Reads JSONL from *stdin* when *items* is ``None`` (the primary bash-bridge path).
-    Each JSONL line is parsed, lane-classified, and appended to the corresponding file.
-    Silently skips blank lines.
+    Each JSONL line is parsed, lane-classified, ordered least-recently-dispatched
+    first within its lane (see ``order_lane_lru``), and written to the
+    corresponding file. Silently skips blank lines.
     Ensures both output files exist on return even when no items are written.
     """
     fast_path.parent.mkdir(parents=True, exist_ok=True)
@@ -902,6 +968,7 @@ def _partition_jsonl_io(
     slow_path.touch()
     if items is None:
         # Read JSONL from stdin (bash bridge path)
+        lanes: dict[str, list[dict[str, Any]]] = {"fast": [], "slow": []}
         for raw in sys.stdin:
             raw = raw.strip()
             if not raw:
@@ -911,14 +978,11 @@ def _partition_jsonl_io(
             except json.JSONDecodeError:
                 logger.warning("skipping unparseable JSONL line: %.80s", raw)
                 continue
-            item_types = data.get("types") or []
-            if not isinstance(item_types, list) or not item_types:
-                t = data.get("type")
-                item_types = [t] if isinstance(t, str) else []
-            lane = classify_lane(item_types)
-            target_path = slow_path if lane == "slow" else fast_path
+            lanes[classify_lane(_item_types(data))].append(data)
+        for lane, target_path in (("fast", fast_path), ("slow", slow_path)):
             with target_path.open("a", encoding="utf-8") as fh:
-                fh.write(json.dumps(data, ensure_ascii=False) + "\n")
+                for data in order_lane_lru(lanes[lane]):
+                    fh.write(json.dumps(data, ensure_ascii=False) + "\n")
         return
 
     # Direct SlotItem path (Python-to-Python)

--- a/packages/gptme-runloops/tests/test_pm_dispatch.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch.py
@@ -11,6 +11,7 @@ import pytest
 from gptme_runloops.pm_dispatch import (
     DEFAULT_FAST_BURST_ALLOWANCE,
     DEFAULT_SLOT_CAP,
+    DISPATCH_COOLDOWN_DIR_ENV,
     MIN_BANDIT_OBSERVATIONS,
     SLOW_LANE_TYPES,
     DispatchLedger,
@@ -28,6 +29,7 @@ from gptme_runloops.pm_dispatch import (
     derive_slot_key,
     dispatch_grouped_items,
     is_direct_mention,
+    order_lane_lru,
     partition_items,
     resolve_lane_model,
 )
@@ -1626,3 +1628,89 @@ class TestRecordBanditOutcomeCLI:
                     str(tmp_path),
                 ]
             )
+
+
+class TestOrderLaneLru:
+    """LRU lane ordering — slot-starvation fairness (never-dispatched first)."""
+
+    @staticmethod
+    def _item(number: int, types: list[str] | None = None) -> dict:
+        return {
+            "repo": "foo/bar",
+            "number": number,
+            "types": types or ["pr_update"],
+        }
+
+    @staticmethod
+    def _mark(cooldown_dir, number: int, epoch: int) -> None:
+        (cooldown_dir / f"foo-bar-{number}.ts").write_text(f"{epoch}\n")
+
+    def test_never_dispatched_sorts_first(self, tmp_path):
+        cooldown = tmp_path / "cooldown"
+        cooldown.mkdir()
+        self._mark(cooldown, 1, 1_700_000_000)
+        items = [self._item(1), self._item(2)]
+
+        ordered = order_lane_lru(items, cooldown_dir=cooldown)
+
+        assert [i["number"] for i in ordered] == [2, 1]
+
+    def test_lru_order_oldest_dispatch_first(self, tmp_path):
+        cooldown = tmp_path / "cooldown"
+        cooldown.mkdir()
+        self._mark(cooldown, 1, 3000)
+        self._mark(cooldown, 2, 1000)
+        self._mark(cooldown, 3, 2000)
+        items = [self._item(1), self._item(2), self._item(3)]
+
+        ordered = order_lane_lru(items, cooldown_dir=cooldown)
+
+        assert [i["number"] for i in ordered] == [2, 3, 1]
+
+    def test_ties_preserve_original_order(self, tmp_path):
+        cooldown = tmp_path / "cooldown"
+        cooldown.mkdir()
+        items = [self._item(5), self._item(3), self._item(9)]
+
+        ordered = order_lane_lru(items, cooldown_dir=cooldown)
+
+        assert [i["number"] for i in ordered] == [5, 3, 9]
+
+    def test_missing_cooldown_dir_is_noop(self, tmp_path):
+        items = [self._item(2), self._item(1)]
+
+        ordered = order_lane_lru(items, cooldown_dir=tmp_path / "absent")
+
+        assert [i["number"] for i in ordered] == [2, 1]
+
+    def test_unreadable_marker_counts_as_never_dispatched(self, tmp_path):
+        cooldown = tmp_path / "cooldown"
+        cooldown.mkdir()
+        (cooldown / "foo-bar-1.ts").write_text("not-a-number\n")
+        self._mark(cooldown, 2, 1000)
+        items = [self._item(2), self._item(1)]
+
+        ordered = order_lane_lru(items, cooldown_dir=cooldown)
+
+        # 1's garbage marker reads as epoch 0 -> sorts before 2.
+        assert [i["number"] for i in ordered] == [1, 2]
+
+    def test_partition_stdin_orders_lanes_lru(self, tmp_path, monkeypatch):
+        """End-to-end: the bash-bridge stdin path writes lanes in LRU order."""
+        cooldown = tmp_path / "cooldown"
+        cooldown.mkdir()
+        # Slow lane: 1 dispatched recently, 2 long ago, 3 never.
+        self._mark(cooldown, 1, 2_000_000_000)
+        self._mark(cooldown, 2, 1_000_000_000)
+        monkeypatch.setenv(DISPATCH_COOLDOWN_DIR_ENV, str(cooldown))
+
+        stdin_lines = "".join(json.dumps(self._item(n)) + "\n" for n in (1, 2, 3))
+        monkeypatch.setattr("sys.stdin", io.StringIO(stdin_lines))
+        fast_path = tmp_path / "fast.jsonl"
+        slow_path = tmp_path / "slow.jsonl"
+
+        _partition_jsonl_io(fast_path, slow_path)
+
+        slow = [json.loads(line) for line in slow_path.read_text().splitlines() if line]
+        assert [i["number"] for i in slow] == [3, 2, 1]
+        assert fast_path.read_text() == ""


### PR DESCRIPTION
## Problem

The PM dispatch loop consumes each lane file top-to-bottom under a global slot cap (`PM_SLOT_CAP`). Without any aging, whatever the gate pipeline emitted first wins the remaining cap every cycle — long-blocked items (e.g. sub-floor-Greptile PRs) starve indefinitely while head-of-file items re-dispatch. Observed 2026-07-09 on Bob: `skipped_cap` 13–31/hour with the same early items winning every cycle (ErikBjare/bob merge-health items like gptme-cloud#673 found-for-dispatch every cycle, never dispatched).

## Fix

`order_lane_lru()` sorts each lane **least-recently-dispatched first**, reusing the existing per-slot cooldown markers (`PM_DISPATCH_COOLDOWN_DIR/<slot_safe>.ts`, written by bash `record_slot_dispatch`) — zero new state:

- never-dispatched items (no marker) sort first → freshness preserved (a brand-new mention has no marker and sorts first anyway)
- then ascending by last-dispatch epoch → starvation-free round-robin across cycles
- stable sort: ties (incl. fresh cooldown dir after reboot) keep the original gate order → degrades gracefully to previous behavior
- missing cooldown dir = no-op; unreadable marker = treated as never-dispatched

Wired into `_partition_jsonl_io`'s stdin bash-bridge path (what `partition_grouped_items_by_lane` calls from `project-monitoring-lib.sh`). The direct-`SlotItem` path is unchanged.

## Testing

6 new tests (`TestOrderLaneLru`): never-dispatched-first, LRU order, tie stability, missing-dir no-op, garbage-marker handling, end-to-end stdin partition ordering. Full `test_pm_dispatch.py`: **153 passed**.

## Verification plan (after merge + submodule bump on Bob)

Bob's new `check_pr_blocked_slo` vitals (operator-health) provide the before/after: blocked-PR starvation age is now measured per sweep in `state/pr-merge-health-status.json`. Expect no >24h-blocked merge-health items attributable to never-dispatched starvation within a week.

Design context: `ErikBjare/bob` `tasks/pm-slot-lru-fairness.md` + `knowledge/technical/project-monitoring-architecture.md` (slot-starvation section).