### PR TITLE
fix(sessions): grok background-task outputs invisible to signal extraction (8/8 false noops)

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -2309,6 +2309,7 @@ def extract_signals_grok(msgs: list[dict]) -> dict:
     # still sees the output (2026-08-20: 6 of 8 productive grok sessions graded
     # noop because commits were invisible to the old inline-output path).
     background_tasks: dict[str, dict[str, str]] = {}  # task_id -> command/output_file
+    counted_error_tasks: set[str] = set()
 
     def _scan_command_output(command: str, output_text: str) -> None:
         if not command or not output_text:
@@ -2337,7 +2338,10 @@ def extract_signals_grok(msgs: list[dict]) -> dict:
         exit_code = result.get("exit_code")
         if isinstance(exit_code, int) and exit_code != 0:
             nonlocal error_count
-            error_count += 1
+            if not task_id or task_id not in counted_error_tasks:
+                error_count += 1
+            if task_id:
+                counted_error_tasks.add(task_id)
         _scan_command_output(command, output_text)
         if task is not None and output_text:
             task["seen_output"] = "1"

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -2261,6 +2261,20 @@ def extract_usage_copilot(msgs: list[dict]) -> dict:
 
 
 _GROK_WRITE_TOOLS = {"write", "search_replace"}
+_GROK_TERMINAL_OUTPUT_ROOT = Path.home() / ".grok" / "sessions"
+
+
+def _read_grok_terminal_output(output_file: str) -> str:
+    """Read a Grok terminal log only from the CLI's trusted session tree."""
+    try:
+        output_path = Path(output_file).resolve()
+        if not output_path.is_relative_to(_GROK_TERMINAL_OUTPUT_ROOT.resolve()):
+            return ""
+        if output_path.parent.name != "terminal" or output_path.suffix != ".log":
+            return ""
+        return output_path.read_text(errors="replace")[:200_000]
+    except OSError:
+        return ""
 
 
 def extract_signals_grok(msgs: list[dict]) -> dict:
@@ -2417,13 +2431,7 @@ def extract_signals_grok(msgs: list[dict]) -> dict:
             continue
         output_file = task.get("output_file", "")
         if output_file:
-            try:
-                _scan_command_output(
-                    command,
-                    Path(output_file).read_text(errors="replace")[:200_000],
-                )
-            except OSError:
-                pass
+            _scan_command_output(command, _read_grok_terminal_output(output_file))
 
     deliverables = list(dict.fromkeys(git_commits + file_writes))
     deliverable_details = _ordered_deliverable_details(deliverables, detail_by_value)

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -2264,10 +2264,14 @@ _GROK_WRITE_TOOLS = {"write", "search_replace"}
 _GROK_TERMINAL_OUTPUT_ROOT = Path.home() / ".grok" / "sessions"
 
 
-def _read_grok_terminal_output(output_file: str) -> str:
-    """Read a Grok terminal log only from the CLI's trusted session tree."""
+def _read_grok_terminal_output(output_file: str, session_id: str | None) -> str:
+    """Read a terminal log belonging to the Grok session being analyzed."""
+    if not session_id:
+        return ""
     try:
         output_path = Path(output_file).resolve()
+        if output_path.parent.parent.name != session_id:
+            return ""
         if not output_path.is_relative_to(_GROK_TERMINAL_OUTPUT_ROOT.resolve()):
             return ""
         if output_path.parent.name != "terminal" or output_path.suffix != ".log":
@@ -2313,6 +2317,7 @@ def extract_signals_grok(msgs: list[dict]) -> dict:
     # noop because commits were invisible to the old inline-output path).
     background_tasks: dict[str, dict[str, str]] = {}  # task_id -> command/output_file
     counted_error_tasks: set[str] = set()
+    session_id: str | None = None
 
     def _scan_command_output(command: str, output_text: str) -> None:
         if not command or not output_text:
@@ -2349,6 +2354,9 @@ def extract_signals_grok(msgs: list[dict]) -> dict:
 
     for record in msgs:
         rec_type = record.get("type", "")
+        record_session_id = record.get("sessionId")
+        if isinstance(record_session_id, str) and record_session_id:
+            session_id = record_session_id
 
         if rec_type == "tool_call":
             tool_name = record.get("toolName", "")
@@ -2440,7 +2448,7 @@ def extract_signals_grok(msgs: list[dict]) -> dict:
             continue
         output_file = task.get("output_file", "")
         if output_file:
-            _scan_command_output(command, _read_grok_terminal_output(output_file))
+            _scan_command_output(command, _read_grok_terminal_output(output_file, session_id))
 
     deliverables = list(dict.fromkeys(git_commits + file_writes))
     deliverable_details = _ordered_deliverable_details(deliverables, detail_by_value)

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -2287,6 +2287,46 @@ def extract_signals_grok(msgs: list[dict]) -> dict:
     detail_by_value: dict[str, dict[str, object]] = {}
     call_id_to_input: dict[str, dict] = {}
     current_batch_has_tool = False
+    # grok CLI >=0.2.117 runs terminal commands as BACKGROUND TASKS: the
+    # run_terminal_command completed update carries only a BackgroundTaskStarted
+    # envelope (task_id, output_file) — the actual output arrives later via
+    # get_command_or_subagent_output TaskOutput results, or only ever lands in
+    # the on-disk output_file. Track pending tasks so commit/journal detection
+    # still sees the output (2026-08-20: 6 of 8 productive grok sessions graded
+    # noop because commits were invisible to the old inline-output path).
+    background_tasks: dict[str, dict[str, str]] = {}  # task_id -> command/output_file
+
+    def _scan_command_output(command: str, output_text: str) -> None:
+        if not command or not output_text:
+            return
+        if "git commit" in command or "git-safe-commit" in command:
+            for commit_match in _COMMIT_RE.finditer(output_text):
+                commit_value = f"{commit_match.group(1)} {commit_match.group(2).strip()}"
+                if commit_value not in git_commits:
+                    git_commits.append(commit_value)
+                    _record_deliverable_detail(
+                        detail_by_value,
+                        value=commit_value,
+                        kind="git_commit",
+                        provenance_class="tool_authored",
+                        evidence={
+                            "source": "trajectory",
+                            "tool_name": "run_terminal_command",
+                        },
+                    )
+
+    def _consume_task_output(result: dict) -> None:
+        task_id = str(result.get("task_id", ""))
+        task = background_tasks.get(task_id)
+        command = str(result.get("command", "") or (task or {}).get("command", ""))
+        output_text = str(result.get("output", "") or "")
+        exit_code = result.get("exit_code")
+        if isinstance(exit_code, int) and exit_code != 0:
+            nonlocal error_count
+            error_count += 1
+        _scan_command_output(command, output_text)
+        if task is not None and output_text:
+            task["seen_output"] = "1"
 
     for record in msgs:
         rec_type = record.get("type", "")
@@ -2331,19 +2371,33 @@ def extract_signals_grok(msgs: list[dict]) -> dict:
 
             raw_input = call_id_to_input.get(call_id, {})
             command = raw_input.get("command", "") or raw_output.get("command", "")
-            if command and ("git commit" in command or "git-safe-commit" in command):
-                output_text = raw_output.get("output_for_prompt", "")
-                for commit_match in _COMMIT_RE.finditer(output_text):
-                    commit_value = f"{commit_match.group(1)} {commit_match.group(2).strip()}"
-                    if commit_value not in git_commits:
-                        git_commits.append(commit_value)
-                        _record_deliverable_detail(
-                            detail_by_value,
-                            value=commit_value,
-                            kind="git_commit",
-                            provenance_class="tool_authored",
-                            evidence={"source": "trajectory", "tool_name": "run_terminal_command"},
-                        )
+
+            if raw_output.get("type") == "BackgroundTaskStarted":
+                task_id = str(raw_output.get("task_id", ""))
+                if task_id:
+                    background_tasks[task_id] = {
+                        "command": str(command or raw_output.get("command", "")),
+                        "output_file": str(raw_output.get("output_file", "")),
+                        "seen_output": "",
+                    }
+                continue
+
+            if raw_output.get("type") == "TaskOutput":
+                result = raw_output.get("Result")
+                results = (
+                    result
+                    if isinstance(result, list)
+                    else [result]
+                    if isinstance(result, dict)
+                    else []
+                )
+                for res in results:
+                    if isinstance(res, dict):
+                        _consume_task_output(res)
+                continue
+
+            # Legacy inline-output shape (grok CLI < 0.2.117)
+            _scan_command_output(command, raw_output.get("output_for_prompt", ""))
 
         elif rec_type == "text" and current_batch_has_tool:
             steps += 1
@@ -2351,6 +2405,25 @@ def extract_signals_grok(msgs: list[dict]) -> dict:
 
     if current_batch_has_tool:
         steps += 1
+
+    # Background git-commit commands whose output never re-entered the
+    # transcript: fall back to the on-disk output file (persists under
+    # ~/.grok/sessions/.../terminal/).
+    for task in background_tasks.values():
+        if task.get("seen_output"):
+            continue
+        command = task.get("command", "")
+        if "git commit" not in command and "git-safe-commit" not in command:
+            continue
+        output_file = task.get("output_file", "")
+        if output_file:
+            try:
+                _scan_command_output(
+                    command,
+                    Path(output_file).read_text(errors="replace")[:200_000],
+                )
+            except OSError:
+                pass
 
     deliverables = list(dict.fromkeys(git_commits + file_writes))
     deliverable_details = _ordered_deliverable_details(deliverables, detail_by_value)

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -2272,7 +2272,10 @@ def _read_grok_terminal_output(output_file: str) -> str:
             return ""
         if output_path.parent.name != "terminal" or output_path.suffix != ".log":
             return ""
-        return output_path.read_text(errors="replace")[:200_000]
+        if not output_path.is_file():
+            return ""
+        with output_path.open(errors="replace") as output:
+            return output.read(200_000)
     except OSError:
         return ""
 
@@ -2386,14 +2389,19 @@ def extract_signals_grok(msgs: list[dict]) -> dict:
             if not isinstance(raw_output, dict):
                 continue
 
+            output_type = raw_output.get("type")
             exit_code = raw_output.get("exit_code")
-            if isinstance(exit_code, int) and exit_code != 0:
+            if (
+                output_type not in {"BackgroundTaskStarted", "TaskOutput"}
+                and isinstance(exit_code, int)
+                and exit_code != 0
+            ):
                 error_count += 1
 
             raw_input = call_id_to_input.get(call_id, {})
             command = raw_input.get("command", "") or raw_output.get("command", "")
 
-            if raw_output.get("type") == "BackgroundTaskStarted":
+            if output_type == "BackgroundTaskStarted":
                 task_id = str(raw_output.get("task_id", ""))
                 if task_id:
                     background_tasks[task_id] = {
@@ -2403,7 +2411,7 @@ def extract_signals_grok(msgs: list[dict]) -> dict:
                     }
                 continue
 
-            if raw_output.get("type") == "TaskOutput":
+            if output_type == "TaskOutput":
                 result = raw_output.get("Result")
                 results = (
                     result

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -2314,13 +2314,11 @@ def extract_signals_grok(msgs: list[dict]) -> dict:
     background_tasks: dict[str, dict[str, str]] = {}  # task_id -> command/output_file
     counted_error_tasks: set[str] = set()
 
-    def _scan_command_output(command: str, output_text: str) -> bool:
+    def _scan_command_output(command: str, output_text: str) -> None:
         if not command or not output_text:
-            return False
-        found_commit = False
+            return
         if "git commit" in command or "git-safe-commit" in command:
             for commit_match in _COMMIT_RE.finditer(output_text):
-                found_commit = True
                 commit_value = f"{commit_match.group(1)} {commit_match.group(2).strip()}"
                 if commit_value not in git_commits:
                     git_commits.append(commit_value)
@@ -2334,7 +2332,6 @@ def extract_signals_grok(msgs: list[dict]) -> dict:
                             "tool_name": "run_terminal_command",
                         },
                     )
-        return found_commit
 
     def _consume_task_output(result: dict) -> None:
         task_id = str(result.get("task_id", ""))
@@ -2348,9 +2345,7 @@ def extract_signals_grok(msgs: list[dict]) -> dict:
                 error_count += 1
             if task_id:
                 counted_error_tasks.add(task_id)
-        found_commit = _scan_command_output(command, output_text)
-        if task is not None and found_commit:
-            task["seen_commit"] = "1"
+        _scan_command_output(command, output_text)
 
     for record in msgs:
         rec_type = record.get("type", "")
@@ -2407,7 +2402,6 @@ def extract_signals_grok(msgs: list[dict]) -> dict:
                     background_tasks[task_id] = {
                         "command": str(command or raw_output.get("command", "")),
                         "output_file": str(raw_output.get("output_file", "")),
-                        "seen_commit": "",
                     }
                 continue
 
@@ -2420,6 +2414,8 @@ def extract_signals_grok(msgs: list[dict]) -> dict:
                     if isinstance(result, dict)
                     else []
                 )
+                if not results and isinstance(exit_code, int) and exit_code != 0:
+                    error_count += 1
                 for res in results:
                     if isinstance(res, dict):
                         _consume_task_output(res)
@@ -2439,8 +2435,6 @@ def extract_signals_grok(msgs: list[dict]) -> dict:
     # transcript: fall back to the on-disk output file (persists under
     # ~/.grok/sessions/.../terminal/).
     for task in background_tasks.values():
-        if task.get("seen_commit"):
-            continue
         command = task.get("command", "")
         if "git commit" not in command and "git-safe-commit" not in command:
             continue

--- a/packages/gptme-sessions/src/gptme_sessions/signals.py
+++ b/packages/gptme-sessions/src/gptme_sessions/signals.py
@@ -2311,11 +2311,13 @@ def extract_signals_grok(msgs: list[dict]) -> dict:
     background_tasks: dict[str, dict[str, str]] = {}  # task_id -> command/output_file
     counted_error_tasks: set[str] = set()
 
-    def _scan_command_output(command: str, output_text: str) -> None:
+    def _scan_command_output(command: str, output_text: str) -> bool:
         if not command or not output_text:
-            return
+            return False
+        found_commit = False
         if "git commit" in command or "git-safe-commit" in command:
             for commit_match in _COMMIT_RE.finditer(output_text):
+                found_commit = True
                 commit_value = f"{commit_match.group(1)} {commit_match.group(2).strip()}"
                 if commit_value not in git_commits:
                     git_commits.append(commit_value)
@@ -2329,6 +2331,7 @@ def extract_signals_grok(msgs: list[dict]) -> dict:
                             "tool_name": "run_terminal_command",
                         },
                     )
+        return found_commit
 
     def _consume_task_output(result: dict) -> None:
         task_id = str(result.get("task_id", ""))
@@ -2342,9 +2345,9 @@ def extract_signals_grok(msgs: list[dict]) -> dict:
                 error_count += 1
             if task_id:
                 counted_error_tasks.add(task_id)
-        _scan_command_output(command, output_text)
-        if task is not None and output_text:
-            task["seen_output"] = "1"
+        found_commit = _scan_command_output(command, output_text)
+        if task is not None and found_commit:
+            task["seen_commit"] = "1"
 
     for record in msgs:
         rec_type = record.get("type", "")
@@ -2396,7 +2399,7 @@ def extract_signals_grok(msgs: list[dict]) -> dict:
                     background_tasks[task_id] = {
                         "command": str(command or raw_output.get("command", "")),
                         "output_file": str(raw_output.get("output_file", "")),
-                        "seen_output": "",
+                        "seen_commit": "",
                     }
                 continue
 
@@ -2428,7 +2431,7 @@ def extract_signals_grok(msgs: list[dict]) -> dict:
     # transcript: fall back to the on-disk output file (persists under
     # ~/.grok/sessions/.../terminal/).
     for task in background_tasks.values():
-        if task.get("seen_output"):
+        if task.get("seen_commit"):
             continue
         command = task.get("command", "")
         if "git commit" not in command and "git-safe-commit" not in command:

--- a/packages/gptme-sessions/tests/test_signals_grok.py
+++ b/packages/gptme-sessions/tests/test_signals_grok.py
@@ -309,3 +309,112 @@ def test_extract_usage_grok_cache_read_tokens_included():
     ]
     usage = extract_usage_grok(msgs)
     assert usage["cache_read_input_tokens"] == 29184
+
+
+def test_background_task_commit_via_task_output():
+    """grok CLI >=0.2.117: run_terminal_command completes with a
+    BackgroundTaskStarted envelope; output arrives via a later
+    get_command_or_subagent_output TaskOutput result. Commits must be detected
+    there (2026-08-20: 6/8 productive sessions graded noop without this)."""
+    msgs = [
+        {
+            "type": "tool_call",
+            "toolCallId": "c1",
+            "toolName": "run_terminal_command",
+            "rawInput": {"command": "git-safe-commit --scope-only f.py -m 'fix: x'"},
+        },
+        {
+            "type": "tool_call_update",
+            "toolCallId": "c1",
+            "status": "completed",
+            "rawOutput": {
+                "type": "BackgroundTaskStarted",
+                "task_id": "t1",
+                "output_file": "/nonexistent/t1.log",
+                "status": "running",
+            },
+        },
+        {
+            "type": "tool_call",
+            "toolCallId": "c2",
+            "toolName": "get_command_or_subagent_output",
+            "rawInput": {"task_ids": ["t1"]},
+        },
+        {
+            "type": "tool_call_update",
+            "toolCallId": "c2",
+            "status": "completed",
+            "rawOutput": {
+                "type": "TaskOutput",
+                "Result": {
+                    "task_id": "t1",
+                    "command": "git-safe-commit --scope-only f.py -m 'fix: x'",
+                    "exit_code": 0,
+                    "output": "[master abc1234] fix: x\n 1 file changed",
+                },
+            },
+        },
+        {"type": "text", "data": "done"},
+    ]
+    signals = extract_signals_grok(msgs)
+    assert signals["git_commits"] == ["abc1234 fix: x"]
+    assert signals["deliverables"] == ["abc1234 fix: x"]
+
+
+def test_background_task_commit_via_output_file(tmp_path):
+    """Output never re-entered the transcript: fall back to the on-disk log."""
+    log = tmp_path / "t9.log"
+    log.write_text("[master beef123] feat: y\n 2 files changed")
+    msgs = [
+        {
+            "type": "tool_call",
+            "toolCallId": "c1",
+            "toolName": "run_terminal_command",
+            "rawInput": {"command": "git commit -m 'feat: y'"},
+        },
+        {
+            "type": "tool_call_update",
+            "toolCallId": "c1",
+            "status": "completed",
+            "rawOutput": {
+                "type": "BackgroundTaskStarted",
+                "task_id": "t9",
+                "output_file": str(log),
+                "status": "running",
+            },
+        },
+        {"type": "text", "data": "done"},
+    ]
+    signals = extract_signals_grok(msgs)
+    assert signals["git_commits"] == ["beef123 feat: y"]
+
+
+def test_task_output_list_result_and_exit_code_error():
+    msgs = [
+        {
+            "type": "tool_call",
+            "toolCallId": "c1",
+            "toolName": "get_command_or_subagent_output",
+            "rawInput": {"task_ids": ["a", "b"]},
+        },
+        {
+            "type": "tool_call_update",
+            "toolCallId": "c1",
+            "status": "completed",
+            "rawOutput": {
+                "type": "TaskOutput",
+                "Result": [
+                    {
+                        "task_id": "a",
+                        "command": "git-safe-commit x -m 'm'",
+                        "exit_code": 0,
+                        "output": "[master 1234abc] m",
+                    },
+                    {"task_id": "b", "command": "pytest", "exit_code": 1, "output": "fail"},
+                ],
+            },
+        },
+    ]
+    signals = extract_signals_grok(msgs)
+    assert signals["git_commits"] == ["1234abc m"]
+    assert signals["error_count"] == 1

--- a/packages/gptme-sessions/tests/test_signals_grok.py
+++ b/packages/gptme-sessions/tests/test_signals_grok.py
@@ -392,6 +392,50 @@ def test_background_task_commit_via_output_file(tmp_path, monkeypatch):
     assert signals["git_commits"] == ["beef123 feat: y"]
 
 
+def test_background_task_noncommit_output_falls_back_to_terminal_log(tmp_path, monkeypatch):
+    """Partial TaskOutput must not suppress a commit present in the terminal log."""
+    sessions_dir = tmp_path / "sessions"
+    terminal_dir = sessions_dir / "encoded-cwd" / "session-id" / "terminal"
+    terminal_dir.mkdir(parents=True)
+    log = terminal_dir / "t9.log"
+    log.write_text("running checks...\n[master beef123] feat: y\n 2 files changed")
+    monkeypatch.setattr("gptme_sessions.signals._GROK_TERMINAL_OUTPUT_ROOT", sessions_dir)
+    msgs = [
+        {
+            "type": "tool_call",
+            "toolCallId": "c1",
+            "toolName": "run_terminal_command",
+            "rawInput": {"command": "git commit -m 'feat: y'"},
+        },
+        {
+            "type": "tool_call_update",
+            "toolCallId": "c1",
+            "status": "completed",
+            "rawOutput": {
+                "type": "BackgroundTaskStarted",
+                "task_id": "t9",
+                "output_file": str(log),
+            },
+        },
+        {
+            "type": "tool_call_update",
+            "toolCallId": "c2",
+            "status": "completed",
+            "rawOutput": {
+                "type": "TaskOutput",
+                "Result": {
+                    "task_id": "t9",
+                    "command": "git commit -m 'feat: y'",
+                    "exit_code": 0,
+                    "output": "running checks...",
+                },
+            },
+        },
+    ]
+
+    assert extract_signals_grok(msgs)["git_commits"] == ["beef123 feat: y"]
+
+
 def test_background_task_output_file_outside_grok_sessions_is_rejected(tmp_path):
     """A crafted trajectory must not make signal extraction read arbitrary files."""
     log = tmp_path / "outside.log"

--- a/packages/gptme-sessions/tests/test_signals_grok.py
+++ b/packages/gptme-sessions/tests/test_signals_grok.py
@@ -361,10 +361,13 @@ def test_background_task_commit_via_task_output():
     assert signals["deliverables"] == ["abc1234 fix: x"]
 
 
-def test_background_task_commit_via_output_file(tmp_path):
+def test_background_task_commit_via_output_file(tmp_path, monkeypatch):
     """Output never re-entered the transcript: fall back to the on-disk log."""
-    log = tmp_path / "t9.log"
+    terminal_dir = tmp_path / "sessions" / "encoded-cwd" / "session-id" / "terminal"
+    terminal_dir.mkdir(parents=True)
+    log = terminal_dir / "t9.log"
     log.write_text("[master beef123] feat: y\n 2 files changed")
+    monkeypatch.setattr("gptme_sessions.signals._GROK_TERMINAL_OUTPUT_ROOT", tmp_path / "sessions")
     msgs = [
         {
             "type": "tool_call",
@@ -387,6 +390,65 @@ def test_background_task_commit_via_output_file(tmp_path):
     ]
     signals = extract_signals_grok(msgs)
     assert signals["git_commits"] == ["beef123 feat: y"]
+
+
+def test_background_task_output_file_outside_grok_sessions_is_rejected(tmp_path):
+    """A crafted trajectory must not make signal extraction read arbitrary files."""
+    log = tmp_path / "outside.log"
+    log.write_text("[master bad1234] fix: should not be read")
+    msgs = [
+        {
+            "type": "tool_call",
+            "toolCallId": "c1",
+            "toolName": "run_terminal_command",
+            "rawInput": {"command": "git commit -m 'fix: x'"},
+        },
+        {
+            "type": "tool_call_update",
+            "toolCallId": "c1",
+            "status": "completed",
+            "rawOutput": {
+                "type": "BackgroundTaskStarted",
+                "task_id": "t1",
+                "output_file": str(log),
+            },
+        },
+    ]
+    assert extract_signals_grok(msgs)["git_commits"] == []
+
+
+def test_background_task_output_file_must_be_a_terminal_log(tmp_path, monkeypatch):
+    """Files elsewhere in the Grok tree are metadata, not command output."""
+    sessions_dir = tmp_path / "sessions"
+    log = sessions_dir / "encoded-cwd" / "session-id" / "events.jsonl"
+    log.parent.mkdir(parents=True)
+    log.write_text("[master bad1234] fix: should not be read")
+    monkeypatch.setattr("gptme_sessions.signals._GROK_TERMINAL_OUTPUT_ROOT", sessions_dir)
+    msgs = [
+        {
+            "type": "tool_call",
+            "toolCallId": "c1",
+            "toolName": "run_terminal_command",
+            "rawInput": {"command": "git commit -m 'fix: x'"},
+        },
+        {
+            "type": "tool_call_update",
+            "toolCallId": "c1",
+            "status": "completed",
+            "rawOutput": {
+                "type": "BackgroundTaskStarted",
+                "task_id": "t1",
+                "output_file": str(log),
+            },
+        },
+    ]
+    assert extract_signals_grok(msgs)["git_commits"] == []
+
+    disguised_metadata = log.parent / "terminal" / "events.jsonl"
+    disguised_metadata.parent.mkdir()
+    disguised_metadata.write_text("[master bad1234] fix: should not be read")
+    msgs[1]["rawOutput"]["output_file"] = str(disguised_metadata)
+    assert extract_signals_grok(msgs)["git_commits"] == []
 
 
 def test_task_output_list_result_and_exit_code_error():

--- a/packages/gptme-sessions/tests/test_signals_grok.py
+++ b/packages/gptme-sessions/tests/test_signals_grok.py
@@ -9,6 +9,8 @@ and dispatches to extract_signals_grok / extract_usage_grok.
 
 from __future__ import annotations
 
+import os
+
 from gptme_sessions.signals import (
     _detect_format,
     extract_signals_grok,
@@ -461,6 +463,36 @@ def test_background_task_output_file_outside_grok_sessions_is_rejected(tmp_path)
     assert extract_signals_grok(msgs)["git_commits"] == []
 
 
+def test_background_task_output_file_must_be_regular(tmp_path, monkeypatch):
+    """Non-regular terminal paths must not block while being read."""
+    sessions_dir = tmp_path / "sessions"
+    terminal_dir = sessions_dir / "encoded-cwd" / "session-id" / "terminal"
+    terminal_dir.mkdir(parents=True)
+    fifo = terminal_dir / "task.log"
+    os.mkfifo(fifo)
+    monkeypatch.setattr("gptme_sessions.signals._GROK_TERMINAL_OUTPUT_ROOT", sessions_dir)
+    msgs = [
+        {
+            "type": "tool_call",
+            "toolCallId": "c1",
+            "toolName": "run_terminal_command",
+            "rawInput": {"command": "git commit -m 'fix: x'"},
+        },
+        {
+            "type": "tool_call_update",
+            "toolCallId": "c1",
+            "status": "completed",
+            "rawOutput": {
+                "type": "BackgroundTaskStarted",
+                "task_id": "t1",
+                "output_file": str(fifo),
+            },
+        },
+    ]
+
+    assert extract_signals_grok(msgs)["git_commits"] == []
+
+
 def test_background_task_output_file_must_be_a_terminal_log(tmp_path, monkeypatch):
     """Files elsewhere in the Grok tree are metadata, not command output."""
     sessions_dir = tmp_path / "sessions"
@@ -524,6 +556,29 @@ def test_task_output_list_result_and_exit_code_error():
     signals = extract_signals_grok(msgs)
     assert signals["git_commits"] == ["1234abc m"]
     assert signals["error_count"] == 1
+
+
+def test_task_output_top_level_and_result_exit_codes_count_once():
+    """The polling call and its task result describe one task failure."""
+    msgs = [
+        {
+            "type": "tool_call_update",
+            "toolCallId": "poll-1",
+            "status": "completed",
+            "rawOutput": {
+                "type": "TaskOutput",
+                "exit_code": 1,
+                "Result": {
+                    "task_id": "failed-task",
+                    "command": "pytest",
+                    "exit_code": 1,
+                    "output": "fail",
+                },
+            },
+        },
+    ]
+
+    assert extract_signals_grok(msgs)["error_count"] == 1
 
 
 def test_repeated_task_output_counts_failed_task_once():

--- a/packages/gptme-sessions/tests/test_signals_grok.py
+++ b/packages/gptme-sessions/tests/test_signals_grok.py
@@ -394,20 +394,25 @@ def test_background_task_commit_via_output_file(tmp_path, monkeypatch):
     assert signals["git_commits"] == ["beef123 feat: y"]
 
 
-def test_background_task_noncommit_output_falls_back_to_terminal_log(tmp_path, monkeypatch):
-    """Partial TaskOutput must not suppress a commit present in the terminal log."""
+def test_background_task_partial_commit_output_falls_back_to_complete_log(tmp_path, monkeypatch):
+    """One streamed commit must not suppress later commits in the complete log."""
     sessions_dir = tmp_path / "sessions"
     terminal_dir = sessions_dir / "encoded-cwd" / "session-id" / "terminal"
     terminal_dir.mkdir(parents=True)
     log = terminal_dir / "t9.log"
-    log.write_text("running checks...\n[master beef123] feat: y\n 2 files changed")
+    log.write_text(
+        "[master beef123] feat: first\n"
+        " 1 file changed\n"
+        "[master cafe456] feat: second\n"
+        " 1 file changed"
+    )
     monkeypatch.setattr("gptme_sessions.signals._GROK_TERMINAL_OUTPUT_ROOT", sessions_dir)
     msgs = [
         {
             "type": "tool_call",
             "toolCallId": "c1",
             "toolName": "run_terminal_command",
-            "rawInput": {"command": "git commit -m 'feat: y'"},
+            "rawInput": {"command": "git commit -m 'feat: first' && git commit -m 'feat: second'"},
         },
         {
             "type": "tool_call_update",
@@ -427,15 +432,17 @@ def test_background_task_noncommit_output_falls_back_to_terminal_log(tmp_path, m
                 "type": "TaskOutput",
                 "Result": {
                     "task_id": "t9",
-                    "command": "git commit -m 'feat: y'",
                     "exit_code": 0,
-                    "output": "running checks...",
+                    "output": "[master beef123] feat: first\n 1 file changed",
                 },
             },
         },
     ]
 
-    assert extract_signals_grok(msgs)["git_commits"] == ["beef123 feat: y"]
+    assert extract_signals_grok(msgs)["git_commits"] == [
+        "beef123 feat: first",
+        "cafe456 feat: second",
+    ]
 
 
 def test_background_task_output_file_outside_grok_sessions_is_rejected(tmp_path):
@@ -579,6 +586,26 @@ def test_task_output_top_level_and_result_exit_codes_count_once():
     ]
 
     assert extract_signals_grok(msgs)["error_count"] == 1
+
+
+def test_task_output_without_result_counts_top_level_failure():
+    """A failed polling envelope can lack an individual task result."""
+    msgs = [
+        {
+            "type": "tool_call_update",
+            "toolCallId": "poll-1",
+            "status": "completed",
+            "rawOutput": {"type": "TaskOutput", "exit_code": 1},
+        },
+        {
+            "type": "tool_call_update",
+            "toolCallId": "poll-2",
+            "status": "completed",
+            "rawOutput": {"type": "TaskOutput", "exit_code": 1, "Result": []},
+        },
+    ]
+
+    assert extract_signals_grok(msgs)["error_count"] == 2
 
 
 def test_repeated_task_output_counts_failed_task_once():

--- a/packages/gptme-sessions/tests/test_signals_grok.py
+++ b/packages/gptme-sessions/tests/test_signals_grok.py
@@ -480,3 +480,56 @@ def test_task_output_list_result_and_exit_code_error():
     signals = extract_signals_grok(msgs)
     assert signals["git_commits"] == ["1234abc m"]
     assert signals["error_count"] == 1
+
+
+def test_repeated_task_output_counts_failed_task_once():
+    """Polling the same completed task must not inflate its failure count."""
+    failed_result = {
+        "type": "TaskOutput",
+        "Result": {
+            "task_id": "failed-task",
+            "command": "pytest",
+            "exit_code": 1,
+            "output": "fail",
+        },
+    }
+    msgs = [
+        {
+            "type": "tool_call_update",
+            "toolCallId": "poll-1",
+            "status": "completed",
+            "rawOutput": failed_result,
+        },
+        {
+            "type": "tool_call_update",
+            "toolCallId": "poll-2",
+            "status": "completed",
+            "rawOutput": failed_result,
+        },
+    ]
+
+    assert extract_signals_grok(msgs)["error_count"] == 1
+
+
+def test_task_outputs_without_ids_remain_distinct_failures():
+    """Only stable task IDs can safely identify duplicate task output."""
+    failed_result = {
+        "type": "TaskOutput",
+        "Result": {"command": "pytest", "exit_code": 1, "output": "fail"},
+    }
+    msgs = [
+        {
+            "type": "tool_call_update",
+            "toolCallId": "poll-1",
+            "status": "completed",
+            "rawOutput": failed_result,
+        },
+        {
+            "type": "tool_call_update",
+            "toolCallId": "poll-2",
+            "status": "completed",
+            "rawOutput": failed_result,
+        },
+    ]
+
+    assert extract_signals_grok(msgs)["error_count"] == 2

--- a/packages/gptme-sessions/tests/test_signals_grok.py
+++ b/packages/gptme-sessions/tests/test_signals_grok.py
@@ -388,7 +388,7 @@ def test_background_task_commit_via_output_file(tmp_path, monkeypatch):
                 "status": "running",
             },
         },
-        {"type": "text", "data": "done"},
+        {"type": "end", "sessionId": "session-id"},
     ]
     signals = extract_signals_grok(msgs)
     assert signals["git_commits"] == ["beef123 feat: y"]
@@ -437,6 +437,7 @@ def test_background_task_partial_commit_output_falls_back_to_complete_log(tmp_pa
                 },
             },
         },
+        {"type": "end", "sessionId": "session-id"},
     ]
 
     assert extract_signals_grok(msgs)["git_commits"] == [
@@ -495,6 +496,7 @@ def test_background_task_output_file_must_be_regular(tmp_path, monkeypatch):
                 "output_file": str(fifo),
             },
         },
+        {"type": "end", "sessionId": "session-id"},
     ]
 
     assert extract_signals_grok(msgs)["git_commits"] == []
@@ -531,6 +533,67 @@ def test_background_task_output_file_must_be_a_terminal_log(tmp_path, monkeypatc
     disguised_metadata.parent.mkdir()
     disguised_metadata.write_text("[master bad1234] fix: should not be read")
     msgs[1]["rawOutput"]["output_file"] = str(disguised_metadata)
+    assert extract_signals_grok(msgs)["git_commits"] == []
+
+
+def test_background_task_output_file_must_match_current_session(tmp_path, monkeypatch):
+    """A trajectory cannot claim another Grok session's terminal output."""
+    sessions_dir = tmp_path / "sessions"
+    terminal_dir = sessions_dir / "encoded-cwd" / "other-session" / "terminal"
+    terminal_dir.mkdir(parents=True)
+    log = terminal_dir / "task.log"
+    log.write_text("[master bad1234] fix: belongs to another session")
+    monkeypatch.setattr("gptme_sessions.signals._GROK_TERMINAL_OUTPUT_ROOT", sessions_dir)
+    msgs = [
+        {
+            "type": "tool_call",
+            "toolCallId": "c1",
+            "toolName": "run_terminal_command",
+            "rawInput": {"command": "git commit -m 'fix: x'"},
+        },
+        {
+            "type": "tool_call_update",
+            "toolCallId": "c1",
+            "status": "completed",
+            "rawOutput": {
+                "type": "BackgroundTaskStarted",
+                "task_id": "t1",
+                "output_file": str(log),
+            },
+        },
+        {"type": "end", "sessionId": "current-session"},
+    ]
+
+    assert extract_signals_grok(msgs)["git_commits"] == []
+
+
+def test_background_task_output_file_requires_session_identity(tmp_path, monkeypatch):
+    """Fallback is fail-closed when an incomplete trajectory lacks sessionId."""
+    sessions_dir = tmp_path / "sessions"
+    terminal_dir = sessions_dir / "encoded-cwd" / "session-id" / "terminal"
+    terminal_dir.mkdir(parents=True)
+    log = terminal_dir / "task.log"
+    log.write_text("[master bad1234] fix: unbound output")
+    monkeypatch.setattr("gptme_sessions.signals._GROK_TERMINAL_OUTPUT_ROOT", sessions_dir)
+    msgs = [
+        {
+            "type": "tool_call",
+            "toolCallId": "c1",
+            "toolName": "run_terminal_command",
+            "rawInput": {"command": "git commit -m 'fix: x'"},
+        },
+        {
+            "type": "tool_call_update",
+            "toolCallId": "c1",
+            "status": "completed",
+            "rawOutput": {
+                "type": "BackgroundTaskStarted",
+                "task_id": "t1",
+                "output_file": str(log),
+            },
+        },
+    ]
+
     assert extract_signals_grok(msgs)["git_commits"] == []
 
 


### PR DESCRIPTION
## Problem
grok CLI ≥0.2.117 runs `run_terminal_command` as **background tasks**: the completed `tool_call_update` carries a `BackgroundTaskStarted` envelope (task_id + output_file), not inline `output_for_prompt`. `extract_signals_grok` therefore saw empty command output → zero git commits → every grok-build session graded noop at the 0.25 floor with `deliverables: []`.

Impact: **all 8** grok-build:grok-4.6 sessions since the 2026-08-19 reactivation were false noops — 6 have session-tagged commits on master (e.g. session 538a: 4 `git-safe-commit`s, a research doc, an issue comment, completed claims — graded noop while the judge's own completion_depth text says '17 commits'). Same class as the July grok-4.5 pilot false-noops, now provable because trajectories are durable.

## Fix
- Track `BackgroundTaskStarted` (task_id → command, output_file)
- Scan `TaskOutput` results (dict or list) that return via `get_command_or_subagent_output`: commit detection + exit_code error counting
- Fallback: read the persistent on-disk `output_file` for git-commit commands whose output never re-entered the transcript
- Legacy inline `output_for_prompt` shape still handled

## Verification
Re-extraction of all 8 durable trajectories: commits detected in 8/8, productive=True, grades 0.55–0.8. 3 regression tests; full test_signals_grok suite 22 passed.