### PR TITLE
fix(twitter): give timeline its own budget independent of mentions

### DIFF
--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -2147,12 +2147,12 @@ def auto(
         except Exception as e:
             console.print(f"[red]Error processing mentions: {e}")
 
-    # Process timeline (if not skipped and still under limits)
-    if (
-        not skip_timeline
-        and total_tweets_processed < max_tweets
-        and total_drafts_generated < max_drafts
-    ):
+    # Process timeline (if not skipped and still under draft limits).
+    # Timeline gets its own max_tweets budget independent of mentions so that
+    # stale repeated mentions don't starve timeline processing -- which is the
+    # path that writes fresh tweets to the evaluation/cache pipeline and feeds
+    # surface-interesting.py.  Reference: investigate-twitter-cache-freeze-green-loop.
+    if not skip_timeline and total_drafts_generated < max_drafts:
         console.print("\n[bold]Processing timeline[/bold]")
         try:
             # Get timeline tweets
@@ -2187,10 +2187,9 @@ def auto(
                 source = "home timeline"
 
             if tweets.data:
-                remaining_tweets = max_tweets - total_tweets_processed
-                console.print(
-                    f"Processing {min(len(tweets.data), remaining_tweets)} tweets from {source}"
-                )
+                # Timeline gets its own budget, not what mentions left behind
+                timeline_budget = min(max_tweets, len(tweets.data))
+                console.print(f"Processing {timeline_budget} tweets from {source}")
 
                 if dry_run:
                     console.print(
@@ -2198,7 +2197,7 @@ def auto(
                     )
 
                 drafts_from_timeline = process_timeline_tweets(
-                    tweets.data[:remaining_tweets],
+                    tweets.data[:timeline_budget],
                     tweets.includes["users"] if tweets.includes else None,
                     source,
                     client,
@@ -2208,7 +2207,7 @@ def auto(
                 )
 
                 # Update counters
-                total_tweets_processed += min(len(tweets.data), remaining_tweets)
+                total_tweets_processed += timeline_budget
                 total_drafts_generated += drafts_from_timeline
             else:
                 console.print("[yellow]No new tweets found in timeline")


### PR DESCRIPTION
## Problem

When the twitter-loop service's `auto()` command processes mentions first, each mention feed returns the same recently-mentioned tweets cycle after cycle. The `total_tweets_processed` counter was bumped by the raw fetch count even when every mention was already replied-to or cached, so the subsequent timeline gate `total_tweets_processed < max_tweets` was permanently false — the timeline path never ran, no new tweets were evaluated, and `tweets/cache` never advanced.

From the outside: a green service with a frozen cache (detected by `state-freshness-health.py` after 8 days of zero cache advancement).

## Fix

Remove the shared-budget starvation by giving the timeline path its own `max_tweets` budget so it always runs (gated only by the draft limit). Also fix the counter to use the actual `timeline_budget` instead of the stale `remaining_tweets` calculation.

## Verification

- Dry-run confirms timeline now processes tweets even after mentions consume their budget
- Verified with: `workflow.py auto --skip-mentions --max-tweets 2 --max-drafts 1`
- Live cache writes confirmed with real OpenRouter API key

## Related

- Discovered during investigation for ErikBjare/bob task `investigate-twitter-cache-freeze-green-loop`
- Monitoring fix that detected the frozen cache: `9fdd82c013 fix(monitoring): detect stale twitter cache`