### PR TITLE
fix(self-merge): close two P2 deferred issues from #1393

### DIFF
--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -1395,6 +1395,16 @@ def _consensus_shortfall(consensus: Any) -> str | None:
         )
     if applied < asked:
         return f"consensus agreement clamped to {applied} (requested {asked})"
+    # An agreement threshold higher than the requested pass count is internally
+    # impossible: you cannot have 5 agreeing passes when only 3 were requested.
+    # This is not emitted by our reviewer (it clamps threshold ≤ requested), but
+    # a corrupted or foreign marker could carry it. Treating it as valid would let
+    # a marker escape the clamping guard while still being semantically incoherent.
+    if applied > requested:
+        return (
+            f"consensus agreement threshold {applied} exceeds requested pass count "
+            f"{requested}"
+        )
     return None
 
 
@@ -1539,13 +1549,20 @@ def fetch_ai_review_status(
         return {"accepted": False, "detail": None}
 
     if isinstance(marker_result, _MarkerUnset):
-        marker = _fetch_ai_review_marker(
+        # Use the checked variant so a failed API call (timeout, rate limit,
+        # 5xx) is reported as a distinct detail rather than silently collapsing
+        # into the same "no marker" response that hides the actual root cause.
+        raw = _fetch_ai_review_marker_checked(
             repo, pr_number, expected_author=expected_author
         )
-    elif isinstance(marker_result, _MarkerLookupFailed):
-        marker = None
     else:
-        marker = marker_result
+        raw = marker_result
+    if isinstance(raw, _MarkerLookupFailed):
+        return {
+            "accepted": False,
+            "detail": "AI review marker lookup failed (API timeout or rate limit)",
+        }
+    marker = raw
     if marker is None:
         return {"accepted": False, "detail": None}
 

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -1560,7 +1560,7 @@ def fetch_ai_review_status(
     if isinstance(raw, _MarkerLookupFailed):
         return {
             "accepted": False,
-            "detail": "AI review marker lookup failed (API timeout or rate limit)",
+            "detail": "AI review marker lookup failed (API error, timeout, or identity resolution failure)",
         }
     marker = raw
     if marker is None:

--- a/tests/test_self_merge_ai_review_gate.py
+++ b/tests/test_self_merge_ai_review_gate.py
@@ -1194,3 +1194,44 @@ def test_matching_severity_still_disposes(gh_comments: Any) -> None:
         ),
     )
     assert status["accepted"] is True
+
+
+# --- P2 deferred fixes (raised on #1393, landed separately) ---
+
+
+def test_agreement_threshold_exceeding_requested_passes_is_rejected(
+    gh_comments: Any,
+) -> None:
+    """min_agreement > requested is internally impossible and must be rejected.
+
+    FULL_CONSENSUS has requested=3; a marker with min_agreement=5 passes the
+    clamping guard (applied == asked, so not clamped) while being semantically
+    incoherent — 5 agreeing passes cannot arise from 3 requested passes.  Our
+    reviewer clamps the threshold to ≤ requested, so this is only reachable via
+    a corrupted or foreign marker; the author check already blocks foreign
+    markers, but internal consistency must be rejected uniformly.
+    """
+    consensus = dict(FULL_CONSENSUS, min_agreement=5, min_agreement_requested=5)
+    status = _status(gh_comments, [_comment(_marker(consensus=consensus))])
+    assert status["accepted"] is False
+    assert "exceeds requested pass count" in (status["detail"] or "")
+
+
+def test_marker_lookup_failure_is_surfaced_as_distinct_detail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transient API failure must not silently look like 'no marker posted'.
+
+    The old code called ``_fetch_ai_review_marker``, which collapsed
+    ``MARKER_LOOKUP_FAILED`` to ``None``.  So a timeout or rate-limited call
+    looked identical to a PR our reviewer never posted on — both produced
+    ``{"accepted": False, "detail": None}`` and the gate said "Greptile review
+    not found" with nothing explaining why the AI fallback did not apply.
+    """
+    monkeypatch.setattr(smc, "run_gh_checked", lambda *a, **k: None)
+    monkeypatch.setattr(smc, "run_gh", lambda *a, **k: "")
+    status = smc.fetch_ai_review_status(
+        "gptme/gptme-contrib", 1382, head_sha=HEAD_SHA, expected_author=AUTHOR
+    )
+    assert status["accepted"] is False
+    assert "lookup failed" in (status["detail"] or "")


### PR DESCRIPTION
## Summary

Two deferred P2 issues raised (and judged non-blocking) during review of #1393.

**P2.1 — `fetch_ai_review_status` now surfaces a distinct detail on marker lookup failure**

Previously, `fetch_ai_review_status` called `_fetch_ai_review_marker`, which collapsed `MARKER_LOOKUP_FAILED` (API timeout / rate limit / 5xx) into `None` — the same as "no marker posted". Both paths returned `{"accepted": False, "detail": None}` and the gate printed the bare _"Greptile review not found"_ reason with no hint that the AI fallback even tried and failed.

The fix: switch the call site to `_fetch_ai_review_marker_checked`, which already exists and preserves the `MARKER_LOOKUP_FAILED` sentinel. A failed lookup now returns `{"accepted": False, "detail": "AI review marker lookup failed (API timeout or rate limit)"}`.

**P2.2 — `_consensus_shortfall` rejects `min_agreement > requested`**

A marker carrying `requested: 3, answered: 3, min_agreement: 5, min_agreement_requested: 5` passed every individual guard — `applied < asked` is False, `applied < 1` is False, `answered == requested` — while being semantically incoherent: 5 agreeing passes cannot arise from 3 requested passes.

Our reviewer clamps `min_agreement ≤ requested`, so this is only reachable via a corrupted or foreign marker. The author-account check already blocks foreign markers, but internally impossible records should be treated as corruption uniformly (same treatment as `answered > requested` or `jobs_answered > jobs_requested` from the same PR). The fix: reject when `min_agreement > requested`.

Both fixes are fail-closed and do not change behaviour for well-formed markers.

## Test plan

- [x] `test_agreement_threshold_exceeding_requested_passes_is_rejected` — P2.2 regression
- [x] `test_marker_lookup_failure_is_surfaced_as_distinct_detail` — P2.1 regression
- [x] All 298 existing self-merge tests pass (`pytest tests/test_self_merge_*.py tests/test_self_merge_check.py`)