### PR TITLE
fix(typecheck): add linear_oauth_state mypy override, drop unused type: ignore

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -95,3 +95,6 @@ ignore_missing_imports = True
 
 [mypy-gptme_wisdom.*]
 ignore_missing_imports = True
+
+[mypy-linear_oauth_state]
+ignore_missing_imports = True

--- a/scripts/linear/linear-activity.py
+++ b/scripts/linear/linear-activity.py
@@ -49,7 +49,7 @@ from typing import Any
 from urllib.parse import parse_qs, urlencode, urlparse
 
 import httpx
-import linear_oauth_state  # type: ignore[import-not-found]
+import linear_oauth_state
 from dotenv import load_dotenv
 
 # ============================================================================

--- a/scripts/linear/linear-webhook-server.py
+++ b/scripts/linear/linear-webhook-server.py
@@ -26,7 +26,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import httpx
-import linear_oauth_state  # type: ignore[import-not-found]
+import linear_oauth_state
 from dotenv import load_dotenv
 from flask import Flask, jsonify, request
 


### PR DESCRIPTION
## Summary

- Adds `[mypy-linear_oauth_state]` with `ignore_missing_imports = True` to `mypy.ini`
- Drops the now-redundant `# type: ignore[import-not-found]` from `linear-activity.py` and `linear-webhook-server.py`

## Root Cause

The brain repo (gptme-bob) has `scripts/linear` in its `mypy_path`, so `import linear_oauth_state` resolves cleanly — making the `# type: ignore[import-not-found]` comment **unused** and causing `[unused-ignore]` errors in the brain's CI. gptme-contrib's `mypy.ini` uses `mypy_path = scripts` (no `scripts/linear`), so the comment was needed there.

Adding the `ignore_missing_imports` override makes both mypys agree: no error, no ignore comment needed.

Fixes brain repo master CI failure: `scripts/linear/linear-{activity,webhook-server}.py: error: Unused "type: ignore" comment [unused-ignore]`