### PR TITLE
feat(gptme-sessions): capture failure_reason on harness fast-fail

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/failure_capture.py
+++ b/packages/gptme-sessions/src/gptme_sessions/failure_capture.py
@@ -36,6 +36,34 @@ def _read_tail(path: Path, *, max_bytes: int = 16_000, max_lines: int = 40) -> s
     return tail[:4000] if len(tail) > 4000 else tail
 
 
+def _record_is_assistant(rec: dict) -> bool:
+    """Return True for flat (gptme) and nested (Claude Code) assistant records."""
+    # Flat format: {"role": "assistant", "content": "..."}
+    if rec.get("role") in _ASSISTANT_ROLES:
+        return True
+    # CC nested format: {"type": "assistant", "message": {"role": "assistant", ...}}
+    if rec.get("type") == "assistant":
+        msg = rec.get("message") or {}
+        if msg.get("role") in _ASSISTANT_ROLES or rec.get("type") == "assistant":
+            return True
+    return False
+
+
+def _record_content_text(rec: dict) -> str:
+    """Extract flattened content string from flat or CC nested record."""
+    # Flat format
+    content = rec.get("content") or rec.get("text") or ""
+    if content:
+        return str(content)
+    # CC nested: message.content is a list of typed blocks
+    msg = rec.get("message") or {}
+    msg_content = msg.get("content") or ""
+    if isinstance(msg_content, list):
+        parts = [block.get("text") or "" for block in msg_content if isinstance(block, dict)]
+        return " ".join(p for p in parts if p)
+    return str(msg_content)
+
+
 def _trajectory_has_assistant(trajectory_path: Path | None) -> bool:
     if trajectory_path is None or not trajectory_path.is_file():
         return False
@@ -49,10 +77,8 @@ def _trajectory_has_assistant(trajectory_path: Path | None) -> bool:
                     rec = json.loads(line)
                 except json.JSONDecodeError:
                     continue
-                if rec.get("role") in _ASSISTANT_ROLES:
-                    content = rec.get("content") or rec.get("text") or ""
-                    if str(content).strip():
-                        return True
+                if _record_is_assistant(rec) and _record_content_text(rec).strip():
+                    return True
     except OSError:
         return False
     return False
@@ -72,7 +98,7 @@ def _extract_trajectory_error_line(trajectory_path: Path | None) -> str | None:
                     rec = json.loads(line)
                 except json.JSONDecodeError:
                     continue
-                content = str(rec.get("content") or rec.get("text") or "")
+                content = _record_content_text(rec)
                 if not content:
                     continue
                 for part in content.splitlines():
@@ -105,7 +131,9 @@ def classify_failure_reason(
             or "403" in error_text
         ):
             return FAILURE_REASON_AUTH
-    no_model_tokens = input_tokens == 0 or (input_tokens is None and not has_assistant_turn)
+    # has_assistant_turn is definitive: if the trajectory has a response, model ran.
+    # input_tokens==0 alone can't override it — token accounting can be missing on CC.
+    no_model_tokens = not has_assistant_turn and (input_tokens == 0 or input_tokens is None)
     if exit_code != 0 and no_model_tokens and duration_seconds < 120:
         return FAILURE_REASON_PRE_RESPONSE
     return FAILURE_REASON_NONZERO

--- a/packages/gptme-sessions/src/gptme_sessions/failure_capture.py
+++ b/packages/gptme-sessions/src/gptme_sessions/failure_capture.py
@@ -1,0 +1,146 @@
+"""Capture harness failure reason and error detail for session records."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+# Coarse taxonomy for operator-pulse / bandit post-mortems.
+FAILURE_REASON_AUTH = "auth"
+FAILURE_REASON_NONZERO = "nonzero_exit_unclassified"
+FAILURE_REASON_PRE_RESPONSE = "pre_response_api_failure"
+FAILURE_REASON_RATE_LIMIT = "rate_limit"
+FAILURE_REASON_TIMEOUT = "timeout"
+
+_ERROR_LINE_RE = re.compile(
+    r"(?i)(error|exception|traceback|failed|rate.?limit|401|403|429|authentication)"
+)
+_ASSISTANT_ROLES = frozenset({"assistant"})
+
+
+def _read_tail(path: Path, *, max_bytes: int = 16_000, max_lines: int = 40) -> str | None:
+    if not path.is_file():
+        return None
+    try:
+        data = path.read_bytes()
+    except OSError:
+        return None
+    if not data:
+        return None
+    text = data[-max_bytes:].decode("utf-8", errors="replace")
+    lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+    if not lines:
+        return None
+    tail = "\n".join(lines[-max_lines:])
+    return tail[:4000] if len(tail) > 4000 else tail
+
+
+def _trajectory_has_assistant(trajectory_path: Path | None) -> bool:
+    if trajectory_path is None or not trajectory_path.is_file():
+        return False
+    try:
+        with trajectory_path.open(encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if rec.get("role") in _ASSISTANT_ROLES:
+                    content = rec.get("content") or rec.get("text") or ""
+                    if str(content).strip():
+                        return True
+    except OSError:
+        return False
+    return False
+
+
+def _extract_trajectory_error_line(trajectory_path: Path | None) -> str | None:
+    if trajectory_path is None or not trajectory_path.is_file():
+        return None
+    last_match: str | None = None
+    try:
+        with trajectory_path.open(encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                content = str(rec.get("content") or rec.get("text") or "")
+                if not content:
+                    continue
+                for part in content.splitlines():
+                    part = part.strip()
+                    if part and _ERROR_LINE_RE.search(part):
+                        last_match = part[:500]
+    except OSError:
+        return None
+    return last_match
+
+
+def classify_failure_reason(
+    *,
+    exit_code: int,
+    duration_seconds: int,
+    input_tokens: int | None,
+    has_assistant_turn: bool,
+    error_text: str | None,
+) -> str:
+    if exit_code == 124:
+        return FAILURE_REASON_TIMEOUT
+    if error_text:
+        lower = error_text.lower()
+        if ("rate" in lower and "limit" in lower) or "429" in error_text:
+            return FAILURE_REASON_RATE_LIMIT
+        if (
+            "auth" in lower
+            or "authentication" in lower
+            or "401" in error_text
+            or "403" in error_text
+        ):
+            return FAILURE_REASON_AUTH
+    no_model_tokens = input_tokens == 0 or (input_tokens is None and not has_assistant_turn)
+    if exit_code != 0 and no_model_tokens and duration_seconds < 120:
+        return FAILURE_REASON_PRE_RESPONSE
+    return FAILURE_REASON_NONZERO
+
+
+def capture_session_failure(
+    *,
+    exit_code: int,
+    duration_seconds: int,
+    input_tokens: int | None,
+    trajectory_path: Path | None,
+    harness_stderr_path: Path | None,
+) -> tuple[str | None, str | None]:
+    """Return ``(failure_reason, error)`` for failed harness exits.
+
+    ``None`` pair when ``exit_code`` is zero (success).
+    """
+    if exit_code == 0:
+        return None, None
+
+    has_assistant = _trajectory_has_assistant(trajectory_path)
+    stderr_tail = _read_tail(harness_stderr_path) if harness_stderr_path else None
+    traj_error = _extract_trajectory_error_line(trajectory_path)
+    error_text = stderr_tail or traj_error
+    if stderr_tail and traj_error and traj_error not in stderr_tail:
+        error_text = f"{stderr_tail}\n---\n{traj_error}"
+
+    reason = classify_failure_reason(
+        exit_code=exit_code,
+        duration_seconds=duration_seconds,
+        input_tokens=input_tokens,
+        has_assistant_turn=has_assistant,
+        error_text=error_text,
+    )
+    detail = error_text
+    if detail is None and reason == FAILURE_REASON_PRE_RESPONSE:
+        detail = "exit before first assistant response (input_tokens=0)"
+    return reason, detail

--- a/packages/gptme-sessions/src/gptme_sessions/failure_capture.py
+++ b/packages/gptme-sessions/src/gptme_sessions/failure_capture.py
@@ -50,18 +50,33 @@ def _record_is_assistant(rec: dict) -> bool:
 
 
 def _record_content_text(rec: dict) -> str:
-    """Extract flattened content string from flat or CC nested record."""
+    """Extract flattened text string from flat or CC nested record."""
     # Flat format
     content = rec.get("content") or rec.get("text") or ""
     if content:
         return str(content)
-    # CC nested: message.content is a list of typed blocks
+    # CC nested: message.content is a list of typed blocks — extract text blocks only
     msg = rec.get("message") or {}
     msg_content = msg.get("content") or ""
     if isinstance(msg_content, list):
         parts = [block.get("text") or "" for block in msg_content if isinstance(block, dict)]
         return " ".join(p for p in parts if p)
     return str(msg_content)
+
+
+def _record_has_any_content(rec: dict) -> bool:
+    """Return True if the record has any content (text or tool-use blocks).
+
+    Unlike _record_content_text, this treats tool_use-only assistant turns as
+    non-empty — the model already responded even if it only issued tool calls.
+    """
+    if rec.get("content") or rec.get("text"):
+        return True
+    msg = rec.get("message") or {}
+    msg_content = msg.get("content")
+    if isinstance(msg_content, list):
+        return bool(msg_content)
+    return bool(msg_content)
 
 
 def _trajectory_has_assistant(trajectory_path: Path | None) -> bool:
@@ -77,7 +92,7 @@ def _trajectory_has_assistant(trajectory_path: Path | None) -> bool:
                     rec = json.loads(line)
                 except json.JSONDecodeError:
                     continue
-                if _record_is_assistant(rec) and _record_content_text(rec).strip():
+                if _record_is_assistant(rec) and _record_has_any_content(rec):
                     return True
     except OSError:
         return False

--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -34,6 +34,7 @@ from .deliverables import (
     project_deliverable_details,
 )
 from .discovery import extract_project, extract_session_name
+from .failure_capture import capture_session_failure
 from .record import SessionRecord
 from .signals import extract_from_path
 from .smell import compute_smell_score
@@ -250,6 +251,9 @@ def post_session(
     deliverables: list[str] | None = None,
     journal_path: str | None = None,
     session_id: str | None = None,
+    harness_stderr_path: Path | None = None,
+    failure_reason: str | None = None,
+    error: str | None = None,
 ) -> PostSessionResult:
     """Record a completed agent session and extract trajectory signals.
 
@@ -320,6 +324,16 @@ def post_session(
         the first ``/journal/`` write in the trajectory signals.
     session_id:
         Override the auto-generated session ID.
+    harness_stderr_path:
+        Optional path to a harness stderr log (e.g. gptme ``2>>`` capture from
+        ``run.sh``). Used with the trajectory to populate ``failure_reason`` and
+        ``error`` when ``exit_code`` is non-zero.
+    failure_reason:
+        Optional override for the coarse failure class. When ``None`` and the
+        session failed, computed automatically.
+    error:
+        Optional override for error detail text. When ``None`` and the session
+        failed, extracted from ``harness_stderr_path`` / trajectory.
 
     Returns
     -------
@@ -715,6 +729,25 @@ def post_session(
         record_kwargs["session_total_bytes"] = session_total_bytes
     if summarizer_fired is not None:
         record_kwargs["summarizer_fired"] = summarizer_fired
+
+    if exit_code != 0:
+        if failure_reason is None or error is None:
+            auto_reason, auto_error = capture_session_failure(
+                exit_code=exit_code,
+                duration_seconds=duration_seconds,
+                input_tokens=input_tokens,
+                trajectory_path=trajectory_path,
+                harness_stderr_path=harness_stderr_path,
+            )
+            if failure_reason is None:
+                failure_reason = auto_reason
+            if error is None:
+                error = auto_error
+        if failure_reason is not None:
+            record_kwargs["failure_reason"] = failure_reason
+        if error is not None:
+            record_kwargs["error"] = error
+
     record = SessionRecord(**record_kwargs)
     if grade is not None:
         record.set_productivity_grade(grade)

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -204,6 +204,8 @@ class SessionRecord:
     # Outcome
     outcome: str = "unknown"  # productive, noop, violated_policy, failed
     exit_code: int | None = None  # process exit code (124 = timeout)
+    failure_reason: str | None = None  # coarse harness failure class (see failure_capture.py)
+    error: str | None = None  # stderr tail or trajectory error snippet when harness failed
     duration_seconds: int = 0
     token_count: int | None = None
     input_tokens: int | None = None
@@ -272,7 +274,7 @@ class SessionRecord:
 
     # Preserve fields written by older schema versions so load→mutate→rewrite
     # round-trips don't silently drop data (e.g. ``inferred_category``,
-    # ``failure_reason``, ``recommended_confidence``, ``notes``).
+    # ``recommended_confidence``, ``notes``).
     _legacy_fields: dict[str, Any] = field(default_factory=dict, repr=False, compare=False)
 
     def __post_init__(self) -> None:

--- a/packages/gptme-sessions/tests/test_failure_capture.py
+++ b/packages/gptme-sessions/tests/test_failure_capture.py
@@ -7,9 +7,11 @@ from pathlib import Path
 
 
 from gptme_sessions.failure_capture import (
+    FAILURE_REASON_NONZERO,
     FAILURE_REASON_PRE_RESPONSE,
     FAILURE_REASON_RATE_LIMIT,
     FAILURE_REASON_TIMEOUT,
+    _trajectory_has_assistant,
     capture_session_failure,
     classify_failure_reason,
 )
@@ -101,3 +103,50 @@ def test_post_session_no_failure_fields_on_success(tmp_path: Path):
     )
     assert result.record.failure_reason is None
     assert result.record.error is None
+
+
+def test_classify_not_pre_response_when_has_assistant_turn():
+    """Zero input_tokens must not override a confirmed assistant turn (Greptile P1)."""
+    result = classify_failure_reason(
+        exit_code=1,
+        duration_seconds=60,
+        input_tokens=0,
+        has_assistant_turn=True,
+        error_text=None,
+    )
+    assert result == FAILURE_REASON_NONZERO
+
+
+def test_trajectory_has_assistant_cc_nested_format(tmp_path: Path):
+    """CC nested assistant records must be detected (Greptile P1)."""
+    traj = tmp_path / "conversation.jsonl"
+    cc_record = {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "Hello, how can I help?"}],
+        },
+    }
+    traj.write_text(json.dumps(cc_record) + "\n", encoding="utf-8")
+    assert _trajectory_has_assistant(traj) is True
+
+
+def test_capture_cc_session_with_assistant_not_pre_response(tmp_path: Path):
+    """A CC-format trajectory with assistant response must not get pre_response class."""
+    traj = tmp_path / "conversation.jsonl"
+    cc_record = {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "Sure, I can do that."}],
+        },
+    }
+    traj.write_text(json.dumps(cc_record) + "\n", encoding="utf-8")
+    reason, _ = capture_session_failure(
+        exit_code=1,
+        duration_seconds=45,
+        input_tokens=0,
+        trajectory_path=traj,
+        harness_stderr_path=None,
+    )
+    assert reason == FAILURE_REASON_NONZERO

--- a/packages/gptme-sessions/tests/test_failure_capture.py
+++ b/packages/gptme-sessions/tests/test_failure_capture.py
@@ -1,0 +1,103 @@
+"""Tests for harness failure_reason / error capture."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+from gptme_sessions.failure_capture import (
+    FAILURE_REASON_PRE_RESPONSE,
+    FAILURE_REASON_RATE_LIMIT,
+    FAILURE_REASON_TIMEOUT,
+    capture_session_failure,
+    classify_failure_reason,
+)
+from gptme_sessions.post_session import post_session
+from gptme_sessions.store import SessionStore
+
+
+def test_classify_pre_response_fast_fail():
+    assert (
+        classify_failure_reason(
+            exit_code=1,
+            duration_seconds=73,
+            input_tokens=0,
+            has_assistant_turn=False,
+            error_text=None,
+        )
+        == FAILURE_REASON_PRE_RESPONSE
+    )
+
+
+def test_classify_timeout_exit_124():
+    assert (
+        classify_failure_reason(
+            exit_code=124,
+            duration_seconds=3600,
+            input_tokens=1000,
+            has_assistant_turn=True,
+            error_text=None,
+        )
+        == FAILURE_REASON_TIMEOUT
+    )
+
+
+def test_classify_rate_limit_from_stderr():
+    assert (
+        classify_failure_reason(
+            exit_code=1,
+            duration_seconds=200,
+            input_tokens=500,
+            has_assistant_turn=True,
+            error_text="HTTP 429 rate limit exceeded",
+        )
+        == FAILURE_REASON_RATE_LIMIT
+    )
+
+
+def test_capture_from_stderr_tail(tmp_path: Path):
+    stderr = tmp_path / "stderr.log"
+    stderr.write_text("line1\nOpenAI API error: connection reset\n", encoding="utf-8")
+    reason, err = capture_session_failure(
+        exit_code=1,
+        duration_seconds=30,
+        input_tokens=100,
+        trajectory_path=None,
+        harness_stderr_path=stderr,
+    )
+    assert reason is not None
+    assert err is not None
+    assert "connection reset" in err
+
+
+def test_post_session_records_failure_on_nonzero_exit(tmp_path: Path):
+    traj = tmp_path / "conversation.jsonl"
+    traj.write_text(
+        json.dumps({"role": "user", "content": "hi"}) + "\n",
+        encoding="utf-8",
+    )
+    store = SessionStore(sessions_dir=tmp_path / "sessions")
+    result = post_session(
+        store=store,
+        harness="gptme",
+        model="gpt-5.5",
+        exit_code=1,
+        duration_seconds=82,
+        trajectory_path=traj,
+    )
+    assert result.record.outcome == "failed"
+    assert result.record.failure_reason == FAILURE_REASON_PRE_RESPONSE
+    assert result.record.error is not None
+
+
+def test_post_session_no_failure_fields_on_success(tmp_path: Path):
+    store = SessionStore(sessions_dir=tmp_path / "sessions")
+    result = post_session(
+        store=store,
+        harness="gptme",
+        exit_code=0,
+        duration_seconds=10,
+    )
+    assert result.record.failure_reason is None
+    assert result.record.error is None

--- a/packages/gptme-sessions/tests/test_failure_capture.py
+++ b/packages/gptme-sessions/tests/test_failure_capture.py
@@ -11,6 +11,7 @@ from gptme_sessions.failure_capture import (
     FAILURE_REASON_PRE_RESPONSE,
     FAILURE_REASON_RATE_LIMIT,
     FAILURE_REASON_TIMEOUT,
+    _record_has_any_content,
     _trajectory_has_assistant,
     capture_session_failure,
     classify_failure_reason,
@@ -129,6 +130,55 @@ def test_trajectory_has_assistant_cc_nested_format(tmp_path: Path):
     }
     traj.write_text(json.dumps(cc_record) + "\n", encoding="utf-8")
     assert _trajectory_has_assistant(traj) is True
+
+
+def test_trajectory_has_assistant_cc_tool_use_only(tmp_path: Path):
+    """CC assistant turns with only tool_use blocks must be detected (Greptile P1)."""
+    traj = tmp_path / "conversation.jsonl"
+    cc_record = {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [
+                {"type": "tool_use", "id": "toolu_abc", "name": "Bash", "input": {"cmd": "ls"}}
+            ],
+        },
+    }
+    traj.write_text(json.dumps(cc_record) + "\n", encoding="utf-8")
+    assert _trajectory_has_assistant(traj) is True
+
+
+def test_capture_cc_tool_use_only_not_pre_response(tmp_path: Path):
+    """A CC assistant turn with only tool_use must not get pre_response_api_failure."""
+    traj = tmp_path / "conversation.jsonl"
+    cc_record = {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "tool_use", "id": "toolu_abc", "name": "Bash", "input": {}}],
+        },
+    }
+    traj.write_text(json.dumps(cc_record) + "\n", encoding="utf-8")
+    reason, _ = capture_session_failure(
+        exit_code=1,
+        duration_seconds=45,
+        input_tokens=0,
+        trajectory_path=traj,
+        harness_stderr_path=None,
+    )
+    assert reason == FAILURE_REASON_NONZERO
+
+
+def test_record_has_any_content_tool_use():
+    """_record_has_any_content returns True for tool_use-only CC assistant turns."""
+    rec = {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "tool_use", "id": "toolu_x", "name": "Read", "input": {}}],
+        },
+    }
+    assert _record_has_any_content(rec) is True
 
 
 def test_capture_cc_session_with_assistant_not_pre_response(tmp_path: Path):


### PR DESCRIPTION
## Summary
- Add first-class `failure_reason` and `error` fields on `SessionRecord`
- `post_session()` classifies non-zero exits (pre-response API failure, timeout, auth, rate limit) and stores stderr/trajectory snippets via `failure_capture.py`
- Tests cover classification and post_session recording

## Motivation
gptme-harness fast-fails (exit 1, <90s, 0 input_tokens) were landing in session-records with no failure_reason — operator forensics required journal archaeology (bottleneck review F2, ErikBjare/bob task).

## Test plan
- `uv run pytest packages/gptme-sessions/tests/test_failure_capture.py -q`