### PR TITLE
fix(failure-capture): prevent lesson names from triggering auth misclassification

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/failure_capture.py
+++ b/packages/gptme-sessions/src/gptme_sessions/failure_capture.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 # Coarse taxonomy for operator-pulse / bandit post-mortems.
 FAILURE_REASON_AUTH = "auth"
+FAILURE_REASON_INVALID_REQUEST = "invalid_request"
 FAILURE_REASON_NONZERO = "nonzero_exit_unclassified"
 FAILURE_REASON_PRE_RESPONSE = "pre_response_api_failure"
 FAILURE_REASON_RATE_LIMIT = "rate_limit"
@@ -139,9 +140,14 @@ def classify_failure_reason(
         lower = error_text.lower()
         if ("rate" in lower and "limit" in lower) or "429" in error_text:
             return FAILURE_REASON_RATE_LIMIT
+        # Check invalid_request_error BEFORE auth: a 400 bad-request from a
+        # provider (e.g. deepseek rejecting tool_calls format) is NOT an auth
+        # failure even if the error blob contains lesson names like "Auth Blueprint".
+        if "invalid_request_error" in lower:
+            return FAILURE_REASON_INVALID_REQUEST
         if (
-            "auth" in lower
-            or "authentication" in lower
+            "authentication" in lower
+            or "unauthorized" in lower
             or "401" in error_text
             or "403" in error_text
         ):

--- a/packages/gptme-sessions/tests/test_failure_capture.py
+++ b/packages/gptme-sessions/tests/test_failure_capture.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 
 from gptme_sessions.failure_capture import (
+    FAILURE_REASON_AUTH,
+    FAILURE_REASON_INVALID_REQUEST,
     FAILURE_REASON_NONZERO,
     FAILURE_REASON_PRE_RESPONSE,
     FAILURE_REASON_RATE_LIMIT,
@@ -167,6 +169,74 @@ def test_capture_cc_tool_use_only_not_pre_response(tmp_path: Path):
         harness_stderr_path=None,
     )
     assert reason == FAILURE_REASON_NONZERO
+
+
+def test_classify_auth_not_triggered_by_lesson_name():
+    """'Auth Blueprint' in gptme startup lesson list must NOT classify as auth.
+
+    Regression: 'auth' in lower matched lesson names like 'Auth Blueprint'
+    injected into gptme stdout, causing valid deepseek 400 errors to be
+    misclassified as failure_reason='auth'. (ErikBjare/bob#1116)
+    """
+    # Realistic gptme stderr that includes lesson list but no real auth error
+    error_text = (
+        "· Auto-included 20 lessons:\n"
+        "- Autonomous Session Workflow\n"
+        "- Ship\n"
+        "- Auth Blueprint\n"  # ← was triggering the false positive
+        "- Lesson Quality Standards\n"
+        "· ERROR    provider_error_code: invalid_request_error"
+    )
+    result = classify_failure_reason(
+        exit_code=1,
+        duration_seconds=90,
+        input_tokens=75000,
+        has_assistant_turn=False,
+        error_text=error_text,
+    )
+    assert (
+        result != FAILURE_REASON_AUTH
+    ), "lesson name 'Auth Blueprint' must not trigger auth classification"
+
+
+def test_classify_invalid_request_deepseek_tool_calls():
+    """deepseek 400 invalid_request_error (tool_calls) → FAILURE_REASON_INVALID_REQUEST."""
+    error_text = (
+        "{'error': {'message': 'tool calls must be followed by tool responses', "
+        "'type': 'invalid_request_error', 'provider_error_code': 'invalid_request_error'}}"
+    )
+    result = classify_failure_reason(
+        exit_code=1,
+        duration_seconds=120,
+        input_tokens=70000,
+        has_assistant_turn=False,
+        error_text=error_text,
+    )
+    assert result == FAILURE_REASON_INVALID_REQUEST
+
+
+def test_classify_auth_real_401():
+    """Real 401 Unauthorized error text → FAILURE_REASON_AUTH."""
+    result = classify_failure_reason(
+        exit_code=1,
+        duration_seconds=30,
+        input_tokens=0,
+        has_assistant_turn=False,
+        error_text="HTTP error: 401 Unauthorized — authentication failed",
+    )
+    assert result == FAILURE_REASON_AUTH
+
+
+def test_classify_auth_unauthorized_text():
+    """'unauthorized' in error text → FAILURE_REASON_AUTH even without '401'."""
+    result = classify_failure_reason(
+        exit_code=1,
+        duration_seconds=30,
+        input_tokens=0,
+        has_assistant_turn=False,
+        error_text="Error: Unauthorized access, check your API key",
+    )
+    assert result == FAILURE_REASON_AUTH
 
 
 def test_record_has_any_content_tool_use():


### PR DESCRIPTION
## Summary

- Removes overly broad `"auth" in lower` check that matched lesson names like `"Auth Blueprint"` injected into gptme stdout during session startup
- Adds `FAILURE_REASON_INVALID_REQUEST` for proper classification of 400 `invalid_request_error` responses (e.g. deepseek tool-call format errors)  
- Checks `invalid_request_error` before `auth` to prevent false positives
- Adds `"unauthorized" in lower` as a more precise auth signal
- 4 regression tests covering the bug and fixed behavior

## Root cause

The `classify_failure_reason()` function checked `"auth" in lower` against the full error text. For gptme sessions with deepseek, the error text included the session startup banner listing auto-injected lessons — one of which is called "Auth Blueprint". This matched `"auth" in lower` and caused valid 400 `invalid_request_error` failures to be recorded as `failure_reason="auth"`.

Evidence: 5 deepseek sessions misclassified across 3 consecutive operator observations (ErikBjare/bob#1116).

## Impact

- Wrong failure attribution → auth escalation logic fires incorrectly for tool-format errors
- Bandit posterior contaminated: deepseek penalized for "auth failures" when real issue is tool call incompatibility

## Test plan

- [x] All 16 existing tests pass
- [x] `test_classify_auth_not_triggered_by_lesson_name` — reproduces the bug, confirms fix
- [x] `test_classify_invalid_request_deepseek_tool_calls` — new classification works
- [x] `test_classify_auth_real_401` — real auth errors still classified correctly
- [x] `test_classify_auth_unauthorized_text` — "unauthorized" text still caught