### PR TITLE
feat(voice): pre-fetch recent activity log for standup follow-up questions

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -360,7 +360,12 @@ async def _fetch_recent_activity_log(
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.DEVNULL,
         )
-        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5.0)
+        try:
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5.0)
+        except BaseException:
+            proc.kill()
+            await proc.wait()
+            raise
         lines = stdout.decode().strip().splitlines()
         if not lines:
             return ""

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -283,7 +283,7 @@ def _build_fresh_call_greeting_instructions(
     )
 
 
-def _build_standup_instructions_guidance() -> str:
+def _build_standup_instructions_guidance(*, has_activity_log: bool = False) -> str:
     """Return a guidance block prepended to the main instructions for standup calls.
 
     Unlike ``_build_standup_call_instructions`` (which only controls the model's
@@ -299,13 +299,25 @@ def _build_standup_instructions_guidance() -> str:
     2. **Stale queue references**: The model's session knowledge may include tweet
        drafts or deferred tasks that have already been resolved between brief
        generation and the call.
+
+    ``has_activity_log`` controls whether the guidance mentions the RECENT ACTIVITY
+    LOG section — only set to True when the log is actually populated.
     """
+    activity_log_hint = (
+        "- A RECENT ACTIVITY LOG (last 24h of git commits) is also loaded below the "
+        "brief. Use it to answer follow-up recap questions like 'what did you work on "
+        "today?' or 'what happened in the last 12 hours?' without dispatching a "
+        "subagent — the log gives you enough context for standard recap queries.\n"
+        if has_activity_log
+        else ""
+    )
     return (
         "STANDUP CALL GUIDANCE:\n"
         "- A pre-generated standup brief is loaded in your instructions below. "
         "The brief contains the latest blockers, active work, and recent highlights "
         "as of ~30 minutes before the call.\n"
-        "- When Erik asks follow-up questions about items in the brief (including "
+        + activity_log_hint
+        + "- When Erik asks follow-up questions about items in the brief (including "
         "'what else happened?', 'tell me more about X', or 'what's blocking Y'), "
         "answer from the brief content first. Do NOT use the subagent tool for "
         "routine recap or elaboration on items already covered by the brief.\n"
@@ -317,6 +329,47 @@ def _build_standup_instructions_guidance() -> str:
         "rather than definitely pending. Do NOT volunteer stale queue state that "
         "is not mentioned in the brief.\n"
     )
+
+
+async def _fetch_recent_activity_log(
+    workspace: str | None,
+    *,
+    hours: int = 24,
+    max_commits: int = 20,
+) -> str:
+    """Fetch a compact recent activity log from git for standup follow-up questions.
+
+    Returns a bullet-list of commit summaries (hashes stripped) from the last
+    ``hours`` hours, suitable for injection into session instructions so the voice
+    model can answer "what did you work on today?" without spawning a subagent.
+
+    Returns an empty string on failure or when workspace is not a git repo.
+    """
+    if not workspace:
+        return ""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "git",
+            "-C",
+            workspace,
+            "log",
+            "--oneline",
+            "--no-merges",
+            f"--since={hours} hours ago",
+            f"--max-count={max_commits}",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5.0)
+        lines = stdout.decode().strip().splitlines()
+        if not lines:
+            return ""
+        # Strip 7-char hash prefix before returning readable summaries
+        summaries = [line.split(" ", 1)[1] if " " in line else line for line in lines]
+        return "\n".join(f"- {s}" for s in summaries)
+    except Exception:
+        logger.debug("Failed to fetch recent activity log", exc_info=True)
+        return ""
 
 
 def _build_standup_call_instructions(brief_text: str) -> str:
@@ -938,11 +991,21 @@ class VoiceServer:
         # standup_brief takes priority over recent-call resume: an explicit outbound
         # standup should always deliver the brief, not silently resume a prior session.
         if standup_brief:
+            activity_log = await _fetch_recent_activity_log(self.workspace)
+            activity_section = (
+                "\n\nRECENT ACTIVITY LOG (last 24h — answer recap follow-ups from this, no subagent needed):\n"
+                + activity_log
+                if activity_log
+                else ""
+            )
             return SessionBootstrap(
                 instructions=(
-                    _build_standup_instructions_guidance()
+                    _build_standup_instructions_guidance(
+                        has_activity_log=bool(activity_log)
+                    )
                     + "\n\n"
                     + standup_brief
+                    + activity_section
                     + "\n\n"
                     + instructions
                 ),

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -1714,6 +1714,27 @@ def test_fetch_recent_activity_log_strips_hash_prefix(
     assert result.startswith("- ")
 
 
+def test_fetch_recent_activity_log_kills_process_on_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A timed-out git subprocess is terminated and reaped."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    fake_proc = MagicMock()
+    fake_proc.communicate = AsyncMock(side_effect=TimeoutError)
+    fake_proc.wait = AsyncMock()
+    monkeypatch.setattr(
+        "gptme_voice.realtime.server.asyncio.create_subprocess_exec",
+        AsyncMock(return_value=fake_proc),
+    )
+
+    result = asyncio.run(_fetch_recent_activity_log("/some/workspace"))
+
+    assert result == ""
+    fake_proc.kill.assert_called_once_with()
+    fake_proc.wait.assert_awaited_once_with()
+
+
 def test_build_session_bootstrap_standup_injects_activity_log(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -10,6 +10,7 @@ import time
 from pathlib import Path
 
 import pytest
+from gptme_voice.realtime import server as _server_module
 from gptme_voice.realtime.audio import AudioConverter
 from gptme_voice.realtime.server import (
     RecentCallRecord,
@@ -21,6 +22,7 @@ from gptme_voice.realtime.server import (
     _build_fresh_call_greeting_instructions,
     _build_resume_instructions,
     _build_runtime_identity_instructions,
+    _fetch_recent_activity_log,
     _get_twilio_field,
     _lookup_caller_identity,
     _should_trigger_hangup_transcript_fallback,
@@ -1672,3 +1674,93 @@ def test_server_voice_agent_name_overrides_general_name(
 
     assert server._agent_name == "Sven"
     assert server._instructions.startswith("IDENTITY: You are Sven.")
+
+
+# ---------------------------------------------------------------------------
+# Recent activity log: _fetch_recent_activity_log + standup bootstrap
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_recent_activity_log_returns_empty_for_none_workspace() -> None:
+    """No workspace → empty string, no subprocess spawned."""
+    result = asyncio.run(_fetch_recent_activity_log(None))
+    assert result == ""
+
+
+def test_fetch_recent_activity_log_strips_hash_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hash prefix is stripped; output is a bullet list of summaries."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    fake_proc = MagicMock()
+    fake_proc.communicate = AsyncMock(
+        return_value=(
+            b"abc1234 fix: greeting hallucination\ndef5678 chore: update tasks\n",
+            b"",
+        )
+    )
+    monkeypatch.setattr(
+        "gptme_voice.realtime.server.asyncio.create_subprocess_exec",
+        AsyncMock(return_value=fake_proc),
+    )
+
+    result = asyncio.run(_fetch_recent_activity_log("/some/workspace"))
+    assert "fix: greeting hallucination" in result
+    assert "chore: update tasks" in result
+    # Short hashes must not appear in the output
+    assert "abc1234" not in result
+    assert "def5678" not in result
+    assert result.startswith("- ")
+
+
+def test_build_session_bootstrap_standup_injects_activity_log(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Standup bootstrap injects the recent activity log into instructions."""
+
+    async def _fake_fetch(workspace: str | None, **_: object) -> str:
+        return "- fix: greeting hallucination\n- chore: update tasks"
+
+    monkeypatch.setattr(_server_module, "_fetch_recent_activity_log", _fake_fetch)
+
+    voice_server = VoiceServer(workspace="/fake/workspace")
+    voice_server._instructions = "You are Bob."
+
+    bootstrap = asyncio.run(
+        voice_server._build_session_bootstrap(
+            caller_id=None,
+            standup_brief="STANDUP BRIEF: Working on voice features.",
+        )
+    )
+
+    assert "RECENT ACTIVITY LOG" in bootstrap.instructions
+    assert "fix: greeting hallucination" in bootstrap.instructions
+    assert "chore: update tasks" in bootstrap.instructions
+    assert "STANDUP BRIEF: Working on voice features." in bootstrap.instructions
+    assert bootstrap.should_greet_first is True
+
+
+def test_build_session_bootstrap_standup_no_activity_section_when_log_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Standup bootstrap omits the RECENT ACTIVITY LOG section when git is unavailable."""
+
+    async def _fake_fetch(workspace: str | None, **_: object) -> str:
+        return ""  # simulate git failure / empty repo
+
+    monkeypatch.setattr(_server_module, "_fetch_recent_activity_log", _fake_fetch)
+
+    voice_server = VoiceServer(workspace="/fake/workspace")
+    voice_server._instructions = "You are Bob."
+
+    bootstrap = asyncio.run(
+        voice_server._build_session_bootstrap(
+            caller_id=None,
+            standup_brief="STANDUP BRIEF: Working on voice features.",
+        )
+    )
+
+    assert "RECENT ACTIVITY LOG" not in bootstrap.instructions
+    assert "STANDUP BRIEF: Working on voice features." in bootstrap.instructions
+    assert bootstrap.should_greet_first is True


### PR DESCRIPTION
## Problem

During a standup call on 2026-07-28, Erik asked "what have you been doing for
the last 12 hours" and the voice agent dispatched a subagent to research the
answer. The subagent timed out and interrupted Erik mid-sentence.

Root cause: for standup calls, the pre-generated brief covers blockers and
active tasks, but lacks enough recent-work detail to answer broad recap queries
like "what happened today?" The model falls back to the subagent tool, which is
too slow for realtime voice.

## Fix

At standup session bootstrap time, asynchronously run `git log --since=24h` in
the workspace repo (5s timeout, degrades gracefully to empty on failure) and
inject the result as a `RECENT ACTIVITY LOG` section in the session instructions.

The model now has commit-level context to answer standard recap questions inline
— no subagent round-trip needed for the common case.

## Changes

- **`_fetch_recent_activity_log(workspace, *, hours=24, max_commits=20)`** — new
  async helper. Runs `git log --oneline --no-merges --since=Nh`, strips hash
  prefixes, returns a `- bullet` list or `""` on failure.

- **`_build_standup_instructions_guidance(*, has_activity_log=False)`** — new
  keyword param controls whether the guidance mentions the RECENT ACTIVITY LOG
  section. Avoids phantom references when git is unavailable.

- **`_build_session_bootstrap()`** — calls the helper for standup calls and
  injects the `RECENT ACTIVITY LOG` section + guidance hint when non-empty.

- **4 new regression tests**: empty workspace returns `""`, hash stripping,
  log injection into standup bootstrap, empty-log path omits section.

## Scope

Standup (outbound) calls only. The non-standup inbound case (Erik calling in
cold) is deferred — there's no pre-warm window for research before the call
connects.

## Test plan

- [x] `pytest packages/gptme-voice/tests/test_server.py -k "activity_log"` — 4 new tests pass
- [x] Full `pytest packages/gptme-voice/tests/test_server.py` — all 61 tests pass
- [x] Pre-commit hooks (prek) pass