### PR TITLE
feat(runloops): extract is_capable_backend + self-review cooldown to tested Python

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/autonomous.py
+++ b/packages/gptme-runloops/src/gptme_runloops/autonomous.py
@@ -1,10 +1,46 @@
 """Autonomous run loop implementation."""
 
+import json
+import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 from gptme_runloops.base import BaseRunLoop
 from gptme_runloops.utils.executor import Executor
 from gptme_runloops.utils.prompt import generate_base_prompt, get_agent_name
+
+
+def is_capable_backend(backend: str, model: str = "") -> bool:
+    """Return True when this backend+model combo suits self-review / cleanup tasks.
+
+    Mirrors the bash ``_is_capable_backend()`` in autonomous-run.sh.
+    """
+    if backend == "claude-code":
+        return True
+    if model.startswith("glm-5"):
+        return True
+    return False
+
+
+def self_review_hours_since_last(state_path: Path) -> float:
+    """Return hours since the last self-review, or 999.0 if the state is absent/corrupt."""
+    try:
+        with open(state_path) as f:
+            ts = json.load(f).get("timestamp", "")
+        dt = datetime.fromisoformat(ts)
+        now = datetime.now(timezone.utc)
+        return (now - dt).total_seconds() / 3600
+    except Exception:
+        return 999.0
+
+
+def self_review_cooldown_active(state_path: Path, cooldown_hours: float = 6.0) -> bool:
+    """Return True when the self-review cooldown is still active (last review was too recent).
+
+    Mirrors the inline bash time-check in ``_apply_cascade_routing()``.
+    Returns False when the state file is absent (no prior review → no cooldown).
+    """
+    return self_review_hours_since_last(state_path) < cooldown_hours
 
 
 class AutonomousRun(BaseRunLoop):
@@ -81,3 +117,32 @@ class AutonomousRun(BaseRunLoop):
 Begin your autonomous work session now.
 """,
         )
+
+
+if __name__ == "__main__":
+    cmd = sys.argv[1] if len(sys.argv) > 1 else ""
+    if cmd == "is-capable-backend":
+        backend = sys.argv[2] if len(sys.argv) > 2 else ""
+        model = sys.argv[3] if len(sys.argv) > 3 else ""
+        sys.exit(0 if is_capable_backend(backend, model) else 1)
+    elif cmd == "self-review-cooldown":
+        state = Path(sys.argv[2]) if len(sys.argv) > 2 else Path("/dev/null")
+        hours = float(sys.argv[3]) if len(sys.argv) > 3 else 6.0
+        # exit 0 = cooldown active (dispatcher should skip self-review)
+        sys.exit(0 if self_review_cooldown_active(state, hours) else 1)
+    elif cmd == "self-review-hours":
+        state = Path(sys.argv[2]) if len(sys.argv) > 2 else Path("/dev/null")
+        print(f"{self_review_hours_since_last(state):.1f}")
+    else:
+        cmds = [
+            "is-capable-backend BACKEND [MODEL]",
+            "self-review-cooldown STATE_PATH [COOLDOWN_HOURS]",
+            "self-review-hours STATE_PATH",
+        ]
+        print(
+            f"Usage: python3 -m gptme_runloops.autonomous [{' | '.join(c.split()[0] for c in cmds)}]",
+            file=sys.stderr,
+        )
+        for c in cmds:
+            print(f"  {c}", file=sys.stderr)
+        sys.exit(2)

--- a/packages/gptme-runloops/tests/test_autonomous.py
+++ b/packages/gptme-runloops/tests/test_autonomous.py
@@ -1,11 +1,180 @@
-"""Tests for AutonomousRun."""
+"""Tests for AutonomousRun and autonomous dispatch helpers."""
 
+import json
+import subprocess
+import sys
 import tempfile
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import patch
 
-from gptme_runloops.autonomous import AutonomousRun
+from gptme_runloops.autonomous import (
+    AutonomousRun,
+    is_capable_backend,
+    self_review_cooldown_active,
+    self_review_hours_since_last,
+)
 from gptme_runloops.utils.execution import ExecutionResult
+
+# --- is_capable_backend ---
+
+
+def test_capable_backend_claude_code():
+    assert is_capable_backend("claude-code") is True
+    assert is_capable_backend("claude-code", "claude-sonnet-4-6") is True
+
+
+def test_capable_backend_glm5():
+    assert is_capable_backend("gptme", "glm-5.2") is True
+    assert is_capable_backend("gptme", "glm-5-pro") is True
+
+
+def test_incapable_backend_gptme_non_glm():
+    assert is_capable_backend("gptme", "deepseek-v4-pro") is False
+    assert is_capable_backend("gptme") is False
+
+
+def test_incapable_backend_unknown():
+    assert is_capable_backend("codex") is False
+    assert is_capable_backend("") is False
+
+
+# --- self_review_hours_since_last ---
+
+
+def _write_self_review_state(path: Path, age_hours: float) -> None:
+    ts = datetime.now(timezone.utc) - timedelta(hours=age_hours)
+    path.write_text(json.dumps({"timestamp": ts.isoformat()}))
+
+
+def test_hours_since_last_recent(tmp_path):
+    state = tmp_path / "self-review-last.json"
+    _write_self_review_state(state, age_hours=2.0)
+    hours = self_review_hours_since_last(state)
+    assert 1.9 < hours < 2.1
+
+
+def test_hours_since_last_missing_file(tmp_path):
+    assert self_review_hours_since_last(tmp_path / "no-such.json") == 999.0
+
+
+def test_hours_since_last_corrupt_file(tmp_path):
+    state = tmp_path / "bad.json"
+    state.write_text("not json at all")
+    assert self_review_hours_since_last(state) == 999.0
+
+
+def test_hours_since_last_missing_timestamp(tmp_path):
+    state = tmp_path / "empty.json"
+    state.write_text(json.dumps({}))
+    assert self_review_hours_since_last(state) == 999.0
+
+
+# --- self_review_cooldown_active ---
+
+
+def test_cooldown_active_when_recent(tmp_path):
+    state = tmp_path / "self-review-last.json"
+    _write_self_review_state(state, age_hours=3.0)
+    assert self_review_cooldown_active(state, cooldown_hours=6.0) is True
+
+
+def test_cooldown_inactive_when_old(tmp_path):
+    state = tmp_path / "self-review-last.json"
+    _write_self_review_state(state, age_hours=8.0)
+    assert self_review_cooldown_active(state, cooldown_hours=6.0) is False
+
+
+def test_cooldown_inactive_when_missing(tmp_path):
+    assert self_review_cooldown_active(tmp_path / "no-such.json") is False
+
+
+def test_cooldown_boundary(tmp_path):
+    state = tmp_path / "self-review-last.json"
+    _write_self_review_state(state, age_hours=6.0)
+    # Exactly at boundary → NOT active (>= 6h means cooldown cleared)
+    assert self_review_cooldown_active(state, cooldown_hours=6.0) is False
+
+
+# --- CLI exit codes ---
+
+
+def test_cli_is_capable_backend_exit0():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "gptme_runloops.autonomous",
+            "is-capable-backend",
+            "claude-code",
+        ],
+        capture_output=True,
+    )
+    assert result.returncode == 0
+
+
+def test_cli_is_capable_backend_exit1():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "gptme_runloops.autonomous",
+            "is-capable-backend",
+            "codex",
+        ],
+        capture_output=True,
+    )
+    assert result.returncode == 1
+
+
+def test_cli_self_review_cooldown_active(tmp_path):
+    state = tmp_path / "self-review-last.json"
+    _write_self_review_state(state, age_hours=2.0)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "gptme_runloops.autonomous",
+            "self-review-cooldown",
+            str(state),
+        ],
+        capture_output=True,
+    )
+    assert result.returncode == 0  # exit 0 = on cooldown
+
+
+def test_cli_self_review_cooldown_inactive(tmp_path):
+    state = tmp_path / "self-review-last.json"
+    _write_self_review_state(state, age_hours=10.0)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "gptme_runloops.autonomous",
+            "self-review-cooldown",
+            str(state),
+        ],
+        capture_output=True,
+    )
+    assert result.returncode == 1  # exit 1 = not on cooldown
+
+
+def test_cli_self_review_hours(tmp_path):
+    state = tmp_path / "self-review-last.json"
+    _write_self_review_state(state, age_hours=5.0)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "gptme_runloops.autonomous",
+            "self-review-hours",
+            str(state),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert 4.9 < float(result.stdout.strip()) < 5.1
 
 
 def test_autonomous_generate_prompt():


### PR DESCRIPTION
## Summary

- Add three pure policy functions to `autonomous.py` replacing fragile inline shell/Python in `autonomous-run.sh` (ErikBjare/bob sprawl-counter-pressure B3)
- `is_capable_backend(backend, model)` — replaces the bash `case/case` predicate
- `self_review_hours_since_last(path)` — replaces the `python3 -c` heredoc reading a JSON timestamp
- `self_review_cooldown_active(path, cooldown_hours)` — replaces the two-step shell check
- Exposed via `__main__` CLI (`is-capable-backend` / `self-review-cooldown` / `self-review-hours`) with exit codes matching bash conventions
- 17 new unit + CLI tests cover all predicates, edge cases (missing file, corrupt JSON, exact 6h boundary), and CLI exit codes

## Test plan

- [ ] `uv run pytest packages/gptme-runloops/tests/test_autonomous.py -v` — 20 passed
- [ ] `uv run python3 -m gptme_runloops.autonomous is-capable-backend claude-code` → exit 0
- [ ] `uv run python3 -m gptme_runloops.autonomous is-capable-backend codex` → exit 1