### PR TITLE
docs: link gptme.org skills gallery from READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ Archived: [gptme-rag](https://github.com/gptme/gptme-rag) (upstreamed into [pack
 
 ### Discover more
 
+Looking for a good place to start? The **[gptme.org Skills Gallery](https://gptme.org/docs/skills-gallery.html)** curates a handful of battle-tested skills from this registry with install commands and social proof — a quick one-page picker instead of reading the full index below.
+
 To make your own plugin or skill discoverable, add a GitHub topic to your repo:
 
 | Topic | For | Browse |

--- a/skills/README.md
+++ b/skills/README.md
@@ -2,6 +2,8 @@
 
 This directory contains **skills** - enhanced lessons that bundle workflows, scripts, and utilities for gptme.
 
+> **Not sure what to install?** See the curated **[Skills Gallery](https://gptme.org/docs/skills-gallery.html)** on gptme.org for a shortlist of battle-tested skills with install commands and social proof.
+
 ## Overview
 
 Skills extend gptme's lesson system by providing executable components alongside instructional content. While lessons teach patterns and best practices, skills provide ready-to-use workflows with supporting tools.


### PR DESCRIPTION
## Summary
Links the curated [gptme.org Skills Gallery](https://gptme.org/docs/skills-gallery.html) page from the gptme-contrib README `Discover more` section and the skills README, giving users a quick one-page picker for battle-tested skills.

## Why
Part of the Phase 1 skill-gallery work (idea #1106): the gallery page ships in gptme docs (companion PR gptme/gptme#3605); this PR makes it discoverable from the registry that curates it.

## Scope
- `README.md` Discover more section
- `skills/README.md` callout at top