### PR TITLE
fix(voice): inject agent name into inbound greeting to prevent hallucination

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -247,7 +247,7 @@ def _build_caller_instructions(
 
 
 def _build_fresh_call_greeting_instructions(
-    from_number: str, workspace: str | None
+    from_number: str, workspace: str | None, agent_name: str = "bob"
 ) -> str:
     caller_identity = (
         _lookup_caller_identity(from_number, workspace) if from_number else None
@@ -274,7 +274,7 @@ def _build_fresh_call_greeting_instructions(
 
     return (
         "A fresh inbound phone call has just connected and the caller is unknown. "
-        "Introduce yourself by name, then ask exactly: 'Who am I speaking to?' "
+        f"Your name is {agent_name.capitalize()}. Say 'Hello, this is {agent_name.capitalize()}. Who am I speaking to?' "
         "Do NOT say 'thanks for calling' or use other stock phone greetings. "
         "Then stop and wait for them to answer."
     )
@@ -584,6 +584,7 @@ class VoiceServer:
         # Cross-agent handoff writer (optional — only active when GPTME_VOICE_HANDOFF_DIR set)
         handoff_dir_env = _get_config_env("GPTME_VOICE_HANDOFF_DIR")
         agent_name = _get_config_env("GPTME_VOICE_AGENT_NAME") or "bob"
+        self._agent_name = agent_name
         handoff_secret_env = _get_config_env("GPTME_VOICE_HANDOFF_SECRET")
         handoff_agents_env = _get_config_env("GPTME_VOICE_HANDOFF_AGENTS")
         # Comma-separated list of agents the running server can hand off to.
@@ -958,6 +959,7 @@ class VoiceServer:
             initial_response_instructions=_build_fresh_call_greeting_instructions(
                 from_number,
                 self.workspace,
+                self._agent_name,
             ),
         )
 

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -252,6 +252,7 @@ def _build_fresh_call_greeting_instructions(
     caller_identity = (
         _lookup_caller_identity(from_number, workspace) if from_number else None
     )
+    self_identity = f"You are {agent_name.capitalize()}. "
     if caller_identity:
         spoken_name = caller_identity.preferred_spoken_name
         canonical_name = caller_identity.canonical_name
@@ -267,14 +268,16 @@ def _build_fresh_call_greeting_instructions(
                 f"or 'Hey {spoken_name}, what's up?'. "
             )
         return (
-            greeting_target
+            self_identity
+            + greeting_target
             + "Do NOT say 'thanks for calling' or use other stock phone greetings. "
             "Then stop and wait for them to speak."
         )
 
     return (
-        "A fresh inbound phone call has just connected and the caller is unknown. "
-        f"Your name is {agent_name.capitalize()}. Say 'Hello, this is {agent_name.capitalize()}. Who am I speaking to?' "
+        self_identity
+        + "A fresh inbound phone call has just connected and the caller is unknown. "
+        f"Say 'Hello, this is {agent_name.capitalize()}. Who am I speaking to?' "
         "Do NOT say 'thanks for calling' or use other stock phone greetings. "
         "Then stop and wait for them to answer."
     )
@@ -555,13 +558,17 @@ class VoiceServer:
         else:
             self._api_key = openai_api_key or _get_openai_api_key()
         self.workspace = workspace or _detect_agent_repo()
-        # Prepend a truthful runtime-identity block so the voice model can answer
-        # "what model is powering this call?" honestly instead of confabulating.
-        # Built from self.provider/self.model, so it applies to every downstream
-        # call path (caller, resume, standup, handoff) that derives from
-        # self._instructions.
+        self._agent_name = (
+            _get_config_env("GPTME_VOICE_AGENT_NAME")
+            or _get_config_env("AGENT_NAME")
+            or "bob"
+        )
+        # Prepend the stable persona name and truthful runtime identity so neither
+        # gets lost when the compact voice prompt truncates personality files.
         self._instructions = (
-            _build_runtime_identity_instructions(self.provider, self.model)
+            f"IDENTITY: You are {self._agent_name.capitalize()}. "
+            "Never claim to be another agent.\n\n"
+            + _build_runtime_identity_instructions(self.provider, self.model)
             + "\n\n"
             + _load_project_instructions(self.workspace)
         )
@@ -583,14 +590,14 @@ class VoiceServer:
 
         # Cross-agent handoff writer (optional — only active when GPTME_VOICE_HANDOFF_DIR set)
         handoff_dir_env = _get_config_env("GPTME_VOICE_HANDOFF_DIR")
-        agent_name = _get_config_env("GPTME_VOICE_AGENT_NAME") or "bob"
-        self._agent_name = agent_name
         handoff_secret_env = _get_config_env("GPTME_VOICE_HANDOFF_SECRET")
         handoff_agents_env = _get_config_env("GPTME_VOICE_HANDOFF_AGENTS")
         # Comma-separated list of agents the running server can hand off to.
         # Defaults to the known agents minus the current one.
         _default_agents = [
-            a for a in ["alice", "gordon", "sven", "bob"] if a != agent_name
+            a
+            for a in ["alice", "gordon", "sven", "bob"]
+            if a != self._agent_name.lower()
         ]
         self._available_agents: list[str] = (
             [a.strip() for a in handoff_agents_env.split(",") if a.strip()]
@@ -607,11 +614,13 @@ class VoiceServer:
             handoff_secret = (handoff_secret_env or "dev-only-secret").encode("utf-8")
             self._handoff_writer: HandoffWriter | None = HandoffWriter(
                 Path(handoff_dir_env),
-                from_agent=agent_name,
+                from_agent=self._agent_name.lower(),
                 secret=handoff_secret,
             )
             logger.info(
-                "Handoff enabled: from_agent=%s, dir=%s", agent_name, handoff_dir_env
+                "Handoff enabled: from_agent=%s, dir=%s",
+                self._agent_name,
+                handoff_dir_env,
             )
         else:
             self._handoff_writer = None

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -590,14 +590,15 @@ class VoiceServer:
 
         # Cross-agent handoff writer (optional — only active when GPTME_VOICE_HANDOFF_DIR set)
         handoff_dir_env = _get_config_env("GPTME_VOICE_HANDOFF_DIR")
+        handoff_agent_name = (
+            _get_config_env("GPTME_VOICE_AGENT_NAME") or "bob"
+        ).lower()
         handoff_secret_env = _get_config_env("GPTME_VOICE_HANDOFF_SECRET")
         handoff_agents_env = _get_config_env("GPTME_VOICE_HANDOFF_AGENTS")
         # Comma-separated list of agents the running server can hand off to.
-        # Defaults to the known agents minus the current one.
+        # Defaults to the known agents minus the current protocol identity.
         _default_agents = [
-            a
-            for a in ["alice", "gordon", "sven", "bob"]
-            if a != self._agent_name.lower()
+            a for a in ["alice", "gordon", "sven", "bob"] if a != handoff_agent_name
         ]
         self._available_agents: list[str] = (
             [a.strip() for a in handoff_agents_env.split(",") if a.strip()]
@@ -614,12 +615,12 @@ class VoiceServer:
             handoff_secret = (handoff_secret_env or "dev-only-secret").encode("utf-8")
             self._handoff_writer: HandoffWriter | None = HandoffWriter(
                 Path(handoff_dir_env),
-                from_agent=self._agent_name.lower(),
+                from_agent=handoff_agent_name,
                 secret=handoff_secret,
             )
             logger.info(
                 "Handoff enabled: from_agent=%s, dir=%s",
-                self._agent_name,
+                handoff_agent_name,
                 handoff_dir_env,
             )
         else:

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -1607,6 +1607,7 @@ def test_server_g711_passthrough_ignored_for_grok_provider(
 
     session_config = server._build_session_config("You are Bob.")
     assert session_config.g711_passthrough is False
+    assert session_config.input_format == "pcm16"
 
 
 def test_greeting_unknown_caller_uses_configured_agent_name() -> None:
@@ -1637,12 +1638,28 @@ def test_server_uses_general_agent_name_for_identity(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("GPTME_VOICE_AGENT_NAME", raising=False)
-    monkeypatch.setenv("GPTME_AGENT_NAME", "Alice")
+    monkeypatch.setenv("GPTME_AGENT_NAME", "Alice Smith")
 
     server = VoiceServer()
 
-    assert server._agent_name == "Alice"
-    assert server._instructions.startswith("IDENTITY: You are Alice.")
+    assert server._agent_name == "Alice Smith"
+    assert server._instructions.startswith("IDENTITY: You are Alice smith.")
+
+
+def test_server_general_display_name_does_not_change_handoff_identity(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("GPTME_VOICE_AGENT_NAME", raising=False)
+    monkeypatch.setenv("GPTME_AGENT_NAME", "Alice Smith")
+    monkeypatch.setenv("GPTME_VOICE_HANDOFF_DIR", str(tmp_path))
+    monkeypatch.setenv("GPTME_VOICE_HANDOFF_SECRET", "test-secret")
+
+    server = VoiceServer()
+
+    assert server._agent_name == "Alice Smith"
+    assert server._handoff_writer is not None
+    assert server._handoff_writer.from_agent == "bob"
+    assert "bob" not in server._available_agents
 
 
 def test_server_voice_agent_name_overrides_general_name(

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -187,8 +187,9 @@ def test_build_runtime_identity_instructions_unknown_provider() -> None:
 
 def test_voice_server_prepends_runtime_identity_to_instructions() -> None:
     server = VoiceServer(provider="grok")
-    # The runtime-identity block leads the base instructions for every call path.
-    assert server._instructions.startswith("RUNTIME IDENTITY:")
+    # Stable persona identity leads the prompt, followed by runtime provider identity.
+    assert server._instructions.startswith("IDENTITY: You are Bob.")
+    assert "RUNTIME IDENTITY:" in server._instructions
     assert "Grok" in server._instructions
 
 
@@ -575,6 +576,7 @@ def test_build_session_bootstrap_personalizes_known_caller_greeting() -> None:
         )
 
     assert bootstrap.should_greet_first is True
+    assert "You are Bob" in bootstrap.initial_response_instructions
     assert "Erik Bjäreholt" in bootstrap.initial_response_instructions
     assert (
         "using 'Erik', not their full name" in bootstrap.initial_response_instructions
@@ -619,8 +621,9 @@ def test_build_session_bootstrap_asks_unknown_caller_to_identify() -> None:
     )
 
     assert bootstrap.should_greet_first is True
+    assert "You are Bob" in bootstrap.initial_response_instructions
     assert "caller is unknown" in bootstrap.initial_response_instructions
-    assert "Introduce yourself by name" in bootstrap.initial_response_instructions
+    assert "Hello, this is Bob" in bootstrap.initial_response_instructions
     assert "Who am I speaking to?" in bootstrap.initial_response_instructions
 
 
@@ -1626,4 +1629,29 @@ def test_greeting_unknown_caller_capitalizes_agent_name() -> None:
 
 def test_greeting_unknown_caller_default_name_is_bob() -> None:
     greeting = _build_fresh_call_greeting_instructions("+1555000000", None)
-    assert "Bob" in greeting
+    assert "You are Bob" in greeting
+    assert "Hello, this is Bob" in greeting
+
+
+def test_server_uses_general_agent_name_for_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("GPTME_VOICE_AGENT_NAME", raising=False)
+    monkeypatch.setenv("GPTME_AGENT_NAME", "Alice")
+
+    server = VoiceServer()
+
+    assert server._agent_name == "Alice"
+    assert server._instructions.startswith("IDENTITY: You are Alice.")
+
+
+def test_server_voice_agent_name_overrides_general_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENT_NAME", "Bob")
+    monkeypatch.setenv("GPTME_VOICE_AGENT_NAME", "Sven")
+
+    server = VoiceServer()
+
+    assert server._agent_name == "Sven"
+    assert server._instructions.startswith("IDENTITY: You are Sven.")

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -18,6 +18,7 @@ from gptme_voice.realtime.server import (
     VoiceServer,
     _assistant_committed_hangup,
     _build_caller_instructions,
+    _build_fresh_call_greeting_instructions,
     _build_resume_instructions,
     _build_runtime_identity_instructions,
     _get_twilio_field,
@@ -1603,4 +1604,26 @@ def test_server_g711_passthrough_ignored_for_grok_provider(
 
     session_config = server._build_session_config("You are Bob.")
     assert session_config.g711_passthrough is False
-    assert session_config.input_format == "pcm16"
+
+
+def test_greeting_unknown_caller_uses_configured_agent_name() -> None:
+    """Verify the inbound greeting for unknown callers uses the configured agent name.
+
+    Regression test for the trust bug where the model hallucinated names like
+    'Gordon' or 'Alex' because the instructions said 'introduce yourself by name'
+    without specifying what that name is.
+    """
+    greeting = _build_fresh_call_greeting_instructions("+1555000000", None, "bob")
+    assert "Bob" in greeting
+    assert "Gordon" not in greeting
+    assert "Alex" not in greeting
+
+
+def test_greeting_unknown_caller_capitalizes_agent_name() -> None:
+    greeting = _build_fresh_call_greeting_instructions("+1555000000", None, "alice")
+    assert "Alice" in greeting
+
+
+def test_greeting_unknown_caller_default_name_is_bob() -> None:
+    greeting = _build_fresh_call_greeting_instructions("+1555000000", None)
+    assert "Bob" in greeting


### PR DESCRIPTION
## Problem

The inbound call path told the realtime model to introduce itself without making the agent's name a stable, high-priority instruction. On two fresh calls on 2026-07-28, the model called itself “Gordon” and “Alex”. The first patch only covered unknown callers, but Erik's calls exposed a broader identity-path bug.

The contributing conditions were:

- caller admission and caller identification are separate: Erik's number was allowlisted but absent from the `people/*.md` directory scanned by caller lookup;
- the compact voice prompt can truncate personality context, leaving the agent name weak;
- nearby handoff guidance names other agents, making an underspecified “introduce yourself by name” instruction especially unsafe.

This is a trust bug, not a cosmetic greeting bug.

## Fix

- Prepend `IDENTITY: You are <agent>. Never claim to be another agent.` to every realtime voice session, before runtime/provider and project instructions.
- Repeat the configured self-name in fresh-call greeting instructions for both known and unknown callers.
- Resolve the name from the voice-specific `GPTME_VOICE_AGENT_NAME` setting first, then the general `AGENT_NAME` setting, then `bob`.
- Reuse that resolved name for handoff identity and available-agent filtering.

Caller-directory repair is deliberately separate: self-identity must remain correct even when caller recognition fails.

## Tests

Regression coverage verifies:

- known-caller and unknown-caller greetings both state `You are Bob`;
- the unknown-caller greeting says `Hello, this is Bob` rather than asking the model to infer a name;
- the general agent-name setting feeds session identity;
- the voice-specific setting overrides the general name;
- configured names are normalized for spoken display.

Local verification: `62 passed` in `packages/gptme-voice/tests/test_server.py`. CI, typecheck, integration tests, and patch coverage pass on `0ecaaa2a`.
