### PR TITLE
feat(bobutils): add public_safe() — public/private boundary sanitizer

### DIFF
--- a/packages/bobutils/src/bobutils/public_safe.py
+++ b/packages/bobutils/src/bobutils/public_safe.py
@@ -32,7 +32,7 @@ from typing import Callable
 __all__ = ["public_safe", "validate_public_safe", "PublicSafeViolation"]
 
 # Simple punctuation that always trails a URL in prose (never part of a URL).
-_TRAILING_SIMPLE = ".,;:!?'\"> "
+_TRAILING_SIMPLE = ".,;:!?'\">"
 # Balanced pairs: a closing delimiter is prose punctuation only when the URL
 # contains fewer opening counterparts than closing ones.
 _TRAILING_BALANCED: dict[str, str] = {")": "(", "]": "[", "}": "{"}
@@ -84,7 +84,7 @@ _SUBSTITUTIONS: list[tuple[re.Pattern[str], _Replacement]] = [
     # Internal HTTP(S) endpoints (catch before bare-hostname pattern)
     (
         re.compile(
-            r"https?://[a-z0-9.-]*\.bjareho\.lt(?::\d+)?(?:/[^\s]*)?",
+            r"https?://[a-z0-9.-]*\.bjareho\.lt(?::\d+)?(?:/[^\s\[\]]*)?",
             re.IGNORECASE,
         ),
         _strip_trailing_delimiters("<internal-endpoint>"),

--- a/packages/bobutils/src/bobutils/public_safe.py
+++ b/packages/bobutils/src/bobutils/public_safe.py
@@ -19,9 +19,8 @@ Usage::
 
     # Dry-run audit
     violations = validate_public_safe(draft)
-    if violations:
-        for v in violations:
-            print(f"  [{v.kind}] {v.match!r} at offset {v.offset}")
+    for v in violations:
+        logger.warning("[%s] %r at offset %d", v.kind, v.match, v.offset)
 """
 
 from __future__ import annotations

--- a/packages/bobutils/src/bobutils/public_safe.py
+++ b/packages/bobutils/src/bobutils/public_safe.py
@@ -27,26 +27,53 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from typing import Callable
 
 __all__ = ["public_safe", "validate_public_safe", "PublicSafeViolation"]
+
+# Punctuation/markdown delimiters that commonly trail a URL in prose and must
+# not be swallowed into the match (e.g. "see <url>." or "(<url>)").
+_TRAILING_DELIMITERS = ".,;:!?)]}'\">"
+
+_Replacement = str | Callable[[re.Match[str]], str]
+
+
+def _strip_trailing_delimiters(placeholder: str) -> Callable[[re.Match[str]], str]:
+    """Build a `re.sub` replacement fn that trims trailing prose delimiters."""
+
+    def _replace(m: re.Match[str]) -> str:
+        text = m.group()
+        trailing = ""
+        while text and text[-1] in _TRAILING_DELIMITERS:
+            trailing = text[-1] + trailing
+            text = text[:-1]
+        return placeholder + trailing
+
+    return _replace
 
 
 # ---------------------------------------------------------------------------
 # Substitution table — applied in declaration order (most-specific first).
 # ---------------------------------------------------------------------------
 
-_SUBSTITUTIONS: list[tuple[re.Pattern[str], str]] = [
+_SUBSTITUTIONS: list[tuple[re.Pattern[str], _Replacement]] = [
     # Absolute workspace root — most specific, must come before /home/bob/
     (re.compile(r"/home/bob/bob/"), "<workspace>/"),
     # Home directory
     (re.compile(r"/home/bob/"), "<home>/"),
     # Internal HTTP(S) endpoints (catch before bare-hostname pattern)
     (
-        re.compile(r"https?://[a-z0-9.-]*\.bjareho\.lt(?::\d+)?(?:/[^\s]*)?"),
-        "<internal-endpoint>",
+        re.compile(
+            r"https?://[a-z0-9.-]*\.bjareho\.lt(?::\d+)?(?:/[^\s]*)?",
+            re.IGNORECASE,
+        ),
+        _strip_trailing_delimiters("<internal-endpoint>"),
     ),
     # Internal bare hostnames
-    (re.compile(r"\b[a-z0-9-]+\.bjareho\.lt\b"), "<internal-host>"),
+    (
+        re.compile(r"\b[a-z0-9-]+\.bjareho\.lt\b", re.IGNORECASE),
+        "<internal-host>",
+    ),
     # Known private SSH remotes
     (re.compile(r"\berb-hetzner-ax41\b"), "<ssh-remote>"),
     # Cluster node references
@@ -60,8 +87,14 @@ _SUBSTITUTIONS: list[tuple[re.Pattern[str], str]] = [
 _VALIDATORS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"/home/bob/bob/"), "workspace absolute path"),
     (re.compile(r"/home/bob/"), "home directory path"),
-    (re.compile(r"https?://[a-z0-9.-]*\.bjareho\.lt"), "internal endpoint URL"),
-    (re.compile(r"\b[a-z0-9-]+\.bjareho\.lt\b"), "internal hostname"),
+    (
+        re.compile(r"https?://[a-z0-9.-]*\.bjareho\.lt", re.IGNORECASE),
+        "internal endpoint URL",
+    ),
+    (
+        re.compile(r"\b[a-z0-9-]+\.bjareho\.lt\b", re.IGNORECASE),
+        "internal hostname",
+    ),
     (re.compile(r"\berb-hetzner-ax41\b"), "private SSH remote"),
     (re.compile(r"\bcluster1(?:-node\d+)?\b"), "cluster node reference"),
     (re.compile(r"\bCT\d{3}\b"), "LXC container reference"),

--- a/packages/bobutils/src/bobutils/public_safe.py
+++ b/packages/bobutils/src/bobutils/public_safe.py
@@ -31,22 +31,42 @@ from typing import Callable
 
 __all__ = ["public_safe", "validate_public_safe", "PublicSafeViolation"]
 
-# Punctuation/markdown delimiters that commonly trail a URL in prose and must
-# not be swallowed into the match (e.g. "see <url>." or "(<url>)").
-_TRAILING_DELIMITERS = ".,;:!?)]}'\">"
+# Simple punctuation that always trails a URL in prose (never part of a URL).
+_TRAILING_SIMPLE = ".,;:!?'\"> "
+# Balanced pairs: a closing delimiter is prose punctuation only when the URL
+# contains fewer opening counterparts than closing ones.
+_TRAILING_BALANCED: dict[str, str] = {")": "(", "]": "[", "}": "{"}
 
 _Replacement = str | Callable[[re.Match[str]], str]
 
 
 def _strip_trailing_delimiters(placeholder: str) -> Callable[[re.Match[str]], str]:
-    """Build a `re.sub` replacement fn that trims trailing prose delimiters."""
+    """Build a `re.sub` replacement fn that trims trailing prose delimiters.
+
+    Simple punctuation (``.,;:!?`` etc.) is always stripped.  Balanced
+    delimiters (``)``, ``]``, ``}``) are only stripped when the URL contains
+    fewer opening counterparts than closing ones — i.e. the delimiter belongs
+    to surrounding prose, not the URL path (e.g. ``/path/(archive)`` keeps its
+    ``)``, but ``(http://…/path/)`` strips the trailing ``)``) .
+    """
 
     def _replace(m: re.Match[str]) -> str:
         text = m.group()
         trailing = ""
-        while text and text[-1] in _TRAILING_DELIMITERS:
-            trailing = text[-1] + trailing
-            text = text[:-1]
+        while text:
+            c = text[-1]
+            if c in _TRAILING_SIMPLE:
+                trailing = c + trailing
+                text = text[:-1]
+            elif c in _TRAILING_BALANCED:
+                open_char = _TRAILING_BALANCED[c]
+                if text.count(open_char) < text.count(c):
+                    trailing = c + trailing
+                    text = text[:-1]
+                else:
+                    break
+            else:
+                break
         return placeholder + trailing
 
     return _replace

--- a/packages/bobutils/src/bobutils/public_safe.py
+++ b/packages/bobutils/src/bobutils/public_safe.py
@@ -1,0 +1,117 @@
+"""Public/private boundary sanitizer.
+
+Prevents operational internals (workspace paths, internal hostnames, SSH
+remotes) from leaking into external-facing outputs — tweets, GitHub comments,
+status pages, blog posts.
+
+Mirrors the hard boundary established by LoopX's ``public_safe_compact_text()``
+/ ``validate_public_safe_text()`` pattern, adapted for Bob's workspace topology.
+Complements ``packages/redact/`` (which strips *secrets*) by stripping
+*structural* private identifiers that are not secrets but still should not
+appear in public channels.
+
+Usage::
+
+    from bobutils.public_safe import public_safe, validate_public_safe
+
+    # Sanitize before publishing
+    tweet_body = public_safe(draft)
+
+    # Dry-run audit
+    violations = validate_public_safe(draft)
+    if violations:
+        for v in violations:
+            print(f"  [{v.kind}] {v.match!r} at offset {v.offset}")
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+__all__ = ["public_safe", "validate_public_safe", "PublicSafeViolation"]
+
+
+# ---------------------------------------------------------------------------
+# Substitution table — applied in declaration order (most-specific first).
+# ---------------------------------------------------------------------------
+
+_SUBSTITUTIONS: list[tuple[re.Pattern[str], str]] = [
+    # Absolute workspace root — most specific, must come before /home/bob/
+    (re.compile(r"/home/bob/bob/"), "<workspace>/"),
+    # Home directory
+    (re.compile(r"/home/bob/"), "<home>/"),
+    # Internal HTTP(S) endpoints (catch before bare-hostname pattern)
+    (
+        re.compile(r"https?://[a-z0-9.-]*\.bjareho\.lt(?::\d+)?(?:/[^\s]*)?"),
+        "<internal-endpoint>",
+    ),
+    # Internal bare hostnames
+    (re.compile(r"\b[a-z0-9-]+\.bjareho\.lt\b"), "<internal-host>"),
+    # Known private SSH remotes
+    (re.compile(r"\berb-hetzner-ax41\b"), "<ssh-remote>"),
+    # Cluster node references
+    (re.compile(r"\bcluster1(?:-node\d+)?\b"), "<cluster-node>"),
+    # LXC container identifiers
+    (re.compile(r"\bCT\d{3}\b"), "<lxc-container>"),
+    (re.compile(r"\bpct exec \d+\b"), "pct exec <N>"),
+]
+
+# Validators mirror the same patterns for audit/dry-run reporting.
+_VALIDATORS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"/home/bob/bob/"), "workspace absolute path"),
+    (re.compile(r"/home/bob/"), "home directory path"),
+    (re.compile(r"https?://[a-z0-9.-]*\.bjareho\.lt"), "internal endpoint URL"),
+    (re.compile(r"\b[a-z0-9-]+\.bjareho\.lt\b"), "internal hostname"),
+    (re.compile(r"\berb-hetzner-ax41\b"), "private SSH remote"),
+    (re.compile(r"\bcluster1(?:-node\d+)?\b"), "cluster node reference"),
+    (re.compile(r"\bCT\d{3}\b"), "LXC container reference"),
+    (re.compile(r"\bpct exec \d+\b"), "LXC exec command"),
+]
+
+
+@dataclass
+class PublicSafeViolation:
+    """A single private-content finding."""
+
+    kind: str
+    match: str
+    offset: int
+
+
+def validate_public_safe(text: str) -> list[PublicSafeViolation]:
+    """Return private-content violations found in *text* without mutating it.
+
+    An empty list means the text passes all public-safety checks defined by
+    this module.  Use this for dry-run / audit mode before publishing.
+
+    Note: patterns are applied independently, so a URL that matches both the
+    endpoint pattern and the hostname pattern will appear twice — once per
+    matched rule.
+    """
+    violations: list[PublicSafeViolation] = []
+    for pattern, kind in _VALIDATORS:
+        for m in pattern.finditer(text):
+            violations.append(
+                PublicSafeViolation(kind=kind, match=m.group(), offset=m.start())
+            )
+    return violations
+
+
+def public_safe(text: str) -> str:
+    """Return *text* with private operational details replaced by placeholders.
+
+    Strips workspace paths, internal hostnames, SSH remotes, and LXC
+    container references.  Suitable for tweets, GitHub comments, blog posts,
+    and other external-facing content.
+
+    Substitutions are deterministic and order-dependent — more-specific
+    patterns (e.g. full URL) are applied before broader ones (bare hostname)
+    to avoid double-replacement artifacts.
+
+    For a non-mutating audit pass, use :func:`validate_public_safe`.
+    """
+    result = text
+    for pattern, replacement in _SUBSTITUTIONS:
+        result = pattern.sub(replacement, result)
+    return result

--- a/packages/bobutils/tests/test_public_safe.py
+++ b/packages/bobutils/tests/test_public_safe.py
@@ -101,6 +101,32 @@ def test_multiple_private_patterns_in_one_string() -> None:
     assert "bjareho.lt" not in result
 
 
+def test_mixed_case_hostname_replaced() -> None:
+    text = "Dashboard is at Bob.Hassel.Bjareho.lt"
+    result = public_safe(text)
+    assert "bjareho.lt" not in result.lower()
+    assert "<internal-host>" in result
+
+
+def test_mixed_case_endpoint_replaced() -> None:
+    text = "Visit HTTP://Bob.Hassel.Bjareho.lt:8812/decisions/"
+    result = public_safe(text)
+    assert "bjareho.lt" not in result.lower()
+    assert "<internal-endpoint>" in result
+
+
+def test_endpoint_trailing_punctuation_preserved() -> None:
+    text = "See (http://bob.hassel.bjareho.lt:8812/decisions/)."
+    result = public_safe(text)
+    assert result == "See (<internal-endpoint>)."
+
+
+def test_endpoint_in_markdown_link_preserved() -> None:
+    text = "[dashboard](http://bob.hassel.bjareho.lt:8812/decisions/) is live."
+    result = public_safe(text)
+    assert result == "[dashboard](<internal-endpoint>) is live."
+
+
 def test_idempotent() -> None:
     """Applying public_safe twice must yield the same result as once."""
     text = "See /home/bob/bob/journal/ at bob.hassel.bjareho.lt:8812"

--- a/packages/bobutils/tests/test_public_safe.py
+++ b/packages/bobutils/tests/test_public_safe.py
@@ -127,6 +127,14 @@ def test_endpoint_in_markdown_link_preserved() -> None:
     assert result == "[dashboard](<internal-endpoint>) is live."
 
 
+def test_endpoint_url_as_markdown_link_text() -> None:
+    """URL appearing as Markdown link text [URL](URL) is sanitized without breaking structure."""
+    text = "[http://bob.hassel.bjareho.lt/decisions/](http://bob.hassel.bjareho.lt/decisions/) is live."
+    result = public_safe(text)
+    assert "bjareho.lt" not in result
+    assert result.count("[") == result.count("]")
+
+
 def test_endpoint_url_with_balanced_parens_kept() -> None:
     """A closing ) that is balanced by an earlier ( inside the URL stays."""
     text = "Archive: http://bob.hassel.bjareho.lt/path/(archive) is available."

--- a/packages/bobutils/tests/test_public_safe.py
+++ b/packages/bobutils/tests/test_public_safe.py
@@ -127,6 +127,13 @@ def test_endpoint_in_markdown_link_preserved() -> None:
     assert result == "[dashboard](<internal-endpoint>) is live."
 
 
+def test_endpoint_url_with_balanced_parens_kept() -> None:
+    """A closing ) that is balanced by an earlier ( inside the URL stays."""
+    text = "Archive: http://bob.hassel.bjareho.lt/path/(archive) is available."
+    result = public_safe(text)
+    assert result == "Archive: <internal-endpoint> is available."
+
+
 def test_idempotent() -> None:
     """Applying public_safe twice must yield the same result as once."""
     text = "See /home/bob/bob/journal/ at bob.hassel.bjareho.lt:8812"

--- a/packages/bobutils/tests/test_public_safe.py
+++ b/packages/bobutils/tests/test_public_safe.py
@@ -1,0 +1,141 @@
+"""Tests for bobutils.public_safe."""
+
+from __future__ import annotations
+
+from bobutils.public_safe import PublicSafeViolation, public_safe, validate_public_safe
+
+# ---------------------------------------------------------------------------
+# public_safe() — substitution tests
+# ---------------------------------------------------------------------------
+
+
+def test_workspace_path_replaced() -> None:
+    text = "See /home/bob/bob/journal/2026-08-06/session.md for details."
+    result = public_safe(text)
+    assert "/home/bob/bob/" not in result
+    assert "<workspace>/journal/" in result
+
+
+def test_home_path_replaced() -> None:
+    text = "Config at /home/bob/.config/claude/"
+    result = public_safe(text)
+    assert "/home/bob/" not in result
+    assert "<home>/" in result
+
+
+def test_workspace_path_takes_priority_over_home_path() -> None:
+    """More-specific workspace pattern must win over the bare home pattern."""
+    text = "/home/bob/bob/packages/bobutils/"
+    result = public_safe(text)
+    assert "<workspace>/packages/bobutils/" == result
+
+
+def test_internal_url_replaced() -> None:
+    text = "Visit http://bob.hassel.bjareho.lt:8812/decisions/"
+    result = public_safe(text)
+    assert "bjareho.lt" not in result
+    assert "<internal-endpoint>" in result
+
+
+def test_internal_hostname_replaced() -> None:
+    text = "Dashboard is at bob.hassel.bjareho.lt"
+    result = public_safe(text)
+    assert "bjareho.lt" not in result
+    assert "<internal-host>" in result
+
+
+def test_ssh_remote_replaced() -> None:
+    text = "ssh erb-hetzner-ax41 hostname"
+    result = public_safe(text)
+    assert "erb-hetzner-ax41" not in result
+    assert "<ssh-remote>" in result
+
+
+def test_cluster_node_replaced() -> None:
+    text = "cluster1-node1 has 24 cores and cluster1 is the master."
+    result = public_safe(text)
+    assert "cluster1" not in result
+    assert "<cluster-node>" in result
+
+
+def test_lxc_container_replaced() -> None:
+    text = "Container CT102 is running Alice's workspace."
+    result = public_safe(text)
+    assert "CT102" not in result
+    assert "<lxc-container>" in result
+
+
+def test_pct_exec_replaced() -> None:
+    text = "Run: pct exec 102 -- bash"
+    result = public_safe(text)
+    assert "pct exec 102" not in result
+    assert "pct exec <N>" in result
+
+
+def test_safe_text_unchanged() -> None:
+    text = "Shipped BM25 z-score gate for lesson injection in gptme. PR #3453 is open."
+    assert public_safe(text) == text
+
+
+def test_relative_workspace_path_unchanged() -> None:
+    """Relative paths are fine in public content."""
+    text = "See packages/bobutils/src/bobutils/public_safe.py"
+    assert public_safe(text) == text
+
+
+def test_github_urls_unchanged() -> None:
+    text = "https://github.com/gptme/gptme/pull/3453"
+    assert public_safe(text) == text
+
+
+def test_public_domain_unchanged() -> None:
+    text = "Website: https://timetobuildbob.com"
+    assert public_safe(text) == text
+
+
+def test_multiple_private_patterns_in_one_string() -> None:
+    text = "From /home/bob/bob/ via erb-hetzner-ax41 to bob.hassel.bjareho.lt"
+    result = public_safe(text)
+    assert "/home/bob/" not in result
+    assert "erb-hetzner-ax41" not in result
+    assert "bjareho.lt" not in result
+
+
+def test_idempotent() -> None:
+    """Applying public_safe twice must yield the same result as once."""
+    text = "See /home/bob/bob/journal/ at bob.hassel.bjareho.lt:8812"
+    once = public_safe(text)
+    twice = public_safe(once)
+    assert once == twice
+
+
+# ---------------------------------------------------------------------------
+# validate_public_safe() — audit tests
+# ---------------------------------------------------------------------------
+
+
+def test_validate_workspace_path_violation() -> None:
+    violations = validate_public_safe("/home/bob/bob/tasks/foo.md")
+    kinds = {v.kind for v in violations}
+    assert "workspace absolute path" in kinds
+
+
+def test_validate_internal_hostname_violation() -> None:
+    violations = validate_public_safe("host is hassel.bjareho.lt")
+    assert any(v.kind == "internal hostname" for v in violations)
+
+
+def test_validate_clean_text_returns_empty() -> None:
+    violations = validate_public_safe("This is safe to publish on Twitter.")
+    assert violations == []
+
+
+def test_validate_returns_public_safe_violation_instances() -> None:
+    violations = validate_public_safe("/home/bob/bob/")
+    assert all(isinstance(v, PublicSafeViolation) for v in violations)
+
+
+def test_validate_records_offset() -> None:
+    text = "start /home/bob/bob/end"
+    violations = validate_public_safe(text)
+    assert any(v.offset == text.index("/home/bob/bob/") for v in violations)


### PR DESCRIPTION
## Summary

- Adds `public_safe(text) -> str` — strips operational internals (workspace paths, internal hostnames, SSH remotes, LXC refs) before text reaches external channels
- Adds `validate_public_safe(text) -> list[PublicSafeViolation]` — dry-run audit without mutating the text
- Complements `packages/redact/` (secret redaction) with structural-identifier scrubbing

## Background

Implements the public/private boundary pattern from LoopX peer research (ErikBjare/bob idea #999). LoopX maintains a hard `validate_public_safe_text` / `validate_local_control_text` split at the evidence layer; Bob's workspace relies on convention only. This adds the same enforcement as a utility function in bobutils.

## What gets stripped

| Pattern | Replacement |
|---|---|
| `/home/bob/bob/...` | `<workspace>/...` |
| `/home/bob/...` | `<home>/...` |
| `http://bob.hassel.bjareho.lt:8812/...` | `<internal-endpoint>` |
| `hassel.bjareho.lt` | `<internal-host>` |
| `erb-hetzner-ax41` | `<ssh-remote>` |
| `cluster1-node1` | `<cluster-node>` |
| `CT102` | `<lxc-container>` |

## Test plan

- 20 tests covering substitution, priority ordering (workspace > home path), idempotency, and safe pass-through for public content (GitHub URLs, relative paths, public domains)
- `uv run pytest packages/bobutils/tests/test_public_safe.py -v` → 20 passed