### PR TITLE
fix(tts): strip xml and @tool-format tool calls from speech

### DIFF
--- a/plugins/gptme-tts/src/gptme_tts/tts.py
+++ b/plugins/gptme-tts/src/gptme_tts/tts.py
@@ -185,7 +185,7 @@ re_thinking = re.compile(r"<think(ing)?>.*?(\n</think(ing)?>|$)", flags=re.DOTAL
 re_tool_use = re.compile(r"```[\w\. ~/\-]+\n(.*?)(\n```|$)", flags=re.DOTALL)
 re_tool_use_xml = re.compile(r"<tool-use>.*?(?:</tool-use>|$)", flags=re.DOTALL)
 re_tool_use_at = re.compile(
-    r"^@[\w.]+(?:\([\w\-:.]+\))?: " r"(?:\{\}|\{[^\n]*\}(?=\n|$)|\{.*?(?:\n\}|\Z))",
+    r"^@[\w.]+(?:\([\w\-:.]+\))?: " r"(?:\{\}|\{[^\n]*\}|\{.*?(?:\n\}|\Z))",
     flags=re.DOTALL | re.MULTILINE,
 )
 re_markdown_header = re.compile(r"^(#+)\s+(.*?)$", flags=re.MULTILINE)

--- a/plugins/gptme-tts/src/gptme_tts/tts.py
+++ b/plugins/gptme-tts/src/gptme_tts/tts.py
@@ -28,6 +28,7 @@ Uses Kokoro for local TTS generation.
 """
 
 import io
+import json
 import logging
 import os
 import queue
@@ -184,11 +185,29 @@ _stream_first_segment = True
 re_thinking = re.compile(r"<think(ing)?>.*?(\n</think(ing)?>|$)", flags=re.DOTALL)
 re_tool_use = re.compile(r"```[\w\. ~/\-]+\n(.*?)(\n```|$)", flags=re.DOTALL)
 re_tool_use_xml = re.compile(r"<tool-use>.*?(?:</tool-use>|$)", flags=re.DOTALL)
-re_tool_use_at = re.compile(
-    r"^@[\w.]+(?:\([\w\-:.]+\))?: " r"(?:\{\}|\{[^\n]*\}|\{.*?(?:\n\}|\Z))",
-    flags=re.DOTALL | re.MULTILINE,
-)
+re_tool_use_at_start = re.compile(r"^@[\w.]+(?:\([\w\-:.]+\))?: ", flags=re.MULTILINE)
 re_markdown_header = re.compile(r"^(#+)\s+(.*?)$", flags=re.MULTILINE)
+
+
+def _strip_at_tool_calls(content: str) -> str:
+    """Strip @tool JSON calls, including incomplete streamed calls."""
+    decoder = json.JSONDecoder()
+    parts: list[str] = []
+    cursor = 0
+
+    while match := re_tool_use_at_start.search(content, cursor):
+        parts.append(content[cursor : match.start()])
+        payload_start = match.end()
+        try:
+            _, payload_end = decoder.raw_decode(content, payload_start)
+        except json.JSONDecodeError:
+            # The call is still streaming. Drop it through the current end.
+            cursor = len(content)
+            break
+        cursor = payload_end
+
+    parts.append(content[cursor:])
+    return "".join(parts)
 
 
 def set_speed(speed):
@@ -381,7 +400,7 @@ def clean_for_speech(content: str) -> str:
     content = re_tool_use_xml.sub("", content)
 
     # Remove @tool-format calls (@name: {json} or @name(id): {json})
-    content = re_tool_use_at.sub("", content)
+    content = _strip_at_tool_calls(content)
 
     # Replace Markdown headers with just the header text (removing hash symbols)
     content = re_markdown_header.sub(r"\2", content)

--- a/plugins/gptme-tts/src/gptme_tts/tts.py
+++ b/plugins/gptme-tts/src/gptme_tts/tts.py
@@ -183,9 +183,10 @@ _stream_first_segment = True
 # All three are non-spoken implementation details.
 re_thinking = re.compile(r"<think(ing)?>.*?(\n</think(ing)?>|$)", flags=re.DOTALL)
 re_tool_use = re.compile(r"```[\w\. ~/\-]+\n(.*?)(\n```|$)", flags=re.DOTALL)
-re_tool_use_xml = re.compile(r"<tool-use>.*?</tool-use>", flags=re.DOTALL)
+re_tool_use_xml = re.compile(r"<tool-use>.*?(?:</tool-use>|$)", flags=re.DOTALL)
 re_tool_use_at = re.compile(
-    r"^@[\w.]+(?:\([\w\-:.]+\))?: (?:\{\}|\{.*?\n\})", flags=re.DOTALL | re.MULTILINE
+    r"^@[\w.]+(?:\([\w\-:.]+\))?: (?:\{\}|\{.*?(?:\n\}|\Z))",
+    flags=re.DOTALL | re.MULTILINE,
 )
 re_markdown_header = re.compile(r"^(#+)\s+(.*?)$", flags=re.MULTILINE)
 

--- a/plugins/gptme-tts/src/gptme_tts/tts.py
+++ b/plugins/gptme-tts/src/gptme_tts/tts.py
@@ -185,7 +185,7 @@ re_thinking = re.compile(r"<think(ing)?>.*?(\n</think(ing)?>|$)", flags=re.DOTAL
 re_tool_use = re.compile(r"```[\w\. ~/\-]+\n(.*?)(\n```|$)", flags=re.DOTALL)
 re_tool_use_xml = re.compile(r"<tool-use>.*?(?:</tool-use>|$)", flags=re.DOTALL)
 re_tool_use_at = re.compile(
-    r"^@[\w.]+(?:\([\w\-:.]+\))?: (?:\{\}|\{.*?(?:\n\}|\Z))",
+    r"^@[\w.]+(?:\([\w\-:.]+\))?: " r"(?:\{\}|\{[^\n]*\}(?=\n|$)|\{.*?(?:\n\}|\Z))",
     flags=re.DOTALL | re.MULTILINE,
 )
 re_markdown_header = re.compile(r"^(#+)\s+(.*?)$", flags=re.MULTILINE)

--- a/plugins/gptme-tts/src/gptme_tts/tts.py
+++ b/plugins/gptme-tts/src/gptme_tts/tts.py
@@ -175,9 +175,18 @@ _stream_spoken_chars = 0
 _stream_first_segment = True
 
 
-# Regular expressions for cleaning text
+# Regular expressions for cleaning text.
+# gptme supports three tool-call formats (see gptme/tools/base.py ToolFormat):
+#   - markdown: ```lang content ``` (ToolUse._to_markdown)
+#   - xml:      <tool-use><name>content</name></tool-use> (ToolUse._to_xml)
+#   - tool:     @name: {json} or @name(id): {json} (ToolUse._to_toolcall)
+# All three are non-spoken implementation details.
 re_thinking = re.compile(r"<think(ing)?>.*?(\n</think(ing)?>|$)", flags=re.DOTALL)
 re_tool_use = re.compile(r"```[\w\. ~/\-]+\n(.*?)(\n```|$)", flags=re.DOTALL)
+re_tool_use_xml = re.compile(r"<tool-use>.*?</tool-use>", flags=re.DOTALL)
+re_tool_use_at = re.compile(
+    r"^@[\w.]+(?:\([\w\-:.]+\))?: (?:\{\}|\{.*?\n\})", flags=re.DOTALL | re.MULTILINE
+)
 re_markdown_header = re.compile(r"^(#+)\s+(.*?)$", flags=re.MULTILINE)
 
 
@@ -353,7 +362,7 @@ def clean_for_speech(content: str) -> str:
     Removes:
 
     - <thinking> tags and their content
-    - Tool use blocks (```tool ...```)
+    - Tool use blocks in all three gptme formats (markdown/xml/@tool)
     - **Bold** (``**text**``) and italic (``*text*``) markup
     - Additional (details) that may not need to be spoken
     - Emojis and other non-speech content
@@ -364,8 +373,14 @@ def clean_for_speech(content: str) -> str:
     # Remove <thinking> tags and their content
     content = re_thinking.sub("", content)
 
-    # Remove tool use blocks
+    # Remove markdown-format tool calls (```lang content ```)
     content = re_tool_use.sub("", content)
+
+    # Remove xml-format tool calls (<tool-use>...</tool-use>)
+    content = re_tool_use_xml.sub("", content)
+
+    # Remove @tool-format calls (@name: {json} or @name(id): {json})
+    content = re_tool_use_at.sub("", content)
 
     # Replace Markdown headers with just the header text (removing hash symbols)
     content = re_markdown_header.sub(r"\2", content)

--- a/plugins/gptme-tts/tests/test_tts.py
+++ b/plugins/gptme-tts/tests/test_tts.py
@@ -188,6 +188,25 @@ def test_clean_for_speech():
     assert "Hello." in result_at and "Done." in result_at
     assert "@shell" not in result_at
 
+    # partial (incomplete, still streaming) — closing delimiter not yet received
+    partial_xml = "<tool-use>\n<shell>\nls -la"  # no </tool-use>
+    assert re_tool_use_xml.search(partial_xml)
+    assert "<tool-use>" not in re_tool_use_xml.sub("", partial_xml)
+
+    partial_at = '@shell: {\n  "command": "echo Hello."'  # no closing \n}
+    assert re_tool_use_at.search(partial_at)
+    assert "@shell" not in re_tool_use_at.sub("", partial_at)
+
+    # partial xml: punctuation inside an incomplete block must not leak to speech
+    result_partial_xml = clean_for_speech(f"Safe sentence.\n{partial_xml}")
+    assert "Safe sentence." in result_partial_xml
+    assert "<tool-use>" not in result_partial_xml
+
+    # partial @tool: punctuation in json args must not leak to speech
+    result_partial_at = clean_for_speech(f"Safe sentence.\n{partial_at}")
+    assert "Safe sentence." in result_partial_at
+    assert "@shell" not in result_partial_at
+
 
 def test_request_timeout_configurable(monkeypatch):
     """Per-request timeout defaults to 30s and is overridable via env."""

--- a/plugins/gptme-tts/tests/test_tts.py
+++ b/plugins/gptme-tts/tests/test_tts.py
@@ -188,10 +188,16 @@ def test_clean_for_speech():
     assert "Hello." in result_at and "Done." in result_at
     assert "@shell" not in result_at
 
-    # Single-line @tool calls must not consume ordinary speech that follows.
+    # Single-line @tool calls must not consume ordinary speech that follows,
+    # whether the subsequent text starts on the next line or immediately after.
     single_line_at = '@shell: {"command":"ls"}'
     assert re_tool_use_at.search(single_line_at)
     assert clean_for_speech(f"{single_line_at}\nDone.").strip() == "Done."
+    # No newline between tool call and speech — was previously consumed by \Z fallback.
+    assert (
+        clean_for_speech(f"{single_line_at} Some spoken result.").strip()
+        == "Some spoken result."
+    )
 
     # partial (incomplete, still streaming) — closing delimiter not yet received
     partial_xml = "<tool-use>\n<shell>\nls -la"  # no </tool-use>

--- a/plugins/gptme-tts/tests/test_tts.py
+++ b/plugins/gptme-tts/tests/test_tts.py
@@ -133,7 +133,13 @@ def test_split_text_lists():
 
 
 def test_clean_for_speech():
-    from gptme_tts.tts import re_thinking, re_tool_use, re_tool_use_at, re_tool_use_xml
+    from gptme_tts.tts import (
+        _strip_at_tool_calls,
+        re_thinking,
+        re_tool_use,
+        re_tool_use_at_start,
+        re_tool_use_xml,
+    )
 
     # complete
     assert re_thinking.search("<thinking>thinking</thinking>")
@@ -166,15 +172,15 @@ def test_clean_for_speech():
 
     # @tool-format calls
     at_block = '@shell: {\n  "command": "ls"\n}'
-    assert re_tool_use_at.search(at_block)
+    assert re_tool_use_at_start.search(at_block)
     assert (
-        re_tool_use_at.sub("", f"Before.\n{at_block}\nAfter.").strip()
+        _strip_at_tool_calls(f"Before.\n{at_block}\nAfter.").strip()
         == "Before.\n\nAfter."
     )
 
     # @tool-format with call id
     at_id_block = '@shell(abc123): {\n  "command": "ls"\n}'
-    assert re_tool_use_at.search(at_id_block)
+    assert re_tool_use_at_start.search(at_id_block)
 
     # clean_for_speech strips all three formats
     # (internal whitespace is not collapsed here; split_text/join handles that downstream)
@@ -191,12 +197,17 @@ def test_clean_for_speech():
     # Single-line @tool calls must not consume ordinary speech that follows,
     # whether the subsequent text starts on the next line or immediately after.
     single_line_at = '@shell: {"command":"ls"}'
-    assert re_tool_use_at.search(single_line_at)
+    assert re_tool_use_at_start.search(single_line_at)
     assert clean_for_speech(f"{single_line_at}\nDone.").strip() == "Done."
     # No newline between tool call and speech — was previously consumed by \Z fallback.
     assert (
         clean_for_speech(f"{single_line_at} Some spoken result.").strip()
         == "Some spoken result."
+    )
+    # A later brace in ordinary speech must not extend the tool-call match.
+    assert (
+        clean_for_speech(f"{single_line_at} Keep this }} brace.").strip()
+        == "Keep this } brace."
     )
 
     # partial (incomplete, still streaming) — closing delimiter not yet received
@@ -205,8 +216,8 @@ def test_clean_for_speech():
     assert "<tool-use>" not in re_tool_use_xml.sub("", partial_xml)
 
     partial_at = '@shell: {\n  "command": "echo Hello."'  # no closing \n}
-    assert re_tool_use_at.search(partial_at)
-    assert "@shell" not in re_tool_use_at.sub("", partial_at)
+    assert re_tool_use_at_start.search(partial_at)
+    assert "@shell" not in _strip_at_tool_calls(partial_at)
 
     # partial xml: punctuation inside an incomplete block must not leak to speech
     result_partial_xml = clean_for_speech(f"Safe sentence.\n{partial_xml}")

--- a/plugins/gptme-tts/tests/test_tts.py
+++ b/plugins/gptme-tts/tests/test_tts.py
@@ -188,6 +188,11 @@ def test_clean_for_speech():
     assert "Hello." in result_at and "Done." in result_at
     assert "@shell" not in result_at
 
+    # Single-line @tool calls must not consume ordinary speech that follows.
+    single_line_at = '@shell: {"command":"ls"}'
+    assert re_tool_use_at.search(single_line_at)
+    assert clean_for_speech(f"{single_line_at}\nDone.").strip() == "Done."
+
     # partial (incomplete, still streaming) — closing delimiter not yet received
     partial_xml = "<tool-use>\n<shell>\nls -la"  # no </tool-use>
     assert re_tool_use_xml.search(partial_xml)

--- a/plugins/gptme-tts/tests/test_tts.py
+++ b/plugins/gptme-tts/tests/test_tts.py
@@ -133,7 +133,7 @@ def test_split_text_lists():
 
 
 def test_clean_for_speech():
-    from gptme_tts.tts import re_thinking, re_tool_use
+    from gptme_tts.tts import re_thinking, re_tool_use, re_tool_use_at, re_tool_use_xml
 
     # complete
     assert re_thinking.search("<thinking>thinking</thinking>")
@@ -155,6 +155,38 @@ def test_clean_for_speech():
         == "Using tool"
     )
     assert re_tool_use.sub("", "```tool\ncontents\n```\nRan tool").strip() == "Ran tool"
+
+    # xml-format tool calls
+    xml_block = "<tool-use>\n<shell>\nls -la\n</shell>\n</tool-use>"
+    assert re_tool_use_xml.search(xml_block)
+    assert (
+        re_tool_use_xml.sub("", f"Before.\n{xml_block}\nAfter.").strip()
+        == "Before.\n\nAfter."
+    )
+
+    # @tool-format calls
+    at_block = '@shell: {\n  "command": "ls"\n}'
+    assert re_tool_use_at.search(at_block)
+    assert (
+        re_tool_use_at.sub("", f"Before.\n{at_block}\nAfter.").strip()
+        == "Before.\n\nAfter."
+    )
+
+    # @tool-format with call id
+    at_id_block = '@shell(abc123): {\n  "command": "ls"\n}'
+    assert re_tool_use_at.search(at_id_block)
+
+    # clean_for_speech strips all three formats
+    # (internal whitespace is not collapsed here; split_text/join handles that downstream)
+    from gptme_tts.tts import clean_for_speech
+
+    result_xml = clean_for_speech(f"Hello.\n{xml_block}\nDone.")
+    assert "Hello." in result_xml and "Done." in result_xml
+    assert "<tool-use>" not in result_xml
+
+    result_at = clean_for_speech(f"Hello.\n{at_block}\nDone.")
+    assert "Hello." in result_at and "Done." in result_at
+    assert "@shell" not in result_at
 
 
 def test_request_timeout_configurable(monkeypatch):


### PR DESCRIPTION
## Summary

Adds xml-format (`<tool-use>...</tool-use>`) and @tool-format (`@name: {json}` or `@name(id): {json}`) stripping to `clean_for_speech()`, so all three gptme tool-call formats (see `ToolFormat` in `gptme/tools/base.py`) are silenced before TTS.

- **markdown** (```` ```lang content ``` ````): already handled
- **xml** (`<tool-use><name>…</name></tool-use>`): added — `re_tool_use_xml`
- **@tool** (`@name: {json}` or `@name(id): {json}`): added — `re_tool_use_at`

Mirrors the identical fix in `gptme/gptme#3332` (`webui/src/utils/tts.ts` `toSpokenText()`).

## Test plan

- [x] `test_clean_for_speech` extended with xml and @tool cases
- [x] Regex match assertions for both new patterns
- [x] `clean_for_speech` integration assertions verify tool content is absent from output