### PR TITLE
fix(self-merge-check): let repo allowlist override sensitive-path heuristic

### DIFF
--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -921,16 +921,19 @@ def is_allowed_file(
     repo_path_allowlist: dict[str, list[str]] | None = None,
 ) -> bool:
     """Check if a file falls into any allowed self-merge category."""
-    # Explicit repo allowlist takes precedence over the sensitive-path heuristic.
-    # If an operator has deliberately allowlisted a path, that decision stands even
-    # when the keyword scanner would flag it (e.g. LLM tokenizer files named tokens.py).
-    if is_repo_allowlisted_path(path, repo, repo_path_allowlist):
-        return True
-    if is_sensitive_path(path):
-        return False
+    # Hard-reject bot config and spec-like docs regardless of allowlist — these
+    # categories require human review regardless of what the operator has allowlisted.
     if is_bot_config(path):
         return False
     if is_doc_file(path) and is_spec_like_doc(path):
+        return False
+    # Explicit repo allowlist overrides only the sensitive-path keyword heuristic.
+    # If an operator has deliberately allowlisted a path, that decision stands even
+    # when the keyword scanner would flag it (e.g. LLM tokenizer files named tokens.py),
+    # but bot-config and spec-like-doc guards above are not bypassable.
+    if is_repo_allowlisted_path(path, repo, repo_path_allowlist):
+        return True
+    if is_sensitive_path(path):
         return False
     return (
         is_test_file(path)

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -921,6 +921,11 @@ def is_allowed_file(
     repo_path_allowlist: dict[str, list[str]] | None = None,
 ) -> bool:
     """Check if a file falls into any allowed self-merge category."""
+    # Explicit repo allowlist takes precedence over the sensitive-path heuristic.
+    # If an operator has deliberately allowlisted a path, that decision stands even
+    # when the keyword scanner would flag it (e.g. LLM tokenizer files named tokens.py).
+    if is_repo_allowlisted_path(path, repo, repo_path_allowlist):
+        return True
     if is_sensitive_path(path):
         return False
     if is_bot_config(path):
@@ -933,7 +938,6 @@ def is_allowed_file(
         or is_task_metadata(path)
         or is_internal_tooling(path)
         or is_doc_file(path)
-        or is_repo_allowlisted_path(path, repo, repo_path_allowlist)
     )
 
 
@@ -950,7 +954,16 @@ def classify_category(
     if not paths:
         return None, ["PR has no changed files"]
 
-    if any(is_sensitive_path(path) for path in paths):
+    # Build the allowlist before the sensitive-path check so that explicitly
+    # allowlisted paths can override the keyword heuristic (e.g. an LLM tokenizer
+    # file named tokens.py passes when the operator adds it to SELF_MERGE_ALLOWED_PATHS).
+    repo_path_allowlist = _get_repo_path_allowlist()
+
+    if any(
+        is_sensitive_path(path)
+        and not is_repo_allowlisted_path(path, repo, repo_path_allowlist)
+        for path in paths
+    ):
         reasons.append("Touches sensitive/security/infra paths")
         return None, reasons
 
@@ -963,8 +976,6 @@ def classify_category(
     if any(is_doc_file(path) and is_spec_like_doc(path) for path in paths):
         reasons.append("Touches spec-like documentation requiring human review")
         return None, reasons
-
-    repo_path_allowlist = _get_repo_path_allowlist()
 
     # Single-category fast paths
     if all(is_test_file(path) for path in paths):

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -1238,6 +1238,43 @@ def test_classify_repo_allowlisted_path_is_repo_scoped() -> None:
         assert any("allowed self-merge category" in reason for reason in reasons)
 
 
+def test_classify_sensitive_path_overridden_by_allowlist() -> None:
+    """Explicitly allowlisted paths pass even when the keyword scanner flags them.
+
+    Real case: LLM tokenizer utility files like gptme/util/tokens.py are flagged by
+    the 'token' keyword heuristic, but they are not auth/security sensitive.
+    An operator can add them to SELF_MERGE_ALLOWED_PATHS to unblock auto-merge.
+    Both the source file and its test file must be allowlisted.
+    """
+    with patch.dict(
+        "os.environ",
+        {
+            "SELF_MERGE_ALLOWED_PATHS": (
+                "gptme/gptme:gptme/util/**,gptme/gptme:tests/test_util_tokens.py"
+            )
+        },
+    ):
+        # Without the fix, both paths would be blocked by "Touches sensitive/security/infra paths"
+        # because "tokens" stem matches the "token" keyword with the plural-s rule.
+        category, reasons = self_merge_check.classify_category(
+            ["gptme/util/tokens.py", "tests/test_util_tokens.py"],
+            repo="gptme/gptme",
+        )
+        assert category is not None, f"Expected allowed, got reasons: {reasons}"
+        assert not any("sensitive" in r.lower() for r in reasons)
+
+
+def test_is_allowed_file_allowlist_overrides_sensitive_path() -> None:
+    """is_allowed_file returns True for an allowlisted path even when it is sensitive."""
+    allowlist = {"gptme/gptme": ["gptme/util/**"]}
+    # Without allowlist: blocked by the sensitive-path heuristic ("token" → "tokens")
+    assert not self_merge_check.is_allowed_file("gptme/util/tokens.py")
+    # With explicit allowlist: allowed (operator override takes precedence)
+    assert self_merge_check.is_allowed_file(
+        "gptme/util/tokens.py", repo="gptme/gptme", repo_path_allowlist=allowlist
+    )
+
+
 def test_evaluate_pr_captures_head_sha() -> None:
     """CheckResult.head_sha reflects the headRefOid from fetch_pr."""
     pr_data = {

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -1269,9 +1269,18 @@ def test_is_allowed_file_allowlist_overrides_sensitive_path() -> None:
     allowlist = {"gptme/gptme": ["gptme/util/**"]}
     # Without allowlist: blocked by the sensitive-path heuristic ("token" → "tokens")
     assert not self_merge_check.is_allowed_file("gptme/util/tokens.py")
-    # With explicit allowlist: allowed (operator override takes precedence)
+    # With explicit allowlist: allowed (operator override takes precedence over heuristic)
     assert self_merge_check.is_allowed_file(
         "gptme/util/tokens.py", repo="gptme/gptme", repo_path_allowlist=allowlist
+    )
+
+
+def test_is_allowed_file_allowlist_does_not_bypass_bot_config() -> None:
+    """Allowlist overrides only the sensitive-path heuristic; bot config is never bypassable."""
+    # Even if an operator accidentally allowlists a CI workflow, it stays blocked.
+    allowlist = {"gptme/gptme": [".github/**"]}
+    assert not self_merge_check.is_allowed_file(
+        ".github/workflows/ci.yml", repo="gptme/gptme", repo_path_allowlist=allowlist
     )
 
 


### PR DESCRIPTION
## Problem

The `SENSITIVE_PATH_PARTS` keyword scanner runs *before* the repo-specific path allowlist check. An operator using `SELF_MERGE_ALLOWED_PATHS` to explicitly approve a path can still be blocked by a keyword false-positive.

**Real trigger**: `gptme/util/tokens.py` (LLM tokenizer utility — counts how many tokens text contains) is flagged by the `"token"` keyword because `"tokens"` matches `token` + plural-s rule. The file is not auth/security-sensitive, but the heuristic can't distinguish LLM-tokenizer from auth-token semantics.

## Fix

Two-line change to the ordering:

1. **`classify_category`**: Move `repo_path_allowlist = _get_repo_path_allowlist()` before the sensitive check, then exclude allowlisted paths from the gate: `is_sensitive_path(p) and not is_repo_allowlisted_path(p, repo, allowlist)`.

2. **`is_allowed_file`**: Check `is_repo_allowlisted_path` *before* `is_sensitive_path`. If explicitly allowlisted, return `True` immediately.

An explicit operator decision (`SELF_MERGE_ALLOWED_PATHS`) now takes precedence over the heuristic, which is the right semantic.

## Usage

```bash
# Allow gptme's tokenizer utility and its test to auto-merge:
export SELF_MERGE_ALLOWED_PATHS="gptme/gptme:gptme/util/**,gptme/gptme:tests/test_util_tokens.py"
```

## Tests

- `test_classify_sensitive_path_overridden_by_allowlist` — a path flagged by the keyword scanner passes when explicitly allowlisted
- `test_is_allowed_file_allowlist_overrides_sensitive_path` — `is_allowed_file` returns True for an allowlisted sensitive path

All 97 existing tests still pass.