### PR TITLE
feat(skills): add exchange frontmatter fields to template skill

### DIFF
--- a/skills/template-skill/SKILL.md
+++ b/skills/template-skill/SKILL.md
@@ -1,6 +1,24 @@
 ---
 name: template-skill
 description: Template for creating new skills in gptme-contrib. Use this as a starting point when creating your own skills.
+
+# Exchange fields (optional — fill in when publishing to a registry)
+# exchange:
+#   version: "1.0.0"         # semantic version
+#   author: null             # GitHub handle
+#   license: null            # e.g. MIT
+#   category: null           # e.g. data-engineering
+#   dependencies:
+#     skills: []             # other skill names this skill depends on
+#     tools: []              # gptme tool requirements (e.g. [shell, python])
+#     packages: []           # Python packages (e.g. [pandas, matplotlib])
+#   quality:
+#     usage_count: 0
+#     success_rate: null     # filled by gptme-sessions telemetry
+#     loo_delta: null        # filled by lesson-loo-analysis.py
+#   provenance:
+#     source_repo: null      # e.g. TimeToBuildBob/bob
+#     source_path: null      # e.g. skills/my-skill
 ---
 
 # Template Skill
@@ -34,6 +52,20 @@ Optional fields:
 - `scripts: []` - List of bundled Python scripts
 - `dependencies: []` - Required Python packages
 - `hooks: []` - Execution hooks (future feature)
+
+Optional exchange fields (for publishing to a skill registry):
+- `exchange.version` - Semantic version string (e.g. `"1.0.0"`)
+- `exchange.author` - GitHub handle of the skill author
+- `exchange.license` - License identifier (e.g. `MIT`)
+- `exchange.category` - Skill category (e.g. `data-engineering`, `devops`)
+- `exchange.dependencies.skills` - Other skill names this skill requires
+- `exchange.dependencies.tools` - gptme tools required (e.g. `[shell, python]`)
+- `exchange.dependencies.packages` - Python packages required
+- `exchange.quality.usage_count` - Number of times invoked (filled by telemetry)
+- `exchange.quality.success_rate` - Fraction of successful invocations (telemetry)
+- `exchange.quality.loo_delta` - Leave-one-out quality delta (lesson-loo-analysis.py)
+- `exchange.provenance.source_repo` - Origin repo (e.g. `TimeToBuildBob/bob`)
+- `exchange.provenance.source_path` - Path within source repo
 
 ## Markdown Content
 
@@ -113,6 +145,34 @@ plot_distribution(df["column"])
 ```
 ```
 
+## Example: Publishable Skill
+
+```yaml
+---
+name: postgres-query-optimizer
+description: Analyze and rewrite slow PostgreSQL queries using EXPLAIN ANALYZE output
+status: active
+match:
+  keywords: [postgres, sql, query, explain, slow query]
+exchange:
+  version: "1.0.0"
+  author: TimeToBuildBob
+  license: MIT
+  category: data-engineering
+  dependencies:
+    skills: []
+    tools: [shell]
+    packages: []
+  quality:
+    usage_count: 0
+    success_rate: null
+    loo_delta: null
+  provenance:
+    source_repo: TimeToBuildBob/bob
+    source_path: skills/postgres-query-optimizer
+---
+```
+
 ## Integration with Lessons
 
 Skills complement lessons:
@@ -122,6 +182,19 @@ Skills complement lessons:
 Example:
 - Lesson teaches: "Use type hints in Python"
 - Skill provides: Type checking utilities and templates
+
+## Publishing and Exchange
+
+The `exchange:` block makes a skill discoverable and installable across the fleet.
+When all agents share a registry (e.g. `gptme-contrib/skills/registry.json`), any
+agent can find skills by category or dependency and install them with one command.
+
+Exchange fields are optional — a skill works fine without them. Add them when you
+want the skill to be findable by other agents or to track quality signals over time.
+
+Quality fields (`usage_count`, `success_rate`, `loo_delta`) are filled automatically
+by `gptme-sessions` telemetry and `lesson-loo-analysis.py` — you don't need to fill
+them in by hand.
 
 ## Related
 


### PR DESCRIPTION
## Summary

- Adds an optional `exchange:` block to `skills/template-skill/SKILL.md` documenting the fields needed for publishing skills to a shared registry
- All fields are optional with null defaults — existing skills are unaffected
- Adds a full usage example (publishable skill) and a "Publishing and Exchange" section explaining the telemetry-filled quality fields

## Motivation

Part of idea #782 (Collaborative Agent Skill Exchange). gptme agents currently develop skills in isolated repos with no way to discover or share them across the fleet. The `exchange:` frontmatter block is Phase 1: define the schema so skills can carry provenance, dependency, and quality signals without breaking anything that already works.

Fields:
- `version`, `author`, `license`, `category` — identity and discovery
- `dependencies.{skills,tools,packages}` — dependency declaration
- `quality.{usage_count,success_rate,loo_delta}` — filled by gptme-sessions telemetry and lesson-loo-analysis.py
- `provenance.{source_repo,source_path}` — origin tracking

Design note: `knowledge/technical-designs/skill-exchange-design.md` in TimeToBuildBob/bob

## Test plan

- [x] Pre-commit hooks pass (`prek` — all clean)
- [x] `validate.py` on the changed file: `✅ SKILL.md is valid (skill format)`
- [x] PR quality gate: 100/100
- [x] Additive only — no behavioral change to existing skills