### PR TITLE
feat(runloops): consolidate Greptile prompt heredocs into parameterized templates

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/merge_lifecycle.py
+++ b/packages/gptme-runloops/src/gptme_runloops/merge_lifecycle.py
@@ -101,13 +101,23 @@ class MergeLifecycleAction(Enum):
 class InstructionKind(Enum):
     """Which fix-instruction template to inject into the session prompt.
 
-    The template *bodies* (lib.sh:423-517 heredocs) are deliberately NOT
-    ported here — that is step 2 of the migration (prompt-template
-    consolidation). This enum is the seam between the two steps.
+    This enum is the seam between the decision port (step 1, contrib#1261)
+    and the prompt-template port (step 2): decisions name a kind, and
+    :func:`gptme_runloops.prompt_templates.render_instruction` renders its
+    body.
+
+    The first two members are produced by the merge-lifecycle decisions in
+    this module. The ``GREPTILE_NEEDS_*`` members correspond to the
+    ``build_item_investigate`` arms keyed by the poller's
+    ``greptile_needs_fix`` / ``greptile_needs_improvement`` item types —
+    rendered by the same template module but selected by item type, not by
+    a decision here.
     """
 
     LOCAL_GREPTILE_FIX = "local_greptile_fix"  # lib.sh:425-470
     CROSS_REPO_GREPTILE_REFRESH = "cross_repo_greptile_refresh"  # lib.sh:474-517
+    GREPTILE_NEEDS_FIX = "greptile_needs_fix"  # lib.sh:886-912
+    GREPTILE_NEEDS_IMPROVEMENT = "greptile_needs_improvement"  # lib.sh:913-932
 
 
 class SelfMergeBlockClass(Enum):

--- a/packages/gptme-runloops/src/gptme_runloops/prompt_templates.py
+++ b/packages/gptme-runloops/src/gptme_runloops/prompt_templates.py
@@ -1,0 +1,371 @@
+"""Greptile fix/improve/re-trigger prompt templates (parameterized).
+
+Behavior-identical consolidation of the four Greptile prompt-building
+heredocs from ErikBjare/bob ``scripts/github/project-monitoring-lib.sh``
+(step 2 of the Phase-2 execution-consolidation migration; see
+``knowledge/technical-designs/reactive-dispatch-phase2-3-execution-consolidation.md``
+in that repo). Step 1 (contrib#1261, :mod:`gptme_runloops.merge_lifecycle`)
+ported the *decisions* and left :class:`~gptme_runloops.merge_lifecycle.InstructionKind`
+as the seam; this module renders the instruction *bodies* the decisions name.
+The bash remains the runtime hotpath until the brain-side switchover PR; the
+golden tests in ``tests/test_prompt_templates.py`` are what that switchover
+will diff against.
+
+Bash source heredocs ported (ErikBjare/bob @
+ca7aa17a2899dbe676fba7074fc5c4dd61d25fe4):
+
+- ``project-monitoring-lib.sh:425-470`` — ``_build_local_greptile_fix_instructions``
+  → :attr:`InstructionKind.LOCAL_GREPTILE_FIX`
+- ``project-monitoring-lib.sh:474-517`` — ``_build_cross_repo_greptile_refresh_instructions``
+  → :attr:`InstructionKind.CROSS_REPO_GREPTILE_REFRESH`
+- ``project-monitoring-lib.sh:886-912`` — ``build_item_investigate`` arm
+  ``greptile_needs_fix`` → :attr:`InstructionKind.GREPTILE_NEEDS_FIX`
+- ``project-monitoring-lib.sh:913-932`` — ``build_item_investigate`` arm
+  ``greptile_needs_improvement`` → :attr:`InstructionKind.GREPTILE_NEEDS_IMPROVEMENT`
+
+The four heredocs are ~90% pairwise-duplicate. They collapse into two shared
+skeletons with per-variant parameter tables:
+
+- **Fix-instruction skeleton** (the two ``_build_*`` functions): title suffix,
+  intro paragraph, STEP-1 comment, STEP-2 qualifier, follow-up block, warning
+  block, and the do-not-loop block vary; the STEP-1/STEP-2 ``gh api`` command
+  blocks are shared verbatim.
+- **Investigate skeleton** (the two ``build_item_investigate`` arms): title,
+  read-commands block, assessment paragraph, and warning block vary; the
+  greptile-helper re-trigger command block is shared verbatim.
+
+Rendering parity (exact bytes, locked by golden tests):
+
+- ``LOCAL_GREPTILE_FIX`` / ``CROSS_REPO_GREPTILE_REFRESH`` render the exact
+  stdout of the bash function, **including the trailing newline** the heredoc
+  emits. The bash call site assigns via ``$(...)`` which strips it; callers
+  that need the assigned-variable form should ``.rstrip("\\n")``.
+- ``GREPTILE_NEEDS_FIX`` / ``GREPTILE_NEEDS_IMPROVEMENT`` render the exact
+  string the bash appends to ``INVESTIGATE``, **including the leading and
+  trailing newline**.
+
+Agent-agnostic by construction: workspace paths, helper-script locations, and
+repo/PR identifiers are all :class:`PromptContext` parameters — nothing
+Bob-specific is baked into the templates (Alice consumes this package too).
+
+Where the variants differ in ways that look like drift rather than intent,
+the difference is preserved and marked with a ``# NOTE(parity):`` comment.
+Behavior changes come later, with the brain-side switchover.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from gptme_runloops.merge_lifecycle import InstructionKind
+
+# --- Context ---
+
+
+@dataclass(frozen=True)
+class PromptContext:
+    """Per-render parameters extracted from the bash globals.
+
+    Attributes:
+        repo: ``owner/name`` of the PR's repository (bash ``$item_repo``).
+        number: PR number (bash ``$item_number``).
+        workspace: absolute path to the agent's workspace repo (bash
+            ``$WORKSPACE``); used only to derive the helper-script paths
+            below when they are not given explicitly.
+        greptile_helper: path to ``greptile-helper.sh`` (the anti-spam
+            trigger wrapper). Default: ``<workspace>/scripts/github/greptile-helper.sh``.
+        pr_address_script: path to ``pr-address-wait-and-merge.sh`` (the
+            address→wait→merge poller). Default:
+            ``<workspace>/scripts/github/pr-address-wait-and-merge.sh``.
+        poll_budget_sec: ``POLL_BUDGET_SEC`` value baked into the
+            pr-address-wait-and-merge invocation lines (bash hardcodes 1800).
+    """
+
+    repo: str
+    number: int | str
+    workspace: str
+    greptile_helper: str | None = None
+    pr_address_script: str | None = None
+    poll_budget_sec: int = 1800
+
+    @property
+    def resolved_greptile_helper(self) -> str:
+        if self.greptile_helper is not None:
+            return self.greptile_helper
+        return f"{self.workspace}/scripts/github/greptile-helper.sh"
+
+    @property
+    def resolved_pr_address_script(self) -> str:
+        if self.pr_address_script is not None:
+            return self.pr_address_script
+        return f"{self.workspace}/scripts/github/pr-address-wait-and-merge.sh"
+
+
+# --- Token substitution ---
+#
+# str.format() would choke on the literal jq braces in the command blocks
+# (``{id, path, line, body}``), so substitution replaces only the exact
+# ``{name}`` tokens present in the mapping and leaves everything else alone.
+
+_TOKEN_RE = re.compile(r"\{([a-z0-9_]+)\}")
+
+
+def _substitute(template: str, mapping: Mapping[str, str]) -> str:
+    def repl(match: re.Match[str]) -> str:
+        key = match.group(1)
+        return mapping[key] if key in mapping else match.group(0)
+
+    return _TOKEN_RE.sub(repl, template)
+
+
+# --- Skeleton A: session-injected fix instructions (lib.sh:425-517) ---
+#
+# Shared shape of _build_local_greptile_fix_instructions and
+# _build_cross_repo_greptile_refresh_instructions. The STEP-1/STEP-2 gh
+# command blocks are byte-identical between the two bash functions; the
+# prose around them varies per variant.
+
+_FIX_SKELETON = """\
+### Also: Address Greptile Review Findings{title_suffix}
+
+{intro}
+
+**STEP 1 — Read the score-DRIVING findings in the summary comment (do this FIRST):**
+```bash
+{step1_comment}
+gh api repos/{repo}/issues/{number}/comments --paginate \\
+  --jq '.[] | select(.user.login | test("greptile"; "i"))
+            | select(.body | test("Confidence Score"; "i")) | .body'
+```
+
+**STEP 2 — Read the inline review threads (usually {step2_qualifier}P2 nits, a SUBSET):**
+```bash
+gh api repos/{repo}/pulls/{number}/comments \\
+  --jq '.[] | select(.user.login | test("greptile"; "i")) | {id, path, line, body}'
+```
+
+**Fix the substantive errors from the summary body FIRST**, then the inline
+findings (P1/P2/P3). {followup}
+
+{warning}
+
+{no_loop}
+"""
+
+# NOTE(parity): the local variant's intro never names the PR (no
+# repo#number interpolation) while the cross-repo intro does — preserved
+# from lib.sh:429 vs lib.sh:478.
+_LOCAL_FIX_SECTIONS = {
+    "title_suffix": "",
+    "intro": (
+        "This PR has a Greptile review below the score floor (or unresolved findings).\n"
+        "The confidence score is driven by the **summary-comment body**, not the inline\n"
+        "P2 nits. Fixing only inline threads leaves the score unchanged (fake remediation)."
+    ),
+    # NOTE(parity): the local STEP-1 comment is the 3-line explanatory form
+    # ("— THESE are what move the score. Read them:"); the cross-repo one
+    # (below) is a 2-line condensed rewrite of the same content. Looks like
+    # one heredoc was updated and the other independently shortened —
+    # preserved verbatim (lib.sh:435-437 vs lib.sh:484-485).
+    "step1_comment": (
+        "# The Greptile SUMMARY comment is an ISSUE comment (not an inline thread). It\n"
+        '# contains "Confidence Score", the confirmed-errors prose, and the per-file\n'
+        '# "Important Files Changed" notes — THESE are what move the score. Read them:'
+    ),
+    # NOTE(parity): "usually just P2 nits" here vs "usually P2 nits" in the
+    # cross-repo variant (lib.sh:443 vs lib.sh:491) — one-word drift,
+    # preserved.
+    "step2_qualifier": "just ",
+    "followup": (
+        "A fix that only touches inline nits forces an extra\n"
+        "round-trip and the score does not move.\n"
+        "\n"
+        "**After addressing the findings:**\n"
+        "1. Push fixes and reply to each comment thread individually with the fix SHA\n"
+        "2. Run `POLL_BUDGET_SEC={poll_budget_sec} bash {pr_address_script} --repo {repo} {number}`\n"
+        "   - Exit 0: merged — done\n"
+        "   - Exit 2: Greptile re-reviewed and found new issues — read the new unresolved threads, fix them, push, reply, then re-run the command once more\n"
+        "   - Exit 3: poll budget exhausted without Greptile re-review completing — stop; next monitoring cycle will continue"
+    ),
+    # NOTE(parity): the local variant never mentions the greptile-helper —
+    # re-triggering for local PRs flows through pr-address-wait-and-merge.sh
+    # (which triggers internally); the cross-repo variant instructs an
+    # explicit helper trigger. Intentional lane difference, not drift.
+    "warning": (
+        "⚠️ **If you cannot fix the findings, do NOT re-trigger Greptile and do NOT call pr-address-wait-and-merge.sh.**\n"
+        "NEVER post raw `@greptileai review` comments — the pr-address-wait-and-merge.sh script triggers Greptile internally.\n"
+        "Only call it AFTER you have actually pushed fix commits."
+    ),
+    "no_loop": (
+        "**Do NOT loop to chase 5/5.** A confidence score is a holistic judgment, not a\n"
+        "resolved-thread counter — some PRs will not reach 5/5 even after every stated\n"
+        "finding is genuinely addressed. Address the summary-body findings, re-review\n"
+        "**once**, and if the score still does not clear the floor, **stop and leave it\n"
+        "for human review** (the self-merge gate correctly blocks below-floor merges)."
+    ),
+}
+
+_CROSS_REPO_REFRESH_SECTIONS = {
+    "title_suffix": " (cross-repo)",
+    "intro": (
+        "This PR ({repo}#{number}) has a Greptile review that is stale or below\n"
+        "the score floor. The confidence score is driven by the **summary-comment body**,\n"
+        "not the inline P2 nits — fixing only inline threads leaves the score unchanged."
+    ),
+    "step1_comment": (
+        '# The Greptile SUMMARY comment is an ISSUE comment containing "Confidence Score",\n'
+        '# the confirmed-errors prose, and the per-file "Important Files Changed" notes.'
+    ),
+    "step2_qualifier": "",
+    "followup": (
+        "After fixing AND pushing commits, re-trigger Greptile:\n"
+        "```bash\n"
+        "# ONLY call this AFTER pushing fix commits — NEVER trigger without actual fixes\n"
+        "bash {greptile_helper} trigger {repo} {number}\n"
+        "```\n"
+        "Then run `POLL_BUDGET_SEC={poll_budget_sec} bash {pr_address_script} --repo {repo} {number}` to wait for the re-review.\n"
+        "- Exit 0: merged — done\n"
+        "- Exit 2: new findings — address them, push, reply, re-run once more\n"
+        "- Exit 3: poll budget exhausted — stop; next monitoring cycle will continue"
+    ),
+    "warning": (
+        "⚠️ **If you cannot fix the issues this session, do NOT re-trigger Greptile.**\n"
+        "**NEVER post raw `@greptileai review` directly — ALWAYS use the helper script (has spam guards).**\n"
+        "Multiple sessions may see the same state; the helper's flock+age guards prevent concurrent spam."
+    ),
+    # NOTE(parity): the exit-code bullets and the do-not-loop paragraph are
+    # independently-worded rewrites of the local variant's (e.g. "Greptile
+    # re-reviewed and found new issues" vs "new findings"; indented vs
+    # flush-left bullets) — preserved verbatim per variant.
+    "no_loop": (
+        "**Do NOT loop to chase 5/5.** Address the summary-body findings, re-review\n"
+        "**once**, and if the score still does not clear the floor after the findings are\n"
+        "genuinely addressed, **stop and leave it for human review** (the self-merge gate\n"
+        "correctly blocks below-floor merges; don't auto-merge below floor)."
+    ),
+}
+
+
+# --- Skeleton B: investigate-section blocks (lib.sh:886-932) ---
+#
+# Shared shape of the greptile_needs_fix / greptile_needs_improvement arms
+# of build_item_investigate. These are string appends (not heredocs) that
+# start and end with a newline; the greptile-helper re-trigger block is
+# byte-identical between the two arms.
+
+_INVESTIGATE_SKELETON = """
+### {title}
+```bash
+{read_commands}
+```
+
+{assessment}
+```bash
+bash {greptile_helper} trigger {repo} {number}
+```
+
+{warnings}
+"""
+
+_NEEDS_FIX_SECTIONS = {
+    "title": "Greptile Score Fix Needed (score < 4/5)",
+    # NOTE(parity): the jq object in both investigate arms is malformed —
+    # `body: (.body | split("\n")[0:5] | join(" ")}` never closes the `(`
+    # opened after `body:`, so jq fails at runtime with a syntax error.
+    # The sibling pr_update arm (lib.sh:688) has the closing paren, which
+    # is the drift tell. Preserved byte-for-byte; fixing the jq is a
+    # switchover-time decision. (`\n` inside split() is the literal
+    # two-character sequence the bash `\\n` renders — correct jq, kept.)
+    "read_commands": (
+        "# Read the PR and full Greptile review comments\n"
+        "gh pr view {number} --repo {repo}\n"
+        "gh pr view {number} --repo {repo} --comments\n"
+        "\n"
+        "# Get Greptile's review comments (the ones that need fixing)\n"
+        "gh api repos/{repo}/pulls/{number}/comments \\\n"
+        '  --jq \'.[] | select(.user.login | test("greptile"; "i")) | {id, path, line, body: (.body | split("\\n")[0:5] | join(" ")}\'\n'
+        "\n"
+        "# Get Greptile's summary review comment (contains score like 3/5 or 4/5)\n"
+        "gh api repos/{repo}/issues/{number}/comments \\\n"
+        '  --jq \'.[] | select(.user.login | test("greptile"; "i")) | {id, body} | select(.body | test("/5"))\' | tail -5'
+    ),
+    "assessment": (
+        "This PR has a low Greptile score and likely has real code issues.\n"
+        "**Action**: Read the Greptile findings, fix the issues in the PR's repo, push commits, then re-trigger:"
+    ),
+    # NOTE(parity): this arm says "leave it for the next cycle" while the
+    # LOCAL_GREPTILE_FIX variant says "leave it for human review" — the
+    # investigate lane retries via monitoring cycles, the self-merge lane
+    # escalates. Different by design; listed as a switchover-time review
+    # point because the divergence is easy to mistake for drift.
+    "warnings": (
+        "⚠️ **Only re-trigger if you ACTUALLY pushed fixes addressing the Greptile findings.**\n"
+        "If you cannot fix the issues in this session, do NOT re-trigger — leave it for the next cycle.\n"
+        "NEVER post raw `@greptileai review` directly — ALWAYS use the helper script above (it has spam guards)."
+    ),
+}
+
+_NEEDS_IMPROVEMENT_SECTIONS = {
+    "title": "Greptile Score Improvement (score = 4/5)",
+    # NOTE(parity): same malformed jq as greptile_needs_fix (missing `)`),
+    # with [0:3] instead of [0:5]. Preserved.
+    "read_commands": (
+        "# Read the PR and Greptile review comments\n"
+        "gh pr view {number} --repo {repo}\n"
+        "gh api repos/{repo}/pulls/{number}/comments \\\n"
+        '  --jq \'.[] | select(.user.login | test("greptile"; "i")) | {id, path, line, body: (.body | split("\\n")[0:3] | join(" ")}\''
+    ),
+    "assessment": (
+        "This PR scored 4/5 — minor issues from Greptile. Address them if quick; **leave it untouched if trivial** (do NOT re-trigger just because you looked at it).\n"
+        "Re-trigger ONLY if you actually pushed fixes:"
+    ),
+    # NOTE(parity): greptile_needs_fix ends its NEVER-post-raw line with
+    # "(it has spam guards)."; this arm ends it with a bare period
+    # (lib.sh:911 vs lib.sh:930) — drift, preserved.
+    "warnings": (
+        "⚠️ **Never re-trigger without having pushed at least one fix commit.**\n"
+        "NEVER post raw `@greptileai review` directly — ALWAYS use the helper script above.\n"
+        "If you skip fixing (issues are truly trivial or out of scope), leave the PR alone and do NOT re-trigger."
+    ),
+}
+
+
+# --- Variant table ---
+
+_VARIANTS: dict[InstructionKind, tuple[str, Mapping[str, str]]] = {
+    InstructionKind.LOCAL_GREPTILE_FIX: (_FIX_SKELETON, _LOCAL_FIX_SECTIONS),
+    InstructionKind.CROSS_REPO_GREPTILE_REFRESH: (
+        _FIX_SKELETON,
+        _CROSS_REPO_REFRESH_SECTIONS,
+    ),
+    InstructionKind.GREPTILE_NEEDS_FIX: (_INVESTIGATE_SKELETON, _NEEDS_FIX_SECTIONS),
+    InstructionKind.GREPTILE_NEEDS_IMPROVEMENT: (
+        _INVESTIGATE_SKELETON,
+        _NEEDS_IMPROVEMENT_SECTIONS,
+    ),
+}
+
+
+def render_instruction(kind: InstructionKind, ctx: PromptContext) -> str:
+    """Render the instruction body for ``kind`` with ``ctx`` parameters.
+
+    Output is byte-identical to the corresponding bash builder (see the
+    module docstring for the newline conventions each family preserves).
+    """
+    try:
+        skeleton, sections = _VARIANTS[kind]
+    except KeyError:  # pragma: no cover - defensive; enum is closed
+        raise ValueError(f"no template registered for {kind!r}") from None
+    params = {
+        "repo": ctx.repo,
+        "number": str(ctx.number),
+        "greptile_helper": ctx.resolved_greptile_helper,
+        "pr_address_script": ctx.resolved_pr_address_script,
+        "poll_budget_sec": str(ctx.poll_budget_sec),
+    }
+    # Sections may themselves carry {repo}/{number}/... tokens — resolve
+    # them first, then fill the skeleton with sections + params in one pass.
+    resolved_sections = {k: _substitute(v, params) for k, v in sections.items()}
+    return _substitute(skeleton, {**resolved_sections, **params})

--- a/packages/gptme-runloops/tests/goldens/prompt_templates/cross_repo_greptile_refresh.alice.txt
+++ b/packages/gptme-runloops/tests/goldens/prompt_templates/cross_repo_greptile_refresh.alice.txt
@@ -1,0 +1,40 @@
+### Also: Address Greptile Review Findings (cross-repo)
+
+This PR (ErikBjare/alice#7) has a Greptile review that is stale or below
+the score floor. The confidence score is driven by the **summary-comment body**,
+not the inline P2 nits — fixing only inline threads leaves the score unchanged.
+
+**STEP 1 — Read the score-DRIVING findings in the summary comment (do this FIRST):**
+```bash
+# The Greptile SUMMARY comment is an ISSUE comment containing "Confidence Score",
+# the confirmed-errors prose, and the per-file "Important Files Changed" notes.
+gh api repos/ErikBjare/alice/issues/7/comments --paginate \
+  --jq '.[] | select(.user.login | test("greptile"; "i"))
+            | select(.body | test("Confidence Score"; "i")) | .body'
+```
+
+**STEP 2 — Read the inline review threads (usually P2 nits, a SUBSET):**
+```bash
+gh api repos/ErikBjare/alice/pulls/7/comments \
+  --jq '.[] | select(.user.login | test("greptile"; "i")) | {id, path, line, body}'
+```
+
+**Fix the substantive errors from the summary body FIRST**, then the inline
+findings (P1/P2/P3). After fixing AND pushing commits, re-trigger Greptile:
+```bash
+# ONLY call this AFTER pushing fix commits — NEVER trigger without actual fixes
+bash /srv/agents/alice/workspace/scripts/github/greptile-helper.sh trigger ErikBjare/alice 7
+```
+Then run `POLL_BUDGET_SEC=1800 bash /srv/agents/alice/workspace/scripts/github/pr-address-wait-and-merge.sh --repo ErikBjare/alice 7` to wait for the re-review.
+- Exit 0: merged — done
+- Exit 2: new findings — address them, push, reply, re-run once more
+- Exit 3: poll budget exhausted — stop; next monitoring cycle will continue
+
+⚠️ **If you cannot fix the issues this session, do NOT re-trigger Greptile.**
+**NEVER post raw `@greptileai review` directly — ALWAYS use the helper script (has spam guards).**
+Multiple sessions may see the same state; the helper's flock+age guards prevent concurrent spam.
+
+**Do NOT loop to chase 5/5.** Address the summary-body findings, re-review
+**once**, and if the score still does not clear the floor after the findings are
+genuinely addressed, **stop and leave it for human review** (the self-merge gate
+correctly blocks below-floor merges; don't auto-merge below floor).

--- a/packages/gptme-runloops/tests/goldens/prompt_templates/cross_repo_greptile_refresh.bob.txt
+++ b/packages/gptme-runloops/tests/goldens/prompt_templates/cross_repo_greptile_refresh.bob.txt
@@ -1,0 +1,40 @@
+### Also: Address Greptile Review Findings (cross-repo)
+
+This PR (gptme/gptme-contrib#1234) has a Greptile review that is stale or below
+the score floor. The confidence score is driven by the **summary-comment body**,
+not the inline P2 nits — fixing only inline threads leaves the score unchanged.
+
+**STEP 1 — Read the score-DRIVING findings in the summary comment (do this FIRST):**
+```bash
+# The Greptile SUMMARY comment is an ISSUE comment containing "Confidence Score",
+# the confirmed-errors prose, and the per-file "Important Files Changed" notes.
+gh api repos/gptme/gptme-contrib/issues/1234/comments --paginate \
+  --jq '.[] | select(.user.login | test("greptile"; "i"))
+            | select(.body | test("Confidence Score"; "i")) | .body'
+```
+
+**STEP 2 — Read the inline review threads (usually P2 nits, a SUBSET):**
+```bash
+gh api repos/gptme/gptme-contrib/pulls/1234/comments \
+  --jq '.[] | select(.user.login | test("greptile"; "i")) | {id, path, line, body}'
+```
+
+**Fix the substantive errors from the summary body FIRST**, then the inline
+findings (P1/P2/P3). After fixing AND pushing commits, re-trigger Greptile:
+```bash
+# ONLY call this AFTER pushing fix commits — NEVER trigger without actual fixes
+bash /home/bob/bob/scripts/github/greptile-helper.sh trigger gptme/gptme-contrib 1234
+```
+Then run `POLL_BUDGET_SEC=1800 bash /home/bob/bob/scripts/github/pr-address-wait-and-merge.sh --repo gptme/gptme-contrib 1234` to wait for the re-review.
+- Exit 0: merged — done
+- Exit 2: new findings — address them, push, reply, re-run once more
+- Exit 3: poll budget exhausted — stop; next monitoring cycle will continue
+
+⚠️ **If you cannot fix the issues this session, do NOT re-trigger Greptile.**
+**NEVER post raw `@greptileai review` directly — ALWAYS use the helper script (has spam guards).**
+Multiple sessions may see the same state; the helper's flock+age guards prevent concurrent spam.
+
+**Do NOT loop to chase 5/5.** Address the summary-body findings, re-review
+**once**, and if the score still does not clear the floor after the findings are
+genuinely addressed, **stop and leave it for human review** (the self-merge gate
+correctly blocks below-floor merges; don't auto-merge below floor).

--- a/packages/gptme-runloops/tests/goldens/prompt_templates/greptile_needs_fix.alice.txt
+++ b/packages/gptme-runloops/tests/goldens/prompt_templates/greptile_needs_fix.alice.txt
@@ -1,0 +1,25 @@
+
+### Greptile Score Fix Needed (score < 4/5)
+```bash
+# Read the PR and full Greptile review comments
+gh pr view 7 --repo ErikBjare/alice
+gh pr view 7 --repo ErikBjare/alice --comments
+
+# Get Greptile's review comments (the ones that need fixing)
+gh api repos/ErikBjare/alice/pulls/7/comments \
+  --jq '.[] | select(.user.login | test("greptile"; "i")) | {id, path, line, body: (.body | split("\n")[0:5] | join(" ")}'
+
+# Get Greptile's summary review comment (contains score like 3/5 or 4/5)
+gh api repos/ErikBjare/alice/issues/7/comments \
+  --jq '.[] | select(.user.login | test("greptile"; "i")) | {id, body} | select(.body | test("/5"))' | tail -5
+```
+
+This PR has a low Greptile score and likely has real code issues.
+**Action**: Read the Greptile findings, fix the issues in the PR's repo, push commits, then re-trigger:
+```bash
+bash /srv/agents/alice/workspace/scripts/github/greptile-helper.sh trigger ErikBjare/alice 7
+```
+
+⚠️ **Only re-trigger if you ACTUALLY pushed fixes addressing the Greptile findings.**
+If you cannot fix the issues in this session, do NOT re-trigger — leave it for the next cycle.
+NEVER post raw `@greptileai review` directly — ALWAYS use the helper script above (it has spam guards).

--- a/packages/gptme-runloops/tests/goldens/prompt_templates/greptile_needs_fix.bob.txt
+++ b/packages/gptme-runloops/tests/goldens/prompt_templates/greptile_needs_fix.bob.txt
@@ -1,0 +1,25 @@
+
+### Greptile Score Fix Needed (score < 4/5)
+```bash
+# Read the PR and full Greptile review comments
+gh pr view 1234 --repo gptme/gptme-contrib
+gh pr view 1234 --repo gptme/gptme-contrib --comments
+
+# Get Greptile's review comments (the ones that need fixing)
+gh api repos/gptme/gptme-contrib/pulls/1234/comments \
+  --jq '.[] | select(.user.login | test("greptile"; "i")) | {id, path, line, body: (.body | split("\n")[0:5] | join(" ")}'
+
+# Get Greptile's summary review comment (contains score like 3/5 or 4/5)
+gh api repos/gptme/gptme-contrib/issues/1234/comments \
+  --jq '.[] | select(.user.login | test("greptile"; "i")) | {id, body} | select(.body | test("/5"))' | tail -5
+```
+
+This PR has a low Greptile score and likely has real code issues.
+**Action**: Read the Greptile findings, fix the issues in the PR's repo, push commits, then re-trigger:
+```bash
+bash /home/bob/bob/scripts/github/greptile-helper.sh trigger gptme/gptme-contrib 1234
+```
+
+⚠️ **Only re-trigger if you ACTUALLY pushed fixes addressing the Greptile findings.**
+If you cannot fix the issues in this session, do NOT re-trigger — leave it for the next cycle.
+NEVER post raw `@greptileai review` directly — ALWAYS use the helper script above (it has spam guards).

--- a/packages/gptme-runloops/tests/goldens/prompt_templates/greptile_needs_improvement.alice.txt
+++ b/packages/gptme-runloops/tests/goldens/prompt_templates/greptile_needs_improvement.alice.txt
@@ -1,0 +1,18 @@
+
+### Greptile Score Improvement (score = 4/5)
+```bash
+# Read the PR and Greptile review comments
+gh pr view 7 --repo ErikBjare/alice
+gh api repos/ErikBjare/alice/pulls/7/comments \
+  --jq '.[] | select(.user.login | test("greptile"; "i")) | {id, path, line, body: (.body | split("\n")[0:3] | join(" ")}'
+```
+
+This PR scored 4/5 — minor issues from Greptile. Address them if quick; **leave it untouched if trivial** (do NOT re-trigger just because you looked at it).
+Re-trigger ONLY if you actually pushed fixes:
+```bash
+bash /srv/agents/alice/workspace/scripts/github/greptile-helper.sh trigger ErikBjare/alice 7
+```
+
+⚠️ **Never re-trigger without having pushed at least one fix commit.**
+NEVER post raw `@greptileai review` directly — ALWAYS use the helper script above.
+If you skip fixing (issues are truly trivial or out of scope), leave the PR alone and do NOT re-trigger.

--- a/packages/gptme-runloops/tests/goldens/prompt_templates/greptile_needs_improvement.bob.txt
+++ b/packages/gptme-runloops/tests/goldens/prompt_templates/greptile_needs_improvement.bob.txt
@@ -1,0 +1,18 @@
+
+### Greptile Score Improvement (score = 4/5)
+```bash
+# Read the PR and Greptile review comments
+gh pr view 1234 --repo gptme/gptme-contrib
+gh api repos/gptme/gptme-contrib/pulls/1234/comments \
+  --jq '.[] | select(.user.login | test("greptile"; "i")) | {id, path, line, body: (.body | split("\n")[0:3] | join(" ")}'
+```
+
+This PR scored 4/5 — minor issues from Greptile. Address them if quick; **leave it untouched if trivial** (do NOT re-trigger just because you looked at it).
+Re-trigger ONLY if you actually pushed fixes:
+```bash
+bash /home/bob/bob/scripts/github/greptile-helper.sh trigger gptme/gptme-contrib 1234
+```
+
+⚠️ **Never re-trigger without having pushed at least one fix commit.**
+NEVER post raw `@greptileai review` directly — ALWAYS use the helper script above.
+If you skip fixing (issues are truly trivial or out of scope), leave the PR alone and do NOT re-trigger.

--- a/packages/gptme-runloops/tests/goldens/prompt_templates/local_greptile_fix.alice.txt
+++ b/packages/gptme-runloops/tests/goldens/prompt_templates/local_greptile_fix.alice.txt
@@ -1,0 +1,42 @@
+### Also: Address Greptile Review Findings
+
+This PR has a Greptile review below the score floor (or unresolved findings).
+The confidence score is driven by the **summary-comment body**, not the inline
+P2 nits. Fixing only inline threads leaves the score unchanged (fake remediation).
+
+**STEP 1 — Read the score-DRIVING findings in the summary comment (do this FIRST):**
+```bash
+# The Greptile SUMMARY comment is an ISSUE comment (not an inline thread). It
+# contains "Confidence Score", the confirmed-errors prose, and the per-file
+# "Important Files Changed" notes — THESE are what move the score. Read them:
+gh api repos/ErikBjare/alice/issues/7/comments --paginate \
+  --jq '.[] | select(.user.login | test("greptile"; "i"))
+            | select(.body | test("Confidence Score"; "i")) | .body'
+```
+
+**STEP 2 — Read the inline review threads (usually just P2 nits, a SUBSET):**
+```bash
+gh api repos/ErikBjare/alice/pulls/7/comments \
+  --jq '.[] | select(.user.login | test("greptile"; "i")) | {id, path, line, body}'
+```
+
+**Fix the substantive errors from the summary body FIRST**, then the inline
+findings (P1/P2/P3). A fix that only touches inline nits forces an extra
+round-trip and the score does not move.
+
+**After addressing the findings:**
+1. Push fixes and reply to each comment thread individually with the fix SHA
+2. Run `POLL_BUDGET_SEC=1800 bash /srv/agents/alice/workspace/scripts/github/pr-address-wait-and-merge.sh --repo ErikBjare/alice 7`
+   - Exit 0: merged — done
+   - Exit 2: Greptile re-reviewed and found new issues — read the new unresolved threads, fix them, push, reply, then re-run the command once more
+   - Exit 3: poll budget exhausted without Greptile re-review completing — stop; next monitoring cycle will continue
+
+⚠️ **If you cannot fix the findings, do NOT re-trigger Greptile and do NOT call pr-address-wait-and-merge.sh.**
+NEVER post raw `@greptileai review` comments — the pr-address-wait-and-merge.sh script triggers Greptile internally.
+Only call it AFTER you have actually pushed fix commits.
+
+**Do NOT loop to chase 5/5.** A confidence score is a holistic judgment, not a
+resolved-thread counter — some PRs will not reach 5/5 even after every stated
+finding is genuinely addressed. Address the summary-body findings, re-review
+**once**, and if the score still does not clear the floor, **stop and leave it
+for human review** (the self-merge gate correctly blocks below-floor merges).

--- a/packages/gptme-runloops/tests/goldens/prompt_templates/local_greptile_fix.bob.txt
+++ b/packages/gptme-runloops/tests/goldens/prompt_templates/local_greptile_fix.bob.txt
@@ -1,0 +1,42 @@
+### Also: Address Greptile Review Findings
+
+This PR has a Greptile review below the score floor (or unresolved findings).
+The confidence score is driven by the **summary-comment body**, not the inline
+P2 nits. Fixing only inline threads leaves the score unchanged (fake remediation).
+
+**STEP 1 — Read the score-DRIVING findings in the summary comment (do this FIRST):**
+```bash
+# The Greptile SUMMARY comment is an ISSUE comment (not an inline thread). It
+# contains "Confidence Score", the confirmed-errors prose, and the per-file
+# "Important Files Changed" notes — THESE are what move the score. Read them:
+gh api repos/gptme/gptme-contrib/issues/1234/comments --paginate \
+  --jq '.[] | select(.user.login | test("greptile"; "i"))
+            | select(.body | test("Confidence Score"; "i")) | .body'
+```
+
+**STEP 2 — Read the inline review threads (usually just P2 nits, a SUBSET):**
+```bash
+gh api repos/gptme/gptme-contrib/pulls/1234/comments \
+  --jq '.[] | select(.user.login | test("greptile"; "i")) | {id, path, line, body}'
+```
+
+**Fix the substantive errors from the summary body FIRST**, then the inline
+findings (P1/P2/P3). A fix that only touches inline nits forces an extra
+round-trip and the score does not move.
+
+**After addressing the findings:**
+1. Push fixes and reply to each comment thread individually with the fix SHA
+2. Run `POLL_BUDGET_SEC=1800 bash /home/bob/bob/scripts/github/pr-address-wait-and-merge.sh --repo gptme/gptme-contrib 1234`
+   - Exit 0: merged — done
+   - Exit 2: Greptile re-reviewed and found new issues — read the new unresolved threads, fix them, push, reply, then re-run the command once more
+   - Exit 3: poll budget exhausted without Greptile re-review completing — stop; next monitoring cycle will continue
+
+⚠️ **If you cannot fix the findings, do NOT re-trigger Greptile and do NOT call pr-address-wait-and-merge.sh.**
+NEVER post raw `@greptileai review` comments — the pr-address-wait-and-merge.sh script triggers Greptile internally.
+Only call it AFTER you have actually pushed fix commits.
+
+**Do NOT loop to chase 5/5.** A confidence score is a holistic judgment, not a
+resolved-thread counter — some PRs will not reach 5/5 even after every stated
+finding is genuinely addressed. Address the summary-body findings, re-review
+**once**, and if the score still does not clear the floor, **stop and leave it
+for human review** (the self-merge gate correctly blocks below-floor merges).

--- a/packages/gptme-runloops/tests/test_prompt_templates.py
+++ b/packages/gptme-runloops/tests/test_prompt_templates.py
@@ -1,0 +1,198 @@
+"""Golden tests for the Greptile prompt templates.
+
+The goldens under ``tests/goldens/prompt_templates/`` are the *captured
+output of the bash builders* in ErikBjare/bob
+``scripts/github/project-monitoring-lib.sh`` @
+ca7aa17a2899dbe676fba7074fc5c4dd61d25fe4 (lines 425-470, 474-517, 886-912,
+913-932), rendered for two parameter sets. :func:`render_instruction` must
+match them byte-for-byte — this is what lets the later brain-side switchover
+PR prove "same prompts out".
+
+Regenerate the goldens from a checkout of the brain repo with::
+
+    source scripts/github/project-monitoring-lib.sh
+    export item_repo=gptme/gptme-contrib item_number=1234 WORKSPACE=/home/bob/bob
+    _build_local_greptile_fix_instructions > local_greptile_fix.bob.txt
+    _build_cross_repo_greptile_refresh_instructions > cross_repo_greptile_refresh.bob.txt
+    item_types="greptile_needs_fix"; build_item_investigate
+    printf '%s' "$INVESTIGATE" > greptile_needs_fix.bob.txt
+    item_types="greptile_needs_improvement"; build_item_investigate
+    printf '%s' "$INVESTIGATE" > greptile_needs_improvement.bob.txt
+    # ...and again with the second parameter set (see CONTEXTS below).
+
+Newline conventions locked in here (see the module docstring):
+
+- fix-instruction kinds render the heredoc's stdout **with** its trailing
+  newline (the bash ``$(...)`` call site strips it);
+- investigate kinds render the ``INVESTIGATE+=`` string **with** its leading
+  and trailing newline.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from gptme_runloops.merge_lifecycle import InstructionKind
+from gptme_runloops.prompt_templates import PromptContext, render_instruction
+
+GOLDEN_DIR = Path(__file__).parent / "goldens" / "prompt_templates"
+
+# Two parameter sets: the brain's own values (proving parity with what the
+# bash renders in production) and a non-Bob agent (proving the Bob-specific
+# bits are really parameters — Alice consumes this package too).
+CONTEXTS: dict[str, PromptContext] = {
+    "bob": PromptContext(
+        repo="gptme/gptme-contrib", number=1234, workspace="/home/bob/bob"
+    ),
+    "alice": PromptContext(
+        repo="ErikBjare/alice", number=7, workspace="/srv/agents/alice/workspace"
+    ),
+}
+
+ALL_KINDS = tuple(InstructionKind)
+
+
+# --- Golden parity ---
+
+
+@pytest.mark.parametrize("kind", ALL_KINDS, ids=lambda k: k.value)
+@pytest.mark.parametrize("ctx_name", sorted(CONTEXTS))
+def test_render_matches_bash_golden(kind: InstructionKind, ctx_name: str) -> None:
+    golden = (GOLDEN_DIR / f"{kind.value}.{ctx_name}.txt").read_text()
+    assert render_instruction(kind, CONTEXTS[ctx_name]) == golden
+
+
+def test_every_kind_has_a_template() -> None:
+    ctx = CONTEXTS["bob"]
+    for kind in InstructionKind:
+        assert render_instruction(kind, ctx)
+
+
+def test_every_kind_and_context_has_a_golden() -> None:
+    expected = {
+        f"{kind.value}.{ctx}.txt" for kind in InstructionKind for ctx in CONTEXTS
+    }
+    assert {p.name for p in GOLDEN_DIR.glob("*.txt")} == expected
+
+
+# --- Newline conventions ---
+
+
+@pytest.mark.parametrize(
+    "kind",
+    [InstructionKind.LOCAL_GREPTILE_FIX, InstructionKind.CROSS_REPO_GREPTILE_REFRESH],
+    ids=lambda k: k.value,
+)
+def test_fix_instruction_kinds_render_heredoc_stdout(kind: InstructionKind) -> None:
+    out = render_instruction(kind, CONTEXTS["bob"])
+    assert out.startswith("### Also: Address Greptile Review Findings")
+    assert out.endswith(".\n") and not out.endswith("\n\n")
+
+
+@pytest.mark.parametrize(
+    "kind",
+    [InstructionKind.GREPTILE_NEEDS_FIX, InstructionKind.GREPTILE_NEEDS_IMPROVEMENT],
+    ids=lambda k: k.value,
+)
+def test_investigate_kinds_render_append_string(kind: InstructionKind) -> None:
+    out = render_instruction(kind, CONTEXTS["bob"])
+    assert out.startswith("\n### Greptile Score ")
+    assert out.endswith(".\n") and not out.endswith("\n\n")
+
+
+# --- Parameterization (nothing Bob-specific baked in) ---
+
+
+@pytest.mark.parametrize("kind", ALL_KINDS, ids=lambda k: k.value)
+def test_no_bob_paths_leak_into_other_agents_render(kind: InstructionKind) -> None:
+    out = render_instruction(kind, CONTEXTS["alice"])
+    assert "/home/bob" not in out
+    assert "gptme/gptme-contrib" not in out
+
+
+def test_helper_paths_derive_from_workspace() -> None:
+    ctx = PromptContext(repo="o/r", number=1, workspace="/ws")
+    assert ctx.resolved_greptile_helper == "/ws/scripts/github/greptile-helper.sh"
+    assert (
+        ctx.resolved_pr_address_script
+        == "/ws/scripts/github/pr-address-wait-and-merge.sh"
+    )
+
+
+def test_explicit_helper_paths_override_workspace_derivation() -> None:
+    ctx = PromptContext(
+        repo="o/r",
+        number=1,
+        workspace="/ws",
+        greptile_helper="/opt/tools/greptile.sh",
+        pr_address_script="/opt/tools/pr-wait.sh",
+    )
+    cross = render_instruction(InstructionKind.CROSS_REPO_GREPTILE_REFRESH, ctx)
+    assert "bash /opt/tools/greptile.sh trigger o/r 1" in cross
+    assert "bash /opt/tools/pr-wait.sh --repo o/r 1" in cross
+    assert "/ws/scripts" not in cross
+
+
+def test_poll_budget_is_a_parameter_with_bash_default() -> None:
+    default = render_instruction(
+        InstructionKind.LOCAL_GREPTILE_FIX, PromptContext("o/r", 1, "/ws")
+    )
+    assert "POLL_BUDGET_SEC=1800 bash" in default
+    custom = render_instruction(
+        InstructionKind.LOCAL_GREPTILE_FIX,
+        PromptContext("o/r", 1, "/ws", poll_budget_sec=600),
+    )
+    assert "POLL_BUDGET_SEC=600 bash" in custom
+
+
+def test_number_accepts_str_and_int() -> None:
+    as_int = render_instruction(
+        InstructionKind.GREPTILE_NEEDS_FIX, PromptContext("o/r", 42, "/ws")
+    )
+    as_str = render_instruction(
+        InstructionKind.GREPTILE_NEEDS_FIX, PromptContext("o/r", "42", "/ws")
+    )
+    assert as_int == as_str
+
+
+# --- Preserved quirks (NOTE(parity) anchors) ---
+
+
+@pytest.mark.parametrize(
+    "kind",
+    [InstructionKind.GREPTILE_NEEDS_FIX, InstructionKind.GREPTILE_NEEDS_IMPROVEMENT],
+    ids=lambda k: k.value,
+)
+def test_investigate_jq_malformation_is_preserved(kind: InstructionKind) -> None:
+    # NOTE(parity): the bash investigate arms ship a jq object whose
+    # `body: (...` group is never closed — a runtime jq syntax error the
+    # sibling pr_update arm does not have. The port preserves it; this test
+    # pins the quirk so an accidental "fix" fails loudly (fixing it is a
+    # switchover-time decision).
+    out = render_instruction(kind, CONTEXTS["bob"])
+    jq_line = next(
+        line for line in out.splitlines() if "split(" in line and "join(" in line
+    )
+    assert jq_line.count("(") == jq_line.count(")") + 1
+
+
+def test_step2_qualifier_drift_is_preserved() -> None:
+    # NOTE(parity): "usually just P2 nits" (local) vs "usually P2 nits"
+    # (cross-repo) — one-word drift between the two heredocs, preserved.
+    ctx = CONTEXTS["bob"]
+    local = render_instruction(InstructionKind.LOCAL_GREPTILE_FIX, ctx)
+    cross = render_instruction(InstructionKind.CROSS_REPO_GREPTILE_REFRESH, ctx)
+    assert "(usually just P2 nits, a SUBSET)" in local
+    assert "(usually P2 nits, a SUBSET)" in cross
+
+
+def test_local_fix_never_names_the_greptile_helper() -> None:
+    # NOTE(parity): local PRs re-trigger via pr-address-wait-and-merge.sh
+    # (internal trigger); only the cross-repo variant instructs an explicit
+    # greptile-helper trigger. Intentional lane difference.
+    ctx = CONTEXTS["bob"]
+    local = render_instruction(InstructionKind.LOCAL_GREPTILE_FIX, ctx)
+    cross = render_instruction(InstructionKind.CROSS_REPO_GREPTILE_REFRESH, ctx)
+    assert "greptile-helper.sh" not in local
+    assert f"greptile-helper.sh trigger {ctx.repo} {ctx.number}" in cross


### PR DESCRIPTION
Step 2 of 8 of the Phase-2 execution-consolidation migration ([design doc](https://github.com/ErikBjare/bob/blob/master/knowledge/technical-designs/reactive-dispatch-phase2-3-execution-consolidation.md), migration table row 2). Builds on #1261 (merge-lifecycle decision core), which deliberately left `InstructionKind` as the seam for this step: decisions name which instruction to issue; this PR adds the module that renders the bodies.

**Pure template port — no brain-side behavior change.** The bash heredocs remain the runtime hotpath; switching `project-monitoring-lib.sh` to consume this module is a later brain-side switchover PR, which will diff its output against the golden tests added here to prove "same prompts out".

## What moved

Four ~90%-pairwise-duplicate Greptile prompt-building heredocs from ErikBjare/bob `scripts/github/project-monitoring-lib.sh` @ `ca7aa17a2899dbe676fba7074fc5c4dd61d25fe4`:

| Bash source (lines @ sha above) | `InstructionKind` | Skeleton |
|---|---|---|
| `_build_local_greptile_fix_instructions` (425-470) | `LOCAL_GREPTILE_FIX` | fix-instruction |
| `_build_cross_repo_greptile_refresh_instructions` (474-517) | `CROSS_REPO_GREPTILE_REFRESH` | fix-instruction |
| `build_item_investigate` arm `greptile_needs_fix` (886-912) | `GREPTILE_NEEDS_FIX` (new enum member) | investigate |
| `build_item_investigate` arm `greptile_needs_improvement` (913-932) | `GREPTILE_NEEDS_IMPROVEMENT` (new enum member) | investigate |

New module: `gptme_runloops/prompt_templates.py` — two shared skeletons + per-variant section tables behind one entry point `render_instruction(kind: InstructionKind, ctx: PromptContext) -> str`.

## Variant → parameter table

`PromptContext` carries everything agent-specific (nothing Bob-hardcoded; Alice consumes the same package):

| Parameter | Bash origin | Default |
|---|---|---|
| `repo` | `$item_repo` | required |
| `number` | `$item_number` | required |
| `workspace` | `$WORKSPACE` | required |
| `greptile_helper` | `$WORKSPACE/scripts/github/greptile-helper.sh` | derived from `workspace` |
| `pr_address_script` | `$WORKSPACE/scripts/github/pr-address-wait-and-merge.sh` | derived from `workspace` |
| `poll_budget_sec` | hardcoded `1800` in the heredocs | `1800` |

Per-variant sections (title/intro/STEP-1 comment/follow-up/warning/closing blocks) live in a variant table in the module; the shared `gh api` command blocks and the greptile-helper re-trigger block are byte-identical across variants and live in the skeletons.

## Golden tests (the core deliverable)

`tests/goldens/prompt_templates/*.txt` are the captured stdout of the actual bash builders (sourced `project-monitoring-lib.sh`, rendered for two parameter sets: Bob's production values + a synthetic non-Bob agent). `test_prompt_templates.py` asserts **byte-identical** renders for every kind × parameter set — no normalization was needed. Newline conventions are preserved and pinned: fix-instruction kinds render the heredoc stdout including its trailing newline (the bash `$(...)` call site strips it); investigate kinds render the `INVESTIGATE+=` string including its leading and trailing newline.

## Drift-bugs found between variants (preserved, NOT fixed — switchover-time decisions)

1. **Malformed jq in both investigate arms** (lib.sh:896, 920): `body: (.body | split("\n")[0:N] | join(" ")}` never closes the `(` opened after `body:` — a runtime jq syntax error. The sibling `pr_update` arm (lib.sh:688) has the closing paren, which is the drift tell. Preserved byte-for-byte and pinned by `test_investigate_jq_malformation_is_preserved`.
2. **STEP-2 wording drift**: local says "usually **just** P2 nits", cross-repo says "usually P2 nits" (lib.sh:443 vs 491). Pinned by `test_step2_qualifier_drift_is_preserved`.
3. **STEP-1 comment drift**: local has the 3-line explanatory comment ("— THESE are what move the score. Read them:"); cross-repo has an independently condensed 2-line rewrite (lib.sh:435-437 vs 484-485).
4. **Spam-guard suffix drift**: `greptile_needs_fix` ends its NEVER-post-raw line with "(it has spam guards)."; `greptile_needs_improvement` ends with a bare period (lib.sh:911 vs 930).
5. **Independently-worded exit-code bullets / do-not-loop paragraphs** between local and cross-repo fix variants ("Greptile re-reviewed and found new issues" vs "new findings"; indented vs flush-left bullets).

Intentional (not drift, documented as such): the local variant never names greptile-helper (local PRs re-trigger via `pr-address-wait-and-merge.sh`'s internal trigger) while cross-repo instructs an explicit helper trigger; and the investigate lane says "leave it for the next cycle" where the self-merge lane says "leave it for human review".

## Follow-up (not in this PR)

- Step 3: worker heredocs → module functions.
- Brain-side switchover: `project-monitoring-lib.sh` consumes `render_instruction` and deletes the heredocs, diffing against these goldens; the drift-bugs above get decided (fix or keep) there.
