### PR TITLE
feat(self-merge): accept our own review as an alternative to Greptile

### DIFF
--- a/scripts/github/README.md
+++ b/scripts/github/README.md
@@ -19,8 +19,18 @@ existed. See `scripts/workflow/read-the-task-before-reinvestigating` patterns.)
 | Read the score signal | `greptile-merge-signal.py` (summary score ≥ threshold + "Safe to merge") | reusable; default 5/5 |
 | Address findings, push | (agent session) | fix the code |
 | **Resolve addressed threads** | `resolve-greptile-threads.py` | the `resolveReviewThread` mutation; fix-first; resolves Greptile-bot threads only |
-| Gate the merge | `self-merge-check.py` | CI green + Greptile present + no unresolved threads + **score floor** (`SELF_MERGE_MIN_GREPTILE_SCORE`, default 5/5) + category/sensitive-path filter |
+| Gate the merge | `self-merge-check.py` | CI green + a clean machine review + no unresolved threads + **score floor** (`SELF_MERGE_MIN_GREPTILE_SCORE`, default 5/5) + category/sensitive-path filter |
 | Merge | `self-merge-if-eligible.sh` / `pr-address-wait-and-merge.sh` *(Bob)* | bounded poll-budget wait → merge |
+
+**Greptile is not the only accepted reviewer.** On repos Greptile does not cover, the gate was
+unsatisfiable ("Greptile review not found"). `self-merge-check.py` now also accepts the self-hosted
+reviewer's `<!-- bob-ai-review {…} -->` summary marker — but only at full strength: 5/5, at the
+current head SHA, with an undegraded consensus record, non-abstaining, and posted by the
+authenticated user. Anything less falls back to requiring Greptile. It is an OR, never a
+replacement: when Greptile has reviewed, the path is byte-for-byte what it always was and the
+marker is not even fetched. Kill switch: `SELF_MERGE_ACCEPT_AI_REVIEW=0`. The strictness is tuned
+for **recall**, not precision — a false finding only lowers the score and costs a wasted round,
+whereas a missed bug produces a clean score and an unreviewed merge.
 
 **Robustness patterns (tuned at scale — reuse, don't reinvent):**
 - **Rate limits**: gate on `github-rate-limit-health.sh` (`GH_RATE_LIMIT_HELPER`; `self-merge-check.py`

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -110,7 +110,7 @@ from datetime import datetime, timezone
 from fnmatch import fnmatchcase
 from functools import cache
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Iterator, cast
 
 MAX_GRAPHQL_PAGE_SIZE = 100
 DEFAULT_MIN_GREPTILE_SCORE = 5
@@ -792,9 +792,29 @@ def _is_ai_review_thread(comments: list[dict[str, Any]]) -> bool:
 # Summary marker upserted by the self-hosted reviewer onto one issue comment per
 # PR: `<!-- bob-ai-review {json} -->`. The space before `{` is load-bearing — it
 # is what stops this pattern from also matching `<!-- bob-ai-review-finding -->`
-# and the per-finding `<!-- bob-ai-review-fp {...} -->`. Same regex the reviewer's
-# own consumers (ai-review.py, ai-review-sweep.py) use; keep them in step.
-_AI_REVIEW_SUMMARY_RE = re.compile(r"<!-- bob-ai-review (\{.*?\}) -->", re.DOTALL)
+# and the per-finding `<!-- bob-ai-review-fp {...} -->`.
+_AI_REVIEW_MARKER_PREFIX = "<!-- bob-ai-review "
+_JSON_DECODER = json.JSONDecoder()
+
+
+def _iter_ai_review_markers(body: str) -> Iterator[dict[str, Any]]:
+    """Yield complete JSON objects from self-hosted-review summary markers.
+
+    Regex cannot safely delimit JSON because real markers contain nested objects.
+    ``raw_decode`` consumes exactly one complete JSON value, after which we verify
+    the marker suffix so arbitrary prose containing the prefix is ignored.
+    """
+    offset = 0
+    while (start := body.find(_AI_REVIEW_MARKER_PREFIX, offset)) != -1:
+        json_start = start + len(_AI_REVIEW_MARKER_PREFIX)
+        try:
+            parsed, json_end = _JSON_DECODER.raw_decode(body, json_start)
+        except json.JSONDecodeError:
+            offset = json_start
+            continue
+        if body.startswith(" -->", json_end) and isinstance(parsed, dict):
+            yield parsed
+        offset = max(json_end, json_start + 1)
 
 
 def _ai_review_enabled() -> bool:
@@ -903,13 +923,8 @@ def _fetch_ai_review_marker(
         # Last match wins within a body, and the last qualifying comment wins
         # overall: the reviewer upserts a single comment, but a repo with legacy
         # append-style comments should still be read at its most recent verdict.
-        for match in _AI_REVIEW_SUMMARY_RE.finditer(comment.get("body") or ""):
-            try:
-                parsed = json.loads(match.group(1))
-            except json.JSONDecodeError:
-                continue
-            if isinstance(parsed, dict):
-                latest = parsed
+        for parsed in _iter_ai_review_markers(comment.get("body") or ""):
+            latest = parsed
     return latest
 
 

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -6,7 +6,9 @@ autonomous AI agent can safely merge its own PRs without human review.
 
 Policy summary:
 - CI must be green (or skipped)
-- Greptile review must be present and have no unresolved threads
+- A machine review must be present and clean: EITHER a Greptile review with no
+  unresolved threads, OR a high-confidence review from the agent's own
+  self-hosted AI reviewer (see "Accepting our own review" below)
 - PR must be authored by the authenticated user
 - Changed files must fall into a low-risk category (tests, docs, lessons, internal
   tooling, task metadata)
@@ -20,6 +22,43 @@ To allow cross-repo merges, either:
   category/CI/Greptile checks still apply.
 - Or clear WORKSPACE_REPO entirely (set it to empty string) to disable the
   cross-repo restriction (not recommended; widens the merge surface).
+
+Accepting our own review
+------------------------
+Greptile does not run on every repo, and when it is absent this gate used to be
+unsatisfiable — "Greptile review not found" blocked PRs that our own reviewer had
+already reviewed in full (observed on gptme/gptme-contrib#1382). The reviewer's
+verdict is now accepted as an *alternative* to Greptile. It is strictly an OR:
+when Greptile has reviewed, nothing about this gate's behaviour changes, and the
+marker is not even fetched.
+
+The strictness here is set by which direction the errors run. The reviewer's
+measured precision is 37%, but precision governs *false findings*, and a false
+finding lowers the score, which makes this gate more conservative — it costs a
+wasted round, not a bad merge. The dangerous direction is **recall**: a missed
+bug produces a clean score and an unreviewed merge. So every condition below
+exists to make "clean" mean "clean on real evidence", and anything short of that
+falls back to requiring Greptile rather than approving:
+
+- score is 5/5 — the rubric's only "nothing outstanding on this head" value.
+  Deliberately not env-overridable, unlike the Greptile floor.
+- the review is at the current head SHA (a review of an older push says nothing
+  about the code about to merge)
+- consensus is present and undegraded — no lost passes, no lost fan-out jobs, no
+  clamped agreement threshold. A degraded run reached its score on less evidence
+  than it asked for, which is exactly the recall failure. A **missing** consensus
+  record means no consensus stage ran at all (the hourly sweep's single-pass
+  reviews, or the agent engine); the reviewer documents that as "unknown, never
+  read as full consensus", so it does not satisfy this gate either. Get a
+  qualifying review with a consensus re-review: `ai-review.py OWNER/REPO N --force`.
+- the reviewer did not abstain (a null score is "no verdict" — the submodule
+  pointer-bump case — and must never read as a pass)
+- the marker comment was posted by the authenticated user. Anyone can write the
+  marker string into a comment on our PR; only our own account posts a real one.
+
+Unresolved findings do not need a separate check: 5/5 is defined as zero findings
+on the reviewed head, and the reviewer deletes its own superseded inline comments
+on each re-review.
 
 Usage:
     python3 scripts/github/self-merge-check.py <pr-url>
@@ -46,6 +85,10 @@ Environment:
                     "owner/repo:path-glob[,owner/repo:path-glob...]".
                     Uses repo-relative segment globs (* stays within one
                     directory segment; ** matches zero or more directories).
+    SELF_MERGE_ACCEPT_AI_REVIEW
+                    Set to 0/false/no/off to disable the self-hosted-AI-review
+                    alternative entirely, restoring the Greptile-only gate.
+                    Kill switch for the "Accepting our own review" path above.
 
 Exit codes:
     0   Eligible for self-merge
@@ -71,6 +114,16 @@ from typing import Any, cast
 
 MAX_GRAPHQL_PAGE_SIZE = 100
 DEFAULT_MIN_GREPTILE_SCORE = 5
+
+# The one score on the reviewer's 0-5 rubric that means "nothing outstanding on
+# the commit reviewed". Not env-overridable, deliberately: SELF_MERGE_MIN_GREPTILE_SCORE
+# can be lowered, and letting the same knob lower *this* floor would turn the
+# alternative path into the weakest link in the gate.
+AI_REVIEW_CLEAN_SCORE = 5
+# Shortest marker SHA prefix accepted when matching against the PR head. The
+# reviewer writes 12 hex chars; this only guards against a truncated/garbage
+# marker whose 1-2 char "sha" would prefix-match almost any head.
+MIN_SHA_PREFIX_LEN = 7
 
 DOC_EXTENSIONS = {".md", ".rst", ".txt", ".adoc"}
 SPEC_LIKE_DOCS = {
@@ -167,6 +220,7 @@ BOT_CONFIG_FILES = {
 }
 BOT_CONFIG_PREFIXES = (".github/",)
 SELF_MERGE_ALLOWED_PATHS_ENV = "SELF_MERGE_ALLOWED_PATHS"
+SELF_MERGE_ACCEPT_AI_REVIEW_ENV = "SELF_MERGE_ACCEPT_AI_REVIEW"
 GATE_HELPER_ENV = "GH_RATE_LIMIT_HELPER"
 GATE_HELPER_ENV_LEGACY = "BOB_GH_RATE_LIMIT_HELPER"
 FORCE_SELF_MERGE_CHECK_ENV = "FORCE_SELF_MERGE_CHECK"
@@ -735,6 +789,182 @@ def _is_ai_review_thread(comments: list[dict[str, Any]]) -> bool:
     return _AI_REVIEW_FINDING_MARKER in (comments[0].get("body") or "")
 
 
+# Summary marker upserted by the self-hosted reviewer onto one issue comment per
+# PR: `<!-- bob-ai-review {json} -->`. The space before `{` is load-bearing — it
+# is what stops this pattern from also matching `<!-- bob-ai-review-finding -->`
+# and the per-finding `<!-- bob-ai-review-fp {...} -->`. Same regex the reviewer's
+# own consumers (ai-review.py, ai-review-sweep.py) use; keep them in step.
+_AI_REVIEW_SUMMARY_RE = re.compile(r"<!-- bob-ai-review (\{.*?\}) -->", re.DOTALL)
+
+
+def _ai_review_enabled() -> bool:
+    """Whether our own review may satisfy the machine-review requirement."""
+    raw = os.environ.get(SELF_MERGE_ACCEPT_AI_REVIEW_ENV, "").strip().lower()
+    return raw not in ("0", "false", "no", "off")
+
+
+def _sha_matches_head(marker_sha: str, head_sha: str) -> bool:
+    """Whether a marker's (possibly abbreviated) SHA names the PR's current head.
+
+    The reviewer records 12 hex chars while the PR carries the full 40, so this
+    is prefix matching -- but only above ``MIN_SHA_PREFIX_LEN``, so a truncated
+    or garbage marker cannot prefix-match its way onto an arbitrary head.
+    """
+    marker_sha = (marker_sha or "").strip().lower()
+    head_sha = (head_sha or "").strip().lower()
+    if len(marker_sha) < MIN_SHA_PREFIX_LEN or len(head_sha) < MIN_SHA_PREFIX_LEN:
+        return False
+    return head_sha.startswith(marker_sha) or marker_sha.startswith(head_sha)
+
+
+def _consensus_shortfall(consensus: Any) -> str | None:
+    """Why a review's consensus is not trustworthy evidence, or None if it is.
+
+    Mirrors the reviewer's own ``consensus_degraded`` (lost passes OR lost
+    fan-out jobs) and additionally rejects a *clamped* agreement threshold and a
+    run where nothing at all answered:
+
+    - lost passes / lost jobs: the score was reached on less evidence than was
+      requested. Job loss is the one that matters in practice -- a pass counts as
+      "answered" when any single one of its aspect jobs returns, so a wave can
+      lose two thirds of its jobs and still report every pass answered.
+    - clamped agreement: the filter that ran is weaker than the filter asked for.
+    - zero answered: every call failed, so there are no findings, so the score
+      computes to a clean 5/5 off an empty result. That is the exact recall
+      failure this whole function exists to catch.
+    """
+    if not isinstance(consensus, dict):
+        # Absent or malformed. The reviewer's contract is explicit that a missing
+        # record means "no consensus stage ran" (single-pass sweep review, or the
+        # agent engine) and must be read as unknown -- never as full consensus.
+        return "no consensus record (single-pass or agent review)"
+
+    def _int(key: str) -> int | None:
+        value = consensus.get(key)
+        return value if isinstance(value, int) else None
+
+    requested, answered = _int("requested"), _int("answered")
+    jobs_requested, jobs_answered = _int("jobs_requested"), _int("jobs_answered")
+    if requested is None or answered is None:
+        return "consensus record is missing pass counts"
+    if jobs_requested is None or jobs_answered is None:
+        return "consensus record is missing job counts"
+
+    if answered < 1 or jobs_answered < 1:
+        return "no consensus pass answered"
+    if requested > 1 and answered < requested:
+        return f"consensus degraded ({answered}/{requested} passes answered)"
+    if jobs_requested > 1 and jobs_answered < jobs_requested:
+        return f"consensus degraded ({jobs_answered}/{jobs_requested} jobs answered)"
+
+    applied, asked = _int("min_agreement"), _int("min_agreement_requested")
+    if applied is not None and asked is not None and applied < asked:
+        return f"consensus agreement clamped to {applied} (requested {asked})"
+    return None
+
+
+def _fetch_ai_review_marker(
+    repo: str, pr_number: int, *, expected_author: str
+) -> dict[str, Any] | None:
+    """Latest self-hosted-review summary marker on the PR, parsed.
+
+    Only comments authored by *expected_author* are considered: the marker is
+    plain text in a comment body, so any account that can comment on the PR could
+    otherwise forge a clean verdict for a gate that then merges without a human.
+    An empty *expected_author* means the identity could not be established, and
+    the marker is not trusted at all.
+    """
+    if not expected_author:
+        return None
+    raw = run_gh(
+        [
+            "api",
+            f"repos/{repo}/issues/{pr_number}/comments",
+            "--paginate",
+            "--jq",
+            ".[] | {author: .user.login, body: .body}",
+        ],
+        timeout=30,
+    )
+    if not raw:
+        return None
+
+    latest: dict[str, Any] | None = None
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            comment = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(comment, dict) or comment.get("author") != expected_author:
+            continue
+        # Last match wins within a body, and the last qualifying comment wins
+        # overall: the reviewer upserts a single comment, but a repo with legacy
+        # append-style comments should still be read at its most recent verdict.
+        for match in _AI_REVIEW_SUMMARY_RE.finditer(comment.get("body") or ""):
+            try:
+                parsed = json.loads(match.group(1))
+            except json.JSONDecodeError:
+                continue
+            if isinstance(parsed, dict):
+                latest = parsed
+    return latest
+
+
+def fetch_ai_review_status(
+    repo: str, pr_number: int, *, head_sha: str, expected_author: str
+) -> dict[str, Any]:
+    """Whether our own reviewer's verdict is strong enough to stand in for Greptile.
+
+    Returns ``{"accepted": bool, "detail": str | None}``. ``detail`` explains a
+    refusal so the gate's "Greptile review not found" reason can say *why* the
+    fallback did not apply, rather than leaving the operator to guess whether the
+    reviewer ran at all.
+
+    Every refusal path falls back to today's Greptile-only behaviour. Nothing
+    here can make a PR *more* mergeable than the rest of the gate allows -- CI,
+    category, human threads and author identity are all still evaluated.
+    """
+    if not _ai_review_enabled():
+        return {"accepted": False, "detail": None}
+
+    marker = _fetch_ai_review_marker(repo, pr_number, expected_author=expected_author)
+    if marker is None:
+        return {"accepted": False, "detail": None}
+
+    if not _sha_matches_head(str(marker.get("sha") or ""), head_sha):
+        return {
+            "accepted": False,
+            "detail": (
+                f"AI review is stale (reviewed {marker.get('sha') or 'unknown'}, "
+                f"head is {head_sha[:12]})"
+            ),
+        }
+
+    score = marker.get("score")
+    if score is None:
+        return {"accepted": False, "detail": "AI reviewer abstained (no score)"}
+    if not isinstance(score, int) or score < AI_REVIEW_CLEAN_SCORE:
+        return {
+            "accepted": False,
+            "detail": f"AI review score {score}/5 below {AI_REVIEW_CLEAN_SCORE}/5",
+        }
+
+    shortfall = _consensus_shortfall(marker.get("consensus"))
+    if shortfall:
+        return {"accepted": False, "detail": f"AI review {shortfall}"}
+
+    return {
+        "accepted": True,
+        "detail": (
+            f"AI review {score}/5 at current head {str(marker.get('sha'))[:12]}, "
+            "full consensus"
+        ),
+    }
+
+
 def fetch_unresolved_human_threads(
     repo: str,
     pr_number: int,
@@ -1250,7 +1480,26 @@ def evaluate_pr(
 
     greptile = fetch_greptile_status(repo, number, review_data=shared_review_data)
     if not greptile["has_review"]:
-        result.reasons.append("Greptile review not found")
+        # OR, not replacement: only reached when Greptile has not reviewed, so a
+        # repo where Greptile still runs takes the identical path it always has
+        # and does not even pay the extra API call. See "Accepting our own
+        # review" in the module docstring for why the bar is set where it is.
+        ai_review = fetch_ai_review_status(
+            repo,
+            number,
+            head_sha=result.head_sha,
+            expected_author=current_user,
+        )
+        if ai_review["accepted"]:
+            result.warnings.append(
+                f"Greptile review not found; satisfied by self-hosted "
+                f"AI review ({ai_review['detail']})"
+            )
+        else:
+            reason = "Greptile review not found"
+            if ai_review["detail"]:
+                reason += f"; {ai_review['detail']}"
+            result.reasons.append(reason)
     elif greptile["unresolved"] > 0:
         result.reasons.append(
             f"Greptile has {greptile['unresolved']} unresolved review thread(s)"

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -861,7 +861,8 @@ def _consensus_shortfall(consensus: Any) -> str | None:
 
     def _int(key: str) -> int | None:
         value = consensus.get(key)
-        return value if isinstance(value, int) else None
+        # bool is an int subclass in Python, but it is never a valid count.
+        return value if type(value) is int else None
 
     requested, answered = _int("requested"), _int("answered")
     jobs_requested, jobs_answered = _int("jobs_requested"), _int("jobs_answered")
@@ -870,15 +871,22 @@ def _consensus_shortfall(consensus: Any) -> str | None:
     if jobs_requested is None or jobs_answered is None:
         return "consensus record is missing job counts"
 
+    # One pass is the sweep's non-consensus mode even if a marker explicitly
+    # serializes 1/1 counts. Qualifying evidence must contain multiple independent
+    # passes, not merely a present consensus object.
+    if requested < 2:
+        return "consensus requires at least 2 requested passes"
     if answered < 1 or jobs_answered < 1:
         return "no consensus pass answered"
-    if requested > 1 and answered < requested:
+    if answered < requested:
         return f"consensus degraded ({answered}/{requested} passes answered)"
-    if jobs_requested > 1 and jobs_answered < jobs_requested:
+    if jobs_answered < jobs_requested:
         return f"consensus degraded ({jobs_answered}/{jobs_requested} jobs answered)"
 
     applied, asked = _int("min_agreement"), _int("min_agreement_requested")
-    if applied is not None and asked is not None and applied < asked:
+    if applied is None or asked is None:
+        return "consensus record is missing agreement thresholds"
+    if applied < asked:
         return f"consensus agreement clamped to {applied} (requested {asked})"
     return None
 

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -889,6 +889,20 @@ def _consensus_shortfall(consensus: Any) -> str | None:
     applied, asked = _int("min_agreement"), _int("min_agreement_requested")
     if applied is None or asked is None:
         return "consensus record is missing agreement thresholds"
+    # A threshold below 1 is not a weaker consensus, it is *no* consensus: a
+    # finding surviving on zero agreeing passes is exactly what a single pass
+    # already produces. Checking only `applied < asked` misses it, because a
+    # record with min_agreement 0 AND min_agreement_requested 0 is unclamped and
+    # would read as full consensus — while `answered >= 1` above is satisfied by
+    # one pass. That combination hands the gate a single-pass review dressed as
+    # consensus, gutting the recall guard this whole path exists to enforce.
+    # Negatives are rejected by the same test rather than a separate one; both
+    # mean "no agreement was required".
+    if applied < 1 or asked < 1:
+        return (
+            f"consensus agreement threshold below 1 "
+            f"(applied {applied}, requested {asked})"
+        )
     if applied < asked:
         return f"consensus agreement clamped to {applied} (requested {asked})"
     return None
@@ -972,7 +986,22 @@ def fetch_ai_review_status(
     score = marker.get("score")
     if score is None:
         return {"accepted": False, "detail": "AI reviewer abstained (no score)"}
-    if not isinstance(score, int) or score < AI_REVIEW_CLEAN_SCORE:
+    # Type and threshold are separate refusals so the detail names the actual
+    # defect. Folding them together reported a malformed marker (score "5" as a
+    # string, or 5.0) as `AI review score 5/5 below 5/5` — a sentence that is
+    # false on its face and sends whoever reads it hunting for a scoring bug
+    # instead of the marker corruption that caused it. Both still fail closed.
+    # `type(...) is not int` rather than `isinstance`, matching `_int` above:
+    # bool is an int subclass, and `True` is not a review score.
+    if type(score) is not int:
+        return {
+            "accepted": False,
+            "detail": (
+                f"AI review score is not an integer "
+                f"({type(score).__name__}: {score!r})"
+            ),
+        }
+    if score < AI_REVIEW_CLEAN_SCORE:
         return {
             "accepted": False,
             "detail": f"AI review score {score}/5 below {AI_REVIEW_CLEAN_SCORE}/5",

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -824,17 +824,13 @@ def _ai_review_enabled() -> bool:
 
 
 def _sha_matches_head(marker_sha: str, head_sha: str) -> bool:
-    """Whether a marker's (possibly abbreviated) SHA names the PR's current head.
-
-    The reviewer records 12 hex chars while the PR carries the full 40, so this
-    is prefix matching -- but only above ``MIN_SHA_PREFIX_LEN``, so a truncated
-    or garbage marker cannot prefix-match its way onto an arbitrary head.
-    """
+    """Whether a marker's abbreviated SHA names the PR's current head."""
     marker_sha = (marker_sha or "").strip().lower()
     head_sha = (head_sha or "").strip().lower()
     if len(marker_sha) < MIN_SHA_PREFIX_LEN or len(head_sha) < MIN_SHA_PREFIX_LEN:
         return False
-    return head_sha.startswith(marker_sha) or marker_sha.startswith(head_sha)
+    # The marker may abbreviate the authoritative head, never the reverse.
+    return head_sha.startswith(marker_sha)
 
 
 def _consensus_shortfall(consensus: Any) -> str | None:
@@ -880,8 +876,15 @@ def _consensus_shortfall(consensus: Any) -> str | None:
         return "no consensus pass answered"
     if answered < requested:
         return f"consensus degraded ({answered}/{requested} passes answered)"
+    if answered > requested:
+        return f"consensus has invalid pass counts ({answered}/{requested} answered)"
     if jobs_answered < jobs_requested:
         return f"consensus degraded ({jobs_answered}/{jobs_requested} jobs answered)"
+    if jobs_answered > jobs_requested:
+        return (
+            f"consensus has invalid job counts "
+            f"({jobs_answered}/{jobs_requested} answered)"
+        )
 
     applied, asked = _int("min_agreement"), _int("min_agreement_requested")
     if applied is None or asked is None:
@@ -1503,26 +1506,31 @@ def evaluate_pr(
 
     greptile = fetch_greptile_status(repo, number, review_data=shared_review_data)
     if not greptile["has_review"]:
-        # OR, not replacement: only reached when Greptile has not reviewed, so a
-        # repo where Greptile still runs takes the identical path it always has
-        # and does not even pay the extra API call. See "Accepting our own
-        # review" in the module docstring for why the bar is set where it is.
-        ai_review = fetch_ai_review_status(
-            repo,
-            number,
-            head_sha=result.head_sha,
-            expected_author=current_user,
-        )
-        if ai_review["accepted"]:
-            result.warnings.append(
-                f"Greptile review not found; satisfied by self-hosted "
-                f"AI review ({ai_review['detail']})"
+        # The alternative review is safe only after a successful GraphQL fetch
+        # proves there is no Greptile review. An API failure is unknown, not
+        # absence: accepting our marker there would turn a fail-closed outage into
+        # a path around potentially unresolved Greptile feedback.
+        if shared_review_data is None:
+            result.reasons.append(
+                "Could not verify Greptile review state; refusing AI-review fallback"
             )
         else:
-            reason = "Greptile review not found"
-            if ai_review["detail"]:
-                reason += f"; {ai_review['detail']}"
-            result.reasons.append(reason)
+            ai_review = fetch_ai_review_status(
+                repo,
+                number,
+                head_sha=result.head_sha,
+                expected_author=current_user,
+            )
+            if ai_review["accepted"]:
+                result.warnings.append(
+                    f"Greptile review not found; satisfied by self-hosted "
+                    f"AI review ({ai_review['detail']})"
+                )
+            else:
+                reason = "Greptile review not found"
+                if ai_review["detail"]:
+                    reason += f"; {ai_review['detail']}"
+                result.reasons.append(reason)
     elif greptile["unresolved"] > 0:
         result.reasons.append(
             f"Greptile has {greptile['unresolved']} unresolved review thread(s)"

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -262,6 +262,31 @@ def run_gh(args: list[str], timeout: int = 30) -> str:
         return ""
 
 
+def run_gh_checked(args: list[str], timeout: int = 30) -> str | None:
+    """`run_gh`, but `None` means *the call failed* rather than *the result was empty*.
+
+    `run_gh` collapses both into `""`, which is fine wherever an empty result and
+    a failed lookup lead to the same decision. It is not fine where absence is
+    treated as evidence: reading "no Greptile summary comment" out of a timed-out
+    request turns an unknown into a clean bill of health, and here that unknown
+    is what opens the AI-review fallback path.
+    """
+    try:
+        result = subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        if result.returncode != 0:
+            if result.stderr:
+                print(f"[gh error] {result.stderr.strip()}", file=sys.stderr)
+            return None
+        return result.stdout.strip()
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+
+
 def get_gh_user() -> str:
     return run_gh(["api", "user", "-q", ".login"]) or ""
 
@@ -710,7 +735,7 @@ def fetch_greptile_status(
     if not greptile_reviews:
         # Fall back to issue comments for summary-only reviews.
         # Use --paginate so Greptile's comment is found even on PRs with >30 comments.
-        comments_raw = run_gh(
+        comments_raw = run_gh_checked(
             [
                 "api",
                 f"repos/{repo}/issues/{pr_number}/comments",
@@ -720,7 +745,18 @@ def fetch_greptile_status(
             ],
             timeout=30,
         )
-        has_summary = bool(comments_raw and comments_raw.strip())
+        if comments_raw is None:
+            # Could not check — unknown, never absence. Reporting "no Greptile
+            # review" here would open the AI-review fallback on a transient
+            # timeout and could merge a PR that Greptile had unresolved feedback
+            # on, silently bypassing the review this gate exists to require.
+            return {
+                "has_review": False,
+                "unresolved": 0,
+                "total": 0,
+                "unknown": True,
+            }
+        has_summary = bool(comments_raw.strip())
         return {"has_review": has_summary, "unresolved": 0, "total": 0}
 
     def _parse_ts(ts: str) -> datetime:
@@ -1001,10 +1037,15 @@ def fetch_ai_review_status(
                 f"({type(score).__name__}: {score!r})"
             ),
         }
-    if score < AI_REVIEW_CLEAN_SCORE:
+    # Exactly the rubric's clean value, not "at least" it. `confidence_score`
+    # emits 1-5 and nothing else, so a 6 is not a better review — it is a
+    # corrupted or foreign marker, and `<` would wave it through as clean while
+    # every other check (author, SHA, consensus) still passed.
+    if score != AI_REVIEW_CLEAN_SCORE:
+        below = "below" if score < AI_REVIEW_CLEAN_SCORE else "outside the rubric,"
         return {
             "accepted": False,
-            "detail": f"AI review score {score}/5 below {AI_REVIEW_CLEAN_SCORE}/5",
+            "detail": f"AI review score {score}/5 {below} {AI_REVIEW_CLEAN_SCORE}/5",
         }
 
     shortfall = _consensus_shortfall(marker.get("consensus"))
@@ -1539,7 +1580,12 @@ def evaluate_pr(
         # proves there is no Greptile review. An API failure is unknown, not
         # absence: accepting our marker there would turn a fail-closed outage into
         # a path around potentially unresolved Greptile feedback.
-        if shared_review_data is None:
+        # `greptile["unknown"]` covers the second way the lookup can fail: the
+        # GraphQL fetch succeeds and reports no reviews, but the summary-comment
+        # fallback inside `fetch_greptile_status` errors out. That path also
+        # yields `has_review: False`, so gating on `shared_review_data` alone
+        # would let a transient comment-API failure open the AI fallback.
+        if shared_review_data is None or greptile.get("unknown"):
             result.reasons.append(
                 "Could not verify Greptile review state; refusing AI-review fallback"
             )

--- a/tests/test_self_merge_ai_review_gate.py
+++ b/tests/test_self_merge_ai_review_gate.py
@@ -515,3 +515,47 @@ def test_greptile_unresolved_still_blocks_despite_clean_ai_review(
     result, _ = evaluate(greptile=greptile, comments=[_comment(_marker())])
     assert result.eligible is False
     assert any("2 unresolved review thread(s)" in r for r in result.reasons)
+
+
+@pytest.mark.parametrize("score", [6, 7, 100])
+def test_score_above_the_rubric_is_rejected(gh_comments: Any, score: int) -> None:
+    """`confidence_score` emits 1-5; a 6 is corruption, not a better review.
+
+    `score < AI_REVIEW_CLEAN_SCORE` waved these through as clean while author,
+    SHA and consensus checks all still passed — one corrupted numeric field was
+    enough to satisfy the whole alternative path.
+    """
+    status = _status(gh_comments, [_comment(_marker(score=score))])
+    assert status["accepted"] is False
+    assert "outside the rubric" in (status["detail"] or "")
+
+
+def test_failed_summary_comment_fetch_is_unknown_not_absence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transient comment-API failure must not open the AI-review fallback.
+
+    `run_gh` returns "" for both "no Greptile comment" and "the call failed", so
+    `fetch_greptile_status` reported `has_review: False` on a timeout. That is
+    the same shape as a genuinely un-reviewed PR, and `evaluate_pr` only guarded
+    on the GraphQL fetch — so a flaky comment fetch could hand the AI marker a
+    PR that Greptile had unresolved feedback on.
+    """
+    monkeypatch.setattr(smc, "run_gh_checked", lambda *a, **k: None)
+    status = smc.fetch_greptile_status(
+        "gptme/gptme-contrib", 1382, review_data=([], [])
+    )
+    assert status["has_review"] is False
+    assert status["unknown"] is True
+
+
+def test_empty_summary_comment_fetch_is_absence_not_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The other side of the same coin: a real empty result stays actionable."""
+    monkeypatch.setattr(smc, "run_gh_checked", lambda *a, **k: "")
+    status = smc.fetch_greptile_status(
+        "gptme/gptme-contrib", 1382, review_data=([], [])
+    )
+    assert status["has_review"] is False
+    assert not status.get("unknown")

--- a/tests/test_self_merge_ai_review_gate.py
+++ b/tests/test_self_merge_ai_review_gate.py
@@ -176,6 +176,52 @@ def test_clamped_agreement_threshold_is_rejected(gh_comments: Any) -> None:
     assert "clamped" in (status["detail"] or "")
 
 
+@pytest.mark.parametrize(
+    ("applied", "asked"),
+    [
+        (0, 0),  # unclamped, but no agreement was ever required
+        (0, 2),  # clamped to nothing — caught twice over, still must fail
+        (-1, -1),  # nonsense thresholds must not read as "not clamped"
+        (2, 0),  # asked for nothing; `applied < asked` is False here
+    ],
+)
+def test_sub_unit_agreement_thresholds_are_rejected(
+    gh_comments: Any, applied: int, asked: int
+) -> None:
+    """A threshold below 1 is no consensus at all, clamped or not.
+
+    The regression guarded here: `applied < asked` alone accepts `0/0` as
+    undegraded, and since one answered pass satisfies `answered >= 1`, a
+    single-pass review would enter the gate wearing a full-consensus record —
+    the exact recall guard this path exists to enforce, bypassed.
+    """
+    consensus = dict(
+        FULL_CONSENSUS, min_agreement=applied, min_agreement_requested=asked
+    )
+    status = _status(gh_comments, [_comment(_marker(consensus=consensus))])
+    assert status["accepted"] is False
+    assert "below 1" in (status["detail"] or "")
+
+
+@pytest.mark.parametrize("score", ["5", 5.0, True, [5]])
+def test_non_integer_score_is_named_as_a_type_defect(
+    gh_comments: Any, score: Any
+) -> None:
+    """A malformed score must not be reported as a threshold failure.
+
+    `AI review score 5/5 below 5/5` is false on its face and sends a reader
+    hunting for a scoring bug instead of the marker corruption that caused it.
+    Fails closed either way; this pins the *diagnostic*.
+    """
+    marker = _marker()
+    marker["score"] = score
+    status = _status(gh_comments, [_comment(marker)])
+    assert status["accepted"] is False
+    detail = status["detail"] or ""
+    assert "is not an integer" in detail
+    assert "below" not in detail
+
+
 def test_zero_answered_passes_are_rejected(gh_comments: Any) -> None:
     """Every call failed → no findings → a clean 5/5 off an empty result."""
     consensus = dict(FULL_CONSENSUS, answered=0, jobs_answered=0)

--- a/tests/test_self_merge_ai_review_gate.py
+++ b/tests/test_self_merge_ai_review_gate.py
@@ -1,0 +1,380 @@
+"""Our own review may satisfy the self-merge gate — but only at full strength.
+
+The gate hard-required Greptile, so on a repo Greptile does not cover it was
+unsatisfiable: gptme/gptme-contrib#1382 reported
+
+    Eligible: NO
+    - Greptile review not found
+
+while our self-hosted reviewer had already posted a complete review of that PR.
+
+Strictness is set by which direction the errors run. The reviewer's measured
+precision is 37%, but precision governs *false findings*, and a false finding
+lowers the score, which makes the gate more conservative — a wasted round, not a
+bad merge. The dangerous direction is recall: a missed bug yields a clean score
+and an unreviewed merge. So the tests below are mostly about refusing to accept a
+5/5 that was reached on thin evidence — stale head, degraded consensus, abstain,
+forged author — and about the Greptile path being untouched.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "scripts" / "github" / "self-merge-check.py"
+)
+spec = importlib.util.spec_from_file_location("self_merge_check_ai_gate", MODULE_PATH)
+if spec is None or spec.loader is None:
+    pytest.skip(f"Could not load {MODULE_PATH}", allow_module_level=True)
+smc = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = smc
+spec.loader.exec_module(smc)
+
+AUTHOR = "TimeToBuildBob"
+HEAD_SHA = "9af637526840aa11bb22cc33dd44ee55ff667788"
+MARKER_SHA = HEAD_SHA[:12]
+
+FULL_CONSENSUS = {
+    "requested": 3,
+    "answered": 3,
+    "jobs_requested": 9,
+    "jobs_answered": 9,
+    "min_agreement": 2,
+    "min_agreement_requested": 2,
+    "rejected": 4,
+    "failures": [],
+}
+
+
+def _marker(**overrides: Any) -> dict[str, Any]:
+    """A clean, current, full-consensus marker as the reviewer writes it."""
+    marker: dict[str, Any] = {
+        "sha": MARKER_SHA,
+        "score": 5,
+        "engine": "llm",
+        "consensus": dict(FULL_CONSENSUS),
+        "history": [],
+        "suppressed": [],
+    }
+    marker.update(overrides)
+    return marker
+
+
+def _comment(marker: dict[str, Any] | None, author: str = AUTHOR) -> str:
+    """One `gh api --jq` output line: a comment carrying the summary marker."""
+    body = "## AI Review\n\nConfidence Score: 5/5\n"
+    if marker is not None:
+        body += f"\n<!-- bob-ai-review {json.dumps(marker)} -->"
+    return json.dumps({"author": author, "body": body})
+
+
+@pytest.fixture
+def gh_comments(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Stub run_gh so the issue-comments fetch returns canned JSONL."""
+
+    def _install(lines: list[str]) -> list[list[str]]:
+        calls: list[list[str]] = []
+
+        def fake_run_gh(args: list[str], timeout: int = 30) -> str:
+            calls.append(args)
+            return "\n".join(lines)
+
+        monkeypatch.setattr(smc, "run_gh", fake_run_gh)
+        return calls
+
+    return _install
+
+
+def _status(gh_comments: Any, lines: list[str], head: str = HEAD_SHA) -> dict[str, Any]:
+    gh_comments(lines)
+    result: dict[str, Any] = smc.fetch_ai_review_status(
+        "gptme/gptme-contrib", 1382, head_sha=head, expected_author=AUTHOR
+    )
+    return result
+
+
+# --- the case that motivated this: a clean review should satisfy the gate ---
+
+
+def test_clean_current_full_consensus_review_is_accepted(gh_comments: Any) -> None:
+    status = _status(gh_comments, [_comment(_marker())])
+    assert status["accepted"] is True
+    assert "5/5" in (status["detail"] or "")
+
+
+def test_short_marker_sha_matches_full_head(gh_comments: Any) -> None:
+    """The marker records 12 chars; the PR carries 40. Prefix match, either way."""
+    assert smc._sha_matches_head(MARKER_SHA, HEAD_SHA)
+    assert smc._sha_matches_head(HEAD_SHA, MARKER_SHA)
+    status = _status(gh_comments, [_comment(_marker(sha=HEAD_SHA))])
+    assert status["accepted"] is True
+
+
+def test_latest_marker_wins(gh_comments: Any) -> None:
+    """A legacy append-style history reads at its most recent verdict, not its first."""
+    status = _status(
+        gh_comments,
+        [_comment(_marker(score=2)), _comment(_marker())],
+    )
+    assert status["accepted"] is True
+
+
+# --- recall guards: a 5/5 reached on thin evidence must NOT be accepted ---
+
+
+def test_degraded_consensus_is_rejected(gh_comments: Any) -> None:
+    """Lost passes: the score came from fewer samples than were requested."""
+    consensus = dict(FULL_CONSENSUS, answered=2)
+    status = _status(gh_comments, [_comment(_marker(consensus=consensus))])
+    assert status["accepted"] is False
+    assert "degraded" in (status["detail"] or "")
+
+
+def test_lost_fanout_jobs_are_rejected(gh_comments: Any) -> None:
+    """The loss the pass count cannot see: 3/3 passes "answered" on 3 of 9 jobs.
+
+    A pass counts as answered when any single aspect job returns, so this run
+    reports full consensus while two thirds of the evidence is missing.
+    """
+    consensus = dict(FULL_CONSENSUS, jobs_answered=3)
+    status = _status(gh_comments, [_comment(_marker(consensus=consensus))])
+    assert status["accepted"] is False
+    assert "3/9 jobs" in (status["detail"] or "")
+
+
+def test_clamped_agreement_threshold_is_rejected(gh_comments: Any) -> None:
+    """A weaker filter than the one requested is not the filter that was calibrated."""
+    consensus = dict(FULL_CONSENSUS, min_agreement=1)
+    status = _status(gh_comments, [_comment(_marker(consensus=consensus))])
+    assert status["accepted"] is False
+    assert "clamped" in (status["detail"] or "")
+
+
+def test_zero_answered_passes_are_rejected(gh_comments: Any) -> None:
+    """Every call failed → no findings → a clean 5/5 off an empty result."""
+    consensus = dict(FULL_CONSENSUS, answered=0, jobs_answered=0)
+    status = _status(gh_comments, [_comment(_marker(consensus=consensus))])
+    assert status["accepted"] is False
+    assert "no consensus pass answered" in (status["detail"] or "")
+
+
+def test_missing_consensus_record_is_rejected(gh_comments: Any) -> None:
+    """The hourly sweep runs `--passes 1`, which writes no consensus key at all.
+
+    The reviewer documents a missing record as "unknown, never full consensus",
+    and this is the marker shape actually observed live on contrib#1382.
+    """
+    marker = _marker()
+    del marker["consensus"]
+    status = _status(gh_comments, [_comment(marker)])
+    assert status["accepted"] is False
+    assert "no consensus record" in (status["detail"] or "")
+
+
+def test_stale_sha_is_rejected(gh_comments: Any) -> None:
+    """A review of an earlier push says nothing about the code about to merge."""
+    status = _status(gh_comments, [_comment(_marker(sha="deadbeefcafe"))])
+    assert status["accepted"] is False
+    assert "stale" in (status["detail"] or "")
+
+
+def test_abstain_is_rejected(gh_comments: Any) -> None:
+    """`score: null` is the submodule pointer-bump case: no verdict, never a pass."""
+    status = _status(gh_comments, [_comment(_marker(score=None))])
+    assert status["accepted"] is False
+    assert "abstain" in (status["detail"] or "")
+
+
+@pytest.mark.parametrize("score", [1, 2, 3, 4])
+def test_sub_clean_scores_are_rejected(gh_comments: Any, score: int) -> None:
+    status = _status(gh_comments, [_comment(_marker(score=score))])
+    assert status["accepted"] is False
+    assert f"{score}/5" in (status["detail"] or "")
+
+
+def test_marker_from_another_account_is_ignored(gh_comments: Any) -> None:
+    """The marker is plain text; anyone who can comment could otherwise forge it."""
+    status = _status(gh_comments, [_comment(_marker(), author="drive-by-contributor")])
+    assert status["accepted"] is False
+    assert status["detail"] is None
+
+
+def test_unknown_identity_trusts_nothing(gh_comments: Any) -> None:
+    gh_comments([_comment(_marker())])
+    status = smc.fetch_ai_review_status(
+        "gptme/gptme-contrib", 1382, head_sha=HEAD_SHA, expected_author=""
+    )
+    assert status["accepted"] is False
+
+
+def test_no_marker_at_all(gh_comments: Any) -> None:
+    status = _status(gh_comments, [_comment(None)])
+    assert status["accepted"] is False
+    assert status["detail"] is None
+
+
+def test_inline_finding_marker_is_not_a_summary_marker() -> None:
+    """`-finding` and `-fp {..}` share the prefix; only `bob-ai-review {` counts."""
+    assert not smc._AI_REVIEW_SUMMARY_RE.search(smc._AI_REVIEW_FINDING_MARKER)
+    assert not smc._AI_REVIEW_SUMMARY_RE.search('<!-- bob-ai-review-fp {"a": 1} -->')
+    assert smc._AI_REVIEW_SUMMARY_RE.search('<!-- bob-ai-review {"sha": "x"} -->')
+
+
+def test_nested_json_marker_parses_whole() -> None:
+    """The real marker nests objects in `history`; a lazy match must not stop early."""
+    marker = _marker(history=[{"sha": "aaaabbbbcccc", "score": 3}])
+    match = smc._AI_REVIEW_SUMMARY_RE.search(
+        f"text\n<!-- bob-ai-review {json.dumps(marker)} -->\n"
+    )
+    assert match is not None
+    assert json.loads(match.group(1))["consensus"]["jobs_answered"] == 9
+
+
+def test_truncated_sha_cannot_prefix_match_any_head() -> None:
+    assert not smc._sha_matches_head("9a", HEAD_SHA)
+    assert not smc._sha_matches_head("", HEAD_SHA)
+    assert not smc._sha_matches_head(MARKER_SHA, "")
+
+
+def test_kill_switch_restores_greptile_only(
+    gh_comments: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(smc.SELF_MERGE_ACCEPT_AI_REVIEW_ENV, "0")
+    status = _status(gh_comments, [_comment(_marker())])
+    assert status["accepted"] is False
+
+
+def test_enabled_by_default_and_for_non_falsey_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(smc.SELF_MERGE_ACCEPT_AI_REVIEW_ENV, raising=False)
+    assert smc._ai_review_enabled()
+    monkeypatch.setenv(smc.SELF_MERGE_ACCEPT_AI_REVIEW_ENV, "1")
+    assert smc._ai_review_enabled()
+    monkeypatch.setenv(smc.SELF_MERGE_ACCEPT_AI_REVIEW_ENV, "off")
+    assert not smc._ai_review_enabled()
+
+
+# --- end-to-end through evaluate_pr, including the untouched Greptile path ---
+
+
+def _pr_payload() -> dict[str, Any]:
+    return {
+        "number": 1382,
+        "title": "docs: cross-reference the review implementations",
+        "url": "https://github.com/gptme/gptme-contrib/pull/1382",
+        "author": {"login": AUTHOR},
+        "headRefOid": HEAD_SHA,
+        "isDraft": False,
+        "state": "OPEN",
+        "mergeStateStatus": "CLEAN",
+        "statusCheckRollup": [{"conclusion": "SUCCESS", "status": "COMPLETED"}],
+        "reviewDecision": None,
+        "files": [{"path": "docs/review-tools.md"}],
+    }
+
+
+@pytest.fixture
+def evaluate(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Drive evaluate_pr with everything but the review signal stubbed out."""
+
+    def _run(
+        *, greptile: dict[str, Any], comments: list[str]
+    ) -> tuple[Any, list[list[str]]]:
+        calls: list[list[str]] = []
+
+        def fake_run_gh(args: list[str], timeout: int = 30) -> str:
+            calls.append(args)
+            return "\n".join(comments)
+
+        monkeypatch.setattr(smc, "run_gh", fake_run_gh)
+        monkeypatch.setattr(smc, "fetch_pr", lambda repo, number: _pr_payload())
+        monkeypatch.setattr(smc, "get_gh_user", lambda: AUTHOR)
+        monkeypatch.setattr(smc, "merge_permission", lambda repo: True)
+        monkeypatch.setattr(smc, "_fetch_greptile_review_data", lambda r, n: ([], []))
+        monkeypatch.setattr(
+            smc, "fetch_greptile_status", lambda r, n, review_data=None: greptile
+        )
+        monkeypatch.setattr(
+            smc,
+            "fetch_unresolved_human_threads",
+            lambda r, n, review_data=None: {
+                "unresolved": 0,
+                "total": 0,
+                "authors": [],
+            },
+        )
+        monkeypatch.setattr(smc, "greptile_summary_score", lambda r, n: 5)
+        result = smc.evaluate_pr(
+            "gptme/gptme-contrib", 1382, workspace_repos=["gptme/gptme-contrib"]
+        )
+        return result, calls
+
+    return _run
+
+
+NO_GREPTILE = {"has_review": False, "unresolved": 0, "total": 0}
+GREPTILE_CLEAN = {"has_review": True, "unresolved": 0, "total": 0}
+
+
+def test_evaluate_pr_accepts_our_clean_review_without_greptile(evaluate: Any) -> None:
+    """The #1382 regression: eligible on our own review, no Greptile anywhere."""
+    result, _ = evaluate(greptile=NO_GREPTILE, comments=[_comment(_marker())])
+    assert result.eligible is True
+    assert result.reasons == []
+    assert any("satisfied by self-hosted AI review" in w for w in result.warnings)
+
+
+def test_evaluate_pr_blocks_on_degraded_review(evaluate: Any) -> None:
+    consensus = dict(FULL_CONSENSUS, jobs_answered=4)
+    result, _ = evaluate(
+        greptile=NO_GREPTILE, comments=[_comment(_marker(consensus=consensus))]
+    )
+    assert result.eligible is False
+    assert any("Greptile review not found" in r for r in result.reasons)
+    assert any("degraded" in r for r in result.reasons)
+
+
+def test_evaluate_pr_blocks_on_stale_review(evaluate: Any) -> None:
+    result, _ = evaluate(
+        greptile=NO_GREPTILE, comments=[_comment(_marker(sha="deadbeefcafe"))]
+    )
+    assert result.eligible is False
+    assert any("stale" in r for r in result.reasons)
+
+
+def test_evaluate_pr_blocks_on_abstain(evaluate: Any) -> None:
+    result, _ = evaluate(greptile=NO_GREPTILE, comments=[_comment(_marker(score=None))])
+    assert result.eligible is False
+    assert any("abstain" in r for r in result.reasons)
+
+
+def test_evaluate_pr_reason_unchanged_when_no_ai_review(evaluate: Any) -> None:
+    """No reviewer at all still reads exactly as it did before this change."""
+    result, _ = evaluate(greptile=NO_GREPTILE, comments=[_comment(None)])
+    assert result.eligible is False
+    assert "Greptile review not found" in result.reasons
+
+
+def test_greptile_path_is_untouched_and_pays_no_extra_call(evaluate: Any) -> None:
+    """It's an OR: when Greptile reviewed, the marker is never even fetched."""
+    result, calls = evaluate(greptile=GREPTILE_CLEAN, comments=[_comment(_marker())])
+    assert result.eligible is True
+    assert not any("issues/1382/comments" in " ".join(c) for c in calls)
+
+
+def test_greptile_unresolved_still_blocks_despite_clean_ai_review(
+    evaluate: Any,
+) -> None:
+    """Our review is an alternative to a *missing* Greptile, never an override."""
+    greptile = {"has_review": True, "unresolved": 2, "total": 3}
+    result, _ = evaluate(greptile=greptile, comments=[_comment(_marker())])
+    assert result.eligible is False
+    assert any("2 unresolved review thread(s)" in r for r in result.reasons)

--- a/tests/test_self_merge_ai_review_gate.py
+++ b/tests/test_self_merge_ai_review_gate.py
@@ -110,9 +110,9 @@ def test_clean_current_full_consensus_review_is_accepted(gh_comments: Any) -> No
 
 
 def test_short_marker_sha_matches_full_head(gh_comments: Any) -> None:
-    """The marker records 12 chars; the PR carries 40. Prefix match, either way."""
+    """The marker may abbreviate the authoritative full PR head."""
     assert smc._sha_matches_head(MARKER_SHA, HEAD_SHA)
-    assert smc._sha_matches_head(HEAD_SHA, MARKER_SHA)
+    assert not smc._sha_matches_head(HEAD_SHA, MARKER_SHA)
     status = _status(gh_comments, [_comment(_marker(sha=HEAD_SHA))])
     assert status["accepted"] is True
 
@@ -147,6 +147,25 @@ def test_lost_fanout_jobs_are_rejected(gh_comments: Any) -> None:
     status = _status(gh_comments, [_comment(_marker(consensus=consensus))])
     assert status["accepted"] is False
     assert "3/9 jobs" in (status["detail"] or "")
+
+
+@pytest.mark.parametrize(
+    ("field", "requested_field", "kind"),
+    [
+        ("answered", "requested", "pass"),
+        ("jobs_answered", "jobs_requested", "job"),
+    ],
+)
+def test_impossible_consensus_counts_are_rejected(
+    gh_comments: Any, field: str, requested_field: str, kind: str
+) -> None:
+    consensus = dict(FULL_CONSENSUS)
+    requested = consensus[requested_field]
+    assert isinstance(requested, int)
+    consensus[field] = requested + 1
+    status = _status(gh_comments, [_comment(_marker(consensus=consensus))])
+    assert status["accepted"] is False
+    assert f"invalid {kind} counts" in (status["detail"] or "")
 
 
 def test_clamped_agreement_threshold_is_rejected(gh_comments: Any) -> None:
@@ -386,6 +405,22 @@ def test_evaluate_pr_accepts_our_clean_review_without_greptile(evaluate: Any) ->
     assert result.eligible is True
     assert result.reasons == []
     assert any("satisfied by self-hosted AI review" in w for w in result.warnings)
+
+
+def test_evaluate_pr_blocks_fallback_when_greptile_state_fetch_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unknown Greptile state must not become absence and admit our review."""
+    monkeypatch.setattr(smc, "fetch_pr", lambda repo, number: _pr_payload())
+    monkeypatch.setattr(smc, "get_gh_user", lambda: AUTHOR)
+    monkeypatch.setattr(smc, "merge_permission", lambda repo: True)
+    monkeypatch.setattr(smc, "_fetch_greptile_review_data", lambda r, n: None)
+    monkeypatch.setattr(smc, "greptile_summary_score", lambda r, n: 5)
+    result = smc.evaluate_pr(
+        "gptme/gptme-contrib", 1382, workspace_repos=["gptme/gptme-contrib"]
+    )
+    assert result.eligible is False
+    assert any("Could not verify Greptile review state" in r for r in result.reasons)
 
 
 def test_evaluate_pr_blocks_on_degraded_review(evaluate: Any) -> None:

--- a/tests/test_self_merge_ai_review_gate.py
+++ b/tests/test_self_merge_ai_review_gate.py
@@ -178,6 +178,50 @@ def test_missing_consensus_record_is_rejected(gh_comments: Any) -> None:
     assert "no consensus record" in (status["detail"] or "")
 
 
+def test_explicit_single_pass_consensus_is_rejected(gh_comments: Any) -> None:
+    """A serialized 1/1 record is still a single sample, not consensus."""
+    consensus = dict(
+        FULL_CONSENSUS,
+        requested=1,
+        answered=1,
+        jobs_requested=1,
+        jobs_answered=1,
+        min_agreement=1,
+        min_agreement_requested=1,
+    )
+    status = _status(gh_comments, [_comment(_marker(consensus=consensus))])
+    assert status["accepted"] is False
+    assert "at least 2 requested passes" in (status["detail"] or "")
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "requested",
+        "answered",
+        "jobs_requested",
+        "jobs_answered",
+        "min_agreement",
+        "min_agreement_requested",
+    ],
+)
+def test_boolean_consensus_counts_are_rejected(gh_comments: Any, field: str) -> None:
+    """Booleans are JSON-valid but are not trustworthy numeric counts."""
+    consensus = dict(FULL_CONSENSUS, **{field: True})
+    status = _status(gh_comments, [_comment(_marker(consensus=consensus))])
+    assert status["accepted"] is False
+    assert "missing" in (status["detail"] or "")
+
+
+@pytest.mark.parametrize("field", ["min_agreement", "min_agreement_requested"])
+def test_missing_agreement_threshold_is_rejected(gh_comments: Any, field: str) -> None:
+    consensus = dict(FULL_CONSENSUS)
+    del consensus[field]
+    status = _status(gh_comments, [_comment(_marker(consensus=consensus))])
+    assert status["accepted"] is False
+    assert "missing agreement thresholds" in (status["detail"] or "")
+
+
 def test_stale_sha_is_rejected(gh_comments: Any) -> None:
     """A review of an earlier push says nothing about the code about to merge."""
     status = _status(gh_comments, [_comment(_marker(sha="deadbeefcafe"))])

--- a/tests/test_self_merge_ai_review_gate.py
+++ b/tests/test_self_merge_ai_review_gate.py
@@ -222,19 +222,31 @@ def test_no_marker_at_all(gh_comments: Any) -> None:
 
 def test_inline_finding_marker_is_not_a_summary_marker() -> None:
     """`-finding` and `-fp {..}` share the prefix; only `bob-ai-review {` counts."""
-    assert not smc._AI_REVIEW_SUMMARY_RE.search(smc._AI_REVIEW_FINDING_MARKER)
-    assert not smc._AI_REVIEW_SUMMARY_RE.search('<!-- bob-ai-review-fp {"a": 1} -->')
-    assert smc._AI_REVIEW_SUMMARY_RE.search('<!-- bob-ai-review {"sha": "x"} -->')
+    assert not list(smc._iter_ai_review_markers(smc._AI_REVIEW_FINDING_MARKER))
+    assert not list(smc._iter_ai_review_markers('<!-- bob-ai-review-fp {"a": 1} -->'))
+    assert list(smc._iter_ai_review_markers('<!-- bob-ai-review {"sha": "x"} -->'))
 
 
 def test_nested_json_marker_parses_whole() -> None:
-    """The real marker nests objects in `history`; a lazy match must not stop early."""
+    """The real marker nests objects; parsing must reach the top-level close."""
     marker = _marker(history=[{"sha": "aaaabbbbcccc", "score": 3}])
-    match = smc._AI_REVIEW_SUMMARY_RE.search(
-        f"text\n<!-- bob-ai-review {json.dumps(marker)} -->\n"
+    parsed = list(
+        smc._iter_ai_review_markers(
+            f"text\n<!-- bob-ai-review {json.dumps(marker)} -->\n"
+        )
     )
-    assert match is not None
-    assert json.loads(match.group(1))["consensus"]["jobs_answered"] == 9
+    assert parsed[0]["consensus"]["jobs_answered"] == 9
+
+
+def test_multiple_markers_and_malformed_marker_recover() -> None:
+    body = "\n".join(
+        [
+            '<!-- bob-ai-review {"broken": } -->',
+            '<!-- bob-ai-review {"score": 3} -->',
+            '<!-- bob-ai-review {"score": 5, "nested": {"ok": true}} -->',
+        ]
+    )
+    assert [marker["score"] for marker in smc._iter_ai_review_markers(body)] == [3, 5]
 
 
 def test_truncated_sha_cannot_prefix_match_any_head() -> None:

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -997,19 +997,27 @@ def test_fetch_greptile_status_fallback_paginates_issue_comments() -> None:
     # Fallback REST call returns a Greptile comment ID (one line of output)
     fallback_response = "123456789"
 
-    with patch.object(
-        self_merge_check,
-        "run_gh",
-        side_effect=[
-            self_merge_check.json.dumps(graphql_page),
-            fallback_response,
-        ],
-    ) as mock_run_gh:
+    # The GraphQL fetch still goes through `run_gh`; the summary-comment
+    # fallback uses `run_gh_checked`, which distinguishes a failed call from an
+    # empty result so a timeout cannot read as "no Greptile review".
+    with (
+        patch.object(
+            self_merge_check,
+            "run_gh",
+            side_effect=[self_merge_check.json.dumps(graphql_page)],
+        ),
+        patch.object(
+            self_merge_check,
+            "run_gh_checked",
+            side_effect=[fallback_response],
+        ) as mock_fallback,
+    ):
         result = self_merge_check.fetch_greptile_status("gptme/gptme-contrib", 504)
 
     assert result["has_review"] is True
+    assert not result.get("unknown")
     # Verify --paginate was passed to the fallback REST call
-    fallback_call_args = mock_run_gh.call_args_list[1].args[0]
+    fallback_call_args = mock_fallback.call_args_list[0].args[0]
     assert "--paginate" in fallback_call_args
 
 


### PR DESCRIPTION
## The problem

The self-merge gate hard-required Greptile:

```python
greptile = fetch_greptile_status(repo, number, review_data=shared_review_data)
if not greptile["has_review"]:
    result.reasons.append("Greptile review not found")
```

On any repo Greptile does not cover, that made the gate unsatisfiable. Verified live on #1382 — `Eligible: NO — Greptile review not found` — on a PR our own self-hosted reviewer had already reviewed in full. Our marker was used in this file for exactly one thing: classifying inline findings so they don't read as unresolved human threads. The verdict itself was ignored.

## What changed

The reviewer's `<!-- bob-ai-review {…} -->` summary marker now satisfies the same requirement Greptile does.

**It is an OR, never a replacement.** A repo where Greptile still runs takes the identical path it always took, and does not even pay the extra API call — the marker is only fetched when Greptile has *not* reviewed. An unresolved Greptile thread still blocks regardless of what our reviewer says.

## Why it is this strict — the risk runs the other way

Our reviewer's measured precision is 37%. That number is the wrong one to gate on, and reasoning from it would have produced the wrong design.

Precision governs **false findings**. A false finding *lowers* the score, which makes this gate **more conservative**: it blocks a mergeable PR and costs a wasted round. Bad, but bounded and self-correcting.

The dangerous direction is **recall**. A missed bug produces a clean score, and a clean score is an unreviewed merge. That is unbounded and silent.

So every condition below exists to make "clean" mean "clean *on real evidence*":

| Condition | Why |
|---|---|
| score is **5/5** | the rubric's only "nothing outstanding on this head" value. Deliberately **not** env-overridable, unlike the Greptile floor — letting `SELF_MERGE_MIN_GREPTILE_SCORE` lower this too would make the new path the weakest link |
| marker `sha` matches **current head** | a review of an earlier push says nothing about the code about to merge. 12-char prefix vs the full 40, with a minimum prefix length so a truncated marker can't match anything |
| consensus present and **undegraded** | no lost passes, no lost fan-out jobs, no clamped agreement threshold, and ≥1 job actually answered |
| reviewer did **not abstain** | `score: null` is the submodule pointer-bump case — "no verdict", never a pass |
| marker posted by the **authenticated user** | the marker is plain text in a comment body; otherwise anyone who can comment on our PR could forge a clean verdict for a gate that then merges without a human |

Any of those failing falls back to today's behaviour — never to auto-approve.

Two of those deserve expanding:

**Lost fan-out jobs is the loss that hides.** A pass counts as "answered" when *any one* of its aspect jobs returns, so a 3×3 wave that loses 6 of 9 jobs still records `answered: 3 of 3` and reads as full consensus while two thirds of the evidence is missing. Checking passes alone would have missed the common case.

**Zero answered is the sharp edge.** If every call fails there are no findings, and no findings computes to a clean 5/5 off an empty result. That is precisely the recall failure, arriving disguised as the best possible score.

**A missing consensus record does not qualify.** The hourly sweep runs `--passes 1`, which writes no `consensus` key at all — this is the marker shape actually live on #1382 today. The reviewer's own contract says to read a missing record as "unknown, never as full consensus", and this follows it. To get a qualifying review: `ai-review.py OWNER/REPO N --force`.

## Better refusals

Refusals now say *why*, instead of leaving the operator to guess whether the reviewer ran at all. Live against #1382 with this branch:

```
Reasons:
- Greptile review not found; AI review score 2/5 below 5/5
- Touches sensitive/security/infra paths
```

That PR genuinely carries a 2/5 review, so it correctly stays blocked — and now says so.

## Tests

29 new tests in `tests/test_self_merge_ai_review_gate.py`, weighted toward refusing a 5/5 reached on thin evidence:

- our clean/current/full-consensus review satisfies the gate (the #1382 regression), end-to-end through `evaluate_pr`
- degraded consensus does not — separately for lost passes, lost fan-out jobs, clamped agreement, and zero answered
- missing consensus record does not
- stale SHA does not
- abstain does not; scores 1–4 do not
- a marker from another account is ignored; unknown identity trusts nothing
- **Greptile-only path unchanged**: still eligible, and asserts the marker is never fetched; an unresolved Greptile thread still blocks despite a clean AI review
- marker-regex guards: `-finding` and `-fp {…}` must not match `bob-ai-review {`; the nested-object marker must parse whole

Existing suites pass: `test_self_merge_check.py` + `test_self_merge_ai_review_threads.py` = 123 passed. Full suite: 658 passed, 1 pre-existing failure (`test_linear_oauth_state.py`, a Flask version incompatibility — confirmed failing identically on clean `origin/master`).

## Rollback

`SELF_MERGE_ACCEPT_AI_REVIEW=0` restores the Greptile-only gate.

## Note for the reviewer

`self-merge-check.py` is in `SENSITIVE_PATH_PREFIXES`, so this PR cannot self-merge under its own new rule. That is intended — it needs a human.