### PR TITLE
feat(runloops): port PM merge-lifecycle state machine as pure decision core

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/merge_lifecycle.py
+++ b/packages/gptme-runloops/src/gptme_runloops/merge_lifecycle.py
@@ -1,0 +1,753 @@
+"""PR merge-lifecycle state machine (pure decision core + thin gh I/O).
+
+Behavior-identical port of the bash ``run_self_merge_and_greptile`` state
+machine from ErikBjare/bob ``scripts/github/project-monitoring-lib.sh``
+(step 1 of the Phase-2 execution-consolidation migration; see
+``knowledge/technical-designs/reactive-dispatch-phase2-3-execution-consolidation.md``
+in that repo). The bash remains the runtime hotpath until the brain-side
+switchover PR; this module is the reviewable, golden-tested reference the
+switchover will diff against.
+
+Bash source lines ported (ErikBjare/bob @ dcb4bd837cf1d214f6f37e4d5c67e4029382fa61):
+
+- ``project-monitoring-lib.sh:519-609`` — ``run_self_merge_and_greptile``:
+  the two-phase state machine (self-merge gate + reason routing, then the
+  cross-repo Greptile status check). Ported as :func:`decide_self_merge_gate`,
+  :func:`decide_cross_repo_review`, and the :func:`run_merge_lifecycle`
+  orchestrator.
+- ``project-monitoring-lib.sh:577`` — the cross-repo Greptile repo pattern
+  (accepted as config; Bob-side policy values stay in the brain).
+- ``pr-merge-health-poll.py:406-504`` (ErikBjare/bob @
+  6eae7cc00a95dabaf440e589e80a1caaf378cc80) — the head-gated per-PR
+  convergence attempt counter (``f1fce829fb``: an attempt = pushed commits).
+  Ported as :func:`decide_greptile_attempt`. The sweep-level pieces
+  (counter reset for recovered PRs, conflict-timestamp recording, the
+  post-rebase *time-window* detection) stay in the poller; ``post_rebase``
+  is accepted as a computed input here.
+- ``greptile-helper.sh:186`` — the Greptile confidence-score regex, ported
+  as :func:`parse_greptile_score`.
+
+Self-merge eligibility *reason* strings matched by the reason router are
+produced by ``scripts/github/self-merge-check.py`` (this repo,
+``evaluate_pr``): ``"Greptile review not found"``, ``"Greptile has N
+unresolved review thread(s)"``, ``"Greptile score N/5 below floor M/5"``.
+
+Invariants encoded (project-monitoring-architecture.md §7b):
+
+- **Self-merge only via the gate**: the only path to ``SELF_MERGE`` is an
+  ``eligible=True`` gate result; the I/O adapter merges only through the
+  self-merge script.
+- **Greptile-helper-only triggering**: ``TRIGGER_REVIEW`` is executed solely
+  through the helper (which owns the anti-spam guards); when the helper is
+  unavailable the trigger is skipped, never inlined.
+- **An attempt = pushed commits**: :func:`decide_greptile_attempt` consumes
+  convergence budget only when the PR head advanced since the last attempt.
+- **Human > bot** is preserved *as the bash behaves today*: unresolved human
+  review threads block self-merge at the gate, but their reason string does
+  NOT match the Greptile-fix router (the word "human" breaks the substring),
+  so a human-only block routes to the generic proceed-with-session branch —
+  see the ``NOTE(parity)`` in :func:`classify_self_merge_reasons`.
+
+Design rules:
+
+- The decision core is pure: no subprocess calls, no filesystem access.
+- Bob-side policy (repo allowlists, score floors, GraphQL budget fuses) is
+  NOT hardcoded here; callers pass it via :class:`LifecycleConfig` and the
+  I/O adapter's environment.
+- Where the bash behavior is ambiguous or arguably buggy, the port preserves
+  it and marks the spot with a ``# NOTE(parity):`` comment. Behavior changes
+  come later, with the brain-side switchover.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import subprocess
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
+
+# Item types that enable the self-merge fast path (lib.sh:534).
+SELF_MERGE_TYPES: frozenset[str] = frozenset({"pr_update", "merge_ready"})
+
+# Item type that enables the cross-repo Greptile status check (lib.sh:579).
+CROSS_REPO_REVIEW_TYPE = "pr_update"
+
+# Greptile confidence-score extraction — mirrors greptile-helper.sh:186
+# jq: capture("Score[*:]*\\s*(?<n>[0-9])/5") (first match wins).
+GREPTILE_SCORE_RE = re.compile(r"Score[*:]*\s*([0-9])/5")
+
+
+# --- Decision types ---
+
+
+class MergeLifecycleAction(Enum):
+    """What the monitoring cycle should do next for a PR work item."""
+
+    SELF_MERGE = "self_merge"  # attempt merge via the self-merge gate script
+    SKIP_ITEM = "skip_item"  # self-merged — skip the LLM session entirely
+    TRIGGER_REVIEW = "trigger_review"  # trigger Greptile via greptile-helper ONLY
+    FIX_FINDINGS = "fix_findings"  # run a session with fix instructions injected
+    WAIT = "wait"  # review in-flight / unknown state — no Greptile action
+    PROCEED = "proceed"  # run the session with no Greptile injection
+    NOT_APPLICABLE = "not_applicable"  # phase gating did not match this item
+
+
+class InstructionKind(Enum):
+    """Which fix-instruction template to inject into the session prompt.
+
+    The template *bodies* (lib.sh:423-517 heredocs) are deliberately NOT
+    ported here — that is step 2 of the migration (prompt-template
+    consolidation). This enum is the seam between the two steps.
+    """
+
+    LOCAL_GREPTILE_FIX = "local_greptile_fix"  # lib.sh:425-470
+    CROSS_REPO_GREPTILE_REFRESH = "cross_repo_greptile_refresh"  # lib.sh:474-517
+
+
+class SelfMergeBlockClass(Enum):
+    """Classification of a not-eligible self-merge result's reasons."""
+
+    NO_GREPTILE_REVIEW = "no_greptile_review"
+    UNRESOLVED_THREADS = "unresolved_threads"
+    SCORE_BELOW_FLOOR = "score_below_floor"
+    OTHER = "other"
+
+
+class AttemptDecision(Enum):
+    """Outcome of the head-gated greptile convergence counter."""
+
+    DISPATCH = "dispatch"  # dispatch a fix session; one attempt consumed
+    DISPATCH_FREE = "dispatch_free"  # dispatch; no attempt consumed
+    ESCALATE = "escalate"  # suppress dispatch; surface to a human
+
+
+@dataclass(frozen=True)
+class LifecycleDecision:
+    """A single typed decision with its human-readable reason."""
+
+    action: MergeLifecycleAction
+    reason: str
+    instructions: InstructionKind | None = None
+
+
+@dataclass(frozen=True)
+class WorkItem:
+    """The grouped work item under consideration (repo, number, types)."""
+
+    repo: str
+    number: int | str
+    types: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class SelfMergeCheckResult:
+    """Parsed output of the self-merge gate (``self-merge-check.py --json``)."""
+
+    eligible: bool
+    reasons: tuple[str, ...] = ()
+
+    @classmethod
+    def from_json(cls, raw: str) -> SelfMergeCheckResult:
+        """Parse the gate's ``--json`` output the way the bash caller does.
+
+        Mirrors lib.sh:540 (``_json_get eligible False``) and lib.sh:550
+        (reasons list, empty on parse failure). Fail-closed: any parse
+        failure yields ``eligible=False`` with no reasons.
+        """
+        try:
+            data = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            return cls(eligible=False, reasons=())
+        if not isinstance(data, dict):
+            return cls(eligible=False, reasons=())
+        # NOTE(parity): the bash compares the *Python str()* of the JSON value
+        # against "True" (_json_get prints `print(v)`), so JSON `true` AND the
+        # JSON string "True" both count as eligible. Preserved exactly.
+        eligible = str(data.get("eligible", False)) == "True"
+        raw_reasons = data.get("reasons", [])
+        reasons = (
+            tuple(str(r) for r in raw_reasons) if isinstance(raw_reasons, list) else ()
+        )
+        return cls(eligible=eligible, reasons=reasons)
+
+
+@dataclass(frozen=True)
+class LifecycleConfig:
+    """Caller-supplied policy. Bob-side values live in the brain, not here.
+
+    Attributes:
+        primary_repo: the agent's own workspace repo, excluded from the
+            cross-repo Greptile check (lib.sh:579 hardcodes "ErikBjare/bob";
+            the brain passes that value).
+        greptile_repos_pattern: extended regex (``grep -qE`` semantics, i.e.
+            re.search) selecting repos where the cross-repo Greptile
+            lifecycle applies (lib.sh:577).
+    """
+
+    primary_repo: str
+    greptile_repos_pattern: str
+
+
+@dataclass
+class LifecycleResult:
+    """Outcome of one :func:`run_merge_lifecycle` pass over an item."""
+
+    skip_item: bool = False
+    instructions: InstructionKind | None = None
+    decisions: list[LifecycleDecision] = field(default_factory=list)
+
+
+# --- Pure decision core ---
+
+
+def parse_greptile_score(body: str) -> int | None:
+    """Extract the Greptile confidence score (0-5) from a summary-comment body.
+
+    Mirrors greptile-helper.sh:186 — first ``Score[*:]*\\s*N/5`` match wins;
+    returns ``None`` when no score is present.
+    """
+    m = GREPTILE_SCORE_RE.search(body)
+    return int(m.group(1)) if m else None
+
+
+def classify_self_merge_reasons(reasons: Sequence[str]) -> SelfMergeBlockClass:
+    """Classify a not-eligible gate result's reasons (lib.sh:551-572).
+
+    The bash greps the newline-joined reasons text, in priority order:
+    "Greptile review not found" > "unresolved review thread" >
+    ``Greptile score [0-9]/5 below floor``. First match wins even when other
+    blocking reasons (e.g. red CI) are also present.
+
+    NOTE(parity): the *human*-thread reason ("N unresolved human review
+    thread(s) from: ...") does NOT contain the substring "unresolved review
+    thread" (the word "human" sits inside it), so a PR blocked only by
+    unresolved human threads classifies as OTHER: the session still runs
+    (and the worker prompt tells it to answer every human comment) but no
+    Greptile fix instructions are injected. Preserved as-is.
+    """
+    text = "\n".join(reasons)
+    if "Greptile review not found" in text:
+        return SelfMergeBlockClass.NO_GREPTILE_REVIEW
+    if "unresolved review thread" in text:
+        return SelfMergeBlockClass.UNRESOLVED_THREADS
+    # lib.sh:563 — grep -qE "Greptile score [0-9]/5 below floor"
+    if re.search(r"Greptile score [0-9]/5 below floor", text):
+        return SelfMergeBlockClass.SCORE_BELOW_FLOOR
+    return SelfMergeBlockClass.OTHER
+
+
+def self_merge_gate_applicable(item: WorkItem, *, gate_available: bool = True) -> bool:
+    """Phase-A gating (lib.sh:534): gate script present + pr_update/merge_ready."""
+    return gate_available and bool(SELF_MERGE_TYPES & set(item.types))
+
+
+def decide_self_merge_gate(
+    item: WorkItem,
+    check: SelfMergeCheckResult | None,
+    *,
+    gate_available: bool = True,
+) -> LifecycleDecision:
+    """Decide the self-merge phase (lib.sh:534-575) from an observed gate result.
+
+    ``check`` is the parsed gate output (``None`` only when the phase is not
+    applicable and the gate was never run).
+    """
+    if not self_merge_gate_applicable(item, gate_available=gate_available):
+        return LifecycleDecision(
+            MergeLifecycleAction.NOT_APPLICABLE,
+            "self-merge phase skipped: gate script missing or item types "
+            "lack pr_update/merge_ready",
+        )
+    if check is None:
+        raise ValueError("self-merge phase applicable but no gate result provided")
+    if check.eligible:
+        # §7b invariant: self-merge only via the gate — SELF_MERGE is only
+        # reachable through an eligible gate verdict.
+        return LifecycleDecision(
+            MergeLifecycleAction.SELF_MERGE,
+            "self-merge gate reports eligible",
+        )
+    block = classify_self_merge_reasons(check.reasons)
+    if block is SelfMergeBlockClass.NO_GREPTILE_REVIEW:
+        # lib.sh:551-559 — trigger via helper, then proceed with the session
+        # for any other updates (no fix instructions injected).
+        return LifecycleDecision(
+            MergeLifecycleAction.TRIGGER_REVIEW,
+            "no Greptile review found — trigger via greptile-helper, then "
+            "proceed with LLM session for any other updates",
+        )
+    if block is SelfMergeBlockClass.UNRESOLVED_THREADS:
+        return LifecycleDecision(
+            MergeLifecycleAction.FIX_FINDINGS,
+            "Greptile has unresolved findings — spawn LLM session to address them",
+            instructions=InstructionKind.LOCAL_GREPTILE_FIX,
+        )
+    if block is SelfMergeBlockClass.SCORE_BELOW_FLOOR:
+        # lib.sh:563-570 — score floor blocks self-merge; dispatch a fix
+        # session seeded with the summary-body findings (gptme#2987).
+        return LifecycleDecision(
+            MergeLifecycleAction.FIX_FINDINGS,
+            "Greptile score below floor — spawn LLM session to address the "
+            "summary-body findings",
+            instructions=InstructionKind.LOCAL_GREPTILE_FIX,
+        )
+    # lib.sh:571-573 — first reason line only, empty string when no reasons.
+    first_reason = check.reasons[0] if check.reasons else ""
+    return LifecycleDecision(
+        MergeLifecycleAction.PROCEED,
+        f"not eligible for self-merge ({first_reason}), proceeding with LLM session",
+    )
+
+
+def cross_repo_review_applicable(
+    item: WorkItem,
+    config: LifecycleConfig,
+    *,
+    fix_instructions_pending: bool = False,
+) -> bool:
+    """Phase-B gating (lib.sh:579).
+
+    Applies only when: no fix instructions are already queued, the item is a
+    ``pr_update``, the repo is not the agent's primary workspace repo, and
+    the repo matches the cross-repo Greptile pattern.
+
+    NOTE(parity): the primary-repo exclusion is redundant with any sane
+    pattern (the brain's pattern never matches ErikBjare/bob) but is a
+    separate condition in the bash, so it is preserved as one here.
+    """
+    if fix_instructions_pending:
+        return False
+    if CROSS_REPO_REVIEW_TYPE not in item.types:
+        return False
+    if item.repo == config.primary_repo:
+        return False
+    # grep -qE semantics: unanchored search (patterns carry their own anchors).
+    return re.search(config.greptile_repos_pattern, item.repo) is not None
+
+
+def classify_greptile_helper_status(status: str) -> LifecycleDecision:
+    """Map a ``greptile-helper.sh status`` string to a decision (lib.sh:586-604).
+
+    NOTE(parity): the bash arm for ``none`` is dead code — the helper's
+    status command never prints "none" (it prints already-reviewed |
+    needs-re-review | in-progress | awaiting-initial-review | stale |
+    backoff). The arm is preserved because the port is behavior-identical,
+    not because it is reachable.
+
+    NOTE(parity): ``awaiting-initial-review`` and ``backoff`` fall into the
+    unknown-state arm (skip). For awaiting-initial-review that is correct by
+    policy (Greptile auto-reviews new PRs; never manually trigger initial
+    reviews) but it is reached by fallthrough, not by an explicit arm.
+    """
+    if status in ("none", "stale"):
+        return LifecycleDecision(
+            MergeLifecycleAction.TRIGGER_REVIEW,
+            f"cross-repo Greptile status '{status}' — triggering via greptile-helper",
+        )
+    if status == "needs-re-review":
+        return LifecycleDecision(
+            MergeLifecycleAction.FIX_FINDINGS,
+            "cross-repo Greptile review is stale relative to the latest "
+            "commits — injecting follow-up instructions",
+            instructions=InstructionKind.CROSS_REPO_GREPTILE_REFRESH,
+        )
+    if status == "in-progress":
+        return LifecycleDecision(
+            MergeLifecycleAction.WAIT,
+            "cross-repo Greptile review in progress — skipping trigger",
+        )
+    if status == "already-reviewed":
+        return LifecycleDecision(
+            MergeLifecycleAction.PROCEED,
+            "cross-repo Greptile review clean",
+        )
+    return LifecycleDecision(
+        MergeLifecycleAction.WAIT,
+        f"unknown Greptile state: {status} — skipping",
+    )
+
+
+def decide_cross_repo_review(
+    item: WorkItem,
+    config: LifecycleConfig,
+    status: str | None,
+    *,
+    fix_instructions_pending: bool = False,
+    helper_available: bool = True,
+) -> LifecycleDecision:
+    """Decide the cross-repo Greptile phase (lib.sh:577-606).
+
+    ``status`` is the helper's status output; pass ``None`` when the phase is
+    gated off (it is ignored then). Callers running the real helper should
+    map a failed status invocation to ``"in-progress"`` (fail-safe — the
+    bash does this at lib.sh:584; :class:`SubprocessMergeLifecycleIO`
+    replicates it).
+    """
+    if not cross_repo_review_applicable(
+        item, config, fix_instructions_pending=fix_instructions_pending
+    ):
+        return LifecycleDecision(
+            MergeLifecycleAction.NOT_APPLICABLE,
+            "cross-repo Greptile phase skipped: fix instructions pending, "
+            "not a pr_update, primary repo, or repo not in pattern",
+        )
+    if not helper_available:
+        # lib.sh:580-581 — WARN and skip the check; the session still runs.
+        return LifecycleDecision(
+            MergeLifecycleAction.PROCEED,
+            "greptile-helper.sh not found or not executable — skipping Greptile check",
+        )
+    if status is None:
+        raise ValueError("cross-repo phase applicable but no helper status provided")
+    return classify_greptile_helper_status(status)
+
+
+# --- Head-gated convergence attempt counter (f1fce829fb) ---
+
+
+def head_advanced(cur_head: str, last_attempt_head: str | None) -> bool:
+    """True when this emit consumes convergence budget (an attempt = pushed commits).
+
+    Mirrors pr-merge-health-poll.py:485-491: the first observation (no head
+    tracked yet) counts, preserving the initial dispatch; afterwards only a
+    head change counts. A re-emit at the same head means no fix landed
+    (slot-starved dispatch or a no-op session) so we dispatch again without
+    burning an attempt.
+    """
+    # NOTE(parity): an empty cur_head ("" — unparseable dedupe key) never
+    # counts after the first observation, because `bool(cur_head)` gates the
+    # comparison in the poller.
+    return last_attempt_head is None or (
+        bool(cur_head) and cur_head != last_attempt_head
+    )
+
+
+def decide_greptile_attempt(
+    entry: Mapping[str, Any],
+    cur_head: str,
+    max_attempts: int,
+    now_iso: str,
+    *,
+    score: int | None = None,
+    post_rebase: bool = False,
+) -> tuple[AttemptDecision, dict[str, Any]]:
+    """Head-gated per-PR convergence decision for one greptile_low_score emit.
+
+    Behavior-identical port of the per-signal core of
+    ``apply_convergence_cap`` (pr-merge-health-poll.py:430-502, commit
+    f1fce829fb). ``entry`` is the PR's attempt-counter state (the poller's
+    on-disk dict shape); the updated entry is returned alongside the
+    decision and must be persisted by the caller.
+
+    The *time-window* detection of post-rebase grace and the sweep-level
+    counter reset stay in the poller; ``post_rebase`` arrives here as a
+    computed boolean.
+    """
+    updated = dict(entry)
+
+    if updated.get("escalated"):
+        # Legacy escalations from before head-gated counting have no
+        # ``last_attempt_head`` — they may have escalated purely on poll
+        # re-emits that never dispatched a real fix session (incident
+        # 2026-07-09: gptme-contrib#1253 escalated at count=3 with 0
+        # commits). Reset those; real non-convergence re-escalates once
+        # actual fix attempts exhaust the counter.
+        if "last_attempt_head" in updated:
+            return AttemptDecision.ESCALATE, updated
+        updated.update({"escalated": False, "escalated_at": None, "count": 0})
+
+    count = int(updated.get("count", 0))
+
+    if count >= max_attempts:
+        updated.update(
+            {
+                "count": count,
+                "last_score": score,
+                "escalated": True,
+                "escalated_at": now_iso,
+                "last_attempt_at": now_iso,
+            }
+        )
+        return AttemptDecision.ESCALATE, updated
+
+    if post_rebase:
+        # Post-rebase Greptile re-review — dispatch the fix session but do
+        # not consume a convergence attempt slot (one-time grace).
+        updated.update(
+            {
+                "last_score": score,
+                "escalated": False,
+                "escalated_at": None,
+                "first_attempt_at": updated.get("first_attempt_at") or now_iso,
+                "last_attempt_at": now_iso,
+                "last_attempt_head": cur_head or updated.get("last_attempt_head"),
+                "conflict_grace_used_at": now_iso,
+            }
+        )
+        return AttemptDecision.DISPATCH_FREE, updated
+
+    last_head = updated.get("last_attempt_head")
+    counts_this_emit = head_advanced(cur_head, last_head)
+    updated.update(
+        {
+            "count": count + 1 if counts_this_emit else count,
+            "last_score": score,
+            "escalated": False,
+            "escalated_at": None,
+            "first_attempt_at": updated.get("first_attempt_at") or now_iso,
+            "last_attempt_at": now_iso,
+            "last_attempt_head": cur_head or last_head,
+        }
+    )
+    return (
+        AttemptDecision.DISPATCH if counts_this_emit else AttemptDecision.DISPATCH_FREE,
+        updated,
+    )
+
+
+# --- Thin I/O boundary ---
+
+
+class MergeLifecycleIO(Protocol):
+    """Injectable side-effect boundary for :func:`run_merge_lifecycle`.
+
+    Implementations wrap the gh-backed scripts; the decision core above
+    never touches a subprocess.
+    """
+
+    def self_merge_check(self, repo: str, number: int | str) -> SelfMergeCheckResult:
+        """Run the self-merge gate and return its parsed verdict."""
+        ...
+
+    def self_merge(self, repo: str, number: int | str) -> bool:
+        """Attempt the self-merge via the gate script; True on success."""
+        ...
+
+    def greptile_status(self, repo: str, number: int | str) -> str:
+        """Return the greptile-helper status string ('in-progress' on failure)."""
+        ...
+
+    def trigger_review(self, repo: str, number: int | str) -> None:
+        """Trigger a Greptile review via greptile-helper (anti-spam guarded)."""
+        ...
+
+    def promote_item_state(self, repo: str, number: int | str) -> None:
+        """Advance the item's activity-gate state after a self-merge."""
+        ...
+
+
+def run_merge_lifecycle(
+    item: WorkItem,
+    config: LifecycleConfig,
+    io: MergeLifecycleIO,
+    *,
+    gate_available: bool = True,
+    helper_available: bool = True,
+    fix_instructions_pending: bool = False,
+    log: Callable[[str], None] | None = None,
+) -> LifecycleResult:
+    """Run the two-phase merge lifecycle for one work item.
+
+    Orchestrates I/O in exactly the bash order (lib.sh:523-609):
+
+    Phase A (self-merge fast path, lib.sh:534-575): when the gate script is
+    available and the item is a pr_update/merge_ready, evaluate eligibility.
+    Eligible → attempt the merge; success skips the LLM session entirely
+    (returns ``skip_item=True``, mirroring the bash ``return 1``). Not
+    eligible → route on the blocking reason (trigger review / queue local
+    fix instructions / proceed).
+
+    NOTE(parity): when the gate says eligible but the merge attempt fails,
+    the bash falls through *silently* to Phase B — no message, no fix
+    instructions, no retry. Preserved.
+
+    Phase B (cross-repo Greptile check, lib.sh:577-606): when no fix
+    instructions are queued and the item is a cross-repo pr_update in the
+    configured pattern, consult the helper status and trigger / queue
+    refresh instructions / wait accordingly.
+
+    Returns the accumulated decisions plus the instruction kind (if any) the
+    session prompt should inject.
+    """
+    emit = log or (lambda msg: logger.info("%s", msg))
+    result = LifecycleResult()
+
+    # --- Phase A: self-merge fast path (lib.sh:534-575) ---
+    if self_merge_gate_applicable(item, gate_available=gate_available):
+        emit("  Checking self-merge eligibility...")
+        check = io.self_merge_check(item.repo, item.number)
+        decision = decide_self_merge_gate(item, check, gate_available=gate_available)
+        result.decisions.append(decision)
+
+        if decision.action is MergeLifecycleAction.SELF_MERGE:
+            if io.self_merge(item.repo, item.number):
+                emit("  Self-merged! Skipping LLM session.")
+                io.promote_item_state(item.repo, item.number)
+                result.decisions.append(
+                    LifecycleDecision(
+                        MergeLifecycleAction.SKIP_ITEM,
+                        "self-merge succeeded — skip the LLM session",
+                    )
+                )
+                result.skip_item = True
+                return result
+            # NOTE(parity): failed merge attempt falls through silently.
+        elif decision.action is MergeLifecycleAction.TRIGGER_REVIEW:
+            if helper_available:
+                emit(
+                    f"  No Greptile review found. Triggering review on #{item.number}..."
+                )
+                io.trigger_review(item.repo, item.number)
+                emit(
+                    "  Review triggered. Proceeding with LLM session for any "
+                    "other updates."
+                )
+            else:
+                # lib.sh:557 — never trigger outside the helper (spam guard).
+                emit(
+                    "  WARN: greptile-helper.sh not found — skipping trigger to avoid spam"
+                )
+        elif decision.action is MergeLifecycleAction.FIX_FINDINGS:
+            emit(f"  {decision.reason}")
+            result.instructions = decision.instructions
+        else:
+            emit(f"  {decision.reason}")
+
+    # --- Phase B: cross-repo Greptile lifecycle (lib.sh:577-606) ---
+    pending = fix_instructions_pending or result.instructions is not None
+    if cross_repo_review_applicable(item, config, fix_instructions_pending=pending):
+        if not helper_available:
+            decision = decide_cross_repo_review(
+                item,
+                config,
+                None,
+                fix_instructions_pending=pending,
+                helper_available=False,
+            )
+            result.decisions.append(decision)
+            emit(f"  WARN: {decision.reason}")
+            return result
+        emit(
+            f"  [cross-repo] Checking Greptile status for {item.repo}#{item.number}..."
+        )
+        status = io.greptile_status(item.repo, item.number)
+        decision = classify_greptile_helper_status(status)
+        result.decisions.append(decision)
+        emit(f"  [cross-repo] {decision.reason}")
+        if decision.action is MergeLifecycleAction.TRIGGER_REVIEW:
+            io.trigger_review(item.repo, item.number)
+        elif decision.action is MergeLifecycleAction.FIX_FINDINGS:
+            result.instructions = decision.instructions
+
+    return result
+
+
+@dataclass
+class SubprocessMergeLifecycleIO:
+    """Default I/O adapter wrapping the gh-backed scripts, mirroring the bash.
+
+    All paths and policy env are caller-supplied (the brain passes its
+    allowlists via ``env``); nothing Bob-specific is baked in.
+
+    Attributes:
+        self_merge_check_cmd: argv prefix for the gate check, e.g.
+            ``["python3", ".../self-merge-check.py"]``. Invoked as
+            ``<cmd> --json --repo <repo> <number>`` (lib.sh:537-539).
+        self_merge_cmd: argv prefix for the merge script, invoked as
+            ``<cmd> --repo <repo> <number>`` (lib.sh:543).
+        greptile_helper: path to greptile-helper.sh; invoked as
+            ``bash <helper> status|trigger <repo> <number>``.
+        env: extra environment (e.g. WORKSPACE_REPO,
+            SELF_MERGE_ALLOWED_PATHS) merged over os.environ for the gate
+            and merge subprocesses.
+        promote_state: optional hook called after a successful self-merge
+            (the bash ``promote_item_state`` file shuffle stays brain-side
+            in this step).
+        timeout: per-subprocess timeout in seconds (None = no timeout,
+            matching the bash, which sets none).
+    """
+
+    self_merge_check_cmd: Sequence[str]
+    self_merge_cmd: Sequence[str]
+    greptile_helper: str
+    env: Mapping[str, str] | None = None
+    promote_state: Callable[[str, int | str], None] | None = None
+    timeout: float | None = None
+
+    def _env(self) -> dict[str, str] | None:
+        if self.env is None:
+            return None
+        import os
+
+        merged = dict(os.environ)
+        merged.update(self.env)
+        return merged
+
+    def self_merge_check(self, repo: str, number: int | str) -> SelfMergeCheckResult:
+        # lib.sh:537-539: stderr discarded, failure tolerated (|| true) —
+        # a failed check parses as not-eligible with no reasons.
+        try:
+            proc = subprocess.run(
+                [*self.self_merge_check_cmd, "--json", "--repo", repo, str(number)],
+                capture_output=True,
+                text=True,
+                env=self._env(),
+                timeout=self.timeout,
+            )
+            raw = proc.stdout
+        except (OSError, subprocess.SubprocessError):
+            raw = ""
+        return SelfMergeCheckResult.from_json(raw)
+
+    def self_merge(self, repo: str, number: int | str) -> bool:
+        # lib.sh:543: success is exit 0; stderr discarded.
+        try:
+            proc = subprocess.run(
+                [*self.self_merge_cmd, "--repo", repo, str(number)],
+                capture_output=True,
+                text=True,
+                env=self._env(),
+                timeout=self.timeout,
+            )
+            return proc.returncode == 0
+        except (OSError, subprocess.SubprocessError):
+            return False
+
+    def greptile_status(self, repo: str, number: int | str) -> str:
+        # lib.sh:584: any failure fail-safes to "in-progress" (skip trigger).
+        try:
+            proc = subprocess.run(
+                ["bash", self.greptile_helper, "status", repo, str(number)],
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+            )
+            if proc.returncode != 0:
+                return "in-progress"
+            return proc.stdout.strip() or "in-progress"
+        except (OSError, subprocess.SubprocessError):
+            return "in-progress"
+
+    def trigger_review(self, repo: str, number: int | str) -> None:
+        # lib.sh:555/589: helper output passes through; failures non-fatal.
+        try:
+            proc = subprocess.run(
+                ["bash", self.greptile_helper, "trigger", repo, str(number)],
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+            )
+            if proc.stdout.strip():
+                logger.info("%s", proc.stdout.strip())
+        except (OSError, subprocess.SubprocessError):
+            logger.warning("greptile-helper trigger failed for %s#%s", repo, number)
+
+    def promote_item_state(self, repo: str, number: int | str) -> None:
+        if self.promote_state is not None:
+            self.promote_state(repo, number)

--- a/packages/gptme-runloops/src/gptme_runloops/merge_lifecycle.py
+++ b/packages/gptme-runloops/src/gptme_runloops/merge_lifecycle.py
@@ -328,7 +328,18 @@ def cross_repo_review_applicable(
     if item.repo == config.primary_repo:
         return False
     # grep -qE semantics: unanchored search (patterns carry their own anchors).
-    return re.search(config.greptile_repos_pattern, item.repo) is not None
+    # NOTE(parity): `grep -qE` exits non-zero on an invalid pattern, which the
+    # bash `if` treats as no-match — a malformed policy regex silently gates
+    # the phase off, it never aborts the run. Mirror that instead of letting
+    # re.error propagate.
+    try:
+        return re.search(config.greptile_repos_pattern, item.repo) is not None
+    except re.error:
+        logger.warning(
+            "invalid greptile_repos_pattern %r — treating as no-match",
+            config.greptile_repos_pattern,
+        )
+        return False
 
 
 def classify_greptile_helper_status(status: str) -> LifecycleDecision:
@@ -422,7 +433,13 @@ def head_advanced(cur_head: str, last_attempt_head: str | None) -> bool:
     """
     # NOTE(parity): an empty cur_head ("" — unparseable dedupe key) never
     # counts after the first observation, because `bool(cur_head)` gates the
-    # comparison in the poller.
+    # comparison in the poller. The converse edge is also preserved: a stream
+    # of ONLY empty-head emits counts on every emit (last_attempt_head stays
+    # None because `cur_head or last_head` never stores ""), so a PR whose
+    # dedupe keys never parse escalates on re-emits alone — identical
+    # expression in pr-merge-health-poll.py:489-491,500. Unreachable in
+    # practice (dedupe keys embed the probed head SHA) and pre-existing; a
+    # real fix belongs upstream in the poller, not in this parity port.
     return last_attempt_head is None or (
         bool(cur_head) and cur_head != last_attempt_head
     )
@@ -460,10 +477,19 @@ def decide_greptile_attempt(
         # actual fix attempts exhaust the counter.
         if "last_attempt_head" in updated:
             return AttemptDecision.ESCALATE, updated
+        # NOTE(parity): the reset clears count/escalated but deliberately
+        # leaves first_attempt_at untouched (poll.py:443) — a later
+        # re-escalation reports the original legacy start time, not the
+        # start of the head-gated counter window.
         updated.update({"escalated": False, "escalated_at": None, "count": 0})
 
     count = int(updated.get("count", 0))
 
+    # NOTE(parity): the cap is checked BEFORE the post-rebase grace
+    # (poll.py:449-460), so a PR already at max_attempts escalates even when
+    # this emit is the post-rebase re-review — the grace only applies while
+    # budget remains. Preserved; changing the precedence is a behavior
+    # change for the switchover to consider.
     if count >= max_attempts:
         updated.update(
             {

--- a/packages/gptme-runloops/tests/test_merge_lifecycle.py
+++ b/packages/gptme-runloops/tests/test_merge_lifecycle.py
@@ -1,0 +1,645 @@
+"""Golden tests for the merge-lifecycle state machine.
+
+Table-driven encodings of the CURRENT bash behavior of
+``run_self_merge_and_greptile`` (ErikBjare/bob
+``scripts/github/project-monitoring-lib.sh:519-609``) and the head-gated
+convergence counter (``pr-merge-health-poll.py`` ``apply_convergence_cap``
+per-signal core, commit f1fce829fb). Where the bash behavior is quirky the
+test name/comment says so — these tests lock in parity, they do not bless
+the quirk. Behavior changes belong to the brain-side switchover step.
+
+Invariants from project-monitoring-architecture.md §7b covered here:
+- self-merge only via the gate (SELF_MERGE requires eligible=True)
+- Greptile triggering only via greptile-helper (helper missing → no trigger)
+- an attempt = pushed commits (head-gated convergence counting)
+- human > bot (as-implemented: human-thread reasons route to a fix session)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from gptme_runloops.merge_lifecycle import (
+    AttemptDecision,
+    InstructionKind,
+    LifecycleConfig,
+    LifecycleDecision,
+    MergeLifecycleAction,
+    SelfMergeBlockClass,
+    SelfMergeCheckResult,
+    WorkItem,
+    classify_greptile_helper_status,
+    classify_self_merge_reasons,
+    cross_repo_review_applicable,
+    decide_cross_repo_review,
+    decide_greptile_attempt,
+    decide_self_merge_gate,
+    head_advanced,
+    parse_greptile_score,
+    run_merge_lifecycle,
+    self_merge_gate_applicable,
+)
+
+# The brain's policy shape (lib.sh:577,579) — passed as config, not baked in.
+# (The real brain pattern lists one more repo; the exact repo set is caller
+# policy, not module behavior.)
+BOB_CONFIG = LifecycleConfig(
+    primary_repo="ErikBjare/bob",
+    greptile_repos_pattern=r"^(gptme/gptme|gptme/gptme-contrib|gptme/gptme-cloud)$",
+)
+
+
+def make_item(
+    repo: str = "gptme/gptme",
+    number: int = 123,
+    types: tuple[str, ...] = ("pr_update",),
+) -> WorkItem:
+    return WorkItem(repo=repo, number=number, types=types)
+
+
+# --- FakeIO: records the call sequence, returns scripted responses ---
+
+
+class FakeIO:
+    def __init__(
+        self,
+        check: SelfMergeCheckResult | None = None,
+        merge_ok: bool = False,
+        status: str = "already-reviewed",
+    ) -> None:
+        self._check = check or SelfMergeCheckResult(eligible=False)
+        self._merge_ok = merge_ok
+        self._status = status
+        self.calls: list[tuple[str, str, Any]] = []
+
+    def self_merge_check(self, repo: str, number: Any) -> SelfMergeCheckResult:
+        self.calls.append(("self_merge_check", repo, number))
+        return self._check
+
+    def self_merge(self, repo: str, number: Any) -> bool:
+        self.calls.append(("self_merge", repo, number))
+        return self._merge_ok
+
+    def greptile_status(self, repo: str, number: Any) -> str:
+        self.calls.append(("greptile_status", repo, number))
+        return self._status
+
+    def trigger_review(self, repo: str, number: Any) -> None:
+        self.calls.append(("trigger_review", repo, number))
+
+    def promote_item_state(self, repo: str, number: Any) -> None:
+        self.calls.append(("promote_item_state", repo, number))
+
+    def called(self, name: str) -> int:
+        return sum(1 for c in self.calls if c[0] == name)
+
+
+# --- Reason classification (lib.sh:551-572 grep routing) ---
+
+
+@pytest.mark.parametrize(
+    ("reasons", "expected"),
+    [
+        # Empty / unrelated reasons fall through to OTHER.
+        ([], SelfMergeBlockClass.OTHER),
+        (["PR is still a draft"], SelfMergeBlockClass.OTHER),
+        (["CI is not fully green"], SelfMergeBlockClass.OTHER),
+        (["Review decision: CHANGES_REQUESTED"], SelfMergeBlockClass.OTHER),
+        # Exact upstream reason strings (self-merge-check.py evaluate_pr).
+        (["Greptile review not found"], SelfMergeBlockClass.NO_GREPTILE_REVIEW),
+        (
+            ["Greptile has 2 unresolved review thread(s)"],
+            SelfMergeBlockClass.UNRESOLVED_THREADS,
+        ),
+        (
+            ["Greptile score 3/5 below floor 5/5"],
+            SelfMergeBlockClass.SCORE_BELOW_FLOOR,
+        ),
+        # Priority: not-found wins even when other blockers are present —
+        # the bash greps the FULL joined reasons text in a fixed order.
+        (
+            ["CI is not fully green", "Greptile review not found"],
+            SelfMergeBlockClass.NO_GREPTILE_REVIEW,
+        ),
+        (
+            ["Greptile review not found", "Greptile score 3/5 below floor 5/5"],
+            SelfMergeBlockClass.NO_GREPTILE_REVIEW,
+        ),
+        # Priority: unresolved threads beat the score floor.
+        (
+            [
+                "Greptile has 1 unresolved review thread(s)",
+                "Greptile score 3/5 below floor 5/5",
+            ],
+            SelfMergeBlockClass.UNRESOLVED_THREADS,
+        ),
+        # NOTE(parity): the HUMAN-thread reason does NOT match the
+        # "unresolved review thread" grep — the word "human" breaks the
+        # substring — so human-only blocks route to OTHER (proceed with a
+        # session, no Greptile fix instructions). Human>bot is enforced by
+        # the gate (merge stays blocked) + the worker prompt, not here.
+        (
+            ["2 unresolved human review thread(s) from: ErikBjare"],
+            SelfMergeBlockClass.OTHER,
+        ),
+    ],
+)
+def test_classify_self_merge_reasons(
+    reasons: list[str], expected: SelfMergeBlockClass
+) -> None:
+    assert classify_self_merge_reasons(reasons) is expected
+
+
+# --- Gate JSON parsing (lib.sh:540,550 via _json_get) ---
+
+
+@pytest.mark.parametrize(
+    ("raw", "eligible", "reasons"),
+    [
+        ('{"eligible": true, "reasons": []}', True, ()),
+        (
+            '{"eligible": false, "reasons": ["CI is not fully green"]}',
+            False,
+            ("CI is not fully green",),
+        ),
+        # Parse failures fail closed (bash: `|| sm_eligible="False"`).
+        ("", False, ()),
+        ("not json", False, ()),
+        ("[1, 2]", False, ()),
+        ("{}", False, ()),
+        # NOTE(parity): bash compares str() of the JSON value to "True", so
+        # the JSON *string* "True" passes but "true" does not.
+        ('{"eligible": "True"}', True, ()),
+        ('{"eligible": "true"}', False, ()),
+        ('{"eligible": 1}', False, ()),
+    ],
+)
+def test_self_merge_check_result_from_json(
+    raw: str, eligible: bool, reasons: tuple[str, ...]
+) -> None:
+    result = SelfMergeCheckResult.from_json(raw)
+    assert result.eligible is eligible
+    assert result.reasons == reasons
+
+
+# --- Phase A decision (lib.sh:534-575) ---
+
+
+def test_phase_a_gating_by_types() -> None:
+    assert self_merge_gate_applicable(make_item(types=("pr_update",)))
+    assert self_merge_gate_applicable(make_item(types=("merge_ready",)))
+    assert self_merge_gate_applicable(make_item(types=("pr_update", "ci_failure")))
+    assert not self_merge_gate_applicable(make_item(types=("assigned_issue",)))
+    assert not self_merge_gate_applicable(make_item(types=()))
+    # Gate script missing → whole phase skipped.
+    assert not self_merge_gate_applicable(
+        make_item(types=("pr_update",)), gate_available=False
+    )
+
+
+def test_phase_a_not_applicable_decision() -> None:
+    decision = decide_self_merge_gate(make_item(types=("assigned_issue",)), None)
+    assert decision.action is MergeLifecycleAction.NOT_APPLICABLE
+
+
+def test_phase_a_applicable_requires_check_result() -> None:
+    with pytest.raises(ValueError):
+        decide_self_merge_gate(make_item(), None)
+
+
+@pytest.mark.parametrize(
+    ("check", "action", "instructions"),
+    [
+        # §7b: self-merge only via the gate — SELF_MERGE iff eligible.
+        (SelfMergeCheckResult(eligible=True), MergeLifecycleAction.SELF_MERGE, None),
+        (
+            SelfMergeCheckResult(False, ("Greptile review not found",)),
+            MergeLifecycleAction.TRIGGER_REVIEW,
+            None,
+        ),
+        (
+            SelfMergeCheckResult(
+                False, ("Greptile has 1 unresolved review thread(s)",)
+            ),
+            MergeLifecycleAction.FIX_FINDINGS,
+            InstructionKind.LOCAL_GREPTILE_FIX,
+        ),
+        (
+            SelfMergeCheckResult(False, ("Greptile score 4/5 below floor 5/5",)),
+            MergeLifecycleAction.FIX_FINDINGS,
+            InstructionKind.LOCAL_GREPTILE_FIX,
+        ),
+        (
+            SelfMergeCheckResult(False, ("PR is still a draft",)),
+            MergeLifecycleAction.PROCEED,
+            None,
+        ),
+        # Failed/empty gate output → not eligible with no reasons → PROCEED.
+        (SelfMergeCheckResult(False, ()), MergeLifecycleAction.PROCEED, None),
+    ],
+)
+def test_phase_a_decision_table(
+    check: SelfMergeCheckResult,
+    action: MergeLifecycleAction,
+    instructions: InstructionKind | None,
+) -> None:
+    decision = decide_self_merge_gate(make_item(), check)
+    assert decision.action is action
+    assert decision.instructions is instructions
+
+
+def test_phase_a_proceed_reason_carries_first_reason_line() -> None:
+    check = SelfMergeCheckResult(
+        False, ("PR is still a draft", "CI is not fully green")
+    )
+    decision = decide_self_merge_gate(make_item(), check)
+    # lib.sh:572 logs `head -1` of the reasons.
+    assert "PR is still a draft" in decision.reason
+    assert "CI is not fully green" not in decision.reason
+
+
+# --- Phase B gating (lib.sh:579) ---
+
+
+@pytest.mark.parametrize(
+    ("repo", "types", "pending", "expected"),
+    [
+        ("gptme/gptme", ("pr_update",), False, True),
+        ("gptme/gptme-contrib", ("pr_update",), False, True),
+        ("gptme/gptme-cloud", ("pr_update",), False, True),
+        # Fix instructions already queued → phase skipped.
+        ("gptme/gptme", ("pr_update",), True, False),
+        # Phase B needs pr_update specifically; merge_ready alone is not enough.
+        ("gptme/gptme", ("merge_ready",), False, False),
+        # Primary repo excluded (redundant with the pattern, but a separate
+        # condition in the bash — preserved).
+        ("ErikBjare/bob", ("pr_update",), False, False),
+        # NOTE(parity): gptme/gptme-webui is PM-tracked but absent from the
+        # cross-repo Greptile pattern, so its PRs never get the lifecycle.
+        ("gptme/gptme-webui", ("pr_update",), False, False),
+        ("ActivityWatch/activitywatch", ("pr_update",), False, False),
+        # Anchored pattern: no substring matches.
+        ("gptme/gptme-extra", ("pr_update",), False, False),
+    ],
+)
+def test_phase_b_applicability(
+    repo: str, types: tuple[str, ...], pending: bool, expected: bool
+) -> None:
+    item = make_item(repo=repo, types=types)
+    assert (
+        cross_repo_review_applicable(item, BOB_CONFIG, fix_instructions_pending=pending)
+        is expected
+    )
+
+
+# --- Phase B status routing (lib.sh:586-604) ---
+
+
+@pytest.mark.parametrize(
+    ("status", "action", "instructions"),
+    [
+        # NOTE(parity): "none" is a dead arm — the helper's status command
+        # never emits it — but the bash case preserves it, so we do too.
+        ("none", MergeLifecycleAction.TRIGGER_REVIEW, None),
+        ("stale", MergeLifecycleAction.TRIGGER_REVIEW, None),
+        (
+            "needs-re-review",
+            MergeLifecycleAction.FIX_FINDINGS,
+            InstructionKind.CROSS_REPO_GREPTILE_REFRESH,
+        ),
+        ("in-progress", MergeLifecycleAction.WAIT, None),
+        ("already-reviewed", MergeLifecycleAction.PROCEED, None),
+        # Unknown states (incl. real helper outputs the bash has no arm for)
+        # fall through to skip.
+        ("awaiting-initial-review", MergeLifecycleAction.WAIT, None),
+        ("backoff", MergeLifecycleAction.WAIT, None),
+        ("error", MergeLifecycleAction.WAIT, None),
+        ("garbage", MergeLifecycleAction.WAIT, None),
+    ],
+)
+def test_phase_b_status_table(
+    status: str, action: MergeLifecycleAction, instructions: InstructionKind | None
+) -> None:
+    decision = classify_greptile_helper_status(status)
+    assert decision.action is action
+    assert decision.instructions is instructions
+
+
+def test_decide_cross_repo_review_helper_missing_proceeds_without_trigger() -> None:
+    # lib.sh:580-581 — WARN + skip; §7b: no trigger path outside the helper.
+    decision = decide_cross_repo_review(
+        make_item(), BOB_CONFIG, None, helper_available=False
+    )
+    assert decision.action is MergeLifecycleAction.PROCEED
+
+
+def test_decide_cross_repo_review_applicable_requires_status() -> None:
+    with pytest.raises(ValueError):
+        decide_cross_repo_review(make_item(), BOB_CONFIG, None)
+
+
+# --- Orchestrator: call-sequence golden tests ---
+
+
+def test_self_merge_success_skips_session_and_promotes_state() -> None:
+    io = FakeIO(check=SelfMergeCheckResult(eligible=True), merge_ok=True)
+    result = run_merge_lifecycle(make_item(), BOB_CONFIG, io)
+    assert result.skip_item is True
+    assert result.instructions is None
+    assert [c[0] for c in io.calls] == [
+        "self_merge_check",
+        "self_merge",
+        "promote_item_state",
+    ]
+    # Phase B never runs after a successful self-merge (bash `return 1`).
+    assert io.called("greptile_status") == 0
+
+
+def test_self_merge_failure_falls_through_silently_to_phase_b() -> None:
+    # NOTE(parity): eligible-but-merge-failed produces no message, no fix
+    # instructions, no retry — the bash falls through to the cross-repo check.
+    io = FakeIO(
+        check=SelfMergeCheckResult(eligible=True),
+        merge_ok=False,
+        status="already-reviewed",
+    )
+    result = run_merge_lifecycle(make_item(), BOB_CONFIG, io)
+    assert result.skip_item is False
+    assert result.instructions is None
+    assert io.called("promote_item_state") == 0
+    assert io.called("greptile_status") == 1
+
+
+def test_self_merge_never_attempted_when_not_eligible() -> None:
+    # §7b: self-merge only via the gate.
+    io = FakeIO(check=SelfMergeCheckResult(False, ("CI is not fully green",)))
+    run_merge_lifecycle(make_item(), BOB_CONFIG, io)
+    assert io.called("self_merge") == 0
+
+
+def test_no_review_triggers_via_helper_then_evaluates_phase_b() -> None:
+    io = FakeIO(
+        check=SelfMergeCheckResult(False, ("Greptile review not found",)),
+        status="in-progress",
+    )
+    result = run_merge_lifecycle(make_item(), BOB_CONFIG, io)
+    # Phase A triggered once; no instructions queued, so Phase B still runs
+    # (bash: GREPTILE_FIX_INSTRUCTIONS stays empty after a trigger).
+    assert io.called("trigger_review") == 1
+    assert io.called("greptile_status") == 1
+    assert result.instructions is None
+
+
+def test_no_review_can_double_trigger_when_phase_b_sees_stale() -> None:
+    # NOTE(parity): current bash can invoke the helper trigger in BOTH
+    # phases in one pass (Phase A on "review not found", Phase B on
+    # status=stale). The helper's own flock/age/ceiling guards are the
+    # dedupe layer, so this is trigger-request duplication, not spam.
+    io = FakeIO(
+        check=SelfMergeCheckResult(False, ("Greptile review not found",)),
+        status="stale",
+    )
+    run_merge_lifecycle(make_item(), BOB_CONFIG, io)
+    assert io.called("trigger_review") == 2
+
+
+def test_no_review_with_helper_missing_never_triggers() -> None:
+    # §7b: greptile-helper-only triggering — no helper, no trigger, ever.
+    io = FakeIO(check=SelfMergeCheckResult(False, ("Greptile review not found",)))
+    run_merge_lifecycle(make_item(), BOB_CONFIG, io, helper_available=False)
+    assert io.called("trigger_review") == 0
+    assert io.called("greptile_status") == 0
+
+
+def test_unresolved_threads_queue_local_fix_and_skip_phase_b() -> None:
+    io = FakeIO(
+        check=SelfMergeCheckResult(
+            False, ("Greptile has 3 unresolved review thread(s)",)
+        )
+    )
+    result = run_merge_lifecycle(make_item(), BOB_CONFIG, io)
+    assert result.instructions is InstructionKind.LOCAL_GREPTILE_FIX
+    # Fix instructions queued in Phase A gate Phase B off (lib.sh:579 -z check).
+    assert io.called("greptile_status") == 0
+
+
+def test_score_below_floor_queues_local_fix() -> None:
+    io = FakeIO(
+        check=SelfMergeCheckResult(False, ("Greptile score 2/5 below floor 5/5",))
+    )
+    result = run_merge_lifecycle(make_item(), BOB_CONFIG, io)
+    assert result.instructions is InstructionKind.LOCAL_GREPTILE_FIX
+
+
+def test_other_reason_proceeds_then_runs_phase_b() -> None:
+    io = FakeIO(
+        check=SelfMergeCheckResult(False, ("PR is still a draft",)),
+        status="needs-re-review",
+    )
+    result = run_merge_lifecycle(make_item(), BOB_CONFIG, io)
+    assert result.instructions is InstructionKind.CROSS_REPO_GREPTILE_REFRESH
+    assert io.called("greptile_status") == 1
+
+
+def test_primary_repo_item_never_runs_phase_b() -> None:
+    io = FakeIO(check=SelfMergeCheckResult(False, ("CI is not fully green",)))
+    run_merge_lifecycle(make_item(repo="ErikBjare/bob"), BOB_CONFIG, io)
+    assert io.called("greptile_status") == 0
+
+
+def test_merge_ready_only_item_runs_phase_a_but_not_phase_b() -> None:
+    io = FakeIO(check=SelfMergeCheckResult(False, ("CI is not fully green",)))
+    run_merge_lifecycle(make_item(types=("merge_ready",)), BOB_CONFIG, io)
+    assert io.called("self_merge_check") == 1
+    assert io.called("greptile_status") == 0
+
+
+def test_gate_unavailable_skips_phase_a_but_not_phase_b() -> None:
+    io = FakeIO(status="stale")
+    run_merge_lifecycle(make_item(), BOB_CONFIG, io, gate_available=False)
+    assert io.called("self_merge_check") == 0
+    assert io.called("greptile_status") == 1
+    assert io.called("trigger_review") == 1
+
+
+def test_phase_b_in_progress_waits_without_trigger() -> None:
+    io = FakeIO(
+        check=SelfMergeCheckResult(False, ("CI is not fully green",)),
+        status="in-progress",
+    )
+    result = run_merge_lifecycle(make_item(), BOB_CONFIG, io)
+    assert io.called("trigger_review") == 0
+    assert result.instructions is None
+    assert any(d.action is MergeLifecycleAction.WAIT for d in result.decisions)
+
+
+def test_fix_instructions_pending_gates_phase_b_off() -> None:
+    io = FakeIO(check=SelfMergeCheckResult(False, ("CI is not fully green",)))
+    run_merge_lifecycle(make_item(), BOB_CONFIG, io, fix_instructions_pending=True)
+    assert io.called("greptile_status") == 0
+
+
+def test_helper_missing_phase_b_warns_and_proceeds() -> None:
+    io = FakeIO(check=SelfMergeCheckResult(False, ("CI is not fully green",)))
+    result = run_merge_lifecycle(make_item(), BOB_CONFIG, io, helper_available=False)
+    assert io.called("greptile_status") == 0
+    assert result.decisions[-1].action is MergeLifecycleAction.PROCEED
+
+
+def test_non_pr_item_is_a_full_noop() -> None:
+    io = FakeIO()
+    result = run_merge_lifecycle(make_item(types=("assigned_issue",)), BOB_CONFIG, io)
+    assert io.calls == []
+    assert result.skip_item is False
+    assert result.instructions is None
+
+
+# --- Head-gated convergence counter (f1fce829fb; poll.py:430-502) ---
+
+NOW = "2026-07-10T12:00:00+00:00"
+
+
+def test_attempt_first_observation_counts() -> None:
+    decision, entry = decide_greptile_attempt({}, "abc1234", 3, NOW, score=3)
+    assert decision is AttemptDecision.DISPATCH
+    assert entry["count"] == 1
+    assert entry["last_attempt_head"] == "abc1234"
+    assert entry["first_attempt_at"] == NOW
+
+
+def test_attempt_same_head_reemit_is_free() -> None:
+    # §7b invariant: an attempt = pushed commits. A re-emit at the same head
+    # (slot-starved dispatch or no-op session) dispatches again but does not
+    # burn budget.
+    _, entry = decide_greptile_attempt({}, "abc1234", 3, NOW, score=3)
+    decision, entry2 = decide_greptile_attempt(entry, "abc1234", 3, NOW, score=3)
+    assert decision is AttemptDecision.DISPATCH_FREE
+    assert entry2["count"] == 1
+
+
+def test_attempt_head_advance_consumes_budget() -> None:
+    _, entry = decide_greptile_attempt({}, "abc1234", 3, NOW, score=3)
+    decision, entry2 = decide_greptile_attempt(entry, "def5678", 3, NOW, score=3)
+    assert decision is AttemptDecision.DISPATCH
+    assert entry2["count"] == 2
+    assert entry2["last_attempt_head"] == "def5678"
+
+
+def test_attempt_many_same_head_reemits_never_escalate() -> None:
+    # Incident 2026-07-09 (gptme-contrib#1253): pre-fix, poll re-emits alone
+    # escalated a never-dispatched PR. Post-fix, unlimited same-head re-emits
+    # stay below the cap.
+    _, entry = decide_greptile_attempt({}, "abc1234", 3, NOW, score=3)
+    for _ in range(10):
+        decision, entry = decide_greptile_attempt(entry, "abc1234", 3, NOW, score=3)
+    assert decision is AttemptDecision.DISPATCH_FREE
+    assert entry["count"] == 1
+    assert not entry["escalated"]
+
+
+def test_attempt_cap_escalates() -> None:
+    entry: dict[str, Any] = {}
+    decision = AttemptDecision.DISPATCH
+    heads = ["h1", "h2", "h3", "h4"]
+    for head in heads:
+        decision, entry = decide_greptile_attempt(entry, head, 3, NOW, score=3)
+    assert decision is AttemptDecision.ESCALATE
+    assert entry["escalated"] is True
+    assert entry["escalated_at"] == NOW
+
+
+def test_attempt_escalated_with_head_history_stays_escalated() -> None:
+    entry = {"count": 3, "escalated": True, "last_attempt_head": "h3"}
+    decision, updated = decide_greptile_attempt(entry, "h4", 3, NOW, score=3)
+    assert decision is AttemptDecision.ESCALATE
+    assert updated["escalated"] is True
+
+
+def test_attempt_legacy_escalation_without_head_history_resets() -> None:
+    # Legacy escalations (pre-head-gating) carry no last_attempt_head; they
+    # get a fresh start under the head-gated counter (poll.py:432-443).
+    entry = {"count": 3, "escalated": True}
+    decision, updated = decide_greptile_attempt(entry, "h1", 3, NOW, score=3)
+    assert decision is AttemptDecision.DISPATCH
+    assert updated["escalated"] is False
+    assert updated["count"] == 1
+    assert updated["last_attempt_head"] == "h1"
+
+
+def test_attempt_post_rebase_is_free_and_consumes_grace() -> None:
+    _, entry = decide_greptile_attempt({}, "h1", 3, NOW, score=3)
+    decision, updated = decide_greptile_attempt(
+        entry, "h2", 3, NOW, score=3, post_rebase=True
+    )
+    assert decision is AttemptDecision.DISPATCH_FREE
+    assert updated["count"] == 1
+    assert updated["conflict_grace_used_at"] == NOW
+    assert updated["last_attempt_head"] == "h2"
+
+
+def test_attempt_post_rebase_at_cap_still_escalates() -> None:
+    # poll.py checks the cap BEFORE the post-rebase branch.
+    entry = {"count": 3, "last_attempt_head": "h3"}
+    decision, updated = decide_greptile_attempt(
+        entry, "h4", 3, NOW, score=3, post_rebase=True
+    )
+    assert decision is AttemptDecision.ESCALATE
+    assert updated["escalated"] is True
+
+
+def test_attempt_empty_head_never_counts_after_first_observation() -> None:
+    # NOTE(parity): an unparseable dedupe key yields cur_head="" which the
+    # bool() guard keeps from consuming budget or clobbering the stored head.
+    _, entry = decide_greptile_attempt({}, "h1", 3, NOW, score=3)
+    decision, updated = decide_greptile_attempt(entry, "", 3, NOW, score=3)
+    assert decision is AttemptDecision.DISPATCH_FREE
+    assert updated["count"] == 1
+    assert updated["last_attempt_head"] == "h1"
+
+
+@pytest.mark.parametrize(
+    ("cur_head", "last_head", "expected"),
+    [
+        ("h1", None, True),  # first observation counts
+        ("h1", "h1", False),  # same head is free
+        ("h2", "h1", True),  # head advanced
+        ("", "h1", False),  # unparseable head never counts
+        ("", None, True),  # first observation counts even with no head
+    ],
+)
+def test_head_advanced_table(
+    cur_head: str, last_head: str | None, expected: bool
+) -> None:
+    assert head_advanced(cur_head, last_head) is expected
+
+
+# --- Greptile score parsing (greptile-helper.sh:186) ---
+
+
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    [
+        ("Confidence Score: 4/5", 4),
+        ("**Confidence Score:** 3/5", 3),
+        ("Score: 5/5", 5),
+        ("no score here", None),
+        ("", None),
+        # First match wins (jq capture semantics).
+        ("Score: 2/5 ... later Score: 5/5", 2),
+        # Only single digits over /5 parse (regex is [0-9] right after the
+        # Score prefix, so "10/5" matches nothing — same in jq).
+        ("Score: 10/5", None),
+    ],
+)
+def test_parse_greptile_score(body: str, expected: int | None) -> None:
+    assert parse_greptile_score(body) == expected
+
+
+# --- Decision dataclass sanity ---
+
+
+def test_lifecycle_decision_is_frozen() -> None:
+    decision = LifecycleDecision(MergeLifecycleAction.WAIT, "x")
+    with pytest.raises(AttributeError):
+        decision.reason = "y"  # type: ignore[misc]

--- a/packages/gptme-runloops/tests/test_merge_lifecycle.py
+++ b/packages/gptme-runloops/tests/test_merge_lifecycle.py
@@ -293,6 +293,20 @@ def test_phase_b_applicability(
     )
 
 
+def test_phase_b_invalid_pattern_gates_off_without_crashing() -> None:
+    # NOTE(parity): `grep -qE` exits non-zero on a malformed pattern, which
+    # the bash `if` treats as no-match — a policy typo must gate the phase
+    # off, never abort the run.
+    bad = LifecycleConfig(
+        primary_repo="ErikBjare/bob", greptile_repos_pattern="^(gptme/("
+    )
+    assert cross_repo_review_applicable(make_item(), bad) is False
+    io = FakeIO(check=SelfMergeCheckResult(False, ("CI is not fully green",)))
+    result = run_merge_lifecycle(make_item(), bad, io)  # must not raise
+    assert io.called("greptile_status") == 0
+    assert result.skip_item is False
+
+
 # --- Phase B status routing (lib.sh:586-604) ---
 
 
@@ -596,6 +610,33 @@ def test_attempt_empty_head_never_counts_after_first_observation() -> None:
     assert decision is AttemptDecision.DISPATCH_FREE
     assert updated["count"] == 1
     assert updated["last_attempt_head"] == "h1"
+
+
+def test_attempt_empty_head_only_stream_counts_every_emit() -> None:
+    # NOTE(parity): when EVERY emit has an empty head (dedupe key never
+    # parses), last_attempt_head stays None (`"" or None`), so each emit
+    # counts and the PR escalates on re-emits alone. Identical expression in
+    # pr-merge-health-poll.py:489-491,500; unreachable in practice. Locked
+    # in as parity — an upstream poller fix would change this test.
+    entry: dict[str, Any] = {}
+    decision, entry = decide_greptile_attempt(entry, "", 3, NOW, score=3)
+    assert decision is AttemptDecision.DISPATCH
+    for expected_count in (2, 3):
+        decision, entry = decide_greptile_attempt(entry, "", 3, NOW, score=3)
+        assert decision is AttemptDecision.DISPATCH
+        assert entry["count"] == expected_count
+        assert entry["last_attempt_head"] is None
+    decision, entry = decide_greptile_attempt(entry, "", 3, NOW, score=3)
+    assert decision is AttemptDecision.ESCALATE
+
+
+def test_attempt_legacy_reset_preserves_first_attempt_at() -> None:
+    # NOTE(parity): the legacy-escalation reset keeps first_attempt_at
+    # (poll.py:443) — re-escalation reports the original legacy start time.
+    entry = {"count": 3, "escalated": True, "first_attempt_at": "2026-01-01T00:00:00"}
+    decision, updated = decide_greptile_attempt(entry, "h1", 3, NOW, score=3)
+    assert decision is AttemptDecision.DISPATCH
+    assert updated["first_attempt_at"] == "2026-01-01T00:00:00"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What

Step **1 of 8** of the Phase-2 execution-consolidation migration (design doc: ErikBjare/bob `knowledge/technical-designs/reactive-dispatch-phase2-3-execution-consolidation.md`; architecture reference: `knowledge/technical/project-monitoring-architecture.md` §7b): port the PM greptile/self-merge lifecycle state machine from brain shell into `gptme-runloops` as a **pure-logic module with golden tests**.

**Pure port, no brain-side behavior change** — the bash (`project-monitoring-lib.sh`) stays the runtime hotpath; the brain-side switchover is a later step and will diff against this module.

## Bash source lines ported (ErikBjare/bob @ `dcb4bd837c`)

| Source | Ported as |
|---|---|
| `scripts/github/project-monitoring-lib.sh:519-609` — `run_self_merge_and_greptile` (two-phase state machine: self-merge gate + reason routing, then cross-repo Greptile status check) | `decide_self_merge_gate`, `decide_cross_repo_review`, `run_merge_lifecycle` orchestrator |
| `lib.sh:577,579` — cross-repo Greptile repo pattern + primary-repo exclusion | `LifecycleConfig` (caller-supplied policy; Bob values stay in the brain) |
| `scripts/github/pr-merge-health-poll.py:406-504` @ `6eae7cc00a` — head-gated convergence attempt counter (`f1fce829fb`: an attempt = pushed commits) | `decide_greptile_attempt`, `head_advanced` |
| `greptile-helper.sh:186` — confidence-score regex | `parse_greptile_score` |

## Design

- **Pure decision core**: typed decisions (`SELF_MERGE / SKIP_ITEM / TRIGGER_REVIEW / FIX_FINDINGS / WAIT / PROCEED / NOT_APPLICABLE`, plus `AttemptDecision.{DISPATCH, DISPATCH_FREE, ESCALATE}`) with human-readable reasons; **no subprocess calls** in the core.
- **Thin injectable I/O**: `MergeLifecycleIO` protocol + `SubprocessMergeLifecycleIO` adapter mirroring the exact bash invocations (incl. the fail-safe `status → "in-progress"` on helper failure).
- **Policy stays out**: repo allowlists, score floors, GraphQL budget fuses are parameters/env — nothing Bob-specific baked in.
- **Instruction template bodies are NOT ported** — `InstructionKind` is the seam to step 2 (prompt-template consolidation, `lib.sh:423-517`).

## Golden tests (89, table-driven)

Encode the **current** bash behavior, including the §7b invariants:
- self-merge only via the gate (`SELF_MERGE` requires `eligible=True`)
- Greptile triggering only via greptile-helper (helper missing → no trigger, ever)
- an attempt = pushed commits (same-head re-emits never escalate; incident gptme-contrib#1253 regression case)
- human > bot as-implemented (human threads block the gate but route to the generic proceed branch)

Ambiguous/quirky bash behavior is **preserved and marked `NOTE(parity)`** rather than fixed, e.g.: silent fallthrough when an eligible merge attempt fails; the dead `none` status arm; possible double helper-trigger in one pass (helper's own guards dedupe); `_json_get` string-comparison eligibility (`"True"` passes, `"true"` doesn't); human-thread reason not matching the `unresolved review thread` grep.

## Follow-up steps (separate PRs)

2. Greptile prompt-template consolidation (contrib)
3. Worker heredocs → module functions (contrib + brain shim)
4. `run-item` executor entrypoint (contrib)
5. `PM_EXECUTOR=runloops` toggle + 1-week ledger A/B (brain)
6. Backend incident block-files + guard removal (brain + contrib)
7. Delete bash worker + collapse dedupe guards (brain)
8. Referent-folding enforcement in claim guard (contrib)

Coordination thread: ErikBjare/bob `tasks/greptile-pm-machinery-integration-audit.md` (Seam C ownership — gptme-runloops becomes the owner; Alice consumes the same package).

## Testing

- `uv run --with pytest --with pytest-mock pytest tests/` → 429 passed (89 new)
- ruff check + format clean; mypy clean on the new module