### PR TITLE
docs: overhaul root README + add scripts/README index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,62 @@
 # gptme-contrib
 
-Community-contributed plugins, packages, scripts, and lessons for [gptme](https://github.com/gptme/gptme).
+Community-contributed plugins, packages, scripts, skills, and lessons for [gptme](https://github.com/gptme/gptme).
 
-## Overview
+If [gptme](https://github.com/gptme/gptme) is the engine and [gptme-agent-template](https://github.com/gptme/gptme-agent-template) is the chassis, this repo is the parts catalog: everything you need to assemble a full-featured persistent agent — retrieval and memory, a task system, email and social messaging, real-time voice, GitHub automation, run loops for autonomous operation, and the observability to keep it all honest.
 
-This repository contains:
-- **[`plugins/`](./plugins/)** - Extend gptme with custom functionality ([gptme docs](https://gptme.org/docs/plugins.html))
-- **[`packages/`](./packages/)** - Reusable Python packages
-- **[`scripts/`](./scripts/)** - Standalone scripts for automation
-- **[`lessons/`](./lessons/)** - Shared lessons for prompts and workflows
+## Where this fits in the gptme ecosystem
+
+| Layer | Repo | What it provides |
+|-------|------|------------------|
+| Engine | [gptme](https://github.com/gptme/gptme) | The agent runtime: CLI + server/web UI, built-in tools (shell, tmux, patch, python, browser, vision/computer use, `gh`, `rag`, `todo`, MCP client, autocommit/precommit, …), plugin & hook system |
+| Chassis | [gptme-agent-template](https://github.com/gptme/gptme-agent-template) | Workspace template for persistent agents: identity files, journal, tasks, lessons, knowledge base |
+| Parts | **gptme-contrib** (this repo) | Plugins, packages, scripts, skills, and lessons you compose on top |
+
+**Check gptme core before reaching here.** Core already ships a lot, notably the extensive `gptme-util` CLI with subcommands for context (`index`, `retrieve`, `search-conversations`, `git`, `tree`, `journal`), token counting, chat search, models/providers, LLM helpers, tools, prompts, skills, hooks, MCP, status, snapshots, and session resume. See [`gptme-util` docs](https://gptme.org/docs/cli.html#gptme-util). If a capability isn't in core or here, it may exist as a community plugin — see [Discover more](#discover-more).
+
+## Assembling a full agent
+
+A capability-oriented map of this repo. Each entry links to a plugin (`plugins/`), package (`packages/`), or script collection (`scripts/`) below.
+
+| Capability | Components |
+|------------|------------|
+| **Retrieval & memory** | [gptme-rag](./packages/gptme-rag/) (vector/semantic search, ChromaDB), [gptme-wisdom](./packages/gptme-wisdom/) (BM25 reference-book index) + [gptme-wisdom-mcp](./packages/gptme-wisdom-mcp/), [gptme-codegraph](./packages/gptme-codegraph/) (structural code retrieval), [gptme-retrieval](./plugins/gptme-retrieval/) (automatic context retrieval), [gptme-user-memories](./plugins/gptme-user-memories/), [gptme-cc-memory](./packages/gptme-cc-memory/) |
+| **Tasks & work supply** | [gptodo](./packages/gptodo/) (task CLI + work queues), [gptme-gptodo](./plugins/gptme-gptodo/) (coordinator-mode delegation) |
+| **Email** | [gptmail](./packages/gptmail/) — universal email for agents, incl. agent-to-agent messaging |
+| **Chat & social** | [gptme-whatsapp](./packages/gptme-whatsapp/), [gptme-forum](./packages/gptme-forum/) (git-native agent forum), [discord](./scripts/discord/) / [telegram](./scripts/telegram/) / [twitter](./scripts/twitter/) / [bluesky](./scripts/bluesky/) scripts |
+| **Voice** | [gptme-voice](./packages/gptme-voice/) (real-time voice via OpenAI/Grok Realtime APIs), [gptme-tts](./plugins/gptme-tts/) (local Kokoro TTS) |
+| **GitHub** | [github](./scripts/github/) scripts (context, notifications), [github_hygiene](./scripts/github_hygiene/), [github_resolver](./scripts/github_resolver/); core's `gh` tool |
+| **Autonomous operation** | [gptme-runloops](./packages/gptme-runloops/) (run loop framework), [gptme-gupp](./plugins/gptme-gupp/) (work persistence), [gptme-ralph](./plugins/gptme-ralph/) (iterate with context reset), [gptme-coordination](./packages/gptme-coordination/) (work claims, message bus), [credential-slots](./packages/credential-slots/) + [gptme-subscription](./packages/gptme-subscription/) (credential rotation, capacity-aware routing), [gptme-backoff](./packages/gptme-backoff/) |
+| **Context management** | [gptme-ace](./plugins/gptme-ace/), [gptme-attention-tracker](./plugins/gptme-attention-tracker/), [gptme-headroom-compressor](./plugins/gptme-headroom-compressor/), [gptme-tooloutput-trimmer](./plugins/gptme-tooloutput-trimmer/) |
+| **Observability & analytics** | [gptme-sessions](./packages/gptme-sessions/), [gptme-usage](./packages/gptme-usage/), [gptme-dashboard](./packages/gptme-dashboard/), [gptme-activity-summary](./packages/gptme-activity-summary/), [gptme-daily-briefing](./packages/gptme-daily-briefing/), [aw-watcher-agent](./packages/aw-watcher-agent/) (ActivityWatch), [status](./scripts/status/) scripts |
+| **Safety & audit** | [gptme-action-receipts](./plugins/gptme-action-receipts/) (hashed audit ledger), [dotfiles](./dotfiles/) (global git hooks), [agent-write-loss-scan](./scripts/README.md#agent-write-loss-scan), [workspace_validator](./scripts/workspace_validator/) |
+| **Learning & self-improvement** | [lessons/](./lessons/), [skills/](./skills/), [gptme-lessons-extras](./packages/gptme-lessons-extras/), [gptme-lessons-mcp](./packages/gptme-lessons-mcp/) (lessons for any MCP client) |
 
 ## Plugins
 
-Plugins extend gptme's capabilities with custom tools and hooks. See [plugins/README.md](./plugins/README.md) for details.
+Plugins extend gptme with custom tools and hooks ([gptme plugin docs](https://gptme.org/docs/plugins.html)). See [plugins/README.md](./plugins/README.md).
 
 | Plugin | Description |
 |--------|-------------|
-| [gptme-ace](./plugins/gptme-ace/) | ACE-inspired context optimization |
+| [gptme-ace](./plugins/gptme-ace/) | ACE-inspired context optimization — hybrid retrieval, semantic matching, context curation |
+| [gptme-action-receipts](./plugins/gptme-action-receipts/) | Append-only hashed audit ledger for tool actions |
 | [gptme-attention-tracker](./plugins/gptme-attention-tracker/) | Attention routing + history tracking for context management |
 | [gptme-claude-code](./plugins/gptme-claude-code/) | Claude Code subagent integration |
 | [gptme-consortium](./plugins/gptme-consortium/) | Multi-model consensus decision-making |
 | [gptme-gptodo](./plugins/gptme-gptodo/) | gptodo delegation plugin for coordinator-only agent mode |
 | [gptme-gupp](./plugins/gptme-gupp/) | Work persistence for session continuity |
+| [gptme-headroom-compressor](./plugins/gptme-headroom-compressor/) | Lossless compression of tool outputs to reclaim context headroom |
 | [gptme-hooks-examples](./plugins/gptme-hooks-examples/) | Example hook implementations |
 | [gptme-imagen](./plugins/gptme-imagen/) | Multi-provider image generation |
-| [gptme-lsp](./plugins/gptme-lsp/) | Language Server Protocol integration |
+| [gptme-lsp](./plugins/gptme-lsp/) | Language Server Protocol integration for code intelligence |
 | [gptme-ralph](./plugins/gptme-ralph/) | Ralph Loop pattern — iterative execution with context reset |
 | [gptme-retrieval](./plugins/gptme-retrieval/) | Automatic context retrieval via semantic/keyword search |
+| [gptme-tooloutput-trimmer](./plugins/gptme-tooloutput-trimmer/) | Read-time trimming of stale tool outputs |
+| [gptme-tts](./plugins/gptme-tts/) | Text-to-speech with local Kokoro models |
+| [gptme-user-memories](./plugins/gptme-user-memories/) | Automatic user-fact extraction across sessions — local ChatGPT-style memory |
 | [gptme-warpgrep](./plugins/gptme-warpgrep/) | Enhanced search with Warp-style filtering |
 | [gptme-wrapped](./plugins/gptme-wrapped/) | Year-end analytics for your gptme usage (Spotify Wrapped-style) |
+| [gptme-youtube](./plugins/gptme-youtube/) | YouTube transcript extraction and summarization |
 
 ### Plugin Usage
 
@@ -42,109 +70,75 @@ enabled = ["gptme_attention_tracker", "gptme_imagen"]
 
 ## Packages
 
-Reusable Python packages. See [packages/README.md](./packages/README.md).
+Reusable Python packages, installable individually. See [packages/README.md](./packages/README.md).
 
 | Package | Description |
 |---------|-------------|
-| [gptme-codegraph](./packages/gptme-codegraph/) | Structural code retrieval with tree-sitter (parse, call graph, blast/impact analysis, 9 MCP tools) |
-| [gptmail](./packages/gptmail/) | Universal email system for AI agents |
-| [gptodo](./packages/gptodo/) | Task management CLI and utilities |
-| [gptme-activity-summary](./packages/gptme-activity-summary/) | Activity summarization for agents — journals, GitHub, sessions, tweets, email |
-| [gptme-sessions](./packages/gptme-sessions/) | Session tracking, analytics, and trajectory extraction |
-| [gptme-voice](./packages/gptme-voice/) | Voice interface using OpenAI Realtime API |
-| [gptme-whatsapp](./packages/gptme-whatsapp/) | WhatsApp integration for agents via whatsapp-web.js |
-| [gptme_lessons_extras](./packages/gptme-lessons-extras/) | Lesson validation and tools |
-| [gptme_runloops](./packages/gptme-runloops/) | Agent run loop patterns |
-| [gptme_contrib_lib](./packages/gptme-contrib-lib/) | Shared utilities |
-| [gptme-forum](./packages/gptme-forum/) | Git-native agent forum — threaded posts, @mentions, and DMs |
-| [gptme-subscription](./packages/gptme-subscription/) | Subscription observation, pressure scoring, and capacity-aware routing |
+| [aw-watcher-agent](./packages/aw-watcher-agent/) | ActivityWatch watcher for AI coding assistants (gptme, Claude Code, Codex) |
+| [bobutils](./packages/bobutils/) | Shared workspace utilities for gptme agents (stdlib-only) |
+| [credential-slots](./packages/credential-slots/) | Safe credential-slot rotation for OAuth/subscription-backed agents |
+| [gptmail](./packages/gptmail/) | Universal email + inter-agent SSH messaging for agents |
+| [gptme-activity-summary](./packages/gptme-activity-summary/) | Activity summarization — journals, GitHub, sessions, tweets, email |
+| [gptme-backoff](./packages/gptme-backoff/) | Retry utilities: exponential backoff, jitter, async/sync decorators |
+| [gptme-bob-status](./packages/gptme-bob-status/) | Bob-specific StatusProvider for `gptme-util status` |
+| [gptme-cc-memory](./packages/gptme-cc-memory/) | Typed, git-tracked, hook-injected session memory for Claude Code |
+| [gptme-codegraph](./packages/gptme-codegraph/) | Structural code retrieval with tree-sitter (call graph, blast/impact analysis, MCP tools) |
+| [gptme-contrib-lib](./packages/gptme-contrib-lib/) | Shared utilities |
+| [gptme-coordination](./packages/gptme-coordination/) | Inter-agent coordination via SQLite: work claims, message bus |
 | [gptme-daily-briefing](./packages/gptme-daily-briefing/) | Daily briefing generation for agents |
-| [gptme-dashboard](./packages/gptme-dashboard/) | Agent usage dashboards and metrics |
+| [gptme-dashboard](./packages/gptme-dashboard/) | Static dashboard generator for agent workspaces |
+| [gptme-forum](./packages/gptme-forum/) | Git-native agent forum — threaded posts, @mentions, DMs |
+| [gptme-lessons-extras](./packages/gptme-lessons-extras/) | Lesson validation and tools |
+| [gptme-lessons-mcp](./packages/gptme-lessons-mcp/) | MCP server exposing gptme's lesson matching to any MCP client |
+| [gptme-rag](./packages/gptme-rag/) | Local RAG with ChromaDB — semantic search as CLI, gptme tool, or MCP server |
+| [gptme-runloops](./packages/gptme-runloops/) | Run loop framework for autonomous agent operation |
+| [gptme-sessions](./packages/gptme-sessions/) | Session tracking, analytics, and trajectory extraction |
+| [gptme-subscription](./packages/gptme-subscription/) | Subscription observation, pressure scoring, capacity-aware routing |
+| [gptme-usage](./packages/gptme-usage/) | Cross-backend usage, cost, and quota surface (model registry, cost math) |
+| [gptme-voice](./packages/gptme-voice/) | Real-time voice interface via OpenAI and xAI Grok Realtime APIs |
+| [gptme-whatsapp](./packages/gptme-whatsapp/) | WhatsApp integration via whatsapp-web.js |
+| [gptme-wisdom](./packages/gptme-wisdom/) | BM25-searchable index of canonical reference books |
+| [gptme-wisdom-mcp](./packages/gptme-wisdom-mcp/) | RAG-as-MCP knowledge server — search books and session history |
+| [gptodo](./packages/gptodo/) | Task management CLI and work queue generation |
 
 ## Scripts
 
-Standalone scripts for automation. See each directory's README for details.
+Standalone scripts and integrations — see [scripts/README.md](./scripts/README.md) for the full index. Highlights:
 
-| Directory | Description |
-|-----------|-------------|
-| [context/](./scripts/context/) | Context generation for agent system prompts |
-| [discord/](./scripts/discord/) | Discord bot integration |
-| [github/](./scripts/github/) | GitHub context generation, repo status |
-| [linear/](./scripts/linear/) | Linear issue tracking integration |
-| [telegram/](./scripts/telegram/) | Telegram bot integration |
-| [twitter/](./scripts/twitter/) | Twitter automation and monitoring |
-| [bluesky/](./scripts/bluesky/) | Bluesky integration |
-| [status/](./scripts/status/) | Agent infrastructure status monitoring |
-| [workspace_validator/](./scripts/workspace_validator/) | Agent workspace structure validation |
+| Area | Scripts |
+|------|---------|
+| Context | [context/](./scripts/context/) — agent system prompt generation |
+| GitHub | [github/](./scripts/github/), [github_hygiene/](./scripts/github_hygiene/), [github_resolver/](./scripts/github_resolver/) |
+| Social & messaging | [discord/](./scripts/discord/), [telegram/](./scripts/telegram/), [twitter/](./scripts/twitter/), [bluesky/](./scripts/bluesky/) |
+| Issue tracking | [linear/](./scripts/linear/) |
+| Research | [autoresearch/](./scripts/autoresearch/), [exa.py](./scripts/exa.py), [perplexity.py](./scripts/perplexity.py) |
+| Health & quota | [status/](./scripts/status/), [check-quota.py](./scripts/check-quota.py), [fleet_vitals.py](./scripts/fleet_vitals.py) |
+| Safety | [agent-write-loss-scan.py](./scripts/README.md#agent-write-loss-scan), [workspace_validator/](./scripts/workspace_validator/), [git/](./scripts/git/) |
 
-### agent-write-loss-scan
+## Skills, Lessons & More
 
-Detects the **write-loss (git-clobber) hazard** in gptme agent sessions: a session
-writes to a file inside a git-tracked workspace, but the change is silently reverted
-before it is ever committed — the write is lost without any error.
-
-**Why this matters**: Autonomous agents write, but multi-session hot-windows can
-revert those writes via `git stash`/`restore`/`checkout --` operations. Measured
-write-loss rates in production: 0.051% overall, up to 0.68% for memory files.
-
-**Usage**:
-
-```bash
-# Basic scan (human-readable)
-python3 scripts/agent-write-loss-scan.py --repo /path/to/workspace
-
-# JSON output for programmatic use
-python3 scripts/agent-write-loss-scan.py --repo /path/to/workspace --json
-
-# Filter by date, limit session count
-python3 scripts/agent-write-loss-scan.py --repo /path/to/workspace \
-  --since 2025-01-01 --limit 50
-```
-
-**Output fields** (JSON):
-
-```json
-{
-  "total_writes": 142,
-  "persisted": 138,
-  "superseded": 2,
-  "lost": 2,
-  "unknown": 0,
-  "loss_rate": 0.0141,
-  "loss_pct": "1.4%",
-  "events": [...]
-}
-```
-
-**Classification**:
-
-| Outcome | Meaning |
-|---------|---------|
-| `PERSISTED` | Written content was committed to git |
-| `SUPERSEDED` | A later commit changed the file to different content (not a loss) |
-| `LOST` | File reverted to pre-write state; content was never committed |
-| `UNKNOWN` | Untracked path or ambiguous git history |
-
-The scanner is strictly read-only: it never runs `git stash`, `checkout`,
-`reset`, or `restore` — only `git log`, `cat-file`, and `ls-files`.
-
-## Lessons
-
-Shared lessons provide reusable prompts and workflow patterns. See [lessons/README.md](./lessons/README.md).
+- **[skills/](./skills/)** — Skill bundles (workflows + scripts + docs): agent onboarding, plugin development, code review, artifact publishing, Home Assistant, and more. See [skills/README.md](./skills/README.md).
+- **[lessons/](./lessons/)** — Shared lessons injected into agent prompts by keyword match, across categories (autonomous, communication, infrastructure, patterns, social, tools, workflow). See [lessons/README.md](./lessons/README.md).
+- **[dotfiles/](./dotfiles/)** — Global git hooks and config for safer agent development workflows. See [dotfiles/README.md](./dotfiles/README.md).
+- **[docs/](./docs/)** — Plugin deep-dives and cross-agent protocols (e.g. the [heartbeat protocol](./docs/protocols/gptme-heartbeat.md)).
 
 ## Ecosystem
 
-gptme has a broader ecosystem of standalone repos beyond gptme-contrib.
+Beyond core, the template, and this repo:
 
-### External Projects
+| Project | Description |
+|---------|-------------|
+| [gptme-howto](https://github.com/gptme/gptme-howto) | Copy-paste recipes for gptme |
+| [gptme-plugin-registry](https://github.com/gptme/gptme-plugin-registry) | Central registry for gptme plugins — metadata, indexing, discovery |
+| [gptme-lessons](https://github.com/gptme/gptme-lessons) | Agent network protocol — shared lessons across forked agents |
+| [gptme.vim](https://github.com/gptme/gptme.vim) | Vim plugin for gptme |
+| [gptme-cc-plugin](https://github.com/gptme/gptme-cc-plugin) | Claude Code skills for gptme — `/gptme:run`, `/gptme:review`, `/gptme:context` |
+| [gptme-skills-cc](https://github.com/gptme/gptme-skills-cc) | Proven gptme agent skills packaged as a Claude Code plugin |
+| [agent-workspace-plugin](https://github.com/gptme/agent-workspace-plugin) | Claude Code plugin: persistent agent workspace (tasks, journal, lessons, knowledge) |
 
-| Project | Description | Status |
-|---------|-------------|--------|
-| [gptme-rag](https://github.com/gptme/gptme-rag) | Local RAG — semantic document search as a CLI or gptme tool | Active |
-| [gptme-tauri](https://github.com/gptme/gptme-tauri) | Desktop app built with Tauri | Archived |
-| [gptme-webui](https://github.com/gptme/gptme-webui) | Web UI for gptme | Archived |
+Archived: [gptme-rag](https://github.com/gptme/gptme-rag) (upstreamed into [packages/gptme-rag](./packages/gptme-rag/)), [gptme-webui](https://github.com/gptme/gptme-webui), [gptme-tauri](https://github.com/gptme/gptme-tauri).
 
-### Discover More
+### Discover more
 
 To make your own plugin or skill discoverable, add a GitHub topic to your repo:
 

--- a/packages/gptmail/README.md
+++ b/packages/gptmail/README.md
@@ -1,17 +1,22 @@
 # gptmail
 
-Email automation for gptme agents with shared communication utilities.
+Communication tooling for gptme agents, with two transports:
+- **Email** (`gptmail …`) — Gmail via IMAP/SMTP, for talking to the outside world.
+- **Inter-agent messaging** (`gptmail agent …`) — SSH/SCP between agent workspaces,
+  email-free so it runs in isolated LXC sessions with no mail infra.
 
 ## Overview
 
-gptmail provides email automation capabilities including:
+gptmail provides:
 - CLI tools for reading, composing, and sending emails
+- Inter-agent SSH messaging (`gptmail agent`) — a filesystem inbox/outbox delivered
+  over SSH, with no dependency on email infrastructure
 - Background watcher for processing unreplied emails
 - Shared communication utilities (auth, rate limiting, monitoring, state)
 - Integration with Gmail via IMAP/SMTP
 
 This package was originally developed as part of an agent workspace and upstreamed to gptme-contrib
-and upstreamed to gptme-contrib for use by all gptme agents.
+for use by all gptme agents.
 
 ## Installation
 
@@ -57,6 +62,47 @@ gptmail --help
 ```
 
 Note: If installed in development mode, use `python -m gptmail` instead.
+
+### Inter-agent messaging (`gptmail agent`)
+
+Email-free messaging between agent workspaces, delivered over SSH/SCP. Each agent has
+a `messages/` directory (`inbox/`, `outbox/`); sending writes to the local outbox and
+SCPs the message into the recipient's remote inbox. No IMAP/SMTP — works in isolated
+LXC sessions.
+
+```bash
+gptmail agent status                       # self name, registry, inbox/outbox counts
+gptmail agent send bob "Subject" "Body"    # deliver to bob's inbox over SSH
+gptmail agent list                         # unread inbox messages
+gptmail agent read <MESSAGE_ID> --thread   # read (marks read), with thread
+gptmail agent reply <MESSAGE_ID> "Body"    # threaded reply
+gptmail agent pending                      # inbox messages awaiting a reply (SLA)
+gptmail agent broadcast "Subject" "Body"   # send to every agent in the registry
+```
+
+- **Self name**: `AGENT_NAME` env var, else `$USER`. A human can use this to reach
+  agents — set `AGENT_NAME=erik` to send as `erik` rather than your unix username.
+- **Workspace**: resolved via `git rev-parse --show-toplevel`; the registry and your
+  inbox/outbox live under `<workspace>/messages/`.
+- **Registry** (`<workspace>/messages/agents.yaml`) maps names to SSH targets. Both
+  `ssh` and `workspace` (remote workspace root) are required:
+
+  ```yaml
+  bob:
+    ssh: bob@bob          # an ~/.ssh/config Host alias works
+    workspace: bob        # remote path; message lands in <workspace>/messages/inbox/
+  alice:
+    ssh: alice@alice
+    workspace: alice
+  ```
+
+- **Replies without inbound access**: an agent on an unreachable host (e.g. a laptop)
+  can still receive replies by *pulling* — periodically `scp`/`rsync` the sender's
+  remote `messages/outbox/` into your local inbox — instead of requiring the remote to
+  SSH back.
+
+Requires `pyyaml`. If installing standalone, add it:
+`uv tool install --force --with pyyaml git+https://github.com/gptme/gptme-contrib#subdirectory=packages/gptmail`
 
 ### Background Watcher
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,100 @@
+# Scripts
+
+Standalone scripts and script collections for gptme agents and automation.
+Most are runnable directly via `uv run` shebangs; see each directory's README
+for details.
+
+## Directories
+
+| Directory | Description |
+|-----------|-------------|
+| [autoresearch/](./autoresearch/) | Autonomous research pipeline |
+| [bluesky/](./bluesky/) | Bluesky integration |
+| [claude-code-hooks/](./claude-code-hooks/) | Hooks for running agents on the Claude Code runtime |
+| [context/](./context/) | Context generation for agent system prompts |
+| [discord/](./discord/) | Discord bot integration |
+| [git/](./git/) | Git workflow helpers (`git-safe-commit`, mass-delete guard, auto-stage hook) |
+| [github/](./github/) | GitHub context generation, notifications, repo status |
+| [github_actions_common/](./github_actions_common/) | Shared helpers for the GitHub Actions orchestrators (hygiene, resolver) |
+| [github_hygiene/](./github_hygiene/) | Repo hygiene automation (labels, stale issues, etc.) |
+| [github_resolver/](./github_resolver/) | Resolve GitHub issues/PRs to actionable context |
+| [linear/](./linear/) | Linear issue tracking integration |
+| [precommit/](./precommit/) | Pre-commit hook helpers |
+| [runs/](./runs/) | Run/session management helpers |
+| [status/](./status/) | Agent infrastructure status monitoring |
+| [telegram/](./telegram/) | Telegram bot integration |
+| [twitter/](./twitter/) | Twitter automation and monitoring |
+| [workspace_validator/](./workspace_validator/) | Agent workspace structure validation |
+
+## Notable standalone scripts
+
+| Script | Description |
+|--------|-------------|
+| [agent-msg.py](./agent-msg.py) | Send messages between agents |
+| [agent-write-loss-scan.py](./agent-write-loss-scan.py) | Detect silently-reverted writes in agent sessions (see below) |
+| [check-claude-usage.sh](./check-claude-usage.sh) / [check-codex-usage.sh](./check-codex-usage.sh) / [check-openrouter-usage.sh](./check-openrouter-usage.sh) | Provider usage/quota checks |
+| [check-quota.py](./check-quota.py) | Aggregate quota check across providers |
+| [exa.py](./exa.py) | Web search via the Exa API |
+| [fetch-community-plugins.py](./fetch-community-plugins.py) | Discover community plugins via GitHub topics |
+| [fetch-github-trending.py](./fetch-github-trending.py) / [fetch-hn-top.py](./fetch-hn-top.py) | Trending/news feeds for agent context |
+| [find-dupes.py](./find-dupes.py) | Find duplicate/near-duplicate files |
+| [fleet_vitals.py](./fleet_vitals.py) | Health overview across an agent fleet |
+| [gptme-heartbeat-validate.py](./gptme-heartbeat-validate.py) | Validate heartbeat protocol messages ([protocol docs](../docs/protocols/gptme-heartbeat.md)) |
+| [perplexity.py](./perplexity.py) | Web search via the Perplexity API |
+| [quota-gate.sh](./quota-gate.sh) | Gate session start on available quota |
+| [search.py](./search.py) | Workspace-wide search |
+| [state-status.py](./state-status.py) | Agent state/health status |
+| [subscription-token-probe.py](./subscription-token-probe.py) | Probe subscription credential health |
+| [vent.py](./vent.py) | Register friction/blockers to the shared friction ledger |
+| [wordcount.py](./wordcount.py) | Word/token counting helper |
+
+## agent-write-loss-scan
+
+Detects the **write-loss (git-clobber) hazard** in gptme agent sessions: a session
+writes to a file inside a git-tracked workspace, but the change is silently reverted
+before it is ever committed — the write is lost without any error.
+
+**Why this matters**: Autonomous agents write, but multi-session hot-windows can
+revert those writes via `git stash`/`restore`/`checkout --` operations. Measured
+write-loss rates in production: 0.051% overall, up to 0.68% for memory files.
+
+**Usage**:
+
+```bash
+# Basic scan (human-readable)
+python3 scripts/agent-write-loss-scan.py --repo /path/to/workspace
+
+# JSON output for programmatic use
+python3 scripts/agent-write-loss-scan.py --repo /path/to/workspace --json
+
+# Filter by date, limit session count
+python3 scripts/agent-write-loss-scan.py --repo /path/to/workspace \
+  --since 2025-01-01 --limit 50
+```
+
+**Output fields** (JSON):
+
+```json
+{
+  "total_writes": 142,
+  "persisted": 138,
+  "superseded": 2,
+  "lost": 2,
+  "unknown": 0,
+  "loss_rate": 0.0141,
+  "loss_pct": "1.4%",
+  "events": [...]
+}
+```
+
+**Classification**:
+
+| Outcome | Meaning |
+|---------|---------|
+| `PERSISTED` | Written content was committed to git |
+| `SUPERSEDED` | A later commit changed the file to different content (not a loss) |
+| `LOST` | File reverted to pre-write state; content was never committed |
+| `UNKNOWN` | Untracked path or ambiguous git history |
+
+The scanner is strictly read-only: it never runs `git stash`, `checkout`,
+`reset`, or `restore` — only `git log`, `cat-file`, and `ls-files`.


### PR DESCRIPTION
## What

Rewrites the root README from a flat directory listing into a proper front door for the repo, adds a `scripts/README.md` index, and updates the gptmail README to reflect its two transports.

- **Root README**
  - Positions the repo in the gptme ecosystem: engine ([gptme](https://github.com/gptme/gptme)) / chassis ([gptme-agent-template](https://github.com/gptme/gptme-agent-template)) / parts catalog (this repo), with a "check core first" pointer to `gptme-util`
  - New "Assembling a full agent" capability map (retrieval/memory, tasks, messaging, voice, autonomous operation, observability, safety, learning) linking into the actual components
  - Plugin and package tables completed and alphabetized (adds the ~10 packages and 6 plugins that had landed without README entries, incl. `gptme-rag`, `gptme-usage`, `gptme-cc-memory`, `gptme-coordination`, `credential-slots`, `gptme-bob-status`)
  - Ecosystem section refreshed: adds plugin-registry, cc-plugin, skills-cc, agent-workspace-plugin, howto; marks gptme-rag's standalone repo as upstreamed into `packages/gptme-rag`
- **`scripts/README.md` (new)**: index of script directories + notable standalone scripts; absorbs the `agent-write-loss-scan` deep-dive that previously dominated the root README
- **`packages/gptmail/README.md`**: leads with the two transports — email (`gptmail …`) and inter-agent SSH messaging (`gptmail agent …`) — instead of email-only framing; also fixes a duplicated "upstreamed to gptme-contrib" sentence

## Verification

- All relative links in the three files verified to resolve against master (script-checked), and the repo's markdown-link pre-commit hook passes
- Plugin/package tables cross-checked against `plugins/`/`packages/` on disk: no missing entries, no ghosts
- Adapted for #1449: dropped references to the removed `commands/` dir and the relocated `scripts/communication_utils/`