### PR TITLE
fix(gptme-coordination): resolve default DB path

### DIFF
--- a/packages/gptme-coordination/src/gptme_coordination/db.py
+++ b/packages/gptme-coordination/src/gptme_coordination/db.py
@@ -140,7 +140,9 @@ class CoordinationDB:
     to prevent conflicts between parallel agents.
     """
 
-    def __init__(self, db_path: str | Path = DEFAULT_DB_PATH):
+    def __init__(self, db_path: str | Path | None = None):
+        if db_path is None:
+            db_path = resolve_coordination_db_path()
         self.db_path = Path(db_path)
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         self._conn: sqlite3.Connection | None = None

--- a/packages/gptme-coordination/tests/test_db.py
+++ b/packages/gptme-coordination/tests/test_db.py
@@ -144,6 +144,24 @@ class TestResolveCoordinationDbPath:
 class TestCoordinationDB:
     """Tests for CoordinationDB."""
 
+    def test_default_init_uses_resolved_workspace_path(self, monkeypatch):
+        """Default init uses the authoritative workspace path, not cwd."""
+        with tempfile.TemporaryDirectory() as tmp:
+            brain_dir = Path(tmp) / "brain"
+            brain_dir.mkdir()
+            submodule = Path(tmp) / "gptme-contrib"
+            submodule.mkdir()
+            subprocess.run(
+                ["git", "init"], cwd=submodule, capture_output=True, check=True
+            )
+            monkeypatch.chdir(submodule)
+            monkeypatch.setenv("BOB_WORKSPACE", str(brain_dir))
+
+            db = CoordinationDB()
+
+            assert db.db_path == brain_dir / "state/coordination/coord.db"
+            db.close()
+
     def test_init_creates_parent_dir(self):
         """DB init creates parent directories and the DB file."""
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- resolve `CoordinationDB()` through `resolve_coordination_db_path()` when no explicit path is provided
- add a regression test covering `gptme-contrib` cwd with `BOB_WORKSPACE` set

## Reproduction
From a `gptme-contrib` working directory:
```bash
python3 - <<'PY'
from gptme_coordination.db import CoordinationDB

db = CoordinationDB()
print(db.db_path)
PY
```
Before this change, the default constructor pointed at `gptme-contrib/state/coordination/coord.db`.
With `BOB_WORKSPACE=/home/bob/bob`, the authoritative path should be `/home/bob/bob/state/coordination/coord.db`.

## Testing
- `uv run --package gptme-coordination pytest packages/gptme-coordination/tests/test_db.py -q`
