### PR TITLE
fix(harness-models): add short-alias copilot-cli entries to subscription sets

### DIFF
--- a/packages/gptme-usage/src/gptme_usage/harness_models.py
+++ b/packages/gptme-usage/src/gptme_usage/harness_models.py
@@ -410,8 +410,12 @@ _CACHE_PRICING_PROVIDER: dict[tuple[str, str], str] = {
     ("claude-code", "opus"): "anthropic",
     ("claude-code", "sonnet"): "anthropic",
     ("claude-code", "fable-5"): "anthropic",
+    # copilot-cli: both full model names (for existing session records) and short
+    # aliases (for HARNESS_TIERS canonical keys after 2026-08-01 naming alignment).
     ("copilot-cli", "claude-opus-4.6"): "anthropic",
+    ("copilot-cli", "opus"): "anthropic",
     ("copilot-cli", "claude-sonnet-4.6"): "anthropic",
+    ("copilot-cli", "sonnet"): "anthropic",
     ("codex", "gpt-5.4"): "openai",
     ("codex", "gpt-5.5"): "openai",
     ("copilot-cli", "gpt-5.4"): "openai",
@@ -506,8 +510,15 @@ SUBSCRIPTION_BACKED_MODELS: set[tuple[str, str]] = {
     ("grok-build", "grok-build"),
     ("codex", "gpt-5.4"),
     ("codex", "gpt-5.5"),
+    # copilot-cli: both full model name (for pricing-table lookups from existing
+    # session records, where model="claude-sonnet-4.6") and short alias (to match
+    # HARNESS_TIERS canonical keys after the 2026-08-01 naming alignment). Once
+    # harness-quota.toml and dispatch scripts are updated to short aliases, the
+    # full-name entries below can be removed.
     ("copilot-cli", "claude-opus-4.6"),
+    ("copilot-cli", "opus"),
     ("copilot-cli", "claude-sonnet-4.6"),
+    ("copilot-cli", "sonnet"),
     ("copilot-cli", "gpt-5.4"),
     ("gptme", "gpt-5.4"),
     ("gptme", "gpt-5.5"),


### PR DESCRIPTION
## Summary

- Add `("copilot-cli", "sonnet")` and `("copilot-cli", "opus")` to `SUBSCRIPTION_BACKED_MODELS` alongside the existing full-name entries
- Add the same short-alias entries to `_CACHE_PRICING_PROVIDER`

## Background

Bob's `HARNESS_TIERS` canonical keys for copilot-cli were updated in ErikBjare/bob@e9d674f to use the same short aliases as the bandit arm IDs (`"sonnet"`, `"opus"` instead of `"claude-sonnet-4.6"`, `"claude-opus-4.6"`). The pre-commit validator `validate_harness_models_consistency.py` requires all non-retired entries in `HARNESS_TIERS` for subscription-only harnesses to also appear in `SUBSCRIPTION_BACKED_MODELS`.

## Approach

Both the full-name entries (e.g. `"claude-sonnet-4.6"`) and the new short-alias entries (e.g. `"sonnet"`) are kept simultaneously. This is a transitional state:
- Full-name entries remain for **backward compatibility**: existing session records and `harness-quota.toml` still reference `claude-sonnet-4.6`
- Short-alias entries satisfy the validator for the updated `HARNESS_TIERS`

Future cleanup can remove the full-name entries once `harness-quota.toml` and dispatch scripts are updated to use short aliases.

## Test plan

- [ ] Pre-commit checks pass (already verified locally)
- [ ] `validate_harness_models_consistency.py` passes against brain's `harness_models.py` after submodule bump
- [ ] Existing copilot-cli session cost estimation still works (full-name entries preserved)