### PR TITLE
fix(lessons): exclude newline from companion-link path-component regex

### DIFF
--- a/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
+++ b/packages/gptme-lessons-extras/src/gptme_lessons_extras/validate.py
@@ -563,9 +563,15 @@ class LessonValidator:
         # markdown link text/URL boundary — e.g. in "[knowledge/lessons/foo/bar.md](url)"
         # the intermediate pattern [^/]+/ would match "bar.md](../../knowledge/" as a
         # single component, producing a spurious path that does not exist on disk.
+        # Also exclude \n so the pattern does not greedily match across lines — without
+        # this, a lesson whose Related section has both "[knowledge/lessons/X/file.md](url)"
+        # and a nearby "gptme-contrib/lessons/X/file.md" reference can produce a
+        # spurious multi-line match that spans from the URL to the gptme-contrib line,
+        # resulting in a path like "knowledge/lessons/X/file.md)\n- ...gptme-contrib/X/file.md"
+        # which of course does not exist on disk.
         _companion_link_matches = list(
             re.finditer(
-                rf"(knowledge/lessons/(?:[^\]/]+/)*{re.escape(self.filepath.stem)}\.md)",
+                rf"(knowledge/lessons/(?:[^\]/\n]+/)*{re.escape(self.filepath.stem)}\.md)",
                 self.content,
                 re.IGNORECASE,
             )


### PR DESCRIPTION
## Problem

The companion-link path regex `(knowledge/lessons/(?:[^\]/]+/)*{stem}\.md)` uses
`[^\]/]+` as the path-component character class. This class excludes `]` and `/`
but **not `\n`**, so in multi-line input the greedy `+` operator crosses newline
boundaries.

When a lesson's Related section has a companion link immediately followed by another
line whose text contains a `/` before the stem name (e.g. a second reference with
the same stem, or a backtick reference on the next line), the regex constructs a
spurious multi-line path like:

```
knowledge/lessons/patterns/tool-maturation-pattern.md`
- Full design: `knowledge/technical/designs/tool-maturation-pattern.md
```

This spurious string fails `Path.exists()`, triggering a false "non-existent
companion path" error even though the real companion file exists.

## Fix

Add `\n` to the excluded characters in the character class:
```python
# Before (buggy)
rf"(knowledge/lessons/(?:[^\]/]+/)*{re.escape(self.filepath.stem)}\.md)"
# After (fix)
rf"(knowledge/lessons/(?:[^\]/\n]+/)*{re.escape(self.filepath.stem)}\.md)"
```

This correctly confines each path-component match to a single line.

## Impact

Without this fix, lessons with multiple `knowledge/` references in their Related
section fail CI even when the companion file exists on disk. Affected patterns
include backtick references followed by another reference on the next line, and
markdown link display text followed by a companion-shadowing link.