### PR TITLE
docs(lesson): add confound_note to proactive-correction-in-agent-messages

### DIFF
--- a/lessons/workflow/proactive-correction-in-agent-messages.md
+++ b/lessons/workflow/proactive-correction-in-agent-messages.md
@@ -2,6 +2,7 @@
 description: "When a message contains a factual error or misunderstanding, correct it immediately rather than letting it propagate"
 status: active
 tags: [inter-agent, correction, orchestration, epistemic-integrity, communication]
+confound_note: "Keywords are error-signal ('earlier message was wrong', 'retract incorrect recommendation') — fires in already-difficult multi-agent correction scenarios. Observational delta was +0.19 but causal dropout showed -0.08 (p=0.037, n=37/8). Small n and error-signal trigger profile suggest selection confound; archive or rewrite if causal harm confirmed with larger n."
 match:
   keywords:
     - "retract incorrect recommendation"


### PR DESCRIPTION
## Summary

LOO causal dropout analysis (2026-07-23) showed `proactive-correction-in-agent-messages` had causal Δ=-0.0803 (p=0.037, n=37/8), despite an observational delta of +0.1917.

- Large obs vs causal gap (-0.2720) suggests selection confound: the lesson fires on error-signal keywords ("earlier message was wrong", "retract incorrect recommendation") that are present precisely in already-difficult multi-agent correction sessions
- Small n=37/8 makes the causal result borderline
- Adding `confound_note` to suppress premature archiving; the signal should be re-evaluated once n grows

No functional changes — purely metadata to help the LOO tool correctly classify this lesson.