### PR TITLE
fix(credential-slots): allow --switch to slots with expired access token when probe=ok

### DIFF
--- a/packages/credential-slots/README.md
+++ b/packages/credential-slots/README.md
@@ -88,9 +88,12 @@ ok, reason = mgr.slot_is_fresh("bob")
 if not ok and reason_is_refreshable(reason):
     # probe_ok asserts "an online probe just confirmed this slot works". Only
     # pass it with a *fresh* probe result in hand — it disables the expiry gate
-    # that force=True cannot. It is honored only for slots that actually hold a
-    # refresh token (nothing to auto-refresh otherwise; the gate stays in force
-    # and the ignore is logged), and every bypass is logged distinctly.
+    # that force=True cannot. It is deliberately narrow: honored only when the
+    # freshness failure is expiry-class AND the slot actually holds a refresh
+    # token. A malformed/unreadable slot, or one with nothing to auto-refresh,
+    # is still refused (the gate stays in force, the ignore is logged) — so
+    # switch_to re-checks both itself rather than trusting the caller's filter.
+    # Every bypass and every ignored probe_ok is logged distinctly.
     if online_probe_succeeds("bob"):
         mgr.switch_to("bob", "operator switch", probe_ok=True)  # skips the expiry gate
 drift = mgr.detect_live_slot_drift()

--- a/packages/credential-slots/README.md
+++ b/packages/credential-slots/README.md
@@ -61,7 +61,7 @@ uv pip install -e packages/credential-slots
 
 ```python
 from pathlib import Path
-from credential_slots import SlotManager
+from credential_slots import SlotManager, reason_is_refreshable
 
 mgr = SlotManager(
     creds_dir=Path.home() / ".claude",
@@ -81,6 +81,13 @@ mgr.get_available_subscriptions()   # ["bob", "alice"]
 
 # Safety checks
 ok, reason = mgr.slot_is_fresh("bob")
+# A stale access token is often still recoverable: CC refreshes it from the
+# stored refresh token on first use. Classify the reason instead of matching
+# its text — "expired 7m ago" and "expires within grace" are both probeable,
+# while "slot missing"/"unreadable" are not.
+if not ok and reason_is_refreshable(reason):
+    if online_probe_succeeds("bob"):
+        mgr.switch_to("bob", "operator switch", probe_ok=True)  # skips the expiry gate
 drift = mgr.detect_live_slot_drift()
 if drift and drift["drift"]:
     warn("live creds file matches no named slot — run /login then persist")

--- a/packages/credential-slots/README.md
+++ b/packages/credential-slots/README.md
@@ -86,6 +86,11 @@ ok, reason = mgr.slot_is_fresh("bob")
 # its text — "expired 7m ago" and "expires within grace" are both probeable,
 # while "slot missing"/"unreadable" are not.
 if not ok and reason_is_refreshable(reason):
+    # probe_ok asserts "an online probe just confirmed this slot works". Only
+    # pass it with a *fresh* probe result in hand — it disables the expiry gate
+    # that force=True cannot. It is honored only for slots that actually hold a
+    # refresh token (nothing to auto-refresh otherwise; the gate stays in force
+    # and the ignore is logged), and every bypass is logged distinctly.
     if online_probe_succeeds("bob"):
         mgr.switch_to("bob", "operator switch", probe_ok=True)  # skips the expiry gate
 drift = mgr.detect_live_slot_drift()

--- a/packages/credential-slots/src/credential_slots/__init__.py
+++ b/packages/credential-slots/src/credential_slots/__init__.py
@@ -40,6 +40,7 @@ from credential_slots.manager import (
     SwitchResult,
     compute_slot_fingerprint,
     read_slot_expiry,
+    reason_is_refreshable,
     slot_is_fresh,
 )
 
@@ -54,6 +55,7 @@ __all__ = [
     "SwitchResult",
     "compute_slot_fingerprint",
     "read_slot_expiry",
+    "reason_is_refreshable",
     "slot_is_fresh",
 ]
 

--- a/packages/credential-slots/src/credential_slots/manager.py
+++ b/packages/credential-slots/src/credential_slots/manager.py
@@ -392,6 +392,10 @@ class SlotManager:
             now=now,
         )
 
+    def slot_has_refresh_token(self, sub: str) -> bool:
+        """Return whether a named slot contains a usable refresh token."""
+        return _read_refresh_token(self.slot_path(sub)) is not None
+
     # ---- Drift detection ----
 
     def detect_live_slot_drift(self) -> DriftInfo | None:

--- a/packages/credential-slots/src/credential_slots/manager.py
+++ b/packages/credential-slots/src/credential_slots/manager.py
@@ -544,6 +544,7 @@ class SlotManager:
         reason: str,
         *,
         force: bool = False,
+        probe_ok: bool = False,
     ) -> SwitchResult:
         """Flip the live symlink to point at ``sub``'s slot file.
 
@@ -554,6 +555,9 @@ class SlotManager:
         - If the target slot is expired or unreadable, the switch is
           refused **regardless of** ``force`` — landing on a known-bad
           credential just moves the 401 crash loop to the next run.
+          Pass ``probe_ok=True`` to bypass this check when an online probe
+          has already confirmed the slot's refresh token is valid (e.g. an
+          expired access token that CC will auto-refresh on first use).
         - On success, replaces the existing symlink atomically via a
           temp-symlink + ``os.replace`` (single rename syscall) so no
           concurrent reader sees a missing ``live_path``, then calls
@@ -588,11 +592,12 @@ class SlotManager:
             self._log(msg)
             return SwitchResult(ok=False, reason=msg)
 
-        fresh, fresh_reason = self.slot_is_fresh(sub)
-        if not fresh:
-            msg = f"refusing to switch to {sub}: {fresh_reason}"
-            self._log(msg)
-            return SwitchResult(ok=False, reason=msg)
+        if not probe_ok:
+            fresh, fresh_reason = self.slot_is_fresh(sub)
+            if not fresh:
+                msg = f"refusing to switch to {sub}: {fresh_reason}"
+                self._log(msg)
+                return SwitchResult(ok=False, reason=msg)
 
         live = self.live_path
         tmp = self.creds_dir / (self.live_name + f".tmp{os.getpid()}")

--- a/packages/credential-slots/src/credential_slots/manager.py
+++ b/packages/credential-slots/src/credential_slots/manager.py
@@ -595,6 +595,10 @@ class SlotManager:
           Pass ``probe_ok=True`` to bypass this check when an online probe
           has already confirmed the slot's refresh token is valid (e.g. an
           expired access token that CC will auto-refresh on first use).
+          ``probe_ok`` is honored **only** for slots that actually hold a
+          refresh token — there is nothing to auto-refresh otherwise — and
+          every bypass is logged distinctly so a skipped safety check is
+          never indistinguishable from an ordinary switch.
         - On success, replaces the existing symlink atomically via a
           temp-symlink + ``os.replace`` (single rename syscall) so no
           concurrent reader sees a missing ``live_path``, then calls
@@ -629,7 +633,30 @@ class SlotManager:
             self._log(msg)
             return SwitchResult(ok=False, reason=msg)
 
-        if not probe_ok:
+        # ``probe_ok`` is a caller assertion ("an online probe says this slot
+        # works"), so it only earns the bypass when the slot could actually be
+        # revived the way the assertion implies: CC refreshes an expired access
+        # token from the stored refresh token. No refresh token, nothing to
+        # refresh — the assertion cannot be about this slot, so the offline gate
+        # stays in force.
+        bypass_expiry = probe_ok
+        if probe_ok and _read_refresh_token(slot) is None:
+            bypass_expiry = False
+            self._log(
+                f"probe_ok IGNORED for {sub}: slot holds no refresh token, "
+                "so an expired access token cannot be auto-refreshed; "
+                "applying the normal expiry gate"
+            )
+
+        if bypass_expiry:
+            # Never let a skipped safety check look like an ordinary switch in
+            # the logs — this line is the audit trail for the bypass.
+            self._log(
+                f"probe_ok BYPASS: skipping expiry gate for {sub} "
+                f"(caller asserts an online probe confirmed the refresh token) "
+                f"— {reason}"
+            )
+        else:
             fresh, fresh_reason = self.slot_is_fresh(sub)
             if not fresh:
                 msg = f"refusing to switch to {sub}: {fresh_reason}"

--- a/packages/credential-slots/src/credential_slots/manager.py
+++ b/packages/credential-slots/src/credential_slots/manager.py
@@ -595,10 +595,12 @@ class SlotManager:
           Pass ``probe_ok=True`` to bypass this check when an online probe
           has already confirmed the slot's refresh token is valid (e.g. an
           expired access token that CC will auto-refresh on first use).
-          ``probe_ok`` is honored **only** for slots that actually hold a
-          refresh token — there is nothing to auto-refresh otherwise — and
-          every bypass is logged distinctly so a skipped safety check is
-          never indistinguishable from an ordinary switch.
+          ``probe_ok`` is honored **only** when the freshness failure is
+          expiry-class (see :func:`reason_is_refreshable`) *and* the slot
+          actually holds a refresh token — an unreadable/malformed slot, or
+          one with nothing to refresh, is still refused. Every bypass and
+          every ignored ``probe_ok`` is logged distinctly so a skipped safety
+          check is never indistinguishable from an ordinary switch.
         - On success, replaces the existing symlink atomically via a
           temp-symlink + ``os.replace`` (single rename syscall) so no
           concurrent reader sees a missing ``live_path``, then calls
@@ -633,32 +635,47 @@ class SlotManager:
             self._log(msg)
             return SwitchResult(ok=False, reason=msg)
 
-        # ``probe_ok`` is a caller assertion ("an online probe says this slot
-        # works"), so it only earns the bypass when the slot could actually be
-        # revived the way the assertion implies: CC refreshes an expired access
-        # token from the stored refresh token. No refresh token, nothing to
-        # refresh — the assertion cannot be about this slot, so the offline gate
-        # stays in force.
-        bypass_expiry = probe_ok
-        if probe_ok and _read_refresh_token(slot) is None:
+        fresh, fresh_reason = self.slot_is_fresh(sub)
+        if not fresh:
+            # ``probe_ok`` is a caller assertion ("an online probe says this
+            # slot works"), so it only earns a bypass when *both* halves of the
+            # assertion can hold for this slot. It is deliberately narrow:
+            #
+            #  1. The failure must be expiry-class. A slot that is unreadable,
+            #     malformed, or missing ``expiresAt`` (truncated / rewritten
+            #     mid-OAuth-refresh) is not something a refresh can fix, and the
+            #     docstring promises those are refused regardless. Letting
+            #     ``probe_ok`` swallow the whole gate would hand any current or
+            #     future caller a malformed-slot bypass for free.
+            #  2. The slot must hold a refresh token. No refresh token, nothing
+            #     for CC to auto-refresh — the assertion cannot be about this
+            #     slot.
+            #
+            # Anything else keeps the offline gate in force, and says why.
             bypass_expiry = False
-            self._log(
-                f"probe_ok IGNORED for {sub}: slot holds no refresh token, "
-                "so an expired access token cannot be auto-refreshed; "
-                "applying the normal expiry gate"
-            )
+            if probe_ok and not reason_is_refreshable(fresh_reason):
+                self._log(
+                    f"probe_ok IGNORED for {sub}: {fresh_reason} — not an "
+                    "expiry-class failure, so no token refresh can fix it; "
+                    "applying the normal freshness gate"
+                )
+            elif probe_ok and _read_refresh_token(slot) is None:
+                self._log(
+                    f"probe_ok IGNORED for {sub}: slot holds no refresh token, "
+                    "so an expired access token cannot be auto-refreshed; "
+                    "applying the normal expiry gate"
+                )
+            elif probe_ok:
+                bypass_expiry = True
+                # Never let a skipped safety check look like an ordinary switch
+                # in the logs — this line is the audit trail for the bypass.
+                self._log(
+                    f"probe_ok BYPASS: skipping expiry gate for {sub} "
+                    f"(caller asserts an online probe confirmed the refresh token) "
+                    f"— {reason}"
+                )
 
-        if bypass_expiry:
-            # Never let a skipped safety check look like an ordinary switch in
-            # the logs — this line is the audit trail for the bypass.
-            self._log(
-                f"probe_ok BYPASS: skipping expiry gate for {sub} "
-                f"(caller asserts an online probe confirmed the refresh token) "
-                f"— {reason}"
-            )
-        else:
-            fresh, fresh_reason = self.slot_is_fresh(sub)
-            if not fresh:
+            if not bypass_expiry:
                 msg = f"refusing to switch to {sub}: {fresh_reason}"
                 self._log(msg)
                 return SwitchResult(ok=False, reason=msg)

--- a/packages/credential-slots/src/credential_slots/manager.py
+++ b/packages/credential-slots/src/credential_slots/manager.py
@@ -133,6 +133,17 @@ def read_slot_expiry(path: Path) -> datetime | None:
     return _parse_oauth_expiry(payload)
 
 
+#: Reason prefixes emitted by :func:`slot_is_fresh` when a slot fails purely
+#: because of its *access* token clock — already lapsed, or inside the grace
+#: window. Such a slot may still hold a valid refresh token. Kept as module
+#: constants so :func:`reason_is_refreshable` can never drift from the strings
+#: :func:`slot_is_fresh` actually produces.
+REASON_EXPIRED = "expired"
+REASON_WITHIN_GRACE = "expires within grace"
+
+_REFRESHABLE_REASON_MARKERS = (REASON_EXPIRED, REASON_WITHIN_GRACE)
+
+
 def slot_is_fresh(
     path: Path,
     *,
@@ -157,9 +168,35 @@ def slot_is_fresh(
     if expiry <= current + timedelta(seconds=grace_seconds):
         age = int((current - expiry).total_seconds())
         if age >= 0:
-            return False, f"expired {age // 60}m ago (at {expiry.isoformat()})"
-        return False, f"expires within grace ({-age}s left, at {expiry.isoformat()})"
+            return (
+                False,
+                f"{REASON_EXPIRED} {age // 60}m ago (at {expiry.isoformat()})",
+            )
+        return (
+            False,
+            f"{REASON_WITHIN_GRACE} ({-age}s left, at {expiry.isoformat()})",
+        )
     return True, f"valid until {expiry.isoformat()}"
+
+
+def reason_is_refreshable(reason: str) -> bool:
+    """Whether a :func:`slot_is_fresh` failure reason is *only* an expiry problem.
+
+    An expired access token is not necessarily a dead credential: Claude Code
+    refreshes it from the stored refresh token on first use. Callers can probe
+    such a slot online and, when the probe succeeds, switch into it with
+    ``probe_ok=True``.
+
+    Returns ``False`` for reasons no probe can fix (missing slot file,
+    unreadable/malformed slot payload) so those keep failing hard, and for
+    success reasons ("valid until ...").
+
+    Use this instead of substring-matching reason text at the call site: the
+    grace-window reason reads "expire\\ **s** within grace", so a naive
+    ``"expired" in reason`` check silently misses it.
+    """
+    lowered = reason.lower()
+    return any(lowered.startswith(marker) for marker in _REFRESHABLE_REASON_MARKERS)
 
 
 def _hash_file(path: Path) -> str | None:

--- a/packages/credential-slots/tests/test_manager.py
+++ b/packages/credential-slots/tests/test_manager.py
@@ -431,6 +431,44 @@ class TestSwitchTo:
         assert result.ok is True
         assert any("probe_ok BYPASS" in line for line in lines)
 
+    def test_probe_ok_refused_for_slot_with_refresh_token_but_no_expiresat(
+        self, mgr: SlotManager
+    ) -> None:
+        """probe_ok must not launder a malformed slot into the live symlink.
+
+        A payload with a valid ``refreshToken`` but a missing/non-numeric
+        ``expiresAt`` (truncated or rewritten mid-OAuth-refresh) fails
+        ``slot_is_fresh`` as "unreadable or no expiresAt" — a failure no token
+        refresh can fix, and one the docstring promises is refused regardless.
+        The refresh-token check alone does not catch it, so the bypass has to
+        be gated on the failure being expiry-class too.
+        """
+        _write_slot(mgr.slot_path("alice"), _ms_from_now(3600))
+        # refresh token present and valid, but no expiresAt at all
+        _write_slot(mgr.slot_path("bob"), None)
+        mgr.live_path.symlink_to(".credentials.json.alice")
+        lines: list[str] = []
+        mgr.logger = lines.append
+
+        result = mgr.switch_to("bob", "manual --probe-ok", probe_ok=True)
+
+        assert result.ok is False
+        assert "expiresat" in result.reason.lower()
+        assert mgr.get_active_subscription() == "alice"
+        assert any("probe_ok IGNORED" in line for line in lines)
+        assert not any("probe_ok BYPASS" in line for line in lines)
+
+    def test_probe_ok_refused_for_unreadable_slot(self, mgr: SlotManager) -> None:
+        """A slot whose JSON does not parse is refused even with probe_ok."""
+        _write_slot(mgr.slot_path("alice"), _ms_from_now(3600))
+        mgr.slot_path("bob").write_text("{ truncated json")
+        mgr.live_path.symlink_to(".credentials.json.alice")
+
+        result = mgr.switch_to("bob", "manual --probe-ok", probe_ok=True)
+
+        assert result.ok is False
+        assert mgr.get_active_subscription() == "alice"
+
     def test_probe_ok_still_rejects_missing_slot(self, mgr: SlotManager) -> None:
         """probe_ok=True bypasses freshness but not existence checks."""
         mgr.live_path.symlink_to(".credentials.json.alice")

--- a/packages/credential-slots/tests/test_manager.py
+++ b/packages/credential-slots/tests/test_manager.py
@@ -398,6 +398,39 @@ class TestSwitchTo:
         assert result.ok is True
         assert mgr.get_active_subscription() == "bob"
 
+    def test_probe_ok_ignored_when_slot_has_no_refresh_token(
+        self, mgr: SlotManager
+    ) -> None:
+        """probe_ok only earns the bypass for slots CC could actually refresh.
+
+        Without a refresh token there is nothing to auto-refresh, so an
+        "online probe said it works" assertion cannot be about this slot —
+        the offline expiry gate must stay in force.
+        """
+        _write_slot(mgr.slot_path("alice"), _ms_from_now(3600))
+        _write_slot(mgr.slot_path("bob"), _ms_from_now(-3600), refresh_token=None)
+        mgr.live_path.symlink_to(".credentials.json.alice")
+        lines: list[str] = []
+        mgr.logger = lines.append
+
+        result = mgr.switch_to("bob", "manual --probe-ok", probe_ok=True)
+
+        assert result.ok is False
+        assert "expired" in result.reason.lower()
+        assert mgr.get_active_subscription() == "alice"
+        assert any("probe_ok IGNORED" in line for line in lines)
+
+    def test_probe_ok_bypass_is_logged_distinctly(self, mgr: SlotManager) -> None:
+        """A skipped expiry gate must be distinguishable from an ordinary switch."""
+        self._seed(mgr, bob_ms=_ms_from_now(-3600), alice_ms=_ms_from_now(3600))
+        lines: list[str] = []
+        mgr.logger = lines.append
+
+        result = mgr.switch_to("bob", "manual --probe-ok", probe_ok=True)
+
+        assert result.ok is True
+        assert any("probe_ok BYPASS" in line for line in lines)
+
     def test_probe_ok_still_rejects_missing_slot(self, mgr: SlotManager) -> None:
         """probe_ok=True bypasses freshness but not existence checks."""
         mgr.live_path.symlink_to(".credentials.json.alice")

--- a/packages/credential-slots/tests/test_manager.py
+++ b/packages/credential-slots/tests/test_manager.py
@@ -398,6 +398,14 @@ class TestSwitchTo:
         assert result.ok is True
         assert mgr.get_active_subscription() == "bob"
 
+    def test_slot_has_refresh_token(self, mgr: SlotManager) -> None:
+        _write_slot(mgr.slot_path("bob"), _ms_from_now(-3600))
+        assert mgr.slot_has_refresh_token("bob") is True
+
+        _write_slot(mgr.slot_path("bob"), _ms_from_now(-3600), refresh_token=None)
+        assert mgr.slot_has_refresh_token("bob") is False
+        assert mgr.slot_has_refresh_token("missing") is False
+
     def test_probe_ok_ignored_when_slot_has_no_refresh_token(
         self, mgr: SlotManager
     ) -> None:

--- a/packages/credential-slots/tests/test_manager.py
+++ b/packages/credential-slots/tests/test_manager.py
@@ -342,6 +342,26 @@ class TestSwitchTo:
         assert result.ok is False
         assert mgr.get_active_subscription() == "alice"
 
+    def test_probe_ok_bypasses_expiry_check(self, mgr: SlotManager) -> None:
+        """probe_ok=True allows switching to a slot with an expired access token.
+
+        An expired access token with a valid refresh token is NOT a dead credential
+        — CC auto-refreshes on first use. When the caller has already confirmed this
+        via an online probe, probe_ok=True bypasses the offline freshness check.
+        """
+        self._seed(mgr, bob_ms=_ms_from_now(-3600), alice_ms=_ms_from_now(3600))
+        result = mgr.switch_to("bob", "manual --probe-ok", probe_ok=True)
+        assert result.ok is True
+        assert mgr.get_active_subscription() == "bob"
+
+    def test_probe_ok_still_rejects_missing_slot(self, mgr: SlotManager) -> None:
+        """probe_ok=True bypasses freshness but not existence checks."""
+        mgr.live_path.symlink_to(".credentials.json.alice")
+        # No slot files at all
+        result = mgr.switch_to("bob", "probe", probe_ok=True)
+        assert result.ok is False
+        assert "missing" in result.reason.lower()
+
     def test_missing_slot_rejected(self, mgr: SlotManager) -> None:
         mgr.live_path.symlink_to(".credentials.json.alice")
         # No slot files at all

--- a/packages/credential-slots/tests/test_manager.py
+++ b/packages/credential-slots/tests/test_manager.py
@@ -20,6 +20,7 @@ from credential_slots import (
     SwitchResult,
     compute_slot_fingerprint,
     read_slot_expiry,
+    reason_is_refreshable,
     slot_is_fresh,
 )
 
@@ -174,6 +175,49 @@ class TestSlotIsFresh:
         _write_slot(p, _ms_from_now(3600))
         ok, _ = slot_is_fresh(p)
         assert ok is True
+
+
+class TestReasonIsRefreshable:
+    """Classify ``slot_is_fresh`` reasons into probeable vs hopeless.
+
+    Driven through real slot states rather than hand-written strings so the
+    predicate can't drift from the reasons ``slot_is_fresh`` actually emits.
+    """
+
+    def test_expired_reason_is_refreshable(self, mgr: SlotManager) -> None:
+        _write_slot(mgr.slot_path("bob"), _ms_from_now(-3600))
+        fresh, reason = mgr.slot_is_fresh("bob")
+        assert fresh is False
+        assert reason_is_refreshable(reason) is True
+
+    def test_within_grace_reason_is_refreshable(self, mgr: SlotManager) -> None:
+        """Regression: the grace reason says "expire**s**", not "expire**d**".
+
+        A naive ``"expired" in reason`` check misses this branch entirely, which
+        made ``--switch`` fail hard for a slot that only needed a token refresh.
+        """
+        _write_slot(mgr.slot_path("bob"), _ms_from_now(60))
+        fresh, reason = mgr.slot_is_fresh("bob", grace_seconds=300)
+        assert fresh is False
+        assert "expired" not in reason.lower()  # the trap this predicate exists for
+        assert reason_is_refreshable(reason) is True
+
+    def test_missing_slot_reason_is_not_refreshable(self, mgr: SlotManager) -> None:
+        fresh, reason = mgr.slot_is_fresh("bob")
+        assert fresh is False
+        assert reason_is_refreshable(reason) is False
+
+    def test_unreadable_slot_reason_is_not_refreshable(self, mgr: SlotManager) -> None:
+        _write_slot(mgr.slot_path("bob"), expires_at_ms=None)
+        fresh, reason = mgr.slot_is_fresh("bob")
+        assert fresh is False
+        assert reason_is_refreshable(reason) is False
+
+    def test_valid_reason_is_not_refreshable(self, mgr: SlotManager) -> None:
+        _write_slot(mgr.slot_path("bob"), _ms_from_now(3600))
+        fresh, reason = mgr.slot_is_fresh("bob")
+        assert fresh is True
+        assert reason_is_refreshable(reason) is False
 
 
 class TestGetActiveSubscription:

--- a/packages/gptme-subscription/src/gptme_subscription/cli.py
+++ b/packages/gptme-subscription/src/gptme_subscription/cli.py
@@ -354,6 +354,10 @@ def _cmd_switch(args: argparse.Namespace, sm: SubscriptionManager) -> int:
         return 0
     ok = sm.switch_to(target, f"manual switch via --switch {target}", force=True)
     failure_detail: str | None = None
+    # Whether we got in via the probe_ok retry below. That path deliberately
+    # accepts a slot whose access token is still expired, so the post-flip usage
+    # check cannot succeed and must not be reported as a credential problem.
+    switched_via_probe_ok = False
     if not ok:
         # Retry with probe_ok=True if the slot has an expired access token but a
         # valid refresh token — CC auto-refreshes on first use, so this is safe.
@@ -384,6 +388,7 @@ def _cmd_switch(args: argparse.Namespace, sm: SubscriptionManager) -> int:
                         force=True,
                         probe_ok=True,
                     )
+                    switched_via_probe_ok = ok
                     if not ok:
                         retry_fresh, retry_reason = sm.slot_is_fresh(target)
                         failure_detail = (
@@ -420,14 +425,29 @@ def _cmd_switch(args: argparse.Namespace, sm: SubscriptionManager) -> int:
         if not sm.check_usage(no_cache=True) and (
             usage_script is not None and usage_script.exists()
         ):
-            print(
-                f"  WARNING: post-switch usage check against {target} returned "
-                "no usage data — the switch DID happen and is recorded. Either "
-                f"the credential did not answer, or {usage_script} itself failed "
-                "(not executable / timed out / bad output). Verify with "
-                f"`--status --probe` before assuming {target} needs a re-login.",
-                file=sys.stderr,
-            )
+            if switched_via_probe_ok:
+                # Expected, not a fault: we got here precisely because the access
+                # token is expired but refreshable. Claude Code refreshes it on
+                # first use, so the usage script is querying with a token that is
+                # still stale and will 401. Reporting this as "the credential did
+                # not answer" would raise an alarm on every successful retry.
+                print(
+                    f"  Note: post-switch usage check against {target} returned "
+                    "no data, which is expected here — the switch was allowed on "
+                    "a verified refresh token while the access token is still "
+                    "expired. Claude Code refreshes it on first use; usage data "
+                    "appears after that.",
+                    file=sys.stderr,
+                )
+            else:
+                print(
+                    f"  WARNING: post-switch usage check against {target} returned "
+                    "no usage data — the switch DID happen and is recorded. Either "
+                    f"the credential did not answer, or {usage_script} itself failed "
+                    "(not executable / timed out / bad output). Verify with "
+                    f"`--status --probe` before assuming {target} needs a re-login.",
+                    file=sys.stderr,
+                )
         return 0
     # Never exit 1 in silence: a bare non-zero exit is the diagnosis-free
     # failure this command's retry path exists to remove. Say what blocked it.

--- a/packages/gptme-subscription/src/gptme_subscription/cli.py
+++ b/packages/gptme-subscription/src/gptme_subscription/cli.py
@@ -364,23 +364,31 @@ def _cmd_switch(args: argparse.Namespace, sm: SubscriptionManager) -> int:
         if not fresh:
             failure_detail = fresh_reason
         if not fresh and reason_is_refreshable(fresh_reason):
-            print(
-                f"  Access token stale ({fresh_reason}); "
-                f"probing {target!r} to verify refresh token...",
-                file=sys.stderr,
-            )
-            _, probe_ok, probe_msg = probe_credential(
-                sm.config.slot_path(target), target, usage_script=sm.config.usage_script
-            )
-            if probe_ok:
-                ok = sm.switch_to(
-                    target,
-                    f"manual switch via --switch {target} (probe_ok)",
-                    force=True,
-                    probe_ok=True,
-                )
+            if not sm.slot_has_refresh_token(target):
+                failure_detail = f"{fresh_reason}; slot holds no refresh token"
             else:
-                print(f"  Probe failed ({probe_msg}); cannot switch.", file=sys.stderr)
+                print(
+                    f"  Access token stale ({fresh_reason}); "
+                    f"probing {target!r} to verify refresh token...",
+                    file=sys.stderr,
+                )
+                _, probe_ok, probe_msg = probe_credential(
+                    sm.config.slot_path(target),
+                    target,
+                    usage_script=sm.config.usage_script,
+                )
+                if probe_ok:
+                    ok = sm.switch_to(
+                        target,
+                        f"manual switch via --switch {target} (probe_ok)",
+                        force=True,
+                        probe_ok=True,
+                    )
+                else:
+                    print(
+                        f"  Probe failed ({probe_msg}); cannot switch.",
+                        file=sys.stderr,
+                    )
     if ok:
         # Protect the operator's explicit choice: write a manual-switch hold so a
         # concurrent automated --execute doesn't immediately rebalance / forward-

--- a/packages/gptme-subscription/src/gptme_subscription/cli.py
+++ b/packages/gptme-subscription/src/gptme_subscription/cli.py
@@ -13,6 +13,8 @@ import sys
 import tempfile
 from pathlib import Path
 
+from credential_slots import reason_is_refreshable
+
 from gptme_subscription.auth import (
     check_credential_file,
     format_reauth_instructions,
@@ -354,10 +356,14 @@ def _cmd_switch(args: argparse.Namespace, sm: SubscriptionManager) -> int:
     if not ok:
         # Retry with probe_ok=True if the slot has an expired access token but a
         # valid refresh token — CC auto-refreshes on first use, so this is safe.
-        fresh, fresh_reason = sm._slot_manager.slot_is_fresh(target)
-        if not fresh and "expired" in fresh_reason.lower():
+        # ``reason_is_refreshable`` lives next to ``slot_is_fresh`` so the two
+        # can't drift; it covers both "expired Nm ago" and "expires within
+        # grace", and excludes missing/unreadable slots (no probe can fix those).
+        fresh, fresh_reason = sm.slot_is_fresh(target)
+        if not fresh and reason_is_refreshable(fresh_reason):
             print(
-                f"  Access token expired; probing {target!r} to verify refresh token...",
+                f"  Access token stale ({fresh_reason}); "
+                f"probing {target!r} to verify refresh token...",
                 file=sys.stderr,
             )
             _, probe_ok, probe_msg = probe_credential(

--- a/packages/gptme-subscription/src/gptme_subscription/cli.py
+++ b/packages/gptme-subscription/src/gptme_subscription/cli.py
@@ -385,7 +385,23 @@ def _cmd_switch(args: argparse.Namespace, sm: SubscriptionManager) -> int:
         # manual switch unprotected for the next decision.
         sm.record_manual_switch_hold(target)
         print(f"Switched to {target}")
-        sm.check_usage(no_cache=True)
+        # Post-flip validation: this runs the usage script against the *live*
+        # credential, i.e. the slot we just switched into. Don't discard the
+        # result — a failure here is the one signal we have that the credential
+        # is not usable after the flip. ``check_usage`` also returns None when
+        # no usage script is configured, which says nothing about the
+        # credential, so only warn when a script was actually available to run.
+        usage_script = sm.config.usage_script
+        if sm.check_usage(no_cache=True) is None and (
+            usage_script is not None and usage_script.exists()
+        ):
+            print(
+                f"  WARNING: post-switch usage check against {target} failed — "
+                "the switch DID happen and is recorded, but the credential did "
+                "not answer. Verify with `--status --probe`; you may need to "
+                f"re-run /login for {target}.",
+                file=sys.stderr,
+            )
         return 0
     return 1
 

--- a/packages/gptme-subscription/src/gptme_subscription/cli.py
+++ b/packages/gptme-subscription/src/gptme_subscription/cli.py
@@ -384,6 +384,13 @@ def _cmd_switch(args: argparse.Namespace, sm: SubscriptionManager) -> int:
                         force=True,
                         probe_ok=True,
                     )
+                    if not ok:
+                        retry_fresh, retry_reason = sm.slot_is_fresh(target)
+                        failure_detail = (
+                            retry_reason
+                            if not retry_fresh
+                            else "switch refused after successful probe"
+                        )
                 else:
                     print(
                         f"  Probe failed ({probe_msg}); cannot switch.",

--- a/packages/gptme-subscription/src/gptme_subscription/cli.py
+++ b/packages/gptme-subscription/src/gptme_subscription/cli.py
@@ -351,6 +351,27 @@ def _cmd_switch(args: argparse.Namespace, sm: SubscriptionManager) -> int:
         print("  use --execute to apply")
         return 0
     ok = sm.switch_to(target, f"manual switch via --switch {target}", force=True)
+    if not ok:
+        # Retry with probe_ok=True if the slot has an expired access token but a
+        # valid refresh token — CC auto-refreshes on first use, so this is safe.
+        fresh, fresh_reason = sm._slot_manager.slot_is_fresh(target)
+        if not fresh and "expired" in fresh_reason.lower():
+            print(
+                f"  Access token expired; probing {target!r} to verify refresh token...",
+                file=sys.stderr,
+            )
+            _, probe_ok, probe_msg = probe_credential(
+                sm.config.slot_path(target), target, usage_script=sm.config.usage_script
+            )
+            if probe_ok:
+                ok = sm.switch_to(
+                    target,
+                    f"manual switch via --switch {target} (probe_ok)",
+                    force=True,
+                    probe_ok=True,
+                )
+            else:
+                print(f"  Probe failed ({probe_msg}); cannot switch.", file=sys.stderr)
     if ok:
         # Protect the operator's explicit choice: write a manual-switch hold so a
         # concurrent automated --execute doesn't immediately rebalance / forward-

--- a/packages/gptme-subscription/src/gptme_subscription/cli.py
+++ b/packages/gptme-subscription/src/gptme_subscription/cli.py
@@ -353,6 +353,7 @@ def _cmd_switch(args: argparse.Namespace, sm: SubscriptionManager) -> int:
         print("  use --execute to apply")
         return 0
     ok = sm.switch_to(target, f"manual switch via --switch {target}", force=True)
+    failure_detail: str | None = None
     if not ok:
         # Retry with probe_ok=True if the slot has an expired access token but a
         # valid refresh token — CC auto-refreshes on first use, so this is safe.
@@ -360,6 +361,8 @@ def _cmd_switch(args: argparse.Namespace, sm: SubscriptionManager) -> int:
         # can't drift; it covers both "expired Nm ago" and "expires within
         # grace", and excludes missing/unreadable slots (no probe can fix those).
         fresh, fresh_reason = sm.slot_is_fresh(target)
+        if not fresh:
+            failure_detail = fresh_reason
         if not fresh and reason_is_refreshable(fresh_reason):
             print(
                 f"  Access token stale ({fresh_reason}); "
@@ -391,18 +394,30 @@ def _cmd_switch(args: argparse.Namespace, sm: SubscriptionManager) -> int:
         # is not usable after the flip. ``check_usage`` also returns None when
         # no usage script is configured, which says nothing about the
         # credential, so only warn when a script was actually available to run.
+        #
+        # Use a falsy test, matching ``_execute_switch_decision``: a script that
+        # exits 0 printing ``{}`` yields an empty dict, which is just as useless
+        # a post-flip signal as None. And keep the wording honest — check_usage
+        # also returns None when the *script* failed (not executable, timed out,
+        # non-zero exit, unparseable output), which says nothing about the
+        # credential. Don't send an operator to /login for their own script bug.
         usage_script = sm.config.usage_script
-        if sm.check_usage(no_cache=True) is None and (
+        if not sm.check_usage(no_cache=True) and (
             usage_script is not None and usage_script.exists()
         ):
             print(
-                f"  WARNING: post-switch usage check against {target} failed — "
-                "the switch DID happen and is recorded, but the credential did "
-                "not answer. Verify with `--status --probe`; you may need to "
-                f"re-run /login for {target}.",
+                f"  WARNING: post-switch usage check against {target} returned "
+                "no usage data — the switch DID happen and is recorded. Either "
+                f"the credential did not answer, or {usage_script} itself failed "
+                "(not executable / timed out / bad output). Verify with "
+                f"`--status --probe` before assuming {target} needs a re-login.",
                 file=sys.stderr,
             )
         return 0
+    # Never exit 1 in silence: a bare non-zero exit is the diagnosis-free
+    # failure this command's retry path exists to remove. Say what blocked it.
+    detail = f": {failure_detail}" if failure_detail else ""
+    print(f"Failed to switch to {target}{detail}", file=sys.stderr)
     return 1
 
 

--- a/packages/gptme-subscription/src/gptme_subscription/manager.py
+++ b/packages/gptme-subscription/src/gptme_subscription/manager.py
@@ -344,10 +344,14 @@ class SubscriptionManager:
 
     # ---- Switch ----
 
-    def switch_to(self, sub: str, reason: str, force: bool = False) -> bool:
+    def switch_to(
+        self, sub: str, reason: str, force: bool = False, probe_ok: bool = False
+    ) -> bool:
         """Flip the live symlink to a named slot. Returns True on success."""
         self._last_switch_deferred = False
-        result = self._slot_manager.switch_to(sub, reason, force=force)
+        result = self._slot_manager.switch_to(
+            sub, reason, force=force, probe_ok=probe_ok
+        )
         if not result.ok:
             if result.deferred_locks and not force:
                 self._last_switch_deferred = True

--- a/packages/gptme-subscription/src/gptme_subscription/manager.py
+++ b/packages/gptme-subscription/src/gptme_subscription/manager.py
@@ -121,6 +121,14 @@ class SubscriptionManager:
             # emitted only via ``SlotManager._log``, which discards everything
             # when ``logger is None``. This is the production wiring, so a
             # skipped safety check has to be visible here, not just in tests.
+            # Safe as a bare bound method: ``SlotManager._log`` calls
+            # ``self.logger(msg)`` with exactly one argument, and logging only
+            # applies ``%`` interpolation when record args are present. Percent
+            # signs in slot names and reasons ("100% exhausted") therefore pass
+            # through verbatim. Pinned by
+            # ``test_slot_logger_survives_percent_signs_in_messages`` -- do not
+            # "fix" this into ``logger.warning(fmt, *args)``, which would make
+            # the message a format string and reintroduce the hazard.
             logger=logger.warning,
         )
 

--- a/packages/gptme-subscription/src/gptme_subscription/manager.py
+++ b/packages/gptme-subscription/src/gptme_subscription/manager.py
@@ -234,7 +234,8 @@ class SubscriptionManager:
 
     def slot_has_refresh_token(self, sub: str) -> bool:
         """Return whether a subscription slot can refresh its access token."""
-        return self._slot_manager.slot_has_refresh_token(sub)
+        result: bool = self._slot_manager.slot_has_refresh_token(sub)
+        return result
 
     def slot_credential_is_stale(
         self, sub: str, stale_days: float = 7.0, *, now: datetime | None = None

--- a/packages/gptme-subscription/src/gptme_subscription/manager.py
+++ b/packages/gptme-subscription/src/gptme_subscription/manager.py
@@ -232,6 +232,10 @@ class SubscriptionManager:
         )
         return result
 
+    def slot_has_refresh_token(self, sub: str) -> bool:
+        """Return whether a subscription slot can refresh its access token."""
+        return self._slot_manager.slot_has_refresh_token(sub)
+
     def slot_credential_is_stale(
         self, sub: str, stale_days: float = 7.0, *, now: datetime | None = None
     ) -> tuple[bool, str]:

--- a/packages/gptme-subscription/src/gptme_subscription/manager.py
+++ b/packages/gptme-subscription/src/gptme_subscription/manager.py
@@ -116,6 +116,12 @@ class SubscriptionManager:
             fingerprint_template=config.fingerprint_template,
             lock_guard=self._lock_guard,
             on_switch=self._log_switch,
+            # Without this the SlotManager's audit trail is a no-op: its
+            # ``probe_ok BYPASS`` / ``probe_ok IGNORED`` / refusal lines are
+            # emitted only via ``SlotManager._log``, which discards everything
+            # when ``logger is None``. This is the production wiring, so a
+            # skipped safety check has to be visible here, not just in tests.
+            logger=logger.warning,
         )
 
     # ---- Lock guard (autonomous sessions) ----

--- a/packages/gptme-subscription/tests/test_cli.py
+++ b/packages/gptme-subscription/tests/test_cli.py
@@ -17,6 +17,7 @@ from gptme_subscription.cli import (
     _cmd_switch,
     _execute_switch_decision,
 )
+from gptme_subscription.config import Config
 from gptme_subscription.manager import Decision, SubscriptionManager
 
 
@@ -492,6 +493,115 @@ def test_cmd_switch_unprobeable_failure_is_not_probed(
     probe_mock.assert_not_called()
     assert len(sm.switch_calls) == 1
     assert sm.manual_hold_calls == []
+
+
+def _real_manager(
+    tmp_path: Path, *, usage_script: Path | None = None
+) -> SubscriptionManager:
+    """A real SubscriptionManager over tmp creds/state dirs (never real slots)."""
+    creds_dir = tmp_path / "creds"
+    creds_dir.mkdir()
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    return SubscriptionManager(
+        Config(
+            subscriptions=["bob", "alice"],
+            primary="bob",
+            creds_dir=creds_dir,
+            state_dir=state_dir,
+            usage_script=usage_script,
+        )
+    )
+
+
+def _write_real_slot(sm: SubscriptionManager, slot: str, *, expires_in: float) -> None:
+    sm.config.slot_path(slot).write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "fake-access-token",
+                    "refreshToken": "fake-refresh-token",
+                    "expiresAt": int(
+                        (datetime.now(timezone.utc).timestamp() + expires_in) * 1000
+                    ),
+                }
+            }
+        )
+    )
+
+
+def test_cmd_switch_probe_ok_retry_flips_symlink_end_to_end(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """End-to-end over a REAL SubscriptionManager: the retry must flip the symlink.
+
+    Exercises the CLI → SubscriptionManager → SlotManager seam that the
+    FakeManager-based tests cannot: if ``probe_ok`` were dropped anywhere along
+    the chain, the retry would be refused by the freshness gate and the live
+    symlink would stay on bob.
+    """
+    sm = _real_manager(tmp_path)
+    _write_real_slot(sm, "bob", expires_in=3600)
+    _write_real_slot(sm, "alice", expires_in=-3600)  # access token lapsed
+    sm.config.creds_link.symlink_to(".credentials.json.bob")
+
+    probe_mock = MagicMock(return_value=(None, True, "probe ok"))
+    monkeypatch.setattr("gptme_subscription.cli.probe_credential", probe_mock)
+    args = argparse.Namespace(switch="alice", execute=True, dry_run=False)
+
+    rc = _cmd_switch(args, sm)
+
+    assert rc == 0
+    probe_mock.assert_called_once()
+    assert sm.get_active_subscription() == "alice"
+    assert sm.config.creds_link.resolve() == sm.config.slot_path("alice").resolve()
+
+
+def test_cmd_switch_warns_loudly_when_post_flip_usage_check_fails(
+    tmp_path: Path, capsys
+) -> None:
+    """A failed post-flip usage check must not be silently discarded.
+
+    The switch really happened and is recorded, so the exit code stays 0 — but
+    the operator has to be told the credential did not answer.
+    """
+    # Non-executable script → check_usage() returns None (probe could not run).
+    usage_script = tmp_path / "check-usage.sh"
+    usage_script.write_text("#!/bin/sh\necho '{}'\n")
+    usage_script.chmod(0o644)
+
+    sm = _real_manager(tmp_path, usage_script=usage_script)
+    _write_real_slot(sm, "bob", expires_in=3600)
+    _write_real_slot(sm, "alice", expires_in=3600)
+    sm.config.creds_link.symlink_to(".credentials.json.bob")
+
+    args = argparse.Namespace(switch="alice", execute=True, dry_run=False)
+    rc = _cmd_switch(args, sm)
+
+    assert rc == 0  # the flip did happen — exit 1 would read as "it did not"
+    assert sm.get_active_subscription() == "alice"
+    err = capsys.readouterr().err
+    assert "post-switch usage check against alice failed" in err
+
+
+def test_cmd_switch_no_warning_when_post_flip_usage_check_succeeds(
+    tmp_path: Path, capsys
+) -> None:
+    """A healthy post-flip usage check must stay quiet."""
+    usage_script = tmp_path / "check-usage.sh"
+    usage_script.write_text('#!/bin/sh\necho \'{"seven_day": {"utilization": 0.1}}\'\n')
+    usage_script.chmod(0o755)
+
+    sm = _real_manager(tmp_path, usage_script=usage_script)
+    _write_real_slot(sm, "bob", expires_in=3600)
+    _write_real_slot(sm, "alice", expires_in=3600)
+    sm.config.creds_link.symlink_to(".credentials.json.bob")
+
+    args = argparse.Namespace(switch="alice", execute=True, dry_run=False)
+    rc = _cmd_switch(args, sm)
+
+    assert rc == 0
+    assert "post-switch usage check" not in capsys.readouterr().err
 
 
 def test_cmd_switch_fresh_slot_failure_is_not_probed(

--- a/packages/gptme-subscription/tests/test_cli.py
+++ b/packages/gptme-subscription/tests/test_cli.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 import argparse
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
+from unittest.mock import MagicMock
 
+import pytest
+from credential_slots import slot_is_fresh
 from gptme_subscription.cli import (
     _cmd_evaluate,
     _cmd_switch,
@@ -28,15 +32,19 @@ class FakeManager:
         post_switch_usage: dict[str, object] | None = None,
         decision: Decision | None = None,
         blocked_reason: str = "still blocked",
+        slot_fresh_result: tuple[bool, str] = (True, "ok"),
     ) -> None:
         self.config = SimpleNamespace(
             primary=primary,
             subscriptions=[primary, "alice", "erik"],
             probe_primary_cooldown=1800,
             rate_limit_file=Path("/tmp/nonexistent-rate-limit-flag"),
+            slot_path=lambda name: Path(f"/tmp/fake-slot-{name}.json"),
+            usage_script=None,
         )
         self._active = active
         self._switch_results = list(switch_results or [(True, False)])
+        self._slot_fresh_result = slot_fresh_result
         self._blocked = blocked
         self._initial_usage = (
             initial_usage
@@ -67,6 +75,8 @@ class FakeManager:
         self.detect_external_switch_calls = 0
         self.check_usage_calls: list[bool] = []
         self.switch_calls: list[tuple[str, str]] = []
+        self.switch_probe_ok_flags: list[bool] = []
+        self.slot_is_fresh_calls: list[str] = []
         self.saved_decision: dict[str, object] | None = None
         self.cleared_rebalance = 0
         self.manual_hold_calls: list[str] = []
@@ -96,11 +106,18 @@ class FakeManager:
     def seconds_since_last_primary_departure(self) -> None:
         return None
 
-    def switch_to(self, sub: str, reason: str, force: bool = False) -> bool:
+    def switch_to(
+        self, sub: str, reason: str, force: bool = False, probe_ok: bool = False
+    ) -> bool:
         self.switch_calls.append((sub, reason))
+        self.switch_probe_ok_flags.append(probe_ok)
         ok, deferred = self._switch_results.pop(0)
         self.last_switch_deferred = deferred
         return ok
+
+    def slot_is_fresh(self, sub: str, grace_seconds: int = 300) -> tuple[bool, str]:
+        self.slot_is_fresh_calls.append(sub)
+        return self._slot_fresh_result
 
     def save_rebalance_state(self, decision: dict[str, object]) -> None:
         self.saved_decision = decision
@@ -352,4 +369,150 @@ def test_cmd_switch_dry_run_does_not_switch_or_hold(capsys) -> None:
 
     assert rc == 0
     assert sm.switch_calls == []
+    assert sm.manual_hold_calls == []
+
+
+def _real_fresh_reason(
+    tmp_path: Path, *, expires_in: float | None, write: bool = True
+) -> tuple[bool, str]:
+    """Produce a genuine ``slot_is_fresh`` result for a synthetic slot file.
+
+    Using the real producer (rather than a hand-typed string) keeps these CLI
+    tests honest: if ``slot_is_fresh``'s reason wording changes, the classifier
+    it feeds is exercised against the new wording here too.
+
+    ``write=False`` leaves the file absent (missing-slot reason);
+    ``expires_in=None`` writes a payload with no ``expiresAt`` (unreadable).
+    """
+    path = tmp_path / ".credentials.json.alice"
+    if write:
+        oauth: dict[str, object] = {"accessToken": "fake"}
+        if expires_in is not None:
+            oauth["expiresAt"] = int(
+                (datetime.now(timezone.utc).timestamp() + expires_in) * 1000
+            )
+        path.write_text(json.dumps({"claudeAiOauth": oauth}))
+    return slot_is_fresh(path)
+
+
+@pytest.mark.parametrize(
+    "expires_in,label",
+    [
+        (-3600, "already expired"),
+        # Regression for the grace-window branch: its reason reads
+        # "expire*s* within grace", so a naive `"expired" in reason` check
+        # skipped the probe and failed the operator's --switch outright.
+        (60, "within the 5-min grace window"),
+    ],
+)
+def test_cmd_switch_stale_token_probes_and_retries_with_probe_ok(
+    expires_in: float, label: str, tmp_path: Path, monkeypatch
+) -> None:
+    """A stale-but-refreshable slot is probed, then re-switched with probe_ok=True."""
+    fresh, reason = _real_fresh_reason(tmp_path, expires_in=expires_in)
+    assert fresh is False, f"fixture should be stale ({label})"
+
+    sm = FakeManager(
+        active="bob",
+        switch_results=[(False, False), (True, False)],
+        slot_fresh_result=(fresh, reason),
+    )
+    args = argparse.Namespace(switch="alice", execute=True, dry_run=False)
+
+    probe_mock = MagicMock(return_value=(None, True, "probe ok"))
+    monkeypatch.setattr("gptme_subscription.cli.probe_credential", probe_mock)
+
+    rc = _cmd_switch(args, cast(SubscriptionManager, sm))
+
+    assert rc == 0
+    assert sm.slot_is_fresh_calls == ["alice"]
+    probe_mock.assert_called_once()
+    assert probe_mock.call_args.args[0] == sm.config.slot_path("alice")
+    assert sm.switch_calls == [
+        ("alice", "manual switch via --switch alice"),
+        ("alice", "manual switch via --switch alice (probe_ok)"),
+    ]
+    assert sm.switch_probe_ok_flags == [False, True]
+    assert sm.manual_hold_calls == ["alice"]
+
+
+def test_cmd_switch_stale_token_probe_failure_does_not_retry(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """A failed probe means the refresh token is dead: no retry, rc 1, no hold."""
+    fresh, reason = _real_fresh_reason(tmp_path, expires_in=-3600)
+    sm = FakeManager(
+        active="bob",
+        switch_results=[(False, False)],
+        slot_fresh_result=(fresh, reason),
+    )
+    args = argparse.Namespace(switch="alice", execute=True, dry_run=False)
+
+    monkeypatch.setattr(
+        "gptme_subscription.cli.probe_credential",
+        MagicMock(return_value=(None, False, "probe failed: 401")),
+    )
+
+    rc = _cmd_switch(args, cast(SubscriptionManager, sm))
+
+    assert rc == 1
+    assert len(sm.switch_calls) == 1
+    assert sm.switch_probe_ok_flags == [False]
+    assert sm.manual_hold_calls == []
+    assert "probe failed: 401" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "expires_in,write",
+    [
+        (None, True),  # present but no expiresAt → "unreadable ..."
+        (0, False),  # absent file → "slot missing: ..."
+    ],
+)
+def test_cmd_switch_unprobeable_failure_is_not_probed(
+    expires_in: float | None, write: bool, tmp_path: Path, monkeypatch
+) -> None:
+    """Missing/unreadable slots can't be fixed by a probe — fail hard, don't probe."""
+    fresh, reason = _real_fresh_reason(tmp_path, expires_in=expires_in, write=write)
+    assert fresh is False
+
+    probe_mock = MagicMock(return_value=(None, True, "ok"))
+    monkeypatch.setattr("gptme_subscription.cli.probe_credential", probe_mock)
+
+    sm = FakeManager(
+        active="bob",
+        switch_results=[(False, False)],
+        slot_fresh_result=(fresh, reason),
+    )
+    args = argparse.Namespace(switch="alice", execute=True, dry_run=False)
+
+    rc = _cmd_switch(args, cast(SubscriptionManager, sm))
+
+    assert rc == 1
+    probe_mock.assert_not_called()
+    assert len(sm.switch_calls) == 1
+    assert sm.manual_hold_calls == []
+
+
+def test_cmd_switch_fresh_slot_failure_is_not_probed(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """If the slot is fresh, the switch failed for some other reason — no probe."""
+    fresh, reason = _real_fresh_reason(tmp_path, expires_in=3600)
+    assert fresh is True
+
+    probe_mock = MagicMock(return_value=(None, True, "ok"))
+    monkeypatch.setattr("gptme_subscription.cli.probe_credential", probe_mock)
+
+    sm = FakeManager(
+        active="bob",
+        switch_results=[(False, True)],  # deferred by locks
+        slot_fresh_result=(fresh, reason),
+    )
+    args = argparse.Namespace(switch="alice", execute=True, dry_run=False)
+
+    rc = _cmd_switch(args, cast(SubscriptionManager, sm))
+
+    assert rc == 1
+    probe_mock.assert_not_called()
     assert sm.manual_hold_calls == []

--- a/packages/gptme-subscription/tests/test_cli.py
+++ b/packages/gptme-subscription/tests/test_cli.py
@@ -744,3 +744,73 @@ def test_cmd_switch_warns_when_post_flip_usage_returns_empty_dict(
     assert rc == 0
     assert sm.get_active_subscription() == "alice"
     assert "post-switch usage check against alice" in capsys.readouterr().err
+
+
+def test_cmd_switch_probe_ok_retry_does_not_false_alarm_on_usage_check(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """The probe_ok retry must not warn that the credential "did not answer".
+
+    That path exists precisely to switch into a slot whose access token is still
+    expired but whose refresh token is good. Claude Code refreshes on first use,
+    so the post-flip usage script necessarily queries with a stale token and gets
+    nothing back. Reporting that as a possible bad credential fires a false alarm
+    on *every* successful retry and sends the operator to `--status --probe` (or
+    worse, a re-login) for a slot that is fine.
+    """
+    fresh, reason = _real_fresh_reason(tmp_path, expires_in=-3600)
+    assert fresh is False
+
+    usage_script = tmp_path / "check-usage.sh"
+    usage_script.write_text("#!/bin/sh\necho '{}'\n")
+    usage_script.chmod(0o755)
+
+    sm = FakeManager(
+        active="bob",
+        switch_results=[(False, False), (True, False)],
+        slot_fresh_result=(fresh, reason),
+        post_switch_usage={},
+    )
+    sm.config.usage_script = usage_script
+    args = argparse.Namespace(switch="alice", execute=True, dry_run=False)
+
+    monkeypatch.setattr(
+        "gptme_subscription.cli.probe_credential",
+        MagicMock(return_value=(None, True, "probe ok")),
+    )
+
+    rc = _cmd_switch(args, cast(SubscriptionManager, sm))
+    err = capsys.readouterr().err
+
+    assert rc == 0
+    assert sm.switch_probe_ok_flags == [False, True]
+    # The check still ran and is still reported — we lose no information.
+    assert "no data" in err
+    # But not as a fault, and without sending the operator diagnosing.
+    assert "WARNING" not in err
+    assert "did not answer" not in err
+    assert "re-login" not in err
+    assert "expected here" in err
+
+
+def test_cmd_switch_without_probe_ok_retry_still_warns(tmp_path: Path, capsys) -> None:
+    """A plain switch with no usage data keeps the original warning.
+
+    Pins that the probe_ok carve-out above is scoped to the retry path and did
+    not quietly downgrade the real post-flip credential check.
+    """
+    usage_script = tmp_path / "check-usage.sh"
+    usage_script.write_text("#!/bin/sh\necho '{}'\n")
+    usage_script.chmod(0o755)
+
+    sm = FakeManager(active="bob", switch_results=[(True, False)], post_switch_usage={})
+    sm.config.usage_script = usage_script
+    args = argparse.Namespace(switch="alice", execute=True, dry_run=False)
+
+    rc = _cmd_switch(args, cast(SubscriptionManager, sm))
+    err = capsys.readouterr().err
+
+    assert rc == 0
+    assert sm.switch_probe_ok_flags == [False]
+    assert "WARNING" in err
+    assert "did not answer" in err

--- a/packages/gptme-subscription/tests/test_cli.py
+++ b/packages/gptme-subscription/tests/test_cli.py
@@ -120,6 +120,9 @@ class FakeManager:
         self.slot_is_fresh_calls.append(sub)
         return self._slot_fresh_result
 
+    def slot_has_refresh_token(self, sub: str) -> bool:
+        return True
+
     def save_rebalance_state(self, decision: dict[str, object]) -> None:
         self.saved_decision = decision
 
@@ -655,15 +658,10 @@ def test_cmd_switch_unprobeable_failure_explains_itself(tmp_path: Path, capsys) 
     assert "expiresAt" in err  # the actual reason, not just "it failed"
 
 
-def test_cmd_switch_probe_ok_refusal_explains_itself(
+def test_cmd_switch_without_refresh_token_skips_probe(
     tmp_path: Path, monkeypatch, capsys
 ) -> None:
-    """A probe that succeeds but a switch the SlotManager still refuses must talk.
-
-    Slot has no refresh token, so ``probe_ok`` is ignored inside SlotManager
-    and the switch is refused after the probe already printed "probing...".
-    Previously the command then exited 1 with no explanation at all.
-    """
+    """Do not probe when a stale slot has no token it can refresh with."""
     sm = _real_manager(tmp_path)
     _write_real_slot(sm, "bob", expires_in=3600)
     sm.config.slot_path("alice").write_text(
@@ -679,17 +677,19 @@ def test_cmd_switch_probe_ok_refusal_explains_itself(
         )
     )
     sm.config.creds_link.symlink_to(".credentials.json.bob")
-    monkeypatch.setattr(
-        "gptme_subscription.cli.probe_credential",
-        MagicMock(return_value=(None, True, "probe ok")),
-    )
+    probe = MagicMock(return_value=(None, True, "probe ok"))
+    monkeypatch.setattr("gptme_subscription.cli.probe_credential", probe)
 
     args = argparse.Namespace(switch="alice", execute=True, dry_run=False)
     rc = _cmd_switch(args, sm)
 
     assert rc == 1
     assert sm.get_active_subscription() == "bob"
-    assert "Failed to switch to alice" in capsys.readouterr().err
+    probe.assert_not_called()
+    err = capsys.readouterr().err
+    assert "Failed to switch to alice" in err
+    assert "slot holds no refresh token" in err
+    assert "probing" not in err
 
 
 def test_cmd_switch_warns_when_post_flip_usage_returns_empty_dict(

--- a/packages/gptme-subscription/tests/test_cli.py
+++ b/packages/gptme-subscription/tests/test_cli.py
@@ -396,7 +396,8 @@ def _real_fresh_reason(
                 (datetime.now(timezone.utc).timestamp() + expires_in) * 1000
             )
         path.write_text(json.dumps({"claudeAiOauth": oauth}))
-    return slot_is_fresh(path)
+    result: tuple[bool, str] = slot_is_fresh(path)
+    return result
 
 
 @pytest.mark.parametrize(
@@ -690,6 +691,32 @@ def test_cmd_switch_without_refresh_token_skips_probe(
     assert "Failed to switch to alice" in err
     assert "slot holds no refresh token" in err
     assert "probing" not in err
+
+
+def test_cmd_switch_retry_failure_reports_current_reason(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """A failed probe_ok retry must not report the stale pre-probe reason."""
+    sm = _real_manager(tmp_path)
+    _write_real_slot(sm, "bob", expires_in=3600)
+    _write_real_slot(sm, "alice", expires_in=-3600)
+    sm.config.creds_link.symlink_to(".credentials.json.bob")
+
+    def probe_then_remove(*args, **kwargs):
+        sm.config.slot_path("alice").unlink()
+        return None, True, "probe ok"
+
+    monkeypatch.setattr("gptme_subscription.cli.probe_credential", probe_then_remove)
+
+    args = argparse.Namespace(switch="alice", execute=True, dry_run=False)
+    rc = _cmd_switch(args, sm)
+
+    assert rc == 1
+    assert sm.get_active_subscription() == "bob"
+    err = capsys.readouterr().err
+    failure_line = err.strip().splitlines()[-1]
+    assert failure_line.startswith("Failed to switch to alice: slot missing")
+    assert "expired 60m ago" not in failure_line
 
 
 def test_cmd_switch_warns_when_post_flip_usage_returns_empty_dict(

--- a/packages/gptme-subscription/tests/test_cli.py
+++ b/packages/gptme-subscription/tests/test_cli.py
@@ -563,7 +563,9 @@ def test_cmd_switch_warns_loudly_when_post_flip_usage_check_fails(
     """A failed post-flip usage check must not be silently discarded.
 
     The switch really happened and is recorded, so the exit code stays 0 — but
-    the operator has to be told the credential did not answer.
+    the operator has to be told no usage data came back. Note the failure here
+    is the *script* (non-executable), not the credential, so the message must
+    not assert the credential is dead or demand a re-login.
     """
     # Non-executable script → check_usage() returns None (probe could not run).
     usage_script = tmp_path / "check-usage.sh"
@@ -581,7 +583,9 @@ def test_cmd_switch_warns_loudly_when_post_flip_usage_check_fails(
     assert rc == 0  # the flip did happen — exit 1 would read as "it did not"
     assert sm.get_active_subscription() == "alice"
     err = capsys.readouterr().err
-    assert "post-switch usage check against alice failed" in err
+    assert "post-switch usage check against alice returned no usage data" in err
+    # The script is what broke — don't tell the operator to re-login blindly.
+    assert str(usage_script) in err
 
 
 def test_cmd_switch_no_warning_when_post_flip_usage_check_succeeds(
@@ -626,3 +630,90 @@ def test_cmd_switch_fresh_slot_failure_is_not_probed(
     assert rc == 1
     probe_mock.assert_not_called()
     assert sm.manual_hold_calls == []
+
+
+def test_cmd_switch_unprobeable_failure_explains_itself(tmp_path: Path, capsys) -> None:
+    """A non-refreshable failure must not exit 1 in silence.
+
+    The whole point of this command's retry path is to remove the
+    diagnosis-free ``--switch X --execute`` → exit 1. A corrupt slot payload
+    is not probeable, so no probe message is printed — without an explicit
+    failure line the operator gets zero output and a bare non-zero exit.
+    """
+    sm = _real_manager(tmp_path)
+    _write_real_slot(sm, "bob", expires_in=3600)
+    sm.config.slot_path("alice").write_text("{ truncated json")
+    sm.config.creds_link.symlink_to(".credentials.json.bob")
+
+    args = argparse.Namespace(switch="alice", execute=True, dry_run=False)
+    rc = _cmd_switch(args, sm)
+
+    assert rc == 1
+    assert sm.get_active_subscription() == "bob"  # symlink untouched
+    err = capsys.readouterr().err
+    assert "Failed to switch to alice" in err
+    assert "expiresAt" in err  # the actual reason, not just "it failed"
+
+
+def test_cmd_switch_probe_ok_refusal_explains_itself(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """A probe that succeeds but a switch the SlotManager still refuses must talk.
+
+    Slot has no refresh token, so ``probe_ok`` is ignored inside SlotManager
+    and the switch is refused after the probe already printed "probing...".
+    Previously the command then exited 1 with no explanation at all.
+    """
+    sm = _real_manager(tmp_path)
+    _write_real_slot(sm, "bob", expires_in=3600)
+    sm.config.slot_path("alice").write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "fake",
+                    "expiresAt": int(
+                        (datetime.now(timezone.utc).timestamp() - 3600) * 1000
+                    ),
+                }
+            }
+        )
+    )
+    sm.config.creds_link.symlink_to(".credentials.json.bob")
+    monkeypatch.setattr(
+        "gptme_subscription.cli.probe_credential",
+        MagicMock(return_value=(None, True, "probe ok")),
+    )
+
+    args = argparse.Namespace(switch="alice", execute=True, dry_run=False)
+    rc = _cmd_switch(args, sm)
+
+    assert rc == 1
+    assert sm.get_active_subscription() == "bob"
+    assert "Failed to switch to alice" in capsys.readouterr().err
+
+
+def test_cmd_switch_warns_when_post_flip_usage_returns_empty_dict(
+    tmp_path: Path, capsys
+) -> None:
+    """An empty usage payload is as useless a post-flip signal as None.
+
+    ``check_usage`` returns ``{}`` (not None) for a script that exits 0 printing
+    ``{}``, so an ``is None`` test lets a genuinely empty response through
+    silently — while ``_execute_switch_decision`` treats the same value as a
+    failure via ``if not new_usage``.
+    """
+    usage_script = tmp_path / "check-usage.sh"
+    usage_script.write_text("#!/bin/sh\necho '{}'\n")
+    usage_script.chmod(0o755)
+
+    sm = _real_manager(tmp_path, usage_script=usage_script)
+    _write_real_slot(sm, "bob", expires_in=3600)
+    _write_real_slot(sm, "alice", expires_in=3600)
+    sm.config.creds_link.symlink_to(".credentials.json.bob")
+
+    args = argparse.Namespace(switch="alice", execute=True, dry_run=False)
+    rc = _cmd_switch(args, sm)
+
+    assert rc == 0
+    assert sm.get_active_subscription() == "alice"
+    assert "post-switch usage check against alice" in capsys.readouterr().err

--- a/packages/gptme-subscription/tests/test_subscription_manager.py
+++ b/packages/gptme-subscription/tests/test_subscription_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import multiprocessing
 import os
 import time
@@ -283,6 +284,70 @@ def test_switch_to_probe_ok_still_refused_without_refresh_token(
     sm = _make_manager(tmp_path)
     _write_oauth_slot(sm, "alice", expires_in_seconds=3600)
     _write_oauth_slot(sm, "bob", expires_in_seconds=-3600, refresh_token=None)
+    sm.config.creds_link.symlink_to(".credentials.json.alice")
+
+    assert (
+        sm.switch_to("bob", "manual switch (probe_ok)", force=True, probe_ok=True)
+        is False
+    )
+    assert sm.get_active_subscription() == "alice"
+
+
+def test_probe_ok_bypass_is_logged_in_production_wiring(tmp_path: Path, caplog) -> None:
+    """The bypass audit trail must survive the real SubscriptionManager wiring.
+
+    ``SlotManager._log`` is a no-op when ``SlotManager.logger is None``, so the
+    ``probe_ok BYPASS`` line only exists in tests that assign ``mgr.logger``
+    themselves. If ``SubscriptionManager`` builds its SlotManager without a
+    logger, the one production path that skips the expiry gate does so with no
+    trace anywhere — exactly what an operator auditing a 401 needs to see.
+    """
+    sm = _make_manager(tmp_path)
+    _write_oauth_slot(sm, "alice", expires_in_seconds=3600)
+    _write_oauth_slot(sm, "bob", expires_in_seconds=-3600)
+    sm.config.creds_link.symlink_to(".credentials.json.alice")
+
+    with caplog.at_level(logging.WARNING, logger="gptme_subscription.manager"):
+        assert sm.switch_to("bob", "manual (probe_ok)", force=True, probe_ok=True)
+
+    assert any("probe_ok BYPASS" in record.getMessage() for record in caplog.records)
+
+
+def test_switch_refusal_is_logged_in_production_wiring(tmp_path: Path, caplog) -> None:
+    """A refused switch must also leave a trace through the real wiring."""
+    sm = _make_manager(tmp_path)
+    _write_oauth_slot(sm, "alice", expires_in_seconds=3600)
+    _write_oauth_slot(sm, "bob", expires_in_seconds=-3600)
+    sm.config.creds_link.symlink_to(".credentials.json.alice")
+
+    with caplog.at_level(logging.WARNING, logger="gptme_subscription.manager"):
+        assert sm.switch_to("bob", "manual", force=True) is False
+
+    assert any(
+        "refusing to switch to bob" in record.getMessage() for record in caplog.records
+    )
+
+
+def test_switch_to_probe_ok_refused_for_slot_without_expiresat(
+    tmp_path: Path,
+) -> None:
+    """probe_ok must not push a malformed slot onto the live symlink.
+
+    A refresh token alone is not enough: a payload missing ``expiresAt`` fails
+    freshness as "unreadable", which no refresh can repair.
+    """
+    sm = _make_manager(tmp_path)
+    _write_oauth_slot(sm, "alice", expires_in_seconds=3600)
+    sm.config.slot_path("bob").write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "a",
+                    "refreshToken": "fake-refresh-token",
+                }
+            }
+        )
+    )
     sm.config.creds_link.symlink_to(".credentials.json.alice")
 
     assert (

--- a/packages/gptme-subscription/tests/test_subscription_manager.py
+++ b/packages/gptme-subscription/tests/test_subscription_manager.py
@@ -233,6 +233,65 @@ def _write_cred(sm: SubscriptionManager, slot: str, *, age_days: float) -> None:
     os.utime(path, (old_ts, old_ts))
 
 
+def _write_oauth_slot(
+    sm: SubscriptionManager,
+    slot: str,
+    *,
+    expires_in_seconds: float,
+    refresh_token: str | None = "fake-refresh-token",
+) -> None:
+    """Write a real claudeAiOauth slot payload for ``slot``."""
+    oauth: dict[str, object] = {
+        "accessToken": "fake-access-token",
+        "expiresAt": int(
+            (datetime.now(timezone.utc).timestamp() + expires_in_seconds) * 1000
+        ),
+    }
+    if refresh_token is not None:
+        oauth["refreshToken"] = refresh_token
+    sm.config.slot_path(slot).write_text(json.dumps({"claudeAiOauth": oauth}))
+
+
+def test_switch_to_forwards_probe_ok_through_to_slot_manager(tmp_path: Path) -> None:
+    """The SubscriptionManager → SlotManager seam must carry ``probe_ok``.
+
+    The CLI probe-and-retry path is otherwise only exercised against a fake
+    manager that merely records the kwarg, so a wrapper that dropped or
+    mis-forwarded ``probe_ok`` would leave the retry silently refused by the
+    freshness gate with every test still green. This drives real slot files
+    and asserts the symlink actually flips.
+    """
+    sm = _make_manager(tmp_path)
+    _write_oauth_slot(sm, "alice", expires_in_seconds=3600)
+    _write_oauth_slot(sm, "bob", expires_in_seconds=-3600)  # access token lapsed
+    sm.config.creds_link.symlink_to(".credentials.json.alice")
+
+    # Without probe_ok the expiry gate refuses — even under force.
+    assert sm.switch_to("bob", "manual switch", force=True) is False
+    assert sm.get_active_subscription() == "alice"
+
+    # With probe_ok the gate is bypassed and the live symlink really moves.
+    assert sm.switch_to("bob", "manual switch (probe_ok)", force=True, probe_ok=True)
+    assert sm.get_active_subscription() == "bob"
+    assert sm.config.creds_link.resolve() == sm.config.slot_path("bob").resolve()
+
+
+def test_switch_to_probe_ok_still_refused_without_refresh_token(
+    tmp_path: Path,
+) -> None:
+    """probe_ok must not carry a slot CC could never auto-refresh."""
+    sm = _make_manager(tmp_path)
+    _write_oauth_slot(sm, "alice", expires_in_seconds=3600)
+    _write_oauth_slot(sm, "bob", expires_in_seconds=-3600, refresh_token=None)
+    sm.config.creds_link.symlink_to(".credentials.json.alice")
+
+    assert (
+        sm.switch_to("bob", "manual switch (probe_ok)", force=True, probe_ok=True)
+        is False
+    )
+    assert sm.get_active_subscription() == "alice"
+
+
 def test_evaluate_records_observation_for_active_primary(tmp_path: Path) -> None:
     """``evaluate`` must record the live observation for the active slot even
     when it is the primary. Previously gated on ``active != primary``, which

--- a/packages/gptme-subscription/tests/test_subscription_manager.py
+++ b/packages/gptme-subscription/tests/test_subscription_manager.py
@@ -84,9 +84,9 @@ def test_check_usage_stale_cache_fallback_on_script_failure(tmp_path: Path) -> N
     result = sm.check_usage(stale_cache=stale_cache)
     assert result is not None
     assert result["seven_day"]["utilization"] == pytest.approx(0.3)
-    assert result.get("_stale") is True, (
-        "stale fallback must be flagged with _stale=True"
-    )
+    assert (
+        result.get("_stale") is True
+    ), "stale fallback must be flagged with _stale=True"
 
 
 def test_check_usage_stale_cache_rejected_when_too_old(tmp_path: Path) -> None:
@@ -402,9 +402,9 @@ def test_evaluate_does_not_record_observation_for_stale_usage(
 
     sm.evaluate(usage, "bob")
 
-    assert not sm.config.reset_times_file.exists(), (
-        "record_sub_reset_time must not be called when usage._stale=True"
-    )
+    assert (
+        not sm.config.reset_times_file.exists()
+    ), "record_sub_reset_time must not be called when usage._stale=True"
 
 
 def test_evaluate_skips_stale_fallback_picks_fresh(tmp_path: Path) -> None:

--- a/packages/gptme-subscription/tests/test_subscription_manager.py
+++ b/packages/gptme-subscription/tests/test_subscription_manager.py
@@ -84,9 +84,9 @@ def test_check_usage_stale_cache_fallback_on_script_failure(tmp_path: Path) -> N
     result = sm.check_usage(stale_cache=stale_cache)
     assert result is not None
     assert result["seven_day"]["utilization"] == pytest.approx(0.3)
-    assert (
-        result.get("_stale") is True
-    ), "stale fallback must be flagged with _stale=True"
+    assert result.get("_stale") is True, (
+        "stale fallback must be flagged with _stale=True"
+    )
 
 
 def test_check_usage_stale_cache_rejected_when_too_old(tmp_path: Path) -> None:
@@ -402,9 +402,9 @@ def test_evaluate_does_not_record_observation_for_stale_usage(
 
     sm.evaluate(usage, "bob")
 
-    assert (
-        not sm.config.reset_times_file.exists()
-    ), "record_sub_reset_time must not be called when usage._stale=True"
+    assert not sm.config.reset_times_file.exists(), (
+        "record_sub_reset_time must not be called when usage._stale=True"
+    )
 
 
 def test_evaluate_skips_stale_fallback_picks_fresh(tmp_path: Path) -> None:
@@ -664,3 +664,28 @@ def test_record_manual_switch_hold_persists_state(tmp_path: Path) -> None:
     decision = sm.evaluate(_healthy_usage(), "alice", now=now, rebalance_state=loaded)
     assert decision.action == "stay"
     assert decision.mode == "manual-switch-hold"
+
+
+def test_slot_logger_survives_percent_signs_in_messages(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A percent sign in a slot audit line must not kill the switch.
+
+    ``SlotManager._log`` calls ``self.logger(msg)`` with a single, already
+    interpolated string, and ``logging`` only applies ``%`` formatting when a
+    record carries args. So the current wiring is safe, and this test pins that:
+    it fails the moment someone rewrites the call as
+    ``logger.warning(fmt, *args)``, which would turn slot names and reasons into
+    format strings and raise ValueError mid-switch -- leaving ``switch_to`` to
+    die with a traceback instead of returning a SwitchResult.
+    """
+    sm = _make_manager(tmp_path)
+    logger_fn = sm._slot_manager.logger
+    assert logger_fn is not None
+
+    with caplog.at_level(logging.WARNING):
+        # Would raise "ValueError: unsupported format character" if the message
+        # were being interpolated as a format string.
+        logger_fn("probe_ok BYPASS for slot bob%: 100% exhausted")
+
+    assert "100% exhausted" in caplog.text


### PR DESCRIPTION
## Problem

`--switch <slot> --execute` silently fails (exit 1) when the slot's access token
has lapsed, even when `--check-auth --probe` confirms the refresh token is valid
and the slot would work fine — CC auto-refreshes expired access tokens on first use.

**Observed in operator session ef48 (2026-08-07):**
- `--check-auth --probe` showed: `[stale] erik (access token lapsed 2270m ago — will refresh on next use) [max] probe=ok`
- `--switch erik --execute` → silent exit 1, symlink not changed

Root cause: `SlotManager.switch_to()` checks `expiresAt` and refuses any slot
past that timestamp, regardless of `force` — "known-bad credential" guard. But
an expired **access** token with a valid **refresh** token is not a dead credential.

## Fix

Add `probe_ok: bool = False` to `SlotManager.switch_to()` and
`SubscriptionManager.switch_to()`. When `probe_ok=True`, the offline `expiresAt`
freshness check is skipped. Callers are responsible for only passing `probe_ok=True`
after a successful online probe.

In `_cmd_switch()` (the `--switch --execute` path), when a switch is refused for
an expired access token, automatically probe the slot and retry with `probe_ok=True`
if the probe succeeds. This makes `--switch erik --execute` transparent for the
common case of a stale-but-refreshable slot.

## Test plan

- [x] `test_probe_ok_bypasses_expiry_check` — expired slot + `probe_ok=True` → switch succeeds
- [x] `test_probe_ok_still_rejects_missing_slot` — missing slot file + `probe_ok=True` → still rejected
- [x] `test_expired_target_rejected_even_with_force` — existing test unchanged (force alone still rejects)
- [x] All 206 tests pass (80 credential-slots, 126 gptme-subscription)
- [x] mypy clean on both packages