### PR TITLE
feat(pm): rename greptile_needs_{fix,improvement} to reviewer_needs_{fix,improvement}

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/merge_lifecycle.py
+++ b/packages/gptme-runloops/src/gptme_runloops/merge_lifecycle.py
@@ -134,7 +134,9 @@ class InstructionKind(Enum):
     GREPTILE_NEEDS_FIX = "greptile_needs_fix"  # lib.sh:886-912
     GREPTILE_NEEDS_IMPROVEMENT = "greptile_needs_improvement"  # lib.sh:913-932
     REVIEWER_NEEDS_FIX = "reviewer_needs_fix"  # renamed from greptile_needs_fix
-    REVIEWER_NEEDS_IMPROVEMENT = "reviewer_needs_improvement"  # renamed from greptile_needs_improvement
+    REVIEWER_NEEDS_IMPROVEMENT = (
+        "reviewer_needs_improvement"  # renamed from greptile_needs_improvement
+    )
     GREPTILE_CONVERGENCE = "greptile_convergence"  # lib.sh:889-893 adjudication
 
 
@@ -189,7 +191,10 @@ def greptile_convergence_applicable(item: WorkItem, *, helper_available: bool) -
     """
     if not helper_available or not item.types:
         return False
-    return all(t in {"greptile_needs_improvement", "reviewer_needs_improvement"} for t in item.types)
+    return all(
+        t in {"greptile_needs_improvement", "reviewer_needs_improvement"}
+        for t in item.types
+    )
 
 
 def decide_greptile_convergence(

--- a/packages/gptme-runloops/src/gptme_runloops/merge_lifecycle.py
+++ b/packages/gptme-runloops/src/gptme_runloops/merge_lifecycle.py
@@ -137,6 +137,10 @@ class InstructionKind(Enum):
     REVIEWER_NEEDS_IMPROVEMENT = (
         "reviewer_needs_improvement"  # renamed from greptile_needs_improvement
     )
+    AI_REVIEW_NEEDS_FIX = "ai_review_needs_fix"  # reviewer_needs_fix, source=ai-review
+    AI_REVIEW_NEEDS_IMPROVEMENT = (
+        "ai_review_needs_improvement"  # reviewer_needs_improvement, source=ai-review
+    )
     GREPTILE_CONVERGENCE = "greptile_convergence"  # lib.sh:889-893 adjudication
 
 

--- a/packages/gptme-runloops/src/gptme_runloops/merge_lifecycle.py
+++ b/packages/gptme-runloops/src/gptme_runloops/merge_lifecycle.py
@@ -133,6 +133,8 @@ class InstructionKind(Enum):
     CROSS_REPO_GREPTILE_REFRESH = "cross_repo_greptile_refresh"  # lib.sh:474-517
     GREPTILE_NEEDS_FIX = "greptile_needs_fix"  # lib.sh:886-912
     GREPTILE_NEEDS_IMPROVEMENT = "greptile_needs_improvement"  # lib.sh:913-932
+    REVIEWER_NEEDS_FIX = "reviewer_needs_fix"  # renamed from greptile_needs_fix
+    REVIEWER_NEEDS_IMPROVEMENT = "reviewer_needs_improvement"  # renamed from greptile_needs_improvement
     GREPTILE_CONVERGENCE = "greptile_convergence"  # lib.sh:889-893 adjudication
 
 
@@ -187,7 +189,7 @@ def greptile_convergence_applicable(item: WorkItem, *, helper_available: bool) -
     """
     if not helper_available or not item.types:
         return False
-    return all(t == "greptile_needs_improvement" for t in item.types)
+    return all(t in {"greptile_needs_improvement", "reviewer_needs_improvement"} for t in item.types)
 
 
 def decide_greptile_convergence(

--- a/packages/gptme-runloops/src/gptme_runloops/merge_lifecycle.py
+++ b/packages/gptme-runloops/src/gptme_runloops/merge_lifecycle.py
@@ -195,6 +195,10 @@ def greptile_convergence_applicable(item: WorkItem, *, helper_available: bool) -
     """
     if not helper_available or not item.types:
         return False
+    # ai-review items must not enter Greptile backoff logic — the convergence
+    # path consults greptile-helper which is irrelevant for that source.
+    if item.source == "ai-review":
+        return False
     return all(
         t in {"greptile_needs_improvement", "reviewer_needs_improvement"}
         for t in item.types
@@ -271,6 +275,7 @@ class WorkItem:
     repo: str
     number: int | str
     types: tuple[str, ...] = ()
+    source: str = ""  # e.g. "greptile" or "ai-review"; empty = legacy/unknown
 
 
 @dataclass(frozen=True)

--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -453,8 +453,12 @@ def classify_item_work_type(types: list[str], repo: str | None = None) -> str:
         return "strategy-reply"
     if types_set & {"ci_failure", "master_ci_failure"}:
         return "ci-fix"
-    if types_set & {"greptile_needs_fix", "greptile_needs_improvement",
-                    "reviewer_needs_fix", "reviewer_needs_improvement"}:
+    if types_set & {
+        "greptile_needs_fix",
+        "greptile_needs_improvement",
+        "reviewer_needs_fix",
+        "reviewer_needs_improvement",
+    }:
         return "greptile-fix"
     if "greptile_convergence_adjudication" in types_set:
         # Adjudication is a deep review-and-classify task — distinct arm from

--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -35,6 +35,8 @@ SLOW_LANE_TYPES: set[str] = {
     "merge_conflict",
     "greptile_needs_fix",
     "greptile_needs_improvement",
+    "reviewer_needs_fix",
+    "reviewer_needs_improvement",
     "greptile_convergence_adjudication",
 }
 
@@ -451,7 +453,8 @@ def classify_item_work_type(types: list[str], repo: str | None = None) -> str:
         return "strategy-reply"
     if types_set & {"ci_failure", "master_ci_failure"}:
         return "ci-fix"
-    if types_set & {"greptile_needs_fix", "greptile_needs_improvement"}:
+    if types_set & {"greptile_needs_fix", "greptile_needs_improvement",
+                    "reviewer_needs_fix", "reviewer_needs_improvement"}:
         return "greptile-fix"
     if "greptile_convergence_adjudication" in types_set:
         # Adjudication is a deep review-and-classify task — distinct arm from

--- a/packages/gptme-runloops/src/gptme_runloops/prompt_templates.py
+++ b/packages/gptme-runloops/src/gptme_runloops/prompt_templates.py
@@ -1166,10 +1166,10 @@ def build_investigate(types: Sequence[str], params: ItemPromptParams) -> str:
             sections.append(render_instruction(kind, params.to_prompt_context()))
             continue
         try:
-            kind = ItemPromptKind(t)
+            item_kind = ItemPromptKind(t)
         except ValueError:
             continue
-        sections.append(render_item_investigate(kind, params))
+        sections.append(render_item_investigate(item_kind, params))
     return "".join(sections)
 
 

--- a/packages/gptme-runloops/src/gptme_runloops/prompt_templates.py
+++ b/packages/gptme-runloops/src/gptme_runloops/prompt_templates.py
@@ -492,6 +492,12 @@ _VARIANTS: dict[InstructionKind, tuple[str, Mapping[str, str]]] = {
         _INVESTIGATE_SKELETON,
         _NEEDS_IMPROVEMENT_SECTIONS,
     ),
+    # source-agnostic renames — same templates as their greptile counterparts
+    InstructionKind.REVIEWER_NEEDS_FIX: (_INVESTIGATE_SKELETON, _NEEDS_FIX_SECTIONS),
+    InstructionKind.REVIEWER_NEEDS_IMPROVEMENT: (
+        _INVESTIGATE_SKELETON,
+        _NEEDS_IMPROVEMENT_SECTIONS,
+    ),
 }
 
 
@@ -554,6 +560,9 @@ def render_instruction(kind: InstructionKind, ctx: PromptContext) -> str:
 _GREPTILE_INVESTIGATE_KINDS: dict[str, InstructionKind] = {
     "greptile_needs_fix": InstructionKind.GREPTILE_NEEDS_FIX,
     "greptile_needs_improvement": InstructionKind.GREPTILE_NEEDS_IMPROVEMENT,
+    # source-agnostic renames (backward-compat: old names stay above)
+    "reviewer_needs_fix": InstructionKind.REVIEWER_NEEDS_FIX,
+    "reviewer_needs_improvement": InstructionKind.REVIEWER_NEEDS_IMPROVEMENT,
 }
 
 

--- a/packages/gptme-runloops/src/gptme_runloops/prompt_templates.py
+++ b/packages/gptme-runloops/src/gptme_runloops/prompt_templates.py
@@ -405,6 +405,67 @@ _NEEDS_IMPROVEMENT_SECTIONS = {
     ),
 }
 
+# Investigate arm for reviewer_needs_fix / reviewer_needs_improvement when
+# source=ai-review.  No greptile re-trigger step — our AI reviewer fires
+# automatically on the next push, so there is nothing to manually trigger.
+_AI_REVIEW_INVESTIGATE_SKELETON = """
+### {title}
+```bash
+{read_commands}
+```
+
+{assessment}
+
+{warnings}
+"""
+
+_AI_REVIEW_NEEDS_FIX_SECTIONS: dict[str, str] = {
+    "title": "AI Reviewer Findings (score < 4/5)",
+    "read_commands": (
+        "# Read the PR and our AI reviewer's findings\n"
+        "gh pr view {number} --repo {repo}\n"
+        "gh pr view {number} --repo {repo} --comments\n"
+        "\n"
+        "# Get our AI reviewer's inline findings (marked <!-- bob-ai-review -->)\n"
+        "gh api repos/{repo}/pulls/{number}/comments \\\n"
+        '  --jq \'.[] | select(.body | test("<!-- bob-ai-review -->"; "i"))'
+        ' | {id, path, line, body: (.body | split("\\n")[0:5] | join(" "))}\''
+    ),
+    "assessment": (
+        "This PR has a low score from our AI reviewer (not Greptile).\n"
+        "**Action**: Read the findings in the summary comment and inline threads,"
+        " fix the real issues, push commits."
+    ),
+    "warnings": (
+        "Warning: **This is an AI-reviewer dispatch, not Greptile.**"
+        " Do NOT trigger Greptile to clear it.\n"
+        "The reviewer runs automatically on the next push"
+        " — no manual trigger needed or wanted.\n"
+        "If you cannot fix the issues in this session, leave it for the next cycle."
+    ),
+}
+
+_AI_REVIEW_NEEDS_IMPROVEMENT_SECTIONS: dict[str, str] = {
+    "title": "AI Reviewer Findings (score = 4/5)",
+    "read_commands": (
+        "# Read the PR and our AI reviewer's findings\n"
+        "gh pr view {number} --repo {repo}\n"
+        "gh api repos/{repo}/pulls/{number}/comments \\\n"
+        '  --jq \'.[] | select(.body | test("<!-- bob-ai-review -->"; "i"))'
+        ' | {id, path, line, body: (.body | split("\\n")[0:3] | join(" "))}\''
+    ),
+    "assessment": (
+        "This PR scored 4/5 from our AI reviewer — minor issues."
+        " Address them if quick; leave it untouched if trivial.\n"
+        "Do NOT re-trigger the reviewer just because you looked at it."
+    ),
+    "warnings": (
+        "Warning: **Never push trivial changes just to chase 5/5.**\n"
+        "The AI reviewer runs automatically on the next push"
+        " — no manual trigger needed."
+    ),
+}
+
 
 # --- Variant table ---
 
@@ -493,10 +554,20 @@ _VARIANTS: dict[InstructionKind, tuple[str, Mapping[str, str]]] = {
         _NEEDS_IMPROVEMENT_SECTIONS,
     ),
     # source-agnostic renames — same templates as their greptile counterparts
+    # (used when source=greptile or source absent; see build_investigate)
     InstructionKind.REVIEWER_NEEDS_FIX: (_INVESTIGATE_SKELETON, _NEEDS_FIX_SECTIONS),
     InstructionKind.REVIEWER_NEEDS_IMPROVEMENT: (
         _INVESTIGATE_SKELETON,
         _NEEDS_IMPROVEMENT_SECTIONS,
+    ),
+    # source=ai-review variants — no greptile re-trigger, AI-reviewer commands
+    InstructionKind.AI_REVIEW_NEEDS_FIX: (
+        _AI_REVIEW_INVESTIGATE_SKELETON,
+        _AI_REVIEW_NEEDS_FIX_SECTIONS,
+    ),
+    InstructionKind.AI_REVIEW_NEEDS_IMPROVEMENT: (
+        _AI_REVIEW_INVESTIGATE_SKELETON,
+        _AI_REVIEW_NEEDS_IMPROVEMENT_SECTIONS,
     ),
 }
 
@@ -628,6 +699,7 @@ class ItemPromptParams:
     forum_handle: str = ""
     peer_agents: str = "other agents"
     agent_msg_policy_note: str = ""
+    source: str = ""
     greptile_helper: str | None = None
     pr_address_script: str | None = None
     poll_budget_sec: int = 1800
@@ -1082,11 +1154,16 @@ def build_investigate(types: Sequence[str], params: ItemPromptParams) -> str:
     sections: list[str] = []
     for t in types:
         if t in _GREPTILE_INVESTIGATE_KINDS:
-            sections.append(
-                render_instruction(
-                    _GREPTILE_INVESTIGATE_KINDS[t], params.to_prompt_context()
-                )
-            )
+            kind = _GREPTILE_INVESTIGATE_KINDS[t]
+            # Route reviewer_needs_* to the source-specific template when the
+            # item carries a non-Greptile source.  Greptile-source items and
+            # legacy items without a source keep the existing Greptile template.
+            if params.source == "ai-review":
+                if t == "reviewer_needs_fix":
+                    kind = InstructionKind.AI_REVIEW_NEEDS_FIX
+                elif t == "reviewer_needs_improvement":
+                    kind = InstructionKind.AI_REVIEW_NEEDS_IMPROVEMENT
+            sections.append(render_instruction(kind, params.to_prompt_context()))
             continue
         try:
             kind = ItemPromptKind(t)

--- a/packages/gptme-runloops/src/gptme_runloops/prompt_templates.py
+++ b/packages/gptme-runloops/src/gptme_runloops/prompt_templates.py
@@ -426,9 +426,9 @@ _AI_REVIEW_NEEDS_FIX_SECTIONS: dict[str, str] = {
         "gh pr view {number} --repo {repo}\n"
         "gh pr view {number} --repo {repo} --comments\n"
         "\n"
-        "# Get our AI reviewer's inline findings (marked <!-- bob-ai-review -->)\n"
+        "# Get our AI reviewer's inline findings (marked <!-- bob-ai-review-finding -->)\n"
         "gh api repos/{repo}/pulls/{number}/comments \\\n"
-        '  --jq \'.[] | select(.body | test("<!-- bob-ai-review -->"; "i"))'
+        '  --jq \'.[] | select(.body | test("<!-- bob-ai-review-finding -->"; "i"))'
         ' | {id, path, line, body: (.body | split("\\n")[0:5] | join(" "))}\''
     ),
     "assessment": (
@@ -451,7 +451,7 @@ _AI_REVIEW_NEEDS_IMPROVEMENT_SECTIONS: dict[str, str] = {
         "# Read the PR and our AI reviewer's findings\n"
         "gh pr view {number} --repo {repo}\n"
         "gh api repos/{repo}/pulls/{number}/comments \\\n"
-        '  --jq \'.[] | select(.body | test("<!-- bob-ai-review -->"; "i"))'
+        '  --jq \'.[] | select(.body | test("<!-- bob-ai-review-finding -->"; "i"))'
         ' | {id, path, line, body: (.body | split("\\n")[0:3] | join(" "))}\''
     ),
     "assessment": (

--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -256,6 +256,7 @@ class RunItem:
             repo=self.repo,
             number=self.number if self.number is not None else "",
             types=self.types,
+            source=str(self.raw.get("source", "") or ""),
         )
 
 

--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -411,6 +411,7 @@ class RunItemConfig:
             peer_agents=self.peer_agents,
             agent_msg_policy_note=self.agent_msg_policy_note,
             poll_budget_sec=self.poll_budget_sec,
+            source=str(item.raw.get("source") or ""),
         )
 
 

--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -161,6 +161,8 @@ THREAD_DELIVERABLE_TYPES: frozenset[str] = frozenset(
         "merge_ready",
         "greptile_needs_improvement",
         "greptile_needs_fix",
+        "reviewer_needs_improvement",
+        "reviewer_needs_fix",
         "merge_conflict",
         "notification",
     }
@@ -520,7 +522,11 @@ def timeout_tier(
         or instruction_kind == "GREPTILE_CONVERGENCE"
     ):
         return config.adjudication_timeout, config.adjudication_time_desc
-    if "greptile_needs_fix" in types or ("pr_update" in types and has_greptile_fix):
+    if (
+        "greptile_needs_fix" in types
+        or "reviewer_needs_fix" in types
+        or ("pr_update" in types and has_greptile_fix)
+    ):
         return config.greptile_fix_timeout, config.greptile_fix_time_desc
     return config.default_timeout, config.default_time_desc
 

--- a/packages/gptme-runloops/tests/goldens/prompt_templates/ai_review_needs_fix.alice.txt
+++ b/packages/gptme-runloops/tests/goldens/prompt_templates/ai_review_needs_fix.alice.txt
@@ -1,0 +1,18 @@
+
+### AI Reviewer Findings (score < 4/5)
+```bash
+# Read the PR and our AI reviewer's findings
+gh pr view 7 --repo ErikBjare/alice
+gh pr view 7 --repo ErikBjare/alice --comments
+
+# Get our AI reviewer's inline findings (marked <!-- bob-ai-review -->)
+gh api repos/ErikBjare/alice/pulls/7/comments \
+  --jq '.[] | select(.body | test("<!-- bob-ai-review -->"; "i")) | {id, path, line, body: (.body | split("\n")[0:5] | join(" "))}'
+```
+
+This PR has a low score from our AI reviewer (not Greptile).
+**Action**: Read the findings in the summary comment and inline threads, fix the real issues, push commits.
+
+Warning: **This is an AI-reviewer dispatch, not Greptile.** Do NOT trigger Greptile to clear it.
+The reviewer runs automatically on the next push — no manual trigger needed or wanted.
+If you cannot fix the issues in this session, leave it for the next cycle.

--- a/packages/gptme-runloops/tests/goldens/prompt_templates/ai_review_needs_fix.alice.txt
+++ b/packages/gptme-runloops/tests/goldens/prompt_templates/ai_review_needs_fix.alice.txt
@@ -5,9 +5,9 @@
 gh pr view 7 --repo ErikBjare/alice
 gh pr view 7 --repo ErikBjare/alice --comments
 
-# Get our AI reviewer's inline findings (marked <!-- bob-ai-review -->)
+# Get our AI reviewer's inline findings (marked <!-- bob-ai-review-finding -->)
 gh api repos/ErikBjare/alice/pulls/7/comments \
-  --jq '.[] | select(.body | test("<!-- bob-ai-review -->"; "i")) | {id, path, line, body: (.body | split("\n")[0:5] | join(" "))}'
+  --jq '.[] | select(.body | test("<!-- bob-ai-review-finding -->"; "i")) | {id, path, line, body: (.body | split("\n")[0:5] | join(" "))}'
 ```
 
 This PR has a low score from our AI reviewer (not Greptile).

--- a/packages/gptme-runloops/tests/goldens/prompt_templates/ai_review_needs_fix.bob.txt
+++ b/packages/gptme-runloops/tests/goldens/prompt_templates/ai_review_needs_fix.bob.txt
@@ -1,0 +1,18 @@
+
+### AI Reviewer Findings (score < 4/5)
+```bash
+# Read the PR and our AI reviewer's findings
+gh pr view 1234 --repo gptme/gptme-contrib
+gh pr view 1234 --repo gptme/gptme-contrib --comments
+
+# Get our AI reviewer's inline findings (marked <!-- bob-ai-review -->)
+gh api repos/gptme/gptme-contrib/pulls/1234/comments \
+  --jq '.[] | select(.body | test("<!-- bob-ai-review -->"; "i")) | {id, path, line, body: (.body | split("\n")[0:5] | join(" "))}'
+```
+
+This PR has a low score from our AI reviewer (not Greptile).
+**Action**: Read the findings in the summary comment and inline threads, fix the real issues, push commits.
+
+Warning: **This is an AI-reviewer dispatch, not Greptile.** Do NOT trigger Greptile to clear it.
+The reviewer runs automatically on the next push — no manual trigger needed or wanted.
+If you cannot fix the issues in this session, leave it for the next cycle.

--- a/packages/gptme-runloops/tests/goldens/prompt_templates/ai_review_needs_fix.bob.txt
+++ b/packages/gptme-runloops/tests/goldens/prompt_templates/ai_review_needs_fix.bob.txt
@@ -5,9 +5,9 @@
 gh pr view 1234 --repo gptme/gptme-contrib
 gh pr view 1234 --repo gptme/gptme-contrib --comments
 
-# Get our AI reviewer's inline findings (marked <!-- bob-ai-review -->)
+# Get our AI reviewer's inline findings (marked <!-- bob-ai-review-finding -->)
 gh api repos/gptme/gptme-contrib/pulls/1234/comments \
-  --jq '.[] | select(.body | test("<!-- bob-ai-review -->"; "i")) | {id, path, line, body: (.body | split("\n")[0:5] | join(" "))}'
+  --jq '.[] | select(.body | test("<!-- bob-ai-review-finding -->"; "i")) | {id, path, line, body: (.body | split("\n")[0:5] | join(" "))}'
 ```
 
 This PR has a low score from our AI reviewer (not Greptile).

--- a/packages/gptme-runloops/tests/goldens/prompt_templates/ai_review_needs_improvement.alice.txt
+++ b/packages/gptme-runloops/tests/goldens/prompt_templates/ai_review_needs_improvement.alice.txt
@@ -4,7 +4,7 @@
 # Read the PR and our AI reviewer's findings
 gh pr view 7 --repo ErikBjare/alice
 gh api repos/ErikBjare/alice/pulls/7/comments \
-  --jq '.[] | select(.body | test("<!-- bob-ai-review -->"; "i")) | {id, path, line, body: (.body | split("\n")[0:3] | join(" "))}'
+  --jq '.[] | select(.body | test("<!-- bob-ai-review-finding -->"; "i")) | {id, path, line, body: (.body | split("\n")[0:3] | join(" "))}'
 ```
 
 This PR scored 4/5 from our AI reviewer — minor issues. Address them if quick; leave it untouched if trivial.

--- a/packages/gptme-runloops/tests/goldens/prompt_templates/ai_review_needs_improvement.alice.txt
+++ b/packages/gptme-runloops/tests/goldens/prompt_templates/ai_review_needs_improvement.alice.txt
@@ -1,0 +1,14 @@
+
+### AI Reviewer Findings (score = 4/5)
+```bash
+# Read the PR and our AI reviewer's findings
+gh pr view 7 --repo ErikBjare/alice
+gh api repos/ErikBjare/alice/pulls/7/comments \
+  --jq '.[] | select(.body | test("<!-- bob-ai-review -->"; "i")) | {id, path, line, body: (.body | split("\n")[0:3] | join(" "))}'
+```
+
+This PR scored 4/5 from our AI reviewer — minor issues. Address them if quick; leave it untouched if trivial.
+Do NOT re-trigger the reviewer just because you looked at it.
+
+Warning: **Never push trivial changes just to chase 5/5.**
+The AI reviewer runs automatically on the next push — no manual trigger needed.

--- a/packages/gptme-runloops/tests/goldens/prompt_templates/ai_review_needs_improvement.bob.txt
+++ b/packages/gptme-runloops/tests/goldens/prompt_templates/ai_review_needs_improvement.bob.txt
@@ -4,7 +4,7 @@
 # Read the PR and our AI reviewer's findings
 gh pr view 1234 --repo gptme/gptme-contrib
 gh api repos/gptme/gptme-contrib/pulls/1234/comments \
-  --jq '.[] | select(.body | test("<!-- bob-ai-review -->"; "i")) | {id, path, line, body: (.body | split("\n")[0:3] | join(" "))}'
+  --jq '.[] | select(.body | test("<!-- bob-ai-review-finding -->"; "i")) | {id, path, line, body: (.body | split("\n")[0:3] | join(" "))}'
 ```
 
 This PR scored 4/5 from our AI reviewer — minor issues. Address them if quick; leave it untouched if trivial.

--- a/packages/gptme-runloops/tests/goldens/prompt_templates/ai_review_needs_improvement.bob.txt
+++ b/packages/gptme-runloops/tests/goldens/prompt_templates/ai_review_needs_improvement.bob.txt
@@ -1,0 +1,14 @@
+
+### AI Reviewer Findings (score = 4/5)
+```bash
+# Read the PR and our AI reviewer's findings
+gh pr view 1234 --repo gptme/gptme-contrib
+gh api repos/gptme/gptme-contrib/pulls/1234/comments \
+  --jq '.[] | select(.body | test("<!-- bob-ai-review -->"; "i")) | {id, path, line, body: (.body | split("\n")[0:3] | join(" "))}'
+```
+
+This PR scored 4/5 from our AI reviewer — minor issues. Address them if quick; leave it untouched if trivial.
+Do NOT re-trigger the reviewer just because you looked at it.
+
+Warning: **Never push trivial changes just to chase 5/5.**
+The AI reviewer runs automatically on the next push — no manual trigger needed.

--- a/packages/gptme-runloops/tests/goldens/prompt_templates/reviewer_needs_fix.alice.txt
+++ b/packages/gptme-runloops/tests/goldens/prompt_templates/reviewer_needs_fix.alice.txt
@@ -1,0 +1,25 @@
+
+### Greptile Score Fix Needed (score < 4/5)
+```bash
+# Read the PR and full Greptile review comments
+gh pr view 7 --repo ErikBjare/alice
+gh pr view 7 --repo ErikBjare/alice --comments
+
+# Get Greptile's review comments (the ones that need fixing)
+gh api repos/ErikBjare/alice/pulls/7/comments \
+  --jq '.[] | select(.user.login | test("greptile"; "i")) | {id, path, line, body: (.body | split("\n")[0:5] | join(" "))}'
+
+# Get Greptile's summary review comment (contains score like 3/5 or 4/5)
+gh api repos/ErikBjare/alice/issues/7/comments \
+  --jq '.[] | select(.user.login | test("greptile"; "i")) | {id, body} | select(.body | test("/5"))' | tail -5
+```
+
+This PR has a low Greptile score and likely has real code issues.
+**Action**: Read the Greptile findings, fix the issues in the PR's repo, push commits, then re-trigger:
+```bash
+bash /srv/agents/alice/workspace/scripts/github/greptile-helper.sh trigger ErikBjare/alice 7
+```
+
+⚠️ **Only re-trigger if you ACTUALLY pushed fixes addressing the Greptile findings.**
+If you cannot fix the issues in this session, do NOT re-trigger — leave it for the next cycle.
+NEVER post raw `@greptileai review` directly — ALWAYS use the helper script above (it has spam guards).

--- a/packages/gptme-runloops/tests/goldens/prompt_templates/reviewer_needs_fix.bob.txt
+++ b/packages/gptme-runloops/tests/goldens/prompt_templates/reviewer_needs_fix.bob.txt
@@ -1,0 +1,25 @@
+
+### Greptile Score Fix Needed (score < 4/5)
+```bash
+# Read the PR and full Greptile review comments
+gh pr view 1234 --repo gptme/gptme-contrib
+gh pr view 1234 --repo gptme/gptme-contrib --comments
+
+# Get Greptile's review comments (the ones that need fixing)
+gh api repos/gptme/gptme-contrib/pulls/1234/comments \
+  --jq '.[] | select(.user.login | test("greptile"; "i")) | {id, path, line, body: (.body | split("\n")[0:5] | join(" "))}'
+
+# Get Greptile's summary review comment (contains score like 3/5 or 4/5)
+gh api repos/gptme/gptme-contrib/issues/1234/comments \
+  --jq '.[] | select(.user.login | test("greptile"; "i")) | {id, body} | select(.body | test("/5"))' | tail -5
+```
+
+This PR has a low Greptile score and likely has real code issues.
+**Action**: Read the Greptile findings, fix the issues in the PR's repo, push commits, then re-trigger:
+```bash
+bash /home/bob/bob/scripts/github/greptile-helper.sh trigger gptme/gptme-contrib 1234
+```
+
+⚠️ **Only re-trigger if you ACTUALLY pushed fixes addressing the Greptile findings.**
+If you cannot fix the issues in this session, do NOT re-trigger — leave it for the next cycle.
+NEVER post raw `@greptileai review` directly — ALWAYS use the helper script above (it has spam guards).

--- a/packages/gptme-runloops/tests/goldens/prompt_templates/reviewer_needs_improvement.alice.txt
+++ b/packages/gptme-runloops/tests/goldens/prompt_templates/reviewer_needs_improvement.alice.txt
@@ -1,0 +1,18 @@
+
+### Greptile Score Improvement (score = 4/5)
+```bash
+# Read the PR and Greptile review comments
+gh pr view 7 --repo ErikBjare/alice
+gh api repos/ErikBjare/alice/pulls/7/comments \
+  --jq '.[] | select(.user.login | test("greptile"; "i")) | {id, path, line, body: (.body | split("\n")[0:3] | join(" "))}'
+```
+
+This PR scored 4/5 — minor issues from Greptile. Address them if quick; **leave it untouched if trivial** (do NOT re-trigger just because you looked at it).
+Re-trigger ONLY if you actually pushed fixes:
+```bash
+bash /srv/agents/alice/workspace/scripts/github/greptile-helper.sh trigger ErikBjare/alice 7
+```
+
+⚠️ **Never re-trigger without having pushed at least one fix commit.**
+NEVER post raw `@greptileai review` directly — ALWAYS use the helper script above.
+If you skip fixing (issues are truly trivial or out of scope), leave the PR alone and do NOT re-trigger.

--- a/packages/gptme-runloops/tests/goldens/prompt_templates/reviewer_needs_improvement.bob.txt
+++ b/packages/gptme-runloops/tests/goldens/prompt_templates/reviewer_needs_improvement.bob.txt
@@ -1,0 +1,18 @@
+
+### Greptile Score Improvement (score = 4/5)
+```bash
+# Read the PR and Greptile review comments
+gh pr view 1234 --repo gptme/gptme-contrib
+gh api repos/gptme/gptme-contrib/pulls/1234/comments \
+  --jq '.[] | select(.user.login | test("greptile"; "i")) | {id, path, line, body: (.body | split("\n")[0:3] | join(" "))}'
+```
+
+This PR scored 4/5 — minor issues from Greptile. Address them if quick; **leave it untouched if trivial** (do NOT re-trigger just because you looked at it).
+Re-trigger ONLY if you actually pushed fixes:
+```bash
+bash /home/bob/bob/scripts/github/greptile-helper.sh trigger gptme/gptme-contrib 1234
+```
+
+⚠️ **Never re-trigger without having pushed at least one fix commit.**
+NEVER post raw `@greptileai review` directly — ALWAYS use the helper script above.
+If you skip fixing (issues are truly trivial or out of scope), leave the PR alone and do NOT re-trigger.

--- a/packages/gptme-runloops/tests/test_pm_dispatch.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch.py
@@ -179,6 +179,9 @@ class TestClassifyLane:
             "greptile_needs_fix",
             "greptile_needs_improvement",
             "greptile_convergence_adjudication",
+            # source-agnostic renames (backward-compat: old names stay above)
+            "reviewer_needs_fix",
+            "reviewer_needs_improvement",
         }
         assert SLOW_LANE_TYPES == expected
 

--- a/packages/gptme-runloops/tests/test_pm_dispatch.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch.py
@@ -2132,9 +2132,9 @@ class TestSlotCooldownHelpers:
             with caplog.at_level(logging.WARNING, logger="gptme_runloops.pm_dispatch"):
                 result = _write_slot_dispatch_marker("slot-z", ro_dir)
             assert result is False
-            assert any("slot-z" in r.message for r in caplog.records), (
-                "Expected warning mentioning slot name"
-            )
+            assert any(
+                "slot-z" in r.message for r in caplog.records
+            ), "Expected warning mentioning slot name"
         finally:
             ro_dir.chmod(0o755)
 

--- a/packages/gptme-runloops/tests/test_pm_dispatch.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch.py
@@ -2132,9 +2132,9 @@ class TestSlotCooldownHelpers:
             with caplog.at_level(logging.WARNING, logger="gptme_runloops.pm_dispatch"):
                 result = _write_slot_dispatch_marker("slot-z", ro_dir)
             assert result is False
-            assert any(
-                "slot-z" in r.message for r in caplog.records
-            ), "Expected warning mentioning slot name"
+            assert any("slot-z" in r.message for r in caplog.records), (
+                "Expected warning mentioning slot name"
+            )
         finally:
             ro_dir.chmod(0o755)
 

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -208,6 +208,8 @@ emit_item() {
             merge_conflict)         label="CONFLICT" ;;
             reviewer_needs_fix)     label="REVIEW FIX${source:+ ($source)}" ;;
             reviewer_needs_improvement) label="REVIEW${source:+ ($source)}" ;;
+            greptile_needs_fix)     label="GREPTILE FIX" ;;
+            greptile_needs_improvement) label="GREPTILE" ;;
             merge_ready)            label="MERGE READY" ;;
             *)                      label="$type" ;;
         esac

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -1228,11 +1228,15 @@ check_greptile_scores() {
         # asking for work: reporting "Greptile score: 5/5" on an item routed to
         # the fix arm by OUR findings reads as a contradiction.
         local detail="Greptile score: ${greptile_score}/5"
+        local item_source="greptile"
         if [ "$ai_verdict" = "dirty" ]; then
             detail="${detail} · our AI review has open findings"
+            # When Greptile is satisfied (score >= 5) but our reviewer is not,
+            # the dispatch source is our reviewer, not Greptile.
+            [ "$greptile_score" -ge 5 ] 2>/dev/null && item_source="ai-review"
         fi
         echo "${greptile_score}:${fetched_at}:${head_sha}:${ai_verdict}" > "$state_file"
-        emit_item "$item_type" "$repo" "$pr_number" "$pr_title" "$detail" "greptile" "$item_severity"
+        emit_item "$item_type" "$repo" "$pr_number" "$pr_title" "$detail" "$item_source" "$item_severity"
     done
 }
 

--- a/scripts/github/activity-gate.sh
+++ b/scripts/github/activity-gate.sh
@@ -149,7 +149,8 @@ while [[ $# -gt 0 ]]; do
             echo "  --state-dir Directory for state tracking files (default: /tmp/github-activity-gate-state)"
             echo "  --format    Output format: 'markdown' (default) or 'jsonl' (one JSON object per item)"
             echo ""
-            echo "JSONL format: {\"type\":\"pr_update|ci_failure|merge_ready|greptile_needs_fix|greptile_needs_improvement|assigned_issue|notification\","
+            echo "JSONL format: {\"type\":\"pr_update|ci_failure|merge_ready|reviewer_needs_fix|reviewer_needs_improvement|assigned_issue|notification\","
+            echo "               \"source\":\"greptile|ai-review|human\" (reviewer_needs_* only), \"severity\":\"major|minor\" (reviewer_needs_* only),"
             echo "               \"repo\":\"owner/repo\", \"number\":123, \"title\":\"...\", \"detail\":\"...\"}"
             exit 0
             ;;
@@ -190,23 +191,25 @@ portable_hash() {
 # Emit a work item in the configured format.
 # Args: type repo number title detail
 emit_item() {
-    local type=$1 repo=$2 number=$3 title=$4 detail=${5:-}
+    local type=$1 repo=$2 number=$3 title=$4 detail=${5:-} source=${6:-} severity=${7:-}
     if [ "$FORMAT" = "jsonl" ]; then
-        jq -cn --arg t "$type" --arg r "$repo" --argjson n "$number" --arg title "$title" --arg d "$detail" \
-            '{type: $t, repo: $r, number: $n, title: $title, detail: $d}'
+        jq -cn --arg t "$type" --arg r "$repo" --argjson n "$number" --arg title "$title" \
+            --arg d "$detail" --arg src "$source" --arg sev "$severity" \
+            'if $src != "" then {type: $t, source: $src, severity: $sev, repo: $r, number: $n, title: $title, detail: $d}
+             else {type: $t, repo: $r, number: $n, title: $title, detail: $d} end'
     else
         local label
         case "$type" in
-            pr_update)         label="PR" ;;
-            ci_failure)        label="CI FAIL" ;;
-            assigned_issue)    label="Issue" ;;
-            notification)      label="Notification" ;;
-            master_ci_failure) label="MASTER CI" ;;
-            merge_conflict)        label="CONFLICT" ;;
-            greptile_needs_fix)    label="GREPTILE FIX" ;;
-            greptile_needs_improvement) label="GREPTILE" ;;
-            merge_ready)               label="MERGE READY" ;;
-            *)                     label="$type" ;;
+            pr_update)              label="PR" ;;
+            ci_failure)             label="CI FAIL" ;;
+            assigned_issue)         label="Issue" ;;
+            notification)           label="Notification" ;;
+            master_ci_failure)      label="MASTER CI" ;;
+            merge_conflict)         label="CONFLICT" ;;
+            reviewer_needs_fix)     label="REVIEW FIX${source:+ ($source)}" ;;
+            reviewer_needs_improvement) label="REVIEW${source:+ ($source)}" ;;
+            merge_ready)            label="MERGE READY" ;;
+            *)                      label="$type" ;;
         esac
         echo "$repo — $label #$number: $title ($detail)"
     fi
@@ -938,8 +941,9 @@ check_merge_conflicts() {
 #   HEAD unchanged (covers manual @greptileai triggers via greptile-helper.sh).
 #
 # Emits:
-#   greptile_needs_fix       — score < 4 (significant findings to address)
-#   greptile_needs_improvement — score = 4 (minor fixes needed)
+#   reviewer_needs_fix       — score < 4 (significant findings to address)
+#   reviewer_needs_improvement — score = 4 (minor fixes needed)
+# Both carry source (greptile|ai-review) and severity (major|minor) fields.
 # Does our own AI reviewer still want changes on this PR?
 #
 # Why this exists: check_greptile_scores() reads Greptile's score and nothing
@@ -1131,7 +1135,7 @@ check_greptile_scores() {
                 # Always route dirty AI verdict to greptile_needs_fix, matching the
                 # non-dark path (which sets route_score=3 on dirty → always fix).
                 # dark_score does not change the severity when our AI says fix it.
-                emit_item "greptile_needs_fix" "$repo" "$pr_number" "$pr_title" "$detail"
+                emit_item "reviewer_needs_fix" "$repo" "$pr_number" "$pr_title" "$detail" "ai-review" "major"
             else
                 # clean / pending / none — seed/update state, don't emit.
                 echo ":${fetched_at}:${head_sha}:${ai_verdict}:${dark_score}" > "$state_file"
@@ -1188,11 +1192,13 @@ check_greptile_scores() {
         fi
 
         # Score >= 4 is minor, < 4 needs fix
-        local item_type
+        local item_type item_severity
         if [ "$route_score" -lt 4 ]; then
-            item_type="greptile_needs_fix"
+            item_type="reviewer_needs_fix"
+            item_severity="major"
         else
-            item_type="greptile_needs_improvement"
+            item_type="reviewer_needs_improvement"
+            item_severity="minor"
         fi
 
         if [ -n "$last_state" ]; then
@@ -1224,7 +1230,7 @@ check_greptile_scores() {
             detail="${detail} · our AI review has open findings"
         fi
         echo "${greptile_score}:${fetched_at}:${head_sha}:${ai_verdict}" > "$state_file"
-        emit_item "$item_type" "$repo" "$pr_number" "$pr_title" "$detail"
+        emit_item "$item_type" "$repo" "$pr_number" "$pr_title" "$detail" "greptile" "$item_severity"
     done
 }
 
@@ -1321,11 +1327,13 @@ check_own_pr_review_state() {
         fi
 
         # Determine item type from Greptile score
-        local item_type
+        local item_type item_severity
         if [ "$greptile_score" -lt 4 ] 2>/dev/null; then
-            item_type="greptile_needs_fix"
+            item_type="reviewer_needs_fix"
+            item_severity="major"
         else
-            item_type="greptile_needs_improvement"
+            item_type="reviewer_needs_improvement"
+            item_severity="minor"
         fi
 
         # Emit once per (head_sha, greptile_score, merge_state) signature.
@@ -1345,7 +1353,8 @@ check_own_pr_review_state() {
         # New or changed signature — record and emit
         echo "${signature}:${now}" > "$state_file"
         emit_item "$item_type" "$repo" "$pr_number" "$pr_title" \
-            "own-PR review: Greptile ${greptile_score}/5 (merge_state: ${merge_state})"
+            "own-PR review: Greptile ${greptile_score}/5 (merge_state: ${merge_state})" \
+            "greptile" "$item_severity"
     done
 }
 
@@ -1482,9 +1491,10 @@ check_fix_requests() {
             continue
         fi
 
-        emit_item "greptile_needs_fix" "$repo" "$pr_number" \
+        emit_item "reviewer_needs_fix" "$repo" "$pr_number" \
             "${pr_title} [maintainer fix request]" \
-            "fix_request · maintainer asked us to act on outstanding review findings (comment ${comment_id})"
+            "fix_request · maintainer asked us to act on outstanding review findings (comment ${comment_id})" \
+            "greptile" "major"
     done
 }
 

--- a/tests/test_activity_gate_cache.py
+++ b/tests/test_activity_gate_cache.py
@@ -269,7 +269,7 @@ def test_dirty_ai_verdict_keeps_real_greptile_score_and_is_cached() -> None:
         )
         assert result.returncode == 0, result.stderr
         assert call_count == 1, "Only the uncached AI verdict should be fetched"
-        assert "REVIEW FIX (greptile) #42" in result.stdout
+        assert "REVIEW FIX (ai-review) #42" in result.stdout
         assert "Greptile score: 5/5 · our AI review has open findings" in result.stdout
 
         score, _, sha, verdict = _state_file(state_dir).read_text().split(":")
@@ -281,4 +281,4 @@ def test_dirty_ai_verdict_keeps_real_greptile_score_and_is_cached() -> None:
         )
         assert result.returncode in (0, 1), result.stderr
         assert call_count == 1, "Second sweep must not add another comments fetch"
-        assert "REVIEW FIX (greptile) #42" not in result.stdout
+        assert "REVIEW FIX (ai-review) #42" not in result.stdout

--- a/tests/test_activity_gate_cache.py
+++ b/tests/test_activity_gate_cache.py
@@ -269,7 +269,7 @@ def test_dirty_ai_verdict_keeps_real_greptile_score_and_is_cached() -> None:
         )
         assert result.returncode == 0, result.stderr
         assert call_count == 1, "Only the uncached AI verdict should be fetched"
-        assert "GREPTILE FIX #42" in result.stdout
+        assert "REVIEW FIX (greptile) #42" in result.stdout
         assert "Greptile score: 5/5 · our AI review has open findings" in result.stdout
 
         score, _, sha, verdict = _state_file(state_dir).read_text().split(":")
@@ -281,4 +281,4 @@ def test_dirty_ai_verdict_keeps_real_greptile_score_and_is_cached() -> None:
         )
         assert result.returncode in (0, 1), result.stderr
         assert call_count == 1, "Second sweep must not add another comments fetch"
-        assert "GREPTILE FIX #42" not in result.stdout
+        assert "REVIEW FIX (greptile) #42" not in result.stdout

--- a/tests/test_activity_gate_fix_request.py
+++ b/tests/test_activity_gate_fix_request.py
@@ -251,7 +251,7 @@ def test_trusted_request_emits_one_fix_item() -> None:
 
         items = _fix_items(result)
         assert len(items) == 1, f"expected one fix item, got {items}\n{result.stdout}"
-        assert items[0]["type"] == "greptile_needs_fix", items[0]
+        assert items[0]["type"] == "reviewer_needs_fix", items[0]
         assert items[0]["number"] == TEST_PR
         assert "[maintainer fix request]" in items[0]["title"], items[0]
 

--- a/tests/test_activity_gate_fix_request.py
+++ b/tests/test_activity_gate_fix_request.py
@@ -251,7 +251,9 @@ def test_trusted_request_emits_one_fix_item() -> None:
 
         items = _fix_items(result)
         assert len(items) == 1, f"expected one fix item, got {items}\n{result.stdout}"
-        assert items[0]["type"] in ("greptile_needs_fix", "reviewer_needs_fix"), items[0]
+        assert items[0]["type"] in ("greptile_needs_fix", "reviewer_needs_fix"), items[
+            0
+        ]
         assert items[0]["number"] == TEST_PR
         assert "[maintainer fix request]" in items[0]["title"], items[0]
 

--- a/tests/test_activity_gate_fix_request.py
+++ b/tests/test_activity_gate_fix_request.py
@@ -251,7 +251,9 @@ def test_trusted_request_emits_one_fix_item() -> None:
 
         items = _fix_items(result)
         assert len(items) == 1, f"expected one fix item, got {items}\n{result.stdout}"
-        assert items[0]["type"] == "greptile_needs_fix", items[0]
+        assert items[0]["type"] in ("greptile_needs_fix", "reviewer_needs_fix"), items[
+            0
+        ]
         assert items[0]["number"] == TEST_PR
         assert "[maintainer fix request]" in items[0]["title"], items[0]
 

--- a/tests/test_activity_gate_greptile_dark.py
+++ b/tests/test_activity_gate_greptile_dark.py
@@ -183,7 +183,12 @@ def _greptile_items(result: subprocess.CompletedProcess[str]) -> list[dict]:
             obj = json.loads(line)
         except json.JSONDecodeError:
             continue
-        if obj.get("type") in ("greptile_needs_improvement", "greptile_needs_fix"):
+        if obj.get("type") in (
+            "greptile_needs_improvement",
+            "greptile_needs_fix",
+            "reviewer_needs_improvement",
+            "reviewer_needs_fix",
+        ):
             items.append(obj)
     return items
 
@@ -300,8 +305,8 @@ def test_no_greptile_score_dirty_ai_review_emits_needs_fix() -> None:
             f"expected one greptile item, got {items}\n"
             f"stdout: {result.stdout}\nstderr: {result.stderr}"
         )
-        assert items[0]["type"] == "greptile_needs_fix", (
-            f"dirty AI on Greptile-dark PR must emit greptile_needs_fix (not improvement); "
+        assert items[0]["type"] == "reviewer_needs_fix", (
+            f"dirty AI on Greptile-dark PR must emit reviewer_needs_fix (not improvement); "
             f"got: {items[0]}"
         )
         assert items[0]["number"] == TEST_PR
@@ -488,7 +493,13 @@ def test_dark_branch_preserved_score_does_not_cache_hit() -> None:
         cache_path_items = [
             i
             for i in items
-            if i.get("type") in ("greptile_needs_improvement", "greptile_needs_fix")
+            if i.get("type")
+            in (
+                "greptile_needs_improvement",
+                "greptile_needs_fix",
+                "reviewer_needs_improvement",
+                "reviewer_needs_fix",
+            )
             and "Greptile score:" in (i.get("detail") or "")
         ]
         assert cache_path_items == [], (
@@ -617,16 +628,16 @@ def test_dark_branch_sub4_dark_score_emits_needs_fix() -> None:
             f"expected one dark-branch greptile item; got {items}\n"
             f"stdout: {result.stdout}\nstderr: {result.stderr}"
         )
-        assert dark_items[0]["type"] == "greptile_needs_fix", (
-            f"dark_score=3 (<4) must route to greptile_needs_fix, "
-            f"not greptile_needs_improvement; got: {dark_items[0]}"
+        assert dark_items[0]["type"] == "reviewer_needs_fix", (
+            f"dark_score=3 (<4) must route to reviewer_needs_fix, "
+            f"not reviewer_needs_improvement; got: {dark_items[0]}"
         )
         # Verify no item wrongly uses the improvement lane for a sub-4 score.
         improvement_items = [
-            i for i in items if i.get("type") == "greptile_needs_improvement"
+            i for i in items if i.get("type") == "reviewer_needs_improvement"
         ]
         assert improvement_items == [], (
-            f"no item should use greptile_needs_improvement when dark_score=3 (<4); "
+            f"no item should use reviewer_needs_improvement when dark_score=3 (<4); "
             f"got: {improvement_items}"
         )
 
@@ -677,12 +688,12 @@ def test_dark_branch_high_dark_score_dirty_ai_emits_needs_fix() -> None:
             f"expected one dark-branch greptile item; got {items}\n"
             f"stdout: {result.stdout}\nstderr: {result.stderr}"
         )
-        assert dark_items[0]["type"] == "greptile_needs_fix", (
-            f"dirty AI with dark_score=5 (>=4) must still route to greptile_needs_fix "
-            f"(not greptile_needs_improvement); got: {dark_items[0]}"
+        assert dark_items[0]["type"] == "reviewer_needs_fix", (
+            f"dirty AI with dark_score=5 (>=4) must still route to reviewer_needs_fix "
+            f"(not reviewer_needs_improvement); got: {dark_items[0]}"
         )
         improvement_items = [
-            i for i in items if i.get("type") == "greptile_needs_improvement"
+            i for i in items if i.get("type") == "reviewer_needs_improvement"
         ]
         assert (
             improvement_items == []
@@ -1016,11 +1027,11 @@ def test_check_own_pr_review_state_dark_state_preserved_score_emits_needs_fix() 
                 obj = json.loads(line)
             except json.JSONDecodeError:
                 continue
-            if obj.get("type") == "greptile_needs_fix":
+            if obj.get("type") == "reviewer_needs_fix":
                 greptile_fix_items.append(obj)
 
         assert greptile_fix_items, (
-            f"dark-state preserved score 3 must trigger greptile_needs_fix from "
+            f"dark-state preserved score 3 must trigger reviewer_needs_fix from "
             f"check_own_pr_review_state; got nothing.\n"
             f"stdout: {result.stdout}\nstderr: {result.stderr}"
         )
@@ -1080,21 +1091,26 @@ def test_dark_state_dirty_verdict_no_double_dispatch() -> None:
                 obj = json.loads(line)
             except json.JSONDecodeError:
                 continue
-            if obj.get("type", "").startswith("greptile_"):
+            if obj.get("type", "") in (
+                "greptile_needs_fix",
+                "greptile_needs_improvement",
+                "reviewer_needs_fix",
+                "reviewer_needs_improvement",
+            ):
                 all_items.append(obj)
 
         improvement_items = [
-            i for i in all_items if i.get("type") == "greptile_needs_improvement"
+            i for i in all_items if i.get("type") == "reviewer_needs_improvement"
         ]
         assert improvement_items == [], (
-            f"P1 fix: check_own_pr_review_state must not emit greptile_needs_improvement "
+            f"P1 fix: check_own_pr_review_state must not emit reviewer_needs_improvement "
             f"when dark-state AI verdict is dirty (double-dispatch prevention); "
             f"got: {improvement_items}\nall greptile items: {all_items}\n"
             f"stdout: {result.stdout}\nstderr: {result.stderr}"
         )
-        fix_items = [i for i in all_items if i.get("type") == "greptile_needs_fix"]
+        fix_items = [i for i in all_items if i.get("type") == "reviewer_needs_fix"]
         assert fix_items, (
-            f"P1 fix: greptile_needs_fix must still be emitted by check_greptile_scores "
+            f"P1 fix: reviewer_needs_fix must still be emitted by check_greptile_scores "
             f"when AI verdict is dirty (dark state); "
             f"got no fix items\nall greptile items: {all_items}\n"
             f"stdout: {result.stdout}\nstderr: {result.stderr}"

--- a/tests/test_activity_gate_greptile_dark.py
+++ b/tests/test_activity_gate_greptile_dark.py
@@ -183,7 +183,12 @@ def _greptile_items(result: subprocess.CompletedProcess[str]) -> list[dict]:
             obj = json.loads(line)
         except json.JSONDecodeError:
             continue
-        if obj.get("type") in ("greptile_needs_improvement", "greptile_needs_fix"):
+        if obj.get("type") in (
+            "greptile_needs_improvement",
+            "greptile_needs_fix",
+            "reviewer_needs_improvement",
+            "reviewer_needs_fix",
+        ):
             items.append(obj)
     return items
 
@@ -300,8 +305,8 @@ def test_no_greptile_score_dirty_ai_review_emits_needs_fix() -> None:
             f"expected one greptile item, got {items}\n"
             f"stdout: {result.stdout}\nstderr: {result.stderr}"
         )
-        assert items[0]["type"] == "greptile_needs_fix", (
-            f"dirty AI on Greptile-dark PR must emit greptile_needs_fix (not improvement); "
+        assert items[0]["type"] in ("greptile_needs_fix", "reviewer_needs_fix"), (
+            f"dirty AI on Greptile-dark PR must emit needs_fix (not improvement); "
             f"got: {items[0]}"
         )
         assert items[0]["number"] == TEST_PR
@@ -617,16 +622,19 @@ def test_dark_branch_sub4_dark_score_emits_needs_fix() -> None:
             f"expected one dark-branch greptile item; got {items}\n"
             f"stdout: {result.stdout}\nstderr: {result.stderr}"
         )
-        assert dark_items[0]["type"] == "greptile_needs_fix", (
-            f"dark_score=3 (<4) must route to greptile_needs_fix, "
-            f"not greptile_needs_improvement; got: {dark_items[0]}"
+        assert dark_items[0]["type"] in ("greptile_needs_fix", "reviewer_needs_fix"), (
+            f"dark_score=3 (<4) must route to needs_fix, "
+            f"not needs_improvement; got: {dark_items[0]}"
         )
         # Verify no item wrongly uses the improvement lane for a sub-4 score.
         improvement_items = [
-            i for i in items if i.get("type") == "greptile_needs_improvement"
+            i
+            for i in items
+            if i.get("type")
+            in ("greptile_needs_improvement", "reviewer_needs_improvement")
         ]
         assert improvement_items == [], (
-            f"no item should use greptile_needs_improvement when dark_score=3 (<4); "
+            f"no item should use needs_improvement when dark_score=3 (<4); "
             f"got: {improvement_items}"
         )
 
@@ -677,12 +685,15 @@ def test_dark_branch_high_dark_score_dirty_ai_emits_needs_fix() -> None:
             f"expected one dark-branch greptile item; got {items}\n"
             f"stdout: {result.stdout}\nstderr: {result.stderr}"
         )
-        assert dark_items[0]["type"] == "greptile_needs_fix", (
-            f"dirty AI with dark_score=5 (>=4) must still route to greptile_needs_fix "
-            f"(not greptile_needs_improvement); got: {dark_items[0]}"
+        assert dark_items[0]["type"] in ("greptile_needs_fix", "reviewer_needs_fix"), (
+            f"dirty AI with dark_score=5 (>=4) must still route to needs_fix "
+            f"(not needs_improvement); got: {dark_items[0]}"
         )
         improvement_items = [
-            i for i in items if i.get("type") == "greptile_needs_improvement"
+            i
+            for i in items
+            if i.get("type")
+            in ("greptile_needs_improvement", "reviewer_needs_improvement")
         ]
         assert (
             improvement_items == []
@@ -1016,7 +1027,7 @@ def test_check_own_pr_review_state_dark_state_preserved_score_emits_needs_fix() 
                 obj = json.loads(line)
             except json.JSONDecodeError:
                 continue
-            if obj.get("type") == "greptile_needs_fix":
+            if obj.get("type") in ("greptile_needs_fix", "reviewer_needs_fix"):
                 greptile_fix_items.append(obj)
 
         assert greptile_fix_items, (
@@ -1080,21 +1091,28 @@ def test_dark_state_dirty_verdict_no_double_dispatch() -> None:
                 obj = json.loads(line)
             except json.JSONDecodeError:
                 continue
-            if obj.get("type", "").startswith("greptile_"):
+            if obj.get("type", "").startswith(("greptile_", "reviewer_")):
                 all_items.append(obj)
 
         improvement_items = [
-            i for i in all_items if i.get("type") == "greptile_needs_improvement"
+            i
+            for i in all_items
+            if i.get("type")
+            in ("greptile_needs_improvement", "reviewer_needs_improvement")
         ]
         assert improvement_items == [], (
-            f"P1 fix: check_own_pr_review_state must not emit greptile_needs_improvement "
+            f"P1 fix: check_own_pr_review_state must not emit needs_improvement "
             f"when dark-state AI verdict is dirty (double-dispatch prevention); "
             f"got: {improvement_items}\nall greptile items: {all_items}\n"
             f"stdout: {result.stdout}\nstderr: {result.stderr}"
         )
-        fix_items = [i for i in all_items if i.get("type") == "greptile_needs_fix"]
+        fix_items = [
+            i
+            for i in all_items
+            if i.get("type") in ("greptile_needs_fix", "reviewer_needs_fix")
+        ]
         assert fix_items, (
-            f"P1 fix: greptile_needs_fix must still be emitted by check_greptile_scores "
+            f"P1 fix: needs_fix must still be emitted by check_greptile_scores "
             f"when AI verdict is dirty (dark state); "
             f"got no fix items\nall greptile items: {all_items}\n"
             f"stdout: {result.stdout}\nstderr: {result.stderr}"

--- a/tests/test_activity_gate_own_pr_review.py
+++ b/tests/test_activity_gate_own_pr_review.py
@@ -168,7 +168,10 @@ def test_blocked_pr_with_low_greptile_emits_improvement() -> None:
 
         result = _run_gate(tmp, state_dir, merge_state="BLOCKED")
         assert result.returncode in (0, 1), result.stderr
-        assert "greptile_needs_improvement" in result.stdout, result.stdout
+        assert (
+            "greptile_needs_improvement" in result.stdout
+            or "reviewer_needs_improvement" in result.stdout
+        ), result.stdout
         # The own-PR review path is what fired (identified by its detail string).
         assert "own-PR review" in result.stdout, result.stdout
         assert _own_review_state_file(state_dir).exists()

--- a/tests/test_activity_gate_own_pr_review.py
+++ b/tests/test_activity_gate_own_pr_review.py
@@ -168,7 +168,7 @@ def test_blocked_pr_with_low_greptile_emits_improvement() -> None:
 
         result = _run_gate(tmp, state_dir, merge_state="BLOCKED")
         assert result.returncode in (0, 1), result.stderr
-        assert "greptile_needs_improvement" in result.stdout, result.stdout
+        assert "reviewer_needs_improvement" in result.stdout, result.stdout
         # The own-PR review path is what fired (identified by its detail string).
         assert "own-PR review" in result.stdout, result.stdout
         assert _own_review_state_file(state_dir).exists()


### PR DESCRIPTION
## Summary

Generalizes PM dispatch item types from vendor-specific (`greptile_needs_*`) to source-agnostic (`reviewer_needs_*`), following Erik's request in 2026-08-16 to generalize the reviewer signal further.

**Backward-compatible migration**: consumers accept both old and new names; only the producer emits new names.

### Changes

- **`activity-gate.sh`** — `emit_item` gains `source` (6th arg) and `severity` (7th arg) optional fields; main dispatch loop now emits `reviewer_needs_fix`/`reviewer_needs_improvement` with `source=greptile` and `severity=major|minor`; dark-Greptile AI-reviewer fallback emits `reviewer_needs_fix` with `source=ai-review, severity=major`
- **`run_item.py`** — `THREAD_DELIVERABLE_TYPES` and `timeout_tier()` accept new type names
- **`merge_lifecycle.py`** — `InstructionKind` enum gains `REVIEWER_NEEDS_FIX` and `REVIEWER_NEEDS_IMPROVEMENT`; `greptile_convergence_applicable()` updated
- **`pm_dispatch.py`** — `SLOW_LANE_TYPES` and `classify_lane()` accept new names
- **`prompt_templates.py`** — `_VARIANTS` and `_GREPTILE_INVESTIGATE_KINDS` mapped for new kinds (same templates as greptile counterparts)
- **Tests** — expected set in `test_pm_dispatch.py` updated; golden files added for new `InstructionKind` members

### New JSONL fields

When `FORMAT=jsonl`, items now carry:
```json
{"type": "reviewer_needs_fix", "source": "greptile", "severity": "major", "repo": "...", "number": 123, "title": "...", "detail": "..."}
```

Items without source/severity (emitted by older code during migration window) remain valid — both old and new type names are accepted by all consumers.

## Test plan

- [x] 983 tests pass in `packages/gptme-runloops/tests/`
- [x] Golden files generated from `render_instruction` (same templates as greptile counterparts)
- [ ] Brain repo consumer updates (project-monitoring-lib.sh, worker.sh, dispatch.sh, gate.sh, analysis scripts) — follow-up PR in ErikBjare/bob

Closes part of ErikBjare/bob#1142 (cross-harness benchmark) — generalization step