### PR TITLE
fix(sessions): serialize SessionStore mutations with cross-process locking

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -14,14 +14,6 @@ from typing import Any, cast
 
 import click
 
-# fcntl is POSIX-only; on Windows we skip locking.
-try:
-    import fcntl as _fcntl
-
-    _has_fcntl = True
-except ImportError:
-    _has_fcntl = False
-
 from .discovery import (
     discover_cc_sessions,
     discover_codex_sessions,
@@ -1081,81 +1073,67 @@ def annotate(
     store = SessionStore(sessions_dir=ctx.obj["sessions_dir"])
     store.sessions_dir.mkdir(parents=True, exist_ok=True)
 
-    # Hold an exclusive lock to serialise concurrent annotate calls during the
-    # load → mutate → rewrite cycle (prevents annotate-vs-annotate clobber).
-    # Note: sync/post-session use store.append(), which does not acquire this
-    # lock. Fully protecting against annotate+sync races would require locking
-    # inside SessionStore itself — that is a future improvement.
+    # Hold the store's exclusive lock across the whole load → mutate → rewrite
+    # cycle so a concurrent writer cannot land between the load and the
+    # rewrite and have its update clobbered by our stale in-memory copy.
+    # SessionStore.lock() is reentrant, so the rewrite() below nests safely.
+    with store.lock():
+        records = store.load_all()
 
-    # The lock file is a permanent sentinel — never deleted. This ensures all
-    # concurrent annotate calls operate on the same inode, so the flock queue
-    # works correctly. Deleting the file would allow a newly arriving process
-    # to acquire LOCK_EX on a fresh inode while a blocked waiter holds
-    # LOCK_EX on the old inode, breaking mutual exclusion.
-    lock_path = store.path.with_name(store.path.name + ".lock")
-    with open(lock_path, "a", encoding="utf-8") as lock_file:
-        if _has_fcntl:
-            _fcntl.flock(lock_file, _fcntl.LOCK_EX)
-        try:
-            records = store.load_all()
+        if not records:
+            raise click.ClickException("No session records found in store.")
 
-            if not records:
-                raise click.ClickException("No session records found in store.")
+        # Resolve by prefix — short IDs like "a1b2" are common; IDs are lowercase hex
+        matches = [r for r in records if r.session_id.startswith(session_id)]
+        if not matches:
+            raise click.ClickException(
+                f"No session found with ID prefix {session_id!r}. "
+                "Run 'gptme-sessions query' to list available session IDs."
+            )
+        if len(matches) > 1:
+            ids = ", ".join(r.session_id for r in matches)
+            raise click.ClickException(
+                f"Ambiguous prefix {session_id!r} matches {len(matches)} sessions: {ids}"
+            )
 
-            # Resolve by prefix — short IDs like "a1b2" are common; IDs are lowercase hex
-            matches = [r for r in records if r.session_id.startswith(session_id)]
-            if not matches:
-                raise click.ClickException(
-                    f"No session found with ID prefix {session_id!r}. "
-                    "Run 'gptme-sessions query' to list available session IDs."
-                )
-            if len(matches) > 1:
-                ids = ", ".join(r.session_id for r in matches)
-                raise click.ClickException(
-                    f"Ambiguous prefix {session_id!r} matches {len(matches)} sessions: {ids}"
-                )
+        record = matches[0]
 
-            record = matches[0]
+        # Apply only the fields that were explicitly provided
+        if model is not None:
+            record.model = model
+        if harness is not None:
+            record.harness = harness
+        if run_type is not None:
+            record.run_type = normalize_run_type(run_type)
+        if category is not None:
+            record.category = category
+        if outcome is not None:
+            record.outcome = outcome
+        if duration is not None:
+            record.duration_seconds = duration
+        if journal_path is not None:
+            record.journal_path = journal_path
+        if selector_mode is not None:
+            record.selector_mode = selector_mode
+        if trigger is not None:
+            record.trigger = trigger
+        if token_count is not None:
+            record.token_count = token_count
+        if recommended_category is not None:
+            record.recommended_category = recommended_category
+        if add_deliverable:
+            existing = list(record.deliverables or [])
+            for d in add_deliverable:
+                if d not in existing:
+                    existing.append(d)
+            record.deliverables = existing
 
-            # Apply only the fields that were explicitly provided
-            if model is not None:
-                record.model = model
-            if harness is not None:
-                record.harness = harness
-            if run_type is not None:
-                record.run_type = normalize_run_type(run_type)
-            if category is not None:
-                record.category = category
-            if outcome is not None:
-                record.outcome = outcome
-            if duration is not None:
-                record.duration_seconds = duration
-            if journal_path is not None:
-                record.journal_path = journal_path
-            if selector_mode is not None:
-                record.selector_mode = selector_mode
-            if trigger is not None:
-                record.trigger = trigger
-            if token_count is not None:
-                record.token_count = token_count
-            if recommended_category is not None:
-                record.recommended_category = recommended_category
-            if add_deliverable:
-                existing = list(record.deliverables or [])
-                for d in add_deliverable:
-                    if d not in existing:
-                        existing.append(d)
-                record.deliverables = existing
+        store.rewrite(records)
 
-            store.rewrite(records)
-
-            if as_json:
-                click.echo(json.dumps(record.to_dict(), indent=2, default=str))
-            else:
-                click.echo(f"Updated session {record.session_id}.")
-        finally:
-            if _has_fcntl:
-                _fcntl.flock(lock_file, _fcntl.LOCK_UN)
+    if as_json:
+        click.echo(json.dumps(record.to_dict(), indent=2, default=str))
+    else:
+        click.echo(f"Updated session {record.session_id}.")
 
 
 # -- auto-tag ----------------------------------------------------------------

--- a/packages/gptme-sessions/src/gptme_sessions/store.py
+++ b/packages/gptme-sessions/src/gptme_sessions/store.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import sys
+import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import datetime, timezone
@@ -205,10 +206,14 @@ class SessionStore:
           avoid clobbering a concurrent writer's field updates with a stale
           in-memory copy.
 
-        The temp file is per-pid and fsynced before the atomic replace: a
-        fixed shared temp name would let two concurrent rewriters interleave
-        writes on the same inode and install a torn file (the mechanism
-        behind truncated mid-file records observed 2026-07-14).
+        The temp file name is unique per call (pid + random suffix) and
+        fsynced before the atomic replace: a fixed shared temp name would let
+        two concurrent rewriters interleave writes on the same inode and
+        install a torn file (the mechanism behind truncated mid-file records
+        observed 2026-07-14).  Per-call uniqueness also covers the
+        unsupported-but-possible case of two threads sharing one store
+        instance, where the reentrancy counter races and both could
+        otherwise write the same temp.
 
         ``records`` takes precedence for any session_id present in both.
         """
@@ -230,7 +235,9 @@ class SessionStore:
                         except (json.JSONDecodeError, TypeError, AttributeError):
                             malformed_lines.append(raw)
 
-            tmp_path = self.path.with_name(f"{self.path.name}.tmp.{os.getpid()}")
+            tmp_path = self.path.with_name(
+                f"{self.path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex[:8]}"
+            )
             try:
                 with open(tmp_path, "w", encoding="utf-8") as f:
                     for record in records:

--- a/packages/gptme-sessions/src/gptme_sessions/store.py
+++ b/packages/gptme-sessions/src/gptme_sessions/store.py
@@ -6,11 +6,20 @@ import json
 import logging
 import os
 import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TextIO
 
 from .record import SessionRecord
+
+try:
+    import fcntl as _fcntl
+
+    _has_fcntl = True
+except ImportError:  # pragma: no cover - non-POSIX platforms
+    _has_fcntl = False
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +55,49 @@ class SessionStore:
         self.sessions_dir = sessions_dir
         self.sessions_file = sessions_file
         self.path = sessions_dir / sessions_file
+        self._lock_depth = 0
+
+    @contextmanager
+    def lock(self) -> Iterator[None]:
+        """Cross-process exclusive lock over store mutations.
+
+        ``append()`` and ``rewrite()`` acquire this internally, so any two
+        processes mutating the store are serialised.  Callers doing a
+        read-modify-write cycle (``load_all()`` → mutate → ``rewrite()``)
+        should additionally hold this around the *whole* cycle, or a
+        concurrent writer can land between the load and the rewrite and have
+        its field updates clobbered by the stale in-memory copy.
+
+        Reentrant within a single ``SessionStore`` instance (flock treats
+        separate fds in one process as independent owners, so a naive nested
+        acquire would self-deadlock).  Not thread-safe — the store is designed
+        for single-threaded CLI processes.
+
+        The lock file is a permanent sentinel next to the store file — never
+        delete it.  Deleting it would let a newly arriving process acquire
+        LOCK_EX on a fresh inode while a blocked waiter holds LOCK_EX on the
+        old inode, breaking mutual exclusion.
+        """
+        if self._lock_depth > 0:
+            self._lock_depth += 1
+            try:
+                yield
+            finally:
+                self._lock_depth -= 1
+            return
+
+        self.sessions_dir.mkdir(parents=True, exist_ok=True)
+        lock_path = self.path.with_name(self.path.name + ".lock")
+        with open(lock_path, "a", encoding="utf-8") as lock_file:
+            if _has_fcntl:
+                _fcntl.flock(lock_file, _fcntl.LOCK_EX)
+            self._lock_depth = 1
+            try:
+                yield
+            finally:
+                self._lock_depth = 0
+                if _has_fcntl:
+                    _fcntl.flock(lock_file, _fcntl.LOCK_UN)
 
     def _repair_tail(self) -> bool:
         """Remove a corrupt partial JSON line from the end of the file.
@@ -53,6 +105,9 @@ class SessionStore:
         A process killed mid-write (OOM, timeout, SIGKILL) can leave a
         partial JSON record as the last line.  This method detects and
         truncates it so the next ``append()`` starts from a clean state.
+
+        Callers must hold ``lock()`` — a concurrent writer between the read
+        and the ftruncate would make the truncation destructive.
 
         Returns True if a partial line was detected and removed.
         """
@@ -107,12 +162,12 @@ class SessionStore:
 
     def append(self, record: SessionRecord) -> Path:
         """Append a session record to the JSONL store.  Self-heals corrupt tails."""
-        self.sessions_dir.mkdir(parents=True, exist_ok=True)
-        self._repair_tail()
-        with open(self.path, "a", encoding="utf-8") as f:
-            f.write(record.to_json() + "\n")
-            f.flush()
-            os.fsync(f.fileno())
+        with self.lock():
+            self._repair_tail()
+            with open(self.path, "a", encoding="utf-8") as f:
+                f.write(record.to_json() + "\n")
+                f.flush()
+                os.fsync(f.fileno())
         return self.path
 
     def load_all(self) -> list[SessionRecord]:
@@ -139,45 +194,57 @@ class SessionStore:
         and appended to the output).  There is no way to delete a record via
         this method; to remove records, edit the JSONL file directly.
 
-        Re-reads the current file before writing to:
-        - Preserve malformed JSONL lines rather than silently dropping them.
-        - Reduce (but not eliminate) the append-vs-rewrite race: records
-          appended via ``append()`` between the caller's ``load_all()`` and
-          this re-read are picked up.  Any ``append()`` that lands *after* the
-          re-read completes but before the atomic replace will still be lost;
-          fully closing this window would require ``append()`` to participate
-          in the same flock, which is a future improvement.
+        Holds the store lock across the re-read → write → replace cycle, so
+        concurrent ``append()``/``rewrite()`` calls are serialised: an append
+        either lands before the re-read (and is preserved) or blocks until
+        the replace completes (and lands in the new file).  The re-read also:
+        - Preserves malformed JSONL lines rather than silently dropping them.
+        - Picks up records appended between the caller's ``load_all()`` and
+          this call.  Callers that *mutate* loaded records should hold
+          ``lock()`` around their whole load → mutate → rewrite cycle to
+          avoid clobbering a concurrent writer's field updates with a stale
+          in-memory copy.
+
+        The temp file is per-pid and fsynced before the atomic replace: a
+        fixed shared temp name would let two concurrent rewriters interleave
+        writes on the same inode and install a torn file (the mechanism
+        behind truncated mid-file records observed 2026-07-14).
 
         ``records`` takes precedence for any session_id present in both.
         """
-        self.sessions_dir.mkdir(parents=True, exist_ok=True)
+        with self.lock():
+            known_ids = {r.session_id for r in records}
+            extra_records: list[SessionRecord] = []
+            malformed_lines: list[str] = []
 
-        known_ids = {r.session_id for r in records}
-        extra_records: list[SessionRecord] = []
-        malformed_lines: list[str] = []
+            if self.path.exists():
+                with open(self.path, encoding="utf-8") as f:
+                    for raw in f:
+                        raw = raw.strip()
+                        if not raw:
+                            continue
+                        try:
+                            rec = SessionRecord.from_dict(json.loads(raw))
+                            if rec.session_id not in known_ids:
+                                extra_records.append(rec)
+                        except (json.JSONDecodeError, TypeError, AttributeError):
+                            malformed_lines.append(raw)
 
-        if self.path.exists():
-            with open(self.path, encoding="utf-8") as f:
-                for raw in f:
-                    raw = raw.strip()
-                    if not raw:
-                        continue
-                    try:
-                        rec = SessionRecord.from_dict(json.loads(raw))
-                        if rec.session_id not in known_ids:
-                            extra_records.append(rec)
-                    except (json.JSONDecodeError, TypeError, AttributeError):
-                        malformed_lines.append(raw)
-
-        tmp_path = self.path.with_name(self.path.name + ".tmp")
-        with open(tmp_path, "w", encoding="utf-8") as f:
-            for record in records:
-                f.write(record.to_json() + "\n")
-            for record in extra_records:
-                f.write(record.to_json() + "\n")
-            for line in malformed_lines:
-                f.write(line + "\n")
-        tmp_path.replace(self.path)
+            tmp_path = self.path.with_name(f"{self.path.name}.tmp.{os.getpid()}")
+            try:
+                with open(tmp_path, "w", encoding="utf-8") as f:
+                    for record in records:
+                        f.write(record.to_json() + "\n")
+                    for record in extra_records:
+                        f.write(record.to_json() + "\n")
+                    for line in malformed_lines:
+                        f.write(line + "\n")
+                    f.flush()
+                    os.fsync(f.fileno())
+                tmp_path.replace(self.path)
+            except BaseException:
+                tmp_path.unlink(missing_ok=True)
+                raise
         return self.path
 
     def query(

--- a/packages/gptme-sessions/tests/test_store_locking.py
+++ b/packages/gptme-sessions/tests/test_store_locking.py
@@ -180,7 +180,9 @@ def test_rewrite_temp_file_is_per_pid(tmp_path: Path, monkeypatch):
 
     assert len(captured) == 1
     tmp_used = captured[0]
-    assert tmp_used.name == f"{store.path.name}.tmp.{os.getpid()}"
+    # Unique per call: pid + random suffix (pid alone can collide when two
+    # threads share one instance and race the reentrancy counter).
+    assert tmp_used.name.startswith(f"{store.path.name}.tmp.{os.getpid()}.")
 
 
 class _ExplodingRecord(SessionRecord):

--- a/packages/gptme-sessions/tests/test_store_locking.py
+++ b/packages/gptme-sessions/tests/test_store_locking.py
@@ -1,0 +1,289 @@
+"""Tests for SessionStore cross-process locking.
+
+Regression coverage for the 2026-07-14 production incident: concurrent
+writers to session-records.jsonl (via a shared fixed temp-file name and no
+mutual exclusion) produced torn/truncated JSON records. ``SessionStore``
+now takes an ``fcntl.flock`` on a permanent sentinel file for every
+``append()``/``rewrite()``, and ``rewrite()`` writes to a per-pid temp file
+before an atomic ``replace()``.
+"""
+
+from __future__ import annotations
+
+import json
+import multiprocessing
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from gptme_sessions import SessionRecord, SessionStore
+
+try:
+    import fcntl  # noqa: F401
+
+    HAS_FCNTL = True
+except ImportError:  # pragma: no cover - non-POSIX platforms
+    HAS_FCNTL = False
+
+# Prefer "fork". This package's workspace pytest config sets
+# ``--import-mode=importlib`` (needed for cross-package test collection),
+# which gives test modules a synthetic dotted name that isn't reachable via
+# a plain ``import`` in a freshly spawned interpreter — so multiprocessing's
+# "spawn" start method fails to re-import the worker functions in the child
+# (``ModuleNotFoundError: No module named 'packages'``). "fork" duplicates
+# the already-imported parent process instead of re-importing, sidestepping
+# that entirely. Fall back to "spawn" on platforms without fork (e.g. Windows);
+# the fork-dependent tests there would need a different fix, but the module
+# must still be importable.
+MP_CTX = multiprocessing.get_context(
+    "fork" if "fork" in multiprocessing.get_all_start_methods() else "spawn"
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Reentrancy — nested lock() must not self-deadlock
+# ---------------------------------------------------------------------------
+
+
+def _reentrant_worker(sessions_dir: str, result_queue: "multiprocessing.Queue") -> None:
+    """Nest store.lock() twice and mutate the store at both levels.
+
+    Runs in a child process so a self-deadlock regression hangs the child
+    rather than the test process, and can be caught with ``join(timeout=...)``.
+    """
+    try:
+        store = SessionStore(sessions_dir=Path(sessions_dir))
+        with store.lock():
+            store.append(SessionRecord(session_id="outer-1", model="outer"))
+            store.rewrite(store.load_all())
+            with store.lock():
+                store.append(SessionRecord(session_id="inner-1", model="inner"))
+                store.rewrite(store.load_all())
+            store.append(SessionRecord(session_id="outer-2", model="outer"))
+        result_queue.put("ok")
+    except BaseException as e:  # pragma: no cover - only hit on regression
+        result_queue.put(f"error: {e!r}")
+
+
+def test_lock_is_reentrant_no_self_deadlock(tmp_path: Path):
+    """Nested store.lock() calls within one process must complete, not hang."""
+    result_queue = MP_CTX.Queue()
+    proc = MP_CTX.Process(target=_reentrant_worker, args=(str(tmp_path), result_queue), daemon=True)
+    proc.start()
+    proc.join(timeout=20)
+
+    if proc.is_alive():
+        proc.terminate()
+        proc.join(timeout=5)
+        pytest.fail("nested store.lock() hung — self-deadlock regression")
+
+    assert proc.exitcode == 0
+    assert not result_queue.empty()
+    assert result_queue.get(timeout=5) == "ok"
+
+
+# ---------------------------------------------------------------------------
+# 2. Cross-process mutual exclusion — no torn writes under concurrent load
+# ---------------------------------------------------------------------------
+
+ITERATIONS = 30
+N_APPENDERS = 3
+N_REWRITERS = 3
+
+
+def _append_worker(sessions_dir: str, worker_id: int, iterations: int) -> None:
+    store = SessionStore(sessions_dir=Path(sessions_dir))
+    for i in range(iterations):
+        store.append(SessionRecord(session_id=f"append-{worker_id}-{i}", model="appender"))
+
+
+def _rewrite_worker(sessions_dir: str, worker_id: int, iterations: int) -> None:
+    store = SessionStore(sessions_dir=Path(sessions_dir))
+    for _ in range(iterations):
+        with store.lock():
+            records = store.load_all()
+            store.rewrite(records)
+
+
+def test_concurrent_append_and_rewrite_no_torn_writes(tmp_path: Path):
+    """Hammer one store from multiple processes; assert no corruption.
+
+    Regression test for the 2026-07-14 corruption: half the workers append
+    unique records, half do load-modify-rewrite cycles, all against the same
+    file concurrently. Afterward every line must still parse as JSON, every
+    appended record must be present, and no temp-file litter may remain.
+    """
+    store = SessionStore(sessions_dir=tmp_path)
+
+    procs = [
+        MP_CTX.Process(target=_append_worker, args=(str(tmp_path), wid, ITERATIONS))
+        for wid in range(N_APPENDERS)
+    ] + [
+        MP_CTX.Process(target=_rewrite_worker, args=(str(tmp_path), wid, ITERATIONS))
+        for wid in range(N_REWRITERS)
+    ]
+
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=30)
+
+    for i, p in enumerate(procs):
+        assert not p.is_alive(), f"worker {i} did not finish within timeout"
+        assert p.exitcode == 0, f"worker {i} failed (exitcode={p.exitcode})"
+
+    # (a) every line parses as JSON — no torn/truncated records.
+    content = store.path.read_text(encoding="utf-8")
+    lines = [line for line in content.splitlines() if line.strip()]
+    assert lines, "expected records to have been written"
+    parsed = [json.loads(line) for line in lines]  # raises ValueError if any line is torn
+
+    # (b) every appended unique session_id survived (no lost appends).
+    expected_ids = {f"append-{wid}-{i}" for wid in range(N_APPENDERS) for i in range(ITERATIONS)}
+    seen_ids = {rec["session_id"] for rec in parsed}
+    missing = expected_ids - seen_ids
+    assert not missing, f"lost {len(missing)} appended records, e.g. {sorted(missing)[:5]}"
+
+    # (c) no leftover *.tmp* files from interrupted rewrites.
+    leftover_tmp = list(tmp_path.glob("*.tmp*"))
+    assert not leftover_tmp, f"leftover temp files: {leftover_tmp}"
+
+
+# ---------------------------------------------------------------------------
+# 3. Temp file is per-pid and cleaned up on failure
+# ---------------------------------------------------------------------------
+
+
+def test_rewrite_temp_file_is_per_pid(tmp_path: Path, monkeypatch):
+    """rewrite()'s temp file name must embed the current pid (not a fixed name).
+
+    A fixed shared temp name is exactly the mechanism behind the 2026-07-14
+    torn-file corruption: two concurrent rewriters could interleave writes to
+    the same inode. Spy on Path.replace (the atomic-install call) to capture
+    the temp path actually used.
+    """
+    store = SessionStore(sessions_dir=tmp_path)
+    store.append(SessionRecord(session_id="a", model="x"))
+
+    captured: list[Path] = []
+    original_replace = Path.replace
+
+    def spy_replace(self: Path, target):
+        captured.append(self)
+        return original_replace(self, target)
+
+    monkeypatch.setattr(Path, "replace", spy_replace)
+
+    store.rewrite(store.load_all())
+
+    assert len(captured) == 1
+    tmp_used = captured[0]
+    assert tmp_used.name == f"{store.path.name}.tmp.{os.getpid()}"
+
+
+class _ExplodingRecord(SessionRecord):
+    """A record whose serialization always fails, to exercise rewrite()'s
+    exception-cleanup path."""
+
+    def to_json(self) -> str:  # type: ignore[override]
+        raise RuntimeError("boom - injected to_json failure")
+
+
+def test_rewrite_propagates_failure_and_cleans_temp_file(tmp_path: Path):
+    """A failure mid-write must propagate, leave the store file untouched,
+    and not leak a temp file."""
+    store = SessionStore(sessions_dir=tmp_path)
+    store.append(SessionRecord(session_id="baseline", model="opus"))
+    original_content = store.path.read_text(encoding="utf-8")
+
+    exploding = _ExplodingRecord(session_id="boom")
+    with pytest.raises(RuntimeError, match="boom"):
+        store.rewrite([exploding])
+
+    # Store file must be exactly as it was before the failed rewrite.
+    assert store.path.read_text(encoding="utf-8") == original_content
+
+    # No temp file left behind.
+    leftovers = list(tmp_path.glob(f"{store.sessions_file}.tmp*"))
+    assert not leftovers, f"leftover temp files: {leftovers}"
+
+    # Lock must have been released despite the exception — a subsequent
+    # operation must not deadlock or hang.
+    store.append(SessionRecord(session_id="after", model="opus"))
+    records = store.load_all()
+    assert {r.session_id for r in records} == {"baseline", "after"}
+
+
+# ---------------------------------------------------------------------------
+# 4. Lock sentinel semantics — permanent, composes across instances
+# ---------------------------------------------------------------------------
+
+
+def test_lock_sentinel_permanent_and_composes_across_instances(tmp_path: Path):
+    """The <file>.lock sentinel appears after use and is never deleted; two
+    separate SessionStore instances on the same path can both mutate it."""
+    store1 = SessionStore(sessions_dir=tmp_path)
+    store1.append(SessionRecord(session_id="a", model="one"))
+
+    lock_path = store1.path.with_name(store1.path.name + ".lock")
+    assert lock_path.exists()
+
+    # A second, independent instance on the same path must be able to
+    # append and rewrite without issue (locks compose across instances,
+    # not just within one).
+    store2 = SessionStore(sessions_dir=tmp_path)
+    store2.append(SessionRecord(session_id="b", model="two"))
+    store2.rewrite(store2.load_all())
+
+    assert lock_path.exists()  # sentinel is permanent — never unlinked
+    records = store1.load_all()
+    assert {r.session_id for r in records} == {"a", "b"}
+
+
+# ---------------------------------------------------------------------------
+# 5. flock actually blocks a second process
+# ---------------------------------------------------------------------------
+
+
+def _blocking_append_worker(sessions_dir: str, done_queue: "multiprocessing.Queue") -> None:
+    store = SessionStore(sessions_dir=Path(sessions_dir))
+    t0 = time.monotonic()
+    store.append(SessionRecord(session_id="child", model="child"))
+    done_queue.put(time.monotonic() - t0)
+
+
+@pytest.mark.skipif(not HAS_FCNTL, reason="flock is POSIX-only")
+def test_flock_blocks_second_process_until_release(tmp_path: Path):
+    """A process holding store.lock() must block a concurrent append() in
+    another process until it releases."""
+    store = SessionStore(sessions_dir=tmp_path)
+    hold_seconds = 2.0
+
+    done_queue = MP_CTX.Queue()
+    child = MP_CTX.Process(
+        target=_blocking_append_worker, args=(str(tmp_path), done_queue), daemon=True
+    )
+
+    with store.lock():
+        child.start()
+        # Hold the lock well past the child's process-startup time so its
+        # append() is guaranteed to be waiting on flock() when we release.
+        time.sleep(hold_seconds)
+
+    child.join(timeout=15)
+    assert not child.is_alive(), "child did not finish after lock release"
+    assert child.exitcode == 0
+    assert not done_queue.empty()
+
+    elapsed = done_queue.get(timeout=5)
+    # Generous margin below hold_seconds to absorb process-spawn overhead
+    # while still clearly distinguishing "blocked" from "raced right in".
+    assert elapsed >= 0.8, (
+        f"child's append() returned in {elapsed:.2f}s — "
+        "lock does not appear to be blocking a concurrent process"
+    )
+
+    records = store.load_all()
+    assert any(r.session_id == "child" for r in records)


### PR DESCRIPTION
## Problem

Concurrent writers to `session-records.jsonl` (the session ledger feeding KPIs, bandit posteriors, and grading) could silently corrupt it. Found while root-causing a real incident (2026-07-14): a June-25 record's bytes, truncated at char 683, re-materialized near the tail of the file *between same-day records*.

Three defects in `SessionStore`:

1. **Fixed shared temp name.** `rewrite()` wrote to `session-records.jsonl.tmp` — a single fixed path. Two concurrent rewriters open the *same inode* with `O_TRUNC` and interleave writes at independent offsets; whoever renames last installs the torn file. This fully explains the incident, including the "old record near the tail" oddity: writer B truncates the temp midway through writer A's full-file write, so A's *mid-file* content (where old records live) survives as fragments near the tail.
2. **No locking on `append()`/`rewrite()`.** An append landing between a rewriter's re-read and its rename was silently lost — a race `rewrite()`'s own docstring documented as a known gap ("future improvement").
3. **No fsync before rename** in `rewrite()` — a crash could install a short file (`append()` was already careful about this).

## Fix

- **`SessionStore.lock()`**: reentrant cross-process `flock(LOCK_EX)` on the permanent `.lock` sentinel (the same one `annotate` already used, so existing waiters compose). `append()` and `rewrite()` acquire it internally; callers doing read-modify-write cycles can hold it across the whole cycle.
- **`rewrite()`**: per-pid temp file, fsync before the atomic replace, temp unlinked on failure.
- **`annotate`**: refactored onto `store.lock()`. This is *required*, not cosmetic — flock treats separate fds in one process as independent owners, so annotate's old manual flock would self-deadlock against the now-locking `rewrite()` it calls.

Reentrancy is per-`SessionStore`-instance (depth counter); the store remains single-threaded-CLI-oriented. On non-POSIX platforms locking degrades to a no-op (same policy as the old annotate code).

## Tests

New `test_store_locking.py` (6 tests, ~2.4s):
- reentrancy without self-deadlock (deadlock-guarded via child process + join timeout)
- 6-process append/rewrite hammer: every line parses, no lost appends, no temp litter — the regression test for the incident
- per-pid temp naming; cleanup + store-file-unchanged on injected write failure
- lock sentinel persistence + multi-instance composition
- cross-process flock blocking (timed)

Full package suite: **1022 passed**, no regressions. `prek` hooks green (ruff, ruff-format, package typecheck).

## Known trade-offs / follow-ups (deliberately out of scope)

- **Slow CLI read-modify-write paths** (`tag`/`categorize`, `dedup`, `judge --update-store`) still don't hold the lock across their whole load→mutate→rewrite cycle: they do slow trajectory scanning between load and rewrite, and holding flock across that would block every post-session `append()` for the duration. With `rewrite()` internally locked they can no longer corrupt or lose records; the residual risk is field-level clobber of a concurrent update (much less severe). Wrapping them with a narrower re-load-under-lock pattern is a sensible follow-up.
- A process SIGKILLed mid-`rewrite()` can leave a stale `.tmp.<pid>` file. Harmless litter (never renamed by anyone else); not worth a sweep yet.