### PR TITLE
fix(run_item): observe PR effect for every PR-scoped item type

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -1937,10 +1937,11 @@ def run_post_session(
                 f"for {plan.repo}#{plan.number}"
             )
 
-    is_pr_item = bool(PR_OBSERVE_TYPES & set(item.types))
+    is_pr_item = bool(PR_STATE_TYPES & set(item.types))
+    is_pr_observe_item = bool(PR_OBSERVE_TYPES & set(item.types))
 
     # 2. PR-state diff (worker.sh:379-408)
-    if is_pr_item:
+    if is_pr_observe_item:
         try:
             update_record_pr_state(
                 record_file,

--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -131,7 +131,59 @@ from gptme_runloops.worker_records import (
 
 # Item types that enable the PR-state diff / wait-merge / pr-before snapshot
 # steps (worker.sh:72,379,555 — `grep -qwE "pr_update|merge_ready"`).
+#
+# This narrow pair is the *bash* gate. Keep it for parity with the shell
+# executor's wait-and-merge step; it is deliberately NOT the observation gate.
 PR_STATE_TYPES: frozenset[str] = frozenset({"pr_update", "merge_ready"})
+
+# Item types whose `number` addresses a real PR, so a before/after
+# `gh pr view` snapshot is a meaningful observation of whether the dispatch
+# moved anything. This is a strict superset of PR_STATE_TYPES.
+#
+# Every extra member here is emitted by the PR-health poller
+# (scripts/github/pr-merge-health-poll.py -> project-monitoring-gate.sh) and
+# addresses a pull request, but the bash-parity pair above excluded them from
+# observation entirely. The cost is the same class of bug documented on
+# THREAD_DELIVERABLE_TYPES below, one layer over: no snapshot means
+# `run_post_session` returns EFFECT_UNKNOWN, `pm_dispatch_recovery`'s
+# `classify_completion` maps unknown onto CLASS_INEFFECTIVE, the retry budget
+# drains, and PM escalates "PM cannot drive OWNER/REPO#N" about a PR it was
+# visibly driving.
+#
+# Measured on Bob's dispatch ledger 2026-08-20 (1,605 completed dispatches,
+# 7 days), `unknown`-effect rate by item type:
+#
+#     pr_update                          3%   <- observed
+#     merge_ready                        3%   <- observed
+#     greptile_needs_fix                42%
+#     merge_conflict                    68%
+#     reviewer_needs_fix                69%
+#     pr_changes_requested_stale        87%
+#     reviewer_needs_improvement        87%
+#     greptile_convergence_adjudication 93%
+#
+# The two observed types sit at 3%; everything the gate skipped runs 42-93%.
+# gptme/gptme-contrib#1466 is the worked example: a
+# `greptile_convergence_adjudication` item that PM pushed commits and posted
+# review comments on for three rounds, escalated as
+# `retry_budget_exhausted:ineffective`.
+#
+# Types with no PR behind `number` stay out: `master_ci_failure` (workflow run
+# id), `agent_msg_reply` (synthesized 0), `notification` / `assigned_issue`
+# (may address an issue), `erik_decision`, `voice_postcall`, `task_closeout`.
+PR_OBSERVE_TYPES: frozenset[str] = PR_STATE_TYPES | frozenset(
+    {
+        "ci_failure",
+        "greptile_convergence_adjudication",
+        "greptile_needs_fix",
+        "greptile_needs_improvement",
+        "merge_conflict",
+        "pr_changes_requested_stale",
+        "pr_never_checked",
+        "reviewer_needs_fix",
+        "reviewer_needs_improvement",
+    }
+)
 
 # Item types whose `number` addresses a real issue/PR thread, so "did the
 # session reply on the thread?" is a meaningful post-condition
@@ -1576,7 +1628,7 @@ def execute_plan(
         codex_pre = snapshot_codex_rollouts(config.resolved_codex_sessions_dir)
 
     pr_before_json = ""
-    if PR_STATE_TYPES & set(item.types):
+    if PR_OBSERVE_TYPES & set(item.types):
         try:
             proc = hooks.run_cmd(
                 [
@@ -1885,7 +1937,7 @@ def run_post_session(
                 f"for {plan.repo}#{plan.number}"
             )
 
-    is_pr_item = bool(PR_STATE_TYPES & set(item.types))
+    is_pr_item = bool(PR_OBSERVE_TYPES & set(item.types))
 
     # 2. PR-state diff (worker.sh:379-408)
     if is_pr_item:

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -36,6 +36,8 @@ from gptme_runloops.merge_lifecycle import (
     run_merge_lifecycle,
 )
 from gptme_runloops.run_item import (
+    PR_OBSERVE_TYPES,
+    PR_STATE_TYPES,
     THREAD_DELIVERABLE_TYPES,
     ArcInfo,
     RunItem,
@@ -1819,6 +1821,65 @@ def test_execute_plan_pr_before_snapshot_only_for_pr_items(tmp_path) -> None:
     outcome = execute_plan(plan, item, config, hooks)
     assert outcome.pr_before_json == ""
     assert [c for c in run_cmd.calls if c["argv"][0] == "gh"] == []
+
+
+@pytest.mark.parametrize(
+    "item_type",
+    sorted(PR_OBSERVE_TYPES),
+)
+def test_execute_plan_pr_before_snapshot_for_every_pr_scoped_type(
+    tmp_path, item_type
+) -> None:
+    """Every PR-scoped item type must take a before-snapshot.
+
+    Regression guard for the effect-observation gap: when a PR-addressed type
+    is missing from the observation gate, `run_post_session` can only return
+    EFFECT_UNKNOWN, which `pm_dispatch_recovery.classify_completion` maps onto
+    CLASS_INEFFECTIVE — draining the retry budget and escalating PRs that PM
+    was actually driving (gptme/gptme-contrib#1466).
+    """
+    config = make_config(tmp_path)
+    run_cmd = FakeRunCmd()
+    run_cmd.on("gh", stdout='{"state": "OPEN", "headRefOid": "aa"}')
+    hooks = make_hooks(run_cmd=run_cmd)
+    item = make_item(types=[item_type], number=7)
+    plan = plan_item(
+        item,
+        index=1,
+        config=config,
+        backend="codex",
+        model="",
+        monitoring_rules="",
+        lifecycle=LifecycleResult(),
+        arc=None,
+        run_salt=1,
+        records_dir=tmp_path,
+        runner=hooks.runner,
+        sysprompt_file="",
+    )
+    outcome = execute_plan(plan, item, config, hooks)
+    assert (
+        outcome.pr_before_json != ""
+    ), f"{item_type} is in PR_OBSERVE_TYPES but took no before-snapshot"
+    assert any(
+        c["argv"][:3] == ["gh", "pr", "view"] for c in run_cmd.calls
+    ), f"{item_type} did not call `gh pr view`"
+
+
+def test_pr_observe_types_is_superset_of_pr_state_types() -> None:
+    """The observation gate must never be narrower than the bash-parity pair."""
+    assert PR_STATE_TYPES <= PR_OBSERVE_TYPES
+    # Types with no PR behind `number` must stay out, or `gh pr view` is called
+    # with a workflow-run id / synthesized 0 / an issue number.
+    assert not PR_OBSERVE_TYPES & {
+        "agent_msg_reply",
+        "assigned_issue",
+        "erik_decision",
+        "master_ci_failure",
+        "notification",
+        "task_closeout",
+        "voice_postcall",
+    }
 
 
 def test_promote_item_state_copies_matching_files(tmp_path) -> None:


### PR DESCRIPTION
## Problem

PM's effect-observation gate excluded most of the PR-shaped item types it dispatches on.

`PR_STATE_TYPES` held exactly `{pr_update, merge_ready}` — a faithful port of the bash
worker's `grep -qwE "pr_update|merge_ready"`. Every other PR-addressed type skipped the
before/after `gh pr view` snapshot entirely, so `run_post_session` could only ever return
`EFFECT_UNKNOWN` for them.

That is not a metrics-cosmetics problem. The chain:

1. no snapshot → `effect=unknown`
2. `pm_dispatch_recovery.classify_completion` maps unknown → `CLASS_INEFFECTIVE`
3. ineffective drains the retry budget → `retry_exhausted`
4. PM escalates **"PM cannot drive OWNER/REPO#N"** and files an operator task —
   about a PR it was visibly driving.

This is the same failure class already documented on `THREAD_DELIVERABLE_TYPES`
directly below it ("filed a bogus 'PM cannot drive ErikBjare/bob#0' stuck task"),
one layer over.

## Evidence

Measured on Bob's dispatch ledger, 1,605 completed dispatches over 7 days
(2026-08-13 → 2026-08-20). `unknown`-effect rate by item type:

| item type | in old gate | n | `unknown` |
|---|---|---|---|
| `pr_update` | ✅ | 71 | **3%** |
| `merge_ready` | ✅ | 270 | **3%** |
| `greptile_needs_fix` | ❌ | 156 | 42% |
| `ci_failure` | ❌ | 91 | 53% |
| `merge_conflict` | ❌ | 34 | 68% |
| `reviewer_needs_fix` | ❌ | 98 | 69% |
| `pr_changes_requested_stale` | ❌ | 31 | 87% |
| `reviewer_needs_improvement` | ❌ | 120 | 87% |
| `greptile_convergence_adjudication` | ❌ | 42 | **93%** |

The two observed types sit at 3%. Everything the gate skipped runs 42–93%.
Overall, 640 of 1,605 completed dispatches (40%) recorded `unknown`.

**Worked example:** `gptme/gptme-contrib#1466` is a
`greptile_convergence_adjudication` item. PM pushed commits and posted review
comments on it across three review rounds, then escalated it as
`retry_budget_exhausted:ineffective`. The PR is currently `CLEAN` / `MERGEABLE`
with all checks green.

## Change

- Adds `PR_OBSERVE_TYPES` — a strict superset of `PR_STATE_TYPES` covering every
  type emitted by the PR-health poller (`pr-merge-health-poll.py` →
  `project-monitoring-gate.sh`) that addresses a real pull request.
- Points both observation sites (`execute_plan` pre-snapshot, `run_post_session`
  PR-state diff) at the new set.
- Leaves `PR_STATE_TYPES` untouched so the bash executor's **wait-and-merge** gate
  keeps its parity semantics. Widening merge behavior is deliberately out of scope.
- Types with no PR behind `number` stay excluded, or `gh pr view` would be called
  with a workflow-run id / synthesized `0` / an issue number: `master_ci_failure`,
  `agent_msg_reply`, `notification`, `assigned_issue`, `erik_decision`,
  `voice_postcall`, `task_closeout`.

## Tests

- `test_execute_plan_pr_before_snapshot_for_every_pr_scoped_type` — parametrized over
  every member of `PR_OBSERVE_TYPES`; asserts a `gh pr view` snapshot is taken.
  **Verified red first:** with the gate reverted to `PR_STATE_TYPES`, 9 of 11 params
  fail — exactly the previously-excluded types.
- `test_pr_observe_types_is_superset_of_pr_state_types` — pins the superset invariant
  and pins the non-PR types *out*, so a future widening can't start calling
  `gh pr view` with a workflow-run id.

`1044 passed, 1 skipped` for the whole `gptme-runloops` package. `ruff check` clean.

## Known gap (not fixed here)

The **bash** worker has the same narrow gate at
`scripts/github/project-monitoring-worker.sh:72` (pre-snapshot) and `:379`
(PR-state diff) — in Bob's repo, not this one. Line 555 (wait-and-merge) should
stay narrow. Filing separately; that repo is over its PR cap.
