### PR TITLE
fix(git-hooks): allow explicit refspec pushes without an upstream

### DIFF
--- a/dotfiles/.config/git/hooks/validate-worktree-tracking.sh
+++ b/dotfiles/.config/git/hooks/validate-worktree-tracking.sh
@@ -26,7 +26,12 @@ ZERO="0000000000000000000000000000000000000000"
 push_remote_refs=()
 all_deletions=true
 any_pushed=false
-while read -r _local_ref local_sha remote_ref _remote_sha; do
+# The `|| [ -n "$_local_ref" ]` handles a final line with no trailing newline
+# (e.g. stdin piped from a Python subprocess or `printf` without `\n`). Without
+# it, `read` returns non-zero on that last line and the loop drops it — which
+# silently skips validation for the only ref being pushed rather than failing
+# loudly. pre-push uses the same guard when it reads git's stdin.
+while read -r _local_ref local_sha remote_ref _remote_sha || [ -n "${_local_ref:-}" ]; do
     # Skip blank lines. An up-to-date push ("Everything up-to-date") makes git
     # invoke the hook with empty stdin; the caller may forward a single empty
     # line. Treating that as a real ref produced a false "no upstream" error.
@@ -53,27 +58,46 @@ fi
 upstream=$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || echo "")
 
 if [ -z "$upstream" ]; then
-    # Check if this is a push to create new remote branch
-    new_branch_push=false
-    expected_ref="refs/heads/$current_branch"
+    # No upstream tracking branch.
+    #
+    # The hazard this guard exists for is the `git worktree add -b feat origin/master`
+    # + `push.default=upstream` trap, where a *plain* `git push` silently lands on
+    # master. That hazard is entirely about the push DESTINATION — and git resolves
+    # refspecs before invoking this hook, so every destination is already on stdin.
+    # Checking the destination is therefore both necessary and sufficient;
+    # additionally demanding an upstream adds no protection over that check.
+    #
+    # It does produce false blocks. An explicit refspec cannot go somewhere
+    # unintended, because the destination is written out in the command:
+    #     git push origin pr-3468:fix-3440-server-e2e
+    # The old rule only accepted destinations matching the *current branch name*,
+    # so it rejected every PR worker that checks a PR out under a local name
+    # differing from the PR's remote branch — teaching `--no-verify` and local
+    # branch renames as the workaround, which is the habit this hook exists to
+    # prevent. See gptme/gptme#3468 for the case that surfaced it.
+    #
+    # So: block only when a destination actually is master/main.
+    pushing_to_default=false
     for remote_ref in "${push_remote_refs[@]}"; do
-        if [ "$remote_ref" = "$expected_ref" ]; then
-            # Pushing to same-named branch on origin - likely creating new branch
-            new_branch_push=true
+        if [ "$remote_ref" = "refs/heads/master" ] || [ "$remote_ref" = "refs/heads/main" ]; then
+            pushing_to_default=true
             break
         fi
     done
 
-    if [ "$new_branch_push" = true ]; then
-        echo "ℹ️  No upstream set - assuming new branch push to origin/$current_branch"
-        exit 0
+    if [ "$pushing_to_default" = true ]; then
+        echo "❌ Error: Branch '$current_branch' has no upstream tracking branch"
+        echo "   and this push targets master/main — the wrong-destination case"
+        echo "   this guard exists to catch."
+        echo "   Fix with: git branch --set-upstream-to=origin/$current_branch"
+        echo ""
+        exit 1
     fi
 
-    echo "❌ Error: Branch '$current_branch' has no upstream tracking branch"
-    echo "   This can cause pushes to wrong location or branch."
-    echo "   Fix with: git branch --set-upstream-to=origin/$current_branch"
-    echo ""
-    exit 1
+    # Never downgrade a safety check silently — name what was allowed, so an
+    # unexpected destination is visible in the push output rather than implied.
+    echo "ℹ️  No upstream set - allowing push to explicit destination(s): ${push_remote_refs[*]}"
+    exit 0
 fi
 
 # Verify upstream is on origin (not a local branch)

--- a/tests/integration/test_git_hooks.py
+++ b/tests/integration/test_git_hooks.py
@@ -300,6 +300,198 @@ class TestWorktreeValidation:
         assert result.returncode == 0, f"Hook failed on detached HEAD: {result.stderr}"
 
 
+def run_validate_worktree_tracking(
+    repo_path: Path,
+    ref_info: str,
+) -> subprocess.CompletedProcess:
+    """Invoke validate-worktree-tracking.sh directly with the given stdin.
+
+    Calling the validator directly (rather than through pre-push) isolates the
+    tracking rules from the master/main-protection and mass-delete stanzas, which
+    would otherwise mask which check actually fired.
+    """
+    script = repo_path / ".git" / "hooks" / "validate-worktree-tracking.sh"
+    if not script.exists():
+        pytest.skip("validate-worktree-tracking.sh not found")
+
+    # A remote must exist for `git branch --set-upstream-to=origin/...` in the
+    # upstream tests; harmless for the rest. Ignore failure if already added.
+    subprocess.run(
+        ["git", "remote", "add", "origin", "https://github.com/test/repo"],
+        cwd=repo_path,
+        capture_output=True,
+        env=_clean_git_env(),
+    )
+
+    return subprocess.run(
+        ["bash", str(script), "origin", "https://github.com/test/repo"],
+        cwd=repo_path,
+        input=ref_info,
+        text=True,
+        capture_output=True,
+        env=_clean_git_env(),
+    )
+
+
+def _checkout_branch(repo_path: Path, name: str) -> None:
+    subprocess.run(
+        ["git", "checkout", "-q", "-b", name],
+        cwd=repo_path,
+        check=True,
+        capture_output=True,
+        env=_clean_git_env(),
+    )
+
+
+class TestNoUpstreamTracking:
+    """Rules applied when the current branch has no upstream.
+
+    Regression coverage for the false block that hit every PR worker checking a
+    PR out under a local name differing from the PR's remote branch (gptme#3468).
+    The guard's real purpose is preventing a push from landing on master/main
+    unintentionally, which is a property of the *destination* — git resolves
+    refspecs before the hook runs, so the destination is always known here.
+    """
+
+    def test_allows_explicit_refspec_to_differently_named_feature_branch(
+        self, hook_env
+    ):
+        """The #3468 shape: local `pr-3468` -> remote `fix-3440-server-e2e`.
+
+        Destination is explicit and is not master/main, so it must be allowed.
+        """
+        _checkout_branch(hook_env, "pr-3468")
+        result = run_validate_worktree_tracking(
+            hook_env,
+            "refs/heads/pr-3468 abc123 refs/heads/fix-3440-server-e2e "
+            "0000000000000000000000000000000000000000",
+        )
+        assert result.returncode == 0, (
+            f"Explicit refspec to a feature branch was blocked: "
+            f"{result.stdout}{result.stderr}"
+        )
+        # Must not be a silent downgrade — the allowed destination is named.
+        assert "fix-3440-server-e2e" in result.stdout
+
+    def test_blocks_push_to_master_with_no_upstream(self, hook_env):
+        """No upstream + destination master is the real hazard — still blocked."""
+        _checkout_branch(hook_env, "some-feature")
+        result = run_validate_worktree_tracking(
+            hook_env,
+            "refs/heads/some-feature abc123 refs/heads/master def456",
+        )
+        assert result.returncode == 1
+        assert "master" in result.stdout.lower()
+
+    def test_blocks_push_to_main_with_no_upstream(self, hook_env):
+        """Same for `main`-default repos."""
+        _checkout_branch(hook_env, "some-feature")
+        result = run_validate_worktree_tracking(
+            hook_env,
+            "refs/heads/some-feature abc123 refs/heads/main def456",
+        )
+        assert result.returncode == 1
+
+    def test_allows_same_name_new_branch_push(self, hook_env):
+        """The pre-existing allowance (same-named new branch) must keep working."""
+        _checkout_branch(hook_env, "my-feature")
+        result = run_validate_worktree_tracking(
+            hook_env,
+            "refs/heads/my-feature abc123 refs/heads/my-feature "
+            "0000000000000000000000000000000000000000",
+        )
+        assert result.returncode == 0
+
+    def test_allows_branch_deletion(self, hook_env):
+        """Deletions carry a zero local sha and touch nothing we protect."""
+        _checkout_branch(hook_env, "my-feature")
+        result = run_validate_worktree_tracking(
+            hook_env,
+            "(delete) 0000000000000000000000000000000000000000 "
+            "refs/heads/old-branch abc123",
+        )
+        assert result.returncode == 0
+
+    def test_allows_empty_stdin(self, hook_env):
+        """An up-to-date push invokes the hook with nothing to validate."""
+        _checkout_branch(hook_env, "my-feature")
+        result = run_validate_worktree_tracking(hook_env, "")
+        assert result.returncode == 0
+
+    def test_allows_blank_line_stdin(self, hook_env):
+        """A forwarded single empty line must not read as a real ref."""
+        _checkout_branch(hook_env, "my-feature")
+        result = run_validate_worktree_tracking(hook_env, "\n")
+        assert result.returncode == 0
+
+    def test_mixed_push_with_master_destination_is_blocked(self, hook_env):
+        """A feature destination must not launder a master destination beside it."""
+        _checkout_branch(hook_env, "pr-999")
+        result = run_validate_worktree_tracking(
+            hook_env,
+            "refs/heads/pr-999 abc123 refs/heads/some-feature def456\n"
+            "refs/heads/pr-999 abc123 refs/heads/master def456",
+        )
+        assert result.returncode == 1
+
+
+class TestUpstreamTracksDefaultBranch:
+    """The `worktree add -b feat origin/master` trap: upstream IS origin/master."""
+
+    def _set_upstream_to_master(self, repo_path: Path, branch: str) -> None:
+        clean_env = _clean_git_env()
+        subprocess.run(
+            ["git", "remote", "add", "origin", "https://github.com/test/repo"],
+            cwd=repo_path,
+            capture_output=True,
+            env=clean_env,
+        )
+        # Fabricate a remote-tracking ref so `@{u}` resolves without a network.
+        head = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_path,
+            check=True,
+            capture_output=True,
+            text=True,
+            env=clean_env,
+        ).stdout.strip()
+        subprocess.run(
+            ["git", "update-ref", "refs/remotes/origin/master", head],
+            cwd=repo_path,
+            check=True,
+            capture_output=True,
+            env=clean_env,
+        )
+        subprocess.run(
+            ["git", "branch", "--set-upstream-to=origin/master", branch],
+            cwd=repo_path,
+            check=True,
+            capture_output=True,
+            env=clean_env,
+        )
+
+    def test_blocks_when_upstream_is_master_and_destination_is_master(self, hook_env):
+        """The original hazard — must stay blocked."""
+        _checkout_branch(hook_env, "trap-branch")
+        self._set_upstream_to_master(hook_env, "trap-branch")
+        result = run_validate_worktree_tracking(
+            hook_env,
+            "refs/heads/trap-branch abc123 refs/heads/master def456",
+        )
+        assert result.returncode == 1
+        assert "trap-branch" in result.stdout
+
+    def test_allows_when_upstream_is_master_but_destination_is_feature(self, hook_env):
+        """Explicit feature-branch push is safe even with a bad upstream."""
+        _checkout_branch(hook_env, "trap-branch")
+        self._set_upstream_to_master(hook_env, "trap-branch")
+        result = run_validate_worktree_tracking(
+            hook_env,
+            "refs/heads/trap-branch abc123 refs/heads/trap-branch def456",
+        )
+        assert result.returncode == 0
+
+
 def test_hooks_exist():
     """Verify that required hook files exist."""
     assert HOOKS_DIR.exists(), f"Hooks directory not found: {HOOKS_DIR}"


### PR DESCRIPTION
## Problem

The pre-push worktree-tracking guard hard-failed whenever the current branch had no upstream and no push destination matched the **current branch name**:

```
git push origin pr-3468:fix-3440-server-e2e
❌ Error: Branch 'pr-3468' has no upstream tracking branch
```

That rejects every explicit `local:remote` refspec push where the two names differ — exactly the shape a PR worker uses when it checks a PR out under a local name (`pr-3468`) while the PR's remote branch is something else (`fix-3440-server-e2e`).

## Why the check was wrong, not just inconvenient

The guard exists for the `git worktree add -b feat origin/master` + `push.default=upstream` trap, where a *plain* `git push` silently lands on master. That hazard is entirely about the push **destination** — and git resolves refspecs before invoking the hook, so every destination is already on stdin.

Checking the destination is therefore necessary and sufficient. Additionally demanding an upstream adds no protection over that check, and it produces the false block: an explicit refspec cannot go somewhere unintended, because the destination is written out in the command.

The hazard also remains covered twice over — by pre-push's own "Master/Main Push Protection" stanza, and by this file's "upstream tracks origin/master" stanza. Neither is touched here.

## Change

The no-upstream case now blocks only when a destination actually is `refs/heads/master` / `refs/heads/main`. Otherwise it allows the push **and names the destination** — a safety check should never downgrade silently, matching the style used elsewhere in these hooks.

Also fixes a latent silent-skip in the same reader: a final stdin line with no trailing newline was dropped by `while read`, skipping validation entirely for the only ref being pushed. `pre-push` already guards this case; the validator now does too.

## Measured impact

77 distinct agent sessions hit this error between 2026-06-26 and 2026-08-10 (a floor — that is the trajectory retention window, not the rule's age; the rule dates to the file's introduction). Within PM worker systemd units specifically: 21 occurrences across 10 units, 2026-08-05 to 2026-08-10.

It was survivable rather than a hard block — workers eventually discovered they could rename the local branch to match the remote. But only after burning minutes rediscovering the workaround each time, and it taught `--no-verify` as the escape hatch, which is the habit this hook exists to prevent. A guard whose false-positive path is routinely worked around is a guard that trains people to bypass it.

## Tests

`tests/integration/test_git_hooks.py` had no coverage for these rules, which is why this went unnoticed. Added:

- differing-name explicit refspec to a feature branch → **allowed** (the #3468 shape), and asserts the destination is named in the output so it can't regress into a silent allow
- no upstream + destination `master` → **blocked**; same for `main`
- mixed push where one leg targets `master` → **blocked** (a feature destination must not launder a master destination beside it)
- upstream is `origin/master` + destination `master` → **blocked** (original hazard preserved)
- upstream is `origin/master` + destination is the feature branch → allowed
- same-name new-branch push → allowed
- branch deletions, empty stdin, blank-line stdin → allowed

23 passed locally (`uv run pytest tests/integration/test_git_hooks.py`). shellcheck clean.

Context: gptme/gptme#3468 is the case that surfaced it.