### PR TITLE
feat(gptme-backoff): add resilient retry utilities

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
     args: [--config-file=mypy.ini, --explicit-package-bases]
     types: [python]
     pass_filenames: true
-    exclude: ^(packages/(bobutils|gptme-lessons-extras|gptme-runloops|gptme-contrib-lib|gptodo|gptmail|gptme-activity-summary|gptme-voice|gptme-dashboard|gptme-sessions|gptme-daily-briefing|gptme-codegraph|gptme-coordination|gptme-rag)/|plugins/)
+    exclude: ^(packages/(bobutils|gptme-backoff|gptme-lessons-extras|gptme-runloops|gptme-contrib-lib|gptodo|gptmail|gptme-activity-summary|gptme-voice|gptme-dashboard|gptme-sessions|gptme-daily-briefing|gptme-codegraph|gptme-coordination|gptme-rag)/|plugins/)
 - repo: local
   hooks:
   - id: check-markdown-links

--- a/packages/gptme-backoff/Makefile
+++ b/packages/gptme-backoff/Makefile
@@ -1,0 +1,5 @@
+test:
+	uv run --extra test pytest tests/ -v
+
+typecheck:
+	uv run --with mypy mypy src/ --ignore-missing-imports

--- a/packages/gptme-backoff/README.md
+++ b/packages/gptme-backoff/README.md
@@ -1,0 +1,192 @@
+# gptme-backoff
+
+Retry decorators and error-type classification for resilient agent tool calls.
+
+Built on [tenacity](https://tenacity.readthedocs.io/). Two layers:
+
+- **Phase 1** (`retry.py`): Exponential backoff + jitter decorators with preset
+  configurations for API calls and file I/O.
+- **Phase 2** (`error_classification.py`): Error-type classification that selects
+  retry strategy (attempts, backoff, jitter) per exception class — 429s get
+  more attempts + wider jitter; 401s fail immediately.
+
+Both layers are self-contained standard-library code. Phase 2 does not import
+tenacity at all — use it standalone or pair it with Phase 1's presets.
+
+---
+
+## Quick Start
+
+```python
+from gptme_backoff import retry_api_call
+
+@retry_api_call(max_attempts=5, timeout=30)
+def call_api() -> dict:
+    ...
+```
+
+---
+
+## Phase 1: Retry Decorators
+
+### `retry_sync` / `retry_async`
+
+Low-level decorators wrapping `tenacity.Retrying` / `tenacity.AsyncRetrying`.
+Pass any tenacity stop, wait, or retry condition directly:
+
+```python
+from gptme_backoff import retry_sync
+import tenacity
+
+@retry_sync(stop=tenacity.stop_after_attempt(5), wait=tenacity.wait_fixed(1))
+def fetch(url: str) -> str:
+    ...
+```
+
+### `retry_api_call`
+
+Keyword-argument preset tuned for HTTP API calls. Combines exponential backoff
+with optional additive jitter and wall-clock timeout:
+
+```python
+from gptme_backoff import retry_api_call
+
+@retry_api_call(max_attempts=5, timeout=30)
+def call_api() -> dict:
+    ...
+```
+
+| Parameter     | Default | Description |
+|---------------|---------|-------------|
+| `max_attempts`| 3       | Max retry attempts |
+| `timeout`     | None    | Wall-clock timeout (seconds) |
+| `min_wait`    | 1.0     | Minimum wait (seconds) |
+| `max_wait`    | 60.0    | Maximum wait (seconds) |
+| `multiplier`  | 2.0     | Exponential backoff factor |
+| `jitter`      | True    | Add random jitter to waits |
+| `retry_on`    | `Exception` | Which exception types trigger retry |
+
+Works with both sync and async functions (tenacity auto-detects).
+
+### `retry_file_op`
+
+Preset for file I/O. Only retries on `OSError` by default (EAGAIN, EBUSY,
+ENOSPC — not `ValueError` or `TypeError`):
+
+```python
+from gptme_backoff import retry_file_op
+
+@retry_file_op(max_attempts=5)
+def read_config() -> str:
+    ...
+```
+
+| Parameter     | Default    | Description |
+|---------------|------------|-------------|
+| `max_attempts`| 3          | Max retry attempts |
+| `min_wait`    | 0.1        | Minimum wait (seconds) |
+| `max_wait`    | 5.0        | Maximum wait (seconds) |
+| `multiplier`  | 2.0        | Exponential backoff factor |
+| `retry_on`    | `OSError`  | Which exception types trigger retry |
+
+---
+
+## Phase 2: Error-Type Classification
+
+Phase 2 adds a classification layer on top of (or as an alternative to) the
+Phase 1 presets. Instead of one strategy per decorator, the classifier picks a
+strategy per *exception type*.
+
+### `ErrorClassifier`
+
+Maps exception types to retry strategies via ordered rules:
+
+```python
+from gptme_backoff import ErrorClassifier, RetryStrategy, retry_classified
+
+classifier = ErrorClassifier.default()
+
+# 429 -> RATE_LIMIT (more attempts, wider jitter)
+# 401 -> AUTH (no retry)
+# ConnectionError -> TRANSIENT (standard backoff)
+
+@retry_classified(classifier=classifier)
+def call_api() -> dict:
+    ...
+```
+
+### Strategies
+
+| Strategy       | Max attempts | Base wait | Max wait | Jitter | Use case |
+|----------------|-------------|-----------|----------|--------|----------|
+| `TRANSIENT`    | 4           | 0.5s      | 30s      | Yes    | Connection resets, 503s |
+| `RATE_LIMIT`   | 6           | 2.0s      | 120s     | Yes    | 429 throttling |
+| `AUTH`         | 1           | —         | —        | No     | 401/403 — fail fast |
+| `CONSISTENCY`  | 8           | 1.0s      | 60s      | Yes    | Eventual-consistency reads |
+| `UNKNOWN`      | 2           | 1.0s      | 10s      | Yes    | Catch-all |
+
+### Custom Rules
+
+Register explicit exception-type or predicate-based rules:
+
+```python
+from gptme_backoff import ErrorClassifier, ErrorRule, RetryStrategy
+
+classifier = ErrorClassifier(rules=[
+    ErrorRule(RetryStrategy.RATE_LIMIT, exc_types=(RateLimitError,)),
+    ErrorRule(RetryStrategy.AUTH, exc_types=(AuthError,)),
+    ErrorRule(RetryStrategy.TRANSIENT, exc_types=(ConnectionError, TimeoutError)),
+    # Predicate: match any exception with a 429 status code
+    ErrorRule(RetryStrategy.RATE_LIMIT, predicate=lambda e: getattr(e, "status_code", 0) == 429),
+    # Catch-all
+    ErrorRule(RetryStrategy.TRANSIENT, exc_types=(Exception,)),
+])
+```
+
+The first matching rule wins — specific rules shadow broad ones.
+
+### `retry_classified`
+
+Decorator that runs the classifier loop manually (no tenacity dependency).
+Callable for both sync and async functions:
+
+```python
+from gptme_backoff import retry_classified, ErrorClassifier
+
+classifier = ErrorClassifier.default()
+
+@retry_classified(classifier=classifier)
+def call_api() -> dict:
+    ...
+
+# Async works too:
+@retry_classified(classifier=classifier)
+async def call_api_async() -> dict:
+    ...
+
+# Override defaults per call:
+call_api(classifier=custom_classifier)
+```
+
+The decorator supports:
+- An `on_retry` callback invoked before each sleep with `(exception, attempt, strategy)`
+- Injectable `sleep` function for testing (`lambda secs: ...`)
+- Configurable per-strategy configs
+
+---
+
+## Development
+
+```bash
+# Run tests
+make test
+
+# Type check
+make typecheck
+```
+
+---
+
+## License
+
+Same as the gptme-contrib workspace.

--- a/packages/gptme-backoff/pyproject.toml
+++ b/packages/gptme-backoff/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "gptme-backoff"
+version = "0.1.0"
+description = "Thin retry utilities built on tenacity — exponential backoff, jitter, and convenient async/sync decorators for agent tool calls"
+requires-python = ">=3.10"
+dependencies = [
+    "tenacity>=9.0",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=7.0",
+    "pytest-asyncio>=0.25",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/gptme_backoff"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/packages/gptme-backoff/src/gptme_backoff/__init__.py
+++ b/packages/gptme-backoff/src/gptme_backoff/__init__.py
@@ -1,0 +1,37 @@
+"""gptme-backoff — retry decorators and utilities built on tenacity."""
+
+from .circuit_breaker import (
+    CircuitBreaker,
+    CircuitBreakerOpen,
+)
+from .circuit_breaker import (
+    State as CircuitBreakerState,
+)
+from .error_classification import (
+    DEFAULT_STRATEGY_CONFIGS,
+    ErrorClassifier,
+    ErrorRule,
+    RetryStrategy,
+    StrategyConfig,
+    retry_classified,
+)
+from .retry import retry_api_call, retry_async, retry_file_op, retry_sync
+
+__all__ = [
+    # Circuit breaker
+    "CircuitBreaker",
+    "CircuitBreakerOpen",
+    "CircuitBreakerState",
+    # Retry decorators
+    "retry_api_call",
+    "retry_async",
+    "retry_file_op",
+    "retry_sync",
+    # Phase 2: error-type classification
+    "RetryStrategy",
+    "StrategyConfig",
+    "ErrorRule",
+    "ErrorClassifier",
+    "retry_classified",
+    "DEFAULT_STRATEGY_CONFIGS",
+]

--- a/packages/gptme-backoff/src/gptme_backoff/circuit_breaker.py
+++ b/packages/gptme-backoff/src/gptme_backoff/circuit_breaker.py
@@ -1,0 +1,210 @@
+"""Circuit breaker for flaky external calls.
+
+Provides CLOSED → OPEN (on failure threshold) → HALF_OPEN (after cooldown)
+→ CLOSED (on probe success) state machine to prevent cascading failures from
+flaky MCP servers or external APIs.
+
+Usage::
+
+    from gptme_backoff import CircuitBreaker, CircuitBreakerOpen
+
+    cb = CircuitBreaker(name="mcp-filesystem", failure_threshold=5, cooldown=30.0)
+
+    # Direct call interface
+    try:
+        result = cb.call(my_mcp_function, *args, **kwargs)
+    except CircuitBreakerOpen as e:
+        # Fast-fail: don't even attempt the call
+        ...
+
+    # Decorator interface
+    @cb.wrap
+    def call_mcp_tool(*args, **kwargs):
+        ...
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "CircuitBreaker",
+    "CircuitBreakerOpen",
+    "State",
+]
+
+import logging
+import threading
+import time
+from enum import Enum
+from typing import Any, Callable, TypeVar
+
+log = logging.getLogger("gptme_backoff.circuit_breaker")
+
+T = TypeVar("T")
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+class State(str, Enum):
+    CLOSED = "CLOSED"
+    OPEN = "OPEN"
+    HALF_OPEN = "HALF_OPEN"
+
+
+class CircuitBreakerOpen(Exception):
+    """Raised when a call is rejected because the circuit breaker is OPEN."""
+
+    def __init__(self, name: str, retry_after: float | None = None) -> None:
+        self.name = name
+        self.retry_after = retry_after
+        msg = f"Circuit breaker '{name}' is OPEN"
+        if retry_after is not None:
+            msg += f" (retry after {retry_after:.1f}s)"
+        super().__init__(msg)
+
+
+class CircuitBreaker:
+    """Three-state circuit breaker: CLOSED → OPEN → HALF_OPEN → CLOSED.
+
+    CLOSED: calls pass through; consecutive failures increment counter.
+    OPEN: calls rejected immediately after failure_threshold consecutive failures.
+    HALF_OPEN: after cooldown, a single probe call is allowed.
+        - probe success → CLOSED (counter reset)
+        - probe failure → OPEN (cooldown timer reset)
+
+    Thread-safe: all state transitions use an internal lock.
+
+    Parameters
+    ----------
+    name : str
+        Human-readable name for logging and error messages.
+    failure_threshold : int
+        Consecutive failures needed to open the breaker (default 5).
+    cooldown : float
+        Seconds to wait in OPEN state before allowing a probe (default 30.0).
+    """
+
+    def __init__(
+        self,
+        name: str,
+        failure_threshold: int = 5,
+        cooldown: float = 30.0,
+    ) -> None:
+        self.name = name
+        self.failure_threshold = failure_threshold
+        self.cooldown = cooldown
+
+        self._lock = threading.Lock()
+        self._state = State.CLOSED
+        self._failure_count = 0
+        self._opened_at: float | None = None
+        self._probe_in_flight = False
+
+    @property
+    def state(self) -> State:
+        """Current state (may evaluate OPEN→HALF_OPEN transition lazily)."""
+        with self._lock:
+            return self._evaluate_state()
+
+    def _evaluate_state(self) -> State:
+        """Evaluate state, transitioning OPEN→HALF_OPEN when cooldown elapsed.
+
+        Must be called with _lock held.
+        """
+        if self._state == State.OPEN and self._opened_at is not None:
+            elapsed = time.monotonic() - self._opened_at
+            if elapsed >= self.cooldown:
+                self._state = State.HALF_OPEN
+                self._probe_in_flight = False
+                log.info(
+                    "Circuit breaker '%s' → HALF_OPEN (cooldown elapsed)", self.name
+                )
+        return self._state
+
+    def call(self, fn: Callable[..., T], *args: Any, **kwargs: Any) -> T:
+        """Call *fn* through the circuit breaker.
+
+        Raises CircuitBreakerOpen if the breaker is OPEN or a probe is
+        already in-flight in HALF_OPEN state.
+        """
+        with self._lock:
+            state = self._evaluate_state()
+
+            if state == State.OPEN:
+                retry_after = None
+                if self._opened_at is not None:
+                    retry_after = max(
+                        0.0, self.cooldown - (time.monotonic() - self._opened_at)
+                    )
+                raise CircuitBreakerOpen(self.name, retry_after=retry_after)
+
+            if state == State.HALF_OPEN:
+                if self._probe_in_flight:
+                    raise CircuitBreakerOpen(self.name)
+                self._probe_in_flight = True
+
+        try:
+            result = fn(*args, **kwargs)
+        except Exception as exc:
+            self._on_failure(exc)
+            raise
+        else:
+            self._on_success()
+            return result
+
+    def _on_success(self) -> None:
+        with self._lock:
+            if self._state in (State.HALF_OPEN, State.CLOSED):
+                if self._state == State.HALF_OPEN:
+                    log.info(
+                        "Circuit breaker '%s' → CLOSED (probe succeeded)", self.name
+                    )
+                self._state = State.CLOSED
+                self._failure_count = 0
+                self._opened_at = None
+                self._probe_in_flight = False
+
+    def _on_failure(self, exc: Exception) -> None:
+        with self._lock:
+            if self._state == State.HALF_OPEN:
+                self._state = State.OPEN
+                self._opened_at = time.monotonic()
+                self._probe_in_flight = False
+                log.warning(
+                    "Circuit breaker '%s' probe failed (%s) → OPEN (cooldown reset)",
+                    self.name,
+                    exc,
+                )
+            elif self._state == State.CLOSED:
+                self._failure_count += 1
+                if self._failure_count >= self.failure_threshold:
+                    self._state = State.OPEN
+                    self._opened_at = time.monotonic()
+                    log.warning(
+                        "Circuit breaker '%s' → OPEN after %d consecutive failures",
+                        self.name,
+                        self._failure_count,
+                    )
+
+    def reset(self) -> None:
+        """Manually reset to CLOSED state (e.g. after service recovery)."""
+        with self._lock:
+            self._state = State.CLOSED
+            self._failure_count = 0
+            self._opened_at = None
+            self._probe_in_flight = False
+        log.info("Circuit breaker '%s' manually reset to CLOSED", self.name)
+
+    def wrap(self, fn: F) -> F:
+        """Decorator: wrap a callable with this circuit breaker."""
+        from functools import wraps
+
+        @wraps(fn)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            return self.call(fn, *args, **kwargs)
+
+        return wrapper  # type: ignore[return-value]
+
+    def __repr__(self) -> str:
+        return (
+            f"CircuitBreaker(name={self.name!r}, state={self._state.value}, "
+            f"failures={self._failure_count}/{self.failure_threshold})"
+        )

--- a/packages/gptme-backoff/src/gptme_backoff/circuit_breaker.py
+++ b/packages/gptme-backoff/src/gptme_backoff/circuit_breaker.py
@@ -31,6 +31,7 @@ __all__ = [
     "State",
 ]
 
+import inspect
 import logging
 import threading
 import time
@@ -146,6 +147,51 @@ class CircuitBreaker:
         except Exception as exc:
             self._on_failure(exc)
             raise
+        except BaseException:
+            # CancelledError, KeyboardInterrupt, etc. — clear probe so the
+            # breaker doesn't stay permanently stuck in HALF_OPEN.
+            with self._lock:
+                if self._state == State.HALF_OPEN:
+                    self._probe_in_flight = False
+            raise
+        else:
+            self._on_success()
+            return result
+
+    async def async_call(
+        self, fn: Callable[..., Any], *args: Any, **kwargs: Any
+    ) -> Any:
+        """Async version of *call* for coroutine functions.
+
+        Awaits the coroutine so that exceptions raised inside it are captured
+        by the circuit-breaker logic, not by the caller's event loop.
+        """
+        with self._lock:
+            state = self._evaluate_state()
+
+            if state == State.OPEN:
+                retry_after = None
+                if self._opened_at is not None:
+                    retry_after = max(
+                        0.0, self.cooldown - (time.monotonic() - self._opened_at)
+                    )
+                raise CircuitBreakerOpen(self.name, retry_after=retry_after)
+
+            if state == State.HALF_OPEN:
+                if self._probe_in_flight:
+                    raise CircuitBreakerOpen(self.name)
+                self._probe_in_flight = True
+
+        try:
+            result = await fn(*args, **kwargs)
+        except Exception as exc:
+            self._on_failure(exc)
+            raise
+        except BaseException:
+            with self._lock:
+                if self._state == State.HALF_OPEN:
+                    self._probe_in_flight = False
+            raise
         else:
             self._on_success()
             return result
@@ -194,8 +240,20 @@ class CircuitBreaker:
         log.info("Circuit breaker '%s' manually reset to CLOSED", self.name)
 
     def wrap(self, fn: F) -> F:
-        """Decorator: wrap a callable with this circuit breaker."""
+        """Decorator: wrap a callable with this circuit breaker.
+
+        Async functions are wrapped with *async_call* so that exceptions raised
+        inside the coroutine body are captured, not just coroutine creation.
+        """
         from functools import wraps
+
+        if inspect.iscoroutinefunction(fn):
+
+            @wraps(fn)
+            async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                return await self.async_call(fn, *args, **kwargs)
+
+            return async_wrapper  # type: ignore[return-value]
 
         @wraps(fn)
         def wrapper(*args: Any, **kwargs: Any) -> Any:

--- a/packages/gptme-backoff/src/gptme_backoff/circuit_breaker.py
+++ b/packages/gptme-backoff/src/gptme_backoff/circuit_breaker.py
@@ -38,6 +38,14 @@ import time
 from enum import Enum
 from typing import Any, Callable, TypeVar
 
+
+def _is_coroutine_callable(fn: Any) -> bool:
+    """Return True if *fn* is async — either an async def or a callable object with async __call__."""
+    return inspect.iscoroutinefunction(fn) or inspect.iscoroutinefunction(
+        getattr(fn, "__call__", None)
+    )
+
+
 log = logging.getLogger("gptme_backoff.circuit_breaker")
 
 T = TypeVar("T")
@@ -247,7 +255,7 @@ class CircuitBreaker:
         """
         from functools import wraps
 
-        if inspect.iscoroutinefunction(fn):
+        if _is_coroutine_callable(fn):
 
             @wraps(fn)
             async def async_wrapper(*args: Any, **kwargs: Any) -> Any:

--- a/packages/gptme-backoff/src/gptme_backoff/error_classification.py
+++ b/packages/gptme-backoff/src/gptme_backoff/error_classification.py
@@ -44,6 +44,14 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
+
+def _is_coroutine_callable(fn: Any) -> bool:
+    """Return True if *fn* is async — either an async def or a callable object with async __call__."""
+    return inspect.iscoroutinefunction(fn) or inspect.iscoroutinefunction(
+        getattr(fn, "__call__", None)
+    )
+
+
 __all__ = [
     "RetryStrategy",
     "StrategyConfig",
@@ -284,7 +292,7 @@ def retry_classified(
     active_configs = {**DEFAULT_STRATEGY_CONFIGS, **(configs or {})}
 
     def decorator(func: Callable[..., T]) -> Callable[..., T]:
-        if inspect.iscoroutinefunction(func):
+        if _is_coroutine_callable(func):
 
             @functools.wraps(func)
             async def async_wrapper(*args: Any, **kwargs: Any) -> T:
@@ -292,14 +300,14 @@ def retry_classified(
                 while True:
                     attempt += 1
                     try:
-                        return await func(*args, **kwargs)  # type: ignore[no-any-return]
+                        return await func(*args, **kwargs)  # type: ignore[no-any-return, misc]
                     except Exception as exc:
                         strategy = active_classifier.classify(exc)
                         config = active_configs[strategy]
                         if attempt >= config.max_attempts:
                             logger.debug(
                                 "retry_classified: giving up on %s after %d attempt(s) [%s]",
-                                func.__name__,
+                                getattr(func, "__name__", type(func).__qualname__),
                                 attempt,
                                 strategy.value,
                             )
@@ -307,7 +315,7 @@ def retry_classified(
                         wait = config.compute_wait(attempt)
                         logger.debug(
                             "retry_classified: %s failed (attempt %d/%d, %s) -> sleeping %.2fs",
-                            func.__name__,
+                            getattr(func, "__name__", type(func).__qualname__),
                             attempt,
                             config.max_attempts,
                             strategy.value,
@@ -332,7 +340,7 @@ def retry_classified(
                     if attempt >= config.max_attempts:
                         logger.debug(
                             "retry_classified: giving up on %s after %d attempt(s) [%s]",
-                            func.__name__,
+                            getattr(func, "__name__", type(func).__qualname__),
                             attempt,
                             strategy.value,
                         )
@@ -340,7 +348,7 @@ def retry_classified(
                     wait = config.compute_wait(attempt)
                     logger.debug(
                         "retry_classified: %s failed (attempt %d/%d, %s) -> sleeping %.2fs",
-                        func.__name__,
+                        getattr(func, "__name__", type(func).__qualname__),
                         attempt,
                         config.max_attempts,
                         strategy.value,

--- a/packages/gptme-backoff/src/gptme_backoff/error_classification.py
+++ b/packages/gptme-backoff/src/gptme_backoff/error_classification.py
@@ -29,7 +29,9 @@ Example::
 
 from __future__ import annotations
 
+import asyncio
 import functools
+import inspect
 import logging
 import random
 import time
@@ -282,6 +284,41 @@ def retry_classified(
     active_configs = {**DEFAULT_STRATEGY_CONFIGS, **(configs or {})}
 
     def decorator(func: Callable[..., T]) -> Callable[..., T]:
+        if inspect.iscoroutinefunction(func):
+
+            @functools.wraps(func)
+            async def async_wrapper(*args: Any, **kwargs: Any) -> T:
+                attempt = 0
+                while True:
+                    attempt += 1
+                    try:
+                        return await func(*args, **kwargs)  # type: ignore[no-any-return]
+                    except Exception as exc:
+                        strategy = active_classifier.classify(exc)
+                        config = active_configs[strategy]
+                        if attempt >= config.max_attempts:
+                            logger.debug(
+                                "retry_classified: giving up on %s after %d attempt(s) [%s]",
+                                func.__name__,
+                                attempt,
+                                strategy.value,
+                            )
+                            raise
+                        wait = config.compute_wait(attempt)
+                        logger.debug(
+                            "retry_classified: %s failed (attempt %d/%d, %s) -> sleeping %.2fs",
+                            func.__name__,
+                            attempt,
+                            config.max_attempts,
+                            strategy.value,
+                            wait,
+                        )
+                        if on_retry is not None:
+                            on_retry(exc, strategy, attempt + 1, wait)
+                        await asyncio.sleep(wait)
+
+            return async_wrapper  # type: ignore[return-value]
+
         @functools.wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> T:
             attempt = 0

--- a/packages/gptme-backoff/src/gptme_backoff/error_classification.py
+++ b/packages/gptme-backoff/src/gptme_backoff/error_classification.py
@@ -1,0 +1,318 @@
+"""Error-type classification + per-type retry strategy (Phase 2).
+
+Phase 1 (``retry.py``) gives exponential backoff with jitter and coarse presets
+(``retry_api_call``, ``retry_file_op``) where every exception inside a preset
+shares one strategy. Phase 2 adds a thin classification layer on top: an
+:class:`ErrorClassifier` maps an exception to a :class:`RetryStrategy`, and
+:func:`retry_classified` runs a retry loop whose attempts/backoff/jitter are
+chosen *per error class*.
+
+Design goals:
+
+- **Self-contained.** Only the standard library is used so the classifier can be
+  reused without pulling in optional backoff deps.
+- **Extensible.** Callers register ``(exception_type | predicate) -> strategy``
+  rules; the first matching rule wins, so specific rules can shadow broad ones.
+- **Honest fail-fast.** Auth / 4xx-style errors get ``max_attempts=1`` (no
+  retry) — retrying a 401 only wastes time and can trip lockouts.
+
+Example::
+
+    classifier = ErrorClassifier.default()
+
+    @retry_classified(classifier=classifier)
+    def call_api():
+        ...  # raises RateLimitError on 429, AuthError on 401
+
+    call_api()  # 429 -> jittered exponential backoff; 401 -> immediate raise
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+import random
+import time
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, TypeVar
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+__all__ = [
+    "RetryStrategy",
+    "StrategyConfig",
+    "ErrorRule",
+    "ErrorClassifier",
+    "retry_classified",
+    "DEFAULT_STRATEGY_CONFIGS",
+]
+
+
+class RetryStrategy(Enum):
+    """How a class of error should be retried."""
+
+    TRANSIENT = "transient"
+    """Temporary failure (connection reset, 503). Standard backoff."""
+
+    RATE_LIMIT = "rate_limit"
+    """Throttled (429). More attempts, wider jitter to de-correlate retries."""
+
+    AUTH = "auth"
+    """Authn/authz or other 4xx client errors. Fail fast — do not retry."""
+
+    CONSISTENCY = "consistency"
+    """Eventual-consistency / not-found-yet. Longer backoff, more attempts."""
+
+    UNKNOWN = "unknown"
+    """Unclassified. Conservative single-shot retry."""
+
+
+@dataclass(frozen=True)
+class StrategyConfig:
+    """Per-strategy retry parameters.
+
+    Attempts are total tries including the first. ``max_attempts=1`` means no
+    retry. The wait before retry ``n`` (1-indexed) is::
+
+        wait = min(base_wait * multiplier ** (n - 1), max_wait)
+        if jitter: wait += random.uniform(0, wait)
+    """
+
+    max_attempts: int = 3
+    base_wait: float = 1.0
+    multiplier: float = 2.0
+    max_wait: float = 60.0
+    jitter: bool = True
+
+    def compute_wait(self, attempt: int) -> float:
+        """Backoff before the given (1-indexed) retry attempt.
+
+        ``attempt=1`` is the wait after the first failure, before the 2nd try.
+        """
+        if attempt < 1:
+            raise ValueError("attempt must be >= 1")
+        wait = self.base_wait * (self.multiplier ** (attempt - 1))
+        wait = min(wait, self.max_wait)
+        if self.jitter:
+            # Additive jitter: spread retries across [wait, 2*wait) so a fleet
+            # of callers hitting the same 429 don't all retry in lockstep. This
+            # is *not* AWS "full jitter" ([0, wait)) — the spread (variance
+            # wait**2/12) is identical, but the higher floor keeps the
+            # exponential backoff intact so retries never collapse toward 0.
+            wait += random.uniform(0, wait)
+        return wait
+
+
+#: Sensible defaults per strategy. AUTH fails fast; RATE_LIMIT and CONSISTENCY
+#: get extra attempts; CONSISTENCY waits longer between tries.
+DEFAULT_STRATEGY_CONFIGS: dict[RetryStrategy, StrategyConfig] = {
+    RetryStrategy.TRANSIENT: StrategyConfig(
+        max_attempts=4, base_wait=0.5, multiplier=2.0, max_wait=30.0, jitter=True
+    ),
+    RetryStrategy.RATE_LIMIT: StrategyConfig(
+        max_attempts=6, base_wait=2.0, multiplier=2.0, max_wait=120.0, jitter=True
+    ),
+    RetryStrategy.AUTH: StrategyConfig(
+        max_attempts=1, base_wait=0.0, multiplier=1.0, max_wait=0.0, jitter=False
+    ),
+    RetryStrategy.CONSISTENCY: StrategyConfig(
+        max_attempts=8, base_wait=1.0, multiplier=1.5, max_wait=60.0, jitter=True
+    ),
+    RetryStrategy.UNKNOWN: StrategyConfig(
+        max_attempts=2, base_wait=1.0, multiplier=2.0, max_wait=10.0, jitter=True
+    ),
+}
+
+
+@dataclass(frozen=True)
+class ErrorRule:
+    """A single classification rule.
+
+    Either ``exc_types`` (matched with ``isinstance``) or ``predicate``
+    (an arbitrary ``exc -> bool`` callback) must be set. ``predicate`` is useful
+    for matching on a status-code attribute rather than a type, e.g. mapping any
+    exception with ``.status_code == 429`` to ``RATE_LIMIT``.
+    """
+
+    strategy: RetryStrategy
+    exc_types: tuple[type[BaseException], ...] = ()
+    predicate: Callable[[BaseException], bool] | None = None
+
+    def matches(self, exc: BaseException) -> bool:
+        if self.exc_types and isinstance(exc, self.exc_types):
+            return True
+        if self.predicate is not None:
+            try:
+                return bool(self.predicate(exc))
+            except Exception:  # a broken predicate must not break classification
+                logger.debug(
+                    "error-rule predicate raised; treating as no-match", exc_info=True
+                )
+                return False
+        return False
+
+
+def _status_code(exc: BaseException) -> int | None:
+    """Best-effort HTTP status extraction across common client libraries."""
+    for attr in ("status_code", "status", "code"):
+        val = getattr(exc, attr, None)
+        if isinstance(val, int):
+            return val
+    # requests/httpx style: exc.response.status_code
+    response = getattr(exc, "response", None)
+    if response is not None:
+        val = getattr(response, "status_code", None)
+        if isinstance(val, int):
+            return val
+    return None
+
+
+# 4xx codes that are transient despite being client-class, so they should be
+# retried rather than failed fast. 408 Request Timeout (server gave up waiting;
+# RFC 7231 §6.5.7 explicitly allows repeating the request) and 425 Too Early
+# (replay protection; safe to retry later). Mirrors urllib3/requests' default
+# retryable status set, which includes 408 alongside 429/5xx.
+_RETRYABLE_4XX = frozenset({408, 425})
+
+
+def _default_rules() -> list[ErrorRule]:
+    """Built-in rules matched in order; first match wins.
+
+    Status-code predicates come first so a typed ``ConnectionError`` that also
+    happens to carry a 429 is still treated as a rate-limit.
+    """
+
+    def is_rate_limit(exc: BaseException) -> bool:
+        return _status_code(exc) == 429
+
+    def is_retryable_client(exc: BaseException) -> bool:
+        return _status_code(exc) in _RETRYABLE_4XX
+
+    def is_auth_or_client(exc: BaseException) -> bool:
+        code = _status_code(exc)
+        # 401/403/404 and other 4xx -> fail fast. 429 (rate-limit) and the
+        # transient 4xx in _RETRYABLE_4XX are handled by earlier rules.
+        return (
+            code is not None
+            and 400 <= code < 500
+            and code != 429
+            and code not in _RETRYABLE_4XX
+        )
+
+    def is_server_error(exc: BaseException) -> bool:
+        code = _status_code(exc)
+        return code is not None and 500 <= code < 600
+
+    return [
+        ErrorRule(RetryStrategy.RATE_LIMIT, predicate=is_rate_limit),
+        ErrorRule(RetryStrategy.TRANSIENT, predicate=is_retryable_client),
+        ErrorRule(RetryStrategy.AUTH, predicate=is_auth_or_client),
+        ErrorRule(RetryStrategy.TRANSIENT, predicate=is_server_error),
+        ErrorRule(
+            RetryStrategy.TRANSIENT,
+            exc_types=(ConnectionError, TimeoutError),
+        ),
+    ]
+
+
+@dataclass
+class ErrorClassifier:
+    """Maps exceptions to :class:`RetryStrategy` via ordered rules."""
+
+    rules: list[ErrorRule] = field(default_factory=list)
+    default_strategy: RetryStrategy = RetryStrategy.UNKNOWN
+
+    @classmethod
+    def default(cls) -> ErrorClassifier:
+        """Classifier preloaded with sensible built-in rules."""
+        return cls(rules=_default_rules())
+
+    def register(
+        self,
+        strategy: RetryStrategy,
+        *,
+        exc_types: Iterable[type[BaseException]] = (),
+        predicate: Callable[[BaseException], bool] | None = None,
+        prepend: bool = True,
+    ) -> ErrorClassifier:
+        """Add a rule. ``prepend`` (default) lets specific rules shadow broad ones."""
+        types = tuple(exc_types)
+        if not types and predicate is None:
+            raise ValueError("register() needs exc_types or a predicate")
+        rule = ErrorRule(strategy=strategy, exc_types=types, predicate=predicate)
+        if prepend:
+            self.rules.insert(0, rule)
+        else:
+            self.rules.append(rule)
+        return self
+
+    def classify(self, exc: BaseException) -> RetryStrategy:
+        for rule in self.rules:
+            if rule.matches(exc):
+                return rule.strategy
+        return self.default_strategy
+
+
+def retry_classified(
+    *,
+    classifier: ErrorClassifier | None = None,
+    configs: dict[RetryStrategy, StrategyConfig] | None = None,
+    sleep: Callable[[float], None] = time.sleep,
+    on_retry: Callable[[BaseException, RetryStrategy, int, float], None] | None = None,
+) -> Callable[[Callable[..., T]], Callable[..., T]]:
+    """Decorator that retries a function using a per-error-class strategy.
+
+    Args:
+        classifier: maps raised exceptions to a strategy. Defaults to
+            :meth:`ErrorClassifier.default`.
+        configs: per-strategy parameters. Defaults to
+            :data:`DEFAULT_STRATEGY_CONFIGS`.
+        sleep: injectable sleep (tests pass a no-op / recorder).
+        on_retry: optional callback ``(exc, strategy, next_attempt, wait)``
+            invoked before each backoff sleep.
+
+    The wrapped function re-raises the last exception once the strategy's
+    ``max_attempts`` is exhausted.
+    """
+    active_classifier = classifier or ErrorClassifier.default()
+    active_configs = {**DEFAULT_STRATEGY_CONFIGS, **(configs or {})}
+
+    def decorator(func: Callable[..., T]) -> Callable[..., T]:
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> T:
+            attempt = 0
+            while True:
+                attempt += 1
+                try:
+                    return func(*args, **kwargs)
+                except Exception as exc:
+                    strategy = active_classifier.classify(exc)
+                    config = active_configs[strategy]
+                    if attempt >= config.max_attempts:
+                        logger.debug(
+                            "retry_classified: giving up on %s after %d attempt(s) [%s]",
+                            func.__name__,
+                            attempt,
+                            strategy.value,
+                        )
+                        raise
+                    wait = config.compute_wait(attempt)
+                    logger.debug(
+                        "retry_classified: %s failed (attempt %d/%d, %s) -> sleeping %.2fs",
+                        func.__name__,
+                        attempt,
+                        config.max_attempts,
+                        strategy.value,
+                        wait,
+                    )
+                    if on_retry is not None:
+                        on_retry(exc, strategy, attempt + 1, wait)
+                    sleep(wait)
+
+        return wrapper
+
+    return decorator

--- a/packages/gptme-backoff/src/gptme_backoff/retry.py
+++ b/packages/gptme-backoff/src/gptme_backoff/retry.py
@@ -271,10 +271,15 @@ def retry_file_op(
         def read_config() -> str:
             ...
     """
-    return retry_sync(
-        stop=tenacity.stop_after_attempt(max_attempts),
-        wait=tenacity.wait_exponential(
-            min=min_wait, max=max_wait, multiplier=multiplier
-        ),
-        retry=tenacity.retry_if_exception_type(retry_on),
-    )
+
+    def decorator(fn: F) -> F:
+        retry_decorator = retry_async if inspect.iscoroutinefunction(fn) else retry_sync
+        return retry_decorator(
+            stop=tenacity.stop_after_attempt(max_attempts),
+            wait=tenacity.wait_exponential(
+                min=min_wait, max=max_wait, multiplier=multiplier
+            ),
+            retry=tenacity.retry_if_exception_type(retry_on),
+        )(fn)
+
+    return decorator

--- a/packages/gptme-backoff/src/gptme_backoff/retry.py
+++ b/packages/gptme-backoff/src/gptme_backoff/retry.py
@@ -1,0 +1,280 @@
+"""Retry decorators and utilities built on tenacity.
+
+Provides sync/async retry decorators and convenience presets for API calls
+and file operations with exponential backoff, jitter, and timeout support.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "retry_api_call",
+    "retry_async",
+    "retry_file_op",
+    "retry_sync",
+]
+
+import inspect
+from typing import Any, Callable, TypeVar
+
+import tenacity
+from tenacity.retry import retry_base
+from tenacity.stop import stop_base
+from tenacity.wait import wait_base
+
+T = TypeVar("T")
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+# ---------------------------------------------------------------------------
+# shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _default_before_sleep(
+    log_path: str = "/dev/null",
+) -> Callable[[tenacity.RetryCallState], None]:
+    """Build a before_sleep callback that writes to *log_path*."""
+    from pathlib import Path
+
+    def _log(retry_state: tenacity.RetryCallState) -> None:
+        attempt = retry_state.attempt_number
+        exc = retry_state.outcome.exception() if retry_state.outcome else None
+        msg = f"[backoff] attempt {attempt} failed: {exc}"
+
+        try:
+            Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+            with Path(log_path).open("a") as f:
+                f.write(msg + "\n")
+        except OSError:
+            pass
+
+        import logging
+
+        logging.getLogger("gptme_backoff").warning(msg)
+
+    return _log
+
+
+def _retry_error_callback_none(
+    _retry_state: tenacity.RetryCallState,
+) -> None:
+    """Callback that returns None on exhaustion (for reraise=False)."""
+    return None
+
+
+# ---------------------------------------------------------------------------
+# sync decorator
+# ---------------------------------------------------------------------------
+
+
+def retry_sync(
+    stop: stop_base = tenacity.stop_after_attempt(3),
+    wait: wait_base = tenacity.wait_exponential(min=0.5, max=30, multiplier=1.5),
+    retry: retry_base = tenacity.retry_if_exception_type(Exception),
+    reraise: bool = True,
+    before_sleep: Callable[[tenacity.RetryCallState], Any] | None = None,
+    **tenacity_kw: Any,
+) -> Callable[[F], F]:
+    """Decorator: retry a sync function.
+
+    Parameters
+    ----------
+    stop : tenacity.stop_base
+        Stop condition (default: 3 attempts).
+    wait : tenacity.wait_base
+        Wait strategy (default: exp backoff 0.5–30s, ×1.5).
+    retry : tenacity.retry_base
+        Retry condition (default: any Exception).
+    reraise : bool
+        If True (default), re-raise the last caught exception on exhaustion.
+        If False, a ``tenacity.RetryError`` is raised wrapping the last exception.
+    before_sleep : callable | None
+        Called before each sleep with the RetryCallState.
+
+    Usage::
+
+        from gptme_backoff import retry_sync
+        import tenacity
+
+        @retry_sync(stop=tenacity.stop_after_attempt(5),
+                    wait=tenacity.wait_fixed(1))
+        def fetch(url: str) -> str:
+            ...
+    """
+    dec = tenacity.Retrying(
+        stop=stop,
+        wait=wait,
+        retry=retry,
+        reraise=reraise,
+        before_sleep=before_sleep or _default_before_sleep("/dev/null"),
+        **tenacity_kw,
+    )
+
+    def wrapper(fn: F) -> F:
+        return dec.wraps(fn)
+
+    return wrapper
+
+
+# ---------------------------------------------------------------------------
+# async decorator
+# ---------------------------------------------------------------------------
+
+
+def retry_async(
+    stop: stop_base = tenacity.stop_after_attempt(3),
+    wait: wait_base = tenacity.wait_exponential(min=0.5, max=30, multiplier=1.5),
+    retry: retry_base = tenacity.retry_if_exception_type(Exception),
+    reraise: bool = True,
+    before_sleep: Callable[[tenacity.RetryCallState], Any] | None = None,
+    **tenacity_kw: Any,
+) -> Callable[[F], F]:
+    """Decorator: retry an async function.
+
+    Uses ``tenacity.AsyncRetrying`` internally so the retry logic itself is
+    async-compatible (does not block the event loop during waits).
+
+    Parameters are identical to *retry_sync*.
+
+    Usage::
+
+        @retry_async(stop=tenacity.stop_after_attempt(5),
+                     wait=tenacity.wait_fixed(1))
+        async def fetch(url: str) -> str:
+            ...
+    """
+    dec = tenacity.AsyncRetrying(
+        stop=stop,
+        wait=wait,
+        retry=retry,
+        reraise=reraise,
+        before_sleep=before_sleep or _default_before_sleep("/dev/null"),
+        **tenacity_kw,
+    )
+
+    def wrapper(fn: F) -> F:
+        return dec.wraps(fn)
+
+    return wrapper
+
+
+# ---------------------------------------------------------------------------
+# convenience presets (keyword-argument interface for callers who don't want
+# to import tenacity themselves)
+# ---------------------------------------------------------------------------
+
+
+def _make_wait_strategy(
+    min_wait: float,
+    max_wait: float,
+    multiplier: float,
+    jitter: bool,
+) -> wait_base:
+    if jitter:
+        return tenacity.wait_exponential_jitter(
+            initial=min_wait,
+            max=max_wait,
+            exp_base=multiplier,
+            jitter=min_wait,
+        )
+    return tenacity.wait_exponential(min=min_wait, max=max_wait, multiplier=multiplier)
+
+
+def retry_api_call(
+    max_attempts: int = 3,
+    timeout: float | None = None,
+    min_wait: float = 1.0,
+    max_wait: float = 60.0,
+    multiplier: float = 2.0,
+    jitter: bool = True,
+    retry_on: type[BaseException] | tuple[type[BaseException], ...] = Exception,
+) -> Callable[[F], F]:
+    """Convenience decorator tuned for API call retries.
+
+    Combines exponential backoff with optional jitter and a hard wall-clock
+    timeout via ``tenacity.stop_after_delay``.
+
+    Parameters
+    ----------
+    max_attempts : int
+        Maximum retry attempts (default 3).
+    timeout : float | None
+        Wall-clock timeout in seconds. ``None`` = no timeout.
+    min_wait : float
+        Minimum wait between retries, seconds (default 1.0).
+    max_wait : float
+        Maximum wait between retries, seconds (default 60.0).
+    multiplier : float
+        Exponential backoff multiplier (default 2.0).
+    jitter : bool
+        Add random jitter to wait times (default True).
+    retry_on : exception type or tuple
+        Which exceptions trigger a retry (default ``Exception``).
+
+    Usage::
+
+        from gptme_backoff import retry_api_call
+
+        @retry_api_call(max_attempts=5, timeout=30)
+        def call_api() -> dict:
+            ...
+
+    Applies to both sync and async functions (tenacity auto-detects).
+    """
+    stop_conditions: list[stop_base] = [tenacity.stop_after_attempt(max_attempts)]
+    if timeout is not None:
+        stop_conditions.append(tenacity.stop_after_delay(timeout))
+
+    wait_strategy = _make_wait_strategy(min_wait, max_wait, multiplier, jitter)
+
+    def decorator(fn: F) -> F:
+        retry_decorator = retry_async if inspect.iscoroutinefunction(fn) else retry_sync
+        return retry_decorator(
+            stop=tenacity.stop_any(*stop_conditions),
+            wait=wait_strategy,
+            retry=tenacity.retry_if_exception_type(retry_on),
+        )(fn)
+
+    return decorator
+
+
+def retry_file_op(
+    max_attempts: int = 3,
+    min_wait: float = 0.1,
+    max_wait: float = 5.0,
+    multiplier: float = 2.0,
+    retry_on: type[BaseException] | tuple[type[BaseException], ...] = OSError,
+) -> Callable[[F], F]:
+    """Convenience decorator tuned for file I/O retries.
+
+    Only retries on *OSError* by default — transient IO errors (EAGAIN, EBUSY,
+    ENOSPC). Non-OS exceptions (ValueError, TypeError) are not retried.
+
+    Parameters
+    ----------
+    max_attempts : int
+        Maximum retry attempts (default 3).
+    min_wait : float
+        Minimum wait, seconds (default 0.1).
+    max_wait : float
+        Maximum wait, seconds (default 5.0).
+    multiplier : float
+        Exponential backoff multiplier (default 2.0).
+    retry_on : exception type or tuple
+        Which exceptions trigger a retry (default ``OSError``).
+
+    Usage::
+
+        from gptme_backoff import retry_file_op
+
+        @retry_file_op(max_attempts=5)
+        def read_config() -> str:
+            ...
+    """
+    return retry_sync(
+        stop=tenacity.stop_after_attempt(max_attempts),
+        wait=tenacity.wait_exponential(
+            min=min_wait, max=max_wait, multiplier=multiplier
+        ),
+        retry=tenacity.retry_if_exception_type(retry_on),
+    )

--- a/packages/gptme-backoff/src/gptme_backoff/retry.py
+++ b/packages/gptme-backoff/src/gptme_backoff/retry.py
@@ -22,6 +22,15 @@ from tenacity.stop import stop_base
 from tenacity.wait import wait_base
 
 T = TypeVar("T")
+
+
+def _is_coroutine_callable(fn: Any) -> bool:
+    """Return True if *fn* is async — either an async def or a callable object with async __call__."""
+    return inspect.iscoroutinefunction(fn) or inspect.iscoroutinefunction(
+        getattr(fn, "__call__", None)
+    )
+
+
 F = TypeVar("F", bound=Callable[..., Any])
 
 
@@ -228,7 +237,7 @@ def retry_api_call(
     wait_strategy = _make_wait_strategy(min_wait, max_wait, multiplier, jitter)
 
     def decorator(fn: F) -> F:
-        retry_decorator = retry_async if inspect.iscoroutinefunction(fn) else retry_sync
+        retry_decorator = retry_async if _is_coroutine_callable(fn) else retry_sync
         return retry_decorator(
             stop=tenacity.stop_any(*stop_conditions),
             wait=wait_strategy,
@@ -273,7 +282,7 @@ def retry_file_op(
     """
 
     def decorator(fn: F) -> F:
-        retry_decorator = retry_async if inspect.iscoroutinefunction(fn) else retry_sync
+        retry_decorator = retry_async if _is_coroutine_callable(fn) else retry_sync
         return retry_decorator(
             stop=tenacity.stop_after_attempt(max_attempts),
             wait=tenacity.wait_exponential(

--- a/packages/gptme-backoff/tests/test_circuit_breaker.py
+++ b/packages/gptme-backoff/tests/test_circuit_breaker.py
@@ -12,6 +12,16 @@ from gptme_backoff.circuit_breaker import (
     State,
 )
 
+# ── Async helpers ─────────────────────────────────────────────────────────────
+
+
+async def _async_passing(value: int = 42) -> int:
+    return value
+
+
+async def _async_failing(exc: Exception = RuntimeError("boom")) -> None:
+    raise exc
+
 
 def _failing(exc: Exception = RuntimeError("boom")) -> None:
     raise exc
@@ -300,3 +310,67 @@ def test_circuit_breaker_open_str():
 
     exc2 = CircuitBreakerOpen("my-tool")
     assert "retry after" not in str(exc2)
+
+
+# ── Async wrap ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_async_wrap_passes_through():
+    """@cb.wrap on an async function returns an async callable that works."""
+    cb = CircuitBreaker("test", failure_threshold=5, cooldown=30.0)
+
+    @cb.wrap
+    async def add(a: int, b: int) -> int:
+        return a + b
+
+    result = await add(3, 4)
+    assert result == 7
+    assert cb.state == State.CLOSED
+
+
+@pytest.mark.asyncio
+async def test_async_wrap_counts_failures():
+    """Failures inside an async probe are counted, not just coroutine creation."""
+    cb = CircuitBreaker("test", failure_threshold=2, cooldown=30.0)
+
+    @cb.wrap
+    async def boom() -> None:
+        raise ValueError("async fail")
+
+    with pytest.raises(ValueError):
+        await boom()
+    with pytest.raises(ValueError):
+        await boom()
+
+    assert cb.state == State.OPEN
+    with pytest.raises(CircuitBreakerOpen):
+        await boom()
+
+
+@pytest.mark.asyncio
+async def test_async_wrap_probe_flag_cleared_on_base_exception(monkeypatch):
+    """_probe_in_flight is cleared even when BaseException (e.g. CancelledError) escapes."""
+    import asyncio
+
+    cb = CircuitBreaker("test", failure_threshold=1, cooldown=5.0)
+    start = time.monotonic()
+    monkeypatch.setattr("time.monotonic", lambda: start)
+
+    # Open the breaker
+    with pytest.raises(RuntimeError):
+        cb.call(_failing)
+
+    # Advance past cooldown → HALF_OPEN
+    monkeypatch.setattr("time.monotonic", lambda: start + 6.0)
+    assert cb.state == State.HALF_OPEN
+
+    @cb.wrap
+    async def cancellable() -> None:
+        raise asyncio.CancelledError()
+
+    with pytest.raises(asyncio.CancelledError):
+        await cancellable()
+
+    # _probe_in_flight must be cleared so a subsequent probe is allowed
+    assert not cb._probe_in_flight

--- a/packages/gptme-backoff/tests/test_circuit_breaker.py
+++ b/packages/gptme-backoff/tests/test_circuit_breaker.py
@@ -1,0 +1,302 @@
+"""Tests for CircuitBreaker: all state transitions, concurrent access, edge cases."""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+from gptme_backoff.circuit_breaker import (
+    CircuitBreaker,
+    CircuitBreakerOpen,
+    State,
+)
+
+
+def _failing(exc: Exception = RuntimeError("boom")) -> None:
+    raise exc
+
+
+def _passing(value: int = 42) -> int:
+    return value
+
+
+# ── Basic state transitions ────────────────────────────────────────────────
+
+
+def test_initial_state_is_closed():
+    cb = CircuitBreaker("test", failure_threshold=3, cooldown=30.0)
+    assert cb.state == State.CLOSED
+
+
+def test_success_in_closed_state():
+    cb = CircuitBreaker("test", failure_threshold=3, cooldown=30.0)
+    result = cb.call(_passing, 7)
+    assert result == 7
+    assert cb.state == State.CLOSED
+
+
+def test_failure_below_threshold_stays_closed():
+    cb = CircuitBreaker("test", failure_threshold=3, cooldown=30.0)
+    for _ in range(2):
+        with pytest.raises(RuntimeError):
+            cb.call(_failing)
+    assert cb.state == State.CLOSED
+    assert cb._failure_count == 2
+
+
+def test_failure_at_threshold_opens():
+    cb = CircuitBreaker("test", failure_threshold=3, cooldown=30.0)
+    for _ in range(3):
+        with pytest.raises(RuntimeError):
+            cb.call(_failing)
+    assert cb.state == State.OPEN
+
+
+def test_call_rejected_when_open():
+    cb = CircuitBreaker("test", failure_threshold=1, cooldown=60.0)
+    with pytest.raises(RuntimeError):
+        cb.call(_failing)
+    assert cb.state == State.OPEN
+
+    with pytest.raises(CircuitBreakerOpen) as exc_info:
+        cb.call(_passing)
+    assert exc_info.value.name == "test"
+
+
+def test_retry_after_populated_when_open():
+    cb = CircuitBreaker("test", failure_threshold=1, cooldown=10.0)
+    with pytest.raises(RuntimeError):
+        cb.call(_failing)
+    try:
+        cb.call(_passing)
+    except CircuitBreakerOpen as e:
+        assert e.retry_after is not None
+        assert 0.0 <= e.retry_after <= 10.0
+
+
+# ── HALF_OPEN via fake clock ───────────────────────────────────────────────
+
+
+def test_transitions_to_half_open_after_cooldown(monkeypatch):
+    cb = CircuitBreaker("test", failure_threshold=1, cooldown=5.0)
+    start = time.monotonic()
+    monkeypatch.setattr("time.monotonic", lambda: start)
+
+    with pytest.raises(RuntimeError):
+        cb.call(_failing)
+    assert cb.state == State.OPEN
+
+    # Advance clock past cooldown
+    monkeypatch.setattr("time.monotonic", lambda: start + 6.0)
+    assert cb.state == State.HALF_OPEN
+
+
+def test_probe_success_closes_from_half_open(monkeypatch):
+    cb = CircuitBreaker("test", failure_threshold=1, cooldown=5.0)
+    start = time.monotonic()
+    monkeypatch.setattr("time.monotonic", lambda: start)
+
+    with pytest.raises(RuntimeError):
+        cb.call(_failing)
+
+    monkeypatch.setattr("time.monotonic", lambda: start + 6.0)
+    assert cb.state == State.HALF_OPEN
+
+    result = cb.call(_passing, 99)
+    assert result == 99
+    assert cb.state == State.CLOSED
+    assert cb._failure_count == 0
+
+
+def test_probe_failure_reopens_from_half_open(monkeypatch):
+    cb = CircuitBreaker("test", failure_threshold=1, cooldown=5.0)
+    start = time.monotonic()
+    monkeypatch.setattr("time.monotonic", lambda: start)
+
+    with pytest.raises(RuntimeError):
+        cb.call(_failing)
+
+    monkeypatch.setattr("time.monotonic", lambda: start + 6.0)
+    assert cb.state == State.HALF_OPEN
+
+    with pytest.raises(RuntimeError):
+        cb.call(_failing)
+    assert cb.state == State.OPEN
+
+
+def test_probe_failure_resets_cooldown_timer(monkeypatch):
+    cb = CircuitBreaker("test", failure_threshold=1, cooldown=5.0)
+    tick = [0.0]
+    monkeypatch.setattr("time.monotonic", lambda: tick[0])
+
+    with pytest.raises(RuntimeError):
+        cb.call(_failing)
+
+    tick[0] = 6.0  # cooldown elapsed → HALF_OPEN
+    assert cb.state == State.HALF_OPEN
+
+    with pytest.raises(RuntimeError):
+        cb.call(_failing)  # probe fails → OPEN with timer reset to tick[0]=6.0
+
+    tick[0] = 7.0  # only 1s after re-open; cooldown not elapsed yet
+    assert cb.state == State.OPEN
+
+    tick[0] = 12.0  # 6s after re-open; cooldown elapsed → HALF_OPEN again
+    assert cb.state == State.HALF_OPEN
+
+
+def test_only_one_probe_in_half_open(monkeypatch):
+    """Second concurrent call in HALF_OPEN is rejected immediately."""
+    cb = CircuitBreaker("test", failure_threshold=1, cooldown=5.0)
+    start = time.monotonic()
+    monkeypatch.setattr("time.monotonic", lambda: start)
+
+    with pytest.raises(RuntimeError):
+        cb.call(_failing)
+
+    monkeypatch.setattr("time.monotonic", lambda: start + 6.0)
+    assert cb.state == State.HALF_OPEN
+
+    # Manually set probe_in_flight as if a first probe is running
+    cb._probe_in_flight = True
+
+    with pytest.raises(CircuitBreakerOpen):
+        cb.call(_passing)
+
+
+# ── Manual reset ──────────────────────────────────────────────────────────
+
+
+def test_reset_restores_closed_state():
+    cb = CircuitBreaker("test", failure_threshold=1, cooldown=60.0)
+    with pytest.raises(RuntimeError):
+        cb.call(_failing)
+    assert cb.state == State.OPEN
+
+    cb.reset()
+    assert cb.state == State.CLOSED
+    assert cb._failure_count == 0
+
+    result = cb.call(_passing, 5)
+    assert result == 5
+
+
+# ── Decorator interface ────────────────────────────────────────────────────
+
+
+def test_wrap_decorator_passes_through():
+    cb = CircuitBreaker("test", failure_threshold=5, cooldown=30.0)
+
+    @cb.wrap
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    assert add(2, 3) == 5
+
+
+def test_wrap_decorator_opens_on_failures():
+    cb = CircuitBreaker("test", failure_threshold=2, cooldown=30.0)
+
+    @cb.wrap
+    def boom() -> None:
+        raise ValueError("fail")
+
+    with pytest.raises(ValueError):
+        boom()
+    with pytest.raises(ValueError):
+        boom()
+
+    assert cb.state == State.OPEN
+    with pytest.raises(CircuitBreakerOpen):
+        boom()
+
+
+# ── Success resets counter in CLOSED state ────────────────────────────────
+
+
+def test_success_resets_failure_count():
+    cb = CircuitBreaker("test", failure_threshold=3, cooldown=30.0)
+    with pytest.raises(RuntimeError):
+        cb.call(_failing)
+    with pytest.raises(RuntimeError):
+        cb.call(_failing)
+    assert cb._failure_count == 2
+
+    cb.call(_passing)
+    assert cb._failure_count == 0
+    assert cb.state == State.CLOSED
+
+
+# ── Concurrent access ─────────────────────────────────────────────────────
+
+
+def test_concurrent_failures_open_exactly_once():
+    """Multiple threads failing simultaneously should open the breaker once."""
+    cb = CircuitBreaker("test", failure_threshold=5, cooldown=30.0)
+    errors: list[Exception] = []
+
+    def worker() -> None:
+        for _ in range(3):
+            try:
+                cb.call(_failing)
+            except (RuntimeError, CircuitBreakerOpen) as e:
+                errors.append(e)
+
+    threads = [threading.Thread(target=worker) for _ in range(6)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # At some point the breaker must have opened
+    assert cb.state == State.OPEN
+    # Some errors are CircuitBreakerOpen (fast-fail), some are RuntimeError
+    open_errors = [e for e in errors if isinstance(e, CircuitBreakerOpen)]
+    assert len(open_errors) >= 1
+
+
+def test_concurrent_calls_in_closed_state_thread_safe():
+    """Concurrent successes in CLOSED state must not corrupt the counter."""
+    cb = CircuitBreaker("test", failure_threshold=10, cooldown=30.0)
+    results: list[int] = []
+
+    def worker(n: int) -> None:
+        results.append(cb.call(_passing, n))
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(20)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(results) == 20
+    assert cb.state == State.CLOSED
+    assert cb._failure_count == 0
+
+
+# ── Edge cases ────────────────────────────────────────────────────────────
+
+
+def test_failure_threshold_of_one():
+    cb = CircuitBreaker("test", failure_threshold=1, cooldown=30.0)
+    with pytest.raises(RuntimeError):
+        cb.call(_failing)
+    assert cb.state == State.OPEN
+
+
+def test_repr():
+    cb = CircuitBreaker("svc", failure_threshold=5, cooldown=30.0)
+    r = repr(cb)
+    assert "svc" in r
+    assert "CLOSED" in r
+    assert "0/5" in r
+
+
+def test_circuit_breaker_open_str():
+    exc = CircuitBreakerOpen("my-tool", retry_after=12.5)
+    assert "my-tool" in str(exc)
+    assert "12.5" in str(exc)
+
+    exc2 = CircuitBreakerOpen("my-tool")
+    assert "retry after" not in str(exc2)

--- a/packages/gptme-backoff/tests/test_circuit_breaker.py
+++ b/packages/gptme-backoff/tests/test_circuit_breaker.py
@@ -374,3 +374,33 @@ async def test_async_wrap_probe_flag_cleared_on_base_exception(monkeypatch):
 
     # _probe_in_flight must be cleared so a subsequent probe is allowed
     assert not cb._probe_in_flight
+
+
+@pytest.mark.asyncio
+async def test_async_callable_object_wrap_counts_failures():
+    """cb.wrap on a callable object with async __call__ must use the async path.
+
+    inspect.iscoroutinefunction(obj) returns False for callable objects; only
+    inspect.iscoroutinefunction(obj.__call__) returns True.  Without the
+    _is_coroutine_callable fix, wrap() would route through cb.call() which
+    records success when the coroutine object is created (before it is awaited),
+    so failures inside the coroutine body are never counted.
+    """
+    cb = CircuitBreaker("test", failure_threshold=2, cooldown=30.0)
+
+    class AsyncService:
+        async def __call__(self) -> None:
+            raise RuntimeError("service down")
+
+    svc = AsyncService()
+    wrapped = cb.wrap(svc)
+
+    with pytest.raises(RuntimeError):
+        await wrapped()
+    with pytest.raises(RuntimeError):
+        await wrapped()
+
+    # Breaker must have opened — failures were counted, not swallowed
+    assert cb.state == State.OPEN
+    with pytest.raises(CircuitBreakerOpen):
+        await wrapped()

--- a/packages/gptme-backoff/tests/test_error_classification.py
+++ b/packages/gptme-backoff/tests/test_error_classification.py
@@ -277,3 +277,58 @@ def test_retry_classified_custom_configs_override() -> None:
     with pytest.raises(ValueError):
         boom()
     assert calls["n"] == 5
+
+
+# --- async retry_classified --------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retry_classified_async_success_no_retry() -> None:
+    """async functions work and are actually awaited."""
+    calls = {"n": 0}
+
+    @retry_classified(sleep=lambda _: None)
+    async def ok() -> str:
+        calls["n"] += 1
+        return "done"
+
+    result = await ok()
+    assert result == "done"
+    assert calls["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_retry_classified_async_rate_limit_retries() -> None:
+    """Errors raised inside the coroutine body are retried with asyncio.sleep."""
+    calls = {"n": 0}
+    configs = {
+        RetryStrategy.RATE_LIMIT: StrategyConfig(
+            max_attempts=3, base_wait=0.0, multiplier=1.0, max_wait=0.0, jitter=False
+        )
+    }
+
+    @retry_classified(configs=configs)
+    async def flaky() -> str:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise HTTPError(429)
+        return "ok"
+
+    result = await flaky()
+    assert result == "ok"
+    assert calls["n"] == 3
+
+
+@pytest.mark.asyncio
+async def test_retry_classified_async_auth_fails_fast() -> None:
+    """AUTH errors are not retried in async mode."""
+    calls = {"n": 0}
+
+    @retry_classified()
+    async def denied() -> None:
+        calls["n"] += 1
+        raise HTTPError(401)
+
+    with pytest.raises(HTTPError):
+        await denied()
+    assert calls["n"] == 1

--- a/packages/gptme-backoff/tests/test_error_classification.py
+++ b/packages/gptme-backoff/tests/test_error_classification.py
@@ -332,3 +332,26 @@ async def test_retry_classified_async_auth_fails_fast() -> None:
     with pytest.raises(HTTPError):
         await denied()
     assert calls["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_retry_classified_async_callable_objects() -> None:
+    """retry_classified must detect callable objects with async __call__ as async.
+
+    Without _is_coroutine_callable, the sync wrapper is used, which returns the
+    coroutine object as a successful result — exceptions inside the coroutine
+    body are never caught or retried.
+    """
+    calls = {"n": 0}
+
+    class AsyncService:
+        async def __call__(self) -> str:
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise ConnectionError("transient")
+            return "ok"
+
+    svc = retry_classified()(AsyncService())
+    result = await svc()
+    assert result == "ok"
+    assert calls["n"] == 3

--- a/packages/gptme-backoff/tests/test_error_classification.py
+++ b/packages/gptme-backoff/tests/test_error_classification.py
@@ -1,0 +1,279 @@
+"""Tests for the Phase 2 error-classification retry layer."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+from gptme_backoff.error_classification import (
+    DEFAULT_STRATEGY_CONFIGS,
+    ErrorClassifier,
+    RetryStrategy,
+    StrategyConfig,
+    retry_classified,
+)
+
+# --- fake exceptions mimicking common client libraries ---------------------
+
+
+class HTTPError(Exception):
+    def __init__(self, status_code: int) -> None:
+        super().__init__(f"HTTP {status_code}")
+        self.status_code = status_code
+
+
+class _Response:
+    def __init__(self, status_code: int) -> None:
+        self.status_code = status_code
+
+
+class RequestsStyleError(Exception):
+    """requests/httpx-style error carrying a .response.status_code."""
+
+    def __init__(self, status_code: int) -> None:
+        super().__init__(f"response {status_code}")
+        self.response = _Response(status_code)
+
+
+# --- StrategyConfig.compute_wait -------------------------------------------
+
+
+def test_compute_wait_exponential_without_jitter() -> None:
+    cfg = StrategyConfig(base_wait=1.0, multiplier=2.0, max_wait=100.0, jitter=False)
+    assert cfg.compute_wait(1) == 1.0
+    assert cfg.compute_wait(2) == 2.0
+    assert cfg.compute_wait(3) == 4.0
+
+
+def test_compute_wait_respects_max_wait() -> None:
+    cfg = StrategyConfig(base_wait=10.0, multiplier=10.0, max_wait=15.0, jitter=False)
+    assert cfg.compute_wait(1) == 10.0
+    assert cfg.compute_wait(2) == 15.0  # capped
+
+
+def test_compute_wait_additive_jitter_range() -> None:
+    cfg = StrategyConfig(base_wait=4.0, multiplier=1.0, max_wait=100.0, jitter=True)
+    for _ in range(50):
+        w = cfg.compute_wait(1)
+        assert 4.0 <= w < 8.0  # additive jitter: [wait, 2*wait), not AWS full jitter
+
+
+def test_compute_wait_rejects_bad_attempt() -> None:
+    with pytest.raises(ValueError):
+        StrategyConfig().compute_wait(0)
+
+
+# --- ErrorClassifier --------------------------------------------------------
+
+
+def test_classify_rate_limit_by_status_code() -> None:
+    c = ErrorClassifier.default()
+    assert c.classify(HTTPError(429)) is RetryStrategy.RATE_LIMIT
+
+
+def test_classify_auth_and_client_errors_fail_fast() -> None:
+    c = ErrorClassifier.default()
+    for code in (400, 401, 403, 404, 422):
+        assert c.classify(HTTPError(code)) is RetryStrategy.AUTH
+
+
+def test_classify_server_error_is_transient() -> None:
+    c = ErrorClassifier.default()
+    assert c.classify(HTTPError(500)) is RetryStrategy.TRANSIENT
+    assert c.classify(HTTPError(503)) is RetryStrategy.TRANSIENT
+
+
+def test_classify_retryable_4xx_is_transient() -> None:
+    # 408 Request Timeout and 425 Too Early are client-class but transient,
+    # so they must be retried rather than failing fast like 401/403/404.
+    c = ErrorClassifier.default()
+    assert c.classify(HTTPError(408)) is RetryStrategy.TRANSIENT
+    assert c.classify(HTTPError(425)) is RetryStrategy.TRANSIENT
+    # Other 4xx still fail fast.
+    assert c.classify(HTTPError(400)) is RetryStrategy.AUTH
+
+
+def test_classify_uses_response_status_code() -> None:
+    c = ErrorClassifier.default()
+    assert c.classify(RequestsStyleError(429)) is RetryStrategy.RATE_LIMIT
+    assert c.classify(RequestsStyleError(401)) is RetryStrategy.AUTH
+
+
+def test_classify_builtin_connection_errors_transient() -> None:
+    c = ErrorClassifier.default()
+    assert c.classify(ConnectionError("reset")) is RetryStrategy.TRANSIENT
+    assert c.classify(TimeoutError("slow")) is RetryStrategy.TRANSIENT
+
+
+def test_classify_unknown_falls_back() -> None:
+    c = ErrorClassifier.default()
+    assert c.classify(ValueError("???")) is RetryStrategy.UNKNOWN
+
+
+def test_register_custom_type_rule() -> None:
+    class MyConsistencyError(Exception):
+        pass
+
+    c = ErrorClassifier.default()
+    c.register(RetryStrategy.CONSISTENCY, exc_types=[MyConsistencyError])
+    assert c.classify(MyConsistencyError()) is RetryStrategy.CONSISTENCY
+
+
+def test_register_prepend_shadows_broad_rule() -> None:
+    c = ErrorClassifier.default()
+    # By default a 503 is TRANSIENT; override 503 specifically to CONSISTENCY.
+    c.register(
+        RetryStrategy.CONSISTENCY,
+        predicate=lambda e: getattr(e, "status_code", None) == 503,
+    )
+    assert c.classify(HTTPError(503)) is RetryStrategy.CONSISTENCY
+    assert c.classify(HTTPError(500)) is RetryStrategy.TRANSIENT
+
+
+def test_register_requires_matcher() -> None:
+    c = ErrorClassifier()
+    with pytest.raises(ValueError):
+        c.register(RetryStrategy.AUTH)
+
+
+def test_broken_predicate_does_not_crash_classify() -> None:
+    c = ErrorClassifier()
+
+    def boom(_exc: BaseException) -> bool:
+        raise RuntimeError("predicate bug")
+
+    c.register(RetryStrategy.TRANSIENT, predicate=boom)
+    assert c.classify(ValueError()) is RetryStrategy.UNKNOWN  # falls through
+
+
+# --- retry_classified -------------------------------------------------------
+
+
+def _recording_sleep() -> tuple[list[float], Callable[[float], None]]:
+    waits: list[float] = []
+    return waits, waits.append
+
+
+def test_retry_classified_success_no_retry() -> None:
+    waits, sleep = _recording_sleep()
+    calls = {"n": 0}
+
+    @retry_classified(sleep=sleep)
+    def ok() -> str:
+        calls["n"] += 1
+        return "done"
+
+    assert ok() == "done"
+    assert calls["n"] == 1
+    assert waits == []
+
+
+def test_retry_classified_rate_limit_retries_then_succeeds() -> None:
+    waits, sleep = _recording_sleep()
+    calls = {"n": 0}
+
+    @retry_classified(sleep=sleep)
+    def flaky() -> str:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise HTTPError(429)
+        return "ok"
+
+    assert flaky() == "ok"
+    assert calls["n"] == 3
+    assert len(waits) == 2  # two backoffs before the 3rd success
+
+
+def test_retry_classified_auth_fails_fast() -> None:
+    waits, sleep = _recording_sleep()
+    calls = {"n": 0}
+
+    @retry_classified(sleep=sleep)
+    def denied() -> None:
+        calls["n"] += 1
+        raise HTTPError(401)
+
+    with pytest.raises(HTTPError):
+        denied()
+    assert calls["n"] == 1  # no retry
+    assert waits == []
+
+
+def test_retry_classified_exhausts_attempts_and_reraises() -> None:
+    waits, sleep = _recording_sleep()
+    calls = {"n": 0}
+    max_attempts = DEFAULT_STRATEGY_CONFIGS[RetryStrategy.RATE_LIMIT].max_attempts
+
+    @retry_classified(sleep=sleep)
+    def always_429() -> None:
+        calls["n"] += 1
+        raise HTTPError(429)
+
+    with pytest.raises(HTTPError):
+        always_429()
+    assert calls["n"] == max_attempts
+    assert len(waits) == max_attempts - 1
+
+
+def test_retry_classified_success_criterion() -> None:
+    """Task success criterion: 429 retries with backoff; 401 fails immediately."""
+    waits, sleep = _recording_sleep()
+
+    @retry_classified(sleep=sleep)
+    def on_429() -> str:
+        if not waits:
+            raise HTTPError(429)
+        return "recovered"
+
+    assert on_429() == "recovered"
+    assert len(waits) == 1 and waits[0] > 0  # jittered exponential backoff happened
+
+    auth_waits, auth_sleep = _recording_sleep()
+
+    @retry_classified(sleep=auth_sleep)
+    def on_401() -> None:
+        raise HTTPError(401)
+
+    with pytest.raises(HTTPError):
+        on_401()
+    assert auth_waits == []  # immediate, no retry
+
+
+def test_retry_classified_on_retry_callback() -> None:
+    waits, sleep = _recording_sleep()
+    events: list[tuple[RetryStrategy, int]] = []
+
+    def on_retry(
+        exc: BaseException,
+        strategy: RetryStrategy,
+        next_attempt: int,
+        wait: float,
+    ) -> None:
+        events.append((strategy, next_attempt))
+
+    @retry_classified(sleep=sleep, on_retry=on_retry)
+    def flaky() -> str:
+        if len(events) < 2:
+            raise HTTPError(429)
+        return "ok"
+
+    assert flaky() == "ok"
+    assert events == [
+        (RetryStrategy.RATE_LIMIT, 2),
+        (RetryStrategy.RATE_LIMIT, 3),
+    ]
+
+
+def test_retry_classified_custom_configs_override() -> None:
+    waits, sleep = _recording_sleep()
+    calls = {"n": 0}
+    configs = {RetryStrategy.UNKNOWN: StrategyConfig(max_attempts=5, jitter=False)}
+
+    @retry_classified(sleep=sleep, configs=configs)
+    def boom() -> None:
+        calls["n"] += 1
+        raise ValueError("???")  # classified UNKNOWN
+
+    with pytest.raises(ValueError):
+        boom()
+    assert calls["n"] == 5

--- a/packages/gptme-backoff/tests/test_retry.py
+++ b/packages/gptme-backoff/tests/test_retry.py
@@ -272,3 +272,45 @@ def test_kwargs_preserved():
     with pytest.raises(_PermanentError):
         func()
     assert call_count[0] == 1  # no retry for non-temporary errors
+
+
+@pytest.mark.asyncio
+async def test_retry_api_call_retries_async_callable_objects():
+    """retry_api_call must detect callable objects with async __call__ as async.
+
+    inspect.iscoroutinefunction(obj) returns False for such objects; the fix uses
+    _is_coroutine_callable which also checks obj.__call__.  Without the fix, the
+    sync tenacity wrapper returns the coroutine object as a "success" result and
+    never retries.
+    """
+    call_count = [0]
+
+    class AsyncFetcher:
+        async def __call__(self) -> str:
+            call_count[0] += 1
+            if call_count[0] < 3:
+                raise OSError("transient")
+            return "ok"
+
+    fetcher = retry_api_call(max_attempts=5, min_wait=0, max_wait=0)(AsyncFetcher())
+    result = await fetcher()
+    assert result == "ok"
+    assert call_count[0] == 3
+
+
+@pytest.mark.asyncio
+async def test_retry_file_op_retries_async_callable_objects():
+    """retry_file_op must route callable objects with async __call__ through retry_async."""
+    call_count = [0]
+
+    class AsyncReader:
+        async def __call__(self) -> str:
+            call_count[0] += 1
+            if call_count[0] < 2:
+                raise OSError("busy")
+            return "data"
+
+    reader = retry_file_op(max_attempts=3, min_wait=0, max_wait=0)(AsyncReader())
+    result = await reader()
+    assert result == "data"
+    assert call_count[0] == 2

--- a/packages/gptme-backoff/tests/test_retry.py
+++ b/packages/gptme-backoff/tests/test_retry.py
@@ -219,6 +219,23 @@ def test_retry_file_op_does_not_retry_on_valueerror():
     assert call_count[0] == 1
 
 
+@pytest.mark.asyncio
+async def test_retry_file_op_retries_async_on_oserror():
+    """Async file ops are retried on OSError (not swallowed as a coroutine object)."""
+    call_count = [0]
+
+    @retry_file_op(max_attempts=3, min_wait=0.01, max_wait=0.01)
+    async def unstable() -> str:
+        call_count[0] += 1
+        if call_count[0] < 3:
+            raise OSError("file locked")
+        return "ok"
+
+    result = await unstable()
+    assert result == "ok"
+    assert call_count[0] == 3
+
+
 # ---- Edge cases ----
 
 

--- a/packages/gptme-backoff/tests/test_retry.py
+++ b/packages/gptme-backoff/tests/test_retry.py
@@ -1,0 +1,257 @@
+"""Tests for gptme-backoff retry decorators."""
+
+import pytest
+import tenacity
+from gptme_backoff import retry_api_call, retry_async, retry_file_op, retry_sync
+
+
+class _TemporaryError(Exception):
+    """Temporary error used in tests."""
+
+
+class _PermanentError(Exception):
+    """Permanent error that should not be retried."""
+
+
+# ---- Sync retry tests ----
+
+
+def test_retry_sync_eventually_succeeds():
+    call_count = [0]
+
+    @retry_sync(
+        stop=tenacity.stop_after_attempt(3),
+        wait=tenacity.wait_fixed(0.01),
+    )
+    def unstable() -> str:
+        call_count[0] += 1
+        if call_count[0] < 3:
+            raise _TemporaryError("not yet")
+        return "ok"
+
+    result = unstable()
+    assert result == "ok"
+    assert call_count[0] == 3
+
+
+def test_retry_sync_exhausted():
+    call_count = [0]
+
+    @retry_sync(
+        stop=tenacity.stop_after_attempt(2),
+        wait=tenacity.wait_fixed(0.01),
+    )
+    def always_fails() -> str:
+        call_count[0] += 1
+        raise _TemporaryError("boom")
+
+    with pytest.raises(_TemporaryError, match="boom"):
+        always_fails()
+    assert call_count[0] == 2
+
+
+def test_retry_sync_does_not_retry_on_success():
+    call_count = [0]
+
+    @retry_sync(
+        stop=tenacity.stop_after_attempt(5),
+        wait=tenacity.wait_fixed(0.01),
+    )
+    def always_ok() -> str:
+        call_count[0] += 1
+        return "ok"
+
+    result = always_ok()
+    assert result == "ok"
+    assert call_count[0] == 1
+
+
+# ---- Async retry tests ----
+
+
+@pytest.mark.asyncio
+async def test_retry_async_eventually_succeeds():
+    call_count = [0]
+
+    @retry_async(
+        stop=tenacity.stop_after_attempt(3),
+        wait=tenacity.wait_fixed(0.01),
+    )
+    async def unstable() -> str:
+        call_count[0] += 1
+        if call_count[0] < 3:
+            raise _TemporaryError("not yet")
+        return "ok"
+
+    result = await unstable()
+    assert result == "ok"
+    assert call_count[0] == 3
+
+
+@pytest.mark.asyncio
+async def test_retry_async_exhausted():
+    call_count = [0]
+
+    @retry_async(
+        stop=tenacity.stop_after_attempt(2),
+        wait=tenacity.wait_fixed(0.01),
+    )
+    async def always_fails() -> str:
+        call_count[0] += 1
+        raise _TemporaryError("boom")
+
+    with pytest.raises(_TemporaryError, match="boom"):
+        await always_fails()
+    assert call_count[0] == 2
+
+
+@pytest.mark.asyncio
+async def test_retry_async_first_call_ok():
+    call_count = [0]
+
+    @retry_async(
+        stop=tenacity.stop_after_attempt(3),
+        wait=tenacity.wait_fixed(0.01),
+    )
+    async def always_ok() -> str:
+        call_count[0] += 1
+        return "ok"
+
+    result = await always_ok()
+    assert result == "ok"
+    assert call_count[0] == 1
+
+
+# ---- Preset: API call ----
+
+
+def test_retry_api_call_preset():
+    call_count = [0]
+
+    @retry_api_call(max_attempts=3)
+    def unstable() -> str:
+        call_count[0] += 1
+        if call_count[0] < 3:
+            raise _TemporaryError("rate limited")
+        return "ok"
+
+    result = unstable()
+    assert result == "ok"
+    assert call_count[0] == 3
+
+
+def test_retry_api_call_exhausted():
+    call_count = [0]
+
+    @retry_api_call(max_attempts=2)
+    def always_fails() -> str:
+        call_count[0] += 1
+        raise _TemporaryError("server error")
+
+    with pytest.raises(_TemporaryError, match="server error"):
+        always_fails()
+    assert call_count[0] == 2
+
+
+@pytest.mark.asyncio
+async def test_retry_api_call_retries_async_functions():
+    call_count = [0]
+
+    @retry_api_call(max_attempts=3, min_wait=0.01, max_wait=0.01, jitter=False)
+    async def unstable() -> str:
+        call_count[0] += 1
+        if call_count[0] < 3:
+            raise _TemporaryError("rate limited")
+        return "ok"
+
+    result = await unstable()
+    assert result == "ok"
+    assert call_count[0] == 3
+
+
+def test_retry_api_call_timeout_stops_retries():
+    """stop_after_delay limits the total retry budget, not per-call execution time."""
+    call_count = [0]
+
+    @retry_api_call(max_attempts=10, timeout=0.02)
+    def always_fails() -> str:
+        call_count[0] += 1
+        raise _TemporaryError("transient")
+
+    with pytest.raises(_TemporaryError, match="transient"):
+        always_fails()
+    # Should stop retrying after ~0.02s, not attempt all 10
+    assert (
+        call_count[0] < 10
+    ), "timeout should stop retries before exhausting max_attempts"
+
+
+# ---- Preset: File operation ----
+
+
+def test_retry_file_op_on_oserror():
+    call_count = [0]
+
+    @retry_file_op(max_attempts=3)
+    def unstable() -> str:
+        call_count[0] += 1
+        if call_count[0] < 3:
+            raise OSError("file locked")
+        return "ok"
+
+    result = unstable()
+    assert result == "ok"
+    assert call_count[0] == 3
+
+
+def test_retry_file_op_does_not_retry_on_valueerror():
+    """File op preset should NOT retry non-OSError exceptions."""
+    call_count = [0]
+
+    @retry_file_op(max_attempts=3)
+    def fails_with_value_error() -> str:
+        call_count[0] += 1
+        raise _TemporaryError("not an OSError")
+
+    # Non-OSError should propagate immediately
+    with pytest.raises(_TemporaryError):
+        fails_with_value_error()
+    assert call_count[0] == 1
+
+
+# ---- Edge cases ----
+
+
+def test_reraise_true_is_default():
+    """Default retry_sync should re-raise original exception (reraise=True)."""
+    call_count = [0]
+
+    @retry_sync(
+        stop=tenacity.stop_after_attempt(2),
+        wait=tenacity.wait_fixed(0.01),
+    )
+    def always_fails() -> str:
+        call_count[0] += 1
+        raise _TemporaryError("boom")
+
+    with pytest.raises(_TemporaryError, match="boom"):
+        always_fails()
+    assert call_count[0] == 2
+
+
+def test_kwargs_preserved():
+    """retry_kwargs should be passed through to tenacity."""
+    call_count = [0]
+
+    @retry_sync(
+        stop=tenacity.stop_after_attempt(2),
+        wait=tenacity.wait_fixed(0.01),
+        retry=tenacity.retry_if_exception_type(_TemporaryError),
+    )
+    def func() -> str:
+        call_count[0] += 1
+        raise _PermanentError("not retriable")
+
+    with pytest.raises(_PermanentError):
+        func()
+    assert call_count[0] == 1  # no retry for non-temporary errors

--- a/packages/gptme-dashboard/Makefile
+++ b/packages/gptme-dashboard/Makefile
@@ -1,7 +1,7 @@
 .PHONY: test typecheck
 
 test:
-	uv run --with flask pytest tests/ -v
+	uv run pytest tests/ -v
 
 typecheck:
 	uv run --with mypy --with types-PyYAML mypy src/ --ignore-missing-imports

--- a/packages/gptme-lessons-extras/Makefile
+++ b/packages/gptme-lessons-extras/Makefile
@@ -2,7 +2,7 @@
 
 test:  ## Run tests for this package
 	@if [ -d tests ] && [ "$$(find tests -name '*.py' 2>/dev/null | head -1)" ]; then \
-		uv run --with pytest pytest tests/ -v; \
+		uv run pytest tests/ -v; \
 	else \
 		echo "No tests found"; \
 	fi

--- a/uv.lock
+++ b/uv.lock
@@ -19,6 +19,7 @@ members = [
     "gptme-action-receipts",
     "gptme-activity-summary",
     "gptme-attention-tracker",
+    "gptme-backoff",
     "gptme-cc-memory",
     "gptme-claude-code",
     "gptme-codegraph",
@@ -1611,6 +1612,28 @@ requires-dist = [
     { name = "gptme", git = "https://github.com/gptme/gptme.git?branch=master" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
     { name = "pytest-mock", marker = "extra == 'test'", specifier = ">=3.12.0" },
+]
+provides-extras = ["test"]
+
+[[package]]
+name = "gptme-backoff"
+version = "0.1.0"
+source = { editable = "packages/gptme-backoff" }
+dependencies = [
+    { name = "tenacity" },
+]
+
+[package.optional-dependencies]
+test = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
+    { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.25" },
+    { name = "tenacity", specifier = ">=9.0" },
 ]
 provides-extras = ["test"]
 


### PR DESCRIPTION
## Summary

- add `gptme-backoff` as a reusable package with sync/async tenacity decorators and API/file-operation presets
- add error-aware retry classification with fail-fast auth handling and configurable strategies
- add a thread-safe circuit breaker with closed/open/half-open transitions
- add package-local test/typecheck targets and workspace lock metadata

The Bob-specific headroom benchmark is deliberately excluded; this PR contains only the reusable package core.

## Verification

- `uv run --python 3.10 --package gptme-backoff --extra test pytest packages/gptme-backoff/tests -q` — 56 passed
- `uv run --python 3.10 --with mypy mypy packages/gptme-backoff/src --ignore-missing-imports` — clean
- `uv run ruff check packages/gptme-backoff` — clean
- `prek run --all-files` — clean
- Bob PR quality gate — 100/100