### PR TITLE
feat(runloops): pr_review Phase 1 — local CLI runner, no forge required

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/cli.py
+++ b/packages/gptme-runloops/src/gptme_runloops/cli.py
@@ -490,8 +490,8 @@ def review(
             model=model,
             output_path=output_path,
         )
-    except RuntimeError as exc:
-        raise click.ClickException(str(exc)) from exc
+    except (RuntimeError, TypeError, ValueError) as exc:
+        raise click.ClickException(f"Invalid review response: {exc}") from exc
 
     if output_path:
         click.echo(f"Artifact written to {output_path}", err=True)
@@ -504,7 +504,8 @@ def review(
         f"Review complete — {n} finding(s), merge_safety={artifact.merge_safety.value}",
         err=True,
     )
-    if artifact.merge_safety == MergeSafety.unsafe:
+    # Fail closed: automation must only continue after an explicit safe verdict.
+    if artifact.merge_safety != MergeSafety.safe:
         sys.exit(1)
 
 

--- a/packages/gptme-runloops/src/gptme_runloops/cli.py
+++ b/packages/gptme-runloops/src/gptme_runloops/cli.py
@@ -1,6 +1,7 @@
 """Command-line interface for run loops."""
 
 import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -8,6 +9,7 @@ import click
 
 from gptme_runloops.autonomous import AutonomousRun
 from gptme_runloops.email import EmailRun
+from gptme_runloops.pr_review.schema import MergeSafety
 from gptme_runloops.project_monitoring import ProjectMonitoringRun
 from gptme_runloops.team import TeamRun
 from gptme_runloops.utils.executor import get_executor, list_backends
@@ -385,6 +387,125 @@ def run_item_cmd(
         claim_mode=claim_mode,
     )
     sys.exit(exit_code)
+
+
+@main.command()
+@click.option(
+    "--checkout",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=Path.cwd,
+    help="Repository root to review (default: current directory)",
+)
+@click.option(
+    "--working-tree",
+    is_flag=True,
+    default=False,
+    help="Review the current working-tree diff (git diff HEAD). "
+    "No PR or forge access needed.",
+)
+@click.option(
+    "--base",
+    "base_sha",
+    default=None,
+    help="Base commit SHA for a local range review (requires --head).",
+)
+@click.option(
+    "--head",
+    "head_sha",
+    default=None,
+    help="Head commit SHA for a local range review (requires --base).",
+)
+@click.option(
+    "--output",
+    "output_path",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Write ReviewArtifact JSON to this path (default: print to stdout).",
+)
+@click.option(
+    "--model",
+    default=None,
+    help="gptme model spec (e.g. 'anthropic/claude-sonnet-4-6'). "
+    "Defaults to gptme's configured model.",
+)
+def review(
+    checkout: Path,
+    working_tree: bool,
+    base_sha: str | None,
+    head_sha: str | None,
+    output_path: Path | None,
+    model: str | None,
+) -> None:
+    """Review a local diff and emit a ReviewArtifact JSON.
+
+    Phase 1: local-only, no forge API calls, artifact-only output.
+
+    Examples:
+
+      # Review uncommitted working-tree changes (in-session, before a PR):
+      gptme-runloops review --working-tree
+
+      # Review a specific commit range:
+      gptme-runloops review --base abc123 --head def456
+
+      # Write the artifact to a file:
+      gptme-runloops review --working-tree --output /tmp/review.json
+
+      # Use a specific model:
+      gptme-runloops review --working-tree --model anthropic/claude-sonnet-4-6
+    """
+
+    from gptme_runloops.pr_review.reviewer import resolve_local_target, run_review
+
+    if not working_tree and not (base_sha and head_sha):
+        raise click.UsageError(
+            "Specify --working-tree or both --base <SHA> and --head <SHA>."
+        )
+    if working_tree and (base_sha or head_sha):
+        raise click.UsageError(
+            "--working-tree is mutually exclusive with --base / --head."
+        )
+
+    try:
+        target, diff = resolve_local_target(
+            checkout,
+            working_tree=working_tree,
+            base_sha=base_sha,
+            head_sha=head_sha,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise click.ClickException(f"git command failed: {exc.stderr.strip()}") from exc
+
+    if not diff.strip():
+        click.echo("No changes to review.", err=True)
+        sys.exit(0)
+
+    click.echo(f"Reviewing {target.description} …", err=True)
+
+    try:
+        artifact = run_review(
+            checkout,
+            target,
+            diff,
+            model=model,
+            output_path=output_path,
+        )
+    except RuntimeError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if output_path:
+        click.echo(f"Artifact written to {output_path}", err=True)
+    else:
+        click.echo(artifact.model_dump_json(indent=2))
+
+    # Summary to stderr
+    n = len(artifact.findings)
+    click.echo(
+        f"Review complete — {n} finding(s), merge_safety={artifact.merge_safety.value}",
+        err=True,
+    )
+    if artifact.merge_safety == MergeSafety.unsafe:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/packages/gptme-runloops/src/gptme_runloops/pr_review/__init__.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pr_review/__init__.py
@@ -1,13 +1,16 @@
-"""PR review core — schema, corpus, and evaluation tooling.
+"""PR review core — schema, corpus, and review runner.
 
 Phase 0: versioned finding schema + golden corpus for model evaluation.
-Phase 1 (next): CLI runner that produces ReviewArtifact JSON without publishing.
+Phase 1: local CLI runner — working-tree / commit-range reviews without forge.
 Phase 2 (later): GitHub publisher with idempotency guards + PM integration.
 """
 
+from .reviewer import REVIEW_PROMPT_VERSION, resolve_local_target, run_review
 from .schema import (
+    AnyReviewTarget,
     Disposition,
     FindingFingerprint,
+    LocalReviewTarget,
     MergeSafety,
     ReviewArtifact,
     ReviewFinding,
@@ -16,11 +19,18 @@ from .schema import (
 )
 
 __all__ = [
+    # Schema
+    "AnyReviewTarget",
     "Disposition",
     "FindingFingerprint",
+    "LocalReviewTarget",
     "MergeSafety",
     "ReviewArtifact",
     "ReviewFinding",
     "ReviewTarget",
     "Severity",
+    # Phase 1 runner
+    "REVIEW_PROMPT_VERSION",
+    "resolve_local_target",
+    "run_review",
 ]

--- a/packages/gptme-runloops/src/gptme_runloops/pr_review/reviewer.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pr_review/reviewer.py
@@ -1,0 +1,355 @@
+"""Core review runner for Phase 1 — local CLI, artifact only.
+
+Supports three input modes (from the MVP contract):
+  working-tree:  git diff HEAD — in-session, before a PR exists
+  range:         git diff BASE_SHA..HEAD_SHA — local commit range, no forge
+  hosted-pr:     thin adapter calls resolve_local_target after fetching diff
+
+No forge API calls from this module. The GitHub/Forgejo adapters are callers,
+not dependencies of the review logic.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .schema import (
+    Disposition,
+    LocalReviewTarget,
+    MergeSafety,
+    ReviewArtifact,
+    ReviewFinding,
+    Severity,
+)
+
+REVIEW_PROMPT_VERSION = "v1"
+
+# Hard cap to stay within model context limits (~20k tokens for the diff).
+# Larger diffs get a truncation note; future phases can chunk deterministically.
+_MAX_DIFF_BYTES = 80_000
+
+_REVIEW_INSTRUCTIONS = """\
+You are a careful code reviewer. Analyze the provided diff and produce findings.
+
+Rules:
+- Only report findings with concrete evidence visible in the diff.
+- Every finding MUST reference a specific file and line from the changed code.
+- Focus on correctness first, then security, then missing test coverage.
+- Skip purely stylistic findings unless they indicate a real bug risk.
+- Be conservative: a missed real bug is worse than a skipped marginal finding.
+- Do not invent findings about code not in the diff.
+
+Return a single JSON object with this exact structure (no preamble, no fences):
+{
+  "summary": "One to two sentence summary of the changes and overall quality.",
+  "merge_safety": "safe" | "unsafe" | "needs_review",
+  "findings": [
+    {
+      "category": "correctness" | "security" | "test-coverage" | "performance" | "style",
+      "severity": "critical" | "high" | "medium" | "low" | "info",
+      "confidence": <float 0.0-1.0>,
+      "file_path": "<exact path from diff>",
+      "line_range": "<line or range, e.g. 42 or 42-49>",
+      "title": "<short specific title>",
+      "description": "<full description of the problem>",
+      "evidence": "<exact code snippet from the diff showing the issue>",
+      "fix_hint": "<optional fix suggestion>"
+    }
+  ]
+}""".strip()
+
+
+def get_diff(
+    checkout: Path,
+    *,
+    working_tree: bool = False,
+    base_sha: str | None = None,
+    head_sha: str | None = None,
+) -> tuple[str, str, str | None]:
+    """Get unified diff from a local checkout.
+
+    Returns:
+        (diff_text, resolved_base_sha, resolved_head_sha)
+        resolved_head_sha is None for working-tree reviews.
+
+    Raises:
+        ValueError: if neither working_tree nor both base_sha/head_sha are given.
+        subprocess.CalledProcessError: if git commands fail.
+    """
+    if working_tree:
+        base = _git(checkout, "rev-parse", "HEAD").strip()
+        # Include both staged and unstaged changes relative to HEAD
+        unstaged = _git(checkout, "diff", "HEAD")
+        staged = _git(checkout, "diff", "--cached", "HEAD")
+        # Merge: staged usually overlaps with unstaged (diff HEAD covers both)
+        diff = unstaged if unstaged else staged
+        return diff, base, None
+    elif base_sha and head_sha:
+        diff = _git(checkout, "diff", f"{base_sha}..{head_sha}")
+        return diff, base_sha, head_sha
+    else:
+        raise ValueError(
+            "Specify --working-tree or both --base <SHA> and --head <SHA>."
+        )
+
+
+def _git(checkout: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=checkout,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def read_repo_instructions(checkout: Path) -> str:
+    """Read AGENTS.md, CLAUDE.md, or similar repo instruction files.
+
+    Returns the content of the first file found, truncated to 8 KB.
+    Returns an empty string if no instruction file exists.
+    """
+    candidates = ["AGENTS.md", "CLAUDE.md", ".github/CONTRIBUTING.md"]
+    for name in candidates:
+        path = checkout / name
+        if path.exists():
+            content = path.read_text(encoding="utf-8", errors="replace")
+            if len(content) > 8_000:
+                content = content[:8_000] + "\n... [truncated for context size]"
+            return f"# Repository instructions ({name})\n\n{content}"
+    return ""
+
+
+def _diff_fingerprint(diff: str) -> str:
+    """Deterministic 16-char fingerprint of a working-tree diff."""
+    return hashlib.sha256(diff.encode()).hexdigest()[:16]
+
+
+def _detect_repo_name(checkout: Path) -> str:
+    """Infer repo name from git remote or directory name."""
+    try:
+        remote = _git(checkout, "remote", "get-url", "origin").strip()
+        # github.com/org/repo or git@github.com:org/repo.git → org/repo
+        m = re.search(r"[:/]([^/]+/[^/]+?)(?:\.git)?$", remote)
+        if m:
+            return m.group(1)
+    except subprocess.CalledProcessError:
+        pass
+    return checkout.name
+
+
+def resolve_local_target(
+    checkout: Path,
+    *,
+    working_tree: bool = False,
+    base_sha: str | None = None,
+    head_sha: str | None = None,
+) -> tuple[LocalReviewTarget, str]:
+    """Resolve CLI args to a (LocalReviewTarget, diff_text) pair.
+
+    This is the entry point from the CLI. The diff_text is returned separately
+    so callers can inspect size, truncate, or log it before passing to run_review.
+
+    Args:
+        checkout: Path to the git repository root.
+        working_tree: If True, review the current working-tree diff (HEAD).
+        base_sha: Base commit SHA for a range review.
+        head_sha: Head commit SHA for a range review.
+
+    Returns:
+        (target, diff_text) — target is a validated LocalReviewTarget,
+        diff_text is the raw unified diff.
+    """
+    diff, resolved_base, resolved_head = get_diff(
+        checkout,
+        working_tree=working_tree,
+        base_sha=base_sha,
+        head_sha=head_sha,
+    )
+    fingerprint = _diff_fingerprint(diff) if resolved_head is None else ""
+    repo_name = _detect_repo_name(checkout)
+    target = LocalReviewTarget(
+        checkout=str(checkout.resolve()),
+        repo_name=repo_name,
+        base_sha=resolved_base,
+        head_sha=resolved_head,
+        diff_fingerprint=fingerprint,
+    )
+    return target, diff
+
+
+def _build_prompt(diff: str, repo_instructions: str, target_desc: str) -> str:
+    """Build the review prompt, truncating large diffs with a clear note."""
+    diff_bytes = diff.encode()
+    truncation_note = ""
+    if len(diff_bytes) > _MAX_DIFF_BYTES:
+        diff = diff_bytes[:_MAX_DIFF_BYTES].decode(errors="replace")
+        truncation_note = (
+            f"\n\n[DIFF TRUNCATED at {_MAX_DIFF_BYTES} bytes — "
+            "report findings only for code visible above]"
+        )
+
+    parts: list[str] = [_REVIEW_INSTRUCTIONS]
+    if repo_instructions:
+        parts.append(f"\n\n---\n\n{repo_instructions}")
+    parts.append(f"\n\n---\n\nReview target: {target_desc}")
+    parts.append(f"\n\n```diff\n{diff}\n```{truncation_note}")
+    return "".join(parts)
+
+
+def _extract_json(text: str) -> dict:
+    """Extract the first/only JSON object from model output.
+
+    The model is prompted to return only JSON, but may add preamble
+    or wrap in a code fence. This extracts robustly.
+    """
+    text = text.strip()
+    # Direct parse first (clean output)
+    try:
+        result = json.loads(text)
+        assert isinstance(result, dict)
+        return result
+    except (json.JSONDecodeError, AssertionError):
+        pass
+    # Strip code fences (```json ... ```)
+    fenced = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
+    if fenced:
+        try:
+            result = json.loads(fenced.group(1))
+            assert isinstance(result, dict)
+            return result
+        except (json.JSONDecodeError, AssertionError):
+            pass
+    # Find outermost JSON object in the text
+    match = re.search(r"\{.*\}", text, re.DOTALL)
+    if match:
+        try:
+            result = json.loads(match.group(0))
+            assert isinstance(result, dict)
+            return result
+        except (json.JSONDecodeError, AssertionError):
+            pass
+    raise ValueError(
+        f"No valid JSON object found in model output (first 500 chars):\n{text[:500]}"
+    )
+
+
+def _invoke_model(prompt: str, model: str | None, checkout: Path) -> str:
+    """Invoke gptme in one-shot mode with no tools and return stdout.
+
+    Uses --tools none to get a clean text response (no tool calls interspersed).
+    """
+    cmd = ["gptme", "--tools", "none"]
+    if model:
+        cmd.extend(["--model", model])
+    cmd.append(prompt)
+
+    result = subprocess.run(
+        cmd,
+        cwd=checkout,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    # gptme exits 0 on success; non-zero indicates an error (not just "no findings")
+    if result.returncode not in (0, 1):
+        stderr_snip = result.stderr[:1_000] if result.stderr else "(no stderr)"
+        raise RuntimeError(
+            f"gptme exited with code {result.returncode}:\n{stderr_snip}"
+        )
+    return result.stdout
+
+
+def run_review(
+    checkout: Path,
+    target: LocalReviewTarget,
+    diff: str,
+    *,
+    model: str | None = None,
+    output_path: Path | None = None,
+) -> ReviewArtifact:
+    """Run a local review and return the validated ReviewArtifact.
+
+    Args:
+        checkout: Path to the repository root (used for repo instructions and gptme cwd).
+        target: Resolved LocalReviewTarget (from resolve_local_target).
+        diff: Unified diff text to review.
+        model: gptme model spec (e.g. "anthropic/claude-sonnet-4-6"). If None,
+               gptme uses its configured default.
+        output_path: If set, write the artifact JSON here before returning.
+
+    Returns:
+        Validated ReviewArtifact. Findings start in needs_validation disposition;
+        the Phase 2 publication path confirms or drops them before posting.
+    """
+    started_at = datetime.now(timezone.utc)
+
+    repo_instructions = read_repo_instructions(checkout)
+    prompt = _build_prompt(diff, repo_instructions, target.description)
+    raw_output = _invoke_model(prompt, model, checkout)
+
+    completed_at = datetime.now(timezone.utc)
+
+    data = _extract_json(raw_output)
+
+    # Resolve identity anchor for fingerprinting
+    head_anchor = target.head_sha or target.diff_fingerprint or ""
+    repo_id = target.repo_name or target.checkout
+
+    findings: list[ReviewFinding] = []
+    for raw_f in data.get("findings", []):
+        fp = ReviewFinding.local_fingerprint(
+            repo=repo_id,
+            head_sha=head_anchor,
+            file_path=raw_f.get("file_path", ""),
+            title=raw_f.get("title", ""),
+            prompt_version=REVIEW_PROMPT_VERSION,
+        )
+        try:
+            severity = Severity(raw_f.get("severity", "medium"))
+        except ValueError:
+            severity = Severity.medium
+
+        finding = ReviewFinding(
+            id=fp,
+            category=raw_f.get("category", "correctness"),
+            severity=severity,
+            confidence=float(raw_f.get("confidence", 0.5)),
+            file_path=raw_f.get("file_path", ""),
+            line_range=str(raw_f.get("line_range", "1")),
+            title=raw_f.get("title", ""),
+            description=raw_f.get("description", ""),
+            evidence=raw_f.get("evidence", ""),
+            fix_hint=raw_f.get("fix_hint", ""),
+            disposition=Disposition.needs_validation,
+        )
+        findings.append(finding)
+
+    try:
+        merge_safety = MergeSafety(data.get("merge_safety", "unknown"))
+    except ValueError:
+        merge_safety = MergeSafety.unknown
+
+    artifact = ReviewArtifact(
+        target=target,
+        model=model or "default",
+        prompt_version=REVIEW_PROMPT_VERSION,
+        started_at=started_at,
+        completed_at=completed_at,
+        summary=data.get("summary", ""),
+        merge_safety=merge_safety,
+        findings=findings,
+        dry_run=True,
+    )
+
+    if output_path is not None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(artifact.model_dump_json(indent=2), encoding="utf-8")
+
+    return artifact

--- a/packages/gptme-runloops/src/gptme_runloops/pr_review/reviewer.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pr_review/reviewer.py
@@ -302,8 +302,14 @@ def run_review(
     head_anchor = target.head_sha or target.diff_fingerprint or ""
     repo_id = target.repo_name or target.checkout
 
+    raw_findings = data.get("findings", [])
+    if not isinstance(raw_findings, list):
+        raise ValueError("findings must be a list")
+
     findings: list[ReviewFinding] = []
-    for raw_f in data.get("findings", []):
+    for raw_f in raw_findings:
+        if not isinstance(raw_f, dict):
+            raise ValueError("each finding must be an object")
         fp = ReviewFinding.local_fingerprint(
             repo=repo_id,
             head_sha=head_anchor,

--- a/packages/gptme-runloops/src/gptme_runloops/pr_review/schema.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pr_review/schema.py
@@ -6,6 +6,8 @@ ReviewArtifact; the renderer decides how to publish it.
 Version history:
   v1 (2026-08-03): initial schema — target identity, run metadata, findings,
                    fingerprints, merge safety verdict.
+  v1 (2026-08-03): added LocalReviewTarget for working-tree and commit-range
+                   reviews that require no forge access (Phase 1).
 """
 
 from __future__ import annotations
@@ -14,9 +16,9 @@ import hashlib
 import json
 from datetime import datetime
 from enum import Enum
-from typing import Literal
+from typing import Annotated, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Discriminator, Field, Tag
 
 SCHEMA_VERSION = "v1"
 
@@ -43,16 +45,60 @@ class MergeSafety(str, Enum):
 
 
 class ReviewTarget(BaseModel):
-    """Immutable identity of the PR being reviewed.
+    """Immutable identity of a hosted PR being reviewed.
 
     Binding reviews to exact base/head SHAs prevents stale-head publication.
     """
 
+    kind: Literal["hosted"] = "hosted"
     forge: Literal["github", "forgejo"] = "github"
     repo: str  # e.g. "gptme/gptme-contrib"
     pr_number: int
     base_sha: str
     head_sha: str
+
+
+class LocalReviewTarget(BaseModel):
+    """Target for a local-only review — no forge access required.
+
+    Used for working-tree reviews (in-session, before a PR exists) and for
+    reviewing an explicit committed commit range locally.
+
+    Committed/range reviews bind to immutable base/head SHAs.
+    Working-tree reviews record the base SHA plus a deterministic diff fingerprint
+    (since pretending an uncommitted head is immutable would be wrong).
+    """
+
+    kind: Literal["local"] = "local"
+    checkout: str  # Absolute path to the repository root
+    repo_name: str = ""  # e.g. "gptme/gptme-contrib" — for display; may be empty
+    base_sha: str  # Always resolved; working-tree reviews use HEAD
+    head_sha: str | None = None  # None for working-tree reviews
+    diff_fingerprint: str = ""  # SHA256[:16] of diff bytes (working-tree only)
+
+    @property
+    def description(self) -> str:
+        name = self.repo_name or self.checkout
+        if self.head_sha:
+            return f"{name} {self.base_sha[:8]}..{self.head_sha[:8]}"
+        return f"{name} working-tree@{self.base_sha[:8]} (fingerprint:{self.diff_fingerprint})"
+
+
+def _discriminate_target(v: object) -> str:
+    """Return the discriminator tag for Union[ReviewTarget, LocalReviewTarget].
+
+    Existing artifacts without an explicit 'kind' default to 'hosted' for
+    backward compatibility with Phase 0 artifacts.
+    """
+    if isinstance(v, dict):
+        return str(v.get("kind", "hosted"))
+    return str(getattr(v, "kind", "hosted"))
+
+
+AnyReviewTarget = Annotated[
+    Annotated[ReviewTarget, Tag("hosted")] | Annotated[LocalReviewTarget, Tag("local")],
+    Discriminator(_discriminate_target),
+]
 
 
 class ReviewFinding(BaseModel):
@@ -63,7 +109,9 @@ class ReviewFinding(BaseModel):
     """
 
     # Identity
-    id: str = Field(description="Stable fingerprint (see FindingFingerprint)")
+    id: str = Field(
+        description="Stable fingerprint (see fingerprint / local_fingerprint)"
+    )
 
     # Classification
     category: str = Field(description="e.g. correctness, security, test-coverage")
@@ -99,7 +147,7 @@ class ReviewFinding(BaseModel):
         title: str,
         prompt_version: str,
     ) -> str:
-        """Stable, content-addressed fingerprint for deduplication.
+        """Stable fingerprint for a hosted-PR finding.
 
         Same finding on the same head SHA + prompt version always produces the
         same fingerprint, so re-runs cannot post duplicate comments.
@@ -108,6 +156,33 @@ class ReviewFinding(BaseModel):
             {
                 "repo": repo,
                 "pr": pr_number,
+                "head": head_sha,
+                "file": file_path,
+                "title": title,
+                "prompt": prompt_version,
+            },
+            sort_keys=True,
+        )
+        return hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+    @classmethod
+    def local_fingerprint(
+        cls,
+        *,
+        repo: str,
+        head_sha: str,
+        file_path: str,
+        title: str,
+        prompt_version: str,
+    ) -> str:
+        """Stable fingerprint for a local-review finding (no PR number).
+
+        Uses the diff fingerprint (for working-tree) or the head SHA (for
+        range reviews) as the immutable identity anchor.
+        """
+        payload = json.dumps(
+            {
+                "repo": repo,
                 "head": head_sha,
                 "file": file_path,
                 "title": title,
@@ -135,12 +210,15 @@ class ReviewArtifact(BaseModel):
 
     The analysis core produces this; the adapter (GitHub / Forgejo publisher)
     reads it. The core must not call forge APIs directly.
+
+    Supports both hosted-PR targets (ReviewTarget) and local-only targets
+    (LocalReviewTarget) via a discriminated union.
     """
 
     schema_version: str = SCHEMA_VERSION
 
-    # Immutable identity
-    target: ReviewTarget
+    # Immutable identity — hosted PR or local working-tree/range
+    target: AnyReviewTarget
 
     # Run provenance
     model: str
@@ -167,4 +245,9 @@ class ReviewArtifact(BaseModel):
     def token_id(self) -> str:
         """Short readable identity for log messages."""
         t = self.target
-        return f"{t.repo}#{t.pr_number}@{t.head_sha[:8]}"
+        if isinstance(t, ReviewTarget):
+            return f"{t.repo}#{t.pr_number}@{t.head_sha[:8]}"
+        # LocalReviewTarget
+        name = t.repo_name or t.checkout.split("/")[-1]
+        head = (t.head_sha or t.diff_fingerprint or "")[:8]
+        return f"{name}@{head}"

--- a/packages/gptme-runloops/tests/test_pr_review.py
+++ b/packages/gptme-runloops/tests/test_pr_review.py
@@ -1,16 +1,19 @@
-"""Tests for the pr_review schema and corpus module (Phase 0)."""
+"""Tests for the pr_review schema and corpus module (Phase 0 + Phase 1)."""
 
 import json
+import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 
 from gptme_runloops.pr_review import (
     Disposition,
+    LocalReviewTarget,
     MergeSafety,
     ReviewArtifact,
     ReviewFinding,
     ReviewTarget,
     Severity,
+    resolve_local_target,
 )
 from gptme_runloops.pr_review.corpus import (
     CorpusEntry,
@@ -18,6 +21,12 @@ from gptme_runloops.pr_review.corpus import (
     GroundTruthFinding,
     load_corpus,
     score_model,
+)
+from gptme_runloops.pr_review.reviewer import (
+    _build_prompt,
+    _diff_fingerprint,
+    _extract_json,
+    read_repo_instructions,
 )
 from gptme_runloops.pr_review.schema import SCHEMA_VERSION
 
@@ -425,3 +434,286 @@ class TestLoadCorpus:
         assert "corpus_version" in raw
         assert "entries" in raw
         assert raw["corpus_version"] == "v1"
+
+
+# ── Phase 1: LocalReviewTarget, local_fingerprint, reviewer helpers ───────────
+
+
+class TestLocalReviewTarget:
+    def test_description_range(self):
+        t = LocalReviewTarget(
+            checkout="/repo",
+            repo_name="org/repo",
+            base_sha="aabbccdd",
+            head_sha="11223344",
+        )
+        assert "aabbccdd" in t.description
+        assert "11223344" in t.description
+        assert "org/repo" in t.description
+
+    def test_description_working_tree(self):
+        t = LocalReviewTarget(
+            checkout="/repo",
+            repo_name="org/repo",
+            base_sha="aabbccdd",
+            head_sha=None,
+            diff_fingerprint="fp16chars12345",
+        )
+        assert "working-tree" in t.description
+        assert "fp16chars12345" in t.description
+
+    def test_kind_default(self):
+        t = LocalReviewTarget(checkout="/repo", base_sha="abc")
+        assert t.kind == "local"
+
+    def test_roundtrip_json(self):
+        t = LocalReviewTarget(
+            checkout="/repo",
+            repo_name="org/repo",
+            base_sha="abc",
+            head_sha="def",
+        )
+        dumped = t.model_dump_json()
+        loaded = LocalReviewTarget.model_validate_json(dumped)
+        assert loaded.repo_name == "org/repo"
+        assert loaded.head_sha == "def"
+
+
+class TestLocalFingerprintVsHostedFingerprint:
+    def test_local_fingerprint_stable(self):
+        fp1 = ReviewFinding.local_fingerprint(
+            repo="org/repo",
+            head_sha="abc123",
+            file_path="src/foo.py",
+            title="Null deref",
+            prompt_version="v1",
+        )
+        fp2 = ReviewFinding.local_fingerprint(
+            repo="org/repo",
+            head_sha="abc123",
+            file_path="src/foo.py",
+            title="Null deref",
+            prompt_version="v1",
+        )
+        assert fp1 == fp2
+
+    def test_local_fingerprint_differs_from_hosted(self):
+        local_fp = ReviewFinding.local_fingerprint(
+            repo="org/repo",
+            head_sha="abc123",
+            file_path="src/foo.py",
+            title="T",
+            prompt_version="v1",
+        )
+        hosted_fp = ReviewFinding.fingerprint(
+            repo="org/repo",
+            pr_number=42,
+            head_sha="abc123",
+            file_path="src/foo.py",
+            title="T",
+            prompt_version="v1",
+        )
+        assert local_fp != hosted_fp
+
+    def test_local_fingerprint_length(self):
+        fp = ReviewFinding.local_fingerprint(
+            repo="r", head_sha="h", file_path="f", title="t", prompt_version="v1"
+        )
+        assert len(fp) == 16
+
+
+class TestReviewArtifactDiscriminatedUnion:
+    def test_hosted_target_roundtrip(self):
+        a = ReviewArtifact(
+            target=ReviewTarget(
+                repo="org/repo",
+                pr_number=7,
+                base_sha="base",
+                head_sha="head",
+            ),
+            model="test",
+            prompt_version="v1",
+            started_at=datetime.now(tz=timezone.utc),
+            completed_at=datetime.now(tz=timezone.utc),
+            summary="ok",
+            merge_safety=MergeSafety.safe,
+        )
+        raw = a.model_dump_json()
+        loaded = ReviewArtifact.model_validate_json(raw)
+        assert isinstance(loaded.target, ReviewTarget)
+        assert loaded.target.pr_number == 7
+
+    def test_local_target_roundtrip(self):
+        a = ReviewArtifact(
+            target=LocalReviewTarget(
+                checkout="/repo",
+                repo_name="org/repo",
+                base_sha="abc",
+                head_sha=None,
+                diff_fingerprint="fp1234567890abcd",
+            ),
+            model="test",
+            prompt_version="v1",
+            started_at=datetime.now(tz=timezone.utc),
+            completed_at=datetime.now(tz=timezone.utc),
+            summary="Local review",
+            merge_safety=MergeSafety.needs_review,
+        )
+        raw = a.model_dump_json()
+        loaded = ReviewArtifact.model_validate_json(raw)
+        assert isinstance(loaded.target, LocalReviewTarget)
+        assert loaded.target.diff_fingerprint == "fp1234567890abcd"
+
+    def test_token_id_local(self):
+        a = ReviewArtifact(
+            target=LocalReviewTarget(
+                checkout="/home/bob/bob",
+                repo_name="org/repo",
+                base_sha="aabbccdd",
+                head_sha="11223344",
+            ),
+            model="test",
+            prompt_version="v1",
+            started_at=datetime.now(tz=timezone.utc),
+            completed_at=datetime.now(tz=timezone.utc),
+            summary="ok",
+            merge_safety=MergeSafety.safe,
+        )
+        assert "org/repo@11223344" == a.token_id
+
+
+class TestDiffFingerprint:
+    def test_stable(self):
+        assert _diff_fingerprint("abc\n") == _diff_fingerprint("abc\n")
+
+    def test_differs_on_content(self):
+        assert _diff_fingerprint("abc\n") != _diff_fingerprint("def\n")
+
+    def test_length(self):
+        assert len(_diff_fingerprint("x")) == 16
+
+
+class TestExtractJson:
+    def test_direct_json(self):
+        raw = '{"summary": "ok", "merge_safety": "safe", "findings": []}'
+        result = _extract_json(raw)
+        assert result["summary"] == "ok"
+
+    def test_json_in_prose(self):
+        raw = 'Here is my review:\n{"summary": "ok", "merge_safety": "safe", "findings": []}\nDone.'
+        result = _extract_json(raw)
+        assert result["merge_safety"] == "safe"
+
+    def test_json_in_code_fence(self):
+        raw = '```json\n{"summary": "ok", "merge_safety": "safe", "findings": []}\n```'
+        result = _extract_json(raw)
+        assert result["findings"] == []
+
+    def test_raises_on_no_json(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="No valid JSON"):
+            _extract_json("This is not JSON at all.")
+
+
+class TestBuildPrompt:
+    def test_contains_instructions(self):
+        prompt = _build_prompt("diff content", "", "repo@abc")
+        assert "merge_safety" in prompt
+        assert "diff content" in prompt
+
+    def test_contains_repo_instructions(self):
+        prompt = _build_prompt("diff", "# AGENTS.md\n\nBe careful.", "repo@abc")
+        assert "AGENTS.md" in prompt
+
+    def test_truncates_large_diff(self):
+        big_diff = "x" * 100_000
+        prompt = _build_prompt(big_diff, "", "repo@abc")
+        assert "TRUNCATED" in prompt
+        assert len(prompt) < 120_000  # well within reason
+
+    def test_no_truncation_small_diff(self):
+        small_diff = "- old\n+ new\n"
+        prompt = _build_prompt(small_diff, "", "repo@abc")
+        assert "TRUNCATED" not in prompt
+
+
+class TestReadRepoInstructions:
+    def test_reads_agents_md(self, tmp_path):
+        (tmp_path / "AGENTS.md").write_text("# Instructions\nBe careful.")
+        result = read_repo_instructions(tmp_path)
+        assert "Be careful." in result
+        assert "AGENTS.md" in result
+
+    def test_returns_empty_when_none(self, tmp_path):
+        result = read_repo_instructions(tmp_path)
+        assert result == ""
+
+    def test_truncates_long_file(self, tmp_path):
+        (tmp_path / "AGENTS.md").write_text("x" * 10_000)
+        result = read_repo_instructions(tmp_path)
+        assert "truncated" in result
+        assert len(result) < 12_000
+
+
+class TestResolveLocalTarget:
+    def _git(self, path: Path, *args: str, **extra_env: str) -> None:
+        env = {**__import__("os").environ, "ALLOW_GIT_IDENTITY": "1", **extra_env}
+        subprocess.run(
+            ["git", *args], cwd=path, check=True, capture_output=True, env=env
+        )
+
+    def _init_git_repo(self, path: Path) -> None:
+        self._git(path, "init")
+        self._git(path, "config", "user.email", "test@test.com")
+        self._git(path, "config", "user.name", "Test")
+        (path / "README.md").write_text("# Repo\n")
+        self._git(path, "add", ".")
+        self._git(path, "commit", "-m", "init", "--no-verify")
+
+    def test_working_tree(self, tmp_path):
+        self._init_git_repo(tmp_path)
+        (tmp_path / "new_file.py").write_text("x = 1\n")
+        self._git(tmp_path, "add", ".")
+
+        target, diff = resolve_local_target(tmp_path, working_tree=True)
+        assert target.kind == "local"
+        assert target.head_sha is None
+        assert target.diff_fingerprint != ""
+        assert "new_file.py" in diff
+
+    def test_range(self, tmp_path):
+        self._init_git_repo(tmp_path)
+        base_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+
+        (tmp_path / "change.py").write_text("def foo(): pass\n")
+        self._git(tmp_path, "add", ".")
+        self._git(tmp_path, "commit", "-m", "add change", "--no-verify")
+        head_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+
+        target, diff = resolve_local_target(
+            tmp_path, base_sha=base_sha, head_sha=head_sha
+        )
+        assert target.kind == "local"
+        assert target.head_sha == head_sha
+        assert target.base_sha == base_sha
+        assert "change.py" in diff
+
+    def test_raises_without_args(self, tmp_path):
+        self._init_git_repo(tmp_path)
+        import pytest
+
+        with pytest.raises(ValueError, match="Specify"):
+            resolve_local_target(tmp_path)

--- a/packages/gptme-runloops/tests/test_pr_review.py
+++ b/packages/gptme-runloops/tests/test_pr_review.py
@@ -772,6 +772,8 @@ class TestReviewCliExitStatus:
         [
             "not JSON",
             '{"merge_safety":"safe","findings":[{"confidence":"high"}]}',
+            '{"merge_safety":"safe","findings":[42]}',
+            '{"merge_safety":"safe","findings":{}}',
         ],
     )
     def test_invalid_response_is_controlled_cli_error(self, tmp_path, response):

--- a/packages/gptme-runloops/tests/test_pr_review.py
+++ b/packages/gptme-runloops/tests/test_pr_review.py
@@ -4,7 +4,11 @@ import json
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
+from unittest.mock import patch
 
+import pytest
+from click.testing import CliRunner
+from gptme_runloops.cli import main as cli_main
 from gptme_runloops.pr_review import (
     Disposition,
     LocalReviewTarget,
@@ -713,7 +717,84 @@ class TestResolveLocalTarget:
 
     def test_raises_without_args(self, tmp_path):
         self._init_git_repo(tmp_path)
-        import pytest
 
         with pytest.raises(ValueError, match="Specify"):
             resolve_local_target(tmp_path)
+
+
+class TestReviewCliExitStatus:
+    @pytest.mark.parametrize(
+        ("merge_safety", "expected_exit_code"),
+        [
+            (MergeSafety.safe, 0),
+            (MergeSafety.unsafe, 1),
+            (MergeSafety.needs_review, 1),
+            (MergeSafety.unknown, 1),
+        ],
+    )
+    def test_only_safe_verdict_exits_zero(
+        self, tmp_path, merge_safety, expected_exit_code
+    ):
+        target = LocalReviewTarget(
+            checkout=str(tmp_path),
+            base_sha="a" * 40,
+            diff_fingerprint="b" * 16,
+        )
+        artifact = ReviewArtifact(
+            target=target,
+            model="test",
+            prompt_version="v1",
+            started_at=datetime.now(tz=timezone.utc),
+            completed_at=datetime.now(tz=timezone.utc),
+            summary="review",
+            merge_safety=merge_safety,
+        )
+
+        with (
+            patch(
+                "gptme_runloops.pr_review.reviewer.resolve_local_target",
+                return_value=(target, "+new line"),
+            ),
+            patch(
+                "gptme_runloops.pr_review.reviewer.run_review",
+                return_value=artifact,
+            ),
+        ):
+            result = CliRunner().invoke(
+                cli_main,
+                ["review", "--checkout", str(tmp_path), "--working-tree"],
+            )
+
+        assert result.exit_code == expected_exit_code
+
+    @pytest.mark.parametrize(
+        "response",
+        [
+            "not JSON",
+            '{"merge_safety":"safe","findings":[{"confidence":"high"}]}',
+        ],
+    )
+    def test_invalid_response_is_controlled_cli_error(self, tmp_path, response):
+        target = LocalReviewTarget(
+            checkout=str(tmp_path),
+            base_sha="a" * 40,
+            diff_fingerprint="b" * 16,
+        )
+        with (
+            patch(
+                "gptme_runloops.pr_review.reviewer.resolve_local_target",
+                return_value=(target, "+new line"),
+            ),
+            patch(
+                "gptme_runloops.pr_review.reviewer._invoke_model",
+                return_value=response,
+            ),
+        ):
+            result = CliRunner().invoke(
+                cli_main,
+                ["review", "--checkout", str(tmp_path), "--working-tree"],
+            )
+
+        assert result.exit_code == 1
+        assert "Error: Invalid review response:" in result.output
+        assert not isinstance(result.exception, TypeError | ValueError)


### PR DESCRIPTION
## Summary

Phase 1 of the self-hosted PR reviewer (ErikBjare/bob#1122). Adds a local-first review surface with no forge API calls required.

- **`LocalReviewTarget`** — new schema type for working-tree and commit-range reviews (no PR, no forge access). Backward-compatible discriminated union `AnyReviewTarget` preserves the Phase 0 `ReviewTarget` shape.
- **`reviewer.py`** — core runner: `resolve_local_target()` + `run_review()`. Gets diff, reads repo instructions (AGENTS.md/CLAUDE.md), builds prompt, calls `gptme --tools none`, parses JSON findings into a validated `ReviewArtifact`.
- **`gptme-runloops review` CLI command** — `--working-tree` for in-session review before a PR exists, `--base/--head` for a committed range. Exits 1 on `merge_safety=unsafe`.
- 50 passing tests, mypy clean.

## Usage

```bash
# Review uncommitted working-tree changes (in-session, before a PR):
gptme-runloops review --working-tree

# Review a specific commit range:
gptme-runloops review --base abc123 --head def456

# Write the artifact to a file:
gptme-runloops review --working-tree --output /tmp/review.json

# Use a specific model:
gptme-runloops review --working-tree --model anthropic/claude-sonnet-4-6
```

Follows Phase 0 (schema + corpus, gptme-contrib#1355, merged) and implements the local-first design doc Erik acked in ErikBjare/bob#1122.

Phase 2 (GitHub publisher + PM integration) is separate.

## Test plan

- [ ] `uv run pytest packages/gptme-runloops/tests/test_pr_review.py` — 50 tests pass
- [ ] `uv run mypy packages/gptme-runloops/src` — no errors
- [ ] Manual: `gptme-runloops review --working-tree` in a repo with pending changes