### PR TITLE
feat(gptme-rag): add injection logging and index-health reporting

### DIFF
--- a/packages/gptme-rag/README.md
+++ b/packages/gptme-rag/README.md
@@ -17,6 +17,7 @@ This is the **vector search** complement to [`gptme-wisdom`](https://github.com/
 - 👀 File watching and auto-indexing
 - 🔌 MCP server for agent integration (`gptme-rag mcp`)
 - 🛠️ CLI interface (`gptme-rag index`, `gptme-rag search`)
+- 📊 Injection logging and index-health/rot reporting (`gptme_rag.observability`)
 
 ## Quick Start
 

--- a/packages/gptme-rag/src/gptme_rag/__init__.py
+++ b/packages/gptme-rag/src/gptme_rag/__init__.py
@@ -6,14 +6,26 @@ from .lesson_matcher import (
     scan_lessons,
     score_lessons,
 )
+from .observability import (
+    IndexHealth,
+    InjectionStats,
+    assess_index_health,
+    log_injection,
+    summarize_injections,
+)
 from .query.context_assembler import ContextAssembler
 
 __all__ = [
     "ContextAssembler",
+    "IndexHealth",
     "Indexer",
+    "InjectionStats",
+    "assess_index_health",
     "filter_by_session_category",
     "keyword_to_regex",
+    "log_injection",
     "match_keyword",
     "scan_lessons",
     "score_lessons",
+    "summarize_injections",
 ]

--- a/packages/gptme-rag/src/gptme_rag/observability.py
+++ b/packages/gptme-rag/src/gptme_rag/observability.py
@@ -119,7 +119,7 @@ def _as_score(value: Any) -> float:
         return 0.0
     try:
         return float(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return 0.0
 
 
@@ -252,8 +252,8 @@ def summarize_injections(log_file: Path) -> InjectionStats:
             if num_hits > 0:
                 stats.nonzero += 1
                 sum_top += top_score
-            sessions.add(str(rec.get("session_id", "unknown")))
-            harness = str(rec.get("harness", "unknown"))
+            sessions.add(str(rec.get("session_id") or "unknown"))
+            harness = str(rec.get("harness") or "unknown")
             stats.by_harness[harness] = stats.by_harness.get(harness, 0) + 1
 
     stats.unique_sessions = len(sessions)

--- a/packages/gptme-rag/src/gptme_rag/observability.py
+++ b/packages/gptme-rag/src/gptme_rag/observability.py
@@ -84,11 +84,12 @@ def detect_harness() -> str:
     for _ in range(_MAX_PROC_WALK):
         if pid <= 1:
             break
+        comm: str | None = None
         try:
             comm = (Path("/proc") / str(pid) / "comm").read_text().strip()
         except OSError:
-            break
-        if comm in HARNESS_COMMS:
+            pass
+        if comm is not None and comm in HARNESS_COMMS:
             return HARNESS_COMMS[comm]
         try:
             status = (Path("/proc") / str(pid) / "status").read_text()
@@ -165,7 +166,7 @@ def log_injection(
     Returns the record written, or ``None`` if the write failed. Logging is
     best-effort by design: a full disk must never break injection.
     """
-    injected = len(hits) if max_injected is None else max(0, min(len(hits), max_injected))
+    injected = len(hits) if max_injected is None else max(0, min(len(hits), int(max_injected)))
     record: dict[str, Any] = {
         "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "session_id": session_id if session_id is not None else detect_session_id(),
@@ -377,7 +378,7 @@ def assess_index_health(
 
     health = IndexHealth(
         status="ok",
-        age_hours=round(age_hours, 2),
+        age_hours=age_hours,
         built_at=built_at.isoformat(),
         indexed_count=indexed_count,
         on_disk_count=on_disk_count,

--- a/packages/gptme-rag/src/gptme_rag/observability.py
+++ b/packages/gptme-rag/src/gptme_rag/observability.py
@@ -164,8 +164,8 @@ def log_injection(
     injected = len(hits) if max_injected is None else max(0, min(len(hits), max_injected))
     record: dict[str, Any] = {
         "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "session_id": session_id or detect_session_id(),
-        "harness": harness or detect_harness(),
+        "session_id": session_id if session_id is not None else detect_session_id(),
+        "harness": harness if harness is not None else detect_harness(),
         "backend": backend,
         "query": query,
         "query_len": len(query),
@@ -243,7 +243,7 @@ def summarize_injections(log_file: Path) -> InjectionStats:
             try:
                 num_hits = int(rec.get("num_hits", 0) or 0)
                 top_score = float(rec.get("top_score", 0.0) or 0.0)
-            except (TypeError, ValueError):
+            except (TypeError, ValueError, OverflowError):
                 # Same contract as a partial trailing line: skip, don't raise.
                 stats.malformed += 1
                 continue
@@ -398,6 +398,10 @@ def assess_index_health(
             if abs(delta) > slice_delta_tolerance:
                 health.reasons.append(
                     f"slice {name!r} delta {delta:+d} > tolerance {slice_delta_tolerance}"
+                )
+            else:
+                health.reasons.append(
+                    f"slice {name!r} stale (age {age_hours:.1f}h > {max_age_hours}h)"
                 )
         else:
             slice_status = "ok"

--- a/packages/gptme-rag/src/gptme_rag/observability.py
+++ b/packages/gptme-rag/src/gptme_rag/observability.py
@@ -161,7 +161,7 @@ def log_injection(
     Returns the record written, or ``None`` if the write failed. Logging is
     best-effort by design: a full disk must never break injection.
     """
-    injected = len(hits) if max_injected is None else min(len(hits), max_injected)
+    injected = len(hits) if max_injected is None else max(0, min(len(hits), max_injected))
     record: dict[str, Any] = {
         "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "session_id": session_id or detect_session_id(),
@@ -184,10 +184,12 @@ def log_injection(
         record.update(extra)
 
     try:
+        payload = json.dumps(record) + "\n"
         log_file.parent.mkdir(parents=True, exist_ok=True)
         with open(log_file, "a", encoding="utf-8") as f:
-            f.write(json.dumps(record) + "\n")
-    except OSError as exc:
+            f.write(payload)
+    except (OSError, TypeError, ValueError) as exc:
+        # Best-effort: a full disk or an unserializable hit must never break injection.
         logger.debug("injection log write failed (%s): %s", log_file, exc)
         return None
     return record

--- a/packages/gptme-rag/src/gptme_rag/observability.py
+++ b/packages/gptme-rag/src/gptme_rag/observability.py
@@ -102,6 +102,16 @@ def detect_session_id(env_vars: Sequence[str] = DEFAULT_SESSION_ENV_VARS) -> str
     return "unknown"
 
 
+def _as_score(value: Any) -> float:
+    """Coerce a hit score to float; unusable values become 0.0 rather than raise."""
+    if value is None:
+        return 0.0
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
 def log_injection(
     log_file: Path,
     query: str,
@@ -144,11 +154,11 @@ def log_injection(
         "query_len": len(query),
         "num_hits": len(hits),
         "num_injected": injected,
-        "top_score": float(hits[0].get(score_key, 0.0)) if hits else 0.0,
+        "top_score": _as_score(hits[0].get(score_key)) if hits else 0.0,
         "hits": [
             {
                 **{f: hit[f] for f in hit_fields if hit.get(f)},
-                "score": float(hit.get(score_key, 0.0)),
+                "score": _as_score(hit.get(score_key)),
             }
             for hit in hits[:injected]
         ],
@@ -211,12 +221,18 @@ def summarize_injections(log_file: Path) -> InjectionStats:
             if not isinstance(rec, dict):
                 stats.malformed += 1
                 continue
+            try:
+                num_hits = int(rec.get("num_hits", 0) or 0)
+                top_score = float(rec.get("top_score", 0.0) or 0.0)
+            except (TypeError, ValueError):
+                # Same contract as a partial trailing line: skip, don't raise.
+                stats.malformed += 1
+                continue
             stats.total += 1
-            num_hits = int(rec.get("num_hits", 0) or 0)
             sum_hits += num_hits
             if num_hits > 0:
                 stats.nonzero += 1
-                sum_top += float(rec.get("top_score", 0.0) or 0.0)
+                sum_top += top_score
             sessions.add(str(rec.get("session_id", "unknown")))
             harness = str(rec.get("harness", "unknown"))
             stats.by_harness[harness] = stats.by_harness.get(harness, 0) + 1
@@ -321,6 +337,8 @@ def assess_index_health(
     ``stale`` or ``missing``, with ``reasons`` naming every failed check.
     """
     now = now or datetime.now(timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
     if built_at is None:
         return IndexHealth(status="missing", reasons=["no index"])
 

--- a/packages/gptme-rag/src/gptme_rag/observability.py
+++ b/packages/gptme-rag/src/gptme_rag/observability.py
@@ -174,7 +174,11 @@ def log_injection(
         "top_score": _as_score(hits[0].get(score_key)) if hits else 0.0,
         "hits": [
             {
-                **{f: hit[f] for f in hit_fields if f in hit and _copyable_hit_field(hit[f])},
+                **{
+                    f: hit[f].isoformat() if isinstance(hit[f], datetime) else hit[f]
+                    for f in hit_fields
+                    if f in hit and _copyable_hit_field(hit[f])
+                },
                 "score": _as_score(hit.get(score_key)),
             }
             for hit in hits[:injected]

--- a/packages/gptme-rag/src/gptme_rag/observability.py
+++ b/packages/gptme-rag/src/gptme_rag/observability.py
@@ -1,0 +1,389 @@
+"""Injection logging and index-health (rot) reporting for gptme-rag.
+
+Two failure modes make a retrieval system quietly useless, and neither is
+visible from inside the retrieval code:
+
+1. **Invisible injections.** Without a per-injection record there is no way to
+   ask whether retrieval fired, what it put in front of the model, or whether
+   the hits correlated with anything downstream. Tuning a floor without this is
+   guesswork.
+2. **Silent rot.** A stale index keeps answering queries — with stale documents
+   — and nothing fails. Bob's ambient injector ran on a dead index for 51 days
+   before anyone noticed, because "no error" and "working" look identical from
+   the consumer side.
+
+Both are deliberately *policy-free*. This module never decides which
+directories are sources, how documents are counted, or what an acceptable
+staleness is; callers pass counts and thresholds. That split is what keeps the
+consumer's configuration out of the library.
+
+Ported from the Bob brain script (``scripts/build-ambient-memory-index.py``)
+where both patterns were measured against real session data.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from collections.abc import Mapping, Sequence
+
+logger = logging.getLogger(__name__)
+
+#: Process names, as seen in ``/proc/<pid>/comm``, mapped to a harness label.
+#: Extend this rather than branching at the call site.
+HARNESS_COMMS: dict[str, str] = {
+    "claude": "claude-code",
+    "claude-code": "claude-code",
+    "gptme": "gptme",
+    "codex": "codex",
+    "codex-cli": "codex",
+    "copilot": "copilot-cli",
+    "copilot-cli": "copilot-cli",
+    "gh-copilot": "copilot-cli",
+}
+
+#: Environment variables consulted, in order, to identify the calling session.
+DEFAULT_SESSION_ENV_VARS: tuple[str, ...] = (
+    "GPTME_RAG_SESSION_ID",
+    "GPTME_SESSION_ID",
+    "CC_SESSION_ID",
+)
+
+#: How far up the process tree :func:`detect_harness` will walk.
+_MAX_PROC_WALK = 8
+
+
+def detect_harness() -> str:
+    """Best-effort identification of the agent harness that invoked us.
+
+    Walks the process tree looking for a known harness process name. Returns
+    ``"unknown"`` when nothing matches or ``/proc`` is unavailable — this is
+    diagnostic metadata, never a control-flow input.
+    """
+    pid = os.getppid()
+    for _ in range(_MAX_PROC_WALK):
+        if pid <= 1:
+            break
+        try:
+            comm = (Path("/proc") / str(pid) / "comm").read_text().strip()
+        except OSError:
+            break
+        if comm in HARNESS_COMMS:
+            return HARNESS_COMMS[comm]
+        try:
+            status = (Path("/proc") / str(pid) / "status").read_text()
+        except OSError:
+            break
+        ppid = 0
+        for line in status.splitlines():
+            if line.startswith("PPid:"):
+                try:
+                    ppid = int(line.split()[1])
+                except (ValueError, IndexError):
+                    ppid = 0
+                break
+        if ppid == pid or ppid <= 1:
+            break
+        pid = ppid
+    return "unknown"
+
+
+def detect_session_id(env_vars: Sequence[str] = DEFAULT_SESSION_ENV_VARS) -> str:
+    """Return the first non-empty session id from ``env_vars``, else ``unknown``."""
+    for name in env_vars:
+        value = os.environ.get(name)
+        if value:
+            return value
+    return "unknown"
+
+
+def log_injection(
+    log_file: Path,
+    query: str,
+    hits: Sequence[Mapping[str, Any]],
+    *,
+    backend: str,
+    max_injected: int | None = None,
+    session_id: str | None = None,
+    harness: str | None = None,
+    score_key: str = "similarity",
+    hit_fields: Sequence[str] = ("id", "type", "path", "date", "state"),
+    extra: Mapping[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Append one JSONL record describing a retrieval injection.
+
+    Args:
+        log_file: JSONL file to append to; parent directories are created.
+        query: The query text that produced ``hits``.
+        hits: Ranked hits, richest first. Only the first ``max_injected`` are
+            recorded in detail — the rest are still counted.
+        backend: Retrieval backend label (``"tfidf"``, ``"chroma"``, ...).
+        max_injected: How many hits the consumer actually injected. Defaults to
+            all of them.
+        session_id: Overrides :func:`detect_session_id`.
+        harness: Overrides :func:`detect_harness`.
+        score_key: Key holding each hit's score.
+        hit_fields: Hit keys copied into the record when present and non-empty.
+        extra: Additional top-level fields merged into the record.
+
+    Returns the record written, or ``None`` if the write failed. Logging is
+    best-effort by design: a full disk must never break injection.
+    """
+    injected = len(hits) if max_injected is None else min(len(hits), max_injected)
+    record: dict[str, Any] = {
+        "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "session_id": session_id or detect_session_id(),
+        "harness": harness or detect_harness(),
+        "backend": backend,
+        "query": query,
+        "query_len": len(query),
+        "num_hits": len(hits),
+        "num_injected": injected,
+        "top_score": float(hits[0].get(score_key, 0.0)) if hits else 0.0,
+        "hits": [
+            {
+                **{f: hit[f] for f in hit_fields if hit.get(f)},
+                "score": float(hit.get(score_key, 0.0)),
+            }
+            for hit in hits[:injected]
+        ],
+    }
+    if extra:
+        record.update(extra)
+
+    try:
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        with open(log_file, "a", encoding="utf-8") as f:
+            f.write(json.dumps(record) + "\n")
+    except OSError as exc:
+        logger.debug("injection log write failed (%s): %s", log_file, exc)
+        return None
+    return record
+
+
+@dataclass
+class InjectionStats:
+    """Aggregate view of an injection log."""
+
+    total: int = 0
+    nonzero: int = 0
+    avg_hits: float = 0.0
+    avg_top_score: float = 0.0
+    unique_sessions: int = 0
+    by_harness: dict[str, int] = field(default_factory=dict)
+    malformed: int = 0
+
+    @property
+    def fire_rate(self) -> float:
+        """Fraction of injections that returned at least one hit."""
+        return self.nonzero / self.total if self.total else 0.0
+
+
+def summarize_injections(log_file: Path) -> InjectionStats:
+    """Aggregate an injection log into :class:`InjectionStats`.
+
+    A concurrently-appended JSONL file routinely ends in a partially-written
+    line, so undecodable lines are counted in ``malformed`` and skipped rather
+    than raising.
+    """
+    stats = InjectionStats()
+    if not log_file.exists():
+        return stats
+
+    sessions: set[str] = set()
+    sum_hits = 0
+    sum_top = 0.0
+    with open(log_file, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                stats.malformed += 1
+                continue
+            if not isinstance(rec, dict):
+                stats.malformed += 1
+                continue
+            stats.total += 1
+            num_hits = int(rec.get("num_hits", 0) or 0)
+            sum_hits += num_hits
+            if num_hits > 0:
+                stats.nonzero += 1
+                sum_top += float(rec.get("top_score", 0.0) or 0.0)
+            sessions.add(str(rec.get("session_id", "unknown")))
+            harness = str(rec.get("harness", "unknown"))
+            stats.by_harness[harness] = stats.by_harness.get(harness, 0) + 1
+
+    stats.unique_sessions = len(sessions)
+    if stats.total:
+        stats.avg_hits = sum_hits / stats.total
+    if stats.nonzero:
+        stats.avg_top_score = sum_top / stats.nonzero
+    return stats
+
+
+@dataclass
+class SliceHealth:
+    """Health of one named subset of the index (a document type, a source)."""
+
+    name: str
+    indexed: int
+    on_disk: int
+    status: str
+
+    @property
+    def delta(self) -> int:
+        return self.on_disk - self.indexed
+
+
+@dataclass
+class IndexHealth:
+    """Whether an index is fresh enough and complete enough to be trusted."""
+
+    status: str
+    age_hours: float | None = None
+    built_at: str | None = None
+    indexed_count: int = 0
+    on_disk_count: int | None = None
+    slices: dict[str, SliceHealth] = field(default_factory=dict)
+    reasons: list[str] = field(default_factory=list)
+
+    @property
+    def delta(self) -> int | None:
+        if self.on_disk_count is None:
+            return None
+        return self.on_disk_count - self.indexed_count
+
+    @property
+    def ok(self) -> bool:
+        return self.status == "ok"
+
+    def to_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "status": self.status,
+            "age_hours": self.age_hours,
+            "built_at": self.built_at,
+            "indexed_count": self.indexed_count,
+            "on_disk_count": self.on_disk_count,
+            "delta": self.delta,
+            "reasons": list(self.reasons),
+        }
+        if self.slices:
+            data["slices"] = {
+                name: {
+                    "status": s.status,
+                    "indexed": s.indexed,
+                    "on_disk": s.on_disk,
+                    "delta": s.delta,
+                }
+                for name, s in self.slices.items()
+            }
+        return data
+
+
+def assess_index_health(
+    *,
+    built_at: datetime | None,
+    indexed_count: int,
+    on_disk_count: int | None = None,
+    max_age_hours: float = 2.0,
+    count_delta_tolerance: int = 0,
+    slices: Mapping[str, tuple[int, int]] | None = None,
+    slice_delta_tolerance: int = 25,
+    now: datetime | None = None,
+) -> IndexHealth:
+    """Judge index freshness and completeness from counts the caller supplies.
+
+    Args:
+        built_at: When the index was built; ``None`` means no index exists.
+        indexed_count: Documents in the index.
+        on_disk_count: Documents currently on disk, if the caller can count
+            them cheaply. ``None`` skips the completeness check.
+        max_age_hours: Above this age the index is ``stale``.
+        count_delta_tolerance: Absolute indexed/on-disk difference tolerated
+            before the index is ``stale``. A continuously-written corpus should
+            allow some churn; a static one should use ``0``.
+        slices: ``{name: (indexed, on_disk)}`` for subsets worth judging
+            separately. A slice at zero is the rot that matters most: global
+            counts stay healthy while one document type has silently vanished
+            from the index.
+        slice_delta_tolerance: Same as ``count_delta_tolerance``, per slice.
+        now: Injectable clock for tests.
+
+    Returns an :class:`IndexHealth` whose ``status`` is one of ``ok``,
+    ``stale`` or ``missing``, with ``reasons`` naming every failed check.
+    """
+    now = now or datetime.now(timezone.utc)
+    if built_at is None:
+        return IndexHealth(status="missing", reasons=["no index"])
+
+    if built_at.tzinfo is None:
+        built_at = built_at.replace(tzinfo=timezone.utc)
+    age_hours = max(0.0, (now - built_at).total_seconds() / 3600.0)
+
+    health = IndexHealth(
+        status="ok",
+        age_hours=round(age_hours, 2),
+        built_at=built_at.isoformat(),
+        indexed_count=indexed_count,
+        on_disk_count=on_disk_count,
+    )
+
+    if indexed_count == 0:
+        health.status = "missing"
+        health.reasons.append("index is empty")
+        return health
+
+    if age_hours > max_age_hours:
+        health.status = "stale"
+        health.reasons.append(f"age {age_hours:.1f}h > {max_age_hours}h")
+
+    if on_disk_count is not None:
+        delta = on_disk_count - indexed_count
+        if abs(delta) > count_delta_tolerance:
+            health.status = "stale"
+            health.reasons.append(f"count delta {delta:+d} > tolerance {count_delta_tolerance}")
+
+    for name, (indexed, on_disk) in (slices or {}).items():
+        delta = on_disk - indexed
+        if indexed == 0:
+            slice_status = "missing"
+            health.reasons.append(f"slice {name!r} is empty")
+        elif abs(delta) > slice_delta_tolerance or age_hours > max_age_hours:
+            slice_status = "stale"
+            if abs(delta) > slice_delta_tolerance:
+                health.reasons.append(
+                    f"slice {name!r} delta {delta:+d} > tolerance {slice_delta_tolerance}"
+                )
+        else:
+            slice_status = "ok"
+        health.slices[name] = SliceHealth(
+            name=name, indexed=indexed, on_disk=on_disk, status=slice_status
+        )
+        # A dead slice must not be masked by a healthy global count -- that
+        # masking is precisely the rot this function exists to surface.
+        if slice_status != "ok" and health.status == "ok":
+            health.status = slice_status
+
+    return health
+
+
+__all__ = [
+    "HARNESS_COMMS",
+    "DEFAULT_SESSION_ENV_VARS",
+    "IndexHealth",
+    "InjectionStats",
+    "SliceHealth",
+    "assess_index_health",
+    "detect_harness",
+    "detect_session_id",
+    "log_injection",
+    "summarize_injections",
+]

--- a/packages/gptme-rag/src/gptme_rag/observability.py
+++ b/packages/gptme-rag/src/gptme_rag/observability.py
@@ -27,7 +27,7 @@ import json
 import logging
 import os
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any
 from collections.abc import Mapping, Sequence
@@ -55,7 +55,7 @@ DEFAULT_SESSION_ENV_VARS: tuple[str, ...] = (
 )
 
 #: How far up the process tree :func:`detect_harness` will walk.
-_MAX_PROC_WALK = 8
+_MAX_PROC_WALK = 32
 
 #: Worse status wins. A missing slice must not be masked by a stale global
 #: count the way a missing slice used to be masked by a healthy one.
@@ -175,11 +175,11 @@ def log_injection(
         "query_len": len(query),
         "num_hits": len(hits),
         "num_injected": injected,
-        "top_score": _as_score(hits[0].get(score_key)) if hits else 0.0,
+        "top_score": _as_score(hits[0].get(score_key)) if hits and injected > 0 else 0.0,
         "hits": [
             {
                 **{
-                    f: hit[f].isoformat() if isinstance(hit[f], datetime) else hit[f]
+                    f: hit[f].isoformat() if isinstance(hit[f], datetime | date) else hit[f]
                     for f in hit_fields
                     if f in hit and _copyable_hit_field(hit[f])
                 },
@@ -229,7 +229,7 @@ def summarize_injections(log_file: Path) -> InjectionStats:
     than raising.
     """
     stats = InjectionStats()
-    if not log_file.exists():
+    if not log_file.exists() or log_file.is_dir():
         return stats
 
     sessions: set[str] = set()
@@ -260,8 +260,10 @@ def summarize_injections(log_file: Path) -> InjectionStats:
             if num_hits > 0:
                 stats.nonzero += 1
                 sum_top += top_score
-            sessions.add(str(rec.get("session_id") or "unknown"))
-            harness = str(rec.get("harness") or "unknown")
+            _sid = rec.get("session_id")
+            sessions.add(str(_sid) if _sid is not None else "unknown")
+            _h = rec.get("harness")
+            harness = str(_h) if _h is not None else "unknown"
             stats.by_harness[harness] = stats.by_harness.get(harness, 0) + 1
 
     stats.unique_sessions = len(sessions)

--- a/packages/gptme-rag/src/gptme_rag/observability.py
+++ b/packages/gptme-rag/src/gptme_rag/observability.py
@@ -112,6 +112,11 @@ def _as_score(value: Any) -> float:
         return 0.0
 
 
+def _copyable_hit_field(value: Any) -> bool:
+    """Keep present values including 0/False; drop None and empty strings."""
+    return value is not None and value != ""
+
+
 def log_injection(
     log_file: Path,
     query: str,
@@ -138,7 +143,8 @@ def log_injection(
         session_id: Overrides :func:`detect_session_id`.
         harness: Overrides :func:`detect_harness`.
         score_key: Key holding each hit's score.
-        hit_fields: Hit keys copied into the record when present and non-empty.
+        hit_fields: Hit keys copied into the record when present. ``None`` and
+            ``""`` are omitted; ``0`` / ``False`` are kept.
         extra: Additional top-level fields merged into the record.
 
     Returns the record written, or ``None`` if the write failed. Logging is
@@ -157,7 +163,7 @@ def log_injection(
         "top_score": _as_score(hits[0].get(score_key)) if hits else 0.0,
         "hits": [
             {
-                **{f: hit[f] for f in hit_fields if hit.get(f)},
+                **{f: hit[f] for f in hit_fields if f in hit and _copyable_hit_field(hit[f])},
                 "score": _as_score(hit.get(score_key)),
             }
             for hit in hits[:injected]

--- a/packages/gptme-rag/src/gptme_rag/observability.py
+++ b/packages/gptme-rag/src/gptme_rag/observability.py
@@ -76,7 +76,11 @@ def detect_harness() -> str:
     ``"unknown"`` when nothing matches or ``/proc`` is unavailable — this is
     diagnostic metadata, never a control-flow input.
     """
-    pid = os.getppid()
+    try:
+        pid = os.getppid()
+    except AttributeError:
+        # os.getppid is not available on Windows
+        return "unknown"
     for _ in range(_MAX_PROC_WALK):
         if pid <= 1:
             break
@@ -231,7 +235,7 @@ def summarize_injections(log_file: Path) -> InjectionStats:
     sessions: set[str] = set()
     sum_hits = 0
     sum_top = 0.0
-    with open(log_file, encoding="utf-8") as f:
+    with open(log_file, encoding="utf-8", errors="replace") as f:
         for line in f:
             line = line.strip()
             if not line:

--- a/packages/gptme-rag/src/gptme_rag/observability.py
+++ b/packages/gptme-rag/src/gptme_rag/observability.py
@@ -57,6 +57,17 @@ DEFAULT_SESSION_ENV_VARS: tuple[str, ...] = (
 #: How far up the process tree :func:`detect_harness` will walk.
 _MAX_PROC_WALK = 8
 
+#: Worse status wins. A missing slice must not be masked by a stale global
+#: count the way a missing slice used to be masked by a healthy one.
+_STATUS_RANK = {"ok": 0, "stale": 1, "missing": 2}
+
+
+def _worse_status(current: str, candidate: str) -> str:
+    """Return the more severe of two health statuses."""
+    if _STATUS_RANK.get(candidate, 0) > _STATUS_RANK.get(current, 0):
+        return candidate
+    return current
+
 
 def detect_harness() -> str:
     """Best-effort identification of the agent harness that invoked us.
@@ -391,10 +402,9 @@ def assess_index_health(
         health.slices[name] = SliceHealth(
             name=name, indexed=indexed, on_disk=on_disk, status=slice_status
         )
-        # A dead slice must not be masked by a healthy global count -- that
-        # masking is precisely the rot this function exists to surface.
-        if slice_status != "ok" and health.status == "ok":
-            health.status = slice_status
+        # A dead slice must not be masked by a healthier global status --
+        # missing-while-stale is the same rot as missing-while-ok.
+        health.status = _worse_status(health.status, slice_status)
 
     return health
 

--- a/packages/gptme-rag/tests/test_observability.py
+++ b/packages/gptme-rag/tests/test_observability.py
@@ -566,6 +566,24 @@ def test_summarize_treats_null_session_and_harness_as_unknown(tmp_path):
     assert stats.unique_sessions == 1
 
 
+def test_log_injection_coerces_datetime_hit_fields(tmp_path):
+    """A datetime value in a hit field must be serialized, not silently drop the record."""
+    log = tmp_path / "injections.jsonl"
+    from datetime import datetime, timezone
+
+    ts = datetime(2026, 8, 25, 12, 0, tzinfo=timezone.utc)
+    record = log_injection(
+        log,
+        "q",
+        [{"id": "d1", "date": ts, "similarity": 0.5}],
+        backend="tfidf",
+        session_id="s",
+        harness="test",
+    )
+    assert record is not None, "record must not be silently discarded on datetime hit field"
+    assert record["hits"][0]["date"] == ts.isoformat()
+
+
 def test_summarize_skips_overflow_top_score(tmp_path):
     """An overflow-scale top_score in a log record must be skipped, not crash."""
     log = tmp_path / "injections.jsonl"

--- a/packages/gptme-rag/tests/test_observability.py
+++ b/packages/gptme-rag/tests/test_observability.py
@@ -1,0 +1,328 @@
+"""Tests for injection logging and index-health reporting."""
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from gptme_rag.observability import (
+    IndexHealth,
+    assess_index_health,
+    detect_session_id,
+    log_injection,
+    summarize_injections,
+)
+
+NOW = datetime(2026, 8, 24, 12, 0, tzinfo=timezone.utc)
+
+
+def _hits(*scores: float) -> list[dict]:
+    return [
+        {"id": f"doc-{i}", "type": "journal", "path": f"j/{i}.md", "similarity": s}
+        for i, s in enumerate(scores)
+    ]
+
+
+# --- log_injection ---------------------------------------------------------
+
+
+def test_log_injection_writes_one_jsonl_record(tmp_path):
+    log = tmp_path / "nested" / "injections.jsonl"
+
+    record = log_injection(log, "why is CI red", _hits(0.7, 0.4), backend="tfidf", session_id="s1")
+
+    assert record is not None
+    lines = log.read_text().splitlines()
+    assert len(lines) == 1
+    written = json.loads(lines[0])
+    assert written == record
+    assert written["session_id"] == "s1"
+    assert written["backend"] == "tfidf"
+    assert written["num_hits"] == 2
+    assert written["num_injected"] == 2
+    assert written["top_score"] == pytest.approx(0.7)
+    assert written["query_len"] == len("why is CI red")
+
+
+def test_log_injection_appends(tmp_path):
+    log = tmp_path / "injections.jsonl"
+    log_injection(log, "a", _hits(0.5), backend="tfidf", session_id="s")
+    log_injection(log, "b", [], backend="tfidf", session_id="s")
+
+    assert len(log.read_text().splitlines()) == 2
+
+
+def test_log_injection_records_only_injected_hits_but_counts_all(tmp_path):
+    log = tmp_path / "injections.jsonl"
+
+    record = log_injection(
+        log,
+        "q",
+        _hits(0.9, 0.8, 0.7, 0.6),
+        backend="tfidf",
+        max_injected=2,
+        session_id="s",
+    )
+
+    assert record["num_hits"] == 4
+    assert record["num_injected"] == 2
+    assert len(record["hits"]) == 2
+    assert [h["score"] for h in record["hits"]] == [0.9, 0.8]
+
+
+def test_log_injection_omits_empty_hit_fields(tmp_path):
+    log = tmp_path / "injections.jsonl"
+
+    record = log_injection(
+        log,
+        "q",
+        [{"id": "t1", "type": "task", "state": "active", "similarity": 0.3}],
+        backend="tfidf",
+        session_id="s",
+    )
+
+    hit = record["hits"][0]
+    assert hit == {"id": "t1", "type": "task", "state": "active", "score": 0.3}
+    assert "path" not in hit  # absent key must not become a null column
+
+
+def test_log_injection_empty_hits_has_zero_top_score(tmp_path):
+    log = tmp_path / "injections.jsonl"
+
+    record = log_injection(log, "q", [], backend="chroma", session_id="s")
+
+    assert record["num_hits"] == 0
+    assert record["top_score"] == 0.0
+    assert record["hits"] == []
+
+
+def test_log_injection_merges_extra_fields(tmp_path):
+    log = tmp_path / "injections.jsonl"
+
+    record = log_injection(
+        log,
+        "q",
+        _hits(0.5),
+        backend="tfidf",
+        session_id="s",
+        extra={"consumer": "task-retrieval"},
+    )
+
+    assert record["consumer"] == "task-retrieval"
+
+
+def test_log_injection_honours_custom_score_key(tmp_path):
+    log = tmp_path / "injections.jsonl"
+
+    record = log_injection(
+        log,
+        "q",
+        [{"id": "d", "bm25": 4.2}],
+        backend="bm25",
+        session_id="s",
+        score_key="bm25",
+    )
+
+    assert record["top_score"] == pytest.approx(4.2)
+
+
+def test_log_injection_never_raises_on_unwritable_path(tmp_path):
+    blocker = tmp_path / "not-a-dir"
+    blocker.write_text("")
+
+    # Best-effort by design: a bad path must not break the consumer.
+    assert log_injection(blocker / "x.jsonl", "q", [], backend="tfidf") is None
+
+
+def test_detect_session_id_prefers_first_set_var(monkeypatch):
+    monkeypatch.delenv("A", raising=False)
+    monkeypatch.setenv("B", "session-b")
+    assert detect_session_id(["A", "B"]) == "session-b"
+    monkeypatch.delenv("B", raising=False)
+    assert detect_session_id(["A", "B"]) == "unknown"
+
+
+# --- summarize_injections --------------------------------------------------
+
+
+def test_summarize_missing_log_is_empty(tmp_path):
+    stats = summarize_injections(tmp_path / "absent.jsonl")
+    assert stats.total == 0
+    assert stats.fire_rate == 0.0
+
+
+def test_summarize_aggregates_fire_rate_and_harnesses(tmp_path):
+    log = tmp_path / "injections.jsonl"
+    log_injection(log, "a", _hits(0.8, 0.4), backend="tfidf", session_id="s1", harness="gptme")
+    log_injection(log, "b", [], backend="tfidf", session_id="s1", harness="gptme")
+    log_injection(log, "c", _hits(0.6), backend="tfidf", session_id="s2", harness="claude-code")
+
+    stats = summarize_injections(log)
+
+    assert stats.total == 3
+    assert stats.nonzero == 2
+    assert stats.fire_rate == pytest.approx(2 / 3)
+    assert stats.avg_hits == pytest.approx(3 / 3)
+    assert stats.avg_top_score == pytest.approx((0.8 + 0.6) / 2)
+    assert stats.unique_sessions == 2
+    assert stats.by_harness == {"gptme": 2, "claude-code": 1}
+
+
+def test_summarize_skips_partial_trailing_line(tmp_path):
+    """A concurrent append leaves a half-written line — skip it, don't raise."""
+    log = tmp_path / "injections.jsonl"
+    log_injection(log, "a", _hits(0.5), backend="tfidf", session_id="s")
+    with open(log, "a") as f:
+        f.write('{"ts": "2026-08-24T12:00:00Z", "num_hi')
+
+    stats = summarize_injections(log)
+
+    assert stats.total == 1
+    assert stats.malformed == 1
+
+
+def test_summarize_ignores_blank_and_non_object_lines(tmp_path):
+    log = tmp_path / "injections.jsonl"
+    log.write_text('\n[1, 2]\n{"num_hits": 1, "top_score": 0.5}\n\n')
+
+    stats = summarize_injections(log)
+
+    assert stats.total == 1
+    assert stats.malformed == 1
+
+
+# --- assess_index_health ---------------------------------------------------
+
+
+def test_health_missing_when_never_built():
+    health = assess_index_health(built_at=None, indexed_count=0)
+    assert health.status == "missing"
+    assert not health.ok
+    assert health.reasons == ["no index"]
+
+
+def test_health_missing_when_index_is_empty():
+    health = assess_index_health(built_at=NOW, indexed_count=0, now=NOW)
+    assert health.status == "missing"
+    assert "index is empty" in health.reasons
+
+
+def test_health_ok_when_fresh_and_complete():
+    health = assess_index_health(
+        built_at=NOW - timedelta(minutes=10),
+        indexed_count=500,
+        on_disk_count=500,
+        now=NOW,
+    )
+    assert health.ok
+    assert health.reasons == []
+    assert health.age_hours == pytest.approx(0.17, abs=0.01)
+    assert health.delta == 0
+
+
+def test_health_stale_when_too_old():
+    health = assess_index_health(
+        built_at=NOW - timedelta(hours=51 * 24),
+        indexed_count=500,
+        on_disk_count=500,
+        max_age_hours=2.0,
+        now=NOW,
+    )
+    assert health.status == "stale"
+    assert any("age" in r for r in health.reasons)
+
+
+def test_health_stale_when_disk_drifted_past_tolerance():
+    health = assess_index_health(built_at=NOW, indexed_count=500, on_disk_count=540, now=NOW)
+    assert health.status == "stale"
+    assert health.delta == 40
+
+    tolerant = assess_index_health(
+        built_at=NOW,
+        indexed_count=500,
+        on_disk_count=540,
+        count_delta_tolerance=50,
+        now=NOW,
+    )
+    assert tolerant.ok
+
+
+def test_health_skips_completeness_check_without_disk_count():
+    health = assess_index_health(built_at=NOW, indexed_count=500, now=NOW)
+    assert health.ok
+    assert health.delta is None
+
+
+def test_empty_slice_is_flagged_even_when_index_looks_healthy():
+    """The rot that matters: one document type silently gone from a big index."""
+    health = assess_index_health(
+        built_at=NOW,
+        indexed_count=84_000,
+        on_disk_count=84_000,
+        slices={"task": (0, 1079), "journal": (60_000, 60_010)},
+        now=NOW,
+    )
+
+    assert health.slices["task"].status == "missing"
+    assert health.slices["journal"].status == "ok"
+    assert "slice 'task' is empty" in health.reasons
+    # A per-slice failure must not be masked by a healthy global count.
+    assert not health.ok
+
+
+def test_slice_stale_on_delta_and_on_global_age():
+    drifted = assess_index_health(
+        built_at=NOW,
+        indexed_count=100,
+        slices={"task": (100, 200)},
+        slice_delta_tolerance=25,
+        now=NOW,
+    )
+    assert drifted.slices["task"].status == "stale"
+    assert drifted.status == "stale"
+
+    aged = assess_index_health(
+        built_at=NOW - timedelta(hours=5),
+        indexed_count=100,
+        slices={"task": (100, 100)},
+        max_age_hours=2.0,
+        now=NOW,
+    )
+    assert aged.slices["task"].status == "stale"
+
+
+def test_naive_built_at_is_treated_as_utc():
+    health = assess_index_health(built_at=datetime(2026, 8, 24, 11, 30), indexed_count=10, now=NOW)
+    assert health.ok
+    assert health.age_hours == pytest.approx(0.5)
+
+
+def test_future_built_at_clamps_age_to_zero():
+    health = assess_index_health(built_at=NOW + timedelta(hours=3), indexed_count=10, now=NOW)
+    assert health.age_hours == 0.0
+    assert health.ok
+
+
+def test_to_dict_is_json_serializable_and_includes_slices():
+    health = assess_index_health(
+        built_at=NOW,
+        indexed_count=10,
+        on_disk_count=12,
+        count_delta_tolerance=5,
+        slices={"task": (4, 4)},
+        now=NOW,
+    )
+
+    data = health.to_dict()
+    assert json.loads(json.dumps(data)) == data
+    assert data["delta"] == 2
+    assert data["slices"]["task"] == {
+        "status": "ok",
+        "indexed": 4,
+        "on_disk": 4,
+        "delta": 0,
+    }
+
+
+def test_index_health_dataclass_defaults_are_conservative():
+    assert IndexHealth(status="missing").ok is False

--- a/packages/gptme-rag/tests/test_observability.py
+++ b/packages/gptme-rag/tests/test_observability.py
@@ -171,6 +171,41 @@ def test_log_injection_never_raises_on_unwritable_path(tmp_path):
     assert log_injection(blocker / "x.jsonl", "q", [], backend="tfidf") is None
 
 
+def test_log_injection_never_raises_on_unserializable_hit(tmp_path):
+    log = tmp_path / "injections.jsonl"
+
+    assert (
+        log_injection(
+            log,
+            "q",
+            [{"id": object(), "similarity": 0.5}],
+            backend="tfidf",
+            session_id="s",
+            harness="test",
+        )
+        is None
+    )
+    assert not log.exists()
+
+
+def test_log_injection_clamps_negative_max_injected(tmp_path):
+    log = tmp_path / "injections.jsonl"
+
+    record = log_injection(
+        log,
+        "q",
+        _hits(0.9, 0.8, 0.7),
+        backend="tfidf",
+        max_injected=-1,
+        session_id="s",
+        harness="test",
+    )
+
+    assert record["num_hits"] == 3
+    assert record["num_injected"] == 0
+    assert record["hits"] == []
+
+
 def test_detect_session_id_prefers_first_set_var(monkeypatch):
     monkeypatch.delenv("A", raising=False)
     monkeypatch.setenv("B", "session-b")

--- a/packages/gptme-rag/tests/test_observability.py
+++ b/packages/gptme-rag/tests/test_observability.py
@@ -523,3 +523,44 @@ def test_detect_harness_breaks_on_unreadable_proc(monkeypatch):
 def test_detect_harness_breaks_on_pid_cycle(monkeypatch):
     _patch_proc(monkeypatch, 11, {11: ("python", 11)})
     assert detect_harness() == "unknown"
+
+
+def test_as_score_handles_overflow(tmp_path):
+    """log_injection must not raise when a hit carries an overflow-scale integer score."""
+    log = tmp_path / "injections.jsonl"
+    record = log_injection(
+        log,
+        "q",
+        [{"id": "x", "similarity": 10**1000}],
+        backend="tfidf",
+        session_id="s",
+        harness="test",
+    )
+    assert record is not None
+    assert record["top_score"] == 0.0
+
+
+def test_summarize_treats_null_session_and_harness_as_unknown(tmp_path):
+    """str(None) must not appear as a bucket label in summarize_injections."""
+    log = tmp_path / "injections.jsonl"
+    import json
+
+    log.write_text(
+        json.dumps(
+            {
+                "query": "q",
+                "backend": "tfidf",
+                "num_hits": 1,
+                "num_injected": 1,
+                "top_score": 0.5,
+                "session_id": None,
+                "harness": None,
+                "hits": [],
+            }
+        )
+        + "\n"
+    )
+    stats = summarize_injections(log)
+    assert "None" not in stats.by_harness
+    assert stats.by_harness.get("unknown", 0) == 1
+    assert stats.unique_sessions == 1

--- a/packages/gptme-rag/tests/test_observability.py
+++ b/packages/gptme-rag/tests/test_observability.py
@@ -615,6 +615,60 @@ def test_log_injection_empty_string_session_and_harness_kept(tmp_path):
     assert record["harness"] == ""
 
 
+def test_log_injection_coerces_date_hit_fields(tmp_path):
+    """A datetime.date value in a hit field must be serialized, not silently drop the record."""
+    from datetime import date
+
+    d = date(2026, 8, 25)
+    log = tmp_path / "injections.jsonl"
+    record = log_injection(
+        log,
+        "q",
+        [{"id": "d1", "date": d, "similarity": 0.5}],
+        backend="tfidf",
+        session_id="s",
+        harness="test",
+    )
+    assert record is not None, "record must not be silently discarded on date hit field"
+    assert record["hits"][0]["date"] == d.isoformat()
+
+
+def test_log_injection_zero_max_injected_has_zero_top_score(tmp_path):
+    """top_score must be 0.0 when max_injected=0, not the score of the first hit."""
+    log = tmp_path / "injections.jsonl"
+    record = log_injection(
+        log,
+        "q",
+        [{"id": "x", "similarity": 0.9}],
+        backend="tfidf",
+        max_injected=0,
+        session_id="s",
+        harness="test",
+    )
+    assert record is not None
+    assert record["num_injected"] == 0
+    assert record["hits"] == []
+    assert record["top_score"] == 0.0, "top_score must reflect that nothing was injected"
+
+
+def test_summarize_preserves_empty_string_session_and_harness(tmp_path):
+    """summarize_injections must not map empty-string session_id/harness to 'unknown'."""
+    log = tmp_path / "injections.jsonl"
+    log.write_text(
+        json.dumps({"num_hits": 1, "top_score": 0.5, "session_id": "", "harness": ""}) + "\n"
+    )
+    stats = summarize_injections(log)
+    assert stats.total == 1
+    assert "" in stats.by_harness, "empty-string harness must not be collapsed to 'unknown'"
+
+
+def test_summarize_returns_empty_stats_for_directory(tmp_path):
+    """summarize_injections must not crash when given a path that is a directory."""
+    stats = summarize_injections(tmp_path)
+    assert stats.total == 0
+    assert stats.malformed == 0
+
+
 def test_slice_age_only_stale_has_per_slice_reason():
     """When a slice is stale solely because the index is old, a per-slice reason must appear."""
     health = assess_index_health(

--- a/packages/gptme-rag/tests/test_observability.py
+++ b/packages/gptme-rag/tests/test_observability.py
@@ -564,3 +564,49 @@ def test_summarize_treats_null_session_and_harness_as_unknown(tmp_path):
     assert "None" not in stats.by_harness
     assert stats.by_harness.get("unknown", 0) == 1
     assert stats.unique_sessions == 1
+
+
+def test_summarize_skips_overflow_top_score(tmp_path):
+    """An overflow-scale top_score in a log record must be skipped, not crash."""
+    log = tmp_path / "injections.jsonl"
+    log.write_text(
+        json.dumps({"num_hits": 1, "top_score": 10**1000})
+        + "\n"
+        + json.dumps({"num_hits": 2, "top_score": 0.8})
+        + "\n"
+    )
+    stats = summarize_injections(log)
+    assert stats.malformed == 1
+    assert stats.total == 1
+    assert stats.avg_top_score == pytest.approx(0.8)
+
+
+def test_log_injection_empty_string_session_and_harness_kept(tmp_path):
+    """Explicitly passing session_id='' or harness='' must be written as-is."""
+    log = tmp_path / "injections.jsonl"
+    record = log_injection(
+        log,
+        "q",
+        [],
+        backend="tfidf",
+        session_id="",
+        harness="",
+    )
+    assert record is not None
+    assert record["session_id"] == ""
+    assert record["harness"] == ""
+
+
+def test_slice_age_only_stale_has_per_slice_reason():
+    """When a slice is stale solely because the index is old, a per-slice reason must appear."""
+    health = assess_index_health(
+        built_at=NOW - timedelta(hours=5),
+        indexed_count=100,
+        slices={"task": (100, 100)},
+        max_age_hours=2.0,
+        slice_delta_tolerance=25,
+        now=NOW,
+    )
+    assert health.slices["task"].status == "stale"
+    slice_reasons = [r for r in health.reasons if "task" in r]
+    assert slice_reasons, f"expected per-slice reason for 'task', got: {health.reasons}"

--- a/packages/gptme-rag/tests/test_observability.py
+++ b/packages/gptme-rag/tests/test_observability.py
@@ -88,6 +88,25 @@ def test_log_injection_omits_empty_hit_fields(tmp_path):
     assert "path" not in hit  # absent key must not become a null column
 
 
+def test_log_injection_keeps_falsy_but_present_hit_fields(tmp_path):
+    """0/False are values; only None and empty string are omitted."""
+    log = tmp_path / "injections.jsonl"
+
+    record = log_injection(
+        log,
+        "q",
+        [{"id": "t1", "type": "task", "state": 0, "path": "", "date": None, "similarity": 0.3}],
+        backend="tfidf",
+        session_id="s",
+        harness="test",
+    )
+
+    hit = record["hits"][0]
+    assert hit["state"] == 0
+    assert "path" not in hit
+    assert "date" not in hit
+
+
 def test_log_injection_empty_hits_has_zero_top_score(tmp_path):
     log = tmp_path / "injections.jsonl"
 

--- a/packages/gptme-rag/tests/test_observability.py
+++ b/packages/gptme-rag/tests/test_observability.py
@@ -1,6 +1,7 @@
 """Tests for injection logging and index-health reporting."""
 
 import json
+import os
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -8,6 +9,7 @@ import pytest
 from gptme_rag.observability import (
     IndexHealth,
     assess_index_health,
+    detect_harness,
     detect_session_id,
     log_injection,
     summarize_injections,
@@ -126,6 +128,22 @@ def test_log_injection_honours_custom_score_key(tmp_path):
     assert record["top_score"] == pytest.approx(4.2)
 
 
+def test_log_injection_treats_unusable_scores_as_zero(tmp_path):
+    log = tmp_path / "injections.jsonl"
+
+    record = log_injection(
+        log,
+        "q",
+        [{"id": "d", "similarity": None}, {"id": "e", "similarity": "n/a"}],
+        backend="tfidf",
+        session_id="s",
+        harness="test",
+    )
+
+    assert record["top_score"] == 0.0
+    assert [h["score"] for h in record["hits"]] == [0.0, 0.0]
+
+
 def test_log_injection_never_raises_on_unwritable_path(tmp_path):
     blocker = tmp_path / "not-a-dir"
     blocker.write_text("")
@@ -189,6 +207,22 @@ def test_summarize_ignores_blank_and_non_object_lines(tmp_path):
 
     assert stats.total == 1
     assert stats.malformed == 1
+
+
+def test_summarize_skips_non_numeric_fields(tmp_path):
+    """A bad typed field must not crash the aggregator — same skip contract."""
+    log = tmp_path / "injections.jsonl"
+    log.write_text(
+        '{"num_hits": "nope", "top_score": 0.5}\n'
+        '{"num_hits": 2, "top_score": "bad"}\n'
+        '{"num_hits": 1, "top_score": 0.5}\n'
+    )
+
+    stats = summarize_injections(log)
+
+    assert stats.total == 1
+    assert stats.malformed == 2
+    assert stats.avg_top_score == pytest.approx(0.5)
 
 
 # --- assess_index_health ---------------------------------------------------
@@ -297,6 +331,16 @@ def test_naive_built_at_is_treated_as_utc():
     assert health.age_hours == pytest.approx(0.5)
 
 
+def test_naive_now_is_treated_as_utc():
+    health = assess_index_health(
+        built_at=NOW,
+        indexed_count=10,
+        now=datetime(2026, 8, 24, 13, 0),
+    )
+    assert health.ok
+    assert health.age_hours == pytest.approx(1.0)
+
+
 def test_future_built_at_clamps_age_to_zero():
     health = assess_index_health(built_at=NOW + timedelta(hours=3), indexed_count=10, now=NOW)
     assert health.age_hours == 0.0
@@ -326,3 +370,74 @@ def test_to_dict_is_json_serializable_and_includes_slices():
 
 def test_index_health_dataclass_defaults_are_conservative():
     assert IndexHealth(status="missing").ok is False
+
+
+# --- detect_harness --------------------------------------------------------
+
+
+def _patch_proc(monkeypatch, parent_pid: int, tree: dict[int, tuple[str, int | str]]) -> None:
+    """Install a fake /proc tree: pid -> (comm, ppid-or-sentinel)."""
+    monkeypatch.setattr(os, "getppid", lambda: parent_pid)
+
+    class FakePath:
+        def __init__(self, path: str) -> None:
+            self._path = str(path)
+
+        def __truediv__(self, other: object) -> "FakePath":
+            return FakePath(self._path.rstrip("/") + "/" + str(other).lstrip("/"))
+
+        def read_text(self, encoding: str | None = None) -> str:
+            parts = self._path.strip("/").split("/")
+            if len(parts) != 3 or parts[0] != "proc":
+                raise OSError(self._path)
+            try:
+                pid = int(parts[1])
+            except ValueError as exc:
+                raise OSError(self._path) from exc
+            if pid not in tree:
+                raise OSError("no such pid")
+            comm, ppid = tree[pid]
+            kind = parts[2]
+            if kind == "comm":
+                if comm == "OSERROR":
+                    raise OSError("comm vanished")
+                return f"{comm}\n"
+            if kind == "status":
+                if ppid == "OSERROR":
+                    raise OSError("status vanished")
+                if ppid == "MALFORMED":
+                    return "PPid:\n"
+                return f"Name:\t{comm}\nPPid:\t{ppid}\n"
+            raise OSError(kind)
+
+    monkeypatch.setattr("gptme_rag.observability.Path", FakePath)
+
+
+def test_detect_harness_returns_matching_ancestor(monkeypatch):
+    _patch_proc(monkeypatch, 100, {100: ("python", 50), 50: ("gptme", 1)})
+    assert detect_harness() == "gptme"
+
+
+def test_detect_harness_maps_claude_comm(monkeypatch):
+    _patch_proc(monkeypatch, 7, {7: ("claude", 1)})
+    assert detect_harness() == "claude-code"
+
+
+def test_detect_harness_unknown_when_nothing_matches(monkeypatch):
+    _patch_proc(monkeypatch, 3, {3: ("bash", 1)})
+    assert detect_harness() == "unknown"
+
+
+def test_detect_harness_breaks_on_malformed_ppid(monkeypatch):
+    _patch_proc(monkeypatch, 9, {9: ("python", "MALFORMED")})
+    assert detect_harness() == "unknown"
+
+
+def test_detect_harness_breaks_on_unreadable_proc(monkeypatch):
+    _patch_proc(monkeypatch, 4, {4: ("OSERROR", 1)})
+    assert detect_harness() == "unknown"
+
+
+def test_detect_harness_breaks_on_pid_cycle(monkeypatch):
+    _patch_proc(monkeypatch, 11, {11: ("python", 11)})
+    assert detect_harness() == "unknown"

--- a/packages/gptme-rag/tests/test_observability.py
+++ b/packages/gptme-rag/tests/test_observability.py
@@ -306,6 +306,34 @@ def test_health_skips_completeness_check_without_disk_count():
     assert health.delta is None
 
 
+def test_missing_slice_dominates_stale_global():
+    """A vanished document type is worse than mere age — don't report stale."""
+    health = assess_index_health(
+        built_at=NOW - timedelta(hours=5),
+        indexed_count=100,
+        slices={"task": (0, 10)},
+        max_age_hours=2.0,
+        now=NOW,
+    )
+    assert health.slices["task"].status == "missing"
+    assert health.status == "missing"
+    assert any("empty" in r for r in health.reasons)
+    assert any("age" in r for r in health.reasons)
+
+
+def test_missing_slice_dominates_even_after_a_stale_slice():
+    health = assess_index_health(
+        built_at=NOW,
+        indexed_count=100,
+        slices={"journal": (100, 200), "task": (0, 10)},
+        slice_delta_tolerance=25,
+        now=NOW,
+    )
+    assert health.slices["journal"].status == "stale"
+    assert health.slices["task"].status == "missing"
+    assert health.status == "missing"
+
+
 def test_empty_slice_is_flagged_even_when_index_looks_healthy():
     """The rot that matters: one document type silently gone from a big index."""
     health = assess_index_health(


### PR DESCRIPTION
Phase 2.5 of making gptme-rag the canonical retrieval implementation (after #1411 embeddings, #1439/#1440 task retrieval, #1465 sources, #1466 memory_type, #1468 lesson matching).

## Why

Two failure modes make a retrieval system quietly useless, and neither is visible from inside the retrieval code:

- **Invisible injections.** Without a per-injection record there is no way to ask whether retrieval fired, what it surfaced, or whether hits correlated with anything downstream. Tuning a relevance floor without this is guesswork.
- **Silent rot.** A stale index keeps answering queries with stale documents and nothing fails. Bob's ambient injector ran on a dead index for **51 days** because "no error" and "working" look identical from the consumer side.

## What

`gptme_rag/observability.py`:

| API | Does |
|---|---|
| `log_injection()` | Appends one JSONL record per injection: query, backend, hit count, top score, harness, session, per-hit fields. Best-effort — a full disk must never break injection. |
| `summarize_injections()` | Aggregates a log into `InjectionStats` (fire rate, avg hits, avg top score, by-harness). Skips partially-written trailing lines rather than raising. |
| `assess_index_health()` | Judges freshness + completeness from counts the caller supplies, returning `ok` / `stale` / `missing` with `reasons` naming every failed check. |
| `detect_harness()` / `detect_session_id()` | Diagnostic metadata for the log record. |

**Per-slice health is the point.** `slices={"task": (0, 1079)}` flags a document type that has silently gone to zero even while the global count looks perfectly healthy — that masking is the shape of the 51-day outage.

## Design note: policy-free by construction

The module never decides which directories are sources, how documents are counted, or what staleness is acceptable. Callers pass counts and thresholds. Two reasons:

1. Consumer configuration stays out of the library (per the upstreaming rule that Bob-specific policy is config, not library code).
2. It works against ChromaDB or TF-IDF equally. A pickle-shaped or Chroma-shaped API would have hard-coded a backend into a health check.

Generalized from the brain implementation while porting: `similarity` → configurable `score_key` (BM25 hits carry no `similarity`), the harness-process table is a module constant, the session env-var list is a parameter.

## Testing

25 new tests. Notably, they caught a real bug in this module before it was committed: slice failures appended a `reasons` entry but never escalated the overall status, so `assess_index_health` returned `ok` for an index with an empty `task` slice — exactly the masking the function exists to surface. Fixed; `test_empty_slice_is_flagged_even_when_index_looks_healthy` is the guard.

```
290 passed  # observability + every sibling module sharing the package __init__
mypy --ignore-missing-imports: clean
ruff check + ruff format: clean
```

Ported from Bob's `scripts/build-ambient-memory-index.py`, where both patterns were measured on real session data.