### PR TITLE
fix(runloops): a timed-out dispatch is not a success

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -279,6 +279,7 @@ def build_full_ledger_entry(
     note: str | None = None,
     successes: str | int | None = None,
     failures: str | int | None = None,
+    timeouts: str | int | None = None,
     duration_seconds: str | int | None = None,
     exit_code: str | int | None = None,
     effect: str | None = None,
@@ -290,7 +291,7 @@ def build_full_ledger_entry(
     Mirrors the on-disk schema produced by the bash
     ``append_dispatch_ledger()`` function:
     ``timestamp/phase/lane/dispatch_id/unit/item_count/item_refs/types/items``
-    plus optional ``running_units/cap/note/successes/failures/duration_seconds``
+    plus optional ``running_units/cap/note/successes/failures/timeouts/duration_seconds``
     and the derived pair ``exit_code``/``outcome`` (see
     :func:`derive_dispatch_outcome`).
 
@@ -347,6 +348,7 @@ def build_full_ledger_entry(
         "note": note or None,
         "successes": _maybe_int(successes),
         "failures": _maybe_int(failures),
+        "timeouts": _maybe_int(timeouts),
         "duration_seconds": _maybe_int(duration_seconds),
         "exit_code": _maybe_int(exit_code),
         "effect": (effect or None) if phase in TERMINAL_LEDGER_PHASES else None,

--- a/packages/gptme-runloops/src/gptme_runloops/pr_review/github_adapter.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pr_review/github_adapter.py
@@ -231,9 +231,11 @@ def _build_summary_comment_body(
         f"{count} {sev}"
         for sev, count in sorted(
             n_by_severity.items(),
-            key=lambda x: ["critical", "high", "medium", "low", "info"].index(x[0])
-            if x[0] in ["critical", "high", "medium", "low", "info"]
-            else 99,
+            key=lambda x: (
+                ["critical", "high", "medium", "low", "info"].index(x[0])
+                if x[0] in ["critical", "high", "medium", "low", "info"]
+                else 99
+            ),
         )
     )
 

--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -1333,6 +1333,11 @@ class RunItemOutcome:
     ack_result_json: str
     rate_limited: bool = False
     counted_failure: bool = False
+    #: Worker was hard-killed at its time budget (exit 124). Deliberately NOT a
+    #: ``counted_failure`` — an infra timeout must not contaminate the quality
+    #: signal — but it is emphatically not a success either, so it is tracked
+    #: separately and subtracted from the ledger's ``successes``.
+    timed_out: bool = False
 
 
 def _find_arc(
@@ -1563,10 +1568,12 @@ def execute_plan(
 
     rate_limited = False
     counted_failure = False
+    timed_out = False
     if exit_code == 124:
         _log(
             f"WARN: Item {plan.index} timed out after {plan.timeout}s ({plan.time_desc})"
         )
+        timed_out = True
     elif exit_code != 0:
         _log(f"WARN: Item {plan.index} exited with code {exit_code}")
         counted_failure = True
@@ -1602,6 +1609,7 @@ def execute_plan(
         ack_result_json=ack_result_json,
         rate_limited=rate_limited,
         counted_failure=counted_failure,
+        timed_out=timed_out,
     )
 
 
@@ -2396,6 +2404,7 @@ def run_work_file(
 
         group_count = len(items)
         failures = 0
+        timeouts = 0
         rate_limited = False
         overall_exit = 0
         item_effects: list[str] = []
@@ -2474,6 +2483,8 @@ def run_work_file(
                 )
                 if item_outcome.counted_failure:
                     failures += 1
+                if item_outcome.timed_out:
+                    timeouts += 1
                 if item_outcome.rate_limited:
                     rate_limited = True
                 if item_outcome.exit_code != 0 and overall_exit == 0:
@@ -2489,14 +2500,24 @@ def run_work_file(
 
         promote_notification_states(config)
 
-        # NOTE(parity): successes = total - failures, exactly like the bash
+        # NOTE(parity): successes = total - failures, like the bash
         # (`_item_successes=$(( group_count - _item_failures ))`,
         # project-monitoring.sh:713-714) — so self-merged, claim-denied, and
         # rate-limit-skipped items count as "successes" here too. Inaccurate,
         # but the step-5 ledger A/B needs identical accounting on both paths;
         # fixing the metric is a post-cutover behavior change (both sides of
         # the A/B would otherwise diverge on every skip).
-        successes = group_count - failures
+        #
+        # EXCEPT timeouts. A worker hard-killed at its time budget (exit 124)
+        # sets neither `counted_failure` (deliberately: an infra kill must not
+        # contaminate the quality signal) nor, before this, anything else — so
+        # `group_count - failures` counted it as a SUCCESS. Measured on
+        # state/project-monitoring-dispatch.jsonl 2026-08-11: all 17 rows with
+        # exit_code 124 recorded successes=1, failures=0, outcome="failed". A
+        # row that is simultaneously a success and a failure makes every metric
+        # summing `successes` an over-count, and makes "succeeded" in this
+        # ledger unverifiable. A timeout is neither: subtract it from both.
+        successes = group_count - failures - timeouts
         duration = int(time.time()) - run_start
         # INVARIANT: the ledger's `outcome` is derived from `exit_code`,
         # `failures`, and the observable external `effect`

--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -2551,7 +2551,9 @@ def run_work_file(
             exit_code=overall_exit,
             effect=dispatch_effect,
         )
-        _log(f"Items: {group_count} total, {successes} succeeded, {failures} failed, {timeouts} timed out")
+        _log(
+            f"Items: {group_count} total, {successes} succeeded, {failures} failed, {timeouts} timed out"
+        )
 
         if hooks.post_run is not None:
             env = os.environ.copy()

--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -2137,6 +2137,7 @@ def _append_ledger(
     *,
     successes: int | None = None,
     failures: int | None = None,
+    timeouts: int | None = None,
     duration_seconds: int | None = None,
     exit_code: int | None = None,
     effect: str | None = None,
@@ -2152,6 +2153,7 @@ def _append_ledger(
             note=note or None,
             successes=successes,
             failures=failures,
+            timeouts=timeouts,
             duration_seconds=duration_seconds,
             exit_code=exit_code,
             effect=effect,
@@ -2544,11 +2546,12 @@ def run_work_file(
             "transient_completed",
             successes=successes,
             failures=failures,
+            timeouts=timeouts,
             duration_seconds=duration,
             exit_code=overall_exit,
             effect=dispatch_effect,
         )
-        _log(f"Items: {group_count} total, {successes} succeeded, {failures} failed")
+        _log(f"Items: {group_count} total, {successes} succeeded, {failures} failed, {timeouts} timed out")
 
         if hooks.post_run is not None:
             env = os.environ.copy()

--- a/packages/gptme-runloops/tests/test_pm_dispatch.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch.py
@@ -406,6 +406,7 @@ class TestBuildFullLedgerEntry:
         "note",
         "successes",
         "failures",
+        "timeouts",
         "duration_seconds",
     }
     # Added by the outcome-verification invariant: the recorded outcome is

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -686,7 +686,9 @@ def test_timeout_is_not_counted_as_a_success(tmp_path) -> None:
     completed = [r for r in _ledger_rows(config) if r["phase"] == "completed"][0]
     assert completed["successes"] == 0
     assert completed["failures"] == 0  # still not a quality failure
-    assert completed["timeouts"] == 1  # timed-out item is persisted so the row is self-describing
+    assert (
+        completed["timeouts"] == 1
+    )  # timed-out item is persisted so the row is self-describing
     assert completed["exit_code"] == 124
     assert completed["outcome"] == "failed"
 

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -664,6 +664,32 @@ def test_run_work_file_propagates_session_exit_code(tmp_path) -> None:
     assert completed["failures"] == 0
 
 
+def test_timeout_is_not_counted_as_a_success(tmp_path) -> None:
+    """A hard-killed worker (exit 124) must not appear in `successes`.
+
+    Measured on state/project-monitoring-dispatch.jsonl 2026-08-11: all 17 rows
+    with exit_code 124 recorded successes=1, failures=0, outcome="failed" — a
+    row that is simultaneously a success and a failure. Every metric summing
+    `successes` over-counted by those rows.
+    """
+    item = make_item(types=["notification"], number=0)
+    work_file = _write_work_file(tmp_path, item)
+    config = make_config(tmp_path)
+    run_cmd = FakeRunCmd()
+    run_cmd.on("/fake/run.sh", returncode=124)
+
+    assert (
+        run_work_file(work_file, config, make_hooks(run_cmd=run_cmd), backend="codex")
+        == 124
+    )
+
+    completed = [r for r in _ledger_rows(config) if r["phase"] == "completed"][0]
+    assert completed["successes"] == 0
+    assert completed["failures"] == 0  # still not a quality failure
+    assert completed["exit_code"] == 124
+    assert completed["outcome"] == "failed"
+
+
 def test_run_work_file_counts_failures(tmp_path) -> None:
     item = make_item(types=["notification"], number=0)
     work_file = _write_work_file(tmp_path, item)

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -686,6 +686,7 @@ def test_timeout_is_not_counted_as_a_success(tmp_path) -> None:
     completed = [r for r in _ledger_rows(config) if r["phase"] == "completed"][0]
     assert completed["successes"] == 0
     assert completed["failures"] == 0  # still not a quality failure
+    assert completed["timeouts"] == 1  # timed-out item is persisted so the row is self-describing
     assert completed["exit_code"] == 124
     assert completed["outcome"] == "failed"
 


### PR DESCRIPTION
## Problem

Measured on Bob's `state/project-monitoring-dispatch.jsonl` (2026-08-11): **all 17 completion rows with `exit_code: 124` record `successes >= 1`, `failures: 0`, and `outcome: "failed"`** — simultaneously a success and a failure.

```
exit124 rows: 17
 succ/fail/outcome (1, 0, 'failed') -> 17
completed rows: 1541  sum successes: 1430  overcount from 124: 17
```

Any metric summing `successes` over-counts by those rows, and `"succeeded"` in this ledger cannot be trusted without separately cross-checking `exit_code`. This is the known-lying-metric family.

## Cause

`exit_code == 124` deliberately does **not** set `counted_failure` — an infra timeout must not contaminate the quality signal. But `successes = group_count - failures` then counts it as a success *by omission*. A timeout is neither a success nor a quality failure.

## Fix

Track `RunItemOutcome.timed_out` and subtract timeouts from `successes` as well as excluding them from `failures`.

Quality accounting is unchanged: `failures` still excludes timeouts, so the bandit and grade signals see exactly what they saw before. Only the `successes` over-count goes away.

## A/B Parity

The Python side (this PR) and the bash side must use identical accounting so the step-5 A/B comparison is valid. The companion bash-side fix — adding `_timeout_counter` parallel to `_fail_counter` in `project-monitoring.sh` and `project-monitoring-worker.sh` — was committed to Bob's brain repo in `a5271e11e6` alongside this PR.

Both executors now compute: `successes = total - failures - timeouts`.

## Test

`test_timeout_is_not_counted_as_a_success` — a worker exiting 124 yields `successes == 0`, `failures == 0`, `exit_code == 124`, `outcome == "failed"`. 86 tests pass in `test_run_item.py`.

Found while investigating why PM stopped dispatching gptme/gptme-contrib#1410 after its worker was hard-killed at 908s (the dispatch-recovery half of that fix lives in Bob's repo).