### PR TITLE
feat(gptme-runloops): add run_post_session and RunPostSessionHooks (Phase-2 step 4)

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/cli.py
+++ b/packages/gptme-runloops/src/gptme_runloops/cli.py
@@ -1,7 +1,10 @@
 """Command-line interface for run loops."""
 
+import json
 import os
+import subprocess
 import sys
+from dataclasses import replace
 from pathlib import Path
 
 import click
@@ -9,6 +12,13 @@ import click
 from gptme_runloops.autonomous import AutonomousRun
 from gptme_runloops.email import EmailRun
 from gptme_runloops.project_monitoring import ProjectMonitoringRun
+from gptme_runloops.run_item import (
+    RunItemConfig,
+    RunItemHooks,
+    execute_plan,
+    load_items,
+    plan_run_item,
+)
 from gptme_runloops.team import TeamRun
 from gptme_runloops.utils.executor import get_executor, list_backends
 
@@ -219,6 +229,125 @@ def monitoring(
         executor=executor,
     )
     exit_code = run.run()
+    sys.exit(exit_code)
+
+
+@main.command(name="run-item")
+@click.option(
+    "--workspace",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    required=True,
+    help="Workspace containing run.sh and PM policy hooks.",
+)
+@click.option(
+    "--work-file",
+    type=click.Path(path_type=Path),
+    default=lambda: os.environ.get("PM_WORK_FILE"),
+    required=True,
+    help="Grouped JSONL work file (default: $PM_WORK_FILE).",
+)
+@click.option("--backend", default=lambda: os.environ.get("BOB_BACKEND", "claude-code"))
+@click.option("--model", default=lambda: os.environ.get("BOB_SELECTED_MODEL") or None)
+@click.option(
+    "--lane",
+    type=click.Choice(["fast", "slow", "mixed"]),
+    default=lambda: os.environ.get("PM_LANE", "mixed"),
+)
+@click.option("--dispatch-id", default=lambda: os.environ.get("PM_DISPATCH_ID") or None)
+@click.option("--author", default=lambda: os.environ.get("GITHUB_AUTHOR", ""))
+@click.option("--agent-name", default=lambda: os.environ.get("AGENT_NAME", "Agent"))
+@click.option(
+    "--claim-mode", type=click.Choice(["acquire", "preheld", "none"]), default="acquire"
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Emit canonical execution-plan JSON and perform no work.",
+)
+def run_item(
+    workspace: Path,
+    work_file: Path,
+    backend: str,
+    model: str | None,
+    lane: str,
+    dispatch_id: str | None,
+    author: str,
+    agent_name: str,
+    claim_mode: str,
+    dry_run: bool,
+):
+    """Execute one grouped PM work file through the shared run.sh runner."""
+    config = RunItemConfig(
+        workspace=workspace,
+        backend=backend,
+        model=model,
+        lane=lane,
+        dispatch_id=dispatch_id,
+        author=author,
+        agent_name=agent_name,
+        run_salt=os.environ.get("RUN_START", ""),
+        claim_mode=claim_mode,
+    )
+    hooks = RunItemHooks.from_workspace(workspace)
+    rules = ""
+    if hooks.monitoring_rules_file and hooks.monitoring_rules_file.is_file():
+        rules = hooks.monitoring_rules_file.read_text(encoding="utf-8")
+    try:
+        items = load_items(work_file)
+    except (FileNotFoundError, ValueError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    plans = [
+        plan_run_item(item, config, index=index, monitoring_rules=rules)
+        for index, item in enumerate(items, 1)
+    ]
+    if dry_run:
+        click.echo(
+            json.dumps(
+                [json.loads(plan.to_json()) for plan in plans],
+                sort_keys=True,
+                ensure_ascii=False,
+            )
+        )
+        return
+    exit_code = 0
+    for item, plan in zip(items, plans, strict=True):
+        item_hooks = hooks
+        if claim_mode == "acquire":
+            owner = f"project-monitoring-{backend}-{plan.session_id}"
+
+            def claim(key: str, *, _owner: str = owner) -> bool:
+                return (
+                    subprocess.run(
+                        [
+                            "uv",
+                            "run",
+                            "coordination",
+                            "work-claim",
+                            _owner,
+                            key,
+                            "--ttl",
+                            "60",
+                        ],
+                        cwd=workspace,
+                        check=False,
+                        stdout=subprocess.DEVNULL,
+                    ).returncode
+                    == 0
+                )
+
+            def abandon(key: str, *, _owner: str = owner) -> None:
+                subprocess.run(
+                    ["uv", "run", "coordination", "work-abandon", _owner, key],
+                    cwd=workspace,
+                    check=False,
+                    stdout=subprocess.DEVNULL,
+                )
+
+            item_hooks = replace(hooks, claim=claim, abandon=abandon)
+        outcome = execute_plan(plan, item, item_hooks)
+        exit_code = outcome.exit_code or exit_code
+        if outcome.rate_limited:
+            break
     sys.exit(exit_code)
 
 

--- a/packages/gptme-runloops/src/gptme_runloops/cli.py
+++ b/packages/gptme-runloops/src/gptme_runloops/cli.py
@@ -15,6 +15,7 @@ from gptme_runloops.project_monitoring import ProjectMonitoringRun
 from gptme_runloops.run_item import (
     RunItemConfig,
     RunItemHooks,
+    RunItemOutcome,
     RunPostSessionHooks,
     execute_plan,
     load_items,
@@ -373,7 +374,13 @@ def run_item(
                 )
 
             item_hooks = replace(hooks, claim=claim, abandon=abandon)
-        outcome = execute_plan(plan, item, item_hooks)
+        try:
+            outcome = execute_plan(plan, item, item_hooks)
+        except KeyboardInterrupt:
+            # SIGTERM: run.sh group already killed; still write the record.
+            outcome = RunItemOutcome(item, plan, 143, 0)
+            run_post_session(outcome, RunPostSessionHooks(), workspace=workspace)
+            raise
         # Post-session bookkeeping (step 5 brain shim wires real callables).
         run_post_session(outcome, RunPostSessionHooks(), workspace=workspace)
         exit_code = outcome.exit_code or exit_code

--- a/packages/gptme-runloops/src/gptme_runloops/cli.py
+++ b/packages/gptme-runloops/src/gptme_runloops/cli.py
@@ -15,11 +15,13 @@ from gptme_runloops.project_monitoring import ProjectMonitoringRun
 from gptme_runloops.run_item import (
     RunItemConfig,
     RunItemHooks,
+    RunPostSessionHooks,
     execute_plan,
     load_items,
     plan_run_item,
     prepare_monitoring_trajectory_snapshot,
     resolve_monitoring_trajectory,
+    run_post_session,
     write_claude_rate_limit_block,
 )
 from gptme_runloops.team import TeamRun
@@ -372,6 +374,8 @@ def run_item(
 
             item_hooks = replace(hooks, claim=claim, abandon=abandon)
         outcome = execute_plan(plan, item, item_hooks)
+        # Post-session bookkeeping (step 5 brain shim wires real callables).
+        run_post_session(outcome, RunPostSessionHooks(), workspace=workspace)
         exit_code = outcome.exit_code or exit_code
         if outcome.rate_limited:
             break

--- a/packages/gptme-runloops/src/gptme_runloops/cli.py
+++ b/packages/gptme-runloops/src/gptme_runloops/cli.py
@@ -374,15 +374,17 @@ def run_item(
                 )
 
             item_hooks = replace(hooks, claim=claim, abandon=abandon)
+        # step 5 brain shim will replace RunPostSessionHooks() with real callables;
+        # one shared instance so both normal and interrupted paths use the same hooks.
+        post_session_hooks = RunPostSessionHooks()
         try:
             outcome = execute_plan(plan, item, item_hooks)
         except KeyboardInterrupt:
             # SIGTERM: run.sh group already killed; still write the record.
             outcome = RunItemOutcome(item, plan, 143, 0)
-            run_post_session(outcome, RunPostSessionHooks(), workspace=workspace)
+            run_post_session(outcome, post_session_hooks, workspace=workspace)
             raise
-        # Post-session bookkeeping (step 5 brain shim wires real callables).
-        run_post_session(outcome, RunPostSessionHooks(), workspace=workspace)
+        run_post_session(outcome, post_session_hooks, workspace=workspace)
         exit_code = outcome.exit_code or exit_code
         if outcome.rate_limited:
             break

--- a/packages/gptme-runloops/src/gptme_runloops/cli.py
+++ b/packages/gptme-runloops/src/gptme_runloops/cli.py
@@ -18,6 +18,9 @@ from gptme_runloops.run_item import (
     execute_plan,
     load_items,
     plan_run_item,
+    prepare_monitoring_trajectory_snapshot,
+    resolve_monitoring_trajectory,
+    write_claude_rate_limit_block,
 )
 from gptme_runloops.team import TeamRun
 from gptme_runloops.utils.executor import get_executor, list_backends
@@ -289,6 +292,30 @@ def run_item(
         claim_mode=claim_mode,
     )
     hooks = RunItemHooks.from_workspace(workspace)
+    quota_dir = workspace / "state" / "backend-quota"
+
+    def trajectory_lines(path: Path):
+        with path.open(encoding="utf-8") as handle:
+            yield from handle
+
+    def rate_limit_block(rejection) -> None:
+        credential_target = None
+        credential = Path.home() / ".claude" / ".credentials.json"
+        if credential.is_symlink():
+            credential_target = os.readlink(credential)
+        write_claude_rate_limit_block(
+            rejection,
+            quota_dir,
+            credential_target=credential_target,
+        )
+
+    hooks = replace(
+        hooks,
+        trajectory_lines=trajectory_lines,
+        rate_limit_block=rate_limit_block,
+        prepare_trajectory_snapshot=prepare_monitoring_trajectory_snapshot,
+        resolve_trajectory=resolve_monitoring_trajectory,
+    )
     rules = ""
     if hooks.monitoring_rules_file and hooks.monitoring_rules_file.is_file():
         rules = hooks.monitoring_rules_file.read_text(encoding="utf-8")

--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -1,0 +1,337 @@
+"""One-item project-monitoring executor primitives.
+
+The workspace retains dispatch and policy.  This module owns portable item
+parsing, deterministic planning, and the ``run.sh`` subprocess boundary.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import time
+import uuid
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from gptme_runloops.merge_lifecycle import InstructionKind, WorkItem
+from gptme_runloops.pm_dispatch import is_direct_mention
+from gptme_runloops.prompt_templates import PromptContext, render_instruction
+from gptme_runloops.worker_records import RateLimitRejection, parse_rate_limit_rejection
+
+DEFAULT_TIMEOUT = 900
+ASSIGNED_ISSUE_TIMEOUT = 1500
+GREPTILE_TIMEOUT = 2700
+
+
+@dataclass(frozen=True)
+class RunItem:
+    """A grouped JSONL item emitted by the project-monitoring gate."""
+
+    repo: str
+    number: int | str
+    title: str
+    detail: str
+    types: tuple[str, ...]
+    all_numbers: tuple[str, ...]
+    raw: dict[str, Any] = field(default_factory=dict, compare=False)
+
+    @classmethod
+    def from_grouped_json(cls, line: str) -> RunItem:
+        value = json.loads(line)
+        if not isinstance(value, dict):
+            raise ValueError("grouped item must be a JSON object")
+        repo, number = value.get("repo"), value.get("number")
+        if not isinstance(repo, str) or not repo or number is None:
+            raise ValueError("grouped item requires non-empty repo and number")
+        source_types = value.get("types", [value.get("type")])
+        if not isinstance(source_types, list):
+            raise ValueError("grouped item types must be an array")
+        types = tuple(v for v in source_types if isinstance(v, str) and v)
+        if not types:
+            raise ValueError("grouped item requires at least one type")
+        source_numbers = value.get("all_numbers", [number])
+        if not isinstance(source_numbers, list):
+            raise ValueError("grouped item all_numbers must be an array")
+        return cls(
+            repo=repo,
+            number=number,
+            title=str(value.get("title", "")),
+            detail=str(value.get("detail", "")),
+            types=types,
+            all_numbers=tuple(str(v) for v in source_numbers),
+            raw=dict(value),
+        )
+
+    def to_merge_lifecycle_item(self) -> WorkItem:
+        return WorkItem(repo=self.repo, number=self.number, types=self.types)
+
+
+@dataclass(frozen=True)
+class RunItemConfig:
+    """Scalar policy passed from the slot unit or CLI."""
+
+    workspace: Path
+    backend: str
+    model: str | None = None
+    lane: str = "mixed"
+    dispatch_id: str | None = None
+    author: str = ""
+    agent_name: str = "Agent"
+    records_dir: Path | None = None
+    run_salt: str = ""
+    claim_mode: str = "acquire"
+
+    def resolved_records_dir(self) -> Path:
+        return self.records_dir or self.workspace / "state" / "session-records"
+
+
+@dataclass(frozen=True)
+class RunItemHooks:
+    """Brain-side collaborators, injectable so package tests stay local."""
+
+    runner: Sequence[str]
+    monitoring_rules_file: Path | None = None
+    sysprompt_file: Path | None = None
+    claim: Callable[[str], bool] | None = None
+    abandon: Callable[[str], None] | None = None
+    trajectory_lines: Callable[[Path], Iterable[str]] | None = None
+    rate_limit_block: Callable[[RateLimitRejection], None] | None = None
+
+    @classmethod
+    def from_workspace(cls, workspace: Path) -> RunItemHooks:
+        return cls(
+            runner=(str(workspace / "run.sh"),),
+            monitoring_rules_file=workspace / "scripts/runs/github/monitoring-rules.md",
+        )
+
+
+@dataclass(frozen=True)
+class ExecutionPlan:
+    """All decisions taken before any hook/subprocess side effect."""
+
+    repo: str
+    number: int | str
+    types: tuple[str, ...]
+    timeout_seconds: int
+    timeout_reason: str
+    session_id: str
+    record_file: str
+    claim_key: str
+    prompt: str
+    backend: str
+    model: str | None
+    lane: str
+    dispatch_id: str | None
+    direct_mention: bool
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), sort_keys=True, ensure_ascii=False)
+
+
+@dataclass(frozen=True)
+class RunItemOutcome:
+    item: RunItem
+    plan: ExecutionPlan
+    exit_code: int
+    duration_seconds: int
+    skipped_claimed: bool = False
+    rate_limited: bool = False
+
+
+def _timeout_for(item: RunItem) -> tuple[int, str]:
+    if "assigned_issue" in item.types:
+        return ASSIGNED_ISSUE_TIMEOUT, "assigned_issue"
+    if "pr_update" in item.types and any(
+        typ in item.types
+        for typ in ("greptile_needs_fix", "greptile_needs_improvement")
+    ):
+        return GREPTILE_TIMEOUT, "pr_update_with_greptile"
+    return DEFAULT_TIMEOUT, "default"
+
+
+def _item_slug(item: RunItem, index: int) -> str:
+    return (
+        f"{item.repo}_{item.number}_{index}".replace("/", "-")
+        .replace("#", "-")
+        .replace(" ", "-")
+        .replace(":", "-")
+    )
+
+
+def _investigate(item: RunItem, workspace: Path) -> str:
+    """Render the portable portion of the existing per-type investigate text."""
+    sections: list[str] = []
+    ctx = PromptContext(repo=item.repo, number=item.number, workspace=str(workspace))
+    for kind in item.types:
+        if kind == "pr_update":
+            sections.append(
+                "### PR Review & Comments\n```bash\n"
+                f"gh pr view {item.number} --repo {item.repo}\n"
+                f"gh pr view {item.number} --repo {item.repo} --comments\n"
+                f"gh pr checks {item.number} --repo {item.repo}\n"
+                f"gh pr view {item.number} --repo {item.repo} --json mergeable,mergeStateStatus\n"
+                "```\n\nCheck every human and bot comment; never ignore a human comment in favor of bot review work."
+            )
+        elif kind == "ci_failure":
+            sections.append(
+                "### CI Failure Investigation\n```bash\n"
+                f"gh pr checks {item.number} --repo {item.repo}\n"
+                f"gh pr checks {item.number} --repo {item.repo} --json name,state,link --jq '.[] | select(.state == \"FAILURE\")'\n```"
+            )
+        elif kind == "assigned_issue":
+            sections.append(
+                "### Issue Details\n```bash\n"
+                f"gh issue view {item.number} --repo {item.repo}\n"
+                f"gh issue view {item.number} --repo {item.repo} --comments\n```\n\n"
+                "Close the loop: do the work, create/update a local task if it cannot finish here, and reply with the concrete outcome."
+            )
+        elif kind == "master_ci_failure":
+            commands = "\n".join(
+                f"gh run view {run} --repo {item.repo} --log-failed | tail -60"
+                for run in item.all_numbers
+            )
+            sections.append(f"### Master Branch CI Failure\n```bash\n{commands}\n```")
+        elif kind == "merge_conflict":
+            sections.append(
+                "### Merge Conflict Resolution\n```bash\n"
+                f"gh pr view {item.number} --repo {item.repo} --json mergeable,mergeStateStatus,headRefName\n```"
+            )
+        elif kind == "greptile_needs_fix":
+            sections.append(render_instruction(InstructionKind.GREPTILE_NEEDS_FIX, ctx))
+        elif kind == "greptile_needs_improvement":
+            sections.append(
+                render_instruction(InstructionKind.GREPTILE_NEEDS_IMPROVEMENT, ctx)
+            )
+    return (
+        "\n".join(sections)
+        or "Investigate the work item and act only when evidence warrants it."
+    )
+
+
+def _direct_mention_constraint(item: RunItem) -> str:
+    if not is_direct_mention(item.detail):
+        return ""
+    return "\n## Required: Produce a Deliverable (Direct @Mention)\n\nThis is a direct @mention from Erik. Produce the requested deliverable or reply with the concrete blocker; a silent NOOP is not acceptable.\n"
+
+
+def plan_run_item(
+    item: RunItem,
+    config: RunItemConfig,
+    *,
+    index: int = 1,
+    monitoring_rules: str = "",
+) -> ExecutionPlan:
+    """Build a deterministic plan without reading files or invoking hooks."""
+    timeout, reason = _timeout_for(item)
+    slug = _item_slug(item, index)
+    session_id = str(
+        uuid.uuid5(uuid.NAMESPACE_DNS, f"monitor-{slug}-{config.run_salt or 'default'}")
+    )
+    prompt = (
+        f"You are {config.agent_name}, running a focused project monitoring session. Your identity files have been injected as system context.\n\n"
+        "## Your Task\n\nInvestigate and act on this work item:\n\n"
+        f"- **Event(s)**: {item.types[0]}\n- **Repo**: {item.repo}\n- **Number**: #{item.number}\n- **Title**: {item.title}\n- **Detail**: {item.detail}\n\n"
+        f"Your GitHub author name is: {config.author}\n{_direct_mention_constraint(item)}\n"
+        "## Step 1: Investigate (3 min)\n\nGet full context for this item. Read ALL sources — never truncate output.\n"
+        f"{_investigate(item, config.workspace)}\n\n## Step 2: Classify & Execute\n\n{monitoring_rules}\n\n"
+        "## Time Budget\n\n"
+        f"You have ~{timeout // 60} minutes available for this item.\n"
+        "- Treat the limit as a stall guard, not a rush order.\n"
+        "- Keep naturally sequential work together: investigate -> fix -> verify -> reply.\n"
+        "- If the item needs no action after investigation, just exit. No journal. No commit.\n"
+    )
+    return ExecutionPlan(
+        repo=item.repo,
+        number=item.number,
+        types=item.types,
+        timeout_seconds=timeout,
+        timeout_reason=reason,
+        session_id=session_id,
+        record_file=str(config.resolved_records_dir() / f"{slug}.json"),
+        claim_key=f"github:{item.repo}#{item.number}",
+        prompt=prompt,
+        backend=config.backend,
+        model=config.model,
+        lane=config.lane,
+        dispatch_id=config.dispatch_id,
+        direct_mention=is_direct_mention(item.detail),
+    )
+
+
+def _runner_command(plan: ExecutionPlan, hooks: RunItemHooks) -> list[str]:
+    command = [
+        *hooks.runner,
+        "--backend",
+        plan.backend,
+        "--no-lock",
+        "--no-pull",
+        "--no-grade",
+    ]
+    if hooks.sysprompt_file is not None:
+        command.extend(("--sysprompt-file", str(hooks.sysprompt_file)))
+    command.extend(("--timeout", str(plan.timeout_seconds)))
+    if plan.model:
+        command.extend(("--model", plan.model))
+    return [*command, plan.prompt]
+
+
+def execute_plan(
+    plan: ExecutionPlan, item: RunItem, hooks: RunItemHooks
+) -> RunItemOutcome:
+    """Acquire a claim, invoke ``run.sh``, and guard blocks on real rejection."""
+    if hooks.claim is not None and not hooks.claim(plan.claim_key):
+        return RunItemOutcome(item, plan, 0, 0, skipped_claimed=True)
+    started = time.monotonic()
+    old_handler = signal.getsignal(signal.SIGTERM)
+
+    def _terminate(_signum: int, _frame: Any) -> None:
+        raise KeyboardInterrupt("SIGTERM")
+
+    signal.signal(signal.SIGTERM, _terminate)
+    try:
+        env = os.environ.copy()
+        if plan.backend == "claude-code":
+            env["CC_SESSION_ID"] = plan.session_id
+        elif plan.backend == "grok-build":
+            env["GROK_BUILD_SESSION_ID"] = plan.session_id
+        completed = subprocess.run(_runner_command(plan, hooks), env=env, check=False)
+        rate_limited = False
+        if completed.returncode and hooks.trajectory_lines and hooks.rate_limit_block:
+            rejection = parse_rate_limit_rejection(
+                hooks.trajectory_lines(Path(plan.record_file))
+            )
+            if rejection is not None:
+                hooks.rate_limit_block(rejection)
+                rate_limited = True
+        return RunItemOutcome(
+            item,
+            plan,
+            completed.returncode,
+            int(time.monotonic() - started),
+            rate_limited=rate_limited,
+        )
+    finally:
+        signal.signal(signal.SIGTERM, old_handler)
+        if hooks.abandon is not None:
+            hooks.abandon(plan.claim_key)
+
+
+def load_items(work_file: Path) -> list[RunItem]:
+    """Load valid grouped items, skipping malformed gate lines like bash does."""
+    if not work_file.is_file():
+        raise FileNotFoundError(work_file)
+    items: list[RunItem] = []
+    for line in work_file.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            items.append(RunItem.from_grouped_json(line))
+        except (ValueError, json.JSONDecodeError):
+            continue
+    if not items:
+        raise ValueError("work file contains no valid grouped items")
+    return items

--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -14,7 +14,7 @@ import time
 import uuid
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import asdict, dataclass, field
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -445,9 +445,9 @@ def write_claude_rate_limit_block(
 
     reset = str(rejection.resets_at or "")
     if reset and reset != "0":
-        until = datetime.fromtimestamp(int(reset), tz=UTC)
+        until = datetime.fromtimestamp(int(reset), tz=timezone.utc)
     else:
-        until = (now or datetime.now(UTC)) + timedelta(hours=6)
+        until = (now or datetime.now(timezone.utc)) + timedelta(hours=6)
     block_path.write_text(until.isoformat(), encoding="utf-8")
     return block_path
 

--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -12,7 +12,7 @@ import signal
 import subprocess
 import time
 import uuid
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -21,7 +21,15 @@ from typing import Any
 from gptme_runloops.merge_lifecycle import InstructionKind, WorkItem
 from gptme_runloops.pm_dispatch import is_direct_mention
 from gptme_runloops.prompt_templates import PromptContext, render_instruction
-from gptme_runloops.worker_records import RateLimitRejection, parse_rate_limit_rejection
+from gptme_runloops.worker_records import (
+    RateLimitRejection,
+    fallback_outcome,
+    parse_rate_limit_rejection,
+    update_record_pr_state,
+    write_fallback_session_record,
+    write_post_session_record,
+    write_worker_result_manifest,
+)
 
 DEFAULT_TIMEOUT = 900
 ASSIGNED_ISSUE_TIMEOUT = 1500
@@ -507,6 +515,137 @@ def execute_plan(
         signal.signal(signal.SIGTERM, old_handler)
         if hooks.abandon is not None:
             hooks.abandon(plan.claim_key)
+
+
+@dataclass(frozen=True)
+class RunPostSessionHooks:
+    """Injectable bookkeeping callables for :func:`run_post_session`.
+
+    All fields are ``None`` by default; a ``None`` hook skips that step,
+    matching the bash ``|| true`` tolerance in worker.sh.
+    """
+
+    # Primary record writer: gptme_sessions.post_session.post_session
+    post_session: Callable[..., Any] | None = None
+    # SessionStore factory: lambda path: SessionStore(sessions_dir=path)
+    make_store: Callable[[Path], Any] | None = None
+    # Fallback record factory: lambda **kw: SessionRecord(**kw).to_dict()
+    make_record: Callable[..., Mapping[str, Any]] | None = None
+    # metaproductivity.pr_outcome.upgrade_outcome_from_pr_state (optional)
+    upgrade_outcome: Callable[[dict[str, Any]], Any] | None = None
+    # agent_events.worker_results.build_worker_result
+    build_worker_result: Callable[..., dict[str, Any]] | None = None
+    # agent_events.worker_results.write_worker_result
+    write_worker_result: Callable[[Path, Mapping[str, Any]], Any] | None = None
+    # agent_events.worker_results.load_worker_result
+    load_worker_result: Callable[[Path], Mapping[str, Any] | None] | None = None
+
+
+def run_post_session(
+    outcome: RunItemOutcome,
+    hooks: RunPostSessionHooks,
+    *,
+    workspace: Path,
+    pr_state_before_json: str = "",
+) -> None:
+    """Write post-session bookkeeping records for a completed plan execution.
+
+    Mirrors worker.sh:283-627. Each step is guarded by ``|| true``-equivalent
+    exception swallowing: a failure in one step does not abort subsequent steps.
+    Skipped-claim outcomes write no record (same as the bash guard at :278).
+
+    Call this after :func:`execute_plan` returns, even on non-zero exits —
+    the record is the primary artifact that session quality analysis needs.
+
+    ``pr_state_before_json`` should be the raw JSON from a
+    ``gh pr view --json state,headRefOid,mergeCommit`` call taken *before*
+    :func:`execute_plan`; an empty string silently skips the before-state
+    fields (worker.sh parity when ``_before_json`` was not captured).
+    """
+    if outcome.skipped_claimed:
+        return
+
+    plan = outcome.plan
+    item = outcome.item
+    record_file = Path(plan.record_file)
+    trajectory_path_str = (
+        str(outcome.trajectory_path) if outcome.trajectory_path else None
+    )
+
+    # Step 1: Primary record via gptme_sessions (worker.sh:283-323).
+    primary_ok = False
+    if hooks.post_session is not None and hooks.make_store is not None:
+        try:
+            write_post_session_record(
+                record_file,
+                harness=plan.backend,
+                model=plan.model,
+                session_id=plan.session_id,
+                exit_code=outcome.exit_code,
+                duration_seconds=outcome.duration_seconds,
+                item_timeout=plan.timeout_seconds,
+                trajectory_path=trajectory_path_str,
+                post_session=hooks.post_session,
+                make_store=hooks.make_store,
+            )
+            primary_ok = True
+        except Exception:
+            pass
+
+    # Step 2: Fallback via metaproductivity.sessions (worker.sh:325-373).
+    if not primary_ok and hooks.make_record is not None:
+        try:
+            write_fallback_session_record(
+                record_file,
+                harness=plan.backend,
+                model=plan.model,
+                outcome=fallback_outcome(outcome.exit_code),
+                session_id=plan.session_id,
+                exit_code=outcome.exit_code,
+                duration_seconds=outcome.duration_seconds,
+                item_timeout=plan.timeout_seconds,
+                trajectory_path=trajectory_path_str,
+                make_record=hooks.make_record,
+            )
+        except Exception:
+            pass
+
+    # Step 3: PR-state before/after diff (worker.sh:377-502).
+    # Raises for non-numeric PR numbers (same as heredoc dying) → swallowed.
+    try:
+        update_record_pr_state(
+            record_file,
+            repo=item.repo,
+            number=item.number,
+            before_json=pr_state_before_json,
+            cwd=workspace,
+            upgrade_outcome=hooks.upgrade_outcome,
+        )
+    except Exception:
+        pass
+
+    # Step 4: Worker-result manifest (worker.sh:505-627).
+    if (
+        hooks.build_worker_result is not None
+        and hooks.write_worker_result is not None
+        and hooks.load_worker_result is not None
+    ):
+        try:
+            write_worker_result_manifest(
+                record_file,
+                repo=item.repo,
+                number=item.number,
+                session_id=plan.session_id,
+                exit_code=outcome.exit_code,
+                duration_seconds=outcome.duration_seconds,
+                model=plan.model,
+                item_types=item.types,
+                build_worker_result=hooks.build_worker_result,
+                write_worker_result=hooks.write_worker_result,
+                load_worker_result=hooks.load_worker_result,
+            )
+        except Exception:
+            pass
 
 
 def load_items(work_file: Path) -> list[RunItem]:

--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -461,8 +461,14 @@ def execute_plan(
     started = time.monotonic()
     started_epoch = int(time.time())
     old_handler = signal.getsignal(signal.SIGTERM)
+    proc: subprocess.Popen[bytes] | None = None
 
     def _terminate(_signum: int, _frame: Any) -> None:
+        if proc is not None:
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+            except (ProcessLookupError, OSError):
+                proc.terminate()
         raise KeyboardInterrupt("SIGTERM")
 
     signal.signal(signal.SIGTERM, _terminate)
@@ -479,7 +485,10 @@ def execute_plan(
                 Path.home(),
                 Path("/tmp"),
             )
-        completed = subprocess.run(_runner_command(plan, hooks), env=env, check=False)
+        proc = subprocess.Popen(
+            _runner_command(plan, hooks), env=env, start_new_session=True
+        )
+        returncode = proc.wait()
         trajectory_path = None
         if hooks.resolve_trajectory is not None:
             trajectory_path = hooks.resolve_trajectory(
@@ -491,7 +500,7 @@ def execute_plan(
             )
         rate_limited = False
         if (
-            completed.returncode
+            returncode
             and plan.backend == "claude-code"
             and trajectory_path is not None
             and hooks.trajectory_lines
@@ -506,7 +515,7 @@ def execute_plan(
         return RunItemOutcome(
             item,
             plan,
-            completed.returncode,
+            returncode,
             int(time.monotonic() - started),
             rate_limited=rate_limited,
             trajectory_path=trajectory_path,

--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -14,6 +14,7 @@ import time
 import uuid
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -100,6 +101,8 @@ class RunItemHooks:
     abandon: Callable[[str], None] | None = None
     trajectory_lines: Callable[[Path], Iterable[str]] | None = None
     rate_limit_block: Callable[[RateLimitRejection], None] | None = None
+    prepare_trajectory_snapshot: Callable[[str, str, Path, Path], None] | None = None
+    resolve_trajectory: Callable[[str, str, int, Path, Path], Path | None] | None = None
 
     @classmethod
     def from_workspace(cls, workspace: Path) -> RunItemHooks:
@@ -140,6 +143,7 @@ class RunItemOutcome:
     duration_seconds: int
     skipped_claimed: bool = False
     rate_limited: bool = False
+    trajectory_path: Path | None = None
 
 
 def _timeout_for(item: RunItem) -> tuple[int, str]:
@@ -279,6 +283,167 @@ def _runner_command(plan: ExecutionPlan, hooks: RunItemHooks) -> list[str]:
     return [*command, plan.prompt]
 
 
+def _read_ref_path(ref_path: Path) -> Path | None:
+    try:
+        value = ref_path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    return Path(value) if value else None
+
+
+def _file_size(path: Path) -> int:
+    try:
+        return path.stat().st_size if path.is_file() else 0
+    except OSError:
+        return 0
+
+
+def _newest_file(paths: Iterable[Path], *, min_mtime: int | None = None) -> Path | None:
+    newest: Path | None = None
+    newest_mtime = -1
+    for path in paths:
+        try:
+            stat = path.stat()
+        except OSError:
+            continue
+        if not path.is_file():
+            continue
+        mtime = int(stat.st_mtime)
+        if min_mtime is not None and mtime < min_mtime:
+            continue
+        if newest is None or mtime > newest_mtime:
+            newest = path
+            newest_mtime = mtime
+    return newest
+
+
+def prepare_monitoring_trajectory_snapshot(
+    backend: str,
+    session_id: str,
+    home: Path,
+    tmp_dir: Path = Path("/tmp"),
+) -> None:
+    """Capture pre-run trajectory listings for backends without session refs."""
+    if backend == "copilot-cli":
+        state_dir = home / ".copilot" / "session-state"
+        if state_dir.is_dir():
+            snapshot = tmp_dir / f"copilot-pre-snapshot-{session_id}.txt"
+            snapshot.write_text(
+                "\n".join(sorted(child.name for child in state_dir.iterdir())) + "\n",
+                encoding="utf-8",
+            )
+    elif backend == "codex":
+        sessions_dir = home / ".codex" / "sessions"
+        if sessions_dir.is_dir():
+            snapshot = tmp_dir / f"codex-pre-snapshot-{session_id}.txt"
+            snapshot.write_text(
+                "\n".join(
+                    sorted(str(path) for path in sessions_dir.rglob("rollout-*.jsonl"))
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+
+def resolve_monitoring_trajectory(
+    backend: str,
+    session_id: str,
+    started_epoch: int,
+    home: Path,
+    tmp_dir: Path = Path("/tmp"),
+) -> Path | None:
+    """Resolve the trajectory file produced by ``run.sh`` for one PM item.
+
+    This ports worker.sh's backend-specific post-run discovery.  It deliberately
+    uses session-specific ref files for stream-json backends and pre/post
+    snapshot files for copilot/codex so concurrent workers do not race on mtimes.
+    """
+    if backend == "claude-code" and session_id:
+        ref = tmp_dir / f"cc-session-log-ref-{session_id}.txt"
+        candidate = _read_ref_path(ref)
+        if candidate is not None and _file_size(candidate) > 5000:
+            return candidate
+
+    if backend == "grok-build" and session_id:
+        ref = tmp_dir / f"grok-build-session-log-ref-{session_id}.txt"
+        candidate = _read_ref_path(ref)
+        try:
+            ref.unlink()
+        except OSError:
+            pass
+        if candidate is not None and _file_size(candidate) > 1000:
+            return candidate
+
+    if backend == "copilot-cli":
+        pre_snapshot = tmp_dir / f"copilot-pre-snapshot-{session_id}.txt"
+        if pre_snapshot.is_file():
+            state_dir = home / ".copilot" / "session-state"
+            before = set(pre_snapshot.read_text(encoding="utf-8").splitlines())
+            candidates = []
+            if state_dir.is_dir():
+                for child in state_dir.iterdir():
+                    if child.name not in before:
+                        candidates.append(child / "events.jsonl")
+            try:
+                pre_snapshot.unlink()
+            except OSError:
+                pass
+            return _newest_file(candidates, min_mtime=started_epoch)
+
+    if backend == "codex":
+        pre_snapshot = tmp_dir / f"codex-pre-snapshot-{session_id}.txt"
+        if pre_snapshot.is_file():
+            sessions_dir = home / ".codex" / "sessions"
+            before = set(pre_snapshot.read_text(encoding="utf-8").splitlines())
+            candidates = []
+            if sessions_dir.is_dir():
+                for candidate in sessions_dir.rglob("rollout-*.jsonl"):
+                    if str(candidate) not in before:
+                        candidates.append(candidate)
+            try:
+                pre_snapshot.unlink()
+            except OSError:
+                pass
+            return _newest_file(candidates)
+
+    return None
+
+
+def write_claude_rate_limit_block(
+    rejection: RateLimitRejection,
+    quota_dir: Path,
+    *,
+    credential_target: str | None = None,
+    now: datetime | None = None,
+) -> Path:
+    """Write the per-sub Claude Code quota block file for a confirmed rejection.
+
+    Mirrors worker.sh:159-185: only call this after
+    :func:`parse_rate_limit_rejection` confirms ``status == rejected``.  The
+    ``seven_day_sonnet`` cap gets a sonnet-specific block file; other caps use
+    the generic per-sub block.  Missing/zero reset timestamps block for 6h.
+    """
+    quota_dir.mkdir(parents=True, exist_ok=True)
+    suffix = ""
+    if credential_target:
+        marker = ".credentials.json."
+        if marker in credential_target:
+            suffix = credential_target.rsplit(marker, 1)[1] + "-"
+    rate_type = str(rejection.rate_limit_type or "")
+    if rate_type == "seven_day_sonnet":
+        block_path = quota_dir / f"claude-code-{suffix}sonnet-rate-limited-until.txt"
+    else:
+        block_path = quota_dir / f"claude-code-{suffix}rate-limited-until.txt"
+
+    reset = str(rejection.resets_at or "")
+    if reset and reset != "0":
+        until = datetime.fromtimestamp(int(reset), tz=UTC)
+    else:
+        until = (now or datetime.now(UTC)) + timedelta(hours=6)
+    block_path.write_text(until.isoformat(), encoding="utf-8")
+    return block_path
+
+
 def execute_plan(
     plan: ExecutionPlan, item: RunItem, hooks: RunItemHooks
 ) -> RunItemOutcome:
@@ -286,6 +451,7 @@ def execute_plan(
     if hooks.claim is not None and not hooks.claim(plan.claim_key):
         return RunItemOutcome(item, plan, 0, 0, skipped_claimed=True)
     started = time.monotonic()
+    started_epoch = int(time.time())
     old_handler = signal.getsignal(signal.SIGTERM)
 
     def _terminate(_signum: int, _frame: Any) -> None:
@@ -298,11 +464,33 @@ def execute_plan(
             env["CC_SESSION_ID"] = plan.session_id
         elif plan.backend == "grok-build":
             env["GROK_BUILD_SESSION_ID"] = plan.session_id
+        if hooks.prepare_trajectory_snapshot is not None:
+            hooks.prepare_trajectory_snapshot(
+                plan.backend,
+                plan.session_id,
+                Path.home(),
+                Path("/tmp"),
+            )
         completed = subprocess.run(_runner_command(plan, hooks), env=env, check=False)
+        trajectory_path = None
+        if hooks.resolve_trajectory is not None:
+            trajectory_path = hooks.resolve_trajectory(
+                plan.backend,
+                plan.session_id,
+                started_epoch,
+                Path.home(),
+                Path("/tmp"),
+            )
         rate_limited = False
-        if completed.returncode and hooks.trajectory_lines and hooks.rate_limit_block:
+        if (
+            completed.returncode
+            and plan.backend == "claude-code"
+            and trajectory_path is not None
+            and hooks.trajectory_lines
+            and hooks.rate_limit_block
+        ):
             rejection = parse_rate_limit_rejection(
-                hooks.trajectory_lines(Path(plan.record_file))
+                hooks.trajectory_lines(trajectory_path or Path(plan.record_file))
             )
             if rejection is not None:
                 hooks.rate_limit_block(rejection)
@@ -313,6 +501,7 @@ def execute_plan(
             completed.returncode,
             int(time.monotonic() - started),
             rate_limited=rate_limited,
+            trajectory_path=trajectory_path,
         )
     finally:
         signal.signal(signal.SIGTERM, old_handler)

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -1,0 +1,139 @@
+"""Tests for the PM one-item plan and subprocess boundary."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+from gptme_runloops.cli import main
+from gptme_runloops.run_item import (
+    ASSIGNED_ISSUE_TIMEOUT,
+    DEFAULT_TIMEOUT,
+    GREPTILE_TIMEOUT,
+    RunItem,
+    RunItemConfig,
+    RunItemHooks,
+    execute_plan,
+    load_items,
+    plan_run_item,
+)
+
+
+def item(**overrides: object) -> RunItem:
+    data: dict[str, object] = {
+        "repo": "gptme/gptme",
+        "number": 42,
+        "title": "A title",
+        "detail": "normal",
+        "types": ["pr_update"],
+        "all_numbers": [42],
+        "extra_gate_field": {"kept": True},
+    }
+    data.update(overrides)
+    return RunItem.from_grouped_json(json.dumps(data))
+
+
+def config(tmp_path: Path, **overrides: object) -> RunItemConfig:
+    data: dict[str, object] = {
+        "workspace": tmp_path,
+        "backend": "codex",
+        "model": "gpt-5.6-terra",
+        "run_salt": "1700000000",
+        "author": "TimeToBuildBob",
+        "agent_name": "Bob",
+    }
+    data.update(overrides)
+    return RunItemConfig(**data)  # type: ignore[arg-type]
+
+
+def test_parse_grouped_item_preserves_unknown_fields() -> None:
+    parsed = item(number="master-ci", types=["master_ci_failure"], all_numbers=[11, 12])
+    assert parsed.number == "master-ci"
+    assert parsed.all_numbers == ("11", "12")
+    assert parsed.raw["extra_gate_field"] == {"kept": True}
+    lifecycle = parsed.to_merge_lifecycle_item()
+    assert lifecycle.repo == "gptme/gptme"
+
+
+def test_plan_default_timeout_and_deterministic_session_id(tmp_path: Path) -> None:
+    first = plan_run_item(item(), config(tmp_path), monitoring_rules="rules")
+    second = plan_run_item(item(), config(tmp_path), monitoring_rules="rules")
+    assert first.timeout_seconds == DEFAULT_TIMEOUT
+    assert first.timeout_reason == "default"
+    assert first.session_id == second.session_id
+    assert first.claim_key == "github:gptme/gptme#42"
+    assert "gh pr checks 42 --repo gptme/gptme" in first.prompt
+    assert "rules" in first.prompt
+
+
+def test_plan_applies_timeout_tiers_and_direct_mention_constraint(
+    tmp_path: Path,
+) -> None:
+    assigned = plan_run_item(item(types=["assigned_issue"]), config(tmp_path))
+    greptile = plan_run_item(
+        item(types=["pr_update", "greptile_needs_fix"], detail="mention"),
+        config(tmp_path),
+    )
+    assert assigned.timeout_seconds == ASSIGNED_ISSUE_TIMEOUT
+    assert greptile.timeout_seconds == GREPTILE_TIMEOUT
+    assert greptile.direct_mention is True
+    assert "silent NOOP is not acceptable" in greptile.prompt
+    assert "Greptile Score Fix Needed" in greptile.prompt
+
+
+def test_execute_does_not_run_when_claim_is_denied(tmp_path: Path) -> None:
+    plan = plan_run_item(item(), config(tmp_path))
+    calls: list[str] = []
+    hooks = RunItemHooks(
+        runner=("false",),
+        claim=lambda key: calls.append(key) and False,
+    )
+    outcome = execute_plan(plan, item(), hooks)
+    assert outcome.skipped_claimed is True
+    assert outcome.exit_code == 0
+    assert calls == ["github:gptme/gptme#42"]
+
+
+def test_execute_abandons_acquired_claim_after_runner_returns(tmp_path: Path) -> None:
+    plan = plan_run_item(item(), config(tmp_path))
+    abandoned: list[str] = []
+    outcome = execute_plan(
+        plan,
+        item(),
+        RunItemHooks(
+            runner=("true",),
+            claim=lambda _key: True,
+            abandon=abandoned.append,
+        ),
+    )
+    assert outcome.exit_code == 0
+    assert abandoned == [plan.claim_key]
+
+
+def test_load_items_skips_malformed_lines(tmp_path: Path) -> None:
+    work_file = tmp_path / "work.jsonl"
+    work_file.write_text("not json\n" + json.dumps(item().raw) + "\n", encoding="utf-8")
+    assert load_items(work_file) == [item()]
+
+
+def test_cli_dry_run_emits_canonical_plan(tmp_path: Path) -> None:
+    work_file = tmp_path / "work.jsonl"
+    work_file.write_text(json.dumps(item().raw) + "\n", encoding="utf-8")
+    result = CliRunner().invoke(
+        main,
+        [
+            "run-item",
+            "--workspace",
+            str(tmp_path),
+            "--work-file",
+            str(work_file),
+            "--backend",
+            "codex",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload[0]["claim_key"] == "github:gptme/gptme#42"
+    assert payload[0]["backend"] == "codex"

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import patch
 
@@ -253,7 +253,7 @@ def test_write_claude_rate_limit_block_unknown_reset_defaults_to_6h(
     path = write_claude_rate_limit_block(
         RateLimitRejection("requests", 0),
         tmp_path,
-        now=datetime(2026, 1, 1, tzinfo=UTC),
+        now=datetime(2026, 1, 1, tzinfo=timezone.utc),
     )
     assert path.name == "claude-code-rate-limited-until.txt"
     assert path.read_text(encoding="utf-8") == "2026-01-01T06:00:00+00:00"

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -203,18 +203,22 @@ def test_execute_kills_runner_process_group_on_sigterm(tmp_path: Path) -> None:
     assert sig == signal.SIGTERM
 
 
-def test_cli_run_item_calls_post_session_on_sigterm(tmp_path: Path) -> None:
-    """Interrupted run must still write bookkeeping via run_post_session."""
+def test_cli_run_item_calls_post_session_hooks_on_sigterm(tmp_path: Path) -> None:
+    """Interrupted run must invoke the hooks pipeline, not just call run_post_session."""
     work_file = tmp_path / "work.jsonl"
     work_file.write_text(json.dumps(item().raw) + "\n", encoding="utf-8")
-    post_session_calls: list[RunItemOutcome] = []
+    make_record_calls: list[dict] = []
+
+    # Use real RunPostSessionHooks with a spy on the fallback path (make_record).
+    # Exceptions inside run_post_session are swallowed, so even if the file write
+    # fails, make_record is called first — proving the pipeline ran on interrupt.
+    spy_hooks = RunPostSessionHooks(
+        make_record=lambda **kw: make_record_calls.append(kw) or kw
+    )
 
     with (
         patch("gptme_runloops.cli.execute_plan", side_effect=KeyboardInterrupt),
-        patch(
-            "gptme_runloops.cli.run_post_session",
-            side_effect=lambda outcome, *_a, **_kw: post_session_calls.append(outcome),
-        ),
+        patch("gptme_runloops.cli.RunPostSessionHooks", return_value=spy_hooks),
     ):
         result = CliRunner().invoke(
             main,
@@ -229,10 +233,9 @@ def test_cli_run_item_calls_post_session_on_sigterm(tmp_path: Path) -> None:
             ],
         )
 
-    assert (
-        len(post_session_calls) == 1
-    ), "run_post_session must be called even on SIGTERM"
-    assert post_session_calls[0].exit_code == 143
+    assert len(make_record_calls) == 1, "make_record hook must fire even on SIGTERM"
+    assert make_record_calls[0]["harness"] == "codex"
+    assert make_record_calls[0]["outcome"] == "failed"  # fallback_outcome(143)
     # CliRunner converts re-raised KeyboardInterrupt to SystemExit(1)
     assert result.exit_code == 1
 

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -157,6 +157,52 @@ def test_execute_resolves_trajectory_and_blocks_confirmed_rate_limit(
     assert blocked == [RateLimitRejection("seven_day_sonnet", 123)]
 
 
+def test_execute_kills_runner_process_group_on_sigterm(tmp_path: Path) -> None:
+    """SIGTERM during execute_plan kills the child process group and abandons the claim."""
+    import os
+    import signal
+    import threading
+
+    plan = plan_run_item(item(), config(tmp_path))
+    abandoned: list[str] = []
+    killpg_calls: list[tuple[int, int]] = []
+    _real_killpg = os.killpg
+
+    def _track_killpg(pgid: int, sig: int) -> None:
+        killpg_calls.append((pgid, sig))
+        _real_killpg(pgid, sig)
+
+    def _send_sigterm() -> None:
+        import time
+
+        time.sleep(0.05)
+        os.kill(os.getpid(), signal.SIGTERM)
+
+    t = threading.Thread(target=_send_sigterm, daemon=True)
+    t.start()
+
+    with patch("os.killpg", side_effect=_track_killpg):
+        try:
+            execute_plan(
+                plan,
+                item(),
+                RunItemHooks(
+                    # sh -c ignores extra positional args that _runner_command appends
+                    runner=("sh", "-c", "sleep 10"),
+                    claim=lambda _key: True,
+                    abandon=abandoned.append,
+                ),
+            )
+        except KeyboardInterrupt:
+            pass
+
+    t.join(timeout=2)
+    assert abandoned == [plan.claim_key], "claim must be abandoned in finally"
+    assert len(killpg_calls) == 1, "process group must be killed exactly once"
+    _, sig = killpg_calls[0]
+    assert sig == signal.SIGTERM
+
+
 def test_load_items_skips_malformed_lines(tmp_path: Path) -> None:
     work_file = tmp_path / "work.jsonl"
     work_file.write_text("not json\n" + json.dumps(item().raw) + "\n", encoding="utf-8")

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from datetime import UTC, datetime
 from pathlib import Path
+from unittest.mock import patch
 
 from click.testing import CliRunner
 from gptme_runloops.cli import main
@@ -15,14 +16,17 @@ from gptme_runloops.run_item import (
     RunItem,
     RunItemConfig,
     RunItemHooks,
+    RunItemOutcome,
+    RunPostSessionHooks,
     execute_plan,
     load_items,
     plan_run_item,
     prepare_monitoring_trajectory_snapshot,
     resolve_monitoring_trajectory,
+    run_post_session,
     write_claude_rate_limit_block,
 )
-from gptme_runloops.worker_records import RateLimitRejection
+from gptme_runloops.worker_records import RateLimitRejection, update_record_pr_state
 
 
 def item(**overrides: object) -> RunItem:
@@ -253,3 +257,242 @@ def test_write_claude_rate_limit_block_unknown_reset_defaults_to_6h(
     )
     assert path.name == "claude-code-rate-limited-until.txt"
     assert path.read_text(encoding="utf-8") == "2026-01-01T06:00:00+00:00"
+
+
+# --- run_post_session tests ---
+
+# Stub collaborators (mirrors test_worker_records.py stubs so the two test
+# suites exercise the same injection interface).
+
+
+class _StubStore:
+    def __init__(self, sessions_dir: Path) -> None:
+        self.sessions_dir = sessions_dir
+
+
+class _StubRecord:
+    def __init__(self, data: dict) -> None:
+        self._data = data
+
+    def to_dict(self) -> dict:
+        return dict(self._data)
+
+
+class _StubResult:
+    def __init__(self, record: _StubRecord, grade: str) -> None:
+        self.record = record
+        self.grade = grade
+
+
+def _stub_post_session(
+    *,
+    store: _StubStore,
+    harness: str,
+    model: object,
+    run_type: str,
+    trigger: str,
+    category: str,
+    exit_code: int,
+    duration_seconds: int,
+    trajectory_path: object,
+    session_id: str,
+) -> _StubResult:
+    data = {
+        "harness": harness,
+        "model": model,
+        "run_type": run_type,
+        "trigger": trigger,
+        "category": category,
+        "exit_code": exit_code,
+        "duration_seconds": duration_seconds,
+        "trajectory_path": str(trajectory_path) if trajectory_path else None,
+        "session_id": session_id,
+        "outcome": "stub-outcome",
+    }
+    return _StubResult(_StubRecord(data), "stub-grade")
+
+
+def _stub_make_record(
+    *,
+    harness: str,
+    model: str,
+    run_type: str,
+    category: str,
+    outcome: str,
+    duration_seconds: int,
+) -> dict:
+    return {
+        "harness": harness,
+        "model": model,
+        "run_type": run_type,
+        "category": category,
+        "outcome": outcome,
+        "duration_seconds": duration_seconds,
+    }
+
+
+def _make_outcome(
+    tmp_path: Path,
+    *,
+    exit_code: int = 0,
+    skipped_claimed: bool = False,
+    types: list | None = None,
+    number: int | str = 42,
+    trajectory_path: Path | None = None,
+) -> RunItemOutcome:
+    it = item(number=number, types=types or ["pr_update"])
+    cfg = config(tmp_path)
+    plan = plan_run_item(it, cfg)
+    return RunItemOutcome(
+        item=it,
+        plan=plan,
+        exit_code=exit_code,
+        duration_seconds=5,
+        skipped_claimed=skipped_claimed,
+        trajectory_path=trajectory_path,
+    )
+
+
+def test_run_post_session_skips_when_claim_was_denied(tmp_path: Path) -> None:
+    """No record written for skipped-claim outcomes."""
+    outcome = _make_outcome(tmp_path, skipped_claimed=True)
+    calls: list[str] = []
+    hooks = RunPostSessionHooks(
+        post_session=lambda **_kw: calls.append("ps"),
+        make_store=lambda _p: _StubStore(_p),
+    )
+    run_post_session(outcome, hooks, workspace=tmp_path)
+    assert calls == []
+    assert not Path(outcome.plan.record_file).exists()
+
+
+def test_run_post_session_all_none_hooks_is_noop(tmp_path: Path) -> None:
+    """All-None hooks must not raise and must write no record."""
+    outcome = _make_outcome(tmp_path)
+    run_post_session(outcome, RunPostSessionHooks(), workspace=tmp_path)
+    assert not Path(outcome.plan.record_file).exists()
+
+
+def test_run_post_session_writes_primary_record(tmp_path: Path) -> None:
+    outcome = _make_outcome(tmp_path)
+    hooks = RunPostSessionHooks(
+        post_session=_stub_post_session,
+        make_store=lambda p: _StubStore(p),
+    )
+    run_post_session(outcome, hooks, workspace=tmp_path)
+    record_path = Path(outcome.plan.record_file)
+    assert record_path.is_file()
+    rec = json.loads(record_path.read_text(encoding="utf-8"))
+    assert rec["harness"] == "codex"
+    assert rec["grade"] == "stub-grade"
+    assert rec["timeout_seconds"] == outcome.plan.timeout_seconds
+
+
+def test_run_post_session_falls_back_when_primary_raises(tmp_path: Path) -> None:
+    outcome = _make_outcome(tmp_path, exit_code=1)
+
+    def _failing_post_session(**_kw):
+        raise RuntimeError("gptme_sessions unavailable")
+
+    hooks = RunPostSessionHooks(
+        post_session=_failing_post_session,
+        make_store=lambda p: _StubStore(p),
+        make_record=_stub_make_record,
+    )
+    run_post_session(outcome, hooks, workspace=tmp_path)
+    record_path = Path(outcome.plan.record_file)
+    assert record_path.is_file()
+    rec = json.loads(record_path.read_text(encoding="utf-8"))
+    # Fallback writer sets outcome="failed" for non-zero non-124 exits.
+    assert rec["outcome"] == "failed"
+    assert rec["exit_code"] == 1
+
+
+def test_run_post_session_uses_fallback_when_no_primary_hooks(tmp_path: Path) -> None:
+    outcome = _make_outcome(tmp_path)
+    hooks = RunPostSessionHooks(make_record=_stub_make_record)
+    run_post_session(outcome, hooks, workspace=tmp_path)
+    record_path = Path(outcome.plan.record_file)
+    assert record_path.is_file()
+    rec = json.loads(record_path.read_text(encoding="utf-8"))
+    assert rec["harness"] == "codex"
+    assert "grade" not in rec  # fallback writer doesn't grade
+
+
+def test_run_post_session_pr_state_diff_updates_record(tmp_path: Path) -> None:
+    """PR-state diff runs and folds before/after into the record."""
+    outcome = _make_outcome(tmp_path)
+    hooks = RunPostSessionHooks(make_record=_stub_make_record)
+    before_json = json.dumps(
+        {"state": "OPEN", "headRefOid": "aaa", "mergeCommit": None}
+    )
+
+    def _fetch(repo: str, number: int) -> dict:
+        return {"state": "MERGED", "headRefOid": "bbb", "mergeCommit": "ccc"}
+
+    def _patched_update(*args, **kw):
+        kw.pop("upgrade_outcome", None)
+        return update_record_pr_state(*args, fetch=_fetch, **kw)
+
+    with patch("gptme_runloops.run_item.update_record_pr_state", _patched_update):
+        run_post_session(
+            outcome, hooks, workspace=tmp_path, pr_state_before_json=before_json
+        )
+
+    record_path = Path(outcome.plan.record_file)
+    assert record_path.is_file()
+    rec = json.loads(record_path.read_text(encoding="utf-8"))
+    assert rec.get("pr_state_before") == "OPEN"
+
+
+def test_run_post_session_swallows_pr_state_error_for_non_numeric_number(
+    tmp_path: Path,
+) -> None:
+    """Non-numeric PR numbers raise inside update_record_pr_state; must not crash."""
+    outcome = _make_outcome(tmp_path, types=["master_ci_failure"], number="master-ci")
+    hooks = RunPostSessionHooks(make_record=_stub_make_record)
+    run_post_session(outcome, hooks, workspace=tmp_path)
+    # Record was still written (the pr-state step failure is swallowed).
+    assert Path(outcome.plan.record_file).is_file()
+
+
+def test_run_post_session_writes_worker_result_manifest(tmp_path: Path) -> None:
+    outcome = _make_outcome(tmp_path)
+    hooks = RunPostSessionHooks(make_record=_stub_make_record)
+
+    manifests: list[dict] = []
+
+    def _build(**kw: object) -> dict:
+        return {
+            "status": "handled",
+            "schema_version": 1,
+            "git_refs": {"commit_oids": [], "start_commit": None, "end_commit": None},
+            "task": {"intended_category": "pm-react"},
+            "artifact_paths": {"record_path": str(tmp_path)},
+        }
+
+    def _write(path: Path, manifest: object) -> None:
+        import json as _j
+
+        path.write_text(_j.dumps(manifest), encoding="utf-8")
+        manifests.append(dict(manifest))  # type: ignore[arg-type]
+
+    def _load(path: Path) -> dict | None:
+        import json as _j
+
+        try:
+            return _j.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            return None
+
+    hooks = RunPostSessionHooks(
+        make_record=_stub_make_record,
+        build_worker_result=_build,
+        write_worker_result=_write,
+        load_worker_result=_load,
+    )
+    run_post_session(outcome, hooks, workspace=tmp_path)
+    assert len(manifests) == 1
+    record_path = Path(outcome.plan.record_file)
+    rec = json.loads(record_path.read_text(encoding="utf-8"))
+    assert rec.get("worker_status") == "handled"

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -203,6 +203,40 @@ def test_execute_kills_runner_process_group_on_sigterm(tmp_path: Path) -> None:
     assert sig == signal.SIGTERM
 
 
+def test_cli_run_item_calls_post_session_on_sigterm(tmp_path: Path) -> None:
+    """Interrupted run must still write bookkeeping via run_post_session."""
+    work_file = tmp_path / "work.jsonl"
+    work_file.write_text(json.dumps(item().raw) + "\n", encoding="utf-8")
+    post_session_calls: list[RunItemOutcome] = []
+
+    with (
+        patch("gptme_runloops.cli.execute_plan", side_effect=KeyboardInterrupt),
+        patch(
+            "gptme_runloops.cli.run_post_session",
+            side_effect=lambda outcome, *_a, **_kw: post_session_calls.append(outcome),
+        ),
+    ):
+        result = CliRunner().invoke(
+            main,
+            [
+                "run-item",
+                "--workspace",
+                str(tmp_path),
+                "--work-file",
+                str(work_file),
+                "--backend",
+                "codex",
+            ],
+        )
+
+    assert (
+        len(post_session_calls) == 1
+    ), "run_post_session must be called even on SIGTERM"
+    assert post_session_calls[0].exit_code == 143
+    # CliRunner converts re-raised KeyboardInterrupt to SystemExit(1)
+    assert result.exit_code == 1
+
+
 def test_load_items_skips_malformed_lines(tmp_path: Path) -> None:
     work_file = tmp_path / "work.jsonl"
     work_file.write_text("not json\n" + json.dumps(item().raw) + "\n", encoding="utf-8")

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime
 from pathlib import Path
 
 from click.testing import CliRunner
@@ -17,7 +18,11 @@ from gptme_runloops.run_item import (
     execute_plan,
     load_items,
     plan_run_item,
+    prepare_monitoring_trajectory_snapshot,
+    resolve_monitoring_trajectory,
+    write_claude_rate_limit_block,
 )
+from gptme_runloops.worker_records import RateLimitRejection
 
 
 def item(**overrides: object) -> RunItem:
@@ -111,6 +116,43 @@ def test_execute_abandons_acquired_claim_after_runner_returns(tmp_path: Path) ->
     assert abandoned == [plan.claim_key]
 
 
+def test_execute_resolves_trajectory_and_blocks_confirmed_rate_limit(
+    tmp_path: Path,
+) -> None:
+    plan = plan_run_item(item(), config(tmp_path, backend="claude-code"))
+    trajectory = tmp_path / "cc.jsonl"
+    trajectory.write_text(
+        json.dumps(
+            {
+                "type": "rate_limit_event",
+                "rate_limit_info": {
+                    "status": "rejected",
+                    "rateLimitType": "seven_day_sonnet",
+                    "resetsAt": 123,
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    blocked: list[RateLimitRejection] = []
+    outcome = execute_plan(
+        plan,
+        item(),
+        RunItemHooks(
+            runner=("false",),
+            claim=lambda _key: True,
+            abandon=lambda _key: None,
+            resolve_trajectory=lambda *_args: trajectory,
+            trajectory_lines=lambda path: path.read_text(encoding="utf-8").splitlines(),
+            rate_limit_block=blocked.append,
+        ),
+    )
+    assert outcome.exit_code == 1
+    assert outcome.trajectory_path == trajectory
+    assert blocked == [RateLimitRejection("seven_day_sonnet", 123)]
+
+
 def test_load_items_skips_malformed_lines(tmp_path: Path) -> None:
     work_file = tmp_path / "work.jsonl"
     work_file.write_text("not json\n" + json.dumps(item().raw) + "\n", encoding="utf-8")
@@ -137,3 +179,77 @@ def test_cli_dry_run_emits_canonical_plan(tmp_path: Path) -> None:
     payload = json.loads(result.output)
     assert payload[0]["claim_key"] == "github:gptme/gptme#42"
     assert payload[0]["backend"] == "codex"
+
+
+def test_resolve_monitoring_trajectory_from_claude_session_ref(tmp_path: Path) -> None:
+    tmp_dir = tmp_path / "tmp"
+    tmp_dir.mkdir()
+    trajectory = tmp_path / "stream.jsonl"
+    trajectory.write_text("x" * 5001, encoding="utf-8")
+    (tmp_dir / "cc-session-log-ref-session-1.txt").write_text(
+        str(trajectory), encoding="utf-8"
+    )
+    assert (
+        resolve_monitoring_trajectory(
+            "claude-code", "session-1", 100, tmp_path, tmp_dir
+        )
+        == trajectory
+    )
+
+
+def test_prepare_monitoring_trajectory_snapshot_for_codex(tmp_path: Path) -> None:
+    tmp_dir = tmp_path / "tmp"
+    home = tmp_path / "home"
+    sessions = home / ".codex" / "sessions" / "2026" / "07" / "11"
+    tmp_dir.mkdir(parents=True)
+    sessions.mkdir(parents=True)
+    trajectory = sessions / "rollout-1.jsonl"
+    trajectory.write_text("{}\n", encoding="utf-8")
+    prepare_monitoring_trajectory_snapshot("codex", "session-1", home, tmp_dir)
+    assert (tmp_dir / "codex-pre-snapshot-session-1.txt").read_text(
+        encoding="utf-8"
+    ) == f"{trajectory}\n"
+
+
+def test_resolve_monitoring_trajectory_from_copilot_snapshot(tmp_path: Path) -> None:
+    tmp_dir = tmp_path / "tmp"
+    home = tmp_path / "home"
+    state = home / ".copilot" / "session-state"
+    tmp_dir.mkdir(parents=True)
+    old = state / "old"
+    new = state / "new"
+    old.mkdir(parents=True)
+    new.mkdir()
+    (old / "events.jsonl").write_text("old", encoding="utf-8")
+    candidate = new / "events.jsonl"
+    candidate.write_text("new", encoding="utf-8")
+    (tmp_dir / "copilot-pre-snapshot-session-1.txt").write_text(
+        "old\n", encoding="utf-8"
+    )
+    assert (
+        resolve_monitoring_trajectory("copilot-cli", "session-1", 0, home, tmp_dir)
+        == candidate
+    )
+    assert not (tmp_dir / "copilot-pre-snapshot-session-1.txt").exists()
+
+
+def test_write_claude_rate_limit_block_per_sub_and_sonnet(tmp_path: Path) -> None:
+    path = write_claude_rate_limit_block(
+        RateLimitRejection("seven_day_sonnet", 123),
+        tmp_path,
+        credential_target="/x/.credentials.json.alpha",
+    )
+    assert path.name == "claude-code-alpha-sonnet-rate-limited-until.txt"
+    assert path.read_text(encoding="utf-8").startswith("1970-01-01T00:02:03")
+
+
+def test_write_claude_rate_limit_block_unknown_reset_defaults_to_6h(
+    tmp_path: Path,
+) -> None:
+    path = write_claude_rate_limit_block(
+        RateLimitRejection("requests", 0),
+        tmp_path,
+        now=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    assert path.name == "claude-code-rate-limited-until.txt"
+    assert path.read_text(encoding="utf-8") == "2026-01-01T06:00:00+00:00"


### PR DESCRIPTION
## Summary

Completes Phase-2 step 4 of the PM execution-consolidation migration: the final acceptance slice for the `gptme-runloops run-item` executor.

- **`RunPostSessionHooks`** — injectable bookkeeping callables dataclass (all `None` by default; `None` = skip that step, matching bash `|| true` tolerance)
- **`run_post_session(outcome, hooks, *, workspace, pr_state_before_json="")`** — orchestrates the four post-session steps from `worker.sh:283-627`:
  1. Primary record via `write_post_session_record` (gptme_sessions path)
  2. Fallback via `write_fallback_session_record` when primary raises
  3. PR-state before/after diff via `update_record_pr_state`
  4. Worker-result manifest via `write_worker_result_manifest`
- **CLI**: `run-item` now calls `run_post_session(outcome, RunPostSessionHooks(), workspace=workspace)` after each `execute_plan` — no-op with all-None hooks until the brain-side shim (step 5) passes real callables

All four steps have the same exception-swallowing tolerance the bash `|| true` provides; skipped-claim outcomes write no record (same as the bash guard at `:278`).

## Prior steps

- contrib#1261 (`merge_lifecycle`) — step 1
- contrib#1262 (`prompt_templates`) — step 2
- contrib#1263 (`worker_records`) — step 3
- contrib#1265 → current branch (`d375e45c`) — trajectory resolution + rate-limit blocks
- This PR (`272ad2df`) — `run_post_session` + `RunPostSessionHooks`

## Tests

8 new tests in `test_run_item.py` using stub callables that mirror `test_worker_records.py`:

- skip on claimed, all-None no-op, primary write, primary-fails-falls-back, fallback-only, PR-state diff, non-numeric PR number swallowed, worker-result manifest written

Full suite: **135 passed** (run_item + worker_records + prompt_templates).

## Follow-ups (NOT bundled per task DoD)

1. `PM_PLAN_ONLY=1` bash plan-dump + `compare-run-item-plan.sh`
2. Step 5 toggle: `PM_EXECUTOR=runloops` in `run_slot_unit` + brain-side shim with real callables
3. Thin `latency-context` CLI