### PR TITLE
fix(self-merge): block when our AI reviewer explicitly abstained

### DIFF
--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -733,8 +733,10 @@ def ai_review_abstained(repo: str, pr_number: int) -> bool | None:
         [
             "api",
             f"repos/{repo}/issues/{pr_number}/comments?per_page=100",
+            "--paginate",
+            "--slurp",
             "--jq",
-            f'[.[] | select(.body | contains("{AI_REVIEW_COMMENT_MARKER}"))]'
+            f'[.[][] | select(.body | contains("{AI_REVIEW_COMMENT_MARKER}"))]'
             ' | if length == 0 then "__NO_AI_REVIEW__" else last.body end',
         ],
         timeout=30,

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -57,8 +57,6 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
-import base64
-import binascii
 import json
 import os
 import re
@@ -718,57 +716,53 @@ def fetch_greptile_status(
 # Greptile, which is Erik's open decision and not this gate's to make. Nothing
 # here touches the existing `Greptile review not found` blocker.
 #
-# Matching is on the reviewer's own abstention text rather than re-deriving
-# "is this diff submodule-only?" here: the reviewer already made that call and
-# encoded it in the comment, and a second implementation would drift from the
-# first. The coupling to prose is the price; a structured field in the
-# `bob-ai-review` JSON marker would be strictly better and is worth adding
-# upstream, at which point this should read that instead.
-#
-# Selecting on the HTML marker rather than the visible heading avoids matching a
-# human comment that merely *quotes* the abstention.
+# The reviewer encodes abstention as `score: null` in its structured marker.
+# Reading that field avoids coupling this safety gate to human-facing prose.
 AI_REVIEW_COMMENT_MARKER = "<!-- bob-ai-review {"
-AI_REVIEW_ABSTENTION_PHRASES = ("submodule pointer change only", "not reviewed")
+AI_REVIEW_MARKER_RE = re.compile(r"<!-- bob-ai-review (\{.*?\}) -->", re.DOTALL)
 
 
-def ai_review_abstained(repo: str, pr_number: int) -> bool:
-    """Whether our AI reviewer's LATEST review explicitly declined to review.
+def ai_review_abstained(repo: str, pr_number: int) -> bool | None:
+    """Whether our AI reviewer's latest review explicitly declined to review.
 
-    Only the latest AI-review comment counts. An older abstention followed by a
-    real review means the diff outgrew the submodule-only shape and *was*
-    assessed; blocking on the stale one would be wrong.
-
-    Fails OPEN on an API or decode error. This is a supplementary blocker: the
-    Greptile gates are independent and already fail closed when review data
-    cannot be fetched, so a transient error here cannot open a hole on its own.
+    ``None`` means the review state could not be determined and callers must
+    fail closed. Only the latest marker comment counts: a later real review
+    supersedes an earlier abstention.
     """
     raw = run_gh(
         [
             "api",
-            f"repos/{repo}/issues/{pr_number}/comments",
-            "--paginate",
-            # base64 so a comment body's own newlines cannot be mistaken for a
-            # record separator — these bodies are multi-line markdown.
+            f"repos/{repo}/issues/{pr_number}/comments?per_page=100",
             "--jq",
-            f'.[] | select(.body | contains("{AI_REVIEW_COMMENT_MARKER}"))'
-            " | .body | @base64",
+            f'[.[] | select(.body | contains("{AI_REVIEW_COMMENT_MARKER}"))]'
+            ' | if length == 0 then "__NO_AI_REVIEW__" else last.body end',
         ],
         timeout=30,
     )
     if not raw or not raw.strip():
+        return None
+    if raw == "__NO_AI_REVIEW__":
         return False
 
-    encoded = [line for line in raw.splitlines() if line.strip()]
-    if not encoded:
-        return False
-
+    match = AI_REVIEW_MARKER_RE.search(raw)
+    if match is None:
+        return None
     try:
-        latest = base64.b64decode(encoded[-1]).decode("utf-8", errors="replace")
-    except (ValueError, binascii.Error):
-        return False
+        marker = json.loads(match.group(1))
+    except (json.JSONDecodeError, TypeError):
+        return None
 
-    lowered = latest.lower()
-    return all(phrase in lowered for phrase in AI_REVIEW_ABSTENTION_PHRASES)
+    if "score" in marker:
+        score = marker["score"]
+        if score is None:
+            return True
+        if isinstance(score, int) and not isinstance(score, bool) and 1 <= score <= 5:
+            return False
+        return None
+
+    # Markers written before score provenance was added are not abstentions:
+    # the old reviewer had no explicit structured abstention state.
+    return False
 
 
 # Known bot logins (exact match, case-insensitive) to exclude when counting
@@ -1342,13 +1336,13 @@ def evaluate_pr(
         if score is not None and score < min_score:
             result.reasons.append(f"Greptile score {score}/5 below floor {min_score}/5")
 
-    # An explicit "I did not review this" from our own reviewer is a blocker in
-    # its own right — see AI_REVIEW_ABSTENTION_PHRASES above. Negative signal
-    # only: this never *grants* eligibility.
-    if ai_review_abstained(repo, number):
-        result.reasons.append(
-            "AI review abstained (submodule pointer change) — not reviewed"
-        )
+    # An explicit abstention blocks in its own right. If the structured review
+    # state cannot be read, fail closed rather than silently removing the gate.
+    ai_abstention = ai_review_abstained(repo, number)
+    if ai_abstention is True:
+        result.reasons.append("AI review abstained — not reviewed")
+    elif ai_abstention is None:
+        result.reasons.append("AI review status unavailable")
 
     human_threads = fetch_unresolved_human_threads(
         repo, number, review_data=shared_review_data

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -100,8 +100,6 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
-import base64
-import binascii
 import json
 import os
 import re
@@ -880,57 +878,53 @@ def fetch_greptile_status(
 # Greptile, which is Erik's open decision and not this gate's to make. Nothing
 # here touches the existing `Greptile review not found` blocker.
 #
-# Matching is on the reviewer's own abstention text rather than re-deriving
-# "is this diff submodule-only?" here: the reviewer already made that call and
-# encoded it in the comment, and a second implementation would drift from the
-# first. The coupling to prose is the price; a structured field in the
-# `bob-ai-review` JSON marker would be strictly better and is worth adding
-# upstream, at which point this should read that instead.
-#
-# Selecting on the HTML marker rather than the visible heading avoids matching a
-# human comment that merely *quotes* the abstention.
+# The reviewer encodes abstention as `score: null` in its structured marker.
+# Reading that field avoids coupling this safety gate to human-facing prose.
 AI_REVIEW_COMMENT_MARKER = "<!-- bob-ai-review {"
-AI_REVIEW_ABSTENTION_PHRASES = ("submodule pointer change only", "not reviewed")
+AI_REVIEW_MARKER_RE = re.compile(r"<!-- bob-ai-review (\{.*?\}) -->", re.DOTALL)
 
 
-def ai_review_abstained(repo: str, pr_number: int) -> bool:
-    """Whether our AI reviewer's LATEST review explicitly declined to review.
+def ai_review_abstained(repo: str, pr_number: int) -> bool | None:
+    """Whether our AI reviewer's latest review explicitly declined to review.
 
-    Only the latest AI-review comment counts. An older abstention followed by a
-    real review means the diff outgrew the submodule-only shape and *was*
-    assessed; blocking on the stale one would be wrong.
-
-    Fails OPEN on an API or decode error. This is a supplementary blocker: the
-    Greptile gates are independent and already fail closed when review data
-    cannot be fetched, so a transient error here cannot open a hole on its own.
+    ``None`` means the review state could not be determined and callers must
+    fail closed. Only the latest marker comment counts: a later real review
+    supersedes an earlier abstention.
     """
     raw = run_gh(
         [
             "api",
-            f"repos/{repo}/issues/{pr_number}/comments",
-            "--paginate",
-            # base64 so a comment body's own newlines cannot be mistaken for a
-            # record separator — these bodies are multi-line markdown.
+            f"repos/{repo}/issues/{pr_number}/comments?per_page=100",
             "--jq",
-            f'.[] | select(.body | contains("{AI_REVIEW_COMMENT_MARKER}"))'
-            " | .body | @base64",
+            f'[.[] | select(.body | contains("{AI_REVIEW_COMMENT_MARKER}"))]'
+            ' | if length == 0 then "__NO_AI_REVIEW__" else last.body end',
         ],
         timeout=30,
     )
     if not raw or not raw.strip():
+        return None
+    if raw == "__NO_AI_REVIEW__":
         return False
 
-    encoded = [line for line in raw.splitlines() if line.strip()]
-    if not encoded:
-        return False
-
+    match = AI_REVIEW_MARKER_RE.search(raw)
+    if match is None:
+        return None
     try:
-        latest = base64.b64decode(encoded[-1]).decode("utf-8", errors="replace")
-    except (ValueError, binascii.Error):
-        return False
+        marker = json.loads(match.group(1))
+    except (json.JSONDecodeError, TypeError):
+        return None
 
-    lowered = latest.lower()
-    return all(phrase in lowered for phrase in AI_REVIEW_ABSTENTION_PHRASES)
+    if "score" in marker:
+        score = marker["score"]
+        if score is None:
+            return True
+        if isinstance(score, int) and not isinstance(score, bool) and 1 <= score <= 5:
+            return False
+        return None
+
+    # Markers written before score provenance was added are not abstentions:
+    # the old reviewer had no explicit structured abstention state.
+    return False
 
 
 # Known bot logins (exact match, case-insensitive) to exclude when counting
@@ -1815,13 +1809,13 @@ def evaluate_pr(
         if score is not None and score < min_score:
             result.reasons.append(f"Greptile score {score}/5 below floor {min_score}/5")
 
-    # An explicit "I did not review this" from our own reviewer is a blocker in
-    # its own right — see AI_REVIEW_ABSTENTION_PHRASES above. Negative signal
-    # only: this never *grants* eligibility.
-    if ai_review_abstained(repo, number):
-        result.reasons.append(
-            "AI review abstained (submodule pointer change) — not reviewed"
-        )
+    # An explicit abstention blocks in its own right. If the structured review
+    # state cannot be read, fail closed rather than silently removing the gate.
+    ai_abstention = ai_review_abstained(repo, number)
+    if ai_abstention is True:
+        result.reasons.append("AI review abstained — not reviewed")
+    elif ai_abstention is None:
+        result.reasons.append("AI review status unavailable")
 
     human_threads = fetch_unresolved_human_threads(
         repo, number, review_data=shared_review_data

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -872,11 +872,11 @@ def fetch_greptile_status(
 # that comment, pinning prod's submodule to a commit 5 ahead of gptme master —
 # a merge of two still-open PRs' heads, reviewed by nobody.
 #
-# This is deliberately a NEGATIVE signal only. An abstention blocks; the inverse
-# ("our AI review found nothing, therefore mergeable") is NOT implemented and
-# must not be. That would make our own reviewer a merge credential in place of
-# Greptile, which is Erik's open decision and not this gate's to make. Nothing
-# here touches the existing `Greptile review not found` blocker.
+# This is deliberately a NEGATIVE signal only. An abstention blocks. The inverse
+# ("our AI review found nothing, therefore mergeable") is a separate, explicitly
+# gated mechanism -- see `fetch_ai_review_status`, added later -- with its own
+# staleness, consensus and identity requirements. Reaching this function's
+# `False` return means only "the reviewer did not decline"; it grants nothing.
 #
 # The reviewer encodes abstention as `score: null` in its structured marker.
 # Reading that field avoids coupling this safety gate to human-facing prose.
@@ -884,38 +884,69 @@ AI_REVIEW_COMMENT_MARKER = "<!-- bob-ai-review {"
 AI_REVIEW_MARKER_RE = re.compile(r"<!-- bob-ai-review (\{.*?\}) -->", re.DOTALL)
 
 
-def ai_review_abstained(repo: str, pr_number: int) -> bool | None:
+class _MarkerUnset:
+    """Sentinel for "no shared marker supplied, fetch it yourself".
+
+    Distinct from every meaningful marker value, including ``None`` ("fetched,
+    found nothing") and ``MARKER_LOOKUP_FAILED``, so a caller can pass a shared
+    result of any kind without it being mistaken for "not supplied".
+
+    Deliberately not reusing the module's older ``_UNSET``: that one is typed as
+    a bare ``object`` for the Greptile review-data parameter, and sharing it here
+    would make the two unrelated "not supplied" states indistinguishable to a
+    reader and to mypy.
+    """
+
+    __slots__ = ()
+
+
+_MARKER_UNSET = _MarkerUnset()
+
+
+def ai_review_abstained(
+    repo: str,
+    pr_number: int,
+    *,
+    expected_author: str,
+    marker_result: dict[str, Any]
+    | None
+    | _MarkerLookupFailed
+    | _MarkerUnset = _MARKER_UNSET,
+) -> bool | None:
     """Whether our AI reviewer's latest review explicitly declined to review.
 
     ``None`` means the review state could not be determined and callers must
     fail closed. Only the latest marker comment counts: a later real review
     supersedes an earlier abstention.
+
+    The marker is read through `_fetch_ai_review_marker`, which accepts markers
+    only from *expected_author*. That matters more here than it looks: the
+    marker is plain text in a comment body and is invisible in GitHub's rendered
+    view, so without an author check any account able to comment could paste a
+    `score: null` marker and permanently block the PR from merging. Sharing the
+    fetch with the positive path also means this gate is exercised by that
+    path's tests rather than through a bespoke jq pipeline of its own.
     """
-    raw = run_gh(
-        [
-            "api",
-            f"repos/{repo}/issues/{pr_number}/comments?per_page=100",
-            "--paginate",
-            "--slurp",
-            "--jq",
-            f'[.[][] | select(.body | contains("{AI_REVIEW_COMMENT_MARKER}"))]'
-            ' | if length == 0 then "__NO_AI_REVIEW__" else last.body end',
-        ],
-        timeout=30,
+    result = (
+        _fetch_ai_review_marker_checked(
+            repo, pr_number, expected_author=expected_author
+        )
+        if isinstance(marker_result, _MarkerUnset)
+        else marker_result
     )
-    if not raw or not raw.strip():
+    if isinstance(result, _MarkerLookupFailed):
+        # The lookup failed, so we cannot tell whether the reviewer abstained.
+        # Fail closed: inferring "not an abstention" from a failed call would
+        # reopen the gptme-cloud#850 hole on any flaky API response.
         return None
-    if raw == "__NO_AI_REVIEW__":
+    if result is None:
+        # Looked, and there is no marker from our reviewer at all. That is not
+        # an abstention -- it is a PR our reviewer never posted on, which is the
+        # ordinary case in repos the reviewer does not run against. Blocking
+        # here would turn this narrow safety check into a universal blocker.
         return False
 
-    match = AI_REVIEW_MARKER_RE.search(raw)
-    if match is None:
-        return None
-    try:
-        marker = json.loads(match.group(1))
-    except (json.JSONDecodeError, TypeError):
-        return None
-
+    marker = result
     if "score" in marker:
         score = marker["score"]
         if score is None:
@@ -1086,20 +1117,34 @@ def _consensus_shortfall(consensus: Any) -> str | None:
     return None
 
 
-def _fetch_ai_review_marker(
-    repo: str, pr_number: int, *, expected_author: str
-) -> dict[str, Any] | None:
-    """Latest self-hosted-review summary marker on the PR, parsed.
+class _MarkerLookupFailed:
+    """Sentinel: the marker lookup itself failed, so nothing can be concluded.
 
-    Only comments authored by *expected_author* are considered: the marker is
-    plain text in a comment body, so any account that can comment on the PR could
-    otherwise forge a clean verdict for a gate that then merges without a human.
-    An empty *expected_author* means the identity could not be established, and
-    the marker is not trusted at all.
+    Distinct from ``None`` ("looked, found no marker"). Collapsing the two is
+    the failure mode this gate keeps re-learning: a timed-out or rate-limited
+    call must never be read as evidence about what a reviewer did or did not do.
+    """
+
+    __slots__ = ()
+
+
+MARKER_LOOKUP_FAILED = _MarkerLookupFailed()
+
+
+def _fetch_ai_review_marker_checked(
+    repo: str, pr_number: int, *, expected_author: str
+) -> dict[str, Any] | None | _MarkerLookupFailed:
+    """Latest review marker, distinguishing "no marker" from "lookup failed".
+
+    Returns the parsed marker, ``None`` when the fetch succeeded but the PR
+    carries no marker from *expected_author*, or ``MARKER_LOOKUP_FAILED`` when
+    the lookup could not be completed.
     """
     if not expected_author:
-        return None
-    raw = run_gh(
+        # Identity could not be established, so no marker can be attributed.
+        # This is a failed lookup, not an absence of markers.
+        return MARKER_LOOKUP_FAILED
+    raw = run_gh_checked(
         [
             "api",
             f"repos/{repo}/issues/{pr_number}/comments",
@@ -1109,10 +1154,11 @@ def _fetch_ai_review_marker(
         ],
         timeout=30,
     )
-    if not raw:
-        return None
+    if raw is None:
+        return MARKER_LOOKUP_FAILED
 
     latest: dict[str, Any] | None = None
+    saw_unparseable_marker = False
     for line in raw.splitlines():
         line = line.strip()
         if not line:
@@ -1123,16 +1169,58 @@ def _fetch_ai_review_marker(
             continue
         if not isinstance(comment, dict) or comment.get("author") != expected_author:
             continue
+        body = comment.get("body") or ""
         # Last match wins within a body, and the last qualifying comment wins
         # overall: the reviewer upserts a single comment, but a repo with legacy
         # append-style comments should still be read at its most recent verdict.
-        for parsed in _iter_ai_review_markers(comment.get("body") or ""):
+        parsed_any = False
+        for parsed in _iter_ai_review_markers(body):
             latest = parsed
+            parsed_any = True
+        if not parsed_any and AI_REVIEW_COMMENT_MARKER in body:
+            # Our reviewer wrote a marker we cannot read. That is corruption,
+            # not absence -- reporting "no marker" here would let a mangled
+            # abstention read as "did not abstain".
+            saw_unparseable_marker = True
+
+    if latest is None and saw_unparseable_marker:
+        return MARKER_LOOKUP_FAILED
     return latest
 
 
+def _fetch_ai_review_marker(
+    repo: str, pr_number: int, *, expected_author: str
+) -> dict[str, Any] | None:
+    """Latest self-hosted-review summary marker on the PR, parsed.
+
+    Only comments authored by *expected_author* are considered: the marker is
+    plain text in a comment body, so any account that can comment on the PR could
+    otherwise forge a clean verdict for a gate that then merges without a human.
+    An empty *expected_author* means the identity could not be established, and
+    the marker is not trusted at all.
+
+    A failed lookup is reported as ``None`` here, which the positive path treats
+    exactly as "no marker" -- correct for that direction, because both leave the
+    PR on the Greptile-only path and neither can make it *more* mergeable.
+    """
+    result = _fetch_ai_review_marker_checked(
+        repo, pr_number, expected_author=expected_author
+    )
+    if isinstance(result, _MarkerLookupFailed):
+        return None
+    return result
+
+
 def fetch_ai_review_status(
-    repo: str, pr_number: int, *, head_sha: str, expected_author: str
+    repo: str,
+    pr_number: int,
+    *,
+    head_sha: str,
+    expected_author: str,
+    marker_result: dict[str, Any]
+    | None
+    | _MarkerLookupFailed
+    | _MarkerUnset = _MARKER_UNSET,
 ) -> dict[str, Any]:
     """Whether our own reviewer's verdict is strong enough to stand in for Greptile.
 
@@ -1148,7 +1236,14 @@ def fetch_ai_review_status(
     if not _ai_review_enabled():
         return {"accepted": False, "detail": None}
 
-    marker = _fetch_ai_review_marker(repo, pr_number, expected_author=expected_author)
+    if isinstance(marker_result, _MarkerUnset):
+        marker = _fetch_ai_review_marker(
+            repo, pr_number, expected_author=expected_author
+        )
+    elif isinstance(marker_result, _MarkerLookupFailed):
+        marker = None
+    else:
+        marker = marker_result
     if marker is None:
         return {"accepted": False, "detail": None}
 
@@ -1175,8 +1270,7 @@ def fetch_ai_review_status(
         return {
             "accepted": False,
             "detail": (
-                f"AI review score is not an integer "
-                f"({type(score).__name__}: {score!r})"
+                f"AI review score is not an integer ({type(score).__name__}: {score!r})"
             ),
         }
     # Exactly the rubric's clean value, not "at least" it. `confidence_score`
@@ -1762,6 +1856,14 @@ def evaluate_pr(
     # Fetch once; pass to both helpers to avoid duplicate GraphQL round-trips.
     shared_review_data = _fetch_greptile_review_data(repo, number)
 
+    # One fetch, shared by both readers of the review marker: the Greptile-
+    # substitute path below and the abstention blocker after it. They ask
+    # different questions of the same comment, so fetching twice would double
+    # the API cost of every evaluation for no extra information.
+    shared_marker = _fetch_ai_review_marker_checked(
+        repo, number, expected_author=current_user
+    )
+
     greptile = fetch_greptile_status(repo, number, review_data=shared_review_data)
     if not greptile["has_review"]:
         # The alternative review is safe only after a successful GraphQL fetch
@@ -1783,6 +1885,7 @@ def evaluate_pr(
                 number,
                 head_sha=result.head_sha,
                 expected_author=current_user,
+                marker_result=shared_marker,
             )
             if ai_review["accepted"]:
                 result.warnings.append(
@@ -1813,7 +1916,9 @@ def evaluate_pr(
 
     # An explicit abstention blocks in its own right. If the structured review
     # state cannot be read, fail closed rather than silently removing the gate.
-    ai_abstention = ai_review_abstained(repo, number)
+    ai_abstention = ai_review_abstained(
+        repo, number, expected_author=current_user, marker_result=shared_marker
+    )
     if ai_abstention is True:
         result.reasons.append("AI review abstained — not reviewed")
     elif ai_abstention is None:

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -100,6 +100,8 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import base64
+import binascii
 import json
 import os
 import re
@@ -857,6 +859,78 @@ def fetch_greptile_status(
             unresolved += 1
 
     return {"has_review": True, "unresolved": unresolved, "total": total}
+
+
+# --- Our own AI reviewer's explicit abstention -------------------------------
+#
+# The self-hosted reviewer (ErikBjare/bob#1122) can decline to review at all.
+# Today that happens on submodule-pointer bumps, where the diff is a SHA and no
+# source, so there is nothing in it to assess. It says so verbatim:
+#
+#     ℹ️ **Submodule pointer change only — not reviewed.**
+#     ...Treat this as *not reviewed*, not as approved.
+#
+# The gate could not see that. gptme/gptme-cloud#850 self-merged carrying exactly
+# that comment, pinning prod's submodule to a commit 5 ahead of gptme master —
+# a merge of two still-open PRs' heads, reviewed by nobody.
+#
+# This is deliberately a NEGATIVE signal only. An abstention blocks; the inverse
+# ("our AI review found nothing, therefore mergeable") is NOT implemented and
+# must not be. That would make our own reviewer a merge credential in place of
+# Greptile, which is Erik's open decision and not this gate's to make. Nothing
+# here touches the existing `Greptile review not found` blocker.
+#
+# Matching is on the reviewer's own abstention text rather than re-deriving
+# "is this diff submodule-only?" here: the reviewer already made that call and
+# encoded it in the comment, and a second implementation would drift from the
+# first. The coupling to prose is the price; a structured field in the
+# `bob-ai-review` JSON marker would be strictly better and is worth adding
+# upstream, at which point this should read that instead.
+#
+# Selecting on the HTML marker rather than the visible heading avoids matching a
+# human comment that merely *quotes* the abstention.
+AI_REVIEW_COMMENT_MARKER = "<!-- bob-ai-review {"
+AI_REVIEW_ABSTENTION_PHRASES = ("submodule pointer change only", "not reviewed")
+
+
+def ai_review_abstained(repo: str, pr_number: int) -> bool:
+    """Whether our AI reviewer's LATEST review explicitly declined to review.
+
+    Only the latest AI-review comment counts. An older abstention followed by a
+    real review means the diff outgrew the submodule-only shape and *was*
+    assessed; blocking on the stale one would be wrong.
+
+    Fails OPEN on an API or decode error. This is a supplementary blocker: the
+    Greptile gates are independent and already fail closed when review data
+    cannot be fetched, so a transient error here cannot open a hole on its own.
+    """
+    raw = run_gh(
+        [
+            "api",
+            f"repos/{repo}/issues/{pr_number}/comments",
+            "--paginate",
+            # base64 so a comment body's own newlines cannot be mistaken for a
+            # record separator — these bodies are multi-line markdown.
+            "--jq",
+            f'.[] | select(.body | contains("{AI_REVIEW_COMMENT_MARKER}"))'
+            " | .body | @base64",
+        ],
+        timeout=30,
+    )
+    if not raw or not raw.strip():
+        return False
+
+    encoded = [line for line in raw.splitlines() if line.strip()]
+    if not encoded:
+        return False
+
+    try:
+        latest = base64.b64decode(encoded[-1]).decode("utf-8", errors="replace")
+    except (ValueError, binascii.Error):
+        return False
+
+    lowered = latest.lower()
+    return all(phrase in lowered for phrase in AI_REVIEW_ABSTENTION_PHRASES)
 
 
 # Known bot logins (exact match, case-insensitive) to exclude when counting
@@ -1740,6 +1814,14 @@ def evaluate_pr(
         score = greptile_summary_score(repo, number)
         if score is not None and score < min_score:
             result.reasons.append(f"Greptile score {score}/5 below floor {min_score}/5")
+
+    # An explicit "I did not review this" from our own reviewer is a blocker in
+    # its own right — see AI_REVIEW_ABSTENTION_PHRASES above. Negative signal
+    # only: this never *grants* eligibility.
+    if ai_review_abstained(repo, number):
+        result.reasons.append(
+            "AI review abstained (submodule pointer change) — not reviewed"
+        )
 
     human_threads = fetch_unresolved_human_threads(
         repo, number, review_data=shared_review_data

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -895,8 +895,10 @@ def ai_review_abstained(repo: str, pr_number: int) -> bool | None:
         [
             "api",
             f"repos/{repo}/issues/{pr_number}/comments?per_page=100",
+            "--paginate",
+            "--slurp",
             "--jq",
-            f'[.[] | select(.body | contains("{AI_REVIEW_COMMENT_MARKER}"))]'
+            f'[.[][] | select(.body | contains("{AI_REVIEW_COMMENT_MARKER}"))]'
             ' | if length == 0 then "__NO_AI_REVIEW__" else last.body end',
         ],
         timeout=30,

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -57,6 +57,8 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import base64
+import binascii
 import json
 import os
 import re
@@ -697,6 +699,78 @@ def fetch_greptile_status(
     return {"has_review": True, "unresolved": unresolved, "total": total}
 
 
+# --- Our own AI reviewer's explicit abstention -------------------------------
+#
+# The self-hosted reviewer (ErikBjare/bob#1122) can decline to review at all.
+# Today that happens on submodule-pointer bumps, where the diff is a SHA and no
+# source, so there is nothing in it to assess. It says so verbatim:
+#
+#     ℹ️ **Submodule pointer change only — not reviewed.**
+#     ...Treat this as *not reviewed*, not as approved.
+#
+# The gate could not see that. gptme/gptme-cloud#850 self-merged carrying exactly
+# that comment, pinning prod's submodule to a commit 5 ahead of gptme master —
+# a merge of two still-open PRs' heads, reviewed by nobody.
+#
+# This is deliberately a NEGATIVE signal only. An abstention blocks; the inverse
+# ("our AI review found nothing, therefore mergeable") is NOT implemented and
+# must not be. That would make our own reviewer a merge credential in place of
+# Greptile, which is Erik's open decision and not this gate's to make. Nothing
+# here touches the existing `Greptile review not found` blocker.
+#
+# Matching is on the reviewer's own abstention text rather than re-deriving
+# "is this diff submodule-only?" here: the reviewer already made that call and
+# encoded it in the comment, and a second implementation would drift from the
+# first. The coupling to prose is the price; a structured field in the
+# `bob-ai-review` JSON marker would be strictly better and is worth adding
+# upstream, at which point this should read that instead.
+#
+# Selecting on the HTML marker rather than the visible heading avoids matching a
+# human comment that merely *quotes* the abstention.
+AI_REVIEW_COMMENT_MARKER = "<!-- bob-ai-review {"
+AI_REVIEW_ABSTENTION_PHRASES = ("submodule pointer change only", "not reviewed")
+
+
+def ai_review_abstained(repo: str, pr_number: int) -> bool:
+    """Whether our AI reviewer's LATEST review explicitly declined to review.
+
+    Only the latest AI-review comment counts. An older abstention followed by a
+    real review means the diff outgrew the submodule-only shape and *was*
+    assessed; blocking on the stale one would be wrong.
+
+    Fails OPEN on an API or decode error. This is a supplementary blocker: the
+    Greptile gates are independent and already fail closed when review data
+    cannot be fetched, so a transient error here cannot open a hole on its own.
+    """
+    raw = run_gh(
+        [
+            "api",
+            f"repos/{repo}/issues/{pr_number}/comments",
+            "--paginate",
+            # base64 so a comment body's own newlines cannot be mistaken for a
+            # record separator — these bodies are multi-line markdown.
+            "--jq",
+            f'.[] | select(.body | contains("{AI_REVIEW_COMMENT_MARKER}"))'
+            " | .body | @base64",
+        ],
+        timeout=30,
+    )
+    if not raw or not raw.strip():
+        return False
+
+    encoded = [line for line in raw.splitlines() if line.strip()]
+    if not encoded:
+        return False
+
+    try:
+        latest = base64.b64decode(encoded[-1]).decode("utf-8", errors="replace")
+    except (ValueError, binascii.Error):
+        return False
+
+    lowered = latest.lower()
+    return all(phrase in lowered for phrase in AI_REVIEW_ABSTENTION_PHRASES)
+
+
 # Known bot logins (exact match, case-insensitive) to exclude when counting
 # human review threads.  GitHub Apps append "[bot]" to their login, so any
 # login ending with that suffix is also excluded.
@@ -1267,6 +1341,14 @@ def evaluate_pr(
         score = greptile_summary_score(repo, number)
         if score is not None and score < min_score:
             result.reasons.append(f"Greptile score {score}/5 below floor {min_score}/5")
+
+    # An explicit "I did not review this" from our own reviewer is a blocker in
+    # its own right — see AI_REVIEW_ABSTENTION_PHRASES above. Negative signal
+    # only: this never *grants* eligibility.
+    if ai_review_abstained(repo, number):
+        result.reasons.append(
+            "AI review abstained (submodule pointer change) — not reviewed"
+        )
 
     human_threads = fetch_unresolved_human_threads(
         repo, number, review_data=shared_review_data

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -908,6 +908,7 @@ def ai_review_abstained(
     pr_number: int,
     *,
     expected_author: str,
+    head_sha: str = "",
     marker_result: dict[str, Any]
     | None
     | _MarkerLookupFailed
@@ -947,6 +948,21 @@ def ai_review_abstained(
         return False
 
     marker = result
+
+    # An abstention only speaks for the commit it was written against. Without
+    # this, a `score: null` posted for an older head blocks the PR forever: the
+    # head moves, the new head gets reviewed cleanly, and the stale abstention
+    # still fires because this block runs unconditionally. The positive path
+    # already rejects stale markers via `_sha_matches_head`; matching that here
+    # keeps the two directions consistent.
+    #
+    # Only applied when a head is supplied and the marker carries a sha, so a
+    # marker without provenance keeps its previous fail-closed behaviour.
+    if head_sha:
+        marker_sha = str(marker.get("sha") or "")
+        if marker_sha and not _sha_matches_head(marker_sha, head_sha):
+            return False
+
     if "score" in marker:
         score = marker["score"]
         if score is None:
@@ -1158,7 +1174,7 @@ def _fetch_ai_review_marker_checked(
         return MARKER_LOOKUP_FAILED
 
     latest: dict[str, Any] | None = None
-    saw_unparseable_marker = False
+    latest_is_unreadable = False
     for line in raw.splitlines():
         line = line.strip()
         if not line:
@@ -1177,13 +1193,21 @@ def _fetch_ai_review_marker_checked(
         for parsed in _iter_ai_review_markers(body):
             latest = parsed
             parsed_any = True
-        if not parsed_any and AI_REVIEW_COMMENT_MARKER in body:
+        if parsed_any:
+            latest_is_unreadable = False
+        elif AI_REVIEW_COMMENT_MARKER in body:
             # Our reviewer wrote a marker we cannot read. That is corruption,
             # not absence -- reporting "no marker" here would let a mangled
             # abstention read as "did not abstain".
-            saw_unparseable_marker = True
+            #
+            # Tracked as a property of the MOST RECENT marker-bearing comment,
+            # not as "did we ever see one". Gating on `latest is None` instead
+            # would silently fall back to an older, still-parseable marker when
+            # the newest verdict is the corrupt one -- so a truncated abstention
+            # posted after a clean 5/5 would be read as that stale 5/5.
+            latest_is_unreadable = True
 
-    if latest is None and saw_unparseable_marker:
+    if latest_is_unreadable:
         return MARKER_LOOKUP_FAILED
     return latest
 
@@ -1917,11 +1941,27 @@ def evaluate_pr(
     # An explicit abstention blocks in its own right. If the structured review
     # state cannot be read, fail closed rather than silently removing the gate.
     ai_abstention = ai_review_abstained(
-        repo, number, expected_author=current_user, marker_result=shared_marker
+        repo,
+        number,
+        expected_author=current_user,
+        head_sha=result.head_sha,
+        marker_result=shared_marker,
     )
     if ai_abstention is True:
         result.reasons.append("AI review abstained — not reviewed")
-    elif ai_abstention is None:
+    elif ai_abstention is None and not greptile["has_review"]:
+        # Indeterminate blocks only when our own reviewer is the sole evidence.
+        #
+        # Failing closed unconditionally would let one flaky call on the
+        # issue-comments endpoint disqualify EVERY self-merge, including PRs
+        # Greptile reviewed cleanly with all threads resolved -- trading the
+        # deadlock this gate family just escaped for a wider one.
+        #
+        # When Greptile has reviewed, that is independent review evidence and
+        # this check is defence in depth, so its unavailability must not veto.
+        # When Greptile has NOT reviewed, the PR is leaning on our own reviewer,
+        # and an unreadable verdict is exactly the "nobody actually reviewed
+        # this" case (gptme-cloud#850) -- so it still fails closed there.
         result.reasons.append("AI review status unavailable")
 
     human_threads = fetch_unresolved_human_threads(

--- a/tests/test_self_merge_ai_review_abstention.py
+++ b/tests/test_self_merge_ai_review_abstention.py
@@ -1,0 +1,262 @@
+"""Our AI reviewer can decline to review. The gate must treat that as a blocker.
+
+The self-hosted reviewer (ErikBjare/bob#1122) posts a normal review for most
+diffs, but on a submodule-pointer bump it abstains outright — the diff is a SHA
+and no source, so there is nothing in it to assess:
+
+    ℹ️ **Submodule pointer change only — not reviewed.**
+    ...Treat this as *not reviewed*, not as approved.
+
+The gate could not see that. gptme/gptme-cloud#850 self-merged carrying exactly
+that comment, pinning prod's submodule to a commit 5 ahead of gptme master — a
+merge of two still-open PRs' heads, reviewed by nobody.
+
+Scope, deliberately: this is a NEGATIVE signal only. An abstention blocks; a
+clean AI review grants nothing. Making our own reviewer a merge credential in
+place of Greptile is a separate, open decision — the tests below pin that an
+ordinary AI review (and no AI review at all) leaves eligibility untouched.
+"""
+
+from __future__ import annotations
+
+import base64
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+MODULE_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "scripts"
+    / "github"
+    / "self-merge-check.py"
+)
+spec = importlib.util.spec_from_file_location("self_merge_check", MODULE_PATH)
+if spec is None or spec.loader is None:
+    pytest.skip(f"Could not load module from {MODULE_PATH}", allow_module_level=True)
+self_merge_check = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = self_merge_check
+spec.loader.exec_module(self_merge_check)
+
+
+ABSTENTION_BODY = """## 🤖 AI code review
+
+ℹ️ **Submodule pointer change only — not reviewed.**
+
+This diff moves a submodule SHA and contains no source changes, so there is
+nothing here for me to assess. Whether the bump is safe depends on the
+submodule's commit range, which this diff does not include. Treat this as
+*not reviewed*, not as approved.
+
+<!-- bob-ai-review {"sha": "c096e25e50f8", "engine": "llm", "history": []} -->
+"""
+
+ORDINARY_REVIEW_BODY = """## 🤖 AI code review
+
+**2 finding(s)** — ⚠️ **2** P2
+
+<!-- bob-ai-review {"sha": "deadbeef1234", "engine": "llm", "history": []} -->
+"""
+
+CLEAN_REVIEW_BODY = """## 🤖 AI code review
+
+✅ **No findings.** The diff looks correct to me on this pass.
+
+<!-- bob-ai-review {"sha": "deadbeef1234", "engine": "llm", "history": []} -->
+"""
+
+ABSTENTION_REASON = "AI review abstained (submodule pointer change) — not reviewed"
+
+
+def _gh_returning(*bodies: str):
+    """Stand in for `gh api ... --jq '... | @base64'` over issue comments.
+
+    The real jq selects on the HTML marker and base64-encodes each body, one per
+    line — encoding matters, because these bodies are multi-line markdown and a
+    raw dump would be ambiguous to split.
+    """
+
+    def _run_gh(args: list[str], **kwargs: Any) -> str:
+        selected = [b for b in bodies if self_merge_check.AI_REVIEW_COMMENT_MARKER in b]
+        return "\n".join(
+            base64.b64encode(b.encode("utf-8")).decode("ascii") for b in selected
+        )
+
+    return _run_gh
+
+
+# ---------------------------------------------------------------------------
+# ai_review_abstained
+# ---------------------------------------------------------------------------
+
+
+def test_abstention_is_detected() -> None:
+    with patch.object(self_merge_check, "run_gh", _gh_returning(ABSTENTION_BODY)):
+        assert self_merge_check.ai_review_abstained("o/r", 1) is True
+
+
+@pytest.mark.parametrize("body", [ORDINARY_REVIEW_BODY, CLEAN_REVIEW_BODY])
+def test_ordinary_review_is_not_an_abstention(body: str) -> None:
+    with patch.object(self_merge_check, "run_gh", _gh_returning(body)):
+        assert self_merge_check.ai_review_abstained("o/r", 1) is False
+
+
+def test_no_ai_review_at_all_is_not_an_abstention() -> None:
+    with patch.object(self_merge_check, "run_gh", _gh_returning()):
+        assert self_merge_check.ai_review_abstained("o/r", 1) is False
+
+
+def test_only_the_latest_review_counts() -> None:
+    """An abstention superseded by a real review must not keep blocking.
+
+    A submodule-only PR that grows source commits gets re-reviewed for real;
+    the stale abstention above it is not a verdict on the current diff.
+    """
+    with patch.object(
+        self_merge_check,
+        "run_gh",
+        _gh_returning(ABSTENTION_BODY, ORDINARY_REVIEW_BODY),
+    ):
+        assert self_merge_check.ai_review_abstained("o/r", 1) is False
+
+
+def test_latest_abstention_after_an_earlier_real_review_blocks() -> None:
+    with patch.object(
+        self_merge_check,
+        "run_gh",
+        _gh_returning(ORDINARY_REVIEW_BODY, ABSTENTION_BODY),
+    ):
+        assert self_merge_check.ai_review_abstained("o/r", 1) is True
+
+
+def test_a_human_comment_quoting_the_abstention_does_not_count() -> None:
+    """Selection is on the HTML marker, not the visible heading."""
+    quoted = (
+        "> ℹ️ **Submodule pointer change only — not reviewed.**\n\n"
+        "Discussing this, but I am not the reviewer.\n"
+    )
+    with patch.object(self_merge_check, "run_gh", _gh_returning(quoted)):
+        assert self_merge_check.ai_review_abstained("o/r", 1) is False
+
+
+@pytest.mark.parametrize("raw", ["", "   \n", "!!!not-base64!!!"])
+def test_api_or_decode_failure_fails_open(raw: str) -> None:
+    """Supplementary blocker: the Greptile gates already fail closed."""
+    with patch.object(self_merge_check, "run_gh", lambda *a, **k: raw):
+        assert self_merge_check.ai_review_abstained("o/r", 1) is False
+
+
+# ---------------------------------------------------------------------------
+# evaluate_pr wiring
+# ---------------------------------------------------------------------------
+
+
+def _evaluate(*comment_bodies: str) -> Any:
+    """Run evaluate_pr on a PR that passes every other gate."""
+    pr_data: dict[str, object] = {
+        "number": 999,
+        "author": {"login": "TimeToBuildBob"},
+        "title": "Bump submodule",
+        "url": "https://github.com/gptme/gptme-cloud/pull/999",
+        "files": [{"path": "tests/test_example.py"}],
+        "statusCheckRollup": [{"status": "COMPLETED", "conclusion": "SUCCESS"}],
+        "isDraft": False,
+        "state": "OPEN",
+        "reviewDecision": None,
+        "headRefOid": "abc123",
+        "mergeStateStatus": "CLEAN",
+    }
+    with (
+        patch.object(self_merge_check, "fetch_pr", return_value=pr_data),
+        patch.object(self_merge_check, "get_gh_user", return_value="TimeToBuildBob"),
+        patch.object(self_merge_check, "merge_permission", return_value=True),
+        patch.object(
+            self_merge_check, "_fetch_greptile_review_data", return_value=None
+        ),
+        patch.object(
+            self_merge_check,
+            "fetch_greptile_status",
+            return_value={"has_review": True, "unresolved": 0, "total": 1},
+        ),
+        patch.object(self_merge_check, "greptile_summary_score", return_value=None),
+        patch.object(
+            self_merge_check,
+            "fetch_unresolved_human_threads",
+            return_value={"unresolved": 0, "authors": []},
+        ),
+        patch.object(self_merge_check, "run_gh", _gh_returning(*comment_bodies)),
+    ):
+        return self_merge_check.evaluate_pr(
+            "gptme/gptme-cloud", 999, workspace_repos=["gptme/gptme-cloud"]
+        )
+
+
+def test_evaluate_pr_blocks_on_abstention() -> None:
+    """The regression: gptme-cloud#850 merged with exactly this comment."""
+    result = _evaluate(ABSTENTION_BODY)
+    assert not result.eligible
+    assert ABSTENTION_REASON in result.reasons
+
+
+@pytest.mark.parametrize("body", [ORDINARY_REVIEW_BODY, CLEAN_REVIEW_BODY])
+def test_evaluate_pr_unchanged_by_an_ordinary_ai_review(body: str) -> None:
+    """A clean AI review must grant nothing and block nothing.
+
+    Pins the scope: this change adds a blocker, it does not turn our own
+    reviewer into a merge credential.
+    """
+    result = _evaluate(body)
+    assert not any(ABSTENTION_REASON in r for r in result.reasons)
+    assert result.eligible
+
+
+def test_evaluate_pr_unchanged_when_there_is_no_ai_review() -> None:
+    result = _evaluate()
+    assert not any(ABSTENTION_REASON in r for r in result.reasons)
+    assert result.eligible
+
+
+def test_greptile_blocker_is_untouched() -> None:
+    """The existing `Greptile review not found` gate must still fire on its own."""
+    pr_data: dict[str, object] = {
+        "number": 999,
+        "author": {"login": "TimeToBuildBob"},
+        "title": "Bump submodule",
+        "url": "https://github.com/gptme/gptme-cloud/pull/999",
+        "files": [{"path": "tests/test_example.py"}],
+        "statusCheckRollup": [{"status": "COMPLETED", "conclusion": "SUCCESS"}],
+        "isDraft": False,
+        "state": "OPEN",
+        "reviewDecision": None,
+        "headRefOid": "abc123",
+        "mergeStateStatus": "CLEAN",
+    }
+    with (
+        patch.object(self_merge_check, "fetch_pr", return_value=pr_data),
+        patch.object(self_merge_check, "get_gh_user", return_value="TimeToBuildBob"),
+        patch.object(self_merge_check, "merge_permission", return_value=True),
+        patch.object(
+            self_merge_check, "_fetch_greptile_review_data", return_value=None
+        ),
+        patch.object(
+            self_merge_check,
+            "fetch_greptile_status",
+            return_value={"has_review": False, "unresolved": 0, "total": 0},
+        ),
+        patch.object(self_merge_check, "greptile_summary_score", return_value=None),
+        patch.object(
+            self_merge_check,
+            "fetch_unresolved_human_threads",
+            return_value={"unresolved": 0, "authors": []},
+        ),
+        # A clean AI review does not rescue a PR Greptile never reviewed.
+        patch.object(self_merge_check, "run_gh", _gh_returning(CLEAN_REVIEW_BODY)),
+    ):
+        result = self_merge_check.evaluate_pr(
+            "gptme/gptme-cloud", 999, workspace_repos=["gptme/gptme-cloud"]
+        )
+    assert not result.eligible
+    assert "Greptile review not found" in result.reasons

--- a/tests/test_self_merge_ai_review_abstention.py
+++ b/tests/test_self_merge_ai_review_abstention.py
@@ -95,7 +95,11 @@ def _abstained(*bodies: str, author: str = REVIEWER) -> bool | None:
     with patch.object(
         self_merge_check, "run_gh_checked", _gh_returning(*bodies, author=author)
     ):
-        return self_merge_check.ai_review_abstained("o/r", 1, expected_author=REVIEWER)
+        # The module is loaded via importlib, so mypy sees its members as Any.
+        result: bool | None = self_merge_check.ai_review_abstained(
+            "o/r", 1, expected_author=REVIEWER
+        )
+        return result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_self_merge_ai_review_abstention.py
+++ b/tests/test_self_merge_ai_review_abstention.py
@@ -231,7 +231,10 @@ def _evaluate(*comment_bodies: str) -> Any:
         "isDraft": False,
         "state": "OPEN",
         "reviewDecision": None,
-        "headRefOid": "abc123",
+        # Matches ABSTENTION_BODY's marker sha: the #850 regression is an
+        # abstention written for THIS head, and the gate now ignores abstentions
+        # left behind by an older one.
+        "headRefOid": "c096e25e50f8",
         "mergeStateStatus": "CLEAN",
     }
     with (
@@ -304,7 +307,10 @@ def test_unverifiable_greptile_state_refuses_the_ai_fallback() -> None:
         "isDraft": False,
         "state": "OPEN",
         "reviewDecision": None,
-        "headRefOid": "abc123",
+        # Matches ABSTENTION_BODY's marker sha: the #850 regression is an
+        # abstention written for THIS head, and the gate now ignores abstentions
+        # left behind by an older one.
+        "headRefOid": "c096e25e50f8",
         "mergeStateStatus": "CLEAN",
     }
     with (
@@ -336,3 +342,51 @@ def test_unverifiable_greptile_state_refuses_the_ai_fallback() -> None:
         )
     assert not result.eligible
     assert any("Could not verify Greptile review state" in r for r in result.reasons)
+
+
+def test_corrupt_newer_marker_does_not_fall_back_to_older_valid_one() -> None:
+    """A mangled newest verdict must fail closed, not read as the previous one.
+
+    Gating on "no valid marker at all" silently accepts a stale marker when the
+    newest marker-bearing comment is the corrupt one — so a truncated abstention
+    posted after a clean 5/5 would be read as that 5/5 and let the PR merge.
+    """
+    assert _abstained(CLEAN_REVIEW_BODY, "<!-- bob-ai-review {bad json") is None
+
+
+def test_a_readable_newer_marker_clears_an_earlier_corrupt_one() -> None:
+    """The converse: corruption is a property of the latest verdict, not history."""
+    assert _abstained("<!-- bob-ai-review {bad json", CLEAN_REVIEW_BODY) is False
+
+
+def test_abstention_for_an_older_head_is_ignored() -> None:
+    """A stale abstention must not block a PR whose head has since moved on.
+
+    Without a SHA check the abstention block, which runs unconditionally, keeps
+    firing forever: the head advances, the new head is reviewed cleanly, and the
+    old `score: null` still disqualifies the PR.
+    """
+    with patch.object(
+        self_merge_check, "run_gh_checked", _gh_returning(ABSTENTION_BODY)
+    ):
+        stale: bool | None = self_merge_check.ai_review_abstained(
+            "o/r",
+            1,
+            expected_author=REVIEWER,
+            head_sha="ffffffffffffffffffffffffffffffffffffffff",
+        )
+    assert stale is False
+
+
+def test_abstention_for_the_current_head_still_blocks() -> None:
+    """Pins that the staleness carve-out did not disable the check itself."""
+    with patch.object(
+        self_merge_check, "run_gh_checked", _gh_returning(ABSTENTION_BODY)
+    ):
+        current: bool | None = self_merge_check.ai_review_abstained(
+            "o/r",
+            1,
+            expected_author=REVIEWER,
+            head_sha="c096e25e50f8aaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        )
+    assert current is True

--- a/tests/test_self_merge_ai_review_abstention.py
+++ b/tests/test_self_merge_ai_review_abstention.py
@@ -162,9 +162,11 @@ def test_query_requests_latest_structured_marker() -> None:
         assert self_merge_check.ai_review_abstained("o/r", 42) is False
 
     assert "repos/o/r/issues/42/comments?per_page=100" in captured
-    assert "--paginate" not in captured
+    assert "--paginate" in captured
+    assert "--slurp" in captured
     query = captured[captured.index("--jq") + 1]
     assert self_merge_check.AI_REVIEW_COMMENT_MARKER in query
+    assert ".[][]" in query
     assert "last" in query
     assert "__NO_AI_REVIEW__" in query
 

--- a/tests/test_self_merge_ai_review_abstention.py
+++ b/tests/test_self_merge_ai_review_abstention.py
@@ -19,7 +19,6 @@ ordinary AI review (and no AI review at all) leaves eligibility untouched.
 
 from __future__ import annotations
 
-import base64
 import importlib.util
 import sys
 from pathlib import Path
@@ -51,39 +50,32 @@ nothing here for me to assess. Whether the bump is safe depends on the
 submodule's commit range, which this diff does not include. Treat this as
 *not reviewed*, not as approved.
 
-<!-- bob-ai-review {"sha": "c096e25e50f8", "engine": "llm", "history": []} -->
+<!-- bob-ai-review {"sha": "c096e25e50f8", "score": null, "engine": "llm", "history": []} -->
 """
 
 ORDINARY_REVIEW_BODY = """## 🤖 AI code review
 
 **2 finding(s)** — ⚠️ **2** P2
 
-<!-- bob-ai-review {"sha": "deadbeef1234", "engine": "llm", "history": []} -->
+<!-- bob-ai-review {"sha": "deadbeef1234", "score": 3, "engine": "llm", "history": []} -->
 """
 
 CLEAN_REVIEW_BODY = """## 🤖 AI code review
 
 ✅ **No findings.** The diff looks correct to me on this pass.
 
-<!-- bob-ai-review {"sha": "deadbeef1234", "engine": "llm", "history": []} -->
+<!-- bob-ai-review {"sha": "deadbeef1234", "score": 5, "engine": "llm", "history": []} -->
 """
 
-ABSTENTION_REASON = "AI review abstained (submodule pointer change) — not reviewed"
+ABSTENTION_REASON = "AI review abstained — not reviewed"
 
 
 def _gh_returning(*bodies: str):
-    """Stand in for `gh api ... --jq '... | @base64'` over issue comments.
-
-    The real jq selects on the HTML marker and base64-encodes each body, one per
-    line — encoding matters, because these bodies are multi-line markdown and a
-    raw dump would be ambiguous to split.
-    """
+    """Stand in for the jq query returning the latest marker comment body."""
 
     def _run_gh(args: list[str], **kwargs: Any) -> str:
         selected = [b for b in bodies if self_merge_check.AI_REVIEW_COMMENT_MARKER in b]
-        return "\n".join(
-            base64.b64encode(b.encode("utf-8")).decode("ascii") for b in selected
-        )
+        return selected[-1] if selected else "__NO_AI_REVIEW__"
 
     return _run_gh
 
@@ -106,6 +98,15 @@ def test_ordinary_review_is_not_an_abstention(body: str) -> None:
 
 def test_no_ai_review_at_all_is_not_an_abstention() -> None:
     with patch.object(self_merge_check, "run_gh", _gh_returning()):
+        assert self_merge_check.ai_review_abstained("o/r", 1) is False
+
+
+def test_legacy_marker_without_score_is_not_an_abstention() -> None:
+    legacy = (
+        "## 🤖 AI code review\n\n"
+        '<!-- bob-ai-review {"sha": "deadbeef1234", "engine": "llm"} -->'
+    )
+    with patch.object(self_merge_check, "run_gh", _gh_returning(legacy)):
         assert self_merge_check.ai_review_abstained("o/r", 1) is False
 
 
@@ -142,11 +143,30 @@ def test_a_human_comment_quoting_the_abstention_does_not_count() -> None:
         assert self_merge_check.ai_review_abstained("o/r", 1) is False
 
 
-@pytest.mark.parametrize("raw", ["", "   \n", "!!!not-base64!!!"])
-def test_api_or_decode_failure_fails_open(raw: str) -> None:
-    """Supplementary blocker: the Greptile gates already fail closed."""
+@pytest.mark.parametrize(
+    "raw", ["", "   \n", "not a marker", "<!-- bob-ai-review {bad json} -->"]
+)
+def test_api_or_decode_failure_is_unknown(raw: str) -> None:
     with patch.object(self_merge_check, "run_gh", lambda *a, **k: raw):
-        assert self_merge_check.ai_review_abstained("o/r", 1) is False
+        assert self_merge_check.ai_review_abstained("o/r", 1) is None
+
+
+def test_query_requests_latest_structured_marker() -> None:
+    captured: list[str] = []
+
+    def _capture(args: list[str], **kwargs: Any) -> str:
+        captured.extend(args)
+        return CLEAN_REVIEW_BODY
+
+    with patch.object(self_merge_check, "run_gh", _capture):
+        assert self_merge_check.ai_review_abstained("o/r", 42) is False
+
+    assert "repos/o/r/issues/42/comments?per_page=100" in captured
+    assert "--paginate" not in captured
+    query = captured[captured.index("--jq") + 1]
+    assert self_merge_check.AI_REVIEW_COMMENT_MARKER in query
+    assert "last" in query
+    assert "__NO_AI_REVIEW__" in query
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_self_merge_ai_review_abstention.py
+++ b/tests/test_self_merge_ai_review_abstention.py
@@ -20,6 +20,7 @@ ordinary AI review (and no AI review at all) leaves eligibility untouched.
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from pathlib import Path
 from typing import Any
@@ -70,14 +71,31 @@ CLEAN_REVIEW_BODY = """## 🤖 AI code review
 ABSTENTION_REASON = "AI review abstained — not reviewed"
 
 
-def _gh_returning(*bodies: str):
-    """Stand in for the jq query returning the latest marker comment body."""
+REVIEWER = "TimeToBuildBob"
+
+
+def _gh_returning(*bodies: str, author: str = REVIEWER):
+    """Stand in for the comments fetch, in the shared `{author, body}` JSONL form.
+
+    The abstention check reads markers through the same author-validated fetch as
+    the positive path, so the stub returns what `gh` actually emits rather than a
+    pre-selected body. That keeps the selection logic under test instead of
+    hard-coding its answer.
+    """
 
     def _run_gh(args: list[str], **kwargs: Any) -> str:
-        selected = [b for b in bodies if self_merge_check.AI_REVIEW_COMMENT_MARKER in b]
-        return selected[-1] if selected else "__NO_AI_REVIEW__"
+        return "\n".join(
+            json.dumps({"author": author, "body": body}) for body in bodies
+        )
 
     return _run_gh
+
+
+def _abstained(*bodies: str, author: str = REVIEWER) -> bool | None:
+    with patch.object(
+        self_merge_check, "run_gh_checked", _gh_returning(*bodies, author=author)
+    ):
+        return self_merge_check.ai_review_abstained("o/r", 1, expected_author=REVIEWER)
 
 
 # ---------------------------------------------------------------------------
@@ -86,19 +104,16 @@ def _gh_returning(*bodies: str):
 
 
 def test_abstention_is_detected() -> None:
-    with patch.object(self_merge_check, "run_gh", _gh_returning(ABSTENTION_BODY)):
-        assert self_merge_check.ai_review_abstained("o/r", 1) is True
+    assert _abstained(ABSTENTION_BODY) is True
 
 
 @pytest.mark.parametrize("body", [ORDINARY_REVIEW_BODY, CLEAN_REVIEW_BODY])
 def test_ordinary_review_is_not_an_abstention(body: str) -> None:
-    with patch.object(self_merge_check, "run_gh", _gh_returning(body)):
-        assert self_merge_check.ai_review_abstained("o/r", 1) is False
+    assert _abstained(body) is False
 
 
 def test_no_ai_review_at_all_is_not_an_abstention() -> None:
-    with patch.object(self_merge_check, "run_gh", _gh_returning()):
-        assert self_merge_check.ai_review_abstained("o/r", 1) is False
+    assert _abstained() is False
 
 
 def test_legacy_marker_without_score_is_not_an_abstention() -> None:
@@ -106,8 +121,7 @@ def test_legacy_marker_without_score_is_not_an_abstention() -> None:
         "## 🤖 AI code review\n\n"
         '<!-- bob-ai-review {"sha": "deadbeef1234", "engine": "llm"} -->'
     )
-    with patch.object(self_merge_check, "run_gh", _gh_returning(legacy)):
-        assert self_merge_check.ai_review_abstained("o/r", 1) is False
+    assert _abstained(legacy) is False
 
 
 def test_only_the_latest_review_counts() -> None:
@@ -116,21 +130,11 @@ def test_only_the_latest_review_counts() -> None:
     A submodule-only PR that grows source commits gets re-reviewed for real;
     the stale abstention above it is not a verdict on the current diff.
     """
-    with patch.object(
-        self_merge_check,
-        "run_gh",
-        _gh_returning(ABSTENTION_BODY, ORDINARY_REVIEW_BODY),
-    ):
-        assert self_merge_check.ai_review_abstained("o/r", 1) is False
+    assert _abstained(ABSTENTION_BODY, ORDINARY_REVIEW_BODY) is False
 
 
 def test_latest_abstention_after_an_earlier_real_review_blocks() -> None:
-    with patch.object(
-        self_merge_check,
-        "run_gh",
-        _gh_returning(ORDINARY_REVIEW_BODY, ABSTENTION_BODY),
-    ):
-        assert self_merge_check.ai_review_abstained("o/r", 1) is True
+    assert _abstained(ORDINARY_REVIEW_BODY, ABSTENTION_BODY) is True
 
 
 def test_a_human_comment_quoting_the_abstention_does_not_count() -> None:
@@ -139,36 +143,71 @@ def test_a_human_comment_quoting_the_abstention_does_not_count() -> None:
         "> ℹ️ **Submodule pointer change only — not reviewed.**\n\n"
         "Discussing this, but I am not the reviewer.\n"
     )
-    with patch.object(self_merge_check, "run_gh", _gh_returning(quoted)):
-        assert self_merge_check.ai_review_abstained("o/r", 1) is False
+    assert _abstained(quoted) is False
 
 
-@pytest.mark.parametrize(
-    "raw", ["", "   \n", "not a marker", "<!-- bob-ai-review {bad json} -->"]
-)
-def test_api_or_decode_failure_is_unknown(raw: str) -> None:
-    with patch.object(self_merge_check, "run_gh", lambda *a, **k: raw):
-        assert self_merge_check.ai_review_abstained("o/r", 1) is None
+def test_failed_lookup_is_unknown() -> None:
+    """A failed call is not evidence. It must never read as 'did not abstain'."""
+    with patch.object(self_merge_check, "run_gh_checked", lambda *a, **k: None):
+        assert (
+            self_merge_check.ai_review_abstained("o/r", 1, expected_author=REVIEWER)
+            is None
+        )
 
 
-def test_query_requests_latest_structured_marker() -> None:
+def test_unknown_identity_is_unknown() -> None:
+    """Without an identity no marker can be attributed, so nothing is concluded."""
+    with patch.object(
+        self_merge_check, "run_gh_checked", _gh_returning(ABSTENTION_BODY)
+    ):
+        assert (
+            self_merge_check.ai_review_abstained("o/r", 1, expected_author="") is None
+        )
+
+
+def test_corrupt_marker_from_our_reviewer_is_unknown() -> None:
+    """A marker we cannot parse is corruption, not absence.
+
+    Reading it as "no marker" would let a mangled abstention pass as
+    "did not abstain" — the failure this gate exists to prevent.
+    """
+    assert _abstained("<!-- bob-ai-review {bad json} -->") is None
+
+
+@pytest.mark.parametrize("body", ["", "   \n", "not a marker"])
+def test_comments_without_any_marker_are_not_an_abstention(body: str) -> None:
+    assert _abstained(body) is False
+
+
+def test_marker_from_another_account_is_ignored() -> None:
+    """The marker is plain text and invisible in the rendered view.
+
+    Without an author check, anyone able to comment could paste a `score: null`
+    marker and block the PR from ever merging.
+    """
+    assert _abstained(ABSTENTION_BODY, author="mallory") is False
+
+
+def test_fetch_is_author_scoped_and_paginated() -> None:
     captured: list[str] = []
 
     def _capture(args: list[str], **kwargs: Any) -> str:
         captured.extend(args)
-        return CLEAN_REVIEW_BODY
+        return json.dumps({"author": REVIEWER, "body": CLEAN_REVIEW_BODY})
 
-    with patch.object(self_merge_check, "run_gh", _capture):
-        assert self_merge_check.ai_review_abstained("o/r", 42) is False
+    with patch.object(self_merge_check, "run_gh_checked", _capture):
+        assert (
+            self_merge_check.ai_review_abstained("o/r", 42, expected_author=REVIEWER)
+            is False
+        )
 
-    assert "repos/o/r/issues/42/comments?per_page=100" in captured
+    assert "repos/o/r/issues/42/comments" in captured
     assert "--paginate" in captured
-    assert "--slurp" in captured
+    # The author is carried in the response and filtered in Python, so the query
+    # must actually request it rather than selecting on body alone.
     query = captured[captured.index("--jq") + 1]
-    assert self_merge_check.AI_REVIEW_COMMENT_MARKER in query
-    assert ".[][]" in query
-    assert "last" in query
-    assert "__NO_AI_REVIEW__" in query
+    assert "author" in query
+    assert "body" in query
 
 
 # ---------------------------------------------------------------------------
@@ -210,6 +249,9 @@ def _evaluate(*comment_bodies: str) -> Any:
             return_value={"unresolved": 0, "authors": []},
         ),
         patch.object(self_merge_check, "run_gh", _gh_returning(*comment_bodies)),
+        patch.object(
+            self_merge_check, "run_gh_checked", _gh_returning(*comment_bodies)
+        ),
     ):
         return self_merge_check.evaluate_pr(
             "gptme/gptme-cloud", 999, workspace_repos=["gptme/gptme-cloud"]
@@ -241,8 +283,13 @@ def test_evaluate_pr_unchanged_when_there_is_no_ai_review() -> None:
     assert result.eligible
 
 
-def test_greptile_blocker_is_untouched() -> None:
-    """The existing `Greptile review not found` gate must still fire on its own."""
+def test_unverifiable_greptile_state_refuses_the_ai_fallback() -> None:
+    """A clean AI review must not rescue a PR whose Greptile state cannot be read.
+
+    `_fetch_greptile_review_data` returning None means the lookup failed, not that
+    Greptile is absent. Treating it as absence would open the AI-review fallback
+    on any transient API error, so the gate fails closed instead.
+    """
     pr_data: dict[str, object] = {
         "number": 999,
         "author": {"login": "TimeToBuildBob"},
@@ -274,11 +321,14 @@ def test_greptile_blocker_is_untouched() -> None:
             "fetch_unresolved_human_threads",
             return_value={"unresolved": 0, "authors": []},
         ),
-        # A clean AI review does not rescue a PR Greptile never reviewed.
+        # A clean AI review does not rescue a PR whose Greptile state is unknown.
         patch.object(self_merge_check, "run_gh", _gh_returning(CLEAN_REVIEW_BODY)),
+        patch.object(
+            self_merge_check, "run_gh_checked", _gh_returning(CLEAN_REVIEW_BODY)
+        ),
     ):
         result = self_merge_check.evaluate_pr(
             "gptme/gptme-cloud", 999, workspace_repos=["gptme/gptme-cloud"]
         )
     assert not result.eligible
-    assert "Greptile review not found" in result.reasons
+    assert any("Could not verify Greptile review state" in r for r in result.reasons)

--- a/tests/test_self_merge_ai_review_gate.py
+++ b/tests/test_self_merge_ai_review_gate.py
@@ -77,7 +77,12 @@ def _comment(marker: dict[str, Any] | None, author: str = AUTHOR) -> str:
 
 @pytest.fixture
 def gh_comments(monkeypatch: pytest.MonkeyPatch) -> Any:
-    """Stub run_gh so the issue-comments fetch returns canned JSONL."""
+    """Stub the gh helpers so the issue-comments fetch returns canned JSONL.
+
+    Both ``run_gh`` and ``run_gh_checked`` are stubbed: the marker fetch uses the
+    checked variant so it can tell a failed call from an empty one, while other
+    call sites still use the plain one.
+    """
 
     def _install(lines: list[str]) -> list[list[str]]:
         calls: list[list[str]] = []
@@ -87,6 +92,7 @@ def gh_comments(monkeypatch: pytest.MonkeyPatch) -> Any:
             return "\n".join(lines)
 
         monkeypatch.setattr(smc, "run_gh", fake_run_gh)
+        monkeypatch.setattr(smc, "run_gh_checked", fake_run_gh)
         return calls
 
     return _install
@@ -416,6 +422,7 @@ def evaluate(monkeypatch: pytest.MonkeyPatch) -> Any:
             return "\n".join(comments)
 
         monkeypatch.setattr(smc, "run_gh", fake_run_gh)
+        monkeypatch.setattr(smc, "run_gh_checked", fake_run_gh)
         monkeypatch.setattr(smc, "fetch_pr", lambda repo, number: _pr_payload())
         monkeypatch.setattr(smc, "get_gh_user", lambda: AUTHOR)
         monkeypatch.setattr(smc, "merge_permission", lambda repo: True)
@@ -500,11 +507,18 @@ def test_evaluate_pr_reason_unchanged_when_no_ai_review(evaluate: Any) -> None:
     assert "Greptile review not found" in result.reasons
 
 
-def test_greptile_path_is_untouched_and_pays_no_extra_call(evaluate: Any) -> None:
-    """It's an OR: when Greptile reviewed, the marker is never even fetched."""
+def test_greptile_path_is_untouched_and_pays_one_marker_fetch(evaluate: Any) -> None:
+    """It's an OR: a Greptile review still decides the outcome on its own.
+
+    The marker *is* fetched now, because the abstention blocker has to read it on
+    every PR regardless of Greptile. What matters is that it costs exactly one
+    fetch shared by both readers, not one each, and that it does not change the
+    verdict on the Greptile path.
+    """
     result, calls = evaluate(greptile=GREPTILE_CLEAN, comments=[_comment(_marker())])
     assert result.eligible is True
-    assert not any("issues/1382/comments" in " ".join(c) for c in calls)
+    marker_fetches = [c for c in calls if "issues/1382/comments" in " ".join(c)]
+    assert len(marker_fetches) == 1
 
 
 def test_greptile_unresolved_still_blocks_despite_clean_ai_review(

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -28,16 +28,18 @@ _REAL_MERGE_PERMISSION = self_merge_check.merge_permission.__wrapped__
 
 
 @pytest.fixture(autouse=True)
-def _stub_merge_permission():
-    """Default merge_permission to True so evaluate_pr tests don't make a live
-    gh call (and aren't sensitive to the test runner's actual repo access).
+def _stub_external_merge_checks():
+    """Keep evaluate_pr tests independent of GitHub access.
 
-    merge_permission is @cache'd, so clear the cache around each test to keep
-    per-test patches (True/False/None) isolated. Tests exercising the
-    permission gate itself patch merge_permission explicitly.
+    The permission and AI-review helpers both make live ``gh`` calls and fail
+    closed when their state is unreadable. Tests for those gates patch the
+    helpers explicitly.
     """
     self_merge_check.merge_permission.cache_clear()
-    with patch.object(self_merge_check, "merge_permission", return_value=True):
+    with (
+        patch.object(self_merge_check, "merge_permission", return_value=True),
+        patch.object(self_merge_check, "ai_review_abstained", return_value=False),
+    ):
         yield
     self_merge_check.merge_permission.cache_clear()
 


### PR DESCRIPTION
Our self-hosted AI reviewer ([bob#1122](https://github.com/ErikBjare/bob/issues/1122)) can decline to review at all. On a submodule-pointer bump it says so verbatim:

> ℹ️ **Submodule pointer change only — not reviewed.**
>
> This diff moves a submodule SHA and contains no source changes, so there is nothing here for me to assess. Whether the bump is safe depends on the submodule's commit range, which this diff does not include. **Treat this as *not reviewed*, not as approved.**

The self-merge gate could not see that — `grep -c "not reviewed\|abstain" self-merge-check.py` returned **0**.

### What that cost
gptme/gptme-cloud#850 self-merged carrying exactly that comment. gptme-cloud master's submodule now pins `f4899c16eabf` — a merge of `feat/copy-as-markdown-v2` into `feat/resolved-model-id-in-metadata`, i.e. the heads of gptme#3485 and #3486, **both still open**. Five commits ahead of gptme master. Prod is pinned to an unmerged branch snapshot that nothing reviewed.

### The change
An explicit abstention becomes a disqualifying reason:

```
AI review abstained — not reviewed
```

### Scope — read this before extending it
This is deliberately a **negative signal only**.

- **Abstention → BLOCK.** Fail-safe, strictly reduces what can merge, needs no policy decision. That is all this PR does.
- **Clean AI review → ALLOW is NOT implemented and must not be.** That would make our own reviewer a merge credential in place of Greptile — a separate, open decision for Erik. The existing `Greptile review not found` blocker is untouched, and `test_greptile_blocker_is_untouched` pins that a zero-finding AI review does not rescue a PR Greptile never reviewed.

### Design notes
- **Reads structured `score: null` provenance** from the latest `bob-ai-review` marker instead of coupling the gate to human-facing prose.
- **Selects on the `<!-- bob-ai-review {` HTML marker**, not the visible heading, so a human comment *quoting* the abstention does not trip it.
- **Only the latest AI review counts across all comment pages.** A submodule-only PR that grows source commits gets re-reviewed for real; the stale abstention above it is not a verdict on the current diff.
- **Fails closed** on API/decode error. An unreadable review state yields `AI review status unavailable` rather than silently removing the safety gate.

### Verification
17 new tests. The gate-level regression test was confirmed to fail against the current code — with the wiring removed it returns `eligible=True, reasons=[]`, reproducing #850 exactly.

Also verified against live data, not just fixtures:

| PR | shape | `ai_review_abstained` |
|---|---|---|
| gptme-cloud#850 | the one that slipped | `True` |
| gptme-contrib#1380 | ordinary review, 3 findings | `False` |
| gptme-contrib#1387 | clean review, 0 findings | `False` |

### Follow-up not in this PR
`scripts/github/self-merge-check.py` is forked into Bob's brain repo; that copy has the same hole and needs the same change.

