### PR TITLE
fix(runloops): gate PM delivery check on thread-deliverable item types

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -435,6 +435,37 @@ class RunItemHooks:
 
 _SLUG_TRANS = str.maketrans("/# :", "----")
 
+#: Item types whose deliverable IS a comment on a GitHub issue/PR thread, so
+#: the delivery post-condition can meaningfully check for one (worker.sh:453).
+#: Types outside this set — ``agent_msg_reply`` above all — have no thread to
+#: reply to and carry a synthesized ``number`` of 0, so running the check on
+#: them queries a nonexistent issue, always returns ``orphan_no_delivery``, and
+#: drives the dispatch to ``effect=none`` → ``outcome=no_effect`` → retry-budget
+#: exhaustion. Measured on Bob's dispatch ledger 2026-08-13: every ``number: 0``
+#: row was ``agent_msg_reply``, and the two that reached the ported executor
+#: both recorded ``no_effect`` despite the reply actually being delivered.
+THREAD_DELIVERABLE_TYPES: frozenset[str] = frozenset(
+    {
+        "assigned_issue",
+        "pr_update",
+        "ci_failure",
+        "merge_ready",
+        "greptile_needs_improvement",
+        "greptile_needs_fix",
+        "merge_conflict",
+        "notification",
+    }
+)
+
+
+def is_thread_deliverable(types: Sequence[str]) -> bool:
+    """Whether any of ``types`` delivers via a GitHub thread comment.
+
+    Bash parity: ``echo "$item_types" | grep -qwE "assigned_issue|pr_update|..."``
+    (project-monitoring-worker.sh:453-455).
+    """
+    return any(t in THREAD_DELIVERABLE_TYPES for t in types)
+
 
 def item_slug(repo: str, number_str: str, index: int) -> str:
     """``printf '%s_%s_%s' repo number idx | tr '/# :' '----'`` (p-m.sh:590)."""
@@ -1819,7 +1850,12 @@ def run_post_session(
     delivery_verified = False  # True only when the check exited 0 with parseable output
     needs_fallback = "false"
     fallback_posted = "false"
-    if item.repo and item.number is not None and hooks.delivery_check is not None:
+    if (
+        item.repo
+        and item.number is not None
+        and is_thread_deliverable(item.types)
+        and hooks.delivery_check is not None
+    ):
         try:
             try:
                 proc = hooks.run_cmd(

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -1427,6 +1427,49 @@ def test_post_session_gate_exit_2_warns_no_helper(tmp_path) -> None:
     assert gate_rows[0]["gate_exit_code"] == 2
 
 
+def test_post_session_skips_delivery_check_for_non_thread_item_types(
+    tmp_path,
+) -> None:
+    """An ``agent_msg_reply`` item has no GitHub thread — never check delivery.
+
+    Bob's PM ledger, 2026-08-13: every ``number: 0`` dispatch row was an
+    ``agent_msg_reply`` (peer-agent message; the number is synthesized because
+    there is no issue). The bash worker gates the delivery post-condition on an
+    item-type allowlist (worker.sh:453); this port gated only on
+    ``repo and number is not None``, so it ran ``check-pm-delivery.py --number 0``
+    against a nonexistent issue. That always reports ``orphan_no_delivery`` →
+    ``effect=none`` → ``outcome=no_effect``, which drove
+    ``pm_dispatch_recovery.py`` to exhaust the retry budget and file a bogus
+    "PM cannot drive ErikBjare/bob#0" stuck task — while the reply had in fact
+    been delivered.
+    """
+    config, item, plan, outcome, hooks, run_cmd, _latency = _post_session_fixture(
+        tmp_path, types=("agent_msg_reply",)
+    )
+    # If the check DID run it would report an orphan, as it did in production.
+    run_cmd.on("/fake/check-delivery.py", stdout='{"outcome": "orphan_no_delivery"}')
+
+    effect = run_post_session(plan, item, outcome, config, hooks)
+
+    assert not run_cmd.find(
+        "check-delivery"
+    ), "delivery check must not run for item types with no GitHub thread"
+    assert effect != "none", f"non-thread item wrongly scored no-effect: {effect!r}"
+
+
+def test_post_session_still_checks_delivery_for_thread_item_types(tmp_path) -> None:
+    """Guard the other side: the type gate must not silence real PR items."""
+    config, item, plan, outcome, hooks, run_cmd, _latency = _post_session_fixture(
+        tmp_path, types=("pr_update",)
+    )
+    run_cmd.on("/fake/check-delivery.py", stdout='{"outcome": "orphan_no_delivery"}')
+
+    effect = run_post_session(plan, item, outcome, config, hooks)
+
+    assert run_cmd.find("check-delivery"), "pr_update items must still be checked"
+    assert effect == "none"
+
+
 def test_post_session_crashed_delivery_check_does_not_claim_observed_effect(
     tmp_path,
 ) -> None:


### PR DESCRIPTION
## Problem

The ported `run-item` executor runs the PM delivery post-condition for **every** item that has a repo and a non-null number. The bash worker it ports does not — it gates on an item-type allowlist:

```bash
# project-monitoring-worker.sh:453
if echo "${item_types:-}" | grep -qwE "assigned_issue|pr_update|ci_failure|merge_ready|greptile_needs_improvement|greptile_needs_fix|merge_conflict|notification"; then
    _thread_deliverable="true"
fi
```

An `agent_msg_reply` item (peer-agent message) has no GitHub thread at all and carries a **synthesized `number: 0`**. So the port ran `check-pm-delivery.py --repo ErikBjare/bob --number 0` against a nonexistent issue.

## Impact

That check can only ever return `orphan_no_delivery`, which cascades:

`orphan_no_delivery` → `effect=none` → `outcome=no_effect` → `pm_dispatch_recovery.py` re-arms the item → retry budget exhausted → a bogus `PM cannot drive ErikBjare/bob#0 — retry budget exhausted` stuck task is filed.

All of this while the reply had in fact been delivered — it just wasn't delivered to a GitHub thread, because there isn't one.

Measured on Bob's dispatch ledger, 2026-08-13:

```
types with number 0:  [(('agent_msg_reply',), 15)]
completed outcomes:   [(None, None) x3, ('no_effect', 'none') x2]
```

Both dispatches that reached the ported executor recorded `no_effect`. This also produced the live `PM-DELIVERY: 2 post-condition failure(s)` operator-blindspot alert.

## Fix

Restore bash parity: `THREAD_DELIVERABLE_TYPES` + `is_thread_deliverable()`, checked alongside the existing repo/number gate.

## Tests

- `test_post_session_skips_delivery_check_for_non_thread_item_types` — the `agent_msg_reply` case. Verified RED before the fix (asserts the check ran with `--number 1234`), GREEN after.
- `test_post_session_still_checks_delivery_for_thread_item_types` — guards the other side, so the gate can't silently disable delivery checking for real PR items.

88 passed in `test_run_item.py`; ruff + mypy clean.

## Related

- ErikBjare/bob#1144 — the broader "no can't-act exit path" issue. This is a distinct sub-bug: not "PM found nothing to do", but "PM scored a delivered non-thread item as undelivered".