### PR TITLE
feat(gptme-rag): memory_type classification + ranking boost (Phase 2.2)

### DIFF
--- a/packages/gptme-rag/src/gptme_rag/lexical.py
+++ b/packages/gptme-rag/src/gptme_rag/lexical.py
@@ -253,7 +253,7 @@ class TfidfIndex:
         sorted_indices = sorted(range(len(raw_sims)), key=_weighted, reverse=True)
 
         hits: list[LexicalHit] = []
-        for idx in sorted_indices:
+        for rank, idx in enumerate(sorted_indices):
             # Keep relevance_floor's existing raw-cosine semantics.  Memory-type
             # weights only rerank documents that already clear the relevance gate.
             if float(raw_sims[idx]) < self.relevance_floor:
@@ -262,7 +262,9 @@ class TfidfIndex:
             doc = self._documents[idx]
             if self._source_path(doc) in excluded:
                 continue
-            hits.append(LexicalHit(document=doc, score=round(score, 4), rank=len(hits)))
+            # Preserve LexicalHit.rank as the candidate's position in the full
+            # sorted list, including candidates skipped by filters.
+            hits.append(LexicalHit(document=doc, score=round(score, 4), rank=rank))
             if len(hits) >= n_results:
                 break
         return hits

--- a/packages/gptme-rag/src/gptme_rag/lexical.py
+++ b/packages/gptme-rag/src/gptme_rag/lexical.py
@@ -27,6 +27,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from .indexing.document import Document
+from .memory_type import SUPPORTED_MEMORY_TYPES, weighted_similarity
 
 logger = logging.getLogger(__name__)
 
@@ -197,11 +198,21 @@ class TfidfIndex:
         query: str,
         n_results: int = 5,
         exclude_paths: set[str] | None = None,
+        memory_types: set[str] | None = None,
     ) -> list[LexicalHit]:
         """Return up to ``n_results`` hits ranked by cosine similarity.
 
         ``exclude_paths`` is a set of source paths to skip (e.g. documents already
         in context).  Hits below ``relevance_floor`` are discarded.
+
+        ``memory_types`` is an optional set of memory-type labels (e.g.
+        ``{"goal", "identity"}``) that boosts matching documents and penalises
+        non-matching ones via :func:`~gptme_rag.memory_type.weighted_similarity`.
+        Documents must carry a ``"memory_type"`` key in their metadata (set by the
+        caller during indexing) for this to take effect; documents without the key
+        are ranked by raw cosine similarity.  Only types in
+        :data:`~gptme_rag.memory_type.SUPPORTED_MEMORY_TYPES` are considered —
+        unrecognised values are silently ignored.
         """
         if n_results <= 0:
             return []
@@ -217,14 +228,31 @@ class TfidfIndex:
             ) from exc
 
         q_vec = self._vectorizer.transform([query])
-        sims = cosine_similarity(q_vec, self._matrix)[0]
+        raw_sims = cosine_similarity(q_vec, self._matrix)[0]
         excluded = exclude_paths or set()
 
+        # Normalise the requested memory types to only known values so that a
+        # typo in the caller's set does not silently ignore all boosts.
+        requested: set[str] | None = None
+        if memory_types:
+            requested = {t for t in memory_types if t in SUPPORTED_MEMORY_TYPES}
+            if not requested:
+                requested = None
+
+        # Compute weighted scores and sort by them so that boosted documents
+        # rank above documents with a higher raw similarity but wrong type.
+        def _weighted(idx: int) -> float:
+            doc = self._documents[idx]
+            mem_type: str | None = doc.metadata.get("memory_type") or None
+            return weighted_similarity(float(raw_sims[idx]), mem_type, requested)
+
+        sorted_indices = sorted(range(len(raw_sims)), key=_weighted, reverse=True)
+
         hits: list[LexicalHit] = []
-        for rank, idx in enumerate(sims.argsort()[::-1]):
-            score = float(sims[idx])
+        for rank, idx in enumerate(sorted_indices):
+            score = _weighted(idx)
             if score < self.relevance_floor:
-                continue
+                break  # sorted descending — nothing below this will clear the floor
             doc = self._documents[idx]
             if self._source_path(doc) in excluded:
                 continue

--- a/packages/gptme-rag/src/gptme_rag/lexical.py
+++ b/packages/gptme-rag/src/gptme_rag/lexical.py
@@ -253,7 +253,7 @@ class TfidfIndex:
         sorted_indices = sorted(range(len(raw_sims)), key=_weighted, reverse=True)
 
         hits: list[LexicalHit] = []
-        for rank, idx in enumerate(sorted_indices):
+        for idx in sorted_indices:
             # Keep relevance_floor's existing raw-cosine semantics.  Memory-type
             # weights only rerank documents that already clear the relevance gate.
             if float(raw_sims[idx]) < self.relevance_floor:
@@ -262,7 +262,7 @@ class TfidfIndex:
             doc = self._documents[idx]
             if self._source_path(doc) in excluded:
                 continue
-            hits.append(LexicalHit(document=doc, score=round(score, 4), rank=rank))
+            hits.append(LexicalHit(document=doc, score=round(score, 4), rank=len(hits)))
             if len(hits) >= n_results:
                 break
         return hits

--- a/packages/gptme-rag/src/gptme_rag/lexical.py
+++ b/packages/gptme-rag/src/gptme_rag/lexical.py
@@ -250,7 +250,13 @@ class TfidfIndex:
                 mem_type = None
             return weighted_similarity(float(raw_sims[idx]), mem_type, requested)
 
-        sorted_indices = sorted(range(len(raw_sims)), key=_weighted, reverse=True)
+        # Preserve numpy's historical default-path ordering exactly.  Equal
+        # scores have no semantic ordering contract, but callers still should
+        # not see an unrelated order change when memory-type weighting is off.
+        if requested is None:
+            sorted_indices = raw_sims.argsort()[::-1]
+        else:
+            sorted_indices = sorted(range(len(raw_sims)), key=_weighted, reverse=True)
 
         hits: list[LexicalHit] = []
         for rank, idx in enumerate(sorted_indices):

--- a/packages/gptme-rag/src/gptme_rag/lexical.py
+++ b/packages/gptme-rag/src/gptme_rag/lexical.py
@@ -244,6 +244,9 @@ class TfidfIndex:
         def _weighted(idx: int) -> float:
             doc = self._documents[idx]
             mem_type: str | None = doc.metadata.get("memory_type") or None
+            # Treat unrecognised memory-type labels as untagged (no penalty).
+            if mem_type not in SUPPORTED_MEMORY_TYPES:
+                mem_type = None
             return weighted_similarity(float(raw_sims[idx]), mem_type, requested)
 
         sorted_indices = sorted(range(len(raw_sims)), key=_weighted, reverse=True)

--- a/packages/gptme-rag/src/gptme_rag/lexical.py
+++ b/packages/gptme-rag/src/gptme_rag/lexical.py
@@ -203,7 +203,8 @@ class TfidfIndex:
         """Return up to ``n_results`` hits ranked by cosine similarity.
 
         ``exclude_paths`` is a set of source paths to skip (e.g. documents already
-        in context).  Hits below ``relevance_floor`` are discarded.
+        in context).  Hits whose raw cosine similarity is below
+        ``relevance_floor`` are discarded before memory-type weighting.
 
         ``memory_types`` is an optional set of memory-type labels (e.g.
         ``{"goal", "identity"}``) that boosts matching documents and penalises
@@ -253,9 +254,11 @@ class TfidfIndex:
 
         hits: list[LexicalHit] = []
         for rank, idx in enumerate(sorted_indices):
+            # Keep relevance_floor's existing raw-cosine semantics.  Memory-type
+            # weights only rerank documents that already clear the relevance gate.
+            if float(raw_sims[idx]) < self.relevance_floor:
+                continue  # weighted order is not monotonic in raw similarity
             score = _weighted(idx)
-            if score < self.relevance_floor:
-                break  # sorted descending — nothing below this will clear the floor
             doc = self._documents[idx]
             if self._source_path(doc) in excluded:
                 continue

--- a/packages/gptme-rag/src/gptme_rag/memory_type.py
+++ b/packages/gptme-rag/src/gptme_rag/memory_type.py
@@ -161,9 +161,8 @@ def _extract_frontmatter(content: str) -> dict[str, Any]:
 
         parsed = yaml.safe_load(frontmatter_text) or {}
     except Exception:
-        # Fallback: simple key: value regex (no nested structures)
-        import re
-
+        # Fallback: simple key: value regex (no nested structures). Inline YAML
+        # lists stay as strings here and are normalised by _coerce_string_list.
         parsed = {k: v for k, v in re.findall(r"^(\w[\w_-]*):\s*(.*)", frontmatter_text, re.M)}
     return parsed if isinstance(parsed, dict) else {}
 
@@ -175,7 +174,11 @@ def _coerce_string_list(value: Any) -> list[str]:
     strings that YAML leaves as a single string (e.g. ``tags: ai, project``).
     """
     if isinstance(value, str):
-        # Split on commas to handle "preference, project" as two tags.
+        # Split on commas to handle both plain comma-separated tags and inline
+        # YAML lists emitted as strings by the no-PyYAML fallback parser.
+        value = value.strip()
+        if value.startswith("[") and value.endswith("]"):
+            value = value[1:-1]
         return [p.strip().lower() for p in value.split(",") if p.strip()]
     if isinstance(value, list):
         # Also split each list item on commas — YAML may parse "- preference, project"

--- a/packages/gptme-rag/src/gptme_rag/memory_type.py
+++ b/packages/gptme-rag/src/gptme_rag/memory_type.py
@@ -220,7 +220,9 @@ def classify_memory_type(
     exact_paths = rules.get("exact_paths", {})
     if isinstance(exact_paths, dict) and rel_path in exact_paths:
         memory_type = str(exact_paths[rel_path])
-        return memory_type if memory_type in SUPPORTED_MEMORY_TYPES else None
+        if memory_type in SUPPORTED_MEMORY_TYPES:
+            return memory_type
+        # Unsupported type (e.g. typo) — fall through to glob/task rules
 
     # 2. Glob-pattern match
     glob_paths = rules.get("glob_paths", {})

--- a/packages/gptme-rag/src/gptme_rag/memory_type.py
+++ b/packages/gptme-rag/src/gptme_rag/memory_type.py
@@ -1,0 +1,239 @@
+"""Memory-type classification and ranking boost for gptme-rag.
+
+Documents in a personal knowledge base serve different roles: some encode
+identity (SOUL.md, ABOUT.md), others encode active goals, ongoing projects, or
+user preferences.  Classifying documents by *memory type* lets the ranking layer
+boost results that match the caller's retrieval intent without hard-filtering.
+
+The classification is driven by a caller-supplied rules dict (loaded from JSON)
+rather than hardcoded paths — callers embed their own policy and pass it in.
+This keeps the library generic while the brain repo retains its config.
+
+Example rules dict:
+
+    {
+        "exact_paths": {"SOUL.md": "identity", "ABOUT.md": "identity"},
+        "glob_paths": {"tasks/*.md": "project"},
+        "task_rules": {
+            "goal_priorities": ["high"],
+            "goal_states": ["active"],
+            "preference_tags": ["preference"],
+            "project_tags": ["project"],
+            "default": "project"
+        }
+    }
+
+Usage::
+
+    rules = load_memory_type_map(Path("state/ambient-memory/memory-type-map.json"))
+    memory_type = classify_memory_type("tasks/my-task.md", {"priority": "high"}, rules)
+    score = weighted_similarity(0.8, memory_type, {"goal", "identity"})
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from fnmatch import fnmatch
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Memory types the library recognises.  Others are treated as unknown and
+#: silently ignored rather than causing a hard error.
+SUPPORTED_MEMORY_TYPES: tuple[str, ...] = ("identity", "preference", "goal", "project")
+
+#: Multiplicative boost applied to the similarity score when the document's
+#: memory type matches the set of requested types.
+MEMORY_TYPE_BOOST: float = 1.35
+
+#: Multiplicative penalty applied when the document's memory type does *not*
+#: match any of the requested types (and the caller provided a non-empty set).
+MEMORY_TYPE_PENALTY: float = 0.9
+
+
+# ---------------------------------------------------------------------------
+# Rules loading
+# ---------------------------------------------------------------------------
+
+
+def load_memory_type_map(map_file: Path | None = None) -> dict[str, Any]:
+    """Load memory-type classification rules from a JSON file.
+
+    Returns an empty dict when *map_file* is ``None`` or does not exist —
+    callers can safely treat a missing file as "no tagging".
+
+    The expected file schema::
+
+        {
+            "exact_paths":  {"rel/path.md": "identity"},
+            "glob_paths":   {"tasks/*.md": "project"},
+            "task_rules":   {
+                "goal_priorities":  ["high"],
+                "goal_states":      ["active"],
+                "preference_tags":  ["preference"],
+                "project_tags":     ["project"],
+                "default":          "project"
+            }
+        }
+
+    Args:
+        map_file: Absolute or repo-relative path to the JSON rules file.
+    """
+    if map_file is None or not map_file.exists():
+        return {}
+    try:
+        data = json.loads(map_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("Could not load memory-type map from %s: %s", map_file, exc)
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter helpers (inline — avoids cross-module dep on task_retrieval)
+# ---------------------------------------------------------------------------
+
+
+def _extract_frontmatter(content: str) -> dict[str, Any]:
+    """Parse a YAML frontmatter block if present; returns {} on failure."""
+    if not content.startswith("---\n"):
+        return {}
+    end = content.find("\n---\n", 4)
+    if end == -1:
+        return {}
+    frontmatter_text = content[4:end]
+    try:
+        import yaml  # optional — yaml is available in gptme-rag's dependency set
+
+        parsed = yaml.safe_load(frontmatter_text) or {}
+    except Exception:
+        # Fallback: simple key: value regex (no nested structures)
+        import re
+
+        parsed = {k: v for k, v in re.findall(r"^(\w[\w_-]*):\s*(.*)", frontmatter_text, re.M)}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _coerce_string_list(value: Any) -> list[str]:
+    """Normalise a frontmatter value to a list of lowercase strings."""
+    if isinstance(value, str):
+        return [value.strip().lower()] if value.strip() else []
+    if isinstance(value, list):
+        return [item.strip().lower() for item in value if isinstance(item, str) and item.strip()]
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+def classify_memory_type(
+    rel_path: str,
+    metadata: dict[str, Any] | None,
+    rules: dict[str, Any],
+) -> str | None:
+    """Resolve a document's memory type from classification rules + metadata.
+
+    Resolution order:
+    1. ``exact_paths`` — precise path match (highest priority)
+    2. ``glob_paths`` — fnmatch pattern match
+    3. ``task_rules`` — for ``tasks/`` prefixed paths, inspect metadata fields
+
+    Returns one of :data:`SUPPORTED_MEMORY_TYPES` or ``None`` when no rule
+    matches.
+
+    Args:
+        rel_path: Repository-relative path to the document (e.g. ``"tasks/foo.md"``).
+        metadata: Frontmatter metadata dict, if available.  May be ``None``.
+        rules: Classification rules dict as returned by :func:`load_memory_type_map`.
+    """
+    metadata = metadata or {}
+
+    # 1. Exact-path match
+    exact_paths: dict[str, Any] = rules.get("exact_paths", {})
+    if rel_path in exact_paths:
+        memory_type = str(exact_paths[rel_path])
+        return memory_type if memory_type in SUPPORTED_MEMORY_TYPES else None
+
+    # 2. Glob-pattern match
+    for pattern, memory_type in rules.get("glob_paths", {}).items():
+        memory_type_str = str(memory_type)
+        if fnmatch(rel_path, pattern) and memory_type_str in SUPPORTED_MEMORY_TYPES:
+            return memory_type_str
+
+    # 3. Task-specific rules (only for paths under tasks/)
+    if rel_path.startswith("tasks/"):
+        task_rules: dict[str, Any] = rules.get("task_rules", {})
+        priority = str(metadata.get("priority", "")).strip().lower()
+        state = str(metadata.get("state", "")).strip().lower()
+        tags = _coerce_string_list(metadata.get("tags"))
+
+        if priority in task_rules.get("goal_priorities", []):
+            return "goal"
+        if state in task_rules.get("goal_states", []):
+            return "goal"
+        if any(tag in task_rules.get("preference_tags", []) for tag in tags):
+            return "preference"
+        if any(tag in task_rules.get("project_tags", []) for tag in tags):
+            return "project"
+        default_type = task_rules.get("default")
+        return default_type if default_type in SUPPORTED_MEMORY_TYPES else None
+
+    return None
+
+
+def classify_document(
+    rel_path: str,
+    content: str,
+    rules: dict[str, Any],
+) -> str | None:
+    """Classify a document by memory type, extracting frontmatter automatically.
+
+    Convenience wrapper over :func:`classify_memory_type` that parses the
+    document's YAML frontmatter from *content* so callers do not need to parse
+    it themselves.
+
+    Args:
+        rel_path: Repository-relative path to the document.
+        content: Raw document content (may include frontmatter).
+        rules: Classification rules dict.
+    """
+    metadata = _extract_frontmatter(content)
+    return classify_memory_type(rel_path, metadata, rules)
+
+
+# ---------------------------------------------------------------------------
+# Ranking boost
+# ---------------------------------------------------------------------------
+
+
+def weighted_similarity(
+    similarity: float,
+    memory_type: str | None,
+    requested_memory_types: set[str] | None,
+) -> float:
+    """Apply a boost or penalty to *similarity* based on memory-type match.
+
+    When the caller has no preference (``requested_memory_types`` is ``None`` or
+    empty), the similarity is returned unchanged.  When a preference is provided:
+
+    * A match applies :data:`MEMORY_TYPE_BOOST` (default 1.35×), clamped to 1.0.
+    * A miss applies :data:`MEMORY_TYPE_PENALTY` (default 0.9×).
+
+    Args:
+        similarity: Raw cosine similarity score in ``[0, 1]``.
+        memory_type: The document's resolved memory type (or ``None``).
+        requested_memory_types: Set of types the caller wants to boost.
+    """
+    if not requested_memory_types or not memory_type:
+        return similarity
+    if memory_type in requested_memory_types:
+        return min(1.0, similarity * MEMORY_TYPE_BOOST)
+    return similarity * MEMORY_TYPE_PENALTY

--- a/packages/gptme-rag/src/gptme_rag/memory_type.py
+++ b/packages/gptme-rag/src/gptme_rag/memory_type.py
@@ -89,7 +89,7 @@ def load_memory_type_map(map_file: Path | None = None) -> dict[str, Any]:
         return {}
     try:
         data = json.loads(map_file.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         logger.warning("Could not load memory-type map from %s: %s", map_file, exc)
         return {}
     return data if isinstance(data, dict) else {}

--- a/packages/gptme-rag/src/gptme_rag/memory_type.py
+++ b/packages/gptme-rag/src/gptme_rag/memory_type.py
@@ -233,7 +233,11 @@ def classify_memory_type(
     if isinstance(glob_paths, dict):
         for pattern, memory_type in glob_paths.items():
             memory_type_str = str(memory_type)
-            if _glob_match_path(rel_path, pattern) and memory_type_str in SUPPORTED_MEMORY_TYPES:
+            if (
+                isinstance(pattern, str)
+                and _glob_match_path(rel_path, pattern)
+                and memory_type_str in SUPPORTED_MEMORY_TYPES
+            ):
                 return memory_type_str
 
     # 3. Task-specific rules (only for paths under tasks/)
@@ -298,7 +302,7 @@ def weighted_similarity(
     When the caller has no preference (``requested_memory_types`` is ``None`` or
     empty), the similarity is returned unchanged.  When a preference is provided:
 
-    * A match applies :data:`MEMORY_TYPE_BOOST` (default 1.35×), clamped to 1.0.
+    * A match applies :data:`MEMORY_TYPE_BOOST` (default 1.35×).
     * A miss applies :data:`MEMORY_TYPE_PENALTY` (default 0.9×).
 
     Args:
@@ -309,5 +313,5 @@ def weighted_similarity(
     if not requested_memory_types or not memory_type:
         return similarity
     if memory_type in requested_memory_types:
-        return min(1.0, similarity * MEMORY_TYPE_BOOST)
+        return similarity * MEMORY_TYPE_BOOST
     return similarity * MEMORY_TYPE_PENALTY

--- a/packages/gptme-rag/src/gptme_rag/memory_type.py
+++ b/packages/gptme-rag/src/gptme_rag/memory_type.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 
 import json
 import logging
-from fnmatch import fnmatch
+import re
 from pathlib import Path
 from typing import Any
 
@@ -96,6 +96,48 @@ def load_memory_type_map(map_file: Path | None = None) -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Glob helper
+# ---------------------------------------------------------------------------
+
+
+def _glob_match_path(path: str, pattern: str) -> bool:
+    """Match *path* against *pattern*, treating ``**`` as a recursive wildcard.
+
+    Unlike :func:`fnmatch.fnmatch`, this function supports ``**`` to mean
+    "zero or more path segments" (standard shell glob / gitignore semantics).
+    ``*`` still matches within a single directory segment only.
+
+    Examples::
+
+        _glob_match_path("knowledge/design.md", "knowledge/**/*.md")  # True
+        _glob_match_path("knowledge/tech/design.md", "knowledge/**/*.md")  # True
+        _glob_match_path("people/alice.md", "people/*.md")  # True
+    """
+    # Build a regex from the pattern character-by-character.
+    regex_parts: list[str] = []
+    i = 0
+    while i < len(pattern):
+        chunk = pattern[i:]
+        if chunk.startswith("**/"):
+            regex_parts.append("(.*/)?")  # zero or more directories
+            i += 3
+        elif chunk.startswith("**"):
+            regex_parts.append(".*")  # match anything including /
+            i += 2
+        elif pattern[i] == "*":
+            regex_parts.append("[^/]*")  # single-directory wildcard
+            i += 1
+        elif pattern[i] == "?":
+            regex_parts.append("[^/]")
+            i += 1
+        else:
+            regex_parts.append(re.escape(pattern[i]))
+            i += 1
+    regex = "".join(regex_parts)
+    return bool(re.fullmatch(regex, path))
+
+
+# ---------------------------------------------------------------------------
 # Frontmatter helpers (inline — avoids cross-module dep on task_retrieval)
 # ---------------------------------------------------------------------------
 
@@ -106,7 +148,12 @@ def _extract_frontmatter(content: str) -> dict[str, Any]:
         return {}
     end = content.find("\n---\n", 4)
     if end == -1:
-        return {}
+        # Also accept frontmatter whose closing --- has no trailing newline
+        # (common when editors omit the final newline on save).
+        if content.endswith("\n---"):
+            end = len(content) - 4
+        else:
+            return {}
     frontmatter_text = content[4:end]
     try:
         import yaml  # optional — yaml is available in gptme-rag's dependency set
@@ -121,9 +168,14 @@ def _extract_frontmatter(content: str) -> dict[str, Any]:
 
 
 def _coerce_string_list(value: Any) -> list[str]:
-    """Normalise a frontmatter value to a list of lowercase strings."""
+    """Normalise a frontmatter value to a list of lowercase strings.
+
+    Handles both list values and plain strings, including comma-separated
+    strings that YAML leaves as a single string (e.g. ``tags: ai, project``).
+    """
     if isinstance(value, str):
-        return [value.strip().lower()] if value.strip() else []
+        # Split on commas to handle "preference, project" as two tags.
+        return [p.strip().lower() for p in value.split(",") if p.strip()]
     if isinstance(value, list):
         return [item.strip().lower() for item in value if isinstance(item, str) and item.strip()]
     return []
@@ -157,20 +209,24 @@ def classify_memory_type(
     metadata = metadata or {}
 
     # 1. Exact-path match
-    exact_paths: dict[str, Any] = rules.get("exact_paths", {})
-    if rel_path in exact_paths:
+    exact_paths = rules.get("exact_paths", {})
+    if isinstance(exact_paths, dict) and rel_path in exact_paths:
         memory_type = str(exact_paths[rel_path])
         return memory_type if memory_type in SUPPORTED_MEMORY_TYPES else None
 
     # 2. Glob-pattern match
-    for pattern, memory_type in rules.get("glob_paths", {}).items():
-        memory_type_str = str(memory_type)
-        if fnmatch(rel_path, pattern) and memory_type_str in SUPPORTED_MEMORY_TYPES:
-            return memory_type_str
+    glob_paths = rules.get("glob_paths", {})
+    if isinstance(glob_paths, dict):
+        for pattern, memory_type in glob_paths.items():
+            memory_type_str = str(memory_type)
+            if _glob_match_path(rel_path, pattern) and memory_type_str in SUPPORTED_MEMORY_TYPES:
+                return memory_type_str
 
     # 3. Task-specific rules (only for paths under tasks/)
     if rel_path.startswith("tasks/"):
-        task_rules: dict[str, Any] = rules.get("task_rules", {})
+        task_rules = rules.get("task_rules", {})
+        if not isinstance(task_rules, dict):
+            return None
         priority = str(metadata.get("priority", "")).strip().lower()
         state = str(metadata.get("state", "")).strip().lower()
         tags = _coerce_string_list(metadata.get("tags"))

--- a/packages/gptme-rag/src/gptme_rag/memory_type.py
+++ b/packages/gptme-rag/src/gptme_rag/memory_type.py
@@ -144,6 +144,7 @@ def _glob_match_path(path: str, pattern: str) -> bool:
 
 def _extract_frontmatter(content: str) -> dict[str, Any]:
     """Parse a YAML frontmatter block if present; returns {} on failure."""
+    content = content.replace("\r\n", "\n")
     if not content.startswith("---\n"):
         return {}
     end = content.find("\n---\n", 4)

--- a/packages/gptme-rag/src/gptme_rag/memory_type.py
+++ b/packages/gptme-rag/src/gptme_rag/memory_type.py
@@ -161,9 +161,25 @@ def _extract_frontmatter(content: str) -> dict[str, Any]:
 
         parsed = yaml.safe_load(frontmatter_text) or {}
     except Exception:
-        # Fallback: simple key: value regex (no nested structures). Inline YAML
+        # Fallback for simple top-level scalars and string lists. Inline YAML
         # lists stay as strings here and are normalised by _coerce_string_list.
-        parsed = {k: v for k, v in re.findall(r"^(\w[\w_-]*):\s*(.*)", frontmatter_text, re.M)}
+        parsed = {}
+        current_key: str | None = None
+        for line in frontmatter_text.splitlines():
+            key_value = re.fullmatch(r"(\w[\w_-]*):\s*(.*)", line)
+            if key_value:
+                current_key, value = key_value.groups()
+                parsed[current_key] = value
+                continue
+            list_item = re.fullmatch(r"\s+-\s*(.+)", line)
+            if current_key is not None and list_item:
+                existing = parsed[current_key]
+                if not isinstance(existing, list):
+                    existing = [] if not existing else [existing]
+                    parsed[current_key] = existing
+                existing.append(list_item.group(1))
+            elif line.strip():
+                current_key = None
     return parsed if isinstance(parsed, dict) else {}
 
 

--- a/packages/gptme-rag/src/gptme_rag/memory_type.py
+++ b/packages/gptme-rag/src/gptme_rag/memory_type.py
@@ -241,16 +241,18 @@ def classify_memory_type(
         priority = str(metadata.get("priority", "")).strip().lower()
         state = str(metadata.get("state", "")).strip().lower()
         tags = _coerce_string_list(metadata.get("tags"))
+        goal_priorities = _coerce_string_list(task_rules.get("goal_priorities"))
+        goal_states = _coerce_string_list(task_rules.get("goal_states"))
+        preference_tags = _coerce_string_list(task_rules.get("preference_tags"))
+        project_tags = _coerce_string_list(task_rules.get("project_tags"))
 
-        # Use `or []` so that JSON null values fall back to [] rather than
-        # causing `priority in None` TypeError.
-        if priority in (task_rules.get("goal_priorities") or []):
+        if priority in goal_priorities:
             return "goal"
-        if state in (task_rules.get("goal_states") or []):
+        if state in goal_states:
             return "goal"
-        if any(tag in (task_rules.get("preference_tags") or []) for tag in tags):
+        if any(tag in preference_tags for tag in tags):
             return "preference"
-        if any(tag in (task_rules.get("project_tags") or []) for tag in tags):
+        if any(tag in project_tags for tag in tags):
             return "project"
         default_type = task_rules.get("default")
         return default_type if default_type in SUPPORTED_MEMORY_TYPES else None

--- a/packages/gptme-rag/src/gptme_rag/memory_type.py
+++ b/packages/gptme-rag/src/gptme_rag/memory_type.py
@@ -177,7 +177,15 @@ def _coerce_string_list(value: Any) -> list[str]:
         # Split on commas to handle "preference, project" as two tags.
         return [p.strip().lower() for p in value.split(",") if p.strip()]
     if isinstance(value, list):
-        return [item.strip().lower() for item in value if isinstance(item, str) and item.strip()]
+        # Also split each list item on commas — YAML may parse "- preference, project"
+        # as a single list element containing a comma-separated string.
+        return [
+            p.strip().lower()
+            for item in value
+            if isinstance(item, str)
+            for p in item.split(",")
+            if p.strip()
+        ]
     return []
 
 
@@ -231,13 +239,15 @@ def classify_memory_type(
         state = str(metadata.get("state", "")).strip().lower()
         tags = _coerce_string_list(metadata.get("tags"))
 
-        if priority in task_rules.get("goal_priorities", []):
+        # Use `or []` so that JSON null values fall back to [] rather than
+        # causing `priority in None` TypeError.
+        if priority in (task_rules.get("goal_priorities") or []):
             return "goal"
-        if state in task_rules.get("goal_states", []):
+        if state in (task_rules.get("goal_states") or []):
             return "goal"
-        if any(tag in task_rules.get("preference_tags", []) for tag in tags):
+        if any(tag in (task_rules.get("preference_tags") or []) for tag in tags):
             return "preference"
-        if any(tag in task_rules.get("project_tags", []) for tag in tags):
+        if any(tag in (task_rules.get("project_tags") or []) for tag in tags):
             return "project"
         default_type = task_rules.get("default")
         return default_type if default_type in SUPPORTED_MEMORY_TYPES else None

--- a/packages/gptme-rag/tests/test_memory_type.py
+++ b/packages/gptme-rag/tests/test_memory_type.py
@@ -432,46 +432,40 @@ def test_search_memory_types_no_tagged_docs(require_sklearn):
     assert hits[0].document.metadata["source"] == "a.md"
 
 
-def test_search_penalty_pushes_non_matching_below_floor(require_sklearn):
-    """A doc that clears the raw floor but fails penalty may drop below it.
+def test_search_relevance_floor_uses_raw_score_before_penalty(require_sklearn):
+    """A raw-relevant document survives even when its weighted score is lower."""
+    idx = TfidfIndex(relevance_floor=0.95)
+    idx.index([_doc("relevant query terms", "a.md", "project")])
 
-    The test is structured to assert in both branches so it does not silently
-    pass without verifying anything when the penalty score stays above the floor.
-    """
-    floor = 0.3
-    idx = TfidfIndex(relevance_floor=floor)
-    docs = [
-        _doc("relevant query terms here", "a.md", "project"),
-    ]
-    idx.index(docs)
+    hits = idx.search("relevant query terms", n_results=5, memory_types={"goal"})
 
-    # Without memory_types: check raw score clears the floor
-    hits_raw = idx.search("relevant query terms", n_results=5)
-    if not hits_raw:
-        pytest.skip("raw similarity below test floor — adjust test corpus")
+    assert len(hits) == 1
+    assert hits[0].score == pytest.approx(MEMORY_TYPE_PENALTY)
+    assert hits[0].score < idx.relevance_floor
 
-    raw_score = hits_raw[0].score
-    penalised_score = raw_score * MEMORY_TYPE_PENALTY
 
-    # The stored score is rounded to 4 decimal places; the actual floor comparison
-    # in _weighted() uses the unrounded cosine similarity.  Skip when the predicted
-    # penalised score is so close to the floor that rounding (≤5e-5) could flip the
-    # prediction — the assertion below would be unreliable in that boundary zone.
-    ROUNDING_GUARD = 5e-5 * MEMORY_TYPE_PENALTY
-    if abs(penalised_score - floor) < ROUNDING_GUARD:
-        pytest.skip(
-            "penalised score too close to floor boundary — rounding makes prediction unreliable"
-        )
+def test_search_relevance_floor_rejects_raw_score_before_boost(require_sklearn):
+    """A boost must not admit a document below the raw relevance floor."""
+    idx = TfidfIndex(relevance_floor=0.0)
+    idx.index(
+        [
+            _doc("query exact", "exact.md", "project"),
+            _doc("query partial extra terms", "partial.md", "goal"),
+        ]
+    )
 
-    hits_penalised = idx.search("relevant query terms", n_results=5, memory_types={"goal"})
+    # Derive a floor inside the interval where the partial match fails by raw
+    # cosine but would pass after its memory-type boost.
+    unfiltered_hits = idx.search("query exact", n_results=5)
+    raw_scores = {hit.document.metadata["source"]: hit.score for hit in unfiltered_hits}
+    partial_raw = raw_scores["partial.md"]
+    idx.relevance_floor = (partial_raw + partial_raw * MEMORY_TYPE_BOOST) / 2
+    assert partial_raw < idx.relevance_floor
+    assert partial_raw * MEMORY_TYPE_BOOST > idx.relevance_floor
+    assert raw_scores["exact.md"] > idx.relevance_floor
 
-    if penalised_score < floor:
-        # Penalised score drops below the relevance floor — doc must disappear.
-        assert len(hits_penalised) == 0
-    else:
-        # Penalised score stays above the floor — doc survives but with a lower score.
-        assert len(hits_penalised) == 1
-        assert hits_penalised[0].score < raw_score
+    boosted_hits = idx.search("query exact", n_results=5, memory_types={"goal"})
+    assert [hit.document.metadata["source"] for hit in boosted_hits] == ["exact.md"]
 
 
 def test_search_unknown_doc_memory_type_not_penalised(require_sklearn):

--- a/packages/gptme-rag/tests/test_memory_type.py
+++ b/packages/gptme-rag/tests/test_memory_type.py
@@ -312,6 +312,23 @@ def test_classify_document_from_crlf_frontmatter(rules: dict):
     assert result == "goal"
 
 
+def test_classify_document_fallback_parses_inline_list(rules: dict, monkeypatch):
+    """The no-PyYAML fallback normalises inline-list brackets before matching."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def import_without_yaml(name, *args, **kwargs):
+        if name == "yaml":
+            raise ImportError("simulated missing optional dependency")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_yaml)
+    content = "---\ntags: [preference, project]\n---\n# My Task"
+
+    assert classify_document("tasks/foo.md", content, rules) == "preference"
+
+
 def test_classify_document_no_frontmatter(rules: dict):
     content = "# Just a document\nno frontmatter here"
     result = classify_document("SOUL.md", content, rules)
@@ -490,7 +507,25 @@ def test_search_relevance_floor_rejects_raw_score_before_boost(require_sklearn):
 
     boosted_hits = idx.search("query exact", n_results=5, memory_types={"goal"})
     assert [hit.document.metadata["source"] for hit in boosted_hits] == ["exact.md"]
-    assert [hit.rank for hit in boosted_hits] == [0]
+
+
+def test_search_default_rank_preserves_filtered_candidate_position(require_sklearn):
+    """Default search keeps the historical full-candidate rank semantics."""
+    idx = TfidfIndex(relevance_floor=0.0)
+    idx.index(
+        [
+            _doc("same query exact", "excluded.md"),
+            _doc("same query", "included.md"),
+        ]
+    )
+
+    # The first document is the unambiguous top candidate. Exclude it and verify
+    # the surviving candidate retains its original position.
+    hits = idx.search("same query exact", n_results=5, exclude_paths={"excluded.md"})
+
+    assert len(hits) == 1
+    assert hits[0].document.metadata["source"] == "included.md"
+    assert hits[0].rank == 1
 
 
 def test_search_unknown_doc_memory_type_not_penalised(require_sklearn):

--- a/packages/gptme-rag/tests/test_memory_type.py
+++ b/packages/gptme-rag/tests/test_memory_type.py
@@ -113,8 +113,19 @@ def test_classify_glob_people(rules: dict):
 
 
 def test_classify_glob_knowledge(rules: dict):
-    # Matches knowledge/**/*.md
+    # Matches knowledge/**/*.md with one intermediate directory
     result = classify_memory_type("knowledge/technical/design.md", {}, rules)
+    assert result == "project"
+
+
+def test_classify_glob_knowledge_direct_child(rules: dict):
+    """Files directly under knowledge/ must match knowledge/**/*.md.
+
+    fnmatch does not support ** as a zero-or-more-directories wildcard, so
+    'knowledge/**/*.md' would not match 'knowledge/design.md' with plain
+    fnmatch. The _glob_match_path helper is required.
+    """
+    result = classify_memory_type("knowledge/design.md", {}, rules)
     assert result == "project"
 
 
@@ -132,6 +143,25 @@ def test_classify_glob_first_match_wins():
     }
     result = classify_memory_type("tasks/foo.md", {}, rules)
     assert result in SUPPORTED_MEMORY_TYPES
+
+
+def test_classify_malformed_exact_paths_list():
+    """Malformed rules where exact_paths is a list must not raise TypeError."""
+    rules = {"exact_paths": ["SOUL.md", "ABOUT.md"]}
+    # Should not raise; falls through to glob/task rules and returns None
+    assert classify_memory_type("SOUL.md", {}, rules) is None
+
+
+def test_classify_malformed_glob_paths_list():
+    """Malformed rules where glob_paths is a list must not raise TypeError."""
+    rules = {"glob_paths": ["tasks/*.md"]}
+    assert classify_memory_type("tasks/foo.md", {}, rules) is None
+
+
+def test_classify_malformed_task_rules_list():
+    """Malformed rules where task_rules is a list must not raise TypeError."""
+    rules = {"task_rules": ["goal_priorities"]}
+    assert classify_memory_type("tasks/foo.md", {"priority": "high"}, rules) is None
 
 
 # ---------------------------------------------------------------------------
@@ -174,6 +204,16 @@ def test_classify_task_tags_as_string(rules: dict):
     assert result == "preference"
 
 
+def test_classify_task_tags_comma_separated_string(rules: dict):
+    """Tags given as a comma-separated string must be split on commas.
+
+    YAML sometimes leaves 'tags: preference, project' as a single string
+    rather than a list.  _coerce_string_list must split on commas.
+    """
+    result = classify_memory_type("tasks/foo.md", {"tags": "preference, project"}, rules)
+    assert result == "preference"
+
+
 def test_classify_none_metadata(rules: dict):
     """Passing None for metadata must not raise."""
     result = classify_memory_type("SOUL.md", None, rules)
@@ -183,6 +223,17 @@ def test_classify_none_metadata(rules: dict):
 # ---------------------------------------------------------------------------
 # classify_document (content-based)
 # ---------------------------------------------------------------------------
+
+
+def test_classify_document_frontmatter_no_trailing_newline(rules: dict):
+    """Frontmatter blocks without a trailing newline after closing --- must parse.
+
+    _extract_frontmatter previously required '\\n---\\n' and would return {}
+    for files saved without a final newline (ending with '\\n---').
+    """
+    content = "---\npriority: high\nstate: active\n---"  # no trailing newline
+    result = classify_document("tasks/foo.md", content, rules)
+    assert result == "goal"
 
 
 def test_classify_document_from_frontmatter(rules: dict):
@@ -249,12 +300,24 @@ def test_weighted_sim_multi_type_match():
 # ---------------------------------------------------------------------------
 
 
-sklearn = pytest.importorskip("sklearn")
+# Guard sklearn-dependent imports so pure-Python tests above are not skipped
+# when scikit-learn is absent.  Only the TfidfIndex integration tests need it.
+try:
+    from gptme_rag.lexical import TfidfIndex
 
-from pathlib import Path  # noqa: E402 — already imported above but import guard requires this
+    _SKLEARN_AVAILABLE = True
+except ImportError:
+    TfidfIndex = None  # type: ignore[assignment,misc]
+    _SKLEARN_AVAILABLE = False
 
-from gptme_rag.indexing.document import Document  # noqa: E402
-from gptme_rag.lexical import TfidfIndex  # noqa: E402
+from gptme_rag.indexing.document import Document
+
+
+@pytest.fixture()
+def require_sklearn():
+    """Skip the calling test if scikit-learn (and thus TfidfIndex) is not installed."""
+    if not _SKLEARN_AVAILABLE:
+        pytest.skip("scikit-learn is not installed (pip install gptme-rag[lexical])")
 
 
 def _doc(text: str, source: str, memory_type: str | None = None) -> Document:
@@ -264,7 +327,7 @@ def _doc(text: str, source: str, memory_type: str | None = None) -> Document:
     return Document(content=text, metadata=metadata, source_path=Path(source))
 
 
-def test_search_without_memory_types_unchanged():
+def test_search_without_memory_types_unchanged(require_sklearn):
     """Without memory_types, search() behaves exactly as before."""
     idx = TfidfIndex()
     docs = [
@@ -278,7 +341,7 @@ def test_search_without_memory_types_unchanged():
     assert all(h.score > 0 for h in hits)
 
 
-def test_search_boost_reranks_matching_memory_type():
+def test_search_boost_reranks_matching_memory_type(require_sklearn):
     """When two docs have equal raw similarity, the boosted one must rank first.
 
     Using docs with identical content ensures the raw TF-IDF score is the same,
@@ -305,7 +368,7 @@ def test_search_boost_reranks_matching_memory_type():
     assert hits_project[0].score > hits_project[1].score
 
 
-def test_search_memory_types_unknown_type_ignored():
+def test_search_memory_types_unknown_type_ignored(require_sklearn):
     """Unknown types in memory_types must not raise; they are silently filtered."""
     idx = TfidfIndex()
     idx.index([_doc("hello world", "a.md", "goal")])
@@ -314,7 +377,7 @@ def test_search_memory_types_unknown_type_ignored():
     assert len(hits) == 1
 
 
-def test_search_memory_types_no_tagged_docs():
+def test_search_memory_types_no_tagged_docs(require_sklearn):
     """memory_types param is safe when no documents carry a memory_type tag."""
     idx = TfidfIndex()
     idx.index([_doc("hello world", "a.md")])  # no memory_type
@@ -323,7 +386,7 @@ def test_search_memory_types_no_tagged_docs():
     assert hits[0].document.metadata["source"] == "a.md"
 
 
-def test_search_penalty_pushes_non_matching_below_floor():
+def test_search_penalty_pushes_non_matching_below_floor(require_sklearn):
     """A doc that clears the raw floor but fails penalty may drop below it.
 
     The test is structured to assert in both branches so it does not silently
@@ -365,7 +428,7 @@ def test_search_penalty_pushes_non_matching_below_floor():
         assert hits_penalised[0].score < raw_score
 
 
-def test_search_unknown_doc_memory_type_not_penalised():
+def test_search_unknown_doc_memory_type_not_penalised(require_sklearn):
     """A doc with an unrecognised memory_type label is ranked by raw cosine,
     not penalised.  This ensures typos or older labels don't silently downrank
     documents that the caller never intended to penalise."""

--- a/packages/gptme-rag/tests/test_memory_type.py
+++ b/packages/gptme-rag/tests/test_memory_type.py
@@ -8,7 +8,6 @@ import pytest
 from gptme_rag.memory_type import (
     MEMORY_TYPE_BOOST,
     MEMORY_TYPE_PENALTY,
-    SUPPORTED_MEMORY_TYPES,
     classify_document,
     classify_memory_type,
     load_memory_type_map,
@@ -224,9 +223,7 @@ def test_classify_task_tags_list_with_comma_separated_item(rules: dict):
     YAML '- preference, project' parses to the list ['preference, project'];
     the list branch of _coerce_string_list must also split on commas.
     """
-    result = classify_memory_type(
-        "tasks/foo.md", {"tags": ["preference, project"]}, rules
-    )
+    result = classify_memory_type("tasks/foo.md", {"tags": ["preference, project"]}, rules)
     assert result == "preference"
 
 

--- a/packages/gptme-rag/tests/test_memory_type.py
+++ b/packages/gptme-rag/tests/test_memory_type.py
@@ -288,6 +288,12 @@ def test_classify_document_from_frontmatter(rules: dict):
     assert result == "goal"
 
 
+def test_classify_document_from_crlf_frontmatter(rules: dict):
+    content = "---\r\npriority: high\r\nstate: active\r\n---\r\n# My Task"
+    result = classify_document("tasks/foo.md", content, rules)
+    assert result == "goal"
+
+
 def test_classify_document_no_frontmatter(rules: dict):
     content = "# Just a document\nno frontmatter here"
     result = classify_document("SOUL.md", content, rules)

--- a/packages/gptme-rag/tests/test_memory_type.py
+++ b/packages/gptme-rag/tests/test_memory_type.py
@@ -102,6 +102,20 @@ def test_classify_unsupported_type_exact_path_returns_none():
     assert classify_memory_type("foo.md", {}, bad_rules) is None
 
 
+def test_classify_unsupported_exact_path_type_falls_through_to_glob():
+    """A typo in exact_paths must not block a matching glob rule.
+
+    When exact_paths maps a path to an unsupported type (e.g. a typo like
+    ``"identiy"``) the function must fall through to glob_paths and return the
+    valid type found there, rather than short-circuiting to ``None``.
+    """
+    rules = {
+        "exact_paths": {"people/alice.md": "identiy"},  # typo
+        "glob_paths": {"people/*.md": "preference"},
+    }
+    assert classify_memory_type("people/alice.md", {}, rules) == "preference"
+
+
 # ---------------------------------------------------------------------------
 # classify_memory_type — glob paths
 # ---------------------------------------------------------------------------

--- a/packages/gptme-rag/tests/test_memory_type.py
+++ b/packages/gptme-rag/tests/test_memory_type.py
@@ -1,0 +1,344 @@
+"""Tests for gptme_rag.memory_type — classification and ranking boost."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gptme_rag.memory_type import (
+    MEMORY_TYPE_BOOST,
+    MEMORY_TYPE_PENALTY,
+    SUPPORTED_MEMORY_TYPES,
+    classify_document,
+    classify_memory_type,
+    load_memory_type_map,
+    weighted_similarity,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def rules() -> dict:
+    """Minimal but representative rules dict."""
+    return {
+        "exact_paths": {
+            "SOUL.md": "identity",
+            "ABOUT.md": "identity",
+            "GOALS.md": "goal",
+        },
+        "glob_paths": {
+            "people/*.md": "preference",
+            "knowledge/**/*.md": "project",
+        },
+        "task_rules": {
+            "goal_priorities": ["high"],
+            "goal_states": ["active"],
+            "preference_tags": ["preference"],
+            "project_tags": ["project"],
+            "default": "project",
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# load_memory_type_map
+# ---------------------------------------------------------------------------
+
+
+def test_load_missing_file_returns_empty(tmp_path: Path):
+    result = load_memory_type_map(tmp_path / "nonexistent.json")
+    assert result == {}
+
+
+def test_load_none_returns_empty():
+    result = load_memory_type_map(None)
+    assert result == {}
+
+
+def test_load_valid_file(tmp_path: Path, rules: dict):
+    p = tmp_path / "rules.json"
+    p.write_text(json.dumps(rules), encoding="utf-8")
+    loaded = load_memory_type_map(p)
+    assert loaded["exact_paths"]["SOUL.md"] == "identity"
+    assert "task_rules" in loaded
+
+
+def test_load_malformed_json_returns_empty(tmp_path: Path):
+    p = tmp_path / "bad.json"
+    p.write_text("{not valid json", encoding="utf-8")
+    assert load_memory_type_map(p) == {}
+
+
+def test_load_non_dict_json_returns_empty(tmp_path: Path):
+    p = tmp_path / "list.json"
+    p.write_text('["a","b"]', encoding="utf-8")
+    assert load_memory_type_map(p) == {}
+
+
+# ---------------------------------------------------------------------------
+# classify_memory_type — exact paths
+# ---------------------------------------------------------------------------
+
+
+def test_classify_exact_path_identity(rules: dict):
+    assert classify_memory_type("SOUL.md", {}, rules) == "identity"
+    assert classify_memory_type("ABOUT.md", {}, rules) == "identity"
+
+
+def test_classify_exact_path_goal(rules: dict):
+    assert classify_memory_type("GOALS.md", {}, rules) == "goal"
+
+
+def test_classify_unknown_path_returns_none(rules: dict):
+    assert classify_memory_type("README.md", {}, rules) is None
+
+
+def test_classify_unsupported_type_exact_path_returns_none():
+    """An exact_path entry with an unrecognised type is rejected."""
+    bad_rules = {"exact_paths": {"foo.md": "unsupported_type"}}
+    assert classify_memory_type("foo.md", {}, bad_rules) is None
+
+
+# ---------------------------------------------------------------------------
+# classify_memory_type — glob paths
+# ---------------------------------------------------------------------------
+
+
+def test_classify_glob_people(rules: dict):
+    assert classify_memory_type("people/alice.md", {}, rules) == "preference"
+
+
+def test_classify_glob_knowledge(rules: dict):
+    # Matches knowledge/**/*.md
+    result = classify_memory_type("knowledge/technical/design.md", {}, rules)
+    assert result == "project"
+
+
+def test_classify_glob_no_match(rules: dict):
+    assert classify_memory_type("scripts/build.sh", {}, rules) is None
+
+
+def test_classify_glob_first_match_wins():
+    """When multiple glob patterns match, first match in iteration order wins."""
+    rules = {
+        "glob_paths": {
+            "tasks/*.md": "goal",
+            "tasks/special/*.md": "preference",  # more specific but second
+        }
+    }
+    result = classify_memory_type("tasks/foo.md", {}, rules)
+    assert result in SUPPORTED_MEMORY_TYPES
+
+
+# ---------------------------------------------------------------------------
+# classify_memory_type — task rules
+# ---------------------------------------------------------------------------
+
+
+def test_classify_task_by_priority(rules: dict):
+    assert classify_memory_type("tasks/foo.md", {"priority": "high"}, rules) == "goal"
+
+
+def test_classify_task_by_state(rules: dict):
+    assert classify_memory_type("tasks/foo.md", {"state": "active"}, rules) == "goal"
+
+
+def test_classify_task_by_preference_tag(rules: dict):
+    result = classify_memory_type("tasks/foo.md", {"tags": ["preference"]}, rules)
+    assert result == "preference"
+
+
+def test_classify_task_by_project_tag(rules: dict):
+    result = classify_memory_type("tasks/foo.md", {"tags": ["project"]}, rules)
+    assert result == "project"
+
+
+def test_classify_task_default(rules: dict):
+    # No matching sub-rule → falls through to task_rules["default"]
+    result = classify_memory_type("tasks/foo.md", {"priority": "low"}, rules)
+    assert result == "project"  # rules["task_rules"]["default"]
+
+
+def test_classify_task_no_rules():
+    rules = {}
+    assert classify_memory_type("tasks/foo.md", {}, rules) is None
+
+
+def test_classify_task_tags_as_string(rules: dict):
+    """Tags given as a bare string should still match."""
+    result = classify_memory_type("tasks/foo.md", {"tags": "preference"}, rules)
+    assert result == "preference"
+
+
+def test_classify_none_metadata(rules: dict):
+    """Passing None for metadata must not raise."""
+    result = classify_memory_type("SOUL.md", None, rules)
+    assert result == "identity"
+
+
+# ---------------------------------------------------------------------------
+# classify_document (content-based)
+# ---------------------------------------------------------------------------
+
+
+def test_classify_document_from_frontmatter(rules: dict):
+    content = "---\npriority: high\nstate: active\n---\n# My Task\nsome content"
+    result = classify_document("tasks/foo.md", content, rules)
+    assert result == "goal"
+
+
+def test_classify_document_no_frontmatter(rules: dict):
+    content = "# Just a document\nno frontmatter here"
+    result = classify_document("SOUL.md", content, rules)
+    assert result == "identity"  # exact_path match overrides content
+
+
+def test_classify_document_empty_content(rules: dict):
+    result = classify_document("SOUL.md", "", rules)
+    assert result == "identity"
+
+
+# ---------------------------------------------------------------------------
+# weighted_similarity
+# ---------------------------------------------------------------------------
+
+
+def test_weighted_sim_no_requested_types():
+    assert weighted_similarity(0.5, "goal", None) == 0.5
+    assert weighted_similarity(0.5, "goal", set()) == 0.5
+
+
+def test_weighted_sim_no_memory_type():
+    assert weighted_similarity(0.5, None, {"goal"}) == 0.5
+
+
+def test_weighted_sim_boost_on_match():
+    score = weighted_similarity(0.5, "goal", {"goal"})
+    assert score == pytest.approx(0.5 * MEMORY_TYPE_BOOST)
+    assert score > 0.5
+
+
+def test_weighted_sim_penalty_on_mismatch():
+    score = weighted_similarity(0.5, "project", {"goal"})
+    assert score == pytest.approx(0.5 * MEMORY_TYPE_PENALTY)
+    assert score < 0.5
+
+
+def test_weighted_sim_clamp_at_one():
+    """Boosting a high score must not exceed 1.0."""
+    score = weighted_similarity(0.99, "identity", {"identity"})
+    assert score <= 1.0
+
+
+def test_weighted_sim_boost_requires_match_in_set():
+    score = weighted_similarity(0.5, "identity", {"goal", "preference"})
+    assert score == pytest.approx(0.5 * MEMORY_TYPE_PENALTY)
+
+
+def test_weighted_sim_multi_type_match():
+    score = weighted_similarity(0.5, "identity", {"identity", "goal"})
+    assert score == pytest.approx(min(1.0, 0.5 * MEMORY_TYPE_BOOST))
+
+
+# ---------------------------------------------------------------------------
+# Integration: TfidfIndex.search() with memory_types
+# ---------------------------------------------------------------------------
+
+
+sklearn = pytest.importorskip("sklearn")
+
+from pathlib import Path  # noqa: E402 — already imported above but import guard requires this
+
+from gptme_rag.indexing.document import Document  # noqa: E402
+from gptme_rag.lexical import TfidfIndex  # noqa: E402
+
+
+def _doc(text: str, source: str, memory_type: str | None = None) -> Document:
+    metadata: dict = {"source": source}
+    if memory_type is not None:
+        metadata["memory_type"] = memory_type
+    return Document(content=text, metadata=metadata, source_path=Path(source))
+
+
+def test_search_without_memory_types_unchanged():
+    """Without memory_types, search() behaves exactly as before."""
+    idx = TfidfIndex()
+    docs = [
+        _doc("retry_backoff max_attempts", "a.md", "goal"),
+        _doc("retry_backoff implementation", "b.md", "project"),
+    ]
+    idx.index(docs)
+    hits = idx.search("retry_backoff", n_results=5)
+    assert len(hits) == 2
+    # Raw-cosine ranking — both docs match, scores unrestricted
+    assert all(h.score > 0 for h in hits)
+
+
+def test_search_boost_reranks_matching_memory_type():
+    """When two docs have equal raw similarity, the boosted one must rank first.
+
+    Using docs with identical content ensures the raw TF-IDF score is the same,
+    so only the memory-type boost/penalty determines the final ranking — making
+    the expected order deterministic regardless of corpus internals.
+    """
+    idx = TfidfIndex(relevance_floor=0.0)
+
+    docs = [
+        _doc("autonomous agent session work", "a.md", "project"),
+        _doc("autonomous agent session work", "b.md", "goal"),
+    ]
+    idx.index(docs)
+
+    # With goal boost: b.md gets 1.35× boost → must rank above a.md
+    hits_goal = idx.search("autonomous agent", n_results=5, memory_types={"goal"})
+    assert hits_goal[0].document.metadata["source"] == "b.md"
+    # The winning score must reflect the boost
+    assert hits_goal[0].score > hits_goal[1].score
+
+    # With project boost: a.md gets 1.35× boost → must rank above b.md
+    hits_project = idx.search("autonomous agent", n_results=5, memory_types={"project"})
+    assert hits_project[0].document.metadata["source"] == "a.md"
+    assert hits_project[0].score > hits_project[1].score
+
+
+def test_search_memory_types_unknown_type_ignored():
+    """Unknown types in memory_types must not raise; they are silently filtered."""
+    idx = TfidfIndex()
+    idx.index([_doc("hello world", "a.md", "goal")])
+    hits = idx.search("hello", n_results=5, memory_types={"unknown_type"})
+    # unknown_type is not in SUPPORTED_MEMORY_TYPES → treated as no preference
+    assert len(hits) == 1
+
+
+def test_search_memory_types_no_tagged_docs():
+    """memory_types param is safe when no documents carry a memory_type tag."""
+    idx = TfidfIndex()
+    idx.index([_doc("hello world", "a.md")])  # no memory_type
+    hits = idx.search("hello", n_results=5, memory_types={"goal"})
+    assert len(hits) == 1
+    assert hits[0].document.metadata["source"] == "a.md"
+
+
+def test_search_penalty_pushes_non_matching_below_floor():
+    """A doc that clears the raw floor but fails penalty may drop below it."""
+    floor = 0.3
+    idx = TfidfIndex(relevance_floor=floor)
+    docs = [
+        _doc("relevant query terms here", "a.md", "project"),
+    ]
+    idx.index(docs)
+
+    # Without memory_types: check raw score clears the floor
+    hits_raw = idx.search("relevant query terms", n_results=5)
+    if not hits_raw:
+        pytest.skip("raw similarity below test floor — adjust test corpus")
+
+    raw_score = hits_raw[0].score
+    # Apply penalty: if raw * PENALTY < floor, the doc should drop out
+    if raw_score * MEMORY_TYPE_PENALTY < floor:
+        hits_penalised = idx.search("relevant query terms", n_results=5, memory_types={"goal"})
+        assert len(hits_penalised) == 0

--- a/packages/gptme-rag/tests/test_memory_type.py
+++ b/packages/gptme-rag/tests/test_memory_type.py
@@ -175,6 +175,12 @@ def test_classify_malformed_glob_paths_list():
     assert classify_memory_type("tasks/foo.md", {}, rules) is None
 
 
+def test_classify_malformed_glob_pattern_key():
+    """Caller-supplied rules with non-string glob keys must fail soft."""
+    rules = {"glob_paths": {1: "project"}}
+    assert classify_memory_type("tasks/foo.md", {}, rules) is None
+
+
 def test_classify_malformed_task_rules_list():
     """Malformed rules where task_rules is a list must not raise TypeError."""
     rules = {"task_rules": ["goal_priorities"]}
@@ -366,10 +372,13 @@ def test_weighted_sim_penalty_on_mismatch():
     assert score < 0.5
 
 
-def test_weighted_sim_clamp_at_one():
-    """Boosting a high score must not exceed 1.0."""
-    score = weighted_similarity(0.99, "identity", {"identity"})
-    assert score <= 1.0
+def test_weighted_sim_preserves_high_score_ordering():
+    """Boosting must not clamp distinct high scores to the same value."""
+    lower = weighted_similarity(0.8, "identity", {"identity"})
+    higher = weighted_similarity(0.9, "identity", {"identity"})
+    assert lower == pytest.approx(0.8 * MEMORY_TYPE_BOOST)
+    assert higher == pytest.approx(0.9 * MEMORY_TYPE_BOOST)
+    assert higher > lower
 
 
 def test_weighted_sim_boost_requires_match_in_set():
@@ -379,7 +388,7 @@ def test_weighted_sim_boost_requires_match_in_set():
 
 def test_weighted_sim_multi_type_match():
     score = weighted_similarity(0.5, "identity", {"identity", "goal"})
-    assert score == pytest.approx(min(1.0, 0.5 * MEMORY_TYPE_BOOST))
+    assert score == pytest.approx(0.5 * MEMORY_TYPE_BOOST)
 
 
 # ---------------------------------------------------------------------------
@@ -453,6 +462,26 @@ def test_search_boost_reranks_matching_memory_type(require_sklearn):
     hits_project = idx.search("autonomous agent", n_results=5, memory_types={"project"})
     assert hits_project[0].document.metadata["source"] == "a.md"
     assert hits_project[0].score > hits_project[1].score
+
+
+def test_search_boost_preserves_raw_order_above_one(require_sklearn):
+    """Two matching high-similarity docs remain ordered by raw relevance."""
+    idx = TfidfIndex(relevance_floor=0.0)
+    idx.index(
+        [
+            _doc("query exact extra", "lower.md", "goal"),
+            _doc("query exact", "higher.md", "goal"),
+        ]
+    )
+
+    hits = idx.search("query exact", n_results=5, memory_types={"goal"})
+
+    assert [hit.document.metadata["source"] for hit in hits] == [
+        "higher.md",
+        "lower.md",
+    ]
+    assert hits[0].score > 1.0
+    assert hits[0].score > hits[1].score
 
 
 def test_search_memory_types_unknown_type_ignored(require_sklearn):

--- a/packages/gptme-rag/tests/test_memory_type.py
+++ b/packages/gptme-rag/tests/test_memory_type.py
@@ -134,15 +134,19 @@ def test_classify_glob_no_match(rules: dict):
 
 
 def test_classify_glob_first_match_wins():
-    """When multiple glob patterns match, first match in iteration order wins."""
+    """When multiple glob patterns match, first match in iteration order wins.
+
+    Uses two overlapping patterns — tasks/*.md and tasks/f*.md — that both
+    match 'tasks/foo.md', so the assertion can pin the exact expected type.
+    """
     rules = {
         "glob_paths": {
             "tasks/*.md": "goal",
-            "tasks/special/*.md": "preference",  # more specific but second
+            "tasks/f*.md": "preference",  # also matches tasks/foo.md, but second
         }
     }
     result = classify_memory_type("tasks/foo.md", {}, rules)
-    assert result in SUPPORTED_MEMORY_TYPES
+    assert result == "goal"  # first pattern in dict wins
 
 
 def test_classify_malformed_exact_paths_list():
@@ -212,6 +216,37 @@ def test_classify_task_tags_comma_separated_string(rules: dict):
     """
     result = classify_memory_type("tasks/foo.md", {"tags": "preference, project"}, rules)
     assert result == "preference"
+
+
+def test_classify_task_tags_list_with_comma_separated_item(rules: dict):
+    """A YAML list item that is itself comma-separated must be split.
+
+    YAML '- preference, project' parses to the list ['preference, project'];
+    the list branch of _coerce_string_list must also split on commas.
+    """
+    result = classify_memory_type(
+        "tasks/foo.md", {"tags": ["preference, project"]}, rules
+    )
+    assert result == "preference"
+
+
+def test_classify_task_null_rule_value():
+    """JSON null values in task_rules must not raise TypeError.
+
+    `{"goal_priorities": null}` is valid JSON; task_rules.get() returns None,
+    and `priority in None` would raise TypeError without the `or []` guard.
+    """
+    rules = {
+        "task_rules": {
+            "goal_priorities": None,  # null in JSON
+            "goal_states": None,
+            "preference_tags": None,
+            "project_tags": None,
+            "default": "project",
+        }
+    }
+    result = classify_memory_type("tasks/foo.md", {"priority": "high"}, rules)
+    assert result == "project"  # falls through to default, no TypeError
 
 
 def test_classify_none_metadata(rules: dict):

--- a/packages/gptme-rag/tests/test_memory_type.py
+++ b/packages/gptme-rag/tests/test_memory_type.py
@@ -318,8 +318,9 @@ def test_classify_document_from_crlf_frontmatter(rules: dict):
     assert result == "goal"
 
 
-def test_classify_document_fallback_parses_inline_list(rules: dict, monkeypatch):
-    """The no-PyYAML fallback normalises inline-list brackets before matching."""
+@pytest.fixture()
+def without_yaml(monkeypatch):
+    """Force frontmatter parsing through the no-PyYAML fallback."""
     import builtins
 
     real_import = builtins.__import__
@@ -330,7 +331,18 @@ def test_classify_document_fallback_parses_inline_list(rules: dict, monkeypatch)
         return real_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", import_without_yaml)
+
+
+def test_classify_document_fallback_parses_inline_list(rules: dict, without_yaml):
+    """The no-PyYAML fallback normalises inline-list brackets before matching."""
     content = "---\ntags: [preference, project]\n---\n# My Task"
+
+    assert classify_document("tasks/foo.md", content, rules) == "preference"
+
+
+def test_classify_document_fallback_parses_block_list(rules: dict, without_yaml):
+    """The no-PyYAML fallback preserves indented block-list values."""
+    content = "---\ntags:\n  - preference\n  - project\n---\n# My Task"
 
     assert classify_document("tasks/foo.md", content, rules) == "preference"
 

--- a/packages/gptme-rag/tests/test_memory_type.py
+++ b/packages/gptme-rag/tests/test_memory_type.py
@@ -204,6 +204,24 @@ def test_classify_task_by_project_tag(rules: dict):
     assert result == "project"
 
 
+def test_classify_task_rules_are_case_insensitive():
+    rules = {
+        "task_rules": {
+            "goal_priorities": ["High"],
+            "goal_states": ["ACTIVE"],
+            "preference_tags": ["Preference"],
+            "project_tags": ["PROJECT"],
+        }
+    }
+
+    assert classify_memory_type("tasks/priority.md", {"priority": "high"}, rules) == "goal"
+    assert classify_memory_type("tasks/state.md", {"state": "active"}, rules) == "goal"
+    assert (
+        classify_memory_type("tasks/preference.md", {"tags": ["preference"]}, rules) == "preference"
+    )
+    assert classify_memory_type("tasks/project.md", {"tags": ["project"]}, rules) == "project"
+
+
 def test_classify_task_default(rules: dict):
     # No matching sub-rule → falls through to task_rules["default"]
     result = classify_memory_type("tasks/foo.md", {"priority": "low"}, rules)

--- a/packages/gptme-rag/tests/test_memory_type.py
+++ b/packages/gptme-rag/tests/test_memory_type.py
@@ -490,6 +490,7 @@ def test_search_relevance_floor_rejects_raw_score_before_boost(require_sklearn):
 
     boosted_hits = idx.search("query exact", n_results=5, memory_types={"goal"})
     assert [hit.document.metadata["source"] for hit in boosted_hits] == ["exact.md"]
+    assert [hit.rank for hit in boosted_hits] == [0]
 
 
 def test_search_unknown_doc_memory_type_not_penalised(require_sklearn):

--- a/packages/gptme-rag/tests/test_memory_type.py
+++ b/packages/gptme-rag/tests/test_memory_type.py
@@ -344,6 +344,14 @@ def test_search_penalty_pushes_non_matching_below_floor():
     raw_score = hits_raw[0].score
     penalised_score = raw_score * MEMORY_TYPE_PENALTY
 
+    # The stored score is rounded to 4 decimal places; the actual floor comparison
+    # in _weighted() uses the unrounded cosine similarity.  Skip when the predicted
+    # penalised score is so close to the floor that rounding (≤5e-5) could flip the
+    # prediction — the assertion below would be unreliable in that boundary zone.
+    ROUNDING_GUARD = 5e-5 * MEMORY_TYPE_PENALTY
+    if abs(penalised_score - floor) < ROUNDING_GUARD:
+        pytest.skip("penalised score too close to floor boundary — rounding makes prediction unreliable")
+
     hits_penalised = idx.search("relevant query terms", n_results=5, memory_types={"goal"})
 
     if penalised_score < floor:

--- a/packages/gptme-rag/tests/test_memory_type.py
+++ b/packages/gptme-rag/tests/test_memory_type.py
@@ -324,7 +324,11 @@ def test_search_memory_types_no_tagged_docs():
 
 
 def test_search_penalty_pushes_non_matching_below_floor():
-    """A doc that clears the raw floor but fails penalty may drop below it."""
+    """A doc that clears the raw floor but fails penalty may drop below it.
+
+    The test is structured to assert in both branches so it does not silently
+    pass without verifying anything when the penalty score stays above the floor.
+    """
     floor = 0.3
     idx = TfidfIndex(relevance_floor=floor)
     docs = [
@@ -338,7 +342,35 @@ def test_search_penalty_pushes_non_matching_below_floor():
         pytest.skip("raw similarity below test floor — adjust test corpus")
 
     raw_score = hits_raw[0].score
-    # Apply penalty: if raw * PENALTY < floor, the doc should drop out
-    if raw_score * MEMORY_TYPE_PENALTY < floor:
-        hits_penalised = idx.search("relevant query terms", n_results=5, memory_types={"goal"})
+    penalised_score = raw_score * MEMORY_TYPE_PENALTY
+
+    hits_penalised = idx.search("relevant query terms", n_results=5, memory_types={"goal"})
+
+    if penalised_score < floor:
+        # Penalised score drops below the relevance floor — doc must disappear.
         assert len(hits_penalised) == 0
+    else:
+        # Penalised score stays above the floor — doc survives but with a lower score.
+        assert len(hits_penalised) == 1
+        assert hits_penalised[0].score < raw_score
+
+
+def test_search_unknown_doc_memory_type_not_penalised():
+    """A doc with an unrecognised memory_type label is ranked by raw cosine,
+    not penalised.  This ensures typos or older labels don't silently downrank
+    documents that the caller never intended to penalise."""
+    idx = TfidfIndex()
+    docs = [
+        _doc("hello world query", "typo.md", "typo_type"),  # unknown type
+        _doc("hello world query", "untagged.md"),  # no type
+    ]
+    idx.index(docs)
+
+    # When memory_types={"goal"} is requested, both docs have no matching type.
+    # The one with a typo label must NOT be penalised more than the untagged doc.
+    hits = idx.search("hello world query", n_results=5, memory_types={"goal"})
+    assert len(hits) == 2
+    # Both docs have the same raw similarity; with equal treatment their scores
+    # must be equal (no extra penalty on the unknown-label doc).
+    scores = {h.document.metadata["source"]: h.score for h in hits}
+    assert abs(scores["typo.md"] - scores["untagged.md"]) < 1e-6

--- a/packages/gptme-rag/tests/test_memory_type.py
+++ b/packages/gptme-rag/tests/test_memory_type.py
@@ -449,6 +449,24 @@ def test_search_without_memory_types_unchanged(require_sklearn):
     assert all(h.score > 0 for h in hits)
 
 
+def test_search_without_memory_types_preserves_tie_order(require_sklearn):
+    """Default search retains numpy's historical ordering for tied scores."""
+    idx = TfidfIndex(relevance_floor=0.0)
+    idx.index(
+        [
+            _doc("identical content", "first.md", "goal"),
+            _doc("identical content", "second.md", "project"),
+        ]
+    )
+
+    hits = idx.search("identical", n_results=5)
+
+    assert [hit.document.metadata["source"] for hit in hits] == [
+        "second.md",
+        "first.md",
+    ]
+
+
 def test_search_boost_reranks_matching_memory_type(require_sklearn):
     """When two docs have equal raw similarity, the boosted one must rank first.
 

--- a/packages/gptme-rag/tests/test_memory_type.py
+++ b/packages/gptme-rag/tests/test_memory_type.py
@@ -350,7 +350,9 @@ def test_search_penalty_pushes_non_matching_below_floor():
     # prediction — the assertion below would be unreliable in that boundary zone.
     ROUNDING_GUARD = 5e-5 * MEMORY_TYPE_PENALTY
     if abs(penalised_score - floor) < ROUNDING_GUARD:
-        pytest.skip("penalised score too close to floor boundary — rounding makes prediction unreliable")
+        pytest.skip(
+            "penalised score too close to floor boundary — rounding makes prediction unreliable"
+        )
 
     hits_penalised = idx.search("relevant query terms", n_results=5, memory_types={"goal"})
 


### PR DESCRIPTION
## What

Ports the `memory_type` classification + ranking boost from the brain scripts into gptme-rag, as part of upstreaming the ambient memory pipeline.

**Part of the series**: Phase 2.1 (#1465, open), 2.3 (#1440, merged), 2.2 (this PR).

## New module: `gptme_rag/memory_type.py`

Documents in a personal knowledge base serve different roles — some are identity (SOUL.md, ABOUT.md), some are active goals, ongoing projects, or preferences. This module classifies documents by type and adjusts TF-IDF ranking accordingly.

- `load_memory_type_map(path)` — load caller-supplied JSON rules (no hardcoded paths; the brain repo retains its config)
- `classify_memory_type(rel_path, metadata, rules)` — exact path → glob → task-rule resolution
- `classify_document(rel_path, content, rules)` — convenience wrapper that parses YAML frontmatter
- `weighted_similarity(sim, mem_type, requested)` — 1.35× boost on match, 0.9× penalty on mismatch

## `TfidfIndex.search()` integration

Added optional `memory_types: set[str] | None = None` parameter. When set:
- Weighted scores replace raw cosine for sorting (so boosted docs actually rank higher)
- Unknown type labels are silently filtered to `SUPPORTED_MEMORY_TYPES`
- Docs without a `memory_type` metadata key are ranked by raw cosine (no penalty)

## Tests

36 tests in `tests/test_memory_type.py`, all passing:
- `load_memory_type_map`: missing file, malformed JSON, valid file
- `classify_memory_type`: exact paths, glob patterns, task rules (priority/state/tags)
- `classify_document`: frontmatter extraction
- `weighted_similarity`: boost, penalty, clamp, no-op cases
- `TfidfIndex.search()` integration: reranking, unknown types, no-tagged-docs safety

## Source

Brain script: `scripts/build-ambient-memory-index.py` — the `_load_memory_type_map`, `_classify_memory_type`, `_maybe_attach_memory_type`, and `_weighted_similarity` functions.

Generalised for library use: caller supplies the rules dict, no hardcoded file paths.