### PR TITLE
fix(activity-gate): ignore non-push master runs

### DIFF
--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -694,26 +694,43 @@ check_assigned_issues() {
 # These indicate regressions that slipped through — not tied to any specific PR.
 check_master_ci() {
     local repo=$1
-    local runs
-    # Filter at the API boundary instead of fetching a small mixed-event window.
-    # Otherwise non-push runs can consume the limit and hide an older push run.
-    # An allowlist also avoids treating new non-push event types as regressions.
-    runs=$(gh_cache_get_or_fetch "run-master-push-${repo}" "$GH_CACHE_TTL_RUN" \
-        "gh run list --repo '$repo' --branch master --event push --limit 3 \
-            --json databaseId,name,conclusion,createdAt 2>/dev/null" \
+    local runs push_runs
+    runs=$(gh_cache_get_or_fetch "run-master-all-events-${repo}" "$GH_CACHE_TTL_RUN" \
+        "gh run list --repo '$repo' --branch master --limit 3 \
+            --json databaseId,name,conclusion,createdAt,event 2>/dev/null" \
         "[]")
-    # Also try 'main' if master returned no push runs.
+    # Fetch push runs separately so detached/manual runs cannot consume the
+    # mixed-event result window and hide a real branch regression.
+    push_runs=$(gh_cache_get_or_fetch "run-master-push-${repo}" "$GH_CACHE_TTL_RUN" \
+        "gh run list --repo '$repo' --branch master --event push --limit 3 \
+            --json databaseId,name,conclusion,createdAt,event 2>/dev/null" \
+        "[]")
+    runs=$(jq -cn --argjson recent "$runs" --argjson pushes "$push_runs" \
+        '$recent + $pushes | unique_by(.databaseId)')
+
+    # Also try 'main' if master returned nothing.
     if [ "$runs" = "[]" ]; then
-        runs=$(gh_cache_get_or_fetch "run-main-push-${repo}" "$GH_CACHE_TTL_RUN" \
-            "gh run list --repo '$repo' --branch main --event push --limit 3 \
-                --json databaseId,name,conclusion,createdAt 2>/dev/null" \
+        runs=$(gh_cache_get_or_fetch "run-main-all-events-${repo}" "$GH_CACHE_TTL_RUN" \
+            "gh run list --repo '$repo' --branch main --limit 3 \
+                --json databaseId,name,conclusion,createdAt,event 2>/dev/null" \
             "[]")
+        push_runs=$(gh_cache_get_or_fetch "run-main-push-${repo}" "$GH_CACHE_TTL_RUN" \
+            "gh run list --repo '$repo' --branch main --event push --limit 3 \
+                --json databaseId,name,conclusion,createdAt,event 2>/dev/null" \
+            "[]")
+        runs=$(jq -cn --argjson recent "$runs" --argjson pushes "$push_runs" \
+            '$recent + $pushes | unique_by(.databaseId)')
     fi
     [ "$runs" = "[]" ] || [ -z "$runs" ] && return 0
 
-    # Every returned run is push-triggered by construction.
+    # Only detached/manual failures are unrelated to default-branch health.
+    # Scheduled and reusable-workflow failures remain actionable: if those jobs
+    # start failing on the default branch, the workflows should be fixed.
     local failures
-    failures=$(echo "$runs" | jq -c '[.[] | select(.conclusion == "failure")]')
+    failures=$(echo "$runs" | jq -c '[.[] | select(
+        .conclusion == "failure"
+        and (.event as $event | ["workflow_dispatch", "repository_dispatch", "dynamic"] | index($event) | not)
+    )]')
     local fail_count
     fail_count=$(echo "$failures" | jq 'length')
     [ "$fail_count" -eq 0 ] && return 0

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -697,20 +697,27 @@ check_master_ci() {
     local runs
     runs=$(gh_cache_get_or_fetch "run-master-${repo}" "$GH_CACHE_TTL_RUN" \
         "gh run list --repo '$repo' --branch master --limit 3 \
-            --json databaseId,name,conclusion,createdAt 2>/dev/null" \
+            --json databaseId,name,conclusion,createdAt,event 2>/dev/null" \
         "[]")
     # Also try 'main' if master returned nothing
     if [ "$runs" = "[]" ]; then
         runs=$(gh_cache_get_or_fetch "run-main-${repo}" "$GH_CACHE_TTL_RUN" \
             "gh run list --repo '$repo' --branch main --limit 3 \
-                --json databaseId,name,conclusion,createdAt 2>/dev/null" \
+                --json databaseId,name,conclusion,createdAt,event 2>/dev/null" \
             "[]")
     fi
     [ "$runs" = "[]" ] || [ -z "$runs" ] && return 0
 
     # Check for any recent failures
     local failures
-    failures=$(echo "$runs" | jq -c '[.[] | select(.conclusion == "failure")]')
+    # Only branch-triggered failures represent a broken default branch. GitHub
+    # also associates manual, repository-dispatched, and Dependabot `dynamic`
+    # runs with master; those are independent jobs, not regressions from a push.
+    # Missing/unknown event values still fail open toward detection.
+    failures=$(echo "$runs" | jq -c '[.[] | select(
+        .conclusion == "failure"
+        and (.event as $event | ["workflow_dispatch", "repository_dispatch", "dynamic"] | index($event) | not)
+    )]')
     local fail_count
     fail_count=$(echo "$failures" | jq 'length')
     [ "$fail_count" -eq 0 ] && return 0

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -695,29 +695,25 @@ check_assigned_issues() {
 check_master_ci() {
     local repo=$1
     local runs
-    runs=$(gh_cache_get_or_fetch "run-master-${repo}" "$GH_CACHE_TTL_RUN" \
-        "gh run list --repo '$repo' --branch master --limit 3 \
-            --json databaseId,name,conclusion,createdAt,event 2>/dev/null" \
+    # Filter at the API boundary instead of fetching a small mixed-event window.
+    # Otherwise non-push runs can consume the limit and hide an older push run.
+    # An allowlist also avoids treating new non-push event types as regressions.
+    runs=$(gh_cache_get_or_fetch "run-master-push-${repo}" "$GH_CACHE_TTL_RUN" \
+        "gh run list --repo '$repo' --branch master --event push --limit 3 \
+            --json databaseId,name,conclusion,createdAt 2>/dev/null" \
         "[]")
-    # Also try 'main' if master returned nothing
+    # Also try 'main' if master returned no push runs.
     if [ "$runs" = "[]" ]; then
-        runs=$(gh_cache_get_or_fetch "run-main-${repo}" "$GH_CACHE_TTL_RUN" \
-            "gh run list --repo '$repo' --branch main --limit 3 \
-                --json databaseId,name,conclusion,createdAt,event 2>/dev/null" \
+        runs=$(gh_cache_get_or_fetch "run-main-push-${repo}" "$GH_CACHE_TTL_RUN" \
+            "gh run list --repo '$repo' --branch main --event push --limit 3 \
+                --json databaseId,name,conclusion,createdAt 2>/dev/null" \
             "[]")
     fi
     [ "$runs" = "[]" ] || [ -z "$runs" ] && return 0
 
-    # Check for any recent failures
+    # Every returned run is push-triggered by construction.
     local failures
-    # Only branch-triggered failures represent a broken default branch. GitHub
-    # also associates manual, repository-dispatched, and Dependabot `dynamic`
-    # runs with master; those are independent jobs, not regressions from a push.
-    # Missing/unknown event values still fail open toward detection.
-    failures=$(echo "$runs" | jq -c '[.[] | select(
-        .conclusion == "failure"
-        and (.event as $event | ["workflow_dispatch", "repository_dispatch", "dynamic"] | index($event) | not)
-    )]')
+    failures=$(echo "$runs" | jq -c '[.[] | select(.conclusion == "failure")]')
     local fail_count
     fail_count=$(echo "$failures" | jq 'length')
     [ "$fail_count" -eq 0 ] && return 0

--- a/tests/test_activity_gate_master_ci.py
+++ b/tests/test_activity_gate_master_ci.py
@@ -14,12 +14,18 @@ SCRIPT = REPO_ROOT / "scripts" / "github" / "activity-gate.sh"
 FAKE_GH = r"""#!/usr/bin/env python3
 from __future__ import annotations
 
+import json
 import os
 import sys
 
 argv = sys.argv[1:]
 if argv[:2] == ["run", "list"]:
-    print(os.environ.get("TEST_MASTER_RUNS", "[]"))
+    runs = json.loads(os.environ.get("TEST_MASTER_RUNS", "[]"))
+    if "--event" in argv:
+        event = argv[argv.index("--event") + 1]
+        runs = [run for run in runs if run.get("event") == event]
+    limit = int(argv[argv.index("--limit") + 1])
+    print(json.dumps(runs[:limit]))
     raise SystemExit(0)
 if argv[:2] in (["pr", "list"], ["issue", "list"]):
     print("[]")
@@ -68,12 +74,14 @@ def _failed_run(run_id: int, event: str) -> dict:
     }
 
 
-def test_nonblocking_events_are_not_reported_as_master_ci(tmp_path: Path) -> None:
-    """Detached/manual jobs associated with master are not push regressions."""
+def test_nonpush_events_are_not_reported_as_master_ci(tmp_path: Path) -> None:
+    """Known non-push events associated with master are not regressions."""
     runs = [
         _failed_run(101, "dynamic"),
         _failed_run(102, "workflow_dispatch"),
         _failed_run(103, "repository_dispatch"),
+        _failed_run(104, "schedule"),
+        _failed_run(105, "workflow_call"),
     ]
     result = _run_gate(tmp_path, runs)
 
@@ -82,22 +90,27 @@ def test_nonblocking_events_are_not_reported_as_master_ci(tmp_path: Path) -> Non
 
 
 def test_push_failure_is_reported_as_master_ci(tmp_path: Path) -> None:
-    result = _run_gate(tmp_path, [_failed_run(104, "push")])
+    result = _run_gate(tmp_path, [_failed_run(106, "push")])
 
     assert result.returncode == 0, result.stderr
     items = [json.loads(line) for line in result.stdout.splitlines()]
     assert [(item["type"], item["number"]) for item in items] == [
-        ("master_ci_failure", 104)
+        ("master_ci_failure", 106)
     ]
 
 
-def test_unknown_event_still_fails_toward_detection(tmp_path: Path) -> None:
-    run = _failed_run(105, "unknown")
-    run["event"] = None
+def test_nonpush_window_does_not_hide_older_push_failure(tmp_path: Path) -> None:
+    """The API event filter runs before the three-run result limit."""
+    runs = [
+        _failed_run(107, "schedule"),
+        _failed_run(108, "workflow_dispatch"),
+        _failed_run(109, "dynamic"),
+        _failed_run(110, "push"),
+    ]
 
-    result = _run_gate(tmp_path, [run])
+    result = _run_gate(tmp_path, runs)
 
     assert result.returncode == 0, result.stderr
     item = json.loads(result.stdout)
     assert item["type"] == "master_ci_failure"
-    assert item["number"] == 105
+    assert item["number"] == 110

--- a/tests/test_activity_gate_master_ci.py
+++ b/tests/test_activity_gate_master_ci.py
@@ -1,0 +1,103 @@
+"""Regression tests for master-CI event filtering in activity-gate.sh."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "github" / "activity-gate.sh"
+
+FAKE_GH = r"""#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import sys
+
+argv = sys.argv[1:]
+if argv[:2] == ["run", "list"]:
+    print(os.environ.get("TEST_MASTER_RUNS", "[]"))
+    raise SystemExit(0)
+if argv[:2] in (["pr", "list"], ["issue", "list"]):
+    print("[]")
+    raise SystemExit(0)
+if argv and argv[0] == "api":
+    raise SystemExit(0)
+raise SystemExit(0)
+"""
+
+
+def _run_gate(tmp_path: Path, runs: list[dict]) -> subprocess.CompletedProcess[str]:
+    fake_gh = tmp_path / "gh"
+    fake_gh.write_text(FAKE_GH)
+    fake_gh.chmod(fake_gh.stat().st_mode | stat.S_IXUSR)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{tmp_path}:{env['PATH']}"
+    env["TEST_MASTER_RUNS"] = json.dumps(runs)
+    env["GH_CACHE_TTL_RUN"] = "0"
+    return subprocess.run(
+        [
+            str(SCRIPT),
+            "--author",
+            "test-author",
+            "--repo",
+            "owner/repo",
+            "--state-dir",
+            str(tmp_path / "state"),
+            "--format",
+            "jsonl",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+def _failed_run(run_id: int, event: str) -> dict:
+    return {
+        "databaseId": run_id,
+        "name": f"workflow-{event}",
+        "conclusion": "failure",
+        "createdAt": "2026-07-22T13:59:34Z",
+        "event": event,
+    }
+
+
+def test_nonblocking_events_are_not_reported_as_master_ci(tmp_path: Path) -> None:
+    """Detached/manual jobs associated with master are not push regressions."""
+    runs = [
+        _failed_run(101, "dynamic"),
+        _failed_run(102, "workflow_dispatch"),
+        _failed_run(103, "repository_dispatch"),
+    ]
+    result = _run_gate(tmp_path, runs)
+
+    assert result.returncode == 1, result.stderr
+    assert result.stdout == ""
+
+
+def test_push_failure_is_reported_as_master_ci(tmp_path: Path) -> None:
+    result = _run_gate(tmp_path, [_failed_run(104, "push")])
+
+    assert result.returncode == 0, result.stderr
+    items = [json.loads(line) for line in result.stdout.splitlines()]
+    assert [(item["type"], item["number"]) for item in items] == [
+        ("master_ci_failure", 104)
+    ]
+
+
+def test_unknown_event_still_fails_toward_detection(tmp_path: Path) -> None:
+    run = _failed_run(105, "unknown")
+    run["event"] = None
+
+    result = _run_gate(tmp_path, [run])
+
+    assert result.returncode == 0, result.stderr
+    item = json.loads(result.stdout)
+    assert item["type"] == "master_ci_failure"
+    assert item["number"] == 105

--- a/tests/test_activity_gate_master_ci.py
+++ b/tests/test_activity_gate_master_ci.py
@@ -74,14 +74,12 @@ def _failed_run(run_id: int, event: str) -> dict:
     }
 
 
-def test_nonpush_events_are_not_reported_as_master_ci(tmp_path: Path) -> None:
-    """Known non-push events associated with master are not regressions."""
+def test_detached_events_are_not_reported_as_master_ci(tmp_path: Path) -> None:
+    """Detached/manual events associated with master are not regressions."""
     runs = [
         _failed_run(101, "dynamic"),
         _failed_run(102, "workflow_dispatch"),
         _failed_run(103, "repository_dispatch"),
-        _failed_run(104, "schedule"),
-        _failed_run(105, "workflow_call"),
     ]
     result = _run_gate(tmp_path, runs)
 
@@ -89,13 +87,20 @@ def test_nonpush_events_are_not_reported_as_master_ci(tmp_path: Path) -> None:
     assert result.stdout == ""
 
 
-def test_push_failure_is_reported_as_master_ci(tmp_path: Path) -> None:
-    result = _run_gate(tmp_path, [_failed_run(106, "push")])
+def test_branch_health_events_are_reported_as_master_ci(tmp_path: Path) -> None:
+    runs = [
+        _failed_run(104, "push"),
+        _failed_run(105, "schedule"),
+        _failed_run(106, "workflow_call"),
+    ]
+    result = _run_gate(tmp_path, runs)
 
     assert result.returncode == 0, result.stderr
     items = [json.loads(line) for line in result.stdout.splitlines()]
     assert [(item["type"], item["number"]) for item in items] == [
-        ("master_ci_failure", 106)
+        ("master_ci_failure", 104),
+        ("master_ci_failure", 105),
+        ("master_ci_failure", 106),
     ]
 
 
@@ -111,6 +116,7 @@ def test_nonpush_window_does_not_hide_older_push_failure(tmp_path: Path) -> None
     result = _run_gate(tmp_path, runs)
 
     assert result.returncode == 0, result.stderr
-    item = json.loads(result.stdout)
-    assert item["type"] == "master_ci_failure"
-    assert item["number"] == 110
+    items = [json.loads(line) for line in result.stdout.splitlines()]
+    assert ("master_ci_failure", 110) in [
+        (item["type"], item["number"]) for item in items
+    ]


### PR DESCRIPTION
## Problem

`activity-gate.sh` classified every failed run associated with the default branch as `master_ci_failure`, regardless of its trigger event. GitHub associates Dependabot security-update runs (`event: dynamic`) with `master`, so an unsatisfiable dependency update was repeatedly dispatched as a product master regression even though the actual push CI was healthy.

Observed example: [ActivityWatch/activitywatch run 29926434761](https://github.com/ActivityWatch/activitywatch/actions/runs/29926434761), a Dependabot `dynamic` run blocked by the repository's accepted Python 3.9 floor.

## Fix

- Request the `event` field from `gh run list`.
- Exclude `dynamic`, `workflow_dispatch`, and `repository_dispatch` failures from `master_ci_failure` detection.
- Keep unknown/missing events fail-open so real failures are not silently hidden.

This matches the existing event policy in Bob's product master-red watchdog.

## Verification

- Added end-to-end fake-`gh` regressions for all three excluded events, a push failure, and an unknown event.
- `uv run pytest tests/test_activity_gate_*.py -q` — 34 passed.
- `shellcheck scripts/github/activity-gate.sh`.
- Pre-commit hooks passed.
