### PR TITLE
fix(gptmail): surface unreplied messages that age out of the reply window

### DIFF
--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -507,6 +507,46 @@ def _pending_for_mailboxes(
     return pending
 
 
+def _stale_pending(
+    mailboxes: list[str],
+    *,
+    self_name: str,
+    window: int,
+    agents: dict[str, dict[str, str]],
+) -> list[dict]:
+    """Unreplied messages that aged out of the reply window (window=0 -> none).
+
+    These are invisible to the actionable queue by design, but must never be
+    silently dropped: an unanswered message that outlives the SLA window would
+    otherwise disappear from ``pending`` forever, which is how a backlog builds
+    up unnoticed over months.
+    """
+    if window <= 0:
+        return []
+    fresh = {
+        (str(m.get("mailbox", "")), str(m.get("file", "")))
+        for m in _pending_for_mailboxes(
+            mailboxes, self_name=self_name, window=window, agents=agents
+        )
+    }
+    return [
+        m
+        for m in _pending_for_mailboxes(mailboxes, self_name=self_name, window=0, agents=agents)
+        if (str(m.get("mailbox", "")), str(m.get("file", ""))) not in fresh
+    ]
+
+
+def _stale_summary(stale: list[dict]) -> str:
+    """One-line backlog notice: count, oldest age, and how to see them."""
+    now = datetime.now(timezone.utc)
+    ages = [age for age in (_age_days(m, now) for m in stale) if age is not None]
+    oldest = f", oldest {max(ages):.0f}d" if ages else ""
+    return (
+        f"⚠️  {len(stale)} unreplied message(s) older than the reply window{oldest} "
+        "— not shown above. See: agent-msg pending --include-stale"
+    )
+
+
 def _outbox_rows_for_recipient(
     mailboxes: list[str],
     *,
@@ -810,6 +850,11 @@ def reply(message_id: str, content: str | None, mailbox: str | None) -> None:
 @click.option("--for", "for_recipient", default=None, help="Show messages pending for a recipient.")
 @click.option("--fleet", is_flag=True, help="Fan out across all registered agents.")
 @click.option("--json", "json_output", is_flag=True, help="Emit machine-readable JSON.")
+@click.option(
+    "--include-stale",
+    is_flag=True,
+    help="Also list unreplied messages that aged out of the reply window.",
+)
 @click.option("--local-only", is_flag=True, hidden=True, help="Skip fleet fan-out.")
 def pending(
     mailbox: str,
@@ -817,6 +862,7 @@ def pending(
     for_recipient: str | None,
     fleet: bool,
     json_output: bool,
+    include_stale: bool,
     local_only: bool,
 ) -> None:
     """Show inbox messages awaiting a reply (timely-reply SLA)."""
@@ -860,20 +906,24 @@ def pending(
         raise click.BadParameter("--json requires --for", param_hint="--json")
     if local_only:
         raise click.BadParameter("--local-only requires --for", param_hint="--local-only")
+    window = 0 if include_stale else _reply_window_days()
     msgs = _pending_for_mailboxes(
         mailboxes,
         self_name=self_name,
-        window=_reply_window_days(),
+        window=window,
         agents=agents,
     )
-    if not msgs:
-        click.echo("No messages awaiting reply.")
-        return
-    click.echo(f"{len(msgs)} message(s) awaiting reply:")
+    stale = _stale_pending(mailboxes, self_name=self_name, window=window, agents=agents)
     show_prefix = all_mailboxes or any(name != "default" for name in mailboxes)
-    for m in msgs:
-        prefix = _format_mailbox_prefix(str(m.get("mailbox", "default")), show=show_prefix)
-        click.echo(f"  {prefix}{m['file']}  from {m.get('from')}: {m.get('subject', '')}")
+    if msgs:
+        click.echo(f"{len(msgs)} message(s) awaiting reply:")
+        for m in msgs:
+            prefix = _format_mailbox_prefix(str(m.get("mailbox", "default")), show=show_prefix)
+            click.echo(f"  {prefix}{m['file']}  from {m.get('from')}: {m.get('subject', '')}")
+    else:
+        click.echo("No messages awaiting reply.")
+    if stale:
+        click.echo(_stale_summary(stale))
 
 
 @agent.command()
@@ -889,18 +939,22 @@ def status(mailbox: str, all_mailboxes: bool) -> None:
         transport = _transport(mailbox=mailbox_name)
         inbox_count += len(transport.list_inbox("inbox"))
         outbox_count += len(transport.list_inbox("outbox"))
+    window = _reply_window_days()
     pend = _pending_for_mailboxes(
         mailboxes,
         self_name=_self_name(),
-        window=_reply_window_days(),
+        window=window,
         agents=agents,
     )
+    stale = _stale_pending(mailboxes, self_name=_self_name(), window=window, agents=agents)
     click.echo(f"Agent:    {_self_name()}")
     click.echo(f"Registry: {', '.join(agents) or '(none)'}")
     click.echo(f"Mailbox:  {mailboxes[0] if len(mailboxes) == 1 else ', '.join(mailboxes)}")
     click.echo(f"Inbox:    {inbox_count}")
     click.echo(f"Outbox:   {outbox_count}")
     click.echo(f"Pending:  {len(pend)}")
+    if stale:
+        click.echo(f"Stale:    {len(stale)} (unreplied, aged out of reply window)")
 
 
 if __name__ == "__main__":

--- a/packages/gptmail/tests/test_agent_cli.py
+++ b/packages/gptmail/tests/test_agent_cli.py
@@ -405,6 +405,53 @@ def test_pending_respects_reply_window(workspace: Path, monkeypatch: pytest.Monk
     assert "No messages awaiting reply" in result.output
 
 
+def _seed_stale(workspace: Path) -> str:
+    """An unreplied message well past the reply window."""
+    name = "old.md"
+    (workspace / "messages" / "inbox" / name).write_text(
+        "---\nfrom: bob\nto: alice\ntimestamp: 2020-01-01T00:00:00Z\n"
+        "subject: ancient\nread: false\n---\n\nold question\n"
+    )
+    return name
+
+
+def test_pending_warns_about_aged_out_backlog(workspace: Path) -> None:
+    """An aged-out message is not listed, but its existence is never hidden.
+
+    Regression guard: before this, an unreplied message that outlived the SLA
+    window vanished from `pending` permanently, so a backlog could accumulate
+    silently for months with the queue reporting "No messages awaiting reply".
+    """
+    _seed_stale(workspace)
+    result = CliRunner().invoke(agent, ["pending"])
+    assert "No messages awaiting reply" in result.output
+    assert "1 unreplied message(s) older than the reply window" in result.output
+    assert "--include-stale" in result.output
+
+
+def test_pending_include_stale_lists_aged_out_messages(workspace: Path) -> None:
+    name = _seed_stale(workspace)
+    result = CliRunner().invoke(agent, ["pending", "--include-stale"])
+    assert "1 message(s) awaiting reply" in result.output
+    assert name in result.output
+    # No dangling warning when the stale set is already being shown.
+    assert "older than the reply window" not in result.output
+
+
+def test_pending_warning_absent_when_no_stale_backlog(workspace: Path) -> None:
+    _seed_inbox(workspace)
+    result = CliRunner().invoke(agent, ["pending"])
+    assert "1 message(s) awaiting reply" in result.output
+    assert "older than the reply window" not in result.output
+
+
+def test_status_reports_stale_backlog(workspace: Path) -> None:
+    _seed_stale(workspace)
+    result = CliRunner().invoke(agent, ["status"])
+    assert "Pending:  0" in result.output
+    assert "Stale:    1" in result.output
+
+
 def test_pending_excludes_replies_to_my_messages(workspace: Path) -> None:
     """Replies to my own sent messages must not appear in pending.
 


### PR DESCRIPTION
## Problem

`agent-msg pending` silently **drops** any unreplied message older than `AGENT_MSG_REPLY_WINDOW_DAYS` (default 7). The window was intended as a timely-reply SLA, but the effect is a leak: a message you fail to answer within a week disappears from the queue **forever**. There is no escalation path — aging out is indistinguishable from being handled.

The result on Bob's real inbox:

```
$ agent-msg pending
No messages awaiting reply.        # <- 103 unreplied messages, oldest 143 days
```

Three of the hidden messages were from Gordon, asking Bob to fix precisely this "silent backlog builds up over months" failure mode. They aged out before anyone answered them, which is a fairly emphatic demonstration of the bug.

## Fix

Surfacing all 103 in the actionable queue would flood the reply dispatcher (most are long-moot April threads), so the 7-day window stays as the *actionable* queue — but the backlog is no longer allowed to be **silent**:

- `pending` prints a stale-backlog notice (count + oldest age) whenever items aged out, including when the fresh queue is empty
- `pending --include-stale` lists them
- `status` gains a `Stale:` line

```
$ agent-msg pending
No messages awaiting reply.
⚠️  103 unreplied message(s) older than the reply window, oldest 143d — not shown above. See: agent-msg pending --include-stale
```

## Testing

4 new tests (aged-out message warns but isn't listed; `--include-stale` lists it; no warning when backlog is empty; `status` reports it). Full gptmail suite: 150 passed. ruff + mypy clean.

The pre-existing `test_pending_respects_reply_window` still passes unchanged — the window still governs the actionable queue.