### PR TITLE
fix(pm): iterate on our own reviewer's open findings, not just Greptile's score

### DIFF
--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -933,39 +933,66 @@ check_merge_conflicts() {
 # Emits:
 #   greptile_needs_fix       — score < 4 (significant findings to address)
 #   greptile_needs_improvement — score = 4 (minor fixes needed)
-# Count UNRESOLVED inline findings posted by our own AI reviewer.
+# Does our own AI reviewer still want changes on this PR?
 #
 # Why this exists: check_greptile_scores() reads Greptile's score and nothing
-# else, so a PR sitting at Greptile 5/5 with four unaddressed findings from our
+# else, so a PR sitting at Greptile 5/5 with unaddressed findings from our
 # reviewer emits merge_ready and never enters the fix loop. Observed on
 # gptme/gptme#3468 — 5/5 from Greptile, 4 of our findings open, PM silent, and a
 # human triaging the PR reads those findings as blockers.
 #
-# "Unresolved" deliberately excludes OUTDATED threads: GitHub marks a review
-# comment outdated once the code it anchored to changes, which is the cheapest
-# available evidence that the finding was addressed. Counting those would nag
-# forever on PRs that already did the work.
+# The authoritative signal is the LATEST REVIEW AT THE CURRENT HEAD, not the
+# state of comment threads.
 #
-# Note we cannot read our own marker's `score` here: markers written before the
-# score field shipped (2026-08-07/08) carry none, and those are exactly the old
-# PRs sitting in the backlog. Counting open finding threads works on every
-# marker version.
-count_unresolved_ai_findings() {
-    local repo=$1 pr_number=$2
-    gh api graphql -f query='
-      query($owner:String!, $name:String!, $num:Int!) {
-        repository(owner:$owner, name:$name) {
-          pullRequest(number:$num) {
-            reviewThreads(first:100) {
-              nodes { isResolved isOutdated comments(first:1) { nodes { body } } }
-            }
-          }
-        }
-      }' -F owner="${repo%%/*}" -F name="${repo##*/}" -F num="$pr_number" \
-      --jq '[.data.repository.pullRequest.reviewThreads.nodes[]
-             | select(.isResolved == false and .isOutdated == false)
-             | select(.comments.nodes[0].body // "" | contains("bob-ai-review-finding"))]
-            | length' 2>/dev/null || echo 0
+# An earlier version counted unresolved threads and excluded GitHub's
+# `isOutdated` ones, treating outdated as "addressed". Erik flagged that as a
+# cheap heuristic, and he is right: GitHub marks a thread outdated whenever the
+# lines it anchored to change — a rebase, a reformat, or an unrelated edit in the
+# same hunk all do it, with the bug fully intact. Reading that as "fixed"
+# produces a false clean, which is the one direction that costs an unreviewed
+# merge rather than a wasted round.
+#
+# So we ask the reviewer instead of guessing. Our reviewer re-reviews on every
+# head change and deliberately re-raises findings that were never fixed
+# (suppression happens only on explicit dismissal), so the finding count it
+# recorded FOR THE CURRENT HEAD is a measurement, not an inference.
+#
+# Echoes: "dirty" (findings at current head), "clean" (reviewed, none),
+# "pending" (current head not reviewed yet — the sweep will get to it), or
+# "none" (never reviewed).
+ai_review_verdict() {
+    local repo=$1 pr_number=$2 head_sha=$3
+    local marker
+    marker=$(gh api "repos/${repo}/issues/${pr_number}/comments" --paginate \
+        --jq '[.[] | .body // "" | capture("<!-- bob-ai-review (?<j>\\{[^>]*\\}) -->").j] | last // empty' \
+        2>/dev/null | tail -1)
+    [ -z "$marker" ] && { echo "none"; return 0; }
+
+    local reviewed_sha score findings
+    reviewed_sha=$(printf '%s' "$marker" | jq -r '.sha // empty' 2>/dev/null)
+    [ -z "$reviewed_sha" ] && { echo "none"; return 0; }
+
+    # Marker records a short SHA.
+    case "$head_sha" in
+        "$reviewed_sha"*) ;;
+        *) echo "pending"; return 0 ;;
+    esac
+
+    score=$(printf '%s' "$marker" | jq -r '.score // empty' 2>/dev/null)
+    if [ -n "$score" ] && [ "$score" != "null" ]; then
+        [ "$score" -ge 5 ] 2>/dev/null && echo "clean" || echo "dirty"
+        return 0
+    fi
+    # Markers written before the score field shipped (2026-08-07/08) carry none,
+    # and those are exactly the older PRs sitting in the backlog. Fall back to the
+    # finding count the same review recorded.
+    findings=$(printf '%s' "$marker" \
+        | jq -r '(.history // []) | last | .findings // empty' 2>/dev/null)
+    if [ -n "$findings" ] && [ "$findings" != "null" ]; then
+        [ "$findings" -gt 0 ] 2>/dev/null && echo "dirty" || echo "clean"
+        return 0
+    fi
+    echo "none"
 }
 
 
@@ -1043,15 +1070,20 @@ check_greptile_scores() {
         # have open findings on the same PR, and those are invisible to the
         # score above. A PR is only clean when both reviewers are satisfied.
         if [ "$greptile_score" -ge 5 ] 2>/dev/null; then
-            local ai_open
-            ai_open=$(count_unresolved_ai_findings "$repo" "$pr_number")
-            if [ "${ai_open:-0}" -gt 0 ] 2>/dev/null; then
+            local ai_verdict
+            ai_verdict=$(ai_review_verdict "$repo" "$pr_number" "$head_sha")
+            if [ "$ai_verdict" = "dirty" ]; then
                 # Fall through to the fix arm below. Scored as 3 so it routes to
                 # greptile_needs_fix rather than _needs_improvement: unaddressed
                 # findings are work to do, not a polish suggestion.
                 greptile_score=3
-                pr_title="${pr_title} [${ai_open} open AI-review finding(s)]"
+                pr_title="${pr_title} [our AI review wants changes]"
             else
+                # clean / pending / none: nothing WE can say is outstanding.
+                # 'pending' is deliberately not treated as dirty — the head is
+                # simply unreviewed yet, and the sweep re-reviews within minutes.
+                # Emitting a fix item off an unmeasured head would nag on PRs
+                # that may well be clean.
                 echo "${greptile_score}:${now}:${head_sha}" > "$state_file"
                 continue
             fi

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -1017,13 +1017,16 @@ check_greptile_scores() {
         local state_file="$STATE_DIR/${repo_safe}-pr-${pr_number}-greptile.state"
         local now
         now=$(date +%s)
-        local last_state last_score last_timestamp last_sha
-        last_state="" last_score="" last_timestamp=0 last_sha=""
+        local last_state last_score last_timestamp last_sha last_verdict
+        last_state="" last_score="" last_timestamp=0 last_sha="" last_verdict=""
         if [ -f "$state_file" ]; then
             last_state=$(cat "$state_file")
             last_score=$(echo "$last_state" | cut -d: -f1)
             last_timestamp=$(echo "$last_state" | cut -d: -f2)
             last_sha=$(echo "$last_state" | cut -d: -f3)
+            # 4th field added later; state files written before it yield "" here,
+            # which reads as "no cached verdict" and simply costs one refetch.
+            last_verdict=$(echo "$last_state" | cut -d: -f4)
         fi
 
         # Skip the API call if we have a fresh cached score for the current HEAD SHA.
@@ -1069,14 +1072,27 @@ check_greptile_scores() {
         # Score 5 = clean by Greptile's reckoning — but OUR reviewer may still
         # have open findings on the same PR, and those are invisible to the
         # score above. A PR is only clean when both reviewers are satisfied.
+        # Routing may differ from what Greptile said, so it gets its own variable.
+        # greptile_score MUST stay Greptile's real score: it is what we persist and
+        # what every consumer reports. Overwriting it to steer one branch poisons
+        # the state file, and the poison is self-sticking — a persisted 3 fails the
+        # `-ge 5` test on the next cycle, so the AI verdict is never consulted again
+        # and the PR cannot recover even after its findings are resolved.
+        local route_score="$greptile_score"
+        local ai_verdict=""
         if [ "$greptile_score" -ge 5 ] 2>/dev/null; then
-            local ai_verdict
-            ai_verdict=$(ai_review_verdict "$repo" "$pr_number" "$head_sha")
+            # ai_review_verdict() costs a paginated comments fetch, so it obeys the
+            # same TTL as the score above rather than firing every 2-minute cycle.
+            if [ -n "$last_verdict" ] && [ "$last_sha" = "$head_sha" ] \
+                    && [ $(( now - last_timestamp )) -lt "$fetch_cache_ttl" ]; then
+                ai_verdict="$last_verdict"
+            else
+                ai_verdict=$(ai_review_verdict "$repo" "$pr_number" "$head_sha")
+            fi
             if [ "$ai_verdict" = "dirty" ]; then
-                # Fall through to the fix arm below. Scored as 3 so it routes to
-                # greptile_needs_fix rather than _needs_improvement: unaddressed
-                # findings are work to do, not a polish suggestion.
-                greptile_score=3
+                # Route to the fix arm: unaddressed findings are work to do, not a
+                # polish suggestion. Only the routing score moves.
+                route_score=3
                 pr_title="${pr_title} [our AI review wants changes]"
             else
                 # clean / pending / none: nothing WE can say is outstanding.
@@ -1084,22 +1100,26 @@ check_greptile_scores() {
                 # simply unreviewed yet, and the sweep re-reviews within minutes.
                 # Emitting a fix item off an unmeasured head would nag on PRs
                 # that may well be clean.
-                echo "${greptile_score}:${now}:${head_sha}" > "$state_file"
+                echo "${greptile_score}:${now}:${head_sha}:${ai_verdict}" > "$state_file"
                 continue
             fi
         fi
 
         # Score >= 4 is minor, < 4 needs fix
         local item_type
-        if [ "$greptile_score" -lt 4 ]; then
+        if [ "$route_score" -lt 4 ]; then
             item_type="greptile_needs_fix"
         else
             item_type="greptile_needs_improvement"
         fi
 
         if [ -n "$last_state" ]; then
-            # Same score and same HEAD — check cooldown
-            if [ "$greptile_score" = "$last_score" ] && [ "$head_sha" = "$last_sha" ]; then
+            # Same score, same verdict and same HEAD — check cooldown.
+            # The verdict belongs in this test now that it, not the score, is what
+            # moves when our review flips: without it a clean -> dirty flip on an
+            # unchanged head would sit out the cooldown before anyone heard about it.
+            if [ "$greptile_score" = "$last_score" ] && [ "$head_sha" = "$last_sha" ] \
+                    && [ "$ai_verdict" = "$last_verdict" ]; then
                 local elapsed=$(( now - last_timestamp ))
                 if [ "$elapsed" -lt "$cooldown_seconds" ]; then
                     # Within cooldown — skip
@@ -1110,13 +1130,19 @@ check_greptile_scores() {
             # Otherwise: score changed or new commits pushed — always re-emit
         else
             # First time seeing this PR — seed state, don't report
-            echo "${greptile_score}:${now}:${head_sha}" > "$state_file"
+            echo "${greptile_score}:${now}:${head_sha}:${ai_verdict}" > "$state_file"
             continue
         fi
 
-        # Record state and emit
-        echo "${greptile_score}:${now}:${head_sha}" > "$state_file"
-        emit_item "$item_type" "$repo" "$pr_number" "$pr_title" "Greptile score: ${greptile_score}/5"
+        # Record state and emit. The detail names whichever reviewer is actually
+        # asking for work: reporting "Greptile score: 5/5" on an item routed to
+        # the fix arm by OUR findings reads as a contradiction.
+        local detail="Greptile score: ${greptile_score}/5"
+        if [ "$ai_verdict" = "dirty" ]; then
+            detail="${detail} · our AI review has open findings"
+        fi
+        echo "${greptile_score}:${now}:${head_sha}:${ai_verdict}" > "$state_file"
+        emit_item "$item_type" "$repo" "$pr_number" "$pr_title" "$detail"
     done
 }
 

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -933,6 +933,42 @@ check_merge_conflicts() {
 # Emits:
 #   greptile_needs_fix       — score < 4 (significant findings to address)
 #   greptile_needs_improvement — score = 4 (minor fixes needed)
+# Count UNRESOLVED inline findings posted by our own AI reviewer.
+#
+# Why this exists: check_greptile_scores() reads Greptile's score and nothing
+# else, so a PR sitting at Greptile 5/5 with four unaddressed findings from our
+# reviewer emits merge_ready and never enters the fix loop. Observed on
+# gptme/gptme#3468 — 5/5 from Greptile, 4 of our findings open, PM silent, and a
+# human triaging the PR reads those findings as blockers.
+#
+# "Unresolved" deliberately excludes OUTDATED threads: GitHub marks a review
+# comment outdated once the code it anchored to changes, which is the cheapest
+# available evidence that the finding was addressed. Counting those would nag
+# forever on PRs that already did the work.
+#
+# Note we cannot read our own marker's `score` here: markers written before the
+# score field shipped (2026-08-07/08) carry none, and those are exactly the old
+# PRs sitting in the backlog. Counting open finding threads works on every
+# marker version.
+count_unresolved_ai_findings() {
+    local repo=$1 pr_number=$2
+    gh api graphql -f query='
+      query($owner:String!, $name:String!, $num:Int!) {
+        repository(owner:$owner, name:$name) {
+          pullRequest(number:$num) {
+            reviewThreads(first:100) {
+              nodes { isResolved isOutdated comments(first:1) { nodes { body } } }
+            }
+          }
+        }
+      }' -F owner="${repo%%/*}" -F name="${repo##*/}" -F num="$pr_number" \
+      --jq '[.data.repository.pullRequest.reviewThreads.nodes[]
+             | select(.isResolved == false and .isOutdated == false)
+             | select(.comments.nodes[0].body // "" | contains("bob-ai-review-finding"))]
+            | length' 2>/dev/null || echo 0
+}
+
+
 check_greptile_scores() {
     local repo=$1
     local prs=$2
@@ -1003,11 +1039,22 @@ check_greptile_scores() {
             continue
         fi
 
-        # Score 5 = clean — update state file (so check_merge_ready sees
-        # the perfect score instead of a stale sub-5 entry) and skip.
+        # Score 5 = clean by Greptile's reckoning — but OUR reviewer may still
+        # have open findings on the same PR, and those are invisible to the
+        # score above. A PR is only clean when both reviewers are satisfied.
         if [ "$greptile_score" -ge 5 ] 2>/dev/null; then
-            echo "${greptile_score}:${now}:${head_sha}" > "$state_file"
-            continue
+            local ai_open
+            ai_open=$(count_unresolved_ai_findings "$repo" "$pr_number")
+            if [ "${ai_open:-0}" -gt 0 ] 2>/dev/null; then
+                # Fall through to the fix arm below. Scored as 3 so it routes to
+                # greptile_needs_fix rather than _needs_improvement: unaddressed
+                # findings are work to do, not a polish suggestion.
+                greptile_score=3
+                pr_title="${pr_title} [${ai_open} open AI-review finding(s)]"
+            else
+                echo "${greptile_score}:${now}:${head_sha}" > "$state_file"
+                continue
+            fi
         fi
 
         # Score >= 4 is minor, < 4 needs fix

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -1029,6 +1029,14 @@ check_greptile_scores() {
             last_verdict=$(echo "$last_state" | cut -d: -f4)
         fi
 
+        # The persisted timestamp means "when we last FETCHED", not "when we last
+        # ran". Stamping it with $now on a cache hit refreshes the TTL on every
+        # 2-minute cycle, so it never expires and neither the score nor the verdict
+        # is ever refetched for that head — a PR whose verdict was 'pending'
+        # (head not yet reviewed, the normal state right after a push) would stay
+        # pending forever and never reach the fix arm.
+        local fetched_at="$last_timestamp"
+
         # Skip the API call if we have a fresh cached score for the current HEAD SHA.
         # Greptile edits its review comment in-place (PR updatedAt doesn't bump), but
         # a re-review only occurs after new commits (→ head_sha changes, invalidates
@@ -1047,6 +1055,7 @@ check_greptile_scores() {
             # Note: --paginate with --jq applies the filter per-page, so if multiple
             # pages each contain Greptile comments, we'd get multiple lines of output.
             # We take only the last line (tail -1) to get the most recent score.
+            fetched_at="$now"
             greptile_score=$(gh api "repos/${repo}/issues/${pr_number}/comments" \
                 --paginate --jq '
                     [.[] | select(.user.login | test("greptile"; "i"))] | last |
@@ -1088,6 +1097,7 @@ check_greptile_scores() {
                 ai_verdict="$last_verdict"
             else
                 ai_verdict=$(ai_review_verdict "$repo" "$pr_number" "$head_sha")
+                fetched_at="$now"
             fi
             if [ "$ai_verdict" = "dirty" ]; then
                 # Route to the fix arm: unaddressed findings are work to do, not a
@@ -1100,7 +1110,7 @@ check_greptile_scores() {
                 # simply unreviewed yet, and the sweep re-reviews within minutes.
                 # Emitting a fix item off an unmeasured head would nag on PRs
                 # that may well be clean.
-                echo "${greptile_score}:${now}:${head_sha}:${ai_verdict}" > "$state_file"
+                echo "${greptile_score}:${fetched_at}:${head_sha}:${ai_verdict}" > "$state_file"
                 continue
             fi
         fi
@@ -1130,7 +1140,7 @@ check_greptile_scores() {
             # Otherwise: score changed or new commits pushed — always re-emit
         else
             # First time seeing this PR — seed state, don't report
-            echo "${greptile_score}:${now}:${head_sha}:${ai_verdict}" > "$state_file"
+            echo "${greptile_score}:${fetched_at}:${head_sha}:${ai_verdict}" > "$state_file"
             continue
         fi
 
@@ -1141,7 +1151,7 @@ check_greptile_scores() {
         if [ "$ai_verdict" = "dirty" ]; then
             detail="${detail} · our AI review has open findings"
         fi
-        echo "${greptile_score}:${now}:${head_sha}:${ai_verdict}" > "$state_file"
+        echo "${greptile_score}:${fetched_at}:${head_sha}:${ai_verdict}" > "$state_file"
         emit_item "$item_type" "$repo" "$pr_number" "$pr_title" "$detail"
     done
 }
@@ -1403,6 +1413,20 @@ check_merge_ready() {
             greptile_score=$(cut -d: -f1 < "$greptile_state_file")
             # Must be perfect score (>= 5) to be merge-ready
             if [ -n "$greptile_score" ] && [ "$greptile_score" -lt 5 ] 2>/dev/null; then
+                continue
+            fi
+            # ...and OUR reviewer must have nothing open either. Before the score
+            # stopped being overwritten, a dirty verdict reached here disguised as
+            # a Greptile 3 and was filtered by the check above; now that the real 5
+            # is persisted, that accidental filter is gone and a PR with open AI
+            # findings would emit greptile_needs_fix AND merge_ready in the same
+            # run — the dispatcher could merge exactly what the fix arm is queued
+            # to repair. Only "dirty" blocks: clean/pending/none/"" all mean we
+            # have nothing to say, and blocking on an unmeasured head would stall
+            # every merge behind a review that has not happened yet.
+            local greptile_state_verdict
+            greptile_state_verdict=$(cut -d: -f4 < "$greptile_state_file")
+            if [ "$greptile_state_verdict" = "dirty" ]; then
                 continue
             fi
         fi

--- a/tests/test_activity_gate_cache.py
+++ b/tests/test_activity_gate_cache.py
@@ -32,6 +32,8 @@ from pathlib import Path
 argv = sys.argv[1:]
 head_sha  = os.environ.get("TEST_HEAD_SHA", "abc123")
 pr_number = int(os.environ.get("TEST_PR_NUMBER", "42"))
+greptile_score = os.environ.get("TEST_GREPTILE_SCORE", "4")
+ai_review_score = os.environ.get("TEST_AI_REVIEW_SCORE", "")
 count_file = os.environ.get("GH_COMMENT_CALL_COUNT", "")
 
 def apply_jq(data: object, jq_expr: str) -> str:
@@ -92,8 +94,16 @@ if argv[0] == "api":
             "user": {"login": "greptile-apps[bot]"},
             "created_at": "2026-01-01T00:00:00Z",
             "updated_at": "2026-01-01T00:00:00Z",
-            "body": "<h3>Greptile Summary</h3>\nScore: 4/5\nSome findings.",
+            "body": f"<h3>Greptile Summary</h3>\nScore: {greptile_score}/5\nSome findings.",
         }]
+        if ai_review_score:
+            marker = json.dumps({"sha": head_sha[:8], "score": int(ai_review_score)})
+            comments.append({
+                "user": {"login": "test-author"},
+                "created_at": "2026-01-01T00:01:00Z",
+                "updated_at": "2026-01-01T00:01:00Z",
+                "body": f"<!-- bob-ai-review {marker} -->",
+            })
         print(apply_jq(comments, jq_expr))
         sys.exit(0)
 
@@ -115,6 +125,9 @@ def _run_gate(
     tmp: Path,
     state_dir: Path,
     head_sha: str = TEST_HEAD_SHA,
+    *,
+    greptile_score: int = 4,
+    ai_review_score: int | None = None,
 ) -> tuple[subprocess.CompletedProcess[str], int]:
     """Run activity-gate.sh with fake gh. Returns (result, comment_api_call_count)."""
     fake_gh = tmp / "gh"
@@ -126,6 +139,9 @@ def _run_gate(
     env = os.environ.copy()
     env["TEST_HEAD_SHA"] = head_sha
     env["TEST_PR_NUMBER"] = str(TEST_PR)
+    env["TEST_GREPTILE_SCORE"] = str(greptile_score)
+    if ai_review_score is not None:
+        env["TEST_AI_REVIEW_SCORE"] = str(ai_review_score)
     env["GH_COMMENT_CALL_COUNT"] = str(count_file)
     env["PATH"] = f"{tmp}:{env['PATH']}"
 
@@ -235,3 +251,34 @@ def test_no_state_file_calls_api() -> None:
         assert _state_file(
             state_dir
         ).exists(), "State file should be created on first run"
+
+
+def test_dirty_ai_verdict_keeps_real_greptile_score_and_is_cached() -> None:
+    """A dirty own-review routes to fix without poisoning the Greptile cache."""
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+
+        # Legacy state has a fresh Greptile score but predates cached AI verdicts.
+        ts = int(time.time()) - 300
+        _state_file(state_dir).write_text(f"5:{ts}:{TEST_HEAD_SHA}")
+
+        result, call_count = _run_gate(
+            tmp, state_dir, greptile_score=5, ai_review_score=3
+        )
+        assert result.returncode == 0, result.stderr
+        assert call_count == 1, "Only the uncached AI verdict should be fetched"
+        assert "GREPTILE FIX #42" in result.stdout
+        assert "Greptile score: 5/5 · our AI review has open findings" in result.stdout
+
+        score, _, sha, verdict = _state_file(state_dir).read_text().split(":")
+        assert (score, sha, verdict.strip()) == ("5", TEST_HEAD_SHA, "dirty")
+
+        # The next sweep reuses both cached signals and respects the cooldown.
+        result, call_count = _run_gate(
+            tmp, state_dir, greptile_score=5, ai_review_score=3
+        )
+        assert result.returncode in (0, 1), result.stderr
+        assert call_count == 1, "Second sweep must not add another comments fetch"
+        assert "GREPTILE FIX #42" not in result.stdout

--- a/tests/test_activity_gate_greptile_score_not_poisoned.py
+++ b/tests/test_activity_gate_greptile_score_not_poisoned.py
@@ -1,0 +1,92 @@
+"""The Greptile state file must record Greptile's score, not our routing decision.
+
+`check_greptile_scores` consults our own AI reviewer when Greptile says 5/5, and
+routes PRs with open findings to the fix arm. The first implementation did that
+by overwriting `greptile_score=3`, which the shared emit path then persisted to
+`<repo>-pr-<n>-greptile.state`.
+
+That poison is self-sticking. On the next cycle the cache-hit branch reads the
+persisted 3 back into `greptile_score`, the `-ge 5` test fails, and the AI
+verdict is never consulted again — so the PR cannot leave the fix arm even after
+its findings are resolved, until the head changes or the TTL expires. Meanwhile
+every consumer of that file (`check_own_pr_review_state`, `check_merge_ready`)
+reports "Greptile 3/5" for a PR Greptile actually scored 5/5.
+
+Routing therefore uses a separate `route_score`, and the verdict is persisted as
+a 4th field so the paginated comments fetch obeys the same TTL as the score.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+GATE = Path(__file__).resolve().parents[1] / "scripts" / "github" / "activity-gate.sh"
+
+
+def _extract_function(name: str) -> str:
+    src = GATE.read_text()
+    start = src.index(f"{name}() {{")
+    rest = src[start:]
+    return rest[: rest.index("\n}\n") + len("\n}\n")]
+
+
+def test_greptile_score_is_never_assigned_a_literal_score() -> None:
+    """greptile_score may come from the API or the cache — never from a decision.
+
+    Deliberately checks for a *literal* rather than allow-listing the legitimate
+    assignments: the API fetch and the cache read are both fine and both change
+    shape over time, whereas `greptile_score=<digit>` is only ever someone
+    steering a branch by overwriting the reported score.
+    """
+    body = _extract_function("check_greptile_scores")
+    assignments = re.findall(r"^\s*greptile_score=(.*)$", body, re.MULTILINE)
+    assert assignments, "expected greptile_score to be assigned at all"
+    literals = [a.strip() for a in assignments if re.fullmatch(r'"?\d+"?', a.strip())]
+    assert not literals, (
+        f"greptile_score assigned the literal {literals} — this is persisted to "
+        "the state file and read back as Greptile's own score on the next cycle, "
+        "so the PR can never leave the branch the literal routed it to"
+    )
+
+
+def test_routing_uses_route_score_not_greptile_score() -> None:
+    body = _extract_function("check_greptile_scores")
+    assert 'local route_score="$greptile_score"' in body
+    assert '[ "$route_score" -lt 4 ]' in body, (
+        "the item-type decision must read the routing score, or the AI verdict "
+        "cannot influence routing at all"
+    )
+
+
+def test_every_greptile_state_write_carries_the_verdict() -> None:
+    """A write that omits the verdict silently re-enables the per-cycle refetch.
+
+    ai_review_verdict() costs a paginated comments fetch. It is cached by the 4th
+    field, so any new write path that drops the field makes the gate hit the
+    comments endpoint every cycle for every 5/5 PR — the API-budget regression
+    this repo has a rate-limit history with.
+    """
+    body = _extract_function("check_greptile_scores")
+    writes = re.findall(r'^\s*echo "([^"]*)" > "\$state_file"$', body, re.MULTILINE)
+    assert writes, "expected greptile state writes"
+    missing = [w for w in writes if "${ai_verdict}" not in w]
+    assert not missing, f"state writes missing the verdict field: {missing}"
+
+
+def test_verdict_is_read_back_and_reused_within_the_ttl() -> None:
+    body = _extract_function("check_greptile_scores")
+    assert 'last_verdict=$(echo "$last_state" | cut -d: -f4)' in body
+    assert 'ai_verdict="$last_verdict"' in body, (
+        "the cached verdict must actually be reused, or the 4th field is written "
+        "but never read and the fetch happens every cycle anyway"
+    )
+
+
+def test_cooldown_compares_the_verdict_too() -> None:
+    """Score no longer moves on a flip, so the verdict must be in the change test."""
+    body = _extract_function("check_greptile_scores")
+    assert '[ "$ai_verdict" = "$last_verdict" ]' in body, (
+        "without this, a clean -> dirty flip on an unchanged head sits out the "
+        "cooldown before PM hears about it"
+    )

--- a/tests/test_activity_gate_greptile_score_not_poisoned.py
+++ b/tests/test_activity_gate_greptile_score_not_poisoned.py
@@ -90,3 +90,44 @@ def test_cooldown_compares_the_verdict_too() -> None:
         "without this, a clean -> dirty flip on an unchanged head sits out the "
         "cooldown before PM hears about it"
     )
+
+
+def test_state_writes_use_the_fetch_time_not_the_current_time() -> None:
+    """Stamping $now on a cache hit makes the TTL immortal.
+
+    The persisted timestamp means "when we last fetched". If a cache hit rewrites
+    it with $now, every 2-minute cycle refreshes the TTL, so it never expires and
+    neither the score nor the verdict is ever refetched for that head. A PR whose
+    verdict is 'pending' — the normal state right after a push, before the sweep
+    reviews the new head — would stay pending forever and never reach the fix arm,
+    defeating the entire point of consulting our reviewer.
+
+    fetch_cache_ttl and cooldown_seconds are both 3600 by design (the source says
+    "= cooldown"), so preserving the fetch time keeps the nag cooldown correct
+    too: the TTL expiry and the cooldown expiry fall on the same instant.
+    """
+    body = _extract_function("check_greptile_scores")
+    writes = re.findall(r'^\s*echo "([^"]*)" > "\$state_file"$', body, re.MULTILINE)
+    assert writes, "expected greptile state writes"
+    stale = [w for w in writes if "${now}" in w]
+    assert not stale, (
+        f"state writes stamping $now: {stale} — on a cache hit this refreshes the "
+        "TTL every cycle and the verdict is never refetched"
+    )
+    assert all("${fetched_at}" in w for w in writes), writes
+
+
+def test_merge_ready_is_blocked_by_a_dirty_ai_verdict() -> None:
+    """A PR with open findings must not be reported merge-ready.
+
+    check_merge_ready gates on the Greptile score alone. While the score was being
+    overwritten with 3 for dirty verdicts, that check filtered them out by
+    accident; now that the real 5 is persisted, the accidental filter is gone and
+    the same PR would emit greptile_needs_fix AND merge_ready in one run — the
+    dispatcher could merge exactly what the fix arm is queued to repair.
+    """
+    body = _extract_function("check_merge_ready")
+    assert (
+        "cut -d: -f4" in body
+    ), "check_merge_ready must read the verdict field from the greptile state file"
+    assert '= "dirty"' in body, "…and skip the PR when that verdict is dirty"


### PR DESCRIPTION
## The gap

`check_greptile_scores()` reads Greptile's score and nothing else. So a PR sitting at Greptile **5/5** with unaddressed findings from our own reviewer emits `merge_ready` and never enters the fix loop.

Erik, while clearing the PR backlog:

> even though some PRs like gptme/gptme#3468 have 5/5 from Greptile they have unresolved comments from our own reviewer. i want the system/machinery to pick it up (pm) and iterate, not let there be unresolved/unaddressed review comments that seems like blockers when i look to review

Verified live — gptme/gptme#3468: Greptile 5/5, **4 open findings from us**, PM silent.

## The change

At the 5/5 short-circuit, count our own unresolved inline finding threads and fall through to the existing fix arm when any remain. A PR is only clean when *both* reviewers are satisfied.

## Design notes

**OUTDATED threads are excluded.** GitHub marks a review comment outdated once the code it anchored to changes — the cheapest available evidence that the finding was addressed. Counting them would nag forever on PRs that already did the work.

**Counts threads rather than reading our marker's `score`.** Markers written before the score field shipped (2026-08-07/08) carry no score, and those are precisely the older PRs sitting in the backlog. Thread counting works on every marker version.

**Reuses `greptile_needs_fix` rather than adding an item type.** That type is already wired end-to-end through `pm_dispatch` and `prompt_templates`; a new one would need registration in three files for no behavioural gain. The name is now a misnomer — it means "an AI reviewer wants changes". Worth renaming separately, not worth blocking this on.

## Verification

```
gptme#3468 open AI findings: 4
gptme#3486 open AI findings: 2
```

Run against the live GraphQL API with the exact query the helper uses. `bash -n` clean; pre-commit green.

## What this does not do

It does not touch the self-merge gate (that's #1393/#1391), and it does not re-review anything — the sweep does that. A companion fix in Bob's repo now orders re-reviews so a PR whose author just pushed a fix is re-reviewed *before* first-reviews of older PRs, and annotates a stale score with a "re-review pending" note while it waits.