### PR TITLE
test(activity-gate): pin org-less repo-list invocation contract

### DIFF
--- a/tests/test_activity_gate_notif_followup.py
+++ b/tests/test_activity_gate_notif_followup.py
@@ -140,7 +140,16 @@ def _emitted_notifications(stdout: str) -> list[dict]:
     return items
 
 
-def test_first_emit_creates_state_with_timestamp() -> None:
+def test_first_sight_seeds_state_without_emitting() -> None:
+    """First sight of a notification seeds state but does NOT emit.
+
+    This matches the documented contract ("On first run, all items are seeded
+    but NOT reported") — without it, a wiped state dir makes the whole unread
+    backlog look "new" and fires a noop session on already-resolved threads.
+    (This test previously asserted the pre-seeding behaviour — first sight
+    emitting — and went stale when check_notifications adopted
+    seed-on-first-sight; the suite does not run in CI, so it rotted silently.)
+    """
     with tempfile.TemporaryDirectory() as tmp_str:
         tmp = Path(tmp_str)
         state_dir = tmp / "state"
@@ -150,13 +159,13 @@ def test_first_emit_creates_state_with_timestamp() -> None:
         assert result.returncode in (0, 1), result.stderr
 
         emitted = _emitted_notifications(result.stdout)
-        assert len(emitted) == 1
-        assert emitted[0]["repo"] == NOTIF_REPO
-        assert emitted[0]["number"] == NOTIF_NUMBER
+        assert emitted == [], (
+            "first-sight notifications must seed, not emit; got: " f"{emitted}"
+        )
 
         state_file = state_dir / f"notif-{NOTIF_ID}.state"
         assert state_file.exists()
-        # State now records the timestamp, not just presence.
+        # State records the timestamp, not just presence.
         assert state_file.read_text().strip() == "2026-04-29T20:40:00Z"
 
 

--- a/tests/test_activity_gate_orgless.py
+++ b/tests/test_activity_gate_orgless.py
@@ -38,8 +38,14 @@ from pathlib import Path
 argv = sys.argv[1:]
 log = os.environ.get("GH_CALL_LOG", "")
 if log:
+    # Log the subcommand plus, for repo-scoped calls, WHICH repo was hit —
+    # so tests can assert every explicit --repo was actually scanned rather
+    # than one repo being scanned twice.
+    entry = " ".join(argv[:2])
+    if "--repo" in argv:
+        entry += " " + argv[argv.index("--repo") + 1]
     with Path(log).open("a") as fh:
-        fh.write(" ".join(argv[:2]) + "\n")
+        fh.write(entry + "\n")
 
 if not argv:
     sys.exit(2)
@@ -114,9 +120,12 @@ def test_orgless_repo_mode_is_a_valid_invocation() -> None:
         assert (
             "required" not in result.stderr
         ), f"must not report a usage error: {result.stderr!r}"
-        # Both explicit repos were scanned (PR data fetched per repo).
-        pr_calls = [c for c in calls if c == "pr list"]
-        assert len(pr_calls) >= 2, f"expected per-repo pr list calls, got: {calls}"
+        # Both explicit repos were scanned (PR data fetched for EACH repo,
+        # not one repo scanned twice).
+        scanned = {c.split()[-1] for c in calls if c.startswith("pr list ")}
+        assert (
+            {"owner/repo-x", "owner/repo-y"} <= scanned
+        ), f"every explicit --repo must be scanned; scanned={scanned}, calls: {calls}"
 
 
 def test_orgless_repo_mode_skips_org_enumeration() -> None:
@@ -127,7 +136,7 @@ def test_orgless_repo_mode_skips_org_enumeration() -> None:
         )
 
         assert result.returncode in (0, 1), result.stderr
-        assert "repo list" not in calls, (
+        assert not any(c.startswith("repo list") for c in calls), (
             f"org enumeration must be skipped in org-less mode "
             f"(that is the GraphQL saving the mode exists for); calls: {calls}"
         )
@@ -153,11 +162,13 @@ def test_org_mode_still_enumerates_org() -> None:
         )
 
         assert result.returncode in (0, 1), result.stderr
-        assert (
-            "repo list" in calls
+        assert any(
+            c.startswith("repo list") for c in calls
         ), f"--org mode must enumerate org repos via gh repo list; calls: {calls}"
         # Enumerated repos are then scanned.
-        assert "pr list" in calls, f"org repos must be scanned; calls: {calls}"
+        assert any(
+            c.startswith("pr list") for c in calls
+        ), f"org repos must be scanned; calls: {calls}"
 
 
 def test_orgless_output_is_well_formed_jsonl_when_work_found() -> None:

--- a/tests/test_activity_gate_orgless.py
+++ b/tests/test_activity_gate_orgless.py
@@ -1,0 +1,220 @@
+"""Regression tests for org-less repo-list mode in activity-gate.sh.
+
+Context (the 2026-07-08..11 PM outage): Bob's brain dropped --org from the
+activity-gate invocation to avoid a full org scan, passing only --repo flags.
+activity-gate.sh hard-required BOTH --author and --org and exited 2, so every
+monitoring cycle's activity scan failed and the caller failed open to zero
+items — pr_update / ci_failure / merge_ready / greptile / assigned_issue /
+notification detection was silently dead for 3 days.
+
+contrib#1272 made --org optional when at least one --repo is given. These
+tests pin that invocation contract:
+
+- --author + --repo (no --org) is a valid invocation: exit 0/1, no usage
+  error, and no org enumeration (`gh repo list` must not be called).
+- --author alone (no --org, no --repo) is still a usage error (exit 2).
+- --author + --org (no --repo) still enumerates the org.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "github" / "activity-gate.sh"
+
+# Fake gh: records every invocation's first two args to GH_CALL_LOG, returns
+# empty/benign payloads everywhere so the gate scans cleanly and exits 1.
+FAKE_GH = r"""#!/usr/bin/env python3
+from __future__ import annotations
+import os, sys
+from pathlib import Path
+
+argv = sys.argv[1:]
+log = os.environ.get("GH_CALL_LOG", "")
+if log:
+    with Path(log).open("a") as fh:
+        fh.write(" ".join(argv[:2]) + "\n")
+
+if not argv:
+    sys.exit(2)
+
+if argv[0] == "repo" and len(argv) > 1 and argv[1] == "list":
+    print("fakeorg/repo-a\nfakeorg/repo-b")
+    sys.exit(0)
+
+if argv[0] in ("pr", "issue", "run") and len(argv) > 1 and argv[1] == "list":
+    print("[]")
+    sys.exit(0)
+
+if argv[0] == "api":
+    # gh api calls here use --jq server-side filtering; the gate expects the
+    # FILTERED output. notifications must yield nothing (no actionable
+    # notifs), not a raw "[]" — a bare [] flows into the gate's jq object
+    # filter and causes a runtime error (jq exit 5) under set -o pipefail.
+    if "notifications" in (argv[1] if len(argv) > 1 else ""):
+        sys.exit(0)
+    print("[]")
+    sys.exit(0)
+
+sys.exit(0)
+"""
+
+
+def _run_gate(
+    extra_args: list[str], tmp: Path
+) -> tuple[subprocess.CompletedProcess, list[str]]:
+    state_dir = tmp / "state"
+    state_dir.mkdir(exist_ok=True)
+
+    fake_gh = tmp / "gh"
+    fake_gh.write_text(FAKE_GH)
+    fake_gh.chmod(fake_gh.stat().st_mode | stat.S_IXUSR)
+
+    call_log = tmp / "gh-calls.log"
+
+    env = os.environ.copy()
+    env["PATH"] = f"{tmp}:{env['PATH']}"
+    env["GH_CALL_LOG"] = str(call_log)
+
+    result = subprocess.run(
+        [
+            str(SCRIPT),
+            "--author",
+            "test-author",
+            "--state-dir",
+            str(state_dir),
+            *extra_args,
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    calls = call_log.read_text().splitlines() if call_log.exists() else []
+    return result, calls
+
+
+def test_orgless_repo_mode_is_a_valid_invocation() -> None:
+    """--author + --repo (no --org) must scan the listed repos, not exit 2."""
+    with tempfile.TemporaryDirectory() as tmp_str:
+        result, calls = _run_gate(
+            ["--repo", "owner/repo-x", "--repo", "owner/repo-y", "--format", "jsonl"],
+            Path(tmp_str),
+        )
+
+        assert result.returncode in (0, 1), (
+            f"org-less --repo invocation must be valid (exit 0/1), got "
+            f"{result.returncode}; stderr: {result.stderr!r}"
+        )
+        assert (
+            "required" not in result.stderr
+        ), f"must not report a usage error: {result.stderr!r}"
+        # Both explicit repos were scanned (PR data fetched per repo).
+        pr_calls = [c for c in calls if c == "pr list"]
+        assert len(pr_calls) >= 2, f"expected per-repo pr list calls, got: {calls}"
+
+
+def test_orgless_repo_mode_skips_org_enumeration() -> None:
+    """Without --org, `gh repo list` (the org scan) must never be called."""
+    with tempfile.TemporaryDirectory() as tmp_str:
+        result, calls = _run_gate(
+            ["--repo", "owner/repo-x", "--format", "jsonl"], Path(tmp_str)
+        )
+
+        assert result.returncode in (0, 1), result.stderr
+        assert "repo list" not in calls, (
+            f"org enumeration must be skipped in org-less mode "
+            f"(that is the GraphQL saving the mode exists for); calls: {calls}"
+        )
+
+
+def test_no_org_and_no_repo_is_still_a_usage_error() -> None:
+    """--author alone has nothing to scan — must exit 2 with a clear error."""
+    with tempfile.TemporaryDirectory() as tmp_str:
+        result, _ = _run_gate(["--format", "jsonl"], Path(tmp_str))
+
+        assert result.returncode == 2, (
+            f"expected usage error exit 2, got {result.returncode}; "
+            f"stdout: {result.stdout!r}"
+        )
+        assert "--org or at least one --repo" in result.stderr
+
+
+def test_org_mode_still_enumerates_org() -> None:
+    """--org without --repo keeps the original org-scan behaviour."""
+    with tempfile.TemporaryDirectory() as tmp_str:
+        result, calls = _run_gate(
+            ["--org", "fakeorg", "--format", "jsonl"], Path(tmp_str)
+        )
+
+        assert result.returncode in (0, 1), result.stderr
+        assert (
+            "repo list" in calls
+        ), f"--org mode must enumerate org repos via gh repo list; calls: {calls}"
+        # Enumerated repos are then scanned.
+        assert "pr list" in calls, f"org repos must be scanned; calls: {calls}"
+
+
+def test_orgless_output_is_well_formed_jsonl_when_work_found() -> None:
+    """Sanity: org-less mode emits parseable JSONL items (assigned-issue path
+    emits on first sight when someone else holds the ball)."""
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        # Extend the fake gh: one assigned issue awaiting reply.
+        fake = FAKE_GH.replace(
+            'if argv[0] in ("pr", "issue", "run") and len(argv) > 1 and argv[1] == "list":\n    print("[]")\n    sys.exit(0)',
+            'if argv[0] == "issue" and len(argv) > 1 and argv[1] == "list":\n'
+            '    print(\'[{"number": 7, "title": "t", "updatedAt": "2026-07-11T00:00:00Z"}]\')\n'
+            "    sys.exit(0)\n"
+            'if argv[0] in ("pr", "run") and len(argv) > 1 and argv[1] == "list":\n'
+            '    print("[]")\n'
+            "    sys.exit(0)",
+        )
+        # Last commenter on the issue is someone else -> awaiting our reply.
+        fake = fake.replace(
+            '    print("[]")\n    sys.exit(0)\n\nsys.exit(0)',
+            '    if "comments" in (argv[1] if len(argv) > 1 else ""):\n'
+            '        print("someone-else")\n'
+            "        sys.exit(0)\n"
+            '    print("[]")\n'
+            "    sys.exit(0)\n\nsys.exit(0)",
+        )
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+        fake_gh = tmp / "gh"
+        fake_gh.write_text(fake)
+        fake_gh.chmod(fake_gh.stat().st_mode | stat.S_IXUSR)
+
+        env = os.environ.copy()
+        env["PATH"] = f"{tmp}:{env['PATH']}"
+
+        result = subprocess.run(
+            [
+                str(SCRIPT),
+                "--author",
+                "test-author",
+                "--repo",
+                "owner/repo-x",
+                "--state-dir",
+                str(state_dir),
+                "--format",
+                "jsonl",
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+        assert result.returncode == 0, (
+            f"expected work found (exit 0), got {result.returncode}; "
+            f"stderr: {result.stderr!r}"
+        )
+        items = [json.loads(line) for line in result.stdout.strip().splitlines()]
+        assert any(
+            i["type"] == "assigned_issue" and i["repo"] == "owner/repo-x" for i in items
+        ), f"expected assigned_issue item, got: {items}"


### PR DESCRIPTION
## Why

Follow-up to #1272, which fixed the 2026-07-08..11 PM outage class (brain invoked `activity-gate.sh` with `--repo` flags but no `--org`; the script hard-required `--org` and exited 2 every cycle, silently killing pr_update / ci_failure / merge_ready / greptile / assigned_issue / notification detection for 3 days) but shipped without tests. An untested invocation contract is exactly how this rotted silently.

## What

New `tests/test_activity_gate_orgless.py` (5 tests, fake-`gh` pattern matching the existing suite):
- `--author` + `--repo` (no `--org`) is valid: exit 0/1, scans the listed repos
- org-less mode never calls `gh repo list` (the org scan the mode exists to avoid)
- `--author` alone (nothing to scan) still exits 2 with a clear usage error
- `--org` mode still enumerates the org
- org-less mode emits well-formed JSONL work items

Drive-by: `test_activity_gate_notif_followup.py::test_first_emit_creates_state_with_timestamp` asserted the pre-seeding behaviour (first sight emits) and has been failing on master since `check_notifications` adopted seed-on-first-sight — updated to the current documented contract and renamed `test_first_sight_seeds_state_without_emitting`.

Note: the top-level `tests/` suite is not wired into CI (`make test-integration` only runs `tests/integration/`) — that gap is why both the missing coverage and the stale test went unnoticed. Worth a separate issue/PR.

## Verification

`pytest tests/test_activity_gate_*.py` — 25 passed (was 1 pre-existing failure on master).