### PR TITLE
feat(self-merge): add skills/ as an allowed self-merge category

### DIFF
--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -10,8 +10,8 @@ Policy summary:
   unresolved threads, OR a high-confidence review from the agent's own
   self-hosted AI reviewer (see "Accepting our own review" below)
 - PR must be authored by the authenticated user
-- Changed files must fall into a low-risk category (tests, docs, lessons, internal
-  tooling, task metadata)
+- Changed files must fall into a low-risk category (tests, docs, lessons, skills,
+  internal tooling, task metadata)
 - Sensitive/security/infra paths immediately disqualify the PR
 
 The workspace repo (the repo where the agent's brain lives) is detected automatically.
@@ -281,6 +281,14 @@ TASK_METADATA_PREFIXES = (
     "journal/",
 )
 LESSON_PREFIXES = ("lessons/",)
+# Skills are, by this repo's own definition, "enhanced lessons that bundle
+# workflows, scripts, and utilities" (skills/README.md). The prose half
+# (SKILL.md) was already self-mergeable via is_doc_file, so restricting this
+# category to markdown would change no verdict at all — the only files it can
+# newly admit are a skill's bundled helpers. Those carry the same risk profile
+# as packages/** (already allowed wholesale by is_internal_tooling) and are
+# screened by exactly the same is_sensitive_path scan, which runs first.
+SKILL_PREFIXES = ("skills/",)
 # Dependency lockfiles: always auto-generated; low risk, mandatory companion to new packages.
 LOCKFILES = {
     "uv.lock",
@@ -302,7 +310,12 @@ BOT_CONFIG_FILES = {
     ".pre-commit-config.yaml",
     "Makefile",
 }
-BOT_CONFIG_PREFIXES = (".github/",)
+# Any ``.github`` directory COMPONENT, at any depth — not just the repo root.
+# Anchoring this to the root let CI/bot config shapes ride in unreviewed under
+# any wholesale-allowed content directory (skills/, packages/, …) as
+# ``skills/x/.github/workflows/ci.yml``. Bot config requires human review
+# wherever it sits, so this fails closed.
+BOT_CONFIG_DIR_SEGMENTS = frozenset({".github"})
 SELF_MERGE_ALLOWED_PATHS_ENV = "SELF_MERGE_ALLOWED_PATHS"
 SELF_MERGE_ACCEPT_AI_REVIEW_ENV = "SELF_MERGE_ACCEPT_AI_REVIEW"
 GATE_HELPER_ENV = "GH_RATE_LIMIT_HELPER"
@@ -2051,6 +2064,20 @@ def is_lesson_file(path: str) -> bool:
     return path.startswith(LESSON_PREFIXES)
 
 
+def is_skill_file(path: str) -> bool:
+    """Whether a changed path belongs to a bundled agent skill.
+
+    Prefix-anchored at the repository root, mirroring is_lesson_file: a skill
+    lives at ``skills/<name>/``. Substring matching would wrongly admit
+    unrelated code such as ``src/skills_registry/loader.py``.
+
+    Deliberately NOT extension-filtered — see SKILL_PREFIXES for why. Note that
+    is_internal_tooling does not cover these: it is anchored to ``scripts/`` and
+    ``packages/`` at the root, so even ``skills/foo/scripts/bar.py`` misses it.
+    """
+    return path.replace("\\", "/").removeprefix("./").startswith(SKILL_PREFIXES)
+
+
 def is_lockfile(path: str) -> bool:
     """Return True for dependency lockfiles (auto-generated, low-risk).
 
@@ -2063,7 +2090,10 @@ def is_lockfile(path: str) -> bool:
 
 
 def is_bot_config(path: str) -> bool:
-    return path in BOT_CONFIG_FILES or path.startswith(BOT_CONFIG_PREFIXES)
+    normalized = path.replace("\\", "/").removeprefix("./")
+    if normalized in BOT_CONFIG_FILES:
+        return True
+    return any(part in BOT_CONFIG_DIR_SEGMENTS for part in normalized.split("/")[:-1])
 
 
 def _parse_repo_path_allowlist(value: str | None) -> dict[str, list[str]]:
@@ -2190,6 +2220,7 @@ def is_allowed_file(
     return (
         is_test_file(path)
         or is_lesson_file(path)
+        or is_skill_file(path)
         or is_task_metadata(path)
         or is_internal_tooling(path)
         or is_lockfile(path)
@@ -2238,6 +2269,8 @@ def classify_category(
         return "test-only", reasons
     if all(is_lesson_file(path) for path in paths):
         return "lesson-updates", reasons
+    if all(is_skill_file(path) for path in paths):
+        return "skill-updates", reasons
     if all(is_task_metadata(path) for path in paths):
         return "task-journal-metadata", reasons
     if all(is_internal_tooling(path) for path in paths):
@@ -2258,6 +2291,8 @@ def classify_category(
             categories.append("tests")
         if any(is_lesson_file(path) for path in paths):
             categories.append("lessons")
+        if any(is_skill_file(path) for path in paths):
+            categories.append("skills")
         if any(is_task_metadata(path) for path in paths):
             categories.append("task-metadata")
         if any(is_internal_tooling(path) for path in paths):

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -2196,7 +2196,10 @@ def is_sensitive_path(path: str) -> bool:
     if (
         ".ssh" in components[:-1]
         or name in SENSITIVE_PRIVATE_KEY_FILENAMES
-        or "env" in name.split(".")
+        or name == ".env"
+        or name.startswith(".env.")
+        or name.endswith(".env")
+        or ".env." in name
         or name.endswith(SENSITIVE_FILE_SUFFIXES)
     ):
         return True

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -2201,7 +2201,7 @@ def is_sensitive_path(path: str) -> bool:
     name = components[-1]
     if (
         ".ssh" in components[:-1]
-        or name in SENSITIVE_PRIVATE_KEY_FILENAMES
+        or name.startswith(SENSITIVE_PRIVATE_KEY_FILENAMES)
         or name == ".env"
         or name.startswith(".env.")
         or name.endswith(".env")
@@ -2213,7 +2213,11 @@ def is_sensitive_path(path: str) -> bool:
     # detection; e.g. "authToken.py" → "auth_token" catches the "auth" rule.
     original_components = path.replace("\\", "/").split("/")
     for component in original_components:
-        stem = component.rsplit(".", 1)[0] if "." in component else component
+        # Dotfiles (e.g. ".secret") have a leading dot that is NOT an extension
+        # separator. Only split on the last dot when one appears after the first
+        # character; otherwise use the whole component as the stem so keyword
+        # matching sees ".secret" instead of an empty string.
+        stem = component.rsplit(".", 1)[0] if "." in component[1:] else component
         # Normalise camelCase → snake_case so camelCase filenames are matched.
         # e.g. "authToken" → "auth_token", "deployScript" → "deploy_script".
         stem_normalised = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", stem).lower()

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -272,6 +272,12 @@ SENSITIVE_PATH_PARTS = (
     "kube",
     "k8s",
 )
+# Secret-bearing file formats do not necessarily have a sensitive keyword in
+# their name (for example ``skills/foo/.env`` or ``certificate.pem``). Keep
+# these extensions out of every wholesale self-merge category.
+SENSITIVE_FILENAMES = frozenset({".env"})
+SENSITIVE_FILENAME_PREFIXES = (".env.",)
+SENSITIVE_FILE_SUFFIXES = (".key", ".p12", ".pem", ".pfx")
 INTERNAL_TOOLING_PREFIXES = (
     "scripts/",
     "packages/",
@@ -2180,6 +2186,13 @@ def is_repo_allowlisted_path(
 def is_sensitive_path(path: str) -> bool:
     normalized = path.lower().replace("\\", "/")
     if normalized.startswith(tuple(p.lower() for p in SENSITIVE_PATH_PREFIXES)):
+        return True
+    name = normalized.rsplit("/", 1)[-1]
+    if (
+        name in SENSITIVE_FILENAMES
+        or name.startswith(SENSITIVE_FILENAME_PREFIXES)
+        or name.endswith(SENSITIVE_FILE_SUFFIXES)
+    ):
         return True
     # Use the original (pre-lowercase) path to preserve camelCase boundaries for
     # detection; e.g. "authToken.py" → "auth_token" catches the "auth" rule.

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -275,9 +275,7 @@ SENSITIVE_PATH_PARTS = (
 # Secret-bearing file formats do not necessarily have a sensitive keyword in
 # their name (for example ``skills/foo/.env`` or ``certificate.pem``). Keep
 # these extensions out of every wholesale self-merge category.
-SENSITIVE_FILENAMES = frozenset({".env"})
-SENSITIVE_FILENAME_PREFIXES = (".env.",)
-SENSITIVE_FILE_SUFFIXES = (".key", ".p12", ".pem", ".pfx")
+SENSITIVE_FILE_SUFFIXES = (".env", ".key", ".p12", ".pem", ".pfx")
 INTERNAL_TOOLING_PREFIXES = (
     "scripts/",
     "packages/",
@@ -2189,8 +2187,8 @@ def is_sensitive_path(path: str) -> bool:
         return True
     name = normalized.rsplit("/", 1)[-1]
     if (
-        name in SENSITIVE_FILENAMES
-        or name.startswith(SENSITIVE_FILENAME_PREFIXES)
+        name == ".env"
+        or name.startswith(".env.")
         or name.endswith(SENSITIVE_FILE_SUFFIXES)
     ):
         return True

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -275,7 +275,13 @@ SENSITIVE_PATH_PARTS = (
 # Secret-bearing file formats do not necessarily have a sensitive keyword in
 # their name (for example ``skills/foo/.env`` or ``certificate.pem``). Keep
 # these extensions out of every wholesale self-merge category.
-SENSITIVE_FILE_SUFFIXES = (".env", ".key", ".p12", ".pem", ".pfx")
+SENSITIVE_FILE_SUFFIXES = (".key", ".p12", ".pem", ".pfx")
+SENSITIVE_PRIVATE_KEY_FILENAMES = (
+    "id_dsa",
+    "id_ecdsa",
+    "id_ed25519",
+    "id_rsa",
+)
 INTERNAL_TOOLING_PREFIXES = (
     "scripts/",
     "packages/",
@@ -2185,10 +2191,12 @@ def is_sensitive_path(path: str) -> bool:
     normalized = path.lower().replace("\\", "/")
     if normalized.startswith(tuple(p.lower() for p in SENSITIVE_PATH_PREFIXES)):
         return True
-    name = normalized.rsplit("/", 1)[-1]
+    components = normalized.split("/")
+    name = components[-1]
     if (
-        name == ".env"
-        or name.startswith(".env.")
+        ".ssh" in components[:-1]
+        or name in SENSITIVE_PRIVATE_KEY_FILENAMES
+        or "env" in name.split(".")
         or name.endswith(SENSITIVE_FILE_SUFFIXES)
     ):
         return True

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -2093,7 +2093,9 @@ def is_bot_config(path: str) -> bool:
     normalized = path.replace("\\", "/").removeprefix("./")
     if normalized in BOT_CONFIG_FILES:
         return True
-    return any(part in BOT_CONFIG_DIR_SEGMENTS for part in normalized.split("/")[:-1])
+    return any(
+        part.lower() in BOT_CONFIG_DIR_SEGMENTS for part in normalized.split("/")[:-1]
+    )
 
 
 def _parse_repo_path_allowlist(value: str | None) -> dict[str, list[str]]:

--- a/scripts/github/self-merge-check.py
+++ b/scripts/github/self-merge-check.py
@@ -271,6 +271,12 @@ SENSITIVE_PATH_PARTS = (
     "systemd",
     "kube",
     "k8s",
+    "password",
+    "passwd",
+    "apikey",
+    "api_key",
+    "accesstoken",
+    "access_token",
 )
 # Secret-bearing file formats do not necessarily have a sensitive keyword in
 # their name (for example ``skills/foo/.env`` or ``certificate.pem``). Keep

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -882,6 +882,25 @@ def test_is_sensitive_path_handles_deploy_word_forms(path: str, expected: bool) 
 @pytest.mark.parametrize(
     "path",
     [
+        "skills/example/.env",
+        "skills/example/.env.local",
+        "skills/example/certificate.PEM",
+        "skills/example/private.key",
+        "skills/example/identity.p12",
+        "skills/example/identity.pfx",
+    ],
+)
+def test_secret_bearing_file_formats_are_sensitive(path: str) -> None:
+    assert self_merge_check.is_sensitive_path(path)
+    assert not self_merge_check.is_allowed_file(path)
+    category, reasons = self_merge_check.classify_category([path])
+    assert category is None
+    assert any("sensitive" in reason.lower() for reason in reasons)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
         "scripts/session-bandit.py",
         "scripts/session-bandit-v2.py",
         "scripts/session_bandit.py",

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -908,6 +908,20 @@ def test_secret_bearing_file_formats_are_sensitive(path: str) -> None:
 @pytest.mark.parametrize(
     "path",
     [
+        "packages/example/env.py",
+        "skills/example/env.json",
+    ],
+)
+def test_env_named_modules_are_not_sensitive(path: str) -> None:
+    assert not self_merge_check.is_sensitive_path(path)
+    assert self_merge_check.is_allowed_file(path)
+    category, reasons = self_merge_check.classify_category([path])
+    assert category is not None, reasons
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
         "scripts/session-bandit.py",
         "scripts/session-bandit-v2.py",
         "scripts/session_bandit.py",

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -895,6 +895,12 @@ def test_is_sensitive_path_handles_deploy_word_forms(path: str, expected: bool) 
         "skills/example/.ssh/id_rsa",
         "skills/example/.SSH/authorized_keys",
         "skills/example/id_ed25519",
+        "skills/example/password.txt",
+        "skills/example/passwords.json",
+        "skills/example/api_key.py",
+        "skills/example/apikey.json",
+        "skills/example/access_token.txt",
+        "skills/example/accessToken.py",
     ],
 )
 def test_secret_bearing_file_formats_are_sensitive(path: str) -> None:

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -884,6 +884,8 @@ def test_is_sensitive_path_handles_deploy_word_forms(path: str, expected: bool) 
     [
         "skills/example/.env",
         "skills/example/.env.local",
+        "skills/example/prod.env",
+        "skills/example/config.env",
         "skills/example/certificate.PEM",
         "skills/example/private.key",
         "skills/example/identity.p12",
@@ -962,9 +964,9 @@ def test_evaluate_pr_warns_when_workspace_repos_empty() -> None:
 
     # Explicit opt-out → warning, but PR is still eligible
     assert any("cross-repo restriction" in w for w in result.warnings)
-    assert (
-        result.eligible
-    ), f"Explicit opt-out should not disqualify; reasons: {result.reasons}"
+    assert result.eligible, (
+        f"Explicit opt-out should not disqualify; reasons: {result.reasons}"
+    )
 
 
 def _eligible_pr_data() -> dict:

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -964,9 +964,9 @@ def test_evaluate_pr_warns_when_workspace_repos_empty() -> None:
 
     # Explicit opt-out → warning, but PR is still eligible
     assert any("cross-repo restriction" in w for w in result.warnings)
-    assert result.eligible, (
-        f"Explicit opt-out should not disqualify; reasons: {result.reasons}"
-    )
+    assert (
+        result.eligible
+    ), f"Explicit opt-out should not disqualify; reasons: {result.reasons}"
 
 
 def _eligible_pr_data() -> dict:

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -1506,12 +1506,15 @@ def test_is_internal_tooling_does_not_cover_skill_paths() -> None:
         "skills/deployer/helper.py",
         "skills/x/ssh_config.py",
         "skills/x/k8s_apply.py",
-        # Bot/CI config shapes must never ride in under a skill directory.
+        # Bot/CI config shapes must never ride in under a wholesale-allowed
+        # directory, regardless of depth, separator, or case.
         "skills/x/.github/workflows/ci.yml",
-        "skills/x/.github/dependabot.yml",
+        "skills/x/.Github/dependabot.yml",
+        "packages/foo/.github/workflows/ci.yml",
+        "scripts/.GITHUB/dependabot.yml",
     ],
 )
-def test_skill_paths_do_not_bypass_hard_rejects(path: str) -> None:
+def test_allowed_paths_do_not_bypass_hard_rejects(path: str) -> None:
     assert not self_merge_check.is_allowed_file(path)
     category, reasons = self_merge_check.classify_category([path])
     assert category is None, f"{path} should not be self-mergeable (got {category})"

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -1453,6 +1453,108 @@ def test_is_allowed_file_allowlist_does_not_bypass_bot_config() -> None:
 @pytest.mark.parametrize(
     "path",
     [
+        # Instruction prose — the same behaviour-rewriting class as lessons/.
+        "skills/financial-advisor/SKILL.md",
+        "skills/agent-onboarding/framework-reference.md",
+        # Bundled executable helpers: a skill is "lesson + bundled scripts", and
+        # splitting the two leaves every skill PR half-mergeable.
+        "skills/financial-advisor/calibration.py",
+        "skills/code-review-helper/review_helpers.py",
+        # Nested helper dirs do NOT start with "scripts/", so is_internal_tooling
+        # never covered them.
+        "skills/home-assistant/scripts/ha.py",
+        "skills/rewrite-soul/agents/openai.yaml",
+    ],
+)
+def test_is_skill_file_recognized(path: str) -> None:
+    assert self_merge_check.is_skill_file(path)
+    assert self_merge_check.is_allowed_file(path)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        # Must be anchored at the repo root, not matched as a substring.
+        "packages/skills/foo.py",
+        "src/skills_registry/loader.py",
+        "skillset/foo.py",
+        "scripts/skills.py",
+    ],
+)
+def test_is_skill_file_not_recognized(path: str) -> None:
+    assert not self_merge_check.is_skill_file(path)
+
+
+def test_is_internal_tooling_does_not_cover_skill_paths() -> None:
+    """Documents WHY is_skill_file is needed: is_internal_tooling is prefix-anchored."""
+    assert not self_merge_check.is_internal_tooling(
+        "skills/financial-advisor/calibration.py"
+    )
+    assert not self_merge_check.is_internal_tooling(
+        "skills/home-assistant/scripts/ha.py"
+    )
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        # The sensitive-path keyword scan runs before the category predicates and
+        # still wins — same guard that carries packages/** today.
+        "skills/x/deploy_secrets.py",
+        "skills/x/auth_token.py",
+        "skills/x/credentials.py",
+        "skills/deployer/helper.py",
+        "skills/x/ssh_config.py",
+        "skills/x/k8s_apply.py",
+        # Bot/CI config shapes must never ride in under a skill directory.
+        "skills/x/.github/workflows/ci.yml",
+        "skills/x/.github/dependabot.yml",
+    ],
+)
+def test_skill_paths_do_not_bypass_hard_rejects(path: str) -> None:
+    assert not self_merge_check.is_allowed_file(path)
+    category, reasons = self_merge_check.classify_category([path])
+    assert category is None, f"{path} should not be self-mergeable (got {category})"
+    assert reasons
+
+
+def test_skill_allowlist_does_not_bypass_sensitive_paths_in_classify() -> None:
+    """A mixed skill PR is disqualified as a whole by one sensitive file."""
+    category, reasons = self_merge_check.classify_category(
+        [
+            "skills/financial-advisor/SKILL.md",
+            "skills/financial-advisor/deploy_keys.py",
+        ]
+    )
+    assert category is None, reasons
+    assert any("sensitive" in reason.lower() for reason in reasons)
+
+
+def test_classify_category_skills_only() -> None:
+    """PR #1417's exact file set becomes eligible as a skill PR."""
+    category, reasons = self_merge_check.classify_category(
+        [
+            "skills/financial-advisor/SKILL.md",
+            "skills/financial-advisor/calibration.py",
+            "skills/financial-advisor/tests/test_calibration.py",
+        ]
+    )
+    assert category is not None, reasons
+    assert "skill" in category
+
+
+def test_classify_category_skills_mixed_with_allowed() -> None:
+    category, reasons = self_merge_check.classify_category(
+        ["skills/foo/SKILL.md", "skills/foo/helper.py", "tasks/my-task.md"]
+    )
+    assert category is not None, reasons
+    assert "skills" in category
+    assert "task-metadata" in category
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
         "uv.lock",
         "poetry.lock",
         "Pipfile.lock",

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -886,10 +886,15 @@ def test_is_sensitive_path_handles_deploy_word_forms(path: str, expected: bool) 
         "skills/example/.env.local",
         "skills/example/prod.env",
         "skills/example/config.env",
+        "skills/example/prod.env.local",
+        "skills/example/config.env.production",
         "skills/example/certificate.PEM",
         "skills/example/private.key",
         "skills/example/identity.p12",
         "skills/example/identity.pfx",
+        "skills/example/.ssh/id_rsa",
+        "skills/example/.SSH/authorized_keys",
+        "skills/example/id_ed25519",
     ],
 )
 def test_secret_bearing_file_formats_are_sensitive(path: str) -> None:

--- a/tests/test_self_merge_check.py
+++ b/tests/test_self_merge_check.py
@@ -901,6 +901,16 @@ def test_is_sensitive_path_handles_deploy_word_forms(path: str, expected: bool) 
         "skills/example/apikey.json",
         "skills/example/access_token.txt",
         "skills/example/accessToken.py",
+        # Dotfiles with sensitive keywords — stem must not become empty (P0 fix)
+        "skills/example/.secret",
+        "skills/example/.token",
+        "skills/example/.password",
+        "skills/example/.credentials",
+        # Private-key filenames with backup/rotation suffixes (P1 fix)
+        "skills/example/id_rsa.old",
+        "skills/example/id_rsa.bak",
+        "skills/example/id_ed25519.old",
+        "skills/example/id_ecdsa.bak",
     ],
 )
 def test_secret_bearing_file_formats_are_sensitive(path: str) -> None:


### PR DESCRIPTION
Erik: *"skill paths should probably be within self-merge categories."*

Surfaced by gptme/gptme-contrib#1417, green and waiting since 2026-08-13.

## What was actually blocked

The reported blocker listed all three of #1417's files, but that was stale. Running the gate at current master gives exactly one:

```
Files not in any allowed self-merge category: skills/financial-advisor/calibration.py
```

- `skills/financial-advisor/SKILL.md` — already allowed by `is_doc_file` (any `.md`; `is_spec_like_doc` only fires at the repo root, and `SKILL.md` isn't in `SPEC_LIKE_DOCS` anyway)
- `skills/financial-advisor/tests/test_calibration.py` — already allowed by `is_test_file` (`tests/` path component)
- `skills/financial-advisor/calibration.py` — **the only gap**

## Scope decision: all of `skills/**`, not `skills/**/*.md`

`is_internal_tooling` does **not** cover the `.py` — it is `path.startswith(("scripts/", "packages/"))`, anchored at the repo root. Even `skills/home-assistant/scripts/ha.py` (which exists in this repo) misses it. Verified, not assumed; there's a regression test asserting exactly this.

That makes an `.md`-only `is_skill_file` a **strict no-op** — `is_doc_file` already admits every `.md` under `skills/`, so it would add a named category that changes zero verdicts. The only thing this change can actually do is admit a skill's bundled helper files. So the real choice was "do nothing" vs. "all of `skills/**`".

Chose the latter:

1. **The repo's own definition.** `skills/README.md`: skills are *"enhanced lessons that bundle workflows, scripts, and utilities"* — the lesson class *including* its executable companions. Splitting the prose from its helper leaves every skill PR half-mergeable, which churns the review queue without unblocking anything.
2. **Risk parity.** `packages/**` is already allowed wholesale by `is_internal_tooling` — arbitrary Python, no extension filter. `skills/**` is a strictly smaller and more constrained surface, screened by the same `is_sensitive_path` scan.
3. **Consistency with lessons.** `is_lesson_file` is already allowed, and lessons rewrite future agent behaviour. A `SKILL.md` is the same class of artifact — and it was *already* self-mergeable before this PR.

Worth naming where the marginal risk actually sits: it is **not** in `calibration.py`. The behaviour-rewriting artifact in a skill is `SKILL.md`, auto-injected instruction content — and that has been self-mergeable all along via `is_doc_file`. This PR's new exposure is limited to bundled helper files, guarded by the same scan that guards `packages/**` today.

## Hard-rejects still run first and still win

`is_allowed_file` ordering is unchanged: bot-config → spec-like doc → repo allowlist → `is_sensitive_path` → category predicates.

Proven still rejected under `skills/`:

| Path | Verdict |
|---|---|
| `skills/x/deploy_secrets.py` | reject (sensitive) |
| `skills/x/auth_token.py`, `skills/x/authToken.py` | reject (sensitive, incl. camelCase) |
| `skills/x/credentials.yaml`, `skills/x/secrets.py` | reject (sensitive) |
| `skills/deployer/run.py` | reject (sensitive dir component) |
| `skills/x/ssh_keys.py`, `skills/x/systemd_unit.py`, `skills/x/k8s_apply.py` | reject (sensitive) |
| `skills/x/.github/workflows/ci.yml` | reject (bot config) |
| `skills/x/.github/dependabot.yml` | reject (bot config) |

A mixed PR (`skills/f/SKILL.md` + `skills/f/deploy_keys.py`) is disqualified as a whole: `Touches sensitive/security/infra paths`.

`is_skill_file` is prefix-anchored at the repo root, so `packages/skills/foo.py`, `src/skills_registry/loader.py` and `skillset/foo.py` are **not** skill files.

### Drive-by tightening: `is_bot_config`

`is_bot_config` was root-anchored (`path.startswith(".github/")`). Under a new wholesale-allowed content directory that would have let `skills/x/.github/workflows/ci.yml` through unreviewed. It now matches a `.github` directory **component at any depth**. Fails closed, and closes the same latent hole under `packages/**`.

## Verify by symptom — #1417

Run from inside the contrib checkout with `WORKSPACE_REPO=gptme/gptme-contrib`:

**Before**
```
Eligible: NO
Category: none
Reasons:
- Greptile review not found; AI review P1 finding is not resolved
- Files not in any allowed self-merge category: skills/financial-advisor/calibration.py
```

**After**
```
Eligible: NO
Category: skill-updates
Reasons:
- Greptile review not found; AI review P1 finding is not resolved
```

The file-category blocker is cleared. #1417 remains blocked on the **machine-review gate** — Greptile is dark on this repo and the AI reviewer's latest full marker is at `debbff9`, stale against HEAD `99f18ae3`. That is a separate gate and the correct outcome; this PR deliberately does not touch it.

## Tests

Written to fail first against master (12 failures), then implemented.

- `test_is_skill_file_recognized` — SKILL.md, nested reference docs, bundled `.py`, nested `scripts/ha.py`, `agents/*.yaml`
- `test_is_skill_file_not_recognized` — substring lookalikes
- `test_is_internal_tooling_does_not_cover_skill_paths` — documents why the predicate is needed
- `test_skill_paths_do_not_bypass_hard_rejects` — the negative table above
- `test_skill_allowlist_does_not_bypass_sensitive_paths_in_classify`
- `test_classify_category_skills_only` — #1417's exact file set → `skill-updates`
- `test_classify_category_skills_mixed_with_allowed`

Full contrib suite: **1077 passed, 4 skipped**.
