### PR TITLE
feat(runloops): pr_review Phase 0 — versioned schema, golden corpus, evaluation tooling

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/pr_review/__init__.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pr_review/__init__.py
@@ -1,0 +1,26 @@
+"""PR review core — schema, corpus, and evaluation tooling.
+
+Phase 0: versioned finding schema + golden corpus for model evaluation.
+Phase 1 (next): CLI runner that produces ReviewArtifact JSON without publishing.
+Phase 2 (later): GitHub publisher with idempotency guards + PM integration.
+"""
+
+from .schema import (
+    Disposition,
+    FindingFingerprint,
+    MergeSafety,
+    ReviewArtifact,
+    ReviewFinding,
+    ReviewTarget,
+    Severity,
+)
+
+__all__ = [
+    "Disposition",
+    "FindingFingerprint",
+    "MergeSafety",
+    "ReviewArtifact",
+    "ReviewFinding",
+    "ReviewTarget",
+    "Severity",
+]

--- a/packages/gptme-runloops/src/gptme_runloops/pr_review/corpus.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pr_review/corpus.py
@@ -1,0 +1,188 @@
+"""Golden corpus for PR reviewer evaluation.
+
+Corpus format: a list of CorpusEntry objects, each representing a historical PR
+with hand-labeled ground-truth findings. Used in Phase 0 to evaluate candidate
+models before selecting a default.
+
+Scoring metrics (from the MVP spec):
+  - precision: fraction of model findings that are true positives
+  - recall: fraction of known true bugs that the model found
+  - fp_rate: false-positive findings per review
+  - location_accuracy: finding points to the correct file (soft: same file)
+  - duplicate_rate: how often the same finding appears twice
+  - latency: time to first finding (seconds)
+  - cost: estimated token cost in USD
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+
+@dataclass
+class GroundTruthFinding:
+    """A human-labeled finding used as the evaluation standard."""
+
+    label: Literal["true_positive", "false_positive", "true_negative"]
+    category: str
+    severity: str
+    file_path: str
+    title: str
+    description: str
+    # How the finding was verified
+    verification: str = ""
+
+
+@dataclass
+class CorpusEntry:
+    """One PR with hand-labeled ground truth for evaluation."""
+
+    entry_id: str
+    repo: str
+    pr_number: int
+    pr_title: str
+    pr_description: str
+    # Unified diff (or a summary for large PRs)
+    diff_summary: str
+    # Reviewer's ground truth
+    ground_truth: list[GroundTruthFinding] = field(default_factory=list)
+    # Source of truth (greptile, human-review, post-merge incident)
+    attribution: str = ""
+    notes: str = ""
+
+    @property
+    def true_positives(self) -> list[GroundTruthFinding]:
+        return [f for f in self.ground_truth if f.label == "true_positive"]
+
+    @property
+    def false_positives(self) -> list[GroundTruthFinding]:
+        return [f for f in self.ground_truth if f.label == "false_positive"]
+
+
+@dataclass
+class EvalResult:
+    """Evaluation result for one model run against one corpus entry."""
+
+    entry_id: str
+    model: str
+    # Matched findings: (ground_truth_idx, model_finding_title, match_score 0-1)
+    matched_tp: list[tuple[int, str, float]] = field(default_factory=list)
+    false_positives_produced: int = 0
+    duplicate_findings: int = 0
+    latency_s: float = 0.0
+    cost_usd: float = 0.0
+
+    @property
+    def precision(self) -> float:
+        total = len(self.matched_tp) + self.false_positives_produced
+        return len(self.matched_tp) / total if total > 0 else 1.0
+
+    @property
+    def recall(self) -> float:
+        # Caller must supply total known TPs for this entry
+        return 0.0  # overridden in score_model()
+
+
+@dataclass
+class ModelScores:
+    """Aggregate evaluation scores across the full corpus."""
+
+    model: str
+    precision: float
+    recall: float
+    fp_rate: float
+    location_accuracy: float
+    duplicate_rate: float
+    avg_latency_s: float
+    avg_cost_usd: float
+    n_entries: int
+
+    def summary(self) -> str:
+        return (
+            f"{self.model}: precision={self.precision:.2f} recall={self.recall:.2f} "
+            f"fp_rate={self.fp_rate:.2f} loc_acc={self.location_accuracy:.2f} "
+            f"dup_rate={self.duplicate_rate:.2f} "
+            f"latency={self.avg_latency_s:.1f}s cost=${self.avg_cost_usd:.4f}/review "
+            f"(n={self.n_entries})"
+        )
+
+    def passes_gate(
+        self,
+        min_precision: float = 0.80,
+        max_fp_rate: float = 2.0,
+    ) -> bool:
+        """Whether this model meets the Phase 0 gate for pilot use."""
+        return self.precision >= min_precision and self.fp_rate <= max_fp_rate
+
+
+def load_corpus(path: Path | None = None) -> list[CorpusEntry]:
+    """Load the golden corpus from the default fixtures file or a custom path."""
+    if path is None:
+        path = (
+            Path(__file__).parent.parent.parent.parent
+            / "tests"
+            / "fixtures"
+            / "pr_review_corpus.json"
+        )
+    with open(path) as f:
+        raw = json.load(f)
+    entries = []
+    for item in raw["entries"]:
+        findings = [GroundTruthFinding(**g) for g in item.pop("ground_truth", [])]
+        entries.append(CorpusEntry(**item, ground_truth=findings))
+    return entries
+
+
+def score_model(
+    model_results: list[EvalResult],
+    corpus: list[CorpusEntry],
+) -> ModelScores:
+    """Aggregate per-entry EvalResults into a ModelScores summary.
+
+    Call this after running the model against every corpus entry.
+    """
+    total_tp = sum(len(e.true_positives) for e in corpus)
+    matched_tp_total = 0
+    fp_total = 0
+    dup_total = 0
+    location_hits = 0
+    location_checked = 0
+
+    for result in model_results:
+        matched_tp_total += len(result.matched_tp)
+        fp_total += result.false_positives_produced
+        dup_total += result.duplicate_findings
+
+        for _gt_idx, _title, match_score in result.matched_tp:
+            # location_accuracy: does the finding reference the correct file?
+            location_checked += 1
+            if match_score >= 0.5:
+                location_hits += 1
+
+    n = len(model_results)
+    precision = (
+        matched_tp_total / (matched_tp_total + fp_total)
+        if (matched_tp_total + fp_total) > 0
+        else 1.0
+    )
+    recall = matched_tp_total / total_tp if total_tp > 0 else 1.0
+    fp_rate = fp_total / n if n > 0 else 0.0
+    dup_rate = dup_total / n if n > 0 else 0.0
+    loc_acc = location_hits / location_checked if location_checked > 0 else 1.0
+    avg_latency = sum(r.latency_s for r in model_results) / n if n > 0 else 0.0
+    avg_cost = sum(r.cost_usd for r in model_results) / n if n > 0 else 0.0
+
+    return ModelScores(
+        model=model_results[0].model if model_results else "unknown",
+        precision=precision,
+        recall=recall,
+        fp_rate=fp_rate,
+        location_accuracy=loc_acc,
+        duplicate_rate=dup_rate,
+        avg_latency_s=avg_latency,
+        avg_cost_usd=avg_cost,
+        n_entries=n,
+    )

--- a/packages/gptme-runloops/src/gptme_runloops/pr_review/corpus.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pr_review/corpus.py
@@ -68,8 +68,9 @@ class EvalResult:
 
     entry_id: str
     model: str
-    # Matched findings: (ground_truth_idx, model_finding_title, match_score 0-1)
-    matched_tp: list[tuple[int, str, float]] = field(default_factory=list)
+    # Matched findings:
+    # (ground_truth_idx, model_finding_title, match_score 0-1, predicted_file_path)
+    matched_tp: list[tuple[int, str, float, str]] = field(default_factory=list)
     false_positives_produced: int = 0
     duplicate_findings: int = 0
     latency_s: float = 0.0
@@ -145,6 +146,7 @@ def score_model(
     Call this after running the model against every corpus entry.
     """
     total_tp = sum(len(e.true_positives) for e in corpus)
+    corpus_by_id = {entry.entry_id: entry for entry in corpus}
     matched_tp_total = 0
     fp_total = 0
     dup_total = 0
@@ -152,14 +154,23 @@ def score_model(
     location_checked = 0
 
     for result in model_results:
+        entry = corpus_by_id.get(result.entry_id)
+        if entry is None:
+            raise ValueError(f"No corpus entry for EvalResult {result.entry_id!r}")
+
         matched_tp_total += len(result.matched_tp)
         fp_total += result.false_positives_produced
         dup_total += result.duplicate_findings
 
-        for _gt_idx, _title, match_score in result.matched_tp:
-            # location_accuracy: does the finding reference the correct file?
+        for gt_idx, _title, _match_score, predicted_file_path in result.matched_tp:
+            try:
+                expected_file_path = entry.true_positives[gt_idx].file_path
+            except IndexError as exc:
+                raise ValueError(
+                    f"Invalid ground-truth index {gt_idx} for {result.entry_id!r}"
+                ) from exc
             location_checked += 1
-            if match_score >= 0.5:
+            if predicted_file_path == expected_file_path:
                 location_hits += 1
 
     n = len(model_results)

--- a/packages/gptme-runloops/src/gptme_runloops/pr_review/schema.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pr_review/schema.py
@@ -1,0 +1,170 @@
+"""Versioned schema for PR review artifacts.
+
+Designed to be forge-neutral: GitHub and Forgejo adapters can produce the same
+ReviewArtifact; the renderer decides how to publish it.
+
+Version history:
+  v1 (2026-08-03): initial schema — target identity, run metadata, findings,
+                   fingerprints, merge safety verdict.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from enum import Enum
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+SCHEMA_VERSION = "v1"
+
+
+class Severity(str, Enum):
+    critical = "critical"
+    high = "high"
+    medium = "medium"
+    low = "low"
+    info = "info"
+
+
+class Disposition(str, Enum):
+    confirmed = "confirmed"
+    needs_validation = "needs_validation"
+    dropped = "dropped"
+
+
+class MergeSafety(str, Enum):
+    safe = "safe"
+    unsafe = "unsafe"
+    needs_review = "needs_review"
+    unknown = "unknown"
+
+
+class ReviewTarget(BaseModel):
+    """Immutable identity of the PR being reviewed.
+
+    Binding reviews to exact base/head SHAs prevents stale-head publication.
+    """
+
+    forge: Literal["github", "forgejo"] = "github"
+    repo: str  # e.g. "gptme/gptme-contrib"
+    pr_number: int
+    base_sha: str
+    head_sha: str
+
+
+class ReviewFinding(BaseModel):
+    """A single finding from the review agent.
+
+    Compatible with the multi-lens-review SKILL.md schema; extends it with
+    disposition tracking, fingerprinting, and publication state.
+    """
+
+    # Identity
+    id: str = Field(description="Stable fingerprint (see FindingFingerprint)")
+
+    # Classification
+    category: str = Field(description="e.g. correctness, security, test-coverage")
+    severity: Severity
+    confidence: float = Field(ge=0.0, le=1.0)
+
+    # Location — required; no evidence without a file reference
+    file_path: str
+    line_range: str = Field(description="e.g. '42' or '42-49'")
+
+    # Content
+    title: str
+    description: str
+    evidence: str = Field(description="Concrete code evidence tied to the location")
+    fix_hint: str = ""
+
+    # Lifecycle
+    disposition: Disposition = Disposition.needs_validation
+    published: bool = False
+
+    # Validation pass (for high-severity findings before publishing)
+    validated_by: str | None = None
+    validation_note: str = ""
+
+    @classmethod
+    def fingerprint(
+        cls,
+        *,
+        repo: str,
+        pr_number: int,
+        head_sha: str,
+        file_path: str,
+        title: str,
+        prompt_version: str,
+    ) -> str:
+        """Stable, content-addressed fingerprint for deduplication.
+
+        Same finding on the same head SHA + prompt version always produces the
+        same fingerprint, so re-runs cannot post duplicate comments.
+        """
+        payload = json.dumps(
+            {
+                "repo": repo,
+                "pr": pr_number,
+                "head": head_sha,
+                "file": file_path,
+                "title": title,
+                "prompt": prompt_version,
+            },
+            sort_keys=True,
+        )
+        return hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+class FindingFingerprint(BaseModel):
+    """Cross-run fingerprint record for idempotency checking."""
+
+    finding_id: str
+    repo: str
+    pr_number: int
+    head_sha: str
+    prompt_version: str
+    published_at: datetime | None = None
+    comment_id: str | None = None
+
+
+class ReviewArtifact(BaseModel):
+    """Complete, versioned output of one PR review run.
+
+    The analysis core produces this; the adapter (GitHub / Forgejo publisher)
+    reads it. The core must not call forge APIs directly.
+    """
+
+    schema_version: str = SCHEMA_VERSION
+
+    # Immutable identity
+    target: ReviewTarget
+
+    # Run provenance
+    model: str
+    prompt_version: str
+    started_at: datetime
+    completed_at: datetime
+
+    # Summary
+    summary: str
+    merge_safety: MergeSafety
+
+    # Findings
+    findings: list[ReviewFinding] = Field(default_factory=list)
+
+    # Publication state
+    dry_run: bool = True
+    published_at: datetime | None = None
+
+    @property
+    def confirmed_findings(self) -> list[ReviewFinding]:
+        return [f for f in self.findings if f.disposition == Disposition.confirmed]
+
+    @property
+    def token_id(self) -> str:
+        """Short readable identity for log messages."""
+        t = self.target
+        return f"{t.repo}#{t.pr_number}@{t.head_sha[:8]}"

--- a/packages/gptme-runloops/tests/fixtures/pr_review_corpus.json
+++ b/packages/gptme-runloops/tests/fixtures/pr_review_corpus.json
@@ -8,28 +8,28 @@
       "repo": "gptme/gptme-contrib",
       "pr_number": 1341,
       "pr_title": "feat(gptodo): add Mermaid output to dep dag",
-      "pr_description": "Adds --format mermaid to gptodo dep dag. Adds deterministic SHA-256 node identifiers and escaped task labels. State-based styling, dependency edges, filtering, power annotations.",
-      "diff_summary": "packages/gptodo/src/gptodo/deptree.py: new render_dag_mermaid() function using SHA-256 node IDs and Mermaid escaping. packages/gptodo/tests/test_deptree.py: new test suite.",
+      "pr_description": "Initial revision adds --format mermaid to gptodo dep dag with task-derived node identifiers and unescaped task labels. State-based styling, dependency edges, filtering, and power annotations are included.",
+      "diff_summary": "packages/gptodo/src/gptodo/deptree.py at 5a175bb3: new render_dag_mermaid() truncates sanitized task names to 40 characters for node IDs and interpolates task names directly inside quoted Mermaid labels. packages/gptodo/tests/test_deptree.py: initial renderer tests.",
       "attribution": "greptile + bob self-review (2026-08-03)",
-      "notes": "Greptile initially flagged two real bugs in earlier revisions: SHA-256 identifier collision (fixed by using full digest instead of prefix) and Mermaid label injection (fixed by escaping brackets/quotes). Final merged version is clean 5/5.",
+      "notes": "Snapshot pinned to PR head 5a175bb3, before the collision-safe ID and label-escaping fixes in 7a446d96. Greptile flagged both defects against this revision; final merged version is clean 5/5.",
       "ground_truth": [
         {
           "label": "true_positive",
           "category": "correctness",
           "severity": "high",
           "file_path": "packages/gptodo/src/gptodo/deptree.py",
-          "title": "Truncated SHA-256 node IDs can collide for large task sets",
-          "description": "Using only a short prefix of the SHA-256 hash for Mermaid node IDs can produce collisions when the task set is large enough, causing the graph to silently drop edges.",
-          "verification": "Greptile flagged this in review round 1; fixed by using longer digest in round 2 commit."
+          "title": "Lossy Mermaid node IDs merge distinct tasks",
+          "description": "Replacing punctuation and truncating task names to 40 characters gives distinct names such as a-b and a_b, or long names sharing a prefix, the same Mermaid node ID. Mermaid then merges nodes and misattaches edges or state classes.",
+          "verification": "Greptile flagged this against 5a175bb3; fixed in 7a446d96 by using deterministic SHA-256 identifiers."
         },
         {
           "label": "true_positive",
           "category": "security",
           "severity": "medium",
           "file_path": "packages/gptodo/src/gptodo/deptree.py",
-          "title": "Task labels containing brackets or quotes break Mermaid syntax",
-          "description": "Task titles with special Mermaid characters ([ ] \") are embedded raw in node labels, allowing a crafted task name to inject arbitrary Mermaid directives.",
-          "verification": "Greptile flagged this in review round 1; fixed by escaping in round 2."
+          "title": "Unescaped task names break Mermaid syntax",
+          "description": "Raw task names containing quotes, brackets, angle brackets, or newlines are interpolated into a quoted Mermaid label and can terminate or split the node declaration.",
+          "verification": "Greptile flagged this against 5a175bb3; fixed in 7a446d96 by escaping labels and encoding line breaks."
         }
       ]
     },
@@ -38,10 +38,10 @@
       "repo": "gptme/gptme-contrib",
       "pr_number": 1338,
       "pr_title": "refactor(runloops): extract CASCADE JSON parsing from inline bash to tested Python",
-      "pr_description": "Adds a tested CASCADE intent parser and CLI. Normalizes four routing fields from JSON input. Replaces the runtime-adoption test's vacuous success path with an explicit skip when the external script is unavailable.",
-      "diff_summary": "packages/gptme-runloops/src/gptme_runloops/autonomous.py: new parse_cascade_intent() and parse-cascade-intent CLI. packages/gptme-runloops/tests/test_autonomous.py: new test coverage plus fix to a vacuous test.",
+      "pr_description": "Initial revision adds a tested CASCADE intent parser and CLI and normalizes four routing fields from JSON input. The runtime-adoption test returns early when the external script is unavailable.",
+      "diff_summary": "packages/gptme-runloops/src/gptme_runloops/autonomous.py at bd3e2040: new parse_cascade_intent() and parse-cascade-intent CLI. packages/gptme-runloops/tests/test_autonomous.py: runtime-adoption test uses a bare return when autonomous-run.sh is absent.",
       "attribution": "greptile (2026-08-03)",
-      "notes": "Greptile identified the vacuous test success as a real issue: a missing runtime script produced a silent pass instead of a pytest.skip. This was a genuine correctness gap.",
+      "notes": "Snapshot pinned to PR head bd3e2040, before d86b97f2 replaced the vacuous return with pytest.skip(). Greptile identified the silent pass as a real correctness gap.",
       "ground_truth": [
         {
           "label": "true_positive",
@@ -59,10 +59,10 @@
       "repo": "gptme/gptme-contrib",
       "pr_number": 1344,
       "pr_title": "fix(sessions): replace grep subprocess with Python-native binary scan in blame",
-      "pr_description": "Replaces the external grep trajectory prefilter with Python-native recursive discovery and memory-mapped fixed-string scanning. Removes the subprocess timeout and silent fork-failure path.",
-      "diff_summary": "packages/gptme-sessions/src/gptme_sessions/blame.py: new mmap-backed scan replaces subprocess.run(['grep', ...]). Error handling for inaccessible/empty files.",
+      "pr_description": "Initial revision replaces the external grep trajectory prefilter with Python-native recursive discovery and fixed-string scanning by reading each candidate file in full.",
+      "diff_summary": "packages/gptme-sessions/src/gptme_sessions/blame.py at 865e49e2: _traj_candidate_files() opens each JSONL file and calls fh.read() before checking for the basename.",
       "attribution": "greptile (2026-08-03)",
-      "notes": "Greptile initially flagged that the original implementation could allocate each entire trajectory file in Python memory. The mmap approach fixes this. Clean 5/5 on final commit.",
+      "notes": "Snapshot pinned to PR head 865e49e2, before b1a058ce switched the scan to mmap.find(). Greptile flagged the full-file allocation against this revision; final merged version is clean 5/5.",
       "ground_truth": [
         {
           "label": "true_positive",
@@ -91,10 +91,10 @@
       "repo": "gptme/gptme",
       "pr_number": 3419,
       "pr_title": "fix(shell): fold workspace hint into tool response",
-      "pr_description": "Folds the workspace hint into the command output message directly. The generator yields a single message that receives the call_id stamp, producing a clean tool response with zero interleaving. Strict providers that require tool responses to immediately follow tool_calls are no longer broken.",
-      "diff_summary": "gptme/tools/shell.py: yield single tool response instead of hint-then-output. tests/test_shell.py: new single-message contract test.",
+      "pr_description": "Initial revision yields the command output and then emits a separate workspace hint. The last yielded message receives the call_id stamp, so the hint becomes the nominal tool response while the actual output is interleaved as bare context.",
+      "diff_summary": "gptme/tools/shell.py at f75053bf^: execute_shell_impl() yields Message(\"system\", msg) before yielding workspace_hint. The later commit 42005f42 folds the hint into the command output.",
       "attribution": "bob self-review + greptile (2026-08-03)",
-      "notes": "The core issue was that strict providers (Moonshot AI, others) require tool responses to immediately follow tool_calls, but the prior impl inserted a user-role system message between them.",
+      "notes": "Snapshot pinned to the parent of PR head f75053bf, where the strict-provider ordering bug is present. The later commits fix the ordering and add regression coverage.",
       "ground_truth": [
         {
           "label": "true_positive",
@@ -112,16 +112,16 @@
       "repo": "gptme/gptme",
       "pr_number": 3414,
       "pr_title": "fix(server): acquire step_lock in interrupt endpoint to prevent race",
-      "pr_description": "Acquires the step_lock in the interrupt endpoint to prevent a race condition between interrupt handling and step execution.",
-      "diff_summary": "gptme/server/api.py: interrupt endpoint now acquires step_lock before signal delivery.",
+      "pr_description": "Before the fix, the interrupt endpoint checks and mutates generating state and pending tools without acquiring the session step lock.",
+      "diff_summary": "gptme/server/api_v2_sessions.py at c488c07f^: api_conversation_interrupt() performs the idempotency check, generating-state updates, and pending_tools.clear() outside session.step_lock.",
       "attribution": "greptile + bob (2026-08-03)",
-      "notes": "A real concurrency bug: the interrupt endpoint could race with an ongoing step, leaving the agent in an inconsistent state.",
+      "notes": "Snapshot pinned to the parent of PR head c488c07f. The PR wraps the check-and-mutate sequence in session.step_lock to close the TOCTOU race.",
       "ground_truth": [
         {
           "label": "true_positive",
           "category": "correctness",
           "severity": "high",
-          "file_path": "gptme/server/api.py",
+          "file_path": "gptme/server/api_v2_sessions.py",
           "title": "Interrupt endpoint lacks step_lock acquisition, enabling concurrent-step race",
           "description": "The /interrupt endpoint could fire while a step was executing without holding step_lock, potentially corrupting execution state or causing double-execution of a step.",
           "verification": "Fix required acquiring step_lock before sending the interrupt signal; merged as the canonical fix."

--- a/packages/gptme-runloops/tests/fixtures/pr_review_corpus.json
+++ b/packages/gptme-runloops/tests/fixtures/pr_review_corpus.json
@@ -1,0 +1,164 @@
+{
+  "corpus_version": "v1",
+  "created": "2026-08-03",
+  "description": "Hand-labeled golden corpus for PR reviewer Phase 0 evaluation. Sources: real Greptile reviews on gptme-contrib and gptme PRs, plus known post-merge incidents.",
+  "entries": [
+    {
+      "entry_id": "contrib-1341-mermaid-dag",
+      "repo": "gptme/gptme-contrib",
+      "pr_number": 1341,
+      "pr_title": "feat(gptodo): add Mermaid output to dep dag",
+      "pr_description": "Adds --format mermaid to gptodo dep dag. Adds deterministic SHA-256 node identifiers and escaped task labels. State-based styling, dependency edges, filtering, power annotations.",
+      "diff_summary": "packages/gptodo/src/gptodo/deptree.py: new render_dag_mermaid() function using SHA-256 node IDs and Mermaid escaping. packages/gptodo/tests/test_deptree.py: new test suite.",
+      "attribution": "greptile + bob self-review (2026-08-03)",
+      "notes": "Greptile initially flagged two real bugs in earlier revisions: SHA-256 identifier collision (fixed by using full digest instead of prefix) and Mermaid label injection (fixed by escaping brackets/quotes). Final merged version is clean 5/5.",
+      "ground_truth": [
+        {
+          "label": "true_positive",
+          "category": "correctness",
+          "severity": "high",
+          "file_path": "packages/gptodo/src/gptodo/deptree.py",
+          "title": "Truncated SHA-256 node IDs can collide for large task sets",
+          "description": "Using only a short prefix of the SHA-256 hash for Mermaid node IDs can produce collisions when the task set is large enough, causing the graph to silently drop edges.",
+          "verification": "Greptile flagged this in review round 1; fixed by using longer digest in round 2 commit."
+        },
+        {
+          "label": "true_positive",
+          "category": "security",
+          "severity": "medium",
+          "file_path": "packages/gptodo/src/gptodo/deptree.py",
+          "title": "Task labels containing brackets or quotes break Mermaid syntax",
+          "description": "Task titles with special Mermaid characters ([ ] \") are embedded raw in node labels, allowing a crafted task name to inject arbitrary Mermaid directives.",
+          "verification": "Greptile flagged this in review round 1; fixed by escaping in round 2."
+        }
+      ]
+    },
+    {
+      "entry_id": "contrib-1338-cascade-intent",
+      "repo": "gptme/gptme-contrib",
+      "pr_number": 1338,
+      "pr_title": "refactor(runloops): extract CASCADE JSON parsing from inline bash to tested Python",
+      "pr_description": "Adds a tested CASCADE intent parser and CLI. Normalizes four routing fields from JSON input. Replaces the runtime-adoption test's vacuous success path with an explicit skip when the external script is unavailable.",
+      "diff_summary": "packages/gptme-runloops/src/gptme_runloops/autonomous.py: new parse_cascade_intent() and parse-cascade-intent CLI. packages/gptme-runloops/tests/test_autonomous.py: new test coverage plus fix to a vacuous test.",
+      "attribution": "greptile (2026-08-03)",
+      "notes": "Greptile identified the vacuous test success as a real issue: a missing runtime script produced a silent pass instead of a pytest.skip. This was a genuine correctness gap.",
+      "ground_truth": [
+        {
+          "label": "true_positive",
+          "category": "test-coverage",
+          "severity": "medium",
+          "file_path": "packages/gptme-runloops/tests/test_autonomous.py",
+          "title": "Absent runtime script produces silent passing test instead of explicit skip",
+          "description": "The runtime-adoption test returned early with no assertion when the external script was missing, making the test always pass vacuously regardless of whether the integration was working.",
+          "verification": "Greptile flagged this; fixed by adding pytest.skip() when script is absent."
+        }
+      ]
+    },
+    {
+      "entry_id": "contrib-1344-blame-mmap",
+      "repo": "gptme/gptme-contrib",
+      "pr_number": 1344,
+      "pr_title": "fix(sessions): replace grep subprocess with Python-native binary scan in blame",
+      "pr_description": "Replaces the external grep trajectory prefilter with Python-native recursive discovery and memory-mapped fixed-string scanning. Removes the subprocess timeout and silent fork-failure path.",
+      "diff_summary": "packages/gptme-sessions/src/gptme_sessions/blame.py: new mmap-backed scan replaces subprocess.run(['grep', ...]). Error handling for inaccessible/empty files.",
+      "attribution": "greptile (2026-08-03)",
+      "notes": "Greptile initially flagged that the original implementation could allocate each entire trajectory file in Python memory. The mmap approach fixes this. Clean 5/5 on final commit.",
+      "ground_truth": [
+        {
+          "label": "true_positive",
+          "category": "correctness",
+          "severity": "high",
+          "file_path": "packages/gptme-sessions/src/gptme_sessions/blame.py",
+          "title": "Full trajectory file loaded into Python memory during grep scan",
+          "description": "The original implementation read entire append-only trajectory files into memory before searching, causing high RAM usage on systems with large trajectory archives.",
+          "verification": "Greptile flagged the full-file RAM allocation in review round 1; fixed with mmap in round 2."
+        }
+      ]
+    },
+    {
+      "entry_id": "contrib-1347-concurrent-patch",
+      "repo": "gptme/gptme-contrib",
+      "pr_number": 1347,
+      "pr_title": "fix(test): move patch() to main thread in concurrent PM tests",
+      "pr_description": "Moves subprocess.run patches out of worker threads in two concurrent project-monitoring tests so patch installation and restoration occur safely on the main thread.",
+      "diff_summary": "packages/gptme-runloops/tests/test_project_monitoring.py: wraps thread startup and joining in one patch context per test. Calls check_notifications() directly under the shared main-thread patch.",
+      "attribution": "greptile 5/5 clean (2026-08-03)",
+      "notes": "A clean PR — Greptile found no issues and gave 5/5. Ground truth contains no true positives. Useful for measuring false-positive rate.",
+      "ground_truth": []
+    },
+    {
+      "entry_id": "gptme-3419-shell-hint-interleave",
+      "repo": "gptme/gptme",
+      "pr_number": 3419,
+      "pr_title": "fix(shell): fold workspace hint into tool response",
+      "pr_description": "Folds the workspace hint into the command output message directly. The generator yields a single message that receives the call_id stamp, producing a clean tool response with zero interleaving. Strict providers that require tool responses to immediately follow tool_calls are no longer broken.",
+      "diff_summary": "gptme/tools/shell.py: yield single tool response instead of hint-then-output. tests/test_shell.py: new single-message contract test.",
+      "attribution": "bob self-review + greptile (2026-08-03)",
+      "notes": "The core issue was that strict providers (Moonshot AI, others) require tool responses to immediately follow tool_calls, but the prior impl inserted a user-role system message between them.",
+      "ground_truth": [
+        {
+          "label": "true_positive",
+          "category": "correctness",
+          "severity": "high",
+          "file_path": "gptme/tools/shell.py",
+          "title": "System-to-user conversion inserts interleaved message violating tool_calls ordering",
+          "description": "The workspace hint was yielded as a separate system message that llm_openai.py converted to a user-role message, inserted between the assistant tool_call and the tool result. Strict providers reject this ordering.",
+          "verification": "Post-merge investigation by bob confirmed the root cause; Moonshot AI and other strict providers rejected the conversation shape."
+        }
+      ]
+    },
+    {
+      "entry_id": "gptme-3414-step-lock-race",
+      "repo": "gptme/gptme",
+      "pr_number": 3414,
+      "pr_title": "fix(server): acquire step_lock in interrupt endpoint to prevent race",
+      "pr_description": "Acquires the step_lock in the interrupt endpoint to prevent a race condition between interrupt handling and step execution.",
+      "diff_summary": "gptme/server/api.py: interrupt endpoint now acquires step_lock before signal delivery.",
+      "attribution": "greptile + bob (2026-08-03)",
+      "notes": "A real concurrency bug: the interrupt endpoint could race with an ongoing step, leaving the agent in an inconsistent state.",
+      "ground_truth": [
+        {
+          "label": "true_positive",
+          "category": "correctness",
+          "severity": "high",
+          "file_path": "gptme/server/api.py",
+          "title": "Interrupt endpoint lacks step_lock acquisition, enabling concurrent-step race",
+          "description": "The /interrupt endpoint could fire while a step was executing without holding step_lock, potentially corrupting execution state or causing double-execution of a step.",
+          "verification": "Fix required acquiring step_lock before sending the interrupt signal; merged as the canonical fix."
+        }
+      ]
+    },
+    {
+      "entry_id": "contrib-1338-false-positive-example",
+      "repo": "gptme/gptme-contrib",
+      "pr_number": 1338,
+      "pr_title": "refactor(runloops): extract CASCADE JSON parsing from inline bash to tested Python",
+      "pr_description": "Same PR as contrib-1338-cascade-intent but focusing on a different candidate finding that was a false positive.",
+      "diff_summary": "packages/gptme-runloops/src/gptme_runloops/autonomous.py: new parse_cascade_intent() function handles None, empty dict, and non-object JSON gracefully.",
+      "attribution": "synthetic FP example based on common review patterns",
+      "notes": "A reviewer might flag the broad except clause around json.loads() as swallowing errors — but in this context it is intentional: malformed CASCADE output should be tolerated gracefully, not crash the autonomous runner.",
+      "ground_truth": [
+        {
+          "label": "false_positive",
+          "category": "correctness",
+          "severity": "medium",
+          "file_path": "packages/gptme-runloops/src/gptme_runloops/autonomous.py",
+          "title": "Broad except clause around json.loads() swallows unexpected errors",
+          "description": "The bare except around JSON parsing may hide programming errors. A reviewer unfamiliar with the design intent might flag this as dangerous error swallowing.",
+          "verification": "Design intent: CASCADE intent parsing must be fault-tolerant; malformed output from the autonomous runner should degrade gracefully, not crash the caller. The broad catch is intentional."
+        }
+      ]
+    },
+    {
+      "entry_id": "contrib-1349-auth-misclassify",
+      "repo": "gptme/gptme-contrib",
+      "pr_number": 1349,
+      "pr_title": "fix(failure-capture): prevent lesson names from triggering auth misclassification",
+      "pr_description": "Prevents lesson file names that contain auth-related words from triggering false auth-failure classification in the session failure capture module.",
+      "diff_summary": "packages/gptme-sessions/src/gptme_sessions/failure_capture.py: add guard against misclassifying lesson names as auth failures.",
+      "attribution": "bob self-review + greptile (2026-08-03)",
+      "notes": "Clean fix PR. Greptile gave 5/5. No true positives. Useful as a negative corpus example.",
+      "ground_truth": []
+    }
+  ]
+}

--- a/packages/gptme-runloops/tests/test_pr_review.py
+++ b/packages/gptme-runloops/tests/test_pr_review.py
@@ -1,0 +1,341 @@
+"""Tests for the pr_review schema and corpus module (Phase 0)."""
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from gptme_runloops.pr_review import (
+    Disposition,
+    MergeSafety,
+    ReviewArtifact,
+    ReviewFinding,
+    ReviewTarget,
+    Severity,
+)
+from gptme_runloops.pr_review.corpus import (
+    CorpusEntry,
+    EvalResult,
+    GroundTruthFinding,
+    load_corpus,
+    score_model,
+)
+from gptme_runloops.pr_review.schema import SCHEMA_VERSION
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+# ── Schema tests ─────────────────────────────────────────────────────────────
+
+
+class TestReviewFindingFingerprint:
+    def test_stable(self):
+        fp1 = ReviewFinding.fingerprint(
+            repo="gptme/gptme-contrib",
+            pr_number=1341,
+            head_sha="abc123",
+            file_path="deptree.py",
+            title="Node ID collision",
+            prompt_version="v1",
+        )
+        fp2 = ReviewFinding.fingerprint(
+            repo="gptme/gptme-contrib",
+            pr_number=1341,
+            head_sha="abc123",
+            file_path="deptree.py",
+            title="Node ID collision",
+            prompt_version="v1",
+        )
+        assert fp1 == fp2
+
+    def test_differs_on_head_sha(self):
+        common = dict(
+            repo="gptme/gptme-contrib",
+            pr_number=1341,
+            file_path="deptree.py",
+            title="Node ID collision",
+            prompt_version="v1",
+        )
+        assert ReviewFinding.fingerprint(
+            head_sha="abc", **common
+        ) != ReviewFinding.fingerprint(head_sha="def", **common)
+
+    def test_differs_on_prompt_version(self):
+        common = dict(
+            repo="gptme/gptme-contrib",
+            pr_number=1341,
+            head_sha="abc123",
+            file_path="deptree.py",
+            title="Node ID collision",
+        )
+        assert ReviewFinding.fingerprint(
+            prompt_version="v1", **common
+        ) != ReviewFinding.fingerprint(prompt_version="v2", **common)
+
+    def test_length(self):
+        fp = ReviewFinding.fingerprint(
+            repo="r",
+            pr_number=1,
+            head_sha="h",
+            file_path="f",
+            title="t",
+            prompt_version="v1",
+        )
+        assert len(fp) == 16
+
+
+class TestReviewArtifact:
+    def _artifact(self, findings=None):
+        return ReviewArtifact(
+            target=ReviewTarget(
+                repo="gptme/gptme-contrib",
+                pr_number=1341,
+                base_sha="base",
+                head_sha="head",
+            ),
+            model="deepseek/deepseek-v4-flash",
+            prompt_version="v1",
+            started_at=datetime.now(tz=timezone.utc),
+            completed_at=datetime.now(tz=timezone.utc),
+            summary="Two real bugs found.",
+            merge_safety=MergeSafety.unsafe,
+            findings=findings or [],
+            dry_run=True,
+        )
+
+    def test_schema_version(self):
+        a = self._artifact()
+        assert a.schema_version == SCHEMA_VERSION
+
+    def test_confirmed_findings_filter(self):
+        f1 = ReviewFinding(
+            id="a",
+            category="correctness",
+            severity=Severity.high,
+            confidence=0.9,
+            file_path="deptree.py",
+            line_range="42",
+            title="T1",
+            description="D1",
+            evidence="E1",
+            disposition=Disposition.confirmed,
+        )
+        f2 = ReviewFinding(
+            id="b",
+            category="security",
+            severity=Severity.medium,
+            confidence=0.7,
+            file_path="deptree.py",
+            line_range="55",
+            title="T2",
+            description="D2",
+            evidence="E2",
+            disposition=Disposition.dropped,
+        )
+        a = self._artifact(findings=[f1, f2])
+        assert len(a.confirmed_findings) == 1
+        assert a.confirmed_findings[0].title == "T1"
+
+    def test_token_id_format(self):
+        a = self._artifact()
+        assert "gptme/gptme-contrib#1341@" in a.token_id
+
+    def test_roundtrip_json(self):
+        a = self._artifact()
+        dumped = a.model_dump_json()
+        loaded = ReviewArtifact.model_validate_json(dumped)
+        assert loaded.schema_version == a.schema_version
+        assert loaded.target.pr_number == 1341
+
+    def test_dry_run_default(self):
+        a = self._artifact()
+        assert a.dry_run is True
+        assert a.published_at is None
+
+
+# ── Corpus tests ─────────────────────────────────────────────────────────────
+
+
+class TestCorpusEntry:
+    def _entry(self) -> CorpusEntry:
+        return CorpusEntry(
+            entry_id="test-1",
+            repo="gptme/gptme-contrib",
+            pr_number=1341,
+            pr_title="feat: Mermaid DAG",
+            pr_description="Adds mermaid output",
+            diff_summary="deptree.py: new render_dag_mermaid()",
+            ground_truth=[
+                GroundTruthFinding(
+                    label="true_positive",
+                    category="correctness",
+                    severity="high",
+                    file_path="deptree.py",
+                    title="Node ID collision",
+                    description="Short SHA prefix can collide.",
+                    verification="Greptile flagged; fixed in round 2.",
+                ),
+                GroundTruthFinding(
+                    label="false_positive",
+                    category="security",
+                    severity="medium",
+                    file_path="deptree.py",
+                    title="Spurious FP",
+                    description="Not actually an issue.",
+                    verification="Reviewed and dismissed.",
+                ),
+            ],
+        )
+
+    def test_true_positive_filter(self):
+        e = self._entry()
+        assert len(e.true_positives) == 1
+        assert e.true_positives[0].title == "Node ID collision"
+
+    def test_false_positive_filter(self):
+        e = self._entry()
+        assert len(e.false_positives) == 1
+
+
+class TestScoreModel:
+    def test_perfect_precision(self):
+        corpus = [
+            CorpusEntry(
+                entry_id="e1",
+                repo="r",
+                pr_number=1,
+                pr_title="t",
+                pr_description="d",
+                diff_summary="s",
+                ground_truth=[
+                    GroundTruthFinding(
+                        label="true_positive",
+                        category="correctness",
+                        severity="high",
+                        file_path="f.py",
+                        title="Bug",
+                        description="A bug",
+                    )
+                ],
+            )
+        ]
+        results = [
+            EvalResult(
+                entry_id="e1",
+                model="test-model",
+                matched_tp=[(0, "Bug", 1.0)],
+                false_positives_produced=0,
+            )
+        ]
+        scores = score_model(results, corpus)
+        assert scores.precision == 1.0
+        assert scores.recall == 1.0
+        assert scores.fp_rate == 0.0
+
+    def test_all_false_positives(self):
+        corpus = [
+            CorpusEntry(
+                entry_id="e1",
+                repo="r",
+                pr_number=1,
+                pr_title="t",
+                pr_description="d",
+                diff_summary="s",
+                ground_truth=[],
+            )
+        ]
+        results = [
+            EvalResult(
+                entry_id="e1",
+                model="test-model",
+                matched_tp=[],
+                false_positives_produced=3,
+            )
+        ]
+        scores = score_model(results, corpus)
+        assert scores.precision == 0.0
+        assert scores.fp_rate == 3.0
+
+    def test_passes_gate(self):
+        corpus = [
+            CorpusEntry(
+                entry_id="e1",
+                repo="r",
+                pr_number=1,
+                pr_title="t",
+                pr_description="d",
+                diff_summary="s",
+                ground_truth=[
+                    GroundTruthFinding(
+                        label="true_positive",
+                        category="correctness",
+                        severity="high",
+                        file_path="f.py",
+                        title="Bug",
+                        description="A bug",
+                    )
+                ],
+            )
+        ]
+        results = [
+            EvalResult(
+                entry_id="e1",
+                model="test-model",
+                matched_tp=[(0, "Bug", 1.0)],
+                false_positives_produced=0,
+            )
+        ]
+        scores = score_model(results, corpus)
+        assert scores.passes_gate()
+
+    def test_fails_gate_low_precision(self):
+        corpus = [
+            CorpusEntry(
+                entry_id="e1",
+                repo="r",
+                pr_number=1,
+                pr_title="t",
+                pr_description="d",
+                diff_summary="s",
+                ground_truth=[],
+            )
+        ]
+        results = [
+            EvalResult(
+                entry_id="e1",
+                model="test-model",
+                matched_tp=[],
+                false_positives_produced=5,
+            )
+        ]
+        scores = score_model(results, corpus)
+        assert not scores.passes_gate()
+
+
+class TestLoadCorpus:
+    def test_fixture_loads(self):
+        corpus = load_corpus(FIXTURES / "pr_review_corpus.json")
+        assert len(corpus) >= 6
+
+    def test_fixture_has_valid_entries(self):
+        corpus = load_corpus(FIXTURES / "pr_review_corpus.json")
+        for entry in corpus:
+            assert entry.repo
+            assert entry.pr_number > 0
+            assert entry.pr_title
+            for gt in entry.ground_truth:
+                assert gt.label in ("true_positive", "false_positive", "true_negative")
+                assert gt.file_path
+                assert gt.title
+
+    def test_fixture_has_both_tp_and_fp(self):
+        corpus = load_corpus(FIXTURES / "pr_review_corpus.json")
+        has_tp = any(e.true_positives for e in corpus)
+        has_fp = any(e.false_positives for e in corpus)
+        assert has_tp, "corpus should have at least one true positive"
+        assert has_fp, "corpus should have at least one false positive"
+
+    def test_fixture_json_valid(self):
+        raw = json.loads((FIXTURES / "pr_review_corpus.json").read_text())
+        assert "corpus_version" in raw
+        assert "entries" in raw
+        assert raw["corpus_version"] == "v1"

--- a/packages/gptme-runloops/tests/test_pr_review.py
+++ b/packages/gptme-runloops/tests/test_pr_review.py
@@ -222,7 +222,7 @@ class TestScoreModel:
             EvalResult(
                 entry_id="e1",
                 model="test-model",
-                matched_tp=[(0, "Bug", 1.0)],
+                matched_tp=[(0, "Bug", 1.0, "f.py")],
                 false_positives_produced=0,
             )
         ]
@@ -230,6 +230,41 @@ class TestScoreModel:
         assert scores.precision == 1.0
         assert scores.recall == 1.0
         assert scores.fp_rate == 0.0
+        assert scores.location_accuracy == 1.0
+
+    def test_location_accuracy_compares_file_paths(self):
+        corpus = [
+            CorpusEntry(
+                entry_id="e1",
+                repo="r",
+                pr_number=1,
+                pr_title="t",
+                pr_description="d",
+                diff_summary="s",
+                ground_truth=[
+                    GroundTruthFinding(
+                        label="true_positive",
+                        category="correctness",
+                        severity="high",
+                        file_path="expected.py",
+                        title="Bug",
+                        description="A bug",
+                    )
+                ],
+            )
+        ]
+        results = [
+            EvalResult(
+                entry_id="e1",
+                model="test-model",
+                matched_tp=[(0, "Bug", 1.0, "wrong.py")],
+            )
+        ]
+
+        scores = score_model(results, corpus)
+
+        assert scores.precision == 1.0
+        assert scores.location_accuracy == 0.0
 
     def test_all_false_positives(self):
         corpus = [
@@ -280,7 +315,7 @@ class TestScoreModel:
             EvalResult(
                 entry_id="e1",
                 model="test-model",
-                matched_tp=[(0, "Bug", 1.0)],
+                matched_tp=[(0, "Bug", 1.0, "f.py")],
                 false_positives_produced=0,
             )
         ]


### PR DESCRIPTION
## Summary

Phase 0 of the self-hosted PR reviewer ([ErikBjare/bob#1122](https://github.com/ErikBjare/bob/issues/1122)). This PR ships the evaluation infrastructure needed before selecting a default model (DeepSeek V4 Flash 0731 or otherwise).

- **`pr_review/schema.py`** — versioned Pydantic models for the full review lifecycle:
  - `ReviewTarget`: forge-neutral target identity (repo, PR number, base/head SHA)
  - `ReviewFinding`: finding with severity, confidence, location, evidence, disposition, and SHA-256 fingerprint for deduplication
  - `ReviewArtifact`: complete review output bound to an immutable head SHA; `dry_run=True` by default, never publishes
  - Extends the existing multi-lens-review finding format with publication state tracking

- **`pr_review/corpus.py`** — evaluation tooling:
  - `CorpusEntry` / `GroundTruthFinding`: hand-labeled ground truth dataclasses
  - `score_model()`: aggregates per-entry `EvalResult`s into `ModelScores` (precision, recall, FP rate, location accuracy, duplicate rate, latency, cost)
  - `passes_gate()`: ≥80% precision and ≤2.0 FP/review threshold from the MVP spec

- **`tests/fixtures/pr_review_corpus.json`** — 8-entry golden corpus (v1) sourced from verified real Greptile reviews:
  - contrib #1341 Mermaid DAG (2 TPs: node ID collision, label injection)
  - contrib #1338 CASCADE intent parser (1 TP: vacuous test success)
  - contrib #1344 blame mmap (1 TP: full-file RAM allocation)
  - contrib #1347 concurrent patch (0 TP: clean 5/5, FP baseline)
  - gptme #3419 shell hint interleave (1 TP: strict-provider tool ordering)
  - gptme #3414 step-lock race (1 TP: interrupt/step concurrency)
  - 1 labeled false-positive example (broad except that is intentional design)
  - 6 TPs and 1 FP across 8 entries

- **`tests/test_pr_review.py`** — 19 unit tests: fingerprint stability, JSON roundtrip, dry-run default, corpus load, score aggregation. All pass.

## What's next (Phase 1)

CLI runner: `gptme-runloops review-pr OWNER/REPO#NUM --checkout PATH --model MODEL --dry-run`. Produces a `ReviewArtifact` JSON file from a local checkout; no GitHub API calls from the review core.

## Test plan

- [x] `pytest packages/gptme-runloops/tests/test_pr_review.py` — 19 passed
- [x] `mypy pr_review/` — clean
- [x] `prek` — all pre-commit hooks pass