### PR TITLE
feat(signals): add Grok Build streaming-json signal extractor

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -223,11 +223,12 @@ def parse_trajectory(jsonl_path: Path) -> list[dict]:
 def _detect_format(msgs: list[dict]) -> str:
     """Detect trajectory format from parsed JSONL records.
 
-    Returns one of: 'gptme', 'claude_code', 'codex', 'copilot'.
+    Returns one of: 'gptme', 'claude_code', 'codex', 'copilot', 'grok'.
 
     Detection heuristics (checked in order):
     - **Codex**: first record has type='session_meta' with originator='codex_exec'
     - **Copilot**: first record has type='session.start' with producer='copilot-agent'
+    - **Grok Build**: first record has type='available_commands' (capability broadcast)
     - **gptme**: any record has a top-level 'role' field
     - **Claude Code**: any record has type in (user, assistant, result)
 
@@ -246,6 +247,9 @@ def _detect_format(msgs: list[dict]) -> str:
             data = first.get("data") or {}
             if data.get("producer") == "copilot-agent":
                 return "copilot"
+        # Grok Build: first line is always available_commands capability broadcast
+        if first.get("type") == "available_commands":
+            return "grok"
 
     for msg in msgs:
         if "role" in msg:
@@ -2198,10 +2202,151 @@ def extract_usage_copilot(msgs: list[dict]) -> dict:
     return usage
 
 
+_GROK_WRITE_TOOLS = {"write", "search_replace"}
+
+
+def extract_signals_grok(msgs: list[dict]) -> dict:
+    """Extract productivity signals from Grok Build streaming-json trajectories.
+
+    Grok format uses typed NDJSON records (--output-format streaming-json):
+    - available_commands: tool/command catalog (session start marker)
+    - tool_call: agent tool invocation (toolName + rawInput)
+    - tool_call_update: execution update (status=completed has rawOutput)
+    - text/thought: response/reasoning text deltas
+    - usage: per-turn token usage
+    - end: session summary (cumulative usage, num_turns, cost)
+
+    Shell tool: run_terminal_command (rawInput.command, rawOutput.output_for_prompt)
+    File write tools: write, search_replace (rawInput.path)
+    Git commits detected from run_terminal_command rawOutput.output_for_prompt.
+    """
+    tool_calls: dict[str, int] = {}
+    error_count = 0
+    git_commits: list[str] = []
+    file_writes: list[str] = []
+    journal_paths: list[str] = []
+    steps = 0
+    detail_by_value: dict[str, dict[str, object]] = {}
+    call_id_to_input: dict[str, dict] = {}
+    current_batch_has_tool = False
+
+    for record in msgs:
+        rec_type = record.get("type", "")
+
+        if rec_type == "tool_call":
+            tool_name = record.get("toolName", "")
+            raw_input = record.get("rawInput") or {}
+            call_id = record.get("toolCallId", "")
+
+            if tool_name:
+                tool_calls[tool_name] = tool_calls.get(tool_name, 0) + 1
+                current_batch_has_tool = True
+            if call_id:
+                call_id_to_input[call_id] = raw_input
+
+            if tool_name in _GROK_WRITE_TOOLS:
+                path = raw_input.get("path", "")
+                if path:
+                    if "/journal/" in path:
+                        journal_paths.append(path)
+                    else:
+                        file_writes.append(path)
+                    _record_deliverable_detail(
+                        detail_by_value,
+                        value=path,
+                        kind="file",
+                        provenance_class="tool_authored",
+                        evidence={"source": "trajectory", "tool_name": tool_name},
+                    )
+
+        elif rec_type == "tool_call_update":
+            if record.get("status") != "completed":
+                continue
+            call_id = record.get("toolCallId", "")
+            raw_output = record.get("rawOutput") or {}
+            if not isinstance(raw_output, dict):
+                continue
+
+            exit_code = raw_output.get("exit_code")
+            if isinstance(exit_code, int) and exit_code != 0:
+                error_count += 1
+
+            raw_input = call_id_to_input.get(call_id, {})
+            command = raw_input.get("command", "") or raw_output.get("command", "")
+            if command and ("git commit" in command or "git-safe-commit" in command):
+                output_text = raw_output.get("output_for_prompt", "")
+                for commit_match in _COMMIT_RE.finditer(output_text):
+                    commit_value = f"{commit_match.group(1)} {commit_match.group(2).strip()}"
+                    if commit_value not in git_commits:
+                        git_commits.append(commit_value)
+                        _record_deliverable_detail(
+                            detail_by_value,
+                            value=commit_value,
+                            kind="git_commit",
+                            provenance_class="tool_authored",
+                            evidence={"source": "trajectory", "tool_name": "run_terminal_command"},
+                        )
+
+        elif rec_type == "text" and current_batch_has_tool:
+            steps += 1
+            current_batch_has_tool = False
+
+    if current_batch_has_tool:
+        steps += 1
+
+    deliverables = list(dict.fromkeys(git_commits + file_writes))
+    deliverable_details = _ordered_deliverable_details(deliverables, detail_by_value)
+
+    return {
+        "tool_calls": tool_calls,
+        "steps": steps,
+        "error_count": error_count,
+        "git_commits": git_commits,
+        "file_writes": file_writes,
+        "journal_paths": list(dict.fromkeys(journal_paths)),
+        "session_duration_s": None,
+        "retry_count": 0,
+        "deliverables": deliverables,
+        "deliverable_details": deliverable_details,
+        "summarizer_fired": False,
+    }
+
+
+def extract_usage_grok(msgs: list[dict]) -> dict:
+    """Extract token usage from Grok Build streaming-json trajectories.
+
+    Reads from the final 'end' record which has cumulative session totals.
+    Model name comes from the modelUsage dict (keyed by model id).
+    """
+    for record in reversed(msgs):
+        if record.get("type") != "end":
+            continue
+        usage_data = record.get("usage") or {}
+        if not usage_data:
+            continue
+        result: dict = {}
+        input_tokens = usage_data.get("input_tokens")
+        output_tokens = usage_data.get("output_tokens")
+        cache_read = usage_data.get("cache_read_input_tokens")
+        if isinstance(input_tokens, int) and input_tokens > 0:
+            result["input_tokens"] = input_tokens
+        if isinstance(output_tokens, int) and output_tokens > 0:
+            result["output_tokens"] = output_tokens
+        if isinstance(cache_read, int) and cache_read > 0:
+            result["cache_read_input_tokens"] = cache_read
+        model_usage = record.get("modelUsage") or {}
+        if model_usage:
+            model_name = next(iter(model_usage), None)
+            if model_name:
+                result["model"] = model_name
+        return result
+    return {}
+
+
 def extract_from_path(jsonl_path: Path) -> dict:
     """Parse trajectory and return signals + grade in one call.
 
-    Auto-detects format: gptme, Claude Code, Codex, or Copilot.
+    Auto-detects format: gptme, Claude Code, Codex, Copilot, or Grok Build.
     Token usage is extracted when available (CC has full counts, Codex has
     rate-limit percentages only, Copilot has model info only).
 
@@ -2228,6 +2373,9 @@ def extract_from_path(jsonl_path: Path) -> dict:
     elif fmt == "copilot":
         signals = extract_signals_copilot(msgs)
         usage = extract_usage_copilot(msgs)
+    elif fmt == "grok":
+        signals = extract_signals_grok(msgs)
+        usage = extract_usage_grok(msgs)
     else:
         signals = extract_signals(msgs)
         usage = extract_usage_gptme(msgs)

--- a/packages/gptme-sessions/src/gptme_sessions/transcript.py
+++ b/packages/gptme-sessions/src/gptme_sessions/transcript.py
@@ -4,7 +4,7 @@ Reads raw harness-specific JSONL files and produces a stable, version-tagged
 JSON contract that external consumers (dashboards, fleet operators, analysis
 tools) can depend on without parsing harness-specific formats directly.
 
-Supported harnesses: gptme, claude-code, codex, copilot.
+Supported harnesses: gptme, claude-code, codex, copilot, grok.
 
 Schema version: 1 (increment when breaking changes are made to the output shape).
 """
@@ -379,6 +379,72 @@ def _normalize_copilot(msgs: list[dict]) -> list[NormalizedMessage]:
     return normalized
 
 
+def _normalize_grok(msgs: list[dict]) -> list[NormalizedMessage]:
+    """Normalize Grok Build streaming-json NDJSON messages.
+
+    Grok format uses typed records (--output-format streaming-json):
+    - ``available_commands``: tool catalog at session start (skipped)
+    - ``thought``: agent reasoning delta (``content`` field) → assistant turn
+    - ``tool_call``: agent tool invocation (``toolName``, ``rawInput``, ``toolCallId``)
+    - ``tool_call_update``: execution result (``status == "completed"`` carries ``rawOutput``)
+    - ``text``: assistant response text delta (``content`` field)
+    - ``usage``/``end``: token accounting (skipped)
+    """
+    normalized: list[NormalizedMessage] = []
+    call_id_to_input: dict[str, dict] = {}
+
+    for record in msgs:
+        rec_type = record.get("type", "")
+        ts = _ts_str(_parse_timestamp(record.get("timestamp", "")))
+
+        if rec_type in ("thought", "text"):
+            content = record.get("content", "") or ""
+            if content:
+                normalized.append(
+                    NormalizedMessage(role="assistant", content=content, timestamp=ts)
+                )
+
+        elif rec_type == "tool_call":
+            tool_name = record.get("toolName", "")
+            raw_input = record.get("rawInput") or {}
+            call_id = record.get("toolCallId", "")
+            if call_id:
+                call_id_to_input[call_id] = raw_input
+            if tool_name:
+                normalized.append(
+                    NormalizedMessage(
+                        role="assistant",
+                        content="",
+                        timestamp=ts,
+                        tool_name=tool_name,
+                        tool_input=raw_input if isinstance(raw_input, dict) else {},
+                    )
+                )
+
+        elif rec_type == "tool_call_update":
+            if record.get("status") != "completed":
+                continue
+            raw_output = record.get("rawOutput") or {}
+            if not isinstance(raw_output, dict):
+                continue
+            exit_code = raw_output.get("exit_code")
+            is_error = isinstance(exit_code, int) and exit_code != 0
+            output_text = (
+                raw_output.get("output_for_prompt", "") or raw_output.get("output", "") or ""
+            )
+            normalized.append(
+                NormalizedMessage(
+                    role="tool_result",
+                    content=str(output_text),
+                    timestamp=ts,
+                    tool_result=str(output_text),
+                    is_error=is_error,
+                )
+            )
+
+    return normalized
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -417,13 +483,23 @@ def _extract_model(fmt: str, msgs: list[dict], path: Path) -> str | None:
                 return str(model)
         return None
 
+    if fmt == "grok":
+        for record in reversed(msgs):
+            if record.get("type") != "end":
+                continue
+            model_usage = record.get("modelUsage") or {}
+            model_name = next(iter(model_usage), None)
+            if model_name:
+                return str(model_name)
+        return None
+
     return None
 
 
 def read_transcript(path: Path) -> SessionTranscript:
     """Read a trajectory file and return a normalized SessionTranscript.
 
-    Auto-detects the harness format (gptme, claude-code, codex, copilot).
+    Auto-detects the harness format (gptme, claude-code, codex, copilot, grok).
     The ``messages`` list is in chronological order as they appear in the
     source file — no resorting is applied.
 
@@ -457,6 +533,7 @@ def read_transcript(path: Path) -> SessionTranscript:
         "claude_code": "claude-code",
         "codex": "codex",
         "copilot": "copilot",
+        "grok": "grok",
     }
     harness = harness_map.get(fmt, fmt)
 
@@ -467,6 +544,8 @@ def read_transcript(path: Path) -> SessionTranscript:
         norm_msgs = _normalize_codex(msgs)
     elif fmt == "copilot":
         norm_msgs = _normalize_copilot(msgs)
+    elif fmt == "grok":
+        norm_msgs = _normalize_grok(msgs)
     else:
         norm_msgs = _normalize_gptme(msgs)
 

--- a/packages/gptme-sessions/tests/test_signals_grok.py
+++ b/packages/gptme-sessions/tests/test_signals_grok.py
@@ -1,0 +1,311 @@
+"""Unit tests for Grok Build streaming-json signal extraction.
+
+Grok Build records are NDJSON with typed fields:
+  available_commands, thought, tool_call, tool_call_update, text, usage, end.
+
+The extractor detects this format via the opening `available_commands` record
+and dispatches to extract_signals_grok / extract_usage_grok.
+"""
+
+from __future__ import annotations
+
+from gptme_sessions.signals import (
+    _detect_format,
+    extract_signals_grok,
+    extract_usage_grok,
+)
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _available_commands() -> dict:
+    return {
+        "type": "available_commands",
+        "commands": ["run_terminal_command", "write", "search_replace", "read"],
+    }
+
+
+def _thought(text: str = "thinking...") -> dict:
+    return {"type": "thought", "content": text}
+
+
+def _tool_call(
+    tool_name: str,
+    raw_input: dict,
+    call_id: str = "tc1",
+) -> dict:
+    return {
+        "type": "tool_call",
+        "toolName": tool_name,
+        "toolCallId": call_id,
+        "rawInput": raw_input,
+    }
+
+
+def _tool_call_update(
+    call_id: str = "tc1",
+    status: str = "completed",
+    raw_output: dict | None = None,
+    exit_code: int = 0,
+) -> dict:
+    output = (
+        raw_output if raw_output is not None else {"exit_code": exit_code, "output_for_prompt": ""}
+    )
+    return {
+        "type": "tool_call_update",
+        "toolCallId": call_id,
+        "status": status,
+        "rawOutput": output,
+    }
+
+
+def _text(content: str = "Done.") -> dict:
+    return {"type": "text", "content": content}
+
+
+def _end_record(
+    input_tokens: int = 100, output_tokens: int = 50, model: str = "grok-4.5-build"
+) -> dict:
+    return {
+        "type": "end",
+        "usage": {
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cache_read_input_tokens": 0,
+        },
+        "modelUsage": {model: {"input_tokens": input_tokens, "output_tokens": output_tokens}},
+    }
+
+
+# ─── _detect_format ──────────────────────────────────────────────────────────
+
+
+def test_detect_format_grok_on_available_commands_first_record():
+    msgs = [_available_commands(), _thought()]
+    assert _detect_format(msgs) == "grok"
+
+
+def test_detect_format_grok_not_triggered_by_other_types():
+    """Non-grok streams (gptme, CC) must not be mis-detected as grok."""
+    cc_msgs = [
+        {
+            "type": "system",
+            "timestamp": "2026-01-01T00:00:00Z",
+            "message": {"role": "system", "content": "You are an AI."},
+        },
+        {
+            "type": "assistant",
+            "timestamp": "2026-01-01T00:00:01Z",
+            "message": {"role": "assistant", "content": []},
+        },
+    ]
+    fmt = _detect_format(cc_msgs)
+    assert fmt != "grok"
+
+
+def test_detect_format_empty_returns_gptme_default():
+    # _detect_format falls back to 'gptme' when no records match any known format.
+    assert _detect_format([]) == "gptme"
+
+
+# ─── extract_signals_grok ────────────────────────────────────────────────────
+
+
+def test_extract_signals_grok_empty_trajectory_returns_clean_structure():
+    sigs = extract_signals_grok([])
+    assert sigs["tool_calls"] == {}
+    assert sigs["git_commits"] == []
+    assert sigs["file_writes"] == []
+    assert sigs["deliverables"] == []
+
+
+def test_extract_signals_grok_run_terminal_command_counted():
+    msgs = [
+        _available_commands(),
+        _tool_call("run_terminal_command", {"command": "ls -la"}, "tc1"),
+        _tool_call_update("tc1", raw_output={"exit_code": 0, "output_for_prompt": "total 8\n"}),
+    ]
+    sigs = extract_signals_grok(msgs)
+    assert sigs["tool_calls"]["run_terminal_command"] == 1
+    assert sigs["git_commits"] == []
+    assert sigs["file_writes"] == []
+
+
+def test_extract_signals_grok_git_commit_detected_from_output():
+    commit_output = "[master abc1234] feat: add grok extractor\n 3 files changed\n"
+    msgs = [
+        _available_commands(),
+        _tool_call(
+            "run_terminal_command",
+            {"command": "git commit src/foo.py -m 'feat: add grok extractor'"},
+            "tc1",
+        ),
+        _tool_call_update("tc1", raw_output={"exit_code": 0, "output_for_prompt": commit_output}),
+        _text("Committed."),
+    ]
+    sigs = extract_signals_grok(msgs)
+    assert len(sigs["git_commits"]) == 1
+    assert "abc1234" in sigs["git_commits"][0]
+    assert "abc1234" in sigs["deliverables"][0]
+
+
+def test_extract_signals_grok_git_safe_commit_also_detected():
+    """git-safe-commit output should be parsed the same as plain git commit."""
+    commit_output = "[master f3ad1ab] fix: cleanup\n 1 file changed\n"
+    msgs = [
+        _available_commands(),
+        _tool_call(
+            "run_terminal_command",
+            {"command": "git-safe-commit --scope-only file.py -m 'fix: cleanup'"},
+            "tc1",
+        ),
+        _tool_call_update("tc1", raw_output={"exit_code": 0, "output_for_prompt": commit_output}),
+    ]
+    sigs = extract_signals_grok(msgs)
+    assert any("f3ad1ab" in c for c in sigs["git_commits"])
+
+
+def test_extract_signals_grok_no_commit_when_git_command_absent():
+    """A run_terminal_command that does NOT call git commit must not produce a commit record."""
+    commit_output = "[master abc9999] feat: thing"  # looks like commit but command differs
+    msgs = [
+        _available_commands(),
+        _tool_call("run_terminal_command", {"command": "cat CHANGELOG.md"}, "tc1"),
+        _tool_call_update("tc1", raw_output={"exit_code": 0, "output_for_prompt": commit_output}),
+    ]
+    sigs = extract_signals_grok(msgs)
+    assert sigs["git_commits"] == []
+
+
+def test_extract_signals_grok_write_tool_captured_as_file_write():
+    msgs = [
+        _available_commands(),
+        _tool_call("write", {"path": "/home/bob/bob/scripts/foo.py", "content": "x=1"}, "tc1"),
+        _tool_call_update("tc1", raw_output={"exit_code": 0, "output_for_prompt": "Written."}),
+    ]
+    sigs = extract_signals_grok(msgs)
+    assert "/home/bob/bob/scripts/foo.py" in sigs["file_writes"]
+    assert "/home/bob/bob/scripts/foo.py" in sigs["deliverables"]
+
+
+def test_extract_signals_grok_search_replace_captured_as_file_write():
+    msgs = [
+        _available_commands(),
+        _tool_call(
+            "search_replace", {"path": "/home/bob/bob/AGENTS.md", "old": "foo", "new": "bar"}, "tc1"
+        ),
+        _tool_call_update("tc1", raw_output={"exit_code": 0, "output_for_prompt": "Replaced."}),
+    ]
+    sigs = extract_signals_grok(msgs)
+    assert "/home/bob/bob/AGENTS.md" in sigs["file_writes"]
+
+
+def test_extract_signals_grok_journal_path_goes_to_journal_paths_not_file_writes():
+    msgs = [
+        _available_commands(),
+        _tool_call(
+            "write",
+            {
+                "path": "/home/bob/bob/journal/2026-08-04/autonomous-session-f3ad.md",
+                "content": "# Session",
+            },
+            "tc1",
+        ),
+        _tool_call_update("tc1", raw_output={"exit_code": 0, "output_for_prompt": "Written."}),
+    ]
+    sigs = extract_signals_grok(msgs)
+    assert "/home/bob/bob/journal/2026-08-04/autonomous-session-f3ad.md" in sigs["journal_paths"]
+    assert "/home/bob/bob/journal/2026-08-04/autonomous-session-f3ad.md" not in sigs["file_writes"]
+
+
+def test_extract_signals_grok_non_completed_update_skipped():
+    """tool_call_update with status != 'completed' must not be parsed for output."""
+    msgs = [
+        _available_commands(),
+        _tool_call("run_terminal_command", {"command": "git commit file.py -m 'feat: x'"}, "tc1"),
+        # status=running — should be ignored even if output looks like a commit
+        {
+            "type": "tool_call_update",
+            "toolCallId": "tc1",
+            "status": "running",
+            "rawOutput": {"exit_code": 0, "output_for_prompt": "[master abc0000] feat: x"},
+        },
+    ]
+    sigs = extract_signals_grok(msgs)
+    assert sigs["git_commits"] == []
+
+
+def test_extract_signals_grok_error_count_incremented_on_nonzero_exit():
+    msgs = [
+        _available_commands(),
+        _tool_call("run_terminal_command", {"command": "make test"}, "tc1"),
+        _tool_call_update("tc1", raw_output={"exit_code": 1, "output_for_prompt": "FAILED"}),
+    ]
+    sigs = extract_signals_grok(msgs)
+    assert sigs["error_count"] >= 1
+
+
+def test_extract_signals_grok_multiple_tool_calls_aggregated():
+    msgs = [
+        _available_commands(),
+        _tool_call("run_terminal_command", {"command": "ls"}, "tc1"),
+        _tool_call_update("tc1"),
+        _tool_call("write", {"path": "/tmp/a.py", "content": ""}, "tc2"),
+        _tool_call_update("tc2"),
+        _tool_call("run_terminal_command", {"command": "cat /tmp/a.py"}, "tc3"),
+        _tool_call_update("tc3"),
+    ]
+    sigs = extract_signals_grok(msgs)
+    assert sigs["tool_calls"]["run_terminal_command"] == 2
+    assert sigs["tool_calls"]["write"] == 1
+
+
+def test_extract_signals_grok_duplicate_commits_deduplicated():
+    """The same commit SHA appearing twice must yield only one deliverable."""
+    commit_output = "[master aaabbb1] feat: thing"
+    msgs = [
+        _available_commands(),
+        _tool_call("run_terminal_command", {"command": "git commit f.py -m 'feat: thing'"}, "tc1"),
+        _tool_call_update("tc1", raw_output={"exit_code": 0, "output_for_prompt": commit_output}),
+        _tool_call("run_terminal_command", {"command": "git commit -m 'feat: thing'"}, "tc2"),
+        _tool_call_update("tc2", raw_output={"exit_code": 0, "output_for_prompt": commit_output}),
+    ]
+    sigs = extract_signals_grok(msgs)
+    assert len(sigs["git_commits"]) == 1
+
+
+# ─── extract_usage_grok ──────────────────────────────────────────────────────
+
+
+def test_extract_usage_grok_reads_from_end_record():
+    msgs = [
+        _available_commands(),
+        _text("Done."),
+        _end_record(input_tokens=7170, output_tokens=114, model="grok-4.5-build"),
+    ]
+    usage = extract_usage_grok(msgs)
+    assert usage["input_tokens"] == 7170
+    assert usage["output_tokens"] == 114
+    assert usage["model"] == "grok-4.5-build"
+
+
+def test_extract_usage_grok_empty_trajectory():
+    assert extract_usage_grok([]) == {}
+
+
+def test_extract_usage_grok_no_end_record():
+    msgs = [_available_commands(), _text("incomplete")]
+    assert extract_usage_grok(msgs) == {}
+
+
+def test_extract_usage_grok_cache_read_tokens_included():
+    msgs = [
+        _available_commands(),
+        {
+            "type": "end",
+            "usage": {"input_tokens": 1000, "output_tokens": 50, "cache_read_input_tokens": 29184},
+            "modelUsage": {"grok-4.5-build": {}},
+        },
+    ]
+    usage = extract_usage_grok(msgs)
+    assert usage["cache_read_input_tokens"] == 29184

--- a/packages/gptme-sessions/tests/test_transcript.py
+++ b/packages/gptme-sessions/tests/test_transcript.py
@@ -14,6 +14,7 @@ from gptme_sessions.transcript import (
     _normalize_codex,
     _normalize_copilot,
     _normalize_gptme,
+    _normalize_grok,
     read_transcript,
 )
 
@@ -165,6 +166,33 @@ def copilot_jsonl(tmp_path: Path) -> Path:
     return _write_jsonl(tmp_path / "events.jsonl", records)
 
 
+@pytest.fixture
+def grok_jsonl(tmp_path: Path) -> Path:
+    records = [
+        {"type": "available_commands", "commands": ["run_terminal_command", "write"]},
+        {"type": "thought", "content": "I will write a test file."},
+        {
+            "type": "tool_call",
+            "toolName": "write",
+            "toolCallId": "tc1",
+            "rawInput": {"path": "test.py", "content": "# test"},
+        },
+        {
+            "type": "tool_call_update",
+            "toolCallId": "tc1",
+            "status": "completed",
+            "rawOutput": {"exit_code": 0, "output_for_prompt": "File written."},
+        },
+        {"type": "text", "content": "Done."},
+        {
+            "type": "end",
+            "usage": {"input_tokens": 100, "output_tokens": 50},
+            "modelUsage": {"grok-4.5-build": {"input_tokens": 100, "output_tokens": 50}},
+        },
+    ]
+    return _write_jsonl(tmp_path / "session.jsonl", records)
+
+
 # ---------------------------------------------------------------------------
 # Unit tests for normalizers
 # ---------------------------------------------------------------------------
@@ -275,6 +303,57 @@ class TestNormalizeCodex:
         assert "exited" in results[0].content.lower()
 
 
+class TestNormalizeGrok:
+    def test_thought_emitted(self, grok_jsonl: Path):
+        records = [json.loads(line) for line in grok_jsonl.read_text().strip().splitlines()]
+        norm = _normalize_grok(records)
+        text_msgs = [m for m in norm if m.role == "assistant" and not m.tool_name and m.content]
+        assert any("write a test" in m.content.lower() for m in text_msgs)
+
+    def test_tool_call_emitted(self, grok_jsonl: Path):
+        records = [json.loads(line) for line in grok_jsonl.read_text().strip().splitlines()]
+        norm = _normalize_grok(records)
+        tool_msgs = [m for m in norm if m.tool_name]
+        assert len(tool_msgs) == 1
+        assert tool_msgs[0].tool_name == "write"
+        assert tool_msgs[0].tool_input == {"path": "test.py", "content": "# test"}
+
+    def test_tool_result_emitted(self, grok_jsonl: Path):
+        records = [json.loads(line) for line in grok_jsonl.read_text().strip().splitlines()]
+        norm = _normalize_grok(records)
+        results = [m for m in norm if m.role == "tool_result"]
+        assert len(results) == 1
+        assert "written" in results[0].content.lower()
+        assert results[0].is_error is False
+
+    def test_skips_available_commands_and_end(self, grok_jsonl: Path):
+        records = [json.loads(line) for line in grok_jsonl.read_text().strip().splitlines()]
+        norm = _normalize_grok(records)
+        # available_commands and end records must not produce messages
+        assert all(m.role in ("assistant", "tool_result") for m in norm)
+
+    def test_error_tool_result(self):
+        records = [
+            {"type": "available_commands", "commands": ["run_terminal_command"]},
+            {
+                "type": "tool_call",
+                "toolName": "run_terminal_command",
+                "toolCallId": "tc_err",
+                "rawInput": {"command": "ls /nonexistent"},
+            },
+            {
+                "type": "tool_call_update",
+                "toolCallId": "tc_err",
+                "status": "completed",
+                "rawOutput": {"exit_code": 1, "output_for_prompt": "ls: cannot access"},
+            },
+        ]
+        norm = _normalize_grok(records)
+        results = [m for m in norm if m.role == "tool_result"]
+        assert len(results) == 1
+        assert results[0].is_error is True
+
+
 class TestNormalizeCopilot:
     def test_assistant_text(self, copilot_jsonl: Path):
         records = [json.loads(line) for line in copilot_jsonl.read_text().strip().splitlines()]
@@ -330,6 +409,15 @@ class TestReadTranscript:
         assert t.harness == "copilot"
         assert t.model == "gpt-5.4"
         assert len(t.messages) > 0
+
+    def test_grok_transcript(self, grok_jsonl: Path):
+        t = read_transcript(grok_jsonl)
+        assert t.harness == "grok"
+        assert t.model == "grok-4.5-build"
+        assert len(t.messages) > 0
+        tool_msgs = [m for m in t.messages if m.tool_name]
+        assert len(tool_msgs) == 1
+        assert tool_msgs[0].tool_name == "write"
 
     def test_started_at_and_last_activity(self, gptme_jsonl: Path):
         t = read_transcript(gptme_jsonl)


### PR DESCRIPTION
## Summary

- `_detect_format`: recognizes grok format via opening `available_commands` record
- `extract_signals_grok`: parses `tool_call`/`tool_call_update` records; detects git commits from `run_terminal_command` output via `_COMMIT_RE`; routes `write`/`search_replace` paths to `file_writes`; separates journal paths
- `extract_usage_grok`: reads cumulative token counts from the `end` record
- `extract_from_path`: adds `grok` dispatch branch
- `test_signals_grok.py`: 19 tests covering format detection, tool counting, commit extraction, file write routing, dedup, error counting, and usage parsing

**Root cause**: all 37 historical grok-build sessions graded noop (`deliverables: []`) because `_detect_format` had no grok case — the classic trajectory-format-drift false-noop signature. Verified on a live session: `format=grok`, `tool_calls={'run_terminal_command': 1}` (non-empty), `usage={'input_tokens': 7170, 'output_tokens': 114, 'model': 'grok-4.5-build'}`.

## Test plan

- [x] `uv run pytest gptme-contrib/packages/gptme-sessions/tests/test_signals_grok.py -v` → 19 passed
- [x] Full test suite: 1073 passed, no regressions
- [x] Live grok session verified: format detected, tool_calls non-empty