### PR TITLE
feat(bobutils): add safe_write — symlink-safe atomic file writer

### DIFF
--- a/packages/bobutils/src/bobutils/safe_write.py
+++ b/packages/bobutils/src/bobutils/safe_write.py
@@ -32,6 +32,7 @@ Both functions are stdlib-only and have no external dependencies.
 from __future__ import annotations
 
 import os
+import stat
 import tempfile
 from pathlib import Path
 
@@ -50,9 +51,10 @@ def safe_write(path: Path | str, data: str, *, mode: int = 0o644) -> None:
     Args:
         path:  Destination path (may be a symlink or symlink chain).
         data:  Text content to write, encoded as UTF-8.
-        mode:  Permission bits for a *newly created* file.  When the target
-               already exists, its existing permissions are kept by
-               ``os.replace``.
+        mode:  Permission bits applied when creating a *new* file.  When the
+               target already exists, its current permissions are preserved —
+               this prevents accidentally widening restrictive modes (e.g.
+               ``0o600`` credential files).
 
     Raises:
         OSError:  If the write or rename fails (e.g. wrong permissions, full
@@ -69,7 +71,8 @@ def safe_write_bytes(path: Path | str, data: bytes, *, mode: int = 0o644) -> Non
     Args:
         path:  Destination path (may be a symlink or symlink chain).
         data:  Raw bytes to write.
-        mode:  Permission bits for a *newly created* file.
+        mode:  Permission bits applied when creating a *new* file.  Existing
+               file permissions are preserved (see :func:`safe_write`).
 
     Raises:
         OSError:  If the write or rename fails.
@@ -103,11 +106,23 @@ def _atomic_write(path: Path, data: bytes, *, mode: int) -> None:
         # New file or broken symlink — resolve without requiring target to exist
         real = path.resolve(strict=False)
 
-    # Step 2: temp file in the same directory as the real target
-    real.parent.mkdir(parents=True, exist_ok=True)
+    # Step 2: temp file in the same directory as the real target.
+    # parents=False: if the direct parent doesn't exist (e.g. broken symlink
+    # pointing into a missing subtree), raise FileNotFoundError as documented.
+    real.parent.mkdir(parents=False, exist_ok=True)
     fd, tmp_name = tempfile.mkstemp(dir=real.parent)
     try:
-        os.chmod(tmp_name, mode)
+        # Preserve existing permissions; use caller-supplied mode only for new
+        # files.  os.replace() transplants the temp inode, so whatever mode the
+        # temp file carries becomes the mode of the resulting file — we must set
+        # it explicitly or existing restrictive modes (e.g. 0o600 credential
+        # files) would be silently widened to the default 0o644.
+        effective_mode = mode
+        try:
+            effective_mode = stat.S_IMODE(os.stat(real).st_mode)
+        except OSError:
+            pass  # Target doesn't exist yet — use caller-supplied mode
+        os.chmod(tmp_name, effective_mode)
         with os.fdopen(fd, "wb") as f:
             f.write(data)
         # Step 3: atomic replace — lands on real target, not the symlink

--- a/packages/bobutils/src/bobutils/safe_write.py
+++ b/packages/bobutils/src/bobutils/safe_write.py
@@ -1,0 +1,120 @@
+"""Symlink-safe atomic file writer.
+
+Guards the clobber class: ``os.replace(tmp, symlink)`` on Linux replaces the
+*symlink itself* with the temp file instead of updating the target content.
+Writers that use this module resolve the symlink chain first, place the temp
+file in the target's parent directory, then atomically replace the real target
+— not the link — leaving all symlinks intact.
+
+Recorded clobber classes this prevents
+---------------------------------------
+- Subscription-slot live symlink (``~/.claude/.credentials.json →
+  .credentials.json.bob``) replaced by a regular file during a credential
+  refresh, silently forking the credential state.
+- Per-slot OCR cache symlinks replaced by fresh scrape outputs, breaking the
+  symlink-based indirection that lets multiple consumers share one file.
+
+Usage
+-----
+::
+
+    from bobutils.safe_write import safe_write, safe_write_bytes
+
+    # Text write — resolves symlinks, writes atomically to the real target
+    safe_write(Path("~/.claude/.credentials.json"), json_text, mode=0o600)
+
+    # Binary write
+    safe_write_bytes(cache_symlink, png_bytes, mode=0o644)
+
+Both functions are stdlib-only and have no external dependencies.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+__all__ = ["safe_write", "safe_write_bytes"]
+
+
+def safe_write(path: Path | str, data: str, *, mode: int = 0o644) -> None:
+    """Atomically write *data* (text, UTF-8) to *path*, preserving symlinks.
+
+    If *path* is a symlink (or a chain of symlinks), the write lands on the
+    resolved real target so all links in the chain are preserved.  A temp
+    file is created in the same directory as the resolved target (ensuring
+    same-filesystem placement for ``os.replace``) and atomically renamed over
+    the target.
+
+    Args:
+        path:  Destination path (may be a symlink or symlink chain).
+        data:  Text content to write, encoded as UTF-8.
+        mode:  Permission bits for a *newly created* file.  When the target
+               already exists, its existing permissions are kept by
+               ``os.replace``.
+
+    Raises:
+        OSError:  If the write or rename fails (e.g. wrong permissions, full
+                  filesystem).
+        FileNotFoundError:  If *path* is a broken symlink and the target's
+                            parent directory does not exist.
+    """
+    _atomic_write(Path(path), data.encode("utf-8"), mode=mode)
+
+
+def safe_write_bytes(path: Path | str, data: bytes, *, mode: int = 0o644) -> None:
+    """Atomically write *data* (bytes) to *path*, preserving symlinks.
+
+    Args:
+        path:  Destination path (may be a symlink or symlink chain).
+        data:  Raw bytes to write.
+        mode:  Permission bits for a *newly created* file.
+
+    Raises:
+        OSError:  If the write or rename fails.
+        FileNotFoundError:  If *path* is a broken symlink and the target's
+                            parent directory does not exist.
+    """
+    _atomic_write(Path(path), data, mode=mode)
+
+
+def _atomic_write(path: Path, data: bytes, *, mode: int) -> None:
+    """Core implementation: resolve → temp → replace at real target.
+
+    Steps
+    -----
+    1. Resolve any symlink chain to the real file path.
+       - If the target exists (normal case): ``resolve(strict=True)`` follows
+         every link and returns the absolute real path.
+       - If the target does not exist yet (new file): fall back to
+         ``resolve(strict=False)`` which collapses ``..`` and resolves as many
+         links as possible; this lets us create the file at the right location.
+    2. Create a temp file in the **same directory** as the real target.
+       Same-directory placement is required for ``os.replace`` to be atomic
+       on POSIX (``rename(2)`` only works within the same filesystem, and
+       temp files in ``/tmp`` could live on a different mount point).
+    3. Write data and atomically rename temp → real target.
+    """
+    # Step 1: resolve symlinks
+    try:
+        real = path.resolve(strict=True)
+    except (FileNotFoundError, OSError):
+        # New file or broken symlink — resolve without requiring target to exist
+        real = path.resolve(strict=False)
+
+    # Step 2: temp file in the same directory as the real target
+    real.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(dir=real.parent)
+    try:
+        os.chmod(tmp_name, mode)
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+        # Step 3: atomic replace — lands on real target, not the symlink
+        os.replace(tmp_name, real)
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise

--- a/packages/bobutils/tests/test_safe_write.py
+++ b/packages/bobutils/tests/test_safe_write.py
@@ -7,8 +7,9 @@ Key invariants tested
 3. Symlink chain: even multi-hop chains are preserved end-to-end.
 4. New file creation: works when destination doesn't exist yet.
 5. Mode bits: new files get the requested permission mode.
-6. Atomic partial-write safety: a write error leaves the original intact.
-7. safe_write_bytes: binary variant works correctly.
+6. Permission preservation: existing file permissions are NOT overwritten by mode.
+7. Atomic partial-write safety: a write error leaves the original intact.
+8. safe_write_bytes: binary variant works correctly.
 """
 
 from __future__ import annotations
@@ -97,18 +98,55 @@ def test_mode_bits_new_file(tmp_path: Path) -> None:
 
 
 def test_mode_bits_symlink_new_target(tmp_path: Path) -> None:
-    """Mode is applied to the real target when writing through a symlink to a new file."""
+    """Mode is applied when writing through a symlink to a *new* (not yet existing) real file."""
     real = tmp_path / "real.json"
     link = tmp_path / "link.json"
-    # Create real file first so the symlink resolves
-    real.write_text("")
+    # Symlink points at real, but real doesn't exist yet — mode should be applied
     link.symlink_to(real)
+    assert not real.exists()
 
     safe_write(link, '{"key": "val"}', mode=0o600)
 
-    # The real file should have the restrictive mode
+    # The newly created real file should have the requested mode
     assert file_mode(real) == 0o600
     assert link.is_symlink(), "symlink clobbered"
+
+
+def test_existing_permissions_preserved(tmp_path: Path) -> None:
+    """Existing file permissions are NOT overwritten by the mode parameter.
+
+    A credential file with 0o600 must stay 0o600 even if the caller passes
+    mode=0o644 (the default).  Silently widening permissions would expose
+    private content to other local users.
+    """
+    secret = tmp_path / "credentials.json"
+    secret.write_text("{}")
+    os.chmod(secret, 0o600)
+    assert file_mode(secret) == 0o600
+
+    # Write with the default mode (0o644) — existing 0o600 must be preserved
+    safe_write(secret, '{"token": "abc"}')
+
+    assert file_mode(secret) == 0o600, (
+        "safe_write widened a 0o600 credential file to "
+        f"{oct(file_mode(secret))} — permissions NOT preserved"
+    )
+    assert secret.read_text() == '{"token": "abc"}'
+
+
+def test_existing_permissions_preserved_through_symlink(tmp_path: Path) -> None:
+    """Permission preservation works when writing through a symlink."""
+    real = tmp_path / "real_creds.json"
+    real.write_text("{}")
+    os.chmod(real, 0o600)
+    link = tmp_path / "creds.json"
+    link.symlink_to(real)
+
+    safe_write(link, '{"token": "xyz"}')
+
+    assert file_mode(real) == 0o600, "permissions of real target were widened"
+    assert link.is_symlink(), "symlink clobbered"
+    assert real.read_text() == '{"token": "xyz"}'
 
 
 def test_original_intact_after_write(tmp_path: Path) -> None:

--- a/packages/bobutils/tests/test_safe_write.py
+++ b/packages/bobutils/tests/test_safe_write.py
@@ -1,0 +1,217 @@
+"""Tests for bobutils.safe_write — symlink-safe atomic file writer.
+
+Key invariants tested
+---------------------
+1. Plain file: content written correctly, no clobber of existing content on error.
+2. Symlink target: symlink is preserved after write (the link itself survives).
+3. Symlink chain: even multi-hop chains are preserved end-to-end.
+4. New file creation: works when destination doesn't exist yet.
+5. Mode bits: new files get the requested permission mode.
+6. Atomic partial-write safety: a write error leaves the original intact.
+7. safe_write_bytes: binary variant works correctly.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from bobutils.safe_write import safe_write, safe_write_bytes
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def file_mode(path: Path) -> int:
+    """Return the bottom 9 permission bits of *path*."""
+    return os.stat(path).st_mode & 0o777
+
+
+# ---------------------------------------------------------------------------
+# safe_write — text
+# ---------------------------------------------------------------------------
+
+
+def test_plain_file(tmp_path: Path) -> None:
+    """Writing to a regular file works as expected."""
+    target = tmp_path / "data.txt"
+    target.write_text("old content")
+
+    safe_write(target, "new content")
+
+    assert target.read_text() == "new content"
+    assert target.is_file() and not target.is_symlink()
+
+
+def test_symlink_preserved(tmp_path: Path) -> None:
+    """Writing through a symlink keeps the symlink alive."""
+    real = tmp_path / "real.txt"
+    real.write_text("original")
+    link = tmp_path / "link.txt"
+    link.symlink_to(real)
+
+    safe_write(link, "updated via link")
+
+    # Symlink must still exist and still point to the real file
+    assert link.is_symlink(), "symlink was clobbered — replaced with a regular file"
+    assert os.readlink(link) == str(real) or Path(os.readlink(link)).name == real.name
+    assert link.read_text() == "updated via link"
+    assert real.read_text() == "updated via link"
+
+
+def test_symlink_chain_preserved(tmp_path: Path) -> None:
+    """Multi-hop symlink chains are fully preserved."""
+    real = tmp_path / "real.txt"
+    real.write_text("base")
+    hop1 = tmp_path / "hop1.txt"
+    hop1.symlink_to(real)
+    hop2 = tmp_path / "hop2.txt"
+    hop2.symlink_to(hop1)
+
+    safe_write(hop2, "chain write")
+
+    assert hop2.is_symlink(), "hop2 symlink clobbered"
+    assert hop1.is_symlink(), "hop1 symlink clobbered"
+    assert real.read_text() == "chain write"
+    assert hop2.read_text() == "chain write"
+
+
+def test_new_file_creation(tmp_path: Path) -> None:
+    """Writing to a non-existent path creates the file."""
+    new_file = tmp_path / "new.txt"
+    assert not new_file.exists()
+
+    safe_write(new_file, "brand new")
+
+    assert new_file.read_text() == "brand new"
+    assert new_file.is_file() and not new_file.is_symlink()
+
+
+def test_mode_bits_new_file(tmp_path: Path) -> None:
+    """Mode bits are applied to newly created files."""
+    target = tmp_path / "secret.json"
+    safe_write(target, "{}", mode=0o600)
+
+    assert file_mode(target) == 0o600
+
+
+def test_mode_bits_symlink_new_target(tmp_path: Path) -> None:
+    """Mode is applied to the real target when writing through a symlink to a new file."""
+    real = tmp_path / "real.json"
+    link = tmp_path / "link.json"
+    # Create real file first so the symlink resolves
+    real.write_text("")
+    link.symlink_to(real)
+
+    safe_write(link, '{"key": "val"}', mode=0o600)
+
+    # The real file should have the restrictive mode
+    assert file_mode(real) == 0o600
+    assert link.is_symlink(), "symlink clobbered"
+
+
+def test_original_intact_after_write(tmp_path: Path) -> None:
+    """Original content is readable before and after overwrite."""
+    target = tmp_path / "file.txt"
+    target.write_text("v1")
+
+    safe_write(target, "v2")
+
+    assert target.read_text() == "v2"
+
+
+def test_symlink_to_missing_target_creates_file(tmp_path: Path) -> None:
+    """Writing through a broken symlink (target missing) creates the target file."""
+    target = tmp_path / "subdir" / "real.txt"
+    target.parent.mkdir()
+    link = tmp_path / "link.txt"
+    link.symlink_to(target)
+
+    # Target doesn't exist yet
+    assert not target.exists()
+
+    safe_write(link, "created through broken link")
+
+    # Now target exists
+    assert target.exists()
+    assert target.read_text() == "created through broken link"
+    # Symlink still intact
+    assert link.is_symlink()
+
+
+# ---------------------------------------------------------------------------
+# safe_write_bytes — binary
+# ---------------------------------------------------------------------------
+
+
+def test_binary_write_plain_file(tmp_path: Path) -> None:
+    """Binary write to a plain file."""
+    target = tmp_path / "data.bin"
+    safe_write_bytes(target, b"\x00\x01\x02\x03")
+
+    assert target.read_bytes() == b"\x00\x01\x02\x03"
+
+
+def test_binary_write_through_symlink(tmp_path: Path) -> None:
+    """Binary write through a symlink preserves the link."""
+    real = tmp_path / "real.bin"
+    real.write_bytes(b"old")
+    link = tmp_path / "link.bin"
+    link.symlink_to(real)
+
+    safe_write_bytes(link, b"\xff\xfe")
+
+    assert link.is_symlink(), "binary write clobbered symlink"
+    assert real.read_bytes() == b"\xff\xfe"
+
+
+def test_unicode_content(tmp_path: Path) -> None:
+    """Unicode text is encoded correctly as UTF-8."""
+    target = tmp_path / "unicode.txt"
+    text = "こんにちは — café — 🤖"
+    safe_write(target, text)
+
+    assert target.read_text(encoding="utf-8") == text
+
+
+# ---------------------------------------------------------------------------
+# THE canonical anti-regression test: os.replace on a symlink clobbers it
+# (This documents what safe_write prevents)
+# ---------------------------------------------------------------------------
+
+
+def test_naive_replace_would_clobber(tmp_path: Path) -> None:
+    """Demonstrate the clobber class: naive os.replace() on a symlink path
+    destroys the link.  This is what safe_write prevents.
+    """
+    real = tmp_path / "real.txt"
+    real.write_text("original")
+    link = tmp_path / "link.txt"
+    link.symlink_to(real)
+
+    # Naive atomic write: create temp in same dir, replace the SYMLINK path
+    import tempfile
+
+    fd, tmp_name = tempfile.mkstemp(dir=tmp_path)
+    with os.fdopen(fd, "w") as f:
+        f.write("naive write")
+    os.replace(tmp_name, link)  # This clobbers the symlink!
+
+    # Link is now a regular file — the clobber happened
+    assert (
+        not link.is_symlink()
+    ), "expected clobber did NOT happen — test assumption wrong"
+    # And real is untouched (orphaned)
+    assert real.read_text() == "original"
+
+    # Now verify safe_write wouldn't do this:
+    real2 = tmp_path / "real2.txt"
+    real2.write_text("original2")
+    link2 = tmp_path / "link2.txt"
+    link2.symlink_to(real2)
+
+    safe_write(link2, "safe write")
+
+    assert link2.is_symlink(), "safe_write clobbered the symlink — regression!"
+    assert real2.read_text() == "safe write"


### PR DESCRIPTION
## Summary

Adds `bobutils.safe_write` — a primitive that guards the **symlink-clobber class**:
on Linux, `os.replace(tmp, symlink_path)` replaces the symlink itself with a
regular file, permanently destroying the link. This silently breaks credential-slot
and OCR-cache symlinks that many scripts depend on.

## The clobber class

```python
# ❌ Naive pattern — clobbers the symlink:
fd, tmp = tempfile.mkstemp(dir=path.parent)
os.replace(tmp, path)   # if path is a symlink, link is gone

# ✅ safe_write — resolves first:
real = path.resolve()   # follow symlinks to real target
os.replace(tmp, real)   # replaces the real file, link survives
```

## API

```python
from bobutils.safe_write import safe_write, safe_write_bytes

safe_write(path, text_data, mode=0o644)         # text, atomic, symlink-safe
safe_write_bytes(path, binary_data, mode=0o644) # binary variant
```

## Tests

12 tests covering: plain file, single symlink, multi-hop symlink chain, new file
creation, mode bits, binary writes, unicode, broken symlink creation, and a
canonical **anti-regression test** that demonstrates the clobber would happen
with naive `os.replace` (and proves `safe_write` prevents it).

## Motivation

- idea-backlog#975 (Symlink-Clobber Reconcile-on-Write Guard)
- Three credential scripts in `ErikBjare/bob` are being converted to use this
  primitive in a companion commit, removing their local `_atomic_write` copies.

Co-Authored-By: Bob <timetobuildbob@gmail.com>