### PR TITLE
feat(twitter): account profiles, --quote, release announcer

### DIFF
--- a/scripts/twitter/release_announce.py
+++ b/scripts/twitter/release_announce.py
@@ -293,6 +293,11 @@ def _main(args: argparse.Namespace, rel: dict) -> int:
     if record.get("announced_at") and (
         args.skip_quote or "bob_quote_id" in record or _org_id_unknown
     ):
+        # Clear stale quote-pending marker when skip_quote is in effect so a
+        # later normal run can post the missing quote without --force.
+        if args.skip_quote and _pending_key("bob_quote_id") in record:
+            record.pop(_pending_key("bob_quote_id"))
+            save_state(state)
         print(f"{key}: already announced ({record.get('org_tweet_id')})")
         return 0
 

--- a/scripts/twitter/release_announce.py
+++ b/scripts/twitter/release_announce.py
@@ -69,11 +69,11 @@ STABLE_TAG_RE = re.compile(r"^v\d+\.\d+\.\d+$")
 #   - feat(tools): read-only audit preset (#3543)
 _FEAT_RE = re.compile(r"^[*-]\s*feat(?:\(([^)]*)\))?!?:\s*(.+)$")
 _AUTHOR_LIST = r"@[\w-]+(?:\s+(?:and|&)\s+@[\w-]+)*"
-_AUTHOR_TRAIL_RE = re.compile(rf"\s+by {_AUTHOR_LIST}\s*$")
+_AUTHOR_TRAIL_RE = re.compile(rf"\s+by {_AUTHOR_LIST}[.,;:!?]*\s*$")
 _PR_NUMBER_TRAIL_RE = re.compile(r"\s+(?:in\s+)?\(?#\d+\)?\s*$")
 _RELEASE_URL_TRAIL_RE = re.compile(
-    r"\s+(?:in\s+)?https?://(?:www\.)?github\.com/[^/\s]+/[^/\s]+/"
-    r"(?:pull|issues)/\d+/?\s*$"
+    r"\s+(?:in\s+)?\(?https?://(?:www\.)?github\.com/[^/\s]+/[^/\s]+/"
+    r"(?:pull|issues)/\d+/?\)?\s*$"
 )
 
 MAX_TWEET = 270  # headroom under 280

--- a/scripts/twitter/release_announce.py
+++ b/scripts/twitter/release_announce.py
@@ -357,6 +357,10 @@ def _main(args: argparse.Namespace, rel: dict) -> int:
             return 1
         _finish_post(state, record, "bob_quote_id", quote_id)
 
+    # When --skip-quote is in effect, clear any stale quote-pending marker so
+    # a later run without --skip-quote can post the missing quote without --force.
+    if args.skip_quote:
+        record.pop(_pending_key("bob_quote_id"), None)
     record["announced_at"] = datetime.now(timezone.utc).isoformat()
     save_state(state)
     print(f"announced {key}: org={org_id} quote={quote_id}")

--- a/scripts/twitter/release_announce.py
+++ b/scripts/twitter/release_announce.py
@@ -124,7 +124,11 @@ def latest_release(repo: str, tag: str | None) -> dict | None:
     if r.returncode != 0:
         print(f"gh release view failed: {r.stderr.strip()}", file=sys.stderr)
         return None
-    data = json.loads(r.stdout)
+    try:
+        data = json.loads(r.stdout)
+    except json.JSONDecodeError as exc:
+        print(f"gh release view returned invalid JSON: {exc}", file=sys.stderr)
+        return None
     return data if isinstance(data, dict) else None
 
 
@@ -178,6 +182,7 @@ def _post(args: list[str], account: str | None = None) -> tuple[bool, str | None
     else:
         env = os.environ.copy()
         env.pop("TWITTER_ACCOUNT", None)
+        env.pop("TWITTER_EXPECTED_USERNAME", None)
     cmd += args
     r = _run(cmd, env=env)
     out = r.stdout + r.stderr

--- a/scripts/twitter/release_announce.py
+++ b/scripts/twitter/release_announce.py
@@ -65,8 +65,11 @@ STABLE_TAG_RE = re.compile(r"^v\d+\.\d+\.\d+$")
 #   - feat(tools): read-only audit preset (#3543)
 _FEAT_RE = re.compile(r"^[*-]\s*feat(?:\(([^)]*)\))?!?:\s*(.+)$")
 _AUTHOR_LIST = r"@[\w-]+(?:\s+(?:and|&)\s+@[\w-]+)*"
-_TRAIL_RE = re.compile(
-    rf"\s*(?:by {_AUTHOR_LIST}(?:\s+in\s+(?:https?://\S+|\(?#\d+\)?))?|(?:in\s+)?(?:https?://\S+|\(?#\d+\)?))\s*$"
+_AUTHOR_TRAIL_RE = re.compile(rf"\s+by {_AUTHOR_LIST}\s*$")
+_PR_NUMBER_TRAIL_RE = re.compile(r"\s+(?:in\s+)?\(?#\d+\)?\s*$")
+_RELEASE_URL_TRAIL_RE = re.compile(
+    r"\s+(?:in\s+)?https?://(?:www\.)?github\.com/[^/\s]+/[^/\s]+/"
+    r"(?:pull|issues)/\d+/?\s*$"
 )
 
 MAX_TWEET = 270  # headroom under 280
@@ -151,7 +154,9 @@ def extract_features(body: str, limit: int = 5) -> list[str]:
             continue
         desc = m.group(2)
         while True:
-            stripped = _TRAIL_RE.sub("", desc).strip()
+            stripped = _AUTHOR_TRAIL_RE.sub("", desc)
+            stripped = _PR_NUMBER_TRAIL_RE.sub("", stripped)
+            stripped = _RELEASE_URL_TRAIL_RE.sub("", stripped).strip()
             if stripped == desc:
                 break
             desc = stripped
@@ -196,7 +201,7 @@ def _post(args: list[str], account: str | None = None) -> tuple[bool, str | None
         cmd += ["--account", account]
     else:
         env = os.environ.copy()
-        env.pop("TWITTER_ACCOUNT", None)
+        env["TWITTER_ACCOUNT"] = ""
         for var in _USER_CONTEXT_VARS:
             env.pop(var, None)
     cmd += args

--- a/scripts/twitter/release_announce.py
+++ b/scripts/twitter/release_announce.py
@@ -258,7 +258,6 @@ def main() -> int:
     ap.add_argument("--repo", default="gptme/gptme")
     ap.add_argument("--tag", default=None, help="announce this tag (default: latest)")
     ap.add_argument("--org-account", default="gptmeorg")
-    ap.add_argument("--handle", default=None, help="org handle for the quote text")
     ap.add_argument("--skip-quote", action="store_true")
     ap.add_argument("--dry-run", action="store_true")
     ap.add_argument("--force", action="store_true", help="re-announce a done tag")

--- a/scripts/twitter/release_announce.py
+++ b/scripts/twitter/release_announce.py
@@ -30,6 +30,7 @@ import sys
 import tempfile
 from collections.abc import Iterator
 from contextlib import contextmanager
+from datetime import datetime, timezone
 from pathlib import Path
 
 try:
@@ -190,6 +191,37 @@ def _post(args: list[str], account: str | None = None) -> tuple[bool, str | None
     return True, m.group(1)
 
 
+def _pending_key(step: str) -> str:
+    return f"{step.removesuffix('_id')}_pending_at"
+
+
+def _begin_post(state: dict, key: str, record: dict, step: str) -> bool:
+    """Persist post intent, refusing to repeat an ambiguous remote side effect."""
+    pending_key = _pending_key(step)
+    if pending_key in record:
+        print(
+            f"{key}: {step} may already have been posted at "
+            f"{record[pending_key]}; refusing to retry without reconciliation",
+            file=sys.stderr,
+        )
+        return False
+    record[pending_key] = datetime.now(timezone.utc).isoformat()
+    state[key] = record
+    save_state(state)
+    return True
+
+
+def _finish_post(state: dict, record: dict, step: str, tweet_id: str | None) -> None:
+    record[step] = tweet_id
+    record.pop(_pending_key(step), None)
+    save_state(state)
+
+
+def _clear_post_intent(state: dict, record: dict, step: str) -> None:
+    record.pop(_pending_key(step), None)
+    save_state(state)
+
+
 def _main(args: argparse.Namespace, rel: dict) -> int:
     tag = rel["tagName"]
     state = load_state()
@@ -213,12 +245,13 @@ def _main(args: argparse.Namespace, rel: dict) -> int:
 
     org_id = record.get("org_tweet_id")
     if "org_tweet_id" not in record:
+        if not _begin_post(state, key, record, "org_tweet_id"):
+            return 1
         posted, org_id = _post(["post", announcement], account=args.org_account)
         if not posted:
+            _clear_post_intent(state, record, "org_tweet_id")
             return 1
-        record["org_tweet_id"] = org_id
-        state[key] = record
-        save_state(state)
+        _finish_post(state, record, "org_tweet_id", org_id)
     if org_id is None:
         print(
             f"{key}: org tweet was posted but its ID is unknown; "
@@ -229,23 +262,25 @@ def _main(args: argparse.Namespace, rel: dict) -> int:
 
     link_reply_id = record.get("link_reply_id")
     if "link_reply_id" not in record:
+        if not _begin_post(state, key, record, "link_reply_id"):
+            return 1
         posted, link_reply_id = _post(
             ["post", link_reply, "--reply-to", org_id], account=args.org_account
         )
         if not posted:
+            _clear_post_intent(state, record, "link_reply_id")
             return 1
-        record["link_reply_id"] = link_reply_id
-        save_state(state)
+        _finish_post(state, record, "link_reply_id", link_reply_id)
 
     quote_id = record.get("bob_quote_id")
     if not args.skip_quote and "bob_quote_id" not in record:
+        if not _begin_post(state, key, record, "bob_quote_id"):
+            return 1
         posted, quote_id = _post(["post", quote_text, "--quote", org_id])
         if not posted:
+            _clear_post_intent(state, record, "bob_quote_id")
             return 1
-        record["bob_quote_id"] = quote_id
-        save_state(state)
-
-    from datetime import datetime, timezone
+        _finish_post(state, record, "bob_quote_id", quote_id)
 
     record["announced_at"] = datetime.now(timezone.utc).isoformat()
     save_state(state)

--- a/scripts/twitter/release_announce.py
+++ b/scripts/twitter/release_announce.py
@@ -70,10 +70,10 @@ STABLE_TAG_RE = re.compile(r"^v\d+\.\d+\.\d+$")
 _FEAT_RE = re.compile(r"^[*-]\s*feat(?:\(([^)]*)\))?!?:\s*(.+)$")
 _AUTHOR_LIST = r"@[\w-]+(?:\s+(?:and|&)\s+@[\w-]+)*"
 _AUTHOR_TRAIL_RE = re.compile(rf"\s+by {_AUTHOR_LIST}[.,;:!?]*\s*$")
-_PR_NUMBER_TRAIL_RE = re.compile(r"\s+(?:in\s+)?\(?#\d+\)?\s*$")
+_PR_NUMBER_TRAIL_RE = re.compile(r"\s+(?:in\s+)?\(?#\d+\)?[.,;:!?]*\s*$")
 _RELEASE_URL_TRAIL_RE = re.compile(
     r"\s+(?:in\s+)?\(?https?://(?:www\.)?github\.com/[^/\s]+/[^/\s]+/"
-    r"(?:pull|issues)/\d+/?\)?\s*$"
+    r"(?:pull|issues)/\d+/?\)?[.,;:!?]*\s*$"
 )
 
 MAX_TWEET = 270  # headroom under 280
@@ -209,7 +209,13 @@ def _post(args: list[str], account: str | None = None) -> tuple[bool, str | None
         env["TWITTER_ACCOUNT"] = ""
         for var in _USER_CONTEXT_VARS:
             env.pop(var, None)
-    if args and args[0] == "post":
+    if args and args[0] == "post" and len(args) > 1:
+        # Protect the tweet text (second arg) from being parsed as a CLI option
+        # when it starts with '-'. Restructure to: post [options] --headless -- TEXT
+        text = args[1]
+        rest = args[2:]  # any trailing options like --reply-to, --quote
+        args = ["post", *rest, "--headless", "--", text]
+    elif args and args[0] == "post":
         args = [*args, "--headless"]
     cmd += args
     r = _run(cmd, env=env)

--- a/scripts/twitter/release_announce.py
+++ b/scripts/twitter/release_announce.py
@@ -210,8 +210,12 @@ def _post(args: list[str], account: str | None = None) -> tuple[bool, str | None
         for var in _USER_CONTEXT_VARS:
             env.pop(var, None)
     if args and args[0] == "post" and len(args) > 1:
-        # Protect the tweet text (second arg) from being parsed as a CLI option
-        # when it starts with '-'. Restructure to: post [options] --headless -- TEXT
+        # Protect the tweet text from being parsed as a CLI option when it starts
+        # with '-'. Restructure to: post [options] --headless -- TEXT.
+        # CALLER CONTRACT: args[1] must be the tweet text; all trailing options
+        # (--reply-to, --quote …) must come at args[2:]. Placing an option at
+        # args[1] silently corrupts the command line, so _post callers must not
+        # start with an option at position 1.
         text = args[1]
         rest = args[2:]  # any trailing options like --reply-to, --quote
         args = ["post", *rest, "--headless", "--", text]
@@ -279,7 +283,12 @@ def _main(args: argparse.Namespace, rel: dict) -> int:
     state = load_state()
     key = f"{args.repo}#{tag}"
     record = state.get(key, {}) if not args.force else {}
-    if record.get("announced_at") and (args.skip_quote or "bob_quote_id" in record):
+    # "org_tweet_id" in record with value None = posted but ID unknown; quote is
+    # not recoverable without the ID, so treat this as a complete (degraded) state.
+    _org_id_unknown = "org_tweet_id" in record and record["org_tweet_id"] is None
+    if record.get("announced_at") and (
+        args.skip_quote or "bob_quote_id" in record or _org_id_unknown
+    ):
         print(f"{key}: already announced ({record.get('org_tweet_id')})")
         return 0
 
@@ -306,12 +315,21 @@ def _main(args: argparse.Namespace, rel: dict) -> int:
             return 1
         _finish_post(state, record, "org_tweet_id", org_id)
     if org_id is None:
+        # The org tweet was posted but its ID was not captured.  The reply and
+        # quote steps both need the ID, so they cannot be posted automatically.
+        # Mark as announced (degraded: no reply or quote) so that subsequent
+        # timer runs do not permanently fail.
+        # To add the missing reply and quote: edit the state file to set
+        # org_tweet_id to the actual tweet ID and remove announced_at, then re-run.
         print(
             f"{key}: org tweet was posted but its ID is unknown; "
-            "cannot safely post the reply or quote",
+            "reply and quote skipped — marking as announced (degraded). "
+            f"Recovery: set org_tweet_id in {STATE_FILE}, remove announced_at, then re-run.",
             file=sys.stderr,
         )
-        return 1
+        record["announced_at"] = datetime.now(timezone.utc).isoformat()
+        save_state(state)
+        return 0
 
     link_reply_id = record.get("link_reply_id")
     if "link_reply_id" not in record:

--- a/scripts/twitter/release_announce.py
+++ b/scripts/twitter/release_announce.py
@@ -233,12 +233,26 @@ def _pending_key(step: str) -> str:
 
 
 def _begin_post(state: dict, key: str, record: dict, step: str) -> bool:
-    """Persist post intent, refusing to repeat an ambiguous remote side effect."""
+    """Persist post intent, refusing to repeat an ambiguous remote side effect.
+
+    The pending marker is cleared only on confirmed success (``_finish_post``).
+    If the post step failed (subprocess non-zero) or the process was killed
+    after ``_begin_post`` but before the result was recorded, the marker remains
+    so a later timer run refuses to retry blindly.
+
+    Recovery: if you are certain the tweet was NOT posted (e.g. the crash
+    happened before the subprocess started), run with ``--force`` to reset all
+    state for this tag and retry from scratch.  If the tweet WAS posted but the
+    ID was never recorded, reconcile the state file manually (set the tweet ID
+    and remove the pending key) before running without ``--force``.
+    """
     pending_key = _pending_key(step)
     if pending_key in record:
         print(
             f"{key}: {step} may already have been posted at "
-            f"{record[pending_key]}; refusing to retry without reconciliation",
+            f"{record[pending_key]}; refusing to retry without reconciliation. "
+            "Run with --force to reset all state for this tag (risk: duplicate "
+            "tweet if the post succeeded), or edit the state file manually.",
             file=sys.stderr,
         )
         return False
@@ -250,11 +264,6 @@ def _begin_post(state: dict, key: str, record: dict, step: str) -> bool:
 
 def _finish_post(state: dict, record: dict, step: str, tweet_id: str | None) -> None:
     record[step] = tweet_id
-    record.pop(_pending_key(step), None)
-    save_state(state)
-
-
-def _clear_post_intent(state: dict, record: dict, step: str) -> None:
     record.pop(_pending_key(step), None)
     save_state(state)
 
@@ -286,7 +295,8 @@ def _main(args: argparse.Namespace, rel: dict) -> int:
             return 1
         posted, org_id = _post(["post", announcement], account=args.org_account)
         if not posted:
-            _clear_post_intent(state, record, "org_tweet_id")
+            # Keep the pending marker so a later run refuses blind retry.
+            # Use --force to reset if certain no tweet was posted.
             return 1
         _finish_post(state, record, "org_tweet_id", org_id)
     if org_id is None:
@@ -305,7 +315,7 @@ def _main(args: argparse.Namespace, rel: dict) -> int:
             ["post", link_reply, "--reply-to", org_id], account=args.org_account
         )
         if not posted:
-            _clear_post_intent(state, record, "link_reply_id")
+            # Keep the pending marker so a later run refuses blind retry.
             return 1
         _finish_post(state, record, "link_reply_id", link_reply_id)
 
@@ -315,7 +325,7 @@ def _main(args: argparse.Namespace, rel: dict) -> int:
             return 1
         posted, quote_id = _post(["post", quote_text, "--quote", org_id])
         if not posted:
-            _clear_post_intent(state, record, "bob_quote_id")
+            # Keep the pending marker so a later run refuses blind retry.
             return 1
         _finish_post(state, record, "bob_quote_id", quote_id)
 
@@ -332,7 +342,15 @@ def main() -> int:
     ap.add_argument("--org-account", default="gptmeorg")
     ap.add_argument("--skip-quote", action="store_true")
     ap.add_argument("--dry-run", action="store_true")
-    ap.add_argument("--force", action="store_true", help="re-announce a done tag")
+    ap.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "re-announce a done tag or clear stale pending markers left by a "
+            "crashed run; resets all per-tag state, so a partially-completed "
+            "announcement may re-post already-sent tweets"
+        ),
+    )
     args = ap.parse_args()
 
     rel = latest_release(args.repo, args.tag)

--- a/scripts/twitter/release_announce.py
+++ b/scripts/twitter/release_announce.py
@@ -56,7 +56,7 @@ STABLE_TAG_RE = re.compile(r"^v\d+\.\d+\.\d+$")
 #   - feat(tools): read-only audit preset (#3543)
 _FEAT_RE = re.compile(r"^[*-]\s*feat(?:\(([^)]*)\))?!?:\s*(.+)$")
 _TRAIL_RE = re.compile(
-    r"\s*(?:by @[\w-]+)?\s*(?:in\s+)?(?:https?://\S+|\(?#\d+\)?)\s*$"
+    r"\s*(?:by @[\w-]+(?:\s+in\s+(?:https?://\S+|\(?#\d+\)?))?|(?:in\s+)?(?:https?://\S+|\(?#\d+\)?)|by @[\w-]+)\s*$"
 )
 
 MAX_TWEET = 270  # headroom under 280

--- a/scripts/twitter/release_announce.py
+++ b/scripts/twitter/release_announce.py
@@ -200,13 +200,14 @@ def compose_quote(tag: str, repo: str) -> str:
 def _post(args: list[str], account: str | None = None) -> tuple[bool, str | None]:
     """Run twitter.py post ... and return success plus the created tweet id."""
     cmd = [sys.executable, str(TWITTER_CLI)]
-    env = None
+    env = os.environ.copy()
+    for var in _AUTOMATION_UNSAFE_OAUTH_VARS:
+        env.pop(var, None)
     if account:
         cmd += ["--account", account]
     else:
-        env = os.environ.copy()
         env["TWITTER_ACCOUNT"] = ""
-        for var in (*_USER_CONTEXT_VARS, *_AUTOMATION_UNSAFE_OAUTH_VARS):
+        for var in _USER_CONTEXT_VARS:
             env.pop(var, None)
     cmd += args
     r = _run(cmd, env=env)

--- a/scripts/twitter/release_announce.py
+++ b/scripts/twitter/release_announce.py
@@ -33,6 +33,15 @@ from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 
+_USER_CONTEXT_VARS = (
+    "TWITTER_OAUTH2_ACCESS_TOKEN",
+    "TWITTER_OAUTH2_REFRESH_TOKEN",
+    "TWITTER_OAUTH2_EXPIRES_AT",
+    "TWITTER_ACCESS_TOKEN",
+    "TWITTER_ACCESS_SECRET",
+    "TWITTER_EXPECTED_USERNAME",
+)
+
 try:
     import fcntl as _fcntl
 except ImportError:  # pragma: no cover - Windows
@@ -182,7 +191,8 @@ def _post(args: list[str], account: str | None = None) -> tuple[bool, str | None
     else:
         env = os.environ.copy()
         env.pop("TWITTER_ACCOUNT", None)
-        env.pop("TWITTER_EXPECTED_USERNAME", None)
+        for var in _USER_CONTEXT_VARS:
+            env.pop(var, None)
     cmd += args
     r = _run(cmd, env=env)
     out = r.stdout + r.stderr

--- a/scripts/twitter/release_announce.py
+++ b/scripts/twitter/release_announce.py
@@ -209,6 +209,8 @@ def _post(args: list[str], account: str | None = None) -> tuple[bool, str | None
         env["TWITTER_ACCOUNT"] = ""
         for var in _USER_CONTEXT_VARS:
             env.pop(var, None)
+    if args and args[0] == "post":
+        args = [*args, "--headless"]
     cmd += args
     r = _run(cmd, env=env)
     out = r.stdout + r.stderr

--- a/scripts/twitter/release_announce.py
+++ b/scripts/twitter/release_announce.py
@@ -27,6 +27,7 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 TWITTER_CLI = Path(__file__).resolve().parent / "twitter.py"
@@ -62,9 +63,19 @@ def load_state() -> dict:
 
 def save_state(state: dict) -> None:
     STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
-    tmp = STATE_FILE.with_suffix(".tmp")
-    tmp.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n")
-    tmp.replace(STATE_FILE)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{STATE_FILE.name}.", dir=STATE_FILE.parent
+    )
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(state, f, indent=2, sort_keys=True)
+            f.write("\n")
+            f.flush()
+            os.fsync(f.fileno())
+        tmp.replace(STATE_FILE)
+    finally:
+        tmp.unlink(missing_ok=True)
 
 
 def latest_release(repo: str, tag: str | None) -> dict | None:
@@ -88,6 +99,7 @@ def extract_features(body: str, limit: int = 5) -> list[str]:
         if not m:
             continue
         desc = _TRAIL_RE.sub("", m.group(2)).strip().rstrip(".")
+        desc = re.sub(r"\s*\(?#\d+\)?", "", desc).strip()
         # Strip markdown backticks/bold but keep the text
         desc = desc.replace("**", "")
         if desc:
@@ -110,6 +122,14 @@ def compose_announcement(tag: str, body: str, repo: str) -> str:
             break
         lines = candidate
     return "\n".join(lines)
+
+
+def compose_quote(tag: str, repo: str) -> str:
+    repo_name = repo.split("/")[-1]
+    return (
+        f"{repo_name} {tag} is out — release notes below. "
+        "Built with gptme, reviewed by agents, shipped by CI."
+    )
 
 
 def _post(args: list[str], account: str | None = None) -> str | None:
@@ -151,13 +171,14 @@ def main() -> int:
 
     state = load_state()
     key = f"{args.repo}#{tag}"
-    if key in state and not args.force:
-        print(f"{key}: already announced ({state[key].get('org_tweet_id')})")
+    record = state.get(key, {}) if not args.force else {}
+    if record.get("announced_at"):
+        print(f"{key}: already announced ({record.get('org_tweet_id')})")
         return 0
 
     announcement = compose_announcement(tag, rel.get("body", ""), args.repo)
     link_reply = rel["url"]
-    quote_text = f"gptme {tag} is out — release notes below. Built with gptme, reviewed by agents, shipped by CI."
+    quote_text = compose_quote(tag, args.repo)
 
     print(f"--- announcement (@{args.org_account}) ---\n{announcement}\n")
     print(f"--- link reply ---\n{link_reply}\n")
@@ -167,22 +188,36 @@ def main() -> int:
         print("dry-run: nothing posted")
         return 0
 
-    org_id = _post(["post", announcement], account=args.org_account)
+    org_id = record.get("org_tweet_id")
     if not org_id:
-        return 1
-    _post(["post", link_reply, "--reply-to", org_id], account=args.org_account)
+        org_id = _post(["post", announcement], account=args.org_account)
+        if not org_id:
+            return 1
+        record["org_tweet_id"] = org_id
+        state[key] = record
+        save_state(state)
 
-    quote_id = None
-    if not args.skip_quote:
+    link_reply_id = record.get("link_reply_id")
+    if not link_reply_id:
+        link_reply_id = _post(
+            ["post", link_reply, "--reply-to", org_id], account=args.org_account
+        )
+        if not link_reply_id:
+            return 1
+        record["link_reply_id"] = link_reply_id
+        save_state(state)
+
+    quote_id = record.get("bob_quote_id")
+    if not args.skip_quote and not quote_id:
         quote_id = _post(["post", quote_text, "--quote", org_id])
+        if not quote_id:
+            return 1
+        record["bob_quote_id"] = quote_id
+        save_state(state)
 
     from datetime import datetime, timezone
 
-    state[key] = {
-        "org_tweet_id": org_id,
-        "bob_quote_id": quote_id,
-        "announced_at": datetime.now(timezone.utc).isoformat(),
-    }
+    record["announced_at"] = datetime.now(timezone.utc).isoformat()
     save_state(state)
     print(f"announced {key}: org={org_id} quote={quote_id}")
     return 0

--- a/scripts/twitter/release_announce.py
+++ b/scripts/twitter/release_announce.py
@@ -227,15 +227,19 @@ def _post(args: list[str], account: str | None = None) -> tuple[bool, str | None
     if r.returncode != 0:
         print(f"twitter.py failed ({r.returncode}):\n{out}", file=sys.stderr)
         return False, None
-    m = re.search(r"Tweet ID: (\d+)", out)
-    if not m:
+    # Strip ANSI so a Rich-colored "Tweet ID: N" still matches. Line-anchored
+    # last match wins: tweet text containing "Tweet ID: 123" must not steal
+    # the created id (the CLI prints the id on its own line after the body).
+    clean = re.sub(r"\x1b\[[0-9;]*m", "", out)
+    ids = re.findall(r"(?m)^\s*Tweet ID: (\d+)\s*$", clean)
+    if not ids:
         print(
             "twitter.py succeeded but did not report a tweet ID; "
             "recording the step as posted and refusing to retry",
             file=sys.stderr,
         )
         return True, None
-    return True, m.group(1)
+    return True, ids[-1]
 
 
 def _pending_key(step: str) -> str:

--- a/scripts/twitter/release_announce.py
+++ b/scripts/twitter/release_announce.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Announce a new stable release on X, then quote-tweet it from Bob.
+
+Flow (idempotent, state-ledgered):
+  1. Read the latest release of --repo via `gh release view`.
+  2. Skip prereleases and already-announced tags.
+  3. Compose a short announcement from the release notes (feat-line
+     extraction, no LLM) and post it from the org account
+     (``twitter.py --account gptmeorg post``), with the release URL in a
+     reply tweet (links depress reach in the main tweet).
+  4. Quote-tweet the announcement from the default account (Bob).
+
+Designed to run from a timer: exits 0 quickly when there is nothing new.
+
+Usage:
+    release_announce.py                       # announce latest stable, if new
+    release_announce.py --tag v0.33.0         # announce a specific tag
+    release_announce.py --dry-run             # print tweets, post nothing
+    release_announce.py --skip-quote          # org tweet only
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+TWITTER_CLI = Path(__file__).resolve().parent / "twitter.py"
+STATE_FILE = (
+    Path(os.getenv("XDG_STATE_HOME", str(Path.home() / ".local" / "state")))
+    / "gptwitter"
+    / "release-announcements.json"
+)
+
+STABLE_TAG_RE = re.compile(r"^v\d+\.\d+\.\d+$")
+# Release notes carry lines like:
+#   * feat(cli): add `gptme explain` for offline concept answers by @Bob in #3542
+#   - feat(tools): read-only audit preset (#3543)
+_FEAT_RE = re.compile(r"^[*-]\s*feat(?:\(([^)]*)\))?!?:\s*(.+)$")
+_TRAIL_RE = re.compile(
+    r"\s*(?:by @[\w-]+)?\s*(?:in\s+)?(?:https?://\S+|\(?#\d+\)?)\s*$"
+)
+
+MAX_TWEET = 270  # headroom under 280
+
+
+def _run(cmd: list[str], **kw) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, capture_output=True, text=True, **kw)
+
+
+def load_state() -> dict:
+    try:
+        data = json.loads(STATE_FILE.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def save_state(state: dict) -> None:
+    STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    tmp = STATE_FILE.with_suffix(".tmp")
+    tmp.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n")
+    tmp.replace(STATE_FILE)
+
+
+def latest_release(repo: str, tag: str | None) -> dict | None:
+    cmd = ["gh", "release", "view"]
+    if tag:
+        cmd.append(tag)
+    cmd += ["--repo", repo, "--json", "tagName,isPrerelease,body,url,publishedAt"]
+    r = _run(cmd)
+    if r.returncode != 0:
+        print(f"gh release view failed: {r.stderr.strip()}", file=sys.stderr)
+        return None
+    data = json.loads(r.stdout)
+    return data if isinstance(data, dict) else None
+
+
+def extract_features(body: str, limit: int = 5) -> list[str]:
+    """Pull the most user-facing feat lines out of auto-generated notes."""
+    feats: list[str] = []
+    for line in body.splitlines():
+        m = _FEAT_RE.match(line.strip())
+        if not m:
+            continue
+        desc = _TRAIL_RE.sub("", m.group(2)).strip().rstrip(".")
+        # Strip markdown backticks/bold but keep the text
+        desc = desc.replace("**", "")
+        if desc:
+            feats.append(desc)
+    return feats[:limit]
+
+
+def compose_announcement(tag: str, body: str, repo: str) -> str:
+    version = tag.lstrip("v")
+    feats = extract_features(body)
+    header = f"gptme v{version} is out 🎉"
+    if repo.split("/")[-1] != "gptme":
+        header = f"{repo.split('/')[-1]} v{version} is out 🎉"
+    if not feats:
+        return f"{header}\n\nRelease notes in the reply."
+    lines = [header, ""]
+    for f in feats:
+        candidate = lines + [f"— {f}"]
+        if len("\n".join(candidate)) > MAX_TWEET:
+            break
+        lines = candidate
+    return "\n".join(lines)
+
+
+def _post(args: list[str], account: str | None = None) -> str | None:
+    """Run twitter.py post ... and return the created tweet id."""
+    cmd = [sys.executable, str(TWITTER_CLI)]
+    if account:
+        cmd += ["--account", account]
+    cmd += args
+    r = _run(cmd)
+    out = r.stdout + r.stderr
+    if r.returncode != 0:
+        print(f"twitter.py failed ({r.returncode}):\n{out}", file=sys.stderr)
+        return None
+    m = re.search(r"Tweet ID: (\d+)", out)
+    return m.group(1) if m else None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--repo", default="gptme/gptme")
+    ap.add_argument("--tag", default=None, help="announce this tag (default: latest)")
+    ap.add_argument("--org-account", default="gptmeorg")
+    ap.add_argument("--handle", default=None, help="org handle for the quote text")
+    ap.add_argument("--skip-quote", action="store_true")
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--force", action="store_true", help="re-announce a done tag")
+    args = ap.parse_args()
+
+    rel = latest_release(args.repo, args.tag)
+    if rel is None:
+        return 1
+    tag = rel["tagName"]
+    if rel.get("isPrerelease"):
+        print(f"{tag}: prerelease — skipping")
+        return 0
+    if not STABLE_TAG_RE.match(tag):
+        print(f"{tag}: not a stable vX.Y.Z tag — skipping")
+        return 0
+
+    state = load_state()
+    key = f"{args.repo}#{tag}"
+    if key in state and not args.force:
+        print(f"{key}: already announced ({state[key].get('org_tweet_id')})")
+        return 0
+
+    announcement = compose_announcement(tag, rel.get("body", ""), args.repo)
+    link_reply = rel["url"]
+    quote_text = f"gptme {tag} is out — release notes below. Built with gptme, reviewed by agents, shipped by CI."
+
+    print(f"--- announcement (@{args.org_account}) ---\n{announcement}\n")
+    print(f"--- link reply ---\n{link_reply}\n")
+    if not args.skip_quote:
+        print(f"--- Bob quote ---\n{quote_text}\n")
+    if args.dry_run:
+        print("dry-run: nothing posted")
+        return 0
+
+    org_id = _post(["post", announcement], account=args.org_account)
+    if not org_id:
+        return 1
+    _post(["post", link_reply, "--reply-to", org_id], account=args.org_account)
+
+    quote_id = None
+    if not args.skip_quote:
+        quote_id = _post(["post", quote_text, "--quote", org_id])
+
+    from datetime import datetime, timezone
+
+    state[key] = {
+        "org_tweet_id": org_id,
+        "bob_quote_id": quote_id,
+        "announced_at": datetime.now(timezone.utc).isoformat(),
+    }
+    save_state(state)
+    print(f"announced {key}: org={org_id} quote={quote_id}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/twitter/release_announce.py
+++ b/scripts/twitter/release_announce.py
@@ -28,7 +28,19 @@ import re
 import subprocess
 import sys
 import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
+
+try:
+    import fcntl as _fcntl
+except ImportError:  # pragma: no cover - Windows
+    _fcntl = None  # type: ignore[assignment]
+
+try:
+    import msvcrt as _msvcrt
+except ImportError:  # pragma: no cover - non-Windows
+    _msvcrt = None  # type: ignore[assignment]
 
 TWITTER_CLI = Path(__file__).resolve().parent / "twitter.py"
 STATE_FILE = (
@@ -76,6 +88,30 @@ def save_state(state: dict) -> None:
         tmp.replace(STATE_FILE)
     finally:
         tmp.unlink(missing_ok=True)
+
+
+@contextmanager
+def state_lock() -> Iterator[None]:
+    """Serialize the full post-and-record transaction across timer runs."""
+    STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    lock_file = STATE_FILE.with_name(f"{STATE_FILE.name}.lock")
+    with lock_file.open("ab") as lock:
+        if _fcntl is not None:
+            _fcntl.flock(lock, _fcntl.LOCK_EX)
+        elif _msvcrt is not None:  # pragma: no cover - Windows only
+            if lock.tell() == 0:
+                lock.write(b"\x00")
+                lock.flush()
+            lock.seek(0)
+            _msvcrt.locking(lock.fileno(), _msvcrt.LK_LOCK, 1)
+        try:
+            yield
+        finally:
+            if _fcntl is not None:
+                _fcntl.flock(lock, _fcntl.LOCK_UN)
+            elif _msvcrt is not None:  # pragma: no cover - Windows only
+                lock.seek(0)
+                _msvcrt.locking(lock.fileno(), _msvcrt.LK_UNLCK, 1)
 
 
 def latest_release(repo: str, tag: str | None) -> dict | None:
@@ -132,8 +168,8 @@ def compose_quote(tag: str, repo: str) -> str:
     )
 
 
-def _post(args: list[str], account: str | None = None) -> str | None:
-    """Run twitter.py post ... and return the created tweet id."""
+def _post(args: list[str], account: str | None = None) -> tuple[bool, str | None]:
+    """Run twitter.py post ... and return success plus the created tweet id."""
     cmd = [sys.executable, str(TWITTER_CLI)]
     if account:
         cmd += ["--account", account]
@@ -142,9 +178,79 @@ def _post(args: list[str], account: str | None = None) -> str | None:
     out = r.stdout + r.stderr
     if r.returncode != 0:
         print(f"twitter.py failed ({r.returncode}):\n{out}", file=sys.stderr)
-        return None
+        return False, None
     m = re.search(r"Tweet ID: (\d+)", out)
-    return m.group(1) if m else None
+    if not m:
+        print(
+            "twitter.py succeeded but did not report a tweet ID; "
+            "recording the step as posted and refusing to retry",
+            file=sys.stderr,
+        )
+        return True, None
+    return True, m.group(1)
+
+
+def _main(args: argparse.Namespace, rel: dict) -> int:
+    tag = rel["tagName"]
+    state = load_state()
+    key = f"{args.repo}#{tag}"
+    record = state.get(key, {}) if not args.force else {}
+    if record.get("announced_at"):
+        print(f"{key}: already announced ({record.get('org_tweet_id')})")
+        return 0
+
+    announcement = compose_announcement(tag, rel.get("body", ""), args.repo)
+    link_reply = rel["url"]
+    quote_text = compose_quote(tag, args.repo)
+
+    print(f"--- announcement (@{args.org_account}) ---\n{announcement}\n")
+    print(f"--- link reply ---\n{link_reply}\n")
+    if not args.skip_quote:
+        print(f"--- Bob quote ---\n{quote_text}\n")
+    if args.dry_run:
+        print("dry-run: nothing posted")
+        return 0
+
+    org_id = record.get("org_tweet_id")
+    if "org_tweet_id" not in record:
+        posted, org_id = _post(["post", announcement], account=args.org_account)
+        if not posted:
+            return 1
+        record["org_tweet_id"] = org_id
+        state[key] = record
+        save_state(state)
+    if org_id is None:
+        print(
+            f"{key}: org tweet was posted but its ID is unknown; "
+            "cannot safely post the reply or quote",
+            file=sys.stderr,
+        )
+        return 1
+
+    link_reply_id = record.get("link_reply_id")
+    if "link_reply_id" not in record:
+        posted, link_reply_id = _post(
+            ["post", link_reply, "--reply-to", org_id], account=args.org_account
+        )
+        if not posted:
+            return 1
+        record["link_reply_id"] = link_reply_id
+        save_state(state)
+
+    quote_id = record.get("bob_quote_id")
+    if not args.skip_quote and "bob_quote_id" not in record:
+        posted, quote_id = _post(["post", quote_text, "--quote", org_id])
+        if not posted:
+            return 1
+        record["bob_quote_id"] = quote_id
+        save_state(state)
+
+    from datetime import datetime, timezone
+
+    record["announced_at"] = datetime.now(timezone.utc).isoformat()
+    save_state(state)
+    print(f"announced {key}: org={org_id} quote={quote_id}")
+    return 0
 
 
 def main() -> int:
@@ -168,59 +274,10 @@ def main() -> int:
     if not STABLE_TAG_RE.match(tag):
         print(f"{tag}: not a stable vX.Y.Z tag — skipping")
         return 0
-
-    state = load_state()
-    key = f"{args.repo}#{tag}"
-    record = state.get(key, {}) if not args.force else {}
-    if record.get("announced_at"):
-        print(f"{key}: already announced ({record.get('org_tweet_id')})")
-        return 0
-
-    announcement = compose_announcement(tag, rel.get("body", ""), args.repo)
-    link_reply = rel["url"]
-    quote_text = compose_quote(tag, args.repo)
-
-    print(f"--- announcement (@{args.org_account}) ---\n{announcement}\n")
-    print(f"--- link reply ---\n{link_reply}\n")
-    if not args.skip_quote:
-        print(f"--- Bob quote ---\n{quote_text}\n")
     if args.dry_run:
-        print("dry-run: nothing posted")
-        return 0
-
-    org_id = record.get("org_tweet_id")
-    if not org_id:
-        org_id = _post(["post", announcement], account=args.org_account)
-        if not org_id:
-            return 1
-        record["org_tweet_id"] = org_id
-        state[key] = record
-        save_state(state)
-
-    link_reply_id = record.get("link_reply_id")
-    if not link_reply_id:
-        link_reply_id = _post(
-            ["post", link_reply, "--reply-to", org_id], account=args.org_account
-        )
-        if not link_reply_id:
-            return 1
-        record["link_reply_id"] = link_reply_id
-        save_state(state)
-
-    quote_id = record.get("bob_quote_id")
-    if not args.skip_quote and not quote_id:
-        quote_id = _post(["post", quote_text, "--quote", org_id])
-        if not quote_id:
-            return 1
-        record["bob_quote_id"] = quote_id
-        save_state(state)
-
-    from datetime import datetime, timezone
-
-    record["announced_at"] = datetime.now(timezone.utc).isoformat()
-    save_state(state)
-    print(f"announced {key}: org={org_id} quote={quote_id}")
-    return 0
+        return _main(args, rel)
+    with state_lock():
+        return _main(args, rel)
 
 
 if __name__ == "__main__":

--- a/scripts/twitter/release_announce.py
+++ b/scripts/twitter/release_announce.py
@@ -64,8 +64,9 @@ STABLE_TAG_RE = re.compile(r"^v\d+\.\d+\.\d+$")
 #   * feat(cli): add `gptme explain` for offline concept answers by @Bob in #3542
 #   - feat(tools): read-only audit preset (#3543)
 _FEAT_RE = re.compile(r"^[*-]\s*feat(?:\(([^)]*)\))?!?:\s*(.+)$")
+_AUTHOR_LIST = r"@[\w-]+(?:\s+(?:and|&)\s+@[\w-]+)*"
 _TRAIL_RE = re.compile(
-    r"\s*(?:by @[\w-]+(?:\s+in\s+(?:https?://\S+|\(?#\d+\)?))?|(?:in\s+)?(?:https?://\S+|\(?#\d+\)?)|by @[\w-]+)\s*$"
+    rf"\s*(?:by {_AUTHOR_LIST}(?:\s+in\s+(?:https?://\S+|\(?#\d+\)?))?|(?:in\s+)?(?:https?://\S+|\(?#\d+\)?))\s*$"
 )
 
 MAX_TWEET = 270  # headroom under 280
@@ -148,8 +149,13 @@ def extract_features(body: str, limit: int = 5) -> list[str]:
         m = _FEAT_RE.match(line.strip())
         if not m:
             continue
-        desc = _TRAIL_RE.sub("", m.group(2)).strip().rstrip(".")
-        desc = re.sub(r"\s*\(?#\d+\)?", "", desc).strip()
+        desc = m.group(2)
+        while True:
+            stripped = _TRAIL_RE.sub("", desc).strip()
+            if stripped == desc:
+                break
+            desc = stripped
+        desc = desc.rstrip(".")
         # Strip markdown backticks/bold but keep the text
         desc = desc.replace("**", "")
         if desc:

--- a/scripts/twitter/release_announce.py
+++ b/scripts/twitter/release_announce.py
@@ -41,6 +41,10 @@ _USER_CONTEXT_VARS = (
     "TWITTER_ACCESS_SECRET",
     "TWITTER_EXPECTED_USERNAME",
 )
+_AUTOMATION_UNSAFE_OAUTH_VARS = (
+    "TWITTER_OAUTH_CALLBACK_FILE",
+    "TWITTER_OAUTH_CALLBACK_TIMEOUT",
+)
 
 try:
     import fcntl as _fcntl
@@ -202,7 +206,7 @@ def _post(args: list[str], account: str | None = None) -> tuple[bool, str | None
     else:
         env = os.environ.copy()
         env["TWITTER_ACCOUNT"] = ""
-        for var in _USER_CONTEXT_VARS:
+        for var in (*_USER_CONTEXT_VARS, *_AUTOMATION_UNSAFE_OAUTH_VARS):
             env.pop(var, None)
     cmd += args
     r = _run(cmd, env=env)

--- a/scripts/twitter/release_announce.py
+++ b/scripts/twitter/release_announce.py
@@ -172,10 +172,14 @@ def compose_quote(tag: str, repo: str) -> str:
 def _post(args: list[str], account: str | None = None) -> tuple[bool, str | None]:
     """Run twitter.py post ... and return success plus the created tweet id."""
     cmd = [sys.executable, str(TWITTER_CLI)]
+    env = None
     if account:
         cmd += ["--account", account]
+    else:
+        env = os.environ.copy()
+        env.pop("TWITTER_ACCOUNT", None)
     cmd += args
-    r = _run(cmd)
+    r = _run(cmd, env=env)
     out = r.stdout + r.stderr
     if r.returncode != 0:
         print(f"twitter.py failed ({r.returncode}):\n{out}", file=sys.stderr)
@@ -227,7 +231,7 @@ def _main(args: argparse.Namespace, rel: dict) -> int:
     state = load_state()
     key = f"{args.repo}#{tag}"
     record = state.get(key, {}) if not args.force else {}
-    if record.get("announced_at"):
+    if record.get("announced_at") and (args.skip_quote or "bob_quote_id" in record):
         print(f"{key}: already announced ({record.get('org_tweet_id')})")
         return 0
 

--- a/scripts/twitter/twitter.py
+++ b/scripts/twitter/twitter.py
@@ -491,6 +491,13 @@ def load_twitter_client(
                         "[yellow]Waiting for authorization (timeout: 5 minutes)..."
                     )
                     try:
+                        from urllib.parse import parse_qs, urlparse
+
+                        # Capture expected state for CSRF validation below.
+                        _expected_state = parse_qs(urlparse(auth_url).query).get(
+                            "state", [None]
+                        )[0]
+
                         _cb_file = os.getenv("TWITTER_OAUTH_CALLBACK_FILE")
                         if _cb_file:
                             # The authorizing browser is on another machine (an
@@ -514,6 +521,23 @@ def load_twitter_client(
                             raise TimeoutError(
                                 "No authorization callback received within timeout"
                             )
+                        # Explicit CSRF state check: validate the returned state
+                        # against the one embedded in auth_url, before passing
+                        # the full callback URL to fetch_token.  tweepy's
+                        # OAuth2UserHandler also validates state internally, but
+                        # an early explicit check provides a clear error message
+                        # and rejects the callback before any token exchange.
+                        if _expected_state:
+                            _got_state = parse_qs(urlparse(full_url).query).get(
+                                "state", [None]
+                            )[0]
+                            if _got_state != _expected_state:
+                                raise ValueError(
+                                    "OAuth state mismatch in callback: "
+                                    f"expected {_expected_state!r}, "
+                                    f"got {_got_state!r}. "
+                                    "Possible CSRF attempt or stale callback file."
+                                )
                         console.print("[green]Authorization received!")
                     except TimeoutError as e:
                         console.print("[red]Error: Authorization timeout")

--- a/scripts/twitter/twitter.py
+++ b/scripts/twitter/twitter.py
@@ -241,10 +241,12 @@ def _wait_for_callback_file(path: Path, timeout: int) -> tuple[str | None, str |
             raw = ""
         if raw:
             parsed = urlparse(raw)
-            if parsed.scheme in {"http", "https"} and parsed.hostname in {
-                "localhost",
-                "127.0.0.1",
-            }:
+            if (
+                parsed.scheme in {"http", "https"}
+                and parsed.hostname in {"localhost", "127.0.0.1"}
+                and parsed.port == 9876
+                and parsed.path == "/callback"
+            ):
                 # oauthlib enforces https on the redirect URL at parse time
                 # (InsecureTransportError). The URL is never fetched — it only
                 # carries state+code — so upgrading the scheme is safe and

--- a/scripts/twitter/twitter.py
+++ b/scripts/twitter/twitter.py
@@ -288,7 +288,7 @@ def _activate_account_profile(name: str) -> Path:
     for var in _USER_CONTEXT_VARS:
         os.environ.pop(var, None)
     load_dotenv(path, override=True)
-    os.environ.setdefault("TWITTER_EXPECTED_USERNAME", name)
+    os.environ["TWITTER_EXPECTED_USERNAME"] = name
     return path
 
 

--- a/scripts/twitter/twitter.py
+++ b/scripts/twitter/twitter.py
@@ -456,10 +456,13 @@ def load_twitter_client(
                             # redirected URL into this file instead.
                             console.print(
                                 f"[yellow]Waiting for the redirected callback URL to be "
-                                f"written to {_cb_file} (timeout: 30 minutes)..."
+                                f"written to {_cb_file}..."
+                            )
+                            _cb_timeout = int(
+                                os.getenv("TWITTER_OAUTH_CALLBACK_TIMEOUT", "1800")
                             )
                             response_code, full_url = _wait_for_callback_file(
-                                Path(_cb_file), timeout=1800
+                                Path(_cb_file), timeout=_cb_timeout
                             )
                         else:
                             response_code, full_url = run_oauth_callback(

--- a/scripts/twitter/twitter.py
+++ b/scripts/twitter/twitter.py
@@ -252,7 +252,15 @@ def current_account() -> str:
     return os.getenv("TWITTER_ACCOUNT", "").strip()
 
 
+_ACCOUNT_NAME_RE = re.compile(r"^[A-Za-z0-9_]{1,15}$")
+
+
 def account_env_path(name: str) -> Path:
+    if not _ACCOUNT_NAME_RE.fullmatch(name):
+        raise ValueError(
+            "Invalid Twitter account profile: expected a 1-15 character username "
+            "containing only letters, digits, and underscores"
+        )
     base = Path(os.getenv("XDG_CONFIG_HOME", str(Path.home() / ".config")))
     return base / "gptwitter" / "accounts" / f"{name}.env"
 
@@ -263,14 +271,19 @@ def _activate_account_profile(name: str) -> Path:
     Returns the profile env path — the token persistence target for this run.
     """
     path = account_env_path(name)
-    if not path.exists():
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(
-            f"# gptwitter account profile: @{name}\n"
-            f"# OAuth 2.0 user tokens are written here by `twitter.py --account {name} me`\n"
-            f"TWITTER_EXPECTED_USERNAME={name}\n"
-        )
-        path.chmod(0o600)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError:
+        if path.is_symlink() or not path.is_file():
+            raise ValueError(f"Account profile must be a regular file: {path}")
+    else:
+        with os.fdopen(fd, "w") as profile:
+            profile.write(
+                f"# gptwitter account profile: @{name}\n"
+                f"# OAuth 2.0 user tokens are written here by `twitter.py --account {name} me`\n"
+                f"TWITTER_EXPECTED_USERNAME={name}\n"
+            )
     for var in _USER_CONTEXT_VARS:
         os.environ.pop(var, None)
     load_dotenv(path, override=True)

--- a/scripts/twitter/twitter.py
+++ b/scripts/twitter/twitter.py
@@ -255,10 +255,8 @@ def _wait_for_callback_file(path: Path, timeout: int) -> tuple[str | None, str |
                     raw = "https://" + raw[len("http://") :]
                 code = parse_qs(parsed.query).get("code", [None])[0]
                 if code:
-                    try:
-                        path.unlink()
-                    except OSError:
-                        pass
+                    # Unlink deferred to caller after CSRF state validation,
+                    # so a bad paste can be diagnosed without restarting OAuth.
                     return code, raw
         time.sleep(2)
     return None, None
@@ -541,6 +539,12 @@ def load_twitter_client(
                                     "Possible CSRF attempt or stale callback file."
                                 )
                         console.print("[green]Authorization received!")
+                        # Clean up the callback file now that CSRF state passed.
+                        if _cb_file:
+                            try:
+                                Path(_cb_file).unlink()
+                            except OSError:
+                                pass
                     except TimeoutError as e:
                         console.print("[red]Error: Authorization timeout")
                         console.print(f"[red]Details: {str(e)}")

--- a/scripts/twitter/twitter.py
+++ b/scripts/twitter/twitter.py
@@ -193,6 +193,83 @@ def _abort_on_bad_urls(messages: list[str]) -> None:
     sys.exit(1)
 
 
+# ---------------------------------------------------------------------------
+# Account profiles
+#
+# The default profile is the workspace .env (Bob's @TimeToBuildBob). A named
+# profile (``--account gptmeorg`` / ``TWITTER_ACCOUNT=gptmeorg``) keeps its own
+# OAuth 2.0 user tokens in ``$XDG_CONFIG_HOME/gptwitter/accounts/<name>.env``
+# (same variable names, so gptmail's refresh/persist helpers work unchanged) and
+# is authorized against the SAME X app (TWITTER_CLIENT_ID/SECRET from .env).
+#
+# Safety: when a named profile is active, every user-context credential from
+# the default .env (OAuth 2.0 tokens AND OAuth 1.0a access tokens) is removed
+# from the environment before the profile is loaded, so a profile with missing
+# or expired tokens can never silently post as the default account. The
+# identity guard (TWITTER_EXPECTED_USERNAME, defaulting to the profile name)
+# is the second net.
+# ---------------------------------------------------------------------------
+_USER_CONTEXT_VARS = (
+    "TWITTER_OAUTH2_ACCESS_TOKEN",
+    "TWITTER_OAUTH2_REFRESH_TOKEN",
+    "TWITTER_OAUTH2_EXPIRES_AT",
+    "TWITTER_ACCESS_TOKEN",
+    "TWITTER_ACCESS_SECRET",
+    "TWITTER_EXPECTED_USERNAME",
+)
+
+
+def _wait_for_callback_file(path: Path, timeout: int) -> tuple[str | None, str | None]:
+    """Poll ``path`` for a pasted OAuth redirect URL; returns (code, full_url)."""
+    import time
+    from urllib.parse import parse_qs, urlparse
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if path.exists():
+            raw = path.read_text().strip()
+            if raw.startswith("http"):
+                code = parse_qs(urlparse(raw).query).get("code", [None])[0]
+                try:
+                    path.unlink()
+                except OSError:
+                    pass
+                return code, raw
+        time.sleep(2)
+    return None, None
+
+
+def current_account() -> str:
+    """Active account profile name ('' = default workspace .env)."""
+    return os.getenv("TWITTER_ACCOUNT", "").strip()
+
+
+def account_env_path(name: str) -> Path:
+    base = Path(os.getenv("XDG_CONFIG_HOME", str(Path.home() / ".config")))
+    return base / "gptwitter" / "accounts" / f"{name}.env"
+
+
+def _activate_account_profile(name: str) -> Path:
+    """Load a named profile's env file (creating a template if absent).
+
+    Returns the profile env path — the token persistence target for this run.
+    """
+    path = account_env_path(name)
+    if not path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            f"# gptwitter account profile: @{name}\n"
+            f"# OAuth 2.0 user tokens are written here by `twitter.py --account {name} me`\n"
+            f"TWITTER_EXPECTED_USERNAME={name}\n"
+        )
+        path.chmod(0o600)
+    for var in _USER_CONTEXT_VARS:
+        os.environ.pop(var, None)
+    load_dotenv(path, override=True)
+    os.environ.setdefault("TWITTER_EXPECTED_USERNAME", name)
+    return path
+
+
 def _verify_account_identity(username: str, console) -> None:
     """Safety guard: verify the authenticated account matches the expected identity.
 
@@ -239,6 +316,11 @@ def load_twitter_client(
     _env_path = Path(_env_path_str) if _env_path_str else None
     if not _env_path:
         console.print("[yellow]Warning: could not locate .env file for token storage")
+
+    _account = current_account()
+    if _account:
+        _env_path = _activate_account_profile(_account)
+        console.print(f"[dim]Account profile: @{_account} ({_env_path})")
 
     # Check for bearer token (required for read operations)
     bearer_token = os.getenv("TWITTER_BEARER_TOKEN")
@@ -366,9 +448,23 @@ def load_twitter_client(
                         "[yellow]Waiting for authorization (timeout: 5 minutes)..."
                     )
                     try:
-                        response_code, full_url = run_oauth_callback(
-                            port=9876, timeout=300
-                        )
+                        _cb_file = os.getenv("TWITTER_OAUTH_CALLBACK_FILE")
+                        if _cb_file:
+                            # The authorizing browser is on another machine (an
+                            # operator authorizing a shared account): it cannot
+                            # reach our localhost:9876, so the operator pastes the
+                            # redirected URL into this file instead.
+                            console.print(
+                                f"[yellow]Waiting for the redirected callback URL to be "
+                                f"written to {_cb_file} (timeout: 30 minutes)..."
+                            )
+                            response_code, full_url = _wait_for_callback_file(
+                                Path(_cb_file), timeout=1800
+                            )
+                        else:
+                            response_code, full_url = run_oauth_callback(
+                                port=9876, timeout=300
+                            )
                         # run_oauth_callback returns (None, None) on timeout
                         # instead of raising — handle this explicitly
                         if not response_code or not full_url:
@@ -630,9 +726,19 @@ def display_tweets(tweets: tweepy.Response, username: str) -> None:
 
 
 @click.group()
-def cli() -> None:
+@click.option(
+    "--account",
+    envvar="TWITTER_ACCOUNT",
+    default="",
+    help=(
+        "Account profile to act as (e.g. gptmeorg). Tokens live in "
+        "~/.config/gptwitter/accounts/<name>.env; default = workspace .env."
+    ),
+)
+def cli(account: str) -> None:
     """Twitter Tool - Simple CLI for Twitter operations"""
-    pass
+    if account:
+        os.environ["TWITTER_ACCOUNT"] = account
 
 
 @cli.command()
@@ -679,10 +785,16 @@ def me(limit: int) -> None:
 @cli.command()
 @click.argument("text")
 @click.option("--reply-to", help="Tweet ID to reply to")
+@click.option("--quote", "quote_id", help="Tweet ID to quote-tweet")
 @click.option("--thread", is_flag=True, help="Post as thread (split by ---)")
-def post(text: str, reply_to: str | None, thread: bool) -> None:
+def post(
+    text: str, reply_to: str | None, thread: bool, quote_id: str | None = None
+) -> None:
     """Post a tweet (requires OAuth authentication)"""
     client = load_twitter_client(require_auth=True)
+    if quote_id and thread:
+        console.print("[red]--quote cannot be combined with --thread")
+        sys.exit(1)
 
     # Handle thread posting
     if thread:
@@ -717,7 +829,10 @@ def post(text: str, reply_to: str | None, thread: bool) -> None:
         # Single tweet
         _abort_on_bad_urls([text])
         response = client.create_tweet(
-            text=text, in_reply_to_tweet_id=reply_to, user_auth=_get_user_auth(client)
+            text=text,
+            in_reply_to_tweet_id=reply_to,
+            quote_tweet_id=quote_id,
+            user_auth=_get_user_auth(client),
         )
         if not response.data:
             console.print("[red]Error: No response data from tweet creation")

--- a/scripts/twitter/twitter.py
+++ b/scripts/twitter/twitter.py
@@ -277,6 +277,7 @@ def _activate_account_profile(name: str) -> Path:
     except FileExistsError:
         if path.is_symlink() or not path.is_file():
             raise ValueError(f"Account profile must be a regular file: {path}")
+        path.chmod(0o600)
     else:
         with os.fdopen(fd, "w") as profile:
             profile.write(
@@ -326,7 +327,12 @@ def load_twitter_client(
     Twitter's refresh tokens are single-use (RFC 6749 Section 6), so using a
     stale refresh token will result in a 400 Bad Request error.
     """
+    requested_account = current_account()
     load_dotenv(override=True)
+    if requested_account:
+        # A CLI/env-selected profile must outrank TWITTER_ACCOUNT in the
+        # workspace .env, just as command-line options outrank config defaults.
+        os.environ["TWITTER_ACCOUNT"] = requested_account
 
     # Resolve the .env path from THIS script's frame — critical because
     # save_tokens_to_env() calls find_dotenv() from gptmail's installed location

--- a/scripts/twitter/twitter.py
+++ b/scripts/twitter/twitter.py
@@ -825,6 +825,9 @@ def post(
     if quote_id and thread:
         console.print("[red]--quote cannot be combined with --thread")
         sys.exit(1)
+    if quote_id and reply_to:
+        console.print("[red]--quote cannot be combined with --reply-to")
+        sys.exit(1)
 
     # Handle thread posting
     if thread:

--- a/scripts/twitter/twitter.py
+++ b/scripts/twitter/twitter.py
@@ -229,6 +229,14 @@ def _wait_for_callback_file(path: Path, timeout: int) -> tuple[str | None, str |
         if path.exists():
             raw = path.read_text().strip()
             if raw.startswith("http"):
+                # oauthlib enforces https on the redirect URL at parse time
+                # (InsecureTransportError). The URL is never fetched — it only
+                # carries state+code — so upgrading the scheme is safe and
+                # matches the OAUTHLIB_INSECURE_TRANSPORT localhost norm.
+                if raw.startswith("http://localhost") or raw.startswith(
+                    "http://127.0.0.1"
+                ):
+                    raw = "https://" + raw[len("http://") :]
                 code = parse_qs(urlparse(raw).query).get("code", [None])[0]
                 try:
                     path.unlink()

--- a/scripts/twitter/twitter.py
+++ b/scripts/twitter/twitter.py
@@ -338,10 +338,11 @@ def load_twitter_client(
     stale refresh token will result in a 400 Bad Request error.
     """
     requested_account = current_account()
+    account_was_explicit = "TWITTER_ACCOUNT" in os.environ
     load_dotenv(override=True)
-    if requested_account:
-        # A CLI/env-selected profile must outrank TWITTER_ACCOUNT in the
-        # workspace .env, just as command-line options outrank config defaults.
+    if account_was_explicit:
+        # An explicit CLI/env selection, including the empty default-account
+        # sentinel, must outrank TWITTER_ACCOUNT in the workspace .env.
         os.environ["TWITTER_ACCOUNT"] = requested_account
 
     # Resolve the .env path from THIS script's frame — critical because

--- a/scripts/twitter/twitter.py
+++ b/scripts/twitter/twitter.py
@@ -293,6 +293,8 @@ def _activate_account_profile(name: str) -> Path:
         if path.is_symlink() or not path.is_file():
             raise ValueError(f"Account profile must be a regular file: {path}")
         path.chmod(0o600)
+    except PermissionError:
+        raise ValueError(f"Account profile is not writable: {path}")
     else:
         with os.fdopen(fd, "w") as profile:
             profile.write(

--- a/scripts/twitter/twitter.py
+++ b/scripts/twitter/twitter.py
@@ -237,16 +237,18 @@ def _wait_for_callback_file(path: Path, timeout: int) -> tuple[str | None, str |
     while time.monotonic() < deadline:
         if path.exists():
             raw = path.read_text().strip()
-            if raw.startswith("http"):
+            parsed = urlparse(raw)
+            if parsed.scheme in {"http", "https"} and parsed.hostname in {
+                "localhost",
+                "127.0.0.1",
+            }:
                 # oauthlib enforces https on the redirect URL at parse time
                 # (InsecureTransportError). The URL is never fetched — it only
                 # carries state+code — so upgrading the scheme is safe and
                 # matches the OAUTHLIB_INSECURE_TRANSPORT localhost norm.
-                if raw.startswith("http://localhost") or raw.startswith(
-                    "http://127.0.0.1"
-                ):
+                if parsed.scheme == "http":
                     raw = "https://" + raw[len("http://") :]
-                code = parse_qs(urlparse(raw).query).get("code", [None])[0]
+                code = parse_qs(parsed.query).get("code", [None])[0]
                 if code:
                     try:
                         path.unlink()

--- a/scripts/twitter/twitter.py
+++ b/scripts/twitter/twitter.py
@@ -235,8 +235,11 @@ def _wait_for_callback_file(path: Path, timeout: int) -> tuple[str | None, str |
 
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        if path.exists():
+        try:
             raw = path.read_text().strip()
+        except FileNotFoundError:
+            raw = ""
+        if raw:
             parsed = urlparse(raw)
             if parsed.scheme in {"http", "https"} and parsed.hostname in {
                 "localhost",
@@ -827,8 +830,17 @@ def me(limit: int) -> None:
 @click.option("--reply-to", help="Tweet ID to reply to")
 @click.option("--quote", "quote_id", help="Tweet ID to quote-tweet")
 @click.option("--thread", is_flag=True, help="Post as thread (split by ---)")
+@click.option(
+    "--headless",
+    is_flag=True,
+    help="Never start interactive OAuth; fail if saved credentials cannot authenticate.",
+)
 def post(
-    text: str, reply_to: str | None, thread: bool, quote_id: str | None = None
+    text: str,
+    reply_to: str | None,
+    thread: bool,
+    quote_id: str | None = None,
+    headless: bool = False,
 ) -> None:
     """Post a tweet (requires OAuth authentication)"""
     if quote_id and thread:
@@ -837,7 +849,7 @@ def post(
     if quote_id and reply_to:
         console.print("[red]--quote cannot be combined with --reply-to")
         sys.exit(1)
-    client = load_twitter_client(require_auth=True)
+    client = load_twitter_client(require_auth=True, headless=headless)
 
     # Handle thread posting
     if thread:

--- a/scripts/twitter/twitter.py
+++ b/scripts/twitter/twitter.py
@@ -238,11 +238,12 @@ def _wait_for_callback_file(path: Path, timeout: int) -> tuple[str | None, str |
                 ):
                     raw = "https://" + raw[len("http://") :]
                 code = parse_qs(urlparse(raw).query).get("code", [None])[0]
-                try:
-                    path.unlink()
-                except OSError:
-                    pass
-                return code, raw
+                if code:
+                    try:
+                        path.unlink()
+                    except OSError:
+                        pass
+                    return code, raw
         time.sleep(2)
     return None, None
 

--- a/scripts/twitter/twitter.py
+++ b/scripts/twitter/twitter.py
@@ -219,6 +219,15 @@ _USER_CONTEXT_VARS = (
 )
 
 
+def _oauth_callback_timeout() -> int:
+    """Return the callback-file timeout, falling back on invalid config."""
+    try:
+        timeout = int(os.getenv("TWITTER_OAUTH_CALLBACK_TIMEOUT", "1800"))
+    except ValueError:
+        return 1800
+    return timeout if timeout > 0 else 1800
+
+
 def _wait_for_callback_file(path: Path, timeout: int) -> tuple[str | None, str | None]:
     """Poll ``path`` for a pasted OAuth redirect URL; returns (code, full_url)."""
     import time
@@ -486,11 +495,8 @@ def load_twitter_client(
                                 f"[yellow]Waiting for the redirected callback URL to be "
                                 f"written to {_cb_file}..."
                             )
-                            _cb_timeout = int(
-                                os.getenv("TWITTER_OAUTH_CALLBACK_TIMEOUT", "1800")
-                            )
                             response_code, full_url = _wait_for_callback_file(
-                                Path(_cb_file), timeout=_cb_timeout
+                                Path(_cb_file), timeout=_oauth_callback_timeout()
                             )
                         else:
                             response_code, full_url = run_oauth_callback(
@@ -822,13 +828,13 @@ def post(
     text: str, reply_to: str | None, thread: bool, quote_id: str | None = None
 ) -> None:
     """Post a tweet (requires OAuth authentication)"""
-    client = load_twitter_client(require_auth=True)
     if quote_id and thread:
         console.print("[red]--quote cannot be combined with --thread")
         sys.exit(1)
     if quote_id and reply_to:
         console.print("[red]--quote cannot be combined with --reply-to")
         sys.exit(1)
+    client = load_twitter_client(require_auth=True)
 
     # Handle thread posting
     if thread:

--- a/tests/test_release_announce.py
+++ b/tests/test_release_announce.py
@@ -52,6 +52,11 @@ def test_extract_features_strips_standalone_trailing_author():
     assert ra.extract_features(notes) == ["improve caching"]
 
 
+def test_extract_features_strips_multiple_trailing_authors():
+    notes = "* feat(cache): improve caching by @alice and @bob (#100)"
+    assert ra.extract_features(notes) == ["improve caching"]
+
+
 def test_compose_fits_and_headlines():
     text = ra.compose_announcement("v0.33.0", NOTES, "gptme/gptme")
     assert text.startswith("gptme v0.33.0 is out")

--- a/tests/test_release_announce.py
+++ b/tests/test_release_announce.py
@@ -83,6 +83,17 @@ def test_state_roundtrip(tmp_path, monkeypatch):
     assert ra.load_state() == {}
 
 
+def test_latest_release_handles_invalid_json(monkeypatch, capsys):
+    monkeypatch.setattr(
+        ra,
+        "_run",
+        lambda cmd: subprocess.CompletedProcess(cmd, 0, "not json", ""),
+    )
+
+    assert ra.latest_release("gptme/gptme", None) is None
+    assert "returned invalid JSON" in capsys.readouterr().err
+
+
 def test_post_distinguishes_failure_from_success_without_id(monkeypatch):
     monkeypatch.setattr(
         ra,
@@ -254,6 +265,7 @@ def test_main_adds_quote_after_skip_quote_run(monkeypatch, tmp_path):
 
 def test_post_default_account_clears_environment_profile(monkeypatch):
     monkeypatch.setenv("TWITTER_ACCOUNT", "gptmeorg")
+    monkeypatch.setenv("TWITTER_EXPECTED_USERNAME", "gptmeorg")
     seen: dict = {}
 
     def fake_run(cmd, **kwargs):
@@ -264,6 +276,7 @@ def test_post_default_account_clears_environment_profile(monkeypatch):
 
     assert ra._post(["post", "hello"]) == (True, "123")
     assert "TWITTER_ACCOUNT" not in seen["env"]
+    assert "TWITTER_EXPECTED_USERNAME" not in seen["env"]
 
 
 def test_post_named_account_keeps_inherited_environment(monkeypatch):

--- a/tests/test_release_announce.py
+++ b/tests/test_release_announce.py
@@ -182,6 +182,7 @@ def test_main_posts_org_reply_and_quote(monkeypatch, tmp_path):
 
 
 def test_main_resumes_after_link_reply_failure(monkeypatch, tmp_path):
+    """A failed link_reply leaves the pending marker; the next run refuses retry."""
     monkeypatch.setattr(ra, "STATE_FILE", tmp_path / "ra.json")
     monkeypatch.setattr(
         ra,
@@ -194,7 +195,7 @@ def test_main_resumes_after_link_reply_failure(monkeypatch, tmp_path):
         },
     )
     calls: list[tuple] = []
-    results = iter([(True, "101"), (False, None), (True, "102"), (True, "103")])
+    results = iter([(True, "101"), (False, None)])
 
     def fake_post(args, account=None):
         calls.append((account, args))
@@ -203,21 +204,21 @@ def test_main_resumes_after_link_reply_failure(monkeypatch, tmp_path):
     monkeypatch.setattr(ra, "_post", fake_post)
     monkeypatch.setattr(sys, "argv", ["release_announce.py"])
 
+    # First run: org tweet succeeds, link reply fails.
     assert ra.main() == 1
     partial = json.loads(ra.STATE_FILE.read_text())["gptme/gptme#v0.33.0"]
-    assert partial == {"org_tweet_id": "101"}
+    assert partial["org_tweet_id"] == "101"
+    # Pending marker must survive so the next run refuses blind retry.
+    assert "link_reply_pending_at" in partial
+    assert len(calls) == 2
 
-    assert ra.main() == 0
-    assert len(calls) == 4
-    # Resume at the missing reply instead of duplicating the org announcement.
-    assert calls[2][1][2:] == ["--reply-to", "101"]
-    completed = json.loads(ra.STATE_FILE.read_text())["gptme/gptme#v0.33.0"]
-    assert completed["link_reply_id"] == "102"
-    assert completed["bob_quote_id"] == "103"
-    assert "announced_at" in completed
+    # Second run: link_reply_pending_at blocks retry to avoid duplicate tweet.
+    assert ra.main() == 1
+    assert len(calls) == 2  # no new _post calls
 
 
 def test_main_resumes_after_quote_failure(monkeypatch, tmp_path):
+    """A failed quote-tweet leaves the pending marker; the next run refuses retry."""
     monkeypatch.setattr(ra, "STATE_FILE", tmp_path / "ra.json")
     monkeypatch.setattr(
         ra,
@@ -230,7 +231,7 @@ def test_main_resumes_after_quote_failure(monkeypatch, tmp_path):
         },
     )
     calls: list[tuple] = []
-    results = iter([(True, "101"), (True, "102"), (False, None), (True, "103")])
+    results = iter([(True, "101"), (True, "102"), (False, None)])
 
     def fake_post(args, account=None):
         calls.append((account, args))
@@ -239,10 +240,17 @@ def test_main_resumes_after_quote_failure(monkeypatch, tmp_path):
     monkeypatch.setattr(ra, "_post", fake_post)
     monkeypatch.setattr(sys, "argv", ["release_announce.py"])
 
+    # First run: org tweet and link reply succeed, quote fails.
     assert ra.main() == 1
-    assert ra.main() == 0
-    assert len(calls) == 4
-    assert calls[-1][1][2:] == ["--quote", "101"]
+    partial = json.loads(ra.STATE_FILE.read_text())["gptme/gptme#v0.33.0"]
+    assert partial["org_tweet_id"] == "101"
+    assert partial["link_reply_id"] == "102"
+    assert "bob_quote_pending_at" in partial
+    assert len(calls) == 3
+
+    # Second run: bob_quote_pending_at blocks retry.
+    assert ra.main() == 1
+    assert len(calls) == 3  # no new _post calls
 
 
 def test_main_adds_quote_after_skip_quote_run(monkeypatch, tmp_path):
@@ -468,7 +476,10 @@ def test_main_refuses_to_retry_ambiguous_post(monkeypatch, tmp_path, capsys):
     assert "refusing to retry" in capsys.readouterr().err
 
 
-def test_main_clears_intent_after_definite_failure(monkeypatch, tmp_path):
+def test_main_keeps_intent_after_post_failure_prevents_retry(
+    monkeypatch, tmp_path, capsys
+):
+    """A failed org-tweet post keeps the pending marker so blind retry is refused."""
     monkeypatch.setattr(ra, "STATE_FILE", tmp_path / "ra.json")
     monkeypatch.setattr(
         ra,
@@ -480,10 +491,61 @@ def test_main_clears_intent_after_definite_failure(monkeypatch, tmp_path):
             "url": "https://github.com/gptme/gptme/releases/tag/v0.33.0",
         },
     )
-    results = iter([(False, None), (True, "101"), (True, "102"), (True, "103")])
-    monkeypatch.setattr(ra, "_post", lambda args, account=None: next(results))
+    calls = 0
+
+    def fake_post(args, account=None):
+        nonlocal calls
+        calls += 1
+        return False, None  # every attempt fails
+
+    monkeypatch.setattr(ra, "_post", fake_post)
     monkeypatch.setattr(sys, "argv", ["release_announce.py"])
 
+    # First run: org-tweet fails → pending marker stays.
     assert ra.main() == 1
-    assert ra.load_state()["gptme/gptme#v0.33.0"] == {}
+    record = ra.load_state()["gptme/gptme#v0.33.0"]
+    assert "org_tweet_pending_at" in record
+    assert calls == 1
+
+    # Second run: pending marker blocks retry without --force.
+    assert ra.main() == 1
+    assert "refusing to retry" in capsys.readouterr().err
+    assert calls == 1  # _post was NOT called again
+
+
+def test_main_force_clears_pending_markers(monkeypatch, tmp_path):
+    """--force resets state including stale pending markers from a crashed run."""
+    monkeypatch.setattr(ra, "STATE_FILE", tmp_path / "ra.json")
+    monkeypatch.setattr(
+        ra,
+        "latest_release",
+        lambda repo, tag: {
+            "tagName": "v0.33.0",
+            "isPrerelease": False,
+            "body": NOTES,
+            "url": "https://github.com/gptme/gptme/releases/tag/v0.33.0",
+        },
+    )
+    # Seed a stale pending marker from a hypothetical crashed run.
+    ra.save_state(
+        {
+            "gptme/gptme#v0.33.0": {
+                "org_tweet_pending_at": "2026-08-20T10:00:00+00:00",
+            }
+        }
+    )
+    calls: list[tuple] = []
+
+    def fake_post(args, account=None):
+        calls.append((account, args))
+        return True, str(100 + len(calls))
+
+    monkeypatch.setattr(ra, "_post", fake_post)
+    monkeypatch.setattr(sys, "argv", ["release_announce.py", "--force"])
+
+    # --force ignores all pending markers and re-announces from scratch.
     assert ra.main() == 0
+    assert len(calls) == 3
+    record = ra.load_state()["gptme/gptme#v0.33.0"]
+    assert record["org_tweet_id"] == "101"
+    assert "announced_at" in record

--- a/tests/test_release_announce.py
+++ b/tests/test_release_announce.py
@@ -265,7 +265,8 @@ def test_main_adds_quote_after_skip_quote_run(monkeypatch, tmp_path):
 
 def test_post_default_account_clears_environment_profile(monkeypatch):
     monkeypatch.setenv("TWITTER_ACCOUNT", "gptmeorg")
-    monkeypatch.setenv("TWITTER_EXPECTED_USERNAME", "gptmeorg")
+    for var in ra._USER_CONTEXT_VARS:
+        monkeypatch.setenv(var, f"org-{var.lower()}")
     seen: dict = {}
 
     def fake_run(cmd, **kwargs):
@@ -276,7 +277,7 @@ def test_post_default_account_clears_environment_profile(monkeypatch):
 
     assert ra._post(["post", "hello"]) == (True, "123")
     assert "TWITTER_ACCOUNT" not in seen["env"]
-    assert "TWITTER_EXPECTED_USERNAME" not in seen["env"]
+    assert not set(ra._USER_CONTEXT_VARS) & seen["env"].keys()
 
 
 def test_post_named_account_keeps_inherited_environment(monkeypatch):

--- a/tests/test_release_announce.py
+++ b/tests/test_release_announce.py
@@ -47,6 +47,11 @@ def test_extract_features_strips_mid_description_pr_ref():
     assert ra.extract_features(notes) == ["structured handoff"]
 
 
+def test_extract_features_strips_standalone_trailing_author():
+    notes = "* feat(cache): improve caching by @alice"
+    assert ra.extract_features(notes) == ["improve caching"]
+
+
 def test_compose_fits_and_headlines():
     text = ra.compose_announcement("v0.33.0", NOTES, "gptme/gptme")
     assert text.startswith("gptme v0.33.0 is out")

--- a/tests/test_release_announce.py
+++ b/tests/test_release_announce.py
@@ -280,7 +280,7 @@ def test_main_adds_quote_after_skip_quote_run(monkeypatch, tmp_path):
 
 def test_post_default_account_clears_environment_profile(monkeypatch):
     monkeypatch.setenv("TWITTER_ACCOUNT", "gptmeorg")
-    for var in ra._USER_CONTEXT_VARS:
+    for var in (*ra._USER_CONTEXT_VARS, *ra._AUTOMATION_UNSAFE_OAUTH_VARS):
         monkeypatch.setenv(var, f"org-{var.lower()}")
     seen: dict = {}
 
@@ -292,7 +292,8 @@ def test_post_default_account_clears_environment_profile(monkeypatch):
 
     assert ra._post(["post", "hello"]) == (True, "123")
     assert seen["env"]["TWITTER_ACCOUNT"] == ""
-    assert not set(ra._USER_CONTEXT_VARS) & seen["env"].keys()
+    stripped = {*ra._USER_CONTEXT_VARS, *ra._AUTOMATION_UNSAFE_OAUTH_VARS}
+    assert not stripped & seen["env"].keys()
 
 
 def test_post_named_account_keeps_inherited_environment(monkeypatch):

--- a/tests/test_release_announce.py
+++ b/tests/test_release_announce.py
@@ -152,6 +152,21 @@ def test_latest_release_handles_invalid_json(monkeypatch, capsys):
     assert "returned invalid JSON" in capsys.readouterr().err
 
 
+def test_post_ignores_tweet_id_substring_in_body(monkeypatch):
+    """Tweet text containing 'Tweet ID: N' must not steal the created id."""
+
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout="Posted tweet: see Tweet ID: 999 in the notes\nTweet ID: 42\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(ra, "_run", fake_run)
+    assert ra._post(["post", "hello"]) == (True, "42")
+
+
 def test_post_distinguishes_failure_from_success_without_id(monkeypatch):
     monkeypatch.setattr(
         ra,

--- a/tests/test_release_announce.py
+++ b/tests/test_release_announce.py
@@ -302,3 +302,84 @@ def test_main_holds_state_lock_while_posting(monkeypatch, tmp_path):
 
     assert ra.main() == 0
     assert events == ["lock", "post", "post", "post", "unlock"]
+
+
+def test_main_writes_intent_before_each_post(monkeypatch, tmp_path):
+    monkeypatch.setattr(ra, "STATE_FILE", tmp_path / "ra.json")
+    monkeypatch.setattr(
+        ra,
+        "latest_release",
+        lambda repo, tag: {
+            "tagName": "v0.33.0",
+            "isPrerelease": False,
+            "body": NOTES,
+            "url": "https://github.com/gptme/gptme/releases/tag/v0.33.0",
+        },
+    )
+    expected_markers = iter(
+        [
+            "org_tweet_pending_at",
+            "link_reply_pending_at",
+            "bob_quote_pending_at",
+        ]
+    )
+
+    def fake_post(args, account=None):
+        marker = next(expected_markers)
+        record = ra.load_state()["gptme/gptme#v0.33.0"]
+        assert marker in record
+        return True, str(100 + len(record))
+
+    monkeypatch.setattr(ra, "_post", fake_post)
+    monkeypatch.setattr(sys, "argv", ["release_announce.py"])
+
+    assert ra.main() == 0
+    record = ra.load_state()["gptme/gptme#v0.33.0"]
+    assert not any(key.endswith("_pending_at") for key in record)
+
+
+def test_main_refuses_to_retry_ambiguous_post(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(ra, "STATE_FILE", tmp_path / "ra.json")
+    monkeypatch.setattr(
+        ra,
+        "latest_release",
+        lambda repo, tag: {
+            "tagName": "v0.33.0",
+            "isPrerelease": False,
+            "body": NOTES,
+            "url": "https://github.com/gptme/gptme/releases/tag/v0.33.0",
+        },
+    )
+    ra.save_state(
+        {"gptme/gptme#v0.33.0": {"org_tweet_pending_at": "2026-08-20T21:00:00+00:00"}}
+    )
+
+    def unexpected_post(args, account=None):
+        raise AssertionError("an ambiguous post must not be retried")
+
+    monkeypatch.setattr(ra, "_post", unexpected_post)
+    monkeypatch.setattr(sys, "argv", ["release_announce.py"])
+
+    assert ra.main() == 1
+    assert "refusing to retry" in capsys.readouterr().err
+
+
+def test_main_clears_intent_after_definite_failure(monkeypatch, tmp_path):
+    monkeypatch.setattr(ra, "STATE_FILE", tmp_path / "ra.json")
+    monkeypatch.setattr(
+        ra,
+        "latest_release",
+        lambda repo, tag: {
+            "tagName": "v0.33.0",
+            "isPrerelease": False,
+            "body": NOTES,
+            "url": "https://github.com/gptme/gptme/releases/tag/v0.33.0",
+        },
+    )
+    results = iter([(False, None), (True, "101"), (True, "102"), (True, "103")])
+    monkeypatch.setattr(ra, "_post", lambda args, account=None: next(results))
+    monkeypatch.setattr(sys, "argv", ["release_announce.py"])
+
+    assert ra.main() == 1
+    assert ra.load_state()["gptme/gptme#v0.33.0"] == {}
+    assert ra.main() == 0

--- a/tests/test_release_announce.py
+++ b/tests/test_release_announce.py
@@ -1,0 +1,124 @@
+"""Tests for scripts/twitter/release_announce.py (compose + state logic)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+_spec = importlib.util.spec_from_file_location(
+    "release_announce", REPO_ROOT / "scripts" / "twitter" / "release_announce.py"
+)
+assert _spec and _spec.loader
+ra = importlib.util.module_from_spec(_spec)
+sys.modules.setdefault("release_announce", ra)
+_spec.loader.exec_module(ra)
+
+NOTES = """## What's Changed
+* feat(cli): add `gptme explain` for offline concept answers by @Bob in https://github.com/gptme/gptme/pull/3542
+* feat(tools): add read-only audit preset by @Bob in #3543
+* fix(grok-subscription): enable native tools API and add grok-4.6 by @TimeToBuildBob in #3571
+* feat(autocompact): add keep_head to protect task context from compaction (#3567)
+* chore: bump version to 0.33.0
+* feat(prompts): end responses with a concrete next step by @x in #3559
+* feat(webui): add trajectory copy commands by @y in #3491
+* feat(review): artifact mode + structured handoff for review-watch (#3442) by @z in #3449
+
+**Full Changelog**: https://github.com/gptme/gptme/compare/v0.32.1...v0.33.0
+"""
+
+
+def test_extract_features_strips_attribution_and_caps():
+    feats = ra.extract_features(NOTES)
+    assert len(feats) == 5
+    assert feats[0] == "add `gptme explain` for offline concept answers"
+    assert feats[1] == "add read-only audit preset"
+    # fixes and chores are not features
+    assert not any("grok-subscription" in f or "bump version" in f for f in feats)
+    # no PR refs / authors leak through
+    assert not any("#" in f or "@" in f or "http" in f for f in feats)
+
+
+def test_compose_fits_and_headlines():
+    text = ra.compose_announcement("v0.33.0", NOTES, "gptme/gptme")
+    assert text.startswith("gptme v0.33.0 is out")
+    assert len(text) <= ra.MAX_TWEET
+    assert "— add `gptme explain`" in text
+
+
+def test_compose_without_feats_falls_back():
+    text = ra.compose_announcement("v0.33.0", "* fix: only fixes\n", "gptme/gptme")
+    assert "Release notes in the reply" in text
+
+
+def test_stable_tag_gate():
+    assert ra.STABLE_TAG_RE.match("v0.33.0")
+    assert not ra.STABLE_TAG_RE.match("v0.32.2.dev20260817")
+
+
+def test_state_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setattr(ra, "STATE_FILE", tmp_path / "state" / "ra.json")
+    assert ra.load_state() == {}
+    ra.save_state({"gptme/gptme#v0.33.0": {"org_tweet_id": "1"}})
+    assert ra.load_state()["gptme/gptme#v0.33.0"]["org_tweet_id"] == "1"
+    # corrupt file -> empty dict, not crash
+    ra.STATE_FILE.write_text("{broken")
+    assert ra.load_state() == {}
+
+
+def test_main_skips_prerelease(monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr(ra, "STATE_FILE", tmp_path / "ra.json")
+    monkeypatch.setattr(
+        ra,
+        "latest_release",
+        lambda repo, tag: {
+            "tagName": "v0.33.1.dev20260820",
+            "isPrerelease": True,
+            "body": "",
+            "url": "u",
+        },
+    )
+    monkeypatch.setattr(sys, "argv", ["release_announce.py"])
+    assert ra.main() == 0
+    assert "prerelease" in capsys.readouterr().out
+
+
+def test_main_posts_org_reply_and_quote(monkeypatch, tmp_path):
+    monkeypatch.setattr(ra, "STATE_FILE", tmp_path / "ra.json")
+    monkeypatch.setattr(
+        ra,
+        "latest_release",
+        lambda repo, tag: {
+            "tagName": "v0.33.0",
+            "isPrerelease": False,
+            "body": NOTES,
+            "url": "https://github.com/gptme/gptme/releases/tag/v0.33.0",
+        },
+    )
+    calls: list[tuple] = []
+
+    def fake_post(args, account=None):
+        calls.append((account, args))
+        return str(100 + len(calls))
+
+    monkeypatch.setattr(ra, "_post", fake_post)
+    monkeypatch.setattr(sys, "argv", ["release_announce.py"])
+    assert ra.main() == 0
+
+    assert calls[0][0] == "gptmeorg" and calls[0][1][0] == "post"
+    assert calls[1][0] == "gptmeorg" and calls[1][1][1].endswith("v0.33.0")
+    assert calls[1][1][2] == "--reply-to" and calls[1][1][3] == "101"
+    # Bob's quote from the default account
+    assert calls[2][0] is None and calls[2][1][2] == "--quote"
+    assert calls[2][1][3] == "101"
+
+    state = json.loads((tmp_path / "ra.json").read_text())
+    rec = state["gptme/gptme#v0.33.0"]
+    assert rec["org_tweet_id"] == "101" and rec["bob_quote_id"] == "103"
+
+    # Second run: dedupe, no more posts
+    n = len(calls)
+    assert ra.main() == 0
+    assert len(calls) == n

--- a/tests/test_release_announce.py
+++ b/tests/test_release_announce.py
@@ -87,14 +87,14 @@ def test_post_distinguishes_failure_from_success_without_id(monkeypatch):
     monkeypatch.setattr(
         ra,
         "_run",
-        lambda cmd: subprocess.CompletedProcess(cmd, 1, "", "failed"),
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 1, "", "failed"),
     )
     assert ra._post(["post", "hello"]) == (False, None)
 
     monkeypatch.setattr(
         ra,
         "_run",
-        lambda cmd: subprocess.CompletedProcess(cmd, 0, "posted", ""),
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, "posted", ""),
     )
     assert ra._post(["post", "hello"]) == (True, None)
 
@@ -217,6 +217,69 @@ def test_main_resumes_after_quote_failure(monkeypatch, tmp_path):
     assert ra.main() == 0
     assert len(calls) == 4
     assert calls[-1][1][2:] == ["--quote", "101"]
+
+
+def test_main_adds_quote_after_skip_quote_run(monkeypatch, tmp_path):
+    monkeypatch.setattr(ra, "STATE_FILE", tmp_path / "ra.json")
+    monkeypatch.setattr(
+        ra,
+        "latest_release",
+        lambda repo, tag: {
+            "tagName": "v0.33.0",
+            "isPrerelease": False,
+            "body": NOTES,
+            "url": "https://github.com/gptme/gptme/releases/tag/v0.33.0",
+        },
+    )
+    calls: list[tuple] = []
+
+    def fake_post(args, account=None):
+        calls.append((account, args))
+        return True, str(100 + len(calls))
+
+    monkeypatch.setattr(ra, "_post", fake_post)
+    monkeypatch.setattr(sys, "argv", ["release_announce.py", "--skip-quote"])
+
+    assert ra.main() == 0
+    assert len(calls) == 2
+    assert "announced_at" in ra.load_state()["gptme/gptme#v0.33.0"]
+
+    monkeypatch.setattr(sys, "argv", ["release_announce.py"])
+    assert ra.main() == 0
+    assert len(calls) == 3
+    assert calls[-1][0] is None
+    assert calls[-1][1][2:] == ["--quote", "101"]
+    assert ra.load_state()["gptme/gptme#v0.33.0"]["bob_quote_id"] == "103"
+
+
+def test_post_default_account_clears_environment_profile(monkeypatch):
+    monkeypatch.setenv("TWITTER_ACCOUNT", "gptmeorg")
+    seen: dict = {}
+
+    def fake_run(cmd, **kwargs):
+        seen.update(kwargs)
+        return subprocess.CompletedProcess(cmd, 0, stdout="Tweet ID: 123\n", stderr="")
+
+    monkeypatch.setattr(ra, "_run", fake_run)
+
+    assert ra._post(["post", "hello"]) == (True, "123")
+    assert "TWITTER_ACCOUNT" not in seen["env"]
+
+
+def test_post_named_account_keeps_inherited_environment(monkeypatch):
+    monkeypatch.setenv("TWITTER_ACCOUNT", "default")
+    seen: dict = {}
+
+    def fake_run(cmd, **kwargs):
+        seen["cmd"] = cmd
+        seen.update(kwargs)
+        return subprocess.CompletedProcess(cmd, 0, stdout="Tweet ID: 123\n", stderr="")
+
+    monkeypatch.setattr(ra, "_run", fake_run)
+
+    assert ra._post(["post", "hello"], account="gptmeorg") == (True, "123")
+    assert seen["cmd"][2:4] == ["--account", "gptmeorg"]
+    assert seen["env"] is None
 
 
 def test_main_does_not_retry_success_without_tweet_id(monkeypatch, tmp_path):

--- a/tests/test_release_announce.py
+++ b/tests/test_release_announce.py
@@ -285,12 +285,14 @@ def test_post_default_account_clears_environment_profile(monkeypatch):
     seen: dict = {}
 
     def fake_run(cmd, **kwargs):
+        seen["cmd"] = cmd
         seen.update(kwargs)
         return subprocess.CompletedProcess(cmd, 0, stdout="Tweet ID: 123\n", stderr="")
 
     monkeypatch.setattr(ra, "_run", fake_run)
 
     assert ra._post(["post", "hello"]) == (True, "123")
+    assert seen["cmd"][-1] == "--headless"
     assert seen["env"]["TWITTER_ACCOUNT"] == ""
     stripped = {*ra._USER_CONTEXT_VARS, *ra._AUTOMATION_UNSAFE_OAUTH_VARS}
     assert not stripped & seen["env"].keys()
@@ -311,6 +313,7 @@ def test_post_named_account_keeps_inherited_environment(monkeypatch):
 
     assert ra._post(["post", "hello"], account="gptmeorg") == (True, "123")
     assert seen["cmd"][2:4] == ["--account", "gptmeorg"]
+    assert seen["cmd"][-1] == "--headless"
     assert seen["env"]["TWITTER_ACCOUNT"] == "default"
     assert not set(ra._AUTOMATION_UNSAFE_OAUTH_VARS) & seen["env"].keys()
 

--- a/tests/test_release_announce.py
+++ b/tests/test_release_announce.py
@@ -67,6 +67,23 @@ def test_extract_features_strips_github_pr_url():
     assert ra.extract_features(notes) == ["add guide"]
 
 
+def test_extract_features_strips_author_with_trailing_period():
+    # Trailing punctuation after author handle must not block stripping.
+    notes = "* feat(cache): improve caching by @alice."
+    assert ra.extract_features(notes) == ["improve caching"]
+
+
+def test_extract_features_strips_author_with_trailing_comma():
+    notes = "* feat(cache): improve caching by @alice,"
+    assert ra.extract_features(notes) == ["improve caching"]
+
+
+def test_extract_features_strips_github_pr_url_in_parens():
+    # URL wrapped in parentheses must still be stripped.
+    notes = "* feat(docs): add guide (https://github.com/gptme/gptme/pull/123)"
+    assert ra.extract_features(notes) == ["add guide"]
+
+
 def test_compose_fits_and_headlines():
     text = ra.compose_announcement("v0.33.0", NOTES, "gptme/gptme")
     assert text.startswith("gptme v0.33.0 is out")

--- a/tests/test_release_announce.py
+++ b/tests/test_release_announce.py
@@ -298,6 +298,8 @@ def test_post_default_account_clears_environment_profile(monkeypatch):
 
 def test_post_named_account_keeps_inherited_environment(monkeypatch):
     monkeypatch.setenv("TWITTER_ACCOUNT", "default")
+    for var in ra._AUTOMATION_UNSAFE_OAUTH_VARS:
+        monkeypatch.setenv(var, f"unsafe-{var.lower()}")
     seen: dict = {}
 
     def fake_run(cmd, **kwargs):
@@ -309,7 +311,8 @@ def test_post_named_account_keeps_inherited_environment(monkeypatch):
 
     assert ra._post(["post", "hello"], account="gptmeorg") == (True, "123")
     assert seen["cmd"][2:4] == ["--account", "gptmeorg"]
-    assert seen["env"] is None
+    assert seen["env"]["TWITTER_ACCOUNT"] == "default"
+    assert not set(ra._AUTOMATION_UNSAFE_OAUTH_VARS) & seen["env"].keys()
 
 
 def test_main_does_not_retry_success_without_tweet_id(monkeypatch, tmp_path):

--- a/tests/test_release_announce.py
+++ b/tests/test_release_announce.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -77,6 +78,22 @@ def test_state_roundtrip(tmp_path, monkeypatch):
     assert ra.load_state() == {}
 
 
+def test_post_distinguishes_failure_from_success_without_id(monkeypatch):
+    monkeypatch.setattr(
+        ra,
+        "_run",
+        lambda cmd: subprocess.CompletedProcess(cmd, 1, "", "failed"),
+    )
+    assert ra._post(["post", "hello"]) == (False, None)
+
+    monkeypatch.setattr(
+        ra,
+        "_run",
+        lambda cmd: subprocess.CompletedProcess(cmd, 0, "posted", ""),
+    )
+    assert ra._post(["post", "hello"]) == (True, None)
+
+
 def test_main_skips_prerelease(monkeypatch, capsys, tmp_path):
     monkeypatch.setattr(ra, "STATE_FILE", tmp_path / "ra.json")
     monkeypatch.setattr(
@@ -110,7 +127,7 @@ def test_main_posts_org_reply_and_quote(monkeypatch, tmp_path):
 
     def fake_post(args, account=None):
         calls.append((account, args))
-        return str(100 + len(calls))
+        return True, str(100 + len(calls))
 
     monkeypatch.setattr(ra, "_post", fake_post)
     monkeypatch.setattr(sys, "argv", ["release_announce.py"])
@@ -146,7 +163,7 @@ def test_main_resumes_after_link_reply_failure(monkeypatch, tmp_path):
         },
     )
     calls: list[tuple] = []
-    results = iter(["101", None, "102", "103"])
+    results = iter([(True, "101"), (False, None), (True, "102"), (True, "103")])
 
     def fake_post(args, account=None):
         calls.append((account, args))
@@ -182,7 +199,7 @@ def test_main_resumes_after_quote_failure(monkeypatch, tmp_path):
         },
     )
     calls: list[tuple] = []
-    results = iter(["101", "102", None, "103"])
+    results = iter([(True, "101"), (True, "102"), (False, None), (True, "103")])
 
     def fake_post(args, account=None):
         calls.append((account, args))
@@ -195,3 +212,93 @@ def test_main_resumes_after_quote_failure(monkeypatch, tmp_path):
     assert ra.main() == 0
     assert len(calls) == 4
     assert calls[-1][1][2:] == ["--quote", "101"]
+
+
+def test_main_does_not_retry_success_without_tweet_id(monkeypatch, tmp_path):
+    monkeypatch.setattr(ra, "STATE_FILE", tmp_path / "ra.json")
+    monkeypatch.setattr(
+        ra,
+        "latest_release",
+        lambda repo, tag: {
+            "tagName": "v0.33.0",
+            "isPrerelease": False,
+            "body": NOTES,
+            "url": "https://github.com/gptme/gptme/releases/tag/v0.33.0",
+        },
+    )
+    calls = 0
+
+    def fake_post(args, account=None):
+        nonlocal calls
+        calls += 1
+        return True, None
+
+    monkeypatch.setattr(ra, "_post", fake_post)
+    monkeypatch.setattr(sys, "argv", ["release_announce.py"])
+
+    assert ra.main() == 1
+    assert ra.main() == 1
+    assert calls == 1
+    assert ra.load_state()["gptme/gptme#v0.33.0"]["org_tweet_id"] is None
+
+
+def test_main_does_not_retry_reply_success_without_tweet_id(monkeypatch, tmp_path):
+    monkeypatch.setattr(ra, "STATE_FILE", tmp_path / "ra.json")
+    monkeypatch.setattr(
+        ra,
+        "latest_release",
+        lambda repo, tag: {
+            "tagName": "v0.33.0",
+            "isPrerelease": False,
+            "body": NOTES,
+            "url": "https://github.com/gptme/gptme/releases/tag/v0.33.0",
+        },
+    )
+    calls: list[tuple] = []
+    results = iter([(True, "101"), (True, None), (True, "103")])
+
+    def fake_post(args, account=None):
+        calls.append((account, args))
+        return next(results)
+
+    monkeypatch.setattr(ra, "_post", fake_post)
+    monkeypatch.setattr(sys, "argv", ["release_announce.py"])
+
+    assert ra.main() == 0
+    assert ra.main() == 0
+    assert len(calls) == 3
+    assert ra.load_state()["gptme/gptme#v0.33.0"]["link_reply_id"] is None
+
+
+def test_main_holds_state_lock_while_posting(monkeypatch, tmp_path):
+    monkeypatch.setattr(ra, "STATE_FILE", tmp_path / "ra.json")
+    monkeypatch.setattr(
+        ra,
+        "latest_release",
+        lambda repo, tag: {
+            "tagName": "v0.33.0",
+            "isPrerelease": False,
+            "body": NOTES,
+            "url": "https://github.com/gptme/gptme/releases/tag/v0.33.0",
+        },
+    )
+    events: list[str] = []
+
+    class FakeLock:
+        def __enter__(self):
+            events.append("lock")
+
+        def __exit__(self, *exc):
+            events.append("unlock")
+
+    monkeypatch.setattr(ra, "state_lock", FakeLock)
+
+    def fake_post(args, account=None):
+        events.append("post")
+        return True, str(len(events))
+
+    monkeypatch.setattr(ra, "_post", fake_post)
+    monkeypatch.setattr(sys, "argv", ["release_announce.py"])
+
+    assert ra.main() == 0
+    assert events == ["lock", "post", "post", "post", "unlock"]

--- a/tests/test_release_announce.py
+++ b/tests/test_release_announce.py
@@ -344,6 +344,52 @@ def test_main_adds_quote_after_skip_quote_run(monkeypatch, tmp_path):
     assert ra.load_state()["gptme/gptme#v0.33.0"]["bob_quote_id"] == "103"
 
 
+def test_skip_quote_clears_stale_pending_marker(monkeypatch, tmp_path):
+    """--skip-quote must clear a stale bob_quote_pending_at so a later normal
+    run can post the missing quote without needing --force."""
+    monkeypatch.setattr(ra, "STATE_FILE", tmp_path / "ra.json")
+    monkeypatch.setattr(
+        ra,
+        "latest_release",
+        lambda repo, tag: {
+            "tagName": "v0.33.0",
+            "isPrerelease": False,
+            "body": NOTES,
+            "url": "https://github.com/gptme/gptme/releases/tag/v0.33.0",
+        },
+    )
+    calls: list[tuple] = []
+    # Run 1: org + reply succeed, quote fails → leaves bob_quote_pending_at
+    results1 = iter([(True, "101"), (True, "102"), (False, None)])
+
+    def fake_post1(args, account=None):
+        calls.append((account, args))
+        return next(results1)
+
+    monkeypatch.setattr(ra, "_post", fake_post1)
+    monkeypatch.setattr(sys, "argv", ["release_announce.py"])
+    assert ra.main() == 1
+    assert "bob_quote_pending_at" in ra.load_state()["gptme/gptme#v0.33.0"]
+
+    # Run 2: --skip-quote → must clear bob_quote_pending_at and set announced_at
+    monkeypatch.setattr(ra, "_post", lambda *a, **kw: (True, "999"))
+    monkeypatch.setattr(sys, "argv", ["release_announce.py", "--skip-quote"])
+    assert ra.main() == 0
+    state = ra.load_state()["gptme/gptme#v0.33.0"]
+    assert "announced_at" in state
+    assert "bob_quote_pending_at" not in state
+
+    # Run 3: normal run → must be able to post the quote (not stuck at 1)
+    def fake_post3(args, account=None):
+        calls.append((account, args))
+        return True, "103"
+
+    monkeypatch.setattr(ra, "_post", fake_post3)
+    monkeypatch.setattr(sys, "argv", ["release_announce.py"])
+    assert ra.main() == 0
+    assert ra.load_state()["gptme/gptme#v0.33.0"]["bob_quote_id"] == "103"
+
+
 def test_post_default_account_clears_environment_profile(monkeypatch):
     monkeypatch.setenv("TWITTER_ACCOUNT", "gptmeorg")
     for var in (*ra._USER_CONTEXT_VARS, *ra._AUTOMATION_UNSAFE_OAUTH_VARS):

--- a/tests/test_release_announce.py
+++ b/tests/test_release_announce.py
@@ -41,6 +41,11 @@ def test_extract_features_strips_attribution_and_caps():
     assert not any("#" in f or "@" in f or "http" in f for f in feats)
 
 
+def test_extract_features_strips_mid_description_pr_ref():
+    notes = "* feat(review): structured handoff (#3442) by @z in #3449"
+    assert ra.extract_features(notes) == ["structured handoff"]
+
+
 def test_compose_fits_and_headlines():
     text = ra.compose_announcement("v0.33.0", NOTES, "gptme/gptme")
     assert text.startswith("gptme v0.33.0 is out")
@@ -51,6 +56,10 @@ def test_compose_fits_and_headlines():
 def test_compose_without_feats_falls_back():
     text = ra.compose_announcement("v0.33.0", "* fix: only fixes\n", "gptme/gptme")
     assert "Release notes in the reply" in text
+
+
+def test_quote_text_uses_repository_name():
+    assert ra.compose_quote("v1.2.3", "owner/widget").startswith("widget v1.2.3 is out")
 
 
 def test_stable_tag_gate():
@@ -122,3 +131,67 @@ def test_main_posts_org_reply_and_quote(monkeypatch, tmp_path):
     n = len(calls)
     assert ra.main() == 0
     assert len(calls) == n
+
+
+def test_main_resumes_after_link_reply_failure(monkeypatch, tmp_path):
+    monkeypatch.setattr(ra, "STATE_FILE", tmp_path / "ra.json")
+    monkeypatch.setattr(
+        ra,
+        "latest_release",
+        lambda repo, tag: {
+            "tagName": "v0.33.0",
+            "isPrerelease": False,
+            "body": NOTES,
+            "url": "https://github.com/gptme/gptme/releases/tag/v0.33.0",
+        },
+    )
+    calls: list[tuple] = []
+    results = iter(["101", None, "102", "103"])
+
+    def fake_post(args, account=None):
+        calls.append((account, args))
+        return next(results)
+
+    monkeypatch.setattr(ra, "_post", fake_post)
+    monkeypatch.setattr(sys, "argv", ["release_announce.py"])
+
+    assert ra.main() == 1
+    partial = json.loads(ra.STATE_FILE.read_text())["gptme/gptme#v0.33.0"]
+    assert partial == {"org_tweet_id": "101"}
+
+    assert ra.main() == 0
+    assert len(calls) == 4
+    # Resume at the missing reply instead of duplicating the org announcement.
+    assert calls[2][1][2:] == ["--reply-to", "101"]
+    completed = json.loads(ra.STATE_FILE.read_text())["gptme/gptme#v0.33.0"]
+    assert completed["link_reply_id"] == "102"
+    assert completed["bob_quote_id"] == "103"
+    assert "announced_at" in completed
+
+
+def test_main_resumes_after_quote_failure(monkeypatch, tmp_path):
+    monkeypatch.setattr(ra, "STATE_FILE", tmp_path / "ra.json")
+    monkeypatch.setattr(
+        ra,
+        "latest_release",
+        lambda repo, tag: {
+            "tagName": "v0.33.0",
+            "isPrerelease": False,
+            "body": NOTES,
+            "url": "https://github.com/gptme/gptme/releases/tag/v0.33.0",
+        },
+    )
+    calls: list[tuple] = []
+    results = iter(["101", "102", None, "103"])
+
+    def fake_post(args, account=None):
+        calls.append((account, args))
+        return next(results)
+
+    monkeypatch.setattr(ra, "_post", fake_post)
+    monkeypatch.setattr(sys, "argv", ["release_announce.py"])
+
+    assert ra.main() == 1
+    assert ra.main() == 0
+    assert len(calls) == 4
+    assert calls[-1][1][2:] == ["--quote", "101"]

--- a/tests/test_release_announce.py
+++ b/tests/test_release_announce.py
@@ -84,6 +84,32 @@ def test_extract_features_strips_github_pr_url_in_parens():
     assert ra.extract_features(notes) == ["add guide"]
 
 
+def test_extract_features_strips_github_pr_url_with_trailing_period():
+    # A trailing period after the URL must not prevent stripping.
+    notes = "* feat(docs): add guide in https://github.com/gptme/gptme/pull/123."
+    assert ra.extract_features(notes) == ["add guide"]
+
+
+def test_post_places_double_dash_before_tweet_text(monkeypatch):
+    # Tweet text starting with '-' must not be parsed as a CLI option.
+    # _post must insert '--' before the text so Click treats it as positional.
+    captured: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+        captured.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, "Tweet ID: 42", "")
+
+    monkeypatch.setattr(ra, "_run", fake_run)
+    ok, tid = ra._post(["post", "-f, --force option-like text"])
+    assert ok
+    assert tid == "42"
+    cmd = captured[0]
+    assert "--" in cmd
+    dash_idx = cmd.index("--")
+    text_idx = cmd.index("-f, --force option-like text")
+    assert dash_idx < text_idx, "'--' must precede the tweet text"
+
+
 def test_compose_fits_and_headlines():
     text = ra.compose_announcement("v0.33.0", NOTES, "gptme/gptme")
     assert text.startswith("gptme v0.33.0 is out")
@@ -317,7 +343,7 @@ def test_post_default_account_clears_environment_profile(monkeypatch):
     monkeypatch.setattr(ra, "_run", fake_run)
 
     assert ra._post(["post", "hello"]) == (True, "123")
-    assert seen["cmd"][-1] == "--headless"
+    assert "--headless" in seen["cmd"]
     assert seen["env"]["TWITTER_ACCOUNT"] == ""
     stripped = {*ra._USER_CONTEXT_VARS, *ra._AUTOMATION_UNSAFE_OAUTH_VARS}
     assert not stripped & seen["env"].keys()
@@ -338,7 +364,7 @@ def test_post_named_account_keeps_inherited_environment(monkeypatch):
 
     assert ra._post(["post", "hello"], account="gptmeorg") == (True, "123")
     assert seen["cmd"][2:4] == ["--account", "gptmeorg"]
-    assert seen["cmd"][-1] == "--headless"
+    assert "--headless" in seen["cmd"]
     assert seen["env"]["TWITTER_ACCOUNT"] == "default"
     assert not set(ra._AUTOMATION_UNSAFE_OAUTH_VARS) & seen["env"].keys()
 

--- a/tests/test_release_announce.py
+++ b/tests/test_release_announce.py
@@ -390,6 +390,63 @@ def test_skip_quote_clears_stale_pending_marker(monkeypatch, tmp_path):
     assert ra.load_state()["gptme/gptme#v0.33.0"]["bob_quote_id"] == "103"
 
 
+def test_skip_quote_early_exit_clears_stale_pending_marker(monkeypatch, tmp_path):
+    """--skip-quote early-exit path must also clear stale bob_quote_pending_at.
+
+    Scenario: first run with --skip-quote succeeds (sets announced_at), then a
+    normal run fails the quote and leaves bob_quote_pending_at, then another
+    --skip-quote run hits the early-exit branch.  Without the fix, the marker
+    persists and every subsequent normal run is stuck (refuses blind retry).
+    """
+    monkeypatch.setattr(ra, "STATE_FILE", tmp_path / "ra.json")
+    monkeypatch.setattr(
+        ra,
+        "latest_release",
+        lambda repo, tag: {
+            "tagName": "v0.33.0",
+            "isPrerelease": False,
+            "body": NOTES,
+            "url": "https://github.com/gptme/gptme/releases/tag/v0.33.0",
+        },
+    )
+
+    # Run 1: --skip-quote succeeds → sets announced_at
+    monkeypatch.setattr(ra, "_post", lambda *a, **kw: (True, "101"))
+    monkeypatch.setattr(sys, "argv", ["release_announce.py", "--skip-quote"])
+    assert ra.main() == 0
+    state = ra.load_state()["gptme/gptme#v0.33.0"]
+    assert "announced_at" in state
+    assert "bob_quote_id" not in state
+
+    # Run 2: normal run, quote fails → leaves bob_quote_pending_at
+    results2 = iter([(True, "102")])  # org reply already recorded; only quote attempted
+
+    def fake_post2(args, account=None):
+        return next(results2) if "--quote" not in args else (False, None)
+
+    monkeypatch.setattr(ra, "_post", fake_post2)
+    monkeypatch.setattr(sys, "argv", ["release_announce.py"])
+    assert ra.main() == 1
+    assert "bob_quote_pending_at" in ra.load_state()["gptme/gptme#v0.33.0"]
+
+    # Run 3: --skip-quote → early-exit must clear bob_quote_pending_at
+    monkeypatch.setattr(
+        ra,
+        "_post",
+        lambda *a, **kw: (_ for _ in ()).throw(AssertionError("no post expected")),
+    )
+    monkeypatch.setattr(sys, "argv", ["release_announce.py", "--skip-quote"])
+    assert ra.main() == 0
+    state = ra.load_state()["gptme/gptme#v0.33.0"]
+    assert "bob_quote_pending_at" not in state
+
+    # Run 4: normal run → must succeed (not stuck refusing retry)
+    monkeypatch.setattr(ra, "_post", lambda *a, **kw: (True, "103"))
+    monkeypatch.setattr(sys, "argv", ["release_announce.py"])
+    assert ra.main() == 0
+    assert ra.load_state()["gptme/gptme#v0.33.0"]["bob_quote_id"] == "103"
+
+
 def test_post_default_account_clears_environment_profile(monkeypatch):
     monkeypatch.setenv("TWITTER_ACCOUNT", "gptmeorg")
     for var in (*ra._USER_CONTEXT_VARS, *ra._AUTOMATION_UNSAFE_OAUTH_VARS):

--- a/tests/test_release_announce.py
+++ b/tests/test_release_announce.py
@@ -370,6 +370,8 @@ def test_post_named_account_keeps_inherited_environment(monkeypatch):
 
 
 def test_main_does_not_retry_success_without_tweet_id(monkeypatch, tmp_path):
+    """When the org tweet posts but its ID is not captured, mark as announced
+    (degraded: no reply or quote) and do not retry on subsequent runs."""
     monkeypatch.setattr(ra, "STATE_FILE", tmp_path / "ra.json")
     monkeypatch.setattr(
         ra,
@@ -391,10 +393,14 @@ def test_main_does_not_retry_success_without_tweet_id(monkeypatch, tmp_path):
     monkeypatch.setattr(ra, "_post", fake_post)
     monkeypatch.setattr(sys, "argv", ["release_announce.py"])
 
-    assert ra.main() == 1
-    assert ra.main() == 1
+    # First run: org tweet posted (no ID) → degraded completion, exit 0.
+    assert ra.main() == 0
+    state = ra.load_state()["gptme/gptme#v0.33.0"]
+    assert state["org_tweet_id"] is None
+    assert "announced_at" in state
+    # Second run: already announced (degraded) → early exit, no extra posts.
+    assert ra.main() == 0
     assert calls == 1
-    assert ra.load_state()["gptme/gptme#v0.33.0"]["org_tweet_id"] is None
 
 
 def test_main_does_not_retry_reply_success_without_tweet_id(monkeypatch, tmp_path):

--- a/tests/test_release_announce.py
+++ b/tests/test_release_announce.py
@@ -57,6 +57,16 @@ def test_extract_features_strips_multiple_trailing_authors():
     assert ra.extract_features(notes) == ["improve caching"]
 
 
+def test_extract_features_preserves_description_url():
+    notes = "* feat(docs): add guide at https://example.com/guide"
+    assert ra.extract_features(notes) == ["add guide at https://example.com/guide"]
+
+
+def test_extract_features_strips_github_pr_url():
+    notes = "* feat(docs): add guide in https://github.com/gptme/gptme/pull/123"
+    assert ra.extract_features(notes) == ["add guide"]
+
+
 def test_compose_fits_and_headlines():
     text = ra.compose_announcement("v0.33.0", NOTES, "gptme/gptme")
     assert text.startswith("gptme v0.33.0 is out")
@@ -281,7 +291,7 @@ def test_post_default_account_clears_environment_profile(monkeypatch):
     monkeypatch.setattr(ra, "_run", fake_run)
 
     assert ra._post(["post", "hello"]) == (True, "123")
-    assert "TWITTER_ACCOUNT" not in seen["env"]
+    assert seen["env"]["TWITTER_ACCOUNT"] == ""
     assert not set(ra._USER_CONTEXT_VARS) & seen["env"].keys()
 
 

--- a/tests/test_twitter_account_profiles.py
+++ b/tests/test_twitter_account_profiles.py
@@ -58,6 +58,33 @@ def test_profile_clears_default_user_context(
     assert os.environ["TWITTER_EXPECTED_USERNAME"] == "gptmeorg"
 
 
+@pytest.mark.parametrize(
+    "name", ["../bob", "bob\nTWITTER_ACCESS_TOKEN=stolen", "", "a" * 16]
+)
+def test_profile_rejects_invalid_names(
+    twitter_module: Any, monkeypatch: pytest.MonkeyPatch, tmp_path, name: str
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    with pytest.raises(ValueError, match="Invalid Twitter account profile"):
+        twitter_module._activate_account_profile(name)
+
+
+def test_profile_rejects_symlink(
+    twitter_module: Any, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    target = tmp_path / "target.env"
+    target.write_text("do not overwrite\n")
+    profile = tmp_path / "gptwitter" / "accounts" / "gptmeorg.env"
+    profile.parent.mkdir(parents=True)
+    profile.symlink_to(target)
+
+    with pytest.raises(ValueError, match="must be a regular file"):
+        twitter_module._activate_account_profile("gptmeorg")
+    assert target.read_text() == "do not overwrite\n"
+
+
 def test_profile_loads_its_own_tokens(
     twitter_module: Any, monkeypatch: pytest.MonkeyPatch, tmp_path
 ) -> None:
@@ -118,5 +145,5 @@ def test_wait_for_callback_file_parses_code(twitter_module: Any, tmp_path) -> No
     f.write_text("http://localhost:9876/callback?state=x&code=abc123\n")
     code, url = twitter_module._wait_for_callback_file(f, timeout=5)
     assert code == "abc123"
-    assert url.startswith("http://localhost:9876/callback")
+    assert url.startswith("https://localhost:9876/callback")
     assert not f.exists()

--- a/tests/test_twitter_account_profiles.py
+++ b/tests/test_twitter_account_profiles.py
@@ -136,6 +136,32 @@ def test_cli_account_survives_workspace_dotenv_override(
         twitter_module.load_twitter_client(require_auth=True)
 
 
+def test_explicit_default_account_survives_workspace_dotenv_override(
+    twitter_module: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("TWITTER_ACCOUNT", "")
+
+    def load_workspace_dotenv(*args, **kwargs) -> None:
+        monkeypatch.setenv("TWITTER_ACCOUNT", "gptmeorg")
+
+    monkeypatch.setattr(twitter_module, "load_dotenv", load_workspace_dotenv)
+    monkeypatch.setattr(
+        twitter_module,
+        "_activate_account_profile",
+        lambda name: pytest.fail(f"unexpected profile activation: {name}"),
+    )
+    monkeypatch.setattr(
+        twitter_module, "console", SimpleNamespace(print=lambda *a, **k: None)
+    )
+
+    with pytest.raises(SystemExit):
+        twitter_module.load_twitter_client(require_auth=True)
+
+    import os
+
+    assert os.environ["TWITTER_ACCOUNT"] == ""
+
+
 def test_profile_loads_its_own_tokens(
     twitter_module: Any, monkeypatch: pytest.MonkeyPatch, tmp_path
 ) -> None:

--- a/tests/test_twitter_account_profiles.py
+++ b/tests/test_twitter_account_profiles.py
@@ -191,17 +191,31 @@ def test_post_quote_passes_quote_tweet_id(
     assert calls and calls[0]["quote_tweet_id"] == "999"
 
 
-def test_post_rejects_quote_with_reply(
-    twitter_module: Any, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize(
+    ("reply_to", "thread"),
+    [("123", False), (None, True)],
+)
+def test_post_rejects_invalid_quote_combinations_before_auth(
+    twitter_module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    reply_to: str | None,
+    thread: bool,
 ) -> None:
-    monkeypatch.setattr(
-        twitter_module,
-        "load_twitter_client",
-        lambda require_auth=True: SimpleNamespace(),
-    )
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("authentication must not run for invalid arguments")
+
+    monkeypatch.setattr(twitter_module, "load_twitter_client", fail_if_called)
 
     with pytest.raises(SystemExit):
-        twitter_module.post("invalid", "123", False, quote_id="999")
+        twitter_module.post("invalid", reply_to, thread, quote_id="999")
+
+
+@pytest.mark.parametrize("value", ["30m", "", "0", "-1"])
+def test_oauth_callback_timeout_falls_back_on_invalid_config(
+    twitter_module: Any, monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv("TWITTER_OAUTH_CALLBACK_TIMEOUT", value)
+    assert twitter_module._oauth_callback_timeout() == 1800
 
 
 def test_wait_for_callback_file_parses_code(twitter_module: Any, tmp_path) -> None:

--- a/tests/test_twitter_account_profiles.py
+++ b/tests/test_twitter_account_profiles.py
@@ -85,6 +85,42 @@ def test_profile_rejects_symlink(
     assert target.read_text() == "do not overwrite\n"
 
 
+def test_existing_profile_permissions_are_tightened(
+    twitter_module: Any, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    profile = tmp_path / "gptwitter" / "accounts" / "gptmeorg.env"
+    profile.parent.mkdir(parents=True)
+    profile.write_text("TWITTER_EXPECTED_USERNAME=gptmeorg\n")
+    profile.chmod(0o644)
+
+    twitter_module._activate_account_profile("gptmeorg")
+
+    assert (profile.stat().st_mode & 0o777) == 0o600
+
+
+def test_cli_account_survives_workspace_dotenv_override(
+    twitter_module: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("TWITTER_ACCOUNT", "gptmeorg")
+
+    def load_workspace_dotenv(*args, **kwargs) -> None:
+        monkeypatch.setenv("TWITTER_ACCOUNT", "TimeToBuildBob")
+
+    class ProfileActivated(Exception):
+        pass
+
+    def activate_profile(name: str) -> None:
+        assert name == "gptmeorg"
+        raise ProfileActivated
+
+    monkeypatch.setattr(twitter_module, "load_dotenv", load_workspace_dotenv)
+    monkeypatch.setattr(twitter_module, "_activate_account_profile", activate_profile)
+
+    with pytest.raises(ProfileActivated):
+        twitter_module.load_twitter_client(require_auth=True)
+
+
 def test_profile_loads_its_own_tokens(
     twitter_module: Any, monkeypatch: pytest.MonkeyPatch, tmp_path
 ) -> None:

--- a/tests/test_twitter_account_profiles.py
+++ b/tests/test_twitter_account_profiles.py
@@ -324,3 +324,31 @@ def test_wait_for_callback_file_rejects_non_callback_host(
 
     assert twitter_module._wait_for_callback_file(f, timeout=1) == (None, None)
     assert f.exists()
+
+
+def test_wait_for_callback_file_rejects_wrong_port(
+    twitter_module: Any, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """A localhost URL on the wrong port must not be accepted."""
+    f = tmp_path / "cb.txt"
+    f.write_text("http://localhost:9999/callback?state=x&code=abc123")
+    monotonic_values = iter((0.0, 0.0, 2.0))
+    monkeypatch.setattr("time.monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+
+    assert twitter_module._wait_for_callback_file(f, timeout=1) == (None, None)
+    assert f.exists()
+
+
+def test_wait_for_callback_file_rejects_wrong_path(
+    twitter_module: Any, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """A localhost:9876 URL on a path other than /callback must not be accepted."""
+    f = tmp_path / "cb.txt"
+    f.write_text("http://localhost:9876/evil?state=x&code=abc123")
+    monotonic_values = iter((0.0, 0.0, 2.0))
+    monkeypatch.setattr("time.monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+
+    assert twitter_module._wait_for_callback_file(f, timeout=1) == (None, None)
+    assert f.exists()

--- a/tests/test_twitter_account_profiles.py
+++ b/tests/test_twitter_account_profiles.py
@@ -208,7 +208,9 @@ def test_post_quote_passes_quote_tweet_id(
     monkeypatch.setattr(
         twitter_module,
         "load_twitter_client",
-        lambda require_auth=True: SimpleNamespace(create_tweet=fake_create_tweet),
+        lambda require_auth=True, headless=False: SimpleNamespace(
+            create_tweet=fake_create_tweet
+        ),
     )
     monkeypatch.setattr(twitter_module, "_get_user_auth", lambda client: True)
 
@@ -253,6 +255,30 @@ def test_wait_for_callback_file_parses_code(twitter_module: Any, tmp_path) -> No
     assert not f.exists()
 
 
+def test_wait_for_callback_file_handles_file_disappearing_before_read(
+    twitter_module: Any, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    f = tmp_path / "cb.txt"
+    f.write_text("http://localhost:9876/callback?state=x&code=abc123")
+    original_read_text = Path.read_text
+    reads = 0
+
+    def disappearing_read_text(path: Path, *args, **kwargs):
+        nonlocal reads
+        reads += 1
+        if reads == 1:
+            path.unlink()
+            raise FileNotFoundError(path)
+        return original_read_text(path, *args, **kwargs)
+
+    monotonic_values = iter((0.0, 0.0, 2.0))
+    monkeypatch.setattr(Path, "read_text", disappearing_read_text)
+    monkeypatch.setattr("time.monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+
+    assert twitter_module._wait_for_callback_file(f, timeout=1) == (None, None)
+
+
 def test_wait_for_callback_file_keeps_partial_url(
     twitter_module: Any, monkeypatch: pytest.MonkeyPatch, tmp_path
 ) -> None:
@@ -264,6 +290,27 @@ def test_wait_for_callback_file_keeps_partial_url(
 
     assert twitter_module._wait_for_callback_file(f, timeout=1) == (None, None)
     assert f.exists()
+
+
+def test_post_passes_headless_to_auth(
+    twitter_module: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    seen: dict[str, object] = {}
+
+    class Client:
+        def create_tweet(self, **kwargs):
+            return type("Response", (), {"data": {"id": "123"}})()
+
+    def fake_load_twitter_client(**kwargs):
+        seen.update(kwargs)
+        return Client()
+
+    monkeypatch.setattr(twitter_module, "load_twitter_client", fake_load_twitter_client)
+    twitter_module.post(
+        "hello", reply_to=None, thread=False, quote_id=None, headless=True
+    )
+
+    assert seen == {"require_auth": True, "headless": True}
 
 
 def test_wait_for_callback_file_rejects_non_callback_host(

--- a/tests/test_twitter_account_profiles.py
+++ b/tests/test_twitter_account_profiles.py
@@ -1,0 +1,122 @@
+"""Account profiles for scripts/twitter/twitter.py (``--account gptmeorg``).
+
+A named profile keeps its own OAuth 2.0 user tokens in
+``$XDG_CONFIG_HOME/gptwitter/accounts/<name>.env`` and must never inherit the
+default account's user-context credentials (that would post as @TimeToBuildBob
+while claiming to be the profile).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+# Reuse the heavy module loader + fixture from the URL-guard tests (tests/ is
+# not a package, so load it by path).
+_spec = importlib.util.spec_from_file_location(
+    "test_twitter_post_url_guard",
+    Path(__file__).resolve().parent / "test_twitter_post_url_guard.py",
+)
+assert _spec and _spec.loader
+_guard = importlib.util.module_from_spec(_spec)
+sys.modules.setdefault("test_twitter_post_url_guard", _guard)
+_spec.loader.exec_module(_guard)
+twitter_module = _guard.twitter_module  # fixture
+
+
+def test_profile_clears_default_user_context(
+    twitter_module: Any, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    # Default-account credentials that must NOT leak into the profile.
+    monkeypatch.setenv("TWITTER_OAUTH2_ACCESS_TOKEN", "bob-access")
+    monkeypatch.setenv("TWITTER_OAUTH2_REFRESH_TOKEN", "bob-refresh")
+    monkeypatch.setenv("TWITTER_ACCESS_TOKEN", "bob-1a")
+    monkeypatch.setenv("TWITTER_ACCESS_SECRET", "bob-1a-secret")
+    monkeypatch.setenv("TWITTER_EXPECTED_USERNAME", "TimeToBuildBob")
+
+    path = twitter_module._activate_account_profile("gptmeorg")
+
+    assert path == tmp_path / "gptwitter" / "accounts" / "gptmeorg.env"
+    assert path.exists()
+    assert (path.stat().st_mode & 0o777) == 0o600
+    import os
+
+    for var in (
+        "TWITTER_OAUTH2_ACCESS_TOKEN",
+        "TWITTER_OAUTH2_REFRESH_TOKEN",
+        "TWITTER_ACCESS_TOKEN",
+        "TWITTER_ACCESS_SECRET",
+    ):
+        assert os.environ.get(var) is None, var
+    # Identity guard now expects the profile, not the default account.
+    assert os.environ["TWITTER_EXPECTED_USERNAME"] == "gptmeorg"
+
+
+def test_profile_loads_its_own_tokens(
+    twitter_module: Any, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    prof = tmp_path / "gptwitter" / "accounts" / "gptmeorg.env"
+    prof.parent.mkdir(parents=True)
+    prof.write_text(
+        "TWITTER_EXPECTED_USERNAME=gptmeorg\n"
+        "TWITTER_OAUTH2_ACCESS_TOKEN=org-access\n"
+        "TWITTER_OAUTH2_REFRESH_TOKEN=org-refresh\n"
+    )
+    monkeypatch.setenv("TWITTER_OAUTH2_ACCESS_TOKEN", "bob-access")
+
+    # The module loader stubs python-dotenv; give this test a minimal real one.
+    def _load(path, override=False):
+        import os
+
+        for line in Path(path).read_text().splitlines():
+            if "=" in line and not line.startswith("#"):
+                k, v = line.split("=", 1)
+                if override or k not in os.environ:
+                    os.environ[k] = v
+
+    monkeypatch.setattr(twitter_module, "load_dotenv", _load)
+
+    twitter_module._activate_account_profile("gptmeorg")
+
+    import os
+
+    assert os.environ["TWITTER_OAUTH2_ACCESS_TOKEN"] == "org-access"
+    assert os.environ["TWITTER_OAUTH2_REFRESH_TOKEN"] == "org-refresh"
+
+
+def test_post_quote_passes_quote_tweet_id(
+    twitter_module: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[dict] = []
+
+    def fake_create_tweet(**kwargs):
+        calls.append(kwargs)
+        return SimpleNamespace(data={"id": "1"})
+
+    monkeypatch.setattr(twitter_module, "validate_urls_in_text", lambda text: [])
+    monkeypatch.setattr(
+        twitter_module,
+        "load_twitter_client",
+        lambda require_auth=True: SimpleNamespace(create_tweet=fake_create_tweet),
+    )
+    monkeypatch.setattr(twitter_module, "_get_user_auth", lambda client: True)
+
+    twitter_module.post("quoting", None, False, quote_id="999")
+
+    assert calls and calls[0]["quote_tweet_id"] == "999"
+
+
+def test_wait_for_callback_file_parses_code(twitter_module: Any, tmp_path) -> None:
+    f = tmp_path / "cb.txt"
+    f.write_text("http://localhost:9876/callback?state=x&code=abc123\n")
+    code, url = twitter_module._wait_for_callback_file(f, timeout=5)
+    assert code == "abc123"
+    assert url.startswith("http://localhost:9876/callback")
+    assert not f.exists()

--- a/tests/test_twitter_account_profiles.py
+++ b/tests/test_twitter_account_profiles.py
@@ -114,6 +114,26 @@ def test_existing_profile_permissions_are_tightened(
     assert (profile.stat().st_mode & 0o777) == 0o600
 
 
+def test_profile_creation_permission_error_raises_clear_error(
+    twitter_module: Any, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """A PermissionError from os.open (e.g. unwritable directory) raises ValueError."""
+    import os as _os
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    real_os_open = _os.open
+
+    def patched_open(path, flags, mode=0o666, *args, **kwargs):
+        if "gptmeorg.env" in str(path) and (_os.O_EXCL & flags):
+            raise PermissionError(13, "Permission denied", str(path))
+        return real_os_open(path, flags, mode, *args, **kwargs)
+
+    monkeypatch.setattr(twitter_module.os, "open", patched_open)
+
+    with pytest.raises(ValueError, match="not writable"):
+        twitter_module._activate_account_profile("gptmeorg")
+
+
 def test_cli_account_survives_workspace_dotenv_override(
     twitter_module: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_twitter_account_profiles.py
+++ b/tests/test_twitter_account_profiles.py
@@ -252,7 +252,24 @@ def test_wait_for_callback_file_parses_code(twitter_module: Any, tmp_path) -> No
     code, url = twitter_module._wait_for_callback_file(f, timeout=5)
     assert code == "abc123"
     assert url.startswith("https://localhost:9876/callback")
-    assert not f.exists()
+    # Unlink is now deferred to the caller (after CSRF state validation),
+    # so the file should still exist after _wait_for_callback_file returns.
+    assert f.exists()
+
+
+def test_wait_for_callback_file_preserves_file_for_caller_cleanup(
+    twitter_module: Any, tmp_path
+) -> None:
+    """Callback file must survive _wait_for_callback_file so the caller can
+    unlink it after CSRF state validation rather than before."""
+    f = tmp_path / "cb.txt"
+    f.write_text("http://localhost:9876/callback?state=good&code=xyz\n")
+    code, url = twitter_module._wait_for_callback_file(f, timeout=5)
+    assert code == "xyz"
+    # File still present — caller's responsibility to clean up after CSRF check.
+    assert (
+        f.exists()
+    ), "callback file must not be deleted inside _wait_for_callback_file"
 
 
 def test_wait_for_callback_file_handles_file_disappearing_before_read(

--- a/tests/test_twitter_account_profiles.py
+++ b/tests/test_twitter_account_profiles.py
@@ -85,6 +85,21 @@ def test_profile_rejects_symlink(
     assert target.read_text() == "do not overwrite\n"
 
 
+def test_profile_expected_username_cannot_override_profile_name(
+    twitter_module: Any, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    profile = tmp_path / "gptwitter" / "accounts" / "gptmeorg.env"
+    profile.parent.mkdir(parents=True)
+    profile.write_text("TWITTER_EXPECTED_USERNAME=TimeToBuildBob\n")
+
+    twitter_module._activate_account_profile("gptmeorg")
+
+    import os
+
+    assert os.environ["TWITTER_EXPECTED_USERNAME"] == "gptmeorg"
+
+
 def test_existing_profile_permissions_are_tightened(
     twitter_module: Any, monkeypatch: pytest.MonkeyPatch, tmp_path
 ) -> None:

--- a/tests/test_twitter_account_profiles.py
+++ b/tests/test_twitter_account_profiles.py
@@ -264,3 +264,16 @@ def test_wait_for_callback_file_keeps_partial_url(
 
     assert twitter_module._wait_for_callback_file(f, timeout=1) == (None, None)
     assert f.exists()
+
+
+def test_wait_for_callback_file_rejects_non_callback_host(
+    twitter_module: Any, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    f = tmp_path / "cb.txt"
+    f.write_text("https://attacker.example/callback?state=x&code=abc123")
+    monotonic_values = iter((0.0, 0.0, 2.0))
+    monkeypatch.setattr("time.monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+
+    assert twitter_module._wait_for_callback_file(f, timeout=1) == (None, None)
+    assert f.exists()

--- a/tests/test_twitter_account_profiles.py
+++ b/tests/test_twitter_account_profiles.py
@@ -191,6 +191,19 @@ def test_post_quote_passes_quote_tweet_id(
     assert calls and calls[0]["quote_tweet_id"] == "999"
 
 
+def test_post_rejects_quote_with_reply(
+    twitter_module: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        twitter_module,
+        "load_twitter_client",
+        lambda require_auth=True: SimpleNamespace(),
+    )
+
+    with pytest.raises(SystemExit):
+        twitter_module.post("invalid", "123", False, quote_id="999")
+
+
 def test_wait_for_callback_file_parses_code(twitter_module: Any, tmp_path) -> None:
     f = tmp_path / "cb.txt"
     f.write_text("http://localhost:9876/callback?state=x&code=abc123\n")

--- a/tests/test_twitter_account_profiles.py
+++ b/tests/test_twitter_account_profiles.py
@@ -211,3 +211,16 @@ def test_wait_for_callback_file_parses_code(twitter_module: Any, tmp_path) -> No
     assert code == "abc123"
     assert url.startswith("https://localhost:9876/callback")
     assert not f.exists()
+
+
+def test_wait_for_callback_file_keeps_partial_url(
+    twitter_module: Any, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    f = tmp_path / "cb.txt"
+    f.write_text("http://localhost:9876/callback?state=x")
+    monotonic_values = iter((0.0, 0.0, 2.0))
+    monkeypatch.setattr("time.monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+
+    assert twitter_module._wait_for_callback_file(f, timeout=1) == (None, None)
+    assert f.exists()

--- a/tests/test_twitter_post_url_guard.py
+++ b/tests/test_twitter_post_url_guard.py
@@ -137,7 +137,7 @@ def test_post_aborts_before_single_tweet_with_dead_url(
     monkeypatch.setattr(
         twitter_module,
         "load_twitter_client",
-        lambda require_auth=True: SimpleNamespace(
+        lambda require_auth=True, headless=False: SimpleNamespace(
             create_tweet=lambda **kwargs: posted.append(kwargs["text"])
         ),
     )
@@ -175,7 +175,7 @@ def test_post_aborts_before_thread_with_dead_followup_url(
     monkeypatch.setattr(
         twitter_module,
         "load_twitter_client",
-        lambda require_auth=True: SimpleNamespace(
+        lambda require_auth=True, headless=False: SimpleNamespace(
             create_tweet=lambda **kwargs: posted.append(kwargs["text"])
         ),
     )


### PR DESCRIPTION
Adds multi-account support to the twitter CLI and a stable-release announcement automation.

## Why
Release announcements should be posted from @gptmeorg with Bob (@TimeToBuildBob) quote-tweeting them (Erik, 2026-08-19). The CLI previously had exactly one identity (workspace .env).

## What
1. **`--account <name>` profiles** — OAuth 2.0 user tokens per account in `~/.config/gptwitter/accounts/<name>.env` (0600), same X app client. Activation strips all default-account user-context creds from the env first (a profile with missing/expired tokens fails loudly instead of posting as the default account); `TWITTER_EXPECTED_USERNAME` guard defaults to the profile name.
2. **`TWITTER_OAUTH_CALLBACK_FILE`** — remote-operator authorization: waits for the pasted redirect URL in a file when the authorizing browser can't reach our localhost callback.
3. **`post --quote TWEET_ID`** — quote-tweet support.
4. **`release_announce.py`** — timer-driven: latest stable release → feat-line composed tweet from the org account → release link in reply → Bob quote-tweet. Prerelease/dedupe gates + state ledger; `--dry-run`.

## Tests
11 new (profile isolation incl. cred-stripping + 0600, quote wiring, composer extraction/length caps, prerelease + dedupe gates). All twitter test files pass (66).