### PR TITLE
fix(action-receipts): expose folder hook registration

### DIFF
--- a/plugins/gptme-action-receipts/src/gptme_action_receipts/hooks/__init__.py
+++ b/plugins/gptme-action-receipts/src/gptme_action_receipts/hooks/__init__.py
@@ -1,1 +1,5 @@
-# hooks package
+"""Hook registration for the action-receipts folder plugin."""
+
+from .receipt_hook import register
+
+__all__ = ["register"]

--- a/plugins/gptme-action-receipts/tests/test_receipt_hook.py
+++ b/plugins/gptme-action-receipts/tests/test_receipt_hook.py
@@ -6,6 +6,7 @@ import json
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from gptme_action_receipts.hooks import register
 from gptme_action_receipts.hooks.receipt_hook import (
     _make_receipt,
     _receipt_pre,
@@ -65,6 +66,10 @@ class TestMakeReceipt:
         r = _make_receipt("shell", "ls", None, "s1")
 
         assert r["model"] == "gptme-model"
+
+
+def test_hooks_package_exports_register():
+    assert callable(register)
 
 
 class TestReceiptPreHook:


### PR DESCRIPTION
## Problem

Bob workspace sessions load plugins from configured source paths and an explicit allowlist. `gptme-action-receipts` had no `register` export in its `hooks` package, so folder discovery found the package but could not initialize its receipt hook. Merely installing the package entry point in another Python environment left the production ledger empty.

## Change

- export the existing receipt-hook registrar from `gptme_action_receipts.hooks`
- add a regression test for the folder-plugin contract

The Bob-side project path/allowlist wiring is a separate local config change.

## Verification

- `PYTHONPATH=plugins/gptme-action-receipts/src pytest -q plugins/gptme-action-receipts/tests` — 48 passed
- `uvx ruff check plugins/gptme-action-receipts/src plugins/gptme-action-receipts/tests`
- Bob workspace registry discovery finds `gptme_action_receipts` with a hook registrar
- isolated fresh gptme smoke session emitted shell + complete receipts to a temporary ledger