### PR TITLE
perf(gptme-tts): lazy-import scipy/numpy/requests

### DIFF
--- a/plugins/gptme-tts/src/gptme_tts/tts.py
+++ b/plugins/gptme-tts/src/gptme_tts/tts.py
@@ -34,8 +34,8 @@ import queue
 import re
 import socket
 import threading
+from importlib.util import find_spec
 
-import requests
 from gptme.tools.base import ToolSpec
 from gptme.util import console
 from gptme.util.sound import (
@@ -71,15 +71,10 @@ def _request_timeout() -> float:
     return DEFAULT_REQUEST_TIMEOUT
 
 
-# Check for TTS-specific imports
-has_tts_imports = False
-try:
-    import numpy as np  # fmt: skip
-    import scipy.io.wavfile as wavfile  # fmt: skip
-
-    has_tts_imports = True
-except (ImportError, OSError):
-    has_tts_imports = False
+# Check for TTS-specific deps without importing them: importing scipy takes
+# ~0.3s and this module is imported during tool listing (e.g. gptme --help).
+# numpy/scipy are imported lazily at the synthesis call sites instead.
+has_tts_imports = all(find_spec(mod) is not None for mod in ("numpy", "scipy"))
 
 
 # --- Backend selection -------------------------------------------------------
@@ -385,6 +380,9 @@ def clean_for_speech(content: str) -> str:
 
 def _synthesize_server(chunk: str):
     """Synthesize a chunk via the local tts_server.py. Returns (sample_rate, data)."""
+    import requests
+    import scipy.io.wavfile as wavfile
+
     url = f"http://{host}:{port}/tts"
     params: dict[str, str | float] = {"text": chunk, "speed": current_speed}
     if voice := os.getenv("GPTME_TTS_VOICE"):
@@ -420,6 +418,9 @@ def _synthesize_openrouter(chunk: str):
     Uses the ``pcm`` response format (uncompressed 16-bit mono @ 24kHz) so no
     audio decoder is needed and latency stays low.
     """
+    import numpy as np
+    import requests
+
     api_key = _get_openrouter_api_key()
     if not api_key:
         log.warning("OpenRouter TTS backend selected but OPENROUTER_API_KEY is not set")

--- a/plugins/gptme-tts/src/gptme_tts/tts.py
+++ b/plugins/gptme-tts/src/gptme_tts/tts.py
@@ -380,8 +380,14 @@ def clean_for_speech(content: str) -> str:
 
 def _synthesize_server(chunk: str):
     """Synthesize a chunk via the local tts_server.py. Returns (sample_rate, data)."""
-    import requests
-    import scipy.io.wavfile as wavfile
+    try:
+        import requests
+        import scipy.io.wavfile as wavfile
+    except (ImportError, OSError):
+        log.warning(
+            "TTS deps unavailable (scipy/requests failed to import); skipping chunk"
+        )
+        return None
 
     url = f"http://{host}:{port}/tts"
     params: dict[str, str | float] = {"text": chunk, "speed": current_speed}
@@ -418,8 +424,14 @@ def _synthesize_openrouter(chunk: str):
     Uses the ``pcm`` response format (uncompressed 16-bit mono @ 24kHz) so no
     audio decoder is needed and latency stays low.
     """
-    import numpy as np
-    import requests
+    try:
+        import numpy as np
+        import requests
+    except (ImportError, OSError):
+        log.warning(
+            "TTS deps unavailable (numpy/requests failed to import); skipping chunk"
+        )
+        return None
 
     api_key = _get_openrouter_api_key()
     if not api_key:

--- a/plugins/gptme-tts/tests/test_tts.py
+++ b/plugins/gptme-tts/tests/test_tts.py
@@ -204,7 +204,9 @@ def test_synthesize_openrouter_builds_request_and_decodes_pcm(monkeypatch):
         captured.update(url=url, headers=headers, json=json)
         return FakeResp()
 
-    monkeypatch.setattr(tts_mod.requests, "post", fake_post)
+    # requests is imported lazily inside _synthesize_openrouter, so patch the
+    # real module rather than a (nonexistent) tts module attribute
+    monkeypatch.setattr("requests.post", fake_post)
 
     sample_rate, data = tts_mod._synthesize_openrouter("Hello")
 


### PR DESCRIPTION
Importing gptme_tts eagerly pulled in scipy.io.wavfile (~0.25s) and
requests (~0.15s) just to set the has_tts_imports availability flag.
This module is imported during gptme tool listing (e.g. gptme --help),
where the cost is pure startup latency.

Probe availability with importlib.util.find_spec instead, and import
the heavy modules at the synthesis call sites where they're used.
Cuts gptme_tts import time from ~0.7s to ~0.3s (and the remainder is
gptme.tools.base, already loaded in real usage).

Verified end-to-end against a running TTS server (server backend).
