### PR TITLE
docs(pr_review): cross-reference the three PR-review implementations

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/pr_review/__init__.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pr_review/__init__.py
@@ -3,6 +3,28 @@
 Phase 0: versioned finding schema + golden corpus for model evaluation.
 Phase 1: local CLI runner — working-tree / commit-range reviews without forge.
 Phase 2 (later): GitHub publisher with idempotency guards + PM integration.
+
+What this module IS: the forge-neutral entry point for reviewing a *local*
+diff (``review --working-tree`` / commit range) — ``reviewer.py`` makes zero
+forge calls — plus the versioned finding schema and the package shell intended
+to host the production review engine once it is promoted here.
+
+What this module is NOT: the reviewer that runs in production, and not a
+GitHub publisher today. Two siblings exist:
+
+- ``scripts/github/ai-review.py`` (ErikBjare/bob, **private**) is the reviewer
+  that actually posts PR findings on a 20-minute sweep. Its
+  ``<!-- bob-ai-review-finding -->`` marker is a wire protocol read by
+  ``scripts/github/self-merge-check.py`` and ``scripts/github/activity-gate.sh``
+  in this repo — do not emit a competing marker from here.
+- ``gptme.util.review`` / ``gptme-util review pr`` (gptme core, public) is the
+  model-facing primitive and the source of truth for the artifact schema.
+
+The one-shot prompt in ``reviewer.py`` should not be developed further; the
+promoted engine replaces it. Comparison, retirement plan, and a routing table
+("which tool for which task") live in
+``knowledge/technical/pr-review-systems-map.md`` in the ErikBjare/bob
+workspace.
 """
 
 from .reviewer import REVIEW_PROMPT_VERSION, resolve_local_target, run_review


### PR DESCRIPTION
Three PR-review implementations exist across three repos, and until now nothing pointed between them:

1. `scripts/github/ai-review.py` (ErikBjare/bob, **private**) — the only one with production traffic. Posts a marker comment + inline findings to GitHub on a 20-minute sweep.
2. `gptme_runloops.pr_review` (**this repo**) — forge-neutral local-diff entry point (`review --working-tree`) + versioned finding schema + package shell.
3. `gptme-util review pr` (gptme core, public) — the model-facing primitive: diff in, `ReviewArtifact` out, writes nothing.

This adds a short "what this module IS / is NOT" note to the `pr_review` package docstring so a consumer lands on the right tool instead of extending the wrong one. It also records the constraint that matters to *this* repo: `<!-- bob-ai-review-finding -->` is a wire protocol read by `scripts/github/self-merge-check.py:716` and `scripts/github/activity-gate.sh:114` — a competing marker emitted from `pr_review` would double-post and desync the self-merge gate.

**Docstring only — no code change.** `packages/gptme-runloops/tests` review selection: 114 passed. ruff check + format clean.

Full comparison (measured line counts, traffic, precision), retirement plan, migration steps, and a "which tool for which task" routing table live in `knowledge/technical/pr-review-systems-map.md` in the bob workspace.