### PR TITLE
feat(voice): pre-load activity digest for inbound calls

### DIFF
--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -339,17 +339,17 @@ def _load_voice_digest(workspace: str | None) -> str | None:
     if not workspace:
         return None
     digest_path = Path(workspace) / "state" / "voice-digest.md"
-    if not digest_path.exists():
-        return None
-    age = time.time() - digest_path.stat().st_mtime
-    if age > _VOICE_DIGEST_MAX_AGE_SECONDS:
-        logger.debug(
-            "voice digest stale (%.0fs > %ds) — skipping",
-            age,
-            _VOICE_DIGEST_MAX_AGE_SECONDS,
-        )
-        return None
     try:
+        if not digest_path.exists():
+            return None
+        age = time.time() - digest_path.stat().st_mtime
+        if age > _VOICE_DIGEST_MAX_AGE_SECONDS:
+            logger.debug(
+                "voice digest stale (%.0fs > %ds) — skipping",
+                age,
+                _VOICE_DIGEST_MAX_AGE_SECONDS,
+            )
+            return None
         return digest_path.read_text(encoding="utf-8")
     except OSError as exc:
         logger.warning("failed to read voice digest %s: %s", digest_path, exc)

--- a/packages/gptme-voice/src/gptme_voice/realtime/server.py
+++ b/packages/gptme-voice/src/gptme_voice/realtime/server.py
@@ -320,6 +320,63 @@ def _build_standup_instructions_guidance() -> str:
     )
 
 
+# Stale threshold for the pre-computed voice digest (4 hours).  A digest older
+# than this is too stale to be useful and may mislead the model.
+_VOICE_DIGEST_MAX_AGE_SECONDS = 4 * 3600
+
+
+def _load_voice_digest(workspace: str | None) -> str | None:
+    """Load the pre-computed voice activity digest if one exists and is fresh.
+
+    The digest is written by ``scripts/voice-digest-precompute.py`` (run at
+    autonomous session start via autonomous-fanout.sh).  It contains recent
+    session outcome summaries sourced from journal ``**Outcome**`` lines — the
+    same high-level signal used by the outbound standup brief path.
+
+    Returns None when the workspace is unknown, the file is absent, or the
+    file is older than ``_VOICE_DIGEST_MAX_AGE_SECONDS``.
+    """
+    if not workspace:
+        return None
+    digest_path = Path(workspace) / "state" / "voice-digest.md"
+    if not digest_path.exists():
+        return None
+    age = time.time() - digest_path.stat().st_mtime
+    if age > _VOICE_DIGEST_MAX_AGE_SECONDS:
+        logger.debug(
+            "voice digest stale (%.0fs > %ds) — skipping",
+            age,
+            _VOICE_DIGEST_MAX_AGE_SECONDS,
+        )
+        return None
+    try:
+        return digest_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger.warning("failed to read voice digest %s: %s", digest_path, exc)
+        return None
+
+
+def _prepend_activity_digest(digest_text: str, instructions: str) -> str:
+    """Prepend the voice digest to call instructions with guidance to use it.
+
+    Mirrors ``_build_standup_instructions_guidance()`` for the inbound case:
+    the model is told to answer recap questions from the pre-loaded digest
+    instead of spawning a subagent.
+    """
+    guidance = (
+        "ACTIVITY DIGEST (pre-computed — do not read aloud):\n"
+        "- A compact summary of recent work is loaded below. "
+        "Use it to answer 'what did you do today / in the last 12 hours?' "
+        "without spawning a subagent.\n"
+        "- Treat this as of the 'Generated at' timestamp shown in the digest; "
+        "sessions that started after that point are not included.\n"
+        "- For questions about specific task status or anything genuinely absent "
+        "from the digest, you may use the subagent tool for a targeted lookup.\n\n"
+        f"{digest_text.strip()}\n"
+    )
+    return guidance + "\n\n" + instructions
+
+
 def _build_standup_call_instructions(brief_text: str) -> str:
     """Build initial response instructions for a standup call with a pre-generated brief.
 
@@ -935,6 +992,15 @@ class VoiceServer:
                 instructions=f"{handoff_resume_context}\n\n{instructions}",
                 should_greet_first=False,
             )
+
+        # Inject the pre-computed voice activity digest for inbound calls when no
+        # explicit standup_brief was provided.  This ensures Erik's "what did you
+        # do today?" question is answered from the digest rather than a live
+        # subagent lookup (which timed out on 2026-07-28).  Only loaded when the
+        # digest is fresh (< _VOICE_DIGEST_MAX_AGE_SECONDS).
+        activity_digest = _load_voice_digest(self.workspace)
+        if activity_digest and not standup_brief:
+            instructions = _prepend_activity_digest(activity_digest, instructions)
 
         # standup_brief takes priority over recent-call resume: an explicit outbound
         # standup should always deliver the brief, not silently resume a prior session.

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -1729,6 +1729,24 @@ def test_load_voice_digest_returns_none_when_stale(tmp_path: Path) -> None:
     assert _load_voice_digest(str(tmp_path)) is None
 
 
+def test_load_voice_digest_returns_none_when_metadata_read_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    digest_path = tmp_path / "state" / "voice-digest.md"
+    digest_path.parent.mkdir(parents=True)
+    digest_path.write_text("## Recent sessions\n")
+    original_stat = Path.stat
+
+    def fail_digest_stat(path: Path, *args: object, **kwargs: object) -> os.stat_result:
+        if path == digest_path:
+            raise OSError("digest disappeared")
+        return original_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", fail_digest_stat)
+
+    assert _load_voice_digest(str(tmp_path)) is None
+
+
 def test_prepend_activity_digest_includes_guidance_and_content() -> None:
     digest = "## Recent sessions\n- [10:00 UTC] shipped heartbeat widget\n"
     instructions = "You are Bob."

--- a/packages/gptme-voice/tests/test_server.py
+++ b/packages/gptme-voice/tests/test_server.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import pytest
 from gptme_voice.realtime.audio import AudioConverter
 from gptme_voice.realtime.server import (
+    _VOICE_DIGEST_MAX_AGE_SECONDS,
     RecentCallRecord,
     SessionBootstrap,
     TranscriptTurn,
@@ -22,7 +23,9 @@ from gptme_voice.realtime.server import (
     _build_resume_instructions,
     _build_runtime_identity_instructions,
     _get_twilio_field,
+    _load_voice_digest,
     _lookup_caller_identity,
+    _prepend_activity_digest,
     _should_trigger_hangup_transcript_fallback,
     _truncate_resume_transcript,
 )
@@ -1689,3 +1692,56 @@ def test_server_voice_agent_name_overrides_general_name(
 
     assert server._agent_name == "Sven"
     assert server._instructions.startswith("IDENTITY: You are Sven.")
+
+
+# ---------------------------------------------------------------------------
+# Voice activity digest tests
+# ---------------------------------------------------------------------------
+
+
+def test_load_voice_digest_returns_none_without_workspace() -> None:
+    assert _load_voice_digest(None) is None
+
+
+def test_load_voice_digest_returns_none_when_file_missing(tmp_path: Path) -> None:
+    assert _load_voice_digest(str(tmp_path)) is None
+
+
+def test_load_voice_digest_returns_content_when_fresh(tmp_path: Path) -> None:
+    digest_path = tmp_path / "state" / "voice-digest.md"
+    digest_path.parent.mkdir(parents=True)
+    digest_path.write_text("## Recent sessions\n- [10:00 UTC] shipped something\n")
+
+    result = _load_voice_digest(str(tmp_path))
+
+    assert result is not None
+    assert "shipped something" in result
+
+
+def test_load_voice_digest_returns_none_when_stale(tmp_path: Path) -> None:
+    digest_path = tmp_path / "state" / "voice-digest.md"
+    digest_path.parent.mkdir(parents=True)
+    digest_path.write_text("## Recent sessions\n- [10:00 UTC] old work\n")
+    # Make file appear old
+    stale_mtime = time.time() - (_VOICE_DIGEST_MAX_AGE_SECONDS + 60)
+    os.utime(digest_path, (stale_mtime, stale_mtime))
+
+    assert _load_voice_digest(str(tmp_path)) is None
+
+
+def test_prepend_activity_digest_includes_guidance_and_content() -> None:
+    digest = "## Recent sessions\n- [10:00 UTC] shipped heartbeat widget\n"
+    instructions = "You are Bob."
+
+    result = _prepend_activity_digest(digest, instructions)
+
+    assert "ACTIVITY DIGEST" in result
+    assert "shipped heartbeat widget" in result
+    assert "You are Bob." in result
+    # Guidance comes before instructions
+    assert result.index("ACTIVITY DIGEST") < result.index("You are Bob.")
+
+
+def test_prepend_activity_digest_tells_model_to_skip_subagent() -> None:
+    result = _prepend_activity_digest("## Recent sessions\n", "instructions")
+    assert "subagent" in result.lower()


### PR DESCRIPTION
## Summary

- Adds `_load_voice_digest()` and `_prepend_activity_digest()` to `server.py`: reads `state/voice-digest.md` (pre-computed, max 4h old) and prepends it to inbound-call instructions so Erik's "what did you do today?" is answered from the digest — no live subagent needed
- The digest is generated by `scripts/voice-digest-precompute.py` (in Bob's brain repo — not in this PR) and refreshed at every autonomous session start via `autonomous-fanout.sh`
- Outbound standup calls already had `standup_brief` injection; this PR covers **inbound cold calls** only (guard: `if activity_digest and not standup_brief`)

## Root cause

2026-07-28 voice call: Erik asked "what have you been doing for the last 12 hours" and the subagent lookup timed out mid-sentence. Design doc: `knowledge/technical-designs/voice-activity-digest-design.md`.

## Changes

- `packages/gptme-voice/src/gptme_voice/realtime/server.py`: +2 functions + injection in `_build_session_bootstrap()`
- `packages/gptme-voice/tests/test_server.py`: +5 tests (70 total, all passing)

## Test plan

- [ ] `pytest packages/gptme-voice/tests/test_server.py` passes (5 new tests + 65 existing)
- [ ] Inbound call with fresh `state/voice-digest.md`: instructions contain ACTIVITY DIGEST block
- [ ] Inbound call with stale/missing digest: instructions unchanged (fallback graceful)
- [ ] Outbound standup call with `standup_brief`: digest NOT injected (guard holds)