### PR TITLE
fix(gptmail): disable codehilite guess_lang to prevent pygments KeyError

### DIFF
--- a/packages/gptmail/src/gptmail/lib.py
+++ b/packages/gptmail/src/gptmail/lib.py
@@ -912,6 +912,12 @@ class AgentEmail:
                 html_body = markdown.markdown(
                     fix_list_spacing(body),
                     extensions=["extra", "codehilite", "sane_lists"],
+                    # guess_lang triggers pygments' guess_lexer on every
+                    # untagged code block, which raises KeyError on a broken
+                    # lexer-cache entry (pygments 2.20.0: 'Debian Sources
+                    # file') and fails the whole send. Language guessing is
+                    # worthless for email anyway.
+                    extension_configs={"codehilite": {"guess_lang": False}},
                 )
                 # Use quoted-printable instead of base64 to reduce spam
                 # score. MIMEText._charset accepts Charset objects at

--- a/packages/gptmail/tests/test_mime.py
+++ b/packages/gptmail/tests/test_mime.py
@@ -3,8 +3,11 @@
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.utils import parseaddr
+from pathlib import Path
 
-from gptmail.lib import _format_address_header, _is_html, _utf8_qp
+import pytest
+
+from gptmail.lib import AgentEmail, _format_address_header, _is_html, _utf8_qp
 
 
 def test_is_html_detects_html():
@@ -92,6 +95,41 @@ def test_format_address_header_bare_address():
     value = _format_address_header("recipient@example.com")
     _, addr = parseaddr(value)
     assert addr == "recipient@example.com"
+
+
+@pytest.fixture
+def email_agent(tmp_path: Path) -> AgentEmail:
+    email_dir = tmp_path / "email"
+    for subdir in ["inbox", "sent", "archive", "drafts", "filters"]:
+        (email_dir / subdir).mkdir(parents=True, exist_ok=True)
+    return AgentEmail(tmp_path, own_email="sender@example.com")
+
+
+def test_send_disables_code_language_guessing(
+    email_agent: AgentEmail, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Untagged code blocks must not invoke Pygments lexer guessing."""
+    import gptmail.lib as lib
+
+    def fail_if_language_guessed(*args, **kwargs):
+        raise AssertionError("Pygments lexer guessing should be disabled")
+
+    monkeypatch.setattr(
+        "markdown.extensions.codehilite.guess_lexer",
+        fail_if_language_guessed,
+    )
+    monkeypatch.setenv("EMAIL_SEND_ALLOWLIST", "*")
+    monkeypatch.setattr(email_agent, "_validate_msmtp_config", lambda: True)
+    monkeypatch.setattr(email_agent.rate_limiter, "can_proceed", lambda: True)
+    monkeypatch.setattr(lib.subprocess, "run", lambda *args, **kwargs: None)
+
+    message_id = email_agent.compose(
+        "recipient@example.com",
+        "Code sample",
+        "```\napt install gptme\n```\n\n```python\nprint('tagged')\n```",
+    )
+
+    email_agent.send(message_id)
 
 
 def test_send_to_header_non_ascii_name_is_deliverable(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- Disables `guess_lang` in the `codehilite` extension when rendering markdown-to-HTML for emails
- In pygments 2.20.0, calling `guess_lexer()` on untagged code blocks raises `KeyError: 'Debian Sources file'` due to a broken lexer-cache entry, aborting the entire email send
- Language guessing provides no value for email output (no interactive highlighting)

## Test plan

- [ ] Send an email containing an untagged code block via `gptmail` — should not raise `KeyError`
- [ ] Pre-commit / typecheck pass