### PR TITLE
fix(lessons): remove CLAUDE.md-matching keyword from python-invocation

### DIFF
--- a/lessons/tools/python-invocation.md
+++ b/lessons/tools/python-invocation.md
@@ -8,7 +8,6 @@ match:
   - "use python3 instead of python"
   - "python vs python3"
   - "which python to use"
-  - "use python3"
 status: active
 description: "Always use `python3` explicitly instead of `python` in shell commands and scripts."
 ---


### PR DESCRIPTION
## Problem

`lessons/tools/python-invocation.md` had keyword `use python3` which matches CLAUDE.md's autoloaded section "Use python3 Not python" in nearly every session. LOO showed trigger_acc=0.35 and Δ=-0.021 (n=203).

## Fix

Remove the over-broad keyword; keep error-specific and explicit workflow triggers.

## Verification

- `validate.py` on the lesson file
- Scoped pre-commit passed in worktree