### PR TITLE
feat(gptme-rag): add task-scoped TF-IDF retrieval (Phase 2.3)

### DIFF
--- a/packages/gptme-rag/src/gptme_rag/lexical.py
+++ b/packages/gptme-rag/src/gptme_rag/lexical.py
@@ -165,8 +165,11 @@ class TfidfIndex:
         texts = [doc.content for doc in documents]
         try:
             self._matrix = vectorizer.fit_transform(texts)
-        except ValueError:
+        except ValueError as exc:
+            if "empty vocabulary" not in str(exc):
+                raise
             # All texts reduced to empty vocabulary (e.g. all stop words).
+            logger.debug("All documents reduced to empty vocabulary; resetting index")
             self._vectorizer = None
             self._matrix = None
             self._documents = []
@@ -278,6 +281,8 @@ class TfidfIndex:
         try:
             payload = _RestrictedUnpickler(io.BytesIO(data)).load()
         except ImportError as exc:
+            if "sklearn" not in str(exc):
+                raise
             raise LexicalDependencyMissing(
                 "scikit-learn is required to load a lexical index; "
                 "install it with `pip install gptme-rag[lexical]`"


### PR DESCRIPTION
## Summary

Adds `gptme_rag.task_retrieval` — a task-specific ranking layer on top of the TF-IDF backend from #1439.

Retrieval over a general corpus silently drops tasks: they are ~5% of documents and never reach global top-N. This module operates on an index built from task files only, so ranking is not diluted by unrelated content.

**New public API:**

- `load_task_documents(tasks_dir)` — read task `.md` files into `Document` objects with task metadata (`type`, `task_state`, `task_archived`, `title`)
- `rank_tasks(index, query, ...)` — rank task documents by TF-IDF cosine similarity
- `apply_task_silence_rule(hits, floor, trailing_ratio)` — relevance floor (0.27) + trailing-ratio (0.55) drop; keeps the injector quiet on ~73% of real prompts
- `query_tasks(index, query, ...)` — `rank_tasks` + `apply_task_silence_rule` in one call
- `format_task_injection(hits)` — compact markdown block for prompt injection

**Constants** (calibrated on real Bob session data):
- `TASK_RELEVANCE_FLOOR = 0.27`
- `TASK_TRAILING_RATIO = 0.55`
- `MAX_TASKS_PER_QUERY = 3`

**29 tests**, all passing. Requires `gptme-rag[lexical]` (scikit-learn).

Ported from the Bob brain script (`scripts/build-ambient-memory-index.py`) where this pattern was measured and tuned on real session data — see the Phase 2.3 description in [upstream-retrieval-into-gptme-rag](https://github.com/ErikBjare/bob/blob/master/tasks/upstream-retrieval-into-gptme-rag.md).

## Depends on

#1439 (TF-IDF lexical backend) — targets that branch; retarget to `master` after #1439 merges.

## Test plan

- [ ] `uv run --package gptme-rag --extra lexical --extra test pytest packages/gptme-rag/tests/test_task_retrieval.py -v` — 29 tests pass
- [ ] CI green on all Python versions
- [ ] mypy clean (no new errors in `task_retrieval.py` or `lexical.py`)