### PR TITLE
fix(twitter): quarantine current permanent reply error

### DIFF
--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -684,6 +684,7 @@ def move_draft(path: Path, new_status: str) -> Path:
 _PERMANENT_REPLY_FAILURE_MARKERS = (
     "reply to this conversation is not allowed because you have not been mentioned",
     "you have not been mentioned or otherwise engaged by the author",
+    "you can only reply to or quote posts where you are mentioned or are the author",
 )
 
 

--- a/tests/test_twitter_workflow_drafts.py
+++ b/tests/test_twitter_workflow_drafts.py
@@ -478,6 +478,32 @@ def test_quarantine_permanent_reply_failure_moves_draft_to_rejected(
     )
 
 
+def test_quarantine_permanent_reply_failure_recognizes_current_twitter_message(
+    workflow_module: Any, tmp_path: Path
+) -> None:
+    _set_status_dirs(workflow_module, tmp_path)
+    approved_path = workflow_module.APPROVED_DIR / "reply.yml"
+    draft = workflow_module.TweetDraft(
+        text="A useful reply",
+        type="reply",
+        in_reply_to="4242",
+    )
+    draft.save(approved_path)
+
+    moved = workflow_module._quarantine_permanent_reply_failure(
+        approved_path,
+        draft,
+        RuntimeError(
+            "403 Forbidden: You can only reply to or quote posts where "
+            "you are mentioned or are the author."
+        ),
+    )
+
+    assert moved is True
+    assert not approved_path.exists()
+    assert (workflow_module.REJECTED_DIR / approved_path.name).exists()
+
+
 def test_quarantine_permanent_reply_failure_preserves_existing_rejection(
     workflow_module: Any, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary

- recognize Twitter's current permanent unsolicited-reply 403 wording
- quarantine these drafts instead of retrying them every auto-post cycle
- cover the exact observed response with a regression test

## Incident

The live queue contained two approved replies that repeatedly failed with:

```txt
403 Forbidden: You can only reply to or quote posts where you are mentioned or are the author.
```

PR #1295 handled Twitter's older wording, but this current wording did not match its permanent-failure markers, so the drafts stayed wedged in `tweets/approved/`.

## Verification

- `uv run pytest tests/test_twitter_workflow_drafts.py -q` (34 passed)
- `uv tool run ruff@0.6.9 check scripts/twitter/workflow.py tests/test_twitter_workflow_drafts.py`
- `prek run --files scripts/twitter/workflow.py tests/test_twitter_workflow_drafts.py`
