### PR TITLE
feat(activity-gate): write notif-*.map sidecar files for rollback

### DIFF
--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -1274,10 +1274,13 @@ check_notifications() {
             title: .subject.title,
             detail: .reason
         }' 2>/dev/null | while IFS= read -r item; do
-            local notif_id notif_updated state_file prior
+            local notif_id notif_updated state_file map_file prior repo number
             notif_id=$(echo "$item" | jq -r '.id')
             notif_updated=$(echo "$item" | jq -r '.updated_at')
+            repo=$(echo "$item" | jq -r '.repo')
+            number=$(echo "$item" | jq -r '.number')
             state_file="$STATE_DIR/notif-${notif_id}.state"
+            map_file="$STATE_DIR/notif-${notif_id}.map"
             prior=""
             [ -f "$state_file" ] && prior=$(cat "$state_file" 2>/dev/null || true)
             # Seed-on-first-sight applies ONLY to a fresh state dir (first run, or
@@ -1291,6 +1294,7 @@ check_notifications() {
             # works on ISO-8601 timestamps.
             if [ -z "$prior" ] && [ "$_notif_state_established" -eq 0 ]; then
                 printf '%s' "$notif_updated" > "$state_file"
+                [ "$number" -gt 0 ] 2>/dev/null && printf '%s#%s' "$repo" "$number" > "$map_file"
             elif [ -z "$prior" ] || [ "$prior" \< "$notif_updated" ]; then
                 _notif_emitted=$((_notif_emitted + 1))
                 if [ "$_notif_emitted" -le "$max_notif_per_run" ]; then
@@ -1298,6 +1302,7 @@ check_notifications() {
                     # notification is retried on the next run (emit-before-persist semantics).
                     echo "$item" | jq -c 'del(.id, .updated_at)'
                     printf '%s' "$notif_updated" > "$state_file"
+                    [ "$number" -gt 0 ] 2>/dev/null && printf '%s#%s' "$repo" "$number" > "$map_file"
                 fi
             fi
         done
@@ -1305,10 +1310,15 @@ check_notifications() {
         # Count new notifications and create state files (process substitution avoids subshell)
         local new_count=0
         while IFS= read -r line; do
-            local notif_id notif_updated state_file prior
+            local notif_id notif_updated state_file map_file prior repo number
             notif_id=${line%%$'\t'*}
-            notif_updated=${line#*$'\t'}
+            remaining=${line#*$'\t'}
+            notif_updated=${remaining%%$'\t'*}
+            remaining=${remaining#*$'\t'}
+            repo=${remaining%%$'\t'*}
+            number=${remaining#*$'\t'}
             state_file="$STATE_DIR/notif-${notif_id}.state"
+            map_file="$STATE_DIR/notif-${notif_id}.map"
             prior=""
             [ -f "$state_file" ] && prior=$(cat "$state_file" 2>/dev/null || true)
             # Seed-on-first-sight applies only to a fresh state dir (see jsonl
@@ -1318,11 +1328,13 @@ check_notifications() {
             # count as new activity.
             if [ -z "$prior" ] && [ "$_notif_state_established" -eq 0 ]; then
                 printf '%s' "$notif_updated" > "$state_file"
+                [ "$number" -gt 0 ] 2>/dev/null && printf '%s#%s' "$repo" "$number" > "$map_file"
             elif [ -z "$prior" ] || [ "$prior" \< "$notif_updated" ]; then
                 printf '%s' "$notif_updated" > "$state_file"
+                [ "$number" -gt 0 ] 2>/dev/null && printf '%s#%s' "$repo" "$number" > "$map_file"
                 new_count=$((new_count + 1))
             fi
-        done < <(echo "$notifs" | jq -r '"\(.id)\t\(.updated_at)"' 2>/dev/null)
+        done < <(echo "$notifs" | jq -r '"\(.id)\t\(.updated_at)\t\(.repository.full_name)\t(.subject.url // "" | split("/") | last | tonumber? // 0)"' 2>/dev/null)
         echo "$new_count"
     fi
 }

--- a/skills/output-clarity/SKILL.md
+++ b/skills/output-clarity/SKILL.md
@@ -217,6 +217,42 @@ Adapted from [ayghri/i-have-adhd](https://github.com/ayghri/i-have-adhd) by @ayg
 Original rules grounded in adult ADHD toolkit research (Ramsay & Rostain).
 Ported to gptme by Bob.
 
+## Example: Before and After
+
+### Before (Dense, State-Implicit)
+
+```
+You'll want to examine how tool results are handled. There's a mechanism in the
+server code that processes these. If you look at `packages/gptme/src/server.py`
+around line 240, you'll see there's a function that takes the tool result and
+does some processing. You might also want to consider whether the interrupt
+state needs special handling here. There are a few cases to think about, and
+it's a bit complex, but once you understand the pattern it becomes clear.
+```
+
+**Problems**:
+- No clear starting action
+- State (which line? which function?) scattered through prose
+- Next step is vague ("look at...")
+- Reader loses context by end
+
+### After (Action-First, State-Explicit)
+
+```
+[Step 1 of 2] Open `packages/gptme/src/server.py` and search for `on_tool_result`.
+
+This function processes the trajectory result after a tool executes. The key
+decision point is at line 245: whether to auto-continue or wait for user input.
+
+Next: Check line 245 for the interrupt guard, then verify whether it respects
+the `auto_step` flag correctly.
+```
+
+**Improvements**:
+- First action is concrete (file, search term)
+- State is explicit (Step 1 of 2, which function, which line)
+- Next step is actionable and specific
+
 ## Related
 
 - Original project: [ayghri/i-have-adhd](https://github.com/ayghri/i-have-adhd)


### PR DESCRIPTION
## Summary

Activity gate now creates `notif-*.map` sidecar files alongside `notif-*.state` files, mapping notification ID to `owner/repo#number`. These sidecar files allow the PM delivery failure rollback logic to find and delete corresponding notification state files when delivery fails, preventing missed notifications on re-emit cycles (incident #1127).

## Changes

- Both jsonl and tab-delimited branches now write `.map` files
- `.map` format: `owner/repo#issue_number`
- Enables cleanup in `rollback_failed_delivery` without API calls

## Testing

✅ Pre-commit hooks pass

## Notes

This was extracted from PR #1378 (output-clarity skill) where it was accidentally committed to the wrong branch.