### PR TITLE
docs(pr_review): cross-reference the three PR-review implementations

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/pr_review/__init__.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pr_review/__init__.py
@@ -1,8 +1,43 @@
-"""PR review core — schema, corpus, and review runner.
+"""PR review core — schema, corpus, and local review runner.
 
 Phase 0: versioned finding schema + golden corpus for model evaluation.
 Phase 1: local CLI runner — working-tree / commit-range reviews without forge.
-Phase 2 (later): GitHub publisher with idempotency guards + PM integration.
+
+What this package is for
+------------------------
+Reviewing a **local diff with no forge involved**: ``gptme-runloops review
+--working-tree`` (or ``--base``/``--head``). ``reviewer.py`` makes zero forge
+API calls by construction; ``github_adapter.py`` is the quarantined I/O
+boundary that callers use, not a dependency of the review logic. This is the
+entry point to reach for when you want findings on uncommitted work.
+
+What this package is NOT
+------------------------
+It is **not** the reviewer that reviews Bob's PRs. It has never carried
+production traffic, and it has no consensus passes, finding suppression, or
+soundness gates — the machinery that makes posted findings tolerable to a
+human. Do not extend it into a second GitHub-posting reviewer, and do not
+treat its review prompt as canonical: per the decision below this package is
+the *destination shell*, and the production review engine is being lifted into
+it rather than reimplemented here.
+
+Related implementations
+-----------------------
+Three PR-review implementations exist across three repos:
+
+- **this package** (gptme-contrib) — forge-neutral local-diff reviews.
+- **``gptme.util.review`` + ``gptme-util review pr``** (gptme core, public) —
+  canonical finding schema and the model-facing diff→findings primitive.
+  Produces an artifact, writes nothing.
+- **Bob's ``scripts/github/ai-review.py``** (private brain repo) — the only
+  implementation with production traffic; posts marker + inline comments to
+  GitHub, with consensus filtering and a suppression ledger. Its
+  ``<!-- bob-ai-review-finding -->`` marker is a wire protocol read by this
+  repo's ``self-merge-check.py`` and ``activity-gate.sh``.
+
+Full comparison, the canonical-implementation decision, migration steps and a
+"which tool for which task" routing table live in Bob's brain repo (private)
+at ``knowledge/technical/pr-review-systems-map.md``.
 """
 
 from .reviewer import REVIEW_PROMPT_VERSION, resolve_local_target, run_review


### PR DESCRIPTION
Navigation-only. No code changes.

Three PR-review implementations exist across three repos, and nothing in any of them said which one a consumer wants:

1. Bob's `scripts/github/ai-review.py` (private brain repo) — the only one with production traffic; posts marker + inline comments to GitHub.
2. `gptme_runloops.pr_review` (this package) — forge-neutral local-diff reviews (`review --working-tree`); zero production traffic.
3. `gptme.util.review` / `gptme-util review pr` (core, public) — canonical finding schema, model-facing diff→findings primitive, writes nothing.

This PR replaces this package's docstring line promising a *"Phase 2 (later): GitHub publisher"* — which points a reader at building a second forge-posting reviewer — with a short "what this is for / what this is NOT for / related implementations" block and a link to the routing table.

Per the decision recorded in the PR-review systems map, this package is the **destination shell**: the production engine gets lifted into it rather than reimplemented here, so a second publisher grown in-place is exactly the wrong move.

Also notes that the `<!-- bob-ai-review-finding -->` marker is a wire protocol read by this repo's `scripts/github/self-merge-check.py` and `scripts/github/activity-gate.sh` (verified by grep) — renaming it needs a dual-read window.

Companion PR in core: gptme/gptme#3511.