### PR TITLE
feat(security): gate outbound twitter and email content

### DIFF
--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -131,11 +131,6 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update -q
-          sudo apt-get install -y portaudio19-dev libportaudio2 || echo "::warning::portaudio not available, voice tests may skip"
-
       - name: Install dependencies
         run: |
           uv sync --all-packages --all-extras

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -131,6 +131,11 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y portaudio19-dev libportaudio2
+
       - name: Install dependencies
         run: |
           uv sync --all-packages --all-extras

--- a/packages/gptmail/src/gptmail/communication_utils/outbound_redact.py
+++ b/packages/gptmail/src/gptmail/communication_utils/outbound_redact.py
@@ -1,0 +1,50 @@
+"""Optional fail-closed secret gate for outbound communication.
+
+The agent workspace may provide the ``redact`` package. When it does, critical
+findings block delivery and are recorded in the workspace state ledger. A
+standalone gptme-contrib install does not require that package, so its absence is
+reported and the gate is skipped.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def guard_outbound(text: str, channel: str, workspace: Path) -> bool:
+    """Return whether ``text`` may be sent through ``channel``.
+
+    Missing optional redaction support warns and allows delivery. A detected
+    critical secret blocks delivery and writes only finding metadata, never the
+    outbound text, to ``state/outbound-redact-blocks.jsonl``.
+    """
+    try:
+        from redact import collect_secret_literals
+        from redact import redact as scan
+    except ImportError:
+        logger.warning("redact package not available — skipping outbound secret scan")
+        return True
+
+    result = scan(text, literals=collect_secret_literals())
+    if not result.blocked:
+        return True
+
+    ledger = workspace / "state" / "outbound-redact-blocks.jsonl"
+    ledger.parent.mkdir(parents=True, exist_ok=True)
+    record = {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "channel": channel,
+        "blocked": True,
+        "reasons": result.block_reasons,
+    }
+    with ledger.open("a") as f:
+        f.write(json.dumps(record) + "\n")
+
+    reasons = "; ".join(result.block_reasons)
+    logger.error("Outbound content blocked on channel=%s: %s", channel, reasons)
+    return False

--- a/packages/gptmail/src/gptmail/communication_utils/outbound_redact.py
+++ b/packages/gptmail/src/gptmail/communication_utils/outbound_redact.py
@@ -26,7 +26,9 @@ def guard_outbound(text: str, channel: str, workspace: Path) -> bool:
     try:
         from redact import collect_secret_literals
         from redact import redact as scan
-    except ImportError:
+    except ModuleNotFoundError as exc:
+        if exc.name != "redact":
+            raise
         logger.warning("redact package not available — skipping outbound secret scan")
         return True
 
@@ -35,15 +37,18 @@ def guard_outbound(text: str, channel: str, workspace: Path) -> bool:
         return True
 
     ledger = workspace / "state" / "outbound-redact-blocks.jsonl"
-    ledger.parent.mkdir(parents=True, exist_ok=True)
     record = {
         "ts": datetime.now(timezone.utc).isoformat(),
         "channel": channel,
         "blocked": True,
         "reasons": result.block_reasons,
     }
-    with ledger.open("a") as f:
-        f.write(json.dumps(record) + "\n")
+    try:
+        ledger.parent.mkdir(parents=True, exist_ok=True)
+        with ledger.open("a") as f:
+            f.write(json.dumps(record) + "\n")
+    except OSError as exc:
+        logger.error("Could not record outbound security block: %s", exc)
 
     reasons = "; ".join(result.block_reasons)
     logger.error("Outbound content blocked on channel=%s: %s", channel, reasons)

--- a/packages/gptmail/src/gptmail/lib.py
+++ b/packages/gptmail/src/gptmail/lib.py
@@ -58,6 +58,7 @@ from typing import Any, Dict, NamedTuple, Tuple
 
 import markdown
 
+from gptmail.communication_utils.outbound_redact import guard_outbound
 from gptmail.communication_utils.rate_limiting.limiters import RateLimiter
 from gptmail.communication_utils.state.locks import FileLock, LockError
 from gptmail.communication_utils.state.tracking import ConversationTracker, MessageState
@@ -814,6 +815,8 @@ class AgentEmail:
 
         # Read content before moving
         content = draft_path.read_text()
+        if not guard_outbound(content, "email", self.workspace):
+            raise ValueError("Outbound redact gate blocked a secret")
 
         # Actually send via msmtp first
         try:

--- a/packages/gptmail/tests/test_outbound_redact.py
+++ b/packages/gptmail/tests/test_outbound_redact.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import builtins
+import json
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from gptmail.communication_utils.outbound_redact import guard_outbound
+
+
+def test_guard_outbound_allows_when_optional_redact_package_is_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    real_import = builtins.__import__
+
+    def import_without_redact(name: str, *args: object, **kwargs: object) -> object:
+        if name == "redact":
+            raise ImportError("redact is optional")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_redact)
+
+    assert guard_outbound("ordinary text", "email", tmp_path) is True
+    assert "redact package not available" in caplog.text
+    assert not (tmp_path / "state" / "outbound-redact-blocks.jsonl").exists()
+
+
+def test_guard_outbound_blocks_and_records_only_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    result = SimpleNamespace(
+        blocked=True,
+        block_reasons=["1× api_key (critical)"],
+    )
+    redact_stub = types.ModuleType("redact")
+    redact_stub.collect_secret_literals = lambda: {"literal-secret"}  # type: ignore[attr-defined]
+    redact_stub.redact = lambda text, literals: result  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "redact", redact_stub)
+
+    assert guard_outbound("literal-secret", "twitter", tmp_path) is False
+
+    ledger = tmp_path / "state" / "outbound-redact-blocks.jsonl"
+    record = json.loads(ledger.read_text())
+    assert record["channel"] == "twitter"
+    assert record["reasons"] == ["1× api_key (critical)"]
+    assert "literal-secret" not in ledger.read_text()
+
+
+def test_guard_outbound_allows_clean_content(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    result = SimpleNamespace(blocked=False, block_reasons=[])
+    redact_stub = types.ModuleType("redact")
+    redact_stub.collect_secret_literals = lambda: set()  # type: ignore[attr-defined]
+    redact_stub.redact = lambda text, literals: result  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "redact", redact_stub)
+
+    assert guard_outbound("ordinary text", "email", tmp_path) is True
+    assert not (tmp_path / "state" / "outbound-redact-blocks.jsonl").exists()

--- a/packages/gptmail/tests/test_outbound_redact.py
+++ b/packages/gptmail/tests/test_outbound_redact.py
@@ -19,7 +19,7 @@ def test_guard_outbound_allows_when_optional_redact_package_is_missing(
 
     def import_without_redact(name: str, *args: object, **kwargs: object) -> object:
         if name == "redact":
-            raise ImportError("redact is optional")
+            raise ModuleNotFoundError("No module named 'redact'", name="redact")
         return real_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", import_without_redact)
@@ -27,6 +27,24 @@ def test_guard_outbound_allows_when_optional_redact_package_is_missing(
     assert guard_outbound("ordinary text", "email", tmp_path) is True
     assert "redact package not available" in caplog.text
     assert not (tmp_path / "state" / "outbound-redact-blocks.jsonl").exists()
+
+
+def test_guard_outbound_propagates_internal_import_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    real_import = builtins.__import__
+
+    def import_with_broken_dependency(name: str, *args: object, **kwargs: object) -> object:
+        if name == "redact":
+            raise ModuleNotFoundError(
+                "No module named 'scanner_dependency'", name="scanner_dependency"
+            )
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_with_broken_dependency)
+
+    with pytest.raises(ModuleNotFoundError, match="scanner_dependency"):
+        guard_outbound("secret", "email", tmp_path)
 
 
 def test_guard_outbound_blocks_and_records_only_metadata(
@@ -48,6 +66,25 @@ def test_guard_outbound_blocks_and_records_only_metadata(
     assert record["channel"] == "twitter"
     assert record["reasons"] == ["1× api_key (critical)"]
     assert "literal-secret" not in ledger.read_text()
+
+
+def test_guard_outbound_still_blocks_when_ledger_write_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    result = SimpleNamespace(
+        blocked=True,
+        block_reasons=["1× api_key (critical)"],
+    )
+    redact_stub = types.ModuleType("redact")
+    redact_stub.collect_secret_literals = lambda: set()  # type: ignore[attr-defined]
+    redact_stub.redact = lambda text, literals: result  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "redact", redact_stub)
+    monkeypatch.setattr(
+        Path, "open", lambda *args, **kwargs: (_ for _ in ()).throw(OSError("disk full"))
+    )
+
+    assert guard_outbound("secret", "email", tmp_path) is False
+    assert "Could not record outbound security block: disk full" in caplog.text
 
 
 def test_guard_outbound_allows_clean_content(

--- a/packages/gptmail/tests/test_send_recipient_allowlist.py
+++ b/packages/gptmail/tests/test_send_recipient_allowlist.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+import gptmail.lib as gptmail_lib
 from gptmail.lib import AgentEmail
 
 
@@ -86,10 +87,38 @@ def test_send_blocks_non_allowlisted(
     draft_dir.mkdir(parents=True, exist_ok=True)
     draft_id = "test-send-block"
     draft_path = draft_dir / f"{draft_id}.md"
-    draft_path.write_text("To: attacker@evil.com\n" "Subject: Test\n" "\n" "Hello\n")
+    draft_path.write_text("To: attacker@evil.com\nSubject: Test\n\nHello\n")
 
     with pytest.raises(ValueError, match="not in the send allowlist"):
         agent.send(draft_id)
+
+
+def test_send_blocks_redact_failure_before_delivery(
+    agent: AgentEmail, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    draft_id = "test-send-secret"
+    draft_path = tmp_path / "email" / "drafts" / f"{draft_id}.md"
+    content = "To: erik@example.com\nSubject: Secret\n\nsecret payload\n"
+    draft_path.write_text(content)
+    scanned: list[tuple[str, str, Path]] = []
+
+    def block(text: str, channel: str, workspace: Path) -> bool:
+        scanned.append((text, channel, workspace))
+        return False
+
+    monkeypatch.setattr(gptmail_lib, "guard_outbound", block)
+    monkeypatch.setattr(
+        agent,
+        "_validate_msmtp_config",
+        lambda: pytest.fail("delivery setup must not run after a redact block"),
+    )
+
+    with pytest.raises(ValueError, match="Outbound redact gate blocked"):
+        agent.send(draft_id)
+
+    assert scanned == [(content, "email", tmp_path)]
+    assert draft_path.exists()
+    assert not (tmp_path / "email" / "sent" / f"{draft_id}.md").exists()
 
 
 def test_send_allows_allowlisted_recipient(
@@ -108,7 +137,7 @@ def test_send_allows_allowlisted_recipient(
     draft_dir.mkdir(parents=True, exist_ok=True)
     draft_id = "test-send-ok"
     draft_path = draft_dir / f"{draft_id}.md"
-    draft_path.write_text("To: erik@example.com\n" "Subject: Hello\n" "\n" "Hi Erik!\n")
+    draft_path.write_text("To: erik@example.com\nSubject: Hello\n\nHi Erik!\n")
 
     # Stub out the actual SMTP delivery so no real email is sent.
     monkeypatch.setattr(subprocess, "run", lambda *a, **kw: type("R", (), {"returncode": 0})())

--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -60,6 +60,7 @@ from gptmail.communication_utils.monitoring import (
     MetricsCollector,
     get_logger,
 )
+from gptmail.communication_utils.outbound_redact import guard_outbound
 from gptme.init import init as init_gptme
 from rich.console import Console
 from rich.prompt import Confirm, Prompt
@@ -1289,6 +1290,16 @@ def edit(draft_id: str, new_text: str) -> None:
     console.print(f"[cyan]New text: {draft.text}")
 
 
+def _outbound_text(draft: TweetDraft) -> str:
+    """Return every segment that publishing ``draft`` would disclose."""
+    return "\n".join([draft.text, *draft.thread])
+
+
+def _outbound_allowed(draft: TweetDraft) -> bool:
+    """Run the optional workspace secret gate immediately before posting."""
+    return bool(guard_outbound(_outbound_text(draft), "twitter", AGENT_DIR))
+
+
 def _post_tweet_with_thread(client, draft: TweetDraft, tweet_id: str) -> None:
     """Post thread follow-ups after main tweet is posted."""
     if draft.thread:
@@ -1486,6 +1497,13 @@ def post(
             continue
 
         if yes or Confirm.ask("Post this tweet?", default=True):
+            if not _outbound_allowed(draft):
+                console.print(
+                    "[red]Skipping draft — outbound redact gate blocked a secret.[/red]"
+                )
+                move_draft(path, "rejected")
+                continue
+
             try:
                 # Post the main tweet
                 response = client.create_tweet(
@@ -1852,6 +1870,16 @@ def process_timeline_tweets(
                                 drafts_generated += 1
                                 if draft.in_reply_to is not None:
                                     _replied_tweet_ids.add(str(draft.in_reply_to))
+                                continue
+
+                            if not _outbound_allowed(draft):
+                                draft.reject_reason = (
+                                    "Auto-post blocked by outbound redact gate"
+                                )
+                                path = save_draft(draft, "rejected")
+                                console.print(
+                                    f"[yellow]Saved blocked draft to {path}[/yellow]"
+                                )
                                 continue
 
                             client_for_post = load_twitter_client(
@@ -2406,6 +2434,13 @@ def auto(
                         console.print(f"[red]✗ URL returns {http_status}: {url}[/red]")
                     console.print(
                         "[red]Skipping draft — fix dead URLs in the tweet or thread.[/red]"
+                    )
+                    move_draft(path, "rejected")
+                    continue
+
+                if not _outbound_allowed(draft):
+                    console.print(
+                        "[red]Skipping draft — outbound redact gate blocked a secret.[/red]"
                     )
                     move_draft(path, "rejected")
                     continue

--- a/tests/test_twitter_workflow_drafts.py
+++ b/tests/test_twitter_workflow_drafts.py
@@ -38,6 +38,8 @@ def _load_workflow_module() -> tuple[Any, dict[str, Any]]:
     monitoring_stub.get_logger = lambda *args, **kwargs: logging.getLogger(
         "twitter-test"
     )
+    redact_stub: Any = types.ModuleType("gptmail.communication_utils.outbound_redact")
+    redact_stub.guard_outbound = lambda *args, **kwargs: True
 
     gptmail_stub = _make_pkg("gptmail")
     gptmail_comm_stub = _make_pkg("gptmail.communication_utils")
@@ -103,6 +105,7 @@ def _load_workflow_module() -> tuple[Any, dict[str, Any]]:
         "gptmail": gptmail_stub,
         "gptmail.communication_utils": gptmail_comm_stub,
         "gptmail.communication_utils.monitoring": monitoring_stub,
+        "gptmail.communication_utils.outbound_redact": redact_stub,
         "gptme": gptme_stub,
         "gptme.init": gptme_init_stub,
         "dotenv": dotenv_stub,
@@ -578,6 +581,116 @@ def test_post_quarantines_permanently_undeliverable_approved_reply(
 
     assert not approved_path.exists()
     assert (workflow_module.REJECTED_DIR / approved_path.name).exists()
+
+
+def test_post_blocks_secret_before_twitter_api_call(
+    workflow_module: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_status_dirs(workflow_module, tmp_path)
+    approved_path = workflow_module.APPROVED_DIR / "secret.yml"
+    workflow_module.TweetDraft(text="secret payload").save(approved_path)
+    posted: list[str] = []
+
+    class PostingClient:
+        def create_tweet(self, *args: Any, **kwargs: Any) -> Any:
+            posted.append(kwargs["text"])
+            return SimpleNamespace(data={"id": "1"})
+
+    monkeypatch.setattr(
+        workflow_module, "load_twitter_client", lambda *a, **k: PostingClient()
+    )
+    monkeypatch.setattr(workflow_module, "_validate_draft_urls", lambda draft: [])
+    monkeypatch.setattr(workflow_module, "_validate_draft_length", lambda draft: [])
+    scanned: list[tuple[str, str, Path]] = []
+
+    def block(text: str, channel: str, workspace: Path) -> bool:
+        scanned.append((text, channel, workspace))
+        return False
+
+    monkeypatch.setattr(workflow_module, "guard_outbound", block)
+
+    workflow_module.post(
+        dry_run=False,
+        yes=True,
+        draft_id=None,
+        max_posts=1,
+        skip_url_check=False,
+    )
+
+    assert posted == []
+    assert scanned == [("secret payload", "twitter", workflow_module.AGENT_DIR)]
+    assert not approved_path.exists()
+    assert (workflow_module.REJECTED_DIR / approved_path.name).exists()
+
+
+def test_auto_blocks_same_cycle_secret_before_twitter_api_call(
+    workflow_module: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_status_dirs(workflow_module, tmp_path)
+    approved_path = workflow_module.APPROVED_DIR / "same-cycle-secret.yml"
+    workflow_module.TweetDraft(text="secret payload").save(approved_path)
+    posted: list[str] = []
+
+    class PostingClient:
+        def get_home_timeline(self, *args: Any, **kwargs: Any) -> Any:
+            return SimpleNamespace(data=None)
+
+        def create_tweet(self, *args: Any, **kwargs: Any) -> Any:
+            posted.append(kwargs["text"])
+            return SimpleNamespace(data={"id": "1"})
+
+    client = PostingClient()
+    monkeypatch.setattr(workflow_module, "load_twitter_client", lambda *a, **k: client)
+    monkeypatch.setattr(
+        workflow_module,
+        "cached_get_me",
+        lambda *a, **k: SimpleNamespace(data=SimpleNamespace(id="me", username="bob")),
+    )
+    monkeypatch.setattr(workflow_module, "_validate_draft_urls", lambda draft: [])
+    scanned: list[tuple[str, str, Path]] = []
+
+    def block(text: str, channel: str, workspace: Path) -> bool:
+        scanned.append((text, channel, workspace))
+        return False
+
+    monkeypatch.setattr(workflow_module, "guard_outbound", block)
+
+    workflow_module.auto(
+        list_id=None,
+        auto_approve=False,
+        post_approved=True,
+        dry_run=False,
+        max_tweets=1,
+        max_drafts=1,
+        skip_mentions=True,
+        skip_timeline=False,
+    )
+
+    assert posted == []
+    assert scanned == [("secret payload", "twitter", workflow_module.AGENT_DIR)]
+    assert not approved_path.exists()
+    assert (workflow_module.REJECTED_DIR / approved_path.name).exists()
+
+
+def test_outbound_gate_scans_thread_segments(
+    workflow_module: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    scanned: list[tuple[str, str, Path]] = []
+
+    def allow(text: str, channel: str, workspace: Path) -> bool:
+        scanned.append((text, channel, workspace))
+        return True
+
+    monkeypatch.setattr(workflow_module, "guard_outbound", allow)
+
+    allowed = workflow_module._outbound_allowed(
+        workflow_module.TweetDraft(text="main", thread=["follow one", "follow two"])
+    )
+
+    assert allowed is True
+    assert scanned == [
+        ("main\nfollow one\nfollow two", "twitter", workflow_module.AGENT_DIR)
+    ]
 
 
 def test_quarantine_permanent_reply_failure_keeps_transient_failure_approved(


### PR DESCRIPTION
## Problem

Twitter same-cycle posting and direct `gptmail` delivery bypassed the workspace outbound secret scanner. A draft could therefore pass the older pre-cycle Twitter scan, or be sent directly through the library, without a last-mile check.

## Changes

- add a shared optional `guard_outbound()` helper in `gptmail`
- scan all tweet/thread segments immediately before every Twitter publish path (manual approved posts, same-cycle auto posts, trusted-user auto replies)
- scan the full stored email draft inside `AgentEmail.send()` so every caller is covered, not only the CLI
- quarantine blocked Twitter drafts and keep blocked email drafts unsent
- record finding metadata only in `state/outbound-redact-blocks.jsonl`
- preserve contrib-only installs: missing optional `redact` support logs a warning and skips the scan

## Verification

- `uv run --package gptmail pytest tests/test_twitter_workflow_drafts.py tests/test_twitter_post_url_guard.py packages/gptmail/tests -q` — 194 passed
- scoped pre-commit hooks — passed
- `python3 /home/bob/bob/scripts/pr-quality-gate.py --repo gptme/gptme-contrib` — 100/100
- live smoke with Bob workspace redact package: clean content allowed; synthetic Anthropic token blocked

## Scope

This closes the two deferred residual entry-point gaps from the 2026-07-03 outbound-redact rollout. It does not make `redact` a required gptme-contrib dependency.
