### PR TITLE
fix(worker-records): fetch_pr_snapshot returns None on gh failure

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/worker_records.py
+++ b/packages/gptme-runloops/src/gptme_runloops/worker_records.py
@@ -667,9 +667,8 @@ def update_record_pr_state(
             # gh API failure — still apply dedup/state-diff with empty after so
             # deliverables are normalised, but signal the failure so that
             # classify_completion routes this to CLASS_INFRA, not CLASS_INEFFECTIVE.
-            # Value must match _EFFECT_FETCH_FAILED in pm_dispatch_recovery.py.
             apply_pr_state_diff(payload, before, {})
-            payload["effect"] = "fetch_failed"
+            payload["effect"] = EFFECT_FETCH_FAILED
         else:
             apply_pr_state_diff(payload, before, after)
         outcome_before_upgrade = payload.get("outcome")
@@ -1072,6 +1071,7 @@ def read_record_pr_state_after(record_path: Path | str) -> str:
 EFFECT_OBSERVED = "observed"
 EFFECT_NONE = "none"
 EFFECT_UNKNOWN = "unknown"
+EFFECT_FETCH_FAILED = "fetch_failed"  # matched by _EFFECT_FETCH_FAILED in pm_dispatch_recovery.py
 
 
 def derive_effect_signal(

--- a/packages/gptme-runloops/src/gptme_runloops/worker_records.py
+++ b/packages/gptme-runloops/src/gptme_runloops/worker_records.py
@@ -597,10 +597,11 @@ def fetch_pr_snapshot(
     cwd: str | Path,
     timeout: float = 20,
     runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
-) -> dict[str, str]:
+) -> dict[str, str] | None:
     """Fetch the live PR snapshot via gh (worker.sh:413-433).
 
-    A non-zero gh exit → ``{}``; unparseable stdout → ``{}``.
+    A non-zero gh exit → ``None`` (caller should record effect=fetch_failed);
+    unparseable stdout → ``{}`` (empty observation, not a failure).
 
     NOTE(parity): a gh *timeout* raises (``subprocess.TimeoutExpired``),
     killing the whole diff step — including the already-parsed before-fields
@@ -624,7 +625,7 @@ def fetch_pr_snapshot(
         check=False,
     )
     if result.returncode != 0:
-        return {}
+        return None
     return parse_pr_snapshot(result.stdout)
 
 
@@ -635,7 +636,7 @@ def update_record_pr_state(
     number: int | str,
     before_json: str,
     cwd: str | Path,
-    fetch: Callable[[str, int], dict[str, str]] | None = None,
+    fetch: Callable[[str, int], dict[str, str] | None] | None = None,
     upgrade_outcome: Callable[[dict[str, Any]], Any] | None = None,
 ) -> None:
     """Run the whole PR-state diff step against a record file (worker.sh:377-502).
@@ -662,7 +663,15 @@ def update_record_pr_state(
         if not isinstance(payload, dict):
             return
 
-        apply_pr_state_diff(payload, before, after)
+        if after is None:
+            # gh API failure — still apply dedup/state-diff with empty after so
+            # deliverables are normalised, but signal the failure so that
+            # classify_completion routes this to CLASS_INFRA, not CLASS_INEFFECTIVE.
+            # Value must match _EFFECT_FETCH_FAILED in pm_dispatch_recovery.py.
+            apply_pr_state_diff(payload, before, {})
+            payload["effect"] = "fetch_failed"
+        else:
+            apply_pr_state_diff(payload, before, after)
         outcome_before_upgrade = payload.get("outcome")
         if upgrade_outcome is not None:
             upgrade_outcome(payload)

--- a/packages/gptme-runloops/src/gptme_runloops/worker_records.py
+++ b/packages/gptme-runloops/src/gptme_runloops/worker_records.py
@@ -1071,7 +1071,9 @@ def read_record_pr_state_after(record_path: Path | str) -> str:
 EFFECT_OBSERVED = "observed"
 EFFECT_NONE = "none"
 EFFECT_UNKNOWN = "unknown"
-EFFECT_FETCH_FAILED = "fetch_failed"  # matched by _EFFECT_FETCH_FAILED in pm_dispatch_recovery.py
+EFFECT_FETCH_FAILED = (
+    "fetch_failed"  # matched by _EFFECT_FETCH_FAILED in pm_dispatch_recovery.py
+)
 
 
 def derive_effect_signal(

--- a/packages/gptme-runloops/tests/goldens/worker_records/pr_state_diff.json
+++ b/packages/gptme-runloops/tests/goldens/worker_records/pr_state_diff.json
@@ -72,6 +72,7 @@
           "One",
           "Two"
         ],
+        "effect": "fetch_failed",
         "outcome": "productive"
       },
       "gh_fail": true,

--- a/packages/gptme-runloops/tests/test_worker_records.py
+++ b/packages/gptme-runloops/tests/test_worker_records.py
@@ -716,12 +716,35 @@ def test_update_record_pr_state_missing_record_is_noop(ws: Path) -> None:
     assert not (ws / "records" / "missing.json").exists()
 
 
-def test_fetch_pr_snapshot_nonzero_exit_is_empty(ws: Path) -> None:
+def test_fetch_pr_snapshot_nonzero_exit_is_none(ws: Path) -> None:
     def runner(args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
         assert args[:3] == ["gh", "pr", "view"]
         return subprocess.CompletedProcess(args, returncode=1, stdout="{}", stderr="")
 
-    assert fetch_pr_snapshot("gptme/gptme", 1, cwd=ws, runner=runner) == {}
+    assert fetch_pr_snapshot("gptme/gptme", 1, cwd=ws, runner=runner) is None
+
+
+def test_update_record_pr_state_fetch_failure_sets_effect_fetch_failed(
+    ws: Path,
+) -> None:
+    """gh call failure → effect=fetch_failed so classify_completion → CLASS_INFRA."""
+    record = ws / "records" / "fail-fetch.json"
+    record.parent.mkdir(parents=True, exist_ok=True)
+    record.write_text(
+        json.dumps({"outcome": "succeeded", "exit_code": 0, "effect": ""}),
+        encoding="utf-8",
+    )
+    # Simulate gh returning non-zero (API outage)
+    update_record_pr_state(
+        record,
+        repo="gptme/gptme",
+        number=1,
+        before_json='{"state":"OPEN","headRefOid":"abc","mergeCommit":null}',
+        cwd=ws,
+        fetch=lambda repo, num: None,
+    )
+    payload = json.loads(record.read_text(encoding="utf-8"))
+    assert payload["effect"] == "fetch_failed"
 
 
 @pytest.mark.parametrize(

--- a/packages/gptme-runloops/tests/test_worker_records.py
+++ b/packages/gptme-runloops/tests/test_worker_records.py
@@ -38,6 +38,7 @@ from typing import Any
 
 import pytest
 from gptme_runloops.worker_records import (
+    EFFECT_FETCH_FAILED,
     _iter_bash_commands,
     append_wait_merge_gate_log,
     append_worker_latency_records,
@@ -744,7 +745,7 @@ def test_update_record_pr_state_fetch_failure_sets_effect_fetch_failed(
         fetch=lambda repo, num: None,
     )
     payload = json.loads(record.read_text(encoding="utf-8"))
-    assert payload["effect"] == "fetch_failed"
+    assert payload["effect"] == EFFECT_FETCH_FAILED
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- `fetch_pr_snapshot` now returns `None` on non-zero `gh` exit (API outage, rate limit) instead of `{}`, so callers can distinguish "API call failed" from "PR has no diff to observe"
- `update_record_pr_state` detects `None` and writes `effect="fetch_failed"` into the record (still calls `apply_pr_state_diff({})` for deliverable deduplication)
- `classify_completion` in `pm_dispatch_recovery.py` already handles `effect="fetch_failed"` → `CLASS_INFRA`, so the retry budget is not charged for infrastructure failures
- Updated the one test that asserted `== {}` on non-zero exit; added a new test verifying `effect="fetch_failed"` is written when fetch fails; updated the golden fixture for the `empty_before_gh_fails` case

This is Phase 1.3 of `tasks/pm-retry-budget-counts-outage-failures.md` in the brain repo. Phases 1.1 (cross-class budget leak) and 1.2 (infra failure classification via rate-limit ledger) already shipped.

The root problem: a GitHub API outage causes `gh pr view` to exit non-zero, `fetch_pr_snapshot` returned `{}`, and `derive_effect_signal` saw an empty snapshot → `EFFECT_UNKNOWN` → `CLASS_INEFFECTIVE` (budget 2). Two dispatches would exhaust the budget and escalate the PR as "permanently broken," requiring a 24h wait or manual `.retry` file deletion.

## Test plan
- [ ] `uv run pytest packages/gptme-runloops/tests/ -q` — all 1010+ tests pass
- [ ] `test_fetch_pr_snapshot_nonzero_exit_is_none` confirms the return-type change
- [ ] `test_update_record_pr_state_fetch_failure_sets_effect_fetch_failed` confirms the effect propagation
- [ ] `test_pr_state_diff_golden[empty_before_gh_fails]` golden updated to expect `effect: fetch_failed`
- [ ] `tests/test_pm_dispatch_recovery.py::test_classify_completion_gh_fetch_failed_is_class_infra` already covers the downstream routing (no changes needed there)