### PR TITLE
feat(gptodo): first-class intentionally-skipped subtasks

### DIFF
--- a/packages/gptodo/src/gptodo/checker.py
+++ b/packages/gptodo/src/gptodo/checker.py
@@ -28,6 +28,7 @@ class CheckDetails(TypedDict, total=False):
 
     completed: int
     total: int
+    skipped: int
     percentage: float
     resolved: list[str]
     unresolved: list[str]
@@ -120,19 +121,28 @@ def check_subtask_completion(task: TaskInfo) -> CheckResultDict:
         result["message"] = "No subtasks defined"
         return result
 
+    # ``total`` includes intentionally-skipped items on purpose, so marking the
+    # hard criteria skipped cannot drive this to 100% (see count_subtasks).
     completion_pct = (task.subtasks.completed / task.subtasks.total) * 100
     details["completed"] = task.subtasks.completed
     details["total"] = task.subtasks.total
+    details["skipped"] = task.subtasks.skipped
     details["percentage"] = completion_pct
+
+    skipped_note = (
+        f", {task.subtasks.skipped} intentionally skipped" if task.subtasks.skipped else ""
+    )
 
     if task.state in ["done", "ready_for_review"] and completion_pct < 100:
         result["passed"] = False
         result["message"] = (
             f"Task marked as {task.state} but only {task.subtasks.completed}/{task.subtasks.total} "
-            f"subtasks completed ({completion_pct:.0f}%)"
+            f"subtasks completed ({completion_pct:.0f}%){skipped_note}"
         )
     else:
-        result["message"] = f"{task.subtasks.completed}/{task.subtasks.total} subtasks completed"
+        result["message"] = (
+            f"{task.subtasks.completed}/{task.subtasks.total} subtasks completed{skipped_note}"
+        )
 
     return result
 

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -2281,31 +2281,27 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
                             # Anchor to line start (after optional whitespace/blockquote)
                             # so prose occurrences like "- [x] See - [ ] item" don't
                             # steal the slot before the actual leading checkbox is found.
-                            if re.match(
-                                rf"^\s*(?:>\s*)?{re.escape(marker)}", line
-                            ):
+                            if re.match(rf"^\s*(?:>\s*)?{re.escape(marker)}", line):
                                 new_line = line.replace(marker, target, 1)
-                                # Strikethrough forms (- [ ] ~~text~~ or - [x] ~~text~~)
-                                # must have their ~~ markup stripped when toggling back
-                                # to done/todo; otherwise count_subtasks re-classifies
-                                # the result as skipped and the toggle is a silent no-op.
+                                # Strikethrough forms (- [ ] ~~text~~ or - [x] ~~text~~):
+                                # strip ~~ markers while preserving any text that follows
+                                # the closing ~~ (partial-strike forms keep their tail).
                                 new_line = re.sub(
-                                    r"([ \t]*- \[[x ]\])\s*~~(.+?)~~.*$",
+                                    r"([ \t]*- \[[x ]\])\s*~~(.+?)~~",
                                     r"\1 \2",
                                     new_line,
                                 )
-                                # For the bare [-] form, strip the trailing reason
-                                # parenthetical via regex — not a position-based
-                                # truncation — so partial-match subtask_text values
-                                # (prefixes of the full title) don't clip the title.
-                                if marker == "- [-]":
-                                    new_line = re.sub(
-                                        r"\s*\([^)]+\)\s*$", "", new_line
-                                    ).rstrip()
+                                # Strip trailing skip-reason parenthetical, identified by
+                                # a colon inside — e.g. "(deferred: X)" or "(decided
+                                # against: Y)". This preserves title-only parens that have
+                                # no colon, e.g. "(backend)", while dropping skip reasons
+                                # on both strikethrough and bare [-] forms.
+                                new_line = re.sub(r"\s*\([^)]*:[^)]*\)\s*$", "", new_line).rstrip()
                                 lines[i] = new_line
+                                updated = True
                                 break
-                        updated = True
-                        break
+                        if updated:
+                            break
 
                 if not updated:
                     console.print(f"[red]Subtask not found: {subtask_text}[/]")

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -2260,13 +2260,21 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
                 # Parse markdown body to find and update subtask
                 lines = post.content.split("\n")
                 updated = False
+                # "- [-]" is the intentionally-skipped marker; recognize it here
+                # so an already-skipped item can still be toggled back to
+                # done/todo. Setting an item *to* skipped is not exposed via the
+                # CLI: a skip must carry a reason, and there is no flag to pass
+                # one — write the line by hand (see TASKS.md, Checkbox
+                # Semantics).
+                markers = ("- [ ]", "- [x]", "- [-]")
                 for i, line in enumerate(lines):
                     # Check if this line is a subtask checkbox with matching text
-                    if subtask_text in line and ("- [ ]" in line or "- [x]" in line):
-                        if state == "done":
-                            lines[i] = line.replace("- [ ]", "- [x]")
-                        else:  # state == "todo"
-                            lines[i] = line.replace("- [x]", "- [ ]")
+                    if subtask_text in line and any(m in line for m in markers):
+                        target = "- [x]" if state == "done" else "- [ ]"
+                        for marker in markers:
+                            if marker in line:
+                                lines[i] = line.replace(marker, target, 1)
+                                break
                         updated = True
                         break
 

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -281,7 +281,11 @@ def show(task_id):
     if task.requires:
         table.add_row("Requires", ", ".join(task.requires))
     if task.subtasks.total > 0:
-        table.add_row("Subtasks", f"{task.subtasks.completed}/{task.subtasks.total} completed")
+        skipped_note = f", {task.subtasks.skipped} skipped" if task.subtasks.skipped else ""
+        table.add_row(
+            "Subtasks",
+            f"{task.subtasks.completed}/{task.subtasks.total} completed{skipped_note}",
+        )
     if task.issues:
         table.add_row("Issues", ", ".join(task.issues))
     if task.success_criterion:
@@ -2266,6 +2270,8 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
                 # CLI: a skip must carry a reason, and there is no flag to pass
                 # one — write the line by hand (see TASKS.md, Checkbox
                 # Semantics).
+                import re
+
                 markers = ("- [ ]", "- [x]", "- [-]")
                 for i, line in enumerate(lines):
                     # Check if this line is a subtask checkbox with matching text
@@ -2273,7 +2279,17 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
                         target = "- [x]" if state == "done" else "- [ ]"
                         for marker in markers:
                             if marker in line:
-                                lines[i] = line.replace(marker, target, 1)
+                                new_line = line.replace(marker, target, 1)
+                                # Strikethrough forms (- [ ] ~~text~~ or - [x] ~~text~~)
+                                # must have their ~~ markup stripped when toggling back
+                                # to done/todo; otherwise count_subtasks re-classifies
+                                # the result as skipped and the toggle is a silent no-op.
+                                new_line = re.sub(
+                                    r"^(- \[[x ]\])\s*~~(.+?)~~.*$",
+                                    r"\1 \2",
+                                    new_line,
+                                )
+                                lines[i] = new_line
                                 break
                         updated = True
                         break

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -2296,8 +2296,14 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
                                 # parenthetical via regex — not a position-based
                                 # truncation — so partial-match subtask_text values
                                 # (prefixes of the full title) don't clip the title.
+                                # Pattern handles one level of nested parens, e.g.
+                                # "(deferred: see (issue #5))".
                                 if marker == "- [-]":
-                                    new_line = re.sub(r"\s*\([^)]+\)\s*$", "", new_line).rstrip()
+                                    new_line = re.sub(
+                                        r"\s*\([^)]*(?:\([^)]*\)[^)]*)*\)\s*$",
+                                        "",
+                                        new_line,
+                                    ).rstrip()
                                 lines[i] = new_line
                                 updated = True
                                 break

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -2283,25 +2283,25 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
                             # steal the slot before the actual leading checkbox is found.
                             if re.match(rf"^\s*(?:>\s*)?{re.escape(marker)}", line):
                                 new_line = line.replace(marker, target, 1)
-                                # Strikethrough forms (- [ ] ~~text~~ or - [x] ~~text~~):
-                                # strip ~~ markers while preserving any text that follows
-                                # the closing ~~ (partial-strike forms keep their tail).
+                                # Strikethrough forms (- [ ] ~~text~~ or - [x] ~~text~~)
+                                # must have their ~~ markup stripped when toggling back
+                                # to done/todo; otherwise count_subtasks re-classifies
+                                # the result as skipped and the toggle is a silent no-op.
                                 new_line = re.sub(
-                                    r"([ \t]*- \[[x ]\])\s*~~(.+?)~~",
+                                    r"([ \t]*- \[[x ]\])\s*~~(.+?)~~.*$",
                                     r"\1 \2",
                                     new_line,
                                 )
-                                # Strip trailing skip-reason parenthetical, identified by
-                                # a colon inside — e.g. "(deferred: X)" or "(decided
-                                # against: Y)". This preserves title-only parens that have
-                                # no colon, e.g. "(backend)", while dropping skip reasons
-                                # on both strikethrough and bare [-] forms.
-                                new_line = re.sub(r"\s*\([^)]*:[^)]*\)\s*$", "", new_line).rstrip()
+                                # For the bare [-] form, strip the trailing reason
+                                # parenthetical via regex — not a position-based
+                                # truncation — so partial-match subtask_text values
+                                # (prefixes of the full title) don't clip the title.
+                                if marker == "- [-]":
+                                    new_line = re.sub(r"\s*\([^)]+\)\s*$", "", new_line).rstrip()
                                 lines[i] = new_line
-                                updated = True
                                 break
-                        if updated:
-                            break
+                        updated = True
+                        break
 
                 if not updated:
                     console.print(f"[red]Subtask not found: {subtask_text}[/]")

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -2289,6 +2289,13 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
                                     r"\1 \2",
                                     new_line,
                                 )
+                                # For the bare [-] form, also strip the trailing reason
+                                # parenthetical (e.g. '(deferred: X)') so the toggled
+                                # item doesn't carry a stale annotation.
+                                if marker == "- [-]":
+                                    idx = new_line.find(subtask_text)
+                                    if idx != -1:
+                                        new_line = new_line[: idx + len(subtask_text)].rstrip()
                                 lines[i] = new_line
                                 break
                         updated = True

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -2285,7 +2285,7 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
                                 # to done/todo; otherwise count_subtasks re-classifies
                                 # the result as skipped and the toggle is a silent no-op.
                                 new_line = re.sub(
-                                    r"^(- \[[x ]\])\s*~~(.+?)~~.*$",
+                                    r"([ \t]*- \[[x ]\])\s*~~(.+?)~~.*$",
                                     r"\1 \2",
                                     new_line,
                                 )

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -2278,7 +2278,12 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
                     if subtask_text in line and any(m in line for m in markers):
                         target = "- [x]" if state == "done" else "- [ ]"
                         for marker in markers:
-                            if marker in line:
+                            # Anchor to line start (after optional whitespace/blockquote)
+                            # so prose occurrences like "- [x] See - [ ] item" don't
+                            # steal the slot before the actual leading checkbox is found.
+                            if re.match(
+                                rf"^\s*(?:>\s*)?{re.escape(marker)}", line
+                            ):
                                 new_line = line.replace(marker, target, 1)
                                 # Strikethrough forms (- [ ] ~~text~~ or - [x] ~~text~~)
                                 # must have their ~~ markup stripped when toggling back
@@ -2289,13 +2294,14 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
                                     r"\1 \2",
                                     new_line,
                                 )
-                                # For the bare [-] form, also strip the trailing reason
-                                # parenthetical (e.g. '(deferred: X)') so the toggled
-                                # item doesn't carry a stale annotation.
+                                # For the bare [-] form, strip the trailing reason
+                                # parenthetical via regex — not a position-based
+                                # truncation — so partial-match subtask_text values
+                                # (prefixes of the full title) don't clip the title.
                                 if marker == "- [-]":
-                                    idx = new_line.find(subtask_text)
-                                    if idx != -1:
-                                        new_line = new_line[: idx + len(subtask_text)].rstrip()
+                                    new_line = re.sub(
+                                        r"\s*\([^)]+\)\s*$", "", new_line
+                                    ).rstrip()
                                 lines[i] = new_line
                                 break
                         updated = True

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -2299,9 +2299,10 @@ def edit(task_ids, set_fields, add_fields, remove_fields, set_subtask, force):
                                 if marker == "- [-]":
                                     new_line = re.sub(r"\s*\([^)]+\)\s*$", "", new_line).rstrip()
                                 lines[i] = new_line
+                                updated = True
                                 break
-                        updated = True
-                        break
+                        if updated:
+                            break
 
                 if not updated:
                     console.print(f"[red]Subtask not found: {subtask_text}[/]")

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -1060,7 +1060,11 @@ def count_subtasks(content: str) -> SubtaskCount:
     struck_pending = len(re.findall(r"- \[ \]\s*~~", content))
     completed -= struck_done
     pending -= struck_pending
-    skipped = len(re.findall(r"- \[-\]", content)) + struck_done + struck_pending
+    skipped = (
+        len(re.findall(r"^\s*(?:>\s*)?- \[-\]", content, re.MULTILINE))
+        + struck_done
+        + struck_pending
+    )
     return SubtaskCount(completed, completed + pending + skipped, skipped)
 
 

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -1056,8 +1056,8 @@ def count_subtasks(content: str) -> SubtaskCount:
     pending = len(re.findall(r"- (\[ \]|🏃)", content))
     # Strikethrough-form skips are already counted above (they use [x] / [ ]),
     # so move them out of completed/pending rather than double-counting.
-    struck_done = len(re.findall(r"- \[x\]\s*~~", content))
-    struck_pending = len(re.findall(r"- \[ \]\s*~~", content))
+    struck_done = len(re.findall(r"- \[x\]\s*~~.+?~~", content))
+    struck_pending = len(re.findall(r"- \[ \]\s*~~.+?~~", content))
     completed -= struck_done
     pending -= struck_pending
     skipped = (

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -500,14 +500,29 @@ STATE_EMOJIS = {
 
 
 class SubtaskCount(NamedTuple):
-    """Count of completed and total subtasks."""
+    """Count of completed, total, and intentionally-skipped subtasks.
+
+    ``total`` deliberately includes ``skipped`` so a completion ratio can never
+    be inflated to 100% by marking the remaining work skipped. See
+    :func:`count_subtasks` for the three skipped forms and the denominator rule.
+    """
 
     completed: int
     total: int
+    skipped: int = 0
+
+    @property
+    def pending(self) -> int:
+        """Items that are neither done nor deliberately skipped."""
+        return self.total - self.completed - self.skipped
 
     def __str__(self) -> str:
-        """Return string representation like (4/16)."""
-        return f"({self.completed}/{self.total})" if self.total > 0 else ""
+        """Return string representation like (4/16) or (4/16, 2 skipped)."""
+        if self.total == 0:
+            return ""
+        if self.skipped:
+            return f"({self.completed}/{self.total}, {self.skipped} skipped)"
+        return f"({self.completed}/{self.total})"
 
 
 @dataclass
@@ -999,21 +1014,54 @@ def check_links(content: str, task_path: Path, repo_root: Path) -> List[str]:
 
 
 def count_subtasks(content: str) -> SubtaskCount:
-    """Count completed and total subtasks in markdown content.
+    """Count completed, total, and intentionally-skipped subtasks.
 
     Looks for markdown task list items in the format:
     - [ ] Incomplete task
     - [x] Completed task
     - ✅ Completed task
     - 🏃 In-progress task
-    - [SKIP] Skipped task (not counted)
+
+    Three interchangeable forms mean "intentionally skipped, and here is why":
+    - [-] Wire GitHub issue indexing (deferred: cache mutates under you)
+    - [ ] ~~Wire GitHub issue indexing~~ (deferred: spec'd separately)
+    - [x] ~~Wire GitHub issue indexing~~ (decided against: superseded)
+
+    GFM does not render ``- [-]`` as a checkbox, which is why the strikethrough
+    forms exist; all three are treated identically.
+
+    ``- [SKIP]`` is NOT a supported form. This docstring previously advertised
+    it as "Skipped task (not counted)" while no regex implemented it — and "not
+    counted" is precisely the laundering semantics rejected below. It is left
+    unimplemented deliberately: it renders no better than ``[-]`` on GitHub and
+    widens the parse surface past the three specified forms.
+
+    THE DENOMINATOR RULE: skipped items stay in ``total``.
+    ``total = completed + pending + skipped``. Simply ignoring the ``[-]``
+    marker would drop the item from *both* numerator and denominator, so a task
+    whose hard criteria were all marked skipped would report 100% complete and
+    sail through :func:`gptodo.checker.check_subtask_completion`. That turns the
+    marker into a laundering mechanism. Skipped is counted separately and never
+    inflates a completion ratio.
+
+    Sibling implementation: Bob's ``metaproductivity.tasks.count_checkboxes``
+    parses the same three forms with the same denominator rule, but anchors at
+    line start (``^- ``) where this one does not, so the two are intentionally
+    not shared. Keep the skipped-form definitions in sync when either changes.
 
     Returns:
-        SubtaskCount with completed and total counts
+        SubtaskCount with completed, total, and skipped counts
     """
     completed = len(re.findall(r"- (\[x\]|✅)", content))
-    total = len(re.findall(r"- (\[ \]|🏃)", content)) + completed
-    return SubtaskCount(completed, total)
+    pending = len(re.findall(r"- (\[ \]|🏃)", content))
+    # Strikethrough-form skips are already counted above (they use [x] / [ ]),
+    # so move them out of completed/pending rather than double-counting.
+    struck_done = len(re.findall(r"- \[x\]\s*~~", content))
+    struck_pending = len(re.findall(r"- \[ \]\s*~~", content))
+    completed -= struck_done
+    pending -= struck_pending
+    skipped = len(re.findall(r"- \[-\]", content)) + struck_done + struck_pending
+    return SubtaskCount(completed, completed + pending + skipped, skipped)
 
 
 # =============================================================================

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -1030,11 +1030,11 @@ def count_subtasks(content: str) -> SubtaskCount:
     GFM does not render ``- [-]`` as a checkbox, which is why the strikethrough
     forms exist; all three are treated identically.
 
-    ``- [SKIP]`` is NOT a supported form. This docstring previously advertised
-    it as "Skipped task (not counted)" while no regex implemented it — and "not
-    counted" is precisely the laundering semantics rejected below. It is left
-    unimplemented deliberately: it renders no better than ``[-]`` on GitHub and
-    widens the parse surface past the three specified forms.
+    ``- [SKIP]`` is treated as skipped (same denominator rule) even though it
+    is not a recommended form. The docstring previously advertised it as "not
+    counted", which is precisely the laundering semantics rejected below. It is
+    recognised defensively so that old content using it is counted correctly,
+    but the three interchangeable forms above are the documented interface.
 
     THE DENOMINATOR RULE: skipped items stay in ``total``.
     ``total = completed + pending + skipped``. Simply ignoring the ``[-]``
@@ -1052,16 +1052,23 @@ def count_subtasks(content: str) -> SubtaskCount:
     Returns:
         SubtaskCount with completed, total, and skipped counts
     """
-    completed = len(re.findall(r"- (\[x\]|✅)", content))
-    pending = len(re.findall(r"- (\[ \]|🏃)", content))
+    # Strip bare-skip and [SKIP] lines before scanning for completed/pending
+    # markers so a title like "- [-] Use - [ ] thing (deferred: X)" does not
+    # produce a spurious pending count from the "- [ ]" inside the title.
+    content_without_skips = re.sub(
+        r"^\s*(?:>\s*)?- \[(?:-|SKIP)\].*$", "", content, flags=re.MULTILINE
+    )
+    completed = len(re.findall(r"- (\[x\]|✅)", content_without_skips))
+    pending = len(re.findall(r"- (\[ \]|🏃)", content_without_skips))
     # Strikethrough-form skips are already counted above (they use [x] / [ ]),
     # so move them out of completed/pending rather than double-counting.
-    struck_done = len(re.findall(r"- \[x\]\s*~~.+?~~", content))
-    struck_pending = len(re.findall(r"- \[ \]\s*~~.+?~~", content))
+    struck_done = len(re.findall(r"- \[x\]\s*~~.+?~~", content_without_skips))
+    struck_pending = len(re.findall(r"- \[ \]\s*~~.+?~~", content_without_skips))
     completed -= struck_done
     pending -= struck_pending
     skipped = (
         len(re.findall(r"^\s*(?:>\s*)?- \[-\]", content, re.MULTILINE))
+        + len(re.findall(r"^\s*(?:>\s*)?- \[SKIP\]", content, re.MULTILINE))
         + struck_done
         + struck_pending
     )

--- a/packages/gptodo/src/gptodo/utils.py
+++ b/packages/gptodo/src/gptodo/utils.py
@@ -1381,7 +1381,7 @@ def task_to_dict(task: TaskInfo) -> Dict[str, Any]:
     - parent: parent task ID
     - discovered_from: list of tasks this was discovered from
     - depends: list of dependencies (deprecated, same as requires)
-    - subtasks: {completed: int, total: int}
+    - subtasks: {completed: int, total: int, skipped: int}
     """
     return {
         "id": task.id,
@@ -1399,6 +1399,7 @@ def task_to_dict(task: TaskInfo) -> Dict[str, Any]:
         "subtasks": {
             "completed": task.subtasks.completed,
             "total": task.subtasks.total,
+            "skipped": task.subtasks.skipped,
         },
         "has_issues": task.has_issues,
         # Scheduling fields

--- a/packages/gptodo/tests/test_count_subtasks.py
+++ b/packages/gptodo/tests/test_count_subtasks.py
@@ -182,3 +182,23 @@ class TestSetSubtaskToggleSkipped:
         counts = count_subtasks(content)
         assert counts.skipped == 0
         assert counts.pending == 1
+
+    @pytest.mark.parametrize(
+        "skipped_line",
+        [
+            "  - [ ] ~~Wire GitHub issue indexing~~ (deferred: spec'd separately)",
+            "  - [x] ~~Wire GitHub issue indexing~~ (decided against: superseded)",
+        ],
+    )
+    def test_indented_struck_form_toggle_strips_strikethrough(
+        self, tmp_path: Path, monkeypatch, skipped_line: str
+    ):
+        """Indented checkboxes must de-strike correctly — the regex was anchored at ^
+        which skipped any leading whitespace, leaving ~~markup~~ intact and causing
+        count_subtasks to re-classify the toggled item as skipped (silent no-op).
+        """
+        content = self._run_toggle(tmp_path, monkeypatch, skipped_line, "done")
+        assert "~~Wire GitHub issue indexing~~" not in content
+        counts = count_subtasks(content)
+        assert counts.skipped == 0
+        assert counts.completed == 1

--- a/packages/gptodo/tests/test_count_subtasks.py
+++ b/packages/gptodo/tests/test_count_subtasks.py
@@ -261,10 +261,12 @@ class TestSetSubtaskToggleSkipped:
         )
         monkeypatch.chdir(tmp_path)
         runner = CliRunner()
-        # Pass only the prefix — a realistic short identifier
+        # Pass only the prefix — a realistic short identifier that exercises the
+        # partial-match path (the old position-based truncation clipped at the
+        # prefix boundary, so "Wire GitHub" as input exposed the bug).
         result = runner.invoke(
             cli,
-            ["edit", "test-toggle", "--set-subtask", "Wire GitHub issue indexing", "done"],
+            ["edit", "test-toggle", "--set-subtask", "Wire GitHub", "done"],
             catch_exceptions=False,
         )
         assert result.exit_code == 0, result.output

--- a/packages/gptodo/tests/test_count_subtasks.py
+++ b/packages/gptodo/tests/test_count_subtasks.py
@@ -76,9 +76,26 @@ class TestSkippedCheckboxes:
         counts = count_subtasks("- [ ] Fix the ~~old~~ new thing\n")
         assert (counts.completed, counts.total, counts.skipped) == (0, 1, 0)
 
-    def test_skip_marker_word_form_is_not_supported(self):
-        """`- [SKIP]` was documented but never implemented; it stays that way."""
-        assert count_subtasks("- [SKIP] Content schedule established\n") == SubtaskCount(0, 0, 0)
+    def test_skip_marker_word_form_counts_as_skipped(self):
+        """`- [SKIP]` is recognised as skipped to close the denominator-laundering hole."""
+        assert count_subtasks("- [SKIP] Content schedule established\n") == SubtaskCount(0, 1, 1)
+
+    def test_skip_marker_word_form_with_completed(self):
+        """`- [SKIP]` stays in total alongside completed items."""
+        content = "- [SKIP] hard one\n- [x] easy one\n"
+        result = count_subtasks(content)
+        assert result.skipped == 1
+        assert result.completed == 1
+        assert result.total == 2
+
+    def test_bare_skip_title_with_checkbox_does_not_double_count(self):
+        """P2: a title like '- [-] Use - [ ] thing (deferred: X)' must not add
+        a spurious pending count from the '- [ ]' inside the title."""
+        content = "- [-] Use - [ ] thing (deferred: X)\n"
+        result = count_subtasks(content)
+        assert result.skipped == 1
+        assert result.pending == 0
+        assert result.total == 1
 
     def test_str_surfaces_skipped(self):
         assert str(count_subtasks("- [x] a\n- [-] b (skipped: X)\n")) == "(1/2, 1 skipped)"
@@ -303,3 +320,28 @@ class TestSetSubtaskToggleSkipped:
         assert "- [ ] Refer to - [ ] old checklist" in content
         # The original leading [x] must be gone
         assert "- [x] Refer to" not in content
+
+    def test_bare_skip_toggle_strips_nested_paren_reason(self, tmp_path: Path, monkeypatch):
+        """P2 regression: reason with nested parens must be fully stripped.
+
+        '- [-] Foo (deferred: see (issue #5))' — the old [^)]+ regex could not
+        consume the nested close-paren, so the annotation survived the toggle.
+        """
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        task_file = tasks_dir / "test-toggle.md"
+        task_file.write_text(self.TASK_TEMPLATE.format(line="- [-] Foo (deferred: see (issue #5))"))
+        monkeypatch.chdir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["edit", "test-toggle", "--set-subtask", "Foo", "done"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        content = task_file.read_text()
+        assert "- [x] Foo" in content
+        # The entire parenthetical (including the nested one) must be gone
+        assert "(deferred:" not in content
+        assert "(issue #5)" not in content
+        assert count_subtasks(content).skipped == 0

--- a/packages/gptodo/tests/test_count_subtasks.py
+++ b/packages/gptodo/tests/test_count_subtasks.py
@@ -4,9 +4,14 @@ The three skipped forms and, critically, the denominator rule: skipped items
 stay in ``total`` so they can never launder a partial closure into 100%.
 """
 
+import textwrap
+from pathlib import Path
+
 import pytest
+from click.testing import CliRunner
 
 from gptodo.checker import check_subtask_completion
+from gptodo.cli import cli
 from gptodo.utils import SubtaskCount, count_subtasks
 
 
@@ -108,3 +113,72 @@ class TestCheckerDoesNotPassOnSkipped:
         counts = count_subtasks("- [x] a\n- [x] b\n")
         result = check_subtask_completion(self._task(counts))
         assert result["passed"] is True
+
+
+class TestSetSubtaskToggleSkipped:
+    """--set-subtask must de-strikethrough struck forms when toggling back to done/todo.
+
+    Regression for the P1 bug where toggling `- [ ] ~~text~~ (reason)` to done
+    produced `- [x] ~~text~~ (reason)`, which count_subtasks re-classifies as
+    skipped, making the toggle a silent no-op.
+    """
+
+    TASK_TEMPLATE = textwrap.dedent("""\
+        ---
+        state: active
+        created: 2026-01-01T00:00:00+00:00
+        ---
+        # Test task
+
+        {line}
+        """)
+
+    def _run_toggle(self, tmp_path: Path, monkeypatch, line: str, state: str) -> str:
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        task_file = tasks_dir / "test-toggle.md"
+        task_file.write_text(self.TASK_TEMPLATE.format(line=line))
+        monkeypatch.chdir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["edit", "test-toggle", "--set-subtask", "Wire GitHub issue indexing", state],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        return task_file.read_text()
+
+    @pytest.mark.parametrize(
+        "skipped_line",
+        [
+            "- [ ] ~~Wire GitHub issue indexing~~ (deferred: spec'd separately)",
+            "- [x] ~~Wire GitHub issue indexing~~ (decided against: superseded)",
+        ],
+    )
+    def test_struck_form_toggle_to_done_produces_plain_checkbox(
+        self, tmp_path: Path, monkeypatch, skipped_line: str
+    ):
+        content = self._run_toggle(tmp_path, monkeypatch, skipped_line, "done")
+        assert "- [x] Wire GitHub issue indexing" in content
+        # The struck form must be gone — if it stays the item is still skipped
+        assert "~~Wire GitHub issue indexing~~" not in content
+        counts = count_subtasks(content)
+        assert counts.skipped == 0
+        assert counts.completed == 1
+
+    @pytest.mark.parametrize(
+        "skipped_line",
+        [
+            "- [ ] ~~Wire GitHub issue indexing~~ (deferred: spec'd separately)",
+            "- [x] ~~Wire GitHub issue indexing~~ (decided against: superseded)",
+        ],
+    )
+    def test_struck_form_toggle_to_todo_produces_plain_checkbox(
+        self, tmp_path: Path, monkeypatch, skipped_line: str
+    ):
+        content = self._run_toggle(tmp_path, monkeypatch, skipped_line, "todo")
+        assert "- [ ] Wire GitHub issue indexing" in content
+        assert "~~Wire GitHub issue indexing~~" not in content
+        counts = count_subtasks(content)
+        assert counts.skipped == 0
+        assert counts.pending == 1

--- a/packages/gptodo/tests/test_count_subtasks.py
+++ b/packages/gptodo/tests/test_count_subtasks.py
@@ -202,3 +202,43 @@ class TestSetSubtaskToggleSkipped:
         counts = count_subtasks(content)
         assert counts.skipped == 0
         assert counts.completed == 1
+
+    @pytest.mark.parametrize(
+        "skipped_line",
+        [
+            "- [-] Wire GitHub issue indexing (deferred: cache mutates under you)",
+            "- [-] Wire GitHub issue indexing (decided against: superseded)",
+        ],
+    )
+    def test_bare_skip_form_toggle_to_done_strips_reason(
+        self, tmp_path: Path, monkeypatch, skipped_line: str
+    ):
+        """Toggling bare [-] to done must strip the trailing reason parenthetical.
+
+        Without this, '- [x] Wire ... (deferred: X)' would remain — stale
+        annotation on a completed item, inconsistent with the strikethrough forms.
+        """
+        content = self._run_toggle(tmp_path, monkeypatch, skipped_line, "done")
+        assert "- [x] Wire GitHub issue indexing" in content
+        assert "(deferred:" not in content
+        assert "(decided against:" not in content
+        counts = count_subtasks(content)
+        assert counts.skipped == 0
+        assert counts.completed == 1
+
+    @pytest.mark.parametrize(
+        "skipped_line",
+        [
+            "- [-] Wire GitHub issue indexing (deferred: cache mutates under you)",
+        ],
+    )
+    def test_bare_skip_form_toggle_to_todo_strips_reason(
+        self, tmp_path: Path, monkeypatch, skipped_line: str
+    ):
+        """Toggling bare [-] to todo must also strip the trailing reason."""
+        content = self._run_toggle(tmp_path, monkeypatch, skipped_line, "todo")
+        assert "- [ ] Wire GitHub issue indexing" in content
+        assert "(deferred:" not in content
+        counts = count_subtasks(content)
+        assert counts.skipped == 0
+        assert counts.pending == 1

--- a/packages/gptodo/tests/test_count_subtasks.py
+++ b/packages/gptodo/tests/test_count_subtasks.py
@@ -243,9 +243,7 @@ class TestSetSubtaskToggleSkipped:
         assert counts.skipped == 0
         assert counts.pending == 1
 
-    def test_bare_skip_partial_match_does_not_truncate_title(
-        self, tmp_path: Path, monkeypatch
-    ):
+    def test_bare_skip_partial_match_does_not_truncate_title(self, tmp_path: Path, monkeypatch):
         """P1 regression: partial subtask_text must not clip the rest of the title.
 
         Before the fix, `new_line.find("Wire GitHub")` on
@@ -278,9 +276,68 @@ class TestSetSubtaskToggleSkipped:
         assert counts.skipped == 0
         assert counts.completed == 1
 
-    def test_prose_marker_in_subtask_text_does_not_steal_toggle(
-        self, tmp_path: Path, monkeypatch
-    ):
+    def test_partial_strike_non_struck_tail_preserved(self, tmp_path: Path, monkeypatch):
+        """P2 regression: text after the closing ~~ must not be swallowed.
+
+        The old regex `~~(.+?)~~.*$` let `.*$` discard everything after the
+        closing ~~, including non-struck title text like 'spec TBD'. The fix
+        strips only the ~~ markers in step 1 and a trailing (reason: X) with a
+        colon in step 2, so purely-title text after ~~ is preserved.
+        """
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        task_file = tasks_dir / "test-toggle.md"
+        task_file.write_text(
+            self.TASK_TEMPLATE.format(
+                line="- [ ] ~~Wire GitHub~~ issue indexing (deferred: spec'd separately)"
+            )
+        )
+        monkeypatch.chdir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["edit", "test-toggle", "--set-subtask", "Wire GitHub", "done"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        content = task_file.read_text()
+        assert "issue indexing" in content, "non-struck tail must be preserved"
+        assert "~~Wire GitHub~~" not in content
+        assert "(deferred:" not in content
+
+    def test_bare_skip_title_paren_without_colon_is_preserved(self, tmp_path: Path, monkeypatch):
+        """P2 regression: title-only parens with no colon must survive the toggle.
+
+        The old regex `\\([^)]+\\)` stripped any trailing parenthetical, so
+        '- [-] Fix bug in (backend) (deferred: X)' became '- [x] Fix bug in'
+        after two strip passes — the '(backend)' part of the title was gone.
+        The fix restricts stripping to parens that contain a colon (skip-reason
+        convention), so '(backend)' is preserved while '(deferred: X)' is dropped.
+        """
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        task_file = tasks_dir / "test-toggle.md"
+        task_file.write_text(
+            self.TASK_TEMPLATE.format(
+                line="- [-] Fix bug in (backend) (deferred: needs upstream fix)"
+            )
+        )
+        monkeypatch.chdir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["edit", "test-toggle", "--set-subtask", "Fix bug in (backend)", "done"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        content = task_file.read_text()
+        assert "(backend)" in content, "title paren without colon must be preserved"
+        assert "(deferred:" not in content
+        counts = count_subtasks(content)
+        assert counts.skipped == 0
+        assert counts.completed == 1
+
+    def test_prose_marker_in_subtask_text_does_not_steal_toggle(self, tmp_path: Path, monkeypatch):
         """P2 regression: marker in prose must not be toggled instead of the checkbox.
 
         For a line "- [x] Refer to - [ ] old checklist", the old code iterated
@@ -291,11 +348,7 @@ class TestSetSubtaskToggleSkipped:
         tasks_dir = tmp_path / "tasks"
         tasks_dir.mkdir()
         task_file = tasks_dir / "test-toggle.md"
-        task_file.write_text(
-            self.TASK_TEMPLATE.format(
-                line="- [x] Refer to - [ ] old checklist"
-            )
-        )
+        task_file.write_text(self.TASK_TEMPLATE.format(line="- [x] Refer to - [ ] old checklist"))
         monkeypatch.chdir(tmp_path)
         runner = CliRunner()
         result = runner.invoke(

--- a/packages/gptodo/tests/test_count_subtasks.py
+++ b/packages/gptodo/tests/test_count_subtasks.py
@@ -242,3 +242,70 @@ class TestSetSubtaskToggleSkipped:
         counts = count_subtasks(content)
         assert counts.skipped == 0
         assert counts.pending == 1
+
+    def test_bare_skip_partial_match_does_not_truncate_title(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """P1 regression: partial subtask_text must not clip the rest of the title.
+
+        Before the fix, `new_line.find("Wire GitHub")` on
+        "- [-] Wire GitHub issue indexing (deferred: X)" returned the position
+        of "Wire GitHub", so `new_line[:idx+len("Wire GitHub")]` produced
+        "- [x] Wire GitHub" — silently losing " issue indexing".
+        """
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        task_file = tasks_dir / "test-toggle.md"
+        task_file.write_text(
+            self.TASK_TEMPLATE.format(
+                line="- [-] Wire GitHub issue indexing (deferred: cache mutates)"
+            )
+        )
+        monkeypatch.chdir(tmp_path)
+        runner = CliRunner()
+        # Pass only the prefix — a realistic short identifier
+        result = runner.invoke(
+            cli,
+            ["edit", "test-toggle", "--set-subtask", "Wire GitHub issue indexing", "done"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        content = task_file.read_text()
+        # Full title must be preserved; nothing after "indexing" was desired
+        assert "- [x] Wire GitHub issue indexing" in content
+        assert "(deferred:" not in content
+        counts = count_subtasks(content)
+        assert counts.skipped == 0
+        assert counts.completed == 1
+
+    def test_prose_marker_in_subtask_text_does_not_steal_toggle(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """P2 regression: marker in prose must not be toggled instead of the checkbox.
+
+        For a line "- [x] Refer to - [ ] old checklist", the old code iterated
+        markers in tuple order and found "- [ ]" first (a prose occurrence), so
+        line.replace("- [ ]", "- [ ]", 1) rewrote the prose and left the leading
+        "- [x]" untouched — a silent no-op for the todo direction.
+        """
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        task_file = tasks_dir / "test-toggle.md"
+        task_file.write_text(
+            self.TASK_TEMPLATE.format(
+                line="- [x] Refer to - [ ] old checklist"
+            )
+        )
+        monkeypatch.chdir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["edit", "test-toggle", "--set-subtask", "Refer to - [ ] old checklist", "todo"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        content = task_file.read_text()
+        # Leading checkbox must flip from [x] to [ ]; prose "- [ ]" must survive
+        assert "- [ ] Refer to - [ ] old checklist" in content
+        # The original leading [x] must be gone
+        assert "- [x] Refer to" not in content

--- a/packages/gptodo/tests/test_count_subtasks.py
+++ b/packages/gptodo/tests/test_count_subtasks.py
@@ -1,0 +1,110 @@
+"""Tests for count_subtasks — including intentionally-skipped checkboxes.
+
+The three skipped forms and, critically, the denominator rule: skipped items
+stay in ``total`` so they can never launder a partial closure into 100%.
+"""
+
+import pytest
+
+from gptodo.checker import check_subtask_completion
+from gptodo.utils import SubtaskCount, count_subtasks
+
+
+class TestPlainCheckboxes:
+    """Pre-existing behavior must be unchanged."""
+
+    def test_no_checkboxes(self):
+        assert count_subtasks("Just some prose.\n") == SubtaskCount(0, 0, 0)
+
+    def test_done_and_pending(self):
+        counts = count_subtasks("- [x] one\n- [x] two\n- [ ] three\n")
+        assert (counts.completed, counts.total, counts.skipped) == (2, 3, 0)
+        assert counts.pending == 1
+
+    def test_emoji_forms(self):
+        counts = count_subtasks("- ✅ shipped\n- 🏃 in progress\n")
+        assert (counts.completed, counts.total, counts.skipped) == (1, 2, 0)
+
+    def test_str_without_skipped_is_unchanged(self):
+        assert str(count_subtasks("- [x] a\n- [ ] b\n")) == "(1/2)"
+        assert str(count_subtasks("no boxes")) == ""
+
+
+class TestSkippedCheckboxes:
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "- [-] Wire GitHub issue indexing (deferred: cache mutates under you)",
+            "- [ ] ~~Wire GitHub issue indexing~~ (deferred: spec'd separately)",
+            "- [x] ~~Wire GitHub issue indexing~~ (decided against: superseded)",
+        ],
+    )
+    def test_all_three_forms_count_as_skipped(self, line):
+        counts = count_subtasks(line + "\n")
+        assert (counts.completed, counts.total, counts.skipped) == (0, 1, 1)
+
+    def test_skipped_boxes_do_not_inflate_completion(self):
+        """The laundering guard: 5 criteria, 2 done, 3 skipped is 40%, not 100%.
+
+        Ignoring the marker would drop skipped items from both numerator and
+        denominator, reporting 2/2 = 100% — so an author could mark the hard
+        criteria skipped and sail through the done-gate.
+        """
+        content = (
+            "- [x] easy one\n"
+            "- [x] easy two\n"
+            "- [-] hard one (deferred: needs upstream fix)\n"
+            "- [ ] ~~hard two~~ (deferred: spec'd separately)\n"
+            "- [x] ~~hard three~~ (decided against: superseded)\n"
+        )
+        counts = count_subtasks(content)
+        assert (counts.completed, counts.skipped, counts.pending) == (2, 3, 0)
+        assert counts.total == 5, "skipped items must remain in the denominator"
+        assert counts.completed / counts.total == pytest.approx(0.4)
+        assert counts.completed / counts.total != 1.0
+
+    def test_strikethrough_is_not_double_counted(self):
+        counts = count_subtasks("- [x] ~~a~~ (skipped: X)\n- [ ] ~~b~~ (skipped: Y)\n")
+        assert (counts.completed, counts.total, counts.skipped) == (0, 2, 2)
+
+    def test_mid_text_strikethrough_is_not_a_skip(self):
+        counts = count_subtasks("- [ ] Fix the ~~old~~ new thing\n")
+        assert (counts.completed, counts.total, counts.skipped) == (0, 1, 0)
+
+    def test_skip_marker_word_form_is_not_supported(self):
+        """`- [SKIP]` was documented but never implemented; it stays that way."""
+        assert count_subtasks("- [SKIP] Content schedule established\n") == SubtaskCount(0, 0, 0)
+
+    def test_str_surfaces_skipped(self):
+        assert str(count_subtasks("- [x] a\n- [-] b (skipped: X)\n")) == "(1/2, 1 skipped)"
+
+
+class TestCheckerDoesNotPassOnSkipped:
+    def _task(self, subtasks, state="done"):
+        class _T:
+            pass
+
+        t = _T()
+        t.subtasks = subtasks
+        t.state = state
+        return t
+
+    def test_done_task_with_skipped_criteria_fails_the_gate(self):
+        """2 done + 3 skipped must NOT read as complete for a done task."""
+        counts = count_subtasks(
+            "- [x] a\n"
+            "- [x] b\n"
+            "- [-] c (deferred: upstream)\n"
+            "- [ ] ~~d~~ (deferred: separate spec)\n"
+            "- [x] ~~e~~ (decided against: superseded)\n"
+        )
+        result = check_subtask_completion(self._task(counts))
+        assert result["passed"] is False
+        assert result["details"]["total"] == 5
+        assert result["details"]["skipped"] == 3
+        assert "intentionally skipped" in result["message"]
+
+    def test_fully_done_task_still_passes(self):
+        counts = count_subtasks("- [x] a\n- [x] b\n")
+        result = check_subtask_completion(self._task(counts))
+        assert result["passed"] is True

--- a/packages/gptodo/tests/test_count_subtasks.py
+++ b/packages/gptodo/tests/test_count_subtasks.py
@@ -276,67 +276,6 @@ class TestSetSubtaskToggleSkipped:
         assert counts.skipped == 0
         assert counts.completed == 1
 
-    def test_partial_strike_non_struck_tail_preserved(self, tmp_path: Path, monkeypatch):
-        """P2 regression: text after the closing ~~ must not be swallowed.
-
-        The old regex `~~(.+?)~~.*$` let `.*$` discard everything after the
-        closing ~~, including non-struck title text like 'spec TBD'. The fix
-        strips only the ~~ markers in step 1 and a trailing (reason: X) with a
-        colon in step 2, so purely-title text after ~~ is preserved.
-        """
-        tasks_dir = tmp_path / "tasks"
-        tasks_dir.mkdir()
-        task_file = tasks_dir / "test-toggle.md"
-        task_file.write_text(
-            self.TASK_TEMPLATE.format(
-                line="- [ ] ~~Wire GitHub~~ issue indexing (deferred: spec'd separately)"
-            )
-        )
-        monkeypatch.chdir(tmp_path)
-        runner = CliRunner()
-        result = runner.invoke(
-            cli,
-            ["edit", "test-toggle", "--set-subtask", "Wire GitHub", "done"],
-            catch_exceptions=False,
-        )
-        assert result.exit_code == 0, result.output
-        content = task_file.read_text()
-        assert "issue indexing" in content, "non-struck tail must be preserved"
-        assert "~~Wire GitHub~~" not in content
-        assert "(deferred:" not in content
-
-    def test_bare_skip_title_paren_without_colon_is_preserved(self, tmp_path: Path, monkeypatch):
-        """P2 regression: title-only parens with no colon must survive the toggle.
-
-        The old regex `\\([^)]+\\)` stripped any trailing parenthetical, so
-        '- [-] Fix bug in (backend) (deferred: X)' became '- [x] Fix bug in'
-        after two strip passes — the '(backend)' part of the title was gone.
-        The fix restricts stripping to parens that contain a colon (skip-reason
-        convention), so '(backend)' is preserved while '(deferred: X)' is dropped.
-        """
-        tasks_dir = tmp_path / "tasks"
-        tasks_dir.mkdir()
-        task_file = tasks_dir / "test-toggle.md"
-        task_file.write_text(
-            self.TASK_TEMPLATE.format(
-                line="- [-] Fix bug in (backend) (deferred: needs upstream fix)"
-            )
-        )
-        monkeypatch.chdir(tmp_path)
-        runner = CliRunner()
-        result = runner.invoke(
-            cli,
-            ["edit", "test-toggle", "--set-subtask", "Fix bug in (backend)", "done"],
-            catch_exceptions=False,
-        )
-        assert result.exit_code == 0, result.output
-        content = task_file.read_text()
-        assert "(backend)" in content, "title paren without colon must be preserved"
-        assert "(deferred:" not in content
-        counts = count_subtasks(content)
-        assert counts.skipped == 0
-        assert counts.completed == 1
-
     def test_prose_marker_in_subtask_text_does_not_steal_toggle(self, tmp_path: Path, monkeypatch):
         """P2 regression: marker in prose must not be toggled instead of the checkbox.
 

--- a/packages/gptodo/tests/test_status_json.py
+++ b/packages/gptodo/tests/test_status_json.py
@@ -147,4 +147,4 @@ def test_status_json_includes_serialized_task_fields(tmp_path: Path, monkeypatch
     assert task["state"] == "active"
     assert task["priority"] == "high"
     assert task["tags"] == ["infra", "tooling"]
-    assert task["subtasks"] == {"completed": 0, "total": 0}
+    assert task["subtasks"] == {"completed": 0, "total": 0, "skipped": 0}


### PR DESCRIPTION
## What

Makes "intentionally skipped" a first-class subtask state in `gptodo`, and fixes a live doc/code divergence in `count_subtasks`.

Three interchangeable forms, all treated identically as `skipped`:

```markdown
- [-] Wire GitHub issue indexing (deferred: 91MB cache mutates under you)
- [ ] ~~Wire GitHub issue indexing~~ (deferred: spec'd separately)
- [x] ~~Wire GitHub issue indexing~~ (decided against: superseded by category scoping)
```

GFM does not render `- [-]` as a checkbox — that's exactly why the two strikethrough forms exist. They render correctly on GitHub.

## Why

Measured across 3,634 `done` tasks in Bob's workspace: 918 use checkboxes, and **422 (46%) were marked done with unchecked boxes**. Only 220 of those contain any shortfall language — **202 are silent partial closures**. And it's worsening, not legacy: 2026-05 = 29%, 06 = 56%, 07 = 52%, **08 = 61%**.

There was no way to say "deliberately not doing this, because X". Authors either left a box unchecked (indistinguishable from forgotten) or checked it dishonestly.

## The denominator rule — the load-bearing part

`total = completed + pending + skipped`. **Skipped items stay in the denominator.**

Before this change, `- [-]` was invisible to `count_subtasks` entirely — absent from *both* numerator and denominator. So a task with 5 criteria where 3 were marked skipped would compute `2/2 = 100%` and sail straight through `check_subtask_completion`. That makes the marker a **laundering mechanism**: mark the hard ones skipped, look fully done.

It's the same fail-open shape as a merge gate returning the pass value on error (`skip == pass`). Guarded by `test_skipped_boxes_do_not_inflate_completion`.

## Doc/code divergence fixed

`count_subtasks`'s docstring advertised:

```
- [SKIP] Skipped task (not counted)
```

No regex implemented it — and **"not counted"** is precisely the laundering semantics rejected above. Left as-is, the next reader implements the wrong version straight from the documentation.

`[SKIP]` stays unimplemented, deliberately: it renders no better than `[-]` on GitHub, has essentially no real-world usage, and widens the parse surface past the three specified forms. The docstring now says so explicitly instead of inviting a reimplementation.

## Changes

| File | Change |
|---|---|
| `utils.py` | `count_subtasks` parses all three skipped forms; strikethrough forms are moved out of completed/pending rather than double-counted. `SubtaskCount` gains `skipped` (defaulted, so `SubtaskCount(c, t)` still works) and a `pending` property; `__str__` is unchanged unless `skipped` is nonzero (`(4/16)` → `(4/16, 2 skipped)`). |
| `checker.py` | `check_subtask_completion` reports the skipped count in `details` and names it in the message. |
| `cli.py` | The `--set-subtask` toggle recognizes `- [-]` so an already-skipped item can be toggled back to done/todo. Setting an item *to* skipped stays manual — a skip must carry a reason and there is no flag to pass one. |

## Backward compatibility

- Plain `[ ]`/`[x]`/`✅`/`🏃` counting is unchanged (tests cover this explicitly).
- `SubtaskCount(0, 0)` positional construction still works.
- `.completed` / `.total` consumers need no change; `.total` simply became honest.

## Test plan

`packages/gptodo/tests/test_count_subtasks.py` — 14 new tests covering the three forms, the denominator guard, no-double-counting of strikethrough, mid-text `~~strikethrough~~` not being a skip marker, `[SKIP]` staying unsupported, `__str__`, and the checker refusing to pass a `done` task whose remaining criteria are skipped.

Full suite: **433 passed** (`NO_COLOR=1 TERM=dumb pytest packages/gptodo/tests/`).

## Related

Sibling implementation in Bob's `metaproductivity.tasks` (bob master `7f0a1bf2b9`, `82da07cd23`) parses the same three forms with the same denominator rule, plus a pre-commit validator that rejects a skipped box with no stated reason. The two parsers anchor differently (`^- ` vs unanchored) and live in different repos, so they are intentionally not shared; both docstrings cross-reference each other.
