### PR TITLE
fix(gptme-coordination): store the same expiry the claim HMAC signs

### DIFF
--- a/packages/gptme-coordination/src/gptme_coordination/work.py
+++ b/packages/gptme-coordination/src/gptme_coordination/work.py
@@ -234,19 +234,21 @@ class WorkClaimManager:
         """
         ttl = ttl_minutes or self.default_ttl_minutes
         conn = self.db.conn
-        # Compute the expiry once and reuse it for both the HMAC and the
-        # stored expires_at column. Previously these were two separate clock
-        # reads (this Python computation for the HMAC, and a second
-        # SQLite-evaluated datetime('now', ...) for the stored value); when
-        # the two reads straddled a second boundary, the stored HMAC could
-        # never verify against the stored expires_at. Single-sourcing the
-        # expiry string makes the stored signature correct by construction.
-        expires_str = (datetime.now(UTC) + timedelta(minutes=ttl)).strftime(
-            "%Y-%m-%d %H:%M:%S"
-        )
 
         conn.execute("BEGIN IMMEDIATE")
         try:
+            # Compute the expiry once and reuse it for both the HMAC and the
+            # stored expires_at column. Previously these were two separate clock
+            # reads (this Python computation for the HMAC, and a second
+            # SQLite-evaluated datetime('now', ...) for the stored value); when
+            # the two reads straddled a second boundary, the stored HMAC could
+            # never verify against the stored expires_at. Single-sourcing the
+            # expiry string makes the stored signature correct by construction.
+            # Computing it after BEGIN IMMEDIATE ensures the lock-wait time
+            # does not shorten the effective TTL.
+            expires_str = (datetime.now(UTC) + timedelta(minutes=ttl)).strftime(
+                "%Y-%m-%d %H:%M:%S"
+            )
             row = conn.execute(
                 "SELECT claimer, expires_at, status, epoch, hmac FROM work WHERE task_id = ?",
                 (task_id,),

--- a/packages/gptme-coordination/src/gptme_coordination/work.py
+++ b/packages/gptme-coordination/src/gptme_coordination/work.py
@@ -279,6 +279,11 @@ class WorkClaimManager:
                     conn.execute("ROLLBACK")
                     return None
 
+                # Recompute expiry after the callback so the TTL starts from
+                # when we actually write the claim, not before the check ran.
+                expires_str = (datetime.now(UTC) + timedelta(minutes=ttl)).strftime(
+                    "%Y-%m-%d %H:%M:%S"
+                )
                 new_epoch = int(row["epoch"]) + 1
                 hmac_val = None
                 if secret is not None:

--- a/packages/gptme-coordination/src/gptme_coordination/work.py
+++ b/packages/gptme-coordination/src/gptme_coordination/work.py
@@ -234,6 +234,16 @@ class WorkClaimManager:
         """
         ttl = ttl_minutes or self.default_ttl_minutes
         conn = self.db.conn
+        # Compute the expiry once and reuse it for both the HMAC and the
+        # stored expires_at column. Previously these were two separate clock
+        # reads (this Python computation for the HMAC, and a second
+        # SQLite-evaluated datetime('now', ...) for the stored value); when
+        # the two reads straddled a second boundary, the stored HMAC could
+        # never verify against the stored expires_at. Single-sourcing the
+        # expiry string makes the stored signature correct by construction.
+        expires_str = (datetime.now(UTC) + timedelta(minutes=ttl)).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
 
         conn.execute("BEGIN IMMEDIATE")
         try:
@@ -246,22 +256,19 @@ class WorkClaimManager:
                 # Task doesn't exist — auto-submit and claim it
                 hmac_val = None
                 if secret is not None:
-                    py_expires = (datetime.now(UTC) + timedelta(minutes=ttl)).strftime(
-                        "%Y-%m-%d %H:%M:%S"
-                    )
                     hmac_val = self.compute_hmac(
                         agent_id,
                         task_id,
                         1,
-                        py_expires,
+                        expires_str,
                         secret,
                     )
                 conn.execute(
                     """INSERT INTO work (task_id, claimer, epoch, claimed_at,
                         expires_at, status, metadata, hmac)
                     VALUES (?, ?, 1, datetime('now'),
-                        datetime('now', ? || ' minutes'), 'claimed', ?, ?)""",
-                    (task_id, agent_id, str(ttl), metadata, hmac_val),
+                        ?, 'claimed', ?, ?)""",
+                    (task_id, agent_id, expires_str, metadata, hmac_val),
                 )
             elif row["status"] == "completed":
                 # Allow reclaiming if no check or check passes
@@ -273,14 +280,11 @@ class WorkClaimManager:
                 new_epoch = int(row["epoch"]) + 1
                 hmac_val = None
                 if secret is not None:
-                    py_expires = (datetime.now(UTC) + timedelta(minutes=ttl)).strftime(
-                        "%Y-%m-%d %H:%M:%S"
-                    )
                     hmac_val = self.compute_hmac(
                         agent_id,
                         task_id,
                         new_epoch,
-                        py_expires,
+                        expires_str,
                         secret,
                     )
 
@@ -288,14 +292,14 @@ class WorkClaimManager:
                     """UPDATE work
                     SET claimer = ?, epoch = epoch + 1,
                         claimed_at = datetime('now'),
-                        expires_at = datetime('now', ? || ' minutes'),
+                        expires_at = ?,
                         status = 'claimed',
                         result = NULL,
                         completed_at = NULL,
                         metadata = COALESCE(?, metadata),
                         hmac = ?
                     WHERE task_id = ? AND status = 'completed'""",
-                    (agent_id, str(ttl), metadata, hmac_val, task_id),
+                    (agent_id, expires_str, metadata, hmac_val, task_id),
                 )
                 if conn.execute("SELECT changes()").fetchone()[0] == 0:
                     conn.execute("ROLLBACK")
@@ -315,14 +319,11 @@ class WorkClaimManager:
                 hmac_val = None
 
                 if secret is not None:
-                    py_expires = (datetime.now(UTC) + timedelta(minutes=ttl)).strftime(
-                        "%Y-%m-%d %H:%M:%S"
-                    )
                     hmac_val = self.compute_hmac(
                         agent_id,
                         task_id,
                         new_epoch,
-                        py_expires,
+                        expires_str,
                         secret,
                     )
 
@@ -330,7 +331,7 @@ class WorkClaimManager:
                     """UPDATE work
                     SET claimer = ?, epoch = epoch + 1,
                         claimed_at = datetime('now'),
-                        expires_at = datetime('now', ? || ' minutes'),
+                        expires_at = ?,
                         status = 'claimed',
                         result = NULL,
                         completed_at = NULL,
@@ -340,7 +341,7 @@ class WorkClaimManager:
                         AND (status IN ('available', 'abandoned')
                              OR (status = 'claimed'
                                  AND expires_at < datetime('now')))""",
-                    (agent_id, str(ttl), metadata, hmac_val, task_id),
+                    (agent_id, expires_str, metadata, hmac_val, task_id),
                 )
                 if conn.execute("SELECT changes()").fetchone()[0] == 0:
                     conn.execute("ROLLBACK")
@@ -350,9 +351,6 @@ class WorkClaimManager:
                 # Recompute HMAC when we have a secret (expiry changes, so old HMAC is stale)
                 hmac_val = None
                 if secret is not None:
-                    py_expires = (datetime.now(UTC) + timedelta(minutes=ttl)).strftime(
-                        "%Y-%m-%d %H:%M:%S"
-                    )
                     new_epoch = (
                         row["epoch"]
                         if "epoch" in row.keys()
@@ -366,16 +364,16 @@ class WorkClaimManager:
                         agent_id,
                         task_id,
                         new_epoch,
-                        py_expires,
+                        expires_str,
                         secret,
                     )
                 conn.execute(
                     """UPDATE work
-                    SET expires_at = datetime('now', ? || ' minutes'),
+                    SET expires_at = ?,
                         metadata = COALESCE(?, metadata),
                         hmac = ?
                     WHERE task_id = ? AND claimer = ?""",
-                    (str(ttl), metadata, hmac_val, task_id, agent_id),
+                    (expires_str, metadata, hmac_val, task_id, agent_id),
                 )
             else:
                 # Held by another agent and not expired

--- a/packages/gptme-coordination/tests/test_work.py
+++ b/packages/gptme-coordination/tests/test_work.py
@@ -254,6 +254,122 @@ class TestHMACStaleOnReclaim:
         assert abandoned.hmac is None, "abandon() must clear stale HMAC"
 
 
+class TestExpiryHmacCoherence:
+    """The stored HMAC must always verify against the stored expires_at.
+
+    Regression test for a bug where the HMAC was computed over a
+    Python-clock expiry string, while a *separate* SQLite-evaluated
+    ``datetime('now', ...)`` call computed the stored ``expires_at``. When
+    the two clock reads straddled a second boundary, the stored HMAC could
+    never verify against the stored row. This held only probabilistically
+    before the fix (two clock reads) and holds by construction after it
+    (single clock read reused for both).
+    """
+
+    def test_fresh_claim_hmac_matches_stored_expiry(
+        self, work: WorkClaimManager
+    ) -> None:
+        from gptme_coordination.auth import verify_hmac
+
+        secret = b"s"
+        claim = work.claim("agent-x", "task-fresh", ttl_minutes=60, secret=secret)
+        assert claim is not None
+
+        row = work.db.conn.execute(
+            "SELECT expires_at, epoch, hmac FROM work WHERE task_id = ?",
+            ("task-fresh",),
+        ).fetchone()
+        assert verify_hmac(
+            secret,
+            row["hmac"],
+            "agent-x",
+            "task-fresh",
+            row["epoch"],
+            row["expires_at"],
+        )
+
+    def test_reclaim_of_expired_claim_hmac_matches_stored_expiry(
+        self, work: WorkClaimManager
+    ) -> None:
+        from gptme_coordination.auth import verify_hmac
+
+        secret = b"s"
+        work.claim("agent-a", "task-expired", ttl_minutes=60, secret=secret)
+        # Manually backdate expires_at to force the CAS "expired claim" path.
+        work.db.conn.execute(
+            "UPDATE work SET expires_at = datetime('now', '-1 seconds') WHERE task_id = ?",
+            ("task-expired",),
+        )
+
+        claim = work.claim("agent-b", "task-expired", ttl_minutes=60, secret=secret)
+        assert claim is not None
+        assert claim.claimer == "agent-b"
+
+        row = work.db.conn.execute(
+            "SELECT expires_at, epoch, hmac FROM work WHERE task_id = ?",
+            ("task-expired",),
+        ).fetchone()
+        assert verify_hmac(
+            secret,
+            row["hmac"],
+            "agent-b",
+            "task-expired",
+            row["epoch"],
+            row["expires_at"],
+        )
+
+    def test_reclaim_of_completed_task_hmac_matches_stored_expiry(
+        self, work: WorkClaimManager
+    ) -> None:
+        from gptme_coordination.auth import verify_hmac
+
+        secret = b"s"
+        work.claim("agent-a", "task-completed", ttl_minutes=60, secret=secret)
+        work.complete("agent-a", "task-completed")
+
+        claim = work.claim("agent-b", "task-completed", ttl_minutes=60, secret=secret)
+        assert claim is not None
+        assert claim.claimer == "agent-b"
+
+        row = work.db.conn.execute(
+            "SELECT expires_at, epoch, hmac FROM work WHERE task_id = ?",
+            ("task-completed",),
+        ).fetchone()
+        assert verify_hmac(
+            secret,
+            row["hmac"],
+            "agent-b",
+            "task-completed",
+            row["epoch"],
+            row["expires_at"],
+        )
+
+    def test_extend_own_claim_hmac_matches_stored_expiry(
+        self, work: WorkClaimManager
+    ) -> None:
+        from gptme_coordination.auth import verify_hmac
+
+        secret = b"s"
+        work.claim("agent-a", "task-extend", ttl_minutes=60, secret=secret)
+
+        claim = work.claim("agent-a", "task-extend", ttl_minutes=60, secret=secret)
+        assert claim is not None
+        assert claim.claimer == "agent-a"
+
+        row = work.db.conn.execute(
+            "SELECT expires_at, epoch, hmac FROM work WHERE task_id = ?",
+            ("task-extend",),
+        ).fetchone()
+        assert verify_hmac(
+            secret,
+            row["hmac"],
+            "agent-a",
+            "task-extend",
+            row["epoch"],
+            row["expires_at"],
+        )
+
+
 class TestAuthCompatibility:
     def test_verify_hmac_matches_work_claim_manager(
         self, work: WorkClaimManager


### PR DESCRIPTION
## Bug

`WorkClaimManager.claim()` computed the stored HMAC over a **Python-clock**
expiry string, but the SQL stored `expires_at` from a **separate**
SQLite-evaluated `datetime('now', ? || ' minutes')` call. Two independent
clock reads for what's logically the same value: when they straddled a
second boundary, the row was born with an HMAC that could never verify
against its own stored `expires_at`.

This affected all four `claim()` branches: fresh INSERT, completed-task
reclaim UPDATE, available/abandoned/expired CAS UPDATE, and own-claim
extend UPDATE.

## Mechanism (empirically confirmed)

A boundary-targeted repro (claim issued ~200us before a second boundary)
reproduces the failure: 5/300 claims issued just before a second boundary
store an HMAC that can never verify against the stored `expires_at`; 0/400
at random timing. The window is microseconds wide, which is exactly why
this doesn't show up under normal/random-timing testing — it's a real but
narrow race between two clock reads of the same logical timestamp.

## Fix

Compute the expiry string once per `claim()` call (`expires_str`, near the
top of the method) and reuse it for both:
- the HMAC computation in all four branches (replacing the per-branch
  `py_expires` blocks), and
- the stored `expires_at` value (binding `expires_str` directly instead of
  evaluating `datetime('now', ? || ' minutes')` in SQL).

`WHERE`-clause expiry comparisons (`expires_at < datetime('now')`) and
`claimed_at = datetime('now')` are untouched — those correctly stay on the
SQLite clock since they're comparisons against "now at read time," not
values being signed.

## Regression test

Added `TestExpiryHmacCoherence` in `packages/gptme-coordination/tests/test_work.py`,
asserting `verify_hmac` succeeds against the stored row for all four claim
paths (fresh claim, reclaim of an expired claim, reclaim of a completed
task, extend of an own claim). This property held only probabilistically
before the fix; after the fix it holds by construction.

## Context

Found in a claim-lifecycle audit after the 2026-07-10 reap-on-denial
incident (unrelated bug in a different coordination code path — a mutual-
exclusion regression, already fixed separately). Note: work-claim HMACs
are not yet wired into any downstream verification path in this repo, so
this bug is currently latent (no live claim signature was ever actually
checked and rejected) — but the stored signatures are wrong regardless,
and this closes the gap before any downstream verifier is added.

## Test plan
- [x] `uv run pytest packages/gptme-coordination/tests/ -q` — 89 passed
- [x] `ruff check` / `ruff format --check` clean on changed files
- [x] Independently reproduced the boundary-timing failure mode outside the
      test suite to confirm the mechanism before writing this description