### PR TITLE
feat(gptodo): unify frontmatter schema — known fields + workspace extension

### DIFF
--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -124,7 +124,9 @@ from gptodo.utils import (
     get_cache_path,
     has_new_activity,
     is_task_ready,
+    KNOWN_FRONTMATTER_FIELDS,
     lint_frontmatter_fields,
+    resolve_known_frontmatter_fields,
     task_has_waiting_blocker,
     task_is_waiting_for_date,
     task_matches_pool_filter,
@@ -1758,6 +1760,13 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
         "assigned_to": {"type": "string"},
         "waiting_since": {"type": "date"},
         "wait": {"type": "date"},  # Hide from queue until this date
+        # Structured blockers: why this task is waiting, and (for machine-class
+        # blockers) the shell command that decides whether it has cleared.
+        "wait_kind": {
+            "type": "enum",
+            "values": ["machine", "human", "external", "hypothesis"],
+        },
+        "probe": {"type": "string"},
         # Optional fields with arbitrary string values
         "next_action": {"type": "string"},
         "waiting_for": {"type": "string"},
@@ -1769,6 +1778,9 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
         # Auto-expire (Gordon 2026-07-01)
         "expired_from": {"type": "string"},  # State the task came from before auto-expire
         "expired_at": {"type": "date"},  # Date the task was auto-expired
+        # Provenance / concurrency grouping for autonomous loops
+        "follow_on_from": {"type": "string"},  # Task that spawned this one
+        "coordination_family": {"type": "string"},  # Tasks that must not run concurrently
         # List fields handled separately via --add/--remove
         "tags": {"type": "list"},
         "depends": {"type": "list"},  # Deprecated, use requires instead
@@ -1779,6 +1791,16 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
         "output_types": {"type": "list"},
         "tracking": {"type": "list"},  # External issue/PR tracking URLs
     }
+
+    # Workspace-registered fields ([tool.gptodo] extra_frontmatter_fields /
+    # GPTODO_EXTRA_FRONTMATTER_FIELDS) are settable as free-form strings.
+    # Without this, a workspace could register a field so `lint` accepts it and
+    # still be unable to write it with `gptodo edit` — the same two-schema split
+    # one level down. Deliberately scoped to the *extras*: upstream-known fields
+    # that are absent above (session_id, worktree_path, …) are machine-written
+    # and stay unsettable by hand.
+    for _extra in resolve_known_frontmatter_fields(repo_root) - KNOWN_FRONTMATTER_FIELDS:
+        VALID_FIELDS.setdefault(_extra, {"type": "string"})
 
     # Validate set operations
     for field, value in set_fields:
@@ -5971,7 +5993,9 @@ def lint_cmd(output_json: bool, strict: bool, task_files: tuple[str, ...]) -> No
                 }
             )
         # Field-level warnings (deprecated / unknown).
-        for severity, field, message in lint_frontmatter_fields(task.metadata):
+        for severity, field, message in lint_frontmatter_fields(
+            task.metadata, known_fields=resolve_known_frontmatter_fields(repo_root)
+        ):
             all_findings.append(
                 {
                     "task": task.name,

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -102,6 +102,7 @@ from gptodo.unblock import auto_unblock_with_fan_in
 from gptodo.utils import (
     # Constants
     CONFIGS,
+    DEPRECATED_FRONTMATTER_FIELDS,
     STATE_EMOJIS,
     STATE_STYLES,
     # Data classes
@@ -1799,7 +1800,12 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
     # one level down. Deliberately scoped to the *extras*: upstream-known fields
     # that are absent above (session_id, worktree_path, …) are machine-written
     # and stay unsettable by hand.
-    for _extra in resolve_known_frontmatter_fields(repo_root) - KNOWN_FRONTMATTER_FIELDS:
+    # Deprecated fields are explicitly excluded — a workspace cannot opt back
+    # into an anti-design-goal field by registering it as an extra. Registering
+    # `modified` would otherwise make `gptodo edit --set modified ...` succeed
+    # right before `gptodo lint` rejects it, recreating the two-schema split.
+    _excluded = KNOWN_FRONTMATTER_FIELDS | set(DEPRECATED_FRONTMATTER_FIELDS)
+    for _extra in resolve_known_frontmatter_fields(repo_root) - _excluded:
         VALID_FIELDS.setdefault(_extra, {"type": "string"})
 
     # Validate set operations

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -5972,6 +5972,10 @@ def lint_cmd(output_json: bool, strict: bool, task_files: tuple[str, ...]) -> No
             console.print("[yellow]No tasks found[/]")
         return
 
+    # Resolved once, not per task: the workspace pyproject is read from disk on
+    # every call, and this loop runs over every task in the repo.
+    known_fields = resolve_known_frontmatter_fields(repo_root)
+
     # Collect findings across all tasks
     all_findings: list[dict] = []
     for task in tasks:
@@ -6000,7 +6004,7 @@ def lint_cmd(output_json: bool, strict: bool, task_files: tuple[str, ...]) -> No
             )
         # Field-level warnings (deprecated / unknown).
         for severity, field, message in lint_frontmatter_fields(
-            task.metadata, known_fields=resolve_known_frontmatter_fields(repo_root)
+            task.metadata, known_fields=known_fields
         ):
             all_findings.append(
                 {

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -317,7 +317,13 @@ def _pyproject_extra_fields(repo_root: Path) -> frozenset[str]:
             data = _toml.load(f)
     except (OSError, ValueError):
         return frozenset()
-    raw = data.get("tool", {}).get("gptodo", {}).get("extra_frontmatter_fields")
+    tool = data.get("tool", {})
+    if not isinstance(tool, dict):
+        return frozenset()
+    gptodo = tool.get("gptodo", {})
+    if not isinstance(gptodo, dict):
+        return frozenset()
+    raw = gptodo.get("extra_frontmatter_fields")
     if not isinstance(raw, list):
         return frozenset()
     return frozenset(item for item in raw if isinstance(item, str) and item)

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -27,6 +27,7 @@ except ImportError:
 
 from dataclasses import dataclass, field
 from datetime import date, datetime, time, timedelta
+from functools import lru_cache
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -35,6 +36,7 @@ from typing import (
     List,
     NamedTuple,
     Optional,
+    Set,
     Tuple,
 )
 
@@ -176,10 +178,23 @@ KNOWN_FRONTMATTER_FIELDS: set[str] = {
     "completed",
     "output_types",
     "success_criterion",
+    # Structured blockers (see TASKS.md "Blocked means waiting"):
+    # `wait_kind` classifies WHY a task is waiting (machine|human|external|
+    # hypothesis) so sweepers can auto-release only the mechanically-checkable
+    # ones; `probe` carries the shell command that decides whether a
+    # machine-class blocker has cleared.
+    "wait_kind",
+    "probe",
     # External tracking
     "tracking",
     "tracking_issue",
     "upstream_coordination_id",
+    # Provenance / grouping for autonomous loops: `follow_on_from` names the
+    # task that spawned this one (narrower than `parent`, which implies a
+    # subtask tree), `coordination_family` groups tasks that must not run
+    # concurrently because they touch the same subsystem.
+    "follow_on_from",
+    "coordination_family",
     # Work-pool routing (see frontier-pool-routing design)
     "pool",
     # Multi-agent coordination
@@ -232,21 +247,94 @@ DEPRECATED_FRONTMATTER_FIELDS: dict[str, str] = {
         "Not a task schema field — use `assigned_to` instead. "
         "`owner` is a common hallucination for the real assignment field."
     ),
+    "discovered_from": (
+        "Underscore variant of the real field. Use `discovered-from` (hyphen) — "
+        "the underscore spelling is never read by any gptodo code path."
+    ),
 }
 
 
-def lint_frontmatter_fields(metadata: Dict[str, Any]) -> List[Tuple[str, str, str]]:
+# =============================================================================
+# Workspace schema extension
+# =============================================================================
+#
+# Agent workspaces grow fields gptodo cannot reasonably own upstream (Bob's
+# `erik_gate_class` names a specific human). Without an extension point those
+# fields lint as "unknown" forever, which trains everyone to ignore the warning
+# — and a warning nobody reads catches no drift.
+#
+# Two sources, both additive on top of KNOWN_FRONTMATTER_FIELDS:
+#   1. GPTODO_EXTRA_FRONTMATTER_FIELDS — comma/whitespace separated (works in
+#      any workspace, including non-Python ones)
+#   2. <repo_root>/pyproject.toml → [tool.gptodo] extra_frontmatter_fields
+
+EXTRA_FRONTMATTER_FIELDS_ENV = "GPTODO_EXTRA_FRONTMATTER_FIELDS"
+
+
+def _parse_extra_fields_env(raw: str | None) -> set[str]:
+    if not raw:
+        return set()
+    return {part for part in re.split(r"[,\s]+", raw.strip()) if part}
+
+
+@lru_cache(maxsize=16)
+def _pyproject_extra_fields(repo_root: Path) -> frozenset[str]:
+    """Read [tool.gptodo] extra_frontmatter_fields from the workspace pyproject.
+
+    Degrades silently: a missing file, missing tomllib (Python 3.10), malformed
+    TOML, or a non-list value all yield an empty set. Schema linting is a soft
+    check — it must never be the reason a command fails.
+    """
+    pyproject = repo_root / "pyproject.toml"
+    if not pyproject.is_file():
+        return frozenset()
+    try:
+        import tomllib
+    except ImportError:  # pragma: no cover - Python 3.10
+        return frozenset()
+    try:
+        with open(pyproject, "rb") as f:
+            data = tomllib.load(f)
+    except (OSError, ValueError):
+        return frozenset()
+    raw = data.get("tool", {}).get("gptodo", {}).get("extra_frontmatter_fields")
+    if not isinstance(raw, list):
+        return frozenset()
+    return frozenset(item for item in raw if isinstance(item, str) and item)
+
+
+def resolve_known_frontmatter_fields(repo_root: Path | None = None) -> set[str]:
+    """KNOWN_FRONTMATTER_FIELDS plus any workspace-registered extra fields."""
+    fields = set(KNOWN_FRONTMATTER_FIELDS)
+    fields |= _parse_extra_fields_env(os.environ.get(EXTRA_FRONTMATTER_FIELDS_ENV))
+    if repo_root is not None:
+        fields |= _pyproject_extra_fields(repo_root)
+    return fields
+
+
+def lint_frontmatter_fields(
+    metadata: Dict[str, Any],
+    known_fields: Optional[Set[str]] = None,
+) -> List[Tuple[str, str, str]]:
     """Return (severity, field, message) tuples for schema violations.
+
+    Args:
+        metadata: task frontmatter to check.
+        known_fields: accepted field names. Defaults to KNOWN_FRONTMATTER_FIELDS;
+            pass ``resolve_known_frontmatter_fields(repo_root)`` to honor
+            workspace-registered extras.
 
     Severities:
         "warn-deprecated" — field is on the DEPRECATED_FRONTMATTER_FIELDS list
-        "warn-unknown"    — field is not in KNOWN_FRONTMATTER_FIELDS
+        "warn-unknown"    — field is not in the known-field set
 
     This is a soft check: callers should surface these as warnings, not errors.
     Rejecting unknown fields at read time would break autonomous-loop task
     creation, which the schema needs to nudge toward — not wall off from —
     the correct form.
     """
+    if known_fields is None:
+        known_fields = KNOWN_FRONTMATTER_FIELDS
     findings: List[Tuple[str, str, str]] = []
     for key in metadata.keys():
         if not isinstance(key, str):
@@ -259,14 +347,16 @@ def lint_frontmatter_fields(metadata: Dict[str, Any]) -> List[Tuple[str, str, st
                     DEPRECATED_FRONTMATTER_FIELDS[key],
                 )
             )
-        elif key not in KNOWN_FRONTMATTER_FIELDS:
+        elif key not in known_fields:
             findings.append(
                 (
                     "warn-unknown",
                     key,
                     f"Field '{key}' is not in the known schema. If this is a real, "
                     "intentional field, add it to KNOWN_FRONTMATTER_FIELDS in "
-                    "gptodo/utils.py. Otherwise, remove it — the autonomous loop "
+                    "gptodo/utils.py — or, if it is workspace-specific, register it "
+                    "under [tool.gptodo] extra_frontmatter_fields in your "
+                    "pyproject.toml. Otherwise, remove it — the autonomous loop "
                     "tends to invent plausible-sounding fields under load.",
                 )
             )

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -270,6 +270,28 @@ DEPRECATED_FRONTMATTER_FIELDS: dict[str, str] = {
 
 EXTRA_FRONTMATTER_FIELDS_ENV = "GPTODO_EXTRA_FRONTMATTER_FIELDS"
 
+# tomllib is 3.11+; gptodo supports 3.10. `tomli` is its API-identical backport
+# and is already present in most environments transitively — use it when it is,
+# rather than making 3.10 silently lose a documented config source. Neither
+# available => the env var still works.
+# Assigned rather than aliased with `as _toml`: rebinding the same name across
+# both import arms reads as a redefinition to mypy under one repo's config and
+# as a redundant ignore under the other's.
+_toml: Any = None
+try:
+    import tomllib
+
+    _toml = tomllib
+except ImportError:  # pragma: no cover - Python 3.10
+    try:
+        import tomli
+
+        _toml = tomli
+    except ImportError:
+        pass
+
+HAVE_TOML_PARSER = _toml is not None
+
 
 def _parse_extra_fields_env(raw: str | None) -> set[str]:
     if not raw:
@@ -281,20 +303,18 @@ def _parse_extra_fields_env(raw: str | None) -> set[str]:
 def _pyproject_extra_fields(repo_root: Path) -> frozenset[str]:
     """Read [tool.gptodo] extra_frontmatter_fields from the workspace pyproject.
 
-    Degrades silently: a missing file, missing tomllib (Python 3.10), malformed
+    Degrades silently: a missing file, no available TOML parser, malformed
     TOML, or a non-list value all yield an empty set. Schema linting is a soft
     check — it must never be the reason a command fails.
     """
+    if _toml is None:  # pragma: no cover - only without tomllib/tomli
+        return frozenset()
     pyproject = repo_root / "pyproject.toml"
     if not pyproject.is_file():
         return frozenset()
     try:
-        import tomllib
-    except ImportError:  # pragma: no cover - Python 3.10
-        return frozenset()
-    try:
         with open(pyproject, "rb") as f:
-            data = tomllib.load(f)
+            data = _toml.load(f)
     except (OSError, ValueError):
         return frozenset()
     raw = data.get("tool", {}).get("gptodo", {}).get("extra_frontmatter_fields")

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -27,7 +27,6 @@ except ImportError:
 
 from dataclasses import dataclass, field
 from datetime import date, datetime, time, timedelta
-from functools import lru_cache
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -299,7 +298,6 @@ def _parse_extra_fields_env(raw: str | None) -> set[str]:
     return {part for part in re.split(r"[,\s]+", raw.strip()) if part}
 
 
-@lru_cache(maxsize=16)
 def _pyproject_extra_fields(repo_root: Path) -> frozenset[str]:
     """Read [tool.gptodo] extra_frontmatter_fields from the workspace pyproject.
 

--- a/packages/gptodo/tests/test_frontmatter_schema_extension.py
+++ b/packages/gptodo/tests/test_frontmatter_schema_extension.py
@@ -1,0 +1,137 @@
+"""Tests for workspace-extensible frontmatter schema.
+
+Two schemas competing for "what is a valid task field" is worse than one
+imperfect schema. Before this, gptodo's KNOWN_FRONTMATTER_FIELDS did not know
+several fields a workspace's own pre-commit validator actively enforced, so
+`gptodo lint` flagged 284 findings across 205 real tasks — a warning volume
+that trains everyone to ignore the warning.
+
+The fix has two halves, both covered here:
+  1. Genuinely generic fields (wait_kind, probe, follow_on_from,
+     coordination_family) move into the upstream known set.
+  2. Workspace-specific fields (Bob's `erik_gate_class` names a specific human)
+     register via GPTODO_EXTRA_FRONTMATTER_FIELDS or
+     [tool.gptodo] extra_frontmatter_fields in the workspace pyproject.toml.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gptodo.utils import (
+    EXTRA_FRONTMATTER_FIELDS_ENV,
+    KNOWN_FRONTMATTER_FIELDS,
+    _pyproject_extra_fields,
+    lint_frontmatter_fields,
+    resolve_known_frontmatter_fields,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_pyproject_cache():
+    """_pyproject_extra_fields is lru_cached; tests reuse tmp_path names."""
+    _pyproject_extra_fields.cache_clear()
+    yield
+    _pyproject_extra_fields.cache_clear()
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["wait_kind", "probe", "follow_on_from", "coordination_family"],
+)
+def test_generic_workflow_fields_are_known_upstream(field: str) -> None:
+    assert field in KNOWN_FRONTMATTER_FIELDS
+    assert lint_frontmatter_fields({"state": "waiting", field: "x"}) == []
+
+
+def test_underscore_discovered_from_is_flagged_as_deprecated() -> None:
+    """`discovered-from` is the real field; the underscore twin is never read."""
+    findings = lint_frontmatter_fields({"discovered_from": "some-task"})
+    assert [f[0] for f in findings] == ["warn-deprecated"]
+    assert "discovered-from" in findings[0][2]
+
+
+def test_unknown_field_still_warns_by_default() -> None:
+    findings = lint_frontmatter_fields({"state": "todo", "erik_gate_class": "spend"})
+    assert [(sev, fld) for sev, fld, _ in findings] == [("warn-unknown", "erik_gate_class")]
+
+
+def test_env_var_registers_extra_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(EXTRA_FRONTMATTER_FIELDS_ENV, "erik_gate_class, house_style")
+    known = resolve_known_frontmatter_fields()
+    assert {"erik_gate_class", "house_style"} <= known
+    assert (
+        lint_frontmatter_fields(
+            {"erik_gate_class": "spend", "house_style": "loud"}, known_fields=known
+        )
+        == []
+    )
+
+
+def test_env_var_absent_or_empty_is_a_no_op(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(EXTRA_FRONTMATTER_FIELDS_ENV, "   ")
+    assert resolve_known_frontmatter_fields() == set(KNOWN_FRONTMATTER_FIELDS)
+    monkeypatch.delenv(EXTRA_FRONTMATTER_FIELDS_ENV)
+    assert resolve_known_frontmatter_fields() == set(KNOWN_FRONTMATTER_FIELDS)
+
+
+def test_pyproject_registers_extra_fields(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(EXTRA_FRONTMATTER_FIELDS_ENV, raising=False)
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "demo"\n\n'
+        "[tool.gptodo]\n"
+        'extra_frontmatter_fields = ["erik_gate_class", "premise_check"]\n'
+    )
+    known = resolve_known_frontmatter_fields(tmp_path)
+    assert {"erik_gate_class", "premise_check"} <= known
+    assert lint_frontmatter_fields({"erik_gate_class": "spend"}, known_fields=known) == []
+
+
+def test_deprecated_beats_workspace_registration(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A workspace can't opt back into an anti-design-goal field."""
+    monkeypatch.delenv(EXTRA_FRONTMATTER_FIELDS_ENV, raising=False)
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.gptodo]\nextra_frontmatter_fields = ["modified"]\n'
+    )
+    known = resolve_known_frontmatter_fields(tmp_path)
+    findings = lint_frontmatter_fields({"modified": "2026-08-05"}, known_fields=known)
+    assert [f[0] for f in findings] == ["warn-deprecated"]
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "",  # no [tool.gptodo]
+        "[tool.gptodo]\n",  # section but no key
+        '[tool.gptodo]\nextra_frontmatter_fields = "not-a-list"\n',
+        "[tool.gptodo]\nextra_frontmatter_fields = [1, 2]\n",  # non-str entries
+        "this is not = valid toml [[[",
+    ],
+)
+def test_malformed_pyproject_degrades_to_base_schema(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, content: str
+) -> None:
+    """Schema lint is a soft check — bad config must never break a command."""
+    monkeypatch.delenv(EXTRA_FRONTMATTER_FIELDS_ENV, raising=False)
+    (tmp_path / "pyproject.toml").write_text(content)
+    assert resolve_known_frontmatter_fields(tmp_path) == set(KNOWN_FRONTMATTER_FIELDS)
+
+
+def test_missing_pyproject_degrades_to_base_schema(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv(EXTRA_FRONTMATTER_FIELDS_ENV, raising=False)
+    assert resolve_known_frontmatter_fields(tmp_path) == set(KNOWN_FRONTMATTER_FIELDS)
+
+
+def test_env_and_pyproject_are_additive(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(EXTRA_FRONTMATTER_FIELDS_ENV, "from_env")
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.gptodo]\nextra_frontmatter_fields = ["from_toml"]\n'
+    )
+    known = resolve_known_frontmatter_fields(tmp_path)
+    assert {"from_env", "from_toml"} <= known

--- a/packages/gptodo/tests/test_frontmatter_schema_extension.py
+++ b/packages/gptodo/tests/test_frontmatter_schema_extension.py
@@ -22,10 +22,17 @@ import pytest
 
 from gptodo.utils import (
     EXTRA_FRONTMATTER_FIELDS_ENV,
+    HAVE_TOML_PARSER,
     KNOWN_FRONTMATTER_FIELDS,
     _pyproject_extra_fields,
     lint_frontmatter_fields,
     resolve_known_frontmatter_fields,
+)
+
+
+needs_toml = pytest.mark.skipif(
+    not HAVE_TOML_PARSER,
+    reason="pyproject config needs tomllib (3.11+) or the tomli backport",
 )
 
 
@@ -77,6 +84,7 @@ def test_env_var_absent_or_empty_is_a_no_op(monkeypatch: pytest.MonkeyPatch) -> 
     assert resolve_known_frontmatter_fields() == set(KNOWN_FRONTMATTER_FIELDS)
 
 
+@needs_toml
 def test_pyproject_registers_extra_fields(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv(EXTRA_FRONTMATTER_FIELDS_ENV, raising=False)
     (tmp_path / "pyproject.toml").write_text(
@@ -89,6 +97,7 @@ def test_pyproject_registers_extra_fields(tmp_path: Path, monkeypatch: pytest.Mo
     assert lint_frontmatter_fields({"erik_gate_class": "spend"}, known_fields=known) == []
 
 
+@needs_toml
 def test_deprecated_beats_workspace_registration(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -112,6 +121,7 @@ def test_deprecated_beats_workspace_registration(
         "this is not = valid toml [[[",
     ],
 )
+@needs_toml
 def test_malformed_pyproject_degrades_to_base_schema(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, content: str
 ) -> None:
@@ -128,6 +138,7 @@ def test_missing_pyproject_degrades_to_base_schema(
     assert resolve_known_frontmatter_fields(tmp_path) == set(KNOWN_FRONTMATTER_FIELDS)
 
 
+@needs_toml
 def test_env_and_pyproject_are_additive(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(EXTRA_FRONTMATTER_FIELDS_ENV, "from_env")
     (tmp_path / "pyproject.toml").write_text(

--- a/packages/gptodo/tests/test_frontmatter_schema_extension.py
+++ b/packages/gptodo/tests/test_frontmatter_schema_extension.py
@@ -19,12 +19,14 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from click.testing import CliRunner
 
+from gptodo import cli as cli_mod
+from gptodo.cli import cli
 from gptodo.utils import (
     EXTRA_FRONTMATTER_FIELDS_ENV,
     HAVE_TOML_PARSER,
     KNOWN_FRONTMATTER_FIELDS,
-    _pyproject_extra_fields,
     lint_frontmatter_fields,
     resolve_known_frontmatter_fields,
 )
@@ -34,14 +36,6 @@ needs_toml = pytest.mark.skipif(
     not HAVE_TOML_PARSER,
     reason="pyproject config needs tomllib (3.11+) or the tomli backport",
 )
-
-
-@pytest.fixture(autouse=True)
-def _clear_pyproject_cache():
-    """_pyproject_extra_fields is lru_cached; tests reuse tmp_path names."""
-    _pyproject_extra_fields.cache_clear()
-    yield
-    _pyproject_extra_fields.cache_clear()
 
 
 @pytest.mark.parametrize(
@@ -148,3 +142,49 @@ def test_env_and_pyproject_are_additive(tmp_path: Path, monkeypatch: pytest.Monk
     )
     known = resolve_known_frontmatter_fields(tmp_path)
     assert {"from_env", "from_toml"} <= known
+
+
+# -- Schema resolution is hoisted out of the lint loop -----------------------
+
+
+CLEAN_TASK = """\
+---
+state: todo
+created: 2026-06-01T00:00:00+00:00
+---
+# Clean Task
+"""
+
+
+def test_lint_resolves_schema_once_regardless_of_task_count(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`gptodo lint` must resolve the schema once, not once per task.
+
+    `resolve_known_frontmatter_fields` reads the workspace pyproject from disk
+    on every call. It was originally called inside the per-task loop and made
+    cheap with an `lru_cache`; the cache was removed in favour of hoisting the
+    call, so this pins the hoist. Without it the disk read silently returns to
+    O(tasks).
+    """
+    monkeypatch.delenv(EXTRA_FRONTMATTER_FIELDS_ENV, raising=False)
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    for i in range(5):
+        (tasks_dir / f"task-{i}.md").write_text(CLEAN_TASK)
+
+    calls = 0
+    real = cli_mod.resolve_known_frontmatter_fields
+
+    def counting(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(cli_mod, "resolve_known_frontmatter_fields", counting)
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(cli, ["lint"])
+
+    assert result.exit_code == 0, result.output
+    assert calls == 1, f"schema resolved {calls}x for 5 tasks — hoist regressed"

--- a/packages/gptodo/tests/test_frontmatter_schema_extension.py
+++ b/packages/gptodo/tests/test_frontmatter_schema_extension.py
@@ -119,6 +119,8 @@ def test_deprecated_beats_workspace_registration(
         '[tool.gptodo]\nextra_frontmatter_fields = "not-a-list"\n',
         "[tool.gptodo]\nextra_frontmatter_fields = [1, 2]\n",  # non-str entries
         "this is not = valid toml [[[",
+        'tool = "not-a-dict"\n',  # tool is a scalar, not a table — was AttributeError
+        '[tool]\ngptodo = "not-a-dict"\n',  # tool.gptodo scalar — was AttributeError
     ],
 )
 @needs_toml


### PR DESCRIPTION
## Problem

gptodo carried **three disagreeing answers** to "what is a valid task field":

1. `KNOWN_FRONTMATTER_FIELDS` in `utils.py` — used by `gptodo lint`
2. a separate hardcoded `VALID_FIELDS` allowlist inside `edit` — used at *write* time
3. whatever the workspace's own pre-commit validator enforces

In Bob's workspace that split produced **284 lint findings across 205 real tasks** — every one of them a field the workspace validator *actively requires* (`wait_kind` ×149, `erik_gate_class` ×87, `probe`, `follow_on_from`, `coordination_family`). A warning that fires on a quarter of the corpus is a warning nobody reads.

Worse, list 2 meant `gptodo edit --set wait_kind machine` was **hard-rejected** — the CLI refused to write a field the same workspace's validator demanded.

## Change

**1. Generic workflow fields move upstream** (into both the known set and `edit`'s allowlist):

| Field | Meaning |
|---|---|
| `wait_kind` | structured blocker class — validated as an enum: `machine\|human\|external\|hypothesis` |
| `probe` | shell command that decides whether a machine-class blocker cleared |
| `follow_on_from` | task that spawned this one (narrower than `parent`) |
| `coordination_family` | tasks that must not run concurrently |

**2. Workspace-specific fields get an extension point instead of a fork.** Bob's `erik_gate_class` names a specific human and has no business in gptodo's schema. It registers via either:

```toml
# workspace pyproject.toml
[tool.gptodo]
extra_frontmatter_fields = ["erik_gate_class"]
```
```bash
# or, for non-Python workspaces
export GPTODO_EXTRA_FRONTMATTER_FIELDS="erik_gate_class,house_style"
```

Registered extras are accepted by `lint` **and** settable via `gptodo edit` — registering a field you still can't write is the same two-schema split one level down. Scoped deliberately to the *extras*: upstream-known-but-machine-written fields (`session_id`, `worktree_path`, …) stay unsettable by hand.

**3.** `DEPRECATED_FRONTMATTER_FIELDS` gains `discovered_from`, the underscore twin of the real `discovered-from`, which no code path has ever read. Deprecation still beats workspace registration — a workspace cannot opt back into an anti-design-goal field.

## Safety

Config parsing degrades silently on **every** failure path: missing `pyproject.toml`, Python 3.10 without `tomllib`, malformed TOML, non-list value, non-string entries. Schema lint is a soft check and must never be the reason a command fails. Each of those paths has a test.

## Verification

- `pytest packages/gptodo/tests` — **381 passed**, 13 new tests in `test_frontmatter_schema_extension.py`
  - (2 pre-existing failures in `test_ready_selection.py` / `test_pool_filter.py` are unrelated: `ready --json` interleaves a `console.print` before the JSON payload. Untouched by this diff.)
- `mypy` clean on both changed files; `ruff check` + `ruff format` clean
- **Live corpus effect** (Bob's 682 tasks): `gptodo lint` findings go **284 across 205 tasks → 43 across 23**. The remainder is exactly the real ballast (`premise_check`, `minted_by`, `idea_ref`, `design_doc`, `parent_artifact`) emitted by task-minting scripts — i.e. the signal the warning is *supposed* to carry.
- Manual: `gptodo edit demo --set wait_kind machine` now writes; `--set wait_kind bogus` is rejected with the valid values; an unregistered field is still rejected.

Phase 1 of `tasks/gptodo-schema-unification.md` (from a gptodo task-system review). Phases 2–3 (migrate secondary parsers onto the gptodo lib; stop ballast at the minting scripts) are separate.