### PR TITLE
chore(lessons): archive proactive-correction-in-agent-messages (causal harm confirmed)

### DIFF
--- a/lessons/workflow/proactive-correction-in-agent-messages.md
+++ b/lessons/workflow/proactive-correction-in-agent-messages.md
@@ -1,8 +1,8 @@
 ---
 description: "When a message contains a factual error or misunderstanding, correct it immediately rather than letting it propagate"
-status: active
+status: archived
 tags: [inter-agent, correction, orchestration, epistemic-integrity, communication]
-confound_note: "Keywords are error-signal ('earlier message was wrong', 'retract incorrect recommendation') — fires in already-difficult multi-agent correction scenarios. Observational delta was +0.19 but causal dropout showed -0.08 (p=0.037, n=37/8). Small n and error-signal trigger profile suggest selection confound; archive or rewrite if causal harm confirmed with larger n."
+confound_note: "Keywords are error-signal ('earlier message was wrong', 'retract incorrect recommendation') — fires in already-difficult multi-agent correction scenarios. Observational delta was +0.19 but causal dropout showed -0.0955 (p=0.005, n=41/11 kept/withheld). Causal harm confirmed at larger n (original p=0.037 n=37/8 flagged for recheck). Archived 2026-07-25 per own prescription."
 match:
   keywords:
     - "retract incorrect recommendation"


### PR DESCRIPTION
## Summary

- Archives `lessons/workflow/proactive-correction-in-agent-messages.md` (status: active → archived)
- Updates `confound_note` with the confirmed causal evidence

## Rationale

The lesson's own `confound_note` prescribed archival if causal harm was confirmed at larger n. It was written when causal dropout showed p=0.037 (n=37/8 kept/withheld) and called that "small n."

LOO analysis run 2026-07-25 now shows:
- **causal Δ=-0.0955** (vs observational +0.1917 — clear reversal)
- **p=0.005** (stronger than the original p=0.037 trigger)
- **n=41/11** (larger sample, same error-signal confound pattern confirmed)

The lesson fires in sessions where agents are already struggling with multi-agent corrections (error-signal keywords) — a selection confound that makes it look beneficial observationally. Causally, injection hurts. The content is valid guidance, but the trigger profile makes it harmful when injected in unrelated sessions.

## Test plan

- [x] `validate.py` passes (warnings only: `tags` field, `Origin` section — pre-existing)
- [x] `status: archived` prevents future injection without deleting content for reference