### PR TITLE
feat(activity-summary): add gptme fallback for claude quota exhaustion

### DIFF
--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -265,6 +265,7 @@ def call_claude_code(
                 # Attempt fallback slots (GPTME_CC_FALLBACK_CREDS) before raising.
                 last_non_subscription_error: subprocess.CalledProcessError | None = None
                 saw_empty_response = False
+                saw_fallback_auth_failure = False
                 for fb_cred in _fallback_cred_paths:
                     if not fb_cred.exists():
                         logger.debug("Fallback cred file %s not found, skipping", fb_cred)
@@ -299,14 +300,22 @@ def call_claude_code(
                             break
                         # Check whether this fallback slot is also unavailable.
                         fb_combined = (fb_result.stdout or "") + (fb_result.stderr or "")
-                        if any(marker in fb_combined.lower() for marker in _ALL_SKIP_RETRY_MARKERS):
+                        fb_combined_lower = fb_combined.lower()
+                        if any(marker in fb_combined_lower for marker in _ALL_SKIP_RETRY_MARKERS):
                             logger.warning(
                                 "Fallback slot %s also has a subscription failure",
                                 fb_cred.name,
                             )
+                            # Track auth failures from fallback slots so the signal is not
+                            # lost when the primary slot failed with a different (quota)
+                            # error — callers catching ClaudeAuthExpiredError to trigger
+                            # re-auth must see the correct exception type.
+                            if any(marker in fb_combined_lower for marker in _AUTH_FAILURE_MARKERS):
+                                saw_fallback_auth_failure = True
                             # Clear any prior non-subscription error so the caller receives
-                            # ClaudeQuotaExhaustedError rather than a stale error from
-                            # an earlier fallback that failed for a different reason.
+                            # ClaudeQuotaExhaustedError (or ClaudeAuthExpiredError, if the
+                            # fallback also expired) rather than a stale CalledProcessError
+                            # from an earlier fallback that failed for a different reason.
                             last_non_subscription_error = None
                             break
                         logger.warning(
@@ -393,7 +402,10 @@ def call_claude_code(
                 )
                 _exc_cls = (
                     ClaudeAuthExpiredError
-                    if any(marker in combined_out_lower for marker in _AUTH_FAILURE_MARKERS)
+                    if (
+                        any(marker in combined_out_lower for marker in _AUTH_FAILURE_MARKERS)
+                        or saw_fallback_auth_failure
+                    )
                     else ClaudeQuotaExhaustedError
                 )
                 raise _exc_cls(result.returncode, attempt_cmd, result.stdout, result.stderr)

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -392,9 +392,15 @@ def call_claude_code(
                     raise last_non_subscription_error
                 if saw_empty_response:
                     # Even when a fallback slot returned empty, surface the
-                    # auth-expiry signal from the primary so callers can trigger
-                    # re-auth instead of silently falling back to empty defaults.
-                    if any(marker in combined_out_lower for marker in _AUTH_FAILURE_MARKERS):
+                    # auth-expiry signal from the primary OR any fallback slot so
+                    # callers can trigger re-auth instead of silently falling back
+                    # to empty defaults.  saw_fallback_auth_failure covers the case
+                    # where the auth marker appeared in a fallback slot's output
+                    # (combined_out_lower only holds the primary's output).
+                    if (
+                        any(marker in combined_out_lower for marker in _AUTH_FAILURE_MARKERS)
+                        or saw_fallback_auth_failure
+                    ):
                         raise ClaudeAuthExpiredError(
                             result.returncode, attempt_cmd, result.stdout, result.stderr
                         )

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -352,12 +352,12 @@ def call_claude_code(
                     # narrative to "" — a silent empty summary on quota days.
                     if narrative_key and not gptme_result.get(narrative_key):
                         for alt_key in _SUMMARY_NARRATIVE_KEYS:
-                            if alt_key in gptme_result:
+                            if alt_key != narrative_key and gptme_result.get(alt_key):
                                 gptme_result[narrative_key] = gptme_result.pop(alt_key)
                                 gptme_response = json.dumps(gptme_result)
                                 break
                     _keys = (narrative_key,) if narrative_key else _SUMMARY_NARRATIVE_KEYS
-                    if any(key in gptme_result for key in _keys):
+                    if any(gptme_result.get(key) for key in _keys):
                         logger.warning(
                             "Claude subscriptions unavailable; gptme fallback produced a summary"
                         )

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -17,6 +17,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from gptme_activity_summary.gptme_backend import call_gptme
+
 logger = logging.getLogger(__name__)
 
 # Retry configuration for empty CC responses (nesting detection, transient failures)
@@ -293,6 +295,19 @@ def call_claude_code(
                         max_retries,
                     )
                     return ""
+                # All Claude slots are quota-exhausted. Before surfacing the
+                # permanent failure, try the gptme fallback so summary generation
+                # does not hard-fail on quota days (ErikBjare/bob issue: 5
+                # auto-resolve flips in 8 days). The gptme adapter is best-effort
+                # and returns "" on any failure, so we still raise the original
+                # error if it cannot produce a summary.
+                gptme_response = call_gptme(prompt, timeout=timeout)
+                if gptme_response:
+                    logger.warning("Claude quota exhausted; gptme fallback produced a summary")
+                    return gptme_response
+                logger.error(
+                    "Claude quota exhausted and gptme fallback produced no summary; raising"
+                )
                 raise ClaudeQuotaExhaustedError(
                     result.returncode, attempt_cmd, result.stdout, result.stderr
                 )

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -289,22 +289,22 @@ def call_claude_code(
                         break
                 if last_non_quota_error is not None:
                     raise last_non_quota_error
+                # All Claude slots failed (quota exhaustion and/or empty responses).
+                # Before surfacing the permanent failure, try the gptme fallback so
+                # summary generation does not hard-fail on quota days (ErikBjare/bob
+                # issue: 5 auto-resolve flips in 8 days). The gptme adapter is
+                # best-effort and returns "" on any failure, so the original error
+                # path is preserved when no fallback is available.
+                gptme_response = call_gptme(prompt, timeout=timeout)
+                if gptme_response:
+                    logger.warning("Claude quota exhausted; gptme fallback produced a summary")
+                    return gptme_response
                 if saw_empty_response:
                     logger.error(
                         "Fallback slots returned empty responses after %d attempts",
                         max_retries,
                     )
                     return ""
-                # All Claude slots are quota-exhausted. Before surfacing the
-                # permanent failure, try the gptme fallback so summary generation
-                # does not hard-fail on quota days (ErikBjare/bob issue: 5
-                # auto-resolve flips in 8 days). The gptme adapter is best-effort
-                # and returns "" on any failure, so we still raise the original
-                # error if it cannot produce a summary.
-                gptme_response = call_gptme(prompt, timeout=timeout)
-                if gptme_response:
-                    logger.warning("Claude quota exhausted; gptme fallback produced a summary")
-                    return gptme_response
                 logger.error(
                     "Claude quota exhausted and gptme fallback produced no summary; raising"
                 )

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -25,15 +25,24 @@ logger = logging.getLogger(__name__)
 _MAX_RETRIES = 3
 _RETRY_DELAY_S = 5
 
-# Claude Code output markers for permanent subscription failures on the active
-# slot. Retrying the same slot is futile; callers should try a fallback slot or
-# backend instead. Keep the exact observed prefixes narrow so transient errors
-# still use the normal retry path.
+# Truly permanent subscription failures — quota resets require waiting until
+# the next billing period; org blocks require admin action. Retrying the same
+# slot is futile. Keep prefixes narrow so transient errors use the normal retry path.
 _PERMANENT_SUBSCRIPTION_FAILURE_MARKERS = (
     "you've hit your weekly limit",
     "your organization has disabled claude subscription access",
-    "failed to authenticate: oauth session expired",
 )
+
+# OAuth session expiry is distinct from permanent failures: the session CAN be
+# refreshed via /login. In automated contexts that cannot re-authenticate
+# interactively, retrying the same slot is still futile — but the distinction
+# is preserved so callers that can trigger re-auth may catch
+# ClaudeAuthExpiredError specifically rather than being forced into the
+# ClaudeQuotaExhaustedError path.
+_AUTH_FAILURE_MARKERS = ("failed to authenticate: oauth session expired",)
+
+# Combined set used for skip-retry detection.
+_ALL_SKIP_RETRY_MARKERS = _PERMANENT_SUBSCRIPTION_FAILURE_MARKERS + _AUTH_FAILURE_MARKERS
 
 # Every structured summary produced by this module has one of these narrative
 # fields. Requiring one prevents a JSON-shaped provider error from being treated
@@ -50,6 +59,17 @@ class ClaudeQuotaExhaustedError(subprocess.CalledProcessError):
     Subclasses :class:`subprocess.CalledProcessError` so existing callers that
     catch the base type keep working; callers that can switch to a different slot
     should catch this subtype specifically.
+    """
+
+
+class ClaudeAuthExpiredError(ClaudeQuotaExhaustedError):
+    """OAuth session has expired on the active Claude Code slot.
+
+    Unlike quota exhaustion (which requires waiting for a reset period), auth
+    expiry can be resolved by re-authenticating via ``/login`` or similar.
+    Automated invocations cannot re-authenticate interactively, so retries on
+    the same slot are skipped — but callers that can trigger re-auth should
+    catch this subtype specifically and attempt recovery before falling back.
     """
 
 
@@ -227,9 +247,7 @@ def call_claude_code(
             # Subscription failures are permanent and slot-scoped: retrying the
             # same slot is futile and just burns ~N*delay seconds + token budget.
             # Signal them distinctly so a caller can switch slots or backends.
-            if any(
-                marker in combined_out_lower for marker in _PERMANENT_SUBSCRIPTION_FAILURE_MARKERS
-            ):
+            if any(marker in combined_out_lower for marker in _ALL_SKIP_RETRY_MARKERS):
                 logger.warning(
                     "claude -p subscription unavailable (attempt %d/%d): %s",
                     attempt,
@@ -273,10 +291,7 @@ def call_claude_code(
                             break
                         # Check whether this fallback slot is also unavailable.
                         fb_combined = (fb_result.stdout or "") + (fb_result.stderr or "")
-                        if any(
-                            marker in fb_combined.lower()
-                            for marker in _PERMANENT_SUBSCRIPTION_FAILURE_MARKERS
-                        ):
+                        if any(marker in fb_combined.lower() for marker in _ALL_SKIP_RETRY_MARKERS):
                             logger.warning(
                                 "Fallback slot %s also has a subscription failure",
                                 fb_cred.name,
@@ -335,9 +350,12 @@ def call_claude_code(
                     "Claude subscriptions unavailable and gptme fallback produced no summary; "
                     "raising"
                 )
-                raise ClaudeQuotaExhaustedError(
-                    result.returncode, attempt_cmd, result.stdout, result.stderr
+                _exc_cls = (
+                    ClaudeAuthExpiredError
+                    if any(marker in combined_out_lower for marker in _AUTH_FAILURE_MARKERS)
+                    else ClaudeQuotaExhaustedError
                 )
+                raise _exc_cls(result.returncode, attempt_cmd, result.stdout, result.stderr)
             stderr_preview = result.stderr.strip()[:500] if result.stderr else "(none)"
             stdout_preview = result.stdout.strip()[:500] if result.stdout else "(none)"
             logger.warning(

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -320,14 +320,19 @@ def call_claude_code(
                             time.sleep(_RETRY_DELAY_S * fb_attempt)
                             continue
                         break
-                if last_non_subscription_error is not None:
-                    raise last_non_subscription_error
-                # All Claude slots failed (subscription failures and/or empty responses).
-                # Before surfacing the permanent failure, try the gptme fallback so
-                # summary generation does not hard-fail on quota days (ErikBjare/bob
-                # issue: 5 auto-resolve flips in 8 days). The gptme adapter is
-                # best-effort and returns "" on any failure, so the original error
-                # path is preserved when no fallback is available.
+                # All Claude slots failed (subscription failures, non-subscription
+                # errors, and/or empty responses). Before surfacing any permanent
+                # failure, try the gptme fallback so summary generation does not
+                # hard-fail on quota days (ErikBjare/bob issue: 5 auto-resolve
+                # flips in 8 days). The gptme adapter is best-effort and returns
+                # "" on any failure, so the original error path is preserved when
+                # no fallback is available.
+                #
+                # The gptme fallback is attempted BEFORE raising
+                # last_non_subscription_error so that a misconfigured fallback
+                # credential slot (e.g. stale auth, returncode=2) does not
+                # prevent gptme from producing a summary when the primary slot is
+                # subscription-exhausted.
                 gptme_response = call_gptme(prompt, timeout=timeout)
                 if gptme_response:
                     gptme_result = extract_json_from_response(gptme_response)
@@ -340,6 +345,8 @@ def call_claude_code(
                         "Claude subscriptions unavailable; gptme fallback response did not "
                         "contain a recognized summary schema; ignoring"
                     )
+                if last_non_subscription_error is not None:
+                    raise last_non_subscription_error
                 if saw_empty_response:
                     logger.error(
                         "Fallback slots returned empty responses after %d attempts",

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -353,20 +353,26 @@ def call_claude_code(
                 gptme_response = call_gptme(prompt, timeout=timeout)
                 if gptme_response:
                     gptme_result = extract_json_from_response(gptme_response)
+
                     # Check for the exact requested key first.  If an alternate
                     # recognised key is present instead, remap it so the caller
                     # always finds the key it asked for.  Without the remap,
                     # accepting "narrative" when the caller wants "month_narrative"
                     # lets the validation pass but the caller then defaults the
                     # narrative to "" — a silent empty summary on quota days.
-                    if narrative_key and not gptme_result.get(narrative_key):
+                    def _is_nonempty_str(v: object) -> bool:
+                        return isinstance(v, str) and bool(v.strip())
+
+                    if narrative_key and not _is_nonempty_str(gptme_result.get(narrative_key)):
                         for alt_key in _SUMMARY_NARRATIVE_KEYS:
-                            if alt_key != narrative_key and gptme_result.get(alt_key):
+                            if alt_key != narrative_key and _is_nonempty_str(
+                                gptme_result.get(alt_key)
+                            ):
                                 gptme_result[narrative_key] = gptme_result.pop(alt_key)
                                 gptme_response = json.dumps(gptme_result)
                                 break
                     _keys = (narrative_key,) if narrative_key else _SUMMARY_NARRATIVE_KEYS
-                    if any(gptme_result.get(key) for key in _keys):
+                    if any(_is_nonempty_str(gptme_result.get(key)) for key in _keys):
                         logger.warning(
                             "Claude subscriptions unavailable; gptme fallback produced a summary"
                         )

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -130,9 +130,11 @@ def call_claude_code(
             temporary directory so scheduled failures retain diagnostics.
         narrative_key: Expected top-level JSON key for the narrative field in
             the response (e.g. ``"narrative"`` or ``"month_narrative"``). When
-            set, the gptme fallback only accepts responses that contain this
-            exact key; when ``None``, any key from ``_SUMMARY_NARRATIVE_KEYS``
-            is accepted.
+            set, the gptme fallback accepts this exact key or any other key in
+            ``_SUMMARY_NARRATIVE_KEYS``, remapping alternate keys to
+            ``narrative_key`` before returning so the caller always finds the
+            key it expects; when ``None``, any key from
+            ``_SUMMARY_NARRATIVE_KEYS`` is accepted without remapping.
 
     Returns:
         The response text from Claude Code
@@ -342,14 +344,19 @@ def call_claude_code(
                 gptme_response = call_gptme(prompt, timeout=timeout)
                 if gptme_response:
                     gptme_result = extract_json_from_response(gptme_response)
-                    # Accept the specific requested key first, then any other recognised keys
-                    # so a gptme model returning "narrative" instead of "month_narrative" is
-                    # not silently discarded.
-                    _keys = (
-                        tuple(dict.fromkeys([narrative_key] + list(_SUMMARY_NARRATIVE_KEYS)))
-                        if narrative_key
-                        else _SUMMARY_NARRATIVE_KEYS
-                    )
+                    # Check for the exact requested key first.  If an alternate
+                    # recognised key is present instead, remap it so the caller
+                    # always finds the key it asked for.  Without the remap,
+                    # accepting "narrative" when the caller wants "month_narrative"
+                    # lets the validation pass but the caller then defaults the
+                    # narrative to "" — a silent empty summary on quota days.
+                    if narrative_key and narrative_key not in gptme_result:
+                        for alt_key in _SUMMARY_NARRATIVE_KEYS:
+                            if alt_key in gptme_result:
+                                gptme_result[narrative_key] = gptme_result.pop(alt_key)
+                                gptme_response = json.dumps(gptme_result)
+                                break
+                    _keys = (narrative_key,) if narrative_key else _SUMMARY_NARRATIVE_KEYS
                     if any(key in gptme_result for key in _keys):
                         logger.warning(
                             "Claude subscriptions unavailable; gptme fallback produced a summary"

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -378,7 +378,14 @@ def call_claude_code(
                 if last_non_subscription_error is not None:
                     # Preserve the auth-expiry signal from the primary slot even
                     # when a fallback slot produced a non-subscription error.
-                    if any(marker in combined_out_lower for marker in _AUTH_FAILURE_MARKERS):
+                    # Also check saw_fallback_auth_failure: if a fallback slot hit
+                    # OAuth-expiry before another fallback slot hit a non-subscription
+                    # error, the combined_out_lower only holds the primary's output
+                    # and would miss the fallback's auth marker.
+                    if (
+                        any(marker in combined_out_lower for marker in _AUTH_FAILURE_MARKERS)
+                        or saw_fallback_auth_failure
+                    ):
                         raise ClaudeAuthExpiredError(
                             result.returncode, attempt_cmd, result.stdout, result.stderr
                         )

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -35,6 +35,11 @@ _PERMANENT_SUBSCRIPTION_FAILURE_MARKERS = (
     "failed to authenticate: oauth session expired",
 )
 
+# Every structured summary produced by this module has one of these narrative
+# fields. Requiring one prevents a JSON-shaped provider error from being treated
+# as a successful summary and silently filled out with empty defaults.
+_SUMMARY_NARRATIVE_KEYS = ("narrative", "month_narrative")
+
 
 class ClaudeQuotaExhaustedError(subprocess.CalledProcessError):
     """The active Claude Code slot has a permanent subscription failure.
@@ -310,14 +315,15 @@ def call_claude_code(
                 # path is preserved when no fallback is available.
                 gptme_response = call_gptme(prompt, timeout=timeout)
                 if gptme_response:
-                    if extract_json_from_response(gptme_response):
+                    gptme_result = extract_json_from_response(gptme_response)
+                    if any(key in gptme_result for key in _SUMMARY_NARRATIVE_KEYS):
                         logger.warning(
                             "Claude subscriptions unavailable; gptme fallback produced a summary"
                         )
                         return gptme_response
                     logger.warning(
                         "Claude subscriptions unavailable; gptme fallback response did not "
-                        "contain a valid JSON object; ignoring"
+                        "contain a recognized summary schema; ignoring"
                     )
                 if saw_empty_response:
                     logger.error(

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -310,10 +310,15 @@ def call_claude_code(
                 # path is preserved when no fallback is available.
                 gptme_response = call_gptme(prompt, timeout=timeout)
                 if gptme_response:
+                    if extract_json_from_response(gptme_response):
+                        logger.warning(
+                            "Claude subscriptions unavailable; gptme fallback produced a summary"
+                        )
+                        return gptme_response
                     logger.warning(
-                        "Claude subscriptions unavailable; gptme fallback produced a summary"
+                        "Claude subscriptions unavailable; gptme fallback response did not "
+                        "contain a valid JSON object; ignoring"
                     )
-                    return gptme_response
                 if saw_empty_response:
                     logger.error(
                         "Fallback slots returned empty responses after %d attempts",

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -342,7 +342,14 @@ def call_claude_code(
                 gptme_response = call_gptme(prompt, timeout=timeout)
                 if gptme_response:
                     gptme_result = extract_json_from_response(gptme_response)
-                    _keys = (narrative_key,) if narrative_key else _SUMMARY_NARRATIVE_KEYS
+                    # Accept the specific requested key first, then any other recognised keys
+                    # so a gptme model returning "narrative" instead of "month_narrative" is
+                    # not silently discarded.
+                    _keys = (
+                        tuple(dict.fromkeys([narrative_key] + list(_SUMMARY_NARRATIVE_KEYS)))
+                        if narrative_key
+                        else _SUMMARY_NARRATIVE_KEYS
+                    )
                     if any(key in gptme_result for key in _keys):
                         logger.warning(
                             "Claude subscriptions unavailable; gptme fallback produced a summary"

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -375,6 +375,13 @@ def call_claude_code(
                         )
                     raise last_non_subscription_error
                 if saw_empty_response:
+                    # Even when a fallback slot returned empty, surface the
+                    # auth-expiry signal from the primary so callers can trigger
+                    # re-auth instead of silently falling back to empty defaults.
+                    if any(marker in combined_out_lower for marker in _AUTH_FAILURE_MARKERS):
+                        raise ClaudeAuthExpiredError(
+                            result.returncode, attempt_cmd, result.stdout, result.stderr
+                        )
                     logger.error(
                         "Fallback slots returned empty responses after %d attempts",
                         max_retries,

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -113,6 +113,7 @@ def call_claude_code(
     timeout: int = 120,
     max_retries: int = _MAX_RETRIES,
     diagnostic_dir: Path | None = None,
+    narrative_key: str | None = None,
 ) -> str:
     """
     Call Claude Code CLI with a prompt, retrying on non-zero exit or empty responses.
@@ -127,6 +128,11 @@ def call_claude_code(
         max_retries: Maximum number of retry attempts per failure type
         diagnostic_dir: Directory for Claude debug logs. Defaults to a stable
             temporary directory so scheduled failures retain diagnostics.
+        narrative_key: Expected top-level JSON key for the narrative field in
+            the response (e.g. ``"narrative"`` or ``"month_narrative"``). When
+            set, the gptme fallback only accepts responses that contain this
+            exact key; when ``None``, any key from ``_SUMMARY_NARRATIVE_KEYS``
+            is accepted.
 
     Returns:
         The response text from Claude Code
@@ -336,7 +342,8 @@ def call_claude_code(
                 gptme_response = call_gptme(prompt, timeout=timeout)
                 if gptme_response:
                     gptme_result = extract_json_from_response(gptme_response)
-                    if any(key in gptme_result for key in _SUMMARY_NARRATIVE_KEYS):
+                    _keys = (narrative_key,) if narrative_key else _SUMMARY_NARRATIVE_KEYS
+                    if any(key in gptme_result for key in _keys):
                         logger.warning(
                             "Claude subscriptions unavailable; gptme fallback produced a summary"
                         )
@@ -522,7 +529,7 @@ Journal Entry:
 
 Return ONLY the JSON, no additional text."""
 
-    response = call_claude_code(prompt, timeout=timeout)
+    response = call_claude_code(prompt, timeout=timeout, narrative_key="narrative")
     if not response:
         logger.warning("CC returned empty for journal summary (%s), using defaults", entry_date)
     result = extract_json_from_response(response)
@@ -631,7 +638,7 @@ Journal Entries ({len(entries)} total):
 
 Return ONLY the JSON."""
 
-    response = call_claude_code(prompt, timeout=timeout)
+    response = call_claude_code(prompt, timeout=timeout, narrative_key="narrative")
     if not response:
         logger.warning("CC returned empty for daily summary (%s), using defaults", target_date)
     result = extract_json_from_response(response)
@@ -735,7 +742,7 @@ Daily Summaries:
 
 Return ONLY the JSON."""
 
-    response = call_claude_code(prompt, timeout=timeout)
+    response = call_claude_code(prompt, timeout=timeout, narrative_key="narrative")
     if not response:
         logger.warning("CC returned empty for weekly summary (%s), using defaults", week_id)
     result = extract_json_from_response(response)
@@ -806,7 +813,7 @@ Guidelines:
 
 Return ONLY the JSON."""
 
-    response = call_claude_code(prompt, timeout=timeout)
+    response = call_claude_code(prompt, timeout=timeout, narrative_key="narrative")
     if not response:
         logger.warning(
             "CC returned empty for GitHub summary (%s/%s), using defaults", username, period
@@ -874,7 +881,7 @@ Guidelines:
 
 Return ONLY the JSON."""
 
-    response = call_claude_code(prompt, timeout=timeout)
+    response = call_claude_code(prompt, timeout=timeout, narrative_key="narrative")
     if not response:
         logger.warning(
             "CC returned empty for human day summary (%s/%s), using defaults", username, day
@@ -975,7 +982,7 @@ Weekly Summaries:
 
 Return ONLY the JSON."""
 
-    response = call_claude_code(prompt, timeout=timeout)
+    response = call_claude_code(prompt, timeout=timeout, narrative_key="month_narrative")
     if not response:
         logger.warning("CC returned empty for monthly summary (%s), using defaults", month)
     result = extract_json_from_response(response)

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -350,7 +350,7 @@ def call_claude_code(
                     # accepting "narrative" when the caller wants "month_narrative"
                     # lets the validation pass but the caller then defaults the
                     # narrative to "" — a silent empty summary on quota days.
-                    if narrative_key and narrative_key not in gptme_result:
+                    if narrative_key and not gptme_result.get(narrative_key):
                         for alt_key in _SUMMARY_NARRATIVE_KEYS:
                             if alt_key in gptme_result:
                                 gptme_result[narrative_key] = gptme_result.pop(alt_key)

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -25,18 +25,23 @@ logger = logging.getLogger(__name__)
 _MAX_RETRIES = 3
 _RETRY_DELAY_S = 5
 
-# Claude Code stdout marker for weekly quota exhaustion on the active slot. When
-# present, retrying on the same slot is futile — every attempt fails identically
-# until the quota resets. Callers with slot fallback should catch
-# ClaudeQuotaExhaustedError and retry on a different slot instead.
-_QUOTA_EXHAUSTED_MARKERS = ("you've hit your weekly limit",)
+# Claude Code output markers for permanent subscription failures on the active
+# slot. Retrying the same slot is futile; callers should try a fallback slot or
+# backend instead. Keep the exact observed prefixes narrow so transient errors
+# still use the normal retry path.
+_PERMANENT_SUBSCRIPTION_FAILURE_MARKERS = (
+    "you've hit your weekly limit",
+    "your organization has disabled claude subscription access",
+    "failed to authenticate: oauth session expired",
+)
 
 
 class ClaudeQuotaExhaustedError(subprocess.CalledProcessError):
-    """The active Claude Code slot has exhausted its weekly quota.
+    """The active Claude Code slot has a permanent subscription failure.
 
-    Raised immediately (without the usual retry loop) when ``claude -p`` prints a
-    weekly-quota-exhaustion marker, since retrying the same slot is futile.
+    Raised immediately (without the usual retry loop) when ``claude -p`` prints
+    a known quota- or subscription-access marker, since retrying the same slot
+    is futile. The historical name is retained for compatibility.
     Subclasses :class:`subprocess.CalledProcessError` so existing callers that
     catch the base type keep working; callers that can switch to a different slot
     should catch this subtype specifically.
@@ -127,10 +132,10 @@ def call_claude_code(
     # subprocess sessions (the generic cross-agent signal).
     env["GPTME_SUBPROCESS"] = "1"
 
-    # Fallback credential paths for quota exhaustion recovery.  When the active
-    # slot is exhausted, call_claude_code tries each path in order via a temp
-    # CLAUDE_CONFIG_DIR.  Extract here (before the subprocess env is locked) and
-    # strip from the env so the subprocess never sees it (prevents recursion).
+    # Fallback credential paths for permanent subscription failures. When the
+    # active slot is unavailable, call_claude_code tries each path in order via
+    # a temp CLAUDE_CONFIG_DIR. Extract here (before the subprocess env is locked)
+    # and strip from the env so the subprocess never sees it (prevents recursion).
     # Format: colon-separated absolute paths to credential files.
     # Example: /home/bob/.claude/.credentials.json.alice:/home/bob/.claude/.credentials.json.erik
     _fallback_creds_env = env.pop("GPTME_CC_FALLBACK_CREDS", "").strip()
@@ -214,25 +219,27 @@ def call_claude_code(
                     plain_retry_pending = True
             combined_out = (result.stdout or "") + (result.stderr or "")
             combined_out_lower = combined_out.lower()
-            # Weekly quota exhaustion is a permanent, slot-scoped failure: retrying
-            # the same slot is futile and just burns ~N*delay seconds + token budget.
-            # Signal it distinctly so a caller that can switch slots can retry there.
-            if any(marker.lower() in combined_out_lower for marker in _QUOTA_EXHAUSTED_MARKERS):
+            # Subscription failures are permanent and slot-scoped: retrying the
+            # same slot is futile and just burns ~N*delay seconds + token budget.
+            # Signal them distinctly so a caller can switch slots or backends.
+            if any(
+                marker in combined_out_lower for marker in _PERMANENT_SUBSCRIPTION_FAILURE_MARKERS
+            ):
                 logger.warning(
-                    "claude -p weekly quota exhausted (attempt %d/%d): %s",
+                    "claude -p subscription unavailable (attempt %d/%d): %s",
                     attempt,
                     max_retries,
                     result.stdout.strip()[:200] if result.stdout else result.stderr.strip()[:200],
                 )
                 # Attempt fallback slots (GPTME_CC_FALLBACK_CREDS) before raising.
-                last_non_quota_error: subprocess.CalledProcessError | None = None
+                last_non_subscription_error: subprocess.CalledProcessError | None = None
                 saw_empty_response = False
                 for fb_cred in _fallback_cred_paths:
                     if not fb_cred.exists():
                         logger.debug("Fallback cred file %s not found, skipping", fb_cred)
                         continue
                     logger.info(
-                        "Active slot quota exhausted; trying fallback slot: %s",
+                        "Active slot subscription unavailable; trying fallback slot: %s",
                         fb_cred.name,
                     )
                     for fb_attempt in range(1, max_retries + 1):
@@ -259,14 +266,20 @@ def call_claude_code(
                                 time.sleep(_RETRY_DELAY_S * fb_attempt)
                                 continue
                             break
-                        # Check if this fallback slot is also quota-exhausted.
+                        # Check whether this fallback slot is also unavailable.
                         fb_combined = (fb_result.stdout or "") + (fb_result.stderr or "")
-                        if any(m.lower() in fb_combined.lower() for m in _QUOTA_EXHAUSTED_MARKERS):
-                            logger.warning("Fallback slot %s also quota-exhausted", fb_cred.name)
-                            # Clear any prior non-quota error so the caller receives
+                        if any(
+                            marker in fb_combined.lower()
+                            for marker in _PERMANENT_SUBSCRIPTION_FAILURE_MARKERS
+                        ):
+                            logger.warning(
+                                "Fallback slot %s also has a subscription failure",
+                                fb_cred.name,
+                            )
+                            # Clear any prior non-subscription error so the caller receives
                             # ClaudeQuotaExhaustedError rather than a stale error from
                             # an earlier fallback that failed for a different reason.
-                            last_non_quota_error = None
+                            last_non_subscription_error = None
                             break
                         logger.warning(
                             "Fallback slot %s failed (rc=%d, attempt %d/%d): stdout=%s stderr=%s",
@@ -277,7 +290,7 @@ def call_claude_code(
                             (fb_result.stdout or "")[:200],
                             (fb_result.stderr or "")[:200],
                         )
-                        last_non_quota_error = subprocess.CalledProcessError(
+                        last_non_subscription_error = subprocess.CalledProcessError(
                             fb_result.returncode,
                             cmd,
                             fb_result.stdout,
@@ -287,9 +300,9 @@ def call_claude_code(
                             time.sleep(_RETRY_DELAY_S * fb_attempt)
                             continue
                         break
-                if last_non_quota_error is not None:
-                    raise last_non_quota_error
-                # All Claude slots failed (quota exhaustion and/or empty responses).
+                if last_non_subscription_error is not None:
+                    raise last_non_subscription_error
+                # All Claude slots failed (subscription failures and/or empty responses).
                 # Before surfacing the permanent failure, try the gptme fallback so
                 # summary generation does not hard-fail on quota days (ErikBjare/bob
                 # issue: 5 auto-resolve flips in 8 days). The gptme adapter is
@@ -297,7 +310,9 @@ def call_claude_code(
                 # path is preserved when no fallback is available.
                 gptme_response = call_gptme(prompt, timeout=timeout)
                 if gptme_response:
-                    logger.warning("Claude quota exhausted; gptme fallback produced a summary")
+                    logger.warning(
+                        "Claude subscriptions unavailable; gptme fallback produced a summary"
+                    )
                     return gptme_response
                 if saw_empty_response:
                     logger.error(
@@ -306,7 +321,8 @@ def call_claude_code(
                     )
                     return ""
                 logger.error(
-                    "Claude quota exhausted and gptme fallback produced no summary; raising"
+                    "Claude subscriptions unavailable and gptme fallback produced no summary; "
+                    "raising"
                 )
                 raise ClaudeQuotaExhaustedError(
                     result.returncode, attempt_cmd, result.stdout, result.stderr

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/cc_backend.py
@@ -353,6 +353,12 @@ def call_claude_code(
                         "contain a recognized summary schema; ignoring"
                     )
                 if last_non_subscription_error is not None:
+                    # Preserve the auth-expiry signal from the primary slot even
+                    # when a fallback slot produced a non-subscription error.
+                    if any(marker in combined_out_lower for marker in _AUTH_FAILURE_MARKERS):
+                        raise ClaudeAuthExpiredError(
+                            result.returncode, attempt_cmd, result.stdout, result.stderr
+                        )
                     raise last_non_subscription_error
                 if saw_empty_response:
                     logger.error(

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
@@ -144,10 +144,19 @@ def _extract_assistant_text(stdout: str) -> str:
     if not contents:
         logger.warning("gptme fallback produced no assistant messages")
         return ""
-    if len(contents) > 1:
-        logger.debug(
-            "gptme fallback produced %d assistant messages; using first only to avoid "
-            "multi-JSON concatenation that breaks extract_json_from_response",
-            len(contents),
-        )
-    return contents[0]
+    # Reasoning models (e.g. deepseek) emit a thinking/preamble message first
+    # followed by the real JSON answer.  Return the first content that parses as
+    # JSON; fall back to the last content so callers can still attempt extraction
+    # and surface a useful warning instead of silently discarding the summary.
+    for candidate in contents:
+        try:
+            json.loads(candidate)
+            return candidate
+        except json.JSONDecodeError:
+            continue
+    logger.debug(
+        "gptme fallback: no assistant message parsed as JSON (%d messages); "
+        "returning last message for caller to attempt extraction",
+        len(contents),
+    )
+    return contents[-1]

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
@@ -120,6 +120,12 @@ def _extract_assistant_text(stdout: str) -> str:
             content = obj.get("content")
             if isinstance(content, str) and content.strip():
                 contents.append(content)
+            elif isinstance(content, list):
+                for part in content:
+                    if isinstance(part, dict) and part.get("type") == "text":
+                        text = part.get("text", "")
+                        if text.strip():
+                            contents.append(text)
     if not contents:
         logger.warning("gptme fallback produced no assistant messages")
         return ""

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
@@ -144,4 +144,10 @@ def _extract_assistant_text(stdout: str) -> str:
     if not contents:
         logger.warning("gptme fallback produced no assistant messages")
         return ""
-    return "\n".join(contents)
+    if len(contents) > 1:
+        logger.debug(
+            "gptme fallback produced %d assistant messages; using first only to avoid "
+            "multi-JSON concatenation that breaks extract_json_from_response",
+            len(contents),
+        )
+    return contents[0]

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
@@ -144,16 +144,26 @@ def _extract_assistant_text(stdout: str) -> str:
     if not contents:
         logger.warning("gptme fallback produced no assistant messages")
         return ""
-    # Reasoning models (e.g. deepseek) emit a thinking/preamble message first
-    # followed by the real JSON answer.  Return the first content that parses as
-    # JSON; fall back to the last content so callers can still attempt extraction
-    # and surface a useful warning instead of silently discarding the summary.
+    # Reasoning models (e.g. deepseek) emit a thinking/preamble first, which
+    # may itself be valid JSON (e.g. {"thinking": "..."}).  Collect all
+    # JSON-parseable candidates, then prefer the one that contains a recognised
+    # summary key so that a JSON-shaped preamble is not returned instead of the
+    # real answer; only fall back to the first JSON-parseable if none contain a
+    # recognised key.
+    _SUMMARY_KEYS = ("narrative", "month_narrative")
+    json_candidates: list[str] = []
     for candidate in contents:
         try:
             json.loads(candidate)
-            return candidate
+            json_candidates.append(candidate)
         except json.JSONDecodeError:
             continue
+    if json_candidates:
+        for candidate in json_candidates:
+            parsed = json.loads(candidate)
+            if any(parsed.get(k) for k in _SUMMARY_KEYS):
+                return candidate
+        return json_candidates[0]
     logger.debug(
         "gptme fallback: no assistant message parsed as JSON (%d messages); "
         "returning last message for caller to attempt extraction",

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
@@ -161,7 +161,7 @@ def _extract_assistant_text(stdout: str) -> str:
     if json_candidates:
         for candidate in json_candidates:
             parsed = json.loads(candidate)
-            if any(parsed.get(k) for k in _SUMMARY_KEYS):
+            if isinstance(parsed, dict) and any(parsed.get(k) for k in _SUMMARY_KEYS):
                 return candidate
         return json_candidates[0]
     logger.debug(

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
@@ -159,11 +159,15 @@ def _extract_assistant_text(stdout: str) -> str:
         except json.JSONDecodeError:
             continue
     if json_candidates:
-        for candidate in json_candidates:
+        # Iterate in reverse so the last (final answer) wins over an earlier
+        # JSON-shaped thinking preamble that may also contain a summary key.
+        # Reasoning models (e.g. deepseek) emit a preamble first, then the
+        # real answer; scanning forward would return the preamble instead.
+        for candidate in reversed(json_candidates):
             parsed = json.loads(candidate)
             if isinstance(parsed, dict) and any(parsed.get(k) for k in _SUMMARY_KEYS):
                 return candidate
-        return json_candidates[0]
+        return json_candidates[-1]
     logger.debug(
         "gptme fallback: no assistant message parsed as JSON (%d messages); "
         "returning last message for caller to attempt extraction",

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
@@ -19,8 +19,11 @@ import subprocess
 
 logger = logging.getLogger(__name__)
 
-# Env switches so operators can disable the fallback or pin a specific model.
-_DISABLE_ENV = "GPTME_ACTIVITY_SUMMARY_GPTME_FALLBACK"  # set to "0" to disable
+# Env switches to enable the fallback or pin a specific model.
+# The fallback is OFF by default because it sends journal content (potentially
+# sensitive personal data) to an external model via OpenRouter. Operators must
+# explicitly opt in by setting _ENABLE_ENV=1.
+_ENABLE_ENV = "GPTME_ACTIVITY_SUMMARY_GPTME_FALLBACK"  # set to "1" to enable
 _MODEL_ENV = "GPTME_ACTIVITY_SUMMARY_GPTME_MODEL"  # override the default model
 _DEFAULT_MODEL = "openrouter/deepseek/deepseek-v4-flash-0731@deepseek"
 
@@ -34,9 +37,14 @@ _OUTPUT_FORMAT = "json"
 
 
 def is_enabled() -> bool:
-    """Whether the gptme fallback is enabled (on by default, off via env)."""
-    val = os.environ.get(_DISABLE_ENV, "1").strip().lower()
-    return val not in ("0", "false", "no", "off")
+    """Whether the gptme fallback is enabled (off by default, on via env).
+
+    Set GPTME_ACTIVITY_SUMMARY_GPTME_FALLBACK=1 to enable. The fallback sends
+    journal content to an external model via OpenRouter; it is disabled by
+    default to avoid unintended data exfiltration.
+    """
+    val = os.environ.get(_ENABLE_ENV, "0").strip().lower()
+    return val in ("1", "true", "yes", "on")
 
 
 def call_gptme(prompt: str, timeout: int = 120) -> str:
@@ -54,7 +62,7 @@ def call_gptme(prompt: str, timeout: int = 120) -> str:
         The raw assistant response text, or ``""`` if the call failed.
     """
     if not is_enabled():
-        logger.debug("gptme fallback disabled via %s", _DISABLE_ENV)
+        logger.debug("gptme fallback disabled; set %s=1 to enable", _ENABLE_ENV)
         return ""
     if shutil.which("gptme") is None:
         logger.debug("gptme binary not found on PATH; skipping fallback")
@@ -62,9 +70,8 @@ def call_gptme(prompt: str, timeout: int = 120) -> str:
 
     model = os.environ.get(_MODEL_ENV, _DEFAULT_MODEL).strip()
     logger.warning(
-        "gptme fallback: sending prompt to external model %r. " "Set %s=0 to disable.",
+        "gptme fallback: sending prompt to external model %r via OpenRouter.",
         model,
-        _DISABLE_ENV,
     )
     cmd = [
         "gptme",

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
@@ -61,6 +61,11 @@ def call_gptme(prompt: str, timeout: int = 120) -> str:
         return ""
 
     model = os.environ.get(_MODEL_ENV, _DEFAULT_MODEL).strip()
+    logger.warning(
+        "gptme fallback: sending prompt to external model %r. " "Set %s=0 to disable.",
+        model,
+        _DISABLE_ENV,
+    )
     cmd = [
         "gptme",
         "-n",  # non-interactive; implies --no-confirm

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
@@ -1,0 +1,126 @@
+"""
+gptme fallback backend for journal summarization.
+
+Used when the `claude -p` backend fails on quota/auth exhaustion, so daily (and
+weekly/monthly) summary generation does not hard-fail when the active Claude
+subscription is at its weekly quota. Invokes the `gptme` CLI in non-interactive
+mode against a configured model and returns the raw assistant response text.
+
+The caller (cc_backend) owns the retry/failure policy; this module is a thin,
+best-effort adapter that never raises — it returns an empty string on any
+failure so the caller can degrade gracefully.
+"""
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+# Env switches so operators can disable the fallback or pin a specific model.
+_DISABLE_ENV = "GPTME_ACTIVITY_SUMMARY_GPTME_FALLBACK"  # set to "0" to disable
+_MODEL_ENV = "GPTME_ACTIVITY_SUMMARY_GPTME_MODEL"  # override the default model
+_DEFAULT_MODEL = "openrouter/deepseek/deepseek-v4-flash-0731@deepseek"
+
+# gptme emits one JSON object per line on stdout in --output-format json. The
+# JSON answer appears in the first assistant message after the user prompt; the
+# trailing auto-reply ("No tool call detected ... use the `complete` tool") and
+# the `complete` tool-call message are not valid JSON, so extract_json handles
+# them. We still pick the assistant content greedily and let the caller's
+# extract_json_from_response pull the real JSON out of whatever text survives.
+_OUTPUT_FORMAT = "json"
+
+
+def is_enabled() -> bool:
+    """Whether the gptme fallback is enabled (on by default, off via env)."""
+    val = os.environ.get(_DISABLE_ENV, "1").strip().lower()
+    return val not in ("0", "false", "no", "off")
+
+
+def call_gptme(prompt: str, timeout: int = 120) -> str:
+    """
+    Run ``gptme -n --output-format json`` against the fallback model.
+
+    Best-effort: returns ``""`` on any failure (binary missing, non-zero exit,
+    timeout, unparseable output) so callers can degrade gracefully.
+
+    Args:
+        prompt: The prompt to send to gptme.
+        timeout: Maximum time to wait for a response (seconds).
+
+    Returns:
+        The raw assistant response text, or ``""`` if the call failed.
+    """
+    if not is_enabled():
+        logger.debug("gptme fallback disabled via %s", _DISABLE_ENV)
+        return ""
+    if shutil.which("gptme") is None:
+        logger.debug("gptme binary not found on PATH; skipping fallback")
+        return ""
+
+    model = os.environ.get(_MODEL_ENV, _DEFAULT_MODEL).strip()
+    cmd = [
+        "gptme",
+        "-n",  # non-interactive; implies --no-confirm
+        "--no-stream",
+        "--output-format",
+        _OUTPUT_FORMAT,
+        "--tools",
+        "none",
+        "-m",
+        model,
+        prompt,
+    ]
+
+    env = os.environ.copy()
+    # Prevent recursion / contamination from a parent gptme invocation.
+    env.pop("GPTME_SUBPROCESS", None)
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=env,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.warning("gptme fallback failed to run: %s", exc)
+        return ""
+    except Exception as exc:  # noqa: BLE001 - best-effort adapter must not raise
+        logger.warning("gptme fallback errored unexpectedly: %s", exc)
+        return ""
+
+    if result.returncode != 0:
+        logger.warning(
+            "gptme fallback exited %d: stderr=%s stdout=%s",
+            result.returncode,
+            (result.stderr or "")[:300],
+            (result.stdout or "")[:300],
+        )
+        return ""
+
+    return _extract_assistant_text(result.stdout)
+
+
+def _extract_assistant_text(stdout: str) -> str:
+    """Collect assistant message contents from gptme NDJSON output."""
+    contents: list[str] = []
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if obj.get("type") == "message" and obj.get("role") == "assistant":
+            content = obj.get("content")
+            if isinstance(content, str) and content.strip():
+                contents.append(content)
+    if not contents:
+        logger.warning("gptme fallback produced no assistant messages")
+        return ""
+    return "\n".join(contents)

--- a/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
+++ b/packages/gptme-activity-summary/src/gptme_activity_summary/gptme_backend.py
@@ -71,7 +71,9 @@ def call_gptme(prompt: str, timeout: int = 120) -> str:
         "none",
         "-m",
         model,
-        prompt,
+        # Prompt is passed via stdin (not as a positional arg) to avoid exposing
+        # potentially-sensitive journal content in the process list and to prevent
+        # OSError "Argument list too long" for large journal summaries.
     ]
 
     env = os.environ.copy()
@@ -81,6 +83,7 @@ def call_gptme(prompt: str, timeout: int = 120) -> str:
     try:
         result = subprocess.run(
             cmd,
+            input=prompt,
             capture_output=True,
             text=True,
             timeout=timeout,
@@ -124,7 +127,7 @@ def _extract_assistant_text(stdout: str) -> str:
                 for part in content:
                     if isinstance(part, dict) and part.get("type") == "text":
                         text = part.get("text", "")
-                        if text.strip():
+                        if isinstance(text, str) and text.strip():
                             contents.append(text)
     if not contents:
         logger.warning("gptme fallback produced no assistant messages")

--- a/packages/gptme-activity-summary/tests/test_cc_backend.py
+++ b/packages/gptme-activity-summary/tests/test_cc_backend.py
@@ -1090,3 +1090,33 @@ def test_call_gptme_list_content_non_string_text_skipped(mock_run, mock_which):
     mock_run.return_value = subprocess.CompletedProcess(args=["gptme"], returncode=0, stdout=ndjson)
     # Must not raise AttributeError; must return the valid part
     assert gb.call_gptme("hi") == "valid text"
+
+
+@patch("gptme_activity_summary.cc_backend.call_gptme", return_value="")
+@patch("gptme_activity_summary.cc_backend._try_with_credential_file")
+@patch("gptme_activity_summary.cc_backend.time.sleep")
+@patch("subprocess.run")
+def test_call_claude_code_oauth_expiry_preserved_when_fallback_has_non_sub_error(
+    mock_run, mock_sleep, mock_fallback, mock_gptme, tmp_path
+):
+    """Auth-expiry from the primary slot is raised even when a fallback slot produces a
+    non-subscription error (last_non_subscription_error is set).
+
+    Regression: previously ClaudeAuthExpiredError was only raised on the
+    last_non_subscription_error is None path, so a stale-auth fallback slot
+    could mask the primary's OAuth expiry with a generic CalledProcessError.
+    """
+    fb_cred = tmp_path / ".credentials.json.invalid"
+    fb_cred.write_text("{}")
+    mock_run.return_value = _make_completed_process(
+        returncode=1, stdout="Failed to authenticate: OAuth session expired"
+    )
+    mock_fallback.return_value = _make_completed_process(returncode=2, stderr="invalid credentials")
+
+    with patch.dict(
+        "os.environ",
+        {"GPTME_CC_FALLBACK_CREDS": str(fb_cred)},
+        clear=True,
+    ):
+        with pytest.raises(ClaudeAuthExpiredError):
+            call_claude_code("test prompt", max_retries=2)

--- a/packages/gptme-activity-summary/tests/test_cc_backend.py
+++ b/packages/gptme-activity-summary/tests/test_cc_backend.py
@@ -501,17 +501,28 @@ def test_summarize_journal_no_failed_flag_on_success(mock_cc):
 # --- Tests for GPTME_CC_FALLBACK_CREDS slot fallback ---
 
 
+@pytest.mark.parametrize(
+    "primary_failure",
+    [
+        "You've hit your weekly limit · resets 4pm",
+        (
+            "Your organization has disabled Claude subscription access for Claude Code · "
+            "Use an Anthropic API key instead, or ask your admin to enable access"
+        ),
+        "Failed to authenticate: OAuth session expired",
+    ],
+)
 @patch("gptme_activity_summary.cc_backend._try_with_credential_file")
 @patch("gptme_activity_summary.cc_backend.time.sleep")
 @patch("subprocess.run")
-def test_call_claude_code_quota_fallback_success(mock_run, mock_sleep, mock_fallback, tmp_path):
-    """Quota exhaustion on primary slot triggers fallback; first healthy slot wins."""
+def test_call_claude_code_slot_failure_fallback_success(
+    mock_run, mock_sleep, mock_fallback, tmp_path, primary_failure
+):
+    """Permanent subscription failures trigger fallback; first healthy slot wins."""
     fb_cred = tmp_path / ".credentials.json.alice"
     fb_cred.write_text("{}")
 
-    mock_run.return_value = _make_completed_process(
-        returncode=1, stdout="You've hit your weekly limit · resets 4pm"
-    )
+    mock_run.return_value = _make_completed_process(returncode=1, stdout=primary_failure)
     mock_fallback.return_value = _make_completed_process(stdout='{"ok": true}')
 
     import os
@@ -803,6 +814,38 @@ def test_call_claude_code_quota_falls_back_to_gptme(mock_run, mock_sleep, mock_g
 
     assert result == '{"ok": "from-gptme"}'
     assert mock_gptme.call_count == 1
+    mock_gptme.assert_called_once_with("test prompt", timeout=120)
+
+
+@patch("gptme_activity_summary.cc_backend.call_gptme")
+@patch("gptme_activity_summary.cc_backend._try_with_credential_file")
+@patch("gptme_activity_summary.cc_backend.time.sleep")
+@patch("subprocess.run")
+def test_call_claude_code_disabled_fallback_slots_reach_gptme(
+    mock_run, mock_sleep, mock_fallback, mock_gptme, tmp_path
+):
+    """Subscription-disabled fallback slots still fall through to gptme."""
+    import os
+
+    fb_cred = tmp_path / ".credentials.json.alice"
+    fb_cred.write_text("{}")
+    disabled = _make_completed_process(
+        returncode=1,
+        stdout="Your organization has disabled Claude subscription access for Claude Code",
+    )
+    mock_run.return_value = disabled
+    mock_fallback.return_value = disabled
+    mock_gptme.return_value = '{"ok": "from-gptme"}'
+
+    with patch.dict(
+        os.environ,
+        {"GPTME_CC_FALLBACK_CREDS": str(fb_cred)},
+        clear=True,
+    ):
+        result = call_claude_code("test prompt")
+
+    assert result == '{"ok": "from-gptme"}'
+    mock_fallback.assert_called_once()
     mock_gptme.assert_called_once_with("test prompt", timeout=120)
 
 

--- a/packages/gptme-activity-summary/tests/test_cc_backend.py
+++ b/packages/gptme-activity-summary/tests/test_cc_backend.py
@@ -1095,12 +1095,14 @@ def test_call_gptme_list_content_non_string_text_skipped(mock_run, mock_which):
 @patch.dict("os.environ", {"GPTME_ACTIVITY_SUMMARY_GPTME_FALLBACK": "1"})
 @patch("gptme_activity_summary.gptme_backend.shutil.which", return_value="/usr/bin/gptme")
 @patch("subprocess.run")
-def test_call_gptme_multiple_assistant_messages_returns_first_only(mock_run, mock_which):
-    """When gptme emits multiple assistant messages, only the first is returned.
+def test_call_gptme_multiple_assistant_messages_returns_first_json(mock_run, mock_which):
+    """When gptme emits multiple assistant messages, the first JSON-parseable one is returned.
 
-    Joining them with newlines produces a multi-JSON string — the greedy regex
-    in extract_json_from_response then spans across both objects and fails to
-    parse any valid JSON, so the fallback silently yields nothing.
+    Reasoning models emit a thinking/preamble message first, followed by the
+    real JSON answer.  Joining all messages with newlines produces a multi-JSON
+    string — the greedy regex in extract_json_from_response then spans across
+    both objects and fails to parse any valid JSON, so we iterate instead and
+    return the first message that parses as JSON.
     """
     import json as _json
 
@@ -1126,7 +1128,46 @@ def test_call_gptme_multiple_assistant_messages_returns_first_only(mock_run, moc
         args=["gptme"], returncode=0, stdout=f"{first_msg}\n{second_msg}"
     )
     result = gb.call_gptme("hi")
-    assert result == '{"narrative": "first"}', "only the first assistant message must be returned"
+    assert result == '{"narrative": "first"}', "first JSON message must be returned"
+
+
+@patch.dict("os.environ", {"GPTME_ACTIVITY_SUMMARY_GPTME_FALLBACK": "1"})
+@patch("gptme_activity_summary.gptme_backend.shutil.which", return_value="/usr/bin/gptme")
+@patch("subprocess.run")
+def test_call_gptme_reasoning_model_preamble_skipped(mock_run, mock_which):
+    """Reasoning models (e.g. deepseek) emit a thinking preamble before the JSON answer.
+
+    The first assistant message is not valid JSON; the second contains the real
+    JSON summary.  _extract_assistant_text must skip the non-JSON preamble and
+    return the first message that parses as JSON.
+    """
+    import json as _json
+
+    import gptme_activity_summary.gptme_backend as gb
+
+    preamble_msg = _json.dumps(
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": "Let me think about this... I need to summarize the journal entries.",
+            "timestamp": "2026-08-23T00:00:00.000000",
+        }
+    )
+    json_answer_msg = _json.dumps(
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": '{"narrative": "actual summary", "title": "Daily Summary"}',
+            "timestamp": "2026-08-23T00:00:01.000000",
+        }
+    )
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=["gptme"], returncode=0, stdout=f"{preamble_msg}\n{json_answer_msg}"
+    )
+    result = gb.call_gptme("summarize")
+    assert (
+        result == '{"narrative": "actual summary", "title": "Daily Summary"}'
+    ), "must skip non-JSON preamble and return the JSON answer message"
 
 
 @patch.dict("os.environ", {}, clear=True)
@@ -1158,6 +1199,39 @@ def test_call_claude_code_gptme_fallback_remaps_alternate_narrative_key(
     assert "month_narrative" in parsed, "caller-expected key must be present after remap"
     assert parsed["month_narrative"] == "monthly stuff"
     assert "narrative" not in parsed, "original alternate key must be replaced by remap"
+
+
+@patch.dict("os.environ", {}, clear=True)
+@patch("gptme_activity_summary.cc_backend.call_gptme")
+@patch("gptme_activity_summary.cc_backend.time.sleep")
+@patch("subprocess.run")
+def test_call_claude_code_gptme_fallback_remaps_when_requested_key_empty(
+    mock_run, mock_sleep, mock_gptme
+):
+    """When gptme returns JSON with the requested key present but empty, the remap
+    must treat the empty value as absent and use the alternate key.
+
+    Without this fix, narrative_key='month_narrative' and gptme returning
+    '{"month_narrative": "", "narrative": "monthly text"}' passes the
+    `narrative_key not in gptme_result` check (key exists), so no remap happens.
+    The caller then reads month_narrative and gets '', producing a silent empty
+    monthly summary on quota days — the exact failure the remap was introduced to prevent.
+    """
+    import json as _json
+
+    mock_run.return_value = _make_completed_process(
+        returncode=1, stdout="You've hit your weekly limit"
+    )
+    # gptme returns month_narrative as empty string — alternate key has the real value
+    mock_gptme.return_value = '{"month_narrative": "", "narrative": "actual monthly narrative"}'
+
+    result = call_claude_code("test prompt", max_retries=1, narrative_key="month_narrative")
+
+    parsed = _json.loads(result)
+    assert "month_narrative" in parsed, "caller-expected key must be present after remap"
+    assert (
+        parsed["month_narrative"] == "actual monthly narrative"
+    ), "empty requested key must be replaced with the alternate key's value"
 
 
 @patch("gptme_activity_summary.cc_backend.call_gptme", return_value="")

--- a/packages/gptme-activity-summary/tests/test_cc_backend.py
+++ b/packages/gptme-activity-summary/tests/test_cc_backend.py
@@ -210,9 +210,10 @@ def test_call_claude_code_quota_marker_in_stderr(mock_run, mock_sleep, mock_gptm
     assert mock_run.call_count == 1  # primary only; gptme mocked, no extra run
 
 
+@patch("gptme_activity_summary.cc_backend.call_gptme", return_value="")
 @patch("gptme_activity_summary.cc_backend.time.sleep")
 @patch("subprocess.run")
-def test_call_claude_code_quota_is_called_process_error_subtype(mock_run, mock_sleep):
+def test_call_claude_code_quota_is_called_process_error_subtype(mock_run, mock_sleep, mock_gptme):
     """ClaudeQuotaExhaustedError must be catchable as CalledProcessError."""
     from gptme_activity_summary.cc_backend import ClaudeQuotaExhaustedError
 
@@ -224,6 +225,7 @@ def test_call_claude_code_quota_is_called_process_error_subtype(mock_run, mock_s
         assert False, "Should have raised ClaudeQuotaExhaustedError"
     except subprocess.CalledProcessError as e:
         assert isinstance(e, ClaudeQuotaExhaustedError)
+    mock_gptme.assert_called_once_with("test prompt", timeout=120)
 
 
 @patch.dict(
@@ -597,11 +599,12 @@ def test_call_claude_code_quota_fallback_retries_empty_response(
     mock_sleep.assert_called_once()
 
 
+@patch("gptme_activity_summary.cc_backend.call_gptme", return_value="")
 @patch("gptme_activity_summary.cc_backend._try_with_credential_file")
 @patch("gptme_activity_summary.cc_backend.time.sleep")
 @patch("subprocess.run")
 def test_call_claude_code_quota_fallback_empty_exhaustion_returns_empty(
-    mock_run, mock_sleep, mock_fallback, tmp_path
+    mock_run, mock_sleep, mock_fallback, mock_gptme, tmp_path
 ):
     """Repeated empty responses retain the main path's graceful-empty contract."""
     fb_cred = tmp_path / ".credentials.json.alice"
@@ -620,13 +623,15 @@ def test_call_claude_code_quota_fallback_empty_exhaustion_returns_empty(
 
     assert mock_fallback.call_count == 2
     mock_sleep.assert_called_once()
+    mock_gptme.assert_called_once_with("test prompt", timeout=120)
 
 
+@patch("gptme_activity_summary.cc_backend.call_gptme", return_value="")
 @patch("gptme_activity_summary.cc_backend._try_with_credential_file")
 @patch("gptme_activity_summary.cc_backend.time.sleep")
 @patch("subprocess.run")
 def test_call_claude_code_quota_fallback_all_exhausted(
-    mock_run, mock_sleep, mock_fallback, tmp_path
+    mock_run, mock_sleep, mock_fallback, mock_gptme, tmp_path
 ):
     """If all fallback slots are also exhausted, raise ClaudeQuotaExhaustedError."""
     fb_cred = tmp_path / ".credentials.json.erik"
@@ -646,6 +651,7 @@ def test_call_claude_code_quota_fallback_all_exhausted(
     ):
         with pytest.raises(ClaudeQuotaExhaustedError):
             call_claude_code("test prompt")
+    mock_gptme.assert_called_once_with("test prompt", timeout=120)
 
 
 @patch("gptme_activity_summary.cc_backend._try_with_credential_file")
@@ -705,11 +711,12 @@ def test_call_claude_code_quota_fallback_preserves_non_quota_error(
     mock_sleep.assert_called_once_with(5)
 
 
+@patch("gptme_activity_summary.cc_backend.call_gptme", return_value="")
 @patch("gptme_activity_summary.cc_backend._try_with_credential_file")
 @patch("gptme_activity_summary.cc_backend.time.sleep")
 @patch("subprocess.run")
 def test_call_claude_code_quota_fallback_non_quota_then_quota_raises_quota_error(
-    mock_run, mock_sleep, mock_fallback, tmp_path
+    mock_run, mock_sleep, mock_fallback, mock_gptme, tmp_path
 ):
     """Non-quota error on slot A then quota-exhaustion on slot B → ClaudeQuotaExhaustedError.
 
@@ -739,12 +746,16 @@ def test_call_claude_code_quota_fallback_non_quota_then_quota_raises_quota_error
     ):
         with pytest.raises(ClaudeQuotaExhaustedError):
             call_claude_code("test prompt", max_retries=1)
+    mock_gptme.assert_called_once_with("test prompt", timeout=120)
 
 
+@patch("gptme_activity_summary.cc_backend.call_gptme", return_value="")
 @patch("gptme_activity_summary.cc_backend._try_with_credential_file")
 @patch("gptme_activity_summary.cc_backend.time.sleep")
 @patch("subprocess.run")
-def test_call_claude_code_quota_fallback_missing_file_skipped(mock_run, mock_sleep, mock_fallback):
+def test_call_claude_code_quota_fallback_missing_file_skipped(
+    mock_run, mock_sleep, mock_fallback, mock_gptme
+):
     """A fallback cred path that does not exist on disk is silently skipped."""
     import os
 
@@ -767,6 +778,7 @@ def test_call_claude_code_quota_fallback_missing_file_skipped(mock_run, mock_sle
             os.environ["GPTME_CC_FALLBACK_CREDS"] = prev
 
     mock_fallback.assert_not_called()  # missing file never attempted
+    mock_gptme.assert_called_once_with("test prompt", timeout=120)
 
 
 @patch.dict("os.environ", {}, clear=True)
@@ -814,6 +826,23 @@ def test_call_claude_code_quota_falls_back_to_gptme(mock_run, mock_sleep, mock_g
 
     assert result == '{"ok": "from-gptme"}'
     assert mock_gptme.call_count == 1
+    mock_gptme.assert_called_once_with("test prompt", timeout=120)
+
+
+@patch.dict("os.environ", {}, clear=True)
+@patch("gptme_activity_summary.cc_backend.call_gptme")
+@patch("gptme_activity_summary.cc_backend.time.sleep")
+@patch("subprocess.run")
+def test_call_claude_code_rejects_non_json_gptme_fallback(mock_run, mock_sleep, mock_gptme):
+    """Plain-text gptme responses must preserve the Claude failure signal."""
+    mock_run.return_value = _make_completed_process(
+        returncode=1, stdout="You've hit your weekly limit"
+    )
+    mock_gptme.return_value = "I cannot provide JSON."
+
+    with pytest.raises(ClaudeQuotaExhaustedError):
+        call_claude_code("test prompt", max_retries=1)
+
     mock_gptme.assert_called_once_with("test prompt", timeout=120)
 
 

--- a/packages/gptme-activity-summary/tests/test_cc_backend.py
+++ b/packages/gptme-activity-summary/tests/test_cc_backend.py
@@ -811,34 +811,52 @@ def _ndjson(msg: str) -> str:
     )
 
 
+@pytest.mark.parametrize(
+    "gptme_response",
+    [
+        '{"narrative": "from-gptme"}',
+        '{"month_narrative": "from-gptme"}',
+    ],
+)
 @patch.dict("os.environ", {}, clear=True)
 @patch("gptme_activity_summary.cc_backend.call_gptme")
 @patch("gptme_activity_summary.cc_backend.time.sleep")
 @patch("subprocess.run")
-def test_call_claude_code_quota_falls_back_to_gptme(mock_run, mock_sleep, mock_gptme, tmp_path):
+def test_call_claude_code_quota_falls_back_to_gptme(
+    mock_run, mock_sleep, mock_gptme, gptme_response
+):
     """Quota exhaustion on all Claude slots falls back to the gptme backend."""
     mock_run.return_value = _make_completed_process(
         returncode=1, stdout="You've hit your weekly limit"
     )
-    mock_gptme.return_value = '{"ok": "from-gptme"}'
+    mock_gptme.return_value = gptme_response
 
     result = call_claude_code("test prompt", max_retries=3)
 
-    assert result == '{"ok": "from-gptme"}'
+    assert result == gptme_response
     assert mock_gptme.call_count == 1
     mock_gptme.assert_called_once_with("test prompt", timeout=120)
 
 
+@pytest.mark.parametrize(
+    "fallback_response",
+    [
+        "I cannot provide JSON.",
+        '{"error": "model overloaded"}',
+    ],
+)
 @patch.dict("os.environ", {}, clear=True)
 @patch("gptme_activity_summary.cc_backend.call_gptme")
 @patch("gptme_activity_summary.cc_backend.time.sleep")
 @patch("subprocess.run")
-def test_call_claude_code_rejects_non_json_gptme_fallback(mock_run, mock_sleep, mock_gptme):
-    """Plain-text gptme responses must preserve the Claude failure signal."""
+def test_call_claude_code_rejects_invalid_gptme_fallback(
+    mock_run, mock_sleep, mock_gptme, fallback_response
+):
+    """Non-summary gptme responses must preserve the Claude failure signal."""
     mock_run.return_value = _make_completed_process(
         returncode=1, stdout="You've hit your weekly limit"
     )
-    mock_gptme.return_value = "I cannot provide JSON."
+    mock_gptme.return_value = fallback_response
 
     with pytest.raises(ClaudeQuotaExhaustedError):
         call_claude_code("test prompt", max_retries=1)
@@ -864,7 +882,7 @@ def test_call_claude_code_disabled_fallback_slots_reach_gptme(
     )
     mock_run.return_value = disabled
     mock_fallback.return_value = disabled
-    mock_gptme.return_value = '{"ok": "from-gptme"}'
+    mock_gptme.return_value = '{"narrative": "from-gptme"}'
 
     with patch.dict(
         os.environ,
@@ -873,7 +891,7 @@ def test_call_claude_code_disabled_fallback_slots_reach_gptme(
     ):
         result = call_claude_code("test prompt")
 
-    assert result == '{"ok": "from-gptme"}'
+    assert result == '{"narrative": "from-gptme"}'
     mock_fallback.assert_called_once()
     mock_gptme.assert_called_once_with("test prompt", timeout=120)
 
@@ -903,7 +921,7 @@ def test_call_claude_code_quota_gptme_fallback_passes_timeout(mock_run, mock_sle
     mock_run.return_value = _make_completed_process(
         returncode=1, stdout="You've hit your weekly limit"
     )
-    mock_gptme.return_value = '{"ok": 1}'
+    mock_gptme.return_value = '{"narrative": "ok"}'
     call_claude_code("test prompt", timeout=99, max_retries=1)
     mock_gptme.assert_called_once_with("test prompt", timeout=99)
 

--- a/packages/gptme-activity-summary/tests/test_cc_backend.py
+++ b/packages/gptme-activity-summary/tests/test_cc_backend.py
@@ -987,6 +987,38 @@ def test_auth_expiry_raised_when_fallback_slot_returns_empty(
             call_claude_code("test prompt", max_retries=1)
 
 
+@patch("gptme_activity_summary.cc_backend.call_gptme")
+@patch("gptme_activity_summary.cc_backend._try_with_credential_file")
+@patch("gptme_activity_summary.cc_backend.time.sleep")
+@patch("subprocess.run")
+def test_auth_expiry_raised_when_fallback_slot_auth_expires(
+    mock_run, mock_sleep, mock_fallback, mock_gptme, tmp_path
+):
+    """Auth-expiry from a fallback slot must surface even when the primary was quota-exhausted."""
+    import os
+
+    fb_cred = tmp_path / ".credentials.json.alice"
+    fb_cred.write_text("{}")
+    # Primary fails with quota exhaustion.
+    mock_run.return_value = _make_completed_process(
+        returncode=1, stdout="You've hit your weekly limit"
+    )
+    # Fallback credential slot is also auth-expired (non-empty error output).
+    mock_fallback.return_value = _make_completed_process(
+        returncode=1, stdout="Failed to authenticate: OAuth session expired"
+    )
+    # gptme fallback also yields nothing.
+    mock_gptme.return_value = ""
+
+    with patch.dict(
+        os.environ,
+        {"GPTME_CC_FALLBACK_CREDS": str(fb_cred)},
+        clear=True,
+    ):
+        with pytest.raises(ClaudeAuthExpiredError):
+            call_claude_code("test prompt", max_retries=1)
+
+
 # --- Tests for gptme_backend module ---
 
 

--- a/packages/gptme-activity-summary/tests/test_cc_backend.py
+++ b/packages/gptme-activity-summary/tests/test_cc_backend.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from gptme_activity_summary.cc_backend import (
+    ClaudeAuthExpiredError,
     ClaudeQuotaExhaustedError,
     call_claude_code,
     extract_json_from_response,
@@ -652,6 +653,28 @@ def test_call_claude_code_quota_fallback_all_exhausted(
         with pytest.raises(ClaudeQuotaExhaustedError):
             call_claude_code("test prompt")
     mock_gptme.assert_called_once_with("test prompt", timeout=120)
+
+
+@patch("gptme_activity_summary.cc_backend.call_gptme", return_value="")
+@patch("gptme_activity_summary.cc_backend._try_with_credential_file")
+@patch("gptme_activity_summary.cc_backend.time.sleep")
+@patch("subprocess.run")
+def test_call_claude_code_oauth_expiry_raises_auth_error(
+    mock_run, mock_sleep, mock_fallback, mock_gptme
+):
+    """OAuth session expiry raises ClaudeAuthExpiredError (a subtype of ClaudeQuotaExhaustedError).
+
+    ClaudeAuthExpiredError indicates a recoverable auth failure (re-auth via /login)
+    rather than a permanent quota exhaustion, while still inheriting from
+    ClaudeQuotaExhaustedError so existing callers that catch the base type keep working.
+    """
+    mock_run.return_value = _make_completed_process(
+        returncode=1, stdout="Failed to authenticate: OAuth session expired"
+    )
+    with patch.dict("os.environ", {}, clear=True):
+        with pytest.raises(ClaudeAuthExpiredError) as exc_info:
+            call_claude_code("test prompt")
+    assert isinstance(exc_info.value, ClaudeQuotaExhaustedError)
 
 
 @patch("gptme_activity_summary.cc_backend._try_with_credential_file")

--- a/packages/gptme-activity-summary/tests/test_cc_backend.py
+++ b/packages/gptme-activity-summary/tests/test_cc_backend.py
@@ -788,6 +788,7 @@ def _ndjson(msg: str) -> str:
     )
 
 
+@patch.dict("os.environ", {}, clear=True)
 @patch("gptme_activity_summary.cc_backend.call_gptme")
 @patch("gptme_activity_summary.cc_backend.time.sleep")
 @patch("subprocess.run")
@@ -805,6 +806,7 @@ def test_call_claude_code_quota_falls_back_to_gptme(mock_run, mock_sleep, mock_g
     mock_gptme.assert_called_once_with("test prompt", timeout=120)
 
 
+@patch.dict("os.environ", {}, clear=True)
 @patch("gptme_activity_summary.cc_backend.call_gptme")
 @patch("gptme_activity_summary.cc_backend.time.sleep")
 @patch("subprocess.run")
@@ -820,6 +822,7 @@ def test_call_claude_code_quota_gptme_failure_raises_original(mock_run, mock_sle
     mock_gptme.assert_called_once_with("test prompt", timeout=120)
 
 
+@patch.dict("os.environ", {}, clear=True)
 @patch("gptme_activity_summary.cc_backend.call_gptme")
 @patch("gptme_activity_summary.cc_backend.time.sleep")
 @patch("subprocess.run")

--- a/packages/gptme-activity-summary/tests/test_cc_backend.py
+++ b/packages/gptme-activity-summary/tests/test_cc_backend.py
@@ -893,6 +893,36 @@ def test_call_claude_code_rejects_invalid_gptme_fallback(
     mock_gptme.assert_called_once_with("test prompt", timeout=120)
 
 
+@pytest.mark.parametrize(
+    "fallback_response",
+    [
+        # narrative value is a list, not a string
+        '{"narrative": ["some text"]}',
+        # narrative value is a number
+        '{"narrative": 42}',
+        # narrative key exists but maps to None
+        '{"narrative": null}',
+    ],
+)
+@patch.dict("os.environ", {}, clear=True)
+@patch("gptme_activity_summary.cc_backend.call_gptme")
+@patch("gptme_activity_summary.cc_backend.time.sleep")
+@patch("subprocess.run")
+def test_call_claude_code_rejects_non_string_narrative_in_gptme_fallback(
+    mock_run, mock_sleep, mock_gptme, fallback_response
+):
+    """gptme fallback must be rejected when the narrative value is not a string."""
+    mock_run.return_value = _make_completed_process(
+        returncode=1, stdout="You've hit your weekly limit"
+    )
+    mock_gptme.return_value = fallback_response
+
+    with pytest.raises(ClaudeQuotaExhaustedError):
+        call_claude_code("test prompt", max_retries=1)
+
+    mock_gptme.assert_called_once_with("test prompt", timeout=120)
+
+
 @patch("gptme_activity_summary.cc_backend.call_gptme")
 @patch("gptme_activity_summary.cc_backend._try_with_credential_file")
 @patch("gptme_activity_summary.cc_backend.time.sleep")

--- a/packages/gptme-activity-summary/tests/test_cc_backend.py
+++ b/packages/gptme-activity-summary/tests/test_cc_backend.py
@@ -859,12 +859,32 @@ def test_call_gptme_missing_binary(mock_which):
 @patch("gptme_activity_summary.gptme_backend.shutil.which", return_value="/usr/bin/gptme")
 @patch("subprocess.run")
 def test_call_gptme_extracts_assistant_text(mock_run, mock_which):
-    """NDJSON assistant content is extracted from the gptme output."""
+    """NDJSON assistant content is extracted from the gptme output (str form)."""
     import gptme_activity_summary.gptme_backend as gb
 
     mock_run.return_value = subprocess.CompletedProcess(
         args=["gptme"], returncode=0, stdout=_ndjson('{"result": "ok"}')
     )
+    assert gb.call_gptme("hi") == '{"result": "ok"}'
+
+
+@patch("gptme_activity_summary.gptme_backend.shutil.which", return_value="/usr/bin/gptme")
+@patch("subprocess.run")
+def test_call_gptme_extracts_assistant_text_list_content(mock_run, mock_which):
+    """NDJSON assistant content is extracted when content is a list of parts (real gptme format)."""
+    import json as _json
+
+    import gptme_activity_summary.gptme_backend as gb
+
+    ndjson = _json.dumps(
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": '{"result": "ok"}'}],
+            "timestamp": "2026-08-23T00:00:00.000000",
+        }
+    )
+    mock_run.return_value = subprocess.CompletedProcess(args=["gptme"], returncode=0, stdout=ndjson)
     assert gb.call_gptme("hi") == '{"result": "ok"}'
 
 

--- a/packages/gptme-activity-summary/tests/test_cc_backend.py
+++ b/packages/gptme-activity-summary/tests/test_cc_backend.py
@@ -958,8 +958,20 @@ def test_call_claude_code_quota_gptme_fallback_passes_timeout(mock_run, mock_sle
 # --- Tests for gptme_backend module ---
 
 
+def test_call_gptme_disabled_by_default():
+    """Fallback is off by default (no env var set); does not spawn the binary."""
+    import gptme_activity_summary.gptme_backend as gb
+
+    with patch.dict("os.environ", {}, clear=True):
+        with patch.object(gb, "shutil") as mock_shutil:
+            mock_shutil.which.return_value = "/usr/bin/gptme"
+            with patch("subprocess.run") as mock_run:
+                assert gb.call_gptme("hi") == ""
+    mock_run.assert_not_called()
+
+
 def test_call_gptme_disabled_by_env():
-    """Disabling via env short-circuits and does not spawn the binary."""
+    """Explicitly disabling via env (=0) short-circuits and does not spawn the binary."""
     import gptme_activity_summary.gptme_backend as gb
 
     with patch.dict("os.environ", {"GPTME_ACTIVITY_SUMMARY_GPTME_FALLBACK": "0"}, clear=True):
@@ -970,14 +982,16 @@ def test_call_gptme_disabled_by_env():
     mock_run.assert_not_called()
 
 
+@patch.dict("os.environ", {"GPTME_ACTIVITY_SUMMARY_GPTME_FALLBACK": "1"})
 @patch("gptme_activity_summary.gptme_backend.shutil.which", return_value=None)
 def test_call_gptme_missing_binary(mock_which):
-    """Missing gptme binary is handled gracefully."""
+    """Missing gptme binary is handled gracefully (fallback enabled but binary absent)."""
     import gptme_activity_summary.gptme_backend as gb
 
     assert gb.call_gptme("hi") == ""
 
 
+@patch.dict("os.environ", {"GPTME_ACTIVITY_SUMMARY_GPTME_FALLBACK": "1"})
 @patch("gptme_activity_summary.gptme_backend.shutil.which", return_value="/usr/bin/gptme")
 @patch("subprocess.run")
 def test_call_gptme_extracts_assistant_text(mock_run, mock_which):
@@ -990,6 +1004,7 @@ def test_call_gptme_extracts_assistant_text(mock_run, mock_which):
     assert gb.call_gptme("hi") == '{"result": "ok"}'
 
 
+@patch.dict("os.environ", {"GPTME_ACTIVITY_SUMMARY_GPTME_FALLBACK": "1"})
 @patch("gptme_activity_summary.gptme_backend.shutil.which", return_value="/usr/bin/gptme")
 @patch("subprocess.run")
 def test_call_gptme_extracts_assistant_text_list_content(mock_run, mock_which):
@@ -1010,6 +1025,7 @@ def test_call_gptme_extracts_assistant_text_list_content(mock_run, mock_which):
     assert gb.call_gptme("hi") == '{"result": "ok"}'
 
 
+@patch.dict("os.environ", {"GPTME_ACTIVITY_SUMMARY_GPTME_FALLBACK": "1"})
 @patch("gptme_activity_summary.gptme_backend.shutil.which", return_value="/usr/bin/gptme")
 @patch("subprocess.run")
 def test_call_gptme_nonzero_exit_returns_empty(mock_run, mock_which):
@@ -1022,6 +1038,7 @@ def test_call_gptme_nonzero_exit_returns_empty(mock_run, mock_which):
     assert gb.call_gptme("hi") == ""
 
 
+@patch.dict("os.environ", {"GPTME_ACTIVITY_SUMMARY_GPTME_FALLBACK": "1"})
 @patch("gptme_activity_summary.gptme_backend.shutil.which", return_value="/usr/bin/gptme")
 @patch("subprocess.run", side_effect=subprocess.TimeoutExpired("gptme", 30))
 def test_call_gptme_timeout_returns_empty(mock_run, mock_which):
@@ -1031,6 +1048,7 @@ def test_call_gptme_timeout_returns_empty(mock_run, mock_which):
     assert gb.call_gptme("hi") == ""
 
 
+@patch.dict("os.environ", {"GPTME_ACTIVITY_SUMMARY_GPTME_FALLBACK": "1"})
 @patch("gptme_activity_summary.gptme_backend.shutil.which", return_value="/usr/bin/gptme")
 @patch("subprocess.run")
 def test_call_gptme_prompt_passed_via_stdin(mock_run, mock_which):
@@ -1049,6 +1067,7 @@ def test_call_gptme_prompt_passed_via_stdin(mock_run, mock_which):
     assert kwargs.get("input") == "my secret prompt"
 
 
+@patch.dict("os.environ", {"GPTME_ACTIVITY_SUMMARY_GPTME_FALLBACK": "1"})
 @patch("gptme_activity_summary.gptme_backend.shutil.which", return_value="/usr/bin/gptme")
 @patch("subprocess.run")
 def test_call_gptme_list_content_non_string_text_skipped(mock_run, mock_which):

--- a/packages/gptme-activity-summary/tests/test_cc_backend.py
+++ b/packages/gptme-activity-summary/tests/test_cc_backend.py
@@ -171,14 +171,16 @@ def test_call_claude_code_nonzero_exit_raises_after_retries(mock_run, mock_sleep
     assert mock_sleep.call_count == 2  # slept between attempts
 
 
+@patch("gptme_activity_summary.cc_backend.call_gptme", return_value="")
 @patch("gptme_activity_summary.cc_backend.time.sleep")
 @patch("subprocess.run")
-def test_call_claude_code_quota_exhausted_raises_immediately(mock_run, mock_sleep):
+def test_call_claude_code_quota_exhausted_raises_immediately(mock_run, mock_sleep, mock_gptme):
     """Weekly quota exhaustion must raise ClaudeQuotaExhaustedError immediately.
 
     Retrying the same slot is futile when it is quota-exhausted; the failure
     should surface on the first attempt so a caller with slot fallback can retry
-    on a different slot instead of burning the full retry window.
+    on a different slot instead of burning the full retry window. (The gptme
+    fallback is attempted, but returns "" so the original error is re-raised.)
     """
     from gptme_activity_summary.cc_backend import ClaudeQuotaExhaustedError
 
@@ -188,13 +190,15 @@ def test_call_claude_code_quota_exhausted_raises_immediately(mock_run, mock_slee
     with pytest.raises(ClaudeQuotaExhaustedError) as exc_info:
         call_claude_code("test prompt", max_retries=3)
     assert exc_info.value.returncode == 1
-    assert mock_run.call_count == 1  # no retries — quota failure is permanent
+    mock_gptme.assert_called_once_with("test prompt", timeout=120)
+    assert mock_run.call_count == 1  # primary tried once; no retry-loop
     assert mock_sleep.call_count == 0  # no backoff sleep burned
 
 
+@patch("gptme_activity_summary.cc_backend.call_gptme", return_value="")
 @patch("gptme_activity_summary.cc_backend.time.sleep")
 @patch("subprocess.run")
-def test_call_claude_code_quota_marker_in_stderr(mock_run, mock_sleep):
+def test_call_claude_code_quota_marker_in_stderr(mock_run, mock_sleep, mock_gptme):
     """Quota marker in stderr (not stdout) must also be detected."""
     from gptme_activity_summary.cc_backend import ClaudeQuotaExhaustedError
 
@@ -203,7 +207,7 @@ def test_call_claude_code_quota_marker_in_stderr(mock_run, mock_sleep):
     )
     with pytest.raises(ClaudeQuotaExhaustedError):
         call_claude_code("test prompt", max_retries=3)
-    assert mock_run.call_count == 1
+    assert mock_run.call_count == 1  # primary only; gptme mocked, no extra run
 
 
 @patch("gptme_activity_summary.cc_backend.time.sleep")
@@ -765,3 +769,121 @@ def test_call_claude_code_fallback_creds_not_passed_to_subprocess(mock_run):
     call_claude_code("test prompt")
     subprocess_env = mock_run.call_args.kwargs["env"]
     assert "GPTME_CC_FALLBACK_CREDS" not in subprocess_env
+
+
+# --- Tests for gptme fallback on quota exhaustion ---
+
+
+def _ndjson(msg: str) -> str:
+    """Build a minimal gptme NDJSON stream containing one assistant message."""
+    import json as _json
+
+    return _json.dumps(
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": msg,
+            "timestamp": "2026-08-23T00:00:00.000000",
+        }
+    )
+
+
+@patch("gptme_activity_summary.cc_backend.call_gptme")
+@patch("gptme_activity_summary.cc_backend.time.sleep")
+@patch("subprocess.run")
+def test_call_claude_code_quota_falls_back_to_gptme(mock_run, mock_sleep, mock_gptme, tmp_path):
+    """Quota exhaustion on all Claude slots falls back to the gptme backend."""
+    mock_run.return_value = _make_completed_process(
+        returncode=1, stdout="You've hit your weekly limit"
+    )
+    mock_gptme.return_value = '{"ok": "from-gptme"}'
+
+    result = call_claude_code("test prompt", max_retries=3)
+
+    assert result == '{"ok": "from-gptme"}'
+    assert mock_gptme.call_count == 1
+    mock_gptme.assert_called_once_with("test prompt", timeout=120)
+
+
+@patch("gptme_activity_summary.cc_backend.call_gptme")
+@patch("gptme_activity_summary.cc_backend.time.sleep")
+@patch("subprocess.run")
+def test_call_claude_code_quota_gptme_failure_raises_original(mock_run, mock_sleep, mock_gptme):
+    """If the gptme fallback yields nothing, the original quota error is raised."""
+    mock_run.return_value = _make_completed_process(
+        returncode=1, stdout="You've hit your weekly limit"
+    )
+    mock_gptme.return_value = ""  # fallback failed
+
+    with pytest.raises(ClaudeQuotaExhaustedError):
+        call_claude_code("test prompt", max_retries=3)
+    mock_gptme.assert_called_once_with("test prompt", timeout=120)
+
+
+@patch("gptme_activity_summary.cc_backend.call_gptme")
+@patch("gptme_activity_summary.cc_backend.time.sleep")
+@patch("subprocess.run")
+def test_call_claude_code_quota_gptme_fallback_passes_timeout(mock_run, mock_sleep, mock_gptme):
+    """The gptme fallback inherits the caller's timeout."""
+    mock_run.return_value = _make_completed_process(
+        returncode=1, stdout="You've hit your weekly limit"
+    )
+    mock_gptme.return_value = '{"ok": 1}'
+    call_claude_code("test prompt", timeout=99, max_retries=1)
+    mock_gptme.assert_called_once_with("test prompt", timeout=99)
+
+
+# --- Tests for gptme_backend module ---
+
+
+def test_call_gptme_disabled_by_env():
+    """Disabling via env short-circuits and does not spawn the binary."""
+    import gptme_activity_summary.gptme_backend as gb
+
+    with patch.dict("os.environ", {"GPTME_ACTIVITY_SUMMARY_GPTME_FALLBACK": "0"}, clear=True):
+        with patch.object(gb, "shutil") as mock_shutil:
+            mock_shutil.which.return_value = "/usr/bin/gptme"
+            with patch("subprocess.run") as mock_run:
+                assert gb.call_gptme("hi") == ""
+    mock_run.assert_not_called()
+
+
+@patch("gptme_activity_summary.gptme_backend.shutil.which", return_value=None)
+def test_call_gptme_missing_binary(mock_which):
+    """Missing gptme binary is handled gracefully."""
+    import gptme_activity_summary.gptme_backend as gb
+
+    assert gb.call_gptme("hi") == ""
+
+
+@patch("gptme_activity_summary.gptme_backend.shutil.which", return_value="/usr/bin/gptme")
+@patch("subprocess.run")
+def test_call_gptme_extracts_assistant_text(mock_run, mock_which):
+    """NDJSON assistant content is extracted from the gptme output."""
+    import gptme_activity_summary.gptme_backend as gb
+
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=["gptme"], returncode=0, stdout=_ndjson('{"result": "ok"}')
+    )
+    assert gb.call_gptme("hi") == '{"result": "ok"}'
+
+
+@patch("gptme_activity_summary.gptme_backend.shutil.which", return_value="/usr/bin/gptme")
+@patch("subprocess.run")
+def test_call_gptme_nonzero_exit_returns_empty(mock_run, mock_which):
+    """Non-zero gptme exit returns an empty string (no raise)."""
+    import gptme_activity_summary.gptme_backend as gb
+
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=["gptme"], returncode=1, stdout="", stderr="boom"
+    )
+    assert gb.call_gptme("hi") == ""
+
+
+@patch("gptme_activity_summary.gptme_backend.shutil.which", return_value="/usr/bin/gptme")
+@patch("subprocess.run", side_effect=subprocess.TimeoutExpired("gptme", 30))
+def test_call_gptme_timeout_returns_empty(mock_run, mock_which):
+    """A timed-out gptme call returns an empty string (no raise)."""
+    import gptme_activity_summary.gptme_backend as gb
+
+    assert gb.call_gptme("hi") == ""

--- a/packages/gptme-activity-summary/tests/test_cc_backend.py
+++ b/packages/gptme-activity-summary/tests/test_cc_backend.py
@@ -1392,3 +1392,83 @@ def test_call_claude_code_oauth_expiry_preserved_when_fallback_has_non_sub_error
     ):
         with pytest.raises(ClaudeAuthExpiredError):
             call_claude_code("test prompt", max_retries=2)
+
+
+@patch.dict("os.environ", {"GPTME_ACTIVITY_SUMMARY_GPTME_FALLBACK": "1"})
+@patch("gptme_activity_summary.gptme_backend.shutil.which", return_value="/usr/bin/gptme")
+@patch("subprocess.run")
+def test_extract_assistant_text_non_dict_json_does_not_raise(mock_run, mock_which):
+    """_extract_assistant_text must not raise when json.loads produces a non-dict.
+
+    Regression: parsed.get(k) raises AttributeError when the assistant content
+    is valid JSON but not an object (e.g. an array, string, or number).  The fix
+    wraps the key-presence check with isinstance(parsed, dict), so non-object
+    candidates fall through to the first-JSON-parseable fallback without crashing.
+    """
+    import json as _json
+
+    import gptme_activity_summary.gptme_backend as gb
+
+    # First message is valid JSON but an array — not a dict
+    array_msg = _json.dumps(
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": '["item1", "item2"]',
+            "timestamp": "2026-08-26T00:00:00.000000",
+        }
+    )
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=["gptme"], returncode=0, stdout=array_msg
+    )
+    # Must not raise; falls back to returning the (only) JSON candidate
+    result = gb.call_gptme("hi")
+    assert result == '["item1", "item2"]'
+
+
+@patch("gptme_activity_summary.cc_backend.call_gptme", return_value="")
+@patch("gptme_activity_summary.cc_backend._try_with_credential_file")
+@patch("gptme_activity_summary.cc_backend.time.sleep")
+@patch("subprocess.run")
+def test_auth_expiry_raised_when_first_fallback_auth_expires_and_second_fallback_non_sub_error(
+    mock_run, mock_sleep, mock_fallback, mock_gptme, tmp_path
+):
+    """saw_fallback_auth_failure must gate ClaudeAuthExpiredError in the last_non_subscription_error branch.
+
+    Scenario:
+    - Primary slot: quota-exhausted (hits weekly limit)
+    - Fallback slot A: OAuth-expired -> saw_fallback_auth_failure = True, last_non_subscription_error cleared
+    - Fallback slot B: non-subscription rc=2 -> last_non_subscription_error set
+
+    Without the fix, the last_non_subscription_error branch only checked
+    combined_out_lower (the primary's output, which has no auth marker), so
+    ClaudeAuthExpiredError was never raised and a generic CalledProcessError
+    escaped instead — callers catching the subtype to trigger re-auth never saw it.
+    """
+    import os
+
+    fb_auth_cred = tmp_path / ".credentials.json.auth_expired"
+    fb_auth_cred.write_text("{}")
+    fb_badsub_cred = tmp_path / ".credentials.json.bad_sub"
+    fb_badsub_cred.write_text("{}")
+
+    # Primary is quota-exhausted (not auth-expired)
+    mock_run.return_value = _make_completed_process(
+        returncode=1, stdout="You've hit your weekly limit"
+    )
+    # Fallback A: auth-expired -> sets saw_fallback_auth_failure, clears last_non_subscription_error
+    # Fallback B: non-subscription error rc=2 -> sets last_non_subscription_error
+    mock_fallback.side_effect = [
+        _make_completed_process(
+            returncode=1, stdout="Failed to authenticate: OAuth session expired"
+        ),
+        _make_completed_process(returncode=2, stderr="bad credentials"),
+    ]
+
+    with patch.dict(
+        os.environ,
+        {"GPTME_CC_FALLBACK_CREDS": os.pathsep.join([str(fb_auth_cred), str(fb_badsub_cred)])},
+        clear=True,
+    ):
+        with pytest.raises(ClaudeAuthExpiredError):
+            call_claude_code("test prompt", max_retries=1)

--- a/packages/gptme-activity-summary/tests/test_cc_backend.py
+++ b/packages/gptme-activity-summary/tests/test_cc_backend.py
@@ -955,6 +955,38 @@ def test_call_claude_code_quota_gptme_fallback_passes_timeout(mock_run, mock_sle
     mock_gptme.assert_called_once_with("test prompt", timeout=99)
 
 
+@patch("gptme_activity_summary.cc_backend.call_gptme")
+@patch("gptme_activity_summary.cc_backend._try_with_credential_file")
+@patch("gptme_activity_summary.cc_backend.time.sleep")
+@patch("subprocess.run")
+def test_auth_expiry_raised_when_fallback_slot_returns_empty(
+    mock_run, mock_sleep, mock_fallback, mock_gptme, tmp_path
+):
+    """Auth-expiry from primary must surface even when fallback slot returns empty."""
+    import os
+
+    fb_cred = tmp_path / ".credentials.json.alice"
+    fb_cred.write_text("{}")
+    # Primary fails with auth expiry marker.
+    auth_error = _make_completed_process(
+        returncode=1,
+        stdout="Failed to authenticate: OAuth session expired",
+    )
+    mock_run.return_value = auth_error
+    # Fallback credential slot returns rc=0 but empty stdout.
+    mock_fallback.return_value = _make_completed_process(returncode=0, stdout="")
+    # gptme fallback also yields nothing.
+    mock_gptme.return_value = ""
+
+    with patch.dict(
+        os.environ,
+        {"GPTME_CC_FALLBACK_CREDS": str(fb_cred)},
+        clear=True,
+    ):
+        with pytest.raises(ClaudeAuthExpiredError):
+            call_claude_code("test prompt", max_retries=1)
+
+
 # --- Tests for gptme_backend module ---
 
 

--- a/packages/gptme-activity-summary/tests/test_cc_backend.py
+++ b/packages/gptme-activity-summary/tests/test_cc_backend.py
@@ -907,3 +907,45 @@ def test_call_gptme_timeout_returns_empty(mock_run, mock_which):
     import gptme_activity_summary.gptme_backend as gb
 
     assert gb.call_gptme("hi") == ""
+
+
+@patch("gptme_activity_summary.gptme_backend.shutil.which", return_value="/usr/bin/gptme")
+@patch("subprocess.run")
+def test_call_gptme_prompt_passed_via_stdin(mock_run, mock_which):
+    """Prompt is passed as stdin input, not as a positional CLI argument."""
+    import gptme_activity_summary.gptme_backend as gb
+
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=["gptme"], returncode=0, stdout=_ndjson("result")
+    )
+    gb.call_gptme("my secret prompt")
+
+    _, kwargs = mock_run.call_args
+    # prompt must not appear in the command list
+    assert "my secret prompt" not in mock_run.call_args[0][0]
+    # prompt must be passed via the input kwarg
+    assert kwargs.get("input") == "my secret prompt"
+
+
+@patch("gptme_activity_summary.gptme_backend.shutil.which", return_value="/usr/bin/gptme")
+@patch("subprocess.run")
+def test_call_gptme_list_content_non_string_text_skipped(mock_run, mock_which):
+    """Non-string text values in list content parts are skipped without raising."""
+    import json as _json
+
+    import gptme_activity_summary.gptme_backend as gb
+
+    # Emit a part with text=None (edge case in malformed gptme output)
+    ndjson = _json.dumps(
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": None},
+                {"type": "text", "text": "valid text"},
+            ],
+        }
+    )
+    mock_run.return_value = subprocess.CompletedProcess(args=["gptme"], returncode=0, stdout=ndjson)
+    # Must not raise AttributeError; must return the valid part
+    assert gb.call_gptme("hi") == "valid text"

--- a/packages/gptme-activity-summary/tests/test_cc_backend.py
+++ b/packages/gptme-activity-summary/tests/test_cc_backend.py
@@ -1234,6 +1234,45 @@ def test_call_gptme_reasoning_model_preamble_skipped(mock_run, mock_which):
     ), "must skip non-JSON preamble and return the JSON answer message"
 
 
+@patch.dict("os.environ", {"GPTME_ACTIVITY_SUMMARY_GPTME_FALLBACK": "1"})
+@patch("gptme_activity_summary.gptme_backend.shutil.which", return_value="/usr/bin/gptme")
+@patch("subprocess.run")
+def test_call_gptme_json_preamble_not_returned(mock_run, mock_which):
+    """Reasoning models may emit a JSON-shaped thinking block before the real summary.
+
+    When the first assistant message is valid JSON but contains no recognised
+    summary key (e.g. {"thinking": "..."}), _extract_assistant_text must skip it
+    and return the later message that contains the summary key.
+    """
+    import json as _json
+
+    import gptme_activity_summary.gptme_backend as gb
+
+    thinking_msg = _json.dumps(
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": '{"thinking": "let me summarize the entries..."}',
+            "timestamp": "2026-08-26T00:00:00.000000",
+        }
+    )
+    answer_msg = _json.dumps(
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": '{"narrative": "actual summary", "title": "Daily Summary"}',
+            "timestamp": "2026-08-26T00:00:01.000000",
+        }
+    )
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=["gptme"], returncode=0, stdout=f"{thinking_msg}\n{answer_msg}"
+    )
+    result = gb.call_gptme("summarize")
+    assert (
+        result == '{"narrative": "actual summary", "title": "Daily Summary"}'
+    ), "must prefer message containing a summary key over JSON-shaped thinking preamble"
+
+
 @patch.dict("os.environ", {}, clear=True)
 @patch("gptme_activity_summary.cc_backend.call_gptme")
 @patch("gptme_activity_summary.cc_backend.time.sleep")

--- a/packages/gptme-activity-summary/tests/test_cc_backend.py
+++ b/packages/gptme-activity-summary/tests/test_cc_backend.py
@@ -1234,6 +1234,33 @@ def test_call_claude_code_gptme_fallback_remaps_when_requested_key_empty(
     ), "empty requested key must be replaced with the alternate key's value"
 
 
+@patch.dict("os.environ", {}, clear=True)
+@patch("gptme_activity_summary.cc_backend.call_gptme")
+@patch("gptme_activity_summary.cc_backend.time.sleep")
+@patch("subprocess.run")
+def test_call_claude_code_gptme_fallback_rejects_empty_requested_key_no_alternate(
+    mock_run, mock_sleep, mock_gptme
+):
+    """When gptme returns the requested key present but empty and no alternate key
+    has content, the fallback must be rejected — not returned as a 'successful'
+    empty summary.
+
+    Regression: the remap loop previously did a no-op self-assignment
+    (gptme_result[k] = gptme_result.pop(k)) when alt_key == narrative_key, then
+    the validation at line 360 used `key in gptme_result` (existence) rather than
+    `gptme_result.get(key)` (content), so an empty month_narrative was accepted and
+    returned as a successful fallback — producing a silent empty narrative on quota days.
+    """
+    mock_run.return_value = _make_completed_process(
+        returncode=1, stdout="You've hit your weekly limit"
+    )
+    # gptme returns the requested key but empty — no alternate key present
+    mock_gptme.return_value = '{"month_narrative": ""}'
+
+    with pytest.raises(ClaudeQuotaExhaustedError):
+        call_claude_code("test prompt", max_retries=1, narrative_key="month_narrative")
+
+
 @patch("gptme_activity_summary.cc_backend.call_gptme", return_value="")
 @patch("gptme_activity_summary.cc_backend._try_with_credential_file")
 @patch("gptme_activity_summary.cc_backend.time.sleep")

--- a/packages/gptme-activity-summary/tests/test_cc_backend.py
+++ b/packages/gptme-activity-summary/tests/test_cc_backend.py
@@ -705,13 +705,18 @@ def test_call_claude_code_quota_fallback_retries_non_quota_error(
     mock_sleep.assert_called_once_with(5)
 
 
+@patch("gptme_activity_summary.cc_backend.call_gptme", return_value="")
 @patch("gptme_activity_summary.cc_backend._try_with_credential_file")
 @patch("gptme_activity_summary.cc_backend.time.sleep")
 @patch("subprocess.run")
 def test_call_claude_code_quota_fallback_preserves_non_quota_error(
-    mock_run, mock_sleep, mock_fallback, tmp_path
+    mock_run, mock_sleep, mock_fallback, mock_gptme, tmp_path
 ):
-    """An exhausted fallback retry window preserves the last non-quota failure."""
+    """An exhausted fallback retry window preserves the last non-quota failure.
+
+    gptme fallback is attempted first (and produces nothing), then the
+    non-subscription error from the credential slot is re-raised.
+    """
     fb_cred = tmp_path / ".credentials.json.invalid"
     fb_cred.write_text("{}")
     mock_run.return_value = _make_completed_process(
@@ -732,6 +737,7 @@ def test_call_claude_code_quota_fallback_preserves_non_quota_error(
     assert exc_info.value.stderr == "invalid credentials"
     assert mock_fallback.call_count == 2
     mock_sleep.assert_called_once_with(5)
+    mock_gptme.assert_called_once()  # gptme is tried before raising
 
 
 @patch("gptme_activity_summary.cc_backend.call_gptme", return_value="")

--- a/packages/gptme-activity-summary/tests/test_cc_backend.py
+++ b/packages/gptme-activity-summary/tests/test_cc_backend.py
@@ -1092,6 +1092,74 @@ def test_call_gptme_list_content_non_string_text_skipped(mock_run, mock_which):
     assert gb.call_gptme("hi") == "valid text"
 
 
+@patch.dict("os.environ", {"GPTME_ACTIVITY_SUMMARY_GPTME_FALLBACK": "1"})
+@patch("gptme_activity_summary.gptme_backend.shutil.which", return_value="/usr/bin/gptme")
+@patch("subprocess.run")
+def test_call_gptme_multiple_assistant_messages_returns_first_only(mock_run, mock_which):
+    """When gptme emits multiple assistant messages, only the first is returned.
+
+    Joining them with newlines produces a multi-JSON string — the greedy regex
+    in extract_json_from_response then spans across both objects and fails to
+    parse any valid JSON, so the fallback silently yields nothing.
+    """
+    import json as _json
+
+    import gptme_activity_summary.gptme_backend as gb
+
+    first_msg = _json.dumps(
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": '{"narrative": "first"}',
+            "timestamp": "2026-08-23T00:00:00.000000",
+        }
+    )
+    second_msg = _json.dumps(
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": "No tool call detected.",
+            "timestamp": "2026-08-23T00:00:01.000000",
+        }
+    )
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=["gptme"], returncode=0, stdout=f"{first_msg}\n{second_msg}"
+    )
+    result = gb.call_gptme("hi")
+    assert result == '{"narrative": "first"}', "only the first assistant message must be returned"
+
+
+@patch.dict("os.environ", {}, clear=True)
+@patch("gptme_activity_summary.cc_backend.call_gptme")
+@patch("gptme_activity_summary.cc_backend.time.sleep")
+@patch("subprocess.run")
+def test_call_claude_code_gptme_fallback_remaps_alternate_narrative_key(
+    mock_run, mock_sleep, mock_gptme
+):
+    """When gptme returns an alternate recognised key instead of the exact requested one,
+    the key is remapped so the caller always finds narrative_key in the returned JSON.
+
+    Without remapping, a monthly summary call (narrative_key='month_narrative') that
+    receives '{"narrative": "..."}' passes schema validation but leaves the caller
+    reading gptme_result.get('month_narrative', '') — which defaults to '' and
+    silently produces an empty narrative on quota days.
+    """
+    import json as _json
+
+    mock_run.return_value = _make_completed_process(
+        returncode=1, stdout="You've hit your weekly limit"
+    )
+    # gptme returns "narrative" but the caller expects "month_narrative"
+    mock_gptme.return_value = '{"narrative": "monthly stuff"}'
+
+    result = call_claude_code("test prompt", max_retries=1, narrative_key="month_narrative")
+
+    parsed = _json.loads(result)
+    assert "month_narrative" in parsed, "caller-expected key must be present after remap"
+    assert parsed["month_narrative"] == "monthly stuff"
+    assert "narrative" not in parsed, "original alternate key must be replaced by remap"
+
+
 @patch("gptme_activity_summary.cc_backend.call_gptme", return_value="")
 @patch("gptme_activity_summary.cc_backend._try_with_credential_file")
 @patch("gptme_activity_summary.cc_backend.time.sleep")


### PR DESCRIPTION
## Problem

`gptme_activity_summary` summarizes via `claude -p` only (`cc_backend.py`). When the active Claude subscription is at its weekly quota ("You've hit your weekly limit"), daily summary generation fails entirely and `daily-summary-health` fires. This was the **5th auto-resolve flip in 8 days** (2026-08-10, -11, -12, -15, -18). On 2026-08-18 the missing 2026-08-17 summary had to be manually backfilled with gptme because both `bob` and `alice` slots were at 100% weekly.

## Change

Add a **gptme fallback** so `summarize_daily_with_cc` (and siblings — weekly/monthly/journal/GitHub/human-day) do not hard-fail when all Claude slots are quota-exhausted.

- New module `gptme_backend.py`: invokes `gptme -n --no-stream --output-format json --tools none -m <model>` and extracts the assistant text from the NDJSON stream. Best-effort — returns `""` on any failure (missing binary, non-zero exit, timeout, unparseable output) and never raises.
- `call_claude_code`: when all Claude slots raise `ClaudeQuotaExhaustedError`, it first tries `call_gptme`. If gptme produces a summary, it returns it; otherwise the original `ClaudeQuotaExhaustedError` is re-raised so behavior is unchanged when no fallback is available.

Config:
- `GPTME_ACTIVITY_SUMMARY_GPTME_FALLBACK=0` disables the fallback.
- `GPTME_ACTIVITY_SUMMARY_GPTME_MODEL` pins the model (default `openrouter/deepseek/deepseek-v4-flash-0731@deepseek`, a cheap fallback tier).

## Verification

- 199 package tests pass (added gptme fallback + backend unit tests).
- `ruff check` and `mypy` clean.
- End-to-end smoke test: `call_gptme` against the live deepseek model returned the expected JSON.

Closes the reliability gap behind the task `gptme-fallback-for-activity-summary`.
