### PR TITLE
chore(activity-summary): remove deprecated 'summarize' CLI alias

### DIFF
--- a/packages/gptme-activity-summary/pyproject.toml
+++ b/packages/gptme-activity-summary/pyproject.toml
@@ -45,7 +45,6 @@ test = [
 
 [project.scripts]
 gptme-activity-summary = "gptme_activity_summary.cli:main"
-summarize = "gptme_activity_summary.cli:main"  # deprecated alias
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
Removes the `summarize` entry from `[project.scripts]` in `packages/gptme-activity-summary/pyproject.toml`.

The alias was self-declared deprecated in a comment, and a grep across `scripts/`, `dotfiles/systemd/`, and `tests/` finds no callers (only Python functions named `summarize`, not the CLI). Safe to remove.

Closes #1321