### PR TITLE
fix(runloops): mirror investigate-arm jq fix from bash (parity follow-up to #1262)

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/prompt_templates.py
+++ b/packages/gptme-runloops/src/gptme_runloops/prompt_templates.py
@@ -271,13 +271,13 @@ bash {greptile_helper} trigger {repo} {number}
 
 _NEEDS_FIX_SECTIONS = {
     "title": "Greptile Score Fix Needed (score < 4/5)",
-    # NOTE(parity): the jq object in both investigate arms is malformed —
-    # `body: (.body | split("\n")[0:5] | join(" ")}` never closes the `(`
-    # opened after `body:`, so jq fails at runtime with a syntax error.
-    # The sibling pr_update arm (lib.sh:688) has the closing paren, which
-    # is the drift tell. Preserved byte-for-byte; fixing the jq is a
-    # switchover-time decision. (`\n` inside split() is the literal
-    # two-character sequence the bash `\\n` renders — correct jq, kept.)
+    # NOTE(parity): the jq object in both investigate arms was originally
+    # malformed — `body: (.body | split("\n")[0:5] | join(" ")}` never
+    # closed the `(` opened after `body:` (a runtime jq syntax error the
+    # sibling pr_update arm, lib.sh:688, never had). Fixed in bash by
+    # ErikBjare/bob#1067; this template and the goldens mirror the fixed
+    # form. (`\n` inside split() is the literal two-character sequence the
+    # bash `\\n` renders — correct jq, kept.)
     "read_commands": (
         "# Read the PR and full Greptile review comments\n"
         "gh pr view {number} --repo {repo}\n"
@@ -285,7 +285,7 @@ _NEEDS_FIX_SECTIONS = {
         "\n"
         "# Get Greptile's review comments (the ones that need fixing)\n"
         "gh api repos/{repo}/pulls/{number}/comments \\\n"
-        '  --jq \'.[] | select(.user.login | test("greptile"; "i")) | {id, path, line, body: (.body | split("\\n")[0:5] | join(" ")}\'\n'
+        '  --jq \'.[] | select(.user.login | test("greptile"; "i")) | {id, path, line, body: (.body | split("\\n")[0:5] | join(" "))}\'\n'
         "\n"
         "# Get Greptile's summary review comment (contains score like 3/5 or 4/5)\n"
         "gh api repos/{repo}/issues/{number}/comments \\\n"
@@ -309,13 +309,13 @@ _NEEDS_FIX_SECTIONS = {
 
 _NEEDS_IMPROVEMENT_SECTIONS = {
     "title": "Greptile Score Improvement (score = 4/5)",
-    # NOTE(parity): same malformed jq as greptile_needs_fix (missing `)`),
-    # with [0:3] instead of [0:5]. Preserved.
+    # NOTE(parity): same jq as greptile_needs_fix (see the fix note there;
+    # bash fixed in ErikBjare/bob#1067), with [0:3] instead of [0:5].
     "read_commands": (
         "# Read the PR and Greptile review comments\n"
         "gh pr view {number} --repo {repo}\n"
         "gh api repos/{repo}/pulls/{number}/comments \\\n"
-        '  --jq \'.[] | select(.user.login | test("greptile"; "i")) | {id, path, line, body: (.body | split("\\n")[0:3] | join(" ")}\''
+        '  --jq \'.[] | select(.user.login | test("greptile"; "i")) | {id, path, line, body: (.body | split("\\n")[0:3] | join(" "))}\''
     ),
     "assessment": (
         "This PR scored 4/5 — minor issues from Greptile. Address them if quick; **leave it untouched if trivial** (do NOT re-trigger just because you looked at it).\n"

--- a/packages/gptme-runloops/tests/goldens/prompt_templates/greptile_needs_fix.alice.txt
+++ b/packages/gptme-runloops/tests/goldens/prompt_templates/greptile_needs_fix.alice.txt
@@ -7,7 +7,7 @@ gh pr view 7 --repo ErikBjare/alice --comments
 
 # Get Greptile's review comments (the ones that need fixing)
 gh api repos/ErikBjare/alice/pulls/7/comments \
-  --jq '.[] | select(.user.login | test("greptile"; "i")) | {id, path, line, body: (.body | split("\n")[0:5] | join(" ")}'
+  --jq '.[] | select(.user.login | test("greptile"; "i")) | {id, path, line, body: (.body | split("\n")[0:5] | join(" "))}'
 
 # Get Greptile's summary review comment (contains score like 3/5 or 4/5)
 gh api repos/ErikBjare/alice/issues/7/comments \

--- a/packages/gptme-runloops/tests/goldens/prompt_templates/greptile_needs_fix.bob.txt
+++ b/packages/gptme-runloops/tests/goldens/prompt_templates/greptile_needs_fix.bob.txt
@@ -7,7 +7,7 @@ gh pr view 1234 --repo gptme/gptme-contrib --comments
 
 # Get Greptile's review comments (the ones that need fixing)
 gh api repos/gptme/gptme-contrib/pulls/1234/comments \
-  --jq '.[] | select(.user.login | test("greptile"; "i")) | {id, path, line, body: (.body | split("\n")[0:5] | join(" ")}'
+  --jq '.[] | select(.user.login | test("greptile"; "i")) | {id, path, line, body: (.body | split("\n")[0:5] | join(" "))}'
 
 # Get Greptile's summary review comment (contains score like 3/5 or 4/5)
 gh api repos/gptme/gptme-contrib/issues/1234/comments \

--- a/packages/gptme-runloops/tests/goldens/prompt_templates/greptile_needs_improvement.alice.txt
+++ b/packages/gptme-runloops/tests/goldens/prompt_templates/greptile_needs_improvement.alice.txt
@@ -4,7 +4,7 @@
 # Read the PR and Greptile review comments
 gh pr view 7 --repo ErikBjare/alice
 gh api repos/ErikBjare/alice/pulls/7/comments \
-  --jq '.[] | select(.user.login | test("greptile"; "i")) | {id, path, line, body: (.body | split("\n")[0:3] | join(" ")}'
+  --jq '.[] | select(.user.login | test("greptile"; "i")) | {id, path, line, body: (.body | split("\n")[0:3] | join(" "))}'
 ```
 
 This PR scored 4/5 — minor issues from Greptile. Address them if quick; **leave it untouched if trivial** (do NOT re-trigger just because you looked at it).

--- a/packages/gptme-runloops/tests/goldens/prompt_templates/greptile_needs_improvement.bob.txt
+++ b/packages/gptme-runloops/tests/goldens/prompt_templates/greptile_needs_improvement.bob.txt
@@ -4,7 +4,7 @@
 # Read the PR and Greptile review comments
 gh pr view 1234 --repo gptme/gptme-contrib
 gh api repos/gptme/gptme-contrib/pulls/1234/comments \
-  --jq '.[] | select(.user.login | test("greptile"; "i")) | {id, path, line, body: (.body | split("\n")[0:3] | join(" ")}'
+  --jq '.[] | select(.user.login | test("greptile"; "i")) | {id, path, line, body: (.body | split("\n")[0:3] | join(" "))}'
 ```
 
 This PR scored 4/5 — minor issues from Greptile. Address them if quick; **leave it untouched if trivial** (do NOT re-trigger just because you looked at it).

--- a/packages/gptme-runloops/tests/test_prompt_templates.py
+++ b/packages/gptme-runloops/tests/test_prompt_templates.py
@@ -8,6 +8,11 @@ ca7aa17a2899dbe676fba7074fc5c4dd61d25fe4 (lines 425-470, 474-517, 886-912,
 match them byte-for-byte — this is what lets the later brain-side switchover
 PR prove "same prompts out".
 
+The two investigate goldens were re-captured from
+c7f4ac657549d3254b716f4d8590617dcd853dba (ErikBjare/bob#1067), which fixed
+the unbalanced-paren jq malformation in both ``build_item_investigate``
+greptile arms.
+
 Regenerate the goldens from a checkout of the brain repo with::
 
     source scripts/github/project-monitoring-lib.sh
@@ -164,17 +169,18 @@ def test_number_accepts_str_and_int() -> None:
     [InstructionKind.GREPTILE_NEEDS_FIX, InstructionKind.GREPTILE_NEEDS_IMPROVEMENT],
     ids=lambda k: k.value,
 )
-def test_investigate_jq_malformation_is_preserved(kind: InstructionKind) -> None:
-    # NOTE(parity): the bash investigate arms ship a jq object whose
-    # `body: (...` group is never closed — a runtime jq syntax error the
-    # sibling pr_update arm does not have. The port preserves it; this test
-    # pins the quirk so an accidental "fix" fails loudly (fixing it is a
-    # switchover-time decision).
+def test_investigate_jq_is_well_formed(kind: InstructionKind) -> None:
+    # NOTE(parity): the bash investigate arms originally shipped a jq object
+    # whose `body: (...` group was never closed — a runtime jq syntax error
+    # the sibling pr_update arm did not have. The port preserved the quirk
+    # (pinned here as test_investigate_jq_malformation_is_preserved) until
+    # the bash was fixed in ErikBjare/bob#1067; both sides now render
+    # balanced, parseable jq and this test pins the FIXED form.
     out = render_instruction(kind, CONTEXTS["bob"])
     jq_line = next(
         line for line in out.splitlines() if "split(" in line and "join(" in line
     )
-    assert jq_line.count("(") == jq_line.count(")") + 1
+    assert jq_line.count("(") == jq_line.count(")")
 
 
 def test_step2_qualifier_drift_is_preserved() -> None:


### PR DESCRIPTION
## What

Parity follow-up to #1262: the bash source of the two investigate prompt templates was fixed in ErikBjare/bob#1067 (merged `c7f4ac657549`) — both `build_item_investigate` greptile arms had an unbalanced-paren jq object:

```
body: (.body | split("\n")[0:N] | join(" ")}
```

a guaranteed runtime jq compile error. #1262 deliberately preserved the quirk byte-for-byte and pinned it with `test_investigate_jq_malformation_is_preserved`. With the bash now fixed, this PR keeps parity byte-identical on the fixed form:

- `prompt_templates.py`: close the paren in both investigate arms (`GREPTILE_NEEDS_FIX`, `GREPTILE_NEEDS_IMPROVEMENT`); NOTE(parity) comments updated to record the history.
- Goldens (`greptile_needs_fix.{bob,alice}.txt`, `greptile_needs_improvement.{bob,alice}.txt`): re-captured from the FIXED bash at ErikBjare/bob `c7f4ac657549` using the capture method documented in the test module docstring (source `project-monitoring-lib.sh`, render `build_item_investigate` for both parameter sets, `printf '%s' "$INVESTIGATE"`). Each golden's diff is exactly the one jq line.
- Test flipped/renamed: `test_investigate_jq_malformation_is_preserved` → `test_investigate_jq_is_well_formed`, asserting balanced parens (the FIXED form) so a regression back to the malformation fails loudly.

## Proof (bash side, from ErikBjare/bob#1067)

Old expression: `jq -n '<expr>'` → `jq: 1 compile error` (exit 3). Fixed lib rendered end-to-end: all embedded `--jq` expressions in the investigate prompts parse.

## Tests

`uv run pytest packages/gptme-runloops/tests -q` → 457 passed. Ruff clean.