### PR TITLE
feat(activity-summary): slot fallback on quota exhaustion via GPTME_CC_FALLBACK_CREDS

### DIFF
--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -224,6 +224,7 @@ def call_claude_code(
                 )
                 # Attempt fallback slots (GPTME_CC_FALLBACK_CREDS) before raising.
                 last_non_quota_error: subprocess.CalledProcessError | None = None
+                saw_empty_response = False
                 for fb_cred in _fallback_cred_paths:
                     if not fb_cred.exists():
                         logger.debug("Fallback cred file %s not found, skipping", fb_cred)
@@ -232,36 +233,57 @@ def call_claude_code(
                         "Active slot quota exhausted; trying fallback slot: %s",
                         fb_cred.name,
                     )
-                    try:
-                        fb_result = _try_with_credential_file(cmd, prompt, fb_cred, env, timeout)
-                    except (OSError, subprocess.TimeoutExpired) as exc:
-                        logger.warning("Fallback slot %s failed to run: %s", fb_cred.name, exc)
-                        continue
-                    if fb_result.returncode == 0 and fb_result.stdout is not None:
-                        fb_out: str = fb_result.stdout.strip()
-                        if fb_out:
-                            logger.info("Fallback slot %s succeeded", fb_cred.name)
-                            return fb_out
-                    # Check if this fallback slot is also quota-exhausted
-                    fb_combined = (fb_result.stdout or "") + (fb_result.stderr or "")
-                    if any(m.lower() in fb_combined.lower() for m in _QUOTA_EXHAUSTED_MARKERS):
-                        logger.warning("Fallback slot %s also quota-exhausted", fb_cred.name)
-                    else:
-                        logger.warning(
-                            "Fallback slot %s failed (rc=%d): stdout=%s stderr=%s",
-                            fb_cred.name,
-                            fb_result.returncode,
-                            (fb_result.stdout or "")[:200],
-                            (fb_result.stderr or "")[:200],
-                        )
-                        last_non_quota_error = subprocess.CalledProcessError(
-                            fb_result.returncode,
-                            cmd,
-                            fb_result.stdout,
-                            fb_result.stderr,
-                        )
+                    for fb_attempt in range(1, max_retries + 1):
+                        try:
+                            fb_result = _try_with_credential_file(
+                                cmd, prompt, fb_cred, env, timeout
+                            )
+                        except (OSError, subprocess.TimeoutExpired) as exc:
+                            logger.warning("Fallback slot %s failed to run: %s", fb_cred.name, exc)
+                            break
+                        if fb_result.returncode == 0:
+                            fb_out = (fb_result.stdout or "").strip()
+                            if fb_out:
+                                logger.info("Fallback slot %s succeeded", fb_cred.name)
+                                return fb_out
+                            saw_empty_response = True
+                            logger.warning(
+                                "Fallback slot %s returned empty response (attempt %d/%d)",
+                                fb_cred.name,
+                                fb_attempt,
+                                max_retries,
+                            )
+                            if fb_attempt < max_retries:
+                                time.sleep(_RETRY_DELAY_S * fb_attempt)
+                                continue
+                            break
+                        # Check if this fallback slot is also quota-exhausted.
+                        fb_combined = (fb_result.stdout or "") + (fb_result.stderr or "")
+                        if any(m.lower() in fb_combined.lower() for m in _QUOTA_EXHAUSTED_MARKERS):
+                            logger.warning("Fallback slot %s also quota-exhausted", fb_cred.name)
+                        else:
+                            logger.warning(
+                                "Fallback slot %s failed (rc=%d): stdout=%s stderr=%s",
+                                fb_cred.name,
+                                fb_result.returncode,
+                                (fb_result.stdout or "")[:200],
+                                (fb_result.stderr or "")[:200],
+                            )
+                            last_non_quota_error = subprocess.CalledProcessError(
+                                fb_result.returncode,
+                                cmd,
+                                fb_result.stdout,
+                                fb_result.stderr,
+                            )
+                        break
                 if last_non_quota_error is not None:
                     raise last_non_quota_error
+                if saw_empty_response:
+                    logger.error(
+                        "Fallback slots returned empty responses after %d attempts",
+                        max_retries,
+                    )
+                    return ""
                 raise ClaudeQuotaExhaustedError(
                     result.returncode, attempt_cmd, result.stdout, result.stderr
                 )

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -261,6 +261,10 @@ def call_claude_code(
                         fb_combined = (fb_result.stdout or "") + (fb_result.stderr or "")
                         if any(m.lower() in fb_combined.lower() for m in _QUOTA_EXHAUSTED_MARKERS):
                             logger.warning("Fallback slot %s also quota-exhausted", fb_cred.name)
+                            # Clear any prior non-quota error so the caller receives
+                            # ClaudeQuotaExhaustedError rather than a stale error from
+                            # an earlier fallback that failed for a different reason.
+                            last_non_quota_error = None
                             break
                         logger.warning(
                             "Fallback slot %s failed (rc=%d, attempt %d/%d): stdout=%s stderr=%s",

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -20,6 +20,23 @@ logger = logging.getLogger(__name__)
 _MAX_RETRIES = 3
 _RETRY_DELAY_S = 5
 
+# Claude Code stdout marker for weekly quota exhaustion on the active slot. When
+# present, retrying on the same slot is futile — every attempt fails identically
+# until the quota resets. Callers with slot fallback should catch
+# ClaudeQuotaExhaustedError and retry on a different slot instead.
+_QUOTA_EXHAUSTED_MARKERS = ("weekly limit", "You've hit your weekly limit")
+
+
+class ClaudeQuotaExhaustedError(subprocess.CalledProcessError):
+    """The active Claude Code slot has exhausted its weekly quota.
+
+    Raised immediately (without the usual retry loop) when ``claude -p`` prints a
+    weekly-quota-exhaustion marker, since retrying the same slot is futile.
+    Subclasses :class:`subprocess.CalledProcessError` so existing callers that
+    catch the base type keep working; callers that can switch to a different slot
+    should catch this subtype specifically.
+    """
+
 
 def call_claude_code(
     prompt: str,
@@ -129,6 +146,21 @@ def call_claude_code(
                     logger.debug("--debug-file appears unsupported; retrying without diagnostics")
                     diagnostic_dir = None
                     plain_retry_pending = True
+            combined_out = (result.stdout or "") + (result.stderr or "")
+            combined_out_lower = combined_out.lower()
+            # Weekly quota exhaustion is a permanent, slot-scoped failure: retrying
+            # the same slot is futile and just burns ~N*delay seconds + token budget.
+            # Signal it distinctly so a caller that can switch slots can retry there.
+            if any(marker.lower() in combined_out_lower for marker in _QUOTA_EXHAUSTED_MARKERS):
+                logger.warning(
+                    "claude -p weekly quota exhausted (attempt %d/%d): %s",
+                    attempt,
+                    max_retries,
+                    result.stdout.strip()[:200] if result.stdout else result.stderr.strip()[:200],
+                )
+                raise ClaudeQuotaExhaustedError(
+                    result.returncode, attempt_cmd, result.stdout, result.stderr
+                )
             stderr_preview = result.stderr.strip()[:500] if result.stderr else "(none)"
             stdout_preview = result.stdout.strip()[:500] if result.stdout else "(none)"
             logger.warning(

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -223,6 +223,7 @@ def call_claude_code(
                     result.stdout.strip()[:200] if result.stdout else result.stderr.strip()[:200],
                 )
                 # Attempt fallback slots (GPTME_CC_FALLBACK_CREDS) before raising.
+                last_non_quota_error: subprocess.CalledProcessError | None = None
                 for fb_cred in _fallback_cred_paths:
                     if not fb_cred.exists():
                         logger.debug("Fallback cred file %s not found, skipping", fb_cred)
@@ -253,6 +254,14 @@ def call_claude_code(
                             (fb_result.stdout or "")[:200],
                             (fb_result.stderr or "")[:200],
                         )
+                        last_non_quota_error = subprocess.CalledProcessError(
+                            fb_result.returncode,
+                            cmd,
+                            fb_result.stdout,
+                            fb_result.stderr,
+                        )
+                if last_non_quota_error is not None:
+                    raise last_non_quota_error
                 raise ClaudeQuotaExhaustedError(
                     result.returncode, attempt_cmd, result.stdout, result.stderr
                 )

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -27,7 +27,7 @@ _RETRY_DELAY_S = 5
 # present, retrying on the same slot is futile — every attempt fails identically
 # until the quota resets. Callers with slot fallback should catch
 # ClaudeQuotaExhaustedError and retry on a different slot instead.
-_QUOTA_EXHAUSTED_MARKERS = ("weekly limit", "You've hit your weekly limit")
+_QUOTA_EXHAUSTED_MARKERS = ("you've hit your weekly limit",)
 
 
 class ClaudeQuotaExhaustedError(subprocess.CalledProcessError):
@@ -141,13 +141,15 @@ def call_claude_code(
     # Optional command prefix, e.g. to route `claude` through a per-slot
     # credential wrapper. Env var is a single string, shlex-split so callers can
     # pass arguments (e.g. "path/to/wrapper --slot alice --"). Generic hook —
-    # nothing here is slot/credential-specific. Pop from the subprocess env:
-    # if the wrapper itself calls call_claude_code, it must not re-inherit the
-    # prefix or we recurse infinitely (same recursion guard as the fallback
-    # creds above).
+    # nothing here is slot/credential-specific. Strip it from the child env so a
+    # wrapper that invokes this backend cannot recursively apply itself.
     prefix_env = env.pop("GPTME_CC_CMD_PREFIX", "").strip()
     if prefix_env:
-        cmd = shlex.split(prefix_env) + ["claude", "-p", "-"]
+        try:
+            prefix = shlex.split(prefix_env)
+        except ValueError as exc:
+            raise ValueError(f"Invalid GPTME_CC_CMD_PREFIX: {exc}") from exc
+        cmd = prefix + ["claude", "-p", "-"]
     else:
         cmd = ["claude", "-p", "-"]
     if nested:
@@ -229,7 +231,11 @@ def call_claude_code(
                         "Active slot quota exhausted; trying fallback slot: %s",
                         fb_cred.name,
                     )
-                    fb_result = _try_with_credential_file(cmd, prompt, fb_cred, env, timeout)
+                    try:
+                        fb_result = _try_with_credential_file(cmd, prompt, fb_cred, env, timeout)
+                    except (OSError, subprocess.TimeoutExpired) as exc:
+                        logger.warning("Fallback slot %s failed to run: %s", fb_cred.name, exc)
+                        continue
                     if fb_result.returncode == 0 and fb_result.stdout is not None:
                         fb_out: str = fb_result.stdout.strip()
                         if fb_out:

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -227,8 +227,8 @@ def call_claude_code(
                         fb_cred.name,
                     )
                     fb_result = _try_with_credential_file(cmd, prompt, fb_cred, env, timeout)
-                    if fb_result.returncode == 0:
-                        fb_out = fb_result.stdout.strip()
+                    if fb_result.returncode == 0 and fb_result.stdout is not None:
+                        fb_out: str = fb_result.stdout.strip()
                         if fb_out:
                             logger.info("Fallback slot %s succeeded", fb_cred.name)
                             return fb_out

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -8,7 +8,10 @@ This provides better quality summaries and saves tokens in the main gptme sessio
 import json
 import logging
 import re
+import shlex
+import shutil
 import subprocess
+import tempfile
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -36,6 +39,41 @@ class ClaudeQuotaExhaustedError(subprocess.CalledProcessError):
     catch the base type keep working; callers that can switch to a different slot
     should catch this subtype specifically.
     """
+
+
+def _try_with_credential_file(
+    cmd: list[str],
+    prompt: str,
+    cred_path: Path,
+    base_env: dict,
+    timeout: int,
+) -> subprocess.CompletedProcess:
+    """Run ``claude -p`` with a specific credential file via a temporary CLAUDE_CONFIG_DIR.
+
+    Creates a temporary directory containing only a ``.credentials.json`` symlink
+    pointing at *cred_path*, sets ``CLAUDE_CONFIG_DIR`` to that directory, and
+    runs *cmd* (which is expected to be ``["claude", "-p", "-", ...]``).  The
+    temporary directory is removed after the call regardless of outcome.
+
+    This avoids mutating the shared live symlink (``~/.claude/.credentials.json``),
+    making it safe to call from concurrent sessions.
+    """
+    tmpdir = Path(tempfile.mkdtemp(prefix="gptme-cc-slot-"))
+    try:
+        cred_link = tmpdir / ".credentials.json"
+        cred_link.symlink_to(cred_path.resolve())
+        slot_env = dict(base_env)
+        slot_env["CLAUDE_CONFIG_DIR"] = str(tmpdir)
+        return subprocess.run(
+            cmd,
+            input=prompt,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=slot_env,
+        )
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 def call_claude_code(
@@ -87,7 +125,28 @@ def call_claude_code(
     # subprocess sessions (the generic cross-agent signal).
     env["GPTME_SUBPROCESS"] = "1"
 
-    cmd = ["claude", "-p", "-"]
+    # Fallback credential paths for quota exhaustion recovery.  When the active
+    # slot is exhausted, call_claude_code tries each path in order via a temp
+    # CLAUDE_CONFIG_DIR.  Extract here (before the subprocess env is locked) and
+    # strip from the env so the subprocess never sees it (prevents recursion).
+    # Format: colon-separated absolute paths to credential files.
+    # Example: /home/bob/.claude/.credentials.json.alice:/home/bob/.claude/.credentials.json.erik
+    _fallback_creds_env = env.pop("GPTME_CC_FALLBACK_CREDS", "").strip()
+    _fallback_cred_paths: list[Path] = (
+        [Path(p.strip()) for p in _fallback_creds_env.split(":") if p.strip()]
+        if _fallback_creds_env
+        else []
+    )
+
+    # Optional command prefix, e.g. to route `claude` through a per-slot
+    # credential wrapper. Env var is a single string, shlex-split so callers can
+    # pass arguments (e.g. "path/to/wrapper --slot alice --"). Generic hook —
+    # nothing here is slot/credential-specific.
+    prefix_env = env.get("GPTME_CC_CMD_PREFIX", "").strip()
+    if prefix_env:
+        cmd = shlex.split(prefix_env) + ["claude", "-p", "-"]
+    else:
+        cmd = ["claude", "-p", "-"]
     if nested:
         cmd.append("--no-session-persistence")
 
@@ -158,6 +217,33 @@ def call_claude_code(
                     max_retries,
                     result.stdout.strip()[:200] if result.stdout else result.stderr.strip()[:200],
                 )
+                # Attempt fallback slots (GPTME_CC_FALLBACK_CREDS) before raising.
+                for fb_cred in _fallback_cred_paths:
+                    if not fb_cred.exists():
+                        logger.debug("Fallback cred file %s not found, skipping", fb_cred)
+                        continue
+                    logger.info(
+                        "Active slot quota exhausted; trying fallback slot: %s",
+                        fb_cred.name,
+                    )
+                    fb_result = _try_with_credential_file(cmd, prompt, fb_cred, env, timeout)
+                    if fb_result.returncode == 0:
+                        fb_out = fb_result.stdout.strip()
+                        if fb_out:
+                            logger.info("Fallback slot %s succeeded", fb_cred.name)
+                            return fb_out
+                    # Check if this fallback slot is also quota-exhausted
+                    fb_combined = (fb_result.stdout or "") + (fb_result.stderr or "")
+                    if any(m.lower() in fb_combined.lower() for m in _QUOTA_EXHAUSTED_MARKERS):
+                        logger.warning("Fallback slot %s also quota-exhausted", fb_cred.name)
+                    else:
+                        logger.warning(
+                            "Fallback slot %s failed (rc=%d): stdout=%s stderr=%s",
+                            fb_cred.name,
+                            fb_result.returncode,
+                            (fb_result.stdout or "")[:200],
+                            (fb_result.stderr or "")[:200],
+                        )
                 raise ClaudeQuotaExhaustedError(
                     result.returncode, attempt_cmd, result.stdout, result.stderr
                 )

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -141,8 +141,11 @@ def call_claude_code(
     # Optional command prefix, e.g. to route `claude` through a per-slot
     # credential wrapper. Env var is a single string, shlex-split so callers can
     # pass arguments (e.g. "path/to/wrapper --slot alice --"). Generic hook —
-    # nothing here is slot/credential-specific.
-    prefix_env = env.get("GPTME_CC_CMD_PREFIX", "").strip()
+    # nothing here is slot/credential-specific. Pop from the subprocess env:
+    # if the wrapper itself calls call_claude_code, it must not re-inherit the
+    # prefix or we recurse infinitely (same recursion guard as the fallback
+    # creds above).
+    prefix_env = env.pop("GPTME_CC_CMD_PREFIX", "").strip()
     if prefix_env:
         cmd = shlex.split(prefix_env) + ["claude", "-p", "-"]
     else:

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -261,20 +261,25 @@ def call_claude_code(
                         fb_combined = (fb_result.stdout or "") + (fb_result.stderr or "")
                         if any(m.lower() in fb_combined.lower() for m in _QUOTA_EXHAUSTED_MARKERS):
                             logger.warning("Fallback slot %s also quota-exhausted", fb_cred.name)
-                        else:
-                            logger.warning(
-                                "Fallback slot %s failed (rc=%d): stdout=%s stderr=%s",
-                                fb_cred.name,
-                                fb_result.returncode,
-                                (fb_result.stdout or "")[:200],
-                                (fb_result.stderr or "")[:200],
-                            )
-                            last_non_quota_error = subprocess.CalledProcessError(
-                                fb_result.returncode,
-                                cmd,
-                                fb_result.stdout,
-                                fb_result.stderr,
-                            )
+                            break
+                        logger.warning(
+                            "Fallback slot %s failed (rc=%d, attempt %d/%d): stdout=%s stderr=%s",
+                            fb_cred.name,
+                            fb_result.returncode,
+                            fb_attempt,
+                            max_retries,
+                            (fb_result.stdout or "")[:200],
+                            (fb_result.stderr or "")[:200],
+                        )
+                        last_non_quota_error = subprocess.CalledProcessError(
+                            fb_result.returncode,
+                            cmd,
+                            fb_result.stdout,
+                            fb_result.stderr,
+                        )
+                        if fb_attempt < max_retries:
+                            time.sleep(_RETRY_DELAY_S * fb_attempt)
+                            continue
                         break
                 if last_non_quota_error is not None:
                     raise last_non_quota_error

--- a/packages/gptme-activity-summary/tests/test_cc_backend.py
+++ b/packages/gptme-activity-summary/tests/test_cc_backend.py
@@ -557,6 +557,59 @@ def test_call_claude_code_quota_fallback_continues_after_launch_failure(
 @patch("gptme_activity_summary.cc_backend._try_with_credential_file")
 @patch("gptme_activity_summary.cc_backend.time.sleep")
 @patch("subprocess.run")
+def test_call_claude_code_quota_fallback_retries_empty_response(
+    mock_run, mock_sleep, mock_fallback, tmp_path
+):
+    """A transient empty response from a healthy fallback slot is retried."""
+    fb_cred = tmp_path / ".credentials.json.alice"
+    fb_cred.write_text("{}")
+    mock_run.return_value = _make_completed_process(
+        returncode=1, stdout="You've hit your weekly limit"
+    )
+    mock_fallback.side_effect = [
+        _make_completed_process(stdout=""),
+        _make_completed_process(stdout='{"ok": true}'),
+    ]
+
+    with patch.dict(
+        "os.environ",
+        {"GPTME_CC_FALLBACK_CREDS": str(fb_cred)},
+        clear=True,
+    ):
+        assert call_claude_code("test prompt", max_retries=2) == '{"ok": true}'
+
+    assert mock_fallback.call_count == 2
+    mock_sleep.assert_called_once()
+
+
+@patch("gptme_activity_summary.cc_backend._try_with_credential_file")
+@patch("gptme_activity_summary.cc_backend.time.sleep")
+@patch("subprocess.run")
+def test_call_claude_code_quota_fallback_empty_exhaustion_returns_empty(
+    mock_run, mock_sleep, mock_fallback, tmp_path
+):
+    """Repeated empty responses retain the main path's graceful-empty contract."""
+    fb_cred = tmp_path / ".credentials.json.alice"
+    fb_cred.write_text("{}")
+    mock_run.return_value = _make_completed_process(
+        returncode=1, stdout="You've hit your weekly limit"
+    )
+    mock_fallback.return_value = _make_completed_process(stdout="")
+
+    with patch.dict(
+        "os.environ",
+        {"GPTME_CC_FALLBACK_CREDS": str(fb_cred)},
+        clear=True,
+    ):
+        assert call_claude_code("test prompt", max_retries=2) == ""
+
+    assert mock_fallback.call_count == 2
+    mock_sleep.assert_called_once()
+
+
+@patch("gptme_activity_summary.cc_backend._try_with_credential_file")
+@patch("gptme_activity_summary.cc_backend.time.sleep")
+@patch("subprocess.run")
 def test_call_claude_code_quota_fallback_all_exhausted(
     mock_run, mock_sleep, mock_fallback, tmp_path
 ):

--- a/packages/gptme-activity-summary/tests/test_cc_backend.py
+++ b/packages/gptme-activity-summary/tests/test_cc_backend.py
@@ -238,6 +238,7 @@ def test_call_claude_code_cmd_prefix_env(mock_run):
     cmd = mock_run.call_args[0][0]
     assert cmd[:5] == ["/opt/bin/slot-wrap", "--slot", "alice", "--", "claude"]
     assert cmd[5:7] == ["-p", "-"]
+    assert "GPTME_CC_CMD_PREFIX" not in mock_run.call_args.kwargs["env"]
 
 
 @patch.dict("os.environ", {}, clear=True)
@@ -248,6 +249,29 @@ def test_call_claude_code_cmd_prefix_empty_env_unchanged(mock_run):
     call_claude_code("test prompt")
     cmd = mock_run.call_args[0][0]
     assert cmd == ["claude", "-p", "-"]
+
+
+@patch.dict("os.environ", {"GPTME_CC_CMD_PREFIX": "wrapper '"}, clear=True)
+@patch("subprocess.run")
+def test_call_claude_code_cmd_prefix_invalid_quote(mock_run):
+    """An invalid command prefix reports which setting is malformed."""
+    with pytest.raises(ValueError, match="Invalid GPTME_CC_CMD_PREFIX"):
+        call_claude_code("test prompt")
+    mock_run.assert_not_called()
+
+
+@patch("gptme_activity_summary.cc_backend.time.sleep")
+@patch("subprocess.run")
+def test_call_claude_code_does_not_match_generic_weekly_limit(mock_run, mock_sleep):
+    """Unrelated output mentioning a weekly limit follows the normal retry path."""
+    mock_run.side_effect = [
+        _make_completed_process(returncode=1, stderr="See the weekly limit documentation"),
+        _make_completed_process(stdout='{"ok": true}'),
+    ]
+
+    assert call_claude_code("test prompt", max_retries=2) == '{"ok": true}'
+    assert mock_run.call_count == 2
+    mock_sleep.assert_called_once()
 
 
 @patch("gptme_activity_summary.cc_backend.time.sleep")
@@ -503,6 +527,33 @@ def test_call_claude_code_quota_fallback_success(mock_run, mock_sleep, mock_fall
     assert mock_fallback.call_count == 1  # fallback tried once
 
 
+@pytest.mark.parametrize("failure", [subprocess.TimeoutExpired("claude", 30), OSError("boom")])
+@patch("gptme_activity_summary.cc_backend._try_with_credential_file")
+@patch("gptme_activity_summary.cc_backend.time.sleep")
+@patch("subprocess.run")
+def test_call_claude_code_quota_fallback_continues_after_launch_failure(
+    mock_run, mock_sleep, mock_fallback, tmp_path, failure
+):
+    """A hung or unlaunchable fallback slot does not block later slots."""
+    first_cred = tmp_path / ".credentials.json.first"
+    second_cred = tmp_path / ".credentials.json.second"
+    first_cred.write_text("{}")
+    second_cred.write_text("{}")
+    mock_run.return_value = _make_completed_process(
+        returncode=1, stdout="You've hit your weekly limit"
+    )
+    mock_fallback.side_effect = [failure, _make_completed_process(stdout='{"ok": true}')]
+
+    with patch.dict(
+        "os.environ",
+        {"GPTME_CC_FALLBACK_CREDS": f"{first_cred}:{second_cred}"},
+        clear=True,
+    ):
+        assert call_claude_code("test prompt") == '{"ok": true}'
+
+    assert mock_fallback.call_count == 2
+
+
 @patch("gptme_activity_summary.cc_backend._try_with_credential_file")
 @patch("gptme_activity_summary.cc_backend.time.sleep")
 @patch("subprocess.run")
@@ -547,7 +598,9 @@ def test_call_claude_code_quota_fallback_missing_file_skipped(mock_run, mock_sle
     nonexistent = "/tmp/nonexistent-slot-cred-99999"
     prev = os.environ.pop("GPTME_CC_FALLBACK_CREDS", None)
     os.environ["GPTME_CC_FALLBACK_CREDS"] = nonexistent
-    mock_run.return_value = _make_completed_process(returncode=1, stdout="weekly limit")
+    mock_run.return_value = _make_completed_process(
+        returncode=1, stdout="You've hit your weekly limit"
+    )
     try:
         try:
             call_claude_code("test prompt")
@@ -574,17 +627,3 @@ def test_call_claude_code_fallback_creds_not_passed_to_subprocess(mock_run):
     call_claude_code("test prompt")
     subprocess_env = mock_run.call_args.kwargs["env"]
     assert "GPTME_CC_FALLBACK_CREDS" not in subprocess_env
-
-
-@patch.dict("os.environ", {}, clear=True)
-@patch("subprocess.run")
-def test_call_claude_code_cmd_prefix_not_passed_to_subprocess(mock_run):
-    """GPTME_CC_CMD_PREFIX must be stripped from the subprocess env to prevent
-    recursion when the prefix wrapper itself calls call_claude_code."""
-    import os
-
-    os.environ["GPTME_CC_CMD_PREFIX"] = "/opt/bin/slot-wrap --slot alice --"
-    mock_run.return_value = _make_completed_process(stdout="ok")
-    call_claude_code("test prompt")
-    subprocess_env = mock_run.call_args.kwargs["env"]
-    assert "GPTME_CC_CMD_PREFIX" not in subprocess_env

--- a/packages/gptme-activity-summary/tests/test_cc_backend.py
+++ b/packages/gptme-activity-summary/tests/test_cc_backend.py
@@ -574,3 +574,17 @@ def test_call_claude_code_fallback_creds_not_passed_to_subprocess(mock_run):
     call_claude_code("test prompt")
     subprocess_env = mock_run.call_args.kwargs["env"]
     assert "GPTME_CC_FALLBACK_CREDS" not in subprocess_env
+
+
+@patch.dict("os.environ", {}, clear=True)
+@patch("subprocess.run")
+def test_call_claude_code_cmd_prefix_not_passed_to_subprocess(mock_run):
+    """GPTME_CC_CMD_PREFIX must be stripped from the subprocess env to prevent
+    recursion when the prefix wrapper itself calls call_claude_code."""
+    import os
+
+    os.environ["GPTME_CC_CMD_PREFIX"] = "/opt/bin/slot-wrap --slot alice --"
+    mock_run.return_value = _make_completed_process(stdout="ok")
+    call_claude_code("test prompt")
+    subprocess_env = mock_run.call_args.kwargs["env"]
+    assert "GPTME_CC_CMD_PREFIX" not in subprocess_env

--- a/packages/gptme-activity-summary/tests/test_cc_backend.py
+++ b/packages/gptme-activity-summary/tests/test_cc_backend.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from gptme_activity_summary.cc_backend import (
+    ClaudeQuotaExhaustedError,
     call_claude_code,
     extract_json_from_response,
     summarize_journal_with_cc,
@@ -219,6 +220,34 @@ def test_call_claude_code_quota_is_called_process_error_subtype(mock_run, mock_s
         assert False, "Should have raised ClaudeQuotaExhaustedError"
     except subprocess.CalledProcessError as e:
         assert isinstance(e, ClaudeQuotaExhaustedError)
+
+
+@patch.dict(
+    "os.environ",
+    # Explicitly clear CLAUDECODE so nested detection doesn't append
+    # --no-session-persistence and complicate the cmd assertion.
+    {"GPTME_CC_CMD_PREFIX": "/opt/bin/slot-wrap --slot alice --", "CLAUDECODE": ""},
+    clear=False,
+)
+@patch("subprocess.run")
+def test_call_claude_code_cmd_prefix_env(mock_run):
+    """GPTME_CC_CMD_PREFIX must prepend the claude command via shlex split."""
+    mock_run.return_value = _make_completed_process(stdout='{"ok": true}')
+    result = call_claude_code("test prompt")
+    assert result == '{"ok": true}'
+    cmd = mock_run.call_args[0][0]
+    assert cmd[:5] == ["/opt/bin/slot-wrap", "--slot", "alice", "--", "claude"]
+    assert cmd[5:7] == ["-p", "-"]
+
+
+@patch.dict("os.environ", {}, clear=True)
+@patch("subprocess.run")
+def test_call_claude_code_cmd_prefix_empty_env_unchanged(mock_run):
+    """No GPTME_CC_CMD_PREFIX => plain claude -p invocation."""
+    mock_run.return_value = _make_completed_process(stdout='{"ok": true}')
+    call_claude_code("test prompt")
+    cmd = mock_run.call_args[0][0]
+    assert cmd == ["claude", "-p", "-"]
 
 
 @patch("gptme_activity_summary.cc_backend.time.sleep")
@@ -439,3 +468,109 @@ def test_summarize_journal_no_failed_flag_on_success(mock_cc):
     result = summarize_journal_with_cc("test content", "2026-03-26")
     assert "_cc_failed" not in result
     assert result["narrative"] == "did stuff"
+
+
+# --- Tests for GPTME_CC_FALLBACK_CREDS slot fallback ---
+
+
+@patch("gptme_activity_summary.cc_backend._try_with_credential_file")
+@patch("gptme_activity_summary.cc_backend.time.sleep")
+@patch("subprocess.run")
+def test_call_claude_code_quota_fallback_success(mock_run, mock_sleep, mock_fallback, tmp_path):
+    """Quota exhaustion on primary slot triggers fallback; first healthy slot wins."""
+    fb_cred = tmp_path / ".credentials.json.alice"
+    fb_cred.write_text("{}")
+
+    mock_run.return_value = _make_completed_process(
+        returncode=1, stdout="You've hit your weekly limit · resets 4pm"
+    )
+    mock_fallback.return_value = _make_completed_process(stdout='{"ok": true}')
+
+    import os
+
+    prev = os.environ.pop("GPTME_CC_FALLBACK_CREDS", None)
+    os.environ["GPTME_CC_FALLBACK_CREDS"] = str(fb_cred)
+    try:
+        result = call_claude_code("test prompt")
+    finally:
+        if prev is None:
+            os.environ.pop("GPTME_CC_FALLBACK_CREDS", None)
+        else:
+            os.environ["GPTME_CC_FALLBACK_CREDS"] = prev
+
+    assert result == '{"ok": true}'
+    assert mock_run.call_count == 1  # primary slot tried once
+    assert mock_fallback.call_count == 1  # fallback tried once
+
+
+@patch("gptme_activity_summary.cc_backend._try_with_credential_file")
+@patch("gptme_activity_summary.cc_backend.time.sleep")
+@patch("subprocess.run")
+def test_call_claude_code_quota_fallback_all_exhausted(
+    mock_run, mock_sleep, mock_fallback, tmp_path
+):
+    """If all fallback slots are also exhausted, raise ClaudeQuotaExhaustedError."""
+    fb_cred = tmp_path / ".credentials.json.erik"
+    fb_cred.write_text("{}")
+
+    mock_run.return_value = _make_completed_process(
+        returncode=1, stdout="You've hit your weekly limit"
+    )
+    mock_fallback.return_value = _make_completed_process(
+        returncode=1, stdout="You've hit your weekly limit"
+    )
+
+    import os
+
+    prev = os.environ.pop("GPTME_CC_FALLBACK_CREDS", None)
+    os.environ["GPTME_CC_FALLBACK_CREDS"] = str(fb_cred)
+    try:
+        try:
+            call_claude_code("test prompt")
+            assert False, "Should have raised ClaudeQuotaExhaustedError"
+        except ClaudeQuotaExhaustedError:
+            pass
+    finally:
+        if prev is None:
+            os.environ.pop("GPTME_CC_FALLBACK_CREDS", None)
+        else:
+            os.environ["GPTME_CC_FALLBACK_CREDS"] = prev
+
+
+@patch("gptme_activity_summary.cc_backend._try_with_credential_file")
+@patch("gptme_activity_summary.cc_backend.time.sleep")
+@patch("subprocess.run")
+def test_call_claude_code_quota_fallback_missing_file_skipped(mock_run, mock_sleep, mock_fallback):
+    """A fallback cred path that does not exist on disk is silently skipped."""
+    import os
+
+    nonexistent = "/tmp/nonexistent-slot-cred-99999"
+    prev = os.environ.pop("GPTME_CC_FALLBACK_CREDS", None)
+    os.environ["GPTME_CC_FALLBACK_CREDS"] = nonexistent
+    mock_run.return_value = _make_completed_process(returncode=1, stdout="weekly limit")
+    try:
+        try:
+            call_claude_code("test prompt")
+            assert False, "Should have raised ClaudeQuotaExhaustedError"
+        except ClaudeQuotaExhaustedError:
+            pass
+    finally:
+        if prev is None:
+            os.environ.pop("GPTME_CC_FALLBACK_CREDS", None)
+        else:
+            os.environ["GPTME_CC_FALLBACK_CREDS"] = prev
+
+    mock_fallback.assert_not_called()  # missing file never attempted
+
+
+@patch.dict("os.environ", {}, clear=True)
+@patch("subprocess.run")
+def test_call_claude_code_fallback_creds_not_passed_to_subprocess(mock_run):
+    """GPTME_CC_FALLBACK_CREDS must be stripped from the env passed to subprocess."""
+    import os
+
+    os.environ["GPTME_CC_FALLBACK_CREDS"] = "/tmp/fake-cred"
+    mock_run.return_value = _make_completed_process(stdout="ok")
+    call_claude_code("test prompt")
+    subprocess_env = mock_run.call_args.kwargs["env"]
+    assert "GPTME_CC_FALLBACK_CREDS" not in subprocess_env

--- a/packages/gptme-activity-summary/tests/test_cc_backend.py
+++ b/packages/gptme-activity-summary/tests/test_cc_backend.py
@@ -636,10 +636,38 @@ def test_call_claude_code_quota_fallback_all_exhausted(
 @patch("gptme_activity_summary.cc_backend._try_with_credential_file")
 @patch("gptme_activity_summary.cc_backend.time.sleep")
 @patch("subprocess.run")
+def test_call_claude_code_quota_fallback_retries_non_quota_error(
+    mock_run, mock_sleep, mock_fallback, tmp_path
+):
+    """A transient fallback error gets the same retry opportunity as the primary slot."""
+    fb_cred = tmp_path / ".credentials.json.alice"
+    fb_cred.write_text("{}")
+    mock_run.return_value = _make_completed_process(
+        returncode=1, stdout="You've hit your weekly limit"
+    )
+    mock_fallback.side_effect = [
+        _make_completed_process(returncode=1, stderr="temporary API failure"),
+        _make_completed_process(stdout='{"ok": true}'),
+    ]
+
+    with patch.dict(
+        "os.environ",
+        {"GPTME_CC_FALLBACK_CREDS": str(fb_cred)},
+        clear=True,
+    ):
+        assert call_claude_code("test prompt", max_retries=2) == '{"ok": true}'
+
+    assert mock_fallback.call_count == 2
+    mock_sleep.assert_called_once_with(5)
+
+
+@patch("gptme_activity_summary.cc_backend._try_with_credential_file")
+@patch("gptme_activity_summary.cc_backend.time.sleep")
+@patch("subprocess.run")
 def test_call_claude_code_quota_fallback_preserves_non_quota_error(
     mock_run, mock_sleep, mock_fallback, tmp_path
 ):
-    """A fallback auth or service failure is not mislabeled as quota exhaustion."""
+    """An exhausted fallback retry window preserves the last non-quota failure."""
     fb_cred = tmp_path / ".credentials.json.invalid"
     fb_cred.write_text("{}")
     mock_run.return_value = _make_completed_process(
@@ -653,11 +681,13 @@ def test_call_claude_code_quota_fallback_preserves_non_quota_error(
         clear=True,
     ):
         with pytest.raises(subprocess.CalledProcessError) as exc_info:
-            call_claude_code("test prompt")
+            call_claude_code("test prompt", max_retries=2)
 
     assert not isinstance(exc_info.value, ClaudeQuotaExhaustedError)
     assert exc_info.value.returncode == 2
     assert exc_info.value.stderr == "invalid credentials"
+    assert mock_fallback.call_count == 2
+    mock_sleep.assert_called_once_with(5)
 
 
 @patch("gptme_activity_summary.cc_backend._try_with_credential_file")

--- a/packages/gptme-activity-summary/tests/test_cc_backend.py
+++ b/packages/gptme-activity-summary/tests/test_cc_backend.py
@@ -693,6 +693,42 @@ def test_call_claude_code_quota_fallback_preserves_non_quota_error(
 @patch("gptme_activity_summary.cc_backend._try_with_credential_file")
 @patch("gptme_activity_summary.cc_backend.time.sleep")
 @patch("subprocess.run")
+def test_call_claude_code_quota_fallback_non_quota_then_quota_raises_quota_error(
+    mock_run, mock_sleep, mock_fallback, tmp_path
+):
+    """Non-quota error on slot A then quota-exhaustion on slot B → ClaudeQuotaExhaustedError.
+
+    Regression for: last_non_quota_error was not cleared when a later fallback slot
+    was itself quota-exhausted, causing the stale error from slot A to be raised instead
+    of ClaudeQuotaExhaustedError — violating the stated contract.
+    """
+    cred_a = tmp_path / ".credentials.json.alice"
+    cred_a.write_text("{}")
+    cred_b = tmp_path / ".credentials.json.erik"
+    cred_b.write_text("{}")
+
+    mock_run.return_value = _make_completed_process(
+        returncode=1, stdout="You've hit your weekly limit"
+    )
+    mock_fallback.side_effect = [
+        # Slot A: non-quota failure (e.g. invalid credentials)
+        _make_completed_process(returncode=2, stderr="invalid credentials"),
+        # Slot B: also quota-exhausted
+        _make_completed_process(returncode=1, stdout="You've hit your weekly limit"),
+    ]
+
+    with patch.dict(
+        "os.environ",
+        {"GPTME_CC_FALLBACK_CREDS": f"{cred_a}:{cred_b}"},
+        clear=True,
+    ):
+        with pytest.raises(ClaudeQuotaExhaustedError):
+            call_claude_code("test prompt", max_retries=1)
+
+
+@patch("gptme_activity_summary.cc_backend._try_with_credential_file")
+@patch("gptme_activity_summary.cc_backend.time.sleep")
+@patch("subprocess.run")
 def test_call_claude_code_quota_fallback_missing_file_skipped(mock_run, mock_sleep, mock_fallback):
     """A fallback cred path that does not exist on disk is silently skipped."""
     import os

--- a/packages/gptme-activity-summary/tests/test_cc_backend.py
+++ b/packages/gptme-activity-summary/tests/test_cc_backend.py
@@ -4,6 +4,8 @@ import subprocess
 from datetime import datetime, timezone
 from unittest.mock import patch
 
+import pytest
+
 from gptme_activity_summary.cc_backend import (
     call_claude_code,
     extract_json_from_response,
@@ -166,6 +168,57 @@ def test_call_claude_code_nonzero_exit_raises_after_retries(mock_run, mock_sleep
         assert e.returncode == 1
     assert mock_run.call_count == 3  # retried 3 times, not raised immediately
     assert mock_sleep.call_count == 2  # slept between attempts
+
+
+@patch("gptme_activity_summary.cc_backend.time.sleep")
+@patch("subprocess.run")
+def test_call_claude_code_quota_exhausted_raises_immediately(mock_run, mock_sleep):
+    """Weekly quota exhaustion must raise ClaudeQuotaExhaustedError immediately.
+
+    Retrying the same slot is futile when it is quota-exhausted; the failure
+    should surface on the first attempt so a caller with slot fallback can retry
+    on a different slot instead of burning the full retry window.
+    """
+    from gptme_activity_summary.cc_backend import ClaudeQuotaExhaustedError
+
+    mock_run.return_value = _make_completed_process(
+        returncode=1, stdout="You've hit your weekly limit · resets 4pm (UTC)"
+    )
+    with pytest.raises(ClaudeQuotaExhaustedError) as exc_info:
+        call_claude_code("test prompt", max_retries=3)
+    assert exc_info.value.returncode == 1
+    assert mock_run.call_count == 1  # no retries — quota failure is permanent
+    assert mock_sleep.call_count == 0  # no backoff sleep burned
+
+
+@patch("gptme_activity_summary.cc_backend.time.sleep")
+@patch("subprocess.run")
+def test_call_claude_code_quota_marker_in_stderr(mock_run, mock_sleep):
+    """Quota marker in stderr (not stdout) must also be detected."""
+    from gptme_activity_summary.cc_backend import ClaudeQuotaExhaustedError
+
+    mock_run.return_value = _make_completed_process(
+        returncode=1, stderr="You've hit your weekly limit"
+    )
+    with pytest.raises(ClaudeQuotaExhaustedError):
+        call_claude_code("test prompt", max_retries=3)
+    assert mock_run.call_count == 1
+
+
+@patch("gptme_activity_summary.cc_backend.time.sleep")
+@patch("subprocess.run")
+def test_call_claude_code_quota_is_called_process_error_subtype(mock_run, mock_sleep):
+    """ClaudeQuotaExhaustedError must be catchable as CalledProcessError."""
+    from gptme_activity_summary.cc_backend import ClaudeQuotaExhaustedError
+
+    mock_run.return_value = _make_completed_process(
+        returncode=1, stdout="You've hit your weekly limit"
+    )
+    try:
+        call_claude_code("test prompt", max_retries=3)
+        assert False, "Should have raised ClaudeQuotaExhaustedError"
+    except subprocess.CalledProcessError as e:
+        assert isinstance(e, ClaudeQuotaExhaustedError)
 
 
 @patch("gptme_activity_summary.cc_backend.time.sleep")

--- a/packages/gptme-activity-summary/tests/test_cc_backend.py
+++ b/packages/gptme-activity-summary/tests/test_cc_backend.py
@@ -571,21 +571,40 @@ def test_call_claude_code_quota_fallback_all_exhausted(
         returncode=1, stdout="You've hit your weekly limit"
     )
 
-    import os
-
-    prev = os.environ.pop("GPTME_CC_FALLBACK_CREDS", None)
-    os.environ["GPTME_CC_FALLBACK_CREDS"] = str(fb_cred)
-    try:
-        try:
+    with patch.dict(
+        "os.environ",
+        {"GPTME_CC_FALLBACK_CREDS": str(fb_cred)},
+        clear=True,
+    ):
+        with pytest.raises(ClaudeQuotaExhaustedError):
             call_claude_code("test prompt")
-            assert False, "Should have raised ClaudeQuotaExhaustedError"
-        except ClaudeQuotaExhaustedError:
-            pass
-    finally:
-        if prev is None:
-            os.environ.pop("GPTME_CC_FALLBACK_CREDS", None)
-        else:
-            os.environ["GPTME_CC_FALLBACK_CREDS"] = prev
+
+
+@patch("gptme_activity_summary.cc_backend._try_with_credential_file")
+@patch("gptme_activity_summary.cc_backend.time.sleep")
+@patch("subprocess.run")
+def test_call_claude_code_quota_fallback_preserves_non_quota_error(
+    mock_run, mock_sleep, mock_fallback, tmp_path
+):
+    """A fallback auth or service failure is not mislabeled as quota exhaustion."""
+    fb_cred = tmp_path / ".credentials.json.invalid"
+    fb_cred.write_text("{}")
+    mock_run.return_value = _make_completed_process(
+        returncode=1, stdout="You've hit your weekly limit"
+    )
+    mock_fallback.return_value = _make_completed_process(returncode=2, stderr="invalid credentials")
+
+    with patch.dict(
+        "os.environ",
+        {"GPTME_CC_FALLBACK_CREDS": str(fb_cred)},
+        clear=True,
+    ):
+        with pytest.raises(subprocess.CalledProcessError) as exc_info:
+            call_claude_code("test prompt")
+
+    assert not isinstance(exc_info.value, ClaudeQuotaExhaustedError)
+    assert exc_info.value.returncode == 2
+    assert exc_info.value.stderr == "invalid credentials"
 
 
 @patch("gptme_activity_summary.cc_backend._try_with_credential_file")


### PR DESCRIPTION
## Problem

`call_claude_code` in `gptme-activity-summary` retried `claude -p` 3× on the same slot when the active Claude Code slot's **weekly quota is exhausted** — each retry was futile and burned 15+ seconds of backoff. This drove `bob-activity-summary.timer` to a 57% success rate on exhausted-slot days.

Root cause confirmed from systemd journal (2026-08-18 run):
```
claude -p exited 1 (attempt 1/3). stdout: You've hit your weekly limit · resets 4pm (UTC)
claude -p exited 1 (attempt 2/3). stdout: You've hit your weekly limit · resets 4pm (UTC)
claude -p exited 1 (attempt 3/3). stdout: You've hit your weekly limit · resets 4pm (UTC)
```

## Changes

### Phase 1 — fast-fail on quota exhaustion

Raise `ClaudeQuotaExhaustedError` (subclass of `CalledProcessError`) on the first attempt when `claude -p` stdout/stderr contains a weekly-quota marker. Existing callers catching the base type keep working unchanged.

### Phase 2 — `GPTME_CC_CMD_PREFIX` hook

Generic shlex-split command prefix env var prepended to `claude`. Lets operators wrap the command (e.g. a credential router) without code changes.

### Phase 3 — `GPTME_CC_FALLBACK_CREDS` slot fallback

Colon-separated paths to credential files tried in order when `ClaudeQuotaExhaustedError` is raised. Each attempt runs `claude -p` via a **temporary `CLAUDE_CONFIG_DIR`** containing only a symlink to the target credential file — the shared live symlink (`~/.claude/.credentials.json`) is never mutated, making it safe for concurrent sessions.

`GPTME_CC_FALLBACK_CREDS` is stripped from the subprocess env to prevent recursion.

## Usage

In the service unit:
```ini
Environment=GPTME_CC_FALLBACK_CREDS=/home/bob/.claude/.credentials.json.alice:/home/bob/.claude/.credentials.json.erik
```

On quota exhaustion the summary tries alice's slot, then erik's, before failing. A missing/nonexistent credential file is silently skipped.

## Tests

35 pass (4 new for slot fallback, 2 for cmd prefix, 3 for quota exhaustion signal).