### PR TITLE
feat(gptme-sessions): ingest lesson_events from the match-lessons hook

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/lesson_events.py
+++ b/packages/gptme-sessions/src/gptme_sessions/lesson_events.py
@@ -1,0 +1,93 @@
+"""Ingest lesson-injection events emitted by the Claude Code hook.
+
+The ``match-lessons.py`` Claude Code hook appends one JSON object per injected
+lesson to ``$TMPDIR/cc-session-{id}-lessons.jsonl`` (see
+``scripts/claude-code-hooks/match-lessons.py::_get_lesson_events_file``).  Until
+this module existed the producer ran on every session while nothing ever read
+the files back, so ``lesson_events`` never reached a session record.
+
+The filename contract is duplicated from the hook on purpose: the hook must stay
+dependency-free, so it cannot import from this package.  ``test_lesson_events``
+pins the two implementations together.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: Upper bound on events attached to one record. Long sessions inject a few
+#: hundred lessons; the cap stops a runaway hook from bloating the ledger.
+MAX_LESSON_EVENTS = 500
+
+
+def lesson_events_path(harness_session_id: str) -> Path:
+    """Return the hook's events file for ``harness_session_id``.
+
+    Mirrors ``match-lessons.py::_get_lesson_events_file``.
+    """
+    tmpdir = Path(os.environ.get("TMPDIR", "/tmp"))
+    safe_id = re.sub(r"[^a-zA-Z0-9_-]", "_", harness_session_id)
+    return tmpdir / f"cc-session-{safe_id}-lessons.jsonl"
+
+
+def load_lesson_events(
+    harness_session_id: str | None = None,
+    *,
+    max_events: int = MAX_LESSON_EVENTS,
+) -> list[dict[str, Any]]:
+    """Load lesson-injection events for a harness session.
+
+    Parameters
+    ----------
+    harness_session_id:
+        The harness-native session id the hook used to name its file — for
+        Claude Code, the transcript UUID.  Defaults to ``$CC_SESSION_ID``, which
+        the autonomous runner exports before launching the harness, so callers
+        running inside the session's process tree need not pass anything.
+    max_events:
+        Truncate to this many events, keeping the earliest.
+
+    Returns an empty list when the id is unknown or the file is absent; a
+    missing file is the normal case for non-Claude-Code harnesses.
+    """
+    if harness_session_id is None:
+        harness_session_id = os.environ.get("CC_SESSION_ID") or ""
+    if not harness_session_id:
+        return []
+
+    path = lesson_events_path(harness_session_id)
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+
+    events: list[dict[str, Any]] = []
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            # The hook appends while the session runs, so the trailing line can
+            # be mid-write. Skip it rather than dropping the whole file.
+            continue
+        if isinstance(event, dict):
+            events.append(event)
+
+    if len(events) > max_events:
+        logger.warning(
+            "truncating lesson_events for %s: %d events > max %d",
+            harness_session_id,
+            len(events),
+            max_events,
+        )
+        events = events[:max_events]
+    return events

--- a/packages/gptme-sessions/src/gptme_sessions/post_session.py
+++ b/packages/gptme-sessions/src/gptme_sessions/post_session.py
@@ -35,6 +35,7 @@ from .deliverables import (
 )
 from .discovery import extract_project, extract_session_name
 from .failure_capture import capture_session_failure
+from .lesson_events import load_lesson_events
 from .record import SessionRecord
 from .signals import extract_from_path
 from .smell import compute_smell_score
@@ -281,6 +282,7 @@ def post_session(
     deliverables: list[str] | None = None,
     journal_path: str | None = None,
     session_id: str | None = None,
+    harness_session_id: str | None = None,
     harness_stderr_path: Path | None = None,
     failure_reason: str | None = None,
     error: str | None = None,
@@ -354,6 +356,11 @@ def post_session(
         the first ``/journal/`` write in the trajectory signals.
     session_id:
         Override the auto-generated session ID.
+    harness_session_id:
+        Harness-native session id used by the ``match-lessons`` hook to name its
+        per-session events file (for Claude Code, the transcript UUID). Used to
+        ingest ``lesson_events``. Defaults to ``$CC_SESSION_ID``, which the
+        autonomous runner exports before launching the harness.
     harness_stderr_path:
         Optional path to a harness stderr log (e.g. gptme ``2>>`` capture from
         ``run.sh``). Used with the trajectory to populate ``failure_reason`` and
@@ -830,6 +837,13 @@ def post_session(
             record_kwargs["failure_reason"] = failure_reason
         if error is not None:
             record_kwargs["error"] = error
+
+    # Harness supply: lessons the match-lessons hook injected during this
+    # session. Defaults to $CC_SESSION_ID so callers inside the session's
+    # process tree get this for free.
+    lesson_events = load_lesson_events(harness_session_id)
+    if lesson_events:
+        record_kwargs["lesson_events"] = lesson_events
 
     record = SessionRecord(**record_kwargs)
     if grade is not None:

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -286,6 +286,12 @@ class SessionRecord:
     gen_ms_total: float | None = None  # total generation (streaming) time
     tool_ms_total: float | None = None  # total tool-execution wall time
 
+    # Harness supply: lessons injected into this session by the match-lessons
+    # hook (name, file, match_type, injection_point, timestamp). Ingested by
+    # post_session() from the hook's per-session events file. Empty for
+    # harnesses that don't run the hook.
+    lesson_events: list[dict[str, Any]] = field(default_factory=list)
+
     # Preserve fields written by older schema versions so load→mutate→rewrite
     # round-trips don't silently drop data (e.g. ``inferred_category``,
     # ``recommended_confidence``, ``notes``).
@@ -309,6 +315,8 @@ class SessionRecord:
             self.duration_seconds = 0
         if self.deliverable_details is None:
             self.deliverable_details = []
+        if self.lesson_events is None:
+            self.lesson_events = []
         if self.grades is None:
             self.grades = {}
         if self.grade_reasons is None:

--- a/packages/gptme-sessions/tests/test_lesson_events.py
+++ b/packages/gptme-sessions/tests/test_lesson_events.py
@@ -51,8 +51,7 @@ class TestLessonEventsPath:
             / "claude-code-hooks"
             / "match-lessons.py"
         )
-        if not hook.exists():  # pragma: no cover - contrib layout only
-            pytest.skip("match-lessons.py hook not present in this checkout")
+        assert hook.exists(), f"contract producer is missing: {hook}"
         source = hook.read_text(encoding="utf-8")
         assert 'f"cc-session-{safe_id}-lessons.jsonl"' in source
         assert re.search(r'safe_id = re\.sub\(r"\[\^a-zA-Z0-9_-\]", "_", session_id\)', source)

--- a/packages/gptme-sessions/tests/test_lesson_events.py
+++ b/packages/gptme-sessions/tests/test_lesson_events.py
@@ -1,0 +1,112 @@
+"""Tests for lesson-event ingestion (producer: the match-lessons CC hook)."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from gptme_sessions.lesson_events import (
+    MAX_LESSON_EVENTS,
+    lesson_events_path,
+    load_lesson_events,
+)
+from gptme_sessions.record import SessionRecord
+
+
+def _write_events(tmp_path: Path, session_id: str, events: list[dict]) -> Path:
+    path = tmp_path / f"cc-session-{session_id}-lessons.jsonl"
+    path.write_text(
+        "".join(json.dumps(e) + "\n" for e in events),
+        encoding="utf-8",
+    )
+    return path
+
+
+@pytest.fixture
+def tmpdir_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("TMPDIR", str(tmp_path))
+    monkeypatch.delenv("CC_SESSION_ID", raising=False)
+    return tmp_path
+
+
+class TestLessonEventsPath:
+    def test_uses_tmpdir_and_hook_naming(self, tmpdir_env):
+        assert lesson_events_path("abc-123") == tmpdir_env / "cc-session-abc-123-lessons.jsonl"
+
+    def test_sanitizes_session_id(self, tmpdir_env):
+        assert lesson_events_path("a/b:c@d").name == "cc-session-a_b_c_d-lessons.jsonl"
+
+    def test_matches_hook_implementation(self, tmpdir_env):
+        """The hook can't import this package, so pin the shared contract here.
+
+        If ``_get_lesson_events_file`` in match-lessons.py ever changes shape,
+        this fails instead of silently producing files nothing reads.
+        """
+        hook = (
+            Path(__file__).resolve().parents[3]
+            / "scripts"
+            / "claude-code-hooks"
+            / "match-lessons.py"
+        )
+        if not hook.exists():  # pragma: no cover - contrib layout only
+            pytest.skip("match-lessons.py hook not present in this checkout")
+        source = hook.read_text(encoding="utf-8")
+        assert 'f"cc-session-{safe_id}-lessons.jsonl"' in source
+        assert re.search(r'safe_id = re\.sub\(r"\[\^a-zA-Z0-9_-\]", "_", session_id\)', source)
+
+
+class TestLoadLessonEvents:
+    def test_missing_file_returns_empty(self, tmpdir_env):
+        assert load_lesson_events("nope") == []
+
+    def test_no_session_id_returns_empty(self, tmpdir_env):
+        assert load_lesson_events() == []
+
+    def test_loads_events(self, tmpdir_env):
+        events = [
+            {"lesson_name": "A", "match_type": "keyword", "sequence_order": 1},
+            {"lesson_name": "B", "match_type": "semantic", "sequence_order": 2},
+        ]
+        _write_events(tmpdir_env, "s1", events)
+        assert load_lesson_events("s1") == events
+
+    def test_falls_back_to_cc_session_id_env(self, tmpdir_env, monkeypatch):
+        _write_events(tmpdir_env, "envid", [{"lesson_name": "A"}])
+        monkeypatch.setenv("CC_SESSION_ID", "envid")
+        assert load_lesson_events() == [{"lesson_name": "A"}]
+
+    def test_skips_partial_trailing_line(self, tmpdir_env):
+        path = _write_events(tmpdir_env, "s2", [{"lesson_name": "A"}])
+        with path.open("a", encoding="utf-8") as f:
+            f.write('{"lesson_name": "B", "match_ty')
+        assert load_lesson_events("s2") == [{"lesson_name": "A"}]
+
+    def test_skips_non_dict_entries(self, tmpdir_env):
+        path = tmpdir_env / "cc-session-s3-lessons.jsonl"
+        path.write_text('{"lesson_name": "A"}\n["nope"]\n\n', encoding="utf-8")
+        assert load_lesson_events("s3") == [{"lesson_name": "A"}]
+
+    def test_truncates_to_max_events(self, tmpdir_env):
+        _write_events(tmpdir_env, "s4", [{"i": i} for i in range(10)])
+        loaded = load_lesson_events("s4", max_events=3)
+        assert loaded == [{"i": 0}, {"i": 1}, {"i": 2}]
+
+    def test_default_cap_is_positive(self):
+        assert MAX_LESSON_EVENTS > 0
+
+
+class TestSessionRecordField:
+    def test_defaults_to_empty_list(self):
+        assert SessionRecord(session_id="x").lesson_events == []
+
+    def test_json_null_coerced_to_empty_list(self):
+        assert SessionRecord(session_id="x", lesson_events=None).lesson_events == []
+
+    def test_round_trips_through_dict(self):
+        events = [{"lesson_name": "A", "match_type": "keyword"}]
+        record = SessionRecord(session_id="x", lesson_events=events)
+        restored = SessionRecord.from_dict(record.to_dict())
+        assert restored.lesson_events == events


### PR DESCRIPTION
## Problem

The Claude Code `match-lessons` hook has been appending per-session lesson injections to `$TMPDIR/cc-session-{id}-lessons.jsonl` for months. **Nothing ever read them back.**

Measured on Bob's container:

- **2,275** hook event files sitting in `/tmp` (written every session, discarded on reboot)
- **5** of **20,449** session records carry a non-empty `lesson_events` array — all from a single day, 2026-08-12
- Current records dropped the field entirely; `SessionRecord` had no `lesson_events` attribute at all

So the harness-supply signal that lesson-efficacy analysis depends on was being produced continuously and thrown away.

## Root cause: a missing join key

The hook names its files by the **harness-native** session id (the Claude Code transcript UUID). Session records use a short id (`5e74`), and `trajectory_path` is an unrelated mktemp name (`/tmp/cc-session-b0P0QO.log`) — so neither field could locate the hook's file.

The autonomous runner already exports `CC_SESSION_ID` with *exactly* the value the hook uses. `load_lesson_events()` defaults to it, so every existing `post_session()` caller running in the session's process tree picks this up with **no signature change**.

## Changes

- `gptme_sessions.lesson_events` — `load_lesson_events()` / `lesson_events_path()`, tolerant JSONL parse (the hook appends while the session runs, so the trailing line is routinely mid-write), capped at 500 events with a warning on truncation
- `SessionRecord.lesson_events` — defaults to `[]`, coerces JSON `null`
- `post_session()` — wires ingestion, plus an explicit `harness_session_id` param for testability

## Contract test

The hook must stay dependency-free, so it cannot import this package and the filename logic is necessarily duplicated. `test_matches_hook_implementation` asserts the hook's source still produces the shape this module reads — a rename now fails loudly instead of silently orphaning the producer again, which is how this went unnoticed for months.

## Verification

- 14 new tests pass; **1144** existing `gptme-sessions` tests pass
- `ruff check` / `ruff format` clean on changed files
- `mypy` reports no new errors (7 pre-existing missing-stub errors in `discovery`/`transcript`/`judge`/`classification` are untouched)
- End-to-end against a live hook file: loads **26** real events

## Follow-up (not in this PR)

`skill_events` is allowlisted alongside `lesson_events` in Bob's field-coverage monitor, but has no producer at all — that needs its own change.