### PR TITLE
fix(failure-capture): prevent lesson names in stderr from triggering auth misclassification

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/failure_capture.py
+++ b/packages/gptme-sessions/src/gptme_sessions/failure_capture.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 # Coarse taxonomy for operator-pulse / bandit post-mortems.
 FAILURE_REASON_AUTH = "auth"
+FAILURE_REASON_INVALID_REQUEST = "invalid_request"
 FAILURE_REASON_NONZERO = "nonzero_exit_unclassified"
 FAILURE_REASON_PRE_RESPONSE = "pre_response_api_failure"
 FAILURE_REASON_RATE_LIMIT = "rate_limit"
@@ -139,9 +140,15 @@ def classify_failure_reason(
         lower = error_text.lower()
         if ("rate" in lower and "limit" in lower) or "429" in error_text:
             return FAILURE_REASON_RATE_LIMIT
+        # Check for invalid_request before auth: a 400 invalid_request_error (e.g.
+        # deepseek tool_calls without responses) must not be misclassified as auth.
+        if "invalid_request_error" in lower or "invalid_request" in lower:
+            return FAILURE_REASON_INVALID_REQUEST
+        # Auth check: use specific patterns only — bare "auth" matches lesson names
+        # like "Auth Blueprint" injected into the gptme startup log / stderr tail.
         if (
-            "auth" in lower
-            or "authentication" in lower
+            "authentication" in lower
+            or "unauthorized" in lower
             or "401" in error_text
             or "403" in error_text
         ):

--- a/packages/gptme-sessions/tests/test_failure_capture.py
+++ b/packages/gptme-sessions/tests/test_failure_capture.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 
 from gptme_sessions.failure_capture import (
+    FAILURE_REASON_AUTH,
+    FAILURE_REASON_INVALID_REQUEST,
     FAILURE_REASON_NONZERO,
     FAILURE_REASON_PRE_RESPONSE,
     FAILURE_REASON_RATE_LIMIT,
@@ -179,6 +181,97 @@ def test_record_has_any_content_tool_use():
         },
     }
     assert _record_has_any_content(rec) is True
+
+
+def test_classify_no_false_auth_from_lesson_name_in_stderr():
+    """Lesson name 'Auth Blueprint' in startup log must not trigger auth classification.
+
+    Root cause (ErikBjare/bob#1116): gptme startup logs all loaded lessons to stderr,
+    including '- Auth Blueprint'. The bare 'auth' check in classify_failure_reason
+    matched that lesson name and misclassified deepseek 400 errors as auth failures.
+    """
+    # Simulate the gptme startup log that appears in stderr, listing lesson names
+    startup_log_with_auth_lesson = (
+        "· WARNING  Parallel agent detected: gptme PID 12345\n"
+        "· Auto-included 20 lessons:\n"
+        "- Lesson-Effectiveness Lane Gets Over-Grazed\n"
+        "- Autonomous Session Workflow\n"
+        "- Auth Blueprint\n"  # <-- the false-positive trigger
+        "- Lesson Quality Standards\n"
+        "litellm.APIStatusError: Error code: 400 - "
+        "{'error': {'message': 'tool_calls without responses', 'type': 'invalid_request_error'}}"
+    )
+    result = classify_failure_reason(
+        exit_code=1,
+        duration_seconds=300,
+        input_tokens=1000,
+        has_assistant_turn=True,
+        error_text=startup_log_with_auth_lesson,
+    )
+    assert (
+        result != FAILURE_REASON_AUTH
+    ), "Lesson name 'Auth Blueprint' in stderr must not trigger auth classification"
+    assert result == FAILURE_REASON_INVALID_REQUEST
+
+
+def test_classify_invalid_request_error_deepseek_tool_format():
+    """deepseek 400 invalid_request_error for tool_calls must map to invalid_request."""
+    error = (
+        "litellm.APIStatusError: APIStatusError: Error code: 400 - "
+        "{'error': {'message': 'tool_calls without responses', 'type': 'invalid_request_error'}}"
+    )
+    assert (
+        classify_failure_reason(
+            exit_code=1,
+            duration_seconds=200,
+            input_tokens=500,
+            has_assistant_turn=True,
+            error_text=error,
+        )
+        == FAILURE_REASON_INVALID_REQUEST
+    )
+
+
+def test_classify_auth_still_works_for_real_401():
+    """Real 401 authentication failures must still classify as auth."""
+    assert (
+        classify_failure_reason(
+            exit_code=1,
+            duration_seconds=10,
+            input_tokens=0,
+            has_assistant_turn=False,
+            error_text="APIStatusError: Error code: 401 - {'error': 'Invalid API key'}",
+        )
+        == FAILURE_REASON_AUTH
+    )
+
+
+def test_classify_auth_still_works_for_authentication_keyword():
+    """'authentication' keyword in stderr must still classify as auth."""
+    assert (
+        classify_failure_reason(
+            exit_code=1,
+            duration_seconds=10,
+            input_tokens=0,
+            has_assistant_turn=False,
+            error_text="AuthenticationError: Invalid credentials for anthropic",
+        )
+        == FAILURE_REASON_AUTH
+    )
+
+
+def test_classify_auth_still_works_for_unauthorized():
+    """'unauthorized' in error text must classify as auth."""
+    assert (
+        classify_failure_reason(
+            exit_code=1,
+            duration_seconds=10,
+            input_tokens=0,
+            has_assistant_turn=False,
+            error_text="HTTP 403 Forbidden: unauthorized access",
+        )
+        == FAILURE_REASON_AUTH
+    )
 
 
 def test_capture_cc_session_with_assistant_not_pre_response(tmp_path: Path):


### PR DESCRIPTION
## Problem

The `classify_failure_reason` function in `failure_capture.py` used `"auth" in lower` to detect authentication failures. This was too broad: it matched lesson names like `"- Auth Blueprint"` that appear in the gptme startup log written to stderr.

The stderr tail (up to 16KB) includes the full list of auto-loaded lessons. Any lesson whose name contains "auth" caused legitimate failures to be misclassified as `failure_reason='auth'` instead of their true reason.

**Observed impact** (ErikBjare/bob#1116): 5 deepseek sessions with `400 invalid_request_error` (tool_calls without responses) were labeled `failure_reason='auth'`, contaminating the bandit posterior and potentially triggering spurious auth-failure escalation logic.

## Fix

- Remove bare `"auth" in lower` (too broad — matches lesson names, CLI flags, tool names, etc.)
- Add `FAILURE_REASON_INVALID_REQUEST = "invalid_request"` for OpenAI-style 400 errors
- Check `"invalid_request_error" in lower` before the auth check, so deepseek tool-format failures get the right classification
- Keep `"authentication" in lower` and HTTP 401/403 status checks for real auth failures
- Add `"unauthorized" in lower` for completeness

## Tests added

- **Regression test** for the exact false-positive: `"- Auth Blueprint\n"` in startup log must not return `failure_reason='auth'`
- Test that deepseek `400 invalid_request_error` → `failure_reason='invalid_request'`
- Tests confirming real auth signals (`401`, `"authentication"`, `"unauthorized"`) still classify as `auth`