### PR TITLE
fix(git-safe-commit): block exclusion-only pathspec and pathspec-file bypass

### DIFF
--- a/scripts/git/git-safe-commit
+++ b/scripts/git/git-safe-commit
@@ -36,6 +36,8 @@ PARSE_AFTER_DASHDASH=0
 SKIP_NEXT_ARG=0
 SKIP_NEXT_OPTIONAL_ARG=0
 PATHSPEC_FROM_FILE_NEXT=0
+PATHSPEC_FROM_FILE=""
+PATHSPEC_FILE_NUL=0
 FORWARD_ARGS=()
 PATHSPEC_STDIN_TMP=""
 MATERIALIZED_PATHSPEC_FILE=""
@@ -118,6 +120,15 @@ pathspec_file_has_positive() {
     esac
     [ -f "$psfile" ] || return 1
     local line
+    if [ "${PATHSPEC_FILE_NUL:-0}" -eq 1 ]; then
+        while IFS= read -r -d '' line || [ -n "$line" ]; do
+            [ -z "$line" ] && continue
+            if ! is_exclusion_only_pathspec "$line"; then
+                return 0
+            fi
+        done < "$psfile"
+        return 1
+    fi
     while IFS= read -r line || [ -n "$line" ]; do
         [ -z "$line" ] && continue
         if ! is_exclusion_only_pathspec "$line"; then
@@ -125,6 +136,34 @@ pathspec_file_has_positive() {
         fi
     done < "$psfile"
     return 1
+}
+
+# Rewrite FORWARD_ARGS so a materialized stdin pathspec file replaces '-'
+# (equals form or the following argument of --pathspec-from-file).
+rewrite_forward_pathspec_file() {
+    local original="$1"
+    local materialized="$2"
+    local fa skip_replace
+    local new_args=()
+    skip_replace=0
+    for fa in "${FORWARD_ARGS[@]}"; do
+        if [ "$skip_replace" -eq 1 ]; then
+            new_args+=("$materialized")
+            skip_replace=0
+            continue
+        fi
+        if [ "$fa" = "--pathspec-from-file" ]; then
+            new_args+=("$fa")
+            skip_replace=1
+            continue
+        fi
+        if [ "$fa" = "--pathspec-from-file=${original}" ]; then
+            new_args+=("--pathspec-from-file=${materialized}")
+            continue
+        fi
+        new_args+=("$fa")
+    done
+    FORWARD_ARGS=("${new_args[@]}")
 }
 
 for arg in "$@"; do
@@ -145,15 +184,12 @@ for arg in "$@"; do
         # Arg starts with '-': it's a new flag, not a value — fall through
     fi
 
-    # --pathspec-from-file <file>: read the file to check for positive pathspecs
+    # --pathspec-from-file <file>: record the path; validate after all flags
+    # so --pathspec-file-nul can appear before or after the file argument.
     if [ "$PATHSPEC_FROM_FILE_NEXT" -eq 1 ]; then
         PATHSPEC_FROM_FILE_NEXT=0
-        materialize_pathspec_file "$arg"
-        arg="$MATERIALIZED_PATHSPEC_FILE"
+        PATHSPEC_FROM_FILE="$arg"
         FORWARD_ARGS+=("$arg")
-        if pathspec_file_has_positive "$arg"; then
-            PATHSPEC_COUNT=$((PATHSPEC_COUNT + 1))
-        fi
         continue
     fi
 
@@ -193,20 +229,16 @@ for arg in "$@"; do
             SKIP_NEXT_OPTIONAL_ARG=1
             ;;
         --pathspec-from-file)
-            # Value is the next arg; defer counting until we can inspect the file.
+            # Value is the next arg; defer counting until all flags are known.
             PATHSPEC_FROM_FILE_NEXT=1
+            ;;
+        --pathspec-file-nul)
+            PATHSPEC_FILE_NUL=1
             ;;
         --message=*|--file=*|--author=*|--date=*|--fixup=*|--squash=*|--trailer=*|--gpg-sign=*)
             ;;
         --pathspec-from-file=*)
-            _psfile="${arg#--pathspec-from-file=}"
-            materialize_pathspec_file "$_psfile"
-            if [ "$MATERIALIZED_PATHSPEC_FILE" != "$_psfile" ]; then
-                FORWARD_ARGS[-1]="--pathspec-from-file=${MATERIALIZED_PATHSPEC_FILE}"
-            fi
-            if pathspec_file_has_positive "$MATERIALIZED_PATHSPEC_FILE"; then
-                PATHSPEC_COUNT=$((PATHSPEC_COUNT + 1))
-            fi
+            PATHSPEC_FROM_FILE="${arg#--pathspec-from-file=}"
             ;;
         -*)
             ;;
@@ -220,6 +252,19 @@ for arg in "$@"; do
             ;;
     esac
 done
+
+# Validate --pathspec-from-file after the full parse so --pathspec-file-nul
+# is honored regardless of flag order.
+if [ -n "$PATHSPEC_FROM_FILE" ]; then
+    _original_psfile="$PATHSPEC_FROM_FILE"
+    materialize_pathspec_file "$PATHSPEC_FROM_FILE"
+    if [ "$MATERIALIZED_PATHSPEC_FILE" != "$_original_psfile" ]; then
+        rewrite_forward_pathspec_file "$_original_psfile" "$MATERIALIZED_PATHSPEC_FILE"
+    fi
+    if pathspec_file_has_positive "$MATERIALIZED_PATHSPEC_FILE"; then
+        PATHSPEC_COUNT=$((PATHSPEC_COUNT + 1))
+    fi
+fi
 
 if [ "$PATHSPEC_COUNT" -eq 0 ] && [ "$ALLOW_ALL_STAGED" -ne 1 ] && [ "$ALLOW_EMPTY" -ne 1 ]; then
     echo "🚫 Refusing implicit whole-index commit in shared repo" >&2

--- a/scripts/git/git-safe-commit
+++ b/scripts/git/git-safe-commit
@@ -34,12 +34,89 @@ PATHSPEC_COUNT=0
 PATHSPECS=()
 PARSE_AFTER_DASHDASH=0
 SKIP_NEXT_ARG=0
+SKIP_NEXT_OPTIONAL_ARG=0
+PATHSPEC_FROM_FILE_NEXT=0
 FORWARD_ARGS=()
+
+# Returns 0 (true) if the pathspec is exclusion-only (e.g., :(exclude)foo, :!foo, :^foo).
+# Exclusion-only pathspecs don't positively select any files, so they must not be
+# counted toward PATHSPEC_COUNT — otherwise a commit with only exclusion args would
+# bypass the whole-index guard.
+is_exclusion_only_pathspec() {
+    local ps="$1"
+    # Strip C-quoted outer double-quotes, decoding common octal escapes
+    if [[ "$ps" == '"'* && "$ps" == *'"' ]]; then
+        local inner="${ps:1:${#ps}-2}"
+        inner="${inner//\\072/:}"   # \072 (octal) = ':'
+        inner="${inner//\\041/!}"   # \041 (octal) = '!'
+        ps="$inner"
+    fi
+    # Shorthand exclusion prefixes
+    case "$ps" in
+        ':!'*|':^'*) return 0 ;;
+    esac
+    # Long-form :(magic)path — look for 'exclude' in the comma-separated magic list
+    if [[ "$ps" == ':'* ]]; then
+        local rest="${ps:1}"
+        if [[ "$rest" == '('* ]]; then
+            local magic="${rest:1}"
+            magic="${magic%%)*}"
+            local IFS=','
+            for m in $magic; do
+                [[ "$m" == "exclude" ]] && return 0
+            done
+        fi
+    fi
+    return 1
+}
+
+# Returns 0 (true) if the file contains at least one positive (non-exclusion) pathspec.
+# Used for --pathspec-from-file validation: a file of only exclusion lines or blank
+# lines is treated as "no explicit positive pathspecs" for the whole-index guard.
+pathspec_file_has_positive() {
+    local psfile="$1"
+    # /dev/null and empty string explicitly mean "no pathspecs"
+    case "$psfile" in
+        /dev/null|'') return 1 ;;
+    esac
+    # stdin ('-') can't be pre-read; treat it conservatively as having positive entries
+    [ "$psfile" = "-" ] && return 0
+    [ -f "$psfile" ] || return 1
+    local line
+    while IFS= read -r line || [ -n "$line" ]; do
+        [ -z "$line" ] && continue
+        if ! is_exclusion_only_pathspec "$line"; then
+            return 0
+        fi
+    done < "$psfile"
+    return 1
+}
 
 for arg in "$@"; do
     if [ "$SKIP_NEXT_ARG" -eq 1 ]; then
         SKIP_NEXT_ARG=0
         FORWARD_ARGS+=("$arg")
+        continue
+    fi
+
+    # -S/--gpg-sign takes an optional value; only consume the next arg as a key
+    # if it doesn't look like a new option flag.
+    if [ "$SKIP_NEXT_OPTIONAL_ARG" -eq 1 ]; then
+        SKIP_NEXT_OPTIONAL_ARG=0
+        if [[ "$arg" != -* ]]; then
+            FORWARD_ARGS+=("$arg")
+            continue
+        fi
+        # Arg starts with '-': it's a new flag, not a value — fall through
+    fi
+
+    # --pathspec-from-file <file>: read the file to check for positive pathspecs
+    if [ "$PATHSPEC_FROM_FILE_NEXT" -eq 1 ]; then
+        PATHSPEC_FROM_FILE_NEXT=0
+        FORWARD_ARGS+=("$arg")
+        if pathspec_file_has_positive "$arg"; then
+            PATHSPEC_COUNT=$((PATHSPEC_COUNT + 1))
+        fi
         continue
     fi
 
@@ -59,8 +136,10 @@ for arg in "$@"; do
     FORWARD_ARGS+=("$arg")
 
     if [ "$PARSE_AFTER_DASHDASH" -eq 1 ]; then
-        PATHSPEC_COUNT=$((PATHSPEC_COUNT + 1))
-        PATHSPECS+=("$arg")
+        if ! is_exclusion_only_pathspec "$arg"; then
+            PATHSPEC_COUNT=$((PATHSPEC_COUNT + 1))
+            PATHSPECS+=("$arg")
+        fi
         continue
     fi
 
@@ -71,20 +150,32 @@ for arg in "$@"; do
         -m|--message|-F|--file|-c|--reedit-message|-C|--reuse-message|--fixup|--squash|--author|--date|--trailer)
             SKIP_NEXT_ARG=1
             ;;
-        --pathspec-from-file)
-            SKIP_NEXT_ARG=1
-            PATHSPEC_COUNT=$((PATHSPEC_COUNT + 1))
+        -S|--gpg-sign)
+            # -S/--gpg-sign has an optional key-id value; use the optional-skip
+            # path so we don't miscount the key as a pathspec.
+            SKIP_NEXT_OPTIONAL_ARG=1
             ;;
-        --message=*|--file=*|--author=*|--date=*|--fixup=*|--squash=*|--trailer=*)
+        --pathspec-from-file)
+            # Value is the next arg; defer counting until we can inspect the file.
+            PATHSPEC_FROM_FILE_NEXT=1
+            ;;
+        --message=*|--file=*|--author=*|--date=*|--fixup=*|--squash=*|--trailer=*|--gpg-sign=*)
             ;;
         --pathspec-from-file=*)
-            PATHSPEC_COUNT=$((PATHSPEC_COUNT + 1))
+            _psfile="${arg#--pathspec-from-file=}"
+            if pathspec_file_has_positive "$_psfile"; then
+                PATHSPEC_COUNT=$((PATHSPEC_COUNT + 1))
+            fi
             ;;
         -*)
             ;;
         *)
-            PATHSPEC_COUNT=$((PATHSPEC_COUNT + 1))
-            PATHSPECS+=("$arg")
+            # Only count positively-selecting pathspecs; exclusion-only pathspecs
+            # (e.g., :(exclude)foo, :!foo) don't name files to include.
+            if ! is_exclusion_only_pathspec "$arg"; then
+                PATHSPEC_COUNT=$((PATHSPEC_COUNT + 1))
+                PATHSPECS+=("$arg")
+            fi
             ;;
     esac
 done

--- a/scripts/git/git-safe-commit
+++ b/scripts/git/git-safe-commit
@@ -37,6 +37,42 @@ SKIP_NEXT_ARG=0
 SKIP_NEXT_OPTIONAL_ARG=0
 PATHSPEC_FROM_FILE_NEXT=0
 FORWARD_ARGS=()
+PATHSPEC_STDIN_TMP=""
+MATERIALIZED_PATHSPEC_FILE=""
+
+# Invoked via trap; shellcheck cannot see the indirect call.
+# shellcheck disable=SC2317
+cleanup_pathspec_stdin_tmp() {
+    if [ -n "${PATHSPEC_STDIN_TMP}" ]; then
+        rm -f "${PATHSPEC_STDIN_TMP}"
+    fi
+}
+trap cleanup_pathspec_stdin_tmp EXIT
+
+# Copy stdin to a seekable temp file so we can both validate contents and
+# rewrite --pathspec-from-file=- for git commit (stdin cannot be rewound).
+# TTY stdin is treated as empty (/dev/null) so we never hang waiting for input.
+#
+# Writes the result to MATERIALIZED_PATHSPEC_FILE — must NOT use command
+# substitution, or PATHSPEC_STDIN_TMP (and the EXIT trap) would be lost
+# in the subshell.
+materialize_pathspec_file() {
+    local psfile="$1"
+    MATERIALIZED_PATHSPEC_FILE="$psfile"
+    if [ "$psfile" != "-" ]; then
+        return 0
+    fi
+    if [ -t 0 ]; then
+        MATERIALIZED_PATHSPEC_FILE="/dev/null"
+        return 0
+    fi
+    PATHSPEC_STDIN_TMP="$(mktemp "${TMPDIR:-/tmp}/git-safe-commit-pathspec.XXXXXX")" || {
+        echo "error: could not create temp file for --pathspec-from-file=-" >&2
+        exit 1
+    }
+    cat > "$PATHSPEC_STDIN_TMP"
+    MATERIALIZED_PATHSPEC_FILE="$PATHSPEC_STDIN_TMP"
+}
 
 # Returns 0 (true) if the pathspec is exclusion-only (e.g., :(exclude)foo, :!foo, :^foo).
 # Exclusion-only pathspecs don't positively select any files, so they must not be
@@ -75,12 +111,11 @@ is_exclusion_only_pathspec() {
 # lines is treated as "no explicit positive pathspecs" for the whole-index guard.
 pathspec_file_has_positive() {
     local psfile="$1"
-    # /dev/null and empty string explicitly mean "no pathspecs"
+    # /dev/null, empty string, and unresolved stdin ('-') mean "no pathspecs".
+    # Callers should materialize '-' first; this is a safety net if they don't.
     case "$psfile" in
-        /dev/null|'') return 1 ;;
+        /dev/null|''|-) return 1 ;;
     esac
-    # stdin ('-') can't be pre-read; treat it conservatively as having positive entries
-    [ "$psfile" = "-" ] && return 0
     [ -f "$psfile" ] || return 1
     local line
     while IFS= read -r line || [ -n "$line" ]; do
@@ -113,6 +148,8 @@ for arg in "$@"; do
     # --pathspec-from-file <file>: read the file to check for positive pathspecs
     if [ "$PATHSPEC_FROM_FILE_NEXT" -eq 1 ]; then
         PATHSPEC_FROM_FILE_NEXT=0
+        materialize_pathspec_file "$arg"
+        arg="$MATERIALIZED_PATHSPEC_FILE"
         FORWARD_ARGS+=("$arg")
         if pathspec_file_has_positive "$arg"; then
             PATHSPEC_COUNT=$((PATHSPEC_COUNT + 1))
@@ -163,7 +200,11 @@ for arg in "$@"; do
             ;;
         --pathspec-from-file=*)
             _psfile="${arg#--pathspec-from-file=}"
-            if pathspec_file_has_positive "$_psfile"; then
+            materialize_pathspec_file "$_psfile"
+            if [ "$MATERIALIZED_PATHSPEC_FILE" != "$_psfile" ]; then
+                FORWARD_ARGS[-1]="--pathspec-from-file=${MATERIALIZED_PATHSPEC_FILE}"
+            fi
+            if pathspec_file_has_positive "$MATERIALIZED_PATHSPEC_FILE"; then
                 PATHSPEC_COUNT=$((PATHSPEC_COUNT + 1))
             fi
             ;;

--- a/tests/test_git_safe_commit.py
+++ b/tests/test_git_safe_commit.py
@@ -440,6 +440,80 @@ def test_safe_commit_allows_positive_stdin_pathspec(git_repo: Path):
     assert "test: stdin pathspec" in log.stdout
 
 
+def test_safe_commit_refuses_nul_separated_exclusion_only_pathspec_file(
+    git_repo: Path,
+):
+    """--pathspec-file-nul exclusion-only entries must not count as a selector."""
+    _stage_file(git_repo, "test.txt")
+    psfile = git_repo / "pathspecs"
+    psfile.write_bytes(b":!test.txt\0:!other.txt\0")
+    result = subprocess.run(
+        [
+            str(SAFE_COMMIT),
+            "--pathspec-file-nul",
+            f"--pathspec-from-file={psfile}",
+            "-m",
+            "should refuse",
+        ],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1, result.stderr
+    assert "implicit whole-index commit" in result.stderr.lower()
+
+
+def test_safe_commit_refuses_nul_exclusions_when_nul_flag_follows_file(
+    git_repo: Path,
+):
+    """--pathspec-file-nul must apply even when it appears after the file arg."""
+    _stage_file(git_repo, "test.txt")
+    psfile = git_repo / "pathspecs"
+    psfile.write_bytes(b":(exclude)test.txt\0")
+    result = subprocess.run(
+        [
+            str(SAFE_COMMIT),
+            f"--pathspec-from-file={psfile}",
+            "--pathspec-file-nul",
+            "-m",
+            "should refuse",
+        ],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1, result.stderr
+    assert "implicit whole-index commit" in result.stderr.lower()
+
+
+def test_safe_commit_allows_nul_separated_positive_pathspec_file(git_repo: Path):
+    """NUL-separated file naming a real path is a positive selector."""
+    _stage_file(git_repo, "test.txt")
+    psfile = git_repo / "pathspecs"
+    psfile.write_bytes(b"test.txt\0")
+    result = subprocess.run(
+        [
+            str(SAFE_COMMIT),
+            "--pathspec-file-nul",
+            f"--pathspec-from-file={psfile}",
+            "-m",
+            "test: nul pathspec",
+        ],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    log = subprocess.run(
+        ["git", "log", "--oneline", "-1"],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "test: nul pathspec" in log.stdout
+
+
 def test_safe_commit_valueless_gpg_sign_does_not_count_message_as_pathspec(
     git_repo: Path,
 ):

--- a/tests/test_git_safe_commit.py
+++ b/tests/test_git_safe_commit.py
@@ -262,6 +262,199 @@ def test_safe_commit_allows_explicit_all_staged_opt_in(git_repo: Path):
     assert "test: explicit all staged" in log.stdout
 
 
+def _stage_file(git_repo: Path, name: str, content: str = "hello") -> None:
+    (git_repo / name).write_text(content)
+    subprocess.run(["git", "add", name], cwd=git_repo, check=True, capture_output=True)
+
+
+def test_safe_commit_refuses_exclusion_only_pathspec(git_repo: Path):
+    """Exclusion-only args are not a positive selector — refuse whole-index commit."""
+    _stage_file(git_repo, "test.txt")
+    result = subprocess.run(
+        [str(SAFE_COMMIT), ":(exclude)test.txt", "-m", "should refuse"],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert "implicit whole-index commit" in result.stderr.lower()
+
+
+@pytest.mark.parametrize(
+    "pathspec",
+    [
+        ":!test.txt",
+        ":^test.txt",
+        ":(exclude)test.txt",
+        ":(icase,exclude)test.txt",
+        '":!test.txt"',
+        '"\\072!test.txt"',
+    ],
+)
+def test_safe_commit_refuses_exclusion_pathspec_variants(git_repo: Path, pathspec: str):
+    """All exclusion-only spellings must fail the whole-index guard."""
+    _stage_file(git_repo, "test.txt")
+    result = subprocess.run(
+        [str(SAFE_COMMIT), pathspec, "-m", "should refuse"],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1, result.stderr
+    assert "implicit whole-index commit" in result.stderr.lower()
+
+
+def test_safe_commit_refuses_empty_pathspec_file(git_repo: Path):
+    """--pathspec-from-file with no positive entries is not an explicit selector."""
+    _stage_file(git_repo, "test.txt")
+    psfile = git_repo / "pathspecs.txt"
+    psfile.write_text("")
+    result = subprocess.run(
+        [
+            str(SAFE_COMMIT),
+            f"--pathspec-from-file={psfile}",
+            "-m",
+            "should refuse",
+        ],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert "implicit whole-index commit" in result.stderr.lower()
+
+
+def test_safe_commit_refuses_exclusion_only_pathspec_file(git_repo: Path):
+    """A pathspec file of only exclusions / blanks is not a positive selector."""
+    _stage_file(git_repo, "test.txt")
+    psfile = git_repo / "pathspecs.txt"
+    psfile.write_text("\n:(exclude)test.txt\n\n:!other.txt\n")
+    result = subprocess.run(
+        [str(SAFE_COMMIT), "--pathspec-from-file", str(psfile), "-m", "should refuse"],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert "implicit whole-index commit" in result.stderr.lower()
+
+
+def test_safe_commit_refuses_dev_null_pathspec_file(git_repo: Path):
+    """/dev/null is an empty pathspec source."""
+    _stage_file(git_repo, "test.txt")
+    result = subprocess.run(
+        [
+            str(SAFE_COMMIT),
+            "--pathspec-from-file=/dev/null",
+            "-m",
+            "should refuse",
+        ],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert "implicit whole-index commit" in result.stderr.lower()
+
+
+def test_safe_commit_allows_positive_pathspec_file(git_repo: Path):
+    """A pathspec file naming a real file is a positive selector."""
+    _stage_file(git_repo, "test.txt")
+    psfile = git_repo / "pathspecs.txt"
+    psfile.write_text("test.txt\n")
+    result = subprocess.run(
+        [
+            str(SAFE_COMMIT),
+            f"--pathspec-from-file={psfile}",
+            "-m",
+            "test: pathspec file",
+        ],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    log = subprocess.run(
+        ["git", "log", "--oneline", "-1"],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "test: pathspec file" in log.stdout
+
+
+def test_safe_commit_refuses_exclusion_only_stdin_pathspec(git_repo: Path):
+    """Stdin pathspecs must be inspected, not treated as inherently positive."""
+    _stage_file(git_repo, "test.txt")
+    result = subprocess.run(
+        [str(SAFE_COMMIT), "--pathspec-from-file=-", "-m", "should refuse"],
+        cwd=git_repo,
+        input=":(exclude)test.txt\n",
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1, result.stderr
+    assert "implicit whole-index commit" in result.stderr.lower()
+
+
+def test_safe_commit_refuses_exclusion_only_stdin_pathspec_space_form(
+    git_repo: Path,
+):
+    """Space-separated --pathspec-from-file - must inspect stdin too."""
+    _stage_file(git_repo, "test.txt")
+    result = subprocess.run(
+        [str(SAFE_COMMIT), "--pathspec-from-file", "-", "-m", "should refuse"],
+        cwd=git_repo,
+        input=":!test.txt\n",
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1, result.stderr
+    assert "implicit whole-index commit" in result.stderr.lower()
+
+
+def test_safe_commit_allows_positive_stdin_pathspec(git_repo: Path):
+    """Stdin with a real file name is a positive selector after materializing."""
+    _stage_file(git_repo, "test.txt")
+    result = subprocess.run(
+        [
+            str(SAFE_COMMIT),
+            "--pathspec-from-file=-",
+            "-m",
+            "test: stdin pathspec",
+        ],
+        cwd=git_repo,
+        input="test.txt\n",
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    log = subprocess.run(
+        ["git", "log", "--oneline", "-1"],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "test: stdin pathspec" in log.stdout
+
+
+def test_safe_commit_valueless_gpg_sign_does_not_count_message_as_pathspec(
+    git_repo: Path,
+):
+    """-S without a key must not swallow -m and treat the message as a pathspec."""
+    _stage_file(git_repo, "test.txt")
+    result = subprocess.run(
+        [str(SAFE_COMMIT), "-S", "-m", "should refuse"],
+        cwd=git_repo,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert "implicit whole-index commit" in result.stderr.lower()
+
+
 def test_safe_commit_refuses_dirty_worktree_without_no_verify(git_repo: Path):
     """Tracked dirty worktrees are blocked before prek can stash unrelated files."""
     (git_repo / "dirty.txt").write_text("tracked\n")


### PR DESCRIPTION
## Summary

Fixes 6 P1 Greptile findings from gptme/gptme-agent-template#87, all variants of the same bypass class: an invocation using only exclusion-only pathspecs (`:!foo`, `:(exclude)foo`, `:(icase,exclude)foo`) or a `--pathspec-from-file` file containing only exclusion lines would set `PATHSPEC_COUNT > 0` while Git received no positive file selector — resulting in an implicit whole-index commit that could include files staged by a concurrent session.

**Changes:**

- **`is_exclusion_only_pathspec()`** — new helper; returns true for `:!path`, `:^path`, `:(exclude)path`, multi-magic variants like `:(icase,exclude)path`, and C-quoted/octal-escaped equivalents
- **`pathspec_file_has_positive()`** — new helper; reads a `--pathspec-from-file` source and returns false when all entries are blank or exclusion-only (handles `/dev/null`, empty file, and treats stdin conservatively as positive)
- **`*)` catch-all and post-`--` counting** — now calls `is_exclusion_only_pathspec` before incrementing `PATHSPEC_COUNT`
- **`--pathspec-from-file`** (both forms) — defers counting until file is read; only increments if `pathspec_file_has_positive` returns true
- **`-S`/`--gpg-sign` optional-arg handling** — new `SKIP_NEXT_OPTIONAL_ARG` path so a valueless `-S` does not cause the next option flag to be consumed as a signing-key value

## Test plan

- [x] Manual smoke test: 17 cases covering all 6 finding variants — all pass
- [ ] CI green on this PR
- [ ] Bump submodule pointer in gptme/gptme-agent-template#87 once this merges

## Related

- gptme/gptme-agent-template#87 — the PR that surfaced these findings