### PR TITLE
docs(tts): cross-reference WebUI speech cleaner

### DIFF
--- a/plugins/gptme-tts/src/gptme_tts/tts.py
+++ b/plugins/gptme-tts/src/gptme_tts/tts.py
@@ -344,8 +344,13 @@ emoji_pattern = re.compile(
 
 
 def clean_for_speech(content: str) -> str:
-    """
-    Clean content for speech by removing:
+    """Clean assistant content for speech.
+
+    Keep this aligned with the WebUI's TypeScript ``toSpokenText()`` in
+    ``webui/src/utils/tts.ts`` (gptme core): both reasoning and tool-use are
+    implementation details and must never be spoken.
+
+    Removes:
 
     - <thinking> tags and their content
     - Tool use blocks (```tool ...```)


### PR DESCRIPTION
## Summary

Add the reciprocal cross-reference from the Python CLI/plugin speech cleaner to the WebUI's TypeScript cleaner.

This keeps the two deliberately parallel implementations discoverable and documents their shared invariant: reasoning and tool-use are implementation details that must never be spoken.

Companion to gptme/gptme#3332.

## Verification

- `uv run --project plugins/gptme-tts pytest plugins/gptme-tts/tests/test_tts.py -q` (24 passed)
- `uv run ruff check plugins/gptme-tts/src/gptme_tts/tts.py`
- `uv run ruff format --check plugins/gptme-tts/src/gptme_tts/tts.py`
