### PR TITLE
fix(twitter): pipe Claude prompts through stdin

### DIFF
--- a/scripts/twitter/llm.py
+++ b/scripts/twitter/llm.py
@@ -546,7 +546,7 @@ def _reply_with_cc_subprocess(messages: list[Message], model_name: str) -> Messa
         cc_model = cc_model[len("anthropic/") :]
     try:
         result = subprocess.run(
-            ["claude", "-p", "--no-session-persistence", "--model", cc_model, "-"],
+            ["claude", "-p", "--no-session-persistence", "--model", cc_model],
             input=prompt,
             capture_output=True,
             text=True,

--- a/scripts/twitter/llm.py
+++ b/scripts/twitter/llm.py
@@ -546,7 +546,8 @@ def _reply_with_cc_subprocess(messages: list[Message], model_name: str) -> Messa
         cc_model = cc_model[len("anthropic/") :]
     try:
         result = subprocess.run(
-            ["claude", "-p", "--no-session-persistence", "--model", cc_model, prompt],
+            ["claude", "-p", "--no-session-persistence", "--model", cc_model, "-"],
+            input=prompt,
             capture_output=True,
             text=True,
             env=env,

--- a/tests/test_twitter_eval_prompt.py
+++ b/tests/test_twitter_eval_prompt.py
@@ -466,10 +466,12 @@ def test_reply_with_cc_subprocess_success(
     # llm.py strips "anthropic/" prefix before passing to the claude CLI
     assert "claude-sonnet-4-5" in cmd
     assert "anthropic/claude-sonnet-4-5" not in cmd
-    # Combined prompt must contain both system and user parts
-    prompt_arg = cmd[-1]
-    assert "You are a helpful agent." in prompt_arg
-    assert "Review this tweet." in prompt_arg
+    # The prompt must travel over stdin rather than argv: real timeline context can
+    # exceed Linux's per-argument limit and fail before Claude starts.
+    assert cmd[-1] == "-"
+    prompt_input = run_calls[0]["kwargs"]["input"]
+    assert "You are a helpful agent." in prompt_input
+    assert "Review this tweet." in prompt_input
 
 
 def test_our_handle_in_thread_context_triggers_identity_note(

--- a/tests/test_twitter_eval_prompt.py
+++ b/tests/test_twitter_eval_prompt.py
@@ -467,8 +467,15 @@ def test_reply_with_cc_subprocess_success(
     assert "claude-sonnet-4-5" in cmd
     assert "anthropic/claude-sonnet-4-5" not in cmd
     # The prompt must travel over stdin rather than argv: real timeline context can
-    # exceed Linux's per-argument limit and fail before Claude starts.
-    assert cmd[-1] == "-"
+    # exceed Linux's per-argument limit and fail before Claude starts. With no
+    # positional prompt, `claude -p` reads stdin; a positional "-" is ambiguous.
+    assert cmd == [
+        "claude",
+        "-p",
+        "--no-session-persistence",
+        "--model",
+        "claude-sonnet-4-5",
+    ]
     prompt_input = run_calls[0]["kwargs"]["input"]
     assert "You are a helpful agent." in prompt_input
     assert "Review this tweet." in prompt_input


### PR DESCRIPTION
## Problem

The Twitter loop passes the complete timeline/thread context as one positional argument to `claude -p`. A sufficiently large context exceeds Linux's per-argument limit, so process creation fails with `OSError: [Errno 7] Argument list too long` before Claude can evaluate the tweet. This happened in the live loop on 2026-07-21.

## Fix

Omit the positional prompt and send the assembled prompt via subprocess stdin instead. `claude -p` reads stdin when no prompt argument is supplied. This preserves the prompt unchanged without consuming argv space.

## Verification

- `uv run pytest tests/test_twitter_eval_prompt.py -q` (17 passed)
- `uv run ruff check scripts/twitter/llm.py tests/test_twitter_eval_prompt.py`
- `uv run ruff format --check scripts/twitter/llm.py tests/test_twitter_eval_prompt.py`
- Regression test asserts prompt content is supplied via `input=` and no positional prompt is present.

## Review follow-up

Addressed Greptile's concern about a literal `-`: commit `04903d17` removes it and tests the exact argv shape.