### PR TITLE
fix(twitter): quarantine permanently undeliverable replies

### DIFF
--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -657,8 +657,19 @@ def move_draft(path: Path, new_status: str) -> Path:
     if new_status not in status_dirs:
         raise ValueError(f"Invalid status: {new_status}")
 
-    # Simply move the file to the new directory, preserving the filename
+    # Preserve the filename when possible, but never overwrite an older draft.
+    # Repeated failures can legitimately produce the same generated filename.
     new_path = status_dirs[new_status] / path.name
+    if new_path.exists() and new_path != path:
+        counter = 2
+        while True:
+            candidate = new_path.with_name(
+                f"{new_path.stem}-{counter}{new_path.suffix}"
+            )
+            if not candidate.exists():
+                new_path = candidate
+                break
+            counter += 1
 
     # Load and save to ensure any updates are persisted
     draft = TweetDraft.load(path)
@@ -676,6 +687,17 @@ _PERMANENT_REPLY_FAILURE_MARKERS = (
 )
 
 
+def _permanent_reply_failure_reason(draft: TweetDraft, error: Exception) -> str | None:
+    """Return a rejection reason for a non-retryable Twitter reply error."""
+    if not draft.in_reply_to:
+        return None
+
+    message = str(error).lower()
+    if not any(marker in message for marker in _PERMANENT_REPLY_FAILURE_MARKERS):
+        return None
+    return f"Permanent Twitter reply failure: {str(error)}"
+
+
 def _quarantine_permanent_reply_failure(
     path: Path, draft: TweetDraft, error: Exception
 ) -> bool:
@@ -686,14 +708,11 @@ def _quarantine_permanent_reply_failure(
     Retrying that response every cycle only burns API calls and leaves the
     approved queue permanently wedged.
     """
-    if not draft.in_reply_to:
+    reject_reason = _permanent_reply_failure_reason(draft, error)
+    if reject_reason is None:
         return False
 
-    message = str(error).lower()
-    if not any(marker in message for marker in _PERMANENT_REPLY_FAILURE_MARKERS):
-        return False
-
-    draft.reject_reason = f"Permanent Twitter reply failure: {str(error)}"
+    draft.reject_reason = reject_reason
     draft.save(path)
     rejected_path = move_draft(path, "rejected")
     console.print(
@@ -1873,12 +1892,20 @@ def process_timeline_tweets(
                                     _replied_tweet_ids.add(str(draft.in_reply_to))
                         except Exception as e:
                             console.print(f"[red]Error auto-posting: {e}")
-                            # Fall back to saving as new
-                            path = save_draft(draft, "new")
-                            console.print(
-                                f"[yellow]Saved as draft for manual review: {path}"
-                            )
-                            drafts_generated += 1
+                            reject_reason = _permanent_reply_failure_reason(draft, e)
+                            if reject_reason is not None:
+                                draft.reject_reason = reject_reason
+                                path = save_draft(draft, "rejected")
+                                console.print(
+                                    f"[yellow]Saved permanently undeliverable reply to {path}[/yellow]"
+                                )
+                            else:
+                                # Transient errors stay retryable via manual review.
+                                path = save_draft(draft, "new")
+                                console.print(
+                                    f"[yellow]Saved as draft for manual review: {path}"
+                                )
+                                drafts_generated += 1
                             if draft.in_reply_to is not None:
                                 _replied_tweet_ids.add(str(draft.in_reply_to))
                     else:

--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -670,6 +670,38 @@ def move_draft(path: Path, new_status: str) -> Path:
     return new_path
 
 
+_PERMANENT_REPLY_FAILURE_MARKERS = (
+    "reply to this conversation is not allowed because you have not been mentioned",
+    "you have not been mentioned or otherwise engaged by the author",
+)
+
+
+def _quarantine_permanent_reply_failure(
+    path: Path, draft: TweetDraft, error: Exception
+) -> bool:
+    """Reject an approved reply that Twitter says can never be delivered.
+
+    Twitter can report ``reply_settings=everyone`` while still rejecting an
+    unsolicited reply because the author has not engaged with this account.
+    Retrying that response every cycle only burns API calls and leaves the
+    approved queue permanently wedged.
+    """
+    if not draft.in_reply_to:
+        return False
+
+    message = str(error).lower()
+    if not any(marker in message for marker in _PERMANENT_REPLY_FAILURE_MARKERS):
+        return False
+
+    draft.reject_reason = f"Permanent Twitter reply failure: {str(error)}"
+    draft.save(path)
+    rejected_path = move_draft(path, "rejected")
+    console.print(
+        f"[yellow]Moved permanently undeliverable reply to {rejected_path}[/yellow]"
+    )
+    return True
+
+
 def find_draft(
     draft_id: str, status: str | None = None, show_error: bool = True
 ) -> Path | None:
@@ -1455,6 +1487,7 @@ def post(
                     console.print("[red]Error: No response data from tweet creation")
             except Exception as e:
                 console.print(f"[red]Error posting tweet: {e}")
+                _quarantine_permanent_reply_failure(path, draft, e)
         else:
             console.print("[yellow]Skipped posting tweet")
 
@@ -2371,6 +2404,7 @@ def auto(
                         )
                 except Exception as e:
                     console.print(f"[red]Error posting tweet: {e}")
+                    _quarantine_permanent_reply_failure(path, draft, e)
 
     # Summary
     console.print("\n[bold]Automation Cycle Summary:[/bold]")

--- a/tests/test_twitter_workflow_drafts.py
+++ b/tests/test_twitter_workflow_drafts.py
@@ -447,6 +447,102 @@ def test_trusted_user_autopost_with_bad_url_saves_draft_instead_of_posting(
     ]
 
 
+def test_quarantine_permanent_reply_failure_moves_draft_to_rejected(
+    workflow_module: Any, tmp_path: Path
+) -> None:
+    _set_status_dirs(workflow_module, tmp_path)
+    approved_path = workflow_module.APPROVED_DIR / "reply.yml"
+    draft = workflow_module.TweetDraft(
+        text="A useful reply",
+        type="reply",
+        in_reply_to="4242",
+    )
+    draft.save(approved_path)
+
+    moved = workflow_module._quarantine_permanent_reply_failure(
+        approved_path,
+        draft,
+        RuntimeError(
+            "403 Forbidden: Reply to this conversation is not allowed because "
+            "you have not been mentioned or otherwise engaged by the author of the post"
+        ),
+    )
+
+    rejected_path = workflow_module.REJECTED_DIR / approved_path.name
+    assert moved is True
+    assert not approved_path.exists()
+    assert rejected_path.exists()
+    assert (
+        "Permanent Twitter reply failure"
+        in workflow_module.TweetDraft.load(rejected_path).reject_reason
+    )
+
+
+def test_post_quarantines_permanently_undeliverable_approved_reply(
+    workflow_module: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_status_dirs(workflow_module, tmp_path)
+    approved_path = workflow_module.APPROVED_DIR / "reply.yml"
+    workflow_module.TweetDraft(
+        text="A useful reply",
+        type="reply",
+        in_reply_to="4242",
+    ).save(approved_path)
+
+    class PostingClient:
+        def create_tweet(self, *args: Any, **kwargs: Any) -> Any:
+            raise RuntimeError(
+                "403 Forbidden: Reply to this conversation is not allowed because "
+                "you have not been mentioned or otherwise engaged by the author"
+            )
+
+    monkeypatch.setattr(
+        workflow_module, "load_twitter_client", lambda *a, **k: PostingClient()
+    )
+    monkeypatch.setattr(
+        workflow_module, "_check_for_duplicate_replies_internal", lambda draft: {}
+    )
+    monkeypatch.setattr(
+        workflow_module, "_find_live_duplicate_reply_ids", lambda *a, **k: []
+    )
+    monkeypatch.setattr(workflow_module, "_validate_draft_urls", lambda draft: [])
+    monkeypatch.setattr(workflow_module, "_validate_draft_length", lambda draft: [])
+
+    workflow_module.post(
+        dry_run=False,
+        yes=True,
+        draft_id=None,
+        max_posts=1,
+        skip_url_check=False,
+    )
+
+    assert not approved_path.exists()
+    assert (workflow_module.REJECTED_DIR / approved_path.name).exists()
+
+
+def test_quarantine_permanent_reply_failure_keeps_transient_failure_approved(
+    workflow_module: Any, tmp_path: Path
+) -> None:
+    _set_status_dirs(workflow_module, tmp_path)
+    approved_path = workflow_module.APPROVED_DIR / "reply.yml"
+    draft = workflow_module.TweetDraft(
+        text="A useful reply",
+        type="reply",
+        in_reply_to="4242",
+    )
+    draft.save(approved_path)
+
+    moved = workflow_module._quarantine_permanent_reply_failure(
+        approved_path,
+        draft,
+        RuntimeError("503 Service Unavailable"),
+    )
+
+    assert moved is False
+    assert approved_path.exists()
+    assert not (workflow_module.REJECTED_DIR / approved_path.name).exists()
+
+
 def test_find_live_duplicate_reply_ids_matches_own_replies(
     workflow_module: Any,
 ) -> None:

--- a/tests/test_twitter_workflow_drafts.py
+++ b/tests/test_twitter_workflow_drafts.py
@@ -478,6 +478,40 @@ def test_quarantine_permanent_reply_failure_moves_draft_to_rejected(
     )
 
 
+def test_quarantine_permanent_reply_failure_preserves_existing_rejection(
+    workflow_module: Any, tmp_path: Path
+) -> None:
+    _set_status_dirs(workflow_module, tmp_path)
+    approved_path = workflow_module.APPROVED_DIR / "reply.yml"
+    existing_rejected_path = workflow_module.REJECTED_DIR / "reply.yml"
+    existing_rejected_path.write_text("text: Older rejected reply\n")
+    draft = workflow_module.TweetDraft(
+        text="New rejected reply",
+        type="reply",
+        in_reply_to="4242",
+    )
+    draft.save(approved_path)
+
+    moved = workflow_module._quarantine_permanent_reply_failure(
+        approved_path,
+        draft,
+        RuntimeError(
+            "403 Forbidden: Reply to this conversation is not allowed because "
+            "you have not been mentioned or otherwise engaged by the author"
+        ),
+    )
+
+    assert moved is True
+    assert existing_rejected_path.read_text() == "text: Older rejected reply\n"
+    rejected_paths = sorted(workflow_module.REJECTED_DIR.glob("reply*.yml"))
+    assert len(rejected_paths) == 2
+    assert any(
+        workflow_module.TweetDraft.load(path).text == "New rejected reply"
+        for path in rejected_paths
+        if path != existing_rejected_path
+    )
+
+
 def test_post_quarantines_permanently_undeliverable_approved_reply(
     workflow_module: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -541,6 +575,177 @@ def test_quarantine_permanent_reply_failure_keeps_transient_failure_approved(
     assert moved is False
     assert approved_path.exists()
     assert not (workflow_module.REJECTED_DIR / approved_path.name).exists()
+
+
+def test_trusted_user_autopost_quarantines_permanent_reply_failure(
+    workflow_module: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_status_dirs(workflow_module, tmp_path)
+
+    @dataclass
+    class EvalResult:
+        action: str
+        relevance: int
+        priority: int
+
+    @dataclass
+    class Response:
+        text: str
+        type: str
+        thread_needed: bool
+        follow_up: str | None
+
+    tweet = SimpleNamespace(
+        id="4242",
+        author_id="7",
+        text="Please respond.",
+        created_at=datetime.now(timezone.utc),
+        public_metrics={},
+        conversation_id=None,
+    )
+    user = SimpleNamespace(
+        id="7",
+        username="ErikBjare",
+        public_metrics={"followers_count": 1},
+    )
+
+    class PostingClient:
+        def create_tweet(self, *args: Any, **kwargs: Any) -> Any:
+            raise RuntimeError(
+                "403 Forbidden: Reply to this conversation is not allowed because "
+                "you have not been mentioned or otherwise engaged by the author"
+            )
+
+    monkeypatch.setattr(
+        workflow_module,
+        "cached_get_me",
+        lambda *a, **k: SimpleNamespace(data=SimpleNamespace(id="999")),
+    )
+    monkeypatch.setattr(
+        workflow_module, "should_evaluate_tweet", lambda *a, **k: (True, "")
+    )
+    monkeypatch.setattr(workflow_module, "is_reply_restricted", lambda *a, **k: False)
+    monkeypatch.setattr(workflow_module, "is_tweet_cached", lambda *a, **k: False)
+    monkeypatch.setattr(
+        workflow_module,
+        "process_tweet",
+        lambda *a, **k: (
+            EvalResult("respond", 100, 100),
+            Response("A useful reply", "reply", False, None),
+        ),
+    )
+    monkeypatch.setattr(workflow_module, "save_to_cache", lambda *a, **k: None)
+    monkeypatch.setattr(
+        workflow_module, "is_trusted_user", lambda username: username == "ErikBjare"
+    )
+    monkeypatch.setattr(
+        workflow_module, "_check_for_duplicate_replies_internal", lambda draft: {}
+    )
+    monkeypatch.setattr(workflow_module, "_validate_draft_urls", lambda draft: [])
+    monkeypatch.setattr(
+        workflow_module, "load_twitter_client", lambda *a, **k: PostingClient()
+    )
+
+    drafts_generated = workflow_module.process_timeline_tweets(
+        [tweet],
+        [user],
+        source="mentions",
+        client=object(),
+        times=1,
+        dry_run=False,
+        max_drafts=10,
+    )
+
+    assert drafts_generated == 0
+    assert list(workflow_module.NEW_DIR.glob("*")) == []
+    rejected_paths = list(workflow_module.REJECTED_DIR.glob("*.yml"))
+    assert len(rejected_paths) == 1
+    rejected = workflow_module.TweetDraft.load(rejected_paths[0])
+    assert rejected.text == "A useful reply"
+    assert "Permanent Twitter reply failure" in rejected.reject_reason
+
+
+def test_trusted_user_autopost_keeps_transient_failure_retryable(
+    workflow_module: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_status_dirs(workflow_module, tmp_path)
+
+    @dataclass
+    class EvalResult:
+        action: str
+        relevance: int
+        priority: int
+
+    @dataclass
+    class Response:
+        text: str
+        type: str
+        thread_needed: bool
+        follow_up: str | None
+
+    tweet = SimpleNamespace(
+        id="4242",
+        author_id="7",
+        text="Please respond.",
+        created_at=datetime.now(timezone.utc),
+        public_metrics={},
+        conversation_id=None,
+    )
+    user = SimpleNamespace(
+        id="7",
+        username="ErikBjare",
+        public_metrics={"followers_count": 1},
+    )
+
+    class PostingClient:
+        def create_tweet(self, *args: Any, **kwargs: Any) -> Any:
+            raise RuntimeError("503 Service Unavailable")
+
+    monkeypatch.setattr(
+        workflow_module,
+        "cached_get_me",
+        lambda *a, **k: SimpleNamespace(data=SimpleNamespace(id="999")),
+    )
+    monkeypatch.setattr(
+        workflow_module, "should_evaluate_tweet", lambda *a, **k: (True, "")
+    )
+    monkeypatch.setattr(workflow_module, "is_reply_restricted", lambda *a, **k: False)
+    monkeypatch.setattr(workflow_module, "is_tweet_cached", lambda *a, **k: False)
+    monkeypatch.setattr(
+        workflow_module,
+        "process_tweet",
+        lambda *a, **k: (
+            EvalResult("respond", 100, 100),
+            Response("A useful reply", "reply", False, None),
+        ),
+    )
+    monkeypatch.setattr(workflow_module, "save_to_cache", lambda *a, **k: None)
+    monkeypatch.setattr(
+        workflow_module, "is_trusted_user", lambda username: username == "ErikBjare"
+    )
+    monkeypatch.setattr(
+        workflow_module, "_check_for_duplicate_replies_internal", lambda draft: {}
+    )
+    monkeypatch.setattr(workflow_module, "_validate_draft_urls", lambda draft: [])
+    monkeypatch.setattr(
+        workflow_module, "load_twitter_client", lambda *a, **k: PostingClient()
+    )
+
+    drafts_generated = workflow_module.process_timeline_tweets(
+        [tweet],
+        [user],
+        source="mentions",
+        client=object(),
+        times=1,
+        dry_run=False,
+        max_drafts=10,
+    )
+
+    assert drafts_generated == 1
+    new_paths = list(workflow_module.NEW_DIR.glob("*.yml"))
+    assert len(new_paths) == 1
+    assert workflow_module.TweetDraft.load(new_paths[0]).text == "A useful reply"
+    assert list(workflow_module.REJECTED_DIR.glob("*.yml")) == []
 
 
 def test_find_live_duplicate_reply_ids_matches_own_replies(


### PR DESCRIPTION
## Problem

Twitter can report `reply_settings=everyone` while still rejecting an unsolicited reply with a permanent 403 because the author has not mentioned or engaged the account. The posting loop currently catches that error and leaves the draft in `tweets/approved/`, so every 30-minute cycle retries it forever. I reproduced this against five queued replies today.

## Changes

- recognize the specific permanent reply-eligibility error
- persist the failure as `reject_reason` and move the draft to `tweets/rejected/`
- apply quarantine in the manual approved-posting path, `auto --post-approved`, and immediate trusted-user auto-post path
- keep transient failures such as 503s retryable
- preserve older rejected artifacts when destination filenames collide

## Verification

- `uv run pytest tests/test_twitter_workflow_drafts.py -q` — 33 passed
- `prek run --files scripts/twitter/workflow.py tests/test_twitter_workflow_drafts.py` — passed
- reproduction: five approved replies returned the exact permanent 403 and were manually quarantined locally
- both Greptile findings addressed in `0fcb26fb`; review threads resolved