### PR TITLE
fix(git-safe-commit): skip whitespace-only lines in pathspec_file_has_positive

### DIFF
--- a/scripts/git/git-safe-commit
+++ b/scripts/git/git-safe-commit
@@ -122,7 +122,7 @@ pathspec_file_has_positive() {
     local line
     if [ "${PATHSPEC_FILE_NUL:-0}" -eq 1 ]; then
         while IFS= read -r -d '' line || [ -n "$line" ]; do
-            [ -z "$line" ] && continue
+            [ -z "${line//[[:space:]]/}" ] && continue
             if ! is_exclusion_only_pathspec "$line"; then
                 return 0
             fi
@@ -130,7 +130,7 @@ pathspec_file_has_positive() {
         return 1
     fi
     while IFS= read -r line || [ -n "$line" ]; do
-        [ -z "$line" ] && continue
+        [ -z "${line//[[:space:]]/}" ] && continue
         if ! is_exclusion_only_pathspec "$line"; then
             return 0
         fi


### PR DESCRIPTION
## Summary

Follow-up to #1490 addressing the P2 finding from the post-merge review pass.

In `pathspec_file_has_positive`, the blank-line skip used `[ -z "$line" ]`, which only matches the exact empty string. A line consisting solely of spaces or tabs is not empty by that test, so it falls through to `is_exclusion_only_pathspec`. That function returns false (not an exclusion pathspec) for whitespace-only input, causing the loop to treat the line as a positive file selector — incrementing `PATHSPEC_COUNT` and allowing the whole-index guard to be bypassed for a `--pathspec-from-file` that contains only whitespace lines.

**Fix**: replace `[ -z "$line" ]` with `[ -z "${line//[[:space:]]/}" ]` in both the newline-separated and NUL-separated read loops. Same one-liner in each place.

## Test plan

- [ ] CI green
- [x] Manual: `printf '   \n\t\n' > /tmp/ws.txt && git-safe-commit --pathspec-from-file=/tmp/ws.txt -m msg` → correctly refused as whole-index attempt

## Related

- #1490 — the PR that introduced `pathspec_file_has_positive`; this closes the remaining P2 finding