### PR TITLE
feat(skills): add agentic-presentation skill

### DIFF
--- a/skills/agentic-presentation/SKILL.md
+++ b/skills/agentic-presentation/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: agentic-presentation
+description: Generate an offline, single-file HTML presentation from structured slide JSON. Use when turning notes, research, demos, or technical explanations into an agent-generated slide deck.
+license: MIT
+compatibility: "Requires Python 3.10+ (stdlib only for rendering)"
+metadata:
+  author: bob
+  version: "0.1.0"
+  tags: [presentations, content, html, slides, agents]
+  requires_tools: [shell]
+  requires_skills: []
+---
+
+# Agentic Presentation
+
+Turn structured slide JSON into a standalone HTML deck that opens in any browser, offline.
+
+## When to Use
+
+**Use for**: notes, research summaries, demos, or technical explanations that should be delivered as slides.
+
+**Do not use for**: full web apps, long-form blog posts, or hosted dashboards.
+
+## Bundled Files
+
+| File | Purpose |
+|------|---------|
+| `generate_presentation_html.py` | Renderer: validates deck JSON, emits a single self-contained HTML file |
+| `present.py` | Convenience wrapper: render and optionally open in a browser |
+| `presentation.schema.json` | JSON Schema (draft-07) for the deck format |
+| `examples/agentic-presentation-demo.json` | Working demo deck |
+| `tests/test_generate_presentation_html.py` | Tests for the renderer and schema |
+
+## Workflow
+
+1. Convert source notes into slide-deck JSON that conforms to `presentation.schema.json`.
+2. Keep slide count tight: one idea per slide, short text, code blocks only when they teach the point.
+3. Use these MVP slide types: `title-slide`, `content`, `code-reveal`, `code-and-text`, `image`, `gallery`.
+4. Use these MVP animations: `fade-in`, `slide-in`, `line-reveal`. `zoom` and `spin` are schema-reserved but should stay rare.
+5. Render locally — three ways (paths shown from the repo root):
+
+```bash
+# Quick path: render + open in browser
+python3 skills/agentic-presentation/present.py deck.json --live
+
+# Explicit path: render to a named file
+python3 skills/agentic-presentation/present.py deck.json -o /tmp/slides.html
+
+# Low-level: call the generator directly
+python3 skills/agentic-presentation/generate_presentation_html.py \
+  skills/agentic-presentation/examples/agentic-presentation-demo.json \
+  -o /tmp/agentic-presentation-demo.html
+```
+
+The rendered HTML has built-in keyboard navigation: **→** or **Space** / **Enter** to advance, **←** to go back.
+
+## Output Contract
+
+- The generated file must be standalone HTML with inline CSS and JavaScript.
+- Do not depend on CDNs for the MVP path; offline rendering is a hard constraint.
+- Keep generated HTML below 500KB for ordinary decks. Use `--max-kb` to enforce the limit.
+- Escape all user-provided text through the generator; do not hand-write HTML fragments inside slide JSON.
+
+## Authoring Guidance
+
+Good slide JSON is compact and structured:
+
+```json
+{
+  "id": "code",
+  "type": "code-reveal",
+  "title": "Generator shape",
+  "language": "python",
+  "code": "deck = load_presentation(path)\nhtml = render_html(deck)",
+  "animations": [{"type": "line-reveal", "target": "code"}]
+}
+```
+
+Use `content` slides for prose and bullets. Use `code-and-text` only when the prose and code need to be compared side by side. Use image slides only when the image is the point, not decoration.
+
+## Verification
+
+Rendering needs only the Python standard library. The tests additionally need `pytest` and `jsonschema`.
+
+```bash
+# Run the focused tests after changing the generator or schema
+uv run --with pytest --with jsonschema pytest skills/agentic-presentation/tests/ -q
+```
+
+For visual verification, render the demo and open the HTML file in a browser. Check keyboard navigation, the slide counter, and the three MVP animations.
+
+## Related
+
+- [Skills README](../README.md) - Skills system overview

--- a/skills/agentic-presentation/examples/agentic-presentation-demo.json
+++ b/skills/agentic-presentation/examples/agentic-presentation-demo.json
@@ -1,0 +1,79 @@
+{
+  "title": "Agentic Presentations",
+  "metadata": {
+    "author": "gptme agent",
+    "date": "2026-08-13",
+    "theme": {
+      "name": "workbench",
+      "background": "#111418",
+      "surface": "#F7F4EF",
+      "foreground": "#14171A",
+      "muted": "#5E6872",
+      "accent": "#0F766E",
+      "secondary": "#C2410C"
+    }
+  },
+  "slides": [
+    {
+      "id": "intro",
+      "type": "title-slide",
+      "title": "Agentic Presentations",
+      "subtitle": "Structured decks that render as one offline HTML file.",
+      "animations": [
+        {"type": "fade-in", "duration": 500, "delay": 0}
+      ]
+    },
+    {
+      "id": "why-json",
+      "type": "content",
+      "title": "Why a schema first",
+      "body": "Agents are good at structured output when the contract is explicit.",
+      "bullets": [
+        "Decks can be validated before rendering",
+        "The renderer stays small and deterministic",
+        "Future skills can target one stable format"
+      ],
+      "animations": [
+        {"type": "slide-in", "target": "body", "duration": 450, "delay": 80}
+      ]
+    },
+    {
+      "id": "code",
+      "type": "code-reveal",
+      "title": "Generator shape",
+      "language": "python",
+      "code": "deck = load_presentation(path)\nhtml = render_html(deck)\noutput.write_text(html)",
+      "animations": [
+        {"type": "line-reveal", "target": "code", "duration": 220, "stagger": 90}
+      ]
+    },
+    {
+      "id": "deployment",
+      "type": "content",
+      "title": "Deployment boundary",
+      "body": "The generated output has no build step and no runtime network dependency.",
+      "bullets": [
+        "Open the file locally",
+        "Drop it on GitHub Pages or Vercel",
+        "Archive it as a durable artifact"
+      ],
+      "animations": [
+        {"type": "fade-in", "target": "body", "duration": 350, "delay": 0}
+      ]
+    },
+    {
+      "id": "next",
+      "type": "content",
+      "title": "Next increment",
+      "body": "After the MVP proves rendering, the agent skill can generate decks from notes.",
+      "bullets": [
+        "Markdown-to-JSON planning",
+        "Browser visual checks",
+        "Optional code playgrounds in Phase 2"
+      ],
+      "animations": [
+        {"type": "slide-in", "duration": 450, "delay": 0}
+      ]
+    }
+  ]
+}

--- a/skills/agentic-presentation/generate_presentation_html.py
+++ b/skills/agentic-presentation/generate_presentation_html.py
@@ -85,13 +85,16 @@ def validate_presentation(deck: Any) -> None:
             raise ValueError(f"unsupported slide type for {slide_id}: {slide_type}")
         if not isinstance(slide.get("title"), str) or not slide["title"].strip():
             raise ValueError(f"slide {slide_id} must include title")
-        if slide_type == "code-reveal" and "code" not in slide:
-            raise ValueError(f"slide {slide_id} of type code-reveal requires code")
+        if slide_type == "code-reveal" and not isinstance(slide.get("code"), str):
+            raise ValueError(
+                f"slide {slide_id} of type code-reveal requires code as a string"
+            )
         if slide_type == "code-and-text" and (
-            "code" not in slide or "body" not in slide
+            not isinstance(slide.get("code"), str)
+            or not isinstance(slide.get("body"), str)
         ):
             raise ValueError(
-                f"slide {slide_id} of type code-and-text requires body and code"
+                f"slide {slide_id} of type code-and-text requires body and code as strings"
             )
         if slide_type in ("content", "code-and-text"):
             bullets = slide.get("bullets")
@@ -117,6 +120,13 @@ def validate_presentation(deck: Any) -> None:
                 raise ValueError(
                     f"slide {slide_id} has unsupported animation: {animation_type}"
                 )
+            for field in ("duration", "delay", "stagger"):
+                if field in animation and (
+                    not isinstance(animation[field], int) or animation[field] < 0
+                ):
+                    raise ValueError(
+                        f"slide {slide_id} animation {field} must be a non-negative integer"
+                    )
 
 
 def render_html(deck: dict[str, Any]) -> str:

--- a/skills/agentic-presentation/generate_presentation_html.py
+++ b/skills/agentic-presentation/generate_presentation_html.py
@@ -72,6 +72,10 @@ def validate_presentation(deck: Any) -> None:
         slide_id = slide.get("id")
         if not isinstance(slide_id, str) or not slide_id:
             raise ValueError(f"slide {index} must include id")
+        if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]*", slide_id):
+            raise ValueError(
+                f"slide {index} id {slide_id!r} must match ^[A-Za-z0-9][A-Za-z0-9_-]*$"
+            )
         if slide_id in seen_ids:
             raise ValueError(f"duplicate slide id: {slide_id}")
         seen_ids.add(slide_id)
@@ -235,7 +239,8 @@ def _render_gallery(images: list[dict[str, Any]]) -> str:
 
 
 def _animation_payload(slide: dict[str, Any]) -> str:
-    animations = slide.get("animations") or [{"type": "fade-in", "duration": 350}]
+    anims = slide.get("animations")
+    animations = anims if anims is not None else [{"type": "fade-in", "duration": 350}]
     return _attr(json.dumps(animations, separators=(",", ":")))
 
 
@@ -452,9 +457,9 @@ def _javascript() -> str:
       animations.forEach((animation) => {
         const target = selectedTarget(slide, animation.target);
         target.classList.add(`animate-${animation.type}`);
-        target.style.setProperty('--duration', `${animation.duration || 450}ms`);
-        target.style.setProperty('--delay', `${animation.delay || 0}ms`);
-        target.style.setProperty('--stagger', `${animation.stagger || 80}ms`);
+        target.style.setProperty('--duration', `${animation.duration ?? 450}ms`);
+        target.style.setProperty('--delay', `${animation.delay ?? 0}ms`);
+        target.style.setProperty('--stagger', `${animation.stagger ?? 80}ms`);
       });
       requestAnimationFrame(() => {
         animations.forEach((animation) => {
@@ -475,8 +480,14 @@ def _javascript() -> str:
     document.querySelector('#prev').addEventListener('click', () => showSlide(current - 1));
     document.querySelector('#next').addEventListener('click', () => showSlide(current + 1));
     document.addEventListener('keydown', (event) => {
-      if (event.key === 'ArrowLeft') showSlide(current - 1);
-      if (event.key === 'ArrowRight' || event.key === ' ' || event.key === 'Enter') showSlide(current + 1);
+      if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        showSlide(current - 1);
+      }
+      if (event.key === 'ArrowRight' || event.key === ' ' || event.key === 'Enter') {
+        event.preventDefault();
+        showSlide(current + 1);
+      }
     });
     showSlide(0);"""
 

--- a/skills/agentic-presentation/generate_presentation_html.py
+++ b/skills/agentic-presentation/generate_presentation_html.py
@@ -1,0 +1,513 @@
+#!/usr/bin/env python3
+"""Generate a self-contained HTML slide deck from presentation JSON."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+from pathlib import Path
+from typing import Any, cast
+
+SUPPORTED_SLIDE_TYPES = {
+    "title-slide",
+    "content",
+    "code-reveal",
+    "code-and-text",
+    "image",
+    "gallery",
+}
+SUPPORTED_ANIMATION_TYPES = {
+    "fade-in",
+    "slide-in",
+    "line-reveal",
+    "line-by-line-reveal",
+    "zoom",
+    "spin",
+}
+DEFAULT_THEME = {
+    "background": "#111418",
+    "surface": "#F7F4EF",
+    "foreground": "#14171A",
+    "muted": "#5E6872",
+    "accent": "#0F766E",
+    "secondary": "#C2410C",
+}
+
+
+def load_presentation(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        data = json.load(handle)
+    validate_presentation(data)
+    return cast(dict[str, Any], data)
+
+
+def validate_presentation(deck: dict[str, Any]) -> None:
+    if not isinstance(deck.get("title"), str) or not deck["title"].strip():
+        raise ValueError("presentation must include a non-empty title")
+
+    slides = deck.get("slides")
+    if not isinstance(slides, list) or not slides:
+        raise ValueError("presentation must include at least one slide")
+
+    seen_ids: set[str] = set()
+    for index, slide in enumerate(slides, start=1):
+        if not isinstance(slide, dict):
+            raise ValueError(f"slide {index} must be an object")
+        slide_id = slide.get("id")
+        if not isinstance(slide_id, str) or not slide_id:
+            raise ValueError(f"slide {index} must include id")
+        if slide_id in seen_ids:
+            raise ValueError(f"duplicate slide id: {slide_id}")
+        seen_ids.add(slide_id)
+
+        slide_type = slide.get("type")
+        if slide_type not in SUPPORTED_SLIDE_TYPES:
+            raise ValueError(f"unsupported slide type for {slide_id}: {slide_type}")
+        if not isinstance(slide.get("title"), str) or not slide["title"].strip():
+            raise ValueError(f"slide {slide_id} must include title")
+        if slide_type == "code-reveal" and "code" not in slide:
+            raise ValueError(f"slide {slide_id} of type code-reveal requires code")
+        if slide_type == "code-and-text" and (
+            "code" not in slide or "body" not in slide
+        ):
+            raise ValueError(
+                f"slide {slide_id} of type code-and-text requires body and code"
+            )
+        if slide_type == "image" and "image" not in slide:
+            raise ValueError(f"slide {slide_id} of type image requires image")
+        if slide_type == "gallery" and "images" not in slide:
+            raise ValueError(f"slide {slide_id} of type gallery requires images")
+
+        for animation in slide.get("animations", []):
+            animation_type = (
+                animation.get("type") if isinstance(animation, dict) else None
+            )
+            if animation_type not in SUPPORTED_ANIMATION_TYPES:
+                raise ValueError(
+                    f"slide {slide_id} has unsupported animation: {animation_type}"
+                )
+
+
+def render_html(deck: dict[str, Any]) -> str:
+    theme = _theme(deck)
+    title = _escape(deck["title"])
+    metadata = deck.get("metadata", {})
+    author = _escape(metadata.get("author", ""))
+    date = _escape(metadata.get("date", ""))
+    slides = deck["slides"]
+    rendered_slides = "\n".join(
+        _render_slide(slide, index, len(slides)) for index, slide in enumerate(slides)
+    )
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{title}</title>
+  <style>
+{_css(theme)}
+  </style>
+</head>
+<body>
+  <main class="deck" data-slide-count="{len(slides)}">
+{rendered_slides}
+  </main>
+  <nav class="controls" aria-label="Presentation controls">
+    <button type="button" class="icon-button" id="prev" aria-label="Previous slide">‹</button>
+    <output id="counter" aria-live="polite">1 / {len(slides)}</output>
+    <button type="button" class="icon-button" id="next" aria-label="Next slide">›</button>
+  </nav>
+  <footer class="meta">{author}{" · " if author and date else ""}{date}</footer>
+  <script>
+{_javascript()}
+  </script>
+</body>
+</html>
+"""
+
+
+def _theme(deck: dict[str, Any]) -> dict[str, str]:
+    metadata = deck.get("metadata", {})
+    custom = metadata.get("theme", {}) if isinstance(metadata, dict) else {}
+    return {**DEFAULT_THEME, **{k: v for k, v in custom.items() if k in DEFAULT_THEME}}
+
+
+def _render_slide(slide: dict[str, Any], index: int, total: int) -> str:
+    slide_type = slide["type"]
+    title = _escape(slide["title"])
+    subtitle = _escape(slide.get("subtitle", ""))
+    active_class = " active" if index == 0 else ""
+    animations = _animation_payload(slide)
+    content = _render_slide_content(slide)
+
+    return f"""    <section class="slide slide-{slide_type}{active_class}" id="{_attr(slide["id"])}" data-index="{index}" data-animations='{animations}' aria-label="Slide {index + 1} of {total}">
+      <div class="slide-inner">
+        <p class="kicker">{index + 1:02d} / {total:02d}</p>
+        <h1 data-role="title">{title}</h1>
+        {f'<p class="subtitle" data-role="subtitle">{subtitle}</p>' if subtitle else ""}
+        {content}
+      </div>
+    </section>"""
+
+
+def _render_slide_content(slide: dict[str, Any]) -> str:
+    slide_type = slide["type"]
+    if slide_type == "title-slide":
+        return ""
+    if slide_type == "content":
+        return _render_body_and_bullets(slide)
+    if slide_type == "code-reveal":
+        return _render_code(slide)
+    if slide_type == "code-and-text":
+        return f"""<div class="split">
+          <div>{_render_body_and_bullets(slide)}</div>
+          {_render_code(slide)}
+        </div>"""
+    if slide_type == "image":
+        return _render_image(slide["image"])
+    if slide_type == "gallery":
+        return _render_gallery(slide.get("images", []))
+    raise ValueError(f"unsupported slide type: {slide_type}")
+
+
+def _render_body_and_bullets(slide: dict[str, Any]) -> str:
+    body = _escape(slide.get("body", ""))
+    bullets = slide.get("bullets", [])
+    bullet_html = ""
+    if bullets:
+        items = "\n".join(
+            f'            <li class="reveal-line">{_escape(item)}</li>'
+            for item in bullets
+        )
+        bullet_html = f"""          <ul class="bullets" data-role="body">
+{items}
+          </ul>"""
+    body_html = f'<p class="body" data-role="body">{body}</p>' if body else ""
+    return f"""{body_html}
+{bullet_html}"""
+
+
+def _render_code(slide: dict[str, Any]) -> str:
+    language = _escape(slide.get("language", "text"))
+    lines = str(slide.get("code", "")).splitlines() or [""]
+    rendered = "\n".join(
+        f'<span class="code-line reveal-line" style="--line-index: {index}">{_escape(line)}</span>'
+        for index, line in enumerate(lines)
+    )
+    return f"""<figure class="code-panel" data-role="code">
+          <figcaption>{language}</figcaption>
+          <pre><code>{rendered}</code></pre>
+        </figure>"""
+
+
+def _render_image(image: dict[str, Any]) -> str:
+    caption = _escape(image.get("caption", ""))
+    return f"""<figure class="image-panel" data-role="image">
+          <img src="{_attr(image["src"])}" alt="{_attr(image.get("alt", ""))}">
+          {f"<figcaption>{caption}</figcaption>" if caption else ""}
+        </figure>"""
+
+
+def _render_gallery(images: list[dict[str, Any]]) -> str:
+    rendered = "\n".join(_render_image(image) for image in images)
+    return f'<div class="gallery" data-role="gallery">\n{rendered}\n        </div>'
+
+
+def _animation_payload(slide: dict[str, Any]) -> str:
+    animations = slide.get("animations") or [{"type": "fade-in", "duration": 350}]
+    normalized = []
+    for animation in animations:
+        item = dict(animation)
+        if item.get("type") == "line-by-line-reveal":
+            item["type"] = "line-reveal"
+        normalized.append(item)
+    return _attr(json.dumps(normalized, separators=(",", ":")))
+
+
+def _css(theme: dict[str, str]) -> str:
+    return f"""    :root {{
+      --background: {theme["background"]};
+      --surface: {theme["surface"]};
+      --foreground: {theme["foreground"]};
+      --muted: {theme["muted"]};
+      --accent: {theme["accent"]};
+      --secondary: {theme["secondary"]};
+    }}
+    * {{ box-sizing: border-box; }}
+    body {{
+      margin: 0;
+      min-height: 100vh;
+      overflow: hidden;
+      background: var(--background);
+      color: var(--foreground);
+      font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      letter-spacing: 0;
+    }}
+    .deck {{ min-height: 100vh; position: relative; }}
+    .slide {{
+      display: none;
+      min-height: 100vh;
+      padding: clamp(1.5rem, 4vw, 4rem);
+      place-items: center;
+    }}
+    .slide.active {{ display: grid; }}
+    .slide-inner {{
+      width: min(1080px, 100%);
+      min-height: min(680px, calc(100vh - 9rem));
+      display: grid;
+      align-content: center;
+      gap: 1.25rem;
+      padding: clamp(1.25rem, 4vw, 3rem);
+      background: var(--surface);
+      border: 1px solid color-mix(in srgb, var(--foreground) 14%, transparent);
+      border-radius: 8px;
+      box-shadow: 0 24px 80px rgba(0, 0, 0, 0.28);
+    }}
+    .kicker {{
+      margin: 0;
+      color: var(--accent);
+      font-size: 0.8rem;
+      font-weight: 700;
+      text-transform: uppercase;
+    }}
+    h1 {{
+      margin: 0;
+      max-width: 14ch;
+      font-size: clamp(2.8rem, 8vw, 5.8rem);
+      line-height: 0.98;
+      letter-spacing: 0;
+    }}
+    .slide-content h1, .slide-code-reveal h1, .slide-code-and-text h1,
+    .slide-image h1, .slide-gallery h1 {{
+      font-size: clamp(2rem, 5vw, 4rem);
+      max-width: 18ch;
+    }}
+    .subtitle, .body {{
+      max-width: 70ch;
+      margin: 0;
+      color: var(--muted);
+      font-size: clamp(1.05rem, 2.4vw, 1.55rem);
+      line-height: 1.5;
+    }}
+    .bullets {{
+      display: grid;
+      gap: 0.7rem;
+      margin: 0;
+      padding-left: 1.4rem;
+      color: var(--foreground);
+      font-size: clamp(1rem, 2vw, 1.35rem);
+      line-height: 1.45;
+    }}
+    .split {{
+      display: grid;
+      grid-template-columns: minmax(0, 0.9fr) minmax(280px, 1.1fr);
+      gap: clamp(1rem, 4vw, 2.5rem);
+      align-items: start;
+    }}
+    .code-panel {{
+      margin: 0;
+      width: 100%;
+      overflow: hidden;
+      border-radius: 8px;
+      background: #15191E;
+      color: #F3F5F7;
+      border: 1px solid rgba(255, 255, 255, 0.12);
+    }}
+    .code-panel figcaption {{
+      padding: 0.7rem 1rem;
+      color: #A7B0BA;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+      font-size: 0.82rem;
+    }}
+    pre {{
+      margin: 0;
+      padding: 1rem;
+      overflow: auto;
+      font: 0.95rem/1.55 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    }}
+    .code-line {{ display: block; white-space: pre; }}
+    .image-panel {{ margin: 0; }}
+    .image-panel img {{
+      display: block;
+      width: 100%;
+      max-height: 58vh;
+      object-fit: contain;
+      border-radius: 8px;
+    }}
+    figcaption {{ color: var(--muted); margin-top: 0.5rem; }}
+    .gallery {{
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 1rem;
+    }}
+    .controls {{
+      position: fixed;
+      left: 50%;
+      bottom: 1.5rem;
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      transform: translateX(-50%);
+      color: var(--surface);
+    }}
+    .icon-button {{
+      width: 2.5rem;
+      height: 2.5rem;
+      border: 1px solid rgba(255, 255, 255, 0.35);
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.12);
+      color: var(--surface);
+      font-size: 1.5rem;
+      cursor: pointer;
+    }}
+    .icon-button:focus-visible {{ outline: 3px solid var(--secondary); }}
+    #counter {{
+      min-width: 4.5rem;
+      text-align: center;
+      font-variant-numeric: tabular-nums;
+    }}
+    .meta {{
+      position: fixed;
+      right: 1.5rem;
+      bottom: 1.9rem;
+      color: rgba(255, 255, 255, 0.62);
+      font-size: 0.82rem;
+    }}
+    .animate-fade-in {{ opacity: 0; }}
+    .animate-fade-in.is-visible {{
+      opacity: 1;
+      transition: opacity var(--duration, 450ms) ease var(--delay, 0ms);
+    }}
+    .animate-slide-in {{ opacity: 0; transform: translateY(1rem); }}
+    .animate-slide-in.is-visible {{
+      opacity: 1;
+      transform: translateY(0);
+      transition:
+        opacity var(--duration, 450ms) ease var(--delay, 0ms),
+        transform var(--duration, 450ms) ease var(--delay, 0ms);
+    }}
+    .animate-line-reveal .reveal-line {{
+      opacity: 0;
+      transform: translateY(0.35rem);
+    }}
+    .animate-line-reveal.is-visible .reveal-line {{
+      opacity: 1;
+      transform: translateY(0);
+      transition:
+        opacity var(--duration, 220ms) ease calc(var(--delay, 0ms) + (var(--line-index, 0) * var(--stagger, 80ms))),
+        transform var(--duration, 220ms) ease calc(var(--delay, 0ms) + (var(--line-index, 0) * var(--stagger, 80ms)));
+    }}
+    .animate-zoom {{ opacity: 0; transform: scale(0.96); }}
+    .animate-zoom.is-visible {{
+      opacity: 1;
+      transform: scale(1);
+      transition:
+        opacity var(--duration, 450ms) ease var(--delay, 0ms),
+        transform var(--duration, 450ms) ease var(--delay, 0ms);
+    }}
+    .animate-spin {{ transform: rotate(-2deg); }}
+    .animate-spin.is-visible {{
+      transform: rotate(0);
+      transition: transform var(--duration, 450ms) ease var(--delay, 0ms);
+    }}
+    @media (max-width: 760px) {{
+      .slide {{ padding: 1rem; }}
+      .slide-inner {{ min-height: calc(100vh - 7rem); }}
+      .split {{ grid-template-columns: 1fr; }}
+      .meta {{ display: none; }}
+      .controls {{ bottom: 0.85rem; }}
+    }}"""
+
+
+def _javascript() -> str:
+    return """    const slides = Array.from(document.querySelectorAll('.slide'));
+    const counter = document.querySelector('#counter');
+    let current = 0;
+
+    function selectedTarget(slide, target) {
+      if (!target) return slide.querySelector('.slide-inner');
+      return slide.querySelector(`[data-role="${target}"]`) || slide.querySelector('.slide-inner');
+    }
+
+    function prepareAnimations(slide) {
+      const animations = JSON.parse(slide.dataset.animations || '[]');
+      slide.querySelectorAll('[class*="animate-"]').forEach((node) => {
+        node.classList.remove('animate-fade-in', 'animate-slide-in', 'animate-line-reveal', 'animate-zoom', 'animate-spin', 'is-visible');
+      });
+      animations.forEach((animation) => {
+        const target = selectedTarget(slide, animation.target);
+        target.classList.add(`animate-${animation.type}`);
+        target.style.setProperty('--duration', `${animation.duration || 450}ms`);
+        target.style.setProperty('--delay', `${animation.delay || 0}ms`);
+        target.style.setProperty('--stagger', `${animation.stagger || 80}ms`);
+      });
+      requestAnimationFrame(() => {
+        animations.forEach((animation) => {
+          selectedTarget(slide, animation.target).classList.add('is-visible');
+        });
+      });
+    }
+
+    function showSlide(index) {
+      current = (index + slides.length) % slides.length;
+      slides.forEach((slide, slideIndex) => {
+        slide.classList.toggle('active', slideIndex === current);
+      });
+      counter.value = `${current + 1} / ${slides.length}`;
+      prepareAnimations(slides[current]);
+    }
+
+    document.querySelector('#prev').addEventListener('click', () => showSlide(current - 1));
+    document.querySelector('#next').addEventListener('click', () => showSlide(current + 1));
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'ArrowLeft') showSlide(current - 1);
+      if (event.key === 'ArrowRight' || event.key === ' ' || event.key === 'Enter') showSlide(current + 1);
+    });
+    showSlide(0);"""
+
+
+def _escape(value: Any) -> str:
+    return html.escape(str(value), quote=False)
+
+
+def _attr(value: Any) -> str:
+    return html.escape(str(value), quote=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=Path, help="presentation JSON file")
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=Path("index.html"),
+        help="output HTML path (default: index.html)",
+    )
+    parser.add_argument(
+        "--max-kb",
+        type=int,
+        default=500,
+        help="fail if generated HTML exceeds this size (default: 500)",
+    )
+    args = parser.parse_args(argv)
+
+    deck = load_presentation(args.input)
+    output = render_html(deck)
+    encoded = output.encode("utf-8")
+    limit = args.max_kb * 1024
+    if len(encoded) > limit:
+        raise SystemExit(
+            f"generated HTML is {len(encoded)} bytes, above {args.max_kb}KB limit"
+        )
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(output, encoding="utf-8")
+    print(f"wrote {args.output} ({len(encoded)} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/agentic-presentation/generate_presentation_html.py
+++ b/skills/agentic-presentation/generate_presentation_html.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import html
 import json
+import re
 from pathlib import Path
 from typing import Any, cast
 
@@ -21,7 +22,6 @@ SUPPORTED_ANIMATION_TYPES = {
     "fade-in",
     "slide-in",
     "line-reveal",
-    "line-by-line-reveal",
     "zoom",
     "spin",
 }
@@ -42,9 +42,24 @@ def load_presentation(path: Path) -> dict[str, Any]:
     return cast(dict[str, Any], data)
 
 
-def validate_presentation(deck: dict[str, Any]) -> None:
+def validate_presentation(deck: Any) -> None:
+    if not isinstance(deck, dict):
+        raise ValueError("presentation must be an object")
     if not isinstance(deck.get("title"), str) or not deck["title"].strip():
         raise ValueError("presentation must include a non-empty title")
+
+    metadata = deck.get("metadata", {})
+    if not isinstance(metadata, dict):
+        raise ValueError("presentation metadata must be an object")
+    theme = metadata.get("theme", {})
+    if not isinstance(theme, dict):
+        raise ValueError("presentation theme must be an object")
+    for name, value in theme.items():
+        if name in DEFAULT_THEME and (
+            not isinstance(value, str)
+            or re.fullmatch(r"#[0-9A-Fa-f]{6}", value) is None
+        ):
+            raise ValueError(f"theme {name} must be a six-digit hex color")
 
     slides = deck.get("slides")
     if not isinstance(slides, list) or not slides:
@@ -185,7 +200,7 @@ def _render_body_and_bullets(slide: dict[str, Any]) -> str:
             f'            <li class="reveal-line">{_escape(item)}</li>'
             for item in bullets
         )
-        bullet_html = f"""          <ul class="bullets" data-role="body">
+        bullet_html = f"""          <ul class="bullets" data-role="bullets">
 {items}
           </ul>"""
     body_html = f'<p class="body" data-role="body">{body}</p>' if body else ""
@@ -221,13 +236,7 @@ def _render_gallery(images: list[dict[str, Any]]) -> str:
 
 def _animation_payload(slide: dict[str, Any]) -> str:
     animations = slide.get("animations") or [{"type": "fade-in", "duration": 350}]
-    normalized = []
-    for animation in animations:
-        item = dict(animation)
-        if item.get("type") == "line-by-line-reveal":
-            item["type"] = "line-reveal"
-        normalized.append(item)
-    return _attr(json.dumps(normalized, separators=(",", ":")))
+    return _attr(json.dumps(animations, separators=(",", ":")))
 
 
 def _css(theme: dict[str, str]) -> str:

--- a/skills/agentic-presentation/generate_presentation_html.py
+++ b/skills/agentic-presentation/generate_presentation_html.py
@@ -93,6 +93,10 @@ def validate_presentation(deck: Any) -> None:
             raise ValueError(
                 f"slide {slide_id} of type code-and-text requires body and code"
             )
+        if slide_type in ("content", "code-and-text"):
+            bullets = slide.get("bullets")
+            if bullets is not None and not isinstance(bullets, list):
+                raise ValueError(f"slide {slide_id} bullets must be an array")
         if slide_type == "image":
             _validate_image(slide.get("image"), f"slide {slide_id} image")
         if slide_type == "gallery":
@@ -102,7 +106,10 @@ def validate_presentation(deck: Any) -> None:
             for image_index, image in enumerate(images, start=1):
                 _validate_image(image, f"slide {slide_id} image {image_index}")
 
-        for animation in slide.get("animations", []):
+        anims = slide.get("animations")
+        if anims is not None and not isinstance(anims, list):
+            raise ValueError(f"slide {slide_id} animations must be an array")
+        for animation in anims or []:
             animation_type = (
                 animation.get("type") if isinstance(animation, dict) else None
             )

--- a/skills/agentic-presentation/generate_presentation_html.py
+++ b/skills/agentic-presentation/generate_presentation_html.py
@@ -7,6 +7,7 @@ import argparse
 import html
 import json
 import re
+import urllib.parse
 from pathlib import Path
 from typing import Any, cast
 
@@ -509,11 +510,20 @@ def _javascript() -> str:
     showSlide(0);"""
 
 
+_SAFE_URL_SCHEMES = {"", "http", "https"}
+
+
 def _validate_image(image: Any, context: str) -> None:
     if not isinstance(image, dict):
         raise ValueError(f"{context} must be an object")
     if not isinstance(image.get("src"), str) or not image["src"]:
         raise ValueError(f"{context} must include src")
+    scheme = urllib.parse.urlparse(image["src"]).scheme.lower()
+    if scheme not in _SAFE_URL_SCHEMES:
+        raise ValueError(
+            f"{context} src has unsafe scheme '{scheme}'"
+            " — only http/https and relative URLs are allowed"
+        )
     if not isinstance(image.get("alt"), str):
         raise ValueError(f"{context} must include alt")
 

--- a/skills/agentic-presentation/generate_presentation_html.py
+++ b/skills/agentic-presentation/generate_presentation_html.py
@@ -74,10 +74,14 @@ def validate_presentation(deck: dict[str, Any]) -> None:
             raise ValueError(
                 f"slide {slide_id} of type code-and-text requires body and code"
             )
-        if slide_type == "image" and "image" not in slide:
-            raise ValueError(f"slide {slide_id} of type image requires image")
-        if slide_type == "gallery" and "images" not in slide:
-            raise ValueError(f"slide {slide_id} of type gallery requires images")
+        if slide_type == "image":
+            _validate_image(slide.get("image"), f"slide {slide_id} image")
+        if slide_type == "gallery":
+            images = slide.get("images")
+            if not isinstance(images, list):
+                raise ValueError(f"slide {slide_id} images must be an array")
+            for image_index, image in enumerate(images, start=1):
+                _validate_image(image, f"slide {slide_id} image {image_index}")
 
         for animation in slide.get("animations", []):
             animation_type = (
@@ -428,7 +432,7 @@ def _javascript() -> str:
 
     function selectedTarget(slide, target) {
       if (!target) return slide.querySelector('.slide-inner');
-      return slide.querySelector(`[data-role="${target}"]`) || slide.querySelector('.slide-inner');
+      return slide.querySelector(`[data-role="${CSS.escape(target)}"]`) || slide.querySelector('.slide-inner');
     }
 
     function prepareAnimations(slide) {
@@ -466,6 +470,15 @@ def _javascript() -> str:
       if (event.key === 'ArrowRight' || event.key === ' ' || event.key === 'Enter') showSlide(current + 1);
     });
     showSlide(0);"""
+
+
+def _validate_image(image: Any, context: str) -> None:
+    if not isinstance(image, dict):
+        raise ValueError(f"{context} must be an object")
+    if not isinstance(image.get("src"), str) or not image["src"]:
+        raise ValueError(f"{context} must include src")
+    if not isinstance(image.get("alt"), str):
+        raise ValueError(f"{context} must include alt")
 
 
 def _escape(value: Any) -> str:

--- a/skills/agentic-presentation/present.py
+++ b/skills/agentic-presentation/present.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""One-liner: render a presentation deck and optionally open it in a browser.
+
+Usage:
+    python3 skills/agentic-presentation/present.py deck.json
+    python3 skills/agentic-presentation/present.py deck.json --live
+    python3 skills/agentic-presentation/present.py deck.json -o slides.html --live
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("input", type=Path, help="presentation JSON file")
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        help="output HTML path (default: temp file when --live, else index.html)",
+    )
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help="open rendered deck in the default browser",
+    )
+    parser.add_argument(
+        "--max-kb",
+        type=int,
+        default=500,
+        help="fail if generated HTML exceeds this many KB (default: 500)",
+    )
+    args = parser.parse_args(argv)
+
+    skill_dir = Path(__file__).parent
+    generator = skill_dir / "generate_presentation_html.py"
+
+    if args.live and not args.output:
+        tmp_dir = Path(tempfile.mkdtemp())
+        output = tmp_dir / f"{args.input.stem}.html"
+    else:
+        output = args.output or Path("index.html")
+
+    cmd = [
+        sys.executable,
+        str(generator),
+        str(args.input),
+        "-o",
+        str(output),
+        "--max-kb",
+        str(args.max_kb),
+    ]
+    result = subprocess.run(cmd, check=False)
+    if result.returncode != 0:
+        return result.returncode
+
+    if args.live:
+        _open_browser(output)
+
+    return 0
+
+
+def _open_browser(path: Path) -> None:
+    for cmd in ("xdg-open", "open"):
+        if shutil.which(cmd):
+            subprocess.run([cmd, str(path)], check=False)
+            return
+    print(f"[present] browser not found — open manually: {path}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/agentic-presentation/present.py
+++ b/skills/agentic-presentation/present.py
@@ -13,7 +13,6 @@ import argparse
 import shutil
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
 
 
@@ -27,7 +26,7 @@ def main(argv: list[str] | None = None) -> int:
         "-o",
         "--output",
         type=Path,
-        help="output HTML path (default: temp file when --live, else index.html)",
+        help="output HTML path (default: index.html)",
     )
     parser.add_argument(
         "--live",
@@ -45,11 +44,7 @@ def main(argv: list[str] | None = None) -> int:
     skill_dir = Path(__file__).parent
     generator = skill_dir / "generate_presentation_html.py"
 
-    if args.live and not args.output:
-        tmp_dir = Path(tempfile.mkdtemp())
-        output = tmp_dir / f"{args.input.stem}.html"
-    else:
-        output = args.output or Path("index.html")
+    output = args.output or Path("index.html")
 
     cmd = [
         sys.executable,

--- a/skills/agentic-presentation/presentation.schema.json
+++ b/skills/agentic-presentation/presentation.schema.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/gptme/gptme-contrib/master/skills/agentic-presentation/presentation.schema.json",
+  "title": "Agentic Presentation v1",
+  "description": "Structured slide-deck format for the agentic-presentation single-file HTML generator.",
+  "type": "object",
+  "required": ["title", "slides"],
+  "additionalProperties": false,
+  "properties": {
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "author": {"type": "string"},
+        "date": {"type": "string"},
+        "theme": {"$ref": "#/definitions/theme"}
+      }
+    },
+    "slides": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/definitions/slide"}
+    }
+  },
+  "definitions": {
+    "theme": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {"type": "string"},
+        "background": {"type": "string", "pattern": "^#[0-9A-Fa-f]{6}$"},
+        "surface": {"type": "string", "pattern": "^#[0-9A-Fa-f]{6}$"},
+        "foreground": {"type": "string", "pattern": "^#[0-9A-Fa-f]{6}$"},
+        "muted": {"type": "string", "pattern": "^#[0-9A-Fa-f]{6}$"},
+        "accent": {"type": "string", "pattern": "^#[0-9A-Fa-f]{6}$"},
+        "secondary": {"type": "string", "pattern": "^#[0-9A-Fa-f]{6}$"}
+      }
+    },
+    "animation": {
+      "type": "object",
+      "required": ["type"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["fade-in", "slide-in", "line-reveal", "zoom", "spin"]
+        },
+        "target": {
+          "type": "string",
+          "description": "Optional element role to animate, for example title, body, code, image, or gallery."
+        },
+        "duration": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 450
+        },
+        "delay": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0
+        },
+        "stagger": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 80
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": ["src", "alt"],
+      "additionalProperties": false,
+      "properties": {
+        "src": {"type": "string", "minLength": 1},
+        "alt": {"type": "string"},
+        "caption": {"type": "string"}
+      }
+    },
+    "slide": {
+      "type": "object",
+      "required": ["id", "type", "title"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["title-slide", "content", "code-reveal", "code-and-text", "image", "gallery"]
+        },
+        "title": {"type": "string", "minLength": 1},
+        "subtitle": {"type": "string"},
+        "body": {"type": "string"},
+        "bullets": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "code": {"type": "string"},
+        "language": {"type": "string"},
+        "image": {"$ref": "#/definitions/image"},
+        "images": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/image"}
+        },
+        "animations": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/animation"}
+        },
+        "notes": {
+          "type": "string",
+          "description": "Speaker notes for agents and humans; not rendered by default."
+        }
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"type": {"const": "code-reveal"}}},
+          "then": {"required": ["code"]}
+        },
+        {
+          "if": {"properties": {"type": {"const": "code-and-text"}}},
+          "then": {"required": ["body", "code"]}
+        },
+        {
+          "if": {"properties": {"type": {"const": "image"}}},
+          "then": {"required": ["image"]}
+        },
+        {
+          "if": {"properties": {"type": {"const": "gallery"}}},
+          "then": {"required": ["images"]}
+        }
+      ]
+    }
+  }
+}

--- a/skills/agentic-presentation/tests/test_generate_presentation_html.py
+++ b/skills/agentic-presentation/tests/test_generate_presentation_html.py
@@ -167,6 +167,44 @@ def test_validate_presentation_rejects_malformed_images(
         generator.validate_presentation(deck)
 
 
+@pytest.mark.parametrize(
+    "src",
+    [
+        "javascript:alert(1)",
+        "JAVASCRIPT:alert(1)",
+        "data:text/html,<script>alert(1)</script>",
+        "vbscript:msgbox(1)",
+    ],
+)
+def test_validate_image_rejects_unsafe_src_scheme(src: str):
+    deck = _sample_deck()
+    deck["slides"][1] = {
+        "id": "media",
+        "type": "image",
+        "title": "Media",
+        "image": {"src": src, "alt": ""},
+    }
+    with pytest.raises(ValueError, match="unsafe scheme"):
+        generator.validate_presentation(deck)
+
+
+def test_validate_image_allows_safe_src_schemes():
+    deck = _sample_deck()
+    for src in (
+        "https://example.com/img.png",
+        "http://example.com/img.png",
+        "/img.png",
+        "./img.png",
+    ):
+        deck["slides"][1] = {
+            "id": "media",
+            "type": "image",
+            "title": "Media",
+            "image": {"src": src, "alt": ""},
+        }
+        generator.validate_presentation(deck)  # must not raise
+
+
 def test_validate_presentation_rejects_duplicate_slide_ids():
     deck = _sample_deck()
     deck["slides"][1]["id"] = "intro"

--- a/skills/agentic-presentation/tests/test_generate_presentation_html.py
+++ b/skills/agentic-presentation/tests/test_generate_presentation_html.py
@@ -134,6 +134,39 @@ def test_generator_keeps_twenty_slide_deck_under_500kb(tmp_path: Path):
     assert output_path.stat().st_size < 500 * 1024
 
 
+def test_animation_target_is_not_interpolated_into_javascript():
+    deck = _sample_deck()
+    deck["slides"][1]["animations"][0]["target"] = 'body"];alert(1)//'
+
+    html = generator.render_html(deck)
+
+    assert 'slide.querySelector(`[data-role="${target}"]`)' not in html
+    assert "CSS.escape(target)" in html
+
+
+@pytest.mark.parametrize(
+    ("slide_type", "field", "value", "message"),
+    [
+        ("image", "image", "not-an-object", "image must be an object"),
+        ("gallery", "images", "not-an-array", "images must be an array"),
+        ("gallery", "images", ["not-an-object"], "image 1 must be an object"),
+    ],
+)
+def test_validate_presentation_rejects_malformed_images(
+    slide_type: str, field: str, value: object, message: str
+):
+    deck = _sample_deck()
+    deck["slides"][1] = {
+        "id": "media",
+        "type": slide_type,
+        "title": "Media",
+        field: value,
+    }
+
+    with pytest.raises(ValueError, match=message):
+        generator.validate_presentation(deck)
+
+
 def test_validate_presentation_rejects_duplicate_slide_ids():
     deck = _sample_deck()
     deck["slides"][1]["id"] = "intro"

--- a/skills/agentic-presentation/tests/test_generate_presentation_html.py
+++ b/skills/agentic-presentation/tests/test_generate_presentation_html.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = SKILL_ROOT / "presentation.schema.json"
+DEMO = SKILL_ROOT / "examples" / "agentic-presentation-demo.json"
+
+sys.path.insert(0, str(SKILL_ROOT))
+
+import generate_presentation_html as generator  # noqa: E402
+
+
+def _sample_deck() -> dict:
+    return {
+        "title": "Example",
+        "metadata": {
+            "author": "Example Author",
+            "date": "2026-08-13",
+            "theme": {"accent": "#0F766E", "secondary": "#C2410C"},
+        },
+        "slides": [
+            {
+                "id": "intro",
+                "type": "title-slide",
+                "title": "Example",
+                "subtitle": "A tiny deck",
+                "animations": [{"type": "fade-in", "duration": 300}],
+            },
+            {
+                "id": "content",
+                "type": "content",
+                "title": "What matters",
+                "body": "Structured input, deterministic output.",
+                "bullets": ["Validates first", "Renders offline"],
+                "animations": [{"type": "slide-in", "target": "body"}],
+            },
+            {
+                "id": "code",
+                "type": "code-reveal",
+                "title": "Code reveal",
+                "language": "python",
+                "code": "print('hello')\nprint('world')",
+                "animations": [{"type": "line-reveal", "target": "code"}],
+            },
+        ],
+    }
+
+
+def test_schema_accepts_sample_and_demo_decks():
+    # Rendering needs only the stdlib; the schema tests need jsonschema.
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = json.loads(SCHEMA.read_text())
+
+    jsonschema.validate(_sample_deck(), schema)
+    jsonschema.validate(json.loads(DEMO.read_text()), schema)
+
+
+def test_schema_rejects_code_reveal_without_code():
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = json.loads(SCHEMA.read_text())
+    deck = _sample_deck()
+    del deck["slides"][2]["code"]
+
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(deck, schema)
+
+
+def test_render_html_is_self_contained_and_escapes_content():
+    deck = _sample_deck()
+    deck["slides"][1]["body"] = "<script>alert(1)</script>"
+
+    html = generator.render_html(deck)
+
+    assert "<!DOCTYPE html>" in html
+    assert "stylesheet" not in html
+    assert "https://cdn" not in html
+    assert "<script>alert(1)</script>" not in html
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html
+    assert "function showSlide" in html
+
+
+def test_render_html_includes_three_mvp_animation_primitives():
+    html = generator.render_html(_sample_deck())
+
+    assert "animate-fade-in" in html
+    assert "animate-slide-in" in html
+    assert "animate-line-reveal" in html
+    assert "requestAnimationFrame" in html
+    assert "data-animations=" in html
+
+
+def test_generator_writes_single_file_under_500kb(tmp_path: Path):
+    input_path = tmp_path / "deck.json"
+    output_path = tmp_path / "deck.html"
+    input_path.write_text(json.dumps(_sample_deck()), encoding="utf-8")
+
+    assert (
+        generator.main([str(input_path), "-o", str(output_path), "--max-kb", "500"])
+        == 0
+    )
+
+    output = output_path.read_text(encoding="utf-8")
+    assert output_path.stat().st_size < 500 * 1024
+    assert "<style>" in output
+    assert "<script>" in output
+    assert output.count('<section class="slide') == 3
+
+
+def test_generator_keeps_twenty_slide_deck_under_500kb(tmp_path: Path):
+    deck = _sample_deck()
+    content_slide = deck["slides"][1]
+    deck["slides"] = [
+        {
+            **content_slide,
+            "id": f"slide-{index:02d}",
+            "title": f"Slide {index:02d}",
+        }
+        for index in range(20)
+    ]
+    input_path = tmp_path / "twenty.json"
+    output_path = tmp_path / "twenty.html"
+    input_path.write_text(json.dumps(deck), encoding="utf-8")
+
+    assert (
+        generator.main([str(input_path), "-o", str(output_path), "--max-kb", "500"])
+        == 0
+    )
+
+    assert output_path.stat().st_size < 500 * 1024
+
+
+def test_validate_presentation_rejects_duplicate_slide_ids():
+    deck = _sample_deck()
+    deck["slides"][1]["id"] = "intro"
+
+    with pytest.raises(ValueError, match="duplicate slide id"):
+        generator.validate_presentation(deck)

--- a/skills/agentic-presentation/tests/test_generate_presentation_html.py
+++ b/skills/agentic-presentation/tests/test_generate_presentation_html.py
@@ -173,3 +173,30 @@ def test_validate_presentation_rejects_duplicate_slide_ids():
 
     with pytest.raises(ValueError, match="duplicate slide id"):
         generator.validate_presentation(deck)
+
+
+def test_validate_presentation_rejects_non_object_deck():
+    with pytest.raises(ValueError, match="presentation must be an object"):
+        generator.validate_presentation([])
+
+
+def test_validate_presentation_rejects_unsafe_theme_color():
+    deck = _sample_deck()
+    deck["metadata"]["theme"]["accent"] = "red; } body { display: none"
+
+    with pytest.raises(ValueError, match="theme accent must be a six-digit hex color"):
+        generator.validate_presentation(deck)
+
+
+def test_content_body_and_bullets_have_distinct_animation_targets():
+    html = generator.render_html(_sample_deck())
+
+    assert html.count('data-role="body"') == 1
+    assert 'data-role="bullets"' in html
+
+
+def test_runtime_animation_types_match_schema():
+    schema = json.loads(SCHEMA.read_text())
+    schema_types = set(schema["definitions"]["animation"]["properties"]["type"]["enum"])
+
+    assert generator.SUPPORTED_ANIMATION_TYPES == schema_types

--- a/skills/agentic-presentation/tests/test_generate_presentation_html.py
+++ b/skills/agentic-presentation/tests/test_generate_presentation_html.py
@@ -278,3 +278,55 @@ def test_validate_presentation_rejects_non_list_bullets():
         deck["slides"][1]["bullets"] = bad_value
         with pytest.raises(ValueError, match="bullets must be an array"):
             generator.validate_presentation(deck)
+
+
+def _cat_deck(code: object = "print('hello')", body: object = "Explanation.") -> dict:
+    """Return a minimal deck whose last slide is a code-and-text slide."""
+    deck = _sample_deck()
+    deck["slides"][2] = {
+        "id": "cat",
+        "type": "code-and-text",
+        "title": "Side by side",
+        "code": code,
+        "body": body,
+    }
+    return deck
+
+
+def test_validate_presentation_rejects_non_string_code_fields():
+    # code-reveal: code must be a string, not a number or dict.
+    for reveal_bad in (123, {"lines": ["a", "b"]}, None):
+        deck = _sample_deck()
+        deck["slides"][2]["code"] = reveal_bad  # slide 2 is code-reveal
+        with pytest.raises(ValueError, match="requires code as a string"):
+            generator.validate_presentation(deck)
+
+    # code-and-text: valid baseline must not raise.
+    generator.validate_presentation(_cat_deck())
+
+    # code-and-text: non-string code must raise.
+    for cat_bad_code in (42, None, ["line1"]):
+        with pytest.raises(ValueError, match="requires body and code as strings"):
+            generator.validate_presentation(_cat_deck(code=cat_bad_code))
+
+    # code-and-text: non-string body must raise.
+    for cat_bad_body in (42, None, {"text": "x"}):
+        with pytest.raises(ValueError, match="requires body and code as strings"):
+            generator.validate_presentation(_cat_deck(body=cat_bad_body))
+
+
+def test_validate_presentation_rejects_non_integer_animation_timing():
+    # duration, delay, stagger must be non-negative integers per the schema.
+    for field in ("duration", "delay", "stagger"):
+        for bad_val in ("1; } body { display: none; }", -1, 1.5, [450]):
+            deck = _sample_deck()
+            deck["slides"][0]["animations"][0][field] = bad_val
+            with pytest.raises(
+                ValueError, match=f"{field} must be a non-negative integer"
+            ):
+                generator.validate_presentation(deck)
+
+    # Zero is allowed (explicit immediate animation).
+    deck = _sample_deck()
+    deck["slides"][0]["animations"][0]["duration"] = 0
+    generator.validate_presentation(deck)  # must not raise

--- a/skills/agentic-presentation/tests/test_generate_presentation_html.py
+++ b/skills/agentic-presentation/tests/test_generate_presentation_html.py
@@ -200,3 +200,56 @@ def test_runtime_animation_types_match_schema():
     schema_types = set(schema["definitions"]["animation"]["properties"]["type"]["enum"])
 
     assert generator.SUPPORTED_ANIMATION_TYPES == schema_types
+
+
+def test_animation_timing_preserves_zero_values():
+    javascript = generator._javascript()
+
+    assert "animation.duration ?? 450" in javascript
+    assert "animation.delay ?? 0" in javascript
+    assert "animation.stagger ?? 80" in javascript
+
+
+def test_keyboard_navigation_prevents_button_default_click():
+    javascript = generator._javascript()
+
+    assert javascript.count("event.preventDefault();") == 2
+
+
+def test_live_wrapper_defaults_to_durable_index_html():
+    source = (SKILL_ROOT / "present.py").read_text()
+
+    assert 'output = args.output or Path("index.html")' in source
+    assert "mkdtemp" not in source
+
+
+def test_empty_animations_list_produces_no_animation():
+    deck = _sample_deck()
+    deck["slides"][0]["animations"] = []
+
+    html = generator.render_html(deck)
+
+    payload_start = html.index("data-animations='") + len("data-animations='")
+    payload_end = html.index("'", payload_start)
+
+    raw = html[payload_start:payload_end]
+    # The attribute value is HTML-escaped; unescape to get the JSON
+    import html as html_module
+
+    animations = json.loads(html_module.unescape(raw))
+    assert animations == [], f"expected empty animations, got {animations!r}"
+
+
+def test_validate_presentation_rejects_invalid_slide_id():
+    deck = _sample_deck()
+    deck["slides"][0]["id"] = "bad id!"  # space and ! not in pattern
+
+    with pytest.raises(ValueError, match="must match"):
+        generator.validate_presentation(deck)
+
+
+def test_validate_presentation_accepts_valid_slide_id_patterns():
+    for valid_id in ("a", "slide-01", "MySlide_2", "A1"):
+        deck = _sample_deck()
+        deck["slides"][0]["id"] = valid_id
+        generator.validate_presentation(deck)  # must not raise

--- a/skills/agentic-presentation/tests/test_generate_presentation_html.py
+++ b/skills/agentic-presentation/tests/test_generate_presentation_html.py
@@ -253,3 +253,28 @@ def test_validate_presentation_accepts_valid_slide_id_patterns():
         deck = _sample_deck()
         deck["slides"][0]["id"] = valid_id
         generator.validate_presentation(deck)  # must not raise
+
+
+def test_validate_presentation_rejects_non_list_animations():
+    # animations: null or a non-list value must raise a clear ValueError,
+    # not an unhandled TypeError from iterating over None/int.
+    for bad_value in (None, 5, "fade-in", {"type": "fade-in"}):
+        deck = _sample_deck()
+        deck["slides"][0]["animations"] = bad_value
+        if bad_value is None:
+            # null is allowed (treated as absent); validate must not crash
+            generator.validate_presentation(deck)
+        else:
+            with pytest.raises(ValueError, match="animations must be an array"):
+                generator.validate_presentation(deck)
+
+
+def test_validate_presentation_rejects_non_list_bullets():
+    # bullets: 5 or a dict must raise a clear ValueError during validation,
+    # not a TypeError crash inside _render_body_and_bullets.
+    for bad_value in (5, "bullet text", {"item": "x"}):
+        deck = _sample_deck()
+        # Use the content slide (index 1) which supports bullets
+        deck["slides"][1]["bullets"] = bad_value
+        with pytest.raises(ValueError, match="bullets must be an array"):
+            generator.validate_presentation(deck)


### PR DESCRIPTION
Adds an `agentic-presentation` skill: turn structured slide JSON into a standalone, offline HTML deck (inline CSS + JS, keyboard navigation, no CDN dependencies).

### Self-contained layout

This supersedes #1428, which was closed for scattering files across the repo (renderer into `scripts/`, schema into `knowledge/`, tests into top-level `tests/`). That sprawl is fixed — the entire diff is six files, all under `skills/agentic-presentation/`:

```text
skills/agentic-presentation/
├── SKILL.md
├── generate_presentation_html.py          # renderer (stdlib only)
├── present.py                             # render + optionally open in browser
├── presentation.schema.json               # draft-07 deck schema
├── examples/agentic-presentation-demo.json
└── tests/test_generate_presentation_html.py
```

Same shape as `skills/financial-advisor/` (#1417). Delete the folder and nothing outside it breaks, and nothing is left behind — no shared config, no repo-level test registration, no entries in other files.

### What it does

- Validates deck JSON (slide ids unique, required fields per slide type, known animation types), then emits one HTML file.
- MVP slide types: `title-slide`, `content`, `code-reveal`, `code-and-text`, `image`, `gallery`.
- MVP animations: `fade-in`, `slide-in`, `line-reveal` (`zoom`/`spin` reserved).
- All user text is HTML-escaped by the generator; `--max-kb` (default 500) enforces a size budget.

```bash
python3 skills/agentic-presentation/present.py deck.json --live
python3 skills/agentic-presentation/generate_presentation_html.py \
  skills/agentic-presentation/examples/agentic-presentation-demo.json -o /tmp/demo.html
```

### Verification

- 7 tests pass: `uv run --with pytest --with jsonschema pytest skills/agentic-presentation/tests/ -q`
- Demo deck renders end-to-end: 5 slides, 11,992 bytes, no external URLs in the output.
- `prek run` over the changed files: ruff, ruff-format, mypy, markdown links, jscpd, check-names all pass.

Rendering needs only the Python standard library. The two schema tests need `jsonschema`, guarded with `pytest.importorskip` so the suite degrades to 5 passed / 2 skipped rather than erroring when it is absent — this keeps the dependency inside the skill instead of adding it to the repo's mypy/dev dependency lists.
