### PR TITLE
fix(github): unset GH_FORCE_TTY instead of exporting 0 — any value forces TTY (#1266 was inverted)

### DIFF
--- a/scripts/github/repo-status.sh
+++ b/scripts/github/repo-status.sh
@@ -4,8 +4,14 @@
 
 set -euo pipefail
 
-# gh colorizes --json output when it thinks stdout is a TTY, which breaks jq.
-export GH_FORCE_TTY=0
+# gh colorizes --json/--jq output whenever it thinks stdout is a TTY, which
+# breaks downstream jq. GH_FORCE_TTY is NOT a boolean: gh treats ANY set value
+# (including "0") as "force TTY output" (optionally parsed as display width),
+# so exporting GH_FORCE_TTY=0 (#1266) caused the exact corruption it meant to
+# prevent. Unset it, and set NO_COLOR so a real PTY (context pipelines capture
+# through one) cannot re-enable colorized JSON either.
+unset GH_FORCE_TTY
+export NO_COLOR=1
 
 # Get GitHub user (from auth or env var)
 GH_USER="${GH_USER:-$(gh api user -q .login 2>/dev/null || echo "")}"


### PR DESCRIPTION
## Problem

#1266 added `export GH_FORCE_TTY=0` to `scripts/github/repo-status.sh` intending to stop `gh` from colorizing `--json` output for `jq`. This fix is semantically inverted.

`GH_FORCE_TTY` is not a boolean. Per `gh` docs/source, `gh` treats **any set value** (including `"0"`) as "force TTY-like output" — the value is optionally parsed as a display width, but its mere presence in the environment is what flips TTY-mode on. So `GH_FORCE_TTY=0` unconditionally *causes* colorized/ANSI-wrapped JSON output — the exact corruption #1266 was trying to prevent — which then breaks `jq` downstream with `jq: invalid JSON text passed to --argjson`.

## Fix

Unset `GH_FORCE_TTY` entirely instead of exporting `0`, and additionally set `NO_COLOR=1` so that even a real PTY (as can occur in context-capture pipelines that pipe through a pseudo-terminal) can't re-enable colorized JSON either — `NO_COLOR` disables `gh`'s colorization regardless of TTY detection.

## Empirical verification

**Patched (this branch, worktree) — clean JSON, no jq errors:**
```
$ bash scripts/github/repo-status.sh gptme/gptme:TestRepo
=== Repository CI Status ===

✓ TestRepo: Passing
```
(stderr empty)

**Unpatched (current master) — reproduces the #1266 regression:**
```
$ bash scripts/github/repo-status.sh gptme/gptme:TestRepo
=== Repository CI Status ===

jq: invalid JSON text passed to --argjson
Use jq --help for help with command-line options,
or see the jq manpage, or online docs  at https://jqlang.github.io/jq
```

Also spot-checked directly against `gh`:
- `GH_FORCE_TTY=0 gh workflow list --repo gptme/gptme --all --json name,state --jq '...'` → ANSI-wrapped output (fails jq)
- unset `GH_FORCE_TTY` → clean JSON
- `GH_FORCE_TTY=1 NO_COLOR=1 gh ... --json ...` → clean JSON (confirms `NO_COLOR` wins even under forced TTY)

`shellcheck scripts/github/repo-status.sh` is clean before and after (no new warnings).

## Note on test coverage

The companion regression test for this script (`tests/test_github_repo_status_ci.py`) lives in `ErikBjare/bob`, not this repo, and its fake `gh` stub encodes the same inverted `GH_FORCE_TTY=0` semantics #1266 introduced. That test is being fixed separately in that repo to match the corrected semantics — not part of this PR since it's outside gptme-contrib.
