### PR TITLE
feat(skills): add test-discovery skill for auto-detecting test runners

### DIFF
--- a/skills/test-discovery/SKILL.md
+++ b/skills/test-discovery/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: test-discovery
+description: Auto-discover and run the relevant test suite after making code edits. Use when you've edited source files and want to verify correctness without being told which tests to run. Do NOT use for purely exploratory sessions with no file edits, or when the user has already specified which test command to run.
+license: MIT
+compatibility: "Works with projects using pytest, jest/vitest, cargo test, or Makefile targets"
+metadata:
+  author: bob
+  version: "1.0.0"
+  tags: [testing, pytest, jest, cargo, test-discovery, tdd, verification]
+  requires_tools: [shell]
+  requires_skills: []
+---
+
+# Test Discovery Skill
+
+Auto-detect and run the right test suite after code edits. Agents using this skill
+self-correct from test failures without a manual "run tests" prompt.
+
+## When to Use
+
+- After editing source files (`*.py`, `*.ts`, `*.js`, `*.rs`)
+- After fixing a bug — run the suite to catch regressions
+- When you suspect a change might have broken something
+- Before committing, to confirm nothing regressed
+
+## When NOT to Use
+
+- User explicitly says which test command to run — just run that
+- Exploratory or documentation-only session with no source edits
+- The test suite is known to be very slow and the change is clearly non-breaking
+
+## Procedure
+
+### Step 1: Detect the test runner
+
+Run the bundled detector:
+
+```shell
+bash skills/test-discovery/scripts/detect-runner.sh
+```
+
+Or detect manually by priority:
+
+| Signal file | Runner | Command |
+|---|---|---|
+| `pytest.ini` / `[tool.pytest]` in `pyproject.toml` / `setup.cfg [tool:pytest]` | pytest | `uv run pytest -x -q` |
+| `package.json` with `"vitest"` or `"jest"` in scripts | jest/vitest | `npm test` or `npx vitest run` |
+| `Cargo.toml` | cargo | `cargo test 2>&1` |
+| `Makefile` with `test` target | make | `make test` |
+| `tox.ini` | tox | `tox` |
+
+### Step 2: Narrow the scope
+
+Run only the tests relevant to changed files. This keeps feedback fast:
+
+```shell
+# Python: run tests for the module you edited
+uv run pytest tests/test_<module>.py -x -q
+
+# Broader: all tests in the package
+uv run pytest packages/<pkg>/tests/ -x -q
+
+# Last resort: full suite
+uv run pytest -x -q
+```
+
+For JavaScript/TypeScript:
+
+```shell
+# Run test file matching changed source
+npx vitest run src/<module>.test.ts
+# Or jest
+npx jest src/<module>.test.ts --no-coverage
+```
+
+For Rust:
+
+```shell
+cargo test <module_name> 2>&1 | tail -20
+```
+
+### Step 3: Interpret results
+
+**Pass**: Commit with confidence. State "tests pass" in the response.
+
+**Fail**: Read the failure message. One of three paths:
+1. **Fix is obvious** → fix the code, re-run (one cycle max before escalating)
+2. **Test is outdated** → update the test to reflect intentional behavior change
+3. **Unclear root cause** → surface the exact failing assertion to the user; don't guess
+
+### Step 4: Keep output concise
+
+Test output can be verbose. Summarize for the user:
+
+```
+Tests: 47 passed, 0 failed (3.2s)
+```
+
+Or on failure:
+
+```
+FAILED tests/test_shell.py::test_execute_timeout – AssertionError: expected exit 1, got 0
+```
+
+Never dump the full pytest traceback into the response unless the user asks for it.
+
+## Detection Script
+
+`scripts/detect-runner.sh` returns the recommended test command for the current
+directory and prints a brief rationale. Exit 0 = found, exit 1 = no test runner detected.
+
+```shell
+bash skills/test-discovery/scripts/detect-runner.sh
+# → uv run pytest -x -q  (pytest.ini found)
+# → npm test  (package.json with jest script found)
+# → cargo test 2>&1  (Cargo.toml found)
+# → echo "No test runner detected"  (exit 1)
+```
+
+## Anti-Patterns
+
+| Anti-Pattern | Fix |
+|---|---|
+| Running the full suite for a one-line fix | Scope to the test file for the changed module |
+| Dumping the full traceback into the response | Summarize: `FAILED test_foo::test_bar – AssertionError: X != Y` |
+| Skipping tests because "it's obviously right" | Run at least the module-level tests; correctness is not obvious |
+| Re-running tests 3+ times hoping they pass | Two strikes and escalate — report the failing assertion |
+| Guessing the test command from memory | Use the detection script or check for signal files |
+
+## Verification
+
+The skill worked if:
+- You can state a concrete pass/fail count after edits
+- Failures led to a fix or a clear user-facing error message
+- You did not dump raw test output into the conversation
+
+## Related
+
+- `skills/test-driven-development/SKILL.md` — write tests *before* code
+- `lessons/workflow/verifiable-tasks-principle.md` — prefer tasks with objective verification
+- gptme issue idea #1136 — tool-side auto-detection (post-exec hook in shell.py, deferred until PR queue < 12)

--- a/skills/test-discovery/scripts/detect-runner.sh
+++ b/skills/test-discovery/scripts/detect-runner.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Detect the test runner for the current project and print the recommended command.
+# Exit 0 on success (prints command), exit 1 if no runner detected.
+set -euo pipefail
+
+REASON=""
+CMD=""
+
+# Python: pytest (priority: explicit config > pyproject > setup.cfg > presence)
+if [[ -f pytest.ini ]]; then
+    CMD="uv run pytest -x -q"
+    REASON="pytest.ini found"
+elif [[ -f pyproject.toml ]] && grep -q '\[tool\.pytest' pyproject.toml 2>/dev/null; then
+    CMD="uv run pytest -x -q"
+    REASON="[tool.pytest.ini_options] in pyproject.toml"
+elif [[ -f setup.cfg ]] && grep -q '^\[tool:pytest\]' setup.cfg 2>/dev/null; then
+    CMD="uv run pytest -x -q"
+    REASON="[tool:pytest] in setup.cfg"
+elif [[ -f tox.ini ]] && grep -q '^\[pytest\]' tox.ini 2>/dev/null; then
+    CMD="uv run pytest -x -q"
+    REASON="[pytest] section in tox.ini"
+elif command -v pytest &>/dev/null || command -v uv &>/dev/null; then
+    # Heuristic: if there are test files, assume pytest
+    if find . -name 'test_*.py' -o -name '*_test.py' 2>/dev/null | grep -q .; then
+        CMD="uv run pytest -x -q"
+        REASON="test_*.py files found (pytest assumed)"
+    fi
+fi
+
+# JavaScript/TypeScript: vitest or jest (only if no Python runner found)
+if [[ -z "$CMD" ]] && [[ -f package.json ]]; then
+    if python3 -c "import json,sys; s=json.load(open('package.json')).get('scripts',{}); sys.exit(0 if any('vitest' in v for v in s.values()) else 1)" 2>/dev/null; then
+        CMD="npx vitest run"
+        REASON="vitest in package.json scripts"
+    elif python3 -c "import json,sys; s=json.load(open('package.json')).get('scripts',{}); sys.exit(0 if 'test' in s else 1)" 2>/dev/null; then
+        CMD="npm test"
+        REASON="test script in package.json"
+    fi
+fi
+
+# Rust: cargo test
+if [[ -z "$CMD" ]] && [[ -f Cargo.toml ]]; then
+    CMD="cargo test 2>&1"
+    REASON="Cargo.toml found"
+fi
+
+# Makefile: test target
+if [[ -z "$CMD" ]] && [[ -f Makefile ]]; then
+    if grep -q '^test[[:space:]]*:' Makefile 2>/dev/null; then
+        CMD="make test"
+        REASON="test target in Makefile"
+    fi
+fi
+
+if [[ -z "$CMD" ]]; then
+    echo "No test runner detected" >&2
+    exit 1
+fi
+
+echo "$CMD  # $REASON"

--- a/skills/test-discovery/scripts/detect-runner.sh
+++ b/skills/test-discovery/scripts/detect-runner.sh
@@ -6,23 +6,37 @@ set -euo pipefail
 REASON=""
 CMD=""
 
-# Python: pytest (priority: explicit config > pyproject > setup.cfg > presence)
+# Resolve pytest invocation: prefer uv run pytest when uv is available
+if command -v uv &>/dev/null; then
+    PYTEST_CMD="uv run pytest -x -q"
+else
+    PYTEST_CMD="pytest -x -q"
+fi
+
+# Python: pytest (priority: explicit config > pyproject > setup.cfg > tox > presence)
 if [[ -f pytest.ini ]]; then
-    CMD="uv run pytest -x -q"
+    CMD="$PYTEST_CMD"
     REASON="pytest.ini found"
 elif [[ -f pyproject.toml ]] && grep -q '\[tool\.pytest' pyproject.toml 2>/dev/null; then
-    CMD="uv run pytest -x -q"
+    CMD="$PYTEST_CMD"
     REASON="[tool.pytest.ini_options] in pyproject.toml"
 elif [[ -f setup.cfg ]] && grep -q '^\[tool:pytest\]' setup.cfg 2>/dev/null; then
-    CMD="uv run pytest -x -q"
+    CMD="$PYTEST_CMD"
     REASON="[tool:pytest] in setup.cfg"
-elif [[ -f tox.ini ]] && grep -q '^\[pytest\]' tox.ini 2>/dev/null; then
-    CMD="uv run pytest -x -q"
-    REASON="[pytest] section in tox.ini"
+elif [[ -f tox.ini ]]; then
+    if grep -q '^\[pytest\]' tox.ini 2>/dev/null; then
+        # tox.ini used as a plain pytest config — run pytest directly
+        CMD="$PYTEST_CMD"
+        REASON="[pytest] section in tox.ini"
+    else
+        # Real tox project (has [testenv] or similar) — let tox manage the env
+        CMD="tox"
+        REASON="tox.ini found"
+    fi
 elif command -v pytest &>/dev/null || command -v uv &>/dev/null; then
     # Heuristic: if there are test files, assume pytest
     if find . -name 'test_*.py' -o -name '*_test.py' 2>/dev/null | grep -q .; then
-        CMD="uv run pytest -x -q"
+        CMD="$PYTEST_CMD"
         REASON="test_*.py files found (pytest assumed)"
     fi
 fi

--- a/skills/test-discovery/scripts/detect-runner.sh
+++ b/skills/test-discovery/scripts/detect-runner.sh
@@ -24,18 +24,24 @@ elif [[ -f setup.cfg ]] && grep -q '^\[tool:pytest\]' setup.cfg 2>/dev/null; the
     CMD="$PYTEST_CMD"
     REASON="[tool:pytest] in setup.cfg"
 elif [[ -f tox.ini ]]; then
-    if grep -q '^\[pytest\]' tox.ini 2>/dev/null; then
-        # tox.ini used as a plain pytest config — run pytest directly
+    if grep -qE '^\[(tox|testenv)\]' tox.ini 2>/dev/null; then
+        # Real tox project — [tox] or [testenv] section present; let tox manage the env
+        # (A [pytest] section may coexist; tox still owns the run)
+        CMD="tox"
+        REASON="tox.ini found ([tox]/[testenv] section detected)"
+    elif grep -q '^\[pytest\]' tox.ini 2>/dev/null; then
+        # tox.ini used as a plain pytest config (no [testenv]) — run pytest directly
         CMD="$PYTEST_CMD"
-        REASON="[pytest] section in tox.ini"
+        REASON="[pytest] section in tox.ini (no tox/testenv section)"
     else
-        # Real tox project (has [testenv] or similar) — let tox manage the env
         CMD="tox"
         REASON="tox.ini found"
     fi
 elif command -v pytest &>/dev/null || command -v uv &>/dev/null; then
     # Heuristic: if there are test files, assume pytest
-    if find . -name 'test_*.py' -o -name '*_test.py' 2>/dev/null | grep -q .; then
+    # Note: avoid piping find to grep -q under pipefail — grep exits early and find
+    # gets SIGPIPE (exit 141), making the pipeline non-zero even when a match exists.
+    if [[ -n "$(find . -name 'test_*.py' -o -name '*_test.py' 2>/dev/null)" ]]; then
         CMD="$PYTEST_CMD"
         REASON="test_*.py files found (pytest assumed)"
     fi
@@ -49,6 +55,10 @@ if [[ -z "$CMD" ]] && [[ -f package.json ]]; then
     elif python3 -c "import json,sys; s=json.load(open('package.json')).get('scripts',{}); sys.exit(0 if 'test' in s else 1)" 2>/dev/null; then
         CMD="npm test"
         REASON="test script in package.json"
+    elif python3 -c "import json,sys; s=json.load(open('package.json')).get('scripts',{}); sys.exit(0 if any('jest' in v for v in s.values()) else 1)" 2>/dev/null; then
+        # jest found in a script value but no canonical 'test' key (e.g. 'test:unit': 'jest')
+        CMD="npx jest"
+        REASON="jest in package.json scripts"
     fi
 fi
 


### PR DESCRIPTION
## Summary

Adds a `test-discovery` skill that teaches gptme agents to auto-detect and run the relevant test suite after making code edits, without needing an explicit "run tests" prompt.

- **SKILL.md**: Procedure for detecting test framework, scoping test runs, interpreting results, and keeping output concise
- **scripts/detect-runner.sh**: Shell script that inspects project signals (`pytest.ini`, `[tool.pytest.ini_options]` in pyproject.toml, `package.json` scripts, `Cargo.toml`, `Makefile`) and prints the recommended test command

Supports: pytest, jest/vitest, cargo test, Makefile targets.

**Motivation**: Grounded in the Openleetcode HN signal ("tests live in the repo" pattern, score 108, 2026-08-18) — agents that auto-verify after edits catch regressions without human prompting. This is the agent-instruction layer; the tool-side hook in `gptme/tools/shell.py` is a follow-up once the gptme PR queue has capacity.

## Test plan

- [x] `detect-runner.sh` tested against gptme repo (pyproject.toml with `[tool.pytest.ini_options]`) → outputs `uv run pytest -x -q`
- [x] `detect-runner.sh` tested against brain repo → same correct output
- [x] Skill validates via `gptme-lessons-extras` validator
- [x] ShellCheck passes on `detect-runner.sh`
- [x] Root structure check passes (`skills/` is on the allowlist)