### PR TITLE
fix(lessons): restrict cc category gate to universal lessons when category unknown

### DIFF
--- a/scripts/claude-code-hooks/match-lessons.py
+++ b/scripts/claude-code-hooks/match-lessons.py
@@ -633,14 +633,14 @@ def filter_by_session_category(
 
     Lessons that explicitly restrict to specific session categories are filtered out
     when running in a different category, reducing irrelevant lesson injection.
-    If category is unknown (None), all lessons pass through.
+    If category is unknown (None), only universal lessons (no restriction) pass through.
+    This prevents social/triage/research lessons from injecting when context is unavailable.
     """
-    if not category:
-        return lessons
     filtered = []
     for lesson in lessons:
         cats = lesson.get("session_categories") or []
-        if not cats or category in {c.lower() for c in cats}:
+        # Keep lesson if: (1) no category restriction, or (2) category is known and matches
+        if not cats or (category and category in {c.lower() for c in cats}):
             filtered.append(lesson)
     return filtered
 

--- a/tests/test_cc_match_lessons.py
+++ b/tests/test_cc_match_lessons.py
@@ -540,16 +540,22 @@ def test_filter_by_session_category_case_insensitive(hook, tmp_path):
     assert len(dropped) == 0
 
 
-def test_filter_by_session_category_none_keeps_all(hook, tmp_path):
-    """Unknown category (None) keeps all lessons unchanged."""
+def test_filter_by_session_category_none_filters_restricted(hook, tmp_path):
+    """Unknown category (None) filters out lessons with session_categories restrictions."""
     lessons_dir = tmp_path / "lessons"
     lessons_dir.mkdir()
     (lessons_dir / "restricted.md").write_text(
         "---\nmatch:\n  keywords:\n    - x\n  session_categories:\n    - strategic\nstatus: active\n---\n# Restricted\n\nContent.\n"
     )
+    (lessons_dir / "universal.md").write_text(
+        "---\nmatch:\n  keywords:\n    - y\nstatus: active\n---\n# Universal\n\nContent.\n"
+    )
     lessons = hook.scan_lessons([lessons_dir])
     result = hook.filter_by_session_category(lessons, None)
-    assert len(result) == 1
+    # Restricted lesson must be filtered; universal lesson must pass through
+    titles = {l["title"] for l in result}
+    assert "Restricted" not in titles
+    assert "Universal" in titles
 
 
 def test_detect_session_category_from_env(hook, monkeypatch):

--- a/tests/test_cc_match_lessons.py
+++ b/tests/test_cc_match_lessons.py
@@ -553,7 +553,7 @@ def test_filter_by_session_category_none_filters_restricted(hook, tmp_path):
     lessons = hook.scan_lessons([lessons_dir])
     result = hook.filter_by_session_category(lessons, None)
     # Restricted lesson must be filtered; universal lesson must pass through
-    titles = {l["title"] for l in result}
+    titles = {lesson["title"] for lesson in result}
     assert "Restricted" not in titles
     assert "Universal" in titles
 


### PR DESCRIPTION
When session category is unknown (env vars unset), only pass through lessons with no category restriction instead of allowing all lessons through.

This prevents [social], [triage], and [research]-gated lessons from injecting in generic CC sessions where category cannot be inferred. Lessons targeting specific categories now only appear when the category is properly detected.

Fixes test: `tests/test_match_lessons_hook.py::test_session_category_gate_unknown_filters_restricted_lessons` in ErikBjare/bob.