### PR TITLE
fix(activity-summary): preserve Claude failure diagnostics

### DIFF
--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -10,6 +10,7 @@ import logging
 import re
 import subprocess
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -20,7 +21,12 @@ _MAX_RETRIES = 3
 _RETRY_DELAY_S = 5
 
 
-def call_claude_code(prompt: str, timeout: int = 120, max_retries: int = _MAX_RETRIES) -> str:
+def call_claude_code(
+    prompt: str,
+    timeout: int = 120,
+    max_retries: int = _MAX_RETRIES,
+    diagnostic_dir: Path | None = None,
+) -> str:
     """
     Call Claude Code CLI with a prompt, retrying on non-zero exit or empty responses.
 
@@ -32,6 +38,8 @@ def call_claude_code(prompt: str, timeout: int = 120, max_retries: int = _MAX_RE
         prompt: The prompt to send to Claude Code
         timeout: Maximum time to wait for response (seconds)
         max_retries: Maximum number of retry attempts per failure type
+        diagnostic_dir: Directory for Claude debug logs. Defaults to a stable
+            temporary directory so scheduled failures retain diagnostics.
 
     Returns:
         The response text from Claude Code
@@ -66,9 +74,16 @@ def call_claude_code(prompt: str, timeout: int = 120, max_retries: int = _MAX_RE
     if nested:
         cmd.append("--no-session-persistence")
 
+    if diagnostic_dir is None:
+        diagnostic_dir = Path.home() / ".local" / "state" / "gptme-activity-summary"
+    diagnostic_dir.mkdir(parents=True, exist_ok=True)
+    invocation_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
+
     for attempt in range(1, max_retries + 1):
+        debug_file = diagnostic_dir / f"claude-{invocation_id}-attempt-{attempt}.log"
+        attempt_cmd = [*cmd, "--debug-file", str(debug_file)]
         result = subprocess.run(
-            cmd,
+            attempt_cmd,
             input=prompt,
             capture_output=True,
             text=True,
@@ -77,12 +92,15 @@ def call_claude_code(prompt: str, timeout: int = 120, max_retries: int = _MAX_RE
         )
         if result.returncode != 0:
             stderr_preview = result.stderr.strip()[:500] if result.stderr else "(none)"
+            stdout_preview = result.stdout.strip()[:500] if result.stdout else "(none)"
             logger.warning(
-                "claude -p exited %d (attempt %d/%d). stderr: %s",
+                "claude -p exited %d (attempt %d/%d). stderr: %s; stdout: %s; debug_file: %s",
                 result.returncode,
                 attempt,
                 max_retries,
                 stderr_preview,
+                stdout_preview,
+                debug_file,
             )
             if attempt < max_retries:
                 # Retry all non-zero codes without discrimination. This addresses transient
@@ -92,7 +110,7 @@ def call_claude_code(prompt: str, timeout: int = 120, max_retries: int = _MAX_RE
                 time.sleep(_RETRY_DELAY_S * attempt)  # linear backoff
                 continue
             raise subprocess.CalledProcessError(
-                result.returncode, ["claude", "-p"], result.stdout, result.stderr
+                result.returncode, attempt_cmd, result.stdout, result.stderr
             )
 
         output = result.stdout.strip()

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -76,12 +76,27 @@ def call_claude_code(
 
     if diagnostic_dir is None:
         diagnostic_dir = Path.home() / ".local" / "state" / "gptme-activity-summary"
-    diagnostic_dir.mkdir(parents=True, exist_ok=True)
     invocation_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
 
     for attempt in range(1, max_retries + 1):
-        debug_file = diagnostic_dir / f"claude-{invocation_id}-attempt-{attempt}.log"
-        attempt_cmd = [*cmd, "--debug-file", str(debug_file)]
+        debug_file: Path | None = None
+        attempt_cmd = list(cmd)
+        # Keep the healthy path compatible with Claude versions that predate
+        # --debug-file. Enable tracing only after an actual failure triggered a
+        # retry, and make diagnostics best-effort so they cannot block Claude.
+        if attempt > 1 and diagnostic_dir is not None:
+            try:
+                diagnostic_dir.mkdir(parents=True, exist_ok=True)
+            except OSError as exc:
+                logger.debug(
+                    "Cannot create diagnostic dir %s (%s); debug file disabled",
+                    diagnostic_dir,
+                    exc,
+                )
+                diagnostic_dir = None
+            else:
+                debug_file = diagnostic_dir / f"claude-{invocation_id}-attempt-{attempt}.log"
+                attempt_cmd.extend(["--debug-file", str(debug_file)])
         result = subprocess.run(
             attempt_cmd,
             input=prompt,

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -75,7 +75,10 @@ def call_claude_code(
         cmd.append("--no-session-persistence")
 
     if diagnostic_dir is None:
-        diagnostic_dir = Path.home() / ".local" / "state" / "gptme-activity-summary"
+        try:
+            diagnostic_dir = Path.home() / ".local" / "state" / "gptme-activity-summary"
+        except RuntimeError as exc:
+            logger.debug("Cannot resolve home directory (%s); debug file disabled", exc)
     invocation_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
     attempt = 1
     plain_retry_pending = False

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -95,6 +95,15 @@ def call_claude_code(
                 )
                 diagnostic_dir = None
             else:
+                # Prune files older than 7 days on first retry to cap disk growth
+                if attempt == 2:
+                    cutoff = time.time() - 7 * 86400
+                    for old_log in diagnostic_dir.glob("claude-*.log"):
+                        try:
+                            if old_log.stat().st_mtime < cutoff:
+                                old_log.unlink(missing_ok=True)
+                        except OSError:
+                            pass
                 debug_file = diagnostic_dir / f"claude-{invocation_id}-attempt-{attempt}.log"
                 attempt_cmd.extend(["--debug-file", str(debug_file)])
         result = subprocess.run(

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -115,6 +115,16 @@ def call_claude_code(
             env=env,
         )
         if result.returncode != 0:
+            # If --debug-file is not supported by this claude build, the flag itself
+            # can turn a recoverable transient failure into a permanent one. Detect
+            # by looking for the flag name in error output and disable for future retries.
+            if debug_file is not None:
+                combined_out = (result.stderr or "") + (result.stdout or "")
+                if "debug-file" in combined_out.lower():
+                    logger.debug(
+                        "--debug-file appears unsupported; disabling diagnostics for remaining retries"
+                    )
+                    diagnostic_dir = None
             stderr_preview = result.stderr.strip()[:500] if result.stderr else "(none)"
             stdout_preview = result.stdout.strip()[:500] if result.stdout else "(none)"
             logger.warning(

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -77,8 +77,10 @@ def call_claude_code(
     if diagnostic_dir is None:
         diagnostic_dir = Path.home() / ".local" / "state" / "gptme-activity-summary"
     invocation_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
+    attempt = 1
+    plain_retry_pending = False
 
-    for attempt in range(1, max_retries + 1):
+    while attempt <= max_retries or plain_retry_pending:
         debug_file: Path | None = None
         attempt_cmd = list(cmd)
         # Keep the healthy path compatible with Claude versions that predate
@@ -121,10 +123,9 @@ def call_claude_code(
             if debug_file is not None:
                 combined_out = (result.stderr or "") + (result.stdout or "")
                 if "debug-file" in combined_out.lower():
-                    logger.debug(
-                        "--debug-file appears unsupported; disabling diagnostics for remaining retries"
-                    )
+                    logger.debug("--debug-file appears unsupported; retrying without diagnostics")
                     diagnostic_dir = None
+                    plain_retry_pending = True
             stderr_preview = result.stderr.strip()[:500] if result.stderr else "(none)"
             stdout_preview = result.stdout.strip()[:500] if result.stdout else "(none)"
             logger.warning(
@@ -136,12 +137,16 @@ def call_claude_code(
                 stdout_preview,
                 debug_file,
             )
-            if attempt < max_retries:
+            if attempt < max_retries or plain_retry_pending:
                 # Retry all non-zero codes without discrimination. This addresses transient
                 # CC service failures (rate limits, temporary unavailability). Permanent errors
                 # (e.g., command-not-found, auth failure) will exhaust the retry window and
                 # then raise, which is acceptable since they're rare in normal operation.
                 time.sleep(_RETRY_DELAY_S * attempt)  # linear backoff
+                if plain_retry_pending:
+                    plain_retry_pending = False
+                else:
+                    attempt += 1
                 continue
             raise subprocess.CalledProcessError(
                 result.returncode, attempt_cmd, result.stdout, result.stderr
@@ -161,6 +166,9 @@ def call_claude_code(
 
         if attempt < max_retries:
             time.sleep(_RETRY_DELAY_S * attempt)  # linear backoff
+            attempt += 1
+        else:
+            break
 
     # All retries exhausted — return empty string (callers handle gracefully)
     logger.error(

--- a/packages/gptme-activity-summary/tests/test_cc_backend.py
+++ b/packages/gptme-activity-summary/tests/test_cc_backend.py
@@ -235,6 +235,24 @@ def test_call_claude_code_nonzero_logs_stdout_and_debug_file(
 
 @patch("gptme_activity_summary.cc_backend.time.sleep")
 @patch("subprocess.run")
+def test_call_claude_code_unsupported_debug_file_retries_plain(mock_run, mock_sleep, tmp_path):
+    """An unsupported diagnostic flag must not consume the last plain retry."""
+    mock_run.side_effect = [
+        _make_completed_process(returncode=1, stderr="transient API failure"),
+        _make_completed_process(returncode=1, stderr="unknown option --debug-file"),
+        _make_completed_process(stdout='{"ok": true}'),
+    ]
+
+    result = call_claude_code("test prompt", max_retries=2, diagnostic_dir=tmp_path)
+
+    assert result == '{"ok": true}'
+    assert mock_run.call_count == 3
+    assert "--debug-file" in mock_run.call_args_list[1].args[0]
+    assert "--debug-file" not in mock_run.call_args_list[2].args[0]
+
+
+@patch("gptme_activity_summary.cc_backend.time.sleep")
+@patch("subprocess.run")
 def test_call_claude_code_diagnostic_dir_mkdir_failure_still_retries(mock_run, mock_sleep):
     """Diagnostic dir mkdir failure must not block a Claude retry."""
     from pathlib import Path

--- a/packages/gptme-activity-summary/tests/test_cc_backend.py
+++ b/packages/gptme-activity-summary/tests/test_cc_backend.py
@@ -253,6 +253,21 @@ def test_call_claude_code_unsupported_debug_file_retries_plain(mock_run, mock_sl
 
 @patch("gptme_activity_summary.cc_backend.time.sleep")
 @patch("subprocess.run")
+def test_call_claude_code_home_resolution_failure_still_calls_claude(mock_run, mock_sleep):
+    """Missing home-directory metadata must not block Claude invocation."""
+    from unittest.mock import patch
+
+    mock_run.return_value = _make_completed_process(stdout='{"ok": true}')
+
+    with patch("gptme_activity_summary.cc_backend.Path.home", side_effect=RuntimeError("no home")):
+        result = call_claude_code("test prompt")
+
+    assert result == '{"ok": true}'
+    assert "--debug-file" not in mock_run.call_args.args[0]
+
+
+@patch("gptme_activity_summary.cc_backend.time.sleep")
+@patch("subprocess.run")
 def test_call_claude_code_diagnostic_dir_mkdir_failure_still_retries(mock_run, mock_sleep):
     """Diagnostic dir mkdir failure must not block a Claude retry."""
     from pathlib import Path

--- a/packages/gptme-activity-summary/tests/test_cc_backend.py
+++ b/packages/gptme-activity-summary/tests/test_cc_backend.py
@@ -1,6 +1,7 @@
 """Tests for cc_backend module."""
 
 import subprocess
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 from gptme_activity_summary.cc_backend import (
@@ -194,6 +195,40 @@ def test_call_claude_code_nonzero_logs_stderr(mock_run, mock_sleep, caplog):
         except subprocess.CalledProcessError:
             pass
     assert any("quota exhausted" in msg for msg in caplog.messages)
+
+
+@patch("gptme_activity_summary.cc_backend.datetime")
+@patch("gptme_activity_summary.cc_backend.time.sleep")
+@patch("subprocess.run")
+def test_call_claude_code_nonzero_logs_stdout_and_debug_file(
+    mock_run, mock_sleep, mock_datetime, caplog, tmp_path
+):
+    """Test failures preserve stdout and point operators at Claude's debug log."""
+    import logging
+
+    mock_datetime.now.return_value = datetime(2026, 7, 15, 1, 2, 3, tzinfo=timezone.utc)
+    debug_file = tmp_path / "claude-20260715T010203.000000Z-attempt-1.log"
+    mock_run.return_value = _make_completed_process(
+        returncode=1,
+        stdout="Your session quota is exhausted",
+    )
+    with caplog.at_level(logging.WARNING):
+        try:
+            call_claude_code(
+                "test prompt",
+                max_retries=1,
+                diagnostic_dir=tmp_path,
+            )
+        except subprocess.CalledProcessError as error:
+            assert error.output == "Your session quota is exhausted"
+        else:
+            assert False, "Should have raised CalledProcessError"
+
+    log_text = "\n".join(caplog.messages)
+    assert "stdout: Your session quota is exhausted" in log_text
+    assert f"debug_file: {debug_file}" in log_text
+    cmd = mock_run.call_args.args[0]
+    assert cmd[-2:] == ["--debug-file", str(debug_file)]
 
 
 @patch("gptme_activity_summary.cc_backend.time.sleep")

--- a/packages/gptme-activity-summary/tests/test_cc_backend.py
+++ b/packages/gptme-activity-summary/tests/test_cc_backend.py
@@ -203,20 +203,20 @@ def test_call_claude_code_nonzero_logs_stderr(mock_run, mock_sleep, caplog):
 def test_call_claude_code_nonzero_logs_stdout_and_debug_file(
     mock_run, mock_sleep, mock_datetime, caplog, tmp_path
 ):
-    """Test failures preserve stdout and point operators at Claude's debug log."""
+    """Test failures preserve stdout and trace the retry in a debug log."""
     import logging
 
     mock_datetime.now.return_value = datetime(2026, 7, 15, 1, 2, 3, tzinfo=timezone.utc)
-    debug_file = tmp_path / "claude-20260715T010203.000000Z-attempt-1.log"
-    mock_run.return_value = _make_completed_process(
-        returncode=1,
-        stdout="Your session quota is exhausted",
-    )
+    debug_file = tmp_path / "claude-20260715T010203.000000Z-attempt-2.log"
+    mock_run.side_effect = [
+        _make_completed_process(returncode=1, stdout="Your session quota is exhausted"),
+        _make_completed_process(returncode=1, stdout="Your session quota is exhausted"),
+    ]
     with caplog.at_level(logging.WARNING):
         try:
             call_claude_code(
                 "test prompt",
-                max_retries=1,
+                max_retries=2,
                 diagnostic_dir=tmp_path,
             )
         except subprocess.CalledProcessError as error:
@@ -227,8 +227,30 @@ def test_call_claude_code_nonzero_logs_stdout_and_debug_file(
     log_text = "\n".join(caplog.messages)
     assert "stdout: Your session quota is exhausted" in log_text
     assert f"debug_file: {debug_file}" in log_text
-    cmd = mock_run.call_args.args[0]
-    assert cmd[-2:] == ["--debug-file", str(debug_file)]
+    first_cmd = mock_run.call_args_list[0].args[0]
+    retry_cmd = mock_run.call_args_list[1].args[0]
+    assert "--debug-file" not in first_cmd
+    assert retry_cmd[-2:] == ["--debug-file", str(debug_file)]
+
+
+@patch("gptme_activity_summary.cc_backend.time.sleep")
+@patch("subprocess.run")
+def test_call_claude_code_diagnostic_dir_mkdir_failure_still_retries(mock_run, mock_sleep):
+    """Diagnostic dir mkdir failure must not block a Claude retry."""
+    from pathlib import Path
+    from unittest.mock import patch
+
+    mock_run.side_effect = [
+        _make_completed_process(returncode=1),
+        _make_completed_process(stdout='{"ok": true}'),
+    ]
+
+    with patch.object(Path, "mkdir", side_effect=OSError("read-only filesystem")):
+        result = call_claude_code("test prompt", max_retries=2)
+
+    assert result == '{"ok": true}'
+    assert mock_run.call_count == 2
+    assert "--debug-file" not in mock_run.call_args_list[1].args[0]
 
 
 @patch("gptme_activity_summary.cc_backend.time.sleep")


### PR DESCRIPTION
## Problem

`claude -p` can return exit 1 with an empty stderr while putting the actionable error in stdout. The activity-summary backend only logged stderr, leaving scheduled failures as `stderr: (none)` with no durable CLI trace.

## Changes

- log bounded stdout as well as stderr on every non-zero exit
- on retries after a real failure, enable Claude `--debug-file` under `~/.local/state/gptme-activity-summary/`
- keep diagnostic-path setup best-effort, including missing HOME metadata and read-only state directories
- keep the first/healthy invocation compatible with Claude versions that predate `--debug-file`
- if a retry reports that `--debug-file` is unsupported, run one immediate plain compatibility retry without consuming another ordinary retry
- timestamp debug files and prune retry logs older than seven days
- preserve the full attempted command and stdout/stderr on the raised `CalledProcessError`

## Reproduction

A live `claude -p` probe now succeeds. An invalid-model probe reproduced the diagnostic asymmetry: exit 1, actionable explanation on stdout, empty stderr, and detailed API failure only in the debug file.

## Verification

- `PYTHONPATH=packages/gptme-activity-summary/src uv run --package gptme-activity-summary pytest packages/gptme-activity-summary/tests/test_cc_backend.py -q` (26 passed)
- `uv run ruff check ...`
- `uv run mypy packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py`

Follow-up to #1220.
