### PR TITLE
feat(activity-gate): add `@TimeToBuildBob fix` operator trigger

### DIFF
--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -1302,6 +1302,12 @@ check_own_pr_review_state() {
 # fetch_pr_data's GraphQL selection), so it costs ZERO extra API calls on PRs
 # with no trigger comment. Only a comment that literally matches the trigger
 # line costs a reactions lookup.
+#
+# SCOPE, inherited from that payload: fetch_pr_data() lists `--author $AUTHOR`
+# and drops drafts, so the trigger reaches non-draft PRs authored by the bot —
+# which is the case it exists for (a maintainer asking us to fix our own PR).
+# On someone else's PR it is silently inert; widening it means widening the
+# fetch, which is a separate cost decision.
 
 #: The account the trigger addresses, and whose reactions are the watermark.
 #: Matches ``REVIEWER_LOGIN`` in scripts/github/ai-review-sweep.py so the two

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -1361,9 +1361,13 @@ pending_fix_request() {
     # Served-ness: any reaction of ours on the trigger comment. Deliberately
     # broader than the 👀 we post — a superset can only suppress, never spam.
     local ours
+    # Must paginate. If our reaction falls outside the first page, we would read
+    # the comment as unserved and emit again on every cycle — an unbounded
+    # dispatch loop, the exact shape of the 29x @greptileai incident. --slurp
+    # wraps the pages in an outer array, hence the `.[][]` flatten.
     ours=$(gh api "repos/${repo}/issues/comments/${comment_id}/reactions" \
-        -F per_page=100 \
-        --jq "[.[] | select(((.user // {}).login // \"\") == \"$FIX_TRIGGER_LOGIN\")] | length" \
+        --paginate --slurp -F per_page=100 \
+        --jq "[.[][] | select(((.user // {}).login // \"\") == \"$FIX_TRIGGER_LOGIN\")] | length" \
         2>/dev/null) || return 0
     # Empty output means the call failed or returned something unparseable →
     # treat as served, same as a real reaction. Never as pending.

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -76,6 +76,13 @@
 #   GitHub notifications clear when marked as read upstream, so old state files
 #   become inert.
 #
+#   Maintainer fix requests: a whole-line `@TimeToBuildBob fix` comment from an
+#   OWNER/MEMBER/COLLABORATOR forces a greptile_needs_fix item for that PR even
+#   when every organic route is quiet (clean AI verdict, Greptile 5/5, or inside
+#   the 1h cooldown). Served-ness is derived from GitHub — the 👀 reaction we post
+#   on the trigger comment IS the watermark, so exactly one item is emitted per
+#   trigger comment and no state file can drift. See check_fix_requests().
+#
 #   Item grouping: This gate emits one item per event (a PR can produce separate
 #   pr_update, ci_failure, and merge_conflict items). Callers that dispatch
 #   per-item sessions should group items by repo#number before dispatching to
@@ -1264,6 +1271,135 @@ check_own_pr_review_state() {
     done
 }
 
+# --- Maintainer-forced fix requests (`@TimeToBuildBob fix`) ---
+#
+# `@TimeToBuildBob review` (ai-review-sweep.py) forces a fresh REVIEW of a PR.
+# This is its sibling: it forces a WORKER to act on the PR's outstanding review
+# findings, by emitting the item type that Project Monitoring already routes to
+# the fix lane (greptile_needs_fix → slow lane → greptile-fix bandit arm).
+#
+# It exists because every organic route into that lane is gated on a signal the
+# maintainer may already disagree with: check_greptile_scores() only fires on a
+# sub-5 Greptile score or a `dirty` verdict from our own reviewer, and then only
+# once per hour per PR. A maintainer looking at a PR with findings they want
+# addressed *now* had no way to say so.
+#
+# ANTI-SPAM (hard requirement — see memory/feedback_greptile_spam_bug.md, where a
+# poll that waited for a reaction which could never appear posted `@greptileai
+# review` 29 times on one PR):
+#
+#   * Served-ness is DERIVED FROM GITHUB, never from a state file: a request is
+#     pending iff its comment carries no reaction from us. State files drift;
+#     the reaction is on the same object as the request.
+#   * The reaction is POSTED BEFORE the item is emitted, and a failed POST
+#     suppresses the emit. A watermark written after the fact leaves a window in
+#     which a concurrent (or retried) run re-emits — that is exactly the greptile
+#     incident's shape.
+#   * Every API failure is read as "no pending request". Guards that fail open
+#     are how the 29x spam happened.
+#
+# Detection reads the already-fetched PR payload (`comments` is part of
+# fetch_pr_data's GraphQL selection), so it costs ZERO extra API calls on PRs
+# with no trigger comment. Only a comment that literally matches the trigger
+# line costs a reactions lookup.
+
+#: The account the trigger addresses, and whose reactions are the watermark.
+#: Matches ``REVIEWER_LOGIN`` in scripts/github/ai-review-sweep.py so the two
+#: triggers read identically to an operator.
+FIX_TRIGGER_LOGIN="TimeToBuildBob"
+
+#: Whole-line trigger, case-insensitive. Same shape as ai-review-sweep.py's
+#: ``TRIGGER_RE``: prose that merely mentions the phrase must not fire it.
+#: Trailing ``\r`` is allowed because GitHub stores comment bodies CRLF.
+FIX_TRIGGER_LINE_RE='^[ \t]*@'"$FIX_TRIGGER_LOGIN"'[ \t]+fix[ \t\r]*$'
+
+#: Anyone can comment on a public PR; only maintainers can spend worker budget.
+FIX_TRUSTED_ASSOCIATIONS='["OWNER","MEMBER","COLLABORATOR"]'
+
+#: Greptile's convention, reused: 👀 means "queued". Reactions do not touch the
+#: comment body and do not bump ``updated_at``.
+FIX_REACTION_QUEUED="eyes"
+
+# The REST id of the newest UNSERVED `@TimeToBuildBob fix` comment on this PR,
+# or nothing. Prints nothing on any failure (fail toward skip).
+# Args: <owner/repo> <pr_json from fetch_pr_data>
+pending_fix_request() {
+    local repo=$1 pr_json=$2
+
+    # jq's `^`/`$` anchor to the whole string, not to lines, so split first
+    # rather than depending on an inline-modifier dialect.
+    local comment_id
+    comment_id=$(printf '%s' "$pr_json" | jq -r \
+        --arg me "$FIX_TRIGGER_LOGIN" \
+        --arg author "$AUTHOR" \
+        --arg re "$FIX_TRIGGER_LINE_RE" \
+        --argjson trusted "$FIX_TRUSTED_ASSOCIATIONS" '
+        [ (.comments // [])[]
+          # Self-trigger guard: a worker that quotes the trigger phrase in its
+          # own reply (our review footer does exactly that) must never re-arm it.
+          | select((((.author // {}).login) // "") as $l
+                   | ($l | ascii_downcase) != ($me | ascii_downcase)
+                     and ($l | ascii_downcase) != ($author | ascii_downcase))
+          | select(((.authorAssociation) // "") | IN($trusted[]))
+          | select(((.body) // "") | split("\n")
+                   | any(test($re; "i")))
+          | { id: (((.url // "") | capture("issuecomment-(?<n>[0-9]+)")) // {n:""} | .n),
+              created: ((.createdAt) // "") }
+          | select(.id != "")
+        ] | sort_by(.created) | last | .id // empty
+    ' 2>/dev/null) || return 0
+    [ -z "$comment_id" ] && return 0
+    # Defensive: only ever interpolate a bare number into an API path.
+    [[ "$comment_id" =~ ^[0-9]+$ ]] || return 0
+
+    # Served-ness: any reaction of ours on the trigger comment. Deliberately
+    # broader than the 👀 we post — a superset can only suppress, never spam.
+    local ours
+    ours=$(gh api "repos/${repo}/issues/comments/${comment_id}/reactions" \
+        -F per_page=100 \
+        --jq "[.[] | select(((.user // {}).login // \"\") == \"$FIX_TRIGGER_LOGIN\")] | length" \
+        2>/dev/null) || return 0
+    # Empty output means the call failed or returned something unparseable →
+    # treat as served, same as a real reaction. Never as pending.
+    [ -z "$ours" ] && return 0
+    [ "$ours" = "0" ] || return 0
+
+    printf '%s' "$comment_id"
+}
+
+# Emit greptile_needs_fix for every PR carrying an unserved maintainer fix
+# request. Exactly one emit per trigger comment.
+# Args: <owner/repo> <prs json>
+check_fix_requests() {
+    local repo=$1
+    local prs=$2
+    [ "$prs" = "[]" ] || [ -z "$prs" ] && return 0
+
+    echo "$prs" | jq -c '.[]' | while read -r pr_data; do
+        local pr_number pr_title comment_id
+        pr_number=$(echo "$pr_data" | jq -r '.number')
+        pr_title=$(echo "$pr_data" | jq -r '.title')
+
+        comment_id=$(pending_fix_request "$repo" "$pr_data")
+        [ -z "$comment_id" ] && continue
+
+        # Consume BEFORE emitting. This reaction IS the watermark: if the POST
+        # fails we must not emit, because nothing would stop the next cycle from
+        # emitting again. Costs at most one deferred dispatch; the alternative
+        # costs an unbounded dispatch loop.
+        if ! gh api -X POST \
+                "repos/${repo}/issues/comments/${comment_id}/reactions" \
+                -f "content=${FIX_REACTION_QUEUED}" \
+                >/dev/null 2>&1; then
+            continue
+        fi
+
+        emit_item "greptile_needs_fix" "$repo" "$pr_number" \
+            "${pr_title} [maintainer fix request]" \
+            "fix_request · maintainer asked us to act on outstanding review findings (comment ${comment_id})"
+    done
+}
+
 # Check if the bot account has already posted a maintainer-facing status comment
 # on this PR indicating that the ball is in the maintainer's court.
 #
@@ -1671,6 +1807,16 @@ for repo in $all_repos; do
         [ -n "$items" ] && repo_items+="$items"$'\n'
 
         items=$(check_merge_ready "$repo" "$live_pr_data" 2>/dev/null || true)
+        [ -n "$items" ] && repo_items+="$items"$'\n'
+
+        # Maintainer-forced `@TimeToBuildBob fix`. Uses the live lane (180s TTL)
+        # so a maintainer's comment is picked up in minutes rather than after the
+        # 480s cached lane; falls back to the cached lane when live returns [].
+        fix_input="$live_pr_data"
+        if [ "$fix_input" = "[]" ] || [ -z "$fix_input" ]; then
+            fix_input="$pr_data"
+        fi
+        items=$(check_fix_requests "$repo" "$fix_input" 2>/dev/null || true)
         [ -n "$items" ] && repo_items+="$items"$'\n'
 
         [ -n "$repo_items" ] && printf '%s' "$repo_items" > "$PARALLEL_TMPDIR/$repo_safe"

--- a/tests/test_activity_gate_fix_request.py
+++ b/tests/test_activity_gate_fix_request.py
@@ -68,6 +68,7 @@ endpoint = ""
 jq_expr = ""
 method = "GET"
 fields = {}
+slurp = False
 i = 1
 while i < len(argv):
     a = argv[i]
@@ -85,6 +86,8 @@ while i < len(argv):
         i += 2; continue
     if a == "--paginate":
         i += 1; continue
+    if a == "--slurp":
+        slurp = True; i += 1; continue
     if a.startswith("-"):
         i += 1; continue
     endpoint = a; i += 1
@@ -102,7 +105,15 @@ if endpoint.endswith("/reactions"):
             fh.write(json.dumps({"endpoint": endpoint, "content": fields.get("content")}) + "\n")
         print("{}")
         sys.exit(0)
-    data = fixture.get("reactions", [])
+    # `reactions_pages` emulates a paginated response (list of pages); plain
+    # `reactions` is the single-page case. Real `gh --paginate --slurp` wraps
+    # every page in an outer array, so the stub must too — otherwise a jq
+    # filter that is wrong in production would still pass here.
+    pages = fixture.get("reactions_pages")
+    data = pages if pages is not None else [fixture.get("reactions", [])]
+    if not slurp:
+        # Without --slurp real gh returns only the first page.
+        data = data[0] if data else []
 else:
     # Every other REST call the gate makes (greptile comment sweep, merge
     # permission probes, ...) sees an empty result.
@@ -286,6 +297,99 @@ def test_single_trigger_emits_exactly_once_across_runs() -> None:
         assert (
             posts2 == []
         ), f"no reaction should be posted on a served trigger: {posts2}"
+
+
+def test_watermark_on_a_later_reactions_page_still_suppresses() -> None:
+    """The watermark must be found even when it is not on page 1.
+
+    A popular trigger comment can accumulate >100 reactions. If the served-ness
+    lookup reads only the first page, ours falls off the end, the comment reads
+    as unserved, and the gate re-emits on every cycle — an unbounded dispatch
+    loop, which is precisely the 29x @greptileai incident shape. This is why the
+    lookup paginates.
+    """
+    filler = [
+        {"id": n, "content": "heart", "user": {"login": f"fan{n}"}} for n in range(100)
+    ]
+    ours = [{"id": 999, "content": "eyes", "user": {"login": BOT}}]
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+        result, posts = _run_gate(
+            tmp,
+            _fixture(_trusted_request(), reactions_pages=[filler, ours]),
+            state_dir=state_dir,
+            gh_log=tmp / "gh.log",
+        )
+        assert _fix_items(result) == [], (
+            "watermark on page 2 was missed — the gate would re-emit every cycle. "
+            f"stdout: {result.stdout}"
+        )
+        assert posts == [], f"no reaction should be posted on a served trigger: {posts}"
+
+
+def test_two_pending_triggers_collapse_to_one_dispatch() -> None:
+    """Two unserved trigger comments on one PR → exactly ONE dispatch.
+
+    The trigger means "act on this PR's outstanding review findings". That work
+    is the same regardless of how many times it was asked for, so requests
+    collapse. Emitting once per comment would let a maintainer double-post and
+    get two workers on identical findings.
+    """
+    comments = [
+        _comment(body=f"@{BOT} fix", comment_id=111, created_at="2026-08-10T12:00:00Z"),
+        _comment(body=f"@{BOT} fix", comment_id=222, created_at="2026-08-10T12:05:00Z"),
+    ]
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+        result, posts = _run_gate(
+            tmp,
+            _fixture(comments),
+            state_dir=state_dir,
+            gh_log=tmp / "gh.log",
+        )
+        assert (
+            len(_fix_items(result)) == 1
+        ), f"two triggers must collapse to one dispatch, got: {result.stdout}"
+        assert len(posts) == 1, f"exactly one watermark should be posted: {posts}"
+        assert "222" in posts[0]["endpoint"], (
+            "the newest trigger should carry the watermark, so a maintainer's "
+            f"most recent ask is the one marked served: {posts[0]}"
+        )
+
+
+def test_served_newest_trigger_does_not_reopen_an_older_one() -> None:
+    """Once the newest trigger is served, an older one must not re-fire.
+
+    Deliberate: the older comment asked for the same work that the newest one
+    already dispatched. Walking back to it would emit a second dispatch for
+    findings a worker is already handling.
+    """
+    comments = [
+        _comment(body=f"@{BOT} fix", comment_id=111, created_at="2026-08-10T12:00:00Z"),
+        _comment(body=f"@{BOT} fix", comment_id=222, created_at="2026-08-10T12:05:00Z"),
+    ]
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+        result, posts = _run_gate(
+            tmp,
+            _fixture(
+                comments,
+                reactions=[{"id": 1, "content": "eyes", "user": {"login": BOT}}],
+            ),
+            state_dir=state_dir,
+            gh_log=tmp / "gh.log",
+        )
+        assert _fix_items(result) == [], (
+            "an older trigger re-fired after the newest was served — this "
+            f"re-dispatches work already in flight. stdout: {result.stdout}"
+        )
+        assert posts == [], f"no reaction should be posted: {posts}"
 
 
 def test_existing_eyes_reaction_suppresses_emit() -> None:

--- a/tests/test_activity_gate_fix_request.py
+++ b/tests/test_activity_gate_fix_request.py
@@ -1,0 +1,442 @@
+"""Tests for the `@TimeToBuildBob fix` maintainer trigger in activity-gate.sh.
+
+`@TimeToBuildBob review` forces a fresh review; `@TimeToBuildBob fix` forces a
+worker to act on the PR's outstanding review findings, by emitting the
+`greptile_needs_fix` item that Project Monitoring already routes to the fix lane.
+
+The load-bearing property is SINGLE EMIT PER TRIGGER COMMENT. There is a recorded
+incident (memory/feedback_greptile_spam_bug.md) where a poll waiting on a reaction
+that could never appear posted `@greptileai review` 29 times on one PR, so
+`test_single_trigger_emits_exactly_once_across_runs` replays the reaction the
+first run posted into the second run's fixture and asserts the second run is
+silent — asserted on emitted items, not on internal state.
+
+Convention follows tests/test_greptile_helper.py: a fake `gh` stub driven by a
+JSON fixture, written to a temp dir and prepended to PATH.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "github" / "activity-gate.sh"
+
+TEST_REPO = "testorg/testrepo"
+TEST_PR = 42
+TEST_HEAD_SHA = "deadbeef1234"
+BOT = "TimeToBuildBob"
+COMMENT_ID = 987654321
+
+FAKE_GH = r'''#!/usr/bin/env python3
+"""Fake gh CLI for activity-gate.sh fix-request tests.
+
+Serves the PR list (with comments) and the issue-comment reactions endpoint from
+a JSON fixture, applies --jq via the real jq binary, and appends every reaction
+POST to GH_LOG as JSONL so the test can replay it into a later fixture.
+"""
+from pathlib import Path
+import json
+import os
+import subprocess as sp
+import sys
+
+fixture = json.loads(Path(os.environ["GH_FIXTURE"]).read_text())
+argv = sys.argv[1:]
+
+if not argv:
+    sys.exit(2)
+
+if argv[0] == "pr" and argv[1:2] == ["list"]:
+    print(json.dumps(fixture["prs"]))
+    sys.exit(0)
+
+if argv[0] in ("repo", "issue", "run") and argv[1:2] == ["list"]:
+    print("[]")
+    sys.exit(0)
+
+if argv[0] != "api":
+    sys.exit(0)
+
+# Parse the api invocation
+endpoint = ""
+jq_expr = ""
+method = "GET"
+fields = {}
+i = 1
+while i < len(argv):
+    a = argv[i]
+    if a == "--jq":
+        jq_expr = argv[i + 1]; i += 2; continue
+    if a == "-X":
+        method = argv[i + 1]; i += 2; continue
+    if a in ("-f", "-F") and i + 1 < len(argv):
+        kv = argv[i + 1]
+        if "=" in kv:
+            k, v = kv.split("=", 1)
+            fields[k] = v
+        i += 2; continue
+    if a in ("-q", "-H"):
+        i += 2; continue
+    if a == "--paginate":
+        i += 1; continue
+    if a.startswith("-"):
+        i += 1; continue
+    endpoint = a; i += 1
+
+if endpoint == "notifications":
+    sys.exit(0)
+
+if endpoint.endswith("/reactions"):
+    if fixture.get("reactions_api_error"):
+        sys.exit(1)
+    if method == "POST":
+        if fixture.get("reaction_post_error"):
+            sys.exit(1)
+        with open(os.environ["GH_LOG"], "a") as fh:
+            fh.write(json.dumps({"endpoint": endpoint, "content": fields.get("content")}) + "\n")
+        print("{}")
+        sys.exit(0)
+    data = fixture.get("reactions", [])
+else:
+    # Every other REST call the gate makes (greptile comment sweep, merge
+    # permission probes, ...) sees an empty result.
+    if jq_expr:
+        sys.exit(0)
+    print("[]")
+    sys.exit(0)
+
+raw = json.dumps(data)
+if jq_expr:
+    r = sp.run(["jq", "-r", jq_expr], input=raw, capture_output=True, text=True)
+    sys.stdout.write(r.stdout)
+else:
+    print(raw)
+'''
+
+
+def _comment(
+    *,
+    body: str,
+    author: str = "ErikBjare",
+    association: str = "OWNER",
+    comment_id: int = COMMENT_ID,
+    created_at: str = "2026-08-10T12:00:00Z",
+) -> dict:
+    return {
+        "author": {"login": author},
+        "authorAssociation": association,
+        "body": body,
+        "createdAt": created_at,
+        "id": "IC_kwDOfake",
+        "includesCreatedEdit": False,
+        "isMinimized": False,
+        "minimizedReason": "",
+        "reactionGroups": [],
+        "url": f"https://github.com/{TEST_REPO}/pull/{TEST_PR}#issuecomment-{comment_id}",
+        "viewerDidAuthor": author == BOT,
+    }
+
+
+def _pr(comments: list[dict]) -> dict:
+    return {
+        "number": TEST_PR,
+        "title": f"Test PR #{TEST_PR}",
+        "updatedAt": "2026-08-10T12:00:00Z",
+        "comments": comments,
+        "latestReviews": [],
+        "statusCheckRollup": None,
+        "mergeable": "MERGEABLE",
+        "mergeStateStatus": "BLOCKED",
+        "headRefOid": TEST_HEAD_SHA,
+        "isDraft": False,
+    }
+
+
+def _run_gate(
+    tmp: Path, fixture: dict, *, state_dir: Path, gh_log: Path
+) -> tuple[subprocess.CompletedProcess[str], list[dict]]:
+    """Run activity-gate.sh once. Returns (result, reaction POSTs made)."""
+    fixture_path = tmp / "fixture.json"
+    fixture_path.write_text(json.dumps(fixture))
+
+    fake_gh = tmp / "gh"
+    fake_gh.write_text(FAKE_GH)
+    fake_gh.chmod(fake_gh.stat().st_mode | stat.S_IXUSR)
+
+    env = os.environ.copy()
+    env["GH_FIXTURE"] = str(fixture_path)
+    env["GH_LOG"] = str(gh_log)
+    env["PATH"] = f"{tmp}:{env['PATH']}"
+
+    result = subprocess.run(
+        [
+            str(SCRIPT),
+            "--author",
+            BOT,
+            "--repo",
+            TEST_REPO,
+            "--state-dir",
+            str(state_dir),
+            "--format",
+            "jsonl",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=120,
+    )
+    posts = [
+        json.loads(line)
+        for line in (gh_log.read_text().splitlines() if gh_log.exists() else [])
+        if line.strip()
+    ]
+    return result, posts
+
+
+def _fix_items(result: subprocess.CompletedProcess[str]) -> list[dict]:
+    """Emitted items produced by the fix-request path, identified by its token."""
+    items = []
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if "fix_request" in (obj.get("detail") or ""):
+            items.append(obj)
+    return items
+
+
+def _fixture(comments: list[dict], **extra: object) -> dict:
+    return {"prs": [_pr(comments)], "reactions": [], **extra}
+
+
+def _trusted_request() -> list[dict]:
+    return [_comment(body=f"@{BOT} fix")]
+
+
+def test_trusted_request_emits_one_fix_item() -> None:
+    """A well-formed maintainer request emits exactly one greptile_needs_fix."""
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+
+        result, posts = _run_gate(
+            tmp,
+            _fixture(_trusted_request()),
+            state_dir=state_dir,
+            gh_log=tmp / "gh.log",
+        )
+        assert result.returncode in (0, 1), result.stderr
+
+        items = _fix_items(result)
+        assert len(items) == 1, f"expected one fix item, got {items}\n{result.stdout}"
+        assert items[0]["type"] == "greptile_needs_fix", items[0]
+        assert items[0]["number"] == TEST_PR
+        assert "[maintainer fix request]" in items[0]["title"], items[0]
+
+        # The 👀 reaction is the watermark and must have been posted.
+        assert len(posts) == 1, posts
+        assert posts[0]["content"] == "eyes", posts[0]
+        assert str(COMMENT_ID) in posts[0]["endpoint"], posts[0]
+
+
+def test_single_trigger_emits_exactly_once_across_runs() -> None:
+    """THE anti-spam test: one trigger comment → one emit, forever.
+
+    Run 1 emits and posts 👀. That reaction is replayed into run 2's fixture
+    exactly as GitHub would serve it back. Run 2 must emit nothing.
+    """
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+        gh_log = tmp / "gh.log"
+
+        first, posts = _run_gate(
+            tmp, _fixture(_trusted_request()), state_dir=state_dir, gh_log=gh_log
+        )
+        assert len(_fix_items(first)) == 1, first.stdout
+        assert posts, "run 1 must have posted the watermark reaction"
+
+        # Feed run 1's reaction POST back in as GitHub would now report it.
+        replayed = [
+            {"id": 1, "content": p["content"], "user": {"login": BOT}} for p in posts
+        ]
+        gh_log.unlink()
+        second, posts2 = _run_gate(
+            tmp,
+            _fixture(_trusted_request(), reactions=replayed),
+            state_dir=state_dir,
+            gh_log=gh_log,
+        )
+        assert _fix_items(second) == [], (
+            "a served trigger comment re-emitted — this is the 29x greptile spam "
+            f"shape. stdout: {second.stdout}"
+        )
+        assert (
+            posts2 == []
+        ), f"no reaction should be posted on a served trigger: {posts2}"
+
+
+def test_existing_eyes_reaction_suppresses_emit() -> None:
+    """A trigger already carrying our 👀 is served, whatever wrote it."""
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+
+        result, posts = _run_gate(
+            tmp,
+            _fixture(
+                _trusted_request(),
+                reactions=[{"id": 1, "content": "eyes", "user": {"login": BOT}}],
+            ),
+            state_dir=state_dir,
+            gh_log=tmp / "gh.log",
+        )
+        assert _fix_items(result) == [], result.stdout
+        assert posts == [], posts
+
+
+def test_reaction_from_someone_else_does_not_count_as_served() -> None:
+    """A human's 👀 is not our watermark — the request is still pending."""
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+
+        result, _ = _run_gate(
+            tmp,
+            _fixture(
+                _trusted_request(),
+                reactions=[{"id": 1, "content": "eyes", "user": {"login": "someone"}}],
+            ),
+            state_dir=state_dir,
+            gh_log=tmp / "gh.log",
+        )
+        assert len(_fix_items(result)) == 1, result.stdout
+
+
+def test_untrusted_association_does_not_emit() -> None:
+    """Anyone can comment on a public PR; only maintainers spend worker budget."""
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+
+        result, posts = _run_gate(
+            tmp,
+            _fixture(
+                [_comment(body=f"@{BOT} fix", author="drive-by", association="NONE")]
+            ),
+            state_dir=state_dir,
+            gh_log=tmp / "gh.log",
+        )
+        assert _fix_items(result) == [], result.stdout
+        assert posts == [], posts
+
+
+def test_self_authored_trigger_does_not_emit() -> None:
+    """Self-trigger guard: our own comments quote the phrase in the review footer."""
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+
+        result, posts = _run_gate(
+            tmp,
+            _fixture(
+                [
+                    _comment(
+                        body=f"Re-request with `@{BOT} review`.\n@{BOT} fix",
+                        author=BOT,
+                        association="MEMBER",
+                    )
+                ]
+            ),
+            state_dir=state_dir,
+            gh_log=tmp / "gh.log",
+        )
+        assert _fix_items(result) == [], result.stdout
+        assert posts == [], posts
+
+
+def test_reactions_api_failure_fails_toward_skip() -> None:
+    """A guard that fails open is how the 29x spam happened. Fail closed."""
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+
+        result, posts = _run_gate(
+            tmp,
+            _fixture(_trusted_request(), reactions_api_error=True),
+            state_dir=state_dir,
+            gh_log=tmp / "gh.log",
+        )
+        assert _fix_items(result) == [], result.stdout
+        assert posts == [], posts
+
+
+def test_failed_reaction_post_suppresses_emit() -> None:
+    """No watermark, no emit — otherwise the next cycle emits again."""
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+
+        result, posts = _run_gate(
+            tmp,
+            _fixture(_trusted_request(), reaction_post_error=True),
+            state_dir=state_dir,
+            gh_log=tmp / "gh.log",
+        )
+        assert _fix_items(result) == [], result.stdout
+        assert posts == [], posts
+
+
+def test_inline_mention_does_not_trigger() -> None:
+    """Whole-line only: prose about the trigger must not fire it."""
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+
+        result, posts = _run_gate(
+            tmp,
+            _fixture(
+                [_comment(body=f"could you ask @{BOT} fix the lint error please")]
+            ),
+            state_dir=state_dir,
+            gh_log=tmp / "gh.log",
+        )
+        assert _fix_items(result) == [], result.stdout
+        assert posts == [], posts
+
+
+def test_trigger_on_its_own_line_in_a_longer_comment_fires() -> None:
+    """CRLF bodies and surrounding prose lines must not defeat the anchor."""
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = Path(tmp_str)
+        state_dir = tmp / "state"
+        state_dir.mkdir()
+
+        result, _ = _run_gate(
+            tmp,
+            _fixture(
+                [_comment(body=f"P1 looks real to me.\r\n  @{BOT}   FIX  \r\nthanks")]
+            ),
+            state_dir=state_dir,
+            gh_log=tmp / "gh.log",
+        )
+        assert len(_fix_items(result)) == 1, result.stdout


### PR DESCRIPTION
## What

`@TimeToBuildBob review` forces a fresh **review** of a PR. This adds its sibling:
`@TimeToBuildBob fix` forces a PM worker to **act on** the findings that review
already posted.

No new dispatch, prompt, lane, or model-routing logic is needed — PM already routes
`greptile_needs_fix` to the slow lane / `greptile-fix` bandit arm with a 2700s
timeout. What was missing was a *maintainer-forced entry point* that emits it when
the gate would otherwise stay quiet: a `clean`/`pending` verdict from our reviewer,
Greptile 5/5, or inside `check_greptile_scores()`'s 1-hour cooldown. A maintainer who
reads the findings and wants them addressed *now* had no way to say so.

## How

`pending_fix_request()` + `check_fix_requests()` in `scripts/github/activity-gate.sh`,
hooked into the per-repo scan after `check_merge_ready`, reading the live PR lane
(180s TTL) so a comment is picked up in minutes.

- **Whole-line, case-insensitive** match, same shape as `ai-review-sweep.py`'s
  `TRIGGER_RE`. Prose that merely mentions the phrase does not fire it.
- **Trust gate**: `author_association` must be `OWNER`/`MEMBER`/`COLLABORATOR`.
  Anyone can comment on a public PR; only maintainers can spend worker budget.
- **Self-trigger guard**: comments authored by `TimeToBuildBob` are ignored, so a
  worker quoting the phrase in its own reply cannot re-arm the trigger.

## Anti-spam

There is a recorded incident where a poll waiting on a reaction that could never
appear posted `@greptileai review` **29 times** on one PR. This guard is built the
other way round:

- **Served-ness is derived from GitHub, never from a state file.** A request is
  pending iff its comment carries no reaction from us. The 👀 reaction *is* the
  watermark — it lives on the same object as the request, so it cannot drift.
- **The reaction is POSTED BEFORE the emit, and a failed POST suppresses the emit.**
  A watermark written afterwards leaves a window in which the next 2-minute cycle
  re-emits. Costs at most one deferred dispatch; the alternative costs a loop.
- **Every API failure reads as "no pending request."** Guards that fail open are how
  that incident happened.

`test_single_trigger_emits_exactly_once_across_runs` replays the reaction run 1
posted into run 2's fixture exactly as GitHub would serve it back, and asserts run 2
emits nothing — asserted on **emitted items**, not on internal state.

## Cost

Detection reads the already-fetched PR payload (`comments` is part of
`fetch_pr_data`'s GraphQL selection), so it costs **zero extra API calls** on PRs
with no trigger comment. Only a comment that literally matches the trigger line
costs a reactions lookup.

## Test plan

- `tests/test_activity_gate_fix_request.py` — 10 tests: single-emit-across-runs,
  trusted request emits once, untrusted association, self-authored trigger, existing
  👀, someone else's 👀 (still pending), reactions-API failure, failed reaction POST,
  inline mention, and a CRLF multi-line body.
- `make test-unit` green apart from a pre-existing, unrelated
  `tests/test_linear_oauth_state.py` flask failure that also fails on `master`.
- `shellcheck -x scripts/github/activity-gate.sh` clean; `prek` clean.

Operator docs (routing table row, latency, receipt semantics) land in Bob's brain
repo: `knowledge/technical/pr-review-systems-map.md` + `tools/README.md`, and the
`ai-review.py` review footer now names both triggers so they are discoverable from
the artifact a maintainer actually reads.