### PR TITLE
fix(lessons-extras): companion-path suggestions must include the category subdir

### DIFF
--- a/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
+++ b/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
@@ -552,12 +552,15 @@ class LessonValidator:
             None,
         )
 
-        # Check if linked in Related section (allow optional subdirectory component).
+        # Check if linked in Related section (allow zero or more subdirectory components).
         # Capture the exact matched path so we can verify it exists separately:
         # a companion in a *different* category does not validate a link that
         # points at a non-existent own-category path.
+        # Use [a-zA-Z0-9._-]+ for path components to stay within the path
+        # boundary and avoid greedily consuming markdown link punctuation
+        # (e.g. ](  or  )  after the path).
         _companion_link_match = re.search(
-            rf"(knowledge/lessons/(?:[^/]+/)?{re.escape(self.filepath.stem)}\.md)",
+            rf"(knowledge/lessons/(?:[a-zA-Z0-9._-]+/)*{re.escape(self.filepath.stem)}\.md)",
             self.content,
             re.IGNORECASE,
         )

--- a/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
+++ b/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
@@ -577,17 +577,13 @@ class LessonValidator:
         # Suggested companion path. When the companion already exists in the
         # lesson's own category subdir, name its actual location so that any
         # Related link written from this suggestion passes markdown-link checks.
-        # Otherwise mirror the lesson's own category dir so the author creates
-        # the file in the right place from the start.
+        # Otherwise mirror the full category path so the author creates the file
+        # in the right place from the start (including nested categories).
         if own_companion is not None:
             suggested_companion = own_companion.as_posix()
         else:
-            # Mirror the lesson's own category dir, unless it sits at the root.
-            category = self.filepath.parent.name
             target_dir = (
-                COMPANION_DIR
-                if category in ("", ".", "lessons")
-                else COMPANION_DIR / category
+                COMPANION_DIR if lesson_cat == Path(".") else COMPANION_DIR / lesson_cat
             )
             suggested_companion = (target_dir / f"{self.filepath.stem}.md").as_posix()
 

--- a/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
+++ b/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
@@ -511,9 +511,21 @@ class LessonValidator:
         # companion linking or length on superseded files.
         if self.status == "archived":
             return
-        # Check if companion doc exists (search subdirectories too)
+        # Check if companion doc exists (search subdirectories too).
+        # Only count a match as *this* lesson's companion when it lives in the
+        # same category subdir — a match in a different category shares only the
+        # stem name, not the intent.  Falling back to an arbitrary cross-category
+        # match would send the author to the wrong document.
         companion_matches = list(COMPANION_DIR.rglob(f"{self.filepath.stem}.md"))
-        has_companion = len(companion_matches) > 0
+        own_companion = next(
+            (
+                m
+                for m in companion_matches
+                if m.parent.name == self.filepath.parent.name
+            ),
+            None,
+        )
+        has_companion = own_companion is not None
 
         # Check if linked in Related section (allow optional subdirectory component)
         has_companion_link = bool(
@@ -530,23 +542,13 @@ class LessonValidator:
         body_start = len(self.content[:frontmatter_end].split("\n"))
         body_lines = len(lines) - body_start
 
-        # Suggested companion path. When the companion already exists, name where
-        # it ACTUALLY is — companions live under a category subdir mirroring the
-        # lesson's own (knowledge/lessons/<category>/<stem>.md), so a flat
-        # knowledge/lessons/<stem>.md suggestion sends the author to a path that
-        # does not exist and produces a link the markdown-link hook then rejects.
-        if has_companion:
-            # Prefer the companion whose parent dir matches the lesson's own category.
-            # rglob order is filesystem-dependent, so [0] is non-deterministic when
-            # two lessons in different category subdirs share the same stem.
-            suggested_companion = next(
-                (
-                    m
-                    for m in companion_matches
-                    if m.parent.name == self.filepath.parent.name
-                ),
-                companion_matches[0],
-            ).as_posix()
+        # Suggested companion path. When the companion already exists in the
+        # lesson's own category subdir, name its actual location so that any
+        # Related link written from this suggestion passes markdown-link checks.
+        # Otherwise mirror the lesson's own category dir so the author creates
+        # the file in the right place from the start.
+        if own_companion is not None:
+            suggested_companion = own_companion.as_posix()
         else:
             # Mirror the lesson's own category dir, unless it sits at the root.
             category = self.filepath.parent.name

--- a/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
+++ b/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
@@ -553,22 +553,37 @@ class LessonValidator:
         )
 
         # Check if linked in Related section (allow zero or more subdirectory components).
-        # Capture the exact matched path so we can verify it exists separately:
-        # a companion in a *different* category does not validate a link that
-        # points at a non-existent own-category path.
+        # Use finditer rather than search so ALL occurrences are captured — a prose
+        # mention of an existing cross-category companion earlier in the document must
+        # not suppress the dead-link error on a later Related-section link that points
+        # at a non-existent own-category path.
         # Use [a-zA-Z0-9._-]+ for path components to stay within the path
         # boundary and avoid greedily consuming markdown link punctuation
         # (e.g. ](  or  )  after the path).
-        _companion_link_match = re.search(
-            rf"(knowledge/lessons/(?:[a-zA-Z0-9._-]+/)*{re.escape(self.filepath.stem)}\.md)",
-            self.content,
-            re.IGNORECASE,
+        _companion_link_matches = list(
+            re.finditer(
+                rf"(knowledge/lessons/(?:[a-zA-Z0-9._-]+/)*{re.escape(self.filepath.stem)}\.md)",
+                self.content,
+                re.IGNORECASE,
+            )
         )
-        has_companion_link = _companion_link_match is not None
-        # A link is "live" only when the specific path it names exists on disk.
-        linked_companion_exists = (
-            _companion_link_match is not None
-            and Path(_companion_link_match.group(1)).exists()
+        has_companion_link = bool(_companion_link_matches)
+        # A link is "live" only when ALL companion path mentions exist on disk.
+        # If any mention names a non-existent path it is a dead reference — even when
+        # earlier mentions happen to be valid (e.g. cross-category prose references).
+        linked_companion_exists = has_companion_link and all(
+            Path(m.group(1)).exists() for m in _companion_link_matches
+        )
+        # Is the own-category companion's exact path specifically mentioned?
+        # has_companion_link is True for ANY companion mention (cross-category too);
+        # this narrower flag checks only for the lesson's own companion path so the
+        # "exists but not linked" warning is not silenced by an unrelated mention.
+        own_companion_linked = own_companion is not None and bool(
+            re.search(
+                re.escape(own_companion.as_posix()),
+                self.content,
+                re.IGNORECASE,
+            )
         )
 
         # Get line count
@@ -598,20 +613,31 @@ class LessonValidator:
             )
 
         # If lesson links a companion that does not exist, that is a dead reference.
-        # Verified against the actual path in the link — a companion in a different
-        # category does not make a stale or flat link live.
+        # Verified against ALL matched paths — a companion in a different category
+        # does not make a stale or flat link live.
         # Note: the dead link may use a flat path while the canonical location is
         # category-prefixed — remind the author to update the link too.
         if has_companion_link and not linked_companion_exists:
-            self.errors.append(
-                f"Links a companion doc that does not exist. Either create it at "
-                f"{suggested_companion} (and update the Related link to match), "
-                f"or remove the link."
-            )
+            if own_companion is not None:
+                # Companion exists but the Related link doesn't point to it — guide
+                # the author to fix the link rather than create a duplicate file.
+                self.errors.append(
+                    f"Links a companion doc that does not exist. Update the Related "
+                    f"link to point to the correct path: {suggested_companion}, "
+                    f"or remove the link."
+                )
+            else:
+                self.errors.append(
+                    f"Links a companion doc that does not exist. Either create it at "
+                    f"{suggested_companion} (and update the Related link to match), "
+                    f"or remove the link."
+                )
 
-        # If own-category companion exists but is not linked, warn.
-        # Cross-category companions are not flagged — they belong to other lessons.
-        if own_companion is not None and not has_companion_link:
+        # If own-category companion exists but is not specifically linked, warn.
+        # Checked against own_companion_linked (not has_companion_link) so that
+        # a cross-category mention elsewhere in the document doesn't silence the
+        # warning — cross-category companions belong to other lessons.
+        if own_companion is not None and not own_companion_linked:
             self.warnings.append(
                 f"Companion doc exists but not linked. Add to Related section: "
                 f"{suggested_companion}"

--- a/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
+++ b/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
@@ -618,7 +618,21 @@ class LessonValidator:
         # Note: the dead link may use a flat path while the canonical location is
         # category-prefixed — remind the author to update the link too.
         if has_companion_link and not linked_companion_exists:
-            if own_companion is not None:
+            dead_paths = [
+                m.group(1)
+                for m in _companion_link_matches
+                if not Path(m.group(1)).exists()
+            ]
+            if own_companion is not None and own_companion_linked:
+                # Own companion IS correctly linked — the dead reference is a different
+                # mention (e.g. a prose cross-category reference). Report only the dead
+                # path(s) so the author knows what to remove or fix.
+                dead_list = ", ".join(dead_paths)
+                self.errors.append(
+                    f"Links a non-existent companion path. Remove or fix the dead "
+                    f"reference: {dead_list}"
+                )
+            elif own_companion is not None:
                 # Companion exists but the Related link doesn't point to it — guide
                 # the author to fix the link rather than create a duplicate file.
                 self.errors.append(

--- a/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
+++ b/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
@@ -536,7 +536,17 @@ class LessonValidator:
         # knowledge/lessons/<stem>.md suggestion sends the author to a path that
         # does not exist and produces a link the markdown-link hook then rejects.
         if has_companion:
-            suggested_companion = companion_matches[0].as_posix()
+            # Prefer the companion whose parent dir matches the lesson's own category.
+            # rglob order is filesystem-dependent, so [0] is non-deterministic when
+            # two lessons in different category subdirs share the same stem.
+            suggested_companion = next(
+                (
+                    m
+                    for m in companion_matches
+                    if m.parent.name == self.filepath.parent.name
+                ),
+                companion_matches[0],
+            ).as_posix()
         else:
             # Mirror the lesson's own category dir, unless it sits at the root.
             category = self.filepath.parent.name
@@ -554,11 +564,14 @@ class LessonValidator:
                 f"Consider creating companion: {suggested_companion}"
             )
 
-        # If lesson links a companion that does not exist, that is a dead reference
+        # If lesson links a companion that does not exist, that is a dead reference.
+        # Note: the dead link may use a flat path while the canonical location is
+        # category-prefixed — remind the author to update the link too.
         if has_companion_link and not has_companion:
             self.errors.append(
-                f"Links a companion doc that does not exist. Create it or remove the "
-                f"link: {suggested_companion}"
+                f"Links a companion doc that does not exist. Either create it at "
+                f"{suggested_companion} (and update the Related link to match), "
+                f"or remove the link."
             )
 
         # If companion exists but not linked, warn

--- a/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
+++ b/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
@@ -33,6 +33,28 @@ VALID_TARGET_GRADE_FIELDS = frozenset(
 )
 
 
+def _lesson_category(filepath: Path) -> Path:
+    """Return the lesson's category path relative to the lessons root.
+
+    Handles single-level and deeper nesting without relying on a global
+    LESSONS_DIR constant.
+
+    Examples::
+
+        /abs/path/lessons/monitoring/foo.md  → Path("monitoring")
+        /abs/path/lessons/foo/bar/foo.md     → Path("foo/bar")
+        lessons/monitoring/foo.md            → Path("monitoring")
+    """
+    parts = filepath.parts
+    # Find the rightmost "lessons" component not immediately preceded by "knowledge".
+    for i in range(len(parts) - 1, -1, -1):
+        if parts[i] == "lessons" and (i == 0 or parts[i - 1] != "knowledge"):
+            cat_parts = parts[i + 1 : -1]  # segments between "lessons" and the stem
+            return Path(*cat_parts) if cat_parts else Path(".")
+    # Fallback: immediate parent name (single-level category at minimum)
+    return Path(filepath.parent.name)
+
+
 class LessonValidator:
     """Validates lesson and skill structure and content.
 
@@ -517,23 +539,33 @@ class LessonValidator:
         # stem name, not the intent.  Falling back to an arbitrary cross-category
         # match would send the author to the wrong document.
         companion_matches = list(COMPANION_DIR.rglob(f"{self.filepath.stem}.md"))
+        lesson_cat = _lesson_category(self.filepath)
         own_companion = next(
             (
                 m
                 for m in companion_matches
-                if m.parent.name == self.filepath.parent.name
+                # Use the full category-relative path, not just the leaf name, so
+                # nested categories (e.g. lessons/foo/bar/) and different categories
+                # that share a leaf name don't produce false matches.
+                if m.relative_to(COMPANION_DIR).parent == lesson_cat
             ),
             None,
         )
-        has_companion = own_companion is not None
 
-        # Check if linked in Related section (allow optional subdirectory component)
-        has_companion_link = bool(
-            re.search(
-                rf"knowledge/lessons/(?:[^/]+/)?{re.escape(self.filepath.stem)}\.md",
-                self.content,
-                re.IGNORECASE,
-            )
+        # Check if linked in Related section (allow optional subdirectory component).
+        # Capture the exact matched path so we can verify it exists separately:
+        # a companion in a *different* category does not validate a link that
+        # points at a non-existent own-category path.
+        _companion_link_match = re.search(
+            rf"(knowledge/lessons/(?:[^/]+/)?{re.escape(self.filepath.stem)}\.md)",
+            self.content,
+            re.IGNORECASE,
+        )
+        has_companion_link = _companion_link_match is not None
+        # A link is "live" only when the specific path it names exists on disk.
+        linked_companion_exists = (
+            _companion_link_match is not None
+            and Path(_companion_link_match.group(1)).exists()
         )
 
         # Get line count
@@ -559,25 +591,28 @@ class LessonValidator:
             )
             suggested_companion = (target_dir / f"{self.filepath.stem}.md").as_posix()
 
-        # If lesson is long but no companion, suggest creating one
-        if body_lines > TARGET_LENGTH and not has_companion:
+        # If lesson is long but no own-category companion, suggest creating one.
+        if body_lines > TARGET_LENGTH and own_companion is None:
             self.warnings.append(
                 f"Primary lesson is {body_lines} lines (target: {TARGET_LENGTH}). "
                 f"Consider creating companion: {suggested_companion}"
             )
 
         # If lesson links a companion that does not exist, that is a dead reference.
+        # Verified against the actual path in the link — a companion in a different
+        # category does not make a stale or flat link live.
         # Note: the dead link may use a flat path while the canonical location is
         # category-prefixed — remind the author to update the link too.
-        if has_companion_link and not has_companion:
+        if has_companion_link and not linked_companion_exists:
             self.errors.append(
                 f"Links a companion doc that does not exist. Either create it at "
                 f"{suggested_companion} (and update the Related link to match), "
                 f"or remove the link."
             )
 
-        # If companion exists but not linked, warn
-        if has_companion and not has_companion_link:
+        # If own-category companion exists but is not linked, warn.
+        # Cross-category companions are not flagged — they belong to other lessons.
+        if own_companion is not None and not has_companion_link:
             self.warnings.append(
                 f"Companion doc exists but not linked. Add to Related section: "
                 f"{suggested_companion}"

--- a/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
+++ b/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
@@ -557,12 +557,15 @@ class LessonValidator:
         # mention of an existing cross-category companion earlier in the document must
         # not suppress the dead-link error on a later Related-section link that points
         # at a non-existent own-category path.
-        # Use [a-zA-Z0-9._-]+ for path components to stay within the path
-        # boundary and avoid greedily consuming markdown link punctuation
-        # (e.g. ](  or  )  after the path).
+        # Use [^\]/]+ (exclude "]" and "/") for path components so any valid filesystem
+        # name is matched, including those with spaces or non-ASCII characters.
+        # Excluding "]" is critical: without it, the regex greedily matches across the
+        # markdown link text/URL boundary — e.g. in "[knowledge/lessons/foo/bar.md](url)"
+        # the intermediate pattern [^/]+/ would match "bar.md](../../knowledge/" as a
+        # single component, producing a spurious path that does not exist on disk.
         _companion_link_matches = list(
             re.finditer(
-                rf"(knowledge/lessons/(?:[a-zA-Z0-9._-]+/)*{re.escape(self.filepath.stem)}\.md)",
+                rf"(knowledge/lessons/(?:[^\]/]+/)*{re.escape(self.filepath.stem)}\.md)",
                 self.content,
                 re.IGNORECASE,
             )

--- a/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
+++ b/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
@@ -530,25 +530,42 @@ class LessonValidator:
         body_start = len(self.content[:frontmatter_end].split("\n"))
         body_lines = len(lines) - body_start
 
+        # Suggested companion path. When the companion already exists, name where
+        # it ACTUALLY is — companions live under a category subdir mirroring the
+        # lesson's own (knowledge/lessons/<category>/<stem>.md), so a flat
+        # knowledge/lessons/<stem>.md suggestion sends the author to a path that
+        # does not exist and produces a link the markdown-link hook then rejects.
+        if has_companion:
+            suggested_companion = companion_matches[0].as_posix()
+        else:
+            # Mirror the lesson's own category dir, unless it sits at the root.
+            category = self.filepath.parent.name
+            target_dir = (
+                COMPANION_DIR
+                if category in ("", ".", "lessons")
+                else COMPANION_DIR / category
+            )
+            suggested_companion = (target_dir / f"{self.filepath.stem}.md").as_posix()
+
         # If lesson is long but no companion, suggest creating one
         if body_lines > TARGET_LENGTH and not has_companion:
             self.warnings.append(
                 f"Primary lesson is {body_lines} lines (target: {TARGET_LENGTH}). "
-                f"Consider creating companion: knowledge/lessons/{self.filepath.stem}.md"
+                f"Consider creating companion: {suggested_companion}"
             )
 
         # If lesson links a companion that does not exist, that is a dead reference
         if has_companion_link and not has_companion:
             self.errors.append(
                 f"Links a companion doc that does not exist. Create it or remove the "
-                f"link: knowledge/lessons/{self.filepath.stem}.md"
+                f"link: {suggested_companion}"
             )
 
         # If companion exists but not linked, warn
         if has_companion and not has_companion_link:
             self.warnings.append(
                 f"Companion doc exists but not linked. Add to Related section: "
-                f"knowledge/lessons/{self.filepath.stem}.md"
+                f"{suggested_companion}"
             )
 
     def _check_length(self):

--- a/packages/gptme-lessons-extras/tests/test_validate.py
+++ b/packages/gptme-lessons-extras/tests/test_validate.py
@@ -660,3 +660,48 @@ def test_cross_category_companion_not_counted():
         assert "workflow" not in errors[0], (
             "Error must not reference cross-category companion: " + errors[0]
         )
+
+
+def test_cross_category_link_to_existing_companion_not_dead():
+    """A link that resolves to an existing companion must not be flagged as dead.
+
+    If a lesson in lessons/monitoring explicitly links
+    knowledge/lessons/workflow/test-lesson.md and that file exists, the
+    validator must not raise a dead-link error — even though there is no
+    monitoring-category companion.  The previous behavior (has_companion based
+    on any stem match) was correct for this case; the fix must preserve it while
+    still catching genuinely broken links.
+    """
+    # Craft a lesson that links to a cross-category companion that exists.
+    cross_cat_link_lesson = _LESSON_WITH_DEAD_COMPANION_LINK.replace(
+        "../../knowledge/lessons/test-lesson.md",
+        "../../knowledge/lessons/workflow/test-lesson.md",
+    ).replace(
+        "[knowledge/lessons/test-lesson.md]",
+        "[knowledge/lessons/workflow/test-lesson.md]",
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        # Create the cross-category companion that the lesson links to.
+        (root / "knowledge" / "lessons" / "workflow").mkdir(parents=True)
+        (root / "knowledge" / "lessons" / "workflow" / "test-lesson.md").write_text(
+            "# cross-category companion\n"
+        )
+        lesson_dir = root / "lessons" / "monitoring"
+        lesson_dir.mkdir(parents=True)
+        path = _write_lesson(lesson_dir, cross_cat_link_lesson)
+
+        cwd = os.getcwd()
+        try:
+            os.chdir(root)
+            validator = LessonValidator(path)
+            validator.validate()
+        finally:
+            os.chdir(cwd)
+
+        companion_errors = [e for e in validator.errors if "companion" in e.lower()]
+        assert not companion_errors, (
+            "Lesson linking an existing cross-category companion must not be "
+            f"flagged as dead: {companion_errors}"
+        )

--- a/packages/gptme-lessons-extras/tests/test_validate.py
+++ b/packages/gptme-lessons-extras/tests/test_validate.py
@@ -995,9 +995,9 @@ def test_own_companion_linked_but_dead_prose_mention_reports_dead_path():
         "Error should name the specific dead path, not tell the author to update "
         f"the correct Related link. Got: {error!r}"
     )
-    assert "remove or fix" in error.lower(), (
-        f"Error should say 'remove or fix the dead reference', got: {error!r}"
-    )
+    assert (
+        "remove or fix" in error.lower()
+    ), f"Error should say 'remove or fix the dead reference', got: {error!r}"
     # Must NOT tell the author to update/remove the correct own-companion link
     assert "update the related link" not in error.lower(), (
         "Error must not instruct author to change the correctly-linked own companion. "

--- a/packages/gptme-lessons-extras/tests/test_validate.py
+++ b/packages/gptme-lessons-extras/tests/test_validate.py
@@ -790,3 +790,140 @@ def test_nested_companion_link_detected_as_live():
             "Lesson with a live nested-companion link must not warn 'exists but not linked': "
             f"{companion_warnings}"
         )
+
+
+def test_prose_mention_of_existing_cross_category_does_not_mask_dead_related_link():
+    """A prose mention of an existing cross-category companion must not silence the
+    dead-link error when the Related section links a non-existent own-category path.
+
+    P1 regression: re.search found the cross-category mention first (file exists →
+    linked_companion_exists=True), so the dead Related link was never caught.
+    With re.finditer the validator checks ALL mentions; any non-existent path triggers
+    the error regardless of what earlier mentions resolve to.
+    """
+    # Lesson body references an *existing* cross-category companion in prose, but
+    # the Related section links to a non-existent monitoring companion.
+    lesson_with_prose_mention = (
+        "---\n"
+        "description: Test lesson\n"
+        "status: active\n"
+        "---\n"
+        "\n"
+        "## Rule\n"
+        "Test rule.\n"
+        "\n"
+        "## Context\n"
+        "See also knowledge/lessons/workflow/test-lesson.md for the workflow variant.\n"
+        "\n"
+        "## Detection\n"
+        "- signal one\n"
+        "- signal two (three four five six)\n"
+        "\n"
+        "## Pattern\n"
+        "```\npattern\n```\n"
+        "\n"
+        "## Outcome\n"
+        "Good things happen.\n"
+        "\n"
+        "## Related\n"
+        "- Full context: [knowledge/lessons/monitoring/test-lesson.md]"
+        "(../../knowledge/lessons/monitoring/test-lesson.md)\n"
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        # The cross-category companion EXISTS (workflow), the own-category does NOT.
+        (root / "knowledge" / "lessons" / "workflow").mkdir(parents=True)
+        (root / "knowledge" / "lessons" / "workflow" / "test-lesson.md").write_text(
+            "# workflow companion\n"
+        )
+        # No file at knowledge/lessons/monitoring/test-lesson.md
+        (root / "knowledge" / "lessons" / "monitoring").mkdir(parents=True)
+
+        lesson_dir = root / "lessons" / "monitoring"
+        lesson_dir.mkdir(parents=True)
+        path = _write_lesson(lesson_dir, lesson_with_prose_mention)
+
+        cwd = os.getcwd()
+        try:
+            os.chdir(root)
+            validator = LessonValidator(path)
+            validator.validate()
+        finally:
+            os.chdir(cwd)
+
+        companion_errors = [e for e in validator.errors if "companion" in e.lower()]
+        assert companion_errors, (
+            "Dead Related link must be flagged even when an earlier prose mention "
+            "of a cross-category companion exists on disk"
+        )
+
+
+def test_cross_category_link_does_not_silence_own_companion_unlinked_warning():
+    """A cross-category companion link must not suppress the 'exists but not linked'
+    warning when the lesson's own-category companion exists but is unlinked.
+
+    P2 regression: has_companion_link was True for ANY companion mention, so a
+    cross-category link silenced the warning even though the own companion was not
+    specifically referenced.  own_companion_linked now checks the exact path.
+    """
+    # Lesson links to a cross-category companion (workflow) that exists, but its
+    # own monitoring companion also exists and is NOT linked.
+    cross_cat_link_lesson = (
+        "---\n"
+        "description: Test lesson\n"
+        "status: active\n"
+        "---\n"
+        "\n"
+        "## Rule\n"
+        "Test rule.\n"
+        "\n"
+        "## Context\n"
+        "Context text.\n"
+        "\n"
+        "## Detection\n"
+        "- signal one\n"
+        "- signal two (three four five six)\n"
+        "\n"
+        "## Pattern\n"
+        "```\npattern\n```\n"
+        "\n"
+        "## Outcome\n"
+        "Good things happen.\n"
+        "\n"
+        "## Related\n"
+        "- Workflow variant: [knowledge/lessons/workflow/test-lesson.md]"
+        "(../../knowledge/lessons/workflow/test-lesson.md)\n"
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        # Both companions exist: own-category (monitoring) and cross-category (workflow)
+        (root / "knowledge" / "lessons" / "monitoring").mkdir(parents=True)
+        (root / "knowledge" / "lessons" / "monitoring" / "test-lesson.md").write_text(
+            "# monitoring companion\n"
+        )
+        (root / "knowledge" / "lessons" / "workflow").mkdir(parents=True)
+        (root / "knowledge" / "lessons" / "workflow" / "test-lesson.md").write_text(
+            "# workflow companion\n"
+        )
+        lesson_dir = root / "lessons" / "monitoring"
+        lesson_dir.mkdir(parents=True)
+        path = _write_lesson(lesson_dir, cross_cat_link_lesson)
+
+        cwd = os.getcwd()
+        try:
+            os.chdir(root)
+            validator = LessonValidator(path)
+            validator.validate()
+        finally:
+            os.chdir(cwd)
+
+        companion_warnings = [w for w in validator.warnings if "companion" in w.lower()]
+        assert companion_warnings, (
+            "Own-category companion must still be flagged as 'exists but not linked' "
+            "even when the lesson links a cross-category companion"
+        )
+        assert "monitoring/test-lesson.md" in companion_warnings[0], companion_warnings[
+            0
+        ]

--- a/packages/gptme-lessons-extras/tests/test_validate.py
+++ b/packages/gptme-lessons-extras/tests/test_validate.py
@@ -1003,3 +1003,68 @@ def test_own_companion_linked_but_dead_prose_mention_reports_dead_path():
         "Error must not instruct author to change the correctly-linked own companion. "
         f"Got: {error!r}"
     )
+
+
+def test_companion_link_detected_for_category_with_space():
+    """Companion link detection must work when the category dir contains a space.
+
+    The detection regex used [a-zA-Z0-9._-]+ for path components, which silently
+    dropped links to companions in categories like "my lessons" or "tool tips".
+    The fix restores [^/]+ so any valid filesystem name is matched.
+
+    Regression for the P1 finding on gptme-contrib#1460.
+    """
+    lesson_content = (
+        "---\n"
+        "description: Test lesson\n"
+        "status: active\n"
+        "---\n"
+        "\n"
+        "## Rule\n"
+        "Test rule.\n"
+        "\n"
+        "## Context\n"
+        "Context text.\n"
+        "\n"
+        "## Detection\n"
+        "- signal one\n"
+        "- signal two (three four five six)\n"
+        "\n"
+        "## Pattern\n"
+        "```\npattern\n```\n"
+        "\n"
+        "## Outcome\n"
+        "Good things happen.\n"
+        "\n"
+        "## Related\n"
+        "- Companion: [knowledge/lessons/my category/test-lesson.md]"
+        "(../../knowledge/lessons/my category/test-lesson.md)\n"
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        category_dir = root / "knowledge" / "lessons" / "my category"
+        category_dir.mkdir(parents=True)
+        (category_dir / "test-lesson.md").write_text("# companion doc\n")
+        lesson_dir = root / "lessons" / "my category"
+        lesson_dir.mkdir(parents=True)
+        path = _write_lesson(lesson_dir, lesson_content)
+
+        cwd = os.getcwd()
+        try:
+            os.chdir(root)
+            validator = LessonValidator(path)
+            validator.validate()
+        finally:
+            os.chdir(cwd)
+
+    companion_errors = [e for e in validator.errors if "companion" in e.lower()]
+    companion_warnings = [w for w in validator.warnings if "companion" in w.lower()]
+    assert not companion_errors, (
+        "A lesson correctly linking a companion in a space-containing category dir "
+        f"must not have companion errors: {companion_errors}"
+    )
+    assert not companion_warnings, (
+        "A lesson correctly linking a companion in a space-containing category dir "
+        f"must not warn 'exists but not linked': {companion_warnings}"
+    )

--- a/packages/gptme-lessons-extras/tests/test_validate.py
+++ b/packages/gptme-lessons-extras/tests/test_validate.py
@@ -1,5 +1,6 @@
 """Tests for core LessonValidator behavior."""
 
+import os
 import tempfile
 from pathlib import Path
 
@@ -548,3 +549,63 @@ def test_dead_companion_link_archived_skips():
         assert (
             not companion_errors
         ), f"Archived lesson should not flag dead companion link: {companion_errors}"
+
+
+# A concise lesson with no companion link at all — used to check that the
+# suggested companion path mirrors the lesson's category subdir.
+_LESSON_WITHOUT_COMPANION_LINK = _LESSON_WITH_DEAD_COMPANION_LINK.replace(
+    "- Full context: [knowledge/lessons/test-lesson.md](../../knowledge/lessons/test-lesson.md)",
+    "- Some other reference",
+)
+
+
+def test_existing_companion_suggestion_names_real_subdir_path():
+    """The 'exists but not linked' warning must name where the companion ACTUALLY is.
+
+    Companions live under a category subdir (knowledge/lessons/<category>/<stem>.md).
+    Suggesting a flat knowledge/lessons/<stem>.md sends the author to a path that
+    does not exist, and the resulting link fails the markdown-link check.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / "knowledge" / "lessons" / "monitoring").mkdir(parents=True)
+        (root / "knowledge" / "lessons" / "monitoring" / "test-lesson.md").write_text(
+            "# companion\n"
+        )
+        lesson_dir = root / "lessons" / "monitoring"
+        lesson_dir.mkdir(parents=True)
+        path = _write_lesson(lesson_dir, _LESSON_WITHOUT_COMPANION_LINK)
+
+        cwd = os.getcwd()
+        try:
+            os.chdir(root)
+            validator = LessonValidator(path)
+            validator.validate()
+        finally:
+            os.chdir(cwd)
+
+        warnings = [w for w in validator.warnings if "companion" in w.lower()]
+        assert warnings, "Existing-but-unlinked companion should warn"
+        assert "knowledge/lessons/monitoring/test-lesson.md" in warnings[0], warnings[0]
+
+
+def test_missing_companion_suggestion_mirrors_category_subdir():
+    """With no companion on disk, the suggested path still mirrors the category."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / "knowledge" / "lessons").mkdir(parents=True)
+        lesson_dir = root / "lessons" / "monitoring"
+        lesson_dir.mkdir(parents=True)
+        path = _write_lesson(lesson_dir, _LESSON_WITH_DEAD_COMPANION_LINK)
+
+        cwd = os.getcwd()
+        try:
+            os.chdir(root)
+            validator = LessonValidator(path)
+            validator.validate()
+        finally:
+            os.chdir(cwd)
+
+        errors = [e for e in validator.errors if "companion" in e.lower()]
+        assert errors, "Dead companion link should error"
+        assert "knowledge/lessons/monitoring/test-lesson.md" in errors[0], errors[0]

--- a/packages/gptme-lessons-extras/tests/test_validate.py
+++ b/packages/gptme-lessons-extras/tests/test_validate.py
@@ -705,3 +705,37 @@ def test_cross_category_link_to_existing_companion_not_dead():
             "Lesson linking an existing cross-category companion must not be "
             f"flagged as dead: {companion_errors}"
         )
+
+
+def test_missing_companion_suggestion_mirrors_full_nested_category():
+    """Suggested companion path must use the full category path for nested lessons.
+
+    For lessons/foo/bar/lesson.md the validator must suggest
+    knowledge/lessons/foo/bar/lesson.md, not knowledge/lessons/bar/lesson.md
+    (which would be produced by using only .parent.name).
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / "knowledge" / "lessons").mkdir(parents=True)
+        # Lesson is nested two levels deep: lessons/outer/inner/test-lesson.md
+        lesson_dir = root / "lessons" / "outer" / "inner"
+        lesson_dir.mkdir(parents=True)
+        path = _write_lesson(lesson_dir, _LESSON_WITH_DEAD_COMPANION_LINK)
+
+        cwd = os.getcwd()
+        try:
+            os.chdir(root)
+            validator = LessonValidator(path)
+            validator.validate()
+        finally:
+            os.chdir(cwd)
+
+        errors = [e for e in validator.errors if "companion" in e.lower()]
+        assert errors, "Dead companion link should error for nested lesson"
+        # Must suggest the full nested path, not just the immediate parent
+        assert (
+            "knowledge/lessons/outer/inner/test-lesson.md" in errors[0]
+        ), f"Expected full nested path in suggestion, got: {errors[0]}"
+        assert (
+            "knowledge/lessons/inner/test-lesson.md" not in errors[0]
+        ), f"Must not use only immediate parent name: {errors[0]}"

--- a/packages/gptme-lessons-extras/tests/test_validate.py
+++ b/packages/gptme-lessons-extras/tests/test_validate.py
@@ -927,3 +927,79 @@ def test_cross_category_link_does_not_silence_own_companion_unlinked_warning():
         assert "monitoring/test-lesson.md" in companion_warnings[0], companion_warnings[
             0
         ]
+
+
+def test_own_companion_linked_but_dead_prose_mention_reports_dead_path():
+    """When a lesson's own companion is correctly linked but the content also contains
+    a dead companion path mention (e.g. prose cross-category reference), the error
+    should name the dead path rather than telling the author to update the correct link.
+
+    P2 regression (edaae34c): the 'Update the Related link' message fired even when
+    own_companion_linked was True — the own companion was already correctly referenced,
+    so the instruction to update/remove it was misleading. The fix reports the
+    specific dead path(s) and says 'remove or fix', preserving the correct link.
+    """
+    lesson_content = (
+        "---\n"
+        "description: Test lesson\n"
+        "status: active\n"
+        "---\n"
+        "\n"
+        "## Rule\n"
+        "Test rule.\n"
+        "\n"
+        "## Context\n"
+        "Context text.\n"
+        "\n"
+        "## Detection\n"
+        "- signal one\n"
+        "- signal two (three four five six)\n"
+        "\n"
+        "## Pattern\n"
+        "```\npattern\n```\n"
+        "\n"
+        "## Outcome\n"
+        "Good things happen.\n"
+        "\n"
+        "## Related\n"
+        # Own companion correctly linked
+        "- Companion doc: [knowledge/lessons/monitoring/test-lesson.md]"
+        "(../../knowledge/lessons/monitoring/test-lesson.md)\n"
+        # Dead prose mention of a non-existent cross-category path
+        "- See also knowledge/lessons/workflow/test-lesson.md for the workflow variant.\n"
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        # Own companion exists; cross-category file does NOT
+        (root / "knowledge" / "lessons" / "monitoring").mkdir(parents=True)
+        (root / "knowledge" / "lessons" / "monitoring" / "test-lesson.md").write_text(
+            "# monitoring companion\n"
+        )
+        lesson_dir = root / "lessons" / "monitoring"
+        lesson_dir.mkdir(parents=True)
+        path = _write_lesson(lesson_dir, lesson_content)
+
+        cwd = os.getcwd()
+        try:
+            os.chdir(root)
+            validator = LessonValidator(path)
+            validator.validate()
+        finally:
+            os.chdir(cwd)
+
+    # Must flag the dead path
+    assert validator.errors, "Expected an error for the dead prose companion mention"
+    error = validator.errors[0]
+    assert "knowledge/lessons/workflow/test-lesson.md" in error, (
+        "Error should name the specific dead path, not tell the author to update "
+        f"the correct Related link. Got: {error!r}"
+    )
+    assert "remove or fix" in error.lower(), (
+        f"Error should say 'remove or fix the dead reference', got: {error!r}"
+    )
+    # Must NOT tell the author to update/remove the correct own-companion link
+    assert "update the related link" not in error.lower(), (
+        "Error must not instruct author to change the correctly-linked own companion. "
+        f"Got: {error!r}"
+    )

--- a/packages/gptme-lessons-extras/tests/test_validate.py
+++ b/packages/gptme-lessons-extras/tests/test_validate.py
@@ -609,3 +609,54 @@ def test_missing_companion_suggestion_mirrors_category_subdir():
         errors = [e for e in validator.errors if "companion" in e.lower()]
         assert errors, "Dead companion link should error"
         assert "knowledge/lessons/monitoring/test-lesson.md" in errors[0], errors[0]
+
+
+def test_cross_category_companion_not_counted():
+    """A companion in a different category must not be treated as this lesson's companion.
+
+    When two lessons share the same stem but live in different category subdirs,
+    the validator must not suggest (or treat as linked) a companion from the
+    other category — doing so would point the author at the wrong document.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        # Only a cross-category companion exists (e.g. for lessons/workflow/test-lesson.md)
+        (root / "knowledge" / "lessons" / "workflow").mkdir(parents=True)
+        (root / "knowledge" / "lessons" / "workflow" / "test-lesson.md").write_text(
+            "# companion for a different lesson\n"
+        )
+        # Our lesson is in the 'monitoring' category — no companion there
+        lesson_dir = root / "lessons" / "monitoring"
+        lesson_dir.mkdir(parents=True)
+        path = _write_lesson(lesson_dir, _LESSON_WITHOUT_COMPANION_LINK)
+
+        cwd = os.getcwd()
+        try:
+            os.chdir(root)
+            validator = LessonValidator(path)
+            validator.validate()
+        finally:
+            os.chdir(cwd)
+
+        # The monitoring lesson has no companion — the workflow companion must be ignored.
+        companion_warnings = [w for w in validator.warnings if "companion" in w.lower()]
+        # Should NOT warn "exists but not linked" (the cross-category file is not ours)
+        for w in companion_warnings:
+            assert "workflow" not in w, (
+                "Must not suggest cross-category companion: " + w
+            )
+        # The suggested path should mirror the lesson's own category (monitoring), not workflow
+        # (we can only check this via the dead-link path; use the link-bearing version)
+        path2 = _write_lesson(lesson_dir, _LESSON_WITH_DEAD_COMPANION_LINK)
+        try:
+            os.chdir(root)
+            validator2 = LessonValidator(path2)
+            validator2.validate()
+        finally:
+            os.chdir(cwd)
+        errors = [e for e in validator2.errors if "companion" in e.lower()]
+        assert errors, "Dead companion link should still error"
+        assert "knowledge/lessons/monitoring/test-lesson.md" in errors[0], errors[0]
+        assert "workflow" not in errors[0], (
+            "Error must not reference cross-category companion: " + errors[0]
+        )

--- a/packages/gptme-lessons-extras/tests/test_validate.py
+++ b/packages/gptme-lessons-extras/tests/test_validate.py
@@ -739,3 +739,54 @@ def test_missing_companion_suggestion_mirrors_full_nested_category():
         assert (
             "knowledge/lessons/inner/test-lesson.md" not in errors[0]
         ), f"Must not use only immediate parent name: {errors[0]}"
+
+
+def test_nested_companion_link_detected_as_live():
+    """A link to a multi-level companion path must be detected as live.
+
+    For lessons/outer/inner/test-lesson.md with companion at
+    knowledge/lessons/outer/inner/test-lesson.md, a Related link to
+    knowledge/lessons/outer/inner/test-lesson.md must NOT trigger
+    "Companion doc exists but not linked" — the link IS present.
+
+    The detection regex must allow more than one subdir component.
+    """
+    # Lesson linking to its own two-level companion path
+    nested_link_lesson = _LESSON_WITH_DEAD_COMPANION_LINK.replace(
+        "../../knowledge/lessons/test-lesson.md",
+        "../../knowledge/lessons/outer/inner/test-lesson.md",
+    ).replace(
+        "[knowledge/lessons/test-lesson.md]",
+        "[knowledge/lessons/outer/inner/test-lesson.md]",
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        # Create the own-category companion that the lesson links to
+        (root / "knowledge" / "lessons" / "outer" / "inner").mkdir(parents=True)
+        companion = (
+            root / "knowledge" / "lessons" / "outer" / "inner" / "test-lesson.md"
+        )
+        companion.write_text("# companion doc\n")
+        lesson_dir = root / "lessons" / "outer" / "inner"
+        lesson_dir.mkdir(parents=True)
+        path = _write_lesson(lesson_dir, nested_link_lesson)
+
+        cwd = os.getcwd()
+        try:
+            os.chdir(root)
+            validator = LessonValidator(path)
+            validator.validate()
+        finally:
+            os.chdir(cwd)
+
+        companion_errors = [e for e in validator.errors if "companion" in e.lower()]
+        companion_warnings = [w for w in validator.warnings if "companion" in w.lower()]
+        assert not companion_errors, (
+            "Lesson with a live nested-companion link must not have companion errors: "
+            f"{companion_errors}"
+        )
+        assert not companion_warnings, (
+            "Lesson with a live nested-companion link must not warn 'exists but not linked': "
+            f"{companion_warnings}"
+        )


### PR DESCRIPTION
## Problem

The companion-link **detection** regex already allows an optional category subdir:

```python
rf"knowledge/lessons/(?:[^/]+/)?{re.escape(self.filepath.stem)}\.md"
```

but all three **suggestion** messages hardcoded the flat `knowledge/lessons/<stem>.md`. Companions actually live under a category subdir mirroring the lesson's own, so the validator pointed authors at a path that does not exist — and the link written from that suggestion then failed the `check-markdown-links` hook.

Concretely, for `lessons/monitoring/alerts-must-carry-their-diagnosis.md` the validator said:

> Companion doc exists but not linked. Add to Related section: `knowledge/lessons/alerts-must-carry-their-diagnosis.md`

while the companion is at `knowledge/lessons/**monitoring**/alerts-must-carry-their-diagnosis.md`. Following the suggestion verbatim produced a broken link and a failed commit.

## Fix

- **Companion exists** → report where it actually is. `companion_matches` already holds the resolved path from `rglob`; it was computed and then discarded.
- **Companion missing** → mirror the lesson's own category dir, falling back to the root for lessons not in one.

Note `_check_related_section` (line ~602) already got this right with a `<subdir>` placeholder — this brings the other three messages in line.

## Tests

Two regression tests, one per branch (exists-but-unlinked, and dead-link). Both **fail on the pre-fix validator** with the flat path and pass after:

```
AssertionError: assert 'knowledge/lessons/monitoring/test-lesson.md' in
  'Links a companion doc that does not exist. ... knowledge/lessons/test-lesson.md'
```

Full suite: 33 passed.

## Scope

Message strings only — no change to detection, validation outcomes, or exit codes. A lesson that validated before still validates.