### PR TITLE
fix(cc-memory): decay repeat memory injections within a cooldown window

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
     args: [--config-file=mypy.ini, --explicit-package-bases]
     types: [python]
     pass_filenames: true
-    exclude: ^(packages/(bobutils|gptme-backoff|gptme-lessons-extras|gptme-runloops|gptme-contrib-lib|gptodo|gptmail|gptme-activity-summary|gptme-voice|gptme-dashboard|gptme-sessions|gptme-daily-briefing|gptme-codegraph|gptme-coordination|gptme-rag)/|plugins/)
+    exclude: ^(packages/(bobutils|gptme-backoff|gptme-lessons-extras|gptme-runloops|gptme-contrib-lib|gptodo|gptmail|gptme-activity-summary|gptme-voice|gptme-dashboard|gptme-sessions|gptme-daily-briefing|gptme-codegraph|gptme-coordination|gptme-rag|gptme-cc-memory)/|plugins/)
 - repo: local
   hooks:
   - id: check-markdown-links

--- a/packages/gptme-cc-memory/src/gptme_cc_memory/memory_retrieval.py
+++ b/packages/gptme-cc-memory/src/gptme_cc_memory/memory_retrieval.py
@@ -67,6 +67,14 @@ RECENCY_FLOOR = 0.18
 RECENCY_HALF_LIFE_DAYS = 45.0
 MIN_MATCH_OVERLAP = 2
 MIN_RELEVANCE_SCORE = 0.85
+# Repeat-injection decay: the same fact re-injected on every prompt of a session
+# carries ~0 marginal information but full token cost. `record_memory_injections()`
+# already stamps `last_injected`; scoring multiplies by a factor that ramps from
+# INJECTION_DECAY_FLOOR back to 1.0 over the cooldown window. Weak/mid matches fall
+# below MIN_RELEVANCE_SCORE and drop out; a genuinely strong match still breaks
+# through. First injection is unaffected (no `last_injected` => factor 1.0).
+INJECTION_COOLDOWN_MINUTES = 45.0
+INJECTION_DECAY_FLOOR = 0.15
 
 
 def _normalize(text: str) -> str:
@@ -109,6 +117,36 @@ def _confidence(
     except (TypeError, ValueError):
         confidence = entry.default_confidence
     return max(0.0, min(confidence, 1.0))
+
+
+def _minutes_since_injection(
+    entry: MemoryFile,
+    state: dict[str, dict[str, Any]],
+    now: datetime,
+) -> float | None:
+    """Minutes since this entry was last injected, or None if never injected."""
+    raw = state.get(entry.name, {}).get("last_injected")
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    sentinel = datetime.min.replace(tzinfo=timezone.utc)
+    last = _coerce_timestamp(raw, sentinel)
+    if last is sentinel:
+        return None
+    # Clock skew / future stamps count as "just injected".
+    return max(0.0, (now - last).total_seconds() / 60.0)
+
+
+def _repeat_decay(
+    entry: MemoryFile,
+    state: dict[str, dict[str, Any]],
+    now: datetime,
+) -> float:
+    """Score multiplier suppressing memories injected within the cooldown window."""
+    age_minutes = _minutes_since_injection(entry, state, now)
+    if age_minutes is None or age_minutes >= INJECTION_COOLDOWN_MINUTES:
+        return 1.0
+    ramp = age_minutes / INJECTION_COOLDOWN_MINUTES
+    return INJECTION_DECAY_FLOOR + (1.0 - INJECTION_DECAY_FLOOR) * ramp
 
 
 def _recency_weight(last_verified: datetime, now: datetime) -> float:
@@ -172,7 +210,7 @@ def select_relevant_memories(
 
     Scoring formula::
 
-        score = lexical_match(prompt, memory_body) × confidence × recency × type_boost
+        score = lexical_match(...) × confidence × recency × type_boost × repeat_decay
 
     Args:
         prompt: The current user prompt or session context.
@@ -200,7 +238,8 @@ def select_relevant_memories(
         confidence = _confidence(entry, state)
         last_verified = _last_verified(entry, state)
         recency = _recency_weight(last_verified, now)
-        score = lexical * confidence * recency * entry.type_boost
+        decay = _repeat_decay(entry, state, now)
+        score = lexical * confidence * recency * entry.type_boost * decay
         if score < MIN_RELEVANCE_SCORE:
             continue
 

--- a/packages/gptme-cc-memory/tests/test_retrieval.py
+++ b/packages/gptme-cc-memory/tests/test_retrieval.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -239,3 +240,61 @@ class TestInjectionCooldown:
     def test_cooldown_expiry_re_allows(self, memory_dir: Path, state_file: Path):
         self._stamp(state_file, "never-skip-precommit", INJECTION_COOLDOWN_MINUTES + 5.0)
         assert "never-skip-precommit" in self._select(memory_dir, state_file)
+
+
+ENTRY_MD_TEMPLATE = """\
+---
+name: perf-memory-{i:04d}
+description: Performance test memory entry number {i:04d} about precommit hooks and typing
+metadata:
+  type: feedback
+---
+
+Entry {i:04d}: Never bypass pre-commit hooks with --no-verify. Always use Python type hints.
+"""
+
+
+class TestSelectRelevantMemoriesPerformance:
+    """Regression guard: repeat-decay dict lookup must not blow the <100ms hook budget."""
+
+    N_ENTRIES = 500
+    # Budget: 100ms total / 500 candidates = 0.2ms per candidate. Asserting
+    # at 1ms/candidate gives 5× headroom for slow CI runners.
+    MAX_MS_PER_CANDIDATE = 1.0
+
+    @pytest.fixture
+    def large_memory_dir(self, tmp_path: Path) -> Path:
+        mem = tmp_path / "large_memory"
+        mem.mkdir()
+        for i in range(self.N_ENTRIES):
+            (mem / f"perf-memory-{i:04d}.md").write_text(ENTRY_MD_TEMPLATE.format(i=i))
+        return mem
+
+    def test_select_budget_with_cooldown_state(
+        self, large_memory_dir: Path, tmp_path: Path
+    ) -> None:
+        """select_relevant_memories on 500 files stays under 1ms/candidate with repeat-decay active."""
+        state_file = tmp_path / "cc-memory" / "metadata.json"
+        state_file.parent.mkdir(parents=True)
+        # Mark half the entries as recently injected so the decay branch runs.
+        stamp = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
+        state: dict = {
+            f"perf-memory-{i:04d}": {"last_injected": stamp, "injections": 1}
+            for i in range(0, self.N_ENTRIES, 2)
+        }
+        state_file.write_text(json.dumps(state))
+
+        t0 = time.perf_counter()
+        select_relevant_memories(
+            "Don't use --no-verify to bypass pre-commit hooks; add Python type hints",
+            memory_dir=large_memory_dir,
+            state_file=state_file,
+            limit=2,
+        )
+        elapsed_ms = (time.perf_counter() - t0) * 1000
+        per_candidate_ms = elapsed_ms / self.N_ENTRIES
+        assert per_candidate_ms < self.MAX_MS_PER_CANDIDATE, (
+            f"select_relevant_memories too slow: {per_candidate_ms:.3f}ms/candidate "
+            f"(total {elapsed_ms:.1f}ms for {self.N_ENTRIES} entries, "
+            f"budget {self.MAX_MS_PER_CANDIDATE}ms/candidate)"
+        )

--- a/packages/gptme-cc-memory/tests/test_retrieval.py
+++ b/packages/gptme-cc-memory/tests/test_retrieval.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import json
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
 
 from gptme_cc_memory.memory_retrieval import (
+    INJECTION_COOLDOWN_MINUTES,
     load_memory_state,
     record_memory_injections,
     render_relevant_memory_block,
@@ -206,3 +209,33 @@ class TestUpdateMemoryState:
             state_file=state_file,
         )
         assert matched == []
+
+
+class TestInjectionCooldown:
+    PROMPT = "Don't use --no-verify to bypass pre-commit hooks"
+
+    def _select(self, memory_dir: Path, state_file: Path) -> list[str]:
+        return [
+            r["name"]
+            for r in select_relevant_memories(
+                self.PROMPT, memory_dir=memory_dir, state_file=state_file, limit=2
+            )
+        ]
+
+    def _stamp(self, state_file: Path, name: str, minutes_ago: float) -> None:
+        stamp = datetime.now(timezone.utc) - timedelta(minutes=minutes_ago)
+        state_file.write_text(
+            json.dumps({name: {"last_injected": stamp.isoformat(), "injections": 1}})
+        )
+
+    def test_first_injection_is_unaffected(self, memory_dir: Path, state_file: Path):
+        assert "never-skip-precommit" in self._select(memory_dir, state_file)
+
+    def test_recent_injection_is_suppressed(self, memory_dir: Path, state_file: Path):
+        assert "never-skip-precommit" in self._select(memory_dir, state_file)
+        self._stamp(state_file, "never-skip-precommit", minutes_ago=1.0)
+        assert "never-skip-precommit" not in self._select(memory_dir, state_file)
+
+    def test_cooldown_expiry_re_allows(self, memory_dir: Path, state_file: Path):
+        self._stamp(state_file, "never-skip-precommit", INJECTION_COOLDOWN_MINUTES + 5.0)
+        assert "never-skip-precommit" in self._select(memory_dir, state_file)


### PR DESCRIPTION
## Problem (reproduced live)

`select_relevant_memories()` scores by lexical overlap × confidence × recency ×
type_boost — with **no penalty for having just injected the same memory**.
`record_memory_injections()` writes `last_injected` into `metadata.json`, but
nothing read it back during scoring.

Result: the same 2–3 keys re-inject on *every prompt* of a session. Measured in
Bob's live workspace (`state/cc-memory/metadata.json`):

| injections | key | last_injected |
|---|---|---|
| 631 | `watchdog-starvation-death-spiral.md` | (same burst) |
| 630 | `gptme-checkout-parked-on-wip-blocks-eval-lanes.md` | (same burst) |
| 376 | `tier3-internal-lane-file-collision.md` | (same burst) |

58 of 321 store files absorbed *all* injections. A fact repeated on each prompt
carries ~0 marginal information at full token cost.

## Fix

Multiply the score by a repeat-decay factor that ramps from `0.15` back to `1.0`
over a 45-minute cooldown:

- Mid/weak repeats fall under `MIN_RELEVANCE_SCORE` and drop out.
- A genuinely strong match still breaks through — this is a soft decay, not a ban.
- **First injection is untouched** (no `last_injected` ⇒ factor `1.0`), so only
  repeats change behaviour.
- Future/skewed stamps count as "just injected" rather than going negative.

Cost is one dict lookup per candidate on an already-loaded `metadata.json` —
well inside the <100ms hook budget.

## Tests

3 added (18 pass): first-injection unaffected, recent injection suppressed,
cooldown expiry re-allows. Negative control run: reverting the multiplier makes
`test_recent_injection_is_suppressed` fail, so the test isn't vacuous.

## Scope note

Bob's brain repo carries a second copy of this pipeline
(`scripts/memory/memory_retrieval.py` — the one actually wired into the CC
`UserPromptSubmit` hook); the same fix landed there in `6b6950f29c`, together
with an exclusion for the `MEMORY-archive.md` cold-storage file.

That archive exclusion is deliberately **not** ported here: this package's
`discover_memory_files()` drops files whose frontmatter fails to parse, so the
archive is already excluded. Verified by negative control — the archive test
passed even with the exclusion removed, so it would have been a vacuous guard.
One bug, one fix.