### PR TITLE
fix(twitter): skip thread reads for cached posts

### DIFF
--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -1799,18 +1799,29 @@ def process_timeline_tweets(
                     # read-free without degrading draft review context.
                     # Guard against transient API failures: a failed backfill
                     # must not terminate the processing cycle for remaining posts.
+                    # get_conversation_thread swallows its own errors and returns
+                    # [] on both "no tweets found" and internal failure, so an
+                    # empty result must NOT be persisted as a completed backfill
+                    # — that would permanently skip the retry (cached_thread_context
+                    # is no longer None) without ever attaching real context.
                     try:
-                        cached_thread_context = get_conversation_thread(
+                        backfilled_thread_context = get_conversation_thread(
                             client,
                             tweet.id,
                             fallback_conversation_id=tweet.conversation_id,
                         )
-                        save_to_cache(
-                            tweet_id_str,
-                            eval_result,
-                            response,
-                            cached_thread_context,
-                        )
+                        if backfilled_thread_context:
+                            cached_thread_context = backfilled_thread_context
+                            save_to_cache(
+                                tweet_id_str,
+                                eval_result,
+                                response,
+                                cached_thread_context,
+                            )
+                        else:
+                            console.print(
+                                f"[yellow]No thread context found for {tweet_id_str}; will retry next cycle"
+                            )
                     except Exception as e:
                         console.print(
                             f"[yellow]Could not backfill thread context for {tweet_id_str}: {e}"

--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -1714,28 +1714,34 @@ def process_timeline_tweets(
                 },
             }
 
-            # Try to get conversation thread context if this is a reply
-            if hasattr(tweet, "conversation_id") and tweet.conversation_id:
-                try:
-                    thread_tweets = get_conversation_thread(
-                        client, tweet.conversation_id
-                    )
-                    if thread_tweets:
-                        # Add thread context at both the root level (for eval/response) and in context (for storage)
-                        tweet_data["thread_context"] = thread_tweets
-                        tweet_data["context"]["thread_context"] = thread_tweets
-                        console.print(
-                            f"[blue]Added thread context with {len(thread_tweets)} tweets"
-                        )
-                except Exception as e:
-                    console.print(f"[yellow]Could not retrieve thread context: {e}")
+            # Check the durable evaluation cache before fetching conversation context.
+            # Re-seen entries do not need another metered thread search just to reuse
+            # a decision we already made.
+            cached_eval = None
+            cached_response = None
+            tweet_is_cached = is_tweet_cached(tweet_id_str)
+
+            if not tweet_is_cached:
+                # Pass the tweet itself so the helper resolves the canonical
+                # conversation and retains the root post in the context.
+                if hasattr(tweet, "conversation_id") and tweet.conversation_id:
+                    try:
+                        thread_tweets = get_conversation_thread(client, tweet.id)
+                        if thread_tweets:
+                            # Add thread context at both the root level (for eval/response) and in context (for storage)
+                            tweet_data["thread_context"] = thread_tweets
+                            tweet_data["context"]["thread_context"] = thread_tweets
+                            console.print(
+                                f"[blue]Added thread context with {len(thread_tweets)} tweets"
+                            )
+                    except Exception as e:
+                        console.print(f"[yellow]Could not retrieve thread context: {e}")
 
             # Process tweet
             console.print(f"\n[cyan]Processing tweet from @{author_username}:[/cyan]")
             console.print(f"[white]{tweet.text}[/white]")
 
-            # Check if tweet is already cached
-            if is_tweet_cached(tweet_id_str):
+            if tweet_is_cached:
                 console.print(f"[blue]Using cached results for tweet {tweet_id_str}")
                 cached_eval, cached_response = load_from_cache(tweet_id_str)
 

--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -165,14 +165,17 @@ def is_tweet_cached(tweet_id: str) -> bool:
     return cache_path.exists()
 
 
-def save_to_cache(tweet_id: str, eval_result, response=None) -> None:
-    """Save tweet processing results to cache"""
+def save_to_cache(
+    tweet_id: str, eval_result, response=None, thread_context: list[dict] | None = None
+) -> None:
+    """Save tweet processing results and the context used to produce them."""
     cache_path = get_cache_path(tweet_id)
     cache_data = {
         "tweet_id": tweet_id,
         "processed_at": datetime.now().isoformat(),
         "evaluation": asdict(eval_result) if eval_result else None,
         "response": asdict(response) if response else None,
+        "thread_context": thread_context,
     }
 
     with open(cache_path, "w") as f:
@@ -182,16 +185,23 @@ def save_to_cache(tweet_id: str, eval_result, response=None) -> None:
 
 
 def load_from_cache(tweet_id: str) -> Tuple[dict | None, dict | None]:
-    """Load tweet processing results from cache"""
+    """Load tweet processing results from cache."""
     cache_path = get_cache_path(tweet_id)
-
     if not cache_path.exists():
         return None, None
-
     with open(cache_path) as f:
         cache_data = json.load(f)
-
     return cache_data.get("evaluation"), cache_data.get("response")
+
+
+def load_cached_thread_context(tweet_id: str) -> list[dict] | None:
+    """Load the conversation context used to produce a cached response."""
+    cache_path = get_cache_path(tweet_id)
+    if not cache_path.exists():
+        return None
+    with open(cache_path) as f:
+        thread_context = json.load(f).get("thread_context")
+    return thread_context if isinstance(thread_context, list) else None
 
 
 def _list_draft_files(directory: Path) -> List[Path]:
@@ -427,7 +437,12 @@ def save_draft(draft: TweetDraft, status: str = "new") -> Path:
 
 
 def get_conversation_thread(
-    client, tweet_id_or_conversation_id, max_pages=3, max_tweets_per_page=100
+    client,
+    tweet_id_or_conversation_id,
+    max_pages=3,
+    max_tweets_per_page=100,
+    *,
+    fallback_conversation_id=None,
 ):
     """
     Retrieve the complete conversation thread for a given tweet ID or conversation ID.
@@ -483,11 +498,16 @@ def get_conversation_thread(
                             {user.id: user for user in tweet_response.includes["users"]}
                         )
                 else:
-                    # If we couldn't get the tweet, just use the ID as conversation ID
+                    conversation_id = (
+                        fallback_conversation_id or tweet_id_or_conversation_id
+                    )
                     all_tweets = {}
                     all_users = {}
             except Exception as e:
                 console.print(f"[yellow]Error fetching original tweet: {e}")
+                conversation_id = (
+                    fallback_conversation_id or tweet_id_or_conversation_id
+                )
                 all_tweets = {}
                 all_users = {}
         else:
@@ -1726,7 +1746,11 @@ def process_timeline_tweets(
                 # conversation and retains the root post in the context.
                 if hasattr(tweet, "conversation_id") and tweet.conversation_id:
                     try:
-                        thread_tweets = get_conversation_thread(client, tweet.id)
+                        thread_tweets = get_conversation_thread(
+                            client,
+                            tweet.id,
+                            fallback_conversation_id=tweet.conversation_id,
+                        )
                         if thread_tweets:
                             # Add thread context at both the root level (for eval/response) and in context (for storage)
                             tweet_data["thread_context"] = thread_tweets
@@ -1764,10 +1788,39 @@ def process_timeline_tweets(
                     if cached_response
                     else None
                 )
+                cached_thread_context = load_cached_thread_context(tweet_id_str)
+                if (
+                    response
+                    and cached_thread_context is None
+                    and getattr(tweet, "conversation_id", None)
+                ):
+                    # Older cache entries predate persisted thread context. Fetch
+                    # it once, then upgrade the entry so subsequent polls remain
+                    # read-free without degrading draft review context.
+                    cached_thread_context = get_conversation_thread(
+                        client,
+                        tweet.id,
+                        fallback_conversation_id=tweet.conversation_id,
+                    )
+                    save_to_cache(
+                        tweet_id_str,
+                        eval_result,
+                        response,
+                        cached_thread_context,
+                    )
+                if cached_thread_context:
+                    tweet_data["thread_context"] = cached_thread_context
+                    tweet_data["context"]["thread_context"] = cached_thread_context
             else:
-                # Process tweet and cache results
+                # Process tweet and cache results, including the exact context used
+                # to produce a response so later cache hits need no network read.
                 eval_result, response = process_tweet(tweet_data)
-                save_to_cache(tweet_id_str, eval_result, response)
+                save_to_cache(
+                    tweet_id_str,
+                    eval_result,
+                    response,
+                    tweet_data.get("thread_context"),
+                )
 
                 # Show evaluation result
                 console.print(f"[blue]Evaluation: {eval_result.action.upper()}")

--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -1797,17 +1797,24 @@ def process_timeline_tweets(
                     # Older cache entries predate persisted thread context. Fetch
                     # it once, then upgrade the entry so subsequent polls remain
                     # read-free without degrading draft review context.
-                    cached_thread_context = get_conversation_thread(
-                        client,
-                        tweet.id,
-                        fallback_conversation_id=tweet.conversation_id,
-                    )
-                    save_to_cache(
-                        tweet_id_str,
-                        eval_result,
-                        response,
-                        cached_thread_context,
-                    )
+                    # Guard against transient API failures: a failed backfill
+                    # must not terminate the processing cycle for remaining posts.
+                    try:
+                        cached_thread_context = get_conversation_thread(
+                            client,
+                            tweet.id,
+                            fallback_conversation_id=tweet.conversation_id,
+                        )
+                        save_to_cache(
+                            tweet_id_str,
+                            eval_result,
+                            response,
+                            cached_thread_context,
+                        )
+                    except Exception as e:
+                        console.print(
+                            f"[yellow]Could not backfill thread context for {tweet_id_str}: {e}"
+                        )
                 if cached_thread_context:
                     tweet_data["thread_context"] = cached_thread_context
                     tweet_data["context"]["thread_context"] = cached_thread_context

--- a/tests/test_twitter_workflow_drafts.py
+++ b/tests/test_twitter_workflow_drafts.py
@@ -1130,6 +1130,97 @@ def test_cached_response_without_context_fetches_once_and_upgrades_cache(
     assert cache_updates[0][3] == thread_context
 
 
+def test_legacy_context_backfill_failure_does_not_abort_cycle(
+    workflow_module: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    @dataclass
+    class EvalResult:
+        action: str
+        relevance: int
+        priority: int
+
+    @dataclass
+    class Response:
+        text: str
+        type: str
+        thread_needed: bool
+        follow_up: str | None
+
+    _set_status_dirs(workflow_module, tmp_path)
+    tweet = SimpleNamespace(
+        id="4242",
+        author_id="7",
+        text="A legacy cached tweet with enough text to pass filtering successfully.",
+        created_at=datetime.now(timezone.utc),
+        public_metrics={},
+        conversation_id="4000",
+    )
+    user = SimpleNamespace(
+        id="7", username="someone", public_metrics={"followers_count": 1}
+    )
+    cache_updates: list[tuple[Any, ...]] = []
+
+    monkeypatch.setattr(
+        workflow_module,
+        "cached_get_me",
+        lambda *a, **k: SimpleNamespace(data=SimpleNamespace(id="999")),
+    )
+    monkeypatch.setattr(
+        workflow_module, "should_evaluate_tweet", lambda *a, **k: (True, "")
+    )
+    monkeypatch.setattr(workflow_module, "is_reply_restricted", lambda *a, **k: False)
+    monkeypatch.setattr(workflow_module, "is_tweet_cached", lambda *a, **k: True)
+    monkeypatch.setattr(
+        workflow_module,
+        "load_from_cache",
+        lambda *a, **k: ({"action": "respond"}, {"text": "Cached reply"}),
+    )
+    monkeypatch.setattr(
+        workflow_module, "load_cached_thread_context", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        workflow_module.EvaluationResponse,
+        "from_dict",
+        lambda *a, **k: EvalResult("respond", 90, 80),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        workflow_module.TweetResponse,
+        "from_dict",
+        lambda *a, **k: Response("Cached reply", "reply", False, None),
+        raising=False,
+    )
+    monkeypatch.setattr(workflow_module, "is_trusted_user", lambda *a, **k: False)
+
+    def fail_conversation_read(*a: Any, **k: Any) -> list[Any]:
+        raise RuntimeError("transient Twitter API error")
+
+    monkeypatch.setattr(
+        workflow_module, "get_conversation_thread", fail_conversation_read
+    )
+    monkeypatch.setattr(
+        workflow_module,
+        "save_to_cache",
+        lambda *args, **kwargs: cache_updates.append((*args, kwargs)),
+    )
+
+    # A transient backfill failure must not abort processing — the draft
+    # should still be generated (without thread context).
+    drafts_generated = workflow_module.process_timeline_tweets(
+        [tweet],
+        [user],
+        source="mentions",
+        client=object(),
+        times=1,
+        dry_run=False,
+        max_drafts=10,
+    )
+
+    assert drafts_generated == 1
+    # save_to_cache must NOT be called when the backfill failed
+    assert len(cache_updates) == 0
+
+
 def test_process_new_tweet_fetches_thread_by_tweet_id(
     workflow_module: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_twitter_workflow_drafts.py
+++ b/tests/test_twitter_workflow_drafts.py
@@ -887,6 +887,124 @@ def test_trusted_user_autopost_keeps_transient_failure_retryable(
     assert list(workflow_module.REJECTED_DIR.glob("*.yml")) == []
 
 
+def test_process_cached_tweet_skips_conversation_read(
+    workflow_module: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_status_dirs(workflow_module, tmp_path)
+    tweet = SimpleNamespace(
+        id="4242",
+        author_id="7",
+        text="A previously evaluated tweet with enough text to pass filtering.",
+        created_at=datetime.now(timezone.utc),
+        public_metrics={},
+        conversation_id="4000",
+    )
+    user = SimpleNamespace(
+        id="7",
+        username="someone",
+        public_metrics={"followers_count": 1},
+    )
+
+    monkeypatch.setattr(
+        workflow_module,
+        "cached_get_me",
+        lambda *a, **k: SimpleNamespace(data=SimpleNamespace(id="999")),
+    )
+    monkeypatch.setattr(
+        workflow_module, "should_evaluate_tweet", lambda *a, **k: (True, "")
+    )
+    monkeypatch.setattr(workflow_module, "is_reply_restricted", lambda *a, **k: False)
+    monkeypatch.setattr(workflow_module, "is_tweet_cached", lambda *a, **k: True)
+    monkeypatch.setattr(
+        workflow_module,
+        "load_from_cache",
+        lambda *a, **k: ({"action": "ignore"}, None),
+    )
+    monkeypatch.setattr(
+        workflow_module.EvaluationResponse,
+        "from_dict",
+        lambda *a, **k: SimpleNamespace(action="ignore", relevance=1, priority=1),
+        raising=False,
+    )
+
+    def unexpected_conversation_read(*args: Any, **kwargs: Any) -> list[Any]:
+        raise AssertionError("cached tweets must not trigger conversation reads")
+
+    monkeypatch.setattr(
+        workflow_module, "get_conversation_thread", unexpected_conversation_read
+    )
+
+    drafts_generated = workflow_module.process_timeline_tweets(
+        [tweet],
+        [user],
+        source="mentions",
+        client=object(),
+        times=1,
+        dry_run=False,
+        max_drafts=10,
+    )
+
+    assert drafts_generated == 0
+
+
+def test_process_new_tweet_fetches_thread_by_tweet_id(
+    workflow_module: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_status_dirs(workflow_module, tmp_path)
+    tweet = SimpleNamespace(
+        id="4242",
+        author_id="7",
+        text="A new tweet with enough text to pass the cheap prefilter successfully.",
+        created_at=datetime.now(timezone.utc),
+        public_metrics={},
+        conversation_id="4000",
+    )
+    user = SimpleNamespace(
+        id="7",
+        username="someone",
+        public_metrics={"followers_count": 1},
+    )
+    conversation_reads: list[str] = []
+
+    monkeypatch.setattr(
+        workflow_module,
+        "cached_get_me",
+        lambda *a, **k: SimpleNamespace(data=SimpleNamespace(id="999")),
+    )
+    monkeypatch.setattr(
+        workflow_module, "should_evaluate_tweet", lambda *a, **k: (True, "")
+    )
+    monkeypatch.setattr(workflow_module, "is_reply_restricted", lambda *a, **k: False)
+    monkeypatch.setattr(workflow_module, "is_tweet_cached", lambda *a, **k: False)
+
+    def record_conversation_read(client: Any, tweet_id: str) -> list[Any]:
+        conversation_reads.append(str(tweet_id))
+        return []
+
+    monkeypatch.setattr(
+        workflow_module, "get_conversation_thread", record_conversation_read
+    )
+    monkeypatch.setattr(
+        workflow_module,
+        "process_tweet",
+        lambda data: (SimpleNamespace(action="ignore", relevance=1, priority=1), None),
+    )
+    monkeypatch.setattr(workflow_module, "save_to_cache", lambda *a, **k: None)
+
+    drafts_generated = workflow_module.process_timeline_tweets(
+        [tweet],
+        [user],
+        source="mentions",
+        client=object(),
+        times=1,
+        dry_run=False,
+        max_drafts=10,
+    )
+
+    assert drafts_generated == 0
+    assert conversation_reads == ["4242"]
+
+
 def test_find_live_duplicate_reply_ids_matches_own_replies(
     workflow_module: Any,
 ) -> None:

--- a/tests/test_twitter_workflow_drafts.py
+++ b/tests/test_twitter_workflow_drafts.py
@@ -1221,6 +1221,96 @@ def test_legacy_context_backfill_failure_does_not_abort_cycle(
     assert len(cache_updates) == 0
 
 
+def test_legacy_context_backfill_empty_result_is_not_persisted(
+    workflow_module: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    @dataclass
+    class EvalResult:
+        action: str
+        relevance: int
+        priority: int
+
+    @dataclass
+    class Response:
+        text: str
+        type: str
+        thread_needed: bool
+        follow_up: str | None
+
+    _set_status_dirs(workflow_module, tmp_path)
+    tweet = SimpleNamespace(
+        id="4242",
+        author_id="7",
+        text="A legacy cached tweet with enough text to pass filtering successfully.",
+        created_at=datetime.now(timezone.utc),
+        public_metrics={},
+        conversation_id="4000",
+    )
+    user = SimpleNamespace(
+        id="7", username="someone", public_metrics={"followers_count": 1}
+    )
+    cache_updates: list[tuple[Any, ...]] = []
+
+    monkeypatch.setattr(
+        workflow_module,
+        "cached_get_me",
+        lambda *a, **k: SimpleNamespace(data=SimpleNamespace(id="999")),
+    )
+    monkeypatch.setattr(
+        workflow_module, "should_evaluate_tweet", lambda *a, **k: (True, "")
+    )
+    monkeypatch.setattr(workflow_module, "is_reply_restricted", lambda *a, **k: False)
+    monkeypatch.setattr(workflow_module, "is_tweet_cached", lambda *a, **k: True)
+    monkeypatch.setattr(
+        workflow_module,
+        "load_from_cache",
+        lambda *a, **k: ({"action": "respond"}, {"text": "Cached reply"}),
+    )
+    monkeypatch.setattr(
+        workflow_module, "load_cached_thread_context", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        workflow_module.EvaluationResponse,
+        "from_dict",
+        lambda *a, **k: EvalResult("respond", 90, 80),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        workflow_module.TweetResponse,
+        "from_dict",
+        lambda *a, **k: Response("Cached reply", "reply", False, None),
+        raising=False,
+    )
+    monkeypatch.setattr(workflow_module, "is_trusted_user", lambda *a, **k: False)
+    # get_conversation_thread swallows both "nothing found" and internal
+    # errors into an empty list — simulate that here (no exception raised).
+    monkeypatch.setattr(workflow_module, "get_conversation_thread", lambda *a, **k: [])
+    monkeypatch.setattr(
+        workflow_module,
+        "save_to_cache",
+        lambda *args, **kwargs: cache_updates.append((*args, kwargs)),
+    )
+
+    # An empty backfill result must not be persisted as a completed migration —
+    # doing so would permanently skip the retry without ever attaching context.
+    drafts_generated = workflow_module.process_timeline_tweets(
+        [tweet],
+        [user],
+        source="mentions",
+        client=object(),
+        times=1,
+        dry_run=False,
+        max_drafts=10,
+    )
+
+    assert drafts_generated == 1
+    assert len(cache_updates) == 0
+    draft_paths = list(workflow_module.NEW_DIR.glob("*.yml"))
+    assert len(draft_paths) == 1
+    draft = workflow_module.TweetDraft.load(draft_paths[0])
+    assert "thread_context" not in draft.context["original_tweet"]
+
+
 def test_process_new_tweet_fetches_thread_by_tweet_id(
     workflow_module: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_twitter_workflow_drafts.py
+++ b/tests/test_twitter_workflow_drafts.py
@@ -947,6 +947,189 @@ def test_process_cached_tweet_skips_conversation_read(
     assert drafts_generated == 0
 
 
+def test_process_cached_response_restores_persisted_thread_without_read(
+    workflow_module: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    @dataclass
+    class EvalResult:
+        action: str
+        relevance: int
+        priority: int
+
+    @dataclass
+    class Response:
+        text: str
+        type: str
+        thread_needed: bool
+        follow_up: str | None
+
+    _set_status_dirs(workflow_module, tmp_path)
+    tweet = SimpleNamespace(
+        id="4242",
+        author_id="7",
+        text="A previously evaluated tweet with enough text to pass filtering.",
+        created_at=datetime.now(timezone.utc),
+        public_metrics={},
+        conversation_id="4000",
+    )
+    user = SimpleNamespace(
+        id="7",
+        username="someone",
+        public_metrics={"followers_count": 1},
+    )
+    thread_context = [
+        {
+            "id": "4000",
+            "author": "root-author",
+            "text": "Original thread post",
+        }
+    ]
+
+    monkeypatch.setattr(
+        workflow_module,
+        "cached_get_me",
+        lambda *a, **k: SimpleNamespace(data=SimpleNamespace(id="999")),
+    )
+    monkeypatch.setattr(
+        workflow_module, "should_evaluate_tweet", lambda *a, **k: (True, "")
+    )
+    monkeypatch.setattr(workflow_module, "is_reply_restricted", lambda *a, **k: False)
+    monkeypatch.setattr(workflow_module, "is_tweet_cached", lambda *a, **k: True)
+    monkeypatch.setattr(
+        workflow_module,
+        "load_from_cache",
+        lambda *a, **k: ({"action": "respond"}, {"text": "Cached reply"}),
+    )
+    monkeypatch.setattr(
+        workflow_module, "load_cached_thread_context", lambda *a, **k: thread_context
+    )
+    monkeypatch.setattr(
+        workflow_module.EvaluationResponse,
+        "from_dict",
+        lambda *a, **k: EvalResult("respond", 90, 80),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        workflow_module.TweetResponse,
+        "from_dict",
+        lambda *a, **k: Response("Cached reply", "reply", False, None),
+        raising=False,
+    )
+    monkeypatch.setattr(workflow_module, "is_trusted_user", lambda *a, **k: False)
+
+    def unexpected_conversation_read(*args: Any, **kwargs: Any) -> list[Any]:
+        raise AssertionError("persisted context must keep cache hits read-free")
+
+    monkeypatch.setattr(
+        workflow_module, "get_conversation_thread", unexpected_conversation_read
+    )
+
+    drafts_generated = workflow_module.process_timeline_tweets(
+        [tweet],
+        [user],
+        source="mentions",
+        client=object(),
+        times=1,
+        dry_run=False,
+        max_drafts=10,
+    )
+
+    assert drafts_generated == 1
+    draft_paths = list(workflow_module.NEW_DIR.glob("*.yml"))
+    assert len(draft_paths) == 1
+    draft = workflow_module.TweetDraft.load(draft_paths[0])
+    assert draft.context["original_tweet"]["thread_context"] == thread_context
+
+
+def test_cached_response_without_context_fetches_once_and_upgrades_cache(
+    workflow_module: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    @dataclass
+    class EvalResult:
+        action: str
+        relevance: int
+        priority: int
+
+    @dataclass
+    class Response:
+        text: str
+        type: str
+        thread_needed: bool
+        follow_up: str | None
+
+    _set_status_dirs(workflow_module, tmp_path)
+    tweet = SimpleNamespace(
+        id="4242",
+        author_id="7",
+        text="A legacy cached tweet with enough text to pass filtering successfully.",
+        created_at=datetime.now(timezone.utc),
+        public_metrics={},
+        conversation_id="4000",
+    )
+    user = SimpleNamespace(
+        id="7", username="someone", public_metrics={"followers_count": 1}
+    )
+    thread_context = [{"id": "4000", "author": "root", "text": "Root post"}]
+    cache_updates: list[tuple[Any, ...]] = []
+
+    monkeypatch.setattr(
+        workflow_module,
+        "cached_get_me",
+        lambda *a, **k: SimpleNamespace(data=SimpleNamespace(id="999")),
+    )
+    monkeypatch.setattr(
+        workflow_module, "should_evaluate_tweet", lambda *a, **k: (True, "")
+    )
+    monkeypatch.setattr(workflow_module, "is_reply_restricted", lambda *a, **k: False)
+    monkeypatch.setattr(workflow_module, "is_tweet_cached", lambda *a, **k: True)
+    monkeypatch.setattr(
+        workflow_module,
+        "load_from_cache",
+        lambda *a, **k: ({"action": "respond"}, {"text": "Cached reply"}),
+    )
+    monkeypatch.setattr(
+        workflow_module, "load_cached_thread_context", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        workflow_module.EvaluationResponse,
+        "from_dict",
+        lambda *a, **k: EvalResult("respond", 90, 80),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        workflow_module.TweetResponse,
+        "from_dict",
+        lambda *a, **k: Response("Cached reply", "reply", False, None),
+        raising=False,
+    )
+    monkeypatch.setattr(workflow_module, "is_trusted_user", lambda *a, **k: False)
+    monkeypatch.setattr(
+        workflow_module,
+        "get_conversation_thread",
+        lambda client, tweet_id, *, fallback_conversation_id: thread_context,
+    )
+    monkeypatch.setattr(
+        workflow_module,
+        "save_to_cache",
+        lambda *args, **kwargs: cache_updates.append((*args, kwargs)),
+    )
+
+    drafts_generated = workflow_module.process_timeline_tweets(
+        [tweet],
+        [user],
+        source="mentions",
+        client=object(),
+        times=1,
+        dry_run=False,
+        max_drafts=10,
+    )
+
+    assert drafts_generated == 1
+    assert len(cache_updates) == 1
+    assert cache_updates[0][0] == "4242"
+    assert cache_updates[0][3] == thread_context
+
+
 def test_process_new_tweet_fetches_thread_by_tweet_id(
     workflow_module: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -977,8 +1160,10 @@ def test_process_new_tweet_fetches_thread_by_tweet_id(
     monkeypatch.setattr(workflow_module, "is_reply_restricted", lambda *a, **k: False)
     monkeypatch.setattr(workflow_module, "is_tweet_cached", lambda *a, **k: False)
 
-    def record_conversation_read(client: Any, tweet_id: str) -> list[Any]:
-        conversation_reads.append(str(tweet_id))
+    def record_conversation_read(
+        client: Any, tweet_id: str, *, fallback_conversation_id: str
+    ) -> list[Any]:
+        conversation_reads.append(f"{tweet_id}:{fallback_conversation_id}")
         return []
 
     monkeypatch.setattr(
@@ -1002,7 +1187,28 @@ def test_process_new_tweet_fetches_thread_by_tweet_id(
     )
 
     assert drafts_generated == 0
-    assert conversation_reads == ["4242"]
+    assert conversation_reads == ["4242:4000"]
+
+
+def test_conversation_lookup_failure_falls_back_to_canonical_conversation_id(
+    workflow_module: Any,
+) -> None:
+    search_queries: list[str] = []
+
+    class Client:
+        def get_tweet(self, *args: Any, **kwargs: Any) -> Any:
+            raise RuntimeError("transient lookup failure")
+
+        def search_recent_tweets(self, **kwargs: Any) -> Any:
+            search_queries.append(kwargs["query"])
+            return SimpleNamespace(data=None)
+
+    thread = workflow_module.get_conversation_thread(
+        Client(), "4242", fallback_conversation_id="4000"
+    )
+
+    assert thread == []
+    assert search_queries == ["conversation_id:4000"]
 
 
 def test_find_live_duplicate_reply_ids_matches_own_replies(


### PR DESCRIPTION
## Summary

- consult the durable tweet-evaluation cache before fetching conversation context
- avoid repeated metered thread searches when the 30-minute loop re-sees the same mentions/timeline posts
- resolve new thread context from the tweet ID rather than treating a raw conversation ID as a tweet ID

## Why

Bob's Twitter loop polls mentions every 30 minutes. `process_timeline_tweets()` previously fetched a full conversation (one `get_tweet` plus up to three 100-result recent-search pages) **before** checking whether the tweet already had a durable cache entry. A repeatedly returned mention could therefore re-read a large thread every cycle even though its evaluation was cached.

This matches the observed X billing shape: only ~60 top-level poll responses/day are expected, but the portal reported roughly 1k–9k `Read` objects/day. X meters reads by returned posts, so repeated conversation searches amplify one poll into hundreds of billed reads.

## Verification

- `uv run pytest tests/test_twitter_workflow_drafts.py -q` (39 passed)
- scoped pre-commit hooks, including ruff, ruff-format, mypy, package typecheck, and duplicate-code check
