### PR TITLE
fix(pm-dispatch): route pr_never_checked to pr-review work type

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -29,6 +29,7 @@ from typing import Any, Callable, cast
 # else (notifications, assigned issues).
 SLOW_LANE_TYPES: set[str] = {
     "pr_update",
+    "pr_never_checked",
     "ci_failure",
     "master_ci_failure",
     "merge_conflict",
@@ -462,6 +463,7 @@ def classify_item_work_type(types: list[str], repo: str | None = None) -> str:
         # workflow run requires a human click, which an automated review pass cannot do.
         if (
             "pr_update" in types_set
+            and "pr_never_checked" not in types_set
             and repo
             and repo in _automated_pr_review_allowlist()
         ):

--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -457,8 +457,14 @@ def classify_item_work_type(types: list[str], repo: str | None = None) -> str:
         return "greptile-convergence"
     if "merge_conflict" in types_set:
         return "merge-conflict"
-    if "pr_update" in types_set:
-        if repo and repo in _automated_pr_review_allowlist():
+    if types_set & {"pr_update", "pr_never_checked"}:
+        # pr_never_checked never routes to automated-pr-review: approving a held
+        # workflow run requires a human click, which an automated review pass cannot do.
+        if (
+            "pr_update" in types_set
+            and repo
+            and repo in _automated_pr_review_allowlist()
+        ):
             return "automated-pr-review"
         return "pr-review"
     if "assigned" in types_set:

--- a/packages/gptme-runloops/tests/test_pm_dispatch.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch.py
@@ -1461,6 +1461,28 @@ class TestClassifyItemWorkType:
         # No repo → original pr-review behavior
         assert classify_item_work_type(["pr_update"]) == "pr-review"
 
+    def test_pr_never_checked_routes_to_pr_review(self):
+        assert classify_item_work_type(["pr_never_checked"]) == "pr-review"
+
+    def test_pr_never_checked_not_automated_review_in_allowlisted_repo(
+        self, monkeypatch
+    ):
+        # Approving a held workflow run requires a human click — never automated-pr-review
+        monkeypatch.setenv("AUTOMATED_PR_REVIEW_REPOS", "gptme/gptme-cloud")
+        assert (
+            classify_item_work_type(["pr_never_checked"], repo="gptme/gptme-cloud")
+            == "pr-review"
+        )
+
+    def test_pr_update_still_routes_to_automated_review_in_allowlisted_repo(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("AUTOMATED_PR_REVIEW_REPOS", "gptme/gptme-cloud")
+        assert (
+            classify_item_work_type(["pr_update"], repo="gptme/gptme-cloud")
+            == "automated-pr-review"
+        )
+
 
 # --- _bandit_observation_count and _resolve_model_with_bandit ---
 

--- a/packages/gptme-runloops/tests/test_pm_dispatch.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch.py
@@ -172,6 +172,7 @@ class TestClassifyLane:
         """Verify all expected slow-lane types are in the set."""
         expected = {
             "pr_update",
+            "pr_never_checked",
             "ci_failure",
             "master_ci_failure",
             "merge_conflict",
@@ -183,6 +184,9 @@ class TestClassifyLane:
 
     def test_greptile_convergence_adjudication_is_slow(self):
         assert classify_lane(["greptile_convergence_adjudication"]) == "slow"
+
+    def test_pr_never_checked_is_slow(self):
+        assert classify_lane(["pr_never_checked"]) == "slow"
 
 
 class TestClassifyItemWorkTypeGreptileConvergence:
@@ -1481,6 +1485,18 @@ class TestClassifyItemWorkType:
         assert (
             classify_item_work_type(["pr_update"], repo="gptme/gptme-cloud")
             == "automated-pr-review"
+        )
+
+    def test_combined_pr_never_checked_and_pr_update_not_automated_review(
+        self, monkeypatch
+    ):
+        # Even with pr_update present, pr_never_checked must block automated-pr-review
+        monkeypatch.setenv("AUTOMATED_PR_REVIEW_REPOS", "gptme/gptme-cloud")
+        assert (
+            classify_item_work_type(
+                ["pr_never_checked", "pr_update"], repo="gptme/gptme-cloud"
+            )
+            == "pr-review"
         )
 
 


### PR DESCRIPTION
## Problem

`pr_never_checked` items — open, non-draft PRs with zero CI checks past 6h
— were falling through to `notification-triage` in `classify_item_work_type`
because the function had no case for them. This caused the bandit to treat
"review an outside contributor's PR and approve their workflow run" as a
triage-tier task, routing it to a weaker model lane.

## Fix

Add `pr_never_checked` to the `{pr_update, pr_never_checked}` set check in
`classify_item_work_type`. The item always routes to `pr-review`.

`pr_never_checked` is explicitly excluded from `automated-pr-review` even
in allowlisted repos: approving a held workflow run requires a human click,
which an automated review pass cannot perform. `pr_update` items in
allowlisted repos continue to route to `automated-pr-review` as before.

## Tests

Three new tests in `TestClassifyItemWorkType`:
- `test_pr_never_checked_routes_to_pr_review`
- `test_pr_never_checked_not_automated_review_in_allowlisted_repo`
- `test_pr_update_still_routes_to_automated_review_in_allowlisted_repo`

All 20 tests in the class pass.

Companion brain-repo task: `tasks/pm-never-checked-work-type-routing.md`