### PR TITLE
feat(sessions): record eval attempt classification on the session record

### DIFF
--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -3181,6 +3181,8 @@ def stamp_attempt_kind(ctx: click.Context, session_id: str, attempt_kind: str) -
     \b
         gptme-sessions stamp-attempt-kind a1b2 infra_retry
     """
+    if not session_id:
+        raise click.UsageError("SESSION_ID must not be empty.")
     store = SessionStore(sessions_dir=ctx.obj["sessions_dir"])
     if store.stamp_attempt_kind(session_id, attempt_kind):
         click.echo(f"stamped attempt_kind={attempt_kind} on session {session_id}")

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -34,7 +34,7 @@ from .replay import (
     resolve_replay_target,
     resolve_session_record_prefix,
 )
-from .record import SessionRecord, normalize_run_type
+from .record import ATTEMPT_KINDS, SessionRecord, normalize_run_type
 from .signals import extract_from_path
 from .store import (
     SessionStore,
@@ -3165,6 +3165,27 @@ def blame(
         raise click.ClickException(str(exc)) from exc
 
     click.echo(render_json(result) if as_json else render_text(result))
+
+
+@cli.command("stamp-attempt-kind")
+@click.argument("session_id")
+@click.argument("attempt_kind", type=click.Choice(sorted(ATTEMPT_KINDS)))
+@click.pass_context
+def stamp_attempt_kind(ctx: click.Context, session_id: str, attempt_kind: str) -> None:
+    """Record the eval attempt classification on an existing session record.
+
+    Called by the session runner after its infra-failure guards have run —
+    those guards need the final exit code, tokens and failure_reason, so the
+    verdict is only known after post_session() appended the record.
+
+    \b
+        gptme-sessions stamp-attempt-kind a1b2 infra_retry
+    """
+    store = SessionStore(sessions_dir=ctx.obj["sessions_dir"])
+    if store.stamp_attempt_kind(session_id, attempt_kind):
+        click.echo(f"stamped attempt_kind={attempt_kind} on session {session_id}")
+    else:
+        raise click.ClickException(f"no session record found for session_id={session_id!r}")
 
 
 def main() -> int:

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -3184,14 +3184,29 @@ def stamp_attempt_kind(ctx: click.Context, session_id: str, attempt_kind: str) -
     if not session_id:
         raise click.UsageError("SESSION_ID must not be empty.")
     store = SessionStore(sessions_dir=ctx.obj["sessions_dir"])
-    try:
-        record = resolve_session_record_prefix(store.load_all(), session_id)
-    except ValueError as exc:
-        raise click.ClickException(str(exc))
-    if store.stamp_attempt_kind(record.session_id, attempt_kind):
-        click.echo(f"stamped attempt_kind={attempt_kind} on session {record.session_id}")
+    records = store.load_all()
+    # Deduplicate by unique session_id before checking for ambiguity — the
+    # store may hold duplicate rows for the same session_id (e.g. if
+    # post_session() ran twice), and stamp_attempt_kind is designed to stamp
+    # all of them; resolve_session_record_prefix would falsely raise on those.
+    matches = [r for r in records if r.session_id.startswith(session_id)]
+    unique_ids = list(dict.fromkeys(r.session_id for r in matches))
+    if not unique_ids:
+        raise click.ClickException(
+            f"No session found matching {session_id!r}. "
+            "Run 'gptme-sessions query' to list available session IDs."
+        )
+    if len(unique_ids) > 1:
+        raise click.ClickException(
+            f"Ambiguous prefix {session_id!r} matches {len(unique_ids)} sessions: "
+            + ", ".join(unique_ids)
+            + ". Run 'gptme-sessions query' to list available session IDs."
+        )
+    full_id = unique_ids[0]
+    if store.stamp_attempt_kind(full_id, attempt_kind):
+        click.echo(f"stamped attempt_kind={attempt_kind} on session {full_id}")
     else:
-        raise click.ClickException(f"no session record found for session_id={session_id!r}")
+        raise click.ClickException(f"no session record found for session_id={full_id!r}")
 
 
 def main() -> int:

--- a/packages/gptme-sessions/src/gptme_sessions/cli.py
+++ b/packages/gptme-sessions/src/gptme_sessions/cli.py
@@ -3184,8 +3184,12 @@ def stamp_attempt_kind(ctx: click.Context, session_id: str, attempt_kind: str) -
     if not session_id:
         raise click.UsageError("SESSION_ID must not be empty.")
     store = SessionStore(sessions_dir=ctx.obj["sessions_dir"])
-    if store.stamp_attempt_kind(session_id, attempt_kind):
-        click.echo(f"stamped attempt_kind={attempt_kind} on session {session_id}")
+    try:
+        record = resolve_session_record_prefix(store.load_all(), session_id)
+    except ValueError as exc:
+        raise click.ClickException(str(exc))
+    if store.stamp_attempt_kind(record.session_id, attempt_kind):
+        click.echo(f"stamped attempt_kind={attempt_kind} on session {record.session_id}")
     else:
         raise click.ClickException(f"no session record found for session_id={session_id!r}")
 

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -350,6 +350,10 @@ class SessionRecord:
         # Discard unrecognized dropout_depth values so typos don't silently reach consumers.
         if self.dropout_depth is not None and self.dropout_depth not in DROPOUT_DEPTH_VALUES:
             self.dropout_depth = None
+        # Discard unrecognized attempt_kind values so hand-edited JSONL or a buggy writer
+        # cannot persist an invalid value that consumers would silently misclassify.
+        if self.attempt_kind is not None and self.attempt_kind not in ATTEMPT_KINDS:
+            self.attempt_kind = None
         # Cross-field consistency: when explicitly not selected (False), the detail fields
         # have no meaning — clear them to prevent downstream consumers from reading an
         # inconsistent combination (e.g. dropout_selected=False, dropout_depth="deep").

--- a/packages/gptme-sessions/src/gptme_sessions/record.py
+++ b/packages/gptme-sessions/src/gptme_sessions/record.py
@@ -23,6 +23,19 @@ HARM_CATEGORY_TAXONOMY: dict[str, str] = {
 }
 HARM_CATEGORY_LABELS: list[str] = list(HARM_CATEGORY_TAXONOMY.keys())
 
+# Valid values for the attempt_kind field (eval attempt classification).
+#
+#   repetition  — a normal measurable sample: whatever the session produced is
+#                 quality signal and may feed grades/bandits.
+#   infra_retry — the attempt was replaced/lost to capacity or harness failure
+#                 (rate limit, auth, dead backend, zero-token exit).  It carries
+#                 no quality signal and must be excluded from quality analytics.
+#   unknown     — classification was attempted but could not be determined.
+#
+# A record with ``attempt_kind is None`` predates the field; it is *not* the
+# same as ``"unknown"`` and consumers should fall back to their own heuristic.
+ATTEMPT_KINDS: frozenset[str] = frozenset(["repetition", "infra_retry", "unknown"])
+
 # Valid values for the dropout_depth field.
 DROPOUT_DEPTH_VALUES: frozenset[str] = frozenset(["shallow", "deep"])
 
@@ -206,6 +219,12 @@ class SessionRecord:
     exit_code: int | None = None  # process exit code (124 = timeout)
     failure_reason: str | None = None  # coarse harness failure class (see failure_capture.py)
     error: str | None = None  # stderr tail or trajectory error snippet when harness failed
+    # Eval attempt classification, written once by the session runner which
+    # already computes it (see ``ATTEMPT_KINDS``).  ``None`` on every record
+    # written before this field existed, so consumers must treat ``None`` as
+    # "unrecorded" and fall back to their own heuristic rather than assuming
+    # ``repetition``.
+    attempt_kind: str | None = None
     duration_seconds: int = 0
     token_count: int | None = None
     input_tokens: int | None = None

--- a/packages/gptme-sessions/src/gptme_sessions/store.py
+++ b/packages/gptme-sessions/src/gptme_sessions/store.py
@@ -282,13 +282,13 @@ class SessionStore:
 
         with self.lock():
             records = self.load_all()
-            target = next((r for r in reversed(records) if r.session_id == session_id), None)
-            if target is None:
+            targets = [r for r in records if r.session_id == session_id]
+            if not targets:
                 return False
-            target.attempt_kind = attempt_kind
-            # Rewrite the full list, not just the target: rewrite() upserts by
-            # session_id, so passing the single record would collapse any
-            # duplicate rows sharing that id.
+            for target in targets:
+                target.attempt_kind = attempt_kind
+            # Rewrite the full list so all duplicate rows for this session_id
+            # are stamped, not just the most recent one.
             self.rewrite(records)
         return True
 

--- a/packages/gptme-sessions/src/gptme_sessions/store.py
+++ b/packages/gptme-sessions/src/gptme_sessions/store.py
@@ -13,7 +13,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TextIO
 
-from .record import SessionRecord
+from .record import ATTEMPT_KINDS, SessionRecord
 
 try:
     import fcntl as _fcntl
@@ -253,6 +253,44 @@ class SessionStore:
                 tmp_path.unlink(missing_ok=True)
                 raise
         return self.path
+
+    def stamp_attempt_kind(self, session_id: str, attempt_kind: str) -> bool:
+        """Stamp the eval attempt classification onto an already-written record.
+
+        The session runner can only classify the attempt *after* the record has
+        been appended: the infra-failure guards need the final exit code, token
+        count and ``failure_reason``, all of which post_session() itself
+        produces.  So the classification is a second pass over the store rather
+        than a field set at record-creation time.
+
+        Writing it once here is the point — every read-side consumer would
+        otherwise re-derive infra-ness from duration/token heuristics, and each
+        new consumer is another chance to forget and silently report
+        contaminated numbers.
+
+        Returns ``True`` when a record was stamped, ``False`` when no record
+        with ``session_id`` exists (the runner may be recording a session whose
+        post_session() call failed).  Raises ``ValueError`` on an unknown kind:
+        a typo would persist as an unread value forever.
+        """
+        if attempt_kind not in ATTEMPT_KINDS:
+            raise ValueError(
+                f"unknown attempt_kind {attempt_kind!r}; expected one of {sorted(ATTEMPT_KINDS)}"
+            )
+        if not session_id:
+            raise ValueError("session_id is required to stamp attempt_kind")
+
+        with self.lock():
+            records = self.load_all()
+            target = next((r for r in reversed(records) if r.session_id == session_id), None)
+            if target is None:
+                return False
+            target.attempt_kind = attempt_kind
+            # Rewrite the full list, not just the target: rewrite() upserts by
+            # session_id, so passing the single record would collapse any
+            # duplicate rows sharing that id.
+            self.rewrite(records)
+        return True
 
     def query(
         self,

--- a/packages/gptme-sessions/tests/test_attempt_kind.py
+++ b/packages/gptme-sessions/tests/test_attempt_kind.py
@@ -100,3 +100,20 @@ def test_stamp_requires_session_id(tmp_path: Path) -> None:
 
 def test_attempt_kinds_vocabulary_is_closed() -> None:
     assert ATTEMPT_KINDS == frozenset({"repetition", "infra_retry", "unknown"})
+
+
+def test_invalid_attempt_kind_discarded_at_load_time() -> None:
+    """A hand-edited or buggy JSONL with an invalid attempt_kind must not reach consumers."""
+    record = SessionRecord.from_dict(
+        {"session_id": "s1", "outcome": "productive", "attempt_kind": "infra-retry"}
+    )
+    assert record.attempt_kind is None
+
+
+def test_valid_attempt_kind_preserved_at_load_time() -> None:
+    """A valid attempt_kind must survive the round-trip through from_dict."""
+    for kind in ATTEMPT_KINDS:
+        record = SessionRecord.from_dict(
+            {"session_id": "s1", "outcome": "productive", "attempt_kind": kind}
+        )
+        assert record.attempt_kind == kind

--- a/packages/gptme-sessions/tests/test_attempt_kind.py
+++ b/packages/gptme-sessions/tests/test_attempt_kind.py
@@ -1,0 +1,102 @@
+"""Tests for the ``attempt_kind`` eval-attempt classification.
+
+The session runner already computes an infra-failure verdict (rate limit,
+auth failure, dead backend, zero-token exit) and uses it to skip bandit and
+grade updates — but never persisted it, leaving every read-side consumer to
+re-derive infra-ness from duration/token heuristics.  These tests cover the
+write side: the field, its validation, and the second-pass stamp.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gptme_sessions import SessionRecord, SessionStore
+from gptme_sessions.record import ATTEMPT_KINDS
+
+
+def _store(tmp_path: Path) -> SessionStore:
+    return SessionStore(sessions_dir=tmp_path)
+
+
+def test_attempt_kind_defaults_to_none() -> None:
+    """Records written before the field existed must parse unchanged."""
+    record = SessionRecord.from_dict({"session_id": "old1", "outcome": "productive"})
+    assert record.attempt_kind is None
+
+
+def test_infra_failure_session_reads_back_as_infra_retry(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.append(SessionRecord(session_id="dead", outcome="failed", duration_seconds=12))
+
+    assert store.stamp_attempt_kind("dead", "infra_retry") is True
+
+    (loaded,) = store.load_all()
+    assert loaded.attempt_kind == "infra_retry"
+
+
+def test_normal_session_reads_back_as_repetition(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.append(SessionRecord(session_id="good", outcome="productive", duration_seconds=1800))
+
+    assert store.stamp_attempt_kind("good", "repetition") is True
+
+    (loaded,) = store.load_all()
+    assert loaded.attempt_kind == "repetition"
+
+
+def test_stamp_persists_to_jsonl(tmp_path: Path) -> None:
+    """The value must survive to disk, not just to the in-memory record."""
+    store = _store(tmp_path)
+    store.append(SessionRecord(session_id="s1", outcome="noop"))
+    store.stamp_attempt_kind("s1", "infra_retry")
+
+    lines = [json.loads(x) for x in store.path.read_text().splitlines() if x.strip()]
+    assert [x["attempt_kind"] for x in lines] == ["infra_retry"]
+
+
+def test_stamp_leaves_other_records_untouched(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    for sid in ("a", "b", "c"):
+        store.append(SessionRecord(session_id=sid, outcome="productive"))
+
+    store.stamp_attempt_kind("b", "infra_retry")
+
+    by_id = {r.session_id: r for r in store.load_all()}
+    assert by_id["b"].attempt_kind == "infra_retry"
+    assert by_id["a"].attempt_kind is None
+    assert by_id["c"].attempt_kind is None
+    assert len(by_id) == 3
+
+
+def test_stamp_missing_session_returns_false(tmp_path: Path) -> None:
+    """post_session() can fail; the runner must not crash stamping a ghost."""
+    store = _store(tmp_path)
+    store.append(SessionRecord(session_id="present", outcome="productive"))
+
+    assert store.stamp_attempt_kind("absent", "repetition") is False
+
+
+@pytest.mark.parametrize("bad", ["", "retry", "INFRA_RETRY", "continuation"])
+def test_stamp_rejects_unknown_kind(tmp_path: Path, bad: str) -> None:
+    """A typo would persist as an unread value forever — fail loudly instead."""
+    store = _store(tmp_path)
+    store.append(SessionRecord(session_id="s1", outcome="productive"))
+
+    with pytest.raises(ValueError):
+        store.stamp_attempt_kind("s1", bad)
+
+    assert store.load_all()[0].attempt_kind is None
+
+
+def test_stamp_requires_session_id(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    with pytest.raises(ValueError):
+        store.stamp_attempt_kind("", "repetition")
+
+
+def test_attempt_kinds_vocabulary_is_closed() -> None:
+    assert ATTEMPT_KINDS == frozenset({"repetition", "infra_retry", "unknown"})

--- a/packages/gptme-sessions/tests/test_attempt_kind.py
+++ b/packages/gptme-sessions/tests/test_attempt_kind.py
@@ -13,8 +13,10 @@ import json
 from pathlib import Path
 
 import pytest
+from click.testing import CliRunner
 
 from gptme_sessions import SessionRecord, SessionStore
+from gptme_sessions.cli import cli
 from gptme_sessions.record import ATTEMPT_KINDS
 
 
@@ -117,3 +119,63 @@ def test_valid_attempt_kind_preserved_at_load_time() -> None:
             {"session_id": "s1", "outcome": "productive", "attempt_kind": kind}
         )
         assert record.attempt_kind == kind
+
+
+def test_stamp_handles_duplicate_rows(tmp_path: Path) -> None:
+    """stamp_attempt_kind must stamp all rows when a session_id appears twice."""
+    store = _store(tmp_path)
+    store.append(SessionRecord(session_id="dup", outcome="failed", duration_seconds=5))
+    store.append(SessionRecord(session_id="dup", outcome="failed", duration_seconds=5))
+
+    assert store.stamp_attempt_kind("dup", "infra_retry") is True
+
+    records = store.load_all()
+    assert len(records) == 2
+    assert all(r.attempt_kind == "infra_retry" for r in records)
+
+
+def test_cli_stamp_handles_duplicate_rows(tmp_path: Path) -> None:
+    """CLI stamp-attempt-kind must succeed even when the store has duplicate rows."""
+    store = _store(tmp_path)
+    store.append(SessionRecord(session_id="dup", outcome="failed", duration_seconds=5))
+    store.append(SessionRecord(session_id="dup", outcome="failed", duration_seconds=5))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["--sessions-dir", str(tmp_path), "stamp-attempt-kind", "dup", "infra_retry"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "infra_retry" in result.output
+
+    records = store.load_all()
+    assert all(r.attempt_kind == "infra_retry" for r in records)
+
+
+def test_cli_stamp_prefix_resolution(tmp_path: Path) -> None:
+    """CLI stamp-attempt-kind resolves partial session ID prefixes."""
+    store = _store(tmp_path)
+    store.append(SessionRecord(session_id="abcdef", outcome="productive"))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["--sessions-dir", str(tmp_path), "stamp-attempt-kind", "abc", "repetition"],
+    )
+    assert result.exit_code == 0, result.output
+    assert store.load_all()[0].attempt_kind == "repetition"
+
+
+def test_cli_stamp_ambiguous_prefix_raises(tmp_path: Path) -> None:
+    """CLI stamp-attempt-kind raises on a prefix matching two different session IDs."""
+    store = _store(tmp_path)
+    store.append(SessionRecord(session_id="abc1", outcome="productive"))
+    store.append(SessionRecord(session_id="abc2", outcome="failed"))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["--sessions-dir", str(tmp_path), "stamp-attempt-kind", "abc", "repetition"],
+    )
+    assert result.exit_code != 0
+    assert "Ambiguous" in result.output


### PR DESCRIPTION
## Problem

Session runners already classify every attempt as either a measurable sample or an infra failure (rate limit, auth failure, dead backend, zero-token exit) — `autonomous-run.sh` computes `IS_INFRA_FAILURE` across seven guards and uses it to skip bandit and grade updates. That verdict is then **thrown away**.

Because it is never persisted, every read-side consumer re-derives infra-ness from duration/token heuristics. In Bob's workspace that predicate is defined once and called from **7** separate sites — 7 chances to forget, and forgetting reports contaminated quality numbers *silently*.

## What this adds (write side only)

- `SessionRecord.attempt_kind`: `repetition` | `infra_retry` | `unknown`, defaulting to `None` so every existing record parses unchanged. `None` means **unrecorded**, not `repetition` — consumers must keep their own fallback.
- `SessionStore.stamp_attempt_kind(session_id, kind)`: a second-pass stamp held under the store lock. It has to be a second pass: the runner's guards need the final exit code, token count and `failure_reason`, all of which `post_session()` itself produces, so the record already exists by the time the verdict is known. Returns `False` (rather than raising) when no record matches, since `post_session()` can fail. Rejects an unknown kind loudly — a typo would otherwise persist as an unread value forever.
- `gptme-sessions stamp-attempt-kind <session-id> <kind>` so shell runners can call it without an inline `python -c`.

## Explicitly out of scope

No read-side consumer is migrated here. Migration is gated on first **measuring agreement** between the recorded field and the existing heuristic on real records — the disagreement count is the finding, not a test failure. Doing both in one PR would ship an unverified swap.

## Tests

`packages/gptme-sessions/tests/test_attempt_kind.py` — 12 cases: infra session reads back `infra_retry`, normal session reads back `repetition`, value persists to JSONL, neighbours untouched, missing session returns `False`, unknown/empty kinds raise and leave the record unmodified.

```
12 passed          # tests/test_attempt_kind.py
529 passed         # test_record + test_store_locking + test_sessions + test_cli
```

Origin: idea #1144, from apache/maka peer research — Maka's eval boundary separates *repetition* from *infra retry* at the attempt, not at read time.