### PR TITLE
fix(sessions): mock _discover_all in test_runs_empty_store to prevent fs scan timeout

### DIFF
--- a/packages/gptme-sessions/tests/test_cli.py
+++ b/packages/gptme-sessions/tests/test_cli.py
@@ -421,9 +421,12 @@ class TestRunsCommand:
         assert isinstance(data, dict)
 
     def test_runs_empty_store(self, tmp_path: Path):
-        """runs on empty store shows discovery fallback."""
+        """runs on empty store triggers discovery fallback path; exits 0."""
         SessionStore(sessions_dir=tmp_path)
-        rc, out = _invoke(["runs"], tmp_path)
+        # Apply _NO_DISCOVER so we don't scan the real filesystem (20-30s on
+        # a loaded system causes timeouts in the full test suite).
+        with _NO_DISCOVER:
+            rc, out = _invoke(["runs"], tmp_path)
         assert rc == 0
 
     def test_runs_json_has_outcome_counts(self, tmp_path: Path):


### PR DESCRIPTION
## Summary

- `test_runs_empty_store` skipped the module-level `_NO_DISCOVER` patch, causing it to call `_discover_all` which scans the real filesystem for gptme/CC/codex sessions
- On a loaded system (hundreds of sessions), this takes 20-30s and causes the test to fail with a timeout when run as part of the full cross-package `pytest packages/` suite
- The test passes in isolation (26s but within its own timeout budget) and fails only when running alongside 4000+ other tests where the accumulated timeout pressure hits

## Fix

Apply `_NO_DISCOVER` inside `test_runs_empty_store`. The discovery fallback code path is still exercised (we enter `_show_discovery_fallback`), but `_discover_all` returns `[]` instead of scanning real directories. The test assertion (`rc == 0`) still verifies the fallback path exits cleanly.

## Test plan

- [x] `uv run pytest packages/gptme-sessions/tests/test_cli.py::TestRunsCommand -v` — all 5 pass in 0.11s (was 26s for this test alone)
- [x] `prek` pre-commit hooks pass in worktree