### PR TITLE
feat(sessions): add summary field to SearchResult and search output

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -2987,7 +2987,10 @@ def search(
         harness_label = f"[{r.harness}]"
         click.echo(f"  {r.display_date}  {harness_label}  {r.session_id}  ({r.hit_count} hit(s))")
         if r.summary and not no_snippets:
-            click.echo(f"    {r.summary}")
+            # Strip terminal control characters to prevent ANSI injection from
+            # untrusted session file content (e.g. crafted escape sequences).
+            safe_summary = re.sub(r"[\x00-\x1f\x7f]", "", r.summary)
+            click.echo(f"    {safe_summary}")
         if not no_snippets:
             for s in r.snippets:
                 role_label = s.role.upper()[:4]

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -2986,9 +2986,11 @@ def search(
     for r in results:
         harness_label = f"[{r.harness}]"
         click.echo(f"  {r.display_date}  {harness_label}  {r.session_id}  ({r.hit_count} hit(s))")
-        if r.summary and not no_snippets:
+        if r.summary:
             # Strip terminal control characters to prevent ANSI injection from
             # untrusted session file content (e.g. crafted escape sequences).
+            # Summary is shown regardless of --no-snippets; it is a concise
+            # session description, not a text excerpt around the search match.
             safe_summary = re.sub(r"[\x00-\x1f\x7f]", "", r.summary)
             click.echo(f"    {safe_summary}")
         if not no_snippets:

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -2968,6 +2968,7 @@ def search(
                         "path": r.path,
                         "hit_count": r.hit_count,
                         "started_at": r.started_at.isoformat() if r.started_at else None,
+                        "summary": r.summary,
                         "snippets": [dataclasses.asdict(s) for s in r.snippets],
                     }
                     for r in results
@@ -2985,6 +2986,8 @@ def search(
     for r in results:
         harness_label = f"[{r.harness}]"
         click.echo(f"  {r.display_date}  {harness_label}  {r.session_id}  ({r.hit_count} hit(s))")
+        if r.summary and not no_snippets:
+            click.echo(f"    {r.summary}")
         if not no_snippets:
             for s in r.snippets:
                 role_label = s.role.upper()[:4]

--- a/packages/gptme-sessions/src/gptme_sessions/search.py
+++ b/packages/gptme-sessions/src/gptme_sessions/search.py
@@ -105,8 +105,13 @@ def _extract_summary(messages: list) -> str | None:
             content = (msg.content or "").strip()
             if len(content) < SUMMARY_MIN_LEN:
                 continue
-            # Take first non-empty line
-            first_line = next((ln.strip() for ln in content.splitlines() if ln.strip()), content)
+            # Take the first non-empty line that is itself substantial enough to
+            # be a meaningful summary.  A short opener like "Hi" followed by a
+            # long body would otherwise produce a useless one-word summary.
+            lines = [ln.strip() for ln in content.splitlines() if ln.strip()]
+            first_line = next((ln for ln in lines if len(ln) >= SUMMARY_MIN_LEN), None)
+            if first_line is None:
+                continue
             if len(first_line) > SUMMARY_MAX_LEN:
                 return first_line[:SUMMARY_MAX_LEN] + "…"
             return first_line

--- a/packages/gptme-sessions/src/gptme_sessions/search.py
+++ b/packages/gptme-sessions/src/gptme_sessions/search.py
@@ -26,6 +26,8 @@ logger = logging.getLogger(__name__)
 
 SNIPPET_CONTEXT = 120  # chars of surrounding text to include around each match
 MAX_SNIPPETS_PER_SESSION = 3
+SUMMARY_MAX_LEN = 120  # chars for the session summary line
+SUMMARY_MIN_LEN = 20  # min chars to treat a message as a useful summary
 
 
 @dataclass
@@ -46,6 +48,7 @@ class SearchResult:
     hit_count: int
     started_at: datetime | None
     snippets: list[Snippet] = field(default_factory=list)
+    summary: str | None = None  # first substantial user/assistant message
 
     @property
     def display_date(self) -> str:
@@ -86,6 +89,28 @@ def _message_mentions_file(msg, file_pattern: re.Pattern) -> bool:
         (msg.content and file_pattern.search(msg.content))
         or (msg.tool_input and _value_mentions_file(msg.tool_input, file_pattern))
     )
+
+
+def _extract_summary(messages: list) -> str | None:
+    """Extract a short summary from the first substantial user or assistant message.
+
+    Skips system messages and very short messages (e.g. role markers). Returns
+    the first line of the first qualifying message, truncated to SUMMARY_MAX_LEN.
+    Prefers user messages since they typically state the task intent.
+    """
+    for role in ("user", "assistant"):
+        for msg in messages:
+            if msg.role != role:
+                continue
+            content = (msg.content or "").strip()
+            if len(content) < SUMMARY_MIN_LEN:
+                continue
+            # Take first non-empty line
+            first_line = next((ln.strip() for ln in content.splitlines() if ln.strip()), content)
+            if len(first_line) > SUMMARY_MAX_LEN:
+                return first_line[:SUMMARY_MAX_LEN] + "…"
+            return first_line
+    return None
 
 
 def _search_path(
@@ -130,6 +155,8 @@ def _search_path(
         except (ValueError, AttributeError):
             pass
 
+    summary = _extract_summary(transcript.messages)
+
     return SearchResult(
         session_id=transcript.session_id,
         harness=transcript.harness,
@@ -137,6 +164,7 @@ def _search_path(
         hit_count=total_hits,
         started_at=started_at,
         snippets=snippets,
+        summary=summary,
     )
 
 

--- a/packages/gptme-sessions/tests/test_search.py
+++ b/packages/gptme-sessions/tests/test_search.py
@@ -153,6 +153,20 @@ class TestExtractSummary:
         result = _extract_summary(msgs)
         assert result == "First meaningful line here with enough chars"
 
+    def test_skips_short_first_line_falls_back_to_substantial_line(self):
+        # "Hi" is shorter than SUMMARY_MIN_LEN; the summary should come from the
+        # next substantial line rather than returning the terse opener.
+        long_body = "Implement the session search feature with full-text indexing"
+        msgs = [self._msg("user", f"Hi\n{long_body}")]
+        result = _extract_summary(msgs)
+        assert result is not None
+        assert result == long_body
+
+    def test_returns_none_when_all_lines_too_short(self):
+        # Total content >= SUMMARY_MIN_LEN but every individual line is short.
+        msgs = [self._msg("user", "ok\nyes\nno\nhi\nok")]
+        assert _extract_summary(msgs) is None
+
     def test_prefers_user_over_assistant(self):
         msgs = [
             self._msg("assistant", "Here is a detailed assistant response that is long"),
@@ -466,6 +480,24 @@ class TestSearchCLI:
         assert len(data) == 1
         assert data[0]["hit_count"] == 1
         assert "snippets" in data[0]
+        assert "summary" in data[0]
+
+    def test_search_shows_summary_in_text_output(self, tmp_path: Path):
+        """Summary line should appear in text output when the session has one."""
+        session = _gptme_session(
+            tmp_path,
+            [("user", "Fix the broken auth middleware so tokens are validated correctly")],
+        )
+        runner = CliRunner()
+        with (
+            patch("gptme_sessions.search.discover_gptme_sessions", return_value=[session]),
+            patch("gptme_sessions.search.discover_cc_sessions", return_value=[]),
+            patch("gptme_sessions.search.discover_codex_sessions", return_value=[]),
+            patch("gptme_sessions.search.discover_copilot_sessions", return_value=[]),
+        ):
+            result = runner.invoke(cli, ["search", "auth"])
+        assert result.exit_code == 0
+        assert "Fix the broken auth middleware" in result.output
 
     def test_search_no_snippets_flag(self, tmp_path: Path):
         session = _gptme_session(tmp_path, [("assistant", "target found here")])

--- a/packages/gptme-sessions/tests/test_search.py
+++ b/packages/gptme-sessions/tests/test_search.py
@@ -11,7 +11,9 @@ from click.testing import CliRunner
 
 from gptme_sessions.cli import cli
 from gptme_sessions.search import (
+    SUMMARY_MAX_LEN,
     SearchResult,
+    _extract_summary,
     _make_snippet,
     _search_path,
     search_sessions,
@@ -104,6 +106,77 @@ class TestSearchResult:
     def test_display_date_without_timestamp(self):
         r = SearchResult(session_id="abc", harness="gptme", path="/x", hit_count=1, started_at=None)
         assert r.display_date == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _extract_summary
+# ---------------------------------------------------------------------------
+
+
+class TestExtractSummary:
+    def _msg(self, role: str, content: str) -> NormalizedMessage:
+        return NormalizedMessage(role=role, content=content)
+
+    def test_returns_first_user_message(self):
+        msgs = [self._msg("user", "Fix the broken auth middleware in gptme")]
+        assert _extract_summary(msgs) == "Fix the broken auth middleware in gptme"
+
+    def test_skips_messages_shorter_than_min_len(self):
+        msgs = [
+            self._msg("user", "ok"),  # too short
+            self._msg("assistant", "Here is a detailed response that is long enough"),
+        ]
+        result = _extract_summary(msgs)
+        assert result is not None
+        assert "Here is a detailed response" in result
+
+    def test_truncates_long_first_line(self):
+        long_line = "X" * (SUMMARY_MAX_LEN + 50)
+        msgs = [self._msg("user", long_line)]
+        result = _extract_summary(msgs)
+        assert result is not None
+        assert len(result) <= SUMMARY_MAX_LEN + 1  # +1 for the ellipsis char
+        assert result.endswith("…")
+
+    def test_returns_none_for_empty_messages(self):
+        assert _extract_summary([]) is None
+
+    def test_returns_none_when_all_too_short(self):
+        msgs = [
+            self._msg("user", "hi"),
+            self._msg("assistant", "ok"),
+        ]
+        assert _extract_summary(msgs) is None
+
+    def test_uses_first_line_of_multiline(self):
+        msgs = [self._msg("user", "First meaningful line here with enough chars\nSecond line")]
+        result = _extract_summary(msgs)
+        assert result == "First meaningful line here with enough chars"
+
+    def test_prefers_user_over_assistant(self):
+        msgs = [
+            self._msg("assistant", "Here is a detailed assistant response that is long"),
+            self._msg("user", "Fix the auth middleware so it validates tokens correctly"),
+        ]
+        # user is checked first regardless of message order
+        result = _extract_summary(msgs)
+        assert result is not None
+        assert "Fix the auth" in result
+
+    def test_search_result_summary_populated(self, tmp_path: Path):
+        import re
+
+        session = _gptme_session(
+            tmp_path,
+            [
+                ("user", "Implement session search with full-text indexing"),
+                ("assistant", "I will implement that now."),
+                ("user", "target keyword appears here"),
+            ],
+        )
+        result = _search_path(session, re.compile("target keyword"))
+        assert result is not None
+        assert result.summary == "Implement session search with full-text indexing"
 
 
 # ---------------------------------------------------------------------------

--- a/packages/gptme-sessions/tests/test_search.py
+++ b/packages/gptme-sessions/tests/test_search.py
@@ -512,6 +512,27 @@ class TestSearchCLI:
         assert result.exit_code == 0
         assert "target found here" not in result.output
 
+    def test_search_no_snippets_still_shows_summary(self, tmp_path: Path):
+        """Summary is a session description, not a snippet; --no-snippets must not hide it."""
+        user_msg = "Please fix the broken authentication middleware in the login flow."
+        session = _gptme_session(
+            tmp_path,
+            [("user", user_msg), ("assistant", "target match is here in the response")],
+        )
+        runner = CliRunner()
+        with (
+            patch("gptme_sessions.search.discover_gptme_sessions", return_value=[session]),
+            patch("gptme_sessions.search.discover_cc_sessions", return_value=[]),
+            patch("gptme_sessions.search.discover_codex_sessions", return_value=[]),
+            patch("gptme_sessions.search.discover_copilot_sessions", return_value=[]),
+        ):
+            result = runner.invoke(cli, ["search", "target", "--no-snippets"])
+        assert result.exit_code == 0
+        # The snippet text must be hidden
+        assert "target match is here in the response" not in result.output
+        # But the summary (first user message) must still appear
+        assert "Please fix the broken authentication middleware" in result.output
+
     def test_search_harness_choice(self, tmp_path: Path):
         runner = CliRunner()
         with (


### PR DESCRIPTION
## Summary

Add a `summary` field to `SearchResult` that extracts the first substantial user message from the session transcript. Display it in both formatted text output and JSON.

## Problem

The `gptme-sessions search` command (already shipping) was missing a `summary`/first-line field from its output. Per the acceptance criteria for the gptme session archive search task, results should show at least: `date`, `category`, `session_id`, and `summary`.

## Changes

- **search.py**: Add `_extract_summary()` helper + `SUMMARY_MAX_LEN`/`SUMMARY_MIN_LEN` constants; add `summary: str | None` field to `SearchResult` dataclass
- **cli.py**: Display `summary` in formatted text output (below session header line) and in JSON output
- **test_search.py**: 8 new unit tests covering: short message skip, truncation, multiline first-line extraction, fallback to assistant, empty message handling, and end-to-end path

## Validation

- `ruff check` clean
- 46 tests passed (`uv run pytest packages/gptme-sessions/tests/test_search.py`)

## Example output before vs after

Before:
```
  2026-08-14 00:55  [claude-code]  2d437c73  (6 hit(s))
    [TOOL] …gptme-read-only-audit-mode…
```

After:
```
  2026-08-14 00:55  [claude-code]  2d437c73  (6 hit(s))
    Good — I've identified the bug. Let me look at the existing tests…
    [TOOL] …gptme-read-only-audit-mode…
```