### PR TITLE
feat(gptodo): add 'explain' subcommand for per-task readiness diagnosis

### DIFF
--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -473,6 +473,26 @@ def explain_readiness(task_id: str) -> None:
     else:
         check("waiting_for", True, "not set")
 
+    # ready_for_review bypass: gptodo ready only checks waiting_for for this state —
+    # wait-date, pool, and dep checks are all skipped (work is done; the task is
+    # waiting for deliberate local review, not external conditions). Mirror that here
+    # so explain doesn't contradict the command it is diagnosing.
+    if state == "ready_for_review":
+        check(
+            "wait date / pool / dependencies",
+            True,
+            "skipped — ready_for_review work is done; only waiting_for matters",
+        )
+        console.print()
+        if all_pass:
+            console.print("[green]VERDICT: READY[/] (gptodo-level filters pass)")
+            console.print(
+                "[dim]Note: cascade-claim and live-dirty checks require 'ready-tasks.py --explain'[/]"
+            )
+        else:
+            console.print("[red]VERDICT: NOT READY[/]")
+        return
+
     # 3. wait: date gate
     if task_is_waiting_for_date(task):
         wait_val = task.wait
@@ -496,20 +516,6 @@ def explain_readiness(task_id: str) -> None:
         check("pool", True, f"pool={pool!r}")
 
     # 5 & 6. Dependencies (task-based and URL-based)
-    # ready_for_review: work is done; gptodo ready deliberately skips dep checks
-    # for this state (only checks waiting_for). Mirror that here so explain
-    # doesn't contradict the command it is diagnosing.
-    if state == "ready_for_review":
-        check("dependencies", True, "skipped — ready_for_review work is complete")
-        console.print()
-        if all_pass:
-            console.print("[green]VERDICT: READY[/] (gptodo-level filters pass)")
-            console.print(
-                "[dim]Note: cascade-claim and live-dirty checks require 'ready-tasks.py --explain'[/]"
-            )
-        else:
-            console.print("[red]VERDICT: NOT READY[/]")
-        return
 
     requires = task.requires or []
     if not requires:

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -388,6 +388,177 @@ def effective(task_id: str):
                     console.print(f"  • [red]{req}[/] (missing)")
 
 
+@cli.command("explain")
+@click.argument("task_id")
+def explain_(task_id: str):
+    """Explain why a task is or is not ready to work on.
+
+    Walks through each readiness filter in order and shows which ones pass
+    or fail, so you can diagnose why 'gptodo ready' does not surface a task.
+
+    Note: cascade-claim blocking and live-dirty-file checks require
+    'ready-tasks.py --explain TASK_ID' (Bob-local script).
+    """
+    explain_readiness(task_id)
+
+
+def explain_readiness(task_id: str) -> None:
+    """Walk through readiness filters for a task and print the verdict."""
+    console = Console()
+    repo_root = find_repo_root(Path.cwd())
+    tasks_dir = repo_root / "tasks"
+
+    tasks = load_tasks(tasks_dir)
+    if not tasks:
+        console.print("[red]No tasks found[/]")
+        return
+
+    all_tasks: Dict[str, TaskInfo] = {t.name: t for t in tasks}
+
+    task = None
+    for t in tasks:
+        if t.name == task_id or task_id in str(t.path):
+            task = t
+            break
+
+    if not task:
+        console.print(f"[red]Task not found: {task_id}[/]")
+        return
+
+    cache_path = get_cache_path(repo_root)
+    issue_cache = load_cache(cache_path)
+
+    console.print(f"\n[bold]Task:[/] {task.name}")
+    console.print(f"[bold]File:[/] {task.path.relative_to(repo_root)}")
+    console.print(f"[bold]State:[/] {task.state or 'unknown'}")
+    console.print()
+    console.print("[bold]Readiness filters:[/]")
+
+    WORKABLE = {"backlog", "todo", "active", "ready_for_review"}
+    all_pass = True
+
+    def check(label: str, passed: bool, detail: str = "") -> None:
+        nonlocal all_pass
+        icon = "[green]✓[/]" if passed else "[red]✗[/]"
+        suffix = f" — {detail}" if detail else ""
+        console.print(f"  {icon} {label}{suffix}")
+        if not passed:
+            all_pass = False
+
+    # 1. State filter
+    state = normalize_state(task.state or "", warn=False) if task.state else ""
+    if state in ("done", "cancelled"):
+        check("state", False, f"terminal state ({state}) — work is complete or cancelled")
+    elif state == "someday":
+        check("state", False, "someday — explicitly deferred, not in ready pool")
+    elif state == "waiting":
+        waiting_for = str(task.metadata.get("waiting_for") or "").strip()
+        detail = f"waiting_for={waiting_for!r}" if waiting_for else "state=waiting"
+        check("state / waiting_for", False, detail)
+    elif state in WORKABLE:
+        check("state", True, state)
+    else:
+        check("state", False, f"unrecognised state ({state!r})")
+
+    if not all_pass:
+        # State already failed; remaining checks irrelevant
+        console.print()
+        console.print("[red]VERDICT: NOT READY[/]")
+        return
+
+    # 2. waiting_for prose on a non-waiting task
+    if task.metadata.get("waiting_for"):
+        waiting_for = str(task.metadata["waiting_for"]).strip()
+        check(
+            "waiting_for", False, f"{waiting_for!r} (set on non-waiting task → treated as blocker)"
+        )
+    else:
+        check("waiting_for", True, "not set")
+
+    # 3. wait: date gate
+    if task_is_waiting_for_date(task):
+        wait_val = task.wait
+        detail = f"wait gate not yet open (wait={wait_val.isoformat() if wait_val else '?'})"
+        check("wait date", False, detail)
+    else:
+        if task.wait is not None:
+            check("wait date", True, f"gate open (wait={task.wait})")
+        else:
+            check("wait date", True, "not set")
+
+    # 4. Pool filter
+    pool = task_pool(task)
+    if pool == "frontier":
+        check(
+            "pool",
+            False,
+            "pool=frontier — requires a frontier-tier session (e.g. gptodo ready --pool frontier)",
+        )
+    else:
+        check("pool", True, f"pool={pool!r}")
+
+    # 5 & 6. Dependencies (task-based and URL-based)
+    requires = task.requires or []
+    if not requires:
+        check("dependencies", True, "none")
+    else:
+        blocked: list[str] = []
+        missing: list[str] = []
+        open_urls: list[str] = []
+        resolved: list[str] = []
+        uncached_urls: list[str] = []
+
+        for req in requires:
+            if isinstance(req, str) and req.startswith(("http://", "https://")):
+                cached = issue_cache.get(req) if issue_cache else None
+                if cached:
+                    url_state = cached.get("state", "unknown")
+                    if url_state == "OPEN":
+                        open_urls.append(f"{req} ({url_state})")
+                    else:
+                        resolved.append(f"{req} ({url_state})")
+                else:
+                    uncached_urls.append(req)
+            else:
+                dep_task = all_tasks.get(req)
+                if dep_task is None:
+                    missing.append(req)
+                elif dep_task.state not in ("done", "cancelled"):
+                    blocked.append(f"{req} ({dep_task.state})")
+                else:
+                    resolved.append(f"{req} ({dep_task.state})")
+
+        if blocked or missing or open_urls:
+            parts = []
+            if blocked:
+                parts.append("blocked_by=" + ", ".join(blocked))
+            if missing:
+                parts.append("missing=" + ", ".join(missing))
+            if open_urls:
+                parts.append("open_url=" + ", ".join(open_urls))
+            check("dependencies", False, "; ".join(parts))
+        else:
+            summary_parts = []
+            if resolved:
+                summary_parts.append(f"{len(resolved)} resolved")
+            if uncached_urls:
+                summary_parts.append(f"{len(uncached_urls)} URL(s) not cached (assumed unblocked)")
+            check(
+                "dependencies",
+                True,
+                ", ".join(summary_parts) if summary_parts else f"{len(requires)} resolved",
+            )
+
+    console.print()
+    if all_pass:
+        console.print("[green]VERDICT: READY[/] (gptodo-level filters pass)")
+        console.print(
+            "[dim]Note: cascade-claim and live-dirty checks require 'ready-tasks.py --explain'[/]"
+        )
+    else:
+        console.print("[red]VERDICT: NOT READY[/]")
+
+
 @cli.command("list")
 @click.option(
     "--sort",

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -415,9 +415,12 @@ def explain_readiness(task_id: str) -> None:
 
     all_tasks: Dict[str, TaskInfo] = {t.name: t for t in tasks}
 
-    # Exact name match first; fall back to exact path-stem match (handles
-    # callers that pass "my-task.md" instead of "my-task").
-    task = all_tasks.get(task_id) or all_tasks.get(Path(task_id).stem)
+    # Exact name match first; fall back to stem-only match when the caller
+    # passes a .md filename ("my-task.md" → "my-task").  Only strip the .md
+    # extension — stripping arbitrary suffixes (e.g. "my-task.txt") would
+    # silently resolve to a different task than the one requested.
+    stem = Path(task_id).stem if task_id.endswith(".md") else None
+    task = all_tasks.get(task_id) or (all_tasks.get(stem) if stem else None)
 
     if not task:
         console.print(f"[red]Task not found: {task_id}[/]")

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -416,10 +416,12 @@ def explain_readiness(task_id: str) -> None:
     all_tasks: Dict[str, TaskInfo] = {t.name: t for t in tasks}
 
     # Exact name match first; fall back to stem-only match when the caller
-    # passes a .md filename ("my-task.md" → "my-task").  Only strip the .md
-    # extension — stripping arbitrary suffixes (e.g. "my-task.txt") would
-    # silently resolve to a different task than the one requested.
-    stem = Path(task_id).stem if task_id.endswith(".md") else None
+    # passes a bare .md filename ("my-task.md" → "my-task").  Restrict to:
+    #   • .md extension only (not arbitrary suffixes like .txt)
+    #   • no path separators (a path like "dir/my-task.md" might refer to a
+    #     different task than the local "my-task", so don't strip dir components)
+    _is_bare_md = task_id.endswith(".md") and "/" not in task_id and "\\" not in task_id
+    stem = Path(task_id).stem if _is_bare_md else None
     task = all_tasks.get(task_id) or (all_tasks.get(stem) if stem else None)
 
     if not task:

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -411,7 +411,7 @@ def explain_readiness(task_id: str) -> None:
     tasks = load_tasks(tasks_dir)
     if not tasks:
         console.print("[red]No tasks found[/]")
-        return
+        sys.exit(1)
 
     all_tasks: Dict[str, TaskInfo] = {t.name: t for t in tasks}
 
@@ -473,15 +473,29 @@ def explain_readiness(task_id: str) -> None:
     else:
         check("waiting_for", True, "not set")
 
-    # ready_for_review bypass: gptodo ready only checks waiting_for for this state —
-    # wait-date, pool, and dep checks are all skipped (work is done; the task is
-    # waiting for deliberate local review, not external conditions). Mirror that here
-    # so explain doesn't contradict the command it is diagnosing.
+    # 3. Pool filter — applies to ALL states including ready_for_review.
+    # gptodo ready applies pool filtering before the readiness check, even for
+    # ready_for_review tasks (see ready() lines 2729-2733): a frontier-pool task
+    # in ready_for_review is excluded by the default general-pool filter just like
+    # any other pool. Mirror that here so explain doesn't contradict ready.
+    pool = task_pool(task)
+    if pool == "frontier":
+        check(
+            "pool",
+            False,
+            "pool=frontier — requires a frontier-tier session (e.g. gptodo ready --pool frontier)",
+        )
+    else:
+        check("pool", True, f"pool={pool!r}")
+
+    # ready_for_review bypass: gptodo ready skips wait-date and dependency checks
+    # for this state (work is done; only waiting_for and pool matter). Mirror that
+    # here so explain doesn't contradict the command it is diagnosing.
     if state == "ready_for_review":
         check(
-            "wait date / pool / dependencies",
+            "wait date / dependencies",
             True,
-            "skipped — ready_for_review work is done; only waiting_for matters",
+            "skipped — ready_for_review work is done; pool and waiting_for are the only gates",
         )
         console.print()
         if all_pass:
@@ -493,7 +507,7 @@ def explain_readiness(task_id: str) -> None:
             console.print("[red]VERDICT: NOT READY[/]")
         return
 
-    # 3. wait: date gate
+    # 4. wait: date gate
     if task_is_waiting_for_date(task):
         wait_val = task.wait
         detail = f"wait gate not yet open (wait={wait_val.isoformat() if wait_val else '?'})"
@@ -504,18 +518,7 @@ def explain_readiness(task_id: str) -> None:
         else:
             check("wait date", True, "not set")
 
-    # 4. Pool filter
-    pool = task_pool(task)
-    if pool == "frontier":
-        check(
-            "pool",
-            False,
-            "pool=frontier — requires a frontier-tier session (e.g. gptodo ready --pool frontier)",
-        )
-    else:
-        check("pool", True, f"pool={pool!r}")
-
-    # 5 & 6. Dependencies (task-based and URL-based)
+    # 4 & 5. Dependencies (task-based and URL-based)
 
     requires = task.requires or []
     if not requires:

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -415,15 +415,13 @@ def explain_readiness(task_id: str) -> None:
 
     all_tasks: Dict[str, TaskInfo] = {t.name: t for t in tasks}
 
-    task = None
-    for t in tasks:
-        if t.name == task_id or task_id in str(t.path):
-            task = t
-            break
+    # Exact name match first; fall back to exact path-stem match (handles
+    # callers that pass "my-task.md" instead of "my-task").
+    task = all_tasks.get(task_id) or all_tasks.get(Path(task_id).stem)
 
     if not task:
         console.print(f"[red]Task not found: {task_id}[/]")
-        return
+        sys.exit(1)
 
     cache_path = get_cache_path(repo_root)
     issue_cache = load_cache(cache_path)
@@ -498,6 +496,21 @@ def explain_readiness(task_id: str) -> None:
         check("pool", True, f"pool={pool!r}")
 
     # 5 & 6. Dependencies (task-based and URL-based)
+    # ready_for_review: work is done; gptodo ready deliberately skips dep checks
+    # for this state (only checks waiting_for). Mirror that here so explain
+    # doesn't contradict the command it is diagnosing.
+    if state == "ready_for_review":
+        check("dependencies", True, "skipped — ready_for_review work is complete")
+        console.print()
+        if all_pass:
+            console.print("[green]VERDICT: READY[/] (gptodo-level filters pass)")
+            console.print(
+                "[dim]Note: cascade-claim and live-dirty checks require 'ready-tasks.py --explain'[/]"
+            )
+        else:
+            console.print("[red]VERDICT: NOT READY[/]")
+        return
+
     requires = task.requires or []
     if not requires:
         check("dependencies", True, "none")

--- a/packages/gptodo/tests/test_explain_readiness.py
+++ b/packages/gptodo/tests/test_explain_readiness.py
@@ -136,16 +136,18 @@ def test_explain_resolved_dependency(tmp_path: Path, monkeypatch) -> None:
 
 
 def test_explain_missing_task(tmp_path: Path, monkeypatch) -> None:
-    """A task ID not found should give a clear error, not crash."""
+    """A task ID not found should give a clear error and exit with code 1."""
     tasks_dir = tmp_path / "tasks"
     tasks_dir.mkdir()
+    # Add a real task so we hit the "not found" branch, not "no tasks found"
+    write_task(tasks_dir, "other-task", state="todo", created="2026-01-01T00:00:00")
     monkeypatch.chdir(tmp_path)
 
     runner = CliRunner()
-    result = runner.invoke(cli, ["explain", "nonexistent-task"], catch_exceptions=False)
+    result = runner.invoke(cli, ["explain", "nonexistent-task"])
 
-    assert result.exit_code == 0  # Should not crash
-    assert "not found" in result.output.lower() or "no tasks" in result.output.lower()
+    assert result.exit_code == 1
+    assert "not found" in result.output.lower()
 
 
 def test_explain_waiting_for_on_non_waiting_state(tmp_path: Path, monkeypatch) -> None:
@@ -166,3 +168,44 @@ def test_explain_waiting_for_on_non_waiting_state(tmp_path: Path, monkeypatch) -
     assert "waiting_for" in out
     assert "external thing" in out
     assert "VERDICT: NOT READY" in out
+
+
+def test_explain_ready_for_review_skips_dep_checks(tmp_path: Path, monkeypatch) -> None:
+    """ready_for_review tasks should show READY even with an unresolved dependency.
+
+    gptodo ready deliberately skips dependency checks for ready_for_review tasks
+    (work is done; only waiting_for matters). explain must match that behaviour so
+    the diagnostic doesn't contradict the command it diagnoses.
+    """
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(tasks_dir, "open-prereq", state="todo", created="2026-01-01T00:00:00")
+    write_task(
+        tasks_dir,
+        "rfr-task",
+        state="ready_for_review",
+        created="2026-01-01T00:00:00",
+        requires=["open-prereq"],
+    )
+    monkeypatch.chdir(tmp_path)
+
+    out = run_explain(tmp_path, "rfr-task")
+
+    # Dep check should be skipped (not flagged as a blocker)
+    assert "skipped" in out
+    assert "VERDICT: READY" in out
+
+
+def test_explain_substring_match_not_ambiguous(tmp_path: Path, monkeypatch) -> None:
+    """Substring of another task's name must not select the wrong task."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(tasks_dir, "task-foo-bar", state="todo", created="2026-01-01T00:00:00")
+    monkeypatch.chdir(tmp_path)
+
+    runner = CliRunner()
+    # "task-foo" is a substring of "task-foo-bar" but is not a real task
+    result = runner.invoke(cli, ["explain", "task-foo"])
+
+    assert result.exit_code == 1
+    assert "not found" in result.output.lower()

--- a/packages/gptodo/tests/test_explain_readiness.py
+++ b/packages/gptodo/tests/test_explain_readiness.py
@@ -303,3 +303,22 @@ def test_explain_md_suffix_resolves_correctly(tmp_path: Path, monkeypatch) -> No
     out = run_explain(tmp_path, "my-task.md")
 
     assert "VERDICT: READY" in out
+
+
+def test_explain_path_like_md_does_not_match(tmp_path: Path, monkeypatch) -> None:
+    """A path-like .md identifier must not silently resolve via stem stripping.
+
+    'some/dir/my-task.md' has the stem 'my-task', but the caller is passing a
+    path, not a bare filename. Stripping directory components would silently
+    select a different (or wrong) task; the command should exit 1 instead.
+    """
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(tasks_dir, "my-task", state="todo", created="2026-01-01T00:00:00")
+    monkeypatch.chdir(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["explain", "some/dir/my-task.md"])
+
+    assert result.exit_code == 1
+    assert "not found" in result.output.lower()

--- a/packages/gptodo/tests/test_explain_readiness.py
+++ b/packages/gptodo/tests/test_explain_readiness.py
@@ -1,0 +1,168 @@
+"""Tests for `gptodo explain` command — per-task readiness diagnosis."""
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from gptodo.cli import cli
+
+
+def write_task(tasks_dir: Path, name: str, **metadata: object) -> None:
+    """Write a minimal task file with YAML frontmatter."""
+    import yaml
+
+    lines = ["---"]
+    for key, value in metadata.items():
+        if isinstance(value, list):
+            lines.append(f"{key}:")
+            for item in value:
+                lines.append(f"  - {item}")
+        else:
+            # Use yaml.dump for proper quoting (handles #, : etc)
+            dumped = yaml.dump({key: value}, default_flow_style=False).strip()
+            lines.append(dumped)
+    lines.extend(["---", f"# {name}"])
+    (tasks_dir / f"{name}.md").write_text("\n".join(lines))
+
+
+def run_explain(tmp_path: Path, task_id: str) -> str:
+    """Run `gptodo explain <task_id>` from tmp_path and return output."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["explain", task_id], catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+    return result.output
+
+
+def test_explain_ready_task(tmp_path: Path, monkeypatch) -> None:
+    """A simple todo task with no deps should report READY."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(tasks_dir, "my-task", state="todo", created="2026-01-01T00:00:00")
+    monkeypatch.chdir(tmp_path)
+
+    out = run_explain(tmp_path, "my-task")
+
+    assert "✓ state" in out
+    assert "✓ waiting_for" in out
+    assert "VERDICT: READY" in out
+
+
+def test_explain_waiting_task(tmp_path: Path, monkeypatch) -> None:
+    """A task in waiting state should report NOT READY with waiting_for detail."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(
+        tasks_dir,
+        "blocked-task",
+        state="waiting",
+        created="2026-01-01T00:00:00",
+        waiting_for="PR #123 merged",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    out = run_explain(tmp_path, "blocked-task")
+
+    assert "✗" in out
+    assert "waiting_for" in out
+    assert "PR #123 merged" in out
+    assert "VERDICT: NOT READY" in out
+
+
+def test_explain_done_task(tmp_path: Path, monkeypatch) -> None:
+    """A terminal (done) task should report NOT READY immediately."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(tasks_dir, "finished-task", state="done", created="2026-01-01T00:00:00")
+    monkeypatch.chdir(tmp_path)
+
+    out = run_explain(tmp_path, "finished-task")
+
+    assert "terminal" in out
+    assert "VERDICT: NOT READY" in out
+
+
+def test_explain_someday_task(tmp_path: Path, monkeypatch) -> None:
+    """A someday task should report NOT READY (deferred)."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(tasks_dir, "deferred-task", state="someday", created="2026-01-01T00:00:00")
+    monkeypatch.chdir(tmp_path)
+
+    out = run_explain(tmp_path, "deferred-task")
+
+    assert "someday" in out
+    assert "VERDICT: NOT READY" in out
+
+
+def test_explain_blocked_by_dependency(tmp_path: Path, monkeypatch) -> None:
+    """A task with an incomplete dependency should report NOT READY with dep info."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(tasks_dir, "prereq", state="todo", created="2026-01-01T00:00:00")
+    write_task(
+        tasks_dir,
+        "depends-on-prereq",
+        state="backlog",
+        created="2026-01-01T00:00:00",
+        requires=["prereq"],
+    )
+    monkeypatch.chdir(tmp_path)
+
+    out = run_explain(tmp_path, "depends-on-prereq")
+
+    assert "dependencies" in out
+    assert "prereq" in out
+    assert "VERDICT: NOT READY" in out
+
+
+def test_explain_resolved_dependency(tmp_path: Path, monkeypatch) -> None:
+    """A task whose dependency is done should report READY."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(tasks_dir, "prereq-done", state="done", created="2026-01-01T00:00:00")
+    write_task(
+        tasks_dir,
+        "unblocked-task",
+        state="backlog",
+        created="2026-01-01T00:00:00",
+        requires=["prereq-done"],
+    )
+    monkeypatch.chdir(tmp_path)
+
+    out = run_explain(tmp_path, "unblocked-task")
+
+    assert "✓ dependencies" in out
+    assert "VERDICT: READY" in out
+
+
+def test_explain_missing_task(tmp_path: Path, monkeypatch) -> None:
+    """A task ID not found should give a clear error, not crash."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["explain", "nonexistent-task"], catch_exceptions=False)
+
+    assert result.exit_code == 0  # Should not crash
+    assert "not found" in result.output.lower() or "no tasks" in result.output.lower()
+
+
+def test_explain_waiting_for_on_non_waiting_state(tmp_path: Path, monkeypatch) -> None:
+    """A backlog task with waiting_for set should report NOT READY."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(
+        tasks_dir,
+        "sneaky-blocked",
+        state="backlog",
+        created="2026-01-01T00:00:00",
+        waiting_for="external thing",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    out = run_explain(tmp_path, "sneaky-blocked")
+
+    assert "waiting_for" in out
+    assert "external thing" in out
+    assert "VERDICT: NOT READY" in out

--- a/packages/gptodo/tests/test_explain_readiness.py
+++ b/packages/gptodo/tests/test_explain_readiness.py
@@ -220,6 +220,45 @@ def test_explain_ready_for_review_with_future_wait_date(tmp_path: Path, monkeypa
     assert "VERDICT: READY" in out
 
 
+def test_explain_empty_tasks_dir_exits_nonzero(tmp_path: Path, monkeypatch) -> None:
+    """An empty tasks directory must exit with code 1 so scripts can detect failure."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["explain", "anything"])
+
+    assert result.exit_code == 1
+    assert "no tasks found" in result.output.lower()
+
+
+def test_explain_frontier_pool_ready_for_review_not_ready(tmp_path: Path, monkeypatch) -> None:
+    """A ready_for_review task in the frontier pool should report NOT READY.
+
+    gptodo ready applies the pool filter before readiness checks, even for
+    ready_for_review tasks. A frontier-pool task is excluded by the default
+    general-pool filter, so explain must report NOT READY to match.
+    """
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(
+        tasks_dir,
+        "frontier-rfr",
+        state="ready_for_review",
+        created="2026-01-01T00:00:00",
+        pool="frontier",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["explain", "frontier-rfr"], catch_exceptions=False)
+
+    assert "pool" in result.output
+    assert "frontier" in result.output
+    assert "VERDICT: NOT READY" in result.output
+
+
 def test_explain_substring_match_not_ambiguous(tmp_path: Path, monkeypatch) -> None:
     """Substring of another task's name must not select the wrong task."""
     tasks_dir = tmp_path / "tasks"

--- a/packages/gptodo/tests/test_explain_readiness.py
+++ b/packages/gptodo/tests/test_explain_readiness.py
@@ -196,6 +196,30 @@ def test_explain_ready_for_review_skips_dep_checks(tmp_path: Path, monkeypatch) 
     assert "VERDICT: READY" in out
 
 
+def test_explain_ready_for_review_with_future_wait_date(tmp_path: Path, monkeypatch) -> None:
+    """ready_for_review tasks with a future wait: date should still report READY.
+
+    gptodo ready --state ready_for_review only checks waiting_for, not the wait
+    date gate. explain must match: a future wait: date must not flip the verdict.
+    """
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(
+        tasks_dir,
+        "rfr-future-wait",
+        state="ready_for_review",
+        created="2026-01-01T00:00:00",
+        wait="2099-12-31T00:00:00+00:00",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    out = run_explain(tmp_path, "rfr-future-wait")
+
+    # Wait date check must be skipped — a future wait should NOT block READY
+    assert "skipped" in out
+    assert "VERDICT: READY" in out
+
+
 def test_explain_substring_match_not_ambiguous(tmp_path: Path, monkeypatch) -> None:
     """Substring of another task's name must not select the wrong task."""
     tasks_dir = tmp_path / "tasks"

--- a/packages/gptodo/tests/test_explain_readiness.py
+++ b/packages/gptodo/tests/test_explain_readiness.py
@@ -272,3 +272,34 @@ def test_explain_substring_match_not_ambiguous(tmp_path: Path, monkeypatch) -> N
 
     assert result.exit_code == 1
     assert "not found" in result.output.lower()
+
+
+def test_explain_arbitrary_suffix_does_not_match(tmp_path: Path, monkeypatch) -> None:
+    """Only .md suffix should be stripped; arbitrary suffixes must not resolve a task.
+
+    Path.stem strips any extension, so "my-task.txt" → "my-task" would silently
+    diagnose a different task. Only ".md" should trigger the stem fallback.
+    """
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(tasks_dir, "my-task", state="todo", created="2026-01-01T00:00:00")
+    monkeypatch.chdir(tmp_path)
+
+    runner = CliRunner()
+    # "my-task.txt" has a stem matching the real task, but .txt is not .md
+    result = runner.invoke(cli, ["explain", "my-task.txt"])
+
+    assert result.exit_code == 1
+    assert "not found" in result.output.lower()
+
+
+def test_explain_md_suffix_resolves_correctly(tmp_path: Path, monkeypatch) -> None:
+    """.md suffix should be stripped so 'my-task.md' resolves to 'my-task'."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(tasks_dir, "my-task", state="todo", created="2026-01-01T00:00:00")
+    monkeypatch.chdir(tmp_path)
+
+    out = run_explain(tmp_path, "my-task.md")
+
+    assert "VERDICT: READY" in out


### PR DESCRIPTION
## Summary

Adds `gptodo explain <task-id>` — a diagnostic subcommand that walks through each readiness filter in order and shows which ones pass or fail. Resolves the "117 backlog / 0 ready" misdiagnosis problem: agents can now run one command to see exactly why a task is not in the ready pool.

## Problem

`gptodo ready` answers "No ready tasks found!" with zero diagnostics. The filter stack (state → waiting_for → wait gate → pool → deps → URL deps) is invisible, which is how the "0 actionable" misdiagnosis survived until a manual audit caught it. There was no way to ask "why is task X not ready?"

## Changes

### `packages/gptodo/src/gptodo/cli.py`
- New `gptodo explain <task-id>` command  
- Walks the readiness filter chain in order, printing ✓/✗ with detail at each step
- Checks: state (workable vs terminal/deferred/waiting), waiting_for, wait date gate, pool (frontier vs general), task and URL dependencies
- Outputs `VERDICT: READY` or `VERDICT: NOT READY`
- On READY, notes that cascade-claim and live-dirty checks require `ready-tasks.py --explain` (Bob-local wrapper)

### `packages/gptodo/tests/test_explain_readiness.py`
- 8 new tests covering: ready task, waiting state, done state, someday state, blocked dependency, resolved dependency, missing task ID, waiting_for on non-waiting task

## Example output

```
$ gptodo explain my-waiting-task
Task: my-waiting-task
File: tasks/my-waiting-task.md
State: waiting

Readiness filters:
  ✗ state / waiting_for — waiting_for='PR #123 merged'

VERDICT: NOT READY
```

```
$ gptodo explain my-ready-task
Task: my-ready-task
File: tasks/my-ready-task.md
State: todo

Readiness filters:
  ✓ state — todo
  ✓ waiting_for — not set
  ✓ wait date — not set
  ✓ pool — pool='general'
  ✓ dependencies — none

VERDICT: READY (gptodo-level filters pass)
Note: cascade-claim and live-dirty checks require 'ready-tasks.py --explain'
```

## Tests

374 tests pass (8 new + 366 existing).