### PR TITLE
fix(pm): act on our own AI reviewer's findings instead of silencing them

### DIFF
--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -111,8 +111,9 @@ set -euo pipefail
 # GitHub App, so without this its reviews are indistinguishable from the agent
 # talking to itself and get silenced by the self-trigger guard. Matches both
 # the summary comment (`<!-- bob-ai-review {...} -->`) and inline findings
-# (`<!-- bob-ai-review-finding -->`).
-AI_REVIEW_MARKER="<!-- bob-ai-review"
+# (`<!-- bob-ai-review-finding -->`). The reviewer stamps summary comments at
+# the end, so this marker cannot be anchored to the first line.
+AI_REVIEW_MARKER_RE='^<!-- bob-ai-review(-finding| \{.*\}) -->$'
 
 # --- Parse args ---
 AUTHOR=""
@@ -493,7 +494,17 @@ has_actionable_update() {
     # PM dispatches -> push -> re-review), and it terminates the same way, via
     # the fingerprint dedup below plus the per-PR attempt counters. It is
     # bounded by the PR being fixed or merged, not by the reviewer's identity.
-    if [ "$last_actor" = "$AUTHOR" ] && ! echo "$last_body" | grep -q "$AI_REVIEW_MARKER"; then
+    #
+    # The marker must occupy a complete line. A normal reply that merely quotes
+    # or inline-copies the marker remains self-chatter; the reviewer itself emits
+    # the marker as a standalone HTML-comment line. The regex accepts only the
+    # two formats emitted by the reviewer: `-finding` or a JSON state object.
+    local is_ai_review=1
+    if [ "$last_actor" = "$AUTHOR" ] && printf '%s\n' "$last_body" \
+        | grep -qE "$AI_REVIEW_MARKER_RE"; then
+        is_ai_review=0
+    fi
+    if [ "$last_actor" = "$AUTHOR" ] && [ "$is_ai_review" -ne 0 ]; then
         return 1
     fi
 

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -511,7 +511,7 @@ has_actionable_update() {
     # Skip if the comment/review @-mentions someone else but NOT the AUTHOR.
     # This catches cases like "@greptileai review" or "@someone what do you think?"
     # where the commenter is clearly addressing someone other than the agent.
-    if [ -n "$last_body" ]; then
+    if [ "$is_ai_review" -ne 0 ] && [ -n "$last_body" ]; then
         local mentions_anyone mentions_author
         # Match GitHub-style @mentions (start of line or after whitespace).
         # Avoids false positives from emails like user@example.com.

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -106,6 +106,14 @@
 
 set -euo pipefail
 
+# Marker stamped on every comment by Bob's self-hosted AI reviewer
+# (ErikBjare/bob#1122). It posts through Bob's user account rather than a
+# GitHub App, so without this its reviews are indistinguishable from the agent
+# talking to itself and get silenced by the self-trigger guard. Matches both
+# the summary comment (`<!-- bob-ai-review {...} -->`) and inline findings
+# (`<!-- bob-ai-review-finding -->`).
+AI_REVIEW_MARKER="<!-- bob-ai-review"
+
 # --- Parse args ---
 AUTHOR=""
 ORG=""
@@ -467,8 +475,25 @@ has_actionable_update() {
     # If no activity found, this might be a push — allow it
     [ -z "$last_actor" ] && return 0
 
-    # Skip if the last actor is the author (self-triggered update)
-    if [ "$last_actor" = "$AUTHOR" ]; then
+    # Skip if the last actor is the author (self-triggered update).
+    #
+    # EXCEPTION: Bob's self-hosted AI reviewer (ErikBjare/bob#1122) posts its
+    # findings through Bob's *user* account, not a GitHub App, so its reviews
+    # look exactly like the agent talking to itself and were silenced here.
+    # Greptile appears ~70 times in this file; the replacement appeared zero
+    # times, so PM listened to the reviewer we stopped paying for and ignored
+    # the one we run. Reviews were posted and then dropped on the floor.
+    #
+    # Those comments carry a machine marker, so they are distinguishable from
+    # Bob's genuine human-directed comments — which must STILL be silenced,
+    # since those are the actual self-trigger loop this guard exists to stop.
+    # Matching the marker rather than the login is what keeps both properties.
+    #
+    # Loop safety: this is the same cycle Greptile already drives (review ->
+    # PM dispatches -> push -> re-review), and it terminates the same way, via
+    # the fingerprint dedup below plus the per-PR attempt counters. It is
+    # bounded by the PR being fixed or merged, not by the reviewer's identity.
+    if [ "$last_actor" = "$AUTHOR" ] && ! echo "$last_body" | grep -q "$AI_REVIEW_MARKER"; then
         return 1
     fi
 

--- a/tests/test_activity_gate_ai_review_actionable.py
+++ b/tests/test_activity_gate_ai_review_actionable.py
@@ -1,0 +1,77 @@
+"""PM must act on our own AI reviewer's findings, not silence them as self-chatter.
+
+`has_actionable_update` skips an update when the last actor is $AUTHOR, to stop
+the agent re-triggering itself. Bob's self-hosted AI reviewer (ErikBjare/bob#1122)
+posts through Bob's *user* account rather than a GitHub App, so its reviews hit
+that guard and were dropped: PM listened to Greptile (~70 references in the gate)
+and ignored the replacement we actually run (zero references).
+
+The distinguishing signal is the machine marker on the comment body. Bob's
+genuine human-directed comments carry no marker and must STILL be silenced —
+that is the real self-trigger loop this guard exists to stop.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+GATE = Path(__file__).resolve().parents[1] / "scripts" / "github" / "activity-gate.sh"
+BOT = "TimeToBuildBob"
+MARKER = "<!-- bob-ai-review"
+
+
+def _extract_function(name: str) -> str:
+    src = GATE.read_text()
+    start = src.index(f"{name}() {{")
+    rest = src[start:]
+    return rest[: rest.index("\n}\n") + len("\n}\n")]
+
+
+def _actionable(body: str, login: str) -> bool:
+    """Run has_actionable_update against a PR whose latest comment is (login, body)."""
+    pr = {
+        "comments": [
+            {
+                "author": {"login": login},
+                "createdAt": "2026-08-08T10:00:00Z",
+                "body": body,
+            }
+        ],
+        "latestReviews": [],
+    }
+    script = f"""
+set -uo pipefail
+AUTHOR={BOT}
+AI_REVIEW_MARKER='{MARKER}'
+{_extract_function("has_actionable_update")}
+if has_actionable_update '{json.dumps(pr)}'; then echo YES; else echo NO; fi
+"""
+    proc = subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, timeout=30
+    )
+    return "YES" in proc.stdout
+
+
+def test_ai_review_summary_is_actionable():
+    """The regression: our reviewer's findings must reach PM."""
+    assert _actionable(f'{MARKER} {{"sha": "abc"}} -->\n\n3 findings', BOT)
+
+
+def test_ai_review_inline_finding_is_actionable():
+    assert _actionable(f"{MARKER}-finding -->\nP1 — the hash ignores .state", BOT)
+
+
+def test_bobs_own_plain_comment_is_still_silenced():
+    """The loop guard must survive — this is why we match the marker, not the login."""
+    assert not _actionable("Pushed a fix, rerunning CI.", BOT)
+
+
+def test_human_comment_still_actionable():
+    assert _actionable("this looks wrong to me", "ErikBjare")
+
+
+def test_greptile_review_still_actionable():
+    """Do not regress the reviewer PM already listened to."""
+    assert _actionable("<h3>Security Review</h3> looks fine", "greptile-apps[bot]")

--- a/tests/test_activity_gate_ai_review_actionable.py
+++ b/tests/test_activity_gate_ai_review_actionable.py
@@ -44,7 +44,7 @@ def _actionable(body: str, login: str) -> bool:
     script = f"""
 set -uo pipefail
 AUTHOR={BOT}
-AI_REVIEW_MARKER='{MARKER}'
+AI_REVIEW_MARKER_RE='^<!-- bob-ai-review(-finding| \\{{.*\\}}) -->$'
 {_extract_function("has_actionable_update")}
 if has_actionable_update '{json.dumps(pr)}'; then echo YES; else echo NO; fi
 """
@@ -56,7 +56,7 @@ if has_actionable_update '{json.dumps(pr)}'; then echo YES; else echo NO; fi
 
 def test_ai_review_summary_is_actionable():
     """The regression: our reviewer's findings must reach PM."""
-    assert _actionable(f'{MARKER} {{"sha": "abc"}} -->\n\n3 findings', BOT)
+    assert _actionable(f'3 findings\n\n{MARKER} {{"sha": "abc"}} -->', BOT)
 
 
 def test_ai_review_inline_finding_is_actionable():
@@ -66,6 +66,19 @@ def test_ai_review_inline_finding_is_actionable():
 def test_bobs_own_plain_comment_is_still_silenced():
     """The loop guard must survive — this is why we match the marker, not the login."""
     assert not _actionable("Pushed a fix, rerunning CI.", BOT)
+
+
+def test_bobs_reply_quoting_marker_inline_is_still_silenced():
+    assert not _actionable(f"Fixed the parsing of `{MARKER}` and pushed.", BOT)
+
+
+def test_bobs_reply_quoting_marker_line_is_still_silenced():
+    quoted = f"> {MARKER}-finding -->\n> P1 — stale state\n\nFixed in abc123."
+    assert not _actionable(quoted, BOT)
+
+
+def test_similar_standalone_marker_is_still_silenced():
+    assert not _actionable(f"Status update\n\n{MARKER}-manual -->", BOT)
 
 
 def test_human_comment_still_actionable():

--- a/tests/test_activity_gate_ai_review_actionable.py
+++ b/tests/test_activity_gate_ai_review_actionable.py
@@ -22,29 +22,50 @@ BOT = "TimeToBuildBob"
 MARKER = "<!-- bob-ai-review"
 
 
+def _gate_source() -> str:
+    return GATE.read_text()
+
+
 def _extract_function(name: str) -> str:
-    src = GATE.read_text()
+    src = _gate_source()
     start = src.index(f"{name}() {{")
     rest = src[start:]
     return rest[: rest.index("\n}\n") + len("\n}\n")]
 
 
-def _actionable(body: str, login: str) -> bool:
-    """Run has_actionable_update against a PR whose latest comment is (login, body)."""
-    pr = {
-        "comments": [
-            {
-                "author": {"login": login},
-                "createdAt": "2026-08-08T10:00:00Z",
-                "body": body,
-            }
-        ],
-        "latestReviews": [],
+def _extract_shell_assignment(name: str) -> str:
+    prefix = f"{name}="
+    line = next(line for line in _gate_source().splitlines() if line.startswith(prefix))
+    return line
+
+
+def _actionable(
+    body: str,
+    login: str,
+    *,
+    activity_type: str = "comment",
+) -> bool:
+    """Run has_actionable_update with the supplied comment or review activity."""
+    activity = {
+        "author": {"login": login},
+        "body": body,
     }
+    if activity_type == "comment":
+        activity["createdAt"] = "2026-08-08T10:00:00Z"
+        comments = [activity]
+        reviews = []
+    elif activity_type == "review":
+        activity["submittedAt"] = "2026-08-08T10:00:00Z"
+        comments = []
+        reviews = [activity]
+    else:
+        raise ValueError(f"unsupported activity type: {activity_type}")
+
+    pr = {"comments": comments, "latestReviews": reviews}
     script = f"""
 set -uo pipefail
 AUTHOR={BOT}
-AI_REVIEW_MARKER_RE='^<!-- bob-ai-review(-finding| \\{{.*\\}}) -->$'
+{_extract_shell_assignment("AI_REVIEW_MARKER_RE")}
 {_extract_function("has_actionable_update")}
 if has_actionable_update '{json.dumps(pr)}'; then echo YES; else echo NO; fi
 """
@@ -61,6 +82,20 @@ def test_ai_review_summary_is_actionable():
 
 def test_ai_review_inline_finding_is_actionable():
     assert _actionable(f"{MARKER}-finding -->\nP1 — the hash ignores .state", BOT)
+
+
+def test_ai_review_finding_in_latest_review_is_actionable():
+    assert _actionable(
+        f"{MARKER}-finding -->\nP1 — the hash ignores .state",
+        BOT,
+        activity_type="review",
+    )
+
+
+def test_ai_review_mentioning_maintainer_is_still_actionable():
+    assert _actionable(
+        f"{MARKER}-finding -->\nP1 — @ErikBjare should verify this path", BOT
+    )
 
 
 def test_bobs_own_plain_comment_is_still_silenced():


### PR DESCRIPTION
## Problem (spotted by Erik)

PM is tuned for Greptile and was never taught about the replacement. In `activity-gate.sh`: `greptile` appears **~70 times**, `bob-ai-review` appeared **zero times**.

Bob's self-hosted reviewer (ErikBjare/bob#1122) posts through Bob's **user** account, not a GitHub App. So `has_actionable_update`'s self-trigger guard — *last actor is $AUTHOR* — classified every AI review as the agent talking to itself and dropped it.

**Net effect: PM listened to the reviewer we stopped paying for, and ignored the one we run.** Reviews were posted and went nowhere.

## Fix

Exempt comments carrying `<!-- bob-ai-review` from the self-skip.

Keyed on the **marker, not the login**, deliberately: Bob's genuine human-directed comments carry no marker and must **still** be silenced — those are the actual self-trigger loop this guard exists to stop.

**Loop safety**: this is the same cycle Greptile already drives (review → dispatch → push → re-review), terminating the same way via the existing fingerprint dedup and per-PR attempt counters. Bounded by the PR being fixed or merged, not by the reviewer's identity.

## Tests

5 new. The two AI-review cases **fail against the previous guard**; the loop guard (Bob's plain comment still silenced), human comments, and Greptile reviews are all pinned so nothing regresses.