### PR TITLE
fix(subscription): ignore expired rate-limit markers

### DIFF
--- a/packages/gptme-subscription/src/gptme_subscription/manager.py
+++ b/packages/gptme-subscription/src/gptme_subscription/manager.py
@@ -314,7 +314,15 @@ class SubscriptionManager:
 
     def is_rate_limited(self) -> bool:
         rl = self.config.rate_limit_file
-        return bool(rl and rl.exists())
+        if rl is None:
+            return False
+        try:
+            blocked_until = datetime.fromisoformat(rl.read_text().strip())
+        except (FileNotFoundError, OSError, ValueError):
+            return False
+        if blocked_until.tzinfo is None:
+            blocked_until = blocked_until.replace(tzinfo=timezone.utc)
+        return blocked_until > datetime.now(timezone.utc)
 
     def clear_rate_limit(self) -> None:
         rl = self.config.rate_limit_file

--- a/packages/gptme-subscription/tests/test_subscription_manager.py
+++ b/packages/gptme-subscription/tests/test_subscription_manager.py
@@ -148,6 +148,33 @@ def test_detect_external_switch_ignores_unreadable_log(tmp_path: Path) -> None:
     sm.detect_external_switch()
 
 
+def test_rate_limit_file_with_future_expiry_is_active(tmp_path: Path) -> None:
+    sm = _make_manager(tmp_path)
+    rate_limit_file = tmp_path / "rate-limited-until.txt"
+    rate_limit_file.write_text(
+        (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+    )
+    sm.config.rate_limit_file = rate_limit_file
+
+    assert sm.is_rate_limited() is True
+
+
+def test_rate_limit_file_with_expired_or_invalid_value_is_inactive(
+    tmp_path: Path,
+) -> None:
+    sm = _make_manager(tmp_path)
+    rate_limit_file = tmp_path / "rate-limited-until.txt"
+    sm.config.rate_limit_file = rate_limit_file
+
+    rate_limit_file.write_text(
+        (datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat()
+    )
+    assert sm.is_rate_limited() is False
+
+    rate_limit_file.write_text("not-a-timestamp")
+    assert sm.is_rate_limited() is False
+
+
 # ---- slot_credential_is_stale ----
 
 


### PR DESCRIPTION
## Problem

`SubscriptionManager.is_rate_limited()` treated marker existence as an active quota block. An expired marker therefore caused one spurious subscription switch before the switch path removed it.

## Change

- Parse the marker as an ISO-8601 expiry timestamp.
- Return blocked only while the timestamp is in the future.
- Treat missing, unreadable, or invalid markers as inactive.
- Preserve compatibility with timezone-naive historical markers by interpreting them as UTC.

## Verification

- `PYTHONPATH=packages/gptme-subscription/src python -m pytest -q packages/gptme-subscription/tests/test_subscription_manager.py` (27 passed)
- `ruff check` on changed files
- pre-commit hooks passed
