### PR TITLE
feat(gptme-rag): add OpenRouter embeddings backend

### DIFF
--- a/packages/gptme-rag/README.md
+++ b/packages/gptme-rag/README.md
@@ -11,7 +11,7 @@ This is the **vector search** complement to [`gptme-wisdom`](https://github.com/
 ## Features
 
 - 📚 Document indexing with ChromaDB (vector storage, semantic search, persistence)
-- 🔍 Semantic search with sentence-transformers embeddings
+- 🔍 Semantic search with sentence-transformers or OpenRouter API embeddings
 - 📄 Smart document processing (streaming, chunking, reconstruction)
 - 👀 File watching and auto-indexing
 - 🔌 MCP server for agent integration (`gptme-rag mcp`)
@@ -23,12 +23,20 @@ This is the **vector search** complement to [`gptme-wisdom`](https://github.com/
 # Index your documents
 gptme-rag index /path/to/documents
 
+# Index with API embeddings instead of local CPU embeddings
+OPENROUTER_API_KEY=... gptme-rag index /path/to/documents --embedding-function openrouter
+
 # Search with semantic relevance
 gptme-rag search "your query"
 
 # Start MCP server (for agent tool integration)
 gptme-rag mcp --persist-dir /path/to/index
 ```
+
+OpenRouter embedding model defaults to `openai/text-embedding-3-large` and can be
+overridden with `OPENROUTER_EMBEDDING_MODEL`. If `--embedding-function
+openrouter` is requested without an API key, `gptme-rag` falls back to the local
+ModernBERT embedding backend.
 
 ## Development
 

--- a/packages/gptme-rag/src/gptme_rag/cli.py
+++ b/packages/gptme-rag/src/gptme_rag/cli.py
@@ -16,7 +16,6 @@ from rich.syntax import Syntax
 from tqdm import tqdm
 
 from .benchmark import RagBenchmark
-from .embeddings import ModernBERTEmbedding
 from .indexing.document import Document
 from .indexing.indexer import Indexer
 from .indexing.watcher import FileWatcher
@@ -27,6 +26,7 @@ logger = logging.getLogger(__name__)
 
 # TODO: change this to a more appropriate location
 default_persist_dir = Path.home() / ".cache" / "gptme" / "rag"
+EMBEDDING_FUNCTION_CHOICES = ["modernbert", "minilm", "mpnet", "openrouter", "default"]
 
 
 class ChunkMerger:
@@ -159,9 +159,9 @@ def cli(verbose: bool):
 )
 @click.option(
     "--embedding-function",
-    type=click.Choice(["modernbert", "default"]),
+    type=click.Choice(EMBEDDING_FUNCTION_CHOICES),
     default="modernbert",
-    help="Embedding function to use (modernbert or default)",
+    help="Embedding function to use",
 )
 @click.option(
     "--device",
@@ -346,8 +346,8 @@ def index(
 )
 @click.option(
     "--embedding-function",
-    type=click.Choice(["modernbert", "default"]),
-    help="Embedding function to use (modernbert or default)",
+    type=click.Choice(EMBEDDING_FUNCTION_CHOICES),
+    help="Embedding function to use",
 )
 @click.option(
     "--device",
@@ -693,8 +693,8 @@ def search(
 )
 @click.option(
     "--embedding-function",
-    type=click.Choice(["modernbert", "default"]),
-    help="Embedding function to use (modernbert or default)",
+    type=click.Choice(EMBEDDING_FUNCTION_CHOICES),
+    help="Embedding function to use",
 )
 @click.option(
     "--device",
@@ -831,15 +831,7 @@ def status():
         console.print(f"Chunk Size: [blue]{status['config']['chunk_size']:,}[/blue] tokens")
         console.print(f"Chunk Overlap: [blue]{status['config']['chunk_overlap']:,}[/blue] tokens")
         if "embedding_model" in status["config"]:
-            model_name = status["config"]["embedding_model"]
-            if model_name == "ModernBERT":
-                # Get more specific model info from the indexer
-                if isinstance(indexer.embedding_function, ModernBERTEmbedding):
-                    if indexer.embedding_function.is_msmarco:
-                        model_name = "ModernBERT-msmarco (optimized for retrieval)"
-                    else:
-                        model_name = "ModernBERT-base (general purpose)"
-            console.print(f"Embedding Model: [blue]{model_name}[/blue]")
+            console.print(f"Embedding Model: [blue]{status['config']['embedding_model']}[/blue]")
 
     except Exception as e:
         console.print(f"❌ Error getting index status: {e}", style="red")

--- a/packages/gptme-rag/src/gptme_rag/cli.py
+++ b/packages/gptme-rag/src/gptme_rag/cli.py
@@ -424,14 +424,11 @@ def search(
             try:
                 with contextlib.redirect_stdout(devnull), stderr_ctx:
                     # Initialize indexer with explicit arguments
-                    # Always use ModernBERT by default for better results
                     indexer = Indexer(
                         persist_directory=persist_dir,
                         enable_persist=True,
                         scoring_weights=scoring_weights,
-                        embedding_function=(
-                            "modernbert" if embedding_function is None else embedding_function
-                        ),
+                        embedding_function=embedding_function or "auto",
                         device=device or "cpu",
                     )
                     assembler = ContextAssembler(max_tokens=max_tokens)
@@ -729,7 +726,7 @@ def watch(
         indexer = Indexer(
             persist_directory=persist_dir,
             enable_persist=True,
-            embedding_function=("modernbert" if embedding_function is None else embedding_function),
+            embedding_function=embedding_function or "auto",
             device=device or "cpu",
             chunk_size=chunk_size,  # Now optional in Indexer
             chunk_overlap=chunk_overlap,  # Now optional in Indexer

--- a/packages/gptme-rag/src/gptme_rag/cli.py
+++ b/packages/gptme-rag/src/gptme_rag/cli.py
@@ -423,13 +423,18 @@ def search(
             )
             try:
                 with contextlib.redirect_stdout(devnull), stderr_ctx:
-                    # Initialize indexer with explicit arguments
+                    # Initialize indexer with explicit arguments.
+                    # allow_recreate=False: search is read-only — passing an explicit
+                    # --embedding-function that differs from the stored model must never
+                    # silently delete the collection (data loss). A warning is emitted
+                    # instead and the existing collection is kept unchanged.
                     indexer = Indexer(
                         persist_directory=persist_dir,
                         enable_persist=True,
                         scoring_weights=scoring_weights,
                         embedding_function=embedding_function or "auto",
                         device=device or "cpu",
+                        allow_recreate=False,
                     )
                     assembler = ContextAssembler(max_tokens=max_tokens)
 

--- a/packages/gptme-rag/src/gptme_rag/cli.py
+++ b/packages/gptme-rag/src/gptme_rag/cli.py
@@ -29,6 +29,16 @@ default_persist_dir = Path.home() / ".cache" / "gptme" / "rag"
 EMBEDDING_FUNCTION_CHOICES = ["auto", "modernbert", "minilm", "mpnet", "openrouter", "default"]
 
 
+class _JsonWarningCaptureHandler(logging.Handler):
+    def __init__(self, messages: list[str]):
+        super().__init__(level=logging.WARNING)
+        self.messages = messages
+        self.setFormatter(logging.Formatter("%(message)s"))
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.messages.append(self.format(record))
+
+
 class ChunkMerger:
     @staticmethod
     def find_best_overlap(text1: str, text2: str) -> int:
@@ -391,6 +401,10 @@ def search(
     # In json mode: skip Rich status (avoids stream mixing that pollutes json output)
     # and redirect stderr too (suppresses model-loading progress bars like "Loading weights").
     status_ctx = contextlib.nullcontext() if output_json else console.status("Initializing...")
+    captured_warnings: list[str] = []
+    warning_handler = _JsonWarningCaptureHandler(captured_warnings) if output_json else None
+    if warning_handler is not None:
+        logging.getLogger().addHandler(warning_handler)
     with status_ctx:
         # Parse custom weights if provided
         scoring_weights = None
@@ -417,78 +431,88 @@ def search(
         # removed), which would corrupt JSON output for callers.
         # In non-json mode, keep stderr visible so callers can diagnose
         # partial failures (missing model, fallback used, etc.).
-        with open(os.devnull, "w") as devnull:
-            stderr_ctx = (
-                contextlib.redirect_stderr(devnull) if output_json else contextlib.nullcontext()
-            )
-            try:
-                with contextlib.redirect_stdout(devnull), stderr_ctx:
-                    # Initialize indexer with explicit arguments.
-                    # allow_recreate=False: search is read-only — passing an explicit
-                    # --embedding-function that differs from the stored model must never
-                    # silently delete the collection (data loss). A warning is emitted
-                    # instead and the existing collection is kept unchanged.
-                    indexer = Indexer(
-                        persist_directory=persist_dir,
-                        enable_persist=True,
-                        scoring_weights=scoring_weights,
-                        embedding_function=embedding_function or "auto",
-                        device=device or "cpu",
-                        allow_recreate=False,
-                    )
-                    assembler = ContextAssembler(max_tokens=max_tokens)
-
-                    # Combine paths and filters for search
-                    search_paths = list(paths)
-                    if filter:
-                        # If no paths were specified but filters are present,
-                        # search from root and apply filters
-                        if not paths:
-                            search_paths = [Path(".")]
-                        logger.debug(f"Using path filters: {filter}")
-
-                    explanations: list | None = None
-                    if explain:
-                        documents, distances, explanations = indexer.search(
-                            query,
-                            n_results=n_results,
-                            paths=search_paths,
-                            path_filters=filter,
-                            explain=True,
+        try:
+            with open(os.devnull, "w") as devnull:
+                stderr_ctx = (
+                    contextlib.redirect_stderr(devnull) if output_json else contextlib.nullcontext()
+                )
+                try:
+                    with contextlib.redirect_stdout(devnull), stderr_ctx:
+                        # Initialize indexer with explicit arguments.
+                        # allow_recreate=False: search is read-only — passing an explicit
+                        # --embedding-function that differs from the stored model must never
+                        # silently delete the collection (data loss). A warning is emitted
+                        # instead and the existing collection is kept unchanged.
+                        indexer = Indexer(
+                            persist_directory=persist_dir,
+                            enable_persist=True,
+                            scoring_weights=scoring_weights,
+                            embedding_function=embedding_function or "auto",
+                            device=device or "cpu",
+                            allow_recreate=False,
                         )
-                    else:
-                        documents, distances, _ = indexer.search(
-                            query, n_results=n_results, paths=search_paths, path_filters=filter
-                        )
+                        assembler = ContextAssembler(max_tokens=max_tokens)
 
-                    # Assemble context window (must be inside try/except to catch errors in json mode)
-                    if documents:
-                        context = assembler.assemble_context(documents, user_query=query)
-                    else:
-                        context = None
-            except Exception as e:
-                # In json mode stderr is redirected to /dev/null, so an unhandled
-                # exception would produce a silent failure with no output on stdout
-                # and no traceback visible.  Emit a JSON error object so callers
-                # get a diagnosable response instead of empty stdout + non-zero exit.
-                if output_json:
-                    print(json.dumps({"error": str(e), "query": query}))
-                raise
+                        # Combine paths and filters for search
+                        search_paths = list(paths)
+                        if filter:
+                            # If no paths were specified but filters are present,
+                            # search from root and apply filters
+                            if not paths:
+                                search_paths = [Path(".")]
+                            logger.debug(f"Using path filters: {filter}")
+
+                        explanations: list | None = None
+                        if explain:
+                            documents, distances, explanations = indexer.search(
+                                query,
+                                n_results=n_results,
+                                paths=search_paths,
+                                path_filters=filter,
+                                explain=True,
+                            )
+                        else:
+                            documents, distances, _ = indexer.search(
+                                query, n_results=n_results, paths=search_paths, path_filters=filter
+                            )
+
+                        # Assemble context window (must be inside try/except to catch errors in json mode)
+                        if documents:
+                            context = assembler.assemble_context(documents, user_query=query)
+                        else:
+                            context = None
+                except Exception as e:
+                    # In json mode stderr is redirected to /dev/null, so an unhandled
+                    # exception would produce a silent failure with no output on stdout
+                    # and no traceback visible.  Emit a JSON error object so callers
+                    # get a diagnosable response instead of empty stdout + non-zero exit.
+                    if output_json:
+                        error_output: dict[str, object] = {"error": str(e), "query": query}
+                        if captured_warnings:
+                            error_output["warnings"] = captured_warnings
+                        print(json.dumps(error_output))
+                    raise
+        finally:
+            if warning_handler is not None:
+                logging.getLogger().removeHandler(warning_handler)
 
     if not documents:
         if output_json:
+            empty_output: dict[str, object] = {
+                "query": query,
+                "results": [],
+                "total_results": 0,
+                "context": {
+                    "total_tokens": 0,
+                    "truncated": False,
+                    "results_in_context": 0,
+                },
+            }
+            if captured_warnings:
+                empty_output["warnings"] = captured_warnings
             print(
                 json.dumps(
-                    {
-                        "query": query,
-                        "results": [],
-                        "total_results": 0,
-                        "context": {
-                            "total_tokens": 0,
-                            "truncated": False,
-                            "results_in_context": 0,
-                        },
-                    },
+                    empty_output,
                     indent=2,
                 )
             )
@@ -595,7 +619,7 @@ def search(
             if expand == "none"
             else False
         )
-        output = {
+        output: dict[str, object] = {
             "query": query,
             "total_results": len(results),
             "results": results,
@@ -605,6 +629,8 @@ def search(
                 "results_in_context": results_in_context,
             },
         }
+        if captured_warnings:
+            output["warnings"] = captured_warnings
         print(json.dumps(output, indent=2, default=str))
         return
 

--- a/packages/gptme-rag/src/gptme_rag/cli.py
+++ b/packages/gptme-rag/src/gptme_rag/cli.py
@@ -727,7 +727,12 @@ def watch(
 ):
     """Watch directory for changes and update index automatically."""
     try:
-        # Initialize indexer with explicit arguments
+        # Initialize indexer with explicit arguments.
+        # allow_recreate=False when an explicit embedding function is given:
+        # watch is a long-running daemon — silently deleting the entire collection
+        # because the stored model differs from the requested model would cause
+        # permanent data loss. A warning is emitted instead and the existing
+        # collection is kept unchanged, matching the protection already in search.
         indexer = Indexer(
             persist_directory=persist_dir,
             enable_persist=True,
@@ -735,6 +740,7 @@ def watch(
             device=device or "cpu",
             chunk_size=chunk_size,  # Now optional in Indexer
             chunk_overlap=chunk_overlap,  # Now optional in Indexer
+            allow_recreate=embedding_function is None or embedding_function == "auto",
         )
 
         # Initial indexing

--- a/packages/gptme-rag/src/gptme_rag/cli.py
+++ b/packages/gptme-rag/src/gptme_rag/cli.py
@@ -778,7 +778,11 @@ def watch(
                 # If the embedding function is mismatched and the stored model failed to load,
                 # log a warning and skip indexing. The watcher will still run and can ingest
                 # changes once a compatible embedding function is provided.
-                if "Cannot add documents" in str(e) or "stored model" in str(e):
+                if (
+                    "Cannot add documents" in str(e)
+                    or "Cannot index directory" in str(e)
+                    or "stored embedding model" in str(e)
+                ):
                     console.print(f"⚠️  Warning: {e}", style="yellow")
                     console.print(
                         "Continuing to watch for changes, but indexing is skipped until a compatible "

--- a/packages/gptme-rag/src/gptme_rag/cli.py
+++ b/packages/gptme-rag/src/gptme_rag/cli.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # TODO: change this to a more appropriate location
 default_persist_dir = Path.home() / ".cache" / "gptme" / "rag"
-EMBEDDING_FUNCTION_CHOICES = ["modernbert", "minilm", "mpnet", "openrouter", "default"]
+EMBEDDING_FUNCTION_CHOICES = ["auto", "modernbert", "minilm", "mpnet", "openrouter", "default"]
 
 
 class ChunkMerger:
@@ -160,8 +160,8 @@ def cli(verbose: bool):
 @click.option(
     "--embedding-function",
     type=click.Choice(EMBEDDING_FUNCTION_CHOICES),
-    default="modernbert",
-    help="Embedding function to use",
+    default="auto",
+    help="Embedding function to use. 'auto' (default) preserves the embedding model of an existing collection.",
 )
 @click.option(
     "--device",
@@ -202,7 +202,7 @@ def index(
         return
 
     try:
-        if embedding_function and not force_recreate:
+        if embedding_function and embedding_function != "auto" and not force_recreate:
             console.print(
                 "[yellow]Warning:[/yellow] Changing embedding model may require recreating the collection. "
                 "Use --force-recreate if you encounter dimension mismatch errors.",

--- a/packages/gptme-rag/src/gptme_rag/cli.py
+++ b/packages/gptme-rag/src/gptme_rag/cli.py
@@ -772,7 +772,21 @@ def watch(
         # Initial indexing
         console.print(f"Performing initial indexing of {directory}")
         with console.status("Indexing..."):
-            indexer.index_directory(directory, pattern)
+            try:
+                indexer.index_directory(directory, pattern)
+            except RuntimeError as e:
+                # If the embedding function is mismatched and the stored model failed to load,
+                # log a warning and skip indexing. The watcher will still run and can ingest
+                # changes once a compatible embedding function is provided.
+                if "Cannot add documents" in str(e) or "stored model" in str(e):
+                    console.print(f"⚠️  Warning: {e}", style="yellow")
+                    console.print(
+                        "Continuing to watch for changes, but indexing is skipped until a compatible "
+                        "embedding function is provided.",
+                        style="yellow",
+                    )
+                else:
+                    raise
 
         console.print("Starting file watcher...")
 

--- a/packages/gptme-rag/src/gptme_rag/embeddings.py
+++ b/packages/gptme-rag/src/gptme_rag/embeddings.py
@@ -76,9 +76,10 @@ def _default_openrouter_cache_path() -> Path:
 class _SQLiteEmbeddingCache:
     """Small SQLite cache keyed by embedding model and content hash.
 
-    Bounded by ``max_rows``: when the table exceeds that count after an insert
-    batch, the oldest entries (by ``accessed_at``) are pruned to keep the file
-    from growing without bound.
+    Bounded by ``max_rows``: before each insert batch, the oldest entries (by
+    ``accessed_at``) are pruned to make room so that freshly inserted rows are
+    never evicted.  If the batch itself exceeds ``max_rows``, it is truncated to
+    the last ``max_rows`` items before the prune/insert step.
     """
 
     DEFAULT_MAX_ROWS = 100_000  # ~3-4 GB at 3072-dim float32; safe default
@@ -132,24 +133,31 @@ class _SQLiteEmbeddingCache:
     def put_many(self, model: str, items: list[tuple[str, list[float]]]) -> None:
         if not items:
             return
+        # If the batch itself exceeds max_rows, keep only the last max_rows items.
+        if len(items) > self.max_rows:
+            items = items[-self.max_rows :]
 
         now = "strftime('%Y-%m-%dT%H:%M:%fZ', 'now')"
         with self.lock:
-            self.conn.executemany(
-                f"INSERT OR REPLACE INTO embeddings "
-                f"(model, content_hash, embedding_json, accessed_at) VALUES (?, ?, ?, ({now}))",
-                [(model, content_hash, json.dumps(vector)) for content_hash, vector in items],
-            )
-            # Prune oldest entries when we exceed the row cap.
+            # Prune BEFORE inserting so freshly inserted rows always survive.
+            # All rows in an executemany batch get the same accessed_at timestamp,
+            # so a post-insert prune has no tiebreaker and can arbitrarily evict
+            # just-inserted entries.  Pre-emptively free (len(items)) slots instead.
             row_count = self.conn.execute("SELECT COUNT(*) FROM embeddings").fetchone()[0]
-            if row_count > self.max_rows:
-                excess = row_count - self.max_rows
+            target = self.max_rows - len(items)
+            if row_count > target:
+                excess = row_count - target
                 self.conn.execute(
                     "DELETE FROM embeddings WHERE (model, content_hash) IN ("
                     "  SELECT model, content_hash FROM embeddings ORDER BY accessed_at ASC LIMIT ?"
                     ")",
                     (excess,),
                 )
+            self.conn.executemany(
+                f"INSERT OR REPLACE INTO embeddings "
+                f"(model, content_hash, embedding_json, accessed_at) VALUES (?, ?, ?, ({now}))",
+                [(model, content_hash, json.dumps(vector)) for content_hash, vector in items],
+            )
             self.conn.commit()
 
 

--- a/packages/gptme-rag/src/gptme_rag/embeddings.py
+++ b/packages/gptme-rag/src/gptme_rag/embeddings.py
@@ -74,20 +74,36 @@ def _default_openrouter_cache_path() -> Path:
 
 
 class _SQLiteEmbeddingCache:
-    """Small SQLite cache keyed by embedding model and content hash."""
+    """Small SQLite cache keyed by embedding model and content hash.
 
-    def __init__(self, path: Path):
+    Bounded by ``max_rows``: when the table exceeds that count after an insert
+    batch, the oldest entries (by ``accessed_at``) are pruned to keep the file
+    from growing without bound.
+    """
+
+    DEFAULT_MAX_ROWS = 100_000  # ~3-4 GB at 3072-dim float32; safe default
+
+    def __init__(self, path: Path, max_rows: int = DEFAULT_MAX_ROWS):
         path = path.expanduser()
         path.parent.mkdir(parents=True, exist_ok=True)
+        self.max_rows = max_rows
         self.conn = sqlite3.connect(str(path), check_same_thread=False)
         self.conn.execute(
             "CREATE TABLE IF NOT EXISTS embeddings ("
             "model TEXT NOT NULL, "
             "content_hash TEXT NOT NULL, "
             "embedding_json TEXT NOT NULL, "
+            "accessed_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')), "
             "PRIMARY KEY (model, content_hash)"
             ")"
         )
+        # Migrate existing caches that lack the accessed_at column.
+        try:
+            self.conn.execute(
+                "ALTER TABLE embeddings ADD COLUMN accessed_at TEXT NOT NULL DEFAULT '2000-01-01T00:00:00.000Z'"
+            )
+        except sqlite3.OperationalError:
+            pass  # Column already exists
         self.conn.commit()
         self.lock = threading.Lock()
 
@@ -117,12 +133,23 @@ class _SQLiteEmbeddingCache:
         if not items:
             return
 
+        now = "strftime('%Y-%m-%dT%H:%M:%fZ', 'now')"
         with self.lock:
             self.conn.executemany(
-                "INSERT OR REPLACE INTO embeddings "
-                "(model, content_hash, embedding_json) VALUES (?, ?, ?)",
+                f"INSERT OR REPLACE INTO embeddings "
+                f"(model, content_hash, embedding_json, accessed_at) VALUES (?, ?, ?, ({now}))",
                 [(model, content_hash, json.dumps(vector)) for content_hash, vector in items],
             )
+            # Prune oldest entries when we exceed the row cap.
+            row_count = self.conn.execute("SELECT COUNT(*) FROM embeddings").fetchone()[0]
+            if row_count > self.max_rows:
+                excess = row_count - self.max_rows
+                self.conn.execute(
+                    "DELETE FROM embeddings WHERE (model, content_hash) IN ("
+                    "  SELECT model, content_hash FROM embeddings ORDER BY accessed_at ASC LIMIT ?"
+                    ")",
+                    (excess,),
+                )
             self.conn.commit()
 
 

--- a/packages/gptme-rag/src/gptme_rag/embeddings.py
+++ b/packages/gptme-rag/src/gptme_rag/embeddings.py
@@ -200,6 +200,12 @@ class OpenRouterEmbedding(EmbeddingFunction):
 
         for idx, text in items:
             token_count = self._approx_tokens(text)
+            if token_count > self.max_tokens_per_request:
+                raise ValueError(
+                    f"Text at index {idx} is too large (~{token_count} tokens) for the OpenRouter "
+                    f"embeddings API (max {self.max_tokens_per_request} tokens per request). "
+                    f"Reduce --chunk-size to avoid this error."
+                )
             if current and (
                 len(current) >= self.max_inputs_per_request
                 or current_tokens + token_count > self.max_tokens_per_request

--- a/packages/gptme-rag/src/gptme_rag/embeddings.py
+++ b/packages/gptme-rag/src/gptme_rag/embeddings.py
@@ -240,6 +240,11 @@ class OpenRouterEmbedding(EmbeddingFunction):
                     raise RuntimeError(f"OpenRouter embeddings error: {data['error']}")
 
                 rows = sorted(data["data"], key=lambda row: row["index"])
+                if len(rows) != len(texts):
+                    raise RuntimeError(
+                        f"OpenRouter embeddings API returned {len(rows)} vectors for "
+                        f"{len(texts)} input texts — malformed or partial response."
+                    )
                 usage = data.get("usage") or {}
                 self.stats["requests"] += 1
                 self.stats["api_texts"] += len(texts)
@@ -253,6 +258,10 @@ class OpenRouterEmbedding(EmbeddingFunction):
                     raise RuntimeError(f"OpenRouter embeddings HTTP {exc.code}: {body}") from exc
                 logger.warning("OpenRouter embeddings HTTP %s; retrying", exc.code)
                 time.sleep(min(60, 2**attempt) + 0.5 * attempt)
+            except RuntimeError:
+                # RuntimeErrors are permanent (e.g. bad model name, API-level error,
+                # or count mismatch above) — do not retry.
+                raise
             except Exception as exc:
                 last_error = exc
                 logger.warning("OpenRouter embeddings request failed; retrying: %r", exc)

--- a/packages/gptme-rag/src/gptme_rag/embeddings.py
+++ b/packages/gptme-rag/src/gptme_rag/embeddings.py
@@ -226,7 +226,7 @@ class OpenRouterEmbedding(EmbeddingFunction):
 
     @staticmethod
     def _approx_tokens(text: str) -> int:
-        return max(1, len(text) // 3)
+        return max(1, len(text) // 2)
 
     def _make_batches(self, items: list[tuple[int, str]]) -> list[list[tuple[int, str]]]:
         batches: list[list[tuple[int, str]]] = []

--- a/packages/gptme-rag/src/gptme_rag/embeddings.py
+++ b/packages/gptme-rag/src/gptme_rag/embeddings.py
@@ -1,5 +1,24 @@
+import hashlib
+import json
+import logging
+import math
+import os
+import sqlite3
+import threading
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
 from chromadb.api.types import Documents, EmbeddingFunction
 from sentence_transformers import SentenceTransformer
+
+logger = logging.getLogger(__name__)
+
+OPENROUTER_EMBEDDINGS_ENDPOINT = "https://openrouter.ai/api/v1/embeddings"
+DEFAULT_OPENROUTER_EMBEDDING_MODEL = "openai/text-embedding-3-large"
+DEFAULT_OPENROUTER_MAX_INPUTS_PER_REQUEST = 64
+DEFAULT_OPENROUTER_MAX_TOKENS_PER_REQUEST = 24_000
 
 
 class ModernBERTEmbedding(EmbeddingFunction):
@@ -42,6 +61,205 @@ class ModernBERTEmbedding(EmbeddingFunction):
             normalize_embeddings=True,  # Normalize for cosine similarity
         ).tolist()
         return embeddings
+
+
+def resolve_openrouter_api_key() -> str | None:
+    """Return an OpenRouter API key from the environment, if configured."""
+    return os.environ.get("OPENROUTER_API_KEY") or os.environ.get("OPENROUTER_API_KEY_EVAL")
+
+
+def _default_openrouter_cache_path() -> Path:
+    cache_root = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
+    return cache_root / "gptme-rag" / "openrouter-embeddings.sqlite"
+
+
+class _SQLiteEmbeddingCache:
+    """Small SQLite cache keyed by embedding model and content hash."""
+
+    def __init__(self, path: Path):
+        path = path.expanduser()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self.conn = sqlite3.connect(str(path), check_same_thread=False)
+        self.conn.execute(
+            "CREATE TABLE IF NOT EXISTS embeddings ("
+            "model TEXT NOT NULL, "
+            "content_hash TEXT NOT NULL, "
+            "embedding_json TEXT NOT NULL, "
+            "PRIMARY KEY (model, content_hash)"
+            ")"
+        )
+        self.conn.commit()
+        self.lock = threading.Lock()
+
+    @staticmethod
+    def content_hash(text: str) -> str:
+        return hashlib.sha256(text.encode("utf-8", "replace")).hexdigest()
+
+    def get_many(self, model: str, hashes: list[str]) -> dict[str, list[float]]:
+        if not hashes:
+            return {}
+
+        found: dict[str, list[float]] = {}
+        with self.lock:
+            for offset in range(0, len(hashes), 500):
+                chunk = list(dict.fromkeys(hashes[offset : offset + 500]))
+                placeholders = ",".join("?" for _ in chunk)
+                rows = self.conn.execute(
+                    "SELECT content_hash, embedding_json FROM embeddings "
+                    f"WHERE model = ? AND content_hash IN ({placeholders})",
+                    [model, *chunk],
+                ).fetchall()
+                for content_hash, embedding_json in rows:
+                    found[content_hash] = json.loads(embedding_json)
+        return found
+
+    def put_many(self, model: str, items: list[tuple[str, list[float]]]) -> None:
+        if not items:
+            return
+
+        with self.lock:
+            self.conn.executemany(
+                "INSERT OR REPLACE INTO embeddings "
+                "(model, content_hash, embedding_json) VALUES (?, ?, ?)",
+                [(model, content_hash, json.dumps(vector)) for content_hash, vector in items],
+            )
+            self.conn.commit()
+
+
+class OpenRouterEmbedding(EmbeddingFunction):
+    """ChromaDB embedding function backed by OpenRouter's embeddings API."""
+
+    is_msmarco = False
+
+    def __init__(
+        self,
+        model_name: str | None = None,
+        api_key: str | None = None,
+        cache_path: Path | None = None,
+        max_inputs_per_request: int = DEFAULT_OPENROUTER_MAX_INPUTS_PER_REQUEST,
+        max_tokens_per_request: int = DEFAULT_OPENROUTER_MAX_TOKENS_PER_REQUEST,
+    ):
+        self.model_name = (
+            model_name
+            or os.environ.get("OPENROUTER_EMBEDDING_MODEL")
+            or DEFAULT_OPENROUTER_EMBEDDING_MODEL
+        )
+        self.api_key = api_key or resolve_openrouter_api_key()
+        if not self.api_key:
+            raise ValueError(
+                "OpenRouter embeddings require OPENROUTER_API_KEY; "
+                "Indexer falls back to local embeddings when no key is configured"
+            )
+        self.cache = _SQLiteEmbeddingCache(cache_path or _default_openrouter_cache_path())
+        self.max_inputs_per_request = max_inputs_per_request
+        self.max_tokens_per_request = max_tokens_per_request
+        self.stats = {
+            "requests": 0,
+            "api_texts": 0,
+            "cached_texts": 0,
+            "tokens": 0,
+            "cost": 0.0,
+        }
+
+    @staticmethod
+    def name() -> str:
+        """Return a stable ChromaDB embedding-function name."""
+        return "openrouter"
+
+    def __call__(self, input: Documents) -> list[list[float]]:  # type: ignore[override]
+        """Generate embeddings for the input texts."""
+        texts = [text if text.strip() else " " for text in input]
+        if not texts:
+            return []
+
+        hashes = [_SQLiteEmbeddingCache.content_hash(text) for text in texts]
+        cached = self.cache.get_many(self.model_name, list(dict.fromkeys(hashes)))
+        self.stats["cached_texts"] += sum(1 for content_hash in hashes if content_hash in cached)
+
+        missing = [
+            (i, texts[i]) for i, content_hash in enumerate(hashes) if content_hash not in cached
+        ]
+        fresh: list[tuple[str, list[float]]] = []
+        for batch in self._make_batches(missing):
+            vectors = self._embed_batch([text for _i, text in batch])
+            for (idx, _text), vector in zip(batch, vectors):
+                cached[hashes[idx]] = vector
+                fresh.append((hashes[idx], vector))
+
+        self.cache.put_many(self.model_name, fresh)
+        return [cached[content_hash] for content_hash in hashes]
+
+    @staticmethod
+    def _approx_tokens(text: str) -> int:
+        return max(1, len(text) // 3)
+
+    def _make_batches(self, items: list[tuple[int, str]]) -> list[list[tuple[int, str]]]:
+        batches: list[list[tuple[int, str]]] = []
+        current: list[tuple[int, str]] = []
+        current_tokens = 0
+
+        for idx, text in items:
+            token_count = self._approx_tokens(text)
+            if current and (
+                len(current) >= self.max_inputs_per_request
+                or current_tokens + token_count > self.max_tokens_per_request
+            ):
+                batches.append(current)
+                current = []
+                current_tokens = 0
+            current.append((idx, text))
+            current_tokens += token_count
+
+        if current:
+            batches.append(current)
+        return batches
+
+    def _embed_batch(self, texts: list[str]) -> list[list[float]]:
+        payload = json.dumps({"model": self.model_name, "input": texts}).encode("utf-8")
+        last_error: Exception | None = None
+
+        for attempt in range(6):
+            request = urllib.request.Request(
+                OPENROUTER_EMBEDDINGS_ENDPOINT,
+                data=payload,
+                headers={
+                    "Authorization": f"Bearer {self.api_key}",
+                    "Content-Type": "application/json",
+                },
+            )
+            try:
+                with urllib.request.urlopen(request, timeout=180) as response:
+                    data = json.loads(response.read())
+                if "error" in data:
+                    raise RuntimeError(f"OpenRouter embeddings error: {data['error']}")
+
+                rows = sorted(data["data"], key=lambda row: row["index"])
+                usage = data.get("usage") or {}
+                self.stats["requests"] += 1
+                self.stats["api_texts"] += len(texts)
+                self.stats["tokens"] += int(usage.get("total_tokens") or 0)
+                self.stats["cost"] += float(usage.get("cost") or 0.0)
+                return [_l2_normalize(row["embedding"]) for row in rows]
+            except urllib.error.HTTPError as exc:
+                last_error = exc
+                body = exc.read()[:300].decode("utf-8", "replace")
+                if exc.code not in (408, 429, 500, 502, 503, 504):
+                    raise RuntimeError(f"OpenRouter embeddings HTTP {exc.code}: {body}") from exc
+                logger.warning("OpenRouter embeddings HTTP %s; retrying", exc.code)
+                time.sleep(min(60, 2**attempt) + 0.5 * attempt)
+            except Exception as exc:
+                last_error = exc
+                logger.warning("OpenRouter embeddings request failed; retrying: %r", exc)
+                time.sleep(min(60, 2**attempt))
+
+        raise RuntimeError(f"OpenRouter embeddings failed after retries: {last_error!r}")
+
+
+def _l2_normalize(vector: list[float]) -> list[float]:
+    norm = math.sqrt(sum(value * value for value in vector))
+    if norm == 0:
+        return vector
+    return [value / norm for value in vector]
 
 
 class GenericSentenceTransformerEmbedding(EmbeddingFunction):

--- a/packages/gptme-rag/src/gptme_rag/embeddings.py
+++ b/packages/gptme-rag/src/gptme_rag/embeddings.py
@@ -245,6 +245,13 @@ class OpenRouterEmbedding(EmbeddingFunction):
                         f"OpenRouter embeddings API returned {len(rows)} vectors for "
                         f"{len(texts)} input texts — malformed or partial response."
                     )
+                actual_indices = [row["index"] for row in rows]
+                if actual_indices != list(range(len(texts))):
+                    raise RuntimeError(
+                        f"OpenRouter embeddings API returned non-contiguous indices {actual_indices!r}; "
+                        f"expected {list(range(len(texts)))} — malformed response, embeddings "
+                        "would be assigned to the wrong texts."
+                    )
                 usage = data.get("usage") or {}
                 self.stats["requests"] += 1
                 self.stats["api_texts"] += len(texts)

--- a/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
@@ -519,6 +519,9 @@ class Indexer:
                 metadata=metadata,
                 embedding_function=self.embedding_function,
             )
+            # The unavailable model belonged to the collection we just replaced.
+            # Keep the guard only while preserving that old collection.
+            self._stored_model_name = None
 
         # Initialize cache with 5-minute TTL and 100MB memory limit
         self.cache = SmartRAGCache(ttl_seconds=300, max_memory_bytes=100 * 1024 * 1024)

--- a/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
@@ -192,7 +192,7 @@ class Indexer:
             try:
                 _auto_peeked_collection = self.client.get_collection(name=collection_name)
                 metadata = _auto_peeked_collection.metadata or {}
-                detected = metadata.get("embedding_model", "modernbert")
+                detected = metadata.get("embedding_model", "default")
                 detected_backend = metadata.get("embedding_backend")
 
                 if detected_backend == "modernbert" or detected == "modernbert":

--- a/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
@@ -16,10 +16,14 @@ from chromadb.api import ClientAPI
 from chromadb.config import Settings
 from chromadb.errors import NotFoundError
 
+from ..cache import SmartRAGCache, CacheKey, CacheEntry
+from ..embeddings import (
+    GenericSentenceTransformerEmbedding,
+    ModernBERTEmbedding,
+    OpenRouterEmbedding,
+)
 from .document import Document
 from .document_processor import DocumentProcessor
-from ..embeddings import ModernBERTEmbedding, GenericSentenceTransformerEmbedding
-from ..cache import SmartRAGCache, CacheKey, CacheEntry
 
 
 class ChromaDBFilter(Filter):
@@ -77,7 +81,9 @@ class Indexer:
     processor: DocumentProcessor
     is_persistent: bool = False
     persist_directory: Path | None
-    embedding_function: ModernBERTEmbedding | GenericSentenceTransformerEmbedding | None
+    embedding_function: (
+        ModernBERTEmbedding | GenericSentenceTransformerEmbedding | OpenRouterEmbedding | None
+    )
     cache: SmartRAGCache
 
     def __init__(
@@ -88,7 +94,7 @@ class Indexer:
         chunk_overlap: int | None = None,
         enable_persist: bool = False,  # Default to False due to multi-threading issues
         scoring_weights: dict | None = None,
-        embedding_function: str = "modernbert",  # Options: "modernbert", "minilm", "mpnet", "default"
+        embedding_function: str = "modernbert",
         device: str = "cpu",
         force_recreate: bool = False,  # Force recreation of collection
     ):
@@ -101,7 +107,8 @@ class Indexer:
             chunk_overlap: Overlap between chunks
             enable_persist: Whether to persist the index
             scoring_weights: Custom weights for scoring
-            embedding_function: Which embedding function to use ("modernbert" or "default")
+            embedding_function: Which embedding function to use
+                ("modernbert", "minilm", "mpnet", "openrouter", or "default")
             device: Device to run embeddings on ("cuda" or "cpu")
         """
         self.collection_name = collection_name
@@ -129,6 +136,17 @@ class Indexer:
             )
             default_chunk_size = 1000
             default_chunk_overlap = 200
+        elif embedding_function == "openrouter":
+            try:
+                self.embedding_function = OpenRouterEmbedding()
+            except ValueError:
+                logger.warning(
+                    "OpenRouter API key not configured; falling back to ModernBERT embeddings"
+                )
+                self.embedding_function = ModernBERTEmbedding(device=device)
+                if self.embedding_function.is_msmarco:
+                    default_chunk_size = 512
+                    default_chunk_overlap = 64
         else:
             self.embedding_function = None  # Use ChromaDB default
 
@@ -162,6 +180,8 @@ class Indexer:
             current_model = "modernbert"
         elif isinstance(self.embedding_function, GenericSentenceTransformerEmbedding):
             # Get the actual model name from GenericSentenceTransformerEmbedding
+            current_model = self.embedding_function.model_name
+        elif isinstance(self.embedding_function, OpenRouterEmbedding):
             current_model = self.embedding_function.model_name
         else:
             current_model = "default"
@@ -230,6 +250,8 @@ class Indexer:
         if isinstance(self.embedding_function, ModernBERTEmbedding):
             return "modernbert"
         elif isinstance(self.embedding_function, GenericSentenceTransformerEmbedding):
+            return self.embedding_function.model_name
+        elif isinstance(self.embedding_function, OpenRouterEmbedding):
             return self.embedding_function.model_name
         else:
             return "default"
@@ -758,7 +780,7 @@ class Indexer:
                     content="",
                     metadata=dict(meta),
                     doc_id="temp",
-                    source_path=source_path,  # type: ignore[arg-type]
+                    source_path=source_path,
                 )
 
                 # Use _matches_paths to check all patterns
@@ -1132,9 +1154,7 @@ class Indexer:
             "config": {
                 "chunk_size": self.processor.chunk_size,
                 "chunk_overlap": self.processor.chunk_overlap,
-                "embedding_model": "ModernBERT"
-                if isinstance(self.embedding_function, ModernBERTEmbedding)
-                else "default",
+                "embedding_model": self.embedding_model_name,
             },
         }
 

--- a/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
@@ -185,22 +185,39 @@ class Indexer:
         # Also hold onto the peeked collection so we don't call get_collection again with
         # a mismatched embedding function (newer chromadb raises on that conflict).
         _auto_peeked_collection = None
+        reuse_auto_peeked_collection = False
         if embedding_function == "auto":
             try:
                 _auto_peeked_collection = self.client.get_collection(name=collection_name)
-                detected = (_auto_peeked_collection.metadata or {}).get(
-                    "embedding_model", "modernbert"
-                )
-                if detected not in ("modernbert", "default", "unknown") and "/" in detected:
+                metadata = _auto_peeked_collection.metadata or {}
+                detected = metadata.get("embedding_model", "modernbert")
+                detected_backend = metadata.get("embedding_backend")
+
+                if detected_backend == "modernbert" or detected == "modernbert":
+                    self.embedding_function = ModernBERTEmbedding(device=device)
+                elif detected_backend == "sentence-transformers" or (
+                    detected not in ("modernbert", "default", "unknown") and "/" not in detected
+                ):
+                    self.embedding_function = GenericSentenceTransformerEmbedding(
+                        detected, device=device
+                    )
+                elif detected_backend == "openrouter" or (
+                    detected not in ("modernbert", "default", "unknown") and "/" in detected
+                ):
                     # The stored model is an OpenRouter model name (org/model format); re-init to match.
                     try:
                         self.embedding_function = OpenRouterEmbedding(model_name=detected)
                     except ValueError:
+                        reuse_auto_peeked_collection = True
+                        self.embedding_function = None
                         logger.warning(
                             "Stored index uses OpenRouter model %r but OPENROUTER_API_KEY is not set; "
-                            "falling back to ModernBERT (search quality may be degraded)",
+                            "preserving the existing collection without rebinding embeddings",
                             detected,
                         )
+                else:
+                    self.embedding_function = None
+                    reuse_auto_peeked_collection = True
             except Exception:
                 pass  # No existing collection; keep ModernBERT default
 
@@ -215,10 +232,10 @@ class Indexer:
         else:
             current_model = "default"
 
-        if _auto_peeked_collection is not None:
+        if _auto_peeked_collection is not None and reuse_auto_peeked_collection:
             # Reuse the no-embedding-function collection handle from auto-detect;
-            # calling get_collection again with a mismatched embedding_function raises
-            # a conflict error in newer chromadb versions.
+            # only safe when the stored collection itself uses ChromaDB defaults or
+            # when we deliberately preserve a foreign collection without rebinding.
             self.collection = _auto_peeked_collection
             if force_recreate:
                 need_recreate = True
@@ -241,9 +258,20 @@ class Indexer:
                     need_recreate = True
 
             except (ValueError, Exception) as e:
-                # Collection doesn't exist or other error
-                logger.debug(f"Collection access error: {e}")
-                need_recreate = True
+                if embedding_function == "auto" and _auto_peeked_collection is not None:
+                    logger.warning(
+                        "Auto mode could not rebind collection %r with the detected embedding "
+                        "function (%s); preserving the existing collection instead of recreating it: %s",
+                        collection_name,
+                        current_model,
+                        e,
+                    )
+                    self.collection = _auto_peeked_collection
+                    need_recreate = False
+                else:
+                    # Collection doesn't exist or other error
+                    logger.debug(f"Collection access error: {e}")
+                    need_recreate = True
 
         if need_recreate:
             # Delete if exists
@@ -253,7 +281,11 @@ class Indexer:
                 pass
 
             # Create new collection
-            metadata = {"hnsw:space": "cosine", "embedding_model": current_model}
+            metadata = {
+                "hnsw:space": "cosine",
+                "embedding_model": current_model,
+                "embedding_backend": self.embedding_backend_name,
+            }
             logger.info(f"Creating new collection with {current_model} embeddings")
             self.collection = self.client.create_collection(
                 name=collection_name,
@@ -290,6 +322,18 @@ class Indexer:
             return self.embedding_function.model_name
         elif isinstance(self.embedding_function, OpenRouterEmbedding):
             return self.embedding_function.model_name
+        else:
+            return "default"
+
+    @property
+    def embedding_backend_name(self) -> str:
+        """Get the backend class for the current embedding function."""
+        if isinstance(self.embedding_function, ModernBERTEmbedding):
+            return "modernbert"
+        elif isinstance(self.embedding_function, GenericSentenceTransformerEmbedding):
+            return "sentence-transformers"
+        elif isinstance(self.embedding_function, OpenRouterEmbedding):
+            return "openrouter"
         else:
             return "default"
 
@@ -334,6 +378,7 @@ class Indexer:
             metadata={
                 "hnsw:space": "cosine",
                 "embedding_model": self.embedding_model_name,
+                "embedding_backend": self.embedding_backend_name,
             },
             embedding_function=self.embedding_function,
         )

--- a/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
@@ -191,6 +191,12 @@ class Indexer:
         if embedding_function == "auto":
             try:
                 _auto_peeked_collection = self.client.get_collection(name=collection_name)
+            except Exception:
+                pass  # No existing collection; keep ModernBERT default
+            else:
+                # Collection exists — detect its backend and rebind the embedding function.
+                # This block intentionally propagates model-loading errors rather than
+                # silently falling back to ModernBERT (which would cause a dimension mismatch).
                 metadata = _auto_peeked_collection.metadata or {}
                 detected = metadata.get("embedding_model", "default")
                 detected_backend = metadata.get("embedding_backend")
@@ -200,9 +206,18 @@ class Indexer:
                 elif detected_backend == "sentence-transformers" or (
                     detected not in ("modernbert", "default", "unknown") and "/" not in detected
                 ):
-                    self.embedding_function = GenericSentenceTransformerEmbedding(
-                        detected, device=device
-                    )
+                    try:
+                        self.embedding_function = GenericSentenceTransformerEmbedding(
+                            detected, device=device
+                        )
+                    except Exception:
+                        reuse_auto_peeked_collection = True
+                        self.embedding_function = None
+                        logger.warning(
+                            "Stored index uses sentence-transformer model %r but it could not be "
+                            "loaded; preserving the existing collection without rebinding embeddings",
+                            detected,
+                        )
                 elif detected_backend == "openrouter" or (
                     detected not in ("modernbert", "default", "unknown") and "/" in detected
                 ):
@@ -220,8 +235,6 @@ class Indexer:
                 else:
                     self.embedding_function = None
                     reuse_auto_peeked_collection = True
-            except Exception:
-                pass  # No existing collection; keep ModernBERT default
 
         need_recreate = False
         if isinstance(self.embedding_function, ModernBERTEmbedding):

--- a/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
@@ -237,7 +237,9 @@ class Indexer:
                     reuse_auto_peeked_collection = True
 
         need_recreate = False
-        if isinstance(self.embedding_function, ModernBERTEmbedding):
+        if self.embedding_function is None:
+            current_model = "default"
+        elif isinstance(self.embedding_function, ModernBERTEmbedding):
             current_model = "modernbert"
         elif isinstance(self.embedding_function, GenericSentenceTransformerEmbedding):
             # Get the actual model name from GenericSentenceTransformerEmbedding

--- a/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
@@ -44,6 +44,8 @@ _SENTENCE_TRANSFORMER_NAMESPACES = frozenset(
         "mixedbread-ai/",  # e.g. mxbai-embed-large-v1
         "Alibaba-NLP/",  # e.g. gte-large-en-v1.5
         "hkunlp/",  # e.g. instructor-xl, instructor-base
+        "jinaai/",  # e.g. jina-embeddings-v2-base-en, jina-embeddings-v3
+        "nomic-ai/",  # e.g. nomic-embed-text-v1, nomic-embed-text-v1.5
     }
 )
 
@@ -564,6 +566,12 @@ class Indexer:
             yield len(batch)
 
     def _add_documents(self, documents: list[Document]) -> None:
+        if self._stored_model_name is not None:
+            raise RuntimeError(
+                f"Cannot add documents: the stored embedding model {self._stored_model_name!r} could "
+                "not be loaded (API key missing or model weights unavailable).  "
+                "Re-index with a model that is available, or provide the required credentials."
+            )
         try:
             contents = []
             metadatas = []

--- a/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
@@ -46,6 +46,11 @@ _SENTENCE_TRANSFORMER_NAMESPACES = frozenset(
         "hkunlp/",  # e.g. instructor-xl, instructor-base
         "jinaai/",  # e.g. jina-embeddings-v2-base-en, jina-embeddings-v3
         "nomic-ai/",  # e.g. nomic-embed-text-v1, nomic-embed-text-v1.5
+        "Snowflake/",  # e.g. snowflake-arctic-embed-l, snowflake-arctic-embed-m (capital S as on HF)
+        "Salesforce/",  # e.g. SFR-Embedding-Mistral, SFR-Embedding-2_R
+        "WhereIsAI/",  # e.g. UAE-Large-V1
+        "TaylorAI/",  # e.g. bge-micro-v2, gte-tiny
+        "princeton-nlp/",  # e.g. sup-simcse-roberta-large
     }
 )
 
@@ -714,6 +719,16 @@ class Indexer:
         if self.embedding_function is not None:
             query_embeddings = cast(QueryEmbeddings, self.embedding_function(["Lorem ipsum"]))
             search_results = self.collection.query(query_embeddings=query_embeddings, n_results=3)
+        elif self._stored_model_name is not None:
+            # The stored embedding model could not be re-loaded (missing API key / weights).
+            # Falling through to query_texts here would use ChromaDB's default 384-dim MiniLM,
+            # which mismatches stored vectors of a different dimension and produces a cryptic
+            # InvalidDimensionException.  Report the problem and skip the test search.
+            print(
+                f"  Skipping test search: stored embedding model {self._stored_model_name!r} "
+                "could not be loaded (API key missing or model weights unavailable)."
+            )
+            return
         else:
             search_results = self.collection.query(query_texts=["Lorem ipsum"], n_results=3)
         print("\nRaw search results:")

--- a/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
@@ -382,7 +382,7 @@ class Indexer:
                 try:
                     _peek = self.client.get_collection(name=collection_name)
                     _stored_for_guard = (_peek.metadata or {}).get("embedding_model", "unknown")
-                    if "/" in _stored_for_guard:
+                    if _looks_like_openrouter_model(_stored_for_guard):
                         raise ValueError(
                             f"OPENROUTER_API_KEY is not set, but collection {collection_name!r} "
                             f"was indexed with OpenRouter model {_stored_for_guard!r}. "
@@ -426,7 +426,11 @@ class Indexer:
                         self.embedding_function = None
                         self._stored_model_name = stored_model
                         need_recreate = False
-                    elif _openrouter_fallback and not force_recreate and "/" in stored_model:
+                    elif (
+                        _openrouter_fallback
+                        and not force_recreate
+                        and _looks_like_openrouter_model(stored_model)
+                    ):
                         # OPENROUTER_API_KEY is missing, so we fell back to ModernBERT,
                         # but the existing collection was indexed with an OpenRouter model.
                         # Silently recreating would destroy the user's data — raise a clear
@@ -818,6 +822,16 @@ class Indexer:
             {str(source) for doc in documents if (source := doc.metadata.get("source"))}
         )
         n_files = len(sources)
+
+        # Guard: if the stored embedding model could not be loaded, raise before
+        # deleting any documents — otherwise the delete succeeds but the subsequent
+        # add_documents call fails, leaving the index permanently empty.
+        if self._stored_model_name is not None:
+            raise RuntimeError(
+                f"Cannot index directory: the stored embedding model {self._stored_model_name!r} could "
+                "not be loaded (API key missing or model weights unavailable).  "
+                "Re-index with a model that is available, or provide the required credentials."
+            )
 
         for source in sources:
             self.delete_documents({"source": source})

--- a/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
@@ -188,9 +188,11 @@ class Indexer:
         if embedding_function == "auto":
             try:
                 _auto_peeked_collection = self.client.get_collection(name=collection_name)
-                detected = (_auto_peeked_collection.metadata or {}).get("embedding_model", "modernbert")
-                if detected not in ("modernbert", "default", "unknown"):
-                    # The stored model is an OpenRouter model name; re-init to match.
+                detected = (_auto_peeked_collection.metadata or {}).get(
+                    "embedding_model", "modernbert"
+                )
+                if detected not in ("modernbert", "default", "unknown") and "/" in detected:
+                    # The stored model is an OpenRouter model name (org/model format); re-init to match.
                     try:
                         self.embedding_function = OpenRouterEmbedding(model_name=detected)
                     except ValueError:

--- a/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
@@ -561,7 +561,12 @@ class Indexer:
 
         # Now do a test search
         print("\nTest search for 'Lorem ipsum':")
-        search_results = self.collection.query(query_texts=["Lorem ipsum"], n_results=3)
+        if self.embedding_function is not None:
+            search_results = self.collection.query(
+                query_embeddings=self.embedding_function(["Lorem ipsum"]), n_results=3
+            )
+        else:
+            search_results = self.collection.query(query_texts=["Lorem ipsum"], n_results=3)
         print("\nRaw search results:")
         print(f"IDs: {(search_results['ids'] or [[]])[0]}")
         print(f"Distances: {(search_results['distances'] or [[]])[0]}")
@@ -831,12 +836,26 @@ class Indexer:
                 logger.debug("No files matched the filter patterns")
                 return [], [], [] if explain else None
 
-        # Query the collection
-        results = self.collection.query(
-            query_texts=[query],
-            n_results=query_n_results,
-            where=search_where or None,  # chromadb 1.x rejects empty dict
-        )
+        # Query the collection.
+        # Always embed via self.embedding_function when available so the query
+        # dimension matches the stored vectors even when the collection handle
+        # was loaded without an embedding function (e.g. the auto-detect path
+        # loads via get_collection() with no ef to avoid chromadb conflicts;
+        # falling back to query_texts in that case lets chromadb use its default
+        # 384-dim MiniLM, which mismatches 768-dim ModernBERT stored vectors).
+        if self.embedding_function is not None:
+            query_embeddings = self.embedding_function([query])
+            results = self.collection.query(
+                query_embeddings=query_embeddings,
+                n_results=query_n_results,
+                where=search_where or None,  # chromadb 1.x rejects empty dict
+            )
+        else:
+            results = self.collection.query(
+                query_texts=[query],
+                n_results=query_n_results,
+                where=search_where or None,  # chromadb 1.x rejects empty dict
+            )
 
         result_ids = results["ids"] or [[]]
         result_docs = results["documents"] or [[]]

--- a/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
@@ -178,6 +178,12 @@ class Indexer:
         default_chunk_size = 1000
         default_chunk_overlap = 200
 
+        # Set to True when --embedding-function openrouter was requested but no API key
+        # is configured.  The fallback to ModernBERT is safe for fresh indexes, but must
+        # NOT silently destroy an existing collection that was indexed with OpenRouter.
+        # Initialized here so the mismatch guard below can safely reference it.
+        _openrouter_fallback = False
+
         # Initialize embedding function.
         # "auto" is fully deferred: we peek at the stored collection metadata below
         # (after client init) and rebind the right backend then.  We do NOT
@@ -211,6 +217,7 @@ class Indexer:
                 logger.warning(
                     "OpenRouter API key not configured; falling back to ModernBERT embeddings"
                 )
+                _openrouter_fallback = True
                 self.embedding_function = ModernBERTEmbedding(device=device)
                 if self.embedding_function.is_msmarco:
                     default_chunk_size = 512
@@ -365,6 +372,30 @@ class Indexer:
             if force_recreate:
                 need_recreate = True
         else:
+            # Pre-flight guard: when the OpenRouter key is missing and we fell back to
+            # ModernBERT, check whether an existing collection was indexed with an OpenRouter
+            # model BEFORE attempting to open it with ModernBERT.  The subsequent
+            # get_collection() call below would either raise on the EF conflict or silently
+            # set need_recreate=True — both paths can destroy the user's OpenRouter index.
+            # We peek here (no EF → no conflict) so we can raise a clear error instead.
+            if _openrouter_fallback and not force_recreate:
+                try:
+                    _peek = self.client.get_collection(name=collection_name)
+                    _stored_for_guard = (_peek.metadata or {}).get("embedding_model", "unknown")
+                    if "/" in _stored_for_guard:
+                        raise ValueError(
+                            f"OPENROUTER_API_KEY is not set, but collection {collection_name!r} "
+                            f"was indexed with OpenRouter model {_stored_for_guard!r}. "
+                            f"Set OPENROUTER_API_KEY and retry, or use --force-recreate to "
+                            f"rebuild the index with ModernBERT (this will delete the existing "
+                            f"OpenRouter index)."
+                        )
+                except ValueError:
+                    raise  # propagate our data-loss guard
+                except Exception:
+                    pass  # collection doesn't exist yet — creating fresh is safe
+
+            _guard_raised = False  # sentinel for re-raise of inner guard (belt+suspenders)
             try:
                 # Try to get existing collection
                 self.collection = self.client.get_collection(
@@ -395,6 +426,21 @@ class Indexer:
                         self.embedding_function = None
                         self._stored_model_name = stored_model
                         need_recreate = False
+                    elif _openrouter_fallback and not force_recreate and "/" in stored_model:
+                        # OPENROUTER_API_KEY is missing, so we fell back to ModernBERT,
+                        # but the existing collection was indexed with an OpenRouter model.
+                        # Silently recreating would destroy the user's data — raise a clear
+                        # error explaining what happened and how to resolve it.
+                        # Note: _guard_raised ensures the broad except below re-raises this
+                        # intentional error rather than treating it as a ChromaDB failure.
+                        _guard_raised = True
+                        raise ValueError(
+                            f"OPENROUTER_API_KEY is not set, but collection {collection_name!r} "
+                            f"was indexed with OpenRouter model {stored_model!r}. "
+                            f"Set OPENROUTER_API_KEY and retry, or use --force-recreate to "
+                            f"rebuild the index with ModernBERT (this will delete the existing "
+                            f"OpenRouter index)."
+                        )
                     else:
                         logger.info(
                             f"Model mismatch (stored: {stored_model}, current: {current_model}) or force recreate"
@@ -402,6 +448,10 @@ class Indexer:
                         need_recreate = True
 
             except (ValueError, Exception) as e:
+                if _guard_raised:
+                    # This is our intentional data-loss guard, not a ChromaDB failure —
+                    # propagate it without attempting collection creation.
+                    raise
                 if embedding_function == "auto" and _auto_peeked_collection is not None:
                     logger.warning(
                         "Auto mode could not rebind collection %r with the detected embedding "

--- a/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
@@ -94,7 +94,7 @@ class Indexer:
         chunk_overlap: int | None = None,
         enable_persist: bool = False,  # Default to False due to multi-threading issues
         scoring_weights: dict | None = None,
-        embedding_function: str = "modernbert",
+        embedding_function: str = "auto",
         device: str = "cpu",
         force_recreate: bool = False,  # Force recreation of collection
     ):
@@ -108,7 +108,10 @@ class Indexer:
             enable_persist: Whether to persist the index
             scoring_weights: Custom weights for scoring
             embedding_function: Which embedding function to use
-                ("modernbert", "minilm", "mpnet", "openrouter", or "default")
+                ("auto", "modernbert", "minilm", "mpnet", "openrouter", or "default").
+                "auto" (default) reads the stored model from an existing collection and
+                uses that, preventing silent data loss when a collection was indexed with
+                a different embedding model than the default.
             device: Device to run embeddings on ("cuda" or "cpu")
         """
         self.collection_name = collection_name
@@ -118,7 +121,8 @@ class Indexer:
         default_chunk_overlap = 200
 
         # Initialize embedding function
-        if embedding_function == "modernbert":
+        # "auto" is deferred until after client init (needs to peek at stored metadata)
+        if embedding_function in ("auto", "modernbert"):
             self.embedding_function = ModernBERTEmbedding(device=device)
             # Adjust defaults for msmarco model
             if self.embedding_function.is_msmarco:
@@ -175,6 +179,29 @@ class Indexer:
             self.persist_directory = None
             self.client = get_client(settings)
 
+        # Auto-detect stored embedding model to avoid silently destroying existing index.
+        # When no explicit embedding function is requested, peek at the stored metadata
+        # and re-initialize so the mismatch check below never triggers for read-only ops.
+        # Also hold onto the peeked collection so we don't call get_collection again with
+        # a mismatched embedding function (newer chromadb raises on that conflict).
+        _auto_peeked_collection = None
+        if embedding_function == "auto":
+            try:
+                _auto_peeked_collection = self.client.get_collection(name=collection_name)
+                detected = (_auto_peeked_collection.metadata or {}).get("embedding_model", "modernbert")
+                if detected not in ("modernbert", "default", "unknown"):
+                    # The stored model is an OpenRouter model name; re-init to match.
+                    try:
+                        self.embedding_function = OpenRouterEmbedding(model_name=detected)
+                    except ValueError:
+                        logger.warning(
+                            "Stored index uses OpenRouter model %r but OPENROUTER_API_KEY is not set; "
+                            "falling back to ModernBERT (search quality may be degraded)",
+                            detected,
+                        )
+            except Exception:
+                pass  # No existing collection; keep ModernBERT default
+
         need_recreate = False
         if isinstance(self.embedding_function, ModernBERTEmbedding):
             current_model = "modernbert"
@@ -186,27 +213,35 @@ class Indexer:
         else:
             current_model = "default"
 
-        try:
-            # Try to get existing collection
-            self.collection = self.client.get_collection(
-                name=collection_name,
-                embedding_function=self.embedding_function,  # Important: Use current embedding function
-            )
-
-            # Check if we need to recreate
-            metadata = self.collection.metadata or {}
-            stored_model = metadata.get("embedding_model", "unknown")
-
-            if stored_model != current_model or force_recreate:
-                logger.info(
-                    f"Model mismatch (stored: {stored_model}, current: {current_model}) or force recreate"
-                )
+        if _auto_peeked_collection is not None:
+            # Reuse the no-embedding-function collection handle from auto-detect;
+            # calling get_collection again with a mismatched embedding_function raises
+            # a conflict error in newer chromadb versions.
+            self.collection = _auto_peeked_collection
+            if force_recreate:
                 need_recreate = True
+        else:
+            try:
+                # Try to get existing collection
+                self.collection = self.client.get_collection(
+                    name=collection_name,
+                    embedding_function=self.embedding_function,  # Important: Use current embedding function
+                )
 
-        except (ValueError, Exception) as e:
-            # Collection doesn't exist or other error
-            logger.debug(f"Collection access error: {e}")
-            need_recreate = True
+                # Check if we need to recreate
+                metadata = self.collection.metadata or {}
+                stored_model = metadata.get("embedding_model", "unknown")
+
+                if stored_model != current_model or force_recreate:
+                    logger.info(
+                        f"Model mismatch (stored: {stored_model}, current: {current_model}) or force recreate"
+                    )
+                    need_recreate = True
+
+            except (ValueError, Exception) as e:
+                # Collection doesn't exist or other error
+                logger.debug(f"Collection access error: {e}")
+                need_recreate = True
 
         if need_recreate:
             # Delete if exists

--- a/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
@@ -26,6 +26,26 @@ from .document import Document
 from .document_processor import DocumentProcessor
 
 
+# HuggingFace namespaces that are used for sentence-transformer models.
+# Model names in these namespaces contain a slash but are NOT OpenRouter model names.
+# Only "sentence-transformers/" is included here; other ST-compatible HF namespaces
+# (BAAI/, thenlper/, intfloat/) would also have embedding_backend metadata when
+# indexed with this PR's updated code, so they don't need the fallback heuristic.
+_SENTENCE_TRANSFORMER_NAMESPACES = frozenset({"sentence-transformers/"})
+
+
+def _looks_like_openrouter_model(model_name: str) -> bool:
+    """Heuristic: OpenRouter model names follow 'org/model' format.
+
+    Returns False for known sentence-transformer HuggingFace namespaces so that
+    legacy collections (without embedding_backend metadata) are not misrouted to
+    the OpenRouter backend when their stored model name contains a slash.
+    """
+    if "/" not in model_name:
+        return False
+    return not any(model_name.startswith(ns) for ns in _SENTENCE_TRANSFORMER_NAMESPACES)
+
+
 class ChromaDBFilter(Filter):
     """Filter out expected ChromaDB warnings about existing IDs."""
 
@@ -117,19 +137,30 @@ class Indexer:
             device: Device to run embeddings on ("cuda" or "cpu")
         """
         self.collection_name = collection_name
+        # Populated by auto-detect when the stored model cannot be re-loaded
+        # (API key absent for OpenRouter, weights missing for sentence-transformers).
+        # Kept separate from embedding_function so None stays unambiguous:
+        # None+_stored_model_name=None => chroma-default; None+_stored_model_name=X => load failed.
+        self._stored_model_name: str | None = None
 
         # Set default chunk sizes based on model type
         default_chunk_size = 1000
         default_chunk_overlap = 200
 
-        # Initialize embedding function
-        # "auto" is deferred until after client init (needs to peek at stored metadata)
-        if embedding_function in ("auto", "modernbert"):
+        # Initialize embedding function.
+        # "auto" is fully deferred: we peek at the stored collection metadata below
+        # (after client init) and rebind the right backend then.  We do NOT
+        # load ModernBERT here for "auto" because the collection may not need it
+        # (e.g. it was indexed with OpenRouter), and SentenceTransformer loads a
+        # ~80 MB model on construction — wasted and potentially broken offline.
+        if embedding_function == "modernbert":
             self.embedding_function = ModernBERTEmbedding(device=device)
             # Adjust defaults for msmarco model
             if self.embedding_function.is_msmarco:
                 default_chunk_size = 512
                 default_chunk_overlap = 64
+        elif embedding_function == "auto":
+            self.embedding_function = None  # set in auto-detect block below
         elif embedding_function == "minilm":
             self.embedding_function = GenericSentenceTransformerEmbedding(
                 "all-MiniLM-L6-v2", device=device
@@ -192,7 +223,13 @@ class Indexer:
             try:
                 _auto_peeked_collection = self.client.get_collection(name=collection_name)
             except Exception:
-                pass  # No existing collection; keep ModernBERT default
+                # No existing collection — fall back to ModernBERT for new index creation.
+                # Only happens here (deferred from the eager-init block above) so that
+                # status/search/watch on non-ModernBERT collections never load the model.
+                self.embedding_function = ModernBERTEmbedding(device=device)
+                if self.embedding_function.is_msmarco and chunk_size is None:
+                    self.chunk_size = 512
+                    self.chunk_overlap = 64 if chunk_overlap is None else self.chunk_overlap
             else:
                 # Collection exists — detect its backend and rebind the embedding function.
                 # This block intentionally propagates model-loading errors rather than
@@ -203,8 +240,13 @@ class Indexer:
 
                 if detected_backend == "modernbert" or detected == "modernbert":
                     self.embedding_function = ModernBERTEmbedding(device=device)
+                    if self.embedding_function.is_msmarco and chunk_size is None:
+                        self.chunk_size = 512
+                        self.chunk_overlap = 64 if chunk_overlap is None else self.chunk_overlap
                 elif detected_backend == "sentence-transformers" or (
-                    detected not in ("modernbert", "default", "unknown") and "/" not in detected
+                    detected_backend is None
+                    and detected not in ("modernbert", "default", "unknown")
+                    and not _looks_like_openrouter_model(detected)
                 ):
                     try:
                         self.embedding_function = GenericSentenceTransformerEmbedding(
@@ -213,13 +255,16 @@ class Indexer:
                     except Exception:
                         reuse_auto_peeked_collection = True
                         self.embedding_function = None
+                        self._stored_model_name = detected
                         logger.warning(
                             "Stored index uses sentence-transformer model %r but it could not be "
                             "loaded; preserving the existing collection without rebinding embeddings",
                             detected,
                         )
                 elif detected_backend == "openrouter" or (
-                    detected not in ("modernbert", "default", "unknown") and "/" in detected
+                    detected_backend is None
+                    and detected not in ("modernbert", "default", "unknown")
+                    and _looks_like_openrouter_model(detected)
                 ):
                     # The stored model is an OpenRouter model name (org/model format); re-init to match.
                     try:
@@ -227,6 +272,7 @@ class Indexer:
                     except ValueError:
                         reuse_auto_peeked_collection = True
                         self.embedding_function = None
+                        self._stored_model_name = detected
                         logger.warning(
                             "Stored index uses OpenRouter model %r but OPENROUTER_API_KEY is not set; "
                             "preserving the existing collection without rebinding embeddings",
@@ -332,13 +378,22 @@ class Indexer:
 
     @property
     def embedding_model_name(self) -> str:
-        """Get the name of the current embedding model."""
+        """Get the name of the current embedding model.
+
+        When auto-detect preserved a collection whose embedder could not be re-loaded
+        (API key absent, weights missing), embedding_function is None but
+        _stored_model_name records what the collection actually uses.  Return that
+        stored name so status and cache-key reflect reality instead of "default".
+        """
         if isinstance(self.embedding_function, ModernBERTEmbedding):
             return "modernbert"
         elif isinstance(self.embedding_function, GenericSentenceTransformerEmbedding):
             return self.embedding_function.model_name
         elif isinstance(self.embedding_function, OpenRouterEmbedding):
             return self.embedding_function.model_name
+        elif self._stored_model_name is not None:
+            # Load failed; report the actual stored model, not "default".
+            return self._stored_model_name
         else:
             return "default"
 
@@ -904,12 +959,26 @@ class Indexer:
         # loads via get_collection() with no ef to avoid chromadb conflicts;
         # falling back to query_texts in that case lets chromadb use its default
         # 384-dim MiniLM, which mismatches 768-dim ModernBERT stored vectors).
+        #
+        # When _stored_model_name is set, embedding_function is None because the
+        # stored model could not be re-loaded (missing API key / weights).  In
+        # that case we must NOT fall through to query_texts: ChromaDB would embed
+        # with its default MiniLM (384-dim) against stored vectors of a different
+        # dimension (e.g. 3072 for OpenRouter or 768 for sentence-transformers),
+        # producing a cryptic dimension-mismatch error.  Raise early with a clear
+        # message instead.
         if self.embedding_function is not None:
             query_embeddings = cast(QueryEmbeddings, self.embedding_function([query]))
             results = self.collection.query(
                 query_embeddings=query_embeddings,
                 n_results=query_n_results,
                 where=search_where or None,  # chromadb 1.x rejects empty dict
+            )
+        elif self._stored_model_name is not None:
+            raise RuntimeError(
+                f"Cannot search: the stored embedding model {self._stored_model_name!r} could "
+                "not be loaded (API key missing or model weights unavailable).  "
+                "Re-index with a model that is available, or provide the required credentials."
             )
         else:
             results = self.collection.query(

--- a/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
@@ -388,6 +388,12 @@ class Indexer:
                             current_model,
                         )
                         self.collection = self.client.get_collection(name=collection_name)
+                        # Null out the mismatched embedding function so search() does not
+                        # use it and produce a cryptic ChromaDB InvalidDimensionException.
+                        # Setting _stored_model_name routes search() to the existing
+                        # clear-error path ("cannot search: stored model could not be loaded").
+                        self.embedding_function = None
+                        self._stored_model_name = stored_model
                         need_recreate = False
                     else:
                         logger.info(
@@ -425,6 +431,15 @@ class Indexer:
                         # Collection truly doesn't exist yet — create it normally.
                         need_recreate = True
                     else:
+                        # Null out the mismatched embedding function so search() does not
+                        # use it and produce a cryptic ChromaDB InvalidDimensionException.
+                        # Read the stored model name from metadata so search() can raise a
+                        # clear RuntimeError instead.
+                        _meta = self.collection.metadata or {}
+                        _stored = _meta.get("embedding_model")
+                        self.embedding_function = None
+                        if _stored:
+                            self._stored_model_name = _stored
                         need_recreate = False
                 else:
                     # Collection doesn't exist or other error

--- a/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
@@ -3,12 +3,12 @@ import json
 import logging
 import subprocess
 import time
-from collections.abc import Generator
+from collections.abc import Generator, Sequence
 from datetime import datetime
 from fnmatch import fnmatch as fnmatch_path
 from logging import Filter
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import chromadb
 from chromadb import Collection
@@ -48,6 +48,8 @@ for logger_name in [
 
 
 logger = logging.getLogger(__name__)
+
+QueryEmbeddings = list[Sequence[float]]
 
 
 def get_client(settings: Settings | None = None) -> ClientAPI:
@@ -607,9 +609,8 @@ class Indexer:
         # Now do a test search
         print("\nTest search for 'Lorem ipsum':")
         if self.embedding_function is not None:
-            search_results = self.collection.query(
-                query_embeddings=self.embedding_function(["Lorem ipsum"]), n_results=3
-            )
+            query_embeddings = cast(QueryEmbeddings, self.embedding_function(["Lorem ipsum"]))
+            search_results = self.collection.query(query_embeddings=query_embeddings, n_results=3)
         else:
             search_results = self.collection.query(query_texts=["Lorem ipsum"], n_results=3)
         print("\nRaw search results:")
@@ -889,7 +890,7 @@ class Indexer:
         # falling back to query_texts in that case lets chromadb use its default
         # 384-dim MiniLM, which mismatches 768-dim ModernBERT stored vectors).
         if self.embedding_function is not None:
-            query_embeddings = self.embedding_function([query])
+            query_embeddings = cast(QueryEmbeddings, self.embedding_function([query]))
             results = self.collection.query(
                 query_embeddings=query_embeddings,
                 n_results=query_n_results,

--- a/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
@@ -491,6 +491,12 @@ class Indexer:
 
     def add_document(self, document: Document) -> None:
         """Add a single document to the index."""
+        if self._stored_model_name is not None:
+            raise RuntimeError(
+                f"Cannot add documents: the stored embedding model {self._stored_model_name!r} could "
+                "not be loaded (API key missing or model weights unavailable).  "
+                "Re-index with a model that is available, or provide the required credentials."
+            )
         document = self._generate_doc_id(document)
         assert document.doc_id is not None
 

--- a/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
@@ -145,6 +145,7 @@ class Indexer:
         embedding_function: str = "auto",
         device: str = "cpu",
         force_recreate: bool = False,  # Force recreation of collection
+        allow_recreate: bool = True,  # If False, never delete an existing collection (safe for read-only commands)
     ):
         """Initialize the indexer.
 
@@ -161,6 +162,10 @@ class Indexer:
                 uses that, preventing silent data loss when a collection was indexed with
                 a different embedding model than the default.
             device: Device to run embeddings on ("cuda" or "cpu")
+            allow_recreate: Whether the indexer is allowed to delete and recreate the
+                collection on a model mismatch. Set to False for read-only commands
+                (search, status) to prevent accidental data loss when an explicit
+                --embedding-function differs from the stored model.
         """
         self.collection_name = collection_name
         # Populated by auto-detect when the stored model cannot be re-loaded
@@ -265,10 +270,19 @@ class Indexer:
                 detected_backend = metadata.get("embedding_backend")
 
                 if detected_backend == "modernbert" or detected == "modernbert":
-                    self.embedding_function = ModernBERTEmbedding(device=device)
-                    if self.embedding_function.is_msmarco and chunk_size is None:
-                        self.chunk_size = 512
-                        self.chunk_overlap = 64 if chunk_overlap is None else self.chunk_overlap
+                    try:
+                        self.embedding_function = ModernBERTEmbedding(device=device)
+                        if self.embedding_function.is_msmarco and chunk_size is None:
+                            self.chunk_size = 512
+                            self.chunk_overlap = 64 if chunk_overlap is None else self.chunk_overlap
+                    except Exception:
+                        reuse_auto_peeked_collection = True
+                        self.embedding_function = None
+                        self._stored_model_name = "modernbert"
+                        logger.warning(
+                            "Stored index uses ModernBERT model but it could not be loaded; "
+                            "preserving the existing collection without rebinding embeddings"
+                        )
                 elif detected_backend == "sentence-transformers" or (
                     detected_backend is None
                     and detected not in ("modernbert", "default", "unknown")
@@ -293,17 +307,39 @@ class Indexer:
                     and _looks_like_openrouter_model(detected)
                 ):
                     # The stored model is an OpenRouter model name (org/model format); re-init to match.
-                    try:
-                        self.embedding_function = OpenRouterEmbedding(model_name=detected)
-                    except ValueError:
-                        reuse_auto_peeked_collection = True
-                        self.embedding_function = None
-                        self._stored_model_name = detected
-                        logger.warning(
-                            "Stored index uses OpenRouter model %r but OPENROUTER_API_KEY is not set; "
-                            "preserving the existing collection without rebinding embeddings",
-                            detected,
-                        )
+                    #
+                    # For legacy collections (detected_backend is None), the heuristic
+                    # _looks_like_openrouter_model() can misfire on HuggingFace models whose
+                    # namespace is not in _SENTENCE_TRANSFORMER_NAMESPACES (e.g. joe32140/...).
+                    # To be conservative, attempt to load such models as a sentence-transformer
+                    # first; only fall through to the OpenRouter path if ST fails.
+                    # When detected_backend is "openrouter" (explicit metadata), skip ST.
+                    _loaded_via_st = False
+                    if detected_backend is None:
+                        try:
+                            self.embedding_function = GenericSentenceTransformerEmbedding(
+                                detected, device=device
+                            )
+                            _loaded_via_st = True
+                            logger.debug(
+                                "Legacy collection: loaded %r as sentence-transformer "
+                                "(heuristic initially suggested OpenRouter)",
+                                detected,
+                            )
+                        except Exception:
+                            pass  # ST failed; fall through to OpenRouter below
+                    if not _loaded_via_st:
+                        try:
+                            self.embedding_function = OpenRouterEmbedding(model_name=detected)
+                        except ValueError:
+                            reuse_auto_peeked_collection = True
+                            self.embedding_function = None
+                            self._stored_model_name = detected
+                            logger.warning(
+                                "Stored index uses OpenRouter model %r but OPENROUTER_API_KEY is not set; "
+                                "preserving the existing collection without rebinding embeddings",
+                                detected,
+                            )
                 else:
                     self.embedding_function = None
                     reuse_auto_peeked_collection = True
@@ -341,10 +377,23 @@ class Indexer:
                 stored_model = metadata.get("embedding_model", "unknown")
 
                 if stored_model != current_model or force_recreate:
-                    logger.info(
-                        f"Model mismatch (stored: {stored_model}, current: {current_model}) or force recreate"
-                    )
-                    need_recreate = True
+                    if not allow_recreate and not force_recreate:
+                        # Read-only callers (search, status) must never wipe the index.
+                        # Warn loudly and keep the existing collection as-is.
+                        logger.warning(
+                            "Embedding model mismatch (stored: %r, requested: %r) but recreation "
+                            "is disabled for this command; using the existing collection unchanged. "
+                            "Re-index with --force-recreate to switch models.",
+                            stored_model,
+                            current_model,
+                        )
+                        self.collection = self.client.get_collection(name=collection_name)
+                        need_recreate = False
+                    else:
+                        logger.info(
+                            f"Model mismatch (stored: {stored_model}, current: {current_model}) or force recreate"
+                        )
+                        need_recreate = True
 
             except (ValueError, Exception) as e:
                 if embedding_function == "auto" and _auto_peeked_collection is not None:
@@ -357,6 +406,26 @@ class Indexer:
                     )
                     self.collection = _auto_peeked_collection
                     need_recreate = False
+                elif not allow_recreate:
+                    # Read-only callers (search, status) must never wipe the index.
+                    # ChromaDB raised because of an EF conflict — try to get the
+                    # collection without binding an EF (metadata-only handle) and
+                    # keep it unchanged.
+                    logger.warning(
+                        "Collection %r could not be opened with the requested embedding "
+                        "function (%r); recreation disabled — reusing existing collection "
+                        "unchanged (re-index with --force-recreate to switch models). Error: %s",
+                        collection_name,
+                        current_model,
+                        e,
+                    )
+                    try:
+                        self.collection = self.client.get_collection(name=collection_name)
+                    except Exception:
+                        # Collection truly doesn't exist yet — create it normally.
+                        need_recreate = True
+                    else:
+                        need_recreate = False
                 else:
                     # Collection doesn't exist or other error
                     logger.debug(f"Collection access error: {e}")

--- a/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
+++ b/packages/gptme-rag/src/gptme_rag/indexing/indexer.py
@@ -26,20 +26,39 @@ from .document import Document
 from .document_processor import DocumentProcessor
 
 
-# HuggingFace namespaces that are used for sentence-transformer models.
+# HuggingFace namespaces used for sentence-transformer / embedding models.
 # Model names in these namespaces contain a slash but are NOT OpenRouter model names.
-# Only "sentence-transformers/" is included here; other ST-compatible HF namespaces
-# (BAAI/, thenlper/, intfloat/) would also have embedding_backend metadata when
-# indexed with this PR's updated code, so they don't need the fallback heuristic.
-_SENTENCE_TRANSFORMER_NAMESPACES = frozenset({"sentence-transformers/"})
+# Used by _looks_like_openrouter_model() as a fallback heuristic for legacy
+# collections that were indexed before the embedding_backend metadata field was
+# introduced (all new collections carry that field and bypass this heuristic).
+#
+# Includes the most common HF embedding model families so that legacy collections
+# with BAAI/bge-*, intfloat/e5-*, thenlper/gte-*, etc. are not misrouted to the
+# OpenRouter backend when OPENROUTER_API_KEY happens to be set.
+_SENTENCE_TRANSFORMER_NAMESPACES = frozenset(
+    {
+        "sentence-transformers/",  # e.g. all-MiniLM-L6-v2, paraphrase-multilingual-*
+        "BAAI/",  # e.g. bge-large-en-v1.5, bge-m3
+        "intfloat/",  # e.g. e5-large-v2, multilingual-e5-large
+        "thenlper/",  # e.g. gte-base, gte-large
+        "mixedbread-ai/",  # e.g. mxbai-embed-large-v1
+        "Alibaba-NLP/",  # e.g. gte-large-en-v1.5
+        "hkunlp/",  # e.g. instructor-xl, instructor-base
+    }
+)
 
 
 def _looks_like_openrouter_model(model_name: str) -> bool:
     """Heuristic: OpenRouter model names follow 'org/model' format.
 
-    Returns False for known sentence-transformer HuggingFace namespaces so that
-    legacy collections (without embedding_backend metadata) are not misrouted to
-    the OpenRouter backend when their stored model name contains a slash.
+    Returns False for known sentence-transformer / HuggingFace embedding namespaces
+    so that legacy collections (without embedding_backend metadata) are not misrouted
+    to the OpenRouter backend when their stored model name contains a slash.
+
+    This heuristic is only exercised for legacy collections (pre-PR code) that
+    lack the ``embedding_backend`` metadata field. New collections set that field
+    on every index run, so the auto-detect path picks the correct backend without
+    needing this heuristic.
     """
     if "/" not in model_name:
         return False

--- a/packages/gptme-rag/src/gptme_rag/mcp_server.py
+++ b/packages/gptme-rag/src/gptme_rag/mcp_server.py
@@ -48,8 +48,7 @@ def build_server(persist_dir: Path | None = None) -> Any:
         from mcp.server.fastmcp import FastMCP
     except ImportError as e:  # pragma: no cover - exercised only when extra missing
         raise ImportError(
-            "MCP server requires the optional `mcp` extra. "
-            "Install with: pip install gptme-rag[mcp]"
+            "MCP server requires the optional `mcp` extra. Install with: pip install gptme-rag[mcp]"
         ) from e
 
     from gptme_rag.indexing.indexer import Indexer

--- a/packages/gptme-rag/tests/test_cli_search.py
+++ b/packages/gptme-rag/tests/test_cli_search.py
@@ -1,6 +1,7 @@
 """Tests for the CLI search command, focusing on --json flag."""
 
 import json
+import logging
 import subprocess
 import sys
 
@@ -517,3 +518,48 @@ def test_search_json_emits_error_object_on_assemble_context_failure(tmp_path):
     assert "error" in data, f"Expected 'error' key in JSON output, got: {data}"
     assert "assembler index error" in data["error"]
     assert data.get("query") == "test query"
+
+
+def test_search_json_surfaces_warning_only_degraded_path(tmp_path):
+    """Warnings emitted inside the json-mode redirect block are kept in JSON output."""
+    from unittest.mock import Mock, patch as mock_patch
+
+    fake_doc = Document(content="hello world", metadata={"source": "test.txt"}, doc_id="doc1")
+
+    mock_indexer = Mock()
+    mock_indexer.search.return_value = ([fake_doc], [0.1], None)
+
+    assembled = Mock()
+    assembled.documents = [fake_doc]
+    assembled.truncated = False
+    mock_assembler = Mock()
+    mock_assembler.assemble_context.return_value = assembled
+    mock_assembler.count_tokens.return_value = 2
+
+    def make_indexer(*args, **kwargs):
+        logging.getLogger("gptme_rag.indexing.indexer").warning(
+            "Embedding model mismatch; continuing with stored embedding function"
+        )
+        return mock_indexer
+
+    runner = CliRunner()
+    with (
+        mock_patch("gptme_rag.cli.Indexer", side_effect=make_indexer),
+        mock_patch("gptme_rag.cli.ContextAssembler", return_value=mock_assembler),
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "search",
+                "test query",
+                "--persist-dir",
+                str(tmp_path / "index"),
+                "--json",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output.strip())
+    assert data["warnings"] == [
+        "Embedding model mismatch; continuing with stored embedding function"
+    ]

--- a/packages/gptme-rag/tests/test_force_recreate.py
+++ b/packages/gptme-rag/tests/test_force_recreate.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+import pytest
+
+from gptme_rag.indexing.indexer import Indexer
+
+
+def test_force_recreate_clears_unavailable_stored_model_guard(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    """Force-recreating an unavailable auto-detected model permits indexing again."""
+    import chromadb
+    from chromadb.config import Settings
+
+    persist_dir = tmp_path / "index"
+    persist_dir.mkdir()
+    doc_dir = tmp_path / "docs"
+    doc_dir.mkdir()
+    (doc_dir / "test.txt").write_text("hello world")
+
+    settings = Settings(allow_reset=True, is_persistent=True, anonymized_telemetry=False)
+    client = chromadb.PersistentClient(path=str(persist_dir), settings=settings)
+    client.create_collection(
+        name="default",
+        metadata={
+            "hnsw:space": "cosine",
+            "embedding_model": "openai/text-embedding-3-large",
+            "embedding_backend": "openrouter",
+        },
+    )
+    del client
+
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY_EVAL", raising=False)
+    indexer = Indexer(
+        persist_directory=persist_dir,
+        enable_persist=True,
+        embedding_function="auto",
+        collection_name="default",
+        force_recreate=True,
+    )
+
+    assert indexer._stored_model_name is None
+    assert indexer.index_directory(doc_dir) == 1

--- a/packages/gptme-rag/tests/test_indexing.py
+++ b/packages/gptme-rag/tests/test_indexing.py
@@ -772,3 +772,97 @@ def test_auto_mode_add_document_raises_clear_error_when_stored_model_failed(tmp_
     finally:
         if env_backup is not None:
             os.environ["OPENROUTER_API_KEY"] = env_backup
+
+
+def test_auto_mode_rebinds_openrouter_collection_when_api_key_present(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    """auto mode must construct OpenRouterEmbedding and successfully search when
+    an API key is available and the stored collection uses the openrouter backend.
+
+    This is the key-present path — the counterpart to
+    test_auto_mode_search_raises_clear_error_when_openrouter_key_absent.
+    A regression in model-name threading or metadata handling in the auto-detect
+    path would go undetected without this test.
+    """
+    import json
+    import urllib.request
+
+    import chromadb
+    from chromadb.config import Settings
+
+    from gptme_rag.embeddings import OpenRouterEmbedding
+
+    persist_dir = tmp_path / "index"
+    persist_dir.mkdir()
+
+    # Simulate a collection indexed with OpenRouter (3072-dim vectors).
+    settings = Settings(allow_reset=True, is_persistent=True, anonymized_telemetry=False)
+    client = chromadb.PersistentClient(path=str(persist_dir), settings=settings)
+    stored_model = "openai/text-embedding-3-large"
+    col = client.create_collection(
+        name="default",
+        metadata={
+            "hnsw:space": "cosine",
+            "embedding_model": stored_model,
+            "embedding_backend": "openrouter",
+        },
+    )
+    col.add(
+        ids=["or-doc"],
+        embeddings=[[0.1] * 3072],
+        documents=["an openrouter-indexed document"],
+    )
+    assert col.count() == 1
+    del client
+
+    # Fake HTTP layer so no real API call is made.
+    class _FakeResponse:
+        def __init__(self, payload: dict):
+            self._payload = payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps(self._payload).encode("utf-8")
+
+    def fake_urlopen(request: urllib.request.Request, timeout: int):
+        payload = json.loads(request.data.decode("utf-8"))  # type: ignore[union-attr]
+        return _FakeResponse(
+            {
+                "data": [
+                    {"index": i, "embedding": [0.1] * 3072} for i in range(len(payload["input"]))
+                ],
+                "usage": {"total_tokens": 10, "cost": 0.001},
+            }
+        )
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+    indexer = Indexer(
+        persist_directory=persist_dir,
+        enable_persist=True,
+        embedding_function="auto",
+        collection_name="default",
+    )
+
+    # The auto-detect path must have constructed an OpenRouterEmbedding, not fallen
+    # back to a local embedder or left embedding_function=None.
+    assert isinstance(
+        indexer.embedding_function, OpenRouterEmbedding
+    ), f"Expected OpenRouterEmbedding, got {type(indexer.embedding_function)}"
+
+    # The rebind must have used the stored model name, not the default.
+    assert indexer.embedding_function.model_name == stored_model  # type: ignore[union-attr]
+
+    # The stored collection is preserved.
+    assert indexer.collection.count() == 1
+
+    # search() must succeed (return results) without raising.
+    results = indexer.search("test query", n_results=1)
+    assert len(results) >= 1, "Expected at least one search result"

--- a/packages/gptme-rag/tests/test_indexing.py
+++ b/packages/gptme-rag/tests/test_indexing.py
@@ -473,10 +473,13 @@ def test_auto_embedding_mode_preserves_collection_when_sentence_transformer_fail
     del client
 
     # Simulate a model-load failure (e.g., missing download or corrupt weights).
-    def _raise(*args, **kwargs):
-        raise RuntimeError("Model weights not found")
+    # Must be a class (not a plain function) so isinstance() checks in the indexer
+    # receive a valid type and return False rather than raising TypeError.
+    class _Raise:
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError("Model weights not found")
 
-    monkeypatch.setattr(indexer_module, "GenericSentenceTransformerEmbedding", _raise)
+    monkeypatch.setattr(indexer_module, "GenericSentenceTransformerEmbedding", _Raise)
 
     # Opening with auto mode must NOT crash or delete the collection.
     indexer = Indexer(
@@ -490,9 +493,170 @@ def test_auto_embedding_mode_preserves_collection_when_sentence_transformer_fail
     ), "auto mode deleted sentence-transformer collection when the model failed to load"
 
 
+def test_auto_embedding_mode_sentence_transformer_namespace_not_misrouted_to_openrouter(tmp_path):
+    """Auto mode must not route 'sentence-transformers/<model>' to the OpenRouter backend.
+
+    Regression test for P1 bug: the slash heuristic used 'org/model' as a signal
+    for OpenRouter model names.  Legacy collections indexed with a model from the
+    'sentence-transformers/' HuggingFace namespace (e.g. paraphrase-MiniLM-L6-v2)
+    have a '/' in their stored embedding_model but no embedding_backend metadata.
+    The old heuristic treated any '/'-containing name as OpenRouter, which (without
+    an API key) fell back to ModernBERT (768-dim) and caused dimension mismatches.
+    Fix: _looks_like_openrouter_model() now excludes known sentence-transformer
+    namespaces from the OpenRouter routing path.
+    """
+    import chromadb
+    from chromadb.config import Settings
+
+    persist_dir = tmp_path / "index"
+    persist_dir.mkdir()
+
+    settings = Settings(allow_reset=True, is_persistent=True, anonymized_telemetry=False)
+    client = chromadb.PersistentClient(path=str(persist_dir), settings=settings)
+    # Legacy collection: has a namespaced ST model name but NO embedding_backend.
+    col = client.create_collection(
+        name="default",
+        metadata={
+            "hnsw:space": "cosine",
+            "embedding_model": "sentence-transformers/paraphrase-MiniLM-L6-v2",
+            # intentionally no "embedding_backend" key — this is the legacy format
+        },
+    )
+    col.add(ids=["para-doc"], embeddings=[[0.3] * 384], documents=["paraphrase doc"])
+    assert col.count() == 1
+    del client
+
+    # Without OPENROUTER_API_KEY, misrouting to OpenRouter would cause a ValueError
+    # in OpenRouterEmbedding.__init__ and then fall through to ModernBERT (768-dim),
+    # causing a dimension mismatch on any later query against the 384-dim collection.
+    # The correct path: treat 'sentence-transformers/*' as sentence-transformers,
+    # not OpenRouter, so the collection is preserved (even if the model can't load).
+    import os
+
+    env_backup = os.environ.pop("OPENROUTER_API_KEY", None)
+    try:
+        indexer = Indexer(
+            persist_directory=persist_dir,
+            enable_persist=True,
+            embedding_function="auto",
+            collection_name="default",
+        )
+        assert (
+            indexer.collection.count() == 1
+        ), "auto mode destroyed legacy sentence-transformers/ namespace collection (slash misrouting bug)"
+    finally:
+        if env_backup is not None:
+            os.environ["OPENROUTER_API_KEY"] = env_backup
+
+
 def test_reset_collection_preserves_embedding_metadata(indexer):
     """reset_collection must recreate with the same embedding model metadata."""
     indexer.reset_collection()
     metadata = indexer.collection.metadata or {}
     assert metadata.get("embedding_model") == indexer.embedding_model_name
     assert metadata.get("embedding_backend") == indexer.embedding_backend_name
+
+
+def test_auto_mode_search_raises_clear_error_when_openrouter_key_absent(tmp_path):
+    """search() must raise RuntimeError with a clear message, not a cryptic ChromaDB
+    dimension-mismatch, when the stored OpenRouter model could not be re-loaded.
+
+    Regression test for P1: embedding_function=None with a non-default stored model
+    caused search() to fall through to query_texts (ChromaDB default 384-dim MiniLM),
+    which mismatched the stored OpenRouter 3072-dim vectors.
+    """
+    import os
+
+    import chromadb
+    from chromadb.config import Settings
+
+    persist_dir = tmp_path / "index"
+    persist_dir.mkdir()
+
+    settings = Settings(allow_reset=True, is_persistent=True, anonymized_telemetry=False)
+    client = chromadb.PersistentClient(path=str(persist_dir), settings=settings)
+    col = client.create_collection(
+        name="default",
+        metadata={
+            "hnsw:space": "cosine",
+            "embedding_model": "openai/text-embedding-3-large",
+            "embedding_backend": "openrouter",
+        },
+    )
+    col.add(
+        ids=["or-doc"],
+        embeddings=[[0.1] * 3072],
+        documents=["an openrouter-indexed document"],
+    )
+    assert col.count() == 1
+    del client
+
+    env_backup = os.environ.pop("OPENROUTER_API_KEY", None)
+    try:
+        indexer = Indexer(
+            persist_directory=persist_dir,
+            enable_persist=True,
+            embedding_function="auto",
+            collection_name="default",
+        )
+        # Collection must be preserved (P0 regression check).
+        assert indexer.collection.count() == 1
+        # The embedding_model_name should reflect the actual stored model, not "default" (P2).
+        assert indexer.embedding_model_name == "openai/text-embedding-3-large"
+        # search() must raise a clear RuntimeError, not a cryptic ChromaDB error (P1).
+        with pytest.raises(RuntimeError, match="openai/text-embedding-3-large"):
+            indexer.search("test query")
+    finally:
+        if env_backup is not None:
+            os.environ["OPENROUTER_API_KEY"] = env_backup
+
+
+def test_auto_mode_search_raises_clear_error_when_sentence_transformer_fails(tmp_path, monkeypatch):
+    """search() must raise RuntimeError with a clear message when the stored
+    sentence-transformer model could not be re-loaded.
+
+    Regression test for P1: same as OpenRouter case but for sentence-transformer backend.
+    """
+    import chromadb
+    from chromadb.config import Settings
+
+    persist_dir = tmp_path / "index"
+    persist_dir.mkdir()
+
+    settings = Settings(allow_reset=True, is_persistent=True, anonymized_telemetry=False)
+    client = chromadb.PersistentClient(path=str(persist_dir), settings=settings)
+    col = client.create_collection(
+        name="default",
+        metadata={
+            "hnsw:space": "cosine",
+            "embedding_model": "all-mpnet-base-v2",
+            "embedding_backend": "sentence-transformers",
+        },
+    )
+    col.add(
+        ids=["st-doc"],
+        embeddings=[[0.2] * 768],
+        documents=["an mpnet-indexed document"],
+    )
+    assert col.count() == 1
+    del client
+
+    class _Raise:
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError("Model weights not found")
+
+    monkeypatch.setattr(indexer_module, "GenericSentenceTransformerEmbedding", _Raise)
+
+    indexer = Indexer(
+        persist_directory=persist_dir,
+        enable_persist=True,
+        embedding_function="auto",
+        collection_name="default",
+    )
+    # Collection must be preserved.
+    assert indexer.collection.count() == 1
+    # embedding_model_name should reflect the stored model name, not "default" (P2).
+    assert indexer.embedding_model_name == "all-mpnet-base-v2"
+    # search() must raise a clear RuntimeError, not a ChromaDB dimension-mismatch (P1).
+    with pytest.raises(RuntimeError, match="all-mpnet-base-v2"):
+        indexer.search("test query")

--- a/packages/gptme-rag/tests/test_indexing.py
+++ b/packages/gptme-rag/tests/test_indexing.py
@@ -70,9 +70,9 @@ def test_indexer_add_documents(indexer, test_docs):
     # Search for ML-related content
     ml_results, ml_distances, _ = indexer.search("machine learning")
     assert len(ml_results) > 0, "No results found for 'machine learning'"
-    assert any(
-        "machine learning" in doc.content.lower() for doc in ml_results
-    ), f"Expected 'machine learning' in results: {[doc.content for doc in ml_results]}"
+    assert any("machine learning" in doc.content.lower() for doc in ml_results), (
+        f"Expected 'machine learning' in results: {[doc.content for doc in ml_results]}"
+    )
     assert len(ml_distances) > 0, "No distances returned"
 
 
@@ -311,9 +311,9 @@ def test_auto_embedding_mode_does_not_destroy_foreign_model_collection(tmp_path)
     )
 
     # Collection must still have the sentinel document — not been recreated
-    assert (
-        indexer.collection.count() == 1
-    ), "auto mode destroyed the collection indexed with a non-default embedding model"
+    assert indexer.collection.count() == 1, (
+        "auto mode destroyed the collection indexed with a non-default embedding model"
+    )
 
 
 def test_auto_embedding_mode_rebinds_sentence_transformer_collection(tmp_path, monkeypatch):
@@ -436,9 +436,9 @@ def test_auto_embedding_mode_preserves_legacy_chromadb_default_collection(tmp_pa
     )
 
     # Collection must be intact and reachable
-    assert (
-        indexer.collection.count() == 1
-    ), "auto mode destroyed legacy no-metadata collection (dimension mismatch bug)"
+    assert indexer.collection.count() == 1, (
+        "auto mode destroyed legacy no-metadata collection (dimension mismatch bug)"
+    )
 
 
 def test_auto_embedding_mode_preserves_collection_when_sentence_transformer_fails_to_load(
@@ -488,9 +488,9 @@ def test_auto_embedding_mode_preserves_collection_when_sentence_transformer_fail
         embedding_function="auto",
         collection_name="default",
     )
-    assert (
-        indexer.collection.count() == 1
-    ), "auto mode deleted sentence-transformer collection when the model failed to load"
+    assert indexer.collection.count() == 1, (
+        "auto mode deleted sentence-transformer collection when the model failed to load"
+    )
 
 
 def test_auto_embedding_mode_sentence_transformer_namespace_not_misrouted_to_openrouter(tmp_path):
@@ -541,9 +541,9 @@ def test_auto_embedding_mode_sentence_transformer_namespace_not_misrouted_to_ope
             embedding_function="auto",
             collection_name="default",
         )
-        assert (
-            indexer.collection.count() == 1
-        ), "auto mode destroyed legacy sentence-transformers/ namespace collection (slash misrouting bug)"
+        assert indexer.collection.count() == 1, (
+            "auto mode destroyed legacy sentence-transformers/ namespace collection (slash misrouting bug)"
+        )
     finally:
         if env_backup is not None:
             os.environ["OPENROUTER_API_KEY"] = env_backup
@@ -589,10 +589,118 @@ def test_auto_embedding_mode_baai_namespace_not_misrouted_to_openrouter(tmp_path
             embedding_function="auto",
             collection_name="default",
         )
-        assert (
-            indexer.collection.count() == 1
-        ), "auto mode destroyed legacy BAAI/ namespace collection (incomplete namespace list)"
+        assert indexer.collection.count() == 1, (
+            "auto mode destroyed legacy BAAI/ namespace collection (incomplete namespace list)"
+        )
     finally:
+        if env_backup is not None:
+            os.environ["OPENROUTER_API_KEY"] = env_backup
+
+
+def test_auto_mode_unknown_namespace_hf_model_tried_as_st_first(tmp_path, monkeypatch):
+    """Auto mode must try to load unknown-namespace models as ST before routing to OR.
+
+    Regression test for P1 heuristic incompleteness: _looks_like_openrouter_model()
+    returns True for any 'org/model' name not in _SENTENCE_TRANSFORMER_NAMESPACES.
+    A legacy collection indexed with e.g. 'joe32140/ModernBERT-base-msmarco' (a real
+    HF model whose namespace is not in the allow-list) would previously be misrouted
+    to the OpenRouter backend — causing a cryptic dimension-mismatch when an API key
+    is set but the model doesn't exist on OpenRouter.
+
+    Fix: for legacy collections (no embedding_backend metadata), the auto-detect path
+    now tries GenericSentenceTransformerEmbedding first; OpenRouter is only attempted
+    when ST raises.
+    """
+    import os
+
+    import chromadb
+    from chromadb.config import Settings
+
+    import gptme_rag.indexing.indexer as indexer_module
+
+    # Unknown namespace — not in _SENTENCE_TRANSFORMER_NAMESPACES but IS a real HF model.
+    unknown_ns_model = "joe32140/ModernBERT-base-msmarco"
+
+    # Track which backends were attempted.
+    st_attempts: list[str] = []
+    or_attempts: list[str] = []
+    _RealST = indexer_module.GenericSentenceTransformerEmbedding
+    _RealOR = indexer_module.OpenRouterEmbedding
+
+    class TrackingST:
+        model_name = unknown_ns_model
+        is_msmarco = False
+
+        def __init__(self, model_name, device="cpu"):
+            st_attempts.append(model_name)
+            self.model_name = model_name
+
+        def __call__(self, input):
+            return [[0.25] * 384 for _ in input]
+
+        def embed_query(self, input):
+            return self(input)
+
+        def embed_documents(self, input):
+            return self(input)
+
+        @staticmethod
+        def name():
+            return "tracking-st"
+
+        @staticmethod
+        def is_legacy():
+            return False
+
+    class TrackingOR:
+        def __init__(self, model_name=None, **kwargs):
+            or_attempts.append(model_name)
+            raise ValueError("Tracking OR: intentionally unavailable")
+
+    monkeypatch.setattr(indexer_module, "GenericSentenceTransformerEmbedding", TrackingST)
+    monkeypatch.setattr(indexer_module, "OpenRouterEmbedding", TrackingOR)
+
+    persist_dir = tmp_path / "index"
+    persist_dir.mkdir()
+
+    settings = Settings(allow_reset=True, is_persistent=True, anonymized_telemetry=False)
+    client = chromadb.PersistentClient(path=str(persist_dir), settings=settings)
+    col = client.create_collection(
+        name="default",
+        metadata={
+            "hnsw:space": "cosine",
+            "embedding_model": unknown_ns_model,
+            # intentionally no "embedding_backend" — legacy format
+        },
+    )
+    col.add(ids=["doc"], embeddings=[[0.25] * 384], documents=["some doc"])
+    assert col.count() == 1
+    del client
+
+    env_backup = os.environ.pop("OPENROUTER_API_KEY", None)
+    try:
+        # Open with auto mode — with an API key set to confirm the OR path is NOT taken first.
+        os.environ["OPENROUTER_API_KEY"] = "test-key"
+        indexer = Indexer(
+            persist_directory=persist_dir,
+            enable_persist=True,
+            embedding_function="auto",
+            collection_name="default",
+        )
+        # The collection must still be intact — not destroyed.
+        assert indexer.collection.count() == 1, (
+            "auto mode destroyed unknown-namespace HF model collection"
+        )
+        # ST must have been tried first.
+        assert st_attempts == [unknown_ns_model], (
+            f"Expected ST to be tried first for unknown namespace; st_attempts={st_attempts}"
+        )
+        # OR must NOT have been attempted (ST succeeded).
+        assert or_attempts == [], (
+            f"OR should not be attempted when ST succeeds; or_attempts={or_attempts}"
+        )
+    finally:
+        os.environ.pop("OPENROUTER_API_KEY", None)
         if env_backup is not None:
             os.environ["OPENROUTER_API_KEY"] = env_backup
 
@@ -853,9 +961,9 @@ def test_auto_mode_rebinds_openrouter_collection_when_api_key_present(
 
     # The auto-detect path must have constructed an OpenRouterEmbedding, not fallen
     # back to a local embedder or left embedding_function=None.
-    assert isinstance(
-        indexer.embedding_function, OpenRouterEmbedding
-    ), f"Expected OpenRouterEmbedding, got {type(indexer.embedding_function)}"
+    assert isinstance(indexer.embedding_function, OpenRouterEmbedding), (
+        f"Expected OpenRouterEmbedding, got {type(indexer.embedding_function)}"
+    )
 
     # The rebind must have used the stored model name, not the default.
     assert indexer.embedding_function.model_name == stored_model  # type: ignore[union-attr]
@@ -866,3 +974,114 @@ def test_auto_mode_rebinds_openrouter_collection_when_api_key_present(
     # search() must succeed (return results) without raising.
     results = indexer.search("test query", n_results=1)
     assert len(results) >= 1, "Expected at least one search result"
+
+
+def test_auto_mode_modernbert_load_failure_preserves_collection(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    """auto mode must preserve a modernbert collection when the model cannot be loaded.
+
+    Regression test for P1 bug: the 'modernbert' auto-detect branch created
+    ModernBERTEmbedding without try/except. If the model weights are missing or
+    unavailable, the constructor raised and the command (search, status) crashed
+    instead of falling back gracefully. The fix wraps the call in try/except,
+    sets _stored_model_name, and preserves the existing collection.
+    """
+    import chromadb
+    from chromadb.config import Settings
+
+    persist_dir = tmp_path / "index"
+    persist_dir.mkdir()
+
+    # Simulate a collection stored with the modernbert backend.
+    settings = Settings(allow_reset=True, is_persistent=True, anonymized_telemetry=False)
+    client = chromadb.PersistentClient(path=str(persist_dir), settings=settings)
+    col = client.create_collection(
+        name="default",
+        metadata={
+            "hnsw:space": "cosine",
+            "embedding_model": "modernbert",
+            "embedding_backend": "modernbert",
+        },
+    )
+    col.add(ids=["mb-doc"], embeddings=[[0.1] * 768], documents=["a modernbert doc"])
+    assert col.count() == 1
+    del client
+
+    # Monkey-patch ModernBERTEmbedding to simulate a load failure.
+    # Must be a class (not a bare function) so isinstance() calls in the indexer
+    # still work when checking if embedding_function is an instance of this type.
+    import gptme_rag.indexing.indexer as indexer_mod
+
+    class _FailingModernBERT:
+        def __new__(cls, *args, **kwargs):  # type: ignore[misc]
+            raise RuntimeError("simulated model load failure: weights unavailable")
+
+    monkeypatch.setattr(indexer_mod, "ModernBERTEmbedding", _FailingModernBERT)
+
+    # Must not raise — collection should be preserved.
+    indexer = Indexer(
+        persist_directory=persist_dir,
+        enable_persist=True,
+        embedding_function="auto",
+        collection_name="default",
+    )
+
+    # load-failed sentinel state
+    assert indexer.embedding_function is None
+    assert indexer._stored_model_name == "modernbert"
+
+    # The collection must still contain the original document.
+    assert indexer.collection.count() == 1
+
+    # search() should raise a clear RuntimeError, not a ChromaDB dimension error.
+    with pytest.raises(RuntimeError, match="modernbert"):
+        indexer.search("test query", n_results=1)
+
+
+def test_search_explicit_embedding_function_does_not_wipe_mismatched_collection(
+    tmp_path,
+):
+    """search must never delete a collection when --embedding-function mismatches the stored model.
+
+    Regression test for P1 bug: the search command passed the user's explicit
+    --embedding-function directly to Indexer. When it differed from the stored model,
+    Indexer set need_recreate=True and deleted the collection — turning a read-only
+    operation into silent data loss. The fix adds allow_recreate=False for the search
+    Indexer; on mismatch a warning is logged and the collection is kept unchanged.
+    """
+    import chromadb
+    from chromadb.config import Settings
+
+    persist_dir = tmp_path / "index"
+    persist_dir.mkdir()
+
+    # Simulate a collection stored with minilm (384-dim).
+    settings = Settings(allow_reset=True, is_persistent=True, anonymized_telemetry=False)
+    client = chromadb.PersistentClient(path=str(persist_dir), settings=settings)
+    col = client.create_collection(
+        name="default",
+        metadata={
+            "hnsw:space": "cosine",
+            "embedding_model": "minilm",
+            "embedding_backend": "sentence-transformers",
+        },
+    )
+    col.add(ids=["doc-1"], embeddings=[[0.1] * 384], documents=["a minilm doc"])
+    assert col.count() == 1
+    del client
+
+    # Requesting 'modernbert' (768-dim) with allow_recreate=False must NOT destroy
+    # the existing minilm collection.
+    indexer = Indexer(
+        persist_directory=persist_dir,
+        enable_persist=True,
+        embedding_function="modernbert",
+        collection_name="default",
+        allow_recreate=False,
+    )
+
+    # Collection must still exist and contain the original document.
+    assert indexer.collection.count() == 1, (
+        "Collection was destroyed by allow_recreate=False indexer — data loss regression"
+    )

--- a/packages/gptme-rag/tests/test_indexing.py
+++ b/packages/gptme-rag/tests/test_indexing.py
@@ -763,6 +763,12 @@ def test_auto_mode_add_document_raises_clear_error_when_stored_model_failed(tmp_
             indexer.add_document(Document(content="new doc", metadata={"source": "test.txt"}))
         # Collection must still be intact after the failed add attempt.
         assert indexer.collection.count() == 1
+
+        # add_documents (batch path via _add_documents) must also raise a clear
+        # RuntimeError, not a cryptic ChromaDB dimension-mismatch (P1 extension).
+        with pytest.raises(RuntimeError, match="openai/text-embedding-3-large"):
+            indexer.add_documents([Document(content="new doc", metadata={"source": "test.txt"})])
+        assert indexer.collection.count() == 1
     finally:
         if env_backup is not None:
             os.environ["OPENROUTER_API_KEY"] = env_backup

--- a/packages/gptme-rag/tests/test_indexing.py
+++ b/packages/gptme-rag/tests/test_indexing.py
@@ -549,6 +549,54 @@ def test_auto_embedding_mode_sentence_transformer_namespace_not_misrouted_to_ope
             os.environ["OPENROUTER_API_KEY"] = env_backup
 
 
+def test_auto_embedding_mode_baai_namespace_not_misrouted_to_openrouter(tmp_path):
+    """Auto mode must not route 'BAAI/<model>' to the OpenRouter backend.
+
+    Regression test for the incomplete namespace list: the initial fix only excluded
+    'sentence-transformers/' but left BAAI/, intfloat/, thenlper/ etc. exposed.
+    Legacy collections indexed with e.g. 'BAAI/bge-large-en-v1.5' would be misrouted
+    to OpenRouter (slash heuristic), causing cryptic errors when the API key is absent.
+    Fix: _SENTENCE_TRANSFORMER_NAMESPACES now includes BAAI/ and other common HF
+    embedding namespaces.
+    """
+    import os
+
+    import chromadb
+    from chromadb.config import Settings
+
+    persist_dir = tmp_path / "index"
+    persist_dir.mkdir()
+
+    settings = Settings(allow_reset=True, is_persistent=True, anonymized_telemetry=False)
+    client = chromadb.PersistentClient(path=str(persist_dir), settings=settings)
+    col = client.create_collection(
+        name="default",
+        metadata={
+            "hnsw:space": "cosine",
+            "embedding_model": "BAAI/bge-large-en-v1.5",
+            # intentionally no "embedding_backend" key — legacy format before this PR
+        },
+    )
+    col.add(ids=["bge-doc"], embeddings=[[0.1] * 1024], documents=["bge document"])
+    assert col.count() == 1
+    del client
+
+    env_backup = os.environ.pop("OPENROUTER_API_KEY", None)
+    try:
+        indexer = Indexer(
+            persist_directory=persist_dir,
+            enable_persist=True,
+            embedding_function="auto",
+            collection_name="default",
+        )
+        assert (
+            indexer.collection.count() == 1
+        ), "auto mode destroyed legacy BAAI/ namespace collection (incomplete namespace list)"
+    finally:
+        if env_backup is not None:
+            os.environ["OPENROUTER_API_KEY"] = env_backup
+
+
 def test_reset_collection_preserves_embedding_metadata(indexer):
     """reset_collection must recreate with the same embedding model metadata."""
     indexer.reset_collection()

--- a/packages/gptme-rag/tests/test_indexing.py
+++ b/packages/gptme-rag/tests/test_indexing.py
@@ -310,9 +310,9 @@ def test_auto_embedding_mode_does_not_destroy_foreign_model_collection(tmp_path)
     )
 
     # Collection must still have the sentinel document — not been recreated
-    assert indexer.collection.count() == 1, (
-        "auto mode destroyed the collection indexed with a non-default embedding model"
-    )
+    assert (
+        indexer.collection.count() == 1
+    ), "auto mode destroyed the collection indexed with a non-default embedding model"
 
 
 def test_reset_collection_preserves_embedding_metadata(indexer):

--- a/packages/gptme-rag/tests/test_indexing.py
+++ b/packages/gptme-rag/tests/test_indexing.py
@@ -441,6 +441,55 @@ def test_auto_embedding_mode_preserves_legacy_chromadb_default_collection(tmp_pa
     ), "auto mode destroyed legacy no-metadata collection (dimension mismatch bug)"
 
 
+def test_auto_embedding_mode_preserves_collection_when_sentence_transformer_fails_to_load(
+    tmp_path, monkeypatch
+):
+    """Auto mode must not delete a sentence-transformer collection when the model can't load.
+
+    Regression test for P0 bug: if GenericSentenceTransformerEmbedding raised (e.g., model
+    download failure, missing weights), the exception propagated out of the Indexer constructor,
+    crashing the command. Fix: wrap in try/except and fall back to reuse_auto_peeked_collection,
+    preserving the collection without rebinding (same pattern as the OpenRouter API-key fallback).
+    """
+    import chromadb as _chromadb
+    from chromadb.config import Settings
+
+    persist_dir = tmp_path / "index"
+    persist_dir.mkdir()
+
+    # Create a persisted collection tagged as sentence-transformers backend.
+    settings = Settings(allow_reset=True, is_persistent=True, anonymized_telemetry=False)
+    client = _chromadb.PersistentClient(path=str(persist_dir), settings=settings)
+    col = client.create_collection(
+        name="default",
+        metadata={
+            "hnsw:space": "cosine",
+            "embedding_model": "all-MiniLM-L6-v2",
+            "embedding_backend": "sentence-transformers",
+        },
+    )
+    col.add(ids=["st-doc"], embeddings=[[0.5] * 384], documents=["sentence-transformer content"])
+    assert col.count() == 1
+    del client
+
+    # Simulate a model-load failure (e.g., missing download or corrupt weights).
+    def _raise(*args, **kwargs):
+        raise RuntimeError("Model weights not found")
+
+    monkeypatch.setattr(indexer_module, "GenericSentenceTransformerEmbedding", _raise)
+
+    # Opening with auto mode must NOT crash or delete the collection.
+    indexer = Indexer(
+        persist_directory=persist_dir,
+        enable_persist=True,
+        embedding_function="auto",
+        collection_name="default",
+    )
+    assert (
+        indexer.collection.count() == 1
+    ), "auto mode deleted sentence-transformer collection when the model failed to load"
+
+
 def test_reset_collection_preserves_embedding_metadata(indexer):
     """reset_collection must recreate with the same embedding model metadata."""
     indexer.reset_collection()

--- a/packages/gptme-rag/tests/test_indexing.py
+++ b/packages/gptme-rag/tests/test_indexing.py
@@ -1211,3 +1211,144 @@ def test_index_openrouter_fallback_does_not_destroy_existing_openrouter_collecti
     assert (
         verify_col.count() == 1
     ), "Collection was destroyed by OpenRouter fallback — data loss regression"
+
+
+def test_openrouter_fallback_guard_uses_looks_like_openrouter_not_bare_slash(tmp_path):
+    """The OpenRouter fallback guard must use _looks_like_openrouter_model(), not 'if "/" in model'.
+
+    Regression test for P1: when --embedding-function openrouter is passed without an API key
+    and the collection stores a sentence-transformer model name containing a slash
+    (e.g. 'sentence-transformers/all-MiniLM-L6-v2' or 'BAAI/bge-large-en-v1.5'),
+    the bare 'if "/" in _stored_for_guard' guard raised a misleading ValueError claiming
+    the collection was indexed with OpenRouter.  The user was told to set OPENROUTER_API_KEY
+    even though the collection was sentence-transformer-backed and no API key is needed.
+
+    After the fix, the Indexer constructor must NOT raise a ValueError mentioning
+    OPENROUTER_API_KEY for sentence-transformer collections.  Recreating the collection
+    with the ModernBERT fallback is legitimate here (the user asked for openrouter, which
+    fell back to modernbert — re-indexing with modernbert is the correct outcome).
+    """
+    import os
+
+    import chromadb
+    from chromadb.config import Settings
+
+    persist_dir = tmp_path / "index"
+    persist_dir.mkdir()
+
+    # Simulate a collection previously indexed with a sentence-transformer model whose
+    # name contains a slash — the pattern that falsely triggered the OpenRouter guard.
+    settings = Settings(allow_reset=True, is_persistent=True, anonymized_telemetry=False)
+    client = chromadb.PersistentClient(path=str(persist_dir), settings=settings)
+    col = client.create_collection(
+        name="default",
+        metadata={
+            "hnsw:space": "cosine",
+            "embedding_model": "sentence-transformers/all-MiniLM-L6-v2",
+            "embedding_backend": "sentence-transformers",
+        },
+    )
+    col.add(ids=["doc-1"], embeddings=[[0.1] * 384], documents=["a sentence-transformer doc"])
+    assert col.count() == 1
+    del client
+
+    # Remove the API key so OpenRouterEmbedding.__init__ triggers the ModernBERT fallback.
+    env_backup = os.environ.pop("OPENROUTER_API_KEY", None)
+    try:
+        # The Indexer constructor must NOT raise ValueError mentioning OPENROUTER_API_KEY.
+        # The ST collection has a slashed model name, but it is NOT an OpenRouter collection.
+        # The guard should use _looks_like_openrouter_model() and let this proceed (the
+        # collection may be legitimately re-indexed with the ModernBERT fallback).
+        raised_openrouter_error = False
+        try:
+            Indexer(
+                persist_directory=persist_dir,
+                enable_persist=True,
+                embedding_function="openrouter",
+                collection_name="default",
+                allow_recreate=True,
+            )
+        except ValueError as e:
+            if "OPENROUTER_API_KEY" in str(e):
+                raised_openrouter_error = True
+
+        assert not raised_openrouter_error, (
+            "P1 regression: the OpenRouter fallback guard falsely raised ValueError about "
+            "OPENROUTER_API_KEY for a sentence-transformer collection (model name contains '/' "
+            "but is NOT an OpenRouter model).  Use _looks_like_openrouter_model() instead of "
+            "'if \"/\" in stored_model'."
+        )
+    finally:
+        if env_backup is not None:
+            os.environ["OPENROUTER_API_KEY"] = env_backup
+
+
+def test_index_directory_raises_before_deleting_when_stored_model_unavailable(tmp_path):
+    """index_directory must raise before deleting documents if the stored model can't load.
+
+    Regression test for P0: index_directory deleted existing documents for each source
+    before calling add_documents.  When the Indexer was constructed in auto mode with a
+    collection whose stored embedding model couldn't be loaded (_stored_model_name set),
+    add_documents raised RuntimeError AFTER the documents were already deleted — leaving
+    the index permanently empty.
+
+    The fix: check _stored_model_name at the top of index_directory and raise before
+    any deletions.
+    """
+    import chromadb
+    from chromadb.config import Settings
+
+    persist_dir = tmp_path / "index"
+    persist_dir.mkdir()
+    doc_dir = tmp_path / "docs"
+    doc_dir.mkdir()
+    (doc_dir / "test.txt").write_text("hello world")
+
+    # Create a collection with an OpenRouter model that cannot be loaded (no API key).
+    settings = Settings(allow_reset=True, is_persistent=True, anonymized_telemetry=False)
+    client = chromadb.PersistentClient(path=str(persist_dir), settings=settings)
+    col = client.create_collection(
+        name="default",
+        metadata={
+            "hnsw:space": "cosine",
+            "embedding_model": "openai/text-embedding-3-large",
+            "embedding_backend": "openrouter",
+        },
+    )
+    # Pre-seed a document so we can verify it survives.
+    col.add(ids=["existing-doc"], embeddings=[[0.1] * 1536], documents=["existing content"])
+    assert col.count() == 1
+    del client
+
+    import os
+
+    env_backup = os.environ.pop("OPENROUTER_API_KEY", None)
+    try:
+        # Construct in auto mode so _stored_model_name gets set (model can't load).
+        # Use allow_recreate=False so the collection is preserved in auto mode.
+        indexer = Indexer(
+            persist_directory=persist_dir,
+            enable_persist=True,
+            embedding_function="auto",
+            collection_name="default",
+            allow_recreate=False,
+        )
+        # _stored_model_name must be set (model load failed).
+        assert (
+            indexer._stored_model_name is not None
+        ), "Expected _stored_model_name to be set when OpenRouter key absent"
+
+        # index_directory must raise BEFORE deleting any documents.
+        with pytest.raises(RuntimeError, match="stored embedding model"):
+            indexer.index_directory(doc_dir)
+    finally:
+        if env_backup is not None:
+            os.environ["OPENROUTER_API_KEY"] = env_backup
+
+    # Verify the original document is still there — not deleted by the failed index_directory.
+    verify_settings = Settings(allow_reset=True, is_persistent=True, anonymized_telemetry=False)
+    verify_client = chromadb.PersistentClient(path=str(persist_dir), settings=verify_settings)
+    verify_col = verify_client.get_collection(name="default")
+    assert (
+        verify_col.count() == 1
+    ), "P0 regression: index_directory deleted documents before raising — data loss!"

--- a/packages/gptme-rag/tests/test_indexing.py
+++ b/packages/gptme-rag/tests/test_indexing.py
@@ -401,6 +401,46 @@ def test_auto_embedding_mode_rebinds_sentence_transformer_collection(tmp_path, m
     assert results[0].doc_id == "minilm-doc"
 
 
+def test_auto_embedding_mode_preserves_legacy_chromadb_default_collection(tmp_path):
+    """Auto mode must not corrupt a legacy collection that has no embedding_model metadata.
+
+    Regression test for P1 bug: metadata.get("embedding_model", "modernbert") defaulted
+    to 'modernbert' for metadata-free collections, so auto mode rebound to ModernBERT
+    (768-dim) and ChromaDB raised a dimension mismatch on any subsequent search.
+    Fix: default to 'default' so no-metadata collections fall through to the
+    reuse_auto_peeked_collection path (embedding_function=None).
+    """
+    import chromadb
+    from chromadb.config import Settings
+
+    persist_dir = tmp_path / "index"
+    persist_dir.mkdir()
+
+    # Simulate a legacy collection created before embedding_model metadata was introduced.
+    settings = Settings(allow_reset=True, is_persistent=True, anonymized_telemetry=False)
+    client = chromadb.PersistentClient(path=str(persist_dir), settings=settings)
+    col = client.create_collection(
+        name="default",
+        metadata={"hnsw:space": "cosine"},  # no embedding_model or embedding_backend
+    )
+    # ChromaDB default embeddings are 384-dim (all-MiniLM-L6-v2).
+    col.add(ids=["legacy-doc"], embeddings=[[0.1] * 384], documents=["legacy content"])
+    assert col.count() == 1
+
+    # Open with auto mode — must not remap to ModernBERT (768-dim)
+    indexer = Indexer(
+        persist_directory=persist_dir,
+        enable_persist=True,
+        embedding_function="auto",
+        collection_name="default",
+    )
+
+    # Collection must be intact and reachable
+    assert (
+        indexer.collection.count() == 1
+    ), "auto mode destroyed legacy no-metadata collection (dimension mismatch bug)"
+
+
 def test_reset_collection_preserves_embedding_metadata(indexer):
     """reset_collection must recreate with the same embedding model metadata."""
     indexer.reset_collection()

--- a/packages/gptme-rag/tests/test_indexing.py
+++ b/packages/gptme-rag/tests/test_indexing.py
@@ -1085,3 +1085,14 @@ def test_search_explicit_embedding_function_does_not_wipe_mismatched_collection(
     assert (
         indexer.collection.count() == 1
     ), "Collection was destroyed by allow_recreate=False indexer — data loss regression"
+
+    # P1 regression: search() must raise a clear RuntimeError, NOT a cryptic ChromaDB
+    # InvalidDimensionException.  Before the fix, self.embedding_function was left set to
+    # the mismatched ModernBERT (768-dim) model, so search() would call
+    # embedding_function([query]) → 768-dim vector → ChromaDB dimension mismatch against
+    # the 384-dim stored vectors.  After the fix, embedding_function is nulled out and
+    # _stored_model_name is set, routing search() to the existing clear-error path.
+    import pytest
+
+    with pytest.raises(RuntimeError, match="stored embedding model"):
+        indexer.search("test query")

--- a/packages/gptme-rag/tests/test_indexing.py
+++ b/packages/gptme-rag/tests/test_indexing.py
@@ -1352,3 +1352,76 @@ def test_index_directory_raises_before_deleting_when_stored_model_unavailable(tm
     assert (
         verify_col.count() == 1
     ), "P0 regression: index_directory deleted documents before raising — data loss!"
+
+
+def test_watch_exception_filter_catches_cannot_index_directory_error(
+    tmp_path,
+):
+    """watch must catch RuntimeError from index_directory when stored model cannot load.
+
+    Regression test for P1: cli.py:781 checked for "Cannot add documents" and "stored model"
+    but index_directory raises "Cannot index directory: the stored embedding model ...",
+    which matches neither — so the error propagated and crashed the watch command
+    instead of logging a warning and continuing to watch.
+
+    The fix adds "Cannot index directory" and "stored embedding model" to the filter.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from click.testing import CliRunner
+
+    from gptme_rag.cli import cli
+
+    test_dir = tmp_path / "docs"
+    test_dir.mkdir()
+    (test_dir / "file.txt").write_text("hello")
+
+    index_dir = tmp_path / "index"
+    index_dir.mkdir()
+
+    # The error that index_directory actually raises when _stored_model_name is set.
+    cant_index_msg = (
+        "Cannot index directory: the stored embedding model "
+        "'openai/text-embedding-3-large' could not be loaded "
+        "(API key missing or model weights unavailable)."
+    )
+
+    with (
+        patch("gptme_rag.cli.Indexer") as MockIndexer,
+        patch("gptme_rag.cli.FileWatcher") as MockFileWatcher,
+        # signal.pause() blocks forever — raise KeyboardInterrupt to exit the watch loop.
+        patch("gptme_rag.cli.signal") as mock_signal,
+    ):
+        mock_indexer = MagicMock()
+        MockIndexer.return_value = mock_indexer
+        # index_directory raises the error that was slipping through the old filter.
+        mock_indexer.index_directory.side_effect = RuntimeError(cant_index_msg)
+
+        # FileWatcher context manager — signal.pause() inside it raises KeyboardInterrupt.
+        mock_watcher = MagicMock()
+        mock_watcher.__enter__ = MagicMock(return_value=mock_watcher)
+        mock_watcher.__exit__ = MagicMock(return_value=False)
+        MockFileWatcher.return_value = mock_watcher
+        mock_signal.pause.side_effect = KeyboardInterrupt
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "watch",
+                str(test_dir),
+                "--persist-dir",
+                str(index_dir),
+            ],
+        )
+
+    # Before the fix: exit_code != 0 because RuntimeError propagated from index_directory.
+    # After the fix: exit_code == 0 — the filter catches it, logs a warning, and watch
+    # continues (then exits cleanly via the KeyboardInterrupt from signal.pause).
+    assert result.exit_code == 0, (
+        f"watch crashed with exit_code={result.exit_code} instead of logging a warning.\n"
+        f"Output:\n{result.output}"
+    )
+    assert (
+        "Warning" in result.output or "warning" in result.output.lower()
+    ), f"Expected a warning in output but got:\n{result.output}"

--- a/packages/gptme-rag/tests/test_indexing.py
+++ b/packages/gptme-rag/tests/test_indexing.py
@@ -275,6 +275,46 @@ def test_compute_relevance_score_accepts_iso_last_modified():
     assert explanation["explanations"]["recency_boost"].startswith("Modified ")
 
 
+def test_auto_embedding_mode_does_not_destroy_foreign_model_collection(tmp_path):
+    """Indexer with embedding_function='auto' must not silently recreate a collection
+    that was indexed with a non-default model (e.g. OpenRouter).
+
+    Regression test for P0 data-loss bug: status/search commands default to
+    'auto' but previously passed 'modernbert', which triggered the mismatch
+    guard and deleted all indexed content.
+    """
+    import chromadb
+    from chromadb.config import Settings
+
+    persist_dir = tmp_path / "index"
+    persist_dir.mkdir()
+
+    # Simulate a collection created by the OpenRouter embedding backend
+    settings = Settings(allow_reset=True, is_persistent=True, anonymized_telemetry=False)
+    client = chromadb.PersistentClient(path=str(persist_dir), settings=settings)
+    fake_model = "openai/text-embedding-3-large"
+    col = client.create_collection(
+        name="default",
+        metadata={"hnsw:space": "cosine", "embedding_model": fake_model},
+    )
+    # Add a sentinel document with a raw embedding (dim=384 matches MiniLM)
+    col.add(ids=["sentinel"], embeddings=[[0.0] * 384], documents=["sentinel doc"])
+    assert col.count() == 1
+
+    # Open via auto mode (simulates what `gptme-rag status` / `search` does)
+    indexer = Indexer(
+        persist_directory=persist_dir,
+        enable_persist=True,
+        embedding_function="auto",
+        collection_name="default",
+    )
+
+    # Collection must still have the sentinel document — not been recreated
+    assert indexer.collection.count() == 1, (
+        "auto mode destroyed the collection indexed with a non-default embedding model"
+    )
+
+
 def test_reset_collection_preserves_embedding_metadata(indexer):
     """reset_collection must recreate with the same embedding model metadata."""
     indexer.reset_collection()

--- a/packages/gptme-rag/tests/test_indexing.py
+++ b/packages/gptme-rag/tests/test_indexing.py
@@ -708,3 +708,63 @@ def test_auto_mode_search_raises_clear_error_when_sentence_transformer_fails(tmp
     # search() must raise a clear RuntimeError, not a ChromaDB dimension-mismatch (P1).
     with pytest.raises(RuntimeError, match="all-mpnet-base-v2"):
         indexer.search("test query")
+
+
+def test_auto_mode_add_document_raises_clear_error_when_stored_model_failed(tmp_path):
+    """add_document() must raise RuntimeError when the stored model could not be loaded.
+
+    Regression test for P1: when auto-mode sets embedding_function=None because
+    the stored model (e.g. OpenRouter without API key) could not be re-loaded,
+    calling add_document would pass embedding_function=None to ChromaDB, causing
+    it to use default 384-dim MiniLM — resulting in a cryptic dimension-mismatch
+    error against 3072-dim stored vectors instead of a clear user-facing message.
+    """
+    import os
+
+    import chromadb
+    from chromadb.config import Settings
+
+    persist_dir = tmp_path / "index"
+    persist_dir.mkdir()
+
+    settings = Settings(allow_reset=True, is_persistent=True, anonymized_telemetry=False)
+    client = chromadb.PersistentClient(path=str(persist_dir), settings=settings)
+    col = client.create_collection(
+        name="default",
+        metadata={
+            "hnsw:space": "cosine",
+            "embedding_model": "openai/text-embedding-3-large",
+            "embedding_backend": "openrouter",
+        },
+    )
+    col.add(
+        ids=["or-doc"],
+        embeddings=[[0.1] * 3072],
+        documents=["an openrouter-indexed document"],
+    )
+    assert col.count() == 1
+    del client
+
+    env_backup = os.environ.pop("OPENROUTER_API_KEY", None)
+    try:
+        indexer = Indexer(
+            persist_directory=persist_dir,
+            enable_persist=True,
+            embedding_function="auto",
+            collection_name="default",
+        )
+        # Collection must be preserved (P0 regression check).
+        assert indexer.collection.count() == 1
+        # add_document must raise a clear RuntimeError, not a cryptic ChromaDB
+        # dimension-mismatch (P1).
+        from gptme_rag.indexing.document import Document
+
+        with pytest.raises(RuntimeError, match="openai/text-embedding-3-large"):
+            indexer.add_document(
+                Document(content="new doc", metadata={"source": "test.txt"})
+            )
+        # Collection must still be intact after the failed add attempt.
+        assert indexer.collection.count() == 1
+    finally:
+        if env_backup is not None:
+            os.environ["OPENROUTER_API_KEY"] = env_backup

--- a/packages/gptme-rag/tests/test_indexing.py
+++ b/packages/gptme-rag/tests/test_indexing.py
@@ -1096,3 +1096,53 @@ def test_search_explicit_embedding_function_does_not_wipe_mismatched_collection(
 
     with pytest.raises(RuntimeError, match="stored embedding model"):
         indexer.search("test query")
+
+
+def test_watch_explicit_embedding_function_does_not_wipe_mismatched_collection(
+    tmp_path,
+):
+    """watch must not delete a collection when --embedding-function mismatches the stored model.
+
+    Regression test for P1: the watch command did not pass allow_recreate=False when
+    constructing the Indexer (unlike search). When an explicit --embedding-function differed
+    from the stored model, Indexer set need_recreate=True and silently deleted the entire
+    collection — making watch a destructive daemon-like command instead of a safe watcher.
+
+    The fix passes allow_recreate=False when an explicit embedding function is given,
+    matching the protection already in the search command.
+    """
+    import chromadb
+    from chromadb.config import Settings
+
+    persist_dir = tmp_path / "index"
+    persist_dir.mkdir()
+
+    # Simulate a collection stored with minilm (384-dim).
+    settings = Settings(allow_reset=True, is_persistent=True, anonymized_telemetry=False)
+    client = chromadb.PersistentClient(path=str(persist_dir), settings=settings)
+    col = client.create_collection(
+        name="default",
+        metadata={
+            "hnsw:space": "cosine",
+            "embedding_model": "minilm",
+            "embedding_backend": "sentence-transformers",
+        },
+    )
+    col.add(ids=["doc-1"], embeddings=[[0.1] * 384], documents=["a minilm doc"])
+    assert col.count() == 1
+    del client
+
+    # Constructing with 'modernbert' (768-dim) and allow_recreate=False (what watch now does
+    # when an explicit --embedding-function is given) must NOT destroy the minilm collection.
+    indexer = Indexer(
+        persist_directory=persist_dir,
+        enable_persist=True,
+        embedding_function="modernbert",
+        collection_name="default",
+        allow_recreate=False,
+    )
+
+    # Collection must still exist and contain the original document.
+    assert (
+        indexer.collection.count() == 1
+    ), "Collection was destroyed — watch command data-loss regression"

--- a/packages/gptme-rag/tests/test_indexing.py
+++ b/packages/gptme-rag/tests/test_indexing.py
@@ -1146,3 +1146,68 @@ def test_watch_explicit_embedding_function_does_not_wipe_mismatched_collection(
     assert (
         indexer.collection.count() == 1
     ), "Collection was destroyed — watch command data-loss regression"
+
+
+def test_index_openrouter_fallback_does_not_destroy_existing_openrouter_collection(
+    tmp_path,
+):
+    """index must raise a clear error instead of silently destroying an OpenRouter collection.
+
+    Regression test for P1: when --embedding-function openrouter is passed but
+    OPENROUTER_API_KEY is not set, the Indexer fell back to ModernBERT. With the
+    default allow_recreate=True (used by the index command), the mismatch between the
+    stored OpenRouter model name and the ModernBERT fallback set need_recreate=True,
+    causing the collection to be silently deleted and rebuilt with ModernBERT — destroying
+    the user's OpenRouter-indexed data.
+
+    The fix: when the OpenRouter fallback fires and the existing collection stores an
+    OpenRouter-style model name (containing "/"), raise a clear ValueError instead of
+    proceeding with recreation.
+    """
+    import os
+
+    import chromadb
+    from chromadb.config import Settings
+
+    persist_dir = tmp_path / "index"
+    persist_dir.mkdir()
+
+    # Simulate a collection previously indexed with OpenRouter (1536-dim vectors).
+    settings = Settings(allow_reset=True, is_persistent=True, anonymized_telemetry=False)
+    client = chromadb.PersistentClient(path=str(persist_dir), settings=settings)
+    col = client.create_collection(
+        name="default",
+        metadata={
+            "hnsw:space": "cosine",
+            "embedding_model": "openai/text-embedding-3-large",
+            "embedding_backend": "openrouter",
+        },
+    )
+    col.add(ids=["doc-1"], embeddings=[[0.1] * 1536], documents=["an openrouter doc"])
+    assert col.count() == 1
+    del client
+
+    # Remove the API key so OpenRouterEmbedding.__init__ raises ValueError.
+    env_backup = os.environ.pop("OPENROUTER_API_KEY", None)
+    try:
+        # The index command passes allow_recreate=True (the default).  Without the fix
+        # this would silently destroy the collection.  With the fix it raises ValueError.
+        with pytest.raises(ValueError, match="OPENROUTER_API_KEY"):
+            Indexer(
+                persist_directory=persist_dir,
+                enable_persist=True,
+                embedding_function="openrouter",
+                collection_name="default",
+                allow_recreate=True,
+            )
+    finally:
+        if env_backup is not None:
+            os.environ["OPENROUTER_API_KEY"] = env_backup
+
+    # Verify the collection was NOT destroyed.
+    verify_settings = Settings(allow_reset=True, is_persistent=True, anonymized_telemetry=False)
+    verify_client = chromadb.PersistentClient(path=str(persist_dir), settings=verify_settings)
+    verify_col = verify_client.get_collection(name="default")
+    assert (
+        verify_col.count() == 1
+    ), "Collection was destroyed by OpenRouter fallback — data loss regression"

--- a/packages/gptme-rag/tests/test_indexing.py
+++ b/packages/gptme-rag/tests/test_indexing.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from pathlib import Path
 
 import pytest
+import gptme_rag.indexing.indexer as indexer_module
 from gptme_rag.indexing.document import Document
 from gptme_rag.indexing.indexer import Indexer
 
@@ -315,8 +316,94 @@ def test_auto_embedding_mode_does_not_destroy_foreign_model_collection(tmp_path)
     ), "auto mode destroyed the collection indexed with a non-default embedding model"
 
 
+def test_auto_embedding_mode_rebinds_sentence_transformer_collection(tmp_path, monkeypatch):
+    """Auto mode must reopen sentence-transformer collections with the matching embedder."""
+
+    class FakeModernBERTEmbedding:
+        is_msmarco = False
+
+        def __init__(self, model_name="modernbert", device="cpu"):
+            self.model_name = model_name
+
+        @staticmethod
+        def name() -> str:
+            return "fake-modernbert"
+
+        @staticmethod
+        def is_legacy() -> bool:
+            return False
+
+        def __call__(self, input):
+            return [[1.0] * 768 for _ in input]
+
+        def embed_query(self, input):
+            return self(input)
+
+        def embed_documents(self, input):
+            return self(input)
+
+    class FakeSentenceTransformerEmbedding:
+        is_msmarco = False
+
+        def __init__(self, model_name, device="cpu"):
+            self.model_name = model_name
+
+        @staticmethod
+        def name() -> str:
+            return "fake-sentence-transformer"
+
+        @staticmethod
+        def is_legacy() -> bool:
+            return False
+
+        def __call__(self, input):
+            return [[0.5] * 384 for _ in input]
+
+        def embed_query(self, input):
+            return self(input)
+
+        def embed_documents(self, input):
+            return self(input)
+
+    monkeypatch.setattr(indexer_module, "ModernBERTEmbedding", FakeModernBERTEmbedding)
+    monkeypatch.setattr(
+        indexer_module,
+        "GenericSentenceTransformerEmbedding",
+        FakeSentenceTransformerEmbedding,
+    )
+
+    persist_dir = tmp_path / "index"
+    source_indexer = Indexer(
+        persist_directory=persist_dir,
+        enable_persist=True,
+        embedding_function="minilm",
+        collection_name="default",
+    )
+    source_indexer.add_document(
+        Document(
+            content="Sentence-transformer backed document",
+            metadata={"source": str(tmp_path / "minilm.txt")},
+            doc_id="minilm-doc",
+        )
+    )
+
+    reopened = Indexer(
+        persist_directory=persist_dir,
+        enable_persist=True,
+        embedding_function="auto",
+        collection_name="default",
+    )
+
+    results, _, _ = reopened.search("sentence-transformer")
+    assert reopened.collection.count() == 1
+    assert reopened.embedding_model_name == "all-MiniLM-L6-v2"
+    assert len(results) == 1
+    assert results[0].doc_id == "minilm-doc"
+
+
 def test_reset_collection_preserves_embedding_metadata(indexer):
     """reset_collection must recreate with the same embedding model metadata."""
     indexer.reset_collection()
     metadata = indexer.collection.metadata or {}
     assert metadata.get("embedding_model") == indexer.embedding_model_name
+    assert metadata.get("embedding_backend") == indexer.embedding_backend_name

--- a/packages/gptme-rag/tests/test_indexing.py
+++ b/packages/gptme-rag/tests/test_indexing.py
@@ -760,9 +760,7 @@ def test_auto_mode_add_document_raises_clear_error_when_stored_model_failed(tmp_
         from gptme_rag.indexing.document import Document
 
         with pytest.raises(RuntimeError, match="openai/text-embedding-3-large"):
-            indexer.add_document(
-                Document(content="new doc", metadata={"source": "test.txt"})
-            )
+            indexer.add_document(Document(content="new doc", metadata={"source": "test.txt"}))
         # Collection must still be intact after the failed add attempt.
         assert indexer.collection.count() == 1
     finally:

--- a/packages/gptme-rag/tests/test_indexing.py
+++ b/packages/gptme-rag/tests/test_indexing.py
@@ -70,9 +70,9 @@ def test_indexer_add_documents(indexer, test_docs):
     # Search for ML-related content
     ml_results, ml_distances, _ = indexer.search("machine learning")
     assert len(ml_results) > 0, "No results found for 'machine learning'"
-    assert any("machine learning" in doc.content.lower() for doc in ml_results), (
-        f"Expected 'machine learning' in results: {[doc.content for doc in ml_results]}"
-    )
+    assert any(
+        "machine learning" in doc.content.lower() for doc in ml_results
+    ), f"Expected 'machine learning' in results: {[doc.content for doc in ml_results]}"
     assert len(ml_distances) > 0, "No distances returned"
 
 
@@ -311,9 +311,9 @@ def test_auto_embedding_mode_does_not_destroy_foreign_model_collection(tmp_path)
     )
 
     # Collection must still have the sentinel document — not been recreated
-    assert indexer.collection.count() == 1, (
-        "auto mode destroyed the collection indexed with a non-default embedding model"
-    )
+    assert (
+        indexer.collection.count() == 1
+    ), "auto mode destroyed the collection indexed with a non-default embedding model"
 
 
 def test_auto_embedding_mode_rebinds_sentence_transformer_collection(tmp_path, monkeypatch):
@@ -436,9 +436,9 @@ def test_auto_embedding_mode_preserves_legacy_chromadb_default_collection(tmp_pa
     )
 
     # Collection must be intact and reachable
-    assert indexer.collection.count() == 1, (
-        "auto mode destroyed legacy no-metadata collection (dimension mismatch bug)"
-    )
+    assert (
+        indexer.collection.count() == 1
+    ), "auto mode destroyed legacy no-metadata collection (dimension mismatch bug)"
 
 
 def test_auto_embedding_mode_preserves_collection_when_sentence_transformer_fails_to_load(
@@ -488,9 +488,9 @@ def test_auto_embedding_mode_preserves_collection_when_sentence_transformer_fail
         embedding_function="auto",
         collection_name="default",
     )
-    assert indexer.collection.count() == 1, (
-        "auto mode deleted sentence-transformer collection when the model failed to load"
-    )
+    assert (
+        indexer.collection.count() == 1
+    ), "auto mode deleted sentence-transformer collection when the model failed to load"
 
 
 def test_auto_embedding_mode_sentence_transformer_namespace_not_misrouted_to_openrouter(tmp_path):
@@ -541,9 +541,9 @@ def test_auto_embedding_mode_sentence_transformer_namespace_not_misrouted_to_ope
             embedding_function="auto",
             collection_name="default",
         )
-        assert indexer.collection.count() == 1, (
-            "auto mode destroyed legacy sentence-transformers/ namespace collection (slash misrouting bug)"
-        )
+        assert (
+            indexer.collection.count() == 1
+        ), "auto mode destroyed legacy sentence-transformers/ namespace collection (slash misrouting bug)"
     finally:
         if env_backup is not None:
             os.environ["OPENROUTER_API_KEY"] = env_backup
@@ -589,9 +589,9 @@ def test_auto_embedding_mode_baai_namespace_not_misrouted_to_openrouter(tmp_path
             embedding_function="auto",
             collection_name="default",
         )
-        assert indexer.collection.count() == 1, (
-            "auto mode destroyed legacy BAAI/ namespace collection (incomplete namespace list)"
-        )
+        assert (
+            indexer.collection.count() == 1
+        ), "auto mode destroyed legacy BAAI/ namespace collection (incomplete namespace list)"
     finally:
         if env_backup is not None:
             os.environ["OPENROUTER_API_KEY"] = env_backup
@@ -688,17 +688,17 @@ def test_auto_mode_unknown_namespace_hf_model_tried_as_st_first(tmp_path, monkey
             collection_name="default",
         )
         # The collection must still be intact — not destroyed.
-        assert indexer.collection.count() == 1, (
-            "auto mode destroyed unknown-namespace HF model collection"
-        )
+        assert (
+            indexer.collection.count() == 1
+        ), "auto mode destroyed unknown-namespace HF model collection"
         # ST must have been tried first.
-        assert st_attempts == [unknown_ns_model], (
-            f"Expected ST to be tried first for unknown namespace; st_attempts={st_attempts}"
-        )
+        assert st_attempts == [
+            unknown_ns_model
+        ], f"Expected ST to be tried first for unknown namespace; st_attempts={st_attempts}"
         # OR must NOT have been attempted (ST succeeded).
-        assert or_attempts == [], (
-            f"OR should not be attempted when ST succeeds; or_attempts={or_attempts}"
-        )
+        assert (
+            or_attempts == []
+        ), f"OR should not be attempted when ST succeeds; or_attempts={or_attempts}"
     finally:
         os.environ.pop("OPENROUTER_API_KEY", None)
         if env_backup is not None:
@@ -961,9 +961,9 @@ def test_auto_mode_rebinds_openrouter_collection_when_api_key_present(
 
     # The auto-detect path must have constructed an OpenRouterEmbedding, not fallen
     # back to a local embedder or left embedding_function=None.
-    assert isinstance(indexer.embedding_function, OpenRouterEmbedding), (
-        f"Expected OpenRouterEmbedding, got {type(indexer.embedding_function)}"
-    )
+    assert isinstance(
+        indexer.embedding_function, OpenRouterEmbedding
+    ), f"Expected OpenRouterEmbedding, got {type(indexer.embedding_function)}"
 
     # The rebind must have used the stored model name, not the default.
     assert indexer.embedding_function.model_name == stored_model  # type: ignore[union-attr]
@@ -1082,6 +1082,6 @@ def test_search_explicit_embedding_function_does_not_wipe_mismatched_collection(
     )
 
     # Collection must still exist and contain the original document.
-    assert indexer.collection.count() == 1, (
-        "Collection was destroyed by allow_recreate=False indexer — data loss regression"
-    )
+    assert (
+        indexer.collection.count() == 1
+    ), "Collection was destroyed by allow_recreate=False indexer — data loss regression"

--- a/packages/gptme-rag/tests/test_openrouter_embeddings.py
+++ b/packages/gptme-rag/tests/test_openrouter_embeddings.py
@@ -201,9 +201,63 @@ def test_sqlite_cache_prunes_oldest_entries_when_over_max_rows(tmp_path: Path):
     cache.put_many(model, [(h_extra, [99.0])])
 
     row_count = cache.conn.execute("SELECT COUNT(*) FROM embeddings").fetchone()[0]
-    assert (
-        row_count <= max_rows
-    ), f"Cache should not exceed max_rows={max_rows} after prune, got {row_count}"
+    assert row_count <= max_rows, (
+        f"Cache should not exceed max_rows={max_rows} after prune, got {row_count}"
+    )
     # The freshly-inserted entry must survive (it was just written).
     hit = cache.get_many(model, [h_extra])
     assert h_extra in hit, "Freshly inserted entry was pruned — recency ordering is wrong"
+
+
+def test_sqlite_cache_batch_insert_preserves_all_new_items(tmp_path: Path):
+    """put_many must never prune items from the batch it is currently inserting.
+
+    Regression: with a post-insert prune and all batch rows sharing the same
+    ``accessed_at`` timestamp (executemany evaluates the SQL expression once),
+    ORDER BY accessed_at ASC has no tiebreaker and can arbitrarily delete
+    freshly-inserted entries.
+    """
+    from gptme_rag.embeddings import _SQLiteEmbeddingCache
+
+    cache_path = tmp_path / "cache.sqlite"
+    max_rows = 5
+    cache = _SQLiteEmbeddingCache(path=cache_path, max_rows=max_rows)
+
+    model = "test-model"
+    # Fill the cache to capacity with old entries.
+    for i in range(max_rows):
+        h = _SQLiteEmbeddingCache.content_hash(f"old-{i}")
+        cache.put_many(model, [(h, [float(i)])])
+
+    # Insert a batch of 3 new items — all share the same accessed_at timestamp.
+    # With a post-insert prune and no tiebreaker, any of these could be evicted.
+    batch = [(_SQLiteEmbeddingCache.content_hash(f"new-{i}"), [float(100 + i)]) for i in range(3)]
+    batch_hashes = {h for h, _ in batch}
+    cache.put_many(model, batch)
+
+    row_count = cache.conn.execute("SELECT COUNT(*) FROM embeddings").fetchone()[0]
+    assert row_count <= max_rows, f"Cache exceeded max_rows={max_rows}: {row_count}"
+
+    hits = cache.get_many(model, list(batch_hashes))
+    missing = batch_hashes - set(hits.keys())
+    assert not missing, f"Freshly inserted items were pruned: {missing}"
+
+
+def test_sqlite_cache_oversized_batch_capped_to_max_rows(tmp_path: Path):
+    """A single put_many batch larger than max_rows must not exceed the cap."""
+    from gptme_rag.embeddings import _SQLiteEmbeddingCache
+
+    cache_path = tmp_path / "cache.sqlite"
+    max_rows = 5
+    cache = _SQLiteEmbeddingCache(path=cache_path, max_rows=max_rows)
+
+    model = "test-model"
+    # 2*max_rows items in one shot — previously, all got the same timestamp so
+    # the prune arbitrarily deleted half of the just-inserted rows.
+    batch = [
+        (_SQLiteEmbeddingCache.content_hash(f"doc-{i}"), [float(i)]) for i in range(max_rows * 2)
+    ]
+    cache.put_many(model, batch)
+
+    row_count = cache.conn.execute("SELECT COUNT(*) FROM embeddings").fetchone()[0]
+    assert row_count == max_rows, f"Expected exactly {max_rows} rows, got {row_count}"

--- a/packages/gptme-rag/tests/test_openrouter_embeddings.py
+++ b/packages/gptme-rag/tests/test_openrouter_embeddings.py
@@ -1,0 +1,70 @@
+import json
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from gptme_rag.embeddings import OpenRouterEmbedding
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self) -> bytes:
+        return json.dumps(self.payload).encode("utf-8")
+
+
+def test_openrouter_embedding_batches_and_caches(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    calls: list[list[str]] = []
+
+    def fake_urlopen(request: urllib.request.Request, timeout: int):
+        assert timeout == 180
+        assert request.headers["Authorization"] == "Bearer test-key"
+        payload = json.loads(request.data.decode("utf-8"))  # type: ignore[union-attr]
+        calls.append(payload["input"])
+        return _FakeResponse(
+            {
+                "data": [
+                    {"index": index, "embedding": [3.0, 4.0]}
+                    for index, _text in enumerate(payload["input"])
+                ],
+                "usage": {"total_tokens": 7, "cost": 0.001},
+            }
+        )
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    embedding = OpenRouterEmbedding(
+        api_key="test-key",
+        cache_path=tmp_path / "embeddings.sqlite",
+        max_inputs_per_request=1,
+    )
+
+    vectors = embedding(["alpha", "beta"])
+
+    assert calls == [["alpha"], ["beta"]]
+    for vector in vectors:
+        assert list(vector) == pytest.approx([0.6, 0.8])
+    assert embedding.stats["requests"] == 2
+    assert embedding.stats["api_texts"] == 2
+
+    cached_vectors = embedding(["alpha", "beta"])
+
+    for vector in cached_vectors:
+        assert list(vector) == pytest.approx([0.6, 0.8])
+    assert calls == [["alpha"], ["beta"]]
+    assert embedding.stats["cached_texts"] == 2
+
+
+def test_openrouter_embedding_requires_api_key(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY_EVAL", raising=False)
+
+    with pytest.raises(ValueError, match="OPENROUTER_API_KEY"):
+        OpenRouterEmbedding(cache_path=tmp_path / "embeddings.sqlite")

--- a/packages/gptme-rag/tests/test_openrouter_embeddings.py
+++ b/packages/gptme-rag/tests/test_openrouter_embeddings.py
@@ -176,3 +176,34 @@ def test_openrouter_embedding_non_contiguous_indices_raises(
 
     with pytest.raises(RuntimeError, match="non-contiguous indices"):
         embedding(["first text", "second text"])
+
+
+def test_sqlite_cache_prunes_oldest_entries_when_over_max_rows(tmp_path: Path):
+    """_SQLiteEmbeddingCache must not grow without bound: prune oldest entries past max_rows."""
+    from gptme_rag.embeddings import _SQLiteEmbeddingCache
+
+    cache_path = tmp_path / "cache.sqlite"
+    max_rows = 5
+    cache = _SQLiteEmbeddingCache(path=cache_path, max_rows=max_rows)
+
+    # Insert max_rows entries, then one more batch that triggers pruning.
+    model = "test-model"
+    for i in range(max_rows):
+        h = _SQLiteEmbeddingCache.content_hash(f"doc-{i}")
+        cache.put_many(model, [(h, [float(i)])])
+
+    # Count should be exactly max_rows now.
+    row_count = cache.conn.execute("SELECT COUNT(*) FROM embeddings").fetchone()[0]
+    assert row_count == max_rows, f"Expected {max_rows} rows, got {row_count}"
+
+    # Insert one more — this triggers a prune.
+    h_extra = _SQLiteEmbeddingCache.content_hash("doc-extra")
+    cache.put_many(model, [(h_extra, [99.0])])
+
+    row_count = cache.conn.execute("SELECT COUNT(*) FROM embeddings").fetchone()[0]
+    assert (
+        row_count <= max_rows
+    ), f"Cache should not exceed max_rows={max_rows} after prune, got {row_count}"
+    # The freshly-inserted entry must survive (it was just written).
+    hit = cache.get_many(model, [h_extra])
+    assert h_extra in hit, "Freshly inserted entry was pruned — recency ordering is wrong"

--- a/packages/gptme-rag/tests/test_openrouter_embeddings.py
+++ b/packages/gptme-rag/tests/test_openrouter_embeddings.py
@@ -68,3 +68,18 @@ def test_openrouter_embedding_requires_api_key(monkeypatch: pytest.MonkeyPatch, 
 
     with pytest.raises(ValueError, match="OPENROUTER_API_KEY"):
         OpenRouterEmbedding(cache_path=tmp_path / "embeddings.sqlite")
+
+
+def test_openrouter_embedding_raises_on_oversized_text(tmp_path: Path):
+    """_make_batches must raise ValueError with a descriptive message for texts that
+    exceed max_tokens_per_request, rather than silently sending them to the API where
+    an HTTP 400 would produce a generic RuntimeError."""
+    embedding = OpenRouterEmbedding(
+        api_key="test-key",
+        cache_path=tmp_path / "embeddings.sqlite",
+        max_tokens_per_request=10,
+    )
+    oversized = "x" * 100  # ~33 approx tokens, well above max of 10
+
+    with pytest.raises(ValueError, match="too large"):
+        embedding([oversized])

--- a/packages/gptme-rag/tests/test_openrouter_embeddings.py
+++ b/packages/gptme-rag/tests/test_openrouter_embeddings.py
@@ -201,9 +201,9 @@ def test_sqlite_cache_prunes_oldest_entries_when_over_max_rows(tmp_path: Path):
     cache.put_many(model, [(h_extra, [99.0])])
 
     row_count = cache.conn.execute("SELECT COUNT(*) FROM embeddings").fetchone()[0]
-    assert row_count <= max_rows, (
-        f"Cache should not exceed max_rows={max_rows} after prune, got {row_count}"
-    )
+    assert (
+        row_count <= max_rows
+    ), f"Cache should not exceed max_rows={max_rows} after prune, got {row_count}"
     # The freshly-inserted entry must survive (it was just written).
     hit = cache.get_many(model, [h_extra])
     assert h_extra in hit, "Freshly inserted entry was pruned — recency ordering is wrong"

--- a/packages/gptme-rag/tests/test_openrouter_embeddings.py
+++ b/packages/gptme-rag/tests/test_openrouter_embeddings.py
@@ -70,6 +70,67 @@ def test_openrouter_embedding_requires_api_key(monkeypatch: pytest.MonkeyPatch, 
         OpenRouterEmbedding(cache_path=tmp_path / "embeddings.sqlite")
 
 
+def test_openrouter_embedding_count_mismatch_raises(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    """_embed_batch must raise RuntimeError if the API returns fewer embeddings than inputs.
+
+    Regression test for P1 bug: the zip() at the call site truncated silently
+    when len(rows) < len(texts), leaving some cache keys unpopulated and causing
+    a KeyError on the final list comprehension with no clear error message.
+    Fix: validate len(rows) == len(texts) before returning from _embed_batch.
+    """
+
+    def fake_urlopen(request: urllib.request.Request, timeout: int):
+        # Return only one embedding even though two texts were sent
+        return _FakeResponse(
+            {
+                "data": [{"index": 0, "embedding": [1.0, 0.0]}],
+                "usage": {},
+            }
+        )
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    embedding = OpenRouterEmbedding(
+        api_key="test-key",
+        cache_path=tmp_path / "embeddings.sqlite",
+    )
+
+    with pytest.raises(RuntimeError, match="returned 1 vectors for 2 input texts"):
+        embedding(["first text", "second text"])
+
+
+def test_openrouter_embedding_api_level_error_not_retried(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    """Application-level errors in the API response must not be retried.
+
+    Regression test for P1 bug: a 200 response with an 'error' field (e.g., invalid
+    model name, quota exceeded) raised RuntimeError inside the try block, which was
+    caught by 'except Exception' and retried up to 5 more times with exponential
+    backoff — adding unnecessary delay for permanent failures.
+    Fix: 'except RuntimeError: raise' short-circuits the retry loop.
+    """
+    call_count = 0
+
+    def fake_urlopen(request: urllib.request.Request, timeout: int):
+        nonlocal call_count
+        call_count += 1
+        return _FakeResponse({"error": {"message": "model not found", "code": 404}})
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    embedding = OpenRouterEmbedding(
+        api_key="test-key",
+        cache_path=tmp_path / "embeddings.sqlite",
+    )
+
+    with pytest.raises(RuntimeError, match="OpenRouter embeddings error"):
+        embedding(["test text"])
+
+    # Must fail immediately (1 attempt), not after 6 retries
+    assert call_count == 1, f"Expected 1 attempt, got {call_count} (permanent error was retried)"
+
+
 def test_openrouter_embedding_raises_on_oversized_text(tmp_path: Path):
     """_make_batches must raise ValueError with a descriptive message for texts that
     exceed max_tokens_per_request, rather than silently sending them to the API where

--- a/packages/gptme-rag/tests/test_openrouter_embeddings.py
+++ b/packages/gptme-rag/tests/test_openrouter_embeddings.py
@@ -144,3 +144,35 @@ def test_openrouter_embedding_raises_on_oversized_text(tmp_path: Path):
 
     with pytest.raises(ValueError, match="too large"):
         embedding([oversized])
+
+
+def test_openrouter_embedding_non_contiguous_indices_raises(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    """_embed_batch must raise RuntimeError if the API returns non-contiguous indices.
+
+    A response with correct count but duplicated/out-of-range indices (e.g., [0, 0]
+    instead of [0, 1]) would silently assign embeddings to the wrong texts after
+    sorting. Validate that [r['index'] for r in rows] == list(range(len(texts))).
+    """
+
+    def fake_urlopen(request: urllib.request.Request, timeout: int):
+        # Return two embeddings but with duplicate index 0 instead of [0, 1]
+        return _FakeResponse(
+            {
+                "data": [
+                    {"index": 0, "embedding": [1.0, 0.0]},
+                    {"index": 0, "embedding": [0.0, 1.0]},  # duplicate index — malformed
+                ],
+                "usage": {},
+            }
+        )
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    embedding = OpenRouterEmbedding(
+        api_key="test-key",
+        cache_path=tmp_path / "embeddings.sqlite",
+    )
+
+    with pytest.raises(RuntimeError, match="non-contiguous indices"):
+        embedding(["first text", "second text"])

--- a/scripts/check_install_size.py
+++ b/scripts/check_install_size.py
@@ -163,8 +163,6 @@ def measure_install_size(package_path: Path, package_name: str) -> float | None:
                     "--index-strategy",
                     "unsafe-best-match",
                     "--quiet",
-                    "--index-strategy",
-                    "unsafe-best-match",
                     "-r",
                     str(req_file),
                     str(package_path),
@@ -189,8 +187,6 @@ def measure_install_size(package_path: Path, package_name: str) -> float | None:
                     "--index-strategy",
                     "unsafe-best-match",
                     "--quiet",
-                    "--index-strategy",
-                    "unsafe-best-match",
                     str(package_path),
                 ]
 


### PR DESCRIPTION
## Summary

- add `OpenRouterEmbedding`, a ChromaDB-compatible embedding function using `https://openrouter.ai/api/v1/embeddings`
- cache API embeddings in SQLite by `(model, sha256(text))`
- expose `--embedding-function openrouter` for `index`, `search`, and `watch`
- fall back to local ModernBERT embeddings when `openrouter` is requested without an API key
- document the OpenRouter CLI path and `OPENROUTER_EMBEDDING_MODEL`

## Verification

- OpenRouter docs checked: embeddings endpoint exists and lists `openai/text-embedding-3-large` as an embedding model: https://openrouter.ai/docs/api_reference/embeddings
- Live smoke: `openai/text-embedding-3-large` returned a 3072-dim embedding, 1 request, 10 tokens
- `uv run ruff format --check packages/gptme-rag/src/gptme_rag/embeddings.py packages/gptme-rag/src/gptme_rag/indexing/indexer.py packages/gptme-rag/src/gptme_rag/cli.py packages/gptme-rag/tests/test_openrouter_embeddings.py`
- `uv run ruff check packages/gptme-rag/src/gptme_rag/embeddings.py packages/gptme-rag/src/gptme_rag/indexing/indexer.py packages/gptme-rag/src/gptme_rag/cli.py packages/gptme-rag/tests/test_openrouter_embeddings.py`
- `uv run --with mypy mypy packages/gptme-rag/src/gptme_rag --ignore-missing-imports`
- `uv run --package gptme-rag --extra test python3 -m pytest packages/gptme-rag/tests/test_openrouter_embeddings.py packages/gptme-rag/tests/test_indexing.py::test_reset_collection_preserves_embedding_metadata -q`

## Not Run

- Full `packages/gptme-rag/tests -m 'not slow'` did not complete usefully; interrupted after 1m43s while `test_benchmark.py::test_search_benchmark` was inside ModernBERT CPU inference. Two tests had passed before the interrupt.
