### PR TITLE
fix(github): set GH_FORCE_TTY=0 so repo-status jq parses gh --json

### DIFF
--- a/scripts/github/repo-status.sh
+++ b/scripts/github/repo-status.sh
@@ -4,6 +4,9 @@
 
 set -euo pipefail
 
+# gh colorizes --json output when it thinks stdout is a TTY, which breaks jq.
+export GH_FORCE_TTY=0
+
 # Get GitHub user (from auth or env var)
 GH_USER="${GH_USER:-$(gh api user -q .login 2>/dev/null || echo "")}"
 


### PR DESCRIPTION
gh 2.x wraps `--json` output in ANSI color codes when stdout is treated as a TTY. `scripts/github/repo-status.sh` pipes that into `jq`, which fails with `parse error: Invalid numeric literal at line 1, column 2`.

Export `GH_FORCE_TTY=0` at the top of the script so all `gh` invocations emit plain JSON.

Regression test added in ErikBjare/bob (`tests/test_github_repo_status_ci.py`, commit 61d70a2ee5).