### PR TITLE
docs(runloops): update README — fix package name, imports, CLI, add new modules

### DIFF
--- a/packages/gptme-runloops/README.md
+++ b/packages/gptme-runloops/README.md
@@ -1,4 +1,4 @@
-# run-loops
+# gptme-runloops
 
 Python-based run loop framework for autonomous AI agent operation.
 
@@ -8,67 +8,93 @@ This package provides infrastructure for running autonomous AI agents with:
 
 - **Autonomous Run Loops**: Base framework for scheduled/triggered agent execution
 - **Project Monitoring**: GitHub PR/issue monitoring with automated responses
+- **PR Review**: Versioned review schema, golden corpus, and model evaluation tooling
 - **Email Integration**: Email-based communication loops
+- **Team Coordination**: Multi-agent team management
 - **Utilities**: Locking, logging, GitHub API, git operations
 
 ## Installation
 
 ```bash
-uv pip install -e packages/run_loops
+uv pip install -e packages/gptme-runloops
 ```
 
 ## Usage
 
 ### CLI
 
+The primary entrypoint is `gptme-runloops`:
+
 ```bash
 # Run autonomous loop
-run-loops autonomous --workspace /path/to/workspace
+gptme-runloops autonomous --workspace /path/to/workspace
 
 # Run project monitoring
-run-loops project-monitoring --workspace /path/to/workspace
+gptme-runloops monitoring --workspace /path/to/workspace
+
+# Run a single run-item
+gptme-runloops run-item --workspace /path/to/workspace
 
 # Run email monitoring
-run-loops email --workspace /path/to/workspace
+gptme-runloops email --workspace /path/to/workspace
+
+# Run team coordination
+gptme-runloops team --workspace /path/to/workspace
 ```
 
 ### Python API
 
 ```python
-from run_loops.autonomous import AutonomousRunner
-from run_loops.project_monitoring import ProjectMonitor
-from run_loops.email import EmailRunner
-
-# Create and run autonomous loop
-runner = AutonomousRunner(workspace="/path/to/workspace")
-runner.run()
-
-# Monitor GitHub projects
-monitor = ProjectMonitor(workspace="/path/to/workspace")
-monitor.run()
+from gptme_runloops.autonomous import AutonomousRunner
+from gptme_runloops.project_monitoring import ProjectMonitor
+from gptme_runloops.email import EmailRunner
 ```
 
 ## Components
 
-### Autonomous Runner (`autonomous.py`)
-Main autonomous operation loop that:
+### Core Run Loops
+
+**`autonomous.py`** — Main autonomous operation loop
 - Executes scheduled runs via systemd timers
 - Handles task selection and execution
 - Manages hot-loop coordination
 
-### Project Monitor (`project_monitoring.py`)
-GitHub monitoring that:
-- Checks PRs for updates, CI failures, review comments
-- Classifies work as GREEN (executable) or RED (needs escalation)
-- Executes GREEN work automatically
+**`project_monitoring.py`** — GitHub monitoring
+- Checks PRs for CI failures, review comments, and merge eligibility
+- Classifies work as actionable or blocked
+- Executes eligible work automatically
 
-### Email Runner (`email.py`)
-Email-based communication that:
+**`email.py`** — Email-based communication
 - Syncs with Gmail via mbsync
-- Processes incoming emails
-- Generates and sends responses
+- Processes incoming emails and generates responses
+
+**`team.py`** — Multi-agent team coordination
+
+**`run_item.py` / `run_item_config.py`** — Single run-item executor and config
+
+### PM Infrastructure
+
+**`merge_lifecycle.py`** — PR merge lifecycle state machine
+
+**`pm_bandit.py`** — Bandit-based project monitoring dispatch
+
+**`pm_dispatch.py`** — Dispatch logic for PM work items
+
+**`prompt_templates.py`** — Structured prompt templates for agent runs
+
+**`worker_records.py`** — Worker session record tracking
+
+### PR Review (`pr_review/`)
+
+Phase 0 tooling for evaluating PR reviewer models before deployment:
+
+- **`schema.py`** — Versioned `ReviewArtifact` / `Finding` types; forge-neutral (GitHub and Forgejo adapters produce the same schema)
+- **`corpus.py`** — Golden corpus of historical PRs with hand-labeled ground-truth findings for model evaluation
+
+Phase 1 (in progress): CLI runner that produces `ReviewArtifact` JSON locally without publishing to GitHub.
 
 ### Utilities (`utils/`)
+
 - `lock.py`: Distributed locking for coordination
 - `github.py`: GitHub API wrapper
 - `git.py`: Git operations
@@ -78,14 +104,7 @@ Email-based communication that:
 
 ## Configuration
 
-Run loops are typically configured via systemd timers:
-
-```bash
-# Example timer for autonomous runs
-~/.config/systemd/user/agent-autonomous.timer
-```
-
-See `dotfiles/.config/systemd/user/` in agent workspaces for examples.
+Run loops are configured via systemd timers. See `dotfiles/.config/systemd/user/` in agent workspaces for examples.
 
 ## Requirements
 

--- a/packages/gptme-runloops/README.md
+++ b/packages/gptme-runloops/README.md
@@ -32,8 +32,11 @@ gptme-runloops autonomous --workspace /path/to/workspace
 # Run project monitoring
 gptme-runloops monitoring --workspace /path/to/workspace
 
-# Run a single run-item
-gptme-runloops run-item --workspace /path/to/workspace
+# Run a single project-monitoring work item
+gptme-runloops run-item \
+  --workspace /path/to/workspace \
+  --work-file /path/to/work-item.jsonl \
+  --backend gptme
 
 # Run email monitoring
 gptme-runloops email --workspace /path/to/workspace
@@ -45,9 +48,9 @@ gptme-runloops team --workspace /path/to/workspace
 ### Python API
 
 ```python
-from gptme_runloops.autonomous import AutonomousRunner
-from gptme_runloops.project_monitoring import ProjectMonitor
-from gptme_runloops.email import EmailRunner
+from gptme_runloops.autonomous import AutonomousRun
+from gptme_runloops.project_monitoring import ProjectMonitoringRun
+from gptme_runloops.email import EmailRun
 ```
 
 ## Components


### PR DESCRIPTION
## Summary

The gptme-runloops README was stale since May 2026 and had several correctness issues:

- **Wrong install path**: `packages/run_loops` → `packages/gptme-runloops`
- **Wrong import paths**: `from run_loops.X` → `from gptme_runloops.X`
- **Wrong CLI command name**: `run-loops` → `gptme-runloops` (primary; `run-loops` is the deprecated alias)
- **Missing command**: `monitoring` and `run-item` were not listed; `project-monitoring` doesn't exist
- **Missing modules**: `merge_lifecycle`, `pm_bandit`, `pm_dispatch`, `prompt_templates`, `worker_records`, `run_item`, `team`, and the new `pr_review/` subpackage (Phase 0, merged in #1355) were all undocumented

## Changes

Updated README to reflect the current state of the package.