### PR TITLE
fix(ci): separate resolution failures from budget overages in install-size check

### DIFF
--- a/scripts/check_install_size.py
+++ b/scripts/check_install_size.py
@@ -236,7 +236,7 @@ def measure_install_size(package_path: Path, package_name: str) -> float | None:
 
 def check_packages(
     packages_dir: Path, verbose: bool = False, only: str | None = None
-) -> bool:
+) -> tuple[bool, int, int]:
     """Check all packages in packages/ directory.
 
     Args:
@@ -244,9 +244,12 @@ def check_packages(
             builds a venv each, so local runs want a single target).
 
     Returns:
-        True if all packages pass, False if any exceed their budget.
+        Tuple of (all_pass, resolution_failures, budget_overages).
+        all_pass is True if both resolution_failures and budget_overages are 0.
     """
     all_pass = True
+    resolution_failures = 0
+    budget_overages = 0
     packages_dir = packages_dir.resolve()
 
     package_paths = sorted(
@@ -256,7 +259,7 @@ def check_packages(
         package_paths = [p for p in package_paths if p.name == only]
         if not package_paths:
             print(f"❌ No package named {only!r} in {packages_dir}")
-            return False
+            return False, 0, 0
 
     for package_path in package_paths:
         # Skip symlinks (they point to gptme-contrib submodule)
@@ -276,6 +279,7 @@ def check_packages(
         except (ValueError, TypeError) as e:
             print(f"✗ {package_path.name:40} bad max_install_mb in pyproject.toml: {e}")
             all_pass = False
+            resolution_failures += 1
             continue
 
         # Read the canonical distribution name from pyproject.toml [project] name.
@@ -293,6 +297,7 @@ def check_packages(
         if size_mb is None:
             print(f"✗ {package_path.name:40} installation failed")
             all_pass = False
+            resolution_failures += 1
             continue
 
         status = "✓" if size_mb <= budget_mb else "✗"
@@ -303,8 +308,9 @@ def check_packages(
 
         if size_mb > budget_mb:
             all_pass = False
+            budget_overages += 1
 
-    return all_pass
+    return all_pass, resolution_failures, budget_overages
 
 
 if __name__ == "__main__":
@@ -325,11 +331,24 @@ if __name__ == "__main__":
     print("Checking package install sizes...")
     print()
 
-    if check_packages(packages_dir, args.verbose, args.package):
+    all_pass, resolution_failures, budget_overages = check_packages(
+        packages_dir, args.verbose, args.package
+    )
+
+    if all_pass:
         print()
         print("✓ All packages within budget")
         sys.exit(0)
     else:
         print()
-        print("✗ One or more packages exceeded budget")
+        # Report each failure class separately, only if it occurred
+        if resolution_failures > 0:
+            plural = "package" if resolution_failures == 1 else "packages"
+            print(
+                f"✗ {resolution_failures} {plural} failed to resolve dependencies "
+                f"(see per-package output above)"
+            )
+        if budget_overages > 0:
+            plural = "package" if budget_overages == 1 else "packages"
+            print(f"✗ {budget_overages} {plural} exceeded their install-size budget")
         sys.exit(1)

--- a/scripts/check_install_size.py
+++ b/scripts/check_install_size.py
@@ -73,6 +73,8 @@ class CheckResult:
         yield self.budget_overages
 
     def __eq__(self, other: object) -> bool:
+        if isinstance(other, bool):
+            return self.all_pass == other
         if isinstance(other, tuple):
             return tuple(self) == other
         if isinstance(other, CheckResult):

--- a/scripts/check_install_size.py
+++ b/scripts/check_install_size.py
@@ -163,8 +163,6 @@ def measure_install_size(package_path: Path, package_name: str) -> float | None:
                     "--index-strategy",
                     "unsafe-best-match",
                     "--quiet",
-                    "--index-strategy",
-                    "unsafe-best-match",
                     "-r",
                     str(req_file),
                     str(package_path),
@@ -189,8 +187,6 @@ def measure_install_size(package_path: Path, package_name: str) -> float | None:
                     "--index-strategy",
                     "unsafe-best-match",
                     "--quiet",
-                    "--index-strategy",
-                    "unsafe-best-match",
                     str(package_path),
                 ]
 

--- a/scripts/check_install_size.py
+++ b/scripts/check_install_size.py
@@ -16,7 +16,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
-from typing import Iterator
+from typing import Iterator, Literal
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -42,9 +42,10 @@ class CheckResult:
     Prefer attribute access for new code:
     - ``result.all_pass`` — overall pass/fail
     - ``result.config_errors`` — packages with invalid budget config
-    - ``result.install_failures`` — packages that failed to install
+    - ``result.resolution_failures`` — packages whose dependencies could not be resolved
+    - ``result.install_failures`` — packages that failed to install (after resolution)
     - ``result.budget_overages`` — packages that exceeded their size budget
-    - ``result.pre_measurement_failures`` — config_errors + install_failures (combined)
+    - ``result.pre_measurement_failures`` — config_errors + resolution_failures + install_failures (combined)
     """
 
     def __init__(
@@ -53,9 +54,11 @@ class CheckResult:
         config_errors: int,
         install_failures: int,
         budget_overages: int,
+        resolution_failures: int = 0,
     ) -> None:
         for _name, _val in (
             ("config_errors", config_errors),
+            ("resolution_failures", resolution_failures),
             ("install_failures", install_failures),
             ("budget_overages", budget_overages),
         ):
@@ -63,12 +66,13 @@ class CheckResult:
                 raise ValueError(f"{_name} must be non-negative, got {_val!r}")
         self.all_pass = all_pass
         self.config_errors = config_errors
+        self.resolution_failures = resolution_failures
         self.install_failures = install_failures
         self.budget_overages = budget_overages
 
     @property
     def pre_measurement_failures(self) -> int:
-        return self.config_errors + self.install_failures
+        return self.config_errors + self.resolution_failures + self.install_failures
 
     def __bool__(self) -> bool:
         return self.all_pass
@@ -88,6 +92,7 @@ class CheckResult:
             return (
                 self.all_pass == other.all_pass
                 and self.config_errors == other.config_errors
+                and self.resolution_failures == other.resolution_failures
                 and self.install_failures == other.install_failures
                 and self.budget_overages == other.budget_overages
             )
@@ -98,6 +103,7 @@ class CheckResult:
             (
                 self.all_pass,
                 self.config_errors,
+                self.resolution_failures,
                 self.install_failures,
                 self.budget_overages,
             )
@@ -107,6 +113,7 @@ class CheckResult:
         return (
             f"CheckResult(all_pass={self.all_pass!r}, "
             f"config_errors={self.config_errors!r}, "
+            f"resolution_failures={self.resolution_failures!r}, "
             f"install_failures={self.install_failures!r}, "
             f"budget_overages={self.budget_overages!r})"
         )
@@ -158,7 +165,21 @@ def get_package_budget(pyproject_path: Path) -> int:
     return DEFAULT_BUDGETS[category]
 
 
-def measure_install_size(package_path: Path, package_name: str) -> float | None:
+def _is_resolution_failure(stderr: str) -> bool:
+    """Return True when uv stderr indicates a dependency resolution failure.
+
+    uv prints 'No solution found when resolving' for unsatisfiable constraints.
+    Distinguishing these from generic install errors (network errors, permission
+    failures, etc.) lets CI output say "failed to resolve" instead of the
+    misleading "failed to install" when the index or lock is broken.
+    """
+    lower = stderr.lower()
+    return "no solution found" in lower or ("resolv" in lower and "error" in lower)
+
+
+def measure_install_size(
+    package_path: Path, package_name: str
+) -> float | Literal["resolution_failure"] | None:
     """Install package in a temp venv and measure disk usage.
 
     First tries to export workspace-locked requirements via ``uv export --package``.
@@ -171,7 +192,9 @@ def measure_install_size(package_path: Path, package_name: str) -> float | None:
     from PyPI and may overestimate size for index-pinned packages.
 
     Returns:
-        Size in MB, or None if installation failed.
+        Size in MB on success, ``"resolution_failure"`` when uv cannot resolve
+        dependencies, or ``None`` for other install errors (timeout, venv
+        creation failure, network error, etc.).
     """
     with tempfile.TemporaryDirectory() as tmp:
         tmpdir = Path(tmp)
@@ -286,6 +309,8 @@ def measure_install_size(package_path: Path, package_name: str) -> float | None:
             if result.returncode != 0:
                 print(f"❌ Installation failed for {package_name}")
                 print(result.stderr)
+                if _is_resolution_failure(result.stderr):
+                    return "resolution_failure"
                 return None
 
             # Measure venv disk usage with `du -sb` (bytes). du counts each
@@ -319,6 +344,7 @@ def print_failure_summary(result: CheckResult) -> None:
     Uses precise labels for each class so the summary directs developers to the
     right place:
     - config errors → check pyproject.toml
+    - resolution failures → check the dependency constraints / index configuration
     - install failures → check the install command / environment
     - budget overages → trim dependencies or raise the budget
 
@@ -328,6 +354,7 @@ def print_failure_summary(result: CheckResult) -> None:
     """
     if (
         result.config_errors == 0
+        and result.resolution_failures == 0
         and result.install_failures == 0
         and result.budget_overages == 0
     ):
@@ -337,6 +364,12 @@ def print_failure_summary(result: CheckResult) -> None:
         plural = "package" if result.config_errors == 1 else "packages"
         print(
             f"✗ {result.config_errors} {plural} had invalid budget configuration in pyproject.toml "
+            f"(see per-package output above)"
+        )
+    if result.resolution_failures > 0:
+        plural = "package" if result.resolution_failures == 1 else "packages"
+        print(
+            f"✗ {result.resolution_failures} {plural} failed to resolve dependencies "
             f"(see per-package output above)"
         )
     if result.install_failures > 0:
@@ -365,6 +398,7 @@ def check_packages(
     """
     all_pass = True
     config_errors = 0
+    resolution_failures = 0
     install_failures = 0
     budget_overages = 0
     packages_dir = packages_dir.resolve()
@@ -411,6 +445,12 @@ def check_packages(
 
         size_mb = measure_install_size(package_path, package_name)
 
+        if size_mb == "resolution_failure":
+            print(f"✗ {package_path.name:40} failed to resolve dependencies")
+            all_pass = False
+            resolution_failures += 1
+            continue
+
         if size_mb is None:
             print(f"✗ {package_path.name:40} installation failed")
             all_pass = False
@@ -427,7 +467,13 @@ def check_packages(
             all_pass = False
             budget_overages += 1
 
-    return CheckResult(all_pass, config_errors, install_failures, budget_overages)
+    return CheckResult(
+        all_pass,
+        config_errors,
+        install_failures,
+        budget_overages,
+        resolution_failures=resolution_failures,
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/check_install_size.py
+++ b/scripts/check_install_size.py
@@ -86,6 +86,16 @@ class CheckResult:
             )
         return NotImplemented
 
+    def __hash__(self) -> int:
+        return hash(
+            (
+                self.all_pass,
+                self.config_errors,
+                self.install_failures,
+                self.budget_overages,
+            )
+        )
+
     def __repr__(self) -> str:
         return (
             f"CheckResult(all_pass={self.all_pass!r}, "

--- a/scripts/check_install_size.py
+++ b/scripts/check_install_size.py
@@ -234,6 +234,22 @@ def measure_install_size(package_path: Path, package_name: str) -> float | None:
             return None
 
 
+def print_failure_summary(pre_measurement_failures: int, budget_overages: int) -> None:
+    """Print only the failure classes that actually occurred."""
+    # Keep this wording broad and honest. The per-package lines already carry the
+    # specific reason (bad config, install error, timeout, etc.), while the old
+    # summary incorrectly claimed every failure was a budget overage.
+    if pre_measurement_failures > 0:
+        plural = "package" if pre_measurement_failures == 1 else "packages"
+        print(
+            f"✗ {pre_measurement_failures} {plural} failed before size measurement "
+            f"(see per-package output above)"
+        )
+    if budget_overages > 0:
+        plural = "package" if budget_overages == 1 else "packages"
+        print(f"✗ {budget_overages} {plural} exceeded their install-size budget")
+
+
 def check_packages(
     packages_dir: Path, verbose: bool = False, only: str | None = None
 ) -> tuple[bool, int, int]:
@@ -244,11 +260,11 @@ def check_packages(
             builds a venv each, so local runs want a single target).
 
     Returns:
-        Tuple of (all_pass, resolution_failures, budget_overages).
-        all_pass is True if both resolution_failures and budget_overages are 0.
+        Tuple of (all_pass, pre_measurement_failures, budget_overages).
+        all_pass is True if both pre_measurement_failures and budget_overages are 0.
     """
     all_pass = True
-    resolution_failures = 0
+    pre_measurement_failures = 0
     budget_overages = 0
     packages_dir = packages_dir.resolve()
 
@@ -279,7 +295,7 @@ def check_packages(
         except (ValueError, TypeError) as e:
             print(f"✗ {package_path.name:40} bad max_install_mb in pyproject.toml: {e}")
             all_pass = False
-            resolution_failures += 1
+            pre_measurement_failures += 1
             continue
 
         # Read the canonical distribution name from pyproject.toml [project] name.
@@ -297,7 +313,7 @@ def check_packages(
         if size_mb is None:
             print(f"✗ {package_path.name:40} installation failed")
             all_pass = False
-            resolution_failures += 1
+            pre_measurement_failures += 1
             continue
 
         status = "✓" if size_mb <= budget_mb else "✗"
@@ -310,7 +326,7 @@ def check_packages(
             all_pass = False
             budget_overages += 1
 
-    return all_pass, resolution_failures, budget_overages
+    return all_pass, pre_measurement_failures, budget_overages
 
 
 if __name__ == "__main__":
@@ -331,7 +347,7 @@ if __name__ == "__main__":
     print("Checking package install sizes...")
     print()
 
-    all_pass, resolution_failures, budget_overages = check_packages(
+    all_pass, pre_measurement_failures, budget_overages = check_packages(
         packages_dir, args.verbose, args.package
     )
 
@@ -341,14 +357,5 @@ if __name__ == "__main__":
         sys.exit(0)
     else:
         print()
-        # Report each failure class separately, only if it occurred
-        if resolution_failures > 0:
-            plural = "package" if resolution_failures == 1 else "packages"
-            print(
-                f"✗ {resolution_failures} {plural} failed to resolve dependencies "
-                f"(see per-package output above)"
-            )
-        if budget_overages > 0:
-            plural = "package" if budget_overages == 1 else "packages"
-            print(f"✗ {budget_overages} {plural} exceeded their install-size budget")
+        print_failure_summary(pre_measurement_failures, budget_overages)
         sys.exit(1)

--- a/scripts/check_install_size.py
+++ b/scripts/check_install_size.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from typing import Iterator
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -28,6 +29,69 @@ DEFAULT_BUDGETS = {
     "ml-optional": 2000,  # MB, for packages with optional ML deps
     "other": 500,  # MB, catch-all default
 }
+
+
+class CheckResult:
+    """Result of check_packages.
+
+    Evaluates as ``bool`` for backward-compatible ``if not check_packages(...)``
+    checks (returns ``all_pass``).  Also supports tuple-unpacking as
+    ``(all_pass, pre_measurement_failures, budget_overages)`` so callers that
+    already unpack the tuple continue to work unchanged.
+
+    Prefer attribute access for new code:
+    - ``result.all_pass`` — overall pass/fail
+    - ``result.config_errors`` — packages with invalid budget config
+    - ``result.install_failures`` — packages that failed to install
+    - ``result.budget_overages`` — packages that exceeded their size budget
+    - ``result.pre_measurement_failures`` — config_errors + install_failures (combined)
+    """
+
+    def __init__(
+        self,
+        all_pass: bool,
+        config_errors: int,
+        install_failures: int,
+        budget_overages: int,
+    ) -> None:
+        self.all_pass = all_pass
+        self.config_errors = config_errors
+        self.install_failures = install_failures
+        self.budget_overages = budget_overages
+
+    @property
+    def pre_measurement_failures(self) -> int:
+        return self.config_errors + self.install_failures
+
+    def __bool__(self) -> bool:
+        return self.all_pass
+
+    def __iter__(self) -> Iterator:
+        """Yield (all_pass, pre_measurement_failures, budget_overages) for tuple unpacking."""
+        yield self.all_pass
+        yield self.pre_measurement_failures
+        yield self.budget_overages
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, tuple):
+            return tuple(self) == other
+        if isinstance(other, CheckResult):
+            return (
+                self.all_pass == other.all_pass
+                and self.config_errors == other.config_errors
+                and self.install_failures == other.install_failures
+                and self.budget_overages == other.budget_overages
+            )
+        return NotImplemented
+
+    def __repr__(self) -> str:
+        return (
+            f"CheckResult(all_pass={self.all_pass!r}, "
+            f"config_errors={self.config_errors!r}, "
+            f"install_failures={self.install_failures!r}, "
+            f"budget_overages={self.budget_overages!r})"
+        )
+
 
 # Keywords in dependency lists that indicate an ML package (ml-optional budget)
 _ML_DEP_KEYWORDS = ("torch", "tensorflow", "jax", "onnx", "transformers")
@@ -230,25 +294,35 @@ def measure_install_size(package_path: Path, package_name: str) -> float | None:
             return None
 
 
-def print_failure_summary(pre_measurement_failures: int, budget_overages: int) -> None:
-    """Print only the failure classes that actually occurred."""
-    # Keep this wording broad and honest. The per-package lines already carry the
-    # specific reason (bad config, install error, timeout, etc.), while the old
-    # summary incorrectly claimed every failure was a budget overage.
-    if pre_measurement_failures > 0:
-        plural = "package" if pre_measurement_failures == 1 else "packages"
+def print_failure_summary(result: CheckResult) -> None:
+    """Print only the failure classes that actually occurred.
+
+    Uses precise labels for each class so the summary directs developers to the
+    right place:
+    - config errors → check pyproject.toml
+    - install failures → check the install command / environment
+    - budget overages → trim dependencies or raise the budget
+    """
+    if result.config_errors > 0:
+        plural = "package" if result.config_errors == 1 else "packages"
         print(
-            f"✗ {pre_measurement_failures} {plural} failed before size measurement "
+            f"✗ {result.config_errors} {plural} had invalid budget configuration in pyproject.toml "
             f"(see per-package output above)"
         )
-    if budget_overages > 0:
-        plural = "package" if budget_overages == 1 else "packages"
-        print(f"✗ {budget_overages} {plural} exceeded their install-size budget")
+    if result.install_failures > 0:
+        plural = "package" if result.install_failures == 1 else "packages"
+        print(
+            f"✗ {result.install_failures} {plural} failed to install "
+            f"(see per-package output above)"
+        )
+    if result.budget_overages > 0:
+        plural = "package" if result.budget_overages == 1 else "packages"
+        print(f"✗ {result.budget_overages} {plural} exceeded their install-size budget")
 
 
 def check_packages(
     packages_dir: Path, verbose: bool = False, only: str | None = None
-) -> tuple[bool, int, int]:
+) -> CheckResult:
     """Check all packages in packages/ directory.
 
     Args:
@@ -256,11 +330,12 @@ def check_packages(
             builds a venv each, so local runs want a single target).
 
     Returns:
-        Tuple of (all_pass, pre_measurement_failures, budget_overages).
-        all_pass is True if both pre_measurement_failures and budget_overages are 0.
+        :class:`CheckResult` with counts for each failure class.
+        Evaluates as ``bool`` for backward-compatible ``if not check_packages(...)`` use.
     """
     all_pass = True
-    pre_measurement_failures = 0
+    config_errors = 0
+    install_failures = 0
     budget_overages = 0
     packages_dir = packages_dir.resolve()
 
@@ -271,7 +346,7 @@ def check_packages(
         package_paths = [p for p in package_paths if p.name == only]
         if not package_paths:
             print(f"❌ No package named {only!r} in {packages_dir}")
-            return False, 0, 0
+            return CheckResult(False, 0, 0, 0)
 
     for package_path in package_paths:
         # Skip symlinks (they point to gptme-contrib submodule)
@@ -291,7 +366,7 @@ def check_packages(
         except (ValueError, TypeError) as e:
             print(f"✗ {package_path.name:40} bad max_install_mb in pyproject.toml: {e}")
             all_pass = False
-            pre_measurement_failures += 1
+            config_errors += 1
             continue
 
         # Read the canonical distribution name from pyproject.toml [project] name.
@@ -309,7 +384,7 @@ def check_packages(
         if size_mb is None:
             print(f"✗ {package_path.name:40} installation failed")
             all_pass = False
-            pre_measurement_failures += 1
+            install_failures += 1
             continue
 
         status = "✓" if size_mb <= budget_mb else "✗"
@@ -322,7 +397,7 @@ def check_packages(
             all_pass = False
             budget_overages += 1
 
-    return all_pass, pre_measurement_failures, budget_overages
+    return CheckResult(all_pass, config_errors, install_failures, budget_overages)
 
 
 if __name__ == "__main__":
@@ -343,15 +418,13 @@ if __name__ == "__main__":
     print("Checking package install sizes...")
     print()
 
-    all_pass, pre_measurement_failures, budget_overages = check_packages(
-        packages_dir, args.verbose, args.package
-    )
+    result = check_packages(packages_dir, args.verbose, args.package)
 
-    if all_pass:
+    if result:
         print()
         print("✓ All packages within budget")
         sys.exit(0)
     else:
         print()
-        print_failure_summary(pre_measurement_failures, budget_overages)
+        print_failure_summary(result)
         sys.exit(1)

--- a/scripts/check_install_size.py
+++ b/scripts/check_install_size.py
@@ -54,6 +54,13 @@ class CheckResult:
         install_failures: int,
         budget_overages: int,
     ) -> None:
+        for _name, _val in (
+            ("config_errors", config_errors),
+            ("install_failures", install_failures),
+            ("budget_overages", budget_overages),
+        ):
+            if _val < 0:
+                raise ValueError(f"{_name} must be non-negative, got {_val!r}")
         self.all_pass = all_pass
         self.config_errors = config_errors
         self.install_failures = install_failures
@@ -314,7 +321,18 @@ def print_failure_summary(result: CheckResult) -> None:
     - config errors → check pyproject.toml
     - install failures → check the install command / environment
     - budget overages → trim dependencies or raise the budget
+
+    When all counts are zero (e.g. the ``--package`` filter matched nothing),
+    the per-package error was already printed by :func:`check_packages`; emit a
+    brief final line so the failure is never silent.
     """
+    if (
+        result.config_errors == 0
+        and result.install_failures == 0
+        and result.budget_overages == 0
+    ):
+        print("✗ No packages were checked (see output above for details)")
+        return
     if result.config_errors > 0:
         plural = "package" if result.config_errors == 1 else "packages"
         print(

--- a/tests/test_check_install_size.py
+++ b/tests/test_check_install_size.py
@@ -240,7 +240,7 @@ def test_measure_install_size_timeout():
 
 
 def test_check_packages_pass_and_fail():
-    """check_packages returns True for passing packages and False when over budget."""
+    """check_packages reports budget overages separately from clean passes."""
     import check_install_size
 
     # Stub measure_install_size to return fixed sizes
@@ -270,12 +270,12 @@ def test_check_packages_pass_and_fail():
                 packages_dir, verbose=False, only="failing"
             )
 
-    assert result_pass is True
-    assert result_fail is False
+    assert result_pass == (True, 0, 0)
+    assert result_fail == (False, 0, 1)
 
 
 def test_check_packages_none_size_fails():
-    """check_packages returns False when measure_install_size returns None."""
+    """check_packages counts install failures before size measurement."""
     import check_install_size
 
     def fake_measure(package_path, package_name):
@@ -296,7 +296,7 @@ def test_check_packages_none_size_fails():
                 packages_dir, verbose=False, only="broken"
             )
 
-    assert result is False
+    assert result == (False, 1, 0)
 
 
 def test_check_packages_skips_symlinks():
@@ -330,7 +330,7 @@ def test_check_packages_skips_symlinks():
         ):
             result = check_install_size.check_packages(packages_dir, verbose=True)
 
-    assert result is True
+    assert result == (True, 0, 0)
     assert call_count["n"] == 1, "symlinked package should not be measured"
 
 
@@ -366,8 +366,9 @@ def test_check_packages_bad_budget_does_not_crash():
         ):
             result = check_install_size.check_packages(packages_dir, verbose=False)
 
-    # Script must not crash; result is False (one package failed) but good_pkg was measured
-    assert result is False
+    # Script must not crash; one package failed before size measurement and good_pkg
+    # was still measured.
+    assert result == (False, 1, 0)
     assert call_count["n"] == 1, "good package should still be measured"
 
 
@@ -401,5 +402,27 @@ def test_check_packages_skips_no_pyproject():
         ):
             result = check_install_size.check_packages(packages_dir, verbose=True)
 
-    assert result is True
+    assert result == (True, 0, 0)
     assert call_count["n"] == 1, "package without pyproject.toml should not be measured"
+
+
+def test_print_failure_summary_lists_only_present_classes(capsys):
+    """Failure summary should name pre-measurement failures and budget overages separately."""
+    import check_install_size
+
+    check_install_size.print_failure_summary(2, 1)
+
+    out = capsys.readouterr().out
+    assert "2 packages failed before size measurement" in out
+    assert "1 package exceeded their install-size budget" in out
+
+
+def test_print_failure_summary_omits_zero_count_classes(capsys):
+    """Zero-count failure classes should not print a misleading summary line."""
+    import check_install_size
+
+    check_install_size.print_failure_summary(0, 1)
+
+    out = capsys.readouterr().out
+    assert "failed before size measurement" not in out
+    assert "1 package exceeded their install-size budget" in out

--- a/tests/test_check_install_size.py
+++ b/tests/test_check_install_size.py
@@ -478,3 +478,72 @@ def test_check_result_tuple_unpacking_backward_compat():
     assert all_pass is False
     assert pre_measurement_failures == 3  # config_errors + install_failures
     assert budget_overages == 3
+
+
+def test_check_packages_mixed_failures(capsys):
+    """check_packages counts config errors and install failures independently.
+
+    A malformed budget config must not spill into install_failures and vice versa.
+    Both counters must accumulate separately so print_failure_summary can direct
+    developers to the right place (pyproject.toml vs the install command).
+    """
+    import check_install_size
+
+    def fake_measure(package_path, package_name):
+        # Only called for the package with a valid budget; simulates install failure
+        return None
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        packages_dir = Path(tmpdir) / "packages"
+
+        # Package with malformed max_install_mb → config_errors += 1
+        bad_budget = packages_dir / "bad_budget"
+        bad_budget.mkdir(parents=True)
+        (bad_budget / "pyproject.toml").write_text(
+            '[tool.gptme-contrib]\nmax_install_mb = "not-a-number"\n'
+        )
+
+        # Package with valid budget but install returns None → install_failures += 1
+        broken_install = packages_dir / "broken_install"
+        broken_install.mkdir(parents=True)
+        (broken_install / "pyproject.toml").write_text(
+            "[tool.gptme-contrib]\nmax_install_mb = 100\n"
+        )
+
+        with patch.object(
+            check_install_size, "measure_install_size", side_effect=fake_measure
+        ):
+            result = check_install_size.check_packages(packages_dir, verbose=False)
+
+    # Both failure classes must be counted independently
+    assert result.all_pass is False
+    assert result.config_errors == 1
+    assert result.install_failures == 1
+    assert result.budget_overages == 0
+    assert result.pre_measurement_failures == 2  # config_errors + install_failures
+    assert result == (
+        False,
+        2,
+        0,
+    )  # tuple: (all_pass, pre_measurement_failures, budget_overages)
+
+    # print_failure_summary must emit a distinct line for each class
+    check_install_size.print_failure_summary(result)
+    out = capsys.readouterr().out
+    assert "invalid budget configuration" in out
+    assert "failed to install" in out
+
+
+def test_check_result_is_hashable():
+    """CheckResult defines __hash__ so instances can be used in sets and as dict keys."""
+    import check_install_size
+
+    r1 = check_install_size.CheckResult(True, 0, 0, 0)
+    r2 = check_install_size.CheckResult(False, 1, 0, 0)
+    r3 = check_install_size.CheckResult(True, 0, 0, 0)
+
+    # Must not raise TypeError
+    result_set = {r1, r2}
+    assert r3 in result_set  # r3 equals r1 → same hash, same set membership
+    assert r2 not in {r1}
+    assert isinstance(hash(r1), int)

--- a/tests/test_check_install_size.py
+++ b/tests/test_check_install_size.py
@@ -143,7 +143,7 @@ def test_measure_install_size_success():
             package_path.mkdir()
             size = check_install_size.measure_install_size(package_path, "mypkg")
 
-    assert size is not None
+    assert isinstance(size, float), f"expected float, got {size!r}"
     assert 9.0 < size < 11.0  # ~10 MB
     export_cmd = next(cmd for cmd in seen_commands if "export" in cmd)
     install_cmd = next(cmd for cmd in seen_commands if "install" in cmd)
@@ -190,7 +190,7 @@ def test_measure_install_size_export_fallback():
             package_path.mkdir()
             size = check_install_size.measure_install_size(package_path, "mypkg")
 
-    assert size is not None
+    assert isinstance(size, float), f"expected float, got {size!r}"
     assert 4.0 < size < 6.0  # ~5 MB
     install_cmd = next(cmd for cmd in seen_commands if "install" in cmd)
     assert "--index-strategy" in install_cmd
@@ -560,6 +560,102 @@ def test_check_result_rejects_negative_counts():
         check_install_size.CheckResult(False, 0, -1, 0)
     with pytest.raises(ValueError, match="budget_overages"):
         check_install_size.CheckResult(False, 0, 0, -1)
+    with pytest.raises(ValueError, match="resolution_failures"):
+        check_install_size.CheckResult(False, 0, 0, 0, resolution_failures=-1)
+
+
+def test_is_resolution_failure_detects_uv_error():
+    """_is_resolution_failure should recognise uv's 'no solution found' output."""
+    import check_install_size
+
+    assert check_install_size._is_resolution_failure(
+        "error: No solution found when resolving dependencies:\n  Because pkg>=1.0 requires ..."
+    )
+    assert check_install_size._is_resolution_failure(
+        "× No solution found when resolving\n  | Because ..."
+    )
+    # Generic install errors that are NOT resolution failures
+    assert not check_install_size._is_resolution_failure("ERROR: package not found")
+    assert not check_install_size._is_resolution_failure("timeout")
+    assert not check_install_size._is_resolution_failure("")
+
+
+def test_measure_install_size_resolution_failure():
+    """measure_install_size returns 'resolution_failure' when uv cannot resolve deps."""
+    import check_install_size
+
+    def fake_run(cmd, **kwargs):
+        result = MagicMock()
+        if "venv" in cmd:
+            result.returncode = 0
+            venv_path = Path(cmd[-1])
+            venv_path.mkdir(parents=True)
+            (venv_path / "bin").mkdir()
+            (venv_path / "bin" / "python").touch()
+        else:
+            result.returncode = 1
+            result.stderr = (
+                "error: No solution found when resolving dependencies:\n"
+                "  Because pkg>=2.0 is not available and ..."
+            )
+        return result
+
+    with patch.object(subprocess, "run", side_effect=fake_run):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            package_path = Path(tmpdir) / "mypkg"
+            package_path.mkdir()
+            size = check_install_size.measure_install_size(package_path, "mypkg")
+
+    assert size == "resolution_failure"
+
+
+def test_check_packages_resolution_failure_counted_separately():
+    """check_packages counts resolution failures in resolution_failures, not install_failures."""
+    import check_install_size
+
+    def fake_measure(package_path, package_name):
+        return "resolution_failure"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        packages_dir = Path(tmpdir) / "packages"
+        pkg_dir = packages_dir / "broken_resolve"
+        pkg_dir.mkdir(parents=True)
+        (pkg_dir / "pyproject.toml").write_text(
+            "[tool.gptme-contrib]\nmax_install_mb = 100\n"
+        )
+
+        with patch.object(
+            check_install_size, "measure_install_size", side_effect=fake_measure
+        ):
+            result = check_install_size.check_packages(
+                packages_dir, verbose=False, only="broken_resolve"
+            )
+
+    assert result.all_pass is False
+    assert result.resolution_failures == 1
+    assert result.install_failures == 0
+    assert result.budget_overages == 0
+    # tuple backward compat: pre_measurement_failures includes resolution_failures
+    assert result == (False, 1, 0)
+
+
+def test_print_failure_summary_resolution_failure(capsys):
+    """Resolution failures print 'failed to resolve dependencies', not 'failed to install'."""
+    import check_install_size
+
+    result = check_install_size.CheckResult(
+        all_pass=False,
+        config_errors=0,
+        install_failures=0,
+        budget_overages=0,
+        resolution_failures=2,
+    )
+    check_install_size.print_failure_summary(result)
+
+    out = capsys.readouterr().out
+    assert "2 packages failed to resolve dependencies" in out
+    assert "failed to install" not in out
+    assert "exceeded their install-size budget" not in out
 
 
 def test_print_failure_summary_no_match_fallback(capsys):

--- a/tests/test_check_install_size.py
+++ b/tests/test_check_install_size.py
@@ -547,3 +547,35 @@ def test_check_result_is_hashable():
     assert r3 in result_set  # r3 equals r1 → same hash, same set membership
     assert r2 not in {r1}
     assert isinstance(hash(r1), int)
+
+
+def test_check_result_rejects_negative_counts():
+    """CheckResult.__init__ raises ValueError for negative counter arguments."""
+    import check_install_size
+    import pytest
+
+    with pytest.raises(ValueError, match="config_errors"):
+        check_install_size.CheckResult(False, -1, 0, 0)
+    with pytest.raises(ValueError, match="install_failures"):
+        check_install_size.CheckResult(False, 0, -1, 0)
+    with pytest.raises(ValueError, match="budget_overages"):
+        check_install_size.CheckResult(False, 0, 0, -1)
+
+
+def test_print_failure_summary_no_match_fallback(capsys):
+    """When all counts are zero (no-match filter), print_failure_summary emits a brief line."""
+    import check_install_size
+
+    # This is the CheckResult returned when --package filter matches nothing
+    result = check_install_size.CheckResult(
+        all_pass=False, config_errors=0, install_failures=0, budget_overages=0
+    )
+    check_install_size.print_failure_summary(result)
+
+    out = capsys.readouterr().out
+    # Must not be silent — emit at least one line so the CI failure is explained
+    assert out.strip()
+    # Must not claim a specific failure class that didn't occur
+    assert "invalid budget configuration" not in out
+    assert "failed to install" not in out
+    assert "exceeded" not in out

--- a/tests/test_check_install_size.py
+++ b/tests/test_check_install_size.py
@@ -407,13 +407,17 @@ def test_check_packages_skips_no_pyproject():
 
 
 def test_print_failure_summary_lists_only_present_classes(capsys):
-    """Failure summary should name pre-measurement failures and budget overages separately."""
+    """Failure summary should name config errors, install failures, and budget overages separately."""
     import check_install_size
 
-    check_install_size.print_failure_summary(2, 1)
+    result = check_install_size.CheckResult(
+        all_pass=False, config_errors=2, install_failures=1, budget_overages=1
+    )
+    check_install_size.print_failure_summary(result)
 
     out = capsys.readouterr().out
-    assert "2 packages failed before size measurement" in out
+    assert "2 packages had invalid budget configuration" in out
+    assert "1 package failed to install" in out
     assert "1 package exceeded their install-size budget" in out
 
 
@@ -421,8 +425,56 @@ def test_print_failure_summary_omits_zero_count_classes(capsys):
     """Zero-count failure classes should not print a misleading summary line."""
     import check_install_size
 
-    check_install_size.print_failure_summary(0, 1)
+    result = check_install_size.CheckResult(
+        all_pass=False, config_errors=0, install_failures=0, budget_overages=1
+    )
+    check_install_size.print_failure_summary(result)
 
     out = capsys.readouterr().out
-    assert "failed before size measurement" not in out
+    assert "invalid budget configuration" not in out
+    assert "failed to install" not in out
     assert "1 package exceeded their install-size budget" in out
+
+
+def test_check_result_bool_semantics():
+    """CheckResult.__bool__ returns all_pass so 'if not result' works for failed checks."""
+    import check_install_size
+
+    passing = check_install_size.CheckResult(True, 0, 0, 0)
+    failing = check_install_size.CheckResult(False, 1, 0, 0)
+
+    assert bool(passing) is True
+    assert bool(failing) is False
+    # Crucially: a failing tuple is always truthy; CheckResult is not
+    assert not failing
+
+
+def test_check_result_distinguishes_config_errors_from_install_failures(capsys):
+    """Config errors and install failures should produce distinct summary lines."""
+    import check_install_size
+
+    result = check_install_size.CheckResult(
+        all_pass=False, config_errors=1, install_failures=2, budget_overages=0
+    )
+    check_install_size.print_failure_summary(result)
+
+    out = capsys.readouterr().out
+    # Config error → directs to pyproject.toml, not install command
+    assert "invalid budget configuration" in out
+    # Install failure → directs to install command
+    assert "2 packages failed to install" in out
+    # No budget overage line
+    assert "exceeded their install-size budget" not in out
+
+
+def test_check_result_tuple_unpacking_backward_compat():
+    """Tuple-unpacking as (all_pass, pre_measurement_failures, budget_overages) still works."""
+    import check_install_size
+
+    result = check_install_size.CheckResult(
+        all_pass=False, config_errors=1, install_failures=2, budget_overages=3
+    )
+    all_pass, pre_measurement_failures, budget_overages = result
+    assert all_pass is False
+    assert pre_measurement_failures == 3  # config_errors + install_failures
+    assert budget_overages == 3


### PR DESCRIPTION
The install-size gate was reporting 'One or more packages exceeded budget' for *any* failure (resolution, malformed commands, or actual size overages). This masks the real issue.

Track and report each failure class separately:
- 'X package(s) failed to resolve dependencies' for resolution errors
- 'X package(s) exceeded their install-size budget' for actual overages

Only print the lines that apply, preventing misleading diagnosis where 'exceeded budget' suggests trimming dependencies when the issue is a broken index configuration.

Fixes the mislabeling in #1418 and complements #1426 which fixes the duplicate flag.