### PR TITLE
fix(ci): use unsafe-best-match index strategy in install-size check

### DIFF
--- a/scripts/check_install_size.py
+++ b/scripts/check_install_size.py
@@ -158,6 +158,13 @@ def measure_install_size(package_path: Path, package_name: str) -> float | None:
                     # to search all declared indexes and pick the best version match.
                     # This fixes "certifi==2026.7.22 not found" when PyPI has it but the
                     # torch wheel index is searched first (gptme-contrib#1418 regression).
+                    #
+                    # Security: unsafe-best-match widens the search to all declared
+                    # indexes. All indexes here are injected by --emit-index-url from the
+                    # workspace lockfile and pyproject.toml [tool.uv.index] entries —
+                    # project-controlled configuration already trusted at lock time. The
+                    # residual risk is bounded to a compromised project config, the same
+                    # threat model as trusting the lockfile itself.
                     "--index-strategy",
                     "unsafe-best-match",
                     "-r",

--- a/scripts/check_install_size.py
+++ b/scripts/check_install_size.py
@@ -151,6 +151,15 @@ def measure_install_size(package_path: Path, package_name: str) -> float | None:
                     "--python",
                     str(python_exe),
                     "--quiet",
+                    # --emit-index-url injects extra index URLs (e.g. the PyTorch CPU
+                    # wheel index for packages that need torch). uv's default strategy
+                    # stops at the first index that *has* the package, even when that
+                    # index doesn't carry the pinned version. unsafe-best-match tells uv
+                    # to search all declared indexes and pick the best version match.
+                    # This fixes "certifi==2026.7.22 not found" when PyPI has it but the
+                    # torch wheel index is searched first (gptme-contrib#1418 regression).
+                    "--index-strategy",
+                    "unsafe-best-match",
                     "-r",
                     str(req_file),
                     str(package_path),

--- a/tests/test_check_install_size.py
+++ b/tests/test_check_install_size.py
@@ -233,6 +233,11 @@ def test_measure_install_size_index_strategy_flag():
     found on a secondary index (e.g. certifi on PyPI after the PyTorch wheel
     index) cause 'unsatisfiable requirements' errors when --emit-index-url
     injects a non-PyPI index that contains the package at a different version.
+
+    Note: this test verifies command *construction* — that the flag is passed to
+    uv. It cannot exercise uv's real index-resolution logic because subprocess is
+    mocked. The companion test below verifies the flag is absent on the PyPI
+    fallback path, confirming the flag is conditional on the lock-export branch.
     """
     import check_install_size
 
@@ -280,6 +285,61 @@ def test_measure_install_size_index_strategy_flag():
     assert (
         install_cmd[idx + 1] == "unsafe-best-match"
     ), f"Expected 'unsafe-best-match', got {install_cmd[idx + 1]!r}"
+
+
+def test_measure_install_size_pypi_fallback_no_index_strategy():
+    """PyPI fallback path does NOT include --index-strategy in the install command.
+
+    When the workspace lock export fails (e.g. package not in uv.lock), the
+    install falls back to a plain PyPI install without injected index URLs.
+    In that case --index-strategy must be absent: it is only safe to widen the
+    index search when --emit-index-url has explicitly declared trusted sources.
+
+    This is the complement to test_measure_install_size_index_strategy_flag:
+    together they show the flag is conditional on the lock-export branch, not
+    hardcoded on every install invocation.
+    """
+    import check_install_size
+
+    captured_cmds: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        captured_cmds.append(list(cmd))
+        result = MagicMock()
+        result.stderr = ""
+        if "venv" in cmd:
+            venv_path = Path(cmd[-1])
+            _make_fake_venv(venv_path, 1024)
+            (venv_path / "bin").mkdir(exist_ok=True)
+            (venv_path / "bin" / "python").touch()
+            result.returncode = 0
+            result.stdout = ""
+        elif "export" in cmd:
+            # Simulate a failed lock export (package not in uv.lock).
+            # This triggers the PyPI fallback path in measure_install_size.
+            result.returncode = 1
+            result.stdout = ""
+        elif "du" in cmd:
+            result.returncode = 0
+            result.stdout = f"1024\t{cmd[-1]}\n"
+        else:
+            result.returncode = 0
+            result.stdout = ""
+        return result
+
+    with patch.object(subprocess, "run", side_effect=fake_run):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            package_path = Path(tmpdir) / "mypkg"
+            package_path.mkdir()
+            check_install_size.measure_install_size(package_path, "mypkg")
+
+    install_cmds = [cmd for cmd in captured_cmds if "pip" in cmd and "install" in cmd]
+    assert install_cmds, "No pip install command was captured"
+    install_cmd = install_cmds[0]
+
+    assert (
+        "--index-strategy" not in install_cmd
+    ), f"--index-strategy must not appear in PyPI fallback install cmd: {install_cmd}"
 
 
 def test_check_packages_pass_and_fail():

--- a/tests/test_check_install_size.py
+++ b/tests/test_check_install_size.py
@@ -226,6 +226,62 @@ def test_measure_install_size_timeout():
     assert size is None
 
 
+def test_measure_install_size_index_strategy_flag():
+    """Lock-export path includes --index-strategy unsafe-best-match in install command.
+
+    Regression guard for gptme-contrib#1418: without this flag, pinned packages
+    found on a secondary index (e.g. certifi on PyPI after the PyTorch wheel
+    index) cause 'unsatisfiable requirements' errors when --emit-index-url
+    injects a non-PyPI index that contains the package at a different version.
+    """
+    import check_install_size
+
+    captured_cmds: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        captured_cmds.append(list(cmd))
+        result = MagicMock()
+        result.returncode = 0
+        result.stderr = ""
+        if "venv" in cmd:
+            venv_path = Path(cmd[-1])
+            _make_fake_venv(venv_path, 1024)
+            (venv_path / "bin").mkdir(exist_ok=True)
+            (venv_path / "bin" / "python").touch()
+            result.stdout = ""
+        elif "export" in cmd:
+            # Simulate successful lock export with a non-PyPI index URL injected,
+            # which is what triggers the 'pinned version not found on first index'
+            # failure without the unsafe-best-match strategy.
+            result.stdout = (
+                "--index-url https://download.pytorch.org/whl/cpu\npkg==1.0.0\n"
+            )
+        elif "du" in cmd:
+            result.stdout = f"1024\t{cmd[-1]}\n"
+        else:
+            result.stdout = ""
+        return result
+
+    with patch.object(subprocess, "run", side_effect=fake_run):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            package_path = Path(tmpdir) / "mypkg"
+            package_path.mkdir()
+            check_install_size.measure_install_size(package_path, "mypkg")
+
+    # Find the pip install invocation (not venv/export/du)
+    install_cmds = [cmd for cmd in captured_cmds if "pip" in cmd and "install" in cmd]
+    assert install_cmds, "No pip install command was captured"
+    install_cmd = install_cmds[0]
+
+    assert (
+        "--index-strategy" in install_cmd
+    ), f"--index-strategy missing from lock-export install cmd: {install_cmd}"
+    idx = install_cmd.index("--index-strategy")
+    assert (
+        install_cmd[idx + 1] == "unsafe-best-match"
+    ), f"Expected 'unsafe-best-match', got {install_cmd[idx + 1]!r}"
+
+
 def test_check_packages_pass_and_fail():
     """check_packages returns True for passing packages and False when over budget."""
     import check_install_size


### PR DESCRIPTION
## Problem

The `install-size` CI job added in #1418 immediately started failing for packages with torch dependencies (gptme-rag, gptme-voice, gptme-lessons-extras, gptme-lessons-mcp, gptme-wisdom-mcp, gptme-contrib-lib).

Root cause: `--emit-index-url` injects the PyTorch CPU wheel index URL into the exported requirements file. With uv's default `first-match` index strategy, uv finds `certifi` on the torch wheel index (at an older version) and refuses to look at PyPI for the pinned version (`certifi==2026.7.22`):

```
× No solution found when resolving dependencies:
╰─▶ Because there is no version of certifi==2026.7.22 and you require
    certifi==2026.7.22, we can conclude that your requirements are unsatisfiable.

hint: certifi was found on https://download.pytorch.org/whl/cpu, but not at
the requested version. A compatible version may be available on a subsequent index.
By default, uv will only consider versions published on the first index that
contains a given package...
```

The hint even says the fix: use `unsafe-best-match`.

## Fix

Add `--index-strategy unsafe-best-match` to the `uv pip install` command when using the workspace-exported requirements file. This tells uv to search all declared indexes and pick the best version match instead of stopping at the first index.

This unblocks #1415 and any other PRs currently stuck on this failure.