### PR TITLE
feat(precommit): suggest canonical task_type when a synonym is used

### DIFF
--- a/scripts/precommit/validate_task_frontmatter.py
+++ b/scripts/precommit/validate_task_frontmatter.py
@@ -48,6 +48,17 @@ VALID_STATES = {
 VALID_PRIORITIES = ["low", "medium", "high"]
 VALID_TASK_TYPES = ["project", "action"]
 
+# Synonym map: agent-intuitive guesses → canonical GTD values
+TASK_TYPE_SYNONYMS = {
+    "research": "action",
+    "investigation": "action",
+    "chore": "action",
+    "bug": "action",
+    "decision": "action",
+    "task": "action",
+    "epic": "project",
+}
+
 
 def validate_timestamp(ts: str | datetime | date) -> str | None:
     """Validate an ISO 8601 timestamp or datetime/date object.
@@ -114,8 +125,13 @@ def validate_frontmatter(file: Path, type_name: str = "tasks") -> List[str]:
     if "task_type" in metadata:
         task_type = metadata["task_type"]
         if task_type not in VALID_TASK_TYPES:
+            suggestion = ""
+            task_type_lower = str(task_type).lower()
+            if task_type_lower in TASK_TYPE_SYNONYMS:
+                canonical = TASK_TYPE_SYNONYMS[task_type_lower]
+                suggestion = f" — did you mean `task_type: {canonical}`?"
             errors.append(
-                f"Invalid task_type: {task_type}. Must be one of: {', '.join(VALID_TASK_TYPES)}"
+                f"Invalid task_type: {task_type}. Must be one of: {', '.join(VALID_TASK_TYPES)}{suggestion}. See tasks/templates/default.md for examples."
             )
 
     if "tags" in metadata:

--- a/scripts/precommit/validate_task_frontmatter.py
+++ b/scripts/precommit/validate_task_frontmatter.py
@@ -130,6 +130,8 @@ def validate_frontmatter(file: Path, type_name: str = "tasks") -> List[str]:
             if task_type_lower in TASK_TYPE_SYNONYMS:
                 canonical = TASK_TYPE_SYNONYMS[task_type_lower]
                 suggestion = f" — did you mean `task_type: {canonical}`?"
+            elif task_type_lower in VALID_TASK_TYPES:
+                suggestion = f" — did you mean `task_type: {task_type_lower}`?"
             errors.append(
                 f"Invalid task_type: {task_type}. Must be one of: {', '.join(VALID_TASK_TYPES)}{suggestion}. See tasks/templates/default.md for examples."
             )

--- a/scripts/precommit/validate_task_frontmatter.py
+++ b/scripts/precommit/validate_task_frontmatter.py
@@ -132,8 +132,13 @@ def validate_frontmatter(file: Path, type_name: str = "tasks") -> List[str]:
                 suggestion = f" — did you mean `task_type: {canonical}`?"
             elif task_type_lower in VALID_TASK_TYPES:
                 suggestion = f" — did you mean `task_type: {task_type_lower}`?"
+            template_hint = (
+                " See tasks/templates/default.md for examples."
+                if type_name == "tasks"
+                else ""
+            )
             errors.append(
-                f"Invalid task_type: {task_type}. Must be one of: {', '.join(VALID_TASK_TYPES)}{suggestion}. See tasks/templates/default.md for examples."
+                f"Invalid task_type: {task_type}. Must be one of: {', '.join(VALID_TASK_TYPES)}{suggestion}.{template_hint}"
             )
 
     if "tags" in metadata:

--- a/tests/test_validate_task_frontmatter_exit.py
+++ b/tests/test_validate_task_frontmatter_exit.py
@@ -100,3 +100,38 @@ def test_no_files_exits_clean() -> None:
     """precommit can pass empty file lists; should be a no-op."""
     result = _run([])
     assert result.returncode == 0
+
+
+def test_task_type_synonym_suggests_canonical(tmp_path: Path) -> None:
+    """A known synonym like 'research' should fail with a 'did you mean' suggestion."""
+    f = _make_task(
+        tmp_path,
+        "---\nstate: active\ncreated: 2026-03-02\ntask_type: research\n---\n# Task\n",
+    )
+    result = _run([str(f)])
+    assert result.returncode != 0, "validator must reject synonym task_type values"
+    # rich may wrap long lines; collapse whitespace before matching
+    output = " ".join((result.stdout + result.stderr).split())
+    assert (
+        "did you mean `task_type: action`" in output
+    ), f"expected canonical suggestion in output — got: {output!r}"
+    assert (
+        "tasks/templates/default.md" in output
+    ), f"expected template pointer in output — got: {output!r}"
+
+
+def test_task_type_unknown_value_no_suggestion(tmp_path: Path) -> None:
+    """An unknown task_type with no synonym should fail without a 'did you mean' hint."""
+    f = _make_task(
+        tmp_path,
+        "---\nstate: active\ncreated: 2026-03-02\ntask_type: bogus\n---\n# Task\n",
+    )
+    result = _run([str(f)])
+    assert result.returncode != 0, "validator must reject unknown task_type values"
+    output = result.stdout + result.stderr
+    assert (
+        "did you mean" not in output
+    ), f"unknown task_type should not produce a suggestion — got: {output!r}"
+    assert (
+        "tasks/templates/default.md" in output
+    ), f"expected template pointer even for unknown values — got: {output!r}"

--- a/tests/test_validate_task_frontmatter_exit.py
+++ b/tests/test_validate_task_frontmatter_exit.py
@@ -149,3 +149,19 @@ def test_task_type_wrong_case_suggests_lowercase(tmp_path: Path) -> None:
     assert (
         "did you mean `task_type: action`" in output
     ), f"expected lowercase canonical suggestion — got: {output!r}"
+
+
+def test_task_type_no_template_hint_for_tweets(tmp_path: Path) -> None:
+    """When --type tweets, invalid task_type must NOT point at tasks/templates/default.md."""
+    f = tmp_path / "test-tweet.yml"
+    f.write_text(
+        "---\nstate: approved\ncreated: 2026-03-02\ntask_type: research\n---\n"
+    )
+    result = _run(["--type", "tweets", str(f)])
+    assert (
+        result.returncode != 0
+    ), "validator must reject invalid task_type for tweets too"
+    output = result.stdout + result.stderr
+    assert (
+        "tasks/templates/default.md" not in output
+    ), f"tweet validation must not reference tasks template — got: {output!r}"

--- a/tests/test_validate_task_frontmatter_exit.py
+++ b/tests/test_validate_task_frontmatter_exit.py
@@ -135,3 +135,17 @@ def test_task_type_unknown_value_no_suggestion(tmp_path: Path) -> None:
     assert (
         "tasks/templates/default.md" in output
     ), f"expected template pointer even for unknown values — got: {output!r}"
+
+
+def test_task_type_wrong_case_suggests_lowercase(tmp_path: Path) -> None:
+    """'task_type: Action' (wrong case) should suggest 'task_type: action'."""
+    f = _make_task(
+        tmp_path,
+        "---\nstate: active\ncreated: 2026-03-02\ntask_type: Action\n---\n# Task\n",
+    )
+    result = _run([str(f)])
+    assert result.returncode != 0, "validator must reject wrong-case task_type values"
+    output = " ".join((result.stdout + result.stderr).split())
+    assert (
+        "did you mean `task_type: action`" in output
+    ), f"expected lowercase canonical suggestion — got: {output!r}"


### PR DESCRIPTION
## Problem

Task frontmatter often uses an agent-intuitive `task_type` like `research`, `chore`, or `bug` instead of the canonical GTD values (`action` / `project`). The validator rejected these with a bare `"Invalid task_type: ... Must be one of: project, action"` message, leaving the author to guess the mapping.

## Fix

- Add `TASK_TYPE_SYNONYMS` mapping (`research`/`investigation`/`chore`/`bug`/`decision`/`task` → `action`; `epic` → `project`).
- When an invalid `task_type` is a known synonym, append a `— did you mean task_type: <canonical>?` suggestion.
- Point at `tasks/templates/default.md` for examples.

## Verification

- `python3 -m pytest tests/test_validate_task_frontmatter_exit.py -q` → 6 passed.
- pre-commit (mypy, ruff) clean.
