### PR TITLE
feat(lessons-mcp): add gptme-lessons-mcp MCP server

### DIFF
--- a/packages/gptme-lessons-mcp/Makefile
+++ b/packages/gptme-lessons-mcp/Makefile
@@ -1,0 +1,8 @@
+export MYPY_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.mypy_cache
+export RUFF_CACHE_DIR ?= $(shell git rev-parse --show-toplevel)/.ruff_cache
+
+test:
+	uv run pytest tests/ -v
+
+typecheck:
+	uv run --with mypy mypy src/ --ignore-missing-imports

--- a/packages/gptme-lessons-mcp/README.md
+++ b/packages/gptme-lessons-mcp/README.md
@@ -1,0 +1,24 @@
+# gptme-lessons-mcp
+
+MCP server that exposes gptme's lesson matching system to any MCP client (Claude Code, Cursor, Continue.dev, etc.).
+
+## What it does
+
+Agents forget why builds fail between sessions. gptme-lessons-mcp makes lesson knowledge persistent and cross-runtime by exposing it as an MCP server.
+
+## Tools
+
+- `match_lessons(context, top_k=5)` — find lessons relevant to a context string
+- `list_lessons(category?, search?)` — enumerate available lessons
+- `get_lesson(path)` — get the full body of a specific lesson
+- `list_categories()` — list all lesson categories
+
+## Usage
+
+```bash
+# stdio MCP server (auto-discovers lessons from gptme config)
+uv run gptme-lessons-mcp
+
+# with explicit lesson directories
+uv run gptme-lessons-mcp --lessons-dir ~/my-agent/lessons
+```

--- a/packages/gptme-lessons-mcp/pyproject.toml
+++ b/packages/gptme-lessons-mcp/pyproject.toml
@@ -1,0 +1,61 @@
+[project]
+name = "gptme-lessons-mcp"
+version = "0.1.0"
+description = "MCP server that exposes gptme's lesson matching system to any MCP client"
+authors = [
+    {name = "gptme contributors", email = "gptme@superuserlabs.org"}
+]
+license = "MIT"
+readme = "README.md"
+requires-python = ">=3.10"
+keywords = ["mcp", "gptme", "lessons", "agent-memory", "cross-runtime"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Utilities",
+]
+dependencies = [
+    "mcp>=1.0",
+    "gptme>=0.1.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/gptme/gptme-contrib"
+Repository = "https://github.com/gptme/gptme-contrib"
+Issues = "https://github.com/gptme/gptme-contrib/issues"
+
+[project.optional-dependencies]
+dev = [
+    "mypy>=1.0.0",
+    "pytest>=7.0",
+]
+test = [
+    "pytest>=7.0",
+]
+
+[project.scripts]
+gptme-lessons-mcp = "gptme_lessons_mcp.mcp_server:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/gptme_lessons_mcp"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.mypy]
+python_version = "3.10"
+check_untyped_defs = true
+warn_return_any = true
+warn_unused_configs = true
+ignore_missing_imports = true

--- a/packages/gptme-lessons-mcp/src/gptme_lessons_mcp/__init__.py
+++ b/packages/gptme-lessons-mcp/src/gptme_lessons_mcp/__init__.py
@@ -1,0 +1,1 @@
+"""gptme-lessons-mcp: expose gptme lesson matching as an MCP server."""

--- a/packages/gptme-lessons-mcp/src/gptme_lessons_mcp/mcp_server.py
+++ b/packages/gptme-lessons-mcp/src/gptme_lessons_mcp/mcp_server.py
@@ -162,6 +162,9 @@ def get_lesson(path: str) -> dict:
         Full lesson dict including the complete body text, or an error key if
         no lesson matched.
     """
+    if not path:
+        return {"error": "No lesson found for an empty path"}
+
     index = _load_index()
 
     # Try exact path match (substring of full path)

--- a/packages/gptme-lessons-mcp/src/gptme_lessons_mcp/mcp_server.py
+++ b/packages/gptme-lessons-mcp/src/gptme_lessons_mcp/mcp_server.py
@@ -1,0 +1,236 @@
+"""MCP server that exposes gptme's lesson matching system as MCP tools.
+
+Allows any MCP client (Claude Code, Cursor, Continue.dev, etc.) to query
+"what lessons match this context?" so agents can access durable behavioral
+knowledge across runtimes and sessions.
+
+Usage:
+    uv run gptme-lessons-mcp                            # stdio, auto-discover dirs
+    uv run gptme-lessons-mcp --lessons-dir ~/my/lessons # explicit dir (repeatable)
+    uv run gptme-lessons-mcp --lessons-dir dir1 --lessons-dir dir2
+
+Tools exposed:
+    match_lessons(context, top_k?)    → list of matched lessons with content
+    list_lessons(category?, search?)  → list all active lessons
+    get_lesson(path)                  → full body of one lesson by relative path
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Optional
+
+from mcp.server.fastmcp import FastMCP
+
+logger = logging.getLogger(__name__)
+
+# Module-level lesson dirs override — set by main() before mcp.run()
+_extra_lesson_dirs: list[Path] = []
+
+mcp = FastMCP(
+    "gptme-lessons",
+    instructions=(
+        "Access gptme's lesson library — durable behavioral rules for agents.\n"
+        "`match_lessons` finds lessons relevant to a given context string (e.g. the "
+        "current user message or task description).\n"
+        "`list_lessons` enumerates available lessons, optionally by category.\n"
+        "`get_lesson` retrieves the full text of one lesson by its relative path.\n\n"
+        "Lessons are structured guidance files with YAML frontmatter and keyword-based "
+        "triggering. They encode failure modes, anti-patterns, and proven workflows "
+        "that agents should follow."
+    ),
+)
+
+
+def _load_index():
+    """Load lesson index, optionally with extra dirs prepended."""
+    from gptme.lessons.index import LessonIndex
+
+    if _extra_lesson_dirs:
+        return LessonIndex(lesson_dirs=_extra_lesson_dirs)
+    return LessonIndex()
+
+
+def _lesson_to_dict(lesson, include_body: bool = True, max_body: int = 2000) -> dict:
+    """Serialize a Lesson to a plain dict for MCP return."""
+    result = {
+        "path": str(lesson.path),
+        "title": lesson.title,
+        "category": lesson.category,
+        "description": lesson.description,
+        "keywords": lesson.metadata.keywords,
+        "status": lesson.metadata.status,
+    }
+    if include_body:
+        body = lesson.body
+        if len(body) > max_body:
+            body = body[:max_body] + "\n…(truncated)"
+        result["body"] = body
+    return result
+
+
+@mcp.tool()
+def match_lessons(
+    context: str,
+    top_k: int = 5,
+) -> list[dict]:
+    """Find lessons relevant to the given context string.
+
+    Uses gptme's keyword-based lesson matcher to surface behavioral rules,
+    anti-patterns, and proven workflows that apply to the current situation.
+
+    Args:
+        context: The text to match against (e.g. user message, task description,
+                 error output, or a description of what you're about to do).
+        top_k: Maximum number of lessons to return (1–20). Default 5.
+
+    Returns:
+        List of matching lessons, sorted by relevance score (descending). Each entry has:
+            title, category, description, keywords, body (truncated at 2000 chars),
+            score, matched_by (which keywords triggered the match)
+    """
+    top_k = max(1, min(20, top_k))
+
+    from gptme.lessons.matcher import LessonMatcher, MatchContext
+
+    index = _load_index()
+    if not index.lessons:
+        return []
+
+    matcher = LessonMatcher()
+    ctx = MatchContext(message=context)
+    matches = matcher.match(index.lessons, ctx)[:top_k]
+
+    results = []
+    for m in matches:
+        d = _lesson_to_dict(m.lesson)
+        d["score"] = round(m.score, 3)
+        d["matched_by"] = m.matched_by
+        results.append(d)
+    return results
+
+
+@mcp.tool()
+def list_lessons(
+    category: Optional[str] = None,
+    search: Optional[str] = None,
+) -> list[dict]:
+    """List active lessons, optionally filtered by category or text search.
+
+    Args:
+        category: Filter by category name (e.g. "tools", "patterns", "workflow",
+                  "infrastructure"). Pass None to list all categories.
+        search: Case-insensitive text filter applied to title, description, and
+                keywords. Pass None to skip filtering.
+
+    Returns:
+        List of lessons (without body). Each entry has:
+            path, title, category, description, keywords, status
+    """
+    index = _load_index()
+
+    lessons = index.lessons
+    if category:
+        lessons = [lesson for lesson in lessons if lesson.category == category]
+    if search:
+        q = search.lower()
+        lessons = [
+            lesson
+            for lesson in lessons
+            if q in lesson.title.lower()
+            or q in lesson.description.lower()
+            or any(q in kw.lower() for kw in lesson.metadata.keywords)
+        ]
+
+    return [_lesson_to_dict(lesson, include_body=False) for lesson in lessons]
+
+
+@mcp.tool()
+def get_lesson(path: str) -> dict:
+    """Get the full content of a lesson by its relative path or title substring.
+
+    Prefer using the `path` value returned by `match_lessons` or `list_lessons`.
+    If an exact path is not found, falls back to substring match on lesson title.
+
+    Args:
+        path: Relative file path (e.g. "tools/git-safe-commit.md") or title
+              substring to search for.
+
+    Returns:
+        Full lesson dict including the complete body text, or an error key if
+        no lesson matched.
+    """
+    index = _load_index()
+
+    # Try exact path match (substring of full path)
+    for lesson in index.lessons:
+        if path in str(lesson.path):
+            return _lesson_to_dict(lesson, max_body=10000)
+
+    # Fallback: title substring
+    path_lower = path.lower()
+    for lesson in index.lessons:
+        if path_lower in lesson.title.lower():
+            return _lesson_to_dict(lesson, max_body=10000)
+
+    return {"error": f"No lesson found for: {path!r}"}
+
+
+@mcp.tool()
+def list_categories() -> list[str]:
+    """List all categories present in the lesson library.
+
+    Returns:
+        Sorted list of unique category names (e.g. ["infrastructure", "patterns",
+        "tools", "workflow", ...]).
+    """
+    index = _load_index()
+    return sorted({lesson.category for lesson in index.lessons})
+
+
+def main() -> None:
+    """Entry point for `gptme-lessons-mcp` script."""
+    global _extra_lesson_dirs
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "gptme Lessons MCP Server — expose gptme's lesson library as MCP tools "
+            "so any agent runtime can query behavioral knowledge."
+        )
+    )
+    parser.add_argument(
+        "--lessons-dir",
+        type=Path,
+        action="append",
+        default=[],
+        metavar="DIR",
+        help=(
+            "Path to a lessons directory (repeatable). When provided, ONLY these "
+            "directories are searched (gptme config defaults are ignored). "
+            "Example: --lessons-dir ~/my-agent/lessons --lessons-dir ~/shared/lessons"
+        ),
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug logging.",
+    )
+    args = parser.parse_args()
+
+    if args.debug:
+        logging.basicConfig(level=logging.DEBUG)
+
+    if args.lessons_dir:
+        _extra_lesson_dirs = [d.expanduser().resolve() for d in args.lessons_dir]
+        missing = [d for d in _extra_lesson_dirs if not d.exists()]
+        if missing:
+            for d in missing:
+                logger.warning("Lessons dir does not exist: %s", d)
+
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/gptme-lessons-mcp/tests/test_mcp_server.py
+++ b/packages/gptme-lessons-mcp/tests/test_mcp_server.py
@@ -119,6 +119,13 @@ def test_get_lesson_not_found(mock_index):
     assert "error" in results
 
 
+def test_get_lesson_empty_path(mock_index):
+    """get_lesson returns error dict for empty path (not first lesson)."""
+    results = get_lesson("")
+    assert "error" in results
+    assert results.get("title") is None
+
+
 def test_list_categories(mock_index):
     """list_categories returns sorted unique category names."""
     cats = list_categories()

--- a/packages/gptme-lessons-mcp/tests/test_mcp_server.py
+++ b/packages/gptme-lessons-mcp/tests/test_mcp_server.py
@@ -1,0 +1,128 @@
+"""Tests for the gptme-lessons-mcp server."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gptme_lessons_mcp.mcp_server import get_lesson, list_categories, list_lessons, match_lessons
+
+
+def _make_mock_lesson(
+    title="Test Lesson", category="tools", keywords=None, body="# Test\n\nContent."
+):
+    """Create a mock Lesson object."""
+    lesson = MagicMock()
+    lesson.title = title
+    lesson.category = category
+    lesson.description = "A test lesson."
+    lesson.body = body
+    lesson.path = Path(f"/tmp/fake/lessons/{category}/{title.lower().replace(' ', '-')}.md")
+    lesson.metadata.keywords = keywords or ["test", "example"]
+    lesson.metadata.status = "active"
+    lesson.metadata.name = None
+    return lesson
+
+
+@pytest.fixture
+def mock_index():
+    """Patch LessonIndex to return a controlled set of lessons."""
+    lessons = [
+        _make_mock_lesson("Git Workflow", "tools", ["git", "commit", "patch"]),
+        _make_mock_lesson("Error Handling", "patterns", ["error", "exception", "handle"]),
+        _make_mock_lesson("Testing Strategy", "workflow", ["test", "pytest", "coverage"]),
+    ]
+    with patch("gptme_lessons_mcp.mcp_server._load_index") as mock_load:
+        idx = MagicMock()
+        idx.lessons = lessons
+        mock_load.return_value = idx
+        yield mock_load, lessons
+
+
+def test_match_lessons_returns_matches(mock_index):
+    """match_lessons finds relevant lessons for a context string."""
+    _, lessons = mock_index
+    results = match_lessons("I need to commit changes with git patch")
+    assert len(results) >= 1
+    titles = [r["title"] for r in results]
+    assert "Git Workflow" in titles
+
+
+def test_match_lessons_top_k(mock_index):
+    """match_lessons respects top_k limit."""
+    results = match_lessons("test example", top_k=1)
+    assert len(results) <= 1
+
+
+def test_match_lessons_no_match(mock_index):
+    """match_lessons returns empty list when nothing matches."""
+    results = match_lessons("unrelated zebra database query")
+    # May return results since keywords could overlap — just verify it returns a list
+    assert isinstance(results, list)
+
+
+def test_match_lessons_has_required_fields(mock_index):
+    """match_lessons results include expected fields."""
+    results = match_lessons("git commit")
+    if results:
+        r = results[0]
+        assert "title" in r
+        assert "category" in r
+        assert "body" in r
+        assert "score" in r
+        assert "matched_by" in r
+
+
+def test_list_lessons_all(mock_index):
+    """list_lessons returns all lessons when no filter given."""
+    results = list_lessons()
+    assert len(results) == 3
+
+
+def test_list_lessons_by_category(mock_index):
+    """list_lessons filters by category."""
+    results = list_lessons(category="tools")
+    assert all(r["category"] == "tools" for r in results)
+    assert len(results) == 1
+
+
+def test_list_lessons_by_search(mock_index):
+    """list_lessons filters by text search."""
+    results = list_lessons(search="error")
+    titles = [r["title"] for r in results]
+    assert "Error Handling" in titles
+
+
+def test_list_lessons_no_body(mock_index):
+    """list_lessons does not include body to keep responses compact."""
+    results = list_lessons()
+    for r in results:
+        assert "body" not in r
+
+
+def test_get_lesson_by_path(mock_index):
+    """get_lesson finds a lesson by path substring."""
+    results = get_lesson("git-workflow")
+    assert results.get("title") == "Git Workflow"
+    assert "body" in results
+
+
+def test_get_lesson_by_title(mock_index):
+    """get_lesson falls back to title substring match."""
+    results = get_lesson("Error Handling")
+    assert results.get("title") == "Error Handling"
+
+
+def test_get_lesson_not_found(mock_index):
+    """get_lesson returns error dict when nothing matches."""
+    results = get_lesson("does-not-exist-xyz")
+    assert "error" in results
+
+
+def test_list_categories(mock_index):
+    """list_categories returns sorted unique category names."""
+    cats = list_categories()
+    assert "tools" in cats
+    assert "patterns" in cats
+    assert "workflow" in cats
+    assert cats == sorted(cats)

--- a/uv.lock
+++ b/uv.lock
@@ -36,6 +36,7 @@ members = [
     "gptme-hooks-examples",
     "gptme-imagen",
     "gptme-lessons-extras",
+    "gptme-lessons-mcp",
     "gptme-lsp",
     "gptme-rag",
     "gptme-ralph",
@@ -2092,6 +2093,34 @@ requires-dist = [
     { name = "rich", specifier = ">=13.0.0" },
 ]
 provides-extras = ["dev"]
+
+[[package]]
+name = "gptme-lessons-mcp"
+version = "0.1.0"
+source = { editable = "packages/gptme-lessons-mcp" }
+dependencies = [
+    { name = "gptme" },
+    { name = "mcp" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+]
+test = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "gptme", git = "https://github.com/gptme/gptme.git?branch=master" },
+    { name = "mcp", specifier = ">=1.0" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
+]
+provides-extras = ["dev", "test"]
 
 [[package]]
 name = "gptme-lsp"


### PR DESCRIPTION
## Summary

Adds `gptme-lessons-mcp` — a stdio MCP server that exposes gptme's lesson matching system to any MCP client (Claude Code, Cursor, Continue.dev, etc.).

**Problem**: Agents forget why builds fail between sessions. The lesson system encodes durable behavioral knowledge, but it's only accessible to gptme-native runtimes. Claude Code and other agents can't query it.

**Solution**: Wrap `LessonMatcher` + `LessonIndex` as an MCP server so any runtime can call `match_lessons("I'm about to do X")` and get relevant guidance back.

## Tools exposed

- `match_lessons(context, top_k=5)` — keyword-based lesson matching, returns lessons with score and matched keywords
- `list_lessons(category?, search?)` — enumerate active lessons by category or text search
- `get_lesson(path)` — retrieve the full body of a specific lesson
- `list_categories()` — list all lesson categories in the library

## Usage

```bash
# Auto-discover lessons from gptme config (stdio)
uv run gptme-lessons-mcp

# Explicit lesson directory
uv run gptme-lessons-mcp --lessons-dir ~/my-agent/lessons

# Claude Code .mcp.json
{
  "mcpServers": {
    "lessons": {
      "command": "uv",
      "args": ["run", "gptme-lessons-mcp", "--lessons-dir", "~/my-agent/lessons"]
    }
  }
}
```

## What's included

- `packages/gptme-lessons-mcp/` — new package following `gptme-wisdom-mcp` conventions
- `src/gptme_lessons_mcp/mcp_server.py` — FastMCP server wrapping `LessonIndex` + `LessonMatcher`
- `tests/test_mcp_server.py` — 12 passing unit tests (mock-based)
- Validated against Bob's 408-lesson library: keyword matching works correctly

## Test plan

- [x] 12 unit tests pass
- [x] ruff, mypy, typecheck all clean
- [x] Smoke-tested against real lesson library (408 lessons, phrase matching confirmed)
- [ ] Manual test: wire into Claude Code `.mcp.json` pointing at real lessons dir

Closes: gptme/gptme Discussion #3425 (cross-runtime agent memory via lessons)