### PR TITLE
fix(runloops): recover gptme item trajectories

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -713,6 +713,18 @@ def resolve_backend_trajectory(
                     f"Found monitoring trajectory (stream-json, {stream_path.stat().st_size}B): {trajectory}"
                 )
 
+    if backend == "gptme" and not trajectory and session_id:
+        ref = tmp_dir / f"gptme-traj-{session_id}.path"
+        if ref.is_file():
+            trajectory_text = ref.read_text(encoding="utf-8", errors="replace").strip()
+            trajectory_path = Path(trajectory_text) if trajectory_text else None
+            if trajectory_path and trajectory_path.is_file():
+                trajectory = str(trajectory_path)
+                _log(
+                    "Found monitoring trajectory "
+                    f"(gptme, {trajectory_path.stat().st_size}B): {trajectory}"
+                )
+
     if backend == "grok-build" and not trajectory and session_id:
         ref = tmp_dir / f"grok-build-session-log-ref-{session_id}.txt"
         if ref.is_file():
@@ -971,6 +983,11 @@ def plan_item(
     runner_env: dict[str, str] = {}
     if backend == "claude-code":
         runner_env["CC_SESSION_ID"] = session_id
+    elif backend == "gptme":
+        # run.sh uses this id for its trajectory sentinel. Without it the
+        # sentinel is keyed by the runner PID and run-item cannot recover the
+        # trajectory for post_session grading/token extraction.
+        runner_env["BOB_SESSION_ID"] = session_id
     elif backend == "grok-build":
         runner_env["GROK_BUILD_SESSION_ID"] = session_id
 

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -475,6 +475,12 @@ def test_plan_runner_argv_and_env(tmp_path) -> None:
     assert plan.trajectory_path.endswith(f"/{plan.session_id}.jsonl")
 
 
+def test_plan_gptme_env(tmp_path) -> None:
+    plan, _, _ = _plan_for(tmp_path, make_item(), FakeLifecycleIO(), backend="gptme")
+    assert plan.runner_env == {"BOB_SESSION_ID": plan.session_id}
+    assert plan.trajectory_path == ""
+
+
 def test_plan_grok_build_env(tmp_path) -> None:
     plan, _, _ = _plan_for(
         tmp_path, make_item(), FakeLifecycleIO(), backend="grok-build"
@@ -907,6 +913,46 @@ def test_trajectory_copilot_mtime_filter(tmp_path) -> None:
         copilot_pre=pre,
         codex_pre=None,
     )
+    assert got == ""
+
+
+def test_trajectory_gptme_uses_run_sh_sentinel(tmp_path) -> None:
+    trajectory = tmp_path / "gptme-conversation.jsonl"
+    trajectory.write_text('{"role": "assistant"}\n')
+    (tmp_path / "gptme-traj-session-123.path").write_text(str(trajectory) + "\n")
+
+    got = resolve_backend_trajectory(
+        "gptme",
+        "session-123",
+        predicted="",
+        started_epoch=0,
+        copilot_state_dir=tmp_path,
+        codex_sessions_dir=tmp_path,
+        copilot_pre=None,
+        codex_pre=None,
+        tmp_dir=tmp_path,
+    )
+
+    assert got == str(trajectory)
+
+
+def test_trajectory_gptme_ignores_missing_sentinel_target(tmp_path) -> None:
+    (tmp_path / "gptme-traj-session-123.path").write_text(
+        str(tmp_path / "missing.jsonl") + "\n"
+    )
+
+    got = resolve_backend_trajectory(
+        "gptme",
+        "session-123",
+        predicted="",
+        started_epoch=0,
+        copilot_state_dir=tmp_path,
+        codex_sessions_dir=tmp_path,
+        copilot_pre=None,
+        codex_pre=None,
+        tmp_dir=tmp_path,
+    )
+
     assert got == ""
 
 


### PR DESCRIPTION
## Summary
- key run.sh gptme trajectory sentinels with the run-item session ID
- resolve the sentinel after each gptme PM item so post-session can ingest usage and grades
- cover the runner env, valid sentinel, and missing-target cases

## Why
The resource-capped gptme project-monitoring canary has produced hundreds of parent `pm-react` records with null token and grade fields. `run.sh` writes a durable trajectory sentinel, but run-item did not set `BOB_SESSION_ID` or read that sentinel, so the post-session record fell back to telemetry-free output. This also made the brief-mode experiment unmeasurable.

## Verification
- `uv run pytest -q packages/gptme-runloops/tests/test_run_item.py` (68 passed)
- `uv run ruff check packages/gptme-runloops/src/gptme_runloops/run_item.py packages/gptme-runloops/tests/test_run_item.py`
- `uv run mypy packages/gptme-runloops/src/gptme_runloops/run_item.py`
- scoped `prek` checks