### PR TITLE
fix(runloops): wire stem token into voice_postcall verification

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/prompt_templates.py
+++ b/packages/gptme-runloops/src/gptme_runloops/prompt_templates.py
@@ -583,6 +583,13 @@ class ItemPromptParams:
     greptile_helper: str | None = None
     pr_address_script: str | None = None
     poll_budget_sec: int = 1800
+    # Trace-ledger terminal-event regex used by the voice_postcall arm to
+    # verify the post-call.sh script wrote a row. Matches the three terminal
+    # rows post-call.sh can write: run_completed (happy path),
+    # stub_call_skip (transcript-empty stub call), run_failed (subprocess
+    # exit != 0). Default keeps callers from needing to set it; override per
+    # render for tests or future arm variants.
+    stem: str = "(run_completed|stub_call_skip|run_failed)"
 
     def to_prompt_context(self) -> PromptContext:
         """The step-2 context for the greptile investigate arms."""
@@ -610,6 +617,7 @@ class ItemPromptParams:
             "peer_agents": self.peer_agents,
             "greptile_helper": ctx.resolved_greptile_helper,
             "pr_address_script": ctx.resolved_pr_address_script,
+            "stem": self.stem,
         }
 
 
@@ -875,7 +883,7 @@ It is idempotent — re-running on a completed record is harmless.
 
 After the worker finishes, verify the trace ledger shows a terminal row:
 ```bash
-grep '<stem>' "{workspace}/state/voice-calls/post-call-events.tsv" | tail -3
+grep -E '{stem}' "{workspace}/state/voice-calls/post-call-events.tsv" | tail -3
 ```
 """
 

--- a/packages/gptme-runloops/tests/test_run_item_prompts.py
+++ b/packages/gptme-runloops/tests/test_run_item_prompts.py
@@ -356,6 +356,21 @@ def test_no_unsubstituted_angle_bracket_tokens_in_any_arm() -> None:
     )
 
 
+def test_voice_postcall_stem_token_substituted() -> None:
+    """Regression: {stem} must be replaced in the voice_postcall arm.
+
+    _substitute silently leaves unknown {key} tokens verbatim, so if
+    ItemPromptParams._tokens() ever drops the 'stem' key the grep command
+    in voice_postcall embeds the literal string '{stem}' and matches nothing.
+    The angle-bracket test above would NOT catch this (it only scans <...>).
+    """
+    rendered = render_item_investigate(ItemPromptKind("voice_postcall"), BOB_PARAMS)
+    assert "{stem}" not in rendered, (
+        "{stem} survived substitution in voice_postcall — "
+        "likely ItemPromptParams._tokens() lost the 'stem' key"
+    )
+
+
 def test_every_expected_golden_exists() -> None:
     expected = {f"investigate.{t}.bob" for t in SIMPLE_ARMS}
     expected |= {

--- a/packages/gptme-runloops/tests/test_run_item_prompts.py
+++ b/packages/gptme-runloops/tests/test_run_item_prompts.py
@@ -301,6 +301,61 @@ def test_preheld_block_appends_after_optional_blocks() -> None:
     assert with_preheld.replace(render_preheld_claim_block("github:a/b#1"), "") == base
 
 
+# --- Unsubstituted placeholder regression ---
+
+
+def test_no_unsubstituted_angle_bracket_tokens_in_any_arm() -> None:
+    """No rendered investigate arm may retain a literal <...> token.
+
+    Latent-bug regression for the voice_postcall <stem> placeholder
+    (P6 commit a5b79048 carried the literal across from bash). _substitute
+    only replaces {name}-style tokens, so any leftover <...> survives
+    verbatim and breaks the command it is embedded in.
+
+    Scans every arm — including voice_postcall / erik_decision / greptile
+    arms — for the canonical substitution-target shape (regex:
+    ``<[a-z][a-z0-9_-]*>``).
+
+    The whitelist below names intentional *instructional* placeholders:
+    the agent is meant to read the surrounding context (the ``detail=``,
+    a task id from the play, today's date, etc.) and fill them in at
+    runtime. They are NOT substitution targets and are not bugs. When you
+    add a new <...> placeholder, decide which it is and either wire it
+    through ``ItemPromptParams._tokens()`` or append it here with a
+    one-line rationale — otherwise this test fails on your commit.
+    """
+    import re
+
+    pattern = re.compile(r"<[a-z][a-z0-9_-]*>")
+    # Instructional placeholders the agent fills in from context, not
+    # substitution targets. Keep sorted; cite the line where each appears.
+    intentional = frozenset(
+        {
+            "<record-path>",  # voice_postcall: agent extracts from detail.record=
+            "<task-id>",  # erik_decision: literal task id from the playbook
+            "<date>",  # erik_decision: today's date for the note heading
+            "<decision_id>",  # erik_decision: decision permalink id
+        }
+    )
+    arms = SIMPLE_ARMS + [
+        "master_ci_failure",
+        "voice_postcall",
+        "erik_decision",
+        "greptile_convergence_adjudication",
+    ]
+    leftovers = []
+    for arm_name in arms:
+        rendered = render_item_investigate(ItemPromptKind(arm_name), BOB_PARAMS)
+        for match in pattern.findall(rendered):
+            if match in intentional:
+                continue
+            leftovers.append((arm_name, match))
+    assert not leftovers, (
+        f"rendered arms retain unsubstituted <...> tokens: {leftovers}"
+        f"  (if intentional, add to the whitelist with a rationale)"
+    )
+
+
 def test_every_expected_golden_exists() -> None:
     expected = {f"investigate.{t}.bob" for t in SIMPLE_ARMS}
     expected |= {


### PR DESCRIPTION
Latent bug from P6 commit a5b79048 (#1400).

## Bug

The voice_postcall investigate arm embeds a literal `<stem>` in the
post-call trace-ledger verification grep:

```bash
grep '<stem>' "$WORKSPACE/state/voice-calls/post-call-events.tsv" | tail -3
```

`_substitute` only replaces `{name}`-style tokens and
`ItemPromptParams._tokens()` had no `stem` key, so `<stem>` survived
substitution verbatim. The verification grep matched zero rows and
`tail -3` printed nothing, so the mandated "verify the trace ledger
shows a terminal row" step could never succeed.

Every `voice_postcall` session was instructed to perform an impossible
check, so the worker either re-ran the idempotent script hunting for a
state it already wrote, or silently reported an unverified ledger row.

## Fix

- Add `stem: str` field to `ItemPromptParams` with a default of
  `(run_completed|stub_call_skip|run_failed)` — the three terminal rows
  `post-call.sh` can write (matches the bash detector's terminal set in
  `scripts/project_monitoring_voice_postcall.py` plus the failure path).
- Add `stem` to `_tokens()` so `_substitute` replaces `{stem}`.
- Change the verification grep to use `grep -E '{stem}'` — the bare
  pattern needs extended-regex alternation to actually match any of the
  three terminal rows.
- Add `test_no_unsubstituted_angle_bracket_tokens_in_any_arm` as a
  regression: scans every arm for unsubstituted `<[a-z][a-z0-9_-]*>`
  tokens, with an explicit whitelist for intentional *instructional*
  placeholders (`record-path` / `task-id` / `date` / `decision_id`)
  the agent fills in from runtime context.

## Note

The bash source `scripts/github/project-monitoring-lib.sh` has the
same literal `<stem>` — out of scope for this PR. The Python fix
lands the correct behavior in the runloops path first; the bash mirror
will follow in a separate commit (the bash version is currently
deployed via the PM-detached slot, so this fix helps once the step-5
A/B switches the slot over to the Python executor).

Deferred from gptme/gptme-contrib#1400.