### PR TITLE
feat(bobutils): add shared workspace utility package (stdlib-only)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
     args: [--config-file=mypy.ini, --explicit-package-bases]
     types: [python]
     pass_filenames: true
-    exclude: ^(packages/(gptme-lessons-extras|gptme-runloops|gptme-contrib-lib|gptodo|gptmail|gptme-activity-summary|gptme-voice|gptme-dashboard|gptme-sessions|gptme-daily-briefing|gptme-codegraph|gptme-coordination|gptme-rag)/|plugins/)
+    exclude: ^(packages/(bobutils|gptme-lessons-extras|gptme-runloops|gptme-contrib-lib|gptodo|gptmail|gptme-activity-summary|gptme-voice|gptme-dashboard|gptme-sessions|gptme-daily-briefing|gptme-codegraph|gptme-coordination|gptme-rag)/|plugins/)
 - repo: local
   hooks:
   - id: check-markdown-links

--- a/packages/bobutils/Makefile
+++ b/packages/bobutils/Makefile
@@ -1,0 +1,7 @@
+.PHONY: test typecheck
+
+test:  ## Run tests for this package
+	uv run pytest tests/ -v
+
+typecheck:  ## Run mypy for this package
+	uv run --with mypy mypy src/ --ignore-missing-imports

--- a/packages/bobutils/Makefile
+++ b/packages/bobutils/Makefile
@@ -1,7 +1,5 @@
-.PHONY: test typecheck
-
-test:  ## Run tests for this package
+test:
 	uv run pytest tests/ -v
 
-typecheck:  ## Run mypy for this package
-	uv run --with mypy mypy src/ --ignore-missing-imports
+typecheck:
+	uv run mypy src/ --ignore-missing-imports

--- a/packages/bobutils/Makefile
+++ b/packages/bobutils/Makefile
@@ -2,4 +2,4 @@ test:
 	uv run pytest tests/ -v
 
 typecheck:
-	uv run mypy src/ --ignore-missing-imports
+	uv run --with mypy mypy src/ --ignore-missing-imports

--- a/packages/bobutils/pyproject.toml
+++ b/packages/bobutils/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "bobutils"
+version = "0.1.0"
+description = "Shared workspace utilities for gptme agents (stdlib-only)"
+requires-python = ">=3.10"
+dependencies = []
+
+[project.optional-dependencies]
+test = [
+    "pytest>=7.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/bobutils"]

--- a/packages/bobutils/src/bobutils/__init__.py
+++ b/packages/bobutils/src/bobutils/__init__.py
@@ -1,0 +1,4 @@
+"""Shared workspace utilities for gptme agents (stdlib-only)."""
+
+__all__ = ["__version__"]
+__version__ = "0.1.0"

--- a/packages/bobutils/src/bobutils/coerce.py
+++ b/packages/bobutils/src/bobutils/coerce.py
@@ -10,6 +10,7 @@ function — see validate_no_duplicate_utils.py ALLOWLIST.
 
 from __future__ import annotations
 
+import math
 from typing import overload
 
 __all__ = ["coerce_int", "coerce_int_nullable"]
@@ -43,6 +44,8 @@ def coerce_int(value: object, default: int | None = 0) -> int | None:
     if isinstance(value, int):
         return value
     if isinstance(value, float):
+        if not math.isfinite(value):
+            return default
         return int(round(value))
     if isinstance(value, str) and value.strip():
         try:

--- a/packages/bobutils/src/bobutils/coerce.py
+++ b/packages/bobutils/src/bobutils/coerce.py
@@ -1,0 +1,61 @@
+"""Canonical coerce_int helper.
+
+Replaces 5 per-script ``_coerce_int`` definitions whose core logic was
+identical (None/bool → default, int → int, float → int(round), str → int)
+but varied in whether failure returns 0 or None.
+
+Callers that intentionally convert bool to int (e.g. True→1) keep a local
+function — see validate_no_duplicate_utils.py ALLOWLIST.
+"""
+
+from __future__ import annotations
+
+from typing import overload
+
+__all__ = ["coerce_int", "coerce_int_nullable"]
+
+
+@overload
+def coerce_int(value: object) -> int: ...
+@overload
+def coerce_int(value: object, default: int) -> int: ...
+@overload
+def coerce_int(value: object, default: None) -> int | None: ...
+
+
+def coerce_int(value: object, default: int | None = 0) -> int | None:
+    """Coerce a mixed value to int.
+
+    Guards against bool (``isinstance(True, int)`` is True in Python),
+    rounds floats, strips whitespace from strings. Returns *default* for
+    None, bool, or unparseable values.
+
+    Args:
+        value: Value to coerce.
+        default: Returned when value cannot be coerced. Use ``None`` for
+            nullable callers; defaults to 0 (non-nullable).
+
+    Returns:
+        Coerced int, or *default*.
+    """
+    if value is None or isinstance(value, bool):
+        return default
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(round(value))
+    if isinstance(value, str) and value.strip():
+        try:
+            return int(value.strip())
+        except ValueError:
+            pass
+    return default
+
+
+def coerce_int_nullable(value: object) -> int | None:
+    """Coerce a mixed value to int, returning None for uncoercible values.
+
+    Convenience wrapper around :func:`coerce_int` for callers that previously
+    defined ``_coerce_int(value) -> int | None``.
+    """
+    return coerce_int(value, default=None)

--- a/packages/bobutils/src/bobutils/datetimes.py
+++ b/packages/bobutils/src/bobutils/datetimes.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import datetime, timezone
+
+UTC = timezone.utc
 
 
 def parse_datetime(

--- a/packages/bobutils/src/bobutils/datetimes.py
+++ b/packages/bobutils/src/bobutils/datetimes.py
@@ -1,0 +1,48 @@
+"""Canonical datetime parsing utilities."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+
+def parse_datetime(
+    value: str | datetime | None, *, assume_utc: bool = True
+) -> datetime | None:
+    """Parse an ISO 8601 timestamp string into an aware datetime.
+
+    Handles:
+    - None / non-string input → returns None
+    - Already a datetime → coerces naive to UTC if assume_utc, returns as-is if aware
+    - Z-suffix (both Python 3.11+ native and manual replacement)
+    - Naive result → coerces to UTC when assume_utc=True
+    - Unparseable string → returns None (never raises)
+
+    Callers needing raise semantics should check for None and raise locally.
+
+    Note: the metaproductivity wait-value normalizer (parse_wait_value) is a
+    separate, bespoke function that handles Nd/Nh/cron strings in addition to
+    ISO timestamps — it is NOT replaced by this helper.
+    """
+    if value is None:
+        return None
+
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=UTC) if assume_utc else value
+        return value
+
+    if not isinstance(value, str):
+        return None
+
+    # Python 3.11+ handles Z natively, but normalize proactively for clarity
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC) if assume_utc else parsed
+    return parsed

--- a/packages/bobutils/src/bobutils/durations.py
+++ b/packages/bobutils/src/bobutils/durations.py
@@ -1,0 +1,61 @@
+"""Canonical duration-string parsing.
+
+Replaces ~10 per-file ``parse_duration`` implementations that had drifted into
+inconsistent unit sets ("smhd" vs "dh" vs "d"-only), unanchored regexes that
+accepted trailing garbage ("7dx"), and mixed error behavior. One grammar:
+
+    <non-negative integer><unit>   with unit in s/m/h/d/w (case-insensitive)
+
+Bare integers are rejected unless the caller opts in via ``default_unit``
+(preserves CLI compatibility for callers that historically accepted e.g. "30"
+meaning 30 days). Zero is accepted; callers that require a positive duration
+enforce that themselves.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import timedelta
+
+__all__ = ["parse_duration"]
+
+_UNIT_SECONDS = {
+    "s": 1,
+    "m": 60,
+    "h": 3600,
+    "d": 86400,
+    "w": 604800,
+}
+
+_DURATION_RE = re.compile(r"(\d+)\s*([smhdw])", re.IGNORECASE)
+
+
+def parse_duration(value: str, *, default_unit: str | None = None) -> timedelta:
+    """Parse a duration string like "90s", "45m", "24h", "7d", "2w".
+
+    Args:
+        value: The duration string. Surrounding whitespace is ignored.
+        default_unit: If set (one of "s"/"m"/"h"/"d"/"w"), a bare integer is
+            interpreted in that unit ("30" with default_unit="d" → 30 days).
+            If None (default), bare integers raise ValueError.
+
+    Raises:
+        ValueError: On empty input, unknown unit, trailing garbage, negative
+            values, or a bare integer without ``default_unit``.
+    """
+    if default_unit is not None and default_unit not in _UNIT_SECONDS:
+        raise ValueError(
+            f"default_unit must be one of {sorted(_UNIT_SECONDS)}, got {default_unit!r}"
+        )
+    text = value.strip() if isinstance(value, str) else ""
+    if not text:
+        raise ValueError(f"empty duration string: {value!r}")
+    match = _DURATION_RE.fullmatch(text)
+    if match is None:
+        if default_unit is not None and text.isdigit():
+            return timedelta(seconds=int(text) * _UNIT_SECONDS[default_unit])
+        raise ValueError(
+            f"invalid duration {value!r}: expected <integer><unit> with unit in s/m/h/d/w"
+        )
+    amount, unit = int(match.group(1)), match.group(2).lower()
+    return timedelta(seconds=amount * _UNIT_SECONDS[unit])

--- a/packages/bobutils/src/bobutils/jsonl.py
+++ b/packages/bobutils/src/bobutils/jsonl.py
@@ -1,0 +1,108 @@
+"""Canonical JSONL loading.
+
+Replaces ~20 per-file ``load_jsonl``/``_iter_jsonl`` implementations whose
+behavior had drifted across four axes: missing-file handling, corrupt-line
+handling, non-dict-row filtering, and encoding. The canonical semantics match
+the de-facto majority pattern, with explicit opt-ins for the strict callers:
+
+- Missing file: yields nothing / returns ``[]`` (pass ``must_exist=True`` to
+  raise ``FileNotFoundError`` instead — data-integrity checks want a missing
+  ledger to fail loudly, not read as empty).
+- Blank lines: always skipped.
+- Corrupt JSON lines and non-dict rows: governed by ``on_invalid`` —
+  ``"skip"`` (silent, default), ``"warn"`` (``logging.warning`` per line),
+  or ``"raise"`` (``ValueError`` with path and line number).
+- ``.gz`` paths are opened transparently with :mod:`gzip`.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+import logging
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+__all__ = ["iter_jsonl", "load_jsonl"]
+
+logger = logging.getLogger(__name__)
+
+_ON_INVALID_MODES = ("skip", "warn", "raise")
+
+
+def iter_jsonl(
+    path: str | Path,
+    *,
+    encoding: str = "utf-8",
+    on_invalid: str = "skip",
+    must_exist: bool = False,
+) -> Iterator[dict[str, Any]]:
+    """Return an iterator over dict rows from a JSONL file, one per non-blank line.
+
+    Parameters are validated eagerly at call time (not deferred to first iteration),
+    so ``iter_jsonl(path, on_invalid="typo")`` raises immediately rather than
+    raising on the first ``next()`` call.
+    """
+    if on_invalid not in _ON_INVALID_MODES:
+        raise ValueError(
+            f"on_invalid must be one of {_ON_INVALID_MODES}, got {on_invalid!r}"
+        )
+    path = Path(path)
+    if not path.exists():
+        if must_exist:
+            raise FileNotFoundError(f"JSONL file not found: {path}")
+        return iter(())
+    return _iter_jsonl_rows(path, encoding=encoding, on_invalid=on_invalid)
+
+
+def _iter_jsonl_rows(
+    path: Path,
+    *,
+    encoding: str,
+    on_invalid: str,
+) -> Iterator[dict[str, Any]]:
+    opener = gzip.open if path.suffix == ".gz" else open
+    with opener(path, "rt", encoding=encoding) as f:
+        for lineno, line in enumerate(f, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            problem: str | None = None
+            row: Any = None
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as e:
+                problem = f"invalid JSON: {e}"
+            if problem is None and not isinstance(row, dict):
+                problem = f"non-dict row of type {type(row).__name__}"
+            if problem is not None:
+                if on_invalid == "raise":
+                    raise ValueError(f"{path}:{lineno}: {problem}")
+                if on_invalid == "warn":
+                    logger.warning("%s:%d: %s (skipping line)", path, lineno, problem)
+                continue
+            yield row
+
+
+def load_jsonl(
+    path: str | Path,
+    *,
+    encoding: str = "utf-8",
+    on_invalid: str = "skip",
+    must_exist: bool = False,
+    tail: int | None = None,
+) -> list[dict[str, Any]]:
+    """Load dict rows from a JSONL file into a list.
+
+    ``tail=N`` returns only the last N valid rows — useful for append-only
+    ledgers where only recent entries matter.
+    """
+    rows = list(
+        iter_jsonl(
+            path, encoding=encoding, on_invalid=on_invalid, must_exist=must_exist
+        )
+    )
+    if tail is not None:
+        return rows[-tail:] if tail > 0 else []
+    return rows

--- a/packages/bobutils/src/bobutils/roots.py
+++ b/packages/bobutils/src/bobutils/roots.py
@@ -1,0 +1,51 @@
+"""Canonical repo-root resolver.
+
+Replaces ~9 per-script ``find_repo_root`` / ``repo_root`` / ``_resolve_repo_root``
+implementations that all did the same ``git rev-parse --show-toplevel`` call but
+varied in error handling and whether they accepted a ``cwd`` argument.
+
+**Semantics**:
+
+- Raises ``RuntimeError`` on failure (no silent fallbacks — silent fallbacks hid
+  a real bug in ``scripts/cross-repo-supply-probe.py`` where a missing ``.git``
+  made it return the filesystem root).
+- ``cwd`` defaults to ``Path.cwd()`` when *None*, mirroring how ``git`` itself
+  resolves the working directory.
+- Returns the *worktree* root, not the shared-state root.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+__all__ = ["find_repo_root"]
+
+
+def find_repo_root(cwd: Path | None = None) -> Path:
+    """Return the top-level directory of the git repo containing *cwd*.
+
+    Args:
+        cwd: Directory to start from.  Defaults to ``Path.cwd()``.
+
+    Returns:
+        Absolute ``Path`` to the repo root (as reported by git).
+
+    Raises:
+        RuntimeError: If ``cwd`` is not inside a git repository or git fails.
+    """
+    resolved = (cwd or Path.cwd()).resolve()
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=resolved,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError("git executable not found on PATH") from exc
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"git rev-parse --show-toplevel failed in {resolved}: {result.stderr.strip()}"
+        )
+    return Path(result.stdout.strip())

--- a/packages/bobutils/src/bobutils/shell.py
+++ b/packages/bobutils/src/bobutils/shell.py
@@ -32,8 +32,12 @@ def run_cmd(
     """
     try:
         result = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=timeout, cwd=cwd
+            cmd, capture_output=True, text=True, timeout=timeout, cwd=cwd, check=True
         )
         return result.stdout.strip()
-    except (subprocess.TimeoutExpired, FileNotFoundError):
+    except (
+        subprocess.TimeoutExpired,
+        FileNotFoundError,
+        subprocess.CalledProcessError,
+    ):
         return ""

--- a/packages/bobutils/src/bobutils/shell.py
+++ b/packages/bobutils/src/bobutils/shell.py
@@ -1,0 +1,39 @@
+"""Canonical shell subprocess helper.
+
+Replaces ~4 per-script ``run_cmd`` definitions in generate-backlog-ideas.py,
+ideation.py, weekly-review.py, and quarterly-metrics.py that were byte-identical
+except for the default timeout and an optional cwd override.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+__all__ = ["run_cmd"]
+
+
+def run_cmd(
+    cmd: list[str],
+    timeout: int = 30,
+    *,
+    cwd: Path | str | None = None,
+) -> str:
+    """Run a shell command and return stripped stdout, or '' on failure.
+
+    Args:
+        cmd: Command and arguments.
+        timeout: Seconds before subprocess.TimeoutExpired. Defaults to 30.
+        cwd: Working directory. Defaults to the current process directory.
+
+    Returns:
+        stdout stripped of leading/trailing whitespace, or '' on timeout or
+        missing executable.
+    """
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout, cwd=cwd
+        )
+        return result.stdout.strip()
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return ""

--- a/packages/bobutils/src/bobutils/slugs.py
+++ b/packages/bobutils/src/bobutils/slugs.py
@@ -1,0 +1,36 @@
+"""Canonical slug helper.
+
+Replaces ~14 per-script ``slugify`` definitions whose core logic was identical
+(lowercase → non-alphanumeric runs → hyphens → strip) but varied in max_len
+truncation and empty-input fallback.
+
+Markdown-aware callers (session_to_blog_draft.py, extract-candidates.py) keep
+a local strip step piped into this canonical helper.
+"""
+
+from __future__ import annotations
+
+import re
+
+__all__ = ["slugify"]
+
+
+def slugify(text: str, *, max_len: int | None = None, fallback: str = "item") -> str:
+    """Convert text to a filesystem-safe hyphenated slug.
+
+    Lowercases, collapses non-alphanumeric runs to single hyphens, strips
+    leading/trailing hyphens. Optionally truncates to max_len, stripping any
+    trailing hyphen introduced by the cut. Returns fallback when result is empty.
+
+    Args:
+        text: Input text.
+        max_len: Maximum slug length. No limit when None.
+        fallback: Returned when the slug would otherwise be empty.
+
+    Returns:
+        A slug string, or fallback.
+    """
+    slug = re.sub(r"[^a-z0-9]+", "-", text.lower().strip()).strip("-")
+    if max_len is not None:
+        slug = slug[:max_len].rstrip("-")
+    return slug or fallback

--- a/packages/bobutils/tests/test_coerce.py
+++ b/packages/bobutils/tests/test_coerce.py
@@ -75,3 +75,15 @@ def test_coerce_int_nullable_unparseable() -> None:
 def test_coerce_int_nullable_valid_int() -> None:
     result = coerce_int(5, default=None)
     assert result == 5
+
+
+def test_coerce_int_nan_returns_default() -> None:
+    assert coerce_int(float("nan")) == 0
+
+
+def test_coerce_int_inf_returns_default() -> None:
+    assert coerce_int(float("inf")) == 0
+
+
+def test_coerce_int_neg_inf_returns_default() -> None:
+    assert coerce_int(float("-inf")) == 0

--- a/packages/bobutils/tests/test_coerce.py
+++ b/packages/bobutils/tests/test_coerce.py
@@ -1,0 +1,77 @@
+"""Tests for bobutils.coerce."""
+
+from __future__ import annotations
+
+from bobutils.coerce import coerce_int
+
+
+def test_coerce_int_basic_int() -> None:
+    assert coerce_int(42) == 42
+
+
+def test_coerce_int_negative_int() -> None:
+    assert coerce_int(-7) == -7
+
+
+def test_coerce_int_float_rounds() -> None:
+    assert coerce_int(1.7) == 2
+
+
+def test_coerce_int_float_truncates_negative() -> None:
+    assert coerce_int(-1.7) == -2
+
+
+def test_coerce_int_float_half_rounds_up() -> None:
+    assert coerce_int(0.5) == 0 or coerce_int(0.5) == 1  # banker's rounding ok
+
+
+def test_coerce_int_string_digits() -> None:
+    assert coerce_int("42") == 42
+
+
+def test_coerce_int_string_whitespace() -> None:
+    assert coerce_int("  7  ") == 7
+
+
+def test_coerce_int_none_default_zero() -> None:
+    assert coerce_int(None) == 0
+
+
+def test_coerce_int_bool_true_returns_default() -> None:
+    assert coerce_int(True) == 0  # bool must NOT pass as int 1
+
+
+def test_coerce_int_bool_false_returns_default() -> None:
+    assert coerce_int(False) == 0
+
+
+def test_coerce_int_unparseable_string_default() -> None:
+    assert coerce_int("abc") == 0
+
+
+def test_coerce_int_empty_string_default() -> None:
+    assert coerce_int("") == 0
+
+
+def test_coerce_int_custom_default() -> None:
+    assert coerce_int("bad", default=99) == 99
+
+
+def test_coerce_int_nullable_none() -> None:
+    result = coerce_int(None, default=None)
+    assert result is None
+
+
+def test_coerce_int_nullable_bool() -> None:
+    result = coerce_int(True, default=None)
+    assert result is None
+
+
+def test_coerce_int_nullable_unparseable() -> None:
+    result = coerce_int("bad", default=None)
+    assert result is None
+
+
+def test_coerce_int_nullable_valid_int() -> None:
+    result = coerce_int(5, default=None)
+    assert result == 5

--- a/packages/bobutils/tests/test_datetimes.py
+++ b/packages/bobutils/tests/test_datetimes.py
@@ -1,0 +1,141 @@
+"""Tests for bobutils.datetimes.parse_datetime."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timezone
+
+from bobutils.datetimes import parse_datetime
+
+# --- None / invalid input ---
+
+
+def test_none_returns_none():
+    assert parse_datetime(None) is None
+
+
+def test_empty_string_returns_none():
+    assert parse_datetime("") is None
+
+
+def test_non_string_int_returns_none():
+    assert parse_datetime(42) is None  # type: ignore[arg-type]
+
+
+def test_non_string_list_returns_none():
+    assert parse_datetime([]) is None  # type: ignore[arg-type]
+
+
+def test_garbage_string_returns_none():
+    assert parse_datetime("not-a-date") is None
+
+
+def test_partial_date_returns_none():
+    assert parse_datetime("2026-07") is None
+
+
+# --- Aware ISO strings ---
+
+
+def test_utc_offset_aware():
+    result = parse_datetime("2026-07-04T23:18:37+00:00")
+    assert result is not None
+    assert result.tzinfo is not None
+    assert result.year == 2026
+    assert result.month == 7
+    assert result.day == 4
+
+
+def test_z_suffix_aware():
+    result = parse_datetime("2026-07-04T23:18:37Z")
+    assert result is not None
+    assert result.tzinfo is not None
+    assert result == datetime(2026, 7, 4, 23, 18, 37, tzinfo=UTC)
+
+
+def test_positive_offset():
+    result = parse_datetime("2026-07-04T23:18:37+02:00")
+    assert result is not None
+    assert result.tzinfo is not None
+    # Offset preserved
+    assert result.utcoffset().total_seconds() == 7200  # type: ignore[union-attr]
+
+
+def test_z_and_offset_equivalent():
+    z = parse_datetime("2026-07-04T23:18:37Z")
+    offset = parse_datetime("2026-07-04T23:18:37+00:00")
+    assert z == offset
+
+
+# --- Naive strings (assume_utc=True, the default) ---
+
+
+def test_naive_iso_coerced_to_utc():
+    result = parse_datetime("2026-07-04T23:18:37")
+    assert result is not None
+    assert result.tzinfo == UTC
+
+
+def test_naive_iso_assume_utc_false_stays_naive():
+    result = parse_datetime("2026-07-04T23:18:37", assume_utc=False)
+    assert result is not None
+    assert result.tzinfo is None
+
+
+# --- datetime passthrough ---
+
+
+def test_aware_datetime_passthrough():
+    dt = datetime(2026, 7, 4, 23, 18, 37, tzinfo=UTC)
+    result = parse_datetime(dt)
+    assert result is dt
+
+
+def test_naive_datetime_coerced_to_utc():
+    dt = datetime(2026, 7, 4, 23, 18, 37)
+    result = parse_datetime(dt)
+    assert result is not None
+    assert result.tzinfo == UTC
+    assert result.year == 2026
+
+
+def test_naive_datetime_assume_utc_false():
+    dt = datetime(2026, 7, 4, 23, 18, 37)
+    result = parse_datetime(dt, assume_utc=False)
+    assert result is dt  # returned unchanged
+
+
+def test_aware_datetime_non_utc_passthrough():
+    from datetime import timedelta
+
+    cest = timezone(timedelta(hours=2))
+    dt = datetime(2026, 7, 4, 23, 18, 37, tzinfo=cest)
+    result = parse_datetime(dt)
+    assert result is dt
+    assert result.tzinfo == cest
+
+
+# --- Microseconds and date-only ---
+
+
+def test_microseconds_preserved():
+    result = parse_datetime("2026-07-04T23:18:37.123456+00:00")
+    assert result is not None
+    assert result.microsecond == 123456
+
+
+def test_date_only_string_parsed_as_midnight_utc():
+    # In Python 3.12, datetime.fromisoformat("2026-07-04") returns
+    # datetime(2026, 7, 4, 0, 0) — naive midnight, coerced to UTC by default
+    result = parse_datetime("2026-07-04")
+    assert result is not None
+    assert result == datetime(2026, 7, 4, 0, 0, tzinfo=UTC)
+
+
+# --- Z-suffix edge cases ---
+
+
+def test_z_suffix_with_microseconds():
+    result = parse_datetime("2026-07-04T23:18:37.123456Z")
+    assert result is not None
+    assert result.tzinfo == UTC
+    assert result.microsecond == 123456

--- a/packages/bobutils/tests/test_datetimes.py
+++ b/packages/bobutils/tests/test_datetimes.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timezone
+from datetime import datetime, timezone
 
 from bobutils.datetimes import parse_datetime
+
+UTC = timezone.utc  # datetime.UTC added in Python 3.11; alias for >=3.10 compat
 
 # --- None / invalid input ---
 

--- a/packages/bobutils/tests/test_durations.py
+++ b/packages/bobutils/tests/test_durations.py
@@ -1,0 +1,51 @@
+"""Tests for bobutils.durations."""
+
+from datetime import timedelta
+
+import pytest
+from bobutils.durations import parse_duration
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("90s", timedelta(seconds=90)),
+        ("45m", timedelta(minutes=45)),
+        ("24h", timedelta(hours=24)),
+        ("7d", timedelta(days=7)),
+        ("2w", timedelta(weeks=2)),
+        ("0h", timedelta(0)),
+        ("7D", timedelta(days=7)),
+        (" 7d ", timedelta(days=7)),
+        ("7 d", timedelta(days=7)),
+    ],
+)
+def test_valid(text, expected):
+    assert parse_duration(text) == expected
+
+
+@pytest.mark.parametrize(
+    "text", ["", "   ", "d", "7x", "7dx", "x7d", "-7d", "7.5h", "7d8h"]
+)
+def test_invalid_raises(text):
+    with pytest.raises(ValueError):
+        parse_duration(text)
+
+
+def test_bare_int_rejected_by_default():
+    with pytest.raises(ValueError, match="invalid duration"):
+        parse_duration("30")
+
+
+def test_bare_int_with_default_unit():
+    assert parse_duration("30", default_unit="d") == timedelta(days=30)
+    assert parse_duration("30", default_unit="m") == timedelta(minutes=30)
+
+
+def test_explicit_unit_wins_over_default_unit():
+    assert parse_duration("30h", default_unit="d") == timedelta(hours=30)
+
+
+def test_bad_default_unit():
+    with pytest.raises(ValueError, match="default_unit must be one of"):
+        parse_duration("30", default_unit="x")

--- a/packages/bobutils/tests/test_jsonl.py
+++ b/packages/bobutils/tests/test_jsonl.py
@@ -1,0 +1,98 @@
+"""Tests for bobutils.jsonl — canonical semantics for every equivalence class
+found in the #1043 duplicate inventory."""
+
+import gzip
+import logging
+
+import pytest
+from bobutils.jsonl import iter_jsonl, load_jsonl
+
+
+@pytest.fixture
+def jsonl_file(tmp_path):
+    path = tmp_path / "data.jsonl"
+    path.write_text(
+        '{"a": 1}\n\n   \n{"b": 2}\n',
+        encoding="utf-8",
+    )
+    return path
+
+
+@pytest.fixture
+def dirty_file(tmp_path):
+    path = tmp_path / "dirty.jsonl"
+    path.write_text(
+        '{"a": 1}\nnot json at all\n[1, 2, 3]\n"bare string"\n{"b": 2}\n',
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_load_basic(jsonl_file):
+    assert load_jsonl(jsonl_file) == [{"a": 1}, {"b": 2}]
+
+
+def test_iter_is_lazy(jsonl_file):
+    it = iter_jsonl(jsonl_file)
+    assert next(it) == {"a": 1}
+
+
+def test_missing_file_returns_empty(tmp_path):
+    assert load_jsonl(tmp_path / "nope.jsonl") == []
+
+
+def test_missing_file_must_exist_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        load_jsonl(tmp_path / "nope.jsonl", must_exist=True)
+    # iter_jsonl validates eagerly — raises at call time, not at first next()
+    with pytest.raises(FileNotFoundError):
+        iter_jsonl(tmp_path / "nope.jsonl", must_exist=True)
+
+
+def test_skip_invalid_default(dirty_file):
+    assert load_jsonl(dirty_file) == [{"a": 1}, {"b": 2}]
+
+
+def test_raise_on_invalid_json(dirty_file):
+    with pytest.raises(ValueError, match=r"dirty\.jsonl:2: invalid JSON"):
+        load_jsonl(dirty_file, on_invalid="raise")
+
+
+def test_raise_on_non_dict_row(tmp_path):
+    path = tmp_path / "arr.jsonl"
+    path.write_text('{"a": 1}\n[1, 2]\n', encoding="utf-8")
+    with pytest.raises(ValueError, match=r"arr\.jsonl:2: non-dict row of type list"):
+        load_jsonl(path, on_invalid="raise")
+
+
+def test_warn_on_invalid(dirty_file, caplog):
+    with caplog.at_level(logging.WARNING, logger="bobutils.jsonl"):
+        rows = load_jsonl(dirty_file, on_invalid="warn")
+    assert rows == [{"a": 1}, {"b": 2}]
+    assert len(caplog.records) == 3
+    assert "skipping line" in caplog.records[0].getMessage()
+
+
+def test_bad_on_invalid_mode_raises_eagerly(jsonl_file):
+    # iter_jsonl validates on_invalid at call time — no next() needed
+    with pytest.raises(ValueError, match="on_invalid must be one of"):
+        iter_jsonl(jsonl_file, on_invalid="explode")
+
+
+def test_tail(tmp_path):
+    path = tmp_path / "ledger.jsonl"
+    path.write_text("".join(f'{{"n": {i}}}\n' for i in range(10)), encoding="utf-8")
+    assert load_jsonl(path, tail=3) == [{"n": 7}, {"n": 8}, {"n": 9}]
+    assert load_jsonl(path, tail=0) == []
+    assert len(load_jsonl(path, tail=100)) == 10
+
+
+def test_gzip_transparent(tmp_path):
+    path = tmp_path / "data.jsonl.gz"
+    with gzip.open(path, "wt", encoding="utf-8") as f:
+        f.write('{"a": 1}\n{"b": 2}\n')
+    assert load_jsonl(path) == [{"a": 1}, {"b": 2}]
+
+
+def test_accepts_str_path(jsonl_file):
+    assert load_jsonl(str(jsonl_file)) == [{"a": 1}, {"b": 2}]

--- a/packages/bobutils/tests/test_roots.py
+++ b/packages/bobutils/tests/test_roots.py
@@ -1,0 +1,86 @@
+"""Tests for bobutils.roots."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+from bobutils.roots import find_repo_root
+
+
+def test_find_repo_root_returns_path_with_git(tmp_path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    result = find_repo_root(tmp_path)
+    assert result == tmp_path.resolve()
+
+
+def test_find_repo_root_subdirectory(tmp_path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subdir = tmp_path / "a" / "b"
+    subdir.mkdir(parents=True)
+    result = find_repo_root(subdir)
+    assert result == tmp_path.resolve()
+
+
+def test_find_repo_root_raises_outside_git(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="git rev-parse"):
+        find_repo_root(tmp_path)
+
+
+def test_find_repo_root_wraps_missing_git(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def raise_missing_git(
+        *args: Any, **kwargs: Any
+    ) -> subprocess.CompletedProcess[str]:
+        raise FileNotFoundError("git")
+
+    monkeypatch.setattr(subprocess, "run", raise_missing_git)
+
+    with pytest.raises(RuntimeError, match="git executable not found"):
+        find_repo_root(tmp_path)
+
+
+def test_find_repo_root_worktree_returns_worktree_root(tmp_path: Path) -> None:
+    """Worktree root differs from shared-state root — document the contrast."""
+    base = tmp_path / "base"
+    base.mkdir()
+    subprocess.run(
+        ["git", "init"],
+        cwd=base,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "checkout", "-b", "main"],
+        cwd=base,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@test"], cwd=base, capture_output=True
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"], cwd=base, capture_output=True
+    )
+    # Commit something so worktree add can branch.
+    # Use --no-verify to bypass any workspace-level commit hooks.
+    (base / "f.txt").write_text("x")
+    subprocess.run(["git", "add", "."], cwd=base, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "--no-verify", "-m", "init"],
+        cwd=base,
+        check=True,
+        capture_output=True,
+    )
+    wt = tmp_path / "worktree"
+    subprocess.run(
+        ["git", "worktree", "add", str(wt), "-b", "wt-branch"],
+        cwd=base,
+        check=True,
+        capture_output=True,
+    )
+    # find_repo_root resolves to the *worktree* root, not the base
+    assert find_repo_root(wt) == wt.resolve()

--- a/packages/bobutils/tests/test_shell.py
+++ b/packages/bobutils/tests/test_shell.py
@@ -1,0 +1,26 @@
+"""Tests for bobutils.shell."""
+
+from __future__ import annotations
+
+from bobutils.shell import run_cmd
+
+
+def test_run_cmd_basic() -> None:
+    assert run_cmd(["echo", "hello"]) == "hello"
+
+
+def test_run_cmd_strips_trailing_newline() -> None:
+    assert run_cmd(["printf", "world\n"]) == "world"
+
+
+def test_run_cmd_timeout_returns_empty() -> None:
+    assert run_cmd(["sleep", "10"], timeout=0) == ""
+
+
+def test_run_cmd_missing_command_returns_empty() -> None:
+    assert run_cmd(["nonexistent-command-xyz-abc"]) == ""
+
+
+def test_run_cmd_cwd(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    result = run_cmd(["pwd"], cwd=tmp_path)
+    assert result == str(tmp_path)

--- a/packages/bobutils/tests/test_shell.py
+++ b/packages/bobutils/tests/test_shell.py
@@ -24,3 +24,7 @@ def test_run_cmd_missing_command_returns_empty() -> None:
 def test_run_cmd_cwd(tmp_path) -> None:  # type: ignore[no-untyped-def]
     result = run_cmd(["pwd"], cwd=tmp_path)
     assert result == str(tmp_path)
+
+
+def test_run_cmd_nonzero_exit_returns_empty() -> None:
+    assert run_cmd(["sh", "-c", "printf stale; exit 1"]) == ""

--- a/packages/bobutils/tests/test_slugs.py
+++ b/packages/bobutils/tests/test_slugs.py
@@ -1,0 +1,43 @@
+"""Tests for bobutils.slugs."""
+
+from __future__ import annotations
+
+from bobutils.slugs import slugify
+
+
+def test_slugify_basic() -> None:
+    assert slugify("Hello World") == "hello-world"
+
+
+def test_slugify_special_chars() -> None:
+    assert slugify("Fix: some/thing!") == "fix-some-thing"
+
+
+def test_slugify_numbers() -> None:
+    assert slugify("v1.2.3") == "v1-2-3"
+
+
+def test_slugify_strips_input() -> None:
+    assert slugify("  hello  ") == "hello"
+
+
+def test_slugify_max_len() -> None:
+    result = slugify("a" * 100, max_len=20)
+    assert len(result) <= 20
+
+
+def test_slugify_max_len_no_trailing_hyphen() -> None:
+    result = slugify("abc-def", max_len=6)
+    assert not result.endswith("-")
+
+
+def test_slugify_empty_uses_fallback() -> None:
+    assert slugify("", fallback="default") == "default"
+
+
+def test_slugify_empty_default_fallback() -> None:
+    assert slugify("---") == "item"
+
+
+def test_slugify_custom_fallback() -> None:
+    assert slugify("!!!", fallback="spec") == "spec"

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,7 @@ resolution-markers = [
 [manifest]
 members = [
     "aw-watcher-agent",
+    "bobutils",
     "credential-slots",
     "gptmail",
     "gptme-ace",
@@ -508,6 +509,20 @@ sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e0485151
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
 ]
+
+[[package]]
+name = "bobutils"
+version = "0.1.0"
+source = { editable = "packages/bobutils" }
+
+[package.optional-dependencies]
+test = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" }]
+provides-extras = ["test"]
 
 [[package]]
 name = "build"
@@ -1067,7 +1082,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [


### PR DESCRIPTION
## Summary

- Adds `bobutils` — seven stdlib-only utility modules extracted from per-script duplicate implementations found across gptme agent workspaces
- Zero external dependencies; `requires-python = ">=3.10"`
- 89 tests, all passing

### Modules

| Module | Replaces |
|--------|---------|
| `jsonl` | ~20 per-file `load_jsonl`/`iter_jsonl` variants with drifted semantics |
| `durations` | ~10 per-file `parse_duration` implementations (inconsistent unit sets, unanchored regexes) |
| `datetimes` | per-file `parse_datetime` with Z-suffix and naive→UTC coercion |
| `roots` | ~9 per-script `find_repo_root` / `repo_root` / `_resolve_repo_root` calls |
| `shell` | ~4 per-script `run_cmd` definitions |
| `slugs` | ~14 per-script `slugify` definitions |
| `coerce` | ~5 per-script `_coerce_int` definitions |

## Test plan

- [x] `uv run pytest packages/bobutils/tests/ -q` → 89 passed
- [x] Pre-commit hooks pass (ruff, mypy excluded via `.pre-commit-config.yaml`)
- [x] No external dependencies (stdlib-only confirmed via `pyproject.toml`)