### PR TITLE
feat(gptodo): auto-set completed timestamp on done/cancelled transition

### DIFF
--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -136,6 +136,7 @@ from gptodo.utils import (
     load_tasks,
     normalize_state,
     # Phase 4: Effective state computation (bob#240)
+    parse_recur_interval,
     parse_tracking_ref,
     resolve_tasks,
     task_to_dict,
@@ -2354,30 +2355,54 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
         # todo further below and must keep these fields, so skip when recur is set.
         # tracking_issue / upstream_coordination_id are intentionally preserved for
         # permanent traceability.
-        # cancelled is terminal regardless of recur; done skips cleanup only when recurring
-        # (recurrence reset below handles it).
+        # cancelled is terminal regardless of recur. A done task only escapes the
+        # terminal path when the recurrence reset below actually fires, and that
+        # reset is gated on parse_recur_interval() — so gate on the same parse
+        # here rather than on the truthiness of recur:. Values the parser rejects
+        # (malformed strings, and cron expressions, which are documented-valid but
+        # not yet computed) leave the task sitting in done, so they are terminal in
+        # practice and must be stamped and stale-field-cleaned like any other.
+        recur = post.metadata.get("recur")
+        _will_recur = (
+            post.metadata.get("state") == "done"
+            and recur is not None
+            and parse_recur_interval(str(recur)) is not None
+        )
         _is_terminal_nonrecurring = post.metadata.get("state") == "cancelled" or (
-            post.metadata.get("state") == "done" and not post.metadata.get("recur")
+            post.metadata.get("state") == "done" and not _will_recur
         )
         if _is_terminal_nonrecurring:
             for _stale_field in ("next_action", "waiting_for", "waiting_since", "wait"):
                 post.metadata.pop(_stale_field, None)
 
-        # Auto-set completed timestamp when transitioning to a terminal state.
-        # Mirrors the waiting_since auto-set pattern. Skipped for recurring done
-        # tasks (they reset to todo and should not carry a completed stamp).
-        _transitioning_to_terminal = any(
-            op == "set" and field == "state" and value in ("done", "cancelled")
+        # Auto-set completed timestamp when transitioning to a terminal state, and
+        # clear a stale stamp when this edit reopens a task. Both halves defer to an
+        # explicit `--set completed ...` in the same edit: the user's value wins over
+        # the automation in either direction.
+        _state_target = next(
+            (value for op, field, value in reversed(changes) if op == "set" and field == "state"),
+            None,
+        )
+        _completed_explicitly_cleared = any(
+            op == "set" and field == "completed" and value is None for op, field, value in changes
+        )
+        _completed_explicitly_set = any(
+            op == "set" and field == "completed" and value is not None
             for op, field, value in changes
         )
         if (
-            _transitioning_to_terminal
+            _state_target in ("done", "cancelled")
             and _is_terminal_nonrecurring
             and not post.metadata.get("completed")
+            and not _completed_explicitly_cleared
         ):
-            from datetime import datetime as _dt2, timezone as _tz2
-
-            post.metadata["completed"] = _dt2.now(_tz2.utc).isoformat(timespec="seconds")
+            post.metadata["completed"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        elif (
+            _state_target is not None
+            and _state_target not in ("done", "cancelled")
+            and not _completed_explicitly_set
+        ):
+            post.metadata.pop("completed", None)
 
         # Save changes
         with open(task.path, "w") as f:
@@ -2394,8 +2419,6 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
                 # Handle recur: reset task to todo and advance wait: date
                 recur = post.metadata.get("recur")
                 if recur:
-                    from gptodo.utils import parse_recur_interval
-
                     if parse_recur_interval(str(recur)) is None:
                         completed_task_ids.append(task.id)
                         continue
@@ -2405,6 +2428,7 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
                     next_wait = advance_wait(current_wait, recur)
                     post.metadata["state"] = "todo"
                     post.metadata["wait"] = next_wait.isoformat()
+                    post.metadata.pop("completed", None)
                     with open(task.path, "w") as f:
                         f.write(frontmatter.dumps(post))
                     console.print(

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -2400,6 +2400,11 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
         # explicit `--set completed ...` in the same edit: the user's value wins over
         # the automation in either direction.
         #
+        # A non-terminal task carrying completed is stale even if the reopen happened
+        # outside gptodo (for example by editing the Markdown directly). Replace that
+        # stale value on the next terminal transition so the latest completion gets
+        # the timestamp, unless this invocation explicitly supplies or clears it.
+        #
         # Both halves are gated on `_prior_state` — the state the task held *before*
         # this edit — because a post-edit-only check cannot distinguish a transition
         # from a re-assertion:
@@ -2424,11 +2429,14 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
             op == "set" and field == "completed" and value is not None
             for op, field, value in changes
         )
-        if (
+        _is_terminal_transition = (
             _prior_state not in _terminal_states
             and _state_target in _terminal_states
             and _is_terminal_nonrecurring
-            and not post.metadata.get("completed")
+        )
+        if (
+            _is_terminal_transition
+            and not _completed_explicitly_set
             and not _completed_explicitly_cleared
         ):
             post.metadata["completed"] = datetime.now(timezone.utc).isoformat(timespec="seconds")

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -125,6 +125,7 @@ from gptodo.utils import (
     get_cache_path,
     has_new_activity,
     is_task_ready,
+    is_valid_recur_value,
     KNOWN_FRONTMATTER_FIELDS,
     lint_frontmatter_fields,
     resolve_known_frontmatter_fields,
@@ -2167,8 +2168,6 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
                     return
         elif field_spec["type"] == "string":
             if field == "recur":
-                from gptodo.utils import is_valid_recur_value
-
                 if not is_valid_recur_value(value):
                     console.print(
                         "[red]Invalid recur format. Use 7d, 24h, weekly, monthly, "
@@ -2364,21 +2363,35 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
         # permanent traceability.
         # cancelled is terminal regardless of recur. A done task only escapes the
         # terminal path when the recurrence reset below actually fires, and that
-        # reset is gated on parse_recur_interval() — so gate on the same parse
-        # here rather than on the truthiness of recur:. Values the parser rejects
-        # (malformed strings, and cron expressions, which are documented-valid but
-        # not yet computed) leave the task sitting in done, so they are terminal in
-        # practice and must be stamped and stale-field-cleaned like any other.
+        # reset is gated on parse_recur_interval() — so gate the *completed stamp*
+        # on the same parse rather than on the truthiness of recur:. Values the
+        # parser rejects (malformed strings, and cron expressions, which are
+        # documented-valid but not yet computed) leave the task sitting in done, so
+        # they are terminal in practice and must be stamped like any other.
+        #
+        # Stale-field cleanup is deliberately gated *differently*, on
+        # is_valid_recur_value() rather than parse_recur_interval(). A cron recur:
+        # is a documented-valid recurrence that gptodo simply cannot compute yet —
+        # the next-fire date lives in wait: and is maintained by whatever external
+        # scheduler owns the cron. Stripping wait:/next_action: there destroys that
+        # external state irrecoverably, so cron tasks keep their scheduling fields
+        # even though they are stamped and left in done. Genuinely malformed recur:
+        # values are not a recurrence at all, so they are cleaned like any terminal
+        # task.
         recur = post.metadata.get("recur")
         _will_recur = (
             post.metadata.get("state") == "done"
             and recur is not None
             and parse_recur_interval(str(recur)) is not None
         )
+        _recur_is_valid = recur is not None and is_valid_recur_value(str(recur))
         _is_terminal_nonrecurring = post.metadata.get("state") == "cancelled" or (
             post.metadata.get("state") == "done" and not _will_recur
         )
-        if _is_terminal_nonrecurring:
+        _should_strip_stale_fields = post.metadata.get("state") == "cancelled" or (
+            post.metadata.get("state") == "done" and not _recur_is_valid
+        )
+        if _should_strip_stale_fields:
             for _stale_field in ("next_action", "waiting_for", "waiting_since", "wait"):
                 post.metadata.pop(_stale_field, None)
 
@@ -2433,6 +2446,13 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
 
     # Check if any tasks were marked as done and run completion hook
     state_changes = [(op, field, value) for op, field, value in changes if field == "state"]
+    # An explicit `--set completed <value>` in this edit wins over every automatic
+    # clear, including the recurrence reset below — same contract the stamp/clear
+    # pair honours above. `changes` is per-invocation, not per-task, so it is
+    # computed once here.
+    _completed_explicitly_set_global = any(
+        op == "set" and field == "completed" and value is not None for op, field, value in changes
+    )
     if any(value == "done" for _, _, value in state_changes):
         completed_task_ids = []
         for task in target_tasks:
@@ -2451,7 +2471,8 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
                     next_wait = advance_wait(current_wait, recur)
                     post.metadata["state"] = "todo"
                     post.metadata["wait"] = next_wait.isoformat()
-                    post.metadata.pop("completed", None)
+                    if not _completed_explicitly_set_global:
+                        post.metadata.pop("completed", None)
                     with open(task.path, "w") as f:
                         f.write(frontmatter.dumps(post))
                     console.print(

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -2239,47 +2239,6 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
         console.print("[red]No changes specified. Use --set, --add, or --remove.[/]")
         return
 
-    # Show changes to be made
-    console.print("\nChanges to apply:")
-    for task in target_tasks:
-        task_changes = []
-
-        # Group changes by field for cleaner display
-        field_changes: dict[str, list[tuple[str, str | None]]] = {}
-        for op, field, value in changes:
-            if field not in field_changes:
-                field_changes[field] = []
-            field_changes[field].append((op, value))
-
-        # Show changes for each field
-        for field, field_ops in field_changes.items():
-            if field in CANONICAL_LIST_FIELDS:
-                current = task.metadata.get(field, [])
-                new = current.copy()
-
-                # Apply all operations for this field
-                for op, value in field_ops:
-                    if op == "add":
-                        new = list(set(new + [value]))
-                    else:  # remove
-                        new = [x for x in new if x != value]
-
-                if new != current:
-                    task_changes.append(f"{field}: {', '.join(current)} -> {', '.join(new)}")
-            else:
-                # For set operations, only show the final value
-                set_ops = [v for op, v in field_ops if op == "set"]
-                if set_ops:
-                    current = task.metadata.get(field)
-                    new = set_ops[-1]  # Use the last set value
-                    if new != current:
-                        task_changes.append(f"{field}: {current} -> {new}")
-
-        if task_changes:
-            console.print(f"  {task.name}:")
-            for change in task_changes:
-                console.print(f"    {change}")
-
     # Apply changes
     for task in target_tasks:
         post = frontmatter.load(task.path)
@@ -2447,6 +2406,16 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
             and not _completed_explicitly_set
         ):
             post.metadata.pop("completed", None)
+
+        # Report the actual metadata changes, including automatic fields such as
+        # completed and waiting_since, immediately before writing them.
+        console.print(f"\nChanges to apply:\n  {task.name}:")
+        before = task.metadata
+        for field in sorted(set(before) | set(post.metadata)):
+            current = before.get(field)
+            new = post.metadata.get(field)
+            if current != new:
+                console.print(f"    {field}: {current} -> {new}")
 
         # Save changes
         with open(task.path, "w") as f:

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -1958,6 +1958,7 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
         # Keep "none" as the explicit clear value; otherwise accept any string.
         "assigned_to": {"type": "string"},
         "waiting_since": {"type": "date"},
+        "completed": {"type": "date"},  # When the task was marked done/cancelled
         "wait": {"type": "date"},  # Hide from queue until this date
         # Structured blockers: why this task is waiting, and (for machine-class
         # blockers) the shell command that decides whether it has cleared.
@@ -2355,11 +2356,28 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
         # permanent traceability.
         # cancelled is terminal regardless of recur; done skips cleanup only when recurring
         # (recurrence reset below handles it).
-        if post.metadata.get("state") == "cancelled" or (
+        _is_terminal_nonrecurring = post.metadata.get("state") == "cancelled" or (
             post.metadata.get("state") == "done" and not post.metadata.get("recur")
-        ):
+        )
+        if _is_terminal_nonrecurring:
             for _stale_field in ("next_action", "waiting_for", "waiting_since", "wait"):
                 post.metadata.pop(_stale_field, None)
+
+        # Auto-set completed timestamp when transitioning to a terminal state.
+        # Mirrors the waiting_since auto-set pattern. Skipped for recurring done
+        # tasks (they reset to todo and should not carry a completed stamp).
+        _transitioning_to_terminal = any(
+            op == "set" and field == "state" and value in ("done", "cancelled")
+            for op, field, value in changes
+        )
+        if (
+            _transitioning_to_terminal
+            and _is_terminal_nonrecurring
+            and not post.metadata.get("completed")
+        ):
+            from datetime import datetime as _dt2, timezone as _tz2
+
+            post.metadata["completed"] = _dt2.now(_tz2.utc).isoformat(timespec="seconds")
 
         # Save changes
         with open(task.path, "w") as f:

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -2285,6 +2285,13 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
     for task in target_tasks:
         post = frontmatter.load(task.path)
 
+        # Snapshot the pre-edit state: the completed-stamp logic below must key off
+        # a real *transition*, not the post-edit final state (which cannot tell an
+        # idempotent re-save apart from a state change).
+        _prior_state = normalize_state(
+            str(post.metadata.get("state", "backlog") or "backlog"), warn=False
+        )
+
         # Apply all changes
         for op, field, value in changes:
             if op == "set_subtask":
@@ -2379,6 +2386,20 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
         # clear a stale stamp when this edit reopens a task. Both halves defer to an
         # explicit `--set completed ...` in the same edit: the user's value wins over
         # the automation in either direction.
+        #
+        # Both halves are gated on `_prior_state` — the state the task held *before*
+        # this edit — because a post-edit-only check cannot distinguish a transition
+        # from a re-assertion:
+        #   - Without the prior-state gate on the stamp, re-saving an already-done
+        #     legacy task (`--set state done` on a task that is already done and
+        #     predates this feature, so has no `completed`) fabricates a completion
+        #     of "just now", corrupting exactly the completion-duration / fast-close
+        #     signals this stamp exists to measure.
+        #   - Without the prior-state gate on the clear, an ordinary forward move
+        #     like waiting → active or backlog → todo silently deletes a `completed`
+        #     the task legitimately carries. Only a genuine reopen (terminal → open)
+        #     should drop it.
+        _terminal_states = ("done", "cancelled")
         _state_target = next(
             (value for op, field, value in reversed(changes) if op == "set" and field == "state"),
             None,
@@ -2391,15 +2412,17 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
             for op, field, value in changes
         )
         if (
-            _state_target in ("done", "cancelled")
+            _prior_state not in _terminal_states
+            and _state_target in _terminal_states
             and _is_terminal_nonrecurring
             and not post.metadata.get("completed")
             and not _completed_explicitly_cleared
         ):
             post.metadata["completed"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
         elif (
-            _state_target is not None
-            and _state_target not in ("done", "cancelled")
+            _prior_state in _terminal_states
+            and _state_target is not None
+            and _state_target not in _terminal_states
             and not _completed_explicitly_set
         ):
             post.metadata.pop("completed", None)

--- a/packages/gptodo/src/gptodo/validate_frontmatter.py
+++ b/packages/gptodo/src/gptodo/validate_frontmatter.py
@@ -27,7 +27,7 @@ _FRONTMATTER_BLOCK_RE = re.compile(r"(?ms)^---\s*$\n(.*?)^---\s*$")
 
 # Matches timestamp field lines in raw YAML text.
 _TIMESTAMP_FIELD_RE = re.compile(
-    r"^\s*(created|created_at|modified|waiting_since|wait)\s*:\s*(.+?)\s*$"
+    r"^\s*(created|created_at|modified|waiting_since|wait|completed)\s*:\s*(.+?)\s*$"
 )
 
 # Detects space-separated datetime (e.g. ``2026-07-02 20:00:00``) before YAML

--- a/packages/gptodo/tests/test_edit_state_completed.py
+++ b/packages/gptodo/tests/test_edit_state_completed.py
@@ -107,8 +107,8 @@ def test_edit_state_cancelled_auto_sets_completed(tmp_path: Path, monkeypatch) -
     assert before <= injected <= after
 
 
-def test_edit_state_done_does_not_override_existing_completed(tmp_path: Path, monkeypatch) -> None:
-    """If completed is already set, it should not be overwritten on done transition."""
+def test_edit_state_done_replaces_stale_completed(tmp_path: Path, monkeypatch) -> None:
+    """A task reopened outside gptodo gets a fresh completion timestamp."""
     tasks_dir = tmp_path / "tasks"
     tasks_dir.mkdir()
     (tasks_dir / "my-task.md").write_text(ACTIVE_TASK_WITH_COMPLETED)
@@ -120,13 +120,8 @@ def test_edit_state_done_does_not_override_existing_completed(tmp_path: Path, mo
 
     tasks = load_tasks(tasks_dir)
     assert len(tasks) == 1
-    # YAML parses ISO datetimes to Python datetime objects; compare via fromisoformat
     stored = datetime.fromisoformat(str(tasks[0].metadata["completed"]))
-    if stored.tzinfo is None:
-        stored = stored.replace(tzinfo=timezone.utc)
-    assert stored == datetime(
-        2026, 6, 10, 12, 0, 0, tzinfo=timezone.utc
-    ), "pre-existing completed must not change"
+    assert stored > datetime(2026, 6, 10, 12, tzinfo=timezone.utc)
 
 
 def test_edit_unrelated_field_does_not_inject_completed(tmp_path: Path, monkeypatch) -> None:

--- a/packages/gptodo/tests/test_edit_state_completed.py
+++ b/packages/gptodo/tests/test_edit_state_completed.py
@@ -281,6 +281,72 @@ def test_explicit_completed_clear_wins_over_auto_stamp(tmp_path: Path, monkeypat
     assert "completed" not in load_tasks(tasks_dir)[0].metadata
 
 
+def test_resaving_already_done_task_does_not_fabricate_completed(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """An idempotent re-save of an already-done task must not stamp "just now".
+
+    ``--set state done`` on a task that is *already* done is a no-op transition,
+    but the change is still recorded, so a post-edit-only check would stamp it.
+    Legacy tasks closed before this feature shipped carry no ``completed``; a
+    fabricated "completed just now" corrupts the very completion-duration and
+    fast-close signals the stamp exists to measure.
+    """
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "my-task.md").write_text(ACTIVE_TASK.replace("state: active", "state: done"))
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(cli, ["edit", "my-task", "--set", "state", "done"])
+
+    assert result.exit_code == 0, result.output
+    task = load_tasks(tasks_dir)[0]
+    assert task.metadata["state"] == "done"
+    assert "completed" not in task.metadata, (
+        "re-saving an already-done task must not fabricate a completion time; "
+        "only a real non-terminal → terminal transition stamps"
+    )
+
+
+@pytest.mark.parametrize(
+    ("from_state", "to_state", "extra_frontmatter"),
+    [
+        ("waiting", "active", "waiting_for: someone\n"),
+        ("backlog", "todo", ""),
+    ],
+)
+def test_forward_transition_preserves_completed(
+    tmp_path: Path, monkeypatch, from_state: str, to_state: str, extra_frontmatter: str
+) -> None:
+    """Ordinary forward transitions must not delete a ``completed`` the task carries.
+
+    The reopen-clear exists for terminal → open only. Keyed off the post-edit
+    state alone it also fires on waiting → active / backlog → todo, silently
+    dropping a stamp that was set manually or left from an earlier cycle.
+    """
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "my-task.md").write_text(
+        ACTIVE_TASK_WITH_COMPLETED.replace("state: active", f"state: {from_state}").replace(
+            "completed:", f"{extra_frontmatter}completed:"
+        )
+    )
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(cli, ["edit", "my-task", "--set", "state", to_state])
+
+    assert result.exit_code == 0, result.output
+    task = load_tasks(tasks_dir)[0]
+    assert task.metadata["state"] == to_state
+    assert (
+        "completed" in task.metadata
+    ), f"{from_state} → {to_state} is not a reopen; completed must survive"
+    stored = datetime.fromisoformat(str(task.metadata["completed"]))
+    if stored.tzinfo is None:
+        stored = stored.replace(tzinfo=timezone.utc)
+    assert stored == datetime(2026, 6, 10, 12, 0, 0, tzinfo=timezone.utc)
+
+
 def test_recurring_reset_removes_existing_completed(tmp_path: Path, monkeypatch) -> None:
     """The recurrence reset drops a stale stamp carried in from a previous cycle."""
     tasks_dir = tmp_path / "tasks"

--- a/packages/gptodo/tests/test_edit_state_completed.py
+++ b/packages/gptodo/tests/test_edit_state_completed.py
@@ -1,0 +1,156 @@
+"""Tests for auto-injection of completed when editing state to done/cancelled.
+
+When `gptodo edit --set state done` (or cancelled) is called, `completed` should
+be automatically populated with the current UTC datetime if it is not already set.
+This provides a machine-readable completion timestamp without requiring callers to
+set it manually.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from gptodo.cli import cli
+from gptodo.utils import load_tasks
+
+
+ACTIVE_TASK = """\
+---
+state: active
+created: 2026-06-16T00:00:00+00:00
+---
+# Some Active Task
+"""
+
+ACTIVE_TASK_WITH_COMPLETED = """\
+---
+state: active
+created: 2026-06-16T00:00:00+00:00
+completed: 2026-06-10T12:00:00+00:00
+---
+# Task With Pre-existing Completed
+"""
+
+RECURRING_TASK = """\
+---
+state: active
+created: 2026-06-16T00:00:00+00:00
+recur: 7d
+wait: 2026-06-23T00:00:00+00:00
+---
+# A Recurring Task
+"""
+
+
+def test_edit_state_done_auto_sets_completed(tmp_path: Path, monkeypatch) -> None:
+    """Transitioning to done auto-injects completed as a UTC ISO datetime."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "my-task.md").write_text(ACTIVE_TASK)
+
+    monkeypatch.chdir(tmp_path)
+    before = datetime.now(timezone.utc).replace(microsecond=0)
+    result = CliRunner().invoke(cli, ["edit", "my-task", "--set", "state", "done"])
+    after = datetime.now(timezone.utc)
+
+    assert result.exit_code == 0, f"edit failed: {result.output}"
+
+    tasks = load_tasks(tasks_dir)
+    assert len(tasks) == 1
+    task = tasks[0]
+    assert task.metadata["state"] == "done"
+    assert "completed" in task.metadata, "completed should be auto-set on done transition"
+    injected = datetime.fromisoformat(str(task.metadata["completed"]))
+    if injected.tzinfo is None:
+        injected = injected.replace(tzinfo=timezone.utc)
+    assert (
+        before <= injected <= after
+    ), f"completed {injected!r} not between {before!r} and {after!r}"
+
+
+def test_edit_state_cancelled_auto_sets_completed(tmp_path: Path, monkeypatch) -> None:
+    """Transitioning to cancelled auto-injects completed as a UTC ISO datetime."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "my-task.md").write_text(ACTIVE_TASK)
+
+    monkeypatch.chdir(tmp_path)
+    before = datetime.now(timezone.utc).replace(microsecond=0)
+    result = CliRunner().invoke(cli, ["edit", "my-task", "--set", "state", "cancelled"])
+    after = datetime.now(timezone.utc)
+
+    assert result.exit_code == 0, f"edit failed: {result.output}"
+
+    tasks = load_tasks(tasks_dir)
+    assert len(tasks) == 1
+    task = tasks[0]
+    assert task.metadata["state"] == "cancelled"
+    assert "completed" in task.metadata, "completed should be auto-set on cancelled transition"
+    injected = datetime.fromisoformat(str(task.metadata["completed"]))
+    if injected.tzinfo is None:
+        injected = injected.replace(tzinfo=timezone.utc)
+    assert before <= injected <= after
+
+
+def test_edit_state_done_does_not_override_existing_completed(tmp_path: Path, monkeypatch) -> None:
+    """If completed is already set, it should not be overwritten on done transition."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "my-task.md").write_text(ACTIVE_TASK_WITH_COMPLETED)
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(cli, ["edit", "my-task", "--set", "state", "done"])
+
+    assert result.exit_code == 0, f"edit failed: {result.output}"
+
+    tasks = load_tasks(tasks_dir)
+    assert len(tasks) == 1
+    # YAML parses ISO datetimes to Python datetime objects; compare via fromisoformat
+    stored = datetime.fromisoformat(str(tasks[0].metadata["completed"]))
+    if stored.tzinfo is None:
+        stored = stored.replace(tzinfo=timezone.utc)
+    assert stored == datetime(
+        2026, 6, 10, 12, 0, 0, tzinfo=timezone.utc
+    ), "pre-existing completed must not change"
+
+
+def test_edit_unrelated_field_does_not_inject_completed(tmp_path: Path, monkeypatch) -> None:
+    """Editing an unrelated field on an active task must NOT inject completed."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "my-task.md").write_text(ACTIVE_TASK)
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(cli, ["edit", "my-task", "--set", "priority", "high"])
+
+    assert result.exit_code == 0, f"edit failed: {result.output}"
+
+    tasks = load_tasks(tasks_dir)
+    assert len(tasks) == 1
+    assert (
+        "completed" not in tasks[0].metadata
+    ), "completed must not be injected when only editing an unrelated field"
+
+
+def test_edit_state_done_recurring_does_not_set_completed(tmp_path: Path, monkeypatch) -> None:
+    """Recurring tasks transitioning to done reset to todo and must not get completed."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "my-task.md").write_text(RECURRING_TASK)
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(cli, ["edit", "my-task", "--set", "state", "done"])
+
+    assert result.exit_code == 0, f"edit failed: {result.output}"
+
+    tasks = load_tasks(tasks_dir)
+    assert len(tasks) == 1
+    task = tasks[0]
+    # Recurring tasks reset to todo — completed should not be stamped on reset
+    assert task.metadata["state"] == "todo", "recurring task must reset to todo"
+    assert (
+        "completed" not in task.metadata
+    ), "recurring done tasks must not carry a completed stamp into the next cycle"

--- a/packages/gptodo/tests/test_edit_state_completed.py
+++ b/packages/gptodo/tests/test_edit_state_completed.py
@@ -223,27 +223,38 @@ def test_reopening_preserves_explicitly_set_completed(tmp_path: Path, monkeypatc
 
 
 @pytest.mark.parametrize(
-    "recur_value",
+    ("recur_value", "wait_survives"),
     [
-        "sometimes",  # malformed — parser rejects
-        "0 9 * * 1",  # cron — documented-valid but parse_recur_interval() returns None
+        # Malformed — not a recurrence at all, so the task is terminal in every
+        # sense and its stale scheduling fields are cleaned.
+        ("sometimes", False),
+        # Cron — documented-valid (is_valid_recur_value accepts it) but
+        # parse_recur_interval() returns None, so gptodo cannot compute the next
+        # fire date. wait: is owned by the external scheduler and must survive.
+        ("0 9 * * 1", True),
     ],
 )
-def test_unparseable_recur_is_terminal_and_gets_completed(
-    tmp_path: Path, monkeypatch, recur_value: str
+def test_uncomputable_recur_is_terminal_and_gets_completed(
+    tmp_path: Path, monkeypatch, recur_value: str, wait_survives: bool
 ) -> None:
-    """recur: values the parser rejects are terminal, so they get stamped.
+    """recur: values the parser cannot compute are terminal, so they get stamped.
 
     The recurrence handler resets a task to todo only when
     ``parse_recur_interval()`` returns an interval; everything else (malformed
     strings *and* cron expressions, which are documented-valid but not yet
-    computed) is left sitting in done. The terminal predicate must agree, or
-    such tasks end up permanently done with no completed stamp.
+    computed) is left sitting in done. The stamp predicate must agree, or such
+    tasks end up permanently done with no completed stamp.
+
+    Stale-field cleanup, however, must *not* agree: a cron recur: is a real
+    recurrence whose next-fire date lives in wait:, maintained by whatever
+    external scheduler owns the cron. Deleting it on `--set state done` destroys
+    that scheduler's state irrecoverably.
     """
     tasks_dir = tmp_path / "tasks"
     tasks_dir.mkdir()
     (tasks_dir / "my-task.md").write_text(
         RECURRING_TASK.replace("recur: 7d", f"recur: {recur_value!r}")
+        + "next_action: run the export\n"
     )
 
     monkeypatch.chdir(tmp_path)
@@ -251,9 +262,84 @@ def test_unparseable_recur_is_terminal_and_gets_completed(
 
     assert result.exit_code == 0, result.output
     task = load_tasks(tasks_dir)[0]
-    assert task.metadata["state"] == "done", "unparseable recur must not reset to todo"
+    assert task.metadata["state"] == "done", "uncomputable recur must not reset to todo"
     assert "completed" in task.metadata
-    assert "wait" not in task.metadata, "terminal tasks must not keep a stale wait:"
+    if wait_survives:
+        assert task.metadata.get("wait"), (
+            "a cron recur: is a valid recurrence whose next-fire date lives in "
+            "wait:; marking it done must not delete the external scheduler's state"
+        )
+    else:
+        assert "wait" not in task.metadata, "terminal tasks must not keep a stale wait:"
+
+
+def test_cron_recur_done_preserves_scheduling_fields(tmp_path: Path, monkeypatch) -> None:
+    """All four stale-cleanup fields survive `done` on a cron-recurring task.
+
+    Regression guard: the terminal predicate was once gated on
+    ``parse_recur_interval()``, which returns None for cron, so marking a
+    cron task done silently stripped next_action/waiting_for/waiting_since/wait.
+    """
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "my-task.md").write_text(
+        """\
+---
+state: active
+created: 2026-06-16T00:00:00+00:00
+recur: "0 9 * * 1"
+wait: 2026-09-01
+next_action: run the weekly export
+waiting_for: external scheduler
+waiting_since: 2026-08-01
+---
+# Cron Task
+"""
+    )
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(cli, ["edit", "my-task", "--set", "state", "done"])
+
+    assert result.exit_code == 0, result.output
+    task = load_tasks(tasks_dir)[0]
+    assert task.metadata["state"] == "done"
+    assert "completed" in task.metadata
+    for field in ("wait", "next_action", "waiting_for", "waiting_since"):
+        assert field in task.metadata, f"cron-recurring task lost {field} on done"
+
+
+def test_recurring_reset_preserves_explicitly_set_completed(tmp_path: Path, monkeypatch) -> None:
+    """`--set completed <value>` survives the recurrence reset.
+
+    The stamp/clear pair documents that an explicit user value wins over the
+    automation in either direction; the recurrence reset must honour the same
+    contract instead of silently dropping the field the caller just set.
+    """
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "my-task.md").write_text(RECURRING_TASK)
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(
+        cli,
+        [
+            "edit",
+            "my-task",
+            "--set",
+            "state",
+            "done",
+            "--set",
+            "completed",
+            "2026-05-01T00:00:00+00:00",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    task = load_tasks(tasks_dir)[0]
+    assert task.metadata["state"] == "todo", "7d recur must still reset to todo"
+    assert (
+        str(task.metadata.get("completed")) == "2026-05-01T00:00:00+00:00"
+    ), "an explicit --set completed must not be silently deleted by the recurrence reset"
 
 
 def test_explicit_completed_clear_wins_over_auto_stamp(tmp_path: Path, monkeypatch) -> None:

--- a/packages/gptodo/tests/test_edit_state_completed.py
+++ b/packages/gptodo/tests/test_edit_state_completed.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from pathlib import Path
 
+import pytest
 from click.testing import CliRunner
 
 from gptodo.cli import cli
@@ -42,6 +43,17 @@ recur: 7d
 wait: 2026-06-23T00:00:00+00:00
 ---
 # A Recurring Task
+"""
+
+RECURRING_TASK_WITH_COMPLETED = """\
+---
+state: active
+created: 2026-06-16T00:00:00+00:00
+recur: 7d
+wait: 2026-06-23T00:00:00+00:00
+completed: 2026-06-10T12:00:00+00:00
+---
+# A Recurring Task With A Stale Stamp
 """
 
 
@@ -154,3 +166,131 @@ def test_edit_state_done_recurring_does_not_set_completed(tmp_path: Path, monkey
     assert (
         "completed" not in task.metadata
     ), "recurring done tasks must not carry a completed stamp into the next cycle"
+
+
+def test_reopening_terminal_task_clears_completed_for_next_cycle(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Reopening a terminal task drops the stamp so re-completion re-stamps it.
+
+    Without the reopen-clear, the stale first-close value survives and the
+    ``not post.metadata.get("completed")`` guard suppresses the second stamp,
+    leaving the task permanently advertising its *first* completion time.
+    """
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "my-task.md").write_text(
+        ACTIVE_TASK_WITH_COMPLETED.replace("state: active", "state: done")
+    )
+
+    monkeypatch.chdir(tmp_path)
+    reopened = CliRunner().invoke(cli, ["edit", "my-task", "--set", "state", "active", "--force"])
+    assert reopened.exit_code == 0, reopened.output
+    assert "completed" not in load_tasks(tasks_dir)[0].metadata
+
+    closed = CliRunner().invoke(cli, ["edit", "my-task", "--set", "state", "done"])
+    assert closed.exit_code == 0, closed.output
+    completed = datetime.fromisoformat(str(load_tasks(tasks_dir)[0].metadata["completed"]))
+    assert completed > datetime(2026, 6, 10, 12, tzinfo=timezone.utc)
+
+
+def test_reopening_preserves_explicitly_set_completed(tmp_path: Path, monkeypatch) -> None:
+    """An explicit ``--set completed`` survives the reopen-clear in the same edit."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "my-task.md").write_text(
+        ACTIVE_TASK_WITH_COMPLETED.replace("state: active", "state: done")
+    )
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(
+        cli,
+        [
+            "edit",
+            "my-task",
+            "--set",
+            "state",
+            "active",
+            "--set",
+            "completed",
+            "2026-01-01T00:00:00+00:00",
+            "--force",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert load_tasks(tasks_dir)[0].metadata["completed"] == "2026-01-01T00:00:00+00:00"
+
+
+@pytest.mark.parametrize(
+    "recur_value",
+    [
+        "sometimes",  # malformed — parser rejects
+        "0 9 * * 1",  # cron — documented-valid but parse_recur_interval() returns None
+    ],
+)
+def test_unparseable_recur_is_terminal_and_gets_completed(
+    tmp_path: Path, monkeypatch, recur_value: str
+) -> None:
+    """recur: values the parser rejects are terminal, so they get stamped.
+
+    The recurrence handler resets a task to todo only when
+    ``parse_recur_interval()`` returns an interval; everything else (malformed
+    strings *and* cron expressions, which are documented-valid but not yet
+    computed) is left sitting in done. The terminal predicate must agree, or
+    such tasks end up permanently done with no completed stamp.
+    """
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "my-task.md").write_text(
+        RECURRING_TASK.replace("recur: 7d", f"recur: {recur_value!r}")
+    )
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(cli, ["edit", "my-task", "--set", "state", "done"])
+
+    assert result.exit_code == 0, result.output
+    task = load_tasks(tasks_dir)[0]
+    assert task.metadata["state"] == "done", "unparseable recur must not reset to todo"
+    assert "completed" in task.metadata
+    assert "wait" not in task.metadata, "terminal tasks must not keep a stale wait:"
+
+
+def test_explicit_completed_clear_wins_over_auto_stamp(tmp_path: Path, monkeypatch) -> None:
+    """``--set completed none`` is not silently undone by the auto-stamp."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "my-task.md").write_text(ACTIVE_TASK_WITH_COMPLETED)
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(
+        cli,
+        [
+            "edit",
+            "my-task",
+            "--set",
+            "state",
+            "done",
+            "--set",
+            "completed",
+            "none",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "completed" not in load_tasks(tasks_dir)[0].metadata
+
+
+def test_recurring_reset_removes_existing_completed(tmp_path: Path, monkeypatch) -> None:
+    """The recurrence reset drops a stale stamp carried in from a previous cycle."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "my-task.md").write_text(RECURRING_TASK_WITH_COMPLETED)
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(cli, ["edit", "my-task", "--set", "state", "done"])
+
+    assert result.exit_code == 0, result.output
+    task = load_tasks(tasks_dir)[0]
+    assert task.metadata["state"] == "todo"
+    assert "completed" not in task.metadata

--- a/packages/gptodo/tests/test_edit_state_completed.py
+++ b/packages/gptodo/tests/test_edit_state_completed.py
@@ -16,6 +16,7 @@ from click.testing import CliRunner
 
 from gptodo.cli import cli
 from gptodo.utils import load_tasks
+from gptodo.validate_frontmatter import validate_timestamp_syntax
 
 
 ACTIVE_TASK = """\
@@ -75,12 +76,15 @@ def test_edit_state_done_auto_sets_completed(tmp_path: Path, monkeypatch) -> Non
     task = tasks[0]
     assert task.metadata["state"] == "done"
     assert "completed" in task.metadata, "completed should be auto-set on done transition"
+    assert "completed: None ->" in result.output
     injected = datetime.fromisoformat(str(task.metadata["completed"]))
     if injected.tzinfo is None:
         injected = injected.replace(tzinfo=timezone.utc)
     assert (
         before <= injected <= after
     ), f"completed {injected!r} not between {before!r} and {after!r}"
+    raw_frontmatter = (tasks_dir / "my-task.md").read_text().split("---", maxsplit=2)[1]
+    assert validate_timestamp_syntax(raw_frontmatter) == []
 
 
 def test_edit_state_cancelled_auto_sets_completed(tmp_path: Path, monkeypatch) -> None:

--- a/packages/gptodo/tests/test_validate_frontmatter.py
+++ b/packages/gptodo/tests/test_validate_frontmatter.py
@@ -42,6 +42,14 @@ def test_space_datetime_rejected():
     assert "T" in errors[0]
 
 
+def test_completed_space_datetime_rejected():
+    raw = "completed: 2026-07-10 12:00:00\n"
+    errors = validate_timestamp_syntax(raw)
+    assert len(errors) == 1
+    assert "completed" in errors[0]
+    assert "T" in errors[0]
+
+
 def test_iso_datetime_ok():
     raw = "created: 2026-07-02T20:00:00+00:00\n"
     assert validate_timestamp_syntax(raw) == []


### PR DESCRIPTION
## Summary

- Adds `completed` as a recognised frontmatter field in gptodo (both validator and `gptodo edit --set`)
- Auto-injects a UTC ISO datetime when `state` transitions to `done` or `cancelled` — same pattern as `waiting_since` auto-set
- Skips recurring done tasks (they reset to `todo` and shouldn't carry a `completed` stamp into the next cycle)

## Motivation

Erik flagged (2026-08-06) that `completed` wasn't a recognised field and asked whether it should be. Only **1% of done tasks** (58/3473) carry a `completed:` stamp because it had to be set manually. With no completion timestamps:
- Can't measure how long tasks take from creation to close
- Can't detect suspiciously fast closes (false-done signals)
- Can't correlate completion times with commits

Automatic stamping costs nothing and makes the data retrospectively queryable.

## Test plan

- [ ] `gptodo edit task --set state done` → `completed:` auto-set with current UTC timestamp
- [ ] `gptodo edit task --set state cancelled` → `completed:` auto-set
- [ ] Pre-existing `completed:` not overwritten on terminal transition
- [ ] Unrelated field edits on active tasks don't inject `completed`
- [ ] Recurring tasks that reset to `todo` don't get `completed`
- [ ] 5 new pytest cases in `test_edit_state_completed.py` — all pass (`405 passed`)
- [ ] Full gptodo test suite passes: `uv run --package gptodo pytest packages/gptodo/tests/ -k "not cache_concurrency"` → 405 passed