### PR TITLE
fix(hooks): track pre-merge-commit — it existed in no git ref

### DIFF
--- a/dotfiles/.config/git/hooks/pre-merge-commit
+++ b/dotfiles/.config/git/hooks/pre-merge-commit
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Dispatcher: core.hooksPath is global, so this runs for every repo. Delegate to
+# the repo's own guard when it ships one; do nothing anywhere else.
+# Real logic: <brain-repo>/scripts/precommit/prevent-master-merge-commits.sh
+#
+# SECURITY: the guard path is repo-controlled content, and this hook runs in
+# EVERY repository — including untrusted clones. Executing it unconditionally is
+# a remote-code-execution vector: an adversary commits an executable script at
+# that exact path, and a routine `git merge` after cloning runs it with the
+# user's full privileges. Git's normal hook model is opt-in precisely because
+# repo-local .git/hooks are never fetched from a remote; core.hooksPath opts
+# every repo in at once, so the trust check has to be reintroduced here.
+#
+# So: only delegate in repos whose `origin` belongs to an org we control. This
+# keeps the guard working where it is meant to while making a hostile clone
+# inert. Found by our own AI reviewer on gptme/gptme-contrib#1380 (P0).
+set -uo pipefail
+
+root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+[ -n "$root" ] || exit 0
+
+guard_rel="scripts/precommit/prevent-master-merge-commits.sh"
+guard="$root/$guard_rel"
+[ -x "$guard" ] || exit 0
+
+# The guard must be byte-identical to the version on ORIGIN's default branch.
+#
+# A trusted origin does NOT make merged-in content trusted, and this hook runs
+# at the worst possible moment for that distinction: pre-merge-commit fires
+# *after* the merge has been applied to the worktree and before the commit
+# object exists. So a branch from an untrusted fork can introduce — or modify —
+# this exact file, and merging it into a repo whose origin is on the allowlist
+# below would execute the attacker's version with the user's privileges. The
+# origin check cannot see that; it only describes where the repo came from.
+#
+# The first attempt at this anchored to `HEAD:$guard_rel`, which is NOT a trust
+# anchor: `gh pr checkout` moves HEAD onto the contributor's branch, so a
+# hostile PR that carries this exact file makes worktree and HEAD agree, and the
+# next `git merge` in that checkout execs the payload. Anchoring to HEAD only
+# proves "the worktree matches the branch you are standing on" — it says nothing
+# about who wrote that branch. (Fourth P0 on this file, all four found by our own
+# AI reviewer — ErikBjare/bob#1122.)
+#
+# `refs/remotes/origin/*` is the anchor that actually means something: those refs
+# only move on `git fetch origin`, so a match proves the guard is the version
+# that already landed on the trusted org's default branch. A PR branch — even
+# one pushed to origin — is never origin/HEAD, origin/master, or origin/main.
+#
+# Consequences, both intentional:
+#   * A merge that ADDS or EDITS the guard has no matching origin blob, so the
+#     hook goes inert for that merge. It does not abort the merge: refusing
+#     would break every legitimate PR that updates the guard, and once the
+#     origin anchor is in place there is no escalation path to protect against
+#     (the payload becoming the local HEAD no longer grants it execution).
+#   * While you are locally editing the guard, the hook is inert. Fail closed.
+trusted_blob=""
+for _trusted_ref in \
+    refs/remotes/origin/HEAD \
+    refs/remotes/origin/master \
+    refs/remotes/origin/main; do
+    trusted_blob="$(git rev-parse --quiet --verify "$_trusted_ref:$guard_rel" 2>/dev/null || true)"
+    [ -n "$trusted_blob" ] && break
+done
+work_blob="$(git hash-object "$guard" 2>/dev/null || true)"
+[ -n "$trusted_blob" ] && [ "$trusted_blob" = "$work_blob" ] || exit 0
+
+origin="$(git config --get remote.origin.url 2>/dev/null || true)"
+[ -n "$origin" ] || exit 0
+
+# Both HOST and OWNER must be trusted, as a pair.
+#
+# Matching the owner alone is not enough, and that bug shipped here first:
+# `https://evil.com/gptme/malicious.git` parses to owner `gptme`, which was on
+# the allowlist, so an attacker only had to name their account after one of
+# ours to get the RCE back. Caught by our own AI reviewer re-reviewing this PR
+# after the first fix (P0, ErikBjare/bob#1122) — the original tests probed
+# `gptme-fake` and `gptme-evil` but never an attacker host with an *exact*
+# allowed owner, so they all passed.
+#
+# Shapes handled: git@host:OWNER/repo(.git), scheme://[user@]host[:port]/OWNER/repo(.git)
+host=""
+owner=""
+case "$origin" in
+    *://*)
+        host="$(printf '%s' "$origin" | sed -E 's#^[a-z+]+://([^/]+)/.*$#\1#')"
+        owner="$(printf '%s' "$origin" | sed -E 's#^[a-z+]+://[^/]+/([^/]+)/.*$#\1#')"
+        ;;
+    *:*)
+        host="$(printf '%s' "$origin" | sed -E 's#^([^:]+):.*$#\1#')"
+        owner="$(printf '%s' "$origin" | sed -E 's#^[^:]+:([^/]+)/.*$#\1#')"
+        ;;
+esac
+
+# Strip any userinfo ("git@") and port (":3000") from the host.
+host="${host##*@}"
+host="${host%%:*}"
+
+case "$host" in
+    github.com | forgejo.hassel.bjareho.lt) ;;
+    *) exit 0 ;;
+esac
+
+case "$owner" in
+    ErikBjare | gptme | ActivityWatch | superuserlabs) exec "$guard" ;;
+    *) exit 0 ;;
+esac


### PR DESCRIPTION
## The problem

`dotfiles/.config/git/hooks/pre-merge-commit` — the guard against merge commits landing on master — exists **on disk only**. It is in **no git ref**: not master, not any branch.

```
$ git cat-file -e origin/master:dotfiles/.config/git/hooks/pre-merge-commit
fatal: path ... exists on disk, but not in 'origin/master'
$ git log --oneline -- dotfiles/.config/git/hooks/pre-merge-commit
(nothing)
```

So a **clean install of the global hooks silently loses the merge-commit guard.** That just became load-bearing: the hooks were moved today to a versioned install root (`~/.local/share/git-hooks`) precisely so the active hooks come from git — and this file could not follow, because it is not in git. A drift watch now reports it as a standing warning on every run.

## Why the file is worth keeping, not just re-creating

It carries a security argument that would be lost with it:

> `core.hooksPath` is global, so this runs for **every** repo — including untrusted clones. The guard path is repo-controlled content, so executing it unconditionally is an RCE vector: an adversary commits an executable script at that exact path, and a routine `git merge` after cloning runs it with the user's full privileges. Git's normal hook model is opt-in precisely because repo-local `.git/hooks` are never fetched from a remote; `core.hooksPath` opts every repo in at once, so the trust check has to be reintroduced here.

That reasoning is not reconstructible from a re-implementation.

## Scope note

This PR originally also landed `bobutils/prompts.py`, which had the same shape (bob's committed code importing an untracked module). **That commit has been dropped** — a concurrent session moved the module to `packages/context/src/context/prompts.py` in bob and rewired all four importers, which is the better fix: `packages/bobutils` in bob is a symlink into this repo, so a bob-only consumer should not depend across the repo boundary. `bobutils.prompts` now has zero consumers, and adding it here would have been dead code.

`bash -n` and shellcheck clean; committed with its executable bit.