### PR TITLE
feat(coordination): add SQLite fact bus for concurrent agent knowledge sharing

### DIFF
--- a/packages/gptme-coordination/src/gptme_coordination/__init__.py
+++ b/packages/gptme-coordination/src/gptme_coordination/__init__.py
@@ -2,6 +2,7 @@
 
 from gptme_coordination.db import CoordinationDB, resolve_coordination_db_path
 from gptme_coordination.events import Event, EventQueue, QueueStats
+from gptme_coordination.fact_bus import Fact, FactBus
 from gptme_coordination.messages import Message, MessageBus
 from gptme_coordination.work import WorkClaim, WorkClaimManager
 
@@ -11,6 +12,8 @@ __all__ = [
     "Event",
     "EventQueue",
     "QueueStats",
+    "Fact",
+    "FactBus",
     "Message",
     "MessageBus",
     "WorkClaim",

--- a/packages/gptme-coordination/src/gptme_coordination/cli.py
+++ b/packages/gptme-coordination/src/gptme_coordination/cli.py
@@ -25,6 +25,7 @@ from gptme_coordination.db import (
     resolve_coordination_db_path,
 )
 from gptme_coordination.events import EventQueue
+from gptme_coordination.fact_bus import DEFAULT_TTL_MINUTES, FactBus
 from gptme_coordination.messages import MessageBus
 from gptme_coordination.work import WorkClaim, WorkClaimManager
 
@@ -261,6 +262,50 @@ def cmd_queue_discard(args: argparse.Namespace) -> int:
         return 1
 
 
+def cmd_fact_publish(args: argparse.Namespace) -> int:
+    db_path = args.db or get_db_path()
+    with CoordinationDB(db_path) as db:
+        bus = FactBus(db)
+        fact = bus.publish(
+            args.fact_key,
+            args.value,
+            session_id=args.session,
+            ttl_minutes=args.ttl,
+        )
+        expires_in = int((fact.expires_at - fact.created_at) / 60)
+        print(f"published {fact.fact_key!r} = {fact.value!r} (ttl {expires_in}m)")
+        return 0
+
+
+def cmd_fact_query(args: argparse.Namespace) -> int:
+    db_path = args.db or get_db_path()
+    with CoordinationDB(db_path) as db:
+        bus = FactBus(db)
+        fact = bus.query(args.fact_key)
+        if fact is None:
+            print("(no fact)")
+            return 1
+        age_min = int(fact.age_seconds / 60)
+        src = f" [from {fact.session_id}]" if fact.session_id else ""
+        print(f"{fact.value}{src} (age {age_min}m)")
+        return 0
+
+
+def cmd_fact_list(args: argparse.Namespace) -> int:
+    db_path = args.db or get_db_path()
+    with CoordinationDB(db_path) as db:
+        bus = FactBus(db)
+        facts = bus.list_facts(prefix=args.prefix)
+        if not facts:
+            print("(no facts)")
+            return 0
+        for fact in facts:
+            age_min = int(fact.age_seconds / 60)
+            src = f" [{fact.session_id}]" if fact.session_id else ""
+            print(f"  {fact.fact_key} = {fact.value!r}{src} (age {age_min}m)")
+        return 0
+
+
 def cmd_status(args: argparse.Namespace) -> int:
     db_path = args.db or get_db_path()
     with CoordinationDB(db_path) as db:
@@ -331,6 +376,26 @@ def build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("announce", help="Announce presence")
     p.add_argument("agent_id")
 
+    # fact-publish
+    p = sub.add_parser("fact-publish", help="Publish a fact to the shared fact bus")
+    p.add_argument("fact_key", help="Fact key (e.g. cascade:supply-verdict:2026-07-25)")
+    p.add_argument("value", help="Fact value (plain text)")
+    p.add_argument("--session", help="Publishing session ID (for attribution)")
+    p.add_argument(
+        "--ttl",
+        type=int,
+        default=DEFAULT_TTL_MINUTES,
+        help=f"TTL in minutes (default: {DEFAULT_TTL_MINUTES})",
+    )
+
+    # fact-query
+    p = sub.add_parser("fact-query", help="Query a fact from the shared fact bus")
+    p.add_argument("fact_key", help="Fact key to look up")
+
+    # fact-list
+    p = sub.add_parser("fact-list", help="List non-expired facts")
+    p.add_argument("--prefix", help="Filter by key prefix")
+
     # status
     sub.add_parser("status", help="Show coordination DB status")
 
@@ -391,6 +456,9 @@ COMMANDS = {
     "inbox": cmd_inbox,
     "send": cmd_send,
     "announce": cmd_announce,
+    "fact-publish": cmd_fact_publish,
+    "fact-query": cmd_fact_query,
+    "fact-list": cmd_fact_list,
     "status": cmd_status,
     "queue-list": cmd_queue_list,
     "queue-stats": cmd_queue_stats,

--- a/packages/gptme-coordination/src/gptme_coordination/db.py
+++ b/packages/gptme-coordination/src/gptme_coordination/db.py
@@ -74,6 +74,15 @@ CREATE TABLE IF NOT EXISTS events (
 CREATE INDEX IF NOT EXISTS idx_events_state ON events(state);
 CREATE INDEX IF NOT EXISTS idx_events_thread ON events(thread_key, created_at);
 CREATE INDEX IF NOT EXISTS idx_events_priority ON events(state, priority DESC);
+
+CREATE TABLE IF NOT EXISTS fact_bus (
+    fact_key TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    session_id TEXT,
+    created_at REAL NOT NULL,
+    expires_at REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_fact_bus_expires ON fact_bus(expires_at);
 """
 
 

--- a/packages/gptme-coordination/src/gptme_coordination/fact_bus.py
+++ b/packages/gptme-coordination/src/gptme_coordination/fact_bus.py
@@ -1,0 +1,117 @@
+"""Read-many, TTL-keyed fact bus for concurrent agent knowledge sharing.
+
+Unlike work claims (exclusive locks), facts are broadcast: any number of
+sessions can query a fact simultaneously. The primary use case is preventing
+convergent investigation — before spending budget to determine "is X done?",
+a session queries whether a sibling already resolved that fact.
+
+Typical fact keys:
+  cascade:supply-verdict:2026-07-25     "drained"
+  idea:821:status                       "claimed by 2fac"
+  github:gptme/gptme#3355:merged       "true"
+  task:aw-android-release:state        "waiting — Erik must tag v0.14.0"
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from gptme_coordination.db import CoordinationDB
+
+DEFAULT_TTL_MINUTES = 60
+
+
+@dataclass
+class Fact:
+    fact_key: str
+    value: str
+    session_id: str | None
+    created_at: float
+    expires_at: float
+
+    @property
+    def age_seconds(self) -> float:
+        return time.time() - self.created_at
+
+    @property
+    def is_expired(self) -> bool:
+        return time.time() > self.expires_at
+
+
+class FactBus:
+    """TTL-keyed broadcast fact store for inter-session knowledge sharing."""
+
+    def __init__(self, db: CoordinationDB):
+        self.db = db
+
+    def publish(
+        self,
+        fact_key: str,
+        value: str,
+        session_id: str | None = None,
+        ttl_minutes: int = DEFAULT_TTL_MINUTES,
+    ) -> Fact:
+        """Publish or overwrite a fact. Upserts on fact_key conflict."""
+        now = time.time()
+        expires_at = now + ttl_minutes * 60
+        self.db.conn.execute(
+            """INSERT INTO fact_bus (fact_key, value, session_id, created_at, expires_at)
+               VALUES (?, ?, ?, ?, ?)
+               ON CONFLICT(fact_key) DO UPDATE SET
+                   value = excluded.value,
+                   session_id = excluded.session_id,
+                   created_at = excluded.created_at,
+                   expires_at = excluded.expires_at""",
+            (fact_key, value, session_id, now, expires_at),
+        )
+        return Fact(
+            fact_key=fact_key,
+            value=value,
+            session_id=session_id,
+            created_at=now,
+            expires_at=expires_at,
+        )
+
+    def query(self, fact_key: str) -> Fact | None:
+        """Return the non-expired fact for the given key, or None if absent/expired."""
+        row = self.db.conn.execute(
+            "SELECT * FROM fact_bus WHERE fact_key = ? AND expires_at > ?",
+            (fact_key, time.time()),
+        ).fetchone()
+        return _row_to_fact(row) if row is not None else None
+
+    def list_facts(self, prefix: str | None = None) -> list[Fact]:
+        """Return all non-expired facts, optionally filtered by key prefix."""
+        now = time.time()
+        if prefix:
+            rows = self.db.conn.execute(
+                "SELECT * FROM fact_bus WHERE expires_at > ? AND fact_key LIKE ?"
+                " ORDER BY fact_key",
+                (now, f"{prefix}%"),
+            ).fetchall()
+        else:
+            rows = self.db.conn.execute(
+                "SELECT * FROM fact_bus WHERE expires_at > ? ORDER BY fact_key",
+                (now,),
+            ).fetchall()
+        return [_row_to_fact(r) for r in rows]
+
+    def purge_expired(self) -> int:
+        """Delete expired facts; returns count removed."""
+        cursor = self.db.conn.execute(
+            "DELETE FROM fact_bus WHERE expires_at <= ?",
+            (time.time(),),
+        )
+        return cursor.rowcount
+
+
+def _row_to_fact(row: Any) -> Fact:
+    return Fact(
+        fact_key=row["fact_key"],
+        value=row["value"],
+        session_id=row["session_id"],
+        created_at=row["created_at"],
+        expires_at=row["expires_at"],
+    )

--- a/packages/gptme-coordination/src/gptme_coordination/fact_bus.py
+++ b/packages/gptme-coordination/src/gptme_coordination/fact_bus.py
@@ -86,10 +86,14 @@ class FactBus:
         """Return all non-expired facts, optionally filtered by key prefix."""
         now = time.time()
         if prefix:
+            # Escape LIKE wildcards so a literal prefix containing % or _ works correctly
+            escaped = (
+                prefix.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+            )
             rows = self.db.conn.execute(
-                "SELECT * FROM fact_bus WHERE expires_at > ? AND fact_key LIKE ?"
+                "SELECT * FROM fact_bus WHERE expires_at > ? AND fact_key LIKE ? ESCAPE '\\'"
                 " ORDER BY fact_key",
-                (now, f"{prefix}%"),
+                (now, f"{escaped}%"),
             ).fetchall()
         else:
             rows = self.db.conn.execute(

--- a/packages/gptme-coordination/tests/test_fact_bus.py
+++ b/packages/gptme-coordination/tests/test_fact_bus.py
@@ -1,0 +1,115 @@
+"""Tests for the TTL-keyed fact bus."""
+
+import time
+from pathlib import Path
+
+import pytest
+from gptme_coordination.db import CoordinationDB
+from gptme_coordination.fact_bus import FactBus
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> CoordinationDB:
+    return CoordinationDB(tmp_path / "test.db")
+
+
+@pytest.fixture
+def bus(db: CoordinationDB) -> FactBus:
+    return FactBus(db)
+
+
+class TestPublish:
+    def test_publish_returns_fact(self, bus: FactBus) -> None:
+        fact = bus.publish("key:one", "value-one")
+        assert fact.fact_key == "key:one"
+        assert fact.value == "value-one"
+        assert fact.session_id is None
+        assert fact.expires_at > fact.created_at
+
+    def test_publish_with_session(self, bus: FactBus) -> None:
+        fact = bus.publish("key:two", "v2", session_id="session-abc")
+        assert fact.session_id == "session-abc"
+
+    def test_publish_overwrites(self, bus: FactBus) -> None:
+        bus.publish("key:ow", "old")
+        fact = bus.publish("key:ow", "new")
+        assert fact.value == "new"
+        # Only one row for this key
+        result = bus.query("key:ow")
+        assert result is not None
+        assert result.value == "new"
+
+    def test_custom_ttl(self, bus: FactBus) -> None:
+        fact = bus.publish("key:ttl", "val", ttl_minutes=10)
+        expected = fact.created_at + 10 * 60
+        assert abs(fact.expires_at - expected) < 1
+
+
+class TestQuery:
+    def test_query_returns_fact(self, bus: FactBus) -> None:
+        bus.publish("q:one", "hello")
+        result = bus.query("q:one")
+        assert result is not None
+        assert result.value == "hello"
+
+    def test_query_missing_key(self, bus: FactBus) -> None:
+        assert bus.query("nonexistent") is None
+
+    def test_query_expired_returns_none(self, bus: FactBus) -> None:
+        # Publish with tiny TTL (use direct DB write with past expiry)
+        now = time.time()
+        bus.db.conn.execute(
+            "INSERT INTO fact_bus (fact_key, value, session_id, created_at, expires_at)"
+            " VALUES (?, ?, ?, ?, ?)",
+            ("exp:key", "val", None, now - 120, now - 1),
+        )
+        assert bus.query("exp:key") is None
+
+
+class TestList:
+    def test_list_empty(self, bus: FactBus) -> None:
+        assert bus.list_facts() == []
+
+    def test_list_returns_live_facts(self, bus: FactBus) -> None:
+        bus.publish("a:1", "v1")
+        bus.publish("b:2", "v2")
+        facts = bus.list_facts()
+        assert len(facts) == 2
+        keys = {f.fact_key for f in facts}
+        assert keys == {"a:1", "b:2"}
+
+    def test_list_excludes_expired(self, bus: FactBus) -> None:
+        bus.publish("live:1", "ok")
+        now = time.time()
+        bus.db.conn.execute(
+            "INSERT INTO fact_bus (fact_key, value, session_id, created_at, expires_at)"
+            " VALUES (?, ?, ?, ?, ?)",
+            ("dead:1", "gone", None, now - 120, now - 1),
+        )
+        facts = bus.list_facts()
+        assert len(facts) == 1
+        assert facts[0].fact_key == "live:1"
+
+    def test_list_with_prefix(self, bus: FactBus) -> None:
+        bus.publish("cascade:supply:2026-07-25", "drained")
+        bus.publish("cascade:supply:2026-07-24", "live")
+        bus.publish("idea:821:status", "claimed")
+        cascade_facts = bus.list_facts(prefix="cascade:")
+        assert len(cascade_facts) == 2
+        idea_facts = bus.list_facts(prefix="idea:")
+        assert len(idea_facts) == 1
+
+
+class TestPurge:
+    def test_purge_removes_expired(self, bus: FactBus) -> None:
+        bus.publish("live:x", "ok")
+        now = time.time()
+        bus.db.conn.execute(
+            "INSERT INTO fact_bus (fact_key, value, session_id, created_at, expires_at)"
+            " VALUES (?, ?, ?, ?, ?)",
+            ("dead:y", "gone", None, now - 120, now - 1),
+        )
+        removed = bus.purge_expired()
+        assert removed == 1
+        assert bus.query("live:x") is not None
+        assert bus.query("dead:y") is None

--- a/packages/gptme-coordination/tests/test_fact_bus.py
+++ b/packages/gptme-coordination/tests/test_fact_bus.py
@@ -99,6 +99,16 @@ class TestList:
         idea_facts = bus.list_facts(prefix="idea:")
         assert len(idea_facts) == 1
 
+    def test_list_prefix_with_like_wildcards(self, bus: FactBus) -> None:
+        # Keys whose prefixes contain SQL LIKE special chars (% and _) must
+        # match literally, not as wildcards.
+        bus.publish("50%_done:task-a", "yes")
+        bus.publish("50%_done:task-b", "yes")
+        bus.publish("unrelated:key", "no")
+        facts = bus.list_facts(prefix="50%_done:")
+        assert len(facts) == 2
+        assert all(f.fact_key.startswith("50%_done:") for f in facts)
+
 
 class TestPurge:
     def test_purge_removes_expired(self, bus: FactBus) -> None:


### PR DESCRIPTION
## Summary

- Adds `FactBus` — a TTL-keyed, read-many broadcast fact store in the existing coordination SQLite DB
- Prevents convergent investigation: sessions query `fact-query cascade:supply-verdict:DATE` before spending budget to re-derive the same answer a sibling already found
- Upserts on key conflict (last writer wins); facts auto-expire after a configurable TTL

## Changes

- **`fact_bus.py`**: `FactBus.publish()`, `.query()`, `.list_facts()`, `.purge_expired()`
- **`db.py`**: `fact_bus` table + `expires_at` index added to SCHEMA; migration handles existing DBs
- **`cli.py`**: `fact-publish KEY VALUE [--ttl N] [--session ID]`, `fact-query KEY`, `fact-list [--prefix P]`
- **`__init__.py`**: exports `Fact`, `FactBus`
- 12 tests: publish/overwrite semantics, TTL expiry, prefix filtering, purge

## Usage example

```bash
# Sibling session b587 found supply drained at 10:30
uv run coordination fact-publish "cascade:supply-verdict:2026-07-25" "drained" \
  --session b587 --ttl 60

# Later session e097 queries before re-running the full supply probe
uv run coordination fact-query "cascade:supply-verdict:2026-07-25"
# → drained [from b587] (age 3m)
```

## Test plan

- [x] All 12 unit tests pass (`pytest packages/gptme-coordination/tests/test_fact_bus.py -v`)
- [x] `mypy` clean on `fact_bus.py` and updated `cli.py`
- [x] Pre-commit hooks pass