### PR TITLE
refactor(community-plugins): move index from state/ to repo root

### DIFF
--- a/.github/workflows/community-plugins.yml
+++ b/.github/workflows/community-plugins.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add state/community_plugins.json
+          git add community_plugins.json
           if git diff --cached --quiet; then
             echo "No changes to community_plugins.json"
           else
@@ -51,6 +51,6 @@ jobs:
                 --base ${{ github.event.repository.default_branch }} \
                 --head "$branch" \
                 --title "chore(community-plugins): weekly refresh" \
-                --body "Automated weekly refresh of state/community_plugins.json."
+                --body "Automated weekly refresh of community_plugins.json."
             fi
           fi

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -9,7 +9,7 @@ on:
       - 'packages/**'
       - 'skills/**'
       - 'gptme.toml'
-      - 'state/community_plugins.json'
+      - 'community_plugins.json'
       - '.github/workflows/dashboard.yml'
   workflow_dispatch:
 

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ scripts/.env
 venv/
 .gptme/
 
+# Community plugins index (moved to repo root in #1292)
+state/community_plugins.json
+
 # Task lock files (runtime state)
 state/locks/
 

--- a/community_plugins.json
+++ b/community_plugins.json
@@ -1,0 +1,78 @@
+{
+  "fetched_at": "2026-06-29T00:00:00Z",
+  "source": "seeded from gptme/registry.gptme.org registry.json (2026-06-29); future updates via scripts/fetch-community-plugins.py",
+  "entries": [
+    {
+      "name": "gptme/gptme-rag",
+      "description": "RAG plugin for gptme — semantic document search and retrieval-augmented generation.",
+      "url": "https://github.com/gptme/gptme-rag",
+      "stars": 17,
+      "language": "Python",
+      "topics": ["gptme-plugin"]
+    },
+    {
+      "name": "gptme/gptme.vim",
+      "description": "Vim plugin for gptme — use gptme from within vim/neovim.",
+      "url": "https://github.com/gptme/gptme.vim",
+      "stars": 7,
+      "language": "Vim Script",
+      "topics": ["gptme-plugin"]
+    },
+    {
+      "name": "gptme/gptme-tauri",
+      "description": "Desktop app for gptme built with Tauri — GUI wrapper with system tray integration.",
+      "url": "https://github.com/gptme/gptme-tauri",
+      "stars": 6,
+      "language": "Rust",
+      "topics": ["gptme-plugin", "gptme-skill"]
+    },
+    {
+      "name": "gptme/gptme-webui",
+      "description": "Web UI for gptme — browser-based chat interface for remote agents.",
+      "url": "https://github.com/gptme/gptme-webui",
+      "stars": 5,
+      "language": "TypeScript",
+      "topics": ["gptme-plugin", "gptme-skill"]
+    },
+    {
+      "name": "gptme/gptme-voice",
+      "description": "Voice interface for gptme — Twilio telephony and OpenAI Realtime API integration.",
+      "url": "https://github.com/gptme/gptme-voice",
+      "stars": 4,
+      "language": "Python",
+      "topics": ["gptme-skill"]
+    },
+    {
+      "name": "gptme/gptme-codegraph",
+      "description": "Code knowledge graph MCP server for gptme — repository structure awareness.",
+      "url": "https://github.com/gptme/gptme-codegraph",
+      "stars": 3,
+      "language": "Python",
+      "topics": ["gptme-plugin", "gptme-mcp-server"]
+    },
+    {
+      "name": "gptme/gptme-forum",
+      "description": "Forum interaction skill for gptme agents — read and post to online discussion boards.",
+      "url": "https://github.com/gptme/gptme-forum",
+      "stars": 3,
+      "language": "Python",
+      "topics": ["gptme-skill"]
+    },
+    {
+      "name": "gptme/gptme-daily-briefing",
+      "description": "Daily briefing skill — summaries of repos, threads, and contacts for autonomous agents.",
+      "url": "https://github.com/gptme/gptme-daily-briefing",
+      "stars": 3,
+      "language": "Python",
+      "topics": ["gptme-skill"]
+    },
+    {
+      "name": "gptme/gptme-subscription",
+      "description": "Subscription management skill — quota-aware harness selection and rotation.",
+      "url": "https://github.com/gptme/gptme-subscription",
+      "stars": 2,
+      "language": "Python",
+      "topics": ["gptme-skill"]
+    }
+  ]
+}

--- a/packages/gptme-dashboard/src/gptme_dashboard/generate.py
+++ b/packages/gptme-dashboard/src/gptme_dashboard/generate.py
@@ -1029,7 +1029,7 @@ def scan_skills(workspace: Path, source: str = "") -> list[dict]:
 
 
 def scan_community_plugins(workspace: Path) -> list[dict]:
-    """Load community/external gptme extensions from state/community_plugins.json.
+    """Load community/external gptme extensions from community_plugins.json.
 
     Returns an empty list when the file is missing (graceful degradation for
     workspaces that don't run the fetch script).
@@ -1052,7 +1052,7 @@ def scan_community_plugins(workspace: Path) -> list[dict]:
             ]
         }
     """
-    json_path = workspace / "state" / "community_plugins.json"
+    json_path = workspace / "community_plugins.json"
     if not json_path.exists():
         return []
     try:

--- a/scripts/fetch-community-plugins.py
+++ b/scripts/fetch-community-plugins.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Fetch community gptme extensions and update state/community_plugins.json.
+"""Fetch community gptme extensions and update community_plugins.json.
 
 Merges two sources:
 1. registry.gptme.org/registry.json — curated official list (seed/baseline)
@@ -46,7 +46,7 @@ _TYPE_TO_TOPICS: dict[str, list[str]] = {
     "skill / mcp-server": ["gptme-skill", "gptme-mcp-server"],
 }
 
-DEFAULT_OUTPUT = Path(__file__).parent.parent / "state" / "community_plugins.json"
+DEFAULT_OUTPUT = Path(__file__).parent.parent / "community_plugins.json"
 
 
 def fetch_registry() -> tuple[list[dict], bool]:
@@ -183,7 +183,7 @@ def main() -> int:
         "--output",
         type=Path,
         default=DEFAULT_OUTPUT,
-        help="Output JSON file (default: state/community_plugins.json)",
+        help="Output JSON file (default: community_plugins.json)",
     )
     parser.add_argument(
         "--dry-run", action="store_true", help="Print result without writing"


### PR DESCRIPTION
## Summary

- Moves `state/community_plugins.json` to `community_plugins.json` at the repo root
- Updates `scripts/fetch-community-plugins.py` `DEFAULT_OUTPUT` to match the new location
- Adds `state/community_plugins.json` to `.gitignore` to guard against old script versions writing there

## Motivation

`state/community_plugins.json` was the only committed file in `state/`, which Erik noted in #1290 confuses with agent brain `state/` directories (runtime-only state). The index belongs at the root alongside the script that generates it, not mixed with runtime lock files.

Addresses: https://github.com/gptme/gptme-contrib/pull/1290#issuecomment-4957179349