### PR TITLE
fix(dotfiles/hooks): auto-symlink node_modules in linked worktrees

### DIFF
--- a/dotfiles/.config/git/hooks/post-checkout
+++ b/dotfiles/.config/git/hooks/post-checkout
@@ -32,6 +32,16 @@ _gw_common_dir=$(git rev-parse --git-common-dir 2>/dev/null || true)
 if [ -n "$_gw_git_dir" ] && [ "$_gw_git_dir" != "$_gw_common_dir" ]; then
     _gw_main_root=$(realpath "$_gw_common_dir/.." 2>/dev/null || true)
     _gw_wt_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+    # `<common-dir>/..` is the main CHECKOUT only when the shared git dir is a
+    # `.git` inside one. Off a BARE repo (`/srv/repo.git`) it is that repo's
+    # parent directory instead — an unrelated tree. Requiring a `.git` there
+    # (a dir normally, a file when the main checkout is itself submoduled)
+    # stops two things: symlinking a *sibling project's* node_modules into the
+    # worktree, and running `find` across something like /home/bob on every
+    # single checkout.
+    if [ ! -e "$_gw_main_root/.git" ]; then
+        _gw_main_root=""
+    fi
     if [ -n "$_gw_main_root" ] && [ -n "$_gw_wt_root" ] && [ "$_gw_main_root" != "$_gw_wt_root" ]; then
         while IFS= read -r -d '' _gw_base; do
             _gw_rel="${_gw_base#"$_gw_main_root"/}"

--- a/dotfiles/.config/git/hooks/post-checkout
+++ b/dotfiles/.config/git/hooks/post-checkout
@@ -19,6 +19,22 @@ fi
 # Auto-symlink node_modules in linked git worktrees to prevent --no-verify bypass.
 # Proper worktree detection via git-common-dir vs git-dir (works for all git versions).
 #
+# WHAT YOU ARE TRADING: this is a SHARED tree, not a private copy. Every linked
+# worktree points at the ONE node_modules in the main checkout, so anything that
+# writes through it — `npm install`, a pnpm store write, a postinstall script,
+# `node_modules/.cache` — writes into the main checkout, and two worktrees doing
+# that at once race on the same files. That is accepted deliberately: the tree is
+# here to be READ, by lint/format hooks resolving binaries, and the alternative it
+# replaces is not an isolated tree per worktree — a fresh worktree has NO
+# node_modules at all, which fails those hooks with exit 127 and sends the worker
+# to `--no-verify`, i.e. no hooks whatsoever. A shared read-mostly tree is the
+# better of those two, not a free lunch.
+#
+# So: DO NOT run `npm install` (or any installer) inside a linked worktree. If you
+# need one, `rm` the symlink first and let the installer create a real directory —
+# an existing non-symlink node_modules is left alone by the loop below, so a
+# worktree that opts out this way stays opted out across checkouts.
+#
 # ORDERING IS LOAD-BEARING: this runs BEFORE the branch-base validation below,
 # which returns `exit 0` on detached HEAD, on master/main, and when origin has
 # no default branch. Placing the symlinking after those guards makes it a

--- a/dotfiles/.config/git/hooks/post-checkout
+++ b/dotfiles/.config/git/hooks/post-checkout
@@ -16,6 +16,41 @@ if [ "$is_branch_checkout" != "1" ]; then
     exit 0
 fi
 
+# Auto-symlink node_modules in linked git worktrees to prevent --no-verify bypass.
+# Proper worktree detection via git-common-dir vs git-dir (works for all git versions).
+#
+# ORDERING IS LOAD-BEARING: this runs BEFORE the branch-base validation below,
+# which returns `exit 0` on detached HEAD, on master/main, and when origin has
+# no default branch. Placing the symlinking after those guards makes it a
+# silent no-op for `git worktree add --detach <path> <ref>` (and for
+# `git worktree add <path> origin/master`, which is also detached) — measured:
+# a detached worktree got no symlink at all, which is exactly the case that
+# sends a worker back to --no-verify. It is also independent of the `git fetch
+# origin` below, so worktree setup does not wait on the network.
+_gw_git_dir=$(git rev-parse --git-dir 2>/dev/null || true)
+_gw_common_dir=$(git rev-parse --git-common-dir 2>/dev/null || true)
+if [ -n "$_gw_git_dir" ] && [ "$_gw_git_dir" != "$_gw_common_dir" ]; then
+    _gw_main_root=$(realpath "$_gw_common_dir/.." 2>/dev/null || true)
+    _gw_wt_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+    if [ -n "$_gw_main_root" ] && [ -n "$_gw_wt_root" ] && [ "$_gw_main_root" != "$_gw_wt_root" ]; then
+        while IFS= read -r -d '' _gw_base; do
+            _gw_rel="${_gw_base#"$_gw_main_root"/}"
+            _gw_target="$_gw_wt_root/$_gw_rel"
+            _gw_parent=$(dirname "$_gw_target")
+            [ -d "$_gw_parent" ] || continue
+            if [ ! -e "$_gw_target" ]; then
+                ln -s "$_gw_base" "$_gw_target"
+                echo "[git-worktree] Symlinked $_gw_rel -> $_gw_base"
+            elif [ -L "$_gw_target" ] && [ ! -d "$_gw_target" ]; then
+                rm "$_gw_target"
+                ln -s "$_gw_base" "$_gw_target"
+                echo "[git-worktree] Fixed broken symlink $_gw_rel -> $_gw_base"
+            fi
+        done < <(find "$_gw_main_root" -maxdepth 3 -type d -name node_modules \
+                 -not -path "*/node_modules/*" -print0 2>/dev/null)
+    fi
+fi
+
 # Get current branch
 current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
 if [ -z "$current_branch" ] || [ "$current_branch" = "HEAD" ]; then
@@ -80,32 +115,6 @@ if [ "$merge_base" != "$origin_commit" ]; then
     echo ""
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     echo ""
-fi
-
-# Auto-symlink node_modules in linked git worktrees to prevent --no-verify bypass.
-# Proper worktree detection via git-common-dir vs git-dir (works for all git versions).
-_gw_git_dir=$(git rev-parse --git-dir 2>/dev/null || true)
-_gw_common_dir=$(git rev-parse --git-common-dir 2>/dev/null || true)
-if [ -n "$_gw_git_dir" ] && [ "$_gw_git_dir" != "$_gw_common_dir" ]; then
-    _gw_main_root=$(realpath "$_gw_common_dir/.." 2>/dev/null || true)
-    _gw_wt_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
-    if [ -n "$_gw_main_root" ] && [ -n "$_gw_wt_root" ] && [ "$_gw_main_root" != "$_gw_wt_root" ]; then
-        while IFS= read -r -d '' _gw_base; do
-            _gw_rel="${_gw_base#"$_gw_main_root"/}"
-            _gw_target="$_gw_wt_root/$_gw_rel"
-            _gw_parent=$(dirname "$_gw_target")
-            [ -d "$_gw_parent" ] || continue
-            if [ ! -e "$_gw_target" ]; then
-                ln -s "$_gw_base" "$_gw_target"
-                echo "[git-worktree] Symlinked $_gw_rel -> $_gw_base"
-            elif [ -L "$_gw_target" ] && [ ! -d "$_gw_target" ]; then
-                rm "$_gw_target"
-                ln -s "$_gw_base" "$_gw_target"
-                echo "[git-worktree] Fixed broken symlink $_gw_rel -> $_gw_base"
-            fi
-        done < <(find "$_gw_main_root" -maxdepth 3 -type d -name node_modules \
-                 -not -path "*/node_modules/*" -print0 2>/dev/null)
-    fi
 fi
 
 # Git LFS support (don't fail hook if LFS has issues)

--- a/dotfiles/.config/git/hooks/post-checkout
+++ b/dotfiles/.config/git/hooks/post-checkout
@@ -82,6 +82,32 @@ if [ "$merge_base" != "$origin_commit" ]; then
     echo ""
 fi
 
+# Auto-symlink node_modules in linked git worktrees to prevent --no-verify bypass.
+# Proper worktree detection via git-common-dir vs git-dir (works for all git versions).
+_gw_git_dir=$(git rev-parse --git-dir 2>/dev/null || true)
+_gw_common_dir=$(git rev-parse --git-common-dir 2>/dev/null || true)
+if [ -n "$_gw_git_dir" ] && [ "$_gw_git_dir" != "$_gw_common_dir" ]; then
+    _gw_main_root=$(realpath "$_gw_common_dir/.." 2>/dev/null || true)
+    _gw_wt_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+    if [ -n "$_gw_main_root" ] && [ -n "$_gw_wt_root" ] && [ "$_gw_main_root" != "$_gw_wt_root" ]; then
+        while IFS= read -r -d '' _gw_base; do
+            _gw_rel="${_gw_base#"$_gw_main_root"/}"
+            _gw_target="$_gw_wt_root/$_gw_rel"
+            _gw_parent=$(dirname "$_gw_target")
+            [ -d "$_gw_parent" ] || continue
+            if [ ! -e "$_gw_target" ]; then
+                ln -s "$_gw_base" "$_gw_target"
+                echo "[git-worktree] Symlinked $_gw_rel -> $_gw_base"
+            elif [ -L "$_gw_target" ] && [ ! -d "$_gw_target" ]; then
+                rm "$_gw_target"
+                ln -s "$_gw_base" "$_gw_target"
+                echo "[git-worktree] Fixed broken symlink $_gw_rel -> $_gw_base"
+            fi
+        done < <(find "$_gw_main_root" -maxdepth 3 -type d -name node_modules \
+                 -not -path "*/node_modules/*" -print0 2>/dev/null)
+    fi
+fi
+
 # Git LFS support (don't fail hook if LFS has issues)
 command -v git-lfs >/dev/null 2>&1 && git lfs post-checkout "$@" 2>/dev/null || true
 


### PR DESCRIPTION
## Summary

- Adds node_modules symlinking to the global `post-checkout` hook so git worktrees for JS/TS repos (e.g. `gptme/gptme`) automatically symlink `node_modules` from the base checkout
- Uses `git rev-parse --git-common-dir` vs `--git-dir` for reliable linked worktree detection (the `--show-toplevel` approach is unusable here — returns the worktree path in both main checkout and linked worktree contexts)
- Prevents pre-commit hook failures (exit 127) in fresh worktrees that lead PM workers to use `--no-verify` bypass (forbidden)

## Context

PM workers create git worktrees via `git worktree add` for PR branches. Fresh worktrees lack `node_modules`, so JS pre-commit hooks fail with exit 127. Workers then use `--no-verify` to bypass hooks. This hook fix auto-symlinks `node_modules` from the base checkout on worktree creation, applied globally via `core.hookspath`.

## Test plan

- [ ] Create a worktree from a JS repo with `node_modules`: `git worktree add /tmp/test-wt -b test origin/master`
- [ ] Verify `node_modules` symlink appears: `ls -la /tmp/test-wt/node_modules`
- [ ] Verify pre-commit hooks pass in the worktree without `--no-verify`
- [ ] Verify hook is a no-op in Python-only repos (no `node_modules` in base)