### PR TITLE
feat(gptme-sessions): extract per-step phase timings from gptme trajectories

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -417,6 +417,10 @@ def post_session(
     session_total_bytes: int | None = None
     traj_productive: bool | None = None
     summarizer_fired: bool | None = None
+    ttft_ms_avg: float | None = None
+    ttft_ms_p50: float | None = None
+    gen_ms_total: float | None = None
+    tool_ms_total: float | None = None
 
     # --- Extract signals from trajectory ---
     if trajectory_path is not None and trajectory_path.is_file():
@@ -426,6 +430,13 @@ def post_session(
             grade = result.get("grade")
             traj_productive = result.get("productive")
             usage = result.get("usage")
+            # Per-step phase timings (gptme sessions only, gptme/gptme#3436).
+            _traj_timings = result.get("timings")
+            if _traj_timings:
+                ttft_ms_avg = _traj_timings.get("ttft_ms_avg")
+                ttft_ms_p50 = _traj_timings.get("ttft_ms_p50")
+                gen_ms_total = _traj_timings.get("gen_ms_total")
+                tool_ms_total = _traj_timings.get("tool_ms_total")
             if usage:
                 _in = usage.get("input_tokens")
                 _out = usage.get("output_tokens")
@@ -774,6 +785,14 @@ def post_session(
         record_kwargs["session_total_bytes"] = session_total_bytes
     if summarizer_fired is not None:
         record_kwargs["summarizer_fired"] = summarizer_fired
+    if ttft_ms_avg is not None:
+        record_kwargs["ttft_ms_avg"] = ttft_ms_avg
+    if ttft_ms_p50 is not None:
+        record_kwargs["ttft_ms_p50"] = ttft_ms_p50
+    if gen_ms_total is not None:
+        record_kwargs["gen_ms_total"] = gen_ms_total
+    if tool_ms_total is not None:
+        record_kwargs["tool_ms_total"] = tool_ms_total
 
     if exit_code != 0:
         if failure_reason is None or error is None:

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -272,6 +272,14 @@ class SessionRecord:
     # None = trajectory unavailable or pre-dates this field.
     summarizer_fired: bool | None = None
 
+    # Per-step phase timings (gptme sessions only; populated from metadata.timings
+    # written by gptme/gptme#3436). ``None`` for sessions before that PR or for
+    # non-gptme harnesses. All values in milliseconds (wall-clock).
+    ttft_ms_avg: float | None = None  # mean time-to-first-token across timed turns
+    ttft_ms_p50: float | None = None  # median TTFT (more robust to outliers)
+    gen_ms_total: float | None = None  # total generation (streaming) time
+    tool_ms_total: float | None = None  # total tool-execution wall time
+
     # Preserve fields written by older schema versions so load→mutate→rewrite
     # round-trips don't silently drop data (e.g. ``inferred_category``,
     # ``recommended_confidence``, ``notes``).

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -1304,6 +1304,8 @@ def extract_timings_gptme(msgs: list[dict]) -> dict:
         if msg.get("role") != "assistant":
             continue
         metadata = msg.get("metadata") or {}
+        if not isinstance(metadata, dict):
+            continue
         timings = metadata.get("timings")
         if not timings or not isinstance(timings, dict):
             continue

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -1281,6 +1281,62 @@ def extract_usage_gptme(msgs: list[dict]) -> dict:
     }
 
 
+def extract_timings_gptme(msgs: list[dict]) -> dict:
+    """Extract per-step phase timings from a gptme conversation.jsonl trajectory.
+
+    Reads ``metadata.timings`` attached by gptme core (gptme/gptme#3436) to each
+    assistant message.  Returns session-level aggregates:
+
+    - ``ttft_ms_avg``: mean time-to-first-token across all timed turns (ms)
+    - ``ttft_ms_p50``: median TTFT (ms), more robust to outliers
+    - ``gen_ms_total``: total generation (streaming) time across the session (ms)
+    - ``tool_ms_total``: total tool-execution wall time across the session (ms)
+    - ``timed_turns``: number of assistant turns with timing data
+
+    Returns an empty dict when no timing data is present (old sessions, non-gptme
+    formats, or sessions before gptme#3436 merged).
+    """
+    ttft_samples: list[float] = []
+    gen_ms_total = 0.0
+    tool_ms_total = 0.0
+
+    for msg in msgs:
+        if msg.get("role") != "assistant":
+            continue
+        metadata = msg.get("metadata") or {}
+        timings = metadata.get("timings")
+        if not timings or not isinstance(timings, dict):
+            continue
+        ttft = timings.get("ttft_ms")
+        if ttft is not None:
+            ttft_samples.append(float(ttft))
+        gen = timings.get("gen_ms")
+        if gen is not None:
+            gen_ms_total += float(gen)
+        tool = timings.get("tool_ms")
+        if tool is not None:
+            tool_ms_total += float(tool)
+
+    if not ttft_samples and gen_ms_total == 0.0 and tool_ms_total == 0.0:
+        return {}
+
+    result: dict = {"timed_turns": len(ttft_samples)}
+    if ttft_samples:
+        result["ttft_ms_avg"] = round(sum(ttft_samples) / len(ttft_samples), 1)
+        sorted_samples = sorted(ttft_samples)
+        n = len(sorted_samples)
+        mid = n // 2
+        result["ttft_ms_p50"] = round(
+            sorted_samples[mid] if n % 2 else (sorted_samples[mid - 1] + sorted_samples[mid]) / 2,
+            1,
+        )
+    if gen_ms_total > 0.0:
+        result["gen_ms_total"] = round(gen_ms_total, 1)
+    if tool_ms_total > 0.0:
+        result["tool_ms_total"] = round(tool_ms_total, 1)
+    return result
+
+
 def extract_usage_cc(msgs: list[dict]) -> dict:
     """Extract cumulative token usage from a Claude Code trajectory.
 
@@ -2390,4 +2446,10 @@ def extract_from_path(jsonl_path: Path) -> dict:
     }
     if usage:
         result["usage"] = usage
+    # Attach per-step phase timings for gptme sessions (gptme/gptme#3436).
+    # Other formats don't carry per-message timing metadata so we skip them.
+    if fmt == "gptme":
+        timings = extract_timings_gptme(msgs)
+        if timings:
+            result["timings"] = timings
     return result

--- a/packages/gptme-sessions/tests/test_timings_extraction.py
+++ b/packages/gptme-sessions/tests/test_timings_extraction.py
@@ -1,0 +1,186 @@
+"""Tests for extract_timings_gptme and timings integration in post_session."""
+
+from pathlib import Path
+
+from gptme_sessions.post_session import post_session
+from gptme_sessions.signals import extract_timings_gptme
+from gptme_sessions.store import SessionStore
+
+
+def _make_msg(role: str, timings: dict | None = None) -> dict:
+    msg: dict = {"role": role, "content": "test", "timestamp": "2026-01-01T00:00:00+00:00"}
+    if timings is not None:
+        msg["metadata"] = {"timings": timings}
+    return msg
+
+
+# --- extract_timings_gptme unit tests ---
+
+
+def test_extract_timings_empty_returns_empty():
+    assert extract_timings_gptme([]) == {}
+
+
+def test_extract_timings_no_timing_metadata_returns_empty():
+    msgs = [
+        _make_msg("system"),
+        _make_msg("user"),
+        _make_msg("assistant"),  # no timings in metadata
+    ]
+    assert extract_timings_gptme(msgs) == {}
+
+
+def test_extract_timings_basic():
+    msgs = [
+        _make_msg("user"),
+        _make_msg("assistant", timings={"ttft_ms": 500.0, "gen_ms": 2000.0}),
+    ]
+    result = extract_timings_gptme(msgs)
+    assert result["ttft_ms_avg"] == 500.0
+    assert result["ttft_ms_p50"] == 500.0
+    assert result["gen_ms_total"] == 2000.0
+    assert result["timed_turns"] == 1
+    assert "tool_ms_total" not in result
+
+
+def test_extract_timings_with_tool():
+    msgs = [
+        _make_msg("user"),
+        _make_msg("assistant", timings={"ttft_ms": 400.0, "gen_ms": 1500.0, "tool_ms": 800.0}),
+    ]
+    result = extract_timings_gptme(msgs)
+    assert result["tool_ms_total"] == 800.0
+
+
+def test_extract_timings_multi_turn_averages():
+    msgs = [
+        _make_msg("user"),
+        _make_msg("assistant", timings={"ttft_ms": 200.0, "gen_ms": 1000.0}),
+        _make_msg("user"),
+        _make_msg("assistant", timings={"ttft_ms": 800.0, "gen_ms": 2000.0}),
+    ]
+    result = extract_timings_gptme(msgs)
+    assert result["ttft_ms_avg"] == 500.0  # (200 + 800) / 2
+    assert result["ttft_ms_p50"] == 500.0  # median of [200, 800]
+    assert result["gen_ms_total"] == 3000.0
+    assert result["timed_turns"] == 2
+
+
+def test_extract_timings_p50_odd_count():
+    msgs = [
+        _make_msg("assistant", timings={"ttft_ms": 100.0}),
+        _make_msg("assistant", timings={"ttft_ms": 300.0}),
+        _make_msg("assistant", timings={"ttft_ms": 500.0}),
+    ]
+    result = extract_timings_gptme(msgs)
+    assert result["ttft_ms_p50"] == 300.0  # middle of [100, 300, 500]
+
+
+def test_extract_timings_tool_ms_accumulates():
+    msgs = [
+        _make_msg("assistant", timings={"ttft_ms": 200.0, "tool_ms": 300.0}),
+        _make_msg("assistant", timings={"ttft_ms": 400.0, "tool_ms": 700.0}),
+    ]
+    result = extract_timings_gptme(msgs)
+    assert result["tool_ms_total"] == 1000.0
+
+
+def test_extract_timings_ignores_non_assistant_roles():
+    msgs = [
+        {"role": "system", "content": "sys", "metadata": {"timings": {"ttft_ms": 999.0}}},
+        {"role": "user", "content": "hi", "metadata": {"timings": {"ttft_ms": 999.0}}},
+        _make_msg("assistant", timings={"ttft_ms": 100.0, "gen_ms": 500.0}),
+    ]
+    result = extract_timings_gptme(msgs)
+    assert result["ttft_ms_avg"] == 100.0
+    assert result["timed_turns"] == 1
+
+
+def test_extract_timings_partial_fields():
+    """Messages with only gen_ms (no TTFT) still contribute gen_ms_total."""
+    msgs = [
+        _make_msg("assistant", timings={"gen_ms": 1200.0}),
+    ]
+    result = extract_timings_gptme(msgs)
+    assert "ttft_ms_avg" not in result
+    assert result["gen_ms_total"] == 1200.0
+    assert result["timed_turns"] == 0  # TTFT samples list is empty
+
+
+def test_extract_timings_ignores_non_dict_timings():
+    msgs = [
+        {"role": "assistant", "content": "x", "metadata": {"timings": "bad_value"}},
+        _make_msg("assistant", timings={"ttft_ms": 200.0}),
+    ]
+    result = extract_timings_gptme(msgs)
+    assert result["timed_turns"] == 1
+    assert result["ttft_ms_avg"] == 200.0
+
+
+# --- Integration test: timings flow through post_session into SessionRecord ---
+
+
+def test_post_session_timings_populated(tmp_path: Path):
+    """Timings from a gptme trajectory land in the SessionRecord."""
+    # Write a minimal gptme conversation.jsonl with timings metadata
+    import json
+
+    traj = tmp_path / "conversation.jsonl"
+    msgs = [
+        {"role": "system", "content": "sys", "timestamp": "2026-01-01T00:00:00+00:00"},
+        {"role": "user", "content": "hi", "timestamp": "2026-01-01T00:00:01+00:00"},
+        {
+            "role": "assistant",
+            "content": "hello",
+            "timestamp": "2026-01-01T00:00:02+00:00",
+            "metadata": {
+                "model": "claude-sonnet-4-6",
+                "timings": {"ttft_ms": 350.0, "gen_ms": 1800.0, "tool_ms": 600.0},
+            },
+        },
+    ]
+    traj.write_text("\n".join(json.dumps(m) for m in msgs))
+
+    store = SessionStore(sessions_dir=tmp_path / "sessions")
+    result = post_session(
+        store=store,
+        harness="gptme",
+        model="sonnet",
+        duration_seconds=10,
+        trajectory_path=traj,
+    )
+    rec = result.record
+    assert rec.ttft_ms_avg == 350.0
+    assert rec.ttft_ms_p50 == 350.0
+    assert rec.gen_ms_total == 1800.0
+    assert rec.tool_ms_total == 600.0
+
+
+def test_post_session_timings_absent_for_old_sessions(tmp_path: Path):
+    """Sessions without timings metadata leave timing fields as None."""
+    import json
+
+    traj = tmp_path / "conversation.jsonl"
+    msgs = [
+        {"role": "user", "content": "hi", "timestamp": "2026-01-01T00:00:01+00:00"},
+        {
+            "role": "assistant",
+            "content": "hello",
+            "timestamp": "2026-01-01T00:00:02+00:00",
+            "metadata": {"model": "claude-sonnet-4-6"},
+        },
+    ]
+    traj.write_text("\n".join(json.dumps(m) for m in msgs))
+
+    store = SessionStore(sessions_dir=tmp_path / "sessions")
+    result = post_session(
+        store=store,
+        harness="gptme",
+        model="sonnet",
+        duration_seconds=5,
+        trajectory_path=traj,
+    )
+    rec = result.record
+    assert rec.ttft_ms_avg is None
+    assert rec.gen_ms_total is None
+    assert rec.tool_ms_total is None


### PR DESCRIPTION
## Summary

- Adds `extract_timings_gptme()` to `signals.py` that reads `MessageTimings` metadata (`ttft_ms`, `gen_ms`, `tool_ms`) from gptme conversation JSONL and computes session-level aggregates: `ttft_ms_avg`, `ttft_ms_p50`, `gen_ms_total`, `tool_ms_total`
- Adds 4 new optional float fields to `SessionRecord` (`ttft_ms_avg`, `ttft_ms_p50`, `gen_ms_total`, `tool_ms_total`)
- Wires extraction through `post_session.py` so every gptme session record carries latency breakdowns alongside token/cost data

## Context

This is the **consumer side** of per-step phase timing — the producer side was landed in gptme#3436 which added `MessageTimings` to `MessageMetadata`. Now `gptme-sessions` reads those timings and surfaces them at the session level.

The eval-bandit can use TTFT to distinguish API latency from generation speed from tool execution time across model×harness combinations — important for understanding why certain combos have better wall-clock performance.

## Test plan

- [ ] 12 new tests in `tests/test_timings_extraction.py` — all passing locally
- [ ] Unit tests for `extract_timings_gptme`: empty input, no metadata, single/multi-turn, p50 median, tool_ms accumulation, non-assistant role filtering, partial fields, non-dict timings
- [ ] Integration tests: timings flow through `post_session()` into `SessionRecord`, absent timings leave fields as `None`
- [ ] Full suite: `uv run pytest packages/gptme-sessions/tests/ -q` — 1059 passed