### PR TITLE
feat(gptodo): add browse command — interactive fzf TUI for tasks

### DIFF
--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -270,7 +270,7 @@ def show(task_id, render=False):
         # Use FZF_PREVIEW_COLUMNS if available (set by fzf for preview commands)
         # so Rich wraps at the correct width — prevents fzf wrap arrows and
         # ensures code block backgrounds extend to full width
-        preview_width = int(os.environ.get("FZF_PREVIEW_COLUMNS", 0)) or None
+        preview_width = int(os.environ.get("FZF_PREVIEW_COLUMNS") or 0) or None
         console = Console(
             force_terminal=True,
             width=preview_width,
@@ -997,9 +997,9 @@ exec "${EDITOR:-nano}" "$1" </dev/tty >/dev/tty 2>/dev/tty
     # Reload: reads state files and calls browse-list with appropriate args
     Path(sd, "reload.sh").write_text(
         f"""#!/bin/sh
-sort=$(cat {sd}/sort 2>/dev/null || echo date)
-state=$(cat {sd}/state 2>/dev/null || echo "")
-project=$(cat {sd}/project 2>/dev/null || echo "")
+sort=$(cat "{sd}/sort" 2>/dev/null || echo date)
+state=$(cat "{sd}/state" 2>/dev/null || echo "")
+project=$(cat "{sd}/project" 2>/dev/null || echo "")
 args="--sort $sort"
 if [ "$state" = "all" ]; then
     args="$args --all"
@@ -1017,7 +1017,7 @@ gptodo browse-list $args
     Path(sd, "sort-picker.sh").write_text(
         f"""#!/bin/sh
 choice=$(printf 'date\\npriority\\nmodified\\nname' | fzf --no-sort --header 'Sort by:')
-[ -n "$choice" ] && printf '%s' "$choice" > {sd}/sort
+[ -n "$choice" ] && printf '%s' "$choice" > "{sd}/sort"
 """
     )
 
@@ -1027,14 +1027,14 @@ choice=$(printf 'date\\npriority\\nmodified\\nname' | fzf --no-sort --header 'So
 choice=$(printf 'open tasks (default)\\nall states\\nbacklog only\\nsomeday only\\ntodo only\\nactive only\\nwaiting only\\nready for review only' \\
   | fzf --no-sort --header 'Filter by state:')
 case "$choice" in
-  "open tasks"*) printf '' > {sd}/state;;
-  "all"*) printf 'all' > {sd}/state;;
-  "backlog"*) printf 'backlog' > {sd}/state;;
-  "someday"*) printf 'someday' > {sd}/state;;
-  "todo"*) printf 'todo' > {sd}/state;;
-  "active"*) printf 'active' > {sd}/state;;
-  "waiting"*) printf 'waiting' > {sd}/state;;
-  "ready for review"*) printf 'ready_for_review' > {sd}/state;;
+  "open tasks"*) printf '' > "{sd}/state";;
+  "all"*) printf 'all' > "{sd}/state";;
+  "backlog"*) printf 'backlog' > "{sd}/state";;
+  "someday"*) printf 'someday' > "{sd}/state";;
+  "todo"*) printf 'todo' > "{sd}/state";;
+  "active"*) printf 'active' > "{sd}/state";;
+  "waiting"*) printf 'waiting' > "{sd}/state";;
+  "ready for review"*) printf 'ready_for_review' > "{sd}/state";;
 esac
 """
     )
@@ -1085,18 +1085,18 @@ action=$(printf '%s\\n' \\
 task="$1"
 
 case "$action" in
-  "Sort by date") printf 'date' > {sd}/sort;;
-  "Sort by priority") printf 'priority' > {sd}/sort;;
-  "Sort by modified") printf 'modified' > {sd}/sort;;
-  "Sort by name") printf 'name' > {sd}/sort;;
-  "Filter: open tasks"*) printf '' > {sd}/state;;
-  "Filter: all"*) printf 'all' > {sd}/state;;
-  "Filter: backlog"*) printf 'backlog' > {sd}/state;;
-  "Filter: someday"*) printf 'someday' > {sd}/state;;
-  "Filter: todo"*) printf 'todo' > {sd}/state;;
-  "Filter: active"*) printf 'active' > {sd}/state;;
-  "Filter: waiting"*) printf 'waiting' > {sd}/state;;
-  "Filter: ready for review"*) printf 'ready_for_review' > {sd}/state;;
+  "Sort by date") printf 'date' > "{sd}/sort";;
+  "Sort by priority") printf 'priority' > "{sd}/sort";;
+  "Sort by modified") printf 'modified' > "{sd}/sort";;
+  "Sort by name") printf 'name' > "{sd}/sort";;
+  "Filter: open tasks"*) printf '' > "{sd}/state";;
+  "Filter: all"*) printf 'all' > "{sd}/state";;
+  "Filter: backlog"*) printf 'backlog' > "{sd}/state";;
+  "Filter: someday"*) printf 'someday' > "{sd}/state";;
+  "Filter: todo"*) printf 'todo' > "{sd}/state";;
+  "Filter: active"*) printf 'active' > "{sd}/state";;
+  "Filter: waiting"*) printf 'waiting' > "{sd}/state";;
+  "Filter: ready for review"*) printf 'ready_for_review' > "{sd}/state";;
   "Change state"*"backlog") gptodo edit "$task" --set state backlog;;
   "Change state"*"someday") gptodo edit "$task" --set state someday;;
   "Change state"*"todo") gptodo edit "$task" --set state todo;;
@@ -1105,9 +1105,9 @@ case "$action" in
   "Change state"*"ready_for_review") gptodo edit "$task" --set state ready_for_review;;
   "Change state"*"done") gptodo edit "$task" --set state done;;
   "Change state"*"cancelled") gptodo edit "$task" --set state cancelled;;
-  "Edit in"*) sh {sd}/edit-task.sh {rr}/tasks/"$task".md;;
-  "Git blame") git -C {rr} blame --date=short -- tasks/"$task".md | ${{PAGER:-less}};;
-  "Git log"*) git -C {rr} log --follow --oneline --color -- tasks/"$task".md | ${{PAGER:-less -R}};;
+  "Edit in"*) sh "{sd}/edit-task.sh" "{rr}/tasks/$task.md";;
+  "Git blame") git -C "{rr}" blame --date=short -- tasks/"$task".md | ${{PAGER:-less}};;
+  "Git log"*) git -C "{rr}" log --follow --oneline --color -- tasks/"$task".md | ${{PAGER:-less -R}};;
 esac
 """
     )
@@ -1261,18 +1261,22 @@ def _browse_fzf(repo_root, show_all=False, project=None, filter_state=None):
         # Keyboard hints in border label (spans full window width)
         border_label = " ? Actions │ ^S Sort │ ^F Filter │ ^T State │ ^E Edit │ ^B Blame │ ^L Log │ ^P Preview │ ^R Raw │ ^W Layout "
 
+        # Shell-quoted path aliases for embedding in fzf bind commands
+        sd_q = f'"{state_dir}"'
+        rr_q = f'"{repo_root}"'
+
         # Reload command (reads state files, calls browse-list)
-        reload_cmd = f"sh {state_dir}/reload.sh"
+        reload_cmd = f"sh {sd_q}/reload.sh"
 
         # Build keybindings
         bind_list = [
-            f"?:execute(sh {state_dir}/palette.sh {{1}})+reload({reload_cmd})",
-            f"ctrl-s:execute(sh {state_dir}/sort-picker.sh)+reload({reload_cmd})",
-            f"ctrl-f:execute(sh {state_dir}/filter-picker.sh)+reload({reload_cmd})",
-            f"ctrl-t:execute(sh {state_dir}/state-change.sh {{1}})+reload({reload_cmd})",
-            f"ctrl-e:execute(sh {state_dir}/edit-task.sh {repo_root}/tasks/{{1}}.md)+reload({reload_cmd})",
-            f"ctrl-b:change-preview(git -C {repo_root} blame --date=short -- tasks/{{1}}.md)+change-preview-label( Git Blame )",
-            f"ctrl-l:change-preview(git -C {repo_root} log --follow --oneline --color -- tasks/{{1}}.md)+change-preview-label( Git Log )",
+            f"?:execute(sh {sd_q}/palette.sh {{1}})+reload({reload_cmd})",
+            f"ctrl-s:execute(sh {sd_q}/sort-picker.sh)+reload({reload_cmd})",
+            f"ctrl-f:execute(sh {sd_q}/filter-picker.sh)+reload({reload_cmd})",
+            f"ctrl-t:execute(sh {sd_q}/state-change.sh {{1}})+reload({reload_cmd})",
+            f"ctrl-e:execute(sh {sd_q}/edit-task.sh {rr_q}/tasks/{{1}}.md)+reload({reload_cmd})",
+            f"ctrl-b:change-preview(git -C {rr_q} blame --date=short -- tasks/{{1}}.md)+change-preview-label( Git Blame )",
+            f"ctrl-l:change-preview(git -C {rr_q} log --follow --oneline --color -- tasks/{{1}}.md)+change-preview-label( Git Log )",
             "ctrl-p:change-preview(gptodo show --render {1})+change-preview-label( Task Preview )",
             "ctrl-r:change-preview(gptodo show {1})+change-preview-label( Raw Markdown )",
             "ctrl-w:change-preview-window(right:60%:wrap|down:75%:wrap)+refresh-preview",

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -1000,16 +1000,16 @@ exec "${EDITOR:-nano}" "$1" </dev/tty >/dev/tty 2>/dev/tty
 sort=$(cat "{sd}/sort" 2>/dev/null || echo date)
 state=$(cat "{sd}/state" 2>/dev/null || echo "")
 project=$(cat "{sd}/project" 2>/dev/null || echo "")
-args="--sort $sort"
+set -- --sort "$sort"
 if [ "$state" = "all" ]; then
-    args="$args --all"
+    set -- "$@" --all
 elif [ -n "$state" ]; then
-    args="$args --state $state"
+    set -- "$@" --state "$state"
 fi
 if [ -n "$project" ]; then
-    args="$args --project $project"
+    set -- "$@" --project "$project"
 fi
-gptodo browse-list $args
+gptodo browse-list "$@"
 """
     )
 
@@ -1078,8 +1078,6 @@ action=$(printf '%s\\n' \\
   'Edit in $EDITOR' \\
   'Git blame' \\
   'Git log (file history)' \\
-  'Preview: raw markdown (^R)' \\
-  'Preview: rendered (^P)' \\
   | fzf --no-sort --header 'Command Palette')
 
 task="$1"
@@ -1282,8 +1280,8 @@ def _browse_fzf(repo_root, show_all=False, project=None, filter_state=None):
             "ctrl-w:change-preview-window(right:60%:wrap|down:75%:wrap)+refresh-preview",
             "ctrl-/:toggle-preview",
         ]
-        # resize event requires fzf >= 0.42.0
-        if _fzf_version() >= (0, 42, 0):
+        # resize event requires fzf >= 0.46.0
+        if _fzf_version() >= (0, 46, 0):
             bind_list.append("resize:refresh-preview")
         bindings = ",".join(bind_list)
 

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -946,6 +946,20 @@ def _get_browse_lines(tasks_dir, sort_key="date", filter_state=None, project=Non
     if project:
         tasks = [t for t in tasks if t.metadata.get("project") == project]
 
+    # Drop tasks whose names contain single quotes — such names cannot be safely
+    # embedded in fzf's '{1}' quoting context and are not valid per the task schema.
+    unsafe_quote = [t for t in tasks if "'" in t.name]
+    if unsafe_quote:
+        import sys
+
+        print(
+            f"[browse] warning: {len(unsafe_quote)} task(s) skipped — "
+            f"name contains a single quote (shell-unsafe in fzf TUI): "
+            + ", ".join(t.name for t in unsafe_quote),
+            file=sys.stderr,
+        )
+        tasks = [t for t in tasks if "'" not in t.name]
+
     # Sort
     if sort_key == "priority":
         tasks.sort(key=lambda t: (-t.priority_rank, t.name))
@@ -1280,8 +1294,8 @@ def _browse_fzf(repo_root, show_all=False, project=None, filter_state=None):
 
         # Build keybindings.
         # Task names are passed as '{1}' (single-quoted) so shell metacharacters
-        # in task names cannot be evaluated by sh -c (safe for names without
-        # single quotes, which gptodo never creates).
+        # in task names cannot be evaluated by sh -c.  Tasks whose names contain
+        # single quotes are filtered out by _get_browse_lines before reaching here.
         bind_list = [
             f"?:execute(sh {sd_q}/palette.sh '{{1}}')+reload({reload_cmd})",
             f"ctrl-s:execute(sh {sd_q}/sort-picker.sh)+reload({reload_cmd})",

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -166,6 +166,34 @@ from gptodo.worktree import (
 # Keep console instance for CLI output
 console = Console()
 
+BROWSE_DEFAULT_STATES = [
+    "backlog",
+    "todo",
+    "active",
+    "waiting",
+    "ready_for_review",
+]
+BROWSE_FILTER_STATES = [
+    "backlog",
+    "someday",
+    "todo",
+    "active",
+    "waiting",
+    "ready_for_review",
+    "done",
+    "cancelled",
+]
+def _normalize_browse_state(filter_state: str | None) -> str | None:
+    """Normalize and validate browse state filters."""
+    if filter_state is None:
+        return None
+
+    normalized = normalize_state(filter_state.replace("-", "_"), warn=False)
+    if normalized not in BROWSE_FILTER_STATES:
+        valid_states = ", ".join(BROWSE_FILTER_STATES)
+        raise click.BadParameter(f"invalid state '{filter_state}'. Choose from: {valid_states}")
+    return normalized
+
 
 @click.group()
 @click.option("-v", "--verbose", is_flag=True)
@@ -223,17 +251,39 @@ def cli(verbose, tasks_dir):
 
 @cli.command("show")
 @click.argument("task_id", required=False)
-def show_(task_id):
+@click.option("--render/--raw", default=False, help="Render markdown content")
+def show_(task_id, render):
     """Show detailed information about a task.
 
     If task_id is not provided, it will show the first task found.
     """
-    show(task_id)
+    show(task_id, render=render)
 
 
-def show(task_id):
+def show(task_id, render=False):
     """Show detailed information about a task."""
-    console = Console()
+    if render:
+        from rich.theme import Theme
+
+        # Use FZF_PREVIEW_COLUMNS if available (set by fzf for preview commands)
+        # so Rich wraps at the correct width — prevents fzf wrap arrows and
+        # ensures code block backgrounds extend to full width
+        preview_width = int(os.environ.get("FZF_PREVIEW_COLUMNS", 0)) or None
+        console = Console(
+            force_terminal=True,
+            width=preview_width,
+            theme=Theme(
+                {
+                    "markdown.h1": "bold bright_cyan",
+                    "markdown.h2": "bold bright_green",
+                    "markdown.h3": "bold bright_yellow",
+                    "markdown.h4": "bold bright_magenta",
+                    "markdown.code": "on grey23",
+                }
+            ),
+        )
+    else:
+        console = Console()
     repo_root = find_repo_root(Path.cwd())
     tasks_dir = repo_root / "tasks"
 
@@ -241,28 +291,34 @@ def show(task_id):
         console.print("[red]Error: Task ID or filename required[/]")
         return
 
-    # Load all tasks
-    tasks = load_tasks(tasks_dir)
-    if not tasks:
-        console.print("[red]No tasks found[/]")
-        return
-
-    # Sort tasks by creation date for consistent ID mapping
-    tasks.sort(key=lambda t: t.created)
-
-    # Find requested task
     task = None
-    if task_id.isdigit():
-        # Get task by numeric ID
-        idx = int(task_id) - 1
-        if 0 <= idx < len(tasks):
-            task = tasks[idx]
-    else:
-        # Get task by name
+    if not task_id.isdigit():
         task_name = task_id[:-3] if task_id.endswith(".md") else task_id
-        matching = [t for t in tasks if t.name == task_name]
-        if matching:
-            task = matching[0]
+        direct_path = tasks_dir / f"{task_name}.md"
+        if direct_path.is_file():
+            direct_tasks = load_tasks(tasks_dir, single_file=direct_path)
+            if direct_tasks:
+                task = direct_tasks[0]
+
+    if task is None:
+        # Fall back to full task load for numeric IDs or unknown names.
+        tasks = load_tasks(tasks_dir)
+        if not tasks:
+            console.print("[red]No tasks found[/]")
+            return
+
+        # Sort tasks by creation date for consistent ID mapping
+        tasks.sort(key=lambda t: t.created)
+
+        if task_id.isdigit():
+            idx = int(task_id) - 1
+            if 0 <= idx < len(tasks):
+                task = tasks[idx]
+        else:
+            task_name = task_id[:-3] if task_id.endswith(".md") else task_id
+            matching = [t for t in tasks if t.name == task_name]
+            if matching:
+                task = matching[0]
 
     if not task:
         console.print(f"[red]Error: Task {task_id} not found[/]")
@@ -302,7 +358,12 @@ def show(task_id):
     # Print content
     console.print("\n[bold]Content:[/]")
     post = frontmatter.load(task.path)  # Reload to get content
-    console.out(post.content, highlight=True)
+    if render:
+        from rich.markdown import Markdown
+
+        console.print(Markdown(post.content))
+    else:
+        console.out(post.content, highlight=True)
 
 
 @cli.command("effective")
@@ -861,6 +922,440 @@ def list_(sort, active_only, context, output_json, output_jsonl, pool_filter, ex
 
     summary = [f"{count} {state}" for state, count in state_counts.items()]
     console.print(f"\nTotal: {len(tasks)} tasks ({', '.join(summary)})")
+
+
+def _get_browse_lines(tasks_dir, sort_key="date", filter_state=None, project=None, show_all=False):
+    """Get formatted task lines for fzf consumption.
+
+    Returns space-padded aligned lines with a header row first:
+    NAME  STATE  PRI  PROJECT  CREATED
+    """
+    tasks = load_tasks(tasks_dir)
+    if not tasks:
+        return []
+
+    # Filter
+    if filter_state:
+        normalized_state = _normalize_browse_state(filter_state)
+        tasks = [t for t in tasks if t.state == normalized_state]
+    elif not show_all:
+        tasks = [t for t in tasks if t.state in BROWSE_DEFAULT_STATES]
+    if project:
+        tasks = [t for t in tasks if t.metadata.get("project") == project]
+
+    # Sort
+    if sort_key == "priority":
+        tasks.sort(key=lambda t: (-t.priority_rank, t.name))
+    elif sort_key == "modified":
+        tasks.sort(key=lambda t: t.modified, reverse=True)
+    elif sort_key == "name":
+        tasks.sort(key=lambda t: t.name)
+    else:  # date
+        tasks.sort(key=lambda t: t.created)
+
+    if not tasks:
+        return []
+
+    # Compute column widths from data
+    col_name = max(max(len(t.name) for t in tasks), len("NAME"))
+    col_state = max(
+        max(len(t.state or "untracked") + 2 for t in tasks), len("STATE")
+    )  # +2 for emoji+space
+    col_proj = max(max(len(t.metadata.get("project") or "") for t in tasks), len("PROJECT"))
+
+    # Header row
+    header = f"{'NAME':<{col_name}}  {'STATE':<{col_state}}  {'PRI':<2}  {'PROJECT':<{col_proj}}  CREATED"
+    lines = [header]
+
+    # Format data lines
+    for task in tasks:
+        state_emoji = STATE_EMOJIS.get(task.state or "untracked", "•")
+        state_text = f"{state_emoji} {task.state or 'untracked'}"
+        priority_emoji = STATE_EMOJIS.get(task.priority or "", "")
+        project_str = task.metadata.get("project") or ""
+        age = task.created_ago
+        lines.append(
+            f"{task.name:<{col_name}}  {state_text:<{col_state}}  {priority_emoji:<2}  {project_str:<{col_proj}}  {age}"
+        )
+
+    return lines
+
+
+def _write_browse_scripts(state_dir, repo_root):
+    """Write helper shell scripts for the fzf browse TUI."""
+    sd = state_dir  # shorter alias for templates
+    rr = repo_root
+
+    Path(sd, "edit-task.sh").write_text(
+        """#!/bin/sh
+exec "${EDITOR:-nano}" "$1" </dev/tty >/dev/tty 2>/dev/tty
+"""
+    )
+
+    # Reload: reads state files and calls browse-list with appropriate args
+    Path(sd, "reload.sh").write_text(
+        f"""#!/bin/sh
+sort=$(cat {sd}/sort 2>/dev/null || echo date)
+state=$(cat {sd}/state 2>/dev/null || echo "")
+project=$(cat {sd}/project 2>/dev/null || echo "")
+args="--sort $sort"
+if [ "$state" = "all" ]; then
+    args="$args --all"
+elif [ -n "$state" ]; then
+    args="$args --state $state"
+fi
+if [ -n "$project" ]; then
+    args="$args --project $project"
+fi
+gptodo browse-list $args
+"""
+    )
+
+    # Sort picker: sub-fzf to choose sort mode
+    Path(sd, "sort-picker.sh").write_text(
+        f"""#!/bin/sh
+choice=$(printf 'date\\npriority\\nmodified\\nname' | fzf --no-sort --header 'Sort by:')
+[ -n "$choice" ] && printf '%s' "$choice" > {sd}/sort
+"""
+    )
+
+    # Filter picker: sub-fzf to choose state filter
+    Path(sd, "filter-picker.sh").write_text(
+        f"""#!/bin/sh
+choice=$(printf 'open tasks (default)\\nall states\\nbacklog only\\nsomeday only\\ntodo only\\nactive only\\nwaiting only\\nready for review only' \\
+  | fzf --no-sort --header 'Filter by state:')
+case "$choice" in
+  "open tasks"*) printf '' > {sd}/state;;
+  "all"*) printf 'all' > {sd}/state;;
+  "backlog"*) printf 'backlog' > {sd}/state;;
+  "someday"*) printf 'someday' > {sd}/state;;
+  "todo"*) printf 'todo' > {sd}/state;;
+  "active"*) printf 'active' > {sd}/state;;
+  "waiting"*) printf 'waiting' > {sd}/state;;
+  "ready for review"*) printf 'ready_for_review' > {sd}/state;;
+esac
+"""
+    )
+
+    # State change: sub-fzf to pick new state, then call gptodo edit
+    Path(sd, "state-change.sh").write_text(
+        """#!/bin/sh
+choice=$(printf 'backlog\\nsomeday\\ntodo\\nactive\\nwaiting\\nready_for_review\\ndone\\ncancelled' \\
+  | fzf --no-sort --header 'Set state to:')
+[ -n "$choice" ] && gptodo edit "$1" --set state "$choice"
+"""
+    )
+
+    # Command palette: discoverable menu of all actions
+    Path(sd, "palette.sh").write_text(
+        f"""#!/bin/sh
+action=$(printf '%s\\n' \\
+  'Sort by date' \\
+  'Sort by priority' \\
+  'Sort by modified' \\
+  'Sort by name' \\
+  '───────────────────' \\
+  'Filter: open tasks (default)' \\
+  'Filter: all states' \\
+  'Filter: backlog only' \\
+  'Filter: someday only' \\
+  'Filter: todo only' \\
+  'Filter: active only' \\
+  'Filter: waiting only' \\
+  'Filter: ready for review only' \\
+  '───────────────────' \\
+  'Change state -> backlog' \\
+  'Change state -> someday' \\
+  'Change state -> todo' \\
+  'Change state -> active' \\
+  'Change state -> waiting' \\
+  'Change state -> ready_for_review' \\
+  'Change state -> done' \\
+  'Change state -> cancelled' \\
+  '───────────────────' \\
+  'Edit in $EDITOR' \\
+  'Git blame' \\
+  'Git log (file history)' \\
+  'Preview: raw markdown (^R)' \\
+  'Preview: rendered (^P)' \\
+  | fzf --no-sort --header 'Command Palette')
+
+task="$1"
+
+case "$action" in
+  "Sort by date") printf 'date' > {sd}/sort;;
+  "Sort by priority") printf 'priority' > {sd}/sort;;
+  "Sort by modified") printf 'modified' > {sd}/sort;;
+  "Sort by name") printf 'name' > {sd}/sort;;
+  "Filter: open tasks"*) printf '' > {sd}/state;;
+  "Filter: all"*) printf 'all' > {sd}/state;;
+  "Filter: backlog"*) printf 'backlog' > {sd}/state;;
+  "Filter: someday"*) printf 'someday' > {sd}/state;;
+  "Filter: todo"*) printf 'todo' > {sd}/state;;
+  "Filter: active"*) printf 'active' > {sd}/state;;
+  "Filter: waiting"*) printf 'waiting' > {sd}/state;;
+  "Filter: ready for review"*) printf 'ready_for_review' > {sd}/state;;
+  "Change state"*"backlog") gptodo edit "$task" --set state backlog;;
+  "Change state"*"someday") gptodo edit "$task" --set state someday;;
+  "Change state"*"todo") gptodo edit "$task" --set state todo;;
+  "Change state"*"active") gptodo edit "$task" --set state active;;
+  "Change state"*"waiting") gptodo edit "$task" --set state waiting;;
+  "Change state"*"ready_for_review") gptodo edit "$task" --set state ready_for_review;;
+  "Change state"*"done") gptodo edit "$task" --set state done;;
+  "Change state"*"cancelled") gptodo edit "$task" --set state cancelled;;
+  "Edit in"*) sh {sd}/edit-task.sh {rr}/tasks/"$task".md;;
+  "Git blame") git -C {rr} blame --date=short -- tasks/"$task".md | ${{PAGER:-less}};;
+  "Git log"*) git -C {rr} log --follow --oneline --color -- tasks/"$task".md | ${{PAGER:-less -R}};;
+esac
+"""
+    )
+
+
+@cli.command("browse-list", hidden=True)
+@click.option(
+    "--sort",
+    "sort_key",
+    type=click.Choice(["date", "priority", "modified", "name"]),
+    default="date",
+    help="Sort order for tasks",
+)
+@click.option("--state", "filter_state", type=str, default=None, help="Filter by state")
+@click.option("--project", type=str, default=None, help="Filter by project")
+@click.option("--all", "show_all", is_flag=True, help="Include done/cancelled tasks")
+def browse_list_cmd(sort_key, filter_state, project, show_all):
+    """Output formatted task lines for fzf consumption (internal use)."""
+    repo_root = find_repo_root(Path.cwd())
+    tasks_dir = repo_root / "tasks"
+    lines = _get_browse_lines(
+        tasks_dir,
+        sort_key,
+        _normalize_browse_state(filter_state),
+        project,
+        show_all,
+    )
+    for line in lines:
+        click.echo(line)
+
+
+@cli.command("browse")
+@click.option(
+    "--all",
+    "show_all",
+    is_flag=True,
+    help="Include all task states (default: open tasks only)",
+)
+@click.option(
+    "--project",
+    type=str,
+    default=None,
+    help="Filter by project name",
+)
+@click.option(
+    "--state",
+    "filter_state",
+    type=str,
+    default=None,
+    help="Filter by specific task state",
+)
+@click.option(
+    "--no-fzf",
+    "no_fzf",
+    is_flag=True,
+    help="Force pager output (skip fzf even if available)",
+)
+def browse(show_all, project, filter_state, no_fzf):
+    """Interactively browse task contents.
+
+    Uses fzf for interactive selection with a live preview pane.
+    Falls back to a paged view if fzf is not installed or --no-fzf is used.
+
+    By default, shows open tasks: backlog, todo, active, waiting, and
+    ready_for_review. Use --all to include every task state.
+
+    In fzf mode, press ? to open the command palette with all available actions.
+    """
+    import shutil
+
+    console = Console()
+    repo_root = find_repo_root(Path.cwd())
+    tasks_dir = repo_root / "tasks"
+
+    # Decide mode: fzf or pager
+    use_fzf = not no_fzf and shutil.which("fzf")
+    normalized_state = _normalize_browse_state(filter_state)
+
+    if use_fzf:
+        _browse_fzf(
+            repo_root,
+            show_all=show_all,
+            project=project,
+            filter_state=normalized_state,
+        )
+    else:
+        all_tasks = load_tasks(tasks_dir)
+        if not all_tasks:
+            console.print("[yellow]No tasks found[/]")
+            return
+        # Filter for pager mode
+        tasks = all_tasks
+        if normalized_state:
+            tasks = [t for t in tasks if t.state == normalized_state]
+        elif not show_all:
+            tasks = [t for t in tasks if t.state in BROWSE_DEFAULT_STATES]
+        if project:
+            tasks = [t for t in tasks if t.metadata.get("project") == project]
+        if not tasks:
+            console.print("[yellow]No tasks found matching filters[/]")
+            return
+        tasks.sort(key=lambda t: t.created)
+        _browse_pager(tasks, repo_root)
+
+
+def _fzf_version() -> tuple[int, ...]:
+    """Return fzf version as a tuple, e.g. (0, 38, 0)."""
+    import subprocess
+
+    try:
+        out = subprocess.check_output(["fzf", "--version"], text=True, stderr=subprocess.DEVNULL)
+        # "0.38.0 (debian)" -> "0.38.0"
+        ver_str = out.strip().split()[0]
+        return tuple(int(x) for x in ver_str.split("."))
+    except Exception:
+        return (0, 0, 0)
+
+
+def _browse_fzf(repo_root, show_all=False, project=None, filter_state=None):
+    """Browse tasks interactively using fzf with full TUI.
+
+    Features: command palette (?), sort/filter pickers, state changes,
+    git blame/log in preview, editor integration.
+    """
+    import subprocess
+    import tempfile
+
+    tasks_dir = repo_root / "tasks"
+
+    # Get initial lines
+    lines = _get_browse_lines(tasks_dir, "date", filter_state, project, show_all)
+    if not lines:
+        Console().print("[yellow]No tasks found matching filters[/]")
+        return
+
+    input_text = "\n".join(lines)
+
+    with tempfile.TemporaryDirectory(prefix="gptodo-browse-") as state_dir:
+        # Write initial state to temp files
+        Path(state_dir, "sort").write_text("date")
+        if show_all:
+            Path(state_dir, "state").write_text("all")
+        elif filter_state:
+            Path(state_dir, "state").write_text(filter_state)
+        if project:
+            Path(state_dir, "project").write_text(project)
+
+        # Write helper scripts
+        _write_browse_scripts(state_dir, repo_root)
+
+        # Keyboard hints in border label (spans full window width)
+        border_label = " ? Actions │ ^S Sort │ ^F Filter │ ^T State │ ^E Edit │ ^B Blame │ ^L Log │ ^P Preview │ ^R Raw │ ^W Layout "
+
+        # Reload command (reads state files, calls browse-list)
+        reload_cmd = f"sh {state_dir}/reload.sh"
+
+        # Build keybindings
+        bind_list = [
+            f"?:execute(sh {state_dir}/palette.sh {{1}})+reload({reload_cmd})",
+            f"ctrl-s:execute(sh {state_dir}/sort-picker.sh)+reload({reload_cmd})",
+            f"ctrl-f:execute(sh {state_dir}/filter-picker.sh)+reload({reload_cmd})",
+            f"ctrl-t:execute(sh {state_dir}/state-change.sh {{1}})+reload({reload_cmd})",
+            f"ctrl-e:execute(sh {state_dir}/edit-task.sh {repo_root}/tasks/{{1}}.md)+reload({reload_cmd})",
+            f"ctrl-b:change-preview(git -C {repo_root} blame --date=short -- tasks/{{1}}.md)+change-preview-label( Git Blame )",
+            f"ctrl-l:change-preview(git -C {repo_root} log --follow --oneline --color -- tasks/{{1}}.md)+change-preview-label( Git Log )",
+            "ctrl-p:change-preview(gptodo show --render {1})+change-preview-label( Task Preview )",
+            "ctrl-r:change-preview(gptodo show {1})+change-preview-label( Raw Markdown )",
+            "ctrl-w:change-preview-window(right:60%:wrap|down:75%:wrap)+refresh-preview",
+            "ctrl-/:toggle-preview",
+        ]
+        # resize event requires fzf >= 0.42.0
+        if _fzf_version() >= (0, 42, 0):
+            bind_list.append("resize:refresh-preview")
+        bindings = ",".join(bind_list)
+
+        # Run fzf with full TUI.
+        # Only capture stdout (for the selection); let stderr go to the
+        # terminal so fzf can render its TUI via /dev/tty or stderr fallback.
+        result = subprocess.run(
+            [
+                "fzf",
+                "--preview",
+                "gptodo show --render {1}",
+                "--preview-window",
+                "down:75%:wrap",
+                "--preview-label",
+                " Task Preview ",
+                "--layout",
+                "reverse",
+                "--border",
+                "rounded",
+                "--ansi",
+                "--no-sort",
+                "--header-lines",
+                "1",
+                "--border-label",
+                border_label,
+                "--border-label-pos",
+                "0:bottom",
+                "--bind",
+                bindings,
+            ],
+            input=input_text,
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+
+        if result.returncode == 2:
+            # fzf error (bad flags, etc.) — report to stderr (which is the terminal)
+            Console(stderr=True).print("[red]fzf error (exit 2) — try: gptodo browse --no-fzf[/]")
+            return
+        if result.returncode == 0 and result.stdout.strip():
+            # Extract task name (first whitespace-separated field)
+            selected = result.stdout.strip().split()[0]
+            click.echo(selected)
+
+
+def _browse_pager(tasks, repo_root):
+    """Browse tasks using a pager (fallback when fzf unavailable)."""
+    parts = []
+    for i, task in enumerate(tasks):
+        if i > 0:
+            parts.append("")
+
+        # Separator header
+        state_emoji = STATE_EMOJIS.get(task.state or "untracked", "•")
+        header = f"═══ {task.name} [{state_emoji} {task.state}] ═══"
+        parts.append(header)
+
+        # Metadata
+        if task.priority:
+            parts.append(f"  Priority: {task.priority}")
+        if task.metadata.get("project"):
+            parts.append(f"  Project:  {task.metadata['project']}")
+        if task.tags:
+            parts.append(f"  Tags:     {', '.join(task.tags)}")
+        if task.requires:
+            parts.append(f"  Requires: {', '.join(task.requires)}")
+        parts.append(f"  Created:  {task.created_ago}")
+        parts.append(f"  Modified: {task.modified_ago}")
+        if task.subtasks.total > 0:
+            parts.append(f"  Subtasks: {task.subtasks.completed}/{task.subtasks.total}")
+
+        # Content
+        parts.append("")
+        post = frontmatter.load(task.path)
+        parts.append(post.content)
+
+    output = "\n".join(parts) + "\n"
+    click.echo_via_pager(output)
 
 
 def print_status_section(

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -296,6 +296,7 @@ def show(task_id, render=False):
     task = None
     if not task_id.isdigit():
         task_name = task_id[:-3] if task_id.endswith(".md") else task_id
+        task_name = Path(task_name).name  # prevent path traversal via ../
         direct_path = tasks_dir / f"{task_name}.md"
         if direct_path.is_file():
             direct_tasks = load_tasks(tasks_dir, single_file=direct_path)
@@ -989,8 +990,20 @@ def _write_browse_scripts(state_dir, repo_root):
     rr = repo_root
 
     Path(sd, "edit-task.sh").write_text(
-        """#!/bin/sh
-exec "${EDITOR:-nano}" "$1" </dev/tty >/dev/tty 2>/dev/tty
+        f"""#!/bin/sh
+exec "${{EDITOR:-nano}}" "{rr}/tasks/$1.md" </dev/tty >/dev/tty 2>/dev/tty
+"""
+    )
+
+    Path(sd, "git-blame.sh").write_text(
+        f"""#!/bin/sh
+git -C "{rr}" blame --date=short -- "tasks/$1.md"
+"""
+    )
+
+    Path(sd, "git-log.sh").write_text(
+        f"""#!/bin/sh
+git -C "{rr}" log --follow --oneline --color -- "tasks/$1.md"
 """
     )
 
@@ -1103,9 +1116,9 @@ case "$action" in
   "Change state"*"ready_for_review") gptodo edit "$task" --set state ready_for_review;;
   "Change state"*"done") gptodo edit "$task" --set state done;;
   "Change state"*"cancelled") gptodo edit "$task" --set state cancelled;;
-  "Edit in"*) sh "{sd}/edit-task.sh" "{rr}/tasks/$task.md";;
-  "Git blame") git -C "{rr}" blame --date=short -- tasks/"$task".md | ${{PAGER:-less}};;
-  "Git log"*) git -C "{rr}" log --follow --oneline --color -- tasks/"$task".md | ${{PAGER:-less -R}};;
+  "Edit in"*) sh "{sd}/edit-task.sh" "$task";;
+  "Git blame") sh "{sd}/git-blame.sh" "$task" | ${{PAGER:-less}};;
+  "Git log"*) sh "{sd}/git-log.sh" "$task" | ${{PAGER:-less -R}};;
 esac
 """
     )
@@ -1259,24 +1272,26 @@ def _browse_fzf(repo_root, show_all=False, project=None, filter_state=None):
         # Keyboard hints in border label (spans full window width)
         border_label = " ? Actions │ ^S Sort │ ^F Filter │ ^T State │ ^E Edit │ ^B Blame │ ^L Log │ ^P Preview │ ^R Raw │ ^W Layout "
 
-        # Shell-quoted path aliases for embedding in fzf bind commands
+        # Shell-quoted path alias for embedding in fzf bind commands
         sd_q = f'"{state_dir}"'
-        rr_q = f'"{repo_root}"'
 
         # Reload command (reads state files, calls browse-list)
         reload_cmd = f"sh {sd_q}/reload.sh"
 
-        # Build keybindings
+        # Build keybindings.
+        # Task names are passed as '{1}' (single-quoted) so shell metacharacters
+        # in task names cannot be evaluated by sh -c (safe for names without
+        # single quotes, which gptodo never creates).
         bind_list = [
-            f"?:execute(sh {sd_q}/palette.sh {{1}})+reload({reload_cmd})",
+            f"?:execute(sh {sd_q}/palette.sh '{{1}}')+reload({reload_cmd})",
             f"ctrl-s:execute(sh {sd_q}/sort-picker.sh)+reload({reload_cmd})",
             f"ctrl-f:execute(sh {sd_q}/filter-picker.sh)+reload({reload_cmd})",
-            f"ctrl-t:execute(sh {sd_q}/state-change.sh {{1}})+reload({reload_cmd})",
-            f"ctrl-e:execute(sh {sd_q}/edit-task.sh {rr_q}/tasks/{{1}}.md)+reload({reload_cmd})",
-            f"ctrl-b:change-preview(git -C {rr_q} blame --date=short -- tasks/{{1}}.md)+change-preview-label( Git Blame )",
-            f"ctrl-l:change-preview(git -C {rr_q} log --follow --oneline --color -- tasks/{{1}}.md)+change-preview-label( Git Log )",
-            "ctrl-p:change-preview(gptodo show --render {1})+change-preview-label( Task Preview )",
-            "ctrl-r:change-preview(gptodo show {1})+change-preview-label( Raw Markdown )",
+            f"ctrl-t:execute(sh {sd_q}/state-change.sh '{{1}}')+reload({reload_cmd})",
+            f"ctrl-e:execute(sh {sd_q}/edit-task.sh '{{1}}')+reload({reload_cmd})",
+            f"ctrl-b:change-preview(sh {sd_q}/git-blame.sh '{{1}}')+change-preview-label( Git Blame )",
+            f"ctrl-l:change-preview(sh {sd_q}/git-log.sh '{{1}}')+change-preview-label( Git Log )",
+            "ctrl-p:change-preview(gptodo show --render '{1}')+change-preview-label( Task Preview )",
+            "ctrl-r:change-preview(gptodo show '{1}')+change-preview-label( Raw Markdown )",
             "ctrl-w:change-preview-window(right:60%:wrap|down:75%:wrap)+refresh-preview",
             "ctrl-/:toggle-preview",
         ]
@@ -1292,7 +1307,7 @@ def _browse_fzf(repo_root, show_all=False, project=None, filter_state=None):
             [
                 "fzf",
                 "--preview",
-                "gptodo show --render {1}",
+                "gptodo show --render '{1}'",
                 "--preview-window",
                 "down:75%:wrap",
                 "--preview-label",

--- a/packages/gptodo/src/gptodo/cli.py
+++ b/packages/gptodo/src/gptodo/cli.py
@@ -183,6 +183,8 @@ BROWSE_FILTER_STATES = [
     "done",
     "cancelled",
 ]
+
+
 def _normalize_browse_state(filter_state: str | None) -> str | None:
     """Normalize and validate browse state filters."""
     if filter_state is None:

--- a/packages/gptodo/tests/test_browse.py
+++ b/packages/gptodo/tests/test_browse.py
@@ -1,0 +1,964 @@
+"""Tests for the gptodo browse command."""
+
+import subprocess
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import frontmatter
+from click.testing import CliRunner
+
+from gptodo.cli import cli, _get_browse_lines, _write_browse_scripts
+from gptodo.utils import load_tasks as load_tasks_util
+
+
+def create_task(
+    tasks_dir: Path,
+    name: str,
+    state: str,
+    priority: str = "medium",
+    project: str | None = None,
+    content: str = "Task body content.",
+    created: str | None = None,
+    extra_meta: dict | None = None,
+):
+    """Helper to create a task markdown file with frontmatter."""
+    meta = {"state": state, "priority": priority}
+    if project:
+        meta["project"] = project
+    if created:
+        meta["created"] = created
+    if extra_meta:
+        meta.update(extra_meta)
+    post = frontmatter.Post(content, **meta)
+    task_file = tasks_dir / f"{name}.md"
+    task_file.write_text(frontmatter.dumps(post))
+    return task_file
+
+
+def _fzf_side_effect(mock_result):
+    """Create a side_effect function that intercepts fzf subprocess calls."""
+    original_run = subprocess.run
+
+    def side_effect(*args, **kwargs):
+        cmd = args[0] if args else kwargs.get("args", [])
+        if isinstance(cmd, list) and cmd and cmd[0] == "fzf":
+            return mock_result
+        return original_run(*args, **kwargs)
+
+    return side_effect
+
+
+def _get_fzf_calls(mock_run):
+    """Extract fzf calls from a mock subprocess.run."""
+    return [
+        c
+        for c in mock_run.call_args_list
+        if isinstance(c[0][0], list) and c[0][0][0] == "fzf" and c[0][0][1:] != ["--version"]
+    ]
+
+
+def _get_fzf_arg(fzf_cmd, arg_name):
+    """Extract the value of a specific fzf argument from the command list."""
+    for i, a in enumerate(fzf_cmd):
+        if a == arg_name and i + 1 < len(fzf_cmd):
+            return fzf_cmd[i + 1]
+    return None
+
+
+class TestBrowseNoTasks:
+    """Test browse with no tasks available."""
+
+    def test_browse_no_tasks_dir(self, tmp_path, monkeypatch):
+        """Should show error when no tasks directory exists."""
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tmp_path / "tasks"))
+        runner = CliRunner()
+        result = runner.invoke(cli, ["browse", "--no-fzf"])
+        assert result.exit_code == 0
+        assert "No tasks found" in result.output
+
+    def test_browse_empty_tasks_dir(self, tmp_path, monkeypatch):
+        """Should show error when tasks directory is empty."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+        runner = CliRunner()
+        result = runner.invoke(cli, ["browse", "--no-fzf"])
+        assert result.exit_code == 0
+        assert "No tasks found" in result.output
+
+
+class TestBrowseDefaultFilter:
+    """Test that browse defaults to current open-work states."""
+
+    def test_browse_active_only_default(self, tmp_path, monkeypatch):
+        """Default browse should show current open-work states."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "task-active", "active")
+        create_task(tasks_dir, "task-backlog", "backlog")
+        create_task(tasks_dir, "task-todo", "todo")
+        create_task(tasks_dir, "task-review", "ready_for_review")
+        create_task(tasks_dir, "task-waiting", "waiting")
+        create_task(tasks_dir, "task-done", "done")
+        create_task(tasks_dir, "task-cancelled", "cancelled")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["browse", "--no-fzf"])
+        assert "task-active" in result.output
+        assert "task-backlog" in result.output
+        assert "task-todo" in result.output
+        assert "task-review" in result.output
+        assert "task-waiting" in result.output
+        assert "task-done" not in result.output
+        assert "task-cancelled" not in result.output
+
+
+class TestBrowseAllFlag:
+    """Test --all flag includes done/cancelled tasks."""
+
+    def test_browse_all_flag(self, tmp_path, monkeypatch):
+        """--all should include done and cancelled tasks."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "task-active", "active")
+        create_task(tasks_dir, "task-done", "done")
+        create_task(tasks_dir, "task-cancelled", "cancelled")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["browse", "--all", "--no-fzf"])
+        assert "task-active" in result.output
+        assert "task-done" in result.output
+        assert "task-cancelled" in result.output
+
+
+class TestBrowseProjectFilter:
+    """Test --project filter."""
+
+    def test_browse_project_filter(self, tmp_path, monkeypatch):
+        """--project should only show tasks from that project."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "task-gptme", "active", project="gptme")
+        create_task(tasks_dir, "task-other", "active", project="other")
+        create_task(tasks_dir, "task-none", "active")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["browse", "--project", "gptme", "--no-fzf"])
+        assert "task-gptme" in result.output
+        assert "task-other" not in result.output
+        assert "task-none" not in result.output
+
+    def test_browse_project_no_match(self, tmp_path, monkeypatch):
+        """--project with no matches should show message."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "task-other", "active", project="other")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["browse", "--project", "nonexistent", "--no-fzf"])
+        assert "No tasks found" in result.output or "no" in result.output.lower()
+
+
+class TestBrowseStateFilter:
+    """Test --state filter."""
+
+    def test_browse_state_filter(self, tmp_path, monkeypatch):
+        """--state should only show tasks with that state."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "task-active", "active")
+        create_task(tasks_dir, "task-backlog", "backlog")
+        create_task(tasks_dir, "task-waiting", "waiting")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["browse", "--state", "active", "--no-fzf"])
+        assert "task-active" in result.output
+        assert "task-backlog" not in result.output
+        assert "task-waiting" not in result.output
+
+    def test_browse_state_filter_ready_for_review(self, tmp_path, monkeypatch):
+        """--state should accept ready_for_review."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "task-review", "ready_for_review")
+        create_task(tasks_dir, "task-active", "active")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["browse", "--state", "ready_for_review", "--no-fzf"])
+        assert result.exit_code == 0
+        assert "task-review" in result.output
+        assert "task-active" not in result.output
+
+    def test_browse_state_filter_ready_for_review_alias(self, tmp_path, monkeypatch):
+        """--state should accept ready-for-review as a CLI alias."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "task-review", "ready_for_review")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["browse", "--state", "ready-for-review", "--no-fzf"])
+        assert result.exit_code == 0
+        assert "task-review" in result.output
+
+
+class TestBrowsePagerFallback:
+    """Test pager fallback when fzf is unavailable."""
+
+    def test_browse_fzf_unavailable_falls_back_to_pager(self, tmp_path, monkeypatch):
+        """When fzf is not installed, should use pager output."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "my-task", "active", content="This is task content.")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        with patch("shutil.which", return_value=None):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["browse"])
+            # Should not crash, should show content
+            assert result.exit_code == 0
+            assert "my-task" in result.output
+
+    def test_browse_no_fzf_flag_forces_pager(self, tmp_path, monkeypatch):
+        """--no-fzf should use pager even when fzf is available."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "my-task", "active", content="Pager content here.")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        with patch("shutil.which", return_value="/usr/bin/fzf"):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["browse", "--no-fzf"])
+            assert result.exit_code == 0
+            assert "my-task" in result.output
+
+
+class TestBrowsePagerContentFormat:
+    """Test that pager output has proper formatting."""
+
+    def test_browse_pager_content_format(self, tmp_path, monkeypatch):
+        """Pager output should contain task name, state, and content with separators."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "alpha-task", "active", content="Alpha body text.")
+        create_task(tasks_dir, "beta-task", "backlog", content="Beta body text.")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["browse", "--no-fzf"])
+        output = result.output
+
+        # Should contain both task names
+        assert "alpha-task" in output
+        assert "beta-task" in output
+        # Should contain task content bodies
+        assert "Alpha body text." in output
+        assert "Beta body text." in output
+        # Should contain separators (visual dividers between tasks)
+        assert "═" in output or "---" in output or "===" in output
+
+class TestBrowseFzfMode:
+    """Test fzf interactive mode."""
+
+    def test_browse_fzf_available(self, tmp_path, monkeypatch):
+        """When fzf is available, should invoke subprocess with fzf."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "my-task", "active")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        mock_result = MagicMock()
+        mock_result.returncode = 130  # User cancelled with Esc
+        mock_result.stdout = ""
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/fzf"),
+            patch("subprocess.run", side_effect=_fzf_side_effect(mock_result)) as mock_run,
+        ):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["browse"])
+            assert result.exit_code == 0
+            assert len(_get_fzf_calls(mock_run)) == 1
+
+    def test_browse_fzf_preview_command(self, tmp_path, monkeypatch):
+        """fzf should be called with --preview containing gptodo show."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "my-task", "active")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        mock_result = MagicMock()
+        mock_result.returncode = 130
+        mock_result.stdout = ""
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/fzf"),
+            patch("subprocess.run", side_effect=_fzf_side_effect(mock_result)) as mock_run,
+        ):
+            runner = CliRunner()
+            runner.invoke(cli, ["browse"])
+            fzf_calls = _get_fzf_calls(mock_run)
+            assert len(fzf_calls) == 1
+            fzf_cmd = fzf_calls[0][0][0]
+            preview = _get_fzf_arg(fzf_cmd, "--preview")
+            assert preview is not None
+            assert "gptodo" in preview and "show" in preview
+
+    def test_browse_fzf_selection_prints_task_id(self, tmp_path, monkeypatch):
+        """When user selects a task in fzf, should print the task ID."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "selected-task", "active")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        mock_fzf_result = MagicMock()
+        mock_fzf_result.returncode = 0
+        mock_fzf_result.stdout = "selected-task  🏃 active  🟡      3d"
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/fzf"),
+            patch("subprocess.run", side_effect=_fzf_side_effect(mock_fzf_result)),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["browse"])
+            assert "selected-task" in result.output
+
+
+class TestBrowseFzfKeyHints:
+    """Test that fzf border label contains keybinding hints."""
+
+    def test_browse_fzf_border_label_contains_hints(self, tmp_path, monkeypatch):
+        """fzf should have a border-label with keybinding hints."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "my-task", "active")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        mock_result = MagicMock()
+        mock_result.returncode = 130
+        mock_result.stdout = ""
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/fzf"),
+            patch("subprocess.run", side_effect=_fzf_side_effect(mock_result)) as mock_run,
+        ):
+            runner = CliRunner()
+            runner.invoke(cli, ["browse"])
+            fzf_calls = _get_fzf_calls(mock_run)
+            fzf_cmd = fzf_calls[0][0][0]
+            label = _get_fzf_arg(fzf_cmd, "--border-label")
+            assert label is not None
+            # Should contain the command palette hint
+            assert "?" in label
+            # Should contain key hints for common actions
+            assert "Sort" in label
+            assert "Filter" in label
+            assert "Edit" in label
+            assert "Preview" in label
+            assert "Raw" in label
+            assert "Layout" in label
+
+    def test_browse_fzf_border_label_at_bottom(self, tmp_path, monkeypatch):
+        """Border label should be positioned at bottom."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "my-task", "active")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        mock_result = MagicMock()
+        mock_result.returncode = 130
+        mock_result.stdout = ""
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/fzf"),
+            patch("subprocess.run", side_effect=_fzf_side_effect(mock_result)) as mock_run,
+        ):
+            runner = CliRunner()
+            runner.invoke(cli, ["browse"])
+            fzf_calls = _get_fzf_calls(mock_run)
+            fzf_cmd = fzf_calls[0][0][0]
+            pos = _get_fzf_arg(fzf_cmd, "--border-label-pos")
+            assert pos is not None
+            assert "bottom" in pos
+
+
+class TestBrowseFzfBindings:
+    """Test that fzf keybindings are correctly configured."""
+
+    def _get_bindings(self, tmp_path, monkeypatch):
+        """Helper to invoke browse and return the --bind string."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "my-task", "active")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        mock_result = MagicMock()
+        mock_result.returncode = 130
+        mock_result.stdout = ""
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/fzf"),
+            patch("subprocess.run", side_effect=_fzf_side_effect(mock_result)) as mock_run,
+        ):
+            runner = CliRunner()
+            runner.invoke(cli, ["browse"])
+            fzf_calls = _get_fzf_calls(mock_run)
+            fzf_cmd = fzf_calls[0][0][0]
+            return _get_fzf_arg(fzf_cmd, "--bind")
+
+    def test_browse_fzf_command_palette_binding(self, tmp_path, monkeypatch):
+        """fzf --bind should include ?:execute(...) for the command palette."""
+        bindings = self._get_bindings(tmp_path, monkeypatch)
+        assert bindings is not None
+        assert "?:execute(" in bindings
+        assert "palette.sh" in bindings
+
+    def test_browse_fzf_sort_binding(self, tmp_path, monkeypatch):
+        """fzf --bind should include ctrl-s for sort picker."""
+        bindings = self._get_bindings(tmp_path, monkeypatch)
+        assert "ctrl-s:execute(" in bindings
+        assert "sort-picker.sh" in bindings
+
+    def test_browse_fzf_filter_binding(self, tmp_path, monkeypatch):
+        """fzf --bind should include ctrl-f for filter picker."""
+        bindings = self._get_bindings(tmp_path, monkeypatch)
+        assert "ctrl-f:execute(" in bindings
+        assert "filter-picker.sh" in bindings
+
+    def test_browse_fzf_state_change_binding(self, tmp_path, monkeypatch):
+        """fzf --bind should include ctrl-t for state change."""
+        bindings = self._get_bindings(tmp_path, monkeypatch)
+        assert "ctrl-t:execute(" in bindings
+        assert "state-change.sh" in bindings
+
+    def test_browse_fzf_edit_binding(self, tmp_path, monkeypatch):
+        """fzf --bind should include ctrl-e with $EDITOR."""
+        bindings = self._get_bindings(tmp_path, monkeypatch)
+        assert "ctrl-e:execute(" in bindings
+        assert "edit-task.sh" in bindings
+
+    def test_browse_edit_helper_uses_nano_with_tty(self, tmp_path):
+        """Browse edit helper should default to nano and attach to /dev/tty."""
+        state_dir = tmp_path / "browse-state"
+        state_dir.mkdir()
+
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+        (repo_root / "tasks").mkdir()
+
+        _write_browse_scripts(state_dir, repo_root)
+        edit_script = (state_dir / "edit-task.sh").read_text()
+        palette_script = (state_dir / "palette.sh").read_text()
+
+        assert "${EDITOR:-nano}" in edit_script
+        assert "</dev/tty >/dev/tty 2>/dev/tty" in edit_script
+        assert "edit-task.sh" in palette_script
+
+    def test_browse_fzf_blame_binding(self, tmp_path, monkeypatch):
+        """fzf --bind should include ctrl-b with git blame."""
+        bindings = self._get_bindings(tmp_path, monkeypatch)
+        assert "ctrl-b:change-preview(" in bindings
+        assert "git" in bindings and "blame" in bindings
+
+    def test_browse_fzf_log_binding(self, tmp_path, monkeypatch):
+        """fzf --bind should include ctrl-l with git log."""
+        bindings = self._get_bindings(tmp_path, monkeypatch)
+        assert "ctrl-l:change-preview(" in bindings
+        assert "git" in bindings and "log" in bindings
+
+    def test_browse_fzf_preview_reset_binding(self, tmp_path, monkeypatch):
+        """fzf --bind should include ctrl-p to reset preview with rendered markdown."""
+        bindings = self._get_bindings(tmp_path, monkeypatch)
+        assert "ctrl-p:change-preview(" in bindings
+        assert "gptodo show --render" in bindings
+
+    def test_browse_fzf_layout_toggle_binding(self, tmp_path, monkeypatch):
+        """fzf --bind should include ctrl-w to toggle preview layout."""
+        bindings = self._get_bindings(tmp_path, monkeypatch)
+        assert "ctrl-w:change-preview-window(" in bindings
+        assert "down:" in bindings
+        assert "right:" in bindings
+
+    def test_browse_fzf_toggle_preview_binding(self, tmp_path, monkeypatch):
+        """fzf --bind should include ctrl-/ to toggle preview."""
+        bindings = self._get_bindings(tmp_path, monkeypatch)
+        assert "ctrl-/:toggle-preview" in bindings
+
+
+class TestBrowseListCommand:
+    """Test the browse-list hidden subcommand."""
+
+    def test_browse_list_output_format(self, tmp_path, monkeypatch):
+        """browse-list should produce header + space-aligned data lines."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "my-task", "active", priority="high", project="myproj")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["browse-list"])
+        assert result.exit_code == 0
+        lines = result.output.strip().split("\n")
+        assert len(lines) == 2  # header + 1 data line
+        # Header row has column names
+        assert "NAME" in lines[0]
+        assert "STATE" in lines[0]
+        assert "CREATED" in lines[0]
+        # Data line has task name as first field
+        fields = lines[1].split()
+        assert fields[0] == "my-task"
+        assert "active" in lines[1]
+        assert "myproj" in lines[1]
+
+    def test_browse_list_default_filter(self, tmp_path, monkeypatch):
+        """browse-list should default to current open-work states."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "task-active", "active")
+        create_task(tasks_dir, "task-backlog", "backlog")
+        create_task(tasks_dir, "task-todo", "todo")
+        create_task(tasks_dir, "task-review", "ready_for_review")
+        create_task(tasks_dir, "task-done", "done")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["browse-list"])
+        assert "task-active" in result.output
+        assert "task-backlog" in result.output
+        assert "task-todo" in result.output
+        assert "task-review" in result.output
+        assert "task-done" not in result.output
+
+    def test_browse_list_all_flag(self, tmp_path, monkeypatch):
+        """browse-list --all should include done/cancelled tasks."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "task-active", "active")
+        create_task(tasks_dir, "task-done", "done")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["browse-list", "--all"])
+        assert "task-active" in result.output
+        assert "task-done" in result.output
+
+    def test_browse_list_state_filter(self, tmp_path, monkeypatch):
+        """browse-list --state should filter by state."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "task-active", "active")
+        create_task(tasks_dir, "task-backlog", "backlog")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["browse-list", "--state", "active"])
+        assert "task-active" in result.output
+        assert "task-backlog" not in result.output
+
+    def test_browse_list_project_filter(self, tmp_path, monkeypatch):
+        """browse-list --project should filter by project."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "task-gptme", "active", project="gptme")
+        create_task(tasks_dir, "task-other", "active", project="other")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["browse-list", "--project", "gptme"])
+        assert "task-gptme" in result.output
+        assert "task-other" not in result.output
+
+
+class TestBrowseListSort:
+    """Test browse-list sort modes."""
+
+    def test_browse_list_sort_priority(self, tmp_path, monkeypatch):
+        """--sort priority should order high before medium before low."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "task-low", "active", priority="low")
+        create_task(tasks_dir, "task-high", "active", priority="high")
+        create_task(tasks_dir, "task-medium", "active", priority="medium")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["browse-list", "--sort", "priority"])
+        lines = result.output.strip().split("\n")
+        task_names = [line.split()[0] for line in lines[1:]]  # skip header
+        assert task_names == ["task-high", "task-medium", "task-low"]
+
+    def test_browse_list_sort_name(self, tmp_path, monkeypatch):
+        """--sort name should order alphabetically."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "charlie", "active")
+        create_task(tasks_dir, "alpha", "active")
+        create_task(tasks_dir, "bravo", "active")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["browse-list", "--sort", "name"])
+        lines = result.output.strip().split("\n")
+        task_names = [line.split()[0] for line in lines[1:]]  # skip header
+        assert task_names == ["alpha", "bravo", "charlie"]
+
+    def test_browse_list_sort_modified(self, tmp_path, monkeypatch):
+        """--sort modified should order by modification date (newest first)."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        # Create tasks with different modification times
+        create_task(tasks_dir, "old-task", "active")
+        time.sleep(0.05)
+        create_task(tasks_dir, "new-task", "active")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["browse-list", "--sort", "modified"])
+        lines = result.output.strip().split("\n")
+        task_names = [line.split()[0] for line in lines[1:]]  # skip header
+        # Newest first
+        assert task_names[0] == "new-task"
+        assert task_names[1] == "old-task"
+
+
+class TestGetBrowseLines:
+    """Test the _get_browse_lines helper function directly."""
+
+    def test_empty_dir(self, tmp_path):
+        """Should return empty list for empty tasks dir."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        lines = _get_browse_lines(tasks_dir)
+        assert lines == []
+
+    def test_header_and_data_lines(self, tmp_path, monkeypatch):
+        """First line should be header, followed by space-aligned data lines."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "my-task", "active", priority="high", project="proj")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        lines = _get_browse_lines(tasks_dir)
+        assert len(lines) == 2  # header + 1 data line
+        # Header row
+        assert "NAME" in lines[0]
+        assert "STATE" in lines[0]
+        assert "PROJECT" in lines[0]
+        assert "CREATED" in lines[0]
+        # Data line: first field is task name
+        assert lines[1].split()[0] == "my-task"
+
+    def test_filter_defaults_to_backlog_active(self, tmp_path, monkeypatch):
+        """Default filter should include current open-work states."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "t-active", "active")
+        create_task(tasks_dir, "t-backlog", "backlog")
+        create_task(tasks_dir, "t-todo", "todo")
+        create_task(tasks_dir, "t-review", "ready_for_review")
+        create_task(tasks_dir, "t-done", "done")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        lines = _get_browse_lines(tasks_dir)
+        names = [line.split()[0] for line in lines[1:]]  # skip header
+        assert "t-active" in names
+        assert "t-backlog" in names
+        assert "t-todo" in names
+        assert "t-review" in names
+        assert "t-done" not in names
+
+    def test_show_all(self, tmp_path, monkeypatch):
+        """show_all=True should include all tasks."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "t-active", "active")
+        create_task(tasks_dir, "t-done", "done")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        lines = _get_browse_lines(tasks_dir, show_all=True)
+        names = [line.split()[0] for line in lines[1:]]  # skip header
+        assert "t-active" in names
+        assert "t-done" in names
+
+
+class TestBrowseFzfPreviewLabel:
+    """Test that fzf preview has a label."""
+
+    def test_browse_fzf_preview_label(self, tmp_path, monkeypatch):
+        """fzf should have --preview-label set to Task Preview."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "my-task", "active")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        mock_result = MagicMock()
+        mock_result.returncode = 130
+        mock_result.stdout = ""
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/fzf"),
+            patch("subprocess.run", side_effect=_fzf_side_effect(mock_result)) as mock_run,
+        ):
+            runner = CliRunner()
+            runner.invoke(cli, ["browse"])
+            fzf_calls = _get_fzf_calls(mock_run)
+            fzf_cmd = fzf_calls[0][0][0]
+            label = _get_fzf_arg(fzf_cmd, "--preview-label")
+            assert label is not None
+            assert "Task Preview" in label
+
+    def test_browse_fzf_blame_changes_preview_label(self, tmp_path, monkeypatch):
+        """ctrl-b binding should include change-preview-label for Git Blame."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "my-task", "active")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        mock_result = MagicMock()
+        mock_result.returncode = 130
+        mock_result.stdout = ""
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/fzf"),
+            patch("subprocess.run", side_effect=_fzf_side_effect(mock_result)) as mock_run,
+        ):
+            runner = CliRunner()
+            runner.invoke(cli, ["browse"])
+            fzf_calls = _get_fzf_calls(mock_run)
+            fzf_cmd = fzf_calls[0][0][0]
+            bindings = _get_fzf_arg(fzf_cmd, "--bind")
+            assert "change-preview-label( Git Blame )" in bindings
+
+    def test_browse_fzf_log_changes_preview_label(self, tmp_path, monkeypatch):
+        """ctrl-l binding should include change-preview-label for Git Log."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "my-task", "active")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        mock_result = MagicMock()
+        mock_result.returncode = 130
+        mock_result.stdout = ""
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/fzf"),
+            patch("subprocess.run", side_effect=_fzf_side_effect(mock_result)) as mock_run,
+        ):
+            runner = CliRunner()
+            runner.invoke(cli, ["browse"])
+            fzf_calls = _get_fzf_calls(mock_run)
+            fzf_cmd = fzf_calls[0][0][0]
+            bindings = _get_fzf_arg(fzf_cmd, "--bind")
+            assert "change-preview-label( Git Log )" in bindings
+
+
+class TestBrowseFzfRawBinding:
+    """Test ctrl-r binding for raw markdown preview."""
+
+    def test_browse_fzf_raw_binding(self, tmp_path, monkeypatch):
+        """fzf --bind should include ctrl-r for raw markdown preview."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "my-task", "active")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        mock_result = MagicMock()
+        mock_result.returncode = 130
+        mock_result.stdout = ""
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/fzf"),
+            patch("subprocess.run", side_effect=_fzf_side_effect(mock_result)) as mock_run,
+        ):
+            runner = CliRunner()
+            runner.invoke(cli, ["browse"])
+            fzf_calls = _get_fzf_calls(mock_run)
+            fzf_cmd = fzf_calls[0][0][0]
+            bindings = _get_fzf_arg(fzf_cmd, "--bind")
+            assert "ctrl-r:change-preview(gptodo show {1})" in bindings
+            assert "change-preview-label( Raw Markdown )" in bindings
+
+
+class TestShowRenderFlag:
+    """Test the --render flag on the show command."""
+
+    def test_show_render_flag(self, tmp_path, monkeypatch):
+        """show --render should render markdown content."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "my-task", "active", content="# Hello\n\nSome **bold** text.")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["show", "--render", "my-task"])
+        assert result.exit_code == 0
+        # Rich markdown renders bold differently — just check it doesn't crash
+        # and the content appears
+        assert "Hello" in result.output
+
+    def test_show_raw_flag(self, tmp_path, monkeypatch):
+        """show --raw should output raw markdown content."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "my-task", "active", content="# Hello\n\nSome **bold** text.")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["show", "--raw", "my-task"])
+        assert result.exit_code == 0
+        assert "**bold**" in result.output
+
+    def test_show_default_is_raw(self, tmp_path, monkeypatch):
+        """show without --render should default to raw output."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "my-task", "active", content="Some **bold** text.")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["show", "my-task"])
+        assert result.exit_code == 0
+        assert "**bold**" in result.output
+
+    def test_show_named_task_uses_single_file_fast_path(self, tmp_path, monkeypatch):
+        """show by task name should load only the selected file."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(
+            tasks_dir,
+            "fast-task",
+            "active",
+            created="2026-04-03",
+            content="Fast path body.",
+        )
+        create_task(tasks_dir, "other-task", "active", created="2026-04-02")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        calls = []
+
+        def tracked_load_tasks(tasks_dir_arg, recursive=False, single_file=None):
+            calls.append(single_file)
+            return load_tasks_util(tasks_dir_arg, recursive=recursive, single_file=single_file)
+
+        with patch("gptodo.cli.load_tasks", side_effect=tracked_load_tasks):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["show", "fast-task"])
+
+        assert result.exit_code == 0
+        assert "Fast path body." in result.output
+        assert calls == [tasks_dir / "fast-task.md"]
+
+
+class TestLoadTasksTimestampFallbacks:
+    """Test fast timestamp fallbacks used by browse paths."""
+
+    def test_load_tasks_avoids_git_when_modified_missing(self, tmp_path):
+        """Missing modified should fall back to file mtime without git subprocesses."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "mtime-task", "active", created="2026-04-03")
+
+        with patch("gptodo.utils.subprocess.run", side_effect=AssertionError("unexpected git")):
+            tasks = load_tasks_util(tasks_dir)
+
+        assert len(tasks) == 1
+        assert tasks[0].name == "mtime-task"
+        assert tasks[0].modified is not None
+
+
+class TestBrowseFzfHeaderLines:
+    """Test that fzf uses --header-lines for column headers."""
+
+    def test_browse_fzf_header_lines(self, tmp_path, monkeypatch):
+        """fzf should have --header-lines 1 to freeze column header."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "my-task", "active")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        mock_result = MagicMock()
+        mock_result.returncode = 130
+        mock_result.stdout = ""
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/fzf"),
+            patch("subprocess.run", side_effect=_fzf_side_effect(mock_result)) as mock_run,
+        ):
+            runner = CliRunner()
+            runner.invoke(cli, ["browse"])
+            fzf_calls = _get_fzf_calls(mock_run)
+            fzf_cmd = fzf_calls[0][0][0]
+            header_lines = _get_fzf_arg(fzf_cmd, "--header-lines")
+            assert header_lines == "1"
+
+    def test_browse_fzf_has_border(self, tmp_path, monkeypatch):
+        """fzf should have --border for border-label to render on."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "my-task", "active")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        mock_result = MagicMock()
+        mock_result.returncode = 130
+        mock_result.stdout = ""
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/fzf"),
+            patch("subprocess.run", side_effect=_fzf_side_effect(mock_result)) as mock_run,
+        ):
+            runner = CliRunner()
+            runner.invoke(cli, ["browse"])
+            fzf_calls = _get_fzf_calls(mock_run)
+            fzf_cmd = fzf_calls[0][0][0]
+            assert "--border" in fzf_cmd
+
+    def test_browse_fzf_layout_reverse(self, tmp_path, monkeypatch):
+        """fzf should use --layout reverse so column headers appear at top."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "my-task", "active")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        mock_result = MagicMock()
+        mock_result.returncode = 130
+        mock_result.stdout = ""
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/fzf"),
+            patch("subprocess.run", side_effect=_fzf_side_effect(mock_result)) as mock_run,
+        ):
+            runner = CliRunner()
+            runner.invoke(cli, ["browse"])
+            fzf_calls = _get_fzf_calls(mock_run)
+            fzf_cmd = fzf_calls[0][0][0]
+            layout = _get_fzf_arg(fzf_cmd, "--layout")
+            assert layout == "reverse"
+
+    def test_browse_fzf_rendered_preview(self, tmp_path, monkeypatch):
+        """fzf --preview should use gptodo show --render."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        create_task(tasks_dir, "my-task", "active")
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        mock_result = MagicMock()
+        mock_result.returncode = 130
+        mock_result.stdout = ""
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/fzf"),
+            patch("subprocess.run", side_effect=_fzf_side_effect(mock_result)) as mock_run,
+        ):
+            runner = CliRunner()
+            runner.invoke(cli, ["browse"])
+            fzf_calls = _get_fzf_calls(mock_run)
+            fzf_cmd = fzf_calls[0][0][0]
+            preview = _get_fzf_arg(fzf_cmd, "--preview")
+            assert "gptodo show --render" in preview

--- a/packages/gptodo/tests/test_browse.py
+++ b/packages/gptodo/tests/test_browse.py
@@ -264,6 +264,7 @@ class TestBrowsePagerContentFormat:
         # Should contain separators (visual dividers between tasks)
         assert "═" in output or "---" in output or "===" in output
 
+
 class TestBrowseFzfMode:
     """Test fzf interactive mode."""
 

--- a/packages/gptodo/tests/test_browse.py
+++ b/packages/gptodo/tests/test_browse.py
@@ -688,6 +688,25 @@ class TestGetBrowseLines:
         assert "t-active" in names
         assert "t-done" in names
 
+    def test_task_with_single_quote_in_name_is_excluded(self, tmp_path, monkeypatch, capsys):
+        """Tasks with single quotes in name must be silently dropped (shell-injection guard)."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        safe_task = create_task(tasks_dir, "safe-task", "active")  # noqa: F841
+        # Manually create a task file with a single quote in the name; gptodo
+        # won't create such names but they can be added by hand or imported.
+        bad_file = tasks_dir / "bad'task.md"
+        bad_file.write_text(safe_task.read_text())
+        monkeypatch.setenv("GPTODO_TASKS_DIR", str(tasks_dir))
+
+        lines = _get_browse_lines(tasks_dir, show_all=True)
+        names = [line.split()[0] for line in lines[1:]]  # skip header
+        assert "safe-task" in names
+        assert not any("'" in n for n in names), "task with single quote must be excluded"
+        # A warning should have been printed to stderr
+        captured = capsys.readouterr()
+        assert "single quote" in captured.err
+
 
 class TestBrowseFzfPreviewLabel:
     """Test that fzf preview has a label."""

--- a/packages/gptodo/tests/test_browse.py
+++ b/packages/gptodo/tests/test_browse.py
@@ -783,7 +783,7 @@ class TestBrowseFzfRawBinding:
             fzf_calls = _get_fzf_calls(mock_run)
             fzf_cmd = fzf_calls[0][0][0]
             bindings = _get_fzf_arg(fzf_cmd, "--bind")
-            assert "ctrl-r:change-preview(gptodo show {1})" in bindings
+            assert "ctrl-r:change-preview(gptodo show '{1}')" in bindings
             assert "change-preview-label( Raw Markdown )" in bindings
 
 


### PR DESCRIPTION
Ports `gptodo browse`: an interactive fzf TUI for browsing tasks, originally authored by @gptme-thomas in #1240.

This PR supersedes #1240 (see that PR for the full feature description and origin story). The changes here are identical to #1240 plus three bug fixes identified during review:

1. **fzf version gate corrected**: `resize` event requires fzf ≥ 0.46.0, not 0.42.0. The old gate caused `browse` to exit immediately on Ubuntu 24.04 LTS (which ships fzf 0.44.1).
2. **`reload.sh` quoting**: switched from an unquoted `$args` string to positional params (`set --`/`"$@"`), so project names with spaces no longer corrupt the argument list.
3. **Dead command palette entries removed**: the two "Preview" items in `palette.sh` had no `case` handler and silently did nothing when selected.

The original PR stalled on #1240 after @gptme-thomas was unresponsive for 7+ weeks. Full credit to them for the porting work.

## Features
- Aligned columns (state emoji, name, priority, project, subtask progress) with live preview pane
- Rendered-markdown preview by default; `^R` toggles raw; `--render/--raw` added to `gptodo show`
- Command palette (`?`), sort picker (`^S`), state filter (`^F`), state change (`^T`), edit in `$EDITOR` (`^E`), git blame/log (`^B`/`^L`)
- Filters: `--all`, `--project`, `--state`; default shows open tasks only
- `fzf` optional: graceful paged fallback; compatible with fzf ≥ 0.42 (feature-detects `--border-label`/`transform`)