### PR TITLE
fix(sessions): stop defaulting a score-less judge verdict to 0.5

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/judge.py
+++ b/packages/gptme-sessions/src/gptme_sessions/judge.py
@@ -507,7 +507,10 @@ def _coerce_score(raw: Any) -> float | None:
     if raw is None:
         return None
     try:
-        return max(0.0, min(1.0, float(raw)))
+        v = float(raw)
+        if v != v:  # NaN: the only float where x != x is True
+            return None
+        return max(0.0, min(1.0, v))
     except (ValueError, TypeError):
         return None
 
@@ -968,6 +971,12 @@ def write_alignment_grade(
                 normalized.get("judge_status", JUDGE_STATUS_NO_SCORE),
                 normalized.get("model") or "unknown",
             )
+            # Persist the judge's reason even without a score so an analyst
+            # can find out WHY the judge produced no score by querying session
+            # records rather than grepping logs (the records-queryable goal of
+            # judge_status would be undermined without the accompanying reason).
+            if normalized.get("reason"):
+                record.llm_judge_reason = normalized["reason"]
         else:
             record.set_alignment_grade(
                 score,

--- a/packages/gptme-sessions/src/gptme_sessions/judge.py
+++ b/packages/gptme-sessions/src/gptme_sessions/judge.py
@@ -52,7 +52,11 @@ class JudgeMetadata(TypedDict):
 
 
 class JudgeVerdict(TypedDict, total=False):
-    score: float
+    # ``None`` when the judge returned a payload without a usable score.
+    # Never silently substituted with a neutral default — see
+    # ``_coerce_score`` and ``JUDGE_STATUS_NO_SCORE``.
+    score: float | None
+    judge_status: str
     reason: str
     model: str
     alignment_score: float | None
@@ -489,6 +493,25 @@ def _build_judge_meta(*, model: str) -> JudgeMetadata:
 VALID_ALIGNMENT_VALUES = frozenset({"on_track", "partial", "pivot", "off_target"})
 
 
+JUDGE_STATUS_OK = "ok"
+JUDGE_STATUS_NO_SCORE = "no_score"
+
+
+def _coerce_score(raw: Any) -> float | None:
+    """Clamp a raw judge score to 0.0-1.0, or None when it is unusable.
+
+    Returning None is deliberate: a missing or malformed ``score`` used to
+    become a neutral 0.5, which is indistinguishable from a judge that
+    genuinely scored the session at 0.5. Callers must branch on None.
+    """
+    if raw is None:
+        return None
+    try:
+        return max(0.0, min(1.0, float(raw)))
+    except (ValueError, TypeError):
+        return None
+
+
 def _coerce_alignment_score(raw: Any) -> float | None:
     """Normalize an alignment_score value to float 0.0-1.0 or None."""
     if raw is None:
@@ -520,8 +543,20 @@ def normalize_judge_verdict(payload: dict[str, Any]) -> JudgeVerdict:
     raw_meta = payload.get("meta")
     meta = raw_meta if isinstance(raw_meta, dict) else {}
     base_meta = _build_judge_meta(model=model)
+    score = _coerce_score(payload.get("score"))
+    status = str(payload.get("judge_status") or JUDGE_STATUS_OK)
+    if score is None:
+        status = JUDGE_STATUS_NO_SCORE
+        logger.warning(
+            "Judge verdict has no usable score (raw=%r, model=%s); "
+            "recording judge_status=%s instead of a neutral default",
+            payload.get("score"),
+            model or "unknown",
+            JUDGE_STATUS_NO_SCORE,
+        )
     verdict: JudgeVerdict = {
-        "score": max(0.0, min(1.0, float(payload.get("score", 0.5)))),
+        "score": score,
+        "judge_status": status,
         "reason": str(payload.get("reason", "")),
         "model": model,
         "alignment_score": _coerce_alignment_score(payload.get("alignment_score")),
@@ -563,10 +598,20 @@ def _parse_judge_payload(text: str, model: str) -> dict | None:
             logger.warning("LLM judge returned non-JSON response")
             return None
         verdict = json.loads(match.group(0))
-    score = float(verdict.get("score", 0.5))
+    score = _coerce_score(verdict.get("score"))
     reason = str(verdict.get("reason", ""))
-    score = max(0.0, min(1.0, score))
-    result: dict[str, Any] = {"score": score, "reason": reason, "model": model}
+    if score is None:
+        logger.warning(
+            "LLM judge returned a payload without a usable score (raw=%r, model=%s)",
+            verdict.get("score"),
+            model,
+        )
+    result: dict[str, Any] = {
+        "score": score,
+        "judge_status": JUDGE_STATUS_OK if score is not None else JUDGE_STATUS_NO_SCORE,
+        "reason": reason,
+        "model": model,
+    }
     # Phase 3: pass through intent-contract fields when the judge returns them
     alignment_score = _coerce_alignment_score(verdict.get("alignment_score"))
     if alignment_score is not None:
@@ -911,14 +956,30 @@ def write_alignment_grade(
                 except (json.JSONDecodeError, OSError):
                     pass
 
-        record.set_alignment_grade(
-            normalized["score"],
-            reason=normalized["reason"],
-            model=normalized["model"],
-        )
+        score = normalized.get("score")
+        if score is None:
+            # The judge produced a payload but no usable score. Recording a
+            # neutral default here would be indistinguishable from a real 0.5,
+            # so stamp the failure instead and leave the grade unset — the
+            # reward consumer falls back to the heuristic and says so.
+            logger.warning(
+                "No alignment grade written for %s: judge_status=%s (model=%s)",
+                session_id,
+                normalized.get("judge_status", JUDGE_STATUS_NO_SCORE),
+                normalized.get("model") or "unknown",
+            )
+        else:
+            record.set_alignment_grade(
+                score,
+                reason=normalized["reason"],
+                model=normalized["model"],
+            )
         # Phase 3: persist intent-contract alignment fields via legacy bridge
         legacy_fields = getattr(record, "_legacy_fields", None)
         if isinstance(legacy_fields, dict):
+            # Always durable, so score-less verdicts are countable by querying
+            # the session records rather than grepping logs.
+            legacy_fields["judge_status"] = normalized.get("judge_status", JUDGE_STATUS_OK)
             if normalized.get("alignment_score") is not None:
                 legacy_fields["alignment_score"] = normalized["alignment_score"]
             if normalized.get("pivot_verdict") is not None:
@@ -993,5 +1054,7 @@ def judge_and_writeback(
     )
     if not updated:
         return {"status": "no_record", **normalized}
+    if normalized.get("score") is None:
+        return {"status": JUDGE_STATUS_NO_SCORE, **normalized}
 
     return {"status": "ok", **normalized}

--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -503,8 +503,10 @@ def post_session(
     # this is indistinguishable from a genuine noop and the existing
     # unreliable-trajectory-with-no-deliverables path already records
     # "unknown" rather than penalizing the backend.
+    _format_blind = False
     if trajectory_reliable and deliverables and _trajectory_format_blind(signals):
         trajectory_reliable = False
+        _format_blind = True
         logger.warning(
             "Trajectory reports zero tool calls over %ss — extractor may not "
             "support this trajectory format; trusting caller deliverables",
@@ -641,11 +643,18 @@ def post_session(
         if traj_productive:
             outcome = "productive"
         elif not trajectory_reliable and caller_deliverables:
-            # Trajectory says noop but is unreliable (covers far less wall-clock
-            # than the session ran — likely truncated or misattributed) and the
-            # caller observed real git-range commits. Trust the commits.
+            # Trajectory says noop but is unreliable and the caller observed
+            # real git-range commits. Trust the commits.
+            # Distinguish two sub-cases so audit consumers see the real cause:
+            # - format_blind: trajectory had good wall-clock coverage but the
+            #   extractor couldn't parse the tool-call shape (no duration mismatch)
+            # - unreliable: trajectory covered far less wall-clock than the session
             outcome = "productive"
-            outcome_flip_reason = "unreliable_trajectory_caller_deliverables"
+            outcome_flip_reason = (
+                "format_blind_trajectory_caller_deliverables"
+                if _format_blind
+                else "unreliable_trajectory_caller_deliverables"
+            )
         elif not trajectory_reliable and not caller_deliverables:
             # Trajectory is unreliable (truncated/misattributed) and no caller
             # deliverables exist — outcome is genuinely unknown.  Recording noop

--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -632,6 +632,9 @@ def post_session(
     # Rationale: defaulting to "productive" inflates bandit reward signals
     # when callers omit trajectory/commit data.  "unknown" means "we don't
     # know" — callers should skip bandit updates rather than guess.
+    # Records why an outcome was promoted away from what the primary signal
+    # said. None means "no flip" — the signal was taken at face value.
+    outcome_flip_reason: str | None = None
     if exit_code not in (0, 124):
         outcome = "failed"
     elif traj_productive is not None:
@@ -642,6 +645,7 @@ def post_session(
             # than the session ran — likely truncated or misattributed) and the
             # caller observed real git-range commits. Trust the commits.
             outcome = "productive"
+            outcome_flip_reason = "unreliable_trajectory_caller_deliverables"
         elif not trajectory_reliable and not caller_deliverables:
             # Trajectory is unreliable (truncated/misattributed) and no caller
             # deliverables exist — outcome is genuinely unknown.  Recording noop
@@ -681,6 +685,10 @@ def post_session(
             outcome,
             len(caller_deliverables),
         )
+        outcome_flip_reason = (
+            f"no_trajectory_caller_deliverables:{outcome}"
+            f"->productive:n={len(caller_deliverables)}"
+        )
         outcome = "productive"
 
     # --- Compute start_time / end_time from duration ---
@@ -715,6 +723,8 @@ def post_session(
         "deliverables": deliverables,
         "deliverable_details": deliverable_details,
     }
+    if outcome_flip_reason is not None:
+        record_kwargs["outcome_flip_reason"] = outcome_flip_reason
     if context_tier is not None:
         record_kwargs["context_tier"] = context_tier
     if ab_group is not None:

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -246,6 +246,12 @@ class SessionRecord:
     # ``None`` when no journal_path was available to scan.
     smell_score: float | None = None
 
+    # Why the recorded outcome differs from what the primary signal said.
+    # ``None`` means no flip happened — the signal was taken at face value.
+    # Set by post_session() at each promotion site so an upgraded outcome
+    # (e.g. noop -> productive on caller deliverables) stays auditable.
+    outcome_flip_reason: str | None = None
+
     # Optional harm category tag (idea #191).  Populated by the
     # --classify-harm-category classifier in compute-harm-signal.py.
     # One of HARM_CATEGORY_LABELS, or None when not classified.

--- a/packages/gptme-sessions/tests/test_judge.py
+++ b/packages/gptme-sessions/tests/test_judge.py
@@ -427,6 +427,7 @@ class TestJudgeSession:
 
         assert parsed == {
             "score": 1.0,
+            "judge_status": "ok",
             "reason": "Shipped a real fix",
             "model": "openai-subscription/gpt-5.4",
         }
@@ -743,6 +744,7 @@ class TestModelRouting:
 
         assert normalized == {
             "score": 0.74,
+            "judge_status": "ok",
             "reason": "Meaningful progress",
             "model": "openai-subscription/gpt-5.4",
             "alignment_score": None,
@@ -1011,6 +1013,75 @@ class TestSessionRecordJudgeFields:
         assert updated.span_aggregates["dominant_tool"] == "exec_command"
         assert updated.span_aggregates["error_rate"] == 0.0
 
+    def test_parse_judge_payload_without_score_is_no_score(self) -> None:
+        """A payload with no usable score must NOT become a neutral 0.5."""
+        parsed = _parse_judge_payload(
+            '{"reason": "judge forgot the score"}',
+            "openai-subscription/gpt-5.4",
+        )
+
+        assert parsed == {
+            "score": None,
+            "judge_status": "no_score",
+            "reason": "judge forgot the score",
+            "model": "openai-subscription/gpt-5.4",
+        }
+
+    def test_parse_judge_payload_with_unparseable_score_is_no_score(self) -> None:
+        parsed = _parse_judge_payload(
+            '{"score": "excellent", "reason": "prose instead of a number"}',
+            "openai-subscription/gpt-5.4",
+        )
+
+        assert parsed is not None
+        assert parsed["score"] is None
+        assert parsed["judge_status"] == "no_score"
+
+    def test_normalize_judge_verdict_without_score_is_no_score(self) -> None:
+        normalized = normalize_judge_verdict(
+            {"reason": "no score", "model": "openai-subscription/gpt-5.4"}
+        )
+
+        assert normalized["score"] is None
+        assert normalized["judge_status"] == "no_score"
+
+    def test_score_less_verdict_does_not_write_a_grade(self, tmp_path: Path) -> None:
+        """The record is stamped no_score; no alignment grade is written."""
+        store = SessionStore(sessions_dir=tmp_path)
+        store.append(
+            SessionRecord(
+                session_id="sess-no-score",
+                harness="claude-code",
+                model="opus",
+                run_type="autonomous",
+                outcome="productive",
+            )
+        )
+
+        with patch(
+            "gptme_sessions.judge.judge_session",
+            return_value={
+                "reason": "judge returned prose only",
+                "model": "openai-subscription/gpt-5.4",
+            },
+        ):
+            result = judge_and_writeback(
+                text="session text",
+                category="code",
+                goals="ship useful work",
+                session_id="sess-no-score",
+                sessions_dir=tmp_path,
+                model="openai-subscription/gpt-5.4",
+            )
+
+        assert result["status"] == "no_score"
+        assert result["score"] is None
+
+        record = next(r for r in store.load_all() if r.session_id == "sess-no-score")
+        assert record._legacy_fields.get("judge_status") == "no_score"
+        # The neutral 0.5 that used to be written here is the whole point.
+        assert record.grades.get("alignment") is None
+
     def test_judge_and_writeback_reports_missing_record(self, tmp_path: Path) -> None:
         with patch(
             "gptme_sessions.judge.judge_session",
@@ -1032,6 +1103,7 @@ class TestSessionRecordJudgeFields:
         assert result == {
             "status": "no_record",
             "score": 0.5,
+            "judge_status": "ok",
             "reason": "Did work",
             "model": "openai-subscription/gpt-5.4",
             "alignment_score": None,

--- a/packages/gptme-sessions/tests/test_judge.py
+++ b/packages/gptme-sessions/tests/test_judge.py
@@ -1037,6 +1037,25 @@ class TestSessionRecordJudgeFields:
         assert parsed["score"] is None
         assert parsed["judge_status"] == "no_score"
 
+    def test_parse_judge_payload_with_nan_score_is_no_score(self) -> None:
+        """NaN is a valid JSON value via json.loads but not a usable score.
+
+        In CPython, min(1.0, float('nan')) == 1.0 because nan < 1.0 is False.
+        Without an explicit NaN check _coerce_score would return 1.0 — the
+        maximum alignment score — for a judge that produced no real score.
+        """
+        # json.loads accepts the NaN literal (non-standard but widely supported)
+        parsed = _parse_judge_payload(
+            '{"score": NaN, "reason": "lost track of the number"}',
+            "openai-subscription/gpt-5.4",
+        )
+        # json.loads may reject non-standard NaN literal depending on the
+        # Python/stdlib version; if so, the payload is treated as unparseable.
+        # Either path must yield no_score, not a silent 1.0.
+        if parsed is not None:
+            assert parsed["score"] is None
+            assert parsed["judge_status"] == "no_score"
+
     def test_normalize_judge_verdict_without_score_is_no_score(self) -> None:
         normalized = normalize_judge_verdict(
             {"reason": "no score", "model": "openai-subscription/gpt-5.4"}
@@ -1081,6 +1100,41 @@ class TestSessionRecordJudgeFields:
         assert record._legacy_fields.get("judge_status") == "no_score"
         # The neutral 0.5 that used to be written here is the whole point.
         assert record.grades.get("alignment") is None
+
+    def test_score_less_verdict_persists_reason_for_audit(self, tmp_path: Path) -> None:
+        """When score is None the judge's reason must still be queryable from
+        the session record — otherwise judge_status=no_score is an opaque fact
+        with no explanation, defeating the records-queryable audit goal."""
+        store = SessionStore(sessions_dir=tmp_path)
+        store.append(
+            SessionRecord(
+                session_id="sess-no-score-reason",
+                harness="claude-code",
+                model="opus",
+                run_type="autonomous",
+                outcome="productive",
+            )
+        )
+
+        with patch(
+            "gptme_sessions.judge.judge_session",
+            return_value={
+                "reason": "judge forgot the score — explanation is here",
+                "model": "openai-subscription/gpt-5.4",
+            },
+        ):
+            judge_and_writeback(
+                text="session text",
+                category="code",
+                goals="ship useful work",
+                session_id="sess-no-score-reason",
+                sessions_dir=tmp_path,
+                model="openai-subscription/gpt-5.4",
+            )
+
+        record = next(r for r in store.load_all() if r.session_id == "sess-no-score-reason")
+        # The reason must be stored on the record even without a score.
+        assert record.llm_judge_reason == "judge forgot the score — explanation is here"
 
     def test_judge_and_writeback_reports_missing_record(self, tmp_path: Path) -> None:
         with patch(

--- a/packages/gptme-sessions/tests/test_post_session.py
+++ b/packages/gptme-sessions/tests/test_post_session.py
@@ -661,6 +661,39 @@ def test_post_session_caller_only_deliverables_when_no_trajectory(tmp_path: Path
     ]
 
 
+def test_post_session_no_trajectory_flip_records_reason(tmp_path: Path):
+    """The noop/unknown -> productive promotion must be auditable, not silent."""
+    store = SessionStore(sessions_dir=tmp_path)
+
+    result = post_session(
+        store=store,
+        harness="gptme",
+        model="opus",
+        duration_seconds=60,
+        deliverables=["abc1234567890abcdef1234567890abcdef1234"],
+    )
+
+    assert result.record.outcome == "productive"
+    reason = result.record.outcome_flip_reason
+    assert reason is not None
+    assert reason.startswith("no_trajectory_caller_deliverables:")
+    assert "->productive" in reason
+
+
+def test_post_session_unflipped_outcome_has_no_flip_reason(tmp_path: Path):
+    """No flip happened, so nothing is stamped -- absence stays meaningful."""
+    store = SessionStore(sessions_dir=tmp_path)
+
+    result = post_session(
+        store=store,
+        harness="gptme",
+        model="opus",
+        duration_seconds=60,
+    )
+
+    assert result.record.outcome_flip_reason is None
+
+
 def test_post_session_caller_deliverables_no_outcome_override_when_traj_noop(tmp_path: Path):
     """Git-range commits must NOT upgrade outcome when trajectory determined noop.
     Prevents concurrent-session commits from inflating session classification."""

--- a/packages/gptme-sessions/tests/test_post_session.py
+++ b/packages/gptme-sessions/tests/test_post_session.py
@@ -861,6 +861,10 @@ def test_post_session_format_blind_trajectory_keeps_caller_deliverables(tmp_path
 
     assert result.record.outcome == "productive"
     assert result.record.deliverables == [real_sha]
+    # The flip reason must name the real cause (format blindness), not the
+    # duration-unreliable cause — these are distinct mechanisms and audit
+    # consumers need to tell them apart.
+    assert result.record.outcome_flip_reason == "format_blind_trajectory_caller_deliverables"
 
 
 def test_post_session_nonzero_tool_calls_still_drops_caller_deliverables(tmp_path: Path):


### PR DESCRIPTION
## Problem

The session judge fails *honestly* — when it can't produce a verdict it returns nothing. The consumers did not. A payload that parsed but carried no usable `score` was silently coerced to a neutral **0.5**, which is indistinguishable from a judge that genuinely scored the session at 0.5.

Two sites:
- `_parse_judge_payload()` — `float(verdict.get("score", 0.5))`
- `normalize_judge_verdict()` — `float(payload.get("score", 0.5))`

Same shape as the outcome promotions in `post_session()`: a `noop`/`unknown` outcome gets upgraded to `productive` on caller-supplied deliverables, and the record kept no trace of *why*.

## Changes

**No silent 0.5** (`judge.py`)
- `JudgeVerdict.score` is now `float | None`. `_coerce_score()` clamps to 0.0–1.0 and returns `None` for missing/unparseable values instead of substituting a default.
- Verdicts carry `judge_status` (`ok` | `no_score`), logged at WARNING when not `ok`.
- `write_alignment_grade()` stamps `judge_status` on the record and writes **no** alignment grade when the score is absent — so score-less runs are countable by querying session records rather than grepping logs, and the reward consumer falls back to the heuristic as it already does when the judge returns nothing.
- `judge_and_writeback()` reports `status=no_score`.

**Auditable outcome flips** (`post_session.py`, `record.py`)
- New `SessionRecord.outcome_flip_reason: str | None`, stamped at both promotion sites (`unreliable_trajectory_caller_deliverables`, `no_trajectory_caller_deliverables:<from>->productive:n=<k>`). `None` means no flip happened, so absence stays meaningful.

Grading semantics are otherwise unchanged: a verdict *with* a score behaves exactly as before.

## Tests

6 new tests; 3 existing exact-equality assertions updated for the new `judge_status` key.
- score-less / unparseable-score payloads → `judge_status=no_score`, `score=None`
- score-less verdict writes no alignment grade but does stamp `judge_status` on the record
- flip reason present on promotion, absent when no flip occurred

`1128 passed` for the whole `gptme-sessions` package.

Ref: `ErikBjare/bob` `tasks/judge-fallback-holes-visible.md`, design note `knowledge/technical-designs/session-judge-golden-set-and-split.md`.