### PR TITLE
fix(pm): notification state is owned by the handling worker, not the next worker to finish

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -947,10 +947,37 @@ def rollback_failed_delivery(
     return True
 
 
+def _mapped_notif_state_files(pending: Path, repo: str, number: int | str | None):
+    """Yield ``(map_file, state_file)`` for pending notif state mapped to this item.
+
+    Notification state is keyed by GitHub API id (``notif-<id>.state``); the
+    ``.map`` sidecar written by ``activity-gate.sh`` carries the ``repo#number``
+    association. This is the only way to attribute a notif state to an item.
+    """
+    if not pending.is_dir():
+        return
+    target = f"{repo}#{number}"
+    for map_file in pending.glob("notif-*.map"):
+        if not map_file.is_file():
+            continue
+        try:
+            content = map_file.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if content == target:
+            yield map_file, map_file.with_suffix(".state")
+
+
 def promote_item_state(
     config: RunItemConfig, repo: str, number: int | str | None
 ) -> None:
-    """Copy the item's pending activity-gate state files to the real state dir."""
+    """Copy the item's pending activity-gate state files to the real state dir.
+
+    Includes the item's *mapped* ``notif-*.state`` (via the ``.map`` sidecar):
+    notification state is owned by the outcome of the worker that handled the
+    item, not by whichever worker happens to finish next — see
+    :func:`promote_notification_states`.
+    """
     import shutil
 
     # The item advanced, so any redelivery treadmill for it is over — restore
@@ -974,7 +1001,15 @@ def promote_item_state(
     repo_safe = str(repo).replace("/", "-")
     is_zero = str(number) == "0"
     if is_zero:
-        patterns = ["notif-*.state"]
+        # A number-0 item cannot own a mapped thread (the gate only writes a
+        # `.map` for number > 0), so it promotes only the unmapped remainder —
+        # the same rule as promote_notification_states(). Copying every
+        # notif-*.state here would consume siblings' emitted-but-unhandled
+        # threads through a side door.
+        patterns = []
+        for f in pending.glob("notif-*.state"):
+            if f.is_file() and not f.with_suffix(".map").is_file():
+                shutil.copy(f, state / f.name)
     else:
         patterns = [
             f"{repo_safe}-pr-{number}*.state",
@@ -985,14 +1020,38 @@ def promote_item_state(
         for f in pending.glob(pattern):
             if f.is_file():
                 shutil.copy(f, state / f.name)
+    if not is_zero:
+        for map_file, state_file in _mapped_notif_state_files(pending, repo, number):
+            for f in (map_file, state_file):
+                if f.is_file():
+                    shutil.copy(f, state / f.name)
 
 
 def promote_notification_states(config: RunItemConfig) -> None:
-    """Promote ALL pending notif state files at end of run (p-m.sh:695-704).
+    """Promote pending notif state that no item owns, at end of run (p-m.sh:695-704).
 
     Notification state files use GitHub API ids, not repo#number, so the
-    per-item promotion never copies them; without this the gate re-emits the
-    same notifications every cycle.
+    per-item promotion cannot find them by name; the gate writes a ``.map``
+    sidecar (``repo#number``) for every thread it can attribute. Only the
+    *unmapped* remainder is promoted here.
+
+    History: this used to promote EVERY pending ``notif-*.state`` under the
+    assumption "sessions already ran for every emitted notification". That
+    held when one monolithic session handled the whole sweep. With per-slot
+    transient units it does not: the pending dir is shared, so a sibling
+    worker finishing while another item sits emitted-but-skipped
+    (``skipped_active`` / cooldown / recovery backoff) promoted that item's
+    state too — and a worker that *timed out* promoted its own. Either way
+    the gate never re-emitted the thread (it dedupes on ``updated_at``) and
+    ``pm_dispatch_recovery`` was never consulted, because it only runs for
+    emitted items. ActivityWatch/activitywatch#1402 (2026-08-20): an Erik
+    @mention, one 900s worker killed at exit 124, then silence.
+
+    Mapped state is promoted by :func:`promote_item_state` on the handling
+    worker's success path and purged by :func:`purge_pending_notif_state` on
+    its failure path, so the thread re-emits and the bounded recovery retry
+    applies. Skipped items' pending state is simply left for the next sweep's
+    ``rsync --delete`` to discard, so they re-emit and are re-evaluated.
     """
     import shutil
 
@@ -1001,8 +1060,11 @@ def promote_notification_states(config: RunItemConfig) -> None:
         return
     config.state_dir.mkdir(parents=True, exist_ok=True)
     for f in pending.glob("notif-*.state"):
-        if f.is_file():
-            shutil.copy(f, config.state_dir / f.name)
+        if not f.is_file():
+            continue
+        if f.with_suffix(".map").is_file():
+            continue  # owned by an item; its worker's outcome decides
+        shutil.copy(f, config.state_dir / f.name)
 
 
 # --- Trajectory resolution (worker.sh:196-300; design §4.4) ---
@@ -2311,6 +2373,34 @@ def run_post_session(
                 "promoting state to end re-dispatch churn (no reply is likely correct here)"
             )
             promote_item_state(config, item.repo, item.number)
+    elif (outcome.timed_out or outcome.exit_code != 0) and not (
+        delivery_verified and delivery_outcome == "handled"
+    ):
+        # The worker did not finish (exit 124) or failed outright, and the
+        # delivery check did not verify a reply. Its PR-side state still
+        # promotes (the head/score it saw are real), but the item's
+        # notification state must NOT: promoting it tells the gate the
+        # mention was handled, the gate dedupes on `updated_at`, and the thread
+        # goes silent until a human comments again. Purge it so the gate
+        # re-emits next sweep; pm_dispatch_recovery bounds the retry.
+        # (A non-zero exit AFTER a verified reply falls through to the normal
+        # promotion — re-emitting there would post a duplicate reply.)
+        #
+        # Deliberately NOT clearing the slot's `.event`/`.ts` markers here,
+        # unlike rollback_failed_delivery(): once the gate re-emits the thread,
+        # the dispatcher consults pm_dispatch_recovery.py (before its
+        # unchanged-payload and cooldown checks), which clears those markers on
+        # a failed last-terminal row with a 120s→1h backoff and a bounded
+        # attempt budget that escalates to a task. Clearing them here would
+        # re-dispatch on the very next sweep with no backoff and no budget.
+        purged = purge_pending_notif_state(config, item.repo, item.number)
+        if purged:
+            _log(
+                f"WARN: worker exit={outcome.exit_code} timed_out={outcome.timed_out} "
+                f"for {item.repo}#{item.number} — left {purged} notification "
+                "thread(s) un-promoted so the item re-enters the dispatch queue"
+            )
+        promote_item_state(config, item.repo, item.number)
     else:
         promote_item_state(config, item.repo, item.number)
 

--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -2403,24 +2403,26 @@ def run_post_session(
     ):
         # The delivery check did not verify a reply. Count this through the
         # same bounded rollback as orphan_no_delivery so a permanently broken
-        # check cannot re-emit this thread forever. PR-side state is still
-        # valid and promotes on every pass; only mapped notification state is
-        # purged while the retry budget remains.
+        # check cannot re-emit this thread forever. Clear the launch marker so
+        # the item can re-enter after the dispatcher's normal .ts cooldown;
+        # leaving it stamped suppresses a genuinely unanswered mention for the
+        # full event TTL. PR-side state is still valid and promotes on every
+        # pass; only mapped notification state is purged while the retry budget
+        # remains.
         rollback_slot_key = resolve_slot_key(config, item)
         if rollback_failed_delivery(
             config,
             item.repo,
             item.number,
             rollback_slot_key,
-            clear_event_markers=False,
         ):
             promote_item_state(
                 config, item.repo, item.number, reset_redelivery_counter=False
             )
             _log(
                 "WARN: PM delivery post-condition was not verified — rolled back "
-                f"pending notif state for {plan.repo}#{plan.number}; leaving the "
-                "event marker for backed-off dispatch recovery"
+                f"pending notif state and event marker for {plan.repo}#{plan.number} "
+                "(item re-enters after the dispatch cooldown)"
             )
         else:
             _log(

--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -2381,20 +2381,17 @@ def run_post_session(
                 "promoting state to end re-dispatch churn (no reply is likely correct here)"
             )
             promote_item_state(config, item.repo, item.number)
-    elif (
-        (outcome.timed_out or outcome.exit_code != 0)
-        and hooks.delivery_check is not None
-        and not (delivery_verified and delivery_outcome == "handled")
+    elif hooks.delivery_check is not None and not (
+        delivery_verified and delivery_outcome == "handled"
     ):
-        # The worker did not finish (exit 124) or failed outright, and the
-        # delivery check did not verify a reply. Its PR-side state still
+        # The delivery check did not verify a reply. Its PR-side state still
         # promotes (the head/score it saw are real), but the item's
         # notification state must NOT: promoting it tells the gate the
         # mention was handled, the gate dedupes on `updated_at`, and the thread
         # goes silent until a human comments again. Purge it so the gate
         # re-emits next sweep; pm_dispatch_recovery bounds the retry.
-        # (A non-zero exit AFTER a verified reply falls through to the normal
-        # promotion — re-emitting there would post a duplicate reply.)
+        # A verified reply falls through to normal promotion even when the
+        # worker failed afterward; re-emitting there would post a duplicate.
         #
         # Deliberately NOT clearing the slot's `.event`/`.ts` markers here,
         # unlike rollback_failed_delivery(): once the gate re-emits the thread,

--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -976,6 +976,7 @@ def promote_item_state(
     number: int | str | None,
     *,
     reset_redelivery_counter: bool = True,
+    include_master_ci: bool = False,
 ) -> None:
     """Copy the item's pending activity-gate state files to the real state dir.
 
@@ -1022,8 +1023,9 @@ def promote_item_state(
         patterns = [
             f"{repo_safe}-pr-{number}*.state",
             f"{repo_safe}-issue-{number}*.state",
-            f"{repo_safe}-master-ci.state",
         ]
+        if include_master_ci:
+            patterns.append(f"{repo_safe}-master-ci.state")
     for pattern in patterns:
         for f in pending.glob(pattern):
             if f.is_file():
@@ -1041,8 +1043,9 @@ def promote_notification_states(config: RunItemConfig) -> None:
     Notification state files use GitHub API ids, not repo#number, so the
     per-item promotion cannot find them by name; the gate writes a ``.map``
     sidecar (``repo#number``) for every thread it can attribute. Only the
-    *unmapped* remainder is promoted here. An undecodable map cannot establish
-    ownership, so treat its state as unmapped rather than stranding it forever.
+    *unmapped* remainder is promoted here. A readable empty map is unmapped;
+    an unreadable map remains pending because its ownership is unknown and
+    promoting it could silently consume an unhandled notification.
 
     History: this used to promote EVERY pending ``notif-*.state`` under the
     assumption "sessions already ran for every emitted notification". That
@@ -1076,10 +1079,9 @@ def promote_notification_states(config: RunItemConfig) -> None:
             try:
                 owner = map_file.read_text(encoding="utf-8").strip()
             except (OSError, UnicodeDecodeError):
-                pass  # unreadable map cannot prove item ownership
-            else:
-                if owner:
-                    continue  # owned by an item; its worker's outcome decides
+                continue  # unknown ownership: fail closed and retry next sweep
+            if owner:
+                continue  # owned by an item; its worker's outcome decides
         shutil.copy(f, config.state_dir / f.name)
 
 
@@ -2434,7 +2436,12 @@ def run_post_session(
             )
             promote_item_state(config, item.repo, item.number)
     else:
-        promote_item_state(config, item.repo, item.number)
+        promote_item_state(
+            config,
+            item.repo,
+            item.number,
+            include_master_ci="master_ci_failure" in item.types,
+        )
 
     # 9. Observable-effect signal.
     # A clean exit is not evidence the work landed: a worker can commit a fix

--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -113,6 +113,7 @@ from gptme_runloops.prompt_templates import (
     render_preheld_claim_block,
 )
 from gptme_runloops.worker_records import (
+    KNOWN_DELIVERY_OUTCOMES,
     append_wait_merge_gate_log,
     append_worker_latency_records,
     build_wait_merge_gate_entry,
@@ -1005,7 +1006,8 @@ def promote_item_state(
         # `.map` for number > 0), so it promotes only the unmapped remainder —
         # the same rule as promote_notification_states(). Copying every
         # notif-*.state here would consume siblings' emitted-but-unhandled
-        # threads through a side door.
+        # threads through a side door. It cannot own repo-level master-CI
+        # state either.
         patterns = []
         for f in pending.glob("notif-*.state"):
             if f.is_file() and not f.with_suffix(".map").is_file():
@@ -1014,8 +1016,8 @@ def promote_item_state(
         patterns = [
             f"{repo_safe}-pr-{number}*.state",
             f"{repo_safe}-issue-{number}*.state",
+            f"{repo_safe}-master-ci.state",
         ]
-    patterns.append(f"{repo_safe}-master-ci.state")
     for pattern in patterns:
         for f in pending.glob(pattern):
             if f.is_file():
@@ -2114,16 +2116,16 @@ def run_post_session(
                     text=True,
                     cwd=str(config.workspace),
                 )
-                if proc.returncode == 0:
+                check_succeeded = proc.returncode == 0
+                if check_succeeded:
                     raw = proc.stdout
-                    delivery_verified = True
                 else:
                     raw = '{"outcome":"handled"}'
             except (OSError, subprocess.SubprocessError):
+                check_succeeded = False
                 raw = '{"outcome":"handled"}'
-            delivery_outcome = normalize_delivery_outcome(
-                extract_delivery_field(raw, "outcome")
-            )
+            raw_outcome = extract_delivery_field(raw, "outcome")
+            delivery_outcome = normalize_delivery_outcome(raw_outcome)
             needs_fallback = re.sub(
                 r"[ \t\n\r\f\v]+",
                 "",
@@ -2133,6 +2135,12 @@ def run_post_session(
                 r"[ \t\n\r\f\v]+",
                 "",
                 extract_delivery_field(raw, "fallback_reply_posted"),
+            )
+            # normalize_delivery_outcome deliberately maps malformed/unknown
+            # values to the permissive "handled" default. That is safe for
+            # compatibility, but it is not evidence that delivery was observed.
+            delivery_verified = (
+                check_succeeded and raw_outcome.strip() in KNOWN_DELIVERY_OUTCOMES
             )
         except Exception:
             # NOTE(divergence, kept from step 3): total extractor death fails
@@ -2373,8 +2381,10 @@ def run_post_session(
                 "promoting state to end re-dispatch churn (no reply is likely correct here)"
             )
             promote_item_state(config, item.repo, item.number)
-    elif (outcome.timed_out or outcome.exit_code != 0) and not (
-        delivery_verified and delivery_outcome == "handled"
+    elif (
+        (outcome.timed_out or outcome.exit_code != 0)
+        and hooks.delivery_check is not None
+        and not (delivery_verified and delivery_outcome == "handled")
     ):
         # The worker did not finish (exit 124) or failed outright, and the
         # delivery check did not verify a reply. Its PR-side state still

--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -2404,6 +2404,7 @@ def run_post_session(
             )
     elif (
         hooks.delivery_check is not None
+        and resolve_cooldown_dir(config) is not None
         and item.repo
         and item.number is not None
         and item.number_str != "0"
@@ -2419,6 +2420,12 @@ def run_post_session(
         # full event TTL. PR-side state is still valid and promotes on every
         # pass; only mapped notification state is purged while the retry budget
         # remains.
+        #
+        # PM_DISPATCH_COOLDOWN_DIR guard: we only enter this branch when a
+        # durable attempts counter is available. Without it, redelivery_attempts_file()
+        # returns None and rollback_failed_delivery() would retry without any cap.
+        # When the cooldown dir is unset (misconfigured environment), we fall
+        # through to the else branch and promote state directly — safe and bounded.
         rollback_slot_key = resolve_slot_key(config, item)
         if rollback_failed_delivery(
             config,

--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -2422,7 +2422,11 @@ def run_post_session(
             rollback_slot_key,
         ):
             promote_item_state(
-                config, item.repo, item.number, reset_redelivery_counter=False
+                config,
+                item.repo,
+                item.number,
+                reset_redelivery_counter=False,
+                include_master_ci="master_ci_failure" in item.types,
             )
             _log(
                 "WARN: PM delivery post-condition was not verified — rolled back "

--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -1041,7 +1041,8 @@ def promote_notification_states(config: RunItemConfig) -> None:
     Notification state files use GitHub API ids, not repo#number, so the
     per-item promotion cannot find them by name; the gate writes a ``.map``
     sidecar (``repo#number``) for every thread it can attribute. Only the
-    *unmapped* remainder is promoted here.
+    *unmapped* remainder is promoted here. An undecodable map cannot establish
+    ownership, so treat its state as unmapped rather than stranding it forever.
 
     History: this used to promote EVERY pending ``notif-*.state`` under the
     assumption "sessions already ran for every emitted notification". That
@@ -1070,8 +1071,16 @@ def promote_notification_states(config: RunItemConfig) -> None:
     for f in pending.glob("notif-*.state"):
         if not f.is_file():
             continue
-        if f.with_suffix(".map").is_file():
-            continue  # owned by an item; its worker's outcome decides
+        map_file = f.with_suffix(".map")
+        if map_file.is_file():
+            try:
+                map_file.read_text(encoding="utf-8")
+            except UnicodeDecodeError:
+                pass  # corrupt map cannot prove item ownership
+            except OSError:
+                continue  # transient read failure: preserve the safer ownership gate
+            else:
+                continue  # owned by an item; its worker's outcome decides
         shutil.copy(f, config.state_dir / f.name)
 
 

--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -1075,10 +1075,8 @@ def promote_notification_states(config: RunItemConfig) -> None:
         if map_file.is_file():
             try:
                 owner = map_file.read_text(encoding="utf-8").strip()
-            except UnicodeDecodeError:
-                pass  # corrupt map cannot prove item ownership
-            except OSError:
-                continue  # transient read failure: preserve the safer ownership gate
+            except (OSError, UnicodeDecodeError):
+                pass  # unreadable map cannot prove item ownership
             else:
                 if owner:
                     continue  # owned by an item; its worker's outcome decides

--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -891,7 +891,7 @@ def purge_pending_notif_state(
             continue
         try:
             content = map_file.read_text(encoding="utf-8").strip()
-        except OSError:
+        except (OSError, UnicodeDecodeError):
             continue
         # bash matches the anchored regex ^repo#number$ against the file body.
         if content != target:
@@ -906,18 +906,23 @@ def purge_pending_notif_state(
 
 
 def rollback_failed_delivery(
-    config: RunItemConfig, repo: str, number: int | str | None, slot_key: str
+    config: RunItemConfig,
+    repo: str,
+    number: int | str | None,
+    slot_key: str,
+    *,
+    clear_event_markers: bool = True,
 ) -> bool:
-    """bash ``rollback_failed_delivery`` (lib.sh:956-1005), in full.
-
-    Three effects, all required — a partial rollback is a no-op:
+    """Bound and apply a failed-delivery rollback.
 
     1. Count the attempt; past ``PM_MAX_REDELIVERY_ATTEMPTS`` reset the
        counter and return False, telling the caller to promote instead (this
        is what stops the re-dispatch treadmill on items where no reply is
        ever appropriate).
-    2. Clear the slot's ``.event``/``.event_logged`` fingerprints so the item
-       is not suppressed for the 6h TTL.
+    2. Optionally clear the slot's ``.event``/``.event_logged`` fingerprints.
+       The explicit ``orphan_no_delivery`` path needs an immediate re-dispatch;
+       an unverified delivery check leaves them for ``pm_dispatch_recovery`` so
+       that its backed-off retry policy remains authoritative.
     3. Purge this item's pending ``notif-*`` state so the end-of-run blanket
        promotion cannot consume it.
 
@@ -943,7 +948,8 @@ def rollback_failed_delivery(
         except OSError:
             pass
 
-    clear_slot_event_markers(config, slot_key)
+    if clear_event_markers:
+        clear_slot_event_markers(config, slot_key)
     purge_pending_notif_state(config, repo, number)
     return True
 
@@ -963,7 +969,7 @@ def _mapped_notif_state_files(pending: Path, repo: str, number: int | str | None
             continue
         try:
             content = map_file.read_text(encoding="utf-8").strip()
-        except OSError:
+        except (OSError, UnicodeDecodeError):
             continue
         if content == target:
             yield map_file, map_file.with_suffix(".state")
@@ -2401,14 +2407,20 @@ def run_post_session(
         # valid and promotes on every pass; only mapped notification state is
         # purged while the retry budget remains.
         rollback_slot_key = resolve_slot_key(config, item)
-        if rollback_failed_delivery(config, item.repo, item.number, rollback_slot_key):
+        if rollback_failed_delivery(
+            config,
+            item.repo,
+            item.number,
+            rollback_slot_key,
+            clear_event_markers=False,
+        ):
             promote_item_state(
                 config, item.repo, item.number, reset_redelivery_counter=False
             )
             _log(
                 "WARN: PM delivery post-condition was not verified — rolled back "
-                f"event marker and pending notif state for {plan.repo}#{plan.number} "
-                "(item re-enters the dispatch queue)"
+                f"pending notif state for {plan.repo}#{plan.number}; leaving the "
+                "event marker for backed-off dispatch recovery"
             )
         else:
             _log(

--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -1074,13 +1074,14 @@ def promote_notification_states(config: RunItemConfig) -> None:
         map_file = f.with_suffix(".map")
         if map_file.is_file():
             try:
-                map_file.read_text(encoding="utf-8")
+                owner = map_file.read_text(encoding="utf-8").strip()
             except UnicodeDecodeError:
                 pass  # corrupt map cannot prove item ownership
             except OSError:
                 continue  # transient read failure: preserve the safer ownership gate
             else:
-                continue  # owned by an item; its worker's outcome decides
+                if owner:
+                    continue  # owned by an item; its worker's outcome decides
         shutil.copy(f, config.state_dir / f.name)
 
 

--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -970,14 +970,19 @@ def _mapped_notif_state_files(pending: Path, repo: str, number: int | str | None
 
 
 def promote_item_state(
-    config: RunItemConfig, repo: str, number: int | str | None
+    config: RunItemConfig,
+    repo: str,
+    number: int | str | None,
+    *,
+    reset_redelivery_counter: bool = True,
 ) -> None:
     """Copy the item's pending activity-gate state files to the real state dir.
 
     Includes the item's *mapped* ``notif-*.state`` (via the ``.map`` sidecar):
     notification state is owned by the outcome of the worker that handled the
     item, not by whichever worker happens to finish next — see
-    :func:`promote_notification_states`.
+    :func:`promote_notification_states`. A bounded notification retry may set
+    ``reset_redelivery_counter=False`` while still promoting valid PR-side state.
     """
     import shutil
 
@@ -988,7 +993,7 @@ def promote_item_state(
     # so a later genuine failure gets a full retry budget. Without this the
     # budget degrades monotonically until every failure promotes immediately.
     attempts_file = redelivery_attempts_file(config, repo, number)
-    if attempts_file is not None:
+    if reset_redelivery_counter and attempts_file is not None:
         try:
             attempts_file.unlink()
         except OSError:
@@ -2384,30 +2389,27 @@ def run_post_session(
     elif hooks.delivery_check is not None and not (
         delivery_verified and delivery_outcome == "handled"
     ):
-        # The delivery check did not verify a reply. Its PR-side state still
-        # promotes (the head/score it saw are real), but the item's
-        # notification state must NOT: promoting it tells the gate the
-        # mention was handled, the gate dedupes on `updated_at`, and the thread
-        # goes silent until a human comments again. Purge it so the gate
-        # re-emits next sweep; pm_dispatch_recovery bounds the retry.
-        # A verified reply falls through to normal promotion even when the
-        # worker failed afterward; re-emitting there would post a duplicate.
-        #
-        # Deliberately NOT clearing the slot's `.event`/`.ts` markers here,
-        # unlike rollback_failed_delivery(): once the gate re-emits the thread,
-        # the dispatcher consults pm_dispatch_recovery.py (before its
-        # unchanged-payload and cooldown checks), which clears those markers on
-        # a failed last-terminal row with a 120s→1h backoff and a bounded
-        # attempt budget that escalates to a task. Clearing them here would
-        # re-dispatch on the very next sweep with no backoff and no budget.
-        purged = purge_pending_notif_state(config, item.repo, item.number)
-        if purged:
-            _log(
-                f"WARN: worker exit={outcome.exit_code} timed_out={outcome.timed_out} "
-                f"for {item.repo}#{item.number} — left {purged} notification "
-                "thread(s) un-promoted so the item re-enters the dispatch queue"
+        # The delivery check did not verify a reply. Count this through the
+        # same bounded rollback as orphan_no_delivery so a permanently broken
+        # check cannot re-emit this thread forever. PR-side state is still
+        # valid and promotes on every pass; only mapped notification state is
+        # purged while the retry budget remains.
+        rollback_slot_key = resolve_slot_key(config, item)
+        if rollback_failed_delivery(config, item.repo, item.number, rollback_slot_key):
+            promote_item_state(
+                config, item.repo, item.number, reset_redelivery_counter=False
             )
-        promote_item_state(config, item.repo, item.number)
+            _log(
+                "WARN: PM delivery post-condition was not verified — rolled back "
+                f"event marker and pending notif state for {plan.repo}#{plan.number} "
+                "(item re-enters the dispatch queue)"
+            )
+        else:
+            _log(
+                f"WARN: PM redelivery cap reached for {item.repo}#{item.number} — "
+                "promoting state to end re-dispatch churn"
+            )
+            promote_item_state(config, item.repo, item.number)
     else:
         promote_item_state(config, item.repo, item.number)
 

--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -910,8 +910,6 @@ def rollback_failed_delivery(
     repo: str,
     number: int | str | None,
     slot_key: str,
-    *,
-    clear_event_markers: bool = True,
 ) -> bool:
     """Bound and apply a failed-delivery rollback.
 
@@ -919,10 +917,8 @@ def rollback_failed_delivery(
        counter and return False, telling the caller to promote instead (this
        is what stops the re-dispatch treadmill on items where no reply is
        ever appropriate).
-    2. Optionally clear the slot's ``.event``/``.event_logged`` fingerprints.
-       The explicit ``orphan_no_delivery`` path needs an immediate re-dispatch;
-       an unverified delivery check leaves them for ``pm_dispatch_recovery`` so
-       that its backed-off retry policy remains authoritative.
+    2. Clear the slot's ``.event``/``.event_logged`` fingerprints so the item
+       can re-enter after the dispatcher's normal ``.ts`` cooldown.
     3. Purge this item's pending ``notif-*`` state so the end-of-run blanket
        promotion cannot consume it.
 
@@ -948,8 +944,7 @@ def rollback_failed_delivery(
         except OSError:
             pass
 
-    if clear_event_markers:
-        clear_slot_event_markers(config, slot_key)
+    clear_slot_event_markers(config, slot_key)
     purge_pending_notif_state(config, repo, number)
     return True
 

--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -2396,7 +2396,12 @@ def run_post_session(
                 f"WARN: PM redelivery cap reached for {item.repo}#{item.number} — "
                 "promoting state to end re-dispatch churn (no reply is likely correct here)"
             )
-            promote_item_state(config, item.repo, item.number)
+            promote_item_state(
+                config,
+                item.repo,
+                item.number,
+                include_master_ci="master_ci_failure" in item.types,
+            )
     elif (
         hooks.delivery_check is not None
         and item.repo
@@ -2438,7 +2443,12 @@ def run_post_session(
                 f"WARN: PM redelivery cap reached for {item.repo}#{item.number} — "
                 "promoting state to end re-dispatch churn"
             )
-            promote_item_state(config, item.repo, item.number)
+            promote_item_state(
+                config,
+                item.repo,
+                item.number,
+                include_master_ci="master_ci_failure" in item.types,
+            )
     else:
         promote_item_state(
             config,

--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -2386,8 +2386,14 @@ def run_post_session(
                 "promoting state to end re-dispatch churn (no reply is likely correct here)"
             )
             promote_item_state(config, item.repo, item.number)
-    elif hooks.delivery_check is not None and not (
-        delivery_verified and delivery_outcome == "handled"
+    elif (
+        hooks.delivery_check is not None
+        and item.repo
+        and item.number is not None
+        and item.number_str != "0"
+        and THREAD_DELIVERABLE_TYPES & set(item.types)
+        and set(item.types) != {"merge_ready"}
+        and not (delivery_verified and delivery_outcome == "handled")
     ):
         # The delivery check did not verify a reply. Count this through the
         # same bounded rollback as orphan_no_delivery so a permanently broken

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -1607,6 +1607,32 @@ def test_post_session_failed_exit_with_verified_delivery_still_promotes(
     assert (config.state_dir / "notif-555.state").exists()
 
 
+def test_post_session_unverified_delivery_without_cooldown_dir_promotes_directly(
+    tmp_path, monkeypatch
+) -> None:
+    """Without PM_DISPATCH_COOLDOWN_DIR the redelivery counter cannot be persisted.
+    The elif guard (resolve_cooldown_dir is not None) evaluates False, so we fall
+    through to the else branch and promote state directly — no unbounded retry churn.
+    """
+    from gptme_runloops.run_item import promote_notification_states
+
+    monkeypatch.delenv("PM_DISPATCH_COOLDOWN_DIR", raising=False)
+    monkeypatch.setenv("PM_SLOT_KEY", "gptme/gptme-contrib#1234")
+    config, item, plan, outcome, hooks, run_cmd, _ = _post_session_fixture(tmp_path)
+    run_cmd.on("/fake/check-delivery.py", returncode=1, stdout="")
+    run_cmd.on("/fake/gate.py", returncode=1)
+    config.pending_state_dir.mkdir(parents=True)
+    (config.pending_state_dir / "notif-555.map").write_text("gptme/gptme-contrib#1234")
+    (config.pending_state_dir / "notif-555.state").write_text("t")
+
+    run_post_session(plan, item, outcome, config, hooks)
+    promote_notification_states(config)
+
+    # Notification state is promoted (not churn-purged) because the elif guard
+    # (resolve_cooldown_dir is not None) is False → falls through to else branch.
+    assert (config.state_dir / "notif-555.state").exists()
+
+
 def test_post_session_clean_exit_promotes_mapped_notification_state(
     tmp_path, cooldown_dir
 ) -> None:

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -2307,6 +2307,30 @@ def test_invalid_notification_map_is_treated_as_unmapped(tmp_path, map_value) ->
     assert (config.state_dir / "notif-1.state").read_text() == "invalid-map-state"
 
 
+def test_unreadable_notification_map_is_treated_as_unmapped(
+    tmp_path, monkeypatch
+) -> None:
+    """A map read failure cannot establish ownership or strand pending state."""
+    config = make_config(tmp_path)
+    pending = config.pending_state_dir
+    pending.mkdir(parents=True)
+    map_file = pending / "notif-1.map"
+    map_file.write_text("gptme/gptme#3468")
+    (pending / "notif-1.state").write_text("unreadable-map-state")
+    original_read_text = Path.read_text
+
+    def fail_map_read(path, *args, **kwargs):
+        if path == map_file:
+            raise OSError("simulated read failure")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", fail_map_read)
+
+    promote_notification_states(config)
+
+    assert (config.state_dir / "notif-1.state").read_text() == "unreadable-map-state"
+
+
 def test_promote_item_state_resets_redelivery_counter(tmp_path, cooldown_dir) -> None:
     config = make_config(tmp_path)
     config.pending_state_dir.mkdir(parents=True)

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -1550,6 +1550,36 @@ def test_post_session_clean_exit_with_unverified_delivery_does_not_consume_notif
     assert not (config.pending_state_dir / "notif-555.state").exists()
 
 
+def test_post_session_unverified_delivery_honors_redelivery_cap(
+    tmp_path, cooldown_dir, monkeypatch
+) -> None:
+    """A persistently broken delivery check must not re-emit forever."""
+    monkeypatch.delenv("PM_SLOT_KEY", raising=False)
+    monkeypatch.setenv("PM_MAX_REDELIVERY_ATTEMPTS", "1")
+    config, item, plan, outcome, hooks, run_cmd, _ = _post_session_fixture(tmp_path)
+    run_cmd.on("/fake/check-delivery.py", returncode=1, stdout="")
+    run_cmd.on("/fake/gate.py", returncode=1)
+
+    def stage_notification() -> None:
+        config.pending_state_dir.mkdir(parents=True, exist_ok=True)
+        (config.pending_state_dir / "notif-555.map").write_text(
+            "gptme/gptme-contrib#1234"
+        )
+        (config.pending_state_dir / "notif-555.state").write_text("t")
+
+    stage_notification()
+    run_post_session(plan, item, outcome, config, hooks)
+    attempts = redelivery_attempts_file(config, item.repo, item.number)
+    assert attempts is not None
+    assert attempts.read_text() == "1"
+    assert not (config.state_dir / "notif-555.state").exists()
+
+    stage_notification()
+    run_post_session(plan, item, outcome, config, hooks)
+    assert not attempts.exists()
+    assert (config.state_dir / "notif-555.state").exists()
+
+
 def test_post_session_failed_exit_with_verified_delivery_still_promotes(
     tmp_path, cooldown_dir
 ) -> None:

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -2185,7 +2185,9 @@ def test_pr_observe_types_is_superset_of_pr_state_types() -> None:
     }
 
 
-def test_promote_item_state_copies_matching_files(tmp_path) -> None:
+def test_promote_item_state_copies_only_number_scoped_matching_files(
+    tmp_path,
+) -> None:
     config = make_config(tmp_path)
     pending = config.pending_state_dir
     pending.mkdir(parents=True)
@@ -2198,8 +2200,19 @@ def test_promote_item_state_copies_matching_files(tmp_path) -> None:
     assert names == {
         "gptme-gptme-pr-5-update.state",
         "gptme-gptme-issue-5.state",
-        "gptme-gptme-master-ci.state",
     }
+
+
+def test_promote_item_state_copies_master_ci_only_when_requested(tmp_path) -> None:
+    config = make_config(tmp_path)
+    pending = config.pending_state_dir
+    pending.mkdir(parents=True)
+    master_ci = pending / "gptme-gptme-master-ci.state"
+    master_ci.write_text("failed-run")
+
+    promote_item_state(config, "gptme/gptme", 123, include_master_ci=True)
+
+    assert (config.state_dir / master_ci.name).read_text() == "failed-run"
 
 
 # --- Delivery rollback (bash lib.sh:946-995 parity) ---
@@ -2286,14 +2299,14 @@ def test_rollback_respects_max_attempts_env(
     assert not rollback_failed_delivery(config, "gptme/gptme", 3468, "gptme/gptme#3468")
 
 
-@pytest.mark.parametrize("map_value", [b"\xff", b"", b" \n"])
-def test_invalid_notification_map_is_treated_as_unmapped(tmp_path, map_value) -> None:
-    """An invalid sidecar must not strand its notification state pending."""
+@pytest.mark.parametrize("map_value", [b"", b" \n"])
+def test_empty_notification_map_is_treated_as_unmapped(tmp_path, map_value) -> None:
+    """A readable empty sidecar does not establish notification ownership."""
     config = make_config(tmp_path)
     pending = config.pending_state_dir
     pending.mkdir(parents=True)
     (pending / "notif-1.map").write_bytes(map_value)
-    (pending / "notif-1.state").write_text("invalid-map-state")
+    (pending / "notif-1.state").write_text("empty-map-state")
     (pending / "notif-2.map").write_text("gptme/gptme#3468")
     (pending / "notif-2.state").write_text("valid")
 
@@ -2304,13 +2317,11 @@ def test_invalid_notification_map_is_treated_as_unmapped(tmp_path, map_value) ->
     assert (pending / "notif-1.map").exists()
 
     promote_notification_states(config)
-    assert (config.state_dir / "notif-1.state").read_text() == "invalid-map-state"
+    assert (config.state_dir / "notif-1.state").read_text() == "empty-map-state"
 
 
-def test_unreadable_notification_map_is_treated_as_unmapped(
-    tmp_path, monkeypatch
-) -> None:
-    """A map read failure cannot establish ownership or strand pending state."""
+def test_unreadable_notification_map_remains_pending(tmp_path, monkeypatch) -> None:
+    """Unknown ownership fails closed so an unhandled notification can retry."""
     config = make_config(tmp_path)
     pending = config.pending_state_dir
     pending.mkdir(parents=True)
@@ -2328,7 +2339,8 @@ def test_unreadable_notification_map_is_treated_as_unmapped(
 
     promote_notification_states(config)
 
-    assert (config.state_dir / "notif-1.state").read_text() == "unreadable-map-state"
+    assert not (config.state_dir / "notif-1.state").exists()
+    assert (pending / "notif-1.state").read_text() == "unreadable-map-state"
 
 
 def test_promote_item_state_resets_redelivery_counter(tmp_path, cooldown_dir) -> None:

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -1798,7 +1798,9 @@ def test_post_session_malformed_delivery_output_is_not_verified(
     assert not (config.pending_state_dir / "notif-555.state").exists()
 
 
-def test_post_session_repo_level_item_skips_delivery_check(tmp_path) -> None:
+def test_post_session_repo_level_item_skips_delivery_check(
+    tmp_path, cooldown_dir
+) -> None:
     """master_ci_failure has no thread, so the reply post-condition must not run.
 
     Its `number` is a workflow run id, not an issue number, so the check would
@@ -1817,10 +1819,15 @@ def test_post_session_repo_level_item_skips_delivery_check(tmp_path) -> None:
     config.pending_state_dir.mkdir(parents=True, exist_ok=True)
     sentinel = config.pending_state_dir / "gptme-gptme-contrib-master-ci.state"
     sentinel.write_text("promoted")
+    attempts = redelivery_attempts_file(config, item.repo, item.number)
+    assert attempts is not None
+    attempts.parent.mkdir(parents=True, exist_ok=True)
+    attempts.write_text("1")
     run_cmd.on("/fake/check-delivery.py", stdout='{"outcome": "orphan_no_delivery"}')
     effect = run_post_session(plan, item, outcome, config, hooks)
     assert run_cmd.find("/fake/check-delivery.py") == []
     assert latency_calls[0]["outcome"] == "handled"
+    assert not attempts.exists(), "a skipped check must not consume retry budget"
     # State must be promoted, not rolled back — otherwise the item re-enters the queue.
     assert (config.state_dir / sentinel.name).exists(), (
         "promote_item_state was not called — state was not promoted from pending; "
@@ -2204,6 +2211,7 @@ def cooldown_dir(tmp_path, monkeypatch):
     d = tmp_path / "cooldown"
     d.mkdir()
     monkeypatch.setenv("PM_DISPATCH_COOLDOWN_DIR", str(d))
+    monkeypatch.delenv("PM_SLOT_KEY", raising=False)
     return d
 
 

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -1674,6 +1674,64 @@ def test_post_session_unverified_rollback_promotes_master_ci_state(
     assert not (config.state_dir / "notif-555.state").exists()
 
 
+def test_post_session_orphan_delivery_cap_promotes_master_ci_state(
+    tmp_path, cooldown_dir, monkeypatch
+) -> None:
+    """orphan_no_delivery cap-reached path must promote master-CI state for a
+    mixed item (pr_update + master_ci_failure), so the activity gate stops
+    re-emitting the master-CI failure (AI-review finding fp:1cf0f59340b8
+    cap-reached branch on gptme/gptme-contrib#1474)."""
+    monkeypatch.setenv("PM_MAX_REDELIVERY_ATTEMPTS", "0")
+    config, item, plan, outcome, hooks, run_cmd, _ = _post_session_fixture(
+        tmp_path, types=("pr_update", "master_ci_failure")
+    )
+    run_cmd.on(
+        "/fake/check-delivery.py",
+        stdout='{"outcome": "orphan_no_delivery", "needs_fallback_reply": true, '
+        '"fallback_reply_posted": false}',
+    )
+    run_cmd.on("/fake/gate.py", returncode=1)
+    config.pending_state_dir.mkdir(parents=True)
+    master_ci = config.pending_state_dir / "gptme-gptme-contrib-master-ci.state"
+    master_ci.write_text("seen")
+    (config.pending_state_dir / "gptme-gptme-contrib-pr-1234-update.state").write_text("s")
+
+    run_post_session(plan, item, outcome, config, hooks)
+
+    assert (config.state_dir / master_ci.name).is_file(), (
+        "orphan cap-reached path must promote master-CI state so the activity "
+        "gate stops re-emitting a handled master-CI failure"
+    )
+
+
+def test_post_session_unverified_delivery_cap_promotes_master_ci_state(
+    tmp_path, cooldown_dir, monkeypatch
+) -> None:
+    """unverified-delivery cap-reached path must promote master-CI state for a
+    mixed item (pr_update + master_ci_failure), so the activity gate stops
+    re-emitting the master-CI failure (AI-review finding fp:1cf0f59340b8
+    cap-reached branch on gptme/gptme-contrib#1474)."""
+    monkeypatch.setenv("PM_SLOT_KEY", "gptme/gptme-contrib#1234")
+    monkeypatch.setenv("PM_MAX_REDELIVERY_ATTEMPTS", "0")
+    config, item, plan, outcome, hooks, run_cmd, _ = _post_session_fixture(
+        tmp_path, types=("pr_update", "master_ci_failure")
+    )
+    run_cmd.on("/fake/check-delivery.py", returncode=1, stdout="")
+    run_cmd.on("/fake/gate.py", returncode=1)
+    config.pending_state_dir.mkdir(parents=True)
+    master_ci = config.pending_state_dir / "gptme-gptme-contrib-master-ci.state"
+    master_ci.write_text("seen")
+    (config.pending_state_dir / "notif-555.map").write_text("gptme/gptme-contrib#1234")
+    (config.pending_state_dir / "notif-555.state").write_text("t")
+
+    run_post_session(plan, item, outcome, config, hooks)
+
+    assert (config.state_dir / master_ci.name).is_file(), (
+        "unverified cap-reached path must promote master-CI state so the activity "
+        "gate stops re-emitting a handled master-CI failure"
+    )
+
+
 def test_post_session_failed_exit_maps_latency_failed(tmp_path) -> None:
     config, item, plan, outcome, hooks, run_cmd, latency_calls = _post_session_fixture(
         tmp_path, exit_code=1

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -1647,6 +1647,33 @@ def test_post_session_orphan_delivery_promotes_after_redelivery_cap(
     assert (config.state_dir / "gptme-gptme-contrib-pr-1234-update.state").is_file()
 
 
+def test_post_session_unverified_rollback_promotes_master_ci_state(
+    tmp_path, cooldown_dir
+) -> None:
+    """A mixed thread-deliverable + master_ci_failure item that rolls back for
+    unverified delivery must still promote its master-CI state, so the activity
+    gate does not re-emit the master-CI failure it already handled (AI-review
+    finding 1cf0f59340b8 on gptme/gptme-contrib#1474)."""
+    config, item, plan, outcome, hooks, run_cmd, _ = _post_session_fixture(
+        tmp_path, types=("pr_update", "master_ci_failure")
+    )
+    run_cmd.on("/fake/check-delivery.py", returncode=1, stdout="")
+    run_cmd.on("/fake/gate.py", returncode=1)
+    config.pending_state_dir.mkdir(parents=True)
+    master_ci = config.pending_state_dir / "gptme-gptme-contrib-master-ci.state"
+    master_ci.write_text("seen")
+    (config.pending_state_dir / "notif-555.map").write_text("gptme/gptme-contrib#1234")
+    (config.pending_state_dir / "notif-555.state").write_text("t")
+
+    run_post_session(plan, item, outcome, config, hooks)
+
+    assert (config.state_dir / master_ci.name).is_file(), (
+        "rollback-path promotion must copy the item's master-CI state so the "
+        "activity gate stops re-emitting a handled master-CI failure"
+    )
+    assert not (config.state_dir / "notif-555.state").exists()
+
+
 def test_post_session_failed_exit_maps_latency_failed(tmp_path) -> None:
     config, item, plan, outcome, hooks, run_cmd, latency_calls = _post_session_fixture(
         tmp_path, exit_code=1

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -1694,7 +1694,9 @@ def test_post_session_orphan_delivery_cap_promotes_master_ci_state(
     config.pending_state_dir.mkdir(parents=True)
     master_ci = config.pending_state_dir / "gptme-gptme-contrib-master-ci.state"
     master_ci.write_text("seen")
-    (config.pending_state_dir / "gptme-gptme-contrib-pr-1234-update.state").write_text("s")
+    (config.pending_state_dir / "gptme-gptme-contrib-pr-1234-update.state").write_text(
+        "s"
+    )
 
     run_post_session(plan, item, outcome, config, hooks)
 

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -1493,6 +1493,83 @@ def test_post_session_orphan_delivery_rolls_back_instead_of_promoting(
     assert not (cooldown_dir / "gptme-gptme-contrib-1234.event").exists()
 
 
+def test_post_session_timed_out_worker_does_not_consume_notification_state(
+    tmp_path, cooldown_dir
+) -> None:
+    """A worker killed at its time budget (exit 124) handled nothing; promoting
+    the item's notif state would make the gate treat the mention as done
+    (ActivityWatch/activitywatch#1402, 2026-08-20). PR-side state still
+    promotes; the notification thread must stay re-emittable even after the
+    end-of-run blanket promotion."""
+    from gptme_runloops.run_item import promote_notification_states
+
+    config, item, plan, outcome, hooks, run_cmd, _ = _post_session_fixture(
+        tmp_path, exit_code=124
+    )
+    outcome.timed_out = True
+    # A killed worker has no verified delivery (the check cannot attribute a reply).
+    run_cmd.on("/fake/check-delivery.py", returncode=1, stdout="")
+    run_cmd.on("/fake/gate.py", returncode=1)
+    config.pending_state_dir.mkdir(parents=True)
+    (config.pending_state_dir / "gptme-gptme-contrib-pr-1234-update.state").write_text(
+        "s"
+    )
+    (config.pending_state_dir / "notif-555.map").write_text("gptme/gptme-contrib#1234")
+    (config.pending_state_dir / "notif-555.state").write_text("2026-08-20T09:31:35Z")
+    (config.pending_state_dir / "notif-777.map").write_text("gptme/gptme-contrib#9999")
+    (config.pending_state_dir / "notif-777.state").write_text("other-item")
+
+    run_post_session(plan, item, outcome, config, hooks)
+    promote_notification_states(config)
+
+    assert (config.state_dir / "gptme-gptme-contrib-pr-1234-update.state").exists()
+    assert not (config.state_dir / "notif-555.state").exists()
+    assert not (config.pending_state_dir / "notif-555.state").exists()
+    # a sibling's emitted-but-unhandled thread is left alone, not promoted
+    assert not (config.state_dir / "notif-777.state").exists()
+    assert (config.pending_state_dir / "notif-777.state").exists()
+
+
+def test_post_session_failed_exit_with_verified_delivery_still_promotes(
+    tmp_path, cooldown_dir
+) -> None:
+    """A worker that posted its reply and then died non-zero DID handle the
+    thread; purging here would re-emit it and post a duplicate reply."""
+    from gptme_runloops.run_item import promote_notification_states
+
+    config, item, plan, outcome, hooks, run_cmd, _ = _post_session_fixture(
+        tmp_path, exit_code=1
+    )
+    run_cmd.on("/fake/check-delivery.py", stdout='{"outcome": "handled"}')
+    run_cmd.on("/fake/gate.py", returncode=1)
+    config.pending_state_dir.mkdir(parents=True)
+    (config.pending_state_dir / "notif-555.map").write_text("gptme/gptme-contrib#1234")
+    (config.pending_state_dir / "notif-555.state").write_text("t")
+
+    run_post_session(plan, item, outcome, config, hooks)
+    promote_notification_states(config)
+
+    assert (config.state_dir / "notif-555.state").exists()
+
+
+def test_post_session_clean_exit_promotes_mapped_notification_state(
+    tmp_path, cooldown_dir
+) -> None:
+    from gptme_runloops.run_item import promote_notification_states
+
+    config, item, plan, outcome, hooks, run_cmd, _ = _post_session_fixture(tmp_path)
+    run_cmd.on("/fake/check-delivery.py", stdout='{"outcome": "handled"}')
+    run_cmd.on("/fake/gate.py", returncode=1)
+    config.pending_state_dir.mkdir(parents=True)
+    (config.pending_state_dir / "notif-555.map").write_text("gptme/gptme-contrib#1234")
+    (config.pending_state_dir / "notif-555.state").write_text("t")
+
+    run_post_session(plan, item, outcome, config, hooks)
+    promote_notification_states(config)
+
+    assert (config.state_dir / "notif-555.state").exists()
+
+
 def test_post_session_orphan_delivery_promotes_after_redelivery_cap(
     tmp_path, cooldown_dir, monkeypatch
 ) -> None:

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -1530,6 +1530,26 @@ def test_post_session_timed_out_worker_does_not_consume_notification_state(
     assert (config.pending_state_dir / "notif-777.state").exists()
 
 
+def test_post_session_clean_exit_with_unverified_delivery_does_not_consume_notification_state(
+    tmp_path, cooldown_dir
+) -> None:
+    """A clean worker exit cannot compensate for a broken delivery check."""
+    from gptme_runloops.run_item import promote_notification_states
+
+    config, item, plan, outcome, hooks, run_cmd, _ = _post_session_fixture(tmp_path)
+    run_cmd.on("/fake/check-delivery.py", returncode=1, stdout="")
+    run_cmd.on("/fake/gate.py", returncode=1)
+    config.pending_state_dir.mkdir(parents=True)
+    (config.pending_state_dir / "notif-555.map").write_text("gptme/gptme-contrib#1234")
+    (config.pending_state_dir / "notif-555.state").write_text("t")
+
+    run_post_session(plan, item, outcome, config, hooks)
+    promote_notification_states(config)
+
+    assert not (config.state_dir / "notif-555.state").exists()
+    assert not (config.pending_state_dir / "notif-555.state").exists()
+
+
 def test_post_session_failed_exit_with_verified_delivery_still_promotes(
     tmp_path, cooldown_dir
 ) -> None:
@@ -1717,9 +1737,7 @@ def test_post_session_failed_exit_without_delivery_hook_preserves_notification(
     hooks.wait_merge_gate = None
     hooks.arc_manager = None
     config.pending_state_dir.mkdir(parents=True)
-    (config.pending_state_dir / "notif-555.map").write_text(
-        "gptme/gptme-contrib#1234"
-    )
+    (config.pending_state_dir / "notif-555.map").write_text("gptme/gptme-contrib#1234")
     (config.pending_state_dir / "notif-555.state").write_text("t")
 
     run_post_session(plan, item, outcome, config, hooks)
@@ -1740,9 +1758,7 @@ def test_post_session_malformed_delivery_output_is_not_verified(
     run_cmd.on("/fake/check-delivery.py", stdout="not json")
     run_cmd.on("/fake/gate.py", returncode=1)
     config.pending_state_dir.mkdir(parents=True)
-    (config.pending_state_dir / "notif-555.map").write_text(
-        "gptme/gptme-contrib#1234"
-    )
+    (config.pending_state_dir / "notif-555.map").write_text("gptme/gptme-contrib#1234")
     (config.pending_state_dir / "notif-555.state").write_text("t")
 
     run_post_session(plan, item, outcome, config, hooks)

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -1704,6 +1704,54 @@ def test_post_session_merge_ready_only_merge_without_reply_promotes(tmp_path) ->
     ).exists(), "state must be promoted — rollback would re-queue an already-merged PR"
 
 
+def test_post_session_failed_exit_without_delivery_hook_preserves_notification(
+    tmp_path,
+) -> None:
+    """Without an observation hook, failure cannot prove no reply was posted."""
+    from gptme_runloops.run_item import promote_notification_states
+
+    config, item, plan, outcome, hooks, _, _ = _post_session_fixture(
+        tmp_path, exit_code=1, types=("notification",)
+    )
+    hooks.delivery_check = None
+    hooks.wait_merge_gate = None
+    hooks.arc_manager = None
+    config.pending_state_dir.mkdir(parents=True)
+    (config.pending_state_dir / "notif-555.map").write_text(
+        "gptme/gptme-contrib#1234"
+    )
+    (config.pending_state_dir / "notif-555.state").write_text("t")
+
+    run_post_session(plan, item, outcome, config, hooks)
+    promote_notification_states(config)
+
+    assert (config.state_dir / "notif-555.state").exists()
+
+
+def test_post_session_malformed_delivery_output_is_not_verified(
+    tmp_path, cooldown_dir
+) -> None:
+    """Exit zero alone is not verification when the output cannot be parsed."""
+    from gptme_runloops.run_item import promote_notification_states
+
+    config, item, plan, outcome, hooks, run_cmd, _ = _post_session_fixture(
+        tmp_path, exit_code=1
+    )
+    run_cmd.on("/fake/check-delivery.py", stdout="not json")
+    run_cmd.on("/fake/gate.py", returncode=1)
+    config.pending_state_dir.mkdir(parents=True)
+    (config.pending_state_dir / "notif-555.map").write_text(
+        "gptme/gptme-contrib#1234"
+    )
+    (config.pending_state_dir / "notif-555.state").write_text("t")
+
+    run_post_session(plan, item, outcome, config, hooks)
+    promote_notification_states(config)
+
+    assert not (config.state_dir / "notif-555.state").exists()
+    assert not (config.pending_state_dir / "notif-555.state").exists()
+
+
 def test_post_session_repo_level_item_skips_delivery_check(tmp_path) -> None:
     """master_ci_failure has no thread, so the reply post-condition must not run.
 

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -1576,7 +1576,7 @@ def test_post_session_unverified_delivery_honors_redelivery_cap(
     assert attempts is not None
     assert attempts.read_text() == "1"
     assert not (config.state_dir / "notif-555.state").exists()
-    assert event_marker.exists(), "dispatch recovery owns the backed-off re-arm"
+    assert not event_marker.exists(), "failed delivery must not remain suppressed"
 
     stage_notification()
     run_post_session(plan, item, outcome, config, hooks)

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -2286,13 +2286,14 @@ def test_rollback_respects_max_attempts_env(
     assert not rollback_failed_delivery(config, "gptme/gptme", 3468, "gptme/gptme#3468")
 
 
-def test_corrupt_notification_map_is_treated_as_unmapped(tmp_path) -> None:
-    """An unreadable sidecar must not strand its notification state pending."""
+@pytest.mark.parametrize("map_value", [b"\xff", b"", b" \n"])
+def test_invalid_notification_map_is_treated_as_unmapped(tmp_path, map_value) -> None:
+    """An invalid sidecar must not strand its notification state pending."""
     config = make_config(tmp_path)
     pending = config.pending_state_dir
     pending.mkdir(parents=True)
-    (pending / "notif-1.map").write_bytes(b"\xff")
-    (pending / "notif-1.state").write_text("corrupt-map-state")
+    (pending / "notif-1.map").write_bytes(map_value)
+    (pending / "notif-1.state").write_text("invalid-map-state")
     (pending / "notif-2.map").write_text("gptme/gptme#3468")
     (pending / "notif-2.state").write_text("valid")
 
@@ -2303,7 +2304,7 @@ def test_corrupt_notification_map_is_treated_as_unmapped(tmp_path) -> None:
     assert (pending / "notif-1.map").exists()
 
     promote_notification_states(config)
-    assert (config.state_dir / "notif-1.state").read_text() == "corrupt-map-state"
+    assert (config.state_dir / "notif-1.state").read_text() == "invalid-map-state"
 
 
 def test_promote_item_state_resets_redelivery_counter(tmp_path, cooldown_dir) -> None:

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -55,6 +55,7 @@ from gptme_runloops.run_item import (
     plan_item,
     predict_cc_trajectory_path,
     promote_item_state,
+    purge_pending_notif_state,
     redelivery_attempts_file,
     resolve_backend_trajectory,
     resolve_cc_sub_suffix,
@@ -1554,11 +1555,12 @@ def test_post_session_unverified_delivery_honors_redelivery_cap(
     tmp_path, cooldown_dir, monkeypatch
 ) -> None:
     """A persistently broken delivery check must not re-emit forever."""
-    monkeypatch.delenv("PM_SLOT_KEY", raising=False)
+    monkeypatch.setenv("PM_SLOT_KEY", "gptme/gptme-contrib#1234")
     monkeypatch.setenv("PM_MAX_REDELIVERY_ATTEMPTS", "1")
     config, item, plan, outcome, hooks, run_cmd, _ = _post_session_fixture(tmp_path)
     run_cmd.on("/fake/check-delivery.py", returncode=1, stdout="")
     run_cmd.on("/fake/gate.py", returncode=1)
+    event_marker = cooldown_dir / "gptme-gptme-contrib-1234.event"
 
     def stage_notification() -> None:
         config.pending_state_dir.mkdir(parents=True, exist_ok=True)
@@ -1566,6 +1568,7 @@ def test_post_session_unverified_delivery_honors_redelivery_cap(
             "gptme/gptme-contrib#1234"
         )
         (config.pending_state_dir / "notif-555.state").write_text("t")
+        event_marker.write_text("fingerprint")
 
     stage_notification()
     run_post_session(plan, item, outcome, config, hooks)
@@ -1573,6 +1576,7 @@ def test_post_session_unverified_delivery_honors_redelivery_cap(
     assert attempts is not None
     assert attempts.read_text() == "1"
     assert not (config.state_dir / "notif-555.state").exists()
+    assert event_marker.exists(), "dispatch recovery owns the backed-off re-arm"
 
     stage_notification()
     run_post_session(plan, item, outcome, config, hooks)
@@ -2279,6 +2283,23 @@ def test_rollback_respects_max_attempts_env(
     monkeypatch.setenv("PM_MAX_REDELIVERY_ATTEMPTS", "1")
     assert rollback_failed_delivery(config, "gptme/gptme", 3468, "gptme/gptme#3468")
     assert not rollback_failed_delivery(config, "gptme/gptme", 3468, "gptme/gptme#3468")
+
+
+def test_corrupt_notification_map_is_ignored(tmp_path) -> None:
+    """One invalid UTF-8 sidecar must not abort promotion or rollback."""
+    config = make_config(tmp_path)
+    pending = config.pending_state_dir
+    pending.mkdir(parents=True)
+    (pending / "notif-1.map").write_bytes(b"\xff")
+    (pending / "notif-1.state").write_text("corrupt")
+    (pending / "notif-2.map").write_text("gptme/gptme#3468")
+    (pending / "notif-2.state").write_text("valid")
+
+    promote_item_state(config, "gptme/gptme", 3468)
+    assert (config.state_dir / "notif-2.state").read_text() == "valid"
+
+    assert purge_pending_notif_state(config, "gptme/gptme", 3468) == 1
+    assert (pending / "notif-1.map").exists()
 
 
 def test_promote_item_state_resets_redelivery_counter(tmp_path, cooldown_dir) -> None:

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -55,6 +55,7 @@ from gptme_runloops.run_item import (
     plan_item,
     predict_cc_trajectory_path,
     promote_item_state,
+    promote_notification_states,
     purge_pending_notif_state,
     redelivery_attempts_file,
     resolve_backend_trajectory,
@@ -2285,13 +2286,13 @@ def test_rollback_respects_max_attempts_env(
     assert not rollback_failed_delivery(config, "gptme/gptme", 3468, "gptme/gptme#3468")
 
 
-def test_corrupt_notification_map_is_ignored(tmp_path) -> None:
-    """One invalid UTF-8 sidecar must not abort promotion or rollback."""
+def test_corrupt_notification_map_is_treated_as_unmapped(tmp_path) -> None:
+    """An unreadable sidecar must not strand its notification state pending."""
     config = make_config(tmp_path)
     pending = config.pending_state_dir
     pending.mkdir(parents=True)
     (pending / "notif-1.map").write_bytes(b"\xff")
-    (pending / "notif-1.state").write_text("corrupt")
+    (pending / "notif-1.state").write_text("corrupt-map-state")
     (pending / "notif-2.map").write_text("gptme/gptme#3468")
     (pending / "notif-2.state").write_text("valid")
 
@@ -2300,6 +2301,9 @@ def test_corrupt_notification_map_is_ignored(tmp_path) -> None:
 
     assert purge_pending_notif_state(config, "gptme/gptme", 3468) == 1
     assert (pending / "notif-1.map").exists()
+
+    promote_notification_states(config)
+    assert (config.state_dir / "notif-1.state").read_text() == "corrupt-map-state"
 
 
 def test_promote_item_state_resets_redelivery_counter(tmp_path, cooldown_dir) -> None:

--- a/packages/gptme-runloops/tests/test_run_item_rollback.py
+++ b/packages/gptme-runloops/tests/test_run_item_rollback.py
@@ -123,10 +123,15 @@ class TestRollbackSurvivesEndOfRunPromotion:
         (env.pending_state_dir / "notif-11112222.state").write_text("seen")
 
         rollback_failed_delivery(env, "gptme/gptme", 3468, "gptme/gptme#3468")
+        # The unrelated item's pending state is untouched by the rollback ...
+        assert (env.pending_state_dir / "notif-11112222.state").exists()
+        # ... and its own handling worker still promotes it normally. (It is
+        # no longer promoted by the end-of-run blanket pass — mapped state is
+        # owned by its item; see TestNotifStateIsOwnedByTheHandlingWorker.)
+        promote_item_state(env, "gptme/gptme", 9999)
         promote_notification_states(env)
 
         assert not (env.state_dir / "notif-99887766.state").exists()
-        # The unrelated item must still be promoted normally.
         assert (env.state_dir / "notif-11112222.state").exists()
 
     def test_purge_matches_the_key_exactly_not_by_prefix(
@@ -544,3 +549,82 @@ class TestPortedInvestigateArms:
         from gptme_runloops.prompt_templates import build_investigate
 
         assert build_investigate([kind], self._params("d=1")).strip()
+
+
+class TestNotifStateIsOwnedByTheHandlingWorker:
+    """ActivityWatch/activitywatch#1402 (2026-08-20): an Erik @mention whose
+    one worker was killed at exit 124 never re-emitted. Two mechanisms each
+    consumed the thread's gate state on their own:
+
+    - the killed worker's own end-of-run promotion (timeout != delivered);
+    - ANY sibling worker's blanket ``promote_notification_states()`` while the
+      item sat emitted-but-skipped in the shared pending dir.
+
+    ``pm_dispatch_recovery`` would have re-armed the slot, but it only runs for
+    emitted items, and the gate dedupes on ``updated_at``. These tests pin the
+    on-disk contract that closes both holes.
+    """
+
+    def _stage(self, env: RunItemConfig, *, mapped: bool = True) -> None:
+        env.pending_state_dir.mkdir(parents=True, exist_ok=True)
+        (env.pending_state_dir / "notif-25192203058.state").write_text(
+            "2026-08-20T09:31:35Z"
+        )
+        if mapped:
+            (env.pending_state_dir / "notif-25192203058.map").write_text(
+                "ActivityWatch/activitywatch#1402"
+            )
+
+    def test_blanket_promotion_leaves_mapped_state_to_its_item(
+        self, env: RunItemConfig
+    ) -> None:
+        """A sibling worker finishing must not consume another item's thread."""
+        self._stage(env)
+        promote_notification_states(env)
+        assert not (env.state_dir / "notif-25192203058.state").exists()
+
+    def test_blanket_promotion_still_promotes_unmapped_state(
+        self, env: RunItemConfig
+    ) -> None:
+        """Negative control: legacy/unattributable notif state keeps the old path,
+        or the gate would re-emit it every cycle (the 85% NOOP incident)."""
+        self._stage(env, mapped=False)
+        promote_notification_states(env)
+        assert (env.state_dir / "notif-25192203058.state").exists()
+
+    def test_handling_worker_success_promotes_its_mapped_state(
+        self, env: RunItemConfig
+    ) -> None:
+        """The thread IS consumed — by the worker that handled it."""
+        self._stage(env)
+        promote_item_state(env, "ActivityWatch/activitywatch", 1402)
+        promote_notification_states(env)
+        assert (env.state_dir / "notif-25192203058.state").read_text() == (
+            "2026-08-20T09:31:35Z"
+        )
+        assert (env.state_dir / "notif-25192203058.map").exists()
+
+    def test_promotion_is_per_item_not_per_repo(self, env: RunItemConfig) -> None:
+        self._stage(env)
+        promote_item_state(env, "ActivityWatch/activitywatch", 1401)
+        promote_notification_states(env)
+        assert not (env.state_dir / "notif-25192203058.state").exists()
+
+    def test_failed_worker_leaves_thread_re_emittable(self, env: RunItemConfig) -> None:
+        """The failure path: purge, then the blanket promotion must find nothing."""
+        self._stage(env)
+        assert purge_pending_notif_state(env, "ActivityWatch/activitywatch", 1402) == 1
+        promote_item_state(env, "ActivityWatch/activitywatch", 1402)
+        promote_notification_states(env)
+        assert not (env.state_dir / "notif-25192203058.state").exists()
+        assert not (env.pending_state_dir / "notif-25192203058.state").exists()
+
+    def test_zero_number_item_promotes_only_unmapped_state(
+        self, env: RunItemConfig
+    ) -> None:
+        """Side door: a number-0 item used to blanket-copy every notif state."""
+        self._stage(env)
+        (env.pending_state_dir / "notif-1.state").write_text("unmapped")
+        promote_item_state(env, "ErikBjare/bob", 0)
+        assert (env.state_dir / "notif-1.state").exists()
+        assert not (env.state_dir / "notif-25192203058.state").exists()

--- a/packages/gptme-runloops/tests/test_run_item_rollback.py
+++ b/packages/gptme-runloops/tests/test_run_item_rollback.py
@@ -625,6 +625,9 @@ class TestNotifStateIsOwnedByTheHandlingWorker:
         """Side door: a number-0 item used to blanket-copy every notif state."""
         self._stage(env)
         (env.pending_state_dir / "notif-1.state").write_text("unmapped")
+        master_ci = env.pending_state_dir / "ErikBjare-bob-master-ci.state"
+        master_ci.write_text("sibling")
         promote_item_state(env, "ErikBjare/bob", 0)
         assert (env.state_dir / "notif-1.state").exists()
         assert not (env.state_dir / "notif-25192203058.state").exists()
+        assert not (env.state_dir / master_ci.name).exists()


### PR DESCRIPTION
## Symptom

ActivityWatch/activitywatch#1402 (2026-08-20): Erik @mentions Bob at 09:31. PM dispatches within 10 min. The worker is killed at exit 124 after 916s having posted nothing. Then **zero dispatch rows of any kind** — the notification is still `unread: true` on GitHub, but `/tmp/bob-project-monitoring-state/notif-25192203058.state` says it was handled.

## Cause

Two mechanisms each consumed the thread's gate state on their own:

1. The killed worker's own end-of-run `promote_notification_states()` — a timeout is not a delivery.
2. **Any sibling worker's** `promote_notification_states()` while the item sat emitted-but-skipped (`skipped_active` rows 09:43–09:54) in the *shared* pending dir. The function promoted every pending `notif-*.state` under the assumption "sessions already ran for every emitted notification" — true for the old monolithic sweep session, false for per-slot transient units.

The gate dedupes notifications on `updated_at`, so the thread never re-emits until a human comments again. `pm_dispatch_recovery.py` would have re-armed the slot (`rearm failed:attempt1` on dry-run) but it only runs for emitted items — it was never consulted.

## Fix

- `promote_notification_states()`: promote only **unmapped** `notif-*.state`. The gate writes a `.map` sidecar (`repo#number`) for every attributable thread; mapped state is owned by its item.
- `promote_item_state()`: promote the item's mapped notif state on the handling worker's success path. Number-0 items promote only unmapped state (the old blanket copy was a side door — reviewer finding).
- `run_post_session()` step 8: a timed-out / non-zero exit **without a verified delivery** purges the item's pending notif state so the gate re-emits next sweep. A non-zero exit *after* a verified reply still promotes (no duplicate reply — reviewer finding). Slot `.event`/`.ts` markers are intentionally left for `pm_dispatch_recovery`'s backed-off, budgeted re-arm (dispatcher consults it before its unchanged-payload and cooldown checks).

Emitted-but-skipped items' pending state is discarded by the next sweep's `rsync --delete`, so they re-emit and are re-evaluated — the correct semantics.

## Tests

Symptom-shaped: assert on-disk state *after* the end-of-run promotion has also run. The 4 new behaviors fail against the previous code (verified red/green). One existing negative-control test encoded the old "sibling promotes unrelated mapped items" contract and was updated to the ownership contract. 1041 passed.

Pre-PR AI review (`ai-review-local.py`, 3 passes): round 1 raised the two findings above (both fixed), round 2's finding (clear slot markers here) was a design disagreement — now documented inline.

## Not in this PR

- The bash in-process worker path (`project-monitoring.sh` blanket `notif-*.state` loop) has the same shape; the live executor is runloops. Tracked in ErikBjare/bob follow-up.
- Mention items get the 900s fast-lane tier; the model override for direct mentions doesn't cover timeout. Separate follow-up.

https://claude.ai/code/session_011VKFZeMpLvtZ3e15S1fKUW