### PR TITLE
fix(activity-gate): suppress non-comment self-triggered updatedAt bumps (Gap A)

### DIFF
--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -386,6 +386,40 @@ fetch_live_pr_data() {
     fetch_pr_data_with_ttl "$1" "$GH_CACHE_TTL_LIVE_PR"
 }
 
+# Fetch the actor of the most recent non-comment event that bumped updatedAt.
+# Called only in the ambiguous case: updatedAt > watermark but no new comment/review.
+# Returns the actor login on stdout, or empty on error / when no recognized event found.
+# Failure direction: empty output → caller falls through to existing emit behavior.
+# Event types checked: push, draft toggle, label/assignee changes.
+# Args: <owner/repo> <pr_number>
+fetch_pr_noncomment_actor() {
+    local repo=$1
+    local pr_number=$2
+    local owner="${repo%%/*}"
+    local reponame="${repo##*/}"
+    gh api graphql -f query="{
+      repository(owner: \"${owner}\", name: \"${reponame}\") {
+        pullRequest(number: ${pr_number}) {
+          timelineItems(last: 3, itemTypes: [HEAD_REF_FORCE_PUSHED_EVENT, READY_FOR_REVIEW_EVENT, CONVERT_TO_DRAFT_EVENT, LABELED_EVENT, UNLABELED_EVENT, ASSIGNED_EVENT]) {
+            nodes {
+              __typename
+              ... on HeadRefForcePushedEvent { actor { login } }
+              ... on ReadyForReviewEvent { actor { login } }
+              ... on ConvertToDraftEvent { actor { login } }
+              ... on LabeledEvent { actor { login } }
+              ... on UnlabeledEvent { actor { login } }
+              ... on AssignedEvent { actor { login } }
+            }
+          }
+        }
+      }
+    }" --jq \
+        '.data.repository.pullRequest.timelineItems.nodes
+         | map(select(.actor != null and .actor.login != null))
+         | last | .actor.login // empty' \
+        2>/dev/null || true
+}
+
 # Check whether the last activity on a PR was from someone worth responding to.
 # Returns 0 (true) if actionable, 1 if it should be skipped.
 # Skips only two cases:
@@ -503,6 +537,29 @@ check_pr_updates() {
             local last_check
             last_check=$(cat "$state_file")
             if [[ "$updated_at" > "$last_check" ]]; then
+                # Gap A: detect non-comment updatedAt bumps (push, draft toggle,
+                # label/assignee change). If the most recent comment/review predates
+                # the stored watermark, the bump came from a non-comment event.
+                # Fetch timelineItems to check the actor; suppress if it is AUTHOR.
+                # Failure direction: on error, fall through to has_actionable_update.
+                local latest_comment_time
+                latest_comment_time=$(echo "$pr_data" | jq -r '
+                    [
+                        (.comments[-1] | select(. != null) | .createdAt),
+                        (.latestReviews | sort_by(.submittedAt) | last | select(. != null) | .submittedAt)
+                    ]
+                    | map(select(. != null)) | max // ""
+                ' 2>/dev/null)
+                if [ -z "$latest_comment_time" ] || ! [[ "$latest_comment_time" > "$last_check" ]]; then
+                    local noncomment_actor
+                    noncomment_actor=$(fetch_pr_noncomment_actor "$repo" "$pr_number" 2>/dev/null || true)
+                    if [ "$noncomment_actor" = "$AUTHOR" ]; then
+                        # Self-triggered non-comment bump — skip, still advance watermark
+                        echo "$updated_at" > "$state_file"
+                        continue
+                    fi
+                fi
+
                 # Check if the update was from someone we should respond to
                 if has_actionable_update "$pr_data"; then
                     local pr_title priority_tokens item_detail

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -390,7 +390,7 @@ fetch_live_pr_data() {
 # Called only in the ambiguous case: updatedAt > watermark but no new comment/review.
 # Returns the actor login on stdout, or empty on error / when no recognized event found.
 # Failure direction: empty output → caller falls through to existing emit behavior.
-# Event types checked: push, draft toggle, label/assignee changes.
+# Event types checked: regular push, force push, draft toggle, label/assignee/review-request changes.
 # Args: <owner/repo> <pr_number>
 fetch_pr_noncomment_actor() {
     local repo=$1
@@ -400,23 +400,32 @@ fetch_pr_noncomment_actor() {
     gh api graphql -f query="{
       repository(owner: \"${owner}\", name: \"${reponame}\") {
         pullRequest(number: ${pr_number}) {
-          timelineItems(last: 3, itemTypes: [HEAD_REF_FORCE_PUSHED_EVENT, READY_FOR_REVIEW_EVENT, CONVERT_TO_DRAFT_EVENT, LABELED_EVENT, UNLABELED_EVENT, ASSIGNED_EVENT]) {
+          timelineItems(last: 3, itemTypes: [PULL_REQUEST_COMMIT, HEAD_REF_FORCE_PUSHED_EVENT, READY_FOR_REVIEW_EVENT, CONVERT_TO_DRAFT_EVENT, LABELED_EVENT, UNLABELED_EVENT, ASSIGNED_EVENT, UNASSIGNED_EVENT, REVIEW_REQUESTED_EVENT, REVIEW_REQUEST_REMOVED_EVENT]) {
             nodes {
               __typename
+              ... on PullRequestCommit { commit { author { user { login } } } }
               ... on HeadRefForcePushedEvent { actor { login } }
               ... on ReadyForReviewEvent { actor { login } }
               ... on ConvertToDraftEvent { actor { login } }
               ... on LabeledEvent { actor { login } }
               ... on UnlabeledEvent { actor { login } }
               ... on AssignedEvent { actor { login } }
+              ... on UnassignedEvent { actor { login } }
+              ... on ReviewRequestedEvent { actor { login } }
+              ... on ReviewRequestRemovedEvent { actor { login } }
             }
           }
         }
       }
     }" --jq \
         '.data.repository.pullRequest.timelineItems.nodes
-         | map(select(.actor != null and .actor.login != null))
-         | last | .actor.login // empty' \
+         | map(
+             if .actor != null and .actor.login != null then .actor.login
+             elif .commit != null and .commit.author.user.login != null then .commit.author.user.login
+             else null end
+           )
+         | map(select(. != null))
+         | last // empty' \
         2>/dev/null || true
 }
 

--- a/tests/test_activity_gate_gap_a_noncomment_filter.py
+++ b/tests/test_activity_gate_gap_a_noncomment_filter.py
@@ -194,6 +194,42 @@ def test_external_push_after_external_comment_still_emits_pr_update() -> None:
         )
 
 
+def test_fetch_pr_noncomment_actor_includes_regular_push_event() -> None:
+    """P1 regression: PULL_REQUEST_COMMIT must be in the itemTypes list.
+
+    HEAD_REF_FORCE_PUSHED_EVENT only covers force pushes.  A normal `git push`
+    creates PULL_REQUEST_COMMIT timeline items — without this type in the query
+    the helper returns empty for every regular push, leaving the common
+    self-push path unsuppressed.
+    """
+    content = SCRIPT.read_text()
+    assert "PULL_REQUEST_COMMIT" in content, (
+        "fetch_pr_noncomment_actor must include PULL_REQUEST_COMMIT in itemTypes "
+        "to detect regular (non-force) pushes. Without it, normal git pushes by "
+        "the author return an empty actor and fall through to emit pr_update."
+    )
+
+
+def test_fetch_pr_noncomment_actor_includes_metadata_removal_events() -> None:
+    """P2 regression: metadata-removal event types must be in the itemTypes list.
+
+    ASSIGNED_EVENT is present but UNASSIGNED_EVENT, REVIEW_REQUESTED_EVENT, and
+    REVIEW_REQUEST_REMOVED_EVENT were missing.  Author-triggered metadata removals
+    bump updatedAt without a comment, causing spurious pr_update dispatches.
+    """
+    content = SCRIPT.read_text()
+    for event_type in (
+        "UNASSIGNED_EVENT",
+        "REVIEW_REQUESTED_EVENT",
+        "REVIEW_REQUEST_REMOVED_EVENT",
+    ):
+        assert event_type in content, (
+            f"fetch_pr_noncomment_actor must include {event_type} in itemTypes. "
+            "Missing metadata-removal events leave author-triggered updatedAt "
+            "bumps uncovered, producing spurious pr_update dispatches."
+        )
+
+
 def test_timeline_api_error_falls_through_to_emit() -> None:
     """On timeline API error (empty return), fall through to existing emit behavior.
 

--- a/tests/test_activity_gate_gap_a_noncomment_filter.py
+++ b/tests/test_activity_gate_gap_a_noncomment_filter.py
@@ -1,0 +1,218 @@
+"""Regression tests for Gap A in activity-gate.sh.
+
+Gap A (open since 2026-05-23): activity-gate.sh filters self-triggered updates by
+checking the latest comment/review actor, but non-comment events (push, draft toggle,
+label/assignee change) bump updatedAt without creating a comment. If the latest
+comment pre-dates the watermark but was from an external actor (e.g., Greptile),
+the gate incorrectly emits pr_update — dispatching a no-op PM session.
+
+Fix: when updatedAt > watermark but the latest comment/review timestamp is ≤
+watermark, fetch timelineItems(last: 3) via GraphQL to find the actual actor.
+Suppress if the actor is AUTHOR. On error, fall through to existing emit behavior.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "github" / "activity-gate.sh"
+
+TEST_REPO = "testorg/testrepo"
+TEST_PR = 99
+
+# Timeline of events:
+#   COMMENT_TIME  < WATERMARK_TIME  < PUSH_TIME
+# Greptile commented at COMMENT_TIME, we processed it at WATERMARK_TIME
+# (storing that as last_check).  AUTHOR/external-actor pushes at PUSH_TIME.
+COMMENT_TIME = "2026-07-10T09:00:00Z"  # old Greptile comment
+WATERMARK_TIME = "2026-07-10T10:00:00Z"  # stored last_check in state file
+PUSH_TIME = "2026-07-10T12:00:00Z"  # updatedAt after push (> watermark)
+
+FAKE_GH = r"""#!/usr/bin/env python3
+from __future__ import annotations
+import json, os, sys
+
+argv = sys.argv[1:]
+pr_number = int(os.environ.get("TEST_PR_NUMBER", "99"))
+comment_time = os.environ.get("COMMENT_TIME", "2026-07-10T09:00:00Z")
+push_time = os.environ.get("PUSH_TIME", "2026-07-10T12:00:00Z")
+# The actor returned by gh api graphql (timelineItems).
+# Empty string simulates an API error / no-events-found path.
+timeline_actor = os.environ.get("TIMELINE_ACTOR", "")
+
+if not argv:
+    sys.exit(2)
+
+if argv[0] == "repo" and len(argv) > 1 and argv[1] == "list":
+    sys.exit(0)
+
+if argv[0] == "pr" and len(argv) > 1 and argv[1] == "list":
+    pr = [{
+        "number": pr_number,
+        "title": f"fix: some improvement #{pr_number}",
+        "updatedAt": push_time,
+        "comments": [{
+            "author": {"login": "greptile-apps"},
+            "createdAt": comment_time,
+            "body": "Score: 4/5",
+        }],
+        "latestReviews": [],
+        "statusCheckRollup": None,
+        "mergeable": "MERGEABLE",
+        "mergeStateStatus": "BEHIND",
+        "headRefOid": "abc123feed",
+        "isDraft": False,
+    }]
+    print(json.dumps(pr))
+    sys.exit(0)
+
+if argv[0] in ("issue", "run") and len(argv) > 1 and argv[1] == "list":
+    print("[]")
+    sys.exit(0)
+
+if argv[0] == "pr" and len(argv) > 1 and argv[1] == "comment":
+    sys.exit(0)
+
+if argv[0] == "api" and len(argv) > 1 and argv[1] == "graphql":
+    # fetch_pr_noncomment_actor: print the login (what --jq extracts), or nothing.
+    if timeline_actor:
+        print(timeline_actor)
+    sys.exit(0)
+
+if argv[0] == "api":
+    path = argv[1] if len(argv) > 1 else ""
+    jq = argv[argv.index("--jq") + 1] if "--jq" in argv else ""
+    if "permissions" in jq:
+        print("true")
+        sys.exit(0)
+    if "notifications" in path:
+        sys.exit(0)
+    if "--jq" in argv:
+        sys.exit(0)
+    print("[]")
+    sys.exit(0)
+
+sys.exit(0)
+"""
+
+
+def _state_file(state_dir: Path) -> Path:
+    return state_dir / f"{TEST_REPO.replace('/', '-')}-pr-{TEST_PR}.state"
+
+
+def _run_gate(
+    tmp: Path, state_dir: Path, *, timeline_actor: str
+) -> subprocess.CompletedProcess[str]:
+    fake_gh = tmp / "gh"
+    fake_gh.write_text(FAKE_GH)
+    fake_gh.chmod(fake_gh.stat().st_mode | stat.S_IXUSR)
+
+    env = os.environ.copy()
+    env["TEST_PR_NUMBER"] = str(TEST_PR)
+    env["COMMENT_TIME"] = COMMENT_TIME
+    env["PUSH_TIME"] = PUSH_TIME
+    env["TIMELINE_ACTOR"] = timeline_actor
+    env["PATH"] = f"{tmp}:{env['PATH']}"
+
+    return subprocess.run(
+        [
+            str(SCRIPT),
+            "--author",
+            "test-author",
+            "--org",
+            "testorg",
+            "--repo",
+            TEST_REPO,
+            "--state-dir",
+            str(state_dir),
+            "--format",
+            "jsonl",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_own_push_after_external_comment_does_not_emit_pr_update() -> None:
+    """Gap A fix: AUTHOR's own push must NOT trigger a pr_update dispatch.
+
+    Scenario:
+      T=09:00 — Greptile comments (score 4/5)
+      T=10:00 — gate processed, watermark stored as last_check
+      T=12:00 — AUTHOR pushes, updatedAt bumps (no new comment)
+
+    Next gate run: updatedAt(12:00) > watermark(10:00). Latest comment is Greptile
+    at 09:00 ≤ watermark → ambiguous bump. timelineItems returns AUTHOR → suppress.
+
+    Before the fix: has_actionable_update saw Greptile (not AUTHOR) as last actor
+    and emitted pr_update, dispatching a wasted no-op PM session.
+    """
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+
+        _state_file(state_dir).write_text(WATERMARK_TIME)
+
+        result = _run_gate(tmp, state_dir, timeline_actor="test-author")
+
+        assert result.returncode in (0, 1), result.stderr
+        assert '"type":"pr_update"' not in result.stdout, (
+            "Gap A: AUTHOR's own push bumped updatedAt. Latest comment (Greptile) "
+            "predates the watermark. timelineItems returned AUTHOR as actor. "
+            f"pr_update must be suppressed. Output: {result.stdout!r}\n"
+            f"Stderr: {result.stderr!r}"
+        )
+
+
+def test_external_push_after_external_comment_still_emits_pr_update() -> None:
+    """Non-AUTHOR bump must still emit pr_update (safe failure direction).
+
+    Same setup, but the push was by an external collaborator, not AUTHOR.
+    The gate must NOT suppress — external activity is actionable.
+    """
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+
+        _state_file(state_dir).write_text(WATERMARK_TIME)
+
+        result = _run_gate(tmp, state_dir, timeline_actor="external-collaborator")
+
+        assert result.returncode in (0, 1), result.stderr
+        assert '"type":"pr_update"' in result.stdout, (
+            "External actor bumped updatedAt. Gate must still emit pr_update. "
+            f"Output: {result.stdout!r}\n"
+            f"Stderr: {result.stderr!r}"
+        )
+
+
+def test_timeline_api_error_falls_through_to_emit() -> None:
+    """On timeline API error (empty return), fall through to existing emit behavior.
+
+    When fetch_pr_noncomment_actor returns empty, the gate must not silently drop
+    potentially-external activity — emit pr_update as before the fix.
+    """
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+
+        _state_file(state_dir).write_text(WATERMARK_TIME)
+
+        # TIMELINE_ACTOR="" → fake gh returns nothing → empty actor → fall through
+        result = _run_gate(tmp, state_dir, timeline_actor="")
+
+        assert result.returncode in (0, 1), result.stderr
+        assert '"type":"pr_update"' in result.stdout, (
+            "Timeline API returned empty (error). Gate must fall through and emit "
+            f"pr_update. Output: {result.stdout!r}\n"
+            f"Stderr: {result.stderr!r}"
+        )


### PR DESCRIPTION
## Summary

Fixes Gap A in `activity-gate.sh` (open since 2026-05-23): non-comment events
(push, draft toggle, label/assignee change) bump `updatedAt` without creating a
comment. When the latest comment pre-dates the stored watermark but was from an
external actor (e.g. Greptile), the gate incorrectly emitted `pr_update`,
dispatching wasted no-op PM sessions.

**Root cause**: `has_actionable_update` picks the latest comment/review actor.
If AUTHOR's own push bumps `updatedAt` and the most recent comment is from
Greptile (T<watermark), the gate sees Greptile as the actor → emits.

**Fix**: In `check_pr_updates`, when `updatedAt > watermark` but the most recent
comment/review timestamp is ≤ watermark (ambiguous bump), fetch
`timelineItems(last: 3)` via GraphQL and suppress if the actor is `AUTHOR`.
Failure direction is safe: on API error, returns empty and falls through to
existing emit behavior.

**Impact**: Post-#1244, the residue was ~2 cooldown skips per 30h. This closes
the detection gap at the source.

## Changes

- `scripts/github/activity-gate.sh`: add `fetch_pr_noncomment_actor()` helper
  (GraphQL timeline fetch), add Gap A ambiguous-case check in `check_pr_updates`
- `tests/test_activity_gate_gap_a_noncomment_filter.py`: 3 regression tests

## Test plan

- [x] All 28 activity-gate tests pass (`pytest tests/test_activity_gate*.py`)
- [x] `test_own_push_after_external_comment_does_not_emit_pr_update` — AUTHOR push suppressed
- [x] `test_external_push_after_external_comment_still_emits_pr_update` — external push emits
- [x] `test_timeline_api_error_falls_through_to_emit` — API error falls through safely