### PR TITLE
refactor(bob-status): PR-queue depth is an attention watermark, not a cap

### DIFF
--- a/packages/gptme-bob-status/src/gptme_bob_status/provider.py
+++ b/packages/gptme-bob-status/src/gptme_bob_status/provider.py
@@ -48,6 +48,9 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+# (repo, attention watermark). The watermark is a *rot-attention* threshold, not a
+# cap: crossing it means "triage this queue for stale/red/duplicate PRs", never
+# "stop opening PRs". Queue depth must never gate work.
 _TRACKED_REPOS: list[tuple[str, int | None]] = [
     ("gptme/gptme", 10),
     ("gptme/gptme-contrib", None),
@@ -102,7 +105,7 @@ def _pr_queue() -> list[dict]:
     if not author:
         return []
     rows: list[dict] = []
-    for repo, cap in _TRACKED_REPOS:
+    for repo, watermark in _TRACKED_REPOS:
         prs_json = _run(
             [
                 "gh",
@@ -125,7 +128,7 @@ def _pr_queue() -> list[dict]:
             prs = json.loads(prs_json)
         except json.JSONDecodeError:
             continue
-        rows.append({"repo": repo, "count": len(prs), "cap": cap})
+        rows.append({"repo": repo, "count": len(prs), "watermark": watermark})
     return rows
 
 
@@ -231,9 +234,15 @@ def _journal_entries(limit: int = 5) -> list[str]:
     return [str(e) for e in entries[:limit]]
 
 
-def _pr_queue_display(count: int, cap: int | None) -> str:
-    if cap is not None:
-        return f"{count}/{cap}" + (" ⚠ at limit" if count >= cap else "")
+def _pr_queue_display(count: int, watermark: int | None) -> str:
+    """Render open-PR depth against its attention watermark.
+
+    Crossing the watermark is a rot-attention signal — triage the queue for
+    stale, CI-red, or duplicate PRs. It never means "stop opening PRs".
+    """
+    if watermark is not None:
+        suffix = " ⚠ triage" if count >= watermark else ""
+        return f"{count}/{watermark}{suffix}"
     return str(count)
 
 
@@ -276,7 +285,7 @@ class BobStatusProvider:
         if rows:
             lines = ["## PR Queue", "| Repo | Open |", "|------|------|"]
             for row in rows:
-                display = _pr_queue_display(row["count"], row["cap"])
+                display = _pr_queue_display(row["count"], row["watermark"])
                 lines.append(f"| {row['repo']} | {display} |")
             sections.append("\n".join(lines))
 

--- a/packages/gptme-bob-status/tests/test_provider.py
+++ b/packages/gptme-bob-status/tests/test_provider.py
@@ -75,7 +75,7 @@ def test_narrative_sections_non_empty_in_bob_workspace(monkeypatch):
         mod, "_active_tasks", lambda n=3: [{"id": "t1", "title": "Test task"}]
     )
     monkeypatch.setattr(
-        mod, "_pr_queue", lambda: [{"repo": "gptme/gptme", "count": 2, "cap": 10}]
+        mod, "_pr_queue", lambda: [{"repo": "gptme/gptme", "count": 2, "watermark": 10}]
     )
     monkeypatch.setattr(
         mod,
@@ -116,3 +116,18 @@ def test_collect_keys_use_bob_prefix(monkeypatch):
     result = provider.collect()
     for key in result:
         assert key.startswith("bob_"), f"Key {key!r} does not use bob_ prefix"
+
+
+def test_pr_queue_display_marks_watermark_for_triage_not_blocking():
+    """Crossing the watermark reads as triage pressure, never as a cap.
+
+    Queue depth is a rot-attention signal: a deep queue means "triage stale /
+    CI-red / duplicate PRs", not "stop opening PRs".
+    """
+    from gptme_bob_status.provider import _pr_queue_display
+
+    assert _pr_queue_display(2, 10) == "2/10"
+    assert _pr_queue_display(10, 10) == "10/10 ⚠ triage"
+    assert _pr_queue_display(16, 10) == "16/10 ⚠ triage"
+    # No watermark configured → bare count, no pressure marker.
+    assert _pr_queue_display(7, None) == "7"


### PR DESCRIPTION
## Why

Queue counts are rot-attention signals, never gates. Erik, 2026-08-22, verbatim:
*"'under its cap' — we don't believe in caps."* Crossing a per-repo threshold
means *triage this queue for stale / CI-red / duplicate PRs*, not *stop opening PRs*.

`gptme-bob-status` was the last place in contrib that framed depth as a ceiling:
a per-repo `cap` field rendered as `⚠ at limit`. The behavior was display-only
either way — but that wording is exactly what invites someone to re-add a real
gate, which is the failure mode this correction exists to prevent (cost: finished
branches rotting in worktrees instead of becoming PRs).

## What

- rename the per-repo `cap` field to `watermark` (rows + `_pr_queue_display` signature)
- `⚠ at limit` → `⚠ triage`, with a docstring stating the signal is advisory
- document the watermark semantics on `_TRACKED_REPOS`
- add a regression test pinning the display contract

No behavior change beyond the rendered string. This is the upstream half of a
Bob-local cleanup that deleted the corresponding dead gate functions from
`cascade-selector.py` and `idea-backlog-next.py` (−241 lines).

## Verification

- `pytest packages/gptme-bob-status/tests/test_provider.py` — 8 passed (incl. the new case)
- `ruff check` + `ruff format --check` clean
- `prek run --files <both files>` — exit 0