### PR TITLE
feat(pm): human-review dispatch priority — lane ordering + bounded cap overflow

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -884,6 +884,77 @@ class DispatchResult:
     fallback_items: list[SlotItem] = field(default_factory=list)
 
 
+# --- Human-review dispatch priority (§7b human > bot) ---
+#
+# Erik's CHANGES_REQUESTED review on gptme/gptme#3178 (2026-07-11) was emitted
+# by the gate every cycle but skipped_cap twice while all slots drained a
+# 3-day bot-priority backlog. The §7b "human > bot" invariant was only
+# enforced in suppression logic (cooldown bypass), not in dispatch ordering or
+# capacity. These tokens are emitted by activity-gate.sh into the item
+# ``detail`` field (they survive build_grouped_jsonl's ``join("; ")`` the same
+# way the ``mention`` reason token does) and consumed here for lane ordering
+# and by the bash dispatcher for the bounded cap-overflow rule.
+
+# A human's latest review on the PR is CHANGES_REQUESTED — blocking merge.
+HUMAN_PRIORITY_CHANGES_REQUESTED = "human_changes_requested"
+# The most recent comment/review actor on the PR is a human (non-bot, non-self).
+HUMAN_PRIORITY_ACTIVITY = "human_activity"
+
+_HUMAN_PRIORITY_RANKS = {
+    HUMAN_PRIORITY_CHANGES_REQUESTED: 0,
+    HUMAN_PRIORITY_ACTIVITY: 1,
+}
+DEFAULT_PRIORITY_RANK = 2
+
+# Bounded overflow: at most this many slots above the global cap may be
+# consumed by human-priority items (mirrored by the bash dispatcher's
+# PM_HUMAN_OVERFLOW_ALLOWANCE, default 1).
+HUMAN_PRIORITY_OVERFLOW_ALLOWANCE = 1
+
+
+def item_priority_rank(detail: str | None) -> int:
+    """Priority rank of an item from its ``detail`` tokens (lower = first).
+
+    Tokens are ``"; "``-joined in the detail field (same convention as
+    :func:`is_direct_mention`), so exact-token matching avoids false positives
+    on free text. Returns the best (lowest) rank present:
+    0 = human CHANGES_REQUESTED, 1 = human activity, 2 = default (bot/none).
+    """
+    rank = DEFAULT_PRIORITY_RANK
+    for tok in (detail or "").split(";"):
+        tok_rank = _HUMAN_PRIORITY_RANKS.get(tok.strip())
+        if tok_rank is not None and tok_rank < rank:
+            rank = tok_rank
+    return rank
+
+
+def detail_is_human_priority(detail: str | None) -> bool:
+    """True when the item's detail carries a human-priority token."""
+    return item_priority_rank(detail) < DEFAULT_PRIORITY_RANK
+
+
+def human_priority_allows_overflow(
+    detail: str | None,
+    running_slots: int,
+    slot_cap: int,
+    overflow_allowance: int = HUMAN_PRIORITY_OVERFLOW_ALLOWANCE,
+) -> bool:
+    """Cap-overflow rule: may a human-priority item dispatch above the cap?
+
+    Chosen over slot *reservation* because reservation permanently cuts bot
+    throughput to ``cap - 1`` even when no human item exists and requires
+    classifying already-running units by priority. Overflow is strictly
+    additive and self-bounding: ``running_slots`` counts every live slot
+    (including a previously granted overflow slot), so at most
+    *overflow_allowance* slots ever run above the cap.
+    """
+    if not detail_is_human_priority(detail):
+        return False
+    if overflow_allowance <= 0:
+        return False
+    return running_slots < slot_cap + overflow_allowance
+
+
 # --- LRU lane ordering (slot-starvation fairness) ---
 
 # Same convention as the bash runtime's per-slot dispatch cooldown markers
@@ -931,22 +1002,32 @@ def order_lane_lru(
     PRs) starve indefinitely (observed 2026-07-09: ``skipped_cap`` 13-31/hour
     while the same early items re-dispatched).
 
-    Ordering: never-dispatched items first (no cooldown marker → epoch 0), then
-    ascending by last-dispatch epoch. The sort is stable, so ties — including a
-    fresh cooldown dir after reboot — preserve the original gate order, i.e.
-    this degrades gracefully to the previous behavior. Freshness is preserved:
-    a brand-new mention has no marker and therefore sorts first anyway.
+    Ordering: human-priority items first (§7b human > bot — see
+    :func:`item_priority_rank`; CHANGES_REQUESTED ahead of plain human
+    activity), then within each priority class never-dispatched items first
+    (no cooldown marker → epoch 0), then ascending by last-dispatch epoch.
+    The sort is stable, so ties — including a fresh cooldown dir after
+    reboot — preserve the original gate order, i.e. with no human-priority
+    items this degrades gracefully to pure LRU / the previous behavior.
+    Freshness is preserved: a brand-new mention has no marker and therefore
+    sorts first anyway.
     """
     if cooldown_dir is None:
         cooldown_dir = Path(
             os.environ.get(DISPATCH_COOLDOWN_DIR_ENV) or DEFAULT_DISPATCH_COOLDOWN_DIR
         )
-    if not cooldown_dir.is_dir():
-        return list(lane_items)
-    return sorted(
-        lane_items,
-        key=lambda data: _last_dispatch_epoch(_item_slot_safe(data), cooldown_dir),
-    )
+    have_cooldown = cooldown_dir.is_dir()
+
+    def _key(data: dict[str, Any]) -> tuple[int, int]:
+        detail = data.get("detail")
+        epoch = (
+            _last_dispatch_epoch(_item_slot_safe(data), cooldown_dir)
+            if have_cooldown
+            else 0
+        )
+        return (item_priority_rank(detail if isinstance(detail, str) else None), epoch)
+
+    return sorted(lane_items, key=_key)
 
 
 def _partition_jsonl_io(

--- a/packages/gptme-runloops/tests/test_pm_dispatch.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch.py
@@ -10,8 +10,11 @@ from typing import Any
 import pytest
 from gptme_runloops.pm_dispatch import (
     DEFAULT_FAST_BURST_ALLOWANCE,
+    DEFAULT_PRIORITY_RANK,
     DEFAULT_SLOT_CAP,
     DISPATCH_COOLDOWN_DIR_ENV,
+    HUMAN_PRIORITY_ACTIVITY,
+    HUMAN_PRIORITY_CHANGES_REQUESTED,
     MIN_BANDIT_OBSERVATIONS,
     SLOW_LANE_TYPES,
     DispatchLedger,
@@ -27,8 +30,11 @@ from gptme_runloops.pm_dispatch import (
     classify_item_work_type,
     classify_lane,
     derive_slot_key,
+    detail_is_human_priority,
     dispatch_grouped_items,
+    human_priority_allows_overflow,
     is_direct_mention,
+    item_priority_rank,
     order_lane_lru,
     partition_items,
     resolve_lane_model,
@@ -1714,3 +1720,148 @@ class TestOrderLaneLru:
         slow = [json.loads(line) for line in slow_path.read_text().splitlines() if line]
         assert [i["number"] for i in slow] == [3, 2, 1]
         assert fast_path.read_text() == ""
+
+
+class TestItemPriorityRank:
+    """Human-review priority classification from detail tokens (§7b human > bot)."""
+
+    def test_changes_requested_is_highest(self):
+        assert item_priority_rank("updated: X; human_changes_requested") == 0
+
+    def test_human_activity_is_middle(self):
+        assert item_priority_rank("updated: X; human_activity") == 1
+
+    def test_no_tokens_is_default(self):
+        assert item_priority_rank("updated: X") == DEFAULT_PRIORITY_RANK
+
+    def test_both_tokens_take_best_rank(self):
+        detail = "updated: X; human_changes_requested; human_activity"
+        assert item_priority_rank(detail) == 0
+
+    def test_none_and_empty_are_default(self):
+        assert item_priority_rank(None) == DEFAULT_PRIORITY_RANK
+        assert item_priority_rank("") == DEFAULT_PRIORITY_RANK
+
+    def test_exact_token_match_only(self):
+        # Free text containing the token as a substring must not match.
+        assert (
+            item_priority_rank("title mentions human_activity levels")
+            == DEFAULT_PRIORITY_RANK
+        )
+
+    def test_detail_is_human_priority(self):
+        assert detail_is_human_priority(f"x; {HUMAN_PRIORITY_ACTIVITY}")
+        assert detail_is_human_priority(f"{HUMAN_PRIORITY_CHANGES_REQUESTED}")
+        assert not detail_is_human_priority("updated: 2026-07-11T13:26:04Z")
+        assert not detail_is_human_priority(None)
+
+
+class TestOrderLaneLruHumanPriority:
+    """Human-priority items sort ahead of the LRU backlog (§7b human > bot)."""
+
+    @staticmethod
+    def _item(number: int, detail: str = "") -> dict:
+        return {
+            "repo": "foo/bar",
+            "number": number,
+            "types": ["pr_update"],
+            "detail": detail,
+        }
+
+    @staticmethod
+    def _mark(cooldown_dir, number: int, epoch: int) -> None:
+        (cooldown_dir / f"foo-bar-{number}.ts").write_text(f"{epoch}\n")
+
+    def test_human_item_jumps_lru_queue(self, tmp_path):
+        """A human-priority item beats never-dispatched bot backlog items."""
+        cooldown = tmp_path / "cooldown"
+        cooldown.mkdir()
+        # Item 1: human review, dispatched before (worst LRU position).
+        self._mark(cooldown, 1, 1_700_000_000)
+        items = [
+            self._item(2, "updated: X"),  # never dispatched (epoch 0)
+            self._item(3, "updated: X"),  # never dispatched (epoch 0)
+            self._item(1, "updated: X; human_changes_requested"),
+        ]
+
+        ordered = order_lane_lru(items, cooldown_dir=cooldown)
+
+        assert [i["number"] for i in ordered] == [1, 2, 3]
+
+    def test_changes_requested_beats_plain_human_activity(self, tmp_path):
+        cooldown = tmp_path / "cooldown"
+        cooldown.mkdir()
+        items = [
+            self._item(1, "updated: X; human_activity"),
+            self._item(2, "updated: X; human_changes_requested"),
+        ]
+
+        ordered = order_lane_lru(items, cooldown_dir=cooldown)
+
+        assert [i["number"] for i in ordered] == [2, 1]
+
+    def test_no_human_items_is_pure_lru(self, tmp_path):
+        """Without priority tokens the ordering is exactly the LRU order."""
+        cooldown = tmp_path / "cooldown"
+        cooldown.mkdir()
+        self._mark(cooldown, 1, 3000)
+        self._mark(cooldown, 2, 1000)
+        self._mark(cooldown, 3, 2000)
+        items = [self._item(1), self._item(2), self._item(3)]
+
+        ordered = order_lane_lru(items, cooldown_dir=cooldown)
+
+        assert [i["number"] for i in ordered] == [2, 3, 1]
+
+    def test_lru_breaks_ties_within_priority_class(self, tmp_path):
+        cooldown = tmp_path / "cooldown"
+        cooldown.mkdir()
+        self._mark(cooldown, 1, 2000)
+        self._mark(cooldown, 2, 1000)
+        items = [
+            self._item(1, "updated: X; human_activity"),
+            self._item(2, "updated: X; human_activity"),
+        ]
+
+        ordered = order_lane_lru(items, cooldown_dir=cooldown)
+
+        assert [i["number"] for i in ordered] == [2, 1]
+
+    def test_missing_cooldown_dir_still_sorts_by_priority(self, tmp_path):
+        items = [
+            self._item(2, "updated: X"),
+            self._item(1, "updated: X; human_changes_requested"),
+        ]
+
+        ordered = order_lane_lru(items, cooldown_dir=tmp_path / "absent")
+
+        assert [i["number"] for i in ordered] == [1, 2]
+
+
+class TestHumanPriorityOverflow:
+    """Bounded cap-overflow rule for human-priority items."""
+
+    HUMAN = "updated: X; human_changes_requested"
+    BOT = "updated: X"
+
+    def test_human_item_allowed_at_cap(self):
+        assert human_priority_allows_overflow(self.HUMAN, running_slots=5, slot_cap=5)
+
+    def test_overflow_is_bounded_to_allowance(self):
+        # A previously granted overflow slot counts in running_slots, so the
+        # next human item at cap+1 is denied — max 1 slot above cap.
+        assert not human_priority_allows_overflow(
+            self.HUMAN, running_slots=6, slot_cap=5
+        )
+
+    def test_non_human_item_never_overflows(self):
+        assert not human_priority_allows_overflow(self.BOT, running_slots=5, slot_cap=5)
+        assert not human_priority_allows_overflow(None, running_slots=5, slot_cap=5)
+
+    def test_zero_allowance_disables_overflow(self):
+        assert not human_priority_allows_overflow(
+            self.HUMAN, running_slots=5, slot_cap=5, overflow_allowance=0
+        )
+
+    def test_below_cap_is_trivially_allowed_for_human(self):
+        assert human_priority_allows_overflow(self.HUMAN, running_slots=2, slot_cap=5)

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -448,6 +448,43 @@ has_actionable_update() {
     return 0
 }
 
+# --- Human-review dispatch priority tokens (§7b human > bot) ---
+# Detect human (non-bot, non-AUTHOR) review activity on a PR so the dispatcher
+# can prioritize it over bot-triggered backlog. Emits ;-joined detail tokens
+# consumed by gptme_runloops.pm_dispatch (lane ordering) and the dispatcher's
+# bounded cap-overflow rule:
+#   human_changes_requested — a human's latest review state is CHANGES_REQUESTED
+#                             (blocking merge; highest priority)
+#   human_activity          — the most recent comment/review actor is human
+# Bot detection is heuristic on login shape because gh's comments/latestReviews
+# author objects carry only .login (no is_bot / __typename): GitHub Apps appear
+# WITHOUT the "[bot]" suffix here (e.g. "greptile-apps"), so we also match
+# -bot/-apps suffixes and well-known CI/review bots. Failure directions are
+# safe: an unknown bot misread as human costs at most one bounded overflow
+# slot on valid work; a human whose login matches a bot pattern just keeps
+# today's (non-prioritized) behavior.
+# Args: <pr_data_json>. Echoes "tok" / "tok; tok" or nothing.
+pr_human_priority_tokens() {
+    local pr_data=$1
+    echo "$pr_data" | jq -r --arg author "$AUTHOR" '
+        def is_bot_login:
+            test("(\\[bot\\]$)|(-bot$)|(-apps$)|(^github-actions$)|(^dependabot)|(^renovate)|(^codecov)|(^coderabbitai$)|(^copilot)"; "i");
+        def is_human_login:
+            . != null and . != "" and (ascii_downcase != ($author | ascii_downcase)) and (is_bot_login | not);
+        ([
+            (.comments[-1] | select(. != null) | {login: .author.login, time: .createdAt}),
+            ((.latestReviews // []) | sort_by(.submittedAt) | last | select(. != null) | {login: .author.login, time: .submittedAt})
+         ] | sort_by(.time) | last | .login // "") as $last_actor
+        | ([ (.latestReviews // [])[]
+             | select(.state == "CHANGES_REQUESTED")
+             | select(.author.login | is_human_login)
+           ] | length > 0) as $human_changes_requested
+        | [ (if $human_changes_requested then "human_changes_requested" else empty end),
+            (if ($last_actor | is_human_login) then "human_activity" else empty end) ]
+        | join("; ")
+    ' 2>/dev/null || true
+}
+
 # Check for PR updates since last check (state-tracked via updatedAt timestamps)
 # Filters out self-triggered updates and comments directed at others.
 # Accepts pre-fetched PR data from fetch_pr_data() to avoid redundant API calls.
@@ -468,9 +505,17 @@ check_pr_updates() {
             if [[ "$updated_at" > "$last_check" ]]; then
                 # Check if the update was from someone we should respond to
                 if has_actionable_update "$pr_data"; then
-                    local pr_title
+                    local pr_title priority_tokens item_detail
                     pr_title=$(echo "$pr_data" | jq -r '.title')
-                    emit_item "pr_update" "$repo" "$pr_number" "$pr_title" "updated: $updated_at"
+                    # Human-priority tokens (§7b human > bot): let the
+                    # dispatcher sort human review activity ahead of the
+                    # bot backlog and grant bounded cap overflow.
+                    priority_tokens=$(pr_human_priority_tokens "$pr_data")
+                    item_detail="updated: $updated_at"
+                    if [ -n "$priority_tokens" ]; then
+                        item_detail="$item_detail; $priority_tokens"
+                    fi
+                    emit_item "pr_update" "$repo" "$pr_number" "$pr_title" "$item_detail"
                 fi
                 # Always advance state to avoid rechecking this timestamp
                 echo "$updated_at" > "$state_file"

--- a/tests/integration/test_activity_gate_human_priority.py
+++ b/tests/integration/test_activity_gate_human_priority.py
@@ -16,7 +16,7 @@ import subprocess
 import tempfile
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parent.parent
+REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "scripts" / "github" / "activity-gate.sh"
 
 TEST_REPO = "testorg/testrepo"

--- a/tests/test_activity_gate_human_priority.py
+++ b/tests/test_activity_gate_human_priority.py
@@ -1,0 +1,177 @@
+"""Tests for human-review priority tokens in activity-gate.sh (§7b human > bot).
+
+The gate must mark pr_update items whose triggering activity is from a human
+(non-bot, non-AUTHOR) so the dispatcher can sort them ahead of the bot backlog
+and grant bounded cap overflow. Regression context: Erik's CHANGES_REQUESTED
+review on gptme/gptme#3178 (2026-07-11) was emitted every cycle but skipped at
+the global slot cap behind a 3-day bot-priority backlog.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "github" / "activity-gate.sh"
+
+TEST_REPO = "testorg/testrepo"
+TEST_PR = 42
+
+FAKE_GH = r"""#!/usr/bin/env python3
+from __future__ import annotations
+import json, os, sys
+
+argv = sys.argv[1:]
+scenario = os.environ.get("TEST_SCENARIO", "human_cr")
+
+if not argv:
+    sys.exit(2)
+
+if argv[0] == "repo" and len(argv) > 1 and argv[1] == "list":
+    sys.exit(0)
+
+if argv[0] == "pr" and len(argv) > 1 and argv[1] == "list":
+    comments = []
+    latest_reviews = []
+    if scenario == "human_cr":
+        # Bot review first, then a human CHANGES_REQUESTED (the #3178 shape).
+        latest_reviews = [
+            {
+                "author": {"login": "greptile-apps"},
+                "state": "COMMENTED",
+                "submittedAt": "2026-07-11T12:00:00Z",
+                "body": "",
+            },
+            {
+                "author": {"login": "ErikBjare"},
+                "state": "CHANGES_REQUESTED",
+                "submittedAt": "2026-07-11T13:26:04Z",
+                "body": "please fix",
+            },
+        ]
+    elif scenario == "bot_last":
+        latest_reviews = [
+            {
+                "author": {"login": "greptile-apps"},
+                "state": "COMMENTED",
+                "submittedAt": "2026-07-11T13:00:00Z",
+                "body": "bot feedback",
+            },
+        ]
+    elif scenario == "human_comment":
+        comments = [
+            {
+                "author": {"login": "ErikBjare"},
+                "createdAt": "2026-07-11T13:00:00Z",
+                "body": "looks close, one question",
+            },
+        ]
+    pr = [{
+        "number": 42,
+        "title": "Test PR",
+        "updatedAt": "2026-07-11T13:30:00Z",
+        "comments": comments,
+        "latestReviews": latest_reviews,
+        "statusCheckRollup": None,
+        "mergeable": "MERGEABLE",
+        "mergeStateStatus": "CLEAN",
+        "headRefOid": "deadbeef1234",
+        "isDraft": False,
+    }]
+    print(json.dumps(pr))
+    sys.exit(0)
+
+if argv[0] == "issue" and len(argv) > 1 and argv[1] == "list":
+    print("[]")
+    sys.exit(0)
+
+if argv[0] == "run" and len(argv) > 1 and argv[1] == "list":
+    print("[]")
+    sys.exit(0)
+
+if argv[0] == "api":
+    if "--jq" in argv:
+        sys.exit(0)
+    print("[]")
+    sys.exit(0)
+
+sys.exit(0)
+"""
+
+
+def _run_gate(tmp: Path, scenario: str) -> list[dict]:
+    """Run the gate against fake gh; return emitted jsonl pr_update items."""
+    fake_gh = tmp / "gh"
+    fake_gh.write_text(FAKE_GH)
+    fake_gh.chmod(fake_gh.stat().st_mode | stat.S_IXUSR)
+
+    state_dir = tmp / f"state-{scenario}"
+    state_dir.mkdir()
+    # Seed PR state older than updatedAt so the update is reported (a fresh
+    # state dir only seeds without emitting).
+    repo_safe = TEST_REPO.replace("/", "-")
+    (state_dir / f"{repo_safe}-pr-{TEST_PR}.state").write_text("2026-07-11T00:00:00Z")
+
+    env = os.environ.copy()
+    env["TEST_SCENARIO"] = scenario
+    env["PATH"] = f"{tmp}:{env['PATH']}"
+
+    result = subprocess.run(
+        [
+            str(SCRIPT),
+            "--author",
+            "test-author",
+            "--repo",
+            TEST_REPO,
+            "--state-dir",
+            str(state_dir),
+            "--format",
+            "jsonl",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode in (0, 1), result.stderr
+    items = []
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        item = json.loads(line)
+        if item.get("type") == "pr_update":
+            items.append(item)
+    return items
+
+
+def test_human_changes_requested_emits_both_priority_tokens() -> None:
+    with tempfile.TemporaryDirectory() as tmp_str:
+        items = _run_gate(Path(tmp_str), "human_cr")
+        assert len(items) == 1, items
+        detail = items[0]["detail"]
+        assert "human_changes_requested" in detail, detail
+        assert "human_activity" in detail, detail
+
+
+def test_bot_activity_emits_no_priority_tokens() -> None:
+    """Bot reviews still emit pr_update (actionable) but without priority."""
+    with tempfile.TemporaryDirectory() as tmp_str:
+        items = _run_gate(Path(tmp_str), "bot_last")
+        assert len(items) == 1, items
+        detail = items[0]["detail"]
+        assert "human_changes_requested" not in detail, detail
+        assert "human_activity" not in detail, detail
+
+
+def test_plain_human_comment_emits_activity_token_only() -> None:
+    with tempfile.TemporaryDirectory() as tmp_str:
+        items = _run_gate(Path(tmp_str), "human_comment")
+        assert len(items) == 1, items
+        detail = items[0]["detail"]
+        assert "human_activity" in detail, detail
+        assert "human_changes_requested" not in detail, detail


### PR DESCRIPTION
## Why

Erik left a CHANGES_REQUESTED review on gptme/gptme#3178 (2026-07-11 13:26Z). The activity gate correctly emitted the item every cycle, but the dispatcher skipped it at the global slot cap twice (`skipped_cap global_slot_cap_reached key=gptme/gptme#3178` at 13:01 and 13:31) while all 5 slots drained a 3-day backlog of bot-priority items (post-outage burst). Erik: *"i shouldn't have to tag you in a separate comment, review comment (+ request changes blocking merge even) should be enough."*

The §7b invariant (human > bot) was only enforced in suppression logic (cooldown bypass), not in dispatch ordering or capacity.

## What

**1. Gate: human-priority detail tokens** (`scripts/github/activity-gate.sh`)

`pr_update` items now carry `;`-joined detail tokens when the triggering activity is from a human (non-bot, non-AUTHOR):
- `human_changes_requested` — a human's latest review state is CHANGES_REQUESTED (blocking merge; highest priority)
- `human_activity` — the most recent comment/review actor is human

Tokens ride the existing `detail` field and survive `build_grouped_jsonl`'s `join("; ")` — the same convention as the `mention` notification-reason token. Bot detection is heuristic on login shape (`[bot]`/`-bot`/`-apps` suffixes + well-known bots) because gh's `comments`/`latestReviews` author objects carry only `.login` (GitHub Apps appear WITHOUT the `[bot]` suffix there, e.g. `greptile-apps`). Failure directions are safe both ways (see comment in the script). Verified against live gptme/gptme#3178 data: emits `human_changes_requested; human_activity`.

**2. Dispatch ordering** (`pm_dispatch.py`)

`order_lane_lru` (contrib#1259) now sorts by `(priority_rank, lru_epoch)`: human CHANGES_REQUESTED (0) → human activity (1) → default (2), LRU within each class. Stable sort — with no human-priority items the ordering is byte-identical to the previous pure-LRU behavior.

**3. Bounded cap overflow rule** (`human_priority_allows_overflow`)

A human-priority item may dispatch at most `HUMAN_PRIORITY_OVERFLOW_ALLOWANCE` (1) slot above the global cap. **Overflow chosen over slot reservation**: reservation permanently cuts bot throughput to cap−1 even when no human item exists and requires classifying already-running units by priority; overflow is strictly additive and self-bounding (`running_slots` counts a previously granted overflow slot). The bash dispatcher wiring that consumes this rule lands brain-side (ErikBjare/bob).

This is dispatch-ordering/capacity only — upstream of the executor path; does not touch `run_item.py` or the PM_EXECUTOR A/B (bob#1075).

## Tests

⚠️ Contrib CI does not run `tests/` or package unit tests (known gap — bob `tasks/contrib-ci-does-not-run-unit-tests.md`). Run locally:
- Full `gptme-runloops` suite: **658 passed**
- New: priority-rank parsing (exact-token match, no substring FPs), human item jumps LRU queue, CR beats plain comment, pure-LRU unchanged without human items, LRU tie-break within priority class, bounded overflow rule, and 3 gate-level e2e token-emission tests (human CR / bot-last / human comment) via fake-gh harness
- `shellcheck`, `ruff`, `mypy`, full `prek` hooks: clean