### PR TITLE
fix(gptme-rag): surface search degradation warnings in non-json mode

### DIFF
--- a/packages/gptme-rag/src/gptme_rag/cli.py
+++ b/packages/gptme-rag/src/gptme_rag/cli.py
@@ -402,9 +402,11 @@ def search(
     # and redirect stderr too (suppresses model-loading progress bars like "Loading weights").
     status_ctx = contextlib.nullcontext() if output_json else console.status("Initializing...")
     captured_warnings: list[str] = []
-    warning_handler = _JsonWarningCaptureHandler(captured_warnings) if output_json else None
-    if warning_handler is not None:
-        logging.getLogger().addHandler(warning_handler)
+    # Capture in both modes: stdout is redirected to /dev/null during init/search
+    # regardless of --json, and RichHandler logs to stdout, so warnings would
+    # otherwise be swallowed for humans too (not just JSON consumers).
+    warning_handler = _JsonWarningCaptureHandler(captured_warnings)
+    logging.getLogger().addHandler(warning_handler)
     with status_ctx:
         # Parse custom weights if provided
         scoring_weights = None
@@ -493,8 +495,12 @@ def search(
                         print(json.dumps(error_output))
                     raise
         finally:
-            if warning_handler is not None:
-                logging.getLogger().removeHandler(warning_handler)
+            logging.getLogger().removeHandler(warning_handler)
+            if not output_json:
+                # stdout was redirected to /dev/null above, taking RichHandler's
+                # output with it — re-emit so a human sees degraded results too.
+                for message in captured_warnings:
+                    console.print(f"⚠️  {message}", style="yellow")
 
     if not documents:
         if output_json:

--- a/packages/gptme-rag/src/gptme_rag/cli.py
+++ b/packages/gptme-rag/src/gptme_rag/cli.py
@@ -498,12 +498,11 @@ def search(
                     raise
         finally:
             logging.getLogger().removeHandler(warning_handler)
-
-    if not output_json:
-        # stdout was redirected to /dev/null above, taking RichHandler's output
-        # with it. Re-emit after the status display stops so warnings remain visible.
-        for message in captured_warnings:
-            console.print(f"⚠️  {message}", style="yellow", markup=False)
+            if not output_json:
+                # stdout was redirected to /dev/null above, taking RichHandler's
+                # output with it. Re-emit before propagating any search failure.
+                for message in captured_warnings:
+                    console.print(f"⚠️  {message}", style="yellow", markup=False)
 
     if not documents:
         if output_json:

--- a/packages/gptme-rag/src/gptme_rag/cli.py
+++ b/packages/gptme-rag/src/gptme_rag/cli.py
@@ -402,30 +402,32 @@ def search(
     # and redirect stderr too (suppresses model-loading progress bars like "Loading weights").
     status_ctx = contextlib.nullcontext() if output_json else console.status("Initializing...")
     captured_warnings: list[str] = []
+
+    # Parse custom weights before installing the warning handler so early returns
+    # cannot leave the handler attached to the root logger.
+    scoring_weights = None
+    if weights:
+        try:
+            scoring_weights = json.loads(weights)
+        except json.JSONDecodeError as e:
+            if output_json:
+                print(json.dumps({"error": f"Invalid weights JSON: {e}", "query": query}))
+            else:
+                console.print(f"❌ Invalid weights JSON: {e}", style="red")
+            return
+        except Exception as e:
+            if output_json:
+                print(json.dumps({"error": f"Error parsing weights: {e}", "query": query}))
+            else:
+                console.print(f"❌ Error parsing weights: {e}", style="red")
+            return
+
     # Capture in both modes: stdout is redirected to /dev/null during init/search
     # regardless of --json, and RichHandler logs to stdout, so warnings would
     # otherwise be swallowed for humans too (not just JSON consumers).
     warning_handler = _JsonWarningCaptureHandler(captured_warnings)
     logging.getLogger().addHandler(warning_handler)
     with status_ctx:
-        # Parse custom weights if provided
-        scoring_weights = None
-        if weights:
-            try:
-                scoring_weights = json.loads(weights)
-            except json.JSONDecodeError as e:
-                if output_json:
-                    print(json.dumps({"error": f"Invalid weights JSON: {e}", "query": query}))
-                else:
-                    console.print(f"❌ Invalid weights JSON: {e}", style="red")
-                return
-            except Exception as e:
-                if output_json:
-                    print(json.dumps({"error": f"Error parsing weights: {e}", "query": query}))
-                else:
-                    console.print(f"❌ Error parsing weights: {e}", style="red")
-                return
-
         # Redirect stdout to suppress ChromaDB/model-loading noise that would
         # corrupt stdout consumers.  In json mode, also redirect stderr:
         # tqdm "Loading weights" progress bars go to stderr, and Click 8.4+
@@ -496,11 +498,12 @@ def search(
                     raise
         finally:
             logging.getLogger().removeHandler(warning_handler)
-            if not output_json:
-                # stdout was redirected to /dev/null above, taking RichHandler's
-                # output with it — re-emit so a human sees degraded results too.
-                for message in captured_warnings:
-                    console.print(f"⚠️  {message}", style="yellow")
+
+    if not output_json:
+        # stdout was redirected to /dev/null above, taking RichHandler's output
+        # with it. Re-emit after the status display stops so warnings remain visible.
+        for message in captured_warnings:
+            console.print(f"⚠️  {message}", style="yellow", markup=False)
 
     if not documents:
         if output_json:

--- a/packages/gptme-rag/tests/test_cli_search.py
+++ b/packages/gptme-rag/tests/test_cli_search.py
@@ -563,3 +563,44 @@ def test_search_json_surfaces_warning_only_degraded_path(tmp_path):
     assert data["warnings"] == [
         "Embedding model mismatch; continuing with stored embedding function"
     ]
+
+
+def test_search_non_json_surfaces_warning_to_human(tmp_path):
+    """Non-json search must still show degradation warnings.
+
+    stdout is redirected to /dev/null during init/search in *both* modes, and
+    RichHandler logs to stdout — so without an explicit re-emit the warning is
+    swallowed and a human sees a healthy-looking result set.
+    """
+    from unittest.mock import Mock, patch as mock_patch
+
+    fake_doc = Document(content="hello world", metadata={"source": "test.txt"}, doc_id="doc1")
+
+    mock_indexer = Mock()
+    mock_indexer.search.return_value = ([fake_doc], [0.1], None)
+
+    assembled = Mock()
+    assembled.documents = [fake_doc]
+    assembled.truncated = False
+    mock_assembler = Mock()
+    mock_assembler.assemble_context.return_value = assembled
+    mock_assembler.count_tokens.return_value = 2
+
+    def make_indexer(*args, **kwargs):
+        logging.getLogger("gptme_rag.indexing.indexer").warning(
+            "Embedding model mismatch; continuing with stored embedding function"
+        )
+        return mock_indexer
+
+    runner = CliRunner()
+    with (
+        mock_patch("gptme_rag.cli.Indexer", side_effect=make_indexer),
+        mock_patch("gptme_rag.cli.ContextAssembler", return_value=mock_assembler),
+    ):
+        result = runner.invoke(
+            cli,
+            ["search", "test query", "--persist-dir", str(tmp_path / "index")],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Embedding model mismatch" in result.output

--- a/packages/gptme-rag/tests/test_cli_search.py
+++ b/packages/gptme-rag/tests/test_cli_search.py
@@ -565,8 +565,29 @@ def test_search_json_surfaces_warning_only_degraded_path(tmp_path):
     ]
 
 
+def test_search_invalid_weights_does_not_leak_warning_handler(tmp_path):
+    """An early return during weights parsing must not mutate root logging."""
+    root_logger = logging.getLogger()
+    handlers_before = list(root_logger.handlers)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "search",
+            "test query",
+            "--persist-dir",
+            str(tmp_path / "index"),
+            "--weights",
+            "not-valid-json{{{",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert root_logger.handlers == handlers_before
+
+
 def test_search_non_json_surfaces_warning_to_human(tmp_path):
-    """Non-json search must still show degradation warnings.
+    """Non-json search must show arbitrary warning text without Rich parsing it.
 
     stdout is redirected to /dev/null during init/search in *both* modes, and
     RichHandler logs to stdout — so without an explicit re-emit the warning is
@@ -585,11 +606,10 @@ def test_search_non_json_surfaces_warning_to_human(tmp_path):
     mock_assembler = Mock()
     mock_assembler.assemble_context.return_value = assembled
     mock_assembler.count_tokens.return_value = 2
+    warning = "Embedding model mismatch for [bert-base]; continuing with stored model ["
 
     def make_indexer(*args, **kwargs):
-        logging.getLogger("gptme_rag.indexing.indexer").warning(
-            "Embedding model mismatch; continuing with stored embedding function"
-        )
+        logging.getLogger("gptme_rag.indexing.indexer").warning(warning)
         return mock_indexer
 
     runner = CliRunner()
@@ -603,4 +623,4 @@ def test_search_non_json_surfaces_warning_to_human(tmp_path):
         )
 
     assert result.exit_code == 0, result.output
-    assert "Embedding model mismatch" in result.output
+    assert warning in result.output

--- a/packages/gptme-rag/tests/test_cli_search.py
+++ b/packages/gptme-rag/tests/test_cli_search.py
@@ -624,3 +624,29 @@ def test_search_non_json_surfaces_warning_to_human(tmp_path):
 
     assert result.exit_code == 0, result.output
     assert warning in result.output
+
+
+def test_search_non_json_surfaces_warning_before_failure(tmp_path):
+    """A captured warning must remain visible when search later fails."""
+    from unittest.mock import patch as mock_patch
+
+    warning = "Embedding model mismatch; continuing with stored model"
+
+    class FailingIndexer:
+        def __init__(self, *args, **kwargs):
+            logging.getLogger("gptme_rag.indexing.indexer").warning(warning)
+
+        def search(self, *args, **kwargs):
+            raise RuntimeError("embedding dimension mismatch")
+
+    runner = CliRunner()
+    with mock_patch("gptme_rag.cli.Indexer", FailingIndexer):
+        result = runner.invoke(
+            cli,
+            ["search", "test query", "--persist-dir", str(tmp_path / "index")],
+        )
+
+    assert result.exit_code != 0
+    assert warning in result.output
+    assert isinstance(result.exception, RuntimeError)
+    assert str(result.exception) == "embedding dimension mismatch"


### PR DESCRIPTION
Follow-up to #1411, found while symptom-verifying that PR's merged fix.

## The gap

#1411 added an embedding-model-mismatch warning (`allow_recreate=False` keeps
the collection instead of wiping it) and captured it into the `--json`
envelope. That half works — verified live:

```json
{
  "error": "Cannot search: the stored embedding model 'all-MiniLM-L6-v2' could not be loaded ...",
  "query": "fox",
  "warnings": ["Embedding model mismatch (stored: 'all-MiniLM-L6-v2', requested: 'modernbert') but recreation is disabled for this command; ..."]
}
```

The **human** half did not. `search()` wraps init/search in
`contextlib.redirect_stdout(devnull)` in *both* modes, and `RichHandler` logs
to stdout — so the warning went to `/dev/null`. Without `--json` the same
command printed a bare `RuntimeError` traceback and no explanation of why.

The existing comment says non-json mode *"keeps stderr visible so callers can
diagnose partial failures (missing model, fallback used, etc.)"*. Accurate
about stderr, but the diagnostics were on stdout, so the stated intent was
never actually reached.

## The fix

Attach `_JsonWarningCaptureHandler` in both modes, and re-emit captured
warnings to the console after the redirect block when not in json mode.
Six lines; no change to json-mode behaviour or to the tqdm-suppression that
#1416 added.

## Verification

Symptom test (not just unit tests) — index with one model, search with another:

```bash
gptme-rag index docs/ --persist-dir idx --embedding-function minilm
gptme-rag search fox --persist-dir idx --embedding-function modernbert
```

- **Before**: traceback only, no mention of the mismatch.
- **After**: `⚠️  Embedding model mismatch (stored: 'all-MiniLM-L6-v2', requested: 'modernbert') ...`

`--json` output unchanged (still carries `warnings`); stdout still clean.

New regression test `test_search_non_json_surfaces_warning_to_human` — confirmed
RED before the fix, green after. Full `test_cli_search.py`: 17 passed.