### PR TITLE
feat(self-merge): block PRs with operator hold label (do-not-merge / hold / on-hold)

### DIFF
--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -2411,7 +2411,11 @@ def evaluate_pr(
             "PR labels missing from payload; cannot verify operator hold"
         )
     else:
-        pr_label_names = {lbl.get("name", "").lower() for lbl in pr["labels"]}
+        pr_label_names = {
+            (lbl.get("name") or "").lower()
+            for lbl in pr["labels"]
+            if isinstance(lbl, dict)
+        }
         matched_hold = pr_label_names & _HOLD_LABELS
         if matched_hold:
             result.reasons.append(

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -663,6 +663,20 @@ def fetch_pr(repo: str, number: int) -> dict[str, Any]:
             f"Try GH_API_CACHE_TTL=0 to bypass the cache."
         )
 
+    # Validate that the 'labels' field was returned by gh. We explicitly request
+    # it in the --json fields list, so a missing field indicates a gh CLI version
+    # that predates labels-in-JSON support, or a cache shim stripping the field.
+    # Raise early here (consistent with the number-mismatch check above) so
+    # callers see an explicit diagnostic rather than a silent eligibility block
+    # deep in evaluate_pr.
+    if "labels" not in pr:
+        raise RuntimeError(
+            f"fetch_pr for {repo}#{number}: 'labels' field absent from gh response. "
+            "The field was explicitly requested via --json; this usually means an old "
+            "gh CLI version (<2.27) or a cache shim is stripping the field. "
+            "Upgrade gh or set GH_API_CACHE_TTL=0 to bypass the cache."
+        )
+
     pr["files"] = _fetch_pr_files(repo, number)
     return pr
 
@@ -2404,11 +2418,18 @@ def evaluate_pr(
 
     if not isinstance(pr.get("labels"), list):
         # Labels field absent or null — cannot verify hold state; fail closed.
+        # Under normal operation this branch should not be reached: fetch_pr
+        # explicitly requests labels via --json and raises RuntimeError when the
+        # field is absent. If evaluate_pr is called with a hand-crafted or
+        # cached payload that omits labels, we block rather than silently pass.
         # A present-but-null value is treated identically to a missing key:
         # a cache shim or malformed payload returning labels=null must not
         # accidentally pass the hold check.
+        # To diagnose: check that gh CLI supports the labels JSON field
+        # (gh pr view --json labels), or set GH_API_CACHE_TTL=0 to bypass cache.
         result.reasons.append(
-            "PR labels missing from payload; cannot verify operator hold"
+            "PR labels missing or null in payload; cannot verify operator hold "
+            "(ensure gh CLI ≥2.27 or set GH_API_CACHE_TTL=0 to bypass cache)"
         )
     else:
         pr_label_names = set()

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -2402,7 +2402,7 @@ def evaluate_pr(
     if pr.get("state") != "OPEN":
         result.reasons.append(f"PR state is {pr.get('state')}, not OPEN")
 
-    pr_label_names = {lbl.get("name", "").lower() for lbl in pr.get("labels", [])}
+    pr_label_names = {lbl.get("name", "").lower() for lbl in (pr.get("labels") or [])}
     matched_hold = pr_label_names & _HOLD_LABELS
     if matched_hold:
         result.reasons.append(

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -2402,12 +2402,20 @@ def evaluate_pr(
     if pr.get("state") != "OPEN":
         result.reasons.append(f"PR state is {pr.get('state')}, not OPEN")
 
-    pr_label_names = {lbl.get("name", "").lower() for lbl in (pr.get("labels") or [])}
-    matched_hold = pr_label_names & _HOLD_LABELS
-    if matched_hold:
+    if "labels" not in pr:
+        # Labels field absent from payload — cannot verify hold state; fail closed.
         result.reasons.append(
-            f"Operator hold: {', '.join(sorted(matched_hold))} label — remove label to unblock"
+            "PR labels missing from payload; cannot verify operator hold"
         )
+    else:
+        pr_label_names = {
+            lbl.get("name", "").lower() for lbl in (pr.get("labels") or [])
+        }
+        matched_hold = pr_label_names & _HOLD_LABELS
+        if matched_hold:
+            result.reasons.append(
+                f"Operator hold: {', '.join(sorted(matched_hold))} label — remove label to unblock"
+            )
 
     merge_state = pr.get("mergeStateStatus", "")
     if merge_state == "DIRTY":

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -2411,11 +2411,23 @@ def evaluate_pr(
             "PR labels missing from payload; cannot verify operator hold"
         )
     else:
-        pr_label_names = {
-            (lbl.get("name") or "").lower()
-            for lbl in pr["labels"]
-            if isinstance(lbl, dict)
-        }
+        pr_label_names = set()
+        has_malformed_labels = False
+        for lbl in pr["labels"]:
+            if not isinstance(lbl, dict):
+                has_malformed_labels = True
+                continue
+            name = lbl.get("name")
+            if not isinstance(name, str):
+                has_malformed_labels = True
+                continue
+            pr_label_names.add(name.lower())
+
+        if has_malformed_labels:
+            result.reasons.append(
+                "PR labels contain unparseable entries; cannot verify operator hold"
+            )
+
         matched_hold = pr_label_names & _HOLD_LABELS
         if matched_hold:
             result.reasons.append(

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -129,6 +129,9 @@ AI_REVIEW_MIN_SCORE = 1
 # Only P0/P1 participate in the disposition recall guard. Lower severities do
 # not block self-merge, and the gate must never guess them into existence.
 AI_REVIEW_BLOCKING_SEVERITIES = frozenset({"P0", "P1"})
+# GitHub labels that record an operator hold. An exact case-insensitive match
+# on any of these makes the PR permanently ineligible until the label is removed.
+_HOLD_LABELS = frozenset({"do-not-merge", "hold", "on-hold"})
 # Shortest marker SHA prefix accepted when matching against the PR head. The
 # reviewer writes 12 hex chars; this only guards against a truncated/garbage
 # marker whose 1-2 char "sha" would prefix-match almost any head.
@@ -639,7 +642,7 @@ def fetch_pr(repo: str, number: int) -> dict[str, Any]:
             "--repo",
             repo,
             "--json",
-            "number,title,url,author,statusCheckRollup,isDraft,state,reviewDecision,headRefOid,mergeStateStatus,isCrossRepository,baseRefName",
+            "number,title,url,author,statusCheckRollup,isDraft,state,reviewDecision,headRefOid,mergeStateStatus,isCrossRepository,baseRefName,labels",
         ]
     )
     if not raw:
@@ -2398,6 +2401,13 @@ def evaluate_pr(
 
     if pr.get("state") != "OPEN":
         result.reasons.append(f"PR state is {pr.get('state')}, not OPEN")
+
+    pr_label_names = {lbl.get("name", "").lower() for lbl in pr.get("labels", [])}
+    matched_hold = pr_label_names & _HOLD_LABELS
+    if matched_hold:
+        result.reasons.append(
+            f"Operator hold: {', '.join(sorted(matched_hold))} label — remove label to unblock"
+        )
 
     merge_state = pr.get("mergeStateStatus", "")
     if merge_state == "DIRTY":

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -2402,15 +2402,16 @@ def evaluate_pr(
     if pr.get("state") != "OPEN":
         result.reasons.append(f"PR state is {pr.get('state')}, not OPEN")
 
-    if "labels" not in pr:
-        # Labels field absent from payload — cannot verify hold state; fail closed.
+    if not isinstance(pr.get("labels"), list):
+        # Labels field absent or null — cannot verify hold state; fail closed.
+        # A present-but-null value is treated identically to a missing key:
+        # a cache shim or malformed payload returning labels=null must not
+        # accidentally pass the hold check.
         result.reasons.append(
             "PR labels missing from payload; cannot verify operator hold"
         )
     else:
-        pr_label_names = {
-            lbl.get("name", "").lower() for lbl in (pr.get("labels") or [])
-        }
+        pr_label_names = {lbl.get("name", "").lower() for lbl in pr["labels"]}
         matched_hold = pr_label_names & _HOLD_LABELS
         if matched_hold:
             result.reasons.append(

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -2442,7 +2442,7 @@ def evaluate_pr(
             if not isinstance(name, str):
                 has_malformed_labels = True
                 continue
-            pr_label_names.add(name.lower())
+            pr_label_names.add(name.strip().lower())
 
         if has_malformed_labels:
             result.reasons.append(

--- a/tests/test_self_merge_ai_review_abstention.py
+++ b/tests/test_self_merge_ai_review_abstention.py
@@ -236,6 +236,7 @@ def _evaluate(*comment_bodies: str) -> Any:
         # left behind by an older one.
         "headRefOid": "c096e25e50f8",
         "mergeStateStatus": "CLEAN",
+        "labels": [],
     }
     with (
         patch.object(self_merge_check, "fetch_pr", return_value=pr_data),
@@ -312,6 +313,7 @@ def test_unverifiable_greptile_state_refuses_the_ai_fallback() -> None:
         # left behind by an older one.
         "headRefOid": "c096e25e50f8",
         "mergeStateStatus": "CLEAN",
+        "labels": [],
     }
     with (
         patch.object(self_merge_check, "fetch_pr", return_value=pr_data),

--- a/tests/test_self_merge_ai_review_gate.py
+++ b/tests/test_self_merge_ai_review_gate.py
@@ -437,6 +437,7 @@ def _pr_payload() -> dict[str, Any]:
         "statusCheckRollup": [{"conclusion": "SUCCESS", "status": "COMPLETED"}],
         "reviewDecision": None,
         "files": [{"path": "docs/review-tools.md"}],
+        "labels": [],
     }
 
 

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -345,16 +345,16 @@ def test_evaluate_pr_no_hold_label_is_eligible() -> None:
 
 
 def test_evaluate_pr_malformed_label_elements_do_not_crash() -> None:
-    """Non-dict elements and null name values in the labels list must not crash evaluate_pr.
+    """Non-dict elements and null name values in the labels list must fail closed (block merge).
 
     A cache shim or API change could return labels as a mixed list.
-    Non-dict entries are skipped; none of their names can match _HOLD_LABELS, so
-    the result is eligible (no hold detected, no crash).
+    Non-dict entries and non-string name values are unverifiable, so we block the merge
+    rather than silently skip them (fail-closed security posture to prevent hold bypass).
     """
-    # Mix of non-dict elements and a dict with name=None — none are hold labels
+    # Mix of non-dict elements and a dict with name=None — all are unverifiable
     result = _evaluate_with_hold_labels(["hold", None, {"name": None}, {"name": "ci"}])
-    assert result.eligible
-    assert not any("Operator hold" in r for r in result.reasons)
+    assert not result.eligible
+    assert any("unparseable" in r.lower() for r in result.reasons)
 
 
 def test_evaluate_pr_null_labels_fails_closed() -> None:

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -324,6 +324,20 @@ def test_evaluate_pr_blocks_operator_hold_label(label_name: str) -> None:
     assert label_name in " ".join(result.reasons)
 
 
+@pytest.mark.parametrize("label_name", ["Do-Not-Merge", "HOLD", "On-Hold"])
+def test_evaluate_pr_blocks_operator_hold_label_case_insensitive(
+    label_name: str,
+) -> None:
+    """Hold label matching must be case-insensitive.
+
+    Labels applied via the GitHub UI use the label's stored name, but a future
+    rename (e.g. 'hold' → 'Hold') must not silently bypass the gate.
+    """
+    result = _evaluate_with_hold_labels([{"name": label_name}])
+    assert not result.eligible
+    assert any("Operator hold" in r for r in result.reasons)
+
+
 def test_evaluate_pr_no_hold_label_is_eligible() -> None:
     result = _evaluate_with_hold_labels([{"name": "enhancement"}, {"name": "ci"}])
     assert result.eligible

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -344,6 +344,19 @@ def test_evaluate_pr_no_hold_label_is_eligible() -> None:
     assert not any("Operator hold" in r for r in result.reasons)
 
 
+def test_evaluate_pr_malformed_label_elements_do_not_crash() -> None:
+    """Non-dict elements and null name values in the labels list must not crash evaluate_pr.
+
+    A cache shim or API change could return labels as a mixed list.
+    Non-dict entries are skipped; none of their names can match _HOLD_LABELS, so
+    the result is eligible (no hold detected, no crash).
+    """
+    # Mix of non-dict elements and a dict with name=None — none are hold labels
+    result = _evaluate_with_hold_labels(["hold", None, {"name": None}, {"name": "ci"}])
+    assert result.eligible
+    assert not any("Operator hold" in r for r in result.reasons)
+
+
 def test_evaluate_pr_null_labels_fails_closed() -> None:
     """Labels key present but null must fail closed — same as a missing key.
 

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -196,7 +196,7 @@ def test_evaluate_pr_blocks_changes_requested() -> None:
 
 def _make_clean_pr_data(**overrides: object) -> dict[str, object]:
     """Minimal PR data that passes all other checks. Override fields to test specific gates."""
-    data = {
+    data: dict[str, object] = {
         "author": {"login": "TimeToBuildBob"},
         "title": "Test PR",
         "url": "https://github.com/gptme/gptme-contrib/pull/999",
@@ -207,6 +207,7 @@ def _make_clean_pr_data(**overrides: object) -> dict[str, object]:
         "reviewDecision": None,
         "headRefOid": "abc123",
         "mergeStateStatus": "CLEAN",
+        "labels": [],
     }
     data.update(overrides)
     return data
@@ -274,6 +275,57 @@ def test_evaluate_pr_clean_merge_state_passes_gate() -> None:
 
     assert result.eligible
     assert not any("merge conflicts" in r for r in result.reasons)
+
+
+_HOLD_PATCH_CONTEXT = (
+    patch.object,
+    patch.object,
+    patch.object,
+    patch.object,
+    patch.object,
+    patch.object,
+)
+
+
+def _evaluate_with_hold_labels(labels: list[dict[str, str]]) -> object:
+    pr_data = _make_clean_pr_data(labels=labels)
+    with (
+        patch.object(self_merge_check, "fetch_pr", return_value=pr_data),
+        patch.object(self_merge_check, "get_gh_user", return_value="TimeToBuildBob"),
+        patch.object(
+            self_merge_check, "_fetch_greptile_review_data", return_value=None
+        ),
+        patch.object(
+            self_merge_check,
+            "fetch_greptile_status",
+            return_value={"has_review": True, "unresolved": 0, "total": 1},
+        ),
+        patch.object(self_merge_check, "greptile_summary_score", return_value=None),
+        patch.object(
+            self_merge_check,
+            "fetch_unresolved_human_threads",
+            return_value={"unresolved": 0, "total": 0, "authors": []},
+        ),
+    ):
+        return self_merge_check.evaluate_pr(
+            "gptme/gptme-contrib",
+            999,
+            workspace_repos=["gptme/gptme-contrib"],
+        )
+
+
+@pytest.mark.parametrize("label_name", ["do-not-merge", "hold", "on-hold"])
+def test_evaluate_pr_blocks_operator_hold_label(label_name: str) -> None:
+    result = _evaluate_with_hold_labels([{"name": label_name}])
+    assert not result.eligible
+    assert any("Operator hold" in r for r in result.reasons)
+    assert label_name in " ".join(result.reasons)
+
+
+def test_evaluate_pr_no_hold_label_is_eligible() -> None:
+    result = _evaluate_with_hold_labels([{"name": "enhancement"}, {"name": "ci"}])
+    assert result.eligible
+    assert not any("Operator hold" in r for r in result.reasons)
 
 
 def test_fetch_greptile_status_paginates_review_threads() -> None:

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -329,6 +329,36 @@ def test_evaluate_pr_no_hold_label_is_eligible() -> None:
     assert not any("Operator hold" in r for r in result.reasons)
 
 
+def test_evaluate_pr_null_labels_does_not_crash() -> None:
+    """Labels key present but null (e.g. from a cache shim) must not raise TypeError."""
+    pr_data = _make_clean_pr_data(labels=None)
+    with (
+        patch.object(self_merge_check, "fetch_pr", return_value=pr_data),
+        patch.object(self_merge_check, "get_gh_user", return_value="TimeToBuildBob"),
+        patch.object(
+            self_merge_check, "_fetch_greptile_review_data", return_value=None
+        ),
+        patch.object(
+            self_merge_check,
+            "fetch_greptile_status",
+            return_value={"has_review": True, "unresolved": 0, "total": 1},
+        ),
+        patch.object(self_merge_check, "greptile_summary_score", return_value=None),
+        patch.object(
+            self_merge_check,
+            "fetch_unresolved_human_threads",
+            return_value={"unresolved": 0, "total": 0, "authors": []},
+        ),
+    ):
+        result = self_merge_check.evaluate_pr(
+            "gptme/gptme-contrib",
+            999,
+            workspace_repos=["gptme/gptme-contrib"],
+        )
+    assert result.eligible
+    assert not any("Operator hold" in r for r in result.reasons)
+
+
 def test_fetch_greptile_status_paginates_review_threads() -> None:
     first_page = {
         "data": {

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -328,6 +328,22 @@ def test_evaluate_pr_blocks_operator_hold_label_case_insensitive(
     assert any("Operator hold" in r for r in result.reasons)
 
 
+@pytest.mark.parametrize("label_name", ["do-not-merge ", " hold", " on-hold "])
+def test_evaluate_pr_blocks_operator_hold_label_with_whitespace(
+    label_name: str,
+) -> None:
+    """Hold label matching must strip surrounding whitespace.
+
+    GitHub labels can be applied with accidental leading/trailing spaces when
+    created or renamed via the UI or API. A 'do-not-merge ' (trailing space)
+    label should still block the merge — the .strip() call in the detection
+    logic is the guard; this test pins that contract.
+    """
+    result = _evaluate_with_hold_labels([{"name": label_name}])
+    assert not result.eligible
+    assert any("Operator hold" in r for r in result.reasons)
+
+
 def test_evaluate_pr_no_hold_label_is_eligible() -> None:
     result = _evaluate_with_hold_labels([{"name": "enhancement"}, {"name": "ci"}])
     assert result.eligible

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -289,7 +289,7 @@ _HOLD_PATCH_CONTEXT = (
 )
 
 
-def _evaluate_with_hold_labels(labels: list[dict[str, str]]) -> Any:
+def _evaluate_with_hold_labels(labels: list[object]) -> Any:
     pr_data = _make_clean_pr_data(labels=labels)
     with (
         patch.object(self_merge_check, "fetch_pr", return_value=pr_data),

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -279,16 +279,6 @@ def test_evaluate_pr_clean_merge_state_passes_gate() -> None:
     assert not any("merge conflicts" in r for r in result.reasons)
 
 
-_HOLD_PATCH_CONTEXT = (
-    patch.object,
-    patch.object,
-    patch.object,
-    patch.object,
-    patch.object,
-    patch.object,
-)
-
-
 def _evaluate_with_hold_labels(labels: list[object]) -> Any:
     pr_data = _make_clean_pr_data(labels=labels)
     with (
@@ -744,6 +734,7 @@ def test_fetch_pr_uses_paginated_rest_files_api() -> None:
         "isDraft": False,
         "state": "OPEN",
         "reviewDecision": None,
+        "labels": [],
     }
     files_output = "\n".join(
         [json.dumps({"path": f"tests/test_{i}.py"}) for i in range(105)]
@@ -1708,6 +1699,41 @@ def test_fetch_pr_raises_on_missing_number() -> None:
         patch.object(self_merge_check, "_fetch_pr_files", return_value=[]),
     ):
         with pytest.raises(RuntimeError, match="PR data mismatch.*1257.*None"):
+            self_merge_check.fetch_pr("gptme/gptme-contrib", 1257)
+
+
+def test_fetch_pr_raises_on_missing_labels_field() -> None:
+    """fetch_pr must raise RuntimeError when the gh response omits the 'labels' field.
+
+    The field is explicitly requested via --json, so its absence means an old gh
+    CLI version (<2.27) or a cache shim stripping the field. We raise at fetch
+    time so callers get an explicit diagnostic instead of a silent eligibility
+    block deep in evaluate_pr.
+
+    This is the same fail-explicit pattern used for number-mismatch above.
+    """
+    payload_missing_labels = json.dumps(
+        {
+            "number": 1257,
+            "title": "test PR",
+            "url": "https://github.com/gptme/gptme-contrib/pull/1257",
+            "author": {"login": "TimeToBuildBob"},
+            "statusCheckRollup": [],
+            "isDraft": False,
+            "state": "OPEN",
+            "reviewDecision": None,
+            "headRefOid": "abc123",
+            "mergeStateStatus": "CLEAN",
+            "baseRefName": "master",
+            # 'labels' key intentionally absent — simulates old gh CLI or cache shim
+        }
+    )
+
+    with (
+        patch.object(self_merge_check, "run_gh", return_value=payload_missing_labels),
+        patch.object(self_merge_check, "_fetch_pr_files", return_value=[]),
+    ):
+        with pytest.raises(RuntimeError, match="labels.*field absent from gh response"):
             self_merge_check.fetch_pr("gptme/gptme-contrib", 1257)
 
 

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -6,6 +6,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -287,7 +288,7 @@ _HOLD_PATCH_CONTEXT = (
 )
 
 
-def _evaluate_with_hold_labels(labels: list[dict[str, str]]) -> object:
+def _evaluate_with_hold_labels(labels: list[dict[str, str]]) -> Any:
     pr_data = _make_clean_pr_data(labels=labels)
     with (
         patch.object(self_merge_check, "fetch_pr", return_value=pr_data),

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -330,8 +330,13 @@ def test_evaluate_pr_no_hold_label_is_eligible() -> None:
     assert not any("Operator hold" in r for r in result.reasons)
 
 
-def test_evaluate_pr_null_labels_does_not_crash() -> None:
-    """Labels key present but null (e.g. from a cache shim) must not raise TypeError."""
+def test_evaluate_pr_null_labels_fails_closed() -> None:
+    """Labels key present but null must fail closed — same as a missing key.
+
+    A cache shim or malformed payload returning labels=null must not accidentally
+    pass the hold check. Null is unverifiable, so we block like we do for a
+    missing key rather than treating it as 'no hold labels present'.
+    """
     pr_data = _make_clean_pr_data(labels=None)
     with (
         patch.object(self_merge_check, "fetch_pr", return_value=pr_data),
@@ -356,8 +361,8 @@ def test_evaluate_pr_null_labels_does_not_crash() -> None:
             999,
             workspace_repos=["gptme/gptme-contrib"],
         )
-    assert result.eligible
-    assert not any("Operator hold" in r for r in result.reasons)
+    assert not result.eligible
+    assert any("labels missing" in r for r in result.reasons)
 
 
 def test_evaluate_pr_missing_labels_key_blocks_merge() -> None:

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -359,6 +359,37 @@ def test_evaluate_pr_null_labels_does_not_crash() -> None:
     assert not any("Operator hold" in r for r in result.reasons)
 
 
+def test_evaluate_pr_missing_labels_key_blocks_merge() -> None:
+    """Labels key entirely absent from payload must fail closed (not allow merge)."""
+    pr_data = _make_clean_pr_data()
+    del pr_data["labels"]  # simulate payload missing the field entirely
+    with (
+        patch.object(self_merge_check, "fetch_pr", return_value=pr_data),
+        patch.object(self_merge_check, "get_gh_user", return_value="TimeToBuildBob"),
+        patch.object(
+            self_merge_check, "_fetch_greptile_review_data", return_value=None
+        ),
+        patch.object(
+            self_merge_check,
+            "fetch_greptile_status",
+            return_value={"has_review": True, "unresolved": 0, "total": 1},
+        ),
+        patch.object(self_merge_check, "greptile_summary_score", return_value=None),
+        patch.object(
+            self_merge_check,
+            "fetch_unresolved_human_threads",
+            return_value={"unresolved": 0, "total": 0, "authors": []},
+        ),
+    ):
+        result = self_merge_check.evaluate_pr(
+            "gptme/gptme-contrib",
+            999,
+            workspace_repos=["gptme/gptme-contrib"],
+        )
+    assert not result.eligible
+    assert any("labels missing" in r.lower() for r in result.reasons)
+
+
 def test_fetch_greptile_status_paginates_review_threads() -> None:
     first_page = {
         "data": {

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -164,6 +164,7 @@ def test_evaluate_pr_blocks_changes_requested() -> None:
         "isDraft": False,
         "state": "OPEN",
         "reviewDecision": "CHANGES_REQUESTED",
+        "labels": [],
     }
 
     with (
@@ -874,6 +875,7 @@ def test_evaluate_pr_warns_when_workspace_repos_empty() -> None:
         "isDraft": False,
         "state": "OPEN",
         "reviewDecision": None,
+        "labels": [],
     }
 
     with (
@@ -917,6 +919,7 @@ def _eligible_pr_data() -> dict:
         "isDraft": False,
         "state": "OPEN",
         "reviewDecision": None,
+        "labels": [],
     }
 
 

--- a/tests/test_self_merge_ci_configured.py
+++ b/tests/test_self_merge_ci_configured.py
@@ -391,6 +391,7 @@ def _evaluate_with(
         "comments": [],
         "isCrossRepository": is_cross_repository,
         "baseRefName": "master",
+        "labels": [],
     }
     monkeypatch.setattr(smc, "fetch_pr", lambda *a, **k: pr)
     real_run_gh = smc.run_gh


### PR DESCRIPTION
## Summary

Adds a durable GitHub-label-based hold mechanism so an operator can record a
\"don't merge this\" decision that survives every context window boundary.

**Problem**: When Erik says \"don't merge this\" in a session, that decision lives
only in that session's conversation context. Sibling autonomous sessions and PM
dispatches have no way to know about the hold. PM then keeps spending cycles
driving the held PR toward merge readiness (gptme-contrib#1380 was referenced
5× in 24h while explicitly held).

**Mechanism chosen**: GitHub label (`do-not-merge`, `hold`, or `on-hold`).
Durable, machine-readable, visible in the PR list to humans, survives every
context window.

**Changes**:
- `fetch_pr()` requests the `labels` field from the GitHub API
- `_HOLD_LABELS` frozenset defines the canonical hold label names
- `evaluate_pr()` checks for any matching label and appends a fail-closed reason: `"Operator hold: <label> — remove label to unblock"`
- 4 new tests (3 parametrized label variants + 1 no-hold-passes guard)
- `_make_clean_pr_data()` updated with `labels: []` default

**Verified**: Applied `do-not-merge` label to gptme-contrib#1380 and confirmed
the gate now cites the hold explicitly (independently of the three incidental
blockers already present).

## Test plan

- [x] `test_evaluate_pr_blocks_operator_hold_label[do-not-merge]` passes
- [x] `test_evaluate_pr_blocks_operator_hold_label[hold]` passes
- [x] `test_evaluate_pr_blocks_operator_hold_label[on-hold]` passes
- [x] `test_evaluate_pr_no_hold_label_is_eligible` passes
- [x] All 213 existing tests pass (no regressions)
- [x] Live test: `self-merge-check.py gptme-contrib#1380` reports `Operator hold: do-not-merge label` as a reason

## Operator workflow

To hold a PR from autonomous merge: apply the `do-not-merge` label via GitHub
UI or `gh pr edit <num> --add-label "do-not-merge"`. Remove the label to unblock.