### PR TITLE
fix(twitter): distinguish spend-cap 403 from content-rejection 403

### DIFF
--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -849,9 +849,12 @@ def _classify_tweet_post_error(error: Exception) -> str:
             or "usagecapped" in api_error_type.lower()
         ):
             return "cap"
-        # Got a non-cap structured type — the API explicitly says this is a
-        # content rejection or other permanent error.
-        return "permanent"
+        # Non-cap structured type: the X API uses non-specific types (including
+        # "about:blank") for many conditions — some of which are transient (e.g.
+        # temporary account restrictions, permission changes). We cannot reliably
+        # classify an unknown type as "permanent", so return "other" and leave the
+        # tweet queued rather than silently quarantining it.
+        return "other"
 
     # No structured response body. Fall back to substring matching.
     # Cap markers (e.g. "spend cap") could theoretically appear in user tweet

--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -767,6 +767,69 @@ def _quarantine_permanent_reply_failure(
     return True
 
 
+# The X API returns HTTP 403 for BOTH the monthly spend cap AND permanent content
+# rejections (cashtags/dollar amounts, content policy, restricted replies, ...).
+# A bare status-code check cannot tell them apart, which is exactly the bug that
+# let one poison tweet impersonate a spend cap (see the task that filed this).
+# Distinguish by the response body message, never by the status code alone.
+_CAP_403_MARKERS = ("spend cap", "monthly spend cap")
+
+
+def _classify_tweet_post_error(error: Exception) -> str:
+    """Classify a create_tweet failure for the autopost pipeline.
+
+    Returns one of:
+      "cap"       - billing/monthly spend cap. The whole queue is blocked; keep
+                    tweets queued so they post once the cap resets, and signal the
+                    wrapper to set/refresh the spend-cap flag.
+      "permanent" - a non-cap 403 (cashtags/dollar amounts, content policy,
+                    restricted reply, ...) that will NEVER succeed on retry.
+                    Quarantine the offending tweet so it stops blocking the queue.
+      "other"     - transient or unclassified; leave the tweet queued for retry.
+    """
+    message = str(error).lower()
+    # Cap marker takes priority: if the body names a spend cap, treat it as a cap
+    # regardless of exact status framing.
+    if any(marker in message for marker in _CAP_403_MARKERS):
+        return "cap"
+    # A Forbidden/403 on create_tweet is a content/permission rejection. Match on
+    # either the typed tweepy exception (when available) OR the status text in the
+    # message, so a plain Exception carrying a "403 Forbidden: ..." body is still
+    # caught even if the error was wrapped or not a tweepy Forbidden instance.
+    is_403 = "forbidden" in message or message.startswith("403")
+    try:
+        from tweepy.errors import Forbidden as _Forbidden
+
+        is_403 = is_403 or isinstance(error, _Forbidden)
+    except Exception:
+        pass
+    return "permanent" if is_403 else "other"
+
+
+def _quarantine_tweet_post_failure(
+    path: Path, draft: TweetDraft, error: Exception
+) -> bool:
+    """Move an approved tweet that the API permanently rejects to rejected/.
+
+    A non-cap 403 (cashtags/dollar amounts, content policy, restricted reply, etc.)
+    will never succeed on retry. Leaving it in approved/ wedges the queue: every
+    autopost cycle hits the same 403, and the wrapper's "neither posted nor saw a
+    cap" fallback keeps a phantom spend-cap flag alive. Quarantining it on the
+    first confirmed non-cap 403 caps retries at one (content rejections never
+    clear), so the queue can drain.
+    """
+    reason = _permanent_reply_failure_reason(draft, error)
+    if reason is None:
+        reason = f"Permanent Twitter post rejection: {error}"
+    draft.reject_reason = reason
+    draft.save(path)
+    rejected_path = move_draft(path, "rejected")
+    console.print(
+        f"[yellow]Moved permanently rejected tweet to {rejected_path}[/yellow]"
+    )
+    return True
+
+
 def find_draft(
     draft_id: str, status: str | None = None, show_error: bool = True
 ) -> Path | None:
@@ -1580,7 +1643,25 @@ def post(
                     console.print("[red]Error: No response data from tweet creation")
             except Exception as e:
                 console.print(f"[red]Error posting tweet: {e}")
-                _quarantine_permanent_reply_failure(path, draft, e)
+                failure_kind = _classify_tweet_post_error(e)
+                if failure_kind == "cap":
+                    # Whole queue blocked by the billing cap. Keep every tweet queued
+                    # so they post once the cap resets, and stop trying further posts
+                    # this run. The wrapper greps the output for "monthly spend cap"
+                    # to set/refresh its flag.
+                    console.print(
+                        "[yellow]Twitter monthly spend cap reached; tweets will post when the cap resets."
+                    )
+                    break
+                elif failure_kind == "permanent":
+                    # A content/permission 403 that will never succeed on retry.
+                    # Quarantine it so it stops blocking the queue (caps retries).
+                    _quarantine_tweet_post_failure(path, draft, e)
+                else:
+                    # Transient/unclassified; leave queued for the next cycle.
+                    console.print(
+                        "[yellow]Tweet not posted (transient error); leaving queued."
+                    )
         else:
             console.print("[yellow]Skipped posting tweet")
 
@@ -2579,7 +2660,18 @@ def auto(
                         )
                 except Exception as e:
                     console.print(f"[red]Error posting tweet: {e}")
-                    _quarantine_permanent_reply_failure(path, draft, e)
+                    failure_kind = _classify_tweet_post_error(e)
+                    if failure_kind == "cap":
+                        console.print(
+                            "[yellow]Twitter monthly spend cap reached; tweets will post when the cap resets."
+                        )
+                        break
+                    elif failure_kind == "permanent":
+                        _quarantine_tweet_post_failure(path, draft, e)
+                    else:
+                        console.print(
+                            "[yellow]Tweet not posted (transient error); leaving queued."
+                        )
 
     # Summary
     console.print("\n[bold]Automation Cycle Summary:[/bold]")

--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -868,21 +868,25 @@ def _classify_tweet_post_error(error: Exception) -> str:
         return "other"
 
     # No structured response body. Fall back to substring matching.
-    # Cap markers (e.g. "spend cap") could theoretically appear in user tweet
-    # content embedded in an error body, but the X API does not embed user text
-    # in 403 error messages as of 2026-08-16. The structured path above is the
-    # robust fix for that case in production.
-    if any(marker in message for marker in _CAP_403_MARKERS):
-        return "cap"
-
-    # Only quarantine on known-permanent rejection patterns. Unknown 403s
-    # (e.g. transient account restrictions, temporary permission changes) return
-    # "other" so the tweet stays queued for retry rather than being silently dropped.
+    # Check permanent-rejection markers FIRST: they are API-controlled phrases
+    # ("cashtag", "dollar amount", ...) that don't appear in cap messages, so
+    # checking them first is safe. Cap markers (e.g. "spend cap") are checked
+    # only if no permanent marker matched, so a message that happens to contain
+    # both (e.g. the X API echoing rejected tweet text in the error detail)
+    # classifies as "permanent" rather than letting a stray "spend cap"
+    # substring impersonate the billing cap.
     if any(marker in message for marker in _PERMANENT_403_MARKERS):
         return "permanent"
 
     if any(marker in message for marker in _PERMANENT_REPLY_FAILURE_MARKERS):
         return "permanent"
+
+    # Only classify as cap after confirming no permanent marker matched. Unknown
+    # 403s (e.g. transient account restrictions, temporary permission changes)
+    # that match neither list return "other" so the tweet stays queued for retry
+    # rather than being silently dropped or misrouted.
+    if any(marker in message for marker in _CAP_403_MARKERS):
+        return "cap"
 
     return "other"
 

--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -774,6 +774,42 @@ def _quarantine_permanent_reply_failure(
 # Distinguish by the response body message, never by the status code alone.
 _CAP_403_MARKERS = ("spend cap", "monthly spend cap")
 
+# Known-permanent content rejection patterns (cashtags, dollar amounts, restricted
+# replies). These phrases appear in the X API's own error messages, not in the
+# rejected tweet's text, so substring matching is safe for this list.
+_PERMANENT_403_MARKERS = (
+    "cashtag",
+    "dollar amount",
+    "restricted reply",
+    "automated tweet",
+)
+
+
+def _get_twitter_api_error_type(error: Exception) -> str | None:
+    """Extract the X API v2 'type' field from a structured tweepy response body.
+
+    Tweepy HTTP exceptions carry a `response` attribute whose JSON body follows
+    the X API v2 problem schema: {"type": "<URL or title>", "status": 403, ...}.
+    The `type` field is API-generated and never contains user tweet content, making
+    it the most reliable discriminator between cap and content-rejection 403s.
+
+    Returns the type string if available, or None if the exception has no
+    parseable structured response (e.g. a plain Exception used in tests).
+    """
+    response = getattr(error, "response", None)
+    if response is None:
+        return None
+    get_json = getattr(response, "json", None)
+    if get_json is None:
+        return None
+    try:
+        body = get_json()
+        if isinstance(body, dict):
+            return body.get("type") or body.get("title") or ""
+    except Exception:
+        pass
+    return None
+
 
 def _classify_tweet_post_error(error: Exception) -> str:
     """Classify a create_tweet failure for the autopost pipeline.
@@ -803,11 +839,35 @@ def _classify_tweet_post_error(error: Exception) -> str:
     if not is_403:
         return "other"
 
-    # It is a 403. Distinguish billing cap from content rejection by body text.
+    # P1 fix: prefer the structured X API v2 `type` field over substring matching.
+    # The type URI is API-controlled and is never influenced by user tweet content,
+    # so it cannot be spoofed by a tweet that happens to contain "spend cap".
+    api_error_type = _get_twitter_api_error_type(error)
+    if api_error_type:
+        if (
+            "usage-capped" in api_error_type.lower()
+            or "usagecapped" in api_error_type.lower()
+        ):
+            return "cap"
+        # Got a non-cap structured type — the API explicitly says this is a
+        # content rejection or other permanent error.
+        return "permanent"
+
+    # No structured response body. Fall back to substring matching.
+    # Cap markers (e.g. "spend cap") could theoretically appear in user tweet
+    # content embedded in an error body, but the X API does not embed user text
+    # in 403 error messages as of 2026-08-16. The structured path above is the
+    # robust fix for that case in production.
     if any(marker in message for marker in _CAP_403_MARKERS):
         return "cap"
 
-    return "permanent"
+    # P2 fix: only quarantine on known-permanent rejection patterns. Unknown 403s
+    # (e.g. transient account restrictions, temporary permission changes) return
+    # "other" so the tweet stays queued for retry rather than being silently dropped.
+    if any(marker in message for marker in _PERMANENT_403_MARKERS):
+        return "permanent"
+
+    return "other"
 
 
 def _quarantine_tweet_post_failure(

--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -788,22 +788,26 @@ def _classify_tweet_post_error(error: Exception) -> str:
       "other"     - transient or unclassified; leave the tweet queued for retry.
     """
     message = str(error).lower()
-    # Cap marker takes priority: if the body names a spend cap, treat it as a cap
-    # regardless of exact status framing.
-    if any(marker in message for marker in _CAP_403_MARKERS):
-        return "cap"
-    # A Forbidden/403 on create_tweet is a content/permission rejection. Match on
-    # either the typed tweepy exception (when available) OR the status text in the
-    # message, so a plain Exception carrying a "403 Forbidden: ..." body is still
-    # caught even if the error was wrapped or not a tweepy Forbidden instance.
-    is_403 = "forbidden" in message or message.startswith("403")
+    # Establish the 403/Forbidden status FIRST. Cap markers are checked only
+    # within a confirmed 403 to avoid mis-classifying non-403 errors whose
+    # message text happens to contain "spend cap" (e.g. tweet content about
+    # Twitter billing policy). A non-403 can never be a billing cap.
+    is_403 = "403" in message or "forbidden" in message
     try:
         from tweepy.errors import Forbidden as _Forbidden
 
         is_403 = is_403 or isinstance(error, _Forbidden)
     except Exception:
         pass
-    return "permanent" if is_403 else "other"
+
+    if not is_403:
+        return "other"
+
+    # It is a 403. Distinguish billing cap from content rejection by body text.
+    if any(marker in message for marker in _CAP_403_MARKERS):
+        return "cap"
+
+    return "permanent"
 
 
 def _quarantine_tweet_post_failure(

--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -805,7 +805,10 @@ def _get_twitter_api_error_type(error: Exception) -> str | None:
     try:
         body = get_json()
         if isinstance(body, dict):
-            return body.get("type") or body.get("title") or ""
+            # Coerce to str: the X API spec says `type` is a string, but guard
+            # against a non-string (e.g. integer status code) that would cause
+            # AttributeError on the downstream `.lower()` call.
+            return str(body.get("type") or body.get("title") or "")
     except Exception:
         pass
     return None
@@ -849,11 +852,19 @@ def _classify_tweet_post_error(error: Exception) -> str:
             or "usagecapped" in api_error_type.lower()
         ):
             return "cap"
-        # Non-cap structured type: the X API uses non-specific types (including
-        # "about:blank") for many conditions — some of which are transient (e.g.
-        # temporary account restrictions, permission changes). We cannot reliably
-        # classify an unknown type as "permanent", so return "other" and leave the
-        # tweet queued rather than silently quarantining it.
+        # Structured type confirms 403 but is not a billing cap. The type field
+        # short-circuits before cap-marker substring matching, so a tweet whose
+        # content contains "spend cap" cannot impersonate a billing cap. Now check
+        # permanent content-rejection markers in the API error message. The X API
+        # does not embed user tweet text in 403 error bodies, so these markers are
+        # API-controlled and safe to match against.
+        if any(marker in message for marker in _PERMANENT_403_MARKERS):
+            return "permanent"
+        if any(marker in message for marker in _PERMANENT_REPLY_FAILURE_MARKERS):
+            return "permanent"
+        # Unknown structured type with no permanent markers — may be transient
+        # (e.g. temporary account restriction). Leave the tweet queued rather than
+        # silently quarantining it on an unrecognized error type.
         return "other"
 
     # No structured response body. Fall back to substring matching.
@@ -864,14 +875,12 @@ def _classify_tweet_post_error(error: Exception) -> str:
     if any(marker in message for marker in _CAP_403_MARKERS):
         return "cap"
 
-    # P2 fix: only quarantine on known-permanent rejection patterns. Unknown 403s
+    # Only quarantine on known-permanent rejection patterns. Unknown 403s
     # (e.g. transient account restrictions, temporary permission changes) return
     # "other" so the tweet stays queued for retry rather than being silently dropped.
     if any(marker in message for marker in _PERMANENT_403_MARKERS):
         return "permanent"
 
-    # Reply-specific permanent failures (e.g. "Reply to this conversation is not
-    # allowed because you have not been mentioned") are also non-retryable.
     if any(marker in message for marker in _PERMANENT_REPLY_FAILURE_MARKERS):
         return "permanent"
 

--- a/scripts/twitter/workflow.py
+++ b/scripts/twitter/workflow.py
@@ -867,6 +867,11 @@ def _classify_tweet_post_error(error: Exception) -> str:
     if any(marker in message for marker in _PERMANENT_403_MARKERS):
         return "permanent"
 
+    # Reply-specific permanent failures (e.g. "Reply to this conversation is not
+    # allowed because you have not been mentioned") are also non-retryable.
+    if any(marker in message for marker in _PERMANENT_REPLY_FAILURE_MARKERS):
+        return "permanent"
+
     return "other"
 
 

--- a/tests/test_twitter_post_403_classifier.py
+++ b/tests/test_twitter_post_403_classifier.py
@@ -186,11 +186,12 @@ class TestClassifyTweetPostError:
         err = Exception("403 Forbidden: policy violation")
         assert workflow_module._classify_tweet_post_error(err) == "other"
 
-    def test_typed_tweepy_forbidden_uses_structured_type(self, workflow_module):
-        # When the tweepy response body carries the X API v2 `type` field, the
-        # classifier must use it as the primary discriminator. A non-cap type
-        # ("about:blank" is the standard fallback for non-specific rejections)
-        # confirms this is a permanent content rejection, not a billing cap.
+    def test_typed_tweepy_forbidden_unknown_type_is_other(self, workflow_module):
+        # When the tweepy response body carries a non-specific X API v2 `type`
+        # field ("about:blank" is the generic fallback used for many conditions,
+        # including transient ones), we return "other" rather than quarantining.
+        # Transient account restrictions and permission changes can produce this
+        # type — silently quarantining them would cause silent data loss.
         try:
             from tweepy.errors import Forbidden
         except Exception:  # pragma: no cover - tweepy not installed in bare env
@@ -202,11 +203,34 @@ class TestClassifyTweetPostError:
             reason = "Forbidden"
 
             def json(self) -> dict[str, object]:
-                # X API v2 problem schema with non-cap type
+                # X API v2 problem schema with non-specific "about:blank" type
                 return {"type": "about:blank", "title": "Forbidden", "status": 403}
 
         err = Forbidden(_FakeResponse())
-        assert workflow_module._classify_tweet_post_error(err) == "permanent"
+        assert workflow_module._classify_tweet_post_error(err) == "other"
+
+    def test_structured_transient_type_is_other(self, workflow_module):
+        # A structured 403 whose type signals a potentially-transient condition
+        # (e.g. temporary account restriction) must NOT be quarantined.
+        try:
+            from tweepy.errors import Forbidden
+        except Exception:  # pragma: no cover
+            pytest.skip("tweepy not installed")
+
+        class _FakeTransientResponse:
+            status_code = 403
+            status = "Forbidden"
+            reason = "Forbidden"
+
+            def json(self) -> dict[str, object]:
+                return {
+                    "type": "https://api.twitter.com/2/problems/temporarily-restricted",
+                    "title": "Temporarily Restricted",
+                    "status": 403,
+                }
+
+        err = Forbidden(_FakeTransientResponse())
+        assert workflow_module._classify_tweet_post_error(err) == "other"
 
     def test_structured_usage_capped_type_is_cap(self, workflow_module):
         # P1 fix: the X API v2 returns a specific `type` URL for spend-cap 403s.
@@ -233,11 +257,13 @@ class TestClassifyTweetPostError:
         err = Forbidden(_FakeCapResponse())
         assert workflow_module._classify_tweet_post_error(err) == "cap"
 
-    def test_structured_noncap_type_with_cap_text_is_permanent(self, workflow_module):
-        # P1 key test: a 403 whose stringified message contains "spend cap" (e.g.
-        # the API error body might quote user content in some edge case) must NOT be
-        # classified as a billing cap when the structured `type` field says otherwise.
-        # The structured path takes priority over substring matching.
+    def test_structured_noncap_type_with_cap_text_is_not_cap(self, workflow_module):
+        # P1 anti-spoofing test: a 403 whose error body contains "spend cap" text
+        # (e.g. embedded tweet content or API detail referencing billing) but whose
+        # `type` field is NOT "usage-capped" must NOT be classified as a billing cap.
+        # The structured-type check short-circuits before substring matching, so
+        # a spoofed tweet with "monthly spend cap" in its body cannot impersonate
+        # a real billing cap. We return "other" (not "cap") for unknown types.
         try:
             from tweepy.errors import Forbidden
         except Exception:  # pragma: no cover
@@ -258,8 +284,8 @@ class TestClassifyTweetPostError:
                 }
 
         err = Forbidden(_FakeContentRejection())
-        # Despite "spend cap" appearing in str(err), the structured type wins.
-        assert workflow_module._classify_tweet_post_error(err) == "permanent"
+        # "about:blank" is not "usage-capped" → "other", not "cap" (anti-spoofing).
+        assert workflow_module._classify_tweet_post_error(err) == "other"
 
     def test_http_403_prefix_classified_other(self, workflow_module):
         # An unstructured "HTTP 403: ..." with no known-permanent markers is

--- a/tests/test_twitter_post_403_classifier.py
+++ b/tests/test_twitter_post_403_classifier.py
@@ -287,6 +287,34 @@ class TestClassifyTweetPostError:
         # "about:blank" is not "usage-capped" → "other", not "cap" (anti-spoofing).
         assert workflow_module._classify_tweet_post_error(err) == "other"
 
+    def test_structured_type_with_permanent_marker_is_permanent(self, workflow_module):
+        # A structured 403 whose error message contains a known-permanent content
+        # rejection marker (e.g. "cashtag") must still be quarantined, even though
+        # the `type` field is non-specific ("about:blank").
+        # This is the primary poison-tweet case: a cashtag rejection produces a
+        # tweepy Forbidden with a structured body — the structured-type path must
+        # reach the marker check, not skip to "other".
+        try:
+            from tweepy.errors import Forbidden
+        except Exception:  # pragma: no cover
+            pytest.skip("tweepy not installed")
+
+        class _FakeCashtagResponse:
+            status_code = 403
+            status = "Forbidden"
+            reason = "Forbidden"
+
+            def json(self) -> dict[str, object]:
+                return {
+                    "type": "about:blank",
+                    "title": "Forbidden",
+                    "status": 403,
+                    "detail": "Your post was rejected: you may have entered a dollar amount or a cashtag.",
+                }
+
+        err = Forbidden(_FakeCashtagResponse())
+        assert workflow_module._classify_tweet_post_error(err) == "permanent"
+
     def test_http_403_prefix_classified_other(self, workflow_module):
         # An unstructured "HTTP 403: ..." with no known-permanent markers is
         # classified "other" (may be a transient restriction — P2 fix).
@@ -299,6 +327,27 @@ class TestClassifyTweetPostError:
 
     def test_rate_limit_429_is_other(self, workflow_module):
         err = Exception("429 Too Many Requests")
+        assert workflow_module._classify_tweet_post_error(err) == "other"
+
+    def test_non_string_api_type_does_not_raise(self, workflow_module):
+        # Guard against an integer (or other non-string) `type` field in the X API
+        # response body. Without str() coercion, `.lower()` raises AttributeError,
+        # crashing the posting loop. Any non-string type is treated as "other".
+        try:
+            from tweepy.errors import Forbidden
+        except Exception:  # pragma: no cover
+            pytest.skip("tweepy not installed")
+
+        class _FakeIntTypeResponse:
+            status_code = 403
+            status = "Forbidden"
+            reason = "Forbidden"
+
+            def json(self) -> dict[str, object]:
+                return {"type": 403, "title": "Forbidden", "status": 403}
+
+        err = Forbidden(_FakeIntTypeResponse())
+        # Must not raise AttributeError; 403-as-type is not a cap marker
         assert workflow_module._classify_tweet_post_error(err) == "other"
 
 

--- a/tests/test_twitter_post_403_classifier.py
+++ b/tests/test_twitter_post_403_classifier.py
@@ -1,0 +1,206 @@
+"""Regression tests for the post-403 classifier and quarantine behavior.
+
+Background: a non-cap 403 (cashtag / dollar-amount content rejection) was being
+treated by post-approved-tweets.sh as evidence of a spend cap, refreshing the cap
+flag every ~20h and leaving one poison tweet impersonating an active spend cap
+forever. workflow.py now distinguishes cap vs non-cap 403s at the call site and
+quarantines non-cap 403s so they drain out of the approved queue.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import sys
+import types
+from collections.abc import Generator
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW_PATH = REPO_ROOT / "scripts" / "twitter" / "workflow.py"
+_MISSING = object()
+
+
+def _make_pkg(name: str) -> types.ModuleType:
+    mod = types.ModuleType(name)
+    mod.__path__ = []
+    return mod
+
+
+def _load_workflow_module() -> tuple[Any, dict[str, Any]]:
+    class _Operation:
+        def complete(self, *args, **kwargs) -> None:
+            return None
+
+    class _MetricsCollector:
+        def start_operation(self, *args, **kwargs) -> _Operation:
+            return _Operation()
+
+    monitoring_stub: Any = types.ModuleType("gptmail.communication_utils.monitoring")
+    monitoring_stub.MetricsCollector = _MetricsCollector
+    monitoring_stub.get_logger = lambda *args, **kwargs: logging.getLogger(
+        "twitter-test"
+    )
+
+    redact_stub: Any = types.ModuleType("gptmail.communication_utils.outbound_redact")
+    redact_stub.guard_outbound = lambda *args, **kwargs: True
+
+    gptmail_stub = _make_pkg("gptmail")
+    gptmail_comm_stub = _make_pkg("gptmail.communication_utils")
+
+    gptme_stub = _make_pkg("gptme")
+    gptme_init_stub: Any = types.ModuleType("gptme.init")
+    gptme_init_stub.init = lambda *args, **kwargs: None
+
+    dotenv_stub: Any = types.ModuleType("dotenv")
+    dotenv_stub.load_dotenv = lambda *args, **kwargs: None
+
+    click_stub: Any = types.ModuleType("click")
+
+    def _passthrough_decorator(*args, **kwargs):
+        def _decorator(func):
+            return func
+
+        return _decorator
+
+    def _group_decorator(*args, **kwargs):
+        def _decorator(func):
+            func.command = _passthrough_decorator
+            return func
+
+        return _decorator
+
+    click_stub.group = _group_decorator
+    click_stub.command = _passthrough_decorator
+    click_stub.option = _passthrough_decorator
+    click_stub.argument = _passthrough_decorator
+    click_stub.Choice = lambda choices: choices
+    click_stub.Path = lambda **kwargs: kwargs
+    click_stub.echo = lambda *args, **kwargs: None
+
+    rich_stub = _make_pkg("rich")
+    rich_console_stub: Any = types.ModuleType("rich.console")
+    rich_console_stub.Console = lambda *args, **kwargs: SimpleNamespace(
+        print=lambda *print_args, **print_kwargs: None
+    )
+    rich_prompt_stub: Any = types.ModuleType("rich.prompt")
+    rich_prompt_stub.Confirm = SimpleNamespace(ask=lambda *args, **kwargs: True)
+    rich_prompt_stub.Prompt = SimpleNamespace(ask=lambda *args, **kwargs: "")
+
+    trusted_users_stub: Any = types.ModuleType("trusted_users")
+    trusted_users_stub.is_trusted_user = lambda *args, **kwargs: False
+
+    twitter_pkg_stub = _make_pkg("twitter")
+    twitter_llm_stub: Any = types.ModuleType("twitter.llm")
+    twitter_llm_stub.EvaluationResponse = type("EvaluationResponse", (), {})
+    twitter_llm_stub.TweetResponse = type("TweetResponse", (), {})
+    twitter_llm_stub.process_tweet = lambda *args, **kwargs: None
+    twitter_llm_stub.verify_draft = lambda *args, **kwargs: (True, None)
+    twitter_llm_stub._unescape_literal_newlines = lambda text: text.replace("\\n", "\n")
+
+    twitter_api_stub: Any = types.ModuleType("twitter.twitter")
+    twitter_api_stub.cached_get_me = lambda *args, **kwargs: SimpleNamespace(
+        data=SimpleNamespace(id=0)
+    )
+    twitter_api_stub.load_twitter_client = lambda *args, **kwargs: None
+    twitter_api_stub._find_placeholder_in_text = lambda *args, **kwargs: None
+
+    stubbed_modules: dict[str, Any] = {
+        "gptmail": gptmail_stub,
+        "gptmail.communication_utils": gptmail_comm_stub,
+        "gptmail.communication_utils.monitoring": monitoring_stub,
+        "gptmail.communication_utils.outbound_redact": redact_stub,
+        "gptme": gptme_stub,
+        "gptme.init": gptme_init_stub,
+        "dotenv": dotenv_stub,
+        "click": click_stub,
+        "rich": rich_stub,
+        "rich.console": rich_console_stub,
+        "rich.prompt": rich_prompt_stub,
+        "trusted_users": trusted_users_stub,
+        "twitter": twitter_pkg_stub,
+        "twitter.llm": twitter_llm_stub,
+        "twitter.twitter": twitter_api_stub,
+    }
+
+    original_modules = {
+        name: sys.modules.get(name, _MISSING) for name in stubbed_modules
+    }
+    for name, stub in stubbed_modules.items():
+        sys.modules[name] = stub
+
+    spec = importlib.util.spec_from_file_location(
+        "twitter_workflow_under_test", WORKFLOW_PATH
+    )
+    assert spec and spec.loader
+    module: Any = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module, original_modules
+
+
+@pytest.fixture(scope="module")
+def workflow_module() -> Generator[Any, None, None]:
+    module, original_modules = _load_workflow_module()
+    yield module
+    sys.modules.pop("twitter_workflow_under_test", None)
+    for key, original in original_modules.items():
+        if original is _MISSING:
+            sys.modules.pop(key, None)
+        else:
+            sys.modules[key] = original
+
+
+class TestClassifyTweetPostError:
+    def test_spend_cap_403_classified_as_cap(self, workflow_module):
+        err = Exception("403 Forbidden: Your monthly spend cap has been reached")
+        assert workflow_module._classify_tweet_post_error(err) == "cap"
+
+    def test_spend_cap_message_without_403_is_cap(self, workflow_module):
+        err = Exception("your monthly spend cap has been reached")
+        assert workflow_module._classify_tweet_post_error(err) == "cap"
+
+    def test_cashtag_403_classified_permanent(self, workflow_module):
+        # This is the poison-tweet case: content-rejection 403 that will never
+        # succeed on retry, but must NOT be mistaken for a spend cap.
+        err = Exception(
+            "403 Forbidden: your post was rejected, you may have entered a "
+            "dollar amount or a cashtag"
+        )
+        assert workflow_module._classify_tweet_post_error(err) == "permanent"
+
+    def test_generic_forbidden_403_is_permanent(self, workflow_module):
+        err = Exception("403 Forbidden: policy violation")
+        assert workflow_module._classify_tweet_post_error(err) == "permanent"
+
+    def test_typed_tweepy_forbidden_is_permanent(self, workflow_module):
+        # The lazy tweepy.errors import may not be available in a bare test env;
+        # a typed Forbidden instance must still classify as permanent either via
+        # the isinstance check or the status-text fallback.
+        try:
+            from tweepy.errors import Forbidden
+        except Exception:  # pragma: no cover - tweepy not installed in bare env
+            pytest.skip("tweepy not installed")
+
+        class _FakeResponse:
+            status_code = 403
+            status = "Forbidden"
+            reason = "Forbidden"
+
+            def json(self) -> dict[str, object]:
+                return {"errors": [{"code": 403, "message": "Forbidden"}]}
+
+        err = Forbidden(_FakeResponse())
+        assert workflow_module._classify_tweet_post_error(err) == "permanent"
+
+    def test_non_403_error_is_other(self, workflow_module):
+        err = Exception("Connection reset by peer")
+        assert workflow_module._classify_tweet_post_error(err) == "other"
+
+    def test_rate_limit_429_is_other(self, workflow_module):
+        err = Exception("429 Too Many Requests")
+        assert workflow_module._classify_tweet_post_error(err) == "other"

--- a/tests/test_twitter_post_403_classifier.py
+++ b/tests/test_twitter_post_403_classifier.py
@@ -17,6 +17,7 @@ from collections.abc import Generator
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -160,9 +161,14 @@ class TestClassifyTweetPostError:
         err = Exception("403 Forbidden: Your monthly spend cap has been reached")
         assert workflow_module._classify_tweet_post_error(err) == "cap"
 
-    def test_spend_cap_message_without_403_is_cap(self, workflow_module):
+    def test_spend_cap_message_without_403_is_other(self, workflow_module):
+        # A message that mentions "spend cap" but carries no 403 status must NOT
+        # be classified as a billing cap — the error is not from the billing layer.
+        # This guards against a tweet whose text contains "spend cap" triggering a
+        # queue break via a non-cap rejection (e.g. a plain Exception from an
+        # unexpected code path).
         err = Exception("your monthly spend cap has been reached")
-        assert workflow_module._classify_tweet_post_error(err) == "cap"
+        assert workflow_module._classify_tweet_post_error(err) == "other"
 
     def test_cashtag_403_classified_permanent(self, workflow_module):
         # This is the poison-tweet case: content-rejection 403 that will never
@@ -197,6 +203,12 @@ class TestClassifyTweetPostError:
         err = Forbidden(_FakeResponse())
         assert workflow_module._classify_tweet_post_error(err) == "permanent"
 
+    def test_http_403_prefix_classified_permanent(self, workflow_module):
+        # Real tweepy/httpx errors may format the status as "HTTP 403: ..." rather
+        # than leading with "403 Forbidden: ...". The classifier must catch these.
+        err = Exception("HTTP 403: Forbidden - policy violation")
+        assert workflow_module._classify_tweet_post_error(err) == "permanent"
+
     def test_non_403_error_is_other(self, workflow_module):
         err = Exception("Connection reset by peer")
         assert workflow_module._classify_tweet_post_error(err) == "other"
@@ -204,3 +216,57 @@ class TestClassifyTweetPostError:
     def test_rate_limit_429_is_other(self, workflow_module):
         err = Exception("429 Too Many Requests")
         assert workflow_module._classify_tweet_post_error(err) == "other"
+
+
+class TestQuarantineTweetPostFailure:
+    def test_moves_file_to_rejected_and_sets_reason(self, workflow_module, tmp_path):
+        """_quarantine_tweet_post_failure removes the approved draft, writes it to
+        rejected/, and records a reject_reason on the moved draft."""
+        approved_dir = tmp_path / "approved"
+        rejected_dir = tmp_path / "rejected"
+        approved_dir.mkdir()
+        rejected_dir.mkdir()
+
+        draft = workflow_module.TweetDraft(text="Hello world tweet")
+        draft_path = approved_dir / "test-tweet.yaml"
+        draft.save(draft_path)
+        assert draft_path.exists()
+
+        error = Exception("403 Forbidden: policy violation")
+
+        with patch.object(workflow_module, "REJECTED_DIR", rejected_dir):
+            result = workflow_module._quarantine_tweet_post_failure(
+                draft_path, draft, error
+            )
+
+        assert result is True
+        assert not draft_path.exists(), "original file must be removed"
+        rejected_files = list(rejected_dir.iterdir())
+        assert len(rejected_files) == 1, "exactly one file must appear in rejected/"
+        moved_draft = workflow_module.TweetDraft.load(rejected_files[0])
+        assert moved_draft.reject_reason, "reject_reason must be set on moved draft"
+        assert (
+            "403" in moved_draft.reject_reason
+            or "rejection" in moved_draft.reject_reason.lower()
+        )
+
+    def test_preserves_draft_text(self, workflow_module, tmp_path):
+        """Quarantined draft must retain its original tweet text."""
+        approved_dir = tmp_path / "approved"
+        rejected_dir = tmp_path / "rejected"
+        approved_dir.mkdir()
+        rejected_dir.mkdir()
+
+        original_text = "Testing spend cap quarantine behavior"
+        draft = workflow_module.TweetDraft(text=original_text)
+        draft_path = approved_dir / "test-tweet.yaml"
+        draft.save(draft_path)
+
+        error = Exception("403 Forbidden: cashtag rejected")
+
+        with patch.object(workflow_module, "REJECTED_DIR", rejected_dir):
+            workflow_module._quarantine_tweet_post_failure(draft_path, draft, error)
+
+        rejected_files = list(rejected_dir.iterdir())
+        moved_draft = workflow_module.TweetDraft.load(rejected_files[0])
+        assert moved_draft.text == original_text

--- a/tests/test_twitter_post_403_classifier.py
+++ b/tests/test_twitter_post_403_classifier.py
@@ -179,6 +179,18 @@ class TestClassifyTweetPostError:
         )
         assert workflow_module._classify_tweet_post_error(err) == "permanent"
 
+    def test_unstructured_403_with_both_markers_is_permanent(self, workflow_module):
+        # P1 fix: in the unstructured fallback (no structured API response body),
+        # permanent-rejection markers must be checked before cap markers. If the
+        # X API ever echoes rejected tweet text into an unstructured 403 message
+        # that happens to also contain "spend cap", the permanent classification
+        # must win — otherwise the queue-breaking cap path could be spoofed by a
+        # poison tweet, recreating the exact bug this module fixes.
+        err = Exception(
+            "403 Forbidden: rejected, cashtag detected in tweet about spend cap policy"
+        )
+        assert workflow_module._classify_tweet_post_error(err) == "permanent"
+
     def test_generic_forbidden_403_is_other(self, workflow_module):
         # P2 fix: a generic 403 without known-permanent markers may be a transient
         # account restriction. Return "other" so the tweet stays queued for retry

--- a/tests/test_twitter_post_403_classifier.py
+++ b/tests/test_twitter_post_403_classifier.py
@@ -179,14 +179,18 @@ class TestClassifyTweetPostError:
         )
         assert workflow_module._classify_tweet_post_error(err) == "permanent"
 
-    def test_generic_forbidden_403_is_permanent(self, workflow_module):
+    def test_generic_forbidden_403_is_other(self, workflow_module):
+        # P2 fix: a generic 403 without known-permanent markers may be a transient
+        # account restriction. Return "other" so the tweet stays queued for retry
+        # rather than being silently quarantined.
         err = Exception("403 Forbidden: policy violation")
-        assert workflow_module._classify_tweet_post_error(err) == "permanent"
+        assert workflow_module._classify_tweet_post_error(err) == "other"
 
-    def test_typed_tweepy_forbidden_is_permanent(self, workflow_module):
-        # The lazy tweepy.errors import may not be available in a bare test env;
-        # a typed Forbidden instance must still classify as permanent either via
-        # the isinstance check or the status-text fallback.
+    def test_typed_tweepy_forbidden_uses_structured_type(self, workflow_module):
+        # When the tweepy response body carries the X API v2 `type` field, the
+        # classifier must use it as the primary discriminator. A non-cap type
+        # ("about:blank" is the standard fallback for non-specific rejections)
+        # confirms this is a permanent content rejection, not a billing cap.
         try:
             from tweepy.errors import Forbidden
         except Exception:  # pragma: no cover - tweepy not installed in bare env
@@ -198,16 +202,70 @@ class TestClassifyTweetPostError:
             reason = "Forbidden"
 
             def json(self) -> dict[str, object]:
-                return {"errors": [{"code": 403, "message": "Forbidden"}]}
+                # X API v2 problem schema with non-cap type
+                return {"type": "about:blank", "title": "Forbidden", "status": 403}
 
         err = Forbidden(_FakeResponse())
         assert workflow_module._classify_tweet_post_error(err) == "permanent"
 
-    def test_http_403_prefix_classified_permanent(self, workflow_module):
-        # Real tweepy/httpx errors may format the status as "HTTP 403: ..." rather
-        # than leading with "403 Forbidden: ...". The classifier must catch these.
-        err = Exception("HTTP 403: Forbidden - policy violation")
+    def test_structured_usage_capped_type_is_cap(self, workflow_module):
+        # P1 fix: the X API v2 returns a specific `type` URL for spend-cap 403s.
+        # This is API-controlled and immune to user tweet content influencing the
+        # classification (unlike substring matching on the full error message).
+        try:
+            from tweepy.errors import Forbidden
+        except Exception:  # pragma: no cover
+            pytest.skip("tweepy not installed")
+
+        class _FakeCapResponse:
+            status_code = 403
+            status = "Forbidden"
+            reason = "Forbidden"
+
+            def json(self) -> dict[str, object]:
+                return {
+                    "type": "https://api.twitter.com/2/problems/usage-capped",
+                    "title": "UsageCapped",
+                    "status": 403,
+                    "detail": "You have reached your monthly spend cap.",
+                }
+
+        err = Forbidden(_FakeCapResponse())
+        assert workflow_module._classify_tweet_post_error(err) == "cap"
+
+    def test_structured_noncap_type_with_cap_text_is_permanent(self, workflow_module):
+        # P1 key test: a 403 whose stringified message contains "spend cap" (e.g.
+        # the API error body might quote user content in some edge case) must NOT be
+        # classified as a billing cap when the structured `type` field says otherwise.
+        # The structured path takes priority over substring matching.
+        try:
+            from tweepy.errors import Forbidden
+        except Exception:  # pragma: no cover
+            pytest.skip("tweepy not installed")
+
+        class _FakeContentRejection:
+            status_code = 403
+            status = "Forbidden"
+            reason = "Forbidden"
+
+            def json(self) -> dict[str, object]:
+                # Non-cap type even though "spend cap" appears in the detail text.
+                return {
+                    "type": "about:blank",
+                    "title": "Forbidden",
+                    "status": 403,
+                    "detail": "Your post contains restricted content: 'monthly spend cap'",
+                }
+
+        err = Forbidden(_FakeContentRejection())
+        # Despite "spend cap" appearing in str(err), the structured type wins.
         assert workflow_module._classify_tweet_post_error(err) == "permanent"
+
+    def test_http_403_prefix_classified_other(self, workflow_module):
+        # An unstructured "HTTP 403: ..." with no known-permanent markers is
+        # classified "other" (may be a transient restriction — P2 fix).
+        err = Exception("HTTP 403: Forbidden - policy violation")
+        assert workflow_module._classify_tweet_post_error(err) == "other"
 
     def test_non_403_error_is_other(self, workflow_module):
         err = Exception("Connection reset by peer")


### PR DESCRIPTION
## Problem

The X API returns HTTP 403 for **both** the monthly spend cap **and** permanent content rejections (cashtags/dollar amounts, content policy, restricted replies). `post-approved-tweets.sh` treated every 403 as evidence of the spend cap and re-`touch`ed the cap flag, so one poison tweet carrying cashtags could refresh the flag every ~20h **forever** — impersonating an active cap that never actually exists.

Symptoms:
- Posting works fine (tweets went out 08-14/08-15) yet the cap flag stays perpetually present.
- At least one task (`promote-third-failure-never-came-blog`) is parked `waiting` on "the spend cap to reset" — a reset that can never come.

## Fix

- Add `_classify_tweet_post_error()` — branches on the response body message (cap markers) rather than the bare status code. Returns `"cap"` / `"permanent"` / `"other"`.
- Add `_quarantine_tweet_post_failure()` — moves permanently-rejected tweets to `rejected/` so they drain out of the approved queue instead of wedging it (caps retries at one).
- Wire both into the `post()` and `auto()` call sites: cap → keep queued + signal wrapper; permanent → quarantine; other → leave queued.

## Verification

- `python3 -m pytest tests/test_twitter_post_403_classifier.py -q` → 7 passed.
- `python3 -m pytest tests/test_validate_task_frontmatter_exit.py -q` → 6 passed (unaffected).
- Symptom check (prior session): cap flag files absent, approved queue drained from 16 → 0, rejected/ populated with the poison tweets.

Closes the `twitter-poison-tweet-impersonates-spend-cap` bug.
