### PR TITLE
fix(test): prevent gptme stub from polluting sys.modules in multi-package runs

### DIFF
--- a/packages/gptme-lessons-extras/tests/test_generate.py
+++ b/packages/gptme-lessons-extras/tests/test_generate.py
@@ -5,29 +5,33 @@ import sys
 import types
 from pathlib import Path
 
-fake_gptme = types.ModuleType("gptme")
-fake_llm = types.ModuleType("gptme.llm")
-fake_message = types.ModuleType("gptme.message")
+# Only stub gptme when the real package is absent. Installing a bare
+# types.ModuleType (which has no __path__) unconditionally pollutes sys.modules
+# across multi-package test runs: the stub shadows the real package for all
+# later tests in the same process, causing "gptme is not a package" errors.
+try:
+    import gptme as _real_gptme  # noqa: F401 — side-effect: populates sys.modules
+except ImportError:
+    fake_gptme = types.ModuleType("gptme")
+    fake_llm = types.ModuleType("gptme.llm")
+    fake_message = types.ModuleType("gptme.message")
 
+    def _unused_reply(*args, **kwargs):
+        raise NotImplementedError
 
-def _unused_reply(*args, **kwargs):
-    raise NotImplementedError
+    class _FakeMessage:
+        def __init__(self, role: str, content: str):
+            self.role = role
+            self.content = content
 
+    fake_llm.reply = _unused_reply
+    fake_message.Message = _FakeMessage
+    fake_gptme.llm = fake_llm
+    fake_gptme.message = fake_message
 
-class _FakeMessage:
-    def __init__(self, role: str, content: str):
-        self.role = role
-        self.content = content
-
-
-fake_llm.reply = _unused_reply
-fake_message.Message = _FakeMessage
-fake_gptme.llm = fake_llm
-fake_gptme.message = fake_message
-
-sys.modules.setdefault("gptme", fake_gptme)
-sys.modules.setdefault("gptme.llm", fake_llm)
-sys.modules.setdefault("gptme.message", fake_message)
+    sys.modules.setdefault("gptme", fake_gptme)
+    sys.modules.setdefault("gptme.llm", fake_llm)
+    sys.modules.setdefault("gptme.message", fake_message)
 
 from gptme_lessons_extras import generate
 


### PR DESCRIPTION
## Problem

`packages/gptme-lessons-extras/tests/test_generate.py` installs a bare `types.ModuleType("gptme")` stub into `sys.modules` unconditionally at import time. A bare `ModuleType` has no `__path__`, so Python treats it as a plain module, not a package. Any subsequent `from gptme.tools.X import Y` in the same pytest process fails:

```
ModuleNotFoundError: No module named 'gptme.tools'; 'gptme' is not a package
```

This breaks `test_generator_with_real_shell_tool` in `packages/gptme-docs/tests/test_diataxis_generator.py` whenever both packages are collected in the same pytest run (e.g. `uv run pytest packages/`).

## Fix

Wrap the stub setup in `try: import gptme except ImportError:` so the fake module only installs when the real gptme package is genuinely absent. When gptme is installed, the real package populates `sys.modules` and all later `from gptme.*` imports work correctly.

## Test

Verified: `uv run pytest packages/gptme-lessons-extras/tests/ packages/gptme-docs/tests/test_diataxis_generator.py::test_generator_with_real_shell_tool` — 93 passed (was 92 passed + 1 failed before fix).