### PR TITLE
fix(ci): pass --output to community-plugins fetch so git add finds the file

### DIFF
--- a/.github/workflows/community-plugins.yml
+++ b/.github/workflows/community-plugins.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Fetch community plugins
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: python3 scripts/fetch-community-plugins.py
+        run: python3 scripts/fetch-community-plugins.py --output community_plugins.json
 
       - name: Commit if changed
         env:


### PR DESCRIPTION
The refactor in #1292 updated `git add` to use `community_plugins.json` (repo root), but the fetch script still defaults to `docs/community_plugins.json` (which is gitignored on fresh clones).

This caused the weekly `Update Community Plugins` automation to fail on 2026-08-24 with:
```
fatal: pathspec 'community_plugins.json' did not match any files
```

The fix: pass `--output community_plugins.json` explicitly to `scripts/fetch-community-plugins.py` in the workflow, so the script writes to the repo-root path that `git add` expects.