### PR TITLE
fix(ci): remove duplicate --index-strategy in install-size check

### DIFF
--- a/scripts/check_install_size.py
+++ b/scripts/check_install_size.py
@@ -163,8 +163,6 @@ def measure_install_size(package_path: Path, package_name: str) -> float | None:
                     "--index-strategy",
                     "unsafe-best-match",
                     "--quiet",
-                    "--index-strategy",
-                    "unsafe-best-match",
                     "-r",
                     str(req_file),
                     str(package_path),
@@ -189,8 +187,6 @@ def measure_install_size(package_path: Path, package_name: str) -> float | None:
                     "--index-strategy",
                     "unsafe-best-match",
                     "--quiet",
-                    "--index-strategy",
-                    "unsafe-best-match",
                     str(package_path),
                 ]
 


### PR DESCRIPTION
## Problem

PR #1424 added `--index-strategy unsafe-best-match` to both `uv pip install` command lists in `scripts/check_install_size.py`, but a prior fix had already added it once. uv rejects duplicate flag occurrences:

```
error: the argument '--index-strategy <INDEX_STRATEGY>' cannot be used multiple times
```

This caused the `install-size` check to fail for every package after #1424 merged.

## Fix

Remove the second (duplicate) `--index-strategy unsafe-best-match` from each of the two `install_cmd` paths. The first occurrence (already present before #1424) is sufficient.

## Verification

The post-merge CI on #1424 shows this error: https://github.com/gptme/gptme-contrib/actions/runs/31745108143/job/94597778568