### PR TITLE
fix(ci): reduce gptme-rag install-size budget

### DIFF
--- a/packages/gptme-rag/pyproject.toml
+++ b/packages/gptme-rag/pyproject.toml
@@ -83,7 +83,4 @@ markers = [
 ]
 
 [tool.gptme-contrib]
-# gptme-rag installs sentence-transformers which pulls torch+CUDA (~7.3GB from PyPI)
-# until gptme/gptme-contrib#1416 (CPU-torch pin) lands. Reduce to ~1000 MB after
-# #1416 is merged and the measured size confirmed.
-max_install_mb = 8000
+max_install_mb = 1450

--- a/scripts/check_install_size.py
+++ b/scripts/check_install_size.py
@@ -113,6 +113,14 @@ def measure_install_size(package_path: Path, package_name: str) -> float | None:
             # unsafe-best-match is required because PyTorch's CPU index mirrors
             # some non-torch packages with older versions; first-index would make
             # normal PyPI releases invisible once that mirror has any match.
+            #
+            # Note: we do NOT pass --emit-index-url here. Index URLs are not needed
+            # in the generated requirements.txt because the subsequent uv pip install
+            # runs with cwd=package_path.parent.parent (the workspace root), so uv
+            # reads [tool.uv.index] from the workspace pyproject.toml directly and
+            # applies the same pytorch-cpu index override without being told via
+            # requirements-file headers. CI confirms: gptme-rag installs at ~1200MB
+            # (CPU torch), not ~5GB (CUDA build from plain PyPI).
             export_result = subprocess.run(
                 [
                     "uv",
@@ -182,6 +190,8 @@ def measure_install_size(package_path: Path, package_name: str) -> float | None:
                     str(package_path),
                 ]
 
+            # cwd=workspace root so uv reads [tool.uv.index] (pytorch-cpu) from
+            # pyproject.toml, making --emit-index-url on the export unnecessary.
             result = subprocess.run(
                 install_cmd,
                 cwd=package_path.parent.parent,

--- a/scripts/check_install_size.py
+++ b/scripts/check_install_size.py
@@ -110,8 +110,9 @@ def measure_install_size(package_path: Path, package_name: str) -> float | None:
 
             # Try to export workspace-locked requirements. uv export reads uv.lock,
             # which includes [tool.uv.index] overrides (e.g. CPU-only torch index).
-            # --no-hashes produces a plain requirements.txt; --emit-index-url
-            # injects the index URLs so uv pip resolves from the correct source.
+            # unsafe-best-match is required because PyTorch's CPU index mirrors
+            # some non-torch packages with older versions; first-index would make
+            # normal PyPI releases invisible once that mirror has any match.
             export_result = subprocess.run(
                 [
                     "uv",
@@ -122,7 +123,8 @@ def measure_install_size(package_path: Path, package_name: str) -> float | None:
                     package_name,
                     "--no-dev",
                     "--no-hashes",
-                    "--emit-index-url",
+                    "--index-strategy",
+                    "unsafe-best-match",
                 ],
                 cwd=package_path.parent.parent,
                 capture_output=True,
@@ -150,6 +152,8 @@ def measure_install_size(package_path: Path, package_name: str) -> float | None:
                     "install",
                     "--python",
                     str(python_exe),
+                    "--index-strategy",
+                    "unsafe-best-match",
                     "--quiet",
                     "-r",
                     str(req_file),
@@ -172,6 +176,8 @@ def measure_install_size(package_path: Path, package_name: str) -> float | None:
                     "install",
                     "--python",
                     str(python_exe),
+                    "--index-strategy",
+                    "unsafe-best-match",
                     "--quiet",
                     str(package_path),
                 ]

--- a/tests/test_check_install_size.py
+++ b/tests/test_check_install_size.py
@@ -113,8 +113,10 @@ def test_measure_install_size_success():
     import check_install_size
 
     file_size = 10 * 1024 * 1024  # 10 MB
+    seen_commands = []
 
     def fake_run(cmd, **kwargs):
+        seen_commands.append(cmd)
         result = MagicMock()
         result.returncode = 0
         result.stderr = ""
@@ -143,6 +145,12 @@ def test_measure_install_size_success():
 
     assert size is not None
     assert 9.0 < size < 11.0  # ~10 MB
+    export_cmd = next(cmd for cmd in seen_commands if "export" in cmd)
+    install_cmd = next(cmd for cmd in seen_commands if "install" in cmd)
+    assert "--emit-index-url" not in export_cmd
+    assert export_cmd[-2:] == ["--index-strategy", "unsafe-best-match"]
+    assert "--index-strategy" in install_cmd
+    assert "unsafe-best-match" in install_cmd
 
 
 def test_measure_install_size_export_fallback():
@@ -150,8 +158,10 @@ def test_measure_install_size_export_fallback():
     import check_install_size
 
     file_size = 5 * 1024 * 1024  # 5 MB
+    seen_commands = []
 
     def fake_run(cmd, **kwargs):
+        seen_commands.append(cmd)
         result = MagicMock()
         result.stderr = ""
         if "venv" in cmd:
@@ -182,6 +192,9 @@ def test_measure_install_size_export_fallback():
 
     assert size is not None
     assert 4.0 < size < 6.0  # ~5 MB
+    install_cmd = next(cmd for cmd in seen_commands if "install" in cmd)
+    assert "--index-strategy" in install_cmd
+    assert "unsafe-best-match" in install_cmd
 
 
 def test_measure_install_size_install_failure():


### PR DESCRIPTION
## Summary

- replace the stale `uv export --emit-index-url` call in `check_install_size.py` with current uv flags
- use `--index-strategy unsafe-best-match` for export/install so the PyTorch CPU index does not shadow newer PyPI packages like `tqdm`
- reduce `gptme-rag`'s install-size budget from `8000MB` to `1450MB` after the CPU torch pin landed

## Verification

- `uv run --with pytest pytest tests/test_check_install_size.py -v`
- `uv run ruff check scripts/check_install_size.py tests/test_check_install_size.py`
- `uv run python3 scripts/check_install_size.py --package gptme-rag` -> `1198.2MB / 1450MB`
- forced-red check with a temporary `1000MB` budget -> `1198.2MB / 1000MB`, exit code `1`

Follow-up to gptme/gptme-contrib#1416 and gptme/gptme-contrib#1418.
