### PR TITLE
chore(git-hooks): allow gptme/gptme-skills-cc direct master commits

### DIFF
--- a/dotfiles/.config/git/allowed-repos.conf
+++ b/dotfiles/.config/git/allowed-repos.conf
@@ -21,4 +21,7 @@ ALLOWED_PATTERNS=(
     # Agents write standups, task updates, and cross-agent messages directly to master
     # (Missing standup = automatic failure signal — requires direct master writes)
     "gptme/gptme-superuser"
+
+    # gptme/gptme-skills-cc: CC plugin repo, Bob is sole maintainer (direct push ok)
+    "gptme/gptme-skills-cc"
 )


### PR DESCRIPTION
Adds `gptme/gptme-skills-cc` to the allowed-repos.conf so the global pre-commit hook permits direct master commits in that repo.

**Why**: `gptme-skills-cc` is a new Claude Code plugin repo under the gptme org, with Bob as sole maintainer. It's analogous to other first-party org repos that have direct push access.

**Context**: Created in session 846e as part of the gptme Skills → Claude Code plugin PoC (idea #983). The plugin is now live at https://github.com/gptme/gptme-skills-cc.