### PR TITLE
feat(gptodo): allow pool filters in human status output

### DIFF
--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -816,12 +816,38 @@ def _build_status_summary_from_task_dicts(tasks: List[Dict[str, Any]]) -> Dict[s
     }
 
 
+def _filter_status_results_by_pool(
+    results: Dict[str, List[TaskInfo]],
+    *,
+    pool_filter: str | None,
+    exclude_pool: str | None,
+) -> Dict[str, List[TaskInfo]]:
+    """Filter a status result-set by task pool without changing bucket shape."""
+    if pool_filter is None and exclude_pool is None:
+        return results
+
+    filtered: Dict[str, List[TaskInfo]] = {}
+    for bucket, items in results.items():
+        filtered[bucket] = [
+            task
+            for task in items
+            if task_matches_pool_filter(
+                task,
+                pool=pool_filter,
+                exclude_pool=exclude_pool,
+            )
+        ]
+    return filtered
+
+
 def check_directory(
     console: Console,
     dir_type: str,
     repo_root: Path,
     compact: bool = False,
     summary_only: bool = False,
+    pool_filter: str | None = None,
+    exclude_pool: str | None = None,
 ) -> Dict[str, List[TaskInfo]]:
     """Check and display status for a single directory type.
 
@@ -833,6 +859,11 @@ def check_directory(
     config = CONFIGS[dir_type]
     checker = StateChecker(repo_root, config)
     results = checker.check_all()
+    results = _filter_status_results_by_pool(
+        results,
+        pool_filter=pool_filter,
+        exclude_pool=exclude_pool,
+    )
 
     # Print header with type-specific color. No trailing newline: the first
     # section (and the summary) already lead with a blank line, so a trailing
@@ -880,24 +911,25 @@ def check_directory(
     print_summary(console, results, config)
 
     # Discoverability: show hidden non-default pool counts so they are never silently orphaned.
-    all_tasks_flat = [t for lst in results.values() for t in lst]
-    non_default = [t for t in all_tasks_flat if task_pool(t) != "general"]
-    if non_default:
-        pool_totals: Dict[str, list] = {}
-        for t in non_default:
-            p = task_pool(t)
-            if p not in pool_totals:
-                pool_totals[p] = [0, 0]  # [total, actionable]
-            pool_totals[p][0] += 1
-            if t.state in ("backlog", "todo", "active"):
-                pool_totals[p][1] += 1
-        parts = ", ".join(
-            f"{p}: {counts[0]} ({counts[1]} actionable)"
-            for p, counts in sorted(pool_totals.items())
-        )
-        console.print(
-            f"  [dim]Other pools: {parts} (use --pool {next(iter(pool_totals))} to view)[/]"
-        )
+    if pool_filter is None and exclude_pool is None:
+        all_tasks_flat = [t for lst in results.values() for t in lst]
+        non_default = [t for t in all_tasks_flat if task_pool(t) != "general"]
+        if non_default:
+            pool_totals: Dict[str, list] = {}
+            for t in non_default:
+                p = task_pool(t)
+                if p not in pool_totals:
+                    pool_totals[p] = [0, 0]  # [total, actionable]
+                pool_totals[p][0] += 1
+                if t.state in ("backlog", "todo", "active"):
+                    pool_totals[p][1] += 1
+            parts = ", ".join(
+                f"{p}: {counts[0]} ({counts[1]} actionable)"
+                for p, counts in sorted(pool_totals.items())
+            )
+            console.print(
+                f"  [dim]Other pools: {parts} (use --pool {next(iter(pool_totals))} to view)[/]"
+            )
 
     return results
 
@@ -1082,9 +1114,6 @@ def status(
     type, all, compact, summary, issues, github, github_repo, output_json, pool_filter, exclude_pool
 ):
     """Show status of tasks and other tracked items."""
-    if not output_json and (pool_filter is not None or exclude_pool is not None):
-        raise click.UsageError("--pool/--exclude-pool are only supported with --json")
-
     console = Console()
     repo_root = find_repo_root(Path.cwd())
 
@@ -1131,7 +1160,15 @@ def status(
     if all:
         # Check all directory types
         for type_name in CONFIGS.keys():
-            results = check_directory(console, type_name, repo_root, compact, summary_only=summary)
+            results = check_directory(
+                console,
+                type_name,
+                repo_root,
+                compact,
+                summary_only=summary,
+                pool_filter=pool_filter,
+                exclude_pool=exclude_pool,
+            )
             if results:  # Only include directories with items
                 all_results[type_name] = results
 
@@ -1146,7 +1183,15 @@ def status(
 
     else:
         # Check single directory type
-        results = check_directory(console, type, repo_root, compact, summary_only=summary)
+        results = check_directory(
+            console,
+            type,
+            repo_root,
+            compact,
+            summary_only=summary,
+            pool_filter=pool_filter,
+            exclude_pool=exclude_pool,
+        )
         if results:
             all_results[type] = results
 

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -1102,13 +1102,13 @@ def _show_github_issues(
     "--pool",
     "pool_filter",
     default=None,
-    help="Only show tasks in this pool (e.g. 'frontier', 'general'); applies to --json output",
+    help="Only show tasks in this pool (e.g. 'frontier', 'general')",
 )
 @click.option(
     "--exclude-pool",
     "exclude_pool",
     default=None,
-    help="Exclude tasks in this pool (e.g. '--exclude-pool frontier'); applies to --json output",
+    help="Exclude tasks in this pool (e.g. '--exclude-pool frontier')",
 )
 def status(
     type, all, compact, summary, issues, github, github_repo, output_json, pool_filter, exclude_pool

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -912,8 +912,13 @@ def check_directory(
                         results[state],
                     )
 
-    # Print summary
-    print_summary(console, results, config)
+    # Print summary; if filtering resulted in all empty buckets, show explicit message
+    all_tasks_flat = [t for lst in results.values() for t in lst]
+    if (pool_filter is not None or exclude_pool is not None) and not all_tasks_flat:
+        if summary_only:
+            console.print("  [dim]No tasks match the pool filter.[/]")
+    else:
+        print_summary(console, results, config)
 
     # Discoverability: show hidden non-default pool counts so they are never silently orphaned.
     if pool_filter is None and exclude_pool is None:

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -872,40 +872,45 @@ def check_directory(
     console.print(f"\n[bold {style}]{config.emoji} {config.type_name.title()} Status[/]")
 
     if not summary_only:
-        # Print sections in order
-        if results["issues"]:
-            print_status_section(
-                console,
-                "Issues Found",
-                results["issues"],
-                show_state=True,
-            )
-
-        if results["untracked"]:
-            print_status_section(
-                console,
-                "Untracked Files",
-                results["untracked"],
-            )
-
-        # Determine which states to show based on compact mode.
-        # Compact = the active work funnel: untriaged, triaged, in-flight,
-        # and awaiting verification. Exclude blocked, deferred, and terminal
-        # states so the short view stays focused on real work.
-        states_to_show = (
-            [s for s in ("backlog", "todo", "active", "ready_for_review") if s in config.states]
-            if compact
-            else config.states
-        )
-
-        # Print active states in order
-        for state in states_to_show:
-            if state in config.states and results.get(state):
+        # Check if filtering resulted in no matching tasks
+        all_tasks_flat = [t for lst in results.values() for t in lst]
+        if (pool_filter is not None or exclude_pool is not None) and not all_tasks_flat:
+            console.print("  [dim]No tasks match the pool filter.[/]")
+        else:
+            # Print sections in order
+            if results["issues"]:
                 print_status_section(
                     console,
-                    state,
-                    results[state],
+                    "Issues Found",
+                    results["issues"],
+                    show_state=True,
                 )
+
+            if results["untracked"]:
+                print_status_section(
+                    console,
+                    "Untracked Files",
+                    results["untracked"],
+                )
+
+            # Determine which states to show based on compact mode.
+            # Compact = the active work funnel: untriaged, triaged, in-flight,
+            # and awaiting verification. Exclude blocked, deferred, and terminal
+            # states so the short view stays focused on real work.
+            states_to_show = (
+                [s for s in ("backlog", "todo", "active", "ready_for_review") if s in config.states]
+                if compact
+                else config.states
+            )
+
+            # Print active states in order
+            for state in states_to_show:
+                if state in config.states and results.get(state):
+                    print_status_section(
+                        console,
+                        state,
+                        results[state],
+                    )
 
     # Print summary
     print_summary(console, results, config)

--- a/packages/gptodo/tests/test_pool_filter.py
+++ b/packages/gptodo/tests/test_pool_filter.py
@@ -395,6 +395,27 @@ class TestTaskToDictPool:
         assert "frontier-active" in result.output
         assert "general-backlog" not in result.output
 
+    def test_status_exclude_pool_filter_human_output_filters_tasks(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        write_task(tasks_dir, "general-task", state="backlog", created="2026-01-01T00:00:00")
+        write_task(
+            tasks_dir,
+            "frontier-task",
+            state="active",
+            created="2026-01-01T00:00:00",
+            pool="frontier",
+        )
+        monkeypatch.chdir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["status", "--exclude-pool", "frontier"])
+        assert result.exit_code == 0
+        assert "general-task" in result.output
+        assert "frontier-task" not in result.output
+        assert "Other pools:" not in result.output
+
     def test_status_shows_hidden_pools_discoverability(self, tmp_path: Path, monkeypatch) -> None:
         """Human-readable status shows 'Other pools: frontier: N' so non-default pools
         are never silently orphaned when unflagged selection hides them."""

--- a/packages/gptodo/tests/test_pool_filter.py
+++ b/packages/gptodo/tests/test_pool_filter.py
@@ -354,15 +354,46 @@ class TestTaskToDictPool:
         assert tasks_by_id["frontier-task"]["pool"] == "frontier"
         assert tasks_by_id["general-task"]["pool"] == "general"
 
-    def test_status_pool_filter_requires_json(self, tmp_path: Path, monkeypatch) -> None:
+    def test_status_pool_filter_human_output_filters_tasks(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
         tasks_dir = tmp_path / "tasks"
         tasks_dir.mkdir()
-        write_task(tasks_dir, "frontier-task", state="backlog", created="2026-01-01T00:00:00")
+        write_task(tasks_dir, "general-task", state="backlog", created="2026-01-01T00:00:00")
+        write_task(
+            tasks_dir,
+            "frontier-task",
+            state="active",
+            created="2026-01-01T00:00:00",
+            pool="frontier",
+        )
         monkeypatch.chdir(tmp_path)
-        runner = cli_runner_separate_stderr()
+        runner = CliRunner()
         result = runner.invoke(cli, ["status", "--pool", "frontier"])
-        assert result.exit_code == 2
-        assert "--pool/--exclude-pool are only supported with --json" in result.stderr
+        assert result.exit_code == 0
+        assert "frontier-task" in result.output
+        assert "general-task" not in result.output
+        assert "Other pools:" not in result.output
+
+    def test_status_compact_pool_filter_human_output_filters_tasks(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        write_task(tasks_dir, "general-backlog", state="backlog", created="2026-01-01T00:00:00")
+        write_task(
+            tasks_dir,
+            "frontier-active",
+            state="active",
+            created="2026-01-01T00:00:00",
+            pool="frontier",
+        )
+        monkeypatch.chdir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["status", "--compact", "--pool", "frontier"])
+        assert result.exit_code == 0
+        assert "frontier-active" in result.output
+        assert "general-backlog" not in result.output
 
     def test_status_shows_hidden_pools_discoverability(self, tmp_path: Path, monkeypatch) -> None:
         """Human-readable status shows 'Other pools: frontier: N' so non-default pools

--- a/packages/gptodo/tests/test_pool_filter.py
+++ b/packages/gptodo/tests/test_pool_filter.py
@@ -416,6 +416,27 @@ class TestTaskToDictPool:
         assert "frontier-task" not in result.output
         assert "Other pools:" not in result.output
 
+    def test_status_pool_filter_empty_result_shows_message(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """When filtering matches no tasks, show explicit 'No tasks match' message."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        write_task(tasks_dir, "general-task", state="backlog", created="2026-01-01T00:00:00")
+        write_task(
+            tasks_dir,
+            "frontier-task",
+            state="active",
+            created="2026-01-01T00:00:00",
+            pool="frontier",
+        )
+        monkeypatch.chdir(tmp_path)
+        runner = CliRunner()
+        # Filter for a non-existent pool
+        result = runner.invoke(cli, ["status", "--pool", "nonexistent"])
+        assert result.exit_code == 0
+        assert "No tasks match the pool filter" in result.output
+
     def test_status_shows_hidden_pools_discoverability(self, tmp_path: Path, monkeypatch) -> None:
         """Human-readable status shows 'Other pools: frontier: N' so non-default pools
         are never silently orphaned when unflagged selection hides them."""

--- a/packages/gptodo/tests/test_pool_filter.py
+++ b/packages/gptodo/tests/test_pool_filter.py
@@ -437,6 +437,27 @@ class TestTaskToDictPool:
         assert result.exit_code == 0
         assert "No tasks match the pool filter" in result.output
 
+    def test_status_summary_pool_filter_empty_result_shows_message(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """When --summary filtering matches no tasks, show explicit 'No tasks match' message."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        write_task(tasks_dir, "general-task", state="backlog", created="2026-01-01T00:00:00")
+        write_task(
+            tasks_dir,
+            "frontier-task",
+            state="active",
+            created="2026-01-01T00:00:00",
+            pool="frontier",
+        )
+        monkeypatch.chdir(tmp_path)
+        runner = CliRunner()
+        # Filter for a non-existent pool with --summary
+        result = runner.invoke(cli, ["status", "--summary", "--pool", "nonexistent"])
+        assert result.exit_code == 0
+        assert "No tasks match the pool filter" in result.output
+
     def test_status_shows_hidden_pools_discoverability(self, tmp_path: Path, monkeypatch) -> None:
         """Human-readable status shows 'Other pools: frontier: N' so non-default pools
         are never silently orphaned when unflagged selection hides them."""


### PR DESCRIPTION
## Summary
- allow `gptodo status --pool/--exclude-pool` in human-readable output instead of erroring
- filter rendered status buckets by pool before printing summaries and sections
- keep the hidden-pools discoverability hint only for the unfiltered view

## Testing
- `uv run pytest packages/gptodo/tests/test_pool_filter.py -q`
- `gptodo status --compact --pool frontier`