### PR TITLE
feat(sessions-blame): trailer-first attribution + ambiguity detection

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/blame.py
+++ b/packages/gptme-sessions/src/gptme_sessions/blame.py
@@ -57,12 +57,17 @@ class Attribution:
     category: str | None = None
     productivity: float | None = None
     journal_path: str | None = None
-    confidence: str = "unmatched"  # exact | near | unmatched
+    confidence: str = "unmatched"  # exact | near | ambiguous | unmatched
     # Explicit resolution method, never silently downgraded:
-    #   commit-window | nearest | trajectory-exact | unattributable
+    #   trailer | commit-window | nearest | trajectory-exact | unattributable
     method: str = "unattributable"
     model: str | None = None
     harness: str | None = None
+    # Raw Git-Session-Id trailer value parsed from the commit (may name a session
+    # not present in the loaded windows — still authoritative).
+    trailer_session_id: str | None = None
+    # When confidence=="ambiguous": all session_ids whose windows contain this commit.
+    candidates: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -126,7 +131,7 @@ def commits_for_path(path: str, limit: int = 10) -> list[Attribution]:
             "log",
             "--follow",
             f"--max-count={limit}",
-            "--format=%H%x1f%aI%x1f%an%x1f%s",
+            "--format=%H%x1f%aI%x1f%an%x1f%s%x1f%(trailers:key=Git-Session-Id,valueonly)",
             "--",
             path,
         ]
@@ -135,8 +140,18 @@ def commits_for_path(path: str, limit: int = 10) -> list[Attribution]:
     for line in out.splitlines():
         if not line:
             continue
-        sha, when, author, subject = line.split("\x1f", 3)
-        result.append(Attribution(sha=sha, when=_parse_iso(when), author=author, subject=subject))
+        parts = line.split("\x1f", 4)
+        sha, when, author, subject = parts[:4]
+        trailer_sid = parts[4].strip() if len(parts) > 4 else ""
+        result.append(
+            Attribution(
+                sha=sha,
+                when=_parse_iso(when),
+                author=author,
+                subject=subject,
+                trailer_session_id=trailer_sid or None,
+            )
+        )
     return result
 
 
@@ -144,9 +159,27 @@ def commit_for_line(path: str, line: int) -> list[Attribution]:
     """Return the single commit that last touched ``path`` line ``line``."""
     out = _run(["git", "blame", "-L", f"{line},{line}", "--porcelain", "--", path])
     sha = out.splitlines()[0].split(" ", 1)[0]
-    meta = _run(["git", "show", "-s", "--format=%aI%x1f%an%x1f%s", sha])
-    when, author, subject = meta.split("\x1f", 2)
-    return [Attribution(sha=sha, when=_parse_iso(when), author=author, subject=subject)]
+    meta = _run(
+        [
+            "git",
+            "show",
+            "-s",
+            "--format=%aI%x1f%an%x1f%s%x1f%(trailers:key=Git-Session-Id,valueonly)",
+            sha,
+        ]
+    )
+    parts = meta.split("\x1f", 3)
+    when, author, subject = parts[:3]
+    trailer_sid = parts[3].strip() if len(parts) > 3 else ""
+    return [
+        Attribution(
+            sha=sha,
+            when=_parse_iso(when),
+            author=author,
+            subject=subject,
+            trailer_session_id=trailer_sid or None,
+        )
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -337,30 +370,80 @@ def load_windows(records_path: Path) -> list[SessionWindow]:
 # ---------------------------------------------------------------------------
 
 
+def _fill_from_window(att: Attribution, w: SessionWindow) -> None:
+    """Copy session metadata from ``w`` into ``att`` in-place."""
+    att.session_id = w.session_id
+    att.category = w.category
+    att.productivity = w.productivity
+    att.journal_path = w.journal_path
+    att.model = w.model
+    att.harness = w.harness
+
+
 def attribute(att: Attribution, windows: list[SessionWindow]) -> Attribution:
-    """Attribute ``att`` to the best-matching session window in-place."""
-    best: SessionWindow | None = None
+    """Attribute ``att`` to the best-matching session window in-place.
+
+    Priority:
+    1. ``Git-Session-Id`` trailer (``att.trailer_session_id``): strongest evidence;
+       beats any window match.  When the trailer names a session not present in
+       ``windows`` the metadata fields are left None but ``session_id`` is still set.
+    2. Exact window match (distance == 0):
+       - Exactly one window → ``exact`` / ``commit-window`` (unchanged behaviour).
+       - Two or more windows → ``ambiguous`` / ``commit-window``; ``session_id``
+         is set to the closest-midpoint window; all candidates recorded in
+         ``att.candidates``.
+    3. Nearest window within ``NEAREST_TOLERANCE`` → ``near`` / ``nearest``.
+    4. No match → left as ``unmatched`` / ``unattributable``.
+    """
+    # --- Step 1: trailer-first (strongest evidence) ---------------------------
+    if att.trailer_session_id:
+        matching = next((w for w in windows if w.session_id == att.trailer_session_id), None)
+        att.method = "trailer"
+        att.confidence = "exact"
+        att.session_id = att.trailer_session_id
+        if matching:
+            _fill_from_window(att, matching)
+        return att
+
+    # --- Step 2: collect all windows that contain the commit ------------------
+    exact_windows = [w for w in windows if w.distance(att.when) == timedelta(0)]
+
+    if len(exact_windows) == 1:
+        att.confidence = "exact"
+        att.method = "commit-window"
+        _fill_from_window(att, exact_windows[0])
+        return att
+
+    if len(exact_windows) > 1:
+        # Ambiguous: pick the window whose midpoint is closest (deterministic).
+        def _midpoint_dist(w: SessionWindow) -> timedelta:
+            mid = w.start + (w.end - w.start) / 2
+            delta = att.when - mid
+            return delta if delta.total_seconds() >= 0 else -delta
+
+        best = min(exact_windows, key=_midpoint_dist)
+        att.confidence = "ambiguous"
+        att.method = "commit-window"
+        att.candidates = [w.session_id for w in exact_windows]
+        _fill_from_window(att, best)
+        return att
+
+    # --- Step 3: nearest window within tolerance ------------------------------
+    best_w: SessionWindow | None = None
     best_dist: timedelta | None = None
     for w in windows:
         d = w.distance(att.when)
         if best_dist is None or d < best_dist:
-            best, best_dist = w, d
-    if best is None or best_dist is None:
+            best_w, best_dist = w, d
+
+    if best_w is None or best_dist is None:
         return att
-    if best_dist == timedelta(0):
-        att.confidence = "exact"
-        att.method = "commit-window"
-    elif best_dist <= NEAREST_TOLERANCE:
+
+    if best_dist <= NEAREST_TOLERANCE:
         att.confidence = "near"
         att.method = "nearest"
-    else:
-        return att  # too far — leave unmatched
-    att.session_id = best.session_id
-    att.category = best.category
-    att.productivity = best.productivity
-    att.journal_path = best.journal_path
-    att.model = best.model
-    att.harness = best.harness
+        _fill_from_window(att, best_w)
+
     return att
 
 
@@ -394,14 +477,23 @@ def render_text(result: BlameResult) -> str:
         cat = a.category or "—"
         prod = f"{a.productivity:.2f}" if a.productivity is not None else "—"
         model = a.model or "—"
-        mark = {"exact": "●", "near": "○", "unmatched": "·"}[a.confidence]
+        mark = {"exact": "●", "near": "○", "ambiguous": "◐", "unmatched": "·"}.get(
+            a.confidence, "·"
+        )
         lines.append(f"  {mark} {date_str}  {a.sha[:9]}  session={sess}")
         lines.append(f"      category={cat}  model={model}  productivity={prod}  method={a.method}")
         lines.append(f"      {a.subject}")
         if a.journal_path:
             lines.append(f"      journal: {a.journal_path}")
+        if a.candidates:
+            lines.append(f"      candidates: {', '.join(a.candidates)}")
     lines.append("")
-    lines.append("  ● exact (commit-window/trajectory)  ○ nearest (≤30m)  · unattributable")
+    lines.append(
+        "  ● exact (commit-window/trajectory/trailer)"
+        "  ◐ ambiguous (multiple windows)"
+        "  ○ nearest (≤30m)"
+        "  · unattributable"
+    )
     return "\n".join(lines)
 
 
@@ -424,6 +516,7 @@ def render_json(result: BlameResult) -> str:
                     "method": a.method,
                     "model": a.model,
                     "harness": a.harness,
+                    "candidates": a.candidates,
                 }
                 for a in result.attributions
             ],

--- a/packages/gptme-sessions/src/gptme_sessions/blame.py
+++ b/packages/gptme-sessions/src/gptme_sessions/blame.py
@@ -457,6 +457,210 @@ def attribute_all(
 
 
 # ---------------------------------------------------------------------------
+# Trajectory scanning
+# ---------------------------------------------------------------------------
+
+#: Write-ish tool names in CC trajectories that author or mutate a file.
+_WRITE_TOOLS = frozenset(
+    {"Write", "Edit", "MultiEdit", "str_replace_editor", "NotebookEdit", "create"}
+)
+
+#: Max seconds for the grep prefilter per source directory.
+_GREP_TIMEOUT = 60
+
+
+@dataclass
+class TrajectoryHit:
+    """A single Write/Edit tool-call touching the target path."""
+
+    session_uuid: str
+    when: datetime | None
+    tool: str
+    file_path: str  # path as recorded in the trajectory
+    cwd: str | None
+    source: str  # path of the trajectory JSONL file
+
+
+def _parse_traj_ts(value: str | None) -> datetime | None:
+    if not value or not isinstance(value, str):
+        return None
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _traj_tool_uses(record: dict) -> list[tuple[str, dict]]:
+    """Return (tool_name, input_dict) for tool_use blocks in a CC record."""
+    msg = record.get("message")
+    if not isinstance(msg, dict):
+        return []
+    content = msg.get("content")
+    if not isinstance(content, list):
+        return []
+    out: list[tuple[str, dict]] = []
+    for block in content:
+        if not isinstance(block, dict) or block.get("type") != "tool_use":
+            continue
+        name = block.get("name")
+        inp = block.get("input")
+        if isinstance(name, str) and isinstance(inp, dict):
+            out.append((name, inp))
+    return out
+
+
+def _traj_file_paths(inp: dict) -> list[str]:
+    """Extract candidate file paths from a write-ish tool input."""
+    paths: list[str] = []
+    for key in ("file_path", "path", "notebook_path"):
+        val = inp.get(key)
+        if isinstance(val, str) and val:
+            paths.append(val)
+    return paths
+
+
+def _traj_path_matches(traj_path: str, target_rel: str, target_abs: str | None) -> bool:
+    """Return True if ``traj_path`` refers to the target file.
+
+    Matches on exact absolute path or on a ``/``-boundary suffix of the
+    repo-relative target, so worktree checkouts at different roots still match.
+    """
+    if not traj_path:
+        return False
+    norm = traj_path.rstrip("/")
+    if target_abs and norm == target_abs.rstrip("/"):
+        return True
+    rel = target_rel.strip("/")
+    return norm == rel or norm.endswith("/" + rel)
+
+
+def _traj_candidate_files(basename: str, sources: list[Path]) -> list[Path]:
+    """Return trajectory JSONL files whose content mentions ``basename``."""
+    files: list[Path] = []
+    seen: set[str] = set()
+    for src in sources:
+        if not src.exists():
+            continue
+        try:
+            proc = subprocess.run(
+                ["grep", "-rlF", "--include=*.jsonl", basename, str(src)],
+                capture_output=True,
+                text=True,
+                timeout=_GREP_TIMEOUT,
+            )
+        except (subprocess.SubprocessError, OSError):
+            continue
+        for p in proc.stdout.splitlines():
+            if p and p not in seen:
+                seen.add(p)
+                files.append(Path(p))
+    return files
+
+
+def scan_trajectories(
+    target_rel: str,
+    target_abs: str | None = None,
+    sources: list[Path] | None = None,
+    limit: int | None = None,
+) -> list[TrajectoryHit]:
+    """Find Write/Edit tool-calls that authored ``target_rel``, newest first.
+
+    ``sources`` must be supplied explicitly; ``None`` or an empty list returns
+    ``[]`` immediately — non-Bob deployments have no trajectory store, and the
+    caller chooses whether to provide one.
+    """
+    if not sources:
+        return []
+    basename = Path(target_rel).name
+    hits: list[TrajectoryHit] = []
+    for traj in _traj_candidate_files(basename, sources):
+        try:
+            with traj.open(encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        rec = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    for tool, inp in _traj_tool_uses(rec):
+                        if tool not in _WRITE_TOOLS:
+                            continue
+                        matched = [
+                            fp
+                            for fp in _traj_file_paths(inp)
+                            if _traj_path_matches(fp, target_rel, target_abs)
+                        ]
+                        if matched:
+                            hits.append(
+                                TrajectoryHit(
+                                    session_uuid=rec.get("sessionId") or traj.stem,
+                                    when=_parse_traj_ts(rec.get("timestamp")),
+                                    tool=tool,
+                                    file_path=matched[0],
+                                    cwd=rec.get("cwd"),
+                                    source=str(traj),
+                                )
+                            )
+        except OSError:
+            continue
+    _epoch = datetime.min.replace(tzinfo=timezone.utc)
+    hits.sort(key=lambda h: h.when or _epoch, reverse=True)
+    return hits[:limit] if limit else hits
+
+
+def model_for_trajectory(source: str) -> str | None:
+    """Resolve the model used by the trajectory file at ``source``."""
+    try:
+        from gptme_sessions.discovery import extract_cc_model
+    except ImportError:
+        return None
+    try:
+        model = extract_cc_model(Path(source))
+    except (OSError, ValueError):
+        return None
+    return str(model) if model else None
+
+
+def enrich_with_trajectory(
+    att: Attribution,
+    target_rel: str,
+    target_abs: str | None,
+    windows: list[SessionWindow],
+    trajectories_dirs: list[Path],
+) -> None:
+    """Back-fill ``att`` from a trajectory scan when commit-window failed.
+
+    Modifies ``att`` in-place.  On a hit sets ``method='trajectory-exact'`` and
+    ``confidence='exact'``.  On a miss leaves ``method='unattributable'``.
+    """
+    hits = scan_trajectories(target_rel, target_abs, sources=trajectories_dirs, limit=1)
+    if not hits:
+        att.method = "unattributable"
+        return
+    hit = hits[0]
+    att.method = "trajectory-exact"
+    att.confidence = "exact"
+    att.session_id = hit.session_uuid
+    att.harness = "claude-code"
+    att.model = model_for_trajectory(hit.source)
+    if hit.when is not None:
+        for w in windows:
+            if w.distance(hit.when) == timedelta(0):
+                att.category = att.category or w.category
+                att.productivity = (
+                    att.productivity if att.productivity is not None else w.productivity
+                )
+                att.journal_path = att.journal_path or w.journal_path
+                att.model = att.model or w.model
+                break
+
+
+# ---------------------------------------------------------------------------
 # Output rendering
 # ---------------------------------------------------------------------------
 
@@ -539,6 +743,7 @@ def blame(
     line: int | None = None,
     limit: int = 10,
     records: Path | None = None,
+    trajectories_dirs: list[Path] | None = None,
 ) -> BlameResult:
     """Attribute a file path or GitHub ref to its authoring session(s).
 
@@ -548,6 +753,11 @@ def blame(
         limit: Max commits for whole-file mode.
         records: Path to session-records JSONL; defaults to ``DEFAULT_RECORDS``
             resolved against the current git root when inside a repo.
+        trajectories_dirs: Directories containing CC trajectory JSONL files.
+            When provided, trajectory-exact attribution is attempted for commits
+            that remain ``unattributable`` or ``ambiguous`` after commit-window
+            matching.  ``None`` (default) skips trajectory scan — backward
+            compatible with deployments that have no trajectory store.
 
     Returns:
         A :class:`BlameResult` with attributions populated.
@@ -588,4 +798,13 @@ def blame(
         attributions = commits_for_path(rel_path, limit)
 
     attribute_all(attributions, windows)
+
+    if trajectories_dirs is not None:
+        abs_path_str = str(abs_path)
+        for a in attributions:
+            if a.method == "unattributable" or (
+                a.method == "commit-window" and a.confidence == "ambiguous"
+            ):
+                enrich_with_trajectory(a, rel_path, abs_path_str, windows, trajectories_dirs)
+
     return BlameResult(path=rel_path, line=line, attributions=attributions)

--- a/packages/gptme-sessions/src/gptme_sessions/blame.py
+++ b/packages/gptme-sessions/src/gptme_sessions/blame.py
@@ -131,18 +131,22 @@ def commits_for_path(path: str, limit: int = 10) -> list[Attribution]:
             "log",
             "--follow",
             f"--max-count={limit}",
-            "--format=%H%x1f%aI%x1f%an%x1f%s%x1f%(trailers:key=Git-Session-Id,valueonly)",
+            "--format=%H%x1f%aI%x1f%an%x1f%s%x1f%(trailers:key=Git-Session-Id,valueonly,separator=%x1e)",
             "--",
             path,
         ]
     )
     result: list[Attribution] = []
-    for line in out.splitlines():
+    # Use split('\n') not splitlines(): Python's splitlines() treats \x1e (ASCII
+    # Record Separator) as a line boundary, which would corrupt records when \x1e
+    # is used as the within-field separator for multiple trailer values.
+    for line in out.split("\n"):
         if not line:
             continue
         parts = line.split("\x1f", 4)
         sha, when, author, subject = parts[:4]
-        trailer_sid = parts[4].strip() if len(parts) > 4 else ""
+        # Multiple trailers are joined by \x1e; take only the first value.
+        trailer_sid = parts[4].split("\x1e")[0].strip() if len(parts) > 4 else ""
         result.append(
             Attribution(
                 sha=sha,
@@ -164,13 +168,14 @@ def commit_for_line(path: str, line: int) -> list[Attribution]:
             "git",
             "show",
             "-s",
-            "--format=%aI%x1f%an%x1f%s%x1f%(trailers:key=Git-Session-Id,valueonly)",
+            "--format=%aI%x1f%an%x1f%s%x1f%(trailers:key=Git-Session-Id,valueonly,separator=%x1e)",
             sha,
         ]
     )
     parts = meta.split("\x1f", 3)
     when, author, subject = parts[:3]
-    trailer_sid = parts[3].strip() if len(parts) > 3 else ""
+    # Multiple trailers are joined by \x1e; take only the first value.
+    trailer_sid = parts[3].split("\x1e")[0].strip() if len(parts) > 3 else ""
     return [
         Attribution(
             sha=sha,

--- a/packages/gptme-sessions/tests/test_blame.py
+++ b/packages/gptme-sessions/tests/test_blame.py
@@ -15,13 +15,16 @@ from gptme_sessions.blame import (
     Attribution,
     BlameResult,
     SessionWindow,
+    _traj_path_matches,
     attribute,
     attribute_all,
     commits_for_github_ref,
     consolidated_records_sources,
+    enrich_with_trajectory,
     load_windows,
     render_json,
     render_text,
+    scan_trajectories,
 )
 
 
@@ -554,3 +557,157 @@ def test_render_json_candidates_empty_for_exact():
     data = json.loads(render_json(result))
     att = data["attributions"][0]
     assert att["candidates"] == []
+
+
+# ---------------------------------------------------------------------------
+# Trajectory scanning
+# ---------------------------------------------------------------------------
+
+
+def _make_traj_record(
+    session_id: str,
+    tool: str,
+    file_path: str,
+    timestamp: str = "2026-06-01T10:05:00Z",
+    cwd: str | None = "/home/bob/bob",
+) -> str:
+    """Emit a single JSONL line mimicking a CC trajectory Write/Edit record."""
+    return json.dumps(
+        {
+            "sessionId": session_id,
+            "timestamp": timestamp,
+            "cwd": cwd,
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "name": tool,
+                        "input": {"file_path": file_path},
+                    }
+                ]
+            },
+        }
+    )
+
+
+def _traj_dir(tmp_path: Path, records: list[str], filename: str = "traj.jsonl") -> Path:
+    """Write trajectory records into a temporary directory."""
+    d = tmp_path / "trajectories"
+    d.mkdir(exist_ok=True)
+    (d / filename).write_text("\n".join(records) + "\n")
+    return d
+
+
+def test_traj_path_matches_absolute():
+    assert _traj_path_matches("/home/bob/bob/foo.py", "foo.py", "/home/bob/bob/foo.py")
+
+
+def test_traj_path_matches_suffix():
+    assert _traj_path_matches("/tmp/worktree/foo.py", "foo.py", None)
+
+
+def test_traj_path_matches_relative():
+    assert _traj_path_matches("foo.py", "foo.py", None)
+
+
+def test_traj_path_matches_no_partial():
+    assert not _traj_path_matches("/home/bob/bob/notfoo.py", "foo.py", None)
+
+
+def test_scan_trajectories_empty_sources():
+    hits = scan_trajectories("foo.py", sources=[])
+    assert hits == []
+
+
+def test_scan_trajectories_none_sources():
+    hits = scan_trajectories("foo.py", sources=None)
+    assert hits == []
+
+
+def test_scan_trajectories_finds_write(tmp_path: Path):
+    src_dir = _traj_dir(
+        tmp_path,
+        [_make_traj_record("sess-traj-1", "Write", "/home/bob/bob/foo.py")],
+    )
+    hits = scan_trajectories("foo.py", target_abs="/home/bob/bob/foo.py", sources=[src_dir])
+    assert len(hits) == 1
+    assert hits[0].session_uuid == "sess-traj-1"
+    assert hits[0].tool == "Write"
+
+
+def test_scan_trajectories_finds_edit(tmp_path: Path):
+    src_dir = _traj_dir(
+        tmp_path,
+        [_make_traj_record("sess-edit", "Edit", "/home/bob/bob/bar.py")],
+    )
+    hits = scan_trajectories("bar.py", sources=[src_dir])
+    assert len(hits) == 1
+    assert hits[0].tool == "Edit"
+
+
+def test_scan_trajectories_ignores_read_tools(tmp_path: Path):
+    record = json.dumps(
+        {
+            "sessionId": "sess-read",
+            "timestamp": "2026-06-01T10:00:00Z",
+            "message": {
+                "content": [{"type": "tool_use", "name": "Read", "input": {"file_path": "foo.py"}}]
+            },
+        }
+    )
+    src_dir = _traj_dir(tmp_path, [record])
+    hits = scan_trajectories("foo.py", sources=[src_dir])
+    assert hits == []
+
+
+def test_scan_trajectories_limit(tmp_path: Path):
+    records = [
+        _make_traj_record("sess-a", "Write", "/home/bob/bob/foo.py", "2026-06-01T10:00:00Z"),
+        _make_traj_record("sess-b", "Edit", "/home/bob/bob/foo.py", "2026-06-01T11:00:00Z"),
+    ]
+    src_dir = _traj_dir(tmp_path, records)
+    hits = scan_trajectories("foo.py", sources=[src_dir], limit=1)
+    assert len(hits) == 1
+    # newest first
+    assert hits[0].session_uuid == "sess-b"
+
+
+def test_enrich_with_trajectory_sets_exact(tmp_path: Path):
+    src_dir = _traj_dir(
+        tmp_path,
+        [_make_traj_record("sess-traj", "Write", "/home/bob/bob/foo.py", "2026-06-01T10:05:00Z")],
+    )
+    att = Attribution(sha="abc", when=_dt("2026-06-01T08:00:00+00:00"), author="Bob", subject="x")
+    assert att.method == "unattributable"
+    enrich_with_trajectory(att, "foo.py", "/home/bob/bob/foo.py", [], [src_dir])
+    assert att.confidence == "exact"
+    assert att.method == "trajectory-exact"
+    assert att.session_id == "sess-traj"
+    assert att.harness == "claude-code"
+
+
+def test_enrich_with_trajectory_miss_leaves_unattributable(tmp_path: Path):
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+    att = Attribution(sha="abc", when=_dt("2026-06-01T08:00:00+00:00"), author="Bob", subject="x")
+    enrich_with_trajectory(att, "foo.py", None, [], [empty_dir])
+    assert att.method == "unattributable"
+    assert att.confidence == "unmatched"
+
+
+def test_enrich_with_trajectory_backfills_window_metadata(tmp_path: Path):
+    src_dir = _traj_dir(
+        tmp_path,
+        [_make_traj_record("sess-traj", "Write", "/home/bob/bob/foo.py", "2026-06-01T10:05:00Z")],
+    )
+    window = _window(
+        session_id="sess-traj",
+        start="2026-06-01T10:00:00+00:00",
+        end="2026-06-01T10:30:00+00:00",
+        category="code",
+        productivity=0.9,
+    )
+    att = Attribution(sha="abc", when=_dt("2026-06-01T08:00:00+00:00"), author="Bob", subject="x")
+    enrich_with_trajectory(att, "foo.py", "/home/bob/bob/foo.py", [window], [src_dir])
+    assert att.category == "code"
+    assert att.productivity == 0.9

--- a/packages/gptme-sessions/tests/test_blame.py
+++ b/packages/gptme-sessions/tests/test_blame.py
@@ -375,3 +375,182 @@ def test_render_json_round_trip():
     assert att["sha"] == "abc123"
     assert att["session_id"] == "sess-1"
     assert att["confidence"] == "exact"
+
+
+# ---------------------------------------------------------------------------
+# Trailer-first attribution
+# ---------------------------------------------------------------------------
+
+
+def test_attribute_trailer_wins_over_window():
+    """Git-Session-Id trailer beats any window match."""
+    w = _window(session_id="window-sess")
+    a = _att("2026-06-01T10:15:00+00:00")  # inside window-sess window
+    a.trailer_session_id = "trailer-sess"
+    attribute(a, [w])
+    assert a.session_id == "trailer-sess"
+    assert a.method == "trailer"
+    assert a.confidence == "exact"
+    # Window metadata should not bleed through when trailer names unknown session
+    assert a.category is None
+    assert a.model is None
+
+
+def test_attribute_trailer_fills_metadata_when_window_known():
+    """Trailer naming a loaded window still fills category/model etc."""
+    w = _window(session_id="known-sess")
+    a = _att("2026-06-01T08:00:00+00:00")  # far outside window
+    a.trailer_session_id = "known-sess"
+    attribute(a, [w])
+    assert a.session_id == "known-sess"
+    assert a.method == "trailer"
+    assert a.confidence == "exact"
+    assert a.category == "code"
+    assert a.model == "claude-sonnet-4-6"
+
+
+def test_attribute_trailer_no_window():
+    """Trailer naming an unknown session still wins; metadata fields are None."""
+    a = _att("2026-06-01T08:00:00+00:00")
+    a.trailer_session_id = "orphan-sess"
+    attribute(a, [])
+    assert a.session_id == "orphan-sess"
+    assert a.method == "trailer"
+    assert a.confidence == "exact"
+    assert a.category is None
+
+
+# ---------------------------------------------------------------------------
+# Ambiguity detection
+# ---------------------------------------------------------------------------
+
+
+def test_attribute_single_window_exact_unchanged():
+    """Single window containing the commit: unchanged exact/commit-window behaviour."""
+    windows = [_window()]
+    a = _att("2026-06-01T10:15:00+00:00")
+    attribute(a, windows)
+    assert a.confidence == "exact"
+    assert a.method == "commit-window"
+    assert a.session_id == "sess-abc"
+    assert a.candidates == []
+
+
+def test_attribute_overlapping_windows_ambiguous():
+    """Two windows both containing the commit → ambiguous."""
+    w1 = _window(
+        session_id="sess-1",
+        start="2026-06-01T10:00:00+00:00",
+        end="2026-06-01T11:00:00+00:00",
+    )
+    w2 = _window(
+        session_id="sess-2",
+        start="2026-06-01T10:30:00+00:00",
+        end="2026-06-01T11:30:00+00:00",
+    )
+    a = _att("2026-06-01T10:45:00+00:00")  # inside both windows
+    attribute(a, [w1, w2])
+    assert a.confidence == "ambiguous"
+    assert a.method == "commit-window"
+    assert a.session_id in ("sess-1", "sess-2")
+    assert set(a.candidates) == {"sess-1", "sess-2"}
+
+
+def test_attribute_overlapping_deterministic_by_midpoint():
+    """Among overlapping windows, closest midpoint wins deterministically."""
+    # sess-1: 10:00-11:00 → midpoint 10:30
+    # sess-2: 10:30-11:30 → midpoint 11:00
+    # commit at 10:40 → distance to sess-1 midpoint = 10m, to sess-2 midpoint = 20m
+    w1 = _window(
+        session_id="sess-1",
+        start="2026-06-01T10:00:00+00:00",
+        end="2026-06-01T11:00:00+00:00",
+    )
+    w2 = _window(
+        session_id="sess-2",
+        start="2026-06-01T10:30:00+00:00",
+        end="2026-06-01T11:30:00+00:00",
+    )
+    a = _att("2026-06-01T10:40:00+00:00")  # inside both windows
+    attribute(a, [w1, w2])
+    assert a.confidence == "ambiguous"
+    assert a.session_id == "sess-1"  # midpoint at 10:30, 10m closer than sess-2's 11:00
+
+
+def test_attribute_ambiguous_candidates_all_sessions():
+    """All overlapping session_ids appear in candidates."""
+    w1 = _window(
+        session_id="s1", start="2026-06-01T10:00:00+00:00", end="2026-06-01T12:00:00+00:00"
+    )
+    w2 = _window(
+        session_id="s2", start="2026-06-01T10:30:00+00:00", end="2026-06-01T11:30:00+00:00"
+    )
+    w3 = _window(
+        session_id="s3", start="2026-06-01T11:00:00+00:00", end="2026-06-01T13:00:00+00:00"
+    )
+    a = _att("2026-06-01T11:15:00+00:00")  # inside all three
+    attribute(a, [w1, w2, w3])
+    assert a.confidence == "ambiguous"
+    assert set(a.candidates) == {"s1", "s2", "s3"}
+
+
+# ---------------------------------------------------------------------------
+# render_text: ambiguous mark
+# ---------------------------------------------------------------------------
+
+
+def test_render_text_ambiguous_mark():
+    a = Attribution(
+        sha="abc123def456789",
+        when=_dt("2026-06-01T10:00:00+00:00"),
+        author="Bob",
+        subject="fix: ambiguous",
+        session_id="sess-1",
+        confidence="ambiguous",
+        method="commit-window",
+        candidates=["sess-1", "sess-2"],
+    )
+    result = BlameResult(path="scripts/foo.py", line=None, attributions=[a])
+    out = render_text(result)
+    assert "◐" in out
+    assert "sess-1" in out
+    assert "candidates" in out
+
+
+# ---------------------------------------------------------------------------
+# render_json: candidates field
+# ---------------------------------------------------------------------------
+
+
+def test_render_json_candidates_field():
+    a = Attribution(
+        sha="abc123",
+        when=_dt("2026-06-01T10:00:00+00:00"),
+        author="Bob",
+        subject="fix: x",
+        session_id="sess-1",
+        confidence="ambiguous",
+        method="commit-window",
+        candidates=["sess-1", "sess-2"],
+    )
+    result = BlameResult(path="foo.py", line=None, attributions=[a])
+    data = json.loads(render_json(result))
+    att = data["attributions"][0]
+    assert att["confidence"] == "ambiguous"
+    assert set(att["candidates"]) == {"sess-1", "sess-2"}
+
+
+def test_render_json_candidates_empty_for_exact():
+    a = Attribution(
+        sha="abc123",
+        when=_dt("2026-06-01T10:00:00+00:00"),
+        author="Bob",
+        subject="fix: x",
+        session_id="sess-1",
+        confidence="exact",
+        method="commit-window",
+    )
+    result = BlameResult(path="foo.py", line=None, attributions=[a])
+    data = json.loads(render_json(result))
+    att = data["attributions"][0]
+    assert att["candidates"] == []

--- a/packages/gptme-sessions/tests/test_blame.py
+++ b/packages/gptme-sessions/tests/test_blame.py
@@ -18,7 +18,9 @@ from gptme_sessions.blame import (
     _traj_path_matches,
     attribute,
     attribute_all,
+    commit_for_line,
     commits_for_github_ref,
+    commits_for_path,
     consolidated_records_sources,
     enrich_with_trajectory,
     load_windows,
@@ -326,6 +328,82 @@ def test_commits_for_github_ref_gh_unavailable(monkeypatch, capsys):
     assert atts == []
     captured = capsys.readouterr()
     assert "warning" in captured.err.lower()
+
+
+# ---------------------------------------------------------------------------
+# commits_for_path / commit_for_line — duplicate trailer safety
+# ---------------------------------------------------------------------------
+
+
+def _fake_run_git_log(stdout: str):
+    """Return a monkeypatch-compatible callable that fakes subprocess.run output."""
+
+    def _fake(args, **kwargs):
+        result = MagicMock()
+        result.stdout = stdout
+        result.returncode = 0
+        return result
+
+    return _fake
+
+
+def test_commits_for_path_single_trailer(monkeypatch):
+    """Normal single-trailer commit is parsed correctly."""
+    sha = "abc123def456"
+    line = f"{sha}\x1f2026-06-01T10:00:00+00:00\x1fBob\x1ffix: something\x1fsess-abc"
+    monkeypatch.setattr(subprocess, "run", _fake_run_git_log(line))
+    atts = commits_for_path("scripts/foo.py")
+    assert len(atts) == 1
+    assert atts[0].sha == sha
+    assert atts[0].trailer_session_id == "sess-abc"
+
+
+def test_commits_for_path_duplicate_trailers(monkeypatch):
+    """A commit with two Git-Session-Id trailers (separator=\\x1e) picks the first value."""
+    sha = "abc123def456"
+    # git emits multiple trailer values joined by \x1e (our separator= spec)
+    trailer_field = "sess-first\x1esess-second"
+    line = f"{sha}\x1f2026-06-01T10:00:00+00:00\x1fBob\x1ffix: something\x1f{trailer_field}"
+    monkeypatch.setattr(subprocess, "run", _fake_run_git_log(line))
+    atts = commits_for_path("scripts/foo.py")
+    assert len(atts) == 1
+    assert atts[0].trailer_session_id == "sess-first"
+
+
+def test_commits_for_path_no_trailer(monkeypatch):
+    """A commit without a Git-Session-Id trailer sets trailer_session_id to None."""
+    sha = "abc123def456"
+    line = f"{sha}\x1f2026-06-01T10:00:00+00:00\x1fBob\x1ffix: something\x1f"
+    monkeypatch.setattr(subprocess, "run", _fake_run_git_log(line))
+    atts = commits_for_path("scripts/foo.py")
+    assert len(atts) == 1
+    assert atts[0].trailer_session_id is None
+
+
+def test_commit_for_line_duplicate_trailers(monkeypatch):
+    """commit_for_line picks the first Git-Session-Id when duplicates appear."""
+    sha = "abc123def456"
+
+    call_count = 0
+
+    def _fake(args, **kwargs):
+        nonlocal call_count
+        result = MagicMock()
+        call_count += 1
+        if call_count == 1:
+            # git blame --porcelain output: first line is "<sha> ..."
+            result.stdout = f"{sha} 1 1 1\nauthor Bob"
+        else:
+            # git show output: \x1f-delimited, trailer field has two values joined by \x1e
+            result.stdout = (
+                "2026-06-01T10:00:00+00:00\x1fBob\x1ffix: something\x1fsess-first\x1esess-second"
+            )
+        return result
+
+    monkeypatch.setattr(subprocess, "run", _fake)
+    atts = commit_for_line("scripts/foo.py", 42)
+    assert len(atts) == 1
+    assert atts[0].trailer_session_id == "sess-first"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Trailer-first**: When a commit carries a `Git-Session-Id` trailer, that session wins unconditionally over any window match (`method='trailer'`, `confidence='exact'`). A trailer naming an unknown session still wins; metadata fields are left None.
- **Ambiguity detection**: When multiple session windows all contain the commit's author-date, `confidence='ambiguous'` is set (was silently picking the first window). The deterministic pick uses the closest window midpoint. All candidate session IDs are recorded in a new `Attribution.candidates` field.
- **Rendering**: `render_text` uses `◐` for ambiguous entries and lists candidates; `render_json` always includes the `candidates` field.
- **15 new tests**, 34/34 passing.

## What stays unchanged

- Single-window exact matches: `exact`/`commit-window` (unchanged behaviour).
- Nearest-window fallback within 30m: `near`/`nearest` (unchanged).
- Unmatched: `unmatched`/`unattributable` (unchanged).

## Context

`sessions-blame` and `harm-attribute.py` write `culprit_session`/model/harness into `state/harm-incidents.jsonl`. The old code presented arbitrary fanout-window picks as `confidence="exact"` — this PR makes the actual evidence quality visible.

Callers that trigger trajectory enrichment (`sessions-blame.py`, `harm-attribute.py`) will also need to run enrichment on `confidence=="ambiguous"` — that's a brain-repo follow-up patch in the same session.

Audit: `knowledge/technical-designs/commit-window-attribution-audit.md` (session e844).

## Test plan

- [ ] `uv run pytest packages/gptme-sessions/tests/test_blame.py -v` passes (34/34)
- [ ] Trailer-wins, ambiguous-detected, and candidates-field tests all pass
- [ ] Existing exact/near/unmatched tests unchanged and green