### PR TITLE
fix(gptmail): support consolidated reply threads

### DIFF
--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -418,7 +418,9 @@ def _pending_messages(
             continue
         if f.name in replied_to:
             continue
-        if m.get("in_reply_to") in my_outbox_ids:
+        in_reply_to = m.get("in_reply_to")
+        thread_ids = in_reply_to if isinstance(in_reply_to, list) else [in_reply_to]
+        if any(str(thread_id) in my_outbox_ids for thread_id in thread_ids):
             continue
         if window > 0:
             age = _age_days(m, now)

--- a/packages/gptmail/tests/test_agent_cli.py
+++ b/packages/gptmail/tests/test_agent_cli.py
@@ -508,6 +508,31 @@ def test_pending_excludes_replies_to_my_messages(workspace: Path) -> None:
     assert "No messages awaiting reply" in result.output, result.output
 
 
+def test_pending_excludes_consolidated_reply_to_my_messages(workspace: Path) -> None:
+    """A peer may close several threads in one reply with a list of parent IDs."""
+    for subject in ("Question one", "Question two"):
+        result = CliRunner().invoke(agent, ["send", "bob", subject, "thoughts?"])
+        assert result.exit_code == 0, result.output
+    my_msg_ids = sorted(path.name for path in (workspace / "messages" / "outbox").glob("*.md"))
+
+    inbox = workspace / "messages" / "inbox"
+    now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    (inbox / "consolidated-reply.md").write_text(
+        "---\n"
+        "from: bob\n"
+        "to: alice\n"
+        f"timestamp: {now_iso}\n"
+        "subject: Re: both questions\n"
+        "read: false\n"
+        f"in_reply_to: {json.dumps(my_msg_ids)}\n"
+        "---\n\nBoth answers.\n"
+    )
+
+    result = CliRunner().invoke(agent, ["pending"])
+    assert result.exit_code == 0, result.output
+    assert "No messages awaiting reply" in result.output
+
+
 def test_pending_reply_once_for_pull_based_recipient(workspace: Path) -> None:
     """An undelivered reply to a pull-based recipient satisfies reply-once.
 


### PR DESCRIPTION
## Summary

- accept scalar or list-valued `in_reply_to` metadata in the agent-message pending scan
- treat a consolidated peer reply as satisfying any matching local parent thread
- add a regression test for one reply closing multiple outbound threads

## Why

A real Gordon message uses YAML list-valued `in_reply_to` to close three threads. `gptmail agent pending` attempted to hash that list, raised `TypeError: unhashable type: 'list'`, and the timer wrapper then misreported the crash as "No pending agent messages". This restores the inbox dispatcher Erik identified as the intended communication path.

## Verification

- `uv run --directory packages/gptmail pytest tests/test_agent_cli.py -q` (49 passed)
- pre-commit hooks
- `pr-quality-gate.py --repo gptme/gptme-contrib` (100/100)
