### PR TITLE
fix(runloops): serialize and atomically replace state writes

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/base.py
+++ b/packages/gptme-runloops/src/gptme_runloops/base.py
@@ -16,6 +16,7 @@ from gptme_runloops.utils.logging import (
     log_execution_end,
     log_execution_start,
 )
+from gptme_runloops.utils.state import atomic_write_text
 
 # Backoff schedule for consecutive-failure detection.
 # Each entry: (failure_threshold, skip_n, out_of, description)
@@ -109,9 +110,13 @@ class BaseRunLoop(ABC):
         return {}
 
     def _save_backoff_state(self, state: dict[str, Any]) -> None:
-        """Save backoff state to disk."""
-        self._backoff_state_file.parent.mkdir(parents=True, exist_ok=True)
-        self._backoff_state_file.write_text(json.dumps(state))
+        """Save backoff state atomically.
+
+        A run-type's :class:`RunLoopLock` serializes read-modify-write access;
+        atomic replacement additionally prevents a killed writer from leaving
+        truncated JSON for the next run.
+        """
+        atomic_write_text(self._backoff_state_file, json.dumps(state))
 
     def _check_backoff(self, work_hash: str) -> bool:
         """Check if this run should be skipped due to consecutive failures.

--- a/packages/gptme-runloops/src/gptme_runloops/project_monitoring.py
+++ b/packages/gptme-runloops/src/gptme_runloops/project_monitoring.py
@@ -16,6 +16,7 @@ from gptme_runloops.base import BaseRunLoop
 from gptme_runloops.utils.execution import ExecutionResult
 from gptme_runloops.utils.executor import Executor
 from gptme_runloops.utils.github import CommentLoopDetector, has_unresolved_bot_reviews
+from gptme_runloops.utils.state import atomic_write_text, locked_state_file
 
 
 @dataclass
@@ -261,26 +262,22 @@ class ProjectMonitoringRun(BaseRunLoop):
                     self.state_dir / f"{repo.replace('/', '-')}-pr-{pr_number}.state"
                 )
 
-                # Check if PR updated since last check
-                is_new = False
-                if state_file.exists():
-                    last_check = state_file.read_text().strip()
-                    if updated_at > last_check:
-                        is_new = True
-                else:
-                    is_new = True
-
-                if is_new:
-                    # Check if last comment is just mentioning someone else (e.g., "@greptileai review")
-                    if self._is_mention_of_someone_else(repo, pr_number):
-                        # Update state file to avoid re-checking, but don't create work item
-                        state_file.write_text(updated_at)
+                with locked_state_file(state_file):
+                    last_check = (
+                        state_file.read_text().strip() if state_file.exists() else ""
+                    )
+                    if updated_at <= last_check:
                         continue
 
-                    # Check spam prevention before adding work item
+                    # Check if last comment is just mentioning someone else (e.g., "@greptileai review")
+                    if self._is_mention_of_someone_else(repo, pr_number):
+                        atomic_write_text(state_file, updated_at)
+                        continue
+
+                    # Check spam prevention before adding work item. Its own
+                    # per-comment lock protects the separate comment state.
                     if self.should_post_comment(repo, pr_number, "update"):
-                        # Update state file
-                        state_file.write_text(updated_at)
+                        atomic_write_text(state_file, updated_at)
 
                         branch_name = pr.get("headRefName", "unknown")
                         draft_note = (
@@ -358,23 +355,21 @@ class ProjectMonitoringRun(BaseRunLoop):
                 if has_failure:
                     current_failures.append(pr_number)
 
-            # Read previous failures
-            prev_failures = []
-            if state_file.exists():
-                prev_failures = [
-                    int(line.strip())
-                    for line in state_file.read_text().strip().split("\n")
-                    if line.strip()
-                ]
+            with locked_state_file(state_file):
+                prev_failures = []
+                if state_file.exists():
+                    prev_failures = [
+                        int(line.strip())
+                        for line in state_file.read_text().strip().split("\n")
+                        if line.strip()
+                    ]
 
-            # Find new failures
-            new_failures = set(current_failures) - set(prev_failures)
-
-            for pr_number in new_failures:
-                pr_data = next((p for p in prs if p["number"] == pr_number), None)
-                if pr_data:
-                    # Check spam prevention before adding work item
-                    if self.should_post_comment(repo, pr_number, "ci_failure"):
+                new_failures = set(current_failures) - set(prev_failures)
+                for pr_number in new_failures:
+                    pr_data = next((p for p in prs if p["number"] == pr_number), None)
+                    if pr_data and self.should_post_comment(
+                        repo, pr_number, "ci_failure"
+                    ):
                         work_items.append(
                             WorkItem(
                                 repo=repo,
@@ -386,8 +381,9 @@ class ProjectMonitoringRun(BaseRunLoop):
                             )
                         )
 
-            # Update state file
-            state_file.write_text("\n".join(str(n) for n in current_failures))
+                atomic_write_text(
+                    state_file, "\n".join(str(n) for n in current_failures)
+                )
 
         except Exception as e:
             self.logger.error(f"Error checking CI in {repo}: {e}")
@@ -716,36 +712,33 @@ class ProjectMonitoringRun(BaseRunLoop):
             issues = json.loads(result.stdout)
             current_issues = [issue["number"] for issue in issues]
 
-            # Read previous issues
-            prev_issues = []
-            if state_file.exists():
-                prev_issues = [
-                    int(line.strip())
-                    for line in state_file.read_text().strip().split("\n")
-                    if line.strip()
-                ]
+            with locked_state_file(state_file):
+                prev_issues = []
+                if state_file.exists():
+                    prev_issues = [
+                        int(line.strip())
+                        for line in state_file.read_text().strip().split("\n")
+                        if line.strip()
+                    ]
 
-            # Find new issues
-            new_issues = set(current_issues) - set(prev_issues)
-
-            for issue_number in new_issues:
-                issue_data = next(
-                    (i for i in issues if i["number"] == issue_number), None
-                )
-                if issue_data:
-                    work_items.append(
-                        WorkItem(
-                            repo=repo,
-                            item_type="assigned_issue",
-                            number=issue_number,
-                            title=issue_data["title"],
-                            url=issue_data["url"],
-                            details=f"Issue #{issue_number} assigned (NEW)",
-                        )
+                new_issues = set(current_issues) - set(prev_issues)
+                for issue_number in new_issues:
+                    issue_data = next(
+                        (i for i in issues if i["number"] == issue_number), None
                     )
+                    if issue_data:
+                        work_items.append(
+                            WorkItem(
+                                repo=repo,
+                                item_type="assigned_issue",
+                                number=issue_number,
+                                title=issue_data["title"],
+                                url=issue_data["url"],
+                                details=f"Issue #{issue_number} assigned (NEW)",
+                            )
+                        )
 
-            # Update state file
-            state_file.write_text("\n".join(str(n) for n in current_issues))
+                atomic_write_text(state_file, "\n".join(str(n) for n in current_issues))
 
         except Exception as e:
             self.logger.error(f"Error checking issues in {repo}: {e}")
@@ -791,76 +784,64 @@ class ProjectMonitoringRun(BaseRunLoop):
                 if n.get("reason") in relevant_reasons and n.get("unread", False)
             ]
 
-            # Read previous notifications
-            prev_notifications = set()
-            if state_file.exists():
-                prev_notifications = set(state_file.read_text().strip().split("\n"))
+            with locked_state_file(state_file):
+                prev_notifications = set()
+                if state_file.exists():
+                    prev_notifications = set(state_file.read_text().strip().split("\n"))
 
-            current_notifications = set()
+                current_notifications = set()
+                for notif in relevant_notifications:
+                    notif_id = notif["id"]
 
-            for notif in relevant_notifications:
-                notif_id = notif["id"]
+                    if notif_id in prev_notifications:
+                        current_notifications.add(notif_id)
+                        continue
 
-                # Skip if already processed
-                if notif_id in prev_notifications:
+                    repo = notif["repository"]["full_name"]
+                    subject = notif["subject"]
+                    title = subject.get("title", "")
+                    subject_type = subject.get("type", "")
+                    subject_url = subject.get("url", "")
+                    reason = notif.get("reason", "")
+
+                    number = None
+                    html_url = None
+                    if subject_url and subject_type in ["PullRequest", "Issue"]:
+                        match = re.search(r"/(pulls|issues)/(\d+)$", subject_url)
+                        if match:
+                            number = int(match.group(2))
+                            html_url = f"https://github.com/{repo}/{'pull' if subject_type == 'PullRequest' else 'issues'}/{number}"
+                    elif subject_type == "Commit":
+                        comment_url = subject.get("latest_comment_url", "")
+                        match = re.search(r"/comments/(\d+)$", comment_url)
+                        if match:
+                            number = int(match.group(1))
+                            commit_match = re.search(
+                                r"/commits/([0-9a-f]+)$", subject_url
+                            )
+                            commit_sha = commit_match.group(1) if commit_match else ""
+                            html_url = f"https://github.com/{repo}/commit/{commit_sha}#commitcomment-{number}"
+
+                    if not number:
+                        self.logger.debug(
+                            f"Skipping notification {notif_id} ({subject_type}): no number extracted"
+                        )
+                        continue
+
                     current_notifications.add(notif_id)
-                    continue
-
-                repo = notif["repository"]["full_name"]
-                subject = notif["subject"]
-                title = subject.get("title", "")
-                subject_type = subject.get("type", "")
-                subject_url = subject.get("url", "")
-                reason = notif.get("reason", "")
-
-                # Extract number and HTML URL based on subject type
-                number = None
-                html_url = None
-                if subject_url and subject_type in ["PullRequest", "Issue"]:
-                    # URL format: https://api.github.com/repos/owner/repo/pulls/123
-                    # or https://api.github.com/repos/owner/repo/issues/123
-                    match = re.search(r"/(pulls|issues)/(\d+)$", subject_url)
-                    if match:
-                        number = int(match.group(2))
-                        html_url = f"https://github.com/{repo}/{'pull' if subject_type == 'PullRequest' else 'issues'}/{number}"
-                elif subject_type == "Commit":
-                    # Commit comment: extract comment ID from latest_comment_url
-                    # URL format: https://api.github.com/repos/owner/repo/comments/456
-                    comment_url = subject.get("latest_comment_url", "")
-                    match = re.search(r"/comments/(\d+)$", comment_url)
-                    if match:
-                        number = int(match.group(1))
-                        # Extract commit SHA for the HTML URL
-                        # subject.url format: https://api.github.com/repos/owner/repo/commits/sha
-                        commit_match = re.search(r"/commits/([0-9a-f]+)$", subject_url)
-                        commit_sha = commit_match.group(1) if commit_match else ""
-                        html_url = f"https://github.com/{repo}/commit/{commit_sha}#commitcomment-{number}"
-
-                if not number:
-                    # Don't mark as processed — may become parseable after code updates
-                    self.logger.debug(
-                        f"Skipping notification {notif_id} ({subject_type}): no number extracted"
+                    details = f"Notification reason: {reason}\nType: {subject_type}"
+                    work_items.append(
+                        WorkItem(
+                            repo=repo,
+                            item_type="notification",
+                            number=number,
+                            title=title,
+                            url=html_url or "",
+                            details=details,
+                        )
                     )
-                    continue
 
-                # Only mark as processed after successfully creating a work item
-                current_notifications.add(notif_id)
-
-                details = f"Notification reason: {reason}\nType: {subject_type}"
-
-                work_items.append(
-                    WorkItem(
-                        repo=repo,
-                        item_type="notification",
-                        number=number,
-                        title=title,
-                        url=html_url or "",
-                        details=details,
-                    )
-                )
-
-            # Save current notifications
-            state_file.write_text("\n".join(current_notifications))
+                atomic_write_text(state_file, "\n".join(sorted(current_notifications)))
 
         except Exception as e:
             self.logger.error(f"Error checking notifications: {e}")

--- a/packages/gptme-runloops/src/gptme_runloops/utils/state.py
+++ b/packages/gptme-runloops/src/gptme_runloops/utils/state.py
@@ -40,6 +40,10 @@ def atomic_write_text(path: Path, text: str, *, encoding: str = "utf-8") -> None
     fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
     temp_path = Path(temp_name)
     try:
+        try:
+            os.fchmod(fd, path.stat().st_mode & 0o777)
+        except FileNotFoundError:
+            pass
         with os.fdopen(fd, "w", encoding=encoding) as temp_file:
             temp_file.write(text)
             temp_file.flush()

--- a/packages/gptme-runloops/src/gptme_runloops/utils/state.py
+++ b/packages/gptme-runloops/src/gptme_runloops/utils/state.py
@@ -1,0 +1,50 @@
+"""Concurrency-safe helpers for small run-loop state files."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+try:
+    import fcntl as _fcntl
+except ImportError:  # pragma: no cover - Windows fallback
+    _fcntl = None  # type: ignore[assignment]
+
+
+@contextmanager
+def locked_state_file(path: Path) -> Iterator[None]:
+    """Hold the sidecar lock shared by all writers of *path*.
+
+    The state file itself is replaced atomically, so its inode cannot be used as
+    the lock target. A stable ``<name>.lock`` sidecar serializes the complete
+    read-modify-write transaction instead.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_name(f"{path.name}.lock")
+    with lock_path.open("a", encoding="utf-8") as lock_file:
+        if _fcntl is not None:
+            _fcntl.flock(lock_file, _fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            if _fcntl is not None:
+                _fcntl.flock(lock_file, _fcntl.LOCK_UN)
+
+
+def atomic_write_text(path: Path, text: str, *, encoding: str = "utf-8") -> None:
+    """Write *text* via a same-directory temporary file and ``os.replace``."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temp_path = Path(temp_name)
+    try:
+        with os.fdopen(fd, "w", encoding=encoding) as temp_file:
+            temp_file.write(text)
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+        os.replace(temp_path, path)
+    except BaseException:
+        temp_path.unlink(missing_ok=True)
+        raise

--- a/packages/gptme-runloops/src/gptme_runloops/worker_records.py
+++ b/packages/gptme-runloops/src/gptme_runloops/worker_records.py
@@ -242,7 +242,8 @@ def write_post_session_record(
     record = finalize_post_session_record(
         result.record.to_dict(), result.grade, item_timeout
     )
-    _write_record(record_path, record)
+    with locked_state_file(record_path):
+        _write_record(record_path, record)
 
 
 # --- Legacy fallback record write (worker.sh:325-373) ---
@@ -326,7 +327,8 @@ def write_fallback_session_record(
         item_timeout=item_timeout,
         trajectory=trajectory,
     )
-    _write_record(record_path, payload)
+    with locked_state_file(record_path):
+        _write_record(record_path, payload)
 
 
 # --- PR-state before/after diff (worker.sh:377-502) ---
@@ -691,6 +693,9 @@ def write_worker_result_manifest(
     # preserved while this comparatively long manifest build runs.
     with locked_state_file(record_path):
         if not record_path.is_file():
+            # Cleanup removed the record while we were building the manifest;
+            # remove the orphaned manifest so bookkeeping stays consistent.
+            manifest_path.unlink(missing_ok=True)
             return
         latest_payload = json.loads(record_path.read_text(encoding="utf-8"))
         if not isinstance(latest_payload, dict):

--- a/packages/gptme-runloops/src/gptme_runloops/worker_records.py
+++ b/packages/gptme-runloops/src/gptme_runloops/worker_records.py
@@ -80,6 +80,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from gptme_runloops.utils.state import atomic_write_text, locked_state_file
+
 # Commit-oid extraction from deliverable strings (worker.sh:519).
 # NOTE(parity): re.IGNORECASE is redundant in the bash heredoc too — findall
 # runs on ``deliverable.lower()`` — but it is part of the source pattern, so
@@ -171,8 +173,8 @@ def split_item_types(text: str) -> list[str]:
 
 
 def _write_record(record_path: Path, payload: Mapping[str, Any]) -> None:
-    """Serialize a record the way every heredoc does (``ensure_ascii=False``)."""
-    record_path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+    """Atomically serialize a record (``ensure_ascii=False``)."""
+    atomic_write_text(record_path, json.dumps(payload, ensure_ascii=False))
 
 
 # --- Primary session-record write (worker.sh:283-323) ---
@@ -487,13 +489,6 @@ def update_record_pr_state(
     Missing or non-dict record → silently returns (worker.sh:451-457).
     """
     record_path = Path(record_file)
-    if not record_path.is_file():
-        return
-
-    payload = json.loads(record_path.read_text(encoding="utf-8"))
-    if not isinstance(payload, dict):
-        return
-
     before = parse_pr_snapshot(before_json)
     pr_number = int(number)
     if fetch is not None:
@@ -501,12 +496,17 @@ def update_record_pr_state(
     else:
         after = fetch_pr_snapshot(repo, pr_number, cwd=cwd)
 
-    apply_pr_state_diff(payload, before, after)
+    with locked_state_file(record_path):
+        if not record_path.is_file():
+            return
+        payload = json.loads(record_path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            return
 
-    if upgrade_outcome is not None:
-        upgrade_outcome(payload)
-
-    _write_record(record_path, payload)
+        apply_pr_state_diff(payload, before, after)
+        if upgrade_outcome is not None:
+            upgrade_outcome(payload)
+        _write_record(record_path, payload)
 
 
 # --- Worker-result manifest (worker.sh:505-627) ---
@@ -687,8 +687,16 @@ def write_worker_result_manifest(
     write_worker_result(manifest_path, manifest)
     normalized = load_worker_result(manifest_path) or manifest
 
-    apply_worker_result_to_payload(payload, normalized, manifest_path)
-    _write_record(record_path, payload)
+    # Re-read under the shared record lock so a concurrent PR-state update is
+    # preserved while this comparatively long manifest build runs.
+    with locked_state_file(record_path):
+        if not record_path.is_file():
+            return
+        latest_payload = json.loads(record_path.read_text(encoding="utf-8"))
+        if not isinstance(latest_payload, dict):
+            return
+        apply_worker_result_to_payload(latest_payload, normalized, manifest_path)
+        _write_record(record_path, latest_payload)
 
 
 # --- Delivery check (worker.sh:651-666 extractor; :668-690 decisions) ---

--- a/packages/gptme-runloops/tests/test_base.py
+++ b/packages/gptme-runloops/tests/test_base.py
@@ -1,5 +1,6 @@
 """Tests for BaseRunLoop."""
 
+import json
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
@@ -278,6 +279,25 @@ def test_backoff_schedule_skips_at_threshold(threshold, skip_n, out_of, _desc):
         # Allow ±20% variance from expected fraction
         assert skip_count >= (expected_fraction - 0.20) * 100
         assert skip_count <= (expected_fraction + 0.20) * 100
+
+
+def test_save_backoff_state_uses_atomic_replace():
+    """A failed write cannot truncate the last valid backoff state."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        workspace = Path(tmpdir)
+        (workspace / "logs").mkdir()
+        run = TestRunLoop(workspace, "test")
+        original = {"consecutive_failures": 2, "last_hash": "hash1"}
+        run._save_backoff_state(original)
+
+        with patch("gptme_runloops.utils.state.os.replace", side_effect=OSError):
+            with pytest.raises(OSError):
+                run._save_backoff_state(
+                    {"consecutive_failures": 3, "last_hash": "hash1"}
+                )
+
+        assert json.loads(run._backoff_state_file.read_text()) == original
+        assert not list(run._backoff_state_file.parent.glob(".*.tmp"))
 
 
 def test_backoff_corrupted_state_file():

--- a/packages/gptme-runloops/tests/test_project_monitoring.py
+++ b/packages/gptme-runloops/tests/test_project_monitoring.py
@@ -747,6 +747,60 @@ def test_check_notifications_unparseable_not_marked_processed(workspace):
     assert "3" not in state_file.read_text().split("\n")
 
 
+def test_check_assigned_issues_concurrent_claim_is_emitted_once(workspace):
+    """The state-file lock makes assigned-issue discovery a claim gate."""
+    import threading
+
+    issue_data = json.dumps(
+        [{"number": 456, "title": "Fix bug", "url": "https://x/456"}]
+    )
+    barrier = threading.Barrier(2)
+    results: list[list[WorkItem]] = []
+
+    def check() -> None:
+        run = ProjectMonitoringRun(workspace)
+        barrier.wait()
+        with patch(
+            "gptme_runloops.project_monitoring.subprocess.run",
+            return_value=MagicMock(returncode=0, stdout=issue_data),
+        ):
+            results.append(run.check_assigned_issues("gptme/gptme"))
+
+    threads = [threading.Thread(target=check) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert sorted(len(items) for items in results) == [0, 1]
+
+
+def test_check_notifications_concurrent_claim_is_emitted_once(workspace):
+    """Two monitoring instances cannot both surface one notification."""
+    import threading
+
+    notification = _notification(
+        "42",
+        "Issue",
+        "https://api.github.com/repos/owner/repo/issues/123",
+    )
+    barrier = threading.Barrier(2)
+    results: list[list[WorkItem]] = []
+
+    def check() -> None:
+        run = ProjectMonitoringRun(workspace)
+        barrier.wait()
+        results.append(_run_check_notifications(run, [notification]))
+
+    threads = [threading.Thread(target=check) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert sorted(len(items) for items in results) == [0, 1]
+
+
 def test_check_notifications_previously_processed_skipped(workspace):
     """Already-processed notifications are skipped but kept in state."""
     run = ProjectMonitoringRun(workspace)

--- a/packages/gptme-runloops/tests/test_worker_records.py
+++ b/packages/gptme-runloops/tests/test_worker_records.py
@@ -616,6 +616,88 @@ def test_write_worker_result_manifest_raises_on_non_numeric_number(
         )
 
 
+def test_update_record_pr_state_preserves_concurrent_manifest_fields(ws: Path) -> None:
+    record = ws / "records" / "r.json"
+    record.parent.mkdir(parents=True, exist_ok=True)
+    record.write_text(json.dumps({"outcome": "handled"}))
+
+    def fetch(repo: str, number: int) -> dict[str, str]:
+        # Simulate the manifest writer landing while the network fetch runs.
+        payload = json.loads(record.read_text())
+        payload["worker_status"] = "succeeded"
+        record.write_text(json.dumps(payload))
+        return {"state": "OPEN", "headRefOid": "after123"}
+
+    update_record_pr_state(
+        record,
+        repo="gptme/gptme",
+        number=1,
+        before_json=json.dumps({"state": "OPEN", "headRefOid": "before12"}),
+        cwd=ws,
+        fetch=fetch,
+    )
+
+    payload = json.loads(record.read_text())
+    assert payload["worker_status"] == "succeeded"
+    assert payload["pr_head_oid_after"] == "after123"
+
+
+def test_write_worker_result_manifest_preserves_concurrent_record_fields(
+    ws: Path,
+) -> None:
+    record = ws / "records" / "r.json"
+    record.parent.mkdir(parents=True, exist_ok=True)
+    record.write_text(json.dumps({"outcome": "handled", "deliverables": []}))
+
+    def write_manifest(path: Path, manifest: Any) -> None:
+        # Simulate the PR-state writer landing during manifest construction.
+        payload = json.loads(record.read_text())
+        payload["pr_state_after"] = "OPEN"
+        record.write_text(json.dumps(payload))
+        stub_write_worker_result(path, manifest)
+
+    write_worker_result_manifest(
+        record,
+        repo="gptme/gptme",
+        number=1,
+        session_id="s",
+        exit_code=0,
+        duration_seconds=1,
+        model=None,
+        item_types=[],
+        build_worker_result=stub_build_worker_result,
+        write_worker_result=write_manifest,
+        load_worker_result=stub_load_worker_result,
+    )
+
+    payload = json.loads(record.read_text())
+    assert payload["pr_state_after"] == "OPEN"
+    assert payload["worker_status"] == "completed"
+
+
+def test_write_record_failure_preserves_last_valid_json(
+    ws: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    record = ws / "records" / "r.json"
+    record.write_text(json.dumps({"outcome": "handled"}))
+
+    def fail_replace(source: Path, target: Path) -> None:
+        raise OSError("simulated crash before replace")
+
+    monkeypatch.setattr("gptme_runloops.utils.state.os.replace", fail_replace)
+    with pytest.raises(OSError):
+        update_record_pr_state(
+            record,
+            repo="gptme/gptme",
+            number=1,
+            before_json="{}",
+            cwd=ws,
+            fetch=lambda repo, number: {"state": "OPEN"},
+        )
+
+    assert json.loads(record.read_text()) == {"outcome": "handled"}
+
+
 def test_update_record_pr_state_missing_record_is_noop(ws: Path) -> None:
     update_record_pr_state(
         ws / "records" / "missing.json",


### PR DESCRIPTION
## Summary

- add one shared sidecar-flock + atomic-replace helper for run-loop state files
- serialize project-monitoring PR/CI/assignment/notification discovery state so concurrent monitors emit each item once
- preserve concurrent worker-record enrichments by reloading under the record lock, and make backoff/record writes crash-safe

## Why

Several run-loop paths performed unlocked read-modify-write updates or direct `write_text()` calls. Concurrent monitors could both surface the same item, while worker bookkeeping writers could overwrite each other or leave truncated JSON after interruption.

## Verification

- `uv run --package gptme-runloops pytest -q packages/gptme-runloops/tests` — 685 passed
- `uv run --package gptme-runloops mypy packages/gptme-runloops/src`
- `uv run ruff check ...`
- PR quality gate: 100/100
