### PR TITLE
feat(gptodo): add Mermaid output to dep dag (Phase 1 of task graph view)

### DIFF
--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -62,6 +62,7 @@ from gptodo.deptree import (
     compute_unblocking_power,
     detect_circular_dependencies,
     get_dependency_tree,
+    render_dag_mermaid,
     render_full_dag_ascii,
 )
 
@@ -5670,19 +5671,27 @@ def dep_check(output_json: bool):
     flag_value=False,
     help="Hide unblocking power scores",
 )
-def dep_dag(state: tuple[str, ...], show_power: bool):
+@click.option(
+    "--format",
+    "-f",
+    "fmt",
+    type=click.Choice(["ascii", "mermaid"]),
+    default="ascii",
+    help="Output format: ascii (default) or mermaid (for webui / Markdown embedding)",
+)
+def dep_dag(state: tuple[str, ...], show_power: bool, fmt: str):
     """Show the full workspace dependency graph.
 
-    Renders all tasks with their dependency relationships as an ASCII graph,
-    with optional unblocking power scores showing which tasks unlock the most
-    downstream work.
+    Renders all tasks with their dependency relationships, with optional
+    unblocking power scores showing which tasks unlock the most downstream work.
 
     Examples:
 
     \b
-        gptodo dep dag                    # Full graph, non-terminal tasks
-        gptodo dep dag --state active     # Active tasks only
-        gptodo dep dag --no-power         # Hide unblocking power scores
+        gptodo dep dag                        # Full ASCII graph, non-terminal tasks
+        gptodo dep dag --state active         # Active tasks only
+        gptodo dep dag --no-power             # Hide unblocking power scores
+        gptodo dep dag --format mermaid       # Mermaid output (webui / Markdown)
     """
     console = Console()
     repo_root = find_repo_root(Path.cwd())
@@ -5706,6 +5715,18 @@ def dep_dag(state: tuple[str, ...], show_power: bool):
         }
 
     power = compute_unblocking_power(nodes) if show_power else None
+
+    if fmt == "mermaid":
+        dag = render_dag_mermaid(nodes, unblocking_power=power, filter_states=filter_states)
+        if not dag.strip():
+            console.print("[yellow]No tasks with dependencies found.[/]")
+            return
+        title = "Workspace Dependency DAG"
+        if filter_states:
+            title += f" ({', '.join(sorted(filter_states))})"
+        console.print(f"[bold]{title}[/]\n")
+        console.print(f"```mermaid\n{dag}\n```")
+        return
 
     dag = render_full_dag_ascii(nodes, unblocking_power=power, filter_states=filter_states)
 

--- a/packages/gptodo/src/gptodo/deptree.py
+++ b/packages/gptodo/src/gptodo/deptree.py
@@ -7,6 +7,8 @@ Also provides unblocking power computation for priority scoring.
 """
 
 from dataclasses import dataclass, field
+from hashlib import sha256
+from html import escape
 from pathlib import Path
 
 from .utils import TaskInfo, load_tasks
@@ -372,8 +374,13 @@ def render_dag_mermaid(
     if not nodes:
         return ""
 
-    def sanitize_id(name: str) -> str:
-        return name.replace("-", "_").replace("/", "_").replace(".", "_").replace(":", "_")[:40]
+    def mermaid_id(name: str) -> str:
+        """Return a deterministic, collision-resistant Mermaid identifier."""
+        return f"task_{sha256(name.encode()).hexdigest()}"
+
+    def mermaid_label(text: str) -> str:
+        """Escape arbitrary task text for a quoted Mermaid HTML label."""
+        return escape(text, quote=True).replace("\n", "&#10;").replace("\r", "&#13;")
 
     # State → CSS class mapping (matches the classDef blocks below)
     _state_class = {
@@ -401,19 +408,19 @@ def render_dag_mermaid(
     # Node definitions
     for name in sorted(visible):
         node = nodes[name]
-        node_id = sanitize_id(name)
+        node_id = mermaid_id(name)
         label = name
         if unblocking_power and unblocking_power.get(name, 0) > 0:
             label = f"{name} [{unblocking_power[name]}↑]"
-        lines.append(f'    {node_id}["{label}<br/>({node.state})"]')
+        lines.append(f'    {node_id}["{mermaid_label(label)}<br/>({mermaid_label(node.state)})"]')
 
     # Edges (only between visible nodes)
     for name in sorted(visible):
         node = nodes[name]
-        node_id = sanitize_id(name)
+        node_id = mermaid_id(name)
         for req in node.requires:
             if req.name in visible:
-                req_id = sanitize_id(req.name)
+                req_id = mermaid_id(req.name)
                 edge = (req_id, node_id)
                 if edge not in emitted_edges:
                     emitted_edges.add(edge)
@@ -425,7 +432,7 @@ def render_dag_mermaid(
         node = nodes[name]
         css = _state_class.get(node.state)
         if css:
-            class_members.setdefault(css, []).append(sanitize_id(name))
+            class_members.setdefault(css, []).append(mermaid_id(name))
 
     if class_members:
         lines.append("")

--- a/packages/gptodo/src/gptodo/deptree.py
+++ b/packages/gptodo/src/gptodo/deptree.py
@@ -348,6 +348,106 @@ def render_tree_ascii(
     return "\n".join(lines)
 
 
+def render_dag_mermaid(
+    nodes: dict[str, DependencyNode],
+    unblocking_power: dict[str, int] | None = None,
+    filter_states: set[str] | None = None,
+) -> str:
+    """Render the full workspace dependency DAG as a Mermaid graph.
+
+    Produces a ``graph TD`` diagram showing all tasks and their dependency
+    relationships.  The output can be embedded directly in Mermaid-aware
+    renderers such as gptme-webui or GitHub Markdown.
+
+    Args:
+        nodes: Dependency graph (from ``build_dependency_graph``).
+        unblocking_power: Optional mapping of task name → power score.  When
+            provided, scores are appended to node labels.
+        filter_states: When non-None, only tasks whose ``state`` is in this set
+            are included.  Edges that cross the filtered boundary are dropped.
+
+    Returns:
+        Mermaid graph definition string (empty string when nothing to render).
+    """
+    if not nodes:
+        return ""
+
+    def sanitize_id(name: str) -> str:
+        return name.replace("-", "_").replace("/", "_").replace(".", "_").replace(":", "_")[:40]
+
+    # State → CSS class mapping (matches the classDef blocks below)
+    _state_class = {
+        "done": "done",
+        "cancelled": "cancelled",
+        "active": "active",
+        "ready_for_review": "review",
+        "waiting": "waiting",
+    }
+
+    visible: set[str] = set()
+    for name, node in nodes.items():
+        if node.is_external:
+            continue
+        if filter_states is not None and node.state not in filter_states:
+            continue
+        visible.add(name)
+
+    if not visible:
+        return ""
+
+    lines: list[str] = ["graph TD"]
+    emitted_edges: set[tuple[str, str]] = set()
+
+    # Node definitions
+    for name in sorted(visible):
+        node = nodes[name]
+        node_id = sanitize_id(name)
+        label = name
+        if unblocking_power and unblocking_power.get(name, 0) > 0:
+            label = f"{name} [{unblocking_power[name]}↑]"
+        lines.append(f'    {node_id}["{label}<br/>({node.state})"]')
+
+    # Edges (only between visible nodes)
+    for name in sorted(visible):
+        node = nodes[name]
+        node_id = sanitize_id(name)
+        for req in node.requires:
+            if req.name in visible:
+                req_id = sanitize_id(req.name)
+                edge = (req_id, node_id)
+                if edge not in emitted_edges:
+                    emitted_edges.add(edge)
+                    lines.append(f"    {req_id} --> {node_id}")
+
+    # Class assignments
+    class_members: dict[str, list[str]] = {}
+    for name in sorted(visible):
+        node = nodes[name]
+        css = _state_class.get(node.state)
+        if css:
+            class_members.setdefault(css, []).append(sanitize_id(name))
+
+    if class_members:
+        lines.append("")
+        for css, members in sorted(class_members.items()):
+            lines.append(f"    class {','.join(members)} {css}")
+
+    # Class definitions
+    lines.extend(
+        [
+            "",
+            "    classDef done fill:#90EE90",
+            "    classDef cancelled fill:#FFB6C1",
+            "    classDef active fill:#87CEEB",
+            "    classDef review fill:#FFD700",
+            "    classDef waiting fill:#DDA0DD",
+            "    classDef blocked fill:#FF6347",
+        ]
+    )
+
+    return "\n".join(lines)
+
+
 def render_tree_mermaid(
     root_name: str,
     nodes: dict[str, DependencyNode],

--- a/packages/gptodo/tests/test_deptree.py
+++ b/packages/gptodo/tests/test_deptree.py
@@ -7,6 +7,7 @@ from gptodo.deptree import (
     DependencyNode,
     build_dependency_graph,
     compute_unblocking_power,
+    render_dag_mermaid,
     render_full_dag_ascii,
 )
 from gptodo.utils import SubtaskCount, TaskInfo
@@ -262,3 +263,104 @@ class TestRenderFullDagAscii:
         assert result.startswith("── No dependencies ──")
         assert "active-child" in result
         assert "done-base" not in result
+
+
+# ---------------------------------------------------------------------------
+# render_dag_mermaid tests
+# ---------------------------------------------------------------------------
+
+
+class TestRenderDagMermaid:
+    def test_empty_graph(self):
+        """Empty graph returns empty string."""
+        nodes: dict[str, DependencyNode] = {}
+        result = render_dag_mermaid(nodes)
+        assert result == ""
+
+    def test_isolated_tasks_included(self):
+        """Isolated tasks appear in the Mermaid output."""
+        tasks = [make_task("alpha"), make_task("beta")]
+        nodes = build_dependency_graph(tasks)
+        result = render_dag_mermaid(nodes)
+        assert "graph TD" in result
+        assert "alpha" in result
+        assert "beta" in result
+
+    def test_edge_rendered(self):
+        """A dependency edge appears as an arrow in the Mermaid output."""
+        tasks = [
+            make_task("base"),
+            make_task("child", requires=["base"]),
+        ]
+        nodes = build_dependency_graph(tasks)
+        result = render_dag_mermaid(nodes)
+        assert "-->" in result
+        # base must be referenced as the arrow source, child as target
+        assert "base" in result
+        assert "child" in result
+
+    def test_filter_states(self):
+        """filter_states excludes tasks not in the set."""
+        tasks = [
+            make_task("active-task", state="active"),
+            make_task("done-task", state="done"),
+        ]
+        nodes = build_dependency_graph(tasks)
+        result = render_dag_mermaid(nodes, filter_states={"active"})
+        assert "active-task" in result
+        assert "done-task" not in result
+
+    def test_empty_filter_states_returns_empty(self):
+        """An empty filter set produces no output."""
+        tasks = [make_task("done-task", state="done")]
+        nodes = build_dependency_graph(tasks)
+        result = render_dag_mermaid(nodes, filter_states=set())
+        assert result == ""
+
+    def test_cross_boundary_edge_dropped(self):
+        """Edges crossing the filter boundary are suppressed."""
+        tasks = [
+            make_task("done-base", state="done"),
+            make_task("active-child", state="active", requires=["done-base"]),
+        ]
+        nodes = build_dependency_graph(tasks)
+        result = render_dag_mermaid(nodes, filter_states={"active"})
+        # done-base filtered out, so the edge must not appear
+        assert "-->" not in result
+        assert "done-base" not in result
+        assert "active-child" in result
+
+    def test_power_scores_shown(self):
+        """Unblocking power scores appear in node labels when provided."""
+        tasks = [
+            make_task("base"),
+            make_task("child", requires=["base"]),
+        ]
+        nodes = build_dependency_graph(tasks)
+        power = compute_unblocking_power(nodes)
+        result = render_dag_mermaid(nodes, unblocking_power=power)
+        # base has power 1, should appear in its label
+        assert "1↑" in result
+
+    def test_power_scores_absent_when_none(self):
+        """No power annotation in node labels when unblocking_power is None."""
+        tasks = [make_task("a"), make_task("b", requires=["a"])]
+        nodes = build_dependency_graph(tasks)
+        result = render_dag_mermaid(nodes, unblocking_power=None)
+        assert "↑" not in result
+
+    def test_classdefs_present(self):
+        """ClassDef styling lines appear in the output."""
+        tasks = [make_task("task", state="active")]
+        nodes = build_dependency_graph(tasks)
+        result = render_dag_mermaid(nodes)
+        assert "classDef active" in result
+        assert "classDef done" in result
+
+    def test_class_assignment_by_state(self):
+        """Tasks receive a class assignment matching their state."""
+        tasks = [make_task("atask", state="active")]
+        nodes = build_dependency_graph(tasks)
+        result = render_dag_mermaid(nodes)
+        assert "class" in result
+        assert "active" in result

--- a/packages/gptodo/tests/test_deptree.py
+++ b/packages/gptodo/tests/test_deptree.py
@@ -364,3 +364,44 @@ class TestRenderDagMermaid:
         result = render_dag_mermaid(nodes)
         assert "class" in result
         assert "active" in result
+
+    def test_colliding_normalized_names_have_distinct_ids(self):
+        """Names that normalize alike must remain distinct Mermaid nodes."""
+        tasks = [
+            make_task("a-b"),
+            make_task("a_b"),
+            make_task("child", requires=["a-b", "a_b"]),
+        ]
+        nodes = build_dependency_graph(tasks)
+
+        result = render_dag_mermaid(nodes)
+        definitions = [line for line in result.splitlines() if '<br/>(active)"' in line]
+        node_ids = [line.strip().split("[", 1)[0] for line in definitions]
+
+        assert len(definitions) == 3
+        assert len(set(node_ids)) == 3
+        assert result.count(" --> ") == 2
+
+    def test_long_names_with_same_prefix_have_distinct_ids(self):
+        """Long names sharing a prefix must not collide through truncation."""
+        prefix = "a" * 80
+        tasks = [make_task(f"{prefix}-one"), make_task(f"{prefix}-two")]
+        nodes = build_dependency_graph(tasks)
+
+        result = render_dag_mermaid(nodes)
+        definitions = [line for line in result.splitlines() if '<br/>(active)"' in line]
+        node_ids = [line.strip().split("[", 1)[0] for line in definitions]
+
+        assert len(definitions) == 2
+        assert len(set(node_ids)) == 2
+
+    def test_mermaid_significant_label_characters_are_escaped(self):
+        """Arbitrary task names cannot terminate the quoted Mermaid label."""
+        name = 'task "quoted" [bracket] <tag>\nnext'
+        nodes = build_dependency_graph([make_task(name)])
+
+        result = render_dag_mermaid(nodes)
+
+        assert name not in result
+        assert "task &quot;quoted&quot; [bracket] &lt;tag&gt;&#10;next" in result
+        assert "\nnext" not in result


### PR DESCRIPTION
## Summary

Adds `render_dag_mermaid()` to `deptree.py` and a `--format mermaid` option to `gptodo dep dag`, enabling the full workspace task dependency graph to be embedded in Mermaid-aware renderers (gptme-webui, GitHub Markdown).

## Changes

- **`deptree.py`**: `render_dag_mermaid(nodes, unblocking_power, filter_states)` — renders the full workspace DAG as a Mermaid `graph TD` diagram with state-based CSS styling, cross-boundary edge suppression, and optional unblocking power score annotations
- **`cli.py`**: adds `--format [ascii|mermaid]` option to `gptodo dep dag` (default: ascii, backward-compatible)
- **`tests/test_deptree.py`**: 10 new tests covering `TestRenderDagMermaid` — empty graph, edges, filter_states, power scores, class defs

## Example

```
$ gptodo dep dag --state active --format mermaid
```

```mermaid
graph TD
    my_task["my-task<br/>(active)"]

    class my_task active

    classDef done fill:#90EE90
    classDef cancelled fill:#FFB6C1
    classDef active fill:#87CEEB
    ...
```

## Motivation

Phase 1 of idea #921 (gptme-webui Task Graph View). The existing `dep dag` command provides ASCII rendering; this adds the Mermaid path needed for Phase 2 (interactive webui sidebar embed).

Phase 2: read the Mermaid output in `gptme-webui` sidebar and render it with a Mermaid component.