### PR TITLE
feat(runloops): pr_review Phase 2 — GitHub adapter with idempotent inline comment publication

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/cli.py
+++ b/packages/gptme-runloops/src/gptme_runloops/cli.py
@@ -1,6 +1,7 @@
 """Command-line interface for run loops."""
 
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -505,6 +506,126 @@ def review(
         err=True,
     )
     # Fail closed: automation must only continue after an explicit safe verdict.
+    if artifact.merge_safety != MergeSafety.safe:
+        sys.exit(1)
+
+
+@main.command("review-pr")
+@click.argument("pr_ref")
+@click.option(
+    "--shadow/--publish",
+    default=True,
+    help="Shadow mode (default): run review but do not post GitHub comments. "
+    "--publish posts findings as inline PR review comments.",
+)
+@click.option(
+    "--output",
+    "output_path",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Write ReviewArtifact JSON to this path (default: print to stdout).",
+)
+@click.option(
+    "--model",
+    default=None,
+    help="gptme model spec (e.g. 'anthropic/claude-sonnet-4-6'). "
+    "Defaults to gptme's configured model.",
+)
+@click.option(
+    "--checkout",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=None,
+    help="Local checkout of the repository, used to read AGENTS.md/CLAUDE.md "
+    "for reviewer context. Optional.",
+)
+@click.option(
+    "--min-confidence",
+    type=float,
+    default=0.6,
+    show_default=True,
+    help="Skip findings below this confidence threshold when publishing.",
+)
+def review_pr(
+    pr_ref: str,
+    shadow: bool,
+    output_path: Path | None,
+    model: str | None,
+    checkout: Path | None,
+    min_confidence: float,
+) -> None:
+    """Review a GitHub pull request and optionally post findings as inline comments.
+
+    PR_REF must be in the form OWNER/REPO#NUM, e.g. ``gptme/gptme-contrib#42``.
+
+    Phase 2: GitHub-backed review with idempotent inline comment publication.
+
+    Examples:
+
+      # Shadow run — review without posting (safe to run on any PR):
+      gptme-runloops review-pr gptme/gptme-contrib#42
+
+      # Publish findings as inline PR comments:
+      gptme-runloops review-pr gptme/gptme-contrib#42 --publish
+
+      # Shadow run, save artifact:
+      gptme-runloops review-pr gptme/gptme-contrib#42 --output /tmp/review.json
+
+      # Use a local checkout for AGENTS.md context:
+      gptme-runloops review-pr gptme/gptme-contrib#42 --checkout /path/to/checkout
+
+      # Use a specific model:
+      gptme-runloops review-pr gptme/gptme-contrib#42 --model anthropic/claude-sonnet-4-6
+    """
+    # Parse OWNER/REPO#NUM
+    m = re.match(r"^([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)#(\d+)$", pr_ref)
+    if not m:
+        raise click.UsageError(
+            f"Invalid PR reference '{pr_ref}'. Expected format: OWNER/REPO#NUM "
+            "(e.g. gptme/gptme-contrib#42)."
+        )
+    repo = m.group(1)
+    pr_number = int(m.group(2))
+
+    from gptme_runloops.pr_review.github_adapter import run_github_review
+
+    mode_label = "shadow" if shadow else "publish"
+    click.echo(f"Reviewing {repo}#{pr_number} ({mode_label} mode) …", err=True)
+
+    try:
+        artifact, posted, skipped = run_github_review(
+            repo,
+            pr_number,
+            model=model,
+            checkout=checkout,
+            shadow=shadow,
+            output_path=output_path,
+            min_confidence=min_confidence,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise click.ClickException(
+            f"GitHub CLI command failed: {exc.stderr.strip() if exc.stderr else exc}"
+        ) from exc
+    except (RuntimeError, TypeError, ValueError) as exc:
+        raise click.ClickException(f"Review failed: {exc}") from exc
+
+    if output_path:
+        click.echo(f"Artifact written to {output_path}", err=True)
+    else:
+        click.echo(artifact.model_dump_json(indent=2))
+
+    n = len(artifact.findings)
+    if shadow:
+        click.echo(
+            f"Review complete (shadow) — {n} finding(s), merge_safety={artifact.merge_safety.value}",
+            err=True,
+        )
+    else:
+        click.echo(
+            f"Review complete — {n} finding(s), {posted} posted, {skipped} skipped, "
+            f"merge_safety={artifact.merge_safety.value}",
+            err=True,
+        )
+
     if artifact.merge_safety != MergeSafety.safe:
         sys.exit(1)
 

--- a/packages/gptme-runloops/src/gptme_runloops/pr_review/github_adapter.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pr_review/github_adapter.py
@@ -286,28 +286,27 @@ def post_inline_finding(
     owner, name = repo.split("/", 1)
     body = _build_inline_comment_body(finding)
 
-    # Iterate every line in the reported range, trying RIGHT then LEFT at each
-    # position. The first line may fall outside the GitHub diff window when the
-    # finding spans context lines not part of any hunk; later lines in the range
-    # are more likely to be postable anchors.
+    # Iterate every line in the reported range on the model-selected diff side.
+    # Trying the opposite side is unsafe: the same numeric line can exist on both
+    # sides while referring to unrelated code. Later lines in a range remain safe
+    # fallback anchors because they preserve the finding's declared side.
     last_error: subprocess.CalledProcessError | None = None
     for line in _iter_range_lines(finding.line_range):
-        for side in ("RIGHT", "LEFT"):
-            try:
-                data = _gh_api(
-                    f"/repos/{owner}/{name}/pulls/{pr_number}/comments",
-                    method="POST",
-                    fields={
-                        "body": body,
-                        "commit_id": head_sha,
-                        "path": finding.file_path,
-                        "line": line,
-                        "side": side,
-                    },
-                )
-                return str(data.get("id", ""))
-            except subprocess.CalledProcessError as exc:
-                last_error = exc
+        try:
+            data = _gh_api(
+                f"/repos/{owner}/{name}/pulls/{pr_number}/comments",
+                method="POST",
+                fields={
+                    "body": body,
+                    "commit_id": head_sha,
+                    "path": finding.file_path,
+                    "line": line,
+                    "side": finding.line_side,
+                },
+            )
+            return str(data.get("id", ""))
+        except subprocess.CalledProcessError as exc:
+            last_error = exc
     raise last_error  # type: ignore[misc]  # unreachable when loop body always sets it
 
 

--- a/packages/gptme-runloops/src/gptme_runloops/pr_review/github_adapter.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pr_review/github_adapter.py
@@ -60,7 +60,11 @@ def _gh(*args: str, repo: str | None = None) -> str:
 
 
 def _gh_api(
-    path: str, *, method: str = "GET", fields: dict[str, Any] | None = None
+    path: str,
+    *,
+    method: str = "GET",
+    fields: dict[str, Any] | None = None,
+    paginate: bool = False,
 ) -> Any:
     """Call the GitHub REST API via ``gh api`` and return parsed JSON.
 
@@ -68,8 +72,13 @@ def _gh_api(
         path: API path, e.g. ``/repos/owner/repo/pulls/1/comments``.
         method: HTTP method (GET, POST, PATCH, …).
         fields: Fields to pass as ``-f key=value`` or ``-F key=value``.
+        paginate: If True, follow GitHub pagination and return all results
+                  concatenated into a single list (list endpoints only).
     """
-    cmd = ["gh", "api", "--method", method, path]
+    cmd = ["gh", "api", "--method", method]
+    if paginate:
+        cmd.append("--paginate")
+    cmd.append(path)
     if fields:
         for k, v in fields.items():
             # Use -F for values that should stay as native types (int, bool)
@@ -78,7 +87,21 @@ def _gh_api(
             else:
                 cmd.extend(["-f", f"{k}={v}"])
     result = subprocess.run(cmd, capture_output=True, text=True, check=True)
-    return json.loads(result.stdout)
+    if not paginate:
+        return json.loads(result.stdout)
+    # gh api --paginate prints each page as a separate JSON document (one per line).
+    # For list endpoints each page is a JSON array; concatenate them all.
+    all_items: list[Any] = []
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        page = json.loads(line)
+        if isinstance(page, list):
+            all_items.extend(page)
+        else:
+            all_items.append(page)
+    return all_items
 
 
 def fetch_pr_metadata(repo: str, pr_number: int) -> dict[str, str]:
@@ -144,7 +167,7 @@ def get_posted_fingerprints(repo: str, pr_number: int) -> set[str]:
         Set of fingerprint ID strings that are already posted.
     """
     owner, name = repo.split("/", 1)
-    raw = _gh_api(f"/repos/{owner}/{name}/pulls/{pr_number}/comments")
+    raw = _gh_api(f"/repos/{owner}/{name}/pulls/{pr_number}/comments", paginate=True)
     if not isinstance(raw, list):
         return set()
 
@@ -261,18 +284,26 @@ def post_inline_finding(
     body = _build_inline_comment_body(finding)
     line = _parse_first_line(finding.line_range)
 
-    data = _gh_api(
-        f"/repos/{owner}/{name}/pulls/{pr_number}/comments",
-        method="POST",
-        fields={
-            "body": body,
-            "commit_id": head_sha,
-            "path": finding.file_path,
-            "line": line,
-            "side": "RIGHT",
-        },
-    )
-    return str(data.get("id", ""))
+    # Try RIGHT (added/context lines) first; fall back to LEFT (deleted lines).
+    # GitHub rejects a RIGHT anchor on a deletion-only line and vice versa.
+    last_error: subprocess.CalledProcessError | None = None
+    for side in ("RIGHT", "LEFT"):
+        try:
+            data = _gh_api(
+                f"/repos/{owner}/{name}/pulls/{pr_number}/comments",
+                method="POST",
+                fields={
+                    "body": body,
+                    "commit_id": head_sha,
+                    "path": finding.file_path,
+                    "line": line,
+                    "side": side,
+                },
+            )
+            return str(data.get("id", ""))
+        except subprocess.CalledProcessError as exc:
+            last_error = exc
+    raise last_error  # type: ignore[misc]  # unreachable when loop body always sets it
 
 
 def post_summary_comment(

--- a/packages/gptme-runloops/src/gptme_runloops/pr_review/github_adapter.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pr_review/github_adapter.py
@@ -180,12 +180,15 @@ def get_posted_fingerprints(repo: str, pr_number: int) -> set[str]:
     return found
 
 
-def _parse_first_line(line_range: str) -> int:
-    """Extract the first line number from a range string like '42' or '42-49'."""
+def _iter_range_lines(line_range: str):
+    """Yield each line number in a range string like '42' or '42-49'."""
+    parts = line_range.split("-")
     try:
-        return int(line_range.split("-")[0])
+        start = int(parts[0])
+        end = int(parts[1]) if len(parts) > 1 else start
     except (ValueError, IndexError):
-        return 1
+        start, end = 1, 1
+    yield from range(start, end + 1)
 
 
 def _severity_label(severity: Severity) -> str:
@@ -282,27 +285,29 @@ def post_inline_finding(
     """
     owner, name = repo.split("/", 1)
     body = _build_inline_comment_body(finding)
-    line = _parse_first_line(finding.line_range)
 
-    # Try RIGHT (added/context lines) first; fall back to LEFT (deleted lines).
-    # GitHub rejects a RIGHT anchor on a deletion-only line and vice versa.
+    # Iterate every line in the reported range, trying RIGHT then LEFT at each
+    # position. The first line may fall outside the GitHub diff window when the
+    # finding spans context lines not part of any hunk; later lines in the range
+    # are more likely to be postable anchors.
     last_error: subprocess.CalledProcessError | None = None
-    for side in ("RIGHT", "LEFT"):
-        try:
-            data = _gh_api(
-                f"/repos/{owner}/{name}/pulls/{pr_number}/comments",
-                method="POST",
-                fields={
-                    "body": body,
-                    "commit_id": head_sha,
-                    "path": finding.file_path,
-                    "line": line,
-                    "side": side,
-                },
-            )
-            return str(data.get("id", ""))
-        except subprocess.CalledProcessError as exc:
-            last_error = exc
+    for line in _iter_range_lines(finding.line_range):
+        for side in ("RIGHT", "LEFT"):
+            try:
+                data = _gh_api(
+                    f"/repos/{owner}/{name}/pulls/{pr_number}/comments",
+                    method="POST",
+                    fields={
+                        "body": body,
+                        "commit_id": head_sha,
+                        "path": finding.file_path,
+                        "line": line,
+                        "side": side,
+                    },
+                )
+                return str(data.get("id", ""))
+            except subprocess.CalledProcessError as exc:
+                last_error = exc
     raise last_error  # type: ignore[misc]  # unreachable when loop body always sets it
 
 

--- a/packages/gptme-runloops/src/gptme_runloops/pr_review/github_adapter.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pr_review/github_adapter.py
@@ -1,0 +1,416 @@
+"""GitHub adapter for the PR review system (Phase 2).
+
+Responsibilities:
+- Fetch PR metadata (base/head SHA) via ``gh pr view``.
+- Fetch PR diff via ``gh pr diff``.
+- Map to a ReviewTarget (hosted PR, forge=github).
+- Post review findings as inline PR comments with idempotency guard.
+- Shadow mode: run without publishing (default; safe to run on any PR).
+
+Design constraint: the review *core* (reviewer.py) is forge-neutral.
+This adapter is the ONLY module that may call ``gh`` CLI or the GitHub REST API.
+
+Idempotency:
+- Each finding's fingerprint is embedded as a hidden HTML comment in the body.
+- Before posting, existing PR comments are scanned for known fingerprints.
+- Findings already posted are skipped, making re-runs safe.
+
+Shadow mode (default):
+- The adapter fetches the diff and runs the review but does not post comments.
+- Output: a ReviewArtifact JSON file (via --output) or stdout.
+- Enable publication with --publish.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from .schema import (
+    Disposition,
+    ReviewArtifact,
+    ReviewFinding,
+    ReviewTarget,
+    Severity,
+)
+
+# Minimum confidence threshold — findings below this are skipped.
+_MIN_CONFIDENCE = 0.6
+
+# Fingerprint tag embedded as a hidden HTML comment.
+_FP_PREFIX = "<!-- pr-review-fp:"
+_FP_SUFFIX = " -->"
+
+
+def _gh(*args: str, repo: str | None = None) -> str:
+    """Run a ``gh`` CLI command and return stdout as text.
+
+    Raises:
+        subprocess.CalledProcessError: on non-zero exit.
+    """
+    cmd: list[str] = ["gh"]
+    if repo:
+        cmd.extend(["--repo", repo])
+    cmd.extend(args)
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    return result.stdout
+
+
+def _gh_api(
+    path: str, *, method: str = "GET", fields: dict[str, Any] | None = None
+) -> Any:
+    """Call the GitHub REST API via ``gh api`` and return parsed JSON.
+
+    Args:
+        path: API path, e.g. ``/repos/owner/repo/pulls/1/comments``.
+        method: HTTP method (GET, POST, PATCH, …).
+        fields: Fields to pass as ``-f key=value`` or ``-F key=value``.
+    """
+    cmd = ["gh", "api", "--method", method, path]
+    if fields:
+        for k, v in fields.items():
+            # Use -F for values that should stay as native types (int, bool)
+            if isinstance(v, int | bool):
+                cmd.extend(["-F", f"{k}={v}"])
+            else:
+                cmd.extend(["-f", f"{k}={v}"])
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    return json.loads(result.stdout)
+
+
+def fetch_pr_metadata(repo: str, pr_number: int) -> dict[str, str]:
+    """Fetch PR base/head SHAs from GitHub.
+
+    Args:
+        repo: ``OWNER/REPO`` string.
+        pr_number: Pull request number.
+
+    Returns:
+        Dict with keys ``base_sha`` and ``head_sha``.
+    """
+    raw = _gh(
+        "pr",
+        "view",
+        str(pr_number),
+        "--json",
+        "baseRefOid,headRefOid",
+        repo=repo,
+    )
+    data = json.loads(raw)
+    return {
+        "base_sha": data["baseRefOid"],
+        "head_sha": data["headRefOid"],
+    }
+
+
+def fetch_pr_diff(repo: str, pr_number: int) -> str:
+    """Fetch the unified diff for a pull request.
+
+    Args:
+        repo: ``OWNER/REPO`` string.
+        pr_number: Pull request number.
+
+    Returns:
+        Unified diff text.
+    """
+    return _gh("pr", "diff", str(pr_number), repo=repo)
+
+
+def build_review_target(
+    repo: str, pr_number: int, base_sha: str, head_sha: str
+) -> ReviewTarget:
+    """Build a forge-neutral ReviewTarget for a GitHub PR."""
+    return ReviewTarget(
+        kind="hosted",
+        forge="github",
+        repo=repo,
+        pr_number=pr_number,
+        base_sha=base_sha,
+        head_sha=head_sha,
+    )
+
+
+def get_posted_fingerprints(repo: str, pr_number: int) -> set[str]:
+    """Scan existing PR review comments for already-posted fingerprints.
+
+    Uses the fingerprint embedded as a hidden HTML comment to identify
+    findings that have already been published. This prevents duplicates
+    on re-runs of the same head SHA.
+
+    Returns:
+        Set of fingerprint ID strings that are already posted.
+    """
+    owner, name = repo.split("/", 1)
+    raw = _gh_api(f"/repos/{owner}/{name}/pulls/{pr_number}/comments")
+    if not isinstance(raw, list):
+        return set()
+
+    found: set[str] = set()
+    pattern = re.compile(re.escape(_FP_PREFIX) + r"(\w+)" + re.escape(_FP_SUFFIX))
+    for comment in raw:
+        body = comment.get("body", "")
+        for m in pattern.finditer(body):
+            found.add(m.group(1))
+    return found
+
+
+def _parse_first_line(line_range: str) -> int:
+    """Extract the first line number from a range string like '42' or '42-49'."""
+    try:
+        return int(line_range.split("-")[0])
+    except (ValueError, IndexError):
+        return 1
+
+
+def _severity_label(severity: Severity) -> str:
+    labels = {
+        Severity.critical: "🔴 CRITICAL",
+        Severity.high: "🟠 HIGH",
+        Severity.medium: "🟡 MEDIUM",
+        Severity.low: "🔵 LOW",
+        Severity.info: "ℹ️ INFO",
+    }
+    return labels.get(severity, severity.value.upper())
+
+
+def _build_inline_comment_body(finding: ReviewFinding) -> str:
+    """Format a finding as an inline PR comment with embedded fingerprint."""
+    lines = [
+        f"{_FP_PREFIX}{finding.id}{_FP_SUFFIX}",
+        f"**{_severity_label(finding.severity)}**: {finding.title}",
+        "",
+        finding.description,
+    ]
+    if finding.evidence:
+        lines += ["", "```", finding.evidence, "```"]
+    if finding.fix_hint:
+        lines += ["", f"**Suggested fix**: {finding.fix_hint}"]
+    lines += ["", "*Automated finding — self-hosted PR reviewer (Bob)*"]
+    return "\n".join(lines)
+
+
+def _build_summary_comment_body(
+    artifact: ReviewArtifact, posted_count: int, skipped_count: int
+) -> str:
+    """Build a top-level summary comment for the PR."""
+    n_total = len(artifact.findings)
+    n_by_severity: dict[str, int] = {}
+    for f in artifact.findings:
+        n_by_severity[f.severity.value] = n_by_severity.get(f.severity.value, 0) + 1
+
+    severity_line = ", ".join(
+        f"{count} {sev}"
+        for sev, count in sorted(
+            n_by_severity.items(),
+            key=lambda x: ["critical", "high", "medium", "low", "info"].index(x[0])
+            if x[0] in ["critical", "high", "medium", "low", "info"]
+            else 99,
+        )
+    )
+
+    lines = [
+        f"## PR Review — {artifact.merge_safety.value.replace('_', ' ').title()}",
+        "",
+        artifact.summary,
+        "",
+    ]
+
+    if n_total == 0:
+        lines.append("No findings.")
+    else:
+        lines.append(f"**{n_total} finding(s)**: {severity_line}")
+        if skipped_count > 0:
+            lines.append(
+                f"*{skipped_count} finding(s) skipped — already posted or below confidence threshold.*"
+            )
+        if posted_count > 0:
+            lines.append(f"*{posted_count} finding(s) posted as inline comments.*")
+
+    lines += [
+        "",
+        f"*Model: `{artifact.model}` · Prompt: `{artifact.prompt_version}`*",
+        "*Self-hosted PR reviewer (Bob) — Phase 2*",
+    ]
+    return "\n".join(lines)
+
+
+def post_inline_finding(
+    repo: str,
+    pr_number: int,
+    head_sha: str,
+    finding: ReviewFinding,
+) -> str:
+    """Post a single finding as an inline PR review comment.
+
+    Args:
+        repo: ``OWNER/REPO`` string.
+        pr_number: Pull request number.
+        head_sha: The PR's head commit SHA to bind the comment to.
+        finding: The finding to post.
+
+    Returns:
+        The GitHub comment ID (as string).
+
+    Raises:
+        subprocess.CalledProcessError: if the API call fails.
+    """
+    owner, name = repo.split("/", 1)
+    body = _build_inline_comment_body(finding)
+    line = _parse_first_line(finding.line_range)
+
+    data = _gh_api(
+        f"/repos/{owner}/{name}/pulls/{pr_number}/comments",
+        method="POST",
+        fields={
+            "body": body,
+            "commit_id": head_sha,
+            "path": finding.file_path,
+            "line": line,
+            "side": "RIGHT",
+        },
+    )
+    return str(data.get("id", ""))
+
+
+def post_summary_comment(
+    repo: str,
+    pr_number: int,
+    artifact: ReviewArtifact,
+    posted_count: int,
+    skipped_count: int,
+) -> str:
+    """Post a top-level summary comment on the PR.
+
+    Returns:
+        The GitHub comment ID (as string).
+    """
+    owner, name = repo.split("/", 1)
+    body = _build_summary_comment_body(artifact, posted_count, skipped_count)
+    data = _gh_api(
+        f"/repos/{owner}/{name}/issues/{pr_number}/comments",
+        method="POST",
+        fields={"body": body},
+    )
+    return str(data.get("id", ""))
+
+
+def publish_artifact(
+    artifact: ReviewArtifact,
+    *,
+    repo: str,
+    pr_number: int,
+    shadow: bool = True,
+    min_confidence: float = _MIN_CONFIDENCE,
+) -> tuple[int, int]:
+    """Publish review findings to a GitHub PR (or shadow-run without posting).
+
+    Args:
+        artifact: Completed ReviewArtifact from run_review().
+        repo: ``OWNER/REPO`` string.
+        pr_number: Pull request number.
+        shadow: If True (default), do not post anything to GitHub.
+        min_confidence: Skip findings below this confidence.
+
+    Returns:
+        (posted_count, skipped_count) — number of findings posted and skipped.
+    """
+    findings = [f for f in artifact.findings if f.confidence >= min_confidence]
+
+    if shadow:
+        # Shadow mode: return counts as if we would publish, but post nothing.
+        would_post = [f for f in findings if f.disposition != Disposition.dropped]
+        return len(would_post), len(artifact.findings) - len(would_post)
+
+    # Fetch the head SHA from the artifact target for the commit_id.
+    # Only ReviewTarget (hosted PR) has head_sha; LocalReviewTarget has head_sha
+    # as Optional. Both are handled below via the discriminated union.
+    target = artifact.target
+    if not isinstance(target, ReviewTarget) or not target.head_sha:
+        raise ValueError(
+            "publish_artifact requires a hosted ReviewTarget with a non-empty head_sha"
+        )
+    head_sha: str = target.head_sha
+
+    # Idempotency: scan already-posted fingerprints
+    already_posted = get_posted_fingerprints(repo, pr_number)
+
+    posted = 0
+    skipped = 0
+
+    for finding in findings:
+        if finding.disposition == Disposition.dropped:
+            skipped += 1
+            continue
+        if finding.id in already_posted:
+            skipped += 1
+            continue
+        try:
+            post_inline_finding(repo, pr_number, head_sha, finding)
+            posted += 1
+        except subprocess.CalledProcessError:
+            # Silently skip on individual comment failure (line may not be in diff)
+            skipped += 1
+
+    # Post summary comment only if we actually published something
+    if posted > 0:
+        post_summary_comment(repo, pr_number, artifact, posted, skipped)
+
+    return posted, skipped
+
+
+def run_github_review(
+    repo: str,
+    pr_number: int,
+    *,
+    model: str | None = None,
+    checkout: Path | None = None,
+    shadow: bool = True,
+    output_path: Path | None = None,
+    min_confidence: float = _MIN_CONFIDENCE,
+) -> tuple[ReviewArtifact, int, int]:
+    """End-to-end GitHub PR review: fetch → run → publish (or shadow).
+
+    Args:
+        repo: ``OWNER/REPO`` string.
+        pr_number: Pull request number.
+        model: gptme model spec. If None, uses gptme default.
+        checkout: Optional local repo checkout for AGENTS.md/CLAUDE.md context.
+        shadow: If True (default), do not post anything to GitHub.
+        output_path: If set, write artifact JSON here.
+        min_confidence: Skip findings below this threshold.
+
+    Returns:
+        (artifact, posted_count, skipped_count)
+    """
+    from .reviewer import run_review
+
+    meta = fetch_pr_metadata(repo, pr_number)
+    base_sha = meta["base_sha"]
+    head_sha = meta["head_sha"]
+
+    diff = fetch_pr_diff(repo, pr_number)
+    target = build_review_target(repo, pr_number, base_sha, head_sha)
+
+    # Use the provided checkout, or a temporary placeholder path for repo instructions
+    effective_checkout = checkout or Path.cwd()
+
+    artifact = run_review(
+        effective_checkout,
+        target,
+        diff,
+        model=model,
+        output_path=output_path,
+    )
+
+    posted, skipped = publish_artifact(
+        artifact,
+        repo=repo,
+        pr_number=pr_number,
+        shadow=shadow,
+        min_confidence=min_confidence,
+    )
+
+    return artifact, posted, skipped

--- a/packages/gptme-runloops/src/gptme_runloops/pr_review/reviewer.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pr_review/reviewer.py
@@ -19,11 +19,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from .schema import (
+    AnyReviewTarget,
     Disposition,
     LocalReviewTarget,
     MergeSafety,
     ReviewArtifact,
     ReviewFinding,
+    ReviewTarget,
     Severity,
 )
 
@@ -268,17 +270,20 @@ def _invoke_model(prompt: str, model: str | None, checkout: Path) -> str:
 
 def run_review(
     checkout: Path,
-    target: LocalReviewTarget,
+    target: AnyReviewTarget,
     diff: str,
     *,
     model: str | None = None,
     output_path: Path | None = None,
 ) -> ReviewArtifact:
-    """Run a local review and return the validated ReviewArtifact.
+    """Run a review and return the validated ReviewArtifact.
+
+    Accepts both LocalReviewTarget (working-tree / commit-range, Phase 1) and
+    ReviewTarget (hosted PR fetched via GitHub/Forgejo adapter, Phase 2).
 
     Args:
         checkout: Path to the repository root (used for repo instructions and gptme cwd).
-        target: Resolved LocalReviewTarget (from resolve_local_target).
+        target: LocalReviewTarget or ReviewTarget resolved by the caller.
         diff: Unified diff text to review.
         model: gptme model spec (e.g. "anthropic/claude-sonnet-4-6"). If None,
                gptme uses its configured default.
@@ -291,16 +296,23 @@ def run_review(
     started_at = datetime.now(timezone.utc)
 
     repo_instructions = read_repo_instructions(checkout)
-    prompt = _build_prompt(diff, repo_instructions, target.description)
+
+    # Resolve display description and identity anchor for hosted vs local targets.
+    if isinstance(target, ReviewTarget):
+        target_desc = f"{target.repo}#{target.pr_number}@{target.head_sha[:8]}"
+        head_anchor = target.head_sha
+        repo_id = target.repo
+    else:
+        target_desc = target.description
+        head_anchor = target.head_sha or target.diff_fingerprint or ""
+        repo_id = target.repo_name or target.checkout
+
+    prompt = _build_prompt(diff, repo_instructions, target_desc)
     raw_output = _invoke_model(prompt, model, checkout)
 
     completed_at = datetime.now(timezone.utc)
 
     data = _extract_json(raw_output)
-
-    # Resolve identity anchor for fingerprinting
-    head_anchor = target.head_sha or target.diff_fingerprint or ""
-    repo_id = target.repo_name or target.checkout
 
     raw_findings = data.get("findings", [])
     if not isinstance(raw_findings, list):

--- a/packages/gptme-runloops/src/gptme_runloops/pr_review/reviewer.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pr_review/reviewer.py
@@ -41,6 +41,7 @@ You are a careful code reviewer. Analyze the provided diff and produce findings.
 Rules:
 - Only report findings with concrete evidence visible in the diff.
 - Every finding MUST reference a specific file and line from the changed code.
+- Set line_side to LEFT for a deleted line and RIGHT for an added or context line.
 - Focus on correctness first, then security, then missing test coverage.
 - Skip purely stylistic findings unless they indicate a real bug risk.
 - Be conservative: a missed real bug is worse than a skipped marginal finding.
@@ -57,6 +58,7 @@ Return a single JSON object with this exact structure (no preamble, no fences):
       "confidence": <float 0.0-1.0>,
       "file_path": "<exact path from diff>",
       "line_range": "<line or range, e.g. 42 or 42-49>",
+      "line_side": "LEFT" | "RIGHT",
       "title": "<short specific title>",
       "description": "<full description of the problem>",
       "evidence": "<exact code snippet from the diff showing the issue>",
@@ -341,6 +343,7 @@ def run_review(
             confidence=float(raw_f.get("confidence", 0.5)),
             file_path=raw_f.get("file_path", ""),
             line_range=str(raw_f.get("line_range", "1")),
+            line_side=raw_f.get("line_side", "RIGHT"),
             title=raw_f.get("title", ""),
             description=raw_f.get("description", ""),
             evidence=raw_f.get("evidence", ""),

--- a/packages/gptme-runloops/src/gptme_runloops/pr_review/schema.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pr_review/schema.py
@@ -121,6 +121,10 @@ class ReviewFinding(BaseModel):
     # Location — required; no evidence without a file reference
     file_path: str
     line_range: str = Field(description="e.g. '42' or '42-49'")
+    line_side: Literal["LEFT", "RIGHT"] = Field(
+        default="RIGHT",
+        description="Git diff side: LEFT for deleted lines, RIGHT for added/context lines",
+    )
 
     # Content
     title: str

--- a/packages/gptme-runloops/tests/test_pr_review.py
+++ b/packages/gptme-runloops/tests/test_pr_review.py
@@ -857,6 +857,19 @@ class TestGetPostedFingerprints:
 
         assert fps == {"aaaa111122223333", "bbbb444455556666"}
 
+    def test_uses_paginate_to_scan_all_pages(self):
+        """get_posted_fingerprints must request all pages, not just the first."""
+        from gptme_runloops.pr_review.github_adapter import get_posted_fingerprints
+
+        with patch(
+            "gptme_runloops.pr_review.github_adapter._gh_api",
+            return_value=[],
+        ) as mock_api:
+            get_posted_fingerprints("org/repo", 42)
+
+        _, call_kwargs = mock_api.call_args
+        assert call_kwargs.get("paginate") is True
+
 
 class TestPublishArtifactShadowMode:
     """publish_artifact() in shadow mode must not call any GitHub API."""
@@ -999,6 +1012,73 @@ class TestPublishArtifactIdempotency:
 
         assert posted == 1
         assert skipped == 0
+
+
+class TestPostInlineFinding:
+    """post_inline_finding() falls back to LEFT side when RIGHT is rejected."""
+
+    def _make_finding(self) -> ReviewFinding:
+        return ReviewFinding(
+            id="fp1234567890abcd",
+            category="correctness",
+            severity=Severity.high,
+            confidence=0.9,
+            file_path="src/foo.py",
+            line_range="10",
+            title="Bug",
+            description="A bug.",
+            evidence="- old line",
+        )
+
+    def test_right_side_succeeds(self):
+        from gptme_runloops.pr_review.github_adapter import post_inline_finding
+
+        with patch(
+            "gptme_runloops.pr_review.github_adapter._gh_api",
+            return_value={"id": 999},
+        ) as mock_api:
+            comment_id = post_inline_finding(
+                "org/repo", 42, "h" * 40, self._make_finding()
+            )
+
+        assert comment_id == "999"
+        fields = mock_api.call_args[1]["fields"]
+        assert fields["side"] == "RIGHT"
+
+    def test_falls_back_to_left_when_right_rejected(self):
+        """When RIGHT anchor is rejected by GitHub, LEFT is tried automatically."""
+        from gptme_runloops.pr_review.github_adapter import post_inline_finding
+
+        call_count = 0
+
+        def _api_side_effect(path, *, method="GET", fields=None, **kw):
+            nonlocal call_count
+            call_count += 1
+            if fields and fields.get("side") == "RIGHT":
+                raise subprocess.CalledProcessError(1, "gh")
+            return {"id": 777}
+
+        with patch(
+            "gptme_runloops.pr_review.github_adapter._gh_api",
+            side_effect=_api_side_effect,
+        ):
+            comment_id = post_inline_finding(
+                "org/repo", 42, "h" * 40, self._make_finding()
+            )
+
+        assert comment_id == "777"
+        assert call_count == 2  # RIGHT tried first, then LEFT
+
+    def test_raises_when_both_sides_rejected(self):
+        """If both RIGHT and LEFT fail, CalledProcessError propagates."""
+        from gptme_runloops.pr_review.github_adapter import post_inline_finding
+
+        with patch(
+            "gptme_runloops.pr_review.github_adapter._gh_api",
+            side_effect=subprocess.CalledProcessError(1, "gh"),
+        ):
+            with pytest.raises(subprocess.CalledProcessError):
+                post_inline_finding("org/repo", 42, "h" * 40, self._make_finding())
 
 
 class TestReviewPrCliCommand:

--- a/packages/gptme-runloops/tests/test_pr_review.py
+++ b/packages/gptme-runloops/tests/test_pr_review.py
@@ -1,6 +1,7 @@
-"""Tests for the pr_review schema and corpus module (Phase 0 + Phase 1)."""
+"""Tests for the pr_review schema and corpus module (Phase 0 + Phase 2)."""
 
 import json
+import re
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
@@ -800,3 +801,269 @@ class TestReviewCliExitStatus:
         assert result.exit_code == 1
         assert "Error: Invalid review response:" in result.output
         assert not isinstance(result.exception, TypeError | ValueError)
+
+
+# ── Phase 2: GitHub adapter ───────────────────────────────────────────────────
+
+
+class TestGetPostedFingerprints:
+    """get_posted_fingerprints() parses hidden fp tags from existing comments."""
+
+    def test_extracts_fingerprint_from_body(self):
+        from gptme_runloops.pr_review.github_adapter import (
+            _FP_PREFIX,
+            _FP_SUFFIX,
+            get_posted_fingerprints,
+        )
+
+        comment_body = (
+            f"Some text.\n{_FP_PREFIX}abcd1234ef567890{_FP_SUFFIX}\nMore text."
+        )
+        mock_response = [{"body": comment_body}]
+
+        with patch(
+            "gptme_runloops.pr_review.github_adapter._gh_api",
+            return_value=mock_response,
+        ):
+            fps = get_posted_fingerprints("org/repo", 42)
+
+        assert "abcd1234ef567890" in fps
+
+    def test_returns_empty_on_no_comments(self):
+        from gptme_runloops.pr_review.github_adapter import get_posted_fingerprints
+
+        with patch("gptme_runloops.pr_review.github_adapter._gh_api", return_value=[]):
+            fps = get_posted_fingerprints("org/repo", 42)
+
+        assert fps == set()
+
+    def test_multiple_comments_multiple_fingerprints(self):
+        from gptme_runloops.pr_review.github_adapter import (
+            _FP_PREFIX,
+            _FP_SUFFIX,
+            get_posted_fingerprints,
+        )
+
+        mock_response = [
+            {"body": f"Finding A\n{_FP_PREFIX}aaaa111122223333{_FP_SUFFIX}"},
+            {"body": f"Finding B\n{_FP_PREFIX}bbbb444455556666{_FP_SUFFIX}"},
+            {"body": "No fingerprint here"},
+        ]
+        with patch(
+            "gptme_runloops.pr_review.github_adapter._gh_api",
+            return_value=mock_response,
+        ):
+            fps = get_posted_fingerprints("org/repo", 42)
+
+        assert fps == {"aaaa111122223333", "bbbb444455556666"}
+
+
+class TestPublishArtifactShadowMode:
+    """publish_artifact() in shadow mode must not call any GitHub API."""
+
+    def _make_artifact(self, findings=None):
+        return ReviewArtifact(
+            target=ReviewTarget(
+                repo="org/repo",
+                pr_number=42,
+                base_sha="base" * 10,
+                head_sha="head" * 10,
+            ),
+            model="test",
+            prompt_version="v1",
+            started_at=datetime.now(tz=timezone.utc),
+            completed_at=datetime.now(tz=timezone.utc),
+            summary="ok",
+            merge_safety=MergeSafety.needs_review,
+            findings=findings or [],
+        )
+
+    def _make_finding(self, fp_id: str, confidence: float = 0.9) -> ReviewFinding:
+        return ReviewFinding(
+            id=fp_id,
+            category="correctness",
+            severity=Severity.high,
+            confidence=confidence,
+            file_path="src/foo.py",
+            line_range="42",
+            title=f"Bug {fp_id}",
+            description="A bug.",
+            evidence="code here",
+        )
+
+    def test_shadow_no_api_calls(self):
+        from gptme_runloops.pr_review.github_adapter import publish_artifact
+
+        artifact = self._make_artifact([self._make_finding("fp1")])
+        with patch("gptme_runloops.pr_review.github_adapter._gh_api") as mock_api:
+            posted, skipped = publish_artifact(
+                artifact, repo="org/repo", pr_number=42, shadow=True
+            )
+            mock_api.assert_not_called()
+
+        assert posted == 1
+        assert skipped == 0
+
+    def test_shadow_drops_low_confidence(self):
+        from gptme_runloops.pr_review.github_adapter import publish_artifact
+
+        f_high = self._make_finding("fp-high", confidence=0.9)
+        f_low = self._make_finding("fp-low", confidence=0.3)
+        artifact = self._make_artifact([f_high, f_low])
+
+        with patch("gptme_runloops.pr_review.github_adapter._gh_api"):
+            posted, skipped = publish_artifact(
+                artifact, repo="org/repo", pr_number=42, shadow=True, min_confidence=0.6
+            )
+
+        assert posted == 1
+        assert skipped == 1
+
+
+class TestPublishArtifactIdempotency:
+    """publish_artifact() skips findings already posted (idempotency guard)."""
+
+    def _make_artifact(self, fp_id: str) -> ReviewArtifact:
+        finding = ReviewFinding(
+            id=fp_id,
+            category="correctness",
+            severity=Severity.medium,
+            confidence=0.8,
+            file_path="src/foo.py",
+            line_range="10",
+            title="Duplicate finding",
+            description="Already posted.",
+            evidence="...",
+        )
+        return ReviewArtifact(
+            target=ReviewTarget(
+                repo="org/repo",
+                pr_number=99,
+                base_sha="b" * 40,
+                head_sha="h" * 40,
+            ),
+            model="test",
+            prompt_version="v1",
+            started_at=datetime.now(tz=timezone.utc),
+            completed_at=datetime.now(tz=timezone.utc),
+            summary="ok",
+            merge_safety=MergeSafety.safe,
+            findings=[finding],
+        )
+
+    def test_already_posted_fingerprint_is_skipped(self):
+        from gptme_runloops.pr_review.github_adapter import publish_artifact
+
+        artifact = self._make_artifact("alreadypostedfp")
+
+        with (
+            patch(
+                "gptme_runloops.pr_review.github_adapter.get_posted_fingerprints",
+                return_value={"alreadypostedfp"},
+            ),
+            patch(
+                "gptme_runloops.pr_review.github_adapter.post_inline_finding"
+            ) as mock_post,
+        ):
+            posted, skipped = publish_artifact(
+                artifact, repo="org/repo", pr_number=99, shadow=False
+            )
+            mock_post.assert_not_called()
+
+        assert posted == 0
+        assert skipped == 1
+
+    def test_new_fingerprint_is_posted(self):
+        from gptme_runloops.pr_review.github_adapter import publish_artifact
+
+        artifact = self._make_artifact("newfp1234567890a")
+
+        with (
+            patch(
+                "gptme_runloops.pr_review.github_adapter.get_posted_fingerprints",
+                return_value=set(),
+            ),
+            patch(
+                "gptme_runloops.pr_review.github_adapter.post_inline_finding",
+                return_value="comment-id-1",
+            ) as mock_post,
+            patch(
+                "gptme_runloops.pr_review.github_adapter.post_summary_comment",
+                return_value="s1",
+            ),
+        ):
+            posted, skipped = publish_artifact(
+                artifact, repo="org/repo", pr_number=99, shadow=False
+            )
+            mock_post.assert_called_once()
+
+        assert posted == 1
+        assert skipped == 0
+
+
+class TestReviewPrCliCommand:
+    """CLI integration tests for the review-pr command."""
+
+    def test_invalid_pr_ref_format(self):
+        result = CliRunner().invoke(cli_main, ["review-pr", "not-a-valid-ref"])
+        assert result.exit_code != 0
+        assert "Invalid PR reference" in result.output
+
+    def test_invalid_pr_ref_missing_hash(self):
+        result = CliRunner().invoke(cli_main, ["review-pr", "org/repo"])
+        assert result.exit_code != 0
+
+    def test_shadow_mode_calls_run_github_review(self):
+        target = ReviewTarget(
+            repo="org/repo",
+            pr_number=42,
+            base_sha="b" * 40,
+            head_sha="h" * 40,
+        )
+        artifact = ReviewArtifact(
+            target=target,
+            model="test",
+            prompt_version="v1",
+            started_at=datetime.now(tz=timezone.utc),
+            completed_at=datetime.now(tz=timezone.utc),
+            summary="Looks good.",
+            merge_safety=MergeSafety.safe,
+        )
+
+        with patch(
+            "gptme_runloops.pr_review.github_adapter.run_github_review",
+            return_value=(artifact, 0, 0),
+        ):
+            result = CliRunner().invoke(cli_main, ["review-pr", "org/repo#42"])
+
+        assert result.exit_code == 0
+        # Extract JSON object from output (stderr progress lines may be mixed in)
+        m = re.search(r"\{.*\}", result.output, re.DOTALL)
+        assert m is not None, f"No JSON in output: {result.output!r}"
+        data = json.loads(m.group(0))
+        assert data["summary"] == "Looks good."
+
+    def test_unsafe_verdict_exits_nonzero(self):
+        target = ReviewTarget(
+            repo="org/repo",
+            pr_number=1,
+            base_sha="b" * 40,
+            head_sha="h" * 40,
+        )
+        artifact = ReviewArtifact(
+            target=target,
+            model="test",
+            prompt_version="v1",
+            started_at=datetime.now(tz=timezone.utc),
+            completed_at=datetime.now(tz=timezone.utc),
+            summary="Bugs found.",
+            merge_safety=MergeSafety.unsafe,
+        )
+
+        with patch(
+            "gptme_runloops.pr_review.github_adapter.run_github_review",
+            return_value=(artifact, 0, 0),
+        ):
+            result = CliRunner().invoke(cli_main, ["review-pr", "org/repo#1"])
+
+        assert result.exit_code == 1

--- a/packages/gptme-runloops/tests/test_pr_review.py
+++ b/packages/gptme-runloops/tests/test_pr_review.py
@@ -1015,9 +1015,9 @@ class TestPublishArtifactIdempotency:
 
 
 class TestPostInlineFinding:
-    """post_inline_finding() falls back to LEFT side when RIGHT is rejected."""
+    """post_inline_finding() preserves the finding's declared diff side."""
 
-    def _make_finding(self) -> ReviewFinding:
+    def _make_finding(self, *, line_side: str = "RIGHT") -> ReviewFinding:
         return ReviewFinding(
             id="fp1234567890abcd",
             category="correctness",
@@ -1025,12 +1025,14 @@ class TestPostInlineFinding:
             confidence=0.9,
             file_path="src/foo.py",
             line_range="10",
+            line_side=line_side,
             title="Bug",
             description="A bug.",
             evidence="- old line",
         )
 
-    def test_right_side_succeeds(self):
+    @pytest.mark.parametrize("line_side", ["RIGHT", "LEFT"])
+    def test_posts_on_declared_side(self, line_side: str):
         from gptme_runloops.pr_review.github_adapter import post_inline_finding
 
         with patch(
@@ -1038,36 +1040,34 @@ class TestPostInlineFinding:
             return_value={"id": 999},
         ) as mock_api:
             comment_id = post_inline_finding(
-                "org/repo", 42, "h" * 40, self._make_finding()
+                "org/repo",
+                42,
+                "h" * 40,
+                self._make_finding(line_side=line_side),
             )
 
         assert comment_id == "999"
         fields = mock_api.call_args[1]["fields"]
-        assert fields["side"] == "RIGHT"
+        assert fields["side"] == line_side
 
-    def test_falls_back_to_left_when_right_rejected(self):
-        """When RIGHT anchor is rejected by GitHub, LEFT is tried automatically."""
+    def test_does_not_fall_back_to_opposite_side(self):
+        """A rejected anchor must not attach to the same number on another side."""
         from gptme_runloops.pr_review.github_adapter import post_inline_finding
-
-        call_count = 0
-
-        def _api_side_effect(path, *, method="GET", fields=None, **kw):
-            nonlocal call_count
-            call_count += 1
-            if fields and fields.get("side") == "RIGHT":
-                raise subprocess.CalledProcessError(1, "gh")
-            return {"id": 777}
 
         with patch(
             "gptme_runloops.pr_review.github_adapter._gh_api",
-            side_effect=_api_side_effect,
-        ):
-            comment_id = post_inline_finding(
-                "org/repo", 42, "h" * 40, self._make_finding()
-            )
+            side_effect=subprocess.CalledProcessError(1, "gh"),
+        ) as mock_api:
+            with pytest.raises(subprocess.CalledProcessError):
+                post_inline_finding(
+                    "org/repo",
+                    42,
+                    "h" * 40,
+                    self._make_finding(line_side="LEFT"),
+                )
 
-        assert comment_id == "777"
-        assert call_count == 2  # RIGHT tried first, then LEFT
+        mock_api.assert_called_once()
+        assert mock_api.call_args.kwargs["fields"]["side"] == "LEFT"
 
     def test_iterates_range_when_first_line_rejected(self):
         """Falls back to later lines in the range when the first is not a postable anchor."""
@@ -1101,11 +1101,11 @@ class TestPostInlineFinding:
             comment_id = post_inline_finding("org/repo", 42, "h" * 40, finding)
 
         assert comment_id == "888"
-        # line 10 RIGHT+LEFT failed; line 11 RIGHT succeeded
-        assert call_lines == [10, 10, 11]
+        # line 10 failed; line 11 succeeded, preserving RIGHT throughout.
+        assert call_lines == [10, 11]
 
-    def test_raises_when_both_sides_rejected(self):
-        """If both RIGHT and LEFT fail, CalledProcessError propagates."""
+    def test_raises_when_all_range_lines_are_rejected(self):
+        """If every same-side anchor fails, CalledProcessError propagates."""
         from gptme_runloops.pr_review.github_adapter import post_inline_finding
 
         with patch(

--- a/packages/gptme-runloops/tests/test_pr_review.py
+++ b/packages/gptme-runloops/tests/test_pr_review.py
@@ -1069,6 +1069,41 @@ class TestPostInlineFinding:
         assert comment_id == "777"
         assert call_count == 2  # RIGHT tried first, then LEFT
 
+    def test_iterates_range_when_first_line_rejected(self):
+        """Falls back to later lines in the range when the first is not a postable anchor."""
+        from gptme_runloops.pr_review.github_adapter import post_inline_finding
+
+        finding = ReviewFinding(
+            id="fp1234567890abcd",
+            category="correctness",
+            severity=Severity.high,
+            confidence=0.9,
+            file_path="src/foo.py",
+            line_range="10-12",  # multi-line range; line 10 is outside the diff window
+            title="Bug",
+            description="A bug.",
+            evidence="+ new line",
+        )
+
+        call_lines: list[int] = []
+
+        def _api_side_effect(path, *, method="GET", fields=None, **kw):
+            line = fields["line"] if fields else None
+            call_lines.append(line)
+            if line == 10:  # first line not in diff window
+                raise subprocess.CalledProcessError(1, "gh")
+            return {"id": 888}
+
+        with patch(
+            "gptme_runloops.pr_review.github_adapter._gh_api",
+            side_effect=_api_side_effect,
+        ):
+            comment_id = post_inline_finding("org/repo", 42, "h" * 40, finding)
+
+        assert comment_id == "888"
+        # line 10 RIGHT+LEFT failed; line 11 RIGHT succeeded
+        assert call_lines == [10, 10, 11]
+
     def test_raises_when_both_sides_rejected(self):
         """If both RIGHT and LEFT fail, CalledProcessError propagates."""
         from gptme_runloops.pr_review.github_adapter import post_inline_finding


### PR DESCRIPTION
## Summary

Phase 2 of the self-hosted PR reviewer (forge-neutral alternative to Greptile for private repos).

- **NEW `pr_review/github_adapter.py`** — the only module allowed to call `gh` CLI or GitHub REST API:
  - `fetch_pr_metadata()` / `fetch_pr_diff()` — pull base/head SHAs and unified diff via `gh`
  - `get_posted_fingerprints()` — scans existing PR comments for `<!-- pr-review-fp:ID -->` tags (idempotency guard)
  - `publish_artifact()` — posts inline findings + summary comment; skips already-posted or low-confidence findings
  - `run_github_review()` — end-to-end pipeline: fetch → run → publish (or shadow)
  - Shadow mode is the default — runs the full pipeline without posting anything to GitHub

- **`cli.py`** — new `review-pr OWNER/REPO#NUM` command:
  - `--shadow` (default) / `--publish` to control whether findings are posted
  - `--model`, `--checkout`, `--output`, `--min-confidence` options
  - Exits nonzero if `merge_safety != safe`

- **`reviewer.py`** — widened `run_review()` from `LocalReviewTarget` → `AnyReviewTarget` so the GitHub adapter can pass hosted PR targets directly through the same review core

- **`tests/test_pr_review.py`** — 12 new Phase 2 tests (69 total):
  - Fingerprint extraction from comment bodies
  - Shadow mode makes no API calls
  - Low-confidence findings are filtered before posting
  - Already-posted fingerprints are skipped (idempotency)
  - CLI: invalid ref format, shadow mode JSON output, unsafe verdict exits nonzero

## Design notes

- **Forge-neutral**: `reviewer.py` has zero GitHub knowledge; the adapter is the only GitHub-aware module
- **Idempotency**: findings embed a hidden `<!-- pr-review-fp:ID -->` tag; re-runs scan existing comments and skip duplicates
- **Shadow-safe default**: `--publish` must be passed explicitly; omitting it produces only a JSON artifact
- **Confidence gate**: `_MIN_CONFIDENCE = 0.6`; findings below threshold are skipped silently

## Follows

- Phase 0: schema + corpus (PR #1355, merged)
- Phase 1: local CLI runner (PR #1358, merged)
- Phase 3 (next): shadow-mode evaluation on pilot PRs + PM integration for allowlisted private repos

## Test plan

- [x] All 69 tests pass (`uv run pytest packages/gptme-runloops/tests/test_pr_review.py -v`)
- [x] mypy clean (`make typecheck`)
- [x] ruff + format clean (`make lint && make format`)
- [x] All pre-commit hooks pass