### PR TITLE
feat(worker-records): PM worker outcome subtype detection (ship/engage/observe)

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/worker_records.py
+++ b/packages/gptme-runloops/src/gptme_runloops/worker_records.py
@@ -107,15 +107,47 @@ KNOWN_DELIVERY_OUTCOMES: frozenset[str] = frozenset(
 #   - Command-gate ship/engage: match the CLI command input, not output text.
 #   - ship takes priority over engage; both take priority over observe.
 
+# Match only a command position: start of a shell segment, optionally following
+# common wrappers (``env X=...`` / assignments). This deliberately does not
+# match command names inside quoted arguments, comments, or search patterns.
+_WORKER_CMD_PREFIX = r"(?:^|[;&|]\s*)(?:env\s+)?(?:[A-Za-z_]\w*=\S+\s+)*"
+
 # Ship: create or merge a PR (permanently changes repo state).
-_WORKER_SHIP_CMD_RE = re.compile(r"\bgh\s+pr\s+(?:create|merge)\b")
+_WORKER_SHIP_CMD_RE = re.compile(
+    _WORKER_CMD_PREFIX + r"gh\s+pr\s+(?:create|merge)\b", re.MULTILINE
+)
 
 # Engage: push code or post a comment/review (mutating but lower-value than ship).
 _WORKER_ENGAGE_CMD_RE = re.compile(
-    r"\bgit\s+push\b"
-    r"|\bgh\s+(?:pr|issue)\s+(?:comment|review)\b"
-    r"|\bgh\s+api\s+repos/[^\s]+/(?:pulls|issues)/\d+/(?:comments|reviews)\b"
+    _WORKER_CMD_PREFIX + r"(?:git\s+push\b"
+    r"|gh\s+(?:pr|issue)\s+(?:comment|review)\b"
+    r"|gh\s+api\s+repos/[^\s]+/(?:pulls|issues)/\d+/(?:comments|reviews)\b)",
+    re.MULTILINE,
 )
+
+
+def _iter_json_objects(text: str, start: int) -> Iterator[dict[str, Any]]:
+    """Yield adjacent JSON objects from ``text`` beginning at ``start``.
+
+    ``JSONDecoder.raw_decode`` understands braces nested inside objects and
+    quoted strings, unlike a regular expression ending at the first ``}``.
+    The caller invokes this at each AT-tool marker, so adjacent calls are
+    decoded independently.
+    """
+    decoder = json.JSONDecoder()
+    cursor = start
+    while cursor < len(text):
+        while cursor < len(text) and text[cursor].isspace():
+            cursor += 1
+        if cursor >= len(text) or text[cursor] != "{":
+            return
+        try:
+            value, end = decoder.raw_decode(text, cursor)
+        except json.JSONDecodeError:
+            return
+        if isinstance(value, dict):
+            yield value
+        cursor = end
 
 
 def _iter_bash_commands(lines: Iterable[str]) -> Iterator[str]:
@@ -130,7 +162,7 @@ def _iter_bash_commands(lines: Iterable[str]) -> Iterator[str]:
     Skips system, user, and result records to avoid false positives from
     injected prompt text (CLAUDE.md, lessons, system prompts).
     """
-    _at_tool_re = re.compile(r"@(?:shell|bash)\([^)]+\):\s*(\{[^}]*\})", re.DOTALL)
+    _at_tool_re = re.compile(r"@(?:shell|bash)\([^)]+\):\s*", re.DOTALL)
     _fence_re = re.compile(r"```(?:bash|sh)\n(.*?)\n```", re.DOTALL)
 
     for raw in lines:
@@ -151,9 +183,12 @@ def _iter_bash_commands(lines: Iterable[str]) -> Iterator[str]:
                 if not isinstance(item, dict):
                     continue
                 if item.get("type") == "tool_use" and item.get("name") == "Bash":
-                    cmd = item.get("input", {}).get("command", "")
+                    args = item.get("input", {})
+                    if not isinstance(args, dict):
+                        continue
+                    cmd = args.get("command") or args.get("code") or args.get("cmd", "")
                     if cmd:
-                        yield cmd
+                        yield str(cmd)
 
         # gptme format: role='assistant', content is a string with embedded tool calls.
         elif entry.get("role") == "assistant":
@@ -162,13 +197,12 @@ def _iter_bash_commands(lines: Iterable[str]) -> Iterator[str]:
                 continue
             # AT-format: @shell(call_id): {"command": "..."}
             for m in _at_tool_re.finditer(content):
-                try:
-                    args = json.loads(m.group(1))
-                    cmd = args.get("command") or args.get("code") or args.get("cmd", "")
-                    if cmd:
-                        yield str(cmd)
-                except json.JSONDecodeError:
-                    pass
+                args = next(_iter_json_objects(content, m.end()), None)
+                if args is None:
+                    continue
+                cmd = args.get("command") or args.get("code") or args.get("cmd", "")
+                if cmd:
+                    yield str(cmd)
             # Fence-format: ```bash\n...\n```
             for m in _fence_re.finditer(content):
                 yield m.group(1)
@@ -629,8 +663,12 @@ def update_record_pr_state(
             return
 
         apply_pr_state_diff(payload, before, after)
+        outcome_before_upgrade = payload.get("outcome")
         if upgrade_outcome is not None:
             upgrade_outcome(payload)
+        if outcome_before_upgrade != payload.get("outcome"):
+            trajectory = resolve_trajectory(str(payload.get("trajectory_path") or ""))
+            augment_with_outcome_subtype(payload, trajectory)
         _write_record(record_path, payload)
 
 

--- a/packages/gptme-runloops/src/gptme_runloops/worker_records.py
+++ b/packages/gptme-runloops/src/gptme_runloops/worker_records.py
@@ -75,7 +75,7 @@ from __future__ import annotations
 import json
 import re
 import subprocess
-from collections.abc import Callable, Iterable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -92,6 +92,127 @@ COMMIT_OID_RE = re.compile(r"\b[0-9a-f]{7,40}\b", re.IGNORECASE)
 KNOWN_DELIVERY_OUTCOMES: frozenset[str] = frozenset(
     {"handled", "orphan_no_delivery", "no_action_needed", "failed"}
 )
+
+# --- PM worker outcome subtype detection ---
+#
+# Subtypes classify the mutating level of a PM worker pass:
+#   ship    — created or merged a PR (highest mutating signal)
+#   engage  — pushed code, posted a comment/review (lower mutating signal)
+#   observe — read-only pass; no mutating commands detected
+#
+# Rules:
+#   - Only inspect agent-authored entries (CC type='assistant' or gptme
+#     role='assistant'). Never scan whole-file text or injected prompt text
+#     (see lessons/infrastructure/trajectory-predicate-prompt-text-leak.md).
+#   - Command-gate ship/engage: match the CLI command input, not output text.
+#   - ship takes priority over engage; both take priority over observe.
+
+# Ship: create or merge a PR (permanently changes repo state).
+_WORKER_SHIP_CMD_RE = re.compile(r"\bgh\s+pr\s+(?:create|merge)\b")
+
+# Engage: push code or post a comment/review (mutating but lower-value than ship).
+_WORKER_ENGAGE_CMD_RE = re.compile(
+    r"\bgit\s+push\b"
+    r"|\bgh\s+(?:pr|issue)\s+(?:comment|review)\b"
+    r"|\bgh\s+api\s+repos/[^\s]+/(?:pulls|issues)/\d+/(?:comments|reviews)\b"
+)
+
+
+def _iter_bash_commands(lines: Iterable[str]) -> Iterator[str]:
+    """Yield Bash command strings from agent-authored trajectory entries only.
+
+    Handles two trajectory formats:
+    - CC (Claude Code): ``type='assistant'`` records whose ``message.content``
+      contains ``type='tool_use'`` blocks with ``name='Bash'``.
+    - gptme: ``role='assistant'`` records whose ``content`` string embeds tool
+      calls as ``@shell(id): {"command": "..."}`` or `` ```bash\\n...\\n``` ``.
+
+    Skips system, user, and result records to avoid false positives from
+    injected prompt text (CLAUDE.md, lessons, system prompts).
+    """
+    _at_tool_re = re.compile(r"@(?:shell|bash)\([^)]+\):\s*(\{[^}]*\})", re.DOTALL)
+    _fence_re = re.compile(r"```(?:bash|sh)\n(.*?)\n```", re.DOTALL)
+
+    for raw in lines:
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            entry = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+
+        # CC format: type='assistant', message.content is a list of content blocks.
+        if entry.get("type") == "assistant":
+            content = entry.get("message", {}).get("content", [])
+            if not isinstance(content, list):
+                continue
+            for item in content:
+                if not isinstance(item, dict):
+                    continue
+                if item.get("type") == "tool_use" and item.get("name") == "Bash":
+                    cmd = item.get("input", {}).get("command", "")
+                    if cmd:
+                        yield cmd
+
+        # gptme format: role='assistant', content is a string with embedded tool calls.
+        elif entry.get("role") == "assistant":
+            content = entry.get("content", "")
+            if not isinstance(content, str):
+                continue
+            # AT-format: @shell(call_id): {"command": "..."}
+            for m in _at_tool_re.finditer(content):
+                try:
+                    args = json.loads(m.group(1))
+                    cmd = args.get("command") or args.get("code") or args.get("cmd", "")
+                    if cmd:
+                        yield str(cmd)
+                except json.JSONDecodeError:
+                    pass
+            # Fence-format: ```bash\n...\n```
+            for m in _fence_re.finditer(content):
+                yield m.group(1)
+
+
+def detect_worker_outcome_subtype(trajectory: Path | None) -> str:
+    """Derive a PM worker outcome subtype from executed Bash commands.
+
+    Returns one of:
+    - ``"ship"``    — executed ``gh pr create`` or ``gh pr merge``
+    - ``"engage"``  — pushed code or posted a PR/issue comment/review
+    - ``"observe"`` — no mutating commands detected (read-only pass)
+
+    Only inspects agent-authored trajectory entries to avoid false positives
+    from injected prompt text. Returns ``"observe"`` when no trajectory is
+    provided or it cannot be read.
+    """
+    if trajectory is None or not trajectory.is_file():
+        return "observe"
+    has_engage = False
+    try:
+        with trajectory.open(encoding="utf-8", errors="replace") as fh:
+            for cmd in _iter_bash_commands(fh):
+                if _WORKER_SHIP_CMD_RE.search(cmd):
+                    return "ship"
+                if _WORKER_ENGAGE_CMD_RE.search(cmd):
+                    has_engage = True
+    except OSError:
+        return "observe"
+    return "engage" if has_engage else "observe"
+
+
+def augment_with_outcome_subtype(
+    payload: dict[str, Any],
+    trajectory: Path | None,
+) -> dict[str, Any]:
+    """Add ``outcome_subtype`` to a PM session record when outcome is productive.
+
+    Only annotates ``outcome='productive'`` records — failed, noop, and unknown
+    outcomes get no subtype. Mutates and returns ``payload``.
+    """
+    if str(payload.get("outcome") or "").strip().lower() == "productive":
+        payload["outcome_subtype"] = detect_worker_outcome_subtype(trajectory)
+    return payload
 
 
 # --- CC rate-limit log parsing (worker.sh:110-127) ---
@@ -242,6 +363,7 @@ def write_post_session_record(
     record = finalize_post_session_record(
         result.record.to_dict(), result.grade, item_timeout
     )
+    augment_with_outcome_subtype(record, trajectory)
     with locked_state_file(record_path):
         _write_record(record_path, record)
 
@@ -327,6 +449,7 @@ def write_fallback_session_record(
         item_timeout=item_timeout,
         trajectory=trajectory,
     )
+    augment_with_outcome_subtype(payload, trajectory)
     with locked_state_file(record_path):
         _write_record(record_path, payload)
 

--- a/packages/gptme-runloops/tests/test_worker_records.py
+++ b/packages/gptme-runloops/tests/test_worker_records.py
@@ -38,6 +38,7 @@ from typing import Any
 
 import pytest
 from gptme_runloops.worker_records import (
+    _iter_bash_commands,
     append_wait_merge_gate_log,
     append_worker_latency_records,
     apply_pr_state_diff,
@@ -338,7 +339,10 @@ def test_pr_state_diff_golden(case: dict[str, Any], ws: Path) -> None:
         fetch=lambda repo, num: fetch_pr_snapshot(repo, num, cwd=ws, runner=runner),
         upgrade_outcome=stub_upgrade_outcome if case["upgrade_hook"] else None,
     )
-    assert json.loads(record_file.read_text()) == subst(case["expected_record"], ws)
+    expected = subst(case["expected_record"], ws)
+    if case["name"] == "upgrade_hook_present":
+        expected["outcome_subtype"] = "observe"
+    assert json.loads(record_file.read_text()) == expected
 
 
 # --- Golden: worker-result manifest (worker.sh:505-627) ---
@@ -793,7 +797,7 @@ def _traj(tmp_path: Path, name: str, lines: list[str]) -> Path:
     return p
 
 
-def _cc_bash(cmd: str) -> str:
+def _cc_bash(cmd: str, *, input_key: str = "command") -> str:
     """One CC-format assistant entry whose Bash tool_use runs ``cmd``."""
     return json.dumps(
         {
@@ -803,7 +807,7 @@ def _cc_bash(cmd: str) -> str:
                     {
                         "type": "tool_use",
                         "name": "Bash",
-                        "input": {"command": cmd},
+                        "input": {input_key: cmd},
                     }
                 ]
             },
@@ -914,6 +918,53 @@ def test_detect_subtype_gptme_at_format(tmp_path: Path) -> None:
     assert detect_worker_outcome_subtype(traj) == "ship"
 
 
+def test_detect_subtype_gptme_at_format_preserves_nested_json(tmp_path: Path) -> None:
+    cmd = 'gh api repos/o/r/issues/1/comments -f \'body={"body":"LGTM"}\''
+    traj = _traj(tmp_path, "nested.jsonl", [_gptme_bash_at(cmd)])
+    assert detect_worker_outcome_subtype(traj) == "engage"
+
+
+def test_iter_bash_commands_reads_adjacent_gptme_calls() -> None:
+    first = _gptme_bash_at("git push origin HEAD")
+    second = _gptme_bash_at("gh pr create --title x")
+    content = json.loads(first)["content"] + "\n" + json.loads(second)["content"]
+    entry = json.dumps({"role": "assistant", "content": content})
+    assert list(_iter_bash_commands([entry])) == [
+        "git push origin HEAD",
+        "gh pr create --title x",
+    ]
+
+
+def test_detect_subtype_cc_alternate_input_keys(tmp_path: Path) -> None:
+    for key in ("code", "cmd"):
+        traj = _traj(
+            tmp_path, f"{key}.jsonl", [_cc_bash("git push origin HEAD", input_key=key)]
+        )
+        assert detect_worker_outcome_subtype(traj) == "engage"
+
+
+def test_detect_subtype_ignores_mutation_text_used_as_data(tmp_path: Path) -> None:
+    traj = _traj(
+        tmp_path,
+        "mentions.jsonl",
+        [
+            _cc_bash("rg 'git push' README.md"),
+            _cc_bash("printf '%s' 'gh pr create'"),
+            _cc_bash("# gh pr merge 12 --squash\ngit log -1"),
+        ],
+    )
+    assert detect_worker_outcome_subtype(traj) == "observe"
+
+
+def test_detect_subtype_matches_mutation_after_shell_prefixes(tmp_path: Path) -> None:
+    traj = _traj(
+        tmp_path,
+        "prefixes.jsonl",
+        [_cc_bash("cd /tmp/repo && env GH_DEBUG=0 gh pr create --title x")],
+    )
+    assert detect_worker_outcome_subtype(traj) == "ship"
+
+
 def test_detect_subtype_gptme_fence_format_engage(tmp_path: Path) -> None:
     traj = _traj(tmp_path, "fence.jsonl", [_gptme_bash_fence("git push origin HEAD")])
     assert detect_worker_outcome_subtype(traj) == "engage"
@@ -963,3 +1014,28 @@ def test_augment_observe_when_no_trajectory() -> None:
     payload: dict[str, Any] = {"outcome": "productive"}
     augment_with_outcome_subtype(payload, None)
     assert payload["outcome_subtype"] == "observe"
+
+
+def test_update_record_pr_state_adds_subtype_after_productive_upgrade(
+    ws: Path,
+) -> None:
+    trajectory = _traj(ws, "upgrade.jsonl", [_cc_bash("git push origin HEAD")])
+    record = ws / "records" / "upgrade.json"
+    record.parent.mkdir(parents=True, exist_ok=True)
+    record.write_text(
+        json.dumps({"outcome": "unknown", "trajectory_path": str(trajectory)})
+    )
+
+    update_record_pr_state(
+        record,
+        repo="gptme/gptme",
+        number=1,
+        before_json=json.dumps({"state": "OPEN"}),
+        cwd=ws,
+        fetch=lambda repo, number: {"state": "MERGED"},
+        upgrade_outcome=stub_upgrade_outcome,
+    )
+
+    payload = json.loads(record.read_text())
+    assert payload["outcome"] == "productive"
+    assert payload["outcome_subtype"] == "engage"

--- a/packages/gptme-runloops/tests/test_worker_records.py
+++ b/packages/gptme-runloops/tests/test_worker_records.py
@@ -42,10 +42,12 @@ from gptme_runloops.worker_records import (
     append_worker_latency_records,
     apply_pr_state_diff,
     apply_worker_result_to_payload,
+    augment_with_outcome_subtype,
     build_wait_merge_gate_entry,
     collect_commit_oids,
     compute_latency_outcome,
     dedupe_deliverables,
+    detect_worker_outcome_subtype,
     extract_delivery_field,
     fallback_outcome,
     fetch_pr_snapshot,
@@ -777,3 +779,187 @@ def test_parse_latency_inputs_defaults() -> None:
     assert ack is None
     with pytest.raises(json.JSONDecodeError):
         parse_latency_inputs("", "", "")
+
+
+# ---------------------------------------------------------------------------
+# detect_worker_outcome_subtype / augment_with_outcome_subtype
+# ---------------------------------------------------------------------------
+
+
+def _traj(tmp_path: Path, name: str, lines: list[str]) -> Path:
+    """Write a trajectory JSONL fixture and return its path."""
+    p = tmp_path / name
+    p.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return p
+
+
+def _cc_bash(cmd: str) -> str:
+    """One CC-format assistant entry whose Bash tool_use runs ``cmd``."""
+    return json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "name": "Bash",
+                        "input": {"command": cmd},
+                    }
+                ]
+            },
+        }
+    )
+
+
+def _gptme_bash_at(cmd: str) -> str:
+    """One gptme-format assistant entry with AT-style tool call."""
+    return json.dumps(
+        {
+            "role": "assistant",
+            "content": f'@shell(abc123): {{"command": {json.dumps(cmd)}}}',
+        }
+    )
+
+
+def _gptme_bash_fence(cmd: str) -> str:
+    """One gptme-format assistant entry with fence-style bash block."""
+    return json.dumps(
+        {
+            "role": "assistant",
+            "content": f"```bash\n{cmd}\n```",
+        }
+    )
+
+
+def test_detect_subtype_no_trajectory() -> None:
+    assert detect_worker_outcome_subtype(None) == "observe"
+
+
+def test_detect_subtype_missing_file(tmp_path: Path) -> None:
+    assert detect_worker_outcome_subtype(tmp_path / "ghost.jsonl") == "observe"
+
+
+def test_detect_subtype_empty_trajectory(tmp_path: Path) -> None:
+    traj = _traj(tmp_path, "empty.jsonl", [])
+    assert detect_worker_outcome_subtype(traj) == "observe"
+
+
+def test_detect_subtype_cc_ship_pr_create(tmp_path: Path) -> None:
+    traj = _traj(
+        tmp_path, "ship.jsonl", [_cc_bash("gh pr create --title 'foo' --body 'bar'")]
+    )
+    assert detect_worker_outcome_subtype(traj) == "ship"
+
+
+def test_detect_subtype_cc_ship_pr_merge(tmp_path: Path) -> None:
+    traj = _traj(tmp_path, "merge.jsonl", [_cc_bash("gh pr merge 42 --squash")])
+    assert detect_worker_outcome_subtype(traj) == "ship"
+
+
+def test_detect_subtype_cc_engage_git_push(tmp_path: Path) -> None:
+    traj = _traj(tmp_path, "push.jsonl", [_cc_bash("git push origin HEAD")])
+    assert detect_worker_outcome_subtype(traj) == "engage"
+
+
+def test_detect_subtype_cc_engage_pr_comment(tmp_path: Path) -> None:
+    traj = _traj(
+        tmp_path, "comment.jsonl", [_cc_bash("gh pr comment 99 --body 'LGTM'")]
+    )
+    assert detect_worker_outcome_subtype(traj) == "engage"
+
+
+def test_detect_subtype_cc_engage_pr_review(tmp_path: Path) -> None:
+    traj = _traj(tmp_path, "review.jsonl", [_cc_bash("gh pr review 7 --approve")])
+    assert detect_worker_outcome_subtype(traj) == "engage"
+
+
+def test_detect_subtype_cc_engage_gh_api_comment(tmp_path: Path) -> None:
+    traj = _traj(
+        tmp_path,
+        "api_comment.jsonl",
+        [_cc_bash("gh api repos/owner/repo/pulls/5/comments -f body='fixed'")],
+    )
+    assert detect_worker_outcome_subtype(traj) == "engage"
+
+
+def test_detect_subtype_cc_observe_only(tmp_path: Path) -> None:
+    """Read-only commands (gh pr view, gh pr checks, git log) → observe."""
+    traj = _traj(
+        tmp_path,
+        "observe.jsonl",
+        [
+            _cc_bash("gh pr view 42 --json state"),
+            _cc_bash("gh pr checks 42"),
+            _cc_bash("git log --oneline -5"),
+        ],
+    )
+    assert detect_worker_outcome_subtype(traj) == "observe"
+
+
+def test_detect_subtype_ship_wins_over_engage(tmp_path: Path) -> None:
+    """When both engage and ship commands appear, ship wins (early return)."""
+    traj = _traj(
+        tmp_path,
+        "ship_over_engage.jsonl",
+        [
+            _cc_bash("git push origin HEAD"),  # engage
+            _cc_bash("gh pr create --title 'X'"),  # ship
+        ],
+    )
+    assert detect_worker_outcome_subtype(traj) == "ship"
+
+
+def test_detect_subtype_gptme_at_format(tmp_path: Path) -> None:
+    traj = _traj(tmp_path, "at.jsonl", [_gptme_bash_at("gh pr create --title 'y'")])
+    assert detect_worker_outcome_subtype(traj) == "ship"
+
+
+def test_detect_subtype_gptme_fence_format_engage(tmp_path: Path) -> None:
+    traj = _traj(tmp_path, "fence.jsonl", [_gptme_bash_fence("git push origin HEAD")])
+    assert detect_worker_outcome_subtype(traj) == "engage"
+
+
+def test_detect_subtype_skips_system_entries(tmp_path: Path) -> None:
+    """System-prompt / user entries that contain ship commands must not fire."""
+    system_entry = json.dumps(
+        {
+            "type": "system",
+            "message": {"content": "gh pr create --title 'ARCHITECTURE.md text'"},
+        }
+    )
+    user_entry = json.dumps(
+        {
+            "role": "user",
+            "content": "gh pr merge 1 --squash",
+        }
+    )
+    traj = _traj(
+        tmp_path,
+        "injected.jsonl",
+        [system_entry, user_entry, _cc_bash("git log --oneline -3")],
+    )
+    assert detect_worker_outcome_subtype(traj) == "observe"
+
+
+def test_augment_adds_subtype_for_productive(tmp_path: Path) -> None:
+    traj = _traj(tmp_path, "a.jsonl", [_cc_bash("gh pr merge 1 --squash")])
+    payload: dict[str, Any] = {"outcome": "productive", "session_id": "s1"}
+    result = augment_with_outcome_subtype(payload, traj)
+    assert result is payload  # mutates in place
+    assert result["outcome_subtype"] == "ship"
+
+
+def test_augment_skips_non_productive(tmp_path: Path) -> None:
+    traj = _traj(tmp_path, "b.jsonl", [_cc_bash("gh pr merge 1 --squash")])
+    for outcome in ("failed", "unknown", "noop", ""):
+        payload: dict[str, Any] = {"outcome": outcome}
+        augment_with_outcome_subtype(payload, traj)
+        assert (
+            "outcome_subtype" not in payload
+        ), f"should not annotate outcome={outcome!r}"
+
+
+def test_augment_observe_when_no_trajectory() -> None:
+    payload: dict[str, Any] = {"outcome": "productive"}
+    augment_with_outcome_subtype(payload, None)
+    assert payload["outcome_subtype"] == "observe"


### PR DESCRIPTION
## Summary

- Adds `detect_worker_outcome_subtype(trajectory)` to `gptme_runloops.worker_records` — scans agent-authored trajectory entries (CC and gptme formats) for mutating Bash commands and returns `"ship"` / `"engage"` / `"observe"`
- Adds `augment_with_outcome_subtype(payload, trajectory)` — stamps `outcome_subtype` on any `outcome="productive"` session record
- Integrated into both `write_post_session_record` and `write_fallback_session_record`

**Why**: 81/121 PM workers in the 2026-07-21 audit were observe-only (read CI, took no action) yet all counted as `"productive"`, inflating the headline rate from ~43% (artifact-verified) to 90%. This adds the field so the brain-side dashboard can separate real shipping signal from passive monitoring passes.

**Safety**:
- Only inspects `type="assistant"` (CC) / `role="assistant"` (gptme) entries — never whole-file text or system/user injected prompt content — so CLAUDE.md, lessons, and ARCHITECTURE.md can never trigger a false `ship`/`engage` signal
- No retrograde contamination: existing records without the field are unaffected; the field is additive going forward only
- `outcome_subtype` is only set when `outcome="productive"`; failed/unknown/noop records are untouched

## Test plan

- [x] 17 new unit tests in `test_worker_records.py` covering: no/missing/empty trajectory, CC ship (create+merge), CC engage (push, pr comment, review, gh api), CC observe-only, ship-over-engage priority, gptme AT-format, gptme fence-format, system/user entry skip, augment productive/non-productive/no-trajectory cases
- [x] Full golden parity suite: 108/108 tests pass
- [x] `ruff check` clean
- [x] `mypy` clean

Closes part of ErikBjare/bob#pm-worker-outcome-split-observe (brain-side kpi.py follow-up to surface `pm_react_observe_rate` in dashboards is a separate brain-repo change).