### PR TITLE
feat(runloops): automated-pr-review PM work type for allowlisted private repos

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/pm_bandit.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_bandit.py
@@ -52,6 +52,7 @@ PM_WORK_TYPES: set[str] = {
     "ci-fix",
     "greptile-fix",
     "pr-review",
+    "automated-pr-review",
     "merge-conflict",
     "assigned-issue",
     "notification-triage",

--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -45,6 +45,23 @@ DEFAULT_FAST_BURST_ALLOWANCE = 1
 # Minimum bandit observations before preferring bandit routing over static fallback
 MIN_BANDIT_OBSERVATIONS = 5
 
+# Repositories that receive automated shadow PR reviews (no Greptile free tier).
+# Override at runtime via AUTOMATED_PR_REVIEW_REPOS=owner/repo1,owner/repo2.
+_AUTOMATED_PR_REVIEW_REPOS_DEFAULT: frozenset[str] = frozenset()
+
+
+def _automated_pr_review_allowlist() -> frozenset[str]:
+    """Return the set of repos that get automated shadow PR reviews.
+
+    Populated from the AUTOMATED_PR_REVIEW_REPOS env var (comma-separated
+    ``owner/repo`` values). Empty by default so the feature is opt-in.
+    """
+    raw = os.environ.get("AUTOMATED_PR_REVIEW_REPOS", "")
+    if not raw.strip():
+        return _AUTOMATED_PR_REVIEW_REPOS_DEFAULT
+    return frozenset(r.strip() for r in raw.split(",") if r.strip())
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -333,12 +350,17 @@ def classify_lane(types: list[str]) -> str:
     return "fast"
 
 
-def classify_item_work_type(types: list[str]) -> str:
+def classify_item_work_type(types: list[str], repo: str | None = None) -> str:
     """Map SlotItem.types to a PM bandit work type string.
 
     Priority order is significant: ci-fix and greptile-fix take precedence over
     pr-review since a PR with a CI failure should route to the CI-fix arm, not
     the generic PR-review arm.
+
+    ``repo`` (optional) is the ``owner/repo`` string for the item. When provided
+    and the repo is in the automated-review allowlist, ``pr_update`` items route
+    to ``automated-pr-review`` instead of ``pr-review``. The allowlist is
+    populated from the ``AUTOMATED_PR_REVIEW_REPOS`` environment variable.
 
     Returns one of the PM_WORK_TYPES strings defined in pm_bandit.
     """
@@ -352,6 +374,8 @@ def classify_item_work_type(types: list[str]) -> str:
     if "merge_conflict" in types_set:
         return "merge-conflict"
     if "pr_update" in types_set:
+        if repo and repo in _automated_pr_review_allowlist():
+            return "automated-pr-review"
         return "pr-review"
     if "assigned" in types_set:
         return "assigned-issue"
@@ -386,6 +410,7 @@ def _resolve_model_with_bandit(
     fast_model: str | None,
     bandit: Any | None,
     detail: str = "",
+    repo: str | None = None,
 ) -> str | None:
     """Resolve the dispatch model for an item.
 
@@ -405,7 +430,7 @@ def _resolve_model_with_bandit(
 
     if bandit is None:
         return resolve_lane_model(lane, model, fast_model)
-    work_type = classify_item_work_type(item_types)
+    work_type = classify_item_work_type(item_types, repo=repo)
     available = [m for m in [model, fast_model] if m]
     if not available:
         available = ["sonnet"]
@@ -597,7 +622,13 @@ class LaneDispatcher:
                     item=item,
                     backend=backend,
                     model=_resolve_model_with_bandit(
-                        item.types, lane, model, fast_model, bandit, item.detail
+                        item.types,
+                        lane,
+                        model,
+                        fast_model,
+                        bandit,
+                        item.detail,
+                        repo=item.repo,
                     ),
                     script_path=script_path,
                 )

--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -614,6 +614,7 @@ class LaneDispatcher:
                     continue
 
                 # Launch — bandit-driven model selection when observations ≥ threshold
+                work_type = classify_item_work_type(item.types, repo=item.repo)
                 success = self._launch_unit(
                     unit_name=unit_name,
                     legacy_name=legacy_name,
@@ -631,6 +632,7 @@ class LaneDispatcher:
                         repo=item.repo,
                     ),
                     script_path=script_path,
+                    work_type=work_type,
                 )
 
                 if success:
@@ -653,6 +655,7 @@ class LaneDispatcher:
         backend: str,
         model: str | None = None,
         script_path: str | None = None,
+        work_type: str | None = None,
     ) -> bool:
         """Launch a transient systemd unit for a single dispatch slot.
 
@@ -669,6 +672,7 @@ class LaneDispatcher:
                     backend=backend,
                     model=model,
                     script_path=script_path,
+                    work_type=work_type,
                 )
             )
 
@@ -716,6 +720,8 @@ class LaneDispatcher:
         ]
         if model:
             cmd.append(f"--setenv=BOB_SELECTED_MODEL={model}")
+        if work_type:
+            cmd.append(f"--setenv=PM_WORK_TYPE={work_type}")
         cmd.extend(["--", "bash", script_path])
 
         try:

--- a/packages/gptme-runloops/tests/test_pm_dispatch.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch.py
@@ -1305,6 +1305,45 @@ class TestClassifyItemWorkType:
     def test_strategy_highest_priority(self):
         assert classify_item_work_type(["strategy", "ci_failure"]) == "strategy-reply"
 
+    def test_automated_review_allowlisted_repo(self, monkeypatch):
+        monkeypatch.setenv(
+            "AUTOMATED_PR_REVIEW_REPOS", "gptme/gptme-cloud,ErikBjare/bob"
+        )
+        assert (
+            classify_item_work_type(["pr_update"], repo="gptme/gptme-cloud")
+            == "automated-pr-review"
+        )
+        assert (
+            classify_item_work_type(["pr_update"], repo="ErikBjare/bob")
+            == "automated-pr-review"
+        )
+
+    def test_automated_review_non_allowlisted_falls_back(self, monkeypatch):
+        monkeypatch.setenv("AUTOMATED_PR_REVIEW_REPOS", "gptme/gptme-cloud")
+        assert classify_item_work_type(["pr_update"], repo="gptme/gptme") == "pr-review"
+
+    def test_automated_review_no_allowlist(self, monkeypatch):
+        monkeypatch.delenv("AUTOMATED_PR_REVIEW_REPOS", raising=False)
+        # Without allowlist, pr_update is always pr-review even for private repos
+        assert (
+            classify_item_work_type(["pr_update"], repo="gptme/gptme-cloud")
+            == "pr-review"
+        )
+
+    def test_automated_review_ci_takes_precedence(self, monkeypatch):
+        monkeypatch.setenv("AUTOMATED_PR_REVIEW_REPOS", "gptme/gptme-cloud")
+        # CI failure on allowlisted repo still routes to ci-fix
+        assert (
+            classify_item_work_type(
+                ["pr_update", "ci_failure"], repo="gptme/gptme-cloud"
+            )
+            == "ci-fix"
+        )
+
+    def test_automated_review_no_repo(self):
+        # No repo → original pr-review behavior
+        assert classify_item_work_type(["pr_update"]) == "pr-review"
+
 
 # --- _bandit_observation_count and _resolve_model_with_bandit ---
 

--- a/packages/gptme-runloops/tests/test_pm_dispatch.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch.py
@@ -862,6 +862,67 @@ class TestLaneDispatcher:
         assert callback_calls[1]["lane"] == "slow"
         assert callback_calls[1]["slot_key"] == "a/b#2"
 
+    def test_dispatch_work_type_propagated_to_callback(self, ld_no_slots):
+        """work_type is derived and passed to dispatch_callback so the worker
+        session can route to the correct workflow (e.g. automated-pr-review)."""
+        callback_calls = []
+
+        def cb(**kwargs):
+            callback_calls.append(kwargs)
+            return True
+
+        ld = LaneDispatcher(
+            slot_manager=ld_no_slots.slot_manager,
+            dispatch_callback=cb,
+        )
+
+        items = [
+            make_item(repo="a/b", number=1, types=["assigned"]),
+            make_item(repo="a/b", number=2, types=["pr_update"]),
+            make_item(repo="a/b", number=3, types=["ci_failure"]),
+        ]
+        ld.dispatch(items, backend="claude-code")
+        assert len(callback_calls) == 3
+        # work_type key must always be present in the callback kwargs
+        assert all("work_type" in c for c in callback_calls)
+        # Spot-check derived values
+        wt_by_slot = {c["slot_key"]: c["work_type"] for c in callback_calls}
+        assert wt_by_slot["a/b#1"] == "assigned-issue"
+        assert wt_by_slot["a/b#2"] == "pr-review"
+        assert wt_by_slot["a/b#3"] == "ci-fix"
+
+    def test_dispatch_work_type_automated_pr_review_for_allowlisted_repo(
+        self, ld_no_slots, monkeypatch
+    ):
+        """Allowlisted repos route pr_update items to automated-pr-review work type."""
+        monkeypatch.setenv(
+            "AUTOMATED_PR_REVIEW_REPOS", "gptme/gptme-cloud,ErikBjare/bob"
+        )
+        callback_calls = []
+
+        def cb(**kwargs):
+            callback_calls.append(kwargs)
+            return True
+
+        ld = LaneDispatcher(
+            slot_manager=ld_no_slots.slot_manager,
+            dispatch_callback=cb,
+        )
+
+        items = [
+            make_item(repo="gptme/gptme-cloud", number=1, types=["pr_update"]),
+            make_item(repo="ErikBjare/bob", number=2, types=["pr_update"]),
+            make_item(
+                repo="gptme/gptme", number=3, types=["pr_update"]
+            ),  # not allowlisted
+        ]
+        ld.dispatch(items, backend="claude-code")
+        assert len(callback_calls) == 3
+        wt_by_repo = {c["item"].repo: c["work_type"] for c in callback_calls}
+        assert wt_by_repo["gptme/gptme-cloud"] == "automated-pr-review"
+        assert wt_by_repo["ErikBjare/bob"] == "automated-pr-review"
+        assert wt_by_repo["gptme/gptme"] == "pr-review"
+
     def test_dispatch_fast_model_routes_per_lane(self, ld_no_slots):
         callback_calls = []
 
@@ -1548,7 +1609,9 @@ class TestLaneDispatcherWithBandit:
     def _make_dispatcher(self, launched: list, deferred: list):
         """Return a LaneDispatcher whose callback captures routing decisions."""
 
-        def callback(slot_unit, slot_key, lane, item, backend, model, script_path):
+        def callback(
+            slot_unit, slot_key, lane, item, backend, model, script_path, work_type=None
+        ):
             launched.append({"slot_key": slot_key, "lane": lane, "model": model})
             return True
 


### PR DESCRIPTION
## Summary

Phase 3 of the self-hosted PR reviewer (ErikBjare/bob#1122 / design doc: knowledge/technical-designs/self-hosted-pr-reviewer-mvp.md).

- Adds `automated-pr-review` to `PM_WORK_TYPES` — a distinct work type for proactive shadow/publication reviews of PRs in private repos where Greptile has no free tier (gptme-cloud, ErikBjare/bob)
- The existing `pr-review` lane is untouched; it handles Bob's own PR review-feedback loop
- Routing is opt-in via `AUTOMATED_PR_REVIEW_REPOS=owner/repo1,owner/repo2` env var — empty by default
- CI failure and Greptile issues take priority even on allowlisted repos
- 5 new tests covering allowlist routing, non-allowlist fallback, no-allowlist default, CI-takes-precedence, and missing-repo default

## Design

```
# In the bob-project-monitoring systemd unit:
Environment=AUTOMATED_PR_REVIEW_REPOS=gptme/gptme-cloud,ErikBjare/bob

# PM detects a new PR in gptme-cloud → routes to automated-pr-review
# Session calls: gptme-runloops review-pr gptme/gptme-cloud#N --shadow
# Later: --publish once shadow results confirm ≥80% precision
```

The session script that dispatches `gptme-runloops review-pr` for the new work type is wired in the brain repo's PM configuration, not in gptme-contrib itself.

## Test plan

- [x] All 17 `TestClassifyItemWorkType` tests pass (5 new)
- [x] Full `test_pr_review.py` + `test_pm_bandit.py` suite passes (93 tests)
- [x] Typecheck clean