### PR TITLE
fix(sessions): persist Codex cache-read tokens

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -1799,14 +1799,15 @@ def extract_usage_codex(msgs: list[dict]) -> dict:
     if final_total is not None:
         input_tokens = _as_int(final_total.get("input_tokens"))
         output_tokens = _as_int(final_total.get("output_tokens"))
-        cached_input_tokens = _as_int(final_total.get("cached_input_tokens"))
+        cache_read_tokens = _as_int(final_total.get("cached_input_tokens"))
         total_tokens = _as_int(final_total.get("total_tokens"))
         if input_tokens is not None:
             result["input_tokens"] = input_tokens
         if output_tokens is not None:
             result["output_tokens"] = output_tokens
-        if cached_input_tokens is not None:
-            result["cached_input_tokens"] = cached_input_tokens
+        if cache_read_tokens is not None:
+            # Normalize Codex's provider field to the SessionRecord schema.
+            result["cache_read_tokens"] = cache_read_tokens
         if total_tokens is not None:
             result["total_tokens"] = total_tokens
     if sys_prompt_tokens is not None:

--- a/packages/gptme-sessions/tests/test_sessions.py
+++ b/packages/gptme-sessions/tests/test_sessions.py
@@ -4120,7 +4120,7 @@ def test_extract_usage_codex():
     assert usage["context_peak_tokens"] == 12000
     assert usage["context_window"] == 200000
     assert usage["input_tokens"] == 12000
-    assert usage["cached_input_tokens"] == 9000
+    assert usage["cache_read_tokens"] == 9000
     assert usage["output_tokens"] == 100
     assert usage["total_tokens"] == 12100
 


### PR DESCRIPTION
## Problem

Codex trajectories expose cumulative `cached_input_tokens`, but `extract_usage_codex()` stored that provider-specific key. `post_session()` only persists the canonical `cache_read_tokens` key, so every Codex `SessionRecord` silently dropped its cache component. Cost analysis then had to exclude Codex because cached input looked like full-price fresh input.

## Fix

Normalize Codex `cached_input_tokens` to the existing `cache_read_tokens` session schema field. No schema change is needed.

A real 2026-07-17 Codex rollout now extracts `cache_read_tokens=2,013,440` from `total_token_usage` instead of dropping it.

## Verification

- `323 passed` — full `gptme-sessions` test module
- `38 passed` — focused extraction + post-session persistence tests
- Real rollout extraction assertion passed
- Ruff and `git diff --check` passed

---
*Splits out the sessions-only fix from #1305 (which also touched `.github/workflows/` and required human merge). CI workflow fix will be submitted separately.*