### PR TITLE
feat(gptmail): add `agent pull` command for pull-only recipients + version bump

### DIFF
--- a/packages/gptmail/pyproject.toml
+++ b/packages/gptmail/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gptmail"
-version = "0.1.0"
+version = "0.2.0"
 description = "Email automation for gptme agents with shared communication utilities"
 authors = [
     {name = "gptme contributors", email = "gptme@superuserlabs.org"}

--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -678,6 +678,7 @@ def _fleet_pending_rows(
     self_name: str,
     agents: dict[str, dict[str, str]],
     fleet: bool,
+    all_mailboxes: bool,
 ) -> list[dict]:
     rows = _outbox_rows_for_recipient(mailboxes, recipient=recipient, self_name=self_name)
     if not fleet:
@@ -691,7 +692,7 @@ def _fleet_pending_rows(
                 agent,
                 recipient=recipient,
                 mailboxes=mailboxes,
-                all_mailboxes=len(mailboxes) > 1,
+                all_mailboxes=all_mailboxes,
             )
         )
     rows.sort(
@@ -924,6 +925,7 @@ def pending(
             self_name=self_name,
             agents=agents,
             fleet=fleet and not local_only,
+            all_mailboxes=all_mailboxes,
         )
         if json_output:
             click.echo(json.dumps(rows, indent=2, sort_keys=True, default=str))
@@ -1215,7 +1217,7 @@ def pull(
         env["SUMMARY"] = f"{n} new message(s): {subjects}"
         try:
             subprocess.run(shlex.split(notify_cmd), env=env, timeout=10, check=True)
-        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+        except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             click.echo(f"Warning: --notify-cmd failed: {e}", err=True)
 
 

--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -1052,7 +1052,7 @@ def _fetch_from_agent(
         temp_dest = Path(temp_name)
         try:
             subprocess.run(
-                ["scp", *ssh_opts, f"{ssh_target}:{remote_path}", str(temp_dest)],
+                ["scp", *ssh_opts, f"{ssh_target}:{shlex.quote(remote_path)}", str(temp_dest)],
                 check=True,
                 capture_output=True,
                 timeout=15,
@@ -1062,7 +1062,7 @@ def _fetch_from_agent(
             except FileExistsError:
                 continue  # A concurrent pull published this message first.
             new_files.append(dest)
-        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+        except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             click.echo(f"Warning: failed to fetch {filename} from {agent_name}: {e}", err=True)
         finally:
             temp_dest.unlink(missing_ok=True)
@@ -1219,7 +1219,7 @@ def pull(
         env["SUMMARY"] = f"{n} new message(s): {subjects}"
         try:
             subprocess.run(shlex.split(notify_cmd), env=env, timeout=10, check=True)
-        except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+        except (OSError, ValueError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             click.echo(f"Warning: --notify-cmd failed: {e}", err=True)
 
 

--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -1128,17 +1128,14 @@ def pull(
 
     new_files: list[Path] = []
     agents_polled: list[str] = []
-    agents_skipped: list[str] = []
 
     for agent_name, agent_cfg in agents.items():
         if agent_name == self_name:
             continue
         # Skip pull-only or incompletely configured agents — they can't be SSHed.
         if agent_cfg.get("delivery") == "pull-only":
-            agents_skipped.append(agent_name)
             continue
         if not all(agent_cfg.get(k) for k in ("ssh", "workspace")):
-            agents_skipped.append(agent_name)
             continue
 
         agents_polled.append(agent_name)
@@ -1186,31 +1183,20 @@ def pull(
 
     n = len(new_files)
 
-    if json_output:
-        payload = {
-            "new_count": n,
-            "files": [f.name for f in new_files],
-            "agents_polled": agents_polled,
-        }
-        click.echo(json.dumps(payload))
-        return
+    if not json_output and not dry_run:
+        if n == 0:
+            click.echo("No new messages.")
+        else:
+            click.echo(f"{n} new message(s) fetched into inbox:")
+            for f in new_files:
+                meta = meta_of(f) or {}
+                sender = str(meta.get("from", "unknown"))
+                subject = str(meta.get("subject", "(no subject)"))
+                ts = str(meta.get("timestamp", ""))
+                ts_part = f" [{ts}]" if ts else ""
+                click.echo(f"  {sender}{ts_part}: {subject}  ({f.name})")
 
-    if dry_run:
-        return
-
-    if n == 0:
-        click.echo("No new messages.")
-    else:
-        click.echo(f"{n} new message(s) fetched into inbox:")
-        for f in new_files:
-            meta = meta_of(f) or {}
-            sender = str(meta.get("from", "unknown"))
-            subject = str(meta.get("subject", "(no subject)"))
-            ts = str(meta.get("timestamp", ""))
-            ts_part = f" [{ts}]" if ts else ""
-            click.echo(f"  {sender}{ts_part}: {subject}  ({f.name})")
-
-    if notify_cmd and n > 0:
+    if notify_cmd and n > 0 and not dry_run:
         subjects = "; ".join(
             str((meta_of(f) or {}).get("subject", "(no subject)")) for f in new_files
         )
@@ -1221,6 +1207,14 @@ def pull(
             subprocess.run(shlex.split(notify_cmd), env=env, timeout=10, check=True)
         except (OSError, ValueError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             click.echo(f"Warning: --notify-cmd failed: {e}", err=True)
+
+    if json_output:
+        payload = {
+            "new_count": n,
+            "files": [f.name for f in new_files],
+            "agents_polled": agents_polled,
+        }
+        click.echo(json.dumps(payload))
 
 
 @agent.command()

--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -620,6 +620,7 @@ def _remote_pending_rows(
     *,
     recipient: str,
     mailboxes: list[str],
+    all_mailboxes: bool,
 ) -> list[dict]:
     missing = [k for k in ("ssh", "workspace") if not agent.get(k)]
     if missing:
@@ -629,10 +630,10 @@ def _remote_pending_rows(
         )
         return []
     cmd = ["uv", "run", "gptmail", "agent", "pending", "--for", recipient, "--json", "--local-only"]
-    if len(mailboxes) == 1:
-        cmd.extend(["--mailbox", mailboxes[0]])
-    else:
+    if all_mailboxes:
         cmd.append("--all-mailboxes")
+    else:
+        cmd.extend(["--mailbox", mailboxes[0]])
     remote_cmd = " && ".join(
         [
             f"cd {shlex.quote(agent['workspace'])}",
@@ -689,6 +690,7 @@ def _fleet_pending_rows(
                 agent,
                 recipient=recipient,
                 mailboxes=mailboxes,
+                all_mailboxes=len(mailboxes) > 1,
             )
         )
     rows.sort(
@@ -985,6 +987,8 @@ def _fetch_from_agent(
     *,
     self_name: str,
     mailboxes: list[str],
+    all_mailboxes: bool,
+    fallback_mailbox: str | None = None,
 ) -> list[Path]:
     """SCP outbox messages addressed to ``self_name`` from a remote agent's outbox.
 
@@ -992,7 +996,14 @@ def _fetch_from_agent(
     Logs SSH/SCP errors as warnings so one unreachable agent doesn't abort the
     whole pull — the caller collects partial results and reports the total.
     """
-    rows = _remote_pending_rows(agent_name, agent, recipient=self_name, mailboxes=mailboxes)
+    rows = _remote_pending_rows(
+        agent_name,
+        agent,
+        recipient=self_name,
+        mailboxes=mailboxes,
+        all_mailboxes=all_mailboxes,
+    )
+    fallback_mailbox = fallback_mailbox or (mailboxes[0] if mailboxes else "default")
     ssh_target = agent["ssh"]
     workspace = agent["workspace"]
     ctl_path = _ssh_control_path(ssh_target)
@@ -1012,7 +1023,7 @@ def _fetch_from_agent(
     for row in rows:
         filename = str(row.get("file") or "")
         try:
-            dest = _pull_destination(row, fallback_mailbox=mailboxes[0])
+            dest = _pull_destination(row, fallback_mailbox=fallback_mailbox)
         except click.BadParameter as e:
             click.echo(f"Warning: refusing invalid mailbox from {agent_name}: {e}", err=True)
             continue
@@ -1026,7 +1037,7 @@ def _fetch_from_agent(
             continue  # Already fetched — deduplicate by mailbox and filename.
         dest.parent.mkdir(parents=True, exist_ok=True)
         # The row's mailbox field tells us which remote outbox subfolder to look in.
-        row_mailbox = _normalize_mailbox(str(row.get("mailbox") or mailboxes[0]))
+        row_mailbox = _normalize_mailbox(str(row.get("mailbox") or fallback_mailbox))
         if row_mailbox == "default":
             remote_path = f"{workspace}/messages/outbox/{filename}"
         else:
@@ -1040,6 +1051,7 @@ def _fetch_from_agent(
             )
             new_files.append(dest)
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+            dest.unlink(missing_ok=True)
             click.echo(f"Warning: failed to fetch {filename} from {agent_name}: {e}", err=True)
     return new_files
 
@@ -1062,7 +1074,7 @@ def _fetch_from_agent(
     default=None,
     metavar="CMD",
     help=(
-        "Shell command to invoke when new messages arrive. "
+        "Command to invoke when new messages arrive. "
         "Receives NEW_COUNT (integer) and SUMMARY (human-readable string) as environment variables."
     ),
 )
@@ -1093,14 +1105,13 @@ def pull(
     Notification hook:
 
     \b
-        # macOS — post a Notification Center banner
-        gptmail agent pull --notify-cmd 'osascript -e "display notification \\\"$SUMMARY\\\" with title \\\"gptmail\\\""'
-        # Linux — libnotify
-        gptmail agent pull --notify-cmd 'notify-send "gptmail" "$SUMMARY"'
+        # Use an explicit shell when environment expansion is wanted
+        gptmail agent pull --notify-cmd "sh -c 'notify-send gptmail \"$SUMMARY\"'"
     """
     agents = _load_agents()
     self_name = (as_recipient or _self_name()).lower()
     mailboxes = _selected_mailboxes(mailbox, all_mailboxes)
+    remote_mailboxes = [] if all_mailboxes else mailboxes
 
     new_files: list[Path] = []
     agents_polled: list[str] = []
@@ -1120,7 +1131,11 @@ def pull(
         agents_polled.append(agent_name)
         if dry_run:
             rows = _remote_pending_rows(
-                agent_name, agent_cfg, recipient=self_name, mailboxes=mailboxes
+                agent_name,
+                agent_cfg,
+                recipient=self_name,
+                mailboxes=remote_mailboxes,
+                all_mailboxes=all_mailboxes,
             )
             for row in rows:
                 filename = str(row.get("file") or "")
@@ -1147,7 +1162,8 @@ def pull(
             agent_name,
             agent_cfg,
             self_name=self_name,
-            mailboxes=mailboxes,
+            mailboxes=remote_mailboxes,
+            all_mailboxes=all_mailboxes,
         )
         new_files.extend(fetched)
 
@@ -1185,9 +1201,7 @@ def pull(
         env["NEW_COUNT"] = str(n)
         env["SUMMARY"] = f"{n} new message(s): {subjects}"
         try:
-            subprocess.run(  # noqa: S602  (shell=True is intentional — user-supplied hook)
-                notify_cmd, shell=True, env=env, timeout=10
-            )
+            subprocess.run(shlex.split(notify_cmd), env=env, timeout=10, check=True)
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             click.echo(f"Warning: --notify-cmd failed: {e}", err=True)
 

--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -969,6 +969,206 @@ def pending(
         click.echo(_stale_summary(stale))
 
 
+def _fetch_from_agent(
+    agent_name: str,
+    agent: dict[str, str],
+    *,
+    self_name: str,
+    mailboxes: list[str],
+    local_inbox: Path,
+) -> list[Path]:
+    """SCP outbox messages addressed to ``self_name`` from a remote agent's outbox.
+
+    Returns a list of newly-written local inbox paths (skips files already present).
+    Logs SSH/SCP errors as warnings so one unreachable agent doesn't abort the
+    whole pull — the caller collects partial results and reports the total.
+    """
+    rows = _remote_pending_rows(agent_name, agent, recipient=self_name, mailboxes=mailboxes)
+    ssh_target = agent["ssh"]
+    workspace = agent["workspace"]
+    ctl_path = _ssh_control_path(ssh_target)
+    ssh_opts = [
+        "-o",
+        "ConnectTimeout=5",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "ControlMaster=auto",
+        "-o",
+        f"ControlPath={ctl_path}",
+        "-o",
+        "ControlPersist=60",
+    ]
+    new_files: list[Path] = []
+    for row in rows:
+        filename = str(row.get("file") or "")
+        if not filename:
+            continue
+        dest = local_inbox / filename
+        if dest.exists():
+            continue  # Already fetched — deduplicate by filename.
+        # The row's mailbox field tells us which remote outbox subfolder to look in.
+        row_mailbox = str(row.get("mailbox") or "default")
+        if row_mailbox == "default":
+            remote_path = f"{workspace}/messages/outbox/{filename}"
+        else:
+            remote_path = f"{workspace}/messages/mailboxes/{row_mailbox}/outbox/{filename}"
+        try:
+            subprocess.run(
+                ["scp", *ssh_opts, f"{ssh_target}:{remote_path}", str(dest)],
+                check=True,
+                capture_output=True,
+                timeout=15,
+            )
+            new_files.append(dest)
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+            click.echo(f"Warning: failed to fetch {filename} from {agent_name}: {e}", err=True)
+    return new_files
+
+
+@agent.command()
+@click.option(
+    "--as",
+    "as_recipient",
+    default=None,
+    metavar="IDENTITY",
+    help=(
+        "Pull as this identity instead of AGENT_NAME/$USER. "
+        "Useful for pull-only recipients (e.g. humans) checking from a different host."
+    ),
+)
+@click.option("--mailbox", default="default", show_default=True, help="Mailbox to fetch into.")
+@click.option("--all-mailboxes", is_flag=True, help="Pull across default plus every named mailbox.")
+@click.option(
+    "--notify-cmd",
+    default=None,
+    metavar="CMD",
+    help=(
+        "Shell command to invoke when new messages arrive. "
+        "Receives NEW_COUNT (integer) and SUMMARY (human-readable string) as environment variables."
+    ),
+)
+@click.option("--json", "json_output", is_flag=True, help="Emit machine-readable JSON.")
+@click.option("--dry-run", is_flag=True, help="Show what would be fetched without writing files.")
+def pull(
+    as_recipient: str | None,
+    mailbox: str,
+    all_mailboxes: bool,
+    notify_cmd: str | None,
+    json_output: bool,
+    dry_run: bool,
+) -> None:
+    """Pull messages from all SSH-reachable agents' outboxes (pull-only recipients).
+
+    Iterates the agents.yaml registry, fetches outbox messages addressed to
+    this identity from every agent with an SSH target, and deduplicates them
+    into the local inbox by filename.  Intended for human recipients who cannot
+    receive inbound SSH push delivery — run on a cron/launchd schedule (e.g.
+    every 30 minutes) to surface messages without manual polling.
+
+    Machine-readable output (for scripted callers and notification daemons):
+
+    \b
+        gptmail agent pull --json
+        # {"new_count": 3, "files": ["msg-abc.md", ...], "agents_polled": 2}
+
+    Notification hook:
+
+    \b
+        # macOS — post a Notification Center banner
+        gptmail agent pull --notify-cmd 'osascript -e "display notification \\\"$SUMMARY\\\" with title \\\"gptmail\\\""'
+        # Linux — libnotify
+        gptmail agent pull --notify-cmd 'notify-send "gptmail" "$SUMMARY"'
+    """
+    agents = _load_agents()
+    self_name = (as_recipient or _self_name()).lower()
+    mailboxes = _selected_mailboxes(mailbox, all_mailboxes)
+
+    # Local inbox for the chosen mailbox (pull always targets the first/only mailbox).
+    local_inbox = _mailbox_root(mailboxes[0]) / "inbox"
+    if not dry_run:
+        local_inbox.mkdir(parents=True, exist_ok=True)
+
+    new_files: list[Path] = []
+    agents_polled: list[str] = []
+    agents_skipped: list[str] = []
+
+    for agent_name, agent_cfg in agents.items():
+        if agent_name == self_name:
+            continue
+        # Skip pull-only or incompletely configured agents — they can't be SSHed.
+        if agent_cfg.get("delivery") == "pull-only":
+            agents_skipped.append(agent_name)
+            continue
+        if not all(agent_cfg.get(k) for k in ("ssh", "workspace")):
+            agents_skipped.append(agent_name)
+            continue
+
+        agents_polled.append(agent_name)
+        if dry_run:
+            rows = _remote_pending_rows(
+                agent_name, agent_cfg, recipient=self_name, mailboxes=mailboxes
+            )
+            for row in rows:
+                filename = str(row.get("file") or "")
+                if not filename:
+                    continue
+                dest = local_inbox / filename
+                if not dest.exists():
+                    subject = str(row.get("subject", "(no subject)"))
+                    click.echo(f"[dry-run] would fetch from {agent_name}: {subject}  ({filename})")
+            continue
+
+        fetched = _fetch_from_agent(
+            agent_name,
+            agent_cfg,
+            self_name=self_name,
+            mailboxes=mailboxes,
+            local_inbox=local_inbox,
+        )
+        new_files.extend(fetched)
+
+    n = len(new_files)
+
+    if json_output:
+        payload = {
+            "new_count": n,
+            "files": [f.name for f in new_files],
+            "agents_polled": agents_polled,
+        }
+        click.echo(json.dumps(payload))
+        return
+
+    if dry_run:
+        return
+
+    if n == 0:
+        click.echo("No new messages.")
+    else:
+        click.echo(f"{n} new message(s) fetched into inbox:")
+        for f in new_files:
+            meta = meta_of(f) or {}
+            sender = str(meta.get("from", "unknown"))
+            subject = str(meta.get("subject", "(no subject)"))
+            ts = str(meta.get("timestamp", ""))
+            ts_part = f" [{ts}]" if ts else ""
+            click.echo(f"  {sender}{ts_part}: {subject}  ({f.name})")
+
+    if notify_cmd and n > 0:
+        subjects = "; ".join(
+            str((meta_of(f) or {}).get("subject", "(no subject)")) for f in new_files
+        )
+        env = os.environ.copy()
+        env["NEW_COUNT"] = str(n)
+        env["SUMMARY"] = f"{n} new message(s): {subjects}"
+        try:
+            subprocess.run(  # noqa: S602  (shell=True is intentional — user-supplied hook)
+                notify_cmd, shell=True, env=env, timeout=10
+            )
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+            click.echo(f"Warning: --notify-cmd failed: {e}", err=True)
+
+
 @agent.command()
 @click.option("--mailbox", default="default", show_default=True, help="Mailbox to inspect.")
 @click.option("--all-mailboxes", is_flag=True, help="Scan default plus every named mailbox.")

--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -40,6 +40,7 @@ import re
 import shlex
 import subprocess
 import sys
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -1042,17 +1043,25 @@ def _fetch_from_agent(
             remote_path = f"{workspace}/messages/outbox/{filename}"
         else:
             remote_path = f"{workspace}/messages/mailboxes/{row_mailbox}/outbox/{filename}"
+        fd, temp_name = tempfile.mkstemp(prefix=f".{dest.name}.", dir=dest.parent)
+        os.close(fd)
+        temp_dest = Path(temp_name)
         try:
             subprocess.run(
-                ["scp", *ssh_opts, f"{ssh_target}:{remote_path}", str(dest)],
+                ["scp", *ssh_opts, f"{ssh_target}:{remote_path}", str(temp_dest)],
                 check=True,
                 capture_output=True,
                 timeout=15,
             )
+            try:
+                os.link(temp_dest, dest)
+            except FileExistsError:
+                continue  # A concurrent pull published this message first.
             new_files.append(dest)
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
-            dest.unlink(missing_ok=True)
             click.echo(f"Warning: failed to fetch {filename} from {agent_name}: {e}", err=True)
+        finally:
+            temp_dest.unlink(missing_ok=True)
     return new_files
 
 
@@ -1154,8 +1163,12 @@ def pull(
                         )
                     continue
                 if not dest.exists():
-                    subject = str(row.get("subject", "(no subject)"))
-                    click.echo(f"[dry-run] would fetch from {agent_name}: {subject}  ({filename})")
+                    new_files.append(dest)
+                    if not json_output:
+                        subject = str(row.get("subject", "(no subject)"))
+                        click.echo(
+                            f"[dry-run] would fetch from {agent_name}: {subject}  ({filename})"
+                        )
             continue
 
         fetched = _fetch_from_agent(

--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -50,7 +50,7 @@ from gptmail.communication_utils.state.tracking import (
     ConversationTracker,
     MessageState,
 )
-from gptmail.transport.agent import AgentTransport, Deliver, _FM_DELIM, meta_of
+from gptmail.transport.agent import _FM_DELIM, AgentTransport, Deliver, meta_of
 
 
 # Inbox messages older than this (days) are assumed handled and no longer
@@ -969,13 +969,22 @@ def pending(
         click.echo(_stale_summary(stale))
 
 
+def _pull_destination(row: dict, *, fallback_mailbox: str) -> Path | None:
+    """Return a contained local inbox path for a remote pending row."""
+    filename = str(row.get("file") or "")
+    if not filename:
+        return None
+    row_mailbox = _normalize_mailbox(str(row.get("mailbox") or fallback_mailbox))
+    inbox = _mailbox_root(row_mailbox) / "inbox"
+    return _within(inbox, filename)
+
+
 def _fetch_from_agent(
     agent_name: str,
     agent: dict[str, str],
     *,
     self_name: str,
     mailboxes: list[str],
-    local_inbox: Path,
 ) -> list[Path]:
     """SCP outbox messages addressed to ``self_name`` from a remote agent's outbox.
 
@@ -1002,13 +1011,22 @@ def _fetch_from_agent(
     new_files: list[Path] = []
     for row in rows:
         filename = str(row.get("file") or "")
-        if not filename:
+        try:
+            dest = _pull_destination(row, fallback_mailbox=mailboxes[0])
+        except click.BadParameter as e:
+            click.echo(f"Warning: refusing invalid mailbox from {agent_name}: {e}", err=True)
             continue
-        dest = local_inbox / filename
+        if dest is None:
+            if filename:
+                click.echo(
+                    f"Warning: refusing unsafe filename from {agent_name}: {filename}", err=True
+                )
+            continue
         if dest.exists():
-            continue  # Already fetched — deduplicate by filename.
+            continue  # Already fetched — deduplicate by mailbox and filename.
+        dest.parent.mkdir(parents=True, exist_ok=True)
         # The row's mailbox field tells us which remote outbox subfolder to look in.
-        row_mailbox = str(row.get("mailbox") or "default")
+        row_mailbox = _normalize_mailbox(str(row.get("mailbox") or mailboxes[0]))
         if row_mailbox == "default":
             remote_path = f"{workspace}/messages/outbox/{filename}"
         else:
@@ -1084,11 +1102,6 @@ def pull(
     self_name = (as_recipient or _self_name()).lower()
     mailboxes = _selected_mailboxes(mailbox, all_mailboxes)
 
-    # Local inbox for the chosen mailbox (pull always targets the first/only mailbox).
-    local_inbox = _mailbox_root(mailboxes[0]) / "inbox"
-    if not dry_run:
-        local_inbox.mkdir(parents=True, exist_ok=True)
-
     new_files: list[Path] = []
     agents_polled: list[str] = []
     agents_skipped: list[str] = []
@@ -1111,9 +1124,20 @@ def pull(
             )
             for row in rows:
                 filename = str(row.get("file") or "")
-                if not filename:
+                try:
+                    dest = _pull_destination(row, fallback_mailbox=mailboxes[0])
+                except click.BadParameter as e:
+                    click.echo(
+                        f"Warning: refusing invalid mailbox from {agent_name}: {e}", err=True
+                    )
                     continue
-                dest = local_inbox / filename
+                if dest is None:
+                    if filename:
+                        click.echo(
+                            f"Warning: refusing unsafe filename from {agent_name}: {filename}",
+                            err=True,
+                        )
+                    continue
                 if not dest.exists():
                     subject = str(row.get("subject", "(no subject)"))
                     click.echo(f"[dry-run] would fetch from {agent_name}: {subject}  ({filename})")
@@ -1124,7 +1148,6 @@ def pull(
             agent_cfg,
             self_name=self_name,
             mailboxes=mailboxes,
-            local_inbox=local_inbox,
         )
         new_files.extend(fetched)
 

--- a/packages/gptmail/src/gptmail/agent_cli.py
+++ b/packages/gptmail/src/gptmail/agent_cli.py
@@ -977,7 +977,9 @@ def pending(
 def _pull_destination(row: dict, *, fallback_mailbox: str) -> Path | None:
     """Return a contained local inbox path for a remote pending row."""
     filename = str(row.get("file") or "")
-    if not filename:
+    # Pending rows originate on another host. Requiring a basename protects
+    # both the local destination and the separately constructed remote source.
+    if not filename or Path(filename).name != filename:
         return None
     row_mailbox = _normalize_mailbox(str(row.get("mailbox") or fallback_mailbox))
     inbox = _mailbox_root(row_mailbox) / "inbox"

--- a/packages/gptmail/src/gptmail/cli.py
+++ b/packages/gptmail/src/gptmail/cli.py
@@ -16,10 +16,19 @@ import time
 from datetime import timezone
 from pathlib import Path
 
+import importlib.metadata
+
 import click
 
 from gptmail.communication_utils.state.tracking import MessageState
 from gptmail.lib import AgentEmail
+
+
+def _version_string() -> str:
+    try:
+        return importlib.metadata.version("gptmail")
+    except importlib.metadata.PackageNotFoundError:
+        return "0.0.0+dev"
 
 
 def get_workspace_dir() -> Path:
@@ -71,6 +80,7 @@ def edit_content() -> str:
 
 
 @click.group()
+@click.version_option(version=_version_string(), prog_name="gptmail")
 def cli() -> None:
     """Email system for agent communication."""
     pass

--- a/packages/gptmail/tests/test_agent_cli.py
+++ b/packages/gptmail/tests/test_agent_cli.py
@@ -796,10 +796,12 @@ def test_pending_for_recipient_fleet_merges_remote_rows(
         *,
         recipient: str,
         mailboxes: list[str],
+        all_mailboxes: bool,
     ) -> list[dict]:
         assert agent_name == "bob"
         assert recipient == "erik"
         assert mailboxes == ["default", "ops"]
+        assert all_mailboxes is True
         return [
             {
                 "agent": "bob",
@@ -829,11 +831,46 @@ def test_remote_pending_rows_warns_on_missing_transport(capsys: pytest.CaptureFi
         {"workspace": "/tmp/bob"},
         recipient="erik",
         mailboxes=["default"],
+        all_mailboxes=False,
     )
 
     captured = capsys.readouterr()
     assert rows == []
     assert "Warning: skipping bob; missing required key(s): ssh" in captured.err
+
+
+def test_remote_pending_rows_all_mailboxes_is_explicit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    commands: list[str] = []
+
+    class Result:
+        stdout = "[]"
+
+    def _run(cmd, **kwargs):
+        commands.append(cmd[-1])
+        return Result()
+
+    monkeypatch.setattr(agent_cli.subprocess, "run", _run)
+    agent_cfg = {"ssh": "bob.example", "workspace": "/srv/bob"}
+
+    agent_cli._remote_pending_rows(
+        "bob",
+        agent_cfg,
+        recipient="erik",
+        mailboxes=["default"],
+        all_mailboxes=True,
+    )
+    agent_cli._remote_pending_rows(
+        "bob",
+        agent_cfg,
+        recipient="erik",
+        mailboxes=["default"],
+        all_mailboxes=False,
+    )
+
+    assert "--all-mailboxes" in commands[0]
+    assert "--mailbox default" in commands[1]
 
 
 def test_pending_stays_silent_without_registry(

--- a/packages/gptmail/tests/test_agent_cli.py
+++ b/packages/gptmail/tests/test_agent_cli.py
@@ -784,11 +784,14 @@ def test_matches_recipient_normalizes_recipient_argument() -> None:
     assert agent_cli._matches_recipient({"to": ["Erik"]}, "ERIK")
 
 
-def test_pending_for_recipient_fleet_merges_remote_rows(
-    workspace: Path, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize("named_mailbox_exists", [False, True])
+def test_pending_for_recipient_fleet_propagates_all_mailboxes(
+    workspace: Path, monkeypatch: pytest.MonkeyPatch, named_mailbox_exists: bool
 ) -> None:
     local_msg = _seed_outbox(workspace, "erik", "Local")
-    ops_msg = _seed_outbox(workspace, "erik", "Ops", mailbox="ops")
+    ops_msg = (
+        _seed_outbox(workspace, "erik", "Ops", mailbox="ops") if named_mailbox_exists else None
+    )
 
     def _fake_remote_pending_rows(
         agent_name: str,
@@ -800,7 +803,7 @@ def test_pending_for_recipient_fleet_merges_remote_rows(
     ) -> list[dict]:
         assert agent_name == "bob"
         assert recipient == "erik"
-        assert mailboxes == ["default", "ops"]
+        assert mailboxes == (["default", "ops"] if named_mailbox_exists else ["default"])
         assert all_mailboxes is True
         return [
             {
@@ -822,7 +825,10 @@ def test_pending_for_recipient_fleet_merges_remote_rows(
     assert result.exit_code == 0, result.output
     rows = json.loads(result.output)
     assert {row["agent"] for row in rows} == {"alice", "bob"}
-    assert {row["file"] for row in rows} == {local_msg, ops_msg, "20260616-remote.md"}
+    expected_files = {local_msg, "20260616-remote.md"}
+    if ops_msg is not None:
+        expected_files.add(ops_msg)
+    assert {row["file"] for row in rows} == expected_files
 
 
 def test_remote_pending_rows_warns_on_missing_transport(capsys: pytest.CaptureFixture[str]) -> None:

--- a/packages/gptmail/tests/test_agent_pull.py
+++ b/packages/gptmail/tests/test_agent_pull.py
@@ -247,6 +247,19 @@ def test_pull_notify_cmd_invoked_with_env(
     assert "Urgent" in content
 
 
+def test_pull_json_still_invokes_notify_cmd(pull_workspace: Path, tmp_path: Path) -> None:
+    """Machine-readable output and notification hooks can be combined."""
+    gordon_outbox = pull_workspace / "gordon" / "messages" / "outbox"
+    _write_outbox_msg(gordon_outbox, sender="gordon", recipient="erik", subject="Urgent")
+    sentinel = tmp_path / "notify_fired.txt"
+
+    result = CliRunner().invoke(agent, ["pull", "--json", "--notify-cmd", f"touch {sentinel}"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["new_count"] == 1
+    assert sentinel.exists(), "--json must not suppress --notify-cmd"
+
+
 def test_pull_notify_cmd_failure_warns_after_fetch(pull_workspace: Path) -> None:
     """A missing notification executable must not discard a successful pull."""
     gordon_outbox = pull_workspace / "gordon" / "messages" / "outbox"

--- a/packages/gptmail/tests/test_agent_pull.py
+++ b/packages/gptmail/tests/test_agent_pull.py
@@ -12,6 +12,7 @@ Covers the missing human-side delivery introduced in issue #1476:
 """
 
 import json
+import shlex
 import shutil
 import subprocess
 from datetime import datetime, timezone
@@ -135,9 +136,12 @@ def pull_workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
             src_arg = next((a for a in cmd[1:] if ":" in a and not a.startswith("-")), None)
             dest_arg = cmd[-1]
             if src_arg:
-                # Parse "host:/path/to/file" → local equivalent path
+                # Parse "host:/path/to/file" → local equivalent path. SCP's
+                # remote path is shell-quoted because the real command crosses
+                # a remote shell boundary.
                 _, remote_path = src_arg.split(":", 1)
-                src_path = Path(remote_path)
+                parsed_path = shlex.split(remote_path)
+                src_path = Path(parsed_path[0]) if len(parsed_path) == 1 else Path()
                 if src_path.exists():
                     shutil.copy2(src_path, dest_arg)
                     import subprocess
@@ -251,6 +255,21 @@ def test_pull_notify_cmd_failure_warns_after_fetch(pull_workspace: Path) -> None
     )
 
     result = CliRunner().invoke(agent, ["pull", "--notify-cmd", "missing-notifier"])
+
+    assert result.exit_code == 0, result.output
+    assert "Warning: --notify-cmd failed" in result.output
+    local_inbox = pull_workspace / "erik" / "messages" / "inbox"
+    assert (local_inbox / name).exists()
+
+
+def test_pull_notify_cmd_malformed_value_warns_after_fetch(pull_workspace: Path) -> None:
+    """Malformed notification syntax cannot turn a successful pull into failure."""
+    gordon_outbox = pull_workspace / "gordon" / "messages" / "outbox"
+    name = _write_outbox_msg(
+        gordon_outbox, sender="gordon", recipient="erik", subject="Still fetched"
+    )
+
+    result = CliRunner().invoke(agent, ["pull", "--notify-cmd", "unterminated '"])
 
     assert result.exit_code == 0, result.output
     assert "Warning: --notify-cmd failed" in result.output
@@ -432,6 +451,66 @@ def test_pull_all_mailboxes_queries_remote_for_remote_only_mailboxes(
 
     assert result.exit_code == 0, result.output
     assert calls == [([], True)]
+
+
+def test_pull_quotes_remote_workspace_with_spaces(
+    pull_workspace: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The SCP remote source remains one path when the workspace contains spaces."""
+    filename = "message.md"
+    workspace = "/Users/John Doe/workspace"
+    scp_calls: list[list[str]] = []
+    monkeypatch.setattr(
+        agent_cli,
+        "_remote_pending_rows",
+        lambda *args, **kwargs: [{"file": filename, "mailbox": "default"}],
+    )
+
+    def _record_scp(cmd, **kwargs):
+        scp_calls.append(cmd)
+        Path(cmd[-1]).write_text("message")
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(agent_cli.subprocess, "run", _record_scp)
+
+    new_files = agent_cli._fetch_from_agent(
+        "gordon",
+        {"ssh": "gordon@example", "workspace": workspace},
+        self_name="erik",
+        mailboxes=["default"],
+        all_mailboxes=False,
+    )
+
+    assert len(new_files) == 1
+    assert (
+        scp_calls[0][-2]
+        == f"gordon@example:{shlex.quote(f'{workspace}/messages/outbox/{filename}')}"
+    )
+
+
+def test_missing_scp_warns_and_preserves_partial_results(
+    pull_workspace: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A missing SCP executable is a per-agent warning rather than a CLI crash."""
+    filename = "message.md"
+    monkeypatch.setattr(
+        agent_cli,
+        "_remote_pending_rows",
+        lambda *args, **kwargs: [{"file": filename, "mailbox": "default"}],
+    )
+    monkeypatch.setattr(
+        agent_cli.subprocess,
+        "run",
+        lambda cmd, **kwargs: (_ for _ in ()).throw(FileNotFoundError("scp")),
+    )
+
+    result = CliRunner().invoke(agent, ["pull"])
+
+    assert result.exit_code == 0, result.output
+    assert "Warning: failed to fetch" in result.output
+    destination = pull_workspace / "erik" / "messages" / "inbox" / filename
+    assert not destination.exists()
+    assert not list(destination.parent.glob(f".{filename}.*"))
 
 
 def test_failed_scp_removes_partial_destination(

--- a/packages/gptmail/tests/test_agent_pull.py
+++ b/packages/gptmail/tests/test_agent_pull.py
@@ -1,0 +1,313 @@
+"""Tests for ``gptmail agent pull`` — pull-only recipient delivery path.
+
+Covers the missing human-side delivery introduced in issue #1476:
+- ``pull`` fetches messages from SSH-reachable agents' outboxes into local inbox
+- ``pull`` deduplicates by filename (re-pull is idempotent)
+- ``pull --json`` emits machine-readable count + file list
+- ``pull --notify-cmd`` invokes the hook with NEW_COUNT + SUMMARY env vars
+- ``pull --dry-run`` shows what would be fetched without writing
+- ``pull --as IDENTITY`` overrides the self-name for cross-identity polls
+- Agents missing ssh/workspace keys are skipped silently
+- Pull-only agents in the registry are skipped (they have no outbox to SSH into)
+"""
+
+import json
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from gptmail import agent_cli
+from gptmail.agent_cli import agent
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _write_outbox_msg(
+    outbox_dir: Path,
+    *,
+    sender: str,
+    recipient: str,
+    subject: str,
+    mailbox: str = "default",
+) -> str:
+    """Write a message file into ``outbox_dir``; return filename."""
+    outbox_dir.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S-%f")
+    name = f"{ts}-{sender}-{subject[:20].replace(' ', '_')}.md"
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    (outbox_dir / name).write_text(
+        f"---\nfrom: {sender}\nto: {recipient}\n"
+        f"timestamp: {timestamp}\nsubject: {subject}\nmailbox: {mailbox}\n"
+        f"reply_expected: true\n---\n\nPlease advise.\n"
+    )
+    return name
+
+
+@pytest.fixture
+def pull_workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Workspace simulating 'erik' (pull-only) pulling from 'gordon' (SSH-reachable).
+
+    Layout:
+      tmp_path/
+        erik/messages/inbox/          ← local inbox (where pull writes)
+        gordon/messages/outbox/       ← remote outbox (what pull reads)
+      erik/messages/agents.yaml       ← gordon registered with ssh+workspace
+    """
+    erik_dir = tmp_path / "erik"
+    gordon_dir = tmp_path / "gordon"
+
+    # Erik's local workspace
+    (erik_dir / "messages" / "inbox").mkdir(parents=True)
+    (erik_dir / "messages" / "outbox").mkdir(parents=True)
+    (erik_dir / "messages" / "agents.yaml").write_text(
+        yaml.dump(
+            {
+                "gordon": {
+                    "ssh": "gordon@gordon.lxc",
+                    "workspace": str(gordon_dir),
+                },
+                "alice": {
+                    "delivery": "pull-only",
+                },
+            }
+        )
+    )
+
+    # Gordon's remote outbox (local stub — no real SSH needed)
+    (gordon_dir / "messages" / "outbox").mkdir(parents=True)
+
+    # Patch seams: _repo_root → erik_dir, AGENT_NAME → erik
+    monkeypatch.setenv("AGENT_NAME", "erik")
+    monkeypatch.setattr(agent_cli, "_repo_root", lambda: erik_dir)
+
+    # Replace _remote_pending_rows with a local-filesystem scan of gordon's outbox
+    # (avoids SSH; returns the same dict shape _remote_pending_rows produces).
+    def _local_remote_pending_rows(agent_name, agent_cfg, *, recipient, mailboxes):
+        outbox = Path(agent_cfg["workspace"]) / "messages" / "outbox"
+        rows = []
+        if not outbox.exists():
+            return rows
+        for f in sorted(outbox.glob("*.md")):
+            content = f.read_text()
+            if not content.startswith("---"):
+                continue
+            parts = content.split("---", 2)
+            if len(parts) < 3:
+                continue
+            import yaml as _yaml
+
+            meta = _yaml.safe_load(parts[1]) or {}
+            to = meta.get("to")
+            hit = (isinstance(to, list) and recipient.lower() in [str(t).lower() for t in to]) or (
+                isinstance(to, str) and to.lower() == recipient.lower()
+            )
+            if not hit:
+                continue
+            rows.append(
+                {
+                    "file": f.name,
+                    "subject": str(meta.get("subject", "")),
+                    "from": str(meta.get("from", "")),
+                    "timestamp": str(meta.get("timestamp", "")),
+                    "mailbox": "default",
+                    "agent": agent_name,
+                    "workspace": agent_cfg["workspace"],
+                }
+            )
+        return rows
+
+    monkeypatch.setattr(agent_cli, "_remote_pending_rows", _local_remote_pending_rows)
+
+    # Replace the SCP subprocess.run inside _fetch_from_agent with a local copy.
+    # We intercept subprocess.run and, for SCP commands, do a Path.copy instead.
+    original_run = __import__("subprocess").run
+
+    def _stub_run(cmd, **kwargs):
+        if isinstance(cmd, list) and cmd and cmd[0] == "scp":
+            # Find src (contains ':') and dest (last arg)
+            src_arg = next((a for a in cmd[1:] if ":" in a and not a.startswith("-")), None)
+            dest_arg = cmd[-1]
+            if src_arg:
+                # Parse "host:/path/to/file" → local equivalent path
+                _, remote_path = src_arg.split(":", 1)
+                src_path = Path(remote_path)
+                if src_path.exists():
+                    shutil.copy2(src_path, dest_arg)
+                    import subprocess
+
+                    return subprocess.CompletedProcess(cmd, 0)
+            import subprocess
+
+            return subprocess.CompletedProcess(cmd, 0)
+        return original_run(cmd, **kwargs)
+
+    import subprocess
+
+    monkeypatch.setattr(subprocess, "run", _stub_run)
+
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_pull_fetches_addressed_messages(pull_workspace: Path) -> None:
+    """``pull`` copies outbox messages addressed to self into local inbox."""
+    gordon_outbox = pull_workspace / "gordon" / "messages" / "outbox"
+    name = _write_outbox_msg(
+        gordon_outbox, sender="gordon", recipient="erik", subject="Action required"
+    )
+
+    result = CliRunner().invoke(agent, ["pull"])
+    assert result.exit_code == 0, result.output
+    assert "1 new message(s) fetched" in result.output
+    assert "Action required" in result.output
+
+    local_inbox = pull_workspace / "erik" / "messages" / "inbox"
+    assert (local_inbox / name).exists(), "message file must be present in local inbox"
+
+
+def test_pull_skips_messages_for_others(pull_workspace: Path) -> None:
+    """``pull`` ignores outbox messages addressed to a different recipient."""
+    gordon_outbox = pull_workspace / "gordon" / "messages" / "outbox"
+    _write_outbox_msg(gordon_outbox, sender="gordon", recipient="alice", subject="Not for Erik")
+
+    result = CliRunner().invoke(agent, ["pull"])
+    assert result.exit_code == 0, result.output
+    assert "No new messages." in result.output
+
+    local_inbox = pull_workspace / "erik" / "messages" / "inbox"
+    assert not list(local_inbox.glob("*.md")), "inbox must remain empty"
+
+
+def test_pull_deduplicates_on_repull(pull_workspace: Path) -> None:
+    """Re-running ``pull`` does not duplicate already-fetched messages."""
+    gordon_outbox = pull_workspace / "gordon" / "messages" / "outbox"
+    _write_outbox_msg(gordon_outbox, sender="gordon", recipient="erik", subject="Dedup test")
+
+    CliRunner().invoke(agent, ["pull"])  # first pull
+    result = CliRunner().invoke(agent, ["pull"])  # second pull
+    assert result.exit_code == 0, result.output
+    assert "No new messages." in result.output
+
+    local_inbox = pull_workspace / "erik" / "messages" / "inbox"
+    assert len(list(local_inbox.glob("*.md"))) == 1, "only one copy must exist"
+
+
+def test_pull_json_output(pull_workspace: Path) -> None:
+    """``pull --json`` emits machine-readable new_count + files list."""
+    gordon_outbox = pull_workspace / "gordon" / "messages" / "outbox"
+    name = _write_outbox_msg(gordon_outbox, sender="gordon", recipient="erik", subject="JSON test")
+
+    result = CliRunner().invoke(agent, ["pull", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["new_count"] == 1
+    assert name in payload["files"]
+    assert "gordon" in payload["agents_polled"]
+
+
+def test_pull_json_zero_when_empty(pull_workspace: Path) -> None:
+    """``pull --json`` returns new_count=0 when outbox is empty."""
+    result = CliRunner().invoke(agent, ["pull", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["new_count"] == 0
+    assert payload["files"] == []
+
+
+def test_pull_notify_cmd_invoked_with_env(
+    pull_workspace: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``--notify-cmd`` is invoked with NEW_COUNT and SUMMARY env vars when there are new messages."""
+    gordon_outbox = pull_workspace / "gordon" / "messages" / "outbox"
+    _write_outbox_msg(gordon_outbox, sender="gordon", recipient="erik", subject="Urgent")
+
+    sentinel = tmp_path / "notify_fired.txt"
+    # Shell command: write env vars to sentinel file.
+    notify_cmd = f'echo "$NEW_COUNT $SUMMARY" > {sentinel}'
+
+    result = CliRunner().invoke(agent, ["pull", "--notify-cmd", notify_cmd])
+    assert result.exit_code == 0, result.output
+    assert sentinel.exists(), "--notify-cmd must have been invoked"
+    content = sentinel.read_text()
+    assert "1 " in content
+    assert "Urgent" in content
+
+
+def test_pull_notify_cmd_not_invoked_when_empty(pull_workspace: Path, tmp_path: Path) -> None:
+    """``--notify-cmd`` must NOT be invoked when there are no new messages."""
+    sentinel = tmp_path / "notify_fired.txt"
+    notify_cmd = f"touch {sentinel}"
+
+    result = CliRunner().invoke(agent, ["pull", "--notify-cmd", notify_cmd])
+    assert result.exit_code == 0, result.output
+    assert not sentinel.exists(), "--notify-cmd must not fire when new_count=0"
+
+
+def test_pull_dry_run_does_not_write(pull_workspace: Path) -> None:
+    """``pull --dry-run`` shows what would be fetched but does not write to inbox."""
+    gordon_outbox = pull_workspace / "gordon" / "messages" / "outbox"
+    name = _write_outbox_msg(
+        gordon_outbox, sender="gordon", recipient="erik", subject="Dry run msg"
+    )
+
+    result = CliRunner().invoke(agent, ["pull", "--dry-run"])
+    assert result.exit_code == 0, result.output
+    assert "dry-run" in result.output
+    assert "Dry run msg" in result.output
+
+    local_inbox = pull_workspace / "erik" / "messages" / "inbox"
+    assert not (local_inbox / name).exists(), "dry-run must not write files"
+
+
+def test_pull_skips_pull_only_agents(pull_workspace: Path) -> None:
+    """Agents with ``delivery: pull-only`` are skipped (they have no SSH outbox to poll)."""
+    # alice is registered as pull-only in the fixture — polling alice should be a no-op.
+    # Drop a file in a fake alice outbox to confirm nothing is fetched.
+    alice_outbox = pull_workspace / "alice" / "messages" / "outbox"
+    _write_outbox_msg(alice_outbox, sender="alice", recipient="erik", subject="Skipped")
+
+    result = CliRunner().invoke(agent, ["pull", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert "alice" not in payload["agents_polled"]
+    assert payload["new_count"] == 0
+
+
+def test_pull_as_override(pull_workspace: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``pull --as IDENTITY`` overrides the effective self-name for the pull."""
+    gordon_outbox = pull_workspace / "gordon" / "messages" / "outbox"
+    _write_outbox_msg(gordon_outbox, sender="gordon", recipient="bob", subject="For Bob")
+
+    # Self is still 'erik', but we pull --as bob — should fetch messages to bob.
+    result = CliRunner().invoke(agent, ["pull", "--as", "bob", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["new_count"] == 1, "pull --as bob must fetch message addressed to bob"
+
+
+def test_pull_multiple_messages_fetched(pull_workspace: Path) -> None:
+    """``pull`` fetches multiple messages in one run."""
+    gordon_outbox = pull_workspace / "gordon" / "messages" / "outbox"
+    names = [
+        _write_outbox_msg(gordon_outbox, sender="gordon", recipient="erik", subject=f"Msg {i}")
+        for i in range(3)
+    ]
+
+    result = CliRunner().invoke(agent, ["pull"])
+    assert result.exit_code == 0, result.output
+    assert "3 new message(s) fetched" in result.output
+
+    local_inbox = pull_workspace / "erik" / "messages" / "inbox"
+    for name in names:
+        assert (local_inbox / name).exists()

--- a/packages/gptmail/tests/test_agent_pull.py
+++ b/packages/gptmail/tests/test_agent_pull.py
@@ -296,6 +296,61 @@ def test_pull_as_override(pull_workspace: Path, monkeypatch: pytest.MonkeyPatch)
     assert payload["new_count"] == 1, "pull --as bob must fetch message addressed to bob"
 
 
+def test_pull_refuses_path_traversal_filename(
+    pull_workspace: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A filename supplied by a remote pending row cannot escape the inbox."""
+    outside = pull_workspace / "escaped.md"
+    monkeypatch.setattr(
+        agent_cli,
+        "_remote_pending_rows",
+        lambda *args, **kwargs: [{"file": "../../../../escaped.md", "mailbox": "default"}],
+    )
+
+    result = CliRunner().invoke(agent, ["pull"])
+
+    assert result.exit_code == 0, result.output
+    assert "refusing unsafe filename" in result.output
+    assert not outside.exists()
+
+
+def test_pull_all_mailboxes_preserves_mailbox_destination(
+    pull_workspace: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Rows from a named mailbox are copied into that mailbox's local inbox."""
+    gordon_root = pull_workspace / "gordon" / "messages"
+    default_name = _write_outbox_msg(
+        gordon_root / "outbox",
+        sender="gordon",
+        recipient="erik",
+        subject="Default",
+    )
+    ops_name = _write_outbox_msg(
+        gordon_root / "mailboxes" / "ops" / "outbox",
+        sender="gordon",
+        recipient="erik",
+        subject="Ops",
+        mailbox="ops",
+    )
+    (pull_workspace / "erik" / "messages" / "mailboxes" / "ops").mkdir(parents=True)
+    monkeypatch.setattr(
+        agent_cli,
+        "_remote_pending_rows",
+        lambda *args, **kwargs: [
+            {"file": default_name, "mailbox": "default"},
+            {"file": ops_name, "mailbox": "ops"},
+        ],
+    )
+
+    result = CliRunner().invoke(agent, ["pull", "--all-mailboxes"])
+
+    assert result.exit_code == 0, result.output
+    messages = pull_workspace / "erik" / "messages"
+    assert (messages / "inbox" / default_name).exists()
+    assert (messages / "mailboxes" / "ops" / "inbox" / ops_name).exists()
+    assert not (messages / "inbox" / ops_name).exists()
+
+
 def test_pull_multiple_messages_fetched(pull_workspace: Path) -> None:
     """``pull`` fetches multiple messages in one run."""
     gordon_outbox = pull_workspace / "gordon" / "messages" / "outbox"

--- a/packages/gptmail/tests/test_agent_pull.py
+++ b/packages/gptmail/tests/test_agent_pull.py
@@ -13,6 +13,7 @@ Covers the missing human-side delivery introduced in issue #1476:
 
 import json
 import shutil
+import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -22,7 +23,6 @@ from click.testing import CliRunner
 
 from gptmail import agent_cli
 from gptmail.agent_cli import agent
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -89,7 +89,7 @@ def pull_workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
     # Replace _remote_pending_rows with a local-filesystem scan of gordon's outbox
     # (avoids SSH; returns the same dict shape _remote_pending_rows produces).
-    def _local_remote_pending_rows(agent_name, agent_cfg, *, recipient, mailboxes):
+    def _local_remote_pending_rows(agent_name, agent_cfg, *, recipient, mailboxes, all_mailboxes):
         outbox = Path(agent_cfg["workspace"]) / "messages" / "outbox"
         rows = []
         if not outbox.exists():
@@ -233,14 +233,13 @@ def test_pull_notify_cmd_invoked_with_env(
     _write_outbox_msg(gordon_outbox, sender="gordon", recipient="erik", subject="Urgent")
 
     sentinel = tmp_path / "notify_fired.txt"
-    # Shell command: write env vars to sentinel file.
-    notify_cmd = f'echo "$NEW_COUNT $SUMMARY" > {sentinel}'
+    notify_cmd = f'sh -c \'printf "%s %s" "$NEW_COUNT" "$SUMMARY" > {sentinel}\''
 
     result = CliRunner().invoke(agent, ["pull", "--notify-cmd", notify_cmd])
     assert result.exit_code == 0, result.output
     assert sentinel.exists(), "--notify-cmd must have been invoked"
     content = sentinel.read_text()
-    assert "1 " in content
+    assert content.startswith("1 ")
     assert "Urgent" in content
 
 
@@ -252,6 +251,30 @@ def test_pull_notify_cmd_not_invoked_when_empty(pull_workspace: Path, tmp_path: 
     result = CliRunner().invoke(agent, ["pull", "--notify-cmd", notify_cmd])
     assert result.exit_code == 0, result.output
     assert not sentinel.exists(), "--notify-cmd must not fire when new_count=0"
+
+
+def test_pull_notify_cmd_does_not_shell_expand_message_subject(
+    pull_workspace: Path, tmp_path: Path
+) -> None:
+    """Message subjects stay data even when the hook invokes a shell explicitly."""
+    gordon_outbox = pull_workspace / "gordon" / "messages" / "outbox"
+    injected = tmp_path / "injected"
+    filename = _write_outbox_msg(
+        gordon_outbox,
+        sender="gordon",
+        recipient="erik",
+        subject="safe filename",
+    )
+    message = gordon_outbox / filename
+    message.write_text(message.read_text().replace("safe filename", f"$(touch {injected})"))
+
+    sentinel = tmp_path / "summary.txt"
+    notify_cmd = f"sh -c 'printf %s \"$SUMMARY\" > {sentinel}'"
+    result = CliRunner().invoke(agent, ["pull", "--notify-cmd", notify_cmd])
+
+    assert result.exit_code == 0, result.output
+    assert not injected.exists()
+    assert f"$(touch {injected})" in sentinel.read_text()
 
 
 def test_pull_dry_run_does_not_write(pull_workspace: Path) -> None:
@@ -349,6 +372,50 @@ def test_pull_all_mailboxes_preserves_mailbox_destination(
     assert (messages / "inbox" / default_name).exists()
     assert (messages / "mailboxes" / "ops" / "inbox" / ops_name).exists()
     assert not (messages / "inbox" / ops_name).exists()
+
+
+def test_pull_all_mailboxes_queries_remote_for_remote_only_mailboxes(
+    pull_workspace: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``--all-mailboxes`` reaches mailboxes that do not exist locally yet."""
+    calls: list[tuple[list[str], bool]] = []
+
+    def _remote_rows(*args, **kwargs):
+        calls.append((kwargs["mailboxes"], kwargs["all_mailboxes"]))
+        return [{"file": "remote-only.md", "mailbox": "ops"}]
+
+    monkeypatch.setattr(agent_cli, "_remote_pending_rows", _remote_rows)
+
+    result = CliRunner().invoke(agent, ["pull", "--all-mailboxes", "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert calls == [([], True)]
+
+
+def test_failed_scp_removes_partial_destination(
+    pull_workspace: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed transfer cannot leave a file that suppresses the next retry."""
+    filename = "partial.md"
+    destination = pull_workspace / "erik" / "messages" / "inbox" / filename
+    monkeypatch.setattr(
+        agent_cli,
+        "_remote_pending_rows",
+        lambda *args, **kwargs: [{"file": filename, "mailbox": "default"}],
+    )
+
+    def _partial_scp(cmd, **kwargs):
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text("partial")
+        raise subprocess.CalledProcessError(1, cmd)
+
+    monkeypatch.setattr(agent_cli.subprocess, "run", _partial_scp)
+
+    result = CliRunner().invoke(agent, ["pull"])
+
+    assert result.exit_code == 0, result.output
+    assert "failed to fetch" in result.output
+    assert not destination.exists()
 
 
 def test_pull_multiple_messages_fetched(pull_workspace: Path) -> None:

--- a/packages/gptmail/tests/test_agent_pull.py
+++ b/packages/gptmail/tests/test_agent_pull.py
@@ -243,6 +243,21 @@ def test_pull_notify_cmd_invoked_with_env(
     assert "Urgent" in content
 
 
+def test_pull_notify_cmd_failure_warns_after_fetch(pull_workspace: Path) -> None:
+    """A missing notification executable must not discard a successful pull."""
+    gordon_outbox = pull_workspace / "gordon" / "messages" / "outbox"
+    name = _write_outbox_msg(
+        gordon_outbox, sender="gordon", recipient="erik", subject="Still fetched"
+    )
+
+    result = CliRunner().invoke(agent, ["pull", "--notify-cmd", "missing-notifier"])
+
+    assert result.exit_code == 0, result.output
+    assert "Warning: --notify-cmd failed" in result.output
+    local_inbox = pull_workspace / "erik" / "messages" / "inbox"
+    assert (local_inbox / name).exists()
+
+
 def test_pull_notify_cmd_not_invoked_when_empty(pull_workspace: Path, tmp_path: Path) -> None:
     """``--notify-cmd`` must NOT be invoked when there are no new messages."""
     sentinel = tmp_path / "notify_fired.txt"

--- a/packages/gptmail/tests/test_agent_pull.py
+++ b/packages/gptmail/tests/test_agent_pull.py
@@ -353,15 +353,22 @@ def test_pull_as_override(pull_workspace: Path, monkeypatch: pytest.MonkeyPatch)
     assert payload["new_count"] == 1, "pull --as bob must fetch message addressed to bob"
 
 
-def test_pull_refuses_path_traversal_filename(
-    pull_workspace: Path, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize("filename", ["../../../../escaped.md", "subdir/message.md"])
+def test_pull_refuses_unsafe_remote_filename(
+    pull_workspace: Path, monkeypatch: pytest.MonkeyPatch, filename: str
 ) -> None:
-    """A filename supplied by a remote pending row cannot escape the inbox."""
+    """A remote row cannot escape either the source outbox or local inbox."""
     outside = pull_workspace / "escaped.md"
+    scp_calls: list[list[str]] = []
     monkeypatch.setattr(
         agent_cli,
         "_remote_pending_rows",
-        lambda *args, **kwargs: [{"file": "../../../../escaped.md", "mailbox": "default"}],
+        lambda *args, **kwargs: [{"file": filename, "mailbox": "default"}],
+    )
+    monkeypatch.setattr(
+        agent_cli.subprocess,
+        "run",
+        lambda cmd, **kwargs: scp_calls.append(cmd),
     )
 
     result = CliRunner().invoke(agent, ["pull"])
@@ -369,6 +376,7 @@ def test_pull_refuses_path_traversal_filename(
     assert result.exit_code == 0, result.output
     assert "refusing unsafe filename" in result.output
     assert not outside.exists()
+    assert scp_calls == []
 
 
 def test_pull_all_mailboxes_preserves_mailbox_destination(

--- a/packages/gptmail/tests/test_agent_pull.py
+++ b/packages/gptmail/tests/test_agent_pull.py
@@ -293,6 +293,25 @@ def test_pull_dry_run_does_not_write(pull_workspace: Path) -> None:
     assert not (local_inbox / name).exists(), "dry-run must not write files"
 
 
+def test_pull_dry_run_json_is_machine_readable(pull_workspace: Path) -> None:
+    """``--dry-run --json`` emits JSON only and lists prospective messages."""
+    gordon_outbox = pull_workspace / "gordon" / "messages" / "outbox"
+    name = _write_outbox_msg(
+        gordon_outbox, sender="gordon", recipient="erik", subject="Dry run msg"
+    )
+
+    result = CliRunner().invoke(agent, ["pull", "--dry-run", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == {
+        "new_count": 1,
+        "files": [name],
+        "agents_polled": ["gordon"],
+    }
+    local_inbox = pull_workspace / "erik" / "messages" / "inbox"
+    assert not (local_inbox / name).exists()
+
+
 def test_pull_skips_pull_only_agents(pull_workspace: Path) -> None:
     """Agents with ``delivery: pull-only`` are skipped (they have no SSH outbox to poll)."""
     # alice is registered as pull-only in the fixture — polling alice should be a no-op.
@@ -405,8 +424,7 @@ def test_failed_scp_removes_partial_destination(
     )
 
     def _partial_scp(cmd, **kwargs):
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        destination.write_text("partial")
+        Path(cmd[-1]).write_text("partial")
         raise subprocess.CalledProcessError(1, cmd)
 
     monkeypatch.setattr(agent_cli.subprocess, "run", _partial_scp)
@@ -416,6 +434,34 @@ def test_failed_scp_removes_partial_destination(
     assert result.exit_code == 0, result.output
     assert "failed to fetch" in result.output
     assert not destination.exists()
+    assert not list(destination.parent.glob(f".{filename}.*"))
+
+
+def test_pull_concurrent_publish_deduplicates_atomically(
+    pull_workspace: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A concurrent winner is preserved rather than overwritten by this pull."""
+    filename = "concurrent.md"
+    destination = pull_workspace / "erik" / "messages" / "inbox" / filename
+    monkeypatch.setattr(
+        agent_cli,
+        "_remote_pending_rows",
+        lambda *args, **kwargs: [{"file": filename, "mailbox": "default"}],
+    )
+
+    def _concurrent_scp(cmd, **kwargs):
+        Path(cmd[-1]).write_text("this pull")
+        destination.write_text("concurrent winner")
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(agent_cli.subprocess, "run", _concurrent_scp)
+
+    result = CliRunner().invoke(agent, ["pull", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["new_count"] == 0
+    assert destination.read_text() == "concurrent winner"
+    assert not list(destination.parent.glob(f".{filename}.*"))
 
 
 def test_pull_multiple_messages_fetched(pull_workspace: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1531,7 +1531,7 @@ wheels = [
 
 [[package]]
 name = "gptmail"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "packages/gptmail" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Fixes #1476.

## Problem

Pull-only recipients (e.g. humans registered as `delivery: pull-only` in `agents.yaml`) had no mechanism to receive messages. Outbox messages accumulated silently — Gordon's outbox had 68 unpulled messages over ~2 months, including a time-boxed decision request that lapsed.

## Changes

### `gptmail agent pull` (new command)

Iterates `agents.yaml`, SSHes into every push-reachable agent, and fetches outbox messages addressed to `AGENT_NAME` into the local inbox. Safe to run repeatedly — deduplicates by filename.

```
# Fetch new messages
gptmail agent pull

# Machine-readable output (for cron/notification scripts)
gptmail agent pull --json
# -> {"new_count": 3, "files": [...], "agents_polled": [...]}

# macOS notification banner
gptmail agent pull --notify-cmd 'osascript -e "display notification \"$SUMMARY\" with title \"gptmail\""'

# Linux (libnotify)
gptmail agent pull --notify-cmd 'notify-send "gptmail" "$SUMMARY"'

# Pull as a different identity (e.g. from a laptop)
gptmail agent pull --as erik

# Preview without writing
gptmail agent pull --dry-run
```

**Options:**
- `--as IDENTITY` — override the effective recipient name (useful for human recipients pulling from a different host than their registered `AGENT_NAME`)
- `--json` — emit `{new_count, files, agents_polled}` for scripted callers
- `--notify-cmd CMD` — shell hook invoked with `NEW_COUNT` + `SUMMARY` env vars when new messages arrive
- `--dry-run` — show what would be fetched without writing

Per-agent SSH errors are logged as warnings; partial results are still returned so one unreachable host doesn't abort the whole pull.

### `gptmail --version` (new)

Stale installs are now self-diagnosable: `gptmail --version` → `gptmail, version 0.2.0`.

### Version bump: 0.1.0 → 0.2.0

Behavioral changes (new pull command, version surfacing) warrant a minor bump so consumers have a signal to upgrade.

## Tests

11 new tests in `packages/gptmail/tests/test_agent_pull.py`, all green. Full suite: **178 passed**.

Covers: fetch addressed messages, skip messages for others, dedup on re-pull, `--json` output shape, zero-count when empty, `--notify-cmd` invoked with correct env vars, `--notify-cmd` NOT invoked when empty, `--dry-run` writes nothing, pull-only agents skipped, `--as` override, multiple messages in one run.

<!-- gptme-id:v1:gai_dVKUjIjel0s9ctEkvMOM3olBAM7ZdcoveE5T3ky4kko -->