### PR TITLE
test(gptme-coordination): add multi-process claim-lifecycle property suite

### DIFF
--- a/packages/gptme-coordination/tests/test_work.py
+++ b/packages/gptme-coordination/tests/test_work.py
@@ -370,6 +370,43 @@ class TestExpiryHmacCoherence:
         )
 
 
+class TestExpiryHandoff:
+    """A holder's expired claim can be taken over by another agent, and the
+    original holder loses the ability to complete it — the two invariants
+    together (deny stale complete, allow live reclaim) are what make expiry
+    handoff safe. Combines the effects covered separately by
+    ``TestComplete.test_complete_after_expiry_is_denied`` (#1198) and
+    ``TestExpiryHmacCoherence`` (#1265) into one end-to-end scenario.
+    """
+
+    def test_second_agent_claims_over_expired_claim_and_original_holder_cannot_complete(
+        self, work: WorkClaimManager
+    ) -> None:
+        first = work.claim("agent-a", "task-1")
+        assert first is not None
+        assert first.epoch == 1
+
+        # Backdate expires_at to simulate a TTL that has elapsed.
+        work.db.conn.execute(
+            "UPDATE work SET expires_at = datetime('now', '-1 seconds') WHERE task_id = ?",
+            ("task-1",),
+        )
+
+        second = work.claim("agent-b", "task-1")
+        assert second is not None
+        assert second.claimer == "agent-b"
+        assert second.epoch == 2, "reclaim of an expired claim must bump the epoch"
+
+        # The original holder's complete() must fail now that agent-b holds it.
+        assert work.complete("agent-a", "task-1") is False
+
+        # The new holder can complete normally.
+        assert work.complete("agent-b", "task-1") is True
+        claim = work.get("task-1")
+        assert claim is not None
+        assert claim.status == "completed"
+
+
 class TestAuthCompatibility:
     def test_verify_hmac_matches_work_claim_manager(
         self, work: WorkClaimManager

--- a/packages/gptme-coordination/tests/test_work_invariants.py
+++ b/packages/gptme-coordination/tests/test_work_invariants.py
@@ -1,0 +1,187 @@
+"""Property/stress tests for claim-lifecycle invariants under real concurrency.
+
+Multi-process contenders hammer one WAL SQLite database with seeded-random
+interleavings, then a checker asserts the lifecycle invariants that recent
+incidents violated one at a time:
+
+- I-MUTEX: a contested key is won by exactly one claimer (never two live
+  holders of one canonical key).
+- I-EPOCH-UNIQ: every successful (non-renewal) claim consumes a unique
+  ``(key, epoch)`` pair, and per key the epochs form the gapless sequence
+  ``1..n`` — any duplicate or gap is a lost CAS update.
+
+Prior incidents in this class, each caught reactively via a single
+deterministic regression test rather than a stress suite that exercises real
+multi-process interleavings:
+
+- An expired claim could still be ``complete()``-d, letting a session that
+  outlived its TTL ghost-complete a task after another agent had already
+  reclaimed it (fixed in #1198; see ``TestComplete.test_complete_after_expiry_is_denied``
+  in ``test_work.py``).
+- The claim HMAC was computed over a Python-clock expiry string while the
+  stored ``expires_at`` came from a separate SQLite-evaluated
+  ``datetime('now', ...)`` call; when the two reads straddled a second
+  boundary the stored HMAC could never verify (fixed in #1265; see
+  ``TestExpiryHmacCoherence`` in ``test_work.py``).
+
+This module covers the *invariant class* under real concurrency by driving
+many seeded-random multi-process interleavings per run (failures reproduce
+via the fixed seed) rather than one hand-picked interleaving at a time. A
+sibling suite in the Bob workspace repo covers the reap/liveness layer
+(``reap_dead_holders``), which is Bob-local and not part of this package.
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+import random
+import sqlite3
+import time
+from pathlib import Path
+
+from gptme_coordination.db import CoordinationDB
+from gptme_coordination.work import WorkClaimManager
+
+# CI-friendly sizes: the suite completes in a few seconds. Bump locally when
+# hunting a suspected race (the invariant checks don't change with scale).
+N_WORKERS = 6
+N_KEYS = 12
+N_CHURN_ITERATIONS = 40
+SEED = 0x53F6
+
+
+def _open_manager(db_path: str) -> tuple[CoordinationDB, WorkClaimManager]:
+    db = CoordinationDB(Path(db_path))
+    return db, WorkClaimManager(db, default_ttl_minutes=60)
+
+
+def _precreate_db(db_path: str) -> None:
+    """Create the database, WAL mode, and work schema before forking workers.
+
+    The WAL journal-mode switch needs exclusive access, so N processes racing
+    to first-open a fresh file fail with 'database is locked'. Real
+    deployments always run against a pre-existing database.
+    """
+    db, _work = _open_manager(db_path)
+    db.close()
+
+
+def _claim_once_worker(args: tuple[str, str, list[str], int]) -> list[tuple[str, int]]:
+    """S1: attempt to claim every key once, in seeded-random order."""
+    db_path, agent_id, keys, seed = args
+    rng = random.Random(seed)
+    shuffled = list(keys)
+    rng.shuffle(shuffled)
+    wins: list[tuple[str, int]] = []
+    db, work = _open_manager(db_path)
+    with db:
+        for key in shuffled:
+            try:
+                claim = work.claim(agent_id, key, ttl_minutes=60)
+            except sqlite3.OperationalError:
+                claim = None  # lock timeout counts as a denial
+            if claim is not None:
+                wins.append((key, claim.epoch))
+    return wins
+
+
+def _churn_worker(
+    args: tuple[str, str, list[str], int, int],
+) -> tuple[list[tuple[str, int]], int]:
+    """S2: claim -> release churn; returns (claim events, lost-hold count).
+
+    A "lost hold" is a complete()/abandon() that failed for a key this worker
+    had just successfully claimed with a 60-minute TTL — under I-MUTEX that
+    must never happen (nothing may take the key from a live holder inside its
+    TTL).
+    """
+    db_path, agent_id, keys, seed, iterations = args
+    rng = random.Random(seed)
+    events: list[tuple[str, int]] = []
+    lost_holds = 0
+    db, work = _open_manager(db_path)
+    with db:
+        for _ in range(iterations):
+            key = rng.choice(keys)
+            try:
+                claim = work.claim(agent_id, key, ttl_minutes=60)
+            except sqlite3.OperationalError:
+                continue
+            if claim is None:
+                continue
+            events.append((key, claim.epoch))
+            # Hold the claim briefly so concurrent claim/complete paths
+            # actually observe rows in 'claimed' status — instant release
+            # would leave the contention windows empty and the invariants
+            # unexercised.
+            time.sleep(rng.uniform(0.001, 0.01))
+            try:
+                if rng.random() < 0.5:
+                    released = work.complete(agent_id, key)
+                else:
+                    released = work.abandon(agent_id, key)
+            except sqlite3.OperationalError:
+                released = False
+            if not released:
+                lost_holds += 1
+    return events, lost_holds
+
+
+class TestMutualExclusion:
+    def test_contested_keys_have_exactly_one_winner(self, tmp_path: Path) -> None:
+        """I-MUTEX: N processes race for K nonexistent keys; each key is won once."""
+        db_path = str(tmp_path / "stress.db")
+        _precreate_db(db_path)
+        keys = [f"cascade:task:mutex-{i}" for i in range(N_KEYS)]
+        args = [
+            (db_path, f"contrib-stress-w{i}", keys, SEED + i) for i in range(N_WORKERS)
+        ]
+        with multiprocessing.Pool(N_WORKERS) as pool:
+            results = pool.map(_claim_once_worker, args)
+
+        all_wins = [win for wins in results for win in wins]
+        won_keys = [key for key, _epoch in all_wins]
+        assert sorted(won_keys) == sorted(keys), (
+            "each contested key must be won exactly once across all workers; "
+            f"duplicates/missing: {sorted(won_keys)}"
+        )
+        # First claim of a nonexistent key always lands at epoch 1.
+        assert all(epoch == 1 for _key, epoch in all_wins)
+
+    def test_epoch_uniqueness_under_claim_release_churn(self, tmp_path: Path) -> None:
+        """I-EPOCH-UNIQ: churning claim/complete/abandon never reuses an epoch."""
+        db_path = str(tmp_path / "churn.db")
+        _precreate_db(db_path)
+        keys = [f"cascade:task:churn-{i}" for i in range(N_KEYS)]
+        args = [
+            (
+                db_path,
+                f"contrib-stress-w{i}",
+                keys,
+                SEED + 100 + i,
+                N_CHURN_ITERATIONS,
+            )
+            for i in range(N_WORKERS)
+        ]
+        with multiprocessing.Pool(N_WORKERS) as pool:
+            results = pool.map(_churn_worker, args)
+
+        events = [event for evts, _lost in results for event in evts]
+        lost_holds = sum(lost for _evts, lost in results)
+
+        assert lost_holds == 0, (
+            f"{lost_holds} release(s) failed for a freshly-claimed key — "
+            "something took the key from a live holder inside its TTL"
+        )
+        # No two successful claims share (key, epoch)...
+        assert len(set(events)) == len(events), "duplicate (key, epoch) claim event"
+        # ...and per key the consumed epochs are the gapless sequence 1..n:
+        # every ownership transition bumps epoch by exactly 1, so a gap means
+        # a lost update and a duplicate means two CAS winners.
+        by_key: dict[str, list[int]] = {}
+        for key, epoch in events:
+            by_key.setdefault(key, []).append(epoch)
+        for key, epochs in by_key.items():
+            assert sorted(epochs) == list(
+                range(1, len(epochs) + 1)
+            ), f"{key}: epochs not gapless: {sorted(epochs)}"

--- a/packages/gptme-coordination/tests/test_work_invariants.py
+++ b/packages/gptme-coordination/tests/test_work_invariants.py
@@ -42,6 +42,12 @@ from pathlib import Path
 from gptme_coordination.db import CoordinationDB
 from gptme_coordination.work import WorkClaimManager
 
+# Explicitly pin the start method so worker import paths are always available.
+# The default varies by platform (fork on Linux, spawn on macOS/Windows), and
+# spawn re-executes the pytest entry point in each child, which can make the
+# stress tests fail before reaching the claim lifecycle at all.
+_MP_CTX = multiprocessing.get_context("fork")
+
 # CI-friendly sizes: the suite completes in a few seconds. Bump locally when
 # hunting a suspected race (the invariant checks don't change with scale).
 N_WORKERS = 6
@@ -99,6 +105,7 @@ def _churn_worker(
     rng = random.Random(seed)
     events: list[tuple[str, int]] = []
     lost_holds = 0
+    held: set[str] = set()  # keys this worker currently holds
     db, work = _open_manager(db_path)
     with db:
         for _ in range(iterations):
@@ -109,7 +116,14 @@ def _churn_worker(
                 continue
             if claim is None:
                 continue
-            events.append((key, claim.epoch))
+            # Exclude same-holder renewals: if a previous release hit an
+            # OperationalError the worker may re-claim its still-held key,
+            # which returns the existing epoch (not a new CAS slot).  Recording
+            # that epoch again would produce a false duplicate and break the
+            # gapless-sequence assertion.
+            if key not in held:
+                events.append((key, claim.epoch))
+                held.add(key)
             # Hold the claim briefly so concurrent claim/complete paths
             # actually observe rows in 'claimed' status — instant release
             # would leave the contention windows empty and the invariants
@@ -124,6 +138,8 @@ def _churn_worker(
                 released = False
             if not released:
                 lost_holds += 1
+            else:
+                held.discard(key)
     return events, lost_holds
 
 
@@ -136,7 +152,7 @@ class TestMutualExclusion:
         args = [
             (db_path, f"contrib-stress-w{i}", keys, SEED + i) for i in range(N_WORKERS)
         ]
-        with multiprocessing.Pool(N_WORKERS) as pool:
+        with _MP_CTX.Pool(N_WORKERS) as pool:
             results = pool.map(_claim_once_worker, args)
 
         all_wins = [win for wins in results for win in wins]
@@ -163,7 +179,7 @@ class TestMutualExclusion:
             )
             for i in range(N_WORKERS)
         ]
-        with multiprocessing.Pool(N_WORKERS) as pool:
+        with _MP_CTX.Pool(N_WORKERS) as pool:
             results = pool.map(_churn_worker, args)
 
         events = [event for evts, _lost in results for event in evts]


### PR DESCRIPTION
## Motivation

Three mutual-exclusion/CAS bugs in the claim-lifecycle core were each found reactively within an 8-day window, each fixed with a single hand-picked deterministic test:

- #1198 — an expired claim could still be `complete()`-d, letting a session that outlived its TTL ghost-complete a task after another agent had already reclaimed it.
- #1265 — the claim HMAC was computed over a Python-clock expiry string while the stored `expires_at` came from a separate SQLite-evaluated `datetime('now', ...)` call; when the two reads straddled a second boundary the stored HMAC could never verify.
- A third, Bob-workspace-local regression in the reap path (not part of this package — see below).

Each fix landed with a targeted regression test for the *one* interleaving that had actually broken. This PR adds a property/stress suite that instead asserts the invariant *class* under real multi-process concurrency, so the next CAS regression in this area is caught before it ships rather than after.

## What's covered

`packages/gptme-coordination/tests/test_work_invariants.py` spins up real OS processes (`multiprocessing.Pool`) contending on one shared WAL SQLite database, with seeded RNG for deterministic, reproducible failures:

- **I-MUTEX**: N processes race to claim K nonexistent keys once each; every key must be won by exactly one claimer (`TestMutualExclusion.test_contested_keys_have_exactly_one_winner`).
- **I-EPOCH-UNIQ**: N processes churn claim → hold briefly → complete/abandon against a shared key set; no two successful claims may reuse a `(key, epoch)` pair, and per key the consumed epochs must form the gapless sequence `1..n` (`test_epoch_uniqueness_under_claim_release_churn`). A "lost hold" (a release that fails for a key just claimed with a fresh 60-minute TTL) is asserted to never happen — that would mean something took the key from a live holder inside its TTL.

Also added `TestExpiryHandoff` to `test_work.py`: a deterministic scenario where agent A claims, the claim is backdated to expired, agent B claims over it (epoch bumps 1→2), A's `complete()` then fails, and B's `complete()` succeeds. The existing suite covered "expired claim can't be completed" and "HMAC stays coherent across an expired reclaim" as two *separate* tests but never combined effects into one end-to-end handoff check.

## Sizing

Sizes (`N_WORKERS=6`, `N_KEYS=12`, `N_CHURN_ITERATIONS=40`, fixed `SEED`) are chosen to be CI-friendly — the suite adds well under a minute to the run — while still driving enough real interleavings to exercise the CAS path under contention. Bump locally when hunting a suspected race; the invariant checks don't change with scale. The seed makes failures reproducible.

## Note

A sibling stress suite already exists in the Bob workspace repo (`packages/coordination/tests/test_work_invariants.py`) covering the same I-MUTEX/I-EPOCH-UNIQ invariants plus a reap/liveness (I-REAP-SAFETY) scenario against `reap_dead_holders`, which is Bob-local and not part of this generic contrib package — that layer isn't duplicated here.

## Test plan

- [x] `uv run pytest packages/gptme-coordination/tests/ -q` — 92 passed
- [x] `uv run ruff check packages/gptme-coordination/tests/` — clean
- [x] `uv run ruff format` — no changes needed beyond what pre-commit auto-applied