### PR TITLE
fix(agent-msg): accept explicit unread list flag

### DIFF
--- a/scripts/agent-msg.py
+++ b/scripts/agent-msg.py
@@ -85,13 +85,16 @@ def _translate(argv: list[str]) -> list[str]:
 
     The surfaces are near-identical (send/broadcast/list/read/reply/status pass
     through unchanged). The one rename: ``list --needs-reply`` became its own
-    ``pending`` subcommand. Any other flags on that invocation are carried over
-    (not silently dropped) so click validates them and errors on anything
-    ``pending`` doesn't accept.
+    ``pending`` subcommand. ``list --unread`` is accepted as an explicit alias
+    for the default unread-only list view. Any other flags on the
+    ``--needs-reply`` invocation are carried over (not silently dropped) so
+    click validates them and errors on anything ``pending`` doesn't accept.
     """
     if argv and argv[0] == "list" and "--needs-reply" in argv[1:]:
         rest = [a for a in argv[1:] if a != "--needs-reply"]
         return ["pending", *rest]
+    if argv and argv[0] == "list" and "--unread" in argv[1:]:
+        return ["list", *(a for a in argv[1:] if a != "--unread")]
     return argv
 
 

--- a/scripts/agent-msg.py
+++ b/scripts/agent-msg.py
@@ -91,7 +91,7 @@ def _translate(argv: list[str]) -> list[str]:
     click validates them and errors on anything ``pending`` doesn't accept.
     """
     if argv and argv[0] == "list" and "--needs-reply" in argv[1:]:
-        rest = [a for a in argv[1:] if a != "--needs-reply"]
+        rest = [a for a in argv[1:] if a not in {"--needs-reply", "--unread"}]
         return ["pending", *rest]
     if argv and argv[0] == "list" and "--unread" in argv[1:]:
         return ["list", *(a for a in argv[1:] if a != "--unread")]

--- a/tests/test_agent_msg.py
+++ b/tests/test_agent_msg.py
@@ -65,6 +65,22 @@ class TestTranslate:
     def test_other_list_flags_preserved(self):
         assert _shim._translate(["list", "--all"]) == ["list", "--all"]
 
+    def test_list_unread_is_noop_alias(self):
+        assert _shim._translate(["list", "--unread"]) == ["list"]
+
+    def test_list_unread_preserves_other_args(self):
+        assert _shim._translate(["list", "--unread", "--mailbox", "ops"]) == [
+            "list",
+            "--mailbox",
+            "ops",
+        ]
+
+    def test_needs_reply_wins_over_unread_alias(self):
+        assert _shim._translate(["list", "--unread", "--needs-reply"]) == [
+            "pending",
+            "--unread",
+        ]
+
 
 # ---------------------------------------------------------------------------
 # meta_of(): YAML frontmatter parser (from transport.agent)

--- a/tests/test_agent_msg.py
+++ b/tests/test_agent_msg.py
@@ -76,10 +76,8 @@ class TestTranslate:
         ]
 
     def test_needs_reply_wins_over_unread_alias(self):
-        assert _shim._translate(["list", "--unread", "--needs-reply"]) == [
-            "pending",
-            "--unread",
-        ]
+        # --unread must be stripped when routing to `pending` (pending doesn't accept it)
+        assert _shim._translate(["list", "--unread", "--needs-reply"]) == ["pending"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- accept `agent-msg.py list --unread` as an explicit alias for the default unread-only view
- keep `list --needs-reply` routing to `pending`
- add shim translator regression coverage

## Verification
- `uv run pytest /home/bob/bob/gptme-contrib/tests/test_agent_msg.py -q`
- `python3 /home/bob/bob/scripts/agent-msg.py list --unread`