### PR TITLE
feat(activity-summary): add standup subcommand with --since flag

### DIFF
--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cli.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cli.py
@@ -1032,7 +1032,7 @@ def backfill(ctx: click.Context, from_date: str, to_date: str | None, force: boo
 @click.option(
     "--limit",
     default=8,
-    type=int,
+    type=click.IntRange(min=0),
     help="Maximum number of journal summaries to include (default: 8)",
 )
 @click.option(

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cli.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cli.py
@@ -1043,8 +1043,8 @@ def backfill(ctx: click.Context, from_date: str, to_date: str | None, force: boo
 def standup(since: str, output_format: str, limit: int, include_low_signal: bool) -> None:
     """Generate standup context block from journal outcome summaries.
 
-    Reads journal files modified since --since and extracts **Outcome** lines,
-    filtered to remove internal bookkeeping noise. Output is a structured JSON
+    Reads journal outcomes from sessions completed since --since, filtered to
+    remove internal bookkeeping noise. Output is a structured JSON
     block (or text) suitable for injection into voice standup sessions.
 
     Replaces raw `git log --oneline` context with high-level session outcomes.

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cli.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cli.py
@@ -1017,6 +1017,66 @@ def backfill(ctx: click.Context, from_date: str, to_date: str | None, force: boo
 
 
 @cli.command()
+@click.option(
+    "--since",
+    default="24h",
+    help="Lookback window: '24h', '48h', '3d', or ISO timestamp (default: 24h)",
+)
+@click.option(
+    "--format",
+    "output_format",
+    default="json",
+    type=click.Choice(["json", "text"]),
+    help="Output format (default: json)",
+)
+@click.option(
+    "--limit",
+    default=8,
+    type=int,
+    help="Maximum number of journal summaries to include (default: 8)",
+)
+@click.option(
+    "--include-low-signal",
+    is_flag=True,
+    help="Include low-signal entries (typecheck, lint, etc.) as fallback",
+)
+def standup(since: str, output_format: str, limit: int, include_low_signal: bool) -> None:
+    """Generate standup context block from journal outcome summaries.
+
+    Reads journal files modified since --since and extracts **Outcome** lines,
+    filtered to remove internal bookkeeping noise. Output is a structured JSON
+    block (or text) suitable for injection into voice standup sessions.
+
+    Replaces raw `git log --oneline` context with high-level session outcomes.
+    """
+    import json as _json
+
+    from .standup_data import StandupContext, get_standup_context, parse_since
+
+    try:
+        since_dt = parse_since(since)
+    except (ValueError, TypeError) as e:
+        raise click.ClickException(f"Invalid --since value '{since}': {e}") from e
+
+    ctx: StandupContext = get_standup_context(
+        JOURNAL_DIR,
+        since_dt,
+        limit=limit,
+        include_low_signal=include_low_signal,
+    )
+
+    if output_format == "json":
+        click.echo(_json.dumps(ctx.to_dict(), indent=2))
+    else:
+        if not ctx.journal_summaries:
+            click.echo(f"No journal summaries found since {since}.")
+            return
+        click.echo(f"Recent work since {since}:")
+        for s in ctx.journal_summaries:
+            click.echo(f"  [{s.date}] {s.summary}")
+
+
+@cli.command()
 def stats() -> None:
     """Show statistics about journal entries."""
     click.echo("Journal Statistics")

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/standup_data.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/standup_data.py
@@ -28,6 +28,22 @@ _LOW_SIGNAL_PATTERNS = (
     r"\bpre-commit hooks?\b",
     r"\bno new lessons?\b",
 )
+_OUTCOME_STATUS_PREFIXES = (
+    "blocked",
+    "healthy",
+    "no-action",
+    "no-op",
+    "noop",
+    "noop-soft",
+    "partial",
+    "productive",
+    "productive (minor)",
+    "productive (restraint)",
+    "productive restraint",
+    "productive-minor",
+    "restraint",
+    "restrained",
+)
 
 
 def parse_since(since: str) -> datetime:
@@ -55,7 +71,7 @@ def parse_since(since: str) -> datetime:
     dt = datetime.fromisoformat(since.rstrip("Z").replace("Z", "+00:00"))
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
-    return dt
+    return dt.astimezone(timezone.utc)
 
 
 def _extract_outcome_line(path: Path) -> str | None:
@@ -65,9 +81,10 @@ def _extract_outcome_line(path: Path) -> str | None:
             if not line.startswith("**Outcome**:"):
                 continue
             summary = line.split(":", 1)[1].strip()
-            # Strip "productive — " or "blocked — " prefix
-            if "—" in summary:
-                _, rest = summary.split("—", 1)
+            # Strip conventional journal status prefixes, preserving em dashes
+            # that are part of free-form outcome prose.
+            prefix, separator, rest = summary.partition(" — ")
+            if separator and prefix.casefold() in _OUTCOME_STATUS_PREFIXES:
                 summary = rest.strip()
             return summary or None
     except OSError:
@@ -119,10 +136,9 @@ def get_standup_context(
 ) -> StandupContext:
     """Extract journal outcome summaries since `since`.
 
-    Scans journal/YYYY-MM-DD/*.md files whose mtime is after `since`,
-    extracts **Outcome** lines, filters low-signal entries unless
-    include_low_signal=True, and returns up to `limit` summaries ordered
-    newest-first.
+    Scans journal/YYYY-MM-DD/*.md files modified since `since`, extracts
+    **Outcome** lines, filters low-signal entries unless include_low_signal=True,
+    and returns up to `limit` summaries ordered newest-first.
     """
     ctx = StandupContext(since=since)
 
@@ -130,12 +146,13 @@ def get_standup_context(
         return ctx
 
     candidates: list[tuple[float, Path]] = []
+    since_timestamp = since.astimezone(timezone.utc).timestamp()
 
     # Scan only YYYY-MM-DD date directories whose date is >= since (UTC date).
     # Non-date entries (e.g. 'templates/') are skipped.
     # Filtering by directory date (not file mtime) is semantically correct:
     # the directory name IS the journal date regardless of when the file was written.
-    since_date_str = since.date().isoformat()
+    since_date_str = since.astimezone(timezone.utc).date().isoformat()
 
     date_dirs = sorted(
         (
@@ -156,8 +173,9 @@ def get_standup_context(
             try:
                 mtime = path.stat().st_mtime
             except OSError:
-                mtime = 0.0
-            candidates.append((mtime, path))
+                continue
+            if mtime >= since_timestamp:
+                candidates.append((mtime, path))
 
     # Newest first
     candidates.sort(key=lambda t: t[0], reverse=True)

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/standup_data.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/standup_data.py
@@ -15,6 +15,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+from gptme_sessions.store import SessionStore
+
 
 # Phrases whose presence marks a progress entry as internal bookkeeping
 # rather than meaningful standup content (keep narrow — overfitting hurts).
@@ -127,6 +129,36 @@ class StandupContext:
         }
 
 
+def _journal_completion_times(journal_dir: Path) -> dict[Path, datetime]:
+    """Return immutable session completion times keyed by journal path."""
+    workspace = journal_dir.parent.resolve()
+    completion_times: dict[Path, datetime] = {}
+
+    for record in SessionStore().load_all():
+        if not record.journal_path:
+            continue
+        completed_at = record.end_time or record.timestamp
+        if not completed_at:
+            continue
+        try:
+            completed = datetime.fromisoformat(completed_at.replace("Z", "+00:00"))
+        except ValueError:
+            continue
+        if completed.tzinfo is None:
+            completed = completed.replace(tzinfo=timezone.utc)
+
+        path = Path(record.journal_path)
+        if not path.is_absolute():
+            path = workspace / path
+        path = path.resolve()
+        completed = completed.astimezone(timezone.utc)
+        previous = completion_times.get(path)
+        if previous is None or completed > previous:
+            completion_times[path] = completed
+
+    return completion_times
+
+
 def get_standup_context(
     journal_dir: Path,
     since: datetime,
@@ -136,23 +168,24 @@ def get_standup_context(
 ) -> StandupContext:
     """Extract journal outcome summaries since `since`.
 
-    Scans journal/YYYY-MM-DD/*.md files modified since `since`, extracts
-    **Outcome** lines, filters low-signal entries unless include_low_signal=True,
-    and returns up to `limit` summaries ordered newest-first.
+    Scans journal/YYYY-MM-DD/*.md files whose recorded session completion time
+    is after `since`, filters low-signal entries unless include_low_signal=True,
+    and returns up to `limit` summaries ordered newest-first. Files without a
+    session record use their journal date at midnight UTC, preserving whole-day
+    lookbacks without treating mutable filesystem metadata as occurrence time.
     """
     ctx = StandupContext(since=since)
 
     if not journal_dir.exists():
         return ctx
 
-    candidates: list[tuple[float, Path]] = []
-    since_timestamp = since.astimezone(timezone.utc).timestamp()
+    candidates: list[tuple[datetime, Path]] = []
+    since = since.astimezone(timezone.utc)
+    completion_times = _journal_completion_times(journal_dir)
 
     # Scan only YYYY-MM-DD date directories whose date is >= since (UTC date).
     # Non-date entries (e.g. 'templates/') are skipped.
-    # Filtering by directory date (not file mtime) is semantically correct:
-    # the directory name IS the journal date regardless of when the file was written.
-    since_date_str = since.astimezone(timezone.utc).date().isoformat()
+    since_date_str = since.date().isoformat()
 
     date_dirs = sorted(
         (
@@ -167,15 +200,13 @@ def get_standup_context(
         if date_dir.name < since_date_str:
             break  # all remaining dirs are older; sorted so safe to stop
 
+        fallback_time = datetime.fromisoformat(date_dir.name).replace(tzinfo=timezone.utc)
         for path in date_dir.glob("*.md"):
             if path.name == "self-merges.md":
                 continue
-            try:
-                mtime = path.stat().st_mtime
-            except OSError:
-                continue
-            if mtime >= since_timestamp:
-                candidates.append((mtime, path))
+            completed = completion_times.get(path.resolve(), fallback_time)
+            if completed >= since:
+                candidates.append((completed, path))
 
     # Newest first
     candidates.sort(key=lambda t: t[0], reverse=True)

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/standup_data.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/standup_data.py
@@ -171,8 +171,8 @@ def get_standup_context(
     Scans journal/YYYY-MM-DD/*.md files whose recorded session completion time
     is after `since`, filters low-signal entries unless include_low_signal=True,
     and returns up to `limit` summaries ordered newest-first. Files without a
-    session record use their journal date at midnight UTC, preserving whole-day
-    lookbacks without treating mutable filesystem metadata as occurrence time.
+    session record are included for the boundary day because their sub-day
+    occurrence time is unknown; dated directories still exclude older days.
     """
     ctx = StandupContext(since=since)
 
@@ -204,9 +204,10 @@ def get_standup_context(
         for path in date_dir.glob("*.md"):
             if path.name == "self-merges.md":
                 continue
-            completed = completion_times.get(path.resolve(), fallback_time)
-            if completed >= since:
-                candidates.append((completed, path))
+            completed = completion_times.get(path.resolve())
+            if completed is not None and completed < since:
+                continue
+            candidates.append((completed or fallback_time, path))
 
     # Newest first
     candidates.sort(key=lambda t: t[0], reverse=True)

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/standup_data.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/standup_data.py
@@ -1,0 +1,185 @@
+"""
+Standup context extraction from journal outcome summaries.
+
+Provides a reusable "since-last-standup" digest that voice handlers and
+other callers can inject as pre-fetched context instead of using raw commit
+subjects (which are implementation-biased and incomplete).
+
+See: ErikBjare/bob#918, gptme-contrib#1333
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+
+# Phrases whose presence marks a progress entry as internal bookkeeping
+# rather than meaningful standup content (keep narrow — overfitting hurts).
+_LOW_SIGNAL_PATTERNS = (
+    r"\btypecheck\b",
+    r"\blint\b",
+    r"\bloo analysis\b",
+    r"\bself-review\b",
+    r"\bstate saved\b",
+    r"\bgreptile findings tracked\b",
+    r"\bpre-commit hooks?\b",
+    r"\bno new lessons?\b",
+)
+
+
+def parse_since(since: str) -> datetime:
+    """Parse a --since value into an aware UTC datetime.
+
+    Accepts:
+      "24h", "48h", "Nh"  — N hours ago
+      "1d", "3d"          — N days ago
+      ISO 8601 string     — parsed as UTC if no tz info
+    """
+    since = since.strip()
+    now = datetime.now(timezone.utc)
+
+    # Duration: "24h", "48h", "2h"
+    m = re.fullmatch(r"(\d+(?:\.\d+)?)h", since, re.IGNORECASE)
+    if m:
+        return now - timedelta(hours=float(m.group(1)))
+
+    # Duration: "1d", "3d"
+    m = re.fullmatch(r"(\d+(?:\.\d+)?)d", since, re.IGNORECASE)
+    if m:
+        return now - timedelta(days=float(m.group(1)))
+
+    # ISO timestamp
+    dt = datetime.fromisoformat(since.rstrip("Z").replace("Z", "+00:00"))
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _extract_outcome_line(path: Path) -> str | None:
+    """Return the outcome summary from a journal file, or None."""
+    try:
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+            if not line.startswith("**Outcome**:"):
+                continue
+            summary = line.split(":", 1)[1].strip()
+            # Strip "productive — " or "blocked — " prefix
+            if "—" in summary:
+                _, rest = summary.split("—", 1)
+                summary = rest.strip()
+            return summary or None
+    except OSError:
+        return None
+    return None
+
+
+def _is_low_signal(summary: str) -> bool:
+    normalized = summary.strip().lower()
+    return any(re.search(p, normalized) for p in _LOW_SIGNAL_PATTERNS)
+
+
+@dataclass
+class JournalSummary:
+    date: str  # YYYY-MM-DD
+    session: str  # journal filename stem
+    summary: str
+    low_signal: bool = False
+
+
+@dataclass
+class StandupContext:
+    since: datetime
+    journal_summaries: list[JournalSummary] = field(default_factory=list)
+    generated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    def to_dict(self) -> dict:
+        return {
+            "since": self.since.isoformat(),
+            "generated_at": self.generated_at.isoformat(),
+            "journal_summaries": [
+                {
+                    "date": s.date,
+                    "session": s.session,
+                    "summary": s.summary,
+                    "low_signal": s.low_signal,
+                }
+                for s in self.journal_summaries
+            ],
+        }
+
+
+def get_standup_context(
+    journal_dir: Path,
+    since: datetime,
+    *,
+    limit: int = 8,
+    include_low_signal: bool = False,
+) -> StandupContext:
+    """Extract journal outcome summaries since `since`.
+
+    Scans journal/YYYY-MM-DD/*.md files whose mtime is after `since`,
+    extracts **Outcome** lines, filters low-signal entries unless
+    include_low_signal=True, and returns up to `limit` summaries ordered
+    newest-first.
+    """
+    ctx = StandupContext(since=since)
+
+    if not journal_dir.exists():
+        return ctx
+
+    candidates: list[tuple[float, Path]] = []
+
+    # Scan only YYYY-MM-DD date directories whose date is >= since (UTC date).
+    # Non-date entries (e.g. 'templates/') are skipped.
+    # Filtering by directory date (not file mtime) is semantically correct:
+    # the directory name IS the journal date regardless of when the file was written.
+    since_date_str = since.date().isoformat()
+
+    date_dirs = sorted(
+        (
+            d
+            for d in journal_dir.iterdir()
+            if d.is_dir() and re.fullmatch(r"\d{4}-\d{2}-\d{2}", d.name)
+        ),
+        reverse=True,
+    )
+
+    for date_dir in date_dirs:
+        if date_dir.name < since_date_str:
+            break  # all remaining dirs are older; sorted so safe to stop
+
+        for path in date_dir.glob("*.md"):
+            if path.name == "self-merges.md":
+                continue
+            try:
+                mtime = path.stat().st_mtime
+            except OSError:
+                mtime = 0.0
+            candidates.append((mtime, path))
+
+    # Newest first
+    candidates.sort(key=lambda t: t[0], reverse=True)
+
+    high: list[JournalSummary] = []
+    low: list[JournalSummary] = []
+
+    for _mtime, path in candidates:
+        outcome = _extract_outcome_line(path)
+        if not outcome:
+            continue
+        entry = JournalSummary(
+            date=path.parent.name,
+            session=path.stem,
+            summary=outcome,
+            low_signal=_is_low_signal(outcome),
+        )
+        (low if entry.low_signal else high).append(entry)
+
+    selected = high[:limit]
+    if include_low_signal and len(selected) < limit:
+        selected.extend(low[: limit - len(selected)])
+
+    ctx.journal_summaries = selected
+    return ctx

--- a/packages/gptme-activity-summary/tests/test_standup_data.py
+++ b/packages/gptme-activity-summary/tests/test_standup_data.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import os
+import json
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -45,17 +45,35 @@ class TestParseSince:
 
 
 class TestGetStandupContext:
-    def _make_journal(self, tmp_path: Path, entries: list[dict]) -> Path:
-        """Create a minimal journal directory with fake session files."""
+    def _make_journal(
+        self,
+        tmp_path: Path,
+        entries: list[dict],
+        monkeypatch: pytest.MonkeyPatch | None = None,
+    ) -> Path:
+        """Create a minimal journal directory with fake session records."""
         journal = tmp_path / "journal"
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir(exist_ok=True)
+        records = []
         for entry in entries:
             day_dir = journal / entry["date"]
             day_dir.mkdir(parents=True, exist_ok=True)
             path = day_dir / f"{entry['session']}.md"
             path.write_text(f"**Outcome**: productive — {entry['summary']}\n")
             if "timestamp" in entry:
-                timestamp = entry["timestamp"].timestamp()
-                os.utime(path, (timestamp, timestamp))
+                records.append(
+                    {
+                        "session_id": entry["session"],
+                        "journal_path": str(path.relative_to(tmp_path)),
+                        "end_time": entry["timestamp"].isoformat(),
+                    }
+                )
+        (sessions_dir / "session-records.jsonl").write_text(
+            "".join(json.dumps(record) + "\n" for record in records)
+        )
+        if monkeypatch is not None:
+            monkeypatch.setenv("GPTME_SESSIONS_DIR", str(sessions_dir))
         return journal
 
     def test_finds_recent_summaries(self, tmp_path: Path) -> None:
@@ -108,7 +126,9 @@ class TestGetStandupContext:
         ctx = get_standup_context(journal, since)
         assert len(ctx.journal_summaries) == 0
 
-    def test_skips_files_before_since(self, tmp_path: Path) -> None:
+    def test_skips_files_before_since(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         journal = self._make_journal(
             tmp_path,
             [
@@ -119,12 +139,15 @@ class TestGetStandupContext:
                     "timestamp": datetime(2026, 7, 31, 8, tzinfo=timezone.utc),
                 }
             ],
+            monkeypatch,
         )
         since = datetime(2026, 7, 31, 12, tzinfo=timezone.utc)
         ctx = get_standup_context(journal, since)
         assert len(ctx.journal_summaries) == 0
 
-    def test_includes_files_after_subday_cutoff(self, tmp_path: Path) -> None:
+    def test_includes_files_after_subday_cutoff(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         journal = self._make_journal(
             tmp_path,
             [
@@ -135,10 +158,30 @@ class TestGetStandupContext:
                     "timestamp": datetime(2026, 7, 31, 13, tzinfo=timezone.utc),
                 }
             ],
+            monkeypatch,
         )
         since = datetime(2026, 7, 31, 12, tzinfo=timezone.utc)
         ctx = get_standup_context(journal, since)
         assert [s.summary for s in ctx.journal_summaries] == ["new work"]
+
+    def test_ignores_mutable_mtime(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        journal = self._make_journal(
+            tmp_path,
+            [
+                {
+                    "date": "2026-07-31",
+                    "session": "s1",
+                    "summary": "old work",
+                    "timestamp": datetime(2026, 7, 31, 8, tzinfo=timezone.utc),
+                }
+            ],
+            monkeypatch,
+        )
+        path = journal / "2026-07-31" / "s1.md"
+        path.touch()
+
+        ctx = get_standup_context(journal, datetime(2026, 7, 31, 12, tzinfo=timezone.utc))
+        assert ctx.journal_summaries == []
 
     def test_empty_journal_dir(self, tmp_path: Path) -> None:
         journal = tmp_path / "journal"

--- a/packages/gptme-activity-summary/tests/test_standup_data.py
+++ b/packages/gptme-activity-summary/tests/test_standup_data.py
@@ -164,6 +164,21 @@ class TestGetStandupContext:
         ctx = get_standup_context(journal, since)
         assert [s.summary for s in ctx.journal_summaries] == ["new work"]
 
+    def test_includes_boundary_day_file_without_session_record(self, tmp_path: Path) -> None:
+        journal = self._make_journal(
+            tmp_path,
+            [
+                {
+                    "date": "2026-07-31",
+                    "session": "s1",
+                    "summary": "recordless recent work",
+                }
+            ],
+        )
+
+        ctx = get_standup_context(journal, datetime(2026, 7, 31, 12, tzinfo=timezone.utc))
+        assert [s.summary for s in ctx.journal_summaries] == ["recordless recent work"]
+
     def test_ignores_mutable_mtime(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         journal = self._make_journal(
             tmp_path,

--- a/packages/gptme-activity-summary/tests/test_standup_data.py
+++ b/packages/gptme-activity-summary/tests/test_standup_data.py
@@ -1,0 +1,159 @@
+"""Tests for standup_data: journal outcome extraction and --since parsing."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from gptme_activity_summary.standup_data import (
+    get_standup_context,
+    parse_since,
+)
+
+
+class TestParseSince:
+    def test_hours(self) -> None:
+        now = datetime.now(timezone.utc)
+        result = parse_since("24h")
+        delta = now - result
+        assert 23 * 3600 < delta.total_seconds() < 25 * 3600
+
+    def test_days(self) -> None:
+        now = datetime.now(timezone.utc)
+        result = parse_since("3d")
+        delta = now - result
+        assert 2.9 * 86400 < delta.total_seconds() < 3.1 * 86400
+
+    def test_iso_string(self) -> None:
+        result = parse_since("2026-07-31T18:00:00Z")
+        assert result == datetime(2026, 7, 31, 18, 0, 0, tzinfo=timezone.utc)
+
+    def test_iso_without_z(self) -> None:
+        result = parse_since("2026-07-31T18:00:00")
+        assert result == datetime(2026, 7, 31, 18, 0, 0, tzinfo=timezone.utc)
+
+    def test_invalid_raises(self) -> None:
+        with pytest.raises((ValueError, TypeError)):
+            parse_since("not-a-date")
+
+
+class TestGetStandupContext:
+    def _make_journal(self, tmp_path: Path, entries: list[dict]) -> Path:
+        """Create a minimal journal directory with fake session files."""
+        journal = tmp_path / "journal"
+        for entry in entries:
+            day_dir = journal / entry["date"]
+            day_dir.mkdir(parents=True, exist_ok=True)
+            path = day_dir / f"{entry['session']}.md"
+            path.write_text(f"**Outcome**: productive — {entry['summary']}\n")
+        return journal
+
+    def test_finds_recent_summaries(self, tmp_path: Path) -> None:
+        journal = self._make_journal(
+            tmp_path,
+            [
+                {
+                    "date": "2026-07-31",
+                    "session": "autonomous-session-abcd",
+                    "summary": "shipped a cool feature",
+                }
+            ],
+        )
+        since = datetime(2026, 7, 30, tzinfo=timezone.utc)
+        ctx = get_standup_context(journal, since)
+        assert len(ctx.journal_summaries) == 1
+        assert ctx.journal_summaries[0].summary == "shipped a cool feature"
+        assert ctx.journal_summaries[0].date == "2026-07-31"
+
+    def test_skips_low_signal(self, tmp_path: Path) -> None:
+        journal = self._make_journal(
+            tmp_path,
+            [
+                {"date": "2026-07-31", "session": "s1", "summary": "ran typecheck and lint"},
+                {"date": "2026-07-31", "session": "s2", "summary": "shipped real feature"},
+            ],
+        )
+        since = datetime(2026, 7, 30, tzinfo=timezone.utc)
+        ctx = get_standup_context(journal, since)
+        summaries = [s.summary for s in ctx.journal_summaries]
+        assert "shipped real feature" in summaries
+        assert not any("typecheck" in s for s in summaries)
+
+    def test_include_low_signal_as_fallback(self, tmp_path: Path) -> None:
+        journal = self._make_journal(
+            tmp_path,
+            [{"date": "2026-07-31", "session": "s1", "summary": "ran typecheck and lint"}],
+        )
+        since = datetime(2026, 7, 30, tzinfo=timezone.utc)
+        ctx = get_standup_context(journal, since, include_low_signal=True)
+        assert len(ctx.journal_summaries) == 1
+        assert ctx.journal_summaries[0].low_signal is True
+
+    def test_skips_self_merges(self, tmp_path: Path) -> None:
+        journal = tmp_path / "journal"
+        day = journal / "2026-07-31"
+        day.mkdir(parents=True)
+        (day / "self-merges.md").write_text("**Outcome**: productive — merged stuff\n")
+        since = datetime(2026, 7, 30, tzinfo=timezone.utc)
+        ctx = get_standup_context(journal, since)
+        assert len(ctx.journal_summaries) == 0
+
+    def test_skips_files_before_since(self, tmp_path: Path) -> None:
+        journal = self._make_journal(
+            tmp_path,
+            [{"date": "2026-07-28", "session": "s1", "summary": "old work"}],
+        )
+        # Since is after the file was written (we check mtime)
+        since = datetime(2026, 7, 30, tzinfo=timezone.utc)
+        ctx = get_standup_context(journal, since)
+        assert len(ctx.journal_summaries) == 0
+
+    def test_empty_journal_dir(self, tmp_path: Path) -> None:
+        journal = tmp_path / "journal"
+        journal.mkdir()
+        since = datetime(2026, 7, 30, tzinfo=timezone.utc)
+        ctx = get_standup_context(journal, since)
+        assert ctx.journal_summaries == []
+
+    def test_missing_journal_dir(self, tmp_path: Path) -> None:
+        ctx = get_standup_context(
+            tmp_path / "nonexistent", datetime(2026, 7, 30, tzinfo=timezone.utc)
+        )
+        assert ctx.journal_summaries == []
+
+    def test_to_dict_schema(self, tmp_path: Path) -> None:
+        journal = self._make_journal(
+            tmp_path,
+            [{"date": "2026-07-31", "session": "s1", "summary": "did work"}],
+        )
+        since = datetime(2026, 7, 30, tzinfo=timezone.utc)
+        ctx = get_standup_context(journal, since)
+        d = ctx.to_dict()
+        assert "since" in d
+        assert "generated_at" in d
+        assert "journal_summaries" in d
+        assert isinstance(d["journal_summaries"], list)
+        if d["journal_summaries"]:
+            s = d["journal_summaries"][0]
+            assert "date" in s and "session" in s and "summary" in s and "low_signal" in s
+
+    def test_limit_respected(self, tmp_path: Path) -> None:
+        journal = self._make_journal(
+            tmp_path,
+            [{"date": "2026-07-31", "session": f"s{i}", "summary": f"work {i}"} for i in range(10)],
+        )
+        since = datetime(2026, 7, 30, tzinfo=timezone.utc)
+        ctx = get_standup_context(journal, since, limit=3)
+        assert len(ctx.journal_summaries) <= 3
+
+    def test_ignores_non_date_subdirs(self, tmp_path: Path) -> None:
+        journal = tmp_path / "journal"
+        journal.mkdir()
+        templates = journal / "templates"
+        templates.mkdir()
+        (templates / "example.md").write_text("**Outcome**: productive — template stuff\n")
+        since = datetime(2026, 7, 30, tzinfo=timezone.utc)
+        ctx = get_standup_context(journal, since)
+        assert len(ctx.journal_summaries) == 0

--- a/packages/gptme-activity-summary/tests/test_standup_data.py
+++ b/packages/gptme-activity-summary/tests/test_standup_data.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -34,6 +35,10 @@ class TestParseSince:
         result = parse_since("2026-07-31T18:00:00")
         assert result == datetime(2026, 7, 31, 18, 0, 0, tzinfo=timezone.utc)
 
+    def test_iso_offset_is_normalized_to_utc(self) -> None:
+        result = parse_since("2026-08-01T01:00:00+03:00")
+        assert result == datetime(2026, 7, 31, 22, 0, 0, tzinfo=timezone.utc)
+
     def test_invalid_raises(self) -> None:
         with pytest.raises((ValueError, TypeError)):
             parse_since("not-a-date")
@@ -48,6 +53,9 @@ class TestGetStandupContext:
             day_dir.mkdir(parents=True, exist_ok=True)
             path = day_dir / f"{entry['session']}.md"
             path.write_text(f"**Outcome**: productive — {entry['summary']}\n")
+            if "timestamp" in entry:
+                timestamp = entry["timestamp"].timestamp()
+                os.utime(path, (timestamp, timestamp))
         return journal
 
     def test_finds_recent_summaries(self, tmp_path: Path) -> None:
@@ -103,12 +111,34 @@ class TestGetStandupContext:
     def test_skips_files_before_since(self, tmp_path: Path) -> None:
         journal = self._make_journal(
             tmp_path,
-            [{"date": "2026-07-28", "session": "s1", "summary": "old work"}],
+            [
+                {
+                    "date": "2026-07-31",
+                    "session": "s1",
+                    "summary": "old work",
+                    "timestamp": datetime(2026, 7, 31, 8, tzinfo=timezone.utc),
+                }
+            ],
         )
-        # Since is after the file was written (we check mtime)
-        since = datetime(2026, 7, 30, tzinfo=timezone.utc)
+        since = datetime(2026, 7, 31, 12, tzinfo=timezone.utc)
         ctx = get_standup_context(journal, since)
         assert len(ctx.journal_summaries) == 0
+
+    def test_includes_files_after_subday_cutoff(self, tmp_path: Path) -> None:
+        journal = self._make_journal(
+            tmp_path,
+            [
+                {
+                    "date": "2026-07-31",
+                    "session": "s1",
+                    "summary": "new work",
+                    "timestamp": datetime(2026, 7, 31, 13, tzinfo=timezone.utc),
+                }
+            ],
+        )
+        since = datetime(2026, 7, 31, 12, tzinfo=timezone.utc)
+        ctx = get_standup_context(journal, since)
+        assert [s.summary for s in ctx.journal_summaries] == ["new work"]
 
     def test_empty_journal_dir(self, tmp_path: Path) -> None:
         journal = tmp_path / "journal"
@@ -147,6 +177,15 @@ class TestGetStandupContext:
         since = datetime(2026, 7, 30, tzinfo=timezone.utc)
         ctx = get_standup_context(journal, since, limit=3)
         assert len(ctx.journal_summaries) <= 3
+
+    def test_preserves_em_dash_inside_free_form_outcome(self, tmp_path: Path) -> None:
+        journal = tmp_path / "journal"
+        day = journal / "2026-07-31"
+        day.mkdir(parents=True)
+        (day / "s1.md").write_text("**Outcome**: fixed the build — tests now pass\n")
+        since = datetime(2026, 7, 30, tzinfo=timezone.utc)
+        ctx = get_standup_context(journal, since)
+        assert [s.summary for s in ctx.journal_summaries] == ["fixed the build — tests now pass"]
 
     def test_ignores_non_date_subdirs(self, tmp_path: Path) -> None:
         journal = tmp_path / "journal"


### PR DESCRIPTION
## Problem

The voice standup context needs high-level session outcome summaries, not raw
commit subjects. PR #1333 (closed) showed commit subjects are insufficient —
they're implementation-biased and miss the high-level signal Erik needs for
"what did you do today?".

## Fix

Adds a reusable, tested `standup` subcommand to `gptme-activity-summary` that
extracts journal `**Outcome**` lines for a configurable `--since` window.

## Changes

**New: `standup_data.py`**
- `parse_since(since)` — parses "24h", "48h", "3d", ISO timestamps into UTC datetime
- `get_standup_context(journal_dir, since)` — scans YYYY-MM-DD journal dirs, extracts
  **Outcome** lines, filters low-signal entries (typecheck/lint/self-review),
  returns `StandupContext` with ordered summaries
- Filters by directory date (semantic) not file mtime (implementation detail)

**New CLI: `gptme-activity-summary standup`**
```bash
# JSON output (default) — for programmatic consumption
gptme-activity-summary standup --since 24h

# Text output — for human/debug use
gptme-activity-summary standup --since 48h --format text

# ISO timestamp
gptme-activity-summary standup --since "2026-07-31T10:00:00Z"
```

**15 new tests** covering `parse_since` variants (hours, days, ISO, invalid),
journal scanning, low-signal filtering, self-merges skip, date boundary, limit,
non-date subdirectory exclusion, empty/missing dir, `to_dict()` schema.

## Relationship to #1339

PR #1339 (merged) wired the voice server to read `state/voice-digest.md`.
This PR provides the tested, reusable **extraction API** that both
`voice-digest-precompute.py` and any future callers can use to generate that
digest, instead of each script reimplementing the `**Outcome**` extraction logic.

## Test plan

- [x] `uv run pytest packages/gptme-activity-summary/tests/test_standup_data.py -v` — 15 passed
- [x] `uv run gptme-activity-summary standup --since 24h --format text` — shows real journal summaries
- [x] `uv run ruff check` — clean
- [x] pre-commit hooks pass

Closes ErikBjare/bob#918