### PR TITLE
fix(self-merge): make AI-review gate disposition-based, not score-based

### DIFF
--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -1099,6 +1099,11 @@ def _ai_review_disposition_shortfall(
     claimed finding. Threads the reviewer itself retired (``auto_resolved``) do
     not count toward it: they are its own bookkeeping for findings that stopped
     reproducing, so by construction they are not the P0/P1 the score reports.
+    Only threads authored by *expected_author* are read as ours at all. The
+    finding marker is a label anyone with write access can paste, so without
+    that check a forged thread — marker, ``**P0**``, resolved, one reply — is a
+    disposition the gate accepts for a P0 it never saw addressed.
+
     Neither does a thread whose severity did not parse — crediting it against a
     claimed P0 would be guessing in the merge direction.
 
@@ -1127,6 +1132,18 @@ def _ai_review_disposition_shortfall(
         body = str(nodes[0].get("body") or "")
         if _AI_REVIEW_FINDING_MARKER not in body:
             continue  # not one of our findings
+        # The marker is a *label*, not a signature: anyone who can open a review
+        # thread can paste `<!-- bob-ai-review-finding -->` and `**P0**` into a
+        # root comment, resolve it, reply once, and hand the recall guard a
+        # forged disposition for a P0 that was never addressed. The summary
+        # marker has always been author-checked (`_fetch_ai_review_marker`);
+        # these threads were not, and the author is already in the payload the
+        # query fetches, so the check costs nothing. A thread that fails it is
+        # not "ignored" — it stays whatever it is to the rest of the gate,
+        # including an unresolved human thread, which blocks on its own.
+        author = (nodes[0].get("author") or {}).get("login")
+        if expected_author and author != expected_author:
+            continue  # marker-shaped, but not written by our reviewer
         m = _AI_REVIEW_SEVERITY_RE.search(body)
         # A thread carrying our finding marker whose severity we cannot read is
         # NOT a P2. Defaulting it to P2 was a fail-OPEN on the severity parse:
@@ -1547,6 +1564,7 @@ def fetch_ai_review_status(
         ),
         marker=marker,
         score=score,
+        expected_author=expected_author,
     )
     if disposition:
         return {"accepted": False, "detail": f"AI review {disposition}"}

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -120,6 +120,12 @@ DEFAULT_MIN_GREPTILE_SCORE = 5
 # can be lowered, and letting the same knob lower *this* floor would turn the
 # alternative path into the weakest link in the gate.
 AI_REVIEW_CLEAN_SCORE = 5
+# Lowest score the rubric can emit (`confidence_score`: 1 for any P0, up to 5
+# for nothing outstanding; abstain is `None`, not 0). Bounding the score at
+# BOTH ends matters: a `0` or a negative would sail past an upper-bound-only
+# check and be read as "a very bad review we can still tolerate", when it is
+# in fact a marker the rubric cannot have produced.
+AI_REVIEW_MIN_SCORE = 1
 # Shortest marker SHA prefix accepted when matching against the PR head. The
 # reviewer writes 12 hex chars; this only guards against a truncated/garbage
 # marker whose 1-2 char "sha" would prefix-match almost any head.
@@ -1076,23 +1082,27 @@ def _ai_review_disposition_shortfall(
     data) is treated as *unknown* and refuses, preserving the fail-closed
     property the Greptile fallback already has.
 
-    A final recall guard closes the one gap thread state cannot see: if the
-    marker itself reports a P0 or P1 on this head (``score <= 3``) yet there is
-    no P0/P1 finding thread to verify its disposition, we cannot prove it was
-    addressed. That happens with findings the reviewer could not anchor to a
-    diff line ("Comments outside the diff" in the summary body) and with a
-    reviewer that silently stopped posting. Failing open there would let a
-    genuine P0/P1 merge unreviewed — the exact recall failure this path exists
-    to prevent. Threads the reviewer itself retired (``auto_resolved``) do not
-    satisfy that guard: they are its own bookkeeping for findings that stopped
-    reproducing, so by construction they are not the P0/P1 the score reports.
+    A final recall guard closes the one gap thread state cannot see: findings
+    the reviewer could not anchor to a diff line ("Comments outside the diff"
+    in the summary body), and a reviewer that silently stopped posting. Both
+    leave a score that reports a P0/P1 with no thread to verify it was
+    addressed, and failing open there merges a genuine P0/P1 unreviewed.
 
-    **Known residual, tracked separately.** A P0/P1 thread disposed on an
-    *earlier* head stays resolved-and-replied forever and cannot be told apart
-    from one disposed on this head, so it can still satisfy the recall guard
-    for a *different*, unanchored P0/P1 the reviewer reports now. Closing that
-    needs the marker to publish the current pass's finding fingerprints, which
-    is a change to the reviewer, not to this gate.
+    The guard is bound to what the score *claims*, not to "some P0/P1 thread
+    exists". ``confidence_score`` is arithmetic over finding severities, so the
+    score names its findings exactly — 1 = at least one P0, 2 = two or more P1,
+    3 = exactly one P1 — and the guard demands a matching disposed thread per
+    claimed finding. Threads the reviewer itself retired (``auto_resolved``) do
+    not count toward it: they are its own bookkeeping for findings that stopped
+    reproducing, so by construction they are not the P0/P1 the score reports.
+    Neither does a thread whose severity did not parse — crediting it against a
+    claimed P0 would be guessing in the merge direction.
+
+    **Known residual, tracked separately.** Threads carry no head, so a P0/P1
+    disposed on an *earlier* head still counts for a same-severity finding
+    claimed now. Closing that needs the marker to publish the current pass's
+    finding fingerprints so disposition can be matched per finding rather than
+    per severity — a change to the reviewer, not to this gate.
     """
     if review_data is None:
         return "could not read review thread state"
@@ -1102,7 +1112,7 @@ def _ai_review_disposition_shortfall(
         if isinstance(fp, str) and fp
     }
     _, threads = review_data
-    saw_blocking_finding = False
+    disposed: dict[str, int] = {"P0": 0, "P1": 0}
     for thread in threads:
         comments = thread.get("comments") or {}
         nodes = comments.get("nodes") or []
@@ -1128,16 +1138,6 @@ def _ai_review_disposition_shortfall(
             f"{severity} finding" if severity else "finding with unreadable severity"
         )
         fp = _ai_review_fp_from_body(body)
-        # Only threads that could correspond to a CURRENT finding count toward
-        # the recall guard. A fingerprint in `auto_resolved` is the reviewer's
-        # own record that this finding stopped reproducing and it retired the
-        # thread as bookkeeping — by construction not a finding on this head,
-        # so letting it satisfy the guard would let the reviewer's bookkeeping
-        # stand in for a real disposition. (This does not over-block: if the
-        # score still claims a P0/P1, that finding is either open — refused
-        # above — or unanchored, which is precisely what the guard is for.)
-        if not (fp and fp in auto_resolved):
-            saw_blocking_finding = True
         if not thread.get("isResolved"):
             return f"{label} is not resolved"
         total = comments.get("totalCount")
@@ -1146,16 +1146,36 @@ def _ai_review_disposition_shortfall(
             if fp and fp in auto_resolved:
                 continue  # reviewer-retired because the fix stopped it reproducing
             return f"{label} resolved without a reply (not disposed)"
+        # Counted only here — after the thread proved disposed — and only for a
+        # severity we could actually read. Two exclusions, both fail-closed:
+        #   * `auto_resolved` is the reviewer's own record that this finding
+        #     stopped reproducing and it retired the thread as bookkeeping, so
+        #     by construction it is not a finding on this head and must not
+        #     stand in for a real disposition;
+        #   * an unreadable severity could be anything, so crediting it against
+        #     a P0 the score reports would be guessing in the merge direction.
+        if severity in disposed and not (fp and fp in auto_resolved):
+            disposed[severity] += 1
 
-    # Recall guard: the marker says a P0/P1 is on this head, but no P0/P1
-    # thread is present to confirm it was disposed (unanchored finding, or the
-    # reviewer stopped posting). Fail closed — a real P0/P1 must not merge on
-    # the strength of an empty thread list.
-    if score is not None and score <= 3 and not saw_blocking_finding:
-        return (
-            "reports a P0/P1 on this head but no finding thread "
-            "verifies its disposition"
-        )
+    # Recall guard, bound to what the score actually CLAIMS. `confidence_score`
+    # is arithmetic over the finding severities, so the score names its findings
+    # exactly: 1 = at least one P0, 2 = two or more P1, 3 = exactly one P1. The
+    # guard therefore demands a matching disposed thread *per claimed finding*.
+    # A single "did we see any P0/P1 thread" boolean could not tell those apart,
+    # and let one disposed P1 vouch for a different, unanchored P0 — the recall
+    # failure this path exists to prevent. Findings the reviewer could not
+    # anchor to a diff line ("Comments outside the diff" in the summary body)
+    # and a reviewer that silently stopped posting both land here, and both
+    # fail closed.
+    required = {1: ("P0", 1), 2: ("P1", 2), 3: ("P1", 1)}.get(score or 0)
+    if required:
+        need_severity, need_count = required
+        have = disposed[need_severity]
+        if have < need_count:
+            return (
+                f"reports {need_count} {need_severity} finding(s) on this head "
+                f"but only {have} disposed {need_severity} thread(s) verify it"
+            )
     return None
 
 
@@ -1455,15 +1475,22 @@ def fetch_ai_review_status(
                 f"AI review score is not an integer ({type(score).__name__}: {score!r})"
             ),
         }
-    # A score above the rubric (6, 7, 100) is corruption, not a better review —
-    # `confidence_score` emits 1-5 and nothing else, and `<` would wave it
-    # through while every other check (author, SHA, consensus) still passed.
-    # Unlike the old score floor this does NOT reject a 4/5: that is the
-    # sampling event the disposition check below is designed to tolerate.
-    if score > AI_REVIEW_CLEAN_SCORE:
+    # A score outside the rubric is corruption, not a review — `confidence_score`
+    # emits 1-5 and nothing else, and a bare `<` would wave it through while
+    # every other check (author, SHA, consensus) still passed. The bound is
+    # two-sided on purpose: dropping the old equality check for the upper bound
+    # alone would newly admit `0` and negatives, which read as "a very bad score
+    # the disposition check can still clear" rather than as the impossible
+    # markers they are. Unlike the old score floor this does NOT reject a 4/5 —
+    # that is the sampling event the disposition check below is designed to
+    # tolerate.
+    if not AI_REVIEW_MIN_SCORE <= score <= AI_REVIEW_CLEAN_SCORE:
         return {
             "accepted": False,
-            "detail": f"AI review score {score}/5 outside the rubric (max 5/5)",
+            "detail": (
+                f"AI review score {score}/5 outside the rubric "
+                f"({AI_REVIEW_MIN_SCORE}-{AI_REVIEW_CLEAN_SCORE})"
+            ),
         }
 
     # Disposition, not score. A score of 4 (surviving P2s) or even 3 (a P1 that

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -1129,7 +1129,7 @@ def _ai_review_disposition_shortfall(
     current_findings = (marker or {}).get("findings")
     _, threads = review_data
     disposed: dict[str, int] = {"P0": 0, "P1": 0}
-    disposed_fps: set[str] = set()
+    disposed_fps: set[tuple[str, str]] = set()
     for thread in threads:
         comments = thread.get("comments") or {}
         nodes = comments.get("nodes") or []
@@ -1186,7 +1186,15 @@ def _ai_review_disposition_shortfall(
         if severity in disposed and not (fp and fp in auto_resolved):
             disposed[severity] += 1
             if fp:
-                disposed_fps.add(fp)
+                # Keyed by (fp, severity), not fp alone. A fingerprint outlives
+                # a severity: the reviewer can re-raise the same finding at a
+                # higher severity on a later head, and the old thread still
+                # renders the OLD one. Matching on fp alone would let a
+                # disposed P1 thread satisfy a `findings` entry that now calls
+                # that same fingerprint a P0 — which is reachable exactly when
+                # the re-raised P0 could not be anchored, i.e. when the recall
+                # guard is the only thing left checking.
+                disposed_fps.add((fp, severity))
 
     def _blocking_findings(
         marker_findings: list[Any],
@@ -1229,7 +1237,7 @@ def _ai_review_disposition_shortfall(
         missing = [
             (fp, severity)
             for fp, severity in blocking_findings
-            if fp not in disposed_fps
+            if (fp, severity) not in disposed_fps
         ]
         if missing:
             counts: dict[str, int] = {"P0": 0, "P1": 0}

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -1063,7 +1063,12 @@ def _ai_review_disposition_shortfall(
       ``auto_resolved`` ledger — that is evidence-based, the code change is
       the answer, no reply is owed);
     - **surviving P2s do not block** — they regenerate on unchanged code, so
-      gating on them is the treadmill failure mode on file.
+      gating on them is the treadmill failure mode on file;
+    - **an unreadable severity is not a P2** — a thread carrying our finding
+      marker whose ``**P0**``/``**P1**``/``**P2**`` text does not parse blocks
+      and must be disposed like a P0/P1. Defaulting it to P2 would be a
+      fail-open on the severity parse, in a wire protocol whose renderer lives
+      in another repo.
 
     Each finding thread carries its severity in the root body (``**P0**`` etc.)
     and its resolution state on the thread itself; ``totalCount`` on the
@@ -1078,7 +1083,16 @@ def _ai_review_disposition_shortfall(
     diff line ("Comments outside the diff" in the summary body) and with a
     reviewer that silently stopped posting. Failing open there would let a
     genuine P0/P1 merge unreviewed — the exact recall failure this path exists
-    to prevent.
+    to prevent. Threads the reviewer itself retired (``auto_resolved``) do not
+    satisfy that guard: they are its own bookkeeping for findings that stopped
+    reproducing, so by construction they are not the P0/P1 the score reports.
+
+    **Known residual, tracked separately.** A P0/P1 thread disposed on an
+    *earlier* head stays resolved-and-replied forever and cannot be told apart
+    from one disposed on this head, so it can still satisfy the recall guard
+    for a *different*, unanchored P0/P1 the reviewer reports now. Closing that
+    needs the marker to publish the current pass's finding fingerprints, which
+    is a change to the reviewer, not to this gate.
     """
     if review_data is None:
         return "could not read review thread state"
@@ -1098,21 +1112,40 @@ def _ai_review_disposition_shortfall(
         if _AI_REVIEW_FINDING_MARKER not in body:
             continue  # not one of our findings
         m = _AI_REVIEW_SEVERITY_RE.search(body)
-        severity = m.group(1) if m else "P2"
-        if severity not in ("P0", "P1"):
+        # A thread carrying our finding marker whose severity we cannot read is
+        # NOT a P2. Defaulting it to P2 was a fail-OPEN on the severity parse:
+        # the reviewer renders `{icon} **{sev}** —` from a normalised severity,
+        # so a body without it means the wire protocol changed under us (the
+        # renderer lives in a different repo — see the "Keep the exact string"
+        # note on `INLINE_FINDING_MARKER`) or the body is malformed. Silently
+        # downgrading a possible P0 to non-blocking is the exact recall failure
+        # this path exists to prevent, so an unreadable severity blocks and is
+        # cleared the same way a P0/P1 is: resolved, with a reply.
+        severity = m.group(1) if m else None
+        if severity is not None and severity not in ("P0", "P1"):
             continue  # surviving P2s never block
-        saw_blocking_finding = True
+        label = (
+            f"{severity} finding" if severity else "finding with unreadable severity"
+        )
+        fp = _ai_review_fp_from_body(body)
+        # Only threads that could correspond to a CURRENT finding count toward
+        # the recall guard. A fingerprint in `auto_resolved` is the reviewer's
+        # own record that this finding stopped reproducing and it retired the
+        # thread as bookkeeping — by construction not a finding on this head,
+        # so letting it satisfy the guard would let the reviewer's bookkeeping
+        # stand in for a real disposition. (This does not over-block: if the
+        # score still claims a P0/P1, that finding is either open — refused
+        # above — or unanchored, which is precisely what the guard is for.)
+        if not (fp and fp in auto_resolved):
+            saw_blocking_finding = True
         if not thread.get("isResolved"):
-            return f"AI review {severity} finding is not resolved"
+            return f"{label} is not resolved"
         total = comments.get("totalCount")
         replied = isinstance(total, int) and total >= 2
         if not replied:
-            fp = _ai_review_fp_from_body(body)
             if fp and fp in auto_resolved:
                 continue  # reviewer-retired because the fix stopped it reproducing
-            return (
-                f"AI review {severity} finding resolved without a reply (not disposed)"
-            )
+            return f"{label} resolved without a reply (not disposed)"
 
     # Recall guard: the marker says a P0/P1 is on this head, but no P0/P1
     # thread is present to confirm it was disposed (unanchored finding, or the
@@ -1120,7 +1153,7 @@ def _ai_review_disposition_shortfall(
     # the strength of an empty thread list.
     if score is not None and score <= 3 and not saw_blocking_finding:
         return (
-            "AI review reports a P0/P1 on this head but no finding thread "
+            "reports a P0/P1 on this head but no finding thread "
             "verifies its disposition"
         )
     return None

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -126,6 +126,9 @@ AI_REVIEW_CLEAN_SCORE = 5
 # check and be read as "a very bad review we can still tolerate", when it is
 # in fact a marker the rubric cannot have produced.
 AI_REVIEW_MIN_SCORE = 1
+# Only P0/P1 participate in the disposition recall guard. Lower severities do
+# not block self-merge, and the gate must never guess them into existence.
+AI_REVIEW_BLOCKING_SEVERITIES = frozenset({"P0", "P1"})
 # Shortest marker SHA prefix accepted when matching against the PR head. The
 # reviewer writes 12 hex chars; this only guards against a truncated/garbage
 # marker whose 1-2 char "sha" would prefix-match almost any head.
@@ -1052,6 +1055,7 @@ def _ai_review_disposition_shortfall(
     *,
     marker: dict[str, Any] | None = None,
     score: int | None = None,
+    expected_author: str | None = None,
 ) -> str | None:
     """Why the AI-review path should not satisfy the gate, or None if it may.
 
@@ -1098,11 +1102,11 @@ def _ai_review_disposition_shortfall(
     Neither does a thread whose severity did not parse — crediting it against a
     claimed P0 would be guessing in the merge direction.
 
-    **Known residual, tracked separately.** Threads carry no head, so a P0/P1
-    disposed on an *earlier* head still counts for a same-severity finding
-    claimed now. Closing that needs the marker to publish the current pass's
-    finding fingerprints so disposition can be matched per finding rather than
-    per severity — a change to the reviewer, not to this gate.
+    When the marker publishes ``findings`` for the current head, the recall
+    guard upgrades from severity-count matching to per-fingerprint matching:
+    every current P0/P1 fingerprint must have a disposed thread whose root body
+    names that exact ``fp``. A missing ``findings`` key falls back to the older
+    severity-count guard so legacy markers keep working.
     """
     if review_data is None:
         return "could not read review thread state"
@@ -1111,8 +1115,10 @@ def _ai_review_disposition_shortfall(
         for fp in ((marker or {}).get("auto_resolved") or [])
         if isinstance(fp, str) and fp
     }
+    current_findings = (marker or {}).get("findings") or []
     _, threads = review_data
     disposed: dict[str, int] = {"P0": 0, "P1": 0}
+    disposed_fps: set[str] = set()
     for thread in threads:
         comments = thread.get("comments") or {}
         nodes = comments.get("nodes") or []
@@ -1132,7 +1138,7 @@ def _ai_review_disposition_shortfall(
         # this path exists to prevent, so an unreadable severity blocks and is
         # cleared the same way a P0/P1 is: resolved, with a reply.
         severity = m.group(1) if m else None
-        if severity is not None and severity not in ("P0", "P1"):
+        if severity is not None and severity not in AI_REVIEW_BLOCKING_SEVERITIES:
             continue  # surviving P2s never block
         label = (
             f"{severity} finding" if severity else "finding with unreadable severity"
@@ -1156,17 +1162,50 @@ def _ai_review_disposition_shortfall(
         #     a P0 the score reports would be guessing in the merge direction.
         if severity in disposed and not (fp and fp in auto_resolved):
             disposed[severity] += 1
+            if fp:
+                disposed_fps.add(fp)
 
-    # Recall guard, bound to what the score actually CLAIMS. `confidence_score`
-    # is arithmetic over the finding severities, so the score names its findings
-    # exactly: 1 = at least one P0, 2 = two or more P1, 3 = exactly one P1. The
-    # guard therefore demands a matching disposed thread *per claimed finding*.
-    # A single "did we see any P0/P1 thread" boolean could not tell those apart,
-    # and let one disposed P1 vouch for a different, unanchored P0 — the recall
-    # failure this path exists to prevent. Findings the reviewer could not
-    # anchor to a diff line ("Comments outside the diff" in the summary body)
-    # and a reviewer that silently stopped posting both land here, and both
-    # fail closed.
+    def _blocking_findings(marker_findings: Any) -> list[tuple[str, str]]:
+        out: list[tuple[str, str]] = []
+        if not isinstance(marker_findings, list):
+            return out
+        for item in marker_findings:
+            if not isinstance(item, dict):
+                continue
+            fp = item.get("fp")
+            severity = item.get("severity")
+            if not isinstance(fp, str) or not fp:
+                continue
+            if not isinstance(severity, str):
+                continue
+            if severity not in AI_REVIEW_BLOCKING_SEVERITIES:
+                continue
+            out.append((fp, severity))
+        return out
+
+    blocking_findings = _blocking_findings(current_findings)
+    if blocking_findings:
+        missing = [
+            (fp, severity)
+            for fp, severity in blocking_findings
+            if fp not in disposed_fps
+        ]
+        if missing:
+            counts: dict[str, int] = {"P0": 0, "P1": 0}
+            for _, severity in missing:
+                counts[severity] += 1
+            parts = [
+                f"{counts[severity]} {severity}"
+                for severity in ("P0", "P1")
+                if counts[severity]
+            ]
+            return "current marker findings lack disposed threads for: " + ", ".join(
+                parts
+            )
+        return None
+
+    # Legacy fallback for markers that predate the `findings` key: bind the
+    # recall guard to what the score claims by severity/count only.
     required = {1: ("P0", 1), 2: ("P1", 2), 3: ("P1", 1)}.get(score or 0)
     if required:
         need_severity, need_count = required

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -701,6 +701,7 @@ def _fetch_greptile_review_data(
                 nodes {{
                   isResolved
                   comments(first:1) {{
+                    totalCount
                     nodes {{
                       author {{ login }}
                       createdAt
@@ -1014,6 +1015,117 @@ def _is_ai_review_thread(comments: list[dict[str, Any]]) -> bool:
     return _AI_REVIEW_FINDING_MARKER in (comments[0].get("body") or "")
 
 
+#: Severity rendered into an AI finding thread's root body as ``**P0**`` /
+#: ``**P1**`` / ``**P2**`` by the reviewer's ``render``. The disposition gate
+#: needs it to separate *blocking* findings (P0/P1) from *surviving P2s* that
+#: demonstrably regenerate on unchanged code and must not block.
+_AI_REVIEW_SEVERITY_RE = re.compile(r"\*\*(P[0-9])\*\*")
+
+#: Fingerprint embedded in an AI finding thread's root body by the reviewer as
+#: ``<!-- bob-ai-review-fp {...} -->``. The disposition gate uses it to tell
+#: the reviewer's own evidence-based auto-resolution (a finding that stopped
+#: reproducing after a fix, retired without a human reply) apart from a
+#: *casual* resolution with no reply at all — only the former is a disposition.
+_AI_REVIEW_FP_RE = re.compile(
+    r"<!-- bob-ai-review-fp \{.*?\"fp\":\s*\"([0-9a-f]+)\"", re.DOTALL
+)
+
+
+def _ai_review_fp_from_body(body: str) -> str | None:
+    """The finding fingerprint named in a thread body, if readable.
+
+    ``None`` means we cannot prove which finding the thread belongs to — so a
+    resolved thread must not be auto-exempted on its word alone.
+    """
+    m = _AI_REVIEW_FP_RE.search(body or "")
+    return m.group(1) if m else None
+
+
+def _ai_review_disposition_shortfall(
+    review_data: tuple[list[dict[str, Any]], list[dict[str, Any]]] | None,
+    *,
+    marker: dict[str, Any] | None = None,
+    score: int | None = None,
+) -> str | None:
+    """Why the AI-review path should not satisfy the gate, or None if it may.
+
+    **Replaces the 5/5 score floor.** The score is a per-round *sample*, not a
+    converged state: measured on gptme-contrib#1393 with the head frozen, six
+    re-review passes with zero code changes scored 4,5,4,5,4 — a literal
+    ``score == 5`` gate passes or fails the same commit depending on which
+    sample it reads. What the gate *can* decide from real thread state is:
+
+    - **no open P0 or P1** — an unresolved P0/P1 finding thread blocks;
+    - **every finding addressed and disposed** — a resolved P0/P1 thread with
+      no reply is not a disposition (observed on gptme-contrib#1389: threads
+      resolved with no reply at all), UNLESS the reviewer itself retired it
+      because a fix made it stop reproducing (fingerprint in the marker's
+      ``auto_resolved`` ledger — that is evidence-based, the code change is
+      the answer, no reply is owed);
+    - **surviving P2s do not block** — they regenerate on unchanged code, so
+      gating on them is the treadmill failure mode on file.
+
+    Each finding thread carries its severity in the root body (``**P0**`` etc.)
+    and its resolution state on the thread itself; ``totalCount`` on the
+    thread's comments tells us whether anybody replied. ``None`` (no review
+    data) is treated as *unknown* and refuses, preserving the fail-closed
+    property the Greptile fallback already has.
+
+    A final recall guard closes the one gap thread state cannot see: if the
+    marker itself reports a P0 or P1 on this head (``score <= 3``) yet there is
+    no P0/P1 finding thread to verify its disposition, we cannot prove it was
+    addressed. That happens with findings the reviewer could not anchor to a
+    diff line ("Comments outside the diff" in the summary body) and with a
+    reviewer that silently stopped posting. Failing open there would let a
+    genuine P0/P1 merge unreviewed — the exact recall failure this path exists
+    to prevent.
+    """
+    if review_data is None:
+        return "could not read review thread state"
+    auto_resolved = {
+        str(fp)
+        for fp in ((marker or {}).get("auto_resolved") or [])
+        if isinstance(fp, str) and fp
+    }
+    _, threads = review_data
+    saw_blocking_finding = False
+    for thread in threads:
+        comments = thread.get("comments") or {}
+        nodes = comments.get("nodes") or []
+        if not nodes:
+            continue
+        body = str(nodes[0].get("body") or "")
+        if _AI_REVIEW_FINDING_MARKER not in body:
+            continue  # not one of our findings
+        m = _AI_REVIEW_SEVERITY_RE.search(body)
+        severity = m.group(1) if m else "P2"
+        if severity not in ("P0", "P1"):
+            continue  # surviving P2s never block
+        saw_blocking_finding = True
+        if not thread.get("isResolved"):
+            return f"AI review {severity} finding is not resolved"
+        total = comments.get("totalCount")
+        replied = isinstance(total, int) and total >= 2
+        if not replied:
+            fp = _ai_review_fp_from_body(body)
+            if fp and fp in auto_resolved:
+                continue  # reviewer-retired because the fix stopped it reproducing
+            return (
+                f"AI review {severity} finding resolved without a reply (not disposed)"
+            )
+
+    # Recall guard: the marker says a P0/P1 is on this head, but no P0/P1
+    # thread is present to confirm it was disposed (unanchored finding, or the
+    # reviewer stopped posting). Fail closed — a real P0/P1 must not merge on
+    # the strength of an empty thread list.
+    if score is not None and score <= 3 and not saw_blocking_finding:
+        return (
+            "AI review reports a P0/P1 on this head but no finding thread "
+            "verifies its disposition"
+        )
+    return None
+
+
 # Summary marker upserted by the self-hosted reviewer onto one issue comment per
 # PR: `<!-- bob-ai-review {json} -->`. The space before `{` is load-bearing — it
 # is what stops this pattern from also matching `<!-- bob-ai-review-finding -->`
@@ -1245,6 +1357,9 @@ def fetch_ai_review_status(
     | None
     | _MarkerLookupFailed
     | _MarkerUnset = _MARKER_UNSET,
+    review_data: tuple[list[dict[str, Any]], list[dict[str, Any]]]
+    | None
+    | object = _UNSET,
 ) -> dict[str, Any]:
     """Whether our own reviewer's verdict is strong enough to stand in for Greptile.
 
@@ -1256,6 +1371,16 @@ def fetch_ai_review_status(
     Every refusal path falls back to today's Greptile-only behaviour. Nothing
     here can make a PR *more* mergeable than the rest of the gate allows -- CI,
     category, human threads and author identity are all still evaluated.
+
+    The AI-review acceptance is **disposition-based, not score-based**: instead
+    of demanding a literal 5/5 (a per-round sample that passes or fails the
+    same commit depending on which pass the gate reads), it requires that no
+    P0/P1 finding is open and every P0/P1 finding is disposed against real
+    thread state, while surviving P2s do not block. See
+    ``_ai_review_disposition_shortfall`` for the exact predicate and the
+    measured evidence behind it. ``review_data`` (the ``(reviews, threads)``
+    tuple) supplies the thread state; pass it to avoid a duplicate GraphQL
+    round-trip, matching the other review-data helpers.
     """
     if not _ai_review_enabled():
         return {"accepted": False, "detail": None}
@@ -1297,16 +1422,35 @@ def fetch_ai_review_status(
                 f"AI review score is not an integer ({type(score).__name__}: {score!r})"
             ),
         }
-    # Exactly the rubric's clean value, not "at least" it. `confidence_score`
-    # emits 1-5 and nothing else, so a 6 is not a better review — it is a
-    # corrupted or foreign marker, and `<` would wave it through as clean while
-    # every other check (author, SHA, consensus) still passed.
-    if score != AI_REVIEW_CLEAN_SCORE:
-        below = "below" if score < AI_REVIEW_CLEAN_SCORE else "outside the rubric,"
+    # A score above the rubric (6, 7, 100) is corruption, not a better review —
+    # `confidence_score` emits 1-5 and nothing else, and `<` would wave it
+    # through while every other check (author, SHA, consensus) still passed.
+    # Unlike the old score floor this does NOT reject a 4/5: that is the
+    # sampling event the disposition check below is designed to tolerate.
+    if score > AI_REVIEW_CLEAN_SCORE:
         return {
             "accepted": False,
-            "detail": f"AI review score {score}/5 {below} {AI_REVIEW_CLEAN_SCORE}/5",
+            "detail": f"AI review score {score}/5 outside the rubric (max 5/5)",
         }
+
+    # Disposition, not score. A score of 4 (surviving P2s) or even 3 (a P1 that
+    # was argued down and closed) is acceptable when the finding threads prove
+    # it: no open P0/P1, and every P0/P1 finding addressed (replied) AND
+    # disposed (resolved) against real thread state. The only scores that still
+    # categorically fail here are abstain (above), corruption (>5, above), and
+    # a marker whose thread state we cannot read (fail-closed below).
+    if review_data is _UNSET:
+        review_data = _fetch_greptile_review_data(repo, pr_number)
+    disposition = _ai_review_disposition_shortfall(
+        cast(
+            "tuple[list[dict[str, Any]], list[dict[str, Any]]] | None",
+            review_data,
+        ),
+        marker=marker,
+        score=score,
+    )
+    if disposition:
+        return {"accepted": False, "detail": f"AI review {disposition}"}
 
     shortfall = _consensus_shortfall(marker.get("consensus"))
     if shortfall:
@@ -1316,7 +1460,7 @@ def fetch_ai_review_status(
         "accepted": True,
         "detail": (
             f"AI review {score}/5 at current head {str(marker.get('sha'))[:12]}, "
-            "full consensus"
+            "findings disposed"
         ),
     }
 
@@ -1910,6 +2054,7 @@ def evaluate_pr(
                 head_sha=result.head_sha,
                 expected_author=current_user,
                 marker_result=shared_marker,
+                review_data=shared_review_data,
             )
             if ai_review["accepted"]:
                 result.warnings.append(

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -1110,8 +1110,12 @@ def _ai_review_disposition_shortfall(
     When the marker publishes ``findings`` for the current head, the recall
     guard upgrades from severity-count matching to per-fingerprint matching:
     every current P0/P1 fingerprint must have a disposed thread whose root body
-    names that exact ``fp``. A missing ``findings`` key falls back to the older
-    severity-count guard so legacy markers keep working.
+    names that exact ``fp``. Only a *missing* ``findings`` key falls back to the
+    older severity-count guard, so legacy markers keep working; a key that is
+    present is authoritative even when empty or unreadable, because reading
+    those as "absent" would downgrade to the weaker guard exactly when the
+    marker is least trustworthy, and the marker must also publish enough
+    findings to account for its own score.
     """
     if review_data is None:
         return "could not read review thread state"
@@ -1120,7 +1124,9 @@ def _ai_review_disposition_shortfall(
         for fp in ((marker or {}).get("auto_resolved") or [])
         if isinstance(fp, str) and fp
     }
-    current_findings = (marker or {}).get("findings") or []
+    # NOT `... or []`: that reads a present-but-empty list as an absent key and
+    # silently drops to the weaker score-only guard. Presence is the signal.
+    current_findings = (marker or {}).get("findings")
     _, threads = review_data
     disposed: dict[str, int] = {"P0": 0, "P1": 0}
     disposed_fps: set[str] = set()
@@ -1182,26 +1188,44 @@ def _ai_review_disposition_shortfall(
             if fp:
                 disposed_fps.add(fp)
 
-    def _blocking_findings(marker_findings: Any) -> list[tuple[str, str]]:
+    def _blocking_findings(
+        marker_findings: list[Any],
+    ) -> tuple[list[tuple[str, str]], bool]:
+        """``(blocking entries, any entry unreadable)``.
+
+        Unreadable is reported rather than skipped. Dropping a malformed entry
+        shrinks the set of dispositions we demand, which is the fail-open
+        direction: an entry that should have required a disposed thread simply
+        stops requiring one.
+        """
         out: list[tuple[str, str]] = []
-        if not isinstance(marker_findings, list):
-            return out
+        malformed = False
         for item in marker_findings:
             if not isinstance(item, dict):
+                malformed = True
                 continue
             fp = item.get("fp")
             severity = item.get("severity")
-            if not isinstance(fp, str) or not fp:
-                continue
-            if not isinstance(severity, str):
+            if not isinstance(fp, str) or not fp or not isinstance(severity, str):
+                malformed = True
                 continue
             if severity not in AI_REVIEW_BLOCKING_SEVERITIES:
                 continue
             out.append((fp, severity))
-        return out
+        return out, malformed
 
-    blocking_findings = _blocking_findings(current_findings)
-    if blocking_findings:
+    # `findings` PRESENT is authoritative — including when it is empty. Reading
+    # a present-but-empty (or malformed) list as "absent" and dropping to the
+    # score-only guard below is a fail-open: that guard accepts any disposed
+    # thread of the right severity, so a marker publishing `findings: []` with
+    # `score: 1` would be cleared by a stale, already-disposed P0 thread while
+    # this head's P0 went unaddressed. A marker that names its findings must be
+    # taken at its word, and a marker that contradicts itself must not be
+    # quietly downgraded to a weaker check.
+    if isinstance(current_findings, list):
+        blocking_findings, malformed = _blocking_findings(current_findings)
+        if malformed:
+            return "marker publishes a findings entry we cannot read"
         missing = [
             (fp, severity)
             for fp, severity in blocking_findings
@@ -1219,6 +1243,18 @@ def _ai_review_disposition_shortfall(
             return "current marker findings lack disposed threads for: " + ", ".join(
                 parts
             )
+        # The list must also account for the score. `confidence_score` is
+        # arithmetic over the same findings, so a score claiming a P0 with no
+        # P0 entry published is a self-contradictory marker, not a clean head.
+        claimed = {1: ("P0", 1), 2: ("P1", 2), 3: ("P1", 1)}.get(score or 0)
+        if claimed:
+            need_severity, need_count = claimed
+            published = sum(1 for _, sev in blocking_findings if sev == need_severity)
+            if published < need_count:
+                return (
+                    f"marker scores {score}/5 but publishes {published} "
+                    f"{need_severity} finding(s), not {need_count}"
+                )
         return None
 
     # Legacy fallback for markers that predate the `findings` key: bind the

--- a/tests/test_self_merge_ai_review_gate.py
+++ b/tests/test_self_merge_ai_review_gate.py
@@ -1143,3 +1143,54 @@ def test_missing_findings_key_still_uses_the_legacy_score_guard(
         review_data=([], [_finding_thread("P1", resolved=True, total=2)]),
     )
     assert status["accepted"] is True
+
+
+def test_disposed_p1_thread_does_not_satisfy_a_p0_findings_entry(
+    gh_comments: Any,
+) -> None:
+    """A fingerprint outlives a severity. The reviewer can re-raise the same
+    finding at a higher severity on a later head while the old, already-disposed
+    thread still renders the OLD severity — and matching on fingerprint alone
+    then credits a P0 entry to a disposed P1 thread. That is reachable exactly
+    when the re-raised P0 could not be anchored to a diff line, i.e. when this
+    guard is the only thing still checking."""
+    fp = "deadbeef1234"
+    status = _status(
+        gh_comments,
+        [_comment(_marker(score=1, findings=[{"fp": fp, "severity": "P0"}]))],
+        review_data=(
+            [],
+            [
+                _finding_thread_body(
+                    "❌ **P1** — the hash ignores .state",
+                    fp=fp,
+                    resolved=True,
+                    total=2,
+                )
+            ],
+        ),
+    )
+    assert status["accepted"] is False
+    assert "1 P0" in (status["detail"] or "")
+
+
+def test_matching_severity_still_disposes(gh_comments: Any) -> None:
+    """Negative control: the same fingerprint with the severity the marker
+    actually claims disposes it, so the tightening costs nothing legitimate."""
+    fp = "deadbeef1234"
+    status = _status(
+        gh_comments,
+        [_comment(_marker(score=1, findings=[{"fp": fp, "severity": "P0"}]))],
+        review_data=(
+            [],
+            [
+                _finding_thread_body(
+                    "🛑 **P0** — the hash ignores .state",
+                    fp=fp,
+                    resolved=True,
+                    total=2,
+                )
+            ],
+        ),
+    )
+    assert status["accepted"] is True

--- a/tests/test_self_merge_ai_review_gate.py
+++ b/tests/test_self_merge_ai_review_gate.py
@@ -98,10 +98,22 @@ def gh_comments(monkeypatch: pytest.MonkeyPatch) -> Any:
     return _install
 
 
-def _status(gh_comments: Any, lines: list[str], head: str = HEAD_SHA) -> dict[str, Any]:
+def _status(
+    gh_comments: Any,
+    lines: list[str],
+    head: str = HEAD_SHA,
+    review_data: tuple[list[dict[str, Any]], list[dict[str, Any]]] | None = (
+        [],
+        [],
+    ),
+) -> dict[str, Any]:
     gh_comments(lines)
     result: dict[str, Any] = smc.fetch_ai_review_status(
-        "gptme/gptme-contrib", 1382, head_sha=head, expected_author=AUTHOR
+        "gptme/gptme-contrib",
+        1382,
+        head_sha=head,
+        expected_author=AUTHOR,
+        review_data=review_data,
     )
     return result
 
@@ -307,11 +319,25 @@ def test_abstain_is_rejected(gh_comments: Any) -> None:
     assert "abstain" in (status["detail"] or "")
 
 
-@pytest.mark.parametrize("score", [1, 2, 3, 4])
-def test_sub_clean_scores_are_rejected(gh_comments: Any, score: int) -> None:
+@pytest.mark.parametrize("score", [1, 2, 3])
+def test_p0p1_scores_are_rejected_when_no_thread_proves_disposition(
+    gh_comments: Any, score: int
+) -> None:
+    """Scores claiming a P0/P1 on this head block unless a finding thread proves
+    it was disposed. With no finding thread at all (unanchored findings, or a
+    reviewer that stopped posting), we cannot verify disposition — fail closed."""
     status = _status(gh_comments, [_comment(_marker(score=score))])
     assert status["accepted"] is False
-    assert f"{score}/5" in (status["detail"] or "")
+    assert "no finding thread" in (status["detail"] or "")
+
+
+def test_p2_only_score_does_not_block(gh_comments: Any) -> None:
+    """A 4/5 means only P2 findings survive. Those demonstrably regenerate on
+    unchanged code (a frozen head scored 4,5,4,5,4 across six passes with zero
+    code changes), so they must not block — this is the core of replacing the
+    literal 5/5 score floor with a disposition check."""
+    status = _status(gh_comments, [_comment(_marker(score=4))])
+    assert status["accepted"] is True
 
 
 def test_marker_from_another_account_is_ignored(gh_comments: Any) -> None:
@@ -573,3 +599,139 @@ def test_empty_summary_comment_fetch_is_absence_not_unknown(
     )
     assert status["has_review"] is False
     assert not status.get("unknown")
+
+
+# --- disposition-based acceptance (replaces the 5/5 score floor) ------------
+#
+# The literal `score == 5` floor is a sampling event, not a converged state:
+# measured on gptme-contrib#1393 with the head frozen, six re-review passes
+# with zero code changes scored 4,5,4,5,4. So the gate now reads the finding
+# threads directly: no open P0/P1, every P0/P1 finding addressed (replied) AND
+# disposed (resolved), and surviving P2s never block.
+
+
+def _finding_thread(severity: str, *, resolved: bool, total: int) -> dict[str, Any]:
+    """One AI finding thread with the reviewer's marker, severity, and replies."""
+    body = (
+        f"{smc._AI_REVIEW_FINDING_MARKER}\n🛑 **{severity}** — the hash ignores .state"
+    )
+    return {
+        "isResolved": resolved,
+        "comments": {
+            "totalCount": total,
+            "nodes": [{"author": {"login": AUTHOR}, "body": body}],
+        },
+    }
+
+
+def test_open_p0_finding_blocks(gh_comments: Any) -> None:
+    """A P0 finding thread that is not resolved hard-blocks, whatever the score."""
+    status = _status(
+        gh_comments,
+        [_comment(_marker(score=1))],
+        review_data=([], [_finding_thread("P0", resolved=False, total=1)]),
+    )
+    assert status["accepted"] is False
+    assert "not resolved" in (status["detail"] or "")
+
+
+def test_open_p1_finding_blocks(gh_comments: Any) -> None:
+    status = _status(
+        gh_comments,
+        [_comment(_marker(score=3))],
+        review_data=([], [_finding_thread("P1", resolved=False, total=1)]),
+    )
+    assert status["accepted"] is False
+    assert "P1" in (status["detail"] or "")
+    assert "not resolved" in (status["detail"] or "")
+
+
+def test_resolved_p1_with_reply_is_accepted(gh_comments: Any) -> None:
+    """A P1 that was replied to AND resolved is disposed — that is the gate."""
+    status = _status(
+        gh_comments,
+        [_comment(_marker(score=3))],
+        review_data=([], [_finding_thread("P1", resolved=True, total=2)]),
+    )
+    assert status["accepted"] is True
+
+
+def test_resolved_without_reply_blocks(gh_comments: Any) -> None:
+    """The #1389 failure: a resolved P0/P1 thread with no reply is not a
+    disposition. Resolution alone is not evidence anybody addressed it."""
+    status = _status(
+        gh_comments,
+        [_comment(_marker(score=3))],
+        review_data=([], [_finding_thread("P1", resolved=True, total=1)]),
+    )
+    assert status["accepted"] is False
+    assert "without a reply" in (status["detail"] or "")
+
+
+def test_resolved_without_reply_but_auto_resolved_is_accepted(
+    gh_comments: Any,
+) -> None:
+    """The reviewer itself retires a finding when a fix makes it stop
+    reproducing — the marker's `auto_resolved` ledger names those fingerprints.
+    That is evidence-based (the code change is the answer), so no reply is owed."""
+    fp = "abcdef123456"
+    body = (
+        f"{smc._AI_REVIEW_FINDING_MARKER}\n"
+        f'<!-- bob-ai-review-fp {{"fp": "{fp}"}} -->\n'
+        f"🛑 **P1** — the hash ignores .state"
+    )
+    thread = {
+        "isResolved": True,
+        "comments": {
+            "totalCount": 1,
+            "nodes": [{"author": {"login": AUTHOR}, "body": body}],
+        },
+    }
+    marker = _marker(score=3, auto_resolved=[fp])
+    status = _status(gh_comments, [_comment(marker)], review_data=([], [thread]))
+    assert status["accepted"] is True
+
+
+def test_surviving_p2_never_blocks(gh_comments: Any) -> None:
+    """Even an OPEN P2 finding thread must not block — P2s regenerate on
+    unchanged code, so gating on them is the treadmill failure mode."""
+    status = _status(
+        gh_comments,
+        [_comment(_marker(score=4))],
+        review_data=([], [_finding_thread("P2", resolved=False, total=1)]),
+    )
+    assert status["accepted"] is True
+
+
+def test_unanchored_p0p1_fails_closed(gh_comments: Any) -> None:
+    """A score <= 3 with no P0/P1 finding thread at all is unverifiable. The
+    finding may be unanchored (only in the summary body) or the reviewer may
+    have stopped posting. Fail closed rather than merge an unverified P0/P1."""
+    status = _status(
+        gh_comments,
+        [_comment(_marker(score=2))],
+        review_data=([], []),
+    )
+    assert status["accepted"] is False
+    assert "no finding thread" in (status["detail"] or "")
+
+
+def test_unreadable_thread_state_fails_closed(gh_comments: Any) -> None:
+    """review_data=None (fetch failed) is unknown, never clean — same fail-closed
+    property as the Greptile fallback."""
+    status = _status(gh_comments, [_comment(_marker())], review_data=None)
+    assert status["accepted"] is False
+    assert "could not read" in (status["detail"] or "")
+
+
+def test_p0p1_score_with_all_disposed_passes(gh_comments: Any) -> None:
+    """A score of 3 (one P1 reported) is acceptable when the P1 thread proves
+    it was replied to and resolved — the disposition is the truth, not the
+    score."""
+    status = _status(
+        gh_comments,
+        [_comment(_marker(score=3))],
+        review_data=([], [_finding_thread("P1", resolved=True, total=2)]),
+    )
+    assert status["accepted"] is True
+    assert "findings disposed" in (status["detail"] or "")

--- a/tests/test_self_merge_ai_review_gate.py
+++ b/tests/test_self_merge_ai_review_gate.py
@@ -328,7 +328,7 @@ def test_p0p1_scores_are_rejected_when_no_thread_proves_disposition(
     reviewer that stopped posting), we cannot verify disposition — fail closed."""
     status = _status(gh_comments, [_comment(_marker(score=score))])
     assert status["accepted"] is False
-    assert "no finding thread" in (status["detail"] or "")
+    assert "disposed" in (status["detail"] or "")
 
 
 def test_p2_only_score_does_not_block(gh_comments: Any) -> None:
@@ -719,7 +719,7 @@ def test_unanchored_p0p1_fails_closed(gh_comments: Any) -> None:
         review_data=([], []),
     )
     assert status["accepted"] is False
-    assert "no finding thread" in (status["detail"] or "")
+    assert "disposed" in (status["detail"] or "")
 
 
 def test_unreadable_thread_state_fails_closed(gh_comments: Any) -> None:
@@ -846,7 +846,7 @@ def test_auto_resolved_thread_does_not_satisfy_the_recall_guard(
         ),
     )
     assert status["accepted"] is False
-    assert "no finding thread" in (status["detail"] or "")
+    assert "disposed" in (status["detail"] or "")
 
 
 def test_refusal_detail_is_not_double_prefixed(gh_comments: Any) -> None:
@@ -860,3 +860,99 @@ def test_refusal_detail_is_not_double_prefixed(gh_comments: Any) -> None:
     detail = status["detail"] or ""
     assert detail.count("AI review") == 1, detail
     assert detail == "AI review P1 finding is not resolved"
+
+
+# --- the recall guard must match the finding the SCORE claims ---------------
+#
+# `confidence_score` is arithmetic over the finding severities, so a score
+# names its findings exactly: 1 = any P0, 2 = 2+ P1, 3 = exactly one P1. A
+# single "did we see a P0/P1 thread" boolean let one disposed P1 vouch for a
+# different, unanchored P0.
+
+
+def test_disposed_p1_does_not_vouch_for_an_unanchored_p0(gh_comments: Any) -> None:
+    """A score of 1 means the reviewer found a P0 on this head. A resolved and
+    replied-to *P1* thread does not verify that P0 was addressed — if the P0
+    was unanchored ("Comments outside the diff"), accepting here merges it
+    unreviewed, which is exactly what the guard exists to stop."""
+    status = _status(
+        gh_comments,
+        [_comment(_marker(score=1))],
+        review_data=([], [_finding_thread("P1", resolved=True, total=2)]),
+    )
+    assert status["accepted"] is False
+    assert "1 P0 finding(s)" in (status["detail"] or "")
+    assert "only 0 disposed P0" in (status["detail"] or "")
+
+
+def test_two_p1_score_needs_two_disposed_p1_threads(gh_comments: Any) -> None:
+    """A score of 2 means two or more P1s. One disposed P1 thread leaves the
+    other unaccounted for, so the count has to match, not just the severity."""
+    one_disposed = _status(
+        gh_comments,
+        [_comment(_marker(score=2))],
+        review_data=([], [_finding_thread("P1", resolved=True, total=2)]),
+    )
+    assert one_disposed["accepted"] is False
+    assert "only 1 disposed P1" in (one_disposed["detail"] or "")
+
+    both_disposed = _status(
+        gh_comments,
+        [_comment(_marker(score=2))],
+        review_data=(
+            [],
+            [
+                _finding_thread("P1", resolved=True, total=2),
+                _finding_thread("P1", resolved=True, total=2),
+            ],
+        ),
+    )
+    assert both_disposed["accepted"] is True
+
+
+def test_disposed_p0_satisfies_a_p0_score(gh_comments: Any) -> None:
+    """The guard is a correspondence check, not a ban on low scores: a score of
+    1 with its P0 replied to and resolved is disposed, and passes."""
+    status = _status(
+        gh_comments,
+        [_comment(_marker(score=1))],
+        review_data=([], [_finding_thread("P0", resolved=True, total=2)]),
+    )
+    assert status["accepted"] is True
+
+
+def test_unreadable_severity_thread_does_not_credit_a_claimed_p0(
+    gh_comments: Any,
+) -> None:
+    """A disposed thread whose severity did not parse could have been anything.
+    Crediting it against a P0 the score reports would be guessing in the merge
+    direction, so it clears its own block without vouching for the P0."""
+    status = _status(
+        gh_comments,
+        [_comment(_marker(score=1))],
+        review_data=(
+            [],
+            [_finding_thread_body("Security vulnerability", resolved=True, total=2)],
+        ),
+    )
+    assert status["accepted"] is False
+    assert "only 0 disposed P0" in (status["detail"] or "")
+
+
+# --- score corruption is bounded at BOTH ends -------------------------------
+
+
+@pytest.mark.parametrize("score", [0, -1, -5])
+def test_scores_below_the_rubric_are_rejected(gh_comments: Any, score: int) -> None:
+    """`confidence_score` emits 1-5; abstain is `None`, never 0. Replacing the
+    old `score != 5` equality with an upper bound alone would newly admit 0 and
+    negatives, which then read as "a bad score the disposition check can clear"
+    rather than as the impossible markers they are — and with one disposed
+    P0/P1 thread present they would have been accepted."""
+    status = _status(
+        gh_comments,
+        [_comment(_marker(score=score))],
+        review_data=([], [_finding_thread("P1", resolved=True, total=2)]),
+    )
+    assert status["accepted"] is False
+    assert "outside the rubric" in (status["detail"] or "")

--- a/tests/test_self_merge_ai_review_gate.py
+++ b/tests/test_self_merge_ai_review_gate.py
@@ -62,6 +62,7 @@ def _marker(**overrides: Any) -> dict[str, Any]:
         "consensus": dict(FULL_CONSENSUS),
         "history": [],
         "suppressed": [],
+        "findings": [],
     }
     marker.update(overrides)
     return marker
@@ -610,10 +611,15 @@ def test_empty_summary_comment_fetch_is_absence_not_unknown(
 # disposed (resolved), and surviving P2s never block.
 
 
-def _finding_thread(severity: str, *, resolved: bool, total: int) -> dict[str, Any]:
+def _finding_thread(
+    severity: str, *, resolved: bool, total: int, fp: str | None = None
+) -> dict[str, Any]:
     """One AI finding thread with the reviewer's marker, severity, and replies."""
+    fp_line = f'<!-- bob-ai-review-fp {{"fp": "{fp}"}} -->\n' if fp else ""
     body = (
-        f"{smc._AI_REVIEW_FINDING_MARKER}\n🛑 **{severity}** — the hash ignores .state"
+        f"{smc._AI_REVIEW_FINDING_MARKER}\n"
+        f"{fp_line}"
+        f"🛑 **{severity}** — the hash ignores .state"
     )
     return {
         "isResolved": resolved,
@@ -832,7 +838,18 @@ def test_auto_resolved_thread_does_not_satisfy_the_recall_guard(
     fp = "abcdef123456"
     status = _status(
         gh_comments,
-        [_comment(_marker(score=2, auto_resolved=[fp]))],
+        [
+            _comment(
+                _marker(
+                    score=2,
+                    auto_resolved=[fp],
+                    findings=[
+                        {"fp": fp, "severity": "P1"},
+                        {"fp": "feedface5678", "severity": "P1"},
+                    ],
+                )
+            )
+        ],
         review_data=(
             [],
             [
@@ -846,7 +863,9 @@ def test_auto_resolved_thread_does_not_satisfy_the_recall_guard(
         ),
     )
     assert status["accepted"] is False
-    assert "disposed" in (status["detail"] or "")
+    assert "current marker findings lack disposed threads for: 2 P1" in (
+        status["detail"] or ""
+    )
 
 
 def test_refusal_detail_is_not_double_prefixed(gh_comments: Any) -> None:
@@ -854,8 +873,15 @@ def test_refusal_detail_is_not_double_prefixed(gh_comments: Any) -> None:
     Both prefixing produced `AI review AI review P1 finding is not resolved`."""
     status = _status(
         gh_comments,
-        [_comment(_marker(score=3))],
-        review_data=([], [_finding_thread("P1", resolved=False, total=1)]),
+        [
+            _comment(
+                _marker(score=3, findings=[{"fp": "cafe1234beef", "severity": "P1"}])
+            )
+        ],
+        review_data=(
+            [],
+            [_finding_thread("P1", resolved=False, total=1, fp="cafe1234beef")],
+        ),
     )
     detail = status["detail"] or ""
     assert detail.count("AI review") == 1, detail
@@ -877,33 +903,53 @@ def test_disposed_p1_does_not_vouch_for_an_unanchored_p0(gh_comments: Any) -> No
     unreviewed, which is exactly what the guard exists to stop."""
     status = _status(
         gh_comments,
-        [_comment(_marker(score=1))],
-        review_data=([], [_finding_thread("P1", resolved=True, total=2)]),
+        [
+            _comment(
+                _marker(score=1, findings=[{"fp": "c0ffee123abc", "severity": "P0"}])
+            )
+        ],
+        review_data=(
+            [],
+            [_finding_thread("P1", resolved=True, total=2, fp="deadbeef1234")],
+        ),
     )
     assert status["accepted"] is False
-    assert "1 P0 finding(s)" in (status["detail"] or "")
-    assert "only 0 disposed P0" in (status["detail"] or "")
+    assert "current marker findings lack disposed threads for: 1 P0" in (
+        status["detail"] or ""
+    )
 
 
 def test_two_p1_score_needs_two_disposed_p1_threads(gh_comments: Any) -> None:
     """A score of 2 means two or more P1s. One disposed P1 thread leaves the
     other unaccounted for, so the count has to match, not just the severity."""
+    marker = _marker(
+        score=2,
+        findings=[
+            {"fp": "a1b2c3d4e5f6", "severity": "P1"},
+            {"fp": "b1c2d3e4f5a6", "severity": "P1"},
+        ],
+    )
     one_disposed = _status(
         gh_comments,
-        [_comment(_marker(score=2))],
-        review_data=([], [_finding_thread("P1", resolved=True, total=2)]),
+        [_comment(marker)],
+        review_data=(
+            [],
+            [_finding_thread("P1", resolved=True, total=2, fp="a1b2c3d4e5f6")],
+        ),
     )
     assert one_disposed["accepted"] is False
-    assert "only 1 disposed P1" in (one_disposed["detail"] or "")
+    assert "current marker findings lack disposed threads for: 1 P1" in (
+        one_disposed["detail"] or ""
+    )
 
     both_disposed = _status(
         gh_comments,
-        [_comment(_marker(score=2))],
+        [_comment(marker)],
         review_data=(
             [],
             [
-                _finding_thread("P1", resolved=True, total=2),
-                _finding_thread("P1", resolved=True, total=2),
+                _finding_thread("P1", resolved=True, total=2, fp="a1b2c3d4e5f6"),
+                _finding_thread("P1", resolved=True, total=2, fp="b1c2d3e4f5a6"),
             ],
         ),
     )
@@ -915,8 +961,15 @@ def test_disposed_p0_satisfies_a_p0_score(gh_comments: Any) -> None:
     1 with its P0 replied to and resolved is disposed, and passes."""
     status = _status(
         gh_comments,
-        [_comment(_marker(score=1))],
-        review_data=([], [_finding_thread("P0", resolved=True, total=2)]),
+        [
+            _comment(
+                _marker(score=1, findings=[{"fp": "facefeed1234", "severity": "P0"}])
+            )
+        ],
+        review_data=(
+            [],
+            [_finding_thread("P0", resolved=True, total=2, fp="facefeed1234")],
+        ),
     )
     assert status["accepted"] is True
 

--- a/tests/test_self_merge_ai_review_gate.py
+++ b/tests/test_self_merge_ai_review_gate.py
@@ -54,7 +54,13 @@ FULL_CONSENSUS = {
 
 
 def _marker(**overrides: Any) -> dict[str, Any]:
-    """A clean, current, full-consensus marker as the reviewer writes it."""
+    """A clean, current, full-consensus marker as the reviewer writes it.
+
+    No ``findings`` key by default: that is the legacy marker shape, and it is
+    what exercises the score/severity-count guard. Tests for per-fingerprint
+    matching pass ``findings=[...]`` explicitly — and must pass one consistent
+    with the score they set, since a marker claiming a P0 while publishing no
+    P0 entry is refused as self-contradictory rather than downgraded."""
     marker: dict[str, Any] = {
         "sha": MARKER_SHA,
         "score": 5,
@@ -62,7 +68,6 @@ def _marker(**overrides: Any) -> dict[str, Any]:
         "consensus": dict(FULL_CONSENSUS),
         "history": [],
         "suppressed": [],
-        "findings": [],
     }
     marker.update(overrides)
     return marker
@@ -1065,5 +1070,76 @@ def test_forged_open_finding_thread_does_not_block_either(gh_comments: Any) -> N
         gh_comments,
         [_comment(_marker(score=5))],
         review_data=([], [thread]),
+    )
+    assert status["accepted"] is True
+
+
+# --- a PRESENT `findings` key is authoritative, even empty or unreadable -----
+
+
+def test_empty_findings_list_does_not_fall_back_to_the_score_guard(
+    gh_comments: Any,
+) -> None:
+    """`findings: []` with `score: 1` is a self-contradictory marker. Reading
+    the empty list as "key absent" drops to the score-only guard, which accepts
+    any disposed P0 thread — so a stale, already-disposed P0 would clear a head
+    whose own P0 was never addressed. Presence is the signal, not truthiness."""
+    status = _status(
+        gh_comments,
+        [_comment(_marker(score=1, findings=[]))],
+        review_data=([], [_finding_thread("P0", resolved=True, total=2)]),
+    )
+    assert status["accepted"] is False
+    assert "publishes 0 P0 finding(s)" in (status["detail"] or "")
+
+
+def test_findings_entry_without_a_fingerprint_fails_closed(gh_comments: Any) -> None:
+    """Silently skipping an unreadable entry shrinks the set of dispositions
+    demanded — the fail-open direction. An entry we cannot read is refused."""
+    status = _status(
+        gh_comments,
+        [_comment(_marker(score=1, findings=[{"severity": "P0"}]))],
+        review_data=([], [_finding_thread("P0", resolved=True, total=2)]),
+    )
+    assert status["accepted"] is False
+    assert "cannot read" in (status["detail"] or "")
+
+
+def test_findings_must_account_for_the_score(gh_comments: Any) -> None:
+    """A score of 2 means two or more P1s; publishing one P1 entry contradicts
+    it, so the marker is refused rather than half-believed."""
+    fp = "aaaabbbbcccc"
+    status = _status(
+        gh_comments,
+        [_comment(_marker(score=2, findings=[{"fp": fp, "severity": "P1"}]))],
+        # The one published finding IS disposed, so this isolates the score
+        # check from the per-fingerprint one.
+        review_data=(
+            [],
+            [
+                _finding_thread_body(
+                    "\u274c **P1** \u2014 the hash ignores .state",
+                    fp=fp,
+                    resolved=True,
+                    total=2,
+                )
+            ],
+        ),
+    )
+    assert status["accepted"] is False
+    assert "publishes 1 P1 finding(s), not 2" in (status["detail"] or "")
+
+
+def test_missing_findings_key_still_uses_the_legacy_score_guard(
+    gh_comments: Any,
+) -> None:
+    """Negative control: markers written before `findings` existed must keep
+    working, or the gate breaks on every PR reviewed by an older reviewer."""
+    marker = _marker(score=3)
+    assert "findings" not in marker
+    status = _status(
+        gh_comments,
+        [_comment(marker)],
+        review_data=([], [_finding_thread("P1", resolved=True, total=2)]),
     )
     assert status["accepted"] is True

--- a/tests/test_self_merge_ai_review_gate.py
+++ b/tests/test_self_merge_ai_review_gate.py
@@ -1009,3 +1009,61 @@ def test_scores_below_the_rubric_are_rejected(gh_comments: Any, score: int) -> N
     )
     assert status["accepted"] is False
     assert "outside the rubric" in (status["detail"] or "")
+
+
+# --- finding threads must be OURS, not merely marker-shaped ------------------
+
+
+def _foreign_finding_thread(severity: str, *, author: str) -> dict[str, Any]:
+    """A thread that looks exactly like one of our findings but was written by
+    somebody else — the marker is a label, not a signature."""
+    body = f"{smc._AI_REVIEW_FINDING_MARKER}\n🛑 **{severity}** — forged"
+    return {
+        "isResolved": True,
+        "comments": {
+            "totalCount": 2,
+            "nodes": [{"author": {"login": author}, "body": body}],
+        },
+    }
+
+
+def test_forged_finding_thread_does_not_dispose_a_claimed_p0(
+    gh_comments: Any,
+) -> None:
+    """Anyone with write access can paste the finding marker and `**P0**` into a
+    review thread, resolve it and reply once. Counting that as a disposition
+    hands the recall guard a forged answer for a P0 that was never addressed —
+    so a thread not authored by our reviewer is not one of our findings."""
+    status = _status(
+        gh_comments,
+        [_comment(_marker(score=1))],
+        review_data=([], [_foreign_finding_thread("P0", author="mallory")]),
+    )
+    assert status["accepted"] is False
+    assert "only 0 disposed P0" in (status["detail"] or "")
+
+
+def test_our_own_finding_thread_still_counts(gh_comments: Any) -> None:
+    """Negative control for the author check: the same thread from the reviewer
+    itself disposes the P0 exactly as before."""
+    status = _status(
+        gh_comments,
+        [_comment(_marker(score=1))],
+        review_data=([], [_foreign_finding_thread("P0", author=AUTHOR)]),
+    )
+    assert status["accepted"] is True
+
+
+def test_forged_open_finding_thread_does_not_block_either(gh_comments: Any) -> None:
+    """The check cuts both ways and must not become a griefing vector: a forged
+    *unresolved* P0 is not our finding, so it cannot wedge the AI-review path.
+    (It is still an unresolved thread to the human-thread check, which is where
+    a stranger's review comment belongs.)"""
+    thread = _foreign_finding_thread("P0", author="mallory")
+    thread["isResolved"] = False
+    status = _status(
+        gh_comments,
+        [_comment(_marker(score=5))],
+        review_data=([], [thread]),
+    )
+    assert status["accepted"] is True

--- a/tests/test_self_merge_ai_review_gate.py
+++ b/tests/test_self_merge_ai_review_gate.py
@@ -673,7 +673,13 @@ def test_resolved_without_reply_but_auto_resolved_is_accepted(
 ) -> None:
     """The reviewer itself retires a finding when a fix makes it stop
     reproducing — the marker's `auto_resolved` ledger names those fingerprints.
-    That is evidence-based (the code change is the answer), so no reply is owed."""
+    That is evidence-based (the code change is the answer), so no reply is owed.
+
+    Scored 4, not 3, because those are the states that can actually coexist: the
+    retirement and the score are written by the same reviewer run, so a run that
+    retired the P1 no longer reports one. A score of 3 alongside nothing but
+    auto-resolved threads is a contradiction, and the recall guard blocks it —
+    see `test_auto_resolved_thread_does_not_satisfy_the_recall_guard`."""
     fp = "abcdef123456"
     body = (
         f"{smc._AI_REVIEW_FINDING_MARKER}\n"
@@ -687,7 +693,7 @@ def test_resolved_without_reply_but_auto_resolved_is_accepted(
             "nodes": [{"author": {"login": AUTHOR}, "body": body}],
         },
     }
-    marker = _marker(score=3, auto_resolved=[fp])
+    marker = _marker(score=4, auto_resolved=[fp])
     status = _status(gh_comments, [_comment(marker)], review_data=([], [thread]))
     assert status["accepted"] is True
 
@@ -735,3 +741,122 @@ def test_p0p1_score_with_all_disposed_passes(gh_comments: Any) -> None:
     )
     assert status["accepted"] is True
     assert "findings disposed" in (status["detail"] or "")
+
+
+# --- fail-closed on unreadable severity, and the recall guard's blind spot ---
+
+
+def _finding_thread_body(
+    severity_text: str, *, fp: str | None = None, resolved: bool, total: int
+) -> dict[str, Any]:
+    """A finding thread whose severity text is written verbatim, so a test can
+    render a malformed / missing severity the way a protocol drift would."""
+    fp_line = f'<!-- bob-ai-review-fp {{"fp": "{fp}"}} -->\n' if fp else ""
+    body = f"{smc._AI_REVIEW_FINDING_MARKER}\n{fp_line}{severity_text}"
+    return {
+        "isResolved": resolved,
+        "comments": {
+            "totalCount": total,
+            "nodes": [{"author": {"login": AUTHOR}, "body": body}],
+        },
+    }
+
+
+def test_finding_without_severity_text_blocks_instead_of_defaulting_to_p2(
+    gh_comments: Any,
+) -> None:
+    """A thread carrying our finding marker whose severity does not parse is NOT
+    a P2. The renderer that writes `**P0**` lives in another repo, so a body
+    without it means the wire protocol drifted or the body is malformed —
+    downgrading a possible P0 to non-blocking would be a fail-open on the parse.
+    """
+    status = _status(
+        gh_comments,
+        [_comment(_marker(score=5))],
+        review_data=(
+            [],
+            [
+                _finding_thread_body(
+                    "Security vulnerability in auth", resolved=False, total=1
+                )
+            ],
+        ),
+    )
+    assert status["accepted"] is False
+    assert "unreadable severity" in (status["detail"] or "")
+
+
+def test_finding_without_severity_text_can_still_be_disposed(
+    gh_comments: Any,
+) -> None:
+    """Blocking on an unreadable severity must stay clearable the same way a
+    P0/P1 is — replied to and resolved — not become a permanent wedge."""
+    status = _status(
+        gh_comments,
+        [_comment(_marker(score=5))],
+        review_data=(
+            [],
+            [
+                _finding_thread_body(
+                    "Security vulnerability in auth", resolved=True, total=2
+                )
+            ],
+        ),
+    )
+    assert status["accepted"] is True
+
+
+def test_severity_below_p1_still_never_blocks(gh_comments: Any) -> None:
+    """A readable severity outside P0/P1 (P2 today, P3 if the rubric grows) is
+    non-blocking. The fail-closed rule above applies only to severities we
+    cannot read at all, so widening the rubric does not wedge the gate."""
+    status = _status(
+        gh_comments,
+        [_comment(_marker(score=4))],
+        review_data=(
+            [],
+            [_finding_thread_body("⚠️ **P3** — nit", resolved=False, total=1)],
+        ),
+    )
+    assert status["accepted"] is True
+
+
+def test_auto_resolved_thread_does_not_satisfy_the_recall_guard(
+    gh_comments: Any,
+) -> None:
+    """`auto_resolved` is the reviewer's own record that a finding stopped
+    reproducing and it retired the thread as bookkeeping. Such a thread is by
+    construction not the P0/P1 the score reports for THIS head, so it must not
+    stand in for a real disposition — otherwise the reviewer's bookkeeping
+    silently disarms the recall guard for an unanchored finding."""
+    fp = "abcdef123456"
+    status = _status(
+        gh_comments,
+        [_comment(_marker(score=2, auto_resolved=[fp]))],
+        review_data=(
+            [],
+            [
+                _finding_thread_body(
+                    "🛑 **P1** — the hash ignores .state",
+                    fp=fp,
+                    resolved=True,
+                    total=1,
+                )
+            ],
+        ),
+    )
+    assert status["accepted"] is False
+    assert "no finding thread" in (status["detail"] or "")
+
+
+def test_refusal_detail_is_not_double_prefixed(gh_comments: Any) -> None:
+    """The caller prefixes `AI review `; the shortfall returns a bare fragment.
+    Both prefixing produced `AI review AI review P1 finding is not resolved`."""
+    status = _status(
+        gh_comments,
+        [_comment(_marker(score=3))],
+        review_data=([], [_finding_thread("P1", resolved=False, total=1)]),
+    )
+    detail = status["detail"] or ""
+    assert detail.count("AI review") == 1, detail
+    assert detail == "AI review P1 finding is not resolved"


### PR DESCRIPTION
Closes the score-floor treadmill on the AI-review self-merge path.

## Problem

The AI-review fallback (`fetch_ai_review_status`) required a literal `score == 5` to stand in for Greptile. But 5/5 is a **sampling event, not a converged state**:

Measured on gptme-contrib#1393 with the head frozen at `453ef20ad68f`, **six re-review passes, zero code changes**, disposing findings between rounds:

| round | new findings | score |
|---|---|---|
| 1 | 3 | 4 |
| 2 | parse failure | — |
| 3 | 0 | **5** |
| 4 | 2 | 4 |
| 5 | 0 | **5** |
| 6 | 2 | 4 |

`confidence_score()` returns 4 for *any* surviving P2, and fresh P2s keep arriving (~17% of rounds fail to parse, ~29% time out). A gate demanding literal 5/5 passes or fails the same commit depending on which sample it reads — and looping for 5/5 is unbounded (the treadmill failure mode already on file).

Erik flagged this directly: *"weve discussed the 5/5 gate vs things like resolved comments before, just so you dont miss that."*

## Change

Replace the score floor on the **AI-review path** with a **disposition check that reads real thread state**:

- **no open P0 or P1** — hard block, unchanged
- **every finding addressed AND disposed** — per-thread reply *and* resolution, checked against actual thread state, not aged out. A resolved thread with no reply is not a disposition (observed on gptme-contrib#1389: threads resolved with no reply at all), UNLESS the reviewer itself retired it because a fix stopped it reproducing (fingerprint in the marker's `auto_resolved` ledger — that is evidence-based, no reply is owed)
- **surviving P2s do not block** — they demonstrably regenerate on unchanged code
- **fail-closed preserved**: unreadable thread state (`review_data=None`) is unknown, never clean; a P0/P1 score with no verifying finding thread (unanchored findings, or a reviewer that stopped posting) still refuses

Adds `totalCount` to the review-threads GraphQL query to detect replies, and threads the already-fetched `review_data` through from `evaluate_pr` to avoid a duplicate GraphQL round-trip.

## Tests

New + updated coverage in `tests/test_self_merge_ai_review_gate.py`:
- open P0/P1 blocks; resolved+replied P1 accepted; resolved-without-reply blocks; auto_resolved exemption; open P2 never blocks; unanchored P0/P1 fails closed; unreadable state fails closed; P0/P1 score with all disposed passes

All self-merge related suites pass (308 tests). mypy + ruff clean.
