### PR TITLE
feat(sessions): add export command for JSON/CSV session dumps

### DIFF
--- a/packages/gptme-sessions/README.md
+++ b/packages/gptme-sessions/README.md
@@ -54,6 +54,10 @@ gptme-sessions show a1b2 --json
 gptme-sessions query --model opus --since 7d
 gptme-sessions query --run-type autonomous --outcome productive --json
 
+# Structured export (JSON or CSV) — backups, audit trails, data portability
+gptme-sessions export --format json --since 7d
+gptme-sessions export --format csv --category code --model opus -o sessions.csv
+
 # --since accepts sub-day windows and natural phrasing (units: s, m, h, d, w).
 # Sub-day windows filter precisely (no rounding up to a whole day).
 gptme-sessions query --since 2h               # last 2 hours

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -788,6 +788,8 @@ def _csv_cell(value: object) -> str:
         return "true" if value else "false"
     if isinstance(value, (dict, list)):
         return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+    if isinstance(value, str) and value.startswith(("=", "+", "-", "@")):
+        return "'" + value
     return str(value)
 
 

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import csv
 import json
 import logging
 import math
@@ -10,7 +11,7 @@ import sys
 from datetime import date, datetime, timedelta, timezone
 from fnmatch import fnmatch
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, TextIO, cast
 
 import click
 
@@ -662,11 +663,11 @@ def cli(ctx: click.Context, sessions_dir: Path | None) -> None:
                 click.echo("\nTip: Run 'gptme-sessions sync' to keep the store up to date.")
 
 
-# -- Shared filter options for query/stats -----------------------------------
+# -- Shared filter options for query/stats/export ----------------------------
 
 
-def _filter_options(func):  # type: ignore[no-untyped-def,unused-ignore]
-    """Decorator adding common filter options to a command."""
+def _query_filter_options(func):  # type: ignore[no-untyped-def,unused-ignore]
+    """Decorator adding shared query filters (no output format)."""
     for option in reversed(
         [
             click.option("--model", default=None, help="Filter by model (e.g. opus, sonnet)"),
@@ -682,11 +683,16 @@ def _filter_options(func):  # type: ignore[no-untyped-def,unused-ignore]
                 default=None,
                 help="Filter by recency (e.g. 90s, 30m, 2h, 7d, 2w, '2 hours ago', or 'all')",
             ),
-            click.option("--json", "as_json", is_flag=True, help="Output as JSON"),
         ]
     ):
         func = option(func)
     return func
+
+
+def _filter_options(func):  # type: ignore[no-untyped-def,unused-ignore]
+    """Decorator adding common filter options including JSON output."""
+    func = click.option("--json", "as_json", is_flag=True, help="Output as JSON")(func)
+    return _query_filter_options(func)
 
 
 # -- query -------------------------------------------------------------------
@@ -758,6 +764,117 @@ def query(
                 f"{cat:14s}  {dur}  {proj}"
             )
         click.echo(f"\n{len(records)} records")
+
+
+# -- export ------------------------------------------------------------------
+
+
+def _export_record_dict(record: SessionRecord) -> dict[str, Any]:
+    """Serialize a record for export, including the computed model alias."""
+    row = record.to_dict()
+    row["model_normalized"] = record.model_normalized
+    return row
+
+
+def _csv_cell(value: object) -> str:
+    """Render a record field as a CSV cell.
+
+    Nested lists/dicts stay JSON so a spreadsheet round-trip keeps structure.
+    ``None`` becomes empty (not the string ``"None"``).
+    """
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+    return str(value)
+
+
+def _csv_fieldnames(rows: list[dict[str, Any]]) -> list[str]:
+    """Stable CSV header: dataclass field order + model_normalized, then extras."""
+    names = [name for name in SessionRecord.__dataclass_fields__ if not name.startswith("_")]
+    if "model" in names:
+        names.insert(names.index("model") + 1, "model_normalized")
+    else:
+        names.append("model_normalized")
+    extras = sorted({key for row in rows for key in row} - set(names))
+    return names + extras
+
+
+def _write_export(records: list[SessionRecord], fmt: str, dest: TextIO) -> None:
+    """Write session records to *dest* as JSON or CSV."""
+    rows = [_export_record_dict(record) for record in records]
+    if fmt == "json":
+        dest.write(json.dumps(rows, indent=2) + "\n")
+        return
+    if fmt == "csv":
+        fieldnames = _csv_fieldnames(rows)
+        writer = csv.DictWriter(
+            dest,
+            fieldnames=fieldnames,
+            extrasaction="ignore",
+            lineterminator="\n",
+        )
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({key: _csv_cell(row.get(key)) for key in fieldnames})
+        return
+    raise ValueError(f"unsupported export format: {fmt}")
+
+
+@cli.command()
+@_query_filter_options
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(["json", "csv"], case_sensitive=False),
+    default="json",
+    show_default=True,
+    help="Export format",
+)
+@click.option(
+    "-o",
+    "--output",
+    type=click.File("w", encoding="utf-8"),
+    default="-",
+    help="Output path (default: stdout)",
+)
+@click.pass_context
+def export(
+    ctx: click.Context,
+    model: str | None,
+    run_type: str | None,
+    category: str | None,
+    harness: str | None,
+    outcome: str | None,
+    project: str | None,
+    since: str | None,
+    fmt: str,
+    output: TextIO,
+) -> None:
+    """Export session records as JSON or CSV.
+
+    Structured export for backups, audit trails, and data-portability requests.
+    Defaults to all records; pass --since 7d (and the shared --category /
+    --model filters) to narrow the set.
+
+    \b
+        gptme sessions export --format json --since 7d
+        gptme sessions export --format csv --category code --model opus
+        gptme sessions export --format json -o sessions.json
+    """
+    store = SessionStore(sessions_dir=ctx.obj["sessions_dir"])
+    records = store.query(
+        model=model,
+        run_type=run_type,
+        category=category,
+        harness=harness,
+        outcome=outcome,
+        since_days=_parse_since(since),
+        project=project,
+    )
+    _write_export(records, fmt.lower(), output)
 
 
 # -- show --------------------------------------------------------------------

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -788,8 +788,9 @@ def _csv_cell(value: object) -> str:
         return "true" if value else "false"
     if isinstance(value, (dict, list)):
         return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+    # OWASP's trigger set includes these controls and full-width variants, but not space.
     if isinstance(value, str) and value.startswith(
-        ("=", "+", "-", "@", "\t", "\r", "\n", " ", "＝", "＋", "－", "＠")
+        ("=", "+", "-", "@", "\t", "\r", "\n", "＝", "＋", "－", "＠")
     ):
         return "'" + value
     return str(value)
@@ -819,6 +820,7 @@ def _write_export(records: list[SessionRecord], fmt: str, dest: TextIO) -> None:
             fieldnames=fieldnames,
             extrasaction="ignore",
             lineterminator="\n",
+            quoting=csv.QUOTE_ALL,
         )
         writer.writeheader()
         for row in rows:

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -788,7 +788,9 @@ def _csv_cell(value: object) -> str:
         return "true" if value else "false"
     if isinstance(value, (dict, list)):
         return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
-    if isinstance(value, str) and value.startswith(("=", "+", "-", "@")):
+    if isinstance(value, str) and value.startswith(
+        ("=", "+", "-", "@", "\t", "\r", "\n", " ", "＝", "＋", "－", "＠")
+    ):
         return "'" + value
     return str(value)
 

--- a/packages/gptme-sessions/tests/test_cli.py
+++ b/packages/gptme-sessions/tests/test_cli.py
@@ -227,6 +227,24 @@ class TestExportCommand:
         deliverables = json.loads(row["deliverables"])
         assert deliverables == ["abc0000"]
 
+    @pytest.mark.parametrize("prefix", ["=", "+", "-", "@"])
+    def test_export_csv_neutralizes_spreadsheet_formulas(self, tmp_path: Path, prefix: str) -> None:
+        """String cells cannot become formulas when opened in a spreadsheet."""
+        store = SessionStore(sessions_dir=tmp_path)
+        store.append(
+            SessionRecord(
+                harness="claude-code",
+                outcome="productive",
+                project=f"{prefix}1+1",
+            )
+        )
+
+        rc, out = _invoke(["export", "--format", "csv"], tmp_path)
+
+        assert rc == 0
+        row = next(csv.DictReader(StringIO(out)))
+        assert row["project"] == f"'{prefix}1+1"
+
     def test_export_honors_category_and_model_filters(self, tmp_path: Path):
         """Shared --category/--model filters apply to export."""
         _seed_store(tmp_path)

--- a/packages/gptme-sessions/tests/test_cli.py
+++ b/packages/gptme-sessions/tests/test_cli.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import csv
 import json
+from datetime import datetime, timedelta, timezone
+from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
 
@@ -159,6 +162,121 @@ class TestQueryCommand:
         data = json.loads(out)
         assert len(data) == 1
         assert data[0]["outcome"] == "productive"
+
+
+# -- export ------------------------------------------------------------------
+
+
+class TestExportCommand:
+    def test_export_json_is_valid_array(self, tmp_path: Path):
+        """export --format json emits a JSON array of records."""
+        _seed_store(tmp_path)
+        rc, out = _invoke(["export", "--format", "json"], tmp_path)
+        assert rc == 0
+        data = json.loads(out)
+        assert isinstance(data, list)
+        assert len(data) == 5
+        assert {row["session_id"] for row in data}
+
+    def test_export_json_since_7d(self, tmp_path: Path):
+        """export --format json --since 7d drops records older than the window."""
+        store = _seed_store(tmp_path)
+        old = SessionRecord(
+            harness="claude-code",
+            model="opus",
+            category="code",
+            outcome="productive",
+            timestamp=(datetime.now(timezone.utc) - timedelta(days=30)).isoformat(),
+        )
+        store.append(old)
+        rc, out = _invoke(["export", "--format", "json", "--since", "7d"], tmp_path)
+        assert rc == 0
+        data = json.loads(out)
+        ids = {row["session_id"] for row in data}
+        assert old.session_id not in ids
+        assert len(data) == 5
+
+    def test_export_csv_has_record_columns(self, tmp_path: Path):
+        """export --format csv emits a header with the record columns."""
+        _seed_store(tmp_path)
+        rc, out = _invoke(["export", "--format", "csv"], tmp_path)
+        assert rc == 0
+        rows = list(csv.DictReader(StringIO(out)))
+        assert len(rows) == 5
+        header = rows[0].keys()
+        for column in (
+            "session_id",
+            "timestamp",
+            "harness",
+            "model",
+            "model_normalized",
+            "category",
+            "outcome",
+            "duration_seconds",
+            "deliverables",
+        ):
+            assert column in header
+        assert all(row["harness"] == "claude-code" for row in rows)
+
+    def test_export_csv_serializes_nested_fields(self, tmp_path: Path):
+        """CSV cells for list fields stay JSON so structure survives a spreadsheet."""
+        _seed_store(tmp_path, n=1)
+        rc, out = _invoke(["export", "--format", "csv"], tmp_path)
+        assert rc == 0
+        row = next(csv.DictReader(StringIO(out)))
+        deliverables = json.loads(row["deliverables"])
+        assert deliverables == ["abc0000"]
+
+    def test_export_honors_category_and_model_filters(self, tmp_path: Path):
+        """Shared --category/--model filters apply to export."""
+        _seed_store(tmp_path)
+        rc, out = _invoke(
+            ["export", "--format", "json", "--category", "code", "--model", "opus"],
+            tmp_path,
+        )
+        assert rc == 0
+        data = json.loads(out)
+        assert data
+        assert all(row.get("category") == "code" for row in data)
+        assert all(
+            row.get("model_normalized") == "opus" or row.get("model") == "opus" for row in data
+        )
+
+    def test_export_writes_output_file(self, tmp_path: Path):
+        """export -o writes JSON to the given path."""
+        _seed_store(tmp_path)
+        dest = tmp_path / "sessions.json"
+        rc, out = _invoke(["export", "--format", "json", "-o", str(dest)], tmp_path)
+        assert rc == 0
+        assert out == ""
+        data = json.loads(dest.read_text(encoding="utf-8"))
+        assert isinstance(data, list)
+        assert len(data) == 5
+
+    def test_export_empty_store_json(self, tmp_path: Path):
+        """export on an empty store emits an empty JSON array."""
+        SessionStore(sessions_dir=tmp_path)
+        rc, out = _invoke(["export", "--format", "json"], tmp_path)
+        assert rc == 0
+        assert json.loads(out) == []
+
+    def test_export_empty_store_csv_header_only(self, tmp_path: Path):
+        """export --format csv on an empty store still emits the record header."""
+        SessionStore(sessions_dir=tmp_path)
+        rc, out = _invoke(["export", "--format", "csv"], tmp_path)
+        assert rc == 0
+        reader = csv.DictReader(StringIO(out))
+        assert reader.fieldnames is not None
+        assert "session_id" in reader.fieldnames
+        assert "category" in reader.fieldnames
+        assert list(reader) == []
+
+    def test_export_rejects_unknown_format(self, tmp_path: Path):
+        """export --format xml is rejected by Click."""
+        _seed_store(tmp_path)
+        rc, out = _invoke(["export", "--format", "xml"], tmp_path)
+        assert rc != 0
+        assert "invalid choice" in out.lower() or "xml" in out.lower()
 
 
 # -- show --------------------------------------------------------------------

--- a/packages/gptme-sessions/tests/test_cli.py
+++ b/packages/gptme-sessions/tests/test_cli.py
@@ -229,7 +229,7 @@ class TestExportCommand:
 
     @pytest.mark.parametrize(
         "prefix",
-        ["=", "+", "-", "@", "\t", "\r", "\n", " ", "＝", "＋", "－", "＠"],
+        ["=", "+", "-", "@", "\t", "\r", "\n", "＝", "＋", "－", "＠"],
     )
     def test_export_csv_neutralizes_spreadsheet_formulas(self, tmp_path: Path, prefix: str) -> None:
         """String cells cannot become formulas when opened in a spreadsheet."""
@@ -245,8 +245,25 @@ class TestExportCommand:
         rc, out = _invoke(["export", "--format", "csv"], tmp_path)
 
         assert rc == 0
-        row = next(csv.DictReader(StringIO(out)))
+        row = next(csv.DictReader(StringIO(out, newline="")))
         assert row["project"] == f"'{prefix}1+1"
+
+    def test_export_csv_preserves_leading_space(self, tmp_path: Path) -> None:
+        """A normal leading space is data, not a spreadsheet formula trigger."""
+        store = SessionStore(sessions_dir=tmp_path)
+        store.append(
+            SessionRecord(
+                harness="claude-code",
+                outcome="productive",
+                project=" myproject",
+            )
+        )
+
+        rc, out = _invoke(["export", "--format", "csv"], tmp_path)
+
+        assert rc == 0
+        row = next(csv.DictReader(StringIO(out, newline="")))
+        assert row["project"] == " myproject"
 
     def test_export_honors_category_and_model_filters(self, tmp_path: Path):
         """Shared --category/--model filters apply to export."""

--- a/packages/gptme-sessions/tests/test_cli.py
+++ b/packages/gptme-sessions/tests/test_cli.py
@@ -227,7 +227,10 @@ class TestExportCommand:
         deliverables = json.loads(row["deliverables"])
         assert deliverables == ["abc0000"]
 
-    @pytest.mark.parametrize("prefix", ["=", "+", "-", "@"])
+    @pytest.mark.parametrize(
+        "prefix",
+        ["=", "+", "-", "@", "\t", "\r", "\n", " ", "＝", "＋", "－", "＠"],
+    )
     def test_export_csv_neutralizes_spreadsheet_formulas(self, tmp_path: Path, prefix: str) -> None:
         """String cells cannot become formulas when opened in a spreadsheet."""
         store = SessionStore(sessions_dir=tmp_path)


### PR DESCRIPTION
## Summary

Add a first-class `gptme-sessions export` command so session records can be dumped as JSON or CSV for backups, audit trails, and data-portability requests.

This is idea #1087 slice 3. Search and the `gptme sessions` plugin dispatch already exist; structured export was the remaining buildable slice.

```bash
gptme sessions export --format json --since 7d
gptme sessions export --format csv --category code --model opus
gptme sessions export --format json -o sessions.json
```

- `--format json|csv` (default: json)
- Shared query filters: `--since`, `--category`, `--model`, `--harness`, `--outcome`, `--project`, `--run-type`
- `-o/--output` writes to a file; stdout is the default
- CSV uses a stable record-column header; nested fields (deliverables, grades, …) are JSON in the cell
- Empty store: JSON `[]`, CSV header-only

`query --json` is unchanged. Export is the machine-readable portability command; query stays the human/filter REPL.

## Test plan

- [x] `uv run pytest packages/gptme-sessions/tests/test_cli.py::TestExportCommand` (9 tests)
- [x] `uv run pytest packages/gptme-sessions/tests/` — 1095 passed
- [x] Smoke: `gptme-sessions export --format json --since 7d` → valid JSON; `--format csv` → record header
- [ ] CI green on this PR