### PR TITLE
feat(gptodo): next --limit N simulates the unblocking cascade

### DIFF
--- a/packages/gptodo/README.md
+++ b/packages/gptodo/README.md
@@ -101,9 +101,10 @@ the simulation instead of hanging it.
 
 `--limit 1` (and omitting the flag) produce byte-identical output to the
 previous behaviour, including the `--json` shape — autonomous sessions calling
-`gptodo next --json` are unaffected. In multi-task mode the JSON gains
-`sequence`, `order`, `requested`, `reachable`, `complete`, and `note` keys
-alongside the unchanged `next_task` / `alternatives`.
+`gptodo next --json` are unaffected. The `--order` flag is also ignored when
+`--limit 1` (it only changes sequencing within a multi-task cascade). In
+multi-task mode the JSON gains `sequence`, `order`, `requested`, `reachable`,
+`complete`, and `note` keys alongside the unchanged `next_task` / `alternatives`.
 
 ### Machine-Readable Output (`--json`)
 

--- a/packages/gptodo/README.md
+++ b/packages/gptodo/README.md
@@ -66,6 +66,45 @@ gptodo expire --days 60          # tighter window
 gptodo expire --state backlog    # only reap backlog
 ```
 
+### Sequential Planning (`next --limit`)
+
+`gptodo ready` and a bare `gptodo next` answer a **parallel** question: what is
+unblocked *right now*. If task A unblocks task B, B is invisible to both until
+A is actually completed — so a deep queue can look one task shallow.
+
+`gptodo next --limit N` answers the **sequential** question instead. It greedily
+simulates completing each pick (in memory — task files are never written),
+recomputes the ready set, and lets newly unblocked tasks join the list:
+
+```bash
+gptodo next                       # top ready task (unchanged)
+gptodo next --limit 5             # next 5, in unblocking order
+gptodo next -n 5 --order unblock  # critical path first
+gptodo next --limit 5 --json      # ordered array with attribution
+```
+
+Every item past the first states *why* it is there — `unblocked by #3
+<task>`, or `(already ready)` if it needed nothing.
+
+Two orderings:
+
+| `--order` | Behaviour |
+|-----------|-----------|
+| `priority` (default) | Greedy by the normal `next` ordering — literally "what's next, then next". |
+| `unblock` | At each step take the task that unblocks the most downstream work — surfaces the **critical path** rather than the priority path. |
+
+If fewer than N tasks are reachable, that is stated explicitly (`only 3 of 5
+reachable — nothing further is unblocked by this sequence`) rather than
+silently returning a short list. `--pool` / `--exclude-pool` / `--use-cache`
+apply at every step, not just the first pick, and dependency cycles terminate
+the simulation instead of hanging it.
+
+`--limit 1` (and omitting the flag) produce byte-identical output to the
+previous behaviour, including the `--json` shape — autonomous sessions calling
+`gptodo next --json` are unaffected. In multi-task mode the JSON gains
+`sequence`, `order`, `requested`, `reachable`, `complete`, and `note` keys
+alongside the unchanged `next_task` / `alternatives`.
+
 ### Machine-Readable Output (`--json`)
 
 Scripts should parse `--json` rather than grep the rendered human output (the

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -3135,7 +3135,9 @@ def next_(output_json, use_cache, pool_filter, exclude_pool, limit, order):
 
     # Sort tasks. Default ("priority"): priority (high first), then unblocking
     # power (high first), then age (oldest first). "unblock" leads with power.
-    if order == "unblock":
+    # Gate: --order is ignored when limit == 1, preserving the byte-identical
+    # contract for `next --json` and `next --json --limit 1` callers.
+    if order == "unblock" and limit > 1:
         ready_tasks.sort(key=lambda t: (-power.get(t.name, 0), -t.priority_rank, t.created))
     else:
         ready_tasks.sort(key=lambda t: (-t.priority_rank, -power.get(t.name, 0), t.created))

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -94,8 +94,10 @@ from gptodo.subagent import (
     spawn_agent,
 )
 
-# Import unblocking functionality with fan-in support
+# Import greedy sequential ("what's next, then next") simulation
 from gptodo.sequence import SequenceStep, shortfall_note, simulate_sequence
+
+# Import unblocking functionality with fan-in support
 from gptodo.unblock import auto_unblock_with_fan_in
 
 # Import utilities directly from utils
@@ -3215,15 +3217,18 @@ def _render_next_sequence(
 
     for step in steps:
         task = step.task
+        # Escape task names: they come from filenames, which may legally contain
+        # square brackets that rich would otherwise parse as markup.
         if step.unblocked_by is None:
             why = "[dim](already ready)[/]"
         else:
-            why = f"unblocked by #{step.unblocked_by_position} {step.unblocked_by}"
+            blocker = markup_escape(step.unblocked_by)
+            why = f"unblocked by #{step.unblocked_by_position} {blocker}"
         table.add_row(
             f"#{step.position}",
             str(name_to_enum_id.get(task.name, "?")),
             task.priority or "none",
-            task.name,
+            markup_escape(task.name),
             why,
         )
 

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -3045,8 +3045,10 @@ def next_(output_json, use_cache, pool_filter, exclude_pool, limit, order):
     Use --pool all to see every pool; --pool frontier for frontier sessions only.
 
     Examples:
-        gptodo next                     # top ready task (unchanged)
-        gptodo next --limit 5           # next 5, in unblocking order
+
+    \b
+        gptodo next                       # top ready task (unchanged)
+        gptodo next --limit 5             # next 5, in unblocking order
         gptodo next -n 5 --order unblock  # critical path first
     """
     console = Console()

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -95,6 +95,7 @@ from gptodo.subagent import (
 )
 
 # Import unblocking functionality with fan-in support
+from gptodo.sequence import SequenceStep, shortfall_note, simulate_sequence
 from gptodo.unblock import auto_unblock_with_fan_in
 
 # Import utilities directly from utils
@@ -3002,16 +3003,49 @@ def ready(state, output_json, output_jsonl, use_cache, pool_filter, exclude_pool
     default=None,
     help="Exclude tasks in this pool (e.g. '--exclude-pool frontier')",
 )
-def next_(output_json, use_cache, pool_filter, exclude_pool):
+@click.option(
+    "--limit",
+    "-n",
+    default=1,
+    type=click.IntRange(min=1),
+    help=(
+        "Show the next N tasks as a simulated sequence, not just the top one. "
+        "Each pick is 'completed' in memory, so tasks that only become "
+        "unblocked partway down the list still appear. Default: 1."
+    ),
+)
+@click.option(
+    "--order",
+    type=click.Choice(["priority", "unblock"]),
+    default="priority",
+    help=(
+        "priority (default): greedy by the normal next-task ordering — "
+        "literally 'what's next, then next'. "
+        "unblock: at each step take the task that unblocks the most downstream "
+        "work — surfaces the critical path rather than the priority path."
+    ),
+)
+def next_(output_json, use_cache, pool_filter, exclude_pool, limit, order):
     """Show the highest priority ready (unblocked) task.
 
     Picks from new or active tasks that have no dependencies
     or whose dependencies are all completed.
 
+    With --limit N, simulates working the queue sequentially: after each pick
+    the task is treated as done (in memory only — task files are never
+    written), the ready set is recomputed, and newly unblocked tasks become
+    eligible. This surfaces work that `gptodo ready` cannot show, because
+    `ready` only ever lists what is unblocked *right now*.
+
     Use --json for machine-readable output in autonomous workflows.
     Use --use-cache to also check URL-based 'requires' against cached issue states.
     Use --pool to filter by work pool; default hides non-default pools (e.g. frontier).
     Use --pool all to see every pool; --pool frontier for frontier sessions only.
+
+    Examples:
+        gptodo next                     # top ready task (unchanged)
+        gptodo next --limit 5           # next 5, in unblocking order
+        gptodo next -n 5 --order unblock  # critical path first
     """
     console = Console()
     repo_root = find_repo_root(Path.cwd())
@@ -3095,31 +3129,115 @@ def next_(output_json, use_cache, pool_filter, exclude_pool):
     nodes = build_dependency_graph(all_tasks)
     power = compute_unblocking_power(nodes)
 
-    # Sort tasks: priority (high first), then unblocking power (high first), then age (oldest first)
-    ready_tasks.sort(
-        key=lambda t: (
-            -t.priority_rank,
-            -power.get(t.name, 0),
-            t.created,
-        )
-    )
+    # Sort tasks. Default ("priority"): priority (high first), then unblocking
+    # power (high first), then age (oldest first). "unblock" leads with power.
+    if order == "unblock":
+        ready_tasks.sort(key=lambda t: (-power.get(t.name, 0), -t.priority_rank, t.created))
+    else:
+        ready_tasks.sort(key=lambda t: (-t.priority_rank, -power.get(t.name, 0), t.created))
 
     # Get the highest priority ready task
     next_task = ready_tasks[0]
 
+    # Multi-task mode: simulate working the queue sequentially so tasks that are
+    # only unblocked partway down the list still show up. In-memory only.
+    steps: list[SequenceStep] = []
+    note: str | None = None
+    if limit > 1:
+        steps = simulate_sequence(
+            candidates=workable_tasks,
+            tasks_dict=tasks_dict,
+            all_tasks=all_tasks,
+            limit=limit,
+            order=order,
+            issue_cache=issue_cache,
+        )
+        note = shortfall_note(len(steps), limit)
+
     # JSON output for machine consumption
     if output_json:
-        result = {
+        result: Dict[str, Any] = {
             "next_task": task_to_dict(next_task),
             "alternatives": [task_to_dict(t) for t in ready_tasks[1:4]],  # Top 3 alternatives
         }
+        if limit > 1:
+            # Extra keys only in multi-task mode, so `next --json` and
+            # `next --json --limit 1` stay byte-identical for existing callers.
+            result["order"] = order
+            result["requested"] = limit
+            result["reachable"] = len(steps)
+            result["complete"] = note is None
+            result["note"] = note
+            result["sequence"] = [step.to_dict() for step in steps]
         print(json.dumps(result, indent=2))
+        return
+
+    if limit > 1:
+        _render_next_sequence(console, steps, all_tasks, order, note)
         return
 
     # Show task using same format as show command
     console.print(f"\n[bold blue]🏃 Next Task:[/] (Priority: {next_task.priority or 'none'})")
     # Call show command directly instead of using callback
     show(next_task.name)
+
+
+def _render_next_sequence(
+    console: Console,
+    steps: list[SequenceStep],
+    all_tasks: list[TaskInfo],
+    order: str,
+    note: str | None,
+) -> None:
+    """Render the simulated sequence, stating why each task is in it."""
+    tasks_by_date = sorted(all_tasks, key=lambda t: t.created)
+    name_to_enum_id = {task.name: i for i, task in enumerate(tasks_by_date, 1)}
+
+    order_label = (
+        "priority — what's next, then next"
+        if order == "priority"
+        else "unblock — critical path first"
+    )
+    plural = "task" if len(steps) == 1 else "tasks"
+    console.print(
+        f"\n[bold blue]🏃 Next {len(steps)} {plural}[/] [dim](order: {order_label})[/]",
+        highlight=False,
+    )
+
+    table = Table()
+    table.add_column("#", style="bold", justify="right", no_wrap=True)
+    table.add_column("ID", style="cyan", no_wrap=True)
+    table.add_column("Priority", style="yellow")
+    # overflow="fold": task names must stay copy-pasteable into `gptodo show`,
+    # so wrap them rather than truncating with an ellipsis.
+    table.add_column("Task", style="white", overflow="fold")
+    table.add_column("Why", style="green", overflow="fold")
+
+    for step in steps:
+        task = step.task
+        if step.unblocked_by is None:
+            why = "[dim](already ready)[/]"
+        else:
+            why = f"unblocked by #{step.unblocked_by_position} {step.unblocked_by}"
+        table.add_row(
+            f"#{step.position}",
+            str(name_to_enum_id.get(task.name, "?")),
+            task.priority or "none",
+            task.name,
+            why,
+        )
+
+    console.print(table)
+
+    if note:
+        # highlight=False: rich's number highlighter would otherwise splice ANSI
+        # codes into "1 of 5", making the message hard to read and to grep.
+        console.print(f"\n[yellow]⚠ {note}.[/]", highlight=False)
+
+    console.print(
+        "\n[dim]Simulated: each task is treated as done to reveal the next one. "
+        "No task files were modified.[/]"
+    )
 
 
 @cli.command("stale")

--- a/packages/gptodo/src/gptodo/sequence.py
+++ b/packages/gptodo/src/gptodo/sequence.py
@@ -35,8 +35,14 @@ class SequenceStep:
 
     task: TaskInfo
     position: int
-    #: Name of the earlier step whose (simulated) completion made this ready,
+    #: Name of the step whose (simulated) completion made this task newly ready,
     #: or None if it was already ready at the start.
+    #:
+    #: **Fan-in tasks** (requiring multiple dependencies): this is the *last*
+    #: dependency to complete — the "final gate." Prior deps were already done
+    #: in earlier steps; this pick was the one that opened the door. This
+    #: matches how the single-pick ``next`` models readiness: a task is either
+    #: ready or it isn't, and the relevant event is when it first becomes ready.
     unblocked_by: Optional[str] = None
     #: 1-based position of that earlier step, or None.
     unblocked_by_position: Optional[int] = None

--- a/packages/gptodo/src/gptodo/sequence.py
+++ b/packages/gptodo/src/gptodo/sequence.py
@@ -122,6 +122,15 @@ def simulate_sequence(
     attribution: Dict[str, tuple[str, int]] = {}
     ever_ready: set[str] = set()
 
+    # Unblocking power is computed once, against the *original* graph, for two
+    # reasons. Correctness: "how much downstream work does this unlock" is a
+    # property of the real graph, and the single-pick `next` computes it exactly
+    # this way — so step 1 cannot drift from current behaviour. Cost:
+    # compute_unblocking_power is O(V*E), and recomputing it per step made a
+    # 500-deep chain at --limit 100 take 11s instead of 0.2s.
+    power = compute_unblocking_power(build_dependency_graph(list(all_tasks)))
+    sort_key = _sort_key_unblock(power) if order == "unblock" else _sort_key_priority(power)
+
     # Hard iteration bound: each successful step removes exactly one candidate,
     # and we break when nothing is ready. The bound is belt-and-braces so a
     # dependency cycle (or any future readiness bug) can never spin forever.
@@ -142,12 +151,7 @@ def simulate_sequence(
         if not ready:
             break
 
-        # Recompute unblocking power against the *simulated* graph so that
-        # already-picked tasks stop inflating the scores of their blockers.
-        sim_list = [sim_tasks[t.name] for t in all_tasks if t.name in sim_tasks]
-        power = compute_unblocking_power(build_dependency_graph(sim_list))
-        key = _sort_key_unblock(power) if order == "unblock" else _sort_key_priority(power)
-        ready.sort(key=key)
+        ready.sort(key=sort_key)
 
         chosen = ready[0]
         position = len(picked) + 1

--- a/packages/gptodo/src/gptodo/sequence.py
+++ b/packages/gptodo/src/gptodo/sequence.py
@@ -99,7 +99,8 @@ def simulate_sequence(
             filters apply at every step, not just the first pick.
         tasks_dict: Full name -> task lookup used for dependency resolution
             (must include tasks outside ``candidates``, e.g. already-done deps).
-        all_tasks: Full task list, used to rebuild the dependency graph.
+        all_tasks: Full task list, used to build the dependency graph that
+            unblocking-power scoring is computed from.
         limit: Maximum number of tasks to pick.
         order: "priority" (default) or "unblock".
         issue_cache: Optional URL-state cache for URL-based `requires`.

--- a/packages/gptodo/src/gptodo/sequence.py
+++ b/packages/gptodo/src/gptodo/sequence.py
@@ -1,0 +1,180 @@
+"""Greedy sequential simulation of the task queue ("what's next, then next").
+
+`gptodo ready` and `gptodo next` answer a *parallel* question: which tasks are
+unblocked **right now**. If task A unblocks task B, B is invisible until A is
+actually completed — so the queue can look one task deep when it is really five.
+
+This module answers the *sequential* question instead: "if I worked these N in
+order, what would the sequence be, including the tasks that only become
+available partway down?"
+
+The simulation is entirely in memory — task files are never written.
+
+Dependency resolution is **not** reimplemented here: readiness comes from
+:func:`gptodo.utils.is_task_ready` and unblocking power from
+:func:`gptodo.deptree.compute_unblocking_power`, exactly the primitives the
+single-pick `next` already uses.
+"""
+
+from dataclasses import dataclass, replace
+from typing import Any, Dict, List, Literal, Optional, Sequence
+
+from .deptree import build_dependency_graph, compute_unblocking_power
+from .utils import TaskInfo, is_task_ready, task_to_dict
+
+Order = Literal["priority", "unblock"]
+
+#: Simulated completion state. Matches the terminal states `is_task_ready`
+#: treats as satisfying a dependency.
+SIMULATED_DONE_STATE = "done"
+
+
+@dataclass
+class SequenceStep:
+    """One task in the simulated sequence, with the reason it is there."""
+
+    task: TaskInfo
+    position: int
+    #: Name of the earlier step whose (simulated) completion made this ready,
+    #: or None if it was already ready at the start.
+    unblocked_by: Optional[str] = None
+    #: 1-based position of that earlier step, or None.
+    unblocked_by_position: Optional[int] = None
+
+    @property
+    def reason(self) -> str:
+        """Human-readable explanation of why this task is in the sequence."""
+        if self.unblocked_by is None:
+            return "already ready"
+        return f"unblocked by #{self.unblocked_by_position} {self.unblocked_by}"
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize for --json consumption."""
+        return {
+            "position": self.position,
+            "task": task_to_dict(self.task),
+            "unblocked_by": self.unblocked_by,
+            "unblocked_by_position": self.unblocked_by_position,
+            "reason": self.reason,
+        }
+
+
+def _sort_key_priority(power: Dict[str, int]):
+    """Existing `next` ordering: priority, then unblocking power, then age.
+
+    Kept byte-identical to the single-pick ordering so `--limit 1` cannot drift.
+    """
+
+    def key(task: TaskInfo):
+        return (-task.priority_rank, -power.get(task.name, 0), task.created)
+
+    return key
+
+
+def _sort_key_unblock(power: Dict[str, int]):
+    """Critical-path ordering: unblocking power first, then priority, then age."""
+
+    def key(task: TaskInfo):
+        return (-power.get(task.name, 0), -task.priority_rank, task.created)
+
+    return key
+
+
+def simulate_sequence(
+    candidates: Sequence[TaskInfo],
+    tasks_dict: Dict[str, TaskInfo],
+    all_tasks: Sequence[TaskInfo],
+    limit: int = 1,
+    order: Order = "priority",
+    issue_cache: Optional[Dict[str, Any]] = None,
+) -> List[SequenceStep]:
+    """Greedily simulate completing tasks one at a time.
+
+    At each step: compute the ready set, pick the top task by ``order``,
+    simulate its completion in memory, then recompute — so tasks that were
+    blocked at the start surface once their blocker has been picked.
+
+    Args:
+        candidates: Pool/state-filtered tasks eligible to be picked. The same
+            filters apply at every step, not just the first pick.
+        tasks_dict: Full name -> task lookup used for dependency resolution
+            (must include tasks outside ``candidates``, e.g. already-done deps).
+        all_tasks: Full task list, used to rebuild the dependency graph.
+        limit: Maximum number of tasks to pick.
+        order: "priority" (default) or "unblock".
+        issue_cache: Optional URL-state cache for URL-based `requires`.
+
+    Returns:
+        Ordered list of :class:`SequenceStep`. May be shorter than ``limit``
+        when nothing further is unblocked (a dependency cycle, an external
+        blocker, or simply an exhausted queue). Callers must surface that.
+    """
+    if limit < 1:
+        return []
+
+    # Simulated view of the world. Never written back to disk.
+    sim_tasks: Dict[str, TaskInfo] = dict(tasks_dict)
+    remaining: List[TaskInfo] = list(candidates)
+
+    picked: List[SequenceStep] = []
+    # name -> (blocker name, blocker position); populated the moment a task
+    # first becomes ready, so the attribution survives until it is picked.
+    attribution: Dict[str, tuple[str, int]] = {}
+    ever_ready: set[str] = set()
+
+    # Hard iteration bound: each successful step removes exactly one candidate,
+    # and we break when nothing is ready. The bound is belt-and-braces so a
+    # dependency cycle (or any future readiness bug) can never spin forever.
+    for _ in range(len(remaining)):
+        if len(picked) >= limit:
+            break
+
+        ready = [t for t in remaining if is_task_ready(sim_tasks[t.name], sim_tasks, issue_cache)]
+
+        # Attribute anything newly ready to the step that just completed.
+        for task in ready:
+            if task.name not in ever_ready:
+                ever_ready.add(task.name)
+                if picked:
+                    prev = picked[-1]
+                    attribution[task.name] = (prev.task.name, prev.position)
+
+        if not ready:
+            break
+
+        # Recompute unblocking power against the *simulated* graph so that
+        # already-picked tasks stop inflating the scores of their blockers.
+        sim_list = [sim_tasks[t.name] for t in all_tasks if t.name in sim_tasks]
+        power = compute_unblocking_power(build_dependency_graph(sim_list))
+        key = _sort_key_unblock(power) if order == "unblock" else _sort_key_priority(power)
+        ready.sort(key=key)
+
+        chosen = ready[0]
+        position = len(picked) + 1
+        credit = attribution.pop(chosen.name, None)
+        picked.append(
+            SequenceStep(
+                task=sim_tasks[chosen.name],
+                position=position,
+                unblocked_by=credit[0] if credit else None,
+                unblocked_by_position=credit[1] if credit else None,
+            )
+        )
+
+        remaining = [t for t in remaining if t.name != chosen.name]
+        # Simulate completion: `is_task_ready` treats done/cancelled deps as met.
+        sim_tasks[chosen.name] = replace(sim_tasks[chosen.name], state=SIMULATED_DONE_STATE)
+
+    return picked
+
+
+def shortfall_note(reachable: int, requested: int) -> Optional[str]:
+    """Explain a short sequence, or None when the full request was satisfied.
+
+    A short list that looks complete is the failure mode this guards against.
+    """
+    if reachable >= requested:
+        return None
+    return (
+        f"only {reachable} of {requested} reachable — nothing further is unblocked by this sequence"
+    )

--- a/packages/gptodo/tests/test_next_sequence.py
+++ b/packages/gptodo/tests/test_next_sequence.py
@@ -432,6 +432,46 @@ def test_reported_state_is_real_not_simulated(tmp_path: Path, monkeypatch) -> No
     assert "done" not in states.values()
 
 
+def test_fan_in_attribution(tmp_path: Path, monkeypatch) -> None:
+    """Fan-in task (C requires both A and B) is attributed to the last dependency.
+
+    Attribution semantics: ``unblocked_by`` is the *final gate* — the last
+    dependency whose simulated completion made the fan-in task newly ready.
+
+    In this fixture fan-a (high) and fan-b (medium) are both ready initially.
+    Priority ordering picks fan-a first, then fan-b. After fan-b completes
+    (step 2), fan-c — which requires both — becomes newly ready and is
+    attributed to fan-b (the last pick that opened the door).
+    """
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(tasks_dir, "fan-a", state="todo", created="2026-03-28T00:00:00", priority="high")
+    write_task(tasks_dir, "fan-b", state="todo", created="2026-03-28T01:00:00", priority="medium")
+    write_task(
+        tasks_dir,
+        "fan-c",
+        state="backlog",
+        created="2026-03-28T02:00:00",
+        priority="low",
+        requires=["fan-a", "fan-b"],
+    )
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["next", "--json", "--limit", "3"])
+    assert result.exit_code == 0, result.output
+    payload = _payload(result.output)
+    seq = payload["sequence"]
+    names = [s["task"]["name"] for s in seq]
+
+    assert names == ["fan-a", "fan-b", "fan-c"], f"unexpected order: {names}"
+
+    fan_c_step = next(s for s in seq if s["task"]["name"] == "fan-c")
+    # fan-b is the final gate (picked second, at which point fan-c becomes ready)
+    assert fan_c_step["unblocked_by"] == "fan-b"
+    assert fan_c_step["unblocked_by_position"] == 2
+
+
 def test_simulation_does_not_write_to_task_files(tmp_path: Path, monkeypatch) -> None:
     """The cascade is simulated in memory — task files must be untouched."""
     tasks_dir = _chain_fixture(tmp_path)

--- a/packages/gptodo/tests/test_next_sequence.py
+++ b/packages/gptodo/tests/test_next_sequence.py
@@ -1,0 +1,428 @@
+"""Tests for `gptodo next --limit N` greedy sequential (cascade) simulation.
+
+`gptodo ready` / `gptodo next` only ever show the *currently* unblocked set.
+If A unblocks B, B is invisible until A is actually completed. These tests cover
+the simulated cascade: "if I did these N in order, here is the sequence,
+including things that only become available partway down".
+"""
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from gptodo.cli import cli
+
+
+def write_task(tasks_dir: Path, name: str, **metadata: object) -> None:
+    """Write a minimal task file with YAML frontmatter."""
+    lines = ["---"]
+    for key, value in metadata.items():
+        if isinstance(value, list):
+            lines.append(f"{key}:")
+            for item in value:
+                lines.append(f"  - {item}")
+        else:
+            lines.append(f"{key}: {value}")
+    lines.extend(["---", f"# {name}"])
+    (tasks_dir / f"{name}.md").write_text("\n".join(lines))
+
+
+def _payload(output: str) -> dict:
+    """Extract the JSON object from CLI output (stderr notes may be interleaved)."""
+    start = output.index("{")
+    return json.loads(output[start:])
+
+
+def _chain_fixture(tmp_path: Path) -> Path:
+    """A -> B -> C chain: only A is ready; B and C are invisible to `ready`."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(
+        tasks_dir,
+        "chain-a",
+        state="todo",
+        created="2026-03-28T00:00:00",
+        priority="high",
+    )
+    write_task(
+        tasks_dir,
+        "chain-b",
+        state="backlog",
+        created="2026-03-28T01:00:00",
+        priority="medium",
+        requires=["chain-a"],
+    )
+    write_task(
+        tasks_dir,
+        "chain-c",
+        state="backlog",
+        created="2026-03-28T02:00:00",
+        priority="low",
+        requires=["chain-b"],
+    )
+    return tasks_dir
+
+
+# ---------------------------------------------------------------------------
+# Regression guard: the autonomous-session contract must not change
+# ---------------------------------------------------------------------------
+
+
+def test_limit_1_json_identical_to_no_flag(tmp_path: Path, monkeypatch) -> None:
+    """`next --json` and `next --json --limit 1` must produce identical output.
+
+    Autonomous sessions call `gptodo next --json`; breaking that shape breaks them.
+    """
+    _chain_fixture(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+
+    bare = runner.invoke(cli, ["next", "--json"])
+    limited = runner.invoke(cli, ["next", "--json", "--limit", "1"])
+
+    assert bare.exit_code == 0, bare.output
+    assert limited.exit_code == 0, limited.output
+    assert bare.output == limited.output
+    # And the legacy keys are still there, unchanged.
+    payload = _payload(bare.output)
+    assert payload["next_task"]["name"] == "chain-a"
+    assert "alternatives" in payload
+    assert "sequence" not in payload
+
+
+def test_limit_1_text_identical_to_no_flag(tmp_path: Path, monkeypatch) -> None:
+    """Human-readable output for `--limit 1` must match the no-flag output."""
+    _chain_fixture(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+
+    bare = runner.invoke(cli, ["next"])
+    limited = runner.invoke(cli, ["next", "--limit", "1"])
+
+    assert bare.exit_code == 0, bare.output
+    assert limited.exit_code == 0, limited.output
+    assert bare.output == limited.output
+
+
+# ---------------------------------------------------------------------------
+# The point of the feature: tasks invisible to `ready` appear in the cascade
+# ---------------------------------------------------------------------------
+
+
+def test_chain_appears_in_order_with_attribution(tmp_path: Path, monkeypatch) -> None:
+    """B and C are invisible to `ready` but appear in `next --limit 3`, in order."""
+    _chain_fixture(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+
+    ready = runner.invoke(cli, ["ready", "--state", "both", "--json"])
+    assert ready.exit_code == 0, ready.output
+    ready_names = {t["name"] for t in _payload(ready.output)["ready_tasks"]}
+    assert ready_names == {"chain-a"}, "fixture broken: B/C should be blocked"
+
+    result = runner.invoke(cli, ["next", "--json", "--limit", "3"])
+    assert result.exit_code == 0, result.output
+    payload = _payload(result.output)
+
+    seq = payload["sequence"]
+    assert [step["task"]["name"] for step in seq] == ["chain-a", "chain-b", "chain-c"]
+
+    assert seq[0]["unblocked_by"] is None
+    assert seq[0]["unblocked_by_position"] is None
+    assert seq[1]["unblocked_by"] == "chain-a"
+    assert seq[1]["unblocked_by_position"] == 1
+    assert seq[2]["unblocked_by"] == "chain-b"
+    assert seq[2]["unblocked_by_position"] == 2
+
+    assert payload["reachable"] == 3
+    assert payload["requested"] == 3
+    assert payload["complete"] is True
+    # Legacy keys still present for consumers that only read them.
+    assert payload["next_task"]["name"] == "chain-a"
+
+
+def test_chain_text_output_states_why_each_item_is_there(tmp_path: Path, monkeypatch) -> None:
+    """Human output must explain each item past the first (`unblocked by #N`)."""
+    _chain_fixture(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["next", "--limit", "3"])
+    assert result.exit_code == 0, result.output
+    out = result.output
+
+    assert "chain-a" in out and "chain-b" in out and "chain-c" in out
+    assert "already ready" in out
+    assert "unblocked by #1" in out
+    assert "unblocked by #2" in out
+
+
+# ---------------------------------------------------------------------------
+# --order unblock must genuinely diverge from --order priority
+# ---------------------------------------------------------------------------
+
+
+def _diverging_fixture(tmp_path: Path) -> Path:
+    """Graph where priority order and unblock order genuinely differ.
+
+    - `solo-high` : high priority, unblocks nothing.
+    - `hub-low`   : low priority, transitively unblocks 3 tasks.
+
+    priority order -> solo-high first.  unblock order -> hub-low first.
+    """
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(
+        tasks_dir,
+        "solo-high",
+        state="todo",
+        created="2026-03-28T00:00:00",
+        priority="high",
+    )
+    write_task(
+        tasks_dir,
+        "hub-low",
+        state="todo",
+        created="2026-03-28T01:00:00",
+        priority="low",
+    )
+    for i, name in enumerate(["leaf-one", "leaf-two"]):
+        write_task(
+            tasks_dir,
+            name,
+            state="backlog",
+            created=f"2026-03-28T0{2 + i}:00:00",
+            priority="low",
+            requires=["hub-low"],
+        )
+    write_task(
+        tasks_dir,
+        "leaf-deep",
+        state="backlog",
+        created="2026-03-28T04:00:00",
+        priority="low",
+        requires=["leaf-one"],
+    )
+    return tasks_dir
+
+
+def test_order_unblock_differs_from_order_priority(tmp_path: Path, monkeypatch) -> None:
+    """`--order unblock` surfaces the critical path, not the priority path."""
+    _diverging_fixture(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+
+    by_priority = runner.invoke(cli, ["next", "--json", "--limit", "2", "--order", "priority"])
+    by_unblock = runner.invoke(cli, ["next", "--json", "--limit", "2", "--order", "unblock"])
+    assert by_priority.exit_code == 0, by_priority.output
+    assert by_unblock.exit_code == 0, by_unblock.output
+
+    prio_names = [s["task"]["name"] for s in _payload(by_priority.output)["sequence"]]
+    unblock_names = [s["task"]["name"] for s in _payload(by_unblock.output)["sequence"]]
+
+    assert prio_names[0] == "solo-high"
+    assert unblock_names[0] == "hub-low"
+    assert prio_names != unblock_names
+
+
+def test_order_unblock_cascades_through_the_critical_path(tmp_path: Path, monkeypatch) -> None:
+    """With --order unblock the whole chain is reachable and attributed."""
+    _diverging_fixture(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["next", "--json", "--limit", "5", "--order", "unblock"])
+    assert result.exit_code == 0, result.output
+    payload = _payload(result.output)
+    seq = payload["sequence"]
+
+    names = [s["task"]["name"] for s in seq]
+    assert names[0] == "hub-low"
+    assert set(names) == {"hub-low", "solo-high", "leaf-one", "leaf-two", "leaf-deep"}
+
+    by_name = {s["task"]["name"]: s for s in seq}
+    assert by_name["hub-low"]["unblocked_by"] is None
+    assert by_name["solo-high"]["unblocked_by"] is None  # was already ready
+    assert by_name["leaf-one"]["unblocked_by"] == "hub-low"
+    assert by_name["leaf-two"]["unblocked_by"] == "hub-low"
+    assert by_name["leaf-deep"]["unblocked_by"] == "leaf-one"
+    assert payload["complete"] is True
+
+
+# ---------------------------------------------------------------------------
+# Honesty: a short list must say it is short
+# ---------------------------------------------------------------------------
+
+
+def test_fewer_than_n_reachable_is_stated_explicitly(tmp_path: Path, monkeypatch) -> None:
+    """A short list that looks complete is the failure mode; say it is short."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(tasks_dir, "solo", state="todo", created="2026-03-28T00:00:00", priority="high")
+    write_task(
+        tasks_dir,
+        "forever-blocked",
+        state="backlog",
+        created="2026-03-28T01:00:00",
+        priority="high",
+        requires=["nonexistent-task"],
+    )
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["next", "--limit", "5"])
+    assert result.exit_code == 0, result.output
+    assert "1 of 5" in result.output
+    assert "nothing further is unblocked" in result.output
+
+    as_json = runner.invoke(cli, ["next", "--json", "--limit", "5"])
+    assert as_json.exit_code == 0, as_json.output
+    payload = _payload(as_json.output)
+    assert payload["reachable"] == 1
+    assert payload["requested"] == 5
+    assert payload["complete"] is False
+    assert "1 of 5" in payload["note"]
+
+
+# ---------------------------------------------------------------------------
+# Cycles must not hang the simulation
+# ---------------------------------------------------------------------------
+
+
+def test_dependency_cycle_terminates(tmp_path: Path, monkeypatch) -> None:
+    """A cycle blocks its members forever; the simulation must still terminate."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(
+        tasks_dir,
+        "cycle-a",
+        state="todo",
+        created="2026-03-28T00:00:00",
+        priority="high",
+        requires=["cycle-b"],
+    )
+    write_task(
+        tasks_dir,
+        "cycle-b",
+        state="todo",
+        created="2026-03-28T01:00:00",
+        priority="high",
+        requires=["cycle-a"],
+    )
+    write_task(
+        tasks_dir,
+        "standalone",
+        state="todo",
+        created="2026-03-28T02:00:00",
+        priority="medium",
+    )
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["next", "--json", "--limit", "5"])
+    assert result.exit_code == 0, result.output
+    payload = _payload(result.output)
+    names = [s["task"]["name"] for s in payload["sequence"]]
+    assert names == ["standalone"]
+    assert payload["complete"] is False
+
+
+def test_self_cycle_terminates(tmp_path: Path, monkeypatch) -> None:
+    """A task requiring itself must not loop the simulation."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(
+        tasks_dir,
+        "selfref",
+        state="todo",
+        created="2026-03-28T00:00:00",
+        priority="high",
+        requires=["selfref"],
+    )
+    write_task(tasks_dir, "ok", state="todo", created="2026-03-28T01:00:00", priority="low")
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["next", "--json", "--limit", "5"])
+    assert result.exit_code == 0, result.output
+    payload = _payload(result.output)
+    assert [s["task"]["name"] for s in payload["sequence"]] == ["ok"]
+
+
+# ---------------------------------------------------------------------------
+# Filters apply throughout the simulation, not just to the first pick
+# ---------------------------------------------------------------------------
+
+
+def test_pool_filter_applies_to_whole_cascade(tmp_path: Path, monkeypatch) -> None:
+    """A frontier task unblocked mid-cascade must stay hidden under the default pool."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(tasks_dir, "root", state="todo", created="2026-03-28T00:00:00", priority="high")
+    write_task(
+        tasks_dir,
+        "frontier-child",
+        state="backlog",
+        created="2026-03-28T01:00:00",
+        priority="high",
+        pool="frontier",
+        requires=["root"],
+    )
+    write_task(
+        tasks_dir,
+        "general-child",
+        state="backlog",
+        created="2026-03-28T02:00:00",
+        priority="low",
+        requires=["root"],
+    )
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+
+    default_pool = runner.invoke(cli, ["next", "--json", "--limit", "5"])
+    assert default_pool.exit_code == 0, default_pool.output
+    names = [s["task"]["name"] for s in _payload(default_pool.output)["sequence"]]
+    assert names == ["root", "general-child"]
+
+    all_pools = runner.invoke(cli, ["next", "--json", "--limit", "5", "--pool", "all"])
+    assert all_pools.exit_code == 0, all_pools.output
+    all_names = [s["task"]["name"] for s in _payload(all_pools.output)["sequence"]]
+    assert "frontier-child" in all_names
+
+
+def test_waiting_task_never_enters_the_cascade(tmp_path: Path, monkeypatch) -> None:
+    """Tasks blocked on an external actor stay out, even when their deps complete."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    write_task(tasks_dir, "root2", state="todo", created="2026-03-28T00:00:00", priority="high")
+    write_task(
+        tasks_dir,
+        "needs-erik",
+        state="backlog",
+        created="2026-03-28T01:00:00",
+        priority="high",
+        waiting_for="Erik review",
+        requires=["root2"],
+    )
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["next", "--json", "--limit", "5"])
+    assert result.exit_code == 0, result.output
+    payload = _payload(result.output)
+    assert [s["task"]["name"] for s in payload["sequence"]] == ["root2"]
+
+
+def test_simulation_does_not_write_to_task_files(tmp_path: Path, monkeypatch) -> None:
+    """The cascade is simulated in memory — task files must be untouched."""
+    tasks_dir = _chain_fixture(tmp_path)
+    before = {p.name: p.read_text() for p in tasks_dir.glob("*.md")}
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["next", "--json", "--limit", "3"])
+    assert result.exit_code == 0, result.output
+
+    after = {p.name: p.read_text() for p in tasks_dir.glob("*.md")}
+    assert before == after

--- a/packages/gptodo/tests/test_next_sequence.py
+++ b/packages/gptodo/tests/test_next_sequence.py
@@ -414,6 +414,24 @@ def test_waiting_task_never_enters_the_cascade(tmp_path: Path, monkeypatch) -> N
     assert [s["task"]["name"] for s in payload["sequence"]] == ["root2"]
 
 
+def test_reported_state_is_real_not_simulated(tmp_path: Path, monkeypatch) -> None:
+    """Each step reports the task's actual state, not the simulated 'done'.
+
+    The simulation marks picks as done to reveal what they unblock; leaking that
+    into the output would tell the reader the work is already finished.
+    """
+    _chain_fixture(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["next", "--json", "--limit", "3"])
+    assert result.exit_code == 0, result.output
+    states = {s["task"]["name"]: s["task"]["state"] for s in _payload(result.output)["sequence"]}
+
+    assert states == {"chain-a": "todo", "chain-b": "backlog", "chain-c": "backlog"}
+    assert "done" not in states.values()
+
+
 def test_simulation_does_not_write_to_task_files(tmp_path: Path, monkeypatch) -> None:
     """The cascade is simulated in memory — task files must be untouched."""
     tasks_dir = _chain_fixture(tmp_path)


### PR DESCRIPTION
## What

`gptodo ready` and `gptodo next` answer a **parallel** question: what is unblocked *right now*. If task A unblocks task B, **B is invisible to both** until A is actually completed — so a queue that is really five deep can look one task shallow.

`gptodo next --limit N` answers the **sequential** question instead: "if I did these N in order, what is the sequence, including the things that only become available partway down?"

Greedy simulation: compute the ready set → pick the top task → **simulate** completing it (in memory; task files are never written) → recompute the ready set → repeat.

## Legibility

Every item past the first states why it is there:

```
🏃 Next 5 tasks (order: priority — what's next, then next)
┏━━━━┳━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃  # ┃ ID  ┃ Priority ┃ Task                                     ┃ Why                               ┃
┡━━━━╇━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ #1 │ 670 │ high     │ pm-stuck-gptme-gptme-contrib-1419        │ (already ready)                   │
│ #2 │ 672 │ high     │ erik-agenda-has-no-deadline-awareness    │ (already ready)                   │
│ #3 │ 667 │ medium   │ idea-backlog-stranded-row-migration      │ (already ready)                   │
│ #4 │ 656 │ high     │ idea-backlog-stranded-batch-move-phase1- │ unblocked by #3                   │
│    │     │          │ 3                                        │ idea-backlog-stranded-row-migrat… │
│ #5 │ 629 │ medium   │ install-size-budget-reduce-after-torch-p │ (already ready)                   │
│    │     │          │ in                                       │                                   │
└────┴─────┴──────────┴──────────────────────────────────────────┴───────────────────────────────────┘
```

`#4` is **not** in `gptodo ready` — that is the entire point of the feature.

## Two orderings

| `--order` | Behaviour |
|-----------|-----------|
| `priority` (default) | Greedy by the existing `next` ordering — literally "what's next, then next". |
| `unblock` | At each step take the task that unblocks the most downstream work — surfaces the **critical path** rather than the priority path. |

On the real task set they genuinely diverge: `--order unblock` leads with `idea-backlog-stranded-row-migration` (medium priority, but it unblocks a high-priority task) and pulls its dependent to #2, where `--order priority` puts it at #3/#4.

## Honesty about short lists

If fewer than N are reachable, it says so explicitly — `only 3 of 5 reachable — nothing further is unblocked by this sequence` — rather than returning a short list that looks complete.

## Backward compatibility (hard requirement)

`--limit 1` and the no-flag path are **byte-identical** to previous behaviour, text and `--json`. Verified two ways:

- Regression tests asserting `next --json` == `next --json --limit 1` and the same for text output.
- Diffing this branch's output against `origin/master` on the real workspace task set: identical for bare `--json`, `--limit 1`, and bare text.

In multi-task mode the JSON *gains* `sequence` / `order` / `requested` / `reachable` / `complete` / `note` alongside the unchanged `next_task` / `alternatives`. Autonomous sessions calling `gptodo next --json` are unaffected.

## No reinvented dependency resolution

Readiness comes from `is_task_ready`; ordering weight from `compute_unblocking_power` — the same primitives the single-pick `next` already used. The new `sequence.py` only drives the loop and tracks attribution.

## Tests

12 new tests in `tests/test_next_sequence.py`, written to fail first (confirmed: 12/12 failed on `origin/master`, 12/12 pass now):

- `--limit 1` / no-flag identical to current behaviour, JSON **and** text.
- A→B→C chain where B and C are invisible to `ready` but appear in `next --limit 3` in order with correct attribution.
- `--order unblock` picks a genuinely different, correct sequence from `--order priority` on a fixture built so they diverge.
- Fewer-than-N reachable → explicit short-list message, in text and JSON.
- Dependency cycle terminates (both a 2-cycle and a self-cycle).
- `--pool` filtering applies to the whole cascade, not just the first pick.
- `waiting_for` tasks never enter the cascade.
- Task files are byte-identical after a simulation.

Full suite: 459 passed.

## Performance

`compute_unblocking_power` is O(V·E), so calling it inside the simulation loop was quadratic in the limit. A synthetic 500-deep chain at `--limit 100` took **11.3s**; hoisting the computation out of the loop drops it to **0.59s** with byte-identical output. On the real 674-task workspace, `--limit 20 --order unblock` runs in 0.26s — the same as a bare single-pick `next`.

Computing power against the original graph is also the more correct reading: "how much downstream work does this unlock" is a property of the real graph, and it is exactly how the single-pick `next` already computes it.

## Honest note on real-world exercise

The table above is a real capture from the live workspace at the time of writing, and `#4` was verified absent from `gptodo ready` at that moment. Roughly twenty minutes later another session completed `idea-backlog-stranded-row-migration` (and cancelled its dependent), and the live graph went **completely flat**: 674 tasks, 6 open, and **zero** open tasks blocked by another task.

So: the feature is correct and was demonstrably exercised on real data, but the workspace dependency graph is normally shallow enough that `next --limit N` mostly degenerates to "the top N ready tasks". That is worth knowing before anyone treats this as a major planning upgrade — the value shows up only when task chains actually exist.

## Note on the design

Greedy is the right model here *for now*: the real dependency graph is shallow (one two-deep chain in the whole workspace), so greedy and optimal coincide. If the graph ever gets deep enough that greedy leaves obviously-better sequences on the table, `--order unblock` is the escape hatch, and a proper longest-path/topological scheduler would be the next step. Worth knowing that the feature is currently only lightly exercised by real data.
