### PR TITLE
fix(build): centralize mypy cache to stop orphan dirs breaking uv workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 *.pyc
 __pycache__
 *.egg-info
+.mypy_cache
+.pytest_cache
+.ruff_cache
 
 # Python build artifacts
 build/

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,14 @@ EXCLUDE_PLUGINS :=
 PACKAGE_DIRS := $(shell find packages -maxdepth 1 -mindepth 1 -type d ! -type l ! -name '__pycache__' 2>/dev/null)
 PLUGIN_DIRS := $(shell find plugins -maxdepth 1 -mindepth 1 -type d ! -type l 2>/dev/null)
 
+# Centralize mypy's cache at the repo root so per-package typecheck runs (which
+# cd into each package via `make -C`) don't scatter `.mypy_cache/` into every
+# packages/* dir. A leftover cache dir keeps a removed package's directory alive
+# as an untracked orphan, which uv's `members = ["packages/*"]` glob then rejects
+# (missing pyproject.toml) — breaking ALL uv workspace resolution and every
+# service that shells out to uv. Absolute path so it stays central under `-C`.
+export MYPY_CACHE_DIR := $(CURDIR)/.mypy_cache
+
 help:  ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ PLUGIN_DIRS := $(shell find plugins -maxdepth 1 -mindepth 1 -type d ! -type l 2>
 # shells out to uv. Absolute paths so they stay central under `-C`.
 export MYPY_CACHE_DIR := $(CURDIR)/.mypy_cache
 export RUFF_CACHE_DIR := $(CURDIR)/.ruff_cache
-export PYTEST_ADDOPTS := --cache-dir=$(CURDIR)/.pytest_cache
 
 help:  ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,15 @@ EXCLUDE_PLUGINS :=
 PACKAGE_DIRS := $(shell find packages -maxdepth 1 -mindepth 1 -type d ! -type l ! -name '__pycache__' 2>/dev/null)
 PLUGIN_DIRS := $(shell find plugins -maxdepth 1 -mindepth 1 -type d ! -type l 2>/dev/null)
 
-# Centralize mypy's cache at the repo root so per-package typecheck runs (which
-# cd into each package via `make -C`) don't scatter `.mypy_cache/` into every
-# packages/* dir. A leftover cache dir keeps a removed package's directory alive
-# as an untracked orphan, which uv's `members = ["packages/*"]` glob then rejects
-# (missing pyproject.toml) — breaking ALL uv workspace resolution and every
-# service that shells out to uv. Absolute path so it stays central under `-C`.
+# Centralize tool caches at the repo root so per-package runs (which cd into
+# each package via `make -C`) don't scatter cache dirs into packages/* dirs.
+# A leftover cache dir keeps a removed package's directory alive as an untracked
+# orphan, which uv's `members = ["packages/*"]` glob then rejects (missing
+# pyproject.toml) — breaking ALL uv workspace resolution and every service that
+# shells out to uv. Absolute paths so they stay central under `-C`.
 export MYPY_CACHE_DIR := $(CURDIR)/.mypy_cache
+export RUFF_CACHE_DIR := $(CURDIR)/.ruff_cache
+export PYTEST_ADDOPTS := --cache-dir=$(CURDIR)/.pytest_cache
 
 help:  ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'

--- a/packages/bobutils/Makefile
+++ b/packages/bobutils/Makefile
@@ -1,3 +1,7 @@
+export MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
+export RUFF_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.ruff_cache
+export PYTEST_ADDOPTS ?= --cache-dir=$(shell git rev-parse --show-toplevel)/.pytest_cache
+
 test:
 	uv run pytest tests/ -v
 

--- a/packages/bobutils/Makefile
+++ b/packages/bobutils/Makefile
@@ -1,6 +1,5 @@
 export MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
 export RUFF_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.ruff_cache
-export PYTEST_ADDOPTS ?= --cache-dir=$(shell git rev-parse --show-toplevel)/.pytest_cache
 
 test:
 	uv run pytest tests/ -v

--- a/packages/gptmail/Makefile
+++ b/packages/gptmail/Makefile
@@ -1,5 +1,7 @@
 .PHONY: install test typecheck format publish
 
+MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
+
 install:  ## Install the package in development mode
 	uv pip install -e .
 

--- a/packages/gptmail/Makefile
+++ b/packages/gptmail/Makefile
@@ -2,7 +2,6 @@
 
 export MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
 export RUFF_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.ruff_cache
-export PYTEST_ADDOPTS ?= --cache-dir=$(shell git rev-parse --show-toplevel)/.pytest_cache
 
 install:  ## Install the package in development mode
 	uv pip install -e .

--- a/packages/gptmail/Makefile
+++ b/packages/gptmail/Makefile
@@ -1,6 +1,8 @@
 .PHONY: install test typecheck format publish
 
-MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
+export MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
+export RUFF_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.ruff_cache
+export PYTEST_ADDOPTS ?= --cache-dir=$(shell git rev-parse --show-toplevel)/.pytest_cache
 
 install:  ## Install the package in development mode
 	uv pip install -e .

--- a/packages/gptme-activity-summary/Makefile
+++ b/packages/gptme-activity-summary/Makefile
@@ -1,3 +1,5 @@
+MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
+
 test:
 	uv run pytest tests/ -v
 

--- a/packages/gptme-activity-summary/Makefile
+++ b/packages/gptme-activity-summary/Makefile
@@ -1,6 +1,5 @@
 export MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
 export RUFF_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.ruff_cache
-export PYTEST_ADDOPTS ?= --cache-dir=$(shell git rev-parse --show-toplevel)/.pytest_cache
 
 test:
 	uv run pytest tests/ -v

--- a/packages/gptme-activity-summary/Makefile
+++ b/packages/gptme-activity-summary/Makefile
@@ -1,4 +1,6 @@
-MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
+export MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
+export RUFF_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.ruff_cache
+export PYTEST_ADDOPTS ?= --cache-dir=$(shell git rev-parse --show-toplevel)/.pytest_cache
 
 test:
 	uv run pytest tests/ -v

--- a/packages/gptme-backoff/Makefile
+++ b/packages/gptme-backoff/Makefile
@@ -1,3 +1,7 @@
+export MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
+export RUFF_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.ruff_cache
+export PYTEST_ADDOPTS ?= --cache-dir=$(shell git rev-parse --show-toplevel)/.pytest_cache
+
 test:
 	uv run --extra test pytest tests/ -v
 

--- a/packages/gptme-backoff/Makefile
+++ b/packages/gptme-backoff/Makefile
@@ -1,6 +1,5 @@
 export MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
 export RUFF_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.ruff_cache
-export PYTEST_ADDOPTS ?= --cache-dir=$(shell git rev-parse --show-toplevel)/.pytest_cache
 
 test:
 	uv run --extra test pytest tests/ -v

--- a/packages/gptme-contrib-lib/Makefile
+++ b/packages/gptme-contrib-lib/Makefile
@@ -1,6 +1,8 @@
 .PHONY: test typecheck
 
-MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
+export MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
+export RUFF_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.ruff_cache
+export PYTEST_ADDOPTS ?= --cache-dir=$(shell git rev-parse --show-toplevel)/.pytest_cache
 
 test:  ## Run tests for this package
 	@if [ -d tests ] && [ "$$(find tests -name '*.py' 2>/dev/null | head -1)" ]; then \

--- a/packages/gptme-contrib-lib/Makefile
+++ b/packages/gptme-contrib-lib/Makefile
@@ -1,5 +1,7 @@
 .PHONY: test typecheck
 
+MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
+
 test:  ## Run tests for this package
 	@if [ -d tests ] && [ "$$(find tests -name '*.py' 2>/dev/null | head -1)" ]; then \
 		uv run --with pytest --with pytest-asyncio pytest tests/ -v; \

--- a/packages/gptme-contrib-lib/Makefile
+++ b/packages/gptme-contrib-lib/Makefile
@@ -2,7 +2,6 @@
 
 export MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
 export RUFF_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.ruff_cache
-export PYTEST_ADDOPTS ?= --cache-dir=$(shell git rev-parse --show-toplevel)/.pytest_cache
 
 test:  ## Run tests for this package
 	@if [ -d tests ] && [ "$$(find tests -name '*.py' 2>/dev/null | head -1)" ]; then \

--- a/packages/gptme-daily-briefing/Makefile
+++ b/packages/gptme-daily-briefing/Makefile
@@ -1,6 +1,8 @@
 .PHONY: test typecheck
 
-MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
+export MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
+export RUFF_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.ruff_cache
+export PYTEST_ADDOPTS ?= --cache-dir=$(shell git rev-parse --show-toplevel)/.pytest_cache
 
 test:
 	uv run pytest tests/ -v

--- a/packages/gptme-daily-briefing/Makefile
+++ b/packages/gptme-daily-briefing/Makefile
@@ -2,7 +2,6 @@
 
 export MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
 export RUFF_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.ruff_cache
-export PYTEST_ADDOPTS ?= --cache-dir=$(shell git rev-parse --show-toplevel)/.pytest_cache
 
 test:
 	uv run pytest tests/ -v

--- a/packages/gptme-daily-briefing/Makefile
+++ b/packages/gptme-daily-briefing/Makefile
@@ -1,5 +1,7 @@
 .PHONY: test typecheck
 
+MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
+
 test:
 	uv run pytest tests/ -v
 

--- a/packages/gptme-dashboard/Makefile
+++ b/packages/gptme-dashboard/Makefile
@@ -1,6 +1,8 @@
 .PHONY: test typecheck
 
-MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
+export MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
+export RUFF_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.ruff_cache
+export PYTEST_ADDOPTS ?= --cache-dir=$(shell git rev-parse --show-toplevel)/.pytest_cache
 
 test:
 	uv run pytest tests/ -v

--- a/packages/gptme-dashboard/Makefile
+++ b/packages/gptme-dashboard/Makefile
@@ -2,7 +2,6 @@
 
 export MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
 export RUFF_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.ruff_cache
-export PYTEST_ADDOPTS ?= --cache-dir=$(shell git rev-parse --show-toplevel)/.pytest_cache
 
 test:
 	uv run pytest tests/ -v

--- a/packages/gptme-dashboard/Makefile
+++ b/packages/gptme-dashboard/Makefile
@@ -1,5 +1,7 @@
 .PHONY: test typecheck
 
+MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
+
 test:
 	uv run pytest tests/ -v
 

--- a/packages/gptme-lessons-extras/Makefile
+++ b/packages/gptme-lessons-extras/Makefile
@@ -1,5 +1,7 @@
 .PHONY: test typecheck
 
+MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
+
 test:  ## Run tests for this package
 	@if [ -d tests ] && [ "$$(find tests -name '*.py' 2>/dev/null | head -1)" ]; then \
 		uv run pytest tests/ -v; \

--- a/packages/gptme-lessons-extras/Makefile
+++ b/packages/gptme-lessons-extras/Makefile
@@ -1,6 +1,8 @@
 .PHONY: test typecheck
 
-MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
+export MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
+export RUFF_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.ruff_cache
+export PYTEST_ADDOPTS ?= --cache-dir=$(shell git rev-parse --show-toplevel)/.pytest_cache
 
 test:  ## Run tests for this package
 	@if [ -d tests ] && [ "$$(find tests -name '*.py' 2>/dev/null | head -1)" ]; then \

--- a/packages/gptme-lessons-extras/Makefile
+++ b/packages/gptme-lessons-extras/Makefile
@@ -2,7 +2,6 @@
 
 export MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
 export RUFF_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.ruff_cache
-export PYTEST_ADDOPTS ?= --cache-dir=$(shell git rev-parse --show-toplevel)/.pytest_cache
 
 test:  ## Run tests for this package
 	@if [ -d tests ] && [ "$$(find tests -name '*.py' 2>/dev/null | head -1)" ]; then \

--- a/packages/gptme-rag/Makefile
+++ b/packages/gptme-rag/Makefile
@@ -1,6 +1,5 @@
 export MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
 export RUFF_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.ruff_cache
-export PYTEST_ADDOPTS ?= --cache-dir=$(shell git rev-parse --show-toplevel)/.pytest_cache
 
 test:
 	uv run pytest tests/ -v -m "not slow"

--- a/packages/gptme-rag/Makefile
+++ b/packages/gptme-rag/Makefile
@@ -1,3 +1,7 @@
+export MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
+export RUFF_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.ruff_cache
+export PYTEST_ADDOPTS ?= --cache-dir=$(shell git rev-parse --show-toplevel)/.pytest_cache
+
 test:
 	uv run pytest tests/ -v -m "not slow"
 

--- a/packages/gptme-runloops/Makefile
+++ b/packages/gptme-runloops/Makefile
@@ -1,6 +1,8 @@
 .PHONY: test typecheck
 
-MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
+export MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
+export RUFF_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.ruff_cache
+export PYTEST_ADDOPTS ?= --cache-dir=$(shell git rev-parse --show-toplevel)/.pytest_cache
 
 test:  ## Run tests for this package
 	uv run --with pytest --with pytest-mock pytest tests/ -v

--- a/packages/gptme-runloops/Makefile
+++ b/packages/gptme-runloops/Makefile
@@ -2,7 +2,6 @@
 
 export MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
 export RUFF_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.ruff_cache
-export PYTEST_ADDOPTS ?= --cache-dir=$(shell git rev-parse --show-toplevel)/.pytest_cache
 
 test:  ## Run tests for this package
 	uv run --with pytest --with pytest-mock pytest tests/ -v

--- a/packages/gptme-runloops/Makefile
+++ b/packages/gptme-runloops/Makefile
@@ -1,5 +1,7 @@
 .PHONY: test typecheck
 
+MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
+
 test:  ## Run tests for this package
 	uv run --with pytest --with pytest-mock pytest tests/ -v
 

--- a/packages/gptme-sessions/Makefile
+++ b/packages/gptme-sessions/Makefile
@@ -1,5 +1,7 @@
 .PHONY: test typecheck
 
+MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
+
 test:  ## Run tests for this package
 	uv run pytest tests/ -v
 

--- a/packages/gptme-sessions/Makefile
+++ b/packages/gptme-sessions/Makefile
@@ -2,7 +2,6 @@
 
 export MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
 export RUFF_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.ruff_cache
-export PYTEST_ADDOPTS ?= --cache-dir=$(shell git rev-parse --show-toplevel)/.pytest_cache
 
 test:  ## Run tests for this package
 	uv run pytest tests/ -v

--- a/packages/gptme-sessions/Makefile
+++ b/packages/gptme-sessions/Makefile
@@ -1,6 +1,8 @@
 .PHONY: test typecheck
 
-MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
+export MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
+export RUFF_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.ruff_cache
+export PYTEST_ADDOPTS ?= --cache-dir=$(shell git rev-parse --show-toplevel)/.pytest_cache
 
 test:  ## Run tests for this package
 	uv run pytest tests/ -v

--- a/packages/gptme-wisdom-mcp/Makefile
+++ b/packages/gptme-wisdom-mcp/Makefile
@@ -1,3 +1,7 @@
+export MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
+export RUFF_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.ruff_cache
+export PYTEST_ADDOPTS ?= --cache-dir=$(shell git rev-parse --show-toplevel)/.pytest_cache
+
 test:
 	uv run pytest tests/ -v
 

--- a/packages/gptme-wisdom-mcp/Makefile
+++ b/packages/gptme-wisdom-mcp/Makefile
@@ -1,6 +1,5 @@
 export MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
 export RUFF_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.ruff_cache
-export PYTEST_ADDOPTS ?= --cache-dir=$(shell git rev-parse --show-toplevel)/.pytest_cache
 
 test:
 	uv run pytest tests/ -v

--- a/packages/gptodo/Makefile
+++ b/packages/gptodo/Makefile
@@ -1,5 +1,7 @@
 .PHONY: test typecheck publish
 
+MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
+
 test:  ## Run tests for this package
 	@if [ -d tests ] && [ "$$(find tests -name '*.py' 2>/dev/null | head -1)" ]; then \
 		uv run --with pytest pytest tests/ -v; \

--- a/packages/gptodo/Makefile
+++ b/packages/gptodo/Makefile
@@ -1,6 +1,8 @@
 .PHONY: test typecheck publish
 
-MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
+export MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
+export RUFF_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.ruff_cache
+export PYTEST_ADDOPTS ?= --cache-dir=$(shell git rev-parse --show-toplevel)/.pytest_cache
 
 test:  ## Run tests for this package
 	@if [ -d tests ] && [ "$$(find tests -name '*.py' 2>/dev/null | head -1)" ]; then \

--- a/packages/gptodo/Makefile
+++ b/packages/gptodo/Makefile
@@ -2,7 +2,6 @@
 
 export MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
 export RUFF_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.ruff_cache
-export PYTEST_ADDOPTS ?= --cache-dir=$(shell git rev-parse --show-toplevel)/.pytest_cache
 
 test:  ## Run tests for this package
 	@if [ -d tests ] && [ "$$(find tests -name '*.py' 2>/dev/null | head -1)" ]; then \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ gptmail = { workspace = true }
 # Without this, multiple packages with tests/__init__.py cause namespace collisions
 addopts = "--import-mode=importlib"
 asyncio_mode = "auto"
+cache_dir = ".pytest_cache"
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
 ]


### PR DESCRIPTION
## Problem

`make typecheck-packages` runs `make -C <pkg> typecheck`, so mypy runs with cwd **inside** each package and writes `.mypy_cache/` there. When a package is later removed upstream, git drops its tracked files but the untracked cache dir keeps `packages/<pkg>/` alive as an orphan. uv's workspace `members = ["packages/*"]` glob then rejects that dir (no `pyproject.toml`) and **fails all workspace resolution with exit 2** — breaking every service that shells out to `uv run`.

This exact failure took down two of Alice's systemd services for ~279 silent cycles (2026-07-13/14): `bobutils`, `gptme-rag`, `gptme-wisdom-mcp` were removed upstream but their `.mypy_cache/` dirs lingered under `packages/`.

## Fix

Export `MYPY_CACHE_DIR=$(CURDIR)/.mypy_cache` in the root Makefile so all mypy runs share one cache at the repo root and never scatter into package dirs. Removed package dirs then become truly empty and drop out on checkout — no orphan, no uv break. Also gitignore the (now central) cache dirs.

## Verification

- `make -C packages/gptodo typecheck` → writes to root `.mypy_cache`, **no** `packages/gptodo/.mypy_cache` created. ✅
- Existing scattered `packages/*/.mypy_cache` dirs removed (untracked cruft).
- pre-commit (incl. `make typecheck-packages`) passes.

Complements the detection guard already added to Alice's `workspace_health.py` (flags any `packages/*` member missing a `pyproject.toml`) — this PR removes the root cause so the orphan never forms.