### PR TITLE
feat(gptme-rag): add source-descriptor collection + voice-call de-accumulation (Phase 2.1)

### DIFF
--- a/packages/gptme-rag/src/gptme_rag/sources.py
+++ b/packages/gptme-rag/src/gptme_rag/sources.py
@@ -184,14 +184,16 @@ def collect_voice_call_documents(
     voice_calls_dir = Path(voice_calls_dir)
     if not voice_calls_dir.exists():
         return []
-    if repo_root is not None and not voice_calls_dir.is_relative_to(repo_root):
+    if repo_root is not None and not voice_calls_dir.resolve().is_relative_to(
+        Path(repo_root).resolve()
+    ):
         return []
 
     docs: list[Document] = []
     for path in sorted(voice_calls_dir.glob("*.json")):
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
             continue
         if not isinstance(data, dict):
             continue

--- a/packages/gptme-rag/src/gptme_rag/sources.py
+++ b/packages/gptme-rag/src/gptme_rag/sources.py
@@ -44,13 +44,48 @@ logger = logging.getLogger(__name__)
 SourceCollector = Callable[[], Iterable[Document]]
 
 
+def _collapse_partial_chain(run_texts: list[str]) -> list[str]:
+    """Collapse cumulative STT partials within one same-role run.
+
+    A cumulative partial is a *prefix* of the utterance it is a partial of, so a
+    growing chain (``"I want"`` → ``"I want the budget"``) collapses to its final
+    form, and an exactly-repeated turn collapses to one copy.  Anything that is
+    not a prefix relative to its neighbour is a genuine follow-up turn and is
+    kept, because dropping it loses transcript content permanently.
+
+    Args:
+        run_texts: The raw texts of one contiguous same-role run, in order.
+
+    Returns:
+        The de-accumulated turns, in order, with empties removed.
+    """
+    kept: list[str] = []
+    for raw in run_texts:
+        text = raw.strip()
+        if not text:
+            continue
+        if kept:
+            previous = kept[-1]
+            if text.startswith(previous):
+                # Later partial extends (or exactly repeats) the earlier one.
+                kept[-1] = text
+                continue
+            if previous.startswith(text):
+                # Shorter partial arriving after its own longer form.
+                continue
+        kept.append(text)
+    return kept
+
+
 def de_accumulate_transcript(transcript: list[dict[str, Any]], *, cumulative: bool = False) -> str:
     """Render transcript turns, optionally collapsing cumulative STT partials.
 
-    With ``cumulative=True``, each contiguous same-role run is treated as a
-    sequence of cumulative speech-to-text partials and only its longest entry is
-    kept.  With the safe default, every entry is preserved; content alone cannot
-    reliably distinguish a cumulative partial from a genuine follow-up turn.
+    With ``cumulative=True``, each contiguous same-role run may contain
+    cumulative speech-to-text partials, so *prefix chains* within the run are
+    collapsed to their final form (see :func:`_collapse_partial_chain`).  Turns
+    that are not prefixes of their neighbour are genuine follow-up turns and are
+    preserved — a same-role run is not assumed to be a single utterance.  With
+    the safe default, every entry is preserved verbatim.
 
     Args:
         transcript: A list of turn dicts, each with ``role`` and ``text`` keys.
@@ -83,9 +118,10 @@ def de_accumulate_transcript(transcript: list[dict[str, Any]], *, cumulative: bo
             i += 1
 
         if cumulative:
-            best = max(run_texts, key=lambda text: len(text.strip()), default="")
+            kept = _collapse_partial_chain(run_texts)
         else:
-            best = "\n".join(text.strip() for text in run_texts if text.strip())
+            kept = [text.strip() for text in run_texts if text.strip()]
+        best = "\n".join(kept)
         if best.strip():
             turns.append(f"{current_role.upper()}: {best.strip()}")
     return "\n\n".join(turns)
@@ -198,7 +234,20 @@ def collect_voice_call_documents(
         return []
 
     docs: list[Document] = []
+    resolved_root = None if repo_root is None else Path(repo_root).resolve()
     for path in sorted(voice_calls_dir.glob("*.json")):
+        # Resolve *before* reading: a per-file symlink can escape the repo even
+        # though the directory itself passed the guard above, and reading it
+        # first would pull out-of-repo content into memory regardless of the
+        # later skip.
+        resolved_path = path.resolve()
+        if resolved_root is not None and not resolved_path.is_relative_to(resolved_root):
+            logger.warning("sources: skipping %s — resolves outside repo_root", path)
+            continue
+        if not resolved_path.is_file():
+            # Skip anything that is not a regular file (e.g. a FIFO named
+            # ``*.json``, which would block the collector on read).
+            continue
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, UnicodeDecodeError, json.JSONDecodeError):
@@ -221,15 +270,7 @@ def collect_voice_call_documents(
         source = str(data.get("source", "")) if isinstance(data.get("source"), str) else ""
         title = f"Voice call {date_str}" + (f" ({source})" if source else "")
 
-        try:
-            source_path = (
-                path if repo_root is None else path.resolve().relative_to(Path(repo_root).resolve())
-            )
-        except ValueError:
-            # path.resolve() points outside repo_root (e.g. a per-file symlink
-            # that escapes the repo even though the directory passed the guard).
-            logger.warning("sources: skipping %s — resolves outside repo_root", path)
-            continue
+        source_path = path if resolved_root is None else resolved_path.relative_to(resolved_root)
         metadata: dict[str, Any] = {
             "type": "voicecall",
             "source": str(source_path),

--- a/packages/gptme-rag/src/gptme_rag/sources.py
+++ b/packages/gptme-rag/src/gptme_rag/sources.py
@@ -213,7 +213,9 @@ def collect_voice_call_documents(
         source = str(data.get("source", "")) if isinstance(data.get("source"), str) else ""
         title = f"Voice call {date_str}" + (f" ({source})" if source else "")
 
-        source_path = path if repo_root is None else path.relative_to(repo_root)
+        source_path = (
+            path if repo_root is None else path.resolve().relative_to(Path(repo_root).resolve())
+        )
         metadata: dict[str, Any] = {
             "type": "voicecall",
             "source": str(source_path),

--- a/packages/gptme-rag/src/gptme_rag/sources.py
+++ b/packages/gptme-rag/src/gptme_rag/sources.py
@@ -82,14 +82,14 @@ def de_accumulate_transcript(transcript: list[dict[str, Any]]) -> str:
                 break
             run_texts.append(str(transcript[i].get("text", "")))
             i += 1
+
         # Detect cumulative runs: each entry is a prefix of the next (growing STT
         # partials, common in voice-call archives).  Only then is it safe to drop
         # all but the longest entry.  Independent consecutive same-role turns must
         # be joined to avoid silent data loss (P1 finding).
         def _each_is_prefix(texts: list[str]) -> bool:
             return all(
-                texts[j].strip().startswith(texts[j - 1].strip())
-                for j in range(1, len(texts))
+                texts[j].strip().startswith(texts[j - 1].strip()) for j in range(1, len(texts))
             )
 
         is_cumulative = len(run_texts) > 1 and _each_is_prefix(run_texts)
@@ -236,9 +236,7 @@ def collect_voice_call_documents(
 
         try:
             source_path = (
-                path
-                if repo_root is None
-                else path.resolve().relative_to(Path(repo_root).resolve())
+                path if repo_root is None else path.resolve().relative_to(Path(repo_root).resolve())
             )
         except ValueError:
             # path.resolve() points outside repo_root (e.g. a per-file symlink

--- a/packages/gptme-rag/src/gptme_rag/sources.py
+++ b/packages/gptme-rag/src/gptme_rag/sources.py
@@ -105,7 +105,11 @@ def de_accumulate_transcript(transcript: list[dict[str, Any]], *, cumulative: bo
         if not isinstance(transcript[i], dict):
             i += 1
             continue
-        current_role = str(transcript[i].get("role", ""))
+        role = transcript[i].get("role")
+        if not isinstance(role, str) or not role.strip():
+            i += 1
+            continue
+        current_role = role.strip()
         run_texts: list[str] = []
         # Collect all entries for this role run, skipping non-dict entries
         # mid-run without ending the run (P1 fix: a non-dict in the middle of
@@ -238,7 +242,12 @@ def collect_voice_call_documents(
 
     docs: list[Document] = []
     resolved_root = None if repo_root is None else Path(repo_root).resolve()
-    for path in sorted(voice_calls_dir.glob("*.json")):
+    try:
+        paths = sorted(voice_calls_dir.glob("*.json"))
+    except OSError:
+        logger.warning("sources: cannot list %s", voice_calls_dir)
+        return []
+    for path in paths:
         # Resolve *before* reading: a per-file symlink can escape the repo even
         # though the directory itself passed the guard above, and reading it
         # first would pull out-of-repo content into memory regardless of the

--- a/packages/gptme-rag/src/gptme_rag/sources.py
+++ b/packages/gptme-rag/src/gptme_rag/sources.py
@@ -203,7 +203,7 @@ def collect_voice_call_documents(
         missing or contains no parseable transcripts).
     """
     voice_calls_dir = Path(voice_calls_dir)
-    if not voice_calls_dir.exists():
+    if not voice_calls_dir.exists() or not voice_calls_dir.is_dir():
         return []
     if repo_root is not None and not voice_calls_dir.resolve().is_relative_to(
         Path(repo_root).resolve()

--- a/packages/gptme-rag/src/gptme_rag/sources.py
+++ b/packages/gptme-rag/src/gptme_rag/sources.py
@@ -65,9 +65,16 @@ def de_accumulate_transcript(transcript: list[dict[str, Any]]) -> str:
     turns: list[str] = []
     i = 0
     while i < len(transcript):
+        if not isinstance(transcript[i], dict):
+            i += 1
+            continue
         current_role = str(transcript[i].get("role", ""))
         run_texts: list[str] = []
-        while i < len(transcript) and transcript[i].get("role", "") == current_role:
+        while (
+            i < len(transcript)
+            and isinstance(transcript[i], dict)
+            and transcript[i].get("role", "") == current_role
+        ):
             run_texts.append(str(transcript[i].get("text", "")))
             i += 1
         best = max(run_texts, key=len) if run_texts else ""
@@ -185,6 +192,8 @@ def collect_voice_call_documents(
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(data, dict):
             continue
         transcript = data.get("transcript", [])
         if not isinstance(transcript, list) or not transcript:

--- a/packages/gptme-rag/src/gptme_rag/sources.py
+++ b/packages/gptme-rag/src/gptme_rag/sources.py
@@ -127,7 +127,9 @@ def de_accumulate_transcript(transcript: list[dict[str, Any]], *, cumulative: bo
                 continue
             if run_role.strip() != current_role:
                 break
-            run_texts.append(str(transcript[i].get("text", "")))
+            text = transcript[i].get("text")
+            if isinstance(text, str) and text.strip():
+                run_texts.append(text)
             i += 1
 
         if cumulative:

--- a/packages/gptme-rag/src/gptme_rag/sources.py
+++ b/packages/gptme-rag/src/gptme_rag/sources.py
@@ -31,6 +31,8 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import stat
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from pathlib import Path
@@ -265,17 +267,31 @@ def collect_voice_call_documents(
         if resolved_root is not None and not resolved_path.is_relative_to(resolved_root):
             logger.warning("sources: skipping %s — resolves outside repo_root", path)
             continue
-        if not resolved_path.is_file():
-            # Skip anything that is not a regular file (e.g. a FIFO named
-            # ``*.json``, which would block the collector on read).
-            continue
+        fd = -1
         try:
-            # Read the path we validated, not the original directory entry.
-            # Otherwise a symlink swap between resolve() and read_text() could
-            # bypass the repo-root guard.
-            data = json.loads(resolved_path.read_text(encoding="utf-8"))
+            # O_NOFOLLOW closes the final-component race between resolve() and
+            # open(): replacing a checked file with a symlink must not let the
+            # read escape repo_root. O_NONBLOCK also keeps a swapped-in FIFO
+            # from blocking before fstat() can reject it.
+            flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+            fd = os.open(resolved_path, flags)
+            opened = os.fstat(fd)
+            current = os.stat(resolved_path, follow_symlinks=False)
+            if (
+                not stat.S_ISREG(opened.st_mode)
+                or not stat.S_ISREG(current.st_mode)
+                or (opened.st_dev, opened.st_ino) != (current.st_dev, current.st_ino)
+            ):
+                continue
+            stream = os.fdopen(fd, encoding="utf-8")
+            fd = -1  # stream owns the descriptor now
+            with stream:
+                data = json.load(stream)
         except (OSError, UnicodeDecodeError, json.JSONDecodeError):
             continue
+        finally:
+            if fd >= 0:
+                os.close(fd)
         if not isinstance(data, dict):
             continue
         transcript = data.get("transcript", [])

--- a/packages/gptme-rag/src/gptme_rag/sources.py
+++ b/packages/gptme-rag/src/gptme_rag/sources.py
@@ -119,7 +119,8 @@ def de_accumulate_transcript(transcript: list[dict[str, Any]], *, cumulative: bo
             if not isinstance(transcript[i], dict):
                 i += 1
                 continue
-            if transcript[i].get("role", "") != current_role:
+            run_role = transcript[i].get("role")
+            if not isinstance(run_role, str) or run_role.strip() != current_role:
                 break
             run_texts.append(str(transcript[i].get("text", "")))
             i += 1

--- a/packages/gptme-rag/src/gptme_rag/sources.py
+++ b/packages/gptme-rag/src/gptme_rag/sources.py
@@ -44,19 +44,18 @@ logger = logging.getLogger(__name__)
 SourceCollector = Callable[[], Iterable[Document]]
 
 
-def de_accumulate_transcript(transcript: list[dict[str, Any]]) -> str:
-    """Convert a cumulative transcript list to de-duplicated turn text.
+def de_accumulate_transcript(transcript: list[dict[str, Any]], *, cumulative: bool = False) -> str:
+    """Render transcript turns, optionally collapsing cumulative STT partials.
 
-    Some voice-call transcripts are *cumulative*: each entry in a same-role run
-    contains all prior text for that role, so entries grow monotonically within
-    a run.  Indexing such a transcript raw stores the same utterance many times
-    over and weights the final turn far above earlier turns.
-
-    Taking the **longest** text per contiguous same-role run recovers the full
-    final utterance and drops the intermediate partial accumulations.
+    With ``cumulative=True``, each contiguous same-role run is treated as a
+    sequence of cumulative speech-to-text partials and only its longest entry is
+    kept.  With the safe default, every entry is preserved; content alone cannot
+    reliably distinguish a cumulative partial from a genuine follow-up turn.
 
     Args:
         transcript: A list of turn dicts, each with ``role`` and ``text`` keys.
+        cumulative: Whether same-role runs are known to contain cumulative STT
+            partials.
 
     Returns:
         A ``"ROLE: text"`` block per speaker, blank-line separated.  Empty when
@@ -83,22 +82,10 @@ def de_accumulate_transcript(transcript: list[dict[str, Any]]) -> str:
             run_texts.append(str(transcript[i].get("text", "")))
             i += 1
 
-        # Detect cumulative runs: each entry is a prefix of the next (growing STT
-        # partials, common in voice-call archives).  Only then is it safe to drop
-        # all but the longest entry.  Independent consecutive same-role turns must
-        # be joined to avoid silent data loss (P1 finding).
-        def _each_is_prefix(texts: list[str]) -> bool:
-            return all(
-                texts[j].strip().startswith(texts[j - 1].strip()) for j in range(1, len(texts))
-            )
-
-        is_cumulative = len(run_texts) > 1 and _each_is_prefix(run_texts)
-        if is_cumulative:
-            # Use stripped length so whitespace-only entries never win over
-            # real content (P1 fix: raw len would pick "          " over "hello").
-            best = max(run_texts, key=lambda t: len(t.strip()))
+        if cumulative:
+            best = max(run_texts, key=lambda text: len(text.strip()), default="")
         else:
-            best = "\n".join(t.strip() for t in run_texts if t.strip())
+            best = "\n".join(text.strip() for text in run_texts if text.strip())
         if best.strip():
             turns.append(f"{current_role.upper()}: {best.strip()}")
     return "\n\n".join(turns)
@@ -221,7 +208,7 @@ def collect_voice_call_documents(
         transcript = data.get("transcript", [])
         if not isinstance(transcript, list) or not transcript:
             continue
-        text = de_accumulate_transcript(transcript)
+        text = de_accumulate_transcript(transcript, cumulative=True)
         if not text.strip():
             continue
 

--- a/packages/gptme-rag/src/gptme_rag/sources.py
+++ b/packages/gptme-rag/src/gptme_rag/sources.py
@@ -120,7 +120,10 @@ def de_accumulate_transcript(transcript: list[dict[str, Any]], *, cumulative: bo
                 i += 1
                 continue
             run_role = transcript[i].get("role")
-            if not isinstance(run_role, str) or run_role.strip() != current_role:
+            if not isinstance(run_role, str) or not run_role.strip():
+                i += 1
+                continue
+            if run_role.strip() != current_role:
                 break
             run_texts.append(str(transcript[i].get("text", "")))
             i += 1

--- a/packages/gptme-rag/src/gptme_rag/sources.py
+++ b/packages/gptme-rag/src/gptme_rag/sources.py
@@ -1,0 +1,229 @@
+"""Source-descriptor document collection for gptme-rag.
+
+Canonical retrieval needs more than a way to *query* documents — it needs a
+way to *describe where documents come from* so that a consumer (an agent hook,
+a CLI, a batch indexer) can collect a reproducible corpus from a declarative
+list of sources, instead of hand-writing ad-hoc ``glob`` loops each time a new
+source is added.
+
+This module provides two things, ported from the Bob brain script
+(``scripts/build-ambient-memory-index.py``) where the pattern was measured on
+real session data:
+
+1. **A source registry** (:class:`SourceDescriptor` + :class:`SourceRegistry`)
+   — a declarative way to register document sources and collect from them.
+   Each source is a zero-argument callable returning
+   :class:`~gptme_rag.indexing.document.Document` objects, tagged *always-on*
+   (run on every build) or *gated* (only run on full builds, e.g. when
+   memory-type tagging is requested).
+
+2. **Voice-call de-accumulation** (:func:`de_accumulate_transcript` +
+   :func:`collect_voice_call_documents`) — a format-normalization utility for
+   cumulative voice-call transcripts, plus a collector that turns a directory
+   of archived call JSON into indexable documents.
+
+The registry is deliberately *policy-free*: which directories are sources, and
+which are always-on vs. gated, is consumer configuration.  Only the mechanism
+moves upstream.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .indexing.document import Document
+
+logger = logging.getLogger(__name__)
+
+#: A source collector: a zero-argument callable yielding Documents.
+SourceCollector = Callable[[], Iterable[Document]]
+
+
+def de_accumulate_transcript(transcript: list[dict[str, Any]]) -> str:
+    """Convert a cumulative transcript list to de-duplicated turn text.
+
+    Some voice-call transcripts are *cumulative*: each entry in a same-role run
+    contains all prior text for that role, so entries grow monotonically within
+    a run.  Indexing such a transcript raw stores the same utterance many times
+    over and weights the final turn far above earlier turns.
+
+    Taking the **longest** text per contiguous same-role run recovers the full
+    final utterance and drops the intermediate partial accumulations.
+
+    Args:
+        transcript: A list of turn dicts, each with ``role`` and ``text`` keys.
+
+    Returns:
+        A ``"ROLE: text"`` block per speaker, blank-line separated.  Empty when
+        *transcript* has no non-empty turns.
+    """
+    turns: list[str] = []
+    i = 0
+    while i < len(transcript):
+        current_role = str(transcript[i].get("role", ""))
+        run_texts: list[str] = []
+        while i < len(transcript) and transcript[i].get("role", "") == current_role:
+            run_texts.append(str(transcript[i].get("text", "")))
+            i += 1
+        best = max(run_texts, key=len) if run_texts else ""
+        if best.strip():
+            turns.append(f"{current_role.upper()}: {best.strip()}")
+    return "\n\n".join(turns)
+
+
+@dataclass
+class SourceDescriptor:
+    """Describe a document source: a collector plus its gating policy.
+
+    Attributes:
+        name: Human-readable source name (used in logs and metadata).
+        collect: Zero-argument callable returning an iterable of
+            :class:`~gptme_rag.indexing.document.Document`.
+        always_on: When ``True`` (default) the source is collected on every
+            build.  When ``False`` it is *gated* — collected only when a full
+            build is explicitly requested.
+    """
+
+    name: str
+    collect: SourceCollector
+    always_on: bool = True
+
+
+class SourceRegistry:
+    """Register document sources and collect from them in one pass.
+
+    Usage::
+
+        registry = SourceRegistry()
+        registry.register(SourceDescriptor("voice calls", collect_voice_call_documents))
+        docs = registry.collect()          # always-on sources only
+        docs = registry.collect(gated=True)  # all sources
+    """
+
+    def __init__(self) -> None:
+        self._sources: list[SourceDescriptor] = []
+
+    def register(self, descriptor: SourceDescriptor) -> None:
+        """Add a source descriptor to the registry."""
+        self._sources.append(descriptor)
+
+    def add(
+        self,
+        name: str,
+        collect: SourceCollector,
+        *,
+        always_on: bool = True,
+    ) -> None:
+        """Convenience wrapper around :meth:`register`."""
+        self.register(SourceDescriptor(name=name, collect=collect, always_on=always_on))
+
+    def collect(self, *, gated: bool = False) -> list[Document]:
+        """Collect documents from all eligible sources.
+
+        Args:
+            gated: When ``False`` (default), only *always-on* sources are
+                collected.  When ``True``, all registered sources are collected.
+
+        Returns:
+            Flattened list of :class:`~gptme_rag.indexing.document.Document`
+            objects, in registration order.
+        """
+        docs: list[Document] = []
+        for descriptor in self._sources:
+            if not gated and not descriptor.always_on:
+                continue
+            try:
+                for doc in descriptor.collect():
+                    docs.append(doc)
+            except Exception:  # noqa: BLE001 — one bad source must not sink the build
+                logger.exception("sources: collector %r raised", descriptor.name)
+        return docs
+
+    @property
+    def sources(self) -> tuple[SourceDescriptor, ...]:
+        """The registered descriptors, in registration order."""
+        return tuple(self._sources)
+
+
+def collect_voice_call_documents(
+    voice_calls_dir: Path,
+    *,
+    repo_root: Path | None = None,
+) -> list[Document]:
+    """Collect archived voice-call transcripts as indexable documents.
+
+    Each archived call JSON becomes one :class:`Document` keyed
+    ``voicecall:<stem>``.  The content is the de-accumulated conversation
+    transcript (see :func:`de_accumulate_transcript`) so that searches against
+    discussion topics (e.g. "Twitter spend cap") find the call where the topic
+    was discussed.
+
+    Args:
+        voice_calls_dir: Directory containing ``*.json`` call archives, each
+            with a ``transcript`` list of ``{"role", "text"}`` dicts.
+        repo_root: Optional repository root; when set, only calls under it are
+            collected (a safety guard against indexing paths outside the repo)
+            and ``metadata["source"]`` is written relative to it.
+
+    Returns:
+        List of :class:`Document` objects (possibly empty if the directory is
+        missing or contains no parseable transcripts).
+    """
+    voice_calls_dir = Path(voice_calls_dir)
+    if not voice_calls_dir.exists():
+        return []
+    if repo_root is not None and not voice_calls_dir.is_relative_to(repo_root):
+        return []
+
+    docs: list[Document] = []
+    for path in sorted(voice_calls_dir.glob("*.json")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        transcript = data.get("transcript", [])
+        if not isinstance(transcript, list) or not transcript:
+            continue
+        text = de_accumulate_transcript(transcript)
+        if not text.strip():
+            continue
+
+        stem = path.stem
+        # Filename: 20260811T080814Z-358-twilio-CA...  — parse date from prefix
+        date_str = ""
+        if len(stem) >= 8 and stem[:8].isdigit():
+            ts = stem[:8]
+            date_str = f"{ts[:4]}-{ts[4:6]}-{ts[6:8]}"
+        source = str(data.get("source", "")) if isinstance(data.get("source"), str) else ""
+        title = f"Voice call {date_str}" + (f" ({source})" if source else "")
+
+        source_path = path if repo_root is None else path.relative_to(repo_root)
+        metadata: dict[str, Any] = {
+            "type": "voicecall",
+            "source": str(source_path),
+            "title": title,
+            "date": date_str,
+        }
+        docs.append(
+            Document(
+                content=text,
+                metadata=metadata,
+                source_path=path,
+                doc_id=f"voicecall:{stem}",
+            )
+        )
+    return docs
+
+
+__all__ = [
+    "SourceCollector",
+    "SourceDescriptor",
+    "SourceRegistry",
+    "de_accumulate_transcript",
+    "collect_voice_call_documents",
+]

--- a/packages/gptme-rag/src/gptme_rag/sources.py
+++ b/packages/gptme-rag/src/gptme_rag/sources.py
@@ -70,9 +70,6 @@ def _collapse_partial_chain(run_texts: list[str]) -> list[str]:
                 # Later partial extends (or exactly repeats) the earlier one.
                 kept[-1] = text
                 continue
-            if previous.startswith(text):
-                # Shorter partial arriving after its own longer form.
-                continue
         kept.append(text)
     return kept
 

--- a/packages/gptme-rag/src/gptme_rag/sources.py
+++ b/packages/gptme-rag/src/gptme_rag/sources.py
@@ -77,7 +77,21 @@ def de_accumulate_transcript(transcript: list[dict[str, Any]]) -> str:
         ):
             run_texts.append(str(transcript[i].get("text", "")))
             i += 1
-        best = max(run_texts, key=len) if run_texts else ""
+        # Detect cumulative runs: each entry is a prefix of the next (growing STT
+        # partials, common in voice-call archives).  Only then is it safe to drop
+        # all but the longest entry.  Independent consecutive same-role turns must
+        # be joined to avoid silent data loss (P1 finding).
+        def _each_is_prefix(texts: list[str]) -> bool:
+            return all(
+                texts[j].strip().startswith(texts[j - 1].strip())
+                for j in range(1, len(texts))
+            )
+
+        is_cumulative = len(run_texts) > 1 and _each_is_prefix(run_texts)
+        if is_cumulative:
+            best = max(run_texts, key=len)
+        else:
+            best = "\n".join(t.strip() for t in run_texts if t.strip())
         if best.strip():
             turns.append(f"{current_role.upper()}: {best.strip()}")
     return "\n\n".join(turns)
@@ -213,9 +227,17 @@ def collect_voice_call_documents(
         source = str(data.get("source", "")) if isinstance(data.get("source"), str) else ""
         title = f"Voice call {date_str}" + (f" ({source})" if source else "")
 
-        source_path = (
-            path if repo_root is None else path.resolve().relative_to(Path(repo_root).resolve())
-        )
+        try:
+            source_path = (
+                path
+                if repo_root is None
+                else path.resolve().relative_to(Path(repo_root).resolve())
+            )
+        except ValueError:
+            # path.resolve() points outside repo_root (e.g. a per-file symlink
+            # that escapes the repo even though the directory passed the guard).
+            logger.warning("sources: skipping %s — resolves outside repo_root", path)
+            continue
         metadata: dict[str, Any] = {
             "type": "voicecall",
             "source": str(source_path),

--- a/packages/gptme-rag/src/gptme_rag/sources.py
+++ b/packages/gptme-rag/src/gptme_rag/sources.py
@@ -46,6 +46,28 @@ logger = logging.getLogger(__name__)
 SourceCollector = Callable[[], Iterable[Document]]
 
 
+_DIRECTORY_OPEN_FLAGS = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+_FILE_OPEN_FLAGS = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+
+
+def _open_beneath(root: Path, relative_path: Path) -> int:
+    """Open a regular file beneath *root* without following symlink components."""
+    if not hasattr(os, "O_NOFOLLOW"):
+        raise OSError("safe path traversal requires O_NOFOLLOW")
+    if relative_path.is_absolute() or ".." in relative_path.parts:
+        raise ValueError(f"path must be relative to root: {relative_path}")
+
+    directory_fd = os.open(root, _DIRECTORY_OPEN_FLAGS)
+    try:
+        for part in relative_path.parts[:-1]:
+            next_fd = os.open(part, _DIRECTORY_OPEN_FLAGS, dir_fd=directory_fd)
+            os.close(directory_fd)
+            directory_fd = next_fd
+        return os.open(relative_path.name, _FILE_OPEN_FLAGS, dir_fd=directory_fd)
+    finally:
+        os.close(directory_fd)
+
+
 def _collapse_partial_chain(run_texts: list[str]) -> list[str]:
     """Collapse cumulative STT partials within one same-role run.
 
@@ -220,6 +242,7 @@ def collect_voice_call_documents(
     voice_calls_dir: Path,
     *,
     repo_root: Path | None = None,
+    cumulative: bool = True,
 ) -> list[Document]:
     """Collect archived voice-call transcripts as indexable documents.
 
@@ -235,6 +258,9 @@ def collect_voice_call_documents(
         repo_root: Optional repository root; when set, only calls under it are
             collected (a safety guard against indexing paths outside the repo)
             and ``metadata["source"]`` is written relative to it.
+        cumulative: Whether same-role runs contain cumulative STT partials.
+            Disable this for finalized transcripts whose consecutive entries
+            are independent turns.
 
     Returns:
         List of :class:`Document` objects (possibly empty if the directory is
@@ -271,19 +297,15 @@ def collect_voice_call_documents(
             continue
         fd = -1
         try:
-            # O_NOFOLLOW closes the final-component race between resolve() and
-            # open(): replacing a checked file with a symlink must not let the
-            # read escape repo_root. O_NONBLOCK also keeps a swapped-in FIFO
-            # from blocking before fstat() can reject it.
-            flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
-            fd = os.open(resolved_path, flags)
+            # Walk from repo_root one directory descriptor at a time when a
+            # root guard is requested. O_NOFOLLOW on every component prevents
+            # an intermediate-directory symlink swap between resolve and open.
+            if resolved_root is None:
+                fd = os.open(resolved_path, _FILE_OPEN_FLAGS)
+            else:
+                fd = _open_beneath(resolved_root, resolved_path.relative_to(resolved_root))
             opened = os.fstat(fd)
-            current = os.stat(resolved_path, follow_symlinks=False)
-            if (
-                not stat.S_ISREG(opened.st_mode)
-                or not stat.S_ISREG(current.st_mode)
-                or (opened.st_dev, opened.st_ino) != (current.st_dev, current.st_ino)
-            ):
+            if not stat.S_ISREG(opened.st_mode):
                 continue
             stream = os.fdopen(fd, encoding="utf-8")
             fd = -1  # stream owns the descriptor now
@@ -299,7 +321,7 @@ def collect_voice_call_documents(
         transcript = data.get("transcript", [])
         if not isinstance(transcript, list) or not transcript:
             continue
-        text = de_accumulate_transcript(transcript, cumulative=True)
+        text = de_accumulate_transcript(transcript, cumulative=cumulative)
         if not text.strip():
             continue
 

--- a/packages/gptme-rag/src/gptme_rag/sources.py
+++ b/packages/gptme-rag/src/gptme_rag/sources.py
@@ -237,7 +237,12 @@ def collect_voice_call_documents(
         # though the directory itself passed the guard above, and reading it
         # first would pull out-of-repo content into memory regardless of the
         # later skip.
-        resolved_path = path.resolve()
+        try:
+            resolved_path = path.resolve()
+        except (OSError, RuntimeError):
+            # Broken links and symlink loops must not discard valid calls from
+            # the rest of the source.
+            continue
         if resolved_root is not None and not resolved_path.is_relative_to(resolved_root):
             logger.warning("sources: skipping %s — resolves outside repo_root", path)
             continue
@@ -246,7 +251,10 @@ def collect_voice_call_documents(
             # ``*.json``, which would block the collector on read).
             continue
         try:
-            data = json.loads(path.read_text(encoding="utf-8"))
+            # Read the path we validated, not the original directory entry.
+            # Otherwise a symlink swap between resolve() and read_text() could
+            # bypass the repo-root guard.
+            data = json.loads(resolved_path.read_text(encoding="utf-8"))
         except (OSError, UnicodeDecodeError, json.JSONDecodeError):
             continue
         if not isinstance(data, dict):

--- a/packages/gptme-rag/src/gptme_rag/sources.py
+++ b/packages/gptme-rag/src/gptme_rag/sources.py
@@ -66,8 +66,14 @@ def _collapse_partial_chain(run_texts: list[str]) -> list[str]:
             continue
         if kept:
             previous = kept[-1]
-            if text.startswith(previous):
-                # Later partial extends (or exactly repeats) the earlier one.
+            if text == previous:
+                # Exact duplicates carry no new content.
+                continue
+            if len(kept) == 1 and text.startswith(previous):
+                # Only the first monotonic prefix chain is unambiguously a
+                # sequence of cumulative partials. Once a distinct turn has
+                # appeared, a later shared-prefix turn may be a correction or
+                # re-utterance and must remain independent.
                 kept[-1] = text
                 continue
         kept.append(text)

--- a/packages/gptme-rag/src/gptme_rag/sources.py
+++ b/packages/gptme-rag/src/gptme_rag/sources.py
@@ -70,11 +70,16 @@ def de_accumulate_transcript(transcript: list[dict[str, Any]]) -> str:
             continue
         current_role = str(transcript[i].get("role", ""))
         run_texts: list[str] = []
-        while (
-            i < len(transcript)
-            and isinstance(transcript[i], dict)
-            and transcript[i].get("role", "") == current_role
-        ):
+        # Collect all entries for this role run, skipping non-dict entries
+        # mid-run without ending the run (P1 fix: a non-dict in the middle of
+        # a same-role run used to break the inner loop and start a new run,
+        # mis-treating what could be a cumulative sequence as two independent runs).
+        while i < len(transcript):
+            if not isinstance(transcript[i], dict):
+                i += 1
+                continue
+            if transcript[i].get("role", "") != current_role:
+                break
             run_texts.append(str(transcript[i].get("text", "")))
             i += 1
         # Detect cumulative runs: each entry is a prefix of the next (growing STT
@@ -89,7 +94,9 @@ def de_accumulate_transcript(transcript: list[dict[str, Any]]) -> str:
 
         is_cumulative = len(run_texts) > 1 and _each_is_prefix(run_texts)
         if is_cumulative:
-            best = max(run_texts, key=len)
+            # Use stripped length so whitespace-only entries never win over
+            # real content (P1 fix: raw len would pick "          " over "hello").
+            best = max(run_texts, key=lambda t: len(t.strip()))
         else:
             best = "\n".join(t.strip() for t in run_texts if t.strip())
         if best.strip():

--- a/packages/gptme-rag/tests/test_sources.py
+++ b/packages/gptme-rag/tests/test_sources.py
@@ -248,6 +248,68 @@ def test_collect_voice_calls_repo_root_guard_relative_vs_absolute(tmp_path: Path
     assert collect_voice_call_documents(call_dir, repo_root=outside) == []
 
 
+def test_de_accumulate_transcript_preserves_non_cumulative_consecutive_turns():
+    """Genuine consecutive same-role turns (non-cumulative) must NOT be silently dropped.
+
+    Regression for P1 finding: de_accumulate_transcript always took max(run_texts,
+    key=len), discarding shorter turns even when they weren't cumulative partials.
+    Non-cumulative runs now join all turns instead of picking the longest.
+    """
+    transcript = [
+        {"role": "user", "text": "Hello world"},
+        {"role": "user", "text": "How are you?"},
+        {"role": "assistant", "text": "I'm well"},
+    ]
+    result = de_accumulate_transcript(transcript)
+    assert "Hello world" in result
+    assert "How are you?" in result
+    assert "I'm well" in result
+
+
+def test_de_accumulate_transcript_still_collapses_cumulative_runs():
+    """Cumulative partial-utterance runs still deduplicate to the longest entry."""
+    transcript = [
+        {"role": "user", "text": "I"},
+        {"role": "user", "text": "I want"},
+        {"role": "user", "text": "I want to discuss"},
+        {"role": "assistant", "text": "ok"},
+    ]
+    result = de_accumulate_transcript(transcript)
+    # Only the final cumulative entry survives; partials are dropped.
+    assert result == "USER: I want to discuss\n\nASSISTANT: ok"
+
+
+def test_collect_voice_calls_skips_file_symlink_outside_repo(tmp_path: Path):
+    """A per-file symlink inside a valid call_dir that resolves outside repo_root
+    must be skipped without crashing the whole collection.
+
+    Regression for P1 finding: source_path computation used relative_to() without
+    guarding per-file symlinks, so a single stray symlink raised ValueError and
+    aborted collection for all remaining files.
+    """
+    repo = tmp_path / "repo"
+    call_dir = repo / "calls"
+    call_dir.mkdir(parents=True)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    # A real file outside the repo
+    target = outside / "real_call.json"
+    target.write_text(
+        '{"transcript": [{"role": "user", "text": "secret"}]}', encoding="utf-8"
+    )
+    # Symlink inside call_dir pointing outside repo_root
+    link = call_dir / "escaped.json"
+    link.symlink_to(target)
+    # A legitimate in-repo file that must still be collected
+    (call_dir / "good.json").write_text(
+        '{"transcript": [{"role": "user", "text": "hello"}]}', encoding="utf-8"
+    )
+    docs = collect_voice_call_documents(call_dir, repo_root=repo)
+    # Symlinked file outside repo must be skipped; good file must be collected.
+    assert len(docs) == 1
+    assert docs[0].content == "USER: hello"
+
+
 def test_collect_voice_calls_source_path_resolves_before_relative_to(tmp_path: Path):
     """source_path computation must use path.resolve() so relative voice_calls_dir
     does not raise ValueError when repo_root is absolute.

--- a/packages/gptme-rag/tests/test_sources.py
+++ b/packages/gptme-rag/tests/test_sources.py
@@ -35,7 +35,7 @@ def test_de_accumulate_transcript_drops_cumulative_partials():
         {"role": "assistant", "text": "hi"},
         {"role": "assistant", "text": "hi there"},
     ]
-    result = de_accumulate_transcript(transcript)
+    result = de_accumulate_transcript(transcript, cumulative=True)
     assert result == "USER: hello world\n\nASSISTANT: hi there"
 
 
@@ -56,7 +56,7 @@ def test_de_accumulate_transcript_role_reset_resumes_run():
         {"role": "user", "text": "c"},
         {"role": "user", "text": "cd"},
     ]
-    result = de_accumulate_transcript(transcript)
+    result = de_accumulate_transcript(transcript, cumulative=True)
     assert result == "USER: ab\n\nASSISTANT: x\n\nUSER: cd"
 
 
@@ -266,17 +266,26 @@ def test_de_accumulate_transcript_preserves_non_cumulative_consecutive_turns():
     assert "I'm well" in result
 
 
-def test_de_accumulate_transcript_still_collapses_cumulative_runs():
-    """Cumulative partial-utterance runs still deduplicate to the longest entry."""
+def test_de_accumulate_transcript_collapses_explicitly_cumulative_runs():
+    """Known cumulative partial-utterance runs deduplicate when opted in."""
     transcript = [
         {"role": "user", "text": "I"},
         {"role": "user", "text": "I want"},
         {"role": "user", "text": "I want to discuss"},
         {"role": "assistant", "text": "ok"},
     ]
-    result = de_accumulate_transcript(transcript)
-    # Only the final cumulative entry survives; partials are dropped.
+    result = de_accumulate_transcript(transcript, cumulative=True)
     assert result == "USER: I want to discuss\n\nASSISTANT: ok"
+
+
+def test_de_accumulate_transcript_preserves_prefix_follow_up_by_default():
+    """Text prefixes alone do not prove that independent turns are STT partials."""
+    transcript = [
+        {"role": "user", "text": "Hello"},
+        {"role": "user", "text": "Hello, how are you?"},
+    ]
+
+    assert de_accumulate_transcript(transcript) == "USER: Hello\nHello, how are you?"
 
 
 def test_collect_voice_calls_skips_file_symlink_outside_repo(tmp_path: Path):
@@ -351,7 +360,7 @@ def test_de_accumulate_transcript_whitespace_only_entry_loses_to_real_content():
         {"role": "user", "text": "          "},  # 10 spaces — longer raw, empty stripped
         {"role": "user", "text": "hello"},  # shorter raw, has real content
     ]
-    result = de_accumulate_transcript(transcript)
+    result = de_accumulate_transcript(transcript, cumulative=True)
     # "hello" must appear; empty-stripped entry must NOT cause the turn to disappear
     assert "hello" in result.lower()
 
@@ -374,7 +383,7 @@ def test_de_accumulate_transcript_non_dict_mid_run_does_not_break_cumulative():
         {"role": "user", "text": "I want to talk"},
         {"role": "assistant", "text": "sure"},
     ]
-    result = de_accumulate_transcript(transcript)
+    result = de_accumulate_transcript(transcript, cumulative=True)
     # The cumulative user run must collapse to the longest entry (last one)
     assert "I want to talk" in result
     # The partial "I" must NOT appear as a separate block

--- a/packages/gptme-rag/tests/test_sources.py
+++ b/packages/gptme-rag/tests/test_sources.py
@@ -403,3 +403,79 @@ def test_collect_voice_calls_file_path_returns_empty(tmp_path: Path):
     single_file.write_text('{"transcript": [{"role": "user", "text": "hello"}]}', encoding="utf-8")
     # Must return [] rather than raising NotADirectoryError
     assert collect_voice_call_documents(single_file) == []
+
+
+def test_de_accumulate_keeps_distinct_consecutive_same_role_turns():
+    """Two genuine same-role turns must both survive de-accumulation.
+
+    Regression for the P1 finding on head 2429e5a2: ``cumulative=True`` kept
+    only the longest entry of a same-role run, so a real follow-up turn from
+    the same speaker was silently dropped from the indexed content.  Measured
+    against the live archive at ``state/voice-calls/archive`` (81 calls), that
+    behaviour discarded 279 turns across 48 calls.
+    """
+    transcript = [
+        {"role": "assistant", "text": "Understood, I'll leave it for post-call."},
+        {"role": "assistant", "text": "The subagent timed out anyway; I'll handle it after."},
+    ]
+    result = de_accumulate_transcript(transcript, cumulative=True)
+    # Both turns must be present — the shorter one is not a partial of the longer.
+    assert "Understood, I'll leave it for post-call." in result
+    assert "The subagent timed out anyway; I'll handle it after." in result
+
+
+def test_de_accumulate_collapses_exact_duplicate_turns():
+    """Exactly-repeated turns collapse to one copy (the dominant archive shape)."""
+    transcript = [
+        {"role": "user", "text": "Hey, what's up?"},
+        {"role": "user", "text": "Hey, what's up?"},
+    ]
+    result = de_accumulate_transcript(transcript, cumulative=True)
+    assert result == "USER: Hey, what's up?"
+
+
+def test_de_accumulate_collapses_partials_then_keeps_next_turn():
+    """A partial chain collapses, and a following distinct turn is still kept."""
+    transcript = [
+        {"role": "user", "text": "I want"},
+        {"role": "user", "text": "I want the budget"},
+        {"role": "user", "text": "Also the timeline"},
+    ]
+    result = de_accumulate_transcript(transcript, cumulative=True)
+    assert result == "USER: I want the budget\nAlso the timeline"
+
+
+def test_collect_voice_calls_does_not_read_symlink_escaping_repo(tmp_path: Path):
+    """A per-file symlink out of the repo must be skipped *before* being read.
+
+    Regression for the P1 finding on head 2429e5a2: the collector called
+    ``read_text()`` and parsed the JSON before the per-file ``repo_root``
+    resolution check, so out-of-repo content was pulled into memory even though
+    the resulting document was later discarded.
+    """
+    repo = tmp_path / "repo"
+    call_dir = repo / "calls"
+    call_dir.mkdir(parents=True)
+
+    secret = tmp_path / "outside" / "secret.json"
+    secret.parent.mkdir()
+    secret.write_text('{"transcript": [{"role": "user", "text": "classified"}]}', encoding="utf-8")
+
+    (call_dir / "escape.json").symlink_to(secret)
+
+    read_paths: list[Path] = []
+    original_read_text = Path.read_text
+
+    def tracking_read_text(self: Path, *args, **kwargs):  # type: ignore[no-untyped-def]
+        read_paths.append(self)
+        return original_read_text(self, *args, **kwargs)
+
+    Path.read_text = tracking_read_text  # type: ignore[method-assign]
+    try:
+        docs = collect_voice_call_documents(call_dir, repo_root=repo)
+    finally:
+        Path.read_text = original_read_text  # type: ignore[method-assign]
+
+    assert docs == []
+    # The escaping file must never have been read at all.
+    assert read_paths == []

--- a/packages/gptme-rag/tests/test_sources.py
+++ b/packages/gptme-rag/tests/test_sources.py
@@ -423,6 +423,17 @@ def test_de_accumulate_transcript_non_dict_mid_run_does_not_break_cumulative():
     assert "ASSISTANT: sure" in result
 
 
+def test_de_accumulate_transcript_empty_role_mid_run_does_not_break_cumulative():
+    """An empty-role dict is malformed junk, not a boundary between partials."""
+    transcript = [
+        {"role": "user", "text": "I"},
+        {"role": "   ", "text": "ignored"},
+        {"role": "user", "text": "I want"},
+    ]
+
+    assert de_accumulate_transcript(transcript, cumulative=True) == "USER: I want"
+
+
 def test_collect_voice_calls_file_path_returns_empty(tmp_path: Path):
     """Passing a file path instead of a directory must return [] gracefully.
 

--- a/packages/gptme-rag/tests/test_sources.py
+++ b/packages/gptme-rag/tests/test_sources.py
@@ -224,3 +224,25 @@ def test_de_accumulate_transcript_skips_non_dict_entries():
     result = de_accumulate_transcript(transcript)  # type: ignore[arg-type]
     assert "first" in result
     assert "second" in result
+
+
+def test_collect_voice_calls_repo_root_guard_relative_vs_absolute(tmp_path: Path):
+    """Guard works when voice_calls_dir is absolute but repo_root is also absolute.
+
+    Regression for the P2 finding: Path.is_relative_to without .resolve() fails
+    when paths are given in different forms (one relative, one absolute).  Using
+    .resolve() on both normalises them so the comparison is spelling-independent.
+    """
+    repo = tmp_path / "repo"
+    call_dir = repo / "calls"
+    call_dir.mkdir(parents=True)
+    (call_dir / "call.json").write_text(
+        '{"transcript": [{"role": "user", "text": "hello"}]}', encoding="utf-8"
+    )
+    # Both absolute — must succeed (call_dir IS under repo)
+    docs = collect_voice_call_documents(call_dir, repo_root=repo)
+    assert len(docs) == 1
+    # Absolute call_dir, absolute repo_root pointing to sibling — must be empty
+    outside = tmp_path / "other"
+    outside.mkdir()
+    assert collect_voice_call_documents(call_dir, repo_root=outside) == []

--- a/packages/gptme-rag/tests/test_sources.py
+++ b/packages/gptme-rag/tests/test_sources.py
@@ -489,3 +489,49 @@ def test_collect_voice_calls_does_not_read_symlink_escaping_repo(tmp_path: Path)
     assert docs == []
     # The escaping file must never have been read at all.
     assert read_paths == []
+
+
+def test_collect_voice_calls_skips_symlink_loop(tmp_path: Path):
+    """A symlink loop must not abort collection of other valid calls."""
+    call_dir = tmp_path / "calls"
+    call_dir.mkdir()
+    (call_dir / "loop.json").symlink_to("loop.json")
+    (call_dir / "good.json").write_text(
+        '{"transcript": [{"role": "user", "text": "hello"}]}',
+        encoding="utf-8",
+    )
+
+    docs = collect_voice_call_documents(call_dir)
+
+    assert [doc.content for doc in docs] == ["USER: hello"]
+
+
+def test_collect_voice_calls_reads_resolved_path(tmp_path: Path):
+    """The file read must use the same resolved path checked by the guard."""
+    repo = tmp_path / "repo"
+    call_dir = repo / "calls"
+    call_dir.mkdir(parents=True)
+    target = call_dir / "target" / "call.json"
+    target.parent.mkdir()
+    target.write_text(
+        '{"transcript": [{"role": "user", "text": "hello"}]}',
+        encoding="utf-8",
+    )
+    link = call_dir / "call.json"
+    link.symlink_to(target.relative_to(call_dir))
+
+    read_paths: list[Path] = []
+    original_read_text = Path.read_text
+
+    def tracking_read_text(self: Path, *args, **kwargs):  # type: ignore[no-untyped-def]
+        read_paths.append(self)
+        return original_read_text(self, *args, **kwargs)
+
+    Path.read_text = tracking_read_text  # type: ignore[method-assign]
+    try:
+        docs = collect_voice_call_documents(call_dir, repo_root=repo)
+    finally:
+        Path.read_text = original_read_text  # type: ignore[method-assign]
+
+    assert [doc.content for doc in docs] == ["USER: hello"]
+    assert read_paths == [target.resolve()]

--- a/packages/gptme-rag/tests/test_sources.py
+++ b/packages/gptme-rag/tests/test_sources.py
@@ -185,6 +185,34 @@ def test_collect_voice_calls_skips_non_dict_json(tmp_path: Path):
     assert len(docs) == 1
 
 
+def test_collect_voice_calls_skips_non_utf8_file(tmp_path: Path):
+    """Files with invalid UTF-8 bytes must be skipped, not crash the whole collection."""
+    call_dir = tmp_path / "voice"
+    call_dir.mkdir()
+    (call_dir / "bad_encoding.json").write_bytes(b"\xff\xfe{not utf-8}")
+    (call_dir / "good.json").write_text(
+        '{"transcript": [{"role": "user", "text": "hello"}]}', encoding="utf-8"
+    )
+    docs = collect_voice_call_documents(call_dir)
+    assert len(docs) == 1
+
+
+def test_collect_voice_calls_repo_root_guard_resolves_symlinks(tmp_path: Path):
+    """Symlinks pointing outside repo_root must be caught by the guard."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "call.json").write_text(
+        '{"transcript": [{"role": "user", "text": "hello"}]}', encoding="utf-8"
+    )
+    # Symlink inside repo pointing outside
+    symlink = repo / "calls"
+    symlink.symlink_to(outside)
+    # The guard must catch this even though the symlink path is under repo
+    assert collect_voice_call_documents(symlink, repo_root=repo) == []
+
+
 def test_de_accumulate_transcript_skips_non_dict_entries():
     """Non-dict entries in the transcript list must be skipped, not crash."""
     transcript = [

--- a/packages/gptme-rag/tests/test_sources.py
+++ b/packages/gptme-rag/tests/test_sources.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from gptme_rag.indexing.document import Document
 from gptme_rag.sources import (
     SourceDescriptor,
@@ -57,6 +59,16 @@ def test_de_accumulate_transcript_role_reset_resumes_run():
     ]
     result = de_accumulate_transcript(transcript, cumulative=True)
     assert result == "USER: ab\n\nASSISTANT: x\n\nUSER: cd"
+
+
+def test_de_accumulate_transcript_skips_turns_without_roles():
+    transcript = [
+        {"text": "ambiguous"},
+        {"role": "user", "text": "identified"},
+        {"role": "   ", "text": "also ambiguous"},
+    ]
+
+    assert de_accumulate_transcript(transcript) == "USER: identified"
 
 
 # ---------------------------------------------------------------------------
@@ -118,6 +130,23 @@ def test_descriptor_defaults_always_on():
 
 def test_collect_voice_calls_missing_dir(tmp_path: Path):
     assert collect_voice_call_documents(tmp_path / "nope") == []
+
+
+def test_collect_voice_calls_unreadable_dir_returns_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    call_dir = tmp_path / "voice"
+    call_dir.mkdir()
+    original_glob = Path.glob
+
+    def denied_glob(self: Path, pattern: str):
+        if self == call_dir:
+            raise PermissionError("denied")
+        return original_glob(self, pattern)
+
+    monkeypatch.setattr(Path, "glob", denied_glob)
+
+    assert collect_voice_call_documents(call_dir) == []
 
 
 def test_collect_voice_calls_deaccumulates_and_metadata(tmp_path: Path):
@@ -465,7 +494,9 @@ def test_de_accumulate_keeps_ambiguous_prefix_chain():
     assert result == "USER: I want\nI\nI want to go"
 
 
-def test_collect_voice_calls_does_not_read_symlink_escaping_repo(tmp_path: Path):
+def test_collect_voice_calls_does_not_read_symlink_escaping_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
     """A per-file symlink out of the repo must be skipped *before* being read.
 
     Regression for the P1 finding on head 2429e5a2: the collector called
@@ -490,11 +521,8 @@ def test_collect_voice_calls_does_not_read_symlink_escaping_repo(tmp_path: Path)
         read_paths.append(self)
         return original_read_text(self, *args, **kwargs)
 
-    Path.read_text = tracking_read_text  # type: ignore[method-assign]
-    try:
-        docs = collect_voice_call_documents(call_dir, repo_root=repo)
-    finally:
-        Path.read_text = original_read_text  # type: ignore[method-assign]
+    monkeypatch.setattr(Path, "read_text", tracking_read_text)
+    docs = collect_voice_call_documents(call_dir, repo_root=repo)
 
     assert docs == []
     # The escaping file must never have been read at all.
@@ -516,7 +544,7 @@ def test_collect_voice_calls_skips_symlink_loop(tmp_path: Path):
     assert [doc.content for doc in docs] == ["USER: hello"]
 
 
-def test_collect_voice_calls_reads_resolved_path(tmp_path: Path):
+def test_collect_voice_calls_reads_resolved_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """The file read must use the same resolved path checked by the guard."""
     repo = tmp_path / "repo"
     call_dir = repo / "calls"
@@ -537,11 +565,8 @@ def test_collect_voice_calls_reads_resolved_path(tmp_path: Path):
         read_paths.append(self)
         return original_read_text(self, *args, **kwargs)
 
-    Path.read_text = tracking_read_text  # type: ignore[method-assign]
-    try:
-        docs = collect_voice_call_documents(call_dir, repo_root=repo)
-    finally:
-        Path.read_text = original_read_text  # type: ignore[method-assign]
+    monkeypatch.setattr(Path, "read_text", tracking_read_text)
+    docs = collect_voice_call_documents(call_dir, repo_root=repo)
 
     assert [doc.content for doc in docs] == ["USER: hello"]
     assert read_paths == [target.resolve()]

--- a/packages/gptme-rag/tests/test_sources.py
+++ b/packages/gptme-rag/tests/test_sources.py
@@ -2,7 +2,6 @@
 
 from pathlib import Path
 
-
 from gptme_rag.indexing.document import Document
 from gptme_rag.sources import (
     SourceDescriptor,
@@ -453,6 +452,17 @@ def test_de_accumulate_keeps_shorter_prefix_follow_up():
     ]
     result = de_accumulate_transcript(transcript, cumulative=True)
     assert result == "USER: I want the budget\nI want"
+
+
+def test_de_accumulate_keeps_ambiguous_prefix_chain():
+    """A new turn cannot be replaced by a later text merely sharing its prefix."""
+    transcript = [
+        {"role": "user", "text": "I want"},
+        {"role": "user", "text": "I"},
+        {"role": "user", "text": "I want to go"},
+    ]
+    result = de_accumulate_transcript(transcript, cumulative=True)
+    assert result == "USER: I want\nI\nI want to go"
 
 
 def test_collect_voice_calls_does_not_read_symlink_escaping_repo(tmp_path: Path):

--- a/packages/gptme-rag/tests/test_sources.py
+++ b/packages/gptme-rag/tests/test_sources.py
@@ -445,6 +445,16 @@ def test_de_accumulate_collapses_partials_then_keeps_next_turn():
     assert result == "USER: I want the budget\nAlso the timeline"
 
 
+def test_de_accumulate_keeps_shorter_prefix_follow_up():
+    """A later shorter prefix is a new turn, not a cumulative partial."""
+    transcript = [
+        {"role": "user", "text": "I want the budget"},
+        {"role": "user", "text": "I want"},
+    ]
+    result = de_accumulate_transcript(transcript, cumulative=True)
+    assert result == "USER: I want the budget\nI want"
+
+
 def test_collect_voice_calls_does_not_read_symlink_escaping_repo(tmp_path: Path):
     """A per-file symlink out of the repo must be skipped *before* being read.
 

--- a/packages/gptme-rag/tests/test_sources.py
+++ b/packages/gptme-rag/tests/test_sources.py
@@ -1,0 +1,173 @@
+"""Tests for source-descriptor document collection (Phase 2.1)."""
+
+from pathlib import Path
+
+
+from gptme_rag.indexing.document import Document
+from gptme_rag.sources import (
+    SourceDescriptor,
+    SourceRegistry,
+    collect_voice_call_documents,
+    de_accumulate_transcript,
+)
+
+
+# ---------------------------------------------------------------------------
+# de_accumulate_transcript
+# ---------------------------------------------------------------------------
+
+
+def test_de_accumulate_transcript_empty():
+    assert de_accumulate_transcript([]) == ""
+
+
+def test_de_accumulate_transcript_single_turn():
+    transcript = [{"role": "user", "text": "hello"}]
+    assert de_accumulate_transcript(transcript) == "USER: hello"
+
+
+def test_de_accumulate_transcript_drops_cumulative_partials():
+    # A cumulative transcript: the user role repeats with growing text.
+    transcript = [
+        {"role": "user", "text": "he"},
+        {"role": "user", "text": "hello"},
+        {"role": "user", "text": "hello world"},
+        {"role": "assistant", "text": "hi"},
+        {"role": "assistant", "text": "hi there"},
+    ]
+    result = de_accumulate_transcript(transcript)
+    assert result == "USER: hello world\n\nASSISTANT: hi there"
+
+
+def test_de_accumulate_transcript_skips_empty_turns():
+    transcript = [
+        {"role": "user", "text": "   "},
+        {"role": "assistant", "text": "real"},
+    ]
+    assert de_accumulate_transcript(transcript) == "ASSISTANT: real"
+
+
+def test_de_accumulate_transcript_role_reset_resumes_run():
+    # Same role appearing after a different role starts a new run.
+    transcript = [
+        {"role": "user", "text": "a"},
+        {"role": "user", "text": "ab"},
+        {"role": "assistant", "text": "x"},
+        {"role": "user", "text": "c"},
+        {"role": "user", "text": "cd"},
+    ]
+    result = de_accumulate_transcript(transcript)
+    assert result == "USER: ab\n\nASSISTANT: x\n\nUSER: cd"
+
+
+# ---------------------------------------------------------------------------
+# SourceRegistry
+# ---------------------------------------------------------------------------
+
+
+def _mk_doc(text: str, source: str = "s.md") -> Document:
+    return Document(content=text, metadata={"type": "test", "source": source})
+
+
+def test_registry_collect_always_on_only_by_default():
+    registry = SourceRegistry()
+    registry.add("always", lambda: [_mk_doc("a")])
+    registry.add("gated", lambda: [_mk_doc("g")], always_on=False)
+
+    docs = registry.collect()
+    assert [d.content for d in docs] == ["a"]
+
+
+def test_registry_collect_gated_includes_all():
+    registry = SourceRegistry()
+    registry.add("always", lambda: [_mk_doc("a")])
+    registry.add("gated", lambda: [_mk_doc("g")], always_on=False)
+
+    docs = registry.collect(gated=True)
+    assert [d.content for d in docs] == ["a", "g"]
+
+
+def test_registry_collector_exception_does_not_sink_build():
+    registry = SourceRegistry()
+
+    def bad() -> list[Document]:
+        raise RuntimeError("boom")
+
+    registry.add("bad", bad)
+    registry.add("good", lambda: [_mk_doc("ok")])
+
+    docs = registry.collect()
+    assert [d.content for d in docs] == ["ok"]
+
+
+def test_registry_sources_property():
+    registry = SourceRegistry()
+    registry.add("a", lambda: [_mk_doc("a")])
+    assert [s.name for s in registry.sources] == ["a"]
+
+
+def test_descriptor_defaults_always_on():
+    desc = SourceDescriptor("n", lambda: [_mk_doc("x")])
+    assert desc.always_on is True
+    assert desc.name == "n"
+
+
+# ---------------------------------------------------------------------------
+# collect_voice_call_documents
+# ---------------------------------------------------------------------------
+
+
+def test_collect_voice_calls_missing_dir(tmp_path: Path):
+    assert collect_voice_call_documents(tmp_path / "nope") == []
+
+
+def test_collect_voice_calls_deaccumulates_and_metadata(tmp_path: Path):
+    call_dir = tmp_path / "voice"
+    call_dir.mkdir()
+    (call_dir / "20260811T080814Z-358-twilio-CAabc.json").write_text(
+        '{"transcript": [{"role": "user", "text": "h"}, {"role": "user", "text": "hello"}, '
+        '{"role": "assistant", "text": "hi"}], "source": "twilio"}',
+        encoding="utf-8",
+    )
+
+    docs = collect_voice_call_documents(call_dir, repo_root=tmp_path)
+    assert len(docs) == 1
+    doc = docs[0]
+    assert doc.content == "USER: hello\n\nASSISTANT: hi"
+    assert doc.doc_id == "voicecall:20260811T080814Z-358-twilio-CAabc"
+    assert doc.metadata["type"] == "voicecall"
+    assert doc.metadata["title"] == "Voice call 2026-08-11 (twilio)"
+    assert doc.metadata["date"] == "2026-08-11"
+
+
+def test_collect_voice_calls_skips_bad_json(tmp_path: Path):
+    call_dir = tmp_path / "voice"
+    call_dir.mkdir()
+    (call_dir / "good.json").write_text(
+        '{"transcript": [{"role": "user", "text": "hello"}]}', encoding="utf-8"
+    )
+    (call_dir / "bad.json").write_text("{not json", encoding="utf-8")
+
+    docs = collect_voice_call_documents(call_dir)
+    assert len(docs) == 1
+
+
+def test_collect_voice_calls_skips_empty_transcript(tmp_path: Path):
+    call_dir = tmp_path / "voice"
+    call_dir.mkdir()
+    (call_dir / "empty.json").write_text('{"transcript": []}', encoding="utf-8")
+
+    docs = collect_voice_call_documents(call_dir)
+    assert docs == []
+
+
+def test_collect_voice_calls_repo_root_guard(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "call.json").write_text(
+        '{"transcript": [{"role": "user", "text": "hello"}]}', encoding="utf-8"
+    )
+    # repo_root is the `repo` dir; `outside` is a sibling, NOT under it.
+    assert collect_voice_call_documents(outside, repo_root=repo) == []

--- a/packages/gptme-rag/tests/test_sources.py
+++ b/packages/gptme-rag/tests/test_sources.py
@@ -294,9 +294,7 @@ def test_collect_voice_calls_skips_file_symlink_outside_repo(tmp_path: Path):
     outside.mkdir()
     # A real file outside the repo
     target = outside / "real_call.json"
-    target.write_text(
-        '{"transcript": [{"role": "user", "text": "secret"}]}', encoding="utf-8"
-    )
+    target.write_text('{"transcript": [{"role": "user", "text": "secret"}]}', encoding="utf-8")
     # Symlink inside call_dir pointing outside repo_root
     link = call_dir / "escaped.json"
     link.symlink_to(target)
@@ -351,7 +349,7 @@ def test_de_accumulate_transcript_whitespace_only_entry_loses_to_real_content():
     """
     transcript = [
         {"role": "user", "text": "          "},  # 10 spaces — longer raw, empty stripped
-        {"role": "user", "text": "hello"},        # shorter raw, has real content
+        {"role": "user", "text": "hello"},  # shorter raw, has real content
     ]
     result = de_accumulate_transcript(transcript)
     # "hello" must appear; empty-stripped entry must NOT cause the turn to disappear

--- a/packages/gptme-rag/tests/test_sources.py
+++ b/packages/gptme-rag/tests/test_sources.py
@@ -337,3 +337,48 @@ def test_collect_voice_calls_source_path_resolves_before_relative_to(tmp_path: P
         assert not Path(docs[0].metadata["source"]).is_absolute()
     finally:
         os.chdir(orig_cwd)
+
+
+def test_de_accumulate_transcript_whitespace_only_entry_loses_to_real_content():
+    """A whitespace-only entry must not win the max() over real content.
+
+    Regression for P1 finding: max(run_texts, key=len) picked a 10-space string
+    over "hello" (raw lengths 10 vs 5).  The cumulative prefix check passes
+    because "hello".startswith("") is True, so the run was treated as cumulative
+    and the spaces won — resulting in best.strip() == "" and the turn being dropped.
+    Fix: max(key=lambda t: len(t.strip())) strips first so only non-whitespace
+    length counts.
+    """
+    transcript = [
+        {"role": "user", "text": "          "},  # 10 spaces — longer raw, empty stripped
+        {"role": "user", "text": "hello"},        # shorter raw, has real content
+    ]
+    result = de_accumulate_transcript(transcript)
+    # "hello" must appear; empty-stripped entry must NOT cause the turn to disappear
+    assert "hello" in result.lower()
+
+
+def test_de_accumulate_transcript_non_dict_mid_run_does_not_break_cumulative():
+    """A non-dict entry in the middle of a same-role run must be skipped, not split the run.
+
+    Regression for P1 finding: the inner while loop checked isinstance() as a
+    loop condition, so a non-dict at position j in a same-role run would end the
+    run at j, then the outer loop would skip the non-dict and start a *new* run
+    on the next same-role dict — causing a cumulative sequence to be treated as
+    two independent turns (first partial kept, final longer text also kept, but
+    reported as separate speaker blocks).
+    """
+    # A cumulative sequence interrupted by a non-dict junk entry mid-run
+    transcript = [
+        {"role": "user", "text": "I"},
+        "junk",  # non-dict in the middle — must be skipped, not end the run
+        {"role": "user", "text": "I want"},
+        {"role": "user", "text": "I want to talk"},
+        {"role": "assistant", "text": "sure"},
+    ]
+    result = de_accumulate_transcript(transcript)
+    # The cumulative user run must collapse to the longest entry (last one)
+    assert "I want to talk" in result
+    # The partial "I" must NOT appear as a separate block
+    assert result.count("USER:") == 1
+    assert "ASSISTANT: sure" in result

--- a/packages/gptme-rag/tests/test_sources.py
+++ b/packages/gptme-rag/tests/test_sources.py
@@ -169,6 +169,21 @@ def test_collect_voice_calls_deaccumulates_and_metadata(tmp_path: Path):
     assert doc.metadata["date"] == "2026-08-11"
 
 
+def test_collect_voice_calls_can_preserve_finalized_prefix_turns(tmp_path: Path):
+    """Finalized transcripts can opt out of cumulative-partial collapsing."""
+    call_dir = tmp_path / "voice"
+    call_dir.mkdir()
+    (call_dir / "call.json").write_text(
+        '{"transcript": [{"role": "user", "text": "I want"}, '
+        '{"role": "user", "text": "I want to go"}]}',
+        encoding="utf-8",
+    )
+
+    docs = collect_voice_call_documents(call_dir, cumulative=False)
+
+    assert [doc.content for doc in docs] == ["USER: I want\nI want to go"]
+
+
 def test_collect_voice_calls_skips_bad_json(tmp_path: Path):
     call_dir = tmp_path / "voice"
     call_dir.mkdir()
@@ -563,7 +578,7 @@ def test_collect_voice_calls_skips_symlink_loop(tmp_path: Path):
 
 
 def test_collect_voice_calls_reads_resolved_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    """The file open must use the same resolved path checked by the guard."""
+    """The guarded open must traverse the resolved target beneath repo_root."""
     repo = tmp_path / "repo"
     call_dir = repo / "calls"
     call_dir.mkdir(parents=True)
@@ -587,7 +602,7 @@ def test_collect_voice_calls_reads_resolved_path(tmp_path: Path, monkeypatch: py
     docs = collect_voice_call_documents(call_dir, repo_root=repo)
 
     assert [doc.content for doc in docs] == ["USER: hello"]
-    assert opened_paths == [target.resolve()]
+    assert opened_paths == [repo.resolve(), Path("calls"), Path("target"), Path("call.json")]
 
 
 def test_collect_voice_calls_rejects_symlink_swapped_after_resolution(
@@ -615,10 +630,10 @@ def test_collect_voice_calls_rejects_symlink_swapped_after_resolution(
     def swapping_open(path, flags, *args, **kwargs):  # type: ignore[no-untyped-def]
         nonlocal seen_flags
         candidate = Path(path)
-        if candidate == original_call_path and not candidate.is_symlink():
+        if candidate == Path("call.json") and kwargs.get("dir_fd") is not None:
             seen_flags = flags
-            candidate.unlink()
-            candidate.symlink_to(secret)
+            original_call_path.unlink()
+            original_call_path.symlink_to(secret)
         return original_open(path, flags, *args, **kwargs)
 
     monkeypatch.setattr(os, "open", swapping_open)
@@ -627,3 +642,41 @@ def test_collect_voice_calls_rejects_symlink_swapped_after_resolution(
     nofollow = getattr(os, "O_NOFOLLOW", 0)
     if nofollow:
         assert seen_flags & nofollow
+
+
+def test_collect_voice_calls_rejects_intermediate_directory_swap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """An intermediate directory swapped to an escaping symlink is rejected."""
+    repo = tmp_path / "repo"
+    call_dir = repo / "calls"
+    archive_dir = call_dir / "archive"
+    archive_dir.mkdir(parents=True)
+    (archive_dir / "call.json").write_text(
+        '{"transcript": [{"role": "user", "text": "safe"}]}',
+        encoding="utf-8",
+    )
+    link = call_dir / "call.json"
+    link.symlink_to(Path("archive") / "call.json")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "call.json").write_text(
+        '{"transcript": [{"role": "user", "text": "secret"}]}',
+        encoding="utf-8",
+    )
+
+    original_open = os.open
+    swapped = False
+
+    def swapping_open(path, flags, *args, **kwargs):  # type: ignore[no-untyped-def]
+        nonlocal swapped
+        if Path(path) == Path("archive") and kwargs.get("dir_fd") is not None:
+            swapped = True
+            archive_dir.rename(call_dir / "original-archive")
+            archive_dir.symlink_to(outside, target_is_directory=True)
+        return original_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(os, "open", swapping_open)
+
+    assert collect_voice_call_documents(call_dir, repo_root=repo) == []
+    assert swapped

--- a/packages/gptme-rag/tests/test_sources.py
+++ b/packages/gptme-rag/tests/test_sources.py
@@ -171,3 +171,28 @@ def test_collect_voice_calls_repo_root_guard(tmp_path: Path):
     )
     # repo_root is the `repo` dir; `outside` is a sibling, NOT under it.
     assert collect_voice_call_documents(outside, repo_root=repo) == []
+
+
+def test_collect_voice_calls_skips_non_dict_json(tmp_path: Path):
+    """Valid JSON that is not a dict (e.g. an array) must be skipped gracefully."""
+    call_dir = tmp_path / "voice"
+    call_dir.mkdir()
+    (call_dir / "list.json").write_text("[1, 2, 3]", encoding="utf-8")
+    (call_dir / "good.json").write_text(
+        '{"transcript": [{"role": "user", "text": "hello"}]}', encoding="utf-8"
+    )
+    docs = collect_voice_call_documents(call_dir)
+    assert len(docs) == 1
+
+
+def test_de_accumulate_transcript_skips_non_dict_entries():
+    """Non-dict entries in the transcript list must be skipped, not crash."""
+    transcript = [
+        {"role": "user", "text": "first"},
+        "not a dict",
+        42,
+        {"role": "assistant", "text": "second"},
+    ]
+    result = de_accumulate_transcript(transcript)  # type: ignore[arg-type]
+    assert "first" in result
+    assert "second" in result

--- a/packages/gptme-rag/tests/test_sources.py
+++ b/packages/gptme-rag/tests/test_sources.py
@@ -246,3 +246,32 @@ def test_collect_voice_calls_repo_root_guard_relative_vs_absolute(tmp_path: Path
     outside = tmp_path / "other"
     outside.mkdir()
     assert collect_voice_call_documents(call_dir, repo_root=outside) == []
+
+
+def test_collect_voice_calls_source_path_resolves_before_relative_to(tmp_path: Path):
+    """source_path computation must use path.resolve() so relative voice_calls_dir
+    does not raise ValueError when repo_root is absolute.
+
+    Regression for P1 finding: line 216 used path.relative_to(repo_root) with an
+    unresolved (relative) path while the guard used resolved paths, causing a
+    ValueError crash instead of returning collected documents.
+    """
+    import os
+
+    repo = tmp_path / "repo"
+    call_dir = repo / "calls"
+    call_dir.mkdir(parents=True)
+    (call_dir / "call.json").write_text(
+        '{"transcript": [{"role": "user", "text": "hello world"}]}', encoding="utf-8"
+    )
+    # Change to the repo dir so a relative "calls" resolves under repo_root
+    orig_cwd = os.getcwd()
+    os.chdir(repo)
+    try:
+        # Relative voice_calls_dir, absolute repo_root — must not raise ValueError
+        docs = collect_voice_call_documents(Path("calls"), repo_root=repo)
+        assert len(docs) == 1
+        # source metadata must be a relative path (relative to repo_root)
+        assert not Path(docs[0].metadata["source"]).is_absolute()
+    finally:
+        os.chdir(orig_cwd)

--- a/packages/gptme-rag/tests/test_sources.py
+++ b/packages/gptme-rag/tests/test_sources.py
@@ -1,5 +1,6 @@
 """Tests for source-descriptor document collection (Phase 2.1)."""
 
+import os
 from pathlib import Path
 
 import pytest
@@ -560,7 +561,7 @@ def test_collect_voice_calls_skips_symlink_loop(tmp_path: Path):
 
 
 def test_collect_voice_calls_reads_resolved_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    """The file read must use the same resolved path checked by the guard."""
+    """The file open must use the same resolved path checked by the guard."""
     repo = tmp_path / "repo"
     call_dir = repo / "calls"
     call_dir.mkdir(parents=True)
@@ -573,15 +574,52 @@ def test_collect_voice_calls_reads_resolved_path(tmp_path: Path, monkeypatch: py
     link = call_dir / "call.json"
     link.symlink_to(target.relative_to(call_dir))
 
-    read_paths: list[Path] = []
-    original_read_text = Path.read_text
+    opened_paths: list[Path] = []
+    original_open = os.open
 
-    def tracking_read_text(self: Path, *args, **kwargs):  # type: ignore[no-untyped-def]
-        read_paths.append(self)
-        return original_read_text(self, *args, **kwargs)
+    def tracking_open(path, flags, *args, **kwargs):  # type: ignore[no-untyped-def]
+        opened_paths.append(Path(path))
+        return original_open(path, flags, *args, **kwargs)
 
-    monkeypatch.setattr(Path, "read_text", tracking_read_text)
+    monkeypatch.setattr(os, "open", tracking_open)
     docs = collect_voice_call_documents(call_dir, repo_root=repo)
 
     assert [doc.content for doc in docs] == ["USER: hello"]
-    assert read_paths == [target.resolve()]
+    assert opened_paths == [target.resolve()]
+
+
+def test_collect_voice_calls_rejects_symlink_swapped_after_resolution(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A final-component symlink swap after resolve() must not escape repo_root."""
+    repo = tmp_path / "repo"
+    call_dir = repo / "calls"
+    call_dir.mkdir(parents=True)
+    call = call_dir / "call.json"
+    call.write_text(
+        '{"transcript": [{"role": "user", "text": "safe"}]}',
+        encoding="utf-8",
+    )
+    secret = tmp_path / "secret.json"
+    secret.write_text(
+        '{"transcript": [{"role": "user", "text": "secret"}]}',
+        encoding="utf-8",
+    )
+
+    original_open = os.open
+    seen_flags = 0
+    original_call_path = call.resolve()
+
+    def swapping_open(path, flags, *args, **kwargs):  # type: ignore[no-untyped-def]
+        nonlocal seen_flags
+        candidate = Path(path)
+        if candidate == original_call_path and not candidate.is_symlink():
+            seen_flags = flags
+            candidate.unlink()
+            candidate.symlink_to(secret)
+        return original_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(os, "open", swapping_open)
+
+    assert collect_voice_call_documents(call_dir, repo_root=repo) == []
+    assert seen_flags & os.O_NOFOLLOW

--- a/packages/gptme-rag/tests/test_sources.py
+++ b/packages/gptme-rag/tests/test_sources.py
@@ -345,7 +345,9 @@ def test_collect_voice_calls_skips_file_symlink_outside_repo(tmp_path: Path):
     assert docs[0].content == "USER: hello"
 
 
-def test_collect_voice_calls_source_path_resolves_before_relative_to(tmp_path: Path):
+def test_collect_voice_calls_source_path_resolves_before_relative_to(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
     """source_path computation must use path.resolve() so relative voice_calls_dir
     does not raise ValueError when repo_root is absolute.
 
@@ -353,25 +355,27 @@ def test_collect_voice_calls_source_path_resolves_before_relative_to(tmp_path: P
     unresolved (relative) path while the guard used resolved paths, causing a
     ValueError crash instead of returning collected documents.
     """
-    import os
-
     repo = tmp_path / "repo"
     call_dir = repo / "calls"
     call_dir.mkdir(parents=True)
     (call_dir / "call.json").write_text(
         '{"transcript": [{"role": "user", "text": "hello world"}]}', encoding="utf-8"
     )
-    # Change to the repo dir so a relative "calls" resolves under repo_root
-    orig_cwd = os.getcwd()
-    os.chdir(repo)
-    try:
-        # Relative voice_calls_dir, absolute repo_root — must not raise ValueError
-        docs = collect_voice_call_documents(Path("calls"), repo_root=repo)
-        assert len(docs) == 1
-        # source metadata must be a relative path (relative to repo_root)
-        assert not Path(docs[0].metadata["source"]).is_absolute()
-    finally:
-        os.chdir(orig_cwd)
+    # Relative voice_calls_dir, absolute repo_root — must not raise ValueError.
+    monkeypatch.chdir(repo)
+    docs = collect_voice_call_documents(Path("calls"), repo_root=repo)
+    assert len(docs) == 1
+    # source metadata must be a relative path (relative to repo_root)
+    assert not Path(docs[0].metadata["source"]).is_absolute()
+
+
+def test_de_accumulate_transcript_strips_role_whitespace():
+    transcript = [
+        {"role": " user ", "text": "hello"},
+        {"role": "user", "text": "hello world"},
+    ]
+
+    assert de_accumulate_transcript(transcript, cumulative=True) == "USER: hello world"
 
 
 def test_de_accumulate_transcript_whitespace_only_entry_loses_to_real_content():

--- a/packages/gptme-rag/tests/test_sources.py
+++ b/packages/gptme-rag/tests/test_sources.py
@@ -380,3 +380,17 @@ def test_de_accumulate_transcript_non_dict_mid_run_does_not_break_cumulative():
     # The partial "I" must NOT appear as a separate block
     assert result.count("USER:") == 1
     assert "ASSISTANT: sure" in result
+
+
+def test_collect_voice_calls_file_path_returns_empty(tmp_path: Path):
+    """Passing a file path instead of a directory must return [] gracefully.
+
+    Regression for P2 finding: the function checked exists() but not is_dir().
+    If a caller passed a path to an existing JSON file (e.g. a single archive),
+    exists() was True so the code proceeded to glob("*.json") which raises
+    NotADirectoryError and aborts collection.
+    """
+    single_file = tmp_path / "call.json"
+    single_file.write_text('{"transcript": [{"role": "user", "text": "hello"}]}', encoding="utf-8")
+    # Must return [] rather than raising NotADirectoryError
+    assert collect_voice_call_documents(single_file) == []

--- a/packages/gptme-rag/tests/test_sources.py
+++ b/packages/gptme-rag/tests/test_sources.py
@@ -510,16 +510,21 @@ def test_de_accumulate_keeps_ambiguous_prefix_chain():
     assert result == "USER: I want\nI\nI want to go"
 
 
+def test_de_accumulate_skips_non_string_text():
+    """Missing or null STT text must not become indexable placeholder content."""
+    transcript = [
+        {"role": "user", "text": None},
+        {"role": "user", "text": "hello"},
+        {"role": "assistant", "text": 42},
+    ]
+
+    assert de_accumulate_transcript(transcript, cumulative=True) == "USER: hello"
+
+
 def test_collect_voice_calls_does_not_read_symlink_escaping_repo(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    """A per-file symlink out of the repo must be skipped *before* being read.
-
-    Regression for the P1 finding on head 2429e5a2: the collector called
-    ``read_text()`` and parsed the JSON before the per-file ``repo_root``
-    resolution check, so out-of-repo content was pulled into memory even though
-    the resulting document was later discarded.
-    """
+    """A per-file symlink out of the repo must be skipped before opening it."""
     repo = tmp_path / "repo"
     call_dir = repo / "calls"
     call_dir.mkdir(parents=True)
@@ -527,22 +532,19 @@ def test_collect_voice_calls_does_not_read_symlink_escaping_repo(
     secret = tmp_path / "outside" / "secret.json"
     secret.parent.mkdir()
     secret.write_text('{"transcript": [{"role": "user", "text": "classified"}]}', encoding="utf-8")
-
     (call_dir / "escape.json").symlink_to(secret)
 
-    read_paths: list[Path] = []
-    original_read_text = Path.read_text
+    opened_paths: list[Path] = []
+    original_open = os.open
 
-    def tracking_read_text(self: Path, *args, **kwargs):  # type: ignore[no-untyped-def]
-        read_paths.append(self)
-        return original_read_text(self, *args, **kwargs)
+    def tracking_open(path, flags, *args, **kwargs):  # type: ignore[no-untyped-def]
+        opened_paths.append(Path(path))
+        return original_open(path, flags, *args, **kwargs)
 
-    monkeypatch.setattr(Path, "read_text", tracking_read_text)
-    docs = collect_voice_call_documents(call_dir, repo_root=repo)
+    monkeypatch.setattr(os, "open", tracking_open)
 
-    assert docs == []
-    # The escaping file must never have been read at all.
-    assert read_paths == []
+    assert collect_voice_call_documents(call_dir, repo_root=repo) == []
+    assert opened_paths == []
 
 
 def test_collect_voice_calls_skips_symlink_loop(tmp_path: Path):
@@ -622,4 +624,6 @@ def test_collect_voice_calls_rejects_symlink_swapped_after_resolution(
     monkeypatch.setattr(os, "open", swapping_open)
 
     assert collect_voice_call_documents(call_dir, repo_root=repo) == []
-    assert seen_flags & os.O_NOFOLLOW
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if nofollow:
+        assert seen_flags & nofollow


### PR DESCRIPTION
## Summary

Phase 2.1 of `upstream-retrieval-into-gptme-rag`: upstream the **source-descriptor collection** capability from the Bob brain script (`scripts/build-ambient-memory-index.py`) into `gptme-rag`, plus the **voice-call de-accumulation** format-normalization utility.

Follows the same port pattern as Phase 2.3 (`task_retrieval.py`, #1440): mechanism upstream, policy (which dirs are sources, always-on vs gated, boost numbers) stays consumer config.

## What's included

- `SourceDescriptor` + `SourceRegistry` — a declarative registry for document sources. Each source is a zero-arg collector returning `Document`s, tagged *always-on* (every build) or *gated* (full builds only). `collect()` flattens in registration order and isolates a raising collector so one bad source can't sink a build.
- `de_accumulate_transcript()` — recover full utterances from cumulative voice-call transcripts (longest text per contiguous same-role run).
- `collect_voice_call_documents()` — turn archived call JSON into `Document`s keyed `voicecall:<stem>`, with a repo-root safety guard.

## Why this shape

The brain script grew a registry (`_ALWAYS_ON_SOURCES` / `_MEMORY_TYPE_SOURCES`) precisely because ad-hoc `glob` loops per source were unmaintainable. The registry is the reusable mechanism; the source list and gating policy are Bob config.

## Testing

- 15 new tests in `tests/test_sources.py` (de-accumulation edge cases, registry gating + exception isolation, voice-call collection incl. bad-JSON and repo-root guard).
- `ruff` + `mypy` clean on the new module.

## Not included (later phases)

- memory_type classification + ranking boost (Phase 2.2)
- lesson matcher extraction (Phase 2.4)
- hook adoption + brain-script sunset (Phase 3–4)

Closes part of ErikBjare/bob `upstream-retrieval-into-gptme-rag` (Phase 2.1).
