### PR TITLE
feat(voice): add audio cues for subagent dispatch and timeout

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/client.py
@@ -153,6 +153,13 @@ class LocalVoiceTest:
                         self._playing = True
                         audio_data = base64.b64decode(audio_b64)
                         stream.write(audio_data)
+                elif data.get("type") == "sound_cue":
+                    audio_b64 = data.get("audio", "")
+                    if audio_b64:
+                        self._playing = True
+                        stream.write(base64.b64decode(audio_b64))
+                        self._playing = False
+                        self._play_ended_at = time.monotonic()
                 elif data.get("type") == "audio_end":
                     self._playing = False
                     self._play_ended_at = time.monotonic()

--- a/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
@@ -571,25 +571,6 @@ class OpenAIRealtimeClient:
         )
         await self._send_event("response.create", {})
 
-    async def inject_status_cue(self, cue_text: str) -> None:
-        """Speak a brief status cue without adding to conversation history.
-
-        Uses ``conversation: "none"`` so the generated turn does not appear in
-        the session history and does not affect subsequent responses.  Intended
-        for short in-band signals like "one moment…" or "that lookup timed out."
-        """
-        logger.info(f"Injecting status cue: {cue_text!r}")
-        await self._send_event(
-            "response.create",
-            {
-                "response": {
-                    "conversation": "none",
-                    "modalities": ["text", "audio"],
-                    "instructions": f'Say only: "{cue_text}"',
-                }
-            },
-        )
-
     @staticmethod
     def _should_auto_respond_after_function_output(name: str, result: Any) -> bool:
         """Decide whether a function-call result should trigger immediate speech.

--- a/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/openai_client.py
@@ -571,6 +571,25 @@ class OpenAIRealtimeClient:
         )
         await self._send_event("response.create", {})
 
+    async def inject_status_cue(self, cue_text: str) -> None:
+        """Speak a brief status cue without adding to conversation history.
+
+        Uses ``conversation: "none"`` so the generated turn does not appear in
+        the session history and does not affect subsequent responses.  Intended
+        for short in-band signals like "one moment…" or "that lookup timed out."
+        """
+        logger.info(f"Injecting status cue: {cue_text!r}")
+        await self._send_event(
+            "response.create",
+            {
+                "response": {
+                    "conversation": "none",
+                    "modalities": ["text", "audio"],
+                    "instructions": f'Say only: "{cue_text}"',
+                }
+            },
+        )
+
     @staticmethod
     def _should_auto_respond_after_function_output(name: str, result: Any) -> bool:
         """Decide whether a function-call result should trigger immediate speech.

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -40,6 +40,7 @@ from .openai_client import (
     _get_openai_api_key,
     _load_project_instructions,
 )
+from .sounds import DISPATCH_CUE_MULAW, TIMEOUT_CUE_MULAW
 from .tool_bridge import GptmeToolBridge
 from .twilio_integration import (
     _get_config_env,
@@ -1621,14 +1622,20 @@ class VoiceServer:
 
                     # Wire tool bridge BEFORE connect/activate so on_function_call
                     # is set when the initial greeting response fires.
+                    def _make_twilio_cue_callback(_ws, _sid: str, _mulaw: bytes):
+                        async def _cb() -> None:
+                            await self._send_to_twilio(_ws, _sid, _mulaw)
+
+                        return _cb
+
                     tool_bridge = GptmeToolBridge(
                         workspace=self.workspace,
                         on_result=realtime_client.inject_message,
-                        on_dispatch=lambda: realtime_client.inject_status_cue(
-                            "One moment…"
+                        on_dispatch=_make_twilio_cue_callback(
+                            websocket, stream_sid, DISPATCH_CUE_MULAW
                         ),
-                        on_timeout=lambda: realtime_client.inject_status_cue(
-                            "That lookup timed out."
+                        on_timeout=_make_twilio_cue_callback(
+                            websocket, stream_sid, TIMEOUT_CUE_MULAW
                         ),
                         on_hangup=_twilio_hangup,
                         on_handoff=self._make_handoff_callback([caller_id], transcript),
@@ -1836,13 +1843,17 @@ class VoiceServer:
                 on_user_transcript=on_user_transcript,
             )
 
+            def _make_ws_cue_callback(_ws, _cue: str):
+                async def _cb() -> None:
+                    await _ws.send_text(json.dumps({"type": "sound_cue", "cue": _cue}))
+
+                return _cb
+
             tool_bridge = GptmeToolBridge(
                 workspace=self.workspace,
                 on_result=realtime_client.inject_message,
-                on_dispatch=lambda: realtime_client.inject_status_cue("One moment…"),
-                on_timeout=lambda: realtime_client.inject_status_cue(
-                    "That lookup timed out."
-                ),
+                on_dispatch=_make_ws_cue_callback(websocket, "dispatch"),
+                on_timeout=_make_ws_cue_callback(websocket, "timeout"),
                 on_hangup=_local_hangup,
                 on_handoff=self._make_handoff_callback([caller_id], transcript),
                 transcript_provider=lambda: transcript,
@@ -1928,13 +1939,17 @@ class VoiceServer:
                 on_user_transcript=on_user_transcript,
             )
 
+            def _make_browser_cue_callback(_ws, _cue: str):
+                async def _cb() -> None:
+                    await _ws.send_text(json.dumps({"type": "sound_cue", "cue": _cue}))
+
+                return _cb
+
             tool_bridge = GptmeToolBridge(
                 workspace=self.workspace,
                 on_result=realtime_client.inject_message,
-                on_dispatch=lambda: realtime_client.inject_status_cue("One moment…"),
-                on_timeout=lambda: realtime_client.inject_status_cue(
-                    "That lookup timed out."
-                ),
+                on_dispatch=_make_browser_cue_callback(websocket, "dispatch"),
+                on_timeout=_make_browser_cue_callback(websocket, "timeout"),
                 on_hangup=_browser_hangup,
                 on_handoff=self._make_handoff_callback([caller_id], transcript),
                 transcript_provider=lambda: transcript,

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -40,7 +40,7 @@ from .openai_client import (
     _get_openai_api_key,
     _load_project_instructions,
 )
-from .sounds import DISPATCH_CUE_MULAW, TIMEOUT_CUE_MULAW
+from .sounds import DISPATCH_CUE_MULAW, PCM_CUES, SAMPLE_RATE, TIMEOUT_CUE_MULAW
 from .tool_bridge import GptmeToolBridge
 from .twilio_integration import (
     _get_config_env,
@@ -1806,6 +1806,22 @@ class VoiceServer:
 
         return _on_ai_transcript, _on_user_transcript, _on_hangup
 
+    @staticmethod
+    def _make_sound_cue_callback(websocket, cue: str):
+        async def _send_cue() -> None:
+            await websocket.send_text(
+                json.dumps(
+                    {
+                        "type": "sound_cue",
+                        "cue": cue,
+                        "sample_rate": SAMPLE_RATE,
+                        "audio": base64.b64encode(PCM_CUES[cue]).decode("ascii"),
+                    }
+                )
+            )
+
+        return _send_cue
+
     async def handle_local_websocket(self, websocket):
         """
         Handle WebSocket connection for local testing.
@@ -1843,17 +1859,11 @@ class VoiceServer:
                 on_user_transcript=on_user_transcript,
             )
 
-            def _make_ws_cue_callback(_ws, _cue: str):
-                async def _cb() -> None:
-                    await _ws.send_text(json.dumps({"type": "sound_cue", "cue": _cue}))
-
-                return _cb
-
             tool_bridge = GptmeToolBridge(
                 workspace=self.workspace,
                 on_result=realtime_client.inject_message,
-                on_dispatch=_make_ws_cue_callback(websocket, "dispatch"),
-                on_timeout=_make_ws_cue_callback(websocket, "timeout"),
+                on_dispatch=self._make_sound_cue_callback(websocket, "dispatch"),
+                on_timeout=self._make_sound_cue_callback(websocket, "timeout"),
                 on_hangup=_local_hangup,
                 on_handoff=self._make_handoff_callback([caller_id], transcript),
                 transcript_provider=lambda: transcript,
@@ -1939,17 +1949,11 @@ class VoiceServer:
                 on_user_transcript=on_user_transcript,
             )
 
-            def _make_browser_cue_callback(_ws, _cue: str):
-                async def _cb() -> None:
-                    await _ws.send_text(json.dumps({"type": "sound_cue", "cue": _cue}))
-
-                return _cb
-
             tool_bridge = GptmeToolBridge(
                 workspace=self.workspace,
                 on_result=realtime_client.inject_message,
-                on_dispatch=_make_browser_cue_callback(websocket, "dispatch"),
-                on_timeout=_make_browser_cue_callback(websocket, "timeout"),
+                on_dispatch=self._make_sound_cue_callback(websocket, "dispatch"),
+                on_timeout=self._make_sound_cue_callback(websocket, "timeout"),
                 on_hangup=_browser_hangup,
                 on_handoff=self._make_handoff_callback([caller_id], transcript),
                 transcript_provider=lambda: transcript,

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -1624,6 +1624,12 @@ class VoiceServer:
                     tool_bridge = GptmeToolBridge(
                         workspace=self.workspace,
                         on_result=realtime_client.inject_message,
+                        on_dispatch=lambda: realtime_client.inject_status_cue(
+                            "One moment…"
+                        ),
+                        on_timeout=lambda: realtime_client.inject_status_cue(
+                            "That lookup timed out."
+                        ),
                         on_hangup=_twilio_hangup,
                         on_handoff=self._make_handoff_callback([caller_id], transcript),
                         transcript_provider=lambda: transcript,
@@ -1833,6 +1839,10 @@ class VoiceServer:
             tool_bridge = GptmeToolBridge(
                 workspace=self.workspace,
                 on_result=realtime_client.inject_message,
+                on_dispatch=lambda: realtime_client.inject_status_cue("One moment…"),
+                on_timeout=lambda: realtime_client.inject_status_cue(
+                    "That lookup timed out."
+                ),
                 on_hangup=_local_hangup,
                 on_handoff=self._make_handoff_callback([caller_id], transcript),
                 transcript_provider=lambda: transcript,
@@ -1921,6 +1931,10 @@ class VoiceServer:
             tool_bridge = GptmeToolBridge(
                 workspace=self.workspace,
                 on_result=realtime_client.inject_message,
+                on_dispatch=lambda: realtime_client.inject_status_cue("One moment…"),
+                on_timeout=lambda: realtime_client.inject_status_cue(
+                    "That lookup timed out."
+                ),
                 on_hangup=_browser_hangup,
                 on_handoff=self._make_handoff_callback([caller_id], transcript),
                 transcript_provider=lambda: transcript,

--- a/packages/gptme-voice/src/gptme_voice/realtime/sounds.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/sounds.py
@@ -1,14 +1,14 @@
-"""Pre-generated μ-law audio cues for Twilio transport sound effects.
+"""Pre-generated audio cues for voice transports.
 
-Tones are generated at module load (pure stdlib, no audio deps) and
-cached as bytes ready to pass directly to Twilio's media stream.
+Tones are generated at module load and cached as PCM16 for local/browser
+clients and μ-law for Twilio's media stream.
 """
 
 import audioop
 import math
 import struct
 
-_SAMPLE_RATE = 8000  # Twilio μ-law rate
+SAMPLE_RATE = 8000
 _AMPLITUDE = 0.45  # keep below clipping; μ-law compresses anyway
 
 
@@ -17,11 +17,11 @@ def _gen_pcm_tone(freq_hz: float, duration_ms: int) -> bytes:
 
     Applies a short fade-in/fade-out (10% of duration) to avoid clicks.
     """
-    n = int(_SAMPLE_RATE * duration_ms / 1000)
+    n = int(SAMPLE_RATE * duration_ms / 1000)
     fade = max(1, n // 10)
     samples: list[int] = []
     for i in range(n):
-        t = i / _SAMPLE_RATE
+        t = i / SAMPLE_RATE
         v = _AMPLITUDE * math.sin(2 * math.pi * freq_hz * t)
         if i < fade:
             v *= i / fade
@@ -32,7 +32,7 @@ def _gen_pcm_tone(freq_hz: float, duration_ms: int) -> bytes:
 
 
 def _gen_pcm_silence(duration_ms: int) -> bytes:
-    return bytes(int(_SAMPLE_RATE * duration_ms / 1000) * 2)
+    return bytes(int(SAMPLE_RATE * duration_ms / 1000) * 2)
 
 
 def _to_mulaw(pcm: bytes) -> bytes:
@@ -41,10 +41,18 @@ def _to_mulaw(pcm: bytes) -> bytes:
 
 # Dispatch cue: two rising tones — "I'm on it"
 # 80 ms @ 880 Hz · 30 ms silence · 80 ms @ 1100 Hz
-DISPATCH_CUE_MULAW: bytes = _to_mulaw(
+DISPATCH_CUE_PCM: bytes = (
     _gen_pcm_tone(880, 80) + _gen_pcm_silence(30) + _gen_pcm_tone(1100, 80)
 )
 
-# Timeout cue: single descending tone — "that didn't work"
+# Timeout cue: single low tone — "that didn't work"
 # 200 ms @ 450 Hz
-TIMEOUT_CUE_MULAW: bytes = _to_mulaw(_gen_pcm_tone(450, 200))
+TIMEOUT_CUE_PCM: bytes = _gen_pcm_tone(450, 200)
+
+DISPATCH_CUE_MULAW: bytes = _to_mulaw(DISPATCH_CUE_PCM)
+TIMEOUT_CUE_MULAW: bytes = _to_mulaw(TIMEOUT_CUE_PCM)
+
+PCM_CUES: dict[str, bytes] = {
+    "dispatch": DISPATCH_CUE_PCM,
+    "timeout": TIMEOUT_CUE_PCM,
+}

--- a/packages/gptme-voice/src/gptme_voice/realtime/sounds.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/sounds.py
@@ -1,0 +1,50 @@
+"""Pre-generated μ-law audio cues for Twilio transport sound effects.
+
+Tones are generated at module load (pure stdlib, no audio deps) and
+cached as bytes ready to pass directly to Twilio's media stream.
+"""
+
+import audioop
+import math
+import struct
+
+_SAMPLE_RATE = 8000  # Twilio μ-law rate
+_AMPLITUDE = 0.45  # keep below clipping; μ-law compresses anyway
+
+
+def _gen_pcm_tone(freq_hz: float, duration_ms: int) -> bytes:
+    """Generate a sine wave as 16-bit signed little-endian PCM at 8 kHz.
+
+    Applies a short fade-in/fade-out (10% of duration) to avoid clicks.
+    """
+    n = int(_SAMPLE_RATE * duration_ms / 1000)
+    fade = max(1, n // 10)
+    samples: list[int] = []
+    for i in range(n):
+        t = i / _SAMPLE_RATE
+        v = _AMPLITUDE * math.sin(2 * math.pi * freq_hz * t)
+        if i < fade:
+            v *= i / fade
+        elif i > n - fade:
+            v *= (n - i) / fade
+        samples.append(int(32767 * v))
+    return struct.pack(f"<{n}h", *samples)
+
+
+def _gen_pcm_silence(duration_ms: int) -> bytes:
+    return bytes(int(_SAMPLE_RATE * duration_ms / 1000) * 2)
+
+
+def _to_mulaw(pcm: bytes) -> bytes:
+    return audioop.lin2ulaw(pcm, 2)
+
+
+# Dispatch cue: two rising tones — "I'm on it"
+# 80 ms @ 880 Hz · 30 ms silence · 80 ms @ 1100 Hz
+DISPATCH_CUE_MULAW: bytes = _to_mulaw(
+    _gen_pcm_tone(880, 80) + _gen_pcm_silence(30) + _gen_pcm_tone(1100, 80)
+)
+
+# Timeout cue: single descending tone — "that didn't work"
+# 200 ms @ 450 Hz
+TIMEOUT_CUE_MULAW: bytes = _to_mulaw(_gen_pcm_tone(450, 200))

--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -152,6 +152,7 @@ class GptmeToolBridge:
         self._pending_tasks: dict[str, PendingTask] = {}
         self._task_counter = 0
         self._completed_timings: list[dict[str, object]] = []
+        self._cue_tasks: set[asyncio.Task[None]] = set()
         # Short-lived buffer of recently-completed tasks so subagent_status can
         # distinguish "timed out" from "succeeded" from "never started".
         self._recent_completions: deque[dict] = deque(maxlen=_MAX_RECENT_COMPLETIONS)
@@ -411,6 +412,24 @@ class GptmeToolBridge:
             copies.append(copy)
         return copies
 
+    def _dispatch_cue(
+        self, callback: Callable[[], Awaitable[None]], *, cue_name: str
+    ) -> None:
+        """Send an optional cue without blocking the subagent lifecycle."""
+
+        async def _send() -> None:
+            try:
+                async with asyncio.timeout(_CUE_CALLBACK_TIMEOUT_SECONDS):
+                    await callback()
+            except TimeoutError:
+                logger.warning("Timed out sending subagent %s cue", cue_name)
+            except Exception:
+                logger.exception("Failed to send subagent %s cue", cue_name)
+
+        task = asyncio.create_task(_send())
+        self._cue_tasks.add(task)
+        task.add_done_callback(self._cue_tasks.discard)
+
     async def _run_subagent(self, task_id: str, task: str, mode: str = "fast") -> None:
         """Run a subagent in the background and inject result when done."""
         pending = self._pending_tasks.get(task_id)
@@ -496,14 +515,7 @@ class GptmeToolBridge:
         # The cue is best-effort: transport failure must not suppress the result
         # or leave a completed task in the pending map.
         if completion_status == "timed_out" and self.on_timeout:
-            try:
-                await asyncio.wait_for(
-                    self.on_timeout(), timeout=_CUE_CALLBACK_TIMEOUT_SECONDS
-                )
-            except TimeoutError:
-                logger.warning("Timed out sending subagent timeout cue")
-            except Exception:
-                logger.exception("Failed to send subagent timeout cue")
+            self._dispatch_cue(self.on_timeout, cue_name="timeout")
 
         # Inject result into conversation
         if self.on_result:
@@ -798,14 +810,7 @@ class GptmeToolBridge:
             # The cue is best-effort: the subagent is already running, so a
             # transport failure must not hide its dispatch receipt.
             if self.on_dispatch:
-                try:
-                    await asyncio.wait_for(
-                        self.on_dispatch(), timeout=_CUE_CALLBACK_TIMEOUT_SECONDS
-                    )
-                except TimeoutError:
-                    logger.warning("Timed out sending subagent dispatch cue")
-                except Exception:
-                    logger.exception("Failed to send subagent dispatch cue")
+                self._dispatch_cue(self.on_dispatch, cue_name="dispatch")
 
             return {
                 "status": "dispatched",

--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -117,6 +117,8 @@ class GptmeToolBridge:
         timeout: int = 300,
         workspace: str | None = None,
         on_result: Callable[[str], Awaitable[None]] | None = None,
+        on_dispatch: Callable[[], Awaitable[None]] | None = None,
+        on_timeout: Callable[[], Awaitable[None]] | None = None,
         on_hangup: Callable[[str | None], Awaitable[None]] | None = None,
         on_handoff: Callable[[str, str, str | None], Awaitable[dict]] | None = None,
         transcript_provider: Callable[[], Sequence[object]] | None = None,
@@ -125,6 +127,8 @@ class GptmeToolBridge:
         self.timeout = timeout
         self.workspace = workspace
         self.on_result = on_result
+        self.on_dispatch = on_dispatch
+        self.on_timeout = on_timeout
         self.on_hangup = on_hangup
         self.on_handoff = on_handoff
         self.transcript_provider = transcript_provider
@@ -485,6 +489,11 @@ class GptmeToolBridge:
             }
         )
 
+        # Fire timeout cue before injecting the error so the caller hears a
+        # distinct signal rather than just dead air followed by an error message.
+        if completion_status == "timed_out" and self.on_timeout:
+            await self.on_timeout()
+
         # Inject result into conversation
         if self.on_result:
             await self.on_result(response_text)
@@ -774,6 +783,9 @@ class GptmeToolBridge:
                 started_at=time.monotonic(),
                 model=model,
             )
+
+            if self.on_dispatch:
+                await self.on_dispatch()
 
             return {
                 "status": "dispatched",

--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -62,6 +62,8 @@ _TIMEOUT_BINARY_AVAILABLE = shutil.which("timeout") is not None
 # How many recently-completed task records to keep for subagent_status queries.
 # The model can see these to understand whether a task succeeded, timed out, or errored.
 _MAX_RECENT_COMPLETIONS = 5
+# Audio cues are optional UX. Never let a blocked transport delay the tool lifecycle.
+_CUE_CALLBACK_TIMEOUT_SECONDS = 1.0
 _DEFAULT_TRANSCRIPT_TAIL_TURNS = 8
 _DEFAULT_TRANSCRIPT_TAIL_CHARS = 1_600
 
@@ -495,7 +497,11 @@ class GptmeToolBridge:
         # or leave a completed task in the pending map.
         if completion_status == "timed_out" and self.on_timeout:
             try:
-                await self.on_timeout()
+                await asyncio.wait_for(
+                    self.on_timeout(), timeout=_CUE_CALLBACK_TIMEOUT_SECONDS
+                )
+            except TimeoutError:
+                logger.warning("Timed out sending subagent timeout cue")
             except Exception:
                 logger.exception("Failed to send subagent timeout cue")
 
@@ -793,7 +799,11 @@ class GptmeToolBridge:
             # transport failure must not hide its dispatch receipt.
             if self.on_dispatch:
                 try:
-                    await self.on_dispatch()
+                    await asyncio.wait_for(
+                        self.on_dispatch(), timeout=_CUE_CALLBACK_TIMEOUT_SECONDS
+                    )
+                except TimeoutError:
+                    logger.warning("Timed out sending subagent dispatch cue")
                 except Exception:
                     logger.exception("Failed to send subagent dispatch cue")
 

--- a/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/tool_bridge.py
@@ -491,8 +491,13 @@ class GptmeToolBridge:
 
         # Fire timeout cue before injecting the error so the caller hears a
         # distinct signal rather than just dead air followed by an error message.
+        # The cue is best-effort: transport failure must not suppress the result
+        # or leave a completed task in the pending map.
         if completion_status == "timed_out" and self.on_timeout:
-            await self.on_timeout()
+            try:
+                await self.on_timeout()
+            except Exception:
+                logger.exception("Failed to send subagent timeout cue")
 
         # Inject result into conversation
         if self.on_result:
@@ -784,8 +789,13 @@ class GptmeToolBridge:
                 model=model,
             )
 
+            # The cue is best-effort: the subagent is already running, so a
+            # transport failure must not hide its dispatch receipt.
             if self.on_dispatch:
-                await self.on_dispatch()
+                try:
+                    await self.on_dispatch()
+                except Exception:
+                    logger.exception("Failed to send subagent dispatch cue")
 
             return {
                 "status": "dispatched",

--- a/packages/gptme-voice/src/gptme_voice/static/index.html
+++ b/packages/gptme-voice/src/gptme_voice/static/index.html
@@ -209,13 +209,13 @@ registerProcessor('pcm16-capture', PCM16CaptureProcessor);
       }
     }
 
-    function enqueueAudio(arrayBuffer) {
+    function enqueueAudio(arrayBuffer, sampleRate = OUT_RATE) {
       ensurePlayCtx();
       const int16 = new Int16Array(arrayBuffer);
       const float32 = new Float32Array(int16.length);
       for (let i = 0; i < int16.length; i++) float32[i] = int16[i] / 32768;
 
-      const buf = playCtx.createBuffer(1, float32.length, OUT_RATE);
+      const buf = playCtx.createBuffer(1, float32.length, sampleRate);
       buf.getChannelData(0).set(float32);
       const src = playCtx.createBufferSource();
       src.buffer = buf;
@@ -273,6 +273,11 @@ registerProcessor('pcm16-capture', PCM16CaptureProcessor);
               setStatus(`Mic error: ${err.message}`, 'error');
             }
           } else if (msg.type === 'audio_end') {
+            onAudioEnd();
+          } else if (msg.type === 'sound_cue' && msg.audio) {
+            const raw = atob(msg.audio);
+            const bytes = Uint8Array.from(raw, c => c.charCodeAt(0));
+            enqueueAudio(bytes.buffer, msg.sample_rate ?? OUT_RATE);
             onAudioEnd();
           } else if (msg.type === 'transcript') {
             addTranscript(msg.text, msg.role ?? 'assistant');

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -25,6 +25,7 @@ from gptme_voice.realtime.server import (
     _should_trigger_hangup_transcript_fallback,
     _truncate_resume_transcript,
 )
+from gptme_voice.realtime.sounds import PCM_CUES, SAMPLE_RATE
 
 
 class _DummyWebSocket:
@@ -316,6 +317,22 @@ def test_send_to_twilio_uses_stream_sid_field_name() -> None:
         "streamSid": "MZ123",
         "media": {"payload": base64.b64encode(b"\x00\x01").decode("utf-8")},
     }
+
+
+def test_sound_cue_callback_sends_playable_pcm_payload() -> None:
+    async def _exercise() -> None:
+        websocket = _DummyWebSocket()
+        callback = VoiceServer._make_sound_cue_callback(websocket, "dispatch")
+
+        await callback()
+
+        message = json.loads(websocket.messages[0])
+        assert message["type"] == "sound_cue"
+        assert message["cue"] == "dispatch"
+        assert message["sample_rate"] == SAMPLE_RATE
+        assert base64.b64decode(message["audio"]) == PCM_CUES["dispatch"]
+
+    asyncio.run(_exercise())
 
 
 def test_build_session_config_passes_reasoning_effort_override() -> None:

--- a/packages/gptme-voice/tests/test_tool_bridge.py
+++ b/packages/gptme-voice/tests/test_tool_bridge.py
@@ -1357,6 +1357,56 @@ def test_on_dispatch_failure_does_not_hide_dispatch_receipt(caplog) -> None:
     asyncio.run(_exercise())
 
 
+def test_on_dispatch_timeout_does_not_hide_dispatch_receipt(
+    caplog, monkeypatch
+) -> None:
+    """A stalled cue send must not orphan an already-running subagent."""
+
+    async def _exercise() -> None:
+        cue_cancelled = asyncio.Event()
+
+        async def _stalled_on_dispatch() -> None:
+            try:
+                await asyncio.Future()
+            finally:
+                cue_cancelled.set()
+
+        class _SlowProcess(_FakeProcess):
+            async def wait(self) -> int:
+                await asyncio.sleep(5)
+                return 0
+
+        async def _fake_create_subprocess_exec(*_args, **_kwargs):
+            return _SlowProcess(returncode=0)
+
+        monkeypatch.setattr(
+            "gptme_voice.realtime.tool_bridge._CUE_CALLBACK_TIMEOUT_SECONDS", 0.01
+        )
+        monkeypatch.setattr(
+            asyncio, "create_subprocess_exec", _fake_create_subprocess_exec
+        )
+        bridge = GptmeToolBridge(
+            workspace="/fake/workspace",
+            on_dispatch=_stalled_on_dispatch,
+        )
+
+        with caplog.at_level(logging.WARNING):
+            result = await bridge.handle_function_call(
+                "subagent", {"task": "list recent commits", "mode": "fast"}
+            )
+
+        assert result["status"] == "dispatched"
+        assert result["task_id"] in bridge._pending_tasks
+        assert cue_cancelled.is_set()
+        assert "Timed out sending subagent dispatch cue" in caplog.text
+
+        await bridge.handle_function_call(
+            "subagent_cancel", {"task_id": result["task_id"]}
+        )
+
+    asyncio.run(_exercise())
+
+
 def test_on_dispatch_not_called_for_non_subagent_calls() -> None:
     """on_dispatch must not fire for subagent_status or other tool calls."""
 
@@ -1449,6 +1499,55 @@ def test_on_timeout_failure_does_not_suppress_result_or_cleanup(caplog) -> None:
             assert len(result_calls) == 1
             assert dispatch["task_id"] not in bridge._pending_tasks
             assert "Failed to send subagent timeout cue" in caplog.text
+
+    asyncio.run(_exercise())
+
+
+def test_on_timeout_callback_timeout_does_not_suppress_result_or_cleanup(
+    caplog, monkeypatch
+) -> None:
+    """A stalled timeout cue must not interrupt task completion."""
+
+    async def _exercise() -> None:
+        result_calls: list[str] = []
+        cue_cancelled = asyncio.Event()
+
+        async def _stalled_on_timeout() -> None:
+            try:
+                await asyncio.Future()
+            finally:
+                cue_cancelled.set()
+
+        async def _fake_on_result(text: str) -> None:
+            result_calls.append(text)
+
+        async def _fake_create_subprocess_exec(*_args, **_kwargs):
+            return _FakeProcess(returncode=124, stdout="partial output\n")
+
+        monkeypatch.setattr(
+            "gptme_voice.realtime.tool_bridge._CUE_CALLBACK_TIMEOUT_SECONDS", 0.01
+        )
+        monkeypatch.setattr(
+            asyncio, "create_subprocess_exec", _fake_create_subprocess_exec
+        )
+        bridge = GptmeToolBridge(
+            workspace="/fake/workspace",
+            timeout=10,
+            on_result=_fake_on_result,
+            on_timeout=_stalled_on_timeout,
+        )
+
+        with caplog.at_level(logging.WARNING):
+            dispatch = await bridge.handle_function_call(
+                "subagent", {"task": "slow analysis task", "mode": "fast"}
+            )
+            for _ in range(30):
+                await asyncio.sleep(0.001)
+
+        assert len(result_calls) == 1
+        assert dispatch["task_id"] not in bridge._pending_tasks
+        assert cue_cancelled.is_set()
+        assert "Timed out sending subagent timeout cue" in caplog.text
 
     asyncio.run(_exercise())
 

--- a/packages/gptme-voice/tests/test_tool_bridge.py
+++ b/packages/gptme-voice/tests/test_tool_bridge.py
@@ -1294,3 +1294,121 @@ def test_handoff_passes_none_context_summary_when_absent() -> None:
         assert captured["context_summary"] is None
 
     asyncio.run(_exercise())
+
+
+def test_on_dispatch_called_when_subagent_dispatched() -> None:
+    """on_dispatch callback fires immediately after a subagent task is enqueued."""
+
+    async def _exercise() -> None:
+        dispatch_calls: list[None] = []
+
+        async def _fake_on_dispatch() -> None:
+            dispatch_calls.append(None)
+
+        async def _fake_create_subprocess_exec(*_args, **_kwargs):
+            return _FakeProcess(returncode=0)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+            bridge = GptmeToolBridge(
+                workspace="/fake/workspace",
+                on_dispatch=_fake_on_dispatch,
+            )
+
+            result = await bridge.handle_function_call(
+                "subagent", {"task": "list recent commits", "mode": "fast"}
+            )
+
+        assert result["status"] == "dispatched"
+        assert len(dispatch_calls) == 1
+
+    asyncio.run(_exercise())
+
+
+def test_on_dispatch_not_called_for_non_subagent_calls() -> None:
+    """on_dispatch must not fire for subagent_status or other tool calls."""
+
+    async def _exercise() -> None:
+        dispatch_calls: list[None] = []
+
+        async def _fake_on_dispatch() -> None:
+            dispatch_calls.append(None)
+
+        bridge = GptmeToolBridge(
+            workspace="/fake/workspace",
+            on_dispatch=_fake_on_dispatch,
+        )
+        await bridge.handle_function_call("subagent_status", {})
+        assert len(dispatch_calls) == 0
+
+    asyncio.run(_exercise())
+
+
+def test_on_timeout_called_when_subagent_times_out() -> None:
+    """on_timeout fires when the subagent process exits with a timeout returncode."""
+
+    async def _exercise() -> None:
+        timeout_calls: list[None] = []
+        result_calls: list[str] = []
+
+        async def _fake_on_timeout() -> None:
+            timeout_calls.append(None)
+
+        async def _fake_on_result(text: str) -> None:
+            result_calls.append(text)
+
+        async def _fake_create_subprocess_exec(*_args, **_kwargs):
+            return _FakeProcess(returncode=124, stdout="partial output\n")
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+            bridge = GptmeToolBridge(
+                workspace="/fake/workspace",
+                timeout=10,
+                on_result=_fake_on_result,
+                on_timeout=_fake_on_timeout,
+            )
+
+            await bridge.handle_function_call(
+                "subagent", {"task": "slow analysis task", "mode": "fast"}
+            )
+
+            # Drain the event loop until the background task completes
+            for _ in range(20):
+                await asyncio.sleep(0)
+
+        assert len(timeout_calls) == 1, "on_timeout should fire exactly once"
+        assert len(result_calls) == 1, "on_result still fires after timeout"
+
+    asyncio.run(_exercise())
+
+
+def test_on_timeout_not_called_on_successful_completion() -> None:
+    """on_timeout must not fire when the subagent exits successfully."""
+
+    async def _exercise() -> None:
+        timeout_calls: list[None] = []
+
+        async def _fake_on_timeout() -> None:
+            timeout_calls.append(None)
+
+        async def _fake_create_subprocess_exec(*_args, **_kwargs):
+            return _FakeProcess(returncode=0)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+            bridge = GptmeToolBridge(
+                workspace="/fake/workspace",
+                on_timeout=_fake_on_timeout,
+            )
+
+            await bridge.handle_function_call(
+                "subagent", {"task": "quick lookup", "mode": "fast"}
+            )
+
+            for _ in range(20):
+                await asyncio.sleep(0)
+
+        assert len(timeout_calls) == 0
+
+    asyncio.run(_exercise())

--- a/packages/gptme-voice/tests/test_tool_bridge.py
+++ b/packages/gptme-voice/tests/test_tool_bridge.py
@@ -1320,6 +1320,10 @@ def test_on_dispatch_called_when_subagent_dispatched() -> None:
             )
 
         assert result["status"] == "dispatched"
+        for _ in range(20):
+            if dispatch_calls:
+                break
+            await asyncio.sleep(0)
         assert len(dispatch_calls) == 1
 
     asyncio.run(_exercise())
@@ -1349,10 +1353,10 @@ def test_on_dispatch_failure_does_not_hide_dispatch_receipt(caplog) -> None:
 
             assert result["status"] == "dispatched"
             assert result["task_id"] in bridge._pending_tasks
-            assert "Failed to send subagent dispatch cue" in caplog.text
 
             for _ in range(20):
                 await asyncio.sleep(0)
+            assert "Failed to send subagent dispatch cue" in caplog.text
 
     asyncio.run(_exercise())
 
@@ -1397,6 +1401,10 @@ def test_on_dispatch_timeout_does_not_hide_dispatch_receipt(
 
         assert result["status"] == "dispatched"
         assert result["task_id"] in bridge._pending_tasks
+        assert not cue_cancelled.is_set()
+
+        for _ in range(20):
+            await asyncio.sleep(0.001)
         assert cue_cancelled.is_set()
         assert "Timed out sending subagent dispatch cue" in caplog.text
 

--- a/packages/gptme-voice/tests/test_tool_bridge.py
+++ b/packages/gptme-voice/tests/test_tool_bridge.py
@@ -1325,6 +1325,38 @@ def test_on_dispatch_called_when_subagent_dispatched() -> None:
     asyncio.run(_exercise())
 
 
+def test_on_dispatch_failure_does_not_hide_dispatch_receipt(caplog) -> None:
+    """A failed cue send must not orphan an already-running subagent."""
+
+    async def _exercise() -> None:
+        async def _failing_on_dispatch() -> None:
+            raise ConnectionError("voice transport closed")
+
+        async def _fake_create_subprocess_exec(*_args, **_kwargs):
+            return _FakeProcess(returncode=0)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+            bridge = GptmeToolBridge(
+                workspace="/fake/workspace",
+                on_dispatch=_failing_on_dispatch,
+            )
+
+            with caplog.at_level(logging.ERROR):
+                result = await bridge.handle_function_call(
+                    "subagent", {"task": "list recent commits", "mode": "fast"}
+                )
+
+            assert result["status"] == "dispatched"
+            assert result["task_id"] in bridge._pending_tasks
+            assert "Failed to send subagent dispatch cue" in caplog.text
+
+            for _ in range(20):
+                await asyncio.sleep(0)
+
+    asyncio.run(_exercise())
+
+
 def test_on_dispatch_not_called_for_non_subagent_calls() -> None:
     """on_dispatch must not fire for subagent_status or other tool calls."""
 
@@ -1379,6 +1411,44 @@ def test_on_timeout_called_when_subagent_times_out() -> None:
 
         assert len(timeout_calls) == 1, "on_timeout should fire exactly once"
         assert len(result_calls) == 1, "on_result still fires after timeout"
+
+    asyncio.run(_exercise())
+
+
+def test_on_timeout_failure_does_not_suppress_result_or_cleanup(caplog) -> None:
+    """A failed timeout cue must not interrupt task completion."""
+
+    async def _exercise() -> None:
+        result_calls: list[str] = []
+
+        async def _failing_on_timeout() -> None:
+            raise ConnectionError("voice transport closed")
+
+        async def _fake_on_result(text: str) -> None:
+            result_calls.append(text)
+
+        async def _fake_create_subprocess_exec(*_args, **_kwargs):
+            return _FakeProcess(returncode=124, stdout="partial output\n")
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+            bridge = GptmeToolBridge(
+                workspace="/fake/workspace",
+                timeout=10,
+                on_result=_fake_on_result,
+                on_timeout=_failing_on_timeout,
+            )
+
+            with caplog.at_level(logging.ERROR):
+                dispatch = await bridge.handle_function_call(
+                    "subagent", {"task": "slow analysis task", "mode": "fast"}
+                )
+                for _ in range(20):
+                    await asyncio.sleep(0)
+
+            assert len(result_calls) == 1
+            assert dispatch["task_id"] not in bridge._pending_tasks
+            assert "Failed to send subagent timeout cue" in caplog.text
 
     asyncio.run(_exercise())
 


### PR DESCRIPTION
## Summary

- Adds `on_dispatch` callback to `GptmeToolBridge` — fires immediately after a subagent task is enqueued, before returning the dispatch receipt
- Adds `on_timeout` callback — fires when the subagent exits with a timeout return code, just before the error is injected into the conversation
- Adds `inject_status_cue(cue_text)` to `RealtimeClient` — generates a brief spoken cue via `response.create` with `conversation="none"` so the cue plays to the caller but does not appear in conversation history or affect follow-up responses
- Wires both callbacks in all three `GptmeToolBridge` construction sites (Twilio, local WebSocket, browser) with "One moment…" on dispatch and "That lookup timed out." on timeout

## Motivation

Erik's feedback (2026-07-28 voice call): the silence between subagent dispatch and result feels opaque — callers can't tell if the agent is working or hung. An in-band cue ("One moment…") signals activity, and a distinct timeout cue ("That lookup timed out.") distinguishes failure from success without requiring the caller to interpret an error message in context.

## Test plan

- [ ] New tests: `test_on_dispatch_called_when_subagent_dispatched` — dispatch callback fires once
- [ ] `test_on_dispatch_not_called_for_non_subagent_calls` — does not fire on `subagent_status`
- [ ] `test_on_timeout_called_when_subagent_times_out` — fires on rc=124, `on_result` still fires after
- [ ] `test_on_timeout_not_called_on_successful_completion` — does not fire on rc=0
- [ ] Full voice test suite: 178/178 pass (`uv run pytest packages/gptme-voice/tests/ -q`)