### PR TITLE
feat(pm): route ai-review fix dispatches through the in-band review-and-push wrapper

### DIFF
--- a/packages/gptme-runloops/src/gptme_runloops/prompt_templates.py
+++ b/packages/gptme-runloops/src/gptme_runloops/prompt_templates.py
@@ -465,12 +465,19 @@ _AI_REVIEW_NEEDS_FIX_SECTIONS: dict[str, str] = {
     "assessment": (
         "This PR has a low score from our AI reviewer (not Greptile).\n"
         "**Action**: Read the findings in the summary comment and inline threads,"
-        " fix the real issues, push commits."
+        " fix the real issues, then push via the in-band AI review wrapper\n"
+        "(runs the same reviewer locally BEFORE pushing — findings surface here"
+        " in-session instead of costing a GitHub round-trip + re-dispatch,"
+        " max 2 iterations):\n"
+        "```bash\n"
+        "uv run python3 {pm_review_and_push}\n"
+        "```\n"
+        "If it reports P0/P1 findings, fix them and re-run it; once clean it pushes."
     ),
     "warnings": (
         "Warning: **This is an AI-reviewer dispatch, not Greptile.**"
         " Do NOT trigger Greptile to clear it.\n"
-        "The reviewer runs automatically on the next push"
+        "The reviewer still runs automatically on the push the wrapper makes"
         " — no manual trigger needed or wanted.\n"
         "If you cannot fix the issues in this session, leave it for the next cycle."
     ),
@@ -492,8 +499,13 @@ _AI_REVIEW_NEEDS_IMPROVEMENT_SECTIONS: dict[str, str] = {
     ),
     "warnings": (
         "Warning: **Never push trivial changes just to chase 5/5.**\n"
-        "The AI reviewer runs automatically on the next push"
-        " — no manual trigger needed."
+        "If you do fix something, push via the in-band wrapper so the re-review"
+        " happens in-session:\n"
+        "```bash\n"
+        "uv run python3 {pm_review_and_push}\n"
+        "```\n"
+        "The AI reviewer also runs automatically on any push"
+        " — never trigger it manually."
     ),
 }
 

--- a/packages/gptme-runloops/tests/goldens/prompt_templates/ai_review_needs_fix.alice.txt
+++ b/packages/gptme-runloops/tests/goldens/prompt_templates/ai_review_needs_fix.alice.txt
@@ -11,8 +11,13 @@ gh api repos/ErikBjare/alice/pulls/7/comments \
 ```
 
 This PR has a low score from our AI reviewer (not Greptile).
-**Action**: Read the findings in the summary comment and inline threads, fix the real issues, push commits.
+**Action**: Read the findings in the summary comment and inline threads, fix the real issues, then push via the in-band AI review wrapper
+(runs the same reviewer locally BEFORE pushing — findings surface here in-session instead of costing a GitHub round-trip + re-dispatch, max 2 iterations):
+```bash
+uv run python3 /srv/agents/alice/workspace/scripts/github/pm-review-and-push.py
+```
+If it reports P0/P1 findings, fix them and re-run it; once clean it pushes.
 
 Warning: **This is an AI-reviewer dispatch, not Greptile.** Do NOT trigger Greptile to clear it.
-The reviewer runs automatically on the next push — no manual trigger needed or wanted.
+The reviewer still runs automatically on the push the wrapper makes — no manual trigger needed or wanted.
 If you cannot fix the issues in this session, leave it for the next cycle.

--- a/packages/gptme-runloops/tests/goldens/prompt_templates/ai_review_needs_fix.bob.txt
+++ b/packages/gptme-runloops/tests/goldens/prompt_templates/ai_review_needs_fix.bob.txt
@@ -11,8 +11,13 @@ gh api repos/gptme/gptme-contrib/pulls/1234/comments \
 ```
 
 This PR has a low score from our AI reviewer (not Greptile).
-**Action**: Read the findings in the summary comment and inline threads, fix the real issues, push commits.
+**Action**: Read the findings in the summary comment and inline threads, fix the real issues, then push via the in-band AI review wrapper
+(runs the same reviewer locally BEFORE pushing — findings surface here in-session instead of costing a GitHub round-trip + re-dispatch, max 2 iterations):
+```bash
+uv run python3 /home/bob/bob/scripts/github/pm-review-and-push.py
+```
+If it reports P0/P1 findings, fix them and re-run it; once clean it pushes.
 
 Warning: **This is an AI-reviewer dispatch, not Greptile.** Do NOT trigger Greptile to clear it.
-The reviewer runs automatically on the next push — no manual trigger needed or wanted.
+The reviewer still runs automatically on the push the wrapper makes — no manual trigger needed or wanted.
 If you cannot fix the issues in this session, leave it for the next cycle.

--- a/packages/gptme-runloops/tests/goldens/prompt_templates/ai_review_needs_improvement.alice.txt
+++ b/packages/gptme-runloops/tests/goldens/prompt_templates/ai_review_needs_improvement.alice.txt
@@ -11,4 +11,8 @@ This PR scored 4/5 from our AI reviewer — minor issues. Address them if quick;
 Do NOT re-trigger the reviewer just because you looked at it.
 
 Warning: **Never push trivial changes just to chase 5/5.**
-The AI reviewer runs automatically on the next push — no manual trigger needed.
+If you do fix something, push via the in-band wrapper so the re-review happens in-session:
+```bash
+uv run python3 /srv/agents/alice/workspace/scripts/github/pm-review-and-push.py
+```
+The AI reviewer also runs automatically on any push — never trigger it manually.

--- a/packages/gptme-runloops/tests/goldens/prompt_templates/ai_review_needs_improvement.bob.txt
+++ b/packages/gptme-runloops/tests/goldens/prompt_templates/ai_review_needs_improvement.bob.txt
@@ -11,4 +11,8 @@ This PR scored 4/5 from our AI reviewer — minor issues. Address them if quick;
 Do NOT re-trigger the reviewer just because you looked at it.
 
 Warning: **Never push trivial changes just to chase 5/5.**
-The AI reviewer runs automatically on the next push — no manual trigger needed.
+If you do fix something, push via the in-band wrapper so the re-review happens in-session:
+```bash
+uv run python3 /home/bob/bob/scripts/github/pm-review-and-push.py
+```
+The AI reviewer also runs automatically on any push — never trigger it manually.


### PR DESCRIPTION
## Why

The greptile/cross-repo/local fix prompt arms already instruct pushing via `pm-review-and-push.py` (in-band pre-push AI review, max 2 iterations). The **source=ai-review arms did not** — and those are the arms every real dispatch takes in repos where Greptile is dark (contrib, bob, cloud). So even after the dispatcher started exporting `PM_WORK_TYPE` (arming `PM_INBAND_REVIEW`), the wrapper has never once been invoked: fix sessions push raw, and every review round costs a GitHub round-trip (push → 20-min sweep → activity gate → PM re-dispatch).

Measured cost on gptme/gptme-contrib#1473: **23 review revisions** (marker history caps at 10, so ledgers under-report), ~2 new findings per round, 43 distinct findings, ~0 repeats. In-band iteration bounds that at 2 reviewer turns per dispatch instead of 1.

## What

- `_AI_REVIEW_NEEDS_FIX_SECTIONS`: push via the wrapper (fix → re-run → clean → it pushes).
- `_AI_REVIEW_NEEDS_IMPROVEMENT_SECTIONS`: same, only-if-fixing (keeps the don't-chase-5/5 warning).
- Goldens regenerated; `packages/gptme-runloops` suite: 1049 passed, 1 skipped.

Part of the PR-lifecycle latency work (the fix loop is the dominant segment: contrib p50 3.5h / p90 19h post-08-10).