### PR TITLE
docs(lessons): add LOO confound note to pre-mortem lesson

### DIFF
--- a/lessons/autonomous/pre-mortem-for-risky-actions.md
+++ b/lessons/autonomous/pre-mortem-for-risky-actions.md
@@ -11,6 +11,7 @@ match:
   session_categories: [infrastructure, cleanup]
 target_grade: alignment
 status: active
+confound_note: "LOO 2026-08-09: causal Δ=-0.079 (n=37, p=0.008) — LIKELY CONFOUNDED: session_categories:[infrastructure,cleanup] and keywords describe risky/destructive operations (force push, modifying production infrastructure). Sessions that trigger these keywords are already in high-risk scenarios with lower expected reward baseline. Rule is correct safety guidance; the causal delta reflects session baseline, not lesson harm."
 ---
 
 # Pre-Mortem for Risky Actions


### PR DESCRIPTION
LOO checkpoint 2026-08-09 found causal Δ=-0.079 for pre-mortem-for-risky-actions lesson.

Verdict: LIKELY CONFOUNDED — session_categories:[infrastructure,cleanup] and keywords describe risky/destructive operations. Sessions that trigger these keywords are already in high-risk scenarios with lower expected reward baseline.

Rule is correct safety guidance; the causal delta reflects session baseline, not lesson harm.

Adds confound_note frontmatter field to document this finding and prevent future false alarms.