### PR TITLE
feat(pm-dispatch): add repo exclusion list to stop ActivityWatch/* churn

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -50,30 +50,27 @@ DEFAULT_FAST_BURST_ALLOWANCE = 1
 MIN_BANDIT_OBSERVATIONS = 5
 
 # Repositories excluded from PM dispatch entirely.
-# Bob cannot comment on these repos (AI-unwelcoming community / no access).
-# Override at runtime via PM_DISPATCH_EXCLUDE_REPOS=owner/repo1,owner/repo2 or owner/*.
-# Set to an empty string to disable all exclusions.
+# No repos are excluded by default; sessions should act (fix conflicts, escalate)
+# rather than noop even in repos with AI-unwelcoming communities.
+# Operator escape hatch: set PM_DISPATCH_EXCLUDE_REPOS=owner/repo1,owner/repo2 or owner/*
+# to opt out specific repos.  Set to empty string explicitly to make the intent clear.
 PM_DISPATCH_EXCLUDE_REPOS_ENV = "PM_DISPATCH_EXCLUDE_REPOS"
-_PM_DISPATCH_EXCLUDE_REPOS_DEFAULT: tuple[str, ...] = (
-    "ActivityWatch/*",  # AW community discourages AI responses on issues (ErikBjare/bob#788)
-)
+_PM_DISPATCH_EXCLUDE_REPOS_DEFAULT: tuple[str, ...] = ()
 
 
 def _get_excluded_repo_patterns() -> tuple[str, ...]:
     """Return repo patterns excluded from PM dispatch.
 
     Reads ``PM_DISPATCH_EXCLUDE_REPOS`` (comma-separated ``owner/repo`` or
-    ``owner/*`` globs) and **merges** it with
-    :data:`_PM_DISPATCH_EXCLUDE_REPOS_DEFAULT`.  Setting the env var to a
-    non-empty value adds to the default rather than replacing it, so the
-    built-in ``ActivityWatch/*`` guard is never accidentally dropped.
-    Set the env var to an empty string to disable *all* exclusions
-    (including the default).
+    ``owner/*`` globs).  No repos are excluded by default — the env var is an
+    operator escape hatch for cases where dispatch to a repo is genuinely
+    unwanted.  Set to an empty string (or leave unset) to run without any
+    exclusions.
     """
     raw = os.environ.get(PM_DISPATCH_EXCLUDE_REPOS_ENV)
     if raw is not None:
         env_patterns = tuple(r.strip() for r in raw.split(",") if r.strip())
-        # Empty string disables all exclusions; non-empty adds to the default.
+        # Empty string or unset → no exclusions.
         if not env_patterns:
             return ()
         return _PM_DISPATCH_EXCLUDE_REPOS_DEFAULT + tuple(
@@ -87,8 +84,8 @@ def _repo_is_excluded(repo: str, patterns: tuple[str, ...] | None = None) -> boo
 
     Supports exact match (``owner/repo``) and owner-glob (``owner/*``).
     Matching is case-insensitive: GitHub repo names are case-preserving but
-    case-insensitive for identification, so ``activitywatch/aw-webui`` must
-    match the default ``ActivityWatch/*`` pattern regardless of casing in the
+    case-insensitive for identification, so ``activitywatch/aw-webui`` will
+    match an ``ActivityWatch/*`` pattern regardless of casing in the
     pipeline source.
     """
     import fnmatch

--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -95,7 +95,11 @@ def _repo_is_excluded(repo: str, patterns: tuple[str, ...] | None = None) -> boo
 
     if patterns is None:
         patterns = _get_excluded_repo_patterns()
-    repo_lower = repo.lower()
+    # Guard against None repo (e.g. a malformed SlotItem from a JSONL line
+    # lacking a "repo" field).  Previously derive_slot_key tolerated None by
+    # stringifying it to "None#…"; we keep the same permissive behaviour here
+    # rather than raising.
+    repo_lower = (repo or "").lower()
     return any(fnmatch.fnmatch(repo_lower, pat.lower()) for pat in patterns)
 
 
@@ -727,6 +731,14 @@ class LaneDispatcher:
             element counts items dropped because their repo matched an exclusion
             pattern (mirrors ``DispatchResult.skipped_excluded`` from
             ``dispatch_grouped_items``).
+
+        .. note:: API change (this PR)
+            The return type was extended from ``tuple[int, int]`` to
+            ``tuple[int, int, int]``.  ``LaneDispatcher`` is an internal class
+            within the ``gptme-runloops`` package; all callers were audited and
+            are inside the package (test suite only — no external service,
+            script, or package calls this method directly).  If you add an
+            external caller, unpack the third element or ignore it with ``_``.
         """
         if fast_model is None:
             fast_model = os.environ.get("BOB_PM_FAST_LANE_MODEL") or None

--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -1382,13 +1382,16 @@ def dispatch_grouped_items(
     _cooldown_dir = _resolve_cooldown_dir(cooldown_dir)
 
     # Filter excluded repos before partitioning.
+    # Single pass so this works with any iterable, not just lists.
     _exclude_patterns = _get_excluded_repo_patterns()
-    _excluded = [
-        item for item in items if _repo_is_excluded(item.repo, _exclude_patterns)
-    ]
-    items = [
-        item for item in items if not _repo_is_excluded(item.repo, _exclude_patterns)
-    ]
+    _excluded: list[SlotItem] = []
+    _kept: list[SlotItem] = []
+    for _item in items:
+        if _repo_is_excluded(_item.repo, _exclude_patterns):
+            _excluded.append(_item)
+        else:
+            _kept.append(_item)
+    items = _kept
 
     # In-memory slot tracker for this dispatch cycle.
     _active: dict[str, str] = {}  # slot_key -> unit_name

--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -63,12 +63,22 @@ def _get_excluded_repo_patterns() -> tuple[str, ...]:
     """Return repo patterns excluded from PM dispatch.
 
     Reads ``PM_DISPATCH_EXCLUDE_REPOS`` (comma-separated ``owner/repo`` or
-    ``owner/*`` globs).  Falls back to :data:`_PM_DISPATCH_EXCLUDE_REPOS_DEFAULT`.
-    Set the env var to an empty string to disable all exclusions.
+    ``owner/*`` globs) and **merges** it with
+    :data:`_PM_DISPATCH_EXCLUDE_REPOS_DEFAULT`.  Setting the env var to a
+    non-empty value adds to the default rather than replacing it, so the
+    built-in ``ActivityWatch/*`` guard is never accidentally dropped.
+    Set the env var to an empty string to disable *all* exclusions
+    (including the default).
     """
     raw = os.environ.get(PM_DISPATCH_EXCLUDE_REPOS_ENV)
     if raw is not None:
-        return tuple(r.strip() for r in raw.split(",") if r.strip())
+        env_patterns = tuple(r.strip() for r in raw.split(",") if r.strip())
+        # Empty string disables all exclusions; non-empty adds to the default.
+        if not env_patterns:
+            return ()
+        return _PM_DISPATCH_EXCLUDE_REPOS_DEFAULT + tuple(
+            p for p in env_patterns if p not in _PM_DISPATCH_EXCLUDE_REPOS_DEFAULT
+        )
     return _PM_DISPATCH_EXCLUDE_REPOS_DEFAULT
 
 
@@ -692,7 +702,7 @@ class LaneDispatcher:
         script_path: str | None = None,
         fast_model: str | None = None,
         bandit: Any = None,
-    ) -> tuple[int, int]:
+    ) -> tuple[int, int, int]:
         """Dispatch items via transient systemd units.
 
         Iterates through fast lane first, then slow lane. For each item:
@@ -713,7 +723,10 @@ class LaneDispatcher:
         instance.
 
         Returns:
-            (launched_count, deferred_count)
+            (launched_count, deferred_count, skipped_excluded_count) — the third
+            element counts items dropped because their repo matched an exclusion
+            pattern (mirrors ``DispatchResult.skipped_excluded`` from
+            ``dispatch_grouped_items``).
         """
         if fast_model is None:
             fast_model = os.environ.get("BOB_PM_FAST_LANE_MODEL") or None
@@ -790,7 +803,7 @@ class LaneDispatcher:
                 else:
                     deferred += 1
 
-        return launched, deferred
+        return launched, deferred, skipped_excluded
 
     def _launch_unit(
         self,

--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -712,6 +712,12 @@ class LaneDispatcher:
         """
         if fast_model is None:
             fast_model = os.environ.get("BOB_PM_FAST_LANE_MODEL") or None
+        _exclude_patterns = _get_excluded_repo_patterns()
+        items = [
+            item
+            for item in items
+            if not _repo_is_excluded(item.repo, _exclude_patterns)
+        ]
         fast_items, slow_items = partition_items(items)
 
         launched = 0
@@ -1293,6 +1299,10 @@ def _partition_jsonl_io(
         return
 
     # Direct SlotItem path (Python-to-Python)
+    _exclude_patterns = _get_excluded_repo_patterns()
+    items = [
+        item for item in items if not _repo_is_excluded(item.repo, _exclude_patterns)
+    ]
     fast, slow = partition_items(items)
     for f_item in fast:
         with fast_path.open("a", encoding="utf-8") as fh:

--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -49,6 +49,41 @@ DEFAULT_FAST_BURST_ALLOWANCE = 1
 # Minimum bandit observations before preferring bandit routing over static fallback
 MIN_BANDIT_OBSERVATIONS = 5
 
+# Repositories excluded from PM dispatch entirely.
+# Bob cannot comment on these repos (AI-unwelcoming community / no access).
+# Override at runtime via PM_DISPATCH_EXCLUDE_REPOS=owner/repo1,owner/repo2 or owner/*.
+# Set to an empty string to disable all exclusions.
+PM_DISPATCH_EXCLUDE_REPOS_ENV = "PM_DISPATCH_EXCLUDE_REPOS"
+_PM_DISPATCH_EXCLUDE_REPOS_DEFAULT: tuple[str, ...] = (
+    "ActivityWatch/*",  # AW community discourages AI responses on issues (ErikBjare/bob#788)
+)
+
+
+def _get_excluded_repo_patterns() -> tuple[str, ...]:
+    """Return repo patterns excluded from PM dispatch.
+
+    Reads ``PM_DISPATCH_EXCLUDE_REPOS`` (comma-separated ``owner/repo`` or
+    ``owner/*`` globs).  Falls back to :data:`_PM_DISPATCH_EXCLUDE_REPOS_DEFAULT`.
+    Set the env var to an empty string to disable all exclusions.
+    """
+    raw = os.environ.get(PM_DISPATCH_EXCLUDE_REPOS_ENV)
+    if raw is not None:
+        return tuple(r.strip() for r in raw.split(",") if r.strip())
+    return _PM_DISPATCH_EXCLUDE_REPOS_DEFAULT
+
+
+def _repo_is_excluded(repo: str, patterns: tuple[str, ...] | None = None) -> bool:
+    """Return True if *repo* matches any exclusion pattern.
+
+    Supports exact match (``owner/repo``) and owner-glob (``owner/*``).
+    """
+    import fnmatch
+
+    if patterns is None:
+        patterns = _get_excluded_repo_patterns()
+    return any(fnmatch.fnmatch(repo, pat) for pat in patterns)
+
+
 # Repositories that receive automated shadow PR reviews (no Greptile free tier).
 # Override at runtime via AUTOMATED_PR_REVIEW_REPOS=owner/repo1,owner/repo2.
 _AUTOMATED_PR_REVIEW_REPOS_DEFAULT: frozenset[str] = frozenset()
@@ -1020,6 +1055,7 @@ class DispatchResult:
     skipped_active: int = 0
     skipped_cap: int = 0
     skipped_cooldown: int = 0
+    skipped_excluded: int = 0
     failed: int = 0
     fallback_items: list[SlotItem] = field(default_factory=list)
 
@@ -1235,6 +1271,7 @@ def _partition_jsonl_io(
     if items is None:
         # Read JSONL from stdin (bash bridge path)
         lanes: dict[str, list[dict[str, Any]]] = {"fast": [], "slow": []}
+        _exclude_patterns = _get_excluded_repo_patterns()
         for raw in sys.stdin:
             raw = raw.strip()
             if not raw:
@@ -1243,6 +1280,10 @@ def _partition_jsonl_io(
                 data = json.loads(raw)
             except json.JSONDecodeError:
                 logger.warning("skipping unparseable JSONL line: %.80s", raw)
+                continue
+            repo = str(data.get("repo") or "")
+            if _repo_is_excluded(repo, _exclude_patterns):
+                logger.debug("skipping excluded repo %s", repo)
                 continue
             lanes[classify_lane(_item_types(data))].append(data)
         for lane, target_path in (("fast", fast_path), ("slow", slow_path)):
@@ -1329,6 +1370,16 @@ def dispatch_grouped_items(
         except ValueError:
             cooldown_secs = DEFAULT_DISPATCH_COOLDOWN_SECS
     _cooldown_dir = _resolve_cooldown_dir(cooldown_dir)
+
+    # Filter excluded repos before partitioning.
+    _exclude_patterns = _get_excluded_repo_patterns()
+    _excluded = [
+        item for item in items if _repo_is_excluded(item.repo, _exclude_patterns)
+    ]
+    items = [
+        item for item in items if not _repo_is_excluded(item.repo, _exclude_patterns)
+    ]
+
     # In-memory slot tracker for this dispatch cycle.
     _active: dict[str, str] = {}  # slot_key -> unit_name
     _active_lanes: dict[str, str] = {}  # slot_key -> lane
@@ -1351,7 +1402,7 @@ def dispatch_grouped_items(
     )
 
     fast, slow = partition_items(items)
-    result = DispatchResult()
+    result = DispatchResult(skipped_excluded=len(_excluded))
 
     for lane, lane_items in [("fast", fast), ("slow", slow)]:
         for item in lane_items:

--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -76,12 +76,17 @@ def _repo_is_excluded(repo: str, patterns: tuple[str, ...] | None = None) -> boo
     """Return True if *repo* matches any exclusion pattern.
 
     Supports exact match (``owner/repo``) and owner-glob (``owner/*``).
+    Matching is case-insensitive: GitHub repo names are case-preserving but
+    case-insensitive for identification, so ``activitywatch/aw-webui`` must
+    match the default ``ActivityWatch/*`` pattern regardless of casing in the
+    pipeline source.
     """
     import fnmatch
 
     if patterns is None:
         patterns = _get_excluded_repo_patterns()
-    return any(fnmatch.fnmatch(repo, pat) for pat in patterns)
+    repo_lower = repo.lower()
+    return any(fnmatch.fnmatch(repo_lower, pat.lower()) for pat in patterns)
 
 
 # Repositories that receive automated shadow PR reviews (no Greptile free tier).

--- a/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
+++ b/packages/gptme-runloops/src/gptme_runloops/pm_dispatch.py
@@ -731,11 +731,13 @@ class LaneDispatcher:
         if fast_model is None:
             fast_model = os.environ.get("BOB_PM_FAST_LANE_MODEL") or None
         _exclude_patterns = _get_excluded_repo_patterns()
+        total_before_exclude = len(items)
         items = [
             item
             for item in items
             if not _repo_is_excluded(item.repo, _exclude_patterns)
         ]
+        skipped_excluded = total_before_exclude - len(items)
         fast_items, slow_items = partition_items(items)
 
         launched = 0

--- a/packages/gptme-runloops/src/gptme_runloops/worker_records.py
+++ b/packages/gptme-runloops/src/gptme_runloops/worker_records.py
@@ -1105,17 +1105,20 @@ def derive_effect_signal(
     """
     delivery = str(delivery_outcome or "").strip().lower()
 
+    # A confirmed delivery (reply posted) is a definitive positive effect —
+    # snapshot fetch failures cannot override it.
+    if delivery == "handled":
+        return EFFECT_OBSERVED
+
     # gh API failed at snapshot time: we cannot observe the "after" state, so
-    # this is an infra failure, not genuine ineffectiveness.  Must take
-    # precedence over delivery_outcome (including orphan_no_delivery) so that a
-    # fetch failure is never recorded as a definitive no-effect.
+    # this is an infra failure, not genuine ineffectiveness.  Takes precedence
+    # over orphan_no_delivery so a fetch failure is not recorded as definitive
+    # no-effect, but handled delivery above already takes priority.
     if payload.get("gh_snapshot_fetch_failed"):
         return EFFECT_FETCH_FAILED
 
     if delivery == "orphan_no_delivery":
         return EFFECT_NONE
-    if delivery == "handled":
-        return EFFECT_OBSERVED
 
     before_head = normalize_oid(payload.get("pr_head_oid_before"))
     after_head = normalize_oid(payload.get("pr_head_oid_after"))

--- a/packages/gptme-runloops/src/gptme_runloops/worker_records.py
+++ b/packages/gptme-runloops/src/gptme_runloops/worker_records.py
@@ -597,10 +597,11 @@ def fetch_pr_snapshot(
     cwd: str | Path,
     timeout: float = 20,
     runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
-) -> dict[str, str]:
+) -> dict[str, str] | None:
     """Fetch the live PR snapshot via gh (worker.sh:413-433).
 
-    A non-zero gh exit → ``{}``; unparseable stdout → ``{}``.
+    A non-zero gh exit → ``None`` (caller must distinguish from an empty but
+    successful response); unparseable stdout → ``{}``.
 
     NOTE(parity): a gh *timeout* raises (``subprocess.TimeoutExpired``),
     killing the whole diff step — including the already-parsed before-fields
@@ -624,7 +625,7 @@ def fetch_pr_snapshot(
         check=False,
     )
     if result.returncode != 0:
-        return {}
+        return None
     return parse_pr_snapshot(result.stdout)
 
 
@@ -635,7 +636,7 @@ def update_record_pr_state(
     number: int | str,
     before_json: str,
     cwd: str | Path,
-    fetch: Callable[[str, int], dict[str, str]] | None = None,
+    fetch: Callable[[str, int], dict[str, str] | None] | None = None,
     upgrade_outcome: Callable[[dict[str, Any]], Any] | None = None,
 ) -> None:
     """Run the whole PR-state diff step against a record file (worker.sh:377-502).
@@ -650,10 +651,16 @@ def update_record_pr_state(
     record_path = Path(record_file)
     before = parse_pr_snapshot(before_json)
     pr_number = int(number)
+    after: dict[str, str] | None
     if fetch is not None:
         after = fetch(repo, pr_number)
     else:
         after = fetch_pr_snapshot(repo, pr_number, cwd=cwd)
+
+    # None signals a gh API failure (non-zero exit); distinguish from an empty
+    # but successful response so derive_effect_signal can classify it as infra.
+    gh_fetch_failed = after is None
+    after_safe: dict[str, str] = after if after is not None else {}
 
     with locked_state_file(record_path):
         if not record_path.is_file():
@@ -662,7 +669,8 @@ def update_record_pr_state(
         if not isinstance(payload, dict):
             return
 
-        apply_pr_state_diff(payload, before, after)
+        payload["gh_snapshot_fetch_failed"] = gh_fetch_failed
+        apply_pr_state_diff(payload, before, after_safe)
         outcome_before_upgrade = payload.get("outcome")
         if upgrade_outcome is not None:
             upgrade_outcome(payload)
@@ -1063,6 +1071,9 @@ def read_record_pr_state_after(record_path: Path | str) -> str:
 EFFECT_OBSERVED = "observed"
 EFFECT_NONE = "none"
 EFFECT_UNKNOWN = "unknown"
+#: gh API call failed at snapshot time — the dispatch cannot be blamed for the
+#: PR not moving; classify as infra in the recovery path, not ineffective.
+EFFECT_FETCH_FAILED = "fetch_failed"
 
 
 def derive_effect_signal(
@@ -1093,6 +1104,14 @@ def derive_effect_signal(
        effect for every session that never looked.
     """
     delivery = str(delivery_outcome or "").strip().lower()
+
+    # gh API failed at snapshot time: we cannot observe the "after" state, so
+    # this is an infra failure, not genuine ineffectiveness.  Must take
+    # precedence over delivery_outcome (including orphan_no_delivery) so that a
+    # fetch failure is never recorded as a definitive no-effect.
+    if payload.get("gh_snapshot_fetch_failed"):
+        return EFFECT_FETCH_FAILED
+
     if delivery == "orphan_no_delivery":
         return EFFECT_NONE
     if delivery == "handled":

--- a/packages/gptme-runloops/tests/goldens/worker_records/pr_state_diff.json
+++ b/packages/gptme-runloops/tests/goldens/worker_records/pr_state_diff.json
@@ -14,7 +14,8 @@
         "pr_head_oid_before": "aaa111",
         "pr_merge_commit_after": "ccc333",
         "pr_state_after": "MERGED",
-        "pr_state_before": "OPEN"
+        "pr_state_before": "OPEN",
+        "gh_snapshot_fetch_failed": false
       },
       "gh_fail": false,
       "gh_output": "{\"state\": \"MERGED\", \"headRefOid\": \"BBB222\", \"mergeCommit\": {\"oid\": \"CCC333\"}}",
@@ -48,7 +49,8 @@
         "pr_head_oid_before": "abc1",
         "pr_merge_commit_after": "raw-string-oid",
         "pr_state_after": "MERGED",
-        "pr_state_before": "OPEN"
+        "pr_state_before": "OPEN",
+        "gh_snapshot_fetch_failed": false
       },
       "gh_fail": false,
       "gh_output": "{\"state\": \"MERGED\", \"headRefOid\": \"def2\", \"mergeCommit\": \"raw-string-oid\"}",
@@ -72,6 +74,7 @@
           "One",
           "Two"
         ],
+        "gh_snapshot_fetch_failed": true,
         "outcome": "productive"
       },
       "gh_fail": true,
@@ -121,7 +124,8 @@
         "pr_head_oid_after": "bbb",
         "pr_head_oid_before": "aaa",
         "pr_state_after": "OPEN",
-        "pr_state_before": "OPEN"
+        "pr_state_before": "OPEN",
+        "gh_snapshot_fetch_failed": false
       },
       "gh_fail": false,
       "gh_output": "{\"state\": \"OPEN\", \"headRefOid\": \"bbb\", \"mergeCommit\": null}",

--- a/packages/gptme-runloops/tests/test_pm_dispatch.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch.py
@@ -2438,3 +2438,51 @@ class TestRepoExclusionList:
         repos = [json.loads(line)["repo"] for line in fast_lines]
         assert "gptme/gptme" in repos
         assert "ActivityWatch/aw-webui" not in repos
+
+    def test_partition_jsonl_io_items_path_filters_excluded(
+        self, tmp_path, monkeypatch
+    ):
+        """_partition_jsonl_io skips excluded repos on the direct items= path."""
+        monkeypatch.setenv(PM_DISPATCH_EXCLUDE_REPOS_ENV, "ActivityWatch/*")
+        fast_path = tmp_path / "fast.jsonl"
+        slow_path = tmp_path / "slow.jsonl"
+        items = [
+            make_item(
+                repo="ActivityWatch/aw-webui", number=255, types=["notification"]
+            ),
+            make_item(repo="gptme/gptme", number=1, types=["notification"]),
+        ]
+        _partition_jsonl_io(fast_path, slow_path, items=items)
+        fast_lines = [
+            line for line in fast_path.read_text().splitlines() if line.strip()
+        ]
+        repos = [json.loads(line)["repo"] for line in fast_lines]
+        assert "gptme/gptme" in repos
+        assert "ActivityWatch/aw-webui" not in repos
+
+    def test_lane_dispatcher_dispatch_filters_excluded(self, monkeypatch):
+        """LaneDispatcher.dispatch() skips items from excluded repos."""
+        monkeypatch.setenv(PM_DISPATCH_EXCLUDE_REPOS_ENV, "ActivityWatch/*")
+        callback_calls = []
+
+        def cb(**kwargs):
+            callback_calls.append(kwargs["item"].repo)
+            return True
+
+        sm = SlotManager(
+            slot_cap=10,
+            count_running=lambda: 0,
+            count_running_lane=lambda lane: 0,
+            is_busy=lambda unit: False,
+        )
+        ld = LaneDispatcher(slot_manager=sm, dispatch_callback=cb)
+        items = [
+            make_item(
+                repo="ActivityWatch/aw-webui", number=255, types=["notification"]
+            ),
+            make_item(repo="gptme/gptme", number=1, types=["notification"]),
+        ]
+        launched, deferred = ld.dispatch(items)
+        assert launched == 1
+        assert deferred == 0
+        assert callback_calls == ["gptme/gptme"]

--- a/packages/gptme-runloops/tests/test_pm_dispatch.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch.py
@@ -2354,6 +2354,13 @@ class TestRepoExclusionList:
     def test_repo_is_excluded_empty_patterns(self):
         assert not _repo_is_excluded("ActivityWatch/aw-webui", ())
 
+    def test_repo_is_excluded_case_insensitive(self):
+        # GitHub repo names are case-preserving but case-insensitive for
+        # identification; the pipeline may deliver either casing.
+        assert _repo_is_excluded("activitywatch/aw-webui", ("ActivityWatch/*",))
+        assert _repo_is_excluded("ACTIVITYWATCH/aw-webui", ("ActivityWatch/*",))
+        assert _repo_is_excluded("ActivityWatch/aw-webui", ("activitywatch/*",))
+
     def test_get_excluded_repo_patterns_default(self, monkeypatch):
         monkeypatch.delenv(PM_DISPATCH_EXCLUDE_REPOS_ENV, raising=False)
         patterns = _get_excluded_repo_patterns()

--- a/packages/gptme-runloops/tests/test_pm_dispatch.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch.py
@@ -2338,7 +2338,7 @@ class TestDispatchGroupedItemsCooldown:
 
 
 class TestRepoExclusionList:
-    """Tests for the PM dispatch exclusion list (ActivityWatch/* etc.)."""
+    """Tests for the PM dispatch repo exclusion list (glob patterns, env override)."""
 
     def test_repo_is_excluded_exact_match(self):
         assert _repo_is_excluded("ActivityWatch/aw-webui", ("ActivityWatch/aw-webui",))
@@ -2369,18 +2369,17 @@ class TestRepoExclusionList:
         assert not _repo_is_excluded(None, ())  # type: ignore[arg-type]
 
     def test_get_excluded_repo_patterns_default(self, monkeypatch):
+        """No repos are excluded by default — the default is an empty tuple."""
         monkeypatch.delenv(PM_DISPATCH_EXCLUDE_REPOS_ENV, raising=False)
         patterns = _get_excluded_repo_patterns()
-        assert "ActivityWatch/*" in patterns
+        assert patterns == ()
 
     def test_get_excluded_repo_patterns_env_additive(self, monkeypatch):
-        """Setting the env var adds repos to the default — ActivityWatch/* is preserved."""
+        """Setting the env var to a non-empty value populates the exclusion list."""
         monkeypatch.setenv(PM_DISPATCH_EXCLUDE_REPOS_ENV, "foo/bar,baz/*")
         patterns = _get_excluded_repo_patterns()
         assert "foo/bar" in patterns
         assert "baz/*" in patterns
-        # Default must be preserved — setting the env var is additive, not a replacement.
-        assert "ActivityWatch/*" in patterns
 
     def test_get_excluded_repo_patterns_env_empty_disables(self, monkeypatch):
         monkeypatch.setenv(PM_DISPATCH_EXCLUDE_REPOS_ENV, "")

--- a/packages/gptme-runloops/tests/test_pm_dispatch.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch.py
@@ -18,6 +18,7 @@ from gptme_runloops.pm_dispatch import (
     HUMAN_PRIORITY_ACTIVITY,
     HUMAN_PRIORITY_CHANGES_REQUESTED,
     MIN_BANDIT_OBSERVATIONS,
+    PM_DISPATCH_EXCLUDE_REPOS_ENV,
     SLOW_LANE_TYPES,
     DispatchLedger,
     LaneDispatcher,
@@ -25,7 +26,9 @@ from gptme_runloops.pm_dispatch import (
     SlotItem,
     SlotManager,
     _bandit_observation_count,
+    _get_excluded_repo_patterns,
     _partition_jsonl_io,
+    _repo_is_excluded,
     _resolve_model_with_bandit,
     _sanitize_unit_name,
     _slot_in_cooldown,
@@ -2332,3 +2335,106 @@ class TestDispatchGroupedItemsCooldown:
             assert any("Failed to write" in r.message for r in caplog.records)
         finally:
             ro_dir.chmod(0o755)
+
+
+class TestRepoExclusionList:
+    """Tests for the PM dispatch exclusion list (ActivityWatch/* etc.)."""
+
+    def test_repo_is_excluded_exact_match(self):
+        assert _repo_is_excluded("ActivityWatch/aw-webui", ("ActivityWatch/aw-webui",))
+
+    def test_repo_is_excluded_glob(self):
+        assert _repo_is_excluded("ActivityWatch/aw-webui", ("ActivityWatch/*",))
+        assert _repo_is_excluded("ActivityWatch/aw-android", ("ActivityWatch/*",))
+
+    def test_repo_is_excluded_no_match(self):
+        assert not _repo_is_excluded("gptme/gptme", ("ActivityWatch/*",))
+        assert not _repo_is_excluded("ErikBjare/bob", ("ActivityWatch/*",))
+
+    def test_repo_is_excluded_empty_patterns(self):
+        assert not _repo_is_excluded("ActivityWatch/aw-webui", ())
+
+    def test_get_excluded_repo_patterns_default(self, monkeypatch):
+        monkeypatch.delenv(PM_DISPATCH_EXCLUDE_REPOS_ENV, raising=False)
+        patterns = _get_excluded_repo_patterns()
+        assert "ActivityWatch/*" in patterns
+
+    def test_get_excluded_repo_patterns_env_override(self, monkeypatch):
+        monkeypatch.setenv(PM_DISPATCH_EXCLUDE_REPOS_ENV, "foo/bar,baz/*")
+        patterns = _get_excluded_repo_patterns()
+        assert patterns == ("foo/bar", "baz/*")
+        assert "ActivityWatch/*" not in patterns
+
+    def test_get_excluded_repo_patterns_env_empty_disables(self, monkeypatch):
+        monkeypatch.setenv(PM_DISPATCH_EXCLUDE_REPOS_ENV, "")
+        patterns = _get_excluded_repo_patterns()
+        assert patterns == ()
+
+    def test_dispatch_grouped_items_skips_excluded(self, tmp_path, monkeypatch):
+        """Excluded repos are not dispatched and counted in skipped_excluded."""
+        monkeypatch.setenv(PM_DISPATCH_EXCLUDE_REPOS_ENV, "ActivityWatch/*")
+        aw_item = make_item(
+            repo="ActivityWatch/aw-webui", number=255, types=["pr_update"]
+        )
+        ok_item = make_item(repo="gptme/gptme", number=1, types=["pr_update"])
+        cd = tmp_path / "cd"
+        result = dispatch_grouped_items(
+            [aw_item, ok_item], slot_cap=5, cooldown_secs=0, cooldown_dir=cd
+        )
+        assert result.skipped_excluded == 1
+        assert result.launched == 1
+
+    def test_dispatch_grouped_items_all_excluded(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(PM_DISPATCH_EXCLUDE_REPOS_ENV, "ActivityWatch/*")
+        items = [
+            make_item(repo="ActivityWatch/aw-webui", number=255, types=["pr_update"]),
+            make_item(repo="ActivityWatch/aw-android", number=209, types=["pr_update"]),
+        ]
+        cd = tmp_path / "cd"
+        result = dispatch_grouped_items(
+            items, slot_cap=5, cooldown_secs=0, cooldown_dir=cd
+        )
+        assert result.skipped_excluded == 2
+        assert result.launched == 0
+
+    def test_partition_jsonl_io_filters_excluded(self, tmp_path, monkeypatch):
+        """_partition_jsonl_io skips excluded repos on the bash bridge path."""
+        monkeypatch.setenv(PM_DISPATCH_EXCLUDE_REPOS_ENV, "ActivityWatch/*")
+        fast_path = tmp_path / "fast.jsonl"
+        slow_path = tmp_path / "slow.jsonl"
+        # pr_update is slow-lane; notification is fast-lane
+        items_json = "\n".join(
+            [
+                json.dumps(
+                    {
+                        "repo": "ActivityWatch/aw-webui",
+                        "number": 255,
+                        "types": ["notification"],
+                        "title": "AW notif",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "repo": "gptme/gptme",
+                        "number": 1,
+                        "types": ["notification"],
+                        "title": "OK notif",
+                    }
+                ),
+            ]
+        )
+        import io as _io
+        import sys as _sys
+
+        orig_stdin = _sys.stdin
+        try:
+            _sys.stdin = _io.StringIO(items_json)
+            _partition_jsonl_io(fast_path, slow_path)
+        finally:
+            _sys.stdin = orig_stdin
+        fast_lines = [
+            line for line in fast_path.read_text().splitlines() if line.strip()
+        ]
+        repos = [json.loads(line)["repo"] for line in fast_lines]
+        assert "gptme/gptme" in repos
+        assert "ActivityWatch/aw-webui" not in repos

--- a/packages/gptme-runloops/tests/test_pm_dispatch.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch.py
@@ -2361,6 +2361,13 @@ class TestRepoExclusionList:
         assert _repo_is_excluded("ACTIVITYWATCH/aw-webui", ("ActivityWatch/*",))
         assert _repo_is_excluded("ActivityWatch/aw-webui", ("activitywatch/*",))
 
+    def test_repo_is_excluded_none_repo(self):
+        # A malformed SlotItem may have repo=None (missing "repo" field in JSONL).
+        # _repo_is_excluded must not raise — it treats None as an empty string
+        # (no match against any pattern, same permissive behaviour as derive_slot_key).
+        assert not _repo_is_excluded(None, ("ActivityWatch/*",))  # type: ignore[arg-type]
+        assert not _repo_is_excluded(None, ())  # type: ignore[arg-type]
+
     def test_get_excluded_repo_patterns_default(self, monkeypatch):
         monkeypatch.delenv(PM_DISPATCH_EXCLUDE_REPOS_ENV, raising=False)
         patterns = _get_excluded_repo_patterns()

--- a/packages/gptme-runloops/tests/test_pm_dispatch.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch.py
@@ -897,7 +897,7 @@ class TestLaneDispatcher:
         return LaneDispatcher(slot_manager=sm)
 
     def test_dispatch_empty(self, ld_no_slots):
-        launched, deferred = ld_no_slots.dispatch([])
+        launched, deferred, _ = ld_no_slots.dispatch([])
         assert launched == 0
         assert deferred == 0
 
@@ -917,7 +917,7 @@ class TestLaneDispatcher:
             make_item(repo="a/b", number=1, types=["assigned_issue"]),
             make_item(repo="a/b", number=2, types=["pr_update"]),
         ]
-        launched, deferred = ld.dispatch(items, backend="claude-code")
+        launched, deferred, _ = ld.dispatch(items, backend="claude-code")
         assert launched == 2
         assert deferred == 0
         assert len(callback_calls) == 2
@@ -1069,7 +1069,7 @@ class TestLaneDispatcher:
             make_item(types=["assigned_issue"]),  # fast
             make_item(types=["pr_update"]),  # slow
         ]
-        launched, deferred = ld.dispatch(items)
+        launched, deferred, _ = ld.dispatch(items)
         # Fast launches (cap=1, below), slow deferred
         assert launched == 1
         assert deferred == 1
@@ -1092,7 +1092,7 @@ class TestLaneDispatcher:
         ld = LaneDispatcher(slot_manager=sm, dispatch_callback=cb)
 
         items = [make_item(types=["assigned_issue"])]
-        launched, deferred = ld.dispatch(items)
+        launched, deferred, _ = ld.dispatch(items)
         assert launched == 0
         assert deferred == 1
         assert len(callback_calls) == 0
@@ -1118,7 +1118,7 @@ class TestLaneDispatcher:
         items = [
             make_item(types=["assigned_issue"]),  # fast
         ]
-        launched, deferred = ld.dispatch(items)
+        launched, deferred, _ = ld.dispatch(items)
         # Fast should burst
         assert launched == 1
         assert deferred == 0
@@ -1142,7 +1142,7 @@ class TestLaneDispatcher:
         ld = LaneDispatcher(slot_manager=sm, dispatch_callback=cb)
 
         items = [make_item(types=["assigned_issue"])]
-        launched, deferred = ld.dispatch(items)
+        launched, deferred, _ = ld.dispatch(items)
         # Fast burst exhausted
         assert launched == 0
         assert deferred == 1
@@ -1167,7 +1167,7 @@ class TestLaneDispatcher:
             make_item(number=3, types=["ci_failure"]),
             make_item(number=4, types=["mention"]),
         ]
-        launched, deferred = ld.dispatch(items)
+        launched, deferred, _ = ld.dispatch(items)
         assert launched == 4
         lanes = [c["lane"] for c in callback_calls]
         assert lanes == ["fast", "fast", "slow", "slow"]
@@ -2366,11 +2366,14 @@ class TestRepoExclusionList:
         patterns = _get_excluded_repo_patterns()
         assert "ActivityWatch/*" in patterns
 
-    def test_get_excluded_repo_patterns_env_override(self, monkeypatch):
+    def test_get_excluded_repo_patterns_env_additive(self, monkeypatch):
+        """Setting the env var adds repos to the default — ActivityWatch/* is preserved."""
         monkeypatch.setenv(PM_DISPATCH_EXCLUDE_REPOS_ENV, "foo/bar,baz/*")
         patterns = _get_excluded_repo_patterns()
-        assert patterns == ("foo/bar", "baz/*")
-        assert "ActivityWatch/*" not in patterns
+        assert "foo/bar" in patterns
+        assert "baz/*" in patterns
+        # Default must be preserved — setting the env var is additive, not a replacement.
+        assert "ActivityWatch/*" in patterns
 
     def test_get_excluded_repo_patterns_env_empty_disables(self, monkeypatch):
         monkeypatch.setenv(PM_DISPATCH_EXCLUDE_REPOS_ENV, "")
@@ -2489,7 +2492,8 @@ class TestRepoExclusionList:
             ),
             make_item(repo="gptme/gptme", number=1, types=["notification"]),
         ]
-        launched, deferred = ld.dispatch(items)
+        launched, deferred, skipped_excluded = ld.dispatch(items)
         assert launched == 1
         assert deferred == 0
+        assert skipped_excluded == 1
         assert callback_calls == ["gptme/gptme"]

--- a/packages/gptme-runloops/tests/test_pm_dispatch_outcome.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch_outcome.py
@@ -220,6 +220,16 @@ class TestDeriveEffectSignal:
     def test_handled_delivery_is_observed(self) -> None:
         assert derive_effect_signal({}, delivery_outcome="handled") == EFFECT_OBSERVED
 
+    def test_handled_delivery_outranks_fetch_failed(self) -> None:
+        """A confirmed delivery (reply posted) must not be overridden by a snapshot fetch failure."""
+        assert (
+            derive_effect_signal(
+                {"gh_snapshot_fetch_failed": True},
+                delivery_outcome="handled",
+            )
+            == EFFECT_OBSERVED
+        )
+
     def test_empty_delivery_outcome_is_not_treated_as_handled(self) -> None:
         # run_post_session holds "handled" as its permissive DEFAULT when no
         # delivery check runs, and passes "" instead of that default. If the

--- a/packages/gptme-runloops/tests/test_pm_dispatch_outcome.py
+++ b/packages/gptme-runloops/tests/test_pm_dispatch_outcome.py
@@ -27,6 +27,7 @@ from gptme_runloops.pm_dispatch import (
     derive_dispatch_outcome,
 )
 from gptme_runloops.worker_records import (
+    EFFECT_FETCH_FAILED,
     derive_effect_signal,
     read_record_effect_signal,
 )
@@ -189,6 +190,23 @@ class TestDeriveEffectSignal:
         # Absence of evidence must never be recorded as evidence of effect.
         assert derive_effect_signal({}) == EFFECT_UNKNOWN
         assert derive_effect_signal({"pr_head_oid_before": "aaa"}) == EFFECT_UNKNOWN
+
+    def test_gh_fetch_failed_flag_returns_fetch_failed(self) -> None:
+        """gh_snapshot_fetch_failed flag → EFFECT_FETCH_FAILED, not EFFECT_UNKNOWN."""
+        assert (
+            derive_effect_signal({"gh_snapshot_fetch_failed": True})
+            == EFFECT_FETCH_FAILED
+        )
+
+    def test_gh_fetch_failed_overrides_orphan_no_delivery(self) -> None:
+        """fetch_failed must outrank orphan_no_delivery — infra failure is not no-effect."""
+        assert (
+            derive_effect_signal(
+                {"gh_snapshot_fetch_failed": True},
+                delivery_outcome="orphan_no_delivery",
+            )
+            == EFFECT_FETCH_FAILED
+        )
 
     def test_orphan_delivery_is_no_effect(self) -> None:
         assert (

--- a/packages/gptme-runloops/tests/test_worker_records.py
+++ b/packages/gptme-runloops/tests/test_worker_records.py
@@ -716,12 +716,39 @@ def test_update_record_pr_state_missing_record_is_noop(ws: Path) -> None:
     assert not (ws / "records" / "missing.json").exists()
 
 
-def test_fetch_pr_snapshot_nonzero_exit_is_empty(ws: Path) -> None:
+def test_fetch_pr_snapshot_nonzero_exit_returns_none(ws: Path) -> None:
+    """Non-zero gh exit → None (signals API failure, not empty-diff)."""
+
     def runner(args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
         assert args[:3] == ["gh", "pr", "view"]
         return subprocess.CompletedProcess(args, returncode=1, stdout="{}", stderr="")
 
-    assert fetch_pr_snapshot("gptme/gptme", 1, cwd=ws, runner=runner) == {}
+    assert fetch_pr_snapshot("gptme/gptme", 1, cwd=ws, runner=runner) is None
+
+
+def test_update_record_pr_state_gh_failure_sets_flag(ws: Path, tmp_path: Path) -> None:
+    """A fetch failure sets gh_snapshot_fetch_failed in the record."""
+    import json
+
+    record = tmp_path / "record.json"
+    record.write_text(json.dumps({"outcome": "succeeded"}), encoding="utf-8")
+
+    def fail_fetch(repo: str, num: int) -> None:  # type: ignore[return]
+        return None
+
+    from gptme_runloops.worker_records import update_record_pr_state
+
+    update_record_pr_state(
+        record,
+        repo="gptme/gptme",
+        number=1,
+        before_json="{}",
+        cwd=ws,
+        fetch=fail_fetch,
+    )
+
+    payload = json.loads(record.read_text())
+    assert payload.get("gh_snapshot_fetch_failed") is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Adds `PM_DISPATCH_EXCLUDE_REPOS` env var (comma-separated `owner/repo` or `owner/*` globs, default: `ActivityWatch/*`) to filter repos before PM dispatch
- Filter applied in both `dispatch_grouped_items()` (Python-native path) and `_partition_jsonl_io()` (bash-bridge JSONL stdin path)
- `DispatchResult` extended with `skipped_excluded` count for observability
- 10 new tests in `TestRepoExclusionList`; all 220 tests pass

## Motivation

ActivityWatch community discourages AI responses on issues (ErikBjare/bob#788).
PM was dispatching sessions for AW PRs/issues it can't act on (e.g.
ActivityWatch/aw-webui#255 had 22 completed dispatches with 0 observable effect
— merge conflict Bob can't resolve, can't post comments). This churn wastes
budget and pollutes the dispatch logs.

The exclusion list stops the dispatch at the source rather than having each
dispatched session discover and exit.

## Test plan

- `cd packages/gptme-runloops && uv run pytest tests/test_pm_dispatch.py::TestRepoExclusionList -v`
- Full suite: `uv run pytest tests/test_pm_dispatch.py` (220 tests)