### PR TITLE
refactor(pr-queue-health): use bobutils.datetimes.parse_datetime

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -98,3 +98,9 @@ ignore_missing_imports = True
 
 [mypy-linear_oauth_state]
 ignore_missing_imports = True
+
+[mypy-bobutils]
+ignore_missing_imports = True
+
+[mypy-bobutils.*]
+ignore_missing_imports = True

--- a/scripts/github/pr-queue-health.py
+++ b/scripts/github/pr-queue-health.py
@@ -23,6 +23,8 @@ import sys
 from datetime import datetime, timezone
 from typing import Any
 
+from bobutils.datetimes import parse_datetime
+
 # Default repos to scan — override via GPTME_TRACKED_REPOS env var
 DEFAULT_TRACKED_REPOS = [
     "gptme/gptme",
@@ -143,21 +145,6 @@ def fetch_prs_for_repo(repo: str, author: str) -> list[dict[str, Any]] | None:
         warn(f"unexpected gh pr list payload for {repo}: expected list")
         return None
     return result
-
-
-def parse_datetime(dt_str: str) -> datetime | None:
-    """Parse GitHub datetime string."""
-    if not dt_str:
-        return None
-    for fmt in ["%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%dT%H:%M:%S%z"]:
-        try:
-            dt = datetime.strptime(dt_str, fmt)
-            if dt.tzinfo is None:
-                dt = dt.replace(tzinfo=timezone.utc)
-            return dt
-        except ValueError:
-            continue
-    return None
 
 
 def get_ci_status(pr: dict[str, Any]) -> str:

--- a/scripts/github/pr-queue-health.py
+++ b/scripts/github/pr-queue-health.py
@@ -21,9 +21,16 @@ import os
 import subprocess
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
-from bobutils.datetimes import parse_datetime
+# Keep the documented direct-Python invocation working from a source checkout.
+# An installed workspace environment already exposes bobutils; a bare clone does not.
+_BOBUTILS_SRC = Path(__file__).resolve().parents[2] / "packages" / "bobutils" / "src"
+if _BOBUTILS_SRC.is_dir():
+    sys.path.insert(0, str(_BOBUTILS_SRC))
+
+from bobutils.datetimes import parse_datetime  # noqa: E402
 
 # Default repos to scan — override via GPTME_TRACKED_REPOS env var
 DEFAULT_TRACKED_REPOS = [

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -5,6 +5,7 @@ import json
 import os
 import subprocess
 import sys
+import textwrap
 from pathlib import Path
 from unittest.mock import patch
 
@@ -50,12 +51,31 @@ def test_parse_datetime_invalid_returns_none() -> None:
     assert pr_queue_health.parse_datetime("not-a-timestamp") is None
 
 
-def test_direct_python_invocation_loads_bobutils_from_source_checkout() -> None:
+def test_direct_python_invocation_loads_bobutils_from_source_checkout(
+    tmp_path: Path,
+) -> None:
+    fake_gh = tmp_path / "gh"
+    fake_gh.write_text(
+        textwrap.dedent(
+            """\
+            #!/bin/sh
+            case "$1 $2" in
+              "api user") printf '%s\\n' 'TimeToBuildBob' ;;
+              "pr list") printf '%s\\n' '[]' ;;
+              *) exit 1 ;;
+            esac
+            """
+        )
+    )
+    fake_gh.chmod(0o755)
+
+    env = {**os.environ, "PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}"}
     result = subprocess.run(
         [sys.executable, "-I", str(MODULE_PATH), "--json"],
         capture_output=True,
         text=True,
         timeout=30,
+        env=env,
     )
 
     assert result.returncode == 0, result.stderr

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import os
 import subprocess
 import sys
@@ -47,6 +48,18 @@ def test_fetch_prs_for_repo_requests_limit_100() -> None:
 def test_parse_datetime_invalid_returns_none() -> None:
     assert pr_queue_health.parse_datetime("") is None
     assert pr_queue_health.parse_datetime("not-a-timestamp") is None
+
+
+def test_direct_python_invocation_loads_bobutils_from_source_checkout() -> None:
+    result = subprocess.run(
+        [sys.executable, "-I", str(MODULE_PATH), "--json"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert isinstance(json.loads(result.stdout), dict)
 
 
 def test_run_gh_warns_on_failure(capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
## Summary

- Replace the local `parse_datetime` function in `scripts/github/pr-queue-health.py` with the canonical `bobutils.datetimes.parse_datetime`
- Add `[mypy-bobutils.*]` sections to `mypy.ini` to match the existing pattern for other workspace packages

The local implementation used `strptime` with explicit format strings; the canonical version uses `fromisoformat` with better edge case handling. Both return `None` for empty or unparseable inputs.

`bobutils` is a workspace member (installed via `uv sync --all-packages`) and is importable in the environments that invoke this script.

## Test plan

- [x] `uv run ruff check scripts/github/pr-queue-health.py` passes
- [x] `uv run mypy --config-file mypy.ini --explicit-package-bases scripts/github/pr-queue-health.py` passes
- [x] Module imports correctly and `parse_datetime('2026-07-28T14:00:00Z')` returns the expected UTC datetime
- [x] `parse_datetime('')` and `parse_datetime(None)` both return `None`
- [x] Pre-commit hooks pass via `prek`