### PR TITLE
fix(gate): detect CI that is terminal-but-not-green, or stuck

### DIFF
--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -608,6 +608,12 @@ check_ci_failures() {
     now=$(date +%s)
 
     echo "$prs" | jq -c '.[]' | while read -r pr_data; do
+        local pr_number pr_title ci_hash state_file detail
+        # Derived before the classification branches so the green path below can
+        # clear the same file the stuck path writes — one naming site, no drift.
+        pr_number=$(echo "$pr_data" | jq -r '.number')
+        state_file="$STATE_DIR/${repo//\//-}-pr-${pr_number}-ci.state"
+
         # Three-way classification. Previously this matched only
         # `any(.conclusion == "FAILURE")`, which stranded two shapes the
         # 2026-08-06 GitHub Actions outage produced in bulk:
@@ -623,14 +629,22 @@ check_ci_failures() {
         # preserves the previous behaviour exactly. CANCELLED only counts once
         # nothing is in flight — otherwise every `cancel-in-progress` supersede
         # (which leaves CANCELLED behind while the new run starts) would fire.
+        #
+        # The in-flight arm covers both non-terminal StatusState values, not just
+        # PENDING: EXPECTED is what a required status context reports before it
+        # has run at all. An EXPECTED item has no `.status` and no `.conclusion`,
+        # so without this it fell out of `$inflight` while `$bad` still saw a
+        # non-green `.state` — i.e. an instant `ci_failure` on a PR whose checks
+        # simply had not started yet.
         local ci_state
         ci_state=$(echo "$pr_data" | jq -r '
             select(.statusCheckRollup != null) | .statusCheckRollup
-            | (any(.[]; ((.conclusion // "") | ascii_upcase) == "FAILURE")) as $hard
+            | (any(.[]; ((.conclusion // .state // "") | ascii_upcase) == "FAILURE")) as $hard
             | (any(.[]; ((.status // "") | ascii_upcase) as $s
                    | $s == "QUEUED" or $s == "IN_PROGRESS" or $s == "WAITING"
                      or (((.conclusion // "") == "")
-                         and (((.state // "") | ascii_upcase) == "PENDING")))) as $inflight
+                         and (((.state // "") | ascii_upcase) as $st
+                              | $st == "PENDING" or $st == "EXPECTED")))) as $inflight
             | (any(.[]; ((.conclusion // .state // "") | ascii_upcase) as $c
                    | $c != "" and $c != "SUCCESS" and $c != "SKIPPED"
                      and $c != "NEUTRAL")) as $bad
@@ -640,10 +654,17 @@ check_ci_failures() {
               else "green" end')
 
         [ -n "$ci_state" ] || continue
-        [ "$ci_state" = "green" ] && continue
+        if [ "$ci_state" = "green" ]; then
+            # Close the episode. The stuck clock is the state file's mtime, so a
+            # file left behind from an earlier in-flight sighting would make the
+            # *next* run that happens to hash the same look hours old — and
+            # "CI stuck: checks in flight" would fire on a run that started
+            # minutes ago. Deleting on green makes the next in-flight sighting a
+            # genuine first sighting.
+            rm -f "$state_file"
+            continue
+        fi
 
-        local pr_number pr_title ci_hash state_file detail
-        pr_number=$(echo "$pr_data" | jq -r '.number')
         pr_title=$(echo "$pr_data" | jq -r '.title')
         # Hash the CI conclusions to detect state changes.
         # Note: in-progress checks have empty conclusions (mapped to "pending").
@@ -658,8 +679,18 @@ check_ci_failures() {
         # dedup below silently swallowed the `ci_failure` that the classifier
         # above had correctly identified as `bad`. Keep this field list in sync
         # with the `ci_state` classifier.
-        ci_hash=$(echo "$pr_data" | jq -r '[.statusCheckRollup[] | .conclusion // .state // "pending"] | sort | join(",")' | portable_hash)
-        state_file="$STATE_DIR/${repo//\//-}-pr-${pr_number}-ci.state"
+        #
+        # `headRefOid` is part of the hash so a push starts a new episode
+        # *explicitly*, rather than relying on the gate having observed the green
+        # window in between. Green windows are easy to miss: the whole
+        # pending -> green -> force-push -> pending cycle can fit between two
+        # gate runs, leaving a "pending"-hashed file with an hours-old mtime that
+        # the new run matches and is instantly declared stuck. Deleting the file
+        # on green (above) fixes the observed case; keying on the head SHA fixes
+        # the unobserved one. Trade-off: a force-push that reproduces the same
+        # failure now re-emits `ci_failure`. That is the desired behaviour — new
+        # commit, still red, is a fresh actionable signal, not a duplicate.
+        ci_hash=$(echo "$pr_data" | jq -r '(.headRefOid // "") + ":" + ([.statusCheckRollup[] | .conclusion // .state // "pending"] | sort | join(","))' | portable_hash)
         detail="CI failing"
 
         if [ "$ci_state" = "inflight" ]; then

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -636,12 +636,23 @@ check_ci_failures() {
         # so without this it fell out of `$inflight` while `$bad` still saw a
         # non-green `.state` — i.e. an instant `ci_failure` on a PR whose checks
         # simply had not started yet.
+        #
+        # The `.status` list must be the FULL non-terminal half of GraphQL's
+        # CheckStatusState enum (QUEUED, IN_PROGRESS, WAITING, PENDING,
+        # REQUESTED) — COMPLETED is the only terminal member. Listing only the
+        # first three silently mapped PENDING/REQUESTED CheckRuns to `green`:
+        # they match no `.status` literal, and a CheckRun carries no `.state`,
+        # so `$bad`'s `.conclusion // .state // ""` is "" and its `$c != ""`
+        # guard fails too — every predicate false, falling through to `green`.
+        # That deleted the stuck clock (`rm -f` below) on exactly the
+        # not-yet-started shape this function exists to catch.
         local ci_state
         ci_state=$(echo "$pr_data" | jq -r '
             select(.statusCheckRollup != null) | .statusCheckRollup
             | (any(.[]; ((.conclusion // .state // "") | ascii_upcase) == "FAILURE")) as $hard
             | (any(.[]; ((.status // "") | ascii_upcase) as $s
                    | $s == "QUEUED" or $s == "IN_PROGRESS" or $s == "WAITING"
+                     or $s == "PENDING" or $s == "REQUESTED"
                      or (((.conclusion // "") == "")
                          and (((.state // "") | ascii_upcase) as $st
                               | $st == "PENDING" or $st == "EXPECTED")))) as $inflight

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -601,33 +601,85 @@ check_ci_failures() {
     local prs=$2
     [ "$prs" = "[]" ] || [ -z "$prs" ] && return 0
 
-    echo "$prs" | jq -c '.[]' | while read -r pr_data; do
-        local has_failures
-        has_failures=$(echo "$pr_data" | jq -r 'select(.statusCheckRollup != null) | .statusCheckRollup | any(.conclusion == "FAILURE")')
-        if [ "$has_failures" = "true" ]; then
-            local pr_number pr_title ci_hash state_file
-            pr_number=$(echo "$pr_data" | jq -r '.number')
-            pr_title=$(echo "$pr_data" | jq -r '.title')
-            # Hash the CI conclusions to detect state changes.
-            # Note: in-progress checks have empty conclusions (mapped to "pending").
-            # When they complete, the hash changes — this can cause a re-trigger even
-            # if the final result matches the previous run. Acceptable trade-off vs
-            # missing genuine state changes.
-            ci_hash=$(echo "$pr_data" | jq -r '[.statusCheckRollup[] | .conclusion // "pending"] | sort | join(",")' | portable_hash)
-            state_file="$STATE_DIR/${repo//\//-}-pr-${pr_number}-ci.state"
+    # A PR whose checks sit in QUEUED/IN_PROGRESS with an unchanged hash for this
+    # long is stuck, not progressing, and needs a re-trigger rather than patience.
+    local stuck_secs="${CI_STUCK_SECS:-3600}"
+    local now
+    now=$(date +%s)
 
-            if [ -f "$state_file" ]; then
-                local last_hash
-                last_hash=$(cat "$state_file")
-                if [ "$ci_hash" = "$last_hash" ]; then
-                    # CI state unchanged since last check — don't re-trigger
-                    continue
-                fi
+    echo "$prs" | jq -c '.[]' | while read -r pr_data; do
+        # Three-way classification. Previously this matched only
+        # `any(.conclusion == "FAILURE")`, which stranded two shapes the
+        # 2026-08-06 GitHub Actions outage produced in bulk:
+        #
+        #   - terminal but not green (CANCELLED / TIMED_OUT / ACTION_REQUIRED and
+        #     nothing left running). The PR sits UNSTABLE, so check_merge_ready
+        #     (needs CLEAN) skips it, check_merge_conflicts (needs DIRTY) skips
+        #     it, and once updatedAt stops moving check_pr_updates skips it too.
+        #   - permanently QUEUED. Live example: gptme/gptme#3472 had 3 checks
+        #     QUEUED for ~6h behind cancelled/orphaned jobs, matching no predicate.
+        #
+        # FAILURE still fires immediately even with other checks running, which
+        # preserves the previous behaviour exactly. CANCELLED only counts once
+        # nothing is in flight — otherwise every `cancel-in-progress` supersede
+        # (which leaves CANCELLED behind while the new run starts) would fire.
+        local ci_state
+        ci_state=$(echo "$pr_data" | jq -r '
+            select(.statusCheckRollup != null) | .statusCheckRollup
+            | (any(.[]; ((.conclusion // "") | ascii_upcase) == "FAILURE")) as $hard
+            | (any(.[]; ((.status // "") | ascii_upcase) as $s
+                   | $s == "QUEUED" or $s == "IN_PROGRESS" or $s == "WAITING"
+                     or (((.conclusion // "") == "")
+                         and (((.state // "") | ascii_upcase) == "PENDING")))) as $inflight
+            | (any(.[]; ((.conclusion // .state // "") | ascii_upcase) as $c
+                   | $c != "" and $c != "SUCCESS" and $c != "SKIPPED"
+                     and $c != "NEUTRAL")) as $bad
+            | if $hard then "bad"
+              elif ($bad and ($inflight | not)) then "bad"
+              elif $inflight then "inflight"
+              else "green" end')
+
+        [ -n "$ci_state" ] || continue
+        [ "$ci_state" = "green" ] && continue
+
+        local pr_number pr_title ci_hash state_file detail
+        pr_number=$(echo "$pr_data" | jq -r '.number')
+        pr_title=$(echo "$pr_data" | jq -r '.title')
+        # Hash the CI conclusions to detect state changes.
+        # Note: in-progress checks have empty conclusions (mapped to "pending").
+        # When they complete, the hash changes — this can cause a re-trigger even
+        # if the final result matches the previous run. Acceptable trade-off vs
+        # missing genuine state changes.
+        ci_hash=$(echo "$pr_data" | jq -r '[.statusCheckRollup[] | .conclusion // "pending"] | sort | join(",")' | portable_hash)
+        state_file="$STATE_DIR/${repo//\//-}-pr-${pr_number}-ci.state"
+        detail="CI failing"
+
+        if [ "$ci_state" = "inflight" ]; then
+            # Checks still running is normal. Only actionable once the state has
+            # not moved for stuck_secs — the state file's mtime is the clock.
+            if [ -f "$state_file" ] && [ "$(cat "$state_file")" = "$ci_hash" ]; then
+                local mtime age
+                mtime=$(stat -c %Y "$state_file" 2>/dev/null || stat -f %m "$state_file" 2>/dev/null || echo "$now")
+                age=$(( now - mtime ))
+                [ "$age" -ge "$stuck_secs" ] || continue
+                detail="CI stuck: checks in flight ${age}s with no state change"
+                # Re-stamp so a still-stuck PR re-emits at most once per
+                # stuck_secs rather than on every gate run.
+                touch "$state_file"
+            else
+                # First sighting of this in-flight state: record and wait.
+                echo "$ci_hash" > "$state_file"
+                continue
             fi
-            # New failure or CI state changed
+        else
+            if [ -f "$state_file" ] && [ "$(cat "$state_file")" = "$ci_hash" ]; then
+                # CI state unchanged since last check — don't re-trigger
+                continue
+            fi
             echo "$ci_hash" > "$state_file"
-            emit_item "ci_failure" "$repo" "$pr_number" "$pr_title" "CI failing"
         fi
+
+        emit_item "ci_failure" "$repo" "$pr_number" "$pr_title" "$detail"
     done
 }
 

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -667,7 +667,7 @@ check_ci_failures() {
             # not moved for stuck_secs — the state file's mtime is the clock.
             if [ -f "$state_file" ] && [ "$(cat "$state_file")" = "$ci_hash" ]; then
                 local mtime age
-                mtime=$(stat -c %Y "$state_file" 2>/dev/null || stat -f %m "$state_file" 2>/dev/null || echo "$now")
+                mtime=$(stat -c %Y "$state_file" 2>/dev/null || stat -f %m "$state_file" 2>/dev/null) || continue
                 age=$(( now - mtime ))
                 [ "$age" -ge "$stuck_secs" ] || continue
                 detail="CI stuck: checks in flight ${age}s with no state change"

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -650,7 +650,15 @@ check_ci_failures() {
         # When they complete, the hash changes — this can cause a re-trigger even
         # if the final result matches the previous run. Acceptable trade-off vs
         # missing genuine state changes.
-        ci_hash=$(echo "$pr_data" | jq -r '[.statusCheckRollup[] | .conclusion // "pending"] | sort | join(",")' | portable_hash)
+        #
+        # `.state` is part of the hash because legacy StatusContext rollup items
+        # carry no `.conclusion` at all — only `.state`. Hashing `.conclusion`
+        # alone made every such item hash as "pending" forever, so a legacy
+        # status going PENDING -> FAILURE left the hash unchanged and the
+        # dedup below silently swallowed the `ci_failure` that the classifier
+        # above had correctly identified as `bad`. Keep this field list in sync
+        # with the `ci_state` classifier.
+        ci_hash=$(echo "$pr_data" | jq -r '[.statusCheckRollup[] | .conclusion // .state // "pending"] | sort | join(",")' | portable_hash)
         state_file="$STATE_DIR/${repo//\//-}-pr-${pr_number}-ci.state"
         detail="CI failing"
 

--- a/tests/test_activity_gate_stuck_ci.py
+++ b/tests/test_activity_gate_stuck_ci.py
@@ -1,0 +1,177 @@
+"""check_ci_failures must catch CI that is terminal-but-not-green, or stuck.
+
+Before this, the predicate was ``any(.conclusion == "FAILURE")``. The
+2026-08-06 GitHub Actions outage produced two shapes in bulk that it missed,
+and that no other gate predicate covers either:
+
+* **terminal but not green** — CANCELLED / TIMED_OUT / ACTION_REQUIRED with
+  nothing left running. The PR sits ``UNSTABLE``, so ``check_merge_ready``
+  (wants CLEAN) skips it and ``check_merge_conflicts`` (wants DIRTY) skips it;
+  once ``updatedAt`` stops moving ``check_pr_updates`` skips it too.
+* **permanently QUEUED** — observed live on gptme/gptme#3472: three checks
+  QUEUED for ~6h behind cancelled/orphaned jobs.
+
+Such a PR is stranded indefinitely with no human push or comment.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+GATE = Path(__file__).resolve().parents[1] / "scripts" / "github" / "activity-gate.sh"
+
+
+def _classify(rollup: list[dict]) -> str:
+    """Run the gate's ci_state jq classifier exactly as the shell does."""
+    program = _extract_classifier()
+    proc = subprocess.run(
+        ["jq", "-r", program],
+        input=json.dumps({"statusCheckRollup": rollup}),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return proc.stdout.strip()
+
+
+def _extract_classifier() -> str:
+    """Pull the jq program out of activity-gate.sh so the test can't drift from it."""
+    src = GATE.read_text()
+    marker = 'ci_state=$(echo "$pr_data" | jq -r \''
+    assert (
+        marker in src
+    ), "ci_state classifier not found — did check_ci_failures change shape?"
+    body = src.split(marker, 1)[1]
+    return body.split("')", 1)[0]
+
+
+@pytest.mark.parametrize(
+    ("label", "rollup", "expected"),
+    [
+        ("all green", [{"status": "COMPLETED", "conclusion": "SUCCESS"}], "green"),
+        (
+            "skipped and neutral are green",
+            [
+                {"status": "COMPLETED", "conclusion": "SKIPPED"},
+                {"status": "COMPLETED", "conclusion": "NEUTRAL"},
+            ],
+            "green",
+        ),
+        (
+            "failure fires even with checks still running (unchanged behaviour)",
+            [
+                {"status": "COMPLETED", "conclusion": "FAILURE"},
+                {"status": "QUEUED", "conclusion": ""},
+            ],
+            "bad",
+        ),
+        (
+            "cancelled with nothing running is actionable",
+            [{"status": "COMPLETED", "conclusion": "CANCELLED"}],
+            "bad",
+        ),
+        (
+            "cancel-in-progress supersede must NOT fire: new run still going",
+            [
+                {"status": "COMPLETED", "conclusion": "CANCELLED"},
+                {"status": "IN_PROGRESS", "conclusion": ""},
+            ],
+            "inflight",
+        ),
+        ("timed out", [{"status": "COMPLETED", "conclusion": "TIMED_OUT"}], "bad"),
+        ("only queued", [{"status": "QUEUED", "conclusion": ""}], "inflight"),
+        # StatusContext shape (legacy commit statuses) carries .state, not .conclusion.
+        ("status context green", [{"state": "SUCCESS"}], "green"),
+        ("status context red", [{"state": "FAILURE"}], "bad"),
+        ("status context pending", [{"state": "PENDING"}], "inflight"),
+    ],
+)
+def test_ci_state_classification(label: str, rollup: list[dict], expected: str) -> None:
+    assert _classify(rollup) == expected, label
+
+
+def test_pr_3472_shape_is_inflight_not_green() -> None:
+    """The real stranded PR: mostly green, one CANCELLED, three QUEUED for hours.
+
+    It must classify as ``inflight`` so the staleness clock applies — not
+    ``green`` (which would drop it) and not ``bad`` (which would fire instantly
+    on every legitimately-running PR).
+    """
+    rollup = [
+        {"status": "COMPLETED", "conclusion": "SUCCESS", "name": "build"},
+        {"status": "COMPLETED", "conclusion": "SUCCESS", "name": "lint"},
+        {"status": "COMPLETED", "conclusion": "CANCELLED", "name": "typecheck"},
+        {"status": "QUEUED", "conclusion": "", "name": "Test without API keys"},
+        {"status": "QUEUED", "conclusion": "", "name": "API tests"},
+        {"status": "COMPLETED", "conclusion": "SKIPPED", "name": "deploy"},
+    ]
+    assert _classify(rollup) == "inflight"
+
+
+@pytest.mark.parametrize("age_secs,should_emit", [(10, False), (7200, True)])
+def test_stuck_inflight_emits_only_after_threshold(
+    tmp_path: Path, age_secs: int, should_emit: bool
+) -> None:
+    """An in-flight PR is emitted only once its state has not moved for CI_STUCK_SECS."""
+    rollup = [
+        {"status": "COMPLETED", "conclusion": "CANCELLED"},
+        {"status": "QUEUED", "conclusion": ""},
+    ]
+    pr = {"number": 3472, "title": "stuck pr", "statusCheckRollup": rollup}
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    # Pre-seed the state file with the current hash, aged to taste. Compute it
+    # through the identical shell pipeline — hashing the jq output *without* its
+    # trailing newline yields a different digest, the state file then looks like
+    # a first sighting, and the test silently stops exercising the stuck path.
+    digest = subprocess.run(
+        [
+            "bash",
+            "-c",
+            'jq -r \'[.statusCheckRollup[] | .conclusion // "pending"] | sort | join(",")\''
+            " | sha256sum | cut -d' ' -f1",
+        ],
+        input=json.dumps(pr),
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+    state_file = state_dir / "o-r-pr-3472-ci.state"
+    state_file.write_text(digest + "\n")
+    old = time.time() - age_secs
+    os.utime(state_file, (old, old))
+
+    script = f"""
+set -uo pipefail
+STATE_DIR={state_dir!s}
+CI_STUCK_SECS=3600
+portable_hash() {{ sha256sum | cut -d' ' -f1; }}
+emit_item() {{ echo "EMIT type=$1 repo=$2 pr=$3 detail=$5"; }}
+source_only=1
+{_extract_function()}
+check_ci_failures "o/r" '{json.dumps([pr])}'
+"""
+    proc = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    emitted = "EMIT" in proc.stdout
+    assert (
+        emitted is should_emit
+    ), f"stdout={proc.stdout!r} stderr={proc.stderr[-400:]!r}"
+    if should_emit:
+        assert "CI stuck" in proc.stdout
+
+
+def _extract_function() -> str:
+    """Extract check_ci_failures so it can run without sourcing the whole gate."""
+    src = GATE.read_text()
+    start = src.index("check_ci_failures() {")
+    rest = src[start:]
+    end = rest.index("\n}\n") + len("\n}\n")
+    return rest[:end]

--- a/tests/test_activity_gate_stuck_ci.py
+++ b/tests/test_activity_gate_stuck_ci.py
@@ -135,8 +135,7 @@ def test_stuck_inflight_emits_only_after_threshold(
         [
             "bash",
             "-c",
-            'jq -r \'[.statusCheckRollup[] | .conclusion // "pending"] | sort | join(",")\''
-            " | sha256sum | cut -d' ' -f1",
+            f"jq -r '{_extract_hash_program()}' | sha256sum | cut -d' ' -f1",
         ],
         input=json.dumps(pr),
         capture_output=True,

--- a/tests/test_activity_gate_stuck_ci.py
+++ b/tests/test_activity_gate_stuck_ci.py
@@ -175,3 +175,58 @@ def _extract_function() -> str:
     rest = src[start:]
     end = rest.index("\n}\n") + len("\n}\n")
     return rest[:end]
+
+
+def _extract_hash_program() -> str:
+    """Pull the ci_hash jq program out of the gate, same anti-drift trick."""
+    src = GATE.read_text()
+    marker = 'ci_hash=$(echo "$pr_data" | jq -r \''
+    assert marker in src, "ci_hash program not found — did check_ci_failures change?"
+    return src.split(marker, 1)[1].split("'", 1)[0]
+
+
+def _ci_hash_key(rollup: list[dict]) -> str:
+    proc = subprocess.run(
+        ["jq", "-r", _extract_hash_program()],
+        input=json.dumps({"statusCheckRollup": rollup}),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return proc.stdout.strip()
+
+
+def test_ci_hash_tracks_legacy_status_context_transitions() -> None:
+    """A legacy StatusContext going PENDING -> FAILURE must change the hash.
+
+    Regression test for a bug our own self-hosted reviewer caught on the PR that
+    introduced the three-way classifier (gptme/gptme-contrib#1383, 2026-08-07).
+
+    The classifier learned to read ``.state`` so it could see legacy
+    StatusContext items, which carry no ``.conclusion`` at all. The dedup hash
+    did not: it hashed ``.conclusion // "pending"``, so every StatusContext
+    hashed as ``"pending"`` forever. A status flipping PENDING -> FAILURE was
+    therefore classified ``bad`` and then silently swallowed by the
+    unchanged-hash check — precisely the "CI failed but nothing fired" symptom
+    the PR set out to fix.
+
+    The classifier and the hash must agree on which fields carry CI state.
+    """
+    pending = [{"__typename": "StatusContext", "context": "ci", "state": "PENDING"}]
+    failure = [{"__typename": "StatusContext", "context": "ci", "state": "FAILURE"}]
+
+    assert _classify(pending) == "inflight"
+    assert _classify(failure) == "bad"
+    assert _ci_hash_key(pending) != _ci_hash_key(failure), (
+        "legacy StatusContext transition is invisible to the dedup hash — "
+        "the ci_failure emit will be suppressed"
+    )
+
+
+def test_ci_hash_still_tracks_checkrun_transitions() -> None:
+    """The .state fallback must not blind the hash to ordinary CheckRun items."""
+    running = [{"__typename": "CheckRun", "status": "IN_PROGRESS", "conclusion": None}]
+    failed = [
+        {"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "FAILURE"}
+    ]
+    assert _ci_hash_key(running) != _ci_hash_key(failed)

--- a/tests/test_activity_gate_stuck_ci.py
+++ b/tests/test_activity_gate_stuck_ci.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import time
 from pathlib import Path
@@ -25,6 +26,25 @@ from pathlib import Path
 import pytest
 
 GATE = Path(__file__).resolve().parents[1] / "scripts" / "github" / "activity-gate.sh"
+
+
+def _sha256_cmd() -> str:
+    """A sha256 command available on this host.
+
+    ``sha256sum`` is GNU coreutils and absent on macOS, which only ships
+    ``shasum`` — the same portability the gate's own ``portable_hash()`` handles
+    with an md5sum/shasum/cksum fallback chain.
+
+    Both the pre-seeded state-file digest and the ``portable_hash()`` stub
+    injected into the generated bash script go through this one helper. They
+    must stay identical: hash them differently and the state file looks like a
+    first sighting, so the test silently stops exercising the stuck path.
+    """
+    if shutil.which("sha256sum"):
+        return "sha256sum"
+    if shutil.which("shasum"):
+        return "shasum -a 256"
+    pytest.skip("no sha256 utility available (need sha256sum or shasum)")
 
 
 def _classify(rollup: list[dict]) -> str:
@@ -90,6 +110,38 @@ def _extract_classifier() -> str:
         ("status context green", [{"state": "SUCCESS"}], "green"),
         ("status context red", [{"state": "FAILURE"}], "bad"),
         ("status context pending", [{"state": "PENDING"}], "inflight"),
+        (
+            "status context failure fires even with checks still running",
+            [
+                {"__typename": "StatusContext", "state": "FAILURE"},
+                {"status": "IN_PROGRESS", "conclusion": ""},
+            ],
+            "bad",
+        ),
+        # EXPECTED is StatusState's "required context that hasn't reported yet".
+        # It has no .status and no .conclusion, so it must be recognised as
+        # in-flight via .state or it reads as a non-green terminal result.
+        (
+            "status context expected is not yet a result",
+            [{"__typename": "StatusContext", "state": "EXPECTED"}],
+            "inflight",
+        ),
+        (
+            "expected alongside a green check is still just waiting",
+            [
+                {"__typename": "StatusContext", "state": "EXPECTED"},
+                {"status": "COMPLETED", "conclusion": "SUCCESS"},
+            ],
+            "inflight",
+        ),
+        (
+            "a real failure still wins over an EXPECTED context",
+            [
+                {"__typename": "StatusContext", "state": "EXPECTED"},
+                {"__typename": "StatusContext", "state": "FAILURE"},
+            ],
+            "bad",
+        ),
     ],
 )
 def test_ci_state_classification(label: str, rollup: list[dict], expected: str) -> None:
@@ -123,7 +175,12 @@ def test_stuck_inflight_emits_only_after_threshold(
         {"status": "COMPLETED", "conclusion": "CANCELLED"},
         {"status": "QUEUED", "conclusion": ""},
     ]
-    pr = {"number": 3472, "title": "stuck pr", "statusCheckRollup": rollup}
+    pr = {
+        "number": 3472,
+        "title": "stuck pr",
+        "headRefOid": "a" * 40,
+        "statusCheckRollup": rollup,
+    }
 
     state_dir = tmp_path / "state"
     state_dir.mkdir()
@@ -135,7 +192,7 @@ def test_stuck_inflight_emits_only_after_threshold(
         [
             "bash",
             "-c",
-            f"jq -r '{_extract_hash_program()}' | sha256sum | cut -d' ' -f1",
+            f"jq -r '{_extract_hash_program()}' | {_sha256_cmd()} | cut -d' ' -f1",
         ],
         input=json.dumps(pr),
         capture_output=True,
@@ -152,7 +209,7 @@ def test_stuck_inflight_emits_only_after_threshold(
 set -uo pipefail
 STATE_DIR={state_dir!s}
 CI_STUCK_SECS=3600
-portable_hash() {{ sha256sum | cut -d' ' -f1; }}
+portable_hash() {{ {_sha256_cmd()} | cut -d' ' -f1; }}
 emit_item() {{ echo "EMIT type=$1 repo=$2 pr=$3 detail=$5"; }}
 source_only=1
 {_extract_function()}
@@ -184,10 +241,15 @@ def _extract_hash_program() -> str:
     return src.split(marker, 1)[1].split("'", 1)[0]
 
 
-def _ci_hash_key(rollup: list[dict]) -> str:
+def _ci_hash_key(rollup: list[dict], head_sha: str = "d" * 40) -> str:
+    """The gate's dedup key for a rollup on a given head commit.
+
+    ``head_sha`` defaults to a fixed value so callers comparing two rollups vary
+    only the thing they mean to vary.
+    """
     proc = subprocess.run(
         ["jq", "-r", _extract_hash_program()],
-        input=json.dumps({"statusCheckRollup": rollup}),
+        input=json.dumps({"headRefOid": head_sha, "statusCheckRollup": rollup}),
         capture_output=True,
         text=True,
         check=True,
@@ -229,3 +291,112 @@ def test_ci_hash_still_tracks_checkrun_transitions() -> None:
         {"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "FAILURE"}
     ]
     assert _ci_hash_key(running) != _ci_hash_key(failed)
+
+
+def test_green_clears_state_file(tmp_path: Path) -> None:
+    """A PR going green must delete the state file so a future inflight run that
+    hashes to the same initial state doesn't inherit a stale mtime and appear
+    immediately stuck.
+    """
+    rollup = [{"status": "COMPLETED", "conclusion": "SUCCESS"}]
+    pr = {"number": 1, "title": "green pr", "statusCheckRollup": rollup}
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    state_file = state_dir / "o-r-pr-1-ci.state"
+    # Plant a very old state file — simulating a prior inflight sighting.
+    state_file.write_text("old-hash\n")
+    old = time.time() - 7200
+    os.utime(state_file, (old, old))
+
+    script = f"""
+set -uo pipefail
+STATE_DIR={state_dir!s}
+CI_STUCK_SECS=3600
+portable_hash() {{ {_sha256_cmd()} | cut -d' ' -f1; }}
+emit_item() {{ echo "EMIT type=$1 repo=$2 pr=$3 detail=$5"; }}
+source_only=1
+{_extract_function()}
+check_ci_failures "o/r" '{json.dumps([pr])}'
+"""
+    proc = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    assert "EMIT" not in proc.stdout, f"green PR emitted: {proc.stdout!r}"
+    assert not state_file.exists(), "green PR must clean up the state file"
+
+
+def test_ci_hash_changes_on_new_head_commit() -> None:
+    """A push must start a new stuck episode even for an identical rollup.
+
+    The stuck clock is the state file's mtime, and the state file is only
+    replaced when the hash changes. Without the head SHA in the hash, this
+    sequence produces a false "CI stuck" report:
+
+    1. checks go in flight on commit A; hash is "pending", file stamped at T0
+    2. checks go green, then a force-push lands commit B (the whole green window
+       fits between two gate runs, so the green cleanup never gets to run)
+    3. checks go in flight on commit B; the hash is "pending" again and matches,
+       so ``age = now - T0`` — hours — and the gate reports a run that started
+       minutes ago as stuck.
+    """
+    rollup = [{"status": "QUEUED", "conclusion": ""}]
+    assert _ci_hash_key(rollup, head_sha="a" * 40) != _ci_hash_key(
+        rollup, head_sha="b" * 40
+    ), "identical rollup on a new commit must not reuse the previous episode"
+
+
+def test_new_head_commit_resets_the_stuck_clock(tmp_path: Path) -> None:
+    """End-to-end form of the above, through the real shell function.
+
+    An hours-old state file recorded against the *previous* head commit must not
+    make freshly-queued checks on a new commit look stuck.
+    """
+    rollup = [
+        {"status": "COMPLETED", "conclusion": "CANCELLED"},
+        {"status": "QUEUED", "conclusion": ""},
+    ]
+    old_pr = {
+        "number": 7,
+        "title": "pushed pr",
+        "headRefOid": "a" * 40,
+        "statusCheckRollup": rollup,
+    }
+    new_pr = dict(old_pr, headRefOid="b" * 40)
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    stale_digest = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f"jq -r '{_extract_hash_program()}' | {_sha256_cmd()} | cut -d' ' -f1",
+        ],
+        input=json.dumps(old_pr),
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+    state_file = state_dir / "o-r-pr-7-ci.state"
+    state_file.write_text(stale_digest + "\n")
+    old = time.time() - 7200
+    os.utime(state_file, (old, old))
+
+    script = f"""
+set -uo pipefail
+STATE_DIR={state_dir!s}
+CI_STUCK_SECS=3600
+portable_hash() {{ {_sha256_cmd()} | cut -d' ' -f1; }}
+emit_item() {{ echo "EMIT type=$1 repo=$2 pr=$3 detail=$5"; }}
+source_only=1
+{_extract_function()}
+check_ci_failures "o/r" '{json.dumps([new_pr])}'
+"""
+    proc = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    assert "CI stuck" not in proc.stdout, (
+        "checks queued on a brand-new commit reported as stuck using the "
+        f"previous commit's clock: {proc.stdout!r}"
+    )
+    assert "EMIT" not in proc.stdout, f"unexpected emit: {proc.stdout!r}"
+    # The new episode is recorded so the clock starts now, not two hours ago.
+    assert state_file.read_text().strip() != stale_digest
+    assert time.time() - state_file.stat().st_mtime < 60

--- a/tests/test_activity_gate_stuck_ci.py
+++ b/tests/test_activity_gate_stuck_ci.py
@@ -142,6 +142,46 @@ def _extract_classifier() -> str:
             ],
             "bad",
         ),
+        # CheckStatusState has FIVE non-terminal members, not three. A CheckRun
+        # sitting in PENDING/REQUESTED carries no `.state` and an empty
+        # `.conclusion`, so when the classifier only listed
+        # QUEUED/IN_PROGRESS/WAITING every predicate was false and the whole PR
+        # read as `green` — deleting the stuck clock for the not-yet-started
+        # shape this function exists to catch.
+        (
+            "checkrun PENDING is in flight, not green",
+            [{"__typename": "CheckRun", "status": "PENDING", "conclusion": None}],
+            "inflight",
+        ),
+        (
+            "checkrun REQUESTED is in flight, not green",
+            [{"__typename": "CheckRun", "status": "REQUESTED", "conclusion": None}],
+            "inflight",
+        ),
+        (
+            "PENDING alongside a green check is still just waiting",
+            [
+                {"__typename": "CheckRun", "status": "PENDING", "conclusion": None},
+                {"status": "COMPLETED", "conclusion": "SUCCESS"},
+            ],
+            "inflight",
+        ),
+        (
+            "a CANCELLED supersede must not fire while a REQUESTED run is pending",
+            [
+                {"status": "COMPLETED", "conclusion": "CANCELLED"},
+                {"__typename": "CheckRun", "status": "REQUESTED", "conclusion": None},
+            ],
+            "inflight",
+        ),
+        (
+            "a real failure still wins over a PENDING checkrun",
+            [
+                {"__typename": "CheckRun", "status": "PENDING", "conclusion": None},
+                {"status": "COMPLETED", "conclusion": "FAILURE"},
+            ],
+            "bad",
+        ),
     ],
 )
 def test_ci_state_classification(label: str, rollup: list[dict], expected: str) -> None:


### PR DESCRIPTION
## Problem

`check_ci_failures` matched only `any(.conclusion == "FAILURE")`. The 2026-08-06 GitHub Actions outage (7h+, webhooks throttled to ~15%) produced two PR shapes in bulk that it misses — **and that no other gate predicate covers either**, so the PR is stranded with no path back into PM:

| shape | why every predicate skips it |
|---|---|
| **terminal but not green** — CANCELLED / TIMED_OUT / ACTION_REQUIRED, nothing left running | PR is `UNSTABLE`: `check_merge_ready` wants CLEAN, `check_merge_conflicts` wants DIRTY, `check_ci_failures` wants FAILURE. Once `updatedAt` stops moving, `check_pr_updates` stops firing too. |
| **permanently QUEUED** — orphaned jobs behind the outage | same, plus the checks never reach a conclusion at all |

Verified live on **gptme/gptme#3472**: `mergeStateStatus=UNSTABLE`, `mergeable=MERGEABLE`, one CANCELLED check, three QUEUED for ~6h, greptile 5/5, and a stored watermark byte-identical to `updatedAt`. It matches none of the seven per-PR predicates and cannot re-enter PM without a human push or comment.

## Change

Replaces the boolean with a three-way classifier — `green` / `inflight` / `bad`:

- **FAILURE still fires immediately**, even with other checks running. Existing behaviour is byte-for-byte preserved.
- **CANCELLED and friends count only once nothing is in flight.** This matters: repos using `concurrency: cancel-in-progress: true` leave a CANCELLED check behind on *every* supersede while the replacement run starts. Firing on "any CANCELLED" would emit on every force-push. There is an explicit test for this.
- **in-flight is emitted only after `CI_STUCK_SECS`** (default 3600) with an unchanged hash, using the state file's mtime as the clock, then re-stamps so a still-stuck PR re-emits at most once per interval rather than every gate run.

Also handles the `StatusContext` rollup shape (legacy commit statuses carry `.state`, not `.conclusion`) — previously invisible to this predicate entirely.

## Tests

13 new in `tests/test_activity_gate_stuck_ci.py`, including the exact #3472 rollup and the supersede-noise case. The test extracts the jq program and the function body straight out of `activity-gate.sh` so it cannot drift from the implementation.

The 50 existing `activity_gate` tests still pass. `shellcheck -S warning` clean.

## Notes for review

- The staleness threshold is a judgement call. 1h is deliberately conservative — long CI runs are common and a false "stuck" costs a wasted session. Tunable via `CI_STUCK_SECS`.
- Detection only. Nothing here re-triggers a run; it just stops these PRs being invisible. The re-trigger primitive lives in Bob's repo (`scripts/ci/retrigger-pr-checks.sh`) and is not wired to the gate yet.
- Related: #1382 (fail closed when a repo has workflows but no checks ran) covers the adjacent "zero checks" shape at the self-merge gate rather than the activity gate.
