### PR TITLE
feat(release): publish gptme-wisdom-mcp tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,7 @@ on:
       - 'gptodo-v[0-9]*'
       - 'gptmail-v[0-9]*'
       - 'gptme-rag-v[0-9]*'
+      - 'gptme-wisdom-mcp-v[0-9]*'
 
 jobs:
   publish:


### PR DESCRIPTION
## Summary

Allow the shared publish workflow to run for `gptme-wisdom-mcp-v*` tags. The existing workflow already validates the tag against `packages/gptme-wisdom-mcp/pyproject.toml` and publishes via OIDC.

## Verification

- Parsed `.github/workflows/publish.yml` and confirmed the new trigger is present.
- Confirmed `gptme-wisdom-mcp-v0.1.0` resolves to package `gptme-wisdom-mcp` and version `0.1.0`.
- `actionlint` passed.

## Release prerequisite

`gptme-wisdom-mcp` is not yet on PyPI (HTTP 404), and the repository has no visible `pypi` GitHub environment. Before tagging, configure PyPI trusted publishing (pending publisher) for this repository, workflow `.github/workflows/publish.yml`, and environment `pypi`.