### PR TITLE
fix(state): serialize mail and task cache writers

### DIFF
--- a/packages/gptmail/src/gptmail/lib.py
+++ b/packages/gptmail/src/gptmail/lib.py
@@ -1651,17 +1651,26 @@ class AgentEmail:
         return processed_files
 
     def _save_sync_state(self, folder: str, processed_files: set[str]) -> None:
-        """Save set of processed maildir filenames."""
+        """Atomically save the processed maildir filenames."""
         import json
 
         state_path = self._get_sync_state_path(folder)
+        temp_path = state_path.with_name(f".{state_path.name}.{uuid.uuid4().hex}.tmp")
         try:
-            with open(state_path, "w") as f:
+            with open(temp_path, "w") as f:
                 json.dump({"processed_files": sorted(processed_files)}, f)
+            os.replace(temp_path, state_path)
         except OSError as e:
+            temp_path.unlink(missing_ok=True)
             print(f"Warning: Could not save sync state: {e}")
 
     def sync_from_maildir(self, folder: str) -> None:
+        """Sync messages while serializing each folder's state transaction."""
+        lock_path = self.locks_dir / f"sync_state_{folder}.lock"
+        with FileLock(lock_path):
+            self._sync_from_maildir_locked(folder)
+
+    def _sync_from_maildir_locked(self, folder: str) -> None:
         """Sync messages from external maildir to markdown format.
 
         This imports emails from the external maildir (e.g., Gmail via mbsync)

--- a/packages/gptmail/tests/test_sync_state_concurrency.py
+++ b/packages/gptmail/tests/test_sync_state_concurrency.py
@@ -1,0 +1,74 @@
+"""Regression tests for concurrent maildir sync state writers."""
+
+from __future__ import annotations
+
+import json
+import multiprocessing
+import queue
+from pathlib import Path
+
+from gptmail.lib import AgentEmail
+
+
+def _make_workspace(root: Path) -> AgentEmail:
+    for folder in ("inbox", "sent", "archive", "drafts", "filters"):
+        (root / "email" / folder).mkdir(parents=True, exist_ok=True)
+    return AgentEmail(root, "bob@example.com")
+
+
+def _sync_update(
+    workspace: str, entry: str, entered: multiprocessing.Queue, release: multiprocessing.Event
+) -> None:
+    email = AgentEmail(workspace, "bob@example.com")
+    original = email._sync_from_maildir_locked
+
+    def update(folder: str) -> None:
+        state = email._load_sync_state(folder)
+        entered.put(entry)
+        release.wait(timeout=5)
+        state.add(entry)
+        email._save_sync_state(folder, state)
+
+    email._sync_from_maildir_locked = update  # type: ignore[method-assign]
+    try:
+        email.sync_from_maildir("inbox")
+    finally:
+        email._sync_from_maildir_locked = original  # type: ignore[method-assign]
+
+
+def test_sync_state_transactions_preserve_concurrent_updates(tmp_path: Path) -> None:
+    email = _make_workspace(tmp_path)
+    entered: multiprocessing.Queue = multiprocessing.Queue()
+    release = multiprocessing.Event()
+    processes = [
+        multiprocessing.Process(target=_sync_update, args=(str(tmp_path), entry, entered, release))
+        for entry in ("first", "second")
+    ]
+
+    processes[0].start()
+    assert entered.get(timeout=5) == "first"
+    processes[1].start()
+    try:
+        entered.get(timeout=0.1)
+    except queue.Empty:
+        pass
+    else:
+        raise AssertionError("the second sync entered before the first released its lock")
+    release.set()
+    assert entered.get(timeout=5) == "second"
+
+    for process in processes:
+        process.join(timeout=5)
+        assert process.exitcode == 0
+
+    assert email._load_sync_state("inbox") == {"first", "second"}
+
+
+def test_save_sync_state_replaces_json_atomically(tmp_path: Path) -> None:
+    email = _make_workspace(tmp_path)
+
+    email._save_sync_state("inbox", {"message"})
+
+    state_path = email._get_sync_state_path("inbox")
+    assert json.loads(state_path.read_text()) == {"processed_files": ["message"]}
+    assert list(state_path.parent.glob(f".{state_path.name}.*.tmp")) == []

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -134,8 +134,8 @@ from gptodo.utils import (
     # Phase 4: Effective state computation (bob#240)
     parse_tracking_ref,
     resolve_tasks,
-    save_cache,
     task_to_dict,
+    update_cache,
     update_task_state,
 )
 
@@ -3307,21 +3307,22 @@ def sync(update, output_json, use_cache, light, full, changes_only):
 
             if invalidated > 0:
                 console.print(f"[yellow]Invalidated {invalidated} cache entries[/]")
-                save_cache(cache_path, cache)
+                cache = update_cache(cache_path, remove=urls_to_refresh)
 
             # Fetch fresh states for invalidated URLs
             if urls_to_refresh:
                 console.print(f"[cyan]Refreshing {len(urls_to_refresh)} URLs...[/]")
+                updates: dict[str, Any] = {}
                 for url in urls_to_refresh:
                     state_info = fetch_url_state(url)
                     if state_info:
-                        cache[url] = {
+                        updates[url] = {
                             "state": state_info["state"],
                             "source": state_info.get("source", "unknown"),
                             "last_fetched": datetime.now(timezone.utc).isoformat(),
                             "updatedAt": state_info.get("updatedAt"),
                         }
-                save_cache(cache_path, cache)
+                cache = update_cache(cache_path, updates)
         else:
             console.print("[dim]No new notifications found[/]")
 
@@ -3343,10 +3344,11 @@ def sync(update, output_json, use_cache, light, full, changes_only):
             cache = load_cache(cache_path)
 
             fetched = 0
+            updates = {}
             for url in sorted(all_urls):
                 state_info = fetch_url_state(url)
                 if state_info:
-                    cache[url] = {
+                    updates[url] = {
                         "state": state_info["state"],
                         "source": state_info.get("source", "unknown"),
                         "last_fetched": datetime.now(timezone.utc).isoformat(),
@@ -3354,7 +3356,7 @@ def sync(update, output_json, use_cache, light, full, changes_only):
                     }
                     fetched += 1
 
-            save_cache(cache_path, cache)
+            cache = update_cache(cache_path, updates)
             console.print(f"[green]Refreshed {fetched} URLs[/]")
 
         # Continue with sync using refreshed cache
@@ -3908,13 +3910,14 @@ def fetch(fetch_all: bool, max_age: int, output_json: bool, urls: tuple[str, ...
     results = []
     fetched_count = 0
     error_count = 0
+    updates: dict[str, Any] = {}
 
     for url in sorted(stale_urls):
         result = {"url": url}
         state_info = fetch_url_state(url)
 
         if state_info:
-            cache[url] = {
+            updates[url] = {
                 "state": state_info["state"],
                 "source": state_info.get("source", "unknown"),
                 "last_fetched": now.isoformat(),
@@ -3946,8 +3949,8 @@ def fetch(fetch_all: bool, max_age: int, output_json: bool, urls: tuple[str, ...
             }
         )
 
-    # Save cache (even if only errors, to track last attempt)
-    save_cache(cache_path, cache)
+    if updates:
+        cache = update_cache(cache_path, updates)
 
     # Output
     if output_json:

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -10,10 +10,13 @@ This module contains:
 
 from __future__ import annotations
 
+import fcntl
 import json
 import logging
+import os
 import re
 import subprocess
+import tempfile
 import warnings
 from dataclasses import dataclass, field
 from datetime import date, datetime, time, timedelta
@@ -1714,16 +1717,60 @@ def load_cache(cache_path: Path) -> Dict[str, Any]:
     return {}
 
 
-def save_cache(cache_path: Path, cache: Dict[str, Any]) -> None:
-    """Save cache to file with atomic write for crash safety."""
+def _write_cache_atomic(cache_path: Path, cache: Dict[str, Any]) -> None:
+    """Replace a cache file without exposing partial JSON to readers."""
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temp_name = tempfile.mkstemp(
+        prefix=f".{cache_path.name}.", suffix=".tmp", dir=cache_path.parent
+    )
+    temp_path = Path(temp_name)
     try:
-        # Write to temp file first, then rename for atomicity
-        temp_path = cache_path.with_suffix(".tmp")
-        with open(temp_path, "w") as f:
+        with os.fdopen(fd, "w") as f:
             json.dump(cache, f, indent=2)
-        temp_path.rename(cache_path)
+        os.replace(temp_path, cache_path)
+    except Exception:
+        temp_path.unlink(missing_ok=True)
+        raise
+
+
+def update_cache(
+    cache_path: Path,
+    updates: Dict[str, Any] | None = None,
+    remove: set[str] | None = None,
+) -> Dict[str, Any]:
+    """Apply a cache delta under a sidecar lock and return the merged state."""
+    lock_path = cache_path.with_name(f".{cache_path.name}.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with open(lock_path, "a+") as lock_file:
+            fcntl.flock(lock_file, fcntl.LOCK_EX)
+            merged = load_cache(cache_path)
+            for key in remove or set():
+                merged.pop(key, None)
+            merged.update(updates or {})
+            _write_cache_atomic(cache_path, merged)
+            return merged
     except OSError as e:
         # Log but don't crash - cache is non-critical
+        import sys
+
+        print(f"Warning: Could not update cache: {e}", file=sys.stderr)
+        return load_cache(cache_path)
+
+
+def save_cache(cache_path: Path, cache: Dict[str, Any]) -> None:
+    """Replace the cache under a sidecar lock.
+
+    Read-modify-write callers should use :func:`update_cache` so unrelated
+    entries written by concurrent processes are preserved.
+    """
+    lock_path = cache_path.with_name(f".{cache_path.name}.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with open(lock_path, "a+") as lock_file:
+            fcntl.flock(lock_file, fcntl.LOCK_EX)
+            _write_cache_atomic(cache_path, cache)
+    except OSError as e:
         import sys
 
         print(f"Warning: Could not save cache: {e}", file=sys.stderr)

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -34,6 +34,8 @@ from typing import (
 if TYPE_CHECKING:
     from gptodo.frontmatter_compat import Post as fmPost
 
+logger = logging.getLogger(__name__)
+
 # Lazy import compatibility wrapper to avoid broken frontmatter package conflicts
 _frontmatter = None
 
@@ -1752,9 +1754,7 @@ def update_cache(
             return merged
     except OSError as e:
         # Log but don't crash - cache is non-critical
-        import sys
-
-        print(f"Warning: Could not update cache: {e}", file=sys.stderr)
+        logger.warning("Could not update cache: %s", e)
         return load_cache(cache_path)
 
 
@@ -1771,9 +1771,7 @@ def save_cache(cache_path: Path, cache: Dict[str, Any]) -> None:
             fcntl.flock(lock_file, fcntl.LOCK_EX)
             _write_cache_atomic(cache_path, cache)
     except OSError as e:
-        import sys
-
-        print(f"Warning: Could not save cache: {e}", file=sys.stderr)
+        logger.warning("Could not save cache: %s", e)
 
 
 def extract_external_urls(task: TaskInfo) -> List[str]:

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -10,7 +10,6 @@ This module contains:
 
 from __future__ import annotations
 
-import fcntl
 import json
 import logging
 import os
@@ -18,6 +17,14 @@ import re
 import subprocess
 import tempfile
 import warnings
+
+try:
+    import fcntl as _fcntl
+
+    _HAVE_FLOCK = True
+except ImportError:
+    _HAVE_FLOCK = False
+
 from dataclasses import dataclass, field
 from datetime import date, datetime, time, timedelta
 from pathlib import Path
@@ -1745,7 +1752,8 @@ def update_cache(
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     try:
         with open(lock_path, "a+") as lock_file:
-            fcntl.flock(lock_file, fcntl.LOCK_EX)
+            if _HAVE_FLOCK:
+                _fcntl.flock(lock_file, _fcntl.LOCK_EX)
             merged = load_cache(cache_path)
             for key in remove or set():
                 merged.pop(key, None)
@@ -1768,7 +1776,8 @@ def save_cache(cache_path: Path, cache: Dict[str, Any]) -> None:
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     try:
         with open(lock_path, "a+") as lock_file:
-            fcntl.flock(lock_file, fcntl.LOCK_EX)
+            if _HAVE_FLOCK:
+                _fcntl.flock(lock_file, _fcntl.LOCK_EX)
             _write_cache_atomic(cache_path, cache)
     except OSError as e:
         logger.warning("Could not save cache: %s", e)

--- a/packages/gptodo/tests/test_cache_concurrency.py
+++ b/packages/gptodo/tests/test_cache_concurrency.py
@@ -1,0 +1,39 @@
+"""Regression tests for concurrent issue-cache updates."""
+
+from __future__ import annotations
+
+import multiprocessing
+from pathlib import Path
+
+from gptodo.utils import load_cache, save_cache, update_cache
+
+
+def _update(cache_path: str, key: str) -> None:
+    update_cache(Path(cache_path), {key: {"state": "open"}})
+
+
+def test_update_cache_preserves_concurrent_updates(tmp_path: Path) -> None:
+    cache_path = tmp_path / "state" / "issue-cache.json"
+    processes = [
+        multiprocessing.Process(target=_update, args=(str(cache_path), key))
+        for key in ("first", "second", "third")
+    ]
+
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=5)
+        assert process.exitcode == 0
+
+    assert set(load_cache(cache_path)) == {"first", "second", "third"}
+
+
+def test_update_cache_applies_remove_and_update_in_one_transaction(tmp_path: Path) -> None:
+    cache_path = tmp_path / "state" / "issue-cache.json"
+    save_cache(cache_path, {"remove": 1, "keep": 2})
+
+    merged = update_cache(cache_path, {"add": 3}, remove={"remove"})
+
+    assert merged == {"keep": 2, "add": 3}
+    assert load_cache(cache_path) == merged
+    assert list(cache_path.parent.glob(f".{cache_path.name}.*.tmp")) == []


### PR DESCRIPTION
## Summary

- serialize each gptmail folder's full sync-state read/scan/write transaction with the existing `FileLock`
- atomically replace gptmail sync state so interrupted writes cannot expose partial JSON
- add a sidecar-locked `gptodo.update_cache` delta transaction and migrate cache-mutating CLI paths so concurrent fetch/sync processes preserve unrelated entries
- add multiprocessing regressions for both writer races

## Why

Concurrent `gptmail sync-maildir` processes could load the same processed-file set and overwrite one another after a full mailbox scan. Concurrent `gptodo fetch` / `sync` invocations had the same lost-update window despite atomic replacement: each process replaced the whole issue cache from its own stale snapshot.

The gptmail lock deliberately spans the scan because pruning and the final processed set form one transaction. The gptodo helper locks only the short reload/merge/replace section, keeping network fetches outside the critical section.

## Verification

- `153 passed` — full gptmail test suite
- `353 passed` — full gptodo test suite
- mypy clean for gptmail (32 source files) and gptodo (16 source files)
- ruff check + format check clean on changed files
- repo pre-commit hooks passed
- PR quality gate: 100/100
