### PR TITLE
fix(subscription): serialize state writers

### DIFF
--- a/packages/gptme-subscription/src/gptme_subscription/manager.py
+++ b/packages/gptme-subscription/src/gptme_subscription/manager.py
@@ -31,6 +31,7 @@ from gptme_subscription.observation import (
 from gptme_subscription.routing import (
     compute_window_pacing,
 )
+from gptme_subscription.state import atomic_write_text, locked_state_file
 
 logger = logging.getLogger(__name__)
 
@@ -375,23 +376,24 @@ class SubscriptionManager:
         self, now: datetime | None = None
     ) -> dict[str, Any] | None:
         path = self.config.rebalance_state_file
-        if not path.exists():
-            return None
         current_time = now or datetime.now(timezone.utc)
-        try:
-            payload = json.loads(path.read_text())
-            if not isinstance(payload, dict):
+        with locked_state_file(path):
+            if not path.exists():
+                return None
+            try:
+                payload = json.loads(path.read_text())
+                if not isinstance(payload, dict):
+                    path.unlink(missing_ok=True)
+                    return None
+                hold_until = datetime.fromisoformat(payload["hold_until"])
+                if hold_until <= current_time:
+                    path.unlink(missing_ok=True)
+                    return None
+                payload["hold_until"] = hold_until
+                return payload
+            except (OSError, ValueError, KeyError, json.JSONDecodeError):
                 path.unlink(missing_ok=True)
                 return None
-            hold_until = datetime.fromisoformat(payload["hold_until"])
-            if hold_until <= current_time:
-                path.unlink(missing_ok=True)
-                return None
-            payload["hold_until"] = hold_until
-            return payload
-        except (OSError, ValueError, KeyError, json.JSONDecodeError):
-            path.unlink(missing_ok=True)
-            return None
 
     def save_rebalance_state(self, decision: dict[str, Any]) -> None:
         if decision.get("mode") not in (
@@ -407,11 +409,13 @@ class SubscriptionManager:
         if isinstance(hold_until, datetime):
             decision["hold_until"] = hold_until.isoformat()
         path = self.config.rebalance_state_file
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(decision, indent=2) + "\n")
+        with locked_state_file(path):
+            atomic_write_text(path, json.dumps(decision, indent=2) + "\n")
 
     def clear_rebalance_state(self) -> None:
-        self.config.rebalance_state_file.unlink(missing_ok=True)
+        path = self.config.rebalance_state_file
+        with locked_state_file(path):
+            path.unlink(missing_ok=True)
 
     def record_manual_switch_hold(
         self, target: str, now: datetime | None = None
@@ -458,33 +462,33 @@ class SubscriptionManager:
     ) -> None:
         path = self.config.reset_times_file
         try:
-            data: dict[str, Any] = {}
-            if path.exists():
-                data = json.loads(path.read_text())
-            entry: dict[str, Any] = {
-                "observed_at": datetime.now(timezone.utc).isoformat(),
-                "resets_in_seconds": int(resets_in_seconds),
-            }
-            if usage is not None:
-                weekly = usage.get("seven_day", {})
-                five_hour = usage.get("five_hour", {})
-                sonnet = usage.get("seven_day_sonnet", {})
-                for key, source_key, source in (
-                    ("weekly_utilization", "utilization", weekly),
-                    ("five_hour_utilization", "utilization", five_hour),
-                    ("sonnet_weekly_utilization", "utilization", sonnet),
-                    ("five_hour_resets_in_seconds", "resets_in_seconds", five_hour),
-                    ("sonnet_resets_in_seconds", "resets_in_seconds", sonnet),
-                ):
-                    value = source.get(source_key)
-                    if isinstance(value, int | float):
-                        entry[key] = float(value)
-                pressure = subscription_pressure_from_usage(usage)
-                if pressure is not None:
-                    entry["pressure"] = round(pressure, 3)
-            data[sub] = entry
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(json.dumps(data, indent=2) + "\n")
+            with locked_state_file(path):
+                data: dict[str, Any] = {}
+                if path.exists():
+                    data = json.loads(path.read_text())
+                entry: dict[str, Any] = {
+                    "observed_at": datetime.now(timezone.utc).isoformat(),
+                    "resets_in_seconds": int(resets_in_seconds),
+                }
+                if usage is not None:
+                    weekly = usage.get("seven_day", {})
+                    five_hour = usage.get("five_hour", {})
+                    sonnet = usage.get("seven_day_sonnet", {})
+                    for key, source_key, source in (
+                        ("weekly_utilization", "utilization", weekly),
+                        ("five_hour_utilization", "utilization", five_hour),
+                        ("sonnet_weekly_utilization", "utilization", sonnet),
+                        ("five_hour_resets_in_seconds", "resets_in_seconds", five_hour),
+                        ("sonnet_resets_in_seconds", "resets_in_seconds", sonnet),
+                    ):
+                        value = source.get(source_key)
+                        if isinstance(value, int | float):
+                            entry[key] = float(value)
+                    pressure = subscription_pressure_from_usage(usage)
+                    if pressure is not None:
+                        entry["pressure"] = round(pressure, 3)
+                data[sub] = entry
+                atomic_write_text(path, json.dumps(data, indent=2) + "\n")
         except (OSError, json.JSONDecodeError):
             pass
 

--- a/packages/gptme-subscription/src/gptme_subscription/observation.py
+++ b/packages/gptme-subscription/src/gptme_subscription/observation.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+from gptme_subscription.state import atomic_write_text, locked_state_file
+
 
 @dataclass
 class SubscriptionObservation:
@@ -88,22 +90,22 @@ def record_sub_reset_time(
         metric_key: Which metric reset was observed (e.g. ``seven_day``).
         timestamp: ISO-8601 timestamp. Defaults to current UTC time.
     """
-    obs_dir.mkdir(parents=True, exist_ok=True)
     obs_file = obs_dir / f"{sub}.json"
-    entry: dict[str, dict[str, str]] = {}
-    if obs_file.exists():
-        try:
-            raw = obs_file.read_text()
-            if raw.strip():
-                parsed = json.loads(raw)
-                if isinstance(parsed, dict):
-                    entry = parsed
-        except (json.JSONDecodeError, OSError):
-            pass  # corrupt file — start fresh
-    entry.setdefault("track_resets", {})[metric_key] = (
-        timestamp or datetime.now(timezone.utc).isoformat()
-    )
-    obs_file.write_text(json.dumps(entry, indent=2) + "\n")
+    with locked_state_file(obs_file):
+        entry: dict[str, dict[str, str]] = {}
+        if obs_file.exists():
+            try:
+                raw = obs_file.read_text()
+                if raw.strip():
+                    parsed = json.loads(raw)
+                    if isinstance(parsed, dict):
+                        entry = parsed
+            except (json.JSONDecodeError, OSError):
+                pass  # corrupt file — start fresh
+        entry.setdefault("track_resets", {})[metric_key] = (
+            timestamp or datetime.now(timezone.utc).isoformat()
+        )
+        atomic_write_text(obs_file, json.dumps(entry, indent=2) + "\n")
 
 
 def load_sub_observations(

--- a/packages/gptme-subscription/src/gptme_subscription/routing.py
+++ b/packages/gptme-subscription/src/gptme_subscription/routing.py
@@ -27,6 +27,7 @@ from gptme_subscription.observation import (
     remaining_until_observed_reset,
     subscription_pressure_from_usage,
 )
+from gptme_subscription.state import atomic_write_text, locked_state_file
 
 
 @dataclass
@@ -261,8 +262,8 @@ def save_rebalance_state(
         state_path: Path to write the state JSON file.
         decision: Mapping with rebalance decision fields.
     """
-    state_path.parent.mkdir(parents=True, exist_ok=True)
-    state_path.write_text(json.dumps(decision, indent=2) + "\n")
+    with locked_state_file(state_path):
+        atomic_write_text(state_path, json.dumps(decision, indent=2) + "\n")
 
 
 def clear_rebalance_state(state_path: Path) -> None:
@@ -271,8 +272,8 @@ def clear_rebalance_state(state_path: Path) -> None:
     Args:
         state_path: Path to the state JSON file to remove.
     """
-    if state_path.exists():
-        state_path.unlink()
+    with locked_state_file(state_path):
+        state_path.unlink(missing_ok=True)
 
 
 # --- Fallback routing ---

--- a/packages/gptme-subscription/src/gptme_subscription/state.py
+++ b/packages/gptme-subscription/src/gptme_subscription/state.py
@@ -10,8 +10,13 @@ from pathlib import Path
 
 try:
     import fcntl as _fcntl
-except ImportError:  # pragma: no cover - Windows fallback
+except ImportError:  # pragma: no cover - Windows
     _fcntl = None  # type: ignore[assignment]
+
+try:
+    import msvcrt as _msvcrt
+except ImportError:  # pragma: no cover - non-Windows
+    _msvcrt = None  # type: ignore[assignment]
 
 
 @contextmanager
@@ -19,14 +24,25 @@ def locked_state_file(path: Path) -> Iterator[None]:
     """Serialize a complete read-modify-write transaction for *path*."""
     path.parent.mkdir(parents=True, exist_ok=True)
     lock_path = path.with_name(f"{path.name}.lock")
-    with lock_path.open("a", encoding="utf-8") as lock_file:
+    # Binary append: no encoding argument; both fcntl and msvcrt only need the fd.
+    with lock_path.open("ab") as lock_file:
         if _fcntl is not None:
             _fcntl.flock(lock_file, _fcntl.LOCK_EX)
+        elif _msvcrt is not None:  # pragma: no cover - Windows only
+            # locking() needs at least one byte at position 0
+            if lock_file.tell() == 0:
+                lock_file.write(b"\x00")
+                lock_file.flush()
+            lock_file.seek(0)
+            _msvcrt.locking(lock_file.fileno(), _msvcrt.LK_LOCK, 1)
         try:
             yield
         finally:
             if _fcntl is not None:
                 _fcntl.flock(lock_file, _fcntl.LOCK_UN)
+            elif _msvcrt is not None:  # pragma: no cover - Windows only
+                lock_file.seek(0)
+                _msvcrt.locking(lock_file.fileno(), _msvcrt.LK_UNLCK, 1)
 
 
 def atomic_write_text(path: Path, text: str, *, encoding: str = "utf-8") -> None:
@@ -38,7 +54,11 @@ def atomic_write_text(path: Path, text: str, *, encoding: str = "utf-8") -> None
         try:
             os.fchmod(fd, path.stat().st_mode & 0o777)
         except FileNotFoundError:
-            pass
+            # New file: mirror the process umask so permissions match what
+            # Path.write_text() would have produced on first creation.
+            current_umask = os.umask(0)
+            os.umask(current_umask)  # restore immediately
+            os.fchmod(fd, 0o666 & ~current_umask)
         with os.fdopen(fd, "w", encoding=encoding) as temp_file:
             temp_file.write(text)
             temp_file.flush()

--- a/packages/gptme-subscription/src/gptme_subscription/state.py
+++ b/packages/gptme-subscription/src/gptme_subscription/state.py
@@ -1,0 +1,49 @@
+"""Concurrency-safe persistence for small subscription state files."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+try:
+    import fcntl as _fcntl
+except ImportError:  # pragma: no cover - Windows fallback
+    _fcntl = None  # type: ignore[assignment]
+
+
+@contextmanager
+def locked_state_file(path: Path) -> Iterator[None]:
+    """Serialize a complete read-modify-write transaction for *path*."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_name(f"{path.name}.lock")
+    with lock_path.open("a", encoding="utf-8") as lock_file:
+        if _fcntl is not None:
+            _fcntl.flock(lock_file, _fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            if _fcntl is not None:
+                _fcntl.flock(lock_file, _fcntl.LOCK_UN)
+
+
+def atomic_write_text(path: Path, text: str, *, encoding: str = "utf-8") -> None:
+    """Write *text* via a same-directory temporary file and atomic replace."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temp_path = Path(temp_name)
+    try:
+        try:
+            os.fchmod(fd, path.stat().st_mode & 0o777)
+        except FileNotFoundError:
+            pass
+        with os.fdopen(fd, "w", encoding=encoding) as temp_file:
+            temp_file.write(text)
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+        os.replace(temp_path, path)
+    except BaseException:
+        temp_path.unlink(missing_ok=True)
+        raise

--- a/packages/gptme-subscription/tests/test_observation.py
+++ b/packages/gptme-subscription/tests/test_observation.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import multiprocessing
 from pathlib import Path
 
 from gptme_subscription.observation import (
@@ -195,6 +197,23 @@ class TestRecordSubResetTime:
         record_sub_reset_time(tmp_path, "bob", "seven_day", "2026-01-01T00:00:00+00:00")
         data = (tmp_path / "bob.json").read_text()
         assert "seven_day" in data
+
+    def test_concurrent_metric_updates_are_preserved(self, tmp_path: Path) -> None:
+        metrics = [f"metric-{index}" for index in range(20)]
+        processes = [
+            multiprocessing.Process(
+                target=record_sub_reset_time, args=(tmp_path, "bob", metric)
+            )
+            for metric in metrics
+        ]
+        for process in processes:
+            process.start()
+        for process in processes:
+            process.join()
+            assert process.exitcode == 0
+
+        data = json.loads((tmp_path / "bob.json").read_text())
+        assert set(data["track_resets"]) == set(metrics)
 
     def test_corrupt_file_does_not_raise(self, tmp_path: Path) -> None:
         obs_file = tmp_path / "bob.json"

--- a/packages/gptme-subscription/tests/test_subscription_manager.py
+++ b/packages/gptme-subscription/tests/test_subscription_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import multiprocessing
 import os
 import time
 from datetime import datetime, timedelta, timezone
@@ -476,6 +477,23 @@ def test_manual_switch_hold_does_not_block_wrong_slot_fallback(
     # The hold is for bob, but alice is the active fallback.
     assert decision.action == "switch"
     assert decision.mode != "manual-switch-hold"
+
+
+def test_concurrent_reset_time_updates_are_preserved(tmp_path: Path) -> None:
+    sm = _make_manager(tmp_path)
+    subscriptions = [f"slot-{index}" for index in range(20)]
+    processes = [
+        multiprocessing.Process(target=sm.record_sub_reset_time, args=(sub, 3600))
+        for sub in subscriptions
+    ]
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join()
+        assert process.exitcode == 0
+
+    payload = json.loads(sm.config.reset_times_file.read_text())
+    assert set(payload) == set(subscriptions)
 
 
 def test_record_manual_switch_hold_persists_state(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add package-local sidecar flock and atomic-replace helpers for subscription state
- serialize reset-observation read/modify/write transactions so concurrent agents do not lose entries
- make both manager and generic routing rebalance-state writes atomic and coordinate clears/expiry cleanup
- add multi-process regressions for both reset-time stores

## Verification
- `uv run --package gptme-subscription pytest packages/gptme-subscription/tests -q` (124 passed)
- concurrency regressions repeated 30x
- scoped `prek` suite passed
- `scripts/pr-quality-gate.py --repo gptme/gptme-contrib` (100/100)

Follow-up slice from the state-writer audit after #1308. gptmail and gptodo remain explicitly out of scope.
