### PR TITLE
fix(activity-gate): emit first-seen notification threads when state is established

### DIFF
--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -1218,10 +1218,25 @@ check_notifications() {
 
     # Cap emitted notifications per run to avoid flooding the dispatcher when
     # a filter change (e.g. adding new reasons) unlocks a large backlog.
-    # First-seen notifications are always seeded (state written, not emitted).
-    # The cap only gates emit-eligible items (strictly-newer updated_at): those
-    # skipped by the cap get neither emitted nor persisted, so they retry next run.
+    # The cap only gates emit-eligible items: those skipped by the cap get
+    # neither emitted nor persisted, so they retry next run.
     local max_notif_per_run=5
+
+    # Established-state detection: seed-on-first-sight (record without emitting)
+    # is only correct when the notification state itself is fresh — first run,
+    # or recovery after the state dir was reset/wiped. Once ANY notif-*.state
+    # exists, the state is established, and a thread with no prior state file is
+    # a genuinely NEW notification thread (e.g. a maintainer @-mentioning AUTHOR
+    # on a third-party PR for the first time). Silently seeding those swallows
+    # the mention forever: the seed records the current updated_at, so the item
+    # never becomes emit-eligible unless the thread is updated AGAIN. Incident:
+    # ActivityWatch/aw-watcher-afk#82 (2026-07-22) — Erik's follow-up-PR request
+    # was seeded, promoted, and never dispatched. With established state,
+    # first-seen threads are emit-eligible (still subject to the cap above).
+    local _notif_state_established=0
+    if compgen -G "$STATE_DIR/notif-*.state" > /dev/null; then
+        _notif_state_established=1
+    fi
 
     # Notification state files store the most recently seen `updated_at`. GitHub
     # re-uses the same notification ID across follow-up comments on the same
@@ -1245,17 +1260,18 @@ check_notifications() {
             state_file="$STATE_DIR/notif-${notif_id}.state"
             prior=""
             [ -f "$state_file" ] && prior=$(cat "$state_file" 2>/dev/null || true)
-            # Seed-on-first-sight: when there's no prior state (first run, or after the
-            # state dir is reset/cleaned), record the timestamp but do NOT emit. This
-            # matches the documented contract ("On first run, all items are seeded but
-            # NOT reported") and every other check here (check_pr_updates,
-            # check_greptile_scores). Without it, a wiped state dir makes the whole
-            # unread backlog look "new" and fires a noop session investigating already-
-            # resolved threads. Only a strictly-newer updated_at (genuine follow-up
-            # activity) emits. String comparison works on ISO-8601 timestamps.
-            if [ -z "$prior" ]; then
+            # Seed-on-first-sight applies ONLY to a fresh state dir (first run, or
+            # after the state dir is reset/cleaned): record the timestamp but do NOT
+            # emit, matching the documented contract ("On first run, all items are
+            # seeded but NOT reported") — without it, a wiped state dir makes the
+            # whole unread backlog look "new" and fires a noop session investigating
+            # already-resolved threads. With established state (see
+            # _notif_state_established above), a first-seen thread is genuinely new
+            # activity and emits like a strictly-newer updated_at. String comparison
+            # works on ISO-8601 timestamps.
+            if [ -z "$prior" ] && [ "$_notif_state_established" -eq 0 ]; then
                 printf '%s' "$notif_updated" > "$state_file"
-            elif [ "$prior" \< "$notif_updated" ]; then
+            elif [ -z "$prior" ] || [ "$prior" \< "$notif_updated" ]; then
                 _notif_emitted=$((_notif_emitted + 1))
                 if [ "$_notif_emitted" -le "$max_notif_per_run" ]; then
                     # Emit first so a jq failure leaves the state file untouched and the
@@ -1275,12 +1291,14 @@ check_notifications() {
             state_file="$STATE_DIR/notif-${notif_id}.state"
             prior=""
             [ -f "$state_file" ] && prior=$(cat "$state_file" 2>/dev/null || true)
-            # Seed-on-first-sight (see jsonl branch above for rationale): a first-seen
-            # notification is recorded but not counted, so a reset state dir doesn't
-            # report the whole unread backlog as "new" and trigger a noop session.
-            if [ -z "$prior" ]; then
+            # Seed-on-first-sight applies only to a fresh state dir (see jsonl
+            # branch above for rationale): recorded but not counted, so a reset
+            # state dir doesn't report the whole unread backlog as "new" and
+            # trigger a noop session. With established state, first-seen threads
+            # count as new activity.
+            if [ -z "$prior" ] && [ "$_notif_state_established" -eq 0 ]; then
                 printf '%s' "$notif_updated" > "$state_file"
-            elif [ "$prior" \< "$notif_updated" ]; then
+            elif [ -z "$prior" ] || [ "$prior" \< "$notif_updated" ]; then
                 printf '%s' "$notif_updated" > "$state_file"
                 new_count=$((new_count + 1))
             fi

--- a/tests/test_activity_gate_notif_followup.py
+++ b/tests/test_activity_gate_notif_followup.py
@@ -141,14 +141,14 @@ def _emitted_notifications(stdout: str) -> list[dict]:
 
 
 def test_first_sight_seeds_state_without_emitting() -> None:
-    """First sight of a notification seeds state but does NOT emit.
+    """First sight with a FRESH state dir seeds state but does NOT emit.
 
     This matches the documented contract ("On first run, all items are seeded
     but NOT reported") — without it, a wiped state dir makes the whole unread
     backlog look "new" and fires a noop session on already-resolved threads.
-    (This test previously asserted the pre-seeding behaviour — first sight
-    emitting — and went stale when check_notifications adopted
-    seed-on-first-sight; the suite does not run in CI, so it rotted silently.)
+    Scope: seed-on-first-sight applies only when NO notif-*.state exists (fresh
+    state dir / reset recovery); see
+    test_first_seen_thread_emits_when_state_established for the established case.
     """
     with tempfile.TemporaryDirectory() as tmp_str:
         tmp = Path(tmp_str)
@@ -166,6 +166,38 @@ def test_first_sight_seeds_state_without_emitting() -> None:
         state_file = state_dir / f"notif-{NOTIF_ID}.state"
         assert state_file.exists()
         # State records the timestamp, not just presence.
+        assert state_file.read_text().strip() == "2026-04-29T20:40:00Z"
+
+
+def test_first_seen_thread_emits_when_state_established() -> None:
+    """A first-seen thread EMITS when the notification state dir is established.
+
+    Regression for ActivityWatch/aw-watcher-afk#82 (2026-07-22): Erik
+    @-mentioned the bot on a third-party PR the bot had never been notified
+    about. Seed-on-first-sight recorded the mention's updated_at without
+    emitting, so the item never became emit-eligible and the request was
+    silently swallowed. With any other notif-*.state present, a state-file-less
+    thread is genuinely new activity, not reset-recovery backlog.
+    """
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+
+        # An unrelated, previously-seen notification thread establishes state.
+        (state_dir / "notif-99999999999.state").write_text("2026-04-01T00:00:00Z")
+
+        result = _run_gate(tmp, state_dir, "2026-04-29T20:40:00Z")
+        assert result.returncode in (0, 1), result.stderr
+
+        emitted = _emitted_notifications(result.stdout)
+        assert len(emitted) == 1, (
+            "first-seen thread with established state must emit; got: " f"{emitted}"
+        )
+        assert emitted[0]["number"] == NOTIF_NUMBER
+
+        # Emit-before-persist: state rolled forward to the seen timestamp.
+        state_file = state_dir / f"notif-{NOTIF_ID}.state"
         assert state_file.read_text().strip() == "2026-04-29T20:40:00Z"
 
 


### PR DESCRIPTION
## Problem

Erik's merge comment on ActivityWatch/aw-watcher-afk#82 (2026-07-22 07:54 UTC) @-mentioned `@TimeToBuildBob` asking for a follow-up PR addressing Greptile P2s — and project monitoring never reacted.

Root cause: `check_notifications` in `activity-gate.sh` applies **seed-on-first-sight** (record `updated_at` without emitting) to *every* notification thread that has no prior state file — not just to fresh/reset state dirs. For a genuinely new thread (a maintainer mentioning the bot on a third-party PR the bot never interacted with), the seed records the mention's `updated_at`, the PM end-of-cycle bulk promotion persists it, and the item never becomes emit-eligible unless the thread is updated *again*. The mention is silently swallowed forever.

Verified from the live incident: thread `24081413265` was seeded at `2026-07-22T07:54:33Z` on the first scan after a rate-limit window (08:58), promoted to the real state dir (mtime 09:35:43), and never appeared in any dispatch — while same-minute mention notifications on threads with *established* prior state (e.g. gptme#3283 at 09:10, ErikBjare/bob#1021 at 09:21) emitted correctly.

## Fix

Compute `_notif_state_established` (any `notif-*.state` present in the state dir) once per run:

- **Fresh state dir** (first run / reset recovery): unchanged — seed everything silently. The documented noop-flood protection contract is preserved.
- **Established state dir**: a first-seen thread is genuinely new activity and becomes emit-eligible exactly like a strictly-newer `updated_at`, still subject to `max_notif_per_run` (cap-skipped items stay unpersisted and retry next run).

Both the jsonl and markdown-count branches are updated symmetrically.

## Tests

- `test_first_seen_thread_emits_when_state_established` (new regression test for the incident)
- Existing seed-on-first-sight test scoped to the fresh-dir contract; all 5 tests in `test_activity_gate_notif_followup.py` pass.
- `shellcheck scripts/github/activity-gate.sh` clean.
