### PR TITLE
fix(ci): drop duplicated --index-strategy flag breaking install-size

### DIFF
--- a/scripts/check_install_size.py
+++ b/scripts/check_install_size.py
@@ -163,8 +163,6 @@ def measure_install_size(package_path: Path, package_name: str) -> float | None:
                     "--index-strategy",
                     "unsafe-best-match",
                     "--quiet",
-                    "--index-strategy",
-                    "unsafe-best-match",
                     "-r",
                     str(req_file),
                     str(package_path),
@@ -189,8 +187,6 @@ def measure_install_size(package_path: Path, package_name: str) -> float | None:
                     "--index-strategy",
                     "unsafe-best-match",
                     "--quiet",
-                    "--index-strategy",
-                    "unsafe-best-match",
                     str(package_path),
                 ]
 


### PR DESCRIPTION
## Problem

`install-size` is failing on **every** open gptme-contrib PR:

```
❌ Installation failed for gptodo
error: the argument '--index-strategy <INDEX_STRATEGY>' cannot be used multiple times
✗ One or more packages exceeded budget
```

Two independent changes each appended `--index-strategy unsafe-best-match` to the
same two `uv pip install` command lists in `scripts/check_install_size.py`, so uv
received the flag twice and refused to run.

The failure message is actively misleading: **nothing was ever measured**, yet the
job reports "exceeded budget".

## Fix

Remove the duplicate flag pair from both the lock-export path and the PyPI
fallback path. 4 deleted lines, no behaviour change.

## Verification

```
$ uv run python3 scripts/check_install_size.py --package gptodo
✓ gptodo    9.1MB /   500MB (  1.8%)
✓ All packages within budget
```
(before: `installation failed`)

Found while rebasing #1419, whose install-size check failed for this unrelated reason.