### PR TITLE
fix(uv): sync lockfile to include gptme-bob-status member

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -28,6 +28,7 @@ members = [
     "gptme-activity-summary",
     "gptme-attention-tracker",
     "gptme-backoff",
+    "gptme-bob-status",
     "gptme-cc-memory",
     "gptme-claude-code",
     "gptme-codegraph",
@@ -1758,6 +1759,26 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.25" },
     { name = "tenacity", specifier = ">=9.0" },
+]
+provides-extras = ["test"]
+
+[[package]]
+name = "gptme-bob-status"
+version = "0.1.0"
+source = { editable = "packages/gptme-bob-status" }
+dependencies = [
+    { name = "gptme" },
+]
+
+[package.optional-dependencies]
+test = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "gptme", git = "https://github.com/gptme/gptme.git?branch=master" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
 ]
 provides-extras = ["test"]
 


### PR DESCRIPTION
## Problem

`packages/gptme-bob-status` was added in #1442, but `uv.lock` was never regenerated. Since the workspace uses a `members = ["packages/*", "plugins/*"]` glob, the new package is a member but is **missing from the committed lockfile**.

Consequence: every `uv lock` / `uv sync` regenerates the lock dirty, producing recurring working-tree churn across the fleet (a stray `M uv.lock` at session start). This is the same class of noise as #1447 (numpy) and #1456 (pm-dispatch).

## Fix

Regenerated the lockfile on latest master. Pure member sync — **no dependency version changes**:
- Adds `gptme-bob-status` to the members list + its `[[package]]` block (21 insertions)
- No numpy/torch/nvidia deltas (verified)
- `uv lock --check` passes after

## Verification
```
$ uv lock
Resolved 265 packages in 3.12s
Added gptme-bob-status v0.1.0
$ uv lock --check
Resolved 265 packages   # clean, no drift
```