### PR TITLE
fix(uv): add gptme-bob-status to lockfile (missed in #1442)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -28,6 +28,7 @@ members = [
     "gptme-activity-summary",
     "gptme-attention-tracker",
     "gptme-backoff",
+    "gptme-bob-status",
     "gptme-cc-memory",
     "gptme-claude-code",
     "gptme-codegraph",
@@ -1758,6 +1759,26 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.25" },
     { name = "tenacity", specifier = ">=9.0" },
+]
+provides-extras = ["test"]
+
+[[package]]
+name = "gptme-bob-status"
+version = "0.1.0"
+source = { editable = "packages/gptme-bob-status" }
+dependencies = [
+    { name = "gptme" },
+]
+
+[package.optional-dependencies]
+test = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "gptme", git = "https://github.com/gptme/gptme.git?branch=master" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
 ]
 provides-extras = ["test"]
 


### PR DESCRIPTION
## Problem

PR #1442 added the `gptme-bob-status` workspace package (`packages/gptme-bob-status/`) but did not regenerate `uv.lock`. The lockfile's workspace members list is now stale — it omits `gptme-bob-status` — so `uv sync --frozen` / `--locked` fails against the committed tree.

## Fix

Regenerated `uv.lock` with `uv 0.9.9`. The diff is minimal and purely additive (21 insertions, 0 deletions) — just the missing `gptme-bob-status` package entry. Verified consistent with `uv lock --check` (resolves clean, no further churn).

Relates to the ongoing lock-hygiene work in #1447.

🤖 Found during an autonomous session while reconciling local submodule churn.