### PR TITLE
feat(gptmail): support no-reply agent broadcasts

### DIFF
--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -68,7 +68,7 @@ def _no_reply_subject_patterns() -> list[re.Pattern[str]]:
     """Configured receiver-side subject patterns excluded from reply SLA."""
     raw = os.environ.get("AGENT_MSG_NO_REPLY_SUBJECT_PATTERNS", "")
     patterns: list[re.Pattern[str]] = []
-    for item in raw.split(","):
+    for item in raw.splitlines():
         if not item.strip():
             continue
         try:

--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -64,6 +64,30 @@ def _reply_window_days() -> int:
         return 7
 
 
+def _no_reply_subject_patterns() -> list[re.Pattern[str]]:
+    """Configured receiver-side subject patterns excluded from reply SLA."""
+    raw = os.environ.get("AGENT_MSG_NO_REPLY_SUBJECT_PATTERNS", "")
+    patterns: list[re.Pattern[str]] = []
+    for item in raw.split(","):
+        if not item.strip():
+            continue
+        try:
+            patterns.append(re.compile(item.strip(), re.IGNORECASE))
+        except re.error as exc:
+            raise click.ClickException(
+                f"Invalid AGENT_MSG_NO_REPLY_SUBJECT_PATTERNS regex {item.strip()!r}: {exc}"
+            ) from exc
+    return patterns
+
+
+def _reply_expected(meta: dict, patterns: list[re.Pattern[str]]) -> bool:
+    """Whether a message belongs in the receiver's reply-obligation queue."""
+    if meta.get("reply_expected") is False:
+        return False
+    subject = str(meta.get("subject", ""))
+    return not any(pattern.search(subject) for pattern in patterns)
+
+
 @functools.lru_cache(maxsize=1)
 def _repo_root() -> Path:
     """Workspace root via ``git rev-parse --show-toplevel`` (symlink-correct).
@@ -374,10 +398,13 @@ def _pending_messages(
     self_name: str,
     window: int,
     agents: dict[str, dict[str, str]] | None = None,
+    no_reply_subject_patterns: list[re.Pattern[str]] | None = None,
 ) -> list[dict]:
     """Inbox messages addressed to us that we haven't replied to (timely SLA).
 
-    A reply requirement is satisfied by an inbox ``replied: true`` stamp or by an
+    Messages with ``reply_expected: false`` or a subject matching
+    ``AGENT_MSG_NO_REPLY_SUBJECT_PATTERNS`` are informational and omitted. A reply
+    requirement is otherwise satisfied by an inbox ``replied: true`` stamp or by an
     outbox message whose ``in_reply_to`` points at it. Reply-once: a draft reply
     counts even when stamped ``delivered: false`` **if the recipient is
     pull-based** (no push transport), where that stamp is the permanent steady
@@ -390,6 +417,8 @@ def _pending_messages(
     now = datetime.now(timezone.utc)
     if agents is None:
         agents = _load_agents(warn_missing=False)
+    if no_reply_subject_patterns is None:
+        no_reply_subject_patterns = _no_reply_subject_patterns()
 
     replied_to: set[str] = set()
     my_outbox_ids: set[str] = set()
@@ -413,6 +442,8 @@ def _pending_messages(
         if m.get("from") in (None, self_name):
             continue
         if not _addressed_to(m, self_name):
+            continue
+        if not _reply_expected(m, no_reply_subject_patterns):
             continue
         if m.get("replied"):
             continue
@@ -684,7 +715,12 @@ def agent() -> None:
 @click.argument("subject")
 @click.argument("content", required=False)
 @click.option("--mailbox", default="default", show_default=True, help="Mailbox to send from.")
-def send(to: str, subject: str, content: str | None, mailbox: str) -> None:
+@click.option(
+    "--no-reply",
+    is_flag=True,
+    help="Mark the message as informational; the recipient owes no reply.",
+)
+def send(to: str, subject: str, content: str | None, mailbox: str, no_reply: bool) -> None:
     """Send a message to another agent."""
     body = content if content is not None else sys.stdin.read()
     agents = _load_agents()
@@ -696,7 +732,7 @@ def send(to: str, subject: str, content: str | None, mailbox: str) -> None:
         sys.exit(1)
     mailbox = _normalize_mailbox(mailbox)
     transport = _transport(deliver=_ssh_deliver(agents, mailbox=mailbox), mailbox=mailbox)
-    message_id = transport.send(to, subject, body)
+    message_id = transport.send(to, subject, body, reply_expected=not no_reply)
     _track_sent(transport, message_id, reply_to=None)
     if _delivery_failed(message_id, mailbox=mailbox):
         click.echo(
@@ -712,7 +748,12 @@ def send(to: str, subject: str, content: str | None, mailbox: str) -> None:
 @click.argument("subject")
 @click.argument("content", required=False)
 @click.option("--mailbox", default="default", show_default=True, help="Mailbox to send from.")
-def broadcast(subject: str, content: str | None, mailbox: str) -> None:
+@click.option(
+    "--no-reply",
+    is_flag=True,
+    help="Mark the broadcast as informational; recipients owe no reply.",
+)
+def broadcast(subject: str, content: str | None, mailbox: str, no_reply: bool) -> None:
     """Send a message to every agent in the registry except self."""
     body = content if content is not None else sys.stdin.read()
     agents = _load_agents()
@@ -724,7 +765,7 @@ def broadcast(subject: str, content: str | None, mailbox: str) -> None:
         return
     failures = []
     for name in recipients:
-        message_id = transport.send(name, subject, body)
+        message_id = transport.send(name, subject, body, reply_expected=not no_reply)
         _track_sent(transport, message_id, reply_to=None)
         if _delivery_failed(message_id, mailbox=mailbox):
             click.echo(f"Delivery to {name} FAILED (delivered: false).", err=True)

--- a/packages/gptmail/src/gptmail/transport/agent.py
+++ b/packages/gptmail/src/gptmail/transport/agent.py
@@ -145,6 +145,7 @@ class AgentTransport:
         body: str,
         mailbox: str = "default",
         in_reply_to: str | None = None,
+        reply_expected: bool = True,
     ) -> str:
         ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         meta: dict[str, object] = {
@@ -157,6 +158,8 @@ class AgentTransport:
         }
         if in_reply_to:
             meta["in_reply_to"] = in_reply_to
+        if not reply_expected:
+            meta["reply_expected"] = False
         frontmatter = yaml.dump(
             meta, default_flow_style=False, allow_unicode=True, sort_keys=False
         ).rstrip()
@@ -191,13 +194,15 @@ class AgentTransport:
         *,
         reply_to: str | None = None,
         references: list[str] | None = None,
+        reply_expected: bool = True,
     ) -> str:
         """Write a message to the outbox and (optionally) deliver it.
 
         ``references`` is accepted for Protocol parity; agent messages carry a
         single ``in_reply_to`` link rather than a full ancestor chain, so only
-        the immediate parent (``reply_to``) is recorded. Returns the message ID
-        (outbox filename).
+        the immediate parent (``reply_to``) is recorded. ``reply_expected=False``
+        marks an informational message that receivers omit from their reply queue.
+        Returns the message ID (outbox filename).
         """
         filename = self._make_filename(self._self, subject)
         local_path = self.outbox / filename
@@ -209,6 +214,7 @@ class AgentTransport:
                 content,
                 mailbox=self.mailbox,
                 in_reply_to=reply_to,
+                reply_expected=reply_expected,
             )
         )
         if self._deliver is not None and not self._deliver(local_path, to.lower()):

--- a/packages/gptmail/tests/test_agent_cli.py
+++ b/packages/gptmail/tests/test_agent_cli.py
@@ -267,18 +267,23 @@ def _seed_inbox(
     subject: str = "Q",
     *,
     mailbox: str = "default",
+    reply_expected: bool | None = None,
 ) -> str:
     """Drop a message from ``sender`` into alice's inbox; return its filename."""
     inbox = workspace / "messages" / "inbox"
     if mailbox != "default":
         inbox = workspace / "messages" / "mailboxes" / mailbox / "inbox"
         inbox.mkdir(parents=True, exist_ok=True)
-    ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
-    name = f"{ts}-000000-{sender}-{subject}.md"
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S-%f")
+    name = f"{ts}-{sender}-{subject}.md"
     timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    reply_expected_line = (
+        f"reply_expected: {str(reply_expected).lower()}\n" if reply_expected is not None else ""
+    )
     (inbox / name).write_text(
         f"---\nfrom: {sender}\nto: alice\n"
-        f"timestamp: {timestamp}\nsubject: {subject}\nread: false\nmailbox: {mailbox}\n---\n\nplease advise\n"
+        f"timestamp: {timestamp}\nsubject: {subject}\nread: false\nmailbox: {mailbox}\n"
+        f"{reply_expected_line}---\n\nplease advise\n"
     )
     return name
 
@@ -393,6 +398,52 @@ def test_reply_marks_read_no_existing_key(workspace: Path) -> None:
     fm = _frontmatter(workspace / "messages" / "inbox" / name)
     assert fm["read"] is True
     assert fm["replied"] is True
+
+
+def test_pending_excludes_sender_declared_no_reply_but_list_keeps_it(workspace: Path) -> None:
+    name = _seed_inbox(workspace, reply_expected=False)
+
+    pending = CliRunner().invoke(agent, ["pending"])
+    assert pending.exit_code == 0, pending.output
+    assert "No messages awaiting reply" in pending.output
+    assert name not in pending.output
+
+    listed = CliRunner().invoke(agent, ["list"])
+    assert listed.exit_code == 0, listed.output
+    assert name in listed.output
+    read = CliRunner().invoke(agent, ["read", name])
+    assert read.exit_code == 0, read.output
+    assert "please advise" in read.output
+
+
+def test_pending_excludes_configured_no_reply_subject(
+    workspace: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    earnings = _seed_inbox(workspace, subject="EARNINGS - ACME beat")
+    escalation = _seed_inbox(workspace, subject="RISK ALERT - action needed")
+    monkeypatch.setenv("AGENT_MSG_NO_REPLY_SUBJECT_PATTERNS", r"^EARNINGS")
+
+    result = CliRunner().invoke(agent, ["pending"])
+    assert result.exit_code == 0, result.output
+    assert earnings not in result.output
+    assert escalation in result.output
+    assert "1 message(s) awaiting reply" in result.output
+
+
+@pytest.mark.parametrize("command", ["pending", "status"])
+def test_no_reply_subject_filter_rejects_invalid_regex(workspace: Path, command: str) -> None:
+    _seed_inbox(workspace)
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setenv("AGENT_MSG_NO_REPLY_SUBJECT_PATTERNS", "[invalid")
+        result = CliRunner().invoke(agent, [command])
+    assert result.exit_code != 0
+    assert "Invalid AGENT_MSG_NO_REPLY_SUBJECT_PATTERNS regex" in result.output
+
+
+def test_send_no_reply_stamps_frontmatter(workspace: Path) -> None:
+    result = CliRunner().invoke(agent, ["send", "--no-reply", "bob", "FYI", "informational"])
+    assert result.exit_code == 0, result.output
+    assert _frontmatter(_only_outbox_msg(workspace))["reply_expected"] is False
 
 
 def test_pending_lists_unanswered_then_clears_on_reply(workspace: Path) -> None:

--- a/packages/gptmail/tests/test_agent_cli.py
+++ b/packages/gptmail/tests/test_agent_cli.py
@@ -430,6 +430,25 @@ def test_pending_excludes_configured_no_reply_subject(
     assert "1 message(s) awaiting reply" in result.output
 
 
+def test_no_reply_subject_patterns_support_regex_commas_and_multiple_lines(
+    workspace: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    earnings = _seed_inbox(workspace, subject="EARNINGS - ACME beat")
+    digest = _seed_inbox(workspace, subject="Daily, digest")
+    escalation = _seed_inbox(workspace, subject="RISK ALERT - action needed")
+    monkeypatch.setenv(
+        "AGENT_MSG_NO_REPLY_SUBJECT_PATTERNS",
+        "^EARNINGS\n^Daily.{2,4}digest$",
+    )
+
+    result = CliRunner().invoke(agent, ["pending"])
+    assert result.exit_code == 0, result.output
+    assert earnings not in result.output
+    assert digest not in result.output
+    assert escalation in result.output
+    assert "1 message(s) awaiting reply" in result.output
+
+
 @pytest.mark.parametrize("command", ["pending", "status"])
 def test_no_reply_subject_filter_rejects_invalid_regex(workspace: Path, command: str) -> None:
     _seed_inbox(workspace)


### PR DESCRIPTION
## Summary

- add `--no-reply` to `gptmail agent send` and `broadcast`, stamping `reply_expected: false`
- omit sender-declared informational messages from `agent pending` while keeping them listable/readable
- add receiver-side `AGENT_MSG_NO_REPLY_SUBJECT_PATTERNS` regex filtering for known broadcast classes

## Motivation

A real Bob inbox incident had 28 informational earnings broadcasts mixed with 4 substantive messages, including deadline-bearing escalations. This separates retention from reply obligation: messages stay in the inbox but do not dilute the timely-reply SLA queue.

## Verification

- `uv run pytest packages/gptmail/tests/test_agent_cli.py packages/gptmail/tests/test_agent_transport.py -q` — 75 passed
- `uv run ruff check packages/gptmail/src/gptmail/agent_cli.py packages/gptmail/src/gptmail/transport/agent.py packages/gptmail/tests/test_agent_cli.py`
- pre-commit: all checks passed
