### PR TITLE
fix(worker-records): fetch_pr_snapshot returns None on gh failure (phase 1.3)

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/worker_records.py
+++ b/packages/gptme-runloops/src/gptme_runloops/worker_records.py
@@ -1104,15 +1104,18 @@ def derive_effect_signal(
        effect for every session that never looked.
     """
     delivery = str(delivery_outcome or "").strip().lower()
+
+    # gh API failed at snapshot time: we cannot observe the "after" state, so
+    # this is an infra failure, not genuine ineffectiveness.  Must take
+    # precedence over delivery_outcome (including orphan_no_delivery) so that a
+    # fetch failure is never recorded as a definitive no-effect.
+    if payload.get("gh_snapshot_fetch_failed"):
+        return EFFECT_FETCH_FAILED
+
     if delivery == "orphan_no_delivery":
         return EFFECT_NONE
     if delivery == "handled":
         return EFFECT_OBSERVED
-
-    # gh API failed at snapshot time: we cannot observe the "after" state, so
-    # this is an infra failure, not genuine ineffectiveness.
-    if payload.get("gh_snapshot_fetch_failed"):
-        return EFFECT_FETCH_FAILED
 
     before_head = normalize_oid(payload.get("pr_head_oid_before"))
     after_head = normalize_oid(payload.get("pr_head_oid_after"))

--- a/packages/gptme-runloops/src/gptme_runloops/worker_records.py
+++ b/packages/gptme-runloops/src/gptme_runloops/worker_records.py
@@ -669,8 +669,7 @@ def update_record_pr_state(
         if not isinstance(payload, dict):
             return
 
-        if gh_fetch_failed:
-            payload["gh_snapshot_fetch_failed"] = True
+        payload["gh_snapshot_fetch_failed"] = gh_fetch_failed
         apply_pr_state_diff(payload, before, after_safe)
         outcome_before_upgrade = payload.get("outcome")
         if upgrade_outcome is not None:

--- a/packages/gptme-runloops/src/gptme_runloops/worker_records.py
+++ b/packages/gptme-runloops/src/gptme_runloops/worker_records.py
@@ -597,10 +597,11 @@ def fetch_pr_snapshot(
     cwd: str | Path,
     timeout: float = 20,
     runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
-) -> dict[str, str]:
+) -> dict[str, str] | None:
     """Fetch the live PR snapshot via gh (worker.sh:413-433).
 
-    A non-zero gh exit → ``{}``; unparseable stdout → ``{}``.
+    A non-zero gh exit → ``None`` (caller must distinguish from an empty but
+    successful response); unparseable stdout → ``{}``.
 
     NOTE(parity): a gh *timeout* raises (``subprocess.TimeoutExpired``),
     killing the whole diff step — including the already-parsed before-fields
@@ -624,7 +625,7 @@ def fetch_pr_snapshot(
         check=False,
     )
     if result.returncode != 0:
-        return {}
+        return None
     return parse_pr_snapshot(result.stdout)
 
 
@@ -635,7 +636,7 @@ def update_record_pr_state(
     number: int | str,
     before_json: str,
     cwd: str | Path,
-    fetch: Callable[[str, int], dict[str, str]] | None = None,
+    fetch: Callable[[str, int], dict[str, str] | None] | None = None,
     upgrade_outcome: Callable[[dict[str, Any]], Any] | None = None,
 ) -> None:
     """Run the whole PR-state diff step against a record file (worker.sh:377-502).
@@ -650,10 +651,16 @@ def update_record_pr_state(
     record_path = Path(record_file)
     before = parse_pr_snapshot(before_json)
     pr_number = int(number)
+    after: dict[str, str] | None
     if fetch is not None:
         after = fetch(repo, pr_number)
     else:
         after = fetch_pr_snapshot(repo, pr_number, cwd=cwd)
+
+    # None signals a gh API failure (non-zero exit); distinguish from an empty
+    # but successful response so derive_effect_signal can classify it as infra.
+    gh_fetch_failed = after is None
+    after_safe: dict[str, str] = after if after is not None else {}
 
     with locked_state_file(record_path):
         if not record_path.is_file():
@@ -662,7 +669,9 @@ def update_record_pr_state(
         if not isinstance(payload, dict):
             return
 
-        apply_pr_state_diff(payload, before, after)
+        if gh_fetch_failed:
+            payload["gh_snapshot_fetch_failed"] = True
+        apply_pr_state_diff(payload, before, after_safe)
         outcome_before_upgrade = payload.get("outcome")
         if upgrade_outcome is not None:
             upgrade_outcome(payload)
@@ -1063,6 +1072,9 @@ def read_record_pr_state_after(record_path: Path | str) -> str:
 EFFECT_OBSERVED = "observed"
 EFFECT_NONE = "none"
 EFFECT_UNKNOWN = "unknown"
+#: gh API call failed at snapshot time — the dispatch cannot be blamed for the
+#: PR not moving; classify as infra in the recovery path, not ineffective.
+EFFECT_FETCH_FAILED = "fetch_failed"
 
 
 def derive_effect_signal(
@@ -1097,6 +1109,11 @@ def derive_effect_signal(
         return EFFECT_NONE
     if delivery == "handled":
         return EFFECT_OBSERVED
+
+    # gh API failed at snapshot time: we cannot observe the "after" state, so
+    # this is an infra failure, not genuine ineffectiveness.
+    if payload.get("gh_snapshot_fetch_failed"):
+        return EFFECT_FETCH_FAILED
 
     before_head = normalize_oid(payload.get("pr_head_oid_before"))
     after_head = normalize_oid(payload.get("pr_head_oid_after"))

--- a/packages/gptme-runloops/tests/goldens/worker_records/pr_state_diff.json
+++ b/packages/gptme-runloops/tests/goldens/worker_records/pr_state_diff.json
@@ -14,7 +14,8 @@
         "pr_head_oid_before": "aaa111",
         "pr_merge_commit_after": "ccc333",
         "pr_state_after": "MERGED",
-        "pr_state_before": "OPEN"
+        "pr_state_before": "OPEN",
+        "gh_snapshot_fetch_failed": false
       },
       "gh_fail": false,
       "gh_output": "{\"state\": \"MERGED\", \"headRefOid\": \"BBB222\", \"mergeCommit\": {\"oid\": \"CCC333\"}}",
@@ -48,7 +49,8 @@
         "pr_head_oid_before": "abc1",
         "pr_merge_commit_after": "raw-string-oid",
         "pr_state_after": "MERGED",
-        "pr_state_before": "OPEN"
+        "pr_state_before": "OPEN",
+        "gh_snapshot_fetch_failed": false
       },
       "gh_fail": false,
       "gh_output": "{\"state\": \"MERGED\", \"headRefOid\": \"def2\", \"mergeCommit\": \"raw-string-oid\"}",
@@ -122,7 +124,8 @@
         "pr_head_oid_after": "bbb",
         "pr_head_oid_before": "aaa",
         "pr_state_after": "OPEN",
-        "pr_state_before": "OPEN"
+        "pr_state_before": "OPEN",
+        "gh_snapshot_fetch_failed": false
       },
       "gh_fail": false,
       "gh_output": "{\"state\": \"OPEN\", \"headRefOid\": \"bbb\", \"mergeCommit\": null}",

--- a/packages/gptme-runloops/tests/goldens/worker_records/pr_state_diff.json
+++ b/packages/gptme-runloops/tests/goldens/worker_records/pr_state_diff.json
@@ -72,6 +72,7 @@
           "One",
           "Two"
         ],
+        "gh_snapshot_fetch_failed": true,
         "outcome": "productive"
       },
       "gh_fail": true,

--- a/packages/gptme-runloops/tests/test_pm_dispatch_outcome.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch_outcome.py
@@ -27,6 +27,7 @@ from gptme_runloops.pm_dispatch import (
     derive_dispatch_outcome,
 )
 from gptme_runloops.worker_records import (
+    EFFECT_FETCH_FAILED,
     derive_effect_signal,
     read_record_effect_signal,
 )
@@ -189,6 +190,13 @@ class TestDeriveEffectSignal:
         # Absence of evidence must never be recorded as evidence of effect.
         assert derive_effect_signal({}) == EFFECT_UNKNOWN
         assert derive_effect_signal({"pr_head_oid_before": "aaa"}) == EFFECT_UNKNOWN
+
+    def test_gh_fetch_failed_flag_returns_fetch_failed(self) -> None:
+        """gh_snapshot_fetch_failed flag → EFFECT_FETCH_FAILED, not EFFECT_UNKNOWN."""
+        assert (
+            derive_effect_signal({"gh_snapshot_fetch_failed": True})
+            == EFFECT_FETCH_FAILED
+        )
 
     def test_orphan_delivery_is_no_effect(self) -> None:
         assert (

--- a/packages/gptme-runloops/tests/test_pm_dispatch_outcome.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch_outcome.py
@@ -198,6 +198,16 @@ class TestDeriveEffectSignal:
             == EFFECT_FETCH_FAILED
         )
 
+    def test_gh_fetch_failed_overrides_orphan_no_delivery(self) -> None:
+        """fetch_failed must outrank orphan_no_delivery — infra failure is not no-effect."""
+        assert (
+            derive_effect_signal(
+                {"gh_snapshot_fetch_failed": True},
+                delivery_outcome="orphan_no_delivery",
+            )
+            == EFFECT_FETCH_FAILED
+        )
+
     def test_orphan_delivery_is_no_effect(self) -> None:
         assert (
             derive_effect_signal(

--- a/packages/gptme-runloops/tests/test_worker_records.py
+++ b/packages/gptme-runloops/tests/test_worker_records.py
@@ -716,12 +716,39 @@ def test_update_record_pr_state_missing_record_is_noop(ws: Path) -> None:
     assert not (ws / "records" / "missing.json").exists()
 
 
-def test_fetch_pr_snapshot_nonzero_exit_is_empty(ws: Path) -> None:
+def test_fetch_pr_snapshot_nonzero_exit_returns_none(ws: Path) -> None:
+    """Non-zero gh exit → None (signals API failure, not empty-diff)."""
+
     def runner(args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
         assert args[:3] == ["gh", "pr", "view"]
         return subprocess.CompletedProcess(args, returncode=1, stdout="{}", stderr="")
 
-    assert fetch_pr_snapshot("gptme/gptme", 1, cwd=ws, runner=runner) == {}
+    assert fetch_pr_snapshot("gptme/gptme", 1, cwd=ws, runner=runner) is None
+
+
+def test_update_record_pr_state_gh_failure_sets_flag(ws: Path, tmp_path: Path) -> None:
+    """A fetch failure sets gh_snapshot_fetch_failed in the record."""
+    import json
+
+    record = tmp_path / "record.json"
+    record.write_text(json.dumps({"outcome": "succeeded"}), encoding="utf-8")
+
+    def fail_fetch(repo: str, num: int) -> None:  # type: ignore[return]
+        return None
+
+    from gptme_runloops.worker_records import update_record_pr_state
+
+    update_record_pr_state(
+        record,
+        repo="gptme/gptme",
+        number=1,
+        before_json="{}",
+        cwd=ws,
+        fetch=fail_fetch,
+    )
+
+    payload = json.loads(record.read_text())
+    assert payload.get("gh_snapshot_fetch_failed") is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

`fetch_pr_snapshot` was returning `{}` on `gh` API failures, which was indistinguishable from a PR with no observable diff. `derive_effect_signal` then returned `EFFECT_UNKNOWN`, causing `classify_completion` to return `CLASS_INEFFECTIVE` (budget 2), escalating healthy PRs in just 2 dispatches even when no outage was involved.

## Fix

- `fetch_pr_snapshot`: return `None` on non-zero `gh` exit (vs `{}` = empty success)
- `update_record_pr_state`: detect `after is None`, set `gh_snapshot_fetch_failed=True`
- `EFFECT_FETCH_FAILED = "fetch_failed"` constant added
- `derive_effect_signal`: short-circuit to `EFFECT_FETCH_FAILED` on the flag

The `EFFECT_FETCH_FAILED` value flows through the dispatch ledger; the recovery classifier in `pm_dispatch_recovery.py` maps it to `CLASS_INFRA` (separate change).

## Tests

3 new regression tests + 1 golden updated (`empty_before_gh_fails`).

## Part of

Phase 1.3 of the PM executor fallback / backend-outage series.