### PR TITLE
feat(skills): add /end — cross-runtime session wrap-up gate

### DIFF
--- a/skills/end/SKILL.md
+++ b/skills/end/SKILL.md
@@ -166,3 +166,5 @@ bash <this-dir>/install.sh --project   # also .claude/skills/end in the current 
 
 - `skills/autonomous-session-workflow` (Bob) — Phase 5 "Persist" is what this gate enforces.
 - `lessons/workflow/merged-is-not-live` (Bob) — why the closeout has a **Verified** line.
+- `scripts/forward-drive-probe.py` (Bob) — the harness-side sibling: the same invariants checked on every *completion event* fleet-wide, dispatching a full session when a gap is found. Design: `knowledge/technical-designs/forward-drive-completion-reactor.md`.
+- `scripts/closed-loop-check.py` (Bob) — post-hoc session-altitude check; the report-only ancestor of `end-check.py`.

--- a/skills/end/SKILL.md
+++ b/skills/end/SKILL.md
@@ -64,11 +64,13 @@ shared worktree is listed as `info`, not a blocker. Pass `--since 2h` if the
 process-start heuristic is wrong (e.g. a resumed session).
 
 **Shared worktree with parallel sessions** (Bob's brain repo): siblings share
-your time window, so pass the paths *you* touched and only dirt under them can
-block — you know them from the conversation:
+your time window, so declare your footprint — the repo paths you touched plus
+the absolute paths of any linked worktrees you created. Only dirt/commits under
+those paths and only declared worktrees can block; the rest is info:
 
 ```bash
-python3 "$SKILL_DIR/scripts/end-check.py" --paths journal/2026-08-22/my-session.md scripts/foo.py
+python3 "$SKILL_DIR/scripts/end-check.py" \
+  --paths journal/2026-08-22/my-session.md scripts/foo.py /tmp/worktrees/my-feature
 ```
 
 A parallel session's fresh worktree can still show as a blocker; if

--- a/skills/end/SKILL.md
+++ b/skills/end/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: end
+description: "Wrap up the session safely: gate on uncommitted/unpushed work and missing journal, refuse to end if anything is unsaved, write the closing summary, then exit the harness when the session was light (stay alive for review when it was substantial). Invoke as /end (Claude Code, Codex) or /skill:end (gptme)."
+when_to_use: "Use when the user says /end, 'wrap up', 'end the session', 'we're done', or when an autonomous session has finished its work and is about to stop. Do not use mid-task as a way to bail on unfinished work — the check will refuse."
+argument-hint: "[--exit | --stay | --dry-run]"
+license: MIT
+compatibility: "Claude Code (/end), Codex (/end via ~/.codex/skills), gptme (/skill:end, gptme#pending). Linux /proc required for harness detection; stdlib-only Python 3.10+."
+metadata:
+  author: bob
+  version: "1.0.0"
+  tags: [session, wrap-up, lifecycle, cross-runtime]
+keywords:
+  - "/end"
+  - "end the session"
+  - "wrap up the session"
+  - "we're done for now"
+  - "close out this session"
+---
+
+# /end — wrap up, or refuse to
+
+The skill is a **gate, then a closeout, then (maybe) an exit**. It exists so
+"I'm done" is a checked claim, not a feeling. Three rules:
+
+1. **Refuse to end with unsaved work.** Uncommitted files you touched, unpushed
+   commits, dirty worktrees, or a missing journal entry → you are *not* done.
+2. **Closeout is short and stands alone.** The last message must make sense to
+   someone who reads only it.
+3. **Exit only when it's cheap to come back.** Light session → exit the harness.
+   Substantial session → stay alive so the human can review before the context
+   is gone. (`--exit` / `--stay` override.)
+
+## Arguments
+
+`$ARGUMENTS` — optional flags:
+
+| Flag | Effect |
+|---|---|
+| *(none)* | check → closeout → exit iff `CLEAN_LIGHT` |
+| `--exit` | check → closeout → exit even if `CLEAN_SUBSTANTIAL` |
+| `--stay` | check → closeout → never exit |
+| `--dry-run` | run the check and report; change nothing, exit nothing |
+
+## Step 1 — Run the gate (always)
+
+```bash
+# SKILL_DIR: $CLAUDE_SKILL_DIR in Claude Code; otherwise the directory of this
+# SKILL.md (e.g. gptme-contrib/skills/end or ~/.codex/skills/end).
+python3 "$SKILL_DIR/scripts/end-check.py"
+```
+
+It reports, per check, `✅ ok` / `ℹ️ info` / `⚠️ warn` / `❌ block`, and ends with
+one of:
+
+| Verdict | Meaning | What you do |
+|---|---|---|
+| `BLOCKED` | unsaved work attributed to this session | **Refuse.** Go to Step 2. |
+| `CLEAN_LIGHT` | ≤2 commits, ≤10 files, no PRs/worktrees pending | Closeout → exit (Step 3+4) |
+| `CLEAN_SUBSTANTIAL` | more than that, or open PRs / warnings | Closeout → hand-off → stay alive |
+
+"This session" = files/commits newer than the harness process start (from
+`/proc`), or commits carrying this session's id. Other sessions' dirt in a
+shared worktree is listed as `info`, not a blocker. Pass `--since 2h` if the
+process-start heuristic is wrong (e.g. a resumed session). On a shared machine
+a *parallel* session's fresh worktree can still show as a blocker (same time
+window); if `git -C <wt> log -1` proves it isn't yours, say so in the closeout
+and treat it as info — don't touch it.
+
+Also do the **judgment checks** the script can't:
+
+- Did the user ask something you never answered? → not done.
+- Did you promise "I'll …" anywhere in the last few messages? → do it or retract it.
+- Is a subagent or background job still running that produces a deliverable? → wait or kill it explicitly.
+- Is a task/claim still marked active for this session? → release it (Bob: `uv run coordination work-list --claimed`, then `work-complete`; `gptodo edit <id> --set state …`).
+
+## Step 2 — If BLOCKED: say so, then fix
+
+Open with the refusal, verbatim shape:
+
+> **Not ending — N blocker(s):** `<summary list from the check>`
+
+Then fix what is fixable without the human:
+
+```bash
+git commit <explicit paths> -m "..."          # brain repo: git-safe-commit --scope-only <paths> -m "..."
+git push                                      # brain repo: git-safe-push-master
+# journal entry for the work (Bob: journal/YYYY-MM-DD/<session-file>.md, append-only)
+```
+
+Re-run the check. If a blocker needs the human (a decision, a credential, a
+conflict you shouldn't resolve alone), **stay alive and ask** — one question,
+with the default you'd pick. Never "wrap up anyway".
+
+## Step 3 — Closeout message (≤ 12 lines)
+
+```
+## Session closeout
+**Shipped**: <commits/PRs with links — or "nothing shipped">
+**Verified**: <how you know it works — tests run, symptom re-checked — or "not verified: …">
+**Not done / deferred**: <explicitly, so nobody assumes it happened>
+**Next**: <the one action that unblocks continuation>
+**Closing**: exiting now | staying alive for review (say `/end --exit` to close)
+```
+
+Bob-specific: the closeout goes into the journal file too if it isn't there
+already (append-only), and the journal commit must be pushed before Step 4 —
+re-run the check once more after writing it.
+
+## Step 4 — Exit decision
+
+| Verdict | Default | `--exit` | `--stay` |
+|---|---|---|---|
+| `CLEAN_LIGHT` | exit | exit | stay |
+| `CLEAN_SUBSTANTIAL` | stay | exit | stay |
+| `BLOCKED` | stay (refused) | stay (refused) | stay |
+
+To exit, the closeout message must already be sent; then, as the final tool call:
+
+```bash
+python3 "$SKILL_DIR/scripts/end-exit.py"        # SIGTERM to the harness after 3s
+python3 "$SKILL_DIR/scripts/end-exit.py" --dry-run   # show the target first if unsure
+```
+
+It finds the interactive harness process (Claude Code via `CLAUDE_PID`; gptme
+and Codex via the `/proc` parent chain) and schedules the signal from a
+detached helper so your tool call returns first. Non-interactive runs
+(`claude -p`, `gptme -n`, `codex exec`) are left alone — they end with the
+turn. gptme caveat: SIGTERM skips `SESSION_END` hooks; when a human is present
+prefer telling them to type `/exit`.
+
+## Rationalizations this skill exists to block
+
+| Thought | Reality |
+|---|---|
+| "It's just a journal file, I'll commit it next session." | Next session is a different process with no memory of this one. Commit now. |
+| "The other session's changes are in the way, I'll skip the push." | Shared worktree: use `git-safe-push-master`; your commits are still yours to land. |
+| "CI is still running, I'll call it shipped." | Say "not verified: CI pending" in the closeout. Unverified ≠ done. |
+| "The session was big, so exiting saves the human time." | The opposite: big sessions are exactly the ones a human wants to inspect while the context still exists. |
+| "Exit is just `kill`, no big deal." | It's irreversible for this context. The closeout must already be on screen and in the journal. |
+
+## Per-runtime install
+
+Run once per machine (idempotent):
+
+```bash
+bash <this-dir>/install.sh          # symlinks into ~/.claude/skills/end and ~/.codex/skills/end
+bash <this-dir>/install.sh --project   # also .claude/skills/end in the current repo
+```
+
+- **Claude Code**: `~/.claude/skills/end` (or project `.claude/skills/end`) → `/end`.
+- **Codex**: `~/.codex/skills/end` → skills are slash-command packages; `/end` or `$end`.
+- **gptme**: skills in configured lesson dirs are already indexed; `/skill:end` lands with gptme PR "invoke skills as slash commands". Until then, say "wrap up the session" — the `when_to_use` matcher loads this skill.
+
+## Related
+
+- `skills/autonomous-session-workflow` (Bob) — Phase 5 "Persist" is what this gate enforces.
+- `lessons/workflow/merged-is-not-live` (Bob) — why the closeout has a **Verified** line.

--- a/skills/end/SKILL.md
+++ b/skills/end/SKILL.md
@@ -61,10 +61,19 @@ one of:
 "This session" = files/commits newer than the harness process start (from
 `/proc`), or commits carrying this session's id. Other sessions' dirt in a
 shared worktree is listed as `info`, not a blocker. Pass `--since 2h` if the
-process-start heuristic is wrong (e.g. a resumed session). On a shared machine
-a *parallel* session's fresh worktree can still show as a blocker (same time
-window); if `git -C <wt> log -1` proves it isn't yours, say so in the closeout
-and treat it as info — don't touch it.
+process-start heuristic is wrong (e.g. a resumed session).
+
+**Shared worktree with parallel sessions** (Bob's brain repo): siblings share
+your time window, so pass the paths *you* touched and only dirt under them can
+block — you know them from the conversation:
+
+```bash
+python3 "$SKILL_DIR/scripts/end-check.py" --paths journal/2026-08-22/my-session.md scripts/foo.py
+```
+
+A parallel session's fresh worktree can still show as a blocker; if
+`git -C <wt> log -1` proves it isn't yours, say so in the closeout and treat
+it as info — don't touch it.
 
 Also do the **judgment checks** the script can't:
 

--- a/skills/end/install.sh
+++ b/skills/end/install.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Install the `end` skill as a slash command in every harness on this machine.
+#
+#   bash install.sh            # ~/.claude/skills/end + ~/.codex/skills/end
+#   bash install.sh --project  # also <git toplevel>/.claude/skills/end
+#   bash install.sh --uninstall
+#
+# Idempotent: symlinks are (re)pointed at this directory; nothing is copied.
+set -euo pipefail
+
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+NAME="$(basename "$SKILL_DIR")"
+PROJECT=0
+UNINSTALL=0
+for a in "$@"; do
+    case "$a" in
+        --project) PROJECT=1 ;;
+        --uninstall) UNINSTALL=1 ;;
+        -h|--help) sed -n '2,9p' "$0"; exit 0 ;;
+        *) echo "unknown arg: $a" >&2; exit 2 ;;
+    esac
+done
+
+targets=(
+    "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills/$NAME"
+    "${CODEX_HOME:-$HOME/.codex}/skills/$NAME"
+)
+if [ "$PROJECT" = 1 ]; then
+    top="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+    if [ -z "$top" ]; then
+        echo "--project: not inside a git repo" >&2
+        exit 1
+    fi
+    targets+=("$top/.claude/skills/$NAME")
+fi
+
+link_one() {
+    local dst="$1"
+    if [ "$UNINSTALL" = 1 ]; then
+        if [ -L "$dst" ]; then rm "$dst"; echo "removed  $dst"; fi
+        return
+    fi
+    mkdir -p "$(dirname "$dst")"
+    if [ -e "$dst" ] && [ ! -L "$dst" ]; then
+        echo "skip     $dst (exists and is not a symlink)" >&2
+        return
+    fi
+    ln -sfn "$SKILL_DIR" "$dst"
+    echo "linked   $dst -> $SKILL_DIR"
+}
+
+for t in "${targets[@]}"; do link_one "$t"; done
+
+[ "$UNINSTALL" = 1 ] && exit 0
+cat <<EOF
+
+Claude Code: /end            (restart the session to pick up the new skill)
+Codex:       /end  or  \$end  (skills dir: ${CODEX_HOME:-$HOME/.codex}/skills)
+gptme:       /skill:end      (needs gptme with skill slash-commands; otherwise say "wrap up the session")
+EOF

--- a/skills/end/scripts/end-check.py
+++ b/skills/end/scripts/end-check.py
@@ -240,10 +240,32 @@ def _touched_this_session(path: Path, since: datetime | None) -> bool:
     return mt is None or mt >= since
 
 
+def _in_scope(rel: str, scope: list[str] | None) -> bool:
+    """True when `rel` is under one of the scope paths (or no scope given)."""
+    if not scope:
+        return True
+    rel_n = rel.rstrip("/")
+    for sp in scope:
+        sp_n = sp.rstrip("/")
+        if (
+            rel_n == sp_n
+            or rel_n.startswith(sp_n + "/")
+            or sp_n.startswith(rel_n + "/")
+        ):
+            return True
+    return False
+
+
 def _dirty_entries(
-    root: Path, since: datetime | None
+    root: Path, since: datetime | None, scope: list[str] | None = None
 ) -> tuple[list[str], list[str], list[str], str | None]:
-    """Classify `git status` entries: (this-session, older, submodules, error)."""
+    """Classify `git status` entries: (this-session, older, submodules, error).
+
+    With `scope`, only entries under those repo-relative paths can count as
+    this session's; everything else is "older/other" regardless of mtime.
+    This is the escape hatch for shared worktrees where parallel sessions
+    share the same time window.
+    """
     rc, out = git(["status", "--porcelain", "--untracked-files=normal", "-z"], root)
     if rc != 0:
         return [], [], [], out
@@ -262,15 +284,15 @@ def _dirty_entries(
             submods.append(rel)
             continue
         label = f"{code.strip() or '??'} {rel}"
-        if _touched_this_session(root / rel, since):
+        if _in_scope(rel, scope) and _touched_this_session(root / rel, since):
             mine.append(label)
         else:
             others.append(label)
     return mine, others, submods, None
 
 
-def check_dirty(rep: Report) -> None:
-    mine, others, submods, err = _dirty_entries(rep.root, rep.since)
+def check_dirty(rep: Report, scope: list[str] | None = None) -> None:
+    mine, others, submods, err = _dirty_entries(rep.root, rep.since, scope)
     if err is not None:
         rep.add(Check("uncommitted", "warn", "git status failed", [err]))
         return
@@ -290,7 +312,8 @@ def check_dirty(rep: Report) -> None:
             Check(
                 "uncommitted-other",
                 "info",
-                f"{len(others)} dirty path(s) older than this session (other sessions / pre-existing)",
+                f"{len(others)} dirty path(s) not attributed to this session"
+                + (" (outside --paths)" if scope else " (older / other sessions)"),
                 others[:15],
             )
         )
@@ -654,6 +677,13 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--json", action="store_true", help="machine-readable output")
     ap.add_argument("--no-prs", action="store_true", help="skip the gh PR check")
     ap.add_argument(
+        "--paths",
+        nargs="+",
+        metavar="PATH",
+        help="repo-relative paths this session touched; only dirt under them can block "
+        "(use in shared worktrees where parallel sessions share the time window)",
+    )
+    ap.add_argument(
         "--light-commits",
         type=int,
         default=2,
@@ -683,7 +713,18 @@ def main(argv: list[str] | None = None) -> int:
         since, source = None, "unknown (all dirty files count as this session's)"
 
     rep = Report(harness=harness, root=root, since=since, since_source=source)
-    check_dirty(rep)
+    scope = None
+    if args.paths:
+        scope = []
+        for raw in args.paths:
+            pth = Path(raw)
+            if pth.is_absolute():
+                try:
+                    pth = pth.resolve().relative_to(root.resolve())
+                except ValueError:
+                    continue
+            scope.append(pth.as_posix())
+    check_dirty(rep, scope)
     check_commits(rep)
     rep.add(check_unpushed(rep, root, "unpushed")[0])
     check_worktrees(rep)

--- a/skills/end/scripts/end-check.py
+++ b/skills/end/scripts/end-check.py
@@ -156,7 +156,12 @@ def parse_since(value: str) -> datetime:
             "d": timedelta(days=n),
         }[unit]
         return datetime.now(timezone.utc) - delta
-    dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        raise SystemExit(
+            f"error: --since '{value}' is not a valid ISO date or duration (e.g. '90m', '2h', '2026-08-01')"
+        )
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
     return dt
@@ -272,8 +277,10 @@ def _touched_this_session(path: Path, since: datetime | None) -> bool:
 
 def _in_scope(rel: str, scope: list[str] | None) -> bool:
     """True when `rel` is under one of the scope paths (or no scope given)."""
-    if not scope:
+    if scope is None:
         return True
+    if not scope:
+        return False
     rel_n = rel.rstrip("/")
     for sp in scope:
         sp_n = sp.rstrip("/")
@@ -433,7 +440,9 @@ def check_unpushed(
     """
     rc, up = git(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"], cwd)
     if rc != 0:
-        rc2, cnt = git(["rev-list", "--count", "HEAD", "--not", "--remotes"], cwd)
+        base_args = ["rev-list", "--count", "HEAD", "--not", "--remotes"]
+        scoped_args = [*base_args, "--", *scope] if scope else base_args
+        rc2, cnt = git(scoped_args, cwd)
         n = int(cnt) if rc2 == 0 and cnt.isdigit() else 0
         if n:
             newest = _newest_commit_date(cwd, ["HEAD", "--not", "--remotes"])

--- a/skills/end/scripts/end-check.py
+++ b/skills/end/scripts/end-check.py
@@ -408,7 +408,7 @@ def check_commits(rep: Report, scope: list[str] | None = None) -> None:
         # No session id available — can't distinguish our commits from siblings'.
         # Attribute nothing rather than blocking a session that did no work.
         subjects = []
-        shas = []
+        # Keep shas for files_changed calculation (still needed for the verdict)
     rep.commits = subjects
     if shas:
         rc, out = git(["diff", "--shortstat", f"{shas[-1]}^", shas[0]], rep.root)

--- a/skills/end/scripts/end-check.py
+++ b/skills/end/scripts/end-check.py
@@ -321,7 +321,12 @@ def _dirty_entries(
             submods.append(rel)
             continue
         label = f"{code.strip() or '??'} {rel}"
-        if _in_scope(rel, scope) and _touched_this_session(root / rel, since):
+        # A staged index change (explicit `git add`) counts as "mine" regardless of
+        # file mtime, because the staging act itself is the session-time touch.
+        has_index_change = code[0] not in (" ", "?")
+        if _in_scope(rel, scope) and (
+            has_index_change or _touched_this_session(root / rel, since)
+        ):
             mine.append(label)
         else:
             others.append(label)

--- a/skills/end/scripts/end-check.py
+++ b/skills/end/scripts/end-check.py
@@ -194,9 +194,39 @@ def _mtime(path: Path) -> datetime | None:
         return None
 
 
+_SUBMODULE_CACHE: dict[Path, set[str]] = {}
+
+
+def _submodule_paths(root: Path) -> set[str]:
+    """Submodule paths of a checkout, one git call per repo (cached).
+
+    Never call git per status entry: a worktree with thousands of untracked
+    files turned that into minutes.
+    """
+    key = root.resolve()
+    if key not in _SUBMODULE_CACHE:
+        rc, out = git(
+            [
+                "config",
+                "--file",
+                ".gitmodules",
+                "--get-regexp",
+                r"^submodule\..*\.path$",
+            ],
+            root,
+        )
+        paths = set()
+        if rc == 0:
+            for line in out.splitlines():
+                parts = line.split(None, 1)
+                if len(parts) == 2:
+                    paths.add(parts[1].strip().rstrip("/"))
+        _SUBMODULE_CACHE[key] = paths
+    return _SUBMODULE_CACHE[key]
+
+
 def _is_submodule(root: Path, rel: str) -> bool:
-    rc, out = git(["ls-files", "-s", "--", rel], root)
-    return rc == 0 and out.startswith("160000 ")
+    return rel.rstrip("/") in _submodule_paths(root)
 
 
 # --------------------------------------------------------------------------- #
@@ -321,7 +351,7 @@ def check_dirty(rep: Report, scope: list[str] | None = None) -> None:
         rep.add(Check("submodules", "info", "submodule pointer(s) differ", submods))
 
 
-def check_commits(rep: Report) -> None:
+def check_commits(rep: Report, scope: list[str] | None = None) -> None:
     if rep.since is None:
         rep.add(
             Check(
@@ -330,10 +360,16 @@ def check_commits(rep: Report) -> None:
         )
         return
     since_iso = rep.since.isoformat()
-    rc, out = git(
-        ["log", f"--since={since_iso}", "--format=%h%x1f%s%x1f%b%x1e", "-n", "200"],
-        rep.root,
-    )
+    log_args = [
+        "log",
+        f"--since={since_iso}",
+        "--format=%h%x1f%s%x1f%b%x1e",
+        "-n",
+        "200",
+    ]
+    if scope:
+        log_args += ["--", *scope]
+    rc, out = git(log_args, rep.root)
     if rc != 0:
         rep.add(Check("commits", "warn", "git log failed", [out]))
         return
@@ -365,7 +401,8 @@ def check_commits(rep: Report) -> None:
         Check(
             "commits",
             "info",
-            f"{len(subjects)} commit(s) attributed to this session",
+            f"{len(subjects)} commit(s) attributed to this session"
+            + (" (touching --paths)" if scope else ""),
             subjects[:20],
         )
     )
@@ -386,8 +423,14 @@ def _newest_commit_date(cwd: Path, rev_range: list[str]) -> datetime | None:
     return newest
 
 
-def check_unpushed(rep: Report, cwd: Path, label: str) -> tuple[Check, datetime | None]:
-    """Returns the check plus the newest unpushed commit date (None if nothing unpushed)."""
+def check_unpushed(
+    rep: Report, cwd: Path, label: str, scope: list[str] | None = None
+) -> tuple[Check, datetime | None]:
+    """Returns the check plus the newest unpushed commit date (None if nothing unpushed).
+
+    With `scope`, only unpushed commits touching those paths block; the rest
+    are listed as info (another session's commits in a shared worktree).
+    """
     rc, up = git(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"], cwd)
     if rc != 0:
         rc2, cnt = git(["rev-list", "--count", "HEAD", "--not", "--remotes"], cwd)
@@ -406,6 +449,20 @@ def check_unpushed(rep: Report, cwd: Path, label: str) -> tuple[Check, datetime 
         return Check(label, "ok", "no upstream, nothing unpublished"), None
     rc, out = git(["log", "@{u}..HEAD", "--format=%h %s"], cwd)
     lines = [ln for ln in out.splitlines() if ln.strip()] if rc == 0 else []
+    if lines and scope:
+        rc, scoped = git(["log", "@{u}..HEAD", "--format=%h %s", "--", *scope], cwd)
+        mine = [ln for ln in scoped.splitlines() if ln.strip()] if rc == 0 else []
+        if not mine:
+            return (
+                Check(
+                    label,
+                    "info",
+                    f"{len(lines)} unpushed commit(s) on {up}, none touching --paths (other sessions)",
+                    lines[:10],
+                ),
+                None,
+            )
+        lines = mine
     if lines:
         newest = _newest_commit_date(cwd, ["@{u}..HEAD"])
         return (
@@ -417,7 +474,11 @@ def check_unpushed(rep: Report, cwd: Path, label: str) -> tuple[Check, datetime 
     return Check(label, "ok", f"in sync with {up}"), None
 
 
-def check_worktrees(rep: Report) -> None:
+def check_worktrees(
+    rep: Report, declared: list[Path] | None = None, footprint_given: bool = False
+) -> None:
+    """With a declared footprint (--paths), only declared worktrees can block."""
+    declared_set = {d.resolve() for d in (declared or [])}
     rc, out = git(["worktree", "list", "--porcelain"], rep.root)
     if rc != 0:
         return
@@ -455,6 +516,14 @@ def check_worktrees(rep: Report) -> None:
             (recent_problems if unpushed_recent else old_problems).append(
                 unpushed.summary
             )
+        if footprint_given and wt.resolve() not in declared_set:
+            old_problems = recent_problems + old_problems
+            recent_problems = []
+            if old_problems:
+                infos.append(
+                    f"{shown}: {', '.join(old_problems)} (not declared in --paths)"
+                )
+                continue
         if recent_problems:
             blocked.append(f"{shown}: {', '.join(recent_problems)}")
         elif old_problems:
@@ -593,7 +662,9 @@ def decide(rep: Report, light_commits: int, light_files: int) -> None:
         len(rep.commits) > light_commits
         or rep.files_changed > light_files
         or bool(rep.prs)
-        or any(c.name == "worktrees" and c.status != "ok" for c in rep.checks)
+        or any(
+            c.name == "worktrees" and c.status in ("warn", "block") for c in rep.checks
+        )
         or any(c.status == "warn" for c in rep.checks)
     )
     if substantial:
@@ -680,8 +751,9 @@ def main(argv: list[str] | None = None) -> int:
         "--paths",
         nargs="+",
         metavar="PATH",
-        help="repo-relative paths this session touched; only dirt under them can block "
-        "(use in shared worktrees where parallel sessions share the time window)",
+        help="this session's footprint: repo-relative paths it touched and absolute paths of "
+        "linked worktrees it created. Only dirt/commits under them and only declared "
+        "worktrees can block (shared worktrees: parallel sessions share the time window)",
     )
     ap.add_argument(
         "--light-commits",
@@ -713,7 +785,8 @@ def main(argv: list[str] | None = None) -> int:
         since, source = None, "unknown (all dirty files count as this session's)"
 
     rep = Report(harness=harness, root=root, since=since, since_source=source)
-    scope = None
+    scope: list[str] | None = None
+    declared_worktrees: list[Path] = []
     if args.paths:
         scope = []
         for raw in args.paths:
@@ -722,12 +795,15 @@ def main(argv: list[str] | None = None) -> int:
                 try:
                     pth = pth.resolve().relative_to(root.resolve())
                 except ValueError:
+                    declared_worktrees.append(
+                        pth
+                    )  # a linked worktree this session owns
                     continue
             scope.append(pth.as_posix())
     check_dirty(rep, scope)
-    check_commits(rep)
-    rep.add(check_unpushed(rep, root, "unpushed")[0])
-    check_worktrees(rep)
+    check_commits(rep, scope)
+    rep.add(check_unpushed(rep, root, "unpushed", scope)[0])
+    check_worktrees(rep, declared_worktrees, footprint_given=bool(args.paths))
     check_journal(rep)
     if not args.no_prs:
         check_prs(rep)

--- a/skills/end/scripts/end-check.py
+++ b/skills/end/scripts/end-check.py
@@ -404,9 +404,18 @@ def check_commits(rep: Report, scope: list[str] | None = None) -> None:
     if tagged:
         subjects = [f"{s} {j}" for s, j in tagged]
         shas = [s for s, _ in tagged]
+    elif not sid:
+        # No session id available — can't distinguish our commits from siblings'.
+        # Attribute nothing rather than blocking a session that did no work.
+        subjects = []
+        shas = []
     rep.commits = subjects
     if shas:
         rc, out = git(["diff", "--shortstat", f"{shas[-1]}^", shas[0]], rep.root)
+        if rc != 0:
+            # shas[-1] is the root commit (no parent); diff from the empty tree.
+            empty_tree = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+            rc, out = git(["diff", "--shortstat", empty_tree, shas[0]], rep.root)
         m = re.search(r"(\d+) files? changed", out) if rc == 0 else None
         rep.files_changed = int(m.group(1)) if m else 0
     rep.add(

--- a/skills/end/scripts/end-check.py
+++ b/skills/end/scripts/end-check.py
@@ -1,0 +1,703 @@
+#!/usr/bin/env python3
+"""Session wrap-up gate for the `/end` skill.
+
+Runtime-agnostic (Claude Code, gptme, Codex): stdlib only, reads the harness
+from the environment / process tree, and reports whether the session is safe
+to close.
+
+Exit codes:
+    0  clean   — nothing blocks ending the session
+    2  blocked — uncommitted/unpushed work, dirty worktrees, missing journal
+    1  error   — could not run the checks (not a git repo, etc.)
+
+The verdict line is the contract the SKILL.md acts on:
+    VERDICT: BLOCKED            -> refuse to wrap up, fix the blockers
+    VERDICT: CLEAN_LIGHT        -> wrap up and exit the harness
+    VERDICT: CLEAN_SUBSTANTIAL  -> wrap up, hand off, stay alive for review
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+HARNESS_BY_ARGV0 = {
+    "claude": "claude-code",
+    "gptme": "gptme",
+    "codex": "codex",
+}
+
+
+# --------------------------------------------------------------------------- #
+# Harness / session discovery
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class Harness:
+    name: str = "unknown"
+    pid: int | None = None
+    cmdline: str = ""
+    started_at: datetime | None = None
+    session_id: str | None = None
+
+
+def _read(path: str) -> str:
+    try:
+        with open(path, "rb") as f:
+            return f.read().decode("utf-8", "replace")
+    except OSError:
+        return ""
+
+
+def _proc_ppid(pid: int) -> int | None:
+    for line in _read(f"/proc/{pid}/status").splitlines():
+        if line.startswith("PPid:"):
+            try:
+                return int(line.split()[1])
+            except (IndexError, ValueError):
+                return None
+    return None
+
+
+def _proc_cmdline(pid: int) -> list[str]:
+    raw = _read(f"/proc/{pid}/cmdline")
+    return [a for a in raw.split("\0") if a]
+
+
+def _proc_start_time(pid: int) -> datetime | None:
+    """Process start time from /proc/<pid>/stat + /proc/stat btime."""
+    stat = _read(f"/proc/{pid}/stat")
+    if not stat or ")" not in stat:
+        return None
+    # Field 22 (1-based) is starttime, counted after the ")" of comm.
+    fields = stat.rsplit(")", 1)[1].split()
+    try:
+        start_ticks = int(fields[19])
+    except (IndexError, ValueError):
+        return None
+    btime = None
+    for line in _read("/proc/stat").splitlines():
+        if line.startswith("btime "):
+            btime = int(line.split()[1])
+            break
+    if btime is None:
+        return None
+    hz = os.sysconf("SC_CLK_TCK") if hasattr(os, "sysconf") else 100
+    return datetime.fromtimestamp(btime + start_ticks / hz, tz=timezone.utc)
+
+
+def _classify_cmdline(argv: list[str]) -> str | None:
+    """Map a process cmdline to a harness name, or None."""
+    if not argv:
+        return None
+    # argv[0] may be an interpreter (node/python); look at the first two args.
+    for arg in argv[:2]:
+        base = os.path.basename(arg)
+        base = re.sub(r"\.(js|py|exe)$", "", base)
+        if base in HARNESS_BY_ARGV0:
+            return HARNESS_BY_ARGV0[base]
+    return None
+
+
+def find_harness() -> Harness:
+    h = Harness()
+    env_pid = os.environ.get("CLAUDE_PID")
+    if env_pid and env_pid.isdigit() and os.path.exists(f"/proc/{env_pid}"):
+        h.name = "claude-code"
+        h.pid = int(env_pid)
+    else:
+        pid: int | None = os.getppid()
+        hops = 0
+        while pid and pid > 1 and hops < 12:
+            kind = _classify_cmdline(_proc_cmdline(pid))
+            if kind:
+                h.name, h.pid = kind, pid
+                break
+            pid = _proc_ppid(pid)
+            hops += 1
+        if h.pid is None:
+            # Env-only fallbacks (process tree unavailable, e.g. sandboxed).
+            if os.environ.get("CLAUDECODE"):
+                h.name = "claude-code"
+            elif os.environ.get("GPTME_AGENT_NAME") or os.environ.get("GPTME_LOGS_DIR"):
+                h.name = "gptme"
+            elif os.environ.get("CODEX_HOME") or os.environ.get("CODEX_SANDBOX"):
+                h.name = "codex"
+    if h.pid:
+        h.cmdline = " ".join(_proc_cmdline(h.pid))[:200]
+        h.started_at = _proc_start_time(h.pid)
+    h.session_id = (
+        os.environ.get("CLAUDE_CODE_SESSION_ID")
+        or os.environ.get("CC_SESSION_ID")
+        or os.environ.get("GPTME_SESSION_ID")
+        or os.environ.get("CODEX_THREAD_ID")
+    )
+    return h
+
+
+def parse_since(value: str) -> datetime:
+    """Accept ISO-8601 or a relative duration like '90m', '2h', '1d'."""
+    m = re.fullmatch(r"(\d+)([smhd])", value.strip())
+    if m:
+        n, unit = int(m.group(1)), m.group(2)
+        delta = {
+            "s": timedelta(seconds=n),
+            "m": timedelta(minutes=n),
+            "h": timedelta(hours=n),
+            "d": timedelta(days=n),
+        }[unit]
+        return datetime.now(timezone.utc) - delta
+    dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+# --------------------------------------------------------------------------- #
+# Git helpers
+# --------------------------------------------------------------------------- #
+
+
+def git(args: list[str], cwd: Path, timeout: int = 20) -> tuple[int, str]:
+    try:
+        p = subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as e:
+        return 1, str(e)
+    return p.returncode, (p.stdout or "").rstrip("\n")
+
+
+def repo_root(start: Path) -> Path | None:
+    rc, out = git(["rev-parse", "--show-toplevel"], start)
+    return Path(out) if rc == 0 and out else None
+
+
+def _mtime(path: Path) -> datetime | None:
+    try:
+        return datetime.fromtimestamp(path.lstat().st_mtime, tz=timezone.utc)
+    except OSError:
+        return None
+
+
+def _is_submodule(root: Path, rel: str) -> bool:
+    rc, out = git(["ls-files", "-s", "--", rel], root)
+    return rc == 0 and out.startswith("160000 ")
+
+
+# --------------------------------------------------------------------------- #
+# Checks
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class Check:
+    name: str
+    status: str  # ok | info | warn | block
+    summary: str
+    items: list[str] = field(default_factory=list)
+
+
+@dataclass
+class Report:
+    harness: Harness
+    root: Path
+    since: datetime | None
+    since_source: str
+    checks: list[Check] = field(default_factory=list)
+    commits: list[str] = field(default_factory=list)
+    files_changed: int = 0
+    prs: list[dict] = field(default_factory=list)
+    verdict: str = ""
+    reason: str = ""
+
+    def add(self, c: Check) -> None:
+        self.checks.append(c)
+
+    @property
+    def blockers(self) -> list[Check]:
+        return [c for c in self.checks if c.status == "block"]
+
+
+def _touched_this_session(path: Path, since: datetime | None) -> bool:
+    if since is None:
+        return True
+    mt = _mtime(path)
+    return mt is None or mt >= since
+
+
+def _dirty_entries(
+    root: Path, since: datetime | None
+) -> tuple[list[str], list[str], list[str], str | None]:
+    """Classify `git status` entries: (this-session, older, submodules, error)."""
+    rc, out = git(["status", "--porcelain", "--untracked-files=normal", "-z"], root)
+    if rc != 0:
+        return [], [], [], out
+    entries = [e for e in out.split("\0") if e]
+    mine: list[str] = []
+    others: list[str] = []
+    submods: list[str] = []
+    i = 0
+    while i < len(entries):
+        e = entries[i]
+        code, rel = e[:2], e[3:]
+        if code[0] == "R" or code[1] == "R":  # rename: next entry is the source
+            i += 1
+        i += 1
+        if _is_submodule(root, rel):
+            submods.append(rel)
+            continue
+        label = f"{code.strip() or '??'} {rel}"
+        if _touched_this_session(root / rel, since):
+            mine.append(label)
+        else:
+            others.append(label)
+    return mine, others, submods, None
+
+
+def check_dirty(rep: Report) -> None:
+    mine, others, submods, err = _dirty_entries(rep.root, rep.since)
+    if err is not None:
+        rep.add(Check("uncommitted", "warn", "git status failed", [err]))
+        return
+    if mine:
+        rep.add(
+            Check(
+                "uncommitted",
+                "block",
+                f"{len(mine)} uncommitted change(s) touched this session",
+                mine[:40],
+            )
+        )
+    else:
+        rep.add(Check("uncommitted", "ok", "no uncommitted changes from this session"))
+    if others:
+        rep.add(
+            Check(
+                "uncommitted-other",
+                "info",
+                f"{len(others)} dirty path(s) older than this session (other sessions / pre-existing)",
+                others[:15],
+            )
+        )
+    if submods:
+        rep.add(Check("submodules", "info", "submodule pointer(s) differ", submods))
+
+
+def check_commits(rep: Report) -> None:
+    if rep.since is None:
+        rep.add(
+            Check(
+                "commits", "info", "session start unknown — commit attribution skipped"
+            )
+        )
+        return
+    since_iso = rep.since.isoformat()
+    rc, out = git(
+        ["log", f"--since={since_iso}", "--format=%h%x1f%s%x1f%b%x1e", "-n", "200"],
+        rep.root,
+    )
+    if rc != 0:
+        rep.add(Check("commits", "warn", "git log failed", [out]))
+        return
+    subjects: list[str] = []
+    shas: list[str] = []
+    sid = rep.harness.session_id
+    records = [r for r in out.split("\x1e") if r.strip()]
+    tagged = []
+    for r in records:
+        parts = r.strip("\n").split("\x1f")
+        if len(parts) < 2:
+            continue
+        sha, subject = parts[0], parts[1]
+        body = parts[2] if len(parts) > 2 else ""
+        if sid and sid[:8] in body:
+            tagged.append((sha, subject))
+        subjects.append(f"{sha} {subject}")
+        shas.append(sha)
+    # If any commit carries this session's id, trust the tag over the time window.
+    if tagged:
+        subjects = [f"{s} {j}" for s, j in tagged]
+        shas = [s for s, _ in tagged]
+    rep.commits = subjects
+    if shas:
+        rc, out = git(["diff", "--shortstat", f"{shas[-1]}^", shas[0]], rep.root)
+        m = re.search(r"(\d+) files? changed", out) if rc == 0 else None
+        rep.files_changed = int(m.group(1)) if m else 0
+    rep.add(
+        Check(
+            "commits",
+            "info",
+            f"{len(subjects)} commit(s) attributed to this session",
+            subjects[:20],
+        )
+    )
+
+
+def _newest_commit_date(cwd: Path, rev_range: list[str]) -> datetime | None:
+    rc, out = git(["log", *rev_range, "--format=%cI", "-n", "50"], cwd)
+    if rc != 0:
+        return None
+    newest = None
+    for line in out.splitlines():
+        try:
+            dt = datetime.fromisoformat(line.strip())
+        except ValueError:
+            continue
+        if newest is None or dt > newest:
+            newest = dt
+    return newest
+
+
+def check_unpushed(rep: Report, cwd: Path, label: str) -> tuple[Check, datetime | None]:
+    """Returns the check plus the newest unpushed commit date (None if nothing unpushed)."""
+    rc, up = git(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"], cwd)
+    if rc != 0:
+        rc2, cnt = git(["rev-list", "--count", "HEAD", "--not", "--remotes"], cwd)
+        n = int(cnt) if rc2 == 0 and cnt.isdigit() else 0
+        if n:
+            newest = _newest_commit_date(cwd, ["HEAD", "--not", "--remotes"])
+            return (
+                Check(
+                    label,
+                    "block",
+                    f"branch has no upstream and {n} commit(s) not on any remote",
+                    ["publish it: git push -u origin HEAD"],
+                ),
+                newest,
+            )
+        return Check(label, "ok", "no upstream, nothing unpublished"), None
+    rc, out = git(["log", "@{u}..HEAD", "--format=%h %s"], cwd)
+    lines = [ln for ln in out.splitlines() if ln.strip()] if rc == 0 else []
+    if lines:
+        newest = _newest_commit_date(cwd, ["@{u}..HEAD"])
+        return (
+            Check(
+                label, "block", f"{len(lines)} commit(s) not pushed to {up}", lines[:20]
+            ),
+            newest,
+        )
+    return Check(label, "ok", f"in sync with {up}"), None
+
+
+def check_worktrees(rep: Report) -> None:
+    rc, out = git(["worktree", "list", "--porcelain"], rep.root)
+    if rc != 0:
+        return
+    paths: list[Path] = []
+    for block in out.split("\n\n"):
+        for line in block.splitlines():
+            if line.startswith("worktree "):
+                p = Path(line[len("worktree ") :])
+                if p.resolve() != rep.root.resolve():
+                    paths.append(p)
+    blocked: list[str] = []
+    infos: list[str] = []
+    for wt in paths:
+        if not wt.exists():
+            infos.append(f"{wt} (missing on disk — `git worktree prune`)")
+            continue
+        # Display the checkout path, not a gitdir (submodule main checkouts list as .git/modules/...)
+        rc, top = git(["rev-parse", "--show-toplevel"], wt)
+        shown = top if rc == 0 and top else str(wt)
+        mine, others, _, err = _dirty_entries(wt, rep.since)
+        if err is not None:
+            infos.append(f"{shown}: git status failed")
+            continue
+        unpushed, newest = check_unpushed(rep, wt, "worktree")
+        unpushed_recent = unpushed.status == "block" and (
+            rep.since is None or newest is None or newest >= rep.since
+        )
+        recent_problems: list[str] = []
+        old_problems: list[str] = []
+        if mine:
+            recent_problems.append(f"{len(mine)} uncommitted change(s)")
+        elif others:
+            old_problems.append(f"{len(others)} uncommitted change(s)")
+        if unpushed.status == "block":
+            (recent_problems if unpushed_recent else old_problems).append(
+                unpushed.summary
+            )
+        if recent_problems:
+            blocked.append(f"{shown}: {', '.join(recent_problems)}")
+        elif old_problems:
+            infos.append(
+                f"{shown}: {', '.join(old_problems)} (older than this session)"
+            )
+    if blocked:
+        rep.add(
+            Check(
+                "worktrees",
+                "block",
+                f"{len(blocked)} worktree(s) with unsaved work from this session",
+                blocked,
+            )
+        )
+    elif infos:
+        rep.add(
+            Check("worktrees", "info", "other worktrees with leftover state", infos)
+        )
+    elif paths:
+        rep.add(Check("worktrees", "ok", f"{len(paths)} linked worktree(s), all clean"))
+
+
+def check_journal(rep: Report) -> None:
+    jdir = rep.root / "journal"
+    if not jdir.is_dir():
+        return
+    today = datetime.now().strftime("%Y-%m-%d")
+    today_dir = jdir / today
+    recent = []
+    if today_dir.is_dir():
+        for f in today_dir.glob("*.md"):
+            if _touched_this_session(f, rep.since):
+                recent.append(str(f.relative_to(rep.root)))
+    did_work = bool(rep.commits) or any(
+        c.name == "uncommitted" and c.status == "block" for c in rep.checks
+    )
+    if recent:
+        rep.add(Check("journal", "ok", "journal entry written this session", recent))
+    elif did_work:
+        rep.add(
+            Check(
+                "journal",
+                "block",
+                f"work happened this session but no journal entry in journal/{today}/",
+                [f"write journal/{today}/<session-file>.md before ending"],
+            )
+        )
+    else:
+        rep.add(
+            Check("journal", "info", "no journal entry (no attributed work either)")
+        )
+
+
+def check_prs(rep: Report, timeout: int = 20) -> None:
+    if not shutil.which("gh"):
+        rep.add(Check("prs", "info", "gh not installed — PR check skipped"))
+        return
+    since_day = (
+        rep.since or (datetime.now(timezone.utc) - timedelta(days=1))
+    ).strftime("%Y-%m-%d")
+    try:
+        p = subprocess.run(
+            [
+                "gh",
+                "search",
+                "prs",
+                "--author=@me",
+                "--state=open",
+                f"--created=>={since_day}",
+                "--json",
+                "url,title,number,repository",
+                "--limit",
+                "20",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as e:
+        rep.add(Check("prs", "info", f"gh search failed: {e}"))
+        return
+    if p.returncode != 0:
+        rep.add(
+            Check("prs", "info", "gh search failed (auth?)", [p.stderr.strip()[:200]])
+        )
+        return
+    try:
+        prs = json.loads(p.stdout or "[]")
+    except json.JSONDecodeError:
+        prs = []
+    if not prs:
+        rep.add(Check("prs", "ok", "no open PRs opened since session start"))
+        return
+    red: list[str] = []
+    listing: list[str] = []
+    for pr in prs[:10]:
+        url = pr.get("url", "")
+        repo = (pr.get("repository") or {}).get("nameWithOwner", "")
+        listing.append(f"{repo}#{pr.get('number')} {pr.get('title', '')} — {url}")
+        try:
+            c = subprocess.run(
+                ["gh", "pr", "checks", url],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+            )
+            if c.returncode != 0 and "fail" in (c.stdout + c.stderr).lower():
+                red.append(f"{repo}#{pr.get('number')}: failing checks")
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+    rep.prs = prs
+    if red:
+        rep.add(
+            Check("prs", "warn", f"{len(red)} PR(s) with failing CI", red + listing)
+        )
+    else:
+        rep.add(
+            Check("prs", "info", f"{len(prs)} open PR(s) from this session", listing)
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Verdict + rendering
+# --------------------------------------------------------------------------- #
+
+
+def decide(rep: Report, light_commits: int, light_files: int) -> None:
+    if rep.blockers:
+        rep.verdict = "BLOCKED"
+        rep.reason = "; ".join(c.summary for c in rep.blockers)
+        return
+    substantial = (
+        len(rep.commits) > light_commits
+        or rep.files_changed > light_files
+        or bool(rep.prs)
+        or any(c.name == "worktrees" and c.status != "ok" for c in rep.checks)
+        or any(c.status == "warn" for c in rep.checks)
+    )
+    if substantial:
+        rep.verdict = "CLEAN_SUBSTANTIAL"
+        rep.reason = (
+            f"{len(rep.commits)} commit(s), {rep.files_changed} file(s), "
+            f"{len(rep.prs)} PR(s) — worth a human look before closing"
+        )
+    else:
+        rep.verdict = "CLEAN_LIGHT"
+        rep.reason = f"{len(rep.commits)} commit(s), {rep.files_changed} file(s), nothing pending"
+
+
+STATUS_ICON = {"ok": "✅", "info": "ℹ️ ", "warn": "⚠️ ", "block": "❌"}
+
+
+def render(rep: Report) -> str:
+    h = rep.harness
+    lines = [
+        f"# /end check — {rep.root}",
+        f"harness: {h.name}" + (f" (pid {h.pid})" if h.pid else ""),
+        f"session start: {rep.since.isoformat(timespec='seconds') if rep.since else 'unknown'}"
+        f" [{rep.since_source}]",
+        "",
+    ]
+    for c in rep.checks:
+        lines.append(f"{STATUS_ICON.get(c.status, '•')} {c.name}: {c.summary}")
+        for it in c.items:
+            lines.append(f"      - {it}")
+    lines.append("")
+    lines.append(f"VERDICT: {rep.verdict} — {rep.reason}")
+    if rep.verdict == "BLOCKED":
+        lines.append("→ Do NOT wrap up. Fix the ❌ items, then re-run this check.")
+    elif rep.verdict == "CLEAN_LIGHT":
+        lines.append(
+            "→ Write the closing summary, then exit the harness (scripts/end-exit.py)."
+        )
+    else:
+        lines.append(
+            "→ Write the closing summary + hand-off and STAY ALIVE for review."
+        )
+    return "\n".join(lines)
+
+
+def to_json(rep: Report) -> dict:
+    return {
+        "root": str(rep.root),
+        "harness": {
+            "name": rep.harness.name,
+            "pid": rep.harness.pid,
+            "session_id": rep.harness.session_id,
+            "started_at": rep.harness.started_at.isoformat()
+            if rep.harness.started_at
+            else None,
+        },
+        "since": rep.since.isoformat() if rep.since else None,
+        "since_source": rep.since_source,
+        "checks": [
+            {"name": c.name, "status": c.status, "summary": c.summary, "items": c.items}
+            for c in rep.checks
+        ],
+        "commits": rep.commits,
+        "files_changed": rep.files_changed,
+        "prs": rep.prs,
+        "verdict": rep.verdict,
+        "reason": rep.reason,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument(
+        "--workspace", type=Path, default=Path.cwd(), help="any path inside the repo"
+    )
+    ap.add_argument(
+        "--since",
+        help="session start: ISO-8601 or relative (90m, 2h). Default: harness process start",
+    )
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    ap.add_argument("--no-prs", action="store_true", help="skip the gh PR check")
+    ap.add_argument(
+        "--light-commits",
+        type=int,
+        default=2,
+        help="max commits for CLEAN_LIGHT (default 2)",
+    )
+    ap.add_argument(
+        "--light-files",
+        type=int,
+        default=10,
+        help="max files changed for CLEAN_LIGHT (default 10)",
+    )
+    args = ap.parse_args(argv)
+
+    root = repo_root(args.workspace)
+    if root is None:
+        print(
+            f"error: {args.workspace} is not inside a git repository", file=sys.stderr
+        )
+        return 1
+
+    harness = find_harness()
+    if args.since:
+        since, source = parse_since(args.since), "--since"
+    elif harness.started_at:
+        since, source = harness.started_at, f"{harness.name} process start"
+    else:
+        since, source = None, "unknown (all dirty files count as this session's)"
+
+    rep = Report(harness=harness, root=root, since=since, since_source=source)
+    check_dirty(rep)
+    check_commits(rep)
+    rep.add(check_unpushed(rep, root, "unpushed")[0])
+    check_worktrees(rep)
+    check_journal(rep)
+    if not args.no_prs:
+        check_prs(rep)
+    decide(rep, args.light_commits, args.light_files)
+
+    if args.json:
+        print(json.dumps(to_json(rep), indent=2))
+    else:
+        print(render(rep))
+    return 2 if rep.verdict == "BLOCKED" else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/end/scripts/end-exit.py
+++ b/skills/end/scripts/end-exit.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Exit the harness that is running this session (the `/end` skill's last step).
+
+Finds the interactive harness process (Claude Code, gptme, Codex) that owns
+this shell — via CLAUDE_PID or the /proc parent chain — and schedules a
+SIGTERM to it from a detached helper, so the tool call that launched us
+returns cleanly before the process goes away.
+
+    end-exit.py --dry-run     # show which process would be terminated
+    end-exit.py               # terminate after a 3s grace period
+    end-exit.py --delay 10    # longer grace period
+    end-exit.py --pid 12345   # override discovery (refuses pid 1 / self)
+
+Caveats (honest ones):
+  * Claude Code exits with status 143 on SIGTERM (verified 2.1.239). Session
+    state is already on disk; `claude --resume` still works.
+  * gptme's `/exit` runs SESSION_END hooks; SIGTERM does not. Conversation
+    logs are written per message, so nothing is lost, but hook side effects
+    (e.g. session-end summaries) are skipped. Prefer the native `/exit` when
+    a human is at the keyboard.
+  * Non-interactive runs (`claude -p`, `gptme -n`, `codex exec`) exit on their
+    own when the turn ends — this script is a no-op there by design
+    (`--if-interactive` is the default).
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+
+def _load_check_module():
+    spec = importlib.util.spec_from_file_location("end_check", HERE / "end-check.py")
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod  # dataclasses need the module importable
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _is_interactive(pid: int) -> bool:
+    """Best-effort: does the harness own a terminal?"""
+    try:
+        stat = Path(f"/proc/{pid}/stat").read_text()
+        tty_nr = int(stat.rsplit(")", 1)[1].split()[4])
+        return tty_nr != 0
+    except (OSError, ValueError, IndexError):
+        return True  # unknown → assume interactive (safer: don't silently skip)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument(
+        "--delay", type=float, default=3.0, help="grace period in seconds (default 3)"
+    )
+    ap.add_argument("--pid", type=int, help="override harness pid discovery")
+    ap.add_argument("--signal", default="TERM", choices=["TERM", "INT", "HUP"])
+    ap.add_argument(
+        "--even-if-noninteractive",
+        action="store_true",
+        help="send the signal even when the harness has no controlling tty",
+    )
+    args = ap.parse_args(argv)
+
+    check = _load_check_module()
+    h = check.find_harness()
+    pid = args.pid or h.pid
+    if not pid:
+        print(
+            f"end-exit: no harness process found (detected: {h.name}); nothing to do",
+            file=sys.stderr,
+        )
+        return 1
+    if pid in (0, 1, os.getpid(), os.getppid()) and not args.pid:
+        print(f"end-exit: refusing to signal pid {pid}", file=sys.stderr)
+        return 1
+    cmd = " ".join(check._proc_cmdline(pid))[:160]
+    interactive = _is_interactive(pid)
+    print(f"harness: {h.name} pid={pid} interactive={interactive}")
+    print(f"cmdline: {cmd}")
+    if not interactive and not args.even_if_noninteractive:
+        print(
+            "non-interactive run — it exits on its own when this turn ends; not signalling."
+        )
+        return 0
+    if args.dry_run:
+        print(f"dry-run: would send SIG{args.signal} in {args.delay:g}s")
+        return 0
+    helper = f"sleep {args.delay:g}; kill -{args.signal} {pid}"
+    subprocess.Popen(
+        ["sh", "-c", helper],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    print(
+        f"SIG{args.signal} scheduled for pid {pid} in {args.delay:g}s — session ending."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/end/scripts/end-exit.py
+++ b/skills/end/scripts/end-exit.py
@@ -80,7 +80,7 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
         return 1
-    if pid in (0, 1, os.getpid(), os.getppid()) and not args.pid:
+    if pid <= 0 or pid == 1 or pid in (os.getpid(), os.getppid()):
         print(f"end-exit: refusing to signal pid {pid}", file=sys.stderr)
         return 1
     cmd = " ".join(check._proc_cmdline(pid))[:160]

--- a/tests/test_end_skill.py
+++ b/tests/test_end_skill.py
@@ -1,0 +1,243 @@
+"""Tests for skills/end: the wrap-up gate (end-check.py) and exit helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+SKILL_DIR = Path(__file__).resolve().parents[1] / "skills" / "end"
+CHECK = SKILL_DIR / "scripts" / "end-check.py"
+EXIT = SKILL_DIR / "scripts" / "end-exit.py"
+
+
+def _load(path: Path):
+    spec = importlib.util.spec_from_file_location(path.stem.replace("-", "_"), path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod  # dataclasses need the module importable
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def check():
+    return _load(CHECK)
+
+
+GIT_ISOLATION = ["-c", "core.hooksPath=/dev/null", "-c", "commit.gpgsign=false"]
+
+
+def _git(cwd: Path, *args: str) -> str:
+    """git with global hooks/signing disabled (the host's identity hook rejects temp repos)."""
+    env = {**os.environ, "ALLOW_GIT_IDENTITY": "1"}
+    return subprocess.run(
+        ["git", *GIT_ISOLATION, *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    ).stdout.strip()
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A repo with an upstream so @{u} resolves."""
+    origin = tmp_path / "origin.git"
+    _git(tmp_path, "init", "-q", "--bare", str(origin))
+    work = tmp_path / "work"
+    _git(tmp_path, "clone", "-q", str(origin), str(work))
+    _git(work, "config", "user.email", "t@example.com")
+    _git(work, "config", "user.name", "t")
+    (work / "README.md").write_text("hi\n")
+    _git(work, "add", "README.md")
+    _git(work, "commit", "-q", "-m", "init")
+    _git(work, "push", "-q", "-u", "origin", "HEAD:master")
+    return work
+
+
+def run_check(work: Path, *extra: str) -> tuple[int, dict]:
+    p = subprocess.run(
+        [
+            sys.executable,
+            str(CHECK),
+            "--workspace",
+            str(work),
+            "--json",
+            "--no-prs",
+            *extra,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert p.stdout, p.stderr
+    return p.returncode, json.loads(p.stdout)
+
+
+def _status(rep: dict, name: str) -> str | None:
+    for c in rep["checks"]:
+        if c["name"] == name:
+            return str(c["status"])
+    return None
+
+
+def test_clean_repo_is_clean_light(repo: Path):
+    rc, rep = run_check(repo, "--since", "1h")
+    assert rc == 0
+    assert rep["verdict"] == "CLEAN_LIGHT", rep
+    assert _status(rep, "uncommitted") == "ok"
+    assert _status(rep, "unpushed") == "ok"
+
+
+def test_uncommitted_file_blocks(repo: Path):
+    (repo / "new.txt").write_text("x\n")
+    rc, rep = run_check(repo, "--since", "1h")
+    assert rc == 2
+    assert rep["verdict"] == "BLOCKED"
+    assert _status(rep, "uncommitted") == "block"
+    assert any("new.txt" in it for c in rep["checks"] for it in c["items"])
+
+
+def test_old_dirt_is_info_not_block(repo: Path):
+    """A dirty file older than the session window is another session's problem."""
+    f = repo / "old.txt"
+    f.write_text("x\n")
+    old = (datetime.now(timezone.utc) - timedelta(hours=5)).timestamp()
+    os.utime(f, (old, old))
+    rc, rep = run_check(repo, "--since", "1h")
+    assert rc == 0, rep
+    assert _status(rep, "uncommitted") == "ok"
+    assert _status(rep, "uncommitted-other") == "info"
+
+
+def test_unpushed_commit_blocks(repo: Path):
+    (repo / "a.txt").write_text("a\n")
+    _git(repo, "add", "a.txt")
+    _git(repo, "commit", "-q", "-m", "feat: a")
+    rc, rep = run_check(repo, "--since", "1h")
+    assert rc == 2
+    assert _status(rep, "unpushed") == "block"
+    assert any("feat: a" in c for c in rep["commits"])
+
+
+def test_journal_required_when_work_happened(repo: Path):
+    (repo / "journal").mkdir()
+    (repo / "a.txt").write_text("a\n")
+    _git(repo, "add", "a.txt")
+    _git(repo, "commit", "-q", "-m", "feat: a")
+    _git(repo, "push", "-q")
+    rc, rep = run_check(repo, "--since", "1h")
+    assert rc == 2
+    assert _status(rep, "journal") == "block"
+    # Writing today's entry (and committing+pushing it) clears the gate.
+    today = datetime.now().strftime("%Y-%m-%d")
+    jf = repo / "journal" / today / "session.md"
+    jf.parent.mkdir(parents=True)
+    jf.write_text("# done\n")
+    _git(repo, "add", str(jf))
+    _git(repo, "commit", "-q", "-m", "journal")
+    _git(repo, "push", "-q")
+    rc, rep = run_check(repo, "--since", "1h")
+    assert rc == 0, rep
+    assert _status(rep, "journal") == "ok"
+
+
+def test_substantial_session_stays_alive(repo: Path):
+    for i in range(3):
+        (repo / f"f{i}.txt").write_text(f"{i}\n")
+        _git(repo, "add", f"f{i}.txt")
+        _git(repo, "commit", "-q", "-m", f"feat: f{i}")
+    _git(repo, "push", "-q")
+    rc, rep = run_check(repo, "--since", "1h")
+    assert rc == 0
+    assert rep["verdict"] == "CLEAN_SUBSTANTIAL"
+    rc, rep = run_check(repo, "--since", "1h", "--light-commits", "5")
+    assert rep["verdict"] == "CLEAN_LIGHT"
+
+
+def test_dirty_worktree_blocks(repo: Path, tmp_path: Path):
+    wt = tmp_path / "wt"
+    _git(repo, "worktree", "add", "-q", "-b", "feature", str(wt))
+    (wt / "wip.txt").write_text("wip\n")
+    rc, rep = run_check(repo, "--since", "1h")
+    assert rc == 2
+    assert _status(rep, "worktrees") == "block"
+    assert any(str(wt) in it for c in rep["checks"] for it in c["items"])
+
+
+def test_parse_since(check):
+    now = datetime.now(timezone.utc)
+    assert now - check.parse_since("90m") < timedelta(minutes=91)
+    assert check.parse_since("2026-01-01T00:00:00Z").tzinfo is not None
+    assert check.parse_since("2026-01-01T00:00:00").tzinfo is not None
+
+
+def test_classify_cmdline(check):
+    assert (
+        check._classify_cmdline(["claude", "--dangerously-skip-permissions"])
+        == "claude-code"
+    )
+    assert (
+        check._classify_cmdline(["node", "/usr/lib/node_modules/.bin/claude"])
+        == "claude-code"
+    )
+    assert check._classify_cmdline(["/home/x/.local/bin/gptme", "-n"]) == "gptme"
+    assert check._classify_cmdline(["codex"]) == "codex"
+    assert check._classify_cmdline(["bash", "-c", "claude"]) is None
+    assert check._classify_cmdline([]) is None
+
+
+def test_exit_dry_run_never_signals(tmp_path: Path):
+    """--dry-run with an explicit pid reports the target and sends nothing."""
+    victim = subprocess.Popen(["sleep", "30"])
+    try:
+        p = subprocess.run(
+            [
+                sys.executable,
+                str(EXIT),
+                "--dry-run",
+                "--pid",
+                str(victim.pid),
+                "--even-if-noninteractive",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert p.returncode == 0, p.stderr
+        assert "dry-run" in p.stdout
+        assert victim.poll() is None
+    finally:
+        victim.kill()
+
+
+def test_exit_signals_target_after_delay():
+    victim = subprocess.Popen(["sleep", "30"])
+    try:
+        p = subprocess.run(
+            [
+                sys.executable,
+                str(EXIT),
+                "--pid",
+                str(victim.pid),
+                "--delay",
+                "0.2",
+                "--even-if-noninteractive",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert p.returncode == 0, p.stderr
+        assert victim.wait(timeout=5) == -15  # SIGTERM
+    finally:
+        if victim.poll() is None:
+            victim.kill()

--- a/tests/test_end_skill.py
+++ b/tests/test_end_skill.py
@@ -182,6 +182,36 @@ def test_substantial_session_stays_alive(repo: Path):
     assert rep["verdict"] == "CLEAN_LIGHT"
 
 
+def test_paths_scope_commits_unpushed_and_worktrees(repo: Path, tmp_path: Path):
+    # A sibling session's unpushed commit outside the footprint → info, not block
+    (repo / "theirs.txt").write_text("t\n")
+    _git(repo, "add", "theirs.txt")
+    _git(repo, "commit", "-q", "-m", "feat: theirs")
+    rc, rep = run_check(repo, "--since", "1h", "--paths", "mine/")
+    assert rc == 0, rep
+    assert _status(rep, "unpushed") == "info"
+    assert rep["commits"] == []  # commits are attributed by footprint too
+    # Own commit inside the footprint still blocks until pushed
+    (repo / "mine").mkdir()
+    (repo / "mine" / "a.txt").write_text("a\n")
+    _git(repo, "add", "mine/a.txt")
+    _git(repo, "commit", "-q", "-m", "feat: mine")
+    rc, rep = run_check(repo, "--since", "1h", "--paths", "mine/")
+    assert rc == 2 and _status(rep, "unpushed") == "block"
+    assert [c for c in rep["commits"] if "feat: mine" in c] and not [
+        c for c in rep["commits"] if "feat: theirs" in c
+    ]
+    _git(repo, "push", "-q")
+    # Undeclared dirty worktree → info; declared (absolute path in --paths) → block
+    wt = tmp_path / "wt"
+    _git(repo, "worktree", "add", "-q", "-b", "feature", str(wt))
+    (wt / "wip.txt").write_text("wip\n")
+    rc, rep = run_check(repo, "--since", "1h", "--paths", "mine/")
+    assert rc == 0 and _status(rep, "worktrees") == "info"
+    rc, rep = run_check(repo, "--since", "1h", "--paths", "mine/", str(wt))
+    assert rc == 2 and _status(rep, "worktrees") == "block"
+
+
 def test_dirty_worktree_blocks(repo: Path, tmp_path: Path):
     wt = tmp_path / "wt"
     _git(repo, "worktree", "add", "-q", "-b", "feature", str(wt))

--- a/tests/test_end_skill.py
+++ b/tests/test_end_skill.py
@@ -63,7 +63,7 @@ def repo(tmp_path: Path) -> Path:
     return work
 
 
-def run_check(work: Path, *extra: str) -> tuple[int, dict]:
+def run_check(work: Path, *extra: str, env: dict | None = None) -> tuple[int, dict]:
     p = subprocess.run(
         [
             sys.executable,
@@ -77,9 +77,26 @@ def run_check(work: Path, *extra: str) -> tuple[int, dict]:
         capture_output=True,
         text=True,
         check=False,
+        env=env,
     )
     assert p.stdout, p.stderr
     return p.returncode, json.loads(p.stdout)
+
+
+def _env_without_cc_session() -> dict:
+    """Strip Claude Code session vars to simulate a gptme / Codex harness."""
+    return {
+        k: v
+        for k, v in os.environ.items()
+        if k
+        not in (
+            "CC_SESSION_ID",
+            "CLAUDE_CODE_SESSION_ID",
+            "CLAUDECODE",
+            "CLAUDE_CODE_ENTRYPOINT",
+            "CC_MODEL",
+        )
+    }
 
 
 def _status(rep: dict, name: str) -> str | None:
@@ -283,6 +300,55 @@ def test_exit_dry_run_never_signals(tmp_path: Path):
         assert victim.poll() is None
     finally:
         victim.kill()
+
+
+def test_no_session_id_recent_commit_not_attributed(tmp_path: Path):
+    """P1: without a session_id (gptme/Codex env), recent commits must not block.
+
+    When no CC_SESSION_ID is present, `check_commits` cannot distinguish this
+    session's commits from a sibling's or from pre-session repository activity.
+    The old code attributed every time-window commit to this session, which
+    blocked sessions that did nothing just because the repo had recent commits.
+    """
+    origin = tmp_path / "origin.git"
+    _git(tmp_path, "init", "-q", "--bare", str(origin))
+    work = tmp_path / "work"
+    _git(tmp_path, "clone", "-q", str(origin), str(work))
+    _git(work, "config", "user.email", "t@example.com")
+    _git(work, "config", "user.name", "t")
+    (work / "README.md").write_text("hi\n")
+    _git(work, "add", "README.md")
+    _git(work, "commit", "-q", "-m", "feat: pre-session commit")
+    _git(work, "push", "-q", "-u", "origin", "HEAD:master")
+    # Journal dir exists; this is what triggers the false BLOCKED when
+    # did_work=True leaks in from unattributed commits.
+    (work / "journal").mkdir()
+    # Strip CC session env vars to simulate gptme / Codex (no session_id).
+    env = _env_without_cc_session()
+    rc, rep = run_check(work, "--since", "1h", env=env)
+    assert rc == 0, rep
+    assert rep["commits"] == [], "without session_id, no commits should be attributed"
+
+
+def test_root_commit_files_changed_counted(tmp_path: Path):
+    """P2: a session whose only commit is the root commit must have files_changed > 0."""
+    origin = tmp_path / "origin.git"
+    _git(tmp_path, "init", "-q", "--bare", str(origin))
+    work = tmp_path / "work"
+    _git(tmp_path, "clone", "-q", str(origin), str(work))
+    _git(work, "config", "user.email", "t@example.com")
+    _git(work, "config", "user.name", "t")
+    for i in range(15):
+        (work / f"f{i}.txt").write_text(f"{i}\n")
+    _git(work, "add", ".")
+    _git(work, "commit", "-q", "-m", "feat: init 15 files")
+    _git(work, "push", "-q", "-u", "origin", "HEAD:master")
+    rc, rep = run_check(work, "--since", "1h")
+    assert rc == 0, rep
+    assert (
+        rep["files_changed"] >= 15
+    ), "root commit files must be counted via empty-tree diff"
+    assert rep["verdict"] == "CLEAN_SUBSTANTIAL"
 
 
 def test_exit_signals_target_after_delay():

--- a/tests/test_end_skill.py
+++ b/tests/test_end_skill.py
@@ -63,7 +63,15 @@ def repo(tmp_path: Path) -> Path:
     return work
 
 
+_DEFAULT_SESSION_ID = "test-fixture-session-00000000"
+
+
 def run_check(work: Path, *extra: str, env: dict | None = None) -> tuple[int, dict]:
+    # Inject a fake session ID so commit attribution works in CI (which has no
+    # CC_SESSION_ID).  Tests that deliberately strip it pass env= explicitly.
+    base_env = (
+        {**os.environ, "CC_SESSION_ID": _DEFAULT_SESSION_ID} if env is None else env
+    )
     p = subprocess.run(
         [
             sys.executable,
@@ -77,7 +85,7 @@ def run_check(work: Path, *extra: str, env: dict | None = None) -> tuple[int, di
         capture_output=True,
         text=True,
         check=False,
-        env=env,
+        env=base_env,
     )
     assert p.stdout, p.stderr
     return p.returncode, json.loads(p.stdout)

--- a/tests/test_end_skill.py
+++ b/tests/test_end_skill.py
@@ -118,6 +118,25 @@ def test_old_dirt_is_info_not_block(repo: Path):
     assert _status(rep, "uncommitted-other") == "info"
 
 
+def test_paths_scope_ignores_sibling_dirt(repo: Path):
+    """--paths: dirt outside the declared scope is info even inside the time window."""
+    (repo / "mine.txt").write_text("m\n")
+    (repo / "theirs.txt").write_text("t\n")
+    rc, rep = run_check(repo, "--since", "1h", "--paths", "theirs.txt")
+    assert rc == 2 and _status(rep, "uncommitted") == "block"
+    rc, rep = run_check(repo, "--since", "1h", "--paths", "docs/")
+    assert rc == 0, rep
+    assert _status(rep, "uncommitted") == "ok"
+    assert _status(rep, "uncommitted-other") == "info"
+    # absolute paths inside the repo are accepted too
+    rc, rep = run_check(repo, "--since", "1h", "--paths", str(repo / "mine.txt"))
+    assert rc == 2
+    items = [
+        it for c in rep["checks"] if c["name"] == "uncommitted" for it in c["items"]
+    ]
+    assert items == ["?? mine.txt"]
+
+
 def test_unpushed_commit_blocks(repo: Path):
     (repo / "a.txt").write_text("a\n")
     _git(repo, "add", "a.txt")

--- a/tests/test_end_skill.py
+++ b/tests/test_end_skill.py
@@ -118,6 +118,23 @@ def test_old_dirt_is_info_not_block(repo: Path):
     assert _status(rep, "uncommitted-other") == "info"
 
 
+def test_staged_old_file_blocks(repo: Path):
+    """A staged file with an old mtime (content pre-dates session) still blocks."""
+    f = repo / "staged.txt"
+    f.write_text("x\n")
+    old = (datetime.now(timezone.utc) - timedelta(hours=5)).timestamp()
+    os.utime(f, (old, old))
+    # Without staging: old file is "info" (other session's dirt)
+    rc, rep = run_check(repo, "--since", "1h")
+    assert rc == 0 and _status(rep, "uncommitted-other") == "info"
+    # After explicit git add: staged index change must block regardless of mtime
+    _git(repo, "add", "staged.txt")
+    rc, rep = run_check(repo, "--since", "1h")
+    assert rc == 2, rep
+    assert _status(rep, "uncommitted") == "block"
+    assert any("staged.txt" in it for c in rep["checks"] for it in c["items"])
+
+
 def test_paths_scope_ignores_sibling_dirt(repo: Path):
     """--paths: dirt outside the declared scope is info even inside the time window."""
     (repo / "mine.txt").write_text("m\n")


### PR DESCRIPTION
## Summary

A user-invocable skill that makes "I'm done" a checked claim: `/end` runs a wrap-up gate, **refuses** to end with unsaved work, writes a standalone closeout, and exits the harness only when the session was light (stays alive for human review when it was substantial).

Works from every harness with one shared SKILL.md:
- **Claude Code**: `/end` (symlink into `~/.claude/skills/end` or project `.claude/skills/end`; CC follows symlinks)
- **Codex**: `/end` / `$end` via `~/.codex/skills/end` (skills are slash-command packages there)
- **gptme**: `/skill:end` once gptme/gptme#3587 lands (skills as slash commands); until then the `when_to_use` matcher loads it on "wrap up the session"

## Changes

- `skills/end/SKILL.md` — the procedure: gate → refuse/fix → closeout (≤12 lines) → exit decision table; `--exit` / `--stay` / `--dry-run` args; anti-rationalization table.
- `skills/end/scripts/end-check.py` — stdlib-only gate. Finds the harness (`CLAUDE_PID` or `/proc` parent chain) and uses its process start as the session window, so other sessions' dirt in a shared worktree is **info**, not a blocker. Checks: uncommitted files touched this session, unpushed commits, dirty/unpushed linked worktrees, today's journal entry (only when `journal/` exists), open PRs with red CI (gh, optional). Verdicts `BLOCKED` / `CLEAN_LIGHT` / `CLEAN_SUBSTANTIAL`, exit code 2 when blocked, `--json` for machines.
- `skills/end/scripts/end-exit.py` — schedules SIGTERM to the interactive harness from a detached helper (tool call returns first). No-op for non-interactive runs (`claude -p`, `gptme -n`, `codex exec`). Verified: Claude Code 2.1.239 exits 143 cleanly on SIGTERM.
- `skills/end/install.sh` — idempotent symlink installer for `~/.claude/skills`, `~/.codex/skills`, and (`--project`) the repo's `.claude/skills`.
- `tests/test_end_skill.py` — 11 tests against temp repos with a real upstream (clean → CLEAN_LIGHT, uncommitted → BLOCKED, old dirt → info, unpushed → BLOCKED, journal gate, substantial threshold, dirty worktree, harness classification, exit dry-run vs real signal).

## Test plan

- [x] `uv run pytest tests/test_end_skill.py` — 11 passed
- [x] ruff / mypy / shellcheck / skill validator clean (prek passes)
- [x] Live run in the authoring session: correctly returned `BLOCKED` on the skill's own uncommitted files; `end-exit.py --dry-run` identified the right `claude` pid
- [ ] CI

https://claude.ai/code/session_01DqT2GsYkSNsuo1bfU6onZD