### PR TITLE
fix(cc-memory): exclude MEMORY-archive.md from recall candidates

### DIFF
--- a/packages/gptme-cc-memory/src/gptme_cc_memory/schema.py
+++ b/packages/gptme-cc-memory/src/gptme_cc_memory/schema.py
@@ -27,6 +27,12 @@ MEMORY_TYPES = frozenset({"user", "feedback", "project", "reference"})
 SPECIAL_MEMORY_FILES = frozenset(
     {
         "MEMORY.md",
+        # Cold-storage overflow written by memory-overflow tooling. It is a
+        # concatenation of archived one-liners, so as a single retrieval
+        # candidate its vocabulary matches almost any prompt and out-scores
+        # real entries while its excerpt renders static header boilerplate.
+        # Archived == out of automated recall by design; use grep for it.
+        "MEMORY-archive.md",
         "guidance.md",
         # Retired lane — kept here so a leftover file from a pre-retirement
         # install is never discovered as a memory entry.

--- a/packages/gptme-cc-memory/tests/test_retrieval.py
+++ b/packages/gptme-cc-memory/tests/test_retrieval.py
@@ -212,6 +212,61 @@ class TestUpdateMemoryState:
         assert matched == []
 
 
+class TestArchiveExclusion:
+    """MEMORY-archive.md must never surface as a recall result.
+
+    The archive file is cold storage: a concatenation of archived one-liners
+    with broad vocabulary that out-scores real entries on nearly every prompt.
+    Excluding it at discover time (SPECIAL_MEMORY_FILES) is the fix; these
+    tests confirm the exclusion reaches the scoring layer.
+    """
+
+    # Large archive body — broad vocabulary would dominate scoring if not excluded
+    ARCHIVE_MD = """\
+---
+name: archived-memories
+description: Cold-storage overflow of archived one-liner memory entries
+metadata:
+  type: feedback
+---
+
+Archived: pre-commit hooks bypass --no-verify. Archived: database migration zero downtime.
+Archived: Python typing hints function signatures. Archived: git workflow conventional commits.
+Archived: pytest testing code coverage. Archived: PostgreSQL migration table schema.
+Archived: CI/CD pipeline deployment monitoring. Archived: code review authentication.
+"""
+
+    def test_archive_file_not_recalled(self, memory_dir: Path, state_file: Path):
+        """MEMORY-archive.md must not appear in recall results even with a highly matching prompt."""
+        (memory_dir / "MEMORY-archive.md").write_text(self.ARCHIVE_MD)
+        results = select_relevant_memories(
+            "Don't use --no-verify to bypass pre-commit hooks. Add Python type hints.",
+            memory_dir=memory_dir,
+            state_file=state_file,
+            limit=5,
+        )
+        names = [r["name"] for r in results]
+        assert (
+            "archived-memories" not in names
+        ), "MEMORY-archive.md must be excluded from recall but was returned as a result"
+
+    def test_real_memories_still_recalled_with_archive_present(
+        self, memory_dir: Path, state_file: Path
+    ):
+        """Presence of MEMORY-archive.md must not displace real memory entries."""
+        (memory_dir / "MEMORY-archive.md").write_text(self.ARCHIVE_MD)
+        results = select_relevant_memories(
+            "Don't use --no-verify to bypass pre-commit hooks",
+            memory_dir=memory_dir,
+            state_file=state_file,
+            limit=5,
+        )
+        names = [r["name"] for r in results]
+        assert (
+            "never-skip-precommit" in names
+        ), "Real memories should still be recalled when MEMORY-archive.md is present"
+
+
 class TestInjectionCooldown:
     PROMPT = "Don't use --no-verify to bypass pre-commit hooks"
 

--- a/packages/gptme-cc-memory/tests/test_schema.py
+++ b/packages/gptme-cc-memory/tests/test_schema.py
@@ -186,3 +186,36 @@ Some useful content.
         entries = discover_memory_files(mem_dir)
         assert len(entries) == 1
         assert entries[0].type == "memory"
+
+    def test_memory_archive_is_excluded(self, tmp_path: Path):
+        """MEMORY-archive.md must never be discovered as a recall candidate.
+
+        The archive file is a concatenation of ~180 one-liners that gives it a
+        vocabulary broad enough to out-score real entries on almost any prompt.
+        It is cold storage, excluded from automated recall by design.
+        """
+        mem_dir = tmp_path / "memory"
+        mem_dir.mkdir()
+
+        (mem_dir / "feedback-precommit.md").write_text(VALID_FEEDBACK_MD)
+        # A valid-frontmatter archive file that would parse successfully if not excluded.
+        (mem_dir / "MEMORY-archive.md").write_text(
+            """\
+---
+name: archived-memories
+description: Cold-storage overflow of archived one-liner memory entries
+metadata:
+  type: feedback
+---
+
+Archived entry: pre-commit hooks. Archived: database migration. Archived: Python typing.
+Archived: git workflow. Archived: pytest. Archived: code review. Archived: CI/CD.
+"""
+        )
+
+        entries = discover_memory_files(mem_dir)
+        names = [e.name for e in entries]
+        assert (
+            "archived-memories" not in names
+        ), "MEMORY-archive.md was discovered as a recall candidate but must be excluded"
+        assert len(entries) == 1  # only the real feedback entry


### PR DESCRIPTION
## Summary

- Adds `MEMORY-archive.md` to `SPECIAL_MEMORY_FILES` in `schema.py`, so a cold-storage archive file is never discovered as a recall candidate
- Ports the fix from Bob's live `scripts/memory/memory_retrieval.py` (`6b6950f29c`)
- The cooldown fix (PR #1368) was already ported; this is the second and final gap from the `6b6950f29c` commit

## Why

`MEMORY-archive.md` is cold storage: a concatenation of ~180 archived one-liners. As a single retrieval entry its bag-of-words vocabulary matches almost any prompt and out-scores real memory entries, while its excerpt always renders static header boilerplate. It caused 656 injections in Bob's live store before the fix — the most-injected key by a large margin.

On a fresh adopter install the archive file may be small or absent, so this is mostly preventative. The cooldown gap (PR #1368) is the defect that bites immediately at any store size; this fix closes the second one.

## Test plan

- `test_memory_archive_is_excluded` — `discover_memory_files` skips `MEMORY-archive.md` even when it has valid frontmatter
- `test_archive_file_not_recalled` — archive file does not appear in `select_relevant_memories` results even when it lexically dominates the prompt
- `test_real_memories_still_recalled_with_archive_present` — real memory entries are unaffected
- Negative control verified: both behavioural tests **fail** against the pre-fix source (before adding `MEMORY-archive.md` to `SPECIAL_MEMORY_FILES`)
- 34/34 tests pass after fix; no regressions

## Related

- Sibling PR: #1368 (injection cooldown — already merged)
- Sibling PR: #1370 (pending-items retirement — already merged)
- Origin fix: `ErikBjare/bob@6b6950f29c`
- Task: `tasks/cc-memory-package-recall-parity.md`