### PR TITLE
fix(sessions): detect commits in codex exec custom_tool_call format

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -140,6 +140,36 @@ def _trajectory_duration_reliable(
     return traj_span >= min_coverage * duration_seconds
 
 
+#: Minimum trajectory-derived duration (seconds) for a trajectory that parsed
+#: zero tool calls to be treated as "the extractor doesn't recognize this tool
+#: shape" rather than a genuinely trivial/instant session.
+_FORMAT_BLIND_MIN_DURATION_S = 30
+
+
+def _trajectory_format_blind(signals: dict[str, Any] | None) -> bool:
+    """Whether a trajectory ran for real but the extractor doesn't recognize
+    its tool-call shape, as opposed to a genuine no-op.
+
+    Codex has changed its tool-call encoding several times (function_call /
+    exec_command -> write_stdin piping -> custom_tool_call / exec, observed
+    2026-07). Duration-coverage alone (:func:`_trajectory_duration_reliable`)
+    does not catch this: an unrecognized shape still yields message
+    timestamps spanning the full session, just with an empty ``tool_calls``
+    dict. Left unguarded, a trajectory in this state is trusted as an
+    authoritative noop, silently dropping real caller-supplied git-range
+    deliverables and contaminating the model-selection bandit (2026-07-10..15
+    gpt-5.6-sol / gpt-5.6-terra false-noop cluster).
+
+    Only fires when the signals dict explicitly contains a ``tool_calls`` key
+    that is empty — a *missing* key (e.g. in hand-built test fixtures that
+    don't model this field) is not treated as evidence of format blindness.
+    """
+    if not signals or "tool_calls" not in signals or signals.get("tool_calls"):
+        return False
+    traj_span = signals.get("session_duration_s")
+    return isinstance(traj_span, (int, float)) and traj_span >= _FORMAT_BLIND_MIN_DURATION_S
+
+
 #: Default path for grading weights config (Phase 3 multivariate grading).
 _GRADING_WEIGHTS_PATH = (
     Path(__file__).resolve().parent.parent.parent.parent.parent.parent
@@ -454,6 +484,21 @@ def post_session(
     # resolving to the same gptme log dir), so it must not be allowed to drop
     # real git-range deliverables and record a false noop.
     trajectory_reliable = _trajectory_duration_reliable(signals, duration_seconds)
+
+    # Second-layer guard: a trajectory can look duration-reliable (it spans
+    # the right wall-clock) yet still be unusable if the extractor doesn't
+    # recognize the tool-call shape it used (see _trajectory_format_blind).
+    # Only downgrade when the caller has evidence to fall back on — otherwise
+    # this is indistinguishable from a genuine noop and the existing
+    # unreliable-trajectory-with-no-deliverables path already records
+    # "unknown" rather than penalizing the backend.
+    if trajectory_reliable and deliverables and _trajectory_format_blind(signals):
+        trajectory_reliable = False
+        logger.warning(
+            "Trajectory reports zero tool calls over %ss — extractor may not "
+            "support this trajectory format; trusting caller deliverables",
+            signals.get("session_duration_s") if signals else None,
+        )
 
     # --- Resolve deliverables ---
     # Trajectory is the authoritative source when available.  Git-range commits

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -1482,7 +1482,10 @@ def extract_signals_codex(msgs: list[dict]) -> dict:
 
                 exec_input = payload.get("input", "") or ""
                 if isinstance(exec_input, str):
-                    for cmd_match in re.finditer(r'"cmd"\s*:\s*("(?:[^"\\]|\\.)*")', exec_input):
+                    for cmd_match in re.finditer(
+                        r'tools\.exec_command\s*\(\s*[^)]*?"cmd"\s*:\s*("(?:[^"\\]|\\.)*")',
+                        exec_input,
+                    ):
                         try:
                             cmd = json.loads(cmd_match.group(1))
                         except (json.JSONDecodeError, ValueError):
@@ -1553,7 +1556,7 @@ def extract_signals_codex(msgs: list[dict]) -> dict:
                         if code_match and code_match.group(1) != "0":
                             error_count += 1
 
-                    for commit_match in _COMMIT_RE.finditer(output[:8000]):
+                    for commit_match in _COMMIT_RE.finditer(output):
                         commit_hash = commit_match.group(1)
                         commit_msg = commit_match.group(2).strip()
                         commit_value = f"{commit_msg} ({commit_hash})"

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -97,6 +97,52 @@ def _record_deliverable_detail(
     )
 
 
+def _detect_codex_shell_file_writes(
+    cmd: str,
+    *,
+    tool_name: str,
+    journal_paths: list[str],
+    file_writes: list[str],
+    detail_by_value: dict[str, dict[str, object]],
+    recent_sigs: list[str],
+    retry_candidates: list[str],
+) -> None:
+    """Detect redirect/file-write patterns in a Codex shell command string.
+
+    Shared by the "exec_command" (function_call) and "exec" (custom_tool_call)
+    Codex tool shapes, which both ultimately wrap a shell `cmd` string.
+    """
+    # Detect redirects and file-writing commands.
+    # >(?!=) excludes >= comparison operators in heredoc content.
+    for write_match in re.finditer(
+        r"(?:cat\s*>\s*|tee\s+(?:-\S+\s+)*|>(?!=)\s*)([^\s<>|&;]+)",
+        cmd,
+    ):
+        path = write_match.group(1).strip("'\"")
+        if path.startswith("/dev/"):
+            continue
+        elif "/journal/" in path:
+            journal_paths.append(path)
+        else:
+            file_writes.append(path)
+            _record_deliverable_detail(
+                detail_by_value,
+                value=path,
+                kind="file",
+                provenance_class="tool_authored",
+                evidence={
+                    "source": "trajectory",
+                    "tool_name": tool_name,
+                },
+            )
+            sig = f"{tool_name}:{path}"
+            if sig in recent_sigs:
+                retry_candidates.append(tool_name)
+            recent_sigs.append(sig)
+            if len(recent_sigs) > 20:
+                recent_sigs.pop(0)
+
+
 def _ordered_deliverable_details(
     deliverables: list[str],
     detail_by_value: dict[str, dict[str, object]],
@@ -1305,13 +1351,24 @@ def extract_signals_codex(msgs: list[dict]) -> dict:
     - session_meta: session start metadata
     - turn_context: per-turn context (model, cwd)
     - response_item: messages and tool calls (function_call / function_call_output /
-      custom_tool_call for apply_patch)
+      custom_tool_call for apply_patch, or newer "exec" / custom_tool_call_output
+      shell-execution shapes)
     - event_msg: events (token_count, task lifecycle)
 
-    File writes are detected from two sources:
+    Shell execution appears in two different tool shapes across Codex CLI
+    versions:
+    - exec_command (function_call) + function_call_output: the older shape,
+      command args as a JSON string, plain-string output.
+    - exec (custom_tool_call) + custom_tool_call_output: newer shape, where
+      `input` is JS source wrapping one or more `tools.exec_command({...})`
+      calls, and `output` is either a plain string or a list of content
+      blocks (`[{"type": "input_text", "text": "..."}]`).
+
+    File writes are detected from three sources:
     - apply_patch (custom_tool_call): "Add File" / "Update File" directives in patch input
     - exec_command (function_call): shell redirect patterns in the command string
-    Git commits are detected from exec_command and write_stdin outputs.
+    - exec (custom_tool_call): shell redirect patterns in embedded cmd strings
+    Git commits are detected from exec_command, write_stdin, and exec outputs.
     """
     tool_calls: dict[str, int] = {}
     error_count = 0
@@ -1399,35 +1456,46 @@ def extract_signals_codex(msgs: list[dict]) -> dict:
                                 pass
                         if isinstance(args, dict):
                             cmd = args.get("cmd") or ""
-                            # Detect redirects and file-writing commands.
-                            # >(?!=) excludes >= comparison operators in heredoc content.
-                            for write_match in re.finditer(
-                                r"(?:cat\s*>\s*|tee\s+(?:-\S+\s+)*|>(?!=)\s*)([^\s<>|&;]+)",
+                            _detect_codex_shell_file_writes(
                                 cmd,
-                            ):
-                                path = write_match.group(1).strip("'\"")
-                                if path.startswith("/dev/"):
-                                    continue
-                                elif "/journal/" in path:
-                                    journal_paths.append(path)
-                                else:
-                                    file_writes.append(path)
-                                    _record_deliverable_detail(
-                                        detail_by_value,
-                                        value=path,
-                                        kind="file",
-                                        provenance_class="tool_authored",
-                                        evidence={
-                                            "source": "trajectory",
-                                            "tool_name": "exec_command",
-                                        },
-                                    )
-                                    sig = f"exec_command:{path}"
-                                    if sig in recent_sigs:
-                                        retry_candidates.append("exec_command")
-                                    recent_sigs.append(sig)
-                                    if len(recent_sigs) > 20:
-                                        recent_sigs.pop(0)
+                                tool_name="exec_command",
+                                journal_paths=journal_paths,
+                                file_writes=file_writes,
+                                detail_by_value=detail_by_value,
+                                recent_sigs=recent_sigs,
+                                retry_candidates=retry_candidates,
+                            )
+
+            # Newer Codex CLI sessions wrap shell execution in a JS-source
+            # "exec" custom_tool_call instead of the plain "exec_command"
+            # function_call. The `input` field is JS source like:
+            #   const r = await tools.exec_command({"cmd":"...","workdir":"..."})
+            # and may contain multiple exec_command invocations. Without this
+            # branch these sessions report zero tool calls / commits and grade
+            # as noop despite doing real work.
+            elif payload_type == "custom_tool_call" and payload.get("name") == "exec":
+                tool_calls["exec"] = tool_calls.get("exec", 0) + 1
+                current_turn_has_tool = True
+                call_id = payload.get("call_id", "")
+                if call_id:
+                    call_id_to_name[call_id] = "exec"
+
+                exec_input = payload.get("input", "") or ""
+                if isinstance(exec_input, str):
+                    for cmd_match in re.finditer(r'"cmd"\s*:\s*("(?:[^"\\]|\\.)*")', exec_input):
+                        try:
+                            cmd = json.loads(cmd_match.group(1))
+                        except (json.JSONDecodeError, ValueError):
+                            continue
+                        _detect_codex_shell_file_writes(
+                            cmd,
+                            tool_name="exec",
+                            journal_paths=journal_paths,
+                            file_writes=file_writes,
+                            detail_by_value=detail_by_value,
+                            recent_sigs=recent_sigs,
+                            retry_candidates=retry_candidates,
+                        )
 
             elif payload_type == "function_call_output":
                 output = payload.get("output") or ""
@@ -1459,6 +1527,43 @@ def extract_signals_codex(msgs: list[dict]) -> dict:
                             kind="commit",
                             provenance_class="session_committed",
                             evidence={"source": "trajectory", "tool_name": tool_name},
+                        )
+
+            # Parallel to function_call_output, but for the "exec" custom_tool_call
+            # shape. `output` is either a plain string or a list of content
+            # blocks (e.g. [{"type": "input_text", "text": "..."}]).
+            elif payload_type == "custom_tool_call_output":
+                call_id = payload.get("call_id", "")
+                tool_name = call_id_to_name.get(call_id, "")
+
+                if tool_name == "exec":
+                    raw_output = payload.get("output")
+                    if isinstance(raw_output, str):
+                        output = raw_output
+                    elif isinstance(raw_output, list):
+                        output = "\n".join(
+                            block.get("text", "") for block in raw_output if isinstance(block, dict)
+                        )
+                    else:
+                        output = ""
+
+                    # Error detection from shell output
+                    if "Process exited with code " in output:
+                        code_match = re.search(r"Process exited with code (\d+)", output)
+                        if code_match and code_match.group(1) != "0":
+                            error_count += 1
+
+                    for commit_match in _COMMIT_RE.finditer(output[:8000]):
+                        commit_hash = commit_match.group(1)
+                        commit_msg = commit_match.group(2).strip()
+                        commit_value = f"{commit_msg} ({commit_hash})"
+                        git_commits.append(commit_value)
+                        _record_deliverable_detail(
+                            detail_by_value,
+                            value=commit_value,
+                            kind="commit",
+                            provenance_class="session_committed",
+                            evidence={"source": "trajectory", "tool_name": "exec"},
                         )
 
     # Finalize the last turn (not followed by another turn_context)

--- a/packages/gptme-sessions/tests/test_post_session.py
+++ b/packages/gptme-sessions/tests/test_post_session.py
@@ -794,6 +794,72 @@ def test_post_session_reliable_trajectory_still_drops_concurrent_commits(tmp_pat
     assert result.record.deliverables == []
 
 
+def test_post_session_format_blind_trajectory_keeps_caller_deliverables(tmp_path: Path):
+    """A trajectory with zero parsed tool calls over a substantial duration is
+    treated as extractor format-blindness, not a genuine noop, when the
+    caller has real git-range commits to fall back on.
+
+    Reproduces the 2026-07-15 gpt-5.6-sol/gpt-5.6-terra false-noop cluster:
+    Codex's newer custom_tool_call "exec" shape (JS-wrapped exec_command)
+    wasn't recognized by the extractor, which reported tool_calls={} for a
+    trajectory that fully covered the session's wall-clock and said noop,
+    silently dropping real commits.
+    """
+    store = SessionStore(sessions_dir=tmp_path)
+    fake_traj = tmp_path / "trajectory.jsonl"
+    fake_traj.write_text("")
+
+    fake_signals = {
+        "session_duration_s": 600,
+        "tool_calls": {},
+        "productive": False,
+        "deliverables": [],
+    }
+    real_sha = "abc1234567890abcdef1234567890abcdef1234"
+    with patch.object(_post_session_mod, "extract_from_path", return_value=fake_signals):
+        result = post_session(
+            store=store,
+            harness="codex",
+            model="gpt-5.6-sol",
+            duration_seconds=620,  # trajectory covers ~97% — duration-reliable
+            trajectory_path=fake_traj,
+            deliverables=[real_sha],
+        )
+
+    assert result.record.outcome == "productive"
+    assert result.record.deliverables == [real_sha]
+
+
+def test_post_session_nonzero_tool_calls_still_drops_caller_deliverables(tmp_path: Path):
+    """Inverse of the format-blind guard: when the trajectory DID parse tool
+    calls (non-empty tool_calls) and says noop, it remains an authoritative
+    noop — caller git-range commits (likely from a concurrent session) are
+    still dropped."""
+    store = SessionStore(sessions_dir=tmp_path)
+    fake_traj = tmp_path / "trajectory.jsonl"
+    fake_traj.write_text("")
+
+    fake_signals = {
+        "session_duration_s": 600,
+        "tool_calls": {"exec_command": 3},
+        "productive": False,
+        "deliverables": [],
+    }
+    concurrent_sha = "deadbeef" + "01234567" * 4
+    with patch.object(_post_session_mod, "extract_from_path", return_value=fake_signals):
+        result = post_session(
+            store=store,
+            harness="codex",
+            model="gpt-5.6-sol",
+            duration_seconds=620,
+            trajectory_path=fake_traj,
+            deliverables=[concurrent_sha],
+        )
+
+    assert result.record.outcome == "noop"
+    assert result.record.deliverables == []
+
+
 def test_post_session_trajectory_empty_deliverables_keeps_caller_when_productive(
     tmp_path: Path, caplog
 ):

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -4003,6 +4003,83 @@ def test_extract_signals_codex_custom_tool_call_output_unknown_call_id():
     assert signals["tool_calls"] == {}
 
 
+def test_extract_signals_codex_exec_cmd_outside_exec_command_ignored():
+    """A bare "cmd" key in the JS source that is NOT inside tools.exec_command(...)
+    should not be extracted as a shell command (regex anchored to exec_command context)."""
+    msgs = [
+        {
+            "timestamp": "2026-07-15T11:18:06Z",
+            "type": "session_meta",
+            "payload": {"originator": "codex_exec"},
+        },
+        {
+            "timestamp": "2026-07-15T11:18:10Z",
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call",
+                "call_id": "call_exec99",
+                "name": "exec",
+                "input": (
+                    # A "cmd" key inside a config object, NOT tools.exec_command
+                    'const config = {"cmd": "cat /etc/passwd > /tmp/steal"};\n'
+                    'const r = await tools.exec_command({"cmd": "echo hello", "workdir": "/tmp"});\n'
+                    "text(r.output);\n"
+                ),
+            },
+        },
+        {
+            "timestamp": "2026-07-15T11:18:15Z",
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call_output",
+                "call_id": "call_exec99",
+                "output": "hello\n",
+            },
+        },
+    ]
+    signals = extract_signals_codex(msgs)
+    # Only the real exec_command call's cmd should be extracted — not the config object
+    assert signals["tool_calls"] == {"exec": 1}
+    # /tmp/steal must NOT appear; the config "cmd" is not a real exec_command call
+    assert "/tmp/steal" not in signals["file_writes"]
+
+
+def test_extract_signals_codex_exec_commit_after_8k_chars():
+    """Commit lines appearing after 8000 chars of exec output must still be detected.
+    Without the full-output scan, long verbose outputs would drop commits."""
+    msgs = [
+        {
+            "timestamp": "2026-07-15T11:18:06Z",
+            "type": "session_meta",
+            "payload": {"originator": "codex_exec"},
+        },
+        {
+            "timestamp": "2026-07-15T11:18:10Z",
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call",
+                "call_id": "call_exec_long",
+                "name": "exec",
+                "input": 'const r = await tools.exec_command({"cmd": "make && git commit -am \\"build: big\\""});\n',
+            },
+        },
+        {
+            "timestamp": "2026-07-15T11:18:50Z",
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call_output",
+                "call_id": "call_exec_long",
+                # Verbose build output exceeding 8000 chars followed by the commit line
+                "output": ("Compiling module...\n" * 500)
+                + "[master feed1234] build: big\n 3 files changed\n",
+            },
+        },
+    ]
+    signals = extract_signals_codex(msgs)
+    assert len(signals["git_commits"]) == 1
+    assert "build: big (feed1234)" in signals["git_commits"]
+
+
 def test_extract_usage_codex():
     """Extract model, token, and rate-limit info from Codex trajectory."""
     msgs = [

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -3852,6 +3852,157 @@ def test_extract_signals_codex_commit_in_long_output():
     assert "abc1234" in signals["git_commits"][0]
 
 
+def test_extract_signals_codex_exec_custom_tool_call_list_output_commit():
+    """Newer Codex CLI sessions wrap exec_command in a JS-source "exec"
+    custom_tool_call instead of a plain function_call, with output as a list
+    of content blocks. Regression test for gpt-5.6-sol sessions that graded
+    0.25/noop despite containing real commits (2026-07-15 false-noop cluster).
+    """
+    msgs = [
+        {
+            "timestamp": "2026-07-15T11:18:06Z",
+            "type": "session_meta",
+            "payload": {"originator": "codex_exec"},
+        },
+        {
+            "timestamp": "2026-07-15T11:18:10Z",
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call",
+                "call_id": "call_exec1",
+                "name": "exec",
+                "input": (
+                    'const r = await tools.exec_command({"cmd":"set -e\\n'
+                    'git add foo.md\\ngit commit -m \\"fix: something\\"",'
+                    '"workdir":"/home/bob/bob"});\ntext(r.output);\n'
+                ),
+            },
+        },
+        {
+            "timestamp": "2026-07-15T11:18:15Z",
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call_output",
+                "call_id": "call_exec1",
+                "output": [
+                    {"type": "input_text", "text": "Script completed\nOutput:\n"},
+                    {
+                        "type": "input_text",
+                        "text": "[master abc1234] fix: something\n 1 file changed\n",
+                    },
+                ],
+            },
+        },
+    ]
+    signals = extract_signals_codex(msgs)
+    assert signals["tool_calls"] == {"exec": 1}
+    assert signals["steps"] == 1
+    assert len(signals["git_commits"]) == 1
+    assert "fix: something (abc1234)" in signals["git_commits"]
+
+
+def test_extract_signals_codex_exec_custom_tool_call_string_output_commit():
+    """Same "exec" custom_tool_call shape, but output is a plain string
+    rather than a list of content blocks."""
+    msgs = [
+        {
+            "timestamp": "2026-07-15T11:18:06Z",
+            "type": "session_meta",
+            "payload": {"originator": "codex_exec"},
+        },
+        {
+            "timestamp": "2026-07-15T11:18:10Z",
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call",
+                "call_id": "call_exec2",
+                "name": "exec",
+                "input": (
+                    'const r = await tools.exec_command({"cmd":"git commit -m '
+                    '\\"docs: update\\""});\ntext(r.output);\n'
+                ),
+            },
+        },
+        {
+            "timestamp": "2026-07-15T11:18:15Z",
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call_output",
+                "call_id": "call_exec2",
+                "output": "Process exited with code 0\n[master def5678] docs: update\n 1 file changed\n",
+            },
+        },
+    ]
+    signals = extract_signals_codex(msgs)
+    assert len(signals["git_commits"]) == 1
+    assert "docs: update (def5678)" in signals["git_commits"]
+    assert signals["error_count"] == 0
+
+
+def test_extract_signals_codex_exec_multi_invocation_file_write():
+    """A single "exec" custom_tool_call input can contain multiple embedded
+    tools.exec_command(...) calls; each embedded cmd should be scanned for
+    file-write patterns independently."""
+    msgs = [
+        {
+            "timestamp": "2026-07-15T11:18:06Z",
+            "type": "session_meta",
+            "payload": {"originator": "codex_exec"},
+        },
+        {
+            "timestamp": "2026-07-15T11:18:10Z",
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call",
+                "call_id": "call_exec3",
+                "name": "exec",
+                "input": (
+                    'const a = await tools.exec_command({"cmd":"pwd"});\n'
+                    'const b = await tools.exec_command({"cmd":"cat > /tmp/x.py '
+                    "<<'EOF'\\nprint(1)\\nEOF\"});\n"
+                    "text(a.output + b.output);\n"
+                ),
+            },
+        },
+        {
+            "timestamp": "2026-07-15T11:18:15Z",
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call_output",
+                "call_id": "call_exec3",
+                "output": "Process exited with code 0",
+            },
+        },
+    ]
+    signals = extract_signals_codex(msgs)
+    assert signals["tool_calls"] == {"exec": 1}
+    assert "/tmp/x.py" in signals["file_writes"]
+
+
+def test_extract_signals_codex_custom_tool_call_output_unknown_call_id():
+    """A custom_tool_call_output whose call_id has no matching custom_tool_call
+    (e.g. "exec" record was truncated/dropped) should be ignored, not crash."""
+    msgs = [
+        {
+            "timestamp": "2026-07-15T11:18:06Z",
+            "type": "session_meta",
+            "payload": {"originator": "codex_exec"},
+        },
+        {
+            "timestamp": "2026-07-15T11:18:15Z",
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call_output",
+                "call_id": "call_unknown",
+                "output": "[master abc1234] feat: orphaned output\n",
+            },
+        },
+    ]
+    signals = extract_signals_codex(msgs)
+    assert signals["git_commits"] == []
+    assert signals["tool_calls"] == {}
+
+
 def test_extract_usage_codex():
     """Extract model, token, and rate-limit info from Codex trajectory."""
     msgs = [


### PR DESCRIPTION
## Problem

`extract_signals_codex()` in `packages/gptme-sessions/src/gptme_sessions/signals.py` only understood two Codex CLI shell-tool shapes:

- `custom_tool_call` payload `apply_patch`
- `function_call` payload `exec_command`/`write_stdin` + matching `function_call_output`

Newer Codex CLI sessions (observed with gpt-5.6-sol / gpt-5.6-terra, 2026-07-15) use a **third shape** the extractor was blind to:

- `custom_tool_call` with `name: "exec"` — `input` is JS source wrapping one or more `tools.exec_command({"cmd": ..., "workdir": ...})` calls
- `custom_tool_call_output` with matching `call_id` — `output` is either a plain string or a list of content blocks (`[{"type": "input_text", "text": "..."}]`)

For sessions using this shape, the extractor reported zero tool calls, zero commits, zero file writes, grading the session 0.25/noop even though it made real commits — contaminating the model-selection bandit. Found investigating the 2026-07-15 false-noop cluster (sessions 4ec5/835e/175e/fa2b), session 0b0d.

## Fix (commit 1)

`extract_signals_codex()`:
- New `custom_tool_call` branch for `name == "exec"`: parses embedded `"cmd":"..."` JSON strings out of the JS `input` source (regex + `json.loads`), runs the existing redirect/file-write detection on each decoded cmd.
- New `custom_tool_call_output` branch: normalizes `output` (string or block-list), runs the existing error/commit detection over it.
- Factored the redirect/file-write detection shared by `exec_command` and `exec` into `_detect_codex_shell_file_writes()` — `exec_command` behavior is byte-identical (verified against a real old-format rollout, see below).

## Fail-safe guard (commit 2)

Codex has now changed its tool-call encoding three times (`function_call`/`exec_command` → `write_stdin` piping → `custom_tool_call`/`exec`). Each drift silently dropped real caller-supplied git-range deliverables because `post_session()` trusted a format-blind trajectory (zero parsed tool calls) as an authoritative noop.

Added a second-layer guard in `post_session()`: when a trajectory's signals report an empty `tool_calls` dict over a substantial trajectory-derived duration (≥30s) *and* the caller has git-range deliverables to fall back on, the trajectory is treated as unreliable for the noop decision (same treatment as the existing duration-coverage guard) instead of vetoing caller evidence. A trajectory that DID parse tool calls and says noop remains authoritative — concurrent-session contamination filtering is unaffected. Only fires when `signals` explicitly contains a `tool_calls` key (present-but-empty), so hand-built test fixtures that omit the field are unaffected.

This makes the *next* trajectory-format drift fail open (trust caller evidence, log a warning) instead of silently contaminating the bandit posterior again.

## Validation against real data

Ran `extract_from_path()` against real rollouts in `/home/bob/.codex/sessions/2026/07/15/`:

| File | tool_calls | commits | before | after |
|---|---|---|---|---|
| `rollout-...T11-18-06-...8f07...jsonl` | `{exec: 33, wait: 3}` | 2 | 0 commits, grade 0.25, noop | 2 commits, grade 0.67, productive |
| `rollout-...T11-18-06-...8f08...jsonl` | `{exec: 22, wait: 6}` | 1 | 0 commits, grade 0.25, noop | 1 commit, grade 0.6, productive |
| `rollout-...T11-18-06-...8f44...jsonl` | `{exec: 37, wait: 6}` | 2 | 0 commits, grade 0.25, noop | 2 commits, grade 0.7, productive |
| `rollout-...T11-18-29-...e9f3...jsonl` | `{exec: 37, wait: 5}` | 1 | 0 commits, grade 0.25, noop | 1 commit, grade 0.6, productive |
| `rollout-...T11-47-11-...(old format)` | `{exec_command: 41, apply_patch: 8, write_stdin: 1}` | 2 | 2 commits, grade 0.62, productive | **unchanged**: 2 commits, grade 0.62, productive |

The old-format file's output is byte-identical before/after (confirmed by running the pre-change extractor against it directly).

## Tests

- `packages/gptme-sessions/tests/test_sessions.py`: 4 new tests for the `exec`/`custom_tool_call_output` shape (list-form output + commit, string-form output + commit, multi-invocation input with a file write, unknown call_id ignored). All 23 pre-existing codex tests still pass unchanged.
- `packages/gptme-sessions/tests/test_post_session.py`: 2 new tests for the format-blind guard (zero tool_calls + adequate duration + caller SHAs → productive, deliverables kept; non-empty tool_calls + noop → still noop, caller SHAs dropped as before).
- Full package suite: `963 passed` (`--ignore test_judge.py`, which has a pre-existing unrelated `gptme` import error on this checkout).
- `prek run --files <touched files>`: all hooks pass (ruff, ruff-format, mypy/typecheck, jscpd).