### PR TITLE
fix(greptile): fall back to an initial-review trigger when auto-review never arrives

### DIFF
--- a/scripts/github/greptile-helper.sh
+++ b/scripts/github/greptile-helper.sh
@@ -578,46 +578,54 @@ trigger)
     # the symptom reads as "PRs aren't ready" rather than "the reviewer never came".
     #
     # So after a grace period, trigger once. Every existing protection still
-    # applies: the flock above, the in-flight check, the lifetime cap, and the
-    # trigger-timestamp record.
+    # applies: the flock above, the local in-flight check, the lifetime cap, and
+    # the trigger-timestamp record.
     _initial_grace="${GREPTILE_INITIAL_GRACE_MINS:-45}"
+    case "$_initial_grace" in
+        ''|*[!0-9]*)
+            echo "  [greptile] Invalid GREPTILE_INITIAL_GRACE_MINS=$_initial_grace; using 45 minutes." >&2
+            _initial_grace=45
+            ;;
+    esac
 
     # "trigger once" means exactly once. Two guards, in order:
     #
-    #   1. "in-progress" — a trigger is in flight: either the local trigger-timestamp
-    #      file is fresh (propagation-delay guard, INCIDENT #5) or our comment is
-    #      younger than TRIGGER_GRACE_SECONDS. This is also the fail-safe value when
-    #      _our_trigger_status errors, so an API failure backs off instead of posting.
+    #   1. A fresh local trigger timestamp means a post is in flight but may not
+    #      be visible through GitHub's comments API yet (INCIDENT #5). The flock
+    #      handles concurrent runs; this guard handles sequential runs. Do not
+    #      reuse _our_trigger_status here: it broadly matches any of our comments
+    #      containing "greptileai", so fresh review-feedback prose can delay the
+    #      fallback even though no trigger was posted.
     #   2. lifetime trigger count >= 1 — we already posted our one `@greptileai review`
-    #      on this PR (it now reads "stale" or "stale-acked"). The re-review path
-    #      deliberately treats those as re-triggerable, since a new commit or a stuck
-    #      ack justifies another nudge; this path has neither escape hatch, so treating
-    #      them as re-triggerable would re-post every grace window. If Greptile never
-    #      reviews after our one trigger, escalate to a human.
-    #
-    # Guard 2 counts `@greptileai review` comments (_total_trigger_count) rather than
-    # reusing _our_trigger_status's verdict. That function matches ANY comment of ours
-    # containing "greptileai" (case-insensitive), and on this path review_cutoff is
-    # empty — so neither the spent-trigger normalisation nor the max-retries guard can
-    # ever age the match out. A single unrelated comment, e.g. "Thanks for the catch
-    # @greptileai! Fixed in abc123" (a shape we post routinely), would otherwise report
-    # "stale" forever and permanently suppress the fallback on exactly the PRs it
-    # exists to rescue.
-    #
-    # A ceiling of 1 is stricter than MAX_TOTAL_TRIGGERS (8, which governs the
-    # re-review path), and subsumes it — there is no separate cap check below.
-    _ts_status=$(_our_trigger_status 2>/dev/null || echo "in-progress")
-    if [ "$_ts_status" = "in-progress" ]; then
-        echo "  [greptile] Initial-review trigger already in flight on $REPO#$PR_NUMBER. Not triggering again."
+    #      on this PR. The re-review path deliberately permits later attempts after
+    #      new commits or a stuck acknowledgement; this path has no such escape hatch.
+    _initial_ts_in_flight=0
+    if [ -f "$_TRIGGER_TS_FILE" ]; then
+        _local_ts=$(cat "$_TRIGGER_TS_FILE" 2>/dev/null || true)
+        if [ -n "$_local_ts" ]; then
+            _local_age=$(_age_seconds "$_local_ts" 2>/dev/null) || _local_age=9999
+            if [ "${_local_age:-9999}" -lt "$TRIGGER_GRACE_SECONDS" ]; then
+                _initial_ts_in_flight=1
+            fi
+        fi
+    fi
+    if [ "$_initial_ts_in_flight" -eq 1 ]; then
+        echo "  [greptile] Initial-review trigger already in flight on $REPO#$PR_NUMBER (local timestamp is fresh). Not triggering again."
         exit 0
     fi
     _total_triggers=$(_total_trigger_count)
     if [ "${_total_triggers:-0}" -ge 1 ]; then
-        echo "  [greptile] Initial-review trigger already attempted on $REPO#$PR_NUMBER ($_total_triggers trigger comment(s), status: $_ts_status). Not triggering again — escalate to a human if Greptile never reviews."
+        echo "  [greptile] Initial-review trigger already attempted on $REPO#$PR_NUMBER ($_total_triggers trigger comment(s)). Not triggering again — escalate to a human if Greptile never reviews."
         exit 0
     fi
 
-    _created=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.created_at // ""' 2>/dev/null) || _created=""
+    _pr_info=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '{state: (.state // ""), created_at: (.created_at // "")}' 2>/dev/null) || _pr_info=""
+    _pr_state=$(printf '%s' "$_pr_info" | _json_field "state") || _pr_state=""
+    _created=$(printf '%s' "$_pr_info" | _json_field "created_at") || _created=""
+    if [ "$_pr_state" != "open" ]; then
+        echo "  [greptile] PR $REPO#$PR_NUMBER is ${_pr_state:-unavailable}, not open. Skipping initial-review trigger."
+        exit 0
+    fi
     _age_mins=0
     if [ -n "$_created" ]; then
         _created_epoch=$(date -u -d "$_created" +%s 2>/dev/null \

--- a/scripts/github/greptile-helper.sh
+++ b/scripts/github/greptile-helper.sh
@@ -177,13 +177,15 @@ _issue_comments_json() {
 }
 
 _total_trigger_count() {
-    # Count ALL our actual `@greptileai review` trigger commands on this PR
-    # (lifetime), including the legacy `review comment` spelling. Do not count
-    # prose that merely contains the same substring. Fail-open to 0 on API
-    # error so a transient failure never blocks a legitimate trigger.
+    # Count ALL actual `@greptileai review` trigger commands on this PR
+    # (lifetime), including the legacy `review comment` spelling. Initial-review
+    # deduplication is per PR, not per author: a maintainer's manual trigger must
+    # suppress our fallback too. Do not count prose that merely contains the same
+    # substring. Fail-open to 0 on API error; the caller separately checks the
+    # shared comments-error marker before triggering.
     local count
     count=$(_issue_comments_json \
-        | jq -r "[.[][] | select(.user.login == \"$GITHUB_AUTHOR\" and (.body | test(\"^@greptileai review( comment)?([[:space:]]|$)\")))] | length" 2>/dev/null) || count=0
+        | jq -r '[.[][] | select(.body | test("^@greptileai review( comment)?([[:space:]]|$)"))] | length' 2>/dev/null) || count=0
     printf '%s\n' "${count:-0}"
 }
 
@@ -633,14 +635,12 @@ trigger)
         echo "  [greptile] PR $REPO#$PR_NUMBER is ${_pr_state:-unavailable}, not open. Skipping initial-review trigger."
         exit 0
     fi
-    _age_mins=0
-    if [ -n "$_created" ]; then
-        _created_epoch=$(date -u -d "$_created" +%s 2>/dev/null \
-            || date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$_created" +%s 2>/dev/null || echo "")
-        if [ -n "$_created_epoch" ]; then
-            _age_mins=$(( ( $(date -u +%s) - _created_epoch ) / 60 ))
-        fi
+    _age_seconds=$(_age_seconds "$_created" 2>/dev/null) || _age_seconds=""
+    if [ -z "$_age_seconds" ]; then
+        echo "  [greptile] Could not parse PR creation timestamp for $REPO#$PR_NUMBER. Refusing to trigger an initial review."
+        exit 3
     fi
+    _age_mins=$(( _age_seconds / 60 ))
 
     if [ "$_age_mins" -lt "$_initial_grace" ]; then
         echo "  [greptile] No review yet on $REPO#$PR_NUMBER (${_age_mins}m old, grace ${_initial_grace}m). Awaiting Greptile auto-review."

--- a/scripts/github/greptile-helper.sh
+++ b/scripts/github/greptile-helper.sh
@@ -146,7 +146,8 @@ PY
 # Shell variable caching doesn't work here because callers use $() subshells.
 _REVIEW_CACHE_FILE="${TMPDIR:-/tmp}/greptile-review-cache-$$.json"
 _ISSUE_COMMENTS_CACHE_FILE="${TMPDIR:-/tmp}/greptile-issue-comments-$$.json"
-trap 'rm -f "$_REVIEW_CACHE_FILE" "$_ISSUE_COMMENTS_CACHE_FILE"' EXIT
+_ISSUE_COMMENTS_ERROR_FILE="${TMPDIR:-/tmp}/greptile-issue-comments-error-$$"
+trap 'rm -f "$_REVIEW_CACHE_FILE" "$_ISSUE_COMMENTS_CACHE_FILE" "$_ISSUE_COMMENTS_ERROR_FILE"' EXIT
 
 # Shared hash for per-PR state files (lock + trigger timestamp).
 # Used across trigger and _our_trigger_status to coordinate without the GitHub API.
@@ -167,9 +168,11 @@ _issue_comments_json() {
         cat "$_ISSUE_COMMENTS_CACHE_FILE"
         return
     fi
-    gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate 2>/dev/null \
-        | jq -s '.' > "$_ISSUE_COMMENTS_CACHE_FILE" 2>/dev/null \
-        || echo '[]' > "$_ISSUE_COMMENTS_CACHE_FILE"
+    if ! gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate 2>/dev/null \
+        | jq -s '.' > "$_ISSUE_COMMENTS_CACHE_FILE" 2>/dev/null; then
+        echo '[]' > "$_ISSUE_COMMENTS_CACHE_FILE"
+        : > "$_ISSUE_COMMENTS_ERROR_FILE"
+    fi
     cat "$_ISSUE_COMMENTS_CACHE_FILE"
 }
 
@@ -614,6 +617,10 @@ trigger)
         exit 0
     fi
     _total_triggers=$(_total_trigger_count)
+    if [ -f "$_ISSUE_COMMENTS_ERROR_FILE" ]; then
+        echo "  [greptile] Could not read PR comments for $REPO#$PR_NUMBER. Refusing to trigger an initial review without duplicate-check data."
+        exit 3
+    fi
     if [ "${_total_triggers:-0}" -ge 1 ]; then
         echo "  [greptile] Initial-review trigger already attempted on $REPO#$PR_NUMBER ($_total_triggers trigger comment(s)). Not triggering again — escalate to a human if Greptile never reviews."
         exit 0
@@ -661,10 +668,10 @@ trigger)
     #
     # So: write first, and treat a failed write as fatal for this trigger. Not
     # triggering costs one cycle; double-triggering is the incident. If the post
-    # fails, remove the provisional timestamp so status does not report a phantom
-    # in-flight trigger and the next cycle can retry immediately. A process killed
-    # in the tiny write-to-post window still fails safe for at most the bounded
-    # TRIGGER_GRACE_SECONDS window.
+    # fails, keep the provisional timestamp for the bounded grace window. A failed
+    # client response is ambiguous: GitHub may have committed the comment before a
+    # timeout, and deleting the guard would let the next invocation duplicate it
+    # before the comments API catches up.
     if ! date -u +%Y-%m-%dT%H:%M:%SZ > "$_TRIGGER_TS_FILE" 2>/dev/null; then
         echo "  [greptile] Could not write trigger-timestamp file ($_TRIGGER_TS_FILE); refusing to trigger without the propagation-delay guard. Retrying next cycle."
         exit 0
@@ -672,8 +679,7 @@ trigger)
     if BOB_GREPTILE_HELPER=1 gh api "repos/$REPO/issues/$PR_NUMBER/comments" -f body="$_trigger_body" --silent 2>/dev/null; then
         echo "  [greptile] Initial review triggered."
     else
-        rm -f "$_TRIGGER_TS_FILE"
-        echo "  [greptile] Trigger failed (non-fatal)."
+        echo "  [greptile] Trigger failed or its result was ambiguous; retaining the propagation-delay guard for this grace window."
     fi
     exit 0
     ;;

--- a/scripts/github/greptile-helper.sh
+++ b/scripts/github/greptile-helper.sh
@@ -316,14 +316,19 @@ _our_trigger_status() {
         if [ -n "$_local_ts" ]; then
             # Only count this entry if it's from the CURRENT review cycle
             # (i.e., the timestamp is after the last Greptile review).
-            # Note: when review_cutoff is empty (no prior Greptile review), skip the
-            # fast-path — the trigger command only writes this file during re-reviews,
-            # which always have a non-empty cutoff, so this invariant holds.
+            # When review_cutoff is EMPTY there is no prior Greptile review at all,
+            # so there is only one cycle and any timestamp in the file is in it by
+            # definition. The fast-path must apply there too: the trigger command
+            # also writes this file on the initial-review fallback path, and skipping
+            # the guard for an empty cutoff would let two sequential runs both miss
+            # the (not-yet-propagated) comment via the API and both post.
             local _ts_in_cycle=0  # 1 = TS is from current review cycle; 0 = skip fast-path
             if [ -n "$review_cutoff" ]; then
                 if _timestamp_gt "$_local_ts" "$review_cutoff" 2>/dev/null; then
                     _ts_in_cycle=1
                 fi
+            else
+                _ts_in_cycle=1
             fi
             if [ "$_ts_in_cycle" -eq 1 ]; then
                 local _local_age
@@ -561,9 +566,18 @@ trigger)
     # trigger-timestamp record.
     _initial_grace="${GREPTILE_INITIAL_GRACE_MINS:-45}"
 
-    _ts_status=$(_our_trigger_status 2>/dev/null || echo "none")
-    if [ "$_ts_status" = "in-progress" ]; then
-        echo "  [greptile] Initial-review trigger already in flight on $REPO#$PR_NUMBER. Skipping."
+    # "trigger once" means exactly once. Any status other than "none" means a trigger
+    # comment from us already exists on this PR, so the fallback has already fired —
+    # back off regardless of whether it is "in-progress", "stale" or "stale-acked".
+    # The re-review path deliberately treats "stale"/"stale-acked" as re-triggerable
+    # (a new commit or a stuck ack justifies another nudge); this path has neither of
+    # those escape hatches, so treating them as re-triggerable would re-post every
+    # grace window until MAX_TOTAL_TRIGGERS — up to 8 `@greptileai review` comments on
+    # one PR. If Greptile never reviews after our one trigger, escalate to a human.
+    # Fail-safe: an unexpected non-zero return backs off rather than posting.
+    _ts_status=$(_our_trigger_status 2>/dev/null || echo "in-progress")
+    if [ "$_ts_status" != "none" ]; then
+        echo "  [greptile] Initial-review trigger already attempted on $REPO#$PR_NUMBER (status: $_ts_status). Not triggering again — escalate to a human if Greptile never reviews."
         exit 0
     fi
 

--- a/scripts/github/greptile-helper.sh
+++ b/scripts/github/greptile-helper.sh
@@ -177,12 +177,18 @@ _issue_comments_json() {
 }
 
 _total_trigger_count() {
-    # Count ALL actual `@greptileai review` trigger commands on this PR
-    # (lifetime), including the legacy `review comment` spelling. Initial-review
-    # deduplication is per PR, not per author: a maintainer's manual trigger must
-    # suppress our fallback too. Do not count prose that merely contains the same
-    # substring. Fail-open to 0 on API error; the caller separately checks the
-    # shared comments-error marker before triggering.
+    # Count our actual `@greptileai review` trigger commands over the PR lifetime.
+    # This count backs the helper's spam ceiling, so another maintainer's manual
+    # trigger must not consume one of our slots.
+    local count
+    count=$(_issue_comments_json \
+        | jq -r '[.[][] | select(.user.login == "'"${GITHUB_AUTHOR}"'" and (.body | test("^@greptileai review( comment)?([[:space:]]|$)")))] | length' 2>/dev/null) || count=0
+    printf '%s\n' "${count:-0}"
+}
+
+_any_trigger_count() {
+    # Initial-review deduplication is per PR, not per author: a maintainer's
+    # manual trigger must suppress our fallback too.
     local count
     count=$(_issue_comments_json \
         | jq -r '[.[][] | select(.body | test("^@greptileai review( comment)?([[:space:]]|$)"))] | length' 2>/dev/null) || count=0
@@ -619,6 +625,7 @@ trigger)
         exit 0
     fi
     _total_triggers=$(_total_trigger_count)
+    _any_triggers=$(_any_trigger_count)
     if [ -f "$_ISSUE_COMMENTS_ERROR_FILE" ]; then
         echo "  [greptile] Could not read PR comments for $REPO#$PR_NUMBER. Refusing to trigger an initial review without duplicate-check data."
         exit 3
@@ -627,11 +634,11 @@ trigger)
     # but keep the cap explicit: it remains a hard backstop if that policy is
     # relaxed later and makes the protection promised by this helper auditable.
     if [ "${_total_triggers:-0}" -ge "$MAX_TOTAL_TRIGGERS" ]; then
-        echo "  [greptile] BACKOFF: $REPO#$PR_NUMBER has $_total_triggers lifetime triggers (cap $MAX_TOTAL_TRIGGERS). Not triggering an initial review — escalate to a human."
+        echo "  [greptile] BACKOFF: $REPO#$PR_NUMBER has $_total_triggers helper trigger(s) (cap $MAX_TOTAL_TRIGGERS). Not triggering an initial review — escalate to a human."
         exit 0
     fi
-    if [ "${_total_triggers:-0}" -ge 1 ]; then
-        echo "  [greptile] Initial-review trigger already attempted on $REPO#$PR_NUMBER ($_total_triggers trigger comment(s)). Not triggering again — escalate to a human if Greptile never reviews."
+    if [ "${_any_triggers:-0}" -ge 1 ]; then
+        echo "  [greptile] Initial-review trigger already attempted on $REPO#$PR_NUMBER ($_any_triggers trigger comment(s), any author). Not triggering again — escalate to a human if Greptile never reviews."
         exit 0
     fi
 
@@ -720,13 +727,11 @@ status)
             echo "already-reviewed"
         fi
     else
-        # No review yet — check if there's a trigger in-flight (edge case: manual trigger)
-        _ts=$(_our_trigger_status || echo 'error')
-        if [ "$_ts" = "in-progress" ]; then
-            echo "in-progress"
-        else
-            echo "awaiting-initial-review"
-        fi
+        # Keep the public status contract stable for unreviewed PRs. The trigger
+        # command itself owns in-flight deduplication via the timestamp and comment
+        # guards above; callers use this state to distinguish initial-review waits
+        # from re-review work.
+        echo "awaiting-initial-review"
     fi
     ;;
 

--- a/scripts/github/greptile-helper.sh
+++ b/scripts/github/greptile-helper.sh
@@ -17,10 +17,24 @@
 #   1. Reduce 30min age guard → 15min (reviews complete in 5-15min)
 #   2. Re-request after addressing feedback once new commits land after a Greptile review
 #
-# Initial review policy: Greptile automatically reviews all new PRs. We NEVER manually
-# trigger initial reviews. Only re-reviews (new commits after the latest Greptile
-# review) are triggered.
-# Status 'awaiting-initial-review' is returned for ALL unreviewed PRs regardless of age.
+# Initial review policy: Greptile automatically reviews new PRs (drafts included —
+# verified 2026-08-08 across gptme/gptme, gptme-contrib and gptme-cloud: bot reviews
+# land 1-9 min after a draft PR opens, with no trigger comment). So we do not race it;
+# re-reviews (new commits after the latest Greptile review) are the normal trigger path.
+#
+# Exception: auto-review is not guaranteed. On 2026-08-06/07 Greptile stopped reviewing
+# gptme-contrib entirely (#1380-#1383, ~9h) while still reviewing other repos in minutes,
+# leaving every affected PR permanently self-merge ineligible. So after
+# GREPTILE_INITIAL_GRACE_MINS (default 45) with no review, `trigger` posts exactly one
+# initial-review request. See the fallback block in the `trigger` command.
+#
+# NOTE: `check` and `status` still encode the older never-trigger policy — `check` exits 1
+# and `status` prints 'awaiting-initial-review' for ALL unreviewed PRs regardless of age.
+# Callers that gate on them therefore never reach the fallback: pr-greptile-trigger.py
+# (ACTIONABLE_STATES = {"stale", "needs-re-review"}) and project-monitoring-lib.sh's
+# cross-repo `none|stale` case both skip. The fallback is reached via the self-merge path,
+# which calls `trigger` directly when self-merge-check.py reports "Greptile review not
+# found", and via direct manual invocation.
 #
 # Root cause of spam incidents:
 #   Multiple concurrent sessions each check "any trigger comments?" → all see 0
@@ -566,18 +580,38 @@ trigger)
     # trigger-timestamp record.
     _initial_grace="${GREPTILE_INITIAL_GRACE_MINS:-45}"
 
-    # "trigger once" means exactly once. Any status other than "none" means a trigger
-    # comment from us already exists on this PR, so the fallback has already fired —
-    # back off regardless of whether it is "in-progress", "stale" or "stale-acked".
-    # The re-review path deliberately treats "stale"/"stale-acked" as re-triggerable
-    # (a new commit or a stuck ack justifies another nudge); this path has neither of
-    # those escape hatches, so treating them as re-triggerable would re-post every
-    # grace window until MAX_TOTAL_TRIGGERS — up to 8 `@greptileai review` comments on
-    # one PR. If Greptile never reviews after our one trigger, escalate to a human.
-    # Fail-safe: an unexpected non-zero return backs off rather than posting.
+    # "trigger once" means exactly once. Two guards, in order:
+    #
+    #   1. "in-progress" — a trigger is in flight: either the local trigger-timestamp
+    #      file is fresh (propagation-delay guard, INCIDENT #5) or our comment is
+    #      younger than TRIGGER_GRACE_SECONDS. This is also the fail-safe value when
+    #      _our_trigger_status errors, so an API failure backs off instead of posting.
+    #   2. lifetime trigger count >= 1 — we already posted our one `@greptileai review`
+    #      on this PR (it now reads "stale" or "stale-acked"). The re-review path
+    #      deliberately treats those as re-triggerable, since a new commit or a stuck
+    #      ack justifies another nudge; this path has neither escape hatch, so treating
+    #      them as re-triggerable would re-post every grace window. If Greptile never
+    #      reviews after our one trigger, escalate to a human.
+    #
+    # Guard 2 counts `@greptileai review` comments (_total_trigger_count) rather than
+    # reusing _our_trigger_status's verdict. That function matches ANY comment of ours
+    # containing "greptileai" (case-insensitive), and on this path review_cutoff is
+    # empty — so neither the spent-trigger normalisation nor the max-retries guard can
+    # ever age the match out. A single unrelated comment, e.g. "Thanks for the catch
+    # @greptileai! Fixed in abc123" (a shape we post routinely), would otherwise report
+    # "stale" forever and permanently suppress the fallback on exactly the PRs it
+    # exists to rescue.
+    #
+    # A ceiling of 1 is stricter than MAX_TOTAL_TRIGGERS (8, which governs the
+    # re-review path), and subsumes it — there is no separate cap check below.
     _ts_status=$(_our_trigger_status 2>/dev/null || echo "in-progress")
-    if [ "$_ts_status" != "none" ]; then
-        echo "  [greptile] Initial-review trigger already attempted on $REPO#$PR_NUMBER (status: $_ts_status). Not triggering again — escalate to a human if Greptile never reviews."
+    if [ "$_ts_status" = "in-progress" ]; then
+        echo "  [greptile] Initial-review trigger already in flight on $REPO#$PR_NUMBER. Not triggering again."
+        exit 0
+    fi
+    _total_triggers=$(_total_trigger_count)
+    if [ "${_total_triggers:-0}" -ge 1 ]; then
+        echo "  [greptile] Initial-review trigger already attempted on $REPO#$PR_NUMBER ($_total_triggers trigger comment(s), status: $_ts_status). Not triggering again — escalate to a human if Greptile never reviews."
         exit 0
     fi
 
@@ -593,12 +627,6 @@ trigger)
 
     if [ "$_age_mins" -lt "$_initial_grace" ]; then
         echo "  [greptile] No review yet on $REPO#$PR_NUMBER (${_age_mins}m old, grace ${_initial_grace}m). Awaiting Greptile auto-review."
-        exit 0
-    fi
-
-    _total_triggers=$(_total_trigger_count)
-    if [ "${_total_triggers:-0}" -ge "$MAX_TOTAL_TRIGGERS" ]; then
-        echo "  [greptile] BACKOFF: $REPO#$PR_NUMBER has $_total_triggers lifetime triggers (cap $MAX_TOTAL_TRIGGERS) and still no review. Escalate to a human."
         exit 0
     fi
 

--- a/scripts/github/greptile-helper.sh
+++ b/scripts/github/greptile-helper.sh
@@ -610,10 +610,27 @@ trigger)
 
 <!-- greptile-helper head-sha: $_head_sha -->"
     fi
+    # Record the intent BEFORE posting, and refuse to post if it cannot be
+    # recorded.
+    #
+    # Writing the timestamp after a successful post leaves a window with no
+    # guard at all: if the write fails (read-only TMPDIR, full disk), the next
+    # invocation inside TRIGGER_GRACE_SECONDS finds no TS file, and the GitHub
+    # comments API can take minutes to surface the comment we just made — so
+    # `_our_trigger_status` says "none" and we post a second `@greptileai
+    # review`. That is INCIDENT #5 (2026-03-19) exactly, and a warning saying
+    # "the guard is disabled" does not prevent it.
+    #
+    # So: write first, and treat a failed write as fatal for this trigger. Not
+    # triggering costs one cycle; double-triggering is the incident. If the post
+    # then fails, the stale TS only backs us off until the grace window expires,
+    # after which the API query (which will correctly report no comment) lets a
+    # retry through — self-healing, in the safe direction.
+    if ! date -u +%Y-%m-%dT%H:%M:%SZ > "$_TRIGGER_TS_FILE" 2>/dev/null; then
+        echo "  [greptile] Could not write trigger-timestamp file ($_TRIGGER_TS_FILE); refusing to trigger without the propagation-delay guard. Retrying next cycle."
+        exit 0
+    fi
     if BOB_GREPTILE_HELPER=1 gh api "repos/$REPO/issues/$PR_NUMBER/comments" -f body="$_trigger_body" --silent 2>/dev/null; then
-        if ! date -u +%Y-%m-%dT%H:%M:%SZ > "$_TRIGGER_TS_FILE" 2>/dev/null; then
-            echo "  [greptile] Warning: could not write trigger-timestamp file; propagation-delay guard disabled for this trigger."
-        fi
         echo "  [greptile] Initial review triggered."
     else
         echo "  [greptile] Trigger failed (non-fatal)."

--- a/scripts/github/greptile-helper.sh
+++ b/scripts/github/greptile-helper.sh
@@ -174,11 +174,13 @@ _issue_comments_json() {
 }
 
 _total_trigger_count() {
-    # Count ALL our `@greptileai review` trigger comments on this PR (lifetime).
-    # Fail-open to 0 on API error so a transient failure never blocks a legit trigger.
+    # Count ALL our actual `@greptileai review` trigger commands on this PR
+    # (lifetime), including the legacy `review comment` spelling. Do not count
+    # prose that merely contains the same substring. Fail-open to 0 on API
+    # error so a transient failure never blocks a legitimate trigger.
     local count
     count=$(_issue_comments_json \
-        | jq -r "[.[][] | select(.user.login == \"$GITHUB_AUTHOR\" and (.body | test(\"@greptileai review\")))] | length" 2>/dev/null) || count=0
+        | jq -r "[.[][] | select(.user.login == \"$GITHUB_AUTHOR\" and (.body | test(\"^@greptileai review( comment)?([[:space:]]|$)\")))] | length" 2>/dev/null) || count=0
     printf '%s\n' "${count:-0}"
 }
 
@@ -651,9 +653,10 @@ trigger)
     #
     # So: write first, and treat a failed write as fatal for this trigger. Not
     # triggering costs one cycle; double-triggering is the incident. If the post
-    # then fails, the stale TS only backs us off until the grace window expires,
-    # after which the API query (which will correctly report no comment) lets a
-    # retry through — self-healing, in the safe direction.
+    # fails, remove the provisional timestamp so status does not report a phantom
+    # in-flight trigger and the next cycle can retry immediately. A process killed
+    # in the tiny write-to-post window still fails safe for at most the bounded
+    # TRIGGER_GRACE_SECONDS window.
     if ! date -u +%Y-%m-%dT%H:%M:%SZ > "$_TRIGGER_TS_FILE" 2>/dev/null; then
         echo "  [greptile] Could not write trigger-timestamp file ($_TRIGGER_TS_FILE); refusing to trigger without the propagation-delay guard. Retrying next cycle."
         exit 0
@@ -661,6 +664,7 @@ trigger)
     if BOB_GREPTILE_HELPER=1 gh api "repos/$REPO/issues/$PR_NUMBER/comments" -f body="$_trigger_body" --silent 2>/dev/null; then
         echo "  [greptile] Initial review triggered."
     else
+        rm -f "$_TRIGGER_TS_FILE"
         echo "  [greptile] Trigger failed (non-fatal)."
     fi
     exit 0

--- a/scripts/github/greptile-helper.sh
+++ b/scripts/github/greptile-helper.sh
@@ -182,7 +182,7 @@ _total_trigger_count() {
     # trigger must not consume one of our slots.
     local count
     count=$(_issue_comments_json \
-        | jq -r '[.[][] | select(.user.login == "'"${GITHUB_AUTHOR}"'" and (.body | test("^@greptileai review( comment)?([[:space:]]|$)")))] | length' 2>/dev/null) || count=0
+        | jq -r '[.[][] | select(.user.login == "'"${GITHUB_AUTHOR}"'" and (.body | test("^@greptileai review( comment)?(\\s|$)")))] | length' 2>/dev/null) || count=0
     printf '%s\n' "${count:-0}"
 }
 
@@ -191,7 +191,7 @@ _any_trigger_count() {
     # manual trigger must suppress our fallback too.
     local count
     count=$(_issue_comments_json \
-        | jq -r '[.[][] | select(.body | test("^@greptileai review( comment)?([[:space:]]|$)"))] | length' 2>/dev/null) || count=0
+        | jq -r '[.[][] | select(.body | test("^@greptileai review( comment)?(\\s|$)"))] | length' 2>/dev/null) || count=0
     printf '%s\n' "${count:-0}"
 }
 

--- a/scripts/github/greptile-helper.sh
+++ b/scripts/github/greptile-helper.sh
@@ -545,8 +545,65 @@ trigger)
         exit 0
     fi
 
-    # No review yet — let Greptile auto-review. Don't manually trigger initial review.
-    echo "  [greptile] No review yet on $REPO#$PR_NUMBER. Awaiting Greptile auto-review."
+    # No review yet. Normally let Greptile auto-review: manually triggering the
+    # first review races the bot and produces two reviews.
+    #
+    # But auto-review is not guaranteed to arrive, and this branch used to be an
+    # unconditional dead end. Observed 2026-08-06/07: Greptile stopped
+    # auto-reviewing gptme-contrib entirely (#1380-#1383, zero reviews across
+    # ~9h) while still reviewing gptme and aw-server-rust within ~2 minutes. With
+    # no path to a first review, every affected PR is permanently self-merge
+    # ineligible, because the self-merge gate requires a Greptile review — and
+    # the symptom reads as "PRs aren't ready" rather than "the reviewer never came".
+    #
+    # So after a grace period, trigger once. Every existing protection still
+    # applies: the flock above, the in-flight check, the lifetime cap, and the
+    # trigger-timestamp record.
+    _initial_grace="${GREPTILE_INITIAL_GRACE_MINS:-45}"
+
+    _ts_status=$(_our_trigger_status 2>/dev/null || echo "none")
+    if [ "$_ts_status" = "in-progress" ]; then
+        echo "  [greptile] Initial-review trigger already in flight on $REPO#$PR_NUMBER. Skipping."
+        exit 0
+    fi
+
+    _created=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.created_at // ""' 2>/dev/null) || _created=""
+    _age_mins=0
+    if [ -n "$_created" ]; then
+        _created_epoch=$(date -u -d "$_created" +%s 2>/dev/null \
+            || date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$_created" +%s 2>/dev/null || echo "")
+        if [ -n "$_created_epoch" ]; then
+            _age_mins=$(( ( $(date -u +%s) - _created_epoch ) / 60 ))
+        fi
+    fi
+
+    if [ "$_age_mins" -lt "$_initial_grace" ]; then
+        echo "  [greptile] No review yet on $REPO#$PR_NUMBER (${_age_mins}m old, grace ${_initial_grace}m). Awaiting Greptile auto-review."
+        exit 0
+    fi
+
+    _total_triggers=$(_total_trigger_count)
+    if [ "${_total_triggers:-0}" -ge "$MAX_TOTAL_TRIGGERS" ]; then
+        echo "  [greptile] BACKOFF: $REPO#$PR_NUMBER has $_total_triggers lifetime triggers (cap $MAX_TOTAL_TRIGGERS) and still no review. Escalate to a human."
+        exit 0
+    fi
+
+    echo "  [greptile] No auto-review on $REPO#$PR_NUMBER after ${_age_mins}m (grace ${_initial_grace}m) — triggering initial review..."
+    _head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha // ""' 2>/dev/null) || _head_sha=""
+    _trigger_body="@greptileai review"
+    if [ -n "$_head_sha" ]; then
+        _trigger_body="$_trigger_body
+
+<!-- greptile-helper head-sha: $_head_sha -->"
+    fi
+    if BOB_GREPTILE_HELPER=1 gh api "repos/$REPO/issues/$PR_NUMBER/comments" -f body="$_trigger_body" --silent 2>/dev/null; then
+        if ! date -u +%Y-%m-%dT%H:%M:%SZ > "$_TRIGGER_TS_FILE" 2>/dev/null; then
+            echo "  [greptile] Warning: could not write trigger-timestamp file; propagation-delay guard disabled for this trigger."
+        fi
+        echo "  [greptile] Initial review triggered."
+    else
+        echo "  [greptile] Trigger failed (non-fatal)."
+    fi
     exit 0
     ;;
 

--- a/scripts/github/greptile-helper.sh
+++ b/scripts/github/greptile-helper.sh
@@ -623,6 +623,13 @@ trigger)
         echo "  [greptile] Could not read PR comments for $REPO#$PR_NUMBER. Refusing to trigger an initial review without duplicate-check data."
         exit 3
     fi
+    # The exactly-once guard below is stricter than the general lifetime cap,
+    # but keep the cap explicit: it remains a hard backstop if that policy is
+    # relaxed later and makes the protection promised by this helper auditable.
+    if [ "${_total_triggers:-0}" -ge "$MAX_TOTAL_TRIGGERS" ]; then
+        echo "  [greptile] BACKOFF: $REPO#$PR_NUMBER has $_total_triggers lifetime triggers (cap $MAX_TOTAL_TRIGGERS). Not triggering an initial review — escalate to a human."
+        exit 0
+    fi
     if [ "${_total_triggers:-0}" -ge 1 ]; then
         echo "  [greptile] Initial-review trigger already attempted on $REPO#$PR_NUMBER ($_total_triggers trigger comment(s)). Not triggering again — escalate to a human if Greptile never reviews."
         exit 0

--- a/tests/test_greptile_helper.py
+++ b/tests/test_greptile_helper.py
@@ -78,6 +78,8 @@ if endpoint == "user":
     print(github_author)
     raise SystemExit(0)
 elif endpoint.endswith(f"/issues/{pr_number}/comments"):
+    if fixture.get("comments_api_error"):
+        raise SystemExit(1)
     data = fixture.get("raw_comments", [])
 elif endpoint.endswith(f"/pulls/{pr_number}/commits"):
     data = fixture.get("raw_commits", [])
@@ -1315,8 +1317,24 @@ def test_fallback_refuses_to_trigger_when_ts_file_cannot_be_written():
     assert not gh_log, f"posted a trigger with no propagation guard: {gh_log}"
 
 
-def test_fallback_failed_post_removes_provisional_timestamp():
-    """A failed API post must not leave status reporting a phantom trigger."""
+def test_fallback_comments_api_failure_is_fail_safe():
+    """Missing duplicate-check data must never become an initial trigger."""
+    fixture = {
+        "pr_number": 999,
+        "raw_comments": [],
+        "raw_commits": [],
+        "raw_pr": {"created_at": _iso_ago(minutes=60)},
+        "bot_reaction_count": 0,
+        "comments_api_error": True,
+    }
+    result, gh_log = _run_helper("trigger", fixture, capture_gh_log=True)
+    assert result.returncode == 3, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    assert "Refusing to trigger" in result.stdout, result.stdout
+    assert not gh_log, f"posted despite comments API failure: {gh_log}"
+
+
+def test_fallback_failed_post_retains_provisional_timestamp():
+    """An ambiguous POST failure must retain the propagation-delay guard."""
     fixture = {
         "pr_number": 999,
         "raw_comments": [],
@@ -1327,11 +1345,8 @@ def test_fallback_failed_post_removes_provisional_timestamp():
     }
     result, ts_content = _run_helper("trigger", fixture, capture_ts_file=True)
     assert result.returncode == 0, f"stderr: {result.stderr}"
-    assert "Trigger failed" in result.stdout, result.stdout
-    assert ts_content is None, (
-        "failed initial-review post left a provisional timestamp that would "
-        f"misreport in-progress: {ts_content!r}"
-    )
+    assert "ambiguous" in result.stdout, result.stdout
+    assert ts_content, "ambiguous post failure removed its propagation-delay guard"
 
 
 def test_fallback_records_the_timestamp_before_posting():

--- a/tests/test_greptile_helper.py
+++ b/tests/test_greptile_helper.py
@@ -795,6 +795,29 @@ def test_trigger_fallback_invalid_grace_uses_default():
     assert "Awaiting" in result.stdout
 
 
+def test_trigger_fallback_enforces_lifetime_cap():
+    """The initial-review path keeps the global trigger ceiling explicit."""
+    fixture = {
+        "pr_number": 1385,
+        "raw_comments": [
+            _make_trigger_comment("maintainer", _iso_ago(minutes=40)) for _ in range(8)
+        ],
+        "raw_commits": [],
+        "raw_pr": {"created_at": _iso_ago(minutes=180)},
+        "bot_reaction_count": 0,
+    }
+    result, gh_log = _run_helper(
+        "trigger",
+        fixture,
+        capture_gh_log=True,
+        extra_env={"MAX_TOTAL_TRIGGERS": "8"},
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert not gh_log, f"fallback exceeded the lifetime cap: {gh_log!r}"
+    assert "BACKOFF" in result.stdout, f"stdout: {result.stdout!r}"
+    assert "cap 8" in result.stdout, f"stdout: {result.stdout!r}"
+
+
 def test_trigger_fallback_does_not_repost_over_stale_trigger():
     """Initial-review fallback must fire ONCE, not once per grace window.
 

--- a/tests/test_greptile_helper.py
+++ b/tests/test_greptile_helper.py
@@ -162,6 +162,7 @@ def _run_helper(
     capture_gh_log: Literal[False] = ...,
     capture_ts_file: Literal[False] = ...,
     pre_trigger_ts: str | None = ...,
+    ts_file_unwritable: bool = ...,
     repo: str = ...,
 ) -> subprocess.CompletedProcess[str]: ...
 
@@ -174,6 +175,7 @@ def _run_helper(
     capture_gh_log: Literal[True],
     capture_ts_file: Literal[False] = ...,
     pre_trigger_ts: str | None = ...,
+    ts_file_unwritable: bool = ...,
     repo: str = ...,
 ) -> tuple[subprocess.CompletedProcess[str], str]: ...
 
@@ -186,6 +188,7 @@ def _run_helper(
     capture_gh_log: Literal[False] = ...,
     capture_ts_file: Literal[True],
     pre_trigger_ts: str | None = ...,
+    ts_file_unwritable: bool = ...,
     repo: str = ...,
 ) -> tuple[subprocess.CompletedProcess[str], str | None]: ...
 
@@ -197,6 +200,7 @@ def _run_helper(
     capture_gh_log: bool = False,
     capture_ts_file: bool = False,
     pre_trigger_ts: str | None = None,
+    ts_file_unwritable: bool = False,
     repo: str = "gptme/gptme",
 ) -> (
     subprocess.CompletedProcess[str]
@@ -213,6 +217,9 @@ def _run_helper(
             ts_content is the content of _TRIGGER_TS_FILE if it was written, else None
         pre_trigger_ts: if set, pre-create the local trigger-timestamp file with
             this timestamp (simulates a prior successful trigger in the same TMPDIR)
+        ts_file_unwritable: create a DIRECTORY at the trigger-timestamp path so the
+            helper's write fails, without making TMPDIR itself unwritable (the
+            gh stub and its log live there too)
         repo: repo string passed to the helper (default "gptme/gptme")
     """
     if capture_gh_log and capture_ts_file:
@@ -232,6 +239,13 @@ def _run_helper(
             pr_number = int(str(fixture["pr_number"]))
             ts_file = tmp_path / f"greptile-trigger-ts-{_pr_hash(repo, pr_number)}.txt"
             ts_file.write_text(pre_trigger_ts)
+
+        # Make only the TS path unwritable — a directory at that exact name.
+        # Chmod-ing TMPDIR would also break the gh stub and its log, which live
+        # in the same directory.
+        if ts_file_unwritable:
+            pr_number = int(str(fixture["pr_number"]))
+            (tmp_path / f"greptile-trigger-ts-{_pr_hash(repo, pr_number)}.txt").mkdir()
 
         gh_log = tmp_path / "gh-log.json"
         env = os.environ.copy()
@@ -1182,3 +1196,47 @@ def test_stale_unacked_trigger_no_new_commits_does_not_retrigger():
         f"trigger must NOT post @greptileai review comment on stale+no-new-commits. "
         f"Got log: {gh_log!r}"
     )
+
+
+def test_fallback_refuses_to_trigger_when_ts_file_cannot_be_written():
+    """No propagation-delay guard → no trigger. Not "trigger anyway and warn".
+
+    The timestamp used to be written *after* a successful post, so a failed
+    write (read-only TMPDIR, full disk) left a window with no guard at all: the
+    next invocation inside TRIGGER_GRACE_SECONDS finds no TS file, the comments
+    API has not yet surfaced the comment we just made, `_our_trigger_status`
+    reports "none", and we post a second `@greptileai review`. That is INCIDENT
+    #5 (2026-03-19) exactly; warning that the guard is disabled does not prevent
+    it.
+
+    Writing first and treating a failed write as fatal costs one cycle. The
+    alternative costs a duplicate review comment.
+    """
+    fixture = {
+        "pr_number": 999,
+        "raw_comments": [],
+        "raw_commits": [],
+        "raw_pr": {"created_at": _iso_ago(minutes=60)},
+        "bot_reaction_count": 0,
+    }
+    result, gh_log = _run_helper(
+        "trigger", fixture, capture_gh_log=True, ts_file_unwritable=True
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert "refusing to trigger" in result.stdout, result.stdout
+    assert not gh_log, f"posted a trigger with no propagation guard: {gh_log}"
+
+
+def test_fallback_records_the_timestamp_before_posting():
+    """The happy path still records the guard (and still posts)."""
+    fixture = {
+        "pr_number": 999,
+        "raw_comments": [],
+        "raw_commits": [],
+        "raw_pr": {"created_at": _iso_ago(minutes=60)},
+        "bot_reaction_count": 0,
+    }
+    result, ts_content = _run_helper("trigger", fixture, capture_ts_file=True)
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert "triggering initial review" in result.stdout
+    assert ts_content, "_TRIGGER_TS_FILE should have been written by the fallback"

--- a/tests/test_greptile_helper.py
+++ b/tests/test_greptile_helper.py
@@ -84,7 +84,11 @@ elif endpoint.endswith(f"/pulls/{pr_number}/commits"):
 elif endpoint.endswith(f"/pulls/{pr_number}/reviews"):
     data = fixture.get("raw_reviews", [])
 elif endpoint.endswith(f"/pulls/{pr_number}"):
-    data = fixture.get("raw_pr", {"created_at": "2020-01-01T00:00:00Z"})
+    data = fixture.get(
+        "raw_pr", {"state": "open", "created_at": "2020-01-01T00:00:00Z"}
+    )
+    if endpoint.endswith(f"/pulls/{pr_number}") and isinstance(data, dict):
+        data = {"state": "open", **data}
 elif endpoint.endswith("/reactions"):
     if fixture.get("reactions_error"):
         raise SystemExit(1)
@@ -164,6 +168,7 @@ def _run_helper(
     pre_trigger_ts: str | None = ...,
     ts_file_unwritable: bool = ...,
     repo: str = ...,
+    extra_env: dict[str, str] | None = ...,
 ) -> subprocess.CompletedProcess[str]: ...
 
 
@@ -177,6 +182,7 @@ def _run_helper(
     pre_trigger_ts: str | None = ...,
     ts_file_unwritable: bool = ...,
     repo: str = ...,
+    extra_env: dict[str, str] | None = ...,
 ) -> tuple[subprocess.CompletedProcess[str], str]: ...
 
 
@@ -190,6 +196,7 @@ def _run_helper(
     pre_trigger_ts: str | None = ...,
     ts_file_unwritable: bool = ...,
     repo: str = ...,
+    extra_env: dict[str, str] | None = ...,
 ) -> tuple[subprocess.CompletedProcess[str], str | None]: ...
 
 
@@ -202,6 +209,7 @@ def _run_helper(
     pre_trigger_ts: str | None = None,
     ts_file_unwritable: bool = False,
     repo: str = "gptme/gptme",
+    extra_env: dict[str, str] | None = None,
 ) -> (
     subprocess.CompletedProcess[str]
     | tuple[subprocess.CompletedProcess[str], str]
@@ -221,6 +229,7 @@ def _run_helper(
             helper's write fails, without making TMPDIR itself unwritable (the
             gh stub and its log live there too)
         repo: repo string passed to the helper (default "gptme/gptme")
+        extra_env: environment overrides for the helper subprocess
     """
     if capture_gh_log and capture_ts_file:
         raise ValueError("capture_gh_log and capture_ts_file are mutually exclusive")
@@ -254,6 +263,7 @@ def _run_helper(
         env["GITHUB_AUTHOR"] = "test-user"
         env["PATH"] = f"{tmp}:{env['PATH']}"
         env["TMPDIR"] = tmp  # ensure helper writes state files to test's temp dir
+        env.update(extra_env or {})
 
         result = subprocess.run(
             ["bash", str(SCRIPT), command, repo, str(fixture["pr_number"])],
@@ -708,13 +718,49 @@ def test_trigger_falls_back_to_initial_review_after_grace():
         "pr_number": 999,
         "raw_comments": [],
         "raw_commits": [],
-        "raw_pr": {"created_at": _iso_ago(minutes=60)},
+        "raw_pr": {"state": "open", "created_at": _iso_ago(minutes=60)},
         "bot_reaction_count": 0,
     }
     result, gh_log = _run_helper("trigger", fixture, capture_gh_log=True)
     assert result.returncode == 0, f"stderr: {result.stderr}"
     assert "triggering initial review" in result.stdout
     assert gh_log, "a trigger comment should have been posted after the grace window"
+
+
+def test_trigger_fallback_skips_closed_pr():
+    """Never post a fresh review request on a closed or merged PR."""
+    fixture = {
+        "pr_number": 998,
+        "raw_comments": [],
+        "raw_commits": [],
+        "raw_pr": {"state": "closed", "created_at": _iso_ago(minutes=60)},
+        "bot_reaction_count": 0,
+    }
+    result, gh_log = _run_helper("trigger", fixture, capture_gh_log=True)
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert not gh_log, "a closed PR must not receive an initial-review trigger"
+    assert "not open" in result.stdout
+
+
+def test_trigger_fallback_invalid_grace_uses_default():
+    """A malformed grace override must not disable the anti-race window."""
+    fixture = {
+        "pr_number": 997,
+        "raw_comments": [],
+        "raw_commits": [],
+        "raw_pr": {"state": "open", "created_at": _iso_ago(minutes=10)},
+        "bot_reaction_count": 0,
+    }
+    result, gh_log = _run_helper(
+        "trigger",
+        fixture,
+        capture_gh_log=True,
+        extra_env={"GREPTILE_INITIAL_GRACE_MINS": "not-a-number"},
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert not gh_log, "malformed grace must fall back to 45 minutes, not trigger early"
+    assert "using 45 minutes" in result.stderr
+    assert "Awaiting" in result.stdout
 
 
 def test_trigger_fallback_does_not_repost_over_stale_trigger():
@@ -800,7 +846,7 @@ def test_trigger_fallback_ignores_unrelated_greptileai_mention():
             }
         ],
         "raw_commits": [],
-        "raw_pr": {"created_at": _iso_ago(minutes=180)},
+        "raw_pr": {"state": "open", "created_at": _iso_ago(minutes=180)},
         "bot_reaction_count": 0,
     }
     result, gh_log = _run_helper("trigger", fixture, capture_gh_log=True)

--- a/tests/test_greptile_helper.py
+++ b/tests/test_greptile_helper.py
@@ -703,6 +703,121 @@ def test_trigger_falls_back_to_initial_review_after_grace():
     assert gh_log, "a trigger comment should have been posted after the grace window"
 
 
+def test_trigger_fallback_does_not_repost_over_stale_trigger():
+    """Initial-review fallback must fire ONCE, not once per grace window.
+
+    Regression test: the fallback originally backed off only on "in-progress".
+    A trigger comment older than TRIGGER_GRACE_SECONDS with no Greptile ack
+    reports "stale", which fell through and posted another `@greptileai review`
+    — re-posting on every subsequent invocation until MAX_TOTAL_TRIGGERS (8).
+
+    Any status other than "none" means our one trigger already exists, so the
+    fallback must back off and leave escalation to a human.
+    """
+    fixture = {
+        "pr_number": 1385,
+        # Our trigger from 40min ago, never acked by Greptile → "stale".
+        # No greptile-authored comment at all → still no review.
+        "raw_comments": [_make_trigger_comment("test-user", _iso_ago(minutes=40))],
+        "raw_commits": [],
+        "raw_pr": {"created_at": _iso_ago(minutes=180)},
+        "bot_reaction_count": 0,  # never acked → "stale", not "stale-acked"
+    }
+    result, gh_log = _run_helper("trigger", fixture, capture_gh_log=True)
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert not gh_log, (
+        f"fallback must not re-post over an existing (stale) trigger comment. "
+        f"Got log: {gh_log!r}"
+    )
+    assert "already attempted" in result.stdout, f"stdout: {result.stdout!r}"
+
+
+def test_trigger_fallback_stale_acked_does_not_repost():
+    """Same as above for "stale-acked" (Greptile acked but never reviewed).
+
+    The re-review path deliberately re-triggers on "stale-acked" to unstick
+    gptme#1651-style hangs. The initial-review fallback must NOT: our single
+    trigger is already posted and acked, so another comment adds only spam.
+    """
+    fixture = {
+        "pr_number": 1386,
+        # Trigger 3h ago — older than ACK_GRACE_SECONDS (7200s) — and acked.
+        "raw_comments": [_make_trigger_comment("test-user", _iso_ago(minutes=180))],
+        "raw_commits": [],
+        "raw_pr": {"created_at": _iso_ago(minutes=300)},
+        "bot_reaction_count": 1,  # acked but never reviewed → "stale-acked"
+    }
+    result, gh_log = _run_helper("trigger", fixture, capture_gh_log=True)
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert not gh_log, (
+        f"fallback must not re-post over an acked-but-unreviewed trigger. "
+        f"Got log: {gh_log!r}"
+    )
+    assert "already attempted" in result.stdout, f"stdout: {result.stdout!r}"
+
+
+def test_trigger_fallback_local_timestamp_blocks_with_no_prior_review():
+    """TS-file fast-path must apply when review_cutoff is empty (no prior review).
+
+    Regression test for the propagation-delay hole the initial-review fallback
+    opened: the fast-path only marked the local timestamp "in cycle" when a
+    review cutoff existed, on the (now-false) invariant that only re-reviews
+    write the file. The fallback writes it too, so with no prior review the
+    guard was skipped entirely and the function fell through to the comments
+    API — which lags by minutes. Two sequential runs both saw "none" and both
+    posted.
+
+    Simulates INCIDENT #5 on an unreviewed PR: we triggered 5 minutes ago, the
+    comment is not visible in the API yet, a second run must still back off.
+    """
+    fixture = {
+        "pr_number": 1387,
+        "raw_comments": [],  # propagation delay: our trigger is not visible yet
+        "raw_commits": [],
+        "raw_pr": {"created_at": _iso_ago(minutes=180)},  # well past the grace window
+        "bot_reaction_count": 0,
+    }
+    result, gh_log = _run_helper(
+        "trigger",
+        fixture,
+        capture_gh_log=True,
+        pre_trigger_ts=_iso_ago(minutes=5),
+        repo="gptme/gptme-contrib",
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert not gh_log, (
+        f"local TS < 15min must block the initial-review fallback even though the "
+        f"API shows no trigger comment. Got log: {gh_log!r}"
+    )
+
+
+def test_trigger_fallback_stale_local_timestamp_still_allows_first_trigger():
+    """A TS file older than the grace window must not permanently block the fallback.
+
+    Guards the fix for the empty-cutoff fast-path against over-correcting into a
+    permanent block: with no visible trigger comment and a 60-minute-old local
+    timestamp, the fast-path expires and the API (authoritative) says "none".
+    """
+    fixture = {
+        "pr_number": 1388,
+        "raw_comments": [],
+        "raw_commits": [],
+        "raw_pr": {"created_at": _iso_ago(minutes=180)},
+        "bot_reaction_count": 0,
+    }
+    result, gh_log = _run_helper(
+        "trigger",
+        fixture,
+        capture_gh_log=True,
+        pre_trigger_ts=_iso_ago(minutes=60),
+        repo="gptme/gptme-contrib",
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert (
+        gh_log
+    ), "stale local TS + no trigger comment in API should still trigger once"
+
+
 def test_trigger_skips_fresh_pr():
     """Trigger on fresh PR (< 20 min) → skips, waits for auto-review."""
     fixture = {

--- a/tests/test_greptile_helper.py
+++ b/tests/test_greptile_helper.py
@@ -744,6 +744,36 @@ def test_trigger_fallback_skips_closed_pr():
     assert "not open" in result.stdout
 
 
+def test_trigger_fallback_accepts_offset_creation_timestamp():
+    """ISO offsets must work without relying on platform-specific date flags."""
+    fixture = {
+        "pr_number": 996,
+        "raw_comments": [],
+        "raw_commits": [],
+        "raw_pr": {"state": "open", "created_at": "2020-01-01T01:00:00+01:00"},
+        "bot_reaction_count": 0,
+    }
+    result, gh_log = _run_helper("trigger", fixture, capture_gh_log=True)
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert "triggering initial review" in result.stdout
+    assert gh_log, "an old PR with an offset timestamp should receive the fallback"
+
+
+def test_trigger_fallback_invalid_creation_timestamp_fails_safe():
+    """Unparseable age must neither trigger early nor masquerade as fresh forever."""
+    fixture = {
+        "pr_number": 995,
+        "raw_comments": [],
+        "raw_commits": [],
+        "raw_pr": {"state": "open", "created_at": "not-a-timestamp"},
+        "bot_reaction_count": 0,
+    }
+    result, gh_log = _run_helper("trigger", fixture, capture_gh_log=True)
+    assert result.returncode == 3, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    assert "Could not parse" in result.stdout
+    assert not gh_log, f"fallback posted without a trustworthy PR age: {gh_log!r}"
+
+
 def test_trigger_fallback_invalid_grace_uses_default():
     """A malformed grace override must not disable the anti-race window."""
     fixture = {
@@ -791,6 +821,21 @@ def test_trigger_fallback_does_not_repost_over_stale_trigger():
         f"fallback must not re-post over an existing (stale) trigger comment. "
         f"Got log: {gh_log!r}"
     )
+    assert "already attempted" in result.stdout, f"stdout: {result.stdout!r}"
+
+
+def test_trigger_fallback_does_not_repost_another_authors_trigger():
+    """Initial-review deduplication is per PR, not per helper account."""
+    fixture = {
+        "pr_number": 1385,
+        "raw_comments": [_make_trigger_comment("maintainer", _iso_ago(minutes=40))],
+        "raw_commits": [],
+        "raw_pr": {"created_at": _iso_ago(minutes=180)},
+        "bot_reaction_count": 0,
+    }
+    result, gh_log = _run_helper("trigger", fixture, capture_gh_log=True)
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert not gh_log, f"fallback duplicated another author's trigger: {gh_log!r}"
     assert "already attempted" in result.stdout, f"stdout: {result.stdout!r}"
 
 

--- a/tests/test_greptile_helper.py
+++ b/tests/test_greptile_helper.py
@@ -302,7 +302,7 @@ def test_check_blocks_recently_acknowledged_trigger():
     assert result.returncode == 1, f"stderr: {result.stderr}"
 
     status = _run_helper("status", fixture)
-    assert status.stdout.strip() == "in-progress"
+    assert status.stdout.strip() == "awaiting-initial-review"
 
 
 def test_check_retries_acknowledged_trigger_after_timeout():
@@ -796,11 +796,11 @@ def test_trigger_fallback_invalid_grace_uses_default():
 
 
 def test_trigger_fallback_enforces_lifetime_cap():
-    """The initial-review path keeps the global trigger ceiling explicit."""
+    """The initial-review path keeps the helper's trigger ceiling explicit."""
     fixture = {
         "pr_number": 1385,
         "raw_comments": [
-            _make_trigger_comment("maintainer", _iso_ago(minutes=40)) for _ in range(8)
+            _make_trigger_comment("test-user", _iso_ago(minutes=40)) for _ in range(8)
         ],
         "raw_commits": [],
         "raw_pr": {"created_at": _iso_ago(minutes=180)},
@@ -860,6 +860,31 @@ def test_trigger_fallback_does_not_repost_another_authors_trigger():
     assert result.returncode == 0, f"stderr: {result.stderr}"
     assert not gh_log, f"fallback duplicated another author's trigger: {gh_log!r}"
     assert "already attempted" in result.stdout, f"stdout: {result.stdout!r}"
+
+
+def test_other_authors_triggers_do_not_consume_helper_lifetime_cap():
+    """Manual maintainer triggers must not force the helper into global backoff."""
+    reviewed_at = _iso_ago(minutes=60)
+    fixture = {
+        "pr_number": 1385,
+        "raw_comments": [
+            _make_greptile_comment(4, reviewed_at=reviewed_at),
+            *[
+                _make_trigger_comment("maintainer", _iso_ago(minutes=50 - index))
+                for index in range(8)
+            ],
+        ],
+        "raw_commits": [_make_commit(_iso_ago(minutes=10))],
+        "raw_pr": {"created_at": _iso_ago(minutes=180)},
+        "bot_reaction_count": 0,
+    }
+    status = _run_helper(
+        "status",
+        fixture,
+        extra_env={"MAX_TOTAL_TRIGGERS": "8"},
+    )
+    assert status.returncode == 0, f"stderr: {status.stderr}"
+    assert status.stdout.strip() == "needs-re-review"
 
 
 def test_trigger_fallback_stale_acked_does_not_repost():
@@ -926,6 +951,25 @@ def test_trigger_fallback_ignores_unrelated_greptileai_mention():
         f"initial-review fallback. stdout: {result.stdout!r}"
     )
     assert "triggering initial review" in result.stdout, f"stdout: {result.stdout!r}"
+
+
+def test_unreviewed_status_remains_awaiting_while_fallback_is_in_flight():
+    """Unreviewed PRs keep the documented public status during deduplication."""
+    fixture = {
+        "pr_number": 1387,
+        "raw_comments": [],
+        "raw_commits": [],
+        "raw_pr": {"created_at": _iso_ago(minutes=180)},
+        "bot_reaction_count": 0,
+    }
+    status = _run_helper(
+        "status",
+        fixture,
+        pre_trigger_ts=_iso_ago(minutes=5),
+        repo="gptme/gptme-contrib",
+    )
+    assert status.returncode == 0, f"stderr: {status.stderr}"
+    assert status.stdout.strip() == "awaiting-initial-review"
 
 
 def test_trigger_fallback_local_timestamp_blocks_with_no_prior_review():

--- a/tests/test_greptile_helper.py
+++ b/tests/test_greptile_helper.py
@@ -794,8 +794,9 @@ def test_trigger_fallback_ignores_unrelated_greptileai_mention():
                 "user": {"login": "test-user"},
                 "created_at": _iso_ago(minutes=50),
                 "updated_at": _iso_ago(minutes=50),
-                # Mentions greptileai, but is NOT a trigger.
-                "body": "Thanks for the catch @greptileai! Fixed in abc1234.",
+                # Contains the exact trigger substring, but is prose rather than a
+                # trigger command. Substring matching must not count this.
+                "body": "I saw @greptileai review this; thanks for the catch.",
             }
         ],
         "raw_commits": [],
@@ -1266,6 +1267,25 @@ def test_fallback_refuses_to_trigger_when_ts_file_cannot_be_written():
     assert result.returncode == 0, f"stderr: {result.stderr}"
     assert "refusing to trigger" in result.stdout, result.stdout
     assert not gh_log, f"posted a trigger with no propagation guard: {gh_log}"
+
+
+def test_fallback_failed_post_removes_provisional_timestamp():
+    """A failed API post must not leave status reporting a phantom trigger."""
+    fixture = {
+        "pr_number": 999,
+        "raw_comments": [],
+        "raw_commits": [],
+        "raw_pr": {"created_at": _iso_ago(minutes=60)},
+        "bot_reaction_count": 0,
+        "trigger_api_error": True,
+    }
+    result, ts_content = _run_helper("trigger", fixture, capture_ts_file=True)
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert "Trigger failed" in result.stdout, result.stdout
+    assert ts_content is None, (
+        "failed initial-review post left a provisional timestamp that would "
+        f"misreport in-progress: {ts_content!r}"
+    )
 
 
 def test_fallback_records_the_timestamp_before_posting():

--- a/tests/test_greptile_helper.py
+++ b/tests/test_greptile_helper.py
@@ -862,6 +862,24 @@ def test_trigger_fallback_does_not_repost_another_authors_trigger():
     assert "already attempted" in result.stdout, f"stdout: {result.stdout!r}"
 
 
+def test_trigger_fallback_counts_trigger_with_trailing_newline():
+    """A multiline helper trigger must suppress the initial fallback."""
+    trigger = _make_trigger_comment(
+        "maintainer", _iso_ago(minutes=40), head_sha="abc123"
+    )
+    fixture = {
+        "pr_number": 1385,
+        "raw_comments": [trigger],
+        "raw_commits": [],
+        "raw_pr": {"created_at": _iso_ago(minutes=180)},
+        "bot_reaction_count": 0,
+    }
+    result, gh_log = _run_helper("trigger", fixture, capture_gh_log=True)
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert not gh_log, f"fallback duplicated a multiline trigger: {gh_log!r}"
+    assert "already attempted" in result.stdout, f"stdout: {result.stdout!r}"
+
+
 def test_other_authors_triggers_do_not_consume_helper_lifetime_cap():
     """Manual maintainer triggers must not force the helper into global backoff."""
     reviewed_at = _iso_ago(minutes=60)

--- a/tests/test_greptile_helper.py
+++ b/tests/test_greptile_helper.py
@@ -661,8 +661,35 @@ def test_score_5_with_new_commits_needs_rereview():
     assert status.stdout.strip() == "needs-re-review"
 
 
-def test_trigger_skips_unreviewed_pr_initial_review():
-    """Trigger on old PR with no review → skips (awaiting Greptile auto-review)."""
+def test_trigger_waits_for_auto_review_within_grace():
+    """No review yet and inside the grace window → do not race Greptile's auto-review.
+
+    This is the primary behaviour: manually triggering the first review races the
+    bot and yields two reviews.
+    """
+    fixture = {
+        "pr_number": 999,
+        "raw_comments": [],
+        "raw_commits": [],
+        "raw_pr": {"created_at": _iso_ago(minutes=10)},
+        "bot_reaction_count": 0,
+    }
+    result, gh_log = _run_helper("trigger", fixture, capture_gh_log=True)
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert "Awaiting" in result.stdout
+    assert (
+        not gh_log
+    ), "gh pr comment should NOT have been called inside the grace window"
+
+
+def test_trigger_falls_back_to_initial_review_after_grace():
+    """Auto-review never arrived → trigger once, rather than dead-ending forever.
+
+    Regression test for 2026-08-06/07: Greptile stopped auto-reviewing
+    gptme-contrib entirely (#1380-#1383) while still reviewing other repos in
+    minutes. This branch previously returned unconditionally, so those PRs could
+    never obtain the Greptile review the self-merge gate requires.
+    """
     fixture = {
         "pr_number": 999,
         "raw_comments": [],
@@ -672,8 +699,8 @@ def test_trigger_skips_unreviewed_pr_initial_review():
     }
     result, gh_log = _run_helper("trigger", fixture, capture_gh_log=True)
     assert result.returncode == 0, f"stderr: {result.stderr}"
-    assert "Awaiting" in result.stdout
-    assert not gh_log, "gh pr comment should NOT have been called"
+    assert "triggering initial review" in result.stdout
+    assert gh_log, "a trigger comment should have been posted after the grace window"
 
 
 def test_trigger_skips_fresh_pr():

--- a/tests/test_greptile_helper.py
+++ b/tests/test_greptile_helper.py
@@ -770,6 +770,47 @@ def test_trigger_fallback_stale_acked_does_not_repost():
     assert "already attempted" in result.stdout, f"stdout: {result.stdout!r}"
 
 
+def test_trigger_fallback_ignores_unrelated_greptileai_mention():
+    """An unrelated comment mentioning greptileai must not suppress the fallback.
+
+    Regression test: the fallback backed off on any `_our_trigger_status` other
+    than "none", but that function's selector matches ANY comment of ours whose
+    body contains "greptileai" (case-insensitive) — not specifically
+    `@greptileai review`. On this path review_cutoff is empty, so neither the
+    spent-trigger normalisation nor the max-retries guard can age the match out.
+
+    We post comments of exactly this shape routinely when addressing review
+    feedback ("Thanks for the catch @greptileai! Fixed in ..."), so a single one
+    reported "stale" forever and permanently suppressed the initial-review
+    fallback on exactly the PRs it exists to rescue.
+
+    The back-off must key on real `@greptileai review` trigger comments instead.
+    """
+    fixture = {
+        "pr_number": 1389,
+        "raw_comments": [
+            {
+                "id": 4242,
+                "user": {"login": "test-user"},
+                "created_at": _iso_ago(minutes=50),
+                "updated_at": _iso_ago(minutes=50),
+                # Mentions greptileai, but is NOT a trigger.
+                "body": "Thanks for the catch @greptileai! Fixed in abc1234.",
+            }
+        ],
+        "raw_commits": [],
+        "raw_pr": {"created_at": _iso_ago(minutes=180)},
+        "bot_reaction_count": 0,
+    }
+    result, gh_log = _run_helper("trigger", fixture, capture_gh_log=True)
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert gh_log, (
+        "an unrelated comment merely mentioning greptileai must not suppress the "
+        f"initial-review fallback. stdout: {result.stdout!r}"
+    )
+    assert "triggering initial review" in result.stdout, f"stdout: {result.stdout!r}"
+
+
 def test_trigger_fallback_local_timestamp_blocks_with_no_prior_review():
     """TS-file fast-path must apply when review_cutoff is empty (no prior review).
 


### PR DESCRIPTION
## Problem

The `no review yet` branch of `trigger` returned unconditionally, assuming Greptile's auto-review always arrives. It does not.

**2026-08-06/07:** Greptile stopped auto-reviewing gptme-contrib entirely, while continuing to review other repos in ~2 minutes — including *during* the GitHub Actions outage, which rules out the outage as the cause:

| repo | PRs created after 15:00Z | Greptile reviewed |
|---|---|---|
| gptme/gptme | #3471–#3475 | **5/5** (e.g. #3474 created 20:57 → reviewed 20:59) |
| ActivityWatch/aw-server-rust | #648 | **1/1** |
| **gptme/gptme-contrib** | #1380–#1383 | **0/4** |

Within contrib the break brackets cleanly: #1374–#1379 (01:14→10:50) all reviewed, #1380–#1383 (16:09→21:28) none.

Reopening the PRs restored CI but not the review; an empty commit (`synchronize`) on #1383 re-ran CI green and still produced zero comments from any author.

**Why it matters:** `self-merge-check.py` requires a Greptile review, so every affected PR is permanently self-merge ineligible and simply queues. The symptom reads as *"PRs aren't ready"* rather than *"the reviewer never came"* — which is what makes it hard to spot. gptme-contrib#1381 already merged with no Greptile review at all. This also blocks #1383, the activity-gate fix.

## Change

After `GREPTILE_INITIAL_GRACE_MINS` (default 45) with no review, trigger once.

The grace window preserves exactly why this branch existed: manually triggering the first review races the bot and produces two reviews. Inside the window, behaviour is unchanged.

Every existing protection still applies — the `flock`, the in-flight check, the `MAX_TOTAL_TRIGGERS` lifetime cap (so a repo where Greptile is truly gone backs off and escalates rather than commenting forever), and the trigger-timestamp record.

## Tests

`test_trigger_skips_unreviewed_pr_initial_review` encoded the old behaviour. Rather than delete it, it is split so the surviving invariant stays covered:

- `test_trigger_waits_for_auto_review_within_grace` — 10m old → no comment posted
- `test_trigger_falls_back_to_initial_review_after_grace` — 60m old → exactly one trigger

44 tests pass; `shellcheck -S warning` clean.

## Note

This does not diagnose *why* Greptile stopped on contrib — I lack `admin:org` to inspect app installations, so I can neither confirm nor rule out an installation/permissions change. This makes the failure recoverable either way instead of silently terminal.