### PR TITLE
feat(runloops): port PM worker post-session heredocs as module functions

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/worker_records.py
+++ b/packages/gptme-runloops/src/gptme_runloops/worker_records.py
@@ -1,0 +1,863 @@
+"""PM worker post-session bookkeeping (record writing, PR-state diff, delivery check).
+
+Behavior-identical port of the inline ``python3`` heredoc blocks from
+ErikBjare/bob ``scripts/github/project-monitoring-worker.sh`` (step 3 of the
+Phase-2 execution-consolidation migration; see
+``knowledge/technical-designs/reactive-dispatch-phase2-3-execution-consolidation.md``
+in that repo). Steps 1-2 were contrib#1261 (:mod:`gptme_runloops.merge_lifecycle`)
+and contrib#1262 (:mod:`gptme_runloops.prompt_templates`). The bash remains the
+runtime hotpath until the brain-side shim PR; the golden/table tests in
+``tests/test_worker_records.py`` are what that shim will diff against.
+
+Bash source blocks ported (ErikBjare/bob @
+98e7da0eb18543c53ca7f7ee207eb679010ccffb):
+
+- ``project-monitoring-worker.sh:110-127`` — CC rate-limit log parser
+  (``python3 - "$_cc_log" <<'PYEOF'``): find the first *rejected*
+  ``rate_limit_event`` in a stream-json log → :func:`parse_rate_limit_rejection`.
+- ``project-monitoring-worker.sh:283-323`` — primary session-record write via
+  ``gptme_sessions.post_session`` → :func:`write_post_session_record`
+  (``post_session``/``make_store`` injected by the caller).
+- ``project-monitoring-worker.sh:325-373`` — legacy fallback record write via
+  ``metaproductivity.sessions.SessionRecord`` → :func:`fallback_outcome` +
+  :func:`write_fallback_session_record` (``make_record`` injected).
+- ``project-monitoring-worker.sh:377-502`` — PR-state before/after diff +
+  deliverables dedupe + outcome upgrade hook → :func:`parse_pr_snapshot`,
+  :func:`apply_pr_state_diff`, :func:`update_record_pr_state`
+  (``fetch_pr_snapshot`` is the default gh adapter; ``upgrade_outcome``
+  injected).
+- ``project-monitoring-worker.sh:505-627`` — worker-result manifest build +
+  record enrichment → :func:`collect_commit_oids`,
+  :func:`apply_worker_result_to_payload`, :func:`write_worker_result_manifest`
+  (``agent_events.worker_results`` functions injected).
+- ``project-monitoring-worker.sh:651-666`` — delivery-check JSON field
+  extractor (``python3 -c``) → :func:`extract_delivery_field`; plus the
+  surrounding pure bash decisions ``project-monitoring-worker.sh:668-690``
+  → :func:`normalize_delivery_outcome`, :func:`compute_latency_outcome`.
+- ``project-monitoring-worker.sh:692-718`` — latency-ledger append via
+  ``metaproductivity.project_monitoring_latency`` →
+  :func:`append_worker_latency_records` (``append_latency_records`` injected).
+- ``project-monitoring-worker.sh:743-766`` — auto wait-and-merge gate JSONL
+  log entry → :func:`build_wait_merge_gate_entry`,
+  :func:`append_wait_merge_gate_log`.
+- ``project-monitoring-worker.sh:70`` — the ``_item_types_json`` splitter
+  (heredoc-injection hardening) → :func:`split_item_types`.
+- ``project-monitoring-worker.sh:808-815`` — arc auto-close PR-state reader
+  (``python3 -c``) → :func:`read_record_pr_state_after`.
+
+Design rules (same as steps 1-2):
+
+- Parse/compute/diff logic is pure: data in, data out. File and subprocess
+  I/O is separated into thin orchestrators whose side-effecting collaborators
+  (``post_session``, ``make_record``, ``build_worker_result``,
+  ``append_latency_records``, the gh snapshot fetcher) are injected — the
+  agent-side packages they come from (``gptme_sessions``, brain-side
+  ``metaproductivity``/``agent_events``) are NOT imported here.
+- Bob-specific paths/config are parameters with defaults; nothing points at
+  ``/home/bob``.
+- The bash heredocs receive values via ``${var@Q}`` string interpolation
+  (which is why the bash pre-encodes ``item_types`` as JSON — worker.sh:67-70);
+  these functions take real parameters, eliminating that injection class.
+  The brain shim passes values via argv/env instead.
+- Failure contract: the bash runs each heredoc under ``|| true`` (or uses a
+  non-zero exit to trigger the legacy fallback), so a heredoc that dies
+  mid-way simply skips that bookkeeping step. The orchestrators preserve
+  this by *raising* on the same conditions the heredocs die on (bad JSON in
+  required inputs, gh timeout, non-numeric PR number); callers wrap with the
+  same tolerance the bash uses.
+- Where the bash behavior is quirky, the port preserves it and marks the
+  spot with a ``# NOTE(parity):`` comment. Behavior changes come later, with
+  the brain-side switchover.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+# Commit-oid extraction from deliverable strings (worker.sh:519).
+# NOTE(parity): re.IGNORECASE is redundant in the bash heredoc too — findall
+# runs on ``deliverable.lower()`` — but it is part of the source pattern, so
+# it is preserved.
+COMMIT_OID_RE = re.compile(r"\b[0-9a-f]{7,40}\b", re.IGNORECASE)
+
+# Latency outcomes the bash case-whitelist accepts (worker.sh:671-674).
+KNOWN_DELIVERY_OUTCOMES: frozenset[str] = frozenset(
+    {"handled", "orphan_no_delivery", "no_action_needed", "failed"}
+)
+
+
+# --- CC rate-limit log parsing (worker.sh:110-127) ---
+
+
+@dataclass(frozen=True)
+class RateLimitRejection:
+    """The first *rejected* rate_limit_event found in a CC stream-json log.
+
+    Field values are whatever JSON types the log carried (``resetsAt`` is
+    typically an int epoch); :meth:`render` stringifies them exactly the way
+    the heredoc's ``print(..., sep='\\t')`` does.
+    """
+
+    rate_limit_type: Any
+    resets_at: Any
+
+    def render(self) -> str:
+        """The heredoc's stdout line, consumed by the bash via ``cut -f1/-f2``."""
+        return f"{self.rate_limit_type}\t{self.resets_at}"
+
+
+def parse_rate_limit_rejection(lines: Iterable[str]) -> RateLimitRejection | None:
+    """Find the first REJECTED rate_limit_event in a stream-json log.
+
+    Mirrors worker.sh:110-127: blank lines and JSON-invalid lines are
+    skipped; the first ``type == "rate_limit_event"`` whose
+    ``rate_limit_info.status == "rejected"`` wins; missing info keys yield
+    ``""``. Returns ``None`` when no rejection is present (the heredoc
+    prints nothing → the bash sees ``_cc_rl_info=""`` and does NOT block).
+
+    NOTE(parity): a rate_limit_event whose ``rate_limit_info`` is not a dict
+    raises (the heredoc dies on ``.get`` of a non-dict), aborting the scan
+    even if a later line holds a valid rejection. The bash catches the
+    non-zero exit (``|| _cc_rl_info=""``) and treats it as "no rejection".
+    """
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            d = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        # NOTE(parity): non-dict JSON lines (arrays, strings) die on .get in
+        # the heredoc; same here.
+        if d.get("type") == "rate_limit_event":
+            info = d.get("rate_limit_info", {})
+            if info.get("status") == "rejected":
+                return RateLimitRejection(
+                    rate_limit_type=info.get("rateLimitType", ""),
+                    resets_at=info.get("resetsAt", ""),
+                )
+    return None
+
+
+# --- Shared helpers ---
+
+
+def resolve_trajectory(path_str: str | None) -> Path | None:
+    """Trajectory-path resolution shared by both record writers (worker.sh:301-303).
+
+    Empty/None → ``None``; a path that is not an existing regular file →
+    ``None``.
+    """
+    trajectory = Path(path_str) if path_str else None
+    if trajectory is not None and not trajectory.is_file():
+        return None
+    return trajectory
+
+
+def split_item_types(text: str) -> list[str]:
+    """Whitespace-split an ``item_types`` string (worker.sh:70).
+
+    The bash pre-encodes this as a JSON array purely to survive ``${var@Q}``
+    heredoc injection; with real parameters the split is all that remains.
+    """
+    return text.split()
+
+
+def _write_record(record_path: Path, payload: Mapping[str, Any]) -> None:
+    """Serialize a record the way every heredoc does (``ensure_ascii=False``)."""
+    record_path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+
+# --- Primary session-record write (worker.sh:283-323) ---
+
+
+def finalize_post_session_record(
+    record: Mapping[str, Any],
+    grade: Any,
+    item_timeout: int,
+) -> dict[str, Any]:
+    """Post-process a ``post_session`` record dict (worker.sh:318-321).
+
+    Adds the grade and, when a positive timeout was configured, the
+    ``timeout_seconds`` field.
+    """
+    finalized = dict(record)
+    finalized["grade"] = grade
+    if item_timeout > 0:
+        finalized["timeout_seconds"] = item_timeout
+    return finalized
+
+
+def write_post_session_record(
+    record_file: Path | str,
+    *,
+    harness: str,
+    model: str | None,
+    session_id: str,
+    exit_code: int,
+    duration_seconds: int,
+    item_timeout: int,
+    trajectory_path: str | None,
+    post_session: Callable[..., Any],
+    make_store: Callable[[Path], Any],
+) -> None:
+    """Write the monitoring session record via an injected ``post_session``.
+
+    Mirrors worker.sh:283-323. ``post_session`` and ``make_store`` are the
+    caller's ``gptme_sessions.post_session.post_session`` and a
+    ``SessionStore`` factory taking the sessions dir (the record file's
+    parent) — injected so this package does not depend on gptme-sessions.
+
+    Raises on any failure (the bash uses the heredoc's non-zero exit to
+    trigger the legacy fallback writer).
+    """
+    record_path = Path(record_file)
+    record_path.parent.mkdir(parents=True, exist_ok=True)
+    trajectory = resolve_trajectory(trajectory_path)
+
+    store = make_store(record_path.parent)
+    result = post_session(
+        store=store,
+        harness=harness,
+        # NOTE(parity): empty model → None here, but → "unknown" in the
+        # fallback writer below (worker.sh:309 vs :358). Preserved.
+        model=model if model else None,
+        run_type="monitoring",
+        trigger="timer",
+        category="pm-react",
+        exit_code=exit_code,
+        duration_seconds=duration_seconds,
+        trajectory_path=trajectory,
+        session_id=session_id,
+    )
+    record = finalize_post_session_record(
+        result.record.to_dict(), result.grade, item_timeout
+    )
+    _write_record(record_path, record)
+
+
+# --- Legacy fallback record write (worker.sh:325-373) ---
+
+
+def fallback_outcome(exit_code: int) -> str:
+    """The fallback writer's outcome heuristic (worker.sh:325-326).
+
+    NOTE(parity): a timeout (exit 124) records as ``"unknown"``, not
+    ``"failed"`` or ``"timeout"`` — only non-zero non-124 exits are
+    ``"failed"``. Preserved.
+    """
+    if exit_code != 0 and exit_code != 124:
+        return "failed"
+    return "unknown"
+
+
+def build_fallback_record_payload(
+    base_record: Mapping[str, Any],
+    *,
+    session_id: str,
+    duration_seconds: int,
+    exit_code: int,
+    item_timeout: int,
+    trajectory: Path | None,
+) -> dict[str, Any]:
+    """Augment a base SessionRecord dict the way worker.sh:364-372 does.
+
+    NOTE(parity): ``duration_seconds`` is re-assigned even though the base
+    record already carries it (worker.sh:366 duplicates :363's constructor
+    argument). Preserved.
+    """
+    payload = dict(base_record)
+    payload["session_id"] = session_id
+    payload["duration_seconds"] = duration_seconds
+    payload["exit_code"] = int(exit_code)
+    if item_timeout > 0:
+        payload["timeout_seconds"] = item_timeout
+    if trajectory is not None:
+        payload["trajectory_path"] = str(trajectory)
+    return payload
+
+
+def write_fallback_session_record(
+    record_file: Path | str,
+    *,
+    harness: str,
+    model: str | None,
+    outcome: str,
+    session_id: str,
+    exit_code: int,
+    duration_seconds: int,
+    item_timeout: int,
+    trajectory_path: str | None,
+    make_record: Callable[..., Mapping[str, Any]],
+) -> None:
+    """Write the legacy fallback record (worker.sh:335-373).
+
+    ``make_record`` is the caller's base-record factory — e.g.
+    ``lambda **kw: SessionRecord(**kw).to_dict()`` over the brain's
+    ``metaproductivity.sessions.SessionRecord`` — injected so this package
+    does not depend on brain-side code. It receives exactly the constructor
+    arguments the heredoc passes (worker.sh:356-363).
+    """
+    record_path = Path(record_file)
+    record_path.parent.mkdir(parents=True, exist_ok=True)
+    trajectory = resolve_trajectory(trajectory_path)
+    base_record = make_record(
+        harness=harness,
+        model=model if model else "unknown",
+        run_type="monitoring",
+        category="pm-react",
+        outcome=outcome,
+        duration_seconds=duration_seconds,
+    )
+    payload = build_fallback_record_payload(
+        base_record,
+        session_id=session_id,
+        duration_seconds=duration_seconds,
+        exit_code=exit_code,
+        item_timeout=item_timeout,
+        trajectory=trajectory,
+    )
+    _write_record(record_path, payload)
+
+
+# --- PR-state before/after diff (worker.sh:377-502) ---
+
+
+def normalize_oid(value: Any) -> str:
+    """worker.sh:385-386 — stringified, stripped, lowercased ('' for falsy)."""
+    return str(value or "").strip().lower()
+
+
+def normalize_pr_snapshot(payload: Any) -> dict[str, str]:
+    """Normalize a ``gh pr view --json state,headRefOid,mergeCommit`` payload.
+
+    Mirrors worker.sh:389-399: non-dict payloads → ``{}``; ``mergeCommit``
+    may be the gh object form (``{"oid": ...}``) or a bare value; state is
+    uppercased, oids lowercased.
+    """
+    if not isinstance(payload, dict):
+        return {}
+    merge_commit = payload.get("mergeCommit")
+    if isinstance(merge_commit, dict):
+        merge_commit = merge_commit.get("oid")
+    return {
+        "state": str(payload.get("state") or "").strip().upper(),
+        "headRefOid": normalize_oid(payload.get("headRefOid")),
+        "mergeCommit": normalize_oid(merge_commit),
+    }
+
+
+def parse_pr_snapshot(raw: str) -> dict[str, str]:
+    """Parse a raw snapshot JSON string; empty/invalid → ``{}`` (worker.sh:402-410)."""
+    raw = raw.strip()
+    if not raw:
+        return {}
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return normalize_pr_snapshot(payload)
+
+
+def dedupe_deliverables(values: Sequence[Any]) -> list[str]:
+    """Case-insensitive dedupe keeping the first spelling (worker.sh:436-448).
+
+    NOTE(parity): this differs from the worker-result manifest's dedupe
+    (:func:`normalize_manifest_deliverables`), which is case-SENSITIVE.
+    Both are preserved as-is.
+    """
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        text = str(value or "").strip()
+        if not text:
+            continue
+        key = text.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(text)
+    return deduped
+
+
+def apply_pr_state_diff(
+    payload: dict[str, Any],
+    before: Mapping[str, str],
+    after: Mapping[str, str],
+) -> dict[str, Any]:
+    """Fold normalized before/after snapshots into a record payload.
+
+    Pure core of worker.sh:459-486: sets ``pr_state_before/after``,
+    ``pr_head_oid_before/after``, ``pr_merge_commit_before/after`` (each
+    only when truthy — an empty observation never clears a field), appends
+    the new head to deliverables when the head advanced, and replaces
+    ``deliverables`` with the case-insensitively deduped list (always, even
+    when empty). Mutates and returns ``payload``.
+    """
+    deliverables = payload.get("deliverables")
+    if not isinstance(deliverables, list):
+        deliverables = []
+
+    before_head = before.get("headRefOid", "")
+    after_head = after.get("headRefOid", "")
+
+    if before.get("state"):
+        payload["pr_state_before"] = before["state"]
+    if before_head:
+        payload["pr_head_oid_before"] = before_head
+    if before.get("mergeCommit"):
+        payload["pr_merge_commit_before"] = before["mergeCommit"]
+
+    if after.get("state"):
+        payload["pr_state_after"] = after["state"]
+    if after_head:
+        payload["pr_head_oid_after"] = after_head
+    if after.get("mergeCommit"):
+        payload["pr_merge_commit_after"] = after["mergeCommit"]
+
+    if before_head and after_head and before_head != after_head:
+        deliverables.append(after_head)
+
+    payload["deliverables"] = dedupe_deliverables(deliverables)
+    return payload
+
+
+def fetch_pr_snapshot(
+    repo: str,
+    number: int | str,
+    *,
+    cwd: str | Path,
+    timeout: float = 20,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> dict[str, str]:
+    """Fetch the live PR snapshot via gh (worker.sh:413-433).
+
+    A non-zero gh exit → ``{}``; unparseable stdout → ``{}``.
+
+    NOTE(parity): a gh *timeout* raises (``subprocess.TimeoutExpired``),
+    killing the whole diff step — including the already-parsed before-fields
+    — exactly as the heredoc dies under its ``|| true``. Preserved.
+    """
+    result = runner(
+        [
+            "gh",
+            "pr",
+            "view",
+            str(number),
+            "--repo",
+            repo,
+            "--json",
+            "state,headRefOid,mergeCommit",
+        ],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    if result.returncode != 0:
+        return {}
+    return parse_pr_snapshot(result.stdout)
+
+
+def update_record_pr_state(
+    record_file: Path | str,
+    *,
+    repo: str,
+    number: int | str,
+    before_json: str,
+    cwd: str | Path,
+    fetch: Callable[[str, int], dict[str, str]] | None = None,
+    upgrade_outcome: Callable[[dict[str, Any]], Any] | None = None,
+) -> None:
+    """Run the whole PR-state diff step against a record file (worker.sh:377-502).
+
+    ``fetch`` overrides the default gh adapter (tests); ``upgrade_outcome``
+    is the caller's ``metaproductivity.pr_outcome.upgrade_outcome_from_pr_state``
+    or ``None`` when unavailable — the heredoc's ``except ImportError: pass``
+    (worker.sh:495-499) maps to passing ``None``.
+
+    Missing or non-dict record → silently returns (worker.sh:451-457).
+    """
+    record_path = Path(record_file)
+    if not record_path.is_file():
+        return
+
+    payload = json.loads(record_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        return
+
+    before = parse_pr_snapshot(before_json)
+    pr_number = int(number)
+    if fetch is not None:
+        after = fetch(repo, pr_number)
+    else:
+        after = fetch_pr_snapshot(repo, pr_number, cwd=cwd)
+
+    apply_pr_state_diff(payload, before, after)
+
+    if upgrade_outcome is not None:
+        upgrade_outcome(payload)
+
+    _write_record(record_path, payload)
+
+
+# --- Worker-result manifest (worker.sh:505-627) ---
+
+
+def normalize_head(value: Any) -> str | None:
+    """worker.sh:522-524 — stripped+lowercased str, ``None`` when empty."""
+    text = str(value or "").strip().lower()
+    return text or None
+
+
+def normalize_manifest_deliverables(raw: Any) -> list[str]:
+    """Case-SENSITIVE deliverables dedupe (worker.sh:527-538).
+
+    NOTE(parity): unlike :func:`dedupe_deliverables` (the PR-state diff's
+    case-insensitive dedupe), the manifest builder keys on the stripped text
+    itself, so ``"abc"`` and ``"ABC"`` both survive here. Preserved.
+    """
+    if not isinstance(raw, list):
+        return []
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    for item in raw:
+        text = str(item).strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        cleaned.append(text)
+    return cleaned
+
+
+def collect_commit_oids(
+    deliverables: Sequence[str],
+    before_head: str | None,
+    after_head: str | None,
+) -> list[str]:
+    """Extract commit oids from deliverables + the head advance (worker.sh:541-554).
+
+    Hex tokens (7-40 chars) are pulled from each lowercased deliverable in
+    order, deduped; a head advance appends the new head if not already seen.
+    """
+    commit_oids: list[str] = []
+    for deliverable in deliverables:
+        for match in COMMIT_OID_RE.findall(deliverable.lower()):
+            if match not in commit_oids:
+                commit_oids.append(match)
+    if (
+        before_head
+        and after_head
+        and before_head != after_head
+        and after_head not in commit_oids
+    ):
+        commit_oids.append(after_head)
+    return commit_oids
+
+
+def apply_worker_result_to_payload(
+    payload: dict[str, Any],
+    normalized: Mapping[str, Any],
+    manifest_path: Path | str,
+) -> dict[str, Any]:
+    """Reflect the written manifest back into the record payload.
+
+    Pure core of worker.sh:604-626: worker_result_path, worker_status
+    (``"failed"`` when the manifest carries no status), the schema tag,
+    optional blocked-reason, artifact paths (truthy values only, stringified),
+    git refs, and the intended category. Mutates and returns ``payload``.
+    """
+    payload["worker_result_path"] = str(manifest_path)
+    payload["worker_status"] = str(normalized.get("status") or "failed")
+    payload["worker_manifest_schema"] = (
+        f"bob.worker-result.v{normalized.get('schema_version', 1)}"
+    )
+
+    blocked_reason = normalized.get("blocked_reason")
+    if blocked_reason:
+        payload["worker_blocked_reason"] = str(blocked_reason)
+
+    artifact_paths = normalized.get("artifact_paths")
+    if isinstance(artifact_paths, dict):
+        payload["worker_artifact_paths"] = {
+            key: str(value) for key, value in artifact_paths.items() if value
+        }
+
+    git_refs = normalized.get("git_refs")
+    if isinstance(git_refs, dict):
+        payload["worker_git_refs"] = git_refs
+
+    task = normalized.get("task")
+    if isinstance(task, dict) and task.get("intended_category"):
+        payload["worker_intended_category"] = str(task["intended_category"])
+
+    return payload
+
+
+def write_worker_result_manifest(
+    record_file: Path | str,
+    *,
+    repo: str,
+    number: int | str,
+    session_id: str,
+    exit_code: int,
+    duration_seconds: int,
+    model: str | None,
+    item_types: Sequence[str],
+    build_worker_result: Callable[..., dict[str, Any]],
+    write_worker_result: Callable[[Path, Mapping[str, Any]], Any],
+    load_worker_result: Callable[[Path], Mapping[str, Any] | None],
+) -> None:
+    """Build + write the worker-result manifest and enrich the record.
+
+    Mirrors worker.sh:505-627. The three ``agent_events.worker_results``
+    functions are injected (they live in the caller's workspace packages,
+    not here). Missing or non-dict record → silently returns.
+
+    NOTE(parity): ``int(number)`` raises on an empty/non-numeric PR number
+    (worker.sh:565), killing the manifest step under the bash ``|| true`` —
+    the record then simply never gains ``worker_result_path``. Preserved.
+    """
+    record_path = Path(record_file)
+    if not record_path.is_file():
+        return
+
+    payload = json.loads(record_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        return
+
+    pr_number = int(number)
+    deliverables = normalize_manifest_deliverables(payload.get("deliverables"))
+    before_head = normalize_head(payload.get("pr_head_oid_before"))
+    after_head = normalize_head(payload.get("pr_head_oid_after"))
+    manifest_path = record_path.with_name(f"{record_path.stem}.worker-result.json")
+    manifest = build_worker_result(
+        worker_kind="project-monitoring-worker",
+        worker_id=f"project-monitoring-{session_id}",
+        work_item_id=f"{repo}#{pr_number}",
+        session_id=session_id,
+        draft_path=record_path.with_name(
+            f"{record_path.stem}.worker-result.draft.json"
+        ),
+        exit_code=int(exit_code),
+        duration_seconds=int(duration_seconds),
+        started_at=None,
+        ended_at=None,
+        model=model if model else None,
+        intended_category="pm-react",
+        repo=repo,
+        issue_number=pr_number,
+        title=None,
+        attempt=None,
+        deliverables=deliverables,
+        start_commit=before_head,
+        end_commit=after_head,
+        branch=None,
+        output_file=None,
+        trajectory_path=str(payload.get("trajectory_path") or "") or None,
+        worktree_dir=None,
+    )
+    manifest["git_refs"]["commit_oids"] = collect_commit_oids(
+        deliverables, before_head, after_head
+    )
+    manifest["task"]["item_types"] = list(item_types)
+    manifest["task"]["run_type"] = str(payload.get("run_type") or "monitoring")
+    manifest["task"]["recorded_outcome"] = str(payload.get("outcome") or "")
+    manifest["artifact_paths"]["record_path"] = str(record_path)
+    manifest["artifact_paths"].pop("draft_path", None)
+    write_worker_result(manifest_path, manifest)
+    normalized = load_worker_result(manifest_path) or manifest
+
+    apply_worker_result_to_payload(payload, normalized, manifest_path)
+    _write_record(record_path, payload)
+
+
+# --- Delivery check (worker.sh:651-666 extractor; :668-690 decisions) ---
+
+
+def extract_delivery_field(raw_json: str, field: str) -> str:
+    """The delivery-result field extractor (``python3 -c``, worker.sh:651-666).
+
+    Any parse failure → empty payload; booleans render as ``"true"``/
+    ``"false"``, ``None``/missing as ``""``, everything else via ``str``.
+    """
+    try:
+        payload = json.loads(raw_json)
+    except Exception:
+        payload = {}
+    # NOTE(parity): a JSON scalar (e.g. `"handled"` or `5`) parses fine but
+    # dies on .get in the -c snippet; the bash captures the empty stdout of
+    # the failed command, so the observable result is "". Short-circuit
+    # non-dict payloads to {} for the same observable "".
+    if not isinstance(payload, dict):
+        payload = {}
+    value = payload.get(field)
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if value is None:
+        return ""
+    return str(value)
+
+
+def normalize_delivery_outcome(raw: str) -> str:
+    """Whitespace-strip + whitelist the delivery outcome (worker.sh:668-674).
+
+    NOTE(parity): the bash ``tr -d '[:space:]'`` deletes ALL whitespace,
+    including interior (``"no action"`` → ``"noaction"`` → unknown →
+    ``"handled"``). Unknown outcomes normalize to ``"handled"``. The
+    character class is ASCII-only (tr's ``[:space:]``), not Python's
+    unicode-aware ``\\s``.
+    """
+    cleaned = re.sub(r"[ \t\n\r\f\v]+", "", raw)
+    if cleaned in KNOWN_DELIVERY_OUTCOMES:
+        return cleaned
+    return "handled"
+
+
+def compute_latency_outcome(
+    delivery_outcome: str,
+    exit_code: int,
+    *,
+    needs_fallback_reply: str,
+    fallback_reply_posted: str,
+) -> str:
+    """The latency-ledger outcome decision (worker.sh:683-690).
+
+    The two flags arrive as the extractor's rendered strings (``"true"``,
+    ``"false"``, or ``""``) and are compared literally, as the bash does.
+    A failed session whose missing reply could not be backfilled records
+    ``orphan_no_delivery`` (only when the delivery check *asked* for a
+    fallback); any other non-zero-exit case records ``failed``; otherwise
+    the delivery outcome passes through.
+    """
+    if exit_code != 0 and fallback_reply_posted != "true":
+        if delivery_outcome == "orphan_no_delivery" and needs_fallback_reply == "true":
+            return "orphan_no_delivery"
+        return "failed"
+    return delivery_outcome
+
+
+# --- Latency-ledger append (worker.sh:692-718) ---
+
+
+def parse_latency_inputs(
+    item_json: str,
+    latency_context_json: str,
+    ack_result_json: str,
+) -> tuple[Any, Any, Any]:
+    """Decode the three JSON inputs the way the heredoc does (worker.sh:707-716).
+
+    Empty strings select the defaults (``[]`` for the context, ``None`` for
+    the ack result); invalid JSON raises, killing the append under the bash
+    ``|| true``. ``item_json`` has no empty-string arm in the heredoc —
+    ``json.loads("")`` raises. Preserved.
+    """
+    item = json.loads(item_json)
+    latency_context = json.loads(latency_context_json) if latency_context_json else []
+    ack_result = json.loads(ack_result_json) if ack_result_json else None
+    return item, latency_context, ack_result
+
+
+def append_worker_latency_records(
+    *,
+    repo_root: Path | str,
+    item_json: str,
+    latency_context_json: str,
+    ack_result_json: str,
+    handled_at: str,
+    session_id: str,
+    outcome: str,
+    append_latency_records: Callable[..., Any],
+) -> None:
+    """Append this pass to the latency ledger via an injected recorder.
+
+    Mirrors worker.sh:692-718; ``append_latency_records`` is the caller's
+    ``metaproductivity.project_monitoring_latency.append_latency_records``.
+    """
+    item, latency_context, ack_result = parse_latency_inputs(
+        item_json, latency_context_json, ack_result_json
+    )
+    append_latency_records(
+        repo_root=Path(repo_root),
+        item=item,
+        latency_context=latency_context,
+        handled_at=handled_at,
+        session_id=session_id,
+        outcome=outcome,
+        ack_result=ack_result,
+    )
+
+
+# --- Auto wait-and-merge gate log (worker.sh:743-766) ---
+
+
+def build_wait_merge_gate_entry(
+    gate_json: str,
+    *,
+    timestamp: str,
+    repo: str,
+    pr_number: int | str,
+    item_types: Sequence[str],
+    session_id: str,
+    session_start: str,
+    gate_exit_code: int,
+) -> dict[str, Any]:
+    """Build one gates.jsonl entry from the gate script's JSON verdict.
+
+    Mirrors worker.sh:748-761: an empty ``gate_json`` → ``{}``; a non-dict
+    payload → ``{}``; invalid JSON raises (killed by the bash ``|| true`` —
+    no log line). The fixed bookkeeping fields overwrite any same-named
+    fields the gate emitted.
+    """
+    payload = json.loads(gate_json) if gate_json else {}
+    if not isinstance(payload, dict):
+        payload = {}
+    payload.update(
+        {
+            "timestamp": timestamp,
+            "repo": repo,
+            "pr_number": int(pr_number),
+            "item_types": list(item_types),
+            "session_id": session_id,
+            "session_start": session_start,
+            "gate_exit_code": int(gate_exit_code),
+        }
+    )
+    return payload
+
+
+def append_wait_merge_gate_log(
+    log_path: Path | str,
+    entry: Mapping[str, Any],
+) -> None:
+    """Append a gate entry as a sorted-keys JSONL line (worker.sh:762-765)."""
+    path = Path(log_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry, sort_keys=True) + "\n")
+
+
+# --- Arc auto-close PR-state reader (worker.sh:808-815) ---
+
+
+def read_record_pr_state_after(record_path: Path | str) -> str:
+    """Read ``pr_state_after`` (uppercased) from a record file, ``""`` on any error.
+
+    Mirrors the ``python3 -c`` snippet at worker.sh:808-815, whose bare
+    ``except Exception: pass`` yields empty stdout for a missing file, bad
+    JSON, or a non-dict payload.
+    """
+    try:
+        with open(record_path, encoding="utf-8") as handle:
+            data = json.load(handle)
+        return str(data.get("pr_state_after", "")).upper()
+    except Exception:
+        return ""

--- a/packages/gptme-runloops/src/gptme_runloops/worker_records.py
+++ b/packages/gptme-runloops/src/gptme_runloops/worker_records.py
@@ -622,9 +622,20 @@ def write_worker_result_manifest(
     functions are injected (they live in the caller's workspace packages,
     not here). Missing or non-dict record → silently returns.
 
+    ``build_worker_result`` must return a manifest that already contains the
+    ``git_refs``, ``task``, and ``artifact_paths`` submaps (the real
+    ``agent_events.build_worker_result`` always does).
+
     NOTE(parity): ``int(number)`` raises on an empty/non-numeric PR number
     (worker.sh:565), killing the manifest step under the bash ``|| true`` —
     the record then simply never gains ``worker_result_path``. Preserved.
+
+    NOTE(parity): the submap enrichment below hard-indexes ``git_refs``/
+    ``task``/``artifact_paths`` exactly like worker.sh:595-600 — a builder
+    that omits them raises before the manifest is written, and the record
+    never gains ``worker_result_path``, same as the heredoc dying under its
+    ``|| true``. Softening this (setdefault) would silently accept manifests
+    the bash rejects; a behavior change for the switchover to consider.
     """
     record_path = Path(record_file)
     if not record_path.is_file():

--- a/packages/gptme-runloops/tests/goldens/worker_records/delivery_field.json
+++ b/packages/gptme-runloops/tests/goldens/worker_records/delivery_field.json
@@ -1,0 +1,54 @@
+{
+  "_generated_from": "ErikBjare/bob scripts/github/project-monitoring-worker.sh @ 98e7da0eb18543c53ca7f7ee207eb679010ccffb",
+  "_note": "<WS> is the workspace-root placeholder; see test docstring.",
+  "cases": [
+    {
+      "expected": "orphan_no_delivery",
+      "field": "outcome",
+      "name": "outcome_str",
+      "raw_json": "{\"outcome\": \"orphan_no_delivery\", \"needs_fallback_reply\": true, \"fallback_reply_posted\": false, \"detail\": null, \"count\": 3}"
+    },
+    {
+      "expected": "true",
+      "field": "needs_fallback_reply",
+      "name": "bool_true",
+      "raw_json": "{\"outcome\": \"orphan_no_delivery\", \"needs_fallback_reply\": true, \"fallback_reply_posted\": false, \"detail\": null, \"count\": 3}"
+    },
+    {
+      "expected": "false",
+      "field": "fallback_reply_posted",
+      "name": "bool_false",
+      "raw_json": "{\"outcome\": \"orphan_no_delivery\", \"needs_fallback_reply\": true, \"fallback_reply_posted\": false, \"detail\": null, \"count\": 3}"
+    },
+    {
+      "expected": "",
+      "field": "detail",
+      "name": "null_value",
+      "raw_json": "{\"outcome\": \"orphan_no_delivery\", \"needs_fallback_reply\": true, \"fallback_reply_posted\": false, \"detail\": null, \"count\": 3}"
+    },
+    {
+      "expected": "3",
+      "field": "count",
+      "name": "int_value",
+      "raw_json": "{\"outcome\": \"orphan_no_delivery\", \"needs_fallback_reply\": true, \"fallback_reply_posted\": false, \"detail\": null, \"count\": 3}"
+    },
+    {
+      "expected": "",
+      "field": "nope",
+      "name": "missing_field",
+      "raw_json": "{\"outcome\": \"orphan_no_delivery\", \"needs_fallback_reply\": true, \"fallback_reply_posted\": false, \"detail\": null, \"count\": 3}"
+    },
+    {
+      "expected": "",
+      "field": "outcome",
+      "name": "invalid_json",
+      "raw_json": "{nope"
+    },
+    {
+      "expected": "",
+      "field": "outcome",
+      "name": "scalar_json",
+      "raw_json": "\"handled\""
+    }
+  ]
+}

--- a/packages/gptme-runloops/tests/goldens/worker_records/fallback_record.json
+++ b/packages/gptme-runloops/tests/goldens/worker_records/fallback_record.json
@@ -1,0 +1,87 @@
+{
+  "_generated_from": "ErikBjare/bob scripts/github/project-monitoring-worker.sh @ 98e7da0eb18543c53ca7f7ee207eb679010ccffb",
+  "_note": "<WS> is the workspace-root placeholder; see test docstring.",
+  "cases": [
+    {
+      "expected_fallback_outcome": "failed",
+      "expected_record": {
+        "category": "pm-react",
+        "duration_seconds": 44,
+        "exit_code": 1,
+        "harness": "claude-code",
+        "model": "unknown",
+        "outcome": "failed",
+        "run_type": "monitoring",
+        "session_id": "sess-f1",
+        "source": "stub-session-record"
+      },
+      "name": "failed_exit_empty_model",
+      "vars": {
+        "BACKEND": "claude-code",
+        "ITEM_TIMEOUT": "0",
+        "WORKSPACE": "<WS>",
+        "item_duration": "44",
+        "item_exit_code": "1",
+        "item_model": "",
+        "item_record_file": "<WS>/records/fb-failed_exit_empty_model.json",
+        "item_session_id": "sess-f1",
+        "item_trajectory_path": ""
+      }
+    },
+    {
+      "expected_fallback_outcome": "unknown",
+      "expected_record": {
+        "category": "pm-react",
+        "duration_seconds": 600,
+        "exit_code": 124,
+        "harness": "gptme",
+        "model": "anthropic/claude-sonnet-4.5",
+        "outcome": "unknown",
+        "run_type": "monitoring",
+        "session_id": "sess-f2",
+        "source": "stub-session-record",
+        "timeout_seconds": 600,
+        "trajectory_path": "<WS>/traj/fallback-traj.jsonl"
+      },
+      "name": "timeout_exit_with_trajectory",
+      "vars": {
+        "BACKEND": "gptme",
+        "ITEM_TIMEOUT": "600",
+        "WORKSPACE": "<WS>",
+        "item_duration": "600",
+        "item_exit_code": "124",
+        "item_model": "anthropic/claude-sonnet-4.5",
+        "item_record_file": "<WS>/records/fb-timeout_exit_with_trajectory.json",
+        "item_session_id": "sess-f2",
+        "item_trajectory_path": "<WS>/traj/fallback-traj.jsonl"
+      }
+    },
+    {
+      "expected_fallback_outcome": "unknown",
+      "expected_record": {
+        "category": "pm-react",
+        "duration_seconds": 10,
+        "exit_code": 0,
+        "harness": "copilot-cli",
+        "model": "gpt-5",
+        "outcome": "unknown",
+        "run_type": "monitoring",
+        "session_id": "sess-f3",
+        "source": "stub-session-record",
+        "timeout_seconds": 300
+      },
+      "name": "clean_exit",
+      "vars": {
+        "BACKEND": "copilot-cli",
+        "ITEM_TIMEOUT": "300",
+        "WORKSPACE": "<WS>",
+        "item_duration": "10",
+        "item_exit_code": "0",
+        "item_model": "gpt-5",
+        "item_record_file": "<WS>/records/fb-clean_exit.json",
+        "item_session_id": "sess-f3",
+        "item_trajectory_path": ""
+      }
+    }
+  ]
+}

--- a/packages/gptme-runloops/tests/goldens/worker_records/item_types.json
+++ b/packages/gptme-runloops/tests/goldens/worker_records/item_types.json
@@ -1,0 +1,40 @@
+{
+  "_generated_from": "ErikBjare/bob scripts/github/project-monitoring-worker.sh @ 98e7da0eb18543c53ca7f7ee207eb679010ccffb",
+  "_note": "<WS> is the workspace-root placeholder; see test docstring.",
+  "cases": [
+    {
+      "expected_json": [
+        "pr_update",
+        "merge_ready"
+      ],
+      "name": "case_0",
+      "text": "pr_update merge_ready"
+    },
+    {
+      "expected_json": [
+        "pr_update",
+        "ci_failure",
+        "issue_mention"
+      ],
+      "name": "case_1",
+      "text": "pr_update\nci_failure  issue_mention"
+    },
+    {
+      "expected_json": [],
+      "name": "case_2",
+      "text": ""
+    },
+    {
+      "expected_json": [],
+      "name": "case_3",
+      "text": "   "
+    },
+    {
+      "expected_json": [
+        "single"
+      ],
+      "name": "case_4",
+      "text": "single"
+    }
+  ]
+}

--- a/packages/gptme-runloops/tests/goldens/worker_records/latency_append.json
+++ b/packages/gptme-runloops/tests/goldens/worker_records/latency_append.json
@@ -1,0 +1,77 @@
+{
+  "_generated_from": "ErikBjare/bob scripts/github/project-monitoring-worker.sh @ 98e7da0eb18543c53ca7f7ee207eb679010ccffb",
+  "_note": "<WS> is the workspace-root placeholder; see test docstring.",
+  "cases": [
+    {
+      "expected_call": {
+        "ack_result": {
+          "acked": true
+        },
+        "handled_at": "2026-07-10T12:00:00+00:00",
+        "item": {
+          "number": 42,
+          "repo": "gptme/gptme",
+          "types": [
+            "pr_update"
+          ]
+        },
+        "latency_context": [
+          {
+            "at": "2026-07-10T10:00:00+00:00",
+            "event": "comment"
+          }
+        ],
+        "outcome": "handled",
+        "repo_root": "<WS>",
+        "session_id": "sess-l1"
+      },
+      "name": "full_inputs",
+      "vars": {
+        "WORKSPACE": "<WS>",
+        "_latency_outcome": "handled",
+        "_w_started_iso": "2026-07-10T12:00:00+00:00",
+        "item_ack_result_json": "{\"acked\": true}",
+        "item_json": "{\"repo\": \"gptme/gptme\", \"number\": 42, \"types\": [\"pr_update\"]}",
+        "item_latency_context_json": "[{\"event\": \"comment\", \"at\": \"2026-07-10T10:00:00+00:00\"}]",
+        "item_session_id": "sess-l1"
+      }
+    },
+    {
+      "expected_call": {
+        "ack_result": null,
+        "handled_at": "2026-07-10T13:00:00+00:00",
+        "item": {
+          "number": 7,
+          "repo": "gptme/gptme"
+        },
+        "latency_context": [],
+        "outcome": "orphan_no_delivery",
+        "repo_root": "<WS>",
+        "session_id": "sess-l2"
+      },
+      "name": "empty_context_and_ack",
+      "vars": {
+        "WORKSPACE": "<WS>",
+        "_latency_outcome": "orphan_no_delivery",
+        "_w_started_iso": "2026-07-10T13:00:00+00:00",
+        "item_ack_result_json": "",
+        "item_json": "{\"repo\": \"gptme/gptme\", \"number\": 7}",
+        "item_latency_context_json": "",
+        "item_session_id": "sess-l2"
+      }
+    },
+    {
+      "expected_call": null,
+      "name": "empty_item_json_dies",
+      "vars": {
+        "WORKSPACE": "<WS>",
+        "_latency_outcome": "failed",
+        "_w_started_iso": "2026-07-10T14:00:00+00:00",
+        "item_ack_result_json": "",
+        "item_json": "",
+        "item_latency_context_json": "",
+        "item_session_id": "sess-l3"
+      }
+    }
+  ]
+}

--- a/packages/gptme-runloops/tests/goldens/worker_records/post_session_record.json
+++ b/packages/gptme-runloops/tests/goldens/worker_records/post_session_record.json
@@ -1,0 +1,95 @@
+{
+  "_generated_from": "ErikBjare/bob scripts/github/project-monitoring-worker.sh @ 98e7da0eb18543c53ca7f7ee207eb679010ccffb",
+  "_note": "<WS> is the workspace-root placeholder; see test docstring.",
+  "cases": [
+    {
+      "expected_record": {
+        "category": "pm-react",
+        "duration_seconds": 321,
+        "exit_code": 0,
+        "grade": "stub-grade",
+        "harness": "claude-code",
+        "model": "claude-opus-4",
+        "outcome": "stub-outcome",
+        "run_type": "monitoring",
+        "session_id": "sess-aaa",
+        "sessions_dir": "<WS>/records",
+        "timeout_seconds": 1800,
+        "trajectory_path": "<WS>/traj/cc-session.jsonl",
+        "trigger": "timer"
+      },
+      "heredoc_exit": 0,
+      "name": "full_with_trajectory_and_timeout",
+      "vars": {
+        "BACKEND": "claude-code",
+        "ITEM_TIMEOUT": "1800",
+        "WORKSPACE": "<WS>",
+        "item_duration": "321",
+        "item_exit_code": "0",
+        "item_model": "claude-opus-4",
+        "item_record_file": "<WS>/records/ps-full_with_trajectory_and_timeout.json",
+        "item_session_id": "sess-aaa",
+        "item_trajectory_path": "<WS>/traj/cc-session.jsonl"
+      }
+    },
+    {
+      "expected_record": {
+        "category": "pm-react",
+        "duration_seconds": 5,
+        "exit_code": 1,
+        "grade": "stub-grade",
+        "harness": "gptme",
+        "model": null,
+        "outcome": "stub-outcome",
+        "run_type": "monitoring",
+        "session_id": "sess-bbb",
+        "sessions_dir": "<WS>/records",
+        "trajectory_path": null,
+        "trigger": "timer"
+      },
+      "heredoc_exit": 0,
+      "name": "empty_model_no_timeout_no_trajectory",
+      "vars": {
+        "BACKEND": "gptme",
+        "ITEM_TIMEOUT": "0",
+        "WORKSPACE": "<WS>",
+        "item_duration": "5",
+        "item_exit_code": "1",
+        "item_model": "",
+        "item_record_file": "<WS>/records/ps-empty_model_no_timeout_no_trajectory.json",
+        "item_session_id": "sess-bbb",
+        "item_trajectory_path": ""
+      }
+    },
+    {
+      "expected_record": {
+        "category": "pm-react",
+        "duration_seconds": 900,
+        "exit_code": 124,
+        "grade": "stub-grade",
+        "harness": "codex",
+        "model": "gpt-5.2-codex",
+        "outcome": "stub-outcome",
+        "run_type": "monitoring",
+        "session_id": "sess-ccc",
+        "sessions_dir": "<WS>/records",
+        "timeout_seconds": 900,
+        "trajectory_path": null,
+        "trigger": "timer"
+      },
+      "heredoc_exit": 0,
+      "name": "missing_trajectory_file",
+      "vars": {
+        "BACKEND": "codex",
+        "ITEM_TIMEOUT": "900",
+        "WORKSPACE": "<WS>",
+        "item_duration": "900",
+        "item_exit_code": "124",
+        "item_model": "gpt-5.2-codex",
+        "item_record_file": "<WS>/records/ps-missing_trajectory_file.json",
+        "item_session_id": "sess-ccc",
+        "item_trajectory_path": "<WS>/traj/does-not-exist.jsonl"
+      }
+    }
+  ]
+}

--- a/packages/gptme-runloops/tests/goldens/worker_records/pr_state_after.json
+++ b/packages/gptme-runloops/tests/goldens/worker_records/pr_state_after.json
@@ -1,0 +1,31 @@
+{
+  "_generated_from": "ErikBjare/bob scripts/github/project-monitoring-worker.sh @ 98e7da0eb18543c53ca7f7ee207eb679010ccffb",
+  "_note": "<WS> is the workspace-root placeholder; see test docstring.",
+  "cases": [
+    {
+      "content": "{\"pr_state_after\": \"merged\"}",
+      "expected": "MERGED",
+      "name": "merged_lowercase"
+    },
+    {
+      "content": "{\"outcome\": \"unknown\"}",
+      "expected": "",
+      "name": "missing_key"
+    },
+    {
+      "content": "[1]",
+      "expected": "",
+      "name": "non_dict"
+    },
+    {
+      "content": "{nope",
+      "expected": "",
+      "name": "invalid_json"
+    },
+    {
+      "content": null,
+      "expected": "",
+      "name": "missing_file"
+    }
+  ]
+}

--- a/packages/gptme-runloops/tests/goldens/worker_records/pr_state_diff.json
+++ b/packages/gptme-runloops/tests/goldens/worker_records/pr_state_diff.json
@@ -1,0 +1,143 @@
+{
+  "_generated_from": "ErikBjare/bob scripts/github/project-monitoring-worker.sh @ 98e7da0eb18543c53ca7f7ee207eb679010ccffb",
+  "_note": "<WS> is the workspace-root placeholder; see test docstring.",
+  "cases": [
+    {
+      "expected_record": {
+        "deliverables": [
+          "deadbeefcafe",
+          "note",
+          "bbb222"
+        ],
+        "outcome": "unknown",
+        "pr_head_oid_after": "bbb222",
+        "pr_head_oid_before": "aaa111",
+        "pr_merge_commit_after": "ccc333",
+        "pr_state_after": "MERGED",
+        "pr_state_before": "OPEN"
+      },
+      "gh_fail": false,
+      "gh_output": "{\"state\": \"MERGED\", \"headRefOid\": \"BBB222\", \"mergeCommit\": {\"oid\": \"CCC333\"}}",
+      "name": "head_advance_merged_no_upgrade_pkg",
+      "record_before": {
+        "deliverables": [
+          "deadbeefcafe",
+          "DEADBEEFCAFE",
+          "  note  ",
+          ""
+        ],
+        "outcome": "unknown"
+      },
+      "upgrade_hook": false,
+      "vars": {
+        "WORKSPACE": "<WS>",
+        "item_number": "1234",
+        "item_pr_before_json": "{\"state\": \"open\", \"headRefOid\": \"AAA111\", \"mergeCommit\": null}",
+        "item_record_file": "<WS>/records/prdiff-head_advance_merged_no_upgrade_pkg.json",
+        "item_repo": "gptme/gptme-contrib"
+      }
+    },
+    {
+      "expected_record": {
+        "deliverables": [
+          "def2"
+        ],
+        "outcome": "productive",
+        "outcome_upgrade_seen": true,
+        "pr_head_oid_after": "def2",
+        "pr_head_oid_before": "abc1",
+        "pr_merge_commit_after": "raw-string-oid",
+        "pr_state_after": "MERGED",
+        "pr_state_before": "OPEN"
+      },
+      "gh_fail": false,
+      "gh_output": "{\"state\": \"MERGED\", \"headRefOid\": \"def2\", \"mergeCommit\": \"raw-string-oid\"}",
+      "name": "upgrade_hook_present",
+      "record_before": {
+        "deliverables": [],
+        "outcome": "unknown"
+      },
+      "upgrade_hook": true,
+      "vars": {
+        "WORKSPACE": "<WS>",
+        "item_number": "42",
+        "item_pr_before_json": "{\"state\": \"OPEN\", \"headRefOid\": \"abc1\", \"mergeCommit\": null}",
+        "item_record_file": "<WS>/records/prdiff-upgrade_hook_present.json",
+        "item_repo": "gptme/gptme"
+      }
+    },
+    {
+      "expected_record": {
+        "deliverables": [
+          "One",
+          "Two"
+        ],
+        "outcome": "productive"
+      },
+      "gh_fail": true,
+      "gh_output": null,
+      "name": "empty_before_gh_fails",
+      "record_before": {
+        "deliverables": [
+          "One",
+          "one",
+          "Two"
+        ],
+        "outcome": "productive"
+      },
+      "upgrade_hook": false,
+      "vars": {
+        "WORKSPACE": "<WS>",
+        "item_number": "7",
+        "item_pr_before_json": "",
+        "item_record_file": "<WS>/records/prdiff-empty_before_gh_fails.json",
+        "item_repo": "gptme/gptme"
+      }
+    },
+    {
+      "expected_record": [
+        1,
+        2
+      ],
+      "gh_fail": false,
+      "gh_output": "{}",
+      "name": "non_dict_record_untouched",
+      "record_before": "[1, 2]",
+      "upgrade_hook": false,
+      "vars": {
+        "WORKSPACE": "<WS>",
+        "item_number": "8",
+        "item_pr_before_json": "",
+        "item_record_file": "<WS>/records/prdiff-non_dict_record_untouched.json",
+        "item_repo": "gptme/gptme"
+      }
+    },
+    {
+      "expected_record": {
+        "deliverables": [
+          "bbb"
+        ],
+        "outcome": "unknown",
+        "pr_head_oid_after": "bbb",
+        "pr_head_oid_before": "aaa",
+        "pr_state_after": "OPEN",
+        "pr_state_before": "OPEN"
+      },
+      "gh_fail": false,
+      "gh_output": "{\"state\": \"OPEN\", \"headRefOid\": \"bbb\", \"mergeCommit\": null}",
+      "name": "non_list_deliverables",
+      "record_before": {
+        "deliverables": "not-a-list",
+        "outcome": "unknown"
+      },
+      "upgrade_hook": false,
+      "vars": {
+        "WORKSPACE": "<WS>",
+        "item_number": "9",
+        "item_pr_before_json": "{\"state\": \"OPEN\", \"headRefOid\": \"aaa\", \"mergeCommit\": null}",
+        "item_record_file": "<WS>/records/prdiff-non_list_deliverables.json",
+        "item_repo": "gptme/gptme"
+      }
+    }
+  ]
+}

--- a/packages/gptme-runloops/tests/goldens/worker_records/rate_limit.json
+++ b/packages/gptme-runloops/tests/goldens/worker_records/rate_limit.json
@@ -1,0 +1,61 @@
+{
+  "_generated_from": "ErikBjare/bob scripts/github/project-monitoring-worker.sh @ 98e7da0eb18543c53ca7f7ee207eb679010ccffb",
+  "_note": "<WS> is the workspace-root placeholder; see test docstring.",
+  "cases": [
+    {
+      "expected_info": "seven_day\t1760000000",
+      "log_lines": [
+        "{\"type\":\"other\"}",
+        "{\"type\":\"rate_limit_event\",\"rate_limit_info\":{\"status\":\"rejected\",\"rateLimitType\":\"seven_day\",\"resetsAt\":1760000000}}"
+      ],
+      "name": "rejected_with_reset"
+    },
+    {
+      "expected_info": "\t",
+      "log_lines": [
+        "{\"type\":\"rate_limit_event\",\"rate_limit_info\":{\"status\":\"rejected\"}}"
+      ],
+      "name": "rejected_missing_keys"
+    },
+    {
+      "expected_info": "",
+      "log_lines": [
+        "{\"type\":\"rate_limit_event\",\"rate_limit_info\":{\"status\":\"allowed\",\"rateLimitType\":\"five_hour\"}}"
+      ],
+      "name": "non_rejected_only"
+    },
+    {
+      "expected_info": "five_hour\t123",
+      "log_lines": [
+        "",
+        "not json at all {",
+        "{\"type\":\"assistant\",\"message\":\"hi\"}",
+        "{\"type\":\"rate_limit_event\",\"rate_limit_info\":{\"status\":\"rejected\",\"rateLimitType\":\"five_hour\",\"resetsAt\":123}}"
+      ],
+      "name": "rejection_after_noise"
+    },
+    {
+      "expected_info": "",
+      "log_lines": [
+        "{\"type\":\"rate_limit_event\",\"rate_limit_info\":\"oops\"}",
+        "{\"type\":\"rate_limit_event\",\"rate_limit_info\":{\"status\":\"rejected\",\"rateLimitType\":\"five_hour\",\"resetsAt\":123}}"
+      ],
+      "name": "non_dict_info_aborts"
+    },
+    {
+      "expected_info": "",
+      "log_lines": [
+        "{\"type\":\"assistant\"}"
+      ],
+      "name": "no_event"
+    },
+    {
+      "expected_info": "first\t1",
+      "log_lines": [
+        "{\"type\":\"rate_limit_event\",\"rate_limit_info\":{\"status\":\"rejected\",\"rateLimitType\":\"first\",\"resetsAt\":1}}",
+        "{\"type\":\"rate_limit_event\",\"rate_limit_info\":{\"status\":\"rejected\",\"rateLimitType\":\"second\",\"resetsAt\":2}}"
+      ],
+      "name": "first_rejection_wins"
+    }
+  ]
+}

--- a/packages/gptme-runloops/tests/goldens/worker_records/wait_merge_gate.json
+++ b/packages/gptme-runloops/tests/goldens/worker_records/wait_merge_gate.json
@@ -1,0 +1,110 @@
+{
+  "_generated_from": "ErikBjare/bob scripts/github/project-monitoring-worker.sh @ 98e7da0eb18543c53ca7f7ee207eb679010ccffb",
+  "_note": "<WS> is the workspace-root placeholder; see test docstring.",
+  "cases": [
+    {
+      "expected_entry_sans_timestamp": {
+        "decision": "eligible",
+        "gate_exit_code": 0,
+        "item_types": [
+          "pr_update",
+          "merge_ready"
+        ],
+        "pr_number": 1234,
+        "reason": "all green",
+        "repo": "gptme/gptme-contrib",
+        "session_id": "sess-g1",
+        "session_start": "2026-07-10T12:00:00+00:00"
+      },
+      "gate_exit_code": 0,
+      "gate_json": "{\"decision\": \"eligible\", \"reason\": \"all green\"}",
+      "name": "gate_pass_json",
+      "timestamp_present": true,
+      "vars": {
+        "WORKSPACE": "<WS>",
+        "_w_started_iso": "2026-07-10T12:00:00+00:00",
+        "_wait_merge_gate_json": "{\"decision\": \"eligible\", \"reason\": \"all green\"}",
+        "_wait_merge_gate_log": "<WS>/logs/gate-gate_pass_json.jsonl",
+        "_wait_merge_gate_status": "0",
+        "item_number": "1234",
+        "item_repo": "gptme/gptme-contrib",
+        "item_session_id": "sess-g1",
+        "item_types": "pr_update merge_ready"
+      }
+    },
+    {
+      "expected_entry_sans_timestamp": {
+        "gate_exit_code": 2,
+        "item_types": [
+          "pr_update",
+          "merge_ready"
+        ],
+        "pr_number": 1234,
+        "repo": "gptme/gptme-contrib",
+        "session_id": "sess-g1",
+        "session_start": "2026-07-10T12:00:00+00:00"
+      },
+      "gate_exit_code": 2,
+      "gate_json": "",
+      "name": "empty_gate_json",
+      "timestamp_present": true,
+      "vars": {
+        "WORKSPACE": "<WS>",
+        "_w_started_iso": "2026-07-10T12:00:00+00:00",
+        "_wait_merge_gate_json": "",
+        "_wait_merge_gate_log": "<WS>/logs/gate-empty_gate_json.jsonl",
+        "_wait_merge_gate_status": "2",
+        "item_number": "1234",
+        "item_repo": "gptme/gptme-contrib",
+        "item_session_id": "sess-g1",
+        "item_types": "pr_update merge_ready"
+      }
+    },
+    {
+      "expected_entry_sans_timestamp": {
+        "gate_exit_code": 1,
+        "item_types": [
+          "pr_update",
+          "merge_ready"
+        ],
+        "pr_number": 1234,
+        "repo": "gptme/gptme-contrib",
+        "session_id": "sess-g1",
+        "session_start": "2026-07-10T12:00:00+00:00"
+      },
+      "gate_exit_code": 1,
+      "gate_json": "[1, 2]",
+      "name": "non_dict_gate_json",
+      "timestamp_present": true,
+      "vars": {
+        "WORKSPACE": "<WS>",
+        "_w_started_iso": "2026-07-10T12:00:00+00:00",
+        "_wait_merge_gate_json": "[1, 2]",
+        "_wait_merge_gate_log": "<WS>/logs/gate-non_dict_gate_json.jsonl",
+        "_wait_merge_gate_status": "1",
+        "item_number": "1234",
+        "item_repo": "gptme/gptme-contrib",
+        "item_session_id": "sess-g1",
+        "item_types": "pr_update merge_ready"
+      }
+    },
+    {
+      "expected_entry_sans_timestamp": null,
+      "gate_exit_code": 0,
+      "gate_json": "{nope",
+      "name": "invalid_gate_json_dies",
+      "timestamp_present": false,
+      "vars": {
+        "WORKSPACE": "<WS>",
+        "_w_started_iso": "2026-07-10T12:00:00+00:00",
+        "_wait_merge_gate_json": "{nope",
+        "_wait_merge_gate_log": "<WS>/logs/gate-invalid_gate_json_dies.jsonl",
+        "_wait_merge_gate_status": "0",
+        "item_number": "1234",
+        "item_repo": "gptme/gptme-contrib",
+        "item_session_id": "sess-g1",
+        "item_types": "pr_update merge_ready"
+      }
+    }
+  ]
+}

--- a/packages/gptme-runloops/tests/goldens/worker_records/worker_result.json
+++ b/packages/gptme-runloops/tests/goldens/worker_records/worker_result.json
@@ -1,0 +1,248 @@
+{
+  "_generated_from": "ErikBjare/bob scripts/github/project-monitoring-worker.sh @ 98e7da0eb18543c53ca7f7ee207eb679010ccffb",
+  "_note": "<WS> is the workspace-root placeholder; see test docstring.",
+  "cases": [
+    {
+      "expected_manifest": {
+        "artifact_paths": {
+          "record_path": "<WS>/records/wr-completed_with_oids_and_head_advance.json",
+          "trajectory_path": "<WS>/traj/wr-traj.jsonl"
+        },
+        "blocked_reason": null,
+        "deliverables": [
+          "Pushed deadbeefcafe and DEADBEEF",
+          "PR gptme/gptme#42"
+        ],
+        "duration_seconds": 100,
+        "exit_code": 0,
+        "git_refs": {
+          "commit_oids": [
+            "deadbeefcafe",
+            "deadbeef",
+            "def7654321"
+          ],
+          "end_commit": "def7654321",
+          "start_commit": "abc1234567"
+        },
+        "model": "claude-opus-4",
+        "schema_version": 3,
+        "session_id": "sess-w1",
+        "status": "completed",
+        "task": {
+          "intended_category": "pm-react",
+          "issue_number": 1234,
+          "item_types": [
+            "pr_update",
+            "merge_ready"
+          ],
+          "recorded_outcome": "productive",
+          "repo": "gptme/gptme-contrib",
+          "run_type": "monitoring"
+        },
+        "work_item_id": "gptme/gptme-contrib#1234",
+        "worker": {
+          "id": "project-monitoring-sess-w1",
+          "kind": "project-monitoring-worker"
+        }
+      },
+      "expected_record": {
+        "deliverables": [
+          "Pushed deadbeefcafe and DEADBEEF",
+          "PR gptme/gptme#42",
+          "Pushed deadbeefcafe and DEADBEEF"
+        ],
+        "outcome": "productive",
+        "pr_head_oid_after": "def7654321",
+        "pr_head_oid_before": "ABC1234567",
+        "run_type": "monitoring",
+        "trajectory_path": "<WS>/traj/wr-traj.jsonl",
+        "worker_artifact_paths": {
+          "record_path": "<WS>/records/wr-completed_with_oids_and_head_advance.json",
+          "trajectory_path": "<WS>/traj/wr-traj.jsonl"
+        },
+        "worker_git_refs": {
+          "commit_oids": [
+            "deadbeefcafe",
+            "deadbeef",
+            "def7654321"
+          ],
+          "end_commit": "def7654321",
+          "start_commit": "abc1234567"
+        },
+        "worker_intended_category": "pm-react",
+        "worker_manifest_schema": "bob.worker-result.v3",
+        "worker_result_path": "<WS>/records/wr-completed_with_oids_and_head_advance.worker-result.json",
+        "worker_status": "completed"
+      },
+      "name": "completed_with_oids_and_head_advance",
+      "record_before": {
+        "deliverables": [
+          "Pushed deadbeefcafe and DEADBEEF",
+          "PR gptme/gptme#42",
+          "Pushed deadbeefcafe and DEADBEEF"
+        ],
+        "outcome": "productive",
+        "pr_head_oid_after": "def7654321",
+        "pr_head_oid_before": "ABC1234567",
+        "run_type": "monitoring",
+        "trajectory_path": "<WS>/traj/wr-traj.jsonl"
+      },
+      "vars": {
+        "WORKSPACE": "<WS>",
+        "item_duration": "100",
+        "item_exit_code": "0",
+        "item_model": "claude-opus-4",
+        "item_number": "1234",
+        "item_record_file": "<WS>/records/wr-completed_with_oids_and_head_advance.json",
+        "item_repo": "gptme/gptme-contrib",
+        "item_session_id": "sess-w1",
+        "item_types": "pr_update merge_ready"
+      }
+    },
+    {
+      "expected_manifest": {
+        "artifact_paths": {
+          "record_path": "<WS>/records/wr-blocked_75_non_list_deliverables.json",
+          "trajectory_path": null
+        },
+        "blocked_reason": "stub-blocked",
+        "deliverables": [],
+        "duration_seconds": 3,
+        "exit_code": 75,
+        "git_refs": {
+          "commit_oids": [],
+          "end_commit": null,
+          "start_commit": null
+        },
+        "model": null,
+        "schema_version": 3,
+        "session_id": "sess-w2",
+        "status": "failed",
+        "task": {
+          "intended_category": "pm-react",
+          "issue_number": 999,
+          "item_types": [
+            "issue_mention"
+          ],
+          "recorded_outcome": "",
+          "repo": "ErikBjare/bob",
+          "run_type": "monitoring"
+        },
+        "work_item_id": "ErikBjare/bob#999",
+        "worker": {
+          "id": "project-monitoring-sess-w2",
+          "kind": "project-monitoring-worker"
+        }
+      },
+      "expected_record": {
+        "deliverables": {
+          "nope": 1
+        },
+        "outcome": "",
+        "worker_artifact_paths": {
+          "record_path": "<WS>/records/wr-blocked_75_non_list_deliverables.json"
+        },
+        "worker_blocked_reason": "stub-blocked",
+        "worker_git_refs": {
+          "commit_oids": [],
+          "end_commit": null,
+          "start_commit": null
+        },
+        "worker_intended_category": "pm-react",
+        "worker_manifest_schema": "bob.worker-result.v3",
+        "worker_result_path": "<WS>/records/wr-blocked_75_non_list_deliverables.worker-result.json",
+        "worker_status": "failed"
+      },
+      "name": "blocked_75_non_list_deliverables",
+      "record_before": {
+        "deliverables": {
+          "nope": 1
+        },
+        "outcome": ""
+      },
+      "vars": {
+        "WORKSPACE": "<WS>",
+        "item_duration": "3",
+        "item_exit_code": "75",
+        "item_model": "",
+        "item_number": "999",
+        "item_record_file": "<WS>/records/wr-blocked_75_non_list_deliverables.json",
+        "item_repo": "ErikBjare/bob",
+        "item_session_id": "sess-w2",
+        "item_types": "issue_mention"
+      }
+    },
+    {
+      "expected_manifest": {
+        "artifact_paths": {
+          "record_path": "<WS>/records/wr-status_missing_falls_back_failed.json",
+          "trajectory_path": null
+        },
+        "blocked_reason": null,
+        "deliverables": [
+          "no oids here"
+        ],
+        "duration_seconds": 9,
+        "exit_code": 99,
+        "git_refs": {
+          "commit_oids": [],
+          "end_commit": null,
+          "start_commit": null
+        },
+        "model": "gpt-5",
+        "schema_version": 3,
+        "session_id": "sess-w3",
+        "status": null,
+        "task": {
+          "intended_category": "pm-react",
+          "issue_number": 5,
+          "item_types": [
+            "ci_failure"
+          ],
+          "recorded_outcome": "",
+          "repo": "gptme/gptme",
+          "run_type": "monitoring"
+        },
+        "work_item_id": "gptme/gptme#5",
+        "worker": {
+          "id": "project-monitoring-sess-w3",
+          "kind": "project-monitoring-worker"
+        }
+      },
+      "expected_record": {
+        "deliverables": [
+          "no oids here"
+        ],
+        "worker_artifact_paths": {
+          "record_path": "<WS>/records/wr-status_missing_falls_back_failed.json"
+        },
+        "worker_git_refs": {
+          "commit_oids": [],
+          "end_commit": null,
+          "start_commit": null
+        },
+        "worker_intended_category": "pm-react",
+        "worker_manifest_schema": "bob.worker-result.v3",
+        "worker_result_path": "<WS>/records/wr-status_missing_falls_back_failed.worker-result.json",
+        "worker_status": "failed"
+      },
+      "name": "status_missing_falls_back_failed",
+      "record_before": {
+        "deliverables": [
+          "no oids here"
+        ]
+      },
+      "vars": {
+        "WORKSPACE": "<WS>",
+        "item_duration": "9",
+        "item_exit_code": "99",
+        "item_model": "gpt-5",
+        "item_number": "5",
+        "item_record_file": "<WS>/records/wr-status_missing_falls_back_failed.json",
+        "item_repo": "gptme/gptme",
+        "item_session_id": "sess-w3",
+        "item_types": "ci_failure"
+      }
+    }
+  ]
+}

--- a/packages/gptme-runloops/tests/test_worker_records.py
+++ b/packages/gptme-runloops/tests/test_worker_records.py
@@ -1,0 +1,697 @@
+"""Golden tests for the PM worker post-session bookkeeping port.
+
+The fixtures under ``tests/goldens/worker_records/`` are the *captured
+behavior of the actual heredoc blocks* in ErikBjare/bob
+``scripts/github/project-monitoring-worker.sh`` @
+98e7da0eb18543c53ca7f7ee207eb679010ccffb, run standalone (sed-extracted
+verbatim, ``${var@Q}`` expansion performed by bash) against deterministic
+stub packages standing in for ``gptme_sessions`` / ``metaproductivity`` /
+``agent_events`` and a PATH-stubbed ``gh``. The stub callables defined in
+this module mirror those stub packages exactly — the fixtures enforce the
+mirroring: any drift between them and the generator's stubs fails these
+tests. This is what lets the later brain-side shim PR prove "same records
+out".
+
+Fixture conventions:
+
+- ``<WS>`` is the workspace-root placeholder; tests substitute their own
+  ``tmp_path`` for it on both inputs and expected outputs.
+- ``expected_* = null`` (where applicable) means the heredoc *died* on that
+  input (killed by the bash ``|| true``) — the module function must raise.
+
+Regeneration: run the generator against a brain checkout (it sed-extracts
+the heredoc bodies by line number, so update the line ranges if worker.sh
+moved). The generator script is kept with the brain-side migration notes;
+its stub sources are the authoritative copy of the stubs below.
+
+Where the locked-in behavior is a quirk rather than intent, the module
+marks it ``# NOTE(parity):`` — these tests pin parity, they do not bless
+the quirk.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+from gptme_runloops.worker_records import (
+    append_wait_merge_gate_log,
+    append_worker_latency_records,
+    apply_pr_state_diff,
+    apply_worker_result_to_payload,
+    build_wait_merge_gate_entry,
+    collect_commit_oids,
+    compute_latency_outcome,
+    dedupe_deliverables,
+    extract_delivery_field,
+    fallback_outcome,
+    fetch_pr_snapshot,
+    finalize_post_session_record,
+    normalize_delivery_outcome,
+    normalize_manifest_deliverables,
+    normalize_pr_snapshot,
+    parse_latency_inputs,
+    parse_pr_snapshot,
+    parse_rate_limit_rejection,
+    read_record_pr_state_after,
+    resolve_trajectory,
+    split_item_types,
+    update_record_pr_state,
+    write_fallback_session_record,
+    write_post_session_record,
+    write_worker_result_manifest,
+)
+
+GOLDEN_DIR = Path(__file__).parent / "goldens" / "worker_records"
+
+# Trajectory files the golden generator created under its workspace; tests
+# recreate the same set so existence checks resolve identically.
+TRAJ_FILES = ("cc-session.jsonl", "fallback-traj.jsonl", "wr-traj.jsonl")
+
+
+def load_cases(name: str) -> list[dict[str, Any]]:
+    payload = json.loads((GOLDEN_DIR / f"{name}.json").read_text())
+    return payload["cases"]
+
+
+def case_ids(name: str) -> list[str]:
+    return [c["name"] for c in load_cases(name)]
+
+
+def subst(obj: Any, ws: Path) -> Any:
+    """Recursively substitute the <WS> placeholder with a real workspace root."""
+    if isinstance(obj, str):
+        return obj.replace("<WS>", str(ws))
+    if isinstance(obj, list):
+        return [subst(v, ws) for v in obj]
+    if isinstance(obj, dict):
+        return {k: subst(v, ws) for k, v in obj.items()}
+    return obj
+
+
+@pytest.fixture
+def ws(tmp_path: Path) -> Path:
+    for sub in ("records", "traj", "logs"):
+        (tmp_path / sub).mkdir()
+    for name in TRAJ_FILES:
+        (tmp_path / "traj" / name).write_text("x\n")
+    return tmp_path
+
+
+# --- Stub collaborators (mirror the golden generator's stub packages) ---
+
+
+class StubStore:
+    def __init__(self, sessions_dir: Path) -> None:
+        self.sessions_dir = sessions_dir
+
+
+class _StubRecord:
+    def __init__(self, data: dict[str, Any]) -> None:
+        self._data = data
+
+    def to_dict(self) -> dict[str, Any]:
+        return dict(self._data)
+
+
+class _StubResult:
+    def __init__(self, record: _StubRecord, grade: str) -> None:
+        self.record = record
+        self.grade = grade
+
+
+def stub_post_session(
+    *,
+    store: StubStore,
+    harness: str,
+    model: str | None,
+    run_type: str,
+    trigger: str,
+    category: str,
+    exit_code: int,
+    duration_seconds: int,
+    trajectory_path: Path | None,
+    session_id: str,
+) -> _StubResult:
+    data = {
+        "harness": harness,
+        "model": model,
+        "run_type": run_type,
+        "trigger": trigger,
+        "category": category,
+        "exit_code": exit_code,
+        "duration_seconds": duration_seconds,
+        "trajectory_path": str(trajectory_path) if trajectory_path else None,
+        "session_id": session_id,
+        "outcome": "stub-outcome",
+        "sessions_dir": str(store.sessions_dir),
+    }
+    return _StubResult(_StubRecord(data), "stub-grade")
+
+
+def stub_make_record(
+    *,
+    harness: str,
+    model: str,
+    run_type: str,
+    category: str,
+    outcome: str,
+    duration_seconds: int,
+) -> dict[str, Any]:
+    return {
+        "harness": harness,
+        "model": model,
+        "run_type": run_type,
+        "category": category,
+        "outcome": outcome,
+        "duration_seconds": duration_seconds,
+        "source": "stub-session-record",
+    }
+
+
+def stub_upgrade_outcome(payload: dict[str, Any]) -> None:
+    payload["outcome_upgrade_seen"] = True
+    if (
+        payload.get("pr_state_after") == "MERGED"
+        and payload.get("outcome") == "unknown"
+    ):
+        payload["outcome"] = "productive"
+
+
+def stub_build_worker_result(**kwargs: Any) -> dict[str, Any]:
+    exit_code = kwargs.get("exit_code")
+    status: str | None = "completed" if exit_code == 0 else "failed"
+    if exit_code == 99:
+        status = None
+    blocked_reason = "stub-blocked" if exit_code == 75 else None
+    return {
+        "schema_version": 3,
+        "status": status,
+        "blocked_reason": blocked_reason,
+        "worker": {"kind": kwargs.get("worker_kind"), "id": kwargs.get("worker_id")},
+        "work_item_id": kwargs.get("work_item_id"),
+        "session_id": kwargs.get("session_id"),
+        "model": kwargs.get("model"),
+        "exit_code": exit_code,
+        "duration_seconds": kwargs.get("duration_seconds"),
+        "git_refs": {
+            "start_commit": kwargs.get("start_commit"),
+            "end_commit": kwargs.get("end_commit"),
+            "commit_oids": [],
+        },
+        "task": {
+            "intended_category": kwargs.get("intended_category"),
+            "repo": kwargs.get("repo"),
+            "issue_number": kwargs.get("issue_number"),
+        },
+        "artifact_paths": {
+            "draft_path": str(kwargs.get("draft_path")),
+            "trajectory_path": kwargs.get("trajectory_path"),
+        },
+        "deliverables": list(kwargs.get("deliverables") or []),
+    }
+
+
+def stub_write_worker_result(path: Path, manifest: Any) -> None:
+    Path(path).write_text(json.dumps(manifest, sort_keys=True), encoding="utf-8")
+
+
+def stub_load_worker_result(path: Path) -> dict[str, Any] | None:
+    try:
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+# --- Golden: CC rate-limit parser (worker.sh:110-127) ---
+
+
+@pytest.mark.parametrize("case", load_cases("rate_limit"), ids=case_ids("rate_limit"))
+def test_rate_limit_golden(case: dict[str, Any]) -> None:
+    # Mirror the bash contract: heredoc stdout on success, "" when the
+    # parser dies (`|| _cc_rl_info=""`).
+    try:
+        rejection = parse_rate_limit_rejection(case["log_lines"])
+        info = rejection.render() if rejection else ""
+    except Exception:
+        info = ""
+    assert info == case["expected_info"]
+
+
+def test_rate_limit_accepts_file_style_lines() -> None:
+    # The heredoc iterates open(path) — lines carry trailing newlines.
+    lines = [
+        '{"type":"rate_limit_event","rate_limit_info":'
+        '{"status":"rejected","rateLimitType":"five_hour","resetsAt":9}}\n'
+    ]
+    rejection = parse_rate_limit_rejection(lines)
+    assert rejection is not None
+    assert rejection.render() == "five_hour\t9"
+
+
+# --- Golden: post_session record write (worker.sh:283-323) ---
+
+
+@pytest.mark.parametrize(
+    "case", load_cases("post_session_record"), ids=case_ids("post_session_record")
+)
+def test_post_session_record_golden(case: dict[str, Any], ws: Path) -> None:
+    v = subst(case["vars"], ws)
+    record_file = Path(v["item_record_file"])
+    write_post_session_record(
+        record_file,
+        harness=v["BACKEND"],
+        model=v["item_model"],
+        session_id=v["item_session_id"],
+        exit_code=int(v["item_exit_code"]),
+        duration_seconds=int(v["item_duration"]),
+        item_timeout=int(v["ITEM_TIMEOUT"]),
+        trajectory_path=v["item_trajectory_path"],
+        post_session=stub_post_session,
+        make_store=StubStore,
+    )
+    assert json.loads(record_file.read_text()) == subst(case["expected_record"], ws)
+
+
+# --- Golden: legacy fallback record write (worker.sh:325-373) ---
+
+
+@pytest.mark.parametrize(
+    "case", load_cases("fallback_record"), ids=case_ids("fallback_record")
+)
+def test_fallback_record_golden(case: dict[str, Any], ws: Path) -> None:
+    v = subst(case["vars"], ws)
+    exit_code = int(v["item_exit_code"])
+    outcome = fallback_outcome(exit_code)
+    assert outcome == case["expected_fallback_outcome"]
+    record_file = Path(v["item_record_file"])
+    write_fallback_session_record(
+        record_file,
+        harness=v["BACKEND"],
+        model=v["item_model"],
+        outcome=outcome,
+        session_id=v["item_session_id"],
+        exit_code=exit_code,
+        duration_seconds=int(v["item_duration"]),
+        item_timeout=int(v["ITEM_TIMEOUT"]),
+        trajectory_path=v["item_trajectory_path"],
+        make_record=stub_make_record,
+    )
+    assert json.loads(record_file.read_text()) == subst(case["expected_record"], ws)
+
+
+# --- Golden: PR-state diff (worker.sh:377-502) ---
+
+
+@pytest.mark.parametrize(
+    "case", load_cases("pr_state_diff"), ids=case_ids("pr_state_diff")
+)
+def test_pr_state_diff_golden(case: dict[str, Any], ws: Path) -> None:
+    v = subst(case["vars"], ws)
+    record_file = Path(v["item_record_file"])
+    before = case["record_before"]
+    if isinstance(before, str):
+        record_file.write_text(before)
+    else:
+        record_file.write_text(json.dumps(subst(before, ws)))
+
+    gh_fail = case["gh_fail"]
+    gh_output = case["gh_output"] or ""
+
+    def runner(args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args, returncode=1 if gh_fail else 0, stdout=gh_output, stderr=""
+        )
+
+    update_record_pr_state(
+        record_file,
+        repo=v["item_repo"],
+        number=v["item_number"],
+        before_json=v["item_pr_before_json"],
+        cwd=ws,
+        fetch=lambda repo, num: fetch_pr_snapshot(repo, num, cwd=ws, runner=runner),
+        upgrade_outcome=stub_upgrade_outcome if case["upgrade_hook"] else None,
+    )
+    assert json.loads(record_file.read_text()) == subst(case["expected_record"], ws)
+
+
+# --- Golden: worker-result manifest (worker.sh:505-627) ---
+
+
+@pytest.mark.parametrize(
+    "case", load_cases("worker_result"), ids=case_ids("worker_result")
+)
+def test_worker_result_golden(case: dict[str, Any], ws: Path) -> None:
+    v = subst(case["vars"], ws)
+    record_file = Path(v["item_record_file"])
+    record_file.write_text(json.dumps(subst(case["record_before"], ws)))
+    write_worker_result_manifest(
+        record_file,
+        repo=v["item_repo"],
+        number=v["item_number"],
+        session_id=v["item_session_id"],
+        exit_code=int(v["item_exit_code"]),
+        duration_seconds=int(v["item_duration"]),
+        model=v["item_model"],
+        item_types=split_item_types(v["item_types"]),
+        build_worker_result=stub_build_worker_result,
+        write_worker_result=stub_write_worker_result,
+        load_worker_result=stub_load_worker_result,
+    )
+    manifest_file = record_file.with_name(f"{record_file.stem}.worker-result.json")
+    assert json.loads(record_file.read_text()) == subst(case["expected_record"], ws)
+    assert json.loads(manifest_file.read_text()) == subst(case["expected_manifest"], ws)
+
+
+# --- Golden: delivery-field extractor (worker.sh:651-666) ---
+
+
+@pytest.mark.parametrize(
+    "case", load_cases("delivery_field"), ids=case_ids("delivery_field")
+)
+def test_delivery_field_golden(case: dict[str, Any]) -> None:
+    assert extract_delivery_field(case["raw_json"], case["field"]) == case["expected"]
+
+
+# --- Golden: latency append (worker.sh:692-718) ---
+
+
+@pytest.mark.parametrize(
+    "case", load_cases("latency_append"), ids=case_ids("latency_append")
+)
+def test_latency_append_golden(case: dict[str, Any], ws: Path) -> None:
+    v = subst(case["vars"], ws)
+    calls: list[dict[str, Any]] = []
+
+    def capture(**kwargs: Any) -> None:
+        kwargs["repo_root"] = str(kwargs["repo_root"])
+        calls.append(kwargs)
+
+    kwargs = dict(
+        repo_root=v["WORKSPACE"],
+        item_json=v["item_json"],
+        latency_context_json=v["item_latency_context_json"],
+        ack_result_json=v["item_ack_result_json"],
+        handled_at=v["_w_started_iso"],
+        session_id=v["item_session_id"],
+        outcome=v["_latency_outcome"],
+        append_latency_records=capture,
+    )
+    if case["expected_call"] is None:
+        # The heredoc died on this input (bash `|| true` swallows it).
+        with pytest.raises(json.JSONDecodeError):
+            append_worker_latency_records(**kwargs)
+        assert calls == []
+    else:
+        append_worker_latency_records(**kwargs)
+        assert calls == [subst(case["expected_call"], ws)]
+
+
+# --- Golden: wait-and-merge gate log (worker.sh:743-766) ---
+
+
+@pytest.mark.parametrize(
+    "case", load_cases("wait_merge_gate"), ids=case_ids("wait_merge_gate")
+)
+def test_wait_merge_gate_golden(case: dict[str, Any], ws: Path) -> None:
+    v = subst(case["vars"], ws)
+    timestamp = "2026-07-10T15:00:00+00:00"
+    kwargs = dict(
+        timestamp=timestamp,
+        repo=v["item_repo"],
+        pr_number=v["item_number"],
+        item_types=split_item_types(v["item_types"]),
+        session_id=v["item_session_id"],
+        session_start=v["_w_started_iso"],
+        gate_exit_code=case["gate_exit_code"],
+    )
+    log_path = Path(v["_wait_merge_gate_log"])
+    if case["expected_entry_sans_timestamp"] is None:
+        with pytest.raises(json.JSONDecodeError):
+            build_wait_merge_gate_entry(case["gate_json"], **kwargs)
+        return
+    entry = build_wait_merge_gate_entry(case["gate_json"], **kwargs)
+    append_wait_merge_gate_log(log_path, entry)
+    line = json.loads(log_path.read_text().strip())
+    assert line.pop("timestamp") == timestamp
+    assert line == subst(case["expected_entry_sans_timestamp"], ws)
+    # The heredoc writes sorted keys (worker.sh:765).
+    raw = log_path.read_text().strip()
+    assert raw == json.dumps(json.loads(raw), sort_keys=True)
+
+
+# --- Golden: arc pr_state_after reader (worker.sh:808-815) ---
+
+
+@pytest.mark.parametrize(
+    "case", load_cases("pr_state_after"), ids=case_ids("pr_state_after")
+)
+def test_pr_state_after_golden(case: dict[str, Any], ws: Path) -> None:
+    record = ws / "records" / "arc.json"
+    if case["content"] is not None:
+        record.write_text(case["content"])
+    assert read_record_pr_state_after(record) == case["expected"]
+
+
+# --- Golden: item_types splitter (worker.sh:70) ---
+
+
+@pytest.mark.parametrize("case", load_cases("item_types"), ids=case_ids("item_types"))
+def test_item_types_golden(case: dict[str, Any]) -> None:
+    assert split_item_types(case["text"]) == case["expected_json"]
+
+
+# --- Table-driven: pure helpers ---
+
+
+@pytest.mark.parametrize(
+    ("exit_code", "expected"),
+    [(0, "unknown"), (124, "unknown"), (1, "failed"), (75, "failed"), (2, "failed")],
+)
+def test_fallback_outcome(exit_code: int, expected: str) -> None:
+    # NOTE(parity) under test: timeout (124) records "unknown", not "failed".
+    assert fallback_outcome(exit_code) == expected
+
+
+def test_resolve_trajectory(tmp_path: Path) -> None:
+    f = tmp_path / "t.jsonl"
+    f.write_text("x")
+    assert resolve_trajectory(str(f)) == f
+    assert resolve_trajectory(str(tmp_path / "missing")) is None
+    assert resolve_trajectory("") is None
+    assert resolve_trajectory(None) is None
+    # A directory is not a trajectory file.
+    assert resolve_trajectory(str(tmp_path)) is None
+
+
+def test_finalize_post_session_record_zero_timeout_omitted() -> None:
+    out = finalize_post_session_record({"a": 1}, "B", 0)
+    assert out == {"a": 1, "grade": "B"}
+    out = finalize_post_session_record({"a": 1}, None, 60)
+    assert out == {"a": 1, "grade": None, "timeout_seconds": 60}
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        (
+            {"state": "open", "headRefOid": "ABC", "mergeCommit": {"oid": "DeF"}},
+            {"state": "OPEN", "headRefOid": "abc", "mergeCommit": "def"},
+        ),
+        (
+            {"state": None, "headRefOid": None, "mergeCommit": None},
+            {"state": "", "headRefOid": "", "mergeCommit": ""},
+        ),
+        # Non-dict mergeCommit values pass through normalize_oid as-is.
+        (
+            {"state": "MERGED", "headRefOid": " X ", "mergeCommit": "OID"},
+            {"state": "MERGED", "headRefOid": "x", "mergeCommit": "oid"},
+        ),
+        ("not-a-dict", {}),
+        ([1, 2], {}),
+    ],
+)
+def test_normalize_pr_snapshot(payload: Any, expected: dict[str, str]) -> None:
+    assert normalize_pr_snapshot(payload) == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("", {}),
+        ("   ", {}),
+        ("{bad", {}),
+        ('"scalar"', {}),
+        (
+            '{"state":"open","headRefOid":"A","mergeCommit":null}',
+            {"state": "OPEN", "headRefOid": "a", "mergeCommit": ""},
+        ),
+    ],
+)
+def test_parse_pr_snapshot(raw: str, expected: dict[str, str]) -> None:
+    assert parse_pr_snapshot(raw) == expected
+
+
+def test_dedupe_semantics_differ_between_blocks() -> None:
+    # NOTE(parity) under test: the PR-state diff dedupes case-INsensitively
+    # (first spelling wins); the manifest builder case-SENSITIVELY.
+    values = ["abc", "ABC", " abc ", "", None]
+    assert dedupe_deliverables(values) == ["abc"]
+    assert normalize_manifest_deliverables(["abc", "ABC", " abc ", ""]) == [
+        "abc",
+        "ABC",
+    ]
+    assert normalize_manifest_deliverables("not-a-list") == []
+
+
+def test_apply_pr_state_diff_does_not_clear_fields_on_empty_after() -> None:
+    payload: dict[str, Any] = {"deliverables": []}
+    apply_pr_state_diff(
+        payload,
+        {"state": "OPEN", "headRefOid": "aaa", "mergeCommit": ""},
+        {},
+    )
+    assert payload["pr_state_before"] == "OPEN"
+    assert payload["pr_head_oid_before"] == "aaa"
+    assert "pr_state_after" not in payload
+    # No head advance recorded without an after-head.
+    assert payload["deliverables"] == []
+
+
+def test_collect_commit_oids() -> None:
+    oids = collect_commit_oids(
+        ["Pushed deadbeefcafe twice: deadbeefcafe", "short ab12345"],
+        "abc1234",
+        "def5678",
+    )
+    assert oids == ["deadbeefcafe", "ab12345", "def5678"]
+    # Head already present is not duplicated; same head consumes nothing.
+    assert collect_commit_oids(["def5678"], "abc1234", "def5678") == ["def5678"]
+    assert collect_commit_oids([], "same111", "same111") == []
+    assert collect_commit_oids([], None, "def5678") == []
+
+
+def test_apply_worker_result_to_payload_filters_falsy_artifacts() -> None:
+    payload: dict[str, Any] = {}
+    normalized = {
+        "status": None,
+        "schema_version": 2,
+        "blocked_reason": "",
+        "artifact_paths": {"a": "/x", "b": None, "c": ""},
+        "git_refs": {"commit_oids": ["x"]},
+        "task": {"intended_category": ""},
+    }
+    apply_worker_result_to_payload(payload, normalized, "/m.json")
+    assert payload["worker_status"] == "failed"
+    assert payload["worker_manifest_schema"] == "bob.worker-result.v2"
+    assert "worker_blocked_reason" not in payload
+    assert payload["worker_artifact_paths"] == {"a": "/x"}
+    assert payload["worker_git_refs"] == {"commit_oids": ["x"]}
+    assert "worker_intended_category" not in payload
+
+
+def test_write_worker_result_manifest_raises_on_non_numeric_number(
+    ws: Path,
+) -> None:
+    # NOTE(parity) under test: int("") dies in the heredoc (bash || true).
+    record = ws / "records" / "r.json"
+    record.write_text(json.dumps({"deliverables": []}))
+    with pytest.raises(ValueError):
+        write_worker_result_manifest(
+            record,
+            repo="gptme/gptme",
+            number="",
+            session_id="s",
+            exit_code=0,
+            duration_seconds=1,
+            model=None,
+            item_types=[],
+            build_worker_result=stub_build_worker_result,
+            write_worker_result=stub_write_worker_result,
+            load_worker_result=stub_load_worker_result,
+        )
+
+
+def test_update_record_pr_state_missing_record_is_noop(ws: Path) -> None:
+    update_record_pr_state(
+        ws / "records" / "missing.json",
+        repo="gptme/gptme",
+        number=1,
+        before_json="",
+        cwd=ws,
+        fetch=lambda repo, num: {},
+    )
+    assert not (ws / "records" / "missing.json").exists()
+
+
+def test_fetch_pr_snapshot_nonzero_exit_is_empty(ws: Path) -> None:
+    def runner(args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        assert args[:3] == ["gh", "pr", "view"]
+        return subprocess.CompletedProcess(args, returncode=1, stdout="{}", stderr="")
+
+    assert fetch_pr_snapshot("gptme/gptme", 1, cwd=ws, runner=runner) == {}
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("handled", "handled"),
+        ("  handled\n", "handled"),
+        ("orphan_no_delivery", "orphan_no_delivery"),
+        ("no_action_needed", "no_action_needed"),
+        ("failed", "failed"),
+        ("", "handled"),
+        ("something_else", "handled"),
+        # NOTE(parity) under test: tr -d '[:space:]' removes interior
+        # whitespace too — "no action" → "noaction" (no match), while a
+        # space INSIDE a known outcome still whitelist-matches.
+        ("no action", "handled"),
+        ("or phan_no_delivery", "orphan_no_delivery"),
+    ],
+)
+def test_normalize_delivery_outcome(raw: str, expected: str) -> None:
+    assert normalize_delivery_outcome(raw) == expected
+
+
+@pytest.mark.parametrize(
+    ("delivery", "exit_code", "needs", "posted", "expected"),
+    [
+        # exit 0 → delivery outcome passes through.
+        ("handled", 0, "false", "false", "handled"),
+        ("orphan_no_delivery", 0, "true", "false", "orphan_no_delivery"),
+        # non-zero exit but fallback reply posted → passes through.
+        ("handled", 1, "false", "true", "handled"),
+        # non-zero exit, orphan + fallback wanted → orphan.
+        ("orphan_no_delivery", 1, "true", "false", "orphan_no_delivery"),
+        # non-zero exit, orphan but no fallback wanted → failed.
+        ("orphan_no_delivery", 1, "false", "false", "failed"),
+        # non-zero exit, anything else → failed.
+        ("handled", 124, "false", "false", "failed"),
+        ("no_action_needed", 2, "true", "", "failed"),
+    ],
+)
+def test_compute_latency_outcome(
+    delivery: str, exit_code: int, needs: str, posted: str, expected: str
+) -> None:
+    assert (
+        compute_latency_outcome(
+            delivery,
+            exit_code,
+            needs_fallback_reply=needs,
+            fallback_reply_posted=posted,
+        )
+        == expected
+    )
+
+
+def test_parse_latency_inputs_defaults() -> None:
+    item, ctx, ack = parse_latency_inputs('{"repo":"r"}', "", "")
+    assert item == {"repo": "r"}
+    assert ctx == []
+    assert ack is None
+    with pytest.raises(json.JSONDecodeError):
+        parse_latency_inputs("", "", "")


### PR DESCRIPTION
## Summary

**Step 3 of 8** of the Phase-2 execution-consolidation migration (design: ErikBjare/bob `knowledge/technical-designs/reactive-dispatch-phase2-3-execution-consolidation.md`; steps 1-2 were #1261 merge-lifecycle decisions and #1262 prompt templates).

Behavior-identical port of the inline `python3` heredoc blocks from ErikBjare/bob `scripts/github/project-monitoring-worker.sh` @ `98e7da0eb18543c53ca7f7ee207eb679010ccffb` into a new `gptme_runloops.worker_records` module. The bash remains the runtime hotpath; this module is the reviewable, golden-tested reference the brain-side shim will diff against.

## Heredoc → function inventory

| Source (worker.sh) | What it does | Ported as |
|---|---|---|
| `110-127` (`<<'PYEOF'`) | Parse CC stream-json log for the first **rejected** `rate_limit_event` → `type\tresetsAt` | `parse_rate_limit_rejection` + `RateLimitRejection.render` |
| `283-323` | Primary session-record write via `gptme_sessions.post_session` (grade + timeout_seconds post-edit) | `write_post_session_record` (+ `resolve_trajectory`, `finalize_post_session_record`); `post_session`/`make_store` injected |
| `325-373` | Legacy fallback record via `metaproductivity.sessions.SessionRecord` when the primary writer fails | `fallback_outcome` + `build_fallback_record_payload` + `write_fallback_session_record`; `make_record` injected |
| `377-502` | PR-state before/after diff (gh snapshot), deliverables dedupe, `upgrade_outcome_from_pr_state` hook | `normalize_oid`/`normalize_pr_snapshot`/`parse_pr_snapshot`/`dedupe_deliverables`/`apply_pr_state_diff` + `fetch_pr_snapshot` (default gh adapter, runner-injectable) + `update_record_pr_state`; `upgrade_outcome` injected |
| `505-627` | Worker-result manifest build + record enrichment via `agent_events.worker_results` | `normalize_head`/`normalize_manifest_deliverables`/`collect_commit_oids`/`apply_worker_result_to_payload` + `write_worker_result_manifest`; the three agent_events fns injected |
| `650-667` (`python3 -c`) | Delivery-check JSON field extractor (bool→true/false, None→"") | `extract_delivery_field` |
| `668-690` (pure bash) | Delivery-outcome whitelist + latency-outcome decision | `normalize_delivery_outcome`, `compute_latency_outcome` |
| `692-718` | Latency-ledger append via `metaproductivity.project_monitoring_latency` | `parse_latency_inputs` + `append_worker_latency_records`; recorder injected |
| `743-766` | Auto wait-and-merge gate JSONL log entry | `build_wait_merge_gate_entry` + `append_wait_merge_gate_log` |
| `70` (`python3 -c`) | `item_types` splitter (heredoc-injection hardening) | `split_item_types` |
| `808-815` (`python3 -c`) | Arc auto-close `pr_state_after` reader | `read_record_pr_state_after` |

(The design said "six inline blocks" — that counts the six `<<PY` heredocs; the `PYEOF` rate-limit parser and the three `python3 -c` snippets are the same class and are ported too.)

## NOTE(parity) quirks preserved

- Empty model → `None` in the primary writer but → `"unknown"` in the fallback writer.
- Fallback outcome: exit 124 (timeout) records `"unknown"`, not `"failed"`.
- Two different deliverables-dedupe semantics: PR-state diff is case-INsensitive (first spelling wins); manifest builder is case-SENSITIVE.
- PR-state fields only set when truthy — an empty observation never clears a previously-set field.
- gh timeout in the snapshot fetch kills the whole diff step (before-fields included), as the heredoc dies under `|| true`.
- `int()` of an empty/non-numeric PR number raises, silently skipping the manifest step (bash `|| true`).
- Rate-limit parser: a non-dict `rate_limit_info` aborts the whole scan (heredoc dies on `.get`), even if a later line holds a valid rejection.
- `tr -d '[:space:]'` deletes interior whitespace before the outcome whitelist (ASCII-only class, not `\s`).
- `COMMIT_OID_RE` keeps its redundant `re.IGNORECASE` (findall already runs on lowercased text).
- Fallback payload re-assigns `duration_seconds` even though the base record already carries it.
- `${var@Q}` string-interpolation is replaced by real parameters — eliminating the injection class the bash worked around at worker.sh:67-70.

## Tests

- **Golden fixtures** (`tests/goldens/worker_records/*.json`, 46 cases across 10 families) were generated by running the **actual heredocs standalone**: sed-extracted verbatim from worker.sh with bash performing the `${var@Q}` expansion, against deterministic stub packages (`gptme_sessions`/`metaproductivity`/`agent_events`) and a PATH-stubbed `gh`. The pytest stubs mirror the generator stubs; the fixtures enforce the mirroring. Workspace paths are normalized to a `<WS>` placeholder.
- Table-driven unit tests for the pure helpers and their quirk branches.
- Full package suite: 546 passed locally; mypy clean.

## Brain-shim plan (separate ErikBjare/bob PR after merge + submodule bump)

`gptme_runloops` is import-reachable from worker.sh's execution context with a plain `python3` + `sys.path.insert` of the submodule src dir (verified: no third-party deps needed for this module; same pattern the heredocs already use for `gptme_sessions`). Each heredoc collapses to a thin invocation passing values via argv/env, with the brain-side packages injected where the heredocs import them today. Behavior-identical, goldens as the diff-proof.