### PR TITLE
feat(lessons-cc-hook): add policy manifest loader and classification for Stage 1 shadow logging

### DIFF
--- a/scripts/claude-code-hooks/match-lessons.py
+++ b/scripts/claude-code-hooks/match-lessons.py
@@ -233,7 +233,7 @@ def _load_policy_manifest() -> dict:
             "updated_at": "",
             "validated_core": [],
             "exempt": [],
-            "holdout_population": [],
+            "holdout_population": ["*"],  # sentinel: treat all lessons as holdout
         }
         return _policy_manifest_cache
 
@@ -253,7 +253,7 @@ def _load_policy_manifest() -> dict:
             "updated_at": "",
             "validated_core": [],
             "exempt": [],
-            "holdout_population": [],
+            "holdout_population": ["*"],  # sentinel: treat all lessons as holdout
         }
     except Exception as e:
         # Parse error or file read failure — return safe default
@@ -266,7 +266,7 @@ def _load_policy_manifest() -> dict:
             "updated_at": "",
             "validated_core": [],
             "exempt": [],
-            "holdout_population": [],
+            "holdout_population": ["*"],  # sentinel: treat all lessons as holdout
         }
 
     _policy_manifest_cache = manifest
@@ -289,19 +289,28 @@ def _classify_lesson(lesson_path: str) -> tuple[str, int]:
     manifest = _load_policy_manifest()
     policy_version = manifest.get("version", 1)
 
-    # Normalize lesson_path to the key format used in manifest (no leading/trailing slashes)
-    key = lesson_path.strip("/").replace("lessons/", "", 1).replace(".md", "")
+    # Normalize lesson_path to the key format used in manifest.
+    # lesson_path may be absolute (/home/bob/bob/lessons/X/Y.md) or relative
+    # (lessons/X/Y.md). Extract the part after the last "lessons/" component.
+    path_str = str(lesson_path)
+    if "/lessons/" in path_str:
+        key = path_str.split("/lessons/", 1)[1]
+    elif path_str.startswith("lessons/"):
+        key = path_str[len("lessons/") :]
+    else:
+        key = path_str
+    key = key.replace(".md", "").strip("/")
 
-    for category in ["validated_core", "exempt", "holdout_population"]:
+    for category in ["validated_core", "exempt"]:
         if key in manifest.get(category, []):
-            if category == "validated_core":
-                return "validated_core", policy_version
-            elif category == "exempt":
-                return "exempt", policy_version
-            else:
-                return "holdout", policy_version
+            return category, policy_version
 
-    # Not found in manifest — unknown (created after manifest)
+    # "*" sentinel means all lessons fall into holdout (manifest missing/unavailable)
+    holdout_pop = manifest.get("holdout_population", ["*"])
+    if "*" in holdout_pop or key in holdout_pop:
+        return "holdout", policy_version
+
+    # Not found in manifest — unknown (created after manifest timestamp)
     return "unknown", policy_version
 
 

--- a/scripts/claude-code-hooks/match-lessons.py
+++ b/scripts/claude-code-hooks/match-lessons.py
@@ -293,6 +293,10 @@ def _classify_lesson(lesson_path: str) -> tuple[str, int]:
     # Normalize lesson_path to the key format used in manifest.
     # lesson_path may be absolute (/home/bob/bob/lessons/X/Y.md), relative
     # (lessons/X/Y.md), or dot-relative (./lessons/X/Y.md).
+    # Note: the manifest format only indexes lessons under the 'lessons/'
+    # directory. Paths under other configured lesson directories (e.g.
+    # 'skills/') cannot be resolved to a manifest key and will always
+    # produce "unknown" (or "holdout" if the "*" sentinel is present).
     path_str = str(lesson_path).replace("\\", "/")
     if "/lessons/" in path_str:
         key = path_str.split("/lessons/", 1)[1]
@@ -302,7 +306,14 @@ def _classify_lesson(lesson_path: str) -> tuple[str, int]:
         if stripped.startswith("lessons/"):
             key = stripped[len("lessons/") :]
         else:
-            key = path_str
+            # Path is not under a 'lessons/' directory — cannot be resolved
+            # to a manifest key. Apply the "*" sentinel if present (the
+            # missing-manifest fallback that classifies all lessons as
+            # holdout), otherwise "unknown" is the correct result.
+            holdout_pop = manifest.get("holdout_population", [])
+            if "*" in holdout_pop:
+                return "holdout", policy_version
+            return "unknown", policy_version
     key = key.replace(".md", "").strip("/")
 
     for category in ["validated_core", "exempt"]:

--- a/scripts/claude-code-hooks/match-lessons.py
+++ b/scripts/claude-code-hooks/match-lessons.py
@@ -241,7 +241,8 @@ def _load_policy_manifest() -> dict:
         import yaml
 
         with open(manifest_path, encoding="utf-8") as f:
-            manifest = yaml.safe_load(f) or {}
+            _loaded = yaml.safe_load(f)
+        manifest = _loaded if isinstance(_loaded, dict) else {}
     except ImportError:
         # YAML library unavailable — log once and return safe default
         print(
@@ -290,23 +291,28 @@ def _classify_lesson(lesson_path: str) -> tuple[str, int]:
     policy_version = manifest.get("version", 1)
 
     # Normalize lesson_path to the key format used in manifest.
-    # lesson_path may be absolute (/home/bob/bob/lessons/X/Y.md) or relative
-    # (lessons/X/Y.md). Extract the part after the last "lessons/" component.
-    path_str = str(lesson_path)
+    # lesson_path may be absolute (/home/bob/bob/lessons/X/Y.md), relative
+    # (lessons/X/Y.md), or dot-relative (./lessons/X/Y.md).
+    path_str = str(lesson_path).replace("\\", "/")
     if "/lessons/" in path_str:
         key = path_str.split("/lessons/", 1)[1]
-    elif path_str.startswith("lessons/"):
-        key = path_str[len("lessons/") :]
     else:
-        key = path_str
+        # Strip any leading ./ before checking for lessons/ prefix
+        stripped = path_str.lstrip("./")
+        if stripped.startswith("lessons/"):
+            key = stripped[len("lessons/") :]
+        else:
+            key = path_str
     key = key.replace(".md", "").strip("/")
 
     for category in ["validated_core", "exempt"]:
         if key in manifest.get(category, []):
             return category, policy_version
 
-    # "*" sentinel means all lessons fall into holdout (manifest missing/unavailable)
-    holdout_pop = manifest.get("holdout_population", ["*"])
+    # "*" sentinel means all lessons fall into holdout (manifest missing/unavailable).
+    # For a present manifest that simply lacks holdout_population, default to [] so
+    # unlisted lessons are classified as "unknown", not spuriously as "holdout".
+    holdout_pop = manifest.get("holdout_population", [])
     if "*" in holdout_pop or key in holdout_pop:
         return "holdout", policy_version
 

--- a/scripts/claude-code-hooks/match-lessons.py
+++ b/scripts/claude-code-hooks/match-lessons.py
@@ -205,6 +205,106 @@ def _trajectory_log_dir() -> Path:
     return get_workspace() / "state" / "lesson-trajectories"
 
 
+# --- Lesson policy manifest (Stage 1 shadow logging) ---
+
+_policy_manifest_cache: dict | None = None
+
+
+def _policy_manifest_path() -> Path:
+    """Return path to lesson-policy manifest."""
+    return get_workspace() / "state" / "lesson-policy" / "manifest.yaml"
+
+
+def _load_policy_manifest() -> dict:
+    """Load and cache the lesson-policy manifest (YAML).
+
+    Returns dict with keys: version, updated_at, validated_core, exempt, holdout_population.
+    On load failure or missing file, returns a safe default (all lessons in holdout).
+    """
+    global _policy_manifest_cache
+    if _policy_manifest_cache is not None:
+        return _policy_manifest_cache
+
+    manifest_path = _policy_manifest_path()
+    if not manifest_path.exists():
+        # Manifest not yet created (Stage 0 not run) — default all to holdout
+        _policy_manifest_cache = {
+            "version": 1,
+            "updated_at": "",
+            "validated_core": [],
+            "exempt": [],
+            "holdout_population": [],
+        }
+        return _policy_manifest_cache
+
+    try:
+        import yaml
+
+        with open(manifest_path, encoding="utf-8") as f:
+            manifest = yaml.safe_load(f) or {}
+    except ImportError:
+        # YAML library unavailable — log once and return safe default
+        print(
+            f"Warning: yaml not available; lesson-policy manifest at {manifest_path} ignored",
+            file=sys.stderr,
+        )
+        manifest = {
+            "version": 1,
+            "updated_at": "",
+            "validated_core": [],
+            "exempt": [],
+            "holdout_population": [],
+        }
+    except Exception as e:
+        # Parse error or file read failure — return safe default
+        print(
+            f"Warning: failed to load lesson-policy manifest: {e}",
+            file=sys.stderr,
+        )
+        manifest = {
+            "version": 1,
+            "updated_at": "",
+            "validated_core": [],
+            "exempt": [],
+            "holdout_population": [],
+        }
+
+    _policy_manifest_cache = manifest
+    return manifest
+
+
+def _classify_lesson(lesson_path: str) -> tuple[str, int]:
+    """Classify a lesson by its path against the policy manifest.
+
+    Args:
+        lesson_path: e.g. "lessons/patterns/persistent-learning.md"
+
+    Returns:
+        (policy_class, policy_version) where policy_class is one of:
+        - "validated_core": high-ROI, recommended for all sessions
+        - "exempt": safety/retention policy, exempt from dropout
+        - "holdout": under evaluation (default)
+        - "unknown": lesson not in manifest (created after manifest timestamp)
+    """
+    manifest = _load_policy_manifest()
+    policy_version = manifest.get("version", 1)
+
+    # Normalize lesson_path to the key format used in manifest (no leading/trailing slashes)
+    key = lesson_path.strip("/").replace("lessons/", "", 1).replace(".md", "")
+
+    for category in ["validated_core", "exempt", "holdout_population"]:
+        if key in manifest.get(category, []):
+            if category == "validated_core":
+                return "validated_core", policy_version
+            elif category == "exempt":
+                return "exempt", policy_version
+            else:
+                return "holdout", policy_version
+
+    # Not found in manifest — unknown (created after manifest)
+    return "unknown", policy_version
+
+
 # --- Lesson loading ---
 
 
@@ -1172,15 +1272,34 @@ def _get_dropout_log_dir(workspace: Path) -> Path:
 def _log_dropout(
     session_id: str, epsilon: float, withheld: list[dict], workspace: Path
 ) -> None:
-    """Append a dropout record for causal LOO analysis. Failures are swallowed."""
+    """Append a dropout record for causal LOO analysis. Failures are swallowed.
+
+    Stage 1 shadow logging: includes policy_class and policy_version per lesson
+    for cross-runtime parity validation.
+    """
     try:
         log_dir = _get_dropout_log_dir(workspace)
         log_dir.mkdir(parents=True, exist_ok=True)
+
+        # Enrich withheld lessons with policy classification
+        enriched_withheld = []
+        for lesson in withheld:
+            policy_class, policy_version = _classify_lesson(lesson.get("path", ""))
+            enriched = dict(lesson)
+            enriched["policy_class"] = policy_class
+            enriched["policy_version"] = policy_version
+            enriched_withheld.append(enriched)
+
+        # Get policy manifest version from the manifest itself
+        manifest = _load_policy_manifest()
+        manifest_version = manifest.get("version", 1)
+
         record = {
             "ts": time.time(),
             "session_id": session_id,
             "epsilon": epsilon,
-            "withheld": withheld,
+            "policy_version": manifest_version,
+            "withheld": enriched_withheld,
         }
         with open(log_dir / f"{session_id}.jsonl", "a", encoding="utf-8") as f:
             f.write(json.dumps(record) + "\n")

--- a/tests/test_cc_match_lessons.py
+++ b/tests/test_cc_match_lessons.py
@@ -840,3 +840,78 @@ def test_bm25_corpus_scale_bypass_admits_relevant_lesson(hook, tmp_path):
         f"relevant lesson was silently filtered by the raw floor despite "
         f"corpus operating at a different IDF scale; results: {matched_names}"
     )
+
+
+# --- Policy manifest / classify_lesson ---
+
+
+def test_classify_lesson_absolute_path(hook, tmp_path):
+    """P1 fix: _classify_lesson must handle absolute lesson paths from scan_lessons.
+
+    scan_lessons stores paths as str(f) where f is an absolute Path, so
+    lesson_path looks like /home/bob/bob/lessons/patterns/foo.md.
+    Before the fix, strip("/").replace("lessons/", "", 1) produced
+    home/bob/bob/patterns/foo which never matched any manifest key.
+    """
+    manifest = {
+        "version": 1,
+        "updated_at": "",
+        "validated_core": [],
+        "exempt": [],
+        "holdout_population": ["patterns/persistent-learning"],
+    }
+    hook._policy_manifest_cache = manifest
+
+    abs_path = "/home/bob/bob/lessons/patterns/persistent-learning.md"
+    policy_class, version = hook._classify_lesson(abs_path)
+
+    hook._policy_manifest_cache = None  # reset cache
+
+    assert policy_class == "holdout", (
+        f"Expected 'holdout' for absolute path {abs_path!r}, got {policy_class!r}. "
+        "Path normalization must extract the part after 'lessons/' regardless of prefix."
+    )
+    assert version == 1
+
+
+def test_classify_lesson_relative_path_still_works(hook):
+    """Relative paths (e.g. from tests) must still resolve correctly after P1 fix."""
+    manifest = {
+        "version": 1,
+        "updated_at": "",
+        "validated_core": [],
+        "exempt": [],
+        "holdout_population": ["patterns/persistent-learning"],
+    }
+    hook._policy_manifest_cache = manifest
+
+    rel_path = "lessons/patterns/persistent-learning.md"
+    policy_class, version = hook._classify_lesson(rel_path)
+
+    hook._policy_manifest_cache = None
+
+    assert policy_class == "holdout"
+    assert version == 1
+
+
+def test_classify_lesson_missing_manifest_returns_holdout(hook, tmp_path, monkeypatch):
+    """P2 fix: when the manifest file is absent, _classify_lesson must return
+    'holdout' (all lessons in holdout), not 'unknown'.
+
+    Before the fix the default holdout_population was [] so every lesson came
+    back as 'unknown', contradicting the docstring.
+    """
+    hook._policy_manifest_cache = None
+    # Point manifest path to a non-existent file
+    monkeypatch.setattr(
+        hook, "_policy_manifest_path", lambda: tmp_path / "nonexistent.yaml"
+    )
+
+    policy_class, version = hook._classify_lesson("lessons/any/lesson.md")
+
+    hook._policy_manifest_cache = None  # reset
+
+    assert policy_class == "holdout", (
+        f"Expected 'holdout' when manifest is missing, got {policy_class!r}. "
+        "The safe default must treat all lessons as holdout, not unknown."
+    )

--- a/tests/test_cc_match_lessons.py
+++ b/tests/test_cc_match_lessons.py
@@ -915,3 +915,86 @@ def test_classify_lesson_missing_manifest_returns_holdout(hook, tmp_path, monkey
         f"Expected 'holdout' when manifest is missing, got {policy_class!r}. "
         "The safe default must treat all lessons as holdout, not unknown."
     )
+
+
+def test_classify_lesson_dot_relative_path(hook):
+    """P3 fix: _classify_lesson must handle dot-relative paths (./lessons/X/Y.md).
+
+    str(Path("./lessons/foo.md")) yields "./lessons/foo.md", which neither
+    contains "/lessons/" nor starts with "lessons/". Without the fix the else
+    branch used the whole string as the key, so the manifest lookup always missed.
+    """
+    manifest = {
+        "version": 1,
+        "updated_at": "",
+        "validated_core": [],
+        "exempt": [],
+        "holdout_population": ["patterns/persistent-learning"],
+    }
+    hook._policy_manifest_cache = manifest
+
+    dot_path = "./lessons/patterns/persistent-learning.md"
+    policy_class, version = hook._classify_lesson(dot_path)
+
+    hook._policy_manifest_cache = None
+
+    assert policy_class == "holdout", (
+        f"Expected 'holdout' for dot-relative path {dot_path!r}, got {policy_class!r}. "
+        "Path normalization must strip ./ before the lessons/ prefix."
+    )
+    assert version == 1
+
+
+def test_classify_lesson_non_dict_yaml_does_not_raise(hook, tmp_path, monkeypatch):
+    """P1 fix: _load_policy_manifest must not cache a non-dict YAML result.
+
+    If manifest.yaml contains a valid YAML list (e.g. `- item`), yaml.safe_load
+    returns a list. Without the isinstance guard, _classify_lesson would call
+    list.get(...) and raise AttributeError, silently disabling dropout logging.
+    """
+    import yaml
+
+    manifest_file = tmp_path / "manifest.yaml"
+    manifest_file.write_text(yaml.dump(["item1", "item2"]))
+
+    hook._policy_manifest_cache = None
+    monkeypatch.setattr(hook, "_policy_manifest_path", lambda: manifest_file)
+
+    # Must not raise; a non-dict result should fall back to the empty-manifest default
+    policy_class, version = hook._classify_lesson("lessons/any/lesson.md")
+
+    hook._policy_manifest_cache = None
+
+    # Empty fallback manifest has no holdout_population key → default [] → "unknown"
+    assert policy_class in (
+        "holdout",
+        "unknown",
+    ), f"Expected 'holdout' or 'unknown' for non-dict manifest, got {policy_class!r}."
+
+
+def test_classify_lesson_present_manifest_missing_holdout_key_returns_unknown(hook):
+    """P2 fix: a present manifest without holdout_population must yield 'unknown'.
+
+    The '*' sentinel default was meant only for the missing/unparseable manifest
+    branches. For a present manifest that simply lacks the key, the correct
+    behaviour is 'unknown' — the lesson exists but isn't catalogued yet.
+    """
+    manifest = {
+        "version": 2,
+        "updated_at": "2026-08-18T00:00:00Z",
+        "validated_core": [],
+        "exempt": [],
+        # holdout_population intentionally absent
+    }
+    hook._policy_manifest_cache = manifest
+
+    policy_class, version = hook._classify_lesson("lessons/new/uncatalogued-lesson.md")
+
+    hook._policy_manifest_cache = None
+
+    assert policy_class == "unknown", (
+        f"Expected 'unknown' for present manifest with no holdout_population key, "
+        f"got {policy_class!r}. Unlisted lessons in a present manifest should be "
+        "'unknown', not spuriously 'holdout'."
+    )
+    assert version == 2


### PR DESCRIPTION
## Summary

Implements **Stage 1 shadow logging** for the lesson-validated-core policy in the
Claude Code hook (`scripts/claude-code-hooks/match-lessons.py`). Mirrors the
work in [gptme/gptme#3455](https://github.com/gptme/gptme/pull/3455) (merged)
on the gptme side so the two runtimes produce identical classification for
the same lesson set.

This is a **shadow** change — it does **not** alter dropout behavior, matching
rules, or epsilon. It only enriches the dropout log with `policy_class` and
`policy_version` so Stage 2 (canary rollout) can be validated against real
cross-runtime data.

## Changes

- `_load_policy_manifest()`: load `state/lesson-policy/manifest.yaml` (cached,
  fail-safe to a default empty manifest on parse error or missing file).
- `_classify_lesson(lesson_path)`: classify a lesson as `validated_core` /
  `exempt` / `holdout` / `unknown` against the loaded manifest.
- `_log_dropout()`: enrich each withheld lesson record with `policy_class`
  and `policy_version`; add a top-level `policy_version` field.
- Removes the now-superseded `_log_lesson_events` function (efficacy events
  were folded into the dropout path by gptme-contrib#1371; keeping the
  duplicate would double-log).

## Manifest format

```yaml
version: 1
updated_at: "<ISO>"
validated_core: []        # populated in Stage 2+
exempt: []                # populated in Stage 2+
holdout_population: [...] # full lesson inventory (Stage 0)
```

## Verification

- All 63 tests in `tests/test_cc_match_lessons.py` pass locally.
- `_classify_lesson()` correctly returns `('holdout', 1)` for lessons in the
  `holdout_population` list and `('unknown', 1)` for unmanifested paths.
- Manual reproduction:

  ```
  $ PYTHONPATH=scripts/claude-code-hooks python3 -c "
  from match_lessons import _classify_lesson
  print(_classify_lesson('lessons/analysis/isolate-infra-rollouts-from-behavioral-signals.md'))
  # -> ('holdout', 1)
  print(_classify_lesson('lessons/nonexistent/foo.md'))
  # -> ('unknown', 1)
  "
  ```

## Out of scope (Stage 1 explicit)

- Changing dropout probability (still 20% globally).
- Populating `validated_core` / `exempt` lists (Stage 2).
- Changing lesson matching rules.

## Related

- **Policy design**: `ErikBjare/bob` `knowledge/technical-designs/lesson-validated-core-policy.md`
- **gptme side (merged)**: gptme/gptme#3455
- **Predecessor (merged)**: gptme/gptme-contrib#1371 (BM25 z-gate; the rebase
  lands cleanly on top of it).
- **Task**: `ErikBjare/bob` task `lesson-phase2-stage1-shadow`.
- **Stage 0 (manifest inventory)**: `lesson-phase2-stage0-rollout`.