### PR TITLE
fix(pm): gate delivery post-condition on thread-deliverable item types

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -1855,7 +1855,13 @@ def run_post_session(
     if (
         item.repo
         and item.number is not None
-        and item.number != 0  # 0 is a sentinel for items with no real GitHub thread
+        # 0 is a sentinel for items with no real GitHub thread. Compared via
+        # `number_str` because `number` is an `int | str | None` union taken
+        # verbatim from the grouped JSON (`from_grouped_json`) — a sentinel
+        # arriving as the string "0" must be excluded exactly as the int is,
+        # or the check queries `issues/0/comments`, 404s, and reports
+        # `orphan_no_delivery`, re-creating the re-dispatch loop this gates.
+        and item.number_str != "0"
         and hooks.delivery_check is not None
         and THREAD_DELIVERABLE_TYPES & set(item.types)
     ):

--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -1855,6 +1855,7 @@ def run_post_session(
     if (
         item.repo
         and item.number is not None
+        and item.number != 0  # 0 is a sentinel for items with no real GitHub thread
         and hooks.delivery_check is not None
         and THREAD_DELIVERABLE_TYPES & set(item.types)
     ):

--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -2077,7 +2077,12 @@ def run_post_session(
         pr_state_after = ""
         if record_file.is_file():
             pr_state_after = read_record_pr_state_after(record_file)
-        if not pr_state_after and item.repo and item.number is not None:
+        if (
+            not pr_state_after
+            and item.repo
+            and item.number is not None
+            and THREAD_DELIVERABLE_TYPES & set(item.types)
+        ):
             try:
                 proc = hooks.run_cmd(
                     [

--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -137,13 +137,22 @@ PR_STATE_TYPES: frozenset[str] = frozenset({"pr_update", "merge_ready"})
 # session reply on the thread?" is a meaningful post-condition
 # (worker.sh:453 — `grep -qwE "assigned_issue|pr_update|ci_failure|..."`).
 #
-# Repo-level types are deliberately absent. `master_ci_failure` carries a
-# workflow *run id* as `number` (e.g. 31681387507), not an issue number, so
-# `issues/{number}/comments` 404s, no comment is ever found, and the check
-# returns `orphan_no_delivery` → rollback → re-dispatch, forever. The PM prompt
-# tells those sessions to "exit cleanly without inventing a thread reply"
-# (runs/github/project-monitoring.sh), so the post-condition was punishing
-# sessions for obeying their own instructions.
+# Types with no thread are deliberately absent. Two distinct symptom classes,
+# both traced to this one missing gate:
+#
+# 1. `master_ci_failure` carries a workflow *run id* as `number`
+#    (e.g. 31681387507), not an issue number, so `issues/{number}/comments`
+#    404s, no comment is ever found, and the check returns
+#    `orphan_no_delivery` → rollback → re-dispatch, forever. The PM prompt
+#    tells those sessions to "exit cleanly without inventing a thread reply"
+#    (runs/github/project-monitoring.sh), so the post-condition was punishing
+#    sessions for obeying their own instructions.
+# 2. `agent_msg_reply` (peer-agent message) has no issue at all and carries a
+#    synthesized `number` of 0. Measured on Bob's dispatch ledger 2026-08-13:
+#    every `number: 0` row was `agent_msg_reply`, and the two that reached the
+#    ported executor both recorded `no_effect` despite the reply actually
+#    being delivered — which drove `pm_dispatch_recovery.py` to exhaust the
+#    retry budget and file a bogus "PM cannot drive ErikBjare/bob#0" stuck task.
 THREAD_DELIVERABLE_TYPES: frozenset[str] = frozenset(
     {
         "assigned_issue",

--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -2078,10 +2078,12 @@ def run_post_session(
         if record_file.is_file():
             pr_state_after = read_record_pr_state_after(record_file)
         if (
-            not pr_state_after
-            and item.repo
-            and item.number is not None
-            and THREAD_DELIVERABLE_TYPES & set(item.types)
+            not pr_state_after and item.repo and item.number is not None
+            # No THREAD_DELIVERABLE_TYPES filter here: arc auto-close must run
+            # for any item type that carries an arc_id and a plausible PR number.
+            # For non-PR numbers (workflow run ids, synthesized 0 for
+            # agent_msg_reply) `gh pr view` fails naturally and pr_state_after
+            # stays empty — no type filter needed.
         ):
             try:
                 proc = hooks.run_cmd(

--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -133,6 +133,30 @@ from gptme_runloops.worker_records import (
 # steps (worker.sh:72,379,555 — `grep -qwE "pr_update|merge_ready"`).
 PR_STATE_TYPES: frozenset[str] = frozenset({"pr_update", "merge_ready"})
 
+# Item types whose `number` addresses a real issue/PR thread, so "did the
+# session reply on the thread?" is a meaningful post-condition
+# (worker.sh:453 — `grep -qwE "assigned_issue|pr_update|ci_failure|..."`).
+#
+# Repo-level types are deliberately absent. `master_ci_failure` carries a
+# workflow *run id* as `number` (e.g. 31681387507), not an issue number, so
+# `issues/{number}/comments` 404s, no comment is ever found, and the check
+# returns `orphan_no_delivery` → rollback → re-dispatch, forever. The PM prompt
+# tells those sessions to "exit cleanly without inventing a thread reply"
+# (runs/github/project-monitoring.sh), so the post-condition was punishing
+# sessions for obeying their own instructions.
+THREAD_DELIVERABLE_TYPES: frozenset[str] = frozenset(
+    {
+        "assigned_issue",
+        "pr_update",
+        "ci_failure",
+        "merge_ready",
+        "greptile_needs_improvement",
+        "greptile_needs_fix",
+        "merge_conflict",
+        "notification",
+    }
+)
+
 # CC stream-json trajectory floor (worker.sh:205) and grok floor (worker.sh:218).
 CC_TRAJECTORY_MIN_BYTES = 5000
 GROK_TRAJECTORY_MIN_BYTES = 1000
@@ -1819,7 +1843,12 @@ def run_post_session(
     delivery_verified = False  # True only when the check exited 0 with parseable output
     needs_fallback = "false"
     fallback_posted = "false"
-    if item.repo and item.number is not None and hooks.delivery_check is not None:
+    if (
+        item.repo
+        and item.number is not None
+        and hooks.delivery_check is not None
+        and THREAD_DELIVERABLE_TYPES & set(item.types)
+    ):
         try:
             try:
                 proc = hooks.run_cmd(

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -1414,6 +1414,43 @@ def test_post_session_missing_delivery_hook_skips_check(tmp_path) -> None:
     assert latency_calls[0]["outcome"] == "handled"
 
 
+def test_post_session_repo_level_item_skips_delivery_check(tmp_path) -> None:
+    """master_ci_failure has no thread, so the reply post-condition must not run.
+
+    Its `number` is a workflow run id, not an issue number, so the check would
+    query issues/{run_id}/comments, 404, find no comment, and return
+    orphan_no_delivery -> rollback -> re-dispatch forever (ErikBjare/bob#1144).
+    """
+    config, item, plan, outcome, hooks, run_cmd, latency_calls = _post_session_fixture(
+        tmp_path, types=("master_ci_failure",)
+    )
+    hooks.wait_merge_gate = None
+    hooks.arc_manager = None
+    run_cmd.on("/fake/check-delivery.py", stdout='{"outcome": "orphan_no_delivery"}')
+    run_post_session(plan, item, outcome, config, hooks)
+    assert run_cmd.find("/fake/check-delivery.py") == []
+    assert latency_calls[0]["outcome"] == "handled"
+
+
+def test_post_session_thread_deliverable_item_still_runs_delivery_check(
+    tmp_path,
+) -> None:
+    """Regression guard: the type gate must not disable checks for real threads."""
+    config, item, plan, outcome, hooks, run_cmd, latency_calls = _post_session_fixture(
+        tmp_path, types=("assigned_issue",)
+    )
+    hooks.wait_merge_gate = None
+    hooks.arc_manager = None
+    run_cmd.on(
+        "/fake/check-delivery.py",
+        stdout='{"outcome": "orphan_no_delivery", "needs_fallback_reply": true, '
+        '"fallback_reply_posted": false}',
+    )
+    run_post_session(plan, item, outcome, config, hooks)
+    assert run_cmd.find("/fake/check-delivery.py") != []
+    assert latency_calls[0]["outcome"] == "orphan_no_delivery"
+
+
 def test_post_session_gate_exit_2_warns_no_helper(tmp_path) -> None:
     config, item, plan, outcome, hooks, run_cmd, _ = _post_session_fixture(tmp_path)
     run_cmd.on("/fake/check-delivery.py", stdout='{"outcome": "handled"}')

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -1525,6 +1525,39 @@ def test_post_session_notification_zero_number_skips_delivery_check(tmp_path) ->
     )
 
 
+def test_post_session_string_zero_number_skips_delivery_check(tmp_path) -> None:
+    """A grouped item carrying ``"number": "0"`` as a *string* must skip too.
+
+    ``RunItem.number`` is typed ``int | str | None`` and
+    ``from_grouped_json`` takes the JSON value verbatim — no coercion. A
+    sentinel that arrives as the string ``"0"`` is therefore just as real as
+    the int ``0``, and an identity-shaped guard (``number != 0``) lets it
+    through: the delivery check queries ``issues/0/comments``, 404s, reports
+    ``orphan_no_delivery``, and drives the rollback → re-dispatch loop this
+    gate exists to eliminate.
+    """
+    config, item, plan, outcome, hooks, run_cmd, _ = _post_session_fixture(
+        tmp_path, types=("notification",)
+    )
+    # Built through `from_grouped_json`, so `number` really is the str "0".
+    item = make_item(types=["notification"], number="0")
+    assert item.number == "0", "fixture must exercise the str sentinel, not the int"
+    hooks.wait_merge_gate = None
+    hooks.arc_manager = None
+    # If the check DID run it would report an orphan, as it does in production.
+    run_cmd.on("/fake/check-delivery.py", stdout='{"outcome": "orphan_no_delivery"}')
+
+    effect = run_post_session(plan, item, outcome, config, hooks)
+
+    assert (
+        run_cmd.find("/fake/check-delivery.py") == []
+    ), 'delivery check must not run for items with number="0" (string sentinel)'
+    assert effect == "unknown", (
+        f"notification with number=\"0\" must score effect='unknown', not {effect!r}; "
+        "EFFECT_NONE would incorrectly fire the no-effect WARN."
+    )
+
+
 @pytest.mark.parametrize("item_type", sorted(THREAD_DELIVERABLE_TYPES))
 def test_post_session_thread_deliverable_item_still_runs_delivery_check(
     tmp_path,

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -1445,6 +1445,38 @@ def test_post_session_repo_level_item_skips_delivery_check(tmp_path) -> None:
     )
 
 
+def test_post_session_agent_msg_reply_skips_delivery_check(tmp_path) -> None:
+    """An `agent_msg_reply` item has no GitHub thread at all — never check delivery.
+
+    Second symptom class of the same missing gate (the first is
+    master_ci_failure above). Bob's PM ledger, 2026-08-13: every `number: 0`
+    dispatch row was an `agent_msg_reply` (peer-agent message; the number is
+    synthesized because there is no issue). The unguarded check ran
+    `check-pm-delivery.py --number 0` against a nonexistent issue, which always
+    reports `orphan_no_delivery` -> `effect=none` -> `outcome=no_effect`. That
+    drove `pm_dispatch_recovery.py` to exhaust the retry budget and file a bogus
+    "PM cannot drive ErikBjare/bob#0" stuck task — while the reply had in fact
+    been delivered.
+
+    Asserts on the returned effect (not just that the check was skipped), so a
+    regression that skips the check but still scores the item no-effect fails here.
+    """
+    config, item, plan, outcome, hooks, run_cmd, _latency = _post_session_fixture(
+        tmp_path, types=("agent_msg_reply",)
+    )
+    hooks.wait_merge_gate = None
+    hooks.arc_manager = None
+    # If the check DID run it would report an orphan, as it did in production.
+    run_cmd.on("/fake/check-delivery.py", stdout='{"outcome": "orphan_no_delivery"}')
+
+    effect = run_post_session(plan, item, outcome, config, hooks)
+
+    assert (
+        run_cmd.find("/fake/check-delivery.py") == []
+    ), "delivery check must not run for item types with no GitHub thread"
+    assert effect != "none", f"non-thread item wrongly scored no-effect: {effect!r}"
+
+
 @pytest.mark.parametrize("item_type", sorted(THREAD_DELIVERABLE_TYPES))
 def test_post_session_thread_deliverable_item_still_runs_delivery_check(
     tmp_path,

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -1421,16 +1421,28 @@ def test_post_session_repo_level_item_skips_delivery_check(tmp_path) -> None:
     Its `number` is a workflow run id, not an issue number, so the check would
     query issues/{run_id}/comments, 404, find no comment, and return
     orphan_no_delivery -> rollback -> re-dispatch forever (ErikBjare/bob#1144).
+
+    The fix must also promote state (not roll back): verify the pending state
+    file is copied to the real state dir so the item doesn't re-enter the queue.
     """
     config, item, plan, outcome, hooks, run_cmd, latency_calls = _post_session_fixture(
         tmp_path, types=("master_ci_failure",)
     )
     hooks.wait_merge_gate = None
     hooks.arc_manager = None
+    # Seed a pending state file so promote_item_state has something observable to do.
+    config.pending_state_dir.mkdir(parents=True, exist_ok=True)
+    sentinel = config.pending_state_dir / "gptme-gptme-contrib-master-ci.state"
+    sentinel.write_text("promoted")
     run_cmd.on("/fake/check-delivery.py", stdout='{"outcome": "orphan_no_delivery"}')
     run_post_session(plan, item, outcome, config, hooks)
     assert run_cmd.find("/fake/check-delivery.py") == []
     assert latency_calls[0]["outcome"] == "handled"
+    # State must be promoted, not rolled back — otherwise the item re-enters the queue.
+    assert (config.state_dir / sentinel.name).exists(), (
+        "promote_item_state was not called — state was not promoted from pending; "
+        "item would re-enter the dispatch queue"
+    )
 
 
 @pytest.mark.parametrize("item_type", sorted(THREAD_DELIVERABLE_TYPES))

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -1494,6 +1494,37 @@ def test_post_session_agent_msg_reply_skips_delivery_check(tmp_path) -> None:
     )
 
 
+def test_post_session_notification_zero_number_skips_delivery_check(tmp_path) -> None:
+    """A notification item with number=0 must not trigger the delivery check.
+
+    `notification` items in THREAD_DELIVERABLE_TYPES normally have real issue
+    numbers. But synthetic notifications (e.g. agent-bus pings) carry number=0
+    as a sentinel — there is no GitHub thread to check. Querying
+    `issues/0/comments` 404s, returns `orphan_no_delivery`, and triggers
+    rollback → re-dispatch forever, the same loop fixed for master_ci_failure
+    and agent_msg_reply. The number!=0 gate closes this third symptom class.
+    """
+    config, item, plan, outcome, hooks, run_cmd, _ = _post_session_fixture(
+        tmp_path, types=("notification",)
+    )
+    # Override the default number=1234 with the sentinel value
+    item = make_item(types=["notification"], number=0)
+    hooks.wait_merge_gate = None
+    hooks.arc_manager = None
+    # If the check DID run it would report an orphan, as it does in production.
+    run_cmd.on("/fake/check-delivery.py", stdout='{"outcome": "orphan_no_delivery"}')
+
+    effect = run_post_session(plan, item, outcome, config, hooks)
+
+    assert (
+        run_cmd.find("/fake/check-delivery.py") == []
+    ), "delivery check must not run for notification items with number=0"
+    assert effect == "unknown", (
+        f"notification with number=0 must score effect='unknown', not {effect!r}; "
+        "EFFECT_NONE would incorrectly fire the no-effect WARN."
+    )
+
+
 @pytest.mark.parametrize("item_type", sorted(THREAD_DELIVERABLE_TYPES))
 def test_post_session_thread_deliverable_item_still_runs_delivery_check(
     tmp_path,

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -1435,13 +1435,22 @@ def test_post_session_repo_level_item_skips_delivery_check(tmp_path) -> None:
     sentinel = config.pending_state_dir / "gptme-gptme-contrib-master-ci.state"
     sentinel.write_text("promoted")
     run_cmd.on("/fake/check-delivery.py", stdout='{"outcome": "orphan_no_delivery"}')
-    run_post_session(plan, item, outcome, config, hooks)
+    effect = run_post_session(plan, item, outcome, config, hooks)
     assert run_cmd.find("/fake/check-delivery.py") == []
     assert latency_calls[0]["outcome"] == "handled"
     # State must be promoted, not rolled back — otherwise the item re-enters the queue.
     assert (config.state_dir / sentinel.name).exists(), (
         "promote_item_state was not called — state was not promoted from pending; "
         "item would re-enter the dispatch queue"
+    )
+    # For non-thread items the delivery check never runs, so no delivery signal
+    # is observed and the record has no PR state diff. EFFECT_UNKNOWN is the
+    # correct and expected outcome — not EFFECT_NONE (which would fire the
+    # "no observable effect" WARN and implies we *know* nothing happened).
+    assert effect == "unknown", (
+        f"master_ci_failure must score effect='unknown', not {effect!r}; "
+        "EFFECT_NONE would incorrectly trigger the no-effect WARN for a "
+        "repo-level item that is expected to do nothing thread-observable."
     )
 
 
@@ -1474,7 +1483,15 @@ def test_post_session_agent_msg_reply_skips_delivery_check(tmp_path) -> None:
     assert (
         run_cmd.find("/fake/check-delivery.py") == []
     ), "delivery check must not run for item types with no GitHub thread"
-    assert effect != "none", f"non-thread item wrongly scored no-effect: {effect!r}"
+    # Skipping the delivery check means no delivery signal is verified.  The
+    # record also carries no PR state diff (number=0 is not a real issue).
+    # EFFECT_UNKNOWN is correct: we have no mechanism to observe whether
+    # anything happened, so we must not claim EFFECT_NONE ("nothing happened").
+    assert effect == "unknown", (
+        f"agent_msg_reply must score effect='unknown', not {effect!r}; "
+        "EFFECT_NONE would incorrectly fire the no-effect WARN and mark the "
+        "item as a delivery failure when the reply may have been delivered."
+    )
 
 
 @pytest.mark.parametrize("item_type", sorted(THREAD_DELIVERABLE_TYPES))

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -36,6 +36,7 @@ from gptme_runloops.merge_lifecycle import (
     run_merge_lifecycle,
 )
 from gptme_runloops.run_item import (
+    THREAD_DELIVERABLE_TYPES,
     ArcInfo,
     RunItem,
     RunItemConfig,
@@ -1432,12 +1433,21 @@ def test_post_session_repo_level_item_skips_delivery_check(tmp_path) -> None:
     assert latency_calls[0]["outcome"] == "handled"
 
 
+@pytest.mark.parametrize("item_type", sorted(THREAD_DELIVERABLE_TYPES))
 def test_post_session_thread_deliverable_item_still_runs_delivery_check(
     tmp_path,
+    item_type: str,
 ) -> None:
-    """Regression guard: the type gate must not disable checks for real threads."""
+    """Regression guard: the delivery check must run for every thread-deliverable type.
+
+    THREAD_DELIVERABLE_TYPES lists all eight thread-bearing item types. If any of
+    them is accidentally removed from the set, the delivery post-condition would
+    silently stop running for those items. This parametrized test ensures each type
+    in the set actually triggers the check — a future accidental removal will
+    fail exactly here.
+    """
     config, item, plan, outcome, hooks, run_cmd, latency_calls = _post_session_fixture(
-        tmp_path, types=("assigned_issue",)
+        tmp_path, types=(item_type,)
     )
     hooks.wait_merge_gate = None
     hooks.arc_manager = None
@@ -1447,7 +1457,10 @@ def test_post_session_thread_deliverable_item_still_runs_delivery_check(
         '"fallback_reply_posted": false}',
     )
     run_post_session(plan, item, outcome, config, hooks)
-    assert run_cmd.find("/fake/check-delivery.py") != []
+    assert run_cmd.find("/fake/check-delivery.py") != [], (
+        f"delivery check was NOT called for thread-deliverable type {item_type!r} "
+        f"— was it accidentally removed from THREAD_DELIVERABLE_TYPES?"
+    )
     assert latency_calls[0]["outcome"] == "orphan_no_delivery"
 
 


### PR DESCRIPTION
## Problem

`master_ci_failure` items re-enter the PM dispatch queue indefinitely. Each cycle spawns a full session that investigates the same master CI failure for 15+ minutes, produces nothing, and re-queues.

Observed live on `ErikBjare/bob#31681387507` (2026-08-13):

```
08:44  master_ci_failure: ErikBjare/bob #31681387507 — Tests
08:59  WARN: PM delivery post-condition FAILED — ErikBjare/bob#31681387507:
       session exited without a thread reply
08:59  WARN: ... rolled back state, event marker, and pending notif state
       (item re-enters the dispatch queue next cycle)
09:10  master_ci_failure: ErikBjare/bob #31681387507 — Tests      <- again
09:25  WARN: PM delivery post-condition FAILED — ...              <- again
```

## Root cause

The Phase-2 port of the delivery post-condition from `project-monitoring-worker.sh` into `run_item.py` dropped the item-type gate.

`worker.sh:453` ran the check only for thread-bearing types:

```bash
if echo "${item_types:-}" | grep -qwE "assigned_issue|pr_update|ci_failure|merge_ready|greptile_needs_improvement|greptile_needs_fix|merge_conflict|notification"; then
    _thread_deliverable="true"
fi
```

`run_item.py` gates only on `item.repo and item.number is not None`.

`master_ci_failure` carries a workflow **run id** as `number` (`31681387507`), not an issue number. So the check queries `issues/31681387507/comments`, 404s, finds no comment, and returns `orphan_no_delivery` → `rollback_failed_delivery()` → re-dispatch. Forever.

Note `master_ci_failure` does *not* match `grep -qwE "ci_failure"` — `_` is a word character, so the word boundary fails. The exclusion in worker.sh was correct and deliberate.

The contradiction is explicit: the PM prompt tells these sessions to

> "If the item is repo-level only and has no thread target (for example master_ci_failure), ... exit cleanly without inventing a thread reply."

and the post-condition then failed them for doing exactly that.

## Fix

Port the gate as `THREAD_DELIVERABLE_TYPES`, matching `worker.sh:453`. This is consistent with the repo-level exclusions already present elsewhere in the codebase:

- `scripts/monitoring/sentinel-frontier.py`: `NON_THREAD_DELIVERABLE_TYPES = {"master_ci_failure"}`
- `scripts/bob-vitals.py`: `INFORMATIONAL_ORPHAN_EVENT_TYPES = {"merge_ready", "master_ci_failure"}`

Repo-level items now keep `delivery_outcome = "handled"` (the permissive default, exactly as worker.sh left it), so state is promoted instead of rolled back.

**Observability is preserved.** The step-9 observable-effect signal passes `delivery_outcome if delivery_verified else ""`, and `delivery_verified` stays `False` when no check runs — so `WARN: PM dispatch produced NO observable effect` still fires for these items. Only the unsatisfiable rollback loop is removed.

## Tests

- `test_post_session_repo_level_item_skips_delivery_check` — the fix. Verified it **fails without the gate** (asserts the check was invoked with `--number 1234`).
- `test_post_session_thread_deliverable_item_still_runs_delivery_check` — guards against over-broad gating; `assigned_issue` still runs the check and still reports `orphan_no_delivery`.

`951 passed, 1 skipped` in `packages/gptme-runloops/tests/`. Scoped `prek` hooks clean.

Refs: ErikBjare/bob#1144