### PR TITLE
feat(pm-dispatch): port bash cooldown skip into dispatch_grouped_items

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -18,6 +18,7 @@ import logging
 import os
 import re
 import sys
+import time
 from dataclasses import dataclass, field, fields
 from datetime import datetime, timezone
 from pathlib import Path
@@ -880,6 +881,7 @@ class DispatchResult:
     launched: int = 0
     skipped_active: int = 0
     skipped_cap: int = 0
+    skipped_cooldown: int = 0
     failed: int = 0
     fallback_items: list[SlotItem] = field(default_factory=list)
 
@@ -962,6 +964,43 @@ def human_priority_allows_overflow(
 # ``<slot_safe>.ts`` files holding an epoch timestamp).
 DISPATCH_COOLDOWN_DIR_ENV = "PM_DISPATCH_COOLDOWN_DIR"
 DEFAULT_DISPATCH_COOLDOWN_DIR = "/tmp/bob-pm-dispatch-cooldown"
+
+# Per-slot dispatch cooldown (ErikBjare/bob#788). Mirrors bash
+# PM_DISPATCH_COOLDOWN_SECS (default 600, 0 = disabled).
+DISPATCH_COOLDOWN_SECS_ENV = "PM_DISPATCH_COOLDOWN_SECS"
+DEFAULT_DISPATCH_COOLDOWN_SECS = 600
+
+
+def _resolve_cooldown_dir(cooldown_dir: Path | None) -> Path:
+    return cooldown_dir or Path(
+        os.environ.get(DISPATCH_COOLDOWN_DIR_ENV) or DEFAULT_DISPATCH_COOLDOWN_DIR
+    )
+
+
+def _slot_in_cooldown(slot_safe: str, cooldown_secs: int, cooldown_dir: Path) -> bool:
+    """True when *slot_safe* was dispatched within *cooldown_secs* seconds.
+
+    Mirrors bash ``slot_dispatch_in_cooldown()`` in
+    ``project-monitoring-dispatch.sh``.  Returns False when cooldown_secs ≤ 0,
+    when no marker exists, or when the marker is unreadable.
+    """
+    if cooldown_secs <= 0:
+        return False
+    marker = cooldown_dir / f"{slot_safe}.ts"
+    try:
+        last = int(marker.read_text().strip())
+    except (OSError, ValueError):
+        return False
+    return (int(time.time()) - last) < cooldown_secs
+
+
+def _write_slot_dispatch_marker(slot_safe: str, cooldown_dir: Path) -> None:
+    """Record that *slot_safe* was just dispatched (mirrors ``record_slot_dispatch``)."""
+    try:
+        cooldown_dir.mkdir(parents=True, exist_ok=True)
+        (cooldown_dir / f"{slot_safe}.ts").write_text(str(int(time.time())))
+    except OSError:
+        pass  # best-effort; a missing marker just means no cooldown suppression
 
 
 def _item_types(data: dict[str, Any]) -> list[str]:
@@ -1087,6 +1126,8 @@ def dispatch_grouped_items(
     slot_cap: int = DEFAULT_SLOT_CAP,
     fast_burst_allowance: int = DEFAULT_FAST_BURST_ALLOWANCE,
     ledger: DispatchLedger | None = None,
+    cooldown_secs: int | None = None,
+    cooldown_dir: Path | None = None,
 ) -> DispatchResult:
     """Orchestrate slot dispatch for a list of grouped work items.
 
@@ -1110,12 +1151,29 @@ def dispatch_grouped_items(
         fast worker is active.
     ledger
         Optional ``DispatchLedger`` for telemetry recording.
+    cooldown_secs
+        Per-slot dispatch cooldown in seconds (mirrors bash
+        ``PM_DISPATCH_COOLDOWN_SECS``, default 600, 0 = disabled).  When
+        ``None``, reads ``PM_DISPATCH_COOLDOWN_SECS`` from the environment,
+        falling back to ``DEFAULT_DISPATCH_COOLDOWN_SECS``.
+    cooldown_dir
+        Directory for cooldown timestamp markers.  Defaults to
+        ``PM_DISPATCH_COOLDOWN_DIR`` env var or ``DEFAULT_DISPATCH_COOLDOWN_DIR``.
 
     Returns
     -------
     DispatchResult
         Summary of what was launched, skipped, or set aside as fallback.
     """
+    if cooldown_secs is None:
+        _env_val = os.environ.get(DISPATCH_COOLDOWN_SECS_ENV, "")
+        try:
+            cooldown_secs = (
+                int(_env_val) if _env_val else DEFAULT_DISPATCH_COOLDOWN_SECS
+            )
+        except ValueError:
+            cooldown_secs = DEFAULT_DISPATCH_COOLDOWN_SECS
+    _cooldown_dir = _resolve_cooldown_dir(cooldown_dir)
     # In-memory slot tracker for this dispatch cycle.
     _active: dict[str, str] = {}  # slot_key -> unit_name
     _active_lanes: dict[str, str] = {}  # slot_key -> lane
@@ -1143,6 +1201,7 @@ def dispatch_grouped_items(
     for lane, lane_items in [("fast", fast), ("slow", slow)]:
         for item in lane_items:
             key = derive_slot_key(item.repo, item.number, item.types, item.title)
+            slot_safe = _sanitize_unit_name(key)
 
             if _is_busy(key):
                 result.skipped_active += 1
@@ -1152,12 +1211,44 @@ def dispatch_grouped_items(
                             phase="skipped_active",
                             lane=lane,
                             dispatch_id=key,
-                            unit_name=f"{unit_prefix}-{_sanitize_unit_name(key)}",
+                            unit_name=f"{unit_prefix}-{slot_safe}",
                             item_refs=[key],
                             note=f"slot_already_active key={key}",
                         )
                     )
                 continue
+
+            # Cooldown backstop (ErikBjare/bob#788): skip re-dispatch within
+            # the cooldown window even if the prior worker already finished.
+            # Two bypasses mirror the bash dispatcher:
+            #   (a) merge_conflict items — gate doesn't state-track conflicts,
+            #       so they nag every run; a pr_update cooldown on the same slot
+            #       must never suppress a freshly-detected conflict.
+            #   (b) comment-driven items (pr_update/assigned_issue) whose detail
+            #       carries a human-priority token — human follow-ups always get
+            #       a session, same as merge_conflict (pm-cooldown task).
+            if _slot_in_cooldown(slot_safe, cooldown_secs, _cooldown_dir):
+                _has_conflict = "merge_conflict" in item.types
+                _is_comment_driven = bool(
+                    set(item.types) & {"pr_update", "assigned_issue"}
+                )
+                _bypass = _has_conflict or (
+                    _is_comment_driven and detail_is_human_priority(item.detail)
+                )
+                if not _bypass:
+                    result.skipped_cooldown += 1
+                    if ledger:
+                        ledger.append(
+                            LedgerEntry.now(
+                                phase="skipped_cooldown",
+                                lane=lane,
+                                dispatch_id=key,
+                                unit_name=f"{unit_prefix}-{slot_safe}",
+                                item_refs=[key],
+                                note=f"dispatch_cooldown key={key}",
+                            )
+                        )
+                    continue
 
             if not mgr.slot_is_available(lane):
                 result.skipped_cap += 1
@@ -1168,7 +1259,7 @@ def dispatch_grouped_items(
                             phase="skipped_cap",
                             lane=lane,
                             dispatch_id=key,
-                            unit_name=f"{unit_prefix}-{_sanitize_unit_name(key)}",
+                            unit_name=f"{unit_prefix}-{slot_safe}",
                             item_refs=[key],
                             running_units=_count_running(),
                             cap=slot_cap,
@@ -1178,8 +1269,9 @@ def dispatch_grouped_items(
                 continue
 
             # Slot available — register and record
-            _active[key] = f"{unit_prefix}-{_sanitize_unit_name(key)}"
+            _active[key] = f"{unit_prefix}-{slot_safe}"
             _active_lanes[key] = lane
+            _write_slot_dispatch_marker(slot_safe, _cooldown_dir)
             result.launched += 1
             if ledger:
                 ledger.append(

--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -994,18 +994,21 @@ def _slot_in_cooldown(slot_safe: str, cooldown_secs: int, cooldown_dir: Path) ->
     return (int(time.time()) - last) < cooldown_secs
 
 
-def _write_slot_dispatch_marker(slot_safe: str, cooldown_dir: Path) -> None:
+def _write_slot_dispatch_marker(slot_safe: str, cooldown_dir: Path) -> bool:
     """Record that *slot_safe* was just dispatched (mirrors ``record_slot_dispatch``).
 
-    Best-effort: on ``OSError`` a warning is logged and the marker is skipped,
-    meaning no cooldown suppression for that slot.  This matches the bash
-    reference, which also does not roll back if the file write fails.
+    Returns ``True`` on success, ``False`` on ``OSError`` (a warning is logged).
+    Callers should skip dispatch when ``False`` is returned: dispatching without
+    a marker would let the same slot re-dispatch on the next cycle, defeating the
+    cooldown entirely.
     """
     try:
         cooldown_dir.mkdir(parents=True, exist_ok=True)
         (cooldown_dir / f"{slot_safe}.ts").write_text(str(int(time.time())))
+        return True
     except OSError as e:
         logger.warning("Failed to write dispatch marker for %s: %s", slot_safe, e)
+        return False
 
 
 def _item_types(data: dict[str, Any]) -> list[str]:
@@ -1282,10 +1285,24 @@ def dispatch_grouped_items(
                     )
                 continue
 
-            # Slot available — register and record
+            # Slot available — write marker first; skip if write fails so the
+            # next cycle's cooldown check still gates this slot correctly.
+            if not _write_slot_dispatch_marker(slot_safe, _cooldown_dir):
+                result.skipped_cooldown += 1
+                if ledger:
+                    ledger.append(
+                        LedgerEntry.now(
+                            phase="skipped_cooldown",
+                            lane=lane,
+                            dispatch_id=key,
+                            unit_name=f"{unit_prefix}-{slot_safe}",
+                            item_refs=[key],
+                            note=f"marker_write_failed key={key}",
+                        )
+                    )
+                continue
             _active[key] = f"{unit_prefix}-{slot_safe}"
             _active_lanes[key] = lane
-            _write_slot_dispatch_marker(slot_safe, _cooldown_dir)
             result.launched += 1
             if ledger:
                 ledger.append(

--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -995,12 +995,17 @@ def _slot_in_cooldown(slot_safe: str, cooldown_secs: int, cooldown_dir: Path) ->
 
 
 def _write_slot_dispatch_marker(slot_safe: str, cooldown_dir: Path) -> None:
-    """Record that *slot_safe* was just dispatched (mirrors ``record_slot_dispatch``)."""
+    """Record that *slot_safe* was just dispatched (mirrors ``record_slot_dispatch``).
+
+    Best-effort: on ``OSError`` a warning is logged and the marker is skipped,
+    meaning no cooldown suppression for that slot.  This matches the bash
+    reference, which also does not roll back if the file write fails.
+    """
     try:
         cooldown_dir.mkdir(parents=True, exist_ok=True)
         (cooldown_dir / f"{slot_safe}.ts").write_text(str(int(time.time())))
-    except OSError:
-        pass  # best-effort; a missing marker just means no cooldown suppression
+    except OSError as e:
+        logger.warning("Failed to write dispatch marker for %s: %s", slot_safe, e)
 
 
 def _item_types(data: dict[str, Any]) -> list[str]:
@@ -1164,6 +1169,15 @@ def dispatch_grouped_items(
     -------
     DispatchResult
         Summary of what was launched, skipped, or set aside as fallback.
+
+    Notes
+    -----
+    Cooldown markers are written **optimistically** — before the caller performs
+    the actual external launch (e.g. ``systemd-run``).  If the external launch
+    fails after this function returns, the marker remains, suppressing re-dispatch
+    for up to *cooldown_secs*.  This matches the bash reference
+    (``project-monitoring-dispatch.sh``) where ``record_slot_dispatch`` is called
+    immediately before ``systemd-run`` with no rollback on failure.
     """
     if cooldown_secs is None:
         _env_val = os.environ.get(DISPATCH_COOLDOWN_SECS_ENV, "")

--- a/packages/gptme-runloops/tests/test_pm_dispatch.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch.py
@@ -1924,18 +1924,24 @@ class TestSlotCooldownHelpers:
     def test_write_marker_oserror_logs_warning(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ):
-        """OSError on marker write emits a warning (not a silent pass)."""
+        """OSError on marker write emits a warning and returns False."""
         ro_dir = tmp_path / "readonly"
         ro_dir.mkdir()
         ro_dir.chmod(0o555)
         try:
             with caplog.at_level(logging.WARNING, logger="gptme_runloops.pm_dispatch"):
-                _write_slot_dispatch_marker("slot-z", ro_dir)
+                result = _write_slot_dispatch_marker("slot-z", ro_dir)
+            assert result is False
             assert any(
                 "slot-z" in r.message for r in caplog.records
             ), "Expected warning mentioning slot name"
         finally:
             ro_dir.chmod(0o755)
+
+    def test_write_marker_success_returns_true(self, tmp_path: Path):
+        """Successful marker write returns True."""
+        assert _write_slot_dispatch_marker("slot-ok", tmp_path) is True
+        assert (tmp_path / "slot-ok.ts").exists()
 
 
 def _slot_safe_for(repo: str, number: int, types: list[str]) -> str:
@@ -2106,3 +2112,23 @@ class TestDispatchGroupedItemsCooldown:
         )
         assert result.skipped_cooldown == 0
         assert result.launched == 1
+
+    def test_marker_write_failure_skips_dispatch(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ):
+        """If the marker write fails, the slot is skipped (not launched) to
+        preserve cooldown integrity and prevent re-dispatch storms."""
+        item = make_item(repo="a/x", number=1, types=["notification"])
+        ro_dir = tmp_path / "readonly"
+        ro_dir.mkdir()
+        ro_dir.chmod(0o555)
+        try:
+            with caplog.at_level(logging.WARNING, logger="gptme_runloops.pm_dispatch"):
+                result = dispatch_grouped_items(
+                    [item], slot_cap=5, cooldown_secs=600, cooldown_dir=ro_dir
+                )
+            assert result.launched == 0
+            assert result.skipped_cooldown == 1
+            assert any("Failed to write" in r.message for r in caplog.records)
+        finally:
+            ro_dir.chmod(0o755)

--- a/packages/gptme-runloops/tests/test_pm_dispatch.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import json
+import logging
 import time
 from pathlib import Path
 from typing import Any
@@ -1919,6 +1920,22 @@ class TestSlotCooldownHelpers:
         _write_slot_dispatch_marker("slot-a", tmp_path)
         ts = int((tmp_path / "slot-a.ts").read_text().strip())
         assert ts > 1000
+
+    def test_write_marker_oserror_logs_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ):
+        """OSError on marker write emits a warning (not a silent pass)."""
+        ro_dir = tmp_path / "readonly"
+        ro_dir.mkdir()
+        ro_dir.chmod(0o555)
+        try:
+            with caplog.at_level(logging.WARNING, logger="gptme_runloops.pm_dispatch"):
+                _write_slot_dispatch_marker("slot-z", ro_dir)
+            assert any(
+                "slot-z" in r.message for r in caplog.records
+            ), "Expected warning mentioning slot name"
+        finally:
+            ro_dir.chmod(0o755)
 
 
 def _slot_safe_for(repo: str, number: int, types: list[str]) -> str:

--- a/packages/gptme-runloops/tests/test_pm_dispatch.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import json
+import time
 from pathlib import Path
 from typing import Any
 
@@ -25,6 +26,9 @@ from gptme_runloops.pm_dispatch import (
     _bandit_observation_count,
     _partition_jsonl_io,
     _resolve_model_with_bandit,
+    _sanitize_unit_name,
+    _slot_in_cooldown,
+    _write_slot_dispatch_marker,
     append_full_ledger_entry,
     build_full_ledger_entry,
     classify_item_work_type,
@@ -58,6 +62,7 @@ def make_item(
     number: int | None = 42,
     types: list[str] | None = None,
     title: str = "Test item",
+    detail: str = "",
 ) -> SlotItem:
     return SlotItem(
         repo=repo,
@@ -67,6 +72,7 @@ def make_item(
         url=f"https://github.com/{repo}/pull/{number}"
         if number is not None
         else f"https://github.com/{repo}",
+        detail=detail,
     )
 
 
@@ -618,6 +624,14 @@ class TestSlotManager:
 
 
 class TestDispatchGroupedItems:
+    @pytest.fixture(autouse=True)
+    def _isolate_cooldown(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Point PM_DISPATCH_COOLDOWN_DIR at an empty tmp dir so production markers
+        don't affect tests that don't explicitly test cooldown behavior."""
+        monkeypatch.setenv(DISPATCH_COOLDOWN_DIR_ENV, str(tmp_path / "cooldown"))
+
     def test_empty_items(self):
         result = dispatch_grouped_items([])
         assert result.launched == 0
@@ -1865,3 +1879,213 @@ class TestHumanPriorityOverflow:
 
     def test_below_cap_is_trivially_allowed_for_human(self):
         assert human_priority_allows_overflow(self.HUMAN, running_slots=2, slot_cap=5)
+
+
+# ---------------------------------------------------------------------------
+# Cooldown helpers
+# ---------------------------------------------------------------------------
+
+
+class TestSlotCooldownHelpers:
+    def test_no_marker_returns_false(self, tmp_path: Path):
+        assert not _slot_in_cooldown("slot-a-b-1", 600, tmp_path)
+
+    def test_fresh_marker_returns_true(self, tmp_path: Path):
+        (tmp_path / "slot-a-b-1.ts").write_text(str(int(time.time())))
+        assert _slot_in_cooldown("slot-a-b-1", 600, tmp_path)
+
+    def test_expired_marker_returns_false(self, tmp_path: Path):
+        (tmp_path / "slot-a-b-1.ts").write_text(str(int(time.time()) - 700))
+        assert not _slot_in_cooldown("slot-a-b-1", 600, tmp_path)
+
+    def test_zero_secs_always_false(self, tmp_path: Path):
+        (tmp_path / "slot-a-b-1.ts").write_text(str(int(time.time())))
+        assert not _slot_in_cooldown("slot-a-b-1", 0, tmp_path)
+
+    def test_write_marker_creates_file(self, tmp_path: Path):
+        _write_slot_dispatch_marker("slot-a-b-1", tmp_path)
+        marker = tmp_path / "slot-a-b-1.ts"
+        assert marker.exists()
+        ts = int(marker.read_text().strip())
+        assert abs(ts - int(time.time())) <= 2
+
+    def test_write_marker_creates_dir(self, tmp_path: Path):
+        cooldown_dir = tmp_path / "nested" / "cooldown"
+        _write_slot_dispatch_marker("slot-x", cooldown_dir)
+        assert (cooldown_dir / "slot-x.ts").exists()
+
+    def test_write_marker_overwrites(self, tmp_path: Path):
+        (tmp_path / "slot-a.ts").write_text("1000")
+        _write_slot_dispatch_marker("slot-a", tmp_path)
+        ts = int((tmp_path / "slot-a.ts").read_text().strip())
+        assert ts > 1000
+
+
+def _slot_safe_for(repo: str, number: int, types: list[str]) -> str:
+    return _sanitize_unit_name(derive_slot_key(repo, number, types))
+
+
+# ---------------------------------------------------------------------------
+# dispatch_grouped_items — cooldown integration
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchGroupedItemsCooldown:
+    def test_fresh_marker_skips_item(self, tmp_path: Path):
+        item = make_item(repo="a/x", number=1, types=["notification"])
+        cd = tmp_path / "cd"
+        cd.mkdir()
+        (cd / f"{_slot_safe_for('a/x', 1, ['notification'])}.ts").write_text(
+            str(int(time.time()))
+        )
+        result = dispatch_grouped_items(
+            [item], slot_cap=5, cooldown_secs=600, cooldown_dir=cd
+        )
+        assert result.skipped_cooldown == 1
+        assert result.launched == 0
+
+    def test_expired_marker_dispatches(self, tmp_path: Path):
+        item = make_item(repo="a/x", number=1, types=["notification"])
+        cd = tmp_path / "cd"
+        cd.mkdir()
+        (cd / f"{_slot_safe_for('a/x', 1, ['notification'])}.ts").write_text(
+            str(int(time.time()) - 700)
+        )
+        result = dispatch_grouped_items(
+            [item], slot_cap=5, cooldown_secs=600, cooldown_dir=cd
+        )
+        assert result.skipped_cooldown == 0
+        assert result.launched == 1
+
+    def test_zero_cooldown_disables_skip(self, tmp_path: Path):
+        item = make_item(repo="a/x", number=1, types=["notification"])
+        cd = tmp_path / "cd"
+        cd.mkdir()
+        (cd / f"{_slot_safe_for('a/x', 1, ['notification'])}.ts").write_text(
+            str(int(time.time()))
+        )
+        result = dispatch_grouped_items(
+            [item], slot_cap=5, cooldown_secs=0, cooldown_dir=cd
+        )
+        assert result.skipped_cooldown == 0
+        assert result.launched == 1
+
+    def test_merge_conflict_bypasses_cooldown(self, tmp_path: Path):
+        """merge_conflict items always bypass the cooldown (bypass a)."""
+        item = make_item(repo="a/x", number=1, types=["merge_conflict"])
+        cd = tmp_path / "cd"
+        cd.mkdir()
+        (cd / f"{_slot_safe_for('a/x', 1, ['merge_conflict'])}.ts").write_text(
+            str(int(time.time()))
+        )
+        result = dispatch_grouped_items(
+            [item], slot_cap=5, cooldown_secs=600, cooldown_dir=cd
+        )
+        assert result.skipped_cooldown == 0
+        assert result.launched == 1
+
+    def test_pr_update_with_human_activity_bypasses_cooldown(self, tmp_path: Path):
+        """pr_update with human_activity detail bypasses cooldown (bypass b)."""
+        item = make_item(
+            repo="a/x", number=1, types=["pr_update"], detail="human_activity"
+        )
+        cd = tmp_path / "cd"
+        cd.mkdir()
+        (cd / f"{_slot_safe_for('a/x', 1, ['pr_update'])}.ts").write_text(
+            str(int(time.time()))
+        )
+        result = dispatch_grouped_items(
+            [item], slot_cap=5, cooldown_secs=600, cooldown_dir=cd
+        )
+        assert result.skipped_cooldown == 0
+        assert result.launched == 1
+
+    def test_pr_update_with_changes_requested_bypasses_cooldown(self, tmp_path: Path):
+        """pr_update with human_changes_requested detail bypasses cooldown."""
+        item = make_item(
+            repo="a/x",
+            number=1,
+            types=["pr_update"],
+            detail="human_changes_requested",
+        )
+        cd = tmp_path / "cd"
+        cd.mkdir()
+        (cd / f"{_slot_safe_for('a/x', 1, ['pr_update'])}.ts").write_text(
+            str(int(time.time()))
+        )
+        result = dispatch_grouped_items(
+            [item], slot_cap=5, cooldown_secs=600, cooldown_dir=cd
+        )
+        assert result.skipped_cooldown == 0
+        assert result.launched == 1
+
+    def test_pr_update_without_human_detail_respects_cooldown(self, tmp_path: Path):
+        """pr_update with no human detail (bot re-fire) respects cooldown."""
+        item = make_item(repo="a/x", number=1, types=["pr_update"])
+        cd = tmp_path / "cd"
+        cd.mkdir()
+        (cd / f"{_slot_safe_for('a/x', 1, ['pr_update'])}.ts").write_text(
+            str(int(time.time()))
+        )
+        result = dispatch_grouped_items(
+            [item], slot_cap=5, cooldown_secs=600, cooldown_dir=cd
+        )
+        assert result.skipped_cooldown == 1
+        assert result.launched == 0
+
+    def test_assigned_issue_with_human_activity_bypasses_cooldown(self, tmp_path: Path):
+        """assigned_issue with human_activity detail bypasses cooldown."""
+        item = make_item(
+            repo="a/x", number=1, types=["assigned_issue"], detail="human_activity"
+        )
+        cd = tmp_path / "cd"
+        cd.mkdir()
+        (cd / f"{_slot_safe_for('a/x', 1, ['assigned_issue'])}.ts").write_text(
+            str(int(time.time()))
+        )
+        result = dispatch_grouped_items(
+            [item], slot_cap=5, cooldown_secs=600, cooldown_dir=cd
+        )
+        assert result.skipped_cooldown == 0
+        assert result.launched == 1
+
+    def test_marker_written_on_launch(self, tmp_path: Path):
+        """dispatch_grouped_items writes a cooldown marker after launch."""
+        item = make_item(repo="a/x", number=1, types=["notification"])
+        cd = tmp_path / "cd"
+        result = dispatch_grouped_items(
+            [item], slot_cap=5, cooldown_secs=600, cooldown_dir=cd
+        )
+        assert result.launched == 1
+        marker = cd / f"{_slot_safe_for('a/x', 1, ['notification'])}.ts"
+        assert marker.exists()
+        ts = int(marker.read_text().strip())
+        assert abs(ts - int(time.time())) <= 2
+
+    def test_cooldown_skipped_recorded_in_ledger(
+        self, tmp_path: Path, ledger_path: Path
+    ):
+        """skipped_cooldown items appear in the ledger with phase='skipped_cooldown'."""
+        item = make_item(repo="a/x", number=1, types=["notification"])
+        cd = tmp_path / "cd"
+        cd.mkdir()
+        (cd / f"{_slot_safe_for('a/x', 1, ['notification'])}.ts").write_text(
+            str(int(time.time()))
+        )
+        ledger = DispatchLedger(ledger_path)
+        dispatch_grouped_items(
+            [item], slot_cap=5, cooldown_secs=600, cooldown_dir=cd, ledger=ledger
+        )
+        entries = ledger.read()
+        phases = [e.phase for e in entries]
+        assert "skipped_cooldown" in phases
+
+    def test_no_marker_dir_no_skip(self, tmp_path: Path):
+        """Nonexistent cooldown dir means no markers → no skips."""
+        item = make_item(repo="a/x", number=1, types=["notification"])
+        cd = tmp_path / "nonexistent"
+        result = dispatch_grouped_items(
+            [item], slot_cap=5, cooldown_secs=600, cooldown_dir=cd
+        )
+        assert result.skipped_cooldown == 0
+        assert result.launched == 1


### PR DESCRIPTION
## Summary

- Ports the per-slot dispatch cooldown backstop from bash `project-monitoring-dispatch.sh` into Python `dispatch_grouped_items()` in `pm_dispatch.py`
- Hard prerequisite for PM migration step 5 (`PM_EXECUTOR=runloops`) — without this, flipping the executor silently re-introduces the #788 storm class
- Cooldown duration and dir are env-configurable (`PM_DISPATCH_COOLDOWN_SECS`, `PM_DISPATCH_COOLDOWN_DIR`)
- Bypass conditions match bash: `merge_conflict` items always bypass; `pr_update`/`assigned_issue` items with a human actor (detected via `human_activity`/`human_changes_requested` tokens in `detail`) bypass
- All 663 existing tests pass; 18 new tests added (7 unit + 11 integration)

## What changed

- **`pm_dispatch.py`**: Added `_slot_in_cooldown`, `_write_slot_dispatch_marker`, `_resolve_cooldown_dir` helpers; added `skipped_cooldown` field to `DispatchResult`; wired cooldown check + marker write into the main dispatch loop
- **`test_pm_dispatch.py`**: Added `autouse` fixture to isolate existing tests from production cooldown state (monkeypatches `PM_DISPATCH_COOLDOWN_DIR` to `tmp_path`); added `TestSlotCooldownHelpers` + `TestDispatchGroupedItemsCooldown` suites

## Context

Part of reactive-dispatch phase 2/3 execution consolidation. Tracked in ErikBjare/bob#788, prerequisite of step 5 in `knowledge/technical-designs/reactive-dispatch-phase2-3-execution-consolidation.md`.

## Test plan

- [ ] `uv run pytest packages/gptme-runloops/tests/test_pm_dispatch.py -v` — all pass
- [ ] `make typecheck` — clean
- [ ] Review cooldown bypass logic matches bash reference at `scripts/github/project-monitoring-dispatch.sh:355-400`