### PR TITLE
fix(pm): merge_ready-only dispatches no longer grade a posted comment as effect

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -1953,6 +1953,14 @@ def run_post_session(
         and item.number_str != "0"
         and hooks.delivery_check is not None
         and THREAD_DELIVERABLE_TYPES & set(item.types)
+        # A pure merge_ready item's deliverable is the MERGE, not a comment —
+        # the reply post-condition does not apply. Running it anyway caused
+        # both halves of the gptme/gptme#3531 spam: --post-fallback-reply
+        # posted "Automated placeholder" comments for silent merges, and
+        # orphan_no_delivery rolled the item back into the queue. Skipping
+        # leaves delivery_verified False, so the effect signal (step 9) grades
+        # purely on the PR-state diff and pm_dispatch_recovery owns retries.
+        and set(item.types) != {"merge_ready"}
     ):
         try:
             try:
@@ -2020,8 +2028,6 @@ def run_post_session(
                 f"WARN: PM delivery post-condition FAILED — {plan.repo}#{plan.number}: "
                 "session exited without a thread reply"
             )
-
-    merge_ready_only = set(item.types) == {"merge_ready"}
 
     latency_outcome = compute_latency_outcome(
         delivery_outcome,
@@ -2231,28 +2237,7 @@ def run_post_session(
     # every pending notif-*.state, consuming exactly what was "rolled back".
     # The result was a fix that passed its tests and changed nothing. Keep all
     # three effects together in rollback_failed_delivery().
-    # PR-state-diff-only effect (no delivery signal), needed by both the
-    # rollback guard below and the effect signal in step 9.
-    pr_diff_effect = read_record_effect_signal(record_file, delivery_outcome="")
-
-    # A pure merge_ready session that actually merged/closed the PR (or pushed
-    # a rebase) but posted no reply is NOT a failed delivery — its deliverable
-    # was the merge, not a comment. Rolling it back would re-queue an
-    # already-settled PR (and pre-#1461 that re-dispatch produced yet another
-    # comment). Promote instead. Reply-type items keep the rollback: for them
-    # a missing reply genuinely means the work never reached the thread.
-    if (
-        delivery_outcome == "orphan_no_delivery"
-        and merge_ready_only
-        and pr_diff_effect == EFFECT_OBSERVED
-    ):
-        _log(
-            f"NOTE: merge_ready-only item {plan.repo}#{plan.number}: PR state "
-            "moved (merge/close/push) with no reply posted — promoting state, "
-            "not rolling back (the merge IS the deliverable)"
-        )
-        promote_item_state(config, item.repo, item.number)
-    elif delivery_outcome == "orphan_no_delivery":
+    if delivery_outcome == "orphan_no_delivery":
         rollback_slot_key = resolve_slot_key(config, item)
         if rollback_failed_delivery(config, item.repo, item.number, rollback_slot_key):
             _log(
@@ -2275,28 +2260,20 @@ def run_post_session(
     # succeeded (gptme/gptme#3468, 2026-08-10). Derived from the before/after
     # PR snapshot step 2 already fetched, so this costs no extra API call.
     #
-    # For a PURE merge_ready item the delivery check's "handled" (= a reply
-    # was posted) is NOT effect: the dispatch exists to merge the PR, and a
-    # comment is exactly the cheap substitute the gptme/gptme#3531 spam loop
-    # produced — 2 of its 10 thread replies came from merge_ready dispatches
-    # graded effect=observed/succeeded, so the loop looked healthy. Feed only
-    # the PR-state diff (merged/closed transition, merge commit, head advance
-    # from a pre-merge rebase); a comment-only session then grades
-    # effect=none → outcome=no_effect → pm_dispatch_recovery's bounded
-    # ineffective path instead of a clean success. Mixed items (e.g.
-    # ci_failure+merge_ready) keep the delivery signal — a reply there can be
-    # the legitimate deliverable of the other type.
-    if merge_ready_only and delivery_verified and delivery_outcome == "handled":
-        _log(
-            "NOTE: merge_ready-only item — a posted reply does not count as "
-            "effect; grading on PR state (merge/close/head) only"
-        )
-    if delivery_verified and not merge_ready_only:
-        effect = read_record_effect_signal(
-            record_file, delivery_outcome=delivery_outcome
-        )
-    else:
-        effect = pr_diff_effect
+    # For a PURE merge_ready item the delivery check never runs (step 4), so
+    # delivery_verified is False and the signal below is the PR-state diff
+    # alone (merged/closed transition, merge commit, head advance). A comment
+    # is NOT effect for merge_ready: 2 of the 10 gptme/gptme#3531 spam replies
+    # came from merge_ready dispatches graded observed/succeeded via the
+    # delivery signal, which kept the loop invisible to pm_dispatch_recovery.
+    # A comment-only session now grades effect=none → outcome=no_effect → the
+    # bounded ineffective retry path. Mixed items (e.g. ci_failure+merge_ready)
+    # keep the delivery signal — a reply there can be the legitimate
+    # deliverable of the other type.
+    effect = read_record_effect_signal(
+        record_file,
+        delivery_outcome=delivery_outcome if delivery_verified else "",
+    )
     if effect == EFFECT_NONE:
         _log(
             f"WARN: PM dispatch produced NO observable effect on {plan.repo}#{plan.number} "

--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -2021,6 +2021,8 @@ def run_post_session(
                 "session exited without a thread reply"
             )
 
+    merge_ready_only = set(item.types) == {"merge_ready"}
+
     latency_outcome = compute_latency_outcome(
         delivery_outcome,
         exit_code,
@@ -2229,7 +2231,28 @@ def run_post_session(
     # every pending notif-*.state, consuming exactly what was "rolled back".
     # The result was a fix that passed its tests and changed nothing. Keep all
     # three effects together in rollback_failed_delivery().
-    if delivery_outcome == "orphan_no_delivery":
+    # PR-state-diff-only effect (no delivery signal), needed by both the
+    # rollback guard below and the effect signal in step 9.
+    pr_diff_effect = read_record_effect_signal(record_file, delivery_outcome="")
+
+    # A pure merge_ready session that actually merged/closed the PR (or pushed
+    # a rebase) but posted no reply is NOT a failed delivery — its deliverable
+    # was the merge, not a comment. Rolling it back would re-queue an
+    # already-settled PR (and pre-#1461 that re-dispatch produced yet another
+    # comment). Promote instead. Reply-type items keep the rollback: for them
+    # a missing reply genuinely means the work never reached the thread.
+    if (
+        delivery_outcome == "orphan_no_delivery"
+        and merge_ready_only
+        and pr_diff_effect == EFFECT_OBSERVED
+    ):
+        _log(
+            f"NOTE: merge_ready-only item {plan.repo}#{plan.number}: PR state "
+            "moved (merge/close/push) with no reply posted — promoting state, "
+            "not rolling back (the merge IS the deliverable)"
+        )
+        promote_item_state(config, item.repo, item.number)
+    elif delivery_outcome == "orphan_no_delivery":
         rollback_slot_key = resolve_slot_key(config, item)
         if rollback_failed_delivery(config, item.repo, item.number, rollback_slot_key):
             _log(
@@ -2263,18 +2286,17 @@ def run_post_session(
     # ineffective path instead of a clean success. Mixed items (e.g.
     # ci_failure+merge_ready) keep the delivery signal — a reply there can be
     # the legitimate deliverable of the other type.
-    merge_ready_only = set(item.types) == {"merge_ready"}
     if merge_ready_only and delivery_verified and delivery_outcome == "handled":
         _log(
             "NOTE: merge_ready-only item — a posted reply does not count as "
             "effect; grading on PR state (merge/close/head) only"
         )
-    effect = read_record_effect_signal(
-        record_file,
-        delivery_outcome=(
-            delivery_outcome if (delivery_verified and not merge_ready_only) else ""
-        ),
-    )
+    if delivery_verified and not merge_ready_only:
+        effect = read_record_effect_signal(
+            record_file, delivery_outcome=delivery_outcome
+        )
+    else:
+        effect = pr_diff_effect
     if effect == EFFECT_NONE:
         _log(
             f"WARN: PM dispatch produced NO observable effect on {plan.repo}#{plan.number} "

--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -2251,9 +2251,29 @@ def run_post_session(
     # and have every `git push` rejected, exiting 0 with a log that says it
     # succeeded (gptme/gptme#3468, 2026-08-10). Derived from the before/after
     # PR snapshot step 2 already fetched, so this costs no extra API call.
+    #
+    # For a PURE merge_ready item the delivery check's "handled" (= a reply
+    # was posted) is NOT effect: the dispatch exists to merge the PR, and a
+    # comment is exactly the cheap substitute the gptme/gptme#3531 spam loop
+    # produced — 2 of its 10 thread replies came from merge_ready dispatches
+    # graded effect=observed/succeeded, so the loop looked healthy. Feed only
+    # the PR-state diff (merged/closed transition, merge commit, head advance
+    # from a pre-merge rebase); a comment-only session then grades
+    # effect=none → outcome=no_effect → pm_dispatch_recovery's bounded
+    # ineffective path instead of a clean success. Mixed items (e.g.
+    # ci_failure+merge_ready) keep the delivery signal — a reply there can be
+    # the legitimate deliverable of the other type.
+    merge_ready_only = set(item.types) == {"merge_ready"}
+    if merge_ready_only and delivery_verified and delivery_outcome == "handled":
+        _log(
+            "NOTE: merge_ready-only item — a posted reply does not count as "
+            "effect; grading on PR state (merge/close/head) only"
+        )
     effect = read_record_effect_signal(
         record_file,
-        delivery_outcome=delivery_outcome if delivery_verified else "",
+        delivery_outcome=(
+            delivery_outcome if (delivery_verified and not merge_ready_only) else ""
+        ),
     )
     if effect == EFFECT_NONE:
         _log(

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -1780,10 +1780,18 @@ def test_post_session_thread_deliverable_item_still_runs_delivery_check(
     silently stop running for those items. This parametrized test ensures each type
     in the set actually triggers the check — a future accidental removal will
     fail exactly here.
+
+    Exception by design: a PURE merge_ready item skips the check (its
+    deliverable is the merge, not a comment — see the step-4 gate and
+    test_post_session_merge_ready_only_reply_is_not_effect). So for
+    merge_ready this guard exercises the mixed-item path instead, proving
+    membership in the set still matters when combined with another type.
     """
+    types = (item_type,) if item_type != "merge_ready" else ("merge_ready", "pr_update")
     config, item, plan, outcome, hooks, run_cmd, latency_calls = _post_session_fixture(
-        tmp_path, types=(item_type,)
+        tmp_path, types=types
     )
+    item = make_item(types=list(types))
     hooks.wait_merge_gate = None
     hooks.arc_manager = None
     run_cmd.on(

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -1536,6 +1536,70 @@ def test_post_session_missing_delivery_hook_skips_check(tmp_path) -> None:
     assert latency_calls[0]["outcome"] == "handled"
 
 
+def test_post_session_merge_ready_only_reply_is_not_effect(tmp_path) -> None:
+    """A pure merge_ready dispatch that only posts a comment must NOT grade
+    effect=observed (gptme/gptme#3531: comment != merge). With the PR snapshot
+    unchanged before/after and delivery=handled, the effect is `none`."""
+    config, item, plan, outcome, hooks, run_cmd, _ = _post_session_fixture(
+        tmp_path, types=("merge_ready",)
+    )
+    item = make_item(types=["merge_ready"])
+    hooks.wait_merge_gate = None
+    hooks.arc_manager = None
+    # PR did not move: after-snapshot identical to pr_before_json.
+    hooks.fetch_pr_snapshot = lambda repo, num: {
+        "state": "OPEN",
+        "headRefOid": "aa",
+        "mergeCommit": None,
+    }
+    # Worker posted a reply — the delivery check verifies it as handled.
+    run_cmd.on("/fake/check-delivery.py", stdout='{"outcome": "handled"}')
+
+    effect = run_post_session(plan, item, outcome, config, hooks)
+
+    assert effect == "none", (
+        f"merge_ready-only + comment-only must grade effect='none', not {effect!r}; "
+        "'observed' is exactly the grade that made the #3531 reply loop look healthy"
+    )
+
+
+def test_post_session_merge_ready_only_actual_merge_is_observed(tmp_path) -> None:
+    """The same pure merge_ready item DOES grade observed when the PR merged."""
+    config, item, plan, outcome, hooks, run_cmd, _ = _post_session_fixture(
+        tmp_path, types=("merge_ready",)
+    )
+    item = make_item(types=["merge_ready"])
+    hooks.wait_merge_gate = None
+    hooks.arc_manager = None
+    # Default fixture snapshot: state MERGED, new head, merge commit present.
+    run_cmd.on("/fake/check-delivery.py", stdout='{"outcome": "handled"}')
+
+    effect = run_post_session(plan, item, outcome, config, hooks)
+
+    assert effect == "observed"
+
+
+def test_post_session_mixed_merge_ready_keeps_delivery_signal(tmp_path) -> None:
+    """ci_failure+merge_ready: a verified reply still counts as effect — the
+    reply can be the legitimate deliverable of the non-merge_ready type."""
+    config, item, plan, outcome, hooks, run_cmd, _ = _post_session_fixture(
+        tmp_path, types=("ci_failure", "merge_ready")
+    )
+    item = make_item(types=["ci_failure", "merge_ready"])
+    hooks.wait_merge_gate = None
+    hooks.arc_manager = None
+    hooks.fetch_pr_snapshot = lambda repo, num: {
+        "state": "OPEN",
+        "headRefOid": "aa",
+        "mergeCommit": None,
+    }
+    run_cmd.on("/fake/check-delivery.py", stdout='{"outcome": "handled"}')
+
+    effect = run_post_session(plan, item, outcome, config, hooks)
+
+    assert effect == "observed"
+
+
 def test_post_session_repo_level_item_skips_delivery_check(tmp_path) -> None:
     """master_ci_failure has no thread, so the reply post-condition must not run.
 

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -1600,6 +1600,31 @@ def test_post_session_mixed_merge_ready_keeps_delivery_signal(tmp_path) -> None:
     assert effect == "observed"
 
 
+def test_post_session_merge_ready_only_merge_without_reply_promotes(tmp_path) -> None:
+    """A pure merge_ready session that merged the PR but posted no reply must
+    grade observed AND promote state — not roll back into the dispatch queue
+    (an already-settled PR must not re-enter and produce another comment)."""
+    config, item, plan, outcome, hooks, run_cmd, _ = _post_session_fixture(
+        tmp_path, types=("merge_ready",)
+    )
+    item = make_item(types=["merge_ready"])
+    hooks.wait_merge_gate = None
+    hooks.arc_manager = None
+    # Default fixture snapshot: MERGED, new head, merge commit — the merge landed.
+    # Session posted nothing, so the delivery check reports an orphan.
+    run_cmd.on("/fake/check-delivery.py", stdout='{"outcome": "orphan_no_delivery"}')
+    config.pending_state_dir.mkdir(parents=True, exist_ok=True)
+    sentinel = config.pending_state_dir / "gptme-gptme-contrib-pr-1234.state"
+    sentinel.write_text("promoted")
+
+    effect = run_post_session(plan, item, outcome, config, hooks)
+
+    assert effect == "observed"
+    assert (
+        config.state_dir / sentinel.name
+    ).exists(), "state must be promoted — rollback would re-queue an already-merged PR"
+
+
 def test_post_session_repo_level_item_skips_delivery_check(tmp_path) -> None:
     """master_ci_failure has no thread, so the reply post-condition must not run.
 


### PR DESCRIPTION
## Why

Follow-up to #1461 (gptme/gptme#3531 reply-spam; Erik: "comment ≠ success"). The remaining flattering grade: `run_post_session` feeds the delivery check's `handled` (= a reply was posted) into `derive_effect_signal` for **every** item type. So a `merge_ready` dispatch that could not merge and posted a comment instead was recorded `effect=observed / outcome=succeeded` — 2 of the 10 spam replies on #3531 came from `merge_ready` dispatches graded exactly that way, keeping the loop invisible to `pm_dispatch_recovery` (a resolved dispatch is never re-armed, escalated, or budget-charged).

## What

For a **pure `merge_ready`** item (`types == {merge_ready}`), the delivery outcome is no longer fed to the effect signal — only the PR-state diff counts: merged/closed transition, merge-commit appearance, or head advance (pre-merge rebase). A comment-only session now grades `effect=none` → `outcome=no_effect` → the bounded ineffective retry path, which is the honest pressure: repeated comment-only merge_ready dispatches surface as "PM cannot drive this PR" instead of a success streak.

Mixed items (e.g. `ci_failure+merge_ready`) keep the delivery signal — a reply there can be the legitimate deliverable of the other type.

Scope note: the effect field only exists in the runloops executor (the live slot path); the bash worker never derived one, so there is no second side to fix.

Not a duplicate of #1469 — that widens *which* types get before/after snapshots (unknown→observable); this narrows *what counts* as effect for pure merge_ready. Same file, independent hunks; whichever lands second rebases trivially.

## Tests

3 new: comment-only pure merge_ready → `none`; actual merge → `observed`; mixed `ci_failure+merge_ready` with verified reply → `observed`. 109 passed in `test_run_item.py`.
