### PR TITLE
fix(pm): sync worker timeout table with shell script

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/project_monitoring.py
+++ b/packages/gptme-runloops/src/gptme_runloops/project_monitoring.py
@@ -99,6 +99,8 @@ class ProjectMonitoringRun(BaseRunLoop):
         "ci_failure": 1200,  # ~20 min: investigate + fix
         "notification": 600,  # ~10 min: simple processing
         "linear_notification_retry": 600,  # ~10 min: retry a failed Linear notification delivery
+        # greptile_needs_fix and greptile_convergence_adjudication are intentionally
+        # absent: they are dispatcher-derived and handled by run_item.timeout_tier().
     }
     _DEFAULT_ITEM_TIMEOUT = 900  # ~15 min for unknown types
     _MAX_TIMEOUT = 3600  # 60 min cap regardless of item count

--- a/packages/gptme-runloops/src/gptme_runloops/project_monitoring.py
+++ b/packages/gptme-runloops/src/gptme_runloops/project_monitoring.py
@@ -90,16 +90,13 @@ class ProjectMonitoringRun(BaseRunLoop):
         # Cache discovered work between has_work() and generate_prompt()
         self._discovered_work: list[WorkItem] = []
 
-    # Per-item timeout in seconds, mirroring project-monitoring.sh tiers.
-    # Assigned issues need the most time (research + PR + response).
-    # PR updates, CI failures, and greptile review cycles need a mid-tier (fix + re-review cycle).
-    # Simple notifications need the least.
+    # Per-item timeout in seconds for work produced by this legacy discovery loop.
+    # The slot-based executor uses run_item.timeout_tier() for dispatcher-derived
+    # work such as Greptile fixes and convergence adjudication.
     _ITEM_TIMEOUTS: dict[str, int] = {
         "assigned_issue": 1500,  # ~25 min: deep research + PR work + response
-        "greptile_convergence_adjudication": 1500,  # ~25 min: classify findings, fix one blocking issue, recommend
         "pr_update": 1200,  # ~20 min: fix + re-review cycle
         "ci_failure": 1200,  # ~20 min: investigate + fix
-        "greptile_needs_fix": 1200,  # ~20 min: fix + re-review cycle
         "notification": 600,  # ~10 min: simple processing
         "linear_notification_retry": 600,  # ~10 min: retry a failed Linear notification delivery
     }
@@ -109,10 +106,10 @@ class ProjectMonitoringRun(BaseRunLoop):
     def _compute_timeout(self, items: list["WorkItem"]) -> int:
         """Compute session timeout by summing per-item budgets, capped at _MAX_TIMEOUT.
 
-        Mirrors the complexity-based timeout tiers in project-monitoring.sh:
-          - assigned_issue / greptile_convergence_adjudication → 1500s (deep work)
-          - pr_update / ci_failure / greptile_needs_fix → 1200s (fix + re-review)
-          - notification / linear_notification_retry → 600s (simple)
+        Budgets the item types emitted by :meth:`discover_work`:
+          - assigned_issue → 1500s (deep work)
+          - pr_update / ci_failure → 1200s (fix work)
+          - notification / linear_notification_retry → 600s (simple work)
 
         Args:
             items: Discovered work items.

--- a/packages/gptme-runloops/src/gptme_runloops/project_monitoring.py
+++ b/packages/gptme-runloops/src/gptme_runloops/project_monitoring.py
@@ -96,10 +96,12 @@ class ProjectMonitoringRun(BaseRunLoop):
     # Simple notifications need the least.
     _ITEM_TIMEOUTS: dict[str, int] = {
         "assigned_issue": 1500,  # ~25 min: deep research + PR work + response
+        "greptile_convergence_adjudication": 1500,  # ~25 min: classify findings, fix one blocking issue, recommend
         "pr_update": 1200,  # ~20 min: fix + re-review cycle
         "ci_failure": 1200,  # ~20 min: investigate + fix
-        "greptile_needs_fix": 1200,  # ~20 min: fix + re-review cycle (added 2026-08-16)
+        "greptile_needs_fix": 1200,  # ~20 min: fix + re-review cycle
         "notification": 600,  # ~10 min: simple processing
+        "linear_notification_retry": 600,  # ~10 min: retry a failed Linear notification delivery
     }
     _DEFAULT_ITEM_TIMEOUT = 900  # ~15 min for unknown types
     _MAX_TIMEOUT = 3600  # 60 min cap regardless of item count
@@ -108,9 +110,9 @@ class ProjectMonitoringRun(BaseRunLoop):
         """Compute session timeout by summing per-item budgets, capped at _MAX_TIMEOUT.
 
         Mirrors the complexity-based timeout tiers in project-monitoring.sh:
-          - assigned_issue → 1500s (research + PR work)
-          - pr_update / ci_failure → 1200s (fix + re-review)
-          - notification → 600s (simple)
+          - assigned_issue / greptile_convergence_adjudication → 1500s (deep work)
+          - pr_update / ci_failure / greptile_needs_fix → 1200s (fix + re-review)
+          - notification / linear_notification_retry → 600s (simple)
 
         Args:
             items: Discovered work items.

--- a/packages/gptme-runloops/src/gptme_runloops/project_monitoring.py
+++ b/packages/gptme-runloops/src/gptme_runloops/project_monitoring.py
@@ -92,12 +92,13 @@ class ProjectMonitoringRun(BaseRunLoop):
 
     # Per-item timeout in seconds, mirroring project-monitoring.sh tiers.
     # Assigned issues need the most time (research + PR + response).
-    # PR updates and CI failures need a mid-tier (fix + re-review cycle).
+    # PR updates, CI failures, and greptile review cycles need a mid-tier (fix + re-review cycle).
     # Simple notifications need the least.
     _ITEM_TIMEOUTS: dict[str, int] = {
         "assigned_issue": 1500,  # ~25 min: deep research + PR work + response
         "pr_update": 1200,  # ~20 min: fix + re-review cycle
         "ci_failure": 1200,  # ~20 min: investigate + fix
+        "greptile_needs_fix": 1200,  # ~20 min: fix + re-review cycle (added 2026-08-16)
         "notification": 600,  # ~10 min: simple processing
     }
     _DEFAULT_ITEM_TIMEOUT = 900  # ~15 min for unknown types

--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -520,7 +520,7 @@ def timeout_tier(
         or instruction_kind == "GREPTILE_CONVERGENCE"
     ):
         return config.adjudication_timeout, config.adjudication_time_desc
-    if "pr_update" in types and has_greptile_fix:
+    if "greptile_needs_fix" in types or ("pr_update" in types and has_greptile_fix):
         return config.greptile_fix_timeout, config.greptile_fix_time_desc
     return config.default_timeout, config.default_time_desc
 

--- a/packages/gptme-runloops/tests/test_project_monitoring.py
+++ b/packages/gptme-runloops/tests/test_project_monitoring.py
@@ -67,20 +67,30 @@ def test_compute_timeout_single_pr_update(workspace):
     assert run._compute_timeout(items) == 1200
 
 
-def test_compute_timeout_greptile_needs_fix(workspace):
-    """Greptile fix-and-review cycles use the medium-tier budget (same as pr_update)."""
+@pytest.mark.parametrize(
+    ("item_type", "expected_timeout"),
+    [
+        ("greptile_convergence_adjudication", 1500),
+        ("greptile_needs_fix", 1200),
+        ("linear_notification_retry", 600),
+    ],
+)
+def test_compute_timeout_synced_item_types(
+    workspace, item_type: str, expected_timeout: int
+):
+    """Item types synced from the shell dispatcher retain their timeout tier."""
     run = ProjectMonitoringRun(workspace)
     items = [
         WorkItem(
             repo="r/r",
-            item_type="greptile_needs_fix",
+            item_type=item_type,
             number=1,
             title="t",
             url="u",
             details="d",
         )
     ]
-    assert run._compute_timeout(items) == 1200
+    assert run._compute_timeout(items) == expected_timeout
 
 
 def test_compute_timeout_single_notification(workspace):

--- a/packages/gptme-runloops/tests/test_project_monitoring.py
+++ b/packages/gptme-runloops/tests/test_project_monitoring.py
@@ -67,6 +67,22 @@ def test_compute_timeout_single_pr_update(workspace):
     assert run._compute_timeout(items) == 1200
 
 
+def test_compute_timeout_greptile_needs_fix(workspace):
+    """Greptile fix-and-review cycles use the medium-tier budget (same as pr_update)."""
+    run = ProjectMonitoringRun(workspace)
+    items = [
+        WorkItem(
+            repo="r/r",
+            item_type="greptile_needs_fix",
+            number=1,
+            title="t",
+            url="u",
+            details="d",
+        )
+    ]
+    assert run._compute_timeout(items) == 1200
+
+
 def test_compute_timeout_single_notification(workspace):
     """Notifications use the shortest budget."""
     run = ProjectMonitoringRun(workspace)

--- a/packages/gptme-runloops/tests/test_project_monitoring.py
+++ b/packages/gptme-runloops/tests/test_project_monitoring.py
@@ -67,30 +67,20 @@ def test_compute_timeout_single_pr_update(workspace):
     assert run._compute_timeout(items) == 1200
 
 
-@pytest.mark.parametrize(
-    ("item_type", "expected_timeout"),
-    [
-        ("greptile_convergence_adjudication", 1500),
-        ("greptile_needs_fix", 1200),
-        ("linear_notification_retry", 600),
-    ],
-)
-def test_compute_timeout_synced_item_types(
-    workspace, item_type: str, expected_timeout: int
-):
-    """Item types synced from the shell dispatcher retain their timeout tier."""
+def test_compute_timeout_linear_notification_retry(workspace):
+    """Linear retries emitted by discovery use the simple-work tier."""
     run = ProjectMonitoringRun(workspace)
     items = [
         WorkItem(
             repo="r/r",
-            item_type=item_type,
+            item_type="linear_notification_retry",
             number=1,
             title="t",
             url="u",
             details="d",
         )
     ]
-    assert run._compute_timeout(items) == expected_timeout
+    assert run._compute_timeout(items) == 600
 
 
 def test_compute_timeout_single_notification(workspace):

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -213,6 +213,7 @@ def test_predict_cc_trajectory_path() -> None:
         (["assigned_issue"], False, (1500, "~20 minutes")),
         # assigned_issue wins over the greptile-fix tier (bash if/elif order)
         (["assigned_issue", "pr_update"], True, (1500, "~20 minutes")),
+        (["greptile_needs_fix"], True, (2700, "~35 minutes")),
         (["notification"], False, (900, "~10 minutes")),
         (["merge_ready"], True, (900, "~10 minutes")),
     ],


### PR DESCRIPTION
## What

Routes each monitored item type through the executor that actually owns it, then gives
that executor an explicit timeout budget:

- **`greptile_needs_fix`** is dispatcher-derived slot work, so
  `run_item.timeout_tier()` now gives it the existing 2700s Greptile fix/review budget
  even when it is not bundled with `pr_update`.
- **`greptile_convergence_adjudication`** was already explicitly routed by
  `run_item.timeout_tier()` to the 1500s adjudication budget; this PR preserves that
  route rather than adding dead policy to the legacy discovery loop.
- **`linear_notification_retry`** is emitted by the legacy
  `ProjectMonitoringRun.discover_work()` path, so `_ITEM_TIMEOUTS` now gives it the
  600s simple-work budget.

The comments and focused tests now describe this split between the slot executor and
the legacy discovery loop.

## Why

The Aug 15 backend outage produced an 18-of-21 timeout storm. Most failures were
`greptile_needs_fix` items entering the slot executor with the 900s default despite
the Greptile fix/review workflow having a 2700s budget. The old proposal put Greptile
types into `_ITEM_TIMEOUTS`, but that table is only used by the legacy discovery loop
and cannot affect dispatcher-derived Greptile work.

Raising the default would over-budget every unknown future type. Explicit policy in
the owning executor fixes the measured failure without widening unrelated work.
