### PR TITLE
fix(pm): skip GitHub post-conditions for items with no GitHub thread

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -709,6 +709,35 @@ def resolve_slot_key(config: RunItemConfig, item: RunItem, fallback: str = "") -
     return f"{item.repo}#{item.number}"
 
 
+def has_github_thread(item: RunItem) -> bool:
+    """Whether this item names a real GitHub issue/PR thread.
+
+    Not every PM work item is a GitHub thread. The gate synthesises items for
+    off-GitHub work — ``agent_msg_reply`` is emitted with a hardcoded
+    ``number: 0`` (project-monitoring-gate.sh) because the agent-message bus has
+    no issue behind it. ``number is not None`` accepts that ``0`` and sends the
+    GitHub-thread post-conditions at ``ErikBjare/bob#0``, which does not exist.
+
+    The 2026-08-13 failure loop that motivated this: the delivery check 404s on
+    ``issues/0/comments``, so it reports ``orphan_no_delivery`` for a reply that
+    *was* delivered (over the agent-msg bus); ``--post-fallback-reply`` then
+    tries to POST a comment to the phantom issue; the item is rolled back and
+    re-dispatched; the effect signal reads ``none``; and after two re-arms
+    ``pm_dispatch_recovery`` files a ``pm-stuck-erikbjare-bob-0`` escalation
+    task at ``priority: high``. Every agent message from Gordon/Alice/Sven ran
+    this loop.
+
+    A missing thread makes these checks unanswerable, not failed — so callers
+    must skip them rather than read the 404 as a negative result.
+    """
+    if not item.repo or item.number is None:
+        return False
+    try:
+        return int(str(item.number).strip()) > 0
+    except (TypeError, ValueError):
+        return False
+
+
 def resolve_cooldown_dir(config: RunItemConfig) -> Path | None:
     """The dispatch cooldown dir, or None when unset.
 
@@ -1819,7 +1848,7 @@ def run_post_session(
     delivery_verified = False  # True only when the check exited 0 with parseable output
     needs_fallback = "false"
     fallback_posted = "false"
-    if item.repo and item.number is not None and hooks.delivery_check is not None:
+    if has_github_thread(item) and hooks.delivery_check is not None:
         try:
             try:
                 proc = hooks.run_cmd(
@@ -2039,7 +2068,7 @@ def run_post_session(
         pr_state_after = ""
         if record_file.is_file():
             pr_state_after = read_record_pr_state_after(record_file)
-        if not pr_state_after and item.repo and item.number is not None:
+        if not pr_state_after and has_github_thread(item):
             try:
                 proc = hooks.run_cmd(
                     [

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -46,6 +46,7 @@ from gptme_runloops.run_item import (
     derive_lock_paths,
     derive_session_id,
     execute_plan,
+    has_github_thread,
     issue_coordination_key,
     item_slug,
     plan_item,
@@ -1160,10 +1161,10 @@ def test_trajectory_codex_snapshot_diff_newest_wins(tmp_path) -> None:
 # --- Post-session composition (worker.sh order, fake collaborators) ---
 
 
-def _post_session_fixture(tmp_path, *, exit_code=0, types=("pr_update",)):
+def _post_session_fixture(tmp_path, *, exit_code=0, types=("pr_update",), number=1234):
     config = make_config(tmp_path)
     config.resolved("records_dir", "records").mkdir(parents=True, exist_ok=True)
-    item = make_item(types=list(types))
+    item = make_item(types=list(types), number=number, all_numbers=[str(number)])
     run_cmd = FakeRunCmd()
 
     def fake_post_session(**kwargs):
@@ -1412,6 +1413,68 @@ def test_post_session_missing_delivery_hook_skips_check(tmp_path) -> None:
     run_post_session(plan, item, outcome, config, hooks)
     # Delivery defaults to handled when the script is absent (bash [ -f ] guard)
     assert latency_calls[0]["outcome"] == "handled"
+
+
+@pytest.mark.parametrize(
+    "number,expected",
+    [
+        (1234, True),
+        ("1234", True),
+        (" 1234 ", True),
+        (0, False),  # the synthetic agent_msg_reply number
+        ("0", False),
+        (None, False),
+        ("", False),
+        ("unknown", False),
+        (-1, False),
+    ],
+)
+def test_has_github_thread_rejects_synthetic_numbers(number, expected) -> None:
+    """Only a positive item number names a real GitHub issue/PR thread.
+
+    ``agent_msg_reply`` items are emitted with a hardcoded ``number: 0``
+    because the agent-message bus has no issue behind it.
+    """
+    assert has_github_thread(make_item(number=number)) is expected
+
+
+def test_has_github_thread_requires_repo() -> None:
+    assert has_github_thread(make_item(repo="", number=1234)) is False
+
+
+def test_post_session_skips_github_checks_for_synthetic_agent_msg_item(
+    tmp_path,
+) -> None:
+    """An ``agent_msg_reply`` item must not run the GitHub-thread
+    post-conditions against the phantom ``ErikBjare/bob#0``.
+
+    Regression for the 2026-08-13 loop: the delivery check 404s on
+    ``issues/0/comments`` and returns ``orphan_no_delivery``, which made PM
+    (a) try to POST a fallback comment to an issue that does not exist,
+    (b) roll the item back and re-dispatch it every cycle, and
+    (c) record ``effect=none``, so ``pm_dispatch_recovery`` escalated a
+    ``pm-stuck-erikbjare-bob-0`` task at ``priority: high``.
+
+    A missing thread makes the check unanswerable, not failed — so it must be
+    skipped and the item's state promoted normally.
+    """
+    config, item, plan, outcome, hooks, run_cmd, latency_calls = _post_session_fixture(
+        tmp_path, types=("agent_msg_reply",), number=0
+    )
+    # Would report orphan_no_delivery if it were (wrongly) consulted.
+    run_cmd.on("/fake/check-delivery.py", stdout='{"outcome": "orphan_no_delivery"}')
+    hooks.wait_merge_gate = None
+    hooks.arc_manager = None
+
+    run_post_session(plan, item, outcome, config, hooks)
+
+    assert run_cmd.find("/fake/check-delivery.py") == []
+    # No GitHub PR-state fetch for a thread that does not exist
+    assert [c for c in run_cmd.find("gh") if "pr" in c["argv"]] == []
+    # Not treated as a failed delivery => no rollback, no fallback POST
+    assert latency_calls[0]["outcome"] == "handled"
+    record = json.loads(Path(plan.record_file).read_text())
+    assert not record.get("pr_state_after")
 
 
 def test_post_session_gate_exit_2_warns_no_helper(tmp_path) -> None:


### PR DESCRIPTION
## Problem

`agent_msg_reply` items are synthesised by `project-monitoring-gate.sh` with a hardcoded `number: 0` — the agent-message bus has no issue behind it. Both GitHub-thread post-conditions in `run_post_session` gated on `item.number is not None`, which accepts that `0` and aims them at **`ErikBjare/bob#0`, an issue that does not exist**.

Observed 2026-08-13, once per agent message from Gordon/Alice/Sven:

1. `check-pm-delivery.py --repo ErikBjare/bob --number 0` 404s on `issues/0/comments` and returns `orphan_no_delivery` — for a reply that *was* delivered, over the agent-msg bus.
2. `--post-fallback-reply` then tries to POST a comment to the phantom issue.
3. `orphan_no_delivery` triggers `rollback_failed_delivery`, so the item re-enters the dispatch queue every cycle until the redelivery cap.
4. The effect signal reads `none` → `classify_completion` returns `INEFFECTIVE` → after two re-arms `pm_dispatch_recovery` files a `pm-stuck-erikbjare-bob-0` escalation task at `priority: high`, which consumes an autonomous Tier-1 slot with GitHub-shaped instructions that cannot apply.

Reproduction (live, before the fix):

```
$ python3 scripts/runs/github/check-pm-delivery.py --repo ErikBjare/bob --number 0 \
    --since 2026-08-13T12:30:00Z --require-thread-reply --session-id repro
{"delivered": false, "outcome": "orphan_no_delivery", ..., "needs_fallback_reply": true}

$ gh api repos/ErikBjare/bob/issues/0/comments
{"message":"Not Found","status":"404"}
```

21 dispatch-ledger rows accumulated for `ErikBjare/bob#0`.

## Fix

Add `has_github_thread()` — repo present and number parses to a positive int — and gate both the delivery check and the post-run `gh pr view` state fetch on it.

A missing thread makes these checks **unanswerable, not failed**, so skipping is the honest reading; the 404 must not be recorded as a negative result. Skipping leaves `delivery_verified` False, so the effect signal receives no delivery outcome and derives `unknown` rather than `none` — absence of evidence stays distinct from evidence of absence, matching the existing contract in `derive_effect_signal`.

This also covers `voice:<id>` item numbers, which 404 the same way.

## Tests

- `test_has_github_thread_rejects_synthetic_numbers` — parametrized over `1234`/`"1234"`/`0`/`"0"`/`None`/`""`/`"unknown"`/`-1`
- `test_has_github_thread_requires_repo`
- `test_post_session_skips_github_checks_for_synthetic_agent_msg_item` — asserts the delivery check is never invoked, no `gh pr view`, and the item is promoted rather than rolled back

Verified the regression test fails on master (`assert run_cmd.find(...) == []` → the check ran with `--number 0`) and passes with the fix.

```
250 passed  # test_run_item.py + test_run_item_rollback.py + test_worker_records.py
```

ruff + ruff-format + mypy clean.

## Related

Brain-repo half (stops the bogus escalation task that the `effect=none` produced): `ErikBjare/bob@faa0ad3910`