### PR TITLE
fix(pm): direct @mention items get assigned_issue timeout floor (1500s)

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/run_item.py
+++ b/packages/gptme-runloops/src/gptme_runloops/run_item.py
@@ -502,10 +502,12 @@ def timeout_tier(
     config: RunItemConfig,
     *,
     instruction_kind: str | None = None,
+    is_mention: bool = False,
 ) -> tuple[int, str]:
     """Complexity-based timeout tiers (p-m.sh:494-514); order matters:
     assigned_issue wins over adjudication, which wins over the greptile-fix
-    tier.
+    tier.  Direct @mentions are floored at the assigned_issue tier so that a
+    complex "please fix X" ask is not killed at 15 min (AW#1402 incident).
 
     Adjudication reads findings, classifies them, possibly fixes one blocking
     issue and posts a structured recommendation — it never waits on a Greptile
@@ -530,6 +532,10 @@ def timeout_tier(
         or ("pr_update" in types and has_greptile_fix)
     ):
         return config.greptile_fix_timeout, config.greptile_fix_time_desc
+    # Direct @mentions need at least the assigned_issue budget — a 900s fast-lane
+    # session was killed at ~14 min before completing (AW#1402, 2026-08-20).
+    if is_mention:
+        return config.assigned_issue_timeout, config.assigned_issue_time_desc
     return config.default_timeout, config.default_time_desc
 
 
@@ -1212,6 +1218,7 @@ def plan_item(
         bool(greptile_fix),
         config,
         instruction_kind=instruction_kind,
+        is_mention=is_direct_mention(item.detail),
     )
 
     mention = ""

--- a/packages/gptme-runloops/tests/test_run_item.py
+++ b/packages/gptme-runloops/tests/test_run_item.py
@@ -1890,6 +1890,29 @@ def test_timeout_tier_instruction_kind_routes_to_adjudication(tmp_path) -> None:
     assert timeout == config.default_timeout == 900
 
 
+def test_timeout_tier_direct_mention_gets_assigned_issue_budget(tmp_path) -> None:
+    """Direct @mention items must get at least the assigned_issue timeout (1500s).
+
+    A 900s fast-lane session was killed at ~14 min before completing AW#1402.
+    Regression: notification items with detail=direct_mention must land on ≥1500s.
+    """
+    config = make_config(tmp_path)
+    # A bare notification item normally falls to the 900s default.
+    timeout_default, _ = timeout_tier(["notification"], False, config)
+    assert timeout_default == config.default_timeout == 900
+
+    # With is_mention=True it is floored at the assigned_issue budget.
+    timeout, desc = timeout_tier(["notification"], False, config, is_mention=True)
+    assert timeout == config.assigned_issue_timeout == 1500
+    assert desc == config.assigned_issue_time_desc == "~20 minutes"
+
+    # assigned_issue still wins when both flags are set (order of precedence).
+    timeout_ai, _ = timeout_tier(
+        ["assigned_issue", "notification"], False, config, is_mention=True
+    )
+    assert timeout_ai == config.assigned_issue_timeout == 1500
+
+
 # --- Claim behavior via execute path ---
 
 


### PR DESCRIPTION
## Problem

A direct @mention from Erik ('please address & fix') on AW#1402 was dispatched as a `notification` item on the fast lane (900s). The worker had located the failing step at ~14 min and was killed at 15 min. The item is structurally equivalent to an assigned issue — it needs research + analysis + action + reply — but got the default notification timeout.

## Fix

`timeout_tier()` now accepts `is_mention: bool = False`. When set:
- If no higher-priority tier has already been selected (assigned_issue, greptile, adjudication), returns `assigned_issue_timeout` (1500s) instead of `default_timeout` (900s)
- The call site in `render_prompt_for_item()` passes `is_mention=is_direct_mention(item.detail)`

Bash executor parity updated in brain repo `scripts/runs/github/project-monitoring.sh`.

## Test

```
test_timeout_tier_direct_mention_gets_assigned_issue_budget
```
- notification alone → 900s (default; unaffected)
- notification + is_mention=True → 1500s
- assigned_issue + is_mention=True → 1500s (assigned_issue still wins; no double-count)

## Related

- ErikBjare/bob task: pm-mention-items-get-fast-lane-timeout
- gptme-contrib#1474 (why the first failure was silent)