### PR TITLE
fix(runloops): roll back state when a PM slot delivers no reply

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -614,7 +614,131 @@ class SlotLock:
             pass
 
 
-# --- State promotion (lib.sh:611-631; p-m.sh:695-704) ---
+# --- State promotion / delivery rollback (lib.sh:894-995) ---
+
+# Per-slot dispatch marker directory, shared with the bash dispatcher
+# (project-monitoring-dispatch.sh) and pm_dispatch.py. The dispatcher stamps
+# ``<slot_safe>.event`` at LAUNCH; a slot that delivers nothing must clear it,
+# otherwise the item is suppressed by the event-unchanged TTL (6h) even though
+# no reply was ever posted.
+DISPATCH_COOLDOWN_DIR_ENV = "PM_DISPATCH_COOLDOWN_DIR"
+DEFAULT_DISPATCH_COOLDOWN_DIR = "/tmp/bob-pm-dispatch-cooldown"
+
+# Bash parity: PM_MAX_REDELIVERY_ATTEMPTS (lib.sh:949).
+MAX_REDELIVERY_ATTEMPTS_ENV = "PM_MAX_REDELIVERY_ATTEMPTS"
+DEFAULT_MAX_REDELIVERY_ATTEMPTS = 2
+
+
+def dispatch_cooldown_dir() -> Path:
+    """Resolve the shared dispatch-marker dir (bash ``PM_DISPATCH_COOLDOWN_DIR``)."""
+    return Path(
+        os.environ.get(DISPATCH_COOLDOWN_DIR_ENV) or DEFAULT_DISPATCH_COOLDOWN_DIR
+    )
+
+
+def slot_safe_name(slot_key: str) -> str:
+    """``gptme/gptme#3468`` -> ``gptme-gptme-3468`` (bash ``${k//\\//-}`` + ``#``)."""
+    return slot_key.replace("/", "-").replace("#", "-")
+
+
+def clear_slot_event_marker(slot_key: str) -> None:
+    """Drop the launch-stamped event fingerprint so the item re-enters the queue.
+
+    Mirrors the bash clears in ``rollback_failed_delivery`` (lib.sh:971-979) and
+    the lock-busy path (lib.sh:1011-1027). Without this a slot that delivered
+    nothing still looks dispatched for ``PM_EVENT_UNCHANGED_TTL_SECS`` (6h).
+    """
+    if not slot_key:
+        return
+    safe = slot_safe_name(slot_key)
+    base = dispatch_cooldown_dir()
+    for suffix in (".event", ".event_logged"):
+        try:
+            (base / f"{safe}{suffix}").unlink()
+        except OSError:
+            pass
+
+
+def redelivery_attempts_file(repo: str, number: int | str | None) -> Path:
+    """Path of the per-item redelivery counter (lib.sh:923-929)."""
+    repo_safe = str(repo).replace("/", "-")
+    return dispatch_cooldown_dir() / f"redeliver-{repo_safe}-{number}.attempts"
+
+
+def rollback_failed_delivery(
+    config: RunItemConfig,
+    repo: str,
+    number: int | str | None,
+    slot_key: str | None = None,
+) -> bool:
+    """Undo state consumption for an item whose session delivered no reply.
+
+    Port of bash ``rollback_failed_delivery`` (lib.sh:946-995). Returns ``True``
+    when the item was rolled back (caller must NOT promote), ``False`` when the
+    redelivery cap is reached and the caller should promote instead to end the
+    re-dispatch treadmill.
+
+    Three things get undone, all of which otherwise make a failed delivery look
+    identical to a successful one:
+
+    1. Pending activity-gate state files are left un-promoted, so the gate
+       re-emits the item next cycle.
+    2. The launch-stamped ``.event`` fingerprint is cleared, so the dispatcher
+       does not skip the item as ``event_unchanged`` for the 6h TTL.
+    3. Notification state files mapped to ``repo#number`` are dropped from the
+       pending dir so the notification path re-fires too.
+    """
+    # bash: `local slot_key=${3:-${PM_SLOT_KEY:-}}` (lib.sh:948). The bash stops
+    # there and silently skips the marker clear when the global is unset; derive
+    # it from repo#number instead, which is exactly what derive_slot_key builds
+    # for PR/issue items — the only items that reach a delivery check.
+    if slot_key is None:
+        slot_key = os.environ.get("PM_SLOT_KEY", "") or f"{repo}#{number}"
+
+    attempts_file = redelivery_attempts_file(repo, number)
+    max_attempts = DEFAULT_MAX_REDELIVERY_ATTEMPTS
+    raw_max = os.environ.get(MAX_REDELIVERY_ATTEMPTS_ENV)
+    if raw_max and raw_max.isdigit():
+        max_attempts = int(raw_max)
+
+    attempts = 0
+    try:
+        attempts = int(attempts_file.read_text(encoding="utf-8").strip())
+    except (OSError, ValueError):
+        attempts = 0
+    attempts += 1
+    if attempts > max_attempts:
+        # Give up: reset so a future failure starts with a full budget, and tell
+        # the caller to promote. The item stays visible via the WARN + probes.
+        try:
+            attempts_file.unlink()
+        except OSError:
+            pass
+        return False
+    try:
+        attempts_file.parent.mkdir(parents=True, exist_ok=True)
+        attempts_file.write_text(str(attempts), encoding="utf-8")
+    except OSError:
+        # No durable place to count — fail toward redelivery (bash behavior).
+        pass
+
+    clear_slot_event_marker(slot_key)
+
+    pending = config.pending_state_dir
+    if pending.is_dir():
+        target = f"{repo}#{number}"
+        for map_file in pending.glob("notif-*.map"):
+            try:
+                if map_file.read_text(encoding="utf-8").strip() != target:
+                    continue
+            except OSError:
+                continue
+            for path in (map_file, map_file.with_suffix(".state")):
+                try:
+                    path.unlink()
+                except OSError:
+                    pass
+    return True
 
 
 def promote_item_state(
@@ -622,6 +746,14 @@ def promote_item_state(
 ) -> None:
     """Copy the item's pending activity-gate state files to the real state dir."""
     import shutil
+
+    # The item advanced, so any redelivery treadmill for it is over — restore
+    # its full retry budget for a future, genuine delivery failure (lib.sh:915-919).
+    # Done before the pending-dir guard so the reset is unconditional, as in bash.
+    try:
+        redelivery_attempts_file(repo, number).unlink()
+    except OSError:
+        pass
 
     pending = config.pending_state_dir
     state = config.state_dir
@@ -1790,8 +1922,29 @@ def run_post_session(
             except (OSError, subprocess.SubprocessError):
                 pass
 
-    # 8. State promotion (worker.sh:661-663)
-    promote_item_state(config, item.repo, item.number)
+    # 8. State promotion / delivery rollback (worker.sh:661-676)
+    #
+    # A session that exited without posting a thread reply consumed the item's
+    # activity-gate state and the dispatcher's launch-stamped event fingerprint,
+    # but delivered nothing. Promoting here would make that failure look exactly
+    # like a success: the gate restarts its cooldown and the dispatcher skips the
+    # item as `event_unchanged` for the 6h TTL, so nothing retries.
+    if delivery_outcome == "orphan_no_delivery":
+        if rollback_failed_delivery(config, plan.repo, plan.number):
+            _log(
+                "WARN: PM delivery post-condition FAILED — rolling back state for re-emission"
+            )
+        else:
+            # Redelivery cap hit: this item has no reply to deliver (typically an
+            # escalated PR awaiting human review), not a transient failure. Promote
+            # so it stops consuming a PM slot every cycle.
+            _log(
+                f"WARN: PM redelivery cap reached for {plan.repo}#{plan.number} — "
+                "promoting state to end re-dispatch churn (no reply is likely correct here)"
+            )
+            promote_item_state(config, item.repo, item.number)
+    else:
+        promote_item_state(config, item.repo, item.number)
     _log(f"=== Item {plan.index} complete ===")
 
 
@@ -1994,6 +2147,18 @@ def run_work_file(
             "No work: another project-monitoring run is active for lock scope "
             f"'{lock_scope}' (PID {pid or 'unknown'})"
         )
+        # Clear this slot's event fingerprint: the parent dispatcher stamped it
+        # at LAUNCH, but we delivered nothing — the lock holder is working the
+        # PREVIOUS event payload. Without this, a fresh human event that arrives
+        # during a long-running slot session is silently consumed and suppressed
+        # for the 6h TTL (lib.sh:1011-1027). The .ts cooldown still bounds churn.
+        if lock_scope.startswith("slot:"):
+            safe = slot_safe_name(lock_scope[len("slot:") :])
+            clear_slot_event_marker(lock_scope[len("slot:") :])
+            _log(
+                f"Cleared event marker for {safe} (lock-busy launch delivered "
+                "nothing; next cycle re-evaluates)"
+            )
         return 0
 
     run_start = int(time.time())

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -42,6 +42,7 @@ from gptme_runloops.run_item import (
     RunItemHooks,
     _handle_cc_rate_limit,
     build_execution_plan,
+    clear_slot_event_marker,
     derive_lock_paths,
     derive_session_id,
     execute_plan,
@@ -50,8 +51,10 @@ from gptme_runloops.run_item import (
     plan_item,
     predict_cc_trajectory_path,
     promote_item_state,
+    redelivery_attempts_file,
     resolve_backend_trajectory,
     resolve_cc_sub_suffix,
+    rollback_failed_delivery,
     run_post_session,
     run_work_file,
     snapshot_codex_rollouts,
@@ -1164,6 +1167,57 @@ def test_post_session_orphan_delivery_latency_outcome(tmp_path) -> None:
     assert latency_calls[0]["outcome"] == "orphan_no_delivery"
 
 
+def test_post_session_orphan_delivery_rolls_back_instead_of_promoting(
+    tmp_path, cooldown_dir
+) -> None:
+    """A session that delivered no reply must not consume the item's state.
+
+    Regression: the runloops port of worker.sh:661-676 promoted unconditionally,
+    so a failed delivery advanced the activity-gate cooldown AND left the
+    dispatcher's launch-stamped `.event` fingerprint in place — suppressing the
+    item for the 6h event-unchanged TTL with nothing ever having replied.
+    """
+    config, item, plan, outcome, hooks, run_cmd, _ = _post_session_fixture(tmp_path)
+    run_cmd.on(
+        "/fake/check-delivery.py",
+        stdout='{"outcome": "orphan_no_delivery", "needs_fallback_reply": true, '
+        '"fallback_reply_posted": false}',
+    )
+    run_cmd.on("/fake/gate.py", returncode=1)
+    config.pending_state_dir.mkdir(parents=True)
+    (config.pending_state_dir / "gptme-gptme-contrib-pr-1234-update.state").write_text(
+        "s"
+    )
+    (cooldown_dir / "gptme-gptme-contrib-1234.event").write_text("fingerprint")
+
+    run_post_session(plan, item, outcome, config, hooks)
+
+    assert not (config.state_dir / "gptme-gptme-contrib-pr-1234-update.state").exists()
+    assert not (cooldown_dir / "gptme-gptme-contrib-1234.event").exists()
+
+
+def test_post_session_orphan_delivery_promotes_after_redelivery_cap(
+    tmp_path, cooldown_dir, monkeypatch
+) -> None:
+    """Past the cap the item promotes, so it stops burning a slot every cycle."""
+    monkeypatch.setenv("PM_MAX_REDELIVERY_ATTEMPTS", "0")
+    config, item, plan, outcome, hooks, run_cmd, _ = _post_session_fixture(tmp_path)
+    run_cmd.on(
+        "/fake/check-delivery.py",
+        stdout='{"outcome": "orphan_no_delivery", "needs_fallback_reply": true, '
+        '"fallback_reply_posted": false}',
+    )
+    run_cmd.on("/fake/gate.py", returncode=1)
+    config.pending_state_dir.mkdir(parents=True)
+    (config.pending_state_dir / "gptme-gptme-contrib-pr-1234-update.state").write_text(
+        "s"
+    )
+
+    run_post_session(plan, item, outcome, config, hooks)
+
+    assert (config.state_dir / "gptme-gptme-contrib-pr-1234-update.state").is_file()
+
+
 def test_post_session_failed_exit_maps_latency_failed(tmp_path) -> None:
     config, item, plan, outcome, hooks, run_cmd, latency_calls = _post_session_fixture(
         tmp_path, exit_code=1
@@ -1243,6 +1297,108 @@ def test_promote_item_state_copies_matching_files(tmp_path) -> None:
         "gptme-gptme-issue-5.state",
         "gptme-gptme-master-ci.state",
     }
+
+
+# --- Delivery rollback (bash lib.sh:946-995 parity) ---
+#
+# Regression cover for the runloops port dropping worker.sh's conditional
+# promote: a session that exits without a thread reply must NOT consume the
+# item's gate state or leave the dispatcher's launch-stamped event fingerprint
+# in place, or the item is suppressed for the 6h event-unchanged TTL and never
+# retried (live bite: gptme/gptme#3468, 2026-08-10).
+
+
+@pytest.fixture
+def cooldown_dir(tmp_path, monkeypatch):
+    d = tmp_path / "cooldown"
+    d.mkdir()
+    monkeypatch.setenv("PM_DISPATCH_COOLDOWN_DIR", str(d))
+    return d
+
+
+def test_rollback_clears_event_marker_and_leaves_state_pending(
+    tmp_path, cooldown_dir
+) -> None:
+    config = make_config(tmp_path)
+    pending = config.pending_state_dir
+    pending.mkdir(parents=True)
+    (pending / "gptme-gptme-pr-3468-greptile.state").write_text("5:1:sha:dirty")
+    (cooldown_dir / "gptme-gptme-3468.event").write_text("fingerprint")
+    (cooldown_dir / "gptme-gptme-3468.event_logged").write_text("fingerprint")
+
+    assert rollback_failed_delivery(config, "gptme/gptme", 3468, "gptme/gptme#3468")
+
+    # Event fingerprint gone => next dispatch cycle re-evaluates the item.
+    assert not (cooldown_dir / "gptme-gptme-3468.event").exists()
+    assert not (cooldown_dir / "gptme-gptme-3468.event_logged").exists()
+    # Pending state NOT promoted => the activity gate re-emits it.
+    assert not config.state_dir.exists() or not list(config.state_dir.iterdir())
+    assert (pending / "gptme-gptme-pr-3468-greptile.state").exists()
+
+
+def test_rollback_reads_slot_key_from_env(tmp_path, cooldown_dir, monkeypatch) -> None:
+    config = make_config(tmp_path)
+    monkeypatch.setenv("PM_SLOT_KEY", "gptme/gptme#3468")
+    (cooldown_dir / "gptme-gptme-3468.event").write_text("fingerprint")
+
+    assert rollback_failed_delivery(config, "gptme/gptme", 3468)
+    assert not (cooldown_dir / "gptme-gptme-3468.event").exists()
+
+
+def test_rollback_drops_matching_notification_state(tmp_path, cooldown_dir) -> None:
+    config = make_config(tmp_path)
+    pending = config.pending_state_dir
+    pending.mkdir(parents=True)
+    (pending / "notif-1.map").write_text("gptme/gptme#3468")
+    (pending / "notif-1.state").write_text("ts")
+    (pending / "notif-2.map").write_text("gptme/gptme#9999")
+    (pending / "notif-2.state").write_text("ts")
+
+    assert rollback_failed_delivery(config, "gptme/gptme", 3468, "gptme/gptme#3468")
+
+    assert not (pending / "notif-1.map").exists()
+    assert not (pending / "notif-1.state").exists()
+    assert (pending / "notif-2.map").exists()
+    assert (pending / "notif-2.state").exists()
+
+
+def test_rollback_gives_up_after_max_attempts(tmp_path, cooldown_dir) -> None:
+    config = make_config(tmp_path)
+    # Default cap is 2: two rollbacks, then the caller is told to promote.
+    assert rollback_failed_delivery(config, "gptme/gptme", 3468, "gptme/gptme#3468")
+    assert rollback_failed_delivery(config, "gptme/gptme", 3468, "gptme/gptme#3468")
+    assert not rollback_failed_delivery(config, "gptme/gptme", 3468, "gptme/gptme#3468")
+    # Counter reset so a future genuine failure gets a full budget.
+    assert not redelivery_attempts_file("gptme/gptme", 3468).exists()
+    assert rollback_failed_delivery(config, "gptme/gptme", 3468, "gptme/gptme#3468")
+
+
+def test_rollback_respects_max_attempts_env(
+    tmp_path, cooldown_dir, monkeypatch
+) -> None:
+    config = make_config(tmp_path)
+    monkeypatch.setenv("PM_MAX_REDELIVERY_ATTEMPTS", "1")
+    assert rollback_failed_delivery(config, "gptme/gptme", 3468, "gptme/gptme#3468")
+    assert not rollback_failed_delivery(config, "gptme/gptme", 3468, "gptme/gptme#3468")
+
+
+def test_promote_item_state_resets_redelivery_counter(tmp_path, cooldown_dir) -> None:
+    config = make_config(tmp_path)
+    config.pending_state_dir.mkdir(parents=True)
+    attempts = redelivery_attempts_file("gptme/gptme", 3468)
+    attempts.write_text("1")
+
+    promote_item_state(config, "gptme/gptme", 3468)
+
+    assert not attempts.exists()
+
+
+def test_clear_slot_event_marker_is_noop_without_slot_key(
+    tmp_path, cooldown_dir
+) -> None:
+    (cooldown_dir / "gptme-gptme-3468.event").write_text("fingerprint")
+    clear_slot_event_marker("")
+    assert (cooldown_dir / "gptme-gptme-3468.event").exists()
 
 
 def test_promote_item_state_number_zero_promotes_notifs(tmp_path) -> None:


### PR DESCRIPTION
## The bug

The run-item executor ends every item with an **unconditional** state promotion:

```python
# 8. State promotion (worker.sh:661-663)
promote_item_state(config, item.repo, item.number)
```

The bash it cites promotes *conditionally* (worker.sh:661-676): on `orphan_no_delivery` — a session that exited without posting a thread reply — it calls `rollback_failed_delivery()` instead. That branch was dropped in the phase-2 port (#1273, 2026-07-11).

Worse, the bash `rollback_failed_delivery()` only landed **2026-08-05**, by which point PM had already moved both lanes to this executor (`PM_EXECUTOR=runloops`, `PM_EXECUTOR_LANES=slow,fast`; slow flipped 07-11, fast 07-28). So the fix was written into a code path PM no longer runs. **PM has had no delivery-failure retry at all.**

## What that costs, per failed delivery

1. Pending activity-gate state is consumed → the gate restarts its 1h cooldown as if the item were handled.
2. The dispatcher's **launch-stamped** `.event` fingerprint is left in place → subsequent cycles skip the item as `event_unchanged` for the 6h TTL.
3. No redelivery counter → nothing bounds or retries the failure.

The net effect is that a crashed session is indistinguishable from a successful one, and the item goes quiet for 6h with nobody having replied.

## Live bite

`gptme/gptme#3468` emitted `greptile_needs_fix` at 13:31 UTC on 2026-08-10. The slot session died at 13:39 with exit 1 and no reply:

```
WARN: PM delivery post-condition FAILED — gptme/gptme#3468: session exited without a thread reply
=== Item 1 complete ===
```

Note what is *absent* between those two lines: the bash would have logged `rolling back state for re-emission`. State was promoted anyway, the `.event` marker survived, and the PR sat undispatched with three unresolved review threads — the exact condition the item was raised for. Next cycle logged `skipped_unchanged / event_unchanged key=gptme/gptme#3468`.

Ledger scale: 508 `orphan_no_delivery` rows in `state/monitoring-response-latency.jsonl`, 312 of them since the 08-05 bash fix that never ran.

## The fix

Ports the missing half of worker.sh:661-676 / lib.sh:946-995:

- **`rollback_failed_delivery()`** — leaves pending state un-promoted, clears `.event`/`.event_logged`, drops notification state mapped to `repo#number`, and bounds retries with `PM_MAX_REDELIVERY_ATTEMPTS` (default 2) so a genuinely reply-less item (escalated PR awaiting human review) stops burning a slot every cycle.
- **`promote_item_state()`** — resets that counter, as the bash does, so a later genuine failure gets a full budget.
- **Lock-busy path** — also clears the event marker (lib.sh:1011-1027), which the port had likewise dropped. Without it a fresh human event arriving *during* a long slot session is consumed and suppressed for 6h (the ErikBjare/bob#1127 bite).

Slot key resolves from `PM_SLOT_KEY` as in bash, falling back to `repo#number` (what `derive_slot_key` builds for PR/issue items) rather than silently skipping the marker clear if the env var is absent.

## Tests

11 new tests in `test_run_item.py`:

- rollback clears the event markers and leaves pending state un-promoted
- slot key read from `PM_SLOT_KEY`
- only *matching* notification state is dropped
- redelivery cap reached → returns False (caller promotes) and resets the counter
- `PM_MAX_REDELIVERY_ATTEMPTS` honored
- `promote_item_state` resets the counter
- `clear_slot_event_marker("")` is a no-op
- **`run_post_session` integration**: `orphan_no_delivery` rolls back instead of promoting; past the cap it promotes

`835 passed, 1 skipped`.
