### PR TITLE
refactor(cc-memory): retire the pending-items lane

### DIFF
--- a/packages/gptme-cc-memory/README.md
+++ b/packages/gptme-cc-memory/README.md
@@ -80,7 +80,7 @@ Add to your `.claude/settings.local.json`:
 ### 4. The pipeline runs automatically
 
 - **Stop hook**: When the session ends, the extractor reads the trajectory and writes
-  pending updates, pending items, and new feedback memories.
+  pending updates, session context, and new feedback memories.
 - **Prompt injection**: At the next session start, `prompt-inject` reads the memory
   directory, scores each file, and injects the top-N relevant memories.
 
@@ -96,7 +96,7 @@ Interactive session ends
    extractor
      • Reads CC trajectory (JSONL)
      • Detects: corrections, confirmations, new instructions
-     • Writes pending-updates.md + pending-items.md
+     • Writes pending-updates.md + pending-session-context.md
         │
         ▼ (next session starts)
         │

--- a/packages/gptme-cc-memory/src/gptme_cc_memory/extractor.py
+++ b/packages/gptme-cc-memory/src/gptme_cc_memory/extractor.py
@@ -68,14 +68,6 @@ CONFIRMATION_PATTERNS: list[tuple[str, str]] = [
     (r"\b(approved?|accepted?|confirmed?)\b", "explicit_approval"),
 ]
 
-# Patterns for pending items and follow-ups
-PENDING_ITEM_PATTERNS: list[str] = [
-    r"(next|remaining|outstanding|unfinished|todo)\s+(step|task|item|work)",
-    r"(to\s+do|follow.?up|check\s+back|look\s+into|investigate)",
-    r"(i'll|we'll|let's)\s+(come\s+back|continue|finish|address)",
-    r"(pending|deferred|postponed|on\s+hold)",
-]
-
 # Patterns for structured guidance in model responses
 GUIDANCE_PATTERNS: list[str] = [
     r"(reminder|rule|guideline|principle|convention|policy|standard|practice)s?:",
@@ -89,7 +81,6 @@ class ExtractionResult:
 
     corrections: list[dict[str, Any]] = field(default_factory=list)
     confirmations: list[dict[str, Any]] = field(default_factory=list)
-    pending_items: list[str] = field(default_factory=list)
     guidance_blocks: list[str] = field(default_factory=list)
     session_context: dict[str, Any] = field(default_factory=dict)
 
@@ -181,32 +172,6 @@ def detect_confirmations(
     return confirmations
 
 
-def detect_pending_items(
-    messages: list[dict[str, Any]],
-) -> list[str]:
-    """Detect pending items and follow-ups in a trajectory."""
-    items: list[str] = []
-    seen: set[str] = set()
-
-    for msg in messages:
-        # Check both user and assistant messages
-        content = str(msg.get("content", ""))
-        if not content or len(content) > 1000:
-            continue
-
-        for pattern in PENDING_ITEM_PATTERNS:
-            matches = re.finditer(pattern, content, re.IGNORECASE)
-            for match in matches:
-                start = max(0, match.start() - 40)
-                end = min(len(content), match.end() + 80)
-                snippet = content[start:end].strip()
-                if snippet and snippet not in seen:
-                    seen.add(snippet)
-                    items.append(snippet)
-
-    return items
-
-
 def detect_guidance_blocks(
     messages: list[dict[str, Any]],
 ) -> list[str]:
@@ -275,7 +240,6 @@ def extract_memories(
     return ExtractionResult(
         corrections=detect_corrections(messages),
         confirmations=detect_confirmations(messages),
-        pending_items=detect_pending_items(messages),
         guidance_blocks=detect_guidance_blocks(messages),
         session_context=extract_session_context(messages),
     )
@@ -305,17 +269,6 @@ def format_pending_updates(result: ExtractionResult) -> str:
             lines.append(f"- {g[:200]}")
         lines.append("")
 
-    return "\n".join(lines).strip()
-
-
-def format_pending_items(result: ExtractionResult) -> str:
-    """Format extraction results as a pending-items markdown block."""
-    if not result.pending_items:
-        return ""
-
-    lines = ["## Pending Items"]
-    for item in result.pending_items[:5]:  # Limit to 5 items
-        lines.append(f"- {item[:200]}")
     return "\n".join(lines).strip()
 
 
@@ -373,10 +326,6 @@ def main() -> None:
             combined = f"{existing}\n\n{updates}" if existing else updates
             updates_file.write_text(combined.strip() + "\n", encoding="utf-8")
 
-        items = format_pending_items(result)
-        if items:
-            (memory_dir / "pending-items.md").write_text(items + "\n", encoding="utf-8")
-
         ctx = format_session_context(result)
         if ctx:
             (memory_dir / "pending-session-context.md").write_text(ctx + "\n", encoding="utf-8")
@@ -384,7 +333,7 @@ def main() -> None:
     # Also print summary to stdout
     print(
         f"Extracted {len(result.corrections)} corrections, {len(result.confirmations)} confirmations, "
-        f"{len(result.pending_items)} pending items, {len(result.guidance_blocks)} guidance blocks"
+        f"{len(result.guidance_blocks)} guidance blocks"
     )
 
 

--- a/packages/gptme-cc-memory/src/gptme_cc_memory/hooks/prompt_submit.py
+++ b/packages/gptme-cc-memory/src/gptme_cc_memory/hooks/prompt_submit.py
@@ -34,7 +34,6 @@ STATE_DIR = WORKSPACE / "state" / "cc-memory"
 METADATA_FILE = STATE_DIR / "metadata.json"
 GUIDANCE_FILE = MEMORY_DIR / "guidance.md"
 PENDING_UPDATES_FILE = MEMORY_DIR / "pending-updates.md"
-PENDING_ITEMS_FILE = MEMORY_DIR / "pending-items.md"
 PENDING_SESSION_CONTEXT_FILE = MEMORY_DIR / "pending-session-context.md"
 
 
@@ -58,7 +57,6 @@ def main() -> None:
         metadata_file=METADATA_FILE,
         guidance_file=GUIDANCE_FILE,
         pending_updates_file=PENDING_UPDATES_FILE,
-        pending_items_file=PENDING_ITEMS_FILE,
         pending_session_context_file=PENDING_SESSION_CONTEXT_FILE,
     )
 

--- a/packages/gptme-cc-memory/src/gptme_cc_memory/injector.py
+++ b/packages/gptme-cc-memory/src/gptme_cc_memory/injector.py
@@ -92,7 +92,6 @@ def inject_memories(
     metadata_file: Path,
     guidance_file: Path | None = None,
     pending_updates_file: Path | None = None,
-    pending_items_file: Path | None = None,
     pending_session_context_file: Path | None = None,
     max_chars: int = MAX_INJECT_CHARS,
 ) -> str | None:
@@ -120,20 +119,14 @@ def inject_memories(
                 if pruned:
                     blocks.append(f"{pruned}\n\n")
 
-        # 3. Pending items
-        if pending_items_file:
-            items = read_if_exists(pending_items_file)
-            if items:
-                blocks.append(f"## Pending Items\n\n{items}\n\n")
-
-        # 4. Pending session context (one-shot)
+        # 3. Pending session context (one-shot)
         if pending_session_context_file:
             ctx = read_if_exists(pending_session_context_file)
             if ctx:
                 blocks.append(f"## Previous Session Context\n\n{ctx}\n\n")
                 one_shot_files_to_clear.append(pending_session_context_file)
 
-        # 5. Relevant memory entries (scored against prompt)
+        # 4. Relevant memory entries (scored against prompt)
         relevant = select_relevant_memories(
             prompt,
             memory_dir=memory_dir,

--- a/packages/gptme-cc-memory/src/gptme_cc_memory/schema.py
+++ b/packages/gptme-cc-memory/src/gptme_cc_memory/schema.py
@@ -28,6 +28,8 @@ SPECIAL_MEMORY_FILES = frozenset(
     {
         "MEMORY.md",
         "guidance.md",
+        # Retired lane — kept here so a leftover file from a pre-retirement
+        # install is never discovered as a memory entry.
         "pending-items.md",
         "pending-updates.md",
         "pending-session-context.md",

--- a/packages/gptme-cc-memory/tests/test_extractor.py
+++ b/packages/gptme-cc-memory/tests/test_extractor.py
@@ -11,10 +11,8 @@ from gptme_cc_memory.extractor import (
     detect_corrections,
     detect_confirmations,
     detect_guidance_blocks,
-    detect_pending_items,
     extract_memories,
     extract_session_context,
-    format_pending_items,
     format_pending_updates,
     format_session_context,
 )
@@ -25,13 +23,6 @@ CORRECTION_TRAJECTORY = [
     {"role": "human", "content": "Don't use --no-verify, fix the pre-commit failure instead"},
     {"role": "assistant", "content": "You're right, I should fix the hook failure."},
     {"role": "human", "content": "Great, that works!"},
-]
-
-# Sample trajectory with a pending item
-PENDING_TRAJECTORY = [
-    {"role": "human", "content": "Let's start the database migration"},
-    {"role": "assistant", "content": "I'll begin with the schema changes."},
-    {"role": "human", "content": "The next step is to handle the rollback script"},
 ]
 
 # Sample trajectory with guidance
@@ -78,15 +69,6 @@ class TestDetectConfirmations:
         ]
         result = detect_confirmations(messages)
         assert len(result) == 0
-
-
-class TestDetectPendingItems:
-    def test_detects_pending_items(self):
-        result = detect_pending_items(PENDING_TRAJECTORY)
-        assert len(result) >= 1
-
-    def test_no_items_in_empty(self):
-        assert detect_pending_items(EMPTY_TRAJECTORY) == []
 
 
 class TestDetectGuidanceBlocks:
@@ -142,8 +124,14 @@ class TestExtractMemories:
         workspace = tmp_path / "workspace"
         memory_dir = workspace / "memory"
 
+        # Includes a phrase the retired pending-item detector matched
+        # ("The next step is ..."), so this asserts the lane is really gone
+        # rather than merely un-triggered.
+        messages = CORRECTION_TRAJECTORY + [
+            {"role": "human", "content": "The next step is to handle the rollback script"},
+        ]
         with open(traj, "w", encoding="utf-8") as f:
-            for msg in CORRECTION_TRAJECTORY:
+            for msg in messages:
                 f.write(json.dumps(msg) + "\n")
 
         monkeypatch.setenv("GPTME_CC_MEMORY_DIR", str(workspace))
@@ -153,6 +141,8 @@ class TestExtractMemories:
 
         assert (memory_dir / "pending-updates.md").exists()
         assert (memory_dir / "pending-session-context.md").exists()
+        # Retired lane: the extractor must never write pending-items.md again.
+        assert not (memory_dir / "pending-items.md").exists()
 
 
 class TestFormatOutput:
@@ -173,14 +163,6 @@ class TestFormatOutput:
         output = format_pending_updates(r)
         assert "don't use" in output
         assert "Great, that works" in output
-
-    def test_format_pending_items(self):
-        from gptme_cc_memory.extractor import ExtractionResult
-
-        r = ExtractionResult(pending_items=["Finish the migration", "Write tests"])
-        output = format_pending_items(r)
-        assert "Finish" in output
-        assert "Write tests" in output
 
     def test_format_session_context(self):
         from gptme_cc_memory.extractor import ExtractionResult

--- a/packages/gptme-cc-memory/tests/test_injector.py
+++ b/packages/gptme-cc-memory/tests/test_injector.py
@@ -120,21 +120,29 @@ class TestInjectMemories:
         # Guidance should be cleared after injection
         assert not guidance.read_text()
 
-    def test_with_pending_items(self, tmp_path: Path):
+    def test_leftover_pending_items_file_is_never_injected(self, tmp_path: Path):
+        """The pending-items lane is retired.
+
+        A file left behind by a pre-retirement install must not re-enter the
+        prompt — neither as its own block nor as a discovered memory entry.
+        The signature assertion pins the injection point itself: the retired
+        branch cannot be re-wired without this failing.
+        """
+        import inspect
+
+        assert "pending_items_file" not in inspect.signature(inject_memories).parameters
+
         mem_dir = tmp_path / "memory"
         mem_dir.mkdir()
         meta_file = tmp_path / "metadata.json"
-        items = mem_dir / "pending-items.md"
-        items.write_text("## Pending Items\n- Finish the migration")
+        (mem_dir / "pending-items.md").write_text("## Pending Items\n- Finish the migration")
 
         result = inject_memories(
             "test prompt",
             memory_dir=mem_dir,
             metadata_file=meta_file,
-            pending_items_file=items,
         )
-        assert result is not None
-        assert "Finish the migration" in result
+        assert result is None or "Finish the migration" not in result
 
     def test_preserves_one_shot_files_when_recording_injections_fails(
         self, tmp_path: Path, monkeypatch: Any


### PR DESCRIPTION
## Problem

The `pending-items` lane in `gptme-cc-memory` re-injects the same regex-matched snippets into every prompt, with no path to clearing them. Three mechanisms combine:

1. **Never clears.** `extractor.main()` writes `pending-items.md` only when the match list is non-empty (`if items:`), so once a file is written, a later zero-match run leaves it in place forever.
2. **Not one-shot.** Unlike the `guidance` and `pending-session-context` blocks, injector block 3 does not add its file to `one_shot_files_to_clear` — whatever landed there re-injects on *every* prompt.
3. **Early matches hold the slots.** `detect_pending_items()` scans from the start of the trajectory and `format_pending_items()` takes the first 5. As a transcript grows, the earliest five matches keep the slots permanently.

The matches are regex snippets like `(to\s+do|follow.?up|check\s+back|look\s+into|investigate)` lifted with ±40/80 chars of surrounding context — they are not structured handoffs, and the extractor has no guard against re-extracting its own injected output.

## Evidence

Bob's live memory pipeline ran this same design and measured **~0–11% precision across 1,055 injections into 957 distinct sessions over 7 days**. The chosen fix there was retirement, not a fingerprint ledger + transcript cursor + TTL — adding ~150 LOC of machinery to *bound the damage* of a channel with no measured value is machinery where a deletion belongs.

The lane's actual purpose — handing unfinished work to the next session — is already served by two channels that survive here: the one-shot, self-clearing `pending-session-context` block, and `pending-updates` with its date-based pruning.

## Changes

- `extractor.py` — drop `PENDING_ITEM_PATTERNS`, `detect_pending_items`, `format_pending_items`, the `pending_items` field, and the `pending-items.md` write
- `injector.py` — drop the `pending_items_file` parameter and injection block 3
- `hooks/prompt_submit.py` — drop `PENDING_ITEMS_FILE` and its wiring
- `schema.py` — **keep** `pending-items.md` in `SPECIAL_MEMORY_FILES` so a file left behind by a pre-retirement install is never discovered as a memory entry
- `README.md` — pipeline description now matches what the code writes

Net **-98/+30 LOC**. The guidance, session-context, and pending-updates paths are untouched.

## Verification

- `pytest tests/` — **57 passed**
- `prek run --files <changed>` — all hooks pass under the repo's pinned ruff 0.6.9 (`ruff`, `ruff-format`, `mypy`, link check, jscpd)
- Two regression tests pin the removal, and **both were verified to fail against the pre-change source**, not merely pass against the new one:
  - `test_main_writes_pending_files_under_workspace_memory_dir` asserts `pending-items.md` is not written. My first version of this pin was vacuous — the existing `CORRECTION_TRAJECTORY` never triggered the detector even under the old code. The trajectory now includes `"The next step is to handle the rollback script"`, confirmed to match the old `PENDING_ITEM_PATTERNS` and produce a written file pre-change.
  - `test_leftover_pending_items_file_is_never_injected` asserts via `inspect.signature` that `inject_memories` has no `pending_items_file` parameter, pinning the injection point itself so the branch cannot be silently re-wired.

## Notes for review

This package is not wired into any live hook on Bob's container — this is dormant fork-surface, fixed before adopters inherit it. Contrib's variant was somewhat less exposed than Bob's (caps at 5 rather than 10) but also *less* guarded: it has no meta-discussion or inside-quotes filters, so it can re-extract its own injected output.

Bob-local retirement: `ErikBjare/bob@240bcfb845`.