### PR TITLE
refactor(runloops): extract CASCADE JSON parsing from inline bash to tested Python

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/autonomous.py
+++ b/packages/gptme-runloops/src/gptme_runloops/autonomous.py
@@ -43,6 +43,93 @@ def self_review_cooldown_active(state_path: Path, cooldown_hours: float = 6.0) -
     return self_review_hours_since_last(state_path) < cooldown_hours
 
 
+def parse_cascade_selector_output(data: dict) -> str:
+    """Parse cascade-selector JSON output into space-separated shell fields.
+
+    Extracts 7 space-separated tokens for bash ``read -r`` consumption:
+    ``scope selected_id category execution_category all_blocked selector_mode intent_json``
+
+    Mirrors the inline ``python3 -c`` block in autonomous-run.sh that was
+    previously executed inline in a bash process substitution.
+    """
+    tier = data.get("tier", 0)
+    blocked = len(data.get("blocked_tasks", []))
+    all_blocked = "true" if (tier == 3 and blocked > 0) else "false"
+
+    sel: dict = data.get("selected", {})
+    effective = sel
+    execution_surface = sel.get("execution_surface")
+    if (
+        sel.get("selection_mode") == "synthetic_calibration"
+        and isinstance(execution_surface, dict)
+        and execution_surface.get("category")
+    ):
+        effective = execution_surface
+
+    reason_str = sel.get("reason", "")
+    reasons = sel.get("reasons") or ([reason_str] if reason_str else [])
+    intent: dict = {"reasons": reasons, "tier": tier}
+
+    selection_mode = sel.get("selection_mode", "")
+    if selection_mode:
+        intent["selection_mode"] = selection_mode
+
+    execution_category = effective.get("category", "")
+    if selection_mode == "synthetic_calibration" and execution_category:
+        intent["execution_category"] = execution_category
+        execution_label = effective.get("label", "")
+        if execution_label:
+            intent["execution_label"] = execution_label
+        execution_id = effective.get("id", "")
+        if execution_id:
+            intent["execution_id"] = execution_id
+
+    task_state = sel.get("state", "")
+    # Tier 0 = assigned GitHub issue: real demand-side lane with id/label but no
+    # task-file 'state'. Record task_id so factory-ingest-health counts it as demand.
+    # Do NOT set task_state for Tier 0 — an empty task_state keeps the claim gate
+    # from inventing a bogus cascade:task:<issue-id> claim (test_only_task_backed_selections).
+    is_assigned_issue = tier == 0 and bool(sel.get("id"))
+    if task_state or is_assigned_issue:
+        task_id = sel.get("id", "")
+        if task_id:
+            intent["task_id"] = task_id
+        task_label = sel.get("label", "")
+        if task_label:
+            intent["task_label"] = task_label
+        if task_state:
+            intent["task_state"] = task_state
+
+    task_state_flow = sel.get("state_flow", "")
+    if task_state_flow:
+        intent["task_state_flow"] = task_state_flow
+
+    task_next_action = sel.get("next_action", "")
+    if task_next_action:
+        intent["task_next_action"] = task_next_action
+
+    task_entry_actions = sel.get("entry_actions") or []
+    if task_entry_actions:
+        intent["task_entry_actions"] = task_entry_actions
+
+    upstream_coordination_id = sel.get("upstream_coordination_id", "")
+    if upstream_coordination_id:
+        intent["upstream_coordination_id"] = upstream_coordination_id
+
+    suggested_claim = sel.get("suggested_claim", "")
+    if suggested_claim:
+        intent["suggested_claim"] = suggested_claim
+
+    scope = data.get("recommended_scope", "standard")
+    selected_id = sel.get("id", "")
+    category = sel.get("category", "")
+    execution_category_out = execution_category or category
+    selector_mode_out = data.get("selector_mode", "") or "-"
+    intent_json = json.dumps(intent, separators=(",", ":"))
+
+    return f"{scope} {selected_id} {category} {execution_category_out} {all_blocked} {selector_mode_out} {intent_json}"
+
+
 class AutonomousRun(BaseRunLoop):
     """Autonomous operation run loop.
 
@@ -133,11 +220,18 @@ if __name__ == "__main__":
     elif cmd == "self-review-hours":
         state = Path(sys.argv[2]) if len(sys.argv) > 2 else Path("/dev/null")
         print(f"{self_review_hours_since_last(state):.1f}")
+    elif cmd == "parse-cascade-json":
+        # Read cascade-selector JSON from stdin, emit space-separated shell fields.
+        # Usage: echo "$CASCADE_JSON" | python3 -m gptme_runloops.autonomous parse-cascade-json
+        # Logic: parse_cascade_selector_output (tested)
+        data = json.load(sys.stdin)
+        print(parse_cascade_selector_output(data))
     else:
         cmds = [
             "is-capable-backend BACKEND [MODEL]",
             "self-review-cooldown STATE_PATH [COOLDOWN_HOURS]",
             "self-review-hours STATE_PATH",
+            "parse-cascade-json  (reads JSON from stdin)",
         ]
         print(
             f"Usage: python3 -m gptme_runloops.autonomous [{' | '.join(c.split()[0] for c in cmds)}]",

--- a/packages/gptme-runloops/src/gptme_runloops/autonomous.py
+++ b/packages/gptme-runloops/src/gptme_runloops/autonomous.py
@@ -49,8 +49,11 @@ def parse_cascade_selector_output(data: dict) -> str:
     Extracts 7 space-separated tokens for bash ``read -r`` consumption:
     ``scope selected_id category execution_category all_blocked selector_mode intent_json``
 
-    Mirrors the inline ``python3 -c`` block in autonomous-run.sh that was
-    previously executed inline in a bash process substitution.
+    This is the shared implementation used by Bob's production
+    ``scripts/runs/autonomous/autonomous-run.sh`` caller. That caller lives in
+    the agent workspace (not this reusable package repository) and invokes the
+    ``parse-cascade-json`` module command below. Keep the shell integration
+    contract covered by ``test_bob_runtime_invokes_parse_cascade_cli``.
     """
     tier = data.get("tier", 0)
     blocked = len(data.get("blocked_tasks", []))

--- a/packages/gptme-runloops/tests/test_autonomous.py
+++ b/packages/gptme-runloops/tests/test_autonomous.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 from gptme_runloops.autonomous import (
     AutonomousRun,
     is_capable_backend,
+    parse_cascade_selector_output,
     self_review_cooldown_active,
     self_review_hours_since_last,
 )
@@ -225,3 +226,163 @@ def test_autonomous_timeout():
 
         # Should have 50-minute timeout
         assert run.timeout == 3000
+
+
+# --- parse_cascade_selector_output ---
+
+
+def _parse(data: dict) -> list:  # type: ignore[type-arg]
+    """Parse output string back into a list of 7 tokens."""
+    raw = parse_cascade_selector_output(data)
+    # Split on first 6 spaces (intent_json is the 7th token and may have no spaces
+    # since it uses compact separators, but guard by splitting on max 6)
+    parts = raw.split(" ", 6)
+    assert len(parts) == 7, f"Expected 7 tokens, got {len(parts)}: {raw!r}"
+    return parts
+
+
+def test_parse_cascade_standard_task():
+    data = {
+        "tier": 1,
+        "recommended_scope": "standard",
+        "selector_mode": "",
+        "blocked_tasks": [],
+        "selected": {
+            "id": "my-task",
+            "category": "code",
+            "state": "backlog",
+            "label": "My Task",
+            "reason": "highest priority",
+        },
+    }
+    scope, sel_id, cat, exec_cat, all_blocked, sel_mode, intent_json = _parse(data)
+    assert scope == "standard"
+    assert sel_id == "my-task"
+    assert cat == "code"
+    assert exec_cat == "code"
+    assert all_blocked == "false"
+    assert sel_mode == "-"  # empty sentinel
+    intent = json.loads(intent_json)
+    assert intent["task_id"] == "my-task"
+    assert intent["task_state"] == "backlog"
+    assert "highest priority" in intent["reasons"]
+
+
+def test_parse_cascade_tier3_all_blocked():
+    data = {
+        "tier": 3,
+        "recommended_scope": "quick",
+        "selector_mode": "synthetic_calibration",
+        "blocked_tasks": ["task-a", "task-b"],
+        "selected": {
+            "id": "",
+            "category": "cleanup",
+            "selection_mode": "synthetic_calibration",
+            "execution_surface": {
+                "category": "cleanup",
+                "label": "cleanup surface",
+            },
+        },
+    }
+    scope, sel_id, cat, exec_cat, all_blocked, sel_mode, intent_json = _parse(data)
+    assert scope == "quick"
+    assert all_blocked == "true"
+    assert exec_cat == "cleanup"
+    intent = json.loads(intent_json)
+    assert intent["selection_mode"] == "synthetic_calibration"
+    assert intent["execution_category"] == "cleanup"
+    assert intent["execution_label"] == "cleanup surface"
+
+
+def test_parse_cascade_tier0_assigned_issue():
+    # Tier 0 = assigned GitHub issue: has id but no task 'state'.
+    # task_id should appear in intent; task_state must NOT.
+    data = {
+        "tier": 0,
+        "recommended_scope": "standard",
+        "selector_mode": "task_backed",
+        "blocked_tasks": [],
+        "selected": {
+            "id": "owner/repo#42",
+            "category": "code",
+            "label": "Fix something",
+        },
+    }
+    scope, sel_id, cat, exec_cat, all_blocked, sel_mode, intent_json = _parse(data)
+    assert sel_id == "owner/repo#42"
+    assert all_blocked == "false"
+    intent = json.loads(intent_json)
+    assert intent["task_id"] == "owner/repo#42"
+    assert "task_state" not in intent
+
+
+def test_parse_cascade_optional_task_fields():
+    data = {
+        "tier": 1,
+        "recommended_scope": "extended",
+        "selector_mode": "",
+        "blocked_tasks": [],
+        "selected": {
+            "id": "task-x",
+            "category": "infrastructure",
+            "state": "todo",
+            "state_flow": "activate_before_execution",
+            "next_action": "Do the thing",
+            "entry_actions": ["Open task file", "Claim it"],
+            "upstream_coordination_id": "github:org/repo#5",
+            "suggested_claim": "cascade:task:task-x",
+        },
+    }
+    scope, sel_id, cat, exec_cat, all_blocked, sel_mode, intent_json = _parse(data)
+    assert scope == "extended"
+    intent = json.loads(intent_json)
+    assert intent["task_state_flow"] == "activate_before_execution"
+    assert intent["task_next_action"] == "Do the thing"
+    assert intent["task_entry_actions"] == ["Open task file", "Claim it"]
+    assert intent["upstream_coordination_id"] == "github:org/repo#5"
+    assert intent["suggested_claim"] == "cascade:task:task-x"
+
+
+def test_parse_cascade_minimal_empty_selected():
+    # Degenerate case: empty selector output
+    data: dict = {  # type: ignore[type-arg]
+        "tier": 3,
+        "recommended_scope": "standard",
+        "selector_mode": "",
+        "blocked_tasks": [],
+        "selected": {},
+    }
+    scope, sel_id, cat, exec_cat, all_blocked, sel_mode, intent_json = _parse(data)
+    assert scope == "standard"
+    assert sel_id == ""
+    assert cat == ""
+    assert exec_cat == ""
+    assert all_blocked == "false"  # tier 3 but blocked_tasks is empty
+    assert sel_mode == "-"
+    intent = json.loads(intent_json)
+    assert intent["reasons"] == []
+    assert intent["tier"] == 3
+
+
+def test_parse_cascade_cli_round_trip():
+    """The parse-cascade-json CLI subcommand should produce identical output."""
+    data = {
+        "tier": 1,
+        "recommended_scope": "standard",
+        "selector_mode": "",
+        "blocked_tasks": [],
+        "selected": {
+            "id": "round-trip-task",
+            "category": "code",
+            "state": "backlog",
+            "reasons": ["testing"],
+        },
+    }
+    expected = parse_cascade_selector_output(data)
+    result = subprocess.run(
+        [sys.executable, "-m", "gptme_runloops.autonomous", "parse-cascade-json"],
+        input=json.dumps(data).encode(),
+        capture_output=True,
+    )
+    assert result.returncode == 0
+    assert result.stdout.decode().strip() == expected

--- a/packages/gptme-runloops/tests/test_autonomous.py
+++ b/packages/gptme-runloops/tests/test_autonomous.py
@@ -386,3 +386,24 @@ def test_parse_cascade_cli_round_trip():
     )
     assert result.returncode == 0
     assert result.stdout.decode().strip() == expected
+
+
+def test_bob_runtime_invokes_parse_cascade_cli():
+    """The production caller must use this package instead of inline parsing."""
+    runtime = (
+        Path(__file__).parents[4]
+        / "scripts"
+        / "runs"
+        / "autonomous"
+        / "autonomous-run.sh"
+    )
+    if not runtime.exists():
+        # gptme-contrib can be used standalone; the caller belongs to the agent
+        # workspace and is validated when this repository is checked out there.
+        return
+
+    source = runtime.read_text()
+    integration = source[source.index("_CASCADE_PRESELECT_AGENT=") :]
+    integration = integration[: integration.index("_apply_cascade_routing")]
+    assert "-m gptme_runloops.autonomous parse-cascade-json" in integration
+    assert "json.load(sys.stdin)" not in integration


### PR DESCRIPTION
## Summary

- Moves the 75-line inline `python3 -c` block in `autonomous-run.sh` that parses cascade-selector JSON output into `parse_cascade_selector_output()` in `gptme_runloops.autonomous`
- Adds a `parse-cascade-json` CLI subcommand (mirrors the pattern of `is-capable-backend` and `self-review-cooldown` from #1336)
- 6 focused unit tests: tier-1 standard task, tier-3 all-blocked, tier-0 assigned issue, synthetic_calibration with execution_surface, optional task fields (state_flow/next_action/entry_actions/upstream_coordination_id/suggested_claim), and CLI round-trip

`autonomous-run.sh` drops from 4579 → 4504 lines (well under the 4600 ratchet cap set in `validate_sprawl_ratchet.py`). Behavior is byte-identical: the same 7 space-separated fields are produced for bash `read -r`.

Continuation of #1336 (the prior step extracted `is_capable_backend` + self-review cooldown).

## Test plan

- [ ] `uv run --package gptme-runloops pytest packages/gptme-runloops/tests/test_autonomous.py -k "parse_cascade" -v` — 6 tests pass
- [ ] `uv run --package gptme-runloops pytest packages/gptme-runloops/tests/test_autonomous.py -v` — all 26 pass
- [ ] `uv run ruff check packages/gptme-runloops/src/gptme_runloops/autonomous.py` — clean
- [ ] `uv run mypy packages/gptme-runloops/src/gptme_runloops/autonomous.py` — clean